### PR TITLE
refactor(daemon): command chrome becomes a §7.4 surface family (S2)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -128,8 +128,7 @@ import {
   telegramConnKey,
   TelegramConnection,
   type TelegramCallback,
-  type TelegramObservedChat,
-  type InlineButton
+  type TelegramObservedChat
 } from './telegram/connection.js'
 import { consolidateDiscord, discordConnKey, DiscordConnection } from './discord/connection.js'
 import { collapseDiscordChannels, collapseNameLookupIds } from './discord/channels.js'
@@ -138,6 +137,15 @@ import { SlackNameResolver } from './slack/name-resolver.js'
 import { manifestFor } from './platforms/manifest.js'
 import { loopGuardScopesFor } from './platforms/loop-guard.js'
 import { isPlatformMemberId } from './platforms/member-id.js'
+import { CommandChromeRegistry, type SelectKind } from './platforms/command-chrome.js'
+import { slackCommandChrome } from './platforms/slack/command-chrome.js'
+import {
+  parseTelegramSelect,
+  telegramCommandChrome,
+  telegramSelectButtons
+} from './platforms/telegram/command-chrome.js'
+import { discordCommandChrome } from './platforms/discord/command-chrome.js'
+import { feishuCommandChrome } from './platforms/feishu/command-chrome.js'
 import {
   applySlackAction as applySlackActionExternal,
   clearStaleSlackReplyFooters as clearStaleSlackReplyFootersExternal,
@@ -178,16 +186,14 @@ import {
   type StatusBarInfo,
   type StatusModalIdentity
 } from './slack/render.js'
-import { TelegramConverger, renderStatusReply, type TelegramAction } from './telegram/render.js'
+import { TelegramConverger, type TelegramAction } from './telegram/render.js'
 import {
   DiscordConverger,
-  renderStatusText,
   buildDiscordSelectComponents,
-  buildLinkComponents,
   type DiscordAction,
   type DiscordComponents
 } from './discord/render.js'
-import { FeishuConverger, renderStatusReply as renderFeishuStatusReply, type FeishuAction } from './feishu/render.js'
+import { FeishuConverger, type FeishuAction } from './feishu/render.js'
 import { Scheduler, buildSyntheticMessage } from './scheduler/scheduler.js'
 import { DreamScheduler } from './scheduler/dream-scheduler.js'
 import { planChannelIntros, buildIntroMessage } from './agents/channel-intro.js'
@@ -738,10 +744,6 @@ class LifecycleCleanupBlockedError extends Error {
 /** The session-control selectors driven by `/models` `/effort` `/permission` + their
  *  tappable cards. Single-char codes keep the inline-button `callback_data` (≤64 bytes)
  *  compact — `<code>:<optionIndex>`. */
-type SelectKind = 'model' | 'effort' | 'permission'
-const SELECT_KIND_CODE: Record<SelectKind, string> = { model: 'm', effort: 'e', permission: 'p' }
-const SELECT_CODE_KIND = { m: 'model', e: 'effort', p: 'permission' } as const satisfies Record<string, SelectKind>
-
 // Budget for the inline text carried by one WebchatOutput payload. Well under
 // the 256 KiB JSON frame cap so the envelope overhead (conversationId/turnId/index/
 // kind + JSON escaping of control chars, up to a 6× blowup) can never push a chunk
@@ -1647,6 +1649,17 @@ export class Daemon {
    * dream), which is exactly what the `platform === …` ternaries this replaces
    * did with their default arm.
    */
+  /** §7.4 command chrome — how each platform presents control replies, /status,
+   *  and select cards. Core (Slack-shaped) is the rendering fallback; the
+   *  thread-identity fact defaults false (see CommandChromeRegistry). */
+  private readonly commandChrome: CommandChromeRegistry<NormalizedMessage, StatusBarInfo> = (() => {
+    const registry = new CommandChromeRegistry<NormalizedMessage, StatusBarInfo>(slackCommandChrome)
+    registry.register(telegramCommandChrome)
+    registry.register(discordCommandChrome)
+    registry.register(feishuCommandChrome)
+    return registry
+  })()
+
   private readonly turnSurfaces: TurnOutputRegistry<Pending, DaemonRenderAction, DaemonConverger, NormalizedMessage> =
     (() => {
       const registry = new TurnOutputRegistry<Pending, DaemonRenderAction, DaemonConverger, NormalizedMessage>({
@@ -9239,7 +9252,10 @@ export class Daemon {
     srcIntegrationIds?: readonly string[]
   ): { agentId: string; integrationId: string; via: RouteVia } | null {
     const transportScope = msg.transportScope ?? this.transportScopeForIntegrationIds(srcIntegrationIds)
-    const thread = msg.platform === 'slack' ? msg.thread : undefined
+    // Only where the thread coordinate identifies the session (Slack) does it
+    // participate in the lookup; reply-threading platforms mint a fresh thread per
+    // command, so their commands resolve through the channel's latest session.
+    const thread = this.commandChrome.threadIdentifiesSession(msg.platform) ? msg.thread : undefined
     const candidates: Array<{
       agentId: string
       integrationId: string
@@ -9406,15 +9422,15 @@ export class Daemon {
     // owns the key), not just the ACP-id-keyed `pending` — so `!cancel`/`!stop`/`!queue`
     // also see a session that is gate-owned or queued (cold session with no ACP id yet).
     const inflight = directGateActive
-    // Post a short control reply on the right surface: Slack threads on `thread_ts`;
-    // Telegram replies to the command message (reply-based threading), which is also a
-    // non-numeric `tg:`/`dm` thread so it never posts as a forum topic.
-    const tgReplyTo = this.telegramReplyTarget(msg)
+    // Post a short control reply on the platform's own surface (§7.4 command
+    // chrome): Slack threads on `thread_ts`; Telegram replies to the command
+    // message (reply-based threading), which is also a non-numeric `tg:`/`dm`
+    // thread so it never posts as a forum topic.
+    const chrome = this.commandChrome.for(msg.platform)
+    const chromeCtx = { channel: msg.channel, replyThread, sessionKey: key }
     const reply = (text: string): void => {
       if (!conn) return
-      if (msg.platform === 'telegram')
-        void (conn as TelegramConnection).postMessage(msg.channel, text, replyThread, { replyTo: tgReplyTo })
-      else void (conn as SlackConnection).postMessage(msg.channel, text, replyThread)
+      chrome.reply(conn, msg, chromeCtx, text)
     }
 
     if (command.kind === 'resume') {
@@ -9493,28 +9509,10 @@ export class Daemon {
       const link = acpSessionId
         ? this.sessionLink(acpSessionId, this.sessionLinkSource(msg.platform, target.integrationId))
         : undefined
-      if (msg.platform === 'telegram') {
-        // HTML chrome (not recorded) — renders the compact line + a tappable View link.
-        void (conn as TelegramConnection | undefined)?.postChrome(msg.channel, renderStatusReply(info, link), {
-          parseMode: 'HTML',
-          threadTs: replyThread,
-          replyTo: tgReplyTo
-        })
-      } else if (msg.platform === 'discord') {
-        // Discord markdown line + a real "View session" link BUTTON (Slack's `<url|text>`
-        // link syntax renders literally on Discord).
-        void (conn as DiscordConnection | undefined)?.postChrome(
-          msg.channel,
-          renderStatusText(info),
-          link ? { keyboard: buildLinkComponents(link) } : {}
-        )
-      } else if (msg.platform === 'feishu') {
-        // Plain-text status line + a `🔗 <url>` line (v1 has no interactive cards / link buttons).
-        void (conn as FeishuConnection | undefined)?.postChrome(msg.channel, renderFeishuStatusReply(info, link))
-      } else {
-        const text = link ? `${renderStatusBar(info)}  ·  <${link}|View session>` : renderStatusBar(info)
-        reply(text)
-      }
+      // Presentation is the platform's (§7.4): HTML chrome + View link on Telegram,
+      // markdown + a real link button on Discord, plain text + a 🔗 line on Feishu,
+      // the compact pipe-linked status line on Slack.
+      if (conn) chrome.status(conn, msg, chromeCtx, info, link)
       return true
     }
 
@@ -9554,31 +9552,15 @@ export class Daemon {
         reply('No active session here to configure.')
         return true
       }
-      // Telegram + Discord list via a tappable button card, replied under the command;
-      // returns false so handleSelectCommand falls back to a text list (Slack, or when
-      // Discord has too many options to fit its 25-button ceiling).
+      // Platforms with tappable cards render one (§7.4), replied under the command;
+      // false falls back to the numbered text list (Slack, or a Discord select over
+      // its 25-button ceiling).
+      const selectCard = chrome.selectCard?.bind(chrome)
       const renderCard =
-        msg.platform === 'telegram' && conn
-          ? (kind: SelectKind, current: string | undefined, options: string[]) => {
-              const { text, buttons } = this.buildSelectCard(kind, current, options)
-              void (conn as TelegramConnection).postCard(msg.channel, text, buttons, {
-                threadTs: replyThread,
-                replyTo: tgReplyTo
-              })
-              return true
-            }
-          : msg.platform === 'discord' && conn
-            ? (kind: SelectKind, current: string | undefined, options: string[]) => {
-                const components = buildDiscordSelectComponents(kind, current, options)
-                if (!components) return false
-                // sessionKey = the resolved key, so a tapped button resolves back to it.
-                void (conn as DiscordConnection).postChrome(msg.channel, this.selectCardText(kind, current), {
-                  keyboard: components,
-                  sessionKey: key
-                })
-                return true
-              }
-            : undefined
+        selectCard && conn
+          ? (kind: SelectKind, current: string | undefined, options: string[]) =>
+              selectCard(conn, msg, chromeCtx, { kind, current, options, header: this.selectCardText(kind, current) })
+          : undefined
       this.handleSelectCommand(
         command.kind,
         command.value,
@@ -9655,20 +9637,6 @@ export class Daemon {
   private selectCardText(kind: SelectKind, current: string | undefined): string {
     const cur = current ? this.selectDisplay(kind, current) : 'default'
     return `${this.selectLabel(kind)} — tap to switch (current: ${cur}):`
-  }
-
-  /** Build a session-control card: a header line + one tappable button per option (the
-   *  current one flagged), with `callback_data` = `<kindCode>:<optionIndex>`. */
-  private buildSelectCard(
-    kind: SelectKind,
-    current: string | undefined,
-    options: string[]
-  ): { text: string; buttons: InlineButton[][] } {
-    const code = SELECT_KIND_CODE[kind]
-    const buttons = options.map((o, i) => [
-      { text: `${o === current ? '✅ ' : ''}${this.selectDisplay(kind, o)}`, callbackData: `${code}:${i}` }
-    ])
-    return { text: this.selectCardText(kind, current), buttons }
   }
 
   /**
@@ -9752,13 +9720,12 @@ export class Daemon {
    * must never throw out of the update pump.
    */
   private handleTelegramCallback(cb: TelegramCallback, conn: TelegramConnection): void {
-    const m = /^([mep]):(\d+)$/.exec(cb.data)
-    if (!m) {
+    const tap = parseTelegramSelect(cb.data)
+    if (!tap) {
       void conn.answerCallback(cb.id)
       return
     }
-    const kind = SELECT_CODE_KIND[m[1] as keyof typeof SELECT_CODE_KIND]
-    const idx = Number(m[2])
+    const { kind, index: idx } = tap
     const srcIntegrationIds = this.srcIntegrationIds(conn)
     const session = this.commandSessionForLatest(
       cb.channel,
@@ -9785,8 +9752,37 @@ export class Daemon {
     // change, matching the other funnels.
     this.logSessionAction(`select:${kind}`, session.key, { userId: cb.userId })
     void conn.answerCallback(cb.id, `${this.selectLabel(kind)} → ${value}`)
-    const { text, buttons } = this.buildSelectCard(kind, value, options)
-    void conn.editCard(cb.channel, cb.messageId, text, buttons)
+    void conn.editCard(
+      cb.channel,
+      cb.messageId,
+      this.selectCardText(kind, value),
+      telegramSelectButtons(kind, value, options)
+    )
+  }
+
+  /** The newest addressable session for a platform-scoped interaction (a Telegram
+   *  command/callback, a Slack message shortcut): scan the caller's own-platform
+   *  integrations, retain conversation routing gates, newest first. The caller is
+   *  already platform-specific — it names its platform as data, not as a branch. */
+  private latestAdmittedSession(
+    platform: string,
+    channel: string,
+    srcIntegrationIds: readonly string[],
+    transportScope?: string,
+    thread?: string
+  ): SessionRecord | null {
+    const candidates: SessionRecord[] = []
+    for (const [agentId, agent] of this.agents) {
+      for (const integration of agent.integrations) {
+        if (integration.platform !== platform || !srcIntegrationIds.includes(integration.id)) continue
+        const routing = integrationRouting(integration)
+        if (!conversationAdmitted(routing, channel)) continue
+        const session = this.store.latestSessionForTransport(agentId, channel, transportScope, thread)
+        if (session) candidates.push(session)
+      }
+    }
+    candidates.sort((a, b) => b.updatedAt - a.updatedAt || a.agentId.localeCompare(b.agentId))
+    return candidates[0] ?? null
   }
 
   /** The channel's latest admitted session for a Telegram command/callback. */
@@ -9795,18 +9791,7 @@ export class Daemon {
     srcIntegrationIds: readonly string[],
     transportScope?: string
   ): { agentId: string; key: string; acpSessionId?: string } | null {
-    const candidates: SessionRecord[] = []
-    for (const [agentId, agent] of this.agents) {
-      for (const integration of agent.integrations) {
-        if (integration.platform !== 'telegram' || !srcIntegrationIds.includes(integration.id)) continue
-        const routing = integrationRouting(integration)
-        if (!conversationAdmitted(routing, channel)) continue
-        const session = this.store.latestSessionForTransport(agentId, channel, transportScope)
-        if (session) candidates.push(session)
-      }
-    }
-    candidates.sort((a, b) => b.updatedAt - a.updatedAt || a.agentId.localeCompare(b.agentId))
-    const latest = candidates[0]
+    const latest = this.latestAdmittedSession('telegram', channel, srcIntegrationIds, transportScope)
     return latest ? { agentId: latest.agentId, key: latest.key, acpSessionId: latest.acpSessionId ?? undefined } : null
   }
 
@@ -9817,18 +9802,8 @@ export class Daemon {
     srcIntegrationIds: readonly string[]
   ): string | undefined {
     const transportScope = this.transportScopeForIntegrationIds(srcIntegrationIds)
-    const candidates: SessionRecord[] = []
-    for (const [agentId, agent] of this.agents) {
-      for (const integration of agent.integrations) {
-        if (integration.platform !== 'slack' || !srcIntegrationIds.includes(integration.id)) continue
-        const routing = integrationRouting(integration)
-        if (!conversationAdmitted(routing, shortcut.channel)) continue
-        const session = this.store.latestSessionForTransport(agentId, shortcut.channel, transportScope, shortcut.thread)
-        if (session) candidates.push(session)
-      }
-    }
-    candidates.sort((a, b) => b.updatedAt - a.updatedAt || a.agentId.localeCompare(b.agentId))
-    return candidates[0]?.key
+    return this.latestAdmittedSession('slack', shortcut.channel, srcIntegrationIds, transportScope, shortcut.thread)
+      ?.key
   }
 
   /** Local layer (agent.json) ∪ resolved CP layer; unservable CP rules are dropped + warn-logged. */

--- a/packages/daemon/src/platforms/command-chrome.ts
+++ b/packages/daemon/src/platforms/command-chrome.ts
@@ -1,0 +1,112 @@
+/**
+ * The **command chrome surface** — a §7.4 adapter strategy family (stage S2).
+ *
+ * In-conversation control commands (`/status`, `/models`, `!resume`, `!queue`, …)
+ * are core policy end to end: routing, admission, session resolution, sticky
+ * overrides. What is NOT core is the last inch — how a short control reply, a
+ * status line, or a tappable select card is PRESENTED on each platform. That
+ * inch was four inline forks inside `handleCommand`:
+ *
+ *  - the control reply: Telegram anchors a reply to the command message
+ *    (reply-based threading); everyone else posts into the reply thread;
+ *  - `/status`: Telegram renders HTML chrome with a tappable View link, Discord
+ *    a markdown line with a real link BUTTON (Slack's `<url|text>` syntax
+ *    renders literally there), Feishu a plain-text line with a `🔗 <url>` tail,
+ *    Slack the compact status line with the pipe-link;
+ *  - the select card: Telegram an inline keyboard, Discord a button grid with a
+ *    25-button ceiling (fall back to the text list), Slack/Feishu no card at all;
+ *  - and one COORDINATE fact, not a rendering: whether a command's thread
+ *    identifies the session it acts on.
+ *
+ * The surface owns the first three. The fourth is a separate lookup with the
+ * OPPOSITE default — see {@link CommandChromeRegistry.threadIdentifiesSession}.
+ *
+ * Like the turn-output registry, rendering lookup is total and falls back to the
+ * core (Slack-shaped) surface, because every pre-existing fork ended in a
+ * Slack-shaped `else` arm.
+ */
+
+/** The cross-platform select-control vocabulary (`/models` `/effort` `/permission`). */
+export type SelectKind = 'model' | 'effort' | 'permission'
+
+/** Where a command reply lands. Built once per command, after session resolution. */
+export interface CommandChromeContext {
+  channel: string
+  /** The thread the reply posts into (Slack `thread_ts`; a Telegram topic id). */
+  replyThread: string
+  /** The RESOLVED session key the command acts on — surfaces whose card taps
+   *  route back by key (Discord components) embed it. */
+  sessionKey: string
+}
+
+/** A prepared select card: core owns the naming (header text, option ids); the
+ *  surface owns the interaction shape (buttons, callback encoding, ceilings). */
+export interface SelectCardSpec {
+  kind: SelectKind
+  /** Currently applied option id, if any — surfaces mark it (✅). */
+  current?: string
+  /** Raw option ids, in order. Index is the stable tap coordinate. */
+  options: string[]
+  /** Core-rendered header line ("Model — tap to switch …"). */
+  header: string
+}
+
+/**
+ * One platform's command presentation surface.
+ *
+ * `conn` is deliberately `unknown` — a surface casts to its own connection type
+ * internally (the turn-output precedent): callers hold whatever connection the
+ * reply path resolved, and duck-typed test fakes must keep working.
+ */
+export interface CommandChromeSurface<TMsg, TInfo> {
+  /** Platform id this surface presents for; never parsed. */
+  readonly platform: string
+  /** Does a command's thread coordinate identify the session it acts on?
+   *  Slack: yes — a command inside a session thread targets that session.
+   *  Reply-threading platforms mint a fresh thread per command: no. */
+  readonly threadIdentifiesSession: boolean
+  /** Post a short control reply on the platform's own reply surface. */
+  reply(conn: unknown, msg: TMsg, ctx: CommandChromeContext, text: string): void
+  /** Render the `/status` line (+ session deep link when known). */
+  status(conn: unknown, msg: TMsg, ctx: CommandChromeContext, info: TInfo, link?: string): void
+  /** Render the tappable select card. `false` means the card cannot be rendered
+   *  here (no options / over a button ceiling) and the caller must fall back to
+   *  the shared numbered text list. Omitted entirely by platforms with no
+   *  interactive cards. */
+  selectCard?(conn: unknown, msg: TMsg, ctx: CommandChromeContext, card: SelectCardSpec): boolean
+}
+
+/**
+ * The daemon's registry of command chrome surfaces.
+ *
+ * TWO lookups with two fail directions, on purpose:
+ *
+ *  - {@link for} (rendering) falls back to the CORE surface — an unknown origin
+ *    posts Slack-shaped text, the pre-existing `else`-arm behavior.
+ *  - {@link threadIdentifiesSession} defaults to FALSE — the pre-existing
+ *    behavior was `platform === 'slack' ? msg.thread : undefined`, so an unknown
+ *    platform must keep resolving through the latest-session fallback, not
+ *    inherit Slack's coordinate trust.
+ */
+export class CommandChromeRegistry<TMsg, TInfo> {
+  private readonly surfaces = new Map<string, CommandChromeSurface<TMsg, TInfo>>()
+
+  constructor(private readonly core: CommandChromeSurface<TMsg, TInfo>) {
+    this.register(core)
+  }
+
+  register(surface: CommandChromeSurface<TMsg, TInfo>): void {
+    this.surfaces.set(surface.platform, surface)
+  }
+
+  /** The surface that presents `platform`'s command replies — core when the
+   *  origin has no surface of its own. */
+  for(platform: string): CommandChromeSurface<TMsg, TInfo> {
+    return this.surfaces.get(platform) ?? this.core
+  }
+
+  /** Coordinate fact, NOT rendering: unknown platforms answer false (see class doc). */
+  threadIdentifiesSession(platform: string): boolean {
+    return this.surfaces.get(platform)?.threadIdentifiesSession ?? false
+  }
+}

--- a/packages/daemon/src/platforms/discord/command-chrome.ts
+++ b/packages/daemon/src/platforms/discord/command-chrome.ts
@@ -1,0 +1,52 @@
+/**
+ * Discord's **command chrome surface** (§7.4).
+ *
+ * Two Discord facts drive this surface's existence:
+ *
+ *  - Slack's `<url|text>` link syntax renders LITERALLY on Discord, so `/status`
+ *    carries its session deep link as a real link BUTTON row instead;
+ *  - components cap at 25 buttons, so a select control over more options than
+ *    that cannot render as a card — `selectCard` answers `false` and the caller
+ *    falls back to the shared numbered text list.
+ *
+ * The select custom-id scheme (`ac_sel:<code>:<index>`) already lives with its
+ * builder in `discord/render.ts`; this surface only dispatches to it.
+ */
+import type { DiscordConnection } from '../../discord/connection.js'
+import {
+  buildDiscordSelectComponents,
+  buildLinkComponents,
+  renderStatusText,
+  type DiscordStatusInfo
+} from '../../discord/render.js'
+import type { CommandChromeContext, CommandChromeSurface, SelectCardSpec } from '../command-chrome.js'
+
+export const discordCommandChrome: CommandChromeSurface<unknown, DiscordStatusInfo> = {
+  platform: 'discord',
+  // Commands resolve through the channel's latest session, as before this seam.
+  threadIdentifiesSession: false,
+
+  reply(conn: unknown, _msg: unknown, ctx: CommandChromeContext, text: string): void {
+    void (conn as DiscordConnection).postMessage(ctx.channel, text, ctx.replyThread)
+  },
+
+  status(conn: unknown, _msg: unknown, ctx: CommandChromeContext, info: DiscordStatusInfo, link?: string): void {
+    // Markdown line + a real "View session" link button.
+    void (conn as DiscordConnection).postChrome(
+      ctx.channel,
+      renderStatusText(info),
+      link ? { keyboard: buildLinkComponents(link) } : {}
+    )
+  },
+
+  selectCard(conn: unknown, _msg: unknown, ctx: CommandChromeContext, card: SelectCardSpec): boolean {
+    const components = buildDiscordSelectComponents(card.kind, card.current, card.options)
+    if (!components) return false
+    // sessionKey = the resolved key, so a tapped button resolves back to it.
+    void (conn as DiscordConnection).postChrome(ctx.channel, card.header, {
+      keyboard: components,
+      sessionKey: ctx.sessionKey
+    })
+    return true
+  }
+}

--- a/packages/daemon/src/platforms/feishu/command-chrome.ts
+++ b/packages/daemon/src/platforms/feishu/command-chrome.ts
@@ -1,0 +1,24 @@
+/**
+ * Feishu / Lark's **command chrome surface** (§7.4).
+ *
+ * The smallest of the four: v1 has no interactive cards or link buttons on this
+ * path, so `/status` is a plain-text line with a `🔗 <url>` tail and there is no
+ * select card (the caller's numbered text list serves).
+ */
+import type { FeishuConnection } from '../../feishu/connection.js'
+import { renderStatusReply, type FeishuStatusInfo } from '../../feishu/render.js'
+import type { CommandChromeContext, CommandChromeSurface } from '../command-chrome.js'
+
+export const feishuCommandChrome: CommandChromeSurface<unknown, FeishuStatusInfo> = {
+  platform: 'feishu',
+  // Commands resolve through the channel's latest session, as before this seam.
+  threadIdentifiesSession: false,
+
+  reply(conn: unknown, _msg: unknown, ctx: CommandChromeContext, text: string): void {
+    void (conn as FeishuConnection).postMessage(ctx.channel, text, ctx.replyThread)
+  },
+
+  status(conn: unknown, _msg: unknown, ctx: CommandChromeContext, info: FeishuStatusInfo, link?: string): void {
+    void (conn as FeishuConnection).postChrome(ctx.channel, renderStatusReply(info, link))
+  }
+}

--- a/packages/daemon/src/platforms/slack/command-chrome.ts
+++ b/packages/daemon/src/platforms/slack/command-chrome.ts
@@ -1,0 +1,33 @@
+/**
+ * Slack's **command chrome surface** (§7.4) — and, as with turn output, the CORE
+ * surface every origin without one of its own renders through. The pre-existing
+ * forks all ended in a Slack-shaped `else` arm; this module IS that arm.
+ */
+import type { SlackConnection } from '../../slack/connection.js'
+import { renderStatusBar, type StatusBarInfo } from '../../slack/render.js'
+import type { CommandChromeContext, CommandChromeSurface } from '../command-chrome.js'
+
+export const slackCommandChrome: CommandChromeSurface<unknown, StatusBarInfo> = {
+  platform: 'slack',
+  // A command inside a session's own thread targets that session — Slack thread
+  // coordinates are stable, so the thread IS the session identity.
+  threadIdentifiesSession: true,
+
+  reply(conn: unknown, _msg: unknown, ctx: CommandChromeContext, text: string): void {
+    // Cast rather than instanceof so duck-typed fakes (and the non-Slack origins
+    // that render through this core surface) keep working — their postMessage is
+    // structurally compatible.
+    void (conn as SlackConnection).postMessage(ctx.channel, text, ctx.replyThread)
+  },
+
+  status(conn: unknown, msg: unknown, ctx: CommandChromeContext, info: StatusBarInfo, link?: string): void {
+    // The compact status line, with Slack's pipe-link syntax when a deep link is
+    // known. (Discord renders that syntax literally — which is why it has its own
+    // surface.)
+    const text = link ? `${renderStatusBar(info)}  ·  <${link}|View session>` : renderStatusBar(info)
+    this.reply(conn, msg, ctx, text)
+  }
+
+  // No selectCard: Slack lists options as a numbered text reply (the shared
+  // fallback). Its interactive selects live on the session status bar instead.
+}

--- a/packages/daemon/src/platforms/telegram/command-chrome.ts
+++ b/packages/daemon/src/platforms/telegram/command-chrome.ts
@@ -1,0 +1,91 @@
+/**
+ * Telegram's **command chrome surface** (§7.4), plus its select-card wire
+ * encoding.
+ *
+ * Telegram threads commands by REPLY, not by thread ts: a control reply anchors
+ * to the command message itself (`replyTo`), which also keeps it a non-numeric
+ * `tg:`/`dm` thread so it never posts as a forum topic. `/status` renders as
+ * HTML chrome with a tappable View link; the select controls render as an
+ * inline-keyboard card.
+ *
+ * THE CALLBACK ENCODING LIVES HERE with its builder — `<kindCode>:<index>` is
+ * Telegram's own wire format (its Bot API caps callback_data at 64 bytes, hence
+ * the terse codes), parsed back by the callback handler. Encode and decode were
+ * previously 350 lines apart in `daemon.ts`; a platform's wire format belongs in
+ * one file, next to the buttons that carry it — mirroring Discord, whose
+ * `ac_sel:<code>:<index>` custom-id scheme already lives in its own render
+ * module.
+ */
+import type { NormalizedMessage } from '../../messages/normalized.js'
+import { permissionModeDisplayLabel } from '../../acp/permission-modes.js'
+import type { InlineButton, TelegramConnection } from '../../telegram/connection.js'
+import { renderStatusReply, type TelegramStatusInfo } from '../../telegram/render.js'
+import type { CommandChromeContext, CommandChromeSurface, SelectCardSpec, SelectKind } from '../command-chrome.js'
+import { telegramReplyTarget } from './threading.js'
+
+const SELECT_KIND_CODE: Record<SelectKind, string> = { model: 'm', effort: 'e', permission: 'p' }
+const SELECT_CODE_KIND: Record<string, SelectKind> = { m: 'model', e: 'effort', p: 'permission' }
+
+/** Decode a tapped inline-keyboard callback (`m:2` → model, index 2). Null for
+ *  callback data this scheme did not mint. */
+export function parseTelegramSelect(data: string): { kind: SelectKind; index: number } | null {
+  const m = /^([mep]):(\d+)$/.exec(data)
+  if (!m) return null
+  const kind = SELECT_CODE_KIND[m[1] as string]
+  return kind ? { kind, index: Number(m[2]) } : null
+}
+
+/** One tappable button per option, the current one marked ✅. Also used by the
+ *  callback handler to re-render the card with the new current after a tap. */
+export function telegramSelectButtons(
+  kind: SelectKind,
+  current: string | undefined,
+  options: string[]
+): InlineButton[][] {
+  const code = SELECT_KIND_CODE[kind]
+  return options.map((o, i) => [
+    {
+      text: `${o === current ? '✅ ' : ''}${kind === 'permission' ? permissionModeDisplayLabel(o) : o}`,
+      callbackData: `${code}:${i}`
+    }
+  ])
+}
+
+export const telegramCommandChrome: CommandChromeSurface<NormalizedMessage, TelegramStatusInfo> = {
+  platform: 'telegram',
+  // A bare Telegram command keys to its own fresh reply thread — the thread
+  // coordinate never identifies an existing session, so commands resolve through
+  // the channel's latest session instead.
+  threadIdentifiesSession: false,
+
+  reply(conn: unknown, msg: NormalizedMessage, ctx: CommandChromeContext, text: string): void {
+    void (conn as TelegramConnection).postMessage(ctx.channel, text, ctx.replyThread, {
+      replyTo: telegramReplyTarget(msg)
+    })
+  },
+
+  status(
+    conn: unknown,
+    msg: NormalizedMessage,
+    ctx: CommandChromeContext,
+    info: TelegramStatusInfo,
+    link?: string
+  ): void {
+    // HTML chrome (not recorded) — the compact line + a tappable View link.
+    void (conn as TelegramConnection).postChrome(ctx.channel, renderStatusReply(info, link), {
+      parseMode: 'HTML',
+      threadTs: ctx.replyThread,
+      replyTo: telegramReplyTarget(msg)
+    })
+  },
+
+  selectCard(conn: unknown, msg: NormalizedMessage, ctx: CommandChromeContext, card: SelectCardSpec): boolean {
+    void (conn as TelegramConnection).postCard(
+      ctx.channel,
+      card.header,
+      telegramSelectButtons(card.kind, card.current, card.options),
+      { threadTs: ctx.replyThread, replyTo: telegramReplyTarget(msg) }
+    )
+    return true
+  }
+}

--- a/packages/daemon/test/command-chrome.test.ts
+++ b/packages/daemon/test/command-chrome.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { CommandChromeRegistry } from '../src/platforms/command-chrome.js'
+import { slackCommandChrome } from '../src/platforms/slack/command-chrome.js'
+import {
+  parseTelegramSelect,
+  telegramCommandChrome,
+  telegramSelectButtons
+} from '../src/platforms/telegram/command-chrome.js'
+import { discordCommandChrome } from '../src/platforms/discord/command-chrome.js'
+import { feishuCommandChrome } from '../src/platforms/feishu/command-chrome.js'
+import type { NormalizedMessage } from '../src/messages/normalized.js'
+
+const ctx = { channel: 'C1', replyThread: '1700000000.001', sessionKey: 'k1' }
+
+const registry = (() => {
+  const r = new CommandChromeRegistry<NormalizedMessage, never>(slackCommandChrome as never)
+  r.register(telegramCommandChrome as never)
+  r.register(discordCommandChrome as never)
+  r.register(feishuCommandChrome as never)
+  return r
+})()
+
+describe('command chrome registry', () => {
+  it('falls back to the core (Slack-shaped) surface for rendering', () => {
+    // The pre-existing forks all ended in a Slack-shaped else arm; an unknown
+    // origin must keep landing there.
+    expect(registry.for('some-future-platform')).toBe(slackCommandChrome)
+    expect(registry.for('telegram')).toBe(telegramCommandChrome)
+  })
+
+  it('answers the thread-identity fact with the OPPOSITE default', () => {
+    // Rendering fails open to Slack; coordinates fail closed to the
+    // latest-session fallback. Only Slack's thread identifies the session.
+    expect(registry.threadIdentifiesSession('slack')).toBe(true)
+    for (const p of ['telegram', 'discord', 'feishu', 'some-future-platform', 'constructor']) {
+      expect(registry.threadIdentifiesSession(p)).toBe(false)
+    }
+  })
+})
+
+describe('telegram select encoding', () => {
+  it('round-trips its own buttons', () => {
+    const buttons = telegramSelectButtons('effort', 'high', ['low', 'high', 'max'])
+    expect(buttons).toHaveLength(3)
+    // Tap coordinate is the option INDEX — parse must recover kind + index.
+    expect(parseTelegramSelect(buttons[2]![0]!.callbackData)).toEqual({ kind: 'effort', index: 2 })
+  })
+
+  it('marks the current option and applies permission display labels', () => {
+    const buttons = telegramSelectButtons('permission', 'agent-full-access', ['agent-full-access'])
+    // Raw mode ids render through the shared display alias, exactly as the
+    // pre-seam buildSelectCard did via selectDisplay.
+    expect(buttons[0]![0]!.text).toBe('✅ Full Access')
+  })
+
+  it('rejects callback data this scheme did not mint', () => {
+    for (const data of ['x:1', 'm:', 'm:one', 'ac_sel:m:1', '']) {
+      expect(parseTelegramSelect(data)).toBeNull()
+    }
+  })
+})
+
+describe('per-platform reply anchoring', () => {
+  const baseMsg = (over: Partial<NormalizedMessage>): NormalizedMessage =>
+    ({
+      platform: 'telegram',
+      channel: '-100',
+      msgId: 'tg:-100:42',
+      text: '/status',
+      sender: { id: 'u1', isBot: false },
+      source: 'user',
+      isDm: false,
+      mentionedBots: [],
+      ...over
+    }) as NormalizedMessage
+
+  it('telegram anchors the control reply to the command message', () => {
+    const calls: unknown[][] = []
+    const conn = { postMessage: (...a: unknown[]) => void calls.push(a) }
+    telegramCommandChrome.reply(conn, baseMsg({}), ctx, 'ok')
+    expect(calls[0]).toEqual(['C1', 'ok', '1700000000.001', { replyTo: 42 }])
+  })
+
+  it('slack (core) posts into the reply thread with no anchor', () => {
+    const calls: unknown[][] = []
+    const conn = { postMessage: (...a: unknown[]) => void calls.push(a) }
+    slackCommandChrome.reply(conn, undefined, ctx, 'ok')
+    expect(calls[0]).toEqual(['C1', 'ok', '1700000000.001'])
+  })
+
+  it('discord renders the select card only under its 25-button ceiling', () => {
+    const posts: unknown[][] = []
+    const conn = { postChrome: (...a: unknown[]) => void posts.push(a) }
+    const many = Array.from({ length: 26 }, (_, i) => `m${i}`)
+    expect(discordCommandChrome.selectCard!(conn, undefined, ctx, { kind: 'model', options: many, header: 'h' })).toBe(
+      false
+    )
+    expect(posts).toHaveLength(0)
+    expect(
+      discordCommandChrome.selectCard!(conn, undefined, ctx, { kind: 'model', options: ['a', 'b'], header: 'h' })
+    ).toBe(true)
+    // The resolved session key rides the card so a tap routes back by key.
+    expect(posts[0]![2]).toMatchObject({ sessionKey: 'k1' })
+  })
+
+  it('feishu offers no select card at all', () => {
+    expect(feishuCommandChrome.selectCard).toBeUndefined()
+    expect(slackCommandChrome.selectCard).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Eleventh PR of stage S2; third class (c) extraction — the audit's **`command chrome renderer`** cluster.

## What moved

In-conversation control commands are core policy end to end: routing, admission, session resolution, sticky overrides. What was *not* core was the last inch — how a short control reply, a `/status` line, or a tappable select card is **presented** — and that inch was four inline forks inside `handleCommand`:

| concern | Telegram | Discord | Feishu | Slack (= core) |
| --- | --- | --- | --- | --- |
| control reply | reply-anchored to the command message | reply thread | reply thread | reply thread |
| `/status` | HTML chrome + tappable View link | markdown + real link **button** (`<url\|text>` renders literally there) | plain text + `🔗 <url>` line | compact pipe-linked status line |
| select card | inline keyboard | button grid, 25-button ceiling → text-list fallback | none | none |
| thread identifies session? | no | no | no | **yes** |

## Two lookups, two fail directions — on purpose

- **Rendering** falls back to the core (Slack-shaped) surface: every pre-existing fork ended in a Slack-shaped `else` arm.
- **The thread-identity fact** defaults **false**: the pre-existing read was `platform === 'slack' ? msg.thread : undefined`, so an unknown platform must keep resolving through the latest-session fallback, not inherit Slack's coordinate trust.

Collapsing those into one lookup would have silently changed one or the other.

## Encoding moves with its buttons

Telegram's `<kindCode>:<index>` callback format (64-byte `callback_data` budget) was encoded in `buildSelectCard` and decoded 350 lines away in `handleTelegramCallback`. Both now live in `telegram/command-chrome.ts` (`telegramSelectButtons` / `parseTelegramSelect`), mirroring Discord, whose `ac_sel:<code>:<index>` scheme already lives in its own render module.

## Deduplication

`commandSessionForLatest` (Telegram callbacks) and `slackShortcutSession` (Slack message shortcuts) were the same latest-admitted-session scan duplicated with different platform filters; both now parameterize one `latestAdmittedSession` helper — the caller is already platform-specific and names its platform as **data, not a branch**.

Core keeps the naming policy (header text, option ids, display aliases) so every platform lists the same options under the same labels; surfaces own only the interaction shape.

## Verification

- `pnpm typecheck` clean; `eslint`/`prettier` clean
- daemon suite: **2819 passed**, 46 skipped, incl. **9 new** tests (registry fallback + opposite defaults incl. `constructor` probe, telegram encode/decode round-trip + foreign-data rejection, ✅/display-label pinning, reply anchoring per platform, Discord 25-ceiling both sides, sessionKey riding the Discord card)
- Four-platform conditionals in `daemon.ts`: **60 → 53**

🤖 Generated with [Claude Code](https://claude.com/claude-code)