### PR TITLE
refactor(daemon): ingress coordinate semantics become §7.4 strategies (S2)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -137,6 +137,10 @@ import { SlackNameResolver } from './slack/name-resolver.js'
 import { manifestFor } from './platforms/manifest.js'
 import { loopGuardScopesFor } from './platforms/loop-guard.js'
 import { isPlatformMemberId } from './platforms/member-id.js'
+import { threadKeyForPost } from './platforms/thread-keys.js'
+import { isMalformedPlatformTurn } from './platforms/malformed-turn.js'
+import { registerThreadPromotion, threadPromotionFor } from './platforms/thread-promotion.js'
+import { discordThreadPromotion } from './platforms/discord/thread-promotion.js'
 import { CommandChromeRegistry, type SelectKind } from './platforms/command-chrome.js'
 import { slackCommandChrome } from './platforms/slack/command-chrome.js'
 import {
@@ -321,13 +325,7 @@ import type {
   RequestPermissionResponse
 } from '@agentclientprotocol/sdk'
 import type { Agent, CronDef, Integration } from './agents/agent-schema.js'
-import {
-  fromPlatformMessage,
-  stableMessageId,
-  stableTurnId,
-  threadKeyForPost,
-  type NormalizedMessage
-} from './messages/normalized.js'
+import { fromPlatformMessage, stableMessageId, stableTurnId, type NormalizedMessage } from './messages/normalized.js'
 import { ConnectionPool, type ConnectionKey } from './platforms/registry.js'
 import {
   applyTelegramAction as applyTelegramActionExternal,
@@ -928,20 +926,6 @@ function usesLoopGuard(msg: NormalizedMessage): boolean {
   return msg.source === 'user' && msg.platform !== 'webchat'
 }
 
-/** The exact poison shape produced when a Slack message_changed/assistant metadata
- *  wrapper was normalized as if it were a real message. No supported platform has a
- *  legitimate anonymous, empty, attachment-less user turn, so fail closed and latch. */
-function isMalformedPlatformTurn(msg: NormalizedMessage): boolean {
-  return (
-    msg.platform === 'slack' &&
-    msg.source === 'user' &&
-    !msg.sender.isBot &&
-    msg.sender.id === 'unknown' &&
-    msg.text.trim() === '' &&
-    (msg.attachments?.length ?? 0) === 0
-  )
-}
-
 interface GithubReplyTarget {
   hookId: string
   repo: string
@@ -1484,13 +1468,10 @@ function pendingSessionKey(p: Pending): SessionKey {
   return p.thread !== undefined ? { platform, channel: p.channel, thread: p.thread } : { platform, channel: p.channel }
 }
 
-/** Name for a Discord thread opened off a top-level @mention: the first line of the
- *  prompt, collapsed to one line and clamped to Discord's 100-char thread-name cap
- *  (createThread also clamps). Empty prompts (e.g. attachment-only) get a default. */
-function discordThreadName(text: string): string {
-  const oneLine = text.replace(/\s+/g, ' ').trim().slice(0, 90)
-  return oneLine || 'Agent thread'
-}
+// §7.4 thread promotion: Discord is the one platform that answers a top-level
+// channel @mention in a freshly opened thread. Registered at module scope so
+// every Daemon instance (including test constructions) sees the same registry.
+registerThreadPromotion(discordThreadPromotion)
 
 export class Daemon {
   private readonly evaluation: EvaluationEventEmitter
@@ -5598,14 +5579,16 @@ export class Daemon {
       this.log.info(`routing: agent "${result.agentId}" un-muted in ch=${msg.channel} (explicit @mention)`)
     }
     this.log.info(`routing: ch=${msg.channel} → agent "${result.agentId}" (integration ${result.integrationId})`)
-    // A Discord top-level channel @mention: open a thread off it first, then dispatch
-    // into that thread (Slack-parity). Async (a REST call), so it runs on its own path;
-    // dispatch is fire-and-forget either way.
-    if (msg.platform === 'discord' && (msg.promoteToThread ?? msg.discordTopLevel)) {
-      const topLevel = this.dispatchDiscordTopLevel(result.agentId, msg, result.integrationId)
+    // A top-level channel @mention on a platform with thread promotion (§7.4
+    // openThreadForTopLevel — Discord): open a thread off it first, then dispatch
+    // into that thread (Slack-parity). Async (a REST call), so it runs on its own
+    // path; dispatch is fire-and-forget either way.
+    const promotion = threadPromotionFor(msg.platform)
+    if (promotion?.wants(msg)) {
+      const topLevel = this.dispatchPromotedTopLevel(promotion, result.agentId, msg, result.integrationId)
       topLevel.catch((err) => this.log.error(`dispatch failed for agent "${result.agentId}": ${formatErr(err)}`))
       // The re-threaded dispatch owns its own admission; expose a coarse handle
-      // (virtual ingress never produces discordTopLevel messages).
+      // (virtual ingress never produces promotion-seeking messages).
       return {
         kind: 'dispatched',
         handle: {
@@ -5642,29 +5625,25 @@ export class Daemon {
    * continuity. Best-effort: if thread creation fails (e.g. the bot lacks Create Public
    * Threads), we fall back to replying in the channel (the pre-thread behavior).
    */
-  private async dispatchDiscordTopLevel(agentId: string, msg: NormalizedMessage, integrationId: string): Promise<void> {
-    const conn = this.dcConnByIntegration.get(integrationId)
-    const messageId = msg.msgId.split(':').pop() ?? ''
-    const threadId = conn ? await conn.createThread(msg.channel, messageId, discordThreadName(msg.text)) : undefined
-    if (threadId) {
-      this.log.info(`discord: opened thread ${threadId} for ch=${msg.channel} msg=${messageId}`)
-      // The session is about to key on the thread; record the channel it belongs to (and
-      // its space) NOW, while `msg.channel` still names the parent — channel discovery
-      // then reports this one channel instead of a row per thread we open under it.
-      this.store.setChannelScope(threadId, { parentId: msg.channel }, this.clock.now())
-      // Re-key the turn onto the thread channel (channel == thread == session; see
-      // discord/normalize.ts). msgId keeps the original message id → its `ts`, which
-      // equals the thread id, so the session treats this message as the thread root.
-      msg.parentChannel = msg.channel
-      msg.channel = threadId
-      msg.thread = threadId
-      // The session now keys on the thread id, not the parent channel the inbound
-      // resolver already noted — label the thread too so the console shows its name.
-      // `conn` is non-null here (threadId is only set when createThread ran on it).
-      if (conn) this.channelNameResolver?.noteChannel(conn, threadId)
-    } else {
-      this.log.debug(`discord: no thread opened for ch=${msg.channel} — replying in channel`)
-    }
+  /** Run the platform's thread promotion (§7.4), then dispatch onto the re-keyed
+   *  coordinates. The strategy owns everything platform-shaped; core supplies the
+   *  channel-scope/labeling bookkeeping it cannot reach. */
+  private async dispatchPromotedTopLevel(
+    promotion: NonNullable<ReturnType<typeof threadPromotionFor>>,
+    agentId: string,
+    msg: NormalizedMessage,
+    integrationId: string
+  ): Promise<void> {
+    await promotion.promote(
+      {
+        setChannelScope: (channel, scope) => this.store.setChannelScope(channel, scope, this.clock.now()),
+        noteChannel: (conn, channel) => this.channelNameResolver?.noteChannel(conn as never, channel),
+        info: (m) => this.log.info(m),
+        debug: (m) => this.log.debug(m)
+      },
+      this.connForIntegration(integrationId),
+      msg
+    )
     await this.dispatch(agentId, msg, integrationId)
   }
 
@@ -14645,7 +14624,7 @@ export class Daemon {
    *  is independent of which sibling integration ultimately handles the message. */
   private discoverGatedConversations(msg: NormalizedMessage, srcIntegrationIds: string[]): void {
     if (msg.sender.isBot || msg.source !== 'user') return
-    const isDm = msg.isDm || (msg.platform === 'slack' && msg.channel.startsWith('D'))
+    const isDm = msg.isDm || manifestFor(msg.platform).dmChannelPattern?.test(msg.channel) === true
     for (const integrationId of srcIntegrationIds) {
       const int = this.integrationConfigById(integrationId)
       if (!int || int.platform !== msg.platform) continue
@@ -14662,8 +14641,9 @@ export class Daemon {
 
   private maybeGatedNotice(msg: NormalizedMessage, srcIntegrationIds: string[]): void {
     if (msg.sender.isBot || msg.source !== 'user') return
-    // Slack `app_mention` payloads may omit channel_type, so hedge on the D-prefix.
-    const isDm = msg.isDm || (msg.platform === 'slack' && msg.channel.startsWith('D'))
+    // A wire event may omit the conversation type (Slack `app_mention` omits
+    // channel_type) — hedge on the platform's declared DM id syntax (§5).
+    const isDm = msg.isDm || manifestFor(msg.platform).dmChannelPattern?.test(msg.channel) === true
     for (const integrationId of srcIntegrationIds) {
       const int = this.integrationConfigById(integrationId)
       if (!int || int.platform !== msg.platform) continue

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -1,6 +1,6 @@
 import type { ToolDescriptor } from './tools.js'
 import type { MemoryProvider } from '../agents/memory-provider.js'
-import { threadKeyForPost } from '../messages/normalized.js'
+import { threadKeyForPost } from '../platforms/thread-keys.js'
 import type { ChannelAgentsReq, ChannelAgentsOk, KnowledgeSearchOk, Platform } from '@agentconnect.md/protocol'
 import { randomUUID } from 'node:crypto'
 import { MemoryPathError, MemoryTooLargeError } from '../agents/memory.js'

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -90,28 +90,6 @@ export function stableTurnId(agentId: string, msg: MessageIdentityFields): strin
   return `${agentId}:${stableMessageId(msg)}`
 }
 
-/**
- * The session-thread key for a message this daemon just posted at a channel ROOT — the outbound
- * mirror of inbound thread canonicalization, and the ONE place that conversion lives. A post
- * whose key does not match what the next inbound reply resolves to opens a session that reply
- * can never reach, so this has to follow each platform's own conversation model:
- *
- * - Slack, and Feishu group chats, thread off a message: the post's own ts IS the segment.
- * - Telegram groups have no native threads, so a reply resolves to `tg:<root message id>`. The
- *   `tg:` prefix also keeps reply roots out of the numeric forum-TOPIC namespace. (A root post
- *   into a forum lands in General, whose messages carry no `is_topic_message`, so replies there
- *   resolve through the same `tg:` ladder rather than to a topic id.)
- * - Discord conversations are the CHANNEL — every inbound message there keys the channel id, so
- *   a post cannot open a thread of its own.
- * - A DM is one continuous conversation, keyed `dm` on Telegram and by the chat on Feishu. A post
- *   into one joins it; it never starts a second.
- *
- * Whether the target is a DM is not derivable from the id, so callers pass what the platform
- * reports (`isIm` from `getChannelInfo`), defaulting to a non-DM conversation.
- */
-export function threadKeyForPost(platform: string, channel: string, ts: string, isDm = false): string {
-  if (platform === 'discord') return channel
-  if (platform === 'telegram') return isDm ? 'dm' : /^\d+$/.test(ts) ? `tg:${ts}` : ts
-  if (platform === 'feishu' && isDm) return channel
-  return ts
-}
+/** The outbound thread-key strategy moved to `platforms/thread-keys.ts` (§7.4) —
+ * one registered arm per platform, beside the inbound canonicalization it must
+ * agree with. */

--- a/packages/daemon/src/platforms/discord/thread-promotion.ts
+++ b/packages/daemon/src/platforms/discord/thread-promotion.ts
@@ -1,0 +1,58 @@
+/**
+ * Discord's **thread promotion** (§7.4 `openThreadForTopLevel`, stage S2).
+ *
+ * A top-level channel @mention opens a thread off the triggering message first,
+ * then the turn dispatches INTO that thread (Slack-parity). The re-keying rules
+ * are Discord's conversation model: channel == thread == session
+ * (see discord/normalize.ts), so the freshly created thread id becomes all
+ * three coordinates, and the original message id — whose ts equals the thread
+ * id — makes the session treat that message as the thread root.
+ *
+ * WANT is a dual-shape read: the generic `promoteToThread` coordinate (§6.5)
+ * first, Discord's legacy `discordTopLevel` named field as the fallback until
+ * the legacy emission flip retires it.
+ */
+import type { DiscordConnection } from '../../discord/connection.js'
+import type { ThreadPromotion, ThreadPromotionHost, ThreadPromotionMessage } from '../thread-promotion.js'
+
+/** Name for the opened thread: the first line of the prompt, collapsed to one
+ *  line and clamped under Discord's 100-char thread-name cap (createThread also
+ *  clamps). Empty prompts (e.g. attachment-only) get a default. */
+export function discordThreadName(text: string): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim().slice(0, 90)
+  return oneLine || 'Agent thread'
+}
+
+export const discordThreadPromotion: ThreadPromotion<ThreadPromotionMessage> = {
+  platform: 'discord',
+
+  wants(msg: ThreadPromotionMessage): boolean {
+    return (msg.promoteToThread ?? (msg as { discordTopLevel?: boolean }).discordTopLevel) === true
+  },
+
+  async promote(host: ThreadPromotionHost, conn: unknown, msg: ThreadPromotionMessage): Promise<void> {
+    const dc = conn as DiscordConnection | undefined
+    const messageId = msg.msgId.split(':').pop() ?? ''
+    const threadId = dc ? await dc.createThread(msg.channel, messageId, discordThreadName(msg.text)) : undefined
+    if (!threadId) {
+      host.debug(`discord: no thread opened for ch=${msg.channel} — replying in channel`)
+      return
+    }
+    host.info(`discord: opened thread ${threadId} for ch=${msg.channel} msg=${messageId}`)
+    // The session is about to key on the thread; record the channel it belongs to
+    // (and its space) NOW, while `msg.channel` still names the parent — channel
+    // discovery then reports this one channel instead of a row per thread we open
+    // under it.
+    host.setChannelScope(threadId, { parentId: msg.channel })
+    // Re-key the turn onto the thread channel (channel == thread == session; see
+    // discord/normalize.ts). msgId keeps the original message id → its `ts`, which
+    // equals the thread id, so the session treats this message as the thread root.
+    msg.parentChannel = msg.channel
+    msg.channel = threadId
+    msg.thread = threadId
+    // The session now keys on the thread id, not the parent channel the inbound
+    // resolver already noted — label the thread too so the console shows its name.
+    // `conn` is non-null here (threadId is only set when createThread ran on it).
+    host.noteChannel(conn, threadId)
+  }
+}

--- a/packages/daemon/src/platforms/malformed-turn.ts
+++ b/packages/daemon/src/platforms/malformed-turn.ts
@@ -1,0 +1,48 @@
+/**
+ * The **malformed-turn strategy** (§7.4, stage S2): can a platform's ingress
+ * produce a poison shape — a wrapper event normalized as if it were a real
+ * message — and what does that shape look like?
+ *
+ * Only the platform can answer, because the shape is an artifact of ITS wire
+ * format meeting the normalizer. Slack's is the `message_changed` / assistant
+ * metadata wrapper: normalized, it reads as an anonymous, empty,
+ * attachment-less user turn — which no supported platform produces
+ * legitimately, so the detector fails closed and the caller latches the
+ * conversation's loop guard rather than replaying the wrapper as input.
+ *
+ * The default is "never malformed": a platform with no registered detector has
+ * no known poison shape, which is exactly the pre-existing behavior for every
+ * non-Slack platform. Detectors gate DESTRUCTIVE handling (loop-guard latches,
+ * durable inbox drops), so a false positive is worse than a false negative —
+ * register a shape only when it is exact.
+ */
+
+/** The message fields a detector may read. `NormalizedMessage` satisfies it
+ *  structurally. */
+export interface MalformedTurnMessage {
+  platform: string
+  source: string
+  sender: { id: string; isBot: boolean }
+  text: string
+  attachments?: unknown[]
+}
+
+const DETECTORS = new Map<string, (msg: MalformedTurnMessage) => boolean>([
+  [
+    'slack',
+    // The exact poison shape produced when a Slack message_changed/assistant
+    // metadata wrapper was normalized as if it were a real message.
+    (msg) =>
+      msg.source === 'user' &&
+      !msg.sender.isBot &&
+      msg.sender.id === 'unknown' &&
+      msg.text.trim() === '' &&
+      (msg.attachments?.length ?? 0) === 0
+  ]
+])
+
+/** Is this turn a known poison shape of its platform? Total by construction:
+ *  no registered detector means no known poison shape — never malformed. */
+export function isMalformedPlatformTurn(msg: MalformedTurnMessage): boolean {
+  return DETECTORS.get(msg.platform)?.(msg) ?? false
+}

--- a/packages/daemon/src/platforms/manifest.ts
+++ b/packages/daemon/src/platforms/manifest.ts
@@ -56,6 +56,13 @@ export interface PlatformManifest {
   /** Diagnostic label; never parsed. */
   readonly platform: string
   readonly membershipEnumeration: MembershipEnumeration
+  /** Channel ids syntactically recognizable as DIRECT MESSAGES, for ingress whose
+   *  wire event omits the conversation type (Slack `app_mention` may omit
+   *  `channel_type`, but its DM ids are D-prefixed). A PRE-DISPATCH read: gated-
+   *  conversation discovery consults it before routing resolves any target.
+   *  Absent when the id syntax carries no DM signal — then `msg.isDm` is all
+   *  there is. */
+  readonly dmChannelPattern?: RegExp
 }
 
 /** The conservative arm of every axis — see the fail-closed note above. */
@@ -72,7 +79,7 @@ export const DEFAULT_MANIFEST: Omit<PlatformManifest, 'platform'> = {
 const MANIFESTS = new Map<string, Omit<PlatformManifest, 'platform'>>([
   // Slack is the only platform with an authoritative membership snapshot — which
   // is why the branches this replaces read "Slack does X, everyone else does Y".
-  ['slack', { membershipEnumeration: 'authoritative' }],
+  ['slack', { membershipEnumeration: 'authoritative', dmChannelPattern: /^D/ }],
   ['telegram', { membershipEnumeration: 'observed' }],
   ['discord', { membershipEnumeration: 'observed' }],
   ['feishu', { membershipEnumeration: 'observed' }]

--- a/packages/daemon/src/platforms/thread-keys.ts
+++ b/packages/daemon/src/platforms/thread-keys.ts
@@ -1,0 +1,51 @@
+/**
+ * The **outbound thread-key strategy** (`threadKeyForPost` in §7.4, stage S2) —
+ * the outbound mirror of inbound thread canonicalization, and the ONE place that
+ * conversion lives.
+ *
+ * A post whose key does not match what the next inbound reply resolves to opens
+ * a session that reply can never reach, so this has to follow each platform's
+ * own conversation model:
+ *
+ *  - Slack, and Feishu group chats, thread off a message: the post's own ts IS
+ *    the segment.
+ *  - Telegram groups have no native threads, so a reply resolves to
+ *    `tg:<root message id>`. The `tg:` prefix also keeps reply roots out of the
+ *    numeric forum-TOPIC namespace. (A root post into a forum lands in General,
+ *    whose messages carry no `is_topic_message`, so replies there resolve
+ *    through the same `tg:` ladder rather than to a topic id.)
+ *  - Discord conversations are the CHANNEL — every inbound message there keys
+ *    the channel id, so a post cannot open a thread of its own.
+ *  - A DM is one continuous conversation, keyed `dm` on Telegram and by the
+ *    chat on Feishu. A post into one joins it; it never starts a second.
+ *
+ * Whether the target is a DM is not derivable from the id, so callers pass what
+ * the platform reports (`isIm` from `getChannelInfo`), defaulting to a non-DM
+ * conversation.
+ *
+ * The DEFAULT arm — the post's own ts — is Slack's rule and the core one:
+ * webchat/hook/dream anchors and any unknown platform key exactly as before
+ * this seam, when the function was three platform literals in
+ * `messages/normalized.ts`. Each arm must agree with its platform's inbound
+ * canonicalization (`platforms/<id>/threading.ts`), which is why they are
+ * registered per platform rather than inferred.
+ */
+
+type ThreadKeyStrategy = (channel: string, ts: string, isDm: boolean) => string
+
+const STRATEGIES = new Map<string, ThreadKeyStrategy>([
+  // Conversations ARE the channel; a post cannot open a thread of its own.
+  ['discord', (channel) => channel],
+  // Reply-based threading: numeric message ids enter the `tg:` reply-root
+  // namespace; DMs are one continuous conversation.
+  ['telegram', (_channel, ts, isDm) => (isDm ? 'dm' : /^\d+$/.test(ts) ? `tg:${ts}` : ts)],
+  // Group chats thread off the post; a DM is keyed by the chat itself.
+  ['feishu', (channel, ts, isDm) => (isDm ? channel : ts)]
+])
+
+/** The session-thread key for a message this daemon just posted at a channel
+ *  ROOT. Total by construction: an unregistered platform threads off the post's
+ *  own ts, the Slack/core rule. */
+export function threadKeyForPost(platform: string, channel: string, ts: string, isDm = false): string {
+  return STRATEGIES.get(platform)?.(channel, ts, isDm) ?? ts
+}

--- a/packages/daemon/src/platforms/thread-promotion.ts
+++ b/packages/daemon/src/platforms/thread-promotion.ts
@@ -1,0 +1,67 @@
+/**
+ * The **thread-promotion strategy** (`openThreadForTopLevel` in §7.4, stage S2).
+ *
+ * Some platforms want a top-level channel @mention answered in a THREAD opened
+ * off it, Slack-parity style, rather than in the channel body. Whether a
+ * message asks for that, and how the thread is opened and the turn re-keyed
+ * onto it, is the platform's to say:
+ *
+ *  - the WANT is a coordinate fact of the inbound message — the generic
+ *    `promoteToThread` coordinate (§6.5), with the platform's legacy named
+ *    field as the dual-shape fallback until the emission flip;
+ *  - the PROMOTION is a platform API call (Discord `createThread`) plus the
+ *    re-keying rules of that platform's conversation model.
+ *
+ * Only Discord registers one today. The default is "no promotion", which is
+ * the pre-existing behavior for every other platform — their top-level posts
+ * reply in place. Core decides WHEN to run it (before dispatch, owning the
+ * admission handle); the strategy decides everything platform-shaped.
+ */
+
+/** What a promotion may ask of core. Deliberately narrow: recording the
+ *  parent-channel scope and labeling the new thread are core bookkeeping the
+ *  platform cannot reach on its own. */
+export interface ThreadPromotionHost {
+  /** Record the thread's parent channel NOW, while the message still names it —
+   *  channel discovery then reports the one channel instead of a row per thread. */
+  setChannelScope(channel: string, scope: { parentId: string }): void
+  /** Ask the channel-name resolver to label the freshly opened thread. */
+  noteChannel(conn: unknown, channel: string): void
+  info(message: string): void
+  debug(message: string): void
+}
+
+/** The message fields a promotion may read and re-key. `NormalizedMessage`
+ *  satisfies it structurally; `promote` mutates the coordinate fields the same
+ *  way inbound normalization would have, had the message arrived in-thread. */
+export interface ThreadPromotionMessage {
+  platform: string
+  channel: string
+  thread?: string
+  parentChannel?: string
+  msgId: string
+  text: string
+  promoteToThread?: boolean
+}
+
+export interface ThreadPromotion<TMsg extends ThreadPromotionMessage> {
+  readonly platform: string
+  /** Does this inbound message ask to be answered in a fresh thread? */
+  wants(msg: TMsg): boolean
+  /** Open the thread and re-key `msg` onto it (in place). Best-effort: on
+   *  failure the message keeps its channel coordinates and the reply lands
+   *  in-channel. */
+  promote(host: ThreadPromotionHost, conn: unknown, msg: TMsg): Promise<void>
+}
+
+const PROMOTIONS = new Map<string, ThreadPromotion<ThreadPromotionMessage>>()
+
+export function registerThreadPromotion(promotion: ThreadPromotion<ThreadPromotionMessage>): void {
+  PROMOTIONS.set(promotion.platform, promotion)
+}
+
+/** The platform's promotion, or undefined — no registered promotion means
+ *  top-level posts reply in place, every non-Discord platform's behavior. */
+export function threadPromotionFor(platform: string): ThreadPromotion<ThreadPromotionMessage> | undefined {
+  return PROMOTIONS.get(platform)
+}

--- a/packages/daemon/test/ingress-coordinate-strategies.test.ts
+++ b/packages/daemon/test/ingress-coordinate-strategies.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { threadKeyForPost } from '../src/platforms/thread-keys.js'
+import { isMalformedPlatformTurn } from '../src/platforms/malformed-turn.js'
+import { threadPromotionFor, type ThreadPromotionHost } from '../src/platforms/thread-promotion.js'
+import { discordThreadPromotion, discordThreadName } from '../src/platforms/discord/thread-promotion.js'
+import { manifestFor } from '../src/platforms/manifest.js'
+
+describe('outbound thread keys (threadKeyForPost)', () => {
+  it('keeps each platform aligned with its inbound canonicalization', () => {
+    // Slack (and core): the post's own ts IS the thread segment.
+    expect(threadKeyForPost('slack', 'C1', '1700.1')).toBe('1700.1')
+    // Discord: conversations are the channel; a post cannot open a thread.
+    expect(threadKeyForPost('discord', 'chan9', '999')).toBe('chan9')
+    // Telegram: numeric ids enter the tg: reply-root namespace…
+    expect(threadKeyForPost('telegram', '-100', '42')).toBe('tg:42')
+    // …non-numeric anchors (already-canonical keys) pass through…
+    expect(threadKeyForPost('telegram', '-100', 'tg:42')).toBe('tg:42')
+    // …and a DM is one continuous conversation.
+    expect(threadKeyForPost('telegram', '-100', '42', true)).toBe('dm')
+    // Feishu: group chats thread off the post; a DM is keyed by the chat.
+    expect(threadKeyForPost('feishu', 'oc_1', 'om_9')).toBe('om_9')
+    expect(threadKeyForPost('feishu', 'oc_1', 'om_9', true)).toBe('oc_1')
+  })
+
+  it('defaults an unregistered platform to the core rule (own ts)', () => {
+    expect(threadKeyForPost('some-future-platform', 'c', 't1')).toBe('t1')
+    expect(threadKeyForPost('constructor', 'c', 't1', true)).toBe('t1')
+  })
+})
+
+describe('malformed-turn detection', () => {
+  const poison = {
+    platform: 'slack',
+    source: 'user',
+    sender: { id: 'unknown', isBot: false },
+    text: '  ',
+    attachments: []
+  }
+
+  it('recognizes the exact Slack wrapper poison shape', () => {
+    expect(isMalformedPlatformTurn(poison)).toBe(true)
+  })
+
+  it('does not trip on any nearby legitimate shape', () => {
+    // Each single-field deviation is a real message; the detector gates
+    // destructive handling (loop-guard latches, inbox drops), so it must be exact.
+    expect(isMalformedPlatformTurn({ ...poison, text: 'hi' })).toBe(false)
+    expect(isMalformedPlatformTurn({ ...poison, sender: { id: 'U1', isBot: false } })).toBe(false)
+    expect(isMalformedPlatformTurn({ ...poison, attachments: [{}] })).toBe(false)
+    expect(isMalformedPlatformTurn({ ...poison, source: 'hook' })).toBe(false)
+  })
+
+  it('knows no poison shape on other platforms', () => {
+    for (const platform of ['telegram', 'discord', 'feishu', 'webchat', 'some-future-platform']) {
+      expect(isMalformedPlatformTurn({ ...poison, platform })).toBe(false)
+    }
+  })
+})
+
+describe('thread promotion', () => {
+  it('is registered for Discord only; everyone else replies in place', () => {
+    for (const platform of ['slack', 'telegram', 'feishu', 'webchat', 'some-future-platform']) {
+      expect(threadPromotionFor(platform)).toBeUndefined()
+    }
+  })
+
+  it('wants promotion via the generic coordinate, legacy field as fallback', () => {
+    const base = { platform: 'discord', channel: 'c', msgId: 'discord:c:1', text: 'hi' }
+    expect(discordThreadPromotion.wants({ ...base, promoteToThread: true })).toBe(true)
+    expect(discordThreadPromotion.wants({ ...base, discordTopLevel: true } as never)).toBe(true)
+    // The generic coordinate, once present, is authoritative — an explicit false
+    // must not fall through to the legacy field.
+    expect(discordThreadPromotion.wants({ ...base, promoteToThread: false, discordTopLevel: true } as never)).toBe(
+      false
+    )
+    expect(discordThreadPromotion.wants(base)).toBe(false)
+  })
+
+  it('re-keys the turn onto the opened thread, recording the parent first', () => {
+    const events: string[] = []
+    const host: ThreadPromotionHost = {
+      setChannelScope: (channel, scope) => void events.push(`scope:${channel}<-${scope.parentId}`),
+      noteChannel: (_conn, channel) => void events.push(`note:${channel}`),
+      info: () => {},
+      debug: () => {}
+    }
+    const conn = { createThread: async () => 'T9' }
+    const msg = { platform: 'discord', channel: 'C1', msgId: 'discord:C1:M1', text: 'do the thing' }
+    return discordThreadPromotion.promote(host, conn, msg).then(() => {
+      expect(msg).toMatchObject({ parentChannel: 'C1', channel: 'T9', thread: 'T9' })
+      // Parent scope is recorded while msg.channel still names the parent.
+      expect(events).toEqual(['scope:T9<-C1', 'note:T9'])
+    })
+  })
+
+  it('leaves coordinates untouched when no thread opens', async () => {
+    const host: ThreadPromotionHost = {
+      setChannelScope: () => {
+        throw new Error('must not record scope')
+      },
+      noteChannel: () => {
+        throw new Error('must not label')
+      },
+      info: () => {},
+      debug: () => {}
+    }
+    const msg = { platform: 'discord', channel: 'C1', msgId: 'discord:C1:M1', text: 'hi' }
+    await discordThreadPromotion.promote(host, { createThread: async () => undefined }, msg)
+    expect(msg).toEqual({ platform: 'discord', channel: 'C1', msgId: 'discord:C1:M1', text: 'hi' })
+  })
+
+  it('clamps thread names to one line under the Discord cap', () => {
+    expect(discordThreadName('first line\nsecond line')).toBe('first line second line')
+    expect(discordThreadName('x'.repeat(200))).toHaveLength(90)
+    expect(discordThreadName('   ')).toBe('Agent thread')
+  })
+})
+
+describe('manifest dmChannelPattern', () => {
+  it('recognizes Slack D-prefixed DM channels; no one else declares one', () => {
+    // Slack app_mention payloads may omit channel_type — the D-prefix hedge is a
+    // pre-dispatch read (gating discovery runs before routing), hence manifest.
+    expect(manifestFor('slack').dmChannelPattern?.test('D0123')).toBe(true)
+    expect(manifestFor('slack').dmChannelPattern?.test('C0123')).toBe(false)
+    for (const p of ['telegram', 'discord', 'feishu', 'some-future-platform']) {
+      expect(manifestFor(p).dmChannelPattern).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
Twelfth PR of stage S2; fourth class (c) batch — four small strategies that all answer the same question: **what do this platform's coordinates mean, on the way in and out?**

## `threadKeyForPost` → `platforms/thread-keys.ts`

The outbound mirror of inbound thread canonicalization, and the one place that conversion lives: a post whose key does not match what the next inbound reply resolves to opens a session that reply can never reach. Was three platform literals in `messages/normalized.ts` — which the `daemon.ts`-scoped conditional count **never even saw**: a §6 grep blind-spot made concrete. Default arm = the post's own ts (Slack/core rule), so webchat/hook/dream anchors and unknown platforms key exactly as before. `mcp/ops.ts` consumers unchanged beyond the import path.

## `isMalformedPlatformTurn` → `platforms/malformed-turn.ts`

A poison shape is an artifact of a platform's wire format meeting the normalizer — Slack's `message_changed`/assistant wrapper reads as an anonymous, empty, attachment-less user turn. Detectors gate **destructive** handling (loop-guard latches, durable inbox drops), so the default is "never malformed" and a registered shape must be exact; tests pin every single-field deviation as non-poison.

## Thread promotion → `platforms/thread-promotion.ts` + `discord/thread-promotion.ts`

The audit's `openThreadForTopLevel` strategy. Whether a top-level @mention wants a fresh thread is a **coordinate fact of the message** — the generic `promoteToThread` (§6.5) first, legacy `discordTopLevel` as the dual-shape fallback, and an explicit `false` is authoritative (it must not fall through to the legacy field; test-pinned). How the thread opens and how the turn re-keys onto it is the platform's conversation model, so `dispatchDiscordTopLevel`'s body moves behind the strategy with a three-capability host port (`setChannelScope` / `noteChannel` / log); core keeps dispatch and the admission handle.

## `dmChannelPattern` → one new manifest axis (§5)

This one **earns** the manifest, by the exact rule #532 enforced: gated-conversation discovery reads it **before** routing resolves any target — a genuinely pre-dispatch read, unlike the `statusSurface` field that review rejected. Slack declares `/^D/` (`app_mention` may omit `channel_type`); nobody else declares one, so `msg.isDm` remains all there is elsewhere.

## Verification

- `pnpm typecheck` clean; `eslint`/`prettier` clean
- daemon suite: **2830 passed**, 46 skipped, incl. **11 new** tests (per-platform thread-key arms + core default incl. `constructor` probe; exact poison shape + every near-miss + cross-platform immunity; promotion re-keying order — parent scope recorded while `msg.channel` still names the parent — and the no-thread path leaving coordinates untouched; the manifest pattern)
- message package suite unchanged
- Four-platform conditionals in `daemon.ts`: **53 → 49** (plus 3 retired in `normalized.ts` the count never included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)