### PR TITLE
fix(sessions): preserve local source provenance

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -193,13 +193,14 @@ hidden unresolved candidate after GitHub sync is enabled.
 
 ### 4.1 Protocol: new telemetry fields
 
-`EventSession` (`packages/protocol/src/frames/telemetry.ts`) gains three
+`EventSession` (`packages/protocol/src/frames/telemetry.ts`) gains four
 optional fields:
 
 ```ts
 conversationKind?: 'dm' | 'group_dm' | 'channel'
 transportScope?: string // trusted workspace/tenant scope for ownerIdentity, §2
 launchCorrelationId?: string // Web API launch provenance, §4.4
+sourceBindingKind?: 'local' | 'external' // daemon-pinned source provenance
 ```
 
 Shared-source sessions additionally report a provider-specific
@@ -241,6 +242,12 @@ is rejected rather than silently reusing the session. A2A descendants carry
 only the audience identity (without Slack integration ids or GitHub delivery
 proof) and inherit the parent's access boundary across daemons.
 
+`sourceBindingKind` distinguishes a provider-bound session from local
+automation that deliberately keeps platform-shaped coordinates for session-key
+compatibility. An explicit `local` binding bypasses the legacy Slack-candidate
+fallback; an absent value still takes that fail-closed path for older daemons.
+Existing classifications are left unchanged.
+
 Headless GitHub messages also namespace the daemon-local session key with the
 numeric repository id. The first post-upgrade delivery therefore starts a clean
 runtime instead of claiming an unscoped legacy runtime whose repository cannot
@@ -252,7 +259,7 @@ The daemon derives this from `NormalizedMessage.isDm` / `isGroupDm`
 to the CP. The `thread === 'dm'` heuristic and an
 `IntegrationChannel.kind` join were both considered and rejected: the former is
 platform-inconsistent, the latter does not cover webhook/generic ingress and
-moves a write-time fact to read time. All three fields are optional ⇒ old
+moves a write-time fact to read time. All four fields are optional ⇒ old
 daemons remain compatible (absent `conversationKind` = `channel` behavior,
 i.e. `org`; absent `transportScope`/`launchCorrelationId` = no owner, fail
 closed).

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -304,6 +304,28 @@ describe('handleEventSession', () => {
     )
   })
 
+  it('does not treat an explicitly local platform-shaped session as a Slack candidate', async () => {
+    const recordMilestone = vi.fn().mockResolvedValue(
+      recorded({
+        visibility: 'org',
+        externalProvider: null,
+        visibilityRev: 1,
+        visibilityAckedRev: 0
+      })
+    )
+    const deps = scopedDeps({
+      session: { recordMilestone },
+      events: { publish: vi.fn() }
+    })
+    const frame = eventSessionFrame()
+    Object.assign(frame.payload as Record<string, unknown>, { sourceBindingKind: 'local' })
+
+    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    const milestone = recordMilestone.mock.calls[0]![0]
+    expect(milestone).not.toHaveProperty('externalCandidate')
+  })
+
   it('marks a forged Slack workspace binding invalid', async () => {
     const recordMilestone = vi.fn().mockResolvedValue(recorded())
     const deps = scopedDeps({

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -50,6 +50,10 @@ async function classifyMilestone(p: EventSession, agentId: AgentId, deps: Daemon
 
 async function externalCandidate(p: EventSession, agentId: AgentId, deps: DaemonWsDeps) {
   const origin = p.externalOrigin
+  // New daemons pin source provenance in their local session row. An explicit
+  // local binding is authoritative for synthetic/platform-shaped coordinates;
+  // absence still takes the conservative mixed-version fallback below.
+  if (p.sourceBindingKind === 'local' && !origin) return undefined
   if (!origin) {
     const triggerId = p.triggeredBy?.startsWith('hook:')
       ? p.triggeredBy.slice('hook:'.length)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12474,6 +12474,9 @@ export class Daemon {
     if (classification?.launchCorrelationId !== undefined) {
       event.launchCorrelationId = classification.launchCorrelationId
     }
+    if (classification?.sourceBindingKind !== undefined) {
+      event.sourceBindingKind = classification.sourceBindingKind
+    }
     // Only a direct trusted ingress reports a credential locator. A2A children
     // persist the same source tuple for the local gate but let the CP inherit
     // the already-validated parent scope instead of presenting the parent's bot

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1925,13 +1925,15 @@ export class LocalStore {
         externalResourceKey?: string
         externalIntegrationId?: string
         externalOrigin?: ExternalSessionOrigin
+        sourceBindingKind?: 'local' | 'external'
       }
     | undefined {
     const row = this.db
       .prepare(
         `SELECT conversationKind, tenantScope, launchCorrelationId,
                 externalProvider, externalRealmKey, externalResourceKind,
-                externalResourceKey, externalIntegrationId, externalOriginJson
+                externalResourceKey, externalIntegrationId, externalOriginJson,
+                sourceBindingKind
          FROM sessions WHERE agentId = ? AND acpSessionId = ?`
       )
       .get(agentId, acpSessionId) as
@@ -1945,6 +1947,7 @@ export class LocalStore {
           externalResourceKey: string | null
           externalIntegrationId: string | null
           externalOriginJson: string | null
+          sourceBindingKind: 'local' | 'external' | null
         }
       | undefined
     if (!row) return undefined
@@ -1957,7 +1960,10 @@ export class LocalStore {
       ...(row.externalResourceKind ? { externalResourceKind: row.externalResourceKind } : {}),
       ...(row.externalResourceKey ? { externalResourceKey: row.externalResourceKey } : {}),
       ...(row.externalIntegrationId ? { externalIntegrationId: row.externalIntegrationId } : {}),
-      ...(row.externalOriginJson ? { externalOrigin: JSON.parse(row.externalOriginJson) as ExternalSessionOrigin } : {})
+      ...(row.externalOriginJson
+        ? { externalOrigin: JSON.parse(row.externalOriginJson) as ExternalSessionOrigin }
+        : {}),
+      ...(row.sourceBindingKind ? { sourceBindingKind: row.sourceBindingKind } : {})
     }
   }
 

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -361,6 +361,10 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       title: 'first',
       status: 'prompting',
       triggeredBy: 'U1',
+      // This platform-shaped cron session is local automation, not a Slack
+      // audience candidate. The CP uses this durable provenance instead of
+      // guessing from the legacy-compatible session key.
+      sourceBindingKind: 'local',
       // Execution-config snapshot: the agent's runtime + schema-defaulted
       // permission/output modes; no explicit model/effort/fast configured ⇒
       // those fields are omitted (runtime default), never fabricated.

--- a/packages/daemon/test/session-capture-gate.test.ts
+++ b/packages/daemon/test/session-capture-gate.test.ts
@@ -85,7 +85,8 @@ describe('capture gate — local state', () => {
     expect(store.getSessionClassification('bot-a', 'acp-external')).toMatchObject({
       externalRealmKey: 'W1',
       externalResourceKey: 'C1',
-      externalIntegrationId: 'integration-new'
+      externalIntegrationId: 'integration-new',
+      sourceBindingKind: 'external'
     })
   })
 })

--- a/packages/protocol/src/frames/session-visibility.test.ts
+++ b/packages/protocol/src/frames/session-visibility.test.ts
@@ -103,20 +103,24 @@ describe('EventSession visibility-classification fields (session-visibility.md Â
     expect(parsed.conversationKind).toBeUndefined()
     expect(parsed.transportScope).toBeUndefined()
     expect(parsed.launchCorrelationId).toBeUndefined()
+    expect(parsed.sourceBindingKind).toBeUndefined()
   })
 
-  it('carries conversationKind + durable transportScope + launchCorrelationId', () => {
+  it('carries conversationKind + durable transportScope + launchCorrelationId + source provenance', () => {
     const parsed = EventSession.parse({
       ...legacyMilestone,
       conversationKind: 'dm',
       transportScope: 'T024BE7LD',
-      launchCorrelationId: CORRELATION_ID
+      launchCorrelationId: CORRELATION_ID,
+      sourceBindingKind: 'local'
     })
     expect(parsed.conversationKind).toBe('dm')
     expect(parsed.transportScope).toBe('T024BE7LD')
     expect(parsed.launchCorrelationId).toBe(CORRELATION_ID)
+    expect(parsed.sourceBindingKind).toBe('local')
     expect(EventSession.safeParse({ ...legacyMilestone, conversationKind: 'group_dm' }).success).toBe(true)
     expect(EventSession.safeParse({ ...legacyMilestone, conversationKind: 'channel' }).success).toBe(true)
+    expect(EventSession.safeParse({ ...legacyMilestone, sourceBindingKind: 'external' }).success).toBe(true)
   })
 
   it('carries the exact accepted GitHub delivery as repository-scope proof', () => {
@@ -157,6 +161,7 @@ describe('EventSession visibility-classification fields (session-visibility.md Â
     expect(EventSession.safeParse({ ...legacyMilestone, transportScope: '' }).success).toBe(false)
     expect(EventSession.safeParse({ ...legacyMilestone, transportScope: 'x'.repeat(201) }).success).toBe(false)
     expect(EventSession.safeParse({ ...legacyMilestone, launchCorrelationId: 'not-a-uuid' }).success).toBe(false)
+    expect(EventSession.safeParse({ ...legacyMilestone, sourceBindingKind: 'unknown' }).success).toBe(false)
   })
 })
 

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -109,6 +109,11 @@ export const EventSession = z.object({
   // `agent/launch`, echoed back so ingest can attribute the session to the
   // launching console user. NOT the launchId fence above.
   launchCorrelationId: z.string().uuid().optional(),
+  // Durable daemon-local source provenance. `local` distinguishes synthetic or
+  // otherwise non-provider sessions that retain platform-shaped coordinates
+  // for session-key compatibility. Absent keeps mixed-version ingest on the
+  // conservative legacy path.
+  sourceBindingKind: z.enum(['local', 'external']).optional(),
   // Immutable audience candidate for a supported shared input. This is
   // metadata-only: the CP validates the integration before binding a scope and
   // resolves current provider membership only on authorized read paths.


### PR DESCRIPTION
## Summary

- carry daemon-pinned local/external source provenance on session milestones
- keep platform-shaped local automation out of the legacy Slack scope fallback
- preserve mixed-version fail-closed behavior when older daemons omit provenance

## Root cause

Headless crons retain Slack-shaped coordinates for session-key compatibility. The daemon already persisted those sessions as local, but session telemetry dropped that fact, so the Control Plane treated new cron sessions as unresolved Slack candidates and degraded the organization policy.

This is intentionally forward-only: existing pending or hidden session classifications are not migrated or rewritten.

## Validation

- protocol session-visibility tests: 11 passed
- daemon session-capture and smoke tests: 43 passed
- Control Plane event-session unit tests: 14 passed
- protocol, daemon, and Control Plane typechecks
- ESLint and Prettier on changed files
- post-rebase daemon tests and typecheck against latest `main`

Created by Codex . GPT-5
