### PR TITLE
refactor(daemon): platform-action decode registry + link-source strategy (S2)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -141,6 +141,7 @@ import { threadKeyForPost } from './platforms/thread-keys.js'
 import { isMalformedPlatformTurn } from './platforms/malformed-turn.js'
 import { registerThreadPromotion, threadPromotionFor } from './platforms/thread-promotion.js'
 import { discordThreadPromotion } from './platforms/discord/thread-promotion.js'
+import { sessionLinkSourceFor } from './platforms/link-source.js'
 import { CommandChromeRegistry, type SelectKind } from './platforms/command-chrome.js'
 import { slackCommandChrome } from './platforms/slack/command-chrome.js'
 import {
@@ -6421,36 +6422,51 @@ export class Daemon {
    * dual-carries the generic `response` beside the deprecated Feishu-named slot
    * while the relay may still read either.
    */
+  /** §6.6 platform_action decoders, one registry entry per platform: validate the
+   *  opaque payload against the platform's own wire schema and hand it to that
+   *  platform's action handler. Adding a platform adds one entry — the dispatch
+   *  itself never grows a branch. An unregistered platformId (or a payload its
+   *  schema rejects) NAKs `unsupported_action`, which the relay surfaces per item. */
+  private readonly platformActionDecoders = new Map<string, (msg: RdMsgPlatformAction) => RdAck>([
+    [
+      'slack',
+      (msg) => {
+        const payload = RdSlackAction.safeParse(msg.payload)
+        if (!payload.success) return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
+        return this.handleRelaySlackAction({
+          source: 'slack_action',
+          agentId: msg.agentId,
+          sessionKey: msg.sessionKey,
+          msgId: msg.msgId,
+          botId: msg.botId,
+          integrationId: msg.integrationId,
+          ...(msg.userId !== undefined ? { userId: msg.userId } : {}),
+          payload: payload.data
+        })
+      }
+    ],
+    [
+      'feishu',
+      (msg) => {
+        const payload = WireFeishuCardActionEvent.safeParse(msg.payload)
+        if (!payload.success) return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
+        const ack = this.handleRelayFeishuAction({
+          source: 'feishu_action',
+          agentId: msg.agentId,
+          sessionKey: msg.sessionKey,
+          msgId: msg.msgId,
+          botId: msg.botId,
+          integrationId: msg.integrationId,
+          payload: payload.data
+        })
+        return ack.feishuCardAction !== undefined ? { ...ack, response: ack.feishuCardAction } : ack
+      }
+    ]
+  ])
+
   private handleRelayPlatformAction(msg: RdMsgPlatformAction): RdAck {
-    if (msg.platformId === 'slack') {
-      const payload = RdSlackAction.safeParse(msg.payload)
-      if (!payload.success) return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
-      return this.handleRelaySlackAction({
-        source: 'slack_action',
-        agentId: msg.agentId,
-        sessionKey: msg.sessionKey,
-        msgId: msg.msgId,
-        botId: msg.botId,
-        integrationId: msg.integrationId,
-        ...(msg.userId !== undefined ? { userId: msg.userId } : {}),
-        payload: payload.data
-      })
-    }
-    if (msg.platformId === 'feishu') {
-      const payload = WireFeishuCardActionEvent.safeParse(msg.payload)
-      if (!payload.success) return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
-      const ack = this.handleRelayFeishuAction({
-        source: 'feishu_action',
-        agentId: msg.agentId,
-        sessionKey: msg.sessionKey,
-        msgId: msg.msgId,
-        botId: msg.botId,
-        integrationId: msg.integrationId,
-        payload: payload.data
-      })
-      return ack.feishuCardAction !== undefined ? { ...ack, response: ack.feishuCardAction } : ack
-    }
-    return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
+    const decode = this.platformActionDecoders.get(msg.platformId)
+    return decode ? decode(msg) : { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
   }
 
   private handleRelaySlackAction(msg: RdMsgSlackAction): RdAck {
@@ -9292,14 +9308,17 @@ export class Daemon {
     }> = []
     for (const [agentId, agent] of this.agents) {
       for (const integration of agent.integrations) {
+        // Only reachable when the message's platform has a coarse loop-guard
+        // circuit (loopGuardScopesFor), so filtering by the MESSAGE's platform is
+        // the platform-neutral statement of the old `!== 'slack'` literal.
         if (
-          integration.platform !== 'slack' ||
+          integration.platform !== msg.platform ||
           !this.integrationBelongsToSource(integration.id, srcIntegrationIds) ||
           !this.commandSenderAllowed(agentId, integration.id, msg)
         )
           continue
-        const mentioned =
-          integration.slack.botUserId !== undefined && msg.mentionedBots.includes(integration.slack.botUserId)
+        const botUserId = integrationRouting(integration).staticBotUserId
+        const mentioned = botUserId !== undefined && msg.mentionedBots.includes(botUserId)
         candidates.push({
           agentId,
           integrationId: integration.id,
@@ -12351,13 +12370,10 @@ export class Daemon {
    *  when the CP couldn't resolve it; then the segment is dropped. */
   private cpOrgSlug?: string
 
-  /** Presentation-only source hint carried by provider-rendered session links. Feishu and
-   *  Lark share one protocol platform, so their integration region supplies the visible brand. */
-  private sessionLinkSource(platform: string, integrationId?: string): 'slack' | 'github' | FeishuRegion | undefined {
-    if (platform === 'slack' || platform === 'github') return platform
-    if (platform !== 'feishu' || !integrationId) return undefined
-    const integration = this.integrationConfigById(integrationId)
-    return integration?.platform === 'feishu' ? integration.feishu.region : undefined
+  /** Presentation-only source hint carried by provider-rendered session links —
+   *  the platform's own fact (§7.4 link-source strategy). */
+  private sessionLinkSource(platform: string, integrationId?: string): string | undefined {
+    return sessionLinkSourceFor(platform, integrationId ? this.integrationConfigById(integrationId) : undefined)
   }
 
   /** The Web App console URL for a session: `<base>/<orgSlug>/sessions/<id>`, where base is
@@ -12365,7 +12381,7 @@ export class Daemon {
    *  (`DEFAULT_WEB_APP_URL`). The console is org-scoped, so the org slug is inserted when
    *  known; without it the link falls back to `<base>/sessions/<id>`. Provider-rendered
    *  links carry a presentation-only source hint for the generic 404 profile-linking action. */
-  private sessionLink(acpSessionId: string, source?: 'slack' | 'github' | FeishuRegion): string {
+  private sessionLink(acpSessionId: string, source?: string): string {
     const orgSeg = this.cpOrgSlug ? `/${encodeURIComponent(this.cpOrgSlug)}` : ''
     const link = `${this.webAppBase()}${orgSeg}/sessions/${encodeURIComponent(acpSessionId)}`
     return source ? `${link}?source=${source}` : link

--- a/packages/daemon/src/platforms/link-source.ts
+++ b/packages/daemon/src/platforms/link-source.ts
@@ -1,0 +1,39 @@
+/**
+ * The **session-link source strategy** (§7.4, stage S2).
+ *
+ * A provider-rendered session deep link carries a presentation-only `?source=`
+ * hint: the console's generic 404 profile-linking action uses it to show the
+ * right brand. Which hint a platform contributes is its own fact:
+ *
+ *  - Slack and GitHub brand as themselves;
+ *  - Feishu and Lark share ONE protocol platform id, so the visible brand comes
+ *    from the integration's region — a read of the integration's own (legacy
+ *    disk-shape) config block, which is exactly why it belongs here and not in
+ *    core;
+ *  - everyone else contributes nothing, and the link renders unbranded.
+ *
+ * Presentation-only by contract: nothing routes on this value, so the open
+ * `string` return is safe and the console treats unknown hints as no hint.
+ */
+
+type LinkSource = (integration: unknown) => string | undefined
+
+const SOURCES = new Map<string, LinkSource>([
+  ['slack', () => 'slack'],
+  ['github', () => 'github'],
+  [
+    'feishu',
+    (integration) => {
+      // The integration's own config block (legacy disk shape until the emission
+      // flip); structurally read so this file needs no agent-schema import.
+      const feishu = (integration as { feishu?: { region?: string } } | undefined)?.feishu
+      return feishu?.region
+    }
+  ]
+])
+
+/** The `?source=` hint for a session link delivered via `platform` /
+ *  `integration`. Total by construction: no registered source means no hint. */
+export function sessionLinkSourceFor(platform: string, integration?: unknown): string | undefined {
+  return SOURCES.get(platform)?.(integration)
+}

--- a/packages/daemon/test/link-source.test.ts
+++ b/packages/daemon/test/link-source.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { sessionLinkSourceFor } from '../src/platforms/link-source.js'
+
+describe('session-link source strategy', () => {
+  it('brands Slack and GitHub as themselves', () => {
+    expect(sessionLinkSourceFor('slack')).toBe('slack')
+    expect(sessionLinkSourceFor('github')).toBe('github')
+  })
+
+  it('brands Feishu/Lark by integration region', () => {
+    // Feishu and Lark share one protocol platform id; the region is the brand.
+    expect(sessionLinkSourceFor('feishu', { feishu: { region: 'lark' } })).toBe('lark')
+    expect(sessionLinkSourceFor('feishu', { feishu: { region: 'feishu' } })).toBe('feishu')
+    // No integration resolved → no hint, exactly the pre-seam behavior.
+    expect(sessionLinkSourceFor('feishu')).toBeUndefined()
+    expect(sessionLinkSourceFor('feishu', {})).toBeUndefined()
+  })
+
+  it('contributes no hint anywhere else', () => {
+    for (const p of ['telegram', 'discord', 'webchat', 'hook', 'some-future-platform']) {
+      expect(sessionLinkSourceFor(p, { feishu: { region: 'lark' } })).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
Thirteenth PR of stage S2; fifth class (c) batch — three seams.

## `platformActionDecoders`

The §6.6 `platform_action` dispatch becomes a registry: one entry per platform validates the opaque payload against **that platform's own wire schema** and hands it to that platform's action handler. Adding a platform adds one entry; the dispatch itself never grows a branch. An unregistered `platformId` (or a payload its schema rejects) NAKs `unsupported_action` exactly as the old if-chain's fall-through did.

The two handlers behind the registry (`handleRelaySlackAction` / `handleRelayFeishuAction`) are platform code reached **only** through their registry entry now — their internal platform naming is the handler's own, like a `ConnectionPool` label, not a core branch.

## `sessionLinkSourceFor` → `platforms/link-source.ts`

The presentation-only `?source=` brand hint on provider-rendered session links: Slack/GitHub brand as themselves; Feishu/Lark share one protocol platform id, so the brand comes from the integration's **region** — a read of the integration's own (legacy disk-shape) config block, which is exactly why it belongs in the strategy and not core; everyone else contributes nothing. Nothing routes on the value, so `sessionLink`'s `source` param widens to `string`.

## `resolveTopLevelResumeTarget`

The integration filter becomes `integration.platform !== msg.platform`: the method is only reachable when the message's platform has a **coarse loop-guard circuit** (#533's strategy), so the message's platform *is* the old literal, stated platform-neutrally. The bot-mention read goes through `integrationRouting().staticBotUserId`, which is `int.slack.botUserId` verbatim for Slack ([routing-rule.ts:48](packages/daemon/src/router/routing-rule.ts#L48)) — behavior-identical, and no longer needs the discriminant narrowing.

## Verification

- `pnpm typecheck` clean; `eslint`/`prettier` clean
- daemon suite: **2833 passed**, 46 skipped, incl. 3 new link-source tests (brand table, region resolution + missing-integration fallbacks, everyone-else-silent)
- Four-platform conditionals in `daemon.ts`: **49 → 43**

🤖 Generated with [Claude Code](https://claude.com/claude-code)