### PR TITLE
refactor(daemon): binding-map read side + observed-channels strategy (S2)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -131,7 +131,6 @@ import {
   type TelegramObservedChat
 } from './telegram/connection.js'
 import { consolidateDiscord, discordConnKey, DiscordConnection } from './discord/connection.js'
-import { collapseDiscordChannels, collapseNameLookupIds } from './discord/channels.js'
 import { consolidateFeishu, feishuConnKey, FeishuConnection } from './feishu/connection.js'
 import { SlackNameResolver } from './slack/name-resolver.js'
 import { manifestFor } from './platforms/manifest.js'
@@ -142,6 +141,12 @@ import { isMalformedPlatformTurn } from './platforms/malformed-turn.js'
 import { registerThreadPromotion, threadPromotionFor } from './platforms/thread-promotion.js'
 import { discordThreadPromotion } from './platforms/discord/thread-promotion.js'
 import { sessionLinkSourceFor } from './platforms/link-source.js'
+import {
+  observedChannelsFor,
+  registerObservedChannels,
+  type ObservedChannelsHost
+} from './platforms/observed-channels.js'
+import { discordObservedChannels } from './platforms/discord/observed-channels.js'
 import { CommandChromeRegistry, type SelectKind } from './platforms/command-chrome.js'
 import { slackCommandChrome } from './platforms/slack/command-chrome.js'
 import {
@@ -1473,6 +1478,7 @@ function pendingSessionKey(p: Pending): SessionKey {
 // channel @mention in a freshly opened thread. Registered at module scope so
 // every Daemon instance (including test constructions) sees the same registry.
 registerThreadPromotion(discordThreadPromotion)
+registerObservedChannels(discordObservedChannels)
 
 export class Daemon {
   private readonly evaluation: EvaluationEventEmitter
@@ -3780,12 +3786,9 @@ export class Daemon {
       if (!row.transportScope) continue
       const integrationId = this.integrationIdForTransportScope(row.agentId, row.platform, row.transportScope)
       if (!integrationId) continue
-      const conn =
-        row.platform === 'discord'
-          ? this.dcConnByIntegration.get(integrationId)
-          : row.platform === 'telegram'
-            ? this.tgConnByIntegration.get(integrationId)
-            : this.fsConnByIntegration.get(integrationId)
+      // The integration id already names its platform's binding — no need to pick
+      // a map by platform (§7.5 read side).
+      const conn = this.connForIntegration(integrationId)
       if (!conn) continue
       if (row.triggeredBy) {
         resolver.noteMessage(conn, {
@@ -3883,7 +3886,7 @@ export class Daemon {
               const name = names.get(c.id)
               // A retained row has no session behind it (a gated Off channel), so its
               // space is looked up directly rather than coming out of the collapse.
-              const found = platform === 'discord' ? this.spaceFor(c.id) : undefined
+              const found = this.spaceFor(platform, c.id)
               const spaceId = found?.id ?? c.spaceId
               const space = found?.name ?? c.space
               const next = {
@@ -4026,13 +4029,20 @@ export class Daemon {
    * never enters `onInbound` or creates an agent turn.
    */
   private observeTelegramChat(chat: TelegramObservedChat, integrationIds: readonly string[]): void {
+    this.observePlatformChat('telegram', chat, integrationIds)
+  }
+
+  /** Record one observed chat row for a platform that cannot enumerate its bot's
+   *  chats. The event's own platform filters the fan-out — a caller is already
+   *  platform-specific and names it as data, not a branch. */
+  private observePlatformChat(platform: string, chat: TelegramObservedChat, integrationIds: readonly string[]): void {
     if (chat.name) {
       this.store.setDisplayName(chat.id, chat.name, Date.now())
       this.emitSessionMetadataSnapshotsForDisplayName(chat.id)
     }
     for (const integrationId of integrationIds) {
       const integration = this.integrationConfigById(integrationId)
-      if (!integration || integration.platform !== 'telegram') continue
+      if (!integration || integration.platform !== platform) continue
       const prior = this.channelSnapshots.get(integrationId)?.channels ?? []
       const current = prior.find((channel) => channel.id === chat.id)
       const observed: IntegrationChannel = {
@@ -4057,14 +4067,18 @@ export class Daemon {
     }
   }
 
-  /** The space (Discord guild) a channel sits in — the id that keeps one bot's several
-   *  "#general" rows apart, plus its display name once resolved. Undefined until the
-   *  channel's name lookup has recorded its guild. */
-  private spaceFor(channelId: string): { id: string; name?: string } | undefined {
-    const id = this.store.getChannelScopes([channelId]).get(channelId)?.spaceId
-    if (!id) return undefined
-    const name = this.store.getDisplayNames([id]).get(id)
-    return { id, ...(name ? { name } : {}) }
+  /** Store-backed host for the observed-channels strategies (§7.4): channel
+   *  scopes and display names are core bookkeeping the strategies read through. */
+  private readonly observedChannelsHost: ObservedChannelsHost = {
+    channelScopes: (ids) => this.store.getChannelScopes(ids),
+    displayNames: (ids) => this.store.getDisplayNames(ids)
+  }
+
+  /** The space a channel sits in, per its platform's strategy — the id that keeps
+   *  one bot's several same-named rows apart (Discord guilds). Undefined on
+   *  platforms without the notion, or until the lookup has recorded it. */
+  private spaceFor(platform: string, channelId: string): { id: string; name?: string } | undefined {
+    return observedChannelsFor(platform)?.spaceFor(this.observedChannelsHost, channelId)
   }
 
   /**
@@ -4077,16 +4091,9 @@ export class Daemon {
    */
   private collapseObserved(
     observed: { id: string; name?: string }[],
-    platform: 'telegram' | 'discord' | 'feishu'
+    platform: string
   ): { id: string; name?: string; spaceId?: string; space?: string }[] {
-    if (platform !== 'discord') return observed
-    // Two-step: the observed (thread) ids first, then the channels they fold onto —
-    // whose OWN scope carries the guild, which a thread row may never have recorded.
-    const scopes = this.store.getChannelScopes(observed.map((c) => c.id))
-    const parents = [...scopes.values()].map((s) => s.parentId).filter((id): id is string => !!id)
-    for (const [id, scope] of this.store.getChannelScopes(parents)) scopes.set(id, scope)
-    const names = this.store.getDisplayNames(collapseNameLookupIds(observed, scopes))
-    return collapseDiscordChannels(observed, scopes, names)
+    return observedChannelsFor(platform)?.collapse(this.observedChannelsHost, observed) ?? observed
   }
 
   /**
@@ -14716,7 +14723,7 @@ export class Daemon {
     const kind = observed === 'channel' && current?.kind === 'mpim' ? ('mpim' as const) : observed
     const known = this.store.getDisplayNames([channel]).get(channel)
     // Which Discord server the channel belongs to — see spaceFor. Direct rows have none.
-    const found = kind === 'channel' && msg.platform === 'discord' ? this.spaceFor(channel) : undefined
+    const found = kind === 'channel' ? this.spaceFor(msg.platform, channel) : undefined
     const space = found ? { spaceId: found.id, ...(found.name ? { space: found.name } : {}) } : undefined
     // Compare against what a write would actually change — a partially resolved space
     // (id known, name not yet) must not re-emit the snapshot on every message.
@@ -14814,15 +14821,22 @@ export class Daemon {
   }
 
   /** The live platform connection serving `integrationId`, any platform. */
+  /** Every platform's per-integration binding map, in one iterable — the read
+   *  side of the §7.5 registry. An integration id belongs to exactly one
+   *  platform, so first-hit lookup is total and unambiguous; adding a platform
+   *  adds its map here, and no lookup grows a branch. */
+  private readonly integrationBindings: ReadonlyArray<
+    ReadonlyMap<string, SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection>
+  > = [this.connByIntegration, this.tgConnByIntegration, this.dcConnByIntegration, this.fsConnByIntegration]
+
   private connForIntegration(
     integrationId: string
   ): SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection | undefined {
-    return (
-      this.connByIntegration.get(integrationId) ??
-      this.tgConnByIntegration.get(integrationId) ??
-      this.dcConnByIntegration.get(integrationId) ??
-      this.fsConnByIntegration.get(integrationId)
-    )
+    for (const bindings of this.integrationBindings) {
+      const conn = bindings.get(integrationId)
+      if (conn) return conn
+    }
+    return undefined
   }
 
   private replyConnFor(

--- a/packages/daemon/src/platforms/discord/observed-channels.ts
+++ b/packages/daemon/src/platforms/discord/observed-channels.ts
@@ -1,0 +1,35 @@
+/**
+ * Discord's **observed-channels strategy** (§7.4) — the one platform whose
+ * observed rows need folding.
+ *
+ * Sessions key on a THREAD channel (the daemon opens one off every top-level
+ * mention), so the raw observed set repeats the same channel once per thread:
+ * collapse each row onto its enclosing channel, dedupe on the channel
+ * snowflake, and label each row with the guild it sits in — a bot in several
+ * servers reaches a "#general" in each, and the name alone cannot keep those
+ * rows apart. The pure folding rules live in `discord/channels.ts`; this
+ * strategy binds them to the host's scope/name lookups.
+ */
+import { collapseDiscordChannels, collapseNameLookupIds } from '../../discord/channels.js'
+import type { ObservedChannelsHost, ObservedChannelsStrategy } from '../observed-channels.js'
+
+export const discordObservedChannels: ObservedChannelsStrategy = {
+  platform: 'discord',
+
+  collapse(host: ObservedChannelsHost, observed: { id: string; name?: string }[]) {
+    // Two-step: the observed (thread) ids first, then the channels they fold onto —
+    // whose OWN scope carries the guild, which a thread row may never have recorded.
+    const scopes = host.channelScopes(observed.map((c) => c.id))
+    const parents = [...scopes.values()].map((s) => s.parentId).filter((id): id is string => !!id)
+    for (const [id, scope] of host.channelScopes(parents)) scopes.set(id, scope)
+    const names = host.displayNames(collapseNameLookupIds(observed, scopes))
+    return collapseDiscordChannels(observed, scopes, names)
+  },
+
+  spaceFor(host: ObservedChannelsHost, channelId: string) {
+    const id = host.channelScopes([channelId]).get(channelId)?.spaceId
+    if (!id) return undefined
+    const name = host.displayNames([id]).get(id)
+    return { id, ...(name ? { name } : {}) }
+  }
+}

--- a/packages/daemon/src/platforms/observed-channels.ts
+++ b/packages/daemon/src/platforms/observed-channels.ts
@@ -1,0 +1,54 @@
+/**
+ * The **observed-channels strategy** (`collapseObservedChannels` /
+ * `spaceForChannel` in §7.4, stage S2).
+ *
+ * Platforms without an authoritative membership snapshot get their console
+ * channel list rebuilt from OBSERVED conversations (session history, service
+ * records). Two Discord facts made that rebuild platform-conditional:
+ *
+ *  - Discord sessions key on a THREAD channel (the daemon opens one off every
+ *    top-level mention), so the raw observed set repeats the same channel once
+ *    per thread — rows must COLLAPSE onto their enclosing channel;
+ *  - a bot in several servers reaches a "#general" in each, so a row is only
+ *    unambiguous with the SPACE (guild) it sits in.
+ *
+ * Telegram and Feishu chats have neither notion; their rows pass through. That
+ * is the default: no collapse, no spaces — any platform without a registered
+ * strategy reports observed rows exactly as collected.
+ */
+
+/** One observed conversation row, as the snapshot pipeline carries it. */
+export interface ObservedChannelRow {
+  id: string
+  name?: string
+  spaceId?: string
+  space?: string
+}
+
+/** The store reads a strategy may perform — channel scopes (parent/space
+ *  links) and resolved display names are core bookkeeping. */
+export interface ObservedChannelsHost {
+  channelScopes(ids: string[]): Map<string, { parentId?: string; spaceId?: string }>
+  displayNames(ids: string[]): Map<string, string>
+}
+
+export interface ObservedChannelsStrategy {
+  readonly platform: string
+  /** Fold raw observed rows onto the channel set the console should offer. */
+  collapse(host: ObservedChannelsHost, observed: { id: string; name?: string }[]): ObservedChannelRow[]
+  /** The space a channel sits in — the id that keeps one bot's several
+   *  same-named rows apart, plus its display name once resolved. */
+  spaceFor(host: ObservedChannelsHost, channelId: string): { id: string; name?: string } | undefined
+}
+
+const STRATEGIES = new Map<string, ObservedChannelsStrategy>()
+
+export function registerObservedChannels(strategy: ObservedChannelsStrategy): void {
+  STRATEGIES.set(strategy.platform, strategy)
+}
+
+/** The platform's strategy, or undefined — rows then pass through untouched
+ *  and no space is attached, every non-Discord platform's behavior. */
+export function observedChannelsFor(platform: string): ObservedChannelsStrategy | undefined {
+  return STRATEGIES.get(platform)
+}

--- a/packages/daemon/test/observed-channels.test.ts
+++ b/packages/daemon/test/observed-channels.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { observedChannelsFor, registerObservedChannels } from '../src/platforms/observed-channels.js'
+import { discordObservedChannels } from '../src/platforms/discord/observed-channels.js'
+import type { ObservedChannelsHost } from '../src/platforms/observed-channels.js'
+
+registerObservedChannels(discordObservedChannels)
+
+/** A host over fixed scope/name tables. */
+const host = (
+  scopes: Record<string, { parentId?: string; spaceId?: string }>,
+  names: Record<string, string>
+): ObservedChannelsHost => ({
+  channelScopes: (ids) => new Map(ids.filter((id) => scopes[id]).map((id) => [id, scopes[id]!])),
+  displayNames: (ids) => new Map(ids.filter((id) => names[id]).map((id) => [id, names[id]!]))
+})
+
+describe('observed-channels strategies', () => {
+  it('is registered for Discord only; other platforms pass rows through', () => {
+    for (const p of ['telegram', 'feishu', 'slack', 'some-future-platform']) {
+      expect(observedChannelsFor(p)).toBeUndefined()
+    }
+    expect(observedChannelsFor('discord')).toBe(discordObservedChannels)
+  })
+
+  it('collapses thread rows onto their enclosing channel, labeled with the guild', () => {
+    const h = host(
+      {
+        T1: { parentId: 'C1' },
+        T2: { parentId: 'C1' },
+        C1: { spaceId: 'G1' }
+      },
+      { C1: '#general', G1: 'My Server' }
+    )
+    const rows = discordObservedChannels.collapse(h, [{ id: 'T1', name: 'thread one' }, { id: 'T2' }])
+    // Two threads of one channel fold to ONE row, named for the channel, carrying
+    // the guild that keeps same-named channels in different servers apart.
+    expect(rows).toEqual([{ id: 'C1', name: '#general', spaceId: 'G1', space: 'My Server' }])
+  })
+
+  it('resolves the guild through the parent when the thread never recorded one', () => {
+    // The observed thread's own scope has no spaceId; the folded-onto channel's does.
+    const h = host({ T1: { parentId: 'C1' }, C1: { spaceId: 'G9' } }, { G9: 'Server Nine' })
+    const rows = discordObservedChannels.collapse(h, [{ id: 'T1', name: 'x' }])
+    expect(rows[0]).toMatchObject({ id: 'C1', spaceId: 'G9', space: 'Server Nine' })
+  })
+
+  it('spaceFor answers only once the scope recorded a guild', () => {
+    const h = host({ C1: { spaceId: 'G1' } }, { G1: 'My Server' })
+    expect(discordObservedChannels.spaceFor(h, 'C1')).toEqual({ id: 'G1', name: 'My Server' })
+    expect(discordObservedChannels.spaceFor(h, 'C2')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fourteenth PR of stage S2; sixth class (c) batch — the §7.5 registry's **read side** plus the audit's `collapseObservedChannels` / `spaceForChannel` strategies.

## `integrationBindings`

Every platform's per-integration binding map in one iterable. An integration id belongs to exactly one platform, so first-hit lookup is total and unambiguous:

- `connForIntegration` stops chaining four map reads;
- `backfillChannelNames` stops picking a map by platform ternary (the integration id **already names** its platform's binding);
- adding a platform adds its map to the list — no lookup grows a branch.

The typed maps themselves stay per platform, exactly as §7.5 prescribes: they generalize with the remaining read sites, not before.

## Observed-channels strategy

Platforms without an authoritative membership snapshot rebuild their console channel list from observed conversations, and two **Discord facts** made that rebuild conditional:

1. Sessions key on a **thread** channel (the daemon opens one per top-level mention), so raw rows repeat the channel once per thread and must collapse onto it;
2. a bot in several servers reaches a `#general` in each, so a row is only unambiguous with its **guild**.

The pure folding rules stay in `discord/channels.ts`; the strategy binds them to the host's scope/name lookups. Telegram and Feishu rows pass through — that is the default, so any platform without a strategy reports observed rows exactly as collected. `spaceFor` becomes platform-keyed and its three call sites lose their literals.

## `observeTelegramChat` → `observePlatformChat`

The event's own platform filters the integration fan-out — the caller is already platform-specific and names it as **data, not a branch** (the `latestAdmittedSession` precedent from #535).

## Verification

- `pnpm typecheck` clean; `eslint`/`prettier` clean
- daemon suite: **2833 passed**, 46 skipped, plus **4 new** strategy tests (registration table; thread→channel collapse with guild labeling; guild resolution through the parent when the thread never recorded one; `spaceFor` absent-scope behavior)
- Four-platform conditionals in `daemon.ts`: **43 → 34**

🤖 Generated with [Claude Code](https://claude.com/claude-code)