### PR TITLE
refactor(daemon): transport identity + conversation audience become §7.4 strategies (S2)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -147,6 +147,8 @@ import {
   type ObservedChannelsHost
 } from './platforms/observed-channels.js'
 import { discordObservedChannels } from './platforms/discord/observed-channels.js'
+import { connectionIdentityFor, tenantScopeFor, type TenantScopeHost } from './platforms/transport-identity.js'
+import { conversationAudienceFor } from './platforms/session-audience.js'
 import { CommandChromeRegistry, type SelectKind } from './platforms/command-chrome.js'
 import { slackCommandChrome } from './platforms/slack/command-chrome.js'
 import {
@@ -14220,34 +14222,12 @@ export class Daemon {
   }
 
   /** Stable opaque identity for one physical platform connection. Integrations
-   * consolidated onto the same credential receive the same scope, while no raw
-   * credential is ever persisted or logged. */
+   * consolidated onto the same credential receive the same scope (§7.4
+   * transport-identity strategy names the credential), while no raw credential
+   * is ever persisted or logged. */
   private transportScopeForIntegration(integration: Integration): string {
-    let connectionIdentity: string
-    switch (integration.platform) {
-      case 'slack':
-        connectionIdentity =
-          integration.slack.mode === 'shared'
-            ? integration.slack.botToken
-            : (integration.slack.appToken ?? integration.slack.botToken)
-        break
-      case 'telegram': {
-        // BotFather tokens start with the stable public bot id, which survives a
-        // secret rotation. Non-standard test/config tokens fall back to the full
-        // high-entropy credential before hashing.
-        const botId = integration.telegram.botToken.split(':', 1)[0]
-        connectionIdentity = /^\d+$/.test(botId ?? '') ? botId! : integration.telegram.botToken
-        break
-      }
-      case 'discord':
-        connectionIdentity = integration.discord.botToken
-        break
-      case 'feishu':
-        connectionIdentity = `${integration.feishu.region}:${integration.feishu.appId}`
-        break
-    }
     const digest = createHash('sha256')
-      .update(`${integration.platform}\0${connectionIdentity}`)
+      .update(`${integration.platform}\0${connectionIdentityFor(integration)}`)
       .digest('hex')
       .slice(0, 24)
     return `${integration.platform}:${digest}`
@@ -14265,27 +14245,17 @@ export class Daemon {
    * never a guessed one.
    */
   private tenantScopeForIntegration(integration: Integration): string | undefined {
-    switch (integration.platform) {
-      case 'slack': {
-        // The workspace id from auth.test, surfaced by the live connection.
-        // Optional-call: the connection map holds live SlackConnections in
-        // production, but a not-yet-authenticated (or test-substituted) one may
-        // not expose the accessor — fall back to a minted scope rather than throw.
-        const teamId = this.connByIntegration.get(integration.id)?.workspaceId?.()
-        return teamId || this.mintedTenantScope(integration.id)
-      }
-      case 'telegram': {
-        // The public bot id prefix survives a BotFather token rotation.
-        const botId = integration.telegram.botToken.split(':', 1)[0]
-        return /^\d+$/.test(botId ?? '') ? `bot${botId}` : this.mintedTenantScope(integration.id)
-      }
-      case 'feishu':
-        // App id + region is the tenant anchor Feishu/Lark exposes to us.
-        return `${integration.feishu.region}:${integration.feishu.appId}`
-      default:
-        // Discord (and anything new) exposes no durable tenant id here.
-        return this.mintedTenantScope(integration.id)
-    }
+    return tenantScopeFor(this.tenantScopeHost, integration)
+  }
+
+  /** Core-owned inputs of the tenant-scope strategies (§7.4): the live
+   *  connection's workspace id and the minted-once persisted fallback. */
+  private readonly tenantScopeHost: TenantScopeHost = {
+    // Optional-call: the connection map holds live SlackConnections in
+    // production, but a not-yet-authenticated (or test-substituted) one may not
+    // expose the accessor — the strategy falls back to a minted scope.
+    liveWorkspaceId: (integrationId) => this.connByIntegration.get(integrationId)?.workspaceId?.(),
+    minted: (integrationId) => this.mintedTenantScope(integrationId)
   }
 
   /**
@@ -14385,30 +14355,31 @@ export class Daemon {
     isA2aChild: boolean
   ):
     | {
-        externalProvider: 'slack' | 'feishu'
+        externalProvider: string
         externalRealmKey?: string
         externalResourceKind: 'conversation'
         externalResourceKey: string
         externalIntegrationId?: string
       }
     | undefined {
-    if (
-      (msg.platform !== 'slack' && msg.platform !== 'feishu') ||
-      (msg.platform === 'slack' && msg.isDm) ||
-      isA2aChild
-    ) {
+    // Which platforms bind sessions to a conversation audience, which of their
+    // conversations qualify, and what identifies the realm are platform facts
+    // (§7.4 conversation-audience strategy). No registered audience — Telegram,
+    // Discord, webchat — means local classification rules alone, as before.
+    const audience = conversationAudienceFor(msg.platform)
+    if (!audience || !audience.applies(msg) || isA2aChild) {
       return undefined
     }
     const integrationId = this.integrationIdForTransportScope(agentId, msg.platform, msg.transportScope)
     const integration = integrationId ? this.integrationConfigById(integrationId) : undefined
-    const realmKey =
-      msg.platform === 'slack'
-        ? integrationId
-          ? this.connByIntegration.get(integrationId)?.workspaceId?.()
-          : undefined
-        : integration?.platform === 'feishu'
-          ? this.tenantScopeForIntegration(integration)
-          : undefined
+    const realmKey = audience.realmKey(
+      {
+        liveWorkspaceId: (id) => this.connByIntegration.get(id)?.workspaceId?.(),
+        tenantScope: (int) => this.tenantScopeForIntegration(int as Integration)
+      },
+      integrationId,
+      integration
+    )
     // Cron and daemon-owned continuation turns can create or resume a real shared
     // conversation, while synthetic/headless callers may use platform-shaped
     // coordinates with no connection. Bind those trusted system turns only when
@@ -14438,8 +14409,12 @@ export class Daemon {
   ): 'unchanged' | 'mismatch' | 'unavailable' {
     const direct =
       this.githubExternalSource(hookContext) ?? this.conversationExternalSource(agentId, msg, callMeta !== undefined)
+    // A CONVERSATION audience is only bindable when fully attributed (realm +
+    // integration); a repository audience (GitHub) has its own completeness rule.
+    // Keyed on the resource kind, so a new platform's audience gets the same
+    // guard without this growing a provider list.
     if (
-      (direct?.externalProvider === 'slack' || direct?.externalProvider === 'feishu') &&
+      direct?.externalResourceKind === 'conversation' &&
       (!direct.externalRealmKey || !direct.externalIntegrationId)
     ) {
       return 'unavailable'

--- a/packages/daemon/src/platforms/session-audience.ts
+++ b/packages/daemon/src/platforms/session-audience.ts
@@ -1,0 +1,64 @@
+/**
+ * The **conversation-audience strategy** (§7.4, stage S2; the daemon-side
+ * counterpart of §9's per-platform session-audience resolvers).
+ *
+ * A session born in a real shared platform conversation is externally bound:
+ * its visibility follows the CONVERSATION's audience, resolved by the CP
+ * against the platform (who can see this channel?). Which platforms support
+ * that binding, which of their conversations qualify, and what identifies the
+ * REALM the conversation lives in (workspace, tenant) are platform facts:
+ *
+ *  - Slack binds channels but not DMs (a Slack DM's audience is the DM itself,
+ *    already private); realm = the live connection's workspace id.
+ *  - Feishu/Lark binds every conversation; realm = the durable tenant anchor
+ *    (`region:appId`).
+ *  - Telegram and Discord (and anything unregistered) bind nothing — their
+ *    sessions classify by the local rules alone, exactly as before this seam.
+ */
+
+/** Core-owned inputs an audience strategy may consult. */
+export interface ConversationAudienceHost {
+  /** The live connection's workspace/team id, where the platform exposes one. */
+  liveWorkspaceId(integrationId: string): string | undefined
+  /** The integration's durable tenant scope (transport-identity strategy). */
+  tenantScope(integration: { id: string; platform: string }): string | undefined
+}
+
+export interface ConversationAudience {
+  readonly platform: string
+  /** Does THIS conversation carry an external audience? */
+  applies(msg: { isDm: boolean }): boolean
+  /** The realm the conversation lives in. Undefined ⇒ unattributable here and
+   *  now; the caller decides whether that fails closed (system turns) or rides
+   *  incomplete (human ingress). */
+  realmKey(
+    host: ConversationAudienceHost,
+    integrationId: string | undefined,
+    integration: { id: string; platform: string } | undefined
+  ): string | undefined
+}
+
+const AUDIENCES = new Map<string, ConversationAudience>([
+  [
+    'slack',
+    {
+      platform: 'slack',
+      applies: (msg) => !msg.isDm,
+      realmKey: (host, integrationId) => (integrationId ? host.liveWorkspaceId(integrationId) : undefined)
+    }
+  ],
+  [
+    'feishu',
+    {
+      platform: 'feishu',
+      applies: () => true,
+      realmKey: (host, _integrationId, integration) => (integration ? host.tenantScope(integration) : undefined)
+    }
+  ]
+])
+
+/** The platform's conversation audience, or undefined — no registered audience
+ *  means sessions there classify by local rules alone. */
+export function conversationAudienceFor(platform: string): ConversationAudience | undefined {
+  return AUDIENCES.get(platform)
+}

--- a/packages/daemon/src/platforms/transport-identity.ts
+++ b/packages/daemon/src/platforms/transport-identity.ts
@@ -1,0 +1,122 @@
+/**
+ * The **transport identity strategies** (`transportScopeIdentity` /
+ * `tenantScope` in §7.4, stage S2) — two different answers to "what identifies
+ * this integration's connection?", with two different lifetimes:
+ *
+ *  - {@link connectionIdentityFor} feeds the TRANSPORT scope: which credential
+ *    actually identifies one physical connection, so integrations consolidated
+ *    onto the same credential share a scope. It deliberately rotates with the
+ *    credential; the caller hashes it and no raw credential is persisted or
+ *    logged. The §7.5 connection-pool keys state the same fact for LIVE
+ *    connections; this states it for configs, before any connection exists.
+ *
+ *  - {@link tenantScopeFor} feeds the DURABLE owner identity
+ *    (`<platform>:<scope>:<uid>`, session-visibility §2). It must SURVIVE
+ *    rotation, so it prefers the platform's own tenant id and falls back to a
+ *    scope minted once per integration and persisted by core.
+ *
+ * Both read the integration's legacy disk-shape config blocks structurally —
+ * the same S1b decision (#516) that froze that shape until the emission flip is
+ * why these reads belong in a platform strategy and not in core.
+ */
+
+interface SlackConfig {
+  slack: { mode?: string; botToken: string; appToken?: string }
+}
+interface TelegramConfig {
+  telegram: { botToken: string }
+}
+interface DiscordConfig {
+  discord: { botToken: string }
+}
+interface FeishuConfig {
+  feishu: { region: string; appId: string }
+}
+
+/** The stable public BotFather bot-id prefix, or undefined for non-standard
+ *  test/config tokens. */
+function telegramBotId(botToken: string): string | undefined {
+  const botId = botToken.split(':', 1)[0]
+  return /^\d+$/.test(botId ?? '') ? botId : undefined
+}
+
+const CONNECTION_IDENTITY = new Map<string, (integration: unknown) => string>([
+  // A shared bot has no app token to key on; a socket integration keys on it.
+  [
+    'slack',
+    (i) => {
+      const slack = (i as SlackConfig).slack
+      return slack.mode === 'shared' ? slack.botToken : (slack.appToken ?? slack.botToken)
+    }
+  ],
+  // The bot-id prefix survives a secret rotation; non-standard tokens fall back
+  // to the full high-entropy credential before hashing.
+  [
+    'telegram',
+    (i) => {
+      const token = (i as TelegramConfig).telegram.botToken
+      return telegramBotId(token) ?? token
+    }
+  ],
+  ['discord', (i) => (i as DiscordConfig).discord.botToken],
+  [
+    'feishu',
+    (i) => {
+      const feishu = (i as FeishuConfig).feishu
+      return `${feishu.region}:${feishu.appId}`
+    }
+  ]
+])
+
+/** The credential string identifying `integration`'s physical connection —
+ *  hashed by the caller, never persisted raw. Fail-CLOSED default: an
+ *  unregistered platform identifies by integration id, so its scope never
+ *  consolidates across integrations (over-isolating is safe; over-sharing a
+ *  scope would merge unrelated conversations). */
+export function connectionIdentityFor(integration: { id: string; platform: string }): string {
+  return CONNECTION_IDENTITY.get(integration.platform)?.(integration) ?? integration.id
+}
+
+/** Core-owned inputs a tenant-scope strategy may consult. */
+export interface TenantScopeHost {
+  /** The live connection's workspace/team id, where the platform exposes one. */
+  liveWorkspaceId(integrationId: string): string | undefined
+  /** A scope minted once per integration and persisted — the rotation-immune
+   *  fallback when the platform exposes no tenant id. */
+  minted(integrationId: string): string | undefined
+}
+
+const TENANT_SCOPE = new Map<string, (host: TenantScopeHost, integration: unknown) => string | undefined>([
+  // The workspace id from auth.test, surfaced by the live connection. A
+  // not-yet-authenticated (or test-substituted) connection may not expose it —
+  // fall back to the minted scope rather than throw.
+  ['slack', (host, i) => host.liveWorkspaceId((i as { id: string }).id) || host.minted((i as { id: string }).id)],
+  // The public bot id prefix survives a BotFather token rotation.
+  [
+    'telegram',
+    (host, i) => {
+      const botId = telegramBotId((i as TelegramConfig).telegram.botToken)
+      return botId ? `bot${botId}` : host.minted((i as { id: string }).id)
+    }
+  ],
+  // App id + region is the tenant anchor Feishu/Lark exposes to us.
+  [
+    'feishu',
+    (_host, i) => {
+      const feishu = (i as FeishuConfig).feishu
+      return `${feishu.region}:${feishu.appId}`
+    }
+  ]
+])
+
+/** The durable tenant scope for `integration` (session-visibility §2). Total by
+ *  construction: a platform with no durable tenant id of its own — Discord, and
+ *  anything unregistered — gets the minted per-integration scope. Undefined ⇒
+ *  the CP records no owner (fail closed), never a guessed one. */
+export function tenantScopeFor(
+  host: TenantScopeHost,
+  integration: { id: string; platform: string }
+): string | undefined {
+  const strategy = TENANT_SCOPE.get(integration.platform)
+  return strategy ? strategy(host, integration) : host.minted(integration.id)
+}

--- a/packages/daemon/test/transport-identity.test.ts
+++ b/packages/daemon/test/transport-identity.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { connectionIdentityFor, tenantScopeFor, type TenantScopeHost } from '../src/platforms/transport-identity.js'
+import { conversationAudienceFor } from '../src/platforms/session-audience.js'
+
+const host = (live?: string, minted?: string): TenantScopeHost => ({
+  liveWorkspaceId: () => live,
+  minted: () => minted
+})
+
+describe('connection identity (transport scope)', () => {
+  it('names the credential that identifies one physical connection', () => {
+    // A shared Slack bot has no app token to key on; a socket integration keys on it.
+    expect(
+      connectionIdentityFor({ id: 'i1', platform: 'slack', slack: { mode: 'shared', botToken: 'xoxb-1' } } as never)
+    ).toBe('xoxb-1')
+    expect(
+      connectionIdentityFor({
+        id: 'i1',
+        platform: 'slack',
+        slack: { mode: 'socket', botToken: 'xoxb-1', appToken: 'xapp-1' }
+      } as never)
+    ).toBe('xapp-1')
+    // The BotFather bot-id prefix survives a secret rotation…
+    expect(connectionIdentityFor({ id: 'i2', platform: 'telegram', telegram: { botToken: '42:AAff' } } as never)).toBe(
+      '42'
+    )
+    // …non-standard tokens fall back to the full credential.
+    expect(
+      connectionIdentityFor({ id: 'i2', platform: 'telegram', telegram: { botToken: 'test-token' } } as never)
+    ).toBe('test-token')
+    expect(connectionIdentityFor({ id: 'i3', platform: 'discord', discord: { botToken: 'dt' } } as never)).toBe('dt')
+    expect(
+      connectionIdentityFor({ id: 'i4', platform: 'feishu', feishu: { region: 'lark', appId: 'cli_1' } } as never)
+    ).toBe('lark:cli_1')
+  })
+
+  it('over-isolates unknown platforms rather than over-sharing', () => {
+    // Identity = the integration id: the scope never consolidates across
+    // integrations, which cannot merge unrelated conversations.
+    expect(connectionIdentityFor({ id: 'i9', platform: 'some-future-platform' })).toBe('i9')
+  })
+})
+
+describe('tenant scope (durable owner identity)', () => {
+  it('prefers the platform tenant id, falls back to the minted scope', () => {
+    expect(tenantScopeFor(host('T012', 'm1'), { id: 'i1', platform: 'slack' })).toBe('T012')
+    expect(tenantScopeFor(host(undefined, 'm1'), { id: 'i1', platform: 'slack' })).toBe('m1')
+    expect(
+      tenantScopeFor(host(undefined, 'm2'), { id: 'i2', platform: 'telegram', telegram: { botToken: '42:x' } } as never)
+    ).toBe('bot42')
+    expect(
+      tenantScopeFor(host(undefined, 'm2'), {
+        id: 'i2',
+        platform: 'telegram',
+        telegram: { botToken: 'weird' }
+      } as never)
+    ).toBe('m2')
+    expect(
+      tenantScopeFor(host(undefined, 'm3'), {
+        id: 'i4',
+        platform: 'feishu',
+        feishu: { region: 'lark', appId: 'c1' }
+      } as never)
+    ).toBe('lark:c1')
+  })
+
+  it('mints for platforms with no durable tenant id (Discord, unknown)', () => {
+    expect(tenantScopeFor(host(undefined, 'm4'), { id: 'i3', platform: 'discord' })).toBe('m4')
+    expect(tenantScopeFor(host(undefined, 'm5'), { id: 'i9', platform: 'some-future-platform' })).toBe('m5')
+    // No minted scope either ⇒ undefined ⇒ the CP records no owner (fail closed).
+    expect(tenantScopeFor(host(undefined, undefined), { id: 'i9', platform: 'x' })).toBeUndefined()
+  })
+})
+
+describe('conversation audience', () => {
+  it('binds Slack channels but not Slack DMs', () => {
+    const slack = conversationAudienceFor('slack')!
+    expect(slack.applies({ isDm: false })).toBe(true)
+    expect(slack.applies({ isDm: true })).toBe(false)
+    expect(slack.realmKey({ liveWorkspaceId: () => 'T01', tenantScope: () => 'x' }, 'i1', undefined)).toBe('T01')
+    // Unresolved integration ⇒ unattributable realm, not a guessed one.
+    expect(
+      slack.realmKey({ liveWorkspaceId: () => 'T01', tenantScope: () => 'x' }, undefined, undefined)
+    ).toBeUndefined()
+  })
+
+  it('binds every Feishu conversation through the tenant anchor', () => {
+    const feishu = conversationAudienceFor('feishu')!
+    expect(feishu.applies({ isDm: true })).toBe(true)
+    expect(
+      feishu.realmKey({ liveWorkspaceId: () => undefined, tenantScope: () => 'lark:c1' }, 'i4', {
+        id: 'i4',
+        platform: 'feishu'
+      })
+    ).toBe('lark:c1')
+  })
+
+  it('binds nothing elsewhere — local classification rules alone', () => {
+    for (const p of ['telegram', 'discord', 'webchat', 'hook', 'some-future-platform']) {
+      expect(conversationAudienceFor(p)).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
Fifteenth PR of stage S2; seventh class (c) batch — the audit's `transportScopeIdentity` / `tenantScope` / `realmKey` rows, which are **two different answers to "what identifies this integration's connection?"** with two different lifetimes, plus the session-audience fork built on top of them.

## `connectionIdentityFor` → `platforms/transport-identity.ts`

Which credential identifies **one physical connection**, so integrations consolidated onto the same credential share a transport scope. Deliberately rotates with the credential; core hashes it and no raw credential is persisted or logged. The §7.5 pool keys state the same fact for *live* connections; this states it for *configs*, before any connection exists.

Fail-closed default: an unregistered platform identifies by integration id — **over-isolating is safe; over-sharing a scope would merge unrelated conversations.**

## `tenantScopeFor`

The **durable** owner identity (`<platform>:<scope>:<uid>`, session-visibility §2). Must survive rotation, so it prefers the platform's own tenant id — Slack team id via the live connection, Telegram's public bot-id prefix, Feishu `region:appId` — and falls back to a scope minted once per integration by core. Discord and anything unregistered mint; undefined ⇒ the CP records **no owner**, never a guessed one.

## `conversationAudienceFor` → `platforms/session-audience.ts`

Which platforms bind a session to its conversation's audience, which conversations qualify (Slack binds channels but **not DMs** — a DM's audience is the DM itself; Feishu binds everything), and what identifies the realm. No registered audience — Telegram, Discord, webchat — means local classification rules alone, exactly as before.

`bindSessionSource`'s completeness guard re-keys from the provider pair (`'slack' || 'feishu'`) to `externalResourceKind === 'conversation'`: a conversation audience is bindable only when fully attributed, a repository audience (GitHub) has its own rule — and a new platform's audience now gets the same guard without the condition growing a provider list.

Both strategy files read the legacy disk-shape config blocks structurally — the S1b #516 decision that froze that shape is exactly why these reads belong in a platform strategy and not in core.

## Verification

- `pnpm typecheck` clean; `eslint`/`prettier` clean
- daemon suite: **2844 passed**, 46 skipped, incl. **7 new** tests (credential table incl. shared-vs-socket Slack and the BotFather-prefix fallback; tenant preference ladders incl. the no-minted-scope fail-closed `undefined`; audience applies/realm rules incl. Slack DM exclusion and unresolved-integration `undefined`)
- Four-platform conditionals in `daemon.ts`: **34 → 24**

🤖 Generated with [Claude Code](https://claude.com/claude-code)