### PR TITLE
fix(daemon): expose repo root to ACP sessions

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -493,6 +493,9 @@ export class AcpHost {
   private loadingSessions = new Set<string>()
   // whether the agent advertised the `loadSession` capability at initialize.
   private canLoad = false
+  // whether the agent accepts repository roots in addition to the session cwd.
+  // This is capability-gated because older ACP adapters reject the field.
+  private canUseAdditionalDirectories = false
   // prompt content-block variants the agent opted into at initialize. text +
   // resource_link are always baseline; image/audio/embeddedContext are gated.
   private promptCaps: { image?: boolean; audio?: boolean; embeddedContext?: boolean } = {}
@@ -789,6 +792,7 @@ export class AcpHost {
     })
     this.negotiatedProtocolVersion = init.protocolVersion
     this.canLoad = init.agentCapabilities?.loadSession ?? false
+    this.canUseAdditionalDirectories = init.agentCapabilities?.sessionCapabilities?.additionalDirectories != null
     this.promptCaps = init.agentCapabilities?.promptCapabilities ?? {}
     const mcp = init.agentCapabilities?.mcpCapabilities
     this.mcpCaps = {
@@ -804,7 +808,7 @@ export class AcpHost {
         }
       : undefined
     this.opts.log?.debug(
-      `acp: agent initialized (${this.agentInfo?.name ?? 'agent'}${this.agentInfo?.version ? ` v${this.agentInfo.version}` : ''}, loadSession=${this.canLoad}, prompt caps: image=${!!this.promptCaps.image} audio=${!!this.promptCaps.audio} embeddedContext=${!!this.promptCaps.embeddedContext}, mcp: http=${this.mcpCaps.http} sse=${this.mcpCaps.sse})`
+      `acp: agent initialized (${this.agentInfo?.name ?? 'agent'}${this.agentInfo?.version ? ` v${this.agentInfo.version}` : ''}, loadSession=${this.canLoad}, additionalDirectories=${this.canUseAdditionalDirectories}, prompt caps: image=${!!this.promptCaps.image} audio=${!!this.promptCaps.audio} embeddedContext=${!!this.promptCaps.embeddedContext}, mcp: http=${this.mcpCaps.http} sse=${this.mcpCaps.sse})`
     )
   }
 
@@ -828,12 +832,14 @@ export class AcpHost {
    *  effort/model/fast overrides are layered on afterward by the daemon at turn start.
    *  `systemAppend` (the agent meta object + the agent's memory index, for a FRESH
    *  session) rides the Claude `_meta.systemPrompt` append — standing context, never a
-   *  user turn (see #398). */
+   *  user turn (see #398). `additionalDirectories` expands the runtime workspace
+   *  without changing the configured working-subdirectory `cwd`. */
   async newSession(
     cwd: string,
     mcpServers: McpServer[] = [],
     effortOverride?: string,
-    systemAppend?: string
+    systemAppend?: string,
+    additionalDirectories: string[] = []
   ): Promise<string> {
     const _meta = claudeSessionMeta(
       effortOverride ?? this.opts.configPrefs?.reasoningEffort,
@@ -844,8 +850,10 @@ export class AcpHost {
       this.opts.sandbox?.claudeProtectedSettings,
       this.opts.sandbox?.allowModelToolUnixSockets
     )
+    const activeAdditionalDirectories = this.canUseAdditionalDirectories ? additionalDirectories : []
     const res = await this.conn!.agent.request(methods.agent.session.new, {
       cwd,
+      ...(activeAdditionalDirectories.length > 0 ? { additionalDirectories: activeAdditionalDirectories } : {}),
       mcpServers,
       ...(_meta ? { _meta } : {})
     })
@@ -1099,7 +1107,8 @@ export class AcpHost {
     cwd: string,
     mcpServers: McpServer[] = [],
     effortOverride?: string,
-    systemAppend?: string
+    systemAppend?: string,
+    additionalDirectories: string[] = []
   ): Promise<void> {
     this.loadingSessions.add(sessionId)
     try {
@@ -1112,9 +1121,11 @@ export class AcpHost {
         this.opts.sandbox?.claudeProtectedSettings,
         this.opts.sandbox?.allowModelToolUnixSockets
       )
+      const activeAdditionalDirectories = this.canUseAdditionalDirectories ? additionalDirectories : []
       const res = await this.conn!.agent.request(methods.agent.session.load, {
         sessionId,
         cwd,
+        ...(activeAdditionalDirectories.length > 0 ? { additionalDirectories: activeAdditionalDirectories } : {}),
         mcpServers,
         ...(_meta ? { _meta } : {})
       })

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -7,7 +7,7 @@ import { selectAgent } from '../agents/load-agents.js'
 import { agentChildEnv } from '../agents/agent-env.js'
 import { cleanupConfigFiles, materializeConfigFiles } from '../agents/config-file-env.js'
 import { memoryKindOf, memoryProviderFor } from '../agents/memory-provider.js'
-import { prepareWorkspace } from '../workspace/workspace-manager.js'
+import { additionalWorkspaceDirectories, prepareWorkspace } from '../workspace/workspace-manager.js'
 import { configureWorkspaceGitOrigins } from '../workspace/git-origin-policy.js'
 import { AcpHost } from '../acp/acp-host.js'
 import { effectiveRunInSandbox } from '../acp/runtime-launch.js'
@@ -175,7 +175,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     // Runtime adapters may discover skills only during initialization. Finish the
     // complete clone/pull + unified-skill reconciliation before the child starts.
     await host.start()
-    const sessionId = await host.newSession(cwd)
+    const sessionId = await host.newSession(cwd, [], undefined, undefined, additionalWorkspaceDirectories(agent, cwd))
 
     const send = async (text: string) => {
       const blocks: ContentBlock[] = [{ type: 'text', text }]

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -1,7 +1,7 @@
 import type { ContentBlock, McpServer } from '@agentclientprotocol/sdk'
 import { LocalStore, sessionKey, transcriptChannelKey, type TranscriptEntry } from '../store/local-store.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
-import { prepareWorkspace } from '../workspace/workspace-manager.js'
+import { additionalWorkspaceDirectories, prepareWorkspace } from '../workspace/workspace-manager.js'
 import { memoryKindOf, type MemoryProvider } from '../agents/memory-provider.js'
 import { MAX_INDEX_INJECT_BYTES } from '../agents/memory.js'
 import { agentChildEnv } from '../agents/agent-env.js'
@@ -590,10 +590,19 @@ export class SessionManager {
       const value = initialEffort ?? this.deps.store.getEffortOverride(key)
       return { value, chatSelected: value !== undefined }
     }
+    const runtimeWorkspaceDirectories = (cwd: string): string[] =>
+      additionalWorkspaceDirectories(agent, cwd, {
+        sessionKey: key,
+        isolation: workspaceIsolation
+      })
     const newRuntimeSession = async (cwd: string, mcpServers: McpServer[], systemAppend?: string): Promise<string> => {
+      const additionalDirectories = runtimeWorkspaceDirectories(cwd)
       while (true) {
         const selected = sessionStartEffort()
-        const sessionId = await abortable(() => host.newSession(cwd, mcpServers, selected.value, systemAppend), signal)
+        const sessionId = await abortable(
+          () => host.newSession(cwd, mcpServers, selected.value, systemAppend, additionalDirectories),
+          signal
+        )
         if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return sessionId
         host.discardSession(sessionId)
       }
@@ -605,7 +614,11 @@ export class SessionManager {
       systemAppend?: string
     ): Promise<boolean> => {
       const selected = sessionStartEffort()
-      await abortable(() => host.loadSession(sessionId, cwd, mcpServers, selected.value, systemAppend), signal)
+      const additionalDirectories = runtimeWorkspaceDirectories(cwd)
+      await abortable(
+        () => host.loadSession(sessionId, cwd, mcpServers, selected.value, systemAppend, additionalDirectories),
+        signal
+      )
       if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return true
       // The pinned Claude adapter treats a repeated load of the same session/cwd/MCP
       // fingerprint as idempotent, so another load cannot replace metadata-only effort.

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -645,6 +645,29 @@ export function resolvePreparedWorkspaceCwd(agent: Agent): string {
   return resolveAcpCwd(agent.workspace.path, agentDir)
 }
 
+/** Return the checkout root that encloses an already-prepared ACP cwd.
+ *
+ * ACP keeps `cwd` at the configured working subdirectory so relative paths and
+ * project instructions retain their existing meaning. Runtimes that support
+ * additional workspace directories receive this enclosing root separately,
+ * which lets repository-wide tools reach `.git` and sibling paths. */
+export function additionalWorkspaceDirectories(
+  agent: Agent,
+  cwd: string,
+  request?: Pick<PrepareSessionWorkspaceRequest, 'sessionKey' | 'isolation'>
+): string[] {
+  if (agent.workspace.mode !== 'git-repo') return []
+  const expectedRoot =
+    request?.isolation === 'session' ? sessionWorktreePath(agent, request.sessionKey) : agent.workspace.path
+  const root = realpathSync(expectedRoot)
+  const canonicalCwd = realpathSync(cwd)
+  const rel = relative(root, canonicalCwd)
+  if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+    throw new Error(`prepared workspace cwd "${cwd}" resolves outside its checkout root`)
+  }
+  return root === canonicalCwd ? [] : [root]
+}
+
 /** Resolve the checked path ACP receives, closing symlink and prefix-containment gaps. */
 function resolveAcpCwd(workspaceRoot: string, agentDir: string | undefined): string {
   const canonicalRoot = realpathSync(workspaceRoot)

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -86,6 +86,39 @@ describe('AcpHost.mcpCapabilities (MCP transports from initialize)', () => {
   }, 15_000)
 })
 
+describe('AcpHost additional workspace directories', () => {
+  it('forwards them on new/load only when the agent advertises support', async () => {
+    const cwd = '/tmp/repo/agents/node-operator'
+    const repoRoot = '/tmp/repo'
+    const supported = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: [] },
+      {
+        onUpdate: () => {},
+        env: {
+          AC_ADDITIONAL_DIRECTORIES: '1',
+          AC_EXPECT_ADDITIONAL_DIRECTORIES: JSON.stringify([repoRoot]),
+          AC_LOAD_UPDATES: '1'
+        }
+      }
+    )
+    await supported.start()
+    await supported.newSession(cwd, [], undefined, undefined, [repoRoot])
+    await supported.loadSession('persisted-session', cwd, [], undefined, undefined, [repoRoot])
+    await supported.stop()
+
+    const unsupported = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: [] },
+      {
+        onUpdate: () => {},
+        env: { AC_EXPECT_ADDITIONAL_DIRECTORIES: '[]' }
+      }
+    )
+    await unsupported.start()
+    await unsupported.newSession(cwd, [], undefined, undefined, [repoRoot])
+    await unsupported.stop()
+  }, 15_000)
+})
+
 describe('AcpHost session/load update filtering', () => {
   it('forwards restored title metadata while suppressing replayed conversation output', async () => {
     const updates: string[] = []

--- a/packages/daemon/test/fixtures/fake-acp-agent.mjs
+++ b/packages/daemon/test/fixtures/fake-acp-agent.mjs
@@ -28,6 +28,23 @@ const permissionModeList = (process.env.AC_PERMISSION_MODES ?? '')
 const sessionPermissionModes = new Map()
 const reviewerEnabled = process.env.AC_APPROVALS_REVIEWER === '1'
 const sessionReviewers = new Map()
+const additionalDirectoriesEnabled = process.env.AC_ADDITIONAL_DIRECTORIES === '1'
+const expectedAdditionalDirectories = process.env.AC_EXPECT_ADDITIONAL_DIRECTORIES
+  ? JSON.parse(process.env.AC_EXPECT_ADDITIONAL_DIRECTORIES)
+  : undefined
+const acceptsAdditionalDirectories = (id, params) => {
+  if (expectedAdditionalDirectories === undefined) return true
+  if (JSON.stringify(params.additionalDirectories ?? []) === JSON.stringify(expectedAdditionalDirectories)) return true
+  send({
+    jsonrpc: '2.0',
+    id,
+    error: {
+      code: -32602,
+      message: `unexpected additionalDirectories: ${JSON.stringify(params.additionalDirectories)}`
+    }
+  })
+  return false
+}
 
 // Optional MCP transport capabilities advertised at initialize. `AC_MCP_CAPS`
 // (comma list) turns them on; unset ⇒ no mcpCapabilities key at all.
@@ -44,7 +61,8 @@ const agentCapabilities = () => ({
         }
       }
     : {}),
-  ...(process.env.AC_LOAD_UPDATES ? { loadSession: true } : {})
+  ...(process.env.AC_LOAD_UPDATES ? { loadSession: true } : {}),
+  ...(additionalDirectoriesEnabled ? { sessionCapabilities: { additionalDirectories: {} } } : {})
 })
 const configOptions = (sessionId) => {
   const options = []
@@ -88,6 +106,7 @@ rl.on('line', async (line) => {
   if (method === 'initialize') {
     send({ jsonrpc: '2.0', id, result: { protocolVersion: 1, agentCapabilities: agentCapabilities() } })
   } else if (method === 'session/new') {
+    if (!acceptsAdditionalDirectories(id, params)) return
     const sessionId = `s${++sessionCounter}`
     sessionModels.set(sessionId, modelList[0])
     sessionPermissionModes.set(sessionId, permissionModeList[0])
@@ -111,6 +130,7 @@ rl.on('line', async (line) => {
       sessionReviewers.set(params.sessionId, params.value)
     send({ jsonrpc: '2.0', id, result: { configOptions: configOptions(params.sessionId) } })
   } else if (method === 'session/load') {
+    if (!acceptsAdditionalDirectories(id, params)) return
     if (process.env.AC_LOAD_PERMISSION_MODE)
       sessionPermissionModes.set(params.sessionId, process.env.AC_LOAD_PERMISSION_MODE)
     if (process.env.AC_LOAD_APPROVALS_REVIEWER)

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mkdtempSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
@@ -90,6 +90,43 @@ describe('SessionManager', () => {
       sessionKey: 'slack:C1:100.2:bot-a',
       isolation: 'shared'
     })
+    store.close()
+  })
+
+  it('keeps a configured working subdirectory as cwd and adds its repository root', async () => {
+    const store = newStore()
+    const agentRoot = mkdtempSync(join(tmpdir(), 'ac-sm-git-root-'))
+    const repoRoot = join(agentRoot, 'workspace')
+    const cwd = join(repoRoot, 'agents', 'node-operator')
+    mkdirSync(join(repoRoot, '.git'), { recursive: true })
+    mkdirSync(cwd, { recursive: true })
+    const gitAgent = {
+      ...agent,
+      dir: agentRoot,
+      runtime: 'codex',
+      workspace: {
+        mode: 'git-repo',
+        path: repoRoot,
+        gitRepo: 'https://github.com/sentioxyz/production.git',
+        gitBranch: 'main',
+        agentDir: 'agents/node-operator',
+        pullOnNewSession: false,
+        skills: []
+      }
+    } as Agent & { dir: string; env: Record<string, string> }
+    const host = fakeHost()
+    const prepareWorkspace = vi.fn(async () => realpathSync(cwd))
+    const sm = new SessionManager({
+      store,
+      hostFor: async () => host,
+      agentById: () => gitAgent,
+      prepareWorkspace,
+      memory
+    })
+
+    await sm.handle('bot-a', msg({ ts: '100.3', thread: '100.3', text: 'update production' }))
+
+    expect(host.newSession).toHaveBeenCalledWith(realpathSync(cwd), [], undefined, undefined, [realpathSync(repoRoot)])
     store.close()
   })
 
@@ -1110,7 +1147,7 @@ describe('SessionManager', () => {
 
     expect(sessionId).toBe('acp-1') // resumed the SAME session, not recreated
     expect(created).toBe(false) // same id, CP already knows it → no start emit
-    expect(host2.loadSession).toHaveBeenCalledWith('acp-1', expect.any(String), [], undefined, undefined)
+    expect(host2.loadSession).toHaveBeenCalledWith('acp-1', expect.any(String), [], undefined, undefined, [])
     expect(mcpServersFor).toHaveBeenCalledWith(
       expect.objectContaining({ integrationId: 'int-b', isDm: true, thread: '100.1' })
     )
@@ -1162,7 +1199,7 @@ describe('SessionManager', () => {
     expect(host2.loadSession).toHaveBeenCalledTimes(1)
     expect(host2.loadSession.mock.calls[0]?.[3]).toBe('ultracode')
     expect(host2.discardSession).toHaveBeenCalledWith('acp-1')
-    expect(host2.newSession).toHaveBeenCalledWith(expect.any(String), [], undefined, undefined)
+    expect(host2.newSession).toHaveBeenCalledWith(expect.any(String), [], undefined, undefined, [])
     store.close()
   })
 

--- a/packages/daemon/test/turn-output-workflow.test.ts
+++ b/packages/daemon/test/turn-output-workflow.test.ts
@@ -371,7 +371,8 @@ describe('TurnOutputWorkflow', () => {
       expect.any(String),
       expect.any(Array),
       undefined,
-      undefined
+      undefined,
+      []
     )
     expect(prompts).toHaveLength(1)
     const durableQuote = prompts[0]!.indexOf('[U2] durable quote: keep the compatibility branch')

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -40,6 +40,7 @@ vi.mock('simple-git', () => ({
 
 // Imported after vi.mock so the mock is in effect.
 const {
+  additionalWorkspaceDirectories,
   convergeGithubAppWorkspaceRename,
   ensureWorkspaceMaterialization,
   prepareSessionWorkspace,
@@ -367,11 +368,15 @@ describe('prepareSessionWorkspace', () => {
     const root = mkdtempSync(join(tmpdir(), 'ac-session-ws-'))
     const path = join(root, 'workspace')
     mkdirSync(join(path, '.git'), { recursive: true })
-    const agent = gitRepoAgent(path)
+    mkdirSync(join(path, 'agents', 'node-operator'), { recursive: true })
+    const agent = gitRepoAgent(path, 'agents/node-operator')
     agent.workspace.pullOnNewSession = false
     rawMock.mockImplementation(async (args: string[]) => {
       if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/repo.git\n'
-      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(join(args[3]!, '.git'), { recursive: true })
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        mkdirSync(join(args[3]!, '.git'), { recursive: true })
+        mkdirSync(join(args[3]!, 'agents', 'node-operator'), { recursive: true })
+      }
       return args[0] === 'rev-parse' ? `${'c'.repeat(40)}\n` : ''
     })
 
@@ -381,8 +386,12 @@ describe('prepareSessionWorkspace', () => {
 
     expect(again).toBe(first)
     expect(second).not.toBe(first)
-    expect(dirname(first)).toBe(realpathSync(sessionWorktreeRoot(agent)))
-    expect(dirname(second)).toBe(realpathSync(sessionWorktreeRoot(agent)))
+    expect(additionalWorkspaceDirectories(agent, first, { sessionKey: 'session-a', isolation: 'session' })).toEqual([
+      realpathSync(sessionWorktreePath(agent, 'session-a'))
+    ])
+    expect(additionalWorkspaceDirectories(agent, second, { sessionKey: 'session-b', isolation: 'session' })).toEqual([
+      realpathSync(sessionWorktreePath(agent, 'session-b'))
+    ])
   })
 })
 


### PR DESCRIPTION
## Summary

- keep each configured working subdirectory as the ACP `cwd`
- pass the enclosing shared checkout or per-session worktree root through ACP `additionalDirectories`
- capability-gate the field for older adapters and apply it on both `session/new` and `session/load`
- keep standalone `agentconnect chat` consistent with daemon-managed sessions

## Root cause

AgentConnect resolved a repository working subdirectory such as `agents/node-operator` and passed only that path as `cwd`. Codex therefore treated the subdirectory as its complete workspace root, leaving the repository-level `.git` directory and sibling production paths outside the inner writable scope even though the daemon sandbox already allowed the checkout.

## Impact

Codex agents can edit repository-wide files and run Git write operations while relative paths and nested project-instruction discovery continue to use the configured working subdirectory. Session-isolated agents receive only their own worktree root, not the shared checkout.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- 187 focused daemon tests across ACP host, session manager, workspace, and CLI chat
- pre-push `eslint .` completed with only two pre-existing duplicate-import warnings in `packages/relay/src/relay-ingress-manager.ts`

Created by Codex . GPT-5
