### PR TITLE
docs(design): S2 exit reconciliation — audit §9, last literal parameterized

### DIFF
--- a/docs/designs/integration-plugin-audit.md
+++ b/docs/designs/integration-plugin-audit.md
@@ -316,6 +316,88 @@ in §1.
 
 ---
 
+## 9. S2 exit reconciliation (2026-08-04)
+
+S2's exit criterion (design §13): _`daemon.ts` compiles with zero
+platform-conditional edits remaining for the four chat platforms — the audited
+branches are **gone or reclassified** — and evals implement the published
+interface with the Arena suite passing unchanged._ This section is the
+reconciliation.
+
+### 9.1 What landed
+
+Sixteen PRs (#525–#536, #538–#540, #542), in dependency order: Layer 1
+connection contract (`platforms/contract.ts`), the keyed connection registry
+(`platforms/registry.ts`), Layer 2 turn output in two shapes
+(`TurnOutputSurface` for the four streaming platforms, `TurnFinalSurface` for
+GitHub), the four platform turn-output modules, the §5 manifest facet
+(`membershipEnumeration`, `dmChannelPattern`), and eight class-(c) strategy
+batches: loop-guard scopes, member-id recognition, command chrome,
+ingress coordinate semantics (`thread-keys`, `malformed-turn`,
+`thread-promotion`), platform-action decoders + link source, binding-map read
+side + observed channels, transport identity + conversation audience, and the
+turn-chrome facet with surface teardown hooks.
+
+### 9.2 Remaining platform literals in `daemon.ts` — all reclassified
+
+Eleven comparison sites survive, none of them a core branch. Each is platform
+code reached only through a platform-specific entry point, i.e. a FILE-MOVE
+candidate (the mechanical relocation to `platforms/<id>/` that class (a)
+prescribes), not a dispatch fork:
+
+| sites                                                         | what                                                                                 | reached via                                                                                                           |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| 5 in `handleRelaySlackAction`                                 | shared-mode integration lookup, delivery-binding validation, foreign-session rejects | `platformActionDecoders['slack']` only                                                                                |
+| 1 in `handleRelayFeishuAction`                                | shared-mode integration lookup                                                       | `platformActionDecoders['feishu']` only                                                                               |
+| 2 in `isHttpSlackIntegration` / `isShareableSlackIntegration` | Slack shared-mode predicates over the frozen (#516) disk shape                       | Slack-only flows (relay-owned action ids, switch-agent gate)                                                          |
+| 2 in `setSlackTitleForBinding`                                | the Slack DM-title binding writer's own validation                                   | `dmSessionTitle` turn-chrome gate                                                                                     |
+| 1 in `isAgentBotMessage`                                      | managed-Slack-bot echo identity (`botSenderRouting`)                                 | ingress trust check, entangled with the CP collab snapshot's Slack app-id index — moves with the Slack ingress module |
+
+Non-branch platform code still in shared files, likewise pending file moves,
+not extraction: the per-platform connect/consolidate loops (`slackRetryTimers`
+and friends — audit rows 2774/3317/3441, class a) and the two
+`sessionLink(…, 'slack')` literals inside Slack-only status-bar/modal flows.
+
+### 9.3 Blind-spot checklist (§6) sweep results
+
+1. **instanceof as branch** — 14 sites remain, each now the _sanctioned_ gate
+   (duck-type boundary of platform code) rather than a hidden fork; four
+   redundant platform literals that shadowed a stronger instanceof/capability
+   gate were dropped with the gate named (#542).
+2. **Capability probes** — now the sanctioned Layer-1 read-port mechanism
+   (`getThreadReplies`, `getChannelInfo`, `workspaceId?.()`).
+3. **Map-membership forks** — read side unified (`integrationBindings`,
+   #539); the typed maps stay per §7.5.
+4. **Hardcoded literals** — `maybeIntroduceOnJoin`'s `const platform = 'slack'`
+   parameterized (caller passes its platform as data); the two `sessionLink`
+   hints are inside Slack-gated flows (§9.2).
+5. **Id-syntax** — `startsWith('D')` → manifest `dmChannelPattern`;
+   `slackTsMicros`/`compareSlackTs` no longer referenced in `daemon.ts`
+   (platform modules own them).
+6. **Named per-platform fields** — dual-shape readers in place (#518/#536);
+   the named fields retire with the S1b legacy-emission flip, not S2.
+7. **Per-platform state** — `staleReplyFooters`/`feishuStreamTimer`/`tgReplyTo`
+   now live in the opaque per-turn slots; `slackRetryTimers` belongs to the
+   reconcile loops (§9.2 file-move set).
+8. **SQL literals** — `platform <> 'dream'` (local-store) is origin-kind
+   filtering, class (d).
+   9–12, 16. Relay / CP / web items — S3 scope, unchanged by S2.
+9. **Constraint-level branching** — resolved in S1b (#512 generic identity
+   columns).
+10. **Identity-template arity** — realm composition now owned by the
+    transport-identity / session-audience strategies (#540).
+11. **Comment-only invariants** — re-derived in S1a (#504/#507).
+12. False positives excluded throughout (`workspace.mode === 'github'`,
+    `'dream'` memory-write source).
+
+### 9.4 Evals and Arena
+
+`VirtualSlackConnection` / `VirtualDiscordConnection` implement the published
+Layer-1 `PlatformConnection` (`evaluation/virtual-connections.ts`), eval
+integrations resolve through the same §7.5 registry with prune immunity, and
+the evaluation/game ingress suites (`test/evaluation-game-ingress.test.ts`,
+`test/platform-contract.test.ts`) pass unchanged in the 2 847-test daemon run.
+
 ## Appendix A — `packages/daemon/src` (shared/core files; per-platform dirs excluded)
 
 ### 1. Findings

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4145,7 +4145,7 @@ export class Daemon {
         const merged = [...channels, ...ims]
         this.channelSnapshots.set(integrationId, { channels: merged, authoritative: true })
         this.cpClient?.emitIntegrationChannels({ integrationId, channels: merged })
-        this.maybeIntroduceOnJoin(integrationId, channels)
+        this.maybeIntroduceOnJoin('slack', integrationId, channels)
       }
       this.log.debug(`slack: channel snapshot for bot ${conn.botUserId}: ${channels.length} channel(s)`)
     } catch (err) {
@@ -4165,10 +4165,9 @@ export class Daemon {
    * marked BEFORE dispatch, so a failed turn is simply skipped (never retried in a
    * loop). Not opted in ⇒ no seeding either, so enabling it later baselines cleanly.
    */
-  private maybeIntroduceOnJoin(integrationId: string, channels: { id: string }[]): void {
+  private maybeIntroduceOnJoin(platform: string, integrationId: string, channels: { id: string }[]): void {
     const agent = [...this.agents.values()].find((a) => a.integrations.some((i) => i.id === integrationId))
     if (!agent?.introduceOnJoin) return
-    const platform = 'slack'
     const plan = planChannelIntros(
       {
         seeded: this.store.isChannelIntroSeeded(integrationId),
@@ -9418,7 +9417,7 @@ export class Daemon {
     }
     const conn = this.replyConnFor(target.agentId, target.integrationId)
     // Where the command was sent — the reply lands here (Slack thread_ts; Telegram
-    // replies to the command message via tgReplyTo). Kept separate from the session the
+    // replies to the command message via its chrome surface's reply anchor). Kept separate from the session the
     // command ACTS on, resolved just below.
     const replyThread = msg.thread ?? msg.msgId
     // Resolve the session the command acts on. A command that isn't in a session's own

--- a/packages/daemon/test/channel-intro.test.ts
+++ b/packages/daemon/test/channel-intro.test.ts
@@ -157,7 +157,11 @@ describe('Daemon.maybeIntroduceOnJoin: the intro turn carries its own discovery 
       return 'acp-1'
     }
     const introduce = (channels: string[]): void =>
-      (daemon as never as { maybeIntroduceOnJoin: (i: string, c: { id: string }[]) => void }).maybeIntroduceOnJoin(
+      (
+        daemon as never as { maybeIntroduceOnJoin: (p: string, i: string, c: { id: string }[]) => void }
+      ).maybeIntroduceOnJoin(
+        // The caller (Slack's authoritative-snapshot refresh) names its platform as data.
+        'slack',
         'int-1',
         channels.map((id) => ({ id }))
       )


### PR DESCRIPTION
Seventeenth and closing PR of stage S2 — the exit-criteria reconciliation the stage's own definition requires.

> **S2 exit criteria (design §13):** `daemon.ts` compiles with zero platform-conditional edits remaining for the four chat platforms (the audited branches are **gone or reclassified**); evals implement the published interface and the Arena suite passes unchanged.

## Audit §9 (new)

- **What landed** — 16 PRs (#525–#536, #538–#540, #542): the three-facet contract, the keyed registry, Layer 2 in two shapes, five platform modules, eight class-(c) strategy batches.
- **The 11 surviving comparison sites**, each reclassified with its entry point named: platform handler code reached only through platform-specific entries (relay-action handlers behind their #538 registry decoders, Slack shared-mode predicates, the DM-title binding writer, `isAgentBotMessage`/`botSenderRouting`) — **file-move candidates, not core branches**. The non-branch platform code pending the same file moves (the per-platform reconcile loops) is listed beside them, so nothing is silently blessed.
- **The mandatory §6 blind-spot checklist, swept item by item** with verdicts — the four redundant literals #542 dropped, the manifest homes of the id-syntax items (`startsWith('D')` → `dmChannelPattern`), the per-turn state now in opaque slots, and the S1b/S3 items that are not S2's to clear (named legacy fields ride the emission flip; relay/CP/web are S3).
- **Evals** — `VirtualSlackConnection`/`VirtualDiscordConnection` implement the published Layer-1 `PlatformConnection`; the evaluation/game ingress suites pass unchanged in the 2847-test run.

## Two scraps fixed in passing (found by the sweep)

- `maybeIntroduceOnJoin`'s `const platform = 'slack'` (checklist item 4 — a hardcoded literal with no comparison, invisible to the `===` census) becomes a caller-passed parameter: the caller is Slack's authoritative-snapshot refresh, and it names its platform as **data**.
- One comment still referencing the pre-#535 `tgReplyTo` closure.

## Verification

- `pnpm typecheck` clean; daemon suite **2847 passed**, 46 skipped
- `channel-intro` suite updated for the new parameter and green

🤖 Generated with [Claude Code](https://claude.com/claude-code)