### PR TITLE
feat(relay): emit platform_action, retiring slack_action/feishu_action emission (S1b §6.6 flip)

### DIFF
--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -2,9 +2,8 @@ import { createHmac } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 import type {
   RdAck,
-  RdMsgFeishuAction,
+  RdMsgPlatformAction,
   RdMsgIm,
-  RdMsgSlackAction,
   RcBotChannels,
   RcThreadAssign,
   RcThreadLookupOk,
@@ -155,7 +154,7 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
   })
 
   it('forwards to the exact current agent+integration with a stable redelivery msgId', () => {
-    const sendMsg = vi.fn(async (msg: RdMsgSlackAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
+    const sendMsg = vi.fn(async (msg: RdMsgPlatformAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
     const daemon = { sendMsg } as unknown as RelayDaemonConnection
     const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
@@ -171,7 +170,8 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
     const first = sendMsg.mock.calls[0]![0]
     const second = sendMsg.mock.calls[1]![0]
     expect(first).toEqual({
-      source: 'slack_action',
+      source: 'platform_action',
+      platformId: 'slack',
       agentId: AGENT_ID,
       integrationId: INTEGRATION_ID,
       sessionKey: SESSION_KEY,
@@ -184,7 +184,7 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
   })
 
   it('forwards a message shortcut through the current thread affinity', () => {
-    const sendMsg = vi.fn(async (msg: RdMsgSlackAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
+    const sendMsg = vi.fn(async (msg: RdMsgPlatformAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
     const daemon = { sendMsg } as unknown as RelayDaemonConnection
     const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
@@ -206,7 +206,8 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
 
     expect(internals.forwardSessionShortcut(BOT_ID, shortcut)).toBe(true)
     expect(sendMsg).toHaveBeenCalledWith({
-      source: 'slack_action',
+      source: 'platform_action',
+      platformId: 'slack',
       agentId: AGENT_ID,
       integrationId: INTEGRATION_ID,
       sessionKey: 'C123/T1',
@@ -223,7 +224,7 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
   })
 
   it('forwards the tapping user, and omits it entirely when the interaction named none', () => {
-    const sendMsg = vi.fn(async (msg: RdMsgSlackAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
+    const sendMsg = vi.fn(async (msg: RdMsgPlatformAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
     const daemon = { sendMsg } as unknown as RelayDaemonConnection
     const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
@@ -288,10 +289,11 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
 describe('RelayIngressManager HTTP Lark / Feishu card actions', () => {
   it('forwards to the rendered integration and returns the daemon callback response', async () => {
     const response = { toast: { type: 'info' as const, content: 'Cancellation requested.' } }
-    const sendMsg = vi.fn(async (msg: RdMsgFeishuAction): Promise<RdAck> => ({
+    const sendMsg = vi.fn(async (msg: RdMsgPlatformAction): Promise<RdAck> => ({
       msgId: msg.msgId,
       accepted: true,
-      feishuCardAction: response
+      // A fleet daemon answers a platform_action with the generic opaque slot.
+      response
     }))
     const daemon = { sendMsg } as unknown as RelayDaemonConnection
     const manager = new RelayIngressManager(
@@ -338,7 +340,8 @@ describe('RelayIngressManager HTTP Lark / Feishu card actions', () => {
 
     await expect(internals.forwardFeishuAction(BOT_ID, action, 'evt-action')).resolves.toEqual(response)
     expect(sendMsg).toHaveBeenCalledWith({
-      source: 'feishu_action',
+      source: 'platform_action',
+      platformId: 'feishu',
       agentId: AGENT_ID,
       integrationId: INTEGRATION_ID,
       sessionKey: 'feishu-action:om_card',
@@ -346,6 +349,37 @@ describe('RelayIngressManager HTTP Lark / Feishu card actions', () => {
       botId: BOT_ID,
       payload: action
     })
+  })
+
+  it('still reads the deprecated Feishu-named ack slot from a pre-flip daemon', async () => {
+    // Tolerance window: a daemon that has not yet learned to fill `response`
+    // answers through the deprecated slot; the callback must still reach Feishu.
+    const response = { toast: { type: 'info' as const, content: 'Cancellation requested.' } }
+    const sendMsg = vi.fn(async (msg: RdMsgPlatformAction): Promise<RdAck> => ({
+      msgId: msg.msgId,
+      accepted: true,
+      feishuCardAction: response
+    }))
+    const daemon = { sendMsg } as unknown as RelayDaemonConnection
+    const manager = new RelayIngressManager(
+      deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
+    )
+    const internals = manager as unknown as ManagerInternals
+    internals.router.upsert({
+      botId: BOT_ID,
+      platform: 'feishu',
+      secrets: { verificationToken: 'verify-token' },
+      apiAppId: 'cli_http_app',
+      members: [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID] }],
+      agents: [{ agentId: AGENT_ID, name: 'Agent', daemonId: DAEMON_ID, integrationId: INTEGRATION_ID }],
+      routes: []
+    })
+    const action: WireFeishuCardActionEvent = {
+      context: { open_message_id: 'om_card', open_chat_id: 'oc_chat' },
+      operator: { open_id: 'ou_human' },
+      action: { tag: 'overflow', option: 'cancel' }
+    }
+    await expect(internals.forwardFeishuAction(BOT_ID, action, 'evt-action')).resolves.toEqual(response)
   })
 })
 

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -19,8 +19,7 @@ import { createHash } from 'node:crypto'
 import { MAX_AGENT_CALL_HOPS, WireFeishuCardActionResponse, WireFeishuCardActionValue } from '@agentconnect.md/protocol'
 import type {
   RdMsgIm,
-  RdMsgSlackAction,
-  RdMsgFeishuAction,
+  RdMsgPlatformAction,
   RcBotChannels,
   RcBotConversation,
   RcBotRevoked,
@@ -911,8 +910,12 @@ export class RelayIngressManager {
       this.deps.log.warn(`relay-ingress(${botId}): daemon ${route.daemonId} offline — session action dropped`)
       return
     }
-    const rd: RdMsgSlackAction = {
-      source: 'slack_action',
+    // §6.6 emission flip: the relay now speaks the platform_action envelope —
+    // the daemon's per-platform decoder validates the opaque payload against
+    // Slack's own wire schema (gate 2 closed: the fleet reads it since #521).
+    const rd: RdMsgPlatformAction = {
+      source: 'platform_action',
+      platformId: 'slack',
       agentId: route.agentId,
       integrationId: route.integrationId,
       sessionKey: target.sessionKey,
@@ -957,8 +960,9 @@ export class RelayIngressManager {
     const messageId = action.context?.open_message_id ?? action.open_message_id
     if (!messageId) return undefined
     const msgId = httpFeishuActionMsgId(botId, eventId, action)
-    const rd: RdMsgFeishuAction = {
-      source: 'feishu_action',
+    const rd: RdMsgPlatformAction = {
+      source: 'platform_action',
+      platformId: 'feishu',
       agentId: route.agentId,
       integrationId: route.integrationId,
       sessionKey: `feishu-action:${messageId}`,
@@ -971,8 +975,9 @@ export class RelayIngressManager {
       if (!ack.accepted) {
         this.deps.log.warn(`relay-ingress(${botId}): daemon rejected Feishu card action (${ack.reason ?? 'unknown'})`)
       }
-      // §6.6 dual-shape: prefer the generic opaque `response`; a pre-§6.6 daemon
-      // fills only the deprecated Feishu-named slot.
+      // §6.6: a fleet daemon answers a platform_action with the generic opaque
+      // `response`; the Feishu-named slot is read as a tolerance fallback until
+      // the deprecated rd/ack member retires with the legacy readers.
       const generic = WireFeishuCardActionResponse.safeParse(ack.response)
       return generic.success && ack.response !== undefined ? generic.data : ack.feishuCardAction
     } catch (err) {
@@ -1010,8 +1015,9 @@ export class RelayIngressManager {
     if (!route) return false
     const daemon = this.deps.getDaemon(route.daemonId)
     if (!daemon) return false
-    const rd: RdMsgSlackAction = {
-      source: 'slack_action',
+    const rd: RdMsgPlatformAction = {
+      source: 'platform_action',
+      platformId: 'slack',
       agentId: route.agentId,
       integrationId: route.integrationId,
       sessionKey,


### PR DESCRIPTION
First of the two S1b emission flips, unblocked by the prod promote (gate 2): the fleet has read the `platform_action` envelope since #521.

## What flips

All three relay interaction forwards now carry `source: 'platform_action'` + `platformId` + the same opaque payload the daemon's per-platform decoder already validates against the platform's own wire schema (#538):

| forward | platformId |
| --- | --- |
| HTTP Slack status-modal action | `slack` |
| Slack message shortcut (`open-config-for-thread`) | `slack` |
| Lark/Feishu card callback | `feishu` |

Adding a platform's interactions no longer adds an `rd/msg` union member.

## What deliberately stays

- **Dedup identity is unchanged**: msgId scope remains `(botId, sessionKey, msgId)`, identical to the legacy members — retransmits replay the prior ack, fencing unaffected (the §6.6 design note).
- **The Feishu ack keeps its dual-read one more cycle**: a fleet daemon answers with the generic opaque `response`; the deprecated Feishu-named slot is read as a tolerance fallback. The legacy **readers** (the daemon's `slack_action`/`feishu_action` rd/msg members and the `feishuCardAction` ack slot) retire together, one release after nothing emits them.

## Verification

- relay suite: **398 passed** — the three forwards pinned on the new envelope, dedup assertions unchanged, plus a new pre-flip-daemon tolerance case for the Feishu-named ack slot
- `eslint`/`prettier` clean; relay typecheck clean (note: requires fresh `protocol`/`message` dists — stale dists from the #503 merge fail unrelatedly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)