### PR TITLE
feat: stop emitting the S1b legacy wire shapes (§6.4/§6.5/§6.6 flip)

### DIFF
--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -367,7 +367,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
 
     // send-only spec pushed to BOTH member daemons.
     expect(upserts.map((u) => u.daemonId).sort()).toEqual([D1, D2].sort())
-    for (const u of upserts) expect(u.spec.slack?.mode).toBe('shared')
+    for (const u of upserts) expect(u.spec.core?.mode).toBe('shared')
     // signing secret rides to the relay (to HMAC-verify inbound Events API POSTs), NOT the daemons.
     if (!('signingSecret' in assign.secrets)) throw new Error('expected Slack credentials')
     expect(assign.secrets.signingSecret).toBe('shh-x')
@@ -389,7 +389,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     botRow = bot({ slackAppId: 'A123' })
     await makeOrch().syncBot(BOT)
     expect(upserts).toHaveLength(2)
-    expect(upserts.every((upsert) => upsert.spec.slack?.appId === 'A123')).toBe(true)
+    expect(upserts.every((upsert) => (upsert.spec.config as { appId?: string })?.appId === 'A123')).toBe(true)
   })
 
   it('keeps Feishu API credentials on the daemon and sends only callback credentials to the relay', async () => {
@@ -436,7 +436,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         daemonId: D1,
         spec: expect.objectContaining({
           platform: 'feishu',
-          feishu: expect.objectContaining({
+          config: expect.objectContaining({
             mode: 'shared',
             appId: 'cli_http_app',
             appSecret: 'app-secret',
@@ -537,16 +537,17 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         channel({ integrationId: INT_A, channelId: 'C0', agentId: ALICE, trigger: 'off' })
       ]
       await makeOrch().syncBot(BOT)
+      // §6.4 emission flip: the spec carries the envelope only — knobs ride `core`.
       const alice = upserts.find((u) => u.daemonId === D1)!.spec as never as {
-        slack: { gated: boolean; bindRules: unknown[] }
+        core: { gated: boolean; bindRules: unknown[] }
       }
-      expect(alice.slack.gated).toBe(true)
-      expect(alice.slack.bindRules).toEqual([{ channel: 'C9', match: { kind: 'mention' } }])
+      expect(alice.core.gated).toBe(true)
+      expect(alice.core.bindRules).toEqual([{ channel: 'C9', match: { kind: 'mention' } }])
       const bob = upserts.find((u) => u.daemonId === D2)!.spec as never as {
-        slack: { gated: boolean; bindRules: unknown[] }
+        core: { gated: boolean; bindRules: unknown[] }
       }
-      expect(bob.slack.gated).toBe(false)
-      expect(bob.slack.bindRules).toEqual([])
+      expect(bob.core.gated).toBe(false)
+      expect(bob.core.bindRules).toEqual([])
     })
 
     it("replaceChannels makes a gated default owner's fresh channel Off on every membership row", async () => {

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -10,6 +10,19 @@ import { integrationToSpec } from './placement.js'
 import { agentRecordToSpec } from './agentSpecAssembler.js'
 import type { AgentRecord, IntegrationChannelRecord, IntegrationRecord } from '../persistence/ports.js'
 import { AgentId, IntegrationId, OrgId } from '../domain/ids.js'
+import {
+  IntegrationSlackConfig,
+  IntegrationTelegramConfig,
+  IntegrationDiscordConfig,
+  IntegrationFeishuConfig
+} from '@agentconnect.md/protocol'
+
+// §6.4 emission flip: the spec carries envelope (`core`) + opaque `config` only.
+// Tests validate the payload through the SAME wire schema the daemon reader uses.
+const slackCfg = (spec: { config?: unknown }) => IntegrationSlackConfig.parse(spec.config)
+const telegramCfg = (spec: { config?: unknown }) => IntegrationTelegramConfig.parse(spec.config)
+const discordCfg = (spec: { config?: unknown }) => IntegrationDiscordConfig.parse(spec.config)
+const feishuCfg = (spec: { config?: unknown }) => IntegrationFeishuConfig.parse(spec.config)
 
 const INTEGRATION: IntegrationRecord = {
   id: IntegrationId('66666666-6666-4666-8666-666666666666'),
@@ -39,8 +52,8 @@ const channel = (
 describe('integrationToSpec bindRules', () => {
   it('defaults to mention + dm with no channels', () => {
     const spec = integrationToSpec(INTEGRATION, SECRET)
-    expect(spec.slack.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
-    expect(spec.slack.botToken).toBe(SECRET.botToken)
+    expect(slackCfg(spec).bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
+    expect(slackCfg(spec).botToken).toBe(SECRET.botToken)
   })
 
   it("adds one channel-scoped 'auto' rule per 'any message' channel; 'mention' channels add none", () => {
@@ -49,7 +62,7 @@ describe('integrationToSpec bindRules', () => {
       channel('C2', 'any'),
       channel('C3', 'any')
     ])
-    expect(spec.slack.bindRules).toEqual([
+    expect(slackCfg(spec).bindRules).toEqual([
       { match: { kind: 'mention' } },
       { match: { kind: 'dm' } },
       { channel: 'C2', match: { kind: 'auto' } },
@@ -66,7 +79,7 @@ describe('integrationToSpec bindRules', () => {
       channel('D1', 'any', 'im'),
       channel('G1', 'any', 'mpim')
     ])
-    expect(spec.slack.bindRules).toEqual([
+    expect(slackCfg(spec).bindRules).toEqual([
       { match: { kind: 'mention' } },
       { match: { kind: 'dm' } },
       { channel: 'C1', match: { kind: 'auto' } }
@@ -78,9 +91,9 @@ describe('integrationToSpec bindRules', () => {
       channel('-100', 'any')
     ])
     if (spec.platform !== 'telegram') throw new Error('expected telegram spec')
-    expect(spec.telegram.botToken).toBe('123:abc')
+    expect(telegramCfg(spec).botToken).toBe('123:abc')
     expect(spec).not.toHaveProperty('slack')
-    expect(spec.telegram.bindRules).toEqual([
+    expect(telegramCfg(spec).bindRules).toEqual([
       { match: { kind: 'mention' } },
       { match: { kind: 'dm' } },
       { channel: '-100', match: { kind: 'auto' } }
@@ -97,8 +110,8 @@ describe('integrationToSpec conversation gating (§14)', () => {
       true
     )
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
-    expect(spec.slack.gated).toBe(true)
-    expect(spec.slack.bindRules).toEqual([
+    expect(slackCfg(spec).gated).toBe(true)
+    expect(slackCfg(spec).bindRules).toEqual([
       { channel: 'C1', match: { kind: 'mention' } },
       { channel: 'C2', match: { kind: 'auto' } },
       { channel: 'D1', match: { kind: 'dm' } }
@@ -108,19 +121,19 @@ describe('integrationToSpec conversation gating (§14)', () => {
   it('gated with no enabled conversations ships an EMPTY rule set (fail-closed)', () => {
     const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'off'), channel('D1', 'off', 'im')], true)
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
-    expect(spec.slack.bindRules).toEqual([])
-    expect(spec.slack.gated).toBe(true)
+    expect(slackCfg(spec).bindRules).toEqual([])
+    expect(slackCfg(spec).gated).toBe(true)
   })
 
   it("non-gated: an 'off' channel keeps the defaults but is muted; gated is false", () => {
     const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'off'), channel('D1', 'any', 'im')])
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
-    expect(spec.slack.gated).toBe(false)
+    expect(slackCfg(spec).gated).toBe(false)
     // The defaults are unscoped, so Off cannot be expressed by withholding a rule —
     // the fence is what silences C1. The im row adds no auto rule either; DMs are
     // covered by the unscoped dm default.
-    expect(spec.slack.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
-    expect(spec.slack.mutedChannels).toEqual(['C1'])
+    expect(slackCfg(spec).bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
+    expect(slackCfg(spec).mutedChannels).toEqual(['C1'])
   })
 })
 
@@ -133,7 +146,7 @@ describe('integrationToSpec mutedChannels', () => {
       channel('C4', 'off')
     ])
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
-    expect(spec.slack.mutedChannels).toEqual(['C1', 'C4'])
+    expect(spec.core?.mutedChannels).toEqual(['C1', 'C4'])
   })
 
   // §14.4: the console hides a preserved direct row once its owner is org-visible, so
@@ -141,7 +154,7 @@ describe('integrationToSpec mutedChannels', () => {
   it('never mutes a direct row on a non-gated integration', () => {
     const spec = integrationToSpec(INTEGRATION, SECRET, [channel('D1', 'off', 'im'), channel('G1', 'off', 'mpim')])
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
-    expect(spec.slack.mutedChannels).toEqual([])
+    expect(spec.core?.mutedChannels).toEqual([])
   })
 
   // A gated integration says Off by having no rule for the conversation; stating it
@@ -149,8 +162,8 @@ describe('integrationToSpec mutedChannels', () => {
   it('stays empty for a gated integration, whose Off is the missing rule', () => {
     const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'off'), channel('C2', 'mention')], true)
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
-    expect(spec.slack.mutedChannels).toEqual([])
-    expect(spec.slack.bindRules).toEqual([{ channel: 'C2', match: { kind: 'mention' } }])
+    expect(spec.core?.mutedChannels).toEqual([])
+    expect(spec.core?.bindRules).toEqual([{ channel: 'C2', match: { kind: 'mention' } }])
   })
 
   it('rides every platform variant', () => {
@@ -158,17 +171,17 @@ describe('integrationToSpec mutedChannels', () => {
       channel('-100', 'off')
     ])
     if (tg.platform !== 'telegram') throw new Error('expected telegram spec')
-    expect(tg.telegram.mutedChannels).toEqual(['-100'])
+    expect(tg.core?.mutedChannels).toEqual(['-100'])
     const dc = integrationToSpec({ ...INTEGRATION, platform: 'discord' }, { botToken: 'bot', appToken: null }, [
       channel('999', 'off')
     ])
     if (dc.platform !== 'discord') throw new Error('expected discord spec')
-    expect(dc.discord.mutedChannels).toEqual(['999'])
+    expect(dc.core?.mutedChannels).toEqual(['999'])
     const fs = integrationToSpec({ ...INTEGRATION, platform: 'feishu' }, { botToken: 'sec', appToken: 'cli_x' }, [
       channel('oc_1', 'off')
     ])
     if (fs.platform !== 'feishu') throw new Error('expected feishu spec')
-    expect(fs.feishu.mutedChannels).toEqual(['oc_1'])
+    expect(fs.core?.mutedChannels).toEqual(['oc_1'])
   })
 })
 

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -244,18 +244,20 @@ export function integrationToSpec(
     .map((c) => ({ channel: c.channelId, match: { kind: 'auto' as const } }))
   const bindRules = gated ? gatedBindRules(channels) : [...DEFAULT_BIND_RULES, ...channelRules]
   const mutedChannels = mutedChannelIds(channels, gated)
-  // §6.4 dual-shape emission: the legacy nested block AND the core+config envelope
-  // carry the same data (readers prefer the envelope's core knobs); legacy emission
-  // drops once the fleet reads the envelope.
+  // §6.4 emission flip (gate 2 closed): the legacy nested block is no longer
+  // emitted — the fleet's dual-shape reader (write-integration.ts) validates the
+  // opaque `config` against the same wire schema and takes the routing knobs
+  // from `core`. The nested members stay OPTIONAL in the wire schema until the
+  // legacy readers retire.
   const core = { mode: 'direct' as const, bindRules, mutedChannels, gated }
   if (i.platform === 'telegram') {
     const telegram = { botToken: secret.botToken, bindRules, mutedChannels, gated }
-    return { integrationId: i.id, agentId: i.agentId, platform: 'telegram', telegram, core, config: telegram }
+    return { integrationId: i.id, agentId: i.agentId, platform: 'telegram', core, config: telegram }
   }
   if (i.platform === 'discord') {
     // Discord authenticates the Gateway with the single bot token (no appToken).
     const discord = { botToken: secret.botToken, bindRules, mutedChannels, gated }
-    return { integrationId: i.id, agentId: i.agentId, platform: 'discord', discord, core, config: discord }
+    return { integrationId: i.id, agentId: i.agentId, platform: 'discord', core, config: discord }
   }
   if (i.platform === 'feishu') {
     // Feishu authenticates the WSClient with an appId + appSecret pair, stored in the
@@ -270,7 +272,7 @@ export function integrationToSpec(
       mutedChannels,
       gated
     }
-    return { integrationId: i.id, agentId: i.agentId, platform: 'feishu', feishu, core, config: feishu }
+    return { integrationId: i.id, agentId: i.agentId, platform: 'feishu', core, config: feishu }
   }
   // 'direct' (transport==='socket') — this daemon owns the Socket Mode connection.
   // The 'shared' wire variant (transport==='http', xoxb-only, no appToken/bindRules)
@@ -286,7 +288,7 @@ export function integrationToSpec(
     mutedChannels,
     gated
   }
-  return { integrationId: i.id, agentId: i.agentId, platform: 'slack', slack, core, config: slack }
+  return { integrationId: i.id, agentId: i.agentId, platform: 'slack', core, config: slack }
 }
 
 /**
@@ -313,7 +315,7 @@ export function httpIntegrationToSpec(
   providerAppId?: string,
   botUserId?: string
 ): IntegrationSpec {
-  // §6.4 dual-shape emission (see integrationToSpec).
+  // §6.4 emission flip (see integrationToSpec): envelope + opaque config only.
   const httpCore = {
     mode: 'shared' as const,
     bindRules: gated ? gatedBindRules(channels) : [],
@@ -331,7 +333,7 @@ export function httpIntegrationToSpec(
       mutedChannels: httpCore.mutedChannels,
       gated
     }
-    return { integrationId: i.id, agentId: i.agentId, platform: 'feishu', feishu, core: httpCore, config: feishu }
+    return { integrationId: i.id, agentId: i.agentId, platform: 'feishu', core: httpCore, config: feishu }
   }
   // `shareable` gates the daemon's in-thread "Switch agent" control: an HTTP bot
   // routes through the relay either way, but only a multi-agent (shareable) bot has
@@ -345,7 +347,7 @@ export function httpIntegrationToSpec(
     mutedChannels: httpCore.mutedChannels,
     gated
   }
-  return { integrationId: i.id, agentId: i.agentId, platform: 'slack', slack, core: httpCore, config: slack }
+  return { integrationId: i.id, agentId: i.agentId, platform: 'slack', core: httpCore, config: slack }
 }
 
 /** A session to re-home: its key + the agent/workspace that should own it. */

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -144,7 +144,7 @@ describe('PUT /agents/:id/daemon', () => {
     expect(control.activations[0]?.agentId).toBe(agentId)
     expect(
       control.activations[0]?.integrations
-        .flatMap((integration) => (integration.platform === 'slack' ? [integration.slack!.mode] : []))
+        .flatMap((integration) => (integration.platform === 'slack' ? [integration.core!.mode] : []))
         .sort()
     ).toEqual(['direct', 'shared'])
     expect(control.activations[0]?.crons.map((cron) => cron.cronId)).toEqual([cronId])

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -218,7 +218,8 @@ describe('Feishu/Lark one-click app registration', () => {
       spec: {
         agentId,
         platform: 'feishu',
-        feishu: { appId: 'cli_oneclick', appSecret: 'one-click-secret', region: 'lark' }
+        // §6.4 emission flip: credentials ride the opaque config envelope.
+        config: { appId: 'cli_oneclick', appSecret: 'one-click-secret', region: 'lark' }
       }
     })
   }, 15_000)
@@ -532,7 +533,7 @@ describe('Feishu/Lark one-click app registration', () => {
     })
     expect(control.upserts[0]?.spec).toMatchObject({
       platform: 'feishu',
-      feishu: { mode: 'shared', botOpenId: 'ou_http_bot' }
+      config: { mode: 'shared', botOpenId: 'ou_http_bot' }
     })
   })
 

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -305,9 +305,9 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(put.statusCode).toBe(200)
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack!.gated).toBe(true)
+    expect(u0.core!.gated).toBe(true)
     // No dm rule for D1: the private agent answers that DM only once enabled.
-    expect(u0.slack!.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
+    expect(u0.core!.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
   })
 
   it('resets the trigger when a row misclassified as a channel converts to a DM (§14.3)', async () => {
@@ -337,7 +337,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     })
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack!.bindRules).toEqual([])
+    expect(u0.core!.bindRules).toEqual([])
   })
 
   it('stores a group DM OFF and keeps a channel→group-DM conversion fail-closed (§14.3)', async () => {
@@ -436,7 +436,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     })
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack!.bindRules).toEqual([])
+    expect(u0.core!.bindRules).toEqual([])
   })
 
   it('enabling conversations on a GATED integration pushes conversation-scoped rules ONLY (§14)', async () => {
@@ -460,8 +460,8 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(res.statusCode).toBe(200)
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack!.gated).toBe(true)
-    expect(u0.slack!.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
+    expect(u0.core!.gated).toBe(true)
+    expect(u0.core!.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
 
     await running.app.inject({
       method: 'PATCH',
@@ -470,8 +470,8 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     })
     const u1 = spy.upserts[1]!.u
     if (u1.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u1.slack!.bindRules).toHaveLength(2)
-    expect(u1.slack!.bindRules).toEqual(
+    expect(u1.core!.bindRules).toHaveLength(2)
+    expect(u1.core!.bindRules).toEqual(
       expect.arrayContaining([
         { channel: 'C1', match: { kind: 'mention' } },
         { channel: 'D1', match: { kind: 'dm' } }
@@ -497,9 +497,9 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(spy.upserts).toHaveLength(1)
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack!.gated).toBe(true)
+    expect(u0.core!.gated).toBe(true)
     // The pre-flip channel row keeps its 'mention' trigger — grandfathered enabled.
-    expect(u0.slack!.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
+    expect(u0.core!.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
 
     const back = await running.app.inject({
       method: 'PUT',
@@ -509,8 +509,8 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(back.statusCode).toBe(200)
     const u1 = spy.upserts[1]!.u
     if (u1.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u1.slack!.gated).toBe(false)
-    expect(u1.slack!.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
+    expect(u1.core!.gated).toBe(false)
+    expect(u1.core!.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
   })
 
   it('a re-report preserves the trigger, refreshes names, and drops left channels', async () => {
@@ -985,7 +985,7 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
     expect(spy.upserts[0]!.daemonId).toBe(DAEMON)
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack!.bindRules).toEqual([
+    expect(u0.core!.bindRules).toEqual([
       { match: { kind: 'mention' } },
       { match: { kind: 'dm' } },
       { channel: 'C2', match: { kind: 'auto' } }
@@ -999,7 +999,7 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
     })
     const u1 = spy.upserts[1]!.u
     if (u1.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u1.slack!.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
+    expect(u1.core!.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
   })
 
   it('404s on an unknown channel or integration', async () => {

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -122,7 +122,8 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       integrationId: dto.id,
       agentId,
       platform: 'slack',
-      slack: { botToken: SLACK.botToken, appToken: SLACK.appToken }
+      // §6.4 emission flip: credentials ride the opaque config envelope.
+      config: { botToken: SLACK.botToken, appToken: SLACK.appToken }
     })
   })
 
@@ -258,7 +259,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       integrationId: dto.id,
       agentId,
       platform: 'telegram',
-      telegram: { botToken: '123456:AAE-xyz' }
+      config: { botToken: '123456:AAE-xyz' }
     })
     // Cosmetic profile updates are attempted after the durable install, but a
     // Telegram failure never rolls back or blocks the functional integration.
@@ -313,7 +314,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       integrationId: dto.id,
       agentId,
       platform: 'discord',
-      discord: { botToken: DISCORD_TOKEN }
+      config: { botToken: DISCORD_TOKEN }
     })
     // Cosmetic profile updates are attempted after the durable install, but a
     // Discord failure never rolls back or blocks the functional integration.
@@ -458,7 +459,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       agentId,
       platform: 'feishu',
       // New installs default to the international Lark gateway when region is omitted.
-      feishu: { appId: FEISHU.appId, appSecret: FEISHU.appSecret, region: 'lark' }
+      config: { appId: FEISHU.appId, appSecret: FEISHU.appSecret, region: 'lark' }
     })
     expect(dto.region).toBe('lark')
   })
@@ -576,7 +577,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect(spy.upserts).toHaveLength(1)
     const upsert = spy.upserts[0]!.u
     if (upsert.platform !== 'feishu') throw new Error('expected Feishu upsert')
-    expect(upsert.feishu).toMatchObject({
+    expect(upsert.config).toMatchObject({
       mode: 'shared',
       appId: 'cli_http_app',
       appSecret: 'app-secret',
@@ -610,7 +611,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     // The daemon's spec carries region 'feishu' so its SDK dials open.feishu.cn.
     const u = spy.upserts[0]!.u
     if (u.platform !== 'feishu') throw new Error('expected feishu upsert')
-    expect(u.feishu).toMatchObject({ appId: FEISHU.appId, region: 'feishu' })
+    expect(u.config).toMatchObject({ appId: FEISHU.appId, region: 'feishu' })
 
     // Persisted on the integration row so a reconnect reconstructs the same region.
     const row = await prisma.integration.findUnique({ where: { id: dto.id as string } })
@@ -898,7 +899,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect(await prisma.bot.count()).toBe(1) // reused, not re-created
     // The daemon still gets the tokens (from the bot's stored secret).
     expect(spy.upserts).toHaveLength(2)
-    expect(spy.upserts[1]!.u).toMatchObject({ slack: { botToken: SLACK.botToken, appToken: SLACK.appToken } })
+    expect(spy.upserts[1]!.u).toMatchObject({ config: { botToken: SLACK.botToken, appToken: SLACK.appToken } })
   })
 
   it("reinstalling a freed Lark bot by botId preserves region 'lark' (retained creds keep their gateway)", async () => {
@@ -936,7 +937,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     // The daemon's spec dials the Lark gateway for the reinstalled bot.
     const u = spy.upserts[1]!.u
     if (u.platform !== 'feishu') throw new Error('expected feishu upsert')
-    expect(u.feishu!.region).toBe('lark')
+    expect((u.config as { region?: string }).region).toBe('lark')
   })
 
   it('reusing a bot that is STILL installed is refused with 409', async () => {

--- a/packages/control-plane/test/integration/slack-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-install.route.test.ts
@@ -365,7 +365,7 @@ describe('slack auto-install funnel', () => {
     expect(bot?.slackAppId).toBe('A1TEST')
     expect(await prisma.slackInstall.findUnique({ where: { id: installId } })).toBeNull()
     expect(spy.upserts).toHaveLength(1)
-    expect(spy.upserts[0]!.u).toMatchObject({ slack: { botToken: 'xoxb-from-oauth' } })
+    expect(spy.upserts[0]!.u).toMatchObject({ config: { botToken: 'xoxb-from-oauth' } })
     expect(JSON.stringify(dto)).not.toContain('xoxb-')
   })
 

--- a/packages/control-plane/test/protocol/register.handler.test.ts
+++ b/packages/control-plane/test/protocol/register.handler.test.ts
@@ -438,7 +438,7 @@ describe('register handler — authoritative reconcile snapshot + idempotency + 
       integrationId: INTEG,
       agentId: AGENT,
       platform: 'telegram',
-      telegram: { botToken: '123456:AAE-xyz' }
+      config: { botToken: '123456:AAE-xyz' }
     })
     // A non-empty collaboration snapshot used to make this entire register/ok
     // invalid because DEFAULT_ORG_ID is intentionally not a UUID. The in-memory

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6978,7 +6978,7 @@ export class Daemon {
       (msg) => {
         const payload = WireFeishuCardActionEvent.safeParse(msg.payload)
         if (!payload.success) return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
-        const ack = this.handleRelayFeishuAction({
+        const { feishuCardAction, ...ack } = this.handleRelayFeishuAction({
           source: 'feishu_action',
           agentId: msg.agentId,
           sessionKey: msg.sessionKey,
@@ -6987,7 +6987,11 @@ export class Daemon {
           integrationId: msg.integrationId,
           payload: payload.data
         })
-        return ack.feishuCardAction !== undefined ? { ...ack, response: ack.feishuCardAction } : ack
+        // §6.6 emission flip: a platform_action is answered through the generic
+        // opaque `response` only. The deprecated Feishu-named slot still rides
+        // acks of the legacy feishu_action member (the handler above), and both
+        // retire together with the legacy readers.
+        return feishuCardAction !== undefined ? { ...ack, response: feishuCardAction } : ack
       }
     ]
   ])

--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -263,7 +263,7 @@ export class TelegramConnection implements PlatformConnection {
       const msg = normalizeTelegramMessage(message, { traceId: this.deps.newTraceId() })
       log?.debug(
         `telegram: inbound ch=${msg.channel} user=${msg.sender.id} isBot=${msg.sender.isBot} isDm=${msg.isDm} ` +
-          `topic=${msg.telegramTopicId ?? '-'} root=${msg.telegramThreadRoot ?? '-'} replyTo=${msg.replyTo ?? '-'} ` +
+          `topic=${msg.topicId ?? '-'} root=${msg.threadRoot ?? '-'} replyTo=${msg.replyTo ?? '-'} ` +
           `quoted=${msg.quoted ? `${msg.quoted.text.length}c${msg.quoted.excerpt ? ' excerpt' : ''}` : '-'} ` +
           `mentions=[${msg.mentionedBots.join(',')}] text=${JSON.stringify(msg.text.slice(0, 80))}`
       )

--- a/packages/daemon/test/discord-normalize.test.ts
+++ b/packages/daemon/test/discord-normalize.test.ts
@@ -41,7 +41,9 @@ describe('normalizeDiscordMessage', () => {
     })
     // Discord: channel == conversation == session; top-level msg flagged for threading.
     expect(m.thread).toBe('C777')
-    expect(m.discordTopLevel).toBe(true)
+    // §6.5 emission flip: the generic coordinate only — discordTopLevel retired.
+    expect(m.promoteToThread).toBe(true)
+    expect(m.discordTopLevel).toBeUndefined()
     expect(m.attachments).toBeUndefined()
   })
 
@@ -49,13 +51,13 @@ describe('normalizeDiscordMessage', () => {
     const m = normalizeDiscordMessage({ ...base, channelId: 'T555', isThread: true }, { traceId: 't' })
     expect(m.channel).toBe('T555')
     expect(m.thread).toBe('T555')
-    expect(m.discordTopLevel).toBeUndefined()
+    expect(m.promoteToThread).toBeUndefined()
   })
 
   it('flags a non-guild message as a DM and does not auto-thread it', () => {
     const m = normalizeDiscordMessage({ ...base, inGuild: false }, { traceId: 't' })
     expect(m.isDm).toBe(true)
-    expect(m.discordTopLevel).toBeUndefined()
+    expect(m.promoteToThread).toBeUndefined()
   })
 
   it('carries attachments (public CDN url, no auth) when present', () => {

--- a/packages/daemon/test/telegram-normalize.test.ts
+++ b/packages/daemon/test/telegram-normalize.test.ts
@@ -42,7 +42,7 @@ describe('normalizeTelegramMessage', () => {
     expect(n.sender).toEqual({ id: '7', isBot: true })
   })
 
-  it('carries a forum-topic message_thread_id in telegramTopicId (thread left to the daemon)', () => {
+  it('carries a forum-topic message_thread_id in the generic topicId (thread left to the daemon)', () => {
     const n = normalizeTelegramMessage(
       msg({ message_thread_id: 555, is_topic_message: true, reply_to_message: { message_id: 999 } }),
       ctx
@@ -50,26 +50,29 @@ describe('normalizeTelegramMessage', () => {
     // normalize no longer owns Telegram threading — it surfaces the topic id + reply
     // target and leaves `thread` for the daemon's canonicalizeTelegramThread.
     expect(n.thread).toBeUndefined()
-    expect(n.telegramTopicId).toBe('555')
-    expect(n.telegramThreadRoot).toBeUndefined()
+    // §6.5 emission flip: generic coordinates only — the Telegram-named twins retired.
+    expect(n.topicId).toBe('555')
+    expect(n.telegramTopicId).toBeUndefined()
+    expect(n.threadRoot).toBeUndefined()
     expect(n.replyTo).toBe('999')
   })
 
-  it('carries a plain-supergroup message_thread_id as telegramThreadRoot (NOT a topic)', () => {
+  it('carries a plain-supergroup message_thread_id as the generic threadRoot (NOT a topic)', () => {
     // A reply in a non-forum supergroup: message_thread_id is the reply-thread ROOT, not
     // a forum topic — so it must not post back as message_thread_id.
     const n = normalizeTelegramMessage(msg({ message_thread_id: 6, reply_to_message: { message_id: 7 } }), ctx)
     expect(n.thread).toBeUndefined()
-    expect(n.telegramTopicId).toBeUndefined()
-    expect(n.telegramThreadRoot).toBe('6')
+    expect(n.topicId).toBeUndefined()
+    expect(n.threadRoot).toBe('6')
+    expect(n.telegramThreadRoot).toBeUndefined()
     expect(n.replyTo).toBe('7')
   })
 
   it('carries reply_to_message id in replyTo (no thread root) for a basic-group reply', () => {
     const n = normalizeTelegramMessage(msg({ reply_to_message: { message_id: 999 } }), ctx)
     expect(n.thread).toBeUndefined()
-    expect(n.telegramTopicId).toBeUndefined()
-    expect(n.telegramThreadRoot).toBeUndefined()
+    expect(n.topicId).toBeUndefined()
+    expect(n.threadRoot).toBeUndefined()
     expect(n.replyTo).toBe('999')
   })
 

--- a/packages/message/src/discord-message.ts
+++ b/packages/message/src/discord-message.ts
@@ -99,6 +99,7 @@ export function normalizeDiscordMessage(
     isDm,
     ...(message.isThread && message.parentChannelId ? { parentChannel: message.parentChannelId } : {}),
     // §6.5 dual-shape: the generic promote flag alongside the deprecated named one.
-    ...(!isDm && !message.isThread ? { discordTopLevel: true, promoteToThread: true } : {})
+    // §6.5 emission flip: the generic coordinate only — `discordTopLevel` retired.
+    ...(!isDm && !message.isThread ? { promoteToThread: true } : {})
   }
 }

--- a/packages/message/src/telegram-message.ts
+++ b/packages/message/src/telegram-message.ts
@@ -194,8 +194,9 @@ export function normalizeTelegramMessage(
     platform: 'telegram',
     channel: String(message.chat.id),
     // §6.5 dual-shape: generic coordinates alongside the deprecated named fields.
-    ...(isForumTopic && threadId !== undefined ? { telegramTopicId: threadId, topicId: threadId } : {}),
-    ...(!isForumTopic && threadId !== undefined ? { telegramThreadRoot: threadId, threadRoot: threadId } : {}),
+    // §6.5 emission flip: generic coordinates only — the Telegram-named twins retired.
+    ...(isForumTopic && threadId !== undefined ? { topicId: threadId } : {}),
+    ...(!isForumTopic && threadId !== undefined ? { threadRoot: threadId } : {}),
     ...(replyTo !== undefined ? { replyTo } : {}),
     ...(quoted !== undefined ? { quoted } : {}),
     sender: {

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -173,13 +173,15 @@ export type IntegrationCoreEnvelope = z.infer<typeof IntegrationCoreEnvelope>
  * long-poll, a Discord Gateway, or a Feishu long-connection from whichever variant
  * is delivered.
  *
- * DUAL-SHAPE (§6.4): each variant carries the legacy nested block (`slack` /
- * `telegram` / `discord` / `feishu`) AND the `core` + `config` envelope. Readers
- * prefer the legacy block while it is emitted and fall back to `config` (validated
- * against the same per-platform schema); `core` overrides the routing knobs wherever
- * present. A variant carrying NEITHER payload is rejected by the reader, not the
- * schema (tolerant-reader rule). The union itself opens to a flat `platformId`
- * object when legacy emission drops.
+ * DUAL-SHAPE (§6.4) — EMISSION FLIPPED: the CP now emits the `core` + `config`
+ * envelope only; the legacy nested block (`slack` / `telegram` / `discord` /
+ * `feishu`) stays OPTIONAL here so readers keep accepting frames from an older
+ * CP until the legacy readers retire. Readers prefer the legacy block when one
+ * rides and fall back to `config` (validated against the same per-platform
+ * schema); `core` overrides the routing knobs wherever present. A variant
+ * carrying NEITHER payload is rejected by the reader, not the schema
+ * (tolerant-reader rule). The union itself opens to a flat `platformId` object
+ * when the legacy members retire.
  */
 export const IntegrationSpec = z.discriminatedUnion('platform', [
   z.object({

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -328,4 +328,62 @@ describe('toBotAssignment (§6.7 open secrets reader)', () => {
     expect(toBotAssignment({ ...base, secrets: { apiKey: 'k-1' } } as never)).toBeNull()
     expect(toBotAssignment({ ...base, secrets: { botToken: 'xoxb-only' } } as never)).toBeNull()
   })
+
+  // §6.7 demux identity is dual-shape: prefer the opaque ingress bag, fall back
+  // to the named top-level fields. Wrong apiAppId/teamId misroutes inbound
+  // webhook demux, so each arm is pinned.
+  const secrets = { botToken: 'xoxb-x', signingSecret: 'sig' }
+
+  it('reads demux identity from the ingress bag alone (post-flip CP)', () => {
+    const a = toBotAssignment({
+      ...base,
+      secrets,
+      ingress: { apiAppId: 'A9', teamId: 'T9', botUserId: 'U9' }
+    } as never)
+    expect(a).toMatchObject({ apiAppId: 'A9', teamId: 'T9', botUserId: 'U9' })
+  })
+
+  it('falls back to the named top-level fields when no bag rides (pre-flip CP)', () => {
+    const a = toBotAssignment({
+      ...base,
+      secrets,
+      apiAppId: 'A1',
+      teamId: 'T1',
+      botUserId: 'U1'
+    } as never)
+    expect(a).toMatchObject({ apiAppId: 'A1', teamId: 'T1', botUserId: 'U1' })
+  })
+
+  it('prefers the bag over the named fields when both ride (dual-emission window)', () => {
+    const a = toBotAssignment({
+      ...base,
+      secrets,
+      ingress: { apiAppId: 'A-bag', teamId: 'T-bag', botUserId: 'U-bag' },
+      apiAppId: 'A-named',
+      teamId: 'T-named',
+      botUserId: 'U-named'
+    } as never)
+    expect(a).toMatchObject({ apiAppId: 'A-bag', teamId: 'T-bag', botUserId: 'U-bag' })
+  })
+
+  it('ignores non-string bag values per key, falling back to the named field', () => {
+    // The bag is z.unknown() on the wire — a malformed value must not poison the
+    // identity when a valid named fallback rides beside it.
+    const a = toBotAssignment({
+      ...base,
+      secrets,
+      ingress: { apiAppId: 42, teamId: null, botUserId: 'U-bag' },
+      apiAppId: 'A-named',
+      teamId: 'T-named',
+      botUserId: 'U-named'
+    } as never)
+    expect(a).toMatchObject({ apiAppId: 'A-named', teamId: 'T-named', botUserId: 'U-bag' })
+  })
+
+  it('omits absent identity fields rather than inventing them', () => {
+    const a = toBotAssignment({ ...base, secrets } as never)
+    expect(a && 'apiAppId' in a).toBe(false)
+    expect(a && 'teamId' in a).toBe(false)
+    expect(a && 'botUserId' in a).toBe(false)
+  })
 })

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -514,14 +514,22 @@ export function toBotAssignment(a: RcBotAssign): BotAssignment | null {
           }
         : null
   if (!secrets) return null
+  // §6.7 dual-shape READER for the demux identity: prefer the opaque ingress
+  // bag, fall back to the named top-level fields. This reader lands one release
+  // BEFORE the CP stops emitting the named fields (reader-first, the S1a rule) —
+  // a bag-less assign from an older CP keeps working through the fallback.
+  const ingress = (a.ingress ?? {}) as { apiAppId?: unknown; teamId?: unknown; botUserId?: unknown }
+  const apiAppId = typeof ingress.apiAppId === 'string' ? ingress.apiAppId : a.apiAppId
+  const teamId = typeof ingress.teamId === 'string' ? ingress.teamId : a.teamId
+  const botUserId = typeof ingress.botUserId === 'string' ? ingress.botUserId : a.botUserId
   return {
     botId: a.botId,
     platform: a.platform,
     secrets,
-    ...(a.apiAppId ? { apiAppId: a.apiAppId } : {}),
-    ...(a.teamId ? { teamId: a.teamId } : {}),
+    ...(apiAppId ? { apiAppId } : {}),
+    ...(teamId ? { teamId } : {}),
     ...(a.credentialRevision !== undefined ? { credentialRevision: a.credentialRevision } : {}),
-    ...(a.botUserId ? { botUserId: a.botUserId } : {}),
+    ...(botUserId ? { botUserId } : {}),
     members: a.members,
     agents: mapAgentDirectory(a.agents),
     routes: a.routes,


### PR DESCRIPTION
Second S1b emission flip, unblocked by the prod promote (gate 2). **Three of the four legacy shapes stop here; the fourth gets its missing reader first.**

## What stops

| shape | emitter flipped | reader relied on |
| --- | --- | --- |
| `IntegrationSpec` nested blocks (§6.4) | CP `integrationToSpec` / `httpIntegrationToSpec` → envelope (`core`) + opaque `config` only | the fleet's dual-shape reader ([write-integration.ts](packages/daemon/src/agents/write-integration.ts)) validates `config` against the same wire schema; every other daemon consumer routes through it |
| named coordinate fields (§6.5) | message normalizers → generic `topicId` / `threadRoot` / `promoteToThread` only; `telegramTopicId` / `telegramThreadRoot` / `discordTopLevel` retired | every reader was already a daemon-side dual-read (generic first) — verified by sweep; one debug log line switched to the generic fields |
| `feishuCardAction` ack slot (§6.6) | a `platform_action` is answered through the generic opaque `response` only | the relay has read `response` first since #521 (and keeps the named-slot fallback for pre-flip daemons, #544) |

The retired members stay **optional** in the wire schemas until the legacy *readers* retire (one release after nothing emits them).

## What deliberately does NOT stop — named demux fields (§6.7), reader first

The audit of this flip found a real gap: the relay's `toBotAssignment` **never learned to read the opaque `ingress` bag** — #518 landed the CP dual-*emission* only. Stopping the named `apiAppId` / `teamId` / `botUserId` now would strand an old relay mid-rolling-deploy with no demux identity.

So this PR lands the bag-preferring **reader** (named fields as the fallback), and the CP stops emitting the named fields **one release later** — the same reader-first discipline S1a established. That final one-liner is the last dual-shape residue of S1b.

## Verification

- CP unit: **1022 passed** (spec-shape tests now read the envelope, validating `config` through the *same wire schemas the daemon reader uses*)
- daemon: full suite green except `test/daemon-agent-mention-routing.test.ts` (#503), which **times out under full-suite parallel load on clean `main` too** — pre-existing flake, unrelated; passes standalone in 22s
- message: 26 passed (normalize pins moved to the generic coordinates); relay: 397 passed
- full monorepo `pnpm typecheck` clean (note: needs fresh `protocol`/`message` dists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)