### PR TITLE
feat(web): move the session rail to the right edge and make it responsive

### DIFF
--- a/packages/web/STYLE.md
+++ b/packages/web/STYLE.md
@@ -58,7 +58,10 @@ whiteSpace:nowrap` → `truncate`.
    `sm:`–`2xl:` variants are **disabled** in `@theme` — the app's mobile
    boundary is `max-width: 768px` (see `useIsMobile`), and stock `md:` would
    disagree at exactly 768px. Inside an `if (isMobile)` fork you normally need
-   no variant at all.
+   no variant at all. The one exception is `wide:` (≥1240px, `@theme` in
+   `globals.css`) — the session detail page's nav·body·rail three-column
+   threshold; below it the rail collapses to a floating button. It is scoped
+   to that one layout, not a second general breakpoint.
 
 8. **What stays as inline `style`**: values computed from data — status colors
    from a map, `orgColor(id)`, progress-bar `width: pct%`, grid templates held

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -16,6 +16,10 @@
 @theme {
   --breakpoint-*: initial;
   --breakpoint-desktop: 769px;
+  /* `wide:` — the session detail page's three-column threshold (nav · body ·
+     session rail). Below it the rail collapses to a floating button; it is NOT
+     a general layout breakpoint — everything else keeps the single 769px one. */
+  --breakpoint-wide: 1240px;
   --leading-normal: normal;
   --default-transition-duration: var(--duration-fast);
   --default-transition-timing-function: var(--ease-standard);

--- a/packages/web/src/components/console/SessionRail.test.tsx
+++ b/packages/web/src/components/console/SessionRail.test.tsx
@@ -3,7 +3,7 @@
 // must never do is change its own width in response to data arriving. Its three
 // inputs — the agent-filtered session page, the session's family, and the reader's
 // filter — settle in any order and at any time, and every combination has to render
-// the same 224px column. These cases are the orderings that used to shift the page:
+// the same 250px column. These cases are the orderings that used to shift the page:
 // a rail that resolves to "no rows worth showing", and a one-row rail that learns
 // about lineage only after its own list has landed.
 
@@ -92,8 +92,8 @@ function railMarkup({
 // The column's width and its breakpoint gate, as they appear in the markup. A
 // change here is a change to the page's geometry, so it should fail loudly rather
 // than quietly move the transcript.
-const COLUMN = 'w-[224px]'
-const DESKTOP_ONLY = 'desktop:block'
+const COLUMN = 'w-[250px]'
+const WIDE_ONLY = 'wide:block'
 
 describe('SessionRail column', () => {
   it('holds its column with nothing to show, so the body does not re-centre', () => {
@@ -102,7 +102,7 @@ describe('SessionRail column', () => {
     const markup = railMarkup({ sessions: [], total: 0 })
 
     expect(markup).toContain(COLUMN)
-    expect(markup).toContain(DESKTOP_ONLY)
+    expect(markup).toContain(WIDE_ONLY)
     expect(markup).not.toContain('All sessions')
   })
 
@@ -140,7 +140,7 @@ describe('SessionRail column', () => {
     const slot = renderToStaticMarkup(<SessionRailSlot />)
 
     expect(slot).toContain(COLUMN)
-    expect(slot).toContain(DESKTOP_ONLY)
+    expect(slot).toContain(WIDE_ONLY)
     expect(railMarkup({ sessions: [session('a'), session('b')], total: 2 })).toContain(COLUMN)
   })
 })

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -1,12 +1,15 @@
-// The session detail page's left rail: the open session's direct family (parent,
-// siblings, and children), globally pinned shortcuts, then the other sessions of
-// the CURRENT agent. Family rows stay in their tree even when pinned and are
-// removed from the ordinary list below, so lineage never appears twice. Rows only
-// appear when there is another session to navigate to, and only on desktop —
-// ≤768px uses the relation card in SessionDetailView plus the Shell app bar's back
-// affordance.
+// The session detail page's RIGHT rail ([nav · body · rail], flush with the page
+// edge): the open session's direct family (parent, siblings, and children),
+// globally pinned shortcuts, then the other sessions of the CURRENT agent. Family
+// rows stay in their tree even when pinned and are removed from the ordinary list
+// below, so lineage never appears twice. Rows only appear when there is another
+// session to navigate to. ≥1240px (`wide:`) draws the inline column; 769–1239px
+// collapses it to a floating top-right button whose hover popover holds the same
+// list; ≤768px moves that trigger INTO the shell's app bar (MobileActionSlot) and
+// taps it open, since touch has no hover and a fixed overlay would cover the
+// session title. The relation card in SessionDetailView still carries lineage.
 //
-// The COLUMN, though, is unconditional above the breakpoint (SessionRailSlot). The
+// The COLUMN, though, is unconditional above `wide` (SessionRailSlot). The
 // detail body is centred in whatever horizontal space the rail leaves it, so any
 // state-dependent column is a layout shift waiting for its trigger: the rail's list
 // is a round-trip behind the session, so an emptiable column collapses on first
@@ -58,6 +61,7 @@ import { useOrgs } from '@/lib/org-context'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 import { AgentIconView, PlatformMark } from '@/components/marks'
+import { useMobileActionSlot } from '@/components/console/Shell'
 import { groupSessionsByAge } from '@/lib/session-age'
 import {
   partitionPinned,
@@ -100,9 +104,14 @@ function pinIdsOf(session: Session): string[] {
  * The rail's footprint with nothing in it — the shape every session detail state
  * holds so the body beside it never moves. Used by the loading branch, which has
  * no rail to draw, and by a rail with no rows worth drawing.
+ *
+ * The column sits on the page's RIGHT edge ([nav · body · rail]): the negative
+ * right margin bleeds over `.content`'s 30px padding so the reserved track plus
+ * that padding equals the fixed 250px panel the real rail pins to the viewport
+ * edge. Keep these box classes identical to the real rail's container below.
  */
 export function SessionRailSlot() {
-  return <div aria-hidden="true" className="hidden w-[224px] flex-none desktop:block" />
+  return <div aria-hidden="true" className="-mr-[30px] hidden w-[250px] flex-none wide:block" />
 }
 
 export function SessionRail({
@@ -145,6 +154,11 @@ export function SessionRail({
   // `agents` backs the filter chips and their picker.
   const { agents, crons } = useConsoleData()
   const cronName = useCallback((cronId: string) => crons.find((c) => c.id === cronId)?.name, [crons])
+
+  const { register: registerMobileAction } = useMobileActionSlot()
+  // ≤768px only: whether the app-bar-triggered list panel is showing. Touch has no
+  // hover, so this one is a latch rather than the tablet button's CSS hover.
+  const [mobileOpen, setMobileOpen] = useState(false)
 
   // Hydration: the server has no localStorage, so the first client paint must match
   // the SSR markup (every row unpinned) and the stored pins land in an effect.
@@ -264,7 +278,28 @@ export function SessionRail({
   // This test is also true while the rail's page is still in flight, since `rows` is
   // the open session alone until it lands. Same answer either way: hold the column,
   // fill it when there is something to fill it with.
-  if (Math.max(total, rows.length) < 2 && !hasFamily && !filterTouched) return <SessionRailSlot />
+  const empty = Math.max(total, rows.length) < 2 && !hasFamily && !filterTouched
+
+  // ≤768px has no column to hold, so the list hangs off a shell-owned app-bar
+  // button (see MobileActionSlot) whose panel is rendered below. Registration has
+  // to happen before the empty early-return, or the hook order would depend on
+  // whether the rail found rows.
+  const onMobileToggle = useCallback(() => setMobileOpen((v) => !v), [])
+  useEffect(() => {
+    if (empty) return
+    registerMobileAction({
+      icon: 'panel-right',
+      label: 'Sessions list',
+      active: mobileOpen,
+      onClick: onMobileToggle
+    })
+    return () => registerMobileAction(null)
+  }, [empty, mobileOpen, onMobileToggle, registerMobileAction])
+  // The detail view survives navigation, so a tapped row would otherwise leave the
+  // panel open over the session it just opened.
+  useEffect(() => setMobileOpen(false), [currentId])
+
+  if (empty) return <SessionRailSlot />
 
   const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)
@@ -364,79 +399,136 @@ export function SessionRail({
     )
   }
 
-  return (
-    <div className="hidden w-[224px] flex-none desktop:block">
-      <div className="sticky top-[-9px] flex max-h-[calc(100vh-110px)] flex-col pb-1">
-        <RailAgentFilter agents={agents} selected={agentIds} onChange={onAgentIdsChange} />
-        <div className="flex min-h-0 flex-1 flex-col gap-px overflow-auto">
-          {hasFamily && (
-            <>
-              <div className="flex-none px-[9px] pb-[3px] font-mono text-[10px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
-                Related
-              </div>
-              {conversation && parent && (
-                <div className="flex-none px-[9px] pt-[2px] pb-[2px] font-mono text-[9.5px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
-                  Parent conversation
-                </div>
-              )}
-              {parent && row(relationRow(parent), isPinned(parent.id))}
-              {row(sessionRow(current), rowPin(current).pinned, parent ? 1 : 0, true)}
-              {conversation && children.length > 0 && (
-                <div className="flex-none px-[9px] pt-[4px] pb-[2px] font-mono text-[9.5px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
-                  Delegations
-                </div>
-              )}
-              {children.map((child, index) => {
-                const origin = childOriginById?.get(child.id)
-                const previousOrigin = index > 0 ? childOriginById?.get(children[index - 1]!.id) : undefined
-                const originAgent = origin ? agents.find((agent) => agent.id === origin) : undefined
-                return (
-                  <Fragment key={child.id}>
-                    {origin !== undefined && origin !== previousOrigin && (
-                      <div className="flex-none px-[9px] pt-[4px] pb-[1px] font-mono text-[9.5px] font-medium tracking-[0.06em] text-(--text-tertiary)">
-                        via {originAgent ? agentLabel(originAgent) : origin}
-                      </div>
-                    )}
-                    {row(relationRow(child), isPinned(child.id), parent ? 2 : 1)}
-                  </Fragment>
-                )
-              })}
-              {siblings.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
-              {siblings.map((sibling) => row(relationRow(sibling), isPinned(sibling.id), 1))}
-              {ordinaryRows.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
-            </>
-          )}
-          {pinned.map((s) => row(sessionRow(s), true, 0, canonicalSessionId(s) === currentId))}
-          {pinned.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
-          {groups.map((g, i) => (
-            <Fragment key={g.bucket}>
-              {/* The first heading starts flush; separators already provide spacing
-                  when Related or pinned rows precede it. */}
-              <div
-                className={`flex-none px-[9px] pb-[3px] font-mono text-[10px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase ${
-                  i === 0 ? '' : 'pt-[11px]'
-                }`}
-              >
-                {g.label}
-              </div>
-              {g.rows.map((s) => row(sessionRow(s), false, 0, canonicalSessionId(s) === currentId))}
-            </Fragment>
-          ))}
-        </div>
-        {/* Carry the rail's filter into the full list so the link is the same
-            question, unabridged — but only when the list can actually ask it.
-            The sessions page filters by ONE agent, so a shared-conversation
-            filter is dropped rather than silently narrowed to whichever agent
-            happened to be first, which would answer something else entirely. */}
+  // One list, two containers: the ≥wide inline right column, and the 769–1239px
+  // floating button whose hover/focus popover shows the same list. Duplicating
+  // the rendered rows is cheap; duplicating the data plumbing would not be.
+  const body = (
+    <>
+      {/* Header: the list names itself, and "All sessions" rides the title row so
+          the escape to the full page is always visible, not below a long scroll.
+          The link carries the rail's filter when the list can ask the same
+          question — the sessions page filters by ONE agent, so a
+          shared-conversation filter is dropped rather than silently narrowed. */}
+      <div className="mb-[9px] flex flex-none items-center justify-between gap-2 px-[9px]">
+        <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">Sessions</span>
         <Link
-          className="lnk mt-[10px] mr-[9px] ml-[9px] font-sans text-[12px] font-medium leading-normal"
+          className="lnk font-sans text-[12px] font-medium leading-normal"
           href={orgPath(agentIds.length === 1 ? `/sessions?agent=${encodeURIComponent(agentIds[0]!)}` : '/sessions')}
         >
           All sessions
           <Icon name="arrow-right" size={12} />
         </Link>
       </div>
-    </div>
+      <RailAgentFilter agents={agents} selected={agentIds} onChange={onAgentIdsChange} />
+      <div className="flex min-h-0 flex-1 flex-col gap-px overflow-auto">
+        {hasFamily && (
+          <>
+            <div className="flex-none px-[9px] pb-[3px] font-mono text-[10px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
+              Related
+            </div>
+            {conversation && parent && (
+              <div className="flex-none px-[9px] pt-[2px] pb-[2px] font-mono text-[9.5px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
+                Parent conversation
+              </div>
+            )}
+            {parent && row(relationRow(parent), isPinned(parent.id))}
+            {row(sessionRow(current), rowPin(current).pinned, parent ? 1 : 0, true)}
+            {conversation && children.length > 0 && (
+              <div className="flex-none px-[9px] pt-[4px] pb-[2px] font-mono text-[9.5px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
+                Delegations
+              </div>
+            )}
+            {children.map((child, index) => {
+              const origin = childOriginById?.get(child.id)
+              const previousOrigin = index > 0 ? childOriginById?.get(children[index - 1]!.id) : undefined
+              const originAgent = origin ? agents.find((agent) => agent.id === origin) : undefined
+              return (
+                <Fragment key={child.id}>
+                  {origin !== undefined && origin !== previousOrigin && (
+                    <div className="flex-none px-[9px] pt-[4px] pb-[1px] font-mono text-[9.5px] font-medium tracking-[0.06em] text-(--text-tertiary)">
+                      via {originAgent ? agentLabel(originAgent) : origin}
+                    </div>
+                  )}
+                  {row(relationRow(child), isPinned(child.id), parent ? 2 : 1)}
+                </Fragment>
+              )
+            })}
+            {siblings.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
+            {siblings.map((sibling) => row(relationRow(sibling), isPinned(sibling.id), 1))}
+            {ordinaryRows.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
+          </>
+        )}
+        {pinned.map((s) => row(sessionRow(s), true, 0, canonicalSessionId(s) === currentId))}
+        {pinned.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
+        {groups.map((g, i) => (
+          <Fragment key={g.bucket}>
+            {/* The first heading starts flush; separators already provide spacing
+                  when Related or pinned rows precede it. */}
+            <div
+              className={`flex-none px-[9px] pb-[3px] font-mono text-[10px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase ${
+                i === 0 ? '' : 'pt-[11px]'
+              }`}
+            >
+              {g.label}
+            </div>
+            {g.rows.map((s) => row(sessionRow(s), false, 0, canonicalSessionId(s) === currentId))}
+          </Fragment>
+        ))}
+      </div>
+    </>
+  )
+
+  return (
+    <>
+      {/* ≥1240px: inline right column. The in-flow div only reserves the track (box
+          classes must match SessionRailSlot); the panel itself is FIXED to the
+          viewport's right edge — sticky inside the padded `.content` scroller gets
+          pushed down by its 34px top padding, so it could never sit flush. */}
+      <div className="-mr-[30px] hidden w-[250px] flex-none wide:block">
+        <div className="fixed top-0 right-0 bottom-0 flex w-[250px] flex-col border-l border-(--border-subtle) bg-(--surface-app) px-[13px] pt-[18px] pb-[10px]">
+          {body}
+        </div>
+      </div>
+      {/* 769–1239px: the rail collapses to a floating top-right button; hovering or
+          focusing it reveals the list in a popover. The pt-[6px] spacer keeps the
+          hover area contiguous between button and panel. */}
+      <div className="group fixed top-[10px] right-[14px] z-40 hidden desktop:max-wide:block">
+        <button
+          type="button"
+          aria-label="Sessions list"
+          aria-haspopup="true"
+          className="flex h-9 w-9 items-center justify-center rounded-full border border-(--border-default) bg-(--surface-card) text-(--text-secondary) shadow-(--shadow-sm) hover:text-(--text-primary) focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none"
+        >
+          <Icon name="panel-right" size={16} />
+        </button>
+        <div className="absolute top-full right-0 hidden w-[264px] pt-[6px] group-focus-within:block group-hover:block">
+          <div className="flex max-h-[75vh] flex-col rounded-lg border border-(--border-default) bg-(--surface-card) p-[10px] shadow-(--shadow-lg)">
+            {body}
+          </div>
+        </div>
+      </div>
+      {/* ≤768px: the same list, dropped under the app bar by its shell-owned button.
+          The trigger lives in `.mtop` rather than floating over the page, so it
+          cannot cover the session title the way a fixed overlay would.
+
+          Both nodes are `fixed` and sit at the top level of this fragment ON PURPOSE:
+          the caller's row is a flex container with `gap-[26px]`, and an ordinary
+          wrapper div here — zero-width, but still a flex ITEM — would spend that gap
+          as 26px of dead space on the transcript's right edge. Positioned children
+          are out of flow, so they are not flex items and contribute no gap. */}
+      {mobileOpen && (
+        <div className="fixed inset-0 z-50 desktop:hidden" onClick={() => setMobileOpen(false)} aria-hidden="true" />
+      )}
+      {mobileOpen && (
+        <div
+          role="dialog"
+          aria-label="Sessions list"
+          className="fixed top-[52px] right-[8px] z-50 hidden max-h-[70vh] w-[min(300px,calc(100vw-16px))] flex-col rounded-lg border border-(--border-default) bg-(--surface-card) p-[10px] shadow-(--shadow-lg) max-desktop:flex"
+        >
+          {body}
+        </div>
+      )}
+    </>
   )
 }
 

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -192,6 +192,24 @@ const MobileFilterContext = createContext<{
 }>({ filter: null, register: () => {} })
 export const useMobileFilterSlot = () => useContext(MobileFilterContext)
 
+// The same slot idea for ONE push-screen app-bar action: the session detail's
+// right rail fills it so its list can be opened from the app bar on mobile, where
+// the rail has no column to live in. The shell owns the bar, so a view cannot just
+// float a button there — a fixed overlay would sit on top of `.mtop-title`.
+// The panel itself stays with the view that registered the slot.
+export interface MobileActionSlot {
+  icon: string
+  label: string
+  /** Lights the button while the view's panel is open. */
+  active: boolean
+  onClick: () => void
+}
+const MobileActionContext = createContext<{
+  action: MobileActionSlot | null
+  register: (a: MobileActionSlot | null) => void
+}>({ action: null, register: () => {} })
+export const useMobileActionSlot = () => useContext(MobileActionContext)
+
 // The same slot idea for the detail crumb: the view that hydrates its own row publishes
 // title + status here while mounted, and the shell's crumb prefers it over the list
 // lookup. See lib/crumb.ts for why the lists can't carry this on their own.
@@ -378,6 +396,8 @@ function ShellChrome({ children }: { children: ReactNode }) {
   }, [isMobile])
   // Filter slot the current view (Sessions) registers so the app bar can trigger it.
   const [mobileFilter, setMobileFilter] = useState<MobileFilterSlot | null>(null)
+  // Push-screen app-bar action the current view registers (the session rail's list).
+  const [mobileAction, setMobileAction] = useState<MobileActionSlot | null>(null)
   // Status slot the session detail view registers so the crumb can badge it.
   const [crumbSlot, setCrumbSlot] = useState<CrumbSlot | null>(null)
   // Active/crumb matching runs on the console path WITHOUT the org segment
@@ -627,354 +647,376 @@ function ShellChrome({ children }: { children: ReactNode }) {
 
   return (
     <MobileFilterContext.Provider value={{ filter: mobileFilter, register: setMobileFilter }}>
-      <CrumbContext.Provider value={{ register: setCrumbSlot }}>
-        <div className={`app${isListRoute ? '' : ' pushed'}${mounted ? ' mounted' : ''}`}>
-          {/* ===== RAIL =====
+      <MobileActionContext.Provider value={{ action: mobileAction, register: setMobileAction }}>
+        <CrumbContext.Provider value={{ register: setCrumbSlot }}>
+          <div className={`app${isListRoute ? '' : ' pushed'}${mounted ? ' mounted' : ''}`}>
+            {/* ===== RAIL =====
           Only collapsed, icon-only controls get titles; the global layer turns
           those titles into the console's themed tooltips. */}
-          <aside className={`rail${railCollapsed ? ' collapsed' : ''}${railAnim ? ' rail-anim' : ''}`}>
-            <div className="railbrand">
-              <Link
-                href={orgPath('/home')}
-                className="railbrand-logo cursor-pointer select-none"
-                aria-label="Go to Home"
-              >
-                <LogoMark size={24} />
-                <span className="brandword font-sans text-[16px] font-semibold leading-normal tracking-[-.02em] text-white">
-                  Agent<span className="text-(--magenta-300)">Connect</span>
-                </span>
-              </Link>
-              <button
-                type="button"
-                onClick={toggleRail}
-                className="railiconbtn railtoggle"
-                // No `title`: the icon already reads as the collapse/expand affordance,
-                // and a tooltip on the collapsed rail's own toggle is noise. Screen
-                // readers still get the state from aria-label.
-                aria-label={railCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-              >
-                <Icon name={railCollapsed ? 'panel-left-open' : 'panel-left-close'} size={16} />
-              </button>
-              {/* Search sits at the rail's outer edge, permanently visible — with no
+            <aside className={`rail${railCollapsed ? ' collapsed' : ''}${railAnim ? ' rail-anim' : ''}`}>
+              <div className="railbrand">
+                <Link
+                  href={orgPath('/home')}
+                  className="railbrand-logo cursor-pointer select-none"
+                  aria-label="Go to Home"
+                >
+                  <LogoMark size={24} />
+                  <span className="brandword font-sans text-[16px] font-semibold leading-normal tracking-[-.02em] text-white">
+                    Agent<span className="text-(--magenta-300)">Connect</span>
+                  </span>
+                </Link>
+                <button
+                  type="button"
+                  onClick={toggleRail}
+                  className="railiconbtn railtoggle"
+                  // No `title`: the icon already reads as the collapse/expand affordance,
+                  // and a tooltip on the collapsed rail's own toggle is noise. Screen
+                  // readers still get the state from aria-label.
+                  aria-label={railCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+                >
+                  <Icon name={railCollapsed ? 'panel-left-open' : 'panel-left-close'} size={16} />
+                </button>
+                {/* Search sits at the rail's outer edge, permanently visible — with no
               top bar it is the console's only search affordance, so unlike the
               collapse toggle beside it, it never hides. Collapsed, CSS swaps it for
               the `.railsrnav` row below. */}
+                <button
+                  type="button"
+                  onClick={openSearch}
+                  className="railiconbtn railsrbtn"
+                  title="Search"
+                  aria-label="Search"
+                >
+                  <Icon name="search" size={16} />
+                </button>
+              </div>
+              {/* The search dialog itself. It renders in the rail so the trigger and the
+            dialog share one component; `rail` re-seats the open state as a centred
+            command palette (globals.css `.railsr`). */}
+              <GlobalSearch rail />
               <button
                 type="button"
                 onClick={openSearch}
-                className="railiconbtn railsrbtn"
+                className="navitem railsrnav"
                 title="Search"
                 aria-label="Search"
               >
-                <Icon name="search" size={16} />
+                <Icon name="search" size={18} />
+                <span>Search</span>
               </button>
-            </div>
-            {/* The search dialog itself. It renders in the rail so the trigger and the
-            dialog share one component; `rail` re-seats the open state as a centred
-            command palette (globals.css `.railsr`). */}
-            <GlobalSearch rail />
-            <button type="button" onClick={openSearch} className="navitem railsrnav" title="Search" aria-label="Search">
-              <Icon name="search" size={18} />
-              <span>Search</span>
-            </button>
-            {NAV_ITEMS.map((item) => {
-              const on = isActive(barePath, item.href)
-              return (
-                <Link
-                  key={item.href}
-                  href={orgPath(item.href)}
-                  title={railCollapsed ? item.label : undefined}
-                  className={on ? 'navitem on' : 'navitem'}
-                >
-                  {/* No inline color — `.navitem.on svg` tints the active glyph brand. */}
-                  <Icon name={item.icon} size={18} />
-                  <span>{item.label}</span>
-                </Link>
-              )
-            })}
-            {/* Rail footer. In auth mode this is the account block: avatar + name +
+              {NAV_ITEMS.map((item) => {
+                const on = isActive(barePath, item.href)
+                return (
+                  <Link
+                    key={item.href}
+                    href={orgPath(item.href)}
+                    title={railCollapsed ? item.label : undefined}
+                    className={on ? 'navitem on' : 'navitem'}
+                  >
+                    {/* No inline color — `.navitem.on svg` tints the active glyph brand. */}
+                    <Icon name={item.icon} size={18} />
+                    <span>{item.label}</span>
+                  </Link>
+                )
+              })}
+              {/* Rail footer. In auth mode this is the account block: avatar + name +
             active org, whose menu carries everything the deleted top bar used to —
             org switching, Profile, Settings, the theme toggle, sign-out. No-auth has
             no identity and one implicit org, so it keeps just the theme toggle. The
             Help menu shows in both modes — the docs links are useful either way. */}
-            <div className="railfoot">
-              {authOn ? (
-                <RailAccount
-                  display={display}
-                  collapsed={railCollapsed}
-                  orgs={orgs}
-                  activeOrg={activeOrg}
-                  setActiveOrg={setActiveOrg}
-                  orgPath={orgPath}
-                  openModal={openModal}
-                  canCreateOrg={canCreateOrg}
-                  theme={theme}
-                  onToggleTheme={toggleTheme}
-                  onSignOut={signOut}
-                />
-              ) : (
-                <button
-                  type="button"
-                  onClick={toggleTheme}
-                  className="railiconbtn"
-                  title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-                  aria-label="Toggle theme"
-                >
-                  <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={16} />
-                </button>
-              )}
-              {/* Same 22px box as the brand row's search button, and the same 2px
-              inset from the rail's edge — the two sit on one vertical centre line. */}
-              <div className="railhelp relative mr-[2px] flex-none">
-                <button
-                  type="button"
-                  onClick={() => setHelpMenu((v) => !v)}
-                  className="railiconbtn"
-                  title="Help & resources"
-                  aria-label="Help & resources"
-                >
-                  <Icon name="circle-question-mark" size={16} color={helpMenu ? 'var(--brand)' : undefined} />
-                </button>
-                {helpMenu && (
-                  <>
-                    <div className="fixed inset-0 z-45" onClick={() => setHelpMenu(false)} />
-                    <div className="absolute bottom-[calc(100%_+_8px)] left-0 z-50 w-[236px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
-                      {/* The desktop way back to a skipped checklist, both auth modes — the
-                          pill has no other desktop re-entry point. */}
-                      <button
-                        className="dmi"
-                        onClick={() => {
-                          setHelpMenu(false)
-                          openGettingStarted()
-                        }}
-                      >
-                        <Icon name="rocket" size={15} color="var(--text-tertiary)" />
-                        Getting started
-                      </button>
-                      <button
-                        className="dmi"
-                        onClick={() => {
-                          setHelpMenu(false)
-                          setConnectAiOpen(true)
-                        }}
-                      >
-                        <SiModelcontextprotocol className="text-(--text-tertiary)" aria-hidden />
-                        Connect your AI
-                      </button>
-                      <a
-                        className="dmi no-underline"
-                        href={help.docs}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onClick={() => setHelpMenu(false)}
-                      >
-                        <Icon name="book-open" size={15} color="var(--text-tertiary)" />
-                        Documentation
-                      </a>
-                      <div className="dmsep" />
-                      <button
-                        className="dmi"
-                        onClick={() => {
-                          setHelpMenu(false)
-                          setShortcutsOpen(true)
-                        }}
-                      >
-                        <Icon name="command" size={15} color="var(--text-tertiary)" />
-                        Keyboard shortcuts
-                      </button>
-                      <a
-                        className="dmi no-underline"
-                        href={help.releases}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onClick={() => setHelpMenu(false)}
-                      >
-                        <Icon name="gift" size={15} color="var(--text-tertiary)" />
-                        What&rsquo;s new
-                      </a>
-                      <a className="dmi no-underline" href={help.support} onClick={() => setHelpMenu(false)}>
-                        <Icon name="life-buoy" size={15} color="var(--text-tertiary)" />
-                        Help &amp; support
-                      </a>
-                    </div>
-                  </>
-                )}
-              </div>
-            </div>
-          </aside>
-
-          {/* ===== MAIN =====
-          Desktop has NO top bar (design v2 is a pure left/right split): no breadcrumb,
-          no parent back-link, no title strip. The rail states where you are, and each
-          detail view owns its own heading. Mobile still needs one — `.mtop` below. */}
-          <div className="main">
-            {githubNotice && (
-              <div
-                role={githubNotice.tone === 'warning' ? 'alert' : 'status'}
-                className="fixed top-[72px] right-4 left-4 z-50 flex items-start gap-3 rounded-md border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-md) desktop:top-4 desktop:left-auto desktop:w-[460px]"
-              >
-                <Icon
-                  name={githubNotice.tone === 'success' ? 'circle-check' : 'triangle-alert'}
-                  size={16}
-                  color={githubNotice.tone === 'success' ? 'var(--status-online)' : 'var(--amber-500)'}
-                  className="mt-[1px] flex-none"
-                />
-                <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
-                  {githubNotice.message}
-                </span>
+              <div className="railfoot">
                 {authOn ? (
-                  <Link
-                    href={orgPath('/settings')}
-                    className="lnk flex-none text-[12px]"
-                    onClick={() => setGithubNotice(null)}
-                  >
-                    Settings
-                  </Link>
+                  <RailAccount
+                    display={display}
+                    collapsed={railCollapsed}
+                    orgs={orgs}
+                    activeOrg={activeOrg}
+                    setActiveOrg={setActiveOrg}
+                    orgPath={orgPath}
+                    openModal={openModal}
+                    canCreateOrg={canCreateOrg}
+                    theme={theme}
+                    onToggleTheme={toggleTheme}
+                    onSignOut={signOut}
+                  />
                 ) : (
                   <button
                     type="button"
-                    className="lnk flex-none text-[12px]"
-                    onClick={() => {
-                      setGithubNotice(null)
-                      openModal('agent')
-                    }}
+                    onClick={toggleTheme}
+                    className="railiconbtn"
+                    title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+                    aria-label="Toggle theme"
                   >
-                    Add agent
+                    <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={16} />
                   </button>
                 )}
-                <button
-                  type="button"
-                  className="iconbtn -m-1 h-7 w-7 flex-none"
-                  aria-label="Dismiss GitHub installation notice"
-                  onClick={() => setGithubNotice(null)}
-                >
-                  <Icon name="x" size={14} />
-                </button>
-              </div>
-            )}
-            {/* ===== MOBILE APP BAR (hidden ≥ tablet) — list-tab vs push variant ===== */}
-            <header className="mtop">
-              {isListRoute ? (
-                <>
-                  <Link href={orgPath('/home')} className="mtop-logo select-none" aria-label="Go to Home">
-                    <LogoMark />
-                  </Link>
-                  <span className="mtop-title">{crumb}</span>
-                  {addKind && (
-                    <button className="mappbtn" aria-label="Add" onClick={() => openModal(addKind)}>
-                      <Icon name="circle-plus" size={22} />
-                    </button>
-                  )}
-                  {/* Sessions registers a filter slot; surface it as an app-bar button
-                  with a dot when any filter is active (design's Sessions tab). */}
-                  {barePath === '/sessions' && mobileFilter && (
-                    <button className="mappbtn relative" aria-label="Filter sessions" onClick={mobileFilter.open}>
-                      <Icon name="sliders-horizontal" size={20} />
-                      {mobileFilter.active && (
-                        <span className="absolute top-[9px] right-[10px] h-[7px] w-[7px] rounded-full border-[1.5px] border-(--surface-card) bg-(--brand)" />
-                      )}
-                    </button>
-                  )}
-                  <button className="mappbtn" aria-label="Search" onClick={() => setMobileSearch(true)}>
-                    <Icon name="search" size={20} />
-                  </button>
+                {/* Same 22px box as the brand row's search button, and the same 2px
+              inset from the rail's edge — the two sit on one vertical centre line. */}
+                <div className="railhelp relative mr-[2px] flex-none">
                   <button
-                    className="mappbtn"
-                    aria-label="Toggle theme"
-                    title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-                    onClick={toggleTheme}
+                    type="button"
+                    onClick={() => setHelpMenu((v) => !v)}
+                    className="railiconbtn"
+                    title="Help & resources"
+                    aria-label="Help & resources"
                   >
-                    <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={20} />
+                    <Icon name="circle-question-mark" size={16} color={helpMenu ? 'var(--brand)' : undefined} />
                   </button>
-                  {authOn && (
-                    <Link
-                      href={orgPath('/profile')}
-                      aria-label="Profile"
-                      title="Profile"
-                      className="ml-[2px] flex-none leading-[0]"
-                    >
-                      <Avatar src={display.picture} initials={display.initials} size={30} fontSize={11} />
-                    </Link>
+                  {helpMenu && (
+                    <>
+                      <div className="fixed inset-0 z-45" onClick={() => setHelpMenu(false)} />
+                      <div className="absolute bottom-[calc(100%_+_8px)] left-0 z-50 w-[236px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
+                        {/* The desktop way back to a skipped checklist, both auth modes — the
+                          pill has no other desktop re-entry point. */}
+                        <button
+                          className="dmi"
+                          onClick={() => {
+                            setHelpMenu(false)
+                            openGettingStarted()
+                          }}
+                        >
+                          <Icon name="rocket" size={15} color="var(--text-tertiary)" />
+                          Getting started
+                        </button>
+                        <button
+                          className="dmi"
+                          onClick={() => {
+                            setHelpMenu(false)
+                            setConnectAiOpen(true)
+                          }}
+                        >
+                          <SiModelcontextprotocol className="text-(--text-tertiary)" aria-hidden />
+                          Connect your AI
+                        </button>
+                        <a
+                          className="dmi no-underline"
+                          href={help.docs}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={() => setHelpMenu(false)}
+                        >
+                          <Icon name="book-open" size={15} color="var(--text-tertiary)" />
+                          Documentation
+                        </a>
+                        <div className="dmsep" />
+                        <button
+                          className="dmi"
+                          onClick={() => {
+                            setHelpMenu(false)
+                            setShortcutsOpen(true)
+                          }}
+                        >
+                          <Icon name="command" size={15} color="var(--text-tertiary)" />
+                          Keyboard shortcuts
+                        </button>
+                        <a
+                          className="dmi no-underline"
+                          href={help.releases}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={() => setHelpMenu(false)}
+                        >
+                          <Icon name="gift" size={15} color="var(--text-tertiary)" />
+                          What&rsquo;s new
+                        </a>
+                        <a className="dmi no-underline" href={help.support} onClick={() => setHelpMenu(false)}>
+                          <Icon name="life-buoy" size={15} color="var(--text-tertiary)" />
+                          Help &amp; support
+                        </a>
+                      </div>
+                    </>
                   )}
-                </>
-              ) : (
-                <>
-                  <button className="mappbtn" aria-label="Back" onClick={goBack}>
-                    <Icon name="arrow-left" size={20} />
+                </div>
+              </div>
+            </aside>
+
+            {/* ===== MAIN =====
+          Desktop has NO top bar (design v2 is a pure left/right split): no breadcrumb,
+          no parent back-link, no title strip. The rail states where you are, and each
+          detail view owns its own heading. Mobile still needs one — `.mtop` below. */}
+            <div className="main">
+              {githubNotice && (
+                <div
+                  role={githubNotice.tone === 'warning' ? 'alert' : 'status'}
+                  className="fixed top-[72px] right-4 left-4 z-50 flex items-start gap-3 rounded-md border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-md) desktop:top-4 desktop:left-auto desktop:w-[460px]"
+                >
+                  <Icon
+                    name={githubNotice.tone === 'success' ? 'circle-check' : 'triangle-alert'}
+                    size={16}
+                    color={githubNotice.tone === 'success' ? 'var(--status-online)' : 'var(--amber-500)'}
+                    className="mt-[1px] flex-none"
+                  />
+                  <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
+                    {githubNotice.message}
+                  </span>
+                  {authOn ? (
+                    <Link
+                      href={orgPath('/settings')}
+                      className="lnk flex-none text-[12px]"
+                      onClick={() => setGithubNotice(null)}
+                    >
+                      Settings
+                    </Link>
+                  ) : (
+                    <button
+                      type="button"
+                      className="lnk flex-none text-[12px]"
+                      onClick={() => {
+                        setGithubNotice(null)
+                        openModal('agent')
+                      }}
+                    >
+                      Add agent
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className="iconbtn -m-1 h-7 w-7 flex-none"
+                    aria-label="Dismiss GitHub installation notice"
+                    onClick={() => setGithubNotice(null)}
+                  >
+                    <Icon name="x" size={14} />
                   </button>
-                  <span className="mtop-title">{pushTitle}</span>
-                  {isSessionDetail && (
+                </div>
+              )}
+              {/* ===== MOBILE APP BAR (hidden ≥ tablet) — list-tab vs push variant ===== */}
+              <header className="mtop">
+                {isListRoute ? (
+                  <>
+                    <Link href={orgPath('/home')} className="mtop-logo select-none" aria-label="Go to Home">
+                      <LogoMark />
+                    </Link>
+                    <span className="mtop-title">{crumb}</span>
+                    {addKind && (
+                      <button className="mappbtn" aria-label="Add" onClick={() => openModal(addKind)}>
+                        <Icon name="circle-plus" size={22} />
+                      </button>
+                    )}
+                    {/* Sessions registers a filter slot; surface it as an app-bar button
+                  with a dot when any filter is active (design's Sessions tab). */}
+                    {barePath === '/sessions' && mobileFilter && (
+                      <button className="mappbtn relative" aria-label="Filter sessions" onClick={mobileFilter.open}>
+                        <Icon name="sliders-horizontal" size={20} />
+                        {mobileFilter.active && (
+                          <span className="absolute top-[9px] right-[10px] h-[7px] w-[7px] rounded-full border-[1.5px] border-(--surface-card) bg-(--brand)" />
+                        )}
+                      </button>
+                    )}
+                    <button className="mappbtn" aria-label="Search" onClick={() => setMobileSearch(true)}>
+                      <Icon name="search" size={20} />
+                    </button>
                     <button
                       className="mappbtn"
-                      aria-label={linkCopied ? 'Link copied' : 'Copy link'}
-                      onClick={copyLink}
+                      aria-label="Toggle theme"
+                      title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+                      onClick={toggleTheme}
                     >
-                      <Icon
-                        name={linkCopied ? 'check' : 'link'}
-                        size={20}
-                        color={linkCopied ? 'var(--brand)' : undefined}
-                      />
+                      <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={20} />
                     </button>
-                  )}
-                </>
-              )}
-            </header>
+                    {authOn && (
+                      <Link
+                        href={orgPath('/profile')}
+                        aria-label="Profile"
+                        title="Profile"
+                        className="ml-[2px] flex-none leading-[0]"
+                      >
+                        <Avatar src={display.picture} initials={display.initials} size={30} fontSize={11} />
+                      </Link>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <button className="mappbtn" aria-label="Back" onClick={goBack}>
+                      <Icon name="arrow-left" size={20} />
+                    </button>
+                    <span className="mtop-title">{pushTitle}</span>
+                    {mobileAction && (
+                      <button
+                        className={`mappbtn${mobileAction.active ? ' text-(--brand)' : ''}`}
+                        aria-label={mobileAction.label}
+                        aria-expanded={mobileAction.active}
+                        onClick={mobileAction.onClick}
+                      >
+                        <Icon
+                          name={mobileAction.icon}
+                          size={20}
+                          color={mobileAction.active ? 'var(--brand)' : undefined}
+                        />
+                      </button>
+                    )}
+                    {isSessionDetail && (
+                      <button
+                        className="mappbtn"
+                        aria-label={linkCopied ? 'Link copied' : 'Copy link'}
+                        onClick={copyLink}
+                      >
+                        <Icon
+                          name={linkCopied ? 'check' : 'link'}
+                          size={20}
+                          color={linkCopied ? 'var(--brand)' : undefined}
+                        />
+                      </button>
+                    )}
+                  </>
+                )}
+              </header>
 
-            <div className="content">
-              <SearchOpenContext.Provider value={openSearch}>{children}</SearchOpenContext.Provider>
+              <div className="content">
+                <SearchOpenContext.Provider value={openSearch}>{children}</SearchOpenContext.Provider>
+              </div>
+
+              {/* ===== MOBILE BOTTOM NAV — 4 tabs + More, hidden on push screens ===== */}
+              {isListRoute && (
+                <nav className="mnav">
+                  <div className="mnav-tabs">
+                    {MOBILE_NAV.map((item) => {
+                      const on = isActive(barePath, item.href)
+                      return (
+                        <Link key={item.href} href={orgPath(item.href)} className={on ? 'mnavitem on' : 'mnavitem'}>
+                          <Icon name={item.icon} size={20} color={on ? 'var(--magenta-300)' : undefined} />
+                          <span>{item.label}</span>
+                        </Link>
+                      )
+                    })}
+                    <button type="button" className="mnavitem" onClick={() => setMobileSheet('more')}>
+                      <Icon name="ellipsis" size={20} />
+                      <span>More</span>
+                    </button>
+                  </div>
+                  <div className="mnav-home">
+                    <span className="home-pill" />
+                  </div>
+                </nav>
+              )}
             </div>
 
-            {/* ===== MOBILE BOTTOM NAV — 4 tabs + More, hidden on push screens ===== */}
-            {isListRoute && (
-              <nav className="mnav">
-                <div className="mnav-tabs">
-                  {MOBILE_NAV.map((item) => {
-                    const on = isActive(barePath, item.href)
-                    return (
-                      <Link key={item.href} href={orgPath(item.href)} className={on ? 'mnavitem on' : 'mnavitem'}>
-                        <Icon name={item.icon} size={20} color={on ? 'var(--magenta-300)' : undefined} />
-                        <span>{item.label}</span>
-                      </Link>
-                    )
-                  })}
-                  <button type="button" className="mnavitem" onClick={() => setMobileSheet('more')}>
-                    <Icon name="ellipsis" size={20} />
-                    <span>More</span>
-                  </button>
-                </div>
-                <div className="mnav-home">
-                  <span className="home-pill" />
-                </div>
-              </nav>
+            {/* ===== MOBILE SHEETS + full-screen search (mobile-only; opened from the nav) ===== */}
+            {mobileSheet && (
+              <MobileSheets
+                which={mobileSheet}
+                authOn={authOn}
+                orgPath={orgPath}
+                orgs={orgs}
+                activeOrg={activeOrg}
+                setActiveOrg={setActiveOrg}
+                openModal={openModal}
+                canCreateOrg={canCreateOrg}
+                onOpenOrg={() => setMobileSheet('org')}
+                onClose={closeSheets}
+              />
             )}
-          </div>
-
-          {/* ===== MOBILE SHEETS + full-screen search (mobile-only; opened from the nav) ===== */}
-          {mobileSheet && (
-            <MobileSheets
-              which={mobileSheet}
-              authOn={authOn}
-              orgPath={orgPath}
-              orgs={orgs}
-              activeOrg={activeOrg}
-              setActiveOrg={setActiveOrg}
-              openModal={openModal}
-              canCreateOrg={canCreateOrg}
-              onOpenOrg={() => setMobileSheet('org')}
-              onClose={closeSheets}
-            />
-          )}
-          {mobileSearch && <GlobalSearch mobile autoFocus onClose={() => setMobileSearch(false)} />}
-          {shortcutsOpen && <KeyboardShortcutsModal onClose={() => setShortcutsOpen(false)} />}
-          {connectAiOpen && <ConnectAiModal onClose={() => setConnectAiOpen(false)} moreUrl={help.mcp} />}
-          {/* Getting-started pill + drawer (design 1a/1b): a corner checklist derived from
+            {mobileSearch && <GlobalSearch mobile autoFocus onClose={() => setMobileSearch(false)} />}
+            {shortcutsOpen && <KeyboardShortcutsModal onClose={() => setShortcutsOpen(false)} />}
+            {connectAiOpen && <ConnectAiModal onClose={() => setConnectAiOpen(false)} moreUrl={help.mcp} />}
+            {/* Getting-started pill + drawer (design 1a/1b): a corner checklist derived from
           live state, self-gated (desktop, setup-started, incomplete). */}
-          <GettingStarted />
-          {/* Renders every `title` in the console on the design system's timing
+            <GettingStarted />
+            {/* Renders every `title` in the console on the design system's timing
           instead of the browser's ~1s native tooltip. Portals to <body>. */}
-          <TooltipLayer />
-        </div>
-      </CrumbContext.Provider>
+            <TooltipLayer />
+          </div>
+        </CrumbContext.Provider>
+      </MobileActionContext.Provider>
     </MobileFilterContext.Provider>
   )
 }

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -948,8 +948,7 @@ function MobileSessionFamilyLinks({
  */
 function SessionDetailFrame({ children, withRail = true }: { children: ReactNode; withRail?: boolean }) {
   return (
-    <div className="wrap flex min-h-full items-stretch gap-[26px]">
-      {withRail ? <SessionRailSlot /> : null}
+    <div className="flex min-h-full items-stretch gap-[26px]">
       <div
         className={
           withRail
@@ -959,6 +958,7 @@ function SessionDetailFrame({ children, withRail = true }: { children: ReactNode
       >
         {children}
       </div>
+      {withRail ? <SessionRailSlot /> : null}
     </div>
   )
 }
@@ -1143,13 +1143,25 @@ export default function SessionDetailView() {
   const { user: viewer, me } = useProfile()
   const [copied, setCopied] = useState(false)
   const detailTooltipId = useId()
-  const [detailInteraction, setDetailInteraction] = useState({ hovered: false, focused: false, dismissed: false })
-  const detailOpen = (detailInteraction.hovered || detailInteraction.focused) && !detailInteraction.dismissed
+  // `tapped` is the touch path: a tap neither hovers nor reliably focuses a button
+  // (Safari does not focus one on tap), so the mobile header's Details trigger
+  // toggles this latch instead of relying on the desktop hover presence.
+  const [detailInteraction, setDetailInteraction] = useState({
+    hovered: false,
+    focused: false,
+    tapped: false,
+    dismissed: false
+  })
+  const detailOpen =
+    (detailInteraction.hovered || detailInteraction.focused || detailInteraction.tapped) && !detailInteraction.dismissed
   const updateDetailPresence = (key: 'hovered' | 'focused', value: boolean) =>
     setDetailInteraction((current) => {
       const next = { ...current, [key]: value }
-      return { ...next, dismissed: next.hovered || next.focused ? current.dismissed : false }
+      return { ...next, dismissed: next.hovered || next.focused || next.tapped ? current.dismissed : false }
     })
+  const closeDetailTap = () => setDetailInteraction((current) => ({ ...current, tapped: false, dismissed: false }))
+  const toggleDetailTap = () =>
+    setDetailInteraction((current) => ({ ...current, tapped: !current.tapped, dismissed: false }))
   const [msgs, setMsgs] = useState<SessionMessageDto[] | null>(null)
   // Conversation mode: per-member fetched rows + live cursors; the rendered
   // transcript is always mergeConversation() over the CURRENT map, so every
@@ -1243,7 +1255,7 @@ export default function SessionDetailView() {
       if (event.key !== 'Escape') return
       event.preventDefault()
       event.stopPropagation()
-      setDetailInteraction((current) => ({ ...current, dismissed: true }))
+      setDetailInteraction((current) => ({ ...current, tapped: false, dismissed: true }))
     }
     document.addEventListener('keydown', dismissDetails, true)
     return () => document.removeEventListener('keydown', dismissDetails, true)
@@ -1912,7 +1924,7 @@ export default function SessionDetailView() {
   useEffect(() => {
     imagePrepareGenerationRef.current += 1
     setCopied(false)
-    setDetailInteraction({ hovered: false, focused: false, dismissed: false })
+    setDetailInteraction({ hovered: false, focused: false, tapped: false, dismissed: false })
     setWorkOverride(new Map())
     setImagePreparing(false)
     setImageError(null)
@@ -2556,9 +2568,10 @@ export default function SessionDetailView() {
   const pgFastModeAvailable =
     (pgModel === session.model ? session.fastModeAvailable : undefined) ??
     fastModeAvailableFor(agentRuntime, selectedModelCapability)
-  // Run facts for the desktop header's "Details" popover — the stats that used to
-  // live in the header cards (duration, usage) plus the run's identity rows. Status
-  // is not here: it rides the top-bar crumb as a pill next to the session name.
+  // Run facts for the header's "Details" popover — the stats that used to live in
+  // the header cards (duration, usage) plus the run's identity rows. Status is not
+  // here: it rides the top-bar crumb as a pill next to the session name. Both form
+  // factors read this one list (see detailPanel below).
   const headerFacts: { icon: string; label: string; value: string }[] = [
     { icon: 'clock', label: 'Duration', value: displayDuration },
     { icon: 'coins', label: 'Tokens', value: conversationUsage?.tokens ?? session.tokens },
@@ -2570,54 +2583,58 @@ export default function SessionDetailView() {
     headerFacts.push({ icon: 'cpu', label: 'Runtime', value: runtimeLabel(session.runtime, runtimeMeta?.name) })
   if (session.model) headerFacts.push({ icon: 'box', label: 'Model', value: modelLabel(session.model) })
 
-  // Mobile header-region derivations (≤768px meta strip + agent config row).
-  const metaCells: { label: string; value: string }[] = [
-    { label: 'Dur', value: displayDuration },
-    { label: 'Tokens', value: conversationUsage?.tokens ?? session.tokens },
-    { label: 'Cost', value: conversationUsage?.cost ?? session.cost },
-    { label: 'Tools', value: displayToolCount }
-  ]
-  const cfgLine = [
-    daemonName,
-    session.runtime ? runtimeLabel(session.runtime, runtimeMeta?.name) : '',
-    modelLabel(session.model ?? '')
-  ]
-    .filter(Boolean)
-    .join(' · ')
+  // The popover's contents — one definition behind both triggers (desktop hover,
+  // mobile tap), so a fact can never show up on one form factor and not the other.
+  const detailPanel = (
+    <>
+      {headerFacts.map((f) => (
+        <div key={f.label} className="flex items-center gap-[9px] px-3 py-[5px]">
+          <Icon name={f.icon} size={13} color="var(--text-tertiary)" className="flex-none" />
+          <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+            {f.label}
+          </span>
+          <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">{f.value}</span>
+        </div>
+      ))}
+      {usageEntries.length > 0 && (
+        <>
+          <div className="my-1 border-t border-(--border-subtle)" />
+          <div className="px-3 pt-1 pb-[2px] font-mono text-[10px] font-semibold uppercase tracking-[.06em] text-(--text-tertiary)">
+            Token usage
+          </div>
+          {usageEntries.map((e) => (
+            <div key={e.label} className="flex items-center gap-[9px] py-1 pr-3 pl-[34px]">
+              <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+                {e.label}
+              </span>
+              <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">{e.value}</span>
+            </div>
+          ))}
+        </>
+      )}
+    </>
+  )
 
   // ── one responsive tree ─────────────────────────────────────────────────────
   // ≤768px renders the native push-screen body (Shell owns the 56px app bar:
-  // back · title · status-dot/channel · link): meta strip → agent config row →
-  // transcript → live. ≥769px renders the classic page: header → stat/usage
-  // cards → transcript. Breakpoint differences are CSS-gated (desktop: /
+  // back · title · status-dot/channel · link): header row (agent · visibility ·
+  // Details) → transcript → live. ≥769px renders the classic page: header →
+  // meta row → transcript. Both form factors put the run's numbers behind the
+  // same Details popover. Breakpoint differences are CSS-gated (desktop: /
   // max-desktop:), never JS-forked.
   return (
-    // `.wrap` (1180px) is the outer track so the sibling-session rail can sit beside
-    // the 880px body. The rail always occupies its column above the breakpoint, even
-    // with no rows to show, so this is the one position the body ever takes. Keep the
-    // row in step with SessionDetailFrame, which draws the same two columns for every
-    // state that precedes or replaces a session.
-    <div className="wrap flex min-h-full items-stretch gap-[26px]">
-      <SessionRail
-        sessions={railSessions}
-        // The open row has to name its conversation and its members, because that
-        // is how the rail collapses it against the grouped list and how a pin
-        // finds it — matching on the session id alone would double the row (or
-        // lose its pin) whenever the two disagree on which member is newest.
-        // `selfKey` is the same §5.1 key computed for the redirect probe, so a
-        // single-participant thread is deduplicated on exactly the same terms, and
-        // the roster resolver is not agent-filtered, so its members are complete.
-        current={railCurrent ?? session}
-        total={railSessionTotal}
-        agentIds={railFilter.agentIds}
-        filterTouched={railFilter.touched}
-        onAgentIdsChange={setRailAgentIds}
-        family={conversationFamily ?? (currentSessionDetail?.id === session.id ? currentSessionDetail : undefined)}
-        conversation={conversationMode}
-        childOriginById={conversationLineage?.childOriginById}
-        onSelect={setRouteSession}
-      />
-      <div className="mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col max-desktop:pb-6">
+    // Three-column track ([nav · body · rail]): the full-width row lets the
+    // sibling-session rail sit flush against the page's right edge while the 880px
+    // body centres in what remains. The rail always occupies its column above the
+    // `wide` breakpoint, even with no rows to show, so this is the one position the
+    // body ever takes. Keep the row in step with SessionDetailFrame, which draws
+    // the same two columns for every state that precedes or replaces a session.
+    <div className="flex min-h-full items-stretch gap-[26px]">
+      {/* No bottom padding here on mobile: the sticky composer cancels exactly
+          `.content`'s bottom inset (see its negative `bottom`), so any padding
+          BELOW it becomes a strip the composer can never reach — it stops short
+          of the screen edge at the end of the scroll. */}
+      <div className="mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col">
         {/* DESKTOP TITLE ROW — the session name + its status badge. These used to live
           in the top-bar crumb; with the crumb gone the page has to name itself. The
           mobile title/status live in Shell's app bar, so this region is desktop-only. */}
@@ -2722,35 +2739,7 @@ export default function SessionDetailView() {
               }`}
             >
               <div className="max-h-[340px] min-w-[216px] overflow-auto rounded-[9px] border border-(--border-default) bg-(--surface-card) px-0 py-[5px] shadow-(--shadow-lg)">
-                {headerFacts.map((f) => (
-                  <div key={f.label} className="flex items-center gap-[9px] px-3 py-[5px]">
-                    <Icon name={f.icon} size={13} color="var(--text-tertiary)" className="flex-none" />
-                    <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
-                      {f.label}
-                    </span>
-                    <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">
-                      {f.value}
-                    </span>
-                  </div>
-                ))}
-                {usageEntries.length > 0 && (
-                  <>
-                    <div className="my-1 border-t border-(--border-subtle)" />
-                    <div className="px-3 pt-1 pb-[2px] font-mono text-[10px] font-semibold uppercase tracking-[.06em] text-(--text-tertiary)">
-                      Token usage
-                    </div>
-                    {usageEntries.map((e) => (
-                      <div key={e.label} className="flex items-center gap-[9px] py-1 pr-3 pl-[34px]">
-                        <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
-                          {e.label}
-                        </span>
-                        <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">
-                          {e.value}
-                        </span>
-                      </div>
-                    ))}
-                  </>
-                )}
+                {detailPanel}
               </div>
             </div>
           </div>
@@ -2770,63 +2759,66 @@ export default function SessionDetailView() {
           </div>
         )}
 
-        {/* MOBILE META STRIP — single-row 4-up, abbreviated labels tuned for 390px. */}
-        <div className="grid grid-cols-[repeat(4,1fr)] border-b border-(--border-subtle) bg-(--surface-card) desktop:hidden">
-          {metaCells.map((c, i) => (
-            <div
-              key={c.label}
-              className={`min-w-0 overflow-hidden px-3 py-[10px] ${i < 3 ? 'border-r border-(--border-subtle)' : ''}`}
+        {/* MOBILE HEADER ROW — the desktop meta row's shape at 390px: the owning
+          agent (tap-through), visibility, and everything numeric collapsed behind
+          the SAME Details popover. It replaces the old 4-up stat strip and the
+          daemon/runtime/model config line, both of which now live in the popover;
+          three stacked bands of chrome above the transcript were the phone's whole
+          first screen. Tap toggles (`tapped`) — there is no hover to lean on. */}
+        <div className="relative flex items-center gap-2 border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[9px] desktop:hidden">
+          {agentHref ? (
+            <Link
+              href={orgPath(agentHref)}
+              className="flex min-w-0 flex-1 items-center gap-[7px] no-underline"
+              aria-label={`Open ${session.agentName}`}
             >
-              <div className="font-sans text-[10px] font-medium uppercase leading-normal tracking-[.06em] text-(--text-tertiary)">
-                {c.label}
-              </div>
-              <div className="mt-[2px] truncate font-mono text-[13px] font-semibold leading-normal">{c.value}</div>
-            </div>
-          ))}
-        </div>
-
-        {/* MOBILE VISIBILITY ROW — the desktop header is `hidden desktop:flex`, so
-          the badge/toggle needs its own place in the mobile meta strip. */}
-        {visibilityControl && (
-          <div className="flex items-center gap-[10px] border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[10px] desktop:hidden">
-            {visibilityControl}
-          </div>
-        )}
-
-        {/* MOBILE AGENT CONFIG ROW — taps through to the owning agent. */}
-        {agentHref ? (
-          <Link
-            href={orgPath(agentHref)}
-            className="box-border flex w-full items-center gap-[10px] border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[10px] no-underline desktop:hidden"
+              <span className="av h-[22px] w-[22px] flex-none rounded-md">
+                <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={22} />
+              </span>
+              <span className="truncate font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                {session.agentName}
+              </span>
+              <Icon name="chevron-right" size={14} color="var(--text-tertiary)" className="flex-none" />
+            </Link>
+          ) : (
+            <span className="flex min-w-0 flex-1 items-center gap-[7px]">
+              <span className="av h-[22px] w-[22px] flex-none rounded-md">
+                <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={22} />
+              </span>
+              <span className="truncate font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                {session.agentName}
+              </span>
+            </span>
+          )}
+          {visibilityControl}
+          <button
+            type="button"
+            onClick={toggleDetailTap}
+            aria-expanded={detailOpen}
+            // Its own id: the desktop tooltip stays in the DOM (hidden by CSS, not
+            // unmounted), so sharing one would put a duplicate id on the page.
+            aria-controls={`${detailTooltipId}-mobile`}
+            className="inline-flex h-[26px] flex-none items-center gap-1 rounded-md border-0 bg-transparent px-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-secondary) active:bg-(--surface-active)"
           >
-            <span className="av h-8 w-8 flex-none rounded-md">
-              <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={32} />
-            </span>
-            <span className="flex min-w-0 flex-1 flex-col gap-[1px]">
-              <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                {session.agentName}
-              </span>
-              <span className="truncate font-mono text-[11px] font-normal leading-normal text-(--text-tertiary)">
-                {cfgLine}
-              </span>
-            </span>
-            <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="flex-none" />
-          </Link>
-        ) : (
-          <div className="flex items-center gap-[10px] border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[10px] desktop:hidden">
-            <span className="av h-8 w-8 flex-none rounded-md">
-              <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={32} />
-            </span>
-            <span className="flex min-w-0 flex-1 flex-col gap-[1px]">
-              <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                {session.agentName}
-              </span>
-              <span className="truncate font-mono text-[11px] font-normal leading-normal text-(--text-tertiary)">
-                {cfgLine}
-              </span>
-            </span>
-          </div>
-        )}
+            <Icon name="info" size={14} />
+            Details
+          </button>
+          {detailOpen && (
+            <>
+              {/* Tap-away close: a popover a phone cannot dismiss without hitting the
+                  same 26px trigger again is a trap. */}
+              <div className="fixed inset-0 z-40" onClick={closeDetailTap} aria-hidden="true" />
+              <div
+                id={`${detailTooltipId}-mobile`}
+                role="dialog"
+                aria-label="Session details"
+                className="absolute top-full right-4 z-50 max-h-[60vh] w-[min(280px,calc(100vw-32px))] overflow-auto rounded-[9px] border border-(--border-default) bg-(--surface-card) py-[5px] shadow-(--shadow-lg)"
+              >
+                {detailPanel}
+              </div>
+            </>
+          )}
+        </div>
 
         {conversationFamily ? (
           <MobileSessionFamilyLinks
@@ -2913,7 +2905,11 @@ export default function SessionDetailView() {
           turns + live tail. The column grows to fill the page (flex-1 inside the
           min-h-full wrap) so the flex-1 spacer below can pin the composer to the
           bottom even when the transcript is short. */}
-        <div className="flex flex-1 flex-col gap-4 p-4 desktop:gap-0 desktop:p-0">
+        {/* `max-desktop:pb-0` for the same reason as the wrap above: this column's
+          last child is the sticky composer, and a bottom gutter under it is a strip
+          the composer stops short of. (Longhand `pb-*` always sorts after shorthand
+          `p-*`, so the cancel wins — STYLE.md §8.) */}
+        <div className="flex flex-1 flex-col gap-4 p-4 max-desktop:pb-0 desktop:gap-0 desktop:p-0">
           {turns.length > 0 && (
             <div className="flex flex-col gap-4 desktop:gap-[15px]">
               {turns.map((turn, ti) =>
@@ -3494,6 +3490,25 @@ export default function SessionDetailView() {
           )}
         </div>
       </div>
+      <SessionRail
+        sessions={railSessions}
+        // The open row has to name its conversation and its members, because that
+        // is how the rail collapses it against the grouped list and how a pin
+        // finds it — matching on the session id alone would double the row (or
+        // lose its pin) whenever the two disagree on which member is newest.
+        // `selfKey` is the same §5.1 key computed for the redirect probe, so a
+        // single-participant thread is deduplicated on exactly the same terms, and
+        // the roster resolver is not agent-filtered, so its members are complete.
+        current={railCurrent ?? session}
+        total={railSessionTotal}
+        agentIds={railFilter.agentIds}
+        filterTouched={railFilter.touched}
+        onAgentIdsChange={setRailAgentIds}
+        family={conversationFamily ?? (currentSessionDetail?.id === session.id ? currentSessionDetail : undefined)}
+        conversation={conversationMode}
+        childOriginById={conversationLineage?.childOriginById}
+        onSelect={setRouteSession}
+      />
     </div>
   )
 }

--- a/packages/web/src/components/marks.test.tsx
+++ b/packages/web/src/components/marks.test.tsx
@@ -92,10 +92,27 @@ describe('PlatformMark', () => {
     expect(inset.match(/width:60%/g)).toHaveLength(1)
     expect(inset).toContain('<svg')
     expect(inset).not.toContain('<span')
-    expect(full).toContain('width:100%')
-    expect(full).toContain('height:100%')
+    // The full-bleed request is CAPPED at 80% for this mark — see the square-glyph
+    // note in PlatformMark. The style is still applied exactly once.
+    expect(full).toContain('width:80%')
+    expect(full).toContain('height:80%')
     expect(full).toContain('display:block')
     expect(full).not.toContain('width:60%')
+  })
+
+  it('caps the square brand glyphs at 80% while other marks honour a full-bleed box', () => {
+    // Slack / GitHub / Discord have no padding inside their artwork, so a
+    // fillPct=100 caller (the session rail rows) would draw them larger than the
+    // marks beside them. Slack is an Iconify mark, which renders an empty <span>
+    // until it hydrates, so only the react-icons pair is assertable from SSR.
+    for (const platform of ['github', 'discord']) {
+      const markup = renderToStaticMarkup(<PlatformMark platform={platform} fillPct={100} />)
+      expect(markup, platform).toContain('width:80%')
+      expect(markup, platform).not.toContain('width:100%')
+    }
+    // Below the cap nothing changes, and an uncapped mark still fills its box.
+    expect(renderToStaticMarkup(<PlatformMark platform="discord" fillPct={70} />)).toContain('width:70%')
+    expect(renderToStaticMarkup(<PlatformMark platform="telegram" fillPct={100} />)).toContain('width:100%')
   })
 
   it('uses the filled Lark brand asset for the shared Lark and Feishu platform family', () => {

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -209,8 +209,13 @@ export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fil
   // Marks render at 60% of their box to sit inside .av / .imark tiles; callers can override
   // fillPct — e.g. the Bots row fills a 14px box (fillPct=100) to match the design's full-bleed mark.
   const s = fillPct === 60 ? fill : ({ width: `${fillPct}%`, height: `${fillPct}%`, display: 'block' } as const)
+  // Slack / GitHub / Discord ship as full-bleed square glyphs with no internal
+  // padding of their own, so a caller asking for a full-bleed box (fillPct=100,
+  // e.g. the session rail rows) renders them visibly larger than every other mark
+  // beside them. Cap those three at 80% of the box.
+  const sq = fillPct > 80 ? ({ width: '80%', height: '80%', display: 'block' } as const) : s
   if (x.includes('github')) {
-    return <SiGithub style={s} color="currentColor" aria-hidden />
+    return <SiGithub style={sq} color="currentColor" aria-hidden />
   }
   if (x.includes('hook')) {
     return <IconifyIcon icon={webhooksLogoFillIcon} style={s} color="var(--brand)" aria-hidden />
@@ -249,13 +254,13 @@ export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fil
     return <SiTelegram style={s} color="#26A5E4" aria-hidden />
   }
   if (x.includes('disc')) {
-    return <SiDiscord style={s} color="#5865F2" aria-hidden />
+    return <SiDiscord style={sq} color="#5865F2" aria-hidden />
   }
   if (x.includes('feishu') || x.includes('lark')) {
     return <img src={LARK_MARK_SRC} alt="" style={s} className="object-contain" aria-hidden />
   }
   if (x.includes('slack')) {
-    return <IconifyIcon icon={slackIcon} style={s} aria-hidden />
+    return <IconifyIcon icon={slackIcon} style={sq} aria-hidden />
   }
   return (
     <span style={{ width: s.width, height: s.height }} className="flex items-center justify-center" aria-hidden>


### PR DESCRIPTION
## What

The session detail page becomes a **three-column layout — nav · body · session list** — with the list flush against the page's right edge instead of sitting between the nav and the transcript. It degrades in two steps: below 1240px (`wide:`) to a floating button with a hover popover, and at ≤768px to a trigger in the mobile app bar that taps open.

The mobile header region also stops being its own thing and mirrors the desktop one, and a long-standing composer gap on mobile is fixed along the way.

| Width | Session list |
| --- | --- |
| ≥1240px | inline column, fixed to the viewport's right edge |
| 769–1239px | floating top-right button, hover popover |
| ≤768px | app-bar icon, tap popover |

## Why

The list was competing with the nav on the left; on the right it reads as "what else is going on" rather than a second navigation. Everything else here fell out of making that work at every width.

## Notable decisions

- **The rail panel is `fixed`, not `sticky`.** Sticky inside `.content` is pushed down by that scroller's 34px top padding, so it could never sit flush with the page top. The in-flow div only reserves the 250px track.
- **New `MobileActionSlot` in `Shell.tsx`**, mirroring the existing `MobileFilterSlot`: a view registers one push-screen app-bar action. The rail's mobile trigger has to live in `.mtop` — a `fixed` overlay at the top-right would cover `.mtop-title` (the session name), which is `flex-1` all the way to the copy-link button.
- **The rail's mobile popover nodes sit at the fragment's top level deliberately.** A wrapper div there would be a flex *item* in the caller's `gap-[26px]` row and spend that gap as 26px of dead space on the transcript's right edge. Positioned children are out of flow, so they contribute no gap. There's a comment saying so.
- **Registration happens before the rail's empty early-return**, or hook order would depend on whether the rail found rows.
- **`wide:` (1240px) is a second breakpoint**, which `STYLE.md` otherwise forbids. It is scoped to this one layout and documented as such in both `STYLE.md` §7 and the `@theme` block.

## Mobile header → Details popover

The 4-up stat strip (Dur/Tokens/Cost/Tools) and the daemon·runtime·model config line are gone; everything numeric now sits behind the same **Details** popover the desktop header uses. One `detailPanel` definition feeds both triggers, so a fact cannot appear on one form factor and not the other. Nothing was dropped — those values were already in `headerFacts`.

Touch has no hover, so the popover state grew a `tapped` latch (Safari does not focus a button on tap) plus a tap-away scrim. The mobile dialog carries its own DOM id: the desktop tooltip is CSS-hidden, not unmounted, so sharing one would duplicate an id.

## Two fixes

- **Composer flush to the bottom (mobile).** The sticky composer stopped ~40px short of the screen edge at the end of the scroll. It cancels exactly `.content`'s bottom inset via a negative `bottom`, but two more bottom paddings sat below it — a wrap `pb-6` and the transcript column's `p-4` — and a sticky element cannot pass its own flow position. Both are now cancelled on mobile. The cancel is written as `max-desktop:pb-0` rather than splitting `p-4` into `px-4 pt-4`, because Tailwind sorts shorthand before longhand: `p-4` + `pb-0` wins reliably, while `px-4` would fight `desktop:p-0`.
- **`PlatformMark` caps Slack / GitHub / Discord at 80%** of their box. Those glyphs are full-bleed with no internal padding, so a `fillPct=100` caller (the new rail rows) drew them visibly larger than every other mark in the same row. Other marks are untouched.

## Reviewer notes

- Read-only sessions (no composer) lose ~40px of bottom breathing room on mobile — the last message now sits 24px + safe-area from the edge. Deliberate, but say so if it reads too tight.
- The Slack cap is not asserted from SSR: Iconify renders an empty `<span>` until it hydrates, so the new test covers GitHub and Discord and notes why Slack is excluded.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, and `pnpm --filter @agentconnect.md/web test` (93 files / 714 tests) all pass on this branch. Visual verification was done by the author in their own browser — the automated browser tooling in this environment could not reach a signed-in console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)