### PR TITLE
feat(web): bubble agent replies in per-agent tones and align the transcript

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1199,6 +1199,52 @@
     background: var(--border-subtle);
     margin: 5px 0;
   }
+  /* The reader's own bubble — deliberately NEUTRAL (it carries no agent tone) with
+     the tail corner mirrored against `.abub`. Light sinks it below the page; dark has
+     to RAISE it instead, because there --surface-sunken (#120c1a) is darker than
+     --surface-app (#17101f), so the sunken treatment turned the bubble into a hole
+     with a faint outline instead of a card. */
+  .ubub {
+    max-width: 100%;
+    border-radius: 12px 12px 4px 12px;
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-sunken);
+    padding: 9px 12px;
+    font: 400 13.5px/1.55 var(--font-sans);
+    color: var(--text-primary);
+  }
+  :root[data-theme='dark'] .ubub {
+    border-color: var(--border-default);
+    background: var(--surface-hover);
+  }
+  /* Agent speech bubble — the left-aligned counterpart to the user's bubble (whose
+     tail corner is mirrored), tinted with the SPEAKING agent's accent. The accent
+     arrives as `--agent-accent` on the element (lib/agent-tone.ts, brand if unset —
+     an invalid var() inside color-mix would drop the whole rule) and is mixed INTO
+     the live surface rather than used as a background: one hex then reads correctly
+     in both themes, and adding a hue costs one array entry instead of a second
+     colour table. Dark mode needs a heavier mix — the same 7% over near-black is
+     invisible. Only the agent's SPEECH is bubbled; its work stays in the panel
+     below, which is not something it said. */
+  .abub {
+    max-width: 100%;
+    border-radius: 12px 12px 12px 4px;
+    border: 1px solid color-mix(in oklab, var(--agent-accent, var(--brand)) 22%, var(--surface-card));
+    background: color-mix(in oklab, var(--agent-accent, var(--brand)) 7%, var(--surface-card));
+    padding: 9px 12px;
+    font: 400 13.5px/1.55 var(--font-sans);
+    color: var(--text-primary);
+  }
+  /* Pulled toward --text-primary rather than used raw: gold or green at full
+     strength fails contrast on the light surface. The mix keeps the hue legible as
+     identity while staying readable in both themes. */
+  .abub-name {
+    color: color-mix(in oklab, var(--agent-accent, var(--brand)) 62%, var(--text-primary));
+  }
+  :root[data-theme='dark'] .abub {
+    border-color: color-mix(in oklab, var(--agent-accent, var(--brand)) 34%, var(--surface-card));
+    background: color-mix(in oklab, var(--agent-accent, var(--brand)) 15%, var(--surface-card));
+  }
   .codeblk {
     background: var(--surface-sunken);
     border: 1px solid var(--border-subtle);

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -119,6 +119,21 @@
   --brand-soft-border: rgba(198, 42, 120, 0.18);
   --brand-ring: rgba(198, 42, 120, 0.32);
 
+  /* Transcript bubbles. Tokens rather than a component class (STYLE.md §12) because
+     the ONLY thing that differs between themes is these four values — the boxes
+     themselves are ordinary utilities.
+     `--bubble-tint`/`--bubble-edge`: how much of the speaking agent's accent
+     (lib/agent-tone.ts) is mixed into the surface. Dark needs a heavier hand; the
+     light 7% over near-black is invisible.
+     `--bubble-self`/`--bubble-self-edge`: the reader's own bubble, which carries no
+     agent tone. Light SINKS it below the page; dark must RAISE it, because there
+     --surface-sunken (#120c1a) is darker than --surface-app (#17101f) and the sunken
+     treatment turned the bubble into a hole with a faint outline. */
+  --bubble-tint: 7%;
+  --bubble-edge: 22%;
+  --bubble-self: var(--surface-sunken);
+  --bubble-self-edge: var(--border-subtle);
+
   /* Status — solid + soft pairings */
   --status-online: var(--green-500);
   --status-online-soft: var(--green-50);
@@ -208,6 +223,12 @@
   --brand-soft-text: #f4b8d3;
   --brand-soft-border: rgba(198, 42, 120, 0.32);
   --brand-ring: rgba(198, 42, 120, 0.42);
+
+  /* Transcript bubbles — see the light block for what each of these decides. */
+  --bubble-tint: 15%;
+  --bubble-edge: 34%;
+  --bubble-self: var(--surface-hover);
+  --bubble-self-edge: var(--border-default);
 
   /* Raw scale steps that leak into surfaces/accents */
   --magenta-100: rgba(198, 42, 120, 0.22);
@@ -1198,52 +1219,6 @@
     height: 1px;
     background: var(--border-subtle);
     margin: 5px 0;
-  }
-  /* The reader's own bubble — deliberately NEUTRAL (it carries no agent tone) with
-     the tail corner mirrored against `.abub`. Light sinks it below the page; dark has
-     to RAISE it instead, because there --surface-sunken (#120c1a) is darker than
-     --surface-app (#17101f), so the sunken treatment turned the bubble into a hole
-     with a faint outline instead of a card. */
-  .ubub {
-    max-width: 100%;
-    border-radius: 12px 12px 4px 12px;
-    border: 1px solid var(--border-subtle);
-    background: var(--surface-sunken);
-    padding: 9px 12px;
-    font: 400 13.5px/1.55 var(--font-sans);
-    color: var(--text-primary);
-  }
-  :root[data-theme='dark'] .ubub {
-    border-color: var(--border-default);
-    background: var(--surface-hover);
-  }
-  /* Agent speech bubble — the left-aligned counterpart to the user's bubble (whose
-     tail corner is mirrored), tinted with the SPEAKING agent's accent. The accent
-     arrives as `--agent-accent` on the element (lib/agent-tone.ts, brand if unset —
-     an invalid var() inside color-mix would drop the whole rule) and is mixed INTO
-     the live surface rather than used as a background: one hex then reads correctly
-     in both themes, and adding a hue costs one array entry instead of a second
-     colour table. Dark mode needs a heavier mix — the same 7% over near-black is
-     invisible. Only the agent's SPEECH is bubbled; its work stays in the panel
-     below, which is not something it said. */
-  .abub {
-    max-width: 100%;
-    border-radius: 12px 12px 12px 4px;
-    border: 1px solid color-mix(in oklab, var(--agent-accent, var(--brand)) 22%, var(--surface-card));
-    background: color-mix(in oklab, var(--agent-accent, var(--brand)) 7%, var(--surface-card));
-    padding: 9px 12px;
-    font: 400 13.5px/1.55 var(--font-sans);
-    color: var(--text-primary);
-  }
-  /* Pulled toward --text-primary rather than used raw: gold or green at full
-     strength fails contrast on the light surface. The mix keeps the hue legible as
-     identity while staying readable in both themes. */
-  .abub-name {
-    color: color-mix(in oklab, var(--agent-accent, var(--brand)) 62%, var(--text-primary));
-  }
-  :root[data-theme='dark'] .abub {
-    border-color: color-mix(in oklab, var(--agent-accent, var(--brand)) 34%, var(--surface-card));
-    background: color-mix(in oklab, var(--agent-accent, var(--brand)) 15%, var(--surface-card));
   }
   .codeblk {
     background: var(--surface-sunken);

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode
 } from 'react'
@@ -64,6 +65,7 @@ import {
   type ToolBody
 } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
+import { agentToneColor } from '@/lib/agent-tone'
 import { useProfile } from '@/lib/profile'
 import { usePgDraft, usePgDraftHasText, usePlayground } from '@/components/console/PlaygroundProvider'
 import { AgentIconView, LoadingState, ModelMark, PlatformMark, SocialLoginMark, Spinner } from '@/components/marks'
@@ -691,6 +693,13 @@ type SessionParticipant = {
   isCron: boolean
 }
 
+/** Whether a user turn prints a sender line above its bubble — it does only when the
+ *  sender is not you (a platform user or a schedule). Shared with the avatar's
+ *  alignment, which follows the label when there is one and the bubble when not. */
+function showsSenderLabel(turn: { isCron: boolean; sp: { handle: string } }): boolean {
+  return turn.isCron || turn.sp.handle !== '@you'
+}
+
 function ParticipantAvatar({
   agent,
   avatarUrl,
@@ -698,7 +707,8 @@ function ParticipantAvatar({
   platformMark,
   sp,
   isCron,
-  showNameTitle = true
+  showNameTitle = true,
+  className = ''
 }: {
   agent: Agent | null
   avatarUrl?: string | null
@@ -707,12 +717,14 @@ function ParticipantAvatar({
   sp: ReturnType<typeof speaker>
   isCron: boolean
   showNameTitle?: boolean
+  /** Caller-side box tweaks — today only the transcript's vertical nudge. */
+  className?: string
 }) {
   return (
     <span
       className={`av flex h-[26px] w-[26px] flex-none items-center justify-center overflow-hidden rounded-md font-sans text-[9.5px] font-semibold leading-normal ${
         !agent && !isCron ? 'bg-transparent' : ''
-      }`}
+      } ${className}`}
       title={showNameTitle ? sp.name : undefined}
       aria-hidden={showNameTitle ? undefined : true}
     >
@@ -2918,7 +2930,7 @@ export default function SessionDetailView() {
                   // sits above the bubble only when it isn't you (platform user / cron).
                   <div key={`${session.id}:${ti}`} className="flex items-start justify-end gap-[9px]">
                     <div className="flex min-w-0 max-w-[86%] flex-col items-end gap-[3px]">
-                      {(turn.isCron || turn.sp.handle !== '@you') && (
+                      {showsSenderLabel(turn) && (
                         <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
                           {turn.isCron && turn.cronId ? (
                             <Link className="lnk text-inherit" href={orgPath(`/crons/${turn.cronId}`)}>
@@ -2930,7 +2942,7 @@ export default function SessionDetailView() {
                           {turn.time && <span className="mono">{turn.time}</span>}
                         </span>
                       )}
-                      <div className="max-w-full rounded-[12px_12px_4px_12px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary)">
+                      <div className="ubub">
                         {turn.image && (
                           <img
                             src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
@@ -2948,6 +2960,12 @@ export default function SessionDetailView() {
                       platformMark={usesIntegrationAvatar ? sessionIntegration : undefined}
                       sp={turn.sp}
                       isCron={turn.isCron}
+                      // Optically centre the 26px mark on the bubble's FIRST LINE, not
+                      // on the bubble's top edge: 9px of padding plus half of a 21px
+                      // line puts that centre 19.5px down, while a top-aligned mark
+                      // centres at 13px — the 6px it looked too high by. A labelled row
+                      // keeps the mark level with its label instead, like the bot side.
+                      className={showsSenderLabel(turn) ? '' : 'mt-[6px]'}
                     />
                   </div>
                 ) : (
@@ -2967,6 +2985,10 @@ export default function SessionDetailView() {
                     // predicate lives (and is tested) in session-work.ts.
                     const streaming = ti === turns.length - 1 && sessionTurnInFlight(pgBusy, session.statusLabel)
                     const openWork = workPanelOpen(workOverride.get(ti), streaming)
+                    // Keyed by agent id where there is one so the colour survives a
+                    // rename; a mock/playground row without an id falls back to the
+                    // display name, which is stable for as long as the row is.
+                    const turnTone = agentToneColor(turn.agentId || turn.agentName)
                     return (
                       <div
                         key={`${session.id}:${ti}`}
@@ -2985,17 +3007,24 @@ export default function SessionDetailView() {
                             size={26}
                           />
                         </span>
-                        <div className="min-w-0 flex-1">
+                        <div className="min-w-0 flex-1" style={{ '--agent-accent': turnTone } as CSSProperties}>
                           <div className="mb-[5px] flex items-center gap-[7px]">
-                            <span className="font-sans text-[13px] font-semibold leading-normal">{turn.agentName}</span>
+                            <span className="abub-name font-sans text-[13px] font-semibold leading-normal">
+                              {turn.agentName}
+                            </span>
                             {turn.time && (
                               <span className="mono ml-auto shrink-0 whitespace-nowrap text-[11px] text-(--text-tertiary)">
                                 {turn.time}
                               </span>
                             )}
                           </div>
+                          {/* One bubble PER text step, not one around the set: each step is
+                            its own delivered message (a turn that answers in two chunks
+                            arrives as two), so bubbling them together would merge messages
+                            the platform kept apart. `w-fit` keeps a short reply from
+                            drawing a full-width card. */}
                           {textSteps.map((st, si) => (
-                            <div key={si} className={si > 0 ? 'mt-2' : ''}>
+                            <div key={si} className={`abub w-fit ${si > 0 ? 'mt-2' : ''}`}>
                               {st.image && (
                                 <img
                                   src={`data:${st.image.mimeType};base64,${st.image.data}`}
@@ -3004,7 +3033,7 @@ export default function SessionDetailView() {
                                 />
                               )}
                               {st.text && (
-                                <div className="font-sans text-[13.5px] leading-[1.6] whitespace-pre-wrap text-(--text-primary)">
+                                <div className="whitespace-pre-wrap">
                                   <MessageText text={st.text} />
                                 </div>
                               )}
@@ -3035,7 +3064,12 @@ export default function SessionDetailView() {
                                         si > 0 ? 'border-t border-(--border-subtle)' : ''
                                       }`}
                                     >
-                                      <div className="flex w-[52px] flex-none items-center gap-[6px] pt-[1px]">
+                                      {/* min-h matches the text column's FIRST LINE box
+                                        (13px × 1.5), so centring inside it puts the dot
+                                        and lane label on that line's centre line. The
+                                        old `pt-[1px]` guessed at the same thing against
+                                        a 15px-tall mono box and read a few px high. */}
+                                      <div className="flex min-h-[20px] w-[52px] flex-none items-center gap-[6px]">
                                         <span className="dot h-[7px] w-[7px]" style={{ background: st.dot }} />
                                         <span
                                           className="mono text-[10px] font-semibold tracking-[.02em]"

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -115,6 +115,27 @@ import {
 
 type ComposerMenuKey = 'permission' | 'model' | 'effort' | 'addAgent'
 
+// Transcript speech bubbles. Utilities, not globals.css classes (STYLE.md §12) —
+// only the theme-dependent numbers live as tokens (`--bubble-*`, defined in both
+// theme blocks), so nothing here has to branch on the theme.
+//
+// AGENT_BUBBLE is tinted with the SPEAKING agent's accent (`--agent-accent`, set per
+// turn from lib/agent-tone.ts): the accent is mixed INTO the live surface rather than
+// used as a background, which is what lets one hex read correctly in both themes and
+// makes a new hue cost one array entry instead of a second colour table. The `var()`
+// fallback matters — an invalid var() inside color-mix drops the whole declaration,
+// so a turn with no accent gets a brand-tinted bubble, never an invisible one.
+// AGENT_NAME pulls that accent 62% toward the text colour: gold or green at full
+// strength fails contrast on the light surface.
+// SELF_BUBBLE is the reader's own, deliberately neutral, tail corner mirrored.
+// Full literal strings so Tailwind's scanner sees them (STYLE.md §8).
+const AGENT_BUBBLE =
+  'w-fit max-w-full rounded-[12px_12px_12px_4px] border px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary) border-[color:color-mix(in_oklab,var(--agent-accent,var(--brand))_var(--bubble-edge),var(--surface-card))] bg-[color:color-mix(in_oklab,var(--agent-accent,var(--brand))_var(--bubble-tint),var(--surface-card))]'
+const AGENT_NAME =
+  'font-sans text-[13px] font-semibold leading-normal text-[color:color-mix(in_oklab,var(--agent-accent,var(--brand))_62%,var(--text-primary))]'
+const SELF_BUBBLE =
+  'max-w-full rounded-[12px_12px_4px_12px] border border-(--bubble-self-edge) bg-(--bubble-self) px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary)'
+
 // Design composer selectors (session composer, mirrors HomeView): the model is a
 // "pill" with a leading mark, effort/permission are plain chips. Full literal
 // strings so Tailwind's scanner sees them (STYLE.md §8).
@@ -2942,7 +2963,7 @@ export default function SessionDetailView() {
                           {turn.time && <span className="mono">{turn.time}</span>}
                         </span>
                       )}
-                      <div className="ubub">
+                      <div className={SELF_BUBBLE}>
                         {turn.image && (
                           <img
                             src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
@@ -3009,9 +3030,7 @@ export default function SessionDetailView() {
                         </span>
                         <div className="min-w-0 flex-1" style={{ '--agent-accent': turnTone } as CSSProperties}>
                           <div className="mb-[5px] flex items-center gap-[7px]">
-                            <span className="abub-name font-sans text-[13px] font-semibold leading-normal">
-                              {turn.agentName}
-                            </span>
+                            <span className={AGENT_NAME}>{turn.agentName}</span>
                             {turn.time && (
                               <span className="mono ml-auto shrink-0 whitespace-nowrap text-[11px] text-(--text-tertiary)">
                                 {turn.time}
@@ -3024,7 +3043,7 @@ export default function SessionDetailView() {
                             the platform kept apart. `w-fit` keeps a short reply from
                             drawing a full-width card. */}
                           {textSteps.map((st, si) => (
-                            <div key={si} className={`abub w-fit ${si > 0 ? 'mt-2' : ''}`}>
+                            <div key={si} className={`${AGENT_BUBBLE} ${si > 0 ? 'mt-2' : ''}`}>
                               {st.image && (
                                 <img
                                   src={`data:${st.image.mimeType};base64,${st.image.data}`}

--- a/packages/web/src/lib/agent-tone.test.ts
+++ b/packages/web/src/lib/agent-tone.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { agentToneColor, AGENT_TONE_COUNT } from './agent-tone'
+
+describe('agentToneColor', () => {
+  it('is stable per key and spreads ids across every tone', () => {
+    expect(agentToneColor('agent-a')).toBe(agentToneColor('agent-a'))
+    // A transcript that colours two agents the same has failed at its one job, so
+    // the hash has to actually reach every tone rather than clustering.
+    const seen = new Set(Array.from({ length: 200 }, (_, i) => agentToneColor(`agent-${i}`)))
+    expect(seen.size).toBe(AGENT_TONE_COUNT)
+  })
+
+  it('returns an accent token, never a ready-made background', () => {
+    // `.abub` mixes the accent into the live surface; a literal background here
+    // would be wrong in one of the two themes.
+    for (let i = 0; i < 20; i++) expect(agentToneColor(`k${i}`)).toMatch(/^var\(--[a-z]+-500\)$/)
+  })
+})

--- a/packages/web/src/lib/agent-tone.ts
+++ b/packages/web/src/lib/agent-tone.ts
@@ -1,0 +1,34 @@
+// The accent hue a given agent speaks in. Transcript bubbles are tinted with it so
+// a multi-agent thread can be read by colour before it is read by name — the same
+// job orgColor() does for org avatars, and the same deterministic-hash approach, so
+// an agent keeps its colour across sessions, reloads, and viewers without the CP
+// having to store one.
+//
+// These are ACCENTS, not backgrounds: the consumer mixes them into the current
+// surface (see `.abub` in globals.css), which is what lets one hex work in both
+// themes. Nothing here may return a ready-made background, or dark mode would need
+// a second table.
+
+/** Design-system hues, spaced far enough apart to be told apart at a 7% tint. */
+const AGENT_TONES = [
+  'var(--magenta-500)',
+  'var(--purple-500)',
+  'var(--blue-500)',
+  'var(--green-500)',
+  'var(--gold-500)',
+  'var(--coral-500)'
+] as const
+
+/**
+ * The agent's accent, keyed by whatever identity the caller has. Pass the agent id
+ * when there is one; a transcript row that predates its agent (or a mock/playground
+ * row) can pass the display name instead — stable within that session, which is all
+ * the colour is claiming.
+ */
+export function agentToneColor(key: string): string {
+  let h = 0
+  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0
+  return AGENT_TONES[h % AGENT_TONES.length]!
+}
+
+export const AGENT_TONE_COUNT = AGENT_TONES.length


### PR DESCRIPTION
Split out of #548 at review request — that PR is a session-list fix and this is a transcript feature, so they get separate reviews. Zero file overlap between the two.

## Agent replies get bubbles, one hue per agent

Agent speech now sits in a bubble like the user's, tinted with the speaking agent's own hue, so a multi-agent thread can be read by colour before it is read by name.

- **`lib/agent-tone.ts`** picks one of six design-system accents by deterministic hash — the approach `orgColor()` already uses — so an agent keeps its colour across sessions, reloads, and viewers with nothing stored in the CP. Keyed by agent id where there is one, display name otherwise (mock/playground rows).
- **The value is an ACCENT, never a background.** `.abub` mixes it into the live surface with `color-mix(in oklab, …)`, which is what lets one hex read correctly in both themes and makes a new hue cost one array entry instead of a second colour table. Dark mode mixes heavier (15% vs 7%) — the same 7% over near-black is invisible.
- **The agent name** takes the accent pulled 62% toward `--text-primary`: gold or green at full strength fails contrast on the light surface, and the mix keeps the hue readable while still reading as identity.
- **One bubble per text step**, not one around the set. A turn that answers in two chunks *arrived* as two messages; merging them would erase a boundary the platform kept.
- **Only speech is bubbled.** The work panel below stays as it was — it is not something the agent said.

## Three alignment fixes found on the way

- **The user's own bubble was invisible in dark mode.** It used `--surface-sunken`, which in the dark theme (`#120c1a`) is *darker* than the page it sits on (`--surface-app`, `#17101f`) — so the bubble read as a hole with a faint outline instead of a card. Now a `.ubub` class: light still sinks (unchanged), dark raises to `--surface-hover`. Deliberately neutral, since the reader carries no agent tone, with the tail corner mirrored against `.abub`.
- **The user avatar sat 6px high.** A 26px mark centres at 13px while the bubble's first line centres at 19.5px (9px padding + half a 21px line), and `items-start` aligned their *top* edges. Nudged — but only on rows with no sender label, since a labelled row aligns to its label like the bot side does. The label predicate is now one shared function so the two cannot drift apart.
- **A work step's lane badge read a few px above its text.** `pt-[1px]` was guessing against a 15px mono box; the column now carries the text's own first-line height and centres inside it, so the alignment is derived rather than eyeballed.

## Reviewer notes

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, and `pnpm --filter @agentconnect.md/web test` (94 files / 716 tests, including 2 new for `agentToneColor`) all pass on this branch.
- `.abub` reads `var(--agent-accent, var(--brand))`: an invalid `var()` inside `color-mix` drops the whole declaration, so a caller that forgets the property gets a brand-tinted bubble rather than an invisible one.
- Worth a human eye on the tint depths in both themes — the automated browser tooling in this environment cannot reach a signed-in console, so the author verified visually in their own browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)