### PR TITLE
docs(design): messaging primitives — counter-proposal to the sendMessage rework

### DIFF
--- a/docs/designs/messaging-primitives-games.svg
+++ b/docs/designs/messaging-primitives-games.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="680" height="442" viewBox="0 0 680 442" role="img">
+  <title>Arena games as primitive compositions</title>
+  <desc>Top: the counting chain — after the referee's opening Post, agents wake each other by mentioning the next player, each activation charging the room budget, with no depth ceiling. Bottom: werewolf — the all-members day conversation and the wolves-only night conversation are two ordinary Conversations; roles and night orders are session-only Posts with no platform projection.</desc>
+  <style>
+    text { font-family: -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
+    .th { font-size: 14px; font-weight: 500; }
+    .ts { font-size: 12px; font-weight: 400; }
+  </style>
+  <defs>
+    <marker id="arrP2" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#7F77DD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+  <rect x="0" y="0" width="680" height="442" fill="#FFFFFF"/>
+  <g>
+    <rect x="40" y="50" width="140" height="52" rx="4" fill="#EEEDFE" stroke="#534AB7"/>
+    <text class="th" x="110" y="71" text-anchor="middle" fill="#3C3489">Referee opens</text>
+    <text class="ts" x="110" y="89" text-anchor="middle" fill="#534AB7">budget provisioned</text>
+  </g>
+  <g>
+    <rect x="192" y="50" width="140" height="52" rx="4" fill="#F1EFE8" stroke="#5F5E5A"/>
+    <text class="th" x="262" y="71" text-anchor="middle" fill="#2C2C2A">a: "3 @b"</text>
+    <text class="ts" x="262" y="89" text-anchor="middle" fill="#5F5E5A">wakes b · costs 1</text>
+  </g>
+  <g>
+    <rect x="344" y="50" width="140" height="52" rx="4" fill="#F1EFE8" stroke="#5F5E5A"/>
+    <text class="th" x="414" y="71" text-anchor="middle" fill="#2C2C2A">b: "4 @c"</text>
+    <text class="ts" x="414" y="89" text-anchor="middle" fill="#5F5E5A">wakes c · costs 1</text>
+  </g>
+  <g>
+    <rect x="496" y="50" width="140" height="52" rx="4" fill="#F1EFE8" stroke="#5F5E5A"/>
+    <text class="th" x="566" y="71" text-anchor="middle" fill="#2C2C2A">c: "5 @a"</text>
+    <text class="ts" x="566" y="89" text-anchor="middle" fill="#5F5E5A">no depth ceiling</text>
+  </g>
+  <line x1="180" y1="76" x2="188" y2="76" stroke="#7F77DD" stroke-width="1.5" marker-end="url(#arrP2)"/>
+  <line x1="332" y1="76" x2="340" y2="76" stroke="#7F77DD" stroke-width="1.5" marker-end="url(#arrP2)"/>
+  <line x1="484" y1="76" x2="492" y2="76" stroke="#7F77DD" stroke-width="1.5" marker-end="url(#arrP2)"/>
+  <rect x="40" y="150" width="280" height="150" rx="8" fill="none" stroke="#B4B2A9" stroke-dasharray="4 3"/>
+  <text class="th" x="180" y="174" text-anchor="middle" fill="#2C2C2A">Day conversation (all)</text>
+  <rect x="54" y="192" width="76" height="26" rx="4" fill="#EEEDFE" stroke="#534AB7"/>
+  <text class="ts" x="92" y="209" text-anchor="middle" fill="#3C3489">referee</text>
+  <rect x="142" y="192" width="76" height="26" rx="4" fill="#F1EFE8" stroke="#5F5E5A"/>
+  <text class="ts" x="180" y="209" text-anchor="middle" fill="#2C2C2A">villager a</text>
+  <rect x="230" y="192" width="76" height="26" rx="4" fill="#F1EFE8" stroke="#5F5E5A"/>
+  <text class="ts" x="268" y="209" text-anchor="middle" fill="#2C2C2A">villager b</text>
+  <rect x="54" y="230" width="76" height="26" rx="4" fill="#F1EFE8" stroke="#5F5E5A"/>
+  <text class="ts" x="92" y="247" text-anchor="middle" fill="#2C2C2A">villager c</text>
+  <rect x="142" y="230" width="76" height="26" rx="4" fill="#FAECE7" stroke="#993C1D"/>
+  <text class="ts" x="180" y="247" text-anchor="middle" fill="#4A1B0C">wolf d</text>
+  <rect x="230" y="230" width="76" height="26" rx="4" fill="#FAECE7" stroke="#993C1D"/>
+  <text class="ts" x="268" y="247" text-anchor="middle" fill="#4A1B0C">wolf e</text>
+  <text class="ts" x="180" y="284" text-anchor="middle" fill="#5F5E5A">public speech · open @s</text>
+  <rect x="360" y="150" width="280" height="150" rx="8" fill="none" stroke="#B4B2A9" stroke-dasharray="4 3"/>
+  <text class="th" x="500" y="174" text-anchor="middle" fill="#2C2C2A">Night wolf conversation</text>
+  <rect x="374" y="192" width="76" height="26" rx="4" fill="#EEEDFE" stroke="#534AB7"/>
+  <text class="ts" x="412" y="209" text-anchor="middle" fill="#3C3489">referee</text>
+  <rect x="462" y="192" width="76" height="26" rx="4" fill="#FAECE7" stroke="#993C1D"/>
+  <text class="ts" x="500" y="209" text-anchor="middle" fill="#4A1B0C">wolf d</text>
+  <rect x="550" y="192" width="76" height="26" rx="4" fill="#FAECE7" stroke="#993C1D"/>
+  <text class="ts" x="588" y="209" text-anchor="middle" fill="#4A1B0C">wolf e</text>
+  <text class="ts" x="500" y="250" text-anchor="middle" fill="#5F5E5A">not a member = cannot see</text>
+  <text class="ts" x="500" y="284" text-anchor="middle" fill="#5F5E5A">just another Conversation</text>
+  <g>
+    <rect x="190" y="330" width="300" height="52" rx="4" fill="#EEEDFE" stroke="#534AB7"/>
+    <text class="th" x="340" y="351" text-anchor="middle" fill="#3C3489">Roles &amp; night orders</text>
+    <text class="ts" x="340" y="369" text-anchor="middle" fill="#534AB7">session-only Post · no projection</text>
+  </g>
+  <rect x="40" y="408" width="14" height="14" rx="3" fill="#FAECE7" stroke="#993C1D"/>
+  <text class="ts" x="62" y="419" fill="#444441">wolves</text>
+  <rect x="150" y="408" width="14" height="14" rx="3" fill="#F1EFE8" stroke="#5F5E5A"/>
+  <text class="ts" x="172" y="419" fill="#444441">villagers</text>
+  <rect x="260" y="408" width="14" height="14" rx="3" fill="#EEEDFE" stroke="#534AB7"/>
+  <text class="ts" x="282" y="419" fill="#444441">referee / trusted plane</text>
+</svg>

--- a/docs/designs/messaging-primitives-mechanism.svg
+++ b/docs/designs/messaging-primitives-mechanism.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="680" height="410" viewBox="0 0 680 410" role="img">
+  <title>Messaging primitives mechanism</title>
+  <desc>A finalized agent reply becomes a Post envelope; activation travels the trusted plane into the activation ladder, waking the target agent exactly once and charging the conversation budget. The visible platform message is a projection whose echo is transcript-only and never activates anyone. Human messages enter the same activation ladder via the platform.</desc>
+  <style>
+    text { font-family: -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
+    .th { font-size: 14px; font-weight: 500; }
+    .ts { font-size: 12px; font-weight: 400; }
+  </style>
+  <defs>
+    <marker id="arrG" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#888780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="arrP" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#7F77DD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="arrT" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#5DCAA5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="arrA" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#BA7517" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+  <rect x="0" y="0" width="680" height="410" fill="#FFFFFF"/>
+  <g>
+    <rect x="40" y="50" width="180" height="52" rx="4" fill="#F1EFE8" stroke="#5F5E5A"/>
+    <text class="th" x="130" y="71" text-anchor="middle" fill="#2C2C2A">Finalized reply</text>
+    <text class="ts" x="130" y="89" text-anchor="middle" fill="#5F5E5A">@ in text or tool args</text>
+  </g>
+  <g>
+    <rect x="250" y="50" width="180" height="52" rx="4" fill="#EEEDFE" stroke="#534AB7"/>
+    <text class="th" x="340" y="71" text-anchor="middle" fill="#3C3489">Post envelope</text>
+    <text class="ts" x="340" y="89" text-anchor="middle" fill="#534AB7">who · where · visibility</text>
+  </g>
+  <g>
+    <rect x="460" y="50" width="180" height="52" rx="4" fill="#E1F5EE" stroke="#0F6E56"/>
+    <text class="th" x="550" y="71" text-anchor="middle" fill="#085041">Platform message</text>
+    <text class="ts" x="550" y="89" text-anchor="middle" fill="#0F6E56">absent when session-only</text>
+  </g>
+  <line x1="220" y1="76" x2="246" y2="76" stroke="#888780" stroke-width="1.5" marker-end="url(#arrG)"/>
+  <line x1="430" y1="76" x2="456" y2="76" stroke="#888780" stroke-width="1.5" marker-end="url(#arrG)"/>
+  <line x1="340" y1="102" x2="340" y2="166" stroke="#7F77DD" stroke-width="1.5" marker-end="url(#arrP)"/>
+  <text class="ts" x="350" y="138" fill="#534AB7">trusted plane</text>
+  <line x1="550" y1="102" x2="550" y2="166" stroke="#5DCAA5" stroke-width="1.5" marker-end="url(#arrT)"/>
+  <text class="ts" x="560" y="138" fill="#0F6E56">echo</text>
+  <g>
+    <rect x="40" y="170" width="180" height="52" rx="4" fill="#F1EFE8" stroke="#5F5E5A"/>
+    <text class="th" x="130" y="191" text-anchor="middle" fill="#2C2C2A">Human message</text>
+    <text class="ts" x="130" y="209" text-anchor="middle" fill="#5F5E5A">enters via platform</text>
+  </g>
+  <g>
+    <rect x="250" y="170" width="180" height="52" rx="4" fill="#EEEDFE" stroke="#534AB7"/>
+    <text class="th" x="340" y="191" text-anchor="middle" fill="#3C3489">Activation ladder</text>
+    <text class="ts" x="340" y="209" text-anchor="middle" fill="#534AB7">one routing function</text>
+  </g>
+  <g>
+    <rect x="460" y="170" width="180" height="52" rx="4" fill="#E1F5EE" stroke="#0F6E56"/>
+    <text class="th" x="550" y="191" text-anchor="middle" fill="#085041">Echo → transcript</text>
+    <text class="ts" x="550" y="209" text-anchor="middle" fill="#0F6E56">never activates anyone</text>
+  </g>
+  <line x1="220" y1="196" x2="246" y2="196" stroke="#888780" stroke-width="1.5" marker-end="url(#arrG)"/>
+  <line x1="340" y1="222" x2="340" y2="286" stroke="#7F77DD" stroke-width="1.5" marker-end="url(#arrP)"/>
+  <line x1="285" y1="222" x2="155" y2="286" stroke="#BA7517" stroke-width="1.5" marker-end="url(#arrA)"/>
+  <g>
+    <rect x="40" y="290" width="210" height="52" rx="4" fill="#FAEEDA" stroke="#854F0B"/>
+    <text class="th" x="145" y="311" text-anchor="middle" fill="#633806">Conversation budget</text>
+    <text class="ts" x="145" y="329" text-anchor="middle" fill="#854F0B">wakes drain, humans refill</text>
+  </g>
+  <g>
+    <rect x="270" y="290" width="210" height="52" rx="4" fill="#EEEDFE" stroke="#534AB7"/>
+    <text class="th" x="375" y="311" text-anchor="middle" fill="#3C3489">Target agent wakes</text>
+    <text class="ts" x="375" y="329" text-anchor="middle" fill="#534AB7">exactly once, idempotent</text>
+  </g>
+  <rect x="40" y="372" width="14" height="14" rx="3" fill="#EEEDFE" stroke="#534AB7"/>
+  <text class="ts" x="62" y="383" fill="#444441">trusted plane (internal)</text>
+  <rect x="250" y="372" width="14" height="14" rx="3" fill="#E1F5EE" stroke="#0F6E56"/>
+  <text class="ts" x="272" y="383" fill="#444441">platform projection (display)</text>
+  <rect x="470" y="372" width="14" height="14" rx="3" fill="#FAEEDA" stroke="#854F0B"/>
+  <text class="ts" x="492" y="383" fill="#444441">budget (loop protection)</text>
+</svg>

--- a/docs/designs/messaging-primitives.md
+++ b/docs/designs/messaging-primitives.md
@@ -56,6 +56,8 @@ category.
 
 Five concepts, each owning exactly one dimension.
 
+![One Post; the trusted plane carries activation into one routing ladder charging the conversation budget; the platform message is a projection whose echo never activates](messaging-primitives-mechanism.svg)
+
 ### 2.1 Conversation
 
 The unit of exchange. A platform thread, a DM, and an agent session transcript
@@ -260,6 +262,8 @@ never activate itself; a human mention in the body lifts to a user address →
 no agent activation.
 
 ### The arena games
+
+![The counting chain as mention-driven activations charging a provisioned room budget; werewolf day and night rooms as two ordinary Conversations with role delivery as session-only Posts](messaging-primitives-games.svg)
 
 - The peer-driven counting stall (agents' bare numbers wake nobody) reproduces
   identically: bare numbers lift no addresses → transcript-only. The game

--- a/docs/designs/messaging-primitives.md
+++ b/docs/designs/messaging-primitives.md
@@ -1,0 +1,357 @@
+# Messaging Primitives
+
+**Status:** Proposed counter-proposal, for discussion alongside
+[send-message-routing-rework.md](send-message-routing-rework.md)
+
+**Author:** AgentConnect team
+
+**Related:** [session-concept.md](session-concept.md) ·
+[agent-collaboration-implementation.md](agent-collaboration-implementation.md) ·
+[collaboration-arena.md](collaboration-arena.md) ·
+[daemon-centric-architecture.md](daemon-centric-architecture.md)
+
+## 1. Why revisit the rework
+
+The sendMessage routing rework fixes the right product problems: agents cannot
+address each other in a thread, session replies leak to IM, and channel-root
+calls need exactly-once activation. This document does not dispute any of its
+goals or its product invariants. It disputes the shape of the solution.
+
+The rework is written as a set of patches over the current dual-plane
+architecture, and the patch seams show up as accidental complexity:
+
+1. **A durable rendezvous state machine** (`pending` / `admitted` /
+   `transcript-only`, symmetric arrival orders, expiry, retry reattachment)
+   exists only to re-merge two observations of one logical act — the internal
+   wake and the platform echo — that were split upstream by the architecture
+   itself.
+2. **Trusted metadata tunneled through an untrusted medium.** `author_agent_id`,
+   `response_id`, `delivery_state`, `hop_count`, `mentioned_agent_ids`, and
+   `agent_call_delivery_id` ride on platform messages and each needs its own
+   promotion-from-claim verification chain at ingress. Every future field pays
+   the same tax.
+3. **A forbidden-combination table.** `toAgent + channel + thread` invalid,
+   `toUser + channel + thread` invalid, bare `channel + thread` invalid, array
+   `toUser` requires `channel`. When an API needs a table of illegal
+   combinations, its dimensions are entangled: _who_ (addressing), _where_
+   (conversation), and _how visible_ (IM vs session-only) are packed into one
+   target union.
+4. **Three mechanisms for one act.** Addressing someone in the current thread
+   is an ordinary reply with a text mention; addressing someone at a channel
+   root is a tool call; replying to a parent session is a different tool form.
+   "Send a message" splits into three semantics depending on where the recipient
+   is.
+5. **Depth-based loop protection conflates long conversations with loops.** A
+   twenty-step leaderless counting chain and a runaway two-agent loop are
+   indistinguishable to a hop counter; `MAX_AGENT_CALL_HOPS` caps both at the
+   same small depth.
+
+Some complexity in the rework is essential and this proposal keeps it: streaming
+vs finalized responses is real, model text can never prove identity, mention
+tokens must never be split across platform message boundaries, and cross-daemon
+delivery needs relay envelopes. The five findings above are not in that
+category.
+
+## 2. The primitives
+
+Five concepts, each owning exactly one dimension.
+
+### 2.1 Conversation
+
+The unit of exchange. A platform thread, a DM, and an agent session transcript
+are all Conversations. A Conversation has:
+
+- an identity (anchored to platform coordinates when it has a platform
+  projection);
+- a membership set (humans, agents, third-party bots);
+- zero or more **session bindings** — agents holding an open session in it;
+- a **Budget** (§2.5).
+
+Every Post belongs to exactly one Conversation. "Thread", "child session", and
+"parent session" stop being distinct routing constructs; they are Conversations
+with different projections and membership.
+
+### 2.2 Post — the single send primitive
+
+```ts
+Post(
+  conversation: ConversationRef,   // existing, or "new in channel C"
+  body: Content,
+  addresses?: AgentRef[] | UserRef[], // structured; never parsed from model text
+  visibility?: 'visible' | 'session-only'
+)
+```
+
+One primitive replaces the entire target union:
+
+| Rework form                | Primitive composition                                           |
+| -------------------------- | --------------------------------------------------------------- |
+| ordinary in-thread reply   | `Post(current, body, addresses?, 'visible')`                    |
+| `toAgent` (postless)       | `Post(new private conversation, body, [agent], 'session-only')` |
+| `toAgent + channel`        | `Post(new in C, body, [agent], 'visible')`                      |
+| `toUser` (DM)              | `Post(dm(user), body, 'visible')`                               |
+| `toUser + channel`         | `Post(new in C, body, [users], 'visible')`                      |
+| bare `channel`             | `Post(new in C, body, [], 'visible')`                           |
+| `sessionId` (parent reply) | `Post(parent conversation, body, 'session-only')`               |
+
+There is no forbidden-combination table because the dimensions are orthogonal:
+any conversation, any address set the policy allows, either visibility. Invalid
+states are unrepresentable rather than enumerated.
+
+**Addressing is structured data.** The model supplies addresses either as a tool
+argument or by writing platform mention tokens in its reply; in the second case
+the daemon **lifts** the tokens from the finalized text into the same structured
+`addresses` field, using the conversation-scoped directory (the rework's §8.5
+`mention` strings are exactly the inverse projection). After the lift, both
+paths are literally the same Post. Rendering addresses back into
+platform-native mentions is a driver projection concern; parsing and rendering
+are inverses owned by one component.
+
+### 2.3 Activation — one routing function
+
+```ts
+Activate(conversation, post, membership, provenance, budget) -> AgentRef[]
+```
+
+A pure function, one ladder for every sender class:
+
+- explicit addresses → the addressees (author excluded — self-addresses are
+  stripped at the lift);
+- no addresses, human author → the conversation's session-bound agents
+  (today's thread-affinity ladder unchanged);
+- no addresses, agent author → nobody; the post is transcript-only;
+- third-party bot author → existing explicit-mention-only behavior;
+- any activation → charged against Budget (§2.5); an exhausted budget records a
+  rejection and dispatches nothing.
+
+Humans, agents, and third-party bots differ only in provenance weight, not in
+which ladder runs.
+
+### 2.4 Provenance — established once, on the trusted plane
+
+The single load-bearing rule of this proposal:
+
+> **AgentConnect-authored activation travels only on the trusted plane.** The
+> daemon that owns the authoring agent already knows, with certainty, the
+> author, the finalized body, and the lifted addresses. It delivers activation
+> directly (in-process for a local target, relay envelope for a remote one).
+> The platform copy of the same Post is a _projection_ for humans to read; when
+> it echoes back through platform ingress it is merged into the transcript by
+> platform message id and **never activates anyone**.
+
+Consequences:
+
+- The rendezvous state machine disappears. Exactly-once is an idempotency key —
+  `(postId, targetAgentId)` — on a single delivery path, not a durable
+  reconciliation of two racing observations. A platform echo arriving first is
+  a plain transcript insert; the activation envelope arriving later attaches to
+  the same row (idempotent upsert). An envelope that never arrives is a
+  delivery failure alarm, exactly as the rework specifies for expiry — minus
+  the state machine.
+- The metadata tunnel disappears from the load-bearing path. Platform messages
+  still carry `author_agent_id` for display and transcript merge, but no
+  ingress verification chain guards activation, because platform re-entry does
+  not activate. The four-step promotion chain and the selective
+  `message_changed` normalization for routing shrink to a degraded-mode
+  concern (§6).
+- Final-only routing becomes trivial. The lift runs at turn finalization inside
+  the daemon that owns the response; there is no streaming/final flag to
+  transport or verify. Mention-token-safe message splitting remains — as a
+  display-correctness rule, no longer a routing-correctness rule.
+
+### 2.5 Budget — loop protection as a resource, not a depth
+
+Each Conversation carries an activation budget:
+
+- a quota of agent-authored activations (default small; configurable per
+  conversation class — a collaboration room can be provisioned for a long
+  game);
+- **replenished by human posts** — the generalization of the rework's "a
+  human/root turn has depth 0": a human in the loop keeps the conversation
+  alive, but as refueling rather than a reset of a counter that was never
+  spent;
+- optional per-edge rate caps (the same author→target pair activating in a
+  tight cycle drains faster).
+
+A runaway two-agent loop drains the budget and stops with a recorded
+`budget_exhausted` rejection — a first-class, observable activation-rejection
+event (this also answers the acceptance suite's open question about where
+`hop_limit` is observable). A legitimate twenty-step counting chain in a
+provisioned room just runs. Depth counting cannot express that difference;
+budgets can.
+
+## 3. The acceptance cases under the primitives
+
+The four cases from the routing acceptance suite (PR #520), traced end to end.
+None of them needs a special mechanism; each is one Post plus the Activation
+ladder.
+
+### Case 1 — channel-root call with mention
+
+agent1 executes `Post(new in C, task, [agent2], 'visible')`.
+
+1. The owning daemon authorizes the agent1→agent2 edge and charges the room
+   budget.
+2. The Slack driver posts **one** channel-root message; the projection renders
+   agent2's mention token into the body (the §3.2 sub-invariant holds by
+   construction — the visible body is a rendering of the structured address).
+3. One activation `(postId, agent2)` is delivered on the trusted plane. The
+   new Conversation binds **agent2's** session (a conversation-creating Post
+   binds its addressees; the author delegated, it does not bind).
+4. The platform echo of the root post merges into the transcript and activates
+   nobody.
+
+A human then replies in the thread: no addresses, human author → session-bound
+agents = {agent2}. Only agent2 responds; agent1 stays at its original single
+activation. Exactly-once needs no rendezvous — there is only one activation
+delivery to deduplicate, by idempotency key.
+
+### Case 1b — child replies to the parent, session-only
+
+agent2's activation envelope carries the origin conversation (agent1's calling
+session). agent2 finishes and executes
+`Post(origin conversation, result, 'session-only')`.
+
+- `'session-only'` means **no platform projection exists at all** — nothing to
+  post, so "zero new IM outbound" is true by construction rather than by
+  suppressing chrome piece by piece; there is no list of suppressed surfaces to
+  keep complete (this dissolves the §7 chrome-scope ambiguity the suite had to
+  assume around: the child's own visible speech is simply a different Post with
+  its own visibility).
+- The Post lands in the parent Conversation's transcript and activates agent1.
+- **Visibility inheritance:** a turn activated by a session-only Post defaults
+  its ordinary output to `Post(same conversation, 'session-only')`. An explicit
+  `visibility: 'visible'` Post from that turn remains a distinct, separately
+  authorized act — the rework's §7 escape hatch, expressed as a parameter
+  rather than a headless flag threaded through delivery kinds and relay
+  capability negotiation.
+
+agent1 receives the result in the origin conversation's context. No IM message
+exists anywhere.
+
+### Case 2 — unaddressed root post, human follow-up
+
+agent1 executes `Post(new in C, announcement, [], 'visible')`. One visible root
+message; the empty address set activates nobody. The conversation-creating Post
+has no addressees, so it binds the **author's** session — agent1 owns the
+thread it opened. A human reply (no addresses, human author) activates the
+session-bound set = {agent1}. agent2 is never touched.
+
+The binding rule is one sentence: _a conversation-creating Post binds its
+addressees' sessions, or the author's when there are none._ Case 1 and Case 2
+are the two arms of that sentence.
+
+### Case 3 — in-thread mutual mentions
+
+A human activates agent1 in a thread. agent1's ordinary finalized reply
+contains agent2's mention token. The lift turns it into
+`Post(current, body, [agent2], 'visible')` — the same primitive as Case 1, in
+an existing conversation. agent2 activates exactly once (one Post, one
+addressee, one idempotency key; streaming intermediates never reach the lift).
+agent2's counter-mention activates agent1 the same way. The chain consumes
+conversation budget per activation; when it exhausts, the daemon records
+`budget_exhausted` and stops dispatching — same observable slot, but a
+provisioned room plays a full game before hitting it, which a hop cap cannot
+allow without also unleashing loops everywhere else.
+
+Negatives hold structurally: an unmentioned agent post lifts an empty address
+set → transcript-only; a self-mention is stripped at the lift → an author can
+never activate itself; a human mention in the body lifts to a user address →
+no agent activation.
+
+### The arena games
+
+- The peer-driven counting stall (agents' bare numbers wake nobody) reproduces
+  identically: bare numbers lift no addresses → transcript-only. The game
+  becomes winnable by **choosing whom to call** — `"7 <@agent-b>"` — which is
+  precisely the leaderless-coordination skill the arena wants to measure, now
+  with a mechanism that survives past eight steps because the room is
+  provisioned with budget for the game.
+- Quota counting's endgame (nobody tracked who still had numbers left) becomes
+  directly testable at full length.
+- Werewolf needs a wolves-only night channel: that is just a Conversation with
+  subset membership and (optionally) session-only visibility — no new
+  mechanism, where the rework would reach for DMs or headless call chains.
+- The collaboration arena needs no new seams: `injectPlatformEvent` stays the
+  human/platform door, the world sink observes projections, and Budget is one
+  more knob on the synthetic topology.
+
+## 4. What the rework's machinery becomes
+
+| Rework mechanism                                                                           | Under the primitives                                       |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| target union + invalid-combination table                                                   | Post parameters (orthogonal, nothing to forbid)            |
+| rendezvous / `ActivationRecord` state machine                                              | idempotency key `(postId, target)` + transcript upsert     |
+| `author_agent_id` ingress promotion chain                                                  | trusted-plane provenance; display-only on the echo         |
+| `mentioned_agent_ids` response metadata                                                    | the lift (structured addresses at finalization)            |
+| `delivery_state` streaming/final routing guard                                             | lift runs only at finalization; nothing to transport       |
+| `hop_count` + `MAX_AGENT_CALL_HOPS`                                                        | Conversation Budget + human replenishment + edge rate caps |
+| headless flag, `rd/agentmsg` delivery kinds, relay capability `headless-agent-delivery-v1` | `visibility` parameter with turn-default inheritance       |
+| §8.5 `mention` strings                                                                     | the directory projection (render) and its inverse (lift)   |
+| mention-token-safe splitting                                                               | unchanged — display correctness (essential complexity)     |
+
+## 5. Cross-daemon delivery
+
+The trusted plane is in-process for a same-daemon target and a relay envelope
+for a remote one — structurally the rework's §8.2/§8.3 frames, with two
+simplifications: there is **one** envelope shape for every delivery (fields
+vary, kinds do not), and the relay's obligations do not grow — it forwards
+verified envelopes and never synthesizes them, exactly as the rework already
+requires. The platform echo merges wherever it lands, by platform message id.
+
+## 6. Degraded mode: platform as transport
+
+Two daemons that share a workspace but have no relay path between them can fall
+back to platform re-entry as the activation carrier. That fallback — explicit,
+per-integration opt-in — is where the rework's §4 verification chain lives on:
+promotion-from-claim is the _quarantined exception_ for topologies that cannot
+do better, not the core protocol every deployment pays for. Third-party bots
+keep their existing platform-verified, explicit-mention-only behavior in all
+modes.
+
+## 7. What stays hard
+
+Honest costs this proposal does not remove:
+
+- **The lift needs a reliable conversation-scoped directory** (mention token ↔
+  agent), including the shared-bot two-token address form. The rework needs the
+  same directory for §8.5; here it is load-bearing for routing, so its staleness
+  story must be explicit.
+- **Budget policy needs product defaults**: per-conversation-class quotas,
+  replenishment amounts, edge rate caps. A wrong default either strands
+  conversations or readmits loops. (The hop cap has the same tuning problem in
+  one dimension; budgets have it in three, in exchange for expressiveness.)
+- **Finalization boundaries and mention-safe splitting** remain exactly as hard
+  as the rework describes; they are display-essential either way.
+- **Migration**: every current `sendMessage` caller, the queue/replay
+  persistence of activation state, and the existing suppression ladder need a
+  staged path (§8).
+
+## 8. Migration sketch
+
+Each phase keeps the routing acceptance suite (PR #520) green or flips its
+expected-failures; the suite pins invariants, not mechanisms, so it is the
+fixed reference across the whole path.
+
+1. **Introduce Post internally.** Current sendMessage forms compile to Post
+   compositions; no behavior change.
+2. **Same-daemon trusted-plane activation + the lift.** Ordinary finalized
+   replies lift addresses; managed-bot platform echoes stop being routing
+   inputs on daemons that own both ends. Case 3 and the Case 1 mention
+   sub-invariant flip green. Budget lands with conservative defaults.
+3. **Relay envelope unification.** Remote targets get the same envelope;
+   Case 1's exactly-once holds cross-daemon by idempotency key.
+4. **Visibility inheritance.** Session-only Posts and turn-default
+   inheritance replace the headless flag; Case 1b flips green.
+5. **Retire** the rendezvous, the ingress promotion chain (outside degraded
+   mode), and the depth counter.
+
+## 9. Relationship to the acceptance suite
+
+No test in the routing acceptance suite changes under this proposal: the suite
+asserts who activates, what is visible, and exactly-once — properties both
+designs promise. The three expected-failures flip at the phases noted above.
+The suite gains two natural additions once budgets exist: `budget_exhausted` as
+the pinned observable for chain termination (replacing the loosely-grepped
+`hop_limit`), and a provisioned-room test that runs a full twenty-step counting
+chain — the test the hop-cap design structurally cannot pass.


### PR DESCRIPTION
## Summary

Counter-proposal to the sendMessage routing rework (#503), for discussion — not a replacement PR. It keeps every product goal and invariant of the rework and proposes a different shape: five orthogonal primitives (**Conversation, Post, Activation, Provenance, Budget**) composed instead of per-feature mechanisms.

- one `Post(conversation, body, addresses?, visibility)` primitive replaces the target union and its invalid-combination table
- **trusted-plane activation**: AgentConnect-authored activation never re-enters through the platform; the platform echo is a projection that merges into the transcript and activates nobody — the durable activation rendezvous collapses to an idempotency key
- structured addressing with a finalization-time **lift** of mention tokens; render/parse are inverses owned by the driver
- **Budget** (conversation-scoped quota, human replenishment, edge rate caps) replaces depth-based `MAX_AGENT_CALL_HOPS` — distinguishes a long leaderless game from a runaway loop, which a hop counter cannot
- session-only **visibility** as a parameter with turn-default inheritance replaces the headless flag and its relay capability negotiation

§3 traces all four routing acceptance cases (#520) end to end under the primitives; §8 gives a staged migration where each phase flips the suite's expected-failures. The acceptance suite itself needs no changes under either design — it pins invariants, not mechanisms.

## Why

The rework's rendezvous state machine, metadata promotion chains, forbidden-combination table, three addressing mechanisms, and hop cap are argued (§1) to be accidental complexity from patching the current dual-plane architecture; the essential complexity (streaming vs final, identity verification, mention-safe splitting, relay envelopes) is kept and delineated (§7).

## Validation

- `pnpm exec prettier --check docs/designs/messaging-primitives.md`
- Documentation only; no runtime behavior or protocol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
