### PR TITLE
feat(protocol)!: retire the S1b legacy wire shapes' readers

### DIFF
--- a/packages/daemon/src/agents/write-integration.ts
+++ b/packages/daemon/src/agents/write-integration.ts
@@ -30,13 +30,14 @@ import { findAgentFileById } from './write-agent.js'
 /**
  * Map the wire spec to the daemon's `Integration` shape (agent-schema).
  *
- * §6.4 DUAL-SHAPE reader: the platform payload comes from the legacy nested block
- * while the CP still emits it, else from the opaque `config` validated against the
- * SAME per-platform schema (the S2 platform module takes validation over later).
- * `core` overrides the routing knobs wherever present — it is the envelope that
- * survives once legacy emission drops. The wire envelope is folded back into
- * today's on-disk shape, so everything downstream of agent.json is unchanged.
- * Returns null (reader-side rejection) for a spec carrying neither payload.
+ * §6.4 ENVELOPE reader (legacy RETIRED): the platform payload is the opaque
+ * `config`, validated against the per-platform wire schema (the S2 platform
+ * module takes validation over later). `core` overrides the routing knobs
+ * wherever present. An older CP's legacy nested block is stripped at the frame
+ * layer; that CP dual-emitted `config` since §6.4 landed, so nothing is lost.
+ * The wire envelope is folded back into today's on-disk shape, so everything
+ * downstream of agent.json is unchanged. Returns null (reader-side rejection)
+ * for a spec carrying no usable config.
  */
 function toIntegration(spec: IntegrationSpec): Integration | null {
   const core = spec.core
@@ -46,7 +47,7 @@ function toIntegration(spec: IntegrationSpec): Integration | null {
     gated: core?.gated ?? legacy.gated
   })
   if (spec.platform === 'telegram') {
-    const cfg = spec.telegram ?? parseConfig(IntegrationTelegramConfig, spec.config)
+    const cfg = parseConfig(IntegrationTelegramConfig, spec.config)
     if (!cfg) return null
     return {
       id: spec.integrationId,
@@ -56,7 +57,7 @@ function toIntegration(spec: IntegrationSpec): Integration | null {
     }
   }
   if (spec.platform === 'discord') {
-    const cfg = spec.discord ?? parseConfig(IntegrationDiscordConfig, spec.config)
+    const cfg = parseConfig(IntegrationDiscordConfig, spec.config)
     if (!cfg) return null
     return {
       id: spec.integrationId,
@@ -70,7 +71,7 @@ function toIntegration(spec: IntegrationSpec): Integration | null {
     }
   }
   if (spec.platform === 'feishu') {
-    const cfg = spec.feishu ?? parseConfig(IntegrationFeishuConfig, spec.config)
+    const cfg = parseConfig(IntegrationFeishuConfig, spec.config)
     if (!cfg) return null
     return {
       id: spec.integrationId,
@@ -86,7 +87,7 @@ function toIntegration(spec: IntegrationSpec): Integration | null {
       }
     }
   }
-  const cfg = spec.slack ?? parseConfig(IntegrationSlackConfig, spec.config)
+  const cfg = parseConfig(IntegrationSlackConfig, spec.config)
   if (!cfg) return null
   return {
     id: spec.integrationId,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -401,8 +401,6 @@ import type {
   RdMsgWebchat,
   WebchatImageAttachment,
   RdMsgIm,
-  RdMsgSlackAction,
-  RdMsgFeishuAction,
   RdMsgPlatformAction,
   RdMsgHook,
   RdAck,
@@ -6733,13 +6731,9 @@ export class Daemon {
     const ack =
       msg.source === 'webchat'
         ? this.dispatchRelayOp(msg, chat, post)
-        : msg.source === 'slack_action'
-          ? this.handleRelaySlackAction(msg)
-          : msg.source === 'feishu_action'
-            ? this.handleRelayFeishuAction(msg)
-            : msg.source === 'platform_action'
-              ? this.handleRelayPlatformAction(msg)
-              : this.handleRelayIm(msg)
+        : msg.source === 'platform_action'
+          ? this.handleRelayPlatformAction(msg)
+          : this.handleRelayIm(msg)
     if (this.relayMsgAcks.size >= 2000) this.relayMsgAcks.clear() // bound the window
     this.relayMsgAcks.set(dedupKey, ack)
     return ack
@@ -6962,7 +6956,6 @@ export class Daemon {
         const payload = RdSlackAction.safeParse(msg.payload)
         if (!payload.success) return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
         return this.handleRelaySlackAction({
-          source: 'slack_action',
           agentId: msg.agentId,
           sessionKey: msg.sessionKey,
           msgId: msg.msgId,
@@ -6978,8 +6971,7 @@ export class Daemon {
       (msg) => {
         const payload = WireFeishuCardActionEvent.safeParse(msg.payload)
         if (!payload.success) return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
-        const { feishuCardAction, ...ack } = this.handleRelayFeishuAction({
-          source: 'feishu_action',
+        return this.handleRelayFeishuAction({
           agentId: msg.agentId,
           sessionKey: msg.sessionKey,
           msgId: msg.msgId,
@@ -6987,11 +6979,6 @@ export class Daemon {
           integrationId: msg.integrationId,
           payload: payload.data
         })
-        // §6.6 emission flip: a platform_action is answered through the generic
-        // opaque `response` only. The deprecated Feishu-named slot still rides
-        // acks of the legacy feishu_action member (the handler above), and both
-        // retire together with the legacy readers.
-        return feishuCardAction !== undefined ? { ...ack, response: feishuCardAction } : ack
       }
     ]
   ])
@@ -7001,7 +6988,15 @@ export class Daemon {
     return decode ? decode(msg) : { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
   }
 
-  private handleRelaySlackAction(msg: RdMsgSlackAction): RdAck {
+  private handleRelaySlackAction(msg: {
+    agentId: string
+    sessionKey: string
+    msgId: string
+    botId: string
+    integrationId: string
+    userId?: string
+    payload: RdSlackAction
+  }): RdAck {
     const agent = this.agents.get(msg.agentId)
     if (!agent) {
       this.log.warn(`relay: Slack action for unknown agent ${msg.agentId} — dropping`)
@@ -7102,7 +7097,14 @@ export class Daemon {
    * send-only connection that rendered the card. The connection resolves the
    * message id against daemon-local active-card state, so a stale or forged action
    * cannot name an arbitrary session. */
-  private handleRelayFeishuAction(msg: RdMsgFeishuAction): RdAck {
+  private handleRelayFeishuAction(msg: {
+    agentId: string
+    sessionKey: string
+    msgId: string
+    botId: string
+    integrationId: string
+    payload: WireFeishuCardActionEvent
+  }): RdAck {
     const agent = this.agents.get(msg.agentId)
     if (!agent) {
       this.log.warn(`relay: Feishu action for unknown agent ${msg.agentId} — dropping`)
@@ -7124,10 +7126,12 @@ export class Daemon {
       return { msgId: msg.msgId, accepted: false, reason: 'unavailable' }
     }
     const response = conn.handleCardAction(msg.payload)
+    // §6.6: answered through the generic opaque slot — the Feishu-named ack
+    // member retired with the legacy interaction members.
     return {
       msgId: msg.msgId,
       accepted: true,
-      ...(response ? { feishuCardAction: response } : {})
+      ...(response ? { response } : {})
     }
   }
 

--- a/packages/daemon/src/platforms/discord/thread-promotion.ts
+++ b/packages/daemon/src/platforms/discord/thread-promotion.ts
@@ -8,9 +8,8 @@
  * three coordinates, and the original message id — whose ts equals the thread
  * id — makes the session treat that message as the thread root.
  *
- * WANT is a dual-shape read: the generic `promoteToThread` coordinate (§6.5)
- * first, Discord's legacy `discordTopLevel` named field as the fallback until
- * the legacy emission flip retires it.
+ * WANT reads the generic `promoteToThread` coordinate (§6.5); Discord's legacy
+ * `discordTopLevel` named twin retired with the S1b cleanup.
  */
 import type { DiscordConnection } from '../../discord/connection.js'
 import type { ThreadPromotion, ThreadPromotionHost, ThreadPromotionMessage } from '../thread-promotion.js'
@@ -27,7 +26,7 @@ export const discordThreadPromotion: ThreadPromotion<ThreadPromotionMessage> = {
   platform: 'discord',
 
   wants(msg: ThreadPromotionMessage): boolean {
-    return (msg.promoteToThread ?? (msg as { discordTopLevel?: boolean }).discordTopLevel) === true
+    return msg.promoteToThread === true
   },
 
   async promote(host: ThreadPromotionHost, conn: unknown, msg: ThreadPromotionMessage): Promise<void> {

--- a/packages/daemon/src/platforms/telegram/threading.ts
+++ b/packages/daemon/src/platforms/telegram/threading.ts
@@ -50,12 +50,12 @@ export function canonicalizeTelegramThread(
   if (msg.platform !== 'telegram' || msg.thread !== undefined) return
   // §6.5 dual-shape reader: prefer the generic coordinates; the named per-platform
   // fields stop being emitted once the fleet reads the generic ones.
-  const topicId = msg.topicId ?? msg.telegramTopicId
+  const topicId = msg.topicId
   if (topicId !== undefined) {
     msg.thread = topicId
     return
   }
-  const threadRoot = msg.threadRoot ?? msg.telegramThreadRoot
+  const threadRoot = msg.threadRoot
   if (threadRoot !== undefined) {
     msg.thread = `tg:${threadRoot}`
     return

--- a/packages/daemon/test/cp/cp-integration-registry.test.ts
+++ b/packages/daemon/test/cp/cp-integration-registry.test.ts
@@ -13,7 +13,8 @@ const spec = (over: Partial<IntegrationSpec> = {}): IntegrationSpec => ({
   integrationId: I1,
   agentId: A1,
   platform: 'slack',
-  slack: {
+  core: { mode: 'direct', bindRules: [{ match: { kind: 'mention' } }], mutedChannels: [], gated: false },
+  config: {
     botToken: 'xoxb-secret',
     appToken: 'xapp-secret',
     bindRules: [{ match: { kind: 'mention' } }]
@@ -72,7 +73,7 @@ describe('CpIntegrationRegistry (filesystem-backed)', () => {
       ]
     })
     const { reg } = makeReg(dir)
-    reg.upsert(spec({ slack: { botToken: 'xoxb-new', appToken: 'xapp-new', bindRules: [] } }))
+    reg.upsert(spec({ config: { botToken: 'xoxb-new', appToken: 'xapp-new', bindRules: [] } }))
     const a = readAgent(dir, 'helper')
     expect(a.integrations).toHaveLength(2)
     const [cp, local] = a.integrations as any[]
@@ -134,7 +135,7 @@ describe('CpIntegrationRegistry (filesystem-backed)', () => {
       integrations: [{ id: I1, platform: 'slack', slack: { botToken: 'xoxb-a', appToken: 'xapp-a' } }]
     })
     const { reg, onChange } = makeReg(dir)
-    reg.converge([spec({ integrationId: I2, slack: { botToken: 'xoxb-b', appToken: 'xapp-b', bindRules: [] } })])
+    reg.converge([spec({ integrationId: I2, config: { botToken: 'xoxb-b', appToken: 'xapp-b', bindRules: [] } })])
     const a = readAgent(dir, 'helper')
     // I2 created from the roster; I1 NOT pruned (deletion only via integration/remove)
     expect((a.integrations as any[]).map((i) => i.id).sort()).toEqual([I1, I2].sort())

--- a/packages/daemon/test/cp/cp-integration.test.ts
+++ b/packages/daemon/test/cp/cp-integration.test.ts
@@ -78,7 +78,9 @@ const INTEGRATION: IntegrationSpec = {
   integrationId: '66666666-6666-4666-8666-666666666666',
   agentId: 'bot-a',
   platform: 'slack',
-  slack: {
+  // §6.4 envelope wire shape; folds back to the frozen nested DISK shape below.
+  core: { mode: 'direct', bindRules: [{ match: { kind: 'mention' } }], mutedChannels: [], gated: false },
+  config: {
     botToken: 'xoxb-secret-abc',
     appToken: 'xapp-1-secret-def',
     bindRules: [{ match: { kind: 'mention' } }]

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -7,9 +7,8 @@ import {
   SLACK_STATUS_ACTION,
   decodeSharedSlackStatusTarget,
   decodeSlackStatusOverflowValue,
-  type RdMsgFeishuAction,
   type RdMsgIm,
-  type RdMsgSlackAction
+  type RdMsgPlatformAction
 } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
@@ -1591,8 +1590,9 @@ describe('Slack interactive status bar', () => {
       updatedAt: Date.now()
     })
 
-    const action = (over: Partial<RdMsgSlackAction> = {}): RdMsgSlackAction => ({
-      source: 'slack_action',
+    const action = (over: Partial<RdMsgPlatformAction> = {}): RdMsgPlatformAction => ({
+      source: 'platform_action',
+      platformId: 'slack',
       agentId: 'bot-a',
       sessionKey: KEY,
       msgId: 'action-ok',
@@ -1744,8 +1744,9 @@ describe('Slack interactive status bar', () => {
     const handleCardAction = vi.fn(() => response)
     ;(daemon as any).fsConnByIntegration.set('int-a', { handleCardAction })
 
-    const action: RdMsgFeishuAction = {
-      source: 'feishu_action',
+    const action: RdMsgPlatformAction = {
+      source: 'platform_action',
+      platformId: 'feishu',
       agentId: 'bot-a',
       sessionKey: 'feishu-action:om_card',
       msgId: 'feishu-action:one',
@@ -1761,7 +1762,8 @@ describe('Slack interactive status bar', () => {
     expect((daemon as any).handleRelayMsg(action, () => {})).toEqual({
       msgId: action.msgId,
       accepted: true,
-      feishuCardAction: response
+      // §6.6: the generic opaque slot is the one answer (named slot retired).
+      response
     })
     expect(handleCardAction).toHaveBeenCalledWith(action.payload)
     expect(

--- a/packages/daemon/test/ingress-coordinate-strategies.test.ts
+++ b/packages/daemon/test/ingress-coordinate-strategies.test.ts
@@ -64,12 +64,12 @@ describe('thread promotion', () => {
     }
   })
 
-  it('wants promotion via the generic coordinate, legacy field as fallback', () => {
+  it('wants promotion via the generic coordinate alone (legacy twin retired)', () => {
     const base = { platform: 'discord', channel: 'c', msgId: 'discord:c:1', text: 'hi' }
     expect(discordThreadPromotion.wants({ ...base, promoteToThread: true })).toBe(true)
-    expect(discordThreadPromotion.wants({ ...base, discordTopLevel: true } as never)).toBe(true)
-    // The generic coordinate, once present, is authoritative — an explicit false
-    // must not fall through to the legacy field.
+    // The retired named twin no longer participates — even if a stale object
+    // carries it, only the generic coordinate decides.
+    expect(discordThreadPromotion.wants({ ...base, discordTopLevel: true } as never)).toBe(false)
     expect(discordThreadPromotion.wants({ ...base, promoteToThread: false, discordTopLevel: true } as never)).toBe(
       false
     )

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -253,7 +253,7 @@ describe('canonicalizeTelegramThread', () => {
   it('uses the forum-topic id as the thread', async () => {
     const daemon = new Daemon({ root: scaffold() })
     await daemon.start()
-    const m = tg(101, { telegramTopicId: '555', mentionedBots: ['mybot'] })
+    const m = tg(101, { topicId: '555', mentionedBots: ['mybot'] })
     ;(daemon as any).canonicalizeTelegramThread(m)
     expect(m.thread).toBe('555')
   })
@@ -268,7 +268,7 @@ describe('canonicalizeTelegramThread', () => {
     ;(daemon as any).canonicalizeTelegramThread(reply)
     expect(reply.thread).toBe('tg:6')
     // The generic field wins when both are present (dual-shape window).
-    const both = tg(105, { topicId: '7', telegramTopicId: '8' })
+    const both = tg(105, { topicId: '7' })
     ;(daemon as any).canonicalizeTelegramThread(both)
     expect(both.thread).toBe('7')
   })
@@ -291,7 +291,7 @@ describe('canonicalizeTelegramThread', () => {
     // A later reply in that thread carries Telegram's native message_thread_id = 6
     // (the root) — even though it directly replies to the bot's message 7. It must key
     // to the SAME session as the mention (regression: was mis-keyed to the bare id).
-    const reply = tg(8, { telegramThreadRoot: '6', replyTo: '7' })
+    const reply = tg(8, { threadRoot: '6', replyTo: '7' })
     ;(daemon as any).canonicalizeTelegramThread(reply)
     expect(reply.thread).toBe('tg:6')
   })
@@ -301,10 +301,10 @@ describe('canonicalizeTelegramThread', () => {
     await daemon.start()
     // Only a real forum topic yields the bare numeric thread (postable as
     // message_thread_id); a reply-thread root is prefixed so it never is.
-    const forum = tg(9, { telegramTopicId: '6' })
+    const forum = tg(9, { topicId: '6' })
     ;(daemon as any).canonicalizeTelegramThread(forum)
     expect(forum.thread).toBe('6')
-    const replyThread = tg(10, { telegramThreadRoot: '6' })
+    const replyThread = tg(10, { threadRoot: '6' })
     ;(daemon as any).canonicalizeTelegramThread(replyThread)
     expect(replyThread.thread).toBe('tg:6')
   })
@@ -387,8 +387,8 @@ describe('reply-based session continuity (routing)', () => {
     seedSession(daemon, '-100', 'tg:77', { agentId: 'bot-b', integrationId: 'i-b' })
     const dispatch = vi.spyOn(daemon as any, 'dispatch').mockResolvedValue('acp')
 
-    ;(daemon as any).onInbound(tg(78, { telegramThreadRoot: '77', text: 'follow up A' }), ['i-a'])
-    ;(daemon as any).onInbound(tg(78, { telegramThreadRoot: '77', text: 'follow up B' }), ['i-b'])
+    ;(daemon as any).onInbound(tg(78, { threadRoot: '77', text: 'follow up A' }), ['i-a'])
+    ;(daemon as any).onInbound(tg(78, { threadRoot: '77', text: 'follow up B' }), ['i-b'])
 
     expect(dispatch.mock.calls.map(([agentId, , integrationId]) => [agentId, integrationId])).toEqual([
       ['bot-a', 'i-a'],

--- a/packages/daemon/test/write-agent.test.ts
+++ b/packages/daemon/test/write-agent.test.ts
@@ -665,7 +665,7 @@ describe('writeAgentSpec — create (no agent.json)', () => {
           integrationId: 'int-a',
           agentId: 'bot-a',
           platform: 'slack',
-          slack: {
+          config: {
             mode: 'direct',
             shareable: false,
             botToken: 'xoxb-secret',
@@ -813,7 +813,7 @@ describe('cold-move archive', () => {
       integrationId: 'int-current',
       agentId: 'bot-a',
       platform: 'slack',
-      slack: {
+      config: {
         mode: 'direct',
         botToken: 'new-secret',
         appToken: 'new-app',
@@ -874,10 +874,15 @@ describe('cold-move archive', () => {
         platform: 'slack',
         slack: {
           mode: 'direct',
+          // The per-platform wire schema fills the defaulted knobs at the
+          // consumer parse (envelope reader) — they now always reach disk.
+          shareable: false,
           botToken: 'new-secret',
           appToken: 'new-app',
           appId: 'A123',
-          bindRules: []
+          bindRules: [],
+          mutedChannels: [],
+          gated: false
         }
       }
     ])
@@ -932,7 +937,7 @@ describe('cold-move archive', () => {
   })
 })
 
-describe('writeIntegrationSpec §6.4 dual-shape reader', () => {
+describe('writeIntegrationSpec §6.4 envelope reader (legacy retired)', () => {
   const AGENT = '33333333-3333-4333-8333-333333333333'
   const INT = '66666666-6666-4666-8666-666666666666'
   const seeded = () => {
@@ -951,12 +956,10 @@ describe('writeIntegrationSpec §6.4 dual-shape reader', () => {
   const disk = (dir: string) =>
     (readJson(join(dir, 'bot-a', 'agent.json')).integrations as Record<string, unknown>[])[0]
 
-  it('envelope-only and legacy-only specs fold to the SAME on-disk shape', () => {
-    const a = seeded()
-    writeIntegrationSpec(a, { integrationId: INT, agentId: AGENT, platform: 'telegram', telegram } as never, {})
-    const b = seeded()
+  it('an envelope spec folds to the pre-envelope on-disk shape (agent.json unchanged)', () => {
+    const dir = seeded()
     writeIntegrationSpec(
-      b,
+      dir,
       {
         integrationId: INT,
         agentId: AGENT,
@@ -966,10 +969,12 @@ describe('writeIntegrationSpec §6.4 dual-shape reader', () => {
       } as never,
       {}
     )
-    expect(disk(b)).toEqual(disk(a))
+    // The DISK shape is frozen (#516): the wire envelope folds back into the
+    // nested per-platform block everything downstream of agent.json reads.
+    expect(disk(dir)).toMatchObject({ id: INT, platform: 'telegram', telegram: { botToken: telegram.botToken } })
   })
 
-  it('core overrides the legacy routing knobs wherever present', () => {
+  it('core overrides the routing knobs wherever present', () => {
     const dir = seeded()
     writeIntegrationSpec(
       dir,
@@ -977,7 +982,6 @@ describe('writeIntegrationSpec §6.4 dual-shape reader', () => {
         integrationId: INT,
         agentId: AGENT,
         platform: 'telegram',
-        telegram: { ...telegram, gated: false, mutedChannels: [] },
         core: { mode: 'direct', bindRules: [], mutedChannels: ['C_OFF'], gated: true },
         config: telegram
       } as never,
@@ -986,7 +990,22 @@ describe('writeIntegrationSpec §6.4 dual-shape reader', () => {
     expect(disk(dir)).toMatchObject({ telegram: { gated: true, mutedChannels: ['C_OFF'] } })
   })
 
-  it('a spec with neither payload is refused (warn + not persisted)', () => {
+  it('a LEGACY-only spec (retired nested block, no config) is refused, not read', () => {
+    // An emitter this old predates §6.4's dual emission entirely — the reader
+    // refuses (warn + skip) and the CP re-sends on its next push.
+    const dir = seeded()
+    const warns: string[] = []
+    const ok = writeIntegrationSpec(
+      dir,
+      { integrationId: INT, agentId: AGENT, platform: 'telegram', telegram } as never,
+      { warn: (m) => warns.push(m) }
+    )
+    expect(ok).toBe(false)
+    expect(warns[0]).toContain('no usable platform payload')
+    expect(readJson(join(dir, 'bot-a', 'agent.json')).integrations).toEqual([])
+  })
+
+  it('a spec with no payload at all is refused (warn + not persisted)', () => {
     const dir = seeded()
     const warns: string[] = []
     const ok = writeIntegrationSpec(dir, { integrationId: INT, agentId: AGENT, platform: 'telegram' } as never, {

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import {
+  IntegrationSlackConfig,
+  IntegrationTelegramConfig,
+  IntegrationDiscordConfig,
+  IntegrationFeishuConfig,
   AuthReq,
   ControlExt,
   isFrame,
@@ -429,74 +433,101 @@ describe('agent spec / CRUD frames (CP→daemon spec sync)', () => {
 describe('integration frames (CP→daemon platform config distribution)', () => {
   const INTEGRATION_ID = '66666666-6666-4666-8666-666666666666'
 
-  it('integration/upsert carries the slack config incl. tokens; zod defaults fill lists', () => {
+  // §6.4 legacy RETIRED: the wire carries envelope (`core`) + opaque `config`.
+  // The frame layer no longer applies per-platform zod defaults — the CONSUMER
+  // (write-integration.ts) parses `config` through the per-platform schema, so
+  // these tests validate at that layer, exactly as the daemon reader does.
+  it('integration/upsert carries the slack config incl. tokens through the opaque envelope', () => {
     const r = decodeEnvelope(
       envelope('integration/upsert', {
         integrationId: INTEGRATION_ID,
         agentId: AGENT_ID,
         platform: 'slack',
-        slack: { botToken: 'xoxb-abc', appToken: 'xapp-1-def', appId: 'A123' }
+        config: { botToken: 'xoxb-abc', appToken: 'xapp-1-def', appId: 'A123' }
       })
     )
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'slack') throw new Error('expected slack integration')
-    expect(r.frame.payload.slack!.botToken).toBe('xoxb-abc')
-    expect(r.frame.payload.slack!.appToken).toBe('xapp-1-def')
-    expect(r.frame.payload.slack!.appId).toBe('A123')
-    expect(r.frame.payload.slack!.bindRules).toEqual([]) // zod default
+    const cfg = IntegrationSlackConfig.parse(r.frame.payload.config)
+    expect(cfg.botToken).toBe('xoxb-abc')
+    expect(cfg.appToken).toBe('xapp-1-def')
+    expect(cfg.appId).toBe('A123')
+    expect(cfg.bindRules).toEqual([]) // zod default at the consumer parse
   })
 
-  it('integration/upsert carries the telegram config (single botToken, no appToken); zod defaults fill lists', () => {
+  it('integration/upsert STRIPS a legacy nested block from an older CP and reads config', () => {
+    // An older CP dual-emitted the nested block beside config (§6.4 window). The
+    // retired member is now an unknown key — stripped by the non-strict object,
+    // never a decode failure.
+    const r = decodeEnvelope(
+      envelope('integration/upsert', {
+        integrationId: INTEGRATION_ID,
+        agentId: AGENT_ID,
+        platform: 'slack',
+        slack: { botToken: 'xoxb-abc', appToken: 'xapp-1-def' },
+        config: { botToken: 'xoxb-abc', appToken: 'xapp-1-def' }
+      })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
+    expect('slack' in r.frame.payload).toBe(false)
+    expect(IntegrationSlackConfig.parse(r.frame.payload.config).botToken).toBe('xoxb-abc')
+  })
+
+  it('integration/upsert carries the telegram config (single botToken, no appToken)', () => {
     const r = decodeEnvelope(
       envelope('integration/upsert', {
         integrationId: INTEGRATION_ID,
         agentId: AGENT_ID,
         platform: 'telegram',
-        telegram: { botToken: '123456:ABC-def' }
+        config: { botToken: '123456:ABC-def' }
       })
     )
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'telegram') throw new Error('expected telegram integration')
-    expect(r.frame.payload.telegram!.botToken).toBe('123456:ABC-def')
-    expect(r.frame.payload.telegram!.bindRules).toEqual([]) // zod default
+    const cfg = IntegrationTelegramConfig.parse(r.frame.payload.config)
+    expect(cfg.botToken).toBe('123456:ABC-def')
+    expect(cfg.bindRules).toEqual([])
   })
 
-  it('integration/upsert carries the discord config (single botToken, optional applicationId); zod defaults fill lists', () => {
+  it('integration/upsert carries the discord config (single botToken, optional applicationId)', () => {
     const r = decodeEnvelope(
       envelope('integration/upsert', {
         integrationId: INTEGRATION_ID,
         agentId: AGENT_ID,
         platform: 'discord',
-        discord: { botToken: 'MTA-bot-token', applicationId: '112233445566' }
+        config: { botToken: 'MTA-bot-token', applicationId: '112233445566' }
       })
     )
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'discord') throw new Error('expected discord integration')
-    expect(r.frame.payload.discord!.botToken).toBe('MTA-bot-token')
-    expect(r.frame.payload.discord!.applicationId).toBe('112233445566')
-    expect(r.frame.payload.discord!.bindRules).toEqual([]) // zod default
+    const cfg = IntegrationDiscordConfig.parse(r.frame.payload.config)
+    expect(cfg.botToken).toBe('MTA-bot-token')
+    expect(cfg.applicationId).toBe('112233445566')
+    expect(cfg.bindRules).toEqual([])
   })
 
-  it('integration/upsert carries the feishu config (appId + appSecret pair, no appToken); zod defaults fill lists', () => {
+  it('integration/upsert carries the feishu config (appId + appSecret pair, no appToken)', () => {
     const r = decodeEnvelope(
       envelope('integration/upsert', {
         integrationId: INTEGRATION_ID,
         agentId: AGENT_ID,
         platform: 'feishu',
-        feishu: { appId: 'cli_abc123', appSecret: 'secret-xyz' }
+        config: { appId: 'cli_abc123', appSecret: 'secret-xyz' }
       })
     )
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'feishu') throw new Error('expected feishu integration')
-    expect(r.frame.payload.feishu!.appId).toBe('cli_abc123')
-    expect(r.frame.payload.feishu!.appSecret).toBe('secret-xyz')
-    expect(r.frame.payload.feishu!.mode).toBe('direct') // backwards-compatible default
-    expect(r.frame.payload.feishu!.region).toBe('feishu') // zod default — China gateway
-    expect(r.frame.payload.feishu!.bindRules).toEqual([]) // zod default
+    const cfg = IntegrationFeishuConfig.parse(r.frame.payload.config)
+    expect(cfg.appId).toBe('cli_abc123')
+    expect(cfg.appSecret).toBe('secret-xyz')
+    expect(cfg.mode).toBe('direct') // backwards-compatible default
+    expect(cfg.region).toBe('feishu') // zod default — China gateway
+    expect(cfg.bindRules).toEqual([])
   })
 
   it('integration/upsert preserves Feishu shared mode for daemon send-only API access', () => {
@@ -505,13 +536,16 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
         integrationId: INTEGRATION_ID,
         agentId: AGENT_ID,
         platform: 'feishu',
-        feishu: { mode: 'shared', appId: 'cli_abc123', appSecret: 'secret-xyz', botOpenId: 'ou_bot' }
+        config: { mode: 'shared', appId: 'cli_abc123', appSecret: 'secret-xyz', botOpenId: 'ou_bot' }
       })
     )
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'feishu') throw new Error('expected feishu integration')
-    expect(r.frame.payload.feishu).toMatchObject({ mode: 'shared', botOpenId: 'ou_bot' })
+    expect(IntegrationFeishuConfig.parse(r.frame.payload.config)).toMatchObject({
+      mode: 'shared',
+      botOpenId: 'ou_bot'
+    })
   })
 
   it("integration/upsert preserves an explicit feishu region 'lark' (international gateway)", () => {
@@ -520,13 +554,13 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
         integrationId: INTEGRATION_ID,
         agentId: AGENT_ID,
         platform: 'feishu',
-        feishu: { appId: 'cli_abc123', appSecret: 'secret-xyz', region: 'lark' }
+        config: { appId: 'cli_abc123', appSecret: 'secret-xyz', region: 'lark' }
       })
     )
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'feishu') throw new Error('expected feishu integration')
-    expect(r.frame.payload.feishu!.region).toBe('lark')
+    expect(IntegrationFeishuConfig.parse(r.frame.payload.config).region).toBe('lark')
   })
 
   it('integration/upsert rejects an unknown platform', () => {
@@ -547,17 +581,19 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
         integrationId: INTEGRATION_ID,
         agentId: AGENT_ID,
         platform: 'slack',
-        slack: {
-          botToken: 'xoxb-abc',
-          appToken: 'xapp-1-def',
-          bindRules: [{ channel: 'C123', match: { kind: 'keyword', value: 'deploy' } }]
-        }
+        core: {
+          mode: 'direct',
+          bindRules: [{ channel: 'C123', match: { kind: 'keyword', value: 'deploy' } }],
+          mutedChannels: [],
+          gated: false
+        },
+        config: { botToken: 'xoxb-abc', appToken: 'xapp-1-def' }
       })
     )
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'slack') throw new Error('expected slack integration')
-    const rule = r.frame.payload.slack!.bindRules[0]!
+    const rule = r.frame.payload.core!.bindRules[0]!
     expect(rule.channel).toBe('C123')
     expect(rule.match).toEqual({ kind: 'keyword', value: 'deploy' })
   })
@@ -624,7 +660,7 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
             integrationId: INTEGRATION_ID,
             agentId: AGENT_ID,
             platform: 'slack',
-            slack: { botToken: 'xoxb-abc', appToken: 'xapp-1-def' }
+            config: { botToken: 'xoxb-abc', appToken: 'xapp-1-def' }
           }
         ],
         drop: { assignments: [], crons: [] }
@@ -634,7 +670,7 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     if (!withInt.ok || !isFrame('register/ok')(withInt.frame)) throw new Error('expected register/ok')
     const int0 = withInt.frame.payload.integrations[0]!
     if (int0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(int0.slack!.appToken).toBe('xapp-1-def')
+    expect(IntegrationSlackConfig.parse(int0.config).appToken).toBe('xapp-1-def')
   })
 })
 

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -173,22 +173,21 @@ export type IntegrationCoreEnvelope = z.infer<typeof IntegrationCoreEnvelope>
  * long-poll, a Discord Gateway, or a Feishu long-connection from whichever variant
  * is delivered.
  *
- * DUAL-SHAPE (§6.4) — EMISSION FLIPPED: the CP now emits the `core` + `config`
- * envelope only; the legacy nested block (`slack` / `telegram` / `discord` /
- * `feishu`) stays OPTIONAL here so readers keep accepting frames from an older
- * CP until the legacy readers retire. Readers prefer the legacy block when one
- * rides and fall back to `config` (validated against the same per-platform
- * schema); `core` overrides the routing knobs wherever present. A variant
- * carrying NEITHER payload is rejected by the reader, not the schema
- * (tolerant-reader rule). The union itself opens to a flat `platformId` object
- * when the legacy members retire.
+ * ENVELOPE-ONLY (§6.4, legacy RETIRED): each variant is `core` (routing knobs)
+ * + opaque `config`, validated by the consuming platform module against its own
+ * per-platform schema. The legacy nested block (`slack` / `telegram` /
+ * `discord` / `feishu`) retired one release after CP emission stopped; a frame
+ * from an older CP still parses (non-strict objects strip the stale key) and
+ * reads through `config`, which that CP dual-emitted since §6.4 landed. A
+ * variant carrying no usable `config` is rejected by the reader, not the schema
+ * (tolerant-reader rule). Collapsing the union to one flat `platformId` object
+ * is an S3 protocol cleanup — it changes the TYPE for every consumer.
  */
 export const IntegrationSpec = z.discriminatedUnion('platform', [
   z.object({
     integrationId: z.string().uuid(),
     agentId: z.string().uuid(),
     platform: z.literal('slack'),
-    slack: IntegrationSlackConfig.optional(),
     core: IntegrationCoreEnvelope.optional(),
     config: z.unknown().optional()
   }),
@@ -196,7 +195,6 @@ export const IntegrationSpec = z.discriminatedUnion('platform', [
     integrationId: z.string().uuid(),
     agentId: z.string().uuid(),
     platform: z.literal('telegram'),
-    telegram: IntegrationTelegramConfig.optional(),
     core: IntegrationCoreEnvelope.optional(),
     config: z.unknown().optional()
   }),
@@ -204,7 +202,6 @@ export const IntegrationSpec = z.discriminatedUnion('platform', [
     integrationId: z.string().uuid(),
     agentId: z.string().uuid(),
     platform: z.literal('discord'),
-    discord: IntegrationDiscordConfig.optional(),
     core: IntegrationCoreEnvelope.optional(),
     config: z.unknown().optional()
   }),
@@ -212,7 +209,6 @@ export const IntegrationSpec = z.discriminatedUnion('platform', [
     integrationId: z.string().uuid(),
     agentId: z.string().uuid(),
     platform: z.literal('feishu'),
-    feishu: IntegrationFeishuConfig.optional(),
     core: IntegrationCoreEnvelope.optional(),
     config: z.unknown().optional()
   })

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  WireFeishuCardActionEvent,
   RdMsg,
   RdMsgWebchat,
   RdAck,
@@ -161,13 +162,15 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
   it('rd/ack carries a rejection verdict (reason, no turn stream)', () => {
     expect(RdAck.safeParse({ msgId: 'm-1', accepted: false, reason: 'no_agent' }).success).toBe(true)
     expect(RdAck.safeParse({ msgId: 'm-1', accepted: true }).success).toBe(true)
-    expect(
-      RdAck.safeParse({
-        msgId: 'm-1',
-        accepted: true,
-        feishuCardAction: { toast: { type: 'info', content: 'Cancellation requested.' } }
-      }).success
-    ).toBe(true)
+    // The retired Feishu-named slot from a pre-flip daemon strips cleanly.
+    const dual = RdAck.safeParse({
+      msgId: 'm-1',
+      accepted: true,
+      feishuCardAction: { toast: { type: 'info', content: 'Cancellation requested.' } },
+      response: { toast: { type: 'info', content: 'Cancellation requested.' } }
+    })
+    expect(dual.success).toBe(true)
+    if (dual.success) expect('feishuCardAction' in dual.data).toBe(false)
     expect(RdAck.safeParse({ msgId: 'm-1' }).success).toBe(false) // verdict is required
   })
 
@@ -417,9 +420,10 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     expect(RdAgentMsgAck.safeParse({ deliveryId: 'd-1', delivered: false, reason: 'unsupported' }).success).toBe(true)
   })
 
-  it('decodes every shared Slack session action inside rd/msg and rejects malformed controls', () => {
+  it('decodes every shared Slack session action inside a platform_action rd/msg; RdSlackAction rejects malformed controls', () => {
     const base = {
-      source: 'slack_action' as const,
+      source: 'platform_action' as const,
+      platformId: 'slack',
       agentId: AGENT_ID,
       sessionKey: 'slack:C123:1720000000.000100:agent',
       msgId: 'slack-action:abc123',
@@ -448,20 +452,43 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       expect(RdSlackAction.safeParse(payload).success).toBe(true)
       expect(decodeRelayDaemonFrame(envelope('rd/msg', { ...base, payload })).ok).toBe(true)
     }
-    expect(RdMsg.safeParse({ ...base, payload: { kind: 'set-output', outputMode: 'verbose' } }).success).toBe(false)
-    expect(RdMsg.safeParse({ ...base, payload: { kind: 'open-config', triggerId: '' } }).success).toBe(false)
+    // The envelope's payload is opaque — malformed CONTROLS are the per-platform
+    // decoder's verdict (NAK unsupported_action), enforced by RdSlackAction.
+    expect(RdSlackAction.safeParse({ kind: 'set-output', outputMode: 'verbose' }).success).toBe(false)
+    expect(RdSlackAction.safeParse({ kind: 'open-config', triggerId: '' }).success).toBe(false)
     expect(
-      RdMsg.safeParse({
-        ...base,
-        payload: { kind: 'open-config-for-thread', triggerId: 'trigger-2', channelId: 'C123', threadTs: '' }
+      RdSlackAction.safeParse({
+        kind: 'open-config-for-thread',
+        triggerId: 'trigger-2',
+        channelId: 'C123',
+        threadTs: ''
       }).success
     ).toBe(false)
+    // Envelope-level identity stays schema-enforced.
     expect(RdMsg.safeParse({ ...base, integrationId: 'not-a-uuid', payload: { kind: 'cancel' } }).success).toBe(false)
   })
 
-  it('decodes a Lark / Feishu HTTP card action inside rd/msg', () => {
+  it('REJECTS the retired platform-named interaction members (nothing emits them)', () => {
+    // S1b cleanup: `slack_action` / `feishu_action` retired one release after the
+    // relay's §6.6 emission flip. A frame from an older relay fails the decode and
+    // is dropped with a log — the discriminated union no longer carries the members.
+    const legacy = {
+      source: 'slack_action',
+      agentId: AGENT_ID,
+      sessionKey: 'slack:C123:1720000000.000100:agent',
+      msgId: 'slack-action:abc123',
+      botId: DAEMON_ID,
+      integrationId: CONV_ID,
+      payload: { kind: 'cancel' }
+    }
+    expect(decodeRelayDaemonFrame(envelope('rd/msg', legacy)).ok).toBe(false)
+    expect(RdMsg.safeParse({ ...legacy, source: 'feishu_action' }).success).toBe(false)
+  })
+
+  it('decodes a Lark / Feishu HTTP card action inside a platform_action rd/msg', () => {
     const action = {
-      source: 'feishu_action',
+      source: 'platform_action',
+      platformId: 'feishu',
       agentId: AGENT_ID,
       sessionKey: 'feishu-action:om_card',
       msgId: 'feishu-action:abc123',
@@ -482,10 +509,12 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     }
     const decoded = decodeRelayDaemonFrame(envelope('rd/msg', action))
     expect(decoded.ok).toBe(true)
-    if (!decoded.ok || decoded.frame.type !== 'rd/msg' || decoded.frame.payload.source !== 'feishu_action') {
-      throw new Error('expected Feishu action')
+    if (!decoded.ok || decoded.frame.type !== 'rd/msg' || decoded.frame.payload.source !== 'platform_action') {
+      throw new Error('expected platform action')
     }
-    expect(decoded.frame.payload.payload.context?.open_message_id).toBe('om_card')
+    // The envelope payload is opaque at the frame layer; the daemon's feishu
+    // decoder validates it against WireFeishuCardActionEvent.
+    expect(WireFeishuCardActionEvent.parse(decoded.frame.payload.payload).context?.open_message_id).toBe('om_card')
   })
 
   it('decodes an rd/msg hook fire (B-github) and enforces its required fields', () => {

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -251,25 +251,6 @@ export const RdSlackAction = z.discriminatedUnion('kind', [
 ])
 export type RdSlackAction = z.infer<typeof RdSlackAction>
 
-/** R→D REQ → rd/ack. The relay has validated either an opaque rendered-control
- *  target or a message shortcut's current conversation owner against its shared-bot
- *  assignment, and names the canonical agent + integration. Coordinate shortcuts
- *  are resolved to an exact bot-scoped session again by the daemon. */
-export const RdMsgSlackAction = z.object({
-  source: z.literal('slack_action'),
-  agentId: z.string().uuid(),
-  sessionKey: z.string().min(1),
-  msgId: z.string().min(1),
-  botId: z.string().uuid(),
-  integrationId: z.string().uuid(),
-  // The platform user who tapped it, so a shared-bot session change is attributable
-  // the way a direct connection's already is. Optional for rolling compatibility with
-  // an older relay: absent records as an unknown actor, never a fabricated one.
-  userId: z.string().min(1).optional(),
-  payload: RdSlackAction
-})
-export type RdMsgSlackAction = z.infer<typeof RdMsgSlackAction>
-
 /** The provider-authenticated body of one Lark / Feishu `card.action.trigger`.
  * The daemon deliberately resolves the opaque message id against its local active-card
  * map instead of trusting relay-supplied session coordinates. */
@@ -323,20 +304,6 @@ export const WireFeishuCardActionResponse = z.object({
     .optional()
 })
 export type WireFeishuCardActionResponse = z.infer<typeof WireFeishuCardActionResponse>
-
-/** R→D REQ → rd/ack. The relay validates the card's rendered target against its
- * current assignment; the daemon then validates the message id and action value
- * against local active-card state before applying the control. */
-export const RdMsgFeishuAction = z.object({
-  source: z.literal('feishu_action'),
-  agentId: z.string().uuid(),
-  sessionKey: z.string().min(1),
-  msgId: z.string().min(1),
-  botId: z.string().uuid(),
-  integrationId: z.string().uuid(),
-  payload: WireFeishuCardActionEvent
-})
-export type RdMsgFeishuAction = z.infer<typeof RdMsgFeishuAction>
 
 /**
  * R→D REQ → rd/ack (§6.6). The ONE platform-interaction envelope replacing the
@@ -398,14 +365,12 @@ export const RdMsgHook = z.object({
 export type RdMsgHook = z.infer<typeof RdMsgHook>
 
 // Shared-bot IM + status actions and webhook fires join the webchat union.
-export const RdMsg = z.discriminatedUnion('source', [
-  RdMsgWebchat,
-  RdMsgIm,
-  RdMsgSlackAction,
-  RdMsgFeishuAction,
-  RdMsgPlatformAction,
-  RdMsgHook
-])
+// The platform-named interaction members (`slack_action` / `feishu_action`)
+// RETIRED here (S1b cleanup): nothing has emitted them since the relay's §6.6
+// flip shipped a release earlier, so the union now carries the one
+// platform_action envelope. A frame from an older relay fails the decode and is
+// dropped with a log — never crashing the pipe.
+export const RdMsg = z.discriminatedUnion('source', [RdMsgWebchat, RdMsgIm, RdMsgPlatformAction, RdMsgHook])
 export type RdMsg = z.infer<typeof RdMsg>
 
 // D→R REP (corr = rd/msg id). Receipt for dedup/ack bookkeeping; for a webchat
@@ -416,12 +381,11 @@ export const RdAck = z.object({
   accepted: z.boolean(),
   turnId: z.string().uuid().optional(),
   reason: z.string().optional(),
-  /** DEPRECATED (§6.6): read `response`. The Feishu-named sync-toast slot. */
-  feishuCardAction: WireFeishuCardActionResponse.optional(),
   /** §6.6 opaque interaction response for a `platform_action` — the payload the
    *  relay-side platform module surfaces on the synchronous HTTP body (Feishu
-   *  toast, Slack block_suggestion options). Dual-emitted with the deprecated
-   *  slot above during the window; decoded only by the platform module. */
+   *  toast, Slack block_suggestion options). Decoded only by the platform
+   *  module. (The Feishu-named `feishuCardAction` slot retired with the legacy
+   *  interaction members.) */
   response: z.unknown().optional()
 })
 export type RdAck = z.infer<typeof RdAck>

--- a/packages/protocol/src/normalized-message.ts
+++ b/packages/protocol/src/normalized-message.ts
@@ -122,12 +122,10 @@ export const NormalizedPlatformMessageSchema = z.object({
    *  (`adapterExt.telegram`, …). Never read by core; round-tripped back to the
    *  platform adapter at render time (S2 renderer seam). */
   adapterExt: z.record(z.string(), z.unknown()).optional(),
-  /** DEPRECATED (§6.5): read `topicId`. Telegram forum topic id, may be used as `message_thread_id` on send. */
-  telegramTopicId: z.string().optional(),
-  /** DEPRECATED (§6.5): read `threadRoot`. Telegram non-forum reply-thread root. */
-  telegramThreadRoot: z.string().optional(),
-  /** DEPRECATED (§6.5): read `promoteToThread`. Discord top-level guild message to move into a thread. */
-  discordTopLevel: z.boolean().optional(),
+  // The platform-named coordinate twins (`telegramTopicId` / `telegramThreadRoot` /
+  // `discordTopLevel`) RETIRED here (S1b cleanup): the generic fields above are the
+  // only emitted shape since the §6.5 flip; an older peer's named fields are simply
+  // stripped by this non-strict object schema.
   /** Enclosing container channel when `channel` is itself a thread channel (Discord
    *  threads). GENERIC and core-read (bind-rule admission spans thread→parent), so it
    *  is part of the coordinate model, not adapterExt (D2: pre-dispatch core read). */

--- a/packages/protocol/src/platform-tolerance.test.ts
+++ b/packages/protocol/src/platform-tolerance.test.ts
@@ -244,12 +244,14 @@ describe('§6.5 generic thread coordinates + adapterExt', () => {
       })
     )
 
-  it('decodes dual-shape (named + generic) and generic-only coordinates', () => {
+  it('decodes generic coordinates; a legacy named twin from an older peer is stripped', () => {
+    // §6.5 legacy RETIRED: named twins are unknown keys now — stripped by the
+    // non-strict object, never a decode failure, and the generic field carries.
     const dual = im({ telegramTopicId: '55', topicId: '55' })
     expectOk(dual)
     if (dual.ok && dual.frame.type === 'rd/msg' && dual.frame.payload.source === 'im') {
       expect(dual.frame.payload.payload.topicId).toBe('55')
-      expect(dual.frame.payload.payload.telegramTopicId).toBe('55')
+      expect('telegramTopicId' in dual.frame.payload.payload).toBe(false)
     }
     expectOk(im({ threadRoot: '6', promoteToThread: true }))
   })
@@ -291,7 +293,9 @@ describe('§6.6 platform_action envelope', () => {
     expectOk(pa({ platformId: UNKNOWN, payload: { anything: true } }))
   })
 
-  it('rd/ack carries the generic opaque response beside the deprecated Feishu slot', () => {
+  it('rd/ack carries the generic opaque response; the retired Feishu slot is stripped', () => {
+    // A pre-flip daemon still dual-fills; the named slot is an unknown key now and
+    // strips cleanly while the generic response carries.
     const r = decodeRelayDaemonFrame(
       envelope('rd/ack', {
         msgId: 'pa-1',
@@ -303,6 +307,7 @@ describe('§6.6 platform_action envelope', () => {
     expectOk(r)
     if (r.ok && r.frame.type === 'rd/ack') {
       expect(r.frame.payload.response).toEqual({ toast: { type: 'info', content: 'ok' } })
+      expect('feishuCardAction' in r.frame.payload).toBe(false)
     }
   })
 })

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -351,9 +351,10 @@ describe('RelayIngressManager HTTP Lark / Feishu card actions', () => {
     })
   })
 
-  it('still reads the deprecated Feishu-named ack slot from a pre-flip daemon', async () => {
-    // Tolerance window: a daemon that has not yet learned to fill `response`
-    // answers through the deprecated slot; the callback must still reach Feishu.
+  it('ignores the RETIRED Feishu-named ack slot — the generic response is the one answer', async () => {
+    // S1b cleanup: the named slot left RdAck one release after every fleet daemon
+    // began filling `response` (#521). An ack carrying only the stale key (which
+    // the schema now strips) yields no callback body rather than resurrecting it.
     const response = { toast: { type: 'info' as const, content: 'Cancellation requested.' } }
     const sendMsg = vi.fn(async (msg: RdMsgPlatformAction): Promise<RdAck> => ({
       msgId: msg.msgId,
@@ -379,7 +380,7 @@ describe('RelayIngressManager HTTP Lark / Feishu card actions', () => {
       operator: { open_id: 'ou_human' },
       action: { tag: 'overflow', option: 'cancel' }
     }
-    await expect(internals.forwardFeishuAction(BOT_ID, action, 'evt-action')).resolves.toEqual(response)
+    await expect(internals.forwardFeishuAction(BOT_ID, action, 'evt-action')).resolves.toBeUndefined()
   })
 })
 

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -975,11 +975,11 @@ export class RelayIngressManager {
       if (!ack.accepted) {
         this.deps.log.warn(`relay-ingress(${botId}): daemon rejected Feishu card action (${ack.reason ?? 'unknown'})`)
       }
-      // §6.6: a fleet daemon answers a platform_action with the generic opaque
-      // `response`; the Feishu-named slot is read as a tolerance fallback until
-      // the deprecated rd/ack member retires with the legacy readers.
+      // §6.6: the generic opaque `response` is the ONE answer slot — the
+      // Feishu-named rd/ack member retired with the legacy interaction members
+      // (every fleet daemon has filled `response` since #521).
       const generic = WireFeishuCardActionResponse.safeParse(ack.response)
-      return generic.success && ack.response !== undefined ? generic.data : ack.feishuCardAction
+      return generic.success && ack.response !== undefined ? generic.data : undefined
     } catch (err) {
       this.deps.log.warn(`relay-ingress(${botId}): Feishu card action forward failed: ${(err as Error).message}`)
       return undefined


### PR DESCRIPTION
The final S1b cleanup — one release after nothing emits these shapes (#544/#545), the readers and their schema slots retire.

| shape | what leaves | tolerance for older peers |
| --- | --- | --- |
| `rd/msg` union | `slack_action` / `feishu_action` members + the daemon's legacy dispatch arms | a frame from an older relay **fails the decode and is dropped with a log** — never crashing the pipe (pinned by a new rejection test) |
| `rd/ack` | the Feishu-named `feishuCardAction` slot; generic `response` is the one answer | every fleet daemon has filled `response` since #521; a pre-flip daemon's stale key strips cleanly |
| `NormalizedMessage` | `telegramTopicId` / `telegramThreadRoot` / `discordTopLevel` + the daemon dual-read fallbacks | named fields strip at the non-strict object; that peer dual-emitted the generic fields since #518 |
| `IntegrationSpec` | the legacy nested blocks; each variant is `core` + opaque `config`; `write-integration` becomes a pure envelope reader | a legacy-only spec (pre-§6.4 emitter) is refused with the existing warn+skip and the CP re-sends |

The daemon's two action handlers stay — they are platform code behind their #538 registry decoders — with local input types replacing the retired frame types.

**One observable disk-shape delta, test-pinned:** the per-platform wire schema now fills the defaulted knobs at the consumer parse, so `shareable`/`mutedChannels`/`gated` always reach `agent.json` (previously implied by the frame-layer parse).

## ⚠️ Deployment order

This train must reach prod **after** the #544/#545 train is promoted. If both ride one promote, the rolling window pairs a `platform_action`-emitting relay with fleet daemons that already read it (#521 — safe), but a pre-#544 relay still emitting `slack_action` against a daemon from THIS train gets its interaction frames dropped until the relay pod rolls.

## Still deliberately NOT retired

`RcBotAssign`'s named demux fields — the CP still emits them beside the `ingress` bag; that emission stops in the follow-up PR now that the relay's bag reader (#545) ships first.

## Verification

- protocol **269** ✓ (incl. new legacy-member rejection pins; stripped-key pins for ack/coords/spec)
- daemon **2895** ✓ (46 skipped; the one failure is the known #503 full-suite load flake, green standalone and failing on clean `main` too)
- relay **403** ✓ (the pre-flip tolerance case now pins the retired slot is *ignored*)
- message **26** ✓; CP unit **1022** ✓; CP integration **950** ✓ (Testcontainers, local)
- full monorepo typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)