### PR TITLE
feat(cp): demux identity rides the ingress bag only (§6.7 flip — last S1b residue)

### DIFF
--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -423,13 +423,13 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     const assign = ch.sends.find((send) => send.type === 'rc/bot-assign')?.payload as RcBotAssign
     expect(assign).toMatchObject({
       platform: 'feishu',
-      apiAppId: 'cli_http_app',
-      botUserId: 'ou_bot',
+      ingress: { apiAppId: 'cli_http_app', botUserId: 'ou_bot' },
       secrets: { verificationToken: 'verify-token', encryptKey: 'encrypt-key' },
       defaultAgentId: ALICE,
       defaultDaemonId: D1,
       agents: [{ agentId: ALICE, daemonId: D1, integrationId: INT_A }]
     })
+    expect(assign.apiAppId).toBeUndefined()
     expect('botToken' in assign.secrets).toBe(false)
     expect(upserts).toEqual([
       {
@@ -885,17 +885,21 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     expect(ch.sends).toEqual([]) // nothing broadcast
   })
 
-  it('stamps teamId + botUserId into rc/bot-assign for a platform-app install', async () => {
+  it('stamps teamId + botUserId into the rc/bot-assign ingress bag for a platform-app install', async () => {
     // A distributed app's install: every workspace shares the app id + signing
     // secret, so the relay may only demux this bot on (api_app_id, team_id).
+    // §6.7 emission flip: the opaque ingress bag is the ONE carrier — the named
+    // top-level fields are no longer emitted (the relay's bag reader shipped
+    // first in #545).
     botRow = bot({ slackAppId: 'APLATFORM', teamId: 'T1WORKSPACE', botUserId: 'U0BOT' })
 
     await makeOrch().syncBot(BOT)
 
     const assign = ch.sends.find((send) => send.type === 'rc/bot-assign')?.payload as RcBotAssign
-    expect(assign.apiAppId).toBe('APLATFORM')
-    expect(assign.teamId).toBe('T1WORKSPACE')
-    expect(assign.botUserId).toBe('U0BOT')
+    expect(assign.ingress).toEqual({ apiAppId: 'APLATFORM', teamId: 'T1WORKSPACE', botUserId: 'U0BOT' })
+    expect(assign.apiAppId).toBeUndefined()
+    expect(assign.teamId).toBeUndefined()
+    expect(assign.botUserId).toBeUndefined()
   })
 
   it('revokeBot marks the bot + installs revoked, unassigns, and pulls the daemon specs', async () => {

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -881,9 +881,19 @@ export class HttpBotOrchestrator {
       // §6.1: a bot assignment is always a CHAT platform; carried so an older
       // relay can classify an id a newer CP introduces.
       originKind: 'chat',
-      // §6.7 dual-shape: the opaque ingress bag mirrors the named demux fields
-      // below; the platform module (S3) takes its validation over and the named
-      // fields stop being emitted once the fleet reads the bag.
+      // §6.7 emission flip (the last S1b dual-shape residue): the opaque ingress
+      // bag is the ONE carrier of the demux identity — the relay's bag-preferring
+      // reader shipped first (#545). The retired named top-level fields stay
+      // OPTIONAL in the wire schema so an older relay's tolerant reader is not
+      // broken by their absence; they leave the schema with the next cleanup.
+      //   apiAppId — Slack "A…" (== Events API api_app_id) or the Feishu app id;
+      //     O(1) inbound demux. Absent on a manual-paste http bot (no xapp to
+      //     parse); the relay verify-scans instead.
+      //   teamId — workspace "T…", present only for a distributed (platform)
+      //     app's install, where the composite (api_app_id, team_id) is the ONLY
+      //     safe demux (all sibling installs share the app id AND the signing
+      //     secret).
+      //   botUserId — persisted at OAuth exchange; spares an auth.test round-trip.
       ingress: {
         ...(bot.platform === 'feishu' && secret.appToken
           ? { apiAppId: secret.appToken }
@@ -893,19 +903,6 @@ export class HttpBotOrchestrator {
         ...(bot.teamId ? { teamId: bot.teamId } : {}),
         ...(bot.botUserId ? { botUserId: bot.botUserId } : {})
       },
-      // Slack app id ("A…", == Events API api_app_id) — O(1) inbound demux. Absent on
-      // a manual-paste http bot (no xapp to parse); the relay verify-scans instead.
-      ...(bot.platform === 'feishu' && secret.appToken
-        ? { apiAppId: secret.appToken }
-        : bot.slackAppId
-          ? { apiAppId: bot.slackAppId }
-          : {}),
-      // Workspace id ("T…") — present only for a distributed (platform) app's
-      // install, where the composite (api_app_id, team_id) is the ONLY safe demux
-      // (all sibling installs share the app id AND the signing secret).
-      ...(bot.teamId ? { teamId: bot.teamId } : {}),
-      // Persisted at OAuth exchange; spares the relay an auth.test round-trip.
-      ...(bot.botUserId ? { botUserId: bot.botUserId } : {}),
       // Generation of the credentials below — echoed back on `rc/bot-revoked` so a
       // revocation observed under a REPLACED credential cannot kill this one.
       credentialRevision: bot.credentialRevision,

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -527,7 +527,7 @@ describe('Feishu/Lark one-click app registration', () => {
       type: 'rc/bot-assign',
       payload: expect.objectContaining({
         platform: 'feishu',
-        apiAppId: 'cli_http_oneclick',
+        ingress: expect.objectContaining({ apiAppId: 'cli_http_oneclick' }),
         secrets: { verificationToken: secret.verificationToken, encryptKey: secret.encryptKey }
       })
     })

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -561,14 +561,13 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
 
     const assign = relaySends.find((send) => send.type === 'rc/bot-assign')?.payload as {
       platform: string
-      apiAppId: string
-      botUserId: string
+      ingress: Record<string, unknown>
       secrets: Record<string, unknown>
     }
+    // §6.7 emission flip: the demux identity rides the opaque ingress bag only.
     expect(assign).toMatchObject({
       platform: 'feishu',
-      apiAppId: 'cli_http_app',
-      botUserId: 'ou_http_bot',
+      ingress: { apiAppId: 'cli_http_app', botUserId: 'ou_http_bot' },
       secrets: { verificationToken: 'verify-token', encryptKey: 'encrypt-key' }
     })
     expect(assign.secrets).not.toHaveProperty('botToken')


### PR DESCRIPTION
The **final emission flip**: `rc/bot-assign` stops dual-emitting the named top-level demux fields (`apiAppId` / `teamId` / `botUserId`) beside the opaque `ingress` bag. The relay's bag-preferring reader shipped **first** (#545) — the reader-first order that PR's audit established when it found #518 had landed the dual-emission without the bag reader.

The retired named fields stay **optional** in the wire schema so an older relay's tolerant reader is not broken by their absence; they leave the schema with the next cleanup pass alongside the rest of the S1b optional residue.

## ⚠️ Deployment order (same note as #554)

This train must reach prod **after** the #545 train is promoted. If both ride one promote, a pre-#545 relay pod in the rolling window reads only the named fields and loses the demux identity until it rolls — for a distributed Slack app that means the `(api_app_id, team_id)` composite demux degrades to verify-scan, which **cannot distinguish sibling workspace installs**.

## Verification

- CP unit **1022** ✓ (orchestrator suite pins: bag carries the identity, named fields `undefined`)
- CP integration **950** ✓ (both install funnels re-pinned; Testcontainers, local)
- relay **403** ✓ (the #545 bag-reader arms cover the new emission)
- typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)