### PR TITLE
fix(sessions): add actionable access recovery

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -532,6 +532,14 @@ membership. Guests and Slack Connect users also require current conversation mem
 including for a channel that is public to full members of the installing workspace. The
 organization-owner role never bypasses these provider checks.
 
+An external membership check that cannot complete fails closed: affected sessions stay
+hidden. The console offers a provider-specific reconnect only when the failure occurred
+while retrieving the signed-in user's own federated authorization; provider API failures
+and unclassified degradation keep the generic unavailable notice. Feishu versus Lark is
+named from the session scope's verified regional app, never from a URL hint. Diagnostics
+may retain only the provider target, failure stage, HTTP status, and a bounded upstream
+error code — never account ids, bearer tokens, or upstream error messages.
+
 Making a session private hides its transcript immediately, but agent memory is shared
 across the whole agent, so the guarantee about memory is narrower and must be stated
 plainly wherever the change is offered: capture into shared memory stops once the owning

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2475,6 +2475,14 @@ export const ConversationDto = z.object({
   memberSessionIds: z.array(z.string())
 })
 
+/** Safe, requester-scoped explanation for a failed-closed external access check.
+ *  It intentionally excludes upstream response bodies, account ids, and tokens. */
+export const SessionAccessIssueDto = z.object({
+  provider: z.string().min(1),
+  region: z.string().min(1).optional(),
+  reason: z.enum(['authorization', 'unavailable'])
+})
+
 export const SessionListPageDto = z.object({
   /** `view=flat`: the raw session rows (the pre-grouped list shape). */
   sessions: SessionListDto.optional(),
@@ -2489,7 +2497,8 @@ export const SessionListPageDto = z.object({
   // org-wide without exposing metadata of sessions the caller cannot see.
   orgHasSessions: z.boolean().optional(),
   /** True when any provider membership decision failed closed for this page. */
-  accessSyncDegraded: z.boolean().optional()
+  accessSyncDegraded: z.boolean().optional(),
+  accessIssues: z.array(SessionAccessIssueDto).optional()
 })
 
 /** `GET /sessions/:id` — the deep-link detail view, served from CP-stored
@@ -2546,6 +2555,7 @@ export const SessionDetailDto = z.object({
    *  server-side; the console never re-derives permissions from identity. */
   canChangeVisibility: z.boolean(),
   accessSyncDegraded: z.boolean(),
+  accessIssues: z.array(SessionAccessIssueDto).optional(),
   /** Multi-agent webchat conversation roster, in pick order (webchat-multi-agents.md
    *  §3.1). Adopted/refreshed sessions have no live relay socket to deliver the
    *  verified roster, so the composer and header read it from here. Null for
@@ -2997,6 +3007,7 @@ export const UsageAgentDto = z.object({
 export const UsageDto = z.object({
   range: UsageRange,
   accessSyncDegraded: z.boolean().optional(),
+  accessIssues: z.array(SessionAccessIssueDto).optional(),
   totals: z.object({
     sessions: z.number(),
     totalTokens: z.number(),

--- a/packages/control-plane/src/http/feishu-session-access.test.ts
+++ b/packages/control-plane/src/http/feishu-session-access.test.ts
@@ -63,6 +63,7 @@ describe('FeishuSessionAccessService', () => {
     const result = await service(fetchImpl).resolve(scopes, viewer(accessTokenFor))
     expect(result.allowedScopes).toHaveLength(201)
     expect(result.degraded).toBe(false)
+    expect(result.accessIssues).toEqual([])
     expect(accessTokenFor).toHaveBeenCalledOnce()
   })
 
@@ -71,7 +72,8 @@ describe('FeishuSessionAccessService', () => {
 
     await expect(service(fetchImpl).resolve([scope()], viewer())).resolves.toEqual({
       allowedScopes: [{ id: scope().id, aclRevision: 2n }],
-      degraded: false
+      degraded: false,
+      accessIssues: []
     })
     expect(fetchImpl).toHaveBeenCalledWith(
       'https://open.larksuite.com/open-apis/im/v1/chats/oc_chat/members/is_in_chat',
@@ -83,26 +85,49 @@ describe('FeishuSessionAccessService', () => {
   it('denies when the user token is not in the chat', async () => {
     await expect(
       service(async () => json({ code: 0, data: { is_in_chat: false } })).resolve([scope()], viewer())
-    ).resolves.toEqual({ allowedScopes: [], degraded: false })
+    ).resolves.toEqual({ allowedScopes: [], degraded: false, accessIssues: [] })
   })
 
   it('fails closed and reports degradation when no request-bound user credential is present', async () => {
     const fetchImpl = vi.fn(async () => json({ code: 0, data: { is_in_chat: true } }))
-    await expect(service(fetchImpl).resolve([scope()])).resolves.toEqual({ allowedScopes: [], degraded: true })
+    await expect(service(fetchImpl).resolve([scope()])).resolves.toEqual({
+      allowedScopes: [],
+      degraded: true,
+      accessIssues: []
+    })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('identifies a request-bound authorization failure without calling the chat API', async () => {
+    const fetchImpl = vi.fn(async () => json({ code: 0, data: { is_in_chat: true } }))
+    const accessTokenFor = vi.fn(async () => {
+      throw new Error('provider token unavailable')
+    })
+
+    await expect(service(fetchImpl).resolve([scope()], viewer(accessTokenFor))).resolves.toEqual({
+      allowedScopes: [],
+      degraded: true,
+      accessIssues: [{ provider: 'feishu', region: 'lark', reason: 'authorization' }]
+    })
     expect(fetchImpl).not.toHaveBeenCalled()
   })
 
   it('fails closed and reports degradation for a provider permission failure', async () => {
     await expect(
       service(async () => json({ code: 99991672, msg: 'missing scope' })).resolve([scope()], viewer())
-    ).resolves.toEqual({ allowedScopes: [], degraded: true })
+    ).resolves.toEqual({
+      allowedScopes: [],
+      degraded: true,
+      accessIssues: [{ provider: 'feishu', region: 'lark', reason: 'unavailable' }]
+    })
   })
 
   it('rejects a scope whose realm does not match its custom Bot app', async () => {
     const fetchImpl = vi.fn(async () => json({ code: 0, data: { is_in_chat: true } }))
     await expect(service(fetchImpl).resolve([{ ...scope(), realmKey: 'lark:cli_other' }], viewer())).resolves.toEqual({
       allowedScopes: [],
-      degraded: false
+      degraded: false,
+      accessIssues: []
     })
     expect(fetchImpl).not.toHaveBeenCalled()
   })

--- a/packages/control-plane/src/http/feishu-session-access.ts
+++ b/packages/control-plane/src/http/feishu-session-access.ts
@@ -3,6 +3,7 @@ import type { Clock } from '../domain/clock.js'
 import { BotId } from '../domain/ids.js'
 import type { FetchLike } from '../github/api.js'
 import type { BotRepo, ExternalScopeRecord } from '../persistence/ports.js'
+import type { SessionAccessIssue } from './session-access.js'
 
 const REGION_ORIGIN: Record<FeishuRegion, string> = {
   feishu: 'https://open.feishu.cn',
@@ -17,6 +18,7 @@ const SCOPE_CONCURRENCY = 6
 const TIMEOUT_MS = 5_000
 
 type Decision = 'allow' | 'deny' | 'unknown'
+type ScopeDecision = { decision: Decision; issue?: SessionAccessIssue }
 
 const DEFINITIVE_DENIALS = new Set([232006, 232009, 232010, 232011])
 
@@ -28,6 +30,7 @@ export interface FeishuSessionViewer {
 export interface FeishuSessionAccessResult {
   allowedScopes: Array<{ id: string; aclRevision: bigint }>
   degraded: boolean
+  accessIssues: SessionAccessIssue[]
 }
 
 export interface FeishuSessionAccessResolver {
@@ -52,7 +55,7 @@ async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value:
  * app's user token against the custom Bot app's immutable chat id. No app-scoped
  * open_id values are compared. Only bounded membership verdicts are retained. */
 export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
-  private readonly cache = new Map<string, { decision: Decision; expiresAt: number }>()
+  private readonly cache = new Map<string, { result: ScopeDecision; expiresAt: number }>()
 
   constructor(private readonly deps: { bots: BotRepo; clock: Clock; fetchImpl?: FetchLike }) {}
 
@@ -60,8 +63,8 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
     scopes: readonly ExternalScopeRecord[],
     viewer?: FeishuSessionViewer
   ): Promise<FeishuSessionAccessResult> {
-    if (scopes.length === 0) return { allowedScopes: [], degraded: false }
-    if (!viewer) return { allowedScopes: [], degraded: true }
+    if (scopes.length === 0) return { allowedScopes: [], degraded: false, accessIssues: [] }
+    if (!viewer) return { allowedScopes: [], degraded: true, accessIssues: [] }
     const tokens = new Map<FeishuRegion, Promise<string>>()
     const tokenFor = (region: FeishuRegion): Promise<string> => {
       let pending = tokens.get(region)
@@ -72,13 +75,15 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
       return pending
     }
     let degraded = false
+    const accessIssues = new Map<string, SessionAccessIssue>()
     const decisions: Array<{ scope: ExternalScopeRecord; decision: Decision }> = []
     for (let start = 0; start < scopes.length; start += SCOPES_PER_BATCH) {
       const signal = AbortSignal.timeout(TIMEOUT_MS)
       decisions.push(
         ...(await mapLimited(scopes.slice(start, start + SCOPES_PER_BATCH), SCOPE_CONCURRENCY, async (scope) => {
-          const decision = await this.resolveScope(scope, viewer, tokenFor, signal)
+          const { decision, issue } = await this.resolveScope(scope, viewer, tokenFor, signal)
           if (decision === 'unknown') degraded = true
+          if (issue) accessIssues.set(`${issue.provider}:${issue.region ?? ''}:${issue.reason}`, issue)
           return { scope, decision }
         }))
       )
@@ -87,7 +92,8 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
       allowedScopes: decisions
         .filter(({ decision }) => decision === 'allow')
         .map(({ scope }) => ({ id: scope.id, aclRevision: scope.aclRevision })),
-      degraded
+      degraded,
+      accessIssues: [...accessIssues.values()]
     }
   }
 
@@ -96,7 +102,7 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
     viewer: FeishuSessionViewer,
     tokenFor: (region: FeishuRegion) => Promise<string>,
     signal: AbortSignal
-  ): Promise<Decision> {
+  ): Promise<ScopeDecision> {
     if (
       scope.provider !== 'feishu' ||
       scope.resourceKind !== 'conversation' ||
@@ -104,7 +110,7 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
       scope.credentialKind !== 'bot' ||
       !scope.credentialId
     ) {
-      return 'deny'
+      return { decision: 'deny' }
     }
     const bot = await this.deps.bots.get(BotId(scope.credentialId)).catch(() => null)
     const region = bot?.platform === 'feishu' ? (bot.feishuRegion ?? 'feishu') : undefined
@@ -118,17 +124,17 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
       !appId ||
       scope.realmKey !== `${region}:${appId}`
     ) {
-      return 'deny'
+      return { decision: 'deny' }
     }
 
     const key = [scope.id, scope.aclRevision.toString(), bot.credentialRevision, viewer.subject].join(':')
     const cached = this.cache.get(key)
-    let decision = cached && cached.expiresAt > this.deps.clock.now() ? cached.decision : undefined
-    if (!decision) {
-      decision = await this.checkMembership(region, scope.resourceKey, tokenFor, signal)
-      this.putCache(key, decision)
+    let result = cached && cached.expiresAt > this.deps.clock.now() ? cached.result : undefined
+    if (!result) {
+      result = await this.checkMembership(region, scope.resourceKey, tokenFor, signal)
+      this.putCache(key, result)
     }
-    return decision
+    return result
   }
 
   private async checkMembership(
@@ -136,9 +142,14 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
     chatId: string,
     tokenFor: (region: FeishuRegion) => Promise<string>,
     signal: AbortSignal
-  ): Promise<Decision> {
+  ): Promise<ScopeDecision> {
+    let token: string
     try {
-      const token = await tokenFor(region)
+      token = await tokenFor(region)
+    } catch {
+      return { decision: 'unknown', issue: { provider: 'feishu', region, reason: 'authorization' } }
+    }
+    try {
       const body = await this.call<{ code?: unknown; data?: { is_in_chat?: unknown } }>(
         region,
         `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}/members/is_in_chat`,
@@ -146,13 +157,17 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
         signal
       )
       const code = typeof body.code === 'number' ? body.code : Number(body.code)
-      if (code !== 0) return DEFINITIVE_DENIALS.has(code) ? 'deny' : 'unknown'
-      if (body.data?.is_in_chat === true) return 'allow'
-      if (body.data?.is_in_chat === false) return 'deny'
+      if (code !== 0) {
+        return DEFINITIVE_DENIALS.has(code)
+          ? { decision: 'deny' }
+          : { decision: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
+      }
+      if (body.data?.is_in_chat === true) return { decision: 'allow' }
+      if (body.data?.is_in_chat === false) return { decision: 'deny' }
     } catch {
-      return 'unknown'
+      return { decision: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
     }
-    return 'unknown'
+    return { decision: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
   }
 
   private async call<T>(
@@ -175,12 +190,12 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
     return body
   }
 
-  private putCache(key: string, decision: Decision): void {
+  private putCache(key: string, result: ScopeDecision): void {
     if (this.cache.size >= MAX_CACHE_ENTRIES) {
       const oldest = this.cache.keys().next().value as string | undefined
       if (oldest) this.cache.delete(oldest)
     }
-    const ttl = decision === 'allow' ? ALLOW_TTL_MS : decision === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
-    this.cache.set(key, { decision, expiresAt: this.deps.clock.now() + ttl })
+    const ttl = result.decision === 'allow' ? ALLOW_TTL_MS : result.decision === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
+    this.cache.set(key, { result, expiresAt: this.deps.clock.now() + ttl })
   }
 }

--- a/packages/control-plane/src/http/logto-federated-token.test.ts
+++ b/packages/control-plane/src/http/logto-federated-token.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import { LogtoFederatedTokenService, logtoAccountEndpointFromIssuer } from './logto-federated-token.js'
+import {
+  LogtoFederatedTokenError,
+  LogtoFederatedTokenService,
+  logtoAccountEndpointFromIssuer
+} from './logto-federated-token.js'
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
@@ -36,5 +40,30 @@ describe('LogtoFederatedTokenService', () => {
 
     await expect(session.accessTokenFor('lark')).rejects.toMatchObject({ status: 403 })
     expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps only a safe upstream code when federated authorization is unavailable', async () => {
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.endsWith('/api/my-account')
+        ? json({ id: 'logto-user' })
+        : json({ code: 'connector.general', message: 'refresh token secret must not escape' }, 400)
+    )
+    const session = new LogtoFederatedTokenService('https://login.example.test', fetchImpl).forRequest(
+      'logto-user',
+      'account-token'
+    )
+
+    const error = await session.accessTokenFor('lark').catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(LogtoFederatedTokenError)
+    expect(error).toMatchObject({
+      stage: 'federated_token',
+      target: 'lark',
+      status: 400,
+      code: 'connector.general'
+    })
+    expect(String(error)).not.toContain('refresh token secret')
+    expect(JSON.stringify(error)).not.toContain('refresh token secret')
+    expect(JSON.stringify(error)).not.toContain('account-token')
   })
 })

--- a/packages/control-plane/src/http/logto-federated-token.ts
+++ b/packages/control-plane/src/http/logto-federated-token.ts
@@ -14,6 +14,8 @@ export interface LogtoFederatedTokenResolver {
   forRequest(oidcSubject: string, accountToken: string): LogtoFederatedTokenSession
 }
 
+export type LogtoFederatedTokenStage = 'account_verification' | 'federated_token'
+
 /** Account API shares the tenant origin with Logto's `/oidc` issuer. */
 export function logtoAccountEndpointFromIssuer(issuer: string): string {
   const url = new URL(issuer)
@@ -28,15 +30,42 @@ export function logtoAccountEndpointFromIssuer(issuer: string): string {
 export class LogtoFederatedTokenError extends Error {
   constructor(
     message: string,
-    readonly status: number
+    readonly details: {
+      stage: LogtoFederatedTokenStage
+      status?: number
+      target?: LogtoFederatedTarget
+      code?: string
+    }
   ) {
     super(message)
     this.name = 'LogtoFederatedTokenError'
+  }
+
+  get stage(): LogtoFederatedTokenStage {
+    return this.details.stage
+  }
+
+  get status(): number | undefined {
+    return this.details.status
+  }
+
+  get target(): LogtoFederatedTarget | undefined {
+    return this.details.target
+  }
+
+  get code(): string | undefined {
+    return this.details.code
   }
 }
 
 function recordOf(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}
+
+async function safeUpstreamCode(response: Response): Promise<string | undefined> {
+  const value = recordOf(await response.json().catch(() => null)).code
+  const code = typeof value === 'number' ? String(value) : typeof value === 'string' ? value : undefined
+  return code && /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/.test(code) ? code : undefined
 }
 
 /**
@@ -74,21 +103,64 @@ export class LogtoFederatedTokenService implements LogtoFederatedTokenResolver {
   }
 
   private async verifyAccount(oidcSubject: string, accountToken: string): Promise<void> {
-    const response = await this.request('/api/my-account', accountToken)
-    if (!response.ok) throw new LogtoFederatedTokenError('Logto account verification failed', response.status)
+    let response: Response
+    try {
+      response = await this.request('/api/my-account', accountToken)
+    } catch {
+      throw new LogtoFederatedTokenError('Logto account verification failed', {
+        stage: 'account_verification',
+        code: 'request_failed'
+      })
+    }
+    if (!response.ok) {
+      const code = await safeUpstreamCode(response)
+      throw new LogtoFederatedTokenError('Logto account verification failed', {
+        stage: 'account_verification',
+        status: response.status,
+        ...(code ? { code } : {})
+      })
+    }
     const account = recordOf(await response.json().catch(() => null))
-    if (account.id !== oidcSubject) throw new LogtoFederatedTokenError('Logto account token subject mismatch', 403)
+    if (account.id !== oidcSubject) {
+      throw new LogtoFederatedTokenError('Logto account token subject mismatch', {
+        stage: 'account_verification',
+        status: 403,
+        code: 'subject_mismatch'
+      })
+    }
   }
 
   private async fetchAccessToken(target: LogtoFederatedTarget, accountToken: string): Promise<string> {
-    const response = await this.request(
-      `/api/my-account/identities/${encodeURIComponent(target)}/access-token`,
-      accountToken
-    )
-    if (!response.ok) throw new LogtoFederatedTokenError('Federated access token is unavailable', response.status)
+    let response: Response
+    try {
+      response = await this.request(
+        `/api/my-account/identities/${encodeURIComponent(target)}/access-token`,
+        accountToken
+      )
+    } catch {
+      throw new LogtoFederatedTokenError('Federated access token is unavailable', {
+        stage: 'federated_token',
+        target,
+        code: 'request_failed'
+      })
+    }
+    if (!response.ok) {
+      const code = await safeUpstreamCode(response)
+      throw new LogtoFederatedTokenError('Federated access token is unavailable', {
+        stage: 'federated_token',
+        target,
+        status: response.status,
+        ...(code ? { code } : {})
+      })
+    }
     const token = recordOf(await response.json().catch(() => null)).access_token
     if (typeof token !== 'string' || token.length === 0) {
-      throw new LogtoFederatedTokenError('Federated access token response is invalid', 502)
+      throw new LogtoFederatedTokenError('Federated access token response is invalid', {
+        stage: 'federated_token',
+        target,
+        status: 502,
+        code: 'invalid_response'
+      })
     }
     return token
   }

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -606,7 +606,8 @@ export function sessionRoutes(deps: HttpDeps) {
                 : [],
             total: rows.length > 0 ? 1 : 0,
             nextCursor: null,
-            accessSyncDegraded: access.degraded
+            accessSyncDegraded: access.degraded,
+            accessIssues: access.accessIssues
           }
         }
 
@@ -619,6 +620,7 @@ export function sessionRoutes(deps: HttpDeps) {
             total: page.total,
             nextCursor,
             accessSyncDegraded: access.degraded,
+            accessIssues: access.accessIssues,
             ...(orgHasSessions !== undefined ? { orgHasSessions } : {})
           }
         }
@@ -642,6 +644,7 @@ export function sessionRoutes(deps: HttpDeps) {
           total: page.total,
           nextCursor,
           accessSyncDegraded: access.degraded,
+          accessIssues: access.accessIssues,
           ...(orgHasSessions !== undefined ? { orgHasSessions } : {})
         }
       }
@@ -706,6 +709,14 @@ export function sessionRoutes(deps: HttpDeps) {
         const visibleChildren = children.filter((child) =>
           canViewSession(child, ctx, relatedAccess.identitySet, relatedAccess.externalAccess)
         )
+        const accessIssues = [
+          ...new Map(
+            [...access.accessIssues, ...relatedAccess.accessIssues].map((issue) => [
+              `${issue.provider}:${issue.region ?? ''}:${issue.reason}`,
+              issue
+            ])
+          ).values()
+        ]
         return {
           id: s.id,
           parentSession: parentVisible ? sessionRelation(parent) : null,
@@ -754,6 +765,7 @@ export function sessionRoutes(deps: HttpDeps) {
           visibilityState: await visibilityStateOf(deps.visibilityPush, deps.repos, [s.id]),
           canChangeVisibility: canChangeSessionVisibility(s, ctx, access.identitySet),
           accessSyncDegraded: access.degraded || relatedAccess.degraded,
+          accessIssues,
           contentPurgedAt: s.contentPurgedAt ? s.contentPurgedAt.toISOString() : null,
           contentPurgedReason: s.contentPurgedReason ?? null,
           startedAt: s.startedAt.toISOString(),

--- a/packages/control-plane/src/http/routes/usage.ts
+++ b/packages/control-plane/src/http/routes/usage.ts
@@ -53,6 +53,7 @@ export function usageRoutes(deps: HttpDeps) {
         return {
           range: req.query.range,
           accessSyncDegraded: access.degraded,
+          accessIssues: access.accessIssues,
           totals: agg.totals,
           agents: agg.agents,
           series: agg.series

--- a/packages/control-plane/src/http/session-access.test.ts
+++ b/packages/control-plane/src/http/session-access.test.ts
@@ -4,7 +4,7 @@ import { canViewSession } from '../authorization/policy.js'
 import type { ExternalScopeRecord } from '../persistence/ports.js'
 import type { HttpDeps } from './deps.js'
 import type { FeishuSessionViewer } from './feishu-session-access.js'
-import { LOGTO_ACCOUNT_TOKEN_HEADER } from './logto-federated-token.js'
+import { LOGTO_ACCOUNT_TOKEN_HEADER, LogtoFederatedTokenError } from './logto-federated-token.js'
 import { makeSessionAccessResolver } from './session-access.js'
 
 const scope: ExternalScopeRecord = {
@@ -37,7 +37,7 @@ describe('makeSessionAccessResolver', () => {
       expect(scopes).toEqual([scope])
       expect(viewer?.subject).toBe('logto-subject')
       await expect(viewer?.accessTokenFor('lark')).resolves.toBe('lark-user-token')
-      return { allowedScopes: [{ id: scope.id, aclRevision: scope.aclRevision }], degraded: false }
+      return { allowedScopes: [{ id: scope.id, aclRevision: scope.aclRevision }], degraded: false, accessIssues: [] }
     })
     const policy = {
       orgId: 'org-1',
@@ -80,5 +80,63 @@ describe('makeSessionAccessResolver', () => {
     expect(
       canViewSession(session, { userId: 'user-1', role: 'collaborator' }, access.identitySet, access.externalAccess)
     ).toBe(true)
+  })
+
+  it('logs safe federated-token diagnostics and returns an actionable access issue', async () => {
+    const req = request()
+    const upstream = new LogtoFederatedTokenError('Federated access token is unavailable', {
+      stage: 'federated_token',
+      target: 'lark',
+      status: 400,
+      code: 'connector.general'
+    })
+    const getExternalScopes = vi.fn(async (ids: readonly string[]) => (ids.length > 0 ? [scope] : []))
+    const deps = {
+      repos: {
+        session: {
+          getExternalScopes,
+          getExternalAccessPolicy: vi.fn(async () => null)
+        }
+      },
+      clock: { now: () => 1_000 },
+      logtoIdentity: { feishuIdentitiesFor: async () => [] },
+      logtoFederatedToken: {
+        forRequest: () => ({
+          accessTokenFor: async () => {
+            throw upstream
+          }
+        })
+      },
+      feishuSessionAccess: {
+        resolve: async (_scopes: readonly ExternalScopeRecord[], viewer?: FeishuSessionViewer) => {
+          await viewer?.accessTokenFor('lark').catch(() => undefined)
+          return {
+            allowedScopes: [],
+            degraded: true,
+            accessIssues: [{ provider: 'feishu', region: 'lark', reason: 'authorization' as const }]
+          }
+        }
+      }
+    } as unknown as HttpDeps
+
+    const access = await makeSessionAccessResolver(deps).forSessions(req, [
+      {
+        visibility: 'external',
+        externalProvider: 'feishu',
+        externalScopeId: scope.id
+      }
+    ])
+
+    expect(access.accessIssues).toEqual([{ provider: 'feishu', region: 'lark', reason: 'authorization' }])
+    expect(req.log.warn).toHaveBeenCalledWith(
+      {
+        provider: 'feishu',
+        target: 'lark',
+        stage: 'federated_token',
+        status: 400,
+        code: 'connector.general'
+      },
+      'Federated session access token is unavailable'
+    )
   })
 })

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -7,8 +7,17 @@ import type {
 } from '../persistence/ports.js'
 import type { HttpDeps } from './deps.js'
 import { makeViewerIdentitySet } from './viewer-identity.js'
-import { LOGTO_ACCOUNT_TOKEN_HEADER } from './logto-federated-token.js'
+import { LOGTO_ACCOUNT_TOKEN_HEADER, LogtoFederatedTokenError } from './logto-federated-token.js'
 import { ctxOf, orgOf } from './rbac.js'
+
+/** Provider-neutral, requester-safe diagnostic from a session-visibility
+ * plugin. A platform may add a region without turning that region into a
+ * separate provider identity. */
+export interface SessionAccessIssue {
+  provider: string
+  region?: string
+  reason: 'authorization' | 'unavailable'
+}
 
 export interface ResolvedSessionAccess {
   identitySet: Set<string>
@@ -18,6 +27,7 @@ export interface ResolvedSessionAccess {
    *  provider variant from the session's protocol platform. */
   externalScopes: readonly ExternalScopeRecord[]
   degraded: boolean
+  accessIssues: SessionAccessIssue[]
 }
 
 /** Request-bound resolver shared by list/detail/SSE. It never persists a user
@@ -52,7 +62,23 @@ export function makeSessionAccessResolver(deps: HttpDeps) {
     const feishuViewer = federated
       ? {
           subject: req.oidcSubject!,
-          accessTokenFor: (region: 'feishu' | 'lark') => federated.accessTokenFor(region)
+          accessTokenFor: async (region: 'feishu' | 'lark') => {
+            try {
+              return await federated.accessTokenFor(region)
+            } catch (error) {
+              const diagnostic =
+                error instanceof LogtoFederatedTokenError
+                  ? {
+                      target: error.target ?? region,
+                      stage: error.stage,
+                      status: error.status ?? null,
+                      code: error.code ?? null
+                    }
+                  : { target: region, stage: 'federated_token', status: null, code: 'unclassified_failure' }
+              req.log.warn({ provider: 'feishu', ...diagnostic }, 'Federated session access token is unavailable')
+              throw error
+            }
+          }
         }
       : undefined
     const [slackResult, githubResult, feishuResult] = await Promise.all([
@@ -64,7 +90,7 @@ export function makeSessionAccessResolver(deps: HttpDeps) {
         : Promise.resolve({ allowedScopes: [], degraded: githubScopes.length > 0 }),
       deps.feishuSessionAccess
         ? deps.feishuSessionAccess.resolve(feishuScopes, feishuViewer)
-        : Promise.resolve({ allowedScopes: [], degraded: feishuScopes.length > 0 })
+        : Promise.resolve({ allowedScopes: [], degraded: feishuScopes.length > 0, accessIssues: [] })
     ])
     const resolvedScopes = [...slackResult.allowedScopes, ...githubResult.allowedScopes, ...feishuResult.allowedScopes]
     // Provider lookup can take multiple round trips. Re-read the durable fence
@@ -104,7 +130,8 @@ export function makeSessionAccessResolver(deps: HttpDeps) {
         slackResult.degraded ||
         githubResult.degraded ||
         feishuResult.degraded ||
-        allowedScopes.length !== resolvedScopes.length
+        allowedScopes.length !== resolvedScopes.length,
+      accessIssues: feishuResult.accessIssues ?? []
     }
   }
 

--- a/packages/web/src/app/auth/social/callback/page.tsx
+++ b/packages/web/src/app/auth/social/callback/page.tsx
@@ -8,6 +8,7 @@ import { forgetOwnershipProof } from '@/lib/ownership-proof'
 import {
   LogtoAccountError,
   accountErrorMessage,
+  renewSocialIdentityToken,
   saveSocialIdentity,
   takeSocialLinkFlow,
   verifySocialVerification
@@ -17,6 +18,7 @@ export default function SocialAccountCallback() {
   const started = useRef(false)
   const [error, setError] = useState<string>()
   const [returnTo, setReturnTo] = useState('/')
+  const [workingMessage, setWorkingMessage] = useState('Linking your sign-in account…')
 
   useEffect(() => {
     if (started.current) return
@@ -28,6 +30,7 @@ export default function SocialAccountCallback() {
       return
     }
     setReturnTo(flow.returnTo)
+    if (flow.purpose === 'reauthorize') setWorkingMessage(`Updating ${flow.providerName} authorization…`)
 
     const params = new URLSearchParams(window.location.search)
     const providerError = params.get('error')
@@ -49,10 +52,17 @@ export default function SocialAccountCallback() {
     const connectorData = { ...Object.fromEntries(params.entries()), redirectUri: flow.redirectUri }
     verifySocialVerification(flow.verificationRecordId, connectorData)
       .then((verified) =>
-        saveSocialIdentity(verified, flow.currentVerificationRecordId).catch((caught: unknown) => {
-          // Only the SAVE step's refusal implicates the ownership proof; a
-          // failure verifying the provider response says nothing about it.
-          if (caught instanceof LogtoAccountError && (caught.status === 401 || caught.status === 403)) {
+        (flow.purpose === 'reauthorize' && flow.target
+          ? renewSocialIdentityToken(flow.target, verified)
+          : saveSocialIdentity(verified, flow.currentVerificationRecordId)
+        ).catch((caught: unknown) => {
+          // Only saving a new identity implicates the ownership proof; token
+          // renewal and provider verification do not consume that proof.
+          if (
+            flow.purpose !== 'reauthorize' &&
+            caught instanceof LogtoAccountError &&
+            (caught.status === 401 || caught.status === 403)
+          ) {
             forgetOwnershipProof()
           }
           throw caught
@@ -61,11 +71,15 @@ export default function SocialAccountCallback() {
       // Best-effort: the link already succeeded, so a failure here must not be
       // reported as one. It only costs a stale row until the cache expires.
       .then(() => refreshMySocialIdentities().catch(() => undefined))
-      // Straight back to Profile: the row now shows the linked account, which
-      // says it better than a banner that outlives the action.
+      // Return to the initiating Profile view after either linking or renewing.
       .then(() => window.location.replace(flow.returnTo))
       .catch((caught) => {
-        setError(accountErrorMessage(caught, { providerName: flow.providerName, linking: true }))
+        setError(
+          accountErrorMessage(caught, {
+            providerName: flow.providerName,
+            operation: flow.purpose === 'reauthorize' ? 'reauthorize' : 'link'
+          })
+        )
       })
   }, [])
 
@@ -73,7 +87,7 @@ export default function SocialAccountCallback() {
     <div className="authpage">
       <div className="m-auto flex max-w-[420px] flex-col items-center gap-[18px] px-6 text-center font-sans text-[14px] font-normal leading-[1.6] text-(--text-secondary)">
         {!error ? <Spinner size={48} /> : null}
-        <div>{error ?? 'Linking your sign-in account…'}</div>
+        <div>{error ?? workingMessage}</div>
         {error ? (
           <Button variant="secondary" onClick={() => window.location.replace(returnTo)}>
             Back to Profile

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -59,7 +59,7 @@ export function useGsActions() {
             : openModal('agent')
         case 'github-profile':
           // Land on Profile with the GitHub link flow auto-started (`link=github` is
-          // consumed one-shot by ProfileView → SocialSignInCard's autoLinkTarget).
+          // consumed one-shot by ProfileView → SocialSignInCard's autoAuthorize).
           return router.push(orgPath('/profile?link=github'))
         case 'chat':
           // The chat-first Home landing is where conversations start.

--- a/packages/web/src/components/console/SessionAccessNotice.test.tsx
+++ b/packages/web/src/components/console/SessionAccessNotice.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ orgPath: (path: string) => `/agentconnect${path}` })
+}))
+
+import SessionAccessNotice from './SessionAccessNotice'
+
+describe('SessionAccessNotice', () => {
+  it('offers direct renewal for a classified regional authorization failure', () => {
+    const html = renderToStaticMarkup(
+      <SessionAccessNotice
+        degraded
+        issues={[{ provider: 'feishu', region: 'lark', reason: 'authorization' }]}
+        impact="sessions"
+      />
+    )
+
+    expect(html).toContain('Your Lark authorization needs attention.')
+    expect(html).toContain('Reconnect Lark')
+    expect(html).toContain('/agentconnect/profile?reauthorize=lark#sign-in-methods')
+  })
+
+  it('keeps an unclassified provider failure generic and fail-closed', () => {
+    const html = renderToStaticMarkup(
+      <SessionAccessNotice degraded issues={[{ provider: 'linear', reason: 'authorization' }]} impact="sessions" />
+    )
+
+    expect(html).toContain('Affected sessions are hidden until access can be verified.')
+    expect(html).not.toContain('Reconnect')
+  })
+})

--- a/packages/web/src/components/console/SessionAccessNotice.tsx
+++ b/packages/web/src/components/console/SessionAccessNotice.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import Link from 'next/link'
+import type { SessionAccessIssue } from '@/lib/api'
+import { useOrgs } from '@/lib/org-context'
+
+export default function SessionAccessNotice({
+  degraded,
+  issues = [],
+  impact
+}: {
+  degraded?: boolean
+  issues?: SessionAccessIssue[]
+  impact: 'sessions' | 'usage'
+}) {
+  const { orgPath } = useOrgs()
+  if (!degraded) return null
+
+  const regions = [
+    ...new Set(
+      issues.flatMap((issue) =>
+        issue.provider === 'feishu' &&
+        issue.reason === 'authorization' &&
+        (issue.region === 'feishu' || issue.region === 'lark')
+          ? [issue.region]
+          : []
+      )
+    )
+  ]
+  const names = regions.map((region) => (region === 'feishu' ? 'Feishu' : 'Lark')).join(' and ')
+  const message = names
+    ? `Your ${names} ${regions.length === 1 ? 'authorization needs' : 'authorizations need'} attention. Reconnect ${regions.length === 1 ? 'it' : 'them'} in Profile to restore ${impact === 'sessions' ? 'access to affected sessions' : 'usage from affected sessions'}.`
+    : impact === 'sessions'
+      ? 'Some external access checks are unavailable. Affected sessions are hidden until access can be verified.'
+      : 'Some external access checks are unavailable. Usage is temporarily under-counted rather than exposing inaccessible sessions.'
+  const href =
+    regions.length === 1
+      ? orgPath(`/profile?reauthorize=${regions[0]}#sign-in-methods`)
+      : orgPath('/profile#sign-in-methods')
+
+  return (
+    <div
+      className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4"
+      role="status"
+    >
+      <span className="min-w-0 flex-1">{message}</span>
+      {names ? (
+        <Link className="lnk flex-none" href={href}>
+          {regions.length === 1 ? `Reconnect ${names}` : 'Open Profile'}
+        </Link>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/SocialSignInCard.test.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.test.tsx
@@ -48,11 +48,11 @@ function RevalidateAccount() {
 }
 
 async function renderCard({
-  autoLinkTarget,
-  onAutoLinkHandled = vi.fn()
+  autoAuthorize,
+  onAutoAuthorizeHandled = vi.fn()
 }: {
-  autoLinkTarget?: 'github'
-  onAutoLinkHandled?: () => void
+  autoAuthorize?: { target: 'github'; purpose: 'link' }
+  onAutoAuthorizeHandled?: () => void
 } = {}) {
   const cache = new Map()
   container = document.createElement('div')
@@ -68,7 +68,11 @@ async function renderCard({
           shouldRetryOnError: true
         }}
       >
-        <SocialSignInCard onNotice={vi.fn()} autoLinkTarget={autoLinkTarget} onAutoLinkHandled={onAutoLinkHandled} />
+        <SocialSignInCard
+          onNotice={vi.fn()}
+          autoAuthorize={autoAuthorize}
+          onAutoAuthorizeHandled={onAutoAuthorizeHandled}
+        />
         <RevalidateAccount />
       </SWRConfig>
     )
@@ -118,6 +122,23 @@ describe('SocialSignInCard account state', () => {
     expect(
       Array.from(container?.querySelectorAll('button') ?? []).filter((item) => item.textContent === 'Link')
     ).toHaveLength(2)
+  })
+
+  it('offers token renewal for an already linked regional identity', async () => {
+    window.__AC_ENV = { SOCIAL_PROVIDERS: 'lark' }
+    vi.mocked(fetchMySocialAccount).mockResolvedValue({
+      identities: [{ target: 'lark', userId: 'lark-user', name: 'Phil Z' }],
+      hasSecurityVerificationMethod: true,
+      primaryEmail: 'phil@example.test'
+    })
+
+    await renderCard()
+    await waitUntil(() => button('Reconnect') !== undefined)
+    await act(async () => button('Reconnect')?.click())
+    await waitUntil(() => vi.mocked(resolveMySocialConnectorId).mock.calls.length === 1)
+
+    expect(resolveMySocialConnectorId).toHaveBeenCalledWith('lark')
+    expect(container?.querySelector('[role="dialog"]')).toBeNull()
   })
 
   it('keeps a failed request idle and marks an explicit Retry as busy', async () => {
@@ -197,12 +218,12 @@ describe('SocialSignInCard account state', () => {
 
   it('continues a verified install through linking only when GitHub is unlinked', async () => {
     vi.mocked(fetchMySocialAccount).mockResolvedValue({ identities: [], hasSecurityVerificationMethod: false })
-    const onAutoLinkHandled = vi.fn()
+    const onAutoAuthorizeHandled = vi.fn()
 
-    await renderCard({ autoLinkTarget: 'github', onAutoLinkHandled })
+    await renderCard({ autoAuthorize: { target: 'github', purpose: 'link' }, onAutoAuthorizeHandled })
     await waitUntil(() => vi.mocked(resolveMySocialConnectorId).mock.calls.length === 1)
 
-    expect(onAutoLinkHandled).toHaveBeenCalledOnce()
+    expect(onAutoAuthorizeHandled).toHaveBeenCalledOnce()
   })
 
   it('does not reauthorize GitHub when the installed app user already linked it', async () => {
@@ -210,10 +231,10 @@ describe('SocialSignInCard account state', () => {
       identities: [{ target: 'github', userId: 'github-user', name: 'Phil Z' }],
       hasSecurityVerificationMethod: false
     })
-    const onAutoLinkHandled = vi.fn()
+    const onAutoAuthorizeHandled = vi.fn()
 
-    await renderCard({ autoLinkTarget: 'github', onAutoLinkHandled })
-    await waitUntil(() => onAutoLinkHandled.mock.calls.length === 1)
+    await renderCard({ autoAuthorize: { target: 'github', purpose: 'link' }, onAutoAuthorizeHandled })
+    await waitUntil(() => onAutoAuthorizeHandled.mock.calls.length === 1)
 
     expect(resolveMySocialConnectorId).not.toHaveBeenCalled()
   })

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -23,10 +23,18 @@ import {
   type AccountNotice
 } from '@/lib/logto-account'
 import { rememberOwnershipProof, reusableOwnershipProof } from '@/lib/ownership-proof'
-import { socialLoginProviders, type SocialLoginProvider, type SocialLoginTarget } from '@/lib/social-login-providers'
+import {
+  SOCIAL_LOGIN_CATALOG,
+  socialLoginProviders,
+  type SocialLoginProvider,
+  type SocialLoginTarget
+} from '@/lib/social-login-providers'
 
 const byTarget = (account: MySocialAccountDto, target: string): MySocialIdentityDto | undefined =>
   account.identities.find((identity) => identity.target === target)
+
+const targetName = (target: string): string =>
+  SOCIAL_LOGIN_CATALOG.find((provider) => provider.target === target)?.name ?? target
 
 /** Name the workspace the way its own members would. The `T…` id is a last
  *  resort — it is an id, not a name, and readers here manage their own accounts. */
@@ -173,7 +181,7 @@ function VerifyAccountDialog({
       }
       await onVerified(await verifyEmailCode(email, pending.verificationId, code.trim()), pending.expiresAt)
     } catch (caught) {
-      setError(accountErrorMessage(caught, { providerName: provider.name, linking: true }))
+      setError(accountErrorMessage(caught, { providerName: provider.name, operation: 'link' }))
     } finally {
       setBusy(false)
     }
@@ -276,16 +284,15 @@ export default function SocialSignInCard({
   mobile = false,
   notice,
   onNotice,
-  autoLinkTarget,
-  onAutoLinkHandled
+  autoAuthorize,
+  onAutoAuthorizeHandled
 }: {
   mobile?: boolean
   notice?: AccountNotice
   onNotice: (notice: AccountNotice) => void
-  /** Continue an explicit upstream action (currently a verified GitHub App
-   *  install) through the same state-bound link flow as the row button. */
-  autoLinkTarget?: SocialLoginTarget
-  onAutoLinkHandled?: () => void
+  /** Continue an explicit upstream action through the same state-bound provider flow as the row button. */
+  autoAuthorize?: { target: SocialLoginTarget; purpose: 'link' | 'reauthorize' }
+  onAutoAuthorizeHandled?: () => void
 }) {
   const {
     data: account,
@@ -302,7 +309,7 @@ export default function SocialSignInCard({
   const [pendingUnlink, setPendingUnlink] = useState<SocialLoginProvider>()
   const [pendingVerify, setPendingVerify] = useState<SocialLoginProvider>()
   const [busyProvider, setBusyProvider] = useState<SocialLoginProvider['target']>()
-  const handledAutoLink = useRef<SocialLoginTarget | undefined>(undefined)
+  const handledAutoAuthorize = useRef<string | undefined>(undefined)
   const currentAccount = error ? undefined : account
   const linkedProviderCount = currentAccount
     ? socialLoginProviders().filter((provider) => byTarget(currentAccount, provider.target)).length
@@ -316,16 +323,24 @@ export default function SocialSignInCard({
       // same sitting reuses the proof instead of asking again.
       const proof = reusableOwnershipProof()
       if (proof) {
-        void startLink(provider, proof)
+        void startAuthorization(provider, 'link', proof)
         return
       }
       setPendingVerify(provider)
       return
     }
-    void startLink(provider)
+    void startAuthorization(provider, 'link')
   }
 
-  const startLink = async (provider: SocialLoginProvider, currentVerificationRecordId?: string) => {
+  const beginReauthorize = (provider: SocialLoginProvider) => {
+    void startAuthorization(provider, 'reauthorize')
+  }
+
+  const startAuthorization = async (
+    provider: SocialLoginProvider,
+    purpose: 'link' | 'reauthorize',
+    currentVerificationRecordId?: string
+  ) => {
     setBusyProvider(provider.target)
     try {
       const state = createSocialState()
@@ -335,6 +350,8 @@ export default function SocialSignInCard({
       const redirectUri = `${window.location.origin}/auth/social/callback`
       const { authorizationUri, verificationRecordId } = await createSocialVerification(connectorId, redirectUri, state)
       const stored = writeSocialLinkFlow({
+        purpose,
+        target: provider.target,
         state,
         connectorId,
         verificationRecordId,
@@ -350,30 +367,32 @@ export default function SocialSignInCard({
       window.location.assign(authorizationUri)
     } catch (caught) {
       onNotice({
-        message: accountErrorMessage(caught, { providerName: provider.name, linking: true })
+        message: accountErrorMessage(caught, { providerName: provider.name, operation: purpose })
       })
       setBusyProvider(undefined)
     }
   }
 
   useEffect(() => {
-    // The marker is one-shot: once the parent clears it, forget it was handled so a
-    // REPEAT trigger (checklist CTA clicked again after cancelling the dialog, while
-    // already on this page) starts the flow again instead of being swallowed.
-    if (!autoLinkTarget) {
-      handledAutoLink.current = undefined
+    if (!autoAuthorize) {
+      handledAutoAuthorize.current = undefined
       return
     }
-    if (!currentAccount || handledAutoLink.current === autoLinkTarget) return
-    const provider = socialLoginProviders().find((candidate) => candidate.target === autoLinkTarget)
-    handledAutoLink.current = autoLinkTarget
-    onAutoLinkHandled?.()
+    const key = `${autoAuthorize.purpose}:${autoAuthorize.target}`
+    if (!currentAccount || handledAutoAuthorize.current === key) return
+    const provider = socialLoginProviders().find((candidate) => candidate.target === autoAuthorize.target)
+    handledAutoAuthorize.current = key
+    onAutoAuthorizeHandled?.()
     if (!provider) {
-      onNotice({ message: 'GitHub profile linking is not available on this deployment.' })
+      onNotice({
+        message: `${targetName(autoAuthorize.target)} authorization is not available on this deployment.`
+      })
       return
     }
-    if (!byTarget(currentAccount, autoLinkTarget)) beginLink(provider)
-  }, [autoLinkTarget, currentAccount, onAutoLinkHandled, onNotice])
+    const linked = byTarget(currentAccount, autoAuthorize.target)
+    if (autoAuthorize.purpose === 'reauthorize' && linked) beginReauthorize(provider)
+    else if (!linked) beginLink(provider)
+  }, [autoAuthorize, currentAccount, onAutoAuthorizeHandled, onNotice])
 
   const unlink = async (provider: SocialLoginProvider) => {
     await unlinkMySocialIdentity(provider.target)
@@ -479,16 +498,28 @@ export default function SocialSignInCard({
                 <div className="col-start-2 row-start-1 flex items-center justify-end gap-1 desktop:col-start-3">
                   {currentAccount ? (
                     details ? (
-                      canUnlink ? (
-                        <Button
-                          variant="ghost"
-                          size="xs"
-                          disabled={busyProvider !== undefined}
-                          onClick={() => setPendingUnlink(provider)}
-                        >
-                          <span className="text-(--status-error)">Unlink</span>
-                        </Button>
-                      ) : null
+                      <>
+                        {provider.target === 'lark' || provider.target === 'feishu' ? (
+                          <Button
+                            variant="secondary"
+                            size="xs"
+                            disabled={busyProvider !== undefined}
+                            onClick={() => beginReauthorize(provider)}
+                          >
+                            {busyProvider === provider.target ? 'Reconnecting…' : 'Reconnect'}
+                          </Button>
+                        ) : null}
+                        {canUnlink ? (
+                          <Button
+                            variant="ghost"
+                            size="xs"
+                            disabled={busyProvider !== undefined}
+                            onClick={() => setPendingUnlink(provider)}
+                          >
+                            <span className="text-(--status-error)">Unlink</span>
+                          </Button>
+                        ) : null}
+                      </>
                     ) : (
                       <Button
                         variant="secondary"
@@ -525,7 +556,7 @@ export default function SocialSignInCard({
           onVerified={async (currentVerificationRecordId, expiresAt) => {
             setPendingVerify(undefined)
             rememberOwnershipProof(currentVerificationRecordId, expiresAt)
-            await startLink(pendingVerify, currentVerificationRecordId)
+            await startAuthorization(pendingVerify, 'link', currentVerificationRecordId)
           }}
           onClose={() => setPendingVerify(undefined)}
         />

--- a/packages/web/src/components/console/views/ProfileView.tsx
+++ b/packages/web/src/components/console/views/ProfileView.tsx
@@ -46,24 +46,28 @@ export default function ProfileView() {
   // ProfileView survives its desktop-first hydration switch to the mobile tree,
   // so it holds the card's failure notice instead of either short-lived card.
   const [socialNotice, setSocialNotice] = useState<AccountNotice>()
-  const [autoLinkGithub, setAutoLinkGithub] = useState(false)
+  const [autoAuthorize, setAutoAuthorize] = useState<
+    { target: 'github'; purpose: 'link' } | { target: 'lark' | 'feishu'; purpose: 'reauthorize' }
+  >()
 
-  // Two entrances auto-start the GitHub link flow: the GitHub Setup URL's verified
-  // installation marker (`github=installed`) and the getting-started checklist's
-  // "Link GitHub profile" step (`link=github`). Consume the marker before starting
-  // the provider round trip so cancel/reload cannot loop. Keyed on searchParams,
-  // not just mount: the checklist CTA can fire while ALREADY on this page (the
-  // drawer floats over every route), where the push changes only the query.
+  // Explicit upstream actions can auto-start a link or regional token renewal.
+  // Consume each marker before leaving for the provider so cancel/reload cannot
+  // loop. Keyed on searchParams because an action can fire while already here.
   const searchParams = useSearchParams()
   useEffect(() => {
     if (!authOn) return
     const url = new URL(window.location.href)
-    const marked = url.searchParams.get('github') === 'installed' || url.searchParams.get('link') === 'github'
-    if (!marked) return
+    const githubMarked = url.searchParams.get('github') === 'installed' || url.searchParams.get('link') === 'github'
+    const reauthorize = url.searchParams.get('reauthorize')
+    const regionalTarget = reauthorize === 'lark' || reauthorize === 'feishu' ? reauthorize : undefined
+    if (!githubMarked && !regionalTarget) return
     url.searchParams.delete('github')
     url.searchParams.delete('link')
+    url.searchParams.delete('reauthorize')
     window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
-    setAutoLinkGithub(true)
+    setAutoAuthorize(
+      regionalTarget ? { target: regionalTarget, purpose: 'reauthorize' } : { target: 'github', purpose: 'link' }
+    )
   }, [authOn, searchParams])
   // The signed-in user's membership — the same row the Settings page lists.
   // Matched by userId when the CP profile is known (exact), by email otherwise.
@@ -147,8 +151,8 @@ export default function ProfileView() {
               mobile
               notice={socialNotice}
               onNotice={setSocialNotice}
-              autoLinkTarget={autoLinkGithub ? 'github' : undefined}
-              onAutoLinkHandled={() => setAutoLinkGithub(false)}
+              autoAuthorize={autoAuthorize}
+              onAutoAuthorizeHandled={() => setAutoAuthorize(undefined)}
             />
           ) : null}
 
@@ -215,8 +219,8 @@ export default function ProfileView() {
         <SocialSignInCard
           notice={socialNotice}
           onNotice={setSocialNotice}
-          autoLinkTarget={autoLinkGithub ? 'github' : undefined}
-          onAutoLinkHandled={() => setAutoLinkGithub(false)}
+          autoAuthorize={autoAuthorize}
+          onAutoAuthorizeHandled={() => setAutoAuthorize(undefined)}
         />
       ) : null}
 

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -36,6 +36,7 @@ import { usePlayground } from '@/components/console/PlaygroundProvider'
 import { useMobileFilterSlot } from '@/components/console/Shell'
 import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
 import { RestrictedLock } from '@/components/console/VisibilityField'
+import SessionAccessNotice from '@/components/console/SessionAccessNotice'
 import { Avatar, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 
@@ -579,11 +580,11 @@ export default function SessionsView() {
           </span>
         </div>
       )}
-      {sessionList.accessSyncDegraded && (
-        <div className="mb-3 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4">
-          Some external access checks are unavailable. Affected sessions are hidden until access can be verified.
-        </div>
-      )}
+      <SessionAccessNotice
+        degraded={sessionList.accessSyncDegraded}
+        issues={sessionList.accessIssues}
+        impact="sessions"
+      />
       {initialLoading && (
         <div className="desktop:hidden">
           <LoadingState fill />

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -10,6 +10,7 @@ import { AgentIconView, Spinner } from '@/components/marks'
 import { useOrgs } from '@/lib/org-context'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { consoleKeys } from '@/lib/swr-keys'
+import SessionAccessNotice from '@/components/console/SessionAccessNotice'
 
 const RANGES: { key: UsageRange; label: string }[] = [
   { key: 'd1', label: '24 hours' },
@@ -197,12 +198,7 @@ export default function UsageView() {
         })}
       </div>
 
-      {data?.accessSyncDegraded && (
-        <div className="mb-3 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4">
-          Some external access checks are unavailable. Usage is temporarily under-counted rather than exposing
-          inaccessible sessions.
-        </div>
-      )}
+      <SessionAccessNotice degraded={data?.accessSyncDegraded} issues={data?.accessIssues} impact="usage" />
 
       {/* Mobile compact 3-metric strip (Sessions / Tokens / Spend — no fabricated
           p95 latency, it's not in the UsageDto) */}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -420,6 +420,12 @@ export interface ConversationDto {
   memberSessionIds?: string[]
 }
 
+export interface SessionAccessIssue {
+  provider: string
+  region?: string
+  reason: 'authorization' | 'unavailable'
+}
+
 export interface SessionListPageDto {
   /** Present on `view=flat` responses (and older CPs). */
   sessions?: SessionDto[]
@@ -431,6 +437,7 @@ export interface SessionListPageDto {
    *  getting-started conversation step can be org-wide without exposing hidden rows. */
   orgHasSessions?: boolean
   accessSyncDegraded?: boolean
+  accessIssues?: SessionAccessIssue[]
 }
 
 export interface SessionListFilters {
@@ -463,6 +470,7 @@ export interface SessionListPage {
   nextCursor: string | null
   orgHasSessions?: boolean
   accessSyncDegraded?: boolean
+  accessIssues?: SessionAccessIssue[]
 }
 
 export interface SessionRelationDto {
@@ -512,6 +520,7 @@ export interface SessionDetailDto {
   /** Actual source gateway for Feishu/Lark external sessions. Absent on older CPs. */
   feishuRegion?: 'feishu' | 'lark' | null
   accessSyncDegraded?: boolean
+  accessIssues?: SessionAccessIssue[]
   /** Multi-agent webchat conversation roster, in pick order. Null for single-agent
    *  conversations and other platforms; absent on a CP that predates the feature.
    *  `name` is null when the caller cannot view that participant's agent. */
@@ -1994,7 +2003,8 @@ export async function fetchSessions(
     total: page.total,
     nextCursor: page.nextCursor,
     ...(page.orgHasSessions !== undefined ? { orgHasSessions: page.orgHasSessions } : {}),
-    ...(page.accessSyncDegraded !== undefined ? { accessSyncDegraded: page.accessSyncDegraded } : {})
+    ...(page.accessSyncDegraded !== undefined ? { accessSyncDegraded: page.accessSyncDegraded } : {}),
+    ...(page.accessIssues !== undefined ? { accessIssues: page.accessIssues } : {})
   }
 }
 
@@ -2076,7 +2086,8 @@ export async function fetchConversations(
     total: page.total,
     nextCursor: page.nextCursor,
     ...(page.orgHasSessions !== undefined ? { orgHasSessions: page.orgHasSessions } : {}),
-    ...(page.accessSyncDegraded !== undefined ? { accessSyncDegraded: page.accessSyncDegraded } : {})
+    ...(page.accessSyncDegraded !== undefined ? { accessSyncDegraded: page.accessSyncDegraded } : {}),
+    ...(page.accessIssues !== undefined ? { accessIssues: page.accessIssues } : {})
   }
 }
 
@@ -2820,6 +2831,7 @@ export interface UsageAgentDto {
 export interface UsageDto {
   range: UsageRange
   accessSyncDegraded?: boolean
+  accessIssues?: SessionAccessIssue[]
   totals: { sessions: number; totalTokens: number; costAmount: number; costCurrency: string | null }
   agents: UsageAgentDto[]
   // Spend-over-time chart: cost bucketed by hour (d1) or day (longer ranges),

--- a/packages/web/src/lib/logto-account.test.ts
+++ b/packages/web/src/lib/logto-account.test.ts
@@ -43,13 +43,37 @@ describe('Logto Account API', () => {
     expect(takeSocialLinkFlow()).toBeUndefined()
   })
 
+  it('renews an existing social token set without exposing the returned provider token', async () => {
+    const fetchImpl = vi.fn(
+      async (_input: URL | RequestInfo, _init?: RequestInit) =>
+        new Response(JSON.stringify({ access_token: 'new-provider-token' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+    )
+    vi.stubGlobal('fetch', fetchImpl)
+    const { renewSocialIdentityToken } = await import('./logto-account')
+
+    await expect(renewSocialIdentityToken('lark', 'social-verification')).resolves.toBeUndefined()
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL('https://login.example.test/api/my-account/identities/lark/access-token'),
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ verificationRecordId: 'social-verification' }),
+        headers: expect.any(Headers)
+      })
+    )
+    expect(new Headers(fetchImpl.mock.calls[0]?.[1]?.headers).get('authorization')).toBe('Bearer opaque-account-token')
+  })
+
   it('explains identity conflicts without offering account merging', async () => {
     const { LogtoAccountError, accountErrorMessage } = await import('./logto-account')
 
     expect(
       accountErrorMessage(new LogtoAccountError('identity already linked', 409, 'SOCIAL_IDENTITY_IN_USE'), {
         providerName: 'Google',
-        linking: true
+        operation: 'link'
       })
     ).toBe('That Google account is already linked to another AgentConnect account.')
   })
@@ -61,10 +85,16 @@ describe('Logto Account API', () => {
     const { LogtoAccountError, accountErrorMessage } = await import('./logto-account')
     const unauthorized = new LogtoAccountError('unauthorized', 401)
 
-    expect(accountErrorMessage(unauthorized, { providerName: 'Google', linking: true })).toBe(
+    expect(accountErrorMessage(unauthorized, { providerName: 'Google', operation: 'link' })).toBe(
       'This sign-in session cannot change sign-in methods. Sign out, sign in again, and retry.'
     )
     // Outside linking a 401 really is a dead session.
     expect(accountErrorMessage(unauthorized)).toBe('Your sign-in session expired. Sign in again and retry.')
+    expect(
+      accountErrorMessage(new LogtoAccountError('forbidden', 403), {
+        providerName: 'Lark',
+        operation: 'reauthorize'
+      })
+    ).toBe('The Lark authorization could not be renewed. Return to Profile and try again.')
   })
 })

--- a/packages/web/src/lib/logto-account.ts
+++ b/packages/web/src/lib/logto-account.ts
@@ -1,6 +1,10 @@
 import { getAccountToken, getLogtoPublicConfig } from '@/lib/auth'
 
 export interface SocialLinkFlow {
+  /** Existing link flows predate this discriminator and are treated as `link`. */
+  purpose?: 'link' | 'reauthorize'
+  /** Connector target whose stored token set is renewed after reauthorization. */
+  target?: string
   state: string
   connectorId: string
   /** The Account API verification this flow is completing. The provider's
@@ -155,6 +159,16 @@ export async function saveSocialIdentity(
   })
 }
 
+/** Replace an existing social identity's stored provider tokens after the same
+ * verified provider round trip used for linking. The returned access token is
+ * deliberately discarded; Session authorization retrieves it request-bound. */
+export async function renewSocialIdentityToken(target: string, verificationRecordId: string): Promise<void> {
+  await accountRequest(`/api/my-account/identities/${encodeURIComponent(target)}/access-token`, {
+    method: 'PUT',
+    body: JSON.stringify({ verificationRecordId })
+  })
+}
+
 export function createSocialState(): string {
   const bytes = crypto.getRandomValues(new Uint8Array(32))
   return Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('')
@@ -183,6 +197,9 @@ export function takeSocialLinkFlow(): SocialLinkFlow | undefined {
       typeof flow.verificationRecordId !== 'string' ||
       typeof flow.redirectUri !== 'string' ||
       (flow.currentVerificationRecordId !== undefined && typeof flow.currentVerificationRecordId !== 'string') ||
+      (flow.purpose !== undefined && flow.purpose !== 'link' && flow.purpose !== 'reauthorize') ||
+      (flow.target !== undefined && typeof flow.target !== 'string') ||
+      (flow.purpose === 'reauthorize' && (typeof flow.target !== 'string' || flow.target.length === 0)) ||
       typeof flow.providerName !== 'string' ||
       typeof flow.returnTo !== 'string' ||
       !flow.returnTo.startsWith('/') ||
@@ -198,16 +215,23 @@ export function takeSocialLinkFlow(): SocialLinkFlow | undefined {
   }
 }
 
-export function accountErrorMessage(error: unknown, context?: { providerName?: string; linking?: boolean }): string {
+export function accountErrorMessage(
+  error: unknown,
+  context?: { providerName?: string; operation?: 'link' | 'reauthorize' }
+): string {
   const requestError =
     error instanceof LogtoAccountError ||
     (error instanceof Error && typeof (error as Error & { status?: unknown }).status === 'number')
       ? (error as Error & { status: number; code?: string })
       : undefined
   if (!requestError) return 'Something went wrong. Try again.'
-  if ((requestError.status === 409 || requestError.status === 422) && context?.linking) {
+  if ((requestError.status === 409 || requestError.status === 422) && context?.operation) {
     const reason = `${requestError.code ?? ''} ${requestError.message}`.toLowerCase()
-    if (reason.includes('already') && (reason.includes('use') || reason.includes('link'))) {
+    if (
+      context.operation === 'link' &&
+      reason.includes('already') &&
+      (reason.includes('use') || reason.includes('link'))
+    ) {
       return `That ${context.providerName ?? 'social'} account is already linked to another AgentConnect account.`
     }
     return `The ${context.providerName ?? 'social'} authorization expired or could not be used. Try again.`
@@ -215,14 +239,17 @@ export function accountErrorMessage(error: unknown, context?: { providerName?: s
   if (requestError.status === 400) return 'The social authorization response is invalid or expired. Try again.'
   // 403 while linking is Logto refusing an unproven identity change, not a dead
   // session — saying "sign in again" sent us chasing the wrong thing once.
-  if (requestError.status === 403 && context?.linking) {
+  if (requestError.status === 403 && context?.operation === 'link') {
     return 'Verifying your account timed out. Return to Profile and start again.'
   }
-  // A 401 on the link path is usually not an expired session: the identity
+  if (requestError.status === 403 && context?.operation === 'reauthorize') {
+    return `The ${context.providerName ?? 'social'} authorization could not be renewed. Return to Profile and try again.`
+  }
+  // A 401 on a social-authorization path is usually not an expired session: the identity
   // endpoints are scope-gated, and a session opened before the deployment
   // granted that scope keeps working everywhere else while these calls refuse.
   // Only a fresh sign-in re-issues the token, so say that rather than "expired".
-  if (requestError.status === 401 && context?.linking) {
+  if (requestError.status === 401 && context?.operation) {
     return 'This sign-in session cannot change sign-in methods. Sign out, sign in again, and retry.'
   }
   if (requestError.status === 401 || requestError.status === 403) {

--- a/packages/web/src/lib/use-session-list.ts
+++ b/packages/web/src/lib/use-session-list.ts
@@ -111,6 +111,16 @@ export function useSessionList(
     return [...byId.values()]
   }, [pages])
   const nextCursor = pages.at(-1)?.nextCursor ?? null
+  const accessIssues = useMemo(
+    () => [
+      ...new Map(
+        pages
+          .flatMap((page) => page.accessIssues ?? [])
+          .map((issue) => [`${issue.provider}:${issue.region ?? ''}:${issue.reason}`, issue])
+      ).values()
+    ],
+    [pages]
+  )
   const loadingMore = isValidating && size > pages.length
   const loadMore = useCallback(async () => {
     if (!nextCursor || loadingMore) return
@@ -127,6 +137,7 @@ export function useSessionList(
     /** Org-level "any session exists" (first page carries it; older CPs omit it). */
     orgHasSessions: pages[0]?.orgHasSessions,
     accessSyncDegraded: pages.some((page) => page.accessSyncDegraded === true),
+    accessIssues,
     nextCursor,
     loadingMore,
     loadMore,


### PR DESCRIPTION
## Summary
- classify failed-closed Feishu/Lark session access checks without logging provider bodies or credentials
- preserve the compatibility degradation flag while returning requester-scoped access issues
- offer a real Lark/Feishu reconnect flow from Sessions, Usage, and Profile using Logto token renewal

## Safety
- affected sessions remain hidden until membership can be verified
- diagnostics contain only provider target, stage, status, and bounded error code
- Feishu/Lark labels come from verified scope region, not URL hints

## Testing
- pnpm --filter @agentconnect.md/control-plane test:unit
- pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/session-conversations.route.test.ts test/integration/session-metadata.route.test.ts test/integration/usage.route.test.ts
- pnpm --filter @agentconnect.md/control-plane typecheck
- pnpm --filter @agentconnect.md/web test
- pnpm --filter @agentconnect.md/web build
- changed-file ESLint / Prettier

Created by Codex . GPT-5.6