### PR TITLE
fix(integrations): make direct message triggers configurable

### DIFF
--- a/docs/designs/agent-collaboration-implementation.md
+++ b/docs/designs/agent-collaboration-implementation.md
@@ -401,15 +401,14 @@ channel the caller may speak in?"; it can only ask what the snapshot records. Di
 conversations _are_ recordable — `IntegrationChannel.kind` is
 `channel | im | mpim`, and `IntegrationRepo.channelPlacements` selects the channel rows
 with **no** `kind` filter, so an `im`/`mpim` row that exists is a KNOWN coordinate with the
-owning integration's agent as a member. But such a row is only written where something
-observed it: Slack's authoritative membership snapshot enumerates
-`public_channel,private_channel` only, and the two paths that emit `im`/`mpim` —
-`Daemon.reportGatedConversation` and the CP's shared-bot `reportConversation` — both run
-solely for a **gated** integration's (or install's) not-yet-enabled conversations. So an ordinary org-wide integration's DM has no row, and an A2A wake whose
-coordinate is that DM is refused. That is deliberate, and it is not a regression: the
-membership check this replaced refused the same wake, and refusing is recoverable where
-admitting it is not (the aliased session has already been resumed and read back). The same
-applies to a row that has disappeared — bot removed, integration set inactive, or a
+owning integration's agent as a member. Such a row is written only after observation:
+Slack's authoritative membership snapshot enumerates `public_channel,private_channel`
+only, while `Daemon.reportObservedConversation` and the CP shared-bot
+`reportConversation` emit `im`/`mpim` for every visibility. An ordinary DM therefore
+becomes a known coordinate after its first inbound message; before that observation an
+A2A wake asserting it is refused. Refusing the brief unknown state is recoverable where
+admitting it is not (the aliased session has already been resumed and read back). The
+same applies to a row that has disappeared — bot removed, integration set inactive, or a
 snapshot that has not caught up.
 
 The data model stores:

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -931,8 +931,9 @@ agents.
 - **org → restricted:** gating turns on. Existing known channel rows keep
   their current trigger (grandfathered enabled) so running setups are not cut
   mid-conversation; a Console banner prompts the editor to review them. Every
-  known direct row is reset Off before the gated route/spec push; newly observed
-  direct conversations also start Off.
+  known direct row is reset Off in the same transaction as the visibility change,
+  before the gated route/spec push; newly observed direct conversations also start
+  Off.
 - **restricted → org:** gating turns off; unscoped defaults return. Rows and
   their trigger values persist so flipping back restores the previous
   decisions — the same preservation principle as Decision 4. Direct and channel

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -736,9 +736,10 @@ So authorization must live in AgentConnect's own routing layer.
 
 **Gating applies only to restricted agents.**
 
-- **Org-visible agents keep exactly today's behavior.** Unscoped mention
+- **Org-visible agents keep the same routing defaults.** Unscoped mention
   default everywhere, DMs open to the whole workspace, per-channel "All
-  messages" opt-in. Nothing changes for them — no new rows, no new UX.
+  messages" opt-in. Observed direct conversations now have rows so an editor
+  can explicitly turn those defaults Off.
 - **Restricted agents are gated: every conversation defaults to Off.** When
   the bot is invited to a channel, the channel appears on the integration card
   in a pending/Off state. An **editor must enable it in the Console**, choosing
@@ -747,12 +748,12 @@ So authorization must live in AgentConnect's own routing layer.
   exactly the private group — the two ACL worlds meet here without any
   Slack↔AgentConnect identity mapping.
 
-**DMs are conversations too (restricted agents only).** For a gated
-integration, each DM conversation is listed as its own row (platform DM
-conversation id, displayed with the counterpart's name), default **Off**,
-individually enabled by an editor. The integration card groups rows into
-**Channels** and **Direct messages**; DM rows are binary (Off / On — a DM needs
-no mention distinction). Public agents' DMs stay open and produce no rows.
+**DMs are conversations too.** Every observed DM is listed as its own row
+(platform DM conversation id, displayed with the counterpart's name). The
+integration card groups rows into **Channels** and **Direct messages**; 1:1 DM
+rows are binary (Off / On — a DM needs no mention distinction). Org-visible
+agents default new DMs On; restricted agents default them Off. Both expose the
+same control, and both enforce it.
 
 **Behavior of an Off conversation.**
 
@@ -835,12 +836,10 @@ Discord / Lark / Feishu DM id shape when extending.)
 
 **Spec flag: `gated`.** `IntegrationSpec` gains a boolean (working name
 `gated`) so the daemon knows this integration is fail-closed. The daemon needs
-it for the two behaviors a rule miss cannot express: (1) send the one-time
-notice when an explicitly addressed message matches no rule; (2) report a
-previously unseen DM conversation so its row appears in the Console's pending
-list. Without the flag (public agents) daemon behavior is byte-for-byte
-unchanged. This is the §9 derived-form exception: the flag carries no
-identities.
+it to send the one-time notice when an explicitly addressed message matches no
+rule and to discover unknown/Off restricted channels. Direct-conversation
+reporting is visibility-independent. This is the §9 derived-form exception:
+the flag carries no identities.
 
 **Conversation reporting.** The `integration/channels` D→C EVT and
 `IntegrationChannel` protocol shape gain `kind: 'channel' | 'im'` (absent =
@@ -851,16 +850,17 @@ without deleting absent ones — so such a reporter names what it has LEFT in
 `removed`, the only way it can retire a row at all (its omissions carry no
 meaning). A named removal deletes whatever the row's kind, including a DM row
 that no authoritative snapshot could ever drop. An explicitly addressed Off group is reported
-before routing, because it deliberately creates no session. DM rows are likewise
-reported on first inbound DM to a gated integration, carrying the counterpart's
-display name. An optional boot-time sweep (`conversations.list types=im`) can
-backfill DMs opened while the daemon was down.
+before routing, because it deliberately creates no session. Direct rows are
+reported on first inbound conversation for every integration, carrying the
+counterpart's display name where available. An optional boot-time sweep
+(`conversations.list types=im`) can backfill DMs opened while the daemon was down.
 
-_Shared bots:_ the relay's membership snapshot drops IMs, so DM rows take the
-incremental path there too — an unrouted DM to a bot backing ≥1 gated agent
-makes the relay emit `rc/bot-conversation` (conversation id + best-effort
-`users.info` counterpart name), which the CP fans across the bot's **gated
-installs** as pending Off rows; the relay also posts the one-time
+_Shared bots:_ the relay's membership snapshot drops IMs, so direct rows take
+the incremental path there too — every human DM (and addressed group DM) makes
+the relay emit `rc/bot-conversation` (conversation id + best-effort `users.info`
+counterpart name), which the CP fans across **every install**. Restricted rows
+start Off; org-visible 1:1 DMs start On and group DMs on Mention. The relay also
+posts the one-time
 per-conversation notice (chrome-marked; the unrouted @-mention case included)
 since no daemon is involved before arbitration. Because a channel mention
 arrives as two independent Events API POSTs that the pool LB may hand to
@@ -884,9 +884,9 @@ agents.
 **Control-plane and web.**
 
 - `IntegrationChannel` (table `integration_channel`): `ChannelTrigger` enum
-  gains `off`; new `kind` column (`channel` | `im`). Row creation from the
-  membership report derives the default trigger from gating: `off` when gated,
-  `mention` otherwise (today's default).
+  gains `off`; new `kind` column (`channel` | `im` | `mpim`). Row creation
+  derives the default from visibility and kind: restricted conversations Off,
+  org-visible 1:1 DMs On, and other org-visible rooms Mention.
 - The existing per-channel trigger PATCH route accepts `off` and reuses the
   existing recompute-bindRules-and-push flow. A direct integration requires edit
   rights on its parent agent. A shared bot's channel state is bot-scoped, so the
@@ -908,11 +908,12 @@ agents.
   applied ahead of every rung, which the two arbiters populate differently
   because their unscoped rungs differ:
   - **Daemon** (`IntegrationSpec.mutedChannels`, per integration): the Off
-    channels of an UNGATED integration. A gated one leaves it empty — it ships
+    conversations of an UNGATED integration, including direct rows. A gated one leaves it empty — it ships
     no unscoped defaults at all, so its Off already is the absence of a scoped
     rule, and stating the same fact twice would let the two drift apart.
-  - **Relay** (`rc/bot-assign` / `rc/routes`, per bot): EVERY Off channel,
-    gated owner or not. A gated owner's missing route is not enough here: an
+  - **Relay** (`rc/bot-assign` / `rc/routes`, per bot): every bot-scoped Off
+    channel, plus a direct conversation when no placed install has it enabled.
+    A gated owner's missing route is not enough here: an
     ungated sibling's unscoped rungs are still in the same table, so on a
     mixed-visibility bot a bare `@bot` would otherwise reach the public default
     in a channel the console shows as Off.
@@ -929,17 +930,13 @@ agents.
 
 - **org → restricted:** gating turns on. Existing known channel rows keep
   their current trigger (grandfathered enabled) so running setups are not cut
-  mid-conversation; a Console banner prompts the editor to review them. DM
-  conversations start Off — rows appear as counterparts next write, each
-  receiving the one-time notice.
+  mid-conversation; a Console banner prompts the editor to review them. Every
+  known direct row is reset Off before the gated route/spec push; newly observed
+  direct conversations also start Off.
 - **restricted → org:** gating turns off; unscoped defaults return. Rows and
   their trigger values persist so flipping back restores the previous
-  decisions — the same preservation principle as Decision 4. Only the DIRECT
-  rows go inert, because the Console hides them for an org-visible agent and
-  honouring one would be behaviour with no visible control. A CHANNEL row keeps
-  its trigger, Off included: Off is a control every agent has (see
-  "Per-channel trigger" in product-conventions.md), and the row stays on screen
-  for an editor to change.
+  decisions — the same preservation principle as Decision 4. Direct and channel
+  rows remain visible and effective, including Off.
 
 ### 14.5 Rollout / migration
 
@@ -950,6 +947,10 @@ users; the one-time notice tells them what happened and the pending row gives
 editors a one-click re-enable. (The strict alternative — everything Off on
 migration — was considered and rejected as needlessly disruptive to channels
 that editors demonstrably already configured.)
+
+Existing org-visible direct rows were previously hidden and forced Off, so the
+migration seeds them to the new visible defaults: 1:1 DMs On and group DMs on
+Mention.
 
 ### 14.6 Out of scope / future overlays
 

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -350,8 +350,28 @@ removing the owner does not discard the channel or its trigger.
 
 A Console owner change preserves the channel's trigger. An in-Slack owner change or
 automatic fallback to a restricted agent instead leaves the channel Off, because only
-an authorized Console editor may enable it. Direct messages remain separate:
-restricted agents may independently enable or disable their own DM conversation rows.
+an authorized Console editor may enable it. Direct messages remain per-agent rather
+than bot-scoped: every agent may independently enable or disable its own conversation
+row.
+
+## Direct messages
+
+Every observed direct conversation appears under **Direct messages** on the Agent's
+integration card, for both Everyone and Restricted visibility. A 1:1 DM has one binary
+**Off / On** control: On responds to messages in that conversation; Off is an effective
+routing fence, not merely display state.
+
+Visibility determines the initial state, not whether the control exists:
+
+- An **Everyone** agent's newly observed 1:1 DM starts **On**, preserving the normal
+  open-DM behavior while making it explicitly reversible.
+- A **Restricted** agent's newly observed 1:1 DM starts **Off** and remains unroutable
+  until a Console editor enables it.
+
+Direct rows are observed incrementally because platforms do not enumerate them as bot
+membership. Switching Everyone → Restricted closes every known direct row before the
+gated routing configuration is pushed. Switching back keeps the stored choices; the
+rows stay visible and configurable.
 
 ## Group direct messages
 
@@ -363,35 +383,26 @@ way a DM does.
 
 Slack never reports a group DM as bot membership, so one is surfaced the way a DM is —
 on observation, when an inbound message names the bot — and never through a membership
-snapshot. Conversation rows therefore exist only where observation creates them, which
-gives the two visibilities different surfaces, matching how DMs already behave:
+snapshot. It appears under **Direct messages** for both visibilities, with the same
+three-way trigger as a channel:
 
-- An **org-visible** agent answers a group DM whenever it is @-mentioned, with no
-  per-conversation row and nothing to configure — the same way it always answers its
-  DMs.
+- An **Everyone** agent's newly observed group DM starts on **@-mention** and may be
+  changed to Off or Any message.
 - A **restricted** agent's group DM is surfaced as a row that starts Off and stays
-  unroutable until a Console editor enables it, exactly like its DM rows. Because the
-  conversation is channel-like, that row carries a channel's trigger choice, so an
-  editor may also opt it into every message.
-
-A preserved row does not outlive the visibility that created it. When a restricted agent
-becomes org-visible its group-DM and DM rows go inert — the Console stops showing them,
-so honouring one would leave the agent answering a conversation with no visible control
-to stop it. It falls back to the same defaults every org-visible agent has: mention in a
-group DM, every message in a DM.
+  unroutable until a Console editor enables it.
 
 A shared bot is one Slack identity, so a mention in a group DM cannot name which agent
 behind it is meant, and the slug that disambiguates a shared DM does not apply — a DM
 activates on any message, which a slug can outrank, while a group DM activates on the
 mention itself. A group DM served by a shared bot therefore converges on exactly one
-agent, the same way an ownerless channel does: the bot's earliest active install among
-those that enabled it.
+agent: the bot's earliest active install among those whose row is enabled.
 
 A conversation first mistaken for a channel converts to a group DM once resolved, and
-that conversion returns it to Off: the trigger it carried was a channel's default, never
-an operator's choice for this conversation. The resolved classification is durable — it
-lives on the conversation row, not in daemon memory, so a daemon restart that re-reports
-the conversation provisionally as a channel cannot flip an enabled group DM back to Off.
+that conversion receives the visibility-appropriate group-DM default (Mention for
+Everyone, Off for Restricted): the trigger it carried was not a direct-conversation
+choice. The resolved classification is durable — it lives on the conversation row, not
+in daemon memory, so a daemon restart that re-reports the conversation provisionally as
+a channel cannot reset a later operator choice.
 
 ## No-response control marker
 

--- a/packages/control-plane/prisma/migrations/20260804090000_everyone_direct_message_controls/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260804090000_everyone_direct_message_controls/migration.sql
@@ -1,0 +1,16 @@
+-- Direct conversations are now visible and configurable for org-visible agents.
+-- Existing rows were forced Off while they were hidden/inert; seed them to the
+-- same defaults newly observed conversations receive (1:1 DM On, group DM Mention).
+UPDATE "integration_channel" AS ic
+SET
+  "trigger" = CASE
+    WHEN ic."kind" = 'im'::"ConversationKind" THEN 'any'::"ChannelTrigger"
+    ELSE 'mention'::"ChannelTrigger"
+  END,
+  "updatedAt" = NOW()
+FROM "integration" AS i
+JOIN "agent" AS a ON a."id" = i."agentId"
+WHERE ic."integrationId" = i."id"
+  AND a."visibility" = 'org'::"ResourceVisibility"
+  AND ic."kind" IN ('im'::"ConversationKind", 'mpim'::"ConversationKind")
+  AND ic."trigger" = 'off'::"ChannelTrigger";

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1889,7 +1889,7 @@ enum ChannelTrigger {
 }
 
 // Conversation kind (resource-visibility.md §14.3): a member channel vs a direct
-// conversation. `im` rows exist only for gated (restricted-agent) integrations.
+// conversation. Direct rows are observed incrementally for every integration.
 // `mpim` is a Slack multi-person DM — reported on observation like `im` (Slack
 // never lists them as bot membership), but mention-gated like a channel.
 enum ConversationKind {
@@ -1918,7 +1918,7 @@ model IntegrationChannel {
   kind          ConversationKind @default(channel)
   // Relay-backed channel rows repeat the effective trigger across each active
   // integration so deleting the canonical owner does not discard channel state.
-  // DM rows remain independently gated per integration.
+  // Direct rows remain independently configurable per integration.
   trigger       ChannelTrigger   @default(mention)
   // Per-channel default/owning agent for a SHARED bot (shared-bot-relay.md §10.1
   // channel ownership — the primary disambiguation path). Exactly one active

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1348,8 +1348,8 @@ export function buildContainer(
         http.log.error({ err, botId: m.botId }, 'relay: notice-posted record failed')
       }
     },
-    // Incremental DM-conversation report (§14.3): surface a kind:'im' row (Off) on
-    // the bot's gated installs so console editors can enable the DM. Swallow+log.
+    // Incremental direct-conversation report: surface a configurable row on every
+    // install, with its visibility-appropriate default. Swallow+log.
     onBotConversation: async (m) => {
       try {
         await httpBot.reportConversation(m.botId, m.conversation)

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -792,7 +792,7 @@ export const TelegramBotCheckDto = z.object({
  *  `off` = conversation gating (resource-visibility.md §14): the agent does not
  *  activate there — the default for every conversation of a restricted agent.
  *  `kind: 'im'` rows are DM conversations and `kind: 'mpim'` rows are Slack group
- *  DMs (both gated integrations only — neither is ever enumerated). */
+ *  DMs. Both are observed rather than enumerated, for every agent visibility. */
 export const IntegrationChannelDto = z.object({
   channelId: z.string(),
   name: z.string().nullable(), // "#deploys" without the hash (or DM counterpart); null if lookup failed

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -679,15 +679,17 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       )
     })
 
-    it('an enabled im row of a NON-gated owner compiles a scoped route', async () => {
+    it('an enabled public DM compiles scoped auto and slug routes for every target', async () => {
       channels = [channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', agentId: ALICE, trigger: 'any' })]
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
       expect(assign.routes.filter((r) => r.scope?.channel === 'D42')).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } }),
+          expect.objectContaining({ agentId: ALICE, match: { kind: 'keyword', value: 'alice' } }),
           // BOB has not observed the row yet, so his public default remains On.
-          expect.objectContaining({ agentId: BOB, match: { kind: 'auto' } })
+          expect.objectContaining({ agentId: BOB, match: { kind: 'auto' } }),
+          expect.objectContaining({ agentId: BOB, match: { kind: 'keyword', value: 'bob' } })
         ])
       )
     })

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -221,7 +221,10 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
             agentId: opts?.agentId ?? null
           })
           channels.push(row)
-        } else if (conversation.name) row.name = conversation.name
+        } else {
+          if (conversation.name) row.name = conversation.name
+          if (opts?.agentId !== undefined) row.agentId = opts.agentId
+        }
         return row
       },
       upsertAgent: async (integrationId, channelId, agentId, opts) => {
@@ -560,24 +563,29 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(bobRow?.trigger).toBe('off')
     })
 
-    it('reportConversation fans a kind:im row (Off, agent-owned) to GATED installs only, idempotently', async () => {
+    it('reportConversation fans an owned DM row to every install with visibility-aware defaults', async () => {
       gatedAgents = new Set([ALICE])
       channels = []
       const orch = makeOrch()
       await orch.reportConversation(BOT, { id: 'D42', name: '@Alice' })
       const aliceRow = channels.find((c) => c.integrationId === INT_A && c.channelId === 'D42')
+      const bobRow = channels.find((c) => c.integrationId === INT_B && c.channelId === 'D42')
       expect(aliceRow).toMatchObject({ kind: 'im', trigger: 'off', agentId: ALICE, name: '@Alice' })
-      // BOB is org-visible — his DMs already route via defaultAgentId; no row.
-      expect(channels.some((c) => c.integrationId === INT_B && c.channelId === 'D42')).toBe(false)
+      expect(bobRow).toMatchObject({ kind: 'im', trigger: 'any', agentId: BOB, name: '@Alice' })
 
       // Editor enables it; a re-report must keep the trigger (name refresh only).
       aliceRow!.trigger = 'any'
       await orch.reportConversation(BOT, { id: 'D42', name: '@Alice Smith' })
       expect(aliceRow).toMatchObject({ trigger: 'any', name: '@Alice Smith' })
+      expect(bobRow).toMatchObject({ trigger: 'any', name: '@Alice Smith' })
 
-      // Discovery alone must NOT latch the notice: the report triggers no route
-      // re-stamp, and only rc/notice-posted (actual delivery) does.
-      expect(ch.sends.filter((s) => s.type === 'rc/routes')).toHaveLength(0)
+      const assign = ch.sends.filter((s) => s.type === 'rc/routes').at(-1)!.payload as RcBotAssign
+      expect(assign.routes.filter((route) => route.scope?.channel === 'D42')).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } }),
+          expect.objectContaining({ agentId: BOB, match: { kind: 'auto' } })
+        ])
+      )
     })
 
     // A group DM must survive the fan-out as itself. Stamping it 'im' would compile an
@@ -588,11 +596,14 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       channels = []
       const orch = makeOrch()
       await orch.reportConversation(BOT, { id: 'G42', name: 'mpim-alice--bob-1', kind: 'mpim' })
-      const row = channels.find((c) => c.integrationId === INT_A && c.channelId === 'G42')
-      expect(row).toMatchObject({ kind: 'mpim', trigger: 'off', agentId: ALICE })
+      const aliceRow = channels.find((c) => c.integrationId === INT_A && c.channelId === 'G42')
+      const bobRow = channels.find((c) => c.integrationId === INT_B && c.channelId === 'G42')
+      expect(aliceRow).toMatchObject({ kind: 'mpim', trigger: 'off', agentId: ALICE })
+      expect(bobRow).toMatchObject({ kind: 'mpim', trigger: 'mention', agentId: BOB })
 
       ch.sends.length = 0
-      row!.trigger = 'mention'
+      aliceRow!.trigger = 'mention'
+      bobRow!.trigger = 'off'
       await orch.syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
       const compiled = assign.routes.filter((r) => r.scope?.channel === 'G42')
@@ -617,10 +628,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(g42).toEqual([expect.objectContaining({ agentId: ALICE, match: { kind: 'mention' } })])
     })
 
-    // The two rules meet here: an INERT row must not win the convergence it is excluded
-    // from. Alice's preserved row is earlier, but she is org-visible and compiles
-    // nothing — electing her would leave the conversation served by nobody.
-    it('skips an org-visible agent when electing the group DM owner', async () => {
+    it('lets an enabled org-visible agent own a group DM', async () => {
       gatedAgents = new Set([BOB])
       channels = [
         channel({ integrationId: INT_A, channelId: 'G42', kind: 'mpim', agentId: ALICE, trigger: 'any' }),
@@ -629,18 +637,18 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
       expect(assign.routes.filter((r) => r.scope?.channel === 'G42')).toEqual([
-        expect.objectContaining({ agentId: BOB, match: { kind: 'mention' } })
+        expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } })
       ])
     })
 
-    // §14.4: the console hides a preserved direct row once its owner is org-visible, so
-    // compiling it would be behaviour the operator cannot see or stop.
-    it('makes a preserved group-DM row inert once its owner is no longer gated', async () => {
+    it('compiles an org-visible group-DM trigger', async () => {
       gatedAgents = new Set()
       channels = [channel({ integrationId: INT_A, channelId: 'G42', kind: 'mpim', agentId: ALICE, trigger: 'any' })]
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
-      expect(assign.routes.filter((r) => r.scope?.channel === 'G42')).toEqual([])
+      expect(assign.routes.filter((r) => r.scope?.channel === 'G42')).toEqual([
+        expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } })
+      ])
     })
 
     it('recordNoticePosted re-stamps the pool with the DELIVERED conversation', async () => {
@@ -671,12 +679,29 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       )
     })
 
-    it('an enabled im row of a NON-gated owner is inert: no scoped route (DMs stay on defaultAgentId)', async () => {
-      // ALICE flipped restricted → org with an enabled DM row left behind (§14.4).
+    it('an enabled im row of a NON-gated owner compiles a scoped route', async () => {
       channels = [channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', agentId: ALICE, trigger: 'any' })]
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.routes.filter((r) => r.scope?.channel === 'D42')).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } }),
+          // BOB has not observed the row yet, so his public default remains On.
+          expect.objectContaining({ agentId: BOB, match: { kind: 'auto' } })
+        ])
+      )
+    })
+
+    it('mutes a public DM when every placed install switched it Off', async () => {
+      channels = [
+        channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', agentId: ALICE, trigger: 'off' }),
+        channel({ integrationId: INT_B, channelId: 'D42', kind: 'im', agentId: BOB, trigger: 'off' })
+      ]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
       expect(assign.routes.filter((r) => r.scope?.channel === 'D42')).toEqual([])
+      expect(assign.mutedChannels).toContain('D42')
+      expect(assign.gatedOffChannels).not.toContain('D42')
     })
 
     it('stamps a deterministic notice authority from the connected relay roster', async () => {

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -445,13 +445,11 @@ export class HttpBotOrchestrator {
   }
 
   /**
-   * §14.3: fan an INCREMENTAL direct-conversation report across the bot's GATED
-   * installs as `kind:'im'` / `kind:'mpim'` rows (default Off, owned by each install's
-   * agent) so console editors can enable it. The reported kind is preserved: a group DM
-   * stays mention-gated, and stamping it 'im' would compile an `auto` route that answers
-   * every message in a room full of people. Non-gated installs are untouched — their DMs
-   * already route via `defaultAgentId`. Idempotent, and no route recompile: an Off row
-   * compiles nothing; the recompile happens when an editor enables it.
+   * Fan an INCREMENTAL direct-conversation report across every install as an owned
+   * `kind:'im'` / `kind:'mpim'` row. Restricted installs default Off; Everyone installs
+   * default a 1:1 DM On and a group DM to Mention. The reported kind is preserved so a
+   * group DM never accidentally receives an auto rule. Idempotent; route state is
+   * recompiled because a newly observed public row is immediately active.
    */
   async reportConversation(botId: string, conversation: ReportedChannel): Promise<void> {
     const bot = await this.bots.get(BotId(botId))
@@ -462,17 +460,18 @@ export class HttpBotOrchestrator {
     const installs = await this.integrations.listForBot(bot.id)
     for (const install of installs) {
       const agent = await this.agents.get(install.agentId)
-      if (!agent || !isGatedAgent(agent)) continue
+      if (!agent) continue
+      const kind = conversation.kind === 'mpim' ? ('mpim' as const) : ('im' as const)
       await this.channels.upsertConversation(
         install.id,
-        { ...conversation, kind: conversation.kind === 'mpim' ? 'mpim' : 'im' },
-        { agentId: AgentId(install.agentId), defaultTrigger: 'off' }
+        { ...conversation, kind },
+        {
+          agentId: AgentId(install.agentId),
+          defaultTrigger: isGatedAgent(agent) ? 'off' : kind === 'im' ? 'any' : 'mention'
+        }
       )
     }
-    // No route recompile: an Off row compiles nothing, and the notice latch is
-    // deliberately NOT row-derived (rc/notice-posted owns it) — a conversation
-    // discovered while a public default still routed it must keep its claim to a
-    // notice if it later becomes unroutable.
+    await this.syncRoutes(botId)
   }
 
   /**
@@ -620,8 +619,8 @@ export class HttpBotOrchestrator {
   /**
    * Converge every channel to one canonical owner. This repairs owner deletion,
    * legacy ownerless rows, and older Web writes that stored an owner on the wrong
-   * integration. DM rows are intentionally excluded because gated DMs may enable
-   * several agents independently.
+   * integration. Direct rows are intentionally excluded because every install owns
+   * its own trigger.
    */
   private async ensureChannelOwners(botId: BotId, installs: IntegrationRecord[]): Promise<void> {
     if (installs.length === 0) return
@@ -687,18 +686,21 @@ export class HttpBotOrchestrator {
     //    routes to that agent, respecting the channel's trigger (any → auto rule,
     //    mention → mention rule). Emitted FIRST so a scoped rule wins arbitration.
     const chans = await this.channels.listForBot(bot.id)
+    const channelRows = chans.filter((c) => !isDirectConversationKind(c.kind))
     // The channel's owning agent — the one row of the fan-out that carries it (§10.1).
     const channelOwner = new Map<string, string>()
-    for (const c of chans) if (c.agentId && !channelOwner.has(c.channelId)) channelOwner.set(c.channelId, c.agentId)
-    // Off channels split into two facts the relay needs separately.
+    for (const c of channelRows) {
+      if (c.agentId && !channelOwner.has(c.channelId)) channelOwner.set(c.channelId, c.agentId)
+    }
+    // Off conversations split into two facts the relay needs separately.
     //
     // ROUTING (`mutedChannels`): every Off channel, whoever owns it. The trigger is
     // bot-scoped — replicated across every membership row — so Off means this bot does
     // not answer here, and a route being absent is not enough to say so: the keyword slug
     // and `defaultAgentId` rungs are unscoped, and on a mixed bot they would hand a bare
     // @bot to the public default in a channel the console shows as Off. Any row states
-    // the trigger, including one whose owner is not currently placed. Direct rows never
-    // mute (a DM is not a place with an owner to switch off).
+    // the trigger, including one whose owner is not currently placed. Direct rows are
+    // per-agent: the conversation is muted only when no placed install is enabled.
     //
     // NOTICE (`gatedOffChannels`): of those, the ones owned by a GATED agent. Their Off
     // is §14's fail-closed default for a conversation nobody has enabled yet, and it owns
@@ -706,57 +708,77 @@ export class HttpBotOrchestrator {
     // agent is private must not meet a dead bot. An OPERATOR's Off says nothing: they
     // already decided, and that advice would be the opposite of what happened. The two
     // states share a trigger value, so only ownership tells them apart.
-    const offChannels = chans.filter((c) => c.trigger === 'off' && !isDirectConversationKind(c.kind))
+    const offChannels = channelRows.filter((c) => c.trigger === 'off')
     const ownerGated = (channelId: string): boolean => {
       const owner = channelOwner.get(channelId)
       const agent = owner ? agentById.get(owner) : undefined
       return !!agent && isGatedAgent(agent)
     }
-    const mutedChannels = [...new Set(offChannels.map((c) => c.channelId))]
-    const gatedOffChannels = mutedChannels.filter(ownerGated)
-    // A group DM has no owner picker — it is not a place the bot was invited to, so the
-    // observation fan-out gives every gated install its own row. Two agents enabling the
-    // same one would compile two IDENTICAL scoped mention routes and relay order would
-    // silently decide, permanently hiding the loser. Slug disambiguation cannot rescue
-    // it either: unlike a DM's `auto` base, the mention rung outranks keyword. So a group
-    // DM converges on ONE agent exactly as an ownerless channel does (§10.1) — the bot's
-    // earliest active install among those that enabled it.
-    //
-    // Only a GATED install can be a candidate. A preserved row of a now-org-visible agent
-    // is inert (it is skipped below), so letting it claim ownership would elect an owner
-    // that compiles nothing AND lock out the restricted agent that actually has the
-    // conversation enabled — leaving the group DM served by nobody.
-    const groupDmOwner = new Map<string, string>()
-    for (const p of placed) {
-      if (!p.gated) continue
-      for (const c of chans) {
-        if (c.kind !== 'mpim' || c.trigger === 'off' || c.agentId !== p.integration.agentId) continue
-        if (!groupDmOwner.has(c.channelId)) groupDmOwner.set(c.channelId, p.integration.agentId)
+    const muted = new Set(offChannels.map((c) => c.channelId))
+    const gatedOff = new Set([...muted].filter(ownerGated))
+
+    // Direct rows are independent per install. Once a conversation is observed, emit
+    // scoped routes for every enabled 1:1 DM row so those controls outrank the public
+    // keyword/default fallbacks. A missing public row keeps the pre-observation default
+    // (On for a DM, Mention for a group DM); a missing restricted row stays Off.
+    const directByConversation = new Map<string, IntegrationChannelRecord[]>()
+    for (const c of chans) {
+      if (!isDirectConversationKind(c.kind)) continue
+      const rows = directByConversation.get(c.channelId)
+      if (rows) rows.push(c)
+      else directByConversation.set(c.channelId, [c])
+    }
+    for (const [channelId, rows] of directByConversation) {
+      // Prefer the safer room classification if rolling reporters briefly disagree.
+      const kind = rows.some((row) => row.kind === 'mpim') ? ('mpim' as const) : ('im' as const)
+      const enabled = placed.flatMap((p) => {
+        const row = rows.find((candidate) => candidate.integrationId === p.integration.id)
+        const trigger = row?.trigger ?? (p.gated ? 'off' : kind === 'im' ? 'any' : 'mention')
+        return trigger === 'off' ? [] : [{ p, trigger }]
+      })
+      if (enabled.length === 0) {
+        muted.add(channelId)
+        if (placed.some((p) => p.gated)) gatedOff.add(channelId)
+        continue
+      }
+      // A group DM carries one shared @bot identity. Multiple identical mention routes
+      // would make relay order choose silently, so its earliest enabled install owns it.
+      const targets = kind === 'mpim' ? enabled.slice(0, 1) : enabled
+      for (const { p, trigger } of targets) {
+        const match: BindMatch = kind === 'im' || trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }
+        routes.push({
+          agentId: p.integration.agentId,
+          daemonId: p.daemonId,
+          integrationId: p.integration.id,
+          scope: { channel: channelId },
+          match
+        })
+        if (kind === 'im' && p.gated) {
+          const slug = p.agent.name
+          if (slug) {
+            routes.push({
+              agentId: p.integration.agentId,
+              daemonId: p.daemonId,
+              integrationId: p.integration.id,
+              scope: { channel: channelId },
+              match: { kind: 'keyword', value: slug }
+            })
+          }
+        }
       }
     }
-    for (const c of chans) {
+
+    // Member channels have one bot-scoped owner and trigger.
+    for (const c of channelRows) {
       if (!c.agentId) continue
       const p = byAgent.get(c.agentId)
       if (!p) continue // channel assigned to an agent not (yet) placed — skip
-      // Conversation gating (§14): an Off conversation compiles NO route for a
-      // GATED owner (fail-closed until an editor enables it). For a non-gated
-      // owner a preserved row is inert (§14.4): a channel keeps its
-      // mention-trigger ownership (matching integrationToSpec()), while a DIRECT
-      // row (a DM or a group DM) compiles nothing at all — §14 direct rows only
-      // steer gated members, and the console hides them for everyone else, so
-      // honouring one would be behaviour with no visible control. Non-gated DMs
-      // route via defaultAgentId as they always did, and a non-gated group DM via
-      // the unscoped mention default.
-      if (isDirectConversationKind(c.kind) && (!p.gated || c.trigger === 'off')) continue
       // Off compiles no route for ANY owner. That alone does not make the channel
       // unreachable — `mutedChannels` above is what closes the unscoped rungs, for a
       // gated owner just as much as an ungated one (a mixed bot's public default
       // would otherwise answer a bare @bot in a channel the console shows as Off).
       if (c.trigger === 'off') continue
-      if (c.kind === 'mpim' && groupDmOwner.get(c.channelId) !== c.agentId) continue
-      // A DM conversation row activates on any message once enabled (no mention
-      // inside a DM); channels follow their trigger.
-      const match: BindMatch = c.kind === 'im' || c.trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }
+      const match: BindMatch = c.trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }
       routes.push({
         agentId: p.integration.agentId,
         daemonId: p.daemonId,
@@ -764,24 +786,9 @@ export class HttpBotOrchestrator {
         scope: { channel: c.channelId },
         match
       })
-      if (c.kind === 'im' && p.gated) {
-        // Slug disambiguation inside a multi-agent DM enabled for SEVERAL gated agents
-        // (§14.3): a conversation-scoped keyword outranks the scoped auto in the
-        // relay's arbitration, so "<slug> …" names this agent while an unslugged
-        // DM falls to the first enabled auto route. (Unscoped keyword stays
-        // forbidden for gated agents.)
-        const slug = agentById.get(c.agentId)?.name
-        if (slug) {
-          routes.push({
-            agentId: p.integration.agentId,
-            daemonId: p.daemonId,
-            integrationId: p.integration.id,
-            scope: { channel: c.channelId },
-            match: { kind: 'keyword', value: slug }
-          })
-        }
-      }
     }
+    const mutedChannels = [...muted]
+    const gatedOffChannels = [...gatedOff]
 
     // 2. keyword disambiguation (§10.2): one keyword rule per agent = its slug, so
     //    "@bot <slug> …" routes to that agent. No unscoped mention rule — that would

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -753,7 +753,11 @@ export class HttpBotOrchestrator {
           scope: { channel: channelId },
           match
         })
-        if (kind === 'im' && p.gated) {
+        // A shared 1:1 DM may have several enabled installs. Emit every target's
+        // scoped slug so arbitration can evaluate it ahead of scoped auto: naming a
+        // non-default public agent still selects that agent, and gated targets use
+        // the same disambiguation.
+        if (kind === 'im') {
           const slug = p.agent.name
           if (slug) {
             routes.push({

--- a/packages/control-plane/src/orchestrator/integrationPush.ts
+++ b/packages/control-plane/src/orchestrator/integrationPush.ts
@@ -13,6 +13,7 @@ import type {
   IntegrationChannelRepo,
   IntegrationRepo
 } from '../persistence/ports.js'
+import { isDirectConversationKind } from '../persistence/ports.js'
 import { NoConnection, type ControlSender } from './outbound.js'
 import { integrationToSpec, isGatedAgent } from './placement.js'
 import { AgentId } from '../domain/ids.js'
@@ -34,6 +35,33 @@ export async function convergeIntegrationGating(
   log?: { warn(obj: unknown, msg?: string): void }
 ): Promise<void> {
   const integrations = await deps.repos.integration.listForAgent(AgentId(agent.id))
+  const gated = isGatedAgent(agent)
+  const channelCache = new Map<string, Awaited<ReturnType<IntegrationChannelRepo['listForIntegration']>>>()
+  // Everyone direct rows may be On. Becoming Restricted is a new trust boundary, so
+  // close every known direct conversation before compiling or pushing the gated spec.
+  if (gated) {
+    for (const integration of integrations) {
+      try {
+        const channels = await deps.repos.integrationChannel.listForIntegration(integration.id)
+        for (const channel of channels) {
+          if (isDirectConversationKind(channel.kind) && channel.trigger !== 'off') {
+            await deps.repos.integrationChannel.setTrigger(integration.id, channel.channelId, 'off')
+          }
+        }
+        channelCache.set(
+          integration.id,
+          channels.map((channel) =>
+            isDirectConversationKind(channel.kind) ? { ...channel, trigger: 'off' as const } : channel
+          )
+        )
+      } catch (err) {
+        log?.warn(
+          { integrationId: integration.id, err: (err as Error).message },
+          'gating converge: failed to close direct conversations'
+        )
+      }
+    }
+  }
   const syncedBots = new Set<string>()
   for (const i of integrations) {
     try {
@@ -48,10 +76,10 @@ export async function convergeIntegrationGating(
       if (!agent.daemonId) continue
       const [secret, channels] = await Promise.all([
         deps.repos.botSecret.get(i.botId),
-        deps.repos.integrationChannel.listForIntegration(i.id)
+        channelCache.get(i.id) ?? deps.repos.integrationChannel.listForIntegration(i.id)
       ])
       if (!secret) continue
-      await deps.control.integrationUpsert(agent.daemonId, integrationToSpec(i, secret, channels, isGatedAgent(agent)))
+      await deps.control.integrationUpsert(agent.daemonId, integrationToSpec(i, secret, channels, gated))
     } catch (err) {
       if (err instanceof NoConnection) continue // offline daemon → reconcile roster carries it
       log?.warn({ integrationId: i.id, err: (err as Error).message }, 'gating converge: integration push failed')

--- a/packages/control-plane/src/orchestrator/integrationPush.ts
+++ b/packages/control-plane/src/orchestrator/integrationPush.ts
@@ -13,7 +13,6 @@ import type {
   IntegrationChannelRepo,
   IntegrationRepo
 } from '../persistence/ports.js'
-import { isDirectConversationKind } from '../persistence/ports.js'
 import { NoConnection, type ControlSender } from './outbound.js'
 import { integrationToSpec, isGatedAgent } from './placement.js'
 import { AgentId } from '../domain/ids.js'
@@ -36,32 +35,6 @@ export async function convergeIntegrationGating(
 ): Promise<void> {
   const integrations = await deps.repos.integration.listForAgent(AgentId(agent.id))
   const gated = isGatedAgent(agent)
-  const channelCache = new Map<string, Awaited<ReturnType<IntegrationChannelRepo['listForIntegration']>>>()
-  // Everyone direct rows may be On. Becoming Restricted is a new trust boundary, so
-  // close every known direct conversation before compiling or pushing the gated spec.
-  if (gated) {
-    for (const integration of integrations) {
-      try {
-        const channels = await deps.repos.integrationChannel.listForIntegration(integration.id)
-        for (const channel of channels) {
-          if (isDirectConversationKind(channel.kind) && channel.trigger !== 'off') {
-            await deps.repos.integrationChannel.setTrigger(integration.id, channel.channelId, 'off')
-          }
-        }
-        channelCache.set(
-          integration.id,
-          channels.map((channel) =>
-            isDirectConversationKind(channel.kind) ? { ...channel, trigger: 'off' as const } : channel
-          )
-        )
-      } catch (err) {
-        log?.warn(
-          { integrationId: integration.id, err: (err as Error).message },
-          'gating converge: failed to close direct conversations'
-        )
-      }
-    }
-  }
   const syncedBots = new Set<string>()
   for (const i of integrations) {
     try {
@@ -76,7 +49,7 @@ export async function convergeIntegrationGating(
       if (!agent.daemonId) continue
       const [secret, channels] = await Promise.all([
         deps.repos.botSecret.get(i.botId),
-        channelCache.get(i.id) ?? deps.repos.integrationChannel.listForIntegration(i.id)
+        deps.repos.integrationChannel.listForIntegration(i.id)
       ])
       if (!secret) continue
       await deps.control.integrationUpsert(agent.daemonId, integrationToSpec(i, secret, channels, gated))

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -1,9 +1,9 @@
 /**
  * `integrationToSpec` — the per-channel trigger → wire bindRules fold (unit, no I/O).
  *
- * The delivered rule set is always: the defaults (@-mention anywhere + DMs) plus
- * one channel-scoped `auto` rule per channel switched to "any message". A channel
- * left on '@-mention' adds NO extra rule — the unscoped mention default covers it.
+ * The delivered rule set is the defaults (@-mention anywhere + DMs) plus one scoped
+ * `auto` rule per room switched to "any message". A room left on '@-mention' adds no
+ * extra rule; a 1:1 DM's On state uses the unscoped DM default.
  */
 import { describe, it, expect } from 'vitest'
 import { integrationToSpec } from './placement.js'
@@ -70,10 +70,7 @@ describe('integrationToSpec bindRules', () => {
     ])
   })
 
-  // §14.4: a direct row only exists because observation created it while the agent was
-  // restricted, and the console hides it once the agent is org-visible. Compiling its
-  // "any message" would leave the agent answering with no visible control to stop it.
-  it('ignores a preserved DM / group-DM row set to "any" for a non-gated agent', () => {
+  it('uses the DM default for a 1:1 row and scopes a group DM set to "any"', () => {
     const spec = integrationToSpec(INTEGRATION, SECRET, [
       channel('C1', 'any'),
       channel('D1', 'any', 'im'),
@@ -82,7 +79,8 @@ describe('integrationToSpec bindRules', () => {
     expect(slackCfg(spec).bindRules).toEqual([
       { match: { kind: 'mention' } },
       { match: { kind: 'dm' } },
-      { channel: 'C1', match: { kind: 'auto' } }
+      { channel: 'C1', match: { kind: 'auto' } },
+      { channel: 'G1', match: { kind: 'auto' } }
     ])
   })
 
@@ -149,12 +147,10 @@ describe('integrationToSpec mutedChannels', () => {
     expect(spec.core?.mutedChannels).toEqual(['C1', 'C4'])
   })
 
-  // §14.4: the console hides a preserved direct row once its owner is org-visible, so
-  // honouring its Off would silence DMs through a control nobody can see.
-  it('never mutes a direct row on a non-gated integration', () => {
+  it('mutes direct rows on a non-gated integration', () => {
     const spec = integrationToSpec(INTEGRATION, SECRET, [channel('D1', 'off', 'im'), channel('G1', 'off', 'mpim')])
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
-    expect(spec.core?.mutedChannels).toEqual([])
+    expect(spec.core?.mutedChannels).toEqual(['D1', 'G1'])
   })
 
   // A gated integration says Off by having no rule for the conversation; stating it

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -201,7 +201,7 @@ function gatedBindRules(channels: IntegrationChannelRecord[]): IntegrationBindRu
 }
 
 /**
- * The Off channels of an UNGATED integration — its `mutedChannels` fence.
+ * The Off conversations of an UNGATED integration — its `mutedChannels` fence.
  *
  * An ungated integration reaches every conversation through unscoped defaults
  * (@-mention anywhere + DMs), which no channel-scoped rule can subtract from, so Off
@@ -210,13 +210,12 @@ function gatedBindRules(channels: IntegrationChannelRecord[]): IntegrationBindRu
  * naming the channel here would only give the same fact two representations that can
  * disagree — hence the empty list.
  *
- * DIRECT rows never mute. A preserved one is inert on an ungated integration (§14.4 —
- * the console hides it), and a gated integration expresses its Off DMs the same way it
- * expresses every other Off conversation.
+ * Direct rows use the same fence: their Off/On control is visible and effective for
+ * every agent. A gated integration still expresses Off by omitting its scoped rule.
  */
 function mutedChannelIds(channels: IntegrationChannelRecord[], gated: boolean): string[] {
   if (gated) return []
-  return channels.filter((c) => c.trigger === 'off' && !isDirectConversationKind(c.kind)).map((c) => c.channelId)
+  return channels.filter((c) => c.trigger === 'off').map((c) => c.channelId)
 }
 
 /**
@@ -238,13 +237,10 @@ export function integrationToSpec(
   channels: IntegrationChannelRecord[] = [],
   gated = false
 ): IntegrationSpec {
-  // A preserved DIRECT row (§14.4) is inert here. Its "any message" was an editor's
-  // choice while the agent was restricted, and the console hides the row once it is
-  // not — honouring it would leave an org-visible agent answering every message in a
-  // conversation with no visible control to turn it off. Such an agent reaches its DMs
-  // through the unscoped dm default and a group DM through the unscoped mention default.
+  // A 1:1 DM's On state is already covered by the unscoped dm default. A group DM
+  // set to Any needs its own auto rule; Mention is covered by the default mention rule.
   const channelRules: IntegrationBindRule[] = channels
-    .filter((c) => c.trigger === 'any' && !isDirectConversationKind(c.kind))
+    .filter((c) => c.trigger === 'any' && c.kind !== 'im')
     .map((c) => ({ channel: c.channelId, match: { kind: 'auto' as const } }))
   const bindRules = gated ? gatedBindRules(channels) : [...DEFAULT_BIND_RULES, ...channelRules]
   const mutedChannels = mutedChannelIds(channels, gated)

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -61,7 +61,6 @@ import type {
   ExternalMemoryGrantRepo,
   MemoryPluginInstallationRepo
 } from '../persistence/ports.js'
-import { isDirectConversationKind } from '../persistence/ports.js'
 import { telegramIntegrationConfig } from '../platforms/telegram/provider.js'
 import { discordIntegrationConfig } from '../platforms/discord/provider.js'
 import { slackIntegrationConfig, slackSharedIntegrationConfig } from '../platforms/slack/provider.js'

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3151,8 +3151,7 @@ export type ChannelTrigger = 'off' | 'mention' | 'any'
 export type ConversationKind = 'channel' | 'im' | 'mpim'
 
 /** A conversation the bot was never invited to and that is never enumerated — a DM or a
- *  Slack group DM. Its row exists only because observation created it, which is why a
- *  preserved one is inert for a non-gated owner: there is no console control over it. */
+ *  Slack group DM. Observation creates a visible, independently configurable row. */
 export function isDirectConversationKind(kind: ConversationKind | undefined): boolean {
   return kind === 'im' || kind === 'mpim'
 }
@@ -3195,9 +3194,9 @@ export interface IntegrationChannelRepo {
    * Authoritative membership snapshots delete kind='channel' rows the bot is no
    * longer a member of; non-authoritative observed-conversation reports retain
    * missing rows because platforms such as Telegram cannot enumerate all chats.
-   * DM (kind='im') rows are always retained. `defaultTrigger` seeds NEW rows only
-   * ('off' for a gated integration, 'mention' otherwise); existing rows keep
-   * their trigger.
+   * Direct rows are always retained. `defaultTrigger` seeds NEW rows only ('off'
+   * for a gated integration); otherwise a 1:1 DM starts On and a room starts on
+   * Mention. Existing rows keep their trigger.
    *
    * `removed` names conversations to DELETE outright, whatever the report's kind.
    * It is how a non-authoritative reporter retires a row at all — its omissions
@@ -3215,9 +3214,9 @@ export interface IntegrationChannelRepo {
    *  was actually removed. Metadata only — sessions and transcripts are untouched. */
   deleteChannel(integrationId: IntegrationId, channelId: string): Promise<boolean>
   listForIntegration(integrationId: IntegrationId): Promise<IntegrationChannelRecord[]>
-  /** Incremental conversation upsert (§14.3, DM rows): create the row (kind, name,
-   *  `agentId`, `defaultTrigger`) when absent; when it exists refresh only the name
-   *  — trigger and agentId are operator-owned once created. */
+  /** Incremental conversation upsert (§14.3, direct rows): create the row (kind,
+   *  name, `agentId`, `defaultTrigger`) when absent; when it exists refresh metadata
+   *  and a supplied agent attribution while preserving the operator-owned trigger. */
   upsertConversation(
     integrationId: IntegrationId,
     conversation: ReportedChannel,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -746,8 +746,9 @@ export interface AgentRepo {
    *  live. A concurrently deleted or differently repaired agent is a no-op. */
   setWorkspaceRepoId(agentId: AgentId, repoId: bigint): Promise<boolean>
   /** Set the visibility + share set (the dedicated `/sharing` write path, kept
-   *  separate from content `update`). Stamps the last-modified audit; `byUserId`
-   *  is the editing WebUI principal (absent under devAuth). */
+   *  separate from content `update`). An org→restricted transition atomically
+   *  closes known direct-conversation rows. Stamps the last-modified audit;
+   *  `byUserId` is the editing WebUI principal (absent under devAuth). */
   setSharing(
     agentId: AgentId,
     sharing: { visibility: ResourceVisibility; sharedWith: string[] },

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -731,7 +731,7 @@ export class PgAgentRepo implements AgentRepo {
     return this.transaction(async (tx) => {
       const existing = await tx.agent.findUniqueOrThrow({
         where: { id: agentId },
-        select: { orgId: true }
+        select: { orgId: true, visibility: true }
       })
       const memberships = await lockResourceWriteMemberships(tx, {
         orgId: existing.orgId,
@@ -739,6 +739,22 @@ export class PgAgentRepo implements AgentRepo {
         actorUserId: byUserId,
         sharedWith: sharing.sharedWith
       })
+      // Everyone DMs may be On. Crossing into Restricted is a trust-boundary
+      // change, so close every known direct row in the SAME transaction as the
+      // visibility write. A persistence failure rolls the whole transition back;
+      // route/spec convergence can never compile a restricted agent from
+      // still-enabled rows. Do not repeat this for restricted share-set edits — an
+      // editor may have deliberately re-enabled a DM after the initial transition.
+      if (existing.visibility !== 'restricted' && sharing.visibility === 'restricted') {
+        await tx.integrationChannel.updateMany({
+          where: {
+            integration: { agentId },
+            kind: { in: ['im', 'mpim'] },
+            trigger: { not: 'off' }
+          },
+          data: { trigger: 'off' }
+        })
+      }
       // A sharing change is a human edit — advance the last-modified audit
       // (editor stamped when known; absent under devAuth ⇒ leave it unchanged).
       const a = await tx.agent.update({

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -623,18 +623,10 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
 
   // Converge to a daemon channel report: refresh supplied metadata on known
   // conversations (PRESERVING the operator's trigger), insert new ones (trigger =
-  // `defaultTrigger`, 'mention' unless the integration is gated), and, for an
+  // `defaultTrigger`, otherwise On for a 1:1 DM and Mention for a room), and, for an
   // authoritative membership snapshot, drop channel rows that are no longer present.
   // DM rows and rows omitted from a non-authoritative observed-conversation report
   // are retained.
-  //
-  // A DM row is the one exception to `defaultTrigger`, and it is a SECURITY boundary
-  // (resource-visibility.md §14.3). Discovery reports DMs whether or not the owning
-  // agent is gated today, and visibility can flip to restricted later — at which point
-  // `gatedBindRules` enables every non-Off IM row. Storing a discovered DM with the
-  // ordinary 'mention' default would therefore let a newly-private agent keep answering
-  // a DM that no operator ever enabled. Created DM rows, and channel rows converting to
-  // DM, are pinned Off; an operator's later choice is untouched.
   //
   // The channel→DM transition is decided INSIDE the write, off the row's committed kind,
   // never off a prior read. Channel reports are fire-and-forget and their handlers run
@@ -666,12 +658,11 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
       // downgrade an established 'im' row.
       const setName = authoritative || c.name !== undefined
       const setPrivate = authoritative || c.isPrivate !== undefined
-      // Direct conversations (a DM, or a Slack group DM) are only ever reported by
-      // observation, never enumerated — so they are pinned Off on creation and on
-      // conversion for the same fail-closed reason, and an authoritative channel
-      // snapshot (which cannot contain them) must not delete them.
+      // Direct conversations are observed rather than enumerated. Restricted installs
+      // pass `defaultTrigger:'off'`; Everyone installs default a 1:1 DM On and a group
+      // DM to Mention. An authoritative channel snapshot cannot delete either kind.
       const direct = c.kind === 'im' || c.kind === 'mpim'
-      const createTrigger = direct ? 'off' : (opts?.defaultTrigger ?? 'mention')
+      const createTrigger: ChannelTrigger = opts?.defaultTrigger ?? (c.kind === 'im' ? 'any' : 'mention')
       await this.db.$executeRaw`
         INSERT INTO "integration_channel"
           ("integrationId", "channelId", "name", "spaceId", "space", "isPrivate", "kind", "trigger",
@@ -705,14 +696,12 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
               THEN EXCLUDED."kind"
             ELSE "integration_channel"."kind"
           END,
-          -- The fail-closed conversion, resolved against the COMMITTED kind: a row that
-          -- was a channel carried a channel's trigger, which is not an operator's choice
-          -- for a direct conversation. A row already of the reported kind keeps whatever
-          -- the operator set. (Slack classifies a group DM late — an app_mention payload
-          -- carries no channel_type — so channel to mpim is a real transition, not a race.)
+          -- Resolve a late channel→direct classification against the COMMITTED kind.
+          -- The row receives this installation's direct-conversation default; a row
+          -- already of the reported kind keeps whatever the operator set.
           "trigger" = CASE
             WHEN ${direct}::boolean AND "integration_channel"."kind" <> EXCLUDED."kind"
-              THEN 'off'::"ChannelTrigger"
+              THEN ${createTrigger}::"ChannelTrigger"
             ELSE "integration_channel"."trigger"
           END,
           "updatedAt" = NOW()
@@ -747,14 +736,9 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         space: conversation.space ?? null,
         isPrivate: conversation.isPrivate ?? false,
         kind: conversation.kind ?? 'channel',
-        // Same fail-closed rule as replaceSnapshot: a created direct-conversation row
-        // (DM or group DM) starts Off however it was discovered, so a later flip to
-        // restricted cannot grandfather it in.
-        ...(conversation.kind === 'im' || conversation.kind === 'mpim'
-          ? { trigger: 'off' as const }
-          : opts?.defaultTrigger
-            ? { trigger: opts.defaultTrigger }
-            : {}),
+        // Restricted installs supply Off. Otherwise 1:1 DMs start On and rooms use
+        // Mention, matching replaceSnapshot and the controls shown in the Console.
+        trigger: opts?.defaultTrigger ?? (conversation.kind === 'im' ? 'any' : 'mention'),
         ...(opts?.agentId !== undefined ? { agentId: opts.agentId } : {})
       },
       // Refresh only a KNOWN name — a nameless re-report must not clobber a
@@ -762,7 +746,8 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
       update: {
         ...(conversation.name ? { name: conversation.name } : {}),
         ...(conversation.spaceId ? { spaceId: conversation.spaceId } : {}),
-        ...(conversation.space ? { space: conversation.space } : {})
+        ...(conversation.space ? { space: conversation.space } : {}),
+        ...(opts?.agentId !== undefined ? { agentId: opts.agentId } : {})
       }
     })
     return toChannelRecord(row)

--- a/packages/control-plane/src/ws/relay-connection.ts
+++ b/packages/control-plane/src/ws/relay-connection.ts
@@ -60,8 +60,8 @@ export interface RelayConnDeps {
   onSetChannelAgent: (m: RcSetChannelAgent) => Promise<void>
   /** Apply a complete Slack channel-membership snapshot reported by HTTP ingest. */
   onBotChannels: (m: RcBotChannels) => Promise<void>
-  /** Apply an INCREMENTAL DM-conversation report (resource-visibility §14.3): fan a
-   *  kind:'im' row (default Off) across the bot's gated installs. Fire-and-forget. */
+  /** Apply an incremental direct-conversation report (resource-visibility §14.3):
+   *  fan a visibility-defaulted row across the bot's installs. Fire-and-forget. */
   onBotConversation: (m: RcBotConversation) => Promise<void>
   /** Record a DELIVERED §14.3 DM gating notice and re-stamp the pool's latch.
    *  Fire-and-forget. */

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -277,7 +277,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(dto!.channels.find((c) => c.channelId === 'D1')).toMatchObject({ kind: 'im' })
   })
 
-  it('stores a public DM as On, then closes it when the agent becomes restricted (§14.3)', async () => {
+  it('stores a public DM as On, then atomically closes it when the agent becomes restricted (§14.3)', async () => {
     await seedDaemon(prisma, DAEMON)
     const spy = new SpyControl()
     running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -277,11 +277,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(dto!.channels.find((c) => c.channelId === 'D1')).toMatchObject({ kind: 'im' })
   })
 
-  it('stores a DM discovered while the agent is public as OFF, so a later gate stays closed (§14.3)', async () => {
-    // Observed-conversation discovery reports DMs whatever the agent's visibility, and
-    // visibility can flip later — at which point gatedBindRules enables every non-Off IM
-    // row. A DM stored with the ordinary 'mention' default would therefore keep being
-    // answered by a now-private agent that no operator ever enabled it for.
+  it('stores a public DM as On, then closes it when the agent becomes restricted (§14.3)', async () => {
     await seedDaemon(prisma, DAEMON)
     const spy = new SpyControl()
     running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
@@ -296,7 +292,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     const [dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
     const byId = new Map(dto!.channels.map((c) => [c.channelId, c]))
-    expect(byId.get('D1')).toMatchObject({ kind: 'im', trigger: 'off' })
+    expect(byId.get('D1')).toMatchObject({ kind: 'im', trigger: 'any' })
     expect(byId.get('C1')).toMatchObject({ kind: 'channel', trigger: 'mention' })
 
     spy.upserts.length = 0
@@ -311,12 +307,17 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(u0.core!.gated).toBe(true)
     // No dm rule for D1: the private agent answers that DM only once enabled.
     expect(u0.core!.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
+    expect(
+      (await new PgIntegrationChannelRepo(prisma).listForIntegration(IntegrationId(id))).find(
+        (c) => c.channelId === 'D1'
+      )
+    ).toMatchObject({ trigger: 'off' })
   })
 
-  it('resets the trigger when a row misclassified as a channel converts to a DM (§14.3)', async () => {
+  it('applies the public On default when a row misclassified as a channel converts to a DM (§14.3)', async () => {
     // Session-history discovery cannot tell a DM from a group, so a DM could already be
     // stored as a channel carrying a channel's trigger. That is not an operator's DM
-    // choice, so the conversion must not inherit it into the gated DM rule set.
+    // choice, so the conversion receives the public DM default instead.
     await seedDaemon(prisma, DAEMON)
     const spy = new SpyControl()
     running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
@@ -324,13 +325,13 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
 
     await report(DAEMON, id, [{ id: 'D1', name: '@alice' }], undefined, undefined, false)
-    await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'D1', 'any')
+    await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'D1', 'off')
     // The daemon now knows it is a DM and re-reports it as one.
     await report(DAEMON, id, [{ id: 'D1', name: '@alice', kind: 'im' }], undefined, undefined, false)
 
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     const [dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
-    expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'D1', kind: 'im', trigger: 'off' })])
+    expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'D1', kind: 'im', trigger: 'any' })])
 
     spy.upserts.length = 0
     await running.app.inject({
@@ -343,11 +344,11 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(u0.core!.bindRules).toEqual([])
   })
 
-  it('stores a group DM OFF and keeps a channel→group-DM conversion fail-closed (§14.3)', async () => {
+  it('defaults a public group DM to Mention and preserves later choices (§14.3)', async () => {
     // Slack classifies a group DM late: an `app_mention` payload carries no
     // channel_type, so the conversation first lands as a channel with a channel's
     // trigger. That is not an operator's choice for this conversation, so resolving it
-    // must reset to Off — and an authoritative channel snapshot (which can never list a
+    // must receive the group-DM default — and an authoritative channel snapshot (which can never list a
     // group DM) must not delete the row.
     await seedDaemon(prisma, DAEMON)
     running = buildHttpApp(prisma)
@@ -362,12 +363,12 @@ describe('integration/channels EVT → integration_channel convergence', () => {
       const [dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
       return new Map(dto!.channels.map((c) => [c.channelId, c]))
     }
-    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'off' })
+    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'mention' })
 
     // An operator enables it; a later authoritative channel snapshot leaves it alone.
-    await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'G1', 'mention')
+    await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'G1', 'any')
     await report(DAEMON, id, [{ id: 'C1', name: 'general' }])
-    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'mention' })
+    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'any' })
 
     // A daemon restart loses the classification cache, so the next app_mention is
     // re-reported as a provisional channel — and the daemon stamps a kind on every
@@ -375,10 +376,10 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     // the existing preservation rule covers. Accepting it would flip the row twice and
     // reset the operator's trigger to Off on every restart.
     await report(DAEMON, id, [{ id: 'G1', name: 'mpim-alice--bob-1', kind: 'channel' }], undefined, undefined, false)
-    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'mention' })
+    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'any' })
     // The daemon's own conversations.info correction lands afterwards and is a no-op.
     await report(DAEMON, id, [{ id: 'G1', name: 'mpim-alice--bob-1', kind: 'mpim' }], undefined, undefined, false)
-    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'mention' })
+    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'any' })
   })
 
   it('an enabled DM row survives a provisional channel re-report too (§14.3)', async () => {
@@ -397,7 +398,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'D1', kind: 'im', trigger: 'any' })])
   })
 
-  it('keeps the DM conversion fail-closed when a kind-less and an IM report OVERLAP (§14.3)', async () => {
+  it('keeps the public DM default deterministic when a kind-less and an IM report OVERLAP (§14.3)', async () => {
     // Channel reports are fire-and-forget and their handlers run concurrently: a daemon
     // start emits a kind-less observed snapshot, and the resolver's later verdict emits
     // the same conversation as a DM. Deciding the conversion from a read taken BEFORE the
@@ -429,7 +430,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     await dmReport
 
     const [row] = await new PgIntegrationChannelRepo(prisma).listForIntegration(IntegrationId(id))
-    expect(row).toMatchObject({ channelId: 'D1', kind: 'im', trigger: 'off' })
+    expect(row).toMatchObject({ channelId: 'D1', kind: 'im', trigger: 'any' })
 
     spy.upserts.length = 0
     await running.app.inject({
@@ -1155,7 +1156,7 @@ describe('DELETE …/channels/:channelId (forget) and POST …/leave (platform)'
     }
   })
 
-  // §14.3 gives each gated install its OWN DM row, so fanning a forget across the bot
+  // §14.3 gives each install its OWN DM row, so fanning a forget across the bot
   // would let an editor of one agent silently drop another agent's direct message.
   it('forgets a DM row on this install only, never across the bot', async () => {
     await seedDaemon(prisma, DAEMON)

--- a/packages/daemon/src/cp/cp-collab-routes.ts
+++ b/packages/daemon/src/cp/cp-collab-routes.ts
@@ -200,14 +200,12 @@ export class CpCollabRoutes {
    *     snapshot lag can therefore transiently reject a genuine wake — the correct
    *     direction for a security boundary, and the caller retries.
    *     ACCEPTED RECALL LOSS (agent-collaboration §2.5 "what the fail-closed branch actually
-   *     covers", §2.7 item 5): a direct-conversation row is only WRITTEN where something
-   *     observed it — Slack's authoritative membership snapshot enumerates
-   *     `public_channel,private_channel` only, and the two paths that DO emit `im`/`mpim`
-   *     (this daemon's `reportGatedConversation` and the CP's shared-bot
-   *     `reportConversation`) both fire only for a GATED integration/install's
-   *     not-yet-enabled conversations — so an ordinary integration's DM has no row and a
-   *     wake asserting it is refused here. Deliberate, and not a regression: the
-   *     `hasMembers(caller, target)` check this replaced refused the identical wake.
+   *     covers", §2.7 item 5): a direct-conversation row is written only after something
+   *     observes it. `reportObservedConversation` and the CP shared-bot
+   *     `reportConversation` now emit rows for every visibility, so an ordinary DM becomes
+   *     known after its first inbound message; a wake that races ahead of observation is
+   *     still refused here. Deliberate, and not a regression: the `hasMembers(caller,
+   *     target)` check this replaced refused the identical wake.
    *
    * (3) UNKNOWN and channel-free (exactly the session-identity platforms: `webchat`,
    *     `dream`, a target-less `hook` session's own platform) — `synthetic`. NOT a reject:

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4256,12 +4256,13 @@ export class Daemon {
       }
       for (const [integrationId, c] of this.connByIntegration) {
         if (c !== conn) continue
-        // Preserve reported DM rows (§14.3): the membership listing carries channels
-        // only, but a gated integration's snapshot also holds DM conversations — a
-        // refresh must not wipe them (the CP protects them too; this keeps the
-        // in-memory snapshot honest for the reconnect re-assert).
-        const ims = (this.channelSnapshots.get(integrationId)?.channels ?? []).filter((x) => x.kind === 'im')
-        const merged = [...channels, ...ims]
+        // Preserve observed direct rows: the membership listing carries channels
+        // only, while 1:1 and group DMs arrive incrementally. A refresh must not wipe
+        // them from the reconnect snapshot.
+        const direct = (this.channelSnapshots.get(integrationId)?.channels ?? []).filter(
+          (x) => x.kind === 'im' || x.kind === 'mpim'
+        )
+        const merged = [...channels, ...direct]
         this.channelSnapshots.set(integrationId, { channels: merged, authoritative: true })
         this.cpClient?.emitIntegrationChannels({ integrationId, channels: merged })
         this.maybeIntroduceOnJoin('slack', integrationId, channels)
@@ -6070,12 +6071,11 @@ export class Daemon {
       return this.routeVerifiedAgentMessage(msg, verified, srcIntegrationIds)
     }
 
-    // §14.3: gated-conversation discovery must precede command interception AND
-    // routing. An Off DM whose first inbound is a command still needs its row; an
-    // explicitly-mentioned Off channel likewise needs a pending row even though no
-    // session will be created. Report-only: the notice remains conditional on the
-    // message actually resolving to no admitted target.
-    this.discoverGatedConversations(msg, srcIntegrationIds ?? [])
+    // Conversation discovery must precede command interception AND routing. A DM
+    // whose first inbound is a command still needs its configurable row; an
+    // explicitly-mentioned Off restricted channel likewise needs a pending row even
+    // though no session will be created. Report-only: the notice remains gated.
+    this.discoverConversations(msg, srcIntegrationIds ?? [])
     const routingRules = this.mergedRulesForSource(srcIntegrationIds)
 
     // In-conversation control commands (`!stop` / `!queue …`) act on the running
@@ -7043,7 +7043,7 @@ export class Daemon {
     // Off-conversation event so provider egress remains daemon-owned. Discover it
     // before the last-hop gate drops it; the notice below then uses the send-only
     // Feishu connection without ever exposing the app secret to the relay.
-    this.discoverGatedConversations(normalized, [msg.integrationId])
+    this.discoverConversations(normalized, [msg.integrationId])
     // Conversation gating (§14) last-hop backstop: the relay arbitrates HTTP-bot
     // routing, but a stale relay route snapshot must not activate a private agent in
     // an Off conversation. Admission = a bindRule scoped to this conversation (the
@@ -15481,30 +15481,26 @@ export class Daemon {
     return conversationAdmitted(integrationRouting(int), msg.channel, msg.parentChannel)
   }
 
-  /**
-   * §14: an explicitly-addressed message (a mention of a gated integration's bot, or
-   * a DM to it) that routed nowhere gets a ONE-TIME per-conversation notice — the
-   * bot must never look silently broken — and the Off conversation is reported to
-   * the CP so the console can offer enabling it. Bot senders are never noticed.
-   */
-  /** §14.3 pending-conversation discovery, report-only: fan an Off DM across every
-   *  gated source integration, and report an Off channel when the message explicitly
-   *  mentions that integration's bot. This runs before commands/routing so discovery
-   *  is independent of which sibling integration ultimately handles the message. */
-  private discoverGatedConversations(msg: NormalizedMessage, srcIntegrationIds: string[]): void {
+  /** Observed-conversation discovery, report-only: surface every human direct
+   *  conversation and every explicitly addressed conversation for each source
+   *  integration. The latter lets Slack resolve an `app_mention` whose payload omits
+   *  whether its `G…` conversation is a group DM. This runs before commands/routing,
+   *  independent of which sibling ultimately handles it. */
+  private discoverConversations(msg: NormalizedMessage, srcIntegrationIds: string[]): void {
     if (msg.sender.isBot || msg.source !== 'user') return
     const isDm = msg.isDm || manifestFor(msg.platform).dmChannelPattern?.test(msg.channel) === true
+    const isDirect = isDm || msg.isGroupDm === true
     for (const integrationId of srcIntegrationIds) {
       const int = this.integrationConfigById(integrationId)
       if (!int || int.platform !== msg.platform) continue
       const routing = integrationRouting(int)
-      if (!routing.gated) continue
-      // Enabled — including a thread of an enabled channel (the rule is scoped to the
-      // enclosing channel, which is what the console offers).
-      if (routing.bindRules.some((r) => r.channel === msg.channel || r.channel === msg.parentChannel)) continue
+      if (isDirect) {
+        this.reportObservedConversation(integrationId, msg, isDm)
+        continue
+      }
       const botUserId = this.botUserIds[integrationId] ?? routing.staticBotUserId ?? ''
-      if (!isDm && (botUserId === '' || !msg.mentionedBots.includes(botUserId))) continue
-      this.reportGatedConversation(integrationId, msg, isDm)
+      if (botUserId === '' || !msg.mentionedBots.includes(botUserId)) continue
+      this.reportObservedConversation(integrationId, msg, false)
     }
   }
 
@@ -15525,7 +15521,6 @@ export class Daemon {
       const botUserId = this.botUserIds[integrationId] ?? routing.staticBotUserId ?? ''
       const addressed = isDm || (botUserId !== '' && msg.mentionedBots.includes(botUserId))
       if (!addressed) continue
-      if (isDm) this.reportGatedConversation(integrationId, msg, true)
       const latch = `${integrationId}:${msg.channel}`
       if (this.gatedNoticesSent.has(latch)) return
       this.gatedNoticesSent.add(latch)
@@ -15546,14 +15541,13 @@ export class Daemon {
     }
   }
 
-  /** §14.3: surface an explicitly-addressed Off conversation as a pending row so
-   *  the console can enable it. This is an observed/incremental report, not a full
-   *  membership snapshot: Telegram cannot enumerate all chats, and the conversation
+  /** Surface an observed conversation as a configurable row. This is an incremental
+   *  report, not a full membership snapshot: Telegram cannot enumerate all chats, and the conversation
    *  deliberately creates no session while Off.
    *
    *  Name resolution is best-effort. Telegram/Discord getChat results land through
    *  refreshObservedChannels; Slack DMs retain the existing profile fallback below. */
-  private reportGatedConversation(integrationId: string, msg: NormalizedMessage, isDm: boolean): void {
+  private reportObservedConversation(integrationId: string, msg: NormalizedMessage, isDm: boolean): void {
     const cached = this.channelSnapshots.get(integrationId)
     const existing = cached?.channels ?? []
     // A channel row is reported as the ENCLOSING channel when the message arrived in a
@@ -15642,7 +15636,7 @@ export class Daemon {
   }
 
   /** Re-assert cached reports after a CP reconnect without upgrading a partial
-   *  observation (including Slack gated-conversation discovery) to a full snapshot. */
+   *  observation (including Slack direct-conversation discovery) to a full snapshot. */
   private replayChannelSnapshots(): void {
     // Keyed by BOTH sources. The snapshots are in memory and the tombstones are on
     // disk, so a restart before the first reconnect leaves an integration with a

--- a/packages/daemon/test/cp/cp-agent-directory.test.ts
+++ b/packages/daemon/test/cp/cp-agent-directory.test.ts
@@ -176,10 +176,9 @@ describe('CpCollabRoutes: org-scoped directory', () => {
     // The over-block guard. A DM or group DM is an ORDINARY channel row wherever one exists —
     // `IntegrationChannel.kind` is `channel | im | mpim` and `channelPlacements` selects with
     // no `kind` filter — so branch 1 covers it and fail-closed does not strand a caller whose
-    // session lives in a recorded DM. (Such a row is only written for a GATED integration's
-    // not-yet-enabled conversations; an ungated integration's DM has none and takes branch 2,
-    // which is what the channel-membership check this replaced did too — §2.7 item 5.) This
-    // case therefore only goes red if that premise breaks, which is exactly what it guards.
+    // session lives in a recorded DM. Every visibility reports the row after observation; a
+    // wake racing ahead of that still takes branch 2. This case therefore only goes red if
+    // the recorded-row premise breaks, which is exactly what it guards.
     const r = new CpCollabRoutes()
     r.replace({
       generation: 1,

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -370,7 +370,7 @@ describe('Daemon in-conversation commands', () => {
     const notice = vi.fn()
     const dispatch = vi.fn(async () => {})
     ;(daemon as any).agents.set('bot-a', {})
-    ;(daemon as any).discoverGatedConversations = discover
+    ;(daemon as any).discoverConversations = discover
     ;(daemon as any).gatedAdmission = () => false
     ;(daemon as any).maybeGatedNotice = notice
     ;(daemon as any).dispatch = dispatch

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -107,7 +107,25 @@ function tg(id: number, over: Partial<NormalizedMessage> = {}): NormalizedMessag
 
 const owner = (daemon: Daemon) => (c: string, t: string) => (daemon as any).sessions.threadOwner(c, t)
 
-describe('gated Telegram conversation discovery', () => {
+describe('Telegram conversation discovery', () => {
+  it('reports a public DM as a configurable direct row', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    await daemon.start()
+    makeTelegramRoutable(daemon)
+    vi.spyOn(daemon as any, 'dispatch').mockResolvedValue('acp')
+    const emitIntegrationChannels = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels, stop: vi.fn().mockResolvedValue(undefined) }
+
+    ;(daemon as any).onInbound(tg(91, { channel: '424242', isDm: true }), ['i-tg'])
+
+    expect(emitIntegrationChannels).toHaveBeenCalledWith({
+      integrationId: 'i-tg',
+      channels: [{ id: '424242', kind: 'im' }],
+      authoritative: false
+    })
+    await daemon.stop()
+  })
+
   it('reports an explicitly mentioned Off group before routing drops the message', async () => {
     const daemon = new Daemon({ root: scaffold() })
     await daemon.start()

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -229,8 +229,8 @@ export type IntegrationRemove = z.infer<typeof IntegrationRemove>
  * One conversation the bot participates in (metadata only — no messages).
  * `kind` distinguishes member channels from direct conversations (resource-
  * visibility.md §14.3): absent = 'channel' for wire compatibility. DM rows
- * (`kind: 'im'`, Slack "D…" ids) are reported only for gated integrations, on
- * first inbound DM; their `name` is the counterpart's display name. Group DMs
+ * (`kind: 'im'`, Slack "D…" ids) are reported for every integration on first
+ * inbound DM; their `name` is the counterpart's display name. Group DMs
  * (`kind: 'mpim'`, Slack multi-person DMs) are reported on observation the same
  * way — never enumerated, because Slack does not list them as bot membership —
  * but they behave like a channel: several humans share the room, so the agent

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -772,10 +772,9 @@ export const RcBotRevokedOk = z.object({
 export type RcBotRevokedOk = z.infer<typeof RcBotRevokedOk>
 
 // R→C EVT (fire-and-forget) — INCREMENTAL conversation report (resource-visibility
-// §14.3): the relay saw an inbound DM to a shared bot that backs ≥1 gated
-// (restricted-visibility) agent and arbitration found no route. The CP fans a
-// `kind:'im'` row (default Off) across the bot's GATED installs so console editors
-// can enable it. Incremental on purpose — unlike `rc/bot-channels` this must never
+// §14.3): the relay saw an inbound direct conversation to a shared bot. The CP fans
+// a per-install row across every member, using each agent's visibility-appropriate
+// default. Incremental on purpose — unlike `rc/bot-channels` this must never
 // carry full-set semantics (DM rows are never dropped by snapshots). Conversation
 // id/name are control metadata; no message content crosses this wire. Loss is
 // self-healing: the counterpart's next DM re-reports.

--- a/packages/protocol/src/platform-manifest.ts
+++ b/packages/protocol/src/platform-manifest.ts
@@ -47,7 +47,7 @@ export interface PlatformManifest {
   readonly membershipEnumeration: MembershipEnumeration
   /** Channel ids syntactically recognizable as DIRECT MESSAGES, for ingress whose
    *  wire event omits the conversation type (Slack `app_mention` may omit
-   *  `channel_type`, but its DM ids are D-prefixed). A PRE-DISPATCH read: gated-
+   *  `channel_type`, but its DM ids are D-prefixed). A PRE-DISPATCH read:
    *  conversation discovery consults it before routing resolves any target.
    *  Absent when the id syntax carries no DM signal — then `msg.isDm` is all
    *  there is. */

--- a/packages/relay/src/agent-msg-router.test.ts
+++ b/packages/relay/src/agent-msg-router.test.ts
@@ -584,9 +584,8 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     // direct conversation is an ORDINARY channel row wherever one exists. `IntegrationChannel
     // .kind` is `channel | im | mpim` and `IntegrationRepo.channelPlacements` selects the
     // channels with NO filter on `kind`, so a recorded DM arrives in this snapshot as a plain
-    // row with its owning agent in it — branch 1, not the fail-closed one. (Only a GATED
-    // integration's not-yet-enabled conversations get such a row; an ungated integration's DM
-    // has none and takes branch 2 — the same answer the membership check this replaced gave.)
+    // row with its owning agent in it — branch 1, not the fail-closed one. Every visibility
+    // reports the row after observation; a wake racing ahead of that still takes branch 2.
     const INT_DM = '00000000-0000-0000-0000-0000000000f3'
     const s = snap()
     s.channels.push(

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -139,11 +139,10 @@ describe('HTTP-bot arbitration (§10)', () => {
       expect(t).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
     })
 
-    it('a conversation-scoped keyword (DM slug) outranks the scoped auto route', () => {
+    it('a public DM slug selects a non-first agent before the scoped auto route', () => {
       const a = assignment()
-      a.gatedAgentIds = [ALICE, BOB]
       a.routes = [
-        // Both gated agents enabled the same DM: one auto + one slug route each.
+        // Both public agents enabled the same DM: one auto + one slug route each.
         { agentId: ALICE, daemonId: D1, integrationId: 'iA', scope: { channel: 'D9' }, match: { kind: 'auto' } },
         {
           agentId: ALICE,
@@ -165,6 +164,15 @@ describe('HTTP-bot arbitration (§10)', () => {
       expect(slugged).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
       const bare = arbitrate(a, msg({ channel: 'D9', isDm: true, text: 'hello' }), empty())
       expect(bare).toEqual({ agentId: ALICE, daemonId: D1, integrationId: 'iA' })
+    })
+
+    it('refuses public DM continuity after that agent loses its scoped route', () => {
+      const a = assignment()
+      a.routes = []
+      a.defaultAgentId = undefined
+      a.defaultDaemonId = undefined
+      const aff = new Map<string, RouteTarget>([['D9/ts1', { agentId: BOB, daemonId: D2, integrationId: 'iB' }]])
+      expect(arbitrate(a, msg({ channel: 'D9', thread: 'ts1', isDm: true, text: 'continue' }), aff)).toBeNull()
     })
 
     it('thread continuity to a NON-gated agent is unaffected by gatedAgentIds on others', () => {

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -177,7 +177,11 @@ export function arbitrate(
   // thread's remembered owner may BE the agent that just spoke.
   const remembered = affinity.get(sessionKeyOf(msg))
   const cont = remembered && remembered.agentId === verifiedAgentAuthor ? undefined : remembered
-  const contGateOk = !cont || !a.gatedAgentIds?.includes(cont.agentId) || scoped.some((r) => r.agentId === cont.agentId)
+  const directControlOk =
+    !cont || (!msg.isDm && msg.isGroupDm !== true) || scoped.some((r) => r.agentId === cont.agentId)
+  const contGateOk =
+    directControlOk &&
+    (!cont || !a.gatedAgentIds?.includes(cont.agentId) || scoped.some((r) => r.agentId === cont.agentId))
   if (cont && contGateOk && a.members.some((m) => m.daemonId === cont.daemonId && m.agentIds.includes(cont.agentId))) {
     if (cont.integrationId) return cont
     const route = a.routes.find((r) => r.agentId === cont.agentId)

--- a/packages/relay/src/collaboration-router.ts
+++ b/packages/relay/src/collaboration-router.ts
@@ -170,15 +170,12 @@ export class CollaborationRouter {
    *     snapshot lag can therefore transiently reject a genuine wake — the correct
    *     direction for a security boundary, and the caller retries.
    *     ACCEPTED RECALL LOSS (agent-collaboration §2.5 "what the fail-closed branch actually
-   *     covers", §2.7 item 5): a direct-conversation row is only WRITTEN where something
-   *     observed it — Slack's authoritative membership snapshot enumerates
-   *     `public_channel,private_channel` only, and the two paths that DO emit `im`/`mpim`
-   *     (the daemon's `reportGatedConversation` and the CP's shared-bot
-   *     `reportConversation`) both fire only for a GATED integration/install's
-   *     not-yet-enabled conversations — so an ordinary integration's DM has no row and a
-   *     wake asserting it is refused here.
-   *     Deliberate, and not a regression: the `hasMembers(caller, target)` check this
-   *     replaced refused the identical wake.
+   *     covers", §2.7 item 5): a direct-conversation row is written only after something
+   *     observes it. The daemon and shared-bot report paths now emit rows for every
+   *     visibility, so an ordinary DM becomes known after its first inbound message; a
+   *     wake that races ahead of observation is still refused here. Deliberate, and not a
+   *     regression: the `hasMembers(caller, target)` check this replaced refused the
+   *     identical wake.
    *
    * (3) UNKNOWN and channel-free (exactly the session-identity platforms: `webchat`, and
    *     — since the S1a fleet gate passed — a `hook`/`dream` session's raw platform on a

--- a/packages/relay/src/platforms/slack/http-ingest.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.ts
@@ -361,7 +361,7 @@ export class SlackHttpIngest {
   private slackBotId = ''
   private channelRefresh?: Promise<void>
   private channelRefreshQueued = false
-  /** users.info label cache for gated-DM counterpart names (null = lookup failed). */
+  /** users.info label cache for DM counterpart names (null = lookup failed). */
   private readonly userNames = new Map<string, string | null>()
 
   constructor(
@@ -397,7 +397,7 @@ export class SlackHttpIngest {
     })
   }
 
-  /** Cached best-effort users.info lookup → "@Display Name" label for a gated-DM
+  /** Cached best-effort users.info lookup → "@Display Name" label for a DM
    *  conversation row. Undefined when the lookup fails (the row lands nameless). */
   async lookupUserName(userId: string): Promise<string | undefined> {
     if (this.userNames.has(userId)) return this.userNames.get(userId) ?? undefined

--- a/packages/relay/src/relay-cp-client.ts
+++ b/packages/relay/src/relay-cp-client.ts
@@ -268,7 +268,7 @@ export class RelayCpClient {
     return true
   }
 
-  /** Emit one incremental gated-DM conversation report (§14.3). Best-effort: a drop
+  /** Emit one incremental direct-conversation report. Best-effort: a drop
    *  self-heals on the counterpart's next DM, so there is no pending-retry queue. */
   emitBotConversation(m: RcBotConversation): boolean {
     if (this.state !== 'READY' || !this.transport) {

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -1052,7 +1052,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     secrets: { botToken: 'xoxb', signingSecret: 'ssecret' },
     botUserId: 'UBOT',
     members: [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID] }],
-    agents: [{ agentId: AGENT_ID, name: 'Agent' }],
+    agents: [{ agentId: AGENT_ID, name: 'Agent', daemonId: DAEMON_ID, integrationId: INTEGRATION_ID }],
     routes: [], // everything gated ⇒ no keyword rung, no default
     gatedAgentIds: [AGENT_ID],
     noticeAuthority: SELF_RELAY
@@ -1202,7 +1202,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     expect(ingest.postText).not.toHaveBeenCalled()
   })
 
-  it('resets the DM-report latch when the gated member set changes (new install needs its row)', async () => {
+  it('resets the DM-report latch when the install set changes (new install needs its row)', async () => {
     const reportBotConversation = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ reportBotConversation }))
     const internals = manager as unknown as ManagerInternals
@@ -1213,23 +1213,32 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     await internals.forward(BOT_ID, dm())
     expect(reportBotConversation).toHaveBeenCalledTimes(1) // latched for this assignment
 
-    // A routes update with a CHANGED gated set (e.g. a newly restricted install)
-    // must invalidate the latch so the next DM fans out the new install's row.
+    const changedAgents = [
+      ...a.agents,
+      {
+        agentId: OTHER_AGENT_ID,
+        name: 'Public',
+        daemonId: OTHER_DAEMON_ID,
+        integrationId: OTHER_INTEGRATION_ID
+      }
+    ]
+    // A routes update with a changed install set invalidates the latch so the next
+    // DM fans out the new install's row, regardless of visibility.
     manager.updateRoutes(BOT_ID, {
       members: a.members,
-      agents: a.agents,
+      agents: changedAgents,
       routes: a.routes,
-      gatedAgentIds: [AGENT_ID, OTHER_AGENT_ID]
+      gatedAgentIds: [AGENT_ID]
     })
     await internals.forward(BOT_ID, dm({ msgId: 'slack:D42:1720000000.000200' }))
     expect(reportBotConversation).toHaveBeenCalledTimes(2)
 
-    // An unchanged gated set keeps the latch.
+    // An unchanged install set keeps the latch.
     manager.updateRoutes(BOT_ID, {
       members: a.members,
-      agents: a.agents,
+      agents: changedAgents,
       routes: a.routes,
-      gatedAgentIds: [AGENT_ID, OTHER_AGENT_ID]
+      gatedAgentIds: []
     })
     await internals.forward(BOT_ID, dm({ msgId: 'slack:D42:1720000000.000300' }))
     expect(reportBotConversation).toHaveBeenCalledTimes(2)
@@ -1464,12 +1473,12 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
 
     await internals.forward(BOT_ID, mention(M1, '1.1'))
     expect(ingest.postText).not.toHaveBeenCalled()
-    // An authority-less (or non-authority) pod still fans out gated-DM rows.
+    // An authority-less (or non-authority) pod still reports direct rows.
     await internals.forward(BOT_ID, dm())
     expect(reportBotConversation).toHaveBeenCalledTimes(1)
   })
 
-  it('does nothing gated-related for a bot with no gated members', async () => {
+  it('reports a public DM even when the bot has no gated members, without a notice', async () => {
     const reportBotConversation = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ reportBotConversation }))
     const internals = manager as unknown as ManagerInternals
@@ -1480,7 +1489,10 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     internals.slackPool.set(BOT_ID, ingest)
 
     await internals.forward(BOT_ID, dm())
-    expect(reportBotConversation).not.toHaveBeenCalled()
+    expect(reportBotConversation).toHaveBeenCalledWith({
+      botId: BOT_ID,
+      conversation: { id: 'D42', name: '@Alice', kind: 'im' }
+    })
     expect(ingest.postText).not.toHaveBeenCalled()
   })
 })

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -86,7 +86,7 @@ export interface RelayIngressManagerDeps {
   /** Report the authoritative HTTP Slack channel-membership snapshot to the CP.
    *  Returns false when the CP link is down so the latest snapshot can be retried. */
   reportBotChannels: (m: RcBotChannels) => boolean
-  /** Report one gated-DM conversation to the CP (§14.3, → `rc/bot-conversation`).
+  /** Report one observed direct conversation to the CP (→ `rc/bot-conversation`).
    *  Best-effort: loss self-heals on the counterpart's next DM. */
   reportBotConversation: (m: RcBotConversation) => boolean
   /** Report one DELIVERED §14.3 DM gating notice (→ `rc/notice-posted`) so the CP
@@ -247,14 +247,15 @@ export class RelayIngressManager {
   /** §14 one-time gating-notice latch (`botId:channel`) on the AUTHORITY pod —
    *  correct because only one pod ever posts (deterministic per-bot authority). */
   private readonly gatedNoticesSent = new Set<string>()
-  /** §14.3 per-conversation DM-report latch (`botId:channel`) — scoped to the
-   *  CURRENT bot assignment: cleared on assign/unassign and whenever the gated
-   *  member set changes, since rows belong to the installs of that moment. */
-  private readonly gatedDmReported = new Set<string>()
+  /** Per-conversation direct-report latch (`botId:channel`) — scoped to the CURRENT
+   *  bot assignment. Rows belong to the installs of that moment. */
+  private readonly observedConversationsReported = new Set<string>()
 
-  private clearGatedDmLatches(botId: string): void {
+  private clearConversationReportLatches(botId: string): void {
     const prefix = `${botId}:`
-    for (const k of [...this.gatedDmReported]) if (k.startsWith(prefix)) this.gatedDmReported.delete(k)
+    for (const k of [...this.observedConversationsReported]) {
+      if (k.startsWith(prefix)) this.observedConversationsReported.delete(k)
+    }
   }
 
   constructor(private readonly deps: RelayIngressManagerDeps) {}
@@ -355,9 +356,9 @@ export class RelayIngressManager {
 
   /** `rc/bot-assign` — (re)load the routing table + (re)build the bot's HTTP ingest. */
   async assign(a: BotAssignment): Promise<void> {
-    // A full (re)assignment can mean new installs / a changed gated set — stale
-    // DM-report latches would starve a later gated install of its pending row.
-    this.clearGatedDmLatches(a.botId)
+    // A full (re)assignment can mean new installs. Stale report latches would starve
+    // a later install of its own configurable direct row.
+    this.clearConversationReportLatches(a.botId)
     this.router.upsert(a)
     // Rebuild the ingest (secrets or transport may have rotated). Idempotent.
     await this.stopIngest(a.botId)
@@ -400,11 +401,12 @@ export class RelayIngressManager {
       | 'noticedDmConversations'
     >
   ): void {
-    // A changed gated member set may require a fresh DM fan-out (§14.3) — e.g. a
-    // newly restricted or newly installed member needs its own pending Off row.
-    const prev = this.router.get(botId)?.gatedAgentIds ?? []
-    const next = patch.gatedAgentIds ?? []
-    if (prev.length !== next.length || !prev.every((id) => next.includes(id))) this.clearGatedDmLatches(botId)
+    // A changed install set needs a fresh fan-out so every member gets the row.
+    const prev = (this.router.get(botId)?.agents ?? []).map((agent) => agent.integrationId ?? agent.agentId).sort()
+    const next = (patch.agents ?? []).map((agent) => agent.integrationId ?? agent.agentId).sort()
+    if (prev.length !== next.length || !prev.every((id, index) => id === next[index])) {
+      this.clearConversationReportLatches(botId)
+    }
     this.router.updateRoutes(botId, patch)
   }
 
@@ -421,7 +423,7 @@ export class RelayIngressManager {
       this.deps.log.warn(`relay-ingress(${botId}): ignoring stale unassign (rev ${credentialRevision} < held ${held})`)
       return
     }
-    this.clearGatedDmLatches(botId)
+    this.clearConversationReportLatches(botId)
     this.slackDemux.forget(botId)
     this.feishuDemux.forget(botId)
     this.router.remove(botId)
@@ -723,16 +725,15 @@ export class RelayIngressManager {
     const sessionKey = sessionKeyOf(msg)
     const assignment = this.router.get(botId)
     const hasGatedMembers = (assignment?.gatedAgentIds?.length ?? 0) > 0
-    // §14.3 DM discovery must NOT depend on the arbitration outcome: on a
-    // mixed-visibility bot the public default agent wins every unslugged DM, yet
-    // the gated installs still need their pending Off row to ever be enableable.
+    // Direct-conversation discovery must NOT depend on arbitration: every install
+    // needs its own visible trigger row, whether the message routes or not.
     // A group DM is discovered the same way — Slack never lists one as membership, so
     // an unreported one could never be enabled. It is only ever *addressed* by mention,
     // so unlike a DM it is reported only when it names THIS bot: `mentionedBots` also
     // holds the humans and other apps named in the same message.
     const namesThisBot = assignment?.botUserId !== undefined && msg.mentionedBots.includes(assignment.botUserId)
     const addressesBot = msg.isDm || (msg.isGroupDm === true && namesThisBot)
-    if (addressesBot && !msg.sender.isBot && hasGatedMembers) await this.reportGatedConversation(botId, msg)
+    if (addressesBot && !msg.sender.isBot) await this.reportObservedConversation(botId, msg)
     const prior = this.router.peekAffinity(botId, sessionKey)
     let tgt = this.router.route(botId, msg)
     if (tgt) {
@@ -748,8 +749,8 @@ export class RelayIngressManager {
       // Conversation gating (resource-visibility §14.3): an explicitly-addressed
       // message (DM, or @bot mention) that arbitration could not place, on a bot
       // that backs ≥1 gated agent, must not look silently dead — answer once per
-      // conversation (the DM row itself was already reported above, un-gated on
-      // the routing outcome).
+      // conversation (the DM row itself was already reported above, independently
+      // of the routing outcome).
       //
       // Every Off channel arrives here unroutable, and the two kinds answer
       // differently. A channel an OPERATOR silenced says nothing: they already
@@ -824,17 +825,17 @@ export class RelayIngressManager {
   }
 
   /**
-   * §14.3: surface one human direct conversation to the CP as an incremental
-   * `kind:'im'` / `kind:'mpim'` report (fanned to gated installs as pending Off rows —
-   * the console enablement path). Fires for EVERY human DM on a bot with gated members,
-   * routed or not, and for an addressed group DM; latched per conversation per relay
+   * Surface one human direct conversation to the CP as an incremental
+   * `kind:'im'` / `kind:'mpim'` report, fanned to every install with its visibility-
+   * appropriate default. Fires for every human DM, routed or not, and for an addressed
+   * group DM; latched per conversation per relay
    * lifetime (the CP upsert is idempotent, this only bounds chatter — a relay restart
    * re-reports harmlessly). Channel rows need no report here — membership snapshots
    * already carry them, and neither of these kinds appears in one.
    */
-  private async reportGatedConversation(botId: string, msg: WireNormalizedMessage): Promise<void> {
+  private async reportObservedConversation(botId: string, msg: WireNormalizedMessage): Promise<void> {
     const latch = `${botId}:${msg.channel}`
-    if (this.gatedDmReported.has(latch)) return
+    if (this.observedConversationsReported.has(latch)) return
     // A group DM's counterpart is the room, not the sender, so it carries no name here.
     const name = msg.isDm ? await this.ingestFor(botId)?.egress?.lookupUserName(msg.sender.id) : undefined
     const sent = this.deps.reportBotConversation({
@@ -842,7 +843,7 @@ export class RelayIngressManager {
       conversation: { id: msg.channel, ...(name ? { name } : {}), kind: msg.isDm ? 'im' : 'mpim' }
     })
     // Latch only a delivered report — a CP-link-down drop retries on the next DM.
-    if (sent) this.gatedDmReported.add(latch)
+    if (sent) this.observedConversationsReported.add(latch)
   }
 
   /** §14.3: the ONE-TIME per-conversation notice for an explicitly-addressed,

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -1,6 +1,27 @@
-import { describe, expect, it } from 'vitest'
-import { channelOwners, groupBySpace, placePopover, rowLabel, rowMenuAction } from './IntegrationChannelList'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  channelOwners,
+  groupBySpace,
+  IntegrationChannelList,
+  placePopover,
+  rowLabel,
+  rowMenuAction
+} from './IntegrationChannelList'
 import type { IntegrationChannelRow, IntegrationRow } from '@/lib/data'
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    setChannelTrigger: vi.fn(),
+    setChannelAgent: vi.fn(),
+    forgetChannel: vi.fn(),
+    leaveConversation: vi.fn(),
+    bots: [],
+    agents: [],
+    integrations: []
+  })
+}))
 
 // A shared bot fans its membership snapshot out to one integration per member
 // agent, but persists the per-channel owner on a single canonical row. Every
@@ -213,5 +234,20 @@ describe('rowLabel', () => {
     expect(rowLabel({ kind: 'im', name: '@Alice' })).toBe('Alice')
     expect(rowLabel({ kind: 'mpim', name: '@Alice, Bob' })).toBe('Alice, Bob')
     expect(rowLabel({ kind: 'channel', name: 'deploys' })).toBe('deploys')
+  })
+})
+
+describe('IntegrationChannelList direct rows', () => {
+  it('renders an Everyone DM with its Off/On control', () => {
+    const html = renderToStaticMarkup(
+      createElement(IntegrationChannelList, {
+        platform: 'discord',
+        gated: false,
+        channels: [{ channelId: 'D1', name: '@Alice', kind: 'im', trigger: 'any' }]
+      })
+    )
+    expect(html).toContain('Direct messages')
+    expect(html).toContain('>off</button>')
+    expect(html).toContain('>on</button>')
   })
 })

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -10,9 +10,8 @@ import type { AgentIcon } from '@/lib/agent-icon'
 
 /** The per-conversation trigger toggle: a ⚡ marker followed by the segmented
  *  bar. Channels: "off" / "any message" / "@-mention" (the default, so it sits
- *  last). DM rows are binary off/on, and only a gated (restricted-agent)
- *  integration has any — resource-visibility.md §14. Every segment carries
- *  hover copy. */
+ *  last). DM rows are binary off/on for every agent — resource-visibility.md
+ *  §14. Every segment carries hover copy. */
 function TriggerToggle({
   channel,
   platform,
@@ -584,7 +583,7 @@ function DefaultAgentPicker({
 
 /**
  * The conversation rows of one integration — one row per channel the bot is in
- * (plus, on a gated/restricted agent, one row per reported DM conversation), each
+ * (plus one row per reported direct conversation), each
  * with its trigger toggle (and, for a SHARED bot, the per-channel default-dispatch
  * popover ahead of it), closed by the "invite the bot" hint. Render inside a
  * padding-less card whose header row sits above. Demo rows (no `integrationId`)
@@ -612,7 +611,7 @@ export function IntegrationChannelList({
   /** When true (shared bot), show the per-channel default-agent picker. */
   shareable?: boolean
   /** Restricted-agent integration (resource-visibility.md §14): conversations are
-   *  gated — new ones start off, DM rows appear, the banner explains the gate. */
+   *  gated — new ones start off and the banner explains the gate. */
   gated?: boolean
   /** Horizontal row padding, to line up with the host card (18 list / 14 detail). */
   padX?: number
@@ -649,12 +648,9 @@ export function IntegrationChannelList({
     return (explicit ? members.find((m) => m.id === explicit) : undefined) ?? members[0]
   }
   const channelRows = channels.filter((c) => !isDirectConversation(c.kind))
-  // A direct conversation is not a place the bot can be invited to and has no
-  // per-conversation choice to make unless the agent is gated (resource-visibility.md
-  // §14.3) — a non-gated bot always answers its DMs, and answers a group DM whenever
-  // it is @-mentioned. The daemon still REPORTS them (that is how a conversation
-  // previously mistaken for a channel converts), so hide them here, not at the source.
-  const dmRows = gated ? channels.filter((c) => isDirectConversation(c.kind)) : []
+  // Direct conversations are independently configurable for every agent. A 1:1 DM
+  // gets the binary Off/On control above; a group DM keeps the channel-style trigger.
+  const dmRows = channels.filter((c) => isDirectConversation(c.kind))
   const grouped = groupBySpace(channelRows)
   /**
    * Leaving, for a platform that has no per-conversation membership to leave. A
@@ -784,7 +780,7 @@ export function IntegrationChannelList({
               menu's own items: those explain themselves on screen, and repeating them
               here in different words was most of what made this card read oddly. */}
           {`A ${roomNoun(platform)} appears here once the bot is added to it, and its trigger is set per ${roomNoun(platform)}.`}
-          {gated && ' Direct messages appear when someone writes to the bot.'}
+          {' Direct messages appear when someone writes to the bot.'}
           {shareable && ' Default dispatch is the agent who handles unmatched messages.'}
           {platform === 'discord' && ' A Discord bot joins servers, not channels, so it can only leave a whole server.'}
           {platform === 'slack' && ' To remove the bot from a channel, do it in Slack — this list updates by itself.'}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -772,8 +772,8 @@ export interface SlackConfigInput {
 export type ChannelTrigger = 'off' | 'mention' | 'any'
 
 // One conversation the integration's bot is in (daemon-reported) + its trigger
-// choice. kind 'im' rows are DM conversations and 'mpim' rows are Slack group DMs
-// (both gated/restricted agents only — neither is enumerable).
+// choice. kind 'im' rows are DM conversations and 'mpim' rows are Slack group DMs;
+// both are observed rather than enumerable and appear for every agent visibility.
 export interface IntegrationChannelDto {
   channelId: string
   name: string | null // "deploys" without the hash (or DM counterpart); null if lookup failed

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -1195,7 +1195,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     [mutateSkillSources]
   )
 
-  // Flip one conversation's trigger. Shared channels project bot-wide; gated DMs
+  // Flip one conversation's trigger. Shared channels project bot-wide; direct rows
   // remain integration-scoped. Avoid a full re-pull so the toggle does not flash.
   const setChannelTrigger = useCallback(
     async (integrationId: string, channelId: string, trigger: ChannelTrigger) => {

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1684,8 +1684,7 @@ export interface IntegrationChannelRow {
    *  implicit container per bot, on DM rows, and until the daemon resolves them. */
   spaceId?: string
   space?: string
-  /** 'im' = a DM conversation row, 'mpim' = a Slack group DM (both gated/restricted
-   *  agents only); absent = channel. */
+  /** 'im' = a DM conversation row, 'mpim' = a Slack group DM; absent = channel. */
   kind?: 'channel' | 'im' | 'mpim'
   trigger: 'off' | 'mention' | 'any'
   /** Effective per-channel owner for a shared bot. */


### PR DESCRIPTION
## Summary

- Show observed 1:1 and group direct-message rows on Integration cards for both Everyone and Restricted agents across direct and relay-backed chat integrations.
- Make 1:1 DM Off/On effective in routing; keep group DMs on Off/Any message/@-mention controls.
- Default newly observed Everyone DMs to On and group DMs to @-mention, while Restricted direct conversations remain Off until enabled.
- Close every known direct row before an agent switches to Restricted, and make daemon/relay affinity respect later Off changes.
- Backfill previously hidden Everyone direct rows with the new defaults.

## Root cause

Everyone integrations relied on unscoped DM defaults while their observed direct rows were hidden and compiled as inert. That left no visible or enforceable per-DM control. Shared-bot discovery also reported direct rows only when at least one Restricted install existed.

## Database impact

There is no table, column, enum, or Prisma model change. The migration is data-only: it updates existing org-visible direct rows from their former forced Off value to the new visible defaults (1:1 DM On, group DM @-mention).

## Validation

- `pnpm lint`
- `pnpm format:check`
- protocol, message, and connection builds
- control-plane, daemon, relay, and web typechecks
- Control Plane focused unit tests: 63 passed
- Control Plane Postgres integration tests: 33 passed
- Relay tests: 403 passed
- Web tests: 717 passed
- affected Daemon tests (single worker): 143 passed

Created by Codex . GPT-5.6 Sol
