### PR TITLE
feat(relay): ingest pools + demux index store (S3 §8 registry)

### DIFF
--- a/packages/relay/src/platforms/registry.test.ts
+++ b/packages/relay/src/platforms/registry.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { DemuxIndex } from './registry.js'
+
+/** The load-bearing invariant is tenant isolation: every install of a
+ *  distributed app shares one app id AND one signing secret, so an app-only
+ *  entry for a tenant-scoped bot would serve every sibling workspace's events
+ *  to this one bot. These pin each rule that upholds it. */
+describe('DemuxIndex', () => {
+  it('a tenant-scoped assignment enters ONLY the composite index', () => {
+    const idx = new DemuxIndex()
+    idx.indexAssign('bot-1', { appId: 'A1', tenantId: 'T1' })
+    expect(idx.resolve({ appId: 'A1', tenantId: 'T1' })).toBe('bot-1')
+    // The app-only path must MISS — a sibling install's events carry the same
+    // app id with a different tenant.
+    expect(idx.resolve({ appId: 'A1' })).toBeUndefined()
+    expect(idx.resolve({ appId: 'A1', tenantId: 'T2' })).toBeUndefined()
+  })
+
+  it('an app-only assignment resolves on the app index', () => {
+    const idx = new DemuxIndex()
+    idx.indexAssign('bot-2', { appId: 'A2' })
+    expect(idx.resolve({ appId: 'A2' })).toBe('bot-2')
+    // Composite lookups fall through to the app index for legacy bots.
+    expect(idx.resolve({ appId: 'A2', tenantId: 'T9' })).toBe('bot-2')
+  })
+
+  it('gaining a tenant id evicts the stale app-only entry for the same bot', () => {
+    const idx = new DemuxIndex()
+    idx.indexAssign('bot-3', { appId: 'A3' })
+    idx.indexAssign('bot-3', { appId: 'A3', tenantId: 'T3' })
+    // The fast path must not keep serving cross-tenant through the stale entry.
+    expect(idx.resolve({ appId: 'A3' })).toBeUndefined()
+    expect(idx.resolve({ appId: 'A3', tenantId: 'T3' })).toBe('bot-3')
+  })
+
+  it('refuses to LEARN an app-only mapping for a tenant-scoped bot', () => {
+    const idx = new DemuxIndex()
+    idx.indexAssign('bot-4', { appId: 'A4', tenantId: 'T4' })
+    // A learning call site that did not re-check must not be able to break the
+    // tenant invariant.
+    idx.learn('A4', 'bot-4')
+    expect(idx.resolve({ appId: 'A4' })).toBeUndefined()
+  })
+
+  it('learns app-only mappings for legacy bots and forgets on unassign', () => {
+    const idx = new DemuxIndex()
+    idx.learn('A5', 'bot-5')
+    expect(idx.resolve({ appId: 'A5' })).toBe('bot-5')
+    idx.forget('bot-5')
+    expect(idx.resolve({ appId: 'A5' })).toBeUndefined()
+  })
+
+  it('forget cleans the composite entry eagerly', () => {
+    const idx = new DemuxIndex()
+    idx.indexAssign('bot-6', { appId: 'A6', tenantId: 'T6' })
+    idx.forget('bot-6')
+    expect(idx.resolve({ appId: 'A6', tenantId: 'T6' })).toBeUndefined()
+    expect(idx.indexes.byAppTenant.size).toBe(0)
+  })
+})

--- a/packages/relay/src/platforms/registry.ts
+++ b/packages/relay/src/platforms/registry.ts
@@ -1,0 +1,126 @@
+/**
+ * The relay's **per-platform ingest pools + demux index store** (§8, stage S3)
+ * — the S2 registry precedent (#526) applied to the relay: a platform states
+ * how its bots are keyed and built ONCE (the plugin), and the shared lifecycle
+ * only ever works pools and indexes it cannot parse.
+ *
+ * WHAT THIS ABSORBS. Today's manager holds two platform-named instance maps
+ * (`ingests` / `feishuIngests`) and three platform-named identity maps
+ * (`feishuBotByAppId`/`feishuAppIdByBot`, plus the Slack `demuxByApiApp` /
+ * `demuxByAppTeam`/`appTeamKeyByBot` trio). The pool replaces the instance
+ * maps; the {@link DemuxIndex} replaces the identity maps with ONE structure
+ * whose per-assignment scope is derived from the ingress identity (§5, as
+ * amended by #560): a tenant-scoped assignment enters ONLY the composite
+ * index (assign-derived, never learned, eagerly cleaned), an app-only
+ * assignment enters the app index — which may also be LEARNED from a verified
+ * delivery (bounded, lazily evicted), because a legacy bot's CP row may not
+ * carry the app id at all.
+ */
+import type { RelayBotIngress } from './contract.js'
+
+/** One platform's pool of live per-bot ingests. Purely keyed by botId — the
+ *  identity questions live in {@link DemuxIndex}, not here. */
+export class IngressPool<TIngest extends RelayBotIngress> {
+  private readonly live = new Map<string, TIngest>()
+
+  /** @param name Diagnostic label ("slack", "feishu"). Never parsed. */
+  constructor(readonly name: string) {}
+
+  get(botId: string): TIngest | undefined {
+    return this.live.get(botId)
+  }
+
+  set(botId: string, ingest: TIngest): void {
+    this.live.set(botId, ingest)
+  }
+
+  delete(botId: string): void {
+    this.live.delete(botId)
+  }
+
+  entries(): IterableIterator<[string, TIngest]> {
+    return this.live.entries()
+  }
+
+  values(): IterableIterator<TIngest> {
+    return this.live.values()
+  }
+}
+
+const MAX_LEARNED_ENTRIES = 10_000
+
+/**
+ * The demux identity index for ONE platform's pool: `appId → botId` plus the
+ * composite `(appId, tenantId) → botId`. Core owns the STORAGE and the
+ * eviction rules; what goes where is decided by the assignment's own identity
+ * shape, so no caller branches on platform:
+ *
+ *  - `indexAssign` with a tenantId ⇒ composite only. A same-app sibling
+ *    install shares the signing secret, so an app-only entry would serve every
+ *    sibling's events to this one bot.
+ *  - `indexAssign` with only an appId ⇒ the app index (assign-derived).
+ *  - `learn` ⇒ the app index, bounded — and REFUSED for any bot the composite
+ *    index knows, preserving the tenant-scope invariant against a learning
+ *    call site that did not re-check.
+ */
+export class DemuxIndex {
+  private readonly byApp = new Map<string, string>()
+  private readonly byAppTenant = new Map<string, string>()
+  private readonly compositeKeyByBot = new Map<string, string>()
+
+  private key(appId: string, tenantId: string): string {
+    return `${appId}\0${tenantId}`
+  }
+
+  /** Index one assignment's declared identity (idempotent; call after
+   *  {@link forget} on re-assign). */
+  indexAssign(botId: string, identity: { appId?: string; tenantId?: string }): void {
+    const { appId, tenantId } = identity
+    if (appId && tenantId) {
+      const key = this.key(appId, tenantId)
+      this.byAppTenant.set(key, botId)
+      this.compositeKeyByBot.set(botId, key)
+      // A re-assign that GAINED a tenant id must also evict any stale app-only
+      // entry still pointing at this bot, or the fast path would keep serving
+      // cross-tenant.
+      if (this.byApp.get(appId) === botId) this.byApp.delete(appId)
+      return
+    }
+    if (appId) this.byApp.set(appId, botId)
+  }
+
+  /** Learn an app-only mapping from a verified delivery. Bounded; refused for
+   *  tenant-scoped bots (see the class doc). */
+  learn(appId: string, botId: string): void {
+    if (this.compositeKeyByBot.has(botId)) return
+    if (this.byApp.size >= MAX_LEARNED_ENTRIES) this.byApp.clear()
+    this.byApp.set(appId, botId)
+  }
+
+  /** Resolve demux hints to a candidate botId: composite first (exact), then
+   *  the app index. A hit is a CANDIDATE — the plugin's verify still decides. */
+  resolve(hints: { appId?: string; tenantId?: string }): string | undefined {
+    if (hints.appId && hints.tenantId) {
+      const hit = this.byAppTenant.get(this.key(hints.appId, hints.tenantId))
+      if (hit) return hit
+    }
+    return hints.appId ? this.byApp.get(hints.appId) : undefined
+  }
+
+  /** Drop everything indexed for `botId` (unassign/revoke/re-assign). The
+   *  composite entry is assign-derived and eagerly cleaned; learned app-only
+   *  entries for OTHER bots lazily miss, exactly as before. */
+  forget(botId: string): void {
+    const key = this.compositeKeyByBot.get(botId)
+    if (key) {
+      this.byAppTenant.delete(key)
+      this.compositeKeyByBot.delete(botId)
+    }
+    for (const [appId, owner] of this.byApp) if (owner === botId) this.byApp.delete(appId)
+  }
+
+  /** Test/inspection view (no secret material). */
+  get indexes(): { byApp: ReadonlyMap<string, string>; byAppTenant: ReadonlyMap<string, string> } {
+    return { byApp: this.byApp, byAppTenant: this.byAppTenant }
+  }
+}


### PR DESCRIPTION
Second S3-relay PR — the S2 registry precedent (#526) applied to the relay, shipped standalone before the manager rewires through it (same sequencing as the daemon pools).

## `IngressPool`

One pool of per-bot ingest instances per platform, keyed by `botId` alone — replacing the two platform-named instance maps (`ingests` / `feishuIngests`) once the manager rewires. Identity questions live in the index, not the pool.

## `DemuxIndex`

**One** identity structure replacing the three platform-named identity maps (`feishuBotByAppId`/`feishuAppIdByBot` + `demuxByApiApp`/`demuxByAppTeam`/`appTeamKeyByBot`). Where an identity goes is decided by the **assignment's own shape** (#560's per-assignment scope), so no caller branches on platform:

| assignment shape | index | rules |
| --- | --- | --- |
| `appId + tenantId` | composite only | assign-derived, never learned, eagerly cleaned — an app-only entry would serve every same-app sibling install's events to this one bot |
| `appId` only | app index | may also be **learned** from a verified delivery (bounded) — a legacy bot's CP row may not carry the app id at all |

`learn()` **refuses** tenant-scoped bots outright, so a learning call site that did not re-check cannot break the tenant invariant. Gaining a tenant id on re-assign evicts the stale app-only entry (the cross-tenant fast-path hazard the manager comments today).

## Verification

- relay suite **409 passed** (+6): composite-only resolution, legacy fall-through, stale-entry eviction, the learn refusal, learn/forget lifecycle, eager composite cleanup
- Pure structures; the manager still runs on its existing maps — the rewiring PR follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)