### PR TITLE
refactor(relay): manager runs on the §8 pools + demux index (S3)

### DIFF
--- a/packages/relay/src/feishu-http-ingest.ts
+++ b/packages/relay/src/feishu-http-ingest.ts
@@ -93,6 +93,9 @@ export class FeishuHttpIngest {
     private readonly deps: FeishuHttpIngestDeps
   ) {}
 
+  /** §8 RelayBotIngress: a Feishu ingest is a pure decoder — nothing to release. */
+  stop(): void {}
+
   decode(rawBody: Buffer, outerBody: unknown, headers: FeishuCallbackHeaders): VerifiedFeishuCallback | null {
     const outer = asRecord(outerBody)
     if (!outer) return null

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -81,13 +81,15 @@ const action = (over: Partial<HttpSlackSessionAction> = {}): HttpSlackSessionAct
 
 interface ManagerInternals {
   router: BotArbitrationRouter
-  ingests: Map<
-    string,
-    {
-      lookupUserName(u: string): Promise<string | undefined>
-      postText(c: string, t: string, th?: string): Promise<void>
-    }
-  >
+  slackPool: {
+    set(
+      botId: string,
+      ingest: {
+        lookupUserName(u: string): Promise<string | undefined>
+        postText(c: string, t: string, th?: string): Promise<void>
+      }
+    ): void
+  }
   reportChannels(snapshot: RcBotChannels): void
   reportRevoked(m: { botId: string; reason: 'app_uninstalled' | 'tokens_revoked'; credentialRevision?: number }): void
   selectThreadAgent(botId: string, channelId: string, threadTs: string, agentId: string): void
@@ -962,7 +964,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(gatedAssignment())
     const ingest = fakeIngest()
-    internals.ingests.set(BOT_ID, ingest)
+    internals.slackPool.set(BOT_ID, ingest)
 
     await internals.forward(BOT_ID, dm())
     expect(reportBotConversation).toHaveBeenCalledWith({
@@ -983,7 +985,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(gatedAssignment()) // noticeAuthority = SELF_RELAY, not this pod
     const ingest = fakeIngest()
-    internals.ingests.set(BOT_ID, ingest)
+    internals.slackPool.set(BOT_ID, ingest)
 
     await internals.forward(BOT_ID, dm())
     expect(ingest.postText).toHaveBeenCalledTimes(1)
@@ -996,7 +998,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     a.noticedDmConversations = ['D42'] // delivery reported + re-stamped by the CP
     internals.router.upsert(a)
     const ingest = fakeIngest()
-    internals.ingests.set(BOT_ID, ingest)
+    internals.slackPool.set(BOT_ID, ingest)
 
     await internals.forward(BOT_ID, dm())
     expect(ingest.postText).not.toHaveBeenCalled()
@@ -1031,7 +1033,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     a.defaultDaemonId = OTHER_DAEMON_ID
     internals.router.upsert(a)
     const ingest = fakeIngest()
-    internals.ingests.set(BOT_ID, ingest)
+    internals.slackPool.set(BOT_ID, ingest)
 
     // DM 1 routes to the public default: row discovery happens, NO notice.
     await internals.forward(BOT_ID, dm())
@@ -1076,7 +1078,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     a.defaultDaemonId = OTHER_DAEMON_ID
     internals.router.upsert(a)
     const ingest = fakeIngest()
-    internals.ingests.set(BOT_ID, ingest)
+    internals.slackPool.set(BOT_ID, ingest)
 
     await internals.forward(BOT_ID, dm())
     // The DM routed to the public default — the gated install still needs its
@@ -1094,7 +1096,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     const internals = manager as unknown as ManagerInternals
     const a = gatedAssignment()
     internals.router.upsert(a)
-    internals.ingests.set(BOT_ID, fakeIngest())
+    internals.slackPool.set(BOT_ID, fakeIngest())
 
     await internals.forward(BOT_ID, dm())
     expect(reportBotConversation).toHaveBeenCalledTimes(1) // latched for this assignment
@@ -1127,7 +1129,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     const manager = new RelayIngressManager(deps({ reportBotConversation }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(gatedAssignment())
-    internals.ingests.set(BOT_ID, fakeIngest())
+    internals.slackPool.set(BOT_ID, fakeIngest())
 
     await internals.forward(BOT_ID, dm())
     expect(reportBotConversation).toHaveBeenCalledTimes(1) // dropped — not latched
@@ -1144,7 +1146,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(gatedAssignment())
     const ingest = fakeIngest()
-    internals.ingests.set(BOT_ID, ingest)
+    internals.slackPool.set(BOT_ID, ingest)
 
     await internals.forward(
       BOT_ID,
@@ -1226,7 +1228,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     const internals = manager as unknown as ManagerInternals
     const ingest = fakeIngest()
     internals.router.upsert(gatedAssignment()) // noticeAuthority = SELF_RELAY
-    internals.ingests.set(BOT_ID, ingest)
+    internals.slackPool.set(BOT_ID, ingest)
     return { internals, ingest }
   }
   const mention = (msgId: string, thread: string) =>
@@ -1298,7 +1300,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, selfRelayId: () => SELF_RELAY }))
     const internals = manager as unknown as ManagerInternals
     const ingest = fakeIngest()
-    internals.ingests.set(BOT_ID, ingest)
+    internals.slackPool.set(BOT_ID, ingest)
     internals.router.upsert({
       ...gatedAssignment(),
       agents: [
@@ -1346,7 +1348,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     delete a.noticeAuthority
     internals.router.upsert(a)
     const ingest = fakeIngest()
-    internals.ingests.set(BOT_ID, ingest)
+    internals.slackPool.set(BOT_ID, ingest)
 
     await internals.forward(BOT_ID, mention(M1, '1.1'))
     expect(ingest.postText).not.toHaveBeenCalled()
@@ -1363,7 +1365,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     a.gatedAgentIds = []
     internals.router.upsert(a)
     const ingest = fakeIngest()
-    internals.ingests.set(BOT_ID, ingest)
+    internals.slackPool.set(BOT_ID, ingest)
 
     await internals.forward(BOT_ID, dm())
     expect(reportBotConversation).not.toHaveBeenCalled()
@@ -1390,10 +1392,12 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
 
   interface DemuxInternals {
     router: BotArbitrationRouter
-    ingests: Map<string, { signingSecret: string; stop(): Promise<void> }>
-    demuxByApiApp: Map<string, string>
-    demuxByAppTeam: Map<string, string>
-    appTeamKeyByBot: Map<string, string>
+    slackPool: {
+      set(botId: string, ingest: { signingSecret: string; stop(): Promise<void> }): void
+      get(botId: string): { signingSecret: string } | undefined
+    }
+    feishuPool: { get(botId: string): unknown }
+    slackDemux: import('./platforms/registry.js').DemuxIndex
   }
 
   /** Register a bot the way `assign()` would, minus the network-touching ingest
@@ -1406,7 +1410,7 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     opts: { apiAppId?: string; teamId?: string; indexed?: boolean } = {}
   ) => {
     const internals = manager as unknown as DemuxInternals
-    internals.ingests.set(botId, { signingSecret, stop: async () => {} })
+    internals.slackPool.set(botId, { signingSecret, stop: async () => {} })
     internals.router.upsert({
       ...assignment(),
       botId,
@@ -1415,10 +1419,9 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
       ...(opts.teamId ? { teamId: opts.teamId } : {})
     })
     if (opts.apiAppId && opts.teamId && opts.indexed !== false) {
-      internals.demuxByAppTeam.set(`${opts.apiAppId}\u0000${opts.teamId}`, botId)
-      internals.appTeamKeyByBot.set(botId, `${opts.apiAppId}\u0000${opts.teamId}`)
+      internals.slackDemux.indexAssign(botId, { appId: opts.apiAppId, tenantId: opts.teamId })
     }
-    if (opts.apiAppId && !opts.teamId) internals.demuxByApiApp.set(opts.apiAppId, botId)
+    if (opts.apiAppId && !opts.teamId) internals.slackDemux.indexAssign(botId, { appId: opts.apiAppId })
   }
 
   const resolve = (manager: RelayIngressManager, over: { apiAppId?: string; teamId?: string; secret?: string }) =>
@@ -1436,8 +1439,8 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     addBot(manager, BOT_T2, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T2' })
 
     const internals = manager as unknown as DemuxInternals
-    expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T1' })).toBe(internals.ingests.get(BOT_T1))
-    expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T2' })).toBe(internals.ingests.get(BOT_T2))
+    expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T1' })).toBe(internals.slackPool.get(BOT_T1))
+    expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T2' })).toBe(internals.slackPool.get(BOT_T2))
   })
 
   it('never serves a team-scoped bot to another workspace via the signature scan', () => {
@@ -1449,9 +1452,9 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     addBot(manager, BOT_T2, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T2', indexed: false })
 
     const internals = manager as unknown as DemuxInternals
-    expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T2' })).toBe(internals.ingests.get(BOT_T2))
+    expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T2' })).toBe(internals.slackPool.get(BOT_T2))
     // The scan hit must not poison the app-only learned map for a team-scoped bot.
-    expect(internals.demuxByApiApp.has(PLATFORM_APP)).toBe(false)
+    expect(internals.slackDemux.indexes.byApp.has(PLATFORM_APP)).toBe(false)
   })
 
   it('fails closed when a distributed-app envelope carries no team id', () => {
@@ -1468,12 +1471,12 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     addBot(manager, BOT_LEGACY, 'legacy-secret', {}) // no app id stamped — scan learns it
 
     const internals = manager as unknown as DemuxInternals
-    expect(resolve(manager, { apiAppId: 'ALEGACY', secret: 'legacy-secret' })).toBe(internals.ingests.get(BOT_LEGACY))
-    expect(internals.demuxByApiApp.get('ALEGACY')).toBe(BOT_LEGACY)
+    expect(resolve(manager, { apiAppId: 'ALEGACY', secret: 'legacy-secret' })).toBe(internals.slackPool.get(BOT_LEGACY))
+    expect(internals.slackDemux.indexes.byApp.get('ALEGACY')).toBe(BOT_LEGACY)
     // A team-scoped envelope still resolves the legacy bot (guard only skips
     // bots whose ASSIGNMENT carries a different team id).
     expect(resolve(manager, { apiAppId: 'ALEGACY', teamId: 'T9', secret: 'legacy-secret' })).toBe(
-      internals.ingests.get(BOT_LEGACY)
+      internals.slackPool.get(BOT_LEGACY)
     )
   })
 
@@ -1483,7 +1486,7 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
   it('unassign carrying an OLDER generation than the held assignment is ignored', async () => {
     const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     const internals = manager as unknown as DemuxInternals
-    internals.ingests.set(BOT_T1, { signingSecret: SHARED_SECRET, stop: async () => {} })
+    internals.slackPool.set(BOT_T1, { signingSecret: SHARED_SECRET, stop: async () => {} })
     internals.router.upsert({
       ...assignment(),
       botId: BOT_T1,
@@ -1492,19 +1495,19 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
       teamId: 'T1',
       credentialRevision: 2 // the re-install's assign already landed here
     })
-    internals.demuxByAppTeam.set(`${PLATFORM_APP}\u0000T1`, BOT_T1)
+    internals.slackDemux.indexAssign(BOT_T1, { appId: PLATFORM_APP, tenantId: 'T1' })
 
     await manager.unassign(BOT_T1, 1) // the revoke of the REPLACED credential
 
     // Still serving: routing table, ingest, and demux index all intact.
     expect(internals.router.get(BOT_T1)).toBeDefined()
-    expect(internals.ingests.has(BOT_T1)).toBe(true)
-    expect(internals.demuxByAppTeam.size).toBe(1)
+    expect(internals.slackPool.get(BOT_T1)).toBeDefined()
+    expect(internals.slackDemux.indexes.byAppTenant.size).toBe(1)
 
     // The matching generation still releases it.
     await manager.unassign(BOT_T1, 2)
     expect(internals.router.get(BOT_T1)).toBeUndefined()
-    expect(internals.ingests.has(BOT_T1)).toBe(false)
+    expect(internals.slackPool.get(BOT_T1)).toBeUndefined()
   })
 
   it('unassign drops the composite index entries', async () => {
@@ -1513,8 +1516,8 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
 
     await manager.unassign(BOT_T1)
     const internals = manager as unknown as DemuxInternals
-    expect(internals.demuxByAppTeam.size).toBe(0)
-    expect(internals.appTeamKeyByBot.size).toBe(0)
+    expect(internals.slackDemux.indexes.byAppTenant.size).toBe(0)
+    // The reverse map is DemuxIndex-internal now; an empty composite index IS the proof.
     expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T1' })).toBeUndefined()
   })
 })

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -34,17 +34,11 @@ import { BotArbitrationRouter, sessionKeyOf, type BotAssignment, type RouteTarge
 import { SlackHttpIngest, type HttpSlackSessionAction, type HttpSlackSessionShortcut } from './slack-http-ingest.js'
 import { FeishuHttpIngest } from './feishu-http-ingest.js'
 import type { FeishuVerifiedDelivery } from './feishu-http-ingress.js'
+import { DemuxIndex, IngressPool } from './platforms/registry.js'
 import { verifySlackSignature } from './hooks/signature.js'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
 
 /** Cap on the learned `api_app_id → botId` demux index before it is flushed. */
-const MAX_DEMUX_ENTRIES = 10_000
-
-/** Composite demux key for one workspace install of a distributed app. */
-function appTeamKey(apiAppId: string, teamId: string): string {
-  return `${apiAppId}\u0000${teamId}`
-}
-
 /** Cap on the retry buffer for thread-assign reports dropped while the CP link was
  *  down. Bounded so a long CP outage can't grow it without limit; oldest-cleared. */
 const MAX_PENDING_REPORTS = 10_000
@@ -201,20 +195,14 @@ export function httpFeishuActionMsgId(
 
 export class RelayIngressManager {
   private readonly router = new BotArbitrationRouter()
-  private readonly ingests = new Map<string, SlackHttpIngest>()
-  private readonly feishuIngests = new Map<string, FeishuHttpIngest>()
-  private readonly feishuBotByAppId = new Map<string, string>()
-  private readonly feishuAppIdByBot = new Map<string, string>()
-  /** Learned/assigned `api_app_id → botId` index — O(1) HTTP demux (self-populates on
-   *  first verified delivery when the CP didn't stamp `apiAppId`). Bounded flush.
-   *  Team-scoped bots (a distributed app's installs) NEVER enter this map — they
-   *  demux exclusively on the composite index below. */
-  private readonly demuxByApiApp = new Map<string, string>()
-  /** Assigned `(api_app_id, team_id) → botId` composite index — the ONLY demux for
-   *  a distributed app's installs, which all share one app id + signing secret.
-   *  Assign-derived (never learned) and cleaned up on unassign via the reverse map. */
-  private readonly demuxByAppTeam = new Map<string, string>()
-  private readonly appTeamKeyByBot = new Map<string, string>()
+  /** §8 registry (S3): one pool of per-bot ingests per platform, and one demux
+   *  identity index beside each pool. The index owns the composite/app-only
+   *  decision per ASSIGNMENT shape (tenant-scoped ⇒ composite only, never
+   *  learned; app-only ⇒ learnable) — see platforms/registry.ts. */
+  private readonly slackPool = new IngressPool<SlackHttpIngest>('slack')
+  private readonly feishuPool = new IngressPool<FeishuHttpIngest>('feishu')
+  private readonly slackDemux = new DemuxIndex()
+  private readonly feishuDemux = new DemuxIndex()
   /** Bounded-loss counters (per bot) — messages dropped because no daemon connection. */
   private readonly dropped = new Map<string, number>()
   /** Thread-assign reports dropped because the CP link wasn't READY, keyed
@@ -349,8 +337,8 @@ export class RelayIngressManager {
     this.router.upsert(a)
     // Rebuild the ingest (secrets or transport may have rotated). Idempotent.
     await this.stopIngest(a.botId)
-    this.forgetAppTeam(a.botId)
-    this.forgetFeishuApp(a.botId)
+    this.slackDemux.forget(a.botId)
+    this.feishuDemux.forget(a.botId)
 
     if (a.platform === 'feishu') {
       if (!a.apiAppId || !('verificationToken' in a.secrets)) {
@@ -362,9 +350,8 @@ export class RelayIngressManager {
         onCardAction: (action, eventId) => this.forwardFeishuAction(a.botId, action, eventId),
         now: () => this.deps.clock.now()
       })
-      this.feishuIngests.set(a.botId, ingest)
-      this.feishuBotByAppId.set(a.apiAppId, a.botId)
-      this.feishuAppIdByBot.set(a.botId, a.apiAppId)
+      this.feishuPool.set(a.botId, ingest)
+      this.feishuDemux.indexAssign(a.botId, { appId: a.apiAppId })
       return
     }
     if (a.platform !== 'slack') {
@@ -375,18 +362,14 @@ export class RelayIngressManager {
       this.deps.log.warn(`relay-ingress(${a.botId}): incomplete Slack HTTP assignment`)
       return
     }
-    // Deterministic demux when the CP stamped the app id. A team-scoped bot (a
-    // distributed app's install) goes ONLY into the composite index — an app-only
-    // entry would serve every sibling workspace's events to this one bot.
-    if (a.apiAppId && a.teamId) {
-      this.demuxByAppTeam.set(appTeamKey(a.apiAppId, a.teamId), a.botId)
-      this.appTeamKeyByBot.set(a.botId, appTeamKey(a.apiAppId, a.teamId))
-      // A re-assign that GAINED a teamId must also evict any stale app-only entry
-      // still pointing at this bot, or the fast path would keep serving cross-team.
-      if (this.demuxByApiApp.get(a.apiAppId) === a.botId) this.demuxByApiApp.delete(a.apiAppId)
-    } else if (a.apiAppId) {
-      this.rememberApiApp(a.apiAppId, a.botId)
-    }
+    // Deterministic demux when the CP stamped the app id: the index owns the
+    // composite/app-only decision from the assignment's shape (a team-scoped bot
+    // enters ONLY the composite index; gaining a teamId evicts the stale
+    // app-only entry — both invariants are pinned in registry.test.ts).
+    this.slackDemux.indexAssign(a.botId, {
+      ...(a.apiAppId ? { appId: a.apiAppId } : {}),
+      ...(a.teamId ? { tenantId: a.teamId } : {})
+    })
     const ingest = new SlackHttpIngest(
       a.botId,
       { botToken: a.secrets.botToken, signingSecret: a.secrets.signingSecret },
@@ -416,7 +399,7 @@ export class RelayIngressManager {
         log: this.deps.log
       }
     )
-    this.ingests.set(a.botId, ingest)
+    this.slackPool.set(a.botId, ingest)
     await ingest.start()
   }
 
@@ -459,26 +442,10 @@ export class RelayIngressManager {
       return
     }
     this.clearGatedDmLatches(botId)
-    this.forgetAppTeam(botId)
-    this.forgetFeishuApp(botId)
+    this.slackDemux.forget(botId)
+    this.feishuDemux.forget(botId)
     this.router.remove(botId)
     await this.stopIngest(botId)
-  }
-
-  /** Drop the bot's composite demux entry (assign-derived, so eagerly cleaned —
-   *  unlike the learned app-only map, whose stale entries lazily miss). */
-  private forgetAppTeam(botId: string): void {
-    const key = this.appTeamKeyByBot.get(botId)
-    if (key === undefined) return
-    this.appTeamKeyByBot.delete(botId)
-    if (this.demuxByAppTeam.get(key) === botId) this.demuxByAppTeam.delete(key)
-  }
-
-  private forgetFeishuApp(botId: string): void {
-    const appId = this.feishuAppIdByBot.get(botId)
-    if (!appId) return
-    this.feishuAppIdByBot.delete(botId)
-    if (this.feishuBotByAppId.get(appId) === botId) this.feishuBotByAppId.delete(appId)
   }
 
   /** `rc/assign` — durable thread affinity seed. */
@@ -507,23 +474,25 @@ export class RelayIngressManager {
     const { apiAppId, teamId, timestamp, rawBody, signature } = args
     // Composite fast path — assign-derived, so a hit is exact (still HMAC-verified).
     if (apiAppId && teamId) {
-      const botId = this.demuxByAppTeam.get(appTeamKey(apiAppId, teamId))
-      const ingest = botId ? this.ingests.get(botId) : undefined
+      const botId = this.slackDemux.resolve({ appId: apiAppId, tenantId: teamId })
+      const ingest = botId ? this.slackPool.get(botId) : undefined
       if (ingest && verifySlackSignature(ingest.signingSecret, timestamp, rawBody, signature, now)) return ingest
     }
     if (apiAppId) {
-      const botId = this.demuxByApiApp.get(apiAppId)
-      const ingest = botId ? this.ingests.get(botId) : undefined
+      const botId = this.slackDemux.resolve({ appId: apiAppId })
+      const ingest = botId ? this.slackPool.get(botId) : undefined
       if (ingest && verifySlackSignature(ingest.signingSecret, timestamp, rawBody, signature, now)) return ingest
     }
-    for (const [botId, ingest] of this.ingests) {
+    for (const [botId, ingest] of this.slackPool.entries()) {
       // A team-scoped bot may only serve its own workspace: same-secret siblings
       // would all verify, so the envelope team id is the ONLY discriminator.
       const assignedTeam = this.router.get(botId)?.teamId
       if (assignedTeam !== undefined && assignedTeam !== teamId) continue
       if (verifySlackSignature(ingest.signingSecret, timestamp, rawBody, signature, now)) {
-        // Learn only the app-only mapping; composite entries are assign-derived.
-        if (apiAppId && assignedTeam === undefined) this.rememberApiApp(apiAppId, botId)
+        // Learn only the app-only mapping; the index itself refuses a
+        // tenant-scoped bot (registry.test.ts), keeping the invariant even if a
+        // future call site forgets this router check.
+        if (apiAppId && assignedTeam === undefined) this.slackDemux.learn(apiAppId, botId)
         return ingest
       }
     }
@@ -540,26 +509,22 @@ export class RelayIngressManager {
     headers: import('./feishu-http-ingest.js').FeishuCallbackHeaders
   }): FeishuVerifiedDelivery | undefined {
     if (args.appId) {
-      const botId = this.feishuBotByAppId.get(args.appId)
-      const ingest = botId ? this.feishuIngests.get(botId) : undefined
+      const botId = this.feishuDemux.resolve({ appId: args.appId })
+      const ingest = botId ? this.feishuPool.get(botId) : undefined
       const callback = ingest?.decode(args.rawBody, args.body, args.headers)
       if (ingest && callback) return { ingest, callback }
     }
-    for (const ingest of this.feishuIngests.values()) {
+    for (const ingest of this.feishuPool.values()) {
       const callback = ingest.decode(args.rawBody, args.body, args.headers)
       if (callback) return { ingest, callback }
     }
     return undefined
   }
 
-  private rememberApiApp(apiAppId: string, botId: string): void {
-    if (this.demuxByApiApp.size >= MAX_DEMUX_ENTRIES) this.demuxByApiApp.clear()
-    this.demuxByApiApp.set(apiAppId, botId)
-  }
-
   /** Test/inspection view of the demux indexes (no secret material). */
   get demuxIndexes(): { byApiApp: ReadonlyMap<string, string>; byAppTeam: ReadonlyMap<string, string> } {
-    return { byApiApp: this.demuxByApiApp, byAppTeam: this.demuxByAppTeam }
+    const { byApp, byAppTenant } = this.slackDemux.indexes
+    return { byApiApp: byApp, byAppTeam: byAppTenant }
   }
 
   /** Make the inline selector effective for the current Slack thread immediately.
@@ -586,17 +551,23 @@ export class RelayIngressManager {
       this.revokeRetryTimer = undefined
     }
     await Promise.all(
-      [...new Set([...this.ingests.keys(), ...this.feishuIngests.keys()])].map((id) => this.stopIngest(id))
+      [
+        ...new Set([
+          ...[...this.slackPool.entries()].map(([id]) => id),
+          ...[...this.feishuPool.entries()].map(([id]) => id)
+        ])
+      ].map((id) => this.stopIngest(id))
     )
   }
 
   private async stopIngest(botId: string): Promise<void> {
-    const cur = this.ingests.get(botId)
+    const cur = this.slackPool.get(botId)
     if (cur) {
-      this.ingests.delete(botId)
+      this.slackPool.delete(botId)
       await cur.stop()
     }
-    this.feishuIngests.delete(botId)
+    // A Feishu ingest is a pure decoder — nothing to stop, only to drop.
+    this.feishuPool.delete(botId)
   }
 
   private isAgentBotMessage(botId: string, msg: import('@agentconnect.md/protocol').WireNormalizedMessage): boolean {
@@ -837,7 +808,7 @@ export class RelayIngressManager {
     const latch = `${botId}:${msg.channel}`
     if (this.gatedDmReported.has(latch)) return
     // A group DM's counterpart is the room, not the sender, so it carries no name here.
-    const name = msg.isDm ? await this.ingests.get(botId)?.lookupUserName(msg.sender.id) : undefined
+    const name = msg.isDm ? await this.slackPool.get(botId)?.lookupUserName(msg.sender.id) : undefined
     const sent = this.deps.reportBotConversation({
       botId,
       conversation: { id: msg.channel, ...(name ? { name } : {}), kind: msg.isDm ? 'im' : 'mpim' }
@@ -874,7 +845,7 @@ export class RelayIngressManager {
     }
     const key = `${botId}:${msg.channel}`
     if (this.gatedNoticesSent.has(key)) return
-    const ingest = this.ingests.get(botId)
+    const ingest = this.slackPool.get(botId)
     // Feishu relay ingress is receive-only. Its caller first tries the assignment
     // directory's sole gated daemon target; an old CP that did not include the
     // integration id safely lands here and drops instead of leaking API secrets.


### PR DESCRIPTION
Third S3-relay PR — the **mechanical half** of the manager rewiring: the five platform-named maps (`ingests`/`feishuIngests`, `feishuBotByAppId`/`feishuAppIdByBot`, `demuxByApiApp`/`demuxByAppTeam`/`appTeamKeyByBot`) are replaced by two `IngressPool`s and two `DemuxIndex`es (#562). The `assign()` platform fork **deliberately stays** — it becomes the plugin registry in the next PR; replacing state and dispatch in one change is the §16 hazard this split avoids.

## What the index absorbs from the manager

The composite/app-only decision and the gained-a-teamId stale-entry eviction (both inline in `assign()` before), the learned-entry bound, and the reverse-map cleanup (`forgetAppTeam`/`forgetFeishuApp`/`rememberApiApp` deleted). `resolveVerified` keeps its exact ladder — composite fast path, app-only fast path, bounded verify-scan with the team-id discriminator — now reading candidates from the index. The learn call keeps the router's `assignedTeam` check **and** gains the index's own tenant-scope refusal beneath it: a future call site that forgets the check still cannot break the invariant.

`FeishuHttpIngest` gains the no-op `stop()` the `RelayBotIngress` contract requires (a pure decoder — nothing to release).

## Verification

- relay suite **409 passed**; the composite-demux suite (sibling installs, cross-workspace scan refusal, fail-closed no-team envelope, legacy learning, stale-unassign fencing, eager composite cleanup) passes with internals seams moved from raw maps to pool/index accessors
- full monorepo typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)