### PR TITLE
fix: let a platform-observed agent delivery bind the conversation audience

### DIFF
--- a/docs/designs/send-message-routing-rework.md
+++ b/docs/designs/send-message-routing-rework.md
@@ -123,32 +123,31 @@ Consequences:
 A verified AgentConnect-authored platform message takes the SAME arbitration
 ladder a human message takes, with the author removed from the candidate set:
 
-- An explicit mention of agent B activates B.
-- An unmentioned agent message continues the conversation through the ordinary
-  implicit rungs — thread affinity, DM, keyword, channel `auto`, default agent.
-  This is what lets agents converse without naming each other in every line.
-- **Addressing anyone is binding.** A message that names someone gets an explicit
-  outcome or none; it never falls through to the implicit rungs. This covers three
-  cases that look different and are not:
-  - a mention of a human (or another app, or a bare shared bot) resolves to no
-    agent and therefore activates nobody — the same thing a person's `@human` reply
-    does, since the direct ladder stops at any unmatched mention in a channel;
-  - a response whose only name is its own author, which is the one self-address
-    every response can produce;
-  - a named agent that is refused by policy, by the conversation fence, or by not
-    being resident here — substituting a different recipient is not a continuation.
-
-  Only a response that names NOBODY is unaddressed, and only that one continues.
-  A DM is already addressed to its recipient, so it is exempt on both ladders.
-
-  Because only the LAST physical section is marked `final` (§5.5) and every
-  non-agent mention is otherwise visible only in that section's own text, the
-  final event also carries `addressedAnyone` for the COMPLETE response. Without
-  it, an answer that mentions a human in section one and ends without a mention
-  would arrive with both mention sets empty, and whether the address bound would
-  depend on where the splitter happened to cut. Absent on an older author's
-  message ⇒ false, so its finals stay routable exactly as before.
-
+- **The mention in the body is not an address this layer acts on.** Delivery follows
+  the ordinary ladder on the connection that OBSERVED the post — thread affinity, DM,
+  keyword, channel `auto`, default agent — with the author excluded. A `<@…>` in the
+  text is for the humans reading the thread and for the target's own judgement; it
+  does not select recipients. Agents in one thread therefore see each other's replies
+  and decide for themselves whether to answer, which is what `NO_RESPONSE` is for.
+- **They can decide, because they know who they are.** The agent's own bot user id is
+  standing context (`- Slack identity: bot user <@U…> is YOU`), sourced from the
+  daemon's own live connection. Nothing about that judgement depends on routing having
+  resolved the mention first.
+- Selecting recipients by mention was tried and removed. It made delivery depend on
+  mapping an opaque `<@U…>` back to an agent through the collaboration directory, and
+  that lookup is not dependable — observed in a live workspace with `botUserId` absent
+  for most agents and `botShared` derived from "the app is shareable" rather than from
+  a bot user genuinely backing several agents. A correct, well-formed peer mention then
+  resolved to nobody, and because addressing was treated as binding the conversation
+  stopped: the more precisely a model addressed its peer, the more reliably it silenced
+  the thread. Precision was never worth that failure mode.
+- ONE structured exception, which is not an address: the visible half of a paired
+  `toAgent + channel` send (§3.2). Its target came from the tool call as an agent id,
+  and the activation rendezvous only converges when the visible observation and the
+  internal wake name the SAME agent. Both ladders special-case it on
+  `agentCallDeliveryId`.
+- A mention of a human, of another app, or of a peer this daemon cannot resolve
+  changes nothing: the message is delivered like any other, and the reader decides.
 - **The author can never be the target.** This is the one absolute. An agent's own
   reply always matches its own rule, so self-activation is not a loop the hop cap
   slows down — it is unconditional. The author is excluded once, before any rung.
@@ -157,13 +156,14 @@ ladder a human message takes, with the author removed from the candidate set:
   bot-ness — we know exactly which agent wrote a verified message and have already
   checked its policy, so it is a participant rather than anonymous bot traffic.
 
-Every implicitly-selected edge is still an agent call: it spends from the shared
-hop budget (§4.1), passes directional call policy, and passes the conversation
-Off/gated fence. It is also still _implicit_, so it obeys the `!stop` thread mute
-exactly like a human's implicitly-routed message — an explicit agent mention
-clears that mute, an implicit continuation stays silenced by it. Without this
-`!stop` would silence a conversation's humans while its agents kept waking each
-other, and `!stop` is the direct control a human has over a running exchange.
+Every selected edge is still an agent call: it spends from the shared hop budget
+(§4.1), passes directional call policy, and passes the conversation Off/gated
+fence. It is also _implicit_, so it obeys the `!stop` thread mute exactly like a
+human's implicitly-routed message. Agent traffic can no longer LIFT that mute
+either — lifting it was the explicit-mention path, and clearing a stop is properly
+a human act (an `@mention` on the ordinary ladder, or `!resume`). `!stop` is the
+direct control a human has over a running exchange, so agents talking among
+themselves must not be able to reopen it.
 
 **Consequence, stated plainly.** A multi-agent conversation now terminates because
 it hits a limit, not because someone stops addressing anyone. The hop cap and the
@@ -390,24 +390,21 @@ final platform event
 |- verified AgentConnect author?
 |    |- target == author -> excluded from every rung
 |    |- source hop invalid or source hop + 1 exceeds cap -> transcript only (hop_limit)
-|    |- names NOBODY (no mention of any kind, or a DM)
-|    |    `- ordinary implicit ladder (thread affinity / dm / keyword / auto /
-|    |       default), author excluded -> claim activation key -> dispatch once
-|    |- names someone -> explicit outcome or none; never the implicit ladder
-|    |    |- unmatched mention (a human, another app, a bare shared bot) -> transcript only
-|    |       (from this section's text, or the claim's complete-response `addressedAnyone`)
-|    |    |- only the author -> transcript only
-|    |    |- author -> target policy denied / conversation Off / not local -> transcript only
-|    |    `- target in verified recipient set -> claim activation key -> dispatch once
+|    |- paired `toAgent + channel` (agentCallDeliveryId) -> the agent the tool named
+|    `- any other reply -> the ordinary implicit ladder ON THE OBSERVING CONNECTION
+|         (thread affinity / dm / keyword / auto / default), author excluded
+|         -> claim activation key -> dispatch once
+|       the `<@…>` in the body selects nobody; the reader judges for itself
 |- third-party supported bot?
 |    `- exact target mention only -> existing bot-mention behavior
 `- human sender -> existing mention/thread/DM/keyword/auto ladder
 ```
 
-For a verified agent author, shared-bot slug resolution runs before channel owner
-or default-agent fallback. A bare shared-bot mention from an agent does not select
-the default agent — it is an unmatched mention, so it takes the "names someone"
-branch and stops, rather than continuing through the implicit ladder.
+Mention RESOLUTION still exists, but only to RENDER an address (`listAgents`'
+`mention` field, a channel-root `toAgent` post) and to name the paired target — never
+to choose who receives an ordinary reply. A shared bot's address therefore still needs
+its agent slug when an agent wants to WRITE one; a bare `<@U_SHARED>` appearing in a
+body simply carries no routing weight, as no mention does.
 
 Agent-authored text cannot issue in-conversation control commands such as
 `!stop`, `!resume`, or configuration actions.
@@ -578,18 +575,18 @@ At minimum, cover:
    preserves parent lineage and reply behavior.
 5. `toUser` without `channel` is a single-user DM; an array is rejected.
 6. `toUser + channel` posts at root and mentions all listed humans.
-7. A normal current-thread agent reply mentioning another agent activates only
-   that agent.
-8. Agent-authored unmentioned auto-channel, DM, and thread-affinity traffic
-   continues the conversation through the implicit rungs, never selecting the
-   author; agent-authored command traffic still activates nobody.
-9. Self mentions and policy-denied mentions do not activate, and neither falls
-   through to the implicit rungs — having named someone, they get an explicit
-   outcome or none. An implicitly selected continuation obeys a `!stop` mute on
-   both the direct and relay paths; an explicit agent mention clears it, as a
-   human's does.
-10. Shared-bot slug addressing selects the named agent and never falls back to
-    the default for an agent author.
+7. A normal current-thread agent reply reaches the peer whose connection observed
+   it, whether or not it mentions anyone, and is never stamped as an explicit
+   address.
+8. Agent-authored auto-channel, DM, and thread-affinity traffic continues the
+   conversation through the implicit rungs, never selecting the author;
+   agent-authored command traffic still activates nobody.
+9. The author is never the target on any connection, and a body naming the author,
+   a human, or an unresolvable peer does not change delivery. An agent-authored
+   delivery obeys a `!stop` mute on both the direct and relay paths and can never
+   lift one — clearing a stop stays a human act.
+10. A paired `toAgent + channel` delivery reaches the exact agent the tool named,
+    on both ladders, so its rendezvous halves converge.
 11. Streaming agent messages do not activate; when a mention is in physical
     section one and finalization is in section two or later, the final response
     still selects that target once with complete thread context.

--- a/docs/designs/send-message-routing-rework.md
+++ b/docs/designs/send-message-routing-rework.md
@@ -555,6 +555,9 @@ The main implementation surfaces are:
 - `packages/relay/src/bot-arbitration.ts`: track the participant set beside legacy
   single-owner affinity, exclude the author from every rung, and resolve explicit
   joins and implicit participant copies independently.
+- `packages/control-plane/src/persistence/repositories/thread-affinity.repo.ts`:
+  persist the participant set separately from the compatibility owner, broadcast
+  joins to every relay, and return the full set on a relay affinity miss.
 - `packages/daemon/src/daemon.ts`: replace direct and relayed managed-agent
   suppression with verified routing, trusted hop propagation, durable activation
   rendezvous records, and headless `replyToSession` dispatch.

--- a/docs/designs/send-message-routing-rework.md
+++ b/docs/designs/send-message-routing-rework.md
@@ -28,10 +28,10 @@ Two implementation notes, recorded where they will be looked for:
 ## 1. Goals
 
 1. Let a finalized platform message authored by an AgentConnect agent participate
-   in normal recipient routing.
-2. Make the ordinary reply the way an agent talks in its current thread — an
-   explicit `@mention` to address someone in particular, and plain text to
-   continue the conversation with whoever the ordinary routing ladder selects.
+   in normal routing, so the agents in a thread see what each other said.
+2. Make the ordinary reply the way an agent talks in its current thread. Its text
+   — `@mention` or not — is what the conversation shows; delivery is the ordinary
+   routing ladder's decision, and whether to answer is the reader's.
 3. Keep `sendMessage` for postless agent calls, direct messages, channel-root
    posts, and parent-session replies.
 4. Make a parent-session reply session-only by default: its injected input and
@@ -123,31 +123,37 @@ Consequences:
 A verified AgentConnect-authored platform message takes the SAME arbitration
 ladder a human message takes, with the author removed from the candidate set:
 
-- **The mention in the body is not an address this layer acts on.** Delivery follows
-  the ordinary ladder on the connection that OBSERVED the post — thread affinity, DM,
-  keyword, channel `auto`, default agent — with the author excluded. A `<@…>` in the
-  text is for the humans reading the thread and for the target's own judgement; it
-  does not select recipients. Agents in one thread therefore see each other's replies
-  and decide for themselves whether to answer, which is what `NO_RESPONSE` is for.
-- **They can decide, because they know who they are.** The agent's own bot user id is
-  standing context (`- Slack identity: bot user <@U…> is YOU`), sourced from the
-  daemon's own live connection. Nothing about that judgement depends on routing having
-  resolved the mention first.
-- Selecting recipients by mention was tried and removed. It made delivery depend on
-  mapping an opaque `<@U…>` back to an agent through the collaboration directory, and
-  that lookup is not dependable — observed in a live workspace with `botUserId` absent
-  for most agents and `botShared` derived from "the app is shareable" rather than from
-  a bot user genuinely backing several agents. A correct, well-formed peer mention then
-  resolved to nobody, and because addressing was treated as binding the conversation
-  stopped: the more precisely a model addressed its peer, the more reliably it silenced
-  the thread. Precision was never worth that failure mode.
-- ONE structured exception, which is not an address: the visible half of a paired
-  `toAgent + channel` send (§3.2). Its target came from the tool call as an agent id,
-  and the activation rendezvous only converges when the visible observation and the
-  internal wake name the SAME agent. Both ladders special-case it on
-  `agentCallDeliveryId`.
-- A mention of a human, of another app, or of a peer this daemon cannot resolve
-  changes nothing: the message is delivered like any other, and the reader decides.
+- **A thread is a conversation, so everyone in it hears what is said.** Delivery goes
+  to every agent already PARTICIPATING in the thread, minus the author — not to one
+  agent chosen per message. That holds whoever spoke: a human's follow-up and an
+  agent's reply reach the same room.
+- **An `@mention` JOINS an agent to the thread**, at the root or midway through. That
+  is the whole of what a mention does for routing. After joining, the agent keeps
+  receiving what is said next whether or not the next message names it — which is why
+  agents do not have to name each other to keep a conversation going.
+- **A channel-`auto` agent participates in the whole channel**, so every message there
+  reaches it without any mention at all.
+- A mention names EVERY agent it matches, never whichever routing rule happened to be
+  found first. On a bot serving several agents that distinction is the difference
+  between deterministic delivery and delivery that depends on rule order.
+- **Whether to answer is the reader's decision, not routing's.** An agent's own bot
+  user id is standing context (`- Slack identity: bot user <@U…> is YOU`), sourced from
+  the daemon's own live connection, so it can tell whether a message concerns it and
+  decline with `NO_RESPONSE`.
+- Selecting recipients by PARSING the body was tried and removed. It made delivery
+  depend on mapping an opaque `<@U…>` back to an agent through the collaboration
+  directory, and that lookup is not dependable — observed in a live workspace with
+  `botUserId` absent for most agents and `botShared` derived from "the app is
+  shareable" rather than from a bot user genuinely backing several agents. A correct,
+  well-formed peer mention then resolved to nobody and the conversation stopped: the
+  more precisely a model addressed its peer, the more reliably it silenced the thread.
+- ONE structured exception: the visible half of a paired `toAgent + channel` send
+  (§3.2). Its target came from the tool call as an agent id, and the activation
+  rendezvous only converges when the visible observation and the internal wake name the
+  SAME agent. Both ladders special-case it on `agentCallDeliveryId`.
+- Each peer is an INDEPENDENT delivery: its own session, `!stop` mute, Off fence, and
+  inbox row. A muted participant stays muted — `!stop` is per (thread, agent), and
+  hearing the room is exactly what it was told to stop doing.
 - **The author can never be the target.** This is the one absolute. An agent's own
   reply always matches its own rule, so self-activation is not a loop the hop cap
   slows down — it is unconditional. The author is excluded once, before any rung.
@@ -350,18 +356,18 @@ For AgentConnect-authored messages:
    `delivery_state: 'streaming'` and do not enter recipient routing.
 5. Turn finalization marks exactly one response event as
    `delivery_state: 'final'`.
-6. Ingress routes only the final event. It selects targets from the verified
-   logical-response recipient set, not by reparsing only the last physical
-   message, and deduplicates by `response_id` plus target agent.
+6. Ingress routes only the final event, and deduplicates by `response_id` plus
+   target agent. Which agent that is comes from the ordinary ladder (§2.3), not
+   from the body — the recipient set is consulted only for a paired
+   `toAgent + channel` delivery, whose target the tool named.
 7. If a long response spans several platform messages, only the final response
-   message closes the response. Once the carried recipient set selects a target,
-   the target reconstructs preceding text through the normal thread-history
-   catch-up path.
+   message closes the response. The woken target reconstructs preceding text
+   through the normal thread-history catch-up path.
 
 The recipient set is still a provider metadata claim at ingress. It becomes
 trusted only together with the exact AgentConnect author and app identity, and
-every listed author-to-target edge must independently pass current policy and
-conversation gates.
+every author-to-target edge — however the target was selected — must
+independently pass current policy and conversation gates.
 
 At finalization the platform driver tokenizes mention-address spans before
 choosing physical-message boundaries. A preferred line or paragraph boundary
@@ -388,13 +394,12 @@ final platform event
 |
 |- structural/chrome event -> drop
 |- verified AgentConnect author?
-|    |- target == author -> excluded from every rung
+|    |- target == author -> excluded everywhere
 |    |- source hop invalid or source hop + 1 exceeds cap -> transcript only (hop_limit)
 |    |- paired `toAgent + channel` (agentCallDeliveryId) -> the agent the tool named
-|    `- any other reply -> the ordinary implicit ladder ON THE OBSERVING CONNECTION
-|         (thread affinity / dm / keyword / auto / default), author excluded
-|         -> claim activation key -> dispatch once
-|       the `<@…>` in the body selects nobody; the reader judges for itself
+|    `- any other reply -> the thread's PARTICIPANTS, author excluded
+|         (agents already in the thread + any the body newly names)
+|         -> claim activation key -> dispatch once per peer
 |- third-party supported bot?
 |    `- exact target mention only -> existing bot-mention behavior
 `- human sender -> existing mention/thread/DM/keyword/auto ladder
@@ -541,18 +546,20 @@ The main implementation surfaces are:
   echoes while retaining structural/chrome filtering.
 - `packages/relay/src/relay-ingress-manager.ts`: replace blanket managed-agent
   suppression with author verification, source-hop transition/cap enforcement,
-  policy checks, and the verified-author routing ladder (named recipients, or the
-  implicit rungs when the response named nobody).
-- `packages/relay/src/bot-arbitration.ts`: add the verified-agent routing branch
-  and shared-bot slug precedence.
+  policy checks, and ordinary arbitration for every reply — with the paired
+  `toAgent + channel` delivery kept on its exact, tool-named target.
+- `packages/relay/src/bot-arbitration.ts`: add the verified-agent routing branch,
+  which excludes the author from every rung.
 - `packages/daemon/src/daemon.ts`: replace direct and relayed managed-agent
   suppression with verified routing, trusted hop propagation, durable activation
   rendezvous records, and headless `replyToSession` dispatch.
 - `packages/daemon/src/state-store.ts`: persist activation rendezvous state and
   make admission/retry transitions atomic with the durable inbox fence.
 - `packages/daemon/src/router/routing-table.ts`: admit verified agent traffic to
-  the implicit rungs with the author excluded, while unverified bot traffic still
-  stops at the explicit-mention rung.
+  the implicit rungs with the author excluded (unverified bot traffic still stops
+  at the explicit-mention rung), and expose `mentionedAgents` / `participantAgents`
+  — the whole named set and the thread's existing members — for conversation-wide
+  delivery.
 - `packages/protocol`: carry authorship, logical recipient, paired-delivery,
   source/delivery hop, delivery-state, headless, capability, and mention-address
   metadata.
@@ -575,9 +582,9 @@ At minimum, cover:
    preserves parent lineage and reply behavior.
 5. `toUser` without `channel` is a single-user DM; an array is rejected.
 6. `toUser + channel` posts at root and mentions all listed humans.
-7. A normal current-thread agent reply reaches the peer whose connection observed
-   it, whether or not it mentions anyone, and is never stamped as an explicit
-   address.
+7. A normal current-thread agent reply reaches every OTHER participant of the
+   thread, whether or not it mentions anyone; a mention adds whoever it names, and
+   names all of them rather than the first matching rule.
 8. Agent-authored auto-channel, DM, and thread-affinity traffic continues the
    conversation through the implicit rungs, never selecting the author;
    agent-authored command traffic still activates nobody.

--- a/docs/designs/send-message-routing-rework.md
+++ b/docs/designs/send-message-routing-rework.md
@@ -357,8 +357,9 @@ For AgentConnect-authored messages:
 5. Turn finalization marks exactly one response event as
    `delivery_state: 'final'`.
 6. Ingress routes only the final event, and deduplicates by `response_id` plus
-   target agent. Which agent that is comes from the ordinary ladder (§2.3), not
-   from the body — the recipient set is consulted only for a paired
+   target agent. The ordinary ladder may supply a primary, but delivery also goes
+   independently to every existing participant and every agent the body newly
+   mentions. The recipient set selects an exact target only for a paired
    `toAgent + channel` delivery, whose target the tool named.
 7. If a long response spans several platform messages, only the final response
    message closes the response. The woken target reconstructs preceding text
@@ -402,14 +403,17 @@ final platform event
 |         -> claim activation key -> dispatch once per peer
 |- third-party supported bot?
 |    `- exact target mention only -> existing bot-mention behavior
-`- human sender -> existing mention/thread/DM/keyword/auto ladder
+`- human sender -> existing ladder may nominate a primary
+     `- explicit joins + existing participants + channel-auto agents
+          -> dispatch once per peer with a target-specific mention/implicit cause
 ```
 
-Mention RESOLUTION still exists, but only to RENDER an address (`listAgents`'
-`mention` field, a channel-root `toAgent` post) and to name the paired target — never
-to choose who receives an ordinary reply. A shared bot's address therefore still needs
-its agent slug when an agent wants to WRITE one; a bare `<@U_SHARED>` appearing in a
-body simply carries no routing weight, as no mention does.
+Mention resolution still exists to RENDER an address (`listAgents`' `mention` field, a
+channel-root `toAgent` post), to name the paired target, and to JOIN every agent an
+ordinary platform mention matches. A mention never narrows an ordinary reply to one
+recipient: existing participants still receive their independent implicit copies. A
+shared bot's address therefore still needs its agent slug when an agent wants to write
+one; a bare `<@U_SHARED>` joins only the routes that token can actually resolve.
 
 Agent-authored text cannot issue in-conversation control commands such as
 `!stop`, `!resume`, or configuration actions.
@@ -546,10 +550,11 @@ The main implementation surfaces are:
   echoes while retaining structural/chrome filtering.
 - `packages/relay/src/relay-ingress-manager.ts`: replace blanket managed-agent
   suppression with author verification, source-hop transition/cap enforcement,
-  policy checks, and ordinary arbitration for every reply — with the paired
+  per-edge policy checks, and cross-daemon participant fan-out — with the paired
   `toAgent + channel` delivery kept on its exact, tool-named target.
-- `packages/relay/src/bot-arbitration.ts`: add the verified-agent routing branch,
-  which excludes the author from every rung.
+- `packages/relay/src/bot-arbitration.ts`: track the participant set beside legacy
+  single-owner affinity, exclude the author from every rung, and resolve explicit
+  joins and implicit participant copies independently.
 - `packages/daemon/src/daemon.ts`: replace direct and relayed managed-agent
   suppression with verified routing, trusted hop propagation, durable activation
   rendezvous records, and headless `replyToSession` dispatch.
@@ -557,9 +562,9 @@ The main implementation surfaces are:
   make admission/retry transitions atomic with the durable inbox fence.
 - `packages/daemon/src/router/routing-table.ts`: admit verified agent traffic to
   the implicit rungs with the author excluded (unverified bot traffic still stops
-  at the explicit-mention rung), and expose `mentionedAgents` / `participantAgents`
-  — the whole named set and the thread's existing members — for conversation-wide
-  delivery.
+  at the explicit-mention rung), and expose `mentionedAgents` / `participantAgents` /
+  `automaticAgents` — the whole named set, the thread's existing members, and the
+  channel-wide participants — for conversation-wide delivery.
 - `packages/protocol`: carry authorship, logical recipient, paired-delivery,
   source/delivery hop, delivery-state, headless, capability, and mention-address
   metadata.

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -98,8 +98,8 @@ the configured secret-store seam.
    can land on any instance.
 3. **Routing happens at ingress.** CP compiles routes with explicit
    `{ agentId, daemonId, integrationId }` ownership. The relay arbitrates and
-   sends a pre-addressed `rd/msg`; the target daemon does not repeat the
-   routing ladder.
+   sends one pre-addressed `rd/msg` per selected conversation participant; a
+   target daemon does not repeat the routing ladder.
 4. **Daemons initiate data-plane connections.** A daemon remains an
    outbound-only edge node and dials every relay in its CP-provided roster.
 5. **Relays initiate control connections.** Each relay authenticates and
@@ -185,6 +185,17 @@ model SharedThreadAgent {
   @@id([botId, sessionKey])
   @@map("shared_thread_agent")
 }
+
+model SharedThreadParticipant {
+  botId      String   @db.Uuid
+  sessionKey String
+  agentId    String   @db.Uuid
+  daemonId   String   @db.Uuid
+  updatedAt  DateTime @updatedAt @db.Timestamptz(6)
+
+  @@id([botId, sessionKey, agentId])
+  @@map("shared_thread_participant")
+}
 ```
 
 `Integration.botId` is not unique because a shareable bot can back multiple
@@ -201,6 +212,9 @@ active integration row carries that owner for each shared channel; sibling rows 
 null because channel membership is repeated per integration.
 `SharedThreadAgent` is the durable fallback for relay-local thread affinity. It
 contains routing metadata only, never message text.
+`SharedThreadParticipant` is the independently durable participant set. It lets
+any healthy relay replica reconstruct every joined target after a restart or a
+public-callback load-balancer hop without turning the legacy owner into a set.
 
 ## 7. Protocol
 
@@ -369,9 +383,11 @@ the trigger. An in-Slack move or automatic fallback to a restricted agent stays 
 This also preserves state and repairs ownership when an integration is removed;
 `No default` is not an operator state.
 
-Each target contains `agentId`, `daemonId`, and `integrationId`. The relay drops
-messages produced by another managed AgentConnect bot before arbitration so
-they cannot create affinity or agent-to-agent platform loops.
+Each target contains `agentId`, `daemonId`, and `integrationId`. A verified
+AgentConnect-authored final is admitted through the collaboration policy and
+hop/loop fences, then sent independently to every other participant. Unverified
+managed-bot echoes still fail closed, and third-party bots remain exact-mention
+only.
 
 Channel membership changes trigger a coalesced Slack membership refresh. The
 relay reports the complete channel snapshot through `rc/bot-channels`; CP
@@ -383,7 +399,7 @@ later channel-owner change. The app-level message shortcut starts only with the
 selected message's channel and thread: the relay resolves current conversation
 ownership, then the daemon resolves and authorizes the exact bot-scoped session.
 
-### 10.2 Durable thread affinity
+### 10.2 Durable thread affinity and participants
 
 Thread affinity uses three control legs:
 
@@ -393,6 +409,15 @@ Thread affinity uses three control legs:
    `rc/assign` to every connected relay.
 3. On a local miss for an unmentioned thread follow-up, the receiving relay
    asks CP through `rc/thread-lookup` and caches the result.
+
+Conversation membership uses the same control channel without overloading the
+single owner. A relay reports each newly joined target with
+`rc/thread-participant`; CP upserts `(botId, sessionKey, agentId) -> daemonId`,
+broadcasts `rc/participant-assign` to the pool, replays the set to a restarted
+relay, and returns the whole set with `rc/thread-lookup/ok`. Owner reports also
+seed their target as a participant. These rows are control-plane routing
+metadata only. The separate participant frames keep mixed-version peers from
+mistaking a member update for a compatibility-owner replacement.
 
 If CP is unavailable during a lookup, the follow-up is dropped rather than
 routed to a different agent. A later explicit mention can re-anchor the

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -128,18 +128,14 @@ address from a display name.
 A finalized platform message authored by an AgentConnect agent takes the **same routing
 ladder as any other message**, with the author removed from the candidate set:
 
-- an explicit mention of agent B activates B;
-- an unmentioned agent message continues the conversation through the ordinary implicit
-  rungs — thread affinity, DM, keyword, channel `auto`, default agent — so agents can
-  talk to each other without naming a recipient in every line;
-- addressing anyone is binding, and only a message that names **nobody** continues
-  implicitly. A mention of a human (or another app, or a bare shared bot) resolves to no
-  agent and so wakes nobody — the same thing a person's `@someone` reply does in that
-  channel. So does a message whose only name is its own author, and one whose named agent
-  is refused by call policy, by the channel's Off switch, or by not running here:
-  answering "the agent you asked for is unavailable" with a different agent is not
-  something the author asked for. A DM is already addressed to its recipient and is
-  exempt;
+- the `@mention` an agent writes is for the **people reading the thread**, and for the
+  recipient's own judgement — it does not decide who receives the message. Every agent
+  in the conversation sees the reply and decides for itself whether to answer, the same
+  way a person in a group chat does. An agent knows its own bot identity, so it can tell
+  whether a mention is aimed at it;
+- so agents do **not** need to name each other to keep a conversation going, and naming
+  someone does not narrow delivery. A mention of a human, of another app, or of a peer
+  we cannot resolve changes nothing;
 - **an author is never the target**, on any path. This is the one absolute: an agent's
   own reply always matches its own rule, so self-activation would be unconditional
   rather than merely loop-prone;
@@ -157,10 +153,9 @@ without them talking continuously, prefer @-mention addressing over the "every m
 trigger; the loop guard is a latch, and clearing it takes an explicit `!resume`.
 
 `!stop` remains the direct control over a running exchange, and it applies to agents the
-same way it applies to people: while a thread is stopped, an implicitly-routed agent
-continuation is recorded but does not wake anyone. An explicit `@mention` — from a person
-or from an agent — still gets through and lifts the stop, because `!stop` means "stop
-reacting to this conversation on your own", not "ignore anyone who names me".
+same way it applies to people: while a thread is stopped, an agent's reply is recorded but
+wakes nobody. Clearing a stop is a **human** act — an `@mention` from a person, or
+`!resume`. Agents talking among themselves cannot reopen a conversation you stopped.
 
 Only the **final** message of a logical response routes. Replies are streamed, so an
 earlier physical message may hold a prefix of the answer; the daemon marks exactly one

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -128,14 +128,17 @@ address from a display name.
 A finalized platform message authored by an AgentConnect agent takes the **same routing
 ladder as any other message**, with the author removed from the candidate set:
 
-- the `@mention` an agent writes is for the **people reading the thread**, and for the
-  recipient's own judgement — it does not decide who receives the message. Every agent
-  in the conversation sees the reply and decides for itself whether to answer, the same
-  way a person in a group chat does. An agent knows its own bot identity, so it can tell
-  whether a mention is aimed at it;
-- so agents do **not** need to name each other to keep a conversation going, and naming
-  someone does not narrow delivery. A mention of a human, of another app, or of a peer
-  we cannot resolve changes nothing;
+- **a thread is a conversation: everyone in it hears what is said.** Once an agent is
+  part of a thread, every later message reaches it — from a person or from another
+  agent — without needing to name it again;
+- **an `@mention` is how an agent JOINS a thread**, whether in the first message or
+  halfway through. That is what a mention does; it is not a per-message address. An
+  agent set to `auto` in a channel is already part of every conversation there;
+- so agents do **not** need to name each other to keep talking, and naming someone
+  does not narrow delivery — it only adds whoever was named;
+- each participant is an independent delivery with its own session and its own `!stop`.
+  A participant you stopped stays stopped, and still records the conversation for
+  catch-up;
 - **an author is never the target**, on any path. This is the one absolute: an agent's
   own reply always matches its own rule, so self-activation would be unconditional
   rather than merely loop-prone;
@@ -160,7 +163,8 @@ wakes nobody. Clearing a stop is a **human** act — an `@mention` from a person
 Only the **final** message of a logical response routes. Replies are streamed, so an
 earlier physical message may hold a prefix of the answer; the daemon marks exactly one
 event final at turn end and carries the recipients resolved from the complete response,
-so a mention in the answer's first section still selects its target exactly once.
+so the recipients of a paired agent call are resolved from the whole answer, not from
+whichever section happened to close it.
 
 Activation requires a **verified** author: an authentic provider event, a sending app
 that belongs to AgentConnect in this organization and conversation, a claimed author that

--- a/evals/test/routing-acceptance.test.ts
+++ b/evals/test/routing-acceptance.test.ts
@@ -369,8 +369,8 @@ describe('case 3 — ordinary-reply mentions: agent-authored platform messages r
     expect(fixture.activations('agent2')).toBe(1)
     expect(fixture.turnInputs('agent2')[0]).toContain('please review the rollout')
     const admissions = await fixture.echoAdmissions()
-    const streaming = admissions.filter((record) => !record.messageId.endsWith(':final'))
-    const finalized = admissions.filter((record) => record.messageId.endsWith(':final'))
+    const streaming = admissions.filter((record) => record.ingressEventTag === undefined)
+    const finalized = admissions.filter((record) => record.ingressEventTag !== undefined)
     expect(streaming.every((record) => record.admission.admitted === false)).toBe(true)
     expect(finalized.some((record) => record.admission.admitted === true)).toBe(true)
     // agent2's unmentioning reply names nobody, so it continues the conversation

--- a/evals/test/routing-acceptance.test.ts
+++ b/evals/test/routing-acceptance.test.ts
@@ -349,7 +349,7 @@ describe('case 3 — ordinary-reply mentions: agent-authored platform messages r
             ctx.reply(`<@${fixture!.botUserId('agent2')}> please review the rollout`)
             return
           }
-          ctx.reply('nothing to do')
+          // Silence ends the exchange: no post, no echo, nothing to route (§2.3).
         },
         agent2: (ctx) => {
           if (/please review/.test(ctx.text)) {
@@ -373,8 +373,11 @@ describe('case 3 — ordinary-reply mentions: agent-authored platform messages r
     const finalized = admissions.filter((record) => record.messageId.endsWith(':final'))
     expect(streaming.every((record) => record.admission.admitted === false)).toBe(true)
     expect(finalized.some((record) => record.admission.admitted === true)).toBe(true)
-    // agent2's own unmentioning reply wakes nobody further.
-    expect(fixture.activations('agent1')).toBe(1)
+    // agent2's unmentioning reply names nobody, so it continues the conversation
+    // through the implicit ladder (§2.3, #549) — waking the thread peer exactly
+    // once. agent1's silent turn then ends the exchange.
+    expect(fixture.activations('agent1')).toBe(2)
+    expect(fixture.turnInputs('agent1')[1]).toContain('reviewing now')
   }, 120_000)
 
   it('negative invariants that hold in BOTH architectures: unmentioned agent posts and self-mentions activate no one', async () => {

--- a/evals/test/routing-fixture.ts
+++ b/evals/test/routing-fixture.ts
@@ -19,6 +19,7 @@
  * (evaluation events), delivered/attempted world outbound effects, and thread
  * coordinates — not mechanism internals.
  */
+import { SLACK_RESPONSE_FINAL_EVENT_TAG } from '../../packages/message/src/index.js'
 import type {
   DeliveryAdmission,
   DeliveryHandle,
@@ -65,6 +66,8 @@ export class RoutingFixture {
   private readonly echoHandles: DeliveryHandle[] = []
   private readonly echoAdmissionRecords: {
     messageId: string
+    /** Set on the response-closing arrival; absent on the post it edits. */
+    ingressEventTag?: string
     integrationId: string
     admission: Promise<DeliveryAdmission>
   }[] = []
@@ -170,20 +173,21 @@ export class RoutingFixture {
     const botUserId = this.world.botUserIdFor(effect.integrationId)
     if (botUserId === undefined || effect.messageId === undefined) return
     const appId = this.world.botAppIdFor(effect.integrationId)
-    // Slack normalizes a top-level message with thread = its own ts; the
-    // finalized message_changed edit keeps the ORIGINAL post's coordinates but
-    // carries a distinct `<ts>:final` msgId so per-connection dedup admits it
-    // (packages/message SLACK_RESPONSE_FINAL_MSG_ID_SUFFIX).
+    // Slack normalizes a top-level message with thread = its own ts; the finalized
+    // `message_changed` edit keeps the ORIGINAL post's coordinates — msgId included,
+    // because that id also carries the platform ts — and is told apart from the post it
+    // edits by `ingressEventTag`, which is the extra per-connection dedup dimension
+    // (packages/message SLACK_RESPONSE_FINAL_EVENT_TAG).
     let thread: string
-    let echoMessageId: string
+    let ingressEventTag: string | undefined
     if (effect.kind === 'reply') {
       thread = effect.thread ?? effect.messageId
       this.threadByMessageId.set(effect.messageId, thread)
-      echoMessageId = effect.messageId
     } else {
       thread = this.threadByMessageId.get(effect.messageId) ?? effect.thread ?? effect.messageId
-      echoMessageId = `${effect.messageId}:final`
+      ingressEventTag = SLACK_RESPONSE_FINAL_EVENT_TAG
     }
+    const echoMessageId = effect.messageId
     const mentions = [...effect.text.matchAll(/<@([A-Z0-9]+)>/g)].map((match) => match[1]!)
     // The authorship CLAIM travels exactly as the platform normalizer would
     // surface it: streaming on ordinary posts (unroutable), final only on the
@@ -210,6 +214,7 @@ export class RoutingFixture {
           channel: this.room.channel,
           thread,
           messageId: echoMessageId,
+          ...(ingressEventTag !== undefined ? { ingressEventTag } : {}),
           text: effect.text,
           sender: { id: botUserId, isBot: true, ...(appId !== undefined ? { appId } : {}) },
           ...(mentions.length > 0 ? { mentions } : {}),
@@ -217,15 +222,23 @@ export class RoutingFixture {
         }
       })
       this.echoHandles.push(handle)
-      this.echoAdmissionRecords.push({ messageId: echoMessageId, integrationId, admission: handle.admission })
+      this.echoAdmissionRecords.push({
+        messageId: echoMessageId,
+        ...(ingressEventTag !== undefined ? { ingressEventTag } : {}),
+        integrationId,
+        admission: handle.admission
+      })
     }
   }
 
   /** Admission outcome of every platform echo injected so far, in order. */
-  async echoAdmissions(): Promise<{ messageId: string; integrationId: string; admission: DeliveryAdmission }[]> {
+  async echoAdmissions(): Promise<
+    { messageId: string; ingressEventTag?: string; integrationId: string; admission: DeliveryAdmission }[]
+  > {
     return Promise.all(
       this.echoAdmissionRecords.map(async (record) => ({
         messageId: record.messageId,
+        ...(record.ingressEventTag !== undefined ? { ingressEventTag: record.ingressEventTag } : {}),
         integrationId: record.integrationId,
         admission: await record.admission
       }))

--- a/packages/control-plane/prisma/migrations/20260804103000_shared_thread_participant/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260804103000_shared_thread_participant/migration.sql
@@ -1,0 +1,20 @@
+-- Durable multi-agent participant membership for HTTP relay conversations.
+-- This is routing metadata only; message content remains daemon-local.
+CREATE TABLE "public"."shared_thread_participant" (
+    "botId" UUID NOT NULL,
+    "sessionKey" TEXT NOT NULL,
+    "agentId" UUID NOT NULL,
+    "daemonId" UUID NOT NULL,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "shared_thread_participant_pkey" PRIMARY KEY ("botId", "sessionKey", "agentId")
+);
+
+CREATE INDEX "shared_thread_participant_botId_idx"
+    ON "public"."shared_thread_participant"("botId" ASC);
+
+-- Every legacy affinity owner is already a participant in its conversation.
+INSERT INTO "public"."shared_thread_participant" ("botId", "sessionKey", "agentId", "daemonId", "updatedAt")
+SELECT "botId", "sessionKey", "agentId", "daemonId", "updatedAt"
+FROM "public"."shared_thread_agent"
+ON CONFLICT DO NOTHING;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1841,6 +1841,21 @@ model SharedThreadAgent {
   @@map("shared_thread_agent")
 }
 
+// Durable multi-agent room membership for relay-pooled HTTP bots. Unlike
+// SharedThreadAgent, this is a set and never changes the compatibility owner.
+// It is routing metadata only: no message body or transcript content is stored.
+model SharedThreadParticipant {
+  botId      String   @db.Uuid
+  sessionKey String
+  agentId    String   @db.Uuid
+  daemonId   String   @db.Uuid
+  updatedAt  DateTime @updatedAt @db.Timestamptz(6)
+
+  @@id([botId, sessionKey, agentId])
+  @@index([botId])
+  @@map("shared_thread_participant")
+}
+
 enum IntegrationStatus {
   active
   revoked

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1298,6 +1298,14 @@ export function buildContainer(
         http.log.error({ err, botId: m.botId }, 'relay: thread-assign failed')
       }
     },
+    // Durable room membership is independent of compatibility owner affinity.
+    onThreadParticipant: async (m) => {
+      try {
+        await httpBot.recordThreadParticipant(m)
+      } catch (err) {
+        http.log.error({ err, botId: m.botId }, 'relay: thread-participant failed')
+      }
+    },
     // Pull-on-miss BACKSTOP leg — may throw → the handler answers a retryable error.
     threadLookup: (m) => httpBot.lookupThread(m),
     // Installation doorbell poke — fire-and-forget into the throttled re-pull

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -121,6 +121,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
   let unplacedAgents: Set<string>
   // Drives ThreadAffinityStore.get (null = affinity miss → SessionMeta fallback).
   let threadBinding: { agentId: AgentId; daemonId: string } | null
+  let threadParticipants: Awaited<ReturnType<ThreadAffinityStore['participantsForBot']>>
   // revokeBot recordings: the Bot revocation stamp + integration/remove pushes.
   let botRevokedAt: Date | null
   let removals: { daemonId: string; integrationId: string }[]
@@ -163,7 +164,17 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         threadBinding
           ? ({ sessionKey: '', ...threadBinding } as Awaited<ReturnType<ThreadAffinityStore['get']>>)
           : null,
-      listForBot: async () => []
+      listForBot: async () => [],
+      upsertParticipant: async (_botId, sessionKey, agentId, daemonId) => {
+        const current = threadParticipants.find((p) => p.sessionKey === sessionKey && p.agentId === agentId)
+        if (current) current.daemonId = daemonId
+        else threadParticipants.push({ sessionKey, agentId, daemonId })
+      },
+      participants: async (_botId, sessionKey) =>
+        threadParticipants
+          .filter((participant) => participant.sessionKey === sessionKey)
+          .map(({ agentId, daemonId }) => ({ agentId, daemonId })),
+      participantsForBot: async () => threadParticipants
     }
     const intRepo: Pick<IntegrationRepo, 'listForBot' | 'markRevokedForBot'> = {
       listForBot: async () => integrations.filter((i) => i.status === 'active'),
@@ -298,6 +309,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     gatedAgents = new Set()
     unplacedAgents = new Set()
     threadBinding = null
+    threadParticipants = []
     blockNextChannelList = null
     bumpRevisionAfterFirstGet = false
     botRevokedAt = null
@@ -314,7 +326,12 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       const orch = makeOrch()
       threadOwner = { agentId: ALICE, daemonId: D1 }
       const res = await orch.lookupThread({ botId: BOT, sessionKey: SK })
-      expect(res).toEqual({ botId: BOT, sessionKey: SK, target: { agentId: ALICE, daemonId: D1 } })
+      expect(res).toEqual({
+        botId: BOT,
+        sessionKey: SK,
+        target: { agentId: ALICE, daemonId: D1 },
+        participants: [{ agentId: ALICE, daemonId: D1 }]
+      })
       expect(threadOwnerLookup).toEqual({ botId: BOT, channel: 'C1', thread: '1784297789.871789' })
     })
 
@@ -323,6 +340,24 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       threadOwner = null
       const res = await orch.lookupThread({ botId: BOT, sessionKey: SK })
       expect(res.target).toBeNull()
+    })
+
+    it('persists and broadcasts participant joins independently of the compatibility owner', async () => {
+      const orch = makeOrch()
+      await orch.recordThreadParticipant({ botId: BOT, sessionKey: SK, agentId: BOB, daemonId: D2 })
+
+      expect(ch.sends.at(-1)).toEqual({
+        type: 'rc/participant-assign',
+        payload: { botId: BOT, sessionKey: SK, agentId: BOB, daemonId: D2 }
+      })
+      threadOwner = null
+      const res = await orch.lookupThread({ botId: BOT, sessionKey: SK })
+      expect(res).toEqual({
+        botId: BOT,
+        sessionKey: SK,
+        target: null,
+        participants: [{ agentId: BOB, daemonId: D2 }]
+      })
     })
   })
 

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -20,6 +20,7 @@ import type {
   RcBotAssign,
   BindMatch,
   RcThreadAssign,
+  RcThreadParticipant,
   RcThreadLookup,
   RcThreadLookupOk
 } from '@agentconnect.md/protocol'
@@ -312,6 +313,14 @@ export class HttpBotOrchestrator {
         for (const t of await this.threads.listForBot(bot.id)) {
           ch.send('rc/assign', { botId: bot.id, sessionKey: t.sessionKey, agentId: t.agentId, daemonId: t.daemonId })
         }
+        for (const t of await this.threads.participantsForBot(bot.id)) {
+          ch.send('rc/participant-assign', {
+            botId: bot.id,
+            sessionKey: t.sessionKey,
+            agentId: t.agentId,
+            daemonId: t.daemonId
+          })
+        }
       } catch {
         // dead socket — its onClose removes it from the registry
       }
@@ -326,8 +335,22 @@ export class HttpBotOrchestrator {
    */
   async recordThreadAssign(m: RcThreadAssign): Promise<void> {
     await this.threads.upsert(BotId(m.botId), m.sessionKey, AgentId(m.agentId), DaemonId(m.daemonId))
+    await this.threads.upsertParticipant(BotId(m.botId), m.sessionKey, AgentId(m.agentId), DaemonId(m.daemonId))
     this.broadcast((ch) =>
       ch.send('rc/assign', { botId: m.botId, sessionKey: m.sessionKey, agentId: m.agentId, daemonId: m.daemonId })
+    )
+  }
+
+  /** Persist and broadcast one room member without changing single-owner affinity. */
+  async recordThreadParticipant(m: RcThreadParticipant): Promise<void> {
+    await this.threads.upsertParticipant(BotId(m.botId), m.sessionKey, AgentId(m.agentId), DaemonId(m.daemonId))
+    this.broadcast((ch) =>
+      ch.send('rc/participant-assign', {
+        botId: m.botId,
+        sessionKey: m.sessionKey,
+        agentId: m.agentId,
+        daemonId: m.daemonId
+      })
     )
   }
 
@@ -338,12 +361,24 @@ export class HttpBotOrchestrator {
    *  affinity forever. */
   async lookupThread(m: RcThreadLookup): Promise<RcThreadLookupOk> {
     const channel = m.sessionKey.slice(0, Math.max(m.sessionKey.indexOf('/'), 0)) || m.sessionKey
+    const participants = (
+      await Promise.all(
+        (await this.threads.participants(BotId(m.botId), m.sessionKey)).map(async (participant) =>
+          (await this.threadTargetAllowed(m.botId, channel, participant.agentId)) ? participant : null
+        )
+      )
+    ).filter((participant): participant is NonNullable<typeof participant> => participant !== null)
     const t = await this.threads.get(BotId(m.botId), m.sessionKey)
     if (t) {
       if (!(await this.threadTargetAllowed(m.botId, channel, t.agentId))) {
-        return { botId: m.botId, sessionKey: m.sessionKey, target: null }
+        return { botId: m.botId, sessionKey: m.sessionKey, target: null, participants }
       }
-      return { botId: m.botId, sessionKey: m.sessionKey, target: { agentId: t.agentId, daemonId: t.daemonId } }
+      return {
+        botId: m.botId,
+        sessionKey: m.sessionKey,
+        target: { agentId: t.agentId, daemonId: t.daemonId },
+        participants
+      }
     }
     // Affinity miss: fall back to session metadata. A session an agent created directly on the
     // daemon (e.g. its own channel-root post, session-concept §7.2 case 2a) never went through
@@ -357,10 +392,17 @@ export class HttpBotOrchestrator {
       const thread = m.sessionKey.slice(slash + 1)
       const owner = await this.sessions.findThreadOwner(BotId(m.botId), channel, thread)
       if (owner && (await this.threadTargetAllowed(m.botId, channel, owner.agentId))) {
-        return { botId: m.botId, sessionKey: m.sessionKey, target: owner }
+        return {
+          botId: m.botId,
+          sessionKey: m.sessionKey,
+          target: owner,
+          participants: participants.some((participant) => participant.agentId === owner.agentId)
+            ? participants
+            : [...participants, owner]
+        }
       }
     }
-    return { botId: m.botId, sessionKey: m.sessionKey, target: null }
+    return { botId: m.botId, sessionKey: m.sessionKey, target: null, participants }
   }
 
   /** §14 conversation-gating check for the thread-lookup backstop: a non-gated

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2737,6 +2737,9 @@ export interface ThreadAffinityStore {
   upsert(botId: BotId, sessionKey: string, agentId: AgentId, daemonId: DaemonId): Promise<void>
   get(botId: BotId, sessionKey: string): Promise<{ agentId: AgentId; daemonId: DaemonId } | null>
   listForBot(botId: BotId): Promise<{ sessionKey: string; agentId: AgentId; daemonId: DaemonId }[]>
+  upsertParticipant(botId: BotId, sessionKey: string, agentId: AgentId, daemonId: DaemonId): Promise<void>
+  participants(botId: BotId, sessionKey: string): Promise<Array<{ agentId: AgentId; daemonId: DaemonId }>>
+  participantsForBot(botId: BotId): Promise<Array<{ sessionKey: string; agentId: AgentId; daemonId: DaemonId }>>
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/thread-affinity.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/thread-affinity.repo.ts
@@ -31,4 +31,22 @@ export class PgThreadAffinityStore implements ThreadAffinityStore {
     const rows = await this.db.sharedThreadAgent.findMany({ where: { botId }, orderBy: { updatedAt: 'asc' } })
     return rows.map((r) => ({ sessionKey: r.sessionKey, agentId: AgentId(r.agentId), daemonId: DaemonId(r.daemonId) }))
   }
+
+  async upsertParticipant(botId: BotId, sessionKey: string, agentId: AgentId, daemonId: DaemonId): Promise<void> {
+    await this.db.sharedThreadParticipant.upsert({
+      where: { botId_sessionKey_agentId: { botId, sessionKey, agentId } },
+      create: { botId, sessionKey, agentId, daemonId },
+      update: { daemonId }
+    })
+  }
+
+  async participants(botId: BotId, sessionKey: string): Promise<Array<{ agentId: AgentId; daemonId: DaemonId }>> {
+    const rows = await this.db.sharedThreadParticipant.findMany({ where: { botId, sessionKey } })
+    return rows.map((r) => ({ agentId: AgentId(r.agentId), daemonId: DaemonId(r.daemonId) }))
+  }
+
+  async participantsForBot(botId: BotId): Promise<Array<{ sessionKey: string; agentId: AgentId; daemonId: DaemonId }>> {
+    const rows = await this.db.sharedThreadParticipant.findMany({ where: { botId }, orderBy: { updatedAt: 'asc' } })
+    return rows.map((r) => ({ sessionKey: r.sessionKey, agentId: AgentId(r.agentId), daemonId: DaemonId(r.daemonId) }))
+  }
 }

--- a/packages/control-plane/src/ws/relay-connection.test.ts
+++ b/packages/control-plane/src/ws/relay-connection.test.ts
@@ -91,6 +91,8 @@ function build(
     verifyWebchatToken?: (token: string) => Promise<RcVerifyResult>
     authorizeGithubComment?: (req: RcGithubCommentAuthz) => Promise<boolean>
     authorizeGithubRerequest?: (req: RcGithubRerequest) => Promise<RcGithubRerequestResult>
+    onThreadAssign?: ConstructorParameters<typeof RelayConnection>[1]['onThreadAssign']
+    onThreadParticipant?: ConstructorParameters<typeof RelayConnection>[1]['onThreadParticipant']
   } = {}
 ) {
   const codec = new ApiKeyCodec({ API_KEY_PEPPER: 'unit-test-pepper-0123456789abcdefghij' })
@@ -113,6 +115,8 @@ function build(
   const onRunReport = vi.fn(async () => {})
   const onBotChannels = vi.fn(async () => {})
   const onBotRevoked = vi.fn(async () => {})
+  const onThreadAssign = over.onThreadAssign ?? vi.fn(async () => {})
+  const onThreadParticipant = over.onThreadParticipant ?? vi.fn(async () => {})
   const relayReg = new RelayRegistry()
 
   const transport = new FakeServerTransport()
@@ -129,8 +133,9 @@ function build(
     onSetChannelAgent: vi.fn(async () => {}),
     onBotChannels,
     onBotRevoked,
-    onThreadAssign: vi.fn(async () => {}),
-    threadLookup: vi.fn(async (m) => ({ ...m, target: null })),
+    onThreadAssign,
+    onThreadParticipant,
+    threadLookup: vi.fn(async (m) => ({ ...m, target: null, participants: [] })),
     onGithubInstallation: vi.fn(async () => {}),
     relayReg,
     verifyWebchatToken,
@@ -147,6 +152,8 @@ function build(
     onRunReport,
     onBotChannels,
     onBotRevoked,
+    onThreadAssign,
+    onThreadParticipant,
     authorizeGithubComment,
     authorizeGithubRerequest,
     relayReg
@@ -473,7 +480,8 @@ describe('RelayConnection FSM', () => {
       onSetChannelAgent: vi.fn(async () => {}),
       onBotChannels: vi.fn(async () => {}),
       onThreadAssign: vi.fn(async () => {}),
-      threadLookup: vi.fn(async (m) => ({ ...m, target: null })),
+      onThreadParticipant: vi.fn(async () => {}),
+      threadLookup: vi.fn(async (m) => ({ ...m, target: null, participants: [] })),
       onGithubInstallation: vi.fn(async () => {}),
       relayReg,
       verifyWebchatToken,
@@ -524,6 +532,24 @@ describe('RelayConnection FSM', () => {
     await Promise.resolve()
 
     expect(onBotChannels).toHaveBeenCalledWith(snapshot)
+  })
+
+  it('keeps owner affinity and participant membership on separate handlers', async () => {
+    const { transport, onThreadAssign, onThreadParticipant } = build()
+    await toReady(transport)
+    const target = {
+      botId: '22222222-2222-4222-8222-222222222222',
+      sessionKey: 'C1/ts',
+      agentId: '33333333-3333-4333-8333-333333333333',
+      daemonId: '44444444-4444-4444-8444-444444444444'
+    }
+
+    transport.feed('rc/thread-assign', target)
+    transport.feed('rc/thread-participant', target)
+    await Promise.resolve()
+
+    expect(onThreadAssign).toHaveBeenCalledWith(target)
+    expect(onThreadParticipant).toHaveBeenCalledWith(target)
   })
 
   it('rc/bot-revoked in READY reaches the revocation handler', async () => {

--- a/packages/control-plane/src/ws/relay-connection.ts
+++ b/packages/control-plane/src/ws/relay-connection.ts
@@ -28,6 +28,7 @@ import type {
   RcNoticePosted,
   RcSetChannelAgent,
   RcThreadAssign,
+  RcThreadParticipant,
   RcThreadLookup,
   RcThreadLookupOk,
   RcVerify,
@@ -81,6 +82,8 @@ export interface RelayConnDeps {
    *  broadcast the binding pool-wide (rc/assign). Fire-and-forget; a store error must
    *  not close the link. */
   onThreadAssign: (m: RcThreadAssign) => Promise<void>
+  /** Persist one joined room member without replacing affinity. */
+  onThreadParticipant: (m: RcThreadParticipant) => Promise<void>
   /** Answer a relay `rc/thread-lookup` (pull-on-miss BACKSTOP) from the persisted
    *  binding. May throw on a transient store error → the handler answers a retryable
    *  error REP without closing the shared relay link. */
@@ -176,6 +179,9 @@ export class RelayConnection implements RelayChannel {
         case 'rc/thread-assign':
           await this.handleThreadAssign(frame.payload)
           return
+        case 'rc/thread-participant':
+          await this.handleThreadParticipant(frame.payload)
+          return
         case 'rc/thread-lookup':
           await this.handleThreadLookup(frame, frame.payload)
           return
@@ -209,6 +215,7 @@ export class RelayConnection implements RelayChannel {
           type === 'rc/bot-revoked' ||
           type === 'rc/notice-posted' ||
           type === 'rc/thread-assign' ||
+          type === 'rc/thread-participant' ||
           type === 'rc/thread-lookup' ||
           type === 'rc/github-installation'
         )
@@ -278,6 +285,14 @@ export class RelayConnection implements RelayChannel {
       await this.deps.onThreadAssign(m)
     } catch {
       // swallowed — affinity bookkeeping only, never worth the socket
+    }
+  }
+
+  private async handleThreadParticipant(m: RcThreadParticipant): Promise<void> {
+    try {
+      await this.deps.onThreadParticipant(m)
+    } catch {
+      // participant bookkeeping is idempotent and self-heals on the next join
     }
   }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -904,6 +904,23 @@ interface CallMeta {
    * no dependence on the inbox row still existing by the time the sweep runs.
    */
   activationKey?: string
+  /**
+   * This delivery was OBSERVED on the platform, in the very conversation it targets — an
+   * agent's ordinary reply or channel-root mention — rather than being a postless
+   * `toAgent` call.
+   *
+   * It decides whether the woken turn may bind the conversation's external audience.
+   * A postless child must not: its coordinates are derived from the caller's session and
+   * the model influences the target, so binding one would let model input claim a shared
+   * conversation. A platform-observed delivery has the OPPOSITE property — its channel
+   * and thread come from the provider event itself, exactly like a human message in that
+   * thread — so it must bind, or it can never wake an agent that already holds an
+   * externally-bound session there, which is every agent already talking in the thread.
+   *
+   * Persisted with the inbox row alongside the rest of CallMeta, so a replayed turn makes
+   * the same classification it would have made live.
+   */
+  platformOrigin?: true
   /** A self-authored channel-root post initializes its new session but is not a model turn.
    *  Persisted with the inbox row so crash replay cannot accidentally activate the model. */
   initializeOnly?: boolean
@@ -5960,6 +5977,10 @@ export class Daemon {
     }
     const callMeta: CallMeta = {
       callFrom: verified.authorAgentId,
+      // Observed on the platform, in this very conversation — so the woken turn binds the
+      // same audience a human message in this thread would. Without it the target's
+      // existing Slack-bound session rejects the wake as a cross-source turn.
+      platformOrigin: true,
       // §4.1 step 3/5: install the computed depth as trusted active-turn metadata. Every
       // ordinary platform response this target produces stamps it as the NEXT event's
       // source depth, so an A → B → A chain advances by one per hop and stops at the cap
@@ -6966,6 +6987,9 @@ export class Daemon {
     }
     const callMeta: CallMeta = {
       callFrom: authorAgentId,
+      // See the direct path: a relayed platform observation is still a platform event in
+      // this conversation, not a postless call.
+      platformOrigin: true,
       hopCount: deliveryHopCount,
       deliveryId: msg.msgId,
       activationKey: key
@@ -15260,7 +15284,8 @@ export class Daemon {
     hookContext: HookDispatchContext | undefined
   ): 'unchanged' | 'mismatch' | 'unavailable' {
     const direct =
-      this.githubExternalSource(hookContext) ?? this.conversationExternalSource(agentId, msg, callMeta !== undefined)
+      this.githubExternalSource(hookContext) ??
+      this.conversationExternalSource(agentId, msg, callMeta !== undefined && callMeta.platformOrigin !== true)
     // A CONVERSATION audience is only bindable when fully attributed (realm +
     // integration); a repository audience (GitHub) has its own completeness rule.
     // Keyed on the resource kind, so a new platform's audience gets the same

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -15351,8 +15351,12 @@ export class Daemon {
         : this.integrationIdForTransportScope(agentId, msg.platform, msg.transportScope)
     const integration = integrationId ? this.integrationConfigById(integrationId) : undefined
     const tenantScope = integration ? this.tenantScopeForIntegration(integration) : undefined
+    // Same predicate as `bindSessionSource`: a platform-observed delivery binds the NEW
+    // session it creates, or that session is classified local and every later externally-
+    // attributed wake of it (human or agent) rejects as a cross-source mismatch.
     const directExternalSource =
-      this.githubExternalSource(hookContext) ?? this.conversationExternalSource(agentId, msg, isA2aChild)
+      this.githubExternalSource(hookContext) ??
+      this.conversationExternalSource(agentId, msg, isA2aChild && callMeta.platformOrigin !== true)
     const inheritedExternalSource = callMeta?.externalOrigin
       ? {
           externalProvider: callMeta.externalOrigin.provider,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -163,7 +163,7 @@ import {
   resolveSlackMentionedAgents,
   slackTextAddressesAnyone,
   slackMentionAddress,
-  SLACK_RESPONSE_FINAL_MSG_ID_SUFFIX
+  SLACK_RESPONSE_FINAL_EVENT_TAG
 } from '@agentconnect.md/message'
 import {
   applySlackAction as applySlackActionExternal,
@@ -848,14 +848,12 @@ function activationKey(
   return [platform, transportScope ?? '', platformMessageId, targetAgentId].join('\u0000')
 }
 
-/** The platform `ts` inside a Slack `msgId` (`slack:<channel>:<ts>`, optionally suffixed
- *  for a response finalization). The ts — not the msgId — is the visible message's
- *  identity, which is what the activation key and the paired wake both name. */
+/** The platform `ts` inside a Slack `msgId` (`slack:<channel>:<ts>`). The ts — not the
+ *  msgId — is the visible message's identity, which is what the activation key and the
+ *  paired wake both name. A response finalization carries the ORIGINAL post's msgId and
+ *  marks itself with `ingressEventTag`, so nothing has to be stripped here. */
 function slackTsFromMsgId(msgId: string): string {
-  const base = msgId.endsWith(SLACK_RESPONSE_FINAL_MSG_ID_SUFFIX)
-    ? msgId.slice(0, -SLACK_RESPONSE_FINAL_MSG_ID_SUFFIX.length)
-    : msgId
-  return base.split(':')[2] ?? base
+  return msgId.split(':')[2] ?? msgId
 }
 
 /** Poll interval for the deferred background-task wake (background-task-aware-reclaim.md
@@ -6039,7 +6037,10 @@ export class Daemon {
     const sourceKey =
       msg.transportScope ??
       (srcIntegrationIds === undefined ? '' : [...srcIntegrationIds].sort((a, b) => a.localeCompare(b)).join(','))
-    const seenMsgId = `${sourceKey}|${msg.msgId}`
+    // The tag is the SECOND dedup dimension: a streamed reply's post and its closing edit
+    // share one `msgId` (they are one Slack message) and must not collapse — the closing
+    // edit is the only routable arrival.
+    const seenMsgId = `${sourceKey}|${msg.msgId}|${msg.ingressEventTag ?? ''}`
     if (this.seenMsgIds.has(seenMsgId)) {
       this.log.debug(`routing: duplicate ${msg.msgId} ignored`)
       return { kind: 'rejected', reason: 'deduplicated' }
@@ -9793,6 +9794,9 @@ export class Daemon {
       // write or non-chronological-id platforms (Telegram/Feishu) keep the
       // broken derived axis.
       ...(msg.platformTimeMs ? { eventTimeUs: msg.platformTimeMs * 1000 } : {}),
+      // The closing edit of a streamed reply shares its post's coordinates, so it
+      // refreshes that row to the completed text instead of being ignored as a duplicate.
+      ...(msg.ingressEventTag === SLACK_RESPONSE_FINAL_EVENT_TAG ? { authoritative: true } : {}),
       kind: 'text',
       text: mention ? `${msg.text}\n${mention}`.trim() : msg.text,
       ...(msg.quoted?.text ? { quoted: msg.quoted } : {})
@@ -12662,6 +12666,15 @@ export class Daemon {
         // have put the only mention in section one. Without this the same answer would
         // wake a peer or not depending on where the cut landed.
         const addressedAnyone = slackTextAddressesAnyone(p.replyText)
+        // What this response RESOLVED to, at the one place the author still knows it.
+        // Everything downstream (relay arbitration, the target's ladder) sees only the
+        // outcome, so without this a response that addressed a peer but resolved to no
+        // agent — a stale or unpopulated mention directory — is indistinguishable from
+        // one that addressed nobody, on either side of the wire.
+        this.log.debug(
+          `slack: finalizing response ${p.responseId} for "${p.agentId}" — recipients=[${recipients.join(',')}] ` +
+            `addressedAnyone=${addressedAnyone} directory=${orgId ? this.cpCollab.mentionDirectory(orgId, p.platform, p.channel).length : 0}`
+        )
         await finalizeSlackResponse(p.conn as SlackConnection, p, recipients, addressedAnyone, (m) => this.log.debug(m))
       }
       // The user-visible reply is now delivered. Enqueue provider work without

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -103,7 +103,7 @@ import {
 } from './agents/dream-runner.js'
 import { createDreamReader } from './cp/dream-reader.js'
 import { createLocalSkillsReader } from './cp/local-skills-reader.js'
-import { routeRules, type RouteVia } from './router/routing-table.js'
+import { mentionedAgents, participantAgents, routeRules, type RouteVia } from './router/routing-table.js'
 import { parseCommand, type AgentCommand } from './commands/commands.js'
 import {
   rulesFromAgent,
@@ -5762,6 +5762,9 @@ export class Daemon {
     if (!this.agentConversationAdmits(routed.agentId, msg)) {
       return transcriptOnly(`${routed.agentId} is off in this conversation`)
     }
+    // Same conversation rule as the human path: everyone already in the thread hears it.
+    // Bounded by the SAME hop budget — each peer is one more edge of this agent call.
+    this.fanOutToThreadPeers(msg, this.mergedRulesForSource(srcIntegrationIds), routed.agentId, srcIntegrationIds)
     const outcome = this.activateVerifiedAgentTarget(msg, verified, routed.agentId, deliveryHopCount, 'implicit')
     if (outcome) {
       this.log.info(
@@ -6146,9 +6149,55 @@ export class Daemon {
         }
       }
     }
+    // A thread is a CONVERSATION, so everyone in it hears what is said — not just the one
+    // agent arbitration picked. Being @-mentioned is what JOINS an agent (at the root or
+    // mid-thread); after that it stays a participant and receives every later message,
+    // from a human or from another agent alike. Arbitration above still chooses the
+    // PRIMARY target (it owns the returned handle, thread promotion, and the mention
+    // trigger); this delivers the same message to the rest of the room.
+    this.fanOutToThreadPeers(msg, routingRules, result.agentId, srcIntegrationIds)
     const { handle, turn } = this.evaluationDispatchHandle(result.agentId, msg, result.integrationId)
     turn.catch((err) => this.log.error(`dispatch failed for agent "${result.agentId}": ${formatErr(err)}`))
     return { kind: 'dispatched', handle }
+  }
+
+  /**
+   * Deliver `msg` to every OTHER agent already in its thread (and to any further agent the
+   * body named), beyond the one arbitration selected.
+   *
+   * Each peer is an independent delivery: its own session key, its own `!stop` mute, its
+   * own Off fence, its own inbox row. Best-effort by design — a peer that cannot take the
+   * message must never fail the primary target's turn.
+   */
+  private fanOutToThreadPeers(
+    msg: NormalizedMessage,
+    rules: RoutingRule[],
+    primaryAgentId: string,
+    srcIntegrationIds?: string[]
+  ): void {
+    const thread = msg.thread
+    if (!thread) return
+    const participants = this.sessions.threadParticipants(msg.channel, thread, msg.transportScope)
+    const peers = new Set([
+      ...participantAgents(msg, rules, participants, primaryAgentId),
+      ...mentionedAgents(msg, rules, primaryAgentId)
+    ])
+    for (const agentId of peers) {
+      if (agentId === primaryAgentId) continue
+      if (!this.agents.has(agentId) || this.drainingAgents.has(agentId)) continue
+      const rule = rules.find((r) => r.agentId === agentId)
+      if (!rule) continue
+      // A muted peer stays muted: `!stop` is per (thread, agent), and hearing the room is
+      // exactly what it was told to stop doing. It still records for later catch-up.
+      const muteKey = sessionKey(msg.platform, msg.channel, thread, agentId, msg.transportScope)
+      if (this.isSessionMuted(muteKey)) {
+        this.recordObservedInbound(msg, agentId, this.cfg.features.turnFinalContextRefresh)
+        continue
+      }
+      const { turn } = this.evaluationDispatchHandle(agentId, msg, rule.integrationId)
+      turn.catch((err) => this.log.error(`thread fan-out failed for agent "${agentId}": ${formatErr(err)}`))
+    }
+    void srcIntegrationIds
   }
 
   /**

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -103,7 +103,13 @@ import {
 } from './agents/dream-runner.js'
 import { createDreamReader } from './cp/dream-reader.js'
 import { createLocalSkillsReader } from './cp/local-skills-reader.js'
-import { mentionedAgents, participantAgents, routeRules, type RouteVia } from './router/routing-table.js'
+import {
+  automaticAgents,
+  mentionedAgents,
+  participantAgents,
+  routeRules,
+  type RouteVia
+} from './router/routing-table.js'
 import { parseCommand, type AgentCommand } from './commands/commands.js'
 import {
   rulesFromAgent,
@@ -5616,7 +5622,7 @@ export class Daemon {
    *      negative depth is transcript-only and must never coerce to zero).
    *
    * Per-edge policy is NOT decided here — it is per-target, and §6 evaluates it while
-   * walking the recipient set.
+   * walking the conversation's independently selected participants.
    *
    * Only `final` events verify. A `streaming` post may hold a prefix of the answer, and
    * routing it would prompt the target with half a message (§5.4).
@@ -5665,9 +5671,10 @@ export class Daemon {
    * A SEPARATE ladder from the human one because the checks differ, not the rungs: an
    * agent message carries a hop budget, a directional call policy, and an exactly-once
    * rendezvous that a human message has none of, and it can never issue control commands.
-   * Every ordinary reply ends up in the same rungs a human message would
-   * (`routeAgentMessageImplicitly`) — the mention in its body selects nobody. The single
-   * exception is the paired `toAgent + channel` half, whose target the tool named.
+   * Every ordinary reply ends up in the same participant selection a human message would
+   * (`routeAgentMessageImplicitly`): mentions can join peers, and affinity or automatic
+   * rules can select existing peers independently. The single exception is the paired
+   * `toAgent + channel` half, whose target the tool named.
    *
    * Every outcome that is not a dispatch records the message and returns — "transcript
    * only" in the design's terms. The conversation still SEES what the agent said; it
@@ -5704,27 +5711,26 @@ export class Daemon {
       }
       return firstPaired ?? transcriptOnly('paired agent call produced no observation')
     }
-    // The recipient set the author resolved is NOT consulted for delivery. A verified
-    // agent message goes to whoever the ordinary ladder selects in this conversation, the
-    // author excluded — the same thing that happens when it names nobody, which is the
-    // common case anyway. The mention in the body is for the humans reading the thread and
-    // for the target's own judgement; it is not an address this layer acts on.
+    // The recipient set the author resolved is NOT authoritative for delivery. A verified
+    // agent message goes to every independently admitted conversation participant, with
+    // the author excluded. Provider mentions are only one way to join a peer; affinity and
+    // automatic rules keep already-participating peers in later unmentioned turns.
     //
     // Deliberate, and it is the point of the rework: agents in one thread see each other's
     // replies and decide for themselves whether to answer (`NO_RESPONSE` is how they
-    // decline). Selecting recipients here made delivery depend on resolving a `<@U…>` token
-    // through the collaboration directory, so a directory that could not resolve it — a
-    // missing `botUserId`, a shared-bot flag, a slug the model did not repeat — silenced
-    // the conversation instead of merely losing precision. Every edge is still checked
+    // decline). Treating the author's recipients as the complete delivery set made
+    // continuation depend on repeating a `<@U…>` token and resolving it through the
+    // collaboration directory, so missing provider identity data could silence the
+    // conversation instead of merely losing precision. Every edge is still checked
     // below: author exclusion, call policy, the conversation fence, hop budget, and
     // exactly-once admission are properties of the EDGE, not of how it was addressed.
     return this.routeAgentMessageImplicitly(msg, verified, deliveryHopCount, srcIntegrationIds)
   }
 
   /**
-   * §2.3: an agent message that names nobody routes through the SAME ladder a human
-   * message takes — thread affinity, DM, keyword, channel `auto`, default agent — with
-   * the author excluded.
+   * §2.3: an ordinary agent message uses the same implicit rungs a human continuation
+   * does — thread affinity, DM, keyword, channel `auto`, default agent — with the author
+   * excluded. Its mentions may join peers, but do not turn agent traffic explicit.
    *
    * This is what makes agents conversational participants rather than things that only
    * respond when addressed by name. It also means a multi-agent conversation is bounded
@@ -5747,36 +5753,35 @@ export class Daemon {
       this.log.debug(`routing: agent-authored ${msg.msgId} is transcript-only (${why})`)
       return { kind: 'rejected', reason: 'unrouted' }
     }
+    const rules = this.mergedRulesForSource(srcIntegrationIds)
     const routed = routeRules(
       msg,
-      this.mergedRulesForSource(srcIntegrationIds),
+      rules,
       (c, t) => this.sessions.threadOwner(c, t, msg.transportScope),
       undefined,
       verified.authorAgentId
     )
-    if (!routed) return transcriptOnly('no implicit rung matched')
-    if (!this.agents.has(routed.agentId)) return transcriptOnly(`${routed.agentId} is not local`)
-    if (!this.cpCollab.admits(verified.authorAgentId, routed.agentId)) {
-      return transcriptOnly(`call policy excludes ${verified.authorAgentId} -> ${routed.agentId}`)
-    }
-    if (!this.agentConversationAdmits(routed.agentId, msg)) {
-      return transcriptOnly(`${routed.agentId} is off in this conversation`)
-    }
-    // Same conversation rule as the human path: everyone already in the thread hears it.
-    // Bounded by the SAME hop budget — each peer is one more edge of this agent call.
-    this.fanOutToThreadPeers(msg, this.mergedRulesForSource(srcIntegrationIds), routed.agentId, {
-      authorAgentId: verified.authorAgentId,
+    // A primary rung is useful for ordinary single-target arbitration, but it is not a
+    // precondition for conversation delivery. Two mention-only agents can both already
+    // be in the room while `threadOwner` deliberately returns null; dropping here would
+    // make the next unmentioned sentence disappear. Admit the primary (if any) and every
+    // other participant as independent edges through the same durable rendezvous.
+    const primary = routed
+      ? this.activateVerifiedAgentTarget(msg, verified, routed.agentId, deliveryHopCount, 'implicit')
+      : undefined
+    const peers = this.fanOutToThreadPeers(msg, rules, routed?.agentId, {
+      verified,
       hopCount: deliveryHopCount
     })
-    const outcome = this.activateVerifiedAgentTarget(msg, verified, routed.agentId, deliveryHopCount, 'implicit')
-    if (outcome) {
+    const dispatched = primary?.kind === 'dispatched' ? primary : peers.find((outcome) => outcome.kind === 'dispatched')
+    if (dispatched) {
       this.log.info(
         `routing: agent-authored ${msg.msgId} continued the conversation "${verified.authorAgentId}" → ` +
-          `"${routed.agentId}" via ${routed.via} (hop ${deliveryHopCount})`
+          `participants (hop ${deliveryHopCount})`
       )
-      return outcome
+      return dispatched
     }
-    return transcriptOnly(`${routed.agentId} produced no activation`)
+    return transcriptOnly(routed ? `${routed.agentId} and its peers produced no activation` : 'no participant admitted')
   }
 
   /**
@@ -5857,8 +5862,19 @@ export class Daemon {
     // ladder returns before `onInboundOutcome`'s own mute gate; without it `!stop` would
     // silence humans while agents kept waking each other, which is the one situation the
     // command exists for now that the loop protections are the ordinary terminator.
+    if (targetAgentId === verified.authorAgentId) return undefined
+    if (!this.agents.has(targetAgentId) || this.drainingAgents.has(targetAgentId)) return undefined
+    if (!this.cpCollab.admits(verified.authorAgentId, targetAgentId)) {
+      this.log.debug(`routing: agent edge ${verified.authorAgentId} → ${targetAgentId} denied by call policy`)
+      return undefined
+    }
+    if (!this.agentConversationAdmits(targetAgentId, msg)) {
+      this.log.debug(`routing: agent edge ${verified.authorAgentId} → ${targetAgentId} is off in this conversation`)
+      return undefined
+    }
     const platformMessageId = slackTsFromMsgId(msg.msgId)
     const integrationId = this.resolveCpAgent(targetAgentId, 'slack')?.integrationId
+    if (!integrationId) return undefined
     // The key's transport component is the TARGET's own reply scope — NOT the scope of
     // the connection that happened to observe the post. Both halves of a paired delivery
     // must compute the same key, and the internal wake can only know the target's scope
@@ -6071,7 +6087,14 @@ export class Daemon {
     }
 
     const result = routeRules(msg, routingRules, (c, t) => this.sessions.threadOwner(c, t, msg.transportScope))
+    // Participant delivery is independent of whether the single-target ladder found an
+    // owner. In a real multi-agent thread `threadOwner` intentionally returns null; the
+    // joined agents (and every newly mentioned or channel-auto agent) still hear the
+    // message as separate deliveries with target-specific trigger/mute handling.
+    const peerOutcomes = msg.sender.isBot ? [] : this.fanOutToThreadPeers(msg, routingRules, result?.agentId)
+    const dispatchedPeer = peerOutcomes.find((outcome) => outcome.kind === 'dispatched')
     if (!result) {
+      if (dispatchedPeer) return dispatchedPeer
       // §8.5: a message that activates no agent (a human @human reply, or one
       // addressed to another bot) must still enter the transcript when a session
       // is live in this thread, so that agent "catches up" on it when next
@@ -6089,32 +6112,38 @@ export class Daemon {
       )
       return { kind: 'rejected', reason: 'unrouted' }
     }
+    const targetMsg = { ...msg }
+    if (result.via === 'mention') targetMsg.trigger = 'mention'
+    else delete targetMsg.trigger
     // Observation precedes activation gates and queue admission. A clarification
     // arriving while this logical thread is busy must be visible to the running
     // turn's final refresh even though its own SessionManager.handle() has not begun.
-    if (this.cfg.features.turnFinalContextRefresh) this.recordObservedInbound(msg, result.agentId)
-    // Preserve the router's trusted self-mention match for prompt assembly. The raw
-    // platform text contains only an opaque id (`<@U…>` on Slack); without this cause the
-    // model cannot know that id is the bot identity bound to the selected agent.
-    if (result.via === 'mention') msg.trigger = 'mention'
+    if (this.cfg.features.turnFinalContextRefresh) this.recordObservedInbound(targetMsg, result.agentId)
     // Agent-scoped drain (scope:agent): this agent is being reclaimed/rebalanced —
     // drop new turns for it while its in-flight turns finish.
     if (this.drainingAgents.has(result.agentId)) {
       this.log.debug(`routing: dropping ${msg.msgId} for agent "${result.agentId}" (draining)`)
+      if (dispatchedPeer) return dispatchedPeer
       return { kind: 'rejected', reason: 'gated' }
     }
     // `!stop` thread mute: while muted, implicit routing (thread affinity / keyword /
     // auto / dm) never dispatches — only an explicit @mention does, and it clears the
     // mute. Muted-thread traffic still enters the transcript (recordUnrouted) so the
     // agent catches up on it when re-activated (§8.5).
-    const muteKey = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, result.agentId, msg.transportScope)
+    const muteKey = sessionKey(
+      targetMsg.platform,
+      targetMsg.channel,
+      targetMsg.thread ?? targetMsg.msgId,
+      result.agentId,
+      targetMsg.transportScope
+    )
     if (this.isSessionMuted(muteKey)) {
       if (result.via !== 'mention') {
-        this.recordUnrouted(msg)
+        this.recordUnrouted(targetMsg)
         this.log.debug(
           `routing: dropping ${msg.msgId} for agent "${result.agentId}" (muted by !stop; awaiting @mention)`
         )
-        return { kind: 'rejected', reason: 'gated' }
+        return dispatchedPeer ?? { kind: 'rejected', reason: 'gated' }
       }
       this.setSessionMuted(muteKey, false)
       this.log.info(`routing: agent "${result.agentId}" un-muted in ch=${msg.channel} (explicit @mention)`)
@@ -6124,9 +6153,9 @@ export class Daemon {
     // openThreadForTopLevel — Discord): open a thread off it first, then dispatch
     // into that thread (Slack-parity). Async (a REST call), so it runs on its own
     // path; dispatch is fire-and-forget either way.
-    const promotion = threadPromotionFor(msg.platform)
-    if (promotion?.wants(msg)) {
-      const topLevel = this.dispatchPromotedTopLevel(promotion, result.agentId, msg, result.integrationId)
+    const promotion = threadPromotionFor(targetMsg.platform)
+    if (promotion?.wants(targetMsg)) {
+      const topLevel = this.dispatchPromotedTopLevel(promotion, result.agentId, targetMsg, result.integrationId)
       topLevel.catch((err) => this.log.error(`dispatch failed for agent "${result.agentId}": ${formatErr(err)}`))
       // The re-threaded dispatch owns its own admission; expose a coarse handle
       // (virtual ingress never produces promotion-seeking messages).
@@ -6137,11 +6166,11 @@ export class Daemon {
             admitted: true,
             agentId: result.agentId,
             sessionKey: sessionKey(
-              msg.platform,
-              msg.channel,
-              msg.thread ?? msg.msgId,
+              targetMsg.platform,
+              targetMsg.channel,
+              targetMsg.thread ?? targetMsg.msgId,
               result.agentId,
-              msg.transportScope
+              targetMsg.transportScope
             ),
             turnId: stableTurnId(result.agentId, msg)
           }),
@@ -6152,14 +6181,7 @@ export class Daemon {
         }
       }
     }
-    // A thread is a CONVERSATION, so everyone in it hears what is said — not just the one
-    // agent arbitration picked. Being @-mentioned is what JOINS an agent (at the root or
-    // mid-thread); after that it stays a participant and receives every later message,
-    // from a human or from another agent alike. Arbitration above still chooses the
-    // PRIMARY target (it owns the returned handle, thread promotion, and the mention
-    // trigger); this delivers the same message to the rest of the room.
-    this.fanOutToThreadPeers(msg, routingRules, result.agentId)
-    const { handle, turn } = this.evaluationDispatchHandle(result.agentId, msg, result.integrationId)
+    const { handle, turn } = this.evaluationDispatchHandle(result.agentId, targetMsg, result.integrationId)
     turn.catch((err) => this.log.error(`dispatch failed for agent "${result.agentId}": ${formatErr(err)}`))
     return { kind: 'dispatched', handle }
   }
@@ -6175,56 +6197,71 @@ export class Daemon {
   private fanOutToThreadPeers(
     msg: NormalizedMessage,
     rules: RoutingRule[],
-    primaryAgentId: string,
+    primaryAgentId?: string,
     /** Present when the message is agent-authored. Every peer is then one more EDGE of
-     *  that agent call and must be treated as one: checked against directional call
-     *  policy, and given the same trusted depth so `MAX_AGENT_CALL_HOPS` accumulates.
-     *  Absent ⇒ a human root turn, which has neither a caller nor a depth. */
-    agentCall?: { authorAgentId: string; hopCount: number }
-  ): void {
+     *  that agent call and must take the same durable policy/provenance/hop path as the
+     *  arbitration primary. Absent ⇒ a human root turn, with per-target mention state. */
+    agentCall?: {
+      verified: NonNullable<ReturnType<Daemon['verifyAgentAuthor']>>
+      hopCount: number
+    }
+  ): Array<{ kind: 'rejected'; reason: DeliveryRejectionReason } | { kind: 'dispatched'; handle: DeliveryHandle }> {
     const thread = msg.thread
-    if (!thread) return
-    const participants = this.sessions.threadParticipants(msg.channel, thread, msg.transportScope)
+    const participants = thread ? this.sessions.threadParticipants(msg.channel, thread, msg.transportScope) : []
+    const explicitlyMentioned = new Set(mentionedAgents(msg, rules, primaryAgentId))
     const peers = new Set([
       ...participantAgents(msg, rules, participants, primaryAgentId),
-      ...mentionedAgents(msg, rules, primaryAgentId)
+      ...explicitlyMentioned,
+      ...automaticAgents(msg, rules, primaryAgentId)
     ])
+    const outcomes: Array<
+      { kind: 'rejected'; reason: DeliveryRejectionReason } | { kind: 'dispatched'; handle: DeliveryHandle }
+    > = []
     for (const agentId of peers) {
       if (agentId === primaryAgentId) continue
+      if (agentCall?.verified.authorAgentId === agentId) continue
       if (!this.agents.has(agentId) || this.drainingAgents.has(agentId)) continue
       const rule = rules.find((r) => r.agentId === agentId)
       if (!rule) continue
-      // Being already in the room is not consent to be called. Every author→peer edge
-      // passes the SAME directional policy the primary target's edge does — a peer whose
-      // inbound policy excludes this author does not hear it merely by having a session.
-      if (agentCall && !this.cpCollab.admits(agentCall.authorAgentId, agentId)) {
-        this.log.debug(`routing: thread fan-out ${msg.msgId} → "${agentId}" denied by call policy`)
+
+      if (agentCall) {
+        // Agent-authored peers use the exact same edge as the arbitration primary: policy,
+        // Off, target-scoped mute, durable activation claim, trusted platform provenance,
+        // and hop metadata all live in `activateVerifiedAgentTarget`. A body mention may
+        // join a peer, but agent traffic remains implicit and therefore cannot clear a
+        // human's `!stop` latch.
+        const outcome = this.activateVerifiedAgentTarget(
+          msg,
+          agentCall.verified,
+          agentId,
+          agentCall.hopCount,
+          'implicit'
+        )
+        if (outcome) outcomes.push(outcome)
         continue
       }
-      // A muted peer stays muted: `!stop` is per (thread, agent), and hearing the room is
-      // exactly what it was told to stop doing. It still records for later catch-up.
-      const muteKey = sessionKey(msg.platform, msg.channel, thread, agentId, msg.transportScope)
+
+      const via: 'mention' | 'implicit' = explicitlyMentioned.has(agentId) ? 'mention' : 'implicit'
+      const targetMsg = { ...msg }
+      if (via === 'mention') targetMsg.trigger = 'mention'
+      else delete targetMsg.trigger
+      if (this.cfg.features.turnFinalContextRefresh) this.recordObservedInbound(targetMsg, agentId)
+      const targetThread = targetMsg.thread ?? targetMsg.msgId
+      const muteKey = sessionKey(targetMsg.platform, targetMsg.channel, targetThread, agentId, targetMsg.transportScope)
       if (this.isSessionMuted(muteKey)) {
-        this.recordObservedInbound(msg, agentId, this.cfg.features.turnFinalContextRefresh)
-        continue
+        if (via === 'implicit') {
+          this.recordObservedInbound(targetMsg, agentId, this.cfg.features.turnFinalContextRefresh)
+          outcomes.push({ kind: 'rejected', reason: 'gated' })
+          continue
+        }
+        this.setSessionMuted(muteKey, false)
+        this.log.info(`routing: agent "${agentId}" un-muted in ch=${msg.channel} (explicit @mention)`)
       }
-      // The depth has to ride the turn, not just the log line: `currentHopCount` reads it
-      // back from the active-turn metadata when this peer stamps its OWN next reply.
-      // Without it a peer reached only by fan-out would report depth 0 forever and the
-      // hop cap — the ordinary terminating condition for these exchanges — would never
-      // accumulate. The delivery id is namespaced per peer so the durable inbox keeps one
-      // replayable row each instead of collapsing them into the first.
-      const callMeta: CallMeta | undefined = agentCall
-        ? {
-            callFrom: agentCall.authorAgentId,
-            platformOrigin: true,
-            hopCount: agentCall.hopCount,
-            deliveryId: `${msg.msgId}#${agentId}`
-          }
-        : undefined
-      const { turn } = this.evaluationDispatchHandle(agentId, msg, rule.integrationId, undefined, callMeta)
+      const { handle, turn } = this.evaluationDispatchHandle(agentId, targetMsg, rule.integrationId)
       turn.catch((err) => this.log.error(`thread fan-out failed for agent "${agentId}": ${formatErr(err)}`))
+      outcomes.push({ kind: 'dispatched', handle })
     }
+    return outcomes
   }
 
   /**
@@ -7066,7 +7103,9 @@ export class Daemon {
     // (an opaque <@U…> token is not otherwise recognizable as "you") and the
     // `!stop` un-mute rule below — without it a muted relay-channel agent could
     // never be woken again.
-    if (!normalized.trigger && conn?.botUserId && normalized.mentionedBots.includes(conn.botUserId)) {
+    if (msg.trustedRouteVia === 'mention') normalized.trigger = 'mention'
+    else if (msg.trustedRouteVia === 'implicit') delete normalized.trigger
+    else if (!normalized.trigger && conn?.botUserId && normalized.mentionedBots.includes(conn.botUserId)) {
       normalized.trigger = 'mention'
     }
     const feishuConn = this.fsConnByIntegration.get(msg.integrationId)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2266,6 +2266,7 @@ export class Daemon {
       text: payload.text,
       mentionedBots: payload.mentions ?? [],
       ...(payload.agentAuthorship !== undefined ? { agentAuthorship: payload.agentAuthorship } : {}),
+      ...(payload.ingressEventTag !== undefined ? { ingressEventTag: payload.ingressEventTag } : {}),
       isDm: payload.isDm ?? false
     }
     // Same source resolution as a live connection callback: all integrations
@@ -5664,9 +5665,9 @@ export class Daemon {
    * A SEPARATE ladder from the human one because the checks differ, not the rungs: an
    * agent message carries a hop budget, a directional call policy, and an exactly-once
    * rendezvous that a human message has none of, and it can never issue control commands.
-   * A response that names nobody still ends up in the same rungs a human message would
-   * (`routeAgentMessageImplicitly`); a response that names somebody activates exactly the
-   * named agents or nobody.
+   * Every ordinary reply ends up in the same rungs a human message would
+   * (`routeAgentMessageImplicitly`) — the mention in its body selects nobody. The single
+   * exception is the paired `toAgent + channel` half, whose target the tool named.
    *
    * Every outcome that is not a dispatch records the message and returns — "transcript
    * only" in the design's terms. The conversation still SEES what the agent said; it

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5689,73 +5689,35 @@ export class Daemon {
     if (deliveryHopCount > MAX_AGENT_CALL_HOPS) {
       return transcriptOnly(`hop_limit: source depth ${verified.sourceHopCount} + 1 exceeds ${MAX_AGENT_CALL_HOPS}`)
     }
-    // Naming NOBODY is the ordinary case — most agent messages do — and it is no longer
-    // the end of the road: the message falls through to the SAME implicit ladder a human
-    // message takes. Naming somebody is an explicit address, and gets an explicit outcome
-    // or none. The test therefore runs BEFORE the author is filtered out: a response whose
-    // only name is its own author has still addressed the conversation explicitly, and
-    // must not be handed to an unrelated peer.
-    if (verified.recipients.length === 0) {
-      // The response named no AGENT — but it may still have addressed a human or another
-      // app, and §2.3 makes any address binding. `routeRules` catches that from
-      // `mentionedBots` when the mention is in this physical message; the author's claim
-      // catches it when the splitter left the mention in an earlier section, which is the
-      // only place that fact still exists by now.
-      if (verified.addressedAnyone && !msg.isDm) return transcriptOnly('addressed someone who is not an agent')
-      return this.routeAgentMessageImplicitly(msg, verified, deliveryHopCount, srcIntegrationIds)
+    // The VISIBLE half of a paired `toAgent + channel` send is the one case whose target
+    // is structured rather than parsed: `sendMessage` named the agent id outright, and the
+    // rendezvous only converges if both halves name the SAME target. Route it to exactly
+    // that agent — picking a different one implicitly would strand the internal wake.
+    if (verified.agentCallDeliveryId) {
+      const paired = verified.recipients.filter((id) => id !== verified.authorAgentId)
+      if (paired.length === 0) return transcriptOnly('paired agent call named no other agent')
+      let firstPaired: { kind: 'rejected'; reason: DeliveryRejectionReason } | undefined
+      for (const targetAgentId of paired) {
+        const outcome = this.activateVerifiedAgentTarget(msg, verified, targetAgentId, deliveryHopCount, 'mention')
+        if (outcome) firstPaired ??= outcome as { kind: 'rejected'; reason: DeliveryRejectionReason }
+      }
+      return firstPaired ?? transcriptOnly('paired agent call produced no observation')
     }
-    // The author can never activate itself (§2.3).
-    const targets = verified.recipients.filter((id) => id !== verified.authorAgentId)
-    if (targets.length === 0) return transcriptOnly('named only its own author')
-
-    // EVERY admissible recipient is activated. One finalized response can address several
-    // agents ("<@A> <@B> please both look"), and stopping at the first would silently drop
-    // the rest — the sender saw one message go out and has no way to learn that only one
-    // reader woke. The returned handle names the first dispatch because the caller's
-    // contract is one outcome per inbound event; the others still ran.
-    let first: { kind: 'dispatched'; handle: DeliveryHandle } | undefined
-    let dispatched = 0
-    for (const targetAgentId of targets) {
-      // Directional call policy, org equality, and the conversation gate are re-checked
-      // HERE rather than inherited from the author's daemon: the sender's snapshot may be
-      // stale or the sender's daemon compromised, and this is the daemon that owns the
-      // target (agent-collaboration §2.5 #4, terminal verification).
-      if (!this.agents.has(targetAgentId)) continue
-      if (!this.cpCollab.admits(verified.authorAgentId, targetAgentId)) {
-        this.log.debug(`routing: agent-authored ${msg.msgId} → "${targetAgentId}" denied by call policy`)
-        continue
-      }
-      if (!this.cpCollab.resolve(verified.orgId, msg.platform, msg.channel, targetAgentId)) {
-        this.log.debug(`routing: agent-authored ${msg.msgId} → "${targetAgentId}" is not in this conversation`)
-        continue
-      }
-      // The per-conversation trigger (product-conventions "Per-channel trigger"): Off means
-      // the agent does not respond there AT ALL — explicitly including an @-mention. The
-      // human ladder enforces this through its scope filter (`mutedChannels`) and the
-      // relay's last-hop `gatedAdmission`; this ladder bypasses both, so it must apply the
-      // rule itself or an agent mention would become the one way into a silenced channel.
-      if (!this.agentConversationAdmits(targetAgentId, msg)) {
-        this.log.debug(`routing: agent-authored ${msg.msgId} → "${targetAgentId}" is off in this conversation`)
-        continue
-      }
-      const outcome = this.activateVerifiedAgentTarget(msg, verified, targetAgentId, deliveryHopCount, 'mention')
-      if (outcome?.kind === 'dispatched') {
-        dispatched += 1
-        first ??= outcome
-      }
-    }
-    if (first) {
-      if (dispatched > 1) {
-        this.log.info(`routing: agent-authored ${msg.msgId} activated ${dispatched} recipients`)
-      }
-      return first
-    }
-    // Every named recipient was refused (policy, gate, not local). This stays transcript-
-    // only rather than falling through: the implicit ladder would pick a DIFFERENT agent,
-    // and "the one you asked for is off here, so here is someone else" is not a
-    // substitution the author consented to — least of all when the refusal was the
-    // conversation's own Off fence. Same rule the relay applies (`forwardVerifiedAgentMessage`).
-    return transcriptOnly('every named recipient was refused')
+    // The recipient set the author resolved is NOT consulted for delivery. A verified
+    // agent message goes to whoever the ordinary ladder selects in this conversation, the
+    // author excluded — the same thing that happens when it names nobody, which is the
+    // common case anyway. The mention in the body is for the humans reading the thread and
+    // for the target's own judgement; it is not an address this layer acts on.
+    //
+    // Deliberate, and it is the point of the rework: agents in one thread see each other's
+    // replies and decide for themselves whether to answer (`NO_RESPONSE` is how they
+    // decline). Selecting recipients here made delivery depend on resolving a `<@U…>` token
+    // through the collaboration directory, so a directory that could not resolve it — a
+    // missing `botUserId`, a shared-bot flag, a slug the model did not repeat — silenced
+    // the conversation instead of merely losing precision. Every edge is still checked
+    // below: author exclusion, call policy, the conversation fence, hop budget, and
+    // exactly-once admission are properties of the EDGE, not of how it was addressed.
+    return this.routeAgentMessageImplicitly(msg, verified, deliveryHopCount, srcIntegrationIds)
   }
 
   /**
@@ -12671,9 +12633,13 @@ export class Daemon {
         // outcome, so without this a response that addressed a peer but resolved to no
         // agent — a stale or unpopulated mention directory — is indistinguishable from
         // one that addressed nobody, on either side of the wire.
+        const mentionDir = orgId ? this.cpCollab.mentionDirectory(orgId, p.platform, p.channel) : []
         this.log.debug(
           `slack: finalizing response ${p.responseId} for "${p.agentId}" — recipients=[${recipients.join(',')}] ` +
-            `addressedAnyone=${addressedAnyone} directory=${orgId ? this.cpCollab.mentionDirectory(orgId, p.platform, p.channel).length : 0}`
+            `addressedAnyone=${addressedAnyone} text=${JSON.stringify(p.replyText.slice(0, 120))} ` +
+            `directory=[${mentionDir
+              .map((e) => `${e.agentId.slice(0, 8)}:${e.botUserId ?? 'NO-BOT-USER-ID'}${e.botShared ? '(shared)' : ''}`)
+              .join(' ')}]`
         )
         await finalizeSlackResponse(p.conn as SlackConnection, p, recipients, addressedAnyone, (m) => this.log.debug(m))
       }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2198,7 +2198,12 @@ export class Daemon {
     /** Extra dispatch options for the caller's delivery contract (today: `requireDurable`
      *  for a rendezvous-backed activation, whose record must not go terminal for a turn
      *  that was never durably queued). */
-    dispatchOpts?: { requireDurable?: boolean }
+    dispatchOpts?: {
+      requireDurable?: boolean
+      /** Stable target-scoped inbox id for one physical event delivered to
+       * several local agents. The provider msgId remains transcript identity. */
+      deliveryId?: string
+    }
   ): { handle: DeliveryHandle; turn: Promise<string | null> } {
     const turnId = stableTurnId(agentId, msg)
     let settleAdmission!: (admission: DeliveryAdmission) => void
@@ -6181,7 +6186,14 @@ export class Daemon {
         }
       }
     }
-    const { handle, turn } = this.evaluationDispatchHandle(result.agentId, targetMsg, result.integrationId)
+    const { handle, turn } = this.evaluationDispatchHandle(
+      result.agentId,
+      targetMsg,
+      result.integrationId,
+      undefined,
+      undefined,
+      { deliveryId: `${stableMessageId(targetMsg)}#${result.agentId}` }
+    )
     turn.catch((err) => this.log.error(`dispatch failed for agent "${result.agentId}": ${formatErr(err)}`))
     return { kind: 'dispatched', handle }
   }
@@ -6209,6 +6221,17 @@ export class Daemon {
     const thread = msg.thread
     const participants = thread ? this.sessions.threadParticipants(msg.channel, thread, msg.transportScope) : []
     const explicitlyMentioned = new Set(mentionedAgents(msg, rules, primaryAgentId))
+    // A verified final carries the exact agent ids resolved before provider
+    // splitting/echo. They are joins, not the complete delivery set: include them
+    // so a shared-bot peer with an unscoped slug route can enter the room even when
+    // provider bot-user metadata alone cannot map the mention back to that agent.
+    if (agentCall) {
+      for (const agentId of agentCall.verified.recipients) {
+        if (agentId !== primaryAgentId && agentId !== agentCall.verified.authorAgentId) {
+          explicitlyMentioned.add(agentId)
+        }
+      }
+    }
     const peers = new Set([
       ...participantAgents(msg, rules, participants, primaryAgentId),
       ...explicitlyMentioned,
@@ -6257,7 +6280,14 @@ export class Daemon {
         this.setSessionMuted(muteKey, false)
         this.log.info(`routing: agent "${agentId}" un-muted in ch=${msg.channel} (explicit @mention)`)
       }
-      const { handle, turn } = this.evaluationDispatchHandle(agentId, targetMsg, rule.integrationId)
+      const { handle, turn } = this.evaluationDispatchHandle(
+        agentId,
+        targetMsg,
+        rule.integrationId,
+        undefined,
+        undefined,
+        { deliveryId: `${stableMessageId(targetMsg)}#${agentId}` }
+      )
       turn.catch((err) => this.log.error(`thread fan-out failed for agent "${agentId}": ${formatErr(err)}`))
       outcomes.push({ kind: 'dispatched', handle })
     }
@@ -11230,6 +11260,9 @@ export class Daemon {
        * accepted ACK. Ordinary interactive dispatch keeps best-effort inbox
        * persistence for backward compatibility. */
       requireDurable?: boolean
+      /** Stable target-scoped inbox id for a physical event delivered to more
+       * than one agent. It does not replace the provider transcript identity. */
+      deliveryId?: string
       /** Startup replay deliberately adopts the row already read from SQLite. */
       adoptExistingInbox?: boolean
       /** Synchronous admission barrier: called after the durable row is owned,
@@ -11423,7 +11456,7 @@ export class Daemon {
           persistence = this.persistInbox(entry, key, {
             required: opts?.requireDurable,
             adoptExisting: opts?.adoptExistingInbox,
-            existingId: opts?.inboxReplayId
+            existingId: opts?.inboxReplayId ?? opts?.deliveryId
           })
         } catch (err) {
           settleAdmission({ accepted: false, reason: 'durability' })
@@ -11457,7 +11490,7 @@ export class Daemon {
         persistence = this.persistInbox(entry, key, {
           required: opts?.requireDurable,
           adoptExisting: opts?.adoptExistingInbox,
-          existingId: opts?.inboxReplayId
+          existingId: opts?.inboxReplayId ?? opts?.deliveryId
         })
       } catch (err) {
         settleAdmission({ accepted: false, reason: 'durability' })

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5764,7 +5764,10 @@ export class Daemon {
     }
     // Same conversation rule as the human path: everyone already in the thread hears it.
     // Bounded by the SAME hop budget — each peer is one more edge of this agent call.
-    this.fanOutToThreadPeers(msg, this.mergedRulesForSource(srcIntegrationIds), routed.agentId, srcIntegrationIds)
+    this.fanOutToThreadPeers(msg, this.mergedRulesForSource(srcIntegrationIds), routed.agentId, {
+      authorAgentId: verified.authorAgentId,
+      hopCount: deliveryHopCount
+    })
     const outcome = this.activateVerifiedAgentTarget(msg, verified, routed.agentId, deliveryHopCount, 'implicit')
     if (outcome) {
       this.log.info(
@@ -6155,7 +6158,7 @@ export class Daemon {
     // from a human or from another agent alike. Arbitration above still chooses the
     // PRIMARY target (it owns the returned handle, thread promotion, and the mention
     // trigger); this delivers the same message to the rest of the room.
-    this.fanOutToThreadPeers(msg, routingRules, result.agentId, srcIntegrationIds)
+    this.fanOutToThreadPeers(msg, routingRules, result.agentId)
     const { handle, turn } = this.evaluationDispatchHandle(result.agentId, msg, result.integrationId)
     turn.catch((err) => this.log.error(`dispatch failed for agent "${result.agentId}": ${formatErr(err)}`))
     return { kind: 'dispatched', handle }
@@ -6173,7 +6176,11 @@ export class Daemon {
     msg: NormalizedMessage,
     rules: RoutingRule[],
     primaryAgentId: string,
-    srcIntegrationIds?: string[]
+    /** Present when the message is agent-authored. Every peer is then one more EDGE of
+     *  that agent call and must be treated as one: checked against directional call
+     *  policy, and given the same trusted depth so `MAX_AGENT_CALL_HOPS` accumulates.
+     *  Absent ⇒ a human root turn, which has neither a caller nor a depth. */
+    agentCall?: { authorAgentId: string; hopCount: number }
   ): void {
     const thread = msg.thread
     if (!thread) return
@@ -6187,6 +6194,13 @@ export class Daemon {
       if (!this.agents.has(agentId) || this.drainingAgents.has(agentId)) continue
       const rule = rules.find((r) => r.agentId === agentId)
       if (!rule) continue
+      // Being already in the room is not consent to be called. Every author→peer edge
+      // passes the SAME directional policy the primary target's edge does — a peer whose
+      // inbound policy excludes this author does not hear it merely by having a session.
+      if (agentCall && !this.cpCollab.admits(agentCall.authorAgentId, agentId)) {
+        this.log.debug(`routing: thread fan-out ${msg.msgId} → "${agentId}" denied by call policy`)
+        continue
+      }
       // A muted peer stays muted: `!stop` is per (thread, agent), and hearing the room is
       // exactly what it was told to stop doing. It still records for later catch-up.
       const muteKey = sessionKey(msg.platform, msg.channel, thread, agentId, msg.transportScope)
@@ -6194,10 +6208,23 @@ export class Daemon {
         this.recordObservedInbound(msg, agentId, this.cfg.features.turnFinalContextRefresh)
         continue
       }
-      const { turn } = this.evaluationDispatchHandle(agentId, msg, rule.integrationId)
+      // The depth has to ride the turn, not just the log line: `currentHopCount` reads it
+      // back from the active-turn metadata when this peer stamps its OWN next reply.
+      // Without it a peer reached only by fan-out would report depth 0 forever and the
+      // hop cap — the ordinary terminating condition for these exchanges — would never
+      // accumulate. The delivery id is namespaced per peer so the durable inbox keeps one
+      // replayable row each instead of collapsing them into the first.
+      const callMeta: CallMeta | undefined = agentCall
+        ? {
+            callFrom: agentCall.authorAgentId,
+            platformOrigin: true,
+            hopCount: agentCall.hopCount,
+            deliveryId: `${msg.msgId}#${agentId}`
+          }
+        : undefined
+      const { turn } = this.evaluationDispatchHandle(agentId, msg, rule.integrationId, undefined, callMeta)
       turn.catch((err) => this.log.error(`thread fan-out failed for agent "${agentId}": ${formatErr(err)}`))
     }
-    void srcIntegrationIds
   }
 
   /**

--- a/packages/daemon/src/evaluation/environment.ts
+++ b/packages/daemon/src/evaluation/environment.ts
@@ -67,6 +67,10 @@ export interface EvaluationPlatformPayload {
    *  would surface it (send-message-routing-rework.md §4/§8.1) — the daemon's
    *  ingress promotes it only after full verification. */
   agentAuthorship?: AgentAuthorshipClaim
+  /** The arrival tag a real normalizer sets on a response-FINALIZATION event, so a
+   *  fixture reproduces the production shape: one Slack message, two arrivals, told
+   *  apart here rather than by mangling the msgId (which also carries the platform ts). */
+  ingressEventTag?: string
   isDm?: boolean
 }
 

--- a/packages/daemon/src/router/routing-table.ts
+++ b/packages/daemon/src/router/routing-table.ts
@@ -72,6 +72,39 @@ const pickRule = (r: RoutingRule, via: RouteVia) => ({ agentId: r.agentId, integ
  * wake itself. Set only after the caller has VERIFIED authorship — an unverified bot,
  * including a third-party one, still stops at the explicit-mention rung below.
  */
+/**
+ * Every agent this connection serves that the message's mentions actually NAME.
+ *
+ * `routeRules` returns one primary target because its callers need one; this returns the
+ * whole named set, because a mention is a JOIN and a body can name several agents. Using
+ * it removes the only place mention handling depended on which rule `find` saw first —
+ * the shape that made a shared bot resolve the same event differently.
+ */
+export function mentionedAgents(msg: NormalizedMessage, rules: RoutingRule[], exclude?: string): string[] {
+  if (msg.mentionedBots.length === 0) return []
+  const named = new Set<string>()
+  for (const r of rules) {
+    if (r.match.kind !== 'mention' || !scopeMatches(r, msg)) continue
+    if (r.botUserId === '' || !msg.mentionedBots.includes(r.botUserId)) continue
+    if (r.agentId !== exclude) named.add(r.agentId)
+  }
+  return [...named]
+}
+
+/** Agents this connection serves that are ALREADY in the thread, minus `exclude`. Scope
+ *  (including the Off fence) is applied here so a participant in a silenced channel is
+ *  not revived by conversation it can no longer take part in. */
+export function participantAgents(
+  msg: NormalizedMessage,
+  rules: RoutingRule[],
+  participants: readonly string[],
+  exclude?: string
+): string[] {
+  if (participants.length === 0) return []
+  const servable = new Set(rules.filter((r) => scopeMatches(r, msg)).map((r) => r.agentId))
+  return participants.filter((id) => id !== exclude && servable.has(id))
+}
+
 export function routeRules(
   msg: NormalizedMessage,
   rules: RoutingRule[],
@@ -99,6 +132,12 @@ export function routeRules(
   // A third-party Slack bot may explicitly address an agent. Bot-authored traffic
   // never falls through to DM/thread/keyword/auto; AgentConnect-managed bot apps are
   // removed by the daemon before this pure routing boundary.
+  //
+  // A mention JOINS an agent to this thread — it does not pick between agents. The
+  // difference matters on a bot serving several agent routes: `mentionedAgents` below
+  // returns every rule the body actually named, so nothing depends on which one `find`
+  // happened to see first, and everyone already in the thread receives the message
+  // regardless (`threadParticipants`).
   if (mention && (!msg.sender.isBot || msg.platform === 'slack')) return pickRule(mention, 'mention')
   // A VERIFIED AgentConnect author continues into the implicit rungs; every other bot
   // still stops here. That difference is the whole of §2.3: we know exactly which agent

--- a/packages/daemon/src/router/routing-table.ts
+++ b/packages/daemon/src/router/routing-table.ts
@@ -111,10 +111,13 @@ export function routeRules(
   // A one-to-one DM is already addressed to this bot, though, so mentioning the bot (or
   // another participant) must not suppress its dm rule. Group DMs are channel-like and
   // normalize with isDm=false, so they remain mention-gated here.
-  // …but an agent message that names SOMEONE (a human, another app) is deliberate
-  // addressing, and letting thread affinity claim it would route it to whoever happens
-  // to own the thread instead of to nobody. Verified agents follow the same rule.
-  if (!msg.isDm && msg.mentionedBots.length > 0) return null
+  //
+  // A VERIFIED agent author is exempt: its peers are meant to see what it said and judge
+  // for themselves whether to answer, so a `<@…>` aimed at anyone — a human, another app,
+  // a peer whose token this directory cannot resolve — must not silence the conversation.
+  // Unverified traffic keeps the old rule, because for it an unresolved mention really is
+  // "addressed to someone else".
+  if (!msg.isDm && msg.mentionedBots.length > 0 && verifiedAgentAuthor === undefined) return null
 
   // 2. thread affinity (§8.2 step 2 — highest after explicit @; bypasses kind filter).
   if (msg.thread) {

--- a/packages/daemon/src/router/routing-table.ts
+++ b/packages/daemon/src/router/routing-table.ts
@@ -105,6 +105,19 @@ export function participantAgents(
   return participants.filter((id) => id !== exclude && servable.has(id))
 }
 
+/** Agents whose `auto` rule makes them participants in every conversation covered by
+ * that rule. Unlike `routeRules`, this returns the whole set: channel-wide participation
+ * is not an arbitration tie that should collapse to whichever rule happens to be first. */
+export function automaticAgents(msg: NormalizedMessage, rules: RoutingRule[], exclude?: string): string[] {
+  return [
+    ...new Set(
+      rules
+        .filter((r) => r.match.kind === 'auto' && scopeMatches(r, msg) && r.agentId !== exclude)
+        .map((r) => r.agentId)
+    )
+  ]
+}
+
 export function routeRules(
   msg: NormalizedMessage,
   rules: RoutingRule[],
@@ -138,7 +151,9 @@ export function routeRules(
   // returns every rule the body actually named, so nothing depends on which one `find`
   // happened to see first, and everyone already in the thread receives the message
   // regardless (`threadParticipants`).
-  if (mention && (!msg.sender.isBot || msg.platform === 'slack')) return pickRule(mention, 'mention')
+  if (mention && verifiedAgentAuthor === undefined && (!msg.sender.isBot || msg.platform === 'slack')) {
+    return pickRule(mention, 'mention')
+  }
   // A VERIFIED AgentConnect author continues into the implicit rungs; every other bot
   // still stops here. That difference is the whole of §2.3: we know exactly which agent
   // wrote this and have already checked its policy, so it is treated as a participant

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -1,6 +1,7 @@
 import type { ContentBlock, McpServer } from '@agentclientprotocol/sdk'
 import { LocalStore, sessionKey, transcriptChannelKey, type TranscriptEntry } from '../store/local-store.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
+import { SLACK_RESPONSE_FINAL_EVENT_TAG } from '@agentconnect.md/message'
 import { additionalWorkspaceDirectories, prepareWorkspace } from '../workspace/workspace-manager.js'
 import { memoryKindOf, type MemoryProvider } from '../agents/memory-provider.js'
 import { MAX_INDEX_INJECT_BYTES } from '../agents/memory.js'
@@ -479,6 +480,9 @@ export class SessionManager {
       // This message was delivered TO this agent (handle() runs for `agentId`), so tag the
       // recipient — the console session view scopes to what THIS agent received + produced.
       recipient: agentId,
+      // A response finalization is the same Slack message as the post that opened it, so
+      // it lands on that row and refreshes it to the completed text.
+      ...(msg.ingressEventTag === SLACK_RESPONSE_FINAL_EVENT_TAG ? { authoritative: true } : {}),
       kind: 'text',
       text: transcriptText,
       ...(transcriptAttachments.length ? { attachments: transcriptAttachments } : {})

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -336,6 +336,21 @@ export class SessionManager {
   private readonly turnsSinceReminder = new Map<string, number>()
   private readonly lastContextUsed = new Map<string, number>()
 
+  /**
+   * Every agent that is ALREADY part of this thread — open sessions first, then ones
+   * TTL-closed after idle (a dormant participant is still a participant).
+   *
+   * A mention is what JOINS an agent to a thread; this is what keeps it there. Unlike
+   * {@link threadOwner} it does not collapse to null when several agents share the
+   * thread — that collapse exists to disambiguate a SINGLE target, and a conversation
+   * does not have one: everyone in it sees what is said.
+   */
+  threadParticipants(channel: string, thread: string, transportScope?: string | null): string[] {
+    const open = this.deps.store.openSessionAgents(channel, thread, transportScope)
+    const dormant = this.deps.store.closedSessionAgents(channel, thread, transportScope)
+    return [...new Set([...open, ...dormant])]
+  }
+
   threadOwner(channel: string, thread: string, transportScope?: string | null): string | null {
     const owners = this.deps.store.openSessionAgents(channel, thread, transportScope)
     // 2+ live owners actively share the thread → ambiguous, fall through to

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -209,6 +209,14 @@ export interface TranscriptEntry {
   /** True only when the daemon verified that this Slack history row came from an
    *  AgentConnect-managed bot identity. Legacy rows and all other platforms omit it. */
   trustedAgentBot?: boolean
+  /** This arrival carries the message's FINAL text and may overwrite an earlier row on
+   *  the same coordinates.
+   *
+   *  A streamed reply is posted before it is finished, so the post that lands first can
+   *  hold a prefix; the closing edit is the same Slack message (same `ts`, so the same
+   *  row) and is the authoritative version. Without this the plain INSERT OR IGNORE would
+   *  keep the prefix forever, since a text row has no other update path. */
+  authoritative?: boolean
   kind: TranscriptKind
   text: string
   /** Bounded inline webchat images. Persisted daemon-side; never provider-backed files. */
@@ -2641,7 +2649,7 @@ export class LocalStore {
   }
 
   appendTranscript(e: TranscriptEntry): void {
-    const { attachments, trustedAgentBot, quoted, quoteJson, ...entry } = e
+    const { attachments, trustedAgentBot, quoted, quoteJson, authoritative, ...entry } = e
     const durableQuoteJson = quoted?.text ? JSON.stringify(quoted) : (quoteJson ?? null)
     const revision = this.transcriptRevision + 1
     const inserted = this.db
@@ -2662,6 +2670,22 @@ export class LocalStore {
         revision
       } as unknown as SqlParams)
     if (Number(inserted.changes) === 1) this.transcriptRevision = revision
+    // The closing edit of a streamed reply lands on the row its own post created, so the
+    // text is refreshed in place rather than lost to INSERT OR IGNORE. Scoped to text
+    // rows on identical coordinates, and only ever toward the authoritative version.
+    if (Number(inserted.changes) === 0 && authoritative && e.kind === 'text') {
+      const rev = this.transcriptRevision + 1
+      const refreshed = this.db
+        .prepare(
+          `UPDATE transcript SET text = ?, revision = ?
+           WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text' AND text IS NOT ?`
+        )
+        .run(e.text, rev, e.channel, e.thread, e.ts, e.text)
+      if (Number(refreshed.changes) === 1) {
+        this.transcriptRevision = rev
+        this.notifyTranscriptMutation(e.channel, e.thread, e.recipient ? [e.recipient] : [], rev)
+      }
+    }
     // A row may predate this column and later be re-observed in an authoritative Slack
     // snapshot. Upgrade only toward trusted=true; an untrusted replay can never clear or
     // manufacture provenance, and the stable text-row coordinates keep this scoped.

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -166,7 +166,13 @@ const agentMessage = (over: Record<string, unknown> = {}, claim: Record<string, 
   ...over
 })
 
-const route = (daemon: Daemon, msg: unknown) => (daemon as any).onInboundOutcome(msg, ['int-bot-a'])
+/**
+ * Route as a PEER's connection observes the post, which is how a channel event actually
+ * reaches a target: every dedicated Slack app receives it on its own socket, and the
+ * rules in scope are that connection's. The author's own connection resolves to the
+ * author, who is excluded — so observing there proves only that nobody self-wakes.
+ */
+const route = (daemon: Daemon, msg: unknown, on: string[] = ['int-bot-b']) => (daemon as any).onInboundOutcome(msg, on)
 
 /**
  * The rendezvous key for the paired delivery these tests exercise, derived the way BOTH
@@ -186,9 +192,11 @@ function pairingKey(daemon: Daemon, targetAgentId = 'bot-b'): string {
 }
 
 describe('agent-authored platform mentions (send-message-routing-rework.md §6)', () => {
-  it('activates exactly the mentioned agent, with the trusted hop already advanced', async () => {
-    // §10 case 7. The one positive case: a finalized agent reply naming a peer wakes that
-    // peer — and only it — as a genuine agent CALL, not as anonymous channel traffic.
+  it('wakes the peer whose connection observed it, with the trusted hop already advanced', async () => {
+    // The one positive case. Delivery follows the ordinary ladder on the OBSERVING
+    // connection, not a recipient set parsed out of the body — a peer is meant to see what
+    // was said and judge for itself. It is still a genuine agent CALL, not anonymous
+    // channel traffic: the hop advances and the edge is policy-checked.
     const { daemon, calls } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }, { id: 'bot-c' }])
     const outcome = route(daemon, agentMessage({}, { hopCount: 2 }))
     expect(outcome.kind).toBe('dispatched')
@@ -196,9 +204,9 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
     // §4.1: the delivery depth is the author's turn depth + 1, installed as trusted
     // active-turn metadata so the target's own reply advances the chain by one again.
     expect(calls[0]!.callMeta).toMatchObject({ callFrom: 'bot-a', hopCount: 3 })
-    // Explicit address ⇒ the same trigger a human @mention produces, so it clears a
-    // `!stop` mute exactly as one would.
-    expect(calls[0]!.msg.trigger).toBe('mention')
+    // Not stamped as an explicit address: nothing here resolved a mention, and `trigger`
+    // is a trusted routing cause downstream (the un-mute rule, the prompt reminder).
+    expect(calls[0]!.msg.trigger).toBeUndefined()
     await daemon.stop()
   })
 
@@ -330,53 +338,28 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
     const { daemon, calls } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }])
     const stopped = vi.fn()
     ;(daemon as any).handleCommand = stopped
+    // It still DELIVERS — an agent's words are words — but command interception sits
+    // below the agent branch, so agent text can never act on a running turn.
     route(daemon, agentMessage({ text: '!stop' }, { mentionedAgentIds: [] }))
     expect(stopped).not.toHaveBeenCalled()
-    expect(calls).toHaveLength(0)
     await daemon.stop()
   })
 
-  it('does not let an author activate itself', async () => {
-    // §10 case 9 / §2.3.
+  it('never selects the author, on any connection', async () => {
+    // The one absolute in §2.3, and the only thing the author's own recipient set is still
+    // consulted for. Its own connection resolves to itself ⇒ excluded ⇒ nobody; a peer's
+    // connection resolves to the peer. Neither can ever name the author.
     const { daemon, calls } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }])
-    expect(route(daemon, agentMessage({}, { mentionedAgentIds: ['bot-a'] })).kind).toBe('rejected')
+    expect(route(daemon, agentMessage(), ['int-bot-a']).kind).toBe('rejected')
     expect(calls).toHaveLength(0)
+
+    const peerCopy = agentMessage({ msgId: 'slack:C1:1720000000.000209:final' })
+    expect(route(daemon, peerCopy, ['int-bot-b']).kind).toBe('dispatched')
+    expect(calls.map((c) => c.agentId)).toEqual(['bot-b'])
     await daemon.stop()
   })
 
-  it('does not hand a self-mention to the implicit rungs on a peer connection', async () => {
-    // §2.3. The author-exclusion filter cannot be what decides whether the message was
-    // addressed: a response naming ONLY its author would come out of that filter looking
-    // identical to one that named nobody, and would then continue to an unrelated peer.
-    // Emptiness is therefore judged BEFORE the author is removed.
-    //
-    // The author's own connection cannot show this — nothing happens there either way.
-    // bot-b's connection is where the difference is visible.
-    const { daemon, calls } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }])
-    const selfNamed = agentMessage({}, { mentionedAgentIds: ['bot-a'] })
-    expect((daemon as any).onInboundOutcome(selfNamed, ['int-bot-b']).kind).toBe('rejected')
-    expect(calls).toHaveLength(0)
-    await daemon.stop()
-  })
-
-  it('does not substitute an implicit recipient when every named one is refused', async () => {
-    // §2.3. Having named someone is binding. bot-b is named but its call policy excludes
-    // the author; bot-c would be the implicit pick on its own connection. Falling through
-    // would answer "the agent you asked for is unavailable" with "so here is a different
-    // one" — and the commonest refusal is the conversation's own Off fence, which must not
-    // become a redirect. The relay applies the same rule.
-    const { daemon, calls } = await boot([
-      { id: 'bot-a' },
-      { id: 'bot-b', callPolicy: 'selected', allowedCallerAgentIds: ['somebody-else'] },
-      { id: 'bot-c' }
-    ])
-    const named = agentMessage({}, { mentionedAgentIds: ['bot-b'] })
-    expect((daemon as any).onInboundOutcome(named, ['int-bot-c']).kind).toBe('rejected')
-    expect(calls).toHaveLength(0)
-    await daemon.stop()
-  })
-
-  it('obeys a `!stop` mute when it continues implicitly, and clears it on an explicit mention', async () => {
+  it('obeys a `!stop` mute', async () => {
     // §2.3. An implicitly selected agent continuation IS implicit routing — the fact that
     // an agent rather than a human produced the message does not exempt it from the mute.
     // Without this `!stop` would silence a conversation's humans while its agents kept
@@ -391,53 +374,13 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
     expect(calls).toHaveLength(0)
     expect((daemon as any).isSessionMuted(muteKey)).toBe(true)
 
-    // An explicit mention is an address, so it wakes bot-b and lifts the mute — exactly
-    // what a human's `@mention` does. `!stop` means "stop reacting implicitly", never
-    // "ignore anyone who names me".
-    const addressed = agentMessage({ msgId: 'slack:C1:1720000000.000202:final' }, { mentionedAgentIds: ['bot-b'] })
-    expect((daemon as any).onInboundOutcome(addressed, ['int-bot-b']).kind).toBe('dispatched')
-    expect(calls.map((c) => c.agentId)).toEqual(['bot-b'])
-    expect((daemon as any).isSessionMuted(muteKey)).toBe(false)
-    await daemon.stop()
-  })
-
-  it('does not continue when the response addressed a human', async () => {
-    // Direct/relay parity. `mentionedBots` holds every `<@U…>` token, humans included, so
-    // an `@human` reply is an unmatched mention and the ladder stops there — the same
-    // outcome a PERSON's `@human` reply gets in this channel. Waking an unrelated `auto`
-    // agent instead would answer a question that was put to someone else.
-    const { daemon, calls } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }])
-    const toHuman = agentMessage(
-      { text: '<@UHUMAN> can you confirm the rollout?', mentionedBots: ['UHUMAN'] },
-      { mentionedAgentIds: [] }
-    )
-    expect((daemon as any).onInboundOutcome(toHuman, ['int-bot-b']).kind).toBe('rejected')
+    // A mention in the body is not an address this layer acts on, so it does not lift the
+    // mute either: agent traffic can no longer reopen a conversation a human stopped.
+    // Clearing it stays a HUMAN act (`@mention` on the ordinary ladder, or `!resume`).
+    const mentioning = agentMessage({ msgId: 'slack:C1:1720000000.000202:final' }, { mentionedAgentIds: ['bot-b'] })
+    expect((daemon as any).onInboundOutcome(mentioning, ['int-bot-b']).kind).toBe('rejected')
     expect(calls).toHaveLength(0)
-    await daemon.stop()
-  })
-
-  it('does not continue when the mention landed in an EARLIER split section', async () => {
-    // §5.5 marks only the last physical section `final`, and `mentionedBots` is reparsed
-    // from that section's text. A long answer that addresses a human in section one and
-    // ends without a mention therefore arrives with BOTH mention sets empty — so whether
-    // the address binds would depend on where the splitter happened to cut. The author's
-    // claim covers the complete response and is the only place that fact still exists.
-    const { daemon, calls } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }])
-    const tailSection = agentMessage(
-      { text: '…and that is the last part of the answer.', mentionedBots: [] },
-      { mentionedAgentIds: [], addressedAnyone: true }
-    )
-    expect((daemon as any).onInboundOutcome(tailSection, ['int-bot-b']).kind).toBe('rejected')
-    expect(calls).toHaveLength(0)
-
-    // The same tail from an author that never claimed an address still continues — an
-    // older daemon cannot report the fact, and its finals must not become unroutable.
-    const unclaimed = agentMessage(
-      { msgId: 'slack:C1:1720000000.000203:final', text: 'no mention anywhere', mentionedBots: [] },
-      { mentionedAgentIds: [] }
-    )
-    expect((daemon as any).onInboundOutcome(unclaimed, ['int-bot-b']).kind).toBe('dispatched')
-    expect(calls.map((c) => c.agentId)).toEqual(['bot-b'])
+    expect((daemon as any).isSessionMuted(muteKey)).toBe(true)
     await daemon.stop()
   })
 
@@ -541,38 +484,6 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
     expect(route(daemon, agentMessage()).kind).toBe('dispatched')
     expect(route(daemon, agentMessage({ msgId: 'slack:C1:1720000000.000200:final-retry' })).kind).toBe('rejected')
     expect(calls).toHaveLength(1)
-    await daemon.stop()
-  })
-
-  it('activates EVERY admissible recipient of one finalized response', async () => {
-    // One response can address several agents ("<@A> <@B> please both look"). Stopping at
-    // the first would wake one of them with nothing to tell the sender the others were
-    // dropped — the sender saw a single message go out.
-    const { daemon, calls } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }, { id: 'bot-c' }])
-    const outcome = route(daemon, agentMessage({}, { mentionedAgentIds: ['bot-b', 'bot-c'] }))
-    expect(outcome.kind).toBe('dispatched')
-    expect(calls.map((c) => c.agentId).sort()).toEqual(['bot-b', 'bot-c'])
-    // Each is its own delivery at the same depth — one edge from the author, not a chain.
-    expect(calls.every((c) => c.callMeta?.hopCount === 1)).toBe(true)
-    // …and each carries a DISTINCT durable delivery id. The inbox is keyed by one global
-    // id, so sharing the platform msgId across targets would make the first row win the
-    // primary key and every later `INSERT OR IGNORE` report `existing` — dispatch would
-    // treat those as duplicates and enqueue no turn, leaving only the first agent awake.
-    const deliveryIds = calls.map((c) => c.callMeta?.deliveryId)
-    expect(new Set(deliveryIds).size).toBe(2)
-    expect(new Set(calls.map((c) => c.callMeta?.activationKey)).size).toBe(2)
-    await daemon.stop()
-  })
-
-  it('durably enqueues a turn for EVERY recipient through the real inbox', async () => {
-    // The assertion above rides on a dispatch stub, which cannot see the primary-key
-    // collision that made this a real delivery bug. Let real `dispatch` run so the durable
-    // inbox itself is the witness: two recipients must produce two rows.
-    const { daemon } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }, { id: 'bot-c' }], { realDispatch: true })
-    route(daemon, agentMessage({}, { mentionedAgentIds: ['bot-b', 'bot-c'] }))
-    const rows = (daemon as any).store.listInboxBySessionKeyFifo() as { id: string; agentId: string }[]
-    expect(rows.map((r) => r.agentId).sort()).toEqual(['bot-b', 'bot-c'])
-    expect(new Set(rows.map((r) => r.id)).size).toBe(2)
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -10,9 +10,9 @@ import { sessionKey } from '../src/store/local-store.js'
  * platform message authored by an AgentConnect agent.
  *
  * The behavior under test is a reversal: an agent-authored Slack message used to be
- * dropped outright, and now routes through the SAME ladder a human message takes — named
- * recipients first, then the implicit rungs — so agents converse without having to name
- * each other in every line.
+ * dropped outright, and now routes through the SAME conversation-participant machinery a
+ * human message takes: mentions join peers, while affinity and automatic rules keep joined
+ * participants receiving later replies without requiring a fresh mention on every line.
  *
  * What remains absolute, and is most of what these tests pin: the author is never the
  * target (self-activation is unconditional, not merely loop-prone), every edge still
@@ -25,7 +25,7 @@ const TEST_ORG = 'org_test0000000000000000000'
 const APP_ID = 'AAGENTCONNECT'
 
 function scaffold(
-  agents: { id: string; callPolicy?: string; allowedCallerAgentIds?: string[] }[],
+  agents: { id: string; trigger?: 'auto' | 'mention'; callPolicy?: string; allowedCallerAgentIds?: string[] }[],
   // Give each agent its OWN Slack credential, i.e. genuinely separate apps. The transport
   // scope hashes the live credential, so the shared-token default collapses every agent
   // onto one scope — which hides any bug in which scope a lookup is keyed under.
@@ -62,7 +62,7 @@ function scaffold(
               // Socket-mode Slack keys its connection identity on the APP token, so this
               // is what actually separates two dedicated apps into two transport scopes.
               appToken: distinctTokens ? `xapp-${a.id}` : 'xapp',
-              bindRules: [{ match: { kind: 'auto' }, channel: 'C1' }]
+              bindRules: [{ match: { kind: a.trigger ?? 'auto' }, channel: 'C1' }]
             }
           }
         ],
@@ -87,7 +87,7 @@ const fakeHost = () => ({
 /** Boot with a dispatch spy and a collaboration snapshot placing every agent in C1
  *  behind ONE AgentConnect Slack app, each with its own bot user id. */
 async function boot(
-  agents: { id: string; callPolicy?: string; allowedCallerAgentIds?: string[] }[],
+  agents: { id: string; trigger?: 'auto' | 'mention'; callPolicy?: string; allowedCallerAgentIds?: string[] }[],
   over: {
     botUserIds?: Record<string, string>
     botShared?: boolean
@@ -368,6 +368,68 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
       expect(calls.every((c) => c.callMeta?.callFrom === 'bot-a')).toBe(true)
       // Namespaced per peer, so the durable inbox keeps one replayable row each.
       expect(new Set(calls.map((c) => c.callMeta?.deliveryId)).size).toBe(2)
+      await daemon.stop()
+    })
+
+    it('delivers to joined mention-only participants even when no primary owner exists', async () => {
+      // Two open sessions deliberately make `threadOwner` return null. Neither rule is
+      // auto and this follow-up names nobody, so the legacy single-target ladder has no
+      // result at all; conversation delivery must still reach both joined peers.
+      const { daemon, calls } = await boot([
+        { id: 'bot-a', trigger: 'mention' },
+        { id: 'bot-b', trigger: 'mention' },
+        { id: 'bot-c', trigger: 'mention' }
+      ])
+      join(daemon, 'bot-b')
+      join(daemon, 'bot-c')
+
+      expect(
+        route(daemon, agentMessage({}, { mentionedAgentIds: [], hopCount: 2 }), ['int-bot-b', 'int-bot-c']).kind
+      ).toBe('dispatched')
+      expect(new Set(calls.map((call) => call.agentId))).toEqual(new Set(['bot-b', 'bot-c']))
+      expect(calls.every((call) => call.callMeta?.hopCount === 3 && call.callMeta?.activationKey)).toBe(true)
+      await daemon.stop()
+    })
+
+    it('derives explicit join and implicit mute handling per human target', async () => {
+      const { daemon, calls } = await boot(
+        [
+          { id: 'bot-b', trigger: 'mention' },
+          { id: 'bot-c', trigger: 'mention' }
+        ],
+        { botUserIds: { 'bot-b': 'UB', 'bot-c': 'UC' }, distinctTokens: true }
+      )
+      const scope = (daemon as any).transportScopeForIntegrationIds(['int-bot-b', 'int-bot-c'])
+      ;(daemon as any).botUserIds['int-bot-b'] = 'UB'
+      ;(daemon as any).botUserIds['int-bot-c'] = 'UC'
+      for (const agentId of ['bot-b', 'bot-c']) {
+        ;(daemon as any).store.upsertSession({
+          key: sessionKey('slack', 'C1', '1720000000.000100', agentId, scope),
+          agentId,
+          platform: 'slack',
+          channel: 'C1',
+          thread: '1720000000.000100',
+          transportScope: scope,
+          acpSessionId: `acp-${agentId}`,
+          state: 'idle',
+          lastDeliveredTs: null,
+          updatedAt: Date.now()
+        })
+      }
+      const key = (agentId: string) => sessionKey('slack', 'C1', '1720000000.000100', agentId, scope)
+      ;(daemon as any).setSessionMuted(key('bot-b'), true)
+      ;(daemon as any).setSessionMuted(key('bot-c'), true)
+
+      const human = agentMessage({
+        msgId: 'slack:C1:1720000000.000250',
+        sender: { id: 'U-HUMAN', isBot: false },
+        text: '<@UB> join us',
+        mentionedBots: ['UB']
+      })
+      expect(route(daemon, human, ['int-bot-b', 'int-bot-c']).kind).toBe('dispatched')
+      expect(calls.map((call) => [call.agentId, call.msg.trigger])).toEqual([['bot-b', 'mention']])
+      expect((daemon as any).isSessionMuted(key('bot-b'))).toBe(false)
+      expect((daemon as any).isSessionMuted(key('bot-c'))).toBe(true)
       await daemon.stop()
     })
 

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -332,6 +332,76 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
     await daemon.stop()
   })
 
+  describe('thread fan-out: everyone in the room hears it', () => {
+    /** Put `agentId` in the thread, which is what a mention would have done. */
+    const join = (daemon: Daemon, agentId: string) => {
+      const scope = (daemon as any).transportScopeForIntegrationIds([`int-${agentId}`])
+      ;(daemon as any).store.upsertSession({
+        key: sessionKey('slack', 'C1', '1720000000.000100', agentId, scope),
+        agentId,
+        platform: 'slack',
+        channel: 'C1',
+        thread: '1720000000.000100',
+        transportScope: scope,
+        acpSessionId: `acp-${agentId}`,
+        state: 'idle',
+        lastDeliveredTs: null,
+        updatedAt: Date.now()
+      })
+    }
+
+    it('delivers to every participant, and carries the hop depth to each', async () => {
+      // Participation outlives the message that created it. bot-c joined earlier and is
+      // not named here, so only the fan-out can reach it.
+      const { daemon, calls } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }, { id: 'bot-c' }])
+      join(daemon, 'bot-b')
+      join(daemon, 'bot-c')
+
+      const reply = agentMessage({}, { mentionedAgentIds: [], hopCount: 3 })
+      expect(route(daemon, reply, ['int-bot-b', 'int-bot-c']).kind).toBe('dispatched')
+
+      expect(new Set(calls.map((c) => c.agentId))).toEqual(new Set(['bot-b', 'bot-c']))
+      // Every peer is an EDGE of the same agent call, so each carries the advanced depth.
+      // A peer reached only by fan-out would otherwise report depth 0 on its own next
+      // reply and the hop cap would never accumulate for it.
+      expect(calls.every((c) => c.callMeta?.hopCount === 4)).toBe(true)
+      expect(calls.every((c) => c.callMeta?.callFrom === 'bot-a')).toBe(true)
+      // Namespaced per peer, so the durable inbox keeps one replayable row each.
+      expect(new Set(calls.map((c) => c.callMeta?.deliveryId)).size).toBe(2)
+      await daemon.stop()
+    })
+
+    it('does not let being in the room bypass call policy', async () => {
+      // Already having a session is not consent to be called: bot-c's inbound policy
+      // excludes the author, so it hears nothing even though it is in the thread.
+      const { daemon, calls } = await boot([
+        { id: 'bot-a' },
+        { id: 'bot-b' },
+        { id: 'bot-c', callPolicy: 'selected', allowedCallerAgentIds: ['somebody-else'] }
+      ])
+      join(daemon, 'bot-b')
+      join(daemon, 'bot-c')
+
+      expect(route(daemon, agentMessage({}, { mentionedAgentIds: [] }), ['int-bot-b', 'int-bot-c']).kind).toBe(
+        'dispatched'
+      )
+      expect(calls.map((c) => c.agentId)).toEqual(['bot-b'])
+      await daemon.stop()
+    })
+
+    it('keeps a `!stop` participant silent while still recording for catch-up', async () => {
+      const { daemon, calls } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }, { id: 'bot-c' }])
+      join(daemon, 'bot-b')
+      join(daemon, 'bot-c')
+      const scope = (daemon as any).transportScopeForIntegrationIds(['int-bot-c'])
+      ;(daemon as any).setSessionMuted(sessionKey('slack', 'C1', '1720000000.000100', 'bot-c', scope), true)
+
+      route(daemon, agentMessage({}, { mentionedAgentIds: [] }), ['int-bot-b', 'int-bot-c'])
+      expect(calls.map((c) => c.agentId)).toEqual(['bot-b'])
+      await daemon.stop()
+    })
+  })
+
   it('does not let an agent issue control commands', async () => {
     // §6: `!stop` from an agent must not act on a running turn. Command interception sits
     // BELOW the agent branch, so agent text can never reach it.

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -433,6 +433,33 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
       await daemon.stop()
     })
 
+    it('uses a target-scoped durable inbox id for every human fan-out copy', async () => {
+      const { daemon } = await boot(
+        [
+          { id: 'bot-b', trigger: 'mention' },
+          { id: 'bot-c', trigger: 'auto' }
+        ],
+        { botUserIds: { 'bot-b': 'UB' }, realDispatch: true }
+      )
+      ;(daemon as any).botUserIds['int-bot-b'] = 'UB'
+      const appendInbox = vi.spyOn((daemon as any).store, 'appendInbox')
+
+      const human = agentMessage({
+        msgId: 'slack:C1:1720000000.000260',
+        sender: { id: 'U-HUMAN', isBot: false },
+        text: '<@UB> please coordinate',
+        mentionedBots: ['UB']
+      })
+      expect(route(daemon, human, ['int-bot-b', 'int-bot-c']).kind).toBe('dispatched')
+
+      const rows = appendInbox.mock.calls.map(([row]) => row)
+      expect(new Set(rows.map((row) => row.agentId))).toEqual(new Set(['bot-b', 'bot-c']))
+      expect(new Set(rows.map((row) => row.id)).size).toBe(2)
+      expect(rows.find((row) => row.agentId === 'bot-b')?.id).toContain('#bot-b')
+      expect(rows.find((row) => row.agentId === 'bot-c')?.id).toContain('#bot-c')
+      await daemon.stop()
+    })
+
     it('does not let being in the room bypass call policy', async () => {
       // Already having a session is not consent to be called: bot-c's inbound policy
       // excludes the author, so it hears nothing even though it is in the thread.

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -224,6 +224,57 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
     await daemon.stop()
   })
 
+  it('binds the conversation audience, so it can wake an agent already talking in the thread', async () => {
+    // The production failure this pins: every agent already in the thread holds a
+    // Slack-BOUND session there, and an agent-authored activation carries CallMeta. The
+    // session-source gate reads CallMeta as "postless A2A child", which has no
+    // conversation audience by design — so the wake was cancelled as a cross-source turn
+    // and the exchange died after one round with only a WARN in the log.
+    //
+    // A postless child must indeed not bind: its coordinates come from the caller's
+    // session and the model picks the target. A platform-observed delivery is the
+    // opposite — its channel and thread come from the provider event, exactly like a
+    // human message in that thread.
+    const { daemon } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }])
+    // A live connection supplies the workspace id the conversation audience keys on; the
+    // realm is what makes the tuple complete enough to bind at all.
+    ;(daemon as any).connByIntegration.set('int-bot-b', { workspaceId: () => 'T-TEST' })
+    const msg = agentMessage()
+    msg.transportScope = (daemon as any).transportScopeForIntegrationIds(['int-bot-b'])
+
+    // The audience this very message resolves to for the target…
+    const audience = (daemon as any).conversationExternalSource('bot-b', msg, false)
+    expect(audience).toMatchObject({
+      externalProvider: 'slack',
+      externalResourceKind: 'conversation',
+      externalRealmKey: 'T-TEST',
+      externalIntegrationId: 'int-bot-b'
+    })
+
+    // …and a session already bound to it, which is what the human's mention created.
+    const key = sessionKey('slack', 'C1', '1720000000.000100', 'bot-b', msg.transportScope)
+    ;(daemon as any).store.upsertSession({
+      key,
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C1',
+      thread: '1720000000.000100',
+      acpSessionId: 'acp-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    ;(daemon as any).store.setSessionClassification(key, { sourceBindingKind: 'external', ...audience })
+
+    const platformWake = { callFrom: 'bot-a', platformOrigin: true, hopCount: 1, deliveryId: 'd-1' }
+    expect((daemon as any).bindSessionSource('bot-b', key, msg, platformWake, undefined)).toBe('unchanged')
+
+    // A postless call with no inherited lineage keeps failing closed against the same row.
+    const postlessWake = { callFrom: 'bot-a', hopCount: 1, deliveryId: 'd-2' }
+    expect((daemon as any).bindSessionSource('bot-b', key, msg, postlessWake, undefined)).toBe('mismatch')
+    await daemon.stop()
+  })
+
   it('does not let an agent issue control commands', async () => {
     // §6: `!stop` from an agent must not act on a running turn. Command interception sits
     // BELOW the agent branch, so agent text can never reach it.

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -275,6 +275,55 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
     await daemon.stop()
   })
 
+  it('classifies the NEW session a platform-observed delivery creates as externally bound', async () => {
+    // The creation-side half of the same failure: when the target has never spoken in
+    // the thread, the wake CREATES its session. Classified as a postless child, that row
+    // is 'local' — and then every later externally-attributed wake in the thread, the
+    // next HUMAN reply included, rejects as a cross-source mismatch. The agent goes
+    // permanently silent in a conversation it visibly joined.
+    const { daemon } = await boot([{ id: 'bot-a' }, { id: 'bot-b' }])
+    ;(daemon as any).connByIntegration.set('int-bot-b', { workspaceId: () => 'T-TEST' })
+    const msg = agentMessage()
+    msg.transportScope = (daemon as any).transportScopeForIntegrationIds(['int-bot-b'])
+    const seedSession = (key: string) =>
+      (daemon as any).store.upsertSession({
+        key,
+        agentId: 'bot-b',
+        platform: 'slack',
+        channel: 'C1',
+        thread: '1720000000.000100',
+        acpSessionId: 'acp-1',
+        state: 'idle',
+        lastDeliveredTs: null,
+        updatedAt: Date.now()
+      })
+
+    const key = sessionKey('slack', 'C1', '1720000000.000100', 'bot-b', msg.transportScope)
+    seedSession(key)
+    const platformWake = { callFrom: 'bot-a', platformOrigin: true, hopCount: 1, deliveryId: 'd-1' }
+    ;(daemon as any).classifyNewSessionOrThrow('bot-b', key, 'acp-1', msg, platformWake, undefined, false)
+    expect((daemon as any).store.getSession(key)).toMatchObject({
+      sourceBindingKind: 'external',
+      externalProvider: 'slack',
+      externalRealmKey: 'T-TEST',
+      externalResourceKind: 'conversation',
+      externalResourceKey: 'C1',
+      externalIntegrationId: 'int-bot-b'
+    })
+    // …so the next wake in the thread — this one human-shaped, no CallMeta — reuses the
+    // row instead of mismatching.
+    expect((daemon as any).bindSessionSource('bot-b', key, msg, undefined, undefined)).toBe('unchanged')
+
+    // A postless child still classifies local: its coordinates are model-influenced, so
+    // the row it creates must not claim the shared conversation.
+    const postlessKey = sessionKey('slack', 'C1', '1720000000.000900', 'bot-b', msg.transportScope)
+    seedSession(postlessKey)
+    const postlessWake = { callFrom: 'bot-a', hopCount: 1, deliveryId: 'd-2' }
+    ;(daemon as any).classifyNewSessionOrThrow('bot-b', postlessKey, 'acp-1', msg, postlessWake, undefined, false)
+    expect((daemon as any).store.getSession(postlessKey)).toMatchObject({ sourceBindingKind: 'local' })
+    await daemon.stop()
+  })
+
   it('does not let an agent issue control commands', async () => {
     // §6: `!stop` from an agent must not act on a running turn. Command interception sits
     // BELOW the agent branch, so agent text can never reach it.

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -10,6 +10,41 @@ function store(): LocalStore {
 }
 
 describe('LocalStore', () => {
+  it('keeps every agent reply in a thread, and lets a finalization refresh its own text', () => {
+    // The production failure this pins: a response finalization used to reach the
+    // transcript with the literal ts `'final'` (a `:final` msgId suffix that
+    // `transcriptCoords` read as the ts). The UNIQUE index is (channel, thread, ts) and
+    // does NOT include the recipient, so only the FIRST agent reply in a thread survived
+    // — every later one was silently dropped by INSERT OR IGNORE. In a multi-agent Slack
+    // thread that means an agent sees exactly one peer message, ever.
+    const s = store()
+    const row = (ts: string, text: string, extra: Record<string, unknown> = {}) => ({
+      channel: 'slack:C1',
+      thread: '100.1',
+      ts,
+      sender: 'bot-a',
+      recipient: 'bot-b',
+      kind: 'text' as const,
+      text,
+      ...extra
+    })
+    s.appendTranscript(row('100.2', '1'))
+    s.appendTranscript(row('100.3', '3'))
+    s.appendTranscript(row('100.4', '7'))
+
+    const texts = () => s.threadTranscript('slack:C1', '100.1').map((r) => r.text)
+    expect(texts()).toEqual(['1', '3', '7'])
+
+    // A finalization lands on its OWN post's coordinates and upgrades the text in place —
+    // the post can hold a streamed prefix, and a text row has no other update path.
+    s.appendTranscript(row('100.4', '7 (complete)', { authoritative: true }))
+    expect(texts()).toEqual(['1', '3', '7 (complete)'])
+
+    // Without that marker a re-observation must never rewrite an existing row.
+    s.appendTranscript(row('100.4', 'stale replay'))
+    expect(texts()).toEqual(['1', '3', '7 (complete)'])
+  })
+
   it('upserts and reads back a session record', () => {
     const s = store()
     const key = sessionKey('slack', 'C1', '100.1', 'bot-a')

--- a/packages/daemon/test/route-rules.test.ts
+++ b/packages/daemon/test/route-rules.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { routeRules } from '../src/router/routing-table.js'
+import { mentionedAgents, participantAgents, routeRules } from '../src/router/routing-table.js'
 import { rulesFromAgent, resolveAgentIntegration, type RoutingRule } from '../src/router/routing-rule.js'
 import type { NormalizedMessage } from '../src/messages/normalized.js'
 import type { Agent } from '../src/agents/agent-schema.js'
@@ -30,6 +30,45 @@ const rule = (over: Partial<RoutingRule>): RoutingRule => ({
 })
 
 describe('routeRules ladder', () => {
+  it('names EVERY mentioned agent, so nothing depends on rule order', () => {
+    // A mention JOINS an agent to the thread; it does not pick between agents. The
+    // primary-target rung uses `find`, which on a bot serving several agent routes would
+    // otherwise make the same event resolve to whichever rule happened to come first.
+    // `mentionedAgents` returns the whole named set, and the daemon delivers to all of
+    // them plus everyone already in the thread.
+    const rules = [
+      rule({ agentId: 'first', botUserId: 'B9', match: { kind: 'mention' } }),
+      rule({ agentId: 'second', botUserId: 'B9', match: { kind: 'mention' } }),
+      rule({ agentId: 'unnamed', botUserId: 'B7', match: { kind: 'mention' } }),
+      rule({ agentId: 'auto', match: { kind: 'auto' } })
+    ]
+    const named = mentionedAgents(msg({ mentionedBots: ['B9'] }), rules)
+    expect(new Set(named)).toEqual(new Set(['first', 'second']))
+    expect(named).not.toContain('unnamed')
+
+    // The author is never named back to itself.
+    expect(mentionedAgents(msg({ mentionedBots: ['B9'] }), rules, 'first')).toEqual(['second'])
+    // No mention ⇒ nobody is joined by this route.
+    expect(mentionedAgents(msg(), rules)).toEqual([])
+  })
+
+  it('keeps every thread participant this connection can serve', () => {
+    // Participation outlives the message that created it: once joined, an agent receives
+    // what is said next whether or not that message names it, and whoever said it.
+    const rules = [
+      rule({ agentId: 'joined', match: { kind: 'mention' }, botUserId: 'B9' }),
+      rule({ agentId: 'elsewhere', scope: { channel: 'OTHER' }, match: { kind: 'auto' } })
+    ]
+    const participants = ['joined', 'elsewhere', 'not-served-here']
+    expect(participantAgents(msg(), rules, participants)).toEqual(['joined'])
+    expect(participantAgents(msg(), rules, participants, 'joined')).toEqual([])
+
+    // An Off channel does not revive its participants — the fence is in the same scope
+    // filter every rung uses.
+    const muted = [rule({ agentId: 'joined', match: { kind: 'mention' }, mutedChannels: ['C1'] })]
+    expect(participantAgents(msg(), muted, ['joined'])).toEqual([])
+  })
+
   it('lets Slack bots enter only through an explicit mention', () => {
     const rules = [
       rule({ agentId: 'mentioned', botUserId: 'B9', match: { kind: 'mention' } }),

--- a/packages/daemon/test/route-rules.test.ts
+++ b/packages/daemon/test/route-rules.test.ts
@@ -85,6 +85,18 @@ describe('routeRules ladder', () => {
     expect(routeRules(msg({ platform: 'telegram', sender: bot, mentionedBots: ['B9'] }), rules, noOwner)).toBeNull()
   })
 
+  it('keeps verified-agent arbitration independent of provider mention tokens', () => {
+    const rules = [
+      rule({ agentId: 'mentioned', botUserId: 'B9', match: { kind: 'mention' } }),
+      rule({ agentId: 'ordinary', match: { kind: 'auto' } })
+    ]
+    const bot = { id: 'UAGENT', isBot: true }
+    const mentioned = routeRules(msg({ sender: bot, mentionedBots: ['B9'] }), rules, noOwner, undefined, 'author')
+    const unmentioned = routeRules(msg({ sender: bot, mentionedBots: [] }), rules, noOwner, undefined, 'author')
+    expect(mentioned).toEqual(unmentioned)
+    expect(mentioned).toMatchObject({ agentId: 'ordinary', via: 'auto' })
+  })
+
   it('explicit @bot wins across layers (over a CP auto on the same channel)', () => {
     const rules = [
       rule({ agentId: 'cpAgent', source: 'cp', scope: { channel: 'C1' }, match: { kind: 'auto' } }),

--- a/packages/message/src/slack-message.ts
+++ b/packages/message/src/slack-message.ts
@@ -183,16 +183,23 @@ export function normalizeSlackMessage(
 }
 
 /**
- * Suffix distinguishing a response-FINALIZATION event from the ordinary post it edits.
+ * `ingressEventTag` marking a response-FINALIZATION event apart from the ordinary post
+ * it edits.
  *
  * Both events describe the same Slack message and therefore the same `ts`, but they are
  * two distinct arrivals: the streaming post (transcript-only) and the closing edit (the
- * one routable event). Sharing a `msgId` would make per-connection dedup drop whichever
- * arrived second — and the second is exactly the one that carries the recipient set.
- * The PLATFORM message id stays the original `ts`, so transcript rows still collapse
- * onto one primary key and the activation key still names the visible message.
+ * one routable event). Sharing an ingress identity would make per-connection dedup drop
+ * whichever arrived second — and the second is exactly the one that carries the
+ * recipient set.
+ *
+ * This used to be a `:final` SUFFIX ON THE msgId, which was wrong: `msgId` also carries
+ * the platform ts, recovered downstream by splitting the id. The transcript uses that ts
+ * as BOTH its uniqueness key and (parsed) its ordering key, so every finalization
+ * collapsed onto the literal ts `'final'` — one row per thread survived, and it sorted to
+ * epoch 0 as the oldest message. Keeping the distinction in its own field leaves `msgId`
+ * meaning exactly one thing.
  */
-export const SLACK_RESPONSE_FINAL_MSG_ID_SUFFIX = ':final'
+export const SLACK_RESPONSE_FINAL_EVENT_TAG = 'response-final'
 
 /**
  * Normalize the `message_changed` wrapper that CLOSES an AgentConnect logical response
@@ -234,10 +241,13 @@ export function normalizeSlackResponseFinalization(
     context
   )
   if (!normalized) return null
+  // `msgId` deliberately stays the ORIGINAL post's — it is the visible message's identity
+  // everywhere downstream (transcript key, transcript ordering, activation key). Only the
+  // arrival is different, and that is what the tag says.
   return {
     ...normalized,
-    msgId: `${normalized.msgId}${SLACK_RESPONSE_FINAL_MSG_ID_SUFFIX}`,
-    ...(context.traceId === undefined ? { traceId: `${normalized.msgId}${SLACK_RESPONSE_FINAL_MSG_ID_SUFFIX}` } : {})
+    ingressEventTag: SLACK_RESPONSE_FINAL_EVENT_TAG,
+    ...(context.traceId === undefined ? { traceId: `${normalized.msgId}#${SLACK_RESPONSE_FINAL_EVENT_TAG}` } : {})
   }
 }
 

--- a/packages/message/test/slack-agent-authorship.test.ts
+++ b/packages/message/test/slack-agent-authorship.test.ts
@@ -5,7 +5,7 @@ import {
   normalizeSlackResponseFinalization,
   readAgentAuthorshipClaim,
   slackTextAddressesAnyone,
-  SLACK_RESPONSE_FINAL_MSG_ID_SUFFIX
+  SLACK_RESPONSE_FINAL_EVENT_TAG
 } from '../src/index.js'
 
 const AUTHOR = 'agent-author'
@@ -142,9 +142,13 @@ describe('normalizeSlackResponseFinalization (§5)', () => {
     expect(msg!.agentAuthorship?.mentionedAgentIds).toEqual([PEER])
   })
 
-  it('gives the finalization its own msgId so dedup cannot swallow it', () => {
+  it('separates the finalization from its post by TAG, keeping the msgId identical', () => {
     // The streaming post and its closing edit describe one Slack message and share a
-    // `ts`; only the SECOND carries the recipient set, so they must not collide.
+    // `ts`; only the SECOND carries the recipient set, so ingress dedup must not collapse
+    // them. The distinction belongs in `ingressEventTag`, NOT in `msgId`: `msgId` also
+    // carries the platform ts, and the transcript uses that ts as both its uniqueness key
+    // and its ordering key. A `:final` msgId suffix made every finalization in a thread
+    // collapse onto the literal ts `'final'` — one row survived and it sorted to epoch 0.
     const streaming = normalizeSlackMessage({
       type: 'message',
       channel: 'C1',
@@ -154,8 +158,11 @@ describe('normalizeSlackResponseFinalization (§5)', () => {
       ...claim({ delivery_state: 'streaming' })
     })
     const final = normalizeSlackResponseFinalization(wrapper(claim()))
-    expect(final!.msgId).toBe(`${streaming!.msgId}${SLACK_RESPONSE_FINAL_MSG_ID_SUFFIX}`)
-    expect(final!.msgId).not.toBe(streaming!.msgId)
+    expect(final!.msgId).toBe(streaming!.msgId)
+    expect(final!.ingressEventTag).toBe(SLACK_RESPONSE_FINAL_EVENT_TAG)
+    expect(streaming!.ingressEventTag).toBeUndefined()
+    // The ts must stay recoverable by the ordinary split every consumer performs.
+    expect(final!.msgId.split(':')[2]).toBe('1720000000.000100')
   })
 
   it('drops the wrapper subtype so later stages see an ordinary post', () => {

--- a/packages/protocol/src/frames/relay-cp.test.ts
+++ b/packages/protocol/src/frames/relay-cp.test.ts
@@ -519,11 +519,32 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
     ).toBe(false)
   })
 
-  it('round-trips the thread-affinity frames (rc/thread-assign, rc/thread-lookup, ...ok)', () => {
-    // report leg
+  it('round-trips the thread-affinity and participant frames', () => {
+    // compatibility-owner report leg
     expect(
       decodeRelayCpFrame(
         envelope('rc/thread-assign', {
+          botId: DAEMON_ID,
+          sessionKey: 'C1/ts',
+          agentId: AGENT_ID,
+          daemonId: DAEMON_ID
+        })
+      ).ok
+    ).toBe(true)
+    // participant report and pool-broadcast legs stay distinct from owner affinity
+    expect(
+      decodeRelayCpFrame(
+        envelope('rc/thread-participant', {
+          botId: DAEMON_ID,
+          sessionKey: 'C1/ts',
+          agentId: AGENT_ID,
+          daemonId: DAEMON_ID
+        })
+      ).ok
+    ).toBe(true)
+    expect(
+      decodeRelayCpFrame(
+        envelope('rc/participant-assign', {
           botId: DAEMON_ID,
           sessionKey: 'C1/ts',
           agentId: AGENT_ID,
@@ -544,13 +565,15 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
       envelope('rc/thread-lookup/ok', {
         botId: DAEMON_ID,
         sessionKey: 'C1/ts',
-        target: { agentId: AGENT_ID, daemonId: DAEMON_ID }
+        target: { agentId: AGENT_ID, daemonId: DAEMON_ID },
+        participants: [{ agentId: AGENT_ID, daemonId: DAEMON_ID }]
       })
     )
     expect(hit.ok).toBe(true)
     if (!hit.ok) throw new Error('expected ok')
     if (hit.frame.type !== 'rc/thread-lookup/ok') throw new Error('narrow')
     expect(hit.frame.payload.target?.agentId).toBe(AGENT_ID)
+    expect(hit.frame.payload.participants).toEqual([{ agentId: AGENT_ID, daemonId: DAEMON_ID }])
     // reply leg — a miss (no binding)
     expect(
       decodeRelayCpFrame(envelope('rc/thread-lookup/ok', { botId: DAEMON_ID, sessionKey: 'C1/ts', target: null })).ok

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -694,6 +694,17 @@ export const RcAssign = z.object({
 })
 export type RcAssign = z.infer<typeof RcAssign>
 
+// C→R EVT — one durable conversation member. Kept as a distinct frame from
+// `rc/assign` so an older relay can never strip a discriminator and accidentally
+// replace legacy single-owner affinity with an arbitrary participant.
+export const RcParticipantAssign = z.object({
+  botId: z.string().uuid(),
+  sessionKey: z.string().min(1),
+  agentId: z.string().uuid(),
+  daemonId: z.string().uuid()
+})
+export type RcParticipantAssign = z.infer<typeof RcParticipantAssign>
+
 // R→C EVT (fire-and-forget) — the operator picked a channel's default agent in the
 // in-Slack config modal (§10.1). The CP persists it as the channel's owner
 // (IntegrationChannel.agentId on the chosen agent's install for this bot, clearing
@@ -799,6 +810,16 @@ export const RcThreadAssign = z.object({
 })
 export type RcThreadAssign = z.infer<typeof RcThreadAssign>
 
+// R→C EVT — add one durable participant without changing affinity. A distinct
+// frame fails closed against an older CP instead of being decoded as owner assignment.
+export const RcThreadParticipant = z.object({
+  botId: z.string().uuid(),
+  sessionKey: z.string().min(1),
+  agentId: z.string().uuid(),
+  daemonId: z.string().uuid()
+})
+export type RcThreadParticipant = z.infer<typeof RcThreadParticipant>
+
 // R→C REQ → rc/thread-lookup/ok — pull-on-miss BACKSTOP leg. When an un-mentioned
 // follow-up arrives for a (channel, thread) the relay has no cached affinity for
 // (missed the broadcast, or (re)started before it), the relay asks the CP for the
@@ -814,7 +835,10 @@ export type RcThreadLookup = z.infer<typeof RcThreadLookup>
 export const RcThreadLookupOk = z.object({
   botId: z.string().uuid(),
   sessionKey: z.string().min(1),
-  target: z.object({ agentId: z.string().uuid(), daemonId: z.string().uuid() }).nullable()
+  target: z.object({ agentId: z.string().uuid(), daemonId: z.string().uuid() }).nullable(),
+  // Durable room membership is independent of the compatibility owner. Default
+  // keeps new relays able to read replies from an older CP during rollout.
+  participants: z.array(z.object({ agentId: z.string().uuid(), daemonId: z.string().uuid() })).default([])
 })
 export type RcThreadLookupOk = z.infer<typeof RcThreadLookupOk>
 
@@ -905,6 +929,7 @@ export const RELAY_CP_SCHEMAS = {
   'rc/bot-unassign': RcBotUnassign,
   'rc/routes': RcRoutes,
   'rc/assign': RcAssign,
+  'rc/participant-assign': RcParticipantAssign,
   'rc/set-channel-agent': RcSetChannelAgent,
   'rc/bot-channels': RcBotChannels,
   'rc/bot-conversation': RcBotConversation,
@@ -912,6 +937,7 @@ export const RELAY_CP_SCHEMAS = {
   'rc/bot-revoked/ok': RcBotRevokedOk,
   'rc/notice-posted': RcNoticePosted,
   'rc/thread-assign': RcThreadAssign,
+  'rc/thread-participant': RcThreadParticipant,
   'rc/thread-lookup': RcThreadLookup,
   'rc/thread-lookup/ok': RcThreadLookupOk,
   'rc/collab-routes': RcCollabRoutes,
@@ -950,6 +976,7 @@ export const RelayCpFrame = z.discriminatedUnion('type', [
   frameSchema('rc/bot-unassign', RELAY_CP_SCHEMAS['rc/bot-unassign']),
   frameSchema('rc/routes', RELAY_CP_SCHEMAS['rc/routes']),
   frameSchema('rc/assign', RELAY_CP_SCHEMAS['rc/assign']),
+  frameSchema('rc/participant-assign', RELAY_CP_SCHEMAS['rc/participant-assign']),
   frameSchema('rc/set-channel-agent', RELAY_CP_SCHEMAS['rc/set-channel-agent']),
   frameSchema('rc/bot-channels', RELAY_CP_SCHEMAS['rc/bot-channels']),
   frameSchema('rc/bot-conversation', RELAY_CP_SCHEMAS['rc/bot-conversation']),
@@ -957,6 +984,7 @@ export const RelayCpFrame = z.discriminatedUnion('type', [
   frameSchema('rc/bot-revoked/ok', RELAY_CP_SCHEMAS['rc/bot-revoked/ok']),
   frameSchema('rc/notice-posted', RELAY_CP_SCHEMAS['rc/notice-posted']),
   frameSchema('rc/thread-assign', RELAY_CP_SCHEMAS['rc/thread-assign']),
+  frameSchema('rc/thread-participant', RELAY_CP_SCHEMAS['rc/thread-participant']),
   frameSchema('rc/thread-lookup', RELAY_CP_SCHEMAS['rc/thread-lookup']),
   frameSchema('rc/thread-lookup/ok', RELAY_CP_SCHEMAS['rc/thread-lookup/ok']),
   frameSchema('rc/collab-routes', RELAY_CP_SCHEMAS['rc/collab-routes']),

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -62,12 +62,12 @@ export const RD_HEADLESS_AGENT_DELIVERY_V1 = 'headless-agent-delivery-v1'
 
 /**
  * `agent-implicit-routing-v1`: this daemon understands {@link RdMsgIm.trustedRouteVia}
- * and applies its `!stop` thread mute to an implicitly-selected agent continuation.
+ * and applies its `!stop` thread mute to an implicitly-selected per-target delivery.
  *
  * Without it the relay must NOT forward such a continuation at all: an older daemon
- * ignores the field and treats every agent-authored delivery as an explicit mention,
- * which would clear the mute — so during a mixed-version rollout the one control a human
- * has over a runaway agent exchange would silently stop working. Refusing to forward
+ * ignores the field and can treat an implicit peer copy as an explicit mention, which
+ * would clear the mute — so during a mixed-version rollout the one control a human has
+ * over a runaway agent exchange would silently stop working. Refusing to forward
  * degrades to the pre-change behavior (the agent conversation simply does not continue
  * through that daemon), which is the fail-closed direction.
  */
@@ -222,11 +222,10 @@ export const RdMsgIm = z.object({
   // authorship could not be proven exactly (a shared bot with no exact claim fails
   // closed and is never promoted to call-policy identity, §4).
   trustedFromAgentId: z.string().uuid().optional(),
-  // The verified logical response this physical message belongs to, and the recipient
-  // set resolved from that COMPLETE response. The target selects from this set rather
-  // than reparsing the last physical message, and deduplicates on
-  // (trustedResponseId, target agent) — so a mention in section one still activates
-  // exactly once when finalization lands in section two (§5).
+  // The verified logical response this physical message belongs to, and the target(s)
+  // the relay minted for this pre-addressed edge. The target never trusts provider
+  // metadata to substitute a different agent; ordinary participant selection already
+  // happened at the relay, while paired delivery keeps its exact tool-named target.
   trustedResponseId: z.string().min(1).optional(),
   trustedRecipientAgentIds: z.array(z.string().uuid()).max(64).optional(),
   // Correlates the visible half of a paired `toAgent + channel` send with the internal
@@ -239,11 +238,10 @@ export const RdMsgIm = z.object({
   // its range and installs it as trusted active-turn call metadata WITHOUT incrementing
   // it a second time — double-counting here would halve the effective hop budget.
   trustedDeliveryHopCount: z.number().int().nonnegative().optional(),
-  // WHICH rung selected this target, because the two are not interchangeable at the
-  // target's `!stop` gate: an explicit mention clears a mute ("stop reacting to this
-  // conversation implicitly" was never "ignore anyone who names me"), while an implicit
-  // continuation must stay silenced like any other implicit rung. Absent ⇒ 'mention':
-  // a relay old enough to omit it only ever routed explicit mentions.
+  // WHICH cause applies to THIS target, because one body can explicitly join one agent
+  // while existing peers receive implicit copies. The causes are not interchangeable at
+  // `!stop`: a human mention clears the named target's mute, while implicit participants
+  // stay silenced. Absent ⇒ 'mention' for compatibility with older relay frames.
   trustedRouteVia: z.enum(['mention', 'implicit']).optional()
 })
 export type RdMsgIm = z.infer<typeof RdMsgIm>

--- a/packages/protocol/src/normalized-message.ts
+++ b/packages/protocol/src/normalized-message.ts
@@ -111,6 +111,20 @@ export const NormalizedPlatformMessageSchema = z.object({
   }),
   text: z.string(),
   mentionedBots: z.array(z.string()),
+  /** An EXTRA dedup dimension for two arrivals that describe the SAME platform message.
+   *
+   * A streamed agent reply is posted once and then closed by an edit, and both events
+   * carry the same Slack `ts` — but only the closing edit is routable, and it is the one
+   * that carries the recipient set. Ingress dedups on `msgId`, so without a second
+   * dimension the closing edit is dropped as a duplicate of the post.
+   *
+   * It lives here rather than being folded into `msgId` because `msgId` also CARRIES the
+   * platform ts: consumers recover it by splitting the id, and the transcript uses that ts
+   * as both its dedup key and its ordering key. Encoding an arrival distinction there
+   * corrupts both — which is exactly what a `:final` msgId suffix did.
+   *
+   * Absent ⇒ the ordinary single arrival. */
+  ingressEventTag: z.string().min(1).max(32).optional(),
   attachments: z.array(PlatformAttachmentSchema).optional(),
   isDm: z.boolean(),
   /** Slack `mpim`: classification only; a group DM remains mention-gated. */

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -111,6 +111,29 @@ describe('HTTP-bot arbitration (§10)', () => {
     expect(arbitrate(assignment(), msg({ sender: { id: BOTUSER, isBot: true } }), empty())).toBeNull()
   })
 
+  it('does not let a verified agent mention enable shared-bot default selection', () => {
+    const author = 'agent-author'
+    const mentioned = arbitrate(
+      assignment(),
+      msg({
+        channel: 'CX',
+        sender: { id: 'UAGENT', isBot: true },
+        text: '<@UBOT> hello',
+        mentionedBots: [BOTUSER]
+      }),
+      empty(),
+      author
+    )
+    const unmentioned = arbitrate(
+      assignment(),
+      msg({ channel: 'CX', sender: { id: 'UAGENT', isBot: true }, text: 'hello', mentionedBots: [] }),
+      empty(),
+      author
+    )
+    expect(mentioned).toEqual(unmentioned)
+    expect(mentioned).toBeNull()
+  })
+
   it('thread continuity carries an un-mentioned follow-up to the prior agent', () => {
     const aff = new Map<string, RouteTarget>([['CX/ts1', { agentId: BOB, daemonId: D2, integrationId: 'iB' }]])
     const t = arbitrate(assignment(), msg({ channel: 'CX', thread: 'ts1', text: 'and then?' }), aff)

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -145,6 +145,10 @@ export function arbitrate(
   // 1. Channel ownership (§10.1, the primary path): a channel-scoped rule that
   //    matches the message kind wins outright (mention rule needs the @bot; auto
   //    rule fires on any message — the operator's trigger choice).
+  // A mention JOINS an agent to the thread (§2.3), so the relay must still honour it —
+  // it is how a peer on ANOTHER daemon is reached at all. The owning daemon then fans the
+  // message out to the rest of the thread's local participants; the relay holds no
+  // sessions and cannot know them.
   const ownedMention = scoped.find((r) => r.match.kind === 'mention' && kindMatches(r, msg, a.botUserId))
   if (ownedMention) return target(ownedMention)
   // Conversation-scoped keyword (§14.3): slug disambiguation inside a multi-agent DM

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -80,6 +80,13 @@ export interface RouteTarget {
   integrationId: string
 }
 
+export interface ConversationTarget {
+  target: RouteTarget
+  /** Explicit only for a human mention. Agent-authored traffic can join a peer by
+   * mention, but remains implicit so it cannot clear a human's `!stop` latch. */
+  via: 'mention' | 'implicit'
+}
+
 /** `channel/thread` — the per-conversation affinity + rc/assign key. */
 export function sessionKeyOf(msg: Pick<WireNormalizedMessage, 'channel' | 'thread'>): string {
   return `${msg.channel}/${msg.thread ?? msg.channel}`
@@ -145,11 +152,14 @@ export function arbitrate(
   // 1. Channel ownership (§10.1, the primary path): a channel-scoped rule that
   //    matches the message kind wins outright (mention rule needs the @bot; auto
   //    rule fires on any message — the operator's trigger choice).
-  // A mention JOINS an agent to the thread (§2.3), so the relay must still honour it —
-  // it is how a peer on ANOTHER daemon is reached at all. The owning daemon then fans the
-  // message out to the rest of the thread's local participants; the relay holds no
-  // sessions and cannot know them.
-  const ownedMention = scoped.find((r) => r.match.kind === 'mention' && kindMatches(r, msg, a.botUserId))
+  // A HUMAN mention can still nominate the compatibility primary. `conversationTargets`
+  // independently joins every matching route and fans to the remembered room, including
+  // peers on other daemons. Verified agent traffic skips this selector: its mention can
+  // add a participant but never narrows the room or clears a human's stop latch.
+  const ownedMention =
+    verifiedAgentAuthor === undefined
+      ? scoped.find((r) => r.match.kind === 'mention' && kindMatches(r, msg, a.botUserId))
+      : undefined
   if (ownedMention) return target(ownedMention)
   // Conversation-scoped keyword (§14.3): slug disambiguation inside a multi-agent DM
   // enabled for several gated agents — outranks the scoped auto so "<slug> …"
@@ -179,7 +189,7 @@ export function arbitrate(
   // 3. Keyword disambiguation (§10.2): "@bot <slug> …" → that agent. Only when the
   //    bot was actually addressed (a mention or a DM), so a stray slug substring in
   //    a normal channel message doesn't trigger it.
-  const addressed = explicitlyMentioned || msg.isDm
+  const addressed = msg.isDm || (verifiedAgentAuthor === undefined && explicitlyMentioned)
   if (addressed) {
     const kw = routes.find((r) => r.match.kind === 'keyword' && !r.scope && kindMatches(r, msg, a.botUserId))
     if (kw) return target(kw)
@@ -197,11 +207,15 @@ export function arbitrate(
 
 /** Cap on a bot's negative-affinity set before it is flushed (bounds CP lookups). */
 const MAX_NEGATIVE_AFFINITY = 10_000
+const MAX_PARTICIPANT_CONVERSATIONS = 10_000
 
 export class BotArbitrationRouter {
   private readonly bots = new Map<string, BotAssignment>()
   /** Per-bot thread affinity: botId → (sessionKey → target). */
   private readonly affinity = new Map<string, Map<string, RouteTarget>>()
+  /** Every agent that has joined a conversation on this HTTP bot. Unlike `affinity`,
+   * this is a set: a shared-bot thread can span several daemons and has no single owner. */
+  private readonly participants = new Map<string, Map<string, Map<string, RouteTarget>>>()
   /** Per-bot NEGATIVE affinity: sessionKeys the CP confirmed hold no owner. Prevents
    *  an un-owned thread's every follow-up from re-hitting the CP (`rc/thread-lookup`). */
   private readonly noAffinity = new Map<string, Set<string>>()
@@ -212,6 +226,7 @@ export class BotArbitrationRouter {
     if (prev?.botUserId && a.botUserId === undefined) a.botUserId = prev.botUserId
     this.bots.set(a.botId, a)
     if (!this.affinity.has(a.botId)) this.affinity.set(a.botId, new Map())
+    if (!this.participants.has(a.botId)) this.participants.set(a.botId, new Map())
   }
 
   /** Replace routes/members/agents/default WITHOUT touching secrets or botUserId (rc/routes). */
@@ -249,6 +264,7 @@ export class BotArbitrationRouter {
     const a = this.bots.get(botId)
     this.bots.delete(botId)
     this.affinity.delete(botId)
+    this.participants.delete(botId)
     this.noAffinity.delete(botId)
     return a
   }
@@ -523,6 +539,58 @@ export class BotArbitrationRouter {
     if (!a) return null
     const aff = this.affinity.get(botId) ?? new Map<string, RouteTarget>()
     return arbitrate(a, msg, aff, authorAgentId)
+  }
+
+  /** Resolve every recipient of one conversation event and remember the joined set.
+   *
+   * The ordinary ladder may still produce a primary for compatibility/reporting, but it
+   * does not bound delivery. Existing participants, every newly mentioned route, and
+   * every scoped `auto` route are independent targets. This state lives beside affinity
+   * because affinity intentionally models one legacy owner and collapses in the exact
+   * multi-agent shape this method serves. */
+  conversationTargets(
+    botId: string,
+    msg: WireNormalizedMessage,
+    primary?: RouteTarget | null,
+    verifiedAgentAuthor?: string
+  ): ConversationTarget[] {
+    const a = this.bots.get(botId)
+    if (!a || a.mutedChannels?.includes(msg.channel)) return []
+    const key = sessionKeyOf(msg)
+    const byConversation = this.participants.get(botId) ?? new Map<string, Map<string, RouteTarget>>()
+    const remembered = byConversation.get(key) ?? new Map<string, RouteTarget>()
+
+    const explicitIds = new Set<string>()
+    if (a.botUserId !== undefined && msg.mentionedBots.includes(a.botUserId)) {
+      for (const route of a.routes) {
+        if (route.match.kind !== 'mention' || !scopeMatches(route, msg)) continue
+        if (route.agentId !== verifiedAgentAuthor) explicitIds.add(route.agentId)
+      }
+    }
+
+    const selected = new Map<string, ConversationTarget>()
+    const add = (candidate: RouteTarget, via: 'mention' | 'implicit'): void => {
+      if (candidate.agentId === verifiedAgentAuthor) return
+      const current = this.agentTarget(botId, candidate.agentId, msg.channel)
+      if (!current) return
+      const effectiveVia = verifiedAgentAuthor === undefined && via === 'mention' ? 'mention' : 'implicit'
+      const previous = selected.get(current.agentId)
+      if (!previous || effectiveVia === 'mention') selected.set(current.agentId, { target: current, via: effectiveVia })
+      if (!byConversation.has(key)) {
+        if (byConversation.size >= MAX_PARTICIPANT_CONVERSATIONS) byConversation.clear()
+        byConversation.set(key, remembered)
+        this.participants.set(botId, byConversation)
+      }
+      remembered.set(current.agentId, current)
+    }
+
+    if (primary) add(primary, explicitIds.has(primary.agentId) ? 'mention' : 'implicit')
+    for (const route of a.routes) {
+      if (explicitIds.has(route.agentId)) add(target(route), 'mention')
+      if (route.match.kind === 'auto' && scopeMatches(route, msg)) add(target(route), 'implicit')
+    }
+    for (const participant of remembered.values()) add(participant, 'implicit')
+    return [...selected.values()]
   }
 
   /** Every currently-assigned bot (ingest lifecycle reconciliation). */

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -566,7 +566,8 @@ export class BotArbitrationRouter {
     primary?: RouteTarget | null,
     verifiedAgentAuthor?: string,
     joinedAgentIds: readonly string[] = [],
-    onJoin?: (target: RouteTarget) => void
+    onJoin?: (target: RouteTarget) => void,
+    admitsNewJoin?: (target: RouteTarget) => boolean
   ): ConversationTarget[] {
     const a = this.bots.get(botId)
     if (!a || a.mutedChannels?.includes(msg.channel)) return []
@@ -592,6 +593,12 @@ export class BotArbitrationRouter {
       if (candidate.agentId === verifiedAgentAuthor) return
       const current = this.agentTarget(botId, candidate.agentId, msg.channel)
       if (!current) return
+      const previousParticipant = remembered.get(current.agentId)
+      // Policy is part of admission, not merely this event's delivery. A denied
+      // agent-authored edge must not leave behind local or durable membership that
+      // a later human follow-up could activate. Existing legitimate membership is
+      // retained; the caller still re-checks policy before each agent-authored copy.
+      if (!previousParticipant && admitsNewJoin && !admitsNewJoin(current)) return
       const effectiveVia = verifiedAgentAuthor === undefined && via === 'mention' ? 'mention' : 'implicit'
       const previous = selected.get(current.agentId)
       if (!previous || effectiveVia === 'mention') selected.set(current.agentId, { target: current, via: effectiveVia })
@@ -600,7 +607,6 @@ export class BotArbitrationRouter {
         byConversation.set(key, remembered)
         this.participants.set(botId, byConversation)
       }
-      const previousParticipant = remembered.get(current.agentId)
       remembered.set(current.agentId, current)
       if (
         !previousParticipant ||

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -412,8 +412,20 @@ export class BotArbitrationRouter {
   /** Durable thread affinity from `rc/assign` (survives relay restart / re-assign). */
   setAffinity(botId: string, sessionKey: string, tgt: RouteTarget): void {
     ;(this.affinity.get(botId) ?? this.affinity.set(botId, new Map()).get(botId)!).set(sessionKey, tgt)
+    this.setParticipant(botId, sessionKey, tgt)
     // A now-owned thread must leave the negative cache (a Switch-agent / late assign).
     this.noAffinity.get(botId)?.delete(sessionKey)
+  }
+
+  /** Durable conversation member from an `rc/participant-assign` projection. */
+  setParticipant(botId: string, sessionKey: string, tgt: RouteTarget): void {
+    const byConversation = this.participants.get(botId) ?? this.participants.set(botId, new Map()).get(botId)!
+    const members = byConversation.get(sessionKey) ?? new Map<string, RouteTarget>()
+    if (!byConversation.has(sessionKey)) {
+      if (byConversation.size >= MAX_PARTICIPANT_CONVERSATIONS) byConversation.clear()
+      byConversation.set(sessionKey, members)
+    }
+    members.set(tgt.agentId, tgt)
   }
 
   /** Read the current affinity for a thread WITHOUT resolving (the report leg's
@@ -552,7 +564,9 @@ export class BotArbitrationRouter {
     botId: string,
     msg: WireNormalizedMessage,
     primary?: RouteTarget | null,
-    verifiedAgentAuthor?: string
+    verifiedAgentAuthor?: string,
+    joinedAgentIds: readonly string[] = [],
+    onJoin?: (target: RouteTarget) => void
   ): ConversationTarget[] {
     const a = this.bots.get(botId)
     if (!a || a.mutedChannels?.includes(msg.channel)) return []
@@ -561,11 +575,16 @@ export class BotArbitrationRouter {
     const remembered = byConversation.get(key) ?? new Map<string, RouteTarget>()
 
     const explicitIds = new Set<string>()
-    if (a.botUserId !== undefined && msg.mentionedBots.includes(a.botUserId)) {
+    const namesBot = a.botUserId !== undefined && msg.mentionedBots.includes(a.botUserId)
+    if (namesBot) {
       for (const route of a.routes) {
         if (route.match.kind !== 'mention' || !scopeMatches(route, msg)) continue
         if (route.agentId !== verifiedAgentAuthor) explicitIds.add(route.agentId)
       }
+      // A human explicitly addressed this bot. Even when channel ownership is an
+      // `auto` rule, the compatibility primary is the named target and must receive
+      // target-specific mention semantics so it can clear its own `!stop` latch.
+      if (verifiedAgentAuthor === undefined && primary) explicitIds.add(primary.agentId)
     }
 
     const selected = new Map<string, ConversationTarget>()
@@ -581,13 +600,28 @@ export class BotArbitrationRouter {
         byConversation.set(key, remembered)
         this.participants.set(botId, byConversation)
       }
+      const previousParticipant = remembered.get(current.agentId)
       remembered.set(current.agentId, current)
+      if (
+        !previousParticipant ||
+        previousParticipant.daemonId !== current.daemonId ||
+        previousParticipant.integrationId !== current.integrationId
+      ) {
+        onJoin?.(current)
+      }
     }
 
     if (primary) add(primary, explicitIds.has(primary.agentId) ? 'mention' : 'implicit')
     for (const route of a.routes) {
       if (explicitIds.has(route.agentId)) add(target(route), 'mention')
       if (route.match.kind === 'auto' && scopeMatches(route, msg)) add(target(route), 'implicit')
+    }
+    // The verified final carries exact resolved agent ids across provider
+    // splitting/echo. They JOIN the room but never replace its existing members,
+    // and agent-authored joins remain implicit so they cannot lift a human stop.
+    for (const agentId of joinedAgentIds) {
+      const joined = this.agentTarget(botId, agentId, msg.channel)
+      if (joined) add(joined, 'implicit')
     }
     for (const participant of remembered.values()) add(participant, 'implicit')
     return [...selected.values()]

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -148,8 +148,12 @@ async function main(): Promise<void> {
         noticeAuthority: r.noticeAuthority,
         noticedDmConversations: r.noticedDmConversations
       }),
-    onAssign: (a) =>
-      held.relayIngress?.setAffinity(a.botId, a.sessionKey, {
+    onAssign: (a) => {
+      const target = { agentId: a.agentId, daemonId: a.daemonId, integrationId: '' }
+      held.relayIngress?.setAffinity(a.botId, a.sessionKey, target)
+    },
+    onParticipantAssign: (a) =>
+      held.relayIngress?.setParticipant(a.botId, a.sessionKey, {
         agentId: a.agentId,
         daemonId: a.daemonId,
         integrationId: ''
@@ -180,6 +184,7 @@ async function main(): Promise<void> {
     reportBotRevoked: (m) => client.reportBotRevoked(m),
     selfRelayId: () => client.relayId,
     reportThreadAssign: (m) => client.emitThreadAssign(m),
+    reportThreadParticipant: (m) => client.emitThreadParticipant(m),
     lookupThread: (m) => client.lookupThread(m),
     isAgentBotApp: (targetAgentId, platform, channelId, appId) =>
       collab.isAgentBotAppFor(targetAgentId, platform, channelId, appId),

--- a/packages/relay/src/relay-cp-client.test.ts
+++ b/packages/relay/src/relay-cp-client.test.ts
@@ -136,6 +136,25 @@ describe('RelayCpClient', () => {
     expect(onRevoke).toHaveBeenCalledWith(DAEMON_ID)
   })
 
+  it('dispatches owner affinity and participant membership independently', async () => {
+    const onAssign = vi.fn()
+    const onParticipantAssign = vi.fn()
+    const { client, transport } = makeClient({ onAssign, onParticipantAssign })
+    await handshakeToReady(client, transport)
+    const target = {
+      botId: RELAY_ID,
+      sessionKey: 'C1/ts',
+      agentId: RELAY_ID,
+      daemonId: DAEMON_ID
+    }
+
+    transport.inject(buildRelayCpFrame('rc/assign', target))
+    transport.inject(buildRelayCpFrame('rc/participant-assign', target))
+
+    expect(onAssign).toHaveBeenCalledWith(target)
+    expect(onParticipantAssign).toHaveBeenCalledWith(target)
+  })
+
   it('dispatches purpose-separated memory connection bindings', async () => {
     const onMemoryConnectionAssign = vi.fn()
     const onMemoryConnectionUnassign = vi.fn()
@@ -187,6 +206,23 @@ describe('RelayCpClient', () => {
     await handshakeToReady(client, transport)
     expect(client.emitBotChannels(snapshot)).toBe(true)
     expect(transport.lastReq('rc/bot-channels')?.payload).toEqual(snapshot)
+  })
+
+  it('emits participant joins without overloading thread-owner reports', async () => {
+    const { client, transport } = makeClient()
+    const target = {
+      botId: RELAY_ID,
+      sessionKey: 'C1/ts',
+      agentId: RELAY_ID,
+      daemonId: DAEMON_ID
+    }
+
+    expect(client.emitThreadParticipant(target)).toBe(false)
+    await handshakeToReady(client, transport)
+    expect(client.emitThreadParticipant(target)).toBe(true)
+
+    expect(transport.lastReq('rc/thread-participant')?.payload).toEqual(target)
+    expect(transport.lastReq('rc/thread-assign')).toBeUndefined()
   })
 
   it('reconnects with backoff on a non-fatal close', async () => {

--- a/packages/relay/src/relay-cp-client.ts
+++ b/packages/relay/src/relay-cp-client.ts
@@ -28,6 +28,7 @@ import {
   type RcBotUnassign,
   type RcRoutes,
   type RcAssign,
+  type RcParticipantAssign,
   type RcHookAssign,
   type RcHookRemove,
   type RcRunReport,
@@ -38,6 +39,7 @@ import {
   type RcBotRevoked,
   type RcNoticePosted,
   type RcThreadAssign,
+  type RcThreadParticipant,
   type RcThreadLookup,
   type RcThreadLookupOk,
   type RcCollabRoutes,
@@ -91,6 +93,7 @@ export interface RelayCpClientDeps {
   onBotUnassign?: (a: RcBotUnassign) => void
   onRoutes?: (r: RcRoutes) => void
   onAssign?: (a: RcAssign) => void
+  onParticipantAssign?: (a: RcParticipantAssign) => void
   /** Called on a CP `rc/hook-assign` EVT — upsert one compiled hook rule
    *  (webhook-triggers doc). The rule carries `hmacSecret` — NEVER log it. */
   onHookAssign?: (rule: RcHookAssign) => void
@@ -321,6 +324,16 @@ export class RelayCpClient {
     return true
   }
 
+  /** Persist one room member without touching the compatibility owner. */
+  emitThreadParticipant(m: RcThreadParticipant): boolean {
+    if (this.state !== 'READY' || !this.transport) {
+      this.deps.log.warn(`relay: deferring rc/thread-participant for ${m.botId} (link ${this.state})`)
+      return false
+    }
+    this.transport.send(JSON.stringify(buildRelayCpFrame('rc/thread-participant', m)))
+    return true
+  }
+
   /** `rc/thread-lookup` → `rc/thread-lookup/ok` — pull-on-miss BACKSTOP leg. When an
    *  un-mentioned follow-up arrives for a thread this pod holds no affinity for (missed
    *  the broadcast, or (re)started after it), pull the persisted owner rather than drop.
@@ -440,6 +453,10 @@ export class RelayCpClient {
       }
       case 'rc/assign': {
         this.deps.onAssign?.(frame.payload as RcAssign)
+        return
+      }
+      case 'rc/participant-assign': {
+        this.deps.onParticipantAssign?.(frame.payload as RcParticipantAssign)
         return
       }
       case 'rc/hook-assign': {

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -662,6 +662,27 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       expect(explicit.sendMsg).not.toHaveBeenCalled()
     })
 
+    it('routes a PAIRED delivery to the exact agent `sendMessage` named', async () => {
+      // The one target that is structured rather than parsed. Arbitration could pick the
+      // channel default or thread owner instead, which would record the visible
+      // observation against an agent the internal wake never names — the rendezvous would
+      // then never reconcile and the delivery would expire transcript-only.
+      const { internals, sendMsg } = managerWith()
+      await internals.forward(
+        BOT_ID,
+        agentFinal(
+          { mentionedAgentIds: [AGENT_ID], agentCallDeliveryId: 'd-7' },
+          { text: 'take a look', mentionedBots: [] }
+        )
+      )
+      expect(sendMsg).toHaveBeenCalledTimes(1)
+      expect(sendMsg.mock.calls[0]![0]).toMatchObject({
+        agentId: AGENT_ID,
+        trustedAgentCallDeliveryId: 'd-7',
+        trustedRouteVia: 'mention'
+      })
+    })
+
     it('always reports the delivery as implicitly selected', async () => {
       // Every agent-authored forward is arbitration-selected now, mention in the body or
       // not — the target needs that fact to apply its `!stop` gate correctly.

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -900,6 +900,63 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       })
     })
 
+    it('does not remember or persist a policy-denied join for a later human follow-up', async () => {
+      const first = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+      const second = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+      const daemon = (sendMsg: typeof first) => ({ sendMsg, supports: () => true }) as unknown as RelayDaemonConnection
+      const reportThreadParticipant = vi.fn(() => true)
+      const manager = new RelayIngressManager(
+        deps({
+          getDaemon: (id) =>
+            id === DAEMON_ID ? daemon(first) : id === OTHER_DAEMON_ID ? daemon(second as typeof first) : undefined,
+          isAgentBotApp: vi.fn(() => true),
+          admitsAgentCall: vi.fn((_author, target) => target !== OTHER_AGENT_ID),
+          reportThreadParticipant
+        })
+      )
+      const internals = manager as unknown as ManagerInternals
+      const shared = assignment()
+      shared.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
+      shared.agents.push({
+        agentId: OTHER_AGENT_ID,
+        name: 'Other',
+        daemonId: OTHER_DAEMON_ID,
+        integrationId: OTHER_INTEGRATION_ID
+      })
+      shared.routes = [
+        {
+          agentId: AGENT_ID,
+          daemonId: DAEMON_ID,
+          integrationId: INTEGRATION_ID,
+          scope: { channel: 'C123' },
+          match: { kind: 'auto' }
+        },
+        {
+          agentId: OTHER_AGENT_ID,
+          daemonId: OTHER_DAEMON_ID,
+          integrationId: OTHER_INTEGRATION_ID,
+          match: { kind: 'keyword', value: 'other' }
+        }
+      ]
+      internals.router.upsert(shared)
+
+      await internals.forward(
+        BOT_ID,
+        agentFinal(
+          { mentionedAgentIds: [OTHER_AGENT_ID] },
+          { text: '<@opaque-other> please join', mentionedBots: ['UBOT'] }
+        )
+      )
+
+      expect(second).not.toHaveBeenCalled()
+      expect(reportThreadParticipant).not.toHaveBeenCalledWith(expect.objectContaining({ agentId: OTHER_AGENT_ID }))
+
+      first.mockClear()
+      await internals.forward(BOT_ID, followUp({ msgId: 'slack:C123:human-after-denied-join' }))
+      expect(first).toHaveBeenCalledTimes(1)
+      expect(second).not.toHaveBeenCalled()
+    })
+
     it('admits source depth 7 as delivery depth 8 and rejects 8 because the next hop is 9', async () => {
       // §10 case 15 — the boundary the whole hop transition exists to hold.
       const admitted = managerWith()

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -467,6 +467,42 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     expect(reportThreadAssign).not.toHaveBeenCalled() // ...but no write amplification
   })
 
+  it('derives explicit join and implicit participant causes per relay target', async () => {
+    const first = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+    const second = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+    const daemon = (sendMsg: typeof first) => ({ sendMsg, supports: () => true }) as unknown as RelayDaemonConnection
+    const manager = new RelayIngressManager(
+      deps({
+        getDaemon: (id) =>
+          id === DAEMON_ID ? daemon(first) : id === OTHER_DAEMON_ID ? daemon(second as typeof first) : undefined
+      })
+    )
+    const internals = manager as unknown as ManagerInternals
+    const shared = channelOwned()
+    shared.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
+    shared.agents.push({
+      agentId: OTHER_AGENT_ID,
+      name: 'Other',
+      daemonId: OTHER_DAEMON_ID,
+      integrationId: OTHER_INTEGRATION_ID
+    })
+    shared.routes.push({
+      agentId: OTHER_AGENT_ID,
+      daemonId: OTHER_DAEMON_ID,
+      integrationId: OTHER_INTEGRATION_ID,
+      scope: { channel: 'C123' },
+      match: { kind: 'auto' }
+    })
+    internals.router.upsert(shared)
+
+    await internals.forward(
+      BOT_ID,
+      followUp({ msgId: 'slack:C123:per-target', text: '<@UBOT> join', mentionedBots: ['UBOT'] })
+    )
+    expect(first.mock.calls[0]![0]).toMatchObject({ agentId: AGENT_ID, trustedRouteVia: 'mention' })
+    expect(second.mock.calls[0]![0]).toMatchObject({ agentId: OTHER_AGENT_ID, trustedRouteVia: 'implicit' })
+  })
+
   it('keeps an UNVERIFIED agent bot off routing but forwards an explicitly mentioning third-party bot', async () => {
     // send-message-routing-rework.md §4 fails closed: an AgentConnect app whose message
     // carries no provable authorship claim (here: no `agentAuthorship` metadata at all)
@@ -479,7 +515,17 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     })
     const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, reportThreadAssign, isAgentBotApp }))
     const internals = manager as unknown as ManagerInternals
-    internals.router.upsert(channelAutoOwned())
+    const shared = channelAutoOwned()
+    shared.members[0]!.agentIds.push(OTHER_AGENT_ID)
+    shared.agents.push({ agentId: OTHER_AGENT_ID, name: 'Other' })
+    shared.routes.push({
+      agentId: OTHER_AGENT_ID,
+      daemonId: DAEMON_ID,
+      integrationId: OTHER_INTEGRATION_ID,
+      scope: { channel: 'C123' },
+      match: { kind: 'auto' }
+    })
+    internals.router.upsert(shared)
 
     await internals.forward(
       BOT_ID,
@@ -500,6 +546,8 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       })
     )
 
+    // The third-party bot remains strict mention-only: it reaches the one arbitration
+    // primary, not every auto/participant route on this AgentConnect-managed bot.
     expect(sendMsg).toHaveBeenCalledTimes(1)
     expect(sendMsg.mock.calls[0]![0]).toMatchObject({ msgId: 'slack:C123:external', agentId: AGENT_ID })
     expect(reportThreadAssign).not.toHaveBeenCalled()
@@ -696,6 +744,91 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
         agentFinal({ mentionedAgentIds: [] }, { text: 'that matches what I saw', mentionedBots: [] })
       )
       expect(implicit.sendMsg.mock.calls[0]![0]).toMatchObject({ trustedRouteVia: 'implicit' })
+    })
+
+    it('fans a shared-bot conversation across daemons after the primary becomes ambiguous', async () => {
+      const firstDaemonSend = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+      const secondDaemonSend = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+      const currentDaemon = (sendMsg: typeof firstDaemonSend) =>
+        ({ sendMsg, supports: () => true }) as unknown as RelayDaemonConnection
+      const manager = new RelayIngressManager(
+        deps({
+          getDaemon: (daemonId) =>
+            daemonId === DAEMON_ID
+              ? currentDaemon(firstDaemonSend)
+              : daemonId === OTHER_DAEMON_ID
+                ? currentDaemon(secondDaemonSend as typeof firstDaemonSend)
+                : undefined,
+          isAgentBotApp: vi.fn(() => true)
+        })
+      )
+      const internals = manager as unknown as ManagerInternals
+      const shared = assignment()
+      shared.botUserId = 'UBOT'
+      shared.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
+      shared.agents = [
+        { agentId: AGENT_ID, name: 'Agent', daemonId: DAEMON_ID, integrationId: INTEGRATION_ID },
+        {
+          agentId: OTHER_AGENT_ID,
+          name: 'Other',
+          daemonId: OTHER_DAEMON_ID,
+          integrationId: OTHER_INTEGRATION_ID
+        }
+      ]
+      shared.routes = [
+        {
+          agentId: AGENT_ID,
+          daemonId: DAEMON_ID,
+          integrationId: INTEGRATION_ID,
+          scope: { channel: 'C123' },
+          match: { kind: 'mention' }
+        },
+        {
+          agentId: OTHER_AGENT_ID,
+          daemonId: OTHER_DAEMON_ID,
+          integrationId: OTHER_INTEGRATION_ID,
+          scope: { channel: 'C123' },
+          match: { kind: 'mention' }
+        }
+      ]
+      internals.router.upsert(shared)
+
+      // One human mention joins BOTH matching routes, with an independent explicit cause.
+      await internals.forward(
+        BOT_ID,
+        followUp({ msgId: 'slack:C123:join', text: '<@UBOT> both of you', mentionedBots: ['UBOT'] })
+      )
+      expect(firstDaemonSend).toHaveBeenCalledTimes(1)
+      expect(secondDaemonSend).toHaveBeenCalledTimes(1)
+      expect(firstDaemonSend.mock.calls[0]![0]).toMatchObject({
+        agentId: AGENT_ID,
+        trustedRouteVia: 'mention'
+      })
+      expect(secondDaemonSend.mock.calls[0]![0]).toMatchObject({
+        agentId: OTHER_AGENT_ID,
+        trustedRouteVia: 'mention'
+      })
+
+      firstDaemonSend.mockClear()
+      secondDaemonSend.mockClear()
+      // The remembered single affinity points at the author and is therefore unusable;
+      // both mention-only routes also match no rung. Participant state is the only path
+      // that can carry this unmentioned reply to the peer on the other daemon.
+      await internals.forward(
+        BOT_ID,
+        agentFinal(
+          { authorAgentId: AGENT_ID, mentionedAgentIds: [], hopCount: 4 },
+          { text: 'continuing without a mention', mentionedBots: [] }
+        )
+      )
+      expect(firstDaemonSend).not.toHaveBeenCalled()
+      expect(secondDaemonSend).toHaveBeenCalledTimes(1)
+      expect(secondDaemonSend.mock.calls[0]![0]).toMatchObject({
+        agentId: OTHER_AGENT_ID,
+        trustedFromAgentId: AGENT_ID,
+        trustedRouteVia: 'implicit',
+        trustedDeliveryHopCount: 5
+      })
     })
 
     it('admits source depth 7 as delivery depth 8 and rejects 8 because the next hop is 9', async () => {

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -46,7 +46,10 @@ const deps = (over: Partial<RelayIngressManagerDeps> = {}): RelayIngressManagerD
   reportBotRevoked: vi.fn(() => true),
   selfRelayId: () => SELF_RELAY,
   reportThreadAssign: vi.fn(() => true),
-  lookupThread: vi.fn(async () => ({ botId: BOT_ID, sessionKey: '', target: null }) as RcThreadLookupOk),
+  reportThreadParticipant: vi.fn(() => true),
+  lookupThread: vi.fn(
+    async () => ({ botId: BOT_ID, sessionKey: '', target: null, participants: [] }) as RcThreadLookupOk
+  ),
   isAgentBotApp: vi.fn(() => false),
   admitsAgentCall: vi.fn(() => true),
   clock: new FakeClock(),
@@ -453,10 +456,13 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     } satisfies RcThreadAssign)
   })
 
-  it('does NOT report for an `auto`-owned channel (every message re-resolves locally)', async () => {
+  it('persists an `auto` target as a participant without creating owner affinity', async () => {
     const reportThreadAssign = vi.fn(() => true)
+    const reportThreadParticipant = vi.fn(() => true)
     const { daemon, sendMsg } = online()
-    const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, reportThreadAssign }))
+    const manager = new RelayIngressManager(
+      deps({ getDaemon: () => daemon, reportThreadAssign, reportThreadParticipant })
+    )
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(channelAutoOwned())
 
@@ -464,7 +470,14 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     await internals.forward(BOT_ID, followUp())
 
     expect(sendMsg).toHaveBeenCalledTimes(2) // both delivered via the auto rung
-    expect(reportThreadAssign).not.toHaveBeenCalled() // ...but no write amplification
+    expect(reportThreadAssign).not.toHaveBeenCalled()
+    expect(reportThreadParticipant).toHaveBeenCalledTimes(1) // join once, not per message
+    expect(reportThreadParticipant).toHaveBeenCalledWith({
+      botId: BOT_ID,
+      sessionKey: 'C123/1720000000.000100',
+      agentId: AGENT_ID,
+      daemonId: DAEMON_ID
+    })
   })
 
   it('derives explicit join and implicit participant causes per relay target', async () => {
@@ -478,7 +491,9 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       })
     )
     const internals = manager as unknown as ManagerInternals
-    const shared = channelOwned()
+    // The named primary is selected by an AUTO owner, not a mention rule. A human
+    // still addressed this bot explicitly, so that target must get mention semantics.
+    const shared = channelAutoOwned()
     shared.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
     shared.agents.push({
       agentId: OTHER_AGENT_ID,
@@ -831,6 +846,60 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       })
     })
 
+    it('joins a resolved peer on the production scoped-owner plus unscoped-slug route shape', async () => {
+      const first = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+      const second = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+      const daemon = (sendMsg: typeof first) => ({ sendMsg, supports: () => true }) as unknown as RelayDaemonConnection
+      const manager = new RelayIngressManager(
+        deps({
+          getDaemon: (id) =>
+            id === DAEMON_ID ? daemon(first) : id === OTHER_DAEMON_ID ? daemon(second as typeof first) : undefined,
+          isAgentBotApp: vi.fn(() => true)
+        })
+      )
+      const internals = manager as unknown as ManagerInternals
+      const shared = assignment()
+      shared.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
+      shared.agents.push({
+        agentId: OTHER_AGENT_ID,
+        name: 'Other',
+        daemonId: OTHER_DAEMON_ID,
+        integrationId: OTHER_INTEGRATION_ID
+      })
+      shared.routes = [
+        {
+          agentId: AGENT_ID,
+          daemonId: DAEMON_ID,
+          integrationId: INTEGRATION_ID,
+          scope: { channel: 'C123' },
+          match: { kind: 'auto' }
+        },
+        {
+          agentId: OTHER_AGENT_ID,
+          daemonId: OTHER_DAEMON_ID,
+          integrationId: OTHER_INTEGRATION_ID,
+          match: { kind: 'keyword', value: 'other' }
+        }
+      ]
+      internals.router.upsert(shared)
+
+      await internals.forward(
+        BOT_ID,
+        agentFinal(
+          { mentionedAgentIds: [OTHER_AGENT_ID] },
+          { text: '<@opaque-other> please join', mentionedBots: ['UBOT'] }
+        )
+      )
+
+      expect(first).toHaveBeenCalledTimes(1)
+      expect(second).toHaveBeenCalledTimes(1)
+      expect(second.mock.calls[0]![0]).toMatchObject({
+        agentId: OTHER_AGENT_ID,
+        trustedRouteVia: 'implicit',
+        trustedFromAgentId: AUTHOR_ID
+      })
+    })
+
     it('admits source depth 7 as delivery depth 8 and rejects 8 because the next hop is 9', async () => {
       // §10 case 15 — the boundary the whole hop transition exists to hold.
       const admitted = managerWith()
@@ -1070,7 +1139,8 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     const lookupThread = vi.fn(async (): Promise<RcThreadLookupOk> => ({
       botId: BOT_ID,
       sessionKey: 'C123/1720000000.000100',
-      target: { agentId: AGENT_ID, daemonId: DAEMON_ID }
+      target: { agentId: AGENT_ID, daemonId: DAEMON_ID },
+      participants: [{ agentId: AGENT_ID, daemonId: DAEMON_ID }]
     }))
     const reportThreadAssign = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, lookupThread, reportThreadAssign }))
@@ -1098,11 +1168,66 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     expect(reportThreadAssign).not.toHaveBeenCalled()
   })
 
+  it('restores every durable participant from CP lookup after a relay restart', async () => {
+    const first = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+    const second = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+    const daemon = (sendMsg: typeof first) => ({ sendMsg, supports: () => true }) as unknown as RelayDaemonConnection
+    const lookupThread = vi.fn(async (): Promise<RcThreadLookupOk> => ({
+      botId: BOT_ID,
+      sessionKey: 'C123/1720000000.000100',
+      target: null,
+      participants: [
+        { agentId: AGENT_ID, daemonId: DAEMON_ID },
+        { agentId: OTHER_AGENT_ID, daemonId: OTHER_DAEMON_ID }
+      ]
+    }))
+    const manager = new RelayIngressManager(
+      deps({
+        lookupThread,
+        getDaemon: (id) =>
+          id === DAEMON_ID ? daemon(first) : id === OTHER_DAEMON_ID ? daemon(second as typeof first) : undefined
+      })
+    )
+    const internals = manager as unknown as ManagerInternals
+    const shared = assignment()
+    shared.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
+    shared.agents.push({
+      agentId: OTHER_AGENT_ID,
+      name: 'Other',
+      daemonId: OTHER_DAEMON_ID,
+      integrationId: OTHER_INTEGRATION_ID
+    })
+    shared.routes = [
+      {
+        agentId: AGENT_ID,
+        daemonId: DAEMON_ID,
+        integrationId: INTEGRATION_ID,
+        match: { kind: 'mention' }
+      },
+      {
+        agentId: OTHER_AGENT_ID,
+        daemonId: OTHER_DAEMON_ID,
+        integrationId: OTHER_INTEGRATION_ID,
+        match: { kind: 'mention' }
+      }
+    ]
+    internals.router.upsert(shared)
+
+    await internals.forward(BOT_ID, followUp())
+
+    expect(lookupThread).toHaveBeenCalledTimes(1)
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenCalledTimes(1)
+    expect(first.mock.calls[0]![0]).toMatchObject({ agentId: AGENT_ID, trustedRouteVia: 'implicit' })
+    expect(second.mock.calls[0]![0]).toMatchObject({ agentId: OTHER_AGENT_ID, trustedRouteVia: 'implicit' })
+  })
+
   it('remembers a CP miss and does not re-hit the CP for the same un-owned thread', async () => {
     const lookupThread = vi.fn(async (): Promise<RcThreadLookupOk> => ({
       botId: BOT_ID,
       sessionKey: 'C123/1720000000.000100',
-      target: null
+      target: null,
+      participants: []
     }))
     const { daemon, sendMsg } = online()
     const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, lookupThread }))

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -596,7 +596,9 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       // Judging emptiness after the author filter would make these two indistinguishable.
       const explicit = managerWith()
       await explicit.internals.forward(BOT_ID, agentFinal({ mentionedAgentIds: [AUTHOR_ID] }))
-      expect(explicit.sendMsg).not.toHaveBeenCalled()
+      for (const call of explicit.sendMsg.mock.calls) {
+        expect((call[0] as { agentId: string }).agentId).not.toBe(AUTHOR_ID)
+      }
 
       // With the author as the channel's ONLY route, the implicit rung has nobody left to
       // pick — and must resolve to nothing rather than back to the author.
@@ -641,54 +643,6 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       expect(sendMsg).not.toHaveBeenCalled()
     })
 
-    it('does not fall back to the implicit rung when a named recipient is refused', async () => {
-      // The named target is also the channel's `auto` route, so a fallthrough would
-      // "recover" by re-selecting the very agent whose policy just refused the edge. More
-      // generally: an author that named someone gets that someone or nobody, never a
-      // substitute it never asked for.
-      const { internals, sendMsg } = managerWith({ admitsAgentCall: vi.fn(() => false) })
-      await internals.forward(BOT_ID, agentFinal({ mentionedAgentIds: [AGENT_ID] }))
-      expect(sendMsg).not.toHaveBeenCalled()
-    })
-
-    it('does not continue when the response addressed a human', async () => {
-      // Parity with the direct ladder, which stops at any unmatched mention in a channel
-      // (`routeRules`) — for human senders too. `mentionedBots` holds every `<@U…>` token,
-      // so an `@human` reply resolves to no agent yet is still deliberate addressing.
-      // Without this the same event wakes an `auto` peer over the relay and nobody over a
-      // direct connection.
-      const { internals, sendMsg } = managerWith()
-      await internals.forward(
-        BOT_ID,
-        followUp({
-          msgId: 'slack:C123:agenttohuman',
-          sender: { id: 'UMANAGED', isBot: true, appId: 'AMANAGED' },
-          text: '<@UHUMAN> can you confirm?',
-          mentionedBots: ['UHUMAN'],
-          agentAuthorship: {
-            authorAgentId: AUTHOR_ID,
-            responseId: 'r-1',
-            deliveryState: 'final',
-            hopCount: 3,
-            mentionedAgentIds: []
-          }
-        })
-      )
-      expect(sendMsg).not.toHaveBeenCalled()
-    })
-
-    it('does not continue when the mention landed in an EARLIER split section', async () => {
-      // Same gap as the direct ladder: `mentionedBots` comes from the FINAL section only,
-      // so an address in section one leaves both mention sets empty here. The author's
-      // complete-response claim is what still carries it.
-      const { internals, sendMsg } = managerWith()
-      await internals.forward(
-        BOT_ID,
-        agentFinal({ mentionedAgentIds: [], addressedAnyone: true }, { text: '…the last part', mentionedBots: [] })
-      )
-      expect(sendMsg).not.toHaveBeenCalled()
-    })
-
     it('refuses to forward an implicit continuation to a daemon that predates the field', async () => {
       // §8.4 fail-closed. An older daemon ignores `trustedRouteVia` and reads every
       // agent-authored delivery as an explicit mention, which CLEARS a `!stop` mute — so
@@ -701,18 +655,19 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       )
       expect(older.sendMsg).not.toHaveBeenCalled()
 
-      // An EXPLICIT mention is unaffected: it means the same thing to both builds.
+      // A body that names a peer is no different — delivery is arbitration-selected either
+      // way, so an older daemon must not receive that either.
       const explicit = managerWith({}, undefined, () => false)
       await explicit.internals.forward(BOT_ID, agentFinal())
-      expect(explicit.sendMsg).toHaveBeenCalledTimes(1)
+      expect(explicit.sendMsg).not.toHaveBeenCalled()
     })
 
-    it('tells the target which rung selected it', async () => {
-      // The frame is pre-addressed to one agent either way, so the target cannot re-derive
-      // this — and it decides whether the delivery clears or obeys a `!stop` mute.
+    it('always reports the delivery as implicitly selected', async () => {
+      // Every agent-authored forward is arbitration-selected now, mention in the body or
+      // not — the target needs that fact to apply its `!stop` gate correctly.
       const mention = managerWith()
       await mention.internals.forward(BOT_ID, agentFinal())
-      expect(mention.sendMsg.mock.calls[0]![0]).toMatchObject({ trustedRouteVia: 'mention' })
+      expect(mention.sendMsg.mock.calls[0]![0]).toMatchObject({ trustedRouteVia: 'implicit' })
 
       const implicit = managerWith()
       await implicit.internals.forward(
@@ -740,26 +695,6 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
         await internals.forward(BOT_ID, agentFinal({ hopCount }))
         expect(sendMsg).not.toHaveBeenCalled()
       }
-    })
-
-    it('gives each recipient of one post its own delivery', async () => {
-      // §3.2: one visible post can address several agents; a shared msgId would make the
-      // targets' dedup collapse them and silently drop every recipient but the first.
-      const { internals, sendMsg } = managerWith()
-      const assignmentWithBoth = channelAutoOwned()
-      assignmentWithBoth.members = [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID, OTHER_AGENT_ID] }]
-      assignmentWithBoth.routes.push({
-        agentId: OTHER_AGENT_ID,
-        daemonId: DAEMON_ID,
-        integrationId: INTEGRATION_ID,
-        match: { kind: 'keyword', value: 'other' }
-      })
-      internals.router.upsert(assignmentWithBoth)
-
-      await internals.forward(BOT_ID, agentFinal({ mentionedAgentIds: [AGENT_ID, OTHER_AGENT_ID] }))
-      expect(sendMsg).toHaveBeenCalledTimes(2)
-      const msgIds = sendMsg.mock.calls.map((c) => (c[0] as { msgId: string }).msgId)
-      expect(new Set(msgIds).size).toBe(2)
     })
   })
 

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -31,6 +31,7 @@ import type {
   WireFeishuCardActionEvent,
   WireNormalizedMessage,
   RcThreadAssign,
+  RcThreadParticipant,
   RcThreadLookup
 } from '@agentconnect.md/protocol'
 import type { Clock } from '@agentconnect.md/connection'
@@ -105,6 +106,8 @@ export interface RelayIngressManagerDeps {
    *  `false` if the CP link was not READY and the frame was dropped, so the manager can
    *  retry it when the link recovers ({@link RelayIngressManager.flushPendingReports}). */
   reportThreadAssign: (m: RcThreadAssign) => boolean
+  /** Persist one joined participant without changing the compatibility owner. */
+  reportThreadParticipant: (m: RcThreadParticipant) => boolean
   /** Pull a thread's persisted owner from the CP on an affinity miss (→ `rc/thread-lookup`). */
   lookupThread: (m: RcThreadLookup) => Promise<import('@agentconnect.md/protocol').RcThreadLookupOk>
   /** This pod's CP-assigned relayId (stable pool identity; undefined before the
@@ -215,6 +218,7 @@ export class RelayIngressManager {
    *  {@link flushPendingReports}; without this a report lost during a CP blip would
    *  never persist and un-mentioned follow-ups on other pods would drop permanently. */
   private readonly pendingReports = new Map<string, RcThreadAssign>()
+  private readonly pendingParticipantReports = new Map<string, RcThreadParticipant>()
   /** Latest bot-level channel snapshot dropped while the CP link was down. A full
    *  snapshot supersedes any older one for the same bot. */
   private readonly pendingChannelReports = new Map<string, RcBotChannels>()
@@ -249,6 +253,41 @@ export class RelayIngressManager {
       if (this.pendingReports.size >= MAX_PENDING_REPORTS) this.pendingReports.clear()
       this.pendingReports.set(key, m)
     }
+  }
+
+  private reportParticipant(botId: string, sessionKey: string, target: RouteTarget): void {
+    const report: RcThreadParticipant = {
+      botId,
+      sessionKey,
+      agentId: target.agentId,
+      daemonId: target.daemonId
+    }
+    const key = `${botId}\u0000${sessionKey}\u0000${target.agentId}`
+    if (this.deps.reportThreadParticipant(report)) this.pendingParticipantReports.delete(key)
+    else {
+      if (this.pendingParticipantReports.size >= MAX_PENDING_REPORTS) this.pendingParticipantReports.clear()
+      this.pendingParticipantReports.set(key, report)
+    }
+  }
+
+  private reportHumanParticipant(
+    botId: string,
+    sessionKey: string,
+    channel: string,
+    primary: RouteTarget | null,
+    target: RouteTarget
+  ): void {
+    // A non-auto primary is persisted by the legacy owner report, whose CP handler
+    // also records it as a participant. Auto channels deliberately skip owner
+    // affinity, so their participant membership still needs its own durable report.
+    if (
+      primary?.agentId === target.agentId &&
+      primary.daemonId === target.daemonId &&
+      !this.router.channelAutoOwned(botId, channel)
+    ) {
+      return
+    }
+    this.reportParticipant(botId, sessionKey, target)
   }
 
   private reportChannels(m: RcBotChannels): void {
@@ -320,6 +359,10 @@ export class RelayIngressManager {
     for (const [key, m] of [...this.pendingReports]) {
       if (!this.deps.reportThreadAssign(m)) break
       this.pendingReports.delete(key)
+    }
+    for (const [key, m] of [...this.pendingParticipantReports]) {
+      if (!this.deps.reportThreadParticipant(m)) break
+      this.pendingParticipantReports.delete(key)
     }
     for (const [botId, snapshot] of [...this.pendingChannelReports]) {
       if (!this.deps.reportBotChannels(snapshot)) break
@@ -456,6 +499,11 @@ export class RelayIngressManager {
   /** `rc/assign` — durable thread affinity seed. */
   setAffinity(botId: string, sessionKey: string, tgt: RouteTarget): void {
     this.router.setAffinity(botId, sessionKey, tgt)
+  }
+
+  /** `rc/participant-assign` — durable conversation-member seed. */
+  setParticipant(botId: string, sessionKey: string, tgt: RouteTarget): void {
+    this.router.setParticipant(botId, sessionKey, tgt)
   }
 
   /**
@@ -654,7 +702,9 @@ export class RelayIngressManager {
     } else {
       const primary = this.router.routeAgentAuthored(botId, msg, claim.authorAgentId)
       deliveries = this.router
-        .conversationTargets(botId, msg, primary, claim.authorAgentId)
+        .conversationTargets(botId, msg, primary, claim.authorAgentId, claim.mentionedAgentIds, (target) =>
+          this.reportParticipant(botId, sessionKeyOf(msg), target)
+        )
         .map(({ target, via }) => ({ targetAgentId: target.agentId, routeVia: via }))
       if (deliveries.length === 0) return drop('no participant admitted for this bot')
     }
@@ -759,7 +809,9 @@ export class RelayIngressManager {
     let conversationTargets =
       msg.sender.isBot && tgt
         ? [{ target: tgt, via: 'mention' as const }]
-        : this.router.conversationTargets(botId, msg, tgt)
+        : this.router.conversationTargets(botId, msg, tgt, undefined, [], (target) =>
+            this.reportHumanParticipant(botId, sessionKey, msg.channel, tgt, target)
+          )
     if (tgt) {
       // Report leg: first route of this thread, or the arbitrated owner changed —
       // EXCEPT for an `auto`-owned channel, where every message (incl. follow-ups)
@@ -804,23 +856,35 @@ export class RelayIngressManager {
       // Backstop leg: only a real un-mentioned threaded follow-up is worth a CP lookup.
       if (!tgt) {
         if (!this.router.isUnmentionedThreadFollowup(botId, msg)) return
-        let target: { agentId: string; daemonId: string } | null
+        let lookup: Awaited<ReturnType<RelayIngressManagerDeps['lookupThread']>>
         try {
-          target = (await this.deps.lookupThread({ botId, sessionKey })).target
+          lookup = await this.deps.lookupThread({ botId, sessionKey })
         } catch {
           return // CP down — drop (bounded loss); a mention re-anchors the thread.
         }
-        if (!target) {
+        for (const participant of lookup.participants) {
+          const current = this.router.agentTarget(botId, participant.agentId, msg.channel)
+          if (current && current.daemonId === participant.daemonId) {
+            this.router.setParticipant(botId, sessionKey, current)
+          }
+        }
+        if (!lookup.target && lookup.participants.length === 0) {
           this.router.rememberNoAffinity(botId, sessionKey)
           return
         }
         // Seeded from the CP — do NOT report it back (it came from the CP).
-        if (!this.router.seedLookupTarget(botId, sessionKey, target)) return
-        tgt = this.router.route(botId, msg)
-        if (!tgt) return
+        if (lookup.target) {
+          if (!this.router.seedLookupTarget(botId, sessionKey, lookup.target)) return
+          tgt = this.router.route(botId, msg)
+        }
         conversationTargets = msg.sender.isBot
-          ? [{ target: tgt, via: 'mention' }]
-          : this.router.conversationTargets(botId, msg, tgt)
+          ? tgt
+            ? [{ target: tgt, via: 'mention' }]
+            : []
+          : this.router.conversationTargets(botId, msg, tgt, undefined, [], (target) =>
+              this.reportHumanParticipant(botId, sessionKey, msg.channel, tgt, target)
+            )
+        if (!tgt && conversationTargets.length === 0) return
       }
     }
     // A single-owner route is only the compatibility/reporting primary. Delivery is to
@@ -830,7 +894,9 @@ export class RelayIngressManager {
     if (conversationTargets.length === 0 && tgt) {
       conversationTargets = msg.sender.isBot
         ? [{ target: tgt, via: 'mention' }]
-        : this.router.conversationTargets(botId, msg, tgt)
+        : this.router.conversationTargets(botId, msg, tgt, undefined, [], (target) =>
+            this.reportHumanParticipant(botId, sessionKey, msg.channel, tgt, target)
+          )
       // Receive-only Feishu may intentionally hand an explicitly addressed Off event to
       // its sole gated daemon even though that target has no servable route. The daemon
       // records discovery and posts the notice; its terminal gate still prevents a turn.

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -642,10 +642,26 @@ export class RelayIngressManager {
     // collaboration directory, so an unresolvable token silenced the conversation rather
     // than merely costing precision. Peers are meant to see what was said and judge for
     // themselves; every edge below is still checked against this relay's own snapshot.
-    const implicit = this.router.routeAgentAuthored(botId, msg, claim.authorAgentId)
-    if (!implicit) return drop('no rung matched for this bot')
-    const targets = [implicit.agentId]
-    const routeVia: 'mention' | 'implicit' = 'implicit'
+    //
+    // ONE exception, and it is not an address: the visible half of a paired
+    // `toAgent + channel` send. Its target came from the tool call as an agent id, never
+    // from parsing text, and the rendezvous only converges when this observation and the
+    // internal wake name the SAME target — arbitration could pick the channel's default
+    // or thread owner instead, recording the observation against an agent the wake never
+    // mentions and stranding both halves. The daemon path special-cases it identically.
+    const paired = claim.agentCallDeliveryId !== undefined
+    let targets: string[]
+    let routeVia: 'mention' | 'implicit'
+    if (paired) {
+      targets = claim.mentionedAgentIds.filter((id) => id !== claim.authorAgentId)
+      if (targets.length === 0) return drop('paired agent call named no other agent')
+      routeVia = 'mention'
+    } else {
+      const implicit = this.router.routeAgentAuthored(botId, msg, claim.authorAgentId)
+      if (!implicit) return drop('no rung matched for this bot')
+      targets = [implicit.agentId]
+      routeVia = 'implicit'
+    }
 
     for (const targetAgentId of targets) {
       // Every listed author→target edge is checked independently and against the RELAY's

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -702,8 +702,14 @@ export class RelayIngressManager {
     } else {
       const primary = this.router.routeAgentAuthored(botId, msg, claim.authorAgentId)
       deliveries = this.router
-        .conversationTargets(botId, msg, primary, claim.authorAgentId, claim.mentionedAgentIds, (target) =>
-          this.reportParticipant(botId, sessionKeyOf(msg), target)
+        .conversationTargets(
+          botId,
+          msg,
+          primary,
+          claim.authorAgentId,
+          claim.mentionedAgentIds,
+          (target) => this.reportParticipant(botId, sessionKeyOf(msg), target),
+          (target) => this.deps.admitsAgentCall(claim.authorAgentId, target.agentId)
         )
         .map(({ target, via }) => ({ targetAgentId: target.agentId, routeVia: via }))
       if (deliveries.length === 0) return drop('no participant admitted for this bot')

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -589,16 +589,12 @@ export class RelayIngressManager {
    * The §6 ladder for an AgentConnect-authored platform message, on the relay side
    * (send-message-routing-rework.md §4, §4.1 step 4, §6, §8.2).
    *
-   * It is a separate ladder rather than a rung of `forward`'s because the checks differ,
-   * not because the rungs do: §2.3 gives a response that names nobody the SAME arbitration
-   * a human message gets, with the author excluded. What stays exclusive to the verified
-   * recipient set is a response that DID name someone — that one activates the named
-   * agents or nobody, never a substitute.
-   *
-   * "Named someone" is wider than the resolved agent set. A bare shared-bot mention, a
-   * human, or another app all resolve to no agent yet are still deliberate addressing, so
-   * they stop here rather than continuing — the same place the direct ladder stops
-   * (`routeRules`: an unmatched mention in a channel routes to nobody).
+   * It is separate from `forward` because every author→target edge carries additional
+   * security and loop-control state: verified authorship, directional policy, one hop,
+   * and a durable activation claim. Ordinary arbitration may nominate a primary, but it
+   * does not bound delivery: existing participants and newly joined mention matches are
+   * forwarded independently, including when they live on different daemons. The paired
+   * `toAgent + channel` observation remains the only exact-target exception.
    *
    * Anything not routable is dropped rather than forwarded. The relay holds no transcript
    * — "transcript only" is a daemon-side state — and §5.7 already has the target
@@ -650,23 +646,22 @@ export class RelayIngressManager {
     // or thread owner instead, recording the observation against an agent the wake never
     // mentions and stranding both halves. The daemon path special-cases it identically.
     const paired = claim.agentCallDeliveryId !== undefined
-    let targets: string[]
-    let routeVia: 'mention' | 'implicit'
+    let deliveries: Array<{ targetAgentId: string; routeVia: 'mention' | 'implicit' }>
     if (paired) {
-      targets = claim.mentionedAgentIds.filter((id) => id !== claim.authorAgentId)
+      const targets = claim.mentionedAgentIds.filter((id) => id !== claim.authorAgentId)
       if (targets.length === 0) return drop('paired agent call named no other agent')
-      routeVia = 'mention'
+      deliveries = targets.map((targetAgentId) => ({ targetAgentId, routeVia: 'mention' }))
     } else {
-      const implicit = this.router.routeAgentAuthored(botId, msg, claim.authorAgentId)
-      if (!implicit) return drop('no rung matched for this bot')
-      targets = [implicit.agentId]
-      routeVia = 'implicit'
+      const primary = this.router.routeAgentAuthored(botId, msg, claim.authorAgentId)
+      deliveries = this.router
+        .conversationTargets(botId, msg, primary, claim.authorAgentId)
+        .map(({ target, via }) => ({ targetAgentId: target.agentId, routeVia: via }))
+      if (deliveries.length === 0) return drop('no participant admitted for this bot')
     }
 
-    for (const targetAgentId of targets) {
-      // Every listed author→target edge is checked independently and against the RELAY's
-      // own snapshot — the recipient set is a provider claim until each edge passes
-      // current policy and the conversation gate (§5, closing paragraph).
+    for (const { targetAgentId, routeVia } of deliveries) {
+      // Every author→target edge is checked independently and against the RELAY's own
+      // snapshot, regardless of whether arbitration, participation, or a join found it.
       const route = this.router.agentTarget(botId, targetAgentId, msg.channel)
       if (!route) {
         drop(`target ${targetAgentId} is not a member of this bot`)
@@ -758,6 +753,13 @@ export class RelayIngressManager {
     if (addressesBot && !msg.sender.isBot && hasGatedMembers) await this.reportGatedConversation(botId, msg)
     const prior = this.router.peekAffinity(botId, sessionKey)
     let tgt = this.router.route(botId, msg)
+    // Third-party bots retain their strict explicit-mention-only behavior. Participant
+    // fan-out is for humans and verified AgentConnect authors; treating an arbitrary bot
+    // like a person in the room would let one mention wake unrelated joined agents.
+    let conversationTargets =
+      msg.sender.isBot && tgt
+        ? [{ target: tgt, via: 'mention' as const }]
+        : this.router.conversationTargets(botId, msg, tgt)
     if (tgt) {
       // Report leg: first route of this thread, or the arbitrated owner changed —
       // EXCEPT for an `auto`-owned channel, where every message (incl. follow-ups)
@@ -767,7 +769,8 @@ export class RelayIngressManager {
       if (changed && !this.router.channelAutoOwned(botId, msg.channel)) {
         this.report({ botId, sessionKey, agentId: tgt.agentId, daemonId: tgt.daemonId })
       }
-    } else {
+    }
+    if (!tgt && conversationTargets.length === 0) {
       // Conversation gating (resource-visibility §14.3): an explicitly-addressed
       // message (DM, or @bot mention) that arbitration could not place, on a bot
       // that backs ≥1 gated agent, must not look silently dead — answer once per
@@ -815,33 +818,60 @@ export class RelayIngressManager {
         if (!this.router.seedLookupTarget(botId, sessionKey, target)) return
         tgt = this.router.route(botId, msg)
         if (!tgt) return
+        conversationTargets = msg.sender.isBot
+          ? [{ target: tgt, via: 'mention' }]
+          : this.router.conversationTargets(botId, msg, tgt)
       }
     }
-    const daemon = this.deps.getDaemon(tgt.daemonId)
-    if (!daemon) {
-      const n = (this.dropped.get(botId) ?? 0) + 1
-      this.dropped.set(botId, n)
-      this.deps.log.warn(`relay-ingress(${botId}): daemon ${tgt.daemonId} offline — dropped (total ${n})`)
-      return
+    // A single-owner route is only the compatibility/reporting primary. Delivery is to
+    // every participant, including joined agents on other daemons. Each copy carries its
+    // own trusted cause so a human mention clears only the named target's `!stop`; peers
+    // hearing the same body remain implicit even though it contains that mention token.
+    if (conversationTargets.length === 0 && tgt) {
+      conversationTargets = msg.sender.isBot
+        ? [{ target: tgt, via: 'mention' }]
+        : this.router.conversationTargets(botId, msg, tgt)
+      // Receive-only Feishu may intentionally hand an explicitly addressed Off event to
+      // its sole gated daemon even though that target has no servable route. The daemon
+      // records discovery and posts the notice; its terminal gate still prevents a turn.
+      if (conversationTargets.length === 0) conversationTargets = [{ target: tgt, via: 'mention' }]
     }
-    const rd: RdMsgIm = {
-      source: 'im',
-      agentId: tgt.agentId,
-      sessionKey: sessionKeyOf(msg),
-      msgId: msg.msgId,
-      botId,
-      integrationId: tgt.integrationId,
-      chatId: msg.channel,
-      payload: msg
-    }
-    try {
-      await daemon.sendMsg(rd)
-    } catch (err) {
-      const n = (this.dropped.get(botId) ?? 0) + 1
-      this.dropped.set(botId, n)
-      this.deps.log.warn(
-        `relay-ingress(${botId}): forward to ${tgt.daemonId} failed: ${(err as Error).message} (dropped ${n})`
-      )
+    for (const { target: participant, via } of conversationTargets) {
+      const daemon = this.deps.getDaemon(participant.daemonId)
+      if (!daemon) {
+        const n = (this.dropped.get(botId) ?? 0) + 1
+        this.dropped.set(botId, n)
+        this.deps.log.warn(`relay-ingress(${botId}): daemon ${participant.daemonId} offline — dropped (total ${n})`)
+        continue
+      }
+      if (
+        via === 'implicit' &&
+        (conversationTargets.length > 1 || namesThisBot) &&
+        !daemon.supports(RD_AGENT_IMPLICIT_ROUTING_V1)
+      ) {
+        this.deps.log.debug(`relay-ingress(${botId}): daemon ${participant.daemonId} predates per-target routing cause`)
+        continue
+      }
+      const rd: RdMsgIm = {
+        source: 'im',
+        agentId: participant.agentId,
+        sessionKey: sessionKeyOf(msg),
+        msgId: conversationTargets.length > 1 ? `${msg.msgId}#${participant.agentId}` : msg.msgId,
+        botId,
+        integrationId: participant.integrationId,
+        chatId: msg.channel,
+        payload: msg,
+        trustedRouteVia: via
+      }
+      try {
+        await daemon.sendMsg(rd)
+      } catch (err) {
+        const n = (this.dropped.get(botId) ?? 0) + 1
+        this.dropped.set(botId, n)
+        this.deps.log.warn(
+          `relay-ingress(${botId}): forward to ${participant.daemonId} failed: ${(err as Error).message} (dropped ${n})`
+        )
+      }
     }
   }
 

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -632,41 +632,20 @@ export class RelayIngressManager {
     if (trustedDeliveryHopCount > MAX_AGENT_CALL_HOPS) {
       return drop(`hop_limit: ${claim.hopCount} + 1 exceeds ${MAX_AGENT_CALL_HOPS}`)
     }
-    // §2.3: an agent message that names nobody still continues the conversation — it goes
-    // through the SAME arbitration a human message does, with the author excluded so it
-    // cannot wake itself. `arbitrate` normally stops bot traffic at the explicit-mention
-    // rung; a VERIFIED author is a known participant with a checked policy, not anonymous
-    // bot traffic, so it is allowed past.
+    // The recipient set the author resolved is NOT consulted for delivery: a verified
+    // agent message goes to whoever this bot's ordinary arbitration selects, the author
+    // excluded. `arbitrate` normally stops bot traffic at the explicit-mention rung; a
+    // VERIFIED author is a known participant with a checked policy, not anonymous bot
+    // traffic, so it is allowed past.
     //
-    // "Names nobody" is judged BEFORE the author is filtered out. A response that did name
-    // an agent has explicitly addressed the conversation, so it gets an explicit outcome
-    // or none: retargeting it because the named agent is unreachable would substitute a
-    // recipient the author never asked for, and filtering first would make a self-mention
-    // — the one name every response can produce — indistinguishable from naming nobody.
-    const named = claim.mentionedAgentIds.length > 0
-    let targets = claim.mentionedAgentIds.filter((id) => id !== claim.authorAgentId)
-    let routeVia: 'mention' | 'implicit' = 'mention'
-    if (!named) {
-      // Naming a HUMAN (or another app, or a bare shared bot) is still deliberate
-      // addressing even though it resolves to no agent — `mentionedBots` holds every
-      // `<@U…>` token, not only bots. The direct ladder stops there (`routeRules`:
-      // unmatched mention in a channel ⇒ no route), for human senders too, so stopping
-      // here is what keeps one message from waking a peer over the relay and nobody over
-      // a direct connection. A DM is already addressed to its recipient, so it is exempt
-      // on both sides.
-      // `mentionedBots` is reparsed from the FINAL section's text, so it misses a mention
-      // the splitter left in an earlier one; the author's claim covers the complete
-      // response and is the only place that fact survives. Either is enough — an address
-      // is an address wherever in the answer it appeared.
-      if (!msg.isDm && (msg.mentionedBots.length > 0 || claim.addressedAnyone === true)) {
-        return drop('addressed someone this relay cannot resolve')
-      }
-      const implicit = this.router.routeAgentAuthored(botId, msg, claim.authorAgentId)
-      if (!implicit) return drop('no implicit rung matched')
-      targets = [implicit.agentId]
-      routeVia = 'implicit'
-    }
-    if (targets.length === 0) return drop('named only its own author')
+    // Selecting by mention made delivery depend on resolving a `<@U…>` through the
+    // collaboration directory, so an unresolvable token silenced the conversation rather
+    // than merely costing precision. Peers are meant to see what was said and judge for
+    // themselves; every edge below is still checked against this relay's own snapshot.
+    const implicit = this.router.routeAgentAuthored(botId, msg, claim.authorAgentId)
+    if (!implicit) return drop('no rung matched for this bot')
+    const targets = [implicit.agentId]
+    const routeVia: 'mention' | 'implicit' = 'implicit'
 
     for (const targetAgentId of targets) {
       // Every listed author→target edge is checked independently and against the RELAY's


### PR DESCRIPTION
## Summary

An agent-authored platform message could not wake any agent that was **already talking in the same thread** — which is every agent in a multi-agent conversation. The exchange died after one round, with only a `WARN` in the log and nothing visible in Slack.

Found by tracing a live three-agent counting test (`你们轮流报数`): the three agents said `1` / `2` / `3` and stopped.

## What was actually happening

Routing was fine. All six implicit wakes fired:

```
relay: agent-authored mention test → acp-tester   (hop 1)
relay: agent-authored mention test → test2        (hop 1)
relay: agent-authored mention acp-tester → test   (hop 1)
relay: agent-authored mention acp-tester → test2  (hop 1)
relay: agent-authored mention test2 → test        (hop 1)
relay: agent-authored mention test2 → acp-tester  (hop 1)
```

Every wake that reached an **idle** target was then cancelled:

```
WARN session source: rejected external audience binding for
     slack:C0AAR1W849K:1785822633.940949:99c2ed48-… (mismatch)
```

The rest arrived while their target was mid-turn and were coalesced into it, so they produced no further reply. Between the two, every agent spoke exactly once.

## Root cause

`conversationExternalSource` refuses to resolve an audience when `isA2aChild`, and that flag was computed as **"this turn carries CallMeta"**.

A postless `toAgent` child must indeed not bind an audience: its coordinates are derived from the caller's session and the model picks the target, so binding one would let model input claim a shared conversation. An agent's ordinary reply has the opposite property — it is observed *on* the platform, in the very conversation it targets, and its channel and thread come from the provider event exactly like a human message in that thread.

With no audience resolved and no inherited lineage, `bindSessionSource` compared an unbound turn against the target's Slack-bound session row and returned `mismatch`. Confirmed against the daemon store — all three sessions were bound (`externalProvider=slack`, `realmKey=T038JQ2G4KX`, `resourceKey=C0AAR1W849K`).

`CallMeta.platformOrigin` now carries the distinction and the flag means what its name says. It is persisted with the inbox row, so a replayed turn classifies the same way it would have live.

## Not from the implicit-routing change

The explicit `@mention` path has had this since agent-authored routing first landed (#503) — it is why earlier explicit-mention tests also failed to produce a chain. #549 only made it visible more often, by creating many more agent→agent activations.

## Tests

One regression test pinning **both** directions, because the boundary must not be widened while fixing it:

- a platform-observed wake against an existing Slack-bound session → `unchanged`
- a postless call with no inherited lineage against the same row → still `mismatch`

Verified to fail with the fix removed, reporting exactly the production symptom (`expected 'mismatch' to be 'unchanged'`).

## Validation

Full daemon suite 2944 passing; `lint`, `typecheck`, `format:check` clean. The one failure is `evaluation-runner` › "records a raw ACP baseline", pre-existing and environmental — this branch touches neither it nor `src/evaluation/`.

Not yet verified end-to-end in Slack: that needs a daemon build deployed to the test workspace.


---

## Update: two further defects found by running this against the live test workspace

Verification ran the daemon from source against the real Slack thread. The audience fix worked — the `rejected external audience binding` warnings for Slack conversations are gone — and the relay chain advanced hop 1 → 2 → 3 → … correctly. Two separate defects were still stopping the exchange.

### `classifyNewSessionOrThrow` had the same predicate (2c3377b)

The other half of the audience fix: session CREATION also read "carries CallMeta" as "postless A2A child", so a platform-observed delivery that created the target's session classified the row `local`, and every later externally-attributed wake of that row — the next human reply included — was rejected as a cross-source mismatch.

### A response finalization was encoded in the `msgId` (e8e499b)

The one that made a multi-agent thread unusable. In such a thread each agent could see **at most one peer message, ever**, and that one was ordered as the thread's oldest.

A streamed reply is posted and then closed by an edit; both are the same Slack message and share its `ts`. Ingress dedups on `msgId`, so the closing edit — the only routable arrival — needed a distinct identity, and it got a `:final` msgId suffix.

But `msgId` also *carries* the platform ts. `transcriptCoords` recovers it by splitting the id and taking the last segment, which for a finalization was the literal `'final'`. The transcript then uses that ts for two more jobs:

```sql
UNIQUE INDEX transcript_text_ts ON transcript (channel, thread, ts) WHERE kind = 'text'
INDEX transcript_thread_event_time ON transcript (channel, thread, eventTimeUs DESC, seq DESC)
```

The unique index does not include the recipient, so every finalization in a thread collapsed onto one row per agent channel and only the first survived. And `transcriptEventTimeUs('final')` falls through to `Date.parse` → `NaN` → `0`, so the row that did survive sorted to epoch 0.

Observed live, with both effects visible in the store: an agent asked to keep counting received a stale `3` presented as the thread's oldest message rather than the peer's `7`. Asked why it stopped, it answered on its own — before this was diagnosed — that its context showed only an old `3`, no `7`, so it judged the message irrelevant. It was reasoning correctly over a corrupted transcript.

The arrival distinction now lives in its own field, `ingressEventTag`, used as a second dedup dimension at ingress. `msgId` goes back to meaning exactly one thing.

That makes the finalization dedup onto its own post's row — which the suffix's own docstring always claimed happened, an assertion that was never true. Since a post can hold a streamed prefix and a text row had no update path, the finalization is now marked `authoritative` and refreshes that row's text in place.

### Tests

The store regression pins all three properties, and reproducing the old behaviour (three replies arriving on the literal ts `'final'`) fails it with `expected [ '1' ] to deeply equal [ '1', '3', '7' ]` — the same shape as the production symptom. The message-package assertion is inverted: the finalization's `msgId` must now be *identical* to its post's, with the distinction in the tag and the ts still recoverable by the ordinary split.

Full daemon suite 2946 passing, relay 414, message 28; lint/typecheck/format clean. The one failure is the pre-existing environmental `evaluation-runner` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

