### PR TITLE
fix(daemon): resolve canonical skill selections to the CLI's frontmatter names

### DIFF
--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -121,7 +121,12 @@ through its hardened Git path and gives the CLI only a private local snapshot:
 
 - `owner/repo` installs every skill from the repository.
 - `owner/repo` with `skills: ["review-pr", "safe-deploy"]` installs only those
-  skills through `-s`.
+  skills through `-s`. Wire selections are canonical leaf names; because the
+  CLI matches `-s` against SKILL.md frontmatter names (which may differ from
+  the directory name, e.g. `name: Grill Me` inside `skills/grill-me/`), the
+  daemon first resolves each canonical selection against its private snapshot
+  to the frontmatter name the CLI matches, and then requires the CLI output to
+  be exactly the resolved leaf set.
 - `https://github.com/owner/repo/tree/<ref>/<subdir>` points directly to a
   directory or ref inside the repository.
 - Accepted remote spellings are `owner/repo`, canonical

--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -125,8 +125,11 @@ through its hardened Git path and gives the CLI only a private local snapshot:
   CLI matches `-s` against SKILL.md frontmatter names (which may differ from
   the directory name, e.g. `name: Grill Me` inside `skills/grill-me/`), the
   daemon first resolves each canonical selection against its private snapshot
-  to the frontmatter name the CLI matches, and then requires the CLI output to
-  be exactly the resolved leaf set.
+  to the frontmatter name the CLI matches. The resolved set is then closed
+  over same-source slash references — a selected body like
+  ``Run a `/grilling` session.`` pulls the referenced sibling skill in too,
+  transitively, since installing such an alias alone yields a broken skill —
+  and the CLI output must be exactly the resolved leaf set.
 - `https://github.com/owner/repo/tree/<ref>/<subdir>` points directly to a
   directory or ref inside the repository.
 - Accepted remote spellings are `owner/repo`, canonical

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -30,6 +30,7 @@ import {
   SkillLedgerSafetyError,
   type SkillFileReceipt
 } from './skill-install-ledger.js'
+import { resolveSkillSelections } from './skill-cli-selection.js'
 import { acquireGitSkillSource, resolveBoundedGitSkillSource } from './skill-git-source.js'
 import { snapshotLocalSkillSource } from './skill-source-snapshot.js'
 import { PINNED_SKILLS_CLI_VERSION, stageSkillsCliCell, type SkillsCliCellResult } from './skills-cli-cell.js'
@@ -149,7 +150,11 @@ interface PreparedSource {
   key: string
   name: string
   sourceDir: string
+  /** `-s` values for the CLI: the SKILL.md frontmatter names it matches. */
   skills: string[]
+  /** Exact CLI-derived leaf directory names `skills` must produce (empty ⇒
+   * install everything the source exposes, any leaves). */
+  expectedLeaves: string[]
   contentDigest: string
 }
 
@@ -238,6 +243,7 @@ async function installSkillsLocked(
         name: source.name,
         sourceDir: destination,
         skills: [source.name],
+        expectedLeaves: [source.name],
         contentDigest: snapshot.sha256
       })
     }
@@ -321,19 +327,21 @@ async function installSkillsLocked(
         limits: GIT_SOURCE_SNAPSHOT_LIMITS
       })
       accountInput(snapshot.fileCount, snapshot.totalBytes)
-      // One source invocation may carry all selected skills. We independently
-      // require the exact selected leaf-name set below, so a CLI that returns
-      // success after installing only a valid subset still fails the transaction.
-      const selections = [entry.skills]
-      for (const skills of selections) {
-        prepared.push({
-          key: `git:${index}:${definitionDigest}:${resolvedCommit}${skills.length > 0 ? `:${fingerprint(skills)}` : ''}`,
-          name: entry.name,
-          sourceDir: destination,
-          skills,
-          contentDigest: snapshot.sha256
-        })
-      }
+      // The CLI matches `-s` values against SKILL.md frontmatter names but the
+      // wire carries canonical leaf names, so resolve each selection against
+      // the snapshot first (#371). One source invocation carries all selected
+      // skills; we independently require the exact resolved leaf-name set
+      // below, so a CLI that returns success after installing only a valid
+      // subset still fails the transaction.
+      const selection = await resolveSkillSelections(entry.name, destination, snapshot.files, entry.skills)
+      prepared.push({
+        key: `git:${index}:${definitionDigest}:${resolvedCommit}${entry.skills.length > 0 ? `:${fingerprint(entry.skills)}` : ''}`,
+        name: entry.name,
+        sourceDir: destination,
+        skills: selection.cliSelections,
+        expectedLeaves: selection.expectedLeaves,
+        contentDigest: snapshot.sha256
+      })
     }
     prepared.push(...localPrepared)
     const nextGitResolutions = currentGitResolutions(
@@ -360,8 +368,8 @@ async function installSkillsLocked(
         if (invocation.bundles.length === 0) {
           throw new Error(`skills CLI produced no bundles for ${source.name}`)
         }
-        if (source.skills.length > 0) {
-          const expected = [...source.skills].sort()
+        if (source.expectedLeaves.length > 0) {
+          const expected = [...source.expectedLeaves].sort()
           const actual = invocation.bundles.map((bundle) => bundle.relativeRoot.split('/').at(-1) ?? '').sort()
           if (JSON.stringify(actual) !== JSON.stringify(expected)) {
             throw new Error(`skills CLI output did not exactly match selection for ${source.name}`)

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -36,7 +36,11 @@ import { snapshotLocalSkillSource } from './skill-source-snapshot.js'
 import { PINNED_SKILLS_CLI_VERSION, stageSkillsCliCell, type SkillsCliCellResult } from './skills-cli-cell.js'
 
 export const SKILLS_CLI_SPEC = `skills@${PINNED_SKILLS_CLI_VERSION}`
-const INSTALLER_SCHEMA = 2
+// v3: selection resolution + slash-reference dependency expansion change the
+// materialized bundle set for unchanged wire inputs; the bump invalidates
+// ready v2 fingerprints so every workspace reconciles once under the new
+// semantics instead of retaining pre-expansion alias-only installs.
+const INSTALLER_SCHEMA = 3
 const LEGACY_MARKER_BYTES = 64 * 1024
 const LEGACY_MARKERS = ['skills-install.json', 'dream-skills-install.json'] as const
 const LEGACY_OWNED = /^(?:\.claude\/skills|\.agents\/skills)\/[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/

--- a/packages/daemon/src/skills/local-skill-inventory.ts
+++ b/packages/daemon/src/skills/local-skill-inventory.ts
@@ -92,8 +92,10 @@ async function readSkillManifest(cwdReal: string, skillDir: string): Promise<str
 }
 
 /** Pull `name`/`description` out of a SKILL.md's leading YAML frontmatter.
- *  Tolerant: a repo skill need not match the daemon's stricter install rules. */
-function parseManifest(text: string): { name?: string; description: string | null } {
+ *  Tolerant: a repo skill need not match the daemon's stricter install rules.
+ *  Also used by selection resolution (skill-cli-selection.ts), which needs the
+ *  same name the pinned skills CLI reads from a source's SKILL.md. */
+export function parseSkillManifest(text: string): { name?: string; description: string | null } {
   const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(text)
   if (!match) return { description: null }
   let value: unknown
@@ -163,7 +165,7 @@ export async function listLocalSkills(cwd: string, stateDir: string): Promise<Lo
         if (!dirent.isDirectory()) continue
         const text = await readSkillManifest(cwdReal, join(cwdReal, root, dirent.name))
         if (text === undefined) continue // no readable SKILL.md / unsafe ⇒ not a skill
-        const manifest = parseManifest(text)
+        const manifest = parseSkillManifest(text)
         const relPath = `${root}/${dirent.name}`
         const entry: LocalSkillEntry = {
           name: manifest.name ?? dirent.name,

--- a/packages/daemon/src/skills/local-skill-inventory.ts
+++ b/packages/daemon/src/skills/local-skill-inventory.ts
@@ -91,27 +91,34 @@ async function readSkillManifest(cwdReal: string, skillDir: string): Promise<str
   }
 }
 
-/** Pull `name`/`description` out of a SKILL.md's leading YAML frontmatter.
- *  Tolerant: a repo skill need not match the daemon's stricter install rules.
- *  Also used by selection resolution (skill-cli-selection.ts), which needs the
- *  same name the pinned skills CLI reads from a source's SKILL.md. */
-export function parseSkillManifest(text: string): { name?: string; description: string | null } {
+/** Pull `name`/`description` (and the CLI's `metadata.internal` marker) out of
+ *  a SKILL.md's leading YAML frontmatter. Tolerant: a repo skill need not match
+ *  the daemon's stricter install rules. Also used by selection resolution
+ *  (skill-cli-selection.ts), which needs the same fields the pinned skills CLI
+ *  reads from a source's SKILL.md. */
+export function parseSkillManifest(text: string): { name?: string; description: string | null; internal: boolean } {
   const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(text)
-  if (!match) return { description: null }
+  if (!match) return { description: null, internal: false }
   let value: unknown
   try {
     value = parseYaml(match[1]!, { maxAliasCount: 0 })
   } catch {
-    return { description: null }
+    return { description: null, internal: false }
   }
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return { description: null }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return { description: null, internal: false }
   const manifest = value as Record<string, unknown>
   const name = typeof manifest.name === 'string' && manifest.name.trim() ? manifest.name.trim() : undefined
   const description =
     typeof manifest.description === 'string' && manifest.description.trim()
       ? manifest.description.trim().slice(0, MAX_DESCRIPTION_CHARS)
       : null
-  return { name, description }
+  const metadata = manifest.metadata
+  const internal =
+    typeof metadata === 'object' &&
+    metadata !== null &&
+    !Array.isArray(metadata) &&
+    (metadata as Record<string, unknown>).internal === true
+  return { name, description, internal }
 }
 
 /**

--- a/packages/daemon/src/skills/skill-cli-selection.ts
+++ b/packages/daemon/src/skills/skill-cli-selection.ts
@@ -1,0 +1,147 @@
+/**
+ * Canonical-selection resolution for the pinned skills CLI (#371).
+ *
+ * The audited CLI matches `-s` selections against each discovered skill's
+ * SKILL.md frontmatter `name` (compared case-insensitively, otherwise
+ * verbatim), yet installs the matched bundle under a sanitized leaf directory
+ * derived from that name. AgentConnect wire selections are restricted to
+ * canonical leaf names, and the console offers skill directory names — so a
+ * source whose frontmatter name is not already canonical (`name: Grill Me`
+ * inside `skills/grill-me/`) could never be selected: passing the canonical
+ * name through verbatim makes the CLI answer "No matching skills found".
+ *
+ * Resolve every canonical selection against the daemon's private source
+ * snapshot to the frontmatter name the CLI will actually match, and return the
+ * exact leaf set that invocation must produce so the installer keeps its
+ * exact-output receipt check.
+ */
+import { promises as fsp } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
+import { parseSkillManifest } from './local-skill-inventory.js'
+
+// Frontmatter lives at the head of SKILL.md; reading more cannot change the
+// parsed name and only inflates work on an oversized manifest.
+const MAX_MANIFEST_HEAD_BYTES = 64 * 1024
+const MAX_LISTED_AVAILABLE = 32
+
+/** The leaf directory skills@1.5.21 installs a matched skill into — an exact
+ * mirror of its `sanitizeName`. Revalidate against the pinned CLI source when
+ * bumping PINNED_SKILLS_CLI_VERSION. */
+export function skillInstallLeaf(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9._]+/g, '-')
+      .replace(/^[.\-]+|[.\-]+$/g, '')
+      .substring(0, 255) || 'unnamed-skill'
+  )
+}
+
+/** Selections reach the CLI as `-s <value>` argv entries (execFile, never a
+ * shell) and are compared case-insensitively to frontmatter names. Refuse
+ * anything option-shaped or outside printable ASCII rather than quoting. */
+export function isSafeCliSelection(value: string): boolean {
+  return value.length > 0 && value.length <= 255 && !value.startsWith('-') && /^[\x20-\x7e]+$/.test(value)
+}
+
+export interface SnapshotFileRef {
+  /** `/`-separated path relative to the snapshot root. */
+  path: string
+}
+
+export interface ResolvedSkillSelections {
+  /** Frontmatter names to pass as `-s`, ordered like the input selections. */
+  cliSelections: string[]
+  /** The exact CLI-derived leaf directory names those selections must
+   * produce, ordered like the input selections. */
+  expectedLeaves: string[]
+}
+
+interface SelectionCandidate {
+  name: string
+  leaf: string
+  directoryLeaf?: string
+}
+
+/**
+ * Map wire-canonical selections onto the snapshot's skills. A selection
+ * matches a skill when it equals the skill's install leaf (the sanitized
+ * frontmatter name) or the sanitized name of the directory holding SKILL.md
+ * (what the console's source scan offers). Throws when a selection matches
+ * nothing, matches more than one distinct skill name, collides with another
+ * selection, or resolves to a name that cannot ride the CLI argv safely.
+ */
+export async function resolveSkillSelections(
+  sourceName: string,
+  snapshotDir: string,
+  files: readonly SnapshotFileRef[],
+  selections: readonly string[]
+): Promise<ResolvedSkillSelections> {
+  if (selections.length === 0) return { cliSelections: [], expectedLeaves: [] }
+
+  const candidates: SelectionCandidate[] = []
+  for (const file of files) {
+    if (file.path !== 'SKILL.md' && !file.path.endsWith('/SKILL.md')) continue
+    const head = await readHead(join(snapshotDir, ...file.path.split('/')), MAX_MANIFEST_HEAD_BYTES)
+    const name = parseSkillManifest(head).name
+    if (!name) continue // the CLI refuses to install a nameless skill
+    const directory = dirname(file.path)
+    candidates.push({
+      name,
+      leaf: skillInstallLeaf(name),
+      ...(directory === '.' ? {} : { directoryLeaf: skillInstallLeaf(basename(directory)) })
+    })
+  }
+
+  const cliSelections: string[] = []
+  const expectedLeaves: string[] = []
+  const selectionByName = new Map<string, string>()
+  for (const selection of selections) {
+    const matched = candidates.filter(
+      (candidate) => candidate.leaf === selection || candidate.directoryLeaf === selection
+    )
+    const names = [...new Set(matched.map((candidate) => candidate.name))]
+    if (names.length === 0) {
+      const available = [...new Set(candidates.map((candidate) => candidate.leaf))].sort()
+      throw new Error(
+        `skill "${selection}" was not found in source "${sourceName}"` +
+          (available.length > 0 ? ` (available: ${available.slice(0, MAX_LISTED_AVAILABLE).join(', ')})` : '')
+      )
+    }
+    if (names.length > 1) {
+      throw new Error(`skill selection "${selection}" matches more than one skill in source "${sourceName}"`)
+    }
+    const name = names[0]!
+    const previous = selectionByName.get(name)
+    if (previous !== undefined) {
+      throw new Error(
+        `skill selections "${previous}" and "${selection}" resolve to the same skill in source "${sourceName}"`
+      )
+    }
+    if (!isSafeCliSelection(name)) {
+      throw new Error(`skill "${selection}" in source "${sourceName}" has a name the skills CLI cannot select safely`)
+    }
+    selectionByName.set(name, selection)
+    cliSelections.push(name)
+    expectedLeaves.push(matched[0]!.leaf)
+  }
+  return { cliSelections, expectedLeaves }
+}
+
+/** Bounded head read of a daemon-private snapshot file (the snapshot is fresh,
+ * 0o700, and symlink-free by construction, so no adversarial-race hardening). */
+async function readHead(path: string, maxBytes: number): Promise<string> {
+  const handle = await fsp.open(path, 'r')
+  try {
+    const body = Buffer.alloc(maxBytes)
+    let offset = 0
+    while (offset < body.length) {
+      const { bytesRead } = await handle.read(body, offset, body.length - offset, offset)
+      if (bytesRead === 0) break
+      offset += bytesRead
+    }
+    return body.subarray(0, offset).toString('utf8')
+  } finally {
+    await handle.close()
+  }
+}

--- a/packages/daemon/src/skills/skill-cli-selection.ts
+++ b/packages/daemon/src/skills/skill-cli-selection.ts
@@ -11,18 +11,29 @@
  * name through verbatim makes the CLI answer "No matching skills found".
  *
  * Resolve every canonical selection against the daemon's private source
- * snapshot to the frontmatter name the CLI will actually match, and return the
- * exact leaf set that invocation must produce so the installer keeps its
- * exact-output receipt check.
+ * snapshot to the frontmatter name the CLI will actually match, then expand
+ * the set with same-source skills the selected bodies invoke by slash
+ * reference (skill collections publish thin alias skills whose whole body is
+ * e.g. "Run a `/grilling` session." — installing the alias without its target
+ * yields a broken skill). Return the exact leaf set that invocation must
+ * produce so the installer keeps its exact-output receipt check.
  */
 import { promises as fsp } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
 import { parseSkillManifest } from './local-skill-inventory.js'
 
-// Frontmatter lives at the head of SKILL.md; reading more cannot change the
-// parsed name and only inflates work on an oversized manifest.
+// Frontmatter and the short prompt body live at the head of SKILL.md; reading
+// more cannot change the parsed name and only inflates work on an oversized
+// manifest. Slash references beyond this window are not resolved.
 const MAX_MANIFEST_HEAD_BYTES = 64 * 1024
 const MAX_LISTED_AVAILABLE = 32
+// Matches the wire-level cap on explicit selections per source.
+const MAX_RESOLVED_SELECTIONS = 64
+// A dependency reference is a slash-invocation token at a word boundary, e.g.
+// "Run a `/grilling` session." Only tokens naming another skill in the SAME
+// source count; anything else (URL paths, /tmp, ...) is plain text.
+const SLASH_REFERENCE = /(?:^|[\s`'"(])\/([A-Za-z0-9][A-Za-z0-9._-]{0,127})/g
+const FRONTMATTER = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/
 
 /** The leaf directory skills@1.5.21 installs a matched skill into — an exact
  * mirror of its `sanitizeName`. Revalidate against the pinned CLI source when
@@ -50,10 +61,11 @@ export interface SnapshotFileRef {
 }
 
 export interface ResolvedSkillSelections {
-  /** Frontmatter names to pass as `-s`, ordered like the input selections. */
+  /** Frontmatter names to pass as `-s`: the explicit selections first (input
+   * order), then any slash-referenced same-source dependencies. */
   cliSelections: string[]
   /** The exact CLI-derived leaf directory names those selections must
-   * produce, ordered like the input selections. */
+   * produce, ordered like `cliSelections`. */
   expectedLeaves: string[]
 }
 
@@ -61,15 +73,18 @@ interface SelectionCandidate {
   name: string
   leaf: string
   directoryLeaf?: string
+  /** Prompt body (head-bounded, frontmatter stripped) for slash references. */
+  body: string
 }
 
 /**
  * Map wire-canonical selections onto the snapshot's skills. A selection
  * matches a skill when it equals the skill's install leaf (the sanitized
  * frontmatter name) or the sanitized name of the directory holding SKILL.md
- * (what the console's source scan offers). Throws when a selection matches
- * nothing, matches more than one distinct skill name, collides with another
- * selection, or resolves to a name that cannot ride the CLI argv safely.
+ * (what the console's source scan offers); the matched set is then closed
+ * over same-source slash references. Throws when a selection matches nothing,
+ * a selection or reference matches more than one distinct skill name, two
+ * selections collide, or a resolved name cannot ride the CLI argv safely.
  */
 export async function resolveSkillSelections(
   sourceName: string,
@@ -89,17 +104,33 @@ export async function resolveSkillSelections(
     candidates.push({
       name,
       leaf: skillInstallLeaf(name),
-      ...(directory === '.' ? {} : { directoryLeaf: skillInstallLeaf(basename(directory)) })
+      ...(directory === '.' ? {} : { directoryLeaf: skillInstallLeaf(basename(directory)) }),
+      body: head.replace(FRONTMATTER, '')
     })
   }
+
+  const matchCandidates = (token: string): SelectionCandidate[] =>
+    candidates.filter((candidate) => candidate.leaf === token || candidate.directoryLeaf === token)
 
   const cliSelections: string[] = []
   const expectedLeaves: string[] = []
   const selectionByName = new Map<string, string>()
+  const pendingBodies: SelectionCandidate[] = []
+  const admit = (candidate: SelectionCandidate, label: string): void => {
+    if (selectionByName.size >= MAX_RESOLVED_SELECTIONS) {
+      throw new Error(`source "${sourceName}" resolves to too many skills after dependency expansion`)
+    }
+    if (!isSafeCliSelection(candidate.name)) {
+      throw new Error(`skill ${label} in source "${sourceName}" has a name the skills CLI cannot select safely`)
+    }
+    selectionByName.set(candidate.name, label)
+    cliSelections.push(candidate.name)
+    expectedLeaves.push(candidate.leaf)
+    pendingBodies.push(candidate)
+  }
+
   for (const selection of selections) {
-    const matched = candidates.filter(
-      (candidate) => candidate.leaf === selection || candidate.directoryLeaf === selection
-    )
+    const matched = matchCandidates(selection)
     const names = [...new Set(matched.map((candidate) => candidate.name))]
     if (names.length === 0) {
       const available = [...new Set(candidates.map((candidate) => candidate.leaf))].sort()
@@ -111,20 +142,36 @@ export async function resolveSkillSelections(
     if (names.length > 1) {
       throw new Error(`skill selection "${selection}" matches more than one skill in source "${sourceName}"`)
     }
-    const name = names[0]!
-    const previous = selectionByName.get(name)
+    const previous = selectionByName.get(names[0]!)
     if (previous !== undefined) {
       throw new Error(
-        `skill selections "${previous}" and "${selection}" resolve to the same skill in source "${sourceName}"`
+        `skill selections ${previous} and "${selection}" resolve to the same skill in source "${sourceName}"`
       )
     }
-    if (!isSafeCliSelection(name)) {
-      throw new Error(`skill "${selection}" in source "${sourceName}" has a name the skills CLI cannot select safely`)
-    }
-    selectionByName.set(name, selection)
-    cliSelections.push(name)
-    expectedLeaves.push(matched[0]!.leaf)
+    admit(matched[0]!, `"${selection}"`)
   }
+
+  // Close the selection over same-source slash references, e.g. grill-me's
+  // whole body being "Run a `/grilling` session." (#371). A token matching
+  // nothing in this source is plain text and ignored; a token matching more
+  // than one skill stays fail-closed like an explicit selection would.
+  while (pendingBodies.length > 0) {
+    const referrer = pendingBodies.shift()!
+    for (const match of referrer.body.matchAll(SLASH_REFERENCE)) {
+      const token = match[1]!.toLowerCase()
+      const matched = matchCandidates(token)
+      const names = [...new Set(matched.map((candidate) => candidate.name))]
+      if (names.length === 0) continue // plain text, not a same-source skill
+      if (names.some((name) => selectionByName.has(name))) continue // already satisfied
+      if (names.length > 1) {
+        throw new Error(
+          `skill "${referrer.name}" reference "/${token}" matches more than one skill in source "${sourceName}"`
+        )
+      }
+      admit(matched[0]!, `"/${token}" (referenced by "${referrer.name}")`)
+    }
+  }
+
   return { cliSelections, expectedLeaves }
 }
 

--- a/packages/daemon/src/skills/skill-cli-selection.ts
+++ b/packages/daemon/src/skills/skill-cli-selection.ts
@@ -17,15 +17,25 @@
  * e.g. "Run a `/grilling` session." — installing the alias without its target
  * yields a broken skill). Return the exact leaf set that invocation must
  * produce so the installer keeps its exact-output receipt check.
+ *
+ * The candidate universe mirrors skills@1.5.21 discovery exactly — manifest
+ * validity (name AND description, not `metadata.internal`), the root-manifest
+ * early return, the known container/harness/plugin search paths with their
+ * one-grandchild deepening, the committed skills-lock.json exclusion, and the
+ * recursive fallback that runs only when the normal pass finds nothing. A
+ * wider universe would let manifests the CLI ignores poison the ambiguity
+ * checks or the dependency closure. Revalidate this mirror against the pinned
+ * CLI source when bumping PINNED_SKILLS_CLI_VERSION.
  */
 import { promises as fsp } from 'node:fs'
-import { basename, dirname, join } from 'node:path'
+import { basename, join, posix } from 'node:path'
 import { parseSkillManifest } from './local-skill-inventory.js'
 
 // Aligned with Git snapshot per-file admission (GIT_SOURCE_SNAPSHOT_LIMITS
 // .maxFileBytes) so every SKILL.md the snapshot admitted — and the CLI's own
 // full-file parser will read — is parsed in full here too.
 const MAX_MANIFEST_BYTES = 4 * 1024 * 1024
+const MAX_LOCK_BYTES = 1024 * 1024
 const MAX_LISTED_AVAILABLE = 32
 // Matches the wire-level cap on explicit selections per source.
 const MAX_RESOLVED_SELECTIONS = 64
@@ -35,9 +45,41 @@ const MAX_RESOLVED_SELECTIONS = 64
 const SLASH_REFERENCE = /(?:^|[\s`'"(])\/([A-Za-z0-9][A-Za-z0-9._-]{0,127})/g
 const FRONTMATTER = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/
 
+// skills@1.5.21 discovery constants, verbatim.
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '__pycache__'])
+const FALLBACK_MAX_DEPTH = 5
+const SKILL_CONTAINER_DIRS = ['skills', 'skills/.curated', 'skills/.experimental', 'skills/.system']
+const AGENT_PROJECT_SKILL_DIRS = [
+  '.agents/skills',
+  '.claude/skills',
+  '.cline/skills',
+  '.codebuddy/skills',
+  '.codex/skills',
+  '.commandcode/skills',
+  '.continue/skills',
+  '.github/skills',
+  '.goose/skills',
+  '.grok/skills',
+  '.iflow/skills',
+  '.junie/skills',
+  '.kilocode/skills',
+  '.kimchi/skills',
+  '.kiro/skills',
+  '.mux/skills',
+  '.neovate/skills',
+  '.opencode/skills',
+  '.openhands/skills',
+  '.pi/skills',
+  '.qoder/skills',
+  '.roo/skills',
+  '.trae/skills',
+  '.windsurf/skills',
+  '.zcode/skills',
+  '.zencoder/skills'
+]
+
 /** The leaf directory skills@1.5.21 installs a matched skill into — an exact
- * mirror of its `sanitizeName`. Revalidate against the pinned CLI source when
- * bumping PINNED_SKILLS_CLI_VERSION. */
+ * mirror of its `sanitizeName`. */
 export function skillInstallLeaf(name: string): string {
   return (
     name
@@ -58,6 +100,7 @@ export function isSafeCliSelection(value: string): boolean {
 export interface SnapshotFileRef {
   /** `/`-separated path relative to the snapshot root. */
   path: string
+  size: number
 }
 
 export interface ResolvedSkillSelections {
@@ -79,17 +122,26 @@ interface SelectionCandidate {
   body: string
 }
 
+interface SnapshotTree {
+  /** Directories holding a SKILL.md, '' for the snapshot root. */
+  skillDirs: Set<string>
+  /** Immediate child directory names per directory ('' for the root). */
+  childDirs: Map<string, Set<string>>
+  fileSizes: Map<string, number>
+}
+
 /**
- * Map wire-canonical selections onto the snapshot's skills. A selection
- * matches a skill when it equals the skill's install leaf (the sanitized
- * frontmatter name) or the sanitized name of the directory holding SKILL.md
- * (what the console's source scan offers); the matched set is then closed
- * over same-source slash references. Throws when a selection matches nothing,
- * a selection or reference matches more than one distinct skill name, two
- * selections collide, a resolved name cannot ride the CLI argv safely, or the
- * resolved frontmatter name does not uniquely (case-insensitively) identify
- * one skill in the source — the CLI selects by that name alone, so a shared
- * name could install a sibling skill while still producing the expected leaf.
+ * Map wire-canonical selections onto the skills the pinned CLI can discover
+ * in the snapshot. A selection matches a skill when it equals the skill's
+ * install leaf (the sanitized frontmatter name) or the sanitized name of the
+ * directory holding SKILL.md (what the console's source scan offers); the
+ * matched set is then closed over same-source slash references. Throws when a
+ * selection matches nothing, a selection or reference matches more than one
+ * distinct skill name, two selections collide, a resolved name cannot ride
+ * the CLI argv safely, or the resolved frontmatter name does not uniquely
+ * (case-insensitively) identify one discoverable skill — the CLI selects by
+ * that name alone, so a shared name could install a sibling skill while
+ * still producing the expected leaf.
  */
 export async function resolveSkillSelections(
   sourceName: string,
@@ -99,24 +151,21 @@ export async function resolveSkillSelections(
 ): Promise<ResolvedSkillSelections> {
   if (selections.length === 0) return { cliSelections: [], expectedLeaves: [] }
 
-  const candidates: SelectionCandidate[] = []
-  for (const file of files) {
-    if (file.path !== 'SKILL.md' && !file.path.endsWith('/SKILL.md')) continue
-    const text = await readHead(join(snapshotDir, ...file.path.split('/')), MAX_MANIFEST_BYTES)
-    const name = parseSkillManifest(text).name
-    if (!name) continue // the CLI refuses to install a nameless skill
-    const directory = dirname(file.path)
-    candidates.push({
-      path: file.path,
-      name,
-      leaf: skillInstallLeaf(name),
-      ...(directory === '.' ? {} : { directoryLeaf: skillInstallLeaf(basename(directory)) }),
-      body: text.replace(FRONTMATTER, '')
-    })
+  const candidates = await discoverCliCandidates(snapshotDir, files)
+  const byKey = new Map<string, SelectionCandidate[]>()
+  const byLowerName = new Map<string, SelectionCandidate[]>()
+  for (const candidate of candidates) {
+    for (const key of new Set([candidate.leaf, candidate.directoryLeaf])) {
+      if (key === undefined) continue
+      const list = byKey.get(key)
+      if (list) list.push(candidate)
+      else byKey.set(key, [candidate])
+    }
+    const lower = candidate.name.toLowerCase()
+    const list = byLowerName.get(lower)
+    if (list) list.push(candidate)
+    else byLowerName.set(lower, [candidate])
   }
-
-  const matchCandidates = (token: string): SelectionCandidate[] =>
-    candidates.filter((candidate) => candidate.leaf === token || candidate.directoryLeaf === token)
 
   const cliSelections: string[] = []
   const expectedLeaves: string[] = []
@@ -133,8 +182,8 @@ export async function resolveSkillSelections(
     // matches frontmatter names case-insensitively and de-duplicates exact
     // names by discovery order, so a shared name can silently install a
     // SIBLING skill while producing the expected leaf. Fail closed instead.
-    const sharingName = candidates.filter(
-      (other) => other.path !== candidate.path && other.name.toLowerCase() === candidate.name.toLowerCase()
+    const sharingName = (byLowerName.get(candidate.name.toLowerCase()) ?? []).filter(
+      (other) => other.path !== candidate.path
     )
     if (sharingName.length > 0) {
       throw new Error(
@@ -149,7 +198,7 @@ export async function resolveSkillSelections(
   }
 
   for (const selection of selections) {
-    const matched = matchCandidates(selection)
+    const matched = byKey.get(selection) ?? []
     const names = [...new Set(matched.map((candidate) => candidate.name))]
     if (names.length === 0) {
       const available = [...new Set(candidates.map((candidate) => candidate.leaf))].sort()
@@ -176,9 +225,12 @@ export async function resolveSkillSelections(
   // than one skill stays fail-closed like an explicit selection would.
   while (pendingBodies.length > 0) {
     const referrer = pendingBodies.shift()!
+    const seenTokens = new Set<string>()
     for (const match of referrer.body.matchAll(SLASH_REFERENCE)) {
       const token = match[1]!.toLowerCase()
-      const matched = matchCandidates(token)
+      if (seenTokens.has(token)) continue
+      seenTokens.add(token)
+      const matched = byKey.get(token) ?? []
       const names = [...new Set(matched.map((candidate) => candidate.name))]
       if (names.length === 0) continue // plain text, not a same-source skill
       if (names.some((name) => selectionByName.has(name))) continue // already satisfied
@@ -194,9 +246,194 @@ export async function resolveSkillSelections(
   return { cliSelections, expectedLeaves }
 }
 
-/** Bounded head read of a daemon-private snapshot file (the snapshot is fresh,
+/** Enumerate the skills skills@1.5.21 `add` would discover in the snapshot,
+ * mirroring its `discoverSkills`: a valid root manifest wins alone; otherwise
+ * the known container/harness/plugin paths are searched one grandchild deep;
+ * the recursive fallback (depth ≤ 5, SKIP_DIRS-pruned) runs only when that
+ * finds nothing. Candidates keep per-directory identity — the CLI's
+ * first-wins name de-duplication is deliberately NOT applied, so duplicate
+ * names surface as a fail-closed admission error instead of installing
+ * whichever sibling the CLI happened to discover first. */
+async function discoverCliCandidates(
+  snapshotDir: string,
+  files: readonly SnapshotFileRef[]
+): Promise<SelectionCandidate[]> {
+  const tree = buildSnapshotTree(files)
+  const lockedNames = await readCommittedLockNames(snapshotDir, tree)
+  const cache = new Map<string, SelectionCandidate | null>()
+  const candidateAt = async (dir: string): Promise<SelectionCandidate | null> => {
+    const cached = cache.get(dir)
+    if (cached !== undefined) return cached
+    const path = dir === '' ? 'SKILL.md' : `${dir}/SKILL.md`
+    const text = await readBounded(
+      join(snapshotDir, ...path.split('/')),
+      Math.min(tree.fileSizes.get(path) ?? 0, MAX_MANIFEST_BYTES)
+    )
+    const manifest = parseSkillManifest(text)
+    let candidate: SelectionCandidate | null = null
+    // The CLI requires BOTH name and description and skips internal skills;
+    // an incomplete manifest is invisible to it and must stay invisible here.
+    if (manifest.name && manifest.description !== null && !manifest.internal) {
+      candidate = {
+        path,
+        name: manifest.name,
+        leaf: skillInstallLeaf(manifest.name),
+        ...(dir === '' ? {} : { directoryLeaf: skillInstallLeaf(basename(dir)) }),
+        body: text.replace(FRONTMATTER, '')
+      }
+      if (isCommittedLockedInstall(dir, candidate.name, lockedNames)) candidate = null
+    }
+    cache.set(dir, candidate)
+    return candidate
+  }
+
+  // 1. A valid root manifest is the whole source (the CLI returns early).
+  if (tree.skillDirs.has('')) {
+    const root = await candidateAt('')
+    if (root) return [root]
+  }
+
+  // 2. Priority paths: root children (shallow), then containers one
+  //    grandchild deep. A child that HAS a SKILL.md — valid or not — is never
+  //    deepened further, exactly like the CLI's tryAddSkillAt short-circuit.
+  const found = new Map<string, SelectionCandidate>()
+  const tryAdd = async (dir: string): Promise<boolean> => {
+    if (!tree.skillDirs.has(dir)) return false
+    const candidate = await candidateAt(dir)
+    if (candidate && !found.has(dir)) found.set(dir, candidate)
+    return true
+  }
+  // Plugin containers are pushed after the CLI builds its deep-container set,
+  // so they are searched one level only — mirror that.
+  const priority: Array<{ container: string; deep: boolean }> = [
+    { container: '', deep: false },
+    ...SKILL_CONTAINER_DIRS.map((container) => ({ container, deep: true })),
+    ...AGENT_PROJECT_SKILL_DIRS.map((container) => ({ container, deep: true })),
+    ...(await readPluginSkillDirs(snapshotDir, tree)).map((container) => ({ container, deep: false }))
+  ]
+  for (const { container, deep } of priority) {
+    for (const child of tree.childDirs.get(container) ?? []) {
+      const childDir = container === '' ? child : `${container}/${child}`
+      if ((await tryAdd(childDir)) || !deep) continue
+      if (SKIP_DIRS.has(child)) continue
+      for (const grand of tree.childDirs.get(childDir) ?? []) {
+        if (SKIP_DIRS.has(grand)) continue
+        await tryAdd(`${childDir}/${grand}`)
+      }
+    }
+  }
+  if (found.size > 0) return [...found.values()]
+
+  // 3. Recursive fallback, only when the normal pass found nothing.
+  for (const dir of [...tree.skillDirs].sort()) {
+    if (dir === '') continue // parsed (and rejected) in step 1
+    const segments = dir.split('/')
+    if (segments.length > FALLBACK_MAX_DEPTH || segments.some((segment) => SKIP_DIRS.has(segment))) continue
+    const candidate = await candidateAt(dir)
+    if (candidate) found.set(dir, candidate)
+  }
+  return [...found.values()]
+}
+
+function buildSnapshotTree(files: readonly SnapshotFileRef[]): SnapshotTree {
+  const tree: SnapshotTree = { skillDirs: new Set(), childDirs: new Map(), fileSizes: new Map() }
+  for (const file of files) {
+    tree.fileSizes.set(file.path, file.size)
+    const parts = file.path.split('/')
+    if (parts.at(-1) === 'SKILL.md') tree.skillDirs.add(parts.slice(0, -1).join('/'))
+    for (let index = 0; index < parts.length - 1; index++) {
+      const parent = parts.slice(0, index).join('/')
+      let children = tree.childDirs.get(parent)
+      if (!children) {
+        children = new Set()
+        tree.childDirs.set(parent, children)
+      }
+      children.add(parts[index]!)
+    }
+  }
+  return tree
+}
+
+/** Names from a committed root skills-lock.json — the CLI treats matching
+ * skills under harness directories as already-installed and skips them. */
+async function readCommittedLockNames(snapshotDir: string, tree: SnapshotTree): Promise<Set<string>> {
+  const size = tree.fileSizes.get('skills-lock.json')
+  if (size === undefined || size > MAX_LOCK_BYTES) return new Set()
+  try {
+    const parsed = JSON.parse(await readBounded(join(snapshotDir, 'skills-lock.json'), size)) as {
+      skills?: unknown
+    }
+    if (!parsed.skills || typeof parsed.skills !== 'object' || Array.isArray(parsed.skills)) return new Set()
+    return new Set(Object.keys(parsed.skills).map(normalizeCliSkillName))
+  } catch {
+    return new Set()
+  }
+}
+
+/** Mirror of the CLI's normalizeSkillName used for lockfile comparisons. */
+function normalizeCliSkillName(name: string): string {
+  return name.toLowerCase().replace(/[\s_]+/g, '-')
+}
+
+function isCommittedLockedInstall(dir: string, name: string, lockedNames: Set<string>): boolean {
+  if (lockedNames.size === 0) return false
+  if (!AGENT_PROJECT_SKILL_DIRS.some((prefix) => dir === prefix || dir.startsWith(`${prefix}/`))) return false
+  return lockedNames.has(normalizeCliSkillName(name)) || lockedNames.has(normalizeCliSkillName(basename(dir)))
+}
+
+/** Additional search containers declared by committed `.claude-plugin`
+ * manifests, mirroring the CLI's getPluginSkillPaths (including its
+ * `./`-prefixed relative-path requirement and containment checks). */
+async function readPluginSkillDirs(snapshotDir: string, tree: SnapshotTree): Promise<string[]> {
+  const dirs: string[] = []
+  const contained = (path: string): string | undefined => {
+    const normalized = posix.normalize(path)
+    if (normalized.startsWith('..') || posix.isAbsolute(normalized)) return undefined
+    return normalized === '.' ? '' : normalized
+  }
+  const addPluginSkillDirs = (pluginBase: string, skills: unknown): void => {
+    const base = contained(pluginBase)
+    if (base === undefined) return
+    if (Array.isArray(skills)) {
+      for (const skillPath of skills) {
+        if (typeof skillPath !== 'string' || !skillPath.startsWith('./')) continue
+        const skillDir = contained(posix.dirname(posix.join(base, skillPath)))
+        if (skillDir !== undefined) dirs.push(skillDir)
+      }
+    }
+    dirs.push(base === '' ? 'skills' : `${base}/skills`)
+  }
+  const readManifest = async (path: string): Promise<unknown> => {
+    const size = tree.fileSizes.get(path)
+    if (size === undefined || size > MAX_LOCK_BYTES) return undefined
+    try {
+      return JSON.parse(await readBounded(join(snapshotDir, ...path.split('/')), size))
+    } catch {
+      return undefined
+    }
+  }
+  const marketplace = (await readManifest('.claude-plugin/marketplace.json')) as
+    { metadata?: { pluginRoot?: unknown }; plugins?: unknown } | undefined
+  if (marketplace) {
+    const pluginRoot = marketplace.metadata?.pluginRoot
+    if (pluginRoot === undefined || (typeof pluginRoot === 'string' && pluginRoot.startsWith('./'))) {
+      for (const plugin of Array.isArray(marketplace.plugins) ? marketplace.plugins : []) {
+        if (!plugin || typeof plugin !== 'object') continue
+        const { source, skills } = plugin as { source?: unknown; skills?: unknown }
+        if (source !== undefined && (typeof source !== 'string' || !source.startsWith('./'))) continue
+        addPluginSkillDirs(posix.join((pluginRoot as string | undefined) ?? '.', (source as string) ?? '.'), skills)
+      }
+    }
+  }
+  const pluginManifest = (await readManifest('.claude-plugin/plugin.json')) as { skills?: unknown } | undefined
+  if (pluginManifest) addPluginSkillDirs('.', pluginManifest.skills)
+  return dirs
+}
+
+/** Bounded read of a daemon-private snapshot file (the snapshot is fresh,
  * 0o700, and symlink-free by construction, so no adversarial-race hardening). */
-async function readHead(path: string, maxBytes: number): Promise<string> {
+async function readBounded(path: string, maxBytes: number): Promise<string> {
+  if (maxBytes <= 0) return ''
   const handle = await fsp.open(path, 'r')
   try {
     const body = Buffer.alloc(maxBytes)

--- a/packages/daemon/src/skills/skill-cli-selection.ts
+++ b/packages/daemon/src/skills/skill-cli-selection.ts
@@ -22,10 +22,10 @@ import { promises as fsp } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
 import { parseSkillManifest } from './local-skill-inventory.js'
 
-// Frontmatter and the short prompt body live at the head of SKILL.md; reading
-// more cannot change the parsed name and only inflates work on an oversized
-// manifest. Slash references beyond this window are not resolved.
-const MAX_MANIFEST_HEAD_BYTES = 64 * 1024
+// Aligned with Git snapshot per-file admission (GIT_SOURCE_SNAPSHOT_LIMITS
+// .maxFileBytes) so every SKILL.md the snapshot admitted — and the CLI's own
+// full-file parser will read — is parsed in full here too.
+const MAX_MANIFEST_BYTES = 4 * 1024 * 1024
 const MAX_LISTED_AVAILABLE = 32
 // Matches the wire-level cap on explicit selections per source.
 const MAX_RESOLVED_SELECTIONS = 64
@@ -70,10 +70,12 @@ export interface ResolvedSkillSelections {
 }
 
 interface SelectionCandidate {
+  /** Snapshot-relative SKILL.md path — the candidate's identity. */
+  path: string
   name: string
   leaf: string
   directoryLeaf?: string
-  /** Prompt body (head-bounded, frontmatter stripped) for slash references. */
+  /** Prompt body (frontmatter stripped) for slash references. */
   body: string
 }
 
@@ -84,7 +86,10 @@ interface SelectionCandidate {
  * (what the console's source scan offers); the matched set is then closed
  * over same-source slash references. Throws when a selection matches nothing,
  * a selection or reference matches more than one distinct skill name, two
- * selections collide, or a resolved name cannot ride the CLI argv safely.
+ * selections collide, a resolved name cannot ride the CLI argv safely, or the
+ * resolved frontmatter name does not uniquely (case-insensitively) identify
+ * one skill in the source — the CLI selects by that name alone, so a shared
+ * name could install a sibling skill while still producing the expected leaf.
  */
 export async function resolveSkillSelections(
   sourceName: string,
@@ -97,15 +102,16 @@ export async function resolveSkillSelections(
   const candidates: SelectionCandidate[] = []
   for (const file of files) {
     if (file.path !== 'SKILL.md' && !file.path.endsWith('/SKILL.md')) continue
-    const head = await readHead(join(snapshotDir, ...file.path.split('/')), MAX_MANIFEST_HEAD_BYTES)
-    const name = parseSkillManifest(head).name
+    const text = await readHead(join(snapshotDir, ...file.path.split('/')), MAX_MANIFEST_BYTES)
+    const name = parseSkillManifest(text).name
     if (!name) continue // the CLI refuses to install a nameless skill
     const directory = dirname(file.path)
     candidates.push({
+      path: file.path,
       name,
       leaf: skillInstallLeaf(name),
       ...(directory === '.' ? {} : { directoryLeaf: skillInstallLeaf(basename(directory)) }),
-      body: head.replace(FRONTMATTER, '')
+      body: text.replace(FRONTMATTER, '')
     })
   }
 
@@ -122,6 +128,19 @@ export async function resolveSkillSelections(
     }
     if (!isSafeCliSelection(candidate.name)) {
       throw new Error(`skill ${label} in source "${sourceName}" has a name the skills CLI cannot select safely`)
+    }
+    // The emitted `-s` value must uniquely identify this candidate: the CLI
+    // matches frontmatter names case-insensitively and de-duplicates exact
+    // names by discovery order, so a shared name can silently install a
+    // SIBLING skill while producing the expected leaf. Fail closed instead.
+    const sharingName = candidates.filter(
+      (other) => other.path !== candidate.path && other.name.toLowerCase() === candidate.name.toLowerCase()
+    )
+    if (sharingName.length > 0) {
+      throw new Error(
+        `skill ${label} in source "${sourceName}" resolves to CLI name "${candidate.name}", ` +
+          `which does not uniquely identify one skill (also declared by ${sharingName[0]!.path})`
+      )
     }
     selectionByName.set(candidate.name, label)
     cliSelections.push(candidate.name)

--- a/packages/daemon/src/skills/skill-git-source.ts
+++ b/packages/daemon/src/skills/skill-git-source.ts
@@ -474,6 +474,10 @@ interface ArchiveValidationState {
   seen: Map<string, SeenArchivePath>
   ancestors: Set<string>
   inventory: Map<string, SeenArchivePath['type']>
+  /** Symlink/hardlink entries admitted for SKIPPING only — never extracted.
+   * Whether each one is actually tolerable (outside every skill directory) is
+   * decided after the full inventory is known. */
+  skippedLinks: Set<string>
 }
 
 function archiveCollisionComponent(value: string): string {
@@ -502,7 +506,14 @@ function countArchiveEntry(state: ArchiveValidationState, limits: GitSkillArchiv
 
 function validateArchiveEntry(entry: ReadEntry, state: ArchiveValidationState, limits: GitSkillArchiveLimits): void {
   countArchiveEntry(state, limits)
-  if (entry.type !== 'File' && entry.type !== 'Directory') {
+  // Git can only record files, directories, and symlinks (hardlinks can appear
+  // in tar re-encodings of identical blobs). Repositories routinely carry
+  // repo-level links like AGENTS.md -> CLAUDE.md that are unrelated to any
+  // skill, so link entries are admitted here for skipping — never extraction —
+  // and rejected after the full inventory is known if one sits inside a skill
+  // directory (see rejectLinksInsideSkills). Anything else stays fatal.
+  const linkLike = entry.type === 'SymbolicLink' || entry.type === 'Link'
+  if (!linkLike && entry.type !== 'File' && entry.type !== 'Directory') {
     throw new Error('skill GitHub archive contains a link or special entry')
   }
 
@@ -532,15 +543,13 @@ function validateArchiveEntry(entry: ReadEntry, state: ArchiveValidationState, l
   state.root ??= parts[0]
   if (parts[0] !== state.root) throw new Error('skill GitHub archive contains multiple roots')
 
-  const type = entry.type === 'Directory' ? 'directory' : 'file'
-  if (state.inventory.has(path)) throw new Error('skill GitHub archive contains a duplicate path')
-  state.inventory.set(path, type)
-
   const relative = parts.slice(1)
   if (relative.length === 0) {
     if (entry.type !== 'Directory' || entry.size !== 0) {
       throw new Error('skill GitHub archive has an invalid root entry')
     }
+    if (state.inventory.has(path)) throw new Error('skill GitHub archive contains a duplicate path')
+    state.inventory.set(path, 'directory')
     return
   }
   if (relative.length > limits.maxDepth) throw new Error('skill GitHub archive exceeds the depth limit')
@@ -548,6 +557,14 @@ function validateArchiveEntry(entry: ReadEntry, state: ArchiveValidationState, l
   if (Buffer.byteLength(relativePath) > limits.maxPathBytes) {
     throw new Error('skill GitHub archive contains an oversized path')
   }
+
+  if (linkLike) {
+    state.skippedLinks.add(path)
+    return
+  }
+  const type = entry.type === 'Directory' ? 'directory' : 'file'
+  if (state.inventory.has(path)) throw new Error('skill GitHub archive contains a duplicate path')
+  state.inventory.set(path, type)
 
   const collisionKey = relative.map(archiveCollisionComponent).join('/')
   registerArchivePath(state, collisionKey, type)
@@ -566,6 +583,23 @@ function validateArchiveEntry(entry: ReadEntry, state: ArchiveValidationState, l
   }
 }
 
+/** A skipped link is tolerable only OUTSIDE every skill directory (any
+ * directory holding a SKILL.md, recursively): the installed bundles then
+ * cannot silently diverge from the upstream skill content. A link inside a
+ * skill stays fail-closed — such a skill is uninstallable through AgentConnect
+ * anyway (the snapshot and CLI-cell layers both refuse links). */
+function rejectLinksInsideSkills(state: ArchiveValidationState): void {
+  if (state.skippedLinks.size === 0) return
+  const skillDirs = [...state.inventory.keys()]
+    .filter((path) => path.endsWith('/SKILL.md'))
+    .map((path) => path.slice(0, -'/SKILL.md'.length))
+  for (const link of state.skippedLinks) {
+    if (skillDirs.some((dir) => link.startsWith(`${dir}/`))) {
+      throw new Error('skill GitHub archive contains a link or special entry inside a skill directory')
+    }
+  }
+}
+
 async function validateAndExtractArchive(
   tarBody: Buffer,
   destination: string,
@@ -578,7 +612,8 @@ async function validateAndExtractArchive(
     totalFileBytes: 0,
     seen: new Map(),
     ancestors: new Set(),
-    inventory: new Map()
+    inventory: new Map(),
+    skippedLinks: new Set()
   }
   let validationError: Error | undefined
   const parser = listTar({
@@ -615,6 +650,7 @@ async function validateAndExtractArchive(
     throw new Error('skill GitHub archive is not a valid tar stream')
   }
   if (!state.root || state.files === 0) throw new Error('skill GitHub archive contains no files')
+  rejectLinksInsideSkills(state)
 
   const remaining = new Map(state.inventory)
   let extractionError: Error | undefined
@@ -636,6 +672,10 @@ async function validateAndExtractArchive(
     fmode: 0o600,
     filter: (_path, entry) => {
       if (!('type' in entry) || (entry.type !== 'File' && entry.type !== 'Directory')) {
+        // Validated links are skipped without being materialized.
+        if ('type' in entry && (entry.type === 'SymbolicLink' || entry.type === 'Link')) {
+          if (state.skippedLinks.has(entry.path)) return false
+        }
         extractionError = new Error('skill GitHub archive extraction inventory changed')
         return false
       }
@@ -650,7 +690,8 @@ async function validateAndExtractArchive(
       return true
     }
   })
-  extractor.on('ignoredEntry', () => {
+  extractor.on('ignoredEntry', (entry) => {
+    if (state.skippedLinks.has(entry.path)) return
     extractionError ??= new Error('skill GitHub archive extraction inventory changed')
     extractor.abort(extractionError)
   })

--- a/packages/daemon/src/skills/skills-cli-cell.ts
+++ b/packages/daemon/src/skills/skills-cli-cell.ts
@@ -260,7 +260,7 @@ export async function stageSkillsCliCell(options: StageSkillsCliCellOptions): Pr
   const sourceSnapshot = canonicalSnapshotPath(options.sourceSnapshot)
   assertSafeToken(options.agentId, 'agent id')
   const selectedSkills = options.selectedSkills ?? []
-  for (const skill of selectedSkills) assertCanonicalSelection(skill)
+  for (const skill of selectedSkills) assertSafeSelection(skill)
 
   const cli = (options.resolveCli ?? resolvePinnedSkillsCli)()
   if (cli.version !== PINNED_SKILLS_CLI_VERSION) {
@@ -632,11 +632,14 @@ function assertSafeToken(value: string, label: string): void {
   }
 }
 
-function assertCanonicalSelection(value: string): void {
-  // skills@1.5.21 lowercases install leaves and trims terminal dots/hyphens.
-  // Accept only its fixed points so an API selection and the audited output
-  // receipt can be compared exactly without aliases or collision surprises.
-  if (!/^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9_])?$/.test(value)) {
+function assertSafeSelection(value: string): void {
+  // A selection is matched by the CLI against SKILL.md frontmatter names
+  // (case-insensitively), which need not be canonical leaf names — the
+  // installer resolves wire-canonical selections to those names first
+  // (skill-cli-selection.ts) and compares the audited output receipt against
+  // the resolved leaf set itself. This boundary only refuses values that
+  // could be parsed as options or garble the argv.
+  if (value.length === 0 || value.length > 255 || value.startsWith('-') || !/^[\x20-\x7e]+$/.test(value)) {
     throw new SkillsCliCellError('invalid selected skill')
   }
 }

--- a/packages/daemon/test/skill-cli-selection.test.ts
+++ b/packages/daemon/test/skill-cli-selection.test.ts
@@ -15,16 +15,22 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
-/** Write a snapshot-shaped tree of SKILL.md files and return its file refs. */
-async function snapshot(skills: Record<string, string | null>): Promise<{ dir: string; files: SnapshotFileRef[] }> {
+/** Write a snapshot-shaped tree of SKILL.md files and return its file refs.
+ * Values are either a frontmatter name (with a default body) or
+ * `{ name, body }`; `name: null` writes a nameless manifest. */
+async function snapshot(
+  skills: Record<string, string | null | { name: string; body: string }>
+): Promise<{ dir: string; files: SnapshotFileRef[] }> {
   const dir = await mkdtemp(join(tmpdir(), 'ac-skill-selection-'))
   roots.push(dir)
   const files: SnapshotFileRef[] = []
-  for (const [path, name] of Object.entries(skills)) {
+  for (const [path, value] of Object.entries(skills)) {
     const absolute = join(dir, ...path.split('/'))
     await mkdir(dirname(absolute), { recursive: true })
+    const name = typeof value === 'object' && value !== null ? value.name : value
+    const body = typeof value === 'object' && value !== null ? value.body : '# body\n'
     const frontmatter = name === null ? 'description: d' : `name: ${name}\ndescription: d`
-    await writeFile(absolute, `---\n${frontmatter}\n---\n# body\n`)
+    await writeFile(absolute, `---\n${frontmatter}\n---\n${body}`)
     files.push({ path })
   }
   return { dir, files }
@@ -126,5 +132,67 @@ describe('resolveSkillSelections', () => {
   it('refuses a resolved name the CLI argv cannot carry safely', async () => {
     const { dir, files } = await snapshot({ 'skills/grill-me/SKILL.md': '--Grill Me' })
     await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).rejects.toThrow(/cannot select safely/)
+  })
+
+  it('pulls in a same-source skill the selected body invokes by slash reference (#371)', async () => {
+    const { dir, files } = await snapshot({
+      'skills/productivity/grill-me/SKILL.md': { name: 'grill-me', body: 'Run a `/grilling` session.\n' },
+      'skills/productivity/grilling/SKILL.md': 'grilling',
+      'skills/productivity/unrelated/SKILL.md': 'unrelated'
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).resolves.toEqual({
+      cliSelections: ['grill-me', 'grilling'],
+      expectedLeaves: ['grill-me', 'grilling']
+    })
+  })
+
+  it('closes references transitively and tolerates cycles', async () => {
+    const { dir, files } = await snapshot({
+      'skills/a/SKILL.md': { name: 'a', body: 'Run /b now.\n' },
+      'skills/b/SKILL.md': { name: 'b', body: 'Delegate to /c, or restart via /a.\n' },
+      'skills/c/SKILL.md': 'c'
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['a'])).resolves.toEqual({
+      cliSelections: ['a', 'b', 'c'],
+      expectedLeaves: ['a', 'b', 'c']
+    })
+  })
+
+  it('ignores slash tokens that name nothing in the source and explicit duplicates', async () => {
+    const { dir, files } = await snapshot({
+      'skills/grill-me/SKILL.md': {
+        name: 'grill-me',
+        body: 'See /tmp/log, https://x.test/path, then run `/grilling` and `/grill-me`.\n'
+      },
+      'skills/grilling/SKILL.md': 'grilling'
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me', 'grilling'])).resolves.toEqual({
+      cliSelections: ['grill-me', 'grilling'],
+      expectedLeaves: ['grill-me', 'grilling']
+    })
+  })
+
+  it('resolves a display-style referenced name through its canonical token', async () => {
+    const { dir, files } = await snapshot({
+      'skills/grill-me/SKILL.md': { name: 'grill-me', body: 'Run `/grilling`.\n' },
+      'skills/grilling/SKILL.md': 'Grilling Session'
+    })
+    // /grilling matches the grilling DIRECTORY; the CLI matches the display
+    // name and installs under its sanitized leaf.
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).resolves.toEqual({
+      cliSelections: ['grill-me', 'Grilling Session'],
+      expectedLeaves: ['grill-me', 'grilling-session']
+    })
+  })
+
+  it('fails closed when a reference is ambiguous in the source', async () => {
+    const { dir, files } = await snapshot({
+      'skills/grill-me/SKILL.md': { name: 'grill-me', body: 'Run `/grilling`.\n' },
+      'skills/grilling/SKILL.md': 'grilling one',
+      'packs/grilling/SKILL.md': 'grilling two'
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).rejects.toThrow(
+      /reference "\/grilling" matches more than one/
+    )
   })
 })

--- a/packages/daemon/test/skill-cli-selection.test.ts
+++ b/packages/daemon/test/skill-cli-selection.test.ts
@@ -185,6 +185,45 @@ describe('resolveSkillSelections', () => {
     })
   })
 
+  it('rejects a directory alias whose frontmatter name is shared by a sibling skill', async () => {
+    // The CLI selects by frontmatter name alone (case-insensitively, exact
+    // names de-duplicated by discovery order): emitting `-s Shared` here could
+    // install alpha while the user selected beta, with the identical leaf
+    // keeping the receipt check green.
+    const { dir, files } = await snapshot({
+      'skills/alpha/SKILL.md': 'Shared',
+      'skills/beta/SKILL.md': 'Shared'
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['beta'])).rejects.toThrow(
+      /"beta".*"Shared".*does not uniquely identify one skill.*skills\/alpha\/SKILL\.md/
+    )
+  })
+
+  it('rejects a leaf selection and a slash reference resolving to a case-folded shared name', async () => {
+    const caseOnly = await snapshot({
+      'skills/alpha/SKILL.md': 'Shared',
+      'skills/beta/SKILL.md': 'SHARED'
+    })
+    await expect(resolveSkillSelections('src', caseOnly.dir, caseOnly.files, ['shared'])).rejects.toThrow(
+      /matches more than one skill/
+    )
+    const viaAlias = await snapshot({
+      'skills/alpha/SKILL.md': 'Shared',
+      'skills/beta/SKILL.md': 'SHARED'
+    })
+    await expect(resolveSkillSelections('src', viaAlias.dir, viaAlias.files, ['beta'])).rejects.toThrow(
+      /does not uniquely identify one skill/
+    )
+    const viaReference = await snapshot({
+      'skills/entry/SKILL.md': { name: 'entry', body: 'Run `/beta`.\n' },
+      'skills/alpha/SKILL.md': 'Shared',
+      'skills/beta/SKILL.md': 'SHARED'
+    })
+    await expect(resolveSkillSelections('src', viaReference.dir, viaReference.files, ['entry'])).rejects.toThrow(
+      /does not uniquely identify one skill/
+    )
+  })
+
   it('fails closed when a reference is ambiguous in the source', async () => {
     const { dir, files } = await snapshot({
       'skills/grill-me/SKILL.md': { name: 'grill-me', body: 'Run `/grilling`.\n' },

--- a/packages/daemon/test/skill-cli-selection.test.ts
+++ b/packages/daemon/test/skill-cli-selection.test.ts
@@ -15,23 +15,31 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
-/** Write a snapshot-shaped tree of SKILL.md files and return its file refs.
- * Values are either a frontmatter name (with a default body) or
- * `{ name, body }`; `name: null` writes a nameless manifest. */
+/** Write a snapshot-shaped tree of files and return their receipt refs.
+ * SKILL.md values are a frontmatter name (default body), `{ name, body,
+ * frontmatter? }` for control over both, or `null` for a nameless manifest;
+ * `{ raw }` writes any file verbatim (lockfiles, plugin manifests). */
 async function snapshot(
-  skills: Record<string, string | null | { name: string; body: string }>
+  entries: Record<string, string | null | { name?: string; body?: string; frontmatter?: string; raw?: string }>
 ): Promise<{ dir: string; files: SnapshotFileRef[] }> {
   const dir = await mkdtemp(join(tmpdir(), 'ac-skill-selection-'))
   roots.push(dir)
   const files: SnapshotFileRef[] = []
-  for (const [path, value] of Object.entries(skills)) {
+  for (const [path, value] of Object.entries(entries)) {
     const absolute = join(dir, ...path.split('/'))
     await mkdir(dirname(absolute), { recursive: true })
-    const name = typeof value === 'object' && value !== null ? value.name : value
-    const body = typeof value === 'object' && value !== null ? value.body : '# body\n'
-    const frontmatter = name === null ? 'description: d' : `name: ${name}\ndescription: d`
-    await writeFile(absolute, `---\n${frontmatter}\n---\n${body}`)
-    files.push({ path })
+    let content: string
+    if (typeof value === 'object' && value !== null && value.raw !== undefined) {
+      content = value.raw
+    } else {
+      const name = typeof value === 'object' && value !== null ? value.name : (value ?? undefined)
+      const body = (typeof value === 'object' && value !== null ? value.body : undefined) ?? '# body\n'
+      const extra = (typeof value === 'object' && value !== null ? value.frontmatter : undefined) ?? 'description: d'
+      const frontmatter = name === undefined || name === null ? extra : `name: ${name}\n${extra}`
+      content = `---\n${frontmatter}\n---\n${body}`
+    }
+    await writeFile(absolute, content)
+    files.push({ path, size: Buffer.byteLength(content) })
   }
   return { dir, files }
 }
@@ -115,9 +123,11 @@ describe('resolveSkillSelections', () => {
   })
 
   it('rejects a selection matching two distinct skill names', async () => {
+    // skills/more/grill-me sits one grandchild below the skills container, so
+    // the CLI's discovery (and therefore ours) sees both.
     const { dir, files } = await snapshot({
       'skills/grill-me/SKILL.md': 'Grill Me',
-      'packs/grill-me/SKILL.md': 'grill me'
+      'skills/more/grill-me/SKILL.md': 'grill me'
     })
     await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).rejects.toThrow(/matches more than one/)
   })
@@ -228,10 +238,84 @@ describe('resolveSkillSelections', () => {
     const { dir, files } = await snapshot({
       'skills/grill-me/SKILL.md': { name: 'grill-me', body: 'Run `/grilling`.\n' },
       'skills/grilling/SKILL.md': 'grilling one',
-      'packs/grilling/SKILL.md': 'grilling two'
+      'skills/more/grilling/SKILL.md': 'grilling two'
     })
     await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).rejects.toThrow(
       /reference "\/grilling" matches more than one/
     )
+  })
+
+  it('ignores manifests the pinned CLI cannot discover or refuses to parse (#572 review)', async () => {
+    // The reviewer's reproduction: a same-named manifest that the CLI ignores
+    // (outside its discovery paths, or missing a required field) must not make
+    // a valid selection ambiguous.
+    const { dir, files } = await snapshot({
+      'skills/valid/SKILL.md': 'Shared',
+      'examples/fixture/SKILL.md': 'Shared', // valid manifest, undiscoverable path
+      'skills/incomplete/SKILL.md': { name: 'Shared', frontmatter: '' }, // no description
+      'skills/hidden/SKILL.md': { name: 'Shared', frontmatter: 'description: d\nmetadata:\n  internal: true' },
+      'skills/node_modules/dep/SKILL.md': 'Shared' // SKIP_DIRS-pruned grandchild
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['valid'])).resolves.toEqual({
+      cliSelections: ['Shared'],
+      expectedLeaves: ['shared']
+    })
+  })
+
+  it('mirrors the CLI root-manifest early return: a valid root SKILL.md is the whole source', async () => {
+    const { dir, files } = await snapshot({
+      'SKILL.md': 'root-skill',
+      'skills/nested/SKILL.md': 'nested'
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['nested'])).rejects.toThrow(
+      /"nested" was not found in source "src" \(available: root-skill\)/
+    )
+    await expect(resolveSkillSelections('src', dir, files, ['root-skill'])).resolves.toEqual({
+      cliSelections: ['root-skill'],
+      expectedLeaves: ['root-skill']
+    })
+  })
+
+  it('uses the recursive fallback only when the normal discovery pass finds nothing', async () => {
+    const fallback = await snapshot({ 'examples/fixture/SKILL.md': 'deep-skill' })
+    await expect(resolveSkillSelections('src', fallback.dir, fallback.files, ['deep-skill'])).resolves.toEqual({
+      cliSelections: ['deep-skill'],
+      expectedLeaves: ['deep-skill']
+    })
+    const shadowed = await snapshot({
+      'skills/normal/SKILL.md': 'normal',
+      'examples/fixture/SKILL.md': 'deep-skill'
+    })
+    await expect(resolveSkillSelections('src', shadowed.dir, shadowed.files, ['deep-skill'])).rejects.toThrow(
+      /"deep-skill" was not found in source "src" \(available: normal\)/
+    )
+  })
+
+  it('excludes committed lockfile installs under harness directories like the CLI', async () => {
+    const { dir, files } = await snapshot({
+      'skills/deploy/SKILL.md': 'deploy',
+      '.claude/skills/deploy/SKILL.md': 'deploy',
+      'skills-lock.json': { raw: JSON.stringify({ version: 1, skills: { deploy: {} } }) }
+    })
+    // The committed .claude/skills copy is an "installed project skill" to the
+    // CLI; only the real source under skills/ is a candidate, so the selection
+    // stays unambiguous.
+    await expect(resolveSkillSelections('src', dir, files, ['deploy'])).resolves.toEqual({
+      cliSelections: ['deploy'],
+      expectedLeaves: ['deploy']
+    })
+  })
+
+  it('discovers skills below committed .claude-plugin manifests like the CLI', async () => {
+    // A plugin manifest's `skills` entries are skill DIRECTORY paths; the CLI
+    // searches their dirname as an extra container.
+    const { dir, files } = await snapshot({
+      '.claude-plugin/plugin.json': { raw: JSON.stringify({ skills: ['./tools/grill-me'] }) },
+      'tools/grill-me/SKILL.md': 'grill-me'
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).resolves.toEqual({
+      cliSelections: ['grill-me'],
+      expectedLeaves: ['grill-me']
+    })
   })
 })

--- a/packages/daemon/test/skill-cli-selection.test.ts
+++ b/packages/daemon/test/skill-cli-selection.test.ts
@@ -1,0 +1,130 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  isSafeCliSelection,
+  resolveSkillSelections,
+  skillInstallLeaf,
+  type SnapshotFileRef
+} from '../src/skills/skill-cli-selection.js'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+/** Write a snapshot-shaped tree of SKILL.md files and return its file refs. */
+async function snapshot(skills: Record<string, string | null>): Promise<{ dir: string; files: SnapshotFileRef[] }> {
+  const dir = await mkdtemp(join(tmpdir(), 'ac-skill-selection-'))
+  roots.push(dir)
+  const files: SnapshotFileRef[] = []
+  for (const [path, name] of Object.entries(skills)) {
+    const absolute = join(dir, ...path.split('/'))
+    await mkdir(dirname(absolute), { recursive: true })
+    const frontmatter = name === null ? 'description: d' : `name: ${name}\ndescription: d`
+    await writeFile(absolute, `---\n${frontmatter}\n---\n# body\n`)
+    files.push({ path })
+  }
+  return { dir, files }
+}
+
+describe('skillInstallLeaf', () => {
+  it('mirrors the pinned CLI sanitizeName exactly', () => {
+    expect(skillInstallLeaf('grill-me')).toBe('grill-me')
+    expect(skillInstallLeaf('Grill Me')).toBe('grill-me')
+    expect(skillInstallLeaf('grill_me')).toBe('grill_me')
+    expect(skillInstallLeaf('--Grill  Me--')).toBe('grill-me')
+    expect(skillInstallLeaf('.hidden.')).toBe('hidden')
+    expect(skillInstallLeaf('烧烤')).toBe('unnamed-skill')
+    expect(skillInstallLeaf(`x${'y'.repeat(300)}`)).toHaveLength(255)
+  })
+})
+
+describe('isSafeCliSelection', () => {
+  it('accepts display names and refuses option-shaped or non-ASCII values', () => {
+    expect(isSafeCliSelection('Grill Me')).toBe(true)
+    expect(isSafeCliSelection('grill-me')).toBe(true)
+    expect(isSafeCliSelection('')).toBe(false)
+    expect(isSafeCliSelection('-s')).toBe(false)
+    expect(isSafeCliSelection('--agent')).toBe(false)
+    expect(isSafeCliSelection('a\nb')).toBe(false)
+    expect(isSafeCliSelection('烧烤')).toBe(false)
+  })
+})
+
+describe('resolveSkillSelections', () => {
+  it('passes an already-canonical frontmatter name through unchanged', async () => {
+    const { dir, files } = await snapshot({ 'skills/grill-me/SKILL.md': 'grill-me' })
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).resolves.toEqual({
+      cliSelections: ['grill-me'],
+      expectedLeaves: ['grill-me']
+    })
+  })
+
+  it('resolves a canonical selection to a display-style frontmatter name (#371)', async () => {
+    const { dir, files } = await snapshot({
+      'skills/grill-me/SKILL.md': 'Grill Me',
+      'skills/other/SKILL.md': 'other'
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me', 'other'])).resolves.toEqual({
+      cliSelections: ['Grill Me', 'other'],
+      expectedLeaves: ['grill-me', 'other']
+    })
+  })
+
+  it('resolves a directory-name selection and reports the differing install leaf', async () => {
+    const { dir, files } = await snapshot({ 'skills/grill-me/SKILL.md': 'grill_me' })
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).resolves.toEqual({
+      cliSelections: ['grill_me'],
+      expectedLeaves: ['grill_me']
+    })
+  })
+
+  it('resolves a root SKILL.md by its sanitized frontmatter name', async () => {
+    const { dir, files } = await snapshot({ 'SKILL.md': 'Root Skill' })
+    await expect(resolveSkillSelections('src', dir, files, ['root-skill'])).resolves.toEqual({
+      cliSelections: ['Root Skill'],
+      expectedLeaves: ['root-skill']
+    })
+  })
+
+  it('requires no resolution when the selection is empty (install everything)', async () => {
+    const { dir, files } = await snapshot({ 'skills/anything/SKILL.md': 'Whatever Name' })
+    await expect(resolveSkillSelections('src', dir, files, [])).resolves.toEqual({
+      cliSelections: [],
+      expectedLeaves: []
+    })
+  })
+
+  it('lists the available canonical names when a selection matches nothing', async () => {
+    const { dir, files } = await snapshot({
+      'skills/grill-me/SKILL.md': 'Grill Me',
+      'skills/nameless/SKILL.md': null
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['missing'])).rejects.toThrow(
+      /"missing" was not found in source "src" \(available: grill-me\)/
+    )
+  })
+
+  it('rejects a selection matching two distinct skill names', async () => {
+    const { dir, files } = await snapshot({
+      'skills/grill-me/SKILL.md': 'Grill Me',
+      'packs/grill-me/SKILL.md': 'grill me'
+    })
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).rejects.toThrow(/matches more than one/)
+  })
+
+  it('rejects two selections resolving to the same skill', async () => {
+    const { dir, files } = await snapshot({ 'skills/grill-me/SKILL.md': 'grill_me' })
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me', 'grill_me'])).rejects.toThrow(
+      /resolve to the same skill/
+    )
+  })
+
+  it('refuses a resolved name the CLI argv cannot carry safely', async () => {
+    const { dir, files } = await snapshot({ 'skills/grill-me/SKILL.md': '--Grill Me' })
+    await expect(resolveSkillSelections('src', dir, files, ['grill-me'])).rejects.toThrow(/cannot select safely/)
+  })
+})

--- a/packages/daemon/test/skill-git-source.test.ts
+++ b/packages/daemon/test/skill-git-source.test.ts
@@ -419,6 +419,55 @@ describe('Git skill source policy boundary', () => {
     }
   })
 
+  it('skips a repo-level symlink outside every skill directory without materializing it (#371)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ac-skill-git-repo-link-'))
+    // The mattpocock/skills shape: an AGENTS.md -> CLAUDE.md symlink at the
+    // repository root, unrelated to the nested skill being installed.
+    const archive = tarGzip([
+      { path: `skills-${SHA}/CLAUDE.md`, body: '# repo instructions\n' },
+      { path: `skills-${SHA}/AGENTS.md`, type: '2', linkpath: 'CLAUDE.md' },
+      { path: `skills-${SHA}/skills/productivity/grill-me/SKILL.md`, body: '---\nname: grill-me\n---\n# grill\n' }
+    ])
+    const offline = offlineGitHubFetch({ archive })
+    try {
+      const result = await acquireGitSkillSource(entry('acme/skills'), {
+        destination: join(root, 'acquired'),
+        agentId: 'agent-1',
+        useGitCredential: false,
+        fetch: offline.fetch
+      })
+      expect(await readFile(join(result.sourceDir, 'skills/productivity/grill-me/SKILL.md'), 'utf8')).toContain(
+        '# grill'
+      )
+      expect(await readFile(join(result.sourceDir, 'CLAUDE.md'), 'utf8')).toContain('repo instructions')
+      expect(existsSync(join(result.sourceDir, 'AGENTS.md'))).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('still rejects a link inside a skill directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ac-skill-git-skill-link-'))
+    const archive = tarGzip([
+      { path: `skills-${SHA}/skills/grill-me/SKILL.md`, body: '---\nname: grill-me\n---\n# grill\n' },
+      { path: `skills-${SHA}/skills/grill-me/scripts/escape`, type: '2', linkpath: '/tmp/outside' }
+    ])
+    const offline = offlineGitHubFetch({ archive })
+    try {
+      await expect(
+        acquireGitSkillSource(entry('acme/skills'), {
+          destination: join(root, 'acquired'),
+          agentId: 'agent-1',
+          useGitCredential: false,
+          fetch: offline.fetch
+        })
+      ).rejects.toThrow(/link or special entry inside a skill directory/i)
+      expect(existsSync(join(root, 'acquired/repository/skills/grill-me/SKILL.md'))).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('rejects symlink and parser-ignored special archive entries before writing them', async () => {
     for (const [name, special] of [
       ['symlink', { path: `skills-${SHA}/escape`, type: '2' as const, linkpath: '/tmp/outside' }],

--- a/packages/daemon/test/skills-cli-cell.test.ts
+++ b/packages/daemon/test/skills-cli-cell.test.ts
@@ -216,7 +216,9 @@ describe('stageSkillsCliCell', () => {
     await expect(
       stageSkillsCliCell({ ...base, sourceSnapshot: snapshot, selectedSkills: ['--agent', 'safe'] })
     ).rejects.toThrow(/invalid selected skill/)
-    for (const selectedSkill of ['Foo', 'foo.', 'foo-', '.hidden', '_tool']) {
+    // Selections are resolved frontmatter names (skill-cli-selection.ts), not
+    // canonical leaves — only option-shaped or argv-unsafe values are refused.
+    for (const selectedSkill of ['-s', '', 'a\nb', '烧烤', `x${'y'.repeat(256)}`]) {
       await expect(
         stageSkillsCliCell({ ...base, sourceSnapshot: snapshot, selectedSkills: [selectedSkill] })
       ).rejects.toThrow(/invalid selected skill/)

--- a/packages/daemon/test/skills-cli-golden.test.ts
+++ b/packages/daemon/test/skills-cli-golden.test.ts
@@ -56,14 +56,27 @@ describe.skipIf(!hasBwrap)('skills@1.5.21 local-source golden', () => {
     }
   })
 
-  it('installs a canonical selection whose SKILL.md name is display-style (#371)', async () => {
+  it('installs a display-style-named selection plus its slash-referenced dependency (#371)', async () => {
     const root = await mkdtemp(join(tmpdir(), 'ac-skills-cli-golden-'))
     roots.push(root)
+    // The mattpocock/skills shape: two-level nesting, a thin alias skill whose
+    // body invokes a sibling, and a frontmatter name differing from the
+    // directory name.
     const source = join(root, 'grill-source')
-    await mkdir(join(source, 'skills/grill-me'), { recursive: true })
+    await mkdir(join(source, 'skills/productivity/grill-me'), { recursive: true })
+    await mkdir(join(source, 'skills/productivity/grilling'), { recursive: true })
+    await mkdir(join(source, 'skills/productivity/unrelated'), { recursive: true })
     await writeFile(
-      join(source, 'skills/grill-me/SKILL.md'),
-      '---\nname: Grill Me\ndescription: Display-style frontmatter name golden fixture\n---\n# Grill me\n'
+      join(source, 'skills/productivity/grill-me/SKILL.md'),
+      '---\nname: Grill Me\ndescription: Alias with a display-style name\n---\nRun a `/grilling` session.\n'
+    )
+    await writeFile(
+      join(source, 'skills/productivity/grilling/SKILL.md'),
+      '---\nname: grilling\ndescription: The referenced interview skill\n---\n# Interview relentlessly\n'
+    )
+    await writeFile(
+      join(source, 'skills/productivity/unrelated/SKILL.md'),
+      '---\nname: unrelated\ndescription: Must not install\n---\n# unrelated\n'
     )
     const cwd = join(root, 'workspace')
     await mkdir(cwd)
@@ -82,8 +95,12 @@ describe.skipIf(!hasBwrap)('skills@1.5.21 local-source golden', () => {
     )
 
     expect(result.errors).toEqual([])
-    expect(result.installed).toContain('.claude/skills/grill-me')
-    expect(await readFile(join(cwd, '.claude/skills/grill-me/SKILL.md'), 'utf8')).toContain('# Grill me')
+    expect(result.installed.sort()).toEqual(['.claude/skills/grill-me', '.claude/skills/grilling'])
+    expect(await readFile(join(cwd, '.claude/skills/grill-me/SKILL.md'), 'utf8')).toContain('/grilling')
+    expect(await readFile(join(cwd, '.claude/skills/grilling/SKILL.md'), 'utf8')).toContain('# Interview relentlessly')
+    await expect(readFile(join(cwd, '.claude/skills/unrelated/SKILL.md'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
   })
 
   it('uses that same local-source CLI path after Git acquisition and publishes only receipt-derived bundles', async () => {

--- a/packages/daemon/test/skills-cli-golden.test.ts
+++ b/packages/daemon/test/skills-cli-golden.test.ts
@@ -56,6 +56,36 @@ describe.skipIf(!hasBwrap)('skills@1.5.21 local-source golden', () => {
     }
   })
 
+  it('installs a canonical selection whose SKILL.md name is display-style (#371)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ac-skills-cli-golden-'))
+    roots.push(root)
+    const source = join(root, 'grill-source')
+    await mkdir(join(source, 'skills/grill-me'), { recursive: true })
+    await writeFile(
+      join(source, 'skills/grill-me/SKILL.md'),
+      '---\nname: Grill Me\ndescription: Display-style frontmatter name golden fixture\n---\n# Grill me\n'
+    )
+    const cwd = join(root, 'workspace')
+    await mkdir(cwd)
+
+    const result = await installSkills(
+      {
+        id: 'agent-grill',
+        runtime: 'claude',
+        skills: [{ name: 'grill', source: 'acme/grill', githubRepoId: '42', skills: ['grill-me'] }]
+      },
+      cwd,
+      {
+        stateDir: join(root, 'trusted-state'),
+        acquireGit: async () => ({ sourceDir: source, resolvedCommit: 'c'.repeat(40) })
+      }
+    )
+
+    expect(result.errors).toEqual([])
+    expect(result.installed).toContain('.claude/skills/grill-me')
+    expect(await readFile(join(cwd, '.claude/skills/grill-me/SKILL.md'), 'utf8')).toContain('# Grill me')
+  })
+
   it('uses that same local-source CLI path after Git acquisition and publishes only receipt-derived bundles', async () => {
     const { root, source } = await fixture()
     const cwd = join(root, 'workspace')

--- a/packages/daemon/test/skills-cli-golden.test.ts
+++ b/packages/daemon/test/skills-cli-golden.test.ts
@@ -103,6 +103,40 @@ describe.skipIf(!hasBwrap)('skills@1.5.21 local-source golden', () => {
     })
   })
 
+  it('fails closed instead of letting the CLI pick between two directories sharing a frontmatter name', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ac-skills-cli-golden-'))
+    roots.push(root)
+    const source = join(root, 'shared-source')
+    await mkdir(join(source, 'skills/alpha'), { recursive: true })
+    await mkdir(join(source, 'skills/beta'), { recursive: true })
+    await writeFile(join(source, 'skills/alpha/SKILL.md'), '---\nname: Shared\ndescription: first\n---\n# alpha\n')
+    await writeFile(join(source, 'skills/beta/SKILL.md'), '---\nname: Shared\ndescription: second\n---\n# beta\n')
+    const cwd = join(root, 'workspace')
+    await mkdir(cwd)
+
+    const result = await installSkills(
+      {
+        id: 'agent-shared',
+        runtime: 'claude',
+        skills: [{ name: 'shared', source: 'acme/shared', githubRepoId: '42', skills: ['beta'] }]
+      },
+      cwd,
+      {
+        stateDir: join(root, 'trusted-state'),
+        acquireGit: async () => ({ sourceDir: source, resolvedCommit: 'e'.repeat(40) })
+      }
+    )
+
+    // The pinned CLI would select "Shared" by discovery order and install
+    // alpha's content under the same leaf beta would produce — a silent
+    // wrong-skill install. The resolver must refuse before the CLI runs.
+    expect(result.errors[0]?.error).toMatch(/does not uniquely identify one skill/)
+    expect(result.installed).toEqual([])
+    await expect(readFile(join(cwd, '.claude/skills/shared/SKILL.md'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
   it('uses that same local-source CLI path after Git acquisition and publishes only receipt-derived bundles', async () => {
     const { root, source } = await fixture()
     const cwd = join(root, 'workspace')

--- a/packages/daemon/test/skills-cli-golden.test.ts
+++ b/packages/daemon/test/skills-cli-golden.test.ts
@@ -103,6 +103,40 @@ describe.skipIf(!hasBwrap)('skills@1.5.21 local-source golden', () => {
     })
   })
 
+  it('ignores a same-named manifest the CLI cannot discover and installs the valid selection (#572 review)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ac-skills-cli-golden-'))
+    roots.push(root)
+    const source = join(root, 'shadow-source')
+    await mkdir(join(source, 'skills/valid'), { recursive: true })
+    await mkdir(join(source, 'examples/fixture'), { recursive: true })
+    await writeFile(join(source, 'skills/valid/SKILL.md'), '---\nname: Shared\ndescription: the real one\n---\n# ok\n')
+    // Valid manifest, but outside the CLI's discovery paths — it must not make
+    // the selection ambiguous.
+    await writeFile(
+      join(source, 'examples/fixture/SKILL.md'),
+      '---\nname: Shared\ndescription: example only\n---\n# fixture\n'
+    )
+    const cwd = join(root, 'workspace')
+    await mkdir(cwd)
+
+    const result = await installSkills(
+      {
+        id: 'agent-shadow',
+        runtime: 'claude',
+        skills: [{ name: 'shadow', source: 'acme/shadow', githubRepoId: '42', skills: ['valid'] }]
+      },
+      cwd,
+      {
+        stateDir: join(root, 'trusted-state'),
+        acquireGit: async () => ({ sourceDir: source, resolvedCommit: 'f'.repeat(40) })
+      }
+    )
+
+    expect(result.errors).toEqual([])
+    expect(result.installed).toEqual(['.claude/skills/shared'])
+    expect(await readFile(join(cwd, '.claude/skills/shared/SKILL.md'), 'utf8')).toContain('# ok')
+  })
+
   it('fails closed instead of letting the CLI pick between two directories sharing a frontmatter name', async () => {
     const root = await mkdtemp(join(tmpdir(), 'ac-skills-cli-golden-'))
     roots.push(root)

--- a/packages/daemon/test/unified-skills.test.ts
+++ b/packages/daemon/test/unified-skills.test.ts
@@ -154,6 +154,65 @@ describe.skipIf(!hasBwrap)('unified isolated skill installation', () => {
     expect(await readFile(join(cwd, '.runtime/skills/shared/SKILL.md'), 'utf8')).toContain('# dream')
   })
 
+  it('resolves a canonical Git selection to the display-style frontmatter name the CLI matches (#371)', async () => {
+    // Issue #371 shape: the wire selection is the canonical directory name,
+    // but the CLI matches -s against the SKILL.md frontmatter name and derives
+    // the install leaf from it.
+    const gitRoot = join(sources, 'grill')
+    await mkdir(join(gitRoot, 'skills/grill-me'), { recursive: true })
+    await writeFile(join(gitRoot, 'skills/grill-me/SKILL.md'), skillBody('Grill Me', 'grill me'))
+    const calls: SkillsCliInvocation[] = []
+    const runCli = async (input: SkillsCliInvocation): Promise<SkillsCliInvocationResult> => {
+      calls.push(input)
+      // Emulate the pinned CLI: install under the sanitized frontmatter name.
+      const leaf = input.skills[0]!.toLowerCase().replace(/[\s_]+/g, '-')
+      const bundleDir = join(input.cellDir, '.runtime', 'skills', leaf)
+      await mkdir(bundleDir, { recursive: true })
+      const body = await readFile(join(input.sourceDir, 'skills/grill-me/SKILL.md'), 'utf8')
+      await writeFile(join(bundleDir, 'SKILL.md'), body)
+      return {
+        bundles: [{ relativeRoot: `.runtime/skills/${leaf}`, sourceDir: bundleDir }],
+        stdoutDigest: digest('ok'),
+        stderrDigest: digest('')
+      }
+    }
+
+    const result = await installSkills(
+      {
+        id: 'a1',
+        runtime: 'claude',
+        skills: [{ name: 'grill', source: 'acme/grill', githubRepoId: '42', skills: ['grill-me'] }]
+      },
+      cwd,
+      { stateDir, acquireGit: async () => ({ sourceDir: gitRoot, resolvedCommit: 'a'.repeat(40) }), runCli }
+    )
+
+    expect(result.errors).toEqual([])
+    expect(calls.map((call) => call.skills)).toEqual([['Grill Me']])
+    expect(result.installed).toContain('.runtime/skills/grill-me')
+    expect(await readFile(join(cwd, '.runtime/skills/grill-me/SKILL.md'), 'utf8')).toContain('# grill me')
+  })
+
+  it('fails the transaction with the available names when a Git selection matches nothing', async () => {
+    const gitRoot = join(sources, 'grill-missing')
+    await mkdir(join(gitRoot, 'skills/grill-me'), { recursive: true })
+    await writeFile(join(gitRoot, 'skills/grill-me/SKILL.md'), skillBody('Grill Me', 'grill me'))
+    const cli = fakeCli(() => '.runtime')
+
+    const result = await installSkills(
+      {
+        id: 'a1',
+        runtime: 'claude',
+        skills: [{ name: 'grill', source: 'acme/grill', githubRepoId: '42', skills: ['barbecue'] }]
+      },
+      cwd,
+      { stateDir, acquireGit: async () => ({ sourceDir: gitRoot, resolvedCommit: 'a'.repeat(40) }), runCli: cli.run }
+    )
+
+    expect(result.errors[0]?.error).toMatch(/"barbecue" was not found in source "grill" \(available: grill-me\)/)
+    expect(cli.calls).toHaveLength(0)
+  })
+
   it('omits invalid historical Git sources and still installs their valid sibling', async () => {
     const validDir = await writeSkill(sources, 'valid', 'valid')
     const cli = fakeCli(() => '.runtime')
@@ -235,13 +294,16 @@ describe.skipIf(!hasBwrap)('unified isolated skill installation', () => {
   }, 120_000)
 
   it('uses the unchanged fast path for duplicate repo/ref acquisition identities', async () => {
-    const gitDir = await writeSkill(sources, 'repo', 'git')
+    // Real subDir acquisition hands the CLI the subdirectory content, so each
+    // entry's snapshot must actually contain its selected skill.
+    const oneDir = await writeSkill(join(sources, 'catalog'), 'one', 'git')
+    const twoDir = await writeSkill(join(sources, 'catalog'), 'two', 'git')
     const cli = fakeCli(() => '.runtime')
     const commit = 'a'.repeat(40)
     const requestedRefs: Array<string | undefined> = []
-    const acquireGit = async (entry: { ref?: string }) => {
+    const acquireGit = async (entry: { ref?: string; subDir?: string }) => {
       requestedRefs.push(entry.ref)
-      return { sourceDir: gitDir, resolvedCommit: entry.ref ?? commit }
+      return { sourceDir: entry.subDir === 'catalog/one' ? oneDir : twoDir, resolvedCommit: entry.ref ?? commit }
     }
     const skills = [
       { name: 'one', source: 'acme/skills', githubRepoId: '42', subDir: 'catalog/one', skills: ['one'] },


### PR DESCRIPTION
Fixes #371 (`skill like "grill-me" doesn't install correctly`).

## Root cause

The pinned `skills@1.5.21` CLI matches `-s` selections against each skill's **SKILL.md frontmatter `name`** (compared case-insensitively, otherwise verbatim), yet installs the matched bundle under a **sanitized leaf** derived from that name (lowercase, non-`[a-z0-9._]` runs → `-`, terminal dots/hyphens trimmed). AgentConnect's wire selections are restricted to canonical leaf names (`SkillSelectionArg`), and the console's source scan offers **directory names**.

So for a skill like `skills/grill-me/SKILL.md` with `name: Grill Me` (or `grill_me`, or any name whose case/spacing differs from the directory), the only wire-legal selection `grill-me` made the CLI answer `No matching skills found` — reproduced against the real pinned CLI. Worse, the failed transaction then cleared the agent's previously managed skills (the installer's fail-closed cleanup path).

## Fix

- New `skill-cli-selection.ts`: resolves each canonical selection against the daemon's private source snapshot to the frontmatter name the CLI will match. A selection matches a skill by its install leaf (sanitized frontmatter name, an exact mirror of the CLI's `sanitizeName`) **or** its directory name (what the console offers). Unresolvable selections fail with the available canonical names listed; ambiguous or colliding selections and argv-unsafe (option-shaped / non-printable-ASCII) resolved names are refused.
- `install-skills.ts` passes the resolved names as `-s` and keeps its exact-output receipt check, now against the resolved leaf set (`PreparedSource.expectedLeaves`), so a CLI that installs only a subset still fails the transaction.
- `skills-cli-cell.ts`'s selection guard drops the canonical-fixed-point requirement (that property is now enforced by resolution + receipt comparison) and keeps only argv safety: bounded printable ASCII, never option-shaped.
- Wire schema, fingerprints, and ledger identities are unchanged; managed/Dream local sources already enforce canonical frontmatter names at acceptance and keep their existing exact behavior.

## Tests

- `skill-cli-selection.test.ts`: leaf sanitization parity with the pinned CLI, display-name/directory-name/root-SKILL.md resolution, not-found/ambiguity/collision/unsafe-name errors.
- `skills-cli-golden.test.ts`: new golden case installs `skills/grill-me/` with `name: Grill Me` through the **real pinned CLI** in the kernel sandbox via a canonical `grill-me` selection.
- `unified-skills.test.ts`: seam-level resolution + a not-found transaction test; the duplicate-repo/ref fixture now actually contains its selected skills (the new resolution step verifies selections against the snapshot, which the old fixture never satisfied).
- `skills-cli-cell.test.ts`: guard expectations updated to the argv-safety contract.

All daemon skill test files pass locally (including the bwrap-gated golden/unified suites), plus daemon typecheck, eslint, and prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)