### PR TITLE
feat(cp): telegram + discord platform providers + registry wiring (S3 §9)

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -164,6 +164,10 @@ import { searchSkillRegistry } from './http/skills-registry.js'
 import { createTelegramBotIconSyncer } from './http/telegram-bot-profile.js'
 import { ensureDiscordMessageContentIntent, verifyDiscordBot } from './http/discord-identity.js'
 import { createDiscordBotProfileSyncer } from './http/discord-bot-profile.js'
+import type { CpPlatformRegistry } from './platforms/provider.js'
+import { buildCpPlatformRegistry } from './platforms/registry.js'
+import { createTelegramCpProvider } from './platforms/telegram/provider.js'
+import { createDiscordCpProvider } from './platforms/discord/provider.js'
 import { verifyFeishuBot } from './http/feishu-identity.js'
 import { createFeishuAppIconSyncer } from './http/feishu-app-icon.js'
 import { FeishuAppRegistrationService } from './http/feishu-registration.js'
@@ -185,6 +189,10 @@ export interface Container {
   relayGateway(app: FastifyInstance): WebSocketServer
   /** The single-tenant anchors the devAuth stub injects. */
   readonly defaults: { orgId: string; ownerId: string }
+  /** §9 platform-provider registry (S3) — Telegram + Discord today. Composed
+   *  here so the graph is whole; the route / spec-assembly / config call
+   *  sites adopt it in follow-up PRs (nothing consumes it yet). */
+  readonly platforms: CpPlatformRegistry
   /** The process readiness gate — the bootstrap flips it at SIGTERM (`/readyz`). */
   readonly readiness: Readiness
   /** Live webchat preset entitlement + one-time assertion minting. Transport
@@ -762,6 +770,27 @@ export function buildContainer(
     ...(opts.feishuFetch ? { fetchImpl: opts.feishuFetch } : {})
   })
 
+  // Built once and shared between the route deps (the live paths) and the
+  // platform providers below — one closure per platform, not two.
+  const syncTelegramBotIcon = createTelegramBotIconSyncer(iconStore)
+  const syncDiscordBotProfile = createDiscordBotProfileSyncer(iconStore)
+
+  // §9 platform-provider registry (S3): the behavioral CpPlatformProvider
+  // instances, constructed with the SAME verify/sync functions the route deps
+  // receive (one implementation; the providers add no second code path).
+  // Nothing consumes the registry yet beyond construction — the create route,
+  // spec assembly, and rc/bot-assign adopt it in follow-up PRs, and the
+  // Slack / Feishu providers (funnel routes, reapers, env schemas) land with
+  // their own moves.
+  const platforms = buildCpPlatformRegistry([
+    createTelegramCpProvider({ verifyBot: verifyTelegramBot, syncBotIcon: syncTelegramBotIcon }),
+    createDiscordCpProvider({
+      verifyBot: verifyDiscordBot,
+      ensureMessageContentIntent: ensureDiscordMessageContentIntent,
+      syncBotProfile: syncDiscordBotProfile
+    })
+  ])
+
   const httpDeps: HttpDeps = {
     clock,
     repos: {
@@ -846,10 +875,10 @@ export function buildContainer(
     slackConfigApi,
     searchSkillRegistry,
     verifyTelegramBot,
-    syncTelegramBotIcon: createTelegramBotIconSyncer(iconStore),
+    syncTelegramBotIcon,
     verifyDiscordBot,
     ensureDiscordMessageContentIntent,
-    syncDiscordBotProfile: createDiscordBotProfileSyncer(iconStore),
+    syncDiscordBotProfile,
     verifyFeishuBot,
     configureFeishuHttpApp,
     syncFeishuAppIcon: createFeishuAppIconSyncer(iconStore),
@@ -1320,6 +1349,7 @@ export function buildContainer(
     wsGateway: (app: FastifyInstance) => createDaemonWsServer(app, wsDeps),
     relayGateway: (app: FastifyInstance) => createRelayWsServer(app, relayWsDeps),
     defaults: { orgId: DEFAULT_ORG_ID, ownerId: DEFAULT_OWNER_ID },
+    platforms,
     readiness,
     webchatRemoteMcp,
     remoteGrantAuth,

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -29,6 +29,8 @@ import {
   normalizeRepoSubdir
 } from '@agentconnect.md/protocol'
 import { HEX_COLOR_RE, AGENT_ICON_GLYPHS } from '../../agents/agent-icon.js'
+import { TelegramCreateCredentials } from '../../platforms/telegram/provider.js'
+import { DiscordCreateCredentials } from '../../platforms/discord/provider.js'
 
 // ── per-resource visibility / sharing (docs/designs/resource-visibility.md) ──
 /** 'org' = visible to every org member (default); 'restricted' = the current
@@ -731,20 +733,14 @@ export const CreateIntegrationBody = z
         signingSecret: z.string().min(1).optional()
       })
       .optional(),
-    /** Register a new Telegram bot from its BotFather token (single token). */
-    telegram: z
-      .object({
-        botToken: z.string().min(1)
-      })
-      .optional(),
+    /** Register a new Telegram bot from its BotFather token (single token).
+     *  Schema relocated to the platform provider (§9 `credentialBodySchema`) —
+     *  one implementation for the live route and the registry. */
+    telegram: TelegramCreateCredentials.optional(),
     /** Register a new Discord bot from its Gateway bot token (single token). The
-     *  optional applicationId is the public client id for the invite URL. */
-    discord: z
-      .object({
-        botToken: z.string().min(1),
-        applicationId: z.string().min(1).optional()
-      })
-      .optional(),
+     *  optional applicationId is the public client id for the invite URL.
+     *  Schema relocated to the platform provider (§9 `credentialBodySchema`). */
+    discord: DiscordCreateCredentials.optional(),
     /** Register a new Feishu / Lark self-built app from its appId + appSecret pair.
      *  `region` picks the open-platform gateway (feishu.cn vs larksuite.com); it
      *  defaults to international Lark for new create requests. */

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -62,6 +62,8 @@ import type {
   MemoryPluginInstallationRepo
 } from '../persistence/ports.js'
 import { isDirectConversationKind } from '../persistence/ports.js'
+import { telegramIntegrationConfig } from '../platforms/telegram/provider.js'
+import { discordIntegrationConfig } from '../platforms/discord/provider.js'
 import { mcpProxyDef, relayHttpOrigin } from './mcpProvider.js'
 import { memoryConnectionSpec, stdioMemoryConnectionSpec } from './memoryConnection.js'
 import type { DaemonId } from '../domain/ids.js'
@@ -251,12 +253,15 @@ export function integrationToSpec(
   // legacy readers retire.
   const core = { mode: 'direct' as const, bindRules, mutedChannels, gated }
   if (i.platform === 'telegram') {
-    const telegram = { botToken: secret.botToken, bindRules, mutedChannels, gated }
+    // §9 shared projection body — the same function the platform provider's
+    // `projectIntegrationConfig` calls (S3; provider adoption replaces this arm).
+    const telegram = telegramIntegrationConfig(core, secret)
     return { integrationId: i.id, agentId: i.agentId, platform: 'telegram', core, config: telegram }
   }
   if (i.platform === 'discord') {
     // Discord authenticates the Gateway with the single bot token (no appToken).
-    const discord = { botToken: secret.botToken, bindRules, mutedChannels, gated }
+    // §9 shared projection body — see the telegram arm above.
+    const discord = discordIntegrationConfig(core, secret)
     return { integrationId: i.id, agentId: i.agentId, platform: 'discord', core, config: discord }
   }
   if (i.platform === 'feishu') {

--- a/packages/control-plane/src/platforms/discord/provider.test.ts
+++ b/packages/control-plane/src/platforms/discord/provider.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Discord CpPlatformProvider (§9, S3) — unit, no I/O.
+ *
+ * The load-bearing suite is the PROJECTION EQUIVALENCE block: while the live
+ * spec assembly is still `integrationToSpec` (`orchestrator/placement.ts`),
+ * the provider's `projectIntegrationConfig` must produce EXACTLY the `config`
+ * payload that path emits for the same inputs — that equality is what makes
+ * the eventual call-site flip a zero-behavior change.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createDiscordCpProvider, discordIntegrationConfig, DiscordCreateCredentials } from './provider.js'
+import { integrationToSpec } from '../../orchestrator/placement.js'
+import type { DiscordBotVerification, DiscordMessageContentIntentSetup } from '../../http/discord-identity.js'
+import type { BotProfileIconAgent } from '../../http/bot-profile-icon.js'
+import type { BotRecord, IntegrationChannelRecord, IntegrationRecord } from '../../persistence/ports.js'
+import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
+import { IntegrationDiscordConfig } from '@agentconnect.md/protocol'
+
+// A structurally valid Gateway token: first segment base64url-decodes to the
+// 18-digit application id (`discordAppIdFromBotToken`'s contract).
+const APP_ID = '123456789012345678'
+const TOKEN_WITH_APP_ID = `${Buffer.from(APP_ID).toString('base64url')}.x.hmac`
+
+const verifierOk = (name: string | null = 'helper-bot') =>
+  vi.fn(async () => ({ status: 'ok', name }) as DiscordBotVerification)
+const intent = (outcome: DiscordMessageContentIntentSetup = 'ready') => vi.fn(async () => outcome)
+
+const INTEGRATION: IntegrationRecord = {
+  id: IntegrationId('66666666-6666-4666-8666-666666666666'),
+  orgId: OrgId('org'),
+  agentId: AgentId('77777777-7777-4777-8777-777777777777'),
+  botId: BotId('88888888-8888-4888-8888-888888888888'),
+  platform: 'discord',
+  name: 'helper-bot',
+  status: 'active',
+  createdAt: new Date('2026-01-01T00:00:00Z')
+}
+
+const BOT: BotRecord = {
+  id: BotId('88888888-8888-4888-8888-888888888888'),
+  orgId: OrgId('org'),
+  platform: 'discord',
+  name: 'helper-bot',
+  prebuilt: false,
+  slackAppId: null,
+  teamId: null,
+  workspaceId: null,
+  workspaceName: null,
+  botUserId: null,
+  revokedAt: null,
+  credentialRevision: 1,
+  credentialInstalledAt: null,
+  externalAppId: null,
+  externalTenantId: null,
+  platformConfig: null,
+  discordAppId: APP_ID,
+  feishuAppId: null,
+  feishuRegion: null,
+  shareable: false,
+  transport: 'socket',
+  createdBy: null,
+  lastUsedAt: null,
+  lastAgentName: null,
+  agentIds: [AgentId('77777777-7777-4777-8777-777777777777')],
+  inUseByAgentId: AgentId('77777777-7777-4777-8777-777777777777'),
+  createdAt: new Date('2026-01-01T00:00:00Z')
+}
+
+const SECRET = { botToken: TOKEN_WITH_APP_ID, appToken: null, signingSecret: null }
+
+const AGENT: BotProfileIconAgent = { id: INTEGRATION.agentId, icon: null, runtime: 'claude' }
+
+const channel = (
+  channelId: string,
+  trigger: 'off' | 'mention' | 'any',
+  kind: 'channel' | 'im' | 'mpim' = 'channel'
+): IntegrationChannelRecord => ({
+  integrationId: INTEGRATION.id,
+  channelId,
+  name: channelId.toLowerCase(),
+  isPrivate: false,
+  kind,
+  trigger,
+  agentId: null
+})
+
+describe('discord provider identity + declarative facets', () => {
+  const provider = createDiscordCpProvider({ verifyBot: verifierOk(), ensureMessageContentIntent: intent() })
+
+  it('declares the discord platform id', () => {
+    expect(provider.platformId).toBe('discord')
+  })
+
+  it('contributes no funnel routes at either mount scope', () => {
+    expect(provider.installRoutes('org')).toEqual([])
+    expect(provider.installRoutes('public-callback')).toEqual([])
+  })
+
+  it('accepts the token(+optional applicationId) block and rejects an empty token', () => {
+    expect(provider.credentialBodySchema.parse({ botToken: 'tok' })).toEqual({ botToken: 'tok' })
+    expect(provider.credentialBodySchema.parse({ botToken: 'tok', applicationId: APP_ID })).toEqual({
+      botToken: 'tok',
+      applicationId: APP_ID
+    })
+    expect(provider.credentialBodySchema.safeParse({ botToken: '' }).success).toBe(false)
+    expect(provider.credentialBodySchema.safeParse({}).success).toBe(false)
+  })
+
+  it('re-exports the same schema instance the create DTO composes', () => {
+    expect(provider.credentialBodySchema).toBe(DiscordCreateCredentials)
+  })
+
+  it('packs the single-slot secret row and gates no http assign', () => {
+    expect(Object.keys(provider.secretShape.slots)).toEqual(['botToken'])
+    expect(provider.secretShape.httpAssignRequires).toEqual([])
+  })
+
+  it('declares no funnel state, env keys, tooling credentials, or background loops', () => {
+    expect(provider.pendingInstalls).toBeUndefined()
+    expect(provider.envSchema).toBeUndefined()
+    expect(provider.providerToolingCredentials).toBeUndefined()
+    expect(provider.backgroundLoops).toBeUndefined()
+  })
+})
+
+describe('discord validateConfig (route parity: integrations.ts discord arm)', () => {
+  it('derives the bot name and decodes the application id from the token', async () => {
+    const verifyBot = verifierOk()
+    const ensure = intent('ready')
+    const provider = createDiscordCpProvider({ verifyBot, ensureMessageContentIntent: ensure })
+    const result = await provider.validateConfig({ botToken: TOKEN_WITH_APP_ID }, 'socket')
+    expect(verifyBot).toHaveBeenCalledWith(TOKEN_WITH_APP_ID)
+    expect(ensure).toHaveBeenCalledWith(TOKEN_WITH_APP_ID)
+    expect(result).toEqual({ ok: true, identity: { name: 'helper-bot', externalAppId: APP_ID } })
+  })
+
+  it('omits identity fields it cannot derive (no name, unparseable token)', async () => {
+    const provider = createDiscordCpProvider({ verifyBot: verifierOk(null), ensureMessageContentIntent: intent() })
+    expect(await provider.validateConfig({ botToken: 'not-a-real-token' }, 'socket')).toEqual({
+      ok: true,
+      identity: {}
+    })
+  })
+
+  it('refuses a definitive 401 with the route’s 400 copy (no machine code today)', async () => {
+    const ensure = intent()
+    const provider = createDiscordCpProvider({
+      verifyBot: vi.fn(async () => ({ status: 'invalid' as const })),
+      ensureMessageContentIntent: ensure
+    })
+    expect(await provider.validateConfig({ botToken: 'bad' }, 'socket')).toEqual({
+      ok: false,
+      status: 400,
+      message:
+        'Discord rejected the bot token — check you pasted the Bot token from the Developer Portal (Bot → Reset Token).'
+    })
+    // The route returns before the intent call — a rejected token must not
+    // trigger a provider-state mutation.
+    expect(ensure).not.toHaveBeenCalled()
+  })
+
+  it('skips token validation when no verifier is injected (route optionality)', async () => {
+    const provider = createDiscordCpProvider({ ensureMessageContentIntent: intent() })
+    expect(await provider.validateConfig({ botToken: TOKEN_WITH_APP_ID }, 'socket')).toEqual({
+      ok: true,
+      identity: { externalAppId: APP_ID }
+    })
+  })
+
+  it('proceeds without a derived name when users/@me is unreachable (best-effort)', async () => {
+    const provider = createDiscordCpProvider({
+      verifyBot: vi.fn(async () => ({ status: 'unreachable' as const })),
+      ensureMessageContentIntent: intent()
+    })
+    expect(await provider.validateConfig({ botToken: TOKEN_WITH_APP_ID }, 'socket')).toEqual({
+      ok: true,
+      identity: { externalAppId: APP_ID }
+    })
+  })
+
+  it('refuses when the Message-Content intent flip is definitively rejected', async () => {
+    const provider = createDiscordCpProvider({
+      verifyBot: verifierOk(),
+      ensureMessageContentIntent: intent('rejected')
+    })
+    expect(await provider.validateConfig({ botToken: TOKEN_WITH_APP_ID }, 'socket')).toEqual({
+      ok: false,
+      status: 400,
+      code: 'DISCORD_MESSAGE_CONTENT_INTENT_SETUP_FAILED',
+      message:
+        'AgentConnect could not enable Message Content Intent automatically. Open the Discord Developer Portal → Bot → Privileged Gateway Intents, turn on Message Content Intent, save, then try again.'
+    })
+  })
+
+  it('answers an unreachable intent check with 503, never proof of rejection', async () => {
+    const provider = createDiscordCpProvider({
+      verifyBot: verifierOk(),
+      ensureMessageContentIntent: intent('unreachable')
+    })
+    expect(await provider.validateConfig({ botToken: TOKEN_WITH_APP_ID }, 'socket')).toEqual({
+      ok: false,
+      status: 503,
+      code: 'DISCORD_MESSAGE_CONTENT_INTENT_CHECK_UNAVAILABLE',
+      message:
+        'AgentConnect could not reach Discord to check or enable Message Content Intent. Try installing again in a moment.'
+    })
+  })
+})
+
+describe('discord sideEffects (profile push delegation)', () => {
+  it('delegates postCreate and ongoing icon sync to the injected syncer', async () => {
+    const syncBotProfile = vi.fn(async () => {})
+    const provider = createDiscordCpProvider({
+      verifyBot: verifierOk(),
+      ensureMessageContentIntent: intent(),
+      syncBotProfile
+    })
+    await provider.sideEffects?.postCreate?.({ integration: INTEGRATION, bot: BOT, secrets: SECRET, agent: AGENT })
+    expect(syncBotProfile).toHaveBeenNthCalledWith(1, SECRET.botToken, AGENT)
+    await provider.sideEffects?.syncBotProfileIcon?.(BOT, SECRET, AGENT)
+    expect(syncBotProfile).toHaveBeenNthCalledWith(2, SECRET.botToken, AGENT)
+  })
+
+  it('reports no icon capability when the syncer is absent (member presence is the probe)', () => {
+    const provider = createDiscordCpProvider({ verifyBot: verifierOk(), ensureMessageContentIntent: intent() })
+    expect(provider.sideEffects).toBeUndefined()
+  })
+})
+
+describe('discord projection equivalence with the live integrationToSpec path', () => {
+  const provider = createDiscordCpProvider({ verifyBot: verifierOk(), ensureMessageContentIntent: intent() })
+
+  const cases: Array<{ label: string; channels: IntegrationChannelRecord[]; gated: boolean }> = [
+    { label: 'defaults (no channels)', channels: [], gated: false },
+    {
+      label: "ungated with 'any' + muted channels",
+      channels: [channel('C1', 'any'), channel('C2', 'mention'), channel('C3', 'off'), channel('D1', 'off', 'im')],
+      gated: false
+    },
+    {
+      label: 'gated conversation-scoped rules',
+      channels: [channel('C1', 'any'), channel('C2', 'mention'), channel('C3', 'off'), channel('D1', 'any', 'im')],
+      gated: true
+    }
+  ]
+
+  for (const { label, channels, gated } of cases) {
+    it(`emits exactly the live path's config — ${label}`, async () => {
+      const spec = integrationToSpec(INTEGRATION, SECRET, channels, gated)
+      const projected = await provider.projectIntegrationConfig(INTEGRATION, BOT, spec.core!, SECRET)
+      expect(projected).toEqual(spec.config)
+      // Both sides satisfy the daemon reader's wire schema (§6.4).
+      expect(IntegrationDiscordConfig.parse(projected)).toEqual(IntegrationDiscordConfig.parse(spec.config))
+    })
+  }
+
+  it('shares one implementation with placement.ts (the extracted helper)', () => {
+    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'any')], false)
+    expect(discordIntegrationConfig(spec.core!, SECRET)).toEqual(spec.config)
+  })
+})
+
+describe('discord projectBotAssign (no HTTP ingress)', () => {
+  it('refuses: the create route never mints an http-transport discord bot', async () => {
+    const provider = createDiscordCpProvider({ verifyBot: verifierOk(), ensureMessageContentIntent: intent() })
+    await expect(provider.projectBotAssign(BOT, SECRET)).rejects.toThrow(/no HTTP callback ingress/)
+  })
+})

--- a/packages/control-plane/src/platforms/discord/provider.ts
+++ b/packages/control-plane/src/platforms/discord/provider.ts
@@ -1,0 +1,198 @@
+/**
+ * Discord's control-plane platform provider (integration-plugin-architecture.md
+ * §9, stage S3) — built against the merged contract (`../provider.ts`) beside
+ * the Telegram provider, the two simplest platform shapes.
+ *
+ * Like Telegram, Discord has no install funnel (the whole install is the
+ * create-DTO path), no pending-install state, no env keys, and no HTTP
+ * callback ingress. It differs in two audited ways (Appendix C §1.1):
+ *
+ *  - `validateConfig` owns TWO provider round-trips, not one: the
+ *    `users/@me` token check AND the Message-Content intent enablement.
+ *    The intent flip mutates provider state BEFORE anything is stored
+ *    (`integrations.ts:478-496`), which is exactly why the contract places
+ *    every pre-persistence provider call in `validateConfig`, never in
+ *    `sideEffects` — modeling it post-create would reorder observable
+ *    behavior.
+ *  - The bot's application (client) id is DECODED from the token
+ *    (`discordAppIdFromBotToken`), not fetched — public metadata surfaced as
+ *    the validated identity's `externalAppId` (persisted by today's create
+ *    tail as `Bot.discordAppId` for the console's invite URL).
+ *
+ * Every behavioral member delegates to the SAME functions the live create
+ * route calls today (`integrations.ts:467-536` via `deps.verifyDiscordBot` /
+ * `deps.ensureDiscordMessageContentIntent` / `deps.syncDiscordBotProfile`),
+ * injected through {@link DiscordCpProviderDeps} so tests stay offline.
+ *
+ * ADOPTION SEQUENCING: nothing consumes this provider yet beyond registry
+ * construction in `container.ts` — the create route and `placement.ts` remain
+ * the live paths. The shareable pieces ARE shared: the create-DTO credential
+ * block is defined here and imported by `http/dto/index.ts`, and the §6.4
+ * wire projection body is {@link discordIntegrationConfig}, called by BOTH
+ * `integrationToSpec`'s discord arm and
+ * {@link CpPlatformProvider.projectIntegrationConfig}.
+ */
+import { z } from 'zod'
+import type { IntegrationCoreEnvelope, IntegrationDiscordConfig } from '@agentconnect.md/protocol'
+import type { BotSecretMaterial } from '../../persistence/ports.js'
+import {
+  discordAppIdFromBotToken,
+  type DiscordBotVerifier,
+  type DiscordMessageContentIntentEnsurer
+} from '../../http/discord-identity.js'
+import type { DiscordBotProfileSyncer } from '../../http/discord-bot-profile.js'
+import type { CpConfigValidation, CpPlatformProvider } from '../provider.js'
+
+/** The `discord` credential block of the `POST /integrations` create body —
+ *  relocated from `http/dto/index.ts`, which imports it back (one
+ *  implementation for the live route and the provider's
+ *  {@link CpPlatformProvider.credentialBodySchema}). A single Gateway bot
+ *  token; the optional `applicationId` is the public client id for the
+ *  invite URL. */
+export const DiscordCreateCredentials = z.object({
+  botToken: z.string().min(1),
+  applicationId: z.string().min(1).optional()
+})
+export type DiscordCreateCredentials = z.infer<typeof DiscordCreateCredentials>
+
+/**
+ * The §6.4 opaque `IntegrationSpec.config` payload for one Discord
+ * integration — the body of `integrationToSpec`'s discord arm
+ * (`orchestrator/placement.ts`), extracted so the live placement path and the
+ * provider's projector share ONE implementation. Discord authenticates the
+ * Gateway with the single bot token (no appToken); the wire schema's optional
+ * `applicationId` is deliberately NOT emitted — today's spec assembly never
+ * ships it, and the daemon does not read it. Token-bearing — NEVER log.
+ */
+export function discordIntegrationConfig(
+  core: IntegrationCoreEnvelope,
+  secret: Pick<BotSecretMaterial, 'botToken'>
+): IntegrationDiscordConfig {
+  return { botToken: secret.botToken, bindRules: core.bindRules, mutedChannels: core.mutedChannels, gated: core.gated }
+}
+
+/** The provider's injected seams — the same functions `container.ts` wires
+ *  into the route deps today, with the same optionality (`http/deps.ts`):
+ *  `verifyBot` and `syncBotProfile` are optional so test composition stays
+ *  offline; the intent ensurer is required (tests inject an offline success
+ *  stub, exactly as they do for the route). */
+export interface DiscordCpProviderDeps {
+  /** Live `users/@me` token check (`http/discord-identity.ts`). Absent ⇒ no
+   *  token validation (the route's own fallback: name derivation is skipped
+   *  and the create tail falls back to the agent name). */
+  verifyBot?: DiscordBotVerifier
+  /** Idempotent Message-Content intent enablement (`http/discord-identity.ts`). */
+  ensureMessageContentIntent: DiscordMessageContentIntentEnsurer
+  /** Cosmetic avatar/description push (`http/discord-bot-profile.ts`). Absent ⇒
+   *  no icon-sync capability — presence of `sideEffects.syncBotProfileIcon` is
+   *  the capability probe (`http/agent-bot-icon-sync.ts`). */
+  syncBotProfile?: DiscordBotProfileSyncer
+}
+
+export function createDiscordCpProvider(deps: DiscordCpProviderDeps): CpPlatformProvider<DiscordCreateCredentials> {
+  const { verifyBot, ensureMessageContentIntent, syncBotProfile } = deps
+  return {
+    platformId: 'discord',
+
+    // No install funnel: no org-scoped wizard routes, no public OAuth
+    // callbacks. The whole install is the create-DTO path (contract §9 note).
+    installRoutes: () => [],
+
+    credentialBodySchema: DiscordCreateCredentials,
+
+    /**
+     * `users/@me` + Message-Content intent enablement — the live checks the
+     * create route runs before anything is stored (`integrations.ts:467-505`),
+     * with the route's statuses, codes, and user-facing copy verbatim (the
+     * token rejection carries no machine code today — neither does this).
+     * Reachability is best-effort: an unreachable `users/@me` does NOT refuse
+     * (the route proceeds with no derived name), while the intent ensure is
+     * the gating call — its definitive rejection is 400, its network blip 503.
+     */
+    async validateConfig(credentials): Promise<CpConfigValidation> {
+      const check = verifyBot ? await verifyBot(credentials.botToken) : null
+      if (check?.status === 'invalid') {
+        return {
+          ok: false,
+          status: 400,
+          message:
+            'Discord rejected the bot token — check you pasted the Bot token from the Developer Portal (Bot → Reset Token).'
+        }
+      }
+      const intentSetup = await ensureMessageContentIntent(credentials.botToken)
+      if (intentSetup === 'rejected') {
+        return {
+          ok: false,
+          status: 400,
+          code: 'DISCORD_MESSAGE_CONTENT_INTENT_SETUP_FAILED',
+          message:
+            'AgentConnect could not enable Message Content Intent automatically. Open the Discord Developer Portal → Bot → Privileged Gateway Intents, turn on Message Content Intent, save, then try again.'
+        }
+      }
+      if (intentSetup === 'unreachable') {
+        return {
+          ok: false,
+          status: 503,
+          code: 'DISCORD_MESSAGE_CONTENT_INTENT_CHECK_UNAVAILABLE',
+          message:
+            'AgentConnect could not reach Discord to check or enable Message Content Intent. Try installing again in a moment.'
+        }
+      }
+      // `name` is the middle rung of the create tail's name ladder (operator →
+      // users/@me-derived, best-effort → owning agent); `externalAppId` is the
+      // application id decoded from the token (public metadata — persisted by
+      // the create tail as `Bot.discordAppId` for the console's invite URL).
+      const name = check?.status === 'ok' ? check.name : null
+      const externalAppId = discordAppIdFromBotToken(credentials.botToken)
+      return {
+        ok: true,
+        identity: { ...(name ? { name } : {}), ...(externalAppId ? { externalAppId } : {}) }
+      }
+    },
+
+    // One-slot packing of the shared two-slot bot_secret row
+    // (`integrations.ts:515`: appToken/signingSecret stored null). No slot
+    // gates an http assign — Discord has no HTTP callback ingress at all.
+    secretShape: {
+      slots: { botToken: 'Discord bot token (Developer Portal → Bot)' },
+      httpAssignRequires: []
+    },
+
+    // No pending-install funnel state, no env keys, no per-user provider
+    // tooling credentials, no background loops (contract optionality).
+
+    // Post-create profile push (avatar + application icon/description) and
+    // ongoing icon convergence — both are today's `syncDiscordBotProfile`
+    // (`integrations.ts:526-535`, `http/agent-bot-icon-sync.ts:101-102`).
+    // Best-effort by contract: the CALLER logs a failure and keeps the
+    // install. The route additionally skips the post-create push when the
+    // token check came back unreachable — a create-tail optimization that
+    // stays with the caller (the verification outcome is not part of the
+    // side-effect input).
+    ...(syncBotProfile
+      ? {
+          sideEffects: {
+            postCreate: ({ secrets, agent }) => syncBotProfile(secrets.botToken, agent),
+            syncBotProfileIcon: (bot, secrets, agent) => syncBotProfile(secrets.botToken, agent)
+          }
+        }
+      : {}),
+
+    // §6.4 projection: same body as the live `integrationToSpec` discord arm
+    // (both call {@link discordIntegrationConfig}). Async by contract; Discord
+    // maintains no additional secret store to load from. Token-bearing — NEVER log.
+    async projectIntegrationConfig(integration, bot, core, secrets) {
+      return discordIntegrationConfig(core, secrets)
+    },
+
+    // Discord has no HTTP-bot path: the create route refuses
+    // `transport: 'http'` for it (`integrations.ts:392-400`), so no Discord
+    // bot row can carry the http transport and core's assign builder
+    // (`orchestrator/httpBot.ts`) never sees one. The contract still declares
+    // the member as required, so this is a documented refusal stub — reaching
+    // it means a bug upstream, not a recoverable condition.
+    async projectBotAssign(): Promise<never> {
+      throw new Error('discord has no HTTP callback ingress; rc/bot-assign is never built for a discord bot')
+    }
+  }
+}

--- a/packages/control-plane/src/platforms/registry.test.ts
+++ b/packages/control-plane/src/platforms/registry.test.ts
@@ -1,0 +1,52 @@
+/**
+ * CpPlatformRegistry (§9, S3) — unit, no I/O. The registry is deliberately
+ * dumb; what matters is the composition contract: keyed lookup, stable
+ * enumeration order, the id set as the single platform-set authority, and a
+ * duplicate registration failing construction (a composition bug, not data).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { buildCpPlatformRegistry } from './registry.js'
+import { createTelegramCpProvider } from './telegram/provider.js'
+import { createDiscordCpProvider } from './discord/provider.js'
+
+const telegram = () =>
+  createTelegramCpProvider({
+    verifyBot: vi.fn(async () => ({ status: 'ok' as const, name: null, privacyModeDisabled: true }))
+  })
+const discord = () =>
+  createDiscordCpProvider({
+    ensureMessageContentIntent: vi.fn(async () => 'ready' as const)
+  })
+
+describe('buildCpPlatformRegistry', () => {
+  it('keys providers by platform id and misses unknown ids', () => {
+    const tg = telegram()
+    const dc = discord()
+    const registry = buildCpPlatformRegistry([tg, dc])
+    expect(registry.get('telegram')).toBe(tg)
+    expect(registry.get('discord')).toBe(dc)
+    expect(registry.get('slack')).toBeUndefined()
+    expect(registry.get('')).toBeUndefined()
+  })
+
+  it('enumerates providers and ids in registration order', () => {
+    const tg = telegram()
+    const dc = discord()
+    const registry = buildCpPlatformRegistry([tg, dc])
+    expect(registry.all()).toEqual([tg, dc])
+    expect(registry.ids()).toEqual(['telegram', 'discord'])
+  })
+
+  it('fails construction on a duplicate platform id', () => {
+    expect(() => buildCpPlatformRegistry([telegram(), telegram()])).toThrow(
+      'duplicate control-plane platform provider: telegram'
+    )
+  })
+
+  it('holds an empty set without special-casing', () => {
+    const registry = buildCpPlatformRegistry([])
+    expect(registry.all()).toEqual([])
+    expect(registry.ids()).toEqual([])
+    expect(registry.get('telegram')).toBeUndefined()
+  })
+})

--- a/packages/control-plane/src/platforms/registry.ts
+++ b/packages/control-plane/src/platforms/registry.ts
@@ -1,0 +1,38 @@
+/**
+ * The control plane's **platform-provider registry** (integration-plugin-
+ * architecture.md §9, stage S3) — the concrete {@link CpPlatformRegistry},
+ * landing with the first two providers exactly as the contract's seam-first
+ * note promised ("the concrete registry lands with the first provider move,
+ * not with the contract").
+ *
+ * One instance is composed at `buildContainer` time and will be threaded to
+ * the create route, the spec/assign assembly, `loadConfig`'s schema fold, and
+ * `startBackground()` as those call sites adopt it (follow-up PRs) — adding a
+ * platform then registers one provider here and edits no core file beyond the
+ * composition line (§12). Until adoption, construction itself is the value:
+ * the registry is the platform-set authority the audit's six hand-copied
+ * closed unions converge on (S3 exit criterion).
+ *
+ * Deliberately dumb, mirroring the S2 registry precedents (`daemon/src/
+ * platforms/registry.ts`, `relay/src/platforms/registry.ts`): a keyed map
+ * that never parses a platform id and holds no per-platform knowledge — a
+ * duplicate registration is a composition bug and fails construction.
+ */
+import type { CpPlatformProvider, CpPlatformRegistry } from './provider.js'
+
+export function buildCpPlatformRegistry(providers: readonly CpPlatformProvider[]): CpPlatformRegistry {
+  const byId = new Map<string, CpPlatformProvider>()
+  for (const provider of providers) {
+    if (byId.has(provider.platformId)) {
+      throw new Error(`duplicate control-plane platform provider: ${provider.platformId}`)
+    }
+    byId.set(provider.platformId, provider)
+  }
+  const all = Object.freeze([...byId.values()])
+  const ids = Object.freeze([...byId.keys()])
+  return {
+    get: (platformId) => byId.get(platformId),
+    all: () => all,
+    ids: () => ids
+  }
+}

--- a/packages/control-plane/src/platforms/telegram/provider.test.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Telegram CpPlatformProvider (§9, S3) — unit, no I/O.
+ *
+ * The load-bearing suite is the PROJECTION EQUIVALENCE block: while the live
+ * spec assembly is still `integrationToSpec` (`orchestrator/placement.ts`),
+ * the provider's `projectIntegrationConfig` must produce EXACTLY the `config`
+ * payload that path emits for the same inputs — that equality is what makes
+ * the eventual call-site flip a zero-behavior change.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createTelegramCpProvider, telegramIntegrationConfig, TelegramCreateCredentials } from './provider.js'
+import { integrationToSpec } from '../../orchestrator/placement.js'
+import type { TelegramBotVerification } from '../../http/telegram-identity.js'
+import type { BotProfileIconAgent } from '../../http/bot-profile-icon.js'
+import type { BotRecord, IntegrationChannelRecord, IntegrationRecord } from '../../persistence/ports.js'
+import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
+import { IntegrationTelegramConfig } from '@agentconnect.md/protocol'
+
+const verifierOk = (over: Partial<Extract<TelegramBotVerification, { status: 'ok' }>> = {}) =>
+  vi.fn(
+    async () => ({ status: 'ok', name: 'helper_bot', privacyModeDisabled: true, ...over }) as TelegramBotVerification
+  )
+
+const INTEGRATION: IntegrationRecord = {
+  id: IntegrationId('66666666-6666-4666-8666-666666666666'),
+  orgId: OrgId('org'),
+  agentId: AgentId('77777777-7777-4777-8777-777777777777'),
+  botId: BotId('88888888-8888-4888-8888-888888888888'),
+  platform: 'telegram',
+  name: 'helper-bot',
+  status: 'active',
+  createdAt: new Date('2026-01-01T00:00:00Z')
+}
+
+const BOT: BotRecord = {
+  id: BotId('88888888-8888-4888-8888-888888888888'),
+  orgId: OrgId('org'),
+  platform: 'telegram',
+  name: 'helper-bot',
+  prebuilt: false,
+  slackAppId: null,
+  teamId: null,
+  workspaceId: null,
+  workspaceName: null,
+  botUserId: null,
+  revokedAt: null,
+  credentialRevision: 1,
+  credentialInstalledAt: null,
+  externalAppId: null,
+  externalTenantId: null,
+  platformConfig: null,
+  discordAppId: null,
+  feishuAppId: null,
+  feishuRegion: null,
+  shareable: false,
+  transport: 'socket',
+  createdBy: null,
+  lastUsedAt: null,
+  lastAgentName: null,
+  agentIds: [AgentId('77777777-7777-4777-8777-777777777777')],
+  inUseByAgentId: AgentId('77777777-7777-4777-8777-777777777777'),
+  createdAt: new Date('2026-01-01T00:00:00Z')
+}
+
+const SECRET = { botToken: '123456:ABC-tg-token', appToken: null, signingSecret: null }
+
+const AGENT: BotProfileIconAgent = { id: INTEGRATION.agentId, icon: null, runtime: 'claude' }
+
+const channel = (
+  channelId: string,
+  trigger: 'off' | 'mention' | 'any',
+  kind: 'channel' | 'im' | 'mpim' = 'channel'
+): IntegrationChannelRecord => ({
+  integrationId: INTEGRATION.id,
+  channelId,
+  name: channelId.toLowerCase(),
+  isPrivate: false,
+  kind,
+  trigger,
+  agentId: null
+})
+
+describe('telegram provider identity + declarative facets', () => {
+  const provider = createTelegramCpProvider({ verifyBot: verifierOk() })
+
+  it('declares the telegram platform id', () => {
+    expect(provider.platformId).toBe('telegram')
+  })
+
+  it('contributes no funnel routes at either mount scope', () => {
+    expect(provider.installRoutes('org')).toEqual([])
+    expect(provider.installRoutes('public-callback')).toEqual([])
+  })
+
+  it('accepts the single-token credential block and rejects an empty one', () => {
+    expect(provider.credentialBodySchema.parse({ botToken: '123456:abc' })).toEqual({ botToken: '123456:abc' })
+    expect(provider.credentialBodySchema.safeParse({ botToken: '' }).success).toBe(false)
+    expect(provider.credentialBodySchema.safeParse({}).success).toBe(false)
+  })
+
+  it('re-exports the same schema instance the create DTO composes', () => {
+    expect(provider.credentialBodySchema).toBe(TelegramCreateCredentials)
+  })
+
+  it('packs the single-slot secret row and gates no http assign', () => {
+    expect(Object.keys(provider.secretShape.slots)).toEqual(['botToken'])
+    expect(provider.secretShape.httpAssignRequires).toEqual([])
+  })
+
+  it('declares no funnel state, env keys, tooling credentials, or background loops', () => {
+    expect(provider.pendingInstalls).toBeUndefined()
+    expect(provider.envSchema).toBeUndefined()
+    expect(provider.providerToolingCredentials).toBeUndefined()
+    expect(provider.backgroundLoops).toBeUndefined()
+  })
+})
+
+describe('telegram validateConfig (route parity: integrations.ts telegram arm)', () => {
+  it('passes the pasted token to the verifier and derives the bot name', async () => {
+    const verifyBot = verifierOk()
+    const provider = createTelegramCpProvider({ verifyBot })
+    const result = await provider.validateConfig({ botToken: '123456:abc' }, 'socket')
+    expect(verifyBot).toHaveBeenCalledWith('123456:abc')
+    expect(result).toEqual({ ok: true, identity: { name: 'helper_bot' } })
+  })
+
+  it('omits the name when getMe returns none', async () => {
+    const provider = createTelegramCpProvider({ verifyBot: verifierOk({ name: null }) })
+    const result = await provider.validateConfig({ botToken: '123456:abc' }, 'socket')
+    expect(result).toEqual({ ok: true, identity: {} })
+  })
+
+  it('refuses a definitive rejection with the route’s 400 + code + copy', async () => {
+    const provider = createTelegramCpProvider({ verifyBot: vi.fn(async () => ({ status: 'invalid' as const })) })
+    expect(await provider.validateConfig({ botToken: '123456:bad' }, 'socket')).toEqual({
+      ok: false,
+      status: 400,
+      code: 'TELEGRAM_BOT_TOKEN_INVALID',
+      message: 'Telegram rejected the bot token — copy it again from @BotFather.'
+    })
+  })
+
+  it('answers an unreachable Telegram with 503, never proof the token is bad', async () => {
+    const provider = createTelegramCpProvider({ verifyBot: vi.fn(async () => ({ status: 'unreachable' as const })) })
+    expect(await provider.validateConfig({ botToken: '123456:abc' }, 'socket')).toEqual({
+      ok: false,
+      status: 503,
+      code: 'TELEGRAM_BOT_CHECK_UNAVAILABLE',
+      message: 'AgentConnect could not reach Telegram to check this bot. Try again in a moment.'
+    })
+  })
+
+  it('refuses while Group Privacy Mode is still enabled', async () => {
+    const provider = createTelegramCpProvider({ verifyBot: verifierOk({ privacyModeDisabled: false }) })
+    expect(await provider.validateConfig({ botToken: '123456:abc' }, 'socket')).toEqual({
+      ok: false,
+      status: 400,
+      code: 'TELEGRAM_PRIVACY_MODE_ENABLED',
+      message:
+        'Privacy Mode is still on. In @BotFather, send /setprivacy, select this bot, choose Disable, then try again.'
+    })
+  })
+})
+
+describe('telegram sideEffects (icon push delegation)', () => {
+  it('delegates postCreate and ongoing icon sync to the injected syncer', async () => {
+    const syncBotIcon = vi.fn(async () => {})
+    const provider = createTelegramCpProvider({ verifyBot: verifierOk(), syncBotIcon })
+    await provider.sideEffects?.postCreate?.({ integration: INTEGRATION, bot: BOT, secrets: SECRET, agent: AGENT })
+    expect(syncBotIcon).toHaveBeenNthCalledWith(1, SECRET.botToken, AGENT)
+    await provider.sideEffects?.syncBotProfileIcon?.(BOT, SECRET, AGENT)
+    expect(syncBotIcon).toHaveBeenNthCalledWith(2, SECRET.botToken, AGENT)
+  })
+
+  it('reports no icon capability when the syncer is absent (member presence is the probe)', () => {
+    const provider = createTelegramCpProvider({ verifyBot: verifierOk() })
+    expect(provider.sideEffects).toBeUndefined()
+  })
+})
+
+describe('telegram projection equivalence with the live integrationToSpec path', () => {
+  const provider = createTelegramCpProvider({ verifyBot: verifierOk() })
+
+  const cases: Array<{ label: string; channels: IntegrationChannelRecord[]; gated: boolean }> = [
+    { label: 'defaults (no channels)', channels: [], gated: false },
+    {
+      label: "ungated with 'any' + muted channels",
+      channels: [channel('C1', 'any'), channel('C2', 'mention'), channel('C3', 'off'), channel('D1', 'off', 'im')],
+      gated: false
+    },
+    {
+      label: 'gated conversation-scoped rules',
+      channels: [channel('C1', 'any'), channel('C2', 'mention'), channel('C3', 'off'), channel('D1', 'any', 'im')],
+      gated: true
+    }
+  ]
+
+  for (const { label, channels, gated } of cases) {
+    it(`emits exactly the live path's config — ${label}`, async () => {
+      const spec = integrationToSpec(INTEGRATION, SECRET, channels, gated)
+      const projected = await provider.projectIntegrationConfig(INTEGRATION, BOT, spec.core!, SECRET)
+      expect(projected).toEqual(spec.config)
+      // Both sides satisfy the daemon reader's wire schema (§6.4).
+      expect(IntegrationTelegramConfig.parse(projected)).toEqual(IntegrationTelegramConfig.parse(spec.config))
+    })
+  }
+
+  it('shares one implementation with placement.ts (the extracted helper)', () => {
+    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'any')], false)
+    expect(telegramIntegrationConfig(spec.core!, SECRET)).toEqual(spec.config)
+  })
+})
+
+describe('telegram projectBotAssign (no HTTP ingress)', () => {
+  it('refuses: the create route never mints an http-transport telegram bot', async () => {
+    const provider = createTelegramCpProvider({ verifyBot: verifierOk() })
+    await expect(provider.projectBotAssign(BOT, SECRET)).rejects.toThrow(/no HTTP callback ingress/)
+  })
+})

--- a/packages/control-plane/src/platforms/telegram/provider.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.ts
@@ -1,0 +1,162 @@
+/**
+ * Telegram's control-plane platform provider (integration-plugin-architecture.md
+ * §9, stage S3) — the first {@link CpPlatformProvider} instance, built against
+ * the merged contract (`../provider.ts`).
+ *
+ * Telegram is the SIMPLEST provider shape the audit found (Appendix C §1.1):
+ * one BotFather token, no install funnel (the whole install is the create-DTO
+ * path), no pending-install state, no env keys, no HTTP callback ingress, and
+ * one cosmetic side effect (the post-create avatar push). Every behavioral
+ * member below delegates to the SAME function the live create route calls
+ * today (`http/routes/integrations.ts:405-461` via `deps.verifyTelegramBot` /
+ * `deps.syncTelegramBotIcon`), injected through {@link TelegramCpProviderDeps}
+ * so tests fake the provider round-trips exactly like the route tests do.
+ *
+ * ADOPTION SEQUENCING: nothing consumes this provider yet beyond registry
+ * construction in `container.ts` — the create route and `placement.ts` remain
+ * the live paths. To keep ONE implementation while both exist, the pieces that
+ * can be shared ARE shared: the create-DTO credential block is defined here
+ * and imported by `http/dto/index.ts`, and the §6.4 wire projection body is
+ * {@link telegramIntegrationConfig}, called by BOTH `integrationToSpec`'s
+ * telegram arm and {@link CpPlatformProvider.projectIntegrationConfig}.
+ */
+import { z } from 'zod'
+import type { IntegrationCoreEnvelope, IntegrationTelegramConfig } from '@agentconnect.md/protocol'
+import type { BotSecretMaterial } from '../../persistence/ports.js'
+import type { TelegramBotVerifier } from '../../http/telegram-identity.js'
+import type { TelegramBotIconSyncer } from '../../http/telegram-bot-profile.js'
+import type { CpConfigValidation, CpPlatformProvider } from '../provider.js'
+
+/** The `telegram` credential block of the `POST /integrations` create body —
+ *  relocated from `http/dto/index.ts`, which imports it back (one
+ *  implementation for the live route and the provider's
+ *  {@link CpPlatformProvider.credentialBodySchema}). A single BotFather token;
+ *  Telegram has no app-level token and no signing secret. */
+export const TelegramCreateCredentials = z.object({
+  botToken: z.string().min(1)
+})
+export type TelegramCreateCredentials = z.infer<typeof TelegramCreateCredentials>
+
+/**
+ * The §6.4 opaque `IntegrationSpec.config` payload for one Telegram
+ * integration — the body of `integrationToSpec`'s telegram arm
+ * (`orchestrator/placement.ts`), extracted so the live placement path and the
+ * provider's projector share ONE implementation. The routing knobs are
+ * deliberately DUPLICATED from the core envelope: today's daemon readers still
+ * take them from the opaque config (§6.4 tolerant-reader window).
+ * Token-bearing — NEVER log the result.
+ */
+export function telegramIntegrationConfig(
+  core: IntegrationCoreEnvelope,
+  secret: Pick<BotSecretMaterial, 'botToken'>
+): IntegrationTelegramConfig {
+  return { botToken: secret.botToken, bindRules: core.bindRules, mutedChannels: core.mutedChannels, gated: core.gated }
+}
+
+/** The provider's injected seams — the same functions `container.ts` wires
+ *  into the route deps today (`verifyTelegramBot`, `syncTelegramBotIcon`), so
+ *  the live route and the provider share one implementation and tests stay
+ *  offline by faking exactly these. */
+export interface TelegramCpProviderDeps {
+  /** Live `getMe` check (`http/telegram-identity.ts`). */
+  verifyBot: TelegramBotVerifier
+  /** Cosmetic avatar push (`http/telegram-bot-profile.ts`). Absent ⇒ the
+   *  platform reports no icon-sync capability (test composition, no icon
+   *  pipeline) — presence of `sideEffects.syncBotProfileIcon` is the
+   *  capability probe (`http/agent-bot-icon-sync.ts`). */
+  syncBotIcon?: TelegramBotIconSyncer
+}
+
+export function createTelegramCpProvider(deps: TelegramCpProviderDeps): CpPlatformProvider<TelegramCreateCredentials> {
+  const { syncBotIcon } = deps
+  return {
+    platformId: 'telegram',
+
+    // No install funnel: no org-scoped wizard routes, no public OAuth
+    // callbacks. The whole install is the create-DTO path (contract §9 note).
+    installRoutes: () => [],
+
+    credentialBodySchema: TelegramCreateCredentials,
+
+    /**
+     * `getMe` + the Group-Privacy-Mode gate — the live checks the create route
+     * runs before anything is stored (`integrations.ts:405-432`), with the
+     * route's statuses, codes, and user-facing copy verbatim. Reachability is
+     * best-effort by contract: only Telegram's definitive rejection refuses
+     * with 400; a network blip is 503, never proof the token is bad.
+     */
+    async validateConfig(credentials): Promise<CpConfigValidation> {
+      const checked = await deps.verifyBot(credentials.botToken)
+      if (checked.status === 'invalid') {
+        return {
+          ok: false,
+          status: 400,
+          code: 'TELEGRAM_BOT_TOKEN_INVALID',
+          message: 'Telegram rejected the bot token — copy it again from @BotFather.'
+        }
+      }
+      if (checked.status === 'unreachable') {
+        return {
+          ok: false,
+          status: 503,
+          code: 'TELEGRAM_BOT_CHECK_UNAVAILABLE',
+          message: 'AgentConnect could not reach Telegram to check this bot. Try again in a moment.'
+        }
+      }
+      if (!checked.privacyModeDisabled) {
+        return {
+          ok: false,
+          status: 400,
+          code: 'TELEGRAM_PRIVACY_MODE_ENABLED',
+          message:
+            'Privacy Mode is still on. In @BotFather, send /setprivacy, select this bot, choose Disable, then try again.'
+        }
+      }
+      // `name` is the middle rung of the create tail's name ladder
+      // (operator-typed → getMe-derived → owning agent's name).
+      return { ok: true, identity: { ...(checked.name ? { name: checked.name } : {}) } }
+    },
+
+    // One-slot packing of the shared two-slot bot_secret row
+    // (`integrations.ts:443`: appToken/signingSecret stored null). No slot
+    // gates an http assign — Telegram has no HTTP callback ingress at all.
+    secretShape: {
+      slots: { botToken: 'Telegram bot token (from @BotFather)' },
+      httpAssignRequires: []
+    },
+
+    // No pending-install funnel state, no env keys, no per-user provider
+    // tooling credentials, no background loops (contract optionality).
+
+    // Post-create avatar push + ongoing icon convergence — both are today's
+    // `syncTelegramBotIcon` (`integrations.ts:454-460`,
+    // `http/agent-bot-icon-sync.ts:99-100`). Best-effort by contract: the
+    // CALLER logs a failure and keeps the install; member presence is the
+    // capability signal, so an icon-less composition omits the whole facet.
+    ...(syncBotIcon
+      ? {
+          sideEffects: {
+            postCreate: ({ secrets, agent }) => syncBotIcon(secrets.botToken, agent),
+            syncBotProfileIcon: (bot, secrets, agent) => syncBotIcon(secrets.botToken, agent)
+          }
+        }
+      : {}),
+
+    // §6.4 projection: same body as the live `integrationToSpec` telegram arm
+    // (both call {@link telegramIntegrationConfig}). Async by contract; Telegram
+    // maintains no additional secret store to load from. Token-bearing — NEVER log.
+    async projectIntegrationConfig(integration, bot, core, secrets) {
+      return telegramIntegrationConfig(core, secrets)
+    },
+
+    // Telegram has no HTTP-bot path: the create route refuses
+    // `transport: 'http'` for it (`integrations.ts:392-400`), so no Telegram
+    // bot row can carry the http transport and core's assign builder
+    // (`orchestrator/httpBot.ts`) never sees one. The contract still declares
+    // the member as required, so this is a documented refusal stub — reaching
+    // it means a bug upstream, not a recoverable condition.
+    async projectBotAssign(): Promise<never> {
+      throw new Error('telegram has no HTTP callback ingress; rc/bot-assign is never built for a telegram bot')
+    }
+  }
+}


### PR DESCRIPTION
First two `CpPlatformProvider` instances against the merged §9 contract (#565), plus the concrete `CpPlatformRegistry` composed in `buildContainer` — Telegram and Discord first because they are the simplest audited shapes (no funnel routes, no pending-install state, no env keys, no HTTP ingress). Slack/Feishu providers and the create-route / projector adoption follow in their own PRs, per the S2/S3 move-one-thing sequencing (#525, #560).

## The two providers

`src/platforms/telegram/provider.ts` and `src/platforms/discord/provider.ts`, each member verified against the call site it mirrors:

| member | telegram | discord |
| --- | --- | --- |
| `installRoutes(scope)` | `[]` — the whole install is the create-DTO path (the contract's own §9 note) | `[]` |
| `credentialBodySchema` | the create-DTO `telegram` block, **relocated** — `http/dto/index.ts` now imports it back, so route and provider share one schema instance | same for the `discord` block (`botToken` + optional `applicationId`) |
| `validateConfig` | `getMe` + the Privacy-Mode gate with the route's statuses/codes/copy verbatim (`integrations.ts:405-432`) | `users/@me` (non-blocking when unreachable, optional like the route dep) + the Message-Content intent enablement as the gating call (`integrations.ts:467-505`); `externalAppId` decoded from the token per the contract's identity doc |
| `secretShape` | `botToken` slot only, `httpAssignRequires: []` | same |
| `sideEffects` | postCreate avatar push + ongoing icon sync, both today's `syncTelegramBotIcon`; member presence = capability (facet absent when no syncer is injected, matching `agent-bot-icon-sync.ts`'s probe) | same via `syncDiscordBotProfile` |
| `projectIntegrationConfig` | `telegramIntegrationConfig(core, secret)` — the `integrationToSpec` arm body, **extracted**: `placement.ts`'s telegram arm now calls the same function (one implementation, byte-identical output) | same via `discordIntegrationConfig` |
| `projectBotAssign` | documented refusal stub (see mismatch note below) | same |

Both providers take a small deps object carrying exactly the functions the route deps receive today (`verifyTelegramBot` / `verifyDiscordBot` / `ensureDiscordMessageContentIntent` / the two icon syncers), with the same optionality as `http/deps.ts` — the injectability the named slots existed for, now at the provider seam.

## Registry + DI

`src/platforms/registry.ts` — `buildCpPlatformRegistry(providers)`: a keyed map mirroring the S2/S3 registry precedents (daemon #526, relay `IngressPool`/`DemuxIndex`); a duplicate registration fails construction. `buildContainer` composes it with the two providers, built from the **same** function instances the route deps get (the two icon syncers are now created once and shared instead of once per consumer), and exposes it as a new `Container.platforms` member. **Nothing consumes it yet beyond construction** — the create route and `placement.ts` remain the live paths.

## Contract mismatch found (reported, not reshaped)

`projectBotAssign` is declared **required** by the merged contract, but Telegram/Discord have no HTTP-bot path — the create route refuses `transport: 'http'` for them (`integrations.ts:392-400`), so no bot row of these platforms can reach `HttpBotService.buildAssign`. Implemented as a documented refusal stub (throws with the reason) rather than silently making the member optional; if the contract later wants optionality here, that is a contract PR, not a provider PR.

One deliberate non-move, documented in the Discord provider: the route skips the post-create profile push when the token check came back `unreachable` (`integrations.ts:526`). That is create-tail knowledge (the verification outcome is not part of the `sideEffects.postCreate` input), so it stays with the caller for the adoption PR to carry.

## Tests

- `platforms/telegram/provider.test.ts` (18) / `platforms/discord/provider.test.ts` (20): `validateConfig` happy/reject paths with faked verifiers pinning the route's exact statuses, codes, and copy (including Discord's code-less 400 and the invalid-token short-circuit before the intent call), sideEffects delegation + capability absence, schema-instance identity with the create DTO.
- The load-bearing block: **projection equivalence** — for defaults / ungated-with-muted / gated fixtures, `provider.projectIntegrationConfig(...)` deep-equals the `config` emitted by the live `integrationToSpec` path, and both sides round-trip the daemon reader's wire schema (`IntegrationTelegramConfig` / `IntegrationDiscordConfig`).
- `platforms/registry.test.ts` (4): keyed lookup, registration-order enumeration, duplicate-id construction failure.

## Verification

Zero behavior change: `placement.ts`'s arms produce identical objects through the extracted helpers (its tests pass unchanged), and the DTO composes the identical relocated schemas.

- `tsc -p tsconfig.typecheck.json` clean; eslint + prettier clean
- unit suite: 121 files / 1070 tests green (42 new)
- integration suite (`test:int`, real Postgres via Testcontainers): 70 files / 954 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
