### PR TITLE
refactor(relay): routes adopt the §8 verify→handle seam; resolveVerified pair retires (S3)

### DIFF
--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -19,7 +19,6 @@ import { createRelayDaemonServer, type RelayDaemonServer } from './relay-daemon-
 import { createRelayBrowserServer } from './relay-browser-server.js'
 import { WebchatRouter } from './webchat-router.js'
 import { RelayIngressManager } from './relay-ingress-manager.js'
-import { SlackEventDedup } from './slack-event-dedup.js'
 import { registerSlackHttpIngress } from './platforms/slack/http-ingress.js'
 import { registerFeishuHttpIngress } from './platforms/feishu/http-ingress.js'
 import { CollaborationRouter } from './collaboration-router.js'
@@ -191,7 +190,7 @@ async function main(): Promise<void> {
 
   // IM HTTP ingress. Each callback is demuxed, authenticated, deduplicated,
   // normalized, arbitrated, and forwarded. Routes must register before listen.
-  registerSlackHttpIngress(server, { manager: () => held.relayIngress, dedup: new SlackEventDedup(systemClock), log })
+  registerSlackHttpIngress(server, { manager: () => held.relayIngress, log })
   registerFeishuHttpIngress(server, { manager: () => held.relayIngress, log })
 
   // Public webhook ingress (POST /webhooks/in/:token). Routes must register

--- a/packages/relay/src/platforms/contract.ts
+++ b/packages/relay/src/platforms/contract.ts
@@ -159,6 +159,11 @@ export interface RelayIngressHost {
    *  assignment is NOT guaranteed to carry `botUserId` (a manual-paste bot's
    *  CP row learns it from this very report). */
   reportBotUserId(botId: string, botUserId: string): void
+  /** Event-identity dedup — CORE owns the bounded, TTL'd table; the PLUGIN
+   *  mints the identity (it derives from parsed envelope semantics, §8) and
+   *  carries it on its verified product into `handle`. True ⇒ already seen
+   *  (drop); false ⇒ marked now. An absent identity is never deduped. */
+  dedupSeen(identity: string | undefined): boolean
   /** Whether `route`'s daemon is connected RIGHT NOW. For interactions whose
    *  platform affordance is one-shot (a Slack shortcut consumes its trigger
    *  id), the plugin must know synchronously that delivery is possible, so it

--- a/packages/relay/src/platforms/feishu/http-ingress.test.ts
+++ b/packages/relay/src/platforms/feishu/http-ingress.test.ts
@@ -3,7 +3,8 @@ import Fastify, { type FastifyInstance } from 'fastify'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { WireFeishuCardActionEvent, WireNormalizedMessage } from '@agentconnect.md/protocol'
 import { FeishuHttpIngest, type FeishuCallbackHeaders } from './http-ingest.js'
-import { registerFeishuHttpIngress, type FeishuIngestResolver, type FeishuVerifiedDelivery } from './http-ingress.js'
+import { feishuIngressPlugin } from './ingress-plugin.js'
+import { registerFeishuHttpIngress, type FeishuIngestResolver } from './http-ingress.js'
 
 const NOW = 1_720_000_000_000
 const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
@@ -62,10 +63,25 @@ function makeApp(secrets: { verificationToken: string; encryptKey?: string } = {
     },
     now: () => NOW
   })
+  // Drive the REAL plugin (verify → handle) through the seam: token check /
+  // AES decrypt, the encrypted challenge, per-bot dedup, and the card-action
+  // response window all run exactly as production does.
+  const host = {
+    log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    dedupSeen: () => false,
+    clock: { now: () => NOW }
+  } as unknown as import('../contract.js').RelayIngressHost
   const resolver: FeishuIngestResolver = {
-    resolveFeishuVerified(args): FeishuVerifiedDelivery | undefined {
-      const callback = ingest.decode(args.rawBody, args.body, args.headers)
-      return callback ? { ingest, callback } : undefined
+    handleInbound: async (_platformId, rawBody, body, headers) => {
+      const verified = feishuIngressPlugin.verify(
+        ingest,
+        rawBody,
+        body,
+        headers as Record<string, string | string[] | undefined>,
+        NOW
+      )
+      if (verified === undefined) return undefined
+      return feishuIngressPlugin.handle(ingest, verified, host)
     }
   }
   const app = Fastify()

--- a/packages/relay/src/platforms/feishu/http-ingress.ts
+++ b/packages/relay/src/platforms/feishu/http-ingress.ts
@@ -1,11 +1,6 @@
 import type { FastifyInstance } from 'fastify'
 import type { Logger } from '../../log.js'
-import {
-  type FeishuCallbackHeaders,
-  type FeishuHttpIngest,
-  feishuCallbackAppId,
-  type VerifiedFeishuCallback
-} from './http-ingest.js'
+import { type FeishuHttpIngest, type VerifiedFeishuCallback } from './http-ingest.js'
 
 export const FEISHU_BODY_LIMIT = 1024 * 1024
 const FEISHU_CARD_ACTION_RESPONSE_TIMEOUT_MS = 2_500
@@ -16,12 +11,12 @@ export interface FeishuVerifiedDelivery {
 }
 
 export interface FeishuIngestResolver {
-  resolveFeishuVerified(args: {
-    appId?: string
-    rawBody: Buffer
-    body: unknown
-    headers: FeishuCallbackHeaders
-  }): FeishuVerifiedDelivery | undefined
+  handleInbound(
+    platformId: string,
+    rawBody: Buffer,
+    body: unknown,
+    headers: Record<string, string | string[] | undefined>
+  ): Promise<import('../contract.js').HandledDelivery | undefined>
 }
 
 export interface FeishuHttpIngressDeps {
@@ -49,43 +44,12 @@ export function registerFeishuHttpIngress(app: FastifyInstance, deps: FeishuHttp
       } catch {
         return reply.code(400).send({ error: 'Bad Request', statusCode: 400 })
       }
-      const appId = feishuCallbackAppId(body)
-      const timestamp = headerString(req.headers['x-lark-request-timestamp'])
-      const nonce = headerString(req.headers['x-lark-request-nonce'])
-      const signature = headerString(req.headers['x-lark-signature'])
-      const resolved = deps.manager()?.resolveFeishuVerified({
-        ...(appId ? { appId } : {}),
-        rawBody,
-        body,
-        headers: {
-          ...(timestamp ? { timestamp } : {}),
-          ...(nonce ? { nonce } : {}),
-          ...(signature ? { signature } : {})
-        }
-      })
-      if (!resolved) return reply.code(401).send({ error: 'Unauthorized', statusCode: 401 })
-      if (resolved.callback.kind === 'challenge') {
-        return reply.code(200).send({ challenge: resolved.callback.challenge })
-      }
-      if (resolved.ingest.seen(resolved.callback.eventId)) return reply.code(200).send({})
-      if (resolved.callback.eventType === 'card.action.trigger') {
-        let timeout: ReturnType<typeof setTimeout> | undefined
-        const response = await Promise.race([
-          resolved.ingest.handle(resolved.callback).catch((error) => {
-            deps.log.warn(`feishu ingress: card action handler error: ${(error as Error).message}`)
-            return undefined
-          }),
-          new Promise<undefined>((resolve) => {
-            timeout = setTimeout(() => resolve(undefined), FEISHU_CARD_ACTION_RESPONSE_TIMEOUT_MS)
-          })
-        ])
-        if (timeout) clearTimeout(timeout)
-        return reply.code(200).send(response ?? {})
-      }
-      void resolved.ingest.handle(resolved.callback).catch((error) => {
-        deps.log.warn(`feishu ingress: event handler error: ${(error as Error).message}`)
-      })
-      return reply.code(200).send({})
+      // §8 verify → handle: decode (token check / AES decrypt), the encrypted
+      // challenge, per-bot dedup, and the plugin-owned card-action response
+      // window all run inside the seam; the route returns the syncResponse.
+      const handled = await deps.manager()?.handleInbound('feishu', rawBody, body, req.headers)
+      if (!handled) return reply.code(401).send({ error: 'Unauthorized', statusCode: 401 })
+      return reply.code(200).send(handled.syncResponse ?? {})
     })
   })
 }

--- a/packages/relay/src/platforms/feishu/ingress-plugin.ts
+++ b/packages/relay/src/platforms/feishu/ingress-plugin.ts
@@ -116,9 +116,21 @@ export const feishuIngressPlugin: RelayPlatformIngressPlugin<FeishuHttpIngest, V
   },
 
   verify(ingest, rawBody, body, headers): VerifiedFeishuCallback | undefined {
+    // The seam hands RAW HTTP headers; extracting Lark's signature triple is
+    // the plugin's job (the route used to do it before the seam existed).
+    const header = (v: string | string[] | undefined): string | undefined =>
+      typeof v === 'string' && v.length > 0 ? v : undefined
+    const timestamp = header(headers['x-lark-request-timestamp'])
+    const nonce = header(headers['x-lark-request-nonce'])
+    const signature = header(headers['x-lark-signature'])
+    const callbackHeaders: FeishuCallbackHeaders = {
+      ...(timestamp ? { timestamp } : {}),
+      ...(nonce ? { nonce } : {}),
+      ...(signature ? { signature } : {})
+    }
     // Token compare / AES decrypt — the typed decrypted product derives exactly
     // once and flows into handle (the #560 review's first blocking finding).
-    return ingest.decode(rawBody, body, headers as FeishuCallbackHeaders) ?? undefined
+    return ingest.decode(rawBody, body, callbackHeaders) ?? undefined
   },
 
   async handle(ingest, verified, host): Promise<HandledDelivery> {

--- a/packages/relay/src/platforms/slack/http-ingress.test.ts
+++ b/packages/relay/src/platforms/slack/http-ingress.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import Fastify, { type FastifyInstance } from 'fastify'
-import { FakeClock } from '@agentconnect.md/connection'
 import { SHARED_AGENT_SELECT_ACTION_ID } from '@agentconnect.md/protocol'
-import { registerSlackHttpIngress, type SlackIngestHandlers, type SlackIngestResolver } from './http-ingress.js'
-import { SlackEventDedup } from '../../slack-event-dedup.js'
+import { registerSlackHttpIngress, type SlackIngestResolver } from './http-ingress.js'
 
 const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 
@@ -11,44 +9,59 @@ interface Harness {
   app: FastifyInstance
   events: unknown[]
   interactions: unknown[]
-  /** resolveVerified attributes a POST to the stub ingest only for this signature. */
+  /** the seam attributes a POST to the stub only for this signature. */
   goodSignature: string
-  resolveCalls: Array<{ apiAppId?: string; teamId?: string }>
+  inboundCalls: Array<{ platformId: string; hints: { apiAppId?: string; teamId?: string } }>
 }
 
-/** A stub ingest whose `resolveVerified` stands in for the HMAC demux: it returns the
- *  handlers only when the request carried the "good" signature (verification passed). */
+/** A stub of the §8 seam: verification-by-signature stands in for the HMAC
+ *  demux; handling mirrors the slack plugin's split (events fire async and
+ *  return no sync body; interactions return their result as the syncResponse;
+ *  event_id dedup runs inside, on a set-backed stand-in for the core table). */
 function makeHarness(): Harness {
   const h: Harness = {
     app: Fastify(),
     events: [],
     interactions: [],
     goodSignature: 'good-sig',
-    resolveCalls: []
+    inboundCalls: []
   }
-  const ingest: SlackIngestHandlers = {
-    handleEvent: async (event) => {
-      h.events.push(event)
-    },
-    handleInteraction: async (body) => {
-      h.interactions.push(body)
-      if (body.type === 'block_suggestion' && body.action_id === SHARED_AGENT_SELECT_ACTION_ID) {
-        return { options: [{ text: { type: 'plain_text', text: 'Deploy' }, value: 'a1' }] }
-      }
-      return ''
-    }
-  }
+  const seenEventIds = new Set<string>()
   const resolver: SlackIngestResolver = {
-    resolveVerified: (args) => {
-      h.resolveCalls.push({ apiAppId: args.apiAppId, teamId: args.teamId })
-      return args.signature === h.goodSignature ? ingest : undefined
+    handleInbound: async (platformId, _rawBody, body, headers) => {
+      const b = body as {
+        type?: string
+        api_app_id?: string
+        team_id?: string
+        team?: { id?: string }
+        event_id?: string
+        event?: unknown
+        action_id?: string
+      }
+      h.inboundCalls.push({
+        platformId,
+        hints: {
+          ...(b.api_app_id ? { apiAppId: b.api_app_id } : {}),
+          ...((b.team_id ?? b.team?.id) ? { teamId: b.team_id ?? b.team?.id } : {})
+        }
+      })
+      if (headers['x-slack-signature'] !== h.goodSignature) return undefined
+      if (b.type === 'event_callback') {
+        // Plugin-minted composite dedup identity, core-owned table.
+        const key = b.event_id ? `${b.api_app_id ?? ''}\0${b.team_id ?? ''}\0${b.event_id}` : undefined
+        if (key && seenEventIds.has(key)) return {}
+        if (key) seenEventIds.add(key)
+        h.events.push(b.event)
+        return {}
+      }
+      h.interactions.push(b)
+      if (b.type === 'block_suggestion' && b.action_id === SHARED_AGENT_SELECT_ACTION_ID) {
+        return { syncResponse: { options: [{ text: { type: 'plain_text', text: 'Deploy' }, value: 'a1' }] } }
+      }
+      return { syncResponse: '' }
     }
   }
-  registerSlackHttpIngress(h.app, {
-    manager: () => resolver,
-    dedup: new SlackEventDedup(new FakeClock()),
-    log
-  })
+  registerSlackHttpIngress(h.app, { manager: () => resolver, log })
   return h
 }
 
@@ -93,7 +106,7 @@ describe('slack http ingress', () => {
     const res = await postEvent({ type: 'url_verification', token: 't', challenge: 'c-42' }, { signature: 'anything' })
     expect(res.statusCode).toBe(200)
     expect(res.json()).toEqual({ challenge: 'c-42' })
-    expect(h.resolveCalls).toHaveLength(0) // never demuxed
+    expect(h.inboundCalls).toHaveLength(0) // never demuxed
   })
 
   it('401s when no assigned bot verifies the signature', async () => {
@@ -116,7 +129,7 @@ describe('slack http ingress', () => {
     expect(res.statusCode).toBe(200)
     await flush()
     expect(h.events).toHaveLength(1)
-    expect(h.resolveCalls[0]).toEqual({ apiAppId: 'A1', teamId: 'T9' })
+    expect(h.inboundCalls[0]).toEqual({ platformId: 'slack', hints: { apiAppId: 'A1', teamId: 'T9' } })
   })
 
   it('dedups a redelivered event_id (forwards once)', async () => {

--- a/packages/relay/src/platforms/slack/http-ingress.ts
+++ b/packages/relay/src/platforms/slack/http-ingress.ts
@@ -24,33 +24,26 @@
  */
 import type { FastifyInstance } from 'fastify'
 import type { Logger } from '../../log.js'
-import type { SlackEventDedup } from '../../slack-event-dedup.js'
 import type { SlackInteractiveBody, SlackMessageEvent } from './http-ingest.js'
 
 /** Raw-body cap for the Slack endpoints (Slack payloads are well under 1 MiB). */
 export const SLACK_BODY_LIMIT = 1024 * 1024
 
-/** The minimum an ingest must expose to the route (satisfied by `SlackHttpIngest`). */
-export interface SlackIngestHandlers {
-  handleEvent(event: SlackMessageEvent | undefined, eventAtMs?: number): Promise<void>
-  handleInteraction(body: SlackInteractiveBody): Promise<unknown>
-}
-
-/** Demux + authenticate an inbound POST to a bot's ingest (satisfied by `RelayIngressManager`). */
+/** The §8 inbound seam the route drives (satisfied by `RelayIngressManager`):
+ *  demux + verify + handle in one core-owned ladder; the plugin owns the
+ *  cryptography and everything after authentication. `undefined` ⇒ 401. */
 export interface SlackIngestResolver {
-  resolveVerified(args: {
-    apiAppId?: string
-    teamId?: string
-    timestamp: string | undefined
-    rawBody: Buffer
-    signature: string | undefined
-  }): SlackIngestHandlers | undefined
+  handleInbound(
+    platformId: string,
+    rawBody: Buffer,
+    body: unknown,
+    headers: Record<string, string | string[] | undefined>
+  ): Promise<import('../contract.js').HandledDelivery | undefined>
 }
 
 export interface SlackHttpIngressDeps {
   /** Late-bound — the manager is constructed alongside the rd/* server, after routes register. */
   manager: () => SlackIngestResolver | undefined
-  dedup: SlackEventDedup
   log: Logger
 }
 
@@ -111,25 +104,12 @@ export function registerSlackHttpIngress(app: FastifyInstance, deps: SlackHttpIn
         return reply.code(200).send({ challenge: body.challenge ?? '' })
       }
 
-      const ingest = deps.manager()?.resolveVerified({
-        ...(body.api_app_id ? { apiAppId: body.api_app_id } : {}),
-        ...(body.team_id ? { teamId: body.team_id } : {}),
-        timestamp,
-        rawBody: raw,
-        signature
-      })
-      if (!ingest) return reply.code(401).send({ error: 'Unauthorized', statusCode: 401 })
-
-      // A retry for one app/install reuses this composite identity. Do not dedup on
-      // event_id alone: one Slack message may be delivered to several explicitly
-      // mentioned apps, and those callbacks must each reach their own agent.
-      if (deps.dedup.seen(eventDedupKey(body))) return reply.code(200).send()
-
-      // Ack NOW (Slack's 3s window); forward async. A forward miss is bounded loss.
-      // `event_time` is seconds → ms for the CP's revocation fence.
-      void ingest.handleEvent(body.event, body.event_time ? body.event_time * 1000 : undefined).catch((err) => {
-        deps.log.warn(`slack ingress: event handler error: ${(err as Error).message}`)
-      })
+      // §8 verify → handle: demux/authentication and the dedup check (the plugin
+      // mints the composite identity; core owns the table) run inside the seam.
+      // Event handling is fired async by the plugin — the 200 stays inside
+      // Slack's 3s window, exactly as before.
+      const handled = await deps.manager()?.handleInbound('slack', raw, body, req.headers)
+      if (!handled) return reply.code(401).send({ error: 'Unauthorized', statusCode: 401 })
       return reply.code(200).send()
     })
 
@@ -149,18 +129,11 @@ export function registerSlackHttpIngress(app: FastifyInstance, deps: SlackHttpIn
         return reply.code(400).send({ error: 'Bad Request', statusCode: 400 })
       }
 
-      const ingest = deps.manager()?.resolveVerified({
-        ...(body.api_app_id ? { apiAppId: body.api_app_id } : {}),
-        ...(body.team?.id ? { teamId: body.team.id } : {}),
-        timestamp,
-        rawBody: raw,
-        signature
-      })
-      if (!ingest) return reply.code(401).send({ error: 'Unauthorized', statusCode: 401 })
-
-      // block_suggestion needs its options ON the 200 body; every other branch returns ''.
-      const result = await ingest.handleInteraction(body)
-      return reply.code(200).send(result ?? '')
+      // block_suggestion needs its options ON the 200 body — the plugin's
+      // handler returns it as the syncResponse.
+      const handled = await deps.manager()?.handleInbound('slack', raw, body, req.headers)
+      if (!handled) return reply.code(401).send({ error: 'Unauthorized', statusCode: 401 })
+      return reply.code(200).send(handled.syncResponse ?? '')
     })
   })
 }

--- a/packages/relay/src/platforms/slack/ingress-plugin.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.ts
@@ -171,7 +171,8 @@ export function forwardSessionShortcut(
 /** The plugin's typed verified product: one authenticated Slack delivery, as
  *  the two HTTP routes parse it. Opaque to core (§8). */
 export type SlackVerifiedDelivery =
-  { kind: 'event'; event?: SlackMessageEvent; eventAtMs?: number } | { kind: 'interaction'; body: SlackInteractiveBody }
+  | { kind: 'event'; event?: SlackMessageEvent; eventAtMs?: number; dedupKey?: string }
+  | { kind: 'interaction'; body: SlackInteractiveBody }
 
 function headerString(v: string | string[] | undefined): string | undefined {
   return typeof v === 'string' && v.length > 0 ? v : undefined
@@ -227,22 +228,32 @@ export const slackIngressPlugin: RelayPlatformIngressPlugin<SlackHttpIngest, Sla
     const timestamp = headerString(headers['x-slack-request-timestamp'])
     if (!verifySlackSignature(ingest.signingSecret, timestamp, rawBody, signature, now)) return undefined
     const b = body as
-      | { event?: SlackMessageEvent; event_time?: number; payload?: SlackInteractiveBody }
-      | SlackInteractiveBody
-      | undefined
-    // Interactions arrive pre-extracted from the urlencoded `payload=` field by
-    // the route; events keep their envelope shape.
-    if (b && typeof b === 'object' && 'type' in b && (b as SlackInteractiveBody).type !== undefined && !('event' in b))
+      { type?: string; event?: SlackMessageEvent; event_time?: number } | SlackInteractiveBody | undefined
+    // POSITIVE discrimination: an Events API envelope is exactly
+    // `type === 'event_callback'` (url_verification never reaches verify — the
+    // route answers it pre-candidate). Everything else on this seam is an
+    // interaction payload, pre-extracted from the urlencoded `payload=` field
+    // by the route.
+    if (b && typeof b === 'object' && (b as { type?: string }).type !== 'event_callback')
       return { kind: 'interaction', body: b as SlackInteractiveBody }
-    const env = b as { event?: SlackMessageEvent; event_time?: number } | undefined
+    const env = b as
+      | { event?: SlackMessageEvent; event_time?: number; event_id?: string; api_app_id?: string; team_id?: string }
+      | undefined
+    // The dedup identity is the (api_app_id, team_id, event_id) composite: a
+    // retry for one app/install reuses it, while one Slack message delivered to
+    // several explicitly mentioned apps must reach each of their agents.
+    const dedupKey = env?.event_id ? `${env.api_app_id ?? ''}\0${env.team_id ?? ''}\0${env.event_id}` : undefined
     return {
       kind: 'event',
       ...(env?.event ? { event: env.event } : {}),
-      ...(env?.event_time ? { eventAtMs: env.event_time * 1000 } : {})
+      ...(env?.event_time ? { eventAtMs: env.event_time * 1000 } : {}),
+      ...(dedupKey ? { dedupKey } : {})
     }
   },
 
   async handle(ingest, verified, host): Promise<HandledDelivery> {
+    // Plugin-minted identity, core-owned table (§8).
+    if (verified.kind === 'event' && host.dedupSeen(verified.dedupKey)) return {}
     if (verified.kind === 'interaction') {
       // block_suggestion needs its options ON the 200 body; every other branch
       // resolves to '' — the same contract the interactions route holds today.

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -1496,13 +1496,23 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
   const SHARED_SECRET = 'shared-platform-signing-secret'
   const NOW = 1_720_000_000_000
   const ts = String(Math.floor(NOW / 1000))
-  const body = Buffer.from(JSON.stringify({ type: 'event_callback', event_id: 'Ev1' }))
-  const sig = (secret: string) => `v0=${createHmac('sha256', secret).update(`v0:${ts}:${body}`).digest('hex')}`
+  // Hints ride the ENVELOPE now (extractDemuxHints); each resolve() builds a
+  // body carrying them. No event_id ⇒ the dedup table never interferes.
+  const envelopeFor = (over: { apiAppId?: string; teamId?: string }) => ({
+    type: 'event_callback',
+    ...(over.apiAppId ? { api_app_id: over.apiAppId } : {}),
+    ...(over.teamId ? { team_id: over.teamId } : {})
+  })
+  const sigFor = (secret: string, raw: Buffer) =>
+    `v0=${createHmac('sha256', secret).update(`v0:${ts}:${raw}`).digest('hex')}`
 
   interface DemuxInternals {
     router: BotArbitrationRouter
     slackPool: {
-      set(botId: string, ingest: { signingSecret: string; stop(): Promise<void> }): void
+      set(
+        botId: string,
+        ingest: { signingSecret: string; stop(): Promise<void>; handleEvent(e?: unknown, at?: number): Promise<void> }
+      ): void
       get(botId: string): { signingSecret: string } | undefined
     }
     feishuPool: { get(botId: string): unknown }
@@ -1519,7 +1529,13 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     opts: { apiAppId?: string; teamId?: string; indexed?: boolean } = {}
   ) => {
     const internals = manager as unknown as DemuxInternals
-    internals.slackPool.set(botId, { signingSecret, stop: async () => {} })
+    internals.slackPool.set(botId, {
+      signingSecret,
+      stop: async () => {},
+      handleEvent: async () => {
+        handledBy.push(botId)
+      }
+    })
     internals.router.upsert({
       ...assignment(),
       botId,
@@ -1533,26 +1549,38 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     if (opts.apiAppId && !opts.teamId) internals.slackDemux.indexAssign(botId, { appId: opts.apiAppId })
   }
 
-  const resolve = (manager: RelayIngressManager, over: { apiAppId?: string; teamId?: string; secret?: string }) =>
-    manager.resolveVerified({
-      ...(over.apiAppId ? { apiAppId: over.apiAppId } : {}),
-      ...(over.teamId ? { teamId: over.teamId } : {}),
-      timestamp: ts,
-      rawBody: body,
-      signature: sig(over.secret ?? SHARED_SECRET)
+  /** Drive the §8 seam end to end and report WHICH bot's ingest handled the
+   *  delivery (undefined = 401). The envelope parses as an event with no
+   *  event_id, so dedup never interferes with the demux assertions. */
+  const resolve = async (
+    manager: RelayIngressManager,
+    over: { apiAppId?: string; teamId?: string; secret?: string }
+  ): Promise<string | undefined> => {
+    handledBy.length = 0
+    const envelope = envelopeFor(over)
+    const raw = Buffer.from(JSON.stringify(envelope))
+    const handled = await manager.handleInbound('slack', raw, envelope, {
+      'x-slack-request-timestamp': ts,
+      'x-slack-signature': sigFor(over.secret ?? SHARED_SECRET, raw)
     })
+    if (!handled) return undefined
+    // handleEvent fires async inside the plugin; give the microtask a beat.
+    await new Promise((r) => setTimeout(r, 0))
+    return handledBy[0]
+  }
+  const handledBy: string[] = []
 
-  it('demuxes sibling installs of one distributed app by (api_app_id, team_id)', () => {
+  it('demuxes sibling installs of one distributed app by (api_app_id, team_id)', async () => {
     const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     addBot(manager, BOT_T1, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T1' })
     addBot(manager, BOT_T2, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T2' })
 
     const internals = manager as unknown as DemuxInternals
-    expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T1' })).toBe(internals.slackPool.get(BOT_T1))
-    expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T2' })).toBe(internals.slackPool.get(BOT_T2))
+    await expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T1' })).resolves.toBe(BOT_T1)
+    await expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T2' })).resolves.toBe(BOT_T2)
   })
 
-  it('never serves a team-scoped bot to another workspace via the signature scan', () => {
+  it('never serves a team-scoped bot to another workspace via the signature scan', async () => {
     const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     // Composite index deliberately EMPTY (indexed:false) — only the router knows
     // the team ids, so resolution falls through to the verify-scan, where the
@@ -1561,31 +1589,31 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     addBot(manager, BOT_T2, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T2', indexed: false })
 
     const internals = manager as unknown as DemuxInternals
-    expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T2' })).toBe(internals.slackPool.get(BOT_T2))
+    await expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T2' })).resolves.toBe(BOT_T2)
     // The scan hit must not poison the app-only learned map for a team-scoped bot.
     expect(internals.slackDemux.indexes.byApp.has(PLATFORM_APP)).toBe(false)
   })
 
-  it('fails closed when a distributed-app envelope carries no team id', () => {
+  it('fails closed when a distributed-app envelope carries no team id', async () => {
     const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     addBot(manager, BOT_T1, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T1' })
     addBot(manager, BOT_T2, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T2' })
 
     // Both siblings verify the HMAC; without a team id there is no safe pick.
-    expect(resolve(manager, { apiAppId: PLATFORM_APP })).toBeUndefined()
+    await expect(resolve(manager, { apiAppId: PLATFORM_APP })).resolves.toBeUndefined()
   })
 
-  it('keeps the legacy app-only fast path and scan learning for team-less bots', () => {
+  it('keeps the legacy app-only fast path and scan learning for team-less bots', async () => {
     const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     addBot(manager, BOT_LEGACY, 'legacy-secret', {}) // no app id stamped — scan learns it
 
     const internals = manager as unknown as DemuxInternals
-    expect(resolve(manager, { apiAppId: 'ALEGACY', secret: 'legacy-secret' })).toBe(internals.slackPool.get(BOT_LEGACY))
+    await expect(resolve(manager, { apiAppId: 'ALEGACY', secret: 'legacy-secret' })).resolves.toBe(BOT_LEGACY)
     expect(internals.slackDemux.indexes.byApp.get('ALEGACY')).toBe(BOT_LEGACY)
     // A team-scoped envelope still resolves the legacy bot (guard only skips
     // bots whose ASSIGNMENT carries a different team id).
-    expect(resolve(manager, { apiAppId: 'ALEGACY', teamId: 'T9', secret: 'legacy-secret' })).toBe(
-      internals.slackPool.get(BOT_LEGACY)
+    await expect(resolve(manager, { apiAppId: 'ALEGACY', teamId: 'T9', secret: 'legacy-secret' })).resolves.toBe(
+      BOT_LEGACY
     )
   })
 
@@ -1627,6 +1655,6 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     const internals = manager as unknown as DemuxInternals
     expect(internals.slackDemux.indexes.byAppTenant.size).toBe(0)
     // The reverse map is DemuxIndex-internal now; an empty composite index IS the proof.
-    expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T1' })).toBeUndefined()
+    await expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T1' })).resolves.toBeUndefined()
   })
 })

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -30,12 +30,11 @@ import type { Logger } from './log.js'
 import { BotArbitrationRouter, sessionKeyOf, type BotAssignment, type RouteTarget } from './bot-arbitration.js'
 import { SlackHttpIngest } from './platforms/slack/http-ingest.js'
 import { FeishuHttpIngest } from './platforms/feishu/http-ingest.js'
-import type { FeishuVerifiedDelivery } from './platforms/feishu/http-ingress.js'
 import { DemuxIndex, IngressPool } from './platforms/registry.js'
-import type { RelayIngressHost, RelayPlatformIngressPlugin } from './platforms/contract.js'
+import type { HandledDelivery, RelayIngressHost, RelayPlatformIngressPlugin } from './platforms/contract.js'
+import { SlackEventDedup } from './slack-event-dedup.js'
 import { slackIngressPlugin } from './platforms/slack/ingress-plugin.js'
 import { feishuIngressPlugin } from './platforms/feishu/ingress-plugin.js'
-import { verifySlackSignature } from './hooks/signature.js'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
 
 /** Cap on the learned `api_app_id → botId` demux index before it is flushed. */
@@ -204,6 +203,7 @@ export class RelayIngressManager {
           this.router.integrationTarget(botId, agentId, integrationId),
         soleTarget: (botId) => this.router.soleTarget(botId)
       },
+      dedupSeen: (identity) => this.eventDedup.seen(identity),
       canDeliver: (route) => this.deps.getDaemon(route.daemonId) !== undefined,
       setChannelAgent: (botId, channelId, agentId) => this.deps.setChannelAgent(botId, channelId, agentId),
       selectThreadAgent: (botId, channelId, threadTs, agentId) =>
@@ -213,6 +213,14 @@ export class RelayIngressManager {
       log: this.deps.log
     }
   }
+
+  /** Event-identity dedup — the CORE-owned table of §8's split (the plugin
+   *  mints the identity). One table serves every platform's pool; identities
+   *  are platform-prefixed by construction (their envelope fields differ). */
+  private get eventDedup(): SlackEventDedup {
+    return (this.eventDedupMemo ??= new SlackEventDedup(this.deps.clock))
+  }
+  private eventDedupMemo?: SlackEventDedup
 
   /** Bounded-loss counters (per bot) — messages dropped because no daemon connection. */
   private readonly dropped = new Map<string, number>()
@@ -421,71 +429,55 @@ export class RelayIngressManager {
   }
 
   /**
-   * Demux + authenticate one inbound Slack HTTP POST to its bot's ingest. Slack's
-   * HMAC (over the raw body, keyed by the bot's signing secret) authenticates, but
-   * it can only DISCRIMINATE while signing secrets differ — every install of a
-   * distributed app shares one secret, so those bots resolve exclusively on the
-   * composite `(api_app_id, team_id)` index and are skipped by the verify-scan
-   * (a scan hit against a sibling install would leak one workspace's messages
-   * into another tenant's bot). Legacy bots keep the learned app-only fast path
-   * with the verify-scan fallback. `undefined` ⇒ the route answers 401.
+   * §8 verify → handle: demux one inbound HTTP delivery to its bot,
+   * authenticate through the platform plugin, and hand the TYPED verified
+   * product to the plugin's handler. `undefined` ⇒ no assigned bot owns the
+   * delivery (the route answers 401).
+   *
+   * Core drives the ladder — assignment-derived index fast paths (composite
+   * exact first, then app-only), then the bounded scan the assignment's
+   * identity scope permits: a tenant-scoped bot may only serve its own tenant,
+   * because same-secret siblings would all verify and the envelope tenant id
+   * is the ONLY discriminator. The plugin owns the cryptography and everything
+   * after authentication.
    */
-  resolveVerified(args: {
-    apiAppId?: string
-    teamId?: string
-    timestamp: string | undefined
-    rawBody: Buffer
-    signature: string | undefined
-  }): SlackHttpIngest | undefined {
+  async handleInbound(
+    platformId: string,
+    rawBody: Buffer,
+    body: unknown,
+    headers: Record<string, string | string[] | undefined>
+  ): Promise<HandledDelivery | undefined> {
+    const entry = this.ingressPlugins.get(platformId)
+    if (!entry) return undefined
+    const { plugin, pool, demux } = entry
     const now = this.deps.clock.now()
-    const { apiAppId, teamId, timestamp, rawBody, signature } = args
-    // Composite fast path — assign-derived, so a hit is exact (still HMAC-verified).
-    if (apiAppId && teamId) {
-      const botId = this.slackDemux.resolve({ appId: apiAppId, tenantId: teamId })
-      const ingest = botId ? this.slackPool.get(botId) : undefined
-      if (ingest && verifySlackSignature(ingest.signingSecret, timestamp, rawBody, signature, now)) return ingest
+    const hints = plugin.extractDemuxHints(rawBody, body, headers)
+    const tryCandidate = (botId: string | undefined) => {
+      const ingest = botId ? pool.get(botId) : undefined
+      if (!ingest) return undefined
+      const verified = plugin.verify(ingest, rawBody, body, headers, now)
+      return verified === undefined ? undefined : { ingest, verified }
     }
-    if (apiAppId) {
-      const botId = this.slackDemux.resolve({ appId: apiAppId })
-      const ingest = botId ? this.slackPool.get(botId) : undefined
-      if (ingest && verifySlackSignature(ingest.signingSecret, timestamp, rawBody, signature, now)) return ingest
-    }
-    for (const [botId, ingest] of this.slackPool.entries()) {
-      // A team-scoped bot may only serve its own workspace: same-secret siblings
-      // would all verify, so the envelope team id is the ONLY discriminator.
-      const assignedTeam = this.router.get(botId)?.teamId
-      if (assignedTeam !== undefined && assignedTeam !== teamId) continue
-      if (verifySlackSignature(ingest.signingSecret, timestamp, rawBody, signature, now)) {
-        // Learn only the app-only mapping; the index itself refuses a
-        // tenant-scoped bot (registry.test.ts), keeping the invariant even if a
-        // future call site forgets this router check.
-        if (apiAppId && assignedTeam === undefined) this.slackDemux.learn(apiAppId, botId)
-        return ingest
+    // Composite fast path — assign-derived, so a hit is exact (still verified).
+    let hit = hints.appId && hints.tenantId ? tryCandidate(demux.resolve(hints)) : undefined
+    hit ??= hints.appId ? tryCandidate(demux.resolve({ appId: hints.appId })) : undefined
+    if (!hit) {
+      for (const [botId, ingest] of pool.entries()) {
+        const assignedTenant = this.router.get(botId)?.teamId
+        if (assignedTenant !== undefined && assignedTenant !== hints.tenantId) continue
+        const verified = plugin.verify(ingest, rawBody, body, headers, now)
+        if (verified !== undefined) {
+          // Learn only the app-only mapping; the index itself refuses a
+          // tenant-scoped bot (registry.test.ts), keeping the invariant even if
+          // a future call site forgets this assignment check.
+          if (hints.appId && assignedTenant === undefined) demux.learn(hints.appId, botId)
+          hit = { ingest, verified }
+          break
+        }
       }
     }
-    return undefined
-  }
-
-  /** Demux + authenticate one Feishu callback. Unencrypted v2 callbacks carry
-   *  `header.app_id` for O(1) lookup; encrypted callbacks are verified/decrypted
-   *  against the bounded active assignment set because the outer body has no id. */
-  resolveFeishuVerified(args: {
-    appId?: string
-    rawBody: Buffer
-    body: unknown
-    headers: import('./platforms/feishu/http-ingest.js').FeishuCallbackHeaders
-  }): FeishuVerifiedDelivery | undefined {
-    if (args.appId) {
-      const botId = this.feishuDemux.resolve({ appId: args.appId })
-      const ingest = botId ? this.feishuPool.get(botId) : undefined
-      const callback = ingest?.decode(args.rawBody, args.body, args.headers)
-      if (ingest && callback) return { ingest, callback }
-    }
-    for (const ingest of this.feishuPool.values()) {
-      const callback = ingest.decode(args.rawBody, args.body, args.headers)
-      if (callback) return { ingest, callback }
-    }
-    return undefined
+    if (!hit) return undefined
+    return entry.plugin.handle(hit.ingest, hit.verified, this.ingressHost)
   }
 
   /** Test/inspection view of the demux indexes (no secret material). */


### PR DESCRIPTION
Sixth S3-relay PR — the convergence: both HTTP routes now drive **one** core-owned ladder (`manager.handleInbound(platformId, rawBody, body, headers)`), and the two platform-named resolvers (`resolveVerified` / `resolveFeishuVerified`) — the last parallel-function fork the audit flagged in the manager — are gone.

## The ladder

`plugin.extractDemuxHints` → assignment-derived index fast paths (composite exact first, then app-only) → the bounded scan the assignment's identity scope permits (a tenant-scoped bot only serves its own tenant; the learn call keeps both the assignment check **and** the index's own refusal) → `plugin.verify` (the cryptography, per candidate) → `plugin.handle` (everything after authentication, incl. the sync HTTP body).

## Dedup lands in its §8 shape

The **plugin mints the identity** — Slack's `(api_app_id, team_id, event_id)` composite now rides `SlackVerifiedDelivery` out of `verify` — and **core owns the bounded TTL table**, consulted through the new `host.dedupSeen`. The route's dedup dependency is gone; Feishu's per-bot `seen()` stays inside its plugin handle, as before.

Routes shrink to their honest residue: raw-buffer parsing, Slack's unauthenticated `url_verification` (answered pre-candidate — the documented §8 exception), 401 on an unowned delivery, `syncResponse` passthrough. Slack's 3s ack window is preserved (the plugin fires event handling async).

## Two real bugs surfaced by the conversion, fixed and pinned

1. The slack plugin's event/interaction discriminator was *"no `event` field ⇒ interaction"* — an event envelope without `event` misclassified. Now **positive**: `type === 'event_callback'` is the one event shape on this seam.
2. The feishu plugin's `verify` received raw HTTP headers but `decode()` expects Lark's parsed signature triple — the route used to extract it before the seam existed. The plugin owns the extraction now (the **encrypted-callback test caught the 401**).

## Verification

- relay **417 passed**: the composite-demux suite drives the real seam end to end and asserts *which bot handled*; the slack route harness stubs the seam with faithful semantics; the feishu route harness drives the **real plugin** (verify → handle) so token check, AES decrypt, the encrypted challenge, dedup, and the card response window run as production does
- full monorepo typecheck clean; eslint/prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)