### PR TITLE
fix(web): pass flat mode through session routes

### DIFF
--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -174,7 +174,8 @@ C1.
 
 `GET /sessions` returns **conversations by default**; `?view=flat` returns
 today's raw session rows. The console passes the same parameter through (a
-list-mode switch, defaulting to grouped). This deliberately changes the
+URL-addressable diagnostic mode, defaulting to grouped) and keeps it on links
+from the flat list into a raw session. This deliberately changes the
 default response shape of a public REST operation — accepted by product
 decision: console and CP ship on the same train, external consumers pin
 `view=flat`, and the OpenAPI doc describes both shapes on the operation.
@@ -247,17 +248,19 @@ grouped list and the merged page both hold to it (§7).
 
 ### 5.3 Routes and cross-links
 
-- `/conversations/:key` — the merged page, and **the only surfaced page for a
-  multi-participant conversation**.
-- Sessions list rows link here when `participants.length > 1`, to the
+- `/conversations/:key` — the default surfaced page for a multi-participant
+  conversation.
+- Grouped Sessions list rows link here when `participants.length > 1`, to the
   per-agent session page otherwise (for a single-agent session that page IS
-  the conversation page — no change for the common case).
+  the conversation page — no change for the common case). `view=flat` rows
+  always link to their raw `/sessions/:id?view=flat` page.
 - Existing `/sessions/:id` deep links (GitHub check footers, shared URLs,
   crumbs) whose session belongs to a multi-participant conversation
   **redirect** to `/conversations/:key?focus=<agentId>` — the focus preserves
   "whose perspective was linked" as scroll/highlight rather than as a
-  different page. Per-agent pages for such conversations are reachable only
-  as this redirect; nothing links to them (product decision).
+  different page. The explicit `/sessions/:id?view=flat` diagnostic route
+  suppresses that redirect and keeps `view=flat` through the session rail,
+  lineage links, list back-navigation, and copied links.
 - Participant chips link to the agent's page (`/agents/:id`); session-level
   lineage navigation lifts to the conversation level (§9).
 - Webchat Playground adoption: a live multi-agent playground session reopened
@@ -501,8 +504,8 @@ how divergence starts.
 
 1. **Grouped list replaces the flat list as the default.** `GET /sessions`
    returns conversations; `view=flat` (a UI parameter passed through to the
-   CP) returns raw session rows. Accepted as a deliberate change to the
-   operation's default response shape.
+   CP and preserved on raw session links) returns raw session rows. Accepted
+   as a deliberate change to the operation's default response shape.
 2. **Pagination is emit-at-max — still no aggregate query.** A scanned row
    yields its conversation only when it is the conversation's newest member
    row under the full `(lastActivityAt, startedAt, id)` total order AND the

--- a/packages/web/src/components/console/SessionRail.test.tsx
+++ b/packages/web/src/components/console/SessionRail.test.tsx
@@ -64,7 +64,8 @@ function railMarkup({
   sessions = [],
   total = 0,
   family = NO_FAMILY,
-  filterTouched = false
+  filterTouched = false,
+  flatView = false
 }: {
   sessions?: Session[]
   total?: number
@@ -74,6 +75,7 @@ function railMarkup({
     childSessions: SessionRelationDto[]
   }
   filterTouched?: boolean
+  flatView?: boolean
 } = {}) {
   return renderToStaticMarkup(
     <SessionRail
@@ -84,6 +86,7 @@ function railMarkup({
       filterTouched={filterTouched}
       onAgentIdsChange={() => {}}
       family={family}
+      flatView={flatView}
       onSelect={() => {}}
     />
   )
@@ -142,5 +145,12 @@ describe('SessionRail column', () => {
     expect(slot).toContain(COLUMN)
     expect(slot).toContain(WIDE_ONLY)
     expect(railMarkup({ sessions: [session('a'), session('b')], total: 2 })).toContain(COLUMN)
+  })
+
+  it('keeps flat mode on session and list links', () => {
+    const markup = railMarkup({ sessions: [session('a'), session('b')], total: 2, flatView: true })
+
+    expect(markup).toContain('href="/sessions/a?view=flat"')
+    expect(markup).toContain('href="/sessions?view=flat&amp;agent=agent-1"')
   })
 })

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -82,8 +82,7 @@ interface RailRow {
   title: string
   tooltip: string
   /** Where the row goes. A multi-participant row is a CONVERSATION, and the merged
-   *  page is its only surfaced view (merged-conversation-view.md §5.3) — linking to
-   *  the member session instead would just bounce through the redirect. */
+   *  page is its default surfaced view (merged-conversation-view.md §5.3). */
   href: string
   /** The id this row's pin toggle writes: the member already pinned when there is
    *  one, so unpinning releases the pin that is actually claiming the row. */
@@ -125,6 +124,7 @@ export function SessionRail({
   onAgentIdsChange,
   family,
   conversation = false,
+  flatView = false,
   childOriginById,
   onSelect
 }: {
@@ -145,12 +145,15 @@ export function SessionRail({
   /** Conversation-level lineage (merged-conversation-view.md §9.2): relabels the
    *  related tree and groups delegations by their waking member. */
   conversation?: boolean
+  /** Keep raw session rows and links instead of collapsing into conversations. */
+  flatView?: boolean
   /** Delegation target id → waking member agentId (conversation mode). */
   childOriginById?: ReadonlyMap<string, string>
   /** Seed the persistent detail view before the route id changes. */
   onSelect: (session: Session) => void
 }) {
   const { orgPath, activeOrg } = useOrgs()
+  const flatSearch = flatView ? '?view=flat' : ''
   // Schedule-triggered rows show the schedule's name, so the rail needs the crons
   // list — resolve it here instead of threading another display-only callback.
   // `agents` backs the filter chips and their picker.
@@ -310,7 +313,7 @@ export function SessionRail({
   const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)
     const id = canonicalSessionId(s)
-    const merged = isMergedConversationRow(s)
+    const merged = !flatView && isMergedConversationRow(s)
     return {
       // The SESSION id: it is what `current` is matched against and what a fresh
       // pin records. Pin LOOKUP goes through every member (see sessionPinIds).
@@ -320,7 +323,7 @@ export function SessionRail({
       tooltip: `${s.title}\n${s.time} · ${channel.label}`,
       href: merged
         ? orgPath(`/conversations/${encodeURIComponent(s.conversationKey!)}`)
-        : orgPath(`/sessions/${encodeURIComponent(id)}`),
+        : orgPath(`/sessions/${encodeURIComponent(id)}${flatSearch}`),
       pinId: rowPin(s).id,
       session: s
     }
@@ -332,7 +335,7 @@ export function SessionRail({
       platform: relation.platform,
       title,
       tooltip: title,
-      href: orgPath(`/sessions/${encodeURIComponent(relation.id)}`),
+      href: orgPath(`/sessions/${encodeURIComponent(relation.id)}${flatSearch}`),
       pinId: relation.id
     }
   }
@@ -405,6 +408,11 @@ export function SessionRail({
     )
   }
 
+  const allSessionsQuery = new URLSearchParams()
+  if (flatView) allSessionsQuery.set('view', 'flat')
+  if (agentIds.length === 1) allSessionsQuery.set('agent', agentIds[0]!)
+  const allSessionsHref = orgPath(`/sessions${allSessionsQuery.size ? `?${allSessionsQuery}` : ''}`)
+
   // One list, two containers: the ≥wide inline right column, and the 769–1239px
   // floating button whose hover/focus popover shows the same list. Duplicating
   // the rendered rows is cheap; duplicating the data plumbing would not be.
@@ -417,10 +425,7 @@ export function SessionRail({
           shared-conversation filter is dropped rather than silently narrowed. */}
       <div className="mb-[9px] flex flex-none items-center justify-between gap-2 px-[9px]">
         <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">Sessions</span>
-        <Link
-          className="lnk font-sans text-[12px] font-medium leading-normal"
-          href={orgPath(agentIds.length === 1 ? `/sessions?agent=${encodeURIComponent(agentIds[0]!)}` : '/sessions')}
-        >
+        <Link className="lnk font-sans text-[12px] font-medium leading-normal" href={allSessionsHref}>
           All sessions
           <Icon name="arrow-right" size={12} />
         </Link>

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -33,6 +33,7 @@ import { getUser, isAuthConfigured, logout } from '@/lib/auth'
 import { useProfile } from '@/lib/profile'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { applyTheme, clearThemeAttr, getStoredTheme, type Theme } from '@/lib/theme'
+import { isFlatSessionView, sessionListSearchParams } from '@/lib/session-list-view'
 
 interface NavItem {
   href: string
@@ -77,7 +78,6 @@ const MORE_ROWS: NavItem[] = [
 // every other route is a "push" screen (back-button app bar, no bottom nav) on mobile.
 // Home is a top-level surface (the default landing), not a push screen.
 const LIST_ROUTES = ['/home', '/agents', '/sessions', '/crons', '/daemons']
-const SESSION_FILTER_KEYS = ['agent', 'integration', 'channel', 'trigger']
 const CONSOLE_SWR_CONFIG = {
   dedupingInterval: 2_000,
   focusThrottleInterval: 5_000,
@@ -168,13 +168,7 @@ function resolveHelpLinks(): typeof HELP_LINK_DEFAULTS {
 }
 
 function sessionFilterSearch(search: string): string {
-  const current = new URLSearchParams(search)
-  const next = new URLSearchParams()
-  for (const key of SESSION_FILTER_KEYS) {
-    const value = current.get(key)
-    if (value && value !== 'all') next.set(key, value)
-  }
-  const qs = next.toString()
+  const qs = sessionListSearchParams(new URLSearchParams(search)).toString()
   return qs ? `?${qs}` : ''
 }
 
@@ -637,7 +631,8 @@ function ShellChrome({ children }: { children: ReactNode }) {
   const isSessionDetail = seg[0] === 'sessions' && seg.length === 2
   const copyLink = () => {
     try {
-      void navigator.clipboard?.writeText?.(window.location.origin + orgPath(barePath))?.catch?.(() => {})
+      const suffix = isFlatSessionView(searchParams) ? '?view=flat' : ''
+      void navigator.clipboard?.writeText?.(window.location.origin + orgPath(`${barePath}${suffix}`))?.catch?.(() => {})
     } catch {
       /* noop */
     }

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -105,6 +105,7 @@ import {
   type RailAgentFilter
 } from '@/lib/session-rail-filter'
 import { useSessionList } from '@/lib/use-session-list'
+import { isFlatSessionView } from '@/lib/session-list-view'
 import { WebchatMcpApprovalCard } from '@/components/console/WebchatMcpApprovalCard'
 import {
   sessionEffortAfterModelChange,
@@ -842,18 +843,20 @@ function SessionRelationLink({
   relation,
   agent,
   orgPath,
+  flatView = false,
   bordered = false
 }: {
   relation: SessionRelationDto
   agent?: Agent
   orgPath: (path: string) => string
+  flatView?: boolean
   bordered?: boolean
 }) {
   const title = relation.title?.trim() || `Session ${relation.id.slice(0, 8)}`
   const agentName = agent ? agentLabel(agent) : relation.agentId
   return (
     <Link
-      href={orgPath(`/sessions/${encodeURIComponent(relation.id)}`)}
+      href={orgPath(`/sessions/${encodeURIComponent(relation.id)}${flatView ? '?view=flat' : ''}`)}
       title={title}
       className={`lnk flex min-w-0 items-center gap-2 py-[10px] no-underline ${
         bordered ? 'border-t border-(--border-subtle)' : ''
@@ -885,6 +888,7 @@ function MobileSessionFamilyLinks({
   agentById,
   orgPath,
   conversation = false,
+  flatView = false,
   childOriginById
 }: {
   parent: SessionRelationDto | null
@@ -895,6 +899,7 @@ function MobileSessionFamilyLinks({
   /** Conversation-level lineage (merged-conversation-view.md §9.2): relabels
    *  the sections and groups delegations by their waking member. */
   conversation?: boolean
+  flatView?: boolean
   /** Delegation target id → waking member agentId (conversation mode). */
   childOriginById?: ReadonlyMap<string, string>
 }) {
@@ -910,7 +915,12 @@ function MobileSessionFamilyLinks({
           <span className="py-[10px] font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
             {conversation ? 'Parent conversation' : 'Parent session'}
           </span>
-          <SessionRelationLink relation={parent} agent={agentById.get(parent.agentId)} orgPath={orgPath} />
+          <SessionRelationLink
+            relation={parent}
+            agent={agentById.get(parent.agentId)}
+            orgPath={orgPath}
+            flatView={flatView}
+          />
         </div>
       )}
       {siblings.length > 0 && (
@@ -929,6 +939,7 @@ function MobileSessionFamilyLinks({
                 relation={sibling}
                 agent={agentById.get(sibling.agentId)}
                 orgPath={orgPath}
+                flatView={flatView}
                 bordered={index > 0}
               />
             ))}
@@ -963,6 +974,7 @@ function MobileSessionFamilyLinks({
                     relation={child}
                     agent={agentById.get(child.agentId)}
                     orgPath={orgPath}
+                    flatView={flatView}
                     bordered={index > 0 && !newGroup}
                   />
                 </div>
@@ -1002,6 +1014,7 @@ export default function SessionDetailView() {
   const { activeOrg, orgPath } = useOrgs()
   const router = useRouter()
   const searchParams = useSearchParams()
+  const flatView = isFlatSessionView(searchParams)
   const { id: routeId, key: conversationKeyParam } = useParams<{ id?: string; key?: string }>()
   // Merged conversation mode (merged-conversation-view.md §5.3): /conversations/:key
   // resolves the roster through the bounded key-addressed resolver; the
@@ -1391,21 +1404,23 @@ export default function SessionDetailView() {
   // conversation mode); a hit redirects to the merged page (§5.3), carrying
   // whose perspective was linked as ?focus.
   const selfKey = useMemo(() => {
-    if (conversationKey || !currentSessionDetail || currentSessionDetail.platform === 'playground') return null
+    if (flatView || conversationKey || !currentSessionDetail || currentSessionDetail.platform === 'playground') {
+      return null
+    }
     return encodeConversationKey({
       platform: currentSessionDetail.platform ?? 'slack',
       tenantScope: currentSessionDetail.tenantScope ?? null,
       channel: currentSessionDetail.channel,
       thread: currentSessionDetail.thread
     })
-  }, [conversationKey, currentSessionDetail])
+  }, [flatView, conversationKey, currentSessionDetail])
   const { data: selfConversation } = useSWR(
     selfKey && activeOrg?.id ? (['conversation-by-key', activeOrg.id, selfKey] as const) : null,
     ([, orgId, key]) => fetchConversationByKey(key, orgId),
     { revalidateOnFocus: false }
   )
   const selfConversationRedirect =
-    selfKey && selfConversation && selfConversation.sessions.length > 1
+    !flatView && selfKey && selfConversation && selfConversation.sessions.length > 1
       ? orgPath(`/conversations/${encodeURIComponent(selfKey)}?focus=${currentSessionDetail?.agentId ?? ''}`)
       : null
   useEffect(() => {
@@ -1464,17 +1479,15 @@ export default function SessionDetailView() {
   // (no session, and the reader has not touched it), so the org key stays null and
   // no page is fetched to be thrown away.
   //
-  // GROUPED, because the filter is conversation-shaped: the flat view returns one
-  // row per member session, so the moment the filter names a whole roster a thread
-  // two agents worked in listed itself once per agent. One row per conversation is
-  // also what the rail was always showing — that only happened to be true while
-  // the filter named a single agent.
+  // The ordinary detail rail is conversation-shaped. An explicit flat route keeps
+  // the same raw-session mode so navigating the rail cannot silently return to the
+  // grouped list or hide superseded sessions again.
   const railQuery = railAgentFilterQuery(railFilter)
   const railAgentIds = railQuery?.agentId ?? []
   const { sessions: railSessionRows, total: railSessionTotal } = useSessionList(
     MOCK_MODE || !railQuery ? null : activeOrg?.id,
     railQuery ?? {},
-    { grouped: true }
+    { grouped: !flatView }
   )
   const railSessions = useMemo(() => {
     if (!MOCK_MODE) return railSessionRows
@@ -1521,7 +1534,7 @@ export default function SessionDetailView() {
     // A multi-participant conversation's canonical URL is the merged page —
     // refresh must land where the live Playground already looks merged
     // (merged-conversation-view.md §5.3). channelId is the conversation id.
-    const conversationId = (session?.participants?.length ?? 0) > 1 ? session?.channelId : undefined
+    const conversationId = !flatView && (session?.participants?.length ?? 0) > 1 ? session?.channelId : undefined
     if (conversationId) {
       // ADDRESS BAR ONLY (Next shallow history update): a router.replace to
       // /conversations/:key would remount into persisted conversation mode
@@ -1540,6 +1553,7 @@ export default function SessionDetailView() {
     })
   }, [
     id,
+    flatView,
     orgPath,
     router,
     session?.platform,
@@ -2194,7 +2208,8 @@ export default function SessionDetailView() {
   const onCopyLink = () => {
     try {
       const canonicalId = session.realSessionId ?? session.id
-      const link = window.location.origin + orgPath(`/sessions/${encodeURIComponent(canonicalId)}`)
+      const link =
+        window.location.origin + orgPath(`/sessions/${encodeURIComponent(canonicalId)}${flatView ? '?view=flat' : ''}`)
       void navigator.clipboard?.writeText(link)?.catch?.(() => {})
     } catch {
       /* noop */
@@ -2912,6 +2927,7 @@ export default function SessionDetailView() {
             agentById={agentById}
             orgPath={orgPath}
             conversation
+            flatView={flatView}
             childOriginById={conversationLineage?.childOriginById}
           />
         ) : (
@@ -2922,6 +2938,7 @@ export default function SessionDetailView() {
               children={currentSessionDetail.childSessions}
               agentById={agentById}
               orgPath={orgPath}
+              flatView={flatView}
             />
           )
         )}
@@ -3631,6 +3648,7 @@ export default function SessionDetailView() {
         onAgentIdsChange={setRailAgentIds}
         family={conversationFamily ?? (currentSessionDetail?.id === session.id ? currentSessionDetail : undefined)}
         conversation={conversationMode}
+        flatView={flatView}
         childOriginById={conversationLineage?.childOriginById}
         onSelect={setRouteSession}
       />

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -30,6 +30,7 @@ import {
 import { useConsoleData } from '@/lib/data-context'
 import { useSessionFacets } from '@/lib/use-session-facets'
 import { useSessionList } from '@/lib/use-session-list'
+import { isFlatSessionView, sessionListSearchParams } from '@/lib/session-list-view'
 import { useProfile } from '@/lib/profile'
 import { usePlayground } from '@/components/console/PlaygroundProvider'
 import { useMobileFilterSlot } from '@/components/console/Shell'
@@ -39,7 +40,6 @@ import { Avatar, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 
 type FilterKey = 'agent' | 'integration' | 'channel' | 'trigger'
-const FILTER_KEYS: FilterKey[] = ['agent', 'integration', 'channel', 'trigger']
 const DEMO_AGENT_IDS = new Set(AGENTS.map((agent) => agent.id))
 
 // Avatar initials for a person trigger — strip a leading @, then first letters of
@@ -129,6 +129,7 @@ export default function SessionsView() {
   const fInt = params.get('integration') ?? 'all'
   const fChannel = params.get('channel') ?? 'all'
   const fTrigger = params.get('trigger') ?? 'all'
+  const flatView = isFlatSessionView(params)
   const fGithubRepoId = githubRepoIdFromSessionTriggerFilter(fTrigger)
   const sessionFilters = {
     ...(fAgent !== 'all' ? { agentId: fAgent } : {}),
@@ -140,7 +141,7 @@ export default function SessionsView() {
         : {}),
     ...(fGithubRepoId ? { githubRepoId: fGithubRepoId } : fTrigger !== 'all' ? { triggeredBy: fTrigger } : {})
   } satisfies SessionListFilters
-  const sessionList = useSessionList(activeOrg?.id, sessionFilters, { grouped: true })
+  const sessionList = useSessionList(activeOrg?.id, sessionFilters, { grouped: !flatView })
   const { data: sessionFacets = baseSessionFacets } = useSessionFacets(activeOrg?.id, sessionFilters, baseSessionFacets)
   const demoSessions = useMemo(
     () => (MOCK_MODE ? allSessions.filter((session) => DEMO_AGENT_IDS.has(session.agentId ?? '')) : []),
@@ -188,18 +189,14 @@ export default function SessionsView() {
       .map(({ s }) => s)
   }, [filteredServerSessions, localSessions])
   const filterQuery = useMemo(() => {
-    const next = new URLSearchParams()
-    for (const key of FILTER_KEYS) {
-      const value = params.get(key)
-      if (value && value !== 'all') next.set(key, value)
-    }
-    return next.toString()
+    return sessionListSearchParams(params).toString()
   }, [params])
   const sessionHref = useCallback(
     (session: Session) => {
       // A multi-participant conversation row links to the merged page — the only
-      // surfaced view for it (merged-conversation-view.md §5.3).
-      if (isMergedConversationRow(session)) {
+      // default view for it (merged-conversation-view.md §5.3). The explicit flat
+      // list keeps the member session addressable instead.
+      if (!flatView && isMergedConversationRow(session)) {
         return orgPath(`/conversations/${encodeURIComponent(session.conversationKey!)}`)
       }
       const id = canonicalSessionId(session)
@@ -209,7 +206,7 @@ export default function SessionsView() {
       const suffix = query.size ? `?${query.toString()}` : ''
       return orgPath(`/sessions/${id}${suffix}`)
     },
-    [filterQuery, orgPath]
+    [filterQuery, flatView, orgPath]
   )
 
   const setFilter = useCallback(

--- a/packages/web/src/lib/session-list-view.test.ts
+++ b/packages/web/src/lib/session-list-view.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { isFlatSessionView, sessionListSearchParams } from './session-list-view'
+
+describe('session list view query', () => {
+  it('recognizes only the explicit flat view', () => {
+    expect(isFlatSessionView(new URLSearchParams('view=flat'))).toBe(true)
+    expect(isFlatSessionView(new URLSearchParams('view=grouped'))).toBe(false)
+  })
+
+  it('carries flat view and active filters between list and detail routes', () => {
+    const params = new URLSearchParams('view=flat&agent=agent-1&integration=all&ignored=value')
+    expect(sessionListSearchParams(params).toString()).toBe('view=flat&agent=agent-1')
+  })
+})

--- a/packages/web/src/lib/session-list-view.ts
+++ b/packages/web/src/lib/session-list-view.ts
@@ -1,0 +1,19 @@
+const SESSION_FILTER_KEYS = ['agent', 'integration', 'channel', 'trigger'] as const
+
+type SearchParamsReader = Pick<URLSearchParams, 'get'>
+
+export function isFlatSessionView(params: SearchParamsReader): boolean {
+  return params.get('view') === 'flat'
+}
+
+/** Query state that remains meaningful while moving between the Sessions list
+ *  and one raw session. Unknown list modes are deliberately dropped. */
+export function sessionListSearchParams(params: SearchParamsReader): URLSearchParams {
+  const next = new URLSearchParams()
+  if (isFlatSessionView(params)) next.set('view', 'flat')
+  for (const key of SESSION_FILTER_KEYS) {
+    const value = params.get(key)
+    if (value && value !== 'all') next.set(key, value)
+  }
+  return next
+}


### PR DESCRIPTION
## Summary

- honor `view=flat` on the Sessions page and request raw session rows
- preserve flat mode when opening session details, navigating the session rail or lineage, going back, copying links, and adopting a real Playground session ID
- suppress the default redirect from a raw session to its merged conversation while flat mode is explicit
- document the diagnostic route contract and add focused regressions

## Why

The Control Plane already supports `view=flat`, but the Console ignored that query parameter and always fetched grouped conversations. Even a manually opened raw session could redirect back to the merged conversation, making superseded and per-agent session rows inaccessible through the Console.

## Validation

- `pnpm --filter @agentconnect.md/web test` (95 files, 727 tests)
- `pnpm --filter @agentconnect.md/web lint`
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web build`

Created by Codex . GPT-5
