### PR TITLE
feat(cp): slack + feishu platform providers; projectBotAssign becomes optional (S3 §9)

### DIFF
--- a/packages/control-plane/src/config/env.ts
+++ b/packages/control-plane/src/config/env.ts
@@ -6,6 +6,8 @@
  * (`API_KEY_PEPPER`, `HEARTBEAT_SEC`).
  */
 import { z } from 'zod'
+import { SlackCpEnvSchema } from '../platforms/slack/provider.js'
+import { FeishuCpEnvSchema } from '../platforms/feishu/provider.js'
 
 export const AppConfigSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
@@ -25,12 +27,15 @@ export const AppConfigSchema = z.object({
   // sweeps every CRON_RUN_REAP_INTERVAL_SEC.
   CRON_RUN_TTL_SEC: z.coerce.number().int().default(1800),
   CRON_RUN_REAP_INTERVAL_SEC: z.coerce.number().int().default(300),
-  // Slack auto-install funnel (docs/designs/slack-install-smoothing.md §Tier B). A
-  // `slack_install` pending row the operator never finishes (holding a client
-  // secret + bot token) is deleted once older than SLACK_INSTALL_TTL_SEC; the
-  // SlackInstallReaper sweeps every SLACK_INSTALL_REAP_INTERVAL_SEC.
-  SLACK_INSTALL_TTL_SEC: z.coerce.number().int().default(3600),
-  SLACK_INSTALL_REAP_INTERVAL_SEC: z.coerce.number().int().default(600),
+  // Slack + Feishu platform-provider env keys (§9 `envSchema`): the
+  // auto-install reaper knobs (SLACK_INSTALL_*), the platform-published Slack
+  // app (SLACK_PLATFORM_*), and the platform-owned Feishu/Lark apps
+  // (FEISHU/LARK_PLATFORM_*). Defined BY the providers and spread here —
+  // one implementation with each provider's declared `envSchema` — until
+  // `loadConfig` folds the registry's schemas (S3 adoption). Key docs live
+  // with the shapes (`platforms/slack/provider.ts`, `platforms/feishu/provider.ts`).
+  ...SlackCpEnvSchema,
+  ...FeishuCpEnvSchema,
   // HMAC pepper for `api_key.hash` (C4). Required, ≥32 chars. Effectively immutable —
   // rotating it invalidates every stored key hash. See daemon-api-key-auth.md.
   API_KEY_PEPPER: z.string().min(32),
@@ -104,24 +109,8 @@ export const AppConfigSchema = z.object({
     .enum(['true', 'false'])
     .default('true')
     .transform((v) => v === 'true'),
-  // ── Platform-published (distributed) Slack app (preset-agents.md §5.3) — opt-in ──
-  // The deployment-level Slack app users "Add to Slack" via standard OAuth v2.
-  // ALL FOUR must be set to enable the feature; any unset ⇒ absent (the
-  // self-hosted default: the console offers only the quick-install funnel).
-  // MUST stay .optional() so an image bump never fail-fasts an existing deploy.
-  // The install path additionally hard-depends on PUBLIC_CP_URL (the OAuth
-  // callback origin) + PUBLIC_RELAY_URL + a connected relay (Events-API-only).
-  SLACK_PLATFORM_APP_ID: z.string().optional(), // A… — the distributed app's id
-  SLACK_PLATFORM_CLIENT_ID: z.string().optional(),
-  SLACK_PLATFORM_CLIENT_SECRET: z.string().optional(),
-  SLACK_PLATFORM_SIGNING_SECRET: z.string().optional(),
-  // Platform-owned Feishu/Lark apps. Each region is independently all-or-none;
-  // the same app id must back its Logto social connector so app-scoped open_id
-  // values can be compared safely during Session membership checks.
-  FEISHU_PLATFORM_APP_ID: z.string().optional(),
-  FEISHU_PLATFORM_APP_SECRET: z.string().optional(),
-  LARK_PLATFORM_APP_ID: z.string().optional(),
-  LARK_PLATFORM_APP_SECRET: z.string().optional(),
+  // (SLACK_PLATFORM_* and FEISHU/LARK_PLATFORM_* moved into the provider env
+  // shapes spread above.)
   // The MCP endpoint's dedicated public origin (agent-assistant.md §6.1), e.g.
   // https://mcp.example.test. Set ⇒ the canonical MCP resource URL IS this origin (root resource;
   // the URL users paste is just the host) and auth discovery uses the origin-root

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -168,6 +168,11 @@ import type { CpPlatformRegistry } from './platforms/provider.js'
 import { buildCpPlatformRegistry } from './platforms/registry.js'
 import { createTelegramCpProvider } from './platforms/telegram/provider.js'
 import { createDiscordCpProvider } from './platforms/discord/provider.js'
+import { createSlackCpProvider } from './platforms/slack/provider.js'
+import { createFeishuCpProvider, FEISHU_REGISTRATION_TTL_MS } from './platforms/feishu/provider.js'
+import { slackInstallRoutes, slackConfigRoutes, slackOauthCallbackRoutes } from './http/routes/slack-install.js'
+import { slackPlatformInstallRoutes, slackPlatformCallbackRoutes } from './http/routes/slack-platform-install.js'
+import { feishuRegistrationRoutes } from './http/routes/feishu-registration.js'
 import { verifyFeishuBot } from './http/feishu-identity.js'
 import { createFeishuAppIconSyncer } from './http/feishu-app-icon.js'
 import { FeishuAppRegistrationService } from './http/feishu-registration.js'
@@ -189,9 +194,10 @@ export interface Container {
   relayGateway(app: FastifyInstance): WebSocketServer
   /** The single-tenant anchors the devAuth stub injects. */
   readonly defaults: { orgId: string; ownerId: string }
-  /** §9 platform-provider registry (S3) — Telegram + Discord today. Composed
-   *  here so the graph is whole; the route / spec-assembly / config call
-   *  sites adopt it in follow-up PRs (nothing consumes it yet). */
+  /** §9 platform-provider registry (S3) — all four platforms (Telegram,
+   *  Discord, Slack, Feishu). Composed here so the graph is whole; the route /
+   *  spec-assembly / config / background-lifecycle call sites adopt it in
+   *  follow-up PRs (nothing consumes it yet). */
   readonly platforms: CpPlatformRegistry
   /** The process readiness gate — the bootstrap flips it at SIGTERM (`/readyz`). */
   readonly readiness: Readiness
@@ -774,22 +780,7 @@ export function buildContainer(
   // platform providers below — one closure per platform, not two.
   const syncTelegramBotIcon = createTelegramBotIconSyncer(iconStore)
   const syncDiscordBotProfile = createDiscordBotProfileSyncer(iconStore)
-
-  // §9 platform-provider registry (S3): the behavioral CpPlatformProvider
-  // instances, constructed with the SAME verify/sync functions the route deps
-  // receive (one implementation; the providers add no second code path).
-  // Nothing consumes the registry yet beyond construction — the create route,
-  // spec assembly, and rc/bot-assign adopt it in follow-up PRs, and the
-  // Slack / Feishu providers (funnel routes, reapers, env schemas) land with
-  // their own moves.
-  const platforms = buildCpPlatformRegistry([
-    createTelegramCpProvider({ verifyBot: verifyTelegramBot, syncBotIcon: syncTelegramBotIcon }),
-    createDiscordCpProvider({
-      verifyBot: verifyDiscordBot,
-      ensureMessageContentIntent: ensureDiscordMessageContentIntent,
-      syncBotProfile: syncDiscordBotProfile
-    })
-  ])
+  const syncFeishuAppIcon = createFeishuAppIconSyncer(iconStore)
 
   const httpDeps: HttpDeps = {
     clock,
@@ -881,7 +872,7 @@ export function buildContainer(
     syncDiscordBotProfile,
     verifyFeishuBot,
     configureFeishuHttpApp,
-    syncFeishuAppIcon: createFeishuAppIconSyncer(iconStore),
+    syncFeishuAppIcon,
     feishuAppRegistration: new FeishuAppRegistrationService(repos.feishuAppRegistration),
     ...(github ? { github } : {}),
     ...(githubUserAuthz ? { githubUserAuthz } : {}),
@@ -975,10 +966,12 @@ export function buildContainer(
 
   // Device code/App Secret are encrypted but deliberately short-lived. Retain
   // a terminal status briefly for the browser, then clear the durable row.
+  // (The TTL constant lives with the Feishu provider — one implementation with
+  // its §9 `pendingInstalls` declaration.)
   const feishuRegistrationReaper = new SlackInstallReaper(
     repos.feishuAppRegistration,
     clock,
-    { ttlMs: 10 * 60 * 1000, intervalMs: config.SLACK_INSTALL_REAP_INTERVAL_SEC * 1000 },
+    { ttlMs: FEISHU_REGISTRATION_TTL_MS, intervalMs: config.SLACK_INSTALL_REAP_INTERVAL_SEC * 1000 },
     http.log,
     'feishu-registration'
   )
@@ -1034,6 +1027,52 @@ export function buildContainer(
     { intervalMs: 15 * 60 * 1000 },
     http.log
   )
+
+  // §9 platform-provider registry (S3): the behavioral CpPlatformProvider
+  // instances — all four platforms — constructed with the SAME verify/sync
+  // functions, route-dep bundle, funnel stores, and background-loop instances
+  // the live paths use (one implementation; the providers add no second code
+  // path). The Slack/Feishu funnel plugins are handed in PRE-BOUND to
+  // `httpDeps` — the very factories `server.ts` mounts — because the route
+  // modules consume the create-DTO module, which imports the providers'
+  // credential blocks (importing the factories from the provider modules would
+  // close a runtime import cycle). Nothing consumes the registry yet beyond
+  // construction — the create route, spec assembly, rc/bot-assign, route
+  // mounting, `loadConfig`'s schema fold, and `startBackground()` adopt it in
+  // follow-up PRs.
+  const platforms = buildCpPlatformRegistry([
+    createTelegramCpProvider({ verifyBot: verifyTelegramBot, syncBotIcon: syncTelegramBotIcon }),
+    createDiscordCpProvider({
+      verifyBot: verifyDiscordBot,
+      ensureMessageContentIntent: ensureDiscordMessageContentIntent,
+      syncBotProfile: syncDiscordBotProfile
+    }),
+    createSlackCpProvider({
+      verifyBot: verifySlackBot,
+      verifyAppToken: verifySlackAppToken,
+      funnelRoutes: {
+        org: [slackInstallRoutes(httpDeps), slackPlatformInstallRoutes(httpDeps), slackConfigRoutes(httpDeps)],
+        publicCallback: [slackOauthCallbackRoutes(httpDeps), slackPlatformCallbackRoutes(httpDeps)]
+      },
+      userConfigs: httpDeps,
+      pendingInstalls: {
+        installs: repos.slackInstall,
+        platformInstalls: repos.slackPlatformInstall,
+        ttlMs: config.SLACK_INSTALL_TTL_SEC * 1000,
+        intervalMs: config.SLACK_INSTALL_REAP_INTERVAL_SEC * 1000
+      },
+      identityReconciler: slackBotIdentityReconciler
+    }),
+    createFeishuCpProvider({
+      verifyBot: verifyFeishuBot,
+      funnelRoutes: { org: [feishuRegistrationRoutes(httpDeps)], publicCallback: [] },
+      syncAppIcon: syncFeishuAppIcon,
+      pendingInstalls: {
+        registrations: repos.feishuAppRegistration,
+        intervalMs: config.SLACK_INSTALL_REAP_INTERVAL_SEC * 1000
+      }
+    })
+  ])
 
   // ── daemon WS edge (mounted on the live http.Server after listen) ──────────
   const wsDeps: DaemonWsServerDeps = {

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -31,6 +31,8 @@ import {
 import { HEX_COLOR_RE, AGENT_ICON_GLYPHS } from '../../agents/agent-icon.js'
 import { TelegramCreateCredentials } from '../../platforms/telegram/provider.js'
 import { DiscordCreateCredentials } from '../../platforms/discord/provider.js'
+import { SlackCreateCredentials, refineSlackCreateBody } from '../../platforms/slack/provider.js'
+import { FeishuCreateCredentials, refineFeishuCreateBody } from '../../platforms/feishu/provider.js'
 
 // ── per-resource visibility / sharing (docs/designs/resource-visibility.md) ──
 /** 'org' = visible to every org member (default); 'restricted' = the current
@@ -725,14 +727,9 @@ export const CreateIntegrationBody = z
     transport: z.enum(['socket', 'http']).optional(),
     /** Register a new Slack bot from its tokens. Socket transport needs the
      *  app-level token (Socket Mode); http transport needs the signing secret
-     *  (Events API request verification). */
-    slack: z
-      .object({
-        botToken: z.string().min(1),
-        appToken: z.string().min(1).optional(),
-        signingSecret: z.string().min(1).optional()
-      })
-      .optional(),
+     *  (Events API request verification — enforced in the superRefine below).
+     *  Schema relocated to the platform provider (§9 `credentialBodySchema`). */
+    slack: SlackCreateCredentials.optional(),
     /** Register a new Telegram bot from its BotFather token (single token).
      *  Schema relocated to the platform provider (§9 `credentialBodySchema`) —
      *  one implementation for the live route and the registry. */
@@ -743,16 +740,9 @@ export const CreateIntegrationBody = z
     discord: DiscordCreateCredentials.optional(),
     /** Register a new Feishu / Lark self-built app from its appId + appSecret pair.
      *  `region` picks the open-platform gateway (feishu.cn vs larksuite.com); it
-     *  defaults to international Lark for new create requests. */
-    feishu: z
-      .object({
-        appId: z.string().min(1),
-        appSecret: z.string().min(1),
-        region: FeishuRegion.default('lark'),
-        verificationToken: z.string().min(1).optional(),
-        encryptKey: z.string().min(1).optional()
-      })
-      .optional()
+     *  defaults to international Lark for new create requests.
+     *  Schema relocated to the platform provider (§9 `credentialBodySchema`). */
+    feishu: FeishuCreateCredentials.optional()
   })
   .superRefine((b, ctx) => {
     // The credential object for the chosen platform (else reuse an existing bot).
@@ -780,19 +770,16 @@ export const CreateIntegrationBody = z
     // erroring: the console hides the toggle for socket, and `installNewSlackBot`
     // coerces it off for a non-http bot (so a socket bot can never become shareable).
     // No validation needed here.
-    // Per-transport Slack credential requirements (only when registering a NEW bot).
+    // Per-transport credential requirements (only when registering a NEW bot) —
+    // the providers' §9 `refineCreateBody` bodies, called here so the live DTO
+    // and the registry share ONE implementation (an omitted transport is the
+    // create route's socket default).
+    const addIssue = (message: string) => ctx.addIssue({ code: z.ZodIssueCode.custom, message })
     if (b.platform === 'slack' && b.botId === undefined && b.slack) {
-      if (b.transport === 'http') {
-        if (!b.slack.signingSecret)
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'http transport requires slack.signingSecret' })
-      } else if (!b.slack.appToken) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'socket transport requires slack.appToken' })
-      }
+      refineSlackCreateBody({ credentials: b.slack, transport: b.transport ?? 'socket' }, addIssue)
     }
-    if (b.platform === 'feishu' && b.botId === undefined && b.feishu && b.transport === 'http') {
-      if (!b.feishu.verificationToken) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'http transport requires feishu.verificationToken' })
-      }
+    if (b.platform === 'feishu' && b.botId === undefined && b.feishu) {
+      refineFeishuCreateBody({ credentials: b.feishu, transport: b.transport ?? 'socket' }, addIssue)
     }
   })
 

--- a/packages/control-plane/src/http/install-slack.ts
+++ b/packages/control-plane/src/http/install-slack.ts
@@ -17,15 +17,14 @@ import type { AgentRecord, IntegrationRecord, SlackTransport } from '../persiste
 import { BotId, IntegrationId, type OrgId } from '../domain/ids.js'
 import { integrationToSpec, isGatedAgent } from '../orchestrator/placement.js'
 import { NoConnection } from '../orchestrator/outbound.js'
+import { slackAppIdFromAppToken } from '../platforms/slack/provider.js'
 
-/** App-level tokens are structured `xapp-1-{APP_ID}-{epoch}-{hex}`. The id segment
- *  (A…) is public metadata (it appears in every app-page URL) — stored on the bot so
- *  the console can deep-link "manage / delete the app on Slack". An unexpected shape
- *  just leaves it null. */
-export function slackAppIdFromAppToken(appToken: string): string | undefined {
-  const seg = appToken.split('-')[2]
-  return seg && /^A[A-Z0-9]+$/.test(seg) ? seg : undefined
-}
+// Relocated to the Slack platform provider (§9, S3): its `validateConfig` runs
+// the same same-app cross-check as the create route, and this module sits
+// downstream of `placement.ts` (which imports the provider's projection
+// helpers), so the provider cannot import it back. Re-exported so the existing
+// call sites (`routes/integrations.ts`, `routes/slack-install.ts`) are unchanged.
+export { slackAppIdFromAppToken }
 
 export interface InstallSlackBotArgs {
   orgId: OrgId

--- a/packages/control-plane/src/http/slack-user-config.ts
+++ b/packages/control-plane/src/http/slack-user-config.ts
@@ -17,8 +17,18 @@
  * resolution is `expired`, so the console asks the caller to re-enter it. Never logs
  * token material.
  */
-import type { HttpDeps } from './deps.js'
+import type { SlackConfigApi } from './slack-config-api.js'
+import type { SlackUserConfigStore } from '../persistence/ports.js'
 import type { OrgId } from '../domain/ids.js'
+
+/** The narrow slice of `HttpDeps` the resolution needs — a structural subset,
+ *  so route call sites keep passing the full bundle while the Slack platform
+ *  provider's `providerToolingCredentials` facet (§9) can delegate here without
+ *  faking an entire `HttpDeps` in tests. */
+export interface SlackUserConfigDeps {
+  slackConfigApi?: SlackConfigApi
+  repos: { slackUserConfig: SlackUserConfigStore }
+}
 
 /** Rotate when fewer than 5 minutes of access-token life remain (covers clock skew
  *  + the install round-trip that follows). */
@@ -45,7 +55,7 @@ export function configUsable(row: { refreshToken: string | null; accessExpiresAt
 }
 
 export async function resolveUserConfigAccessToken(
-  deps: HttpDeps,
+  deps: SlackUserConfigDeps,
   orgId: OrgId,
   userId: string,
   now: Date

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -44,6 +44,8 @@ import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 import { ControlSender, NoConnection } from './outbound.js'
 import { isDirectConversationKind } from '../persistence/ports.js'
 import { isGatedAgent, httpIntegrationToSpec } from './placement.js'
+import { slackBotAssignBags } from '../platforms/slack/provider.js'
+import { feishuBotAssignBags } from '../platforms/feishu/provider.js'
 import { AgentId, BotId, DaemonId } from '../domain/ids.js'
 
 export interface HttpBotLog {
@@ -875,44 +877,31 @@ export class HttpBotOrchestrator {
   /** Assemble the `rc/bot-assign` frame (credentials + attributed routing table).
    *  Secret — NEVER log the result. */
   private buildAssign(bot: BotRecord, compiled: Compiled, secret: BotSecretMaterial): RcBotAssign {
+    // §6.7 emission flip (the last S1b dual-shape residue): the opaque ingress
+    // bag is the ONE carrier of the demux identity — the relay's bag-preferring
+    // reader shipped first (#545). The retired named top-level fields stay
+    // OPTIONAL in the wire schema so an older relay's tolerant reader is not
+    // broken by their absence; they leave the schema with the next cleanup.
+    //
+    // §9 shared projection bodies (S3): the same functions the Slack/Feishu
+    // platform providers' `projectBotAssign` return — one implementation for
+    // the live frame and the provider seam (each helper documents its bag
+    // fields). Telegram/Discord bots never carry the http transport (the
+    // create route refuses it), so the slack-shaped arm is the effective
+    // default, exactly as the previous inline ternaries fell through.
+    const { secrets, ingress } =
+      bot.platform === 'feishu' ? feishuBotAssignBags(bot, secret) : slackBotAssignBags(bot, secret)
     return {
       botId: bot.id,
       platform: compiled.platform,
       // §6.1: a bot assignment is always a CHAT platform; carried so an older
       // relay can classify an id a newer CP introduces.
       originKind: 'chat',
-      // §6.7 emission flip (the last S1b dual-shape residue): the opaque ingress
-      // bag is the ONE carrier of the demux identity — the relay's bag-preferring
-      // reader shipped first (#545). The retired named top-level fields stay
-      // OPTIONAL in the wire schema so an older relay's tolerant reader is not
-      // broken by their absence; they leave the schema with the next cleanup.
-      //   apiAppId — Slack "A…" (== Events API api_app_id) or the Feishu app id;
-      //     O(1) inbound demux. Absent on a manual-paste http bot (no xapp to
-      //     parse); the relay verify-scans instead.
-      //   teamId — workspace "T…", present only for a distributed (platform)
-      //     app's install, where the composite (api_app_id, team_id) is the ONLY
-      //     safe demux (all sibling installs share the app id AND the signing
-      //     secret).
-      //   botUserId — persisted at OAuth exchange; spares an auth.test round-trip.
-      ingress: {
-        ...(bot.platform === 'feishu' && secret.appToken
-          ? { apiAppId: secret.appToken }
-          : bot.slackAppId
-            ? { apiAppId: bot.slackAppId }
-            : {}),
-        ...(bot.teamId ? { teamId: bot.teamId } : {}),
-        ...(bot.botUserId ? { botUserId: bot.botUserId } : {})
-      },
+      ingress,
       // Generation of the credentials below — echoed back on `rc/bot-revoked` so a
       // revocation observed under a REPLACED credential cannot kill this one.
       credentialRevision: bot.credentialRevision,
-      secrets:
-        bot.platform === 'feishu'
-          ? {
-              verificationToken: secret.verificationToken ?? '',
-              ...(secret.encryptKey ? { encryptKey: secret.encryptKey } : {})
-            }
-          : { botToken: secret.botToken, signingSecret: secret.signingSecret ?? '' },
+      secrets,
       members: compiled.members,
       agents: compiled.agents,
       routes: compiled.routes,

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -64,6 +64,8 @@ import type {
 import { isDirectConversationKind } from '../persistence/ports.js'
 import { telegramIntegrationConfig } from '../platforms/telegram/provider.js'
 import { discordIntegrationConfig } from '../platforms/discord/provider.js'
+import { slackIntegrationConfig, slackSharedIntegrationConfig } from '../platforms/slack/provider.js'
+import { feishuIntegrationConfig, feishuSharedIntegrationConfig } from '../platforms/feishu/provider.js'
 import { mcpProxyDef, relayHttpOrigin } from './mcpProvider.js'
 import { memoryConnectionSpec, stdioMemoryConnectionSpec } from './memoryConnection.js'
 import type { DaemonId } from '../domain/ids.js'
@@ -268,15 +270,8 @@ export function integrationToSpec(
     // Feishu authenticates the WSClient with an appId + appSecret pair, stored in the
     // two-slot bot_secret: botToken = appSecret (the secret), appToken = appId. The
     // region (feishu.cn vs larksuite.com) rides on the integration row; NULL ⇒ 'feishu'.
-    const feishu = {
-      mode: 'direct' as const,
-      appId: secret.appToken ?? '',
-      appSecret: secret.botToken,
-      region: i.feishuRegion ?? 'feishu',
-      bindRules,
-      mutedChannels,
-      gated
-    }
+    // §9 shared projection body — see the telegram arm above.
+    const feishu = feishuIntegrationConfig(core, secret, i)
     return { integrationId: i.id, agentId: i.agentId, platform: 'feishu', core, config: feishu }
   }
   // 'direct' (transport==='socket') — this daemon owns the Socket Mode connection.
@@ -284,15 +279,8 @@ export function integrationToSpec(
   // is assembled by the HTTP-bot path, which reads the bot's `transport`; this mapper
   // is always direct. A socket bot is single-agent, so it is never shareable. Slack
   // always stores an app-level token (Socket Mode).
-  const slack = {
-    mode: 'direct' as const,
-    shareable: false,
-    botToken: secret.botToken,
-    appToken: secret.appToken ?? '',
-    bindRules,
-    mutedChannels,
-    gated
-  }
+  // §9 shared projection body — see the telegram arm above.
+  const slack = slackIntegrationConfig(core, secret)
   return { integrationId: i.id, agentId: i.agentId, platform: 'slack', core, config: slack }
 }
 
@@ -328,30 +316,16 @@ export function httpIntegrationToSpec(
     gated
   }
   if (i.platform === 'feishu') {
-    const feishu = {
-      mode: 'shared' as const,
-      appId: secret.appToken ?? '',
-      appSecret: secret.botToken,
-      ...(botUserId ? { botOpenId: botUserId } : {}),
-      region: i.feishuRegion ?? 'feishu',
-      bindRules: httpCore.bindRules,
-      mutedChannels: httpCore.mutedChannels,
-      gated
-    }
+    // §9 shared projection body — the same function the platform provider's
+    // `projectIntegrationConfig` calls (S3; provider adoption replaces this arm).
+    const feishu = feishuSharedIntegrationConfig(httpCore, secret, i, botUserId)
     return { integrationId: i.id, agentId: i.agentId, platform: 'feishu', core: httpCore, config: feishu }
   }
   // `shareable` gates the daemon's in-thread "Switch agent" control: an HTTP bot
   // routes through the relay either way, but only a multi-agent (shareable) bot has
   // something to switch to.
-  const slack = {
-    mode: 'shared' as const,
-    shareable,
-    botToken: secret.botToken,
-    ...(providerAppId ? { appId: providerAppId } : {}),
-    bindRules: httpCore.bindRules,
-    mutedChannels: httpCore.mutedChannels,
-    gated
-  }
+  // §9 shared projection body — see the feishu arm above.
+  const slack = slackSharedIntegrationConfig(httpCore, secret, shareable, providerAppId)
   return { integrationId: i.id, agentId: i.agentId, platform: 'slack', core: httpCore, config: slack }
 }
 

--- a/packages/control-plane/src/platforms/discord/provider.test.ts
+++ b/packages/control-plane/src/platforms/discord/provider.test.ts
@@ -121,6 +121,12 @@ describe('discord provider identity + declarative facets', () => {
     expect(provider.providerToolingCredentials).toBeUndefined()
     expect(provider.backgroundLoops).toBeUndefined()
   })
+
+  it('declares no projectBotAssign — Discord has no HTTP callback ingress (S3 erratum)', () => {
+    // The create route refuses `transport: 'http'` for discord, so no bot row
+    // can reach core's assign builder; absence IS the "no relay path" signal.
+    expect(provider.projectBotAssign).toBeUndefined()
+  })
 })
 
 describe('discord validateConfig (route parity: integrations.ts discord arm)', () => {
@@ -257,12 +263,5 @@ describe('discord projection equivalence with the live integrationToSpec path', 
   it('shares one implementation with placement.ts (the extracted helper)', () => {
     const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'any')], false)
     expect(discordIntegrationConfig(spec.core!, SECRET)).toEqual(spec.config)
-  })
-})
-
-describe('discord projectBotAssign (no HTTP ingress)', () => {
-  it('refuses: the create route never mints an http-transport discord bot', async () => {
-    const provider = createDiscordCpProvider({ verifyBot: verifierOk(), ensureMessageContentIntent: intent() })
-    await expect(provider.projectBotAssign(BOT, SECRET)).rejects.toThrow(/no HTTP callback ingress/)
   })
 })

--- a/packages/control-plane/src/platforms/discord/provider.ts
+++ b/packages/control-plane/src/platforms/discord/provider.ts
@@ -183,16 +183,12 @@ export function createDiscordCpProvider(deps: DiscordCpProviderDeps): CpPlatform
     // maintains no additional secret store to load from. Token-bearing — NEVER log.
     async projectIntegrationConfig(integration, bot, core, secrets) {
       return discordIntegrationConfig(core, secrets)
-    },
-
-    // Discord has no HTTP-bot path: the create route refuses
-    // `transport: 'http'` for it (`integrations.ts:392-400`), so no Discord
-    // bot row can carry the http transport and core's assign builder
-    // (`orchestrator/httpBot.ts`) never sees one. The contract still declares
-    // the member as required, so this is a documented refusal stub — reaching
-    // it means a bug upstream, not a recoverable condition.
-    async projectBotAssign(): Promise<never> {
-      throw new Error('discord has no HTTP callback ingress; rc/bot-assign is never built for a discord bot')
     }
+
+    // `projectBotAssign` is DELIBERATELY absent: Discord has no HTTP callback
+    // ingress — the create route refuses `transport: 'http'` for it
+    // (`integrations.ts:392-400`), so no Discord bot row can carry the http
+    // transport and core's assign builder (`orchestrator/httpBot.ts`) never
+    // sees one. Absence IS the "no relay path" signal (S3 contract erratum).
   }
 }

--- a/packages/control-plane/src/platforms/feishu/provider.test.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.test.ts
@@ -1,0 +1,513 @@
+/**
+ * Feishu / Lark CpPlatformProvider (§9, S3) — unit, no I/O.
+ *
+ * The load-bearing suites are the EQUIVALENCE blocks: while the live paths are
+ * still `integrationToSpec` / `httpIntegrationToSpec`
+ * (`orchestrator/placement.ts`) and `buildAssign` (`orchestrator/httpBot.ts`),
+ * the provider's `projectIntegrationConfig` / `projectBotAssign` must produce
+ * EXACTLY the payloads those paths emit for the same inputs — that equality is
+ * what makes the eventual call-site flip a zero-behavior change. The
+ * `projectBotAssign` block runs the REAL orchestrator (in-memory repos, a
+ * recording relay channel) and compares the live `rc/bot-assign` frame's two
+ * opaque bags against the provider's projection.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { FastifyPluginAsync } from 'fastify'
+import {
+  createFeishuCpProvider,
+  feishuBotAssignBags,
+  feishuIntegrationConfig,
+  feishuSharedIntegrationConfig,
+  refineFeishuCreateBody,
+  FeishuCpEnvSchema,
+  FeishuCreateCredentials,
+  FEISHU_REGISTRATION_TTL_MS
+} from './provider.js'
+import { integrationToSpec, httpIntegrationToSpec } from '../../orchestrator/placement.js'
+import { HttpBotOrchestrator } from '../../orchestrator/httpBot.js'
+import { RelayRegistry, type RelayChannel } from '../../ws/relay-registry.js'
+import { CreateIntegrationBody } from '../../http/dto/index.js'
+import { AppConfigSchema } from '../../config/env.js'
+import type { FeishuBotVerification } from '../../http/feishu-identity.js'
+import type { BotProfileIconAgent } from '../../http/bot-profile-icon.js'
+import type {
+  AgentRepo,
+  BotRepo,
+  BotRecord,
+  BotSecretMaterial,
+  BotSecretStore,
+  IntegrationChannelRepo,
+  IntegrationChannelRecord,
+  IntegrationRecord,
+  IntegrationRepo,
+  SessionRepo,
+  ThreadAffinityStore
+} from '../../persistence/ports.js'
+import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
+import { IntegrationFeishuConfig, type RcBotAssign, type RelayCpFrameType } from '@agentconnect.md/protocol'
+
+const verifierOk = (over: Partial<Extract<FeishuBotVerification, { status: 'ok' }>> = {}) =>
+  vi.fn(async () => ({ status: 'ok', name: 'helper-app', openId: 'ou_bot', ...over }) as FeishuBotVerification)
+
+const ORG = OrgId('11111111-1111-4111-8111-111111111111')
+const AGENT_ID = AgentId('77777777-7777-4777-8777-777777777777')
+
+const INTEGRATION: IntegrationRecord = {
+  id: IntegrationId('66666666-6666-4666-8666-666666666666'),
+  orgId: ORG,
+  agentId: AGENT_ID,
+  botId: BotId('88888888-8888-4888-8888-888888888888'),
+  platform: 'feishu',
+  name: 'helper-app',
+  status: 'active',
+  feishuRegion: 'lark',
+  createdAt: new Date('2026-01-01T00:00:00Z')
+}
+
+/** A legacy row without the region column — the helpers' 'feishu' default arm. */
+const LEGACY_INTEGRATION: IntegrationRecord = {
+  id: INTEGRATION.id,
+  orgId: INTEGRATION.orgId,
+  agentId: INTEGRATION.agentId,
+  botId: INTEGRATION.botId,
+  platform: 'feishu',
+  name: INTEGRATION.name,
+  status: 'active',
+  createdAt: INTEGRATION.createdAt
+}
+
+function bot(over: Partial<BotRecord> = {}): BotRecord {
+  return {
+    id: BotId('88888888-8888-4888-8888-888888888888'),
+    orgId: ORG,
+    platform: 'feishu',
+    name: 'helper-app',
+    prebuilt: false,
+    slackAppId: null,
+    teamId: null,
+    workspaceId: null,
+    workspaceName: null,
+    botUserId: null,
+    revokedAt: null,
+    credentialRevision: 1,
+    credentialInstalledAt: null,
+    externalAppId: 'cli_testapp',
+    externalTenantId: '-',
+    platformConfig: null,
+    discordAppId: null,
+    feishuAppId: 'cli_testapp',
+    feishuRegion: 'lark',
+    shareable: false,
+    transport: 'socket',
+    createdBy: null,
+    lastUsedAt: null,
+    lastAgentName: null,
+    agentIds: [AGENT_ID],
+    inUseByAgentId: AGENT_ID,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...over
+  }
+}
+
+// The two-slot overloading: botToken = app SECRET, appToken = app ID. The
+// callback credentials ride the optional slots (http installs only).
+const SOCKET_SECRET: BotSecretMaterial = {
+  botToken: 'feishu-app-secret',
+  appToken: 'cli_testapp',
+  signingSecret: null
+}
+const HTTP_SECRET: BotSecretMaterial = {
+  botToken: 'feishu-app-secret',
+  appToken: 'cli_testapp',
+  signingSecret: null,
+  verificationToken: 'verify-token',
+  encryptKey: 'encrypt-key'
+}
+
+const channel = (
+  channelId: string,
+  trigger: 'off' | 'mention' | 'any',
+  kind: 'channel' | 'im' | 'mpim' = 'channel'
+): IntegrationChannelRecord => ({
+  integrationId: INTEGRATION.id,
+  channelId,
+  name: channelId.toLowerCase(),
+  isPrivate: false,
+  kind,
+  trigger,
+  agentId: null
+})
+
+describe('feishu provider identity + declarative facets', () => {
+  const provider = createFeishuCpProvider({ verifyBot: verifierOk() })
+
+  it('declares the feishu platform id', () => {
+    expect(provider.platformId).toBe('feishu')
+  })
+
+  it('hands out the injected funnel plugin at org scope only, empty when uncomposed', () => {
+    expect(provider.installRoutes('org')).toEqual([])
+    expect(provider.installRoutes('public-callback')).toEqual([])
+    // One org-scoped registration funnel; the device flow polls server-side,
+    // so there is no browser OAuth callback at the version root.
+    const org = [vi.fn()] as unknown as FastifyPluginAsync[]
+    const composed = createFeishuCpProvider({ funnelRoutes: { org, publicCallback: [] } })
+    expect(composed.installRoutes('org')).toEqual(org)
+    expect(composed.installRoutes('public-callback')).toEqual([])
+  })
+
+  it('re-exports the same credential schema instance the create DTO composes', () => {
+    expect(provider.credentialBodySchema).toBe(FeishuCreateCredentials)
+    // The region defaults to international Lark for new create requests.
+    expect(provider.credentialBodySchema.parse({ appId: 'cli_x', appSecret: 's' })).toEqual({
+      appId: 'cli_x',
+      appSecret: 's',
+      region: 'lark'
+    })
+    expect(provider.credentialBodySchema.safeParse({ appId: 'cli_x' }).success).toBe(false)
+  })
+
+  it('packs the overloaded secret row and gates http assigns on verificationToken + appToken', () => {
+    expect(Object.keys(provider.secretShape.slots)).toEqual(['botToken', 'appToken', 'verificationToken', 'encryptKey'])
+    // The gate `HttpBotOrchestrator.syncBot` / `replayTo` apply before building
+    // an assign for a feishu bot.
+    expect(provider.secretShape.httpAssignRequires).toEqual(['verificationToken', 'appToken'])
+  })
+
+  it('owns the FEISHU/LARK_PLATFORM_* env keys, spread into AppConfigSchema', () => {
+    expect(provider.envSchema).toBe(FeishuCpEnvSchema)
+    expect(Object.keys(FeishuCpEnvSchema)).toEqual([
+      'FEISHU_PLATFORM_APP_ID',
+      'FEISHU_PLATFORM_APP_SECRET',
+      'LARK_PLATFORM_APP_ID',
+      'LARK_PLATFORM_APP_SECRET'
+    ])
+    // One implementation: the live config schema is composed FROM this shape.
+    for (const key of Object.keys(FeishuCpEnvSchema)) {
+      expect(AppConfigSchema.shape[key as keyof typeof AppConfigSchema.shape]).toBe(
+        FeishuCpEnvSchema[key as keyof typeof FeishuCpEnvSchema]
+      )
+    }
+  })
+
+  it('declares the registration funnel from the injected store + the 10-minute constant TTL', () => {
+    const registrations = { reapExpired: vi.fn(async () => 0) }
+    const composed = createFeishuCpProvider({ pendingInstalls: { registrations, intervalMs: 600_000 } })
+    expect(composed.pendingInstalls).toEqual([
+      {
+        model: 'FeishuAppRegistration',
+        label: 'feishu-registration',
+        store: registrations,
+        ttlMs: FEISHU_REGISTRATION_TTL_MS,
+        intervalMs: 600_000
+      }
+    ])
+    expect(FEISHU_REGISTRATION_TTL_MS).toBe(10 * 60 * 1000)
+    expect(provider.pendingInstalls).toBeUndefined() // uncomposed ⇒ undeclared
+  })
+
+  it('declares no tooling credentials and no background loops', () => {
+    expect(provider.providerToolingCredentials).toBeUndefined()
+    expect(provider.backgroundLoops).toBeUndefined()
+  })
+
+  it('implements projectBotAssign — Feishu has an HTTP/relay path (S3 erratum)', () => {
+    expect(typeof provider.projectBotAssign).toBe('function')
+  })
+})
+
+describe('feishu refineCreateBody (DTO parity: the create body superRefine feishu arm)', () => {
+  const creds = FeishuCreateCredentials.parse({ appId: 'cli_x', appSecret: 's' })
+  const issues = (body: { credentials: FeishuCreateCredentials; transport: 'socket' | 'http' }) => {
+    const out: string[] = []
+    refineFeishuCreateBody(body, (message) => out.push(message))
+    return out
+  }
+
+  it('requires the verification token for http only; encryptKey stays optional', () => {
+    expect(issues({ credentials: creds, transport: 'http' })).toEqual([
+      'http transport requires feishu.verificationToken'
+    ])
+    expect(issues({ credentials: creds, transport: 'socket' })).toEqual([])
+    expect(issues({ credentials: { ...creds, verificationToken: 'v' }, transport: 'http' })).toEqual([])
+  })
+
+  it('is the same rule the live create DTO enforces (one implementation)', () => {
+    const base = { platform: 'feishu', agentId: AGENT_ID as string }
+    const http = CreateIntegrationBody.safeParse({
+      ...base,
+      transport: 'http',
+      feishu: { appId: 'cli_x', appSecret: 's' }
+    })
+    expect(http.success).toBe(false)
+    expect(http.error?.issues.map((i) => i.message)).toContain('http transport requires feishu.verificationToken')
+    // Socket (and the create route's omitted-transport default) needs no
+    // callback credentials.
+    expect(CreateIntegrationBody.safeParse({ ...base, feishu: { appId: 'cli_x', appSecret: 's' } }).success).toBe(true)
+  })
+})
+
+describe('feishu validateConfig (route parity: integrations.ts feishu arm)', () => {
+  const CREDS = FeishuCreateCredentials.parse({ appId: 'cli_testapp', appSecret: 'feishu-app-secret' })
+
+  it('passes the pasted pair + region to the verifier and derives name/openId', async () => {
+    const verifyBot = verifierOk()
+    const provider = createFeishuCpProvider({ verifyBot })
+    const result = await provider.validateConfig(CREDS, 'socket')
+    expect(verifyBot).toHaveBeenCalledWith('cli_testapp', 'feishu-app-secret', 'lark')
+    expect(result).toEqual({
+      ok: true,
+      identity: { name: 'helper-app', externalAppId: 'cli_testapp', botUserId: 'ou_bot' }
+    })
+  })
+
+  it('refuses rejected credentials with the route’s 400 copy', async () => {
+    const provider = createFeishuCpProvider({ verifyBot: vi.fn(async () => ({ status: 'invalid' as const })) })
+    expect(await provider.validateConfig(CREDS, 'socket')).toEqual({
+      ok: false,
+      status: 400,
+      message:
+        'Feishu rejected the credentials — check the App ID (cli_…) and App Secret from the Developer Console (Credentials & Basic Info).'
+    })
+  })
+
+  it('http transport requires a resolved bot open_id — inconclusive is the route’s 503, never a 400', async () => {
+    const refusal = {
+      ok: false,
+      status: 503,
+      message: 'Could not resolve this app’s bot identity. Enable the bot capability in Feishu, then try again.'
+    }
+    const noOpenId = createFeishuCpProvider({ verifyBot: verifierOk({ openId: null }) })
+    expect(await noOpenId.validateConfig(CREDS, 'http')).toEqual(refusal)
+    const unreachable = createFeishuCpProvider({ verifyBot: vi.fn(async () => ({ status: 'unreachable' as const })) })
+    expect(await unreachable.validateConfig(CREDS, 'http')).toEqual(refusal)
+    const unverified = createFeishuCpProvider({})
+    expect(await unverified.validateConfig(CREDS, 'http')).toEqual(refusal)
+  })
+
+  it('socket transport stays best-effort about reachability (route parity)', async () => {
+    const unreachable = createFeishuCpProvider({ verifyBot: vi.fn(async () => ({ status: 'unreachable' as const })) })
+    expect(await unreachable.validateConfig(CREDS, 'socket')).toEqual({
+      ok: true,
+      identity: { externalAppId: 'cli_testapp' }
+    })
+    const unverified = createFeishuCpProvider({})
+    expect(await unverified.validateConfig(CREDS, 'socket')).toEqual({
+      ok: true,
+      identity: { externalAppId: 'cli_testapp' }
+    })
+  })
+})
+
+describe('feishu sideEffects (icon push delegation)', () => {
+  const AGENT: BotProfileIconAgent = { id: AGENT_ID, icon: null, runtime: 'claude' }
+
+  it('resolves the app id from the secret row and delegates to the injected syncer', async () => {
+    const syncAppIcon = vi.fn(async () => {})
+    const provider = createFeishuCpProvider({ verifyBot: verifierOk(), syncAppIcon })
+    await provider.sideEffects?.syncBotProfileIcon?.(bot(), SOCKET_SECRET, AGENT)
+    expect(syncAppIcon).toHaveBeenCalledWith('cli_testapp', 'feishu-app-secret', 'lark', AGENT)
+  })
+
+  it('falls back to the public bot metadata for older rows, and skips when neither exists', async () => {
+    const syncAppIcon = vi.fn(async () => {})
+    const provider = createFeishuCpProvider({ verifyBot: verifierOk(), syncAppIcon })
+    // Older row: no appToken slot — the bot row's feishuAppId (+ its region default).
+    const legacyBot = bot({ feishuAppId: 'cli_legacy', feishuRegion: null })
+    const legacySecret: BotSecretMaterial = { botToken: 'feishu-app-secret', appToken: null, signingSecret: null }
+    await provider.sideEffects?.syncBotProfileIcon?.(legacyBot, legacySecret, AGENT)
+    expect(syncAppIcon).toHaveBeenCalledWith('cli_legacy', 'feishu-app-secret', 'feishu', AGENT)
+    // No app id anywhere: cosmetic sync is skipped, never thrown.
+    syncAppIcon.mockClear()
+    await provider.sideEffects?.syncBotProfileIcon?.(bot({ feishuAppId: null }), legacySecret, AGENT)
+    expect(syncAppIcon).not.toHaveBeenCalled()
+  })
+
+  it('declares no postCreate push (the create arm runs none) and no capability without a syncer', () => {
+    const provider = createFeishuCpProvider({ verifyBot: verifierOk(), syncAppIcon: vi.fn(async () => {}) })
+    expect(provider.sideEffects?.postCreate).toBeUndefined()
+    expect(createFeishuCpProvider({ verifyBot: verifierOk() }).sideEffects).toBeUndefined()
+  })
+})
+
+describe('feishu projection equivalence with the live integrationToSpec path (direct/socket)', () => {
+  const provider = createFeishuCpProvider({ verifyBot: verifierOk() })
+  const SOCKET_BOT = bot()
+
+  const cases: Array<{
+    label: string
+    integration: IntegrationRecord
+    channels: IntegrationChannelRecord[]
+    gated: boolean
+  }> = [
+    { label: 'defaults (no channels)', integration: INTEGRATION, channels: [], gated: false },
+    {
+      label: "ungated with 'any' + muted channels",
+      integration: INTEGRATION,
+      channels: [channel('oc_1', 'any'), channel('oc_2', 'mention'), channel('oc_3', 'off')],
+      gated: false
+    },
+    {
+      label: 'gated conversation-scoped rules',
+      integration: INTEGRATION,
+      channels: [channel('oc_1', 'any'), channel('oc_2', 'off'), channel('om_1', 'any', 'im')],
+      gated: true
+    },
+    {
+      label: "legacy region-less row (region defaults to 'feishu')",
+      integration: LEGACY_INTEGRATION,
+      channels: [channel('oc_1', 'any')],
+      gated: false
+    }
+  ]
+
+  for (const { label, integration, channels, gated } of cases) {
+    it(`emits exactly the live path's config — ${label}`, async () => {
+      const spec = integrationToSpec(integration, SOCKET_SECRET, channels, gated)
+      const projected = await provider.projectIntegrationConfig(integration, SOCKET_BOT, spec.core!, SOCKET_SECRET)
+      expect(projected).toEqual(spec.config)
+      // Both sides satisfy the daemon reader's wire schema (§6.4).
+      expect(IntegrationFeishuConfig.parse(projected)).toEqual(IntegrationFeishuConfig.parse(spec.config))
+    })
+  }
+
+  it('shares one implementation with placement.ts (the extracted helper)', () => {
+    const spec = integrationToSpec(INTEGRATION, SOCKET_SECRET, [channel('oc_1', 'any')], false)
+    expect(feishuIntegrationConfig(spec.core!, SOCKET_SECRET, INTEGRATION)).toEqual(spec.config)
+  })
+})
+
+describe('feishu projection equivalence with the live httpIntegrationToSpec path (shared/http)', () => {
+  const provider = createFeishuCpProvider({ verifyBot: verifierOk() })
+
+  const cases: Array<{
+    label: string
+    bot: BotRecord
+    channels: IntegrationChannelRecord[]
+    gated: boolean
+  }> = [
+    {
+      label: 'http bot with a resolved bot open_id',
+      bot: bot({ transport: 'http', botUserId: 'ou_bot' }),
+      channels: [channel('oc_1', 'any'), channel('oc_2', 'off')],
+      gated: false
+    },
+    {
+      label: 'legacy http bot without a persisted open_id',
+      bot: bot({ transport: 'http' }),
+      channels: [],
+      gated: false
+    },
+    {
+      label: 'gated member (conversation-scoped rules ride the send-only spec)',
+      bot: bot({ transport: 'http', botUserId: 'ou_bot' }),
+      channels: [channel('oc_1', 'mention'), channel('om_1', 'any', 'im'), channel('oc_2', 'off')],
+      gated: true
+    }
+  ]
+
+  for (const { label, bot: httpBot, channels, gated } of cases) {
+    it(`emits exactly the live path's config — ${label}`, async () => {
+      // The live call sites feed the bot row's fields positionally
+      // (`placement.ts` reconcile, `httpBot.ts` pushSpecs).
+      const spec = httpIntegrationToSpec(
+        INTEGRATION,
+        HTTP_SECRET,
+        httpBot.shareable,
+        channels,
+        gated,
+        httpBot.slackAppId ?? undefined,
+        httpBot.botUserId ?? undefined
+      )
+      const projected = await provider.projectIntegrationConfig(INTEGRATION, httpBot, spec.core!, HTTP_SECRET)
+      expect(projected).toEqual(spec.config)
+      expect(IntegrationFeishuConfig.parse(projected)).toEqual(IntegrationFeishuConfig.parse(spec.config))
+    })
+  }
+
+  it('shares one implementation with placement.ts (the extracted helper)', () => {
+    const spec = httpIntegrationToSpec(INTEGRATION, HTTP_SECRET, false, [], false, undefined, 'ou_bot')
+    expect(feishuSharedIntegrationConfig(spec.core!, HTTP_SECRET, INTEGRATION, 'ou_bot')).toEqual(spec.config)
+  })
+})
+
+// ── projectBotAssign equivalence against the LIVE rc/bot-assign frame ────────
+// A minimal real HttpBotOrchestrator: one placed member, no channels, one
+// recording relay channel. `buildAssign` is private, so the frame captured off
+// the wire IS the live path's output.
+class FakeChannel implements RelayChannel {
+  sends: { type: RelayCpFrameType; payload: unknown }[] = []
+  constructor(readonly relayId: string) {}
+  send(type: RelayCpFrameType, payload: unknown): void {
+    this.sends.push({ type, payload })
+  }
+  close(): void {}
+}
+
+async function liveAssignFrame(botRow: BotRecord, secret: BotSecretMaterial): Promise<RcBotAssign> {
+  const ch = new FakeChannel('relay-1')
+  const relayReg = new RelayRegistry()
+  relayReg.add(ch)
+  const integration: IntegrationRecord = { ...INTEGRATION, botId: botRow.id }
+  const bots = { get: async () => botRow, listHttpActive: async () => [botRow] }
+  const orch = new HttpBotOrchestrator(
+    bots as unknown as BotRepo,
+    { get: async () => secret } as unknown as BotSecretStore,
+    // Never reached by syncBot; present to satisfy the constructor.
+    { install: async () => 1, revoke: async () => ({ applied: false, integrationIds: [] }) },
+    { listForBot: async () => [integration] } as unknown as IntegrationRepo,
+    { listForBot: async () => [] } as unknown as IntegrationChannelRepo,
+    {
+      get: async () => ({ id: integration.agentId, name: 'alice', daemonId: 'd1', visibility: 'org' })
+    } as unknown as AgentRepo,
+    relayReg,
+    { integrationUpsert: async () => {} } as never,
+    { upsert: async () => {}, get: async () => null, listForBot: async () => [] } as unknown as ThreadAffinityStore,
+    { findThreadOwner: async () => null } as unknown as SessionRepo,
+    { info() {}, warn() {}, debug() {} }
+  )
+  await orch.syncBot(botRow.id)
+  const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign | undefined
+  if (!assign) throw new Error('live path built no rc/bot-assign for the fixture')
+  return assign
+}
+
+describe('feishu projectBotAssign equivalence with the live buildAssign frame (§6.7)', () => {
+  const provider = createFeishuCpProvider({ verifyBot: verifierOk() })
+
+  it('http bot: verification credentials in the secrets bag, app id + open_id in the ingress bag', async () => {
+    const httpBot = bot({ transport: 'http', botUserId: 'ou_bot' })
+    const frame = await liveAssignFrame(httpBot, HTTP_SECRET)
+    const projected = await provider.projectBotAssign!(httpBot, HTTP_SECRET)
+    expect(projected.secrets).toEqual(frame.secrets)
+    expect(projected.ingress).toEqual(frame.ingress)
+    expect(projected).toEqual({
+      secrets: { verificationToken: 'verify-token', encryptKey: 'encrypt-key' },
+      ingress: { apiAppId: 'cli_testapp', botUserId: 'ou_bot' }
+    })
+    // The daemon-only app secret NEVER rides to the relay.
+    expect(JSON.stringify(projected)).not.toContain('feishu-app-secret')
+  })
+
+  it('plaintext-events app (no encrypt key): the optional slot is omitted, not empty', async () => {
+    const httpBot = bot({ transport: 'http' })
+    const plaintextSecret: BotSecretMaterial = { ...HTTP_SECRET, encryptKey: null }
+    const frame = await liveAssignFrame(httpBot, plaintextSecret)
+    const projected = await provider.projectBotAssign!(httpBot, plaintextSecret)
+    expect(projected.secrets).toEqual(frame.secrets)
+    expect(projected.ingress).toEqual(frame.ingress)
+    expect(projected).toEqual({
+      secrets: { verificationToken: 'verify-token' },
+      ingress: { apiAppId: 'cli_testapp' }
+    })
+  })
+
+  it('shares one implementation with httpBot.ts (the extracted helper)', async () => {
+    const httpBot = bot({ transport: 'http', botUserId: 'ou_bot' })
+    const frame = await liveAssignFrame(httpBot, HTTP_SECRET)
+    expect(feishuBotAssignBags(httpBot, HTTP_SECRET)).toEqual({
+      secrets: frame.secrets,
+      ingress: frame.ingress
+    })
+  })
+})

--- a/packages/control-plane/src/platforms/feishu/provider.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.ts
@@ -1,0 +1,363 @@
+/**
+ * Feishu / Lark's control-plane platform provider (integration-plugin-
+ * architecture.md §9, stage S3) — built against the merged contract
+ * (`../provider.ts`) beside the Slack provider, the second funnel-bearing
+ * shape: a one-click device-registration funnel (`FeishuAppRegistration` +
+ * TTL reaper), provider env keys (the platform-owned regional apps), an icon
+ * side effect, and an HTTP/relay path (`projectBotAssign`).
+ *
+ * Every behavioral member delegates to the SAME functions the live paths call
+ * today, injected through {@link FeishuCpProviderDeps} so tests stay offline:
+ *
+ *  - `validateConfig` → `deps.verifyBot` (the tenant-access-token exchange +
+ *    `bot/v3/info`, `http/feishu-identity.ts`) — the exact checks of the
+ *    create route's feishu arm (`http/routes/integrations.ts`), statuses and
+ *    user-facing copy verbatim, including the http-transport `openId`
+ *    resolution the relay needs for @-mention demux;
+ *  - `installRoutes` → the registration funnel plugin, injected PRE-BOUND to
+ *    the route deps by the composition root (not imported here: the route
+ *    module consumes the create-DTO module, which imports this provider's
+ *    credential block — binding the factory here would close a runtime import
+ *    cycle);
+ *  - the wire projections → {@link feishuIntegrationConfig} /
+ *    {@link feishuSharedIntegrationConfig} / {@link feishuBotAssignBags},
+ *    called by BOTH the live paths (`orchestrator/placement.ts`,
+ *    `orchestrator/httpBot.ts`) and the provider (one implementation).
+ *
+ * ADOPTION SEQUENCING: nothing consumes this provider yet beyond registry
+ * construction in `container.ts` — the create route, `placement.ts`,
+ * `httpBot.ts`, `server.ts` mounting, and `loadConfig`'s schema fold remain
+ * the live paths, sharing the implementations above.
+ */
+import { z } from 'zod'
+import type { ZodRawShape } from 'zod'
+import type { FastifyPluginAsync } from 'fastify'
+import { FeishuRegion } from '@agentconnect.md/protocol'
+import type { IntegrationCoreEnvelope, IntegrationFeishuConfig } from '@agentconnect.md/protocol'
+import type { BotRecord, BotSecretMaterial, IntegrationRecord } from '../../persistence/ports.js'
+import type { FeishuBotVerifier } from '../../http/feishu-identity.js'
+import type { FeishuAppIconSyncer } from '../../http/feishu-app-icon.js'
+import type { CpConfigValidation, CpInstallTransport, CpPlatformProvider } from '../provider.js'
+
+/** The `feishu` credential block of the `POST /integrations` create body —
+ *  relocated from `http/dto/index.ts`, which imports it back (one
+ *  implementation for the live route and the provider's
+ *  {@link CpPlatformProvider.credentialBodySchema}). An appId + appSecret
+ *  pair; `region` picks the open-platform gateway (feishu.cn vs
+ *  larksuite.com) and defaults to international Lark for new create requests.
+ *  The http-transport requirement (`verificationToken`) lives in
+ *  {@link refineFeishuCreateBody}. */
+export const FeishuCreateCredentials = z.object({
+  appId: z.string().min(1),
+  appSecret: z.string().min(1),
+  region: FeishuRegion.default('lark'),
+  verificationToken: z.string().min(1).optional(),
+  encryptKey: z.string().min(1).optional()
+})
+export type FeishuCreateCredentials = z.infer<typeof FeishuCreateCredentials>
+
+/**
+ * Transport-conditional credential requirements the flat schema cannot express
+ * (§9 `refineCreateBody`) — the feishu arm of the create DTO's `superRefine`,
+ * extracted so `http/dto/index.ts` and the provider share ONE implementation:
+ * callback (http) ingress needs the event-subscription verification token the
+ * relay authenticates inbound POSTs with; `encryptKey` stays optional (Feishu
+ * apps may post plaintext events).
+ */
+export function refineFeishuCreateBody(
+  body: { credentials: FeishuCreateCredentials; transport: CpInstallTransport },
+  addIssue: (message: string) => void
+): void {
+  if (body.transport === 'http' && !body.credentials.verificationToken) {
+    addIssue('http transport requires feishu.verificationToken')
+  }
+}
+
+/**
+ * Env keys this provider owns (§9 `envSchema`) — spread into `AppConfigSchema`
+ * by `config/env.ts` until `loadConfig` folds the registry's schemas (S3
+ * adoption), so the live schema and the provider's declaration are ONE object.
+ *
+ * Platform-owned Feishu/Lark apps: each region is independently all-or-none —
+ * the same app id must back its Logto social connector so app-scoped open_id
+ * values can be compared safely during Session membership checks. The
+ * per-region partial-set fail-fast lives in `config/feishu-platform.ts`
+ * (`resolveFeishuPlatformApps`). MUST stay `.optional()` so an image bump
+ * never fail-fasts an existing deploy.
+ */
+export const FeishuCpEnvSchema = {
+  FEISHU_PLATFORM_APP_ID: z.string().optional(),
+  FEISHU_PLATFORM_APP_SECRET: z.string().optional(),
+  LARK_PLATFORM_APP_ID: z.string().optional(),
+  LARK_PLATFORM_APP_SECRET: z.string().optional()
+} satisfies ZodRawShape
+
+/** How long an unfinished one-click registration row may linger. Device code /
+ *  App Secret are encrypted but deliberately short-lived: a terminal status is
+ *  retained briefly for the browser's poll, then the durable row is cleared.
+ *  A funnel-appropriate constant, not an env knob (contract §9) — shared by
+ *  the provider's declaration and the container's live reaper. */
+export const FEISHU_REGISTRATION_TTL_MS = 10 * 60 * 1000
+
+/**
+ * The §6.4 opaque `IntegrationSpec.config` payload for a DIRECT (socket)
+ * Feishu integration — the body of `integrationToSpec`'s feishu arm
+ * (`orchestrator/placement.ts`), extracted so the live placement path and the
+ * provider's projector share ONE implementation. Feishu authenticates the
+ * WSClient with an appId + appSecret pair, stored in the two-slot
+ * `bot_secret`: `botToken` = appSecret (the secret), `appToken` = appId. The
+ * region (feishu.cn vs larksuite.com) rides on the integration row; NULL ⇒
+ * 'feishu'. Token-bearing — NEVER log the result.
+ */
+export function feishuIntegrationConfig(
+  core: IntegrationCoreEnvelope,
+  secret: Pick<BotSecretMaterial, 'botToken' | 'appToken'>,
+  integration: Pick<IntegrationRecord, 'feishuRegion'>
+): IntegrationFeishuConfig {
+  return {
+    mode: 'direct',
+    appId: secret.appToken ?? '',
+    appSecret: secret.botToken,
+    region: integration.feishuRegion ?? 'feishu',
+    bindRules: core.bindRules,
+    mutedChannels: core.mutedChannels,
+    gated: core.gated
+  }
+}
+
+/**
+ * The §6.4 payload for a SHARED (http/relay) Feishu integration — the feishu
+ * arm of `httpIntegrationToSpec` (`orchestrator/placement.ts`), extracted for
+ * the same one-implementation reason. The daemon keeps the authenticated REST
+ * client for send/download; callbacks arrive through the relay pre-addressed.
+ * `botUserId` is the bot's own open_id (from the bot row), shipped as
+ * `botOpenId` so the daemon can skip a `bot/info` round-trip.
+ * Token-bearing — NEVER log.
+ */
+export function feishuSharedIntegrationConfig(
+  core: IntegrationCoreEnvelope,
+  secret: Pick<BotSecretMaterial, 'botToken' | 'appToken'>,
+  integration: Pick<IntegrationRecord, 'feishuRegion'>,
+  botUserId?: string
+): IntegrationFeishuConfig {
+  return {
+    mode: 'shared',
+    appId: secret.appToken ?? '',
+    appSecret: secret.botToken,
+    ...(botUserId ? { botOpenId: botUserId } : {}),
+    region: integration.feishuRegion ?? 'feishu',
+    bindRules: core.bindRules,
+    mutedChannels: core.mutedChannels,
+    gated: core.gated
+  }
+}
+
+/**
+ * The two opaque `rc/bot-assign` bags for a Feishu HTTP bot (§6.7) — the
+ * feishu fork of `buildAssign` (`orchestrator/httpBot.ts`), extracted so the
+ * live frame assembly and the provider's
+ * {@link CpPlatformProvider.projectBotAssign} share ONE implementation.
+ *
+ *  - ingress `apiAppId` — the Feishu app id, read from the SECRET row's
+ *    `appToken` slot (the two-slot overloading above); O(1) inbound demux.
+ *    (The pre-extraction inline chain nominally fell through to
+ *    `bot.slackAppId` when the slot was empty — unreachable for a feishu row,
+ *    which never persists one, so the fork is per-platform here.)
+ *  - ingress `teamId` / `botUserId` — tenant + bot open_id demux identity from
+ *    the bot row, when persisted.
+ *  - secrets — the event-subscription verification token (+ optional encrypt
+ *    key); core's completeness gate requires the verification token AND the
+ *    app id before an assign is built (`secretShape.httpAssignRequires`).
+ *    The daemon-only appSecret deliberately does NOT ride to the relay.
+ *
+ * Token-bearing — NEVER log the result.
+ */
+export function feishuBotAssignBags(
+  bot: Pick<BotRecord, 'teamId' | 'botUserId'>,
+  secret: Pick<BotSecretMaterial, 'appToken' | 'verificationToken' | 'encryptKey'>
+): { secrets: Record<string, unknown>; ingress: Record<string, unknown> } {
+  return {
+    secrets: {
+      verificationToken: secret.verificationToken ?? '',
+      ...(secret.encryptKey ? { encryptKey: secret.encryptKey } : {})
+    },
+    ingress: {
+      ...(secret.appToken ? { apiAppId: secret.appToken } : {}),
+      ...(bot.teamId ? { teamId: bot.teamId } : {}),
+      ...(bot.botUserId ? { botUserId: bot.botUserId } : {})
+    }
+  }
+}
+
+/** The provider's injected seams — the same functions/objects `container.ts`
+ *  wires into the route deps today, so the live paths and the provider share
+ *  one implementation and tests stay offline by faking exactly these. */
+export interface FeishuCpProviderDeps {
+  /** Live tenant-access-token exchange + `bot/v3/info` name/open_id derivation
+   *  (`http/feishu-identity.ts`). Absent ⇒ no credential validation (the
+   *  route's own fallback — except http transport, which then cannot resolve
+   *  the bot identity and refuses with the route's 503). */
+  verifyBot?: FeishuBotVerifier
+  /**
+   * The registration funnel's Fastify plugin, injected PRE-BOUND to the route
+   * deps (`feishuRegistrationRoutes` at `'org'`; Feishu has no browser OAuth
+   * callback — the device flow polls server-side, so `'public-callback'` is
+   * empty). Injected rather than imported (see the module doc: DTO import
+   * cycle). Absent ⇒ no funnel routes (focused tests).
+   */
+  funnelRoutes?: {
+    org: FastifyPluginAsync[]
+    publicCallback: FastifyPluginAsync[]
+  }
+  /** Cosmetic app icon push + version submit (`http/feishu-app-icon.ts`).
+   *  Absent ⇒ no icon-sync capability — presence of
+   *  `sideEffects.syncBotProfileIcon` is the capability probe
+   *  (`http/agent-bot-icon-sync.ts`). */
+  syncAppIcon?: FeishuAppIconSyncer
+  /** Pending-registration funnel state (§9 `pendingInstalls`): the store's
+   *  reap slice + the sweep interval (shared with the Slack reapers' env
+   *  knob today). The TTL is {@link FEISHU_REGISTRATION_TTL_MS}. Absent ⇒ no
+   *  funnel state declared (focused tests). */
+  pendingInstalls?: {
+    registrations: { reapExpired(staleBefore: Date): Promise<number> }
+    intervalMs: number
+  }
+}
+
+export function createFeishuCpProvider(deps: FeishuCpProviderDeps): CpPlatformProvider<FeishuCreateCredentials> {
+  const { verifyBot, funnelRoutes, syncAppIcon, pendingInstalls } = deps
+  return {
+    platformId: 'feishu',
+
+    // The one-click registration funnel rides here (contract §9): org-scoped
+    // start/poll only — no unauthenticated browser callback (device flow).
+    installRoutes: (scope) => (scope === 'org' ? (funnelRoutes?.org ?? []) : (funnelRoutes?.publicCallback ?? [])),
+
+    credentialBodySchema: FeishuCreateCredentials,
+
+    refineCreateBody: refineFeishuCreateBody,
+
+    /**
+     * The tenant-access-token exchange (validates BOTH credentials in one
+     * call) + the http-transport `openId` resolution — the live checks the
+     * create route runs before anything is stored (`integrations.ts` feishu
+     * arm), statuses and user-facing copy verbatim (none carries a machine
+     * code today). Reachability is best-effort for the socket transport (an
+     * unreachable Feishu refuses nothing — the create tail falls back to the
+     * agent name); the http transport REQUIRES a resolved bot open_id (the
+     * relay uses it to distinguish @bot from ordinary-user mentions), so an
+     * inconclusive check refuses with the route's 503 — never a 400, an
+     * unreachable provider is not proof the credentials are bad. The
+     * http-transport relay-availability check is a 409 and stays core, as do
+     * the D6 identity fence's 409s (contract §9).
+     */
+    async validateConfig(credentials, transport): Promise<CpConfigValidation> {
+      const check = verifyBot ? await verifyBot(credentials.appId, credentials.appSecret, credentials.region) : null
+      if (check?.status === 'invalid') {
+        return {
+          ok: false,
+          status: 400,
+          message:
+            'Feishu rejected the credentials — check the App ID (cli_…) and App Secret from the Developer Console (Credentials & Basic Info).'
+        }
+      }
+      // HTTP ingress cannot call Feishu with the app secret, so the CP must
+      // resolve the bot's own open_id now (route parity: 503, inconclusive).
+      if (transport === 'http' && (check?.status !== 'ok' || !check.openId)) {
+        return {
+          ok: false,
+          status: 503,
+          message: 'Could not resolve this app’s bot identity. Enable the bot capability in Feishu, then try again.'
+        }
+      }
+      // `name` is the middle rung of the create tail's name ladder;
+      // `externalAppId` is the pasted `cli_…` app id echoed back (the D6
+      // fence's key — core persists and checks it); `botUserId` is the bot's
+      // own open_id where resolved (http demux).
+      const name = check?.status === 'ok' ? check.name : null
+      const openId = check?.status === 'ok' ? check.openId : null
+      return {
+        ok: true,
+        identity: {
+          ...(name ? { name } : {}),
+          externalAppId: credentials.appId,
+          ...(openId ? { botUserId: openId } : {})
+        }
+      }
+    },
+
+    // Feishu reuses the established two-slot shape (`install-feishu.ts`):
+    // botToken = app SECRET (the credential), appToken = app ID (the
+    // identifier) — the overloading the audit found spelled only in comments,
+    // made data here. An http assign is gated on the verification token AND
+    // the app id (`httpBot.ts`: callback ingress needs both to authenticate
+    // and demux inbound POSTs).
+    secretShape: {
+      slots: {
+        botToken: 'Feishu app secret (Developer Console → Credentials & Basic Info)',
+        appToken: 'Feishu app id (cli_…; identifier, not a secret)',
+        verificationToken: 'Feishu event-subscription verification token (http only)',
+        encryptKey: 'Feishu event encrypt key (http only, optional)'
+      },
+      httpAssignRequires: ['verificationToken', 'appToken']
+    },
+
+    // The one-click registration funnel's durable state (§9): encrypted device
+    // cursor + provisional credentials, swept on a funnel-appropriate constant
+    // TTL rather than the Slack env knob — exactly today's third container
+    // reaper instance.
+    ...(pendingInstalls
+      ? {
+          pendingInstalls: [
+            {
+              model: 'FeishuAppRegistration',
+              label: 'feishu-registration',
+              store: pendingInstalls.registrations,
+              ttlMs: FEISHU_REGISTRATION_TTL_MS,
+              intervalMs: pendingInstalls.intervalMs
+            }
+          ] as const
+        }
+      : {}),
+
+    envSchema: FeishuCpEnvSchema,
+
+    // Ongoing agent-icon convergence only — the feishu create arm runs no
+    // post-create push (the one-click funnel brands the app at registration
+    // time instead, via the deeplink's avatarUrl). The app id is resolved from
+    // the secret row, falling back to public bot metadata for older rows
+    // (`http/agent-bot-icon-sync.ts` feishu arm); a row with neither is
+    // skipped — the sync is cosmetic and best-effort by contract.
+    ...(syncAppIcon
+      ? {
+          sideEffects: {
+            syncBotProfileIcon: async (bot, secrets, agent) => {
+              const appId = secrets.appToken ?? bot.feishuAppId
+              if (!appId) return
+              await syncAppIcon(appId, secrets.botToken, bot.feishuRegion ?? 'feishu', agent)
+            }
+          }
+        }
+      : {}),
+
+    // No per-user provider tooling credentials (Feishu's one-click flow rides
+    // the official device authorization, not a caller-stored config token) and
+    // no background loops (contract optionality).
+
+    // §6.4 projection: `bot.transport` is the direct-vs-shared fork itself
+    // (`integrations.ts`) — the same bodies the live `integrationToSpec` /
+    // `httpIntegrationToSpec` feishu arms call. Async by contract; Feishu
+    // maintains no additional secret store to load from. Token-bearing — NEVER log.
+    async projectIntegrationConfig(integration, bot, core, secrets) {
+      return bot.transport === 'http'
+        ? feishuSharedIntegrationConfig(core, secrets, integration, bot.botUserId ?? undefined)
+        : feishuIntegrationConfig(core, secrets, integration)
+    },
+
+    // §6.7 projection: same body as the live `buildAssign` feishu fork (both
+    // call {@link feishuBotAssignBags}). Token-bearing — NEVER log.
+    async projectBotAssign(bot, secrets) {
+      return feishuBotAssignBags(bot, secrets)
+    }
+  }
+}

--- a/packages/control-plane/src/platforms/provider.ts
+++ b/packages/control-plane/src/platforms/provider.ts
@@ -392,21 +392,31 @@ export interface CpPlatformProvider<TCredentials = unknown> {
   /**
    * Project one HTTP bot's credentials + demux identity into the two opaque
    * bags of `rc/bot-assign` (§6.7) — today's per-platform forks inside
-   * `buildAssign` (`orchestrator/httpBot.ts:897-905` the ingress bag:
+   * `buildAssign` (`orchestrator/httpBot.ts` the ingress bag:
    * Feishu's app id from `secret.appToken` vs Slack's `bot.slackAppId`, the
-   * distributed-install `teamId`, `botUserId`; `:909-915` the secrets bag:
+   * distributed-install `teamId`, `botUserId`; and the secrets bag:
    * Feishu `verificationToken`/`encryptKey` vs Slack
    * `botToken`/`signingSecret`). Everything else on the frame stays core-
    * assembled: the compiled routing table, member directory, gating fences,
-   * and `credentialRevision` (`:877-927`) — and the four-way platform ternary
-   * at `:820-828` disappears entirely under an open `PlatformId` (audit
+   * and `credentialRevision` — and the four-way platform ternary
+   * disappears entirely under an open `PlatformId` (audit
    * ambiguous row 6). Returned as `Record<string, unknown>` (not `unknown`)
    * so the product assigns to the frame's open-reader members
    * (`RcBotSecrets`' record arm / `ingress: z.unknown()`) without a cast;
    * the RELAY platform module validates the shapes (§6.7). Token-bearing —
    * NEVER log.
+   *
+   * OPTIONAL (S3 erratum): a platform without an HTTP/relay transport simply
+   * does not declare the member. Telegram and Discord keep their daemon-owned
+   * long-lived connections — the create route refuses `transport: 'http'` for
+   * them (`integrations.ts:392-400`), so no such bot row can carry the http
+   * transport and core's assign builder never sees one. Modeling that as a
+   * required member forced the first two providers into throwing refusal
+   * stubs; absence is the honest signal, and core's adoption code treats a
+   * missing member as "this platform has no relay path" (the completeness gate
+   * above never even fires — there is nothing to assign).
    */
-  projectBotAssign(
+  projectBotAssign?(
     bot: BotRecord,
     secrets: BotSecretMaterial
   ): Promise<{ secrets: Record<string, unknown>; ingress: Record<string, unknown> }>

--- a/packages/control-plane/src/platforms/registry.test.ts
+++ b/packages/control-plane/src/platforms/registry.test.ts
@@ -8,6 +8,8 @@ import { describe, it, expect, vi } from 'vitest'
 import { buildCpPlatformRegistry } from './registry.js'
 import { createTelegramCpProvider } from './telegram/provider.js'
 import { createDiscordCpProvider } from './discord/provider.js'
+import { createSlackCpProvider } from './slack/provider.js'
+import { createFeishuCpProvider } from './feishu/provider.js'
 
 const telegram = () =>
   createTelegramCpProvider({
@@ -17,6 +19,8 @@ const discord = () =>
   createDiscordCpProvider({
     ensureMessageContentIntent: vi.fn(async () => 'ready' as const)
   })
+const slack = () => createSlackCpProvider({})
+const feishu = () => createFeishuCpProvider({})
 
 describe('buildCpPlatformRegistry', () => {
   it('keys providers by platform id and misses unknown ids', () => {
@@ -35,6 +39,22 @@ describe('buildCpPlatformRegistry', () => {
     const registry = buildCpPlatformRegistry([tg, dc])
     expect(registry.all()).toEqual([tg, dc])
     expect(registry.ids()).toEqual(['telegram', 'discord'])
+  })
+
+  it('holds all four platforms — the container composition (S3 exit criterion)', () => {
+    const providers = [telegram(), discord(), slack(), feishu()]
+    const registry = buildCpPlatformRegistry(providers)
+    expect(registry.ids()).toEqual(['telegram', 'discord', 'slack', 'feishu'])
+    expect(registry.get('slack')).toBe(providers[2])
+    expect(registry.get('feishu')).toBe(providers[3])
+    // The §6.7 relay path is exactly the platforms that implement it (erratum:
+    // absence IS the "no relay path" signal).
+    expect(
+      registry
+        .all()
+        .filter((p) => p.projectBotAssign !== undefined)
+        .map((p) => p.platformId)
+    ).toEqual(['slack', 'feishu'])
   })
 
   it('fails construction on a duplicate platform id', () => {

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -1,0 +1,561 @@
+/**
+ * Slack CpPlatformProvider (§9, S3) — unit, no I/O.
+ *
+ * The load-bearing suites are the EQUIVALENCE blocks: while the live paths are
+ * still `integrationToSpec` / `httpIntegrationToSpec`
+ * (`orchestrator/placement.ts`) and `buildAssign` (`orchestrator/httpBot.ts`),
+ * the provider's `projectIntegrationConfig` / `projectBotAssign` must produce
+ * EXACTLY the payloads those paths emit for the same inputs — that equality is
+ * what makes the eventual call-site flip a zero-behavior change. The
+ * `projectBotAssign` block runs the REAL orchestrator (in-memory repos, a
+ * recording relay channel) and compares the live `rc/bot-assign` frame's two
+ * opaque bags against the provider's projection.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { FastifyPluginAsync } from 'fastify'
+import {
+  createSlackCpProvider,
+  slackAppIdFromAppToken,
+  slackBotAssignBags,
+  slackIntegrationConfig,
+  slackSharedIntegrationConfig,
+  refineSlackCreateBody,
+  SlackCpEnvSchema,
+  SlackCreateCredentials
+} from './provider.js'
+import { integrationToSpec, httpIntegrationToSpec } from '../../orchestrator/placement.js'
+import { HttpBotOrchestrator } from '../../orchestrator/httpBot.js'
+import { RelayRegistry, type RelayChannel } from '../../ws/relay-registry.js'
+import { CreateIntegrationBody } from '../../http/dto/index.js'
+import { AppConfigSchema } from '../../config/env.js'
+import type { SlackBotVerification } from '../../http/slack-identity.js'
+import type { SlackUserConfigDeps } from '../../http/slack-user-config.js'
+import type {
+  AgentRepo,
+  BotRepo,
+  BotRecord,
+  BotSecretMaterial,
+  BotSecretStore,
+  IntegrationChannelRepo,
+  IntegrationChannelRecord,
+  IntegrationRecord,
+  IntegrationRepo,
+  SessionRepo,
+  SlackUserConfigRecord,
+  ThreadAffinityStore
+} from '../../persistence/ports.js'
+import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
+import { IntegrationSlackConfig, type RcBotAssign, type RelayCpFrameType } from '@agentconnect.md/protocol'
+
+const verifierOk = (over: Partial<Extract<SlackBotVerification, { status: 'ok' }>> = {}) =>
+  vi.fn(
+    async () =>
+      ({
+        status: 'ok',
+        name: 'support-bot',
+        appId: 'A0TESTAPP',
+        teamId: 'T0TESTTEAM',
+        teamName: 'Example Workspace',
+        scopes: null,
+        ...over
+      }) as SlackBotVerification
+  )
+
+const ORG = OrgId('11111111-1111-4111-8111-111111111111')
+const AGENT_ID = AgentId('77777777-7777-4777-8777-777777777777')
+
+const INTEGRATION: IntegrationRecord = {
+  id: IntegrationId('66666666-6666-4666-8666-666666666666'),
+  orgId: ORG,
+  agentId: AGENT_ID,
+  botId: BotId('88888888-8888-4888-8888-888888888888'),
+  platform: 'slack',
+  name: 'support-bot',
+  status: 'active',
+  createdAt: new Date('2026-01-01T00:00:00Z')
+}
+
+function bot(over: Partial<BotRecord> = {}): BotRecord {
+  return {
+    id: BotId('88888888-8888-4888-8888-888888888888'),
+    orgId: ORG,
+    platform: 'slack',
+    name: 'support-bot',
+    prebuilt: false,
+    slackAppId: null,
+    teamId: null,
+    workspaceId: null,
+    workspaceName: null,
+    botUserId: null,
+    revokedAt: null,
+    credentialRevision: 1,
+    credentialInstalledAt: null,
+    externalAppId: null,
+    externalTenantId: null,
+    platformConfig: null,
+    discordAppId: null,
+    feishuAppId: null,
+    feishuRegion: null,
+    shareable: false,
+    transport: 'socket',
+    createdBy: null,
+    lastUsedAt: null,
+    lastAgentName: null,
+    agentIds: [AGENT_ID],
+    inUseByAgentId: AGENT_ID,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...over
+  }
+}
+
+// Socket bots store xoxb + xapp; http bots store xoxb + the signing secret.
+const SOCKET_SECRET: BotSecretMaterial = {
+  botToken: 'xoxb-test-token',
+  appToken: 'xapp-1-A0TESTAPP-123-abc',
+  signingSecret: null
+}
+const HTTP_SECRET: BotSecretMaterial = { botToken: 'xoxb-test-token', appToken: null, signingSecret: 'shh-secret' }
+
+const channel = (
+  channelId: string,
+  trigger: 'off' | 'mention' | 'any',
+  kind: 'channel' | 'im' | 'mpim' = 'channel'
+): IntegrationChannelRecord => ({
+  integrationId: INTEGRATION.id,
+  channelId,
+  name: channelId.toLowerCase(),
+  isPrivate: false,
+  kind,
+  trigger,
+  agentId: null
+})
+
+describe('slack provider identity + declarative facets', () => {
+  const provider = createSlackCpProvider({ verifyBot: verifierOk() })
+
+  it('declares the slack platform id', () => {
+    expect(provider.platformId).toBe('slack')
+  })
+
+  it('hands out the injected funnel plugins per mount scope, empty when uncomposed', () => {
+    // Focused composition (no funnel deps) ⇒ nothing at either scope.
+    expect(provider.installRoutes('org')).toEqual([])
+    expect(provider.installRoutes('public-callback')).toEqual([])
+    // Composed: the org-scoped wizard/config plugins and the two public OAuth
+    // callbacks come back exactly as injected (identity — same closures the
+    // composition root builds from the live route factories).
+    const org = [vi.fn(), vi.fn(), vi.fn()] as unknown as FastifyPluginAsync[]
+    const publicCallback = [vi.fn(), vi.fn()] as unknown as FastifyPluginAsync[]
+    const composed = createSlackCpProvider({ funnelRoutes: { org, publicCallback } })
+    expect(composed.installRoutes('org')).toEqual(org)
+    expect(composed.installRoutes('public-callback')).toEqual(publicCallback)
+  })
+
+  it('re-exports the same credential schema instance the create DTO composes', () => {
+    expect(provider.credentialBodySchema).toBe(SlackCreateCredentials)
+    expect(provider.credentialBodySchema.parse({ botToken: 'xoxb-1' })).toEqual({ botToken: 'xoxb-1' })
+    expect(provider.credentialBodySchema.safeParse({ botToken: '' }).success).toBe(false)
+    expect(provider.credentialBodySchema.safeParse({}).success).toBe(false)
+  })
+
+  it('packs the three-slot secret row and gates http assigns on the signing secret', () => {
+    expect(Object.keys(provider.secretShape.slots)).toEqual(['botToken', 'appToken', 'signingSecret'])
+    // The gate `HttpBotOrchestrator.syncBot` / `replayTo` apply before building
+    // an assign for a slack bot.
+    expect(provider.secretShape.httpAssignRequires).toEqual(['signingSecret'])
+  })
+
+  it('owns the install-reaper knobs + SLACK_PLATFORM_* env keys, spread into AppConfigSchema', () => {
+    expect(provider.envSchema).toBe(SlackCpEnvSchema)
+    expect(Object.keys(SlackCpEnvSchema)).toEqual([
+      'SLACK_INSTALL_TTL_SEC',
+      'SLACK_INSTALL_REAP_INTERVAL_SEC',
+      'SLACK_PLATFORM_APP_ID',
+      'SLACK_PLATFORM_CLIENT_ID',
+      'SLACK_PLATFORM_CLIENT_SECRET',
+      'SLACK_PLATFORM_SIGNING_SECRET'
+    ])
+    // One implementation: the live config schema is composed FROM this shape.
+    for (const key of Object.keys(SlackCpEnvSchema)) {
+      expect(AppConfigSchema.shape[key as keyof typeof AppConfigSchema.shape]).toBe(
+        SlackCpEnvSchema[key as keyof typeof SlackCpEnvSchema]
+      )
+    }
+  })
+
+  it('declares the two pending-install funnels from the injected stores + env TTLs', () => {
+    const installs = { reapExpired: vi.fn(async () => 0) }
+    const platformInstalls = { reapExpired: vi.fn(async () => 0) }
+    const composed = createSlackCpProvider({
+      pendingInstalls: { installs, platformInstalls, ttlMs: 3_600_000, intervalMs: 600_000 }
+    })
+    expect(composed.pendingInstalls).toEqual([
+      { model: 'SlackInstall', label: 'slack-install', store: installs, ttlMs: 3_600_000, intervalMs: 600_000 },
+      {
+        model: 'SlackPlatformInstall',
+        label: 'slack-platform-install',
+        store: platformInstalls,
+        ttlMs: 3_600_000,
+        intervalMs: 600_000
+      }
+    ])
+    expect(provider.pendingInstalls).toBeUndefined() // uncomposed ⇒ undeclared
+  })
+
+  it('wraps the injected bot-identity reconciler as the one background loop', () => {
+    const identityReconciler = { start: vi.fn(), stop: vi.fn() }
+    const composed = createSlackCpProvider({ identityReconciler })
+    expect(composed.backgroundLoops).toHaveLength(1)
+    expect(composed.backgroundLoops![0]!.label).toBe('slack-bot-identity')
+    composed.backgroundLoops![0]!.start()
+    expect(identityReconciler.start).toHaveBeenCalledTimes(1)
+    composed.backgroundLoops![0]!.stop()
+    expect(identityReconciler.stop).toHaveBeenCalledTimes(1)
+    expect(provider.backgroundLoops).toBeUndefined()
+  })
+
+  it('declares no install side effects (Slack renders per-message icon_url instead)', () => {
+    expect(provider.sideEffects).toBeUndefined()
+  })
+
+  it('implements projectBotAssign — Slack has an HTTP/relay path (S3 erratum)', () => {
+    expect(typeof provider.projectBotAssign).toBe('function')
+  })
+})
+
+describe('slack refineCreateBody (DTO parity: the create body superRefine slack arm)', () => {
+  const issues = (body: { credentials: SlackCreateCredentials; transport: 'socket' | 'http' }) => {
+    const out: string[] = []
+    refineSlackCreateBody(body, (message) => out.push(message))
+    return out
+  }
+
+  it('requires the signing secret for http and the app token for socket', () => {
+    expect(issues({ credentials: { botToken: 'xoxb-1' }, transport: 'http' })).toEqual([
+      'http transport requires slack.signingSecret'
+    ])
+    expect(issues({ credentials: { botToken: 'xoxb-1' }, transport: 'socket' })).toEqual([
+      'socket transport requires slack.appToken'
+    ])
+    expect(issues({ credentials: { botToken: 'xoxb-1', signingSecret: 's' }, transport: 'http' })).toEqual([])
+    expect(issues({ credentials: { botToken: 'xoxb-1', appToken: 'xapp-1' }, transport: 'socket' })).toEqual([])
+  })
+
+  it('is the same rule the live create DTO enforces (one implementation)', () => {
+    const base = { platform: 'slack', agentId: AGENT_ID as string }
+    const http = CreateIntegrationBody.safeParse({ ...base, transport: 'http', slack: { botToken: 'xoxb-1' } })
+    expect(http.success).toBe(false)
+    expect(http.error?.issues.map((i) => i.message)).toContain('http transport requires slack.signingSecret')
+    // An omitted transport is the create route's socket default.
+    const socket = CreateIntegrationBody.safeParse({ ...base, slack: { botToken: 'xoxb-1' } })
+    expect(socket.success).toBe(false)
+    expect(socket.error?.issues.map((i) => i.message)).toContain('socket transport requires slack.appToken')
+  })
+})
+
+describe('slack validateConfig (route parity: integrations.ts slack arm)', () => {
+  const CREDS: SlackCreateCredentials = { botToken: 'xoxb-test', appToken: 'xapp-1-A0TESTAPP-123-abc' }
+
+  it('derives the full identity from auth.test on the socket path', async () => {
+    const verifyBot = verifierOk()
+    const verifyAppToken = vi.fn(async () => 'ok' as const)
+    const provider = createSlackCpProvider({ verifyBot, verifyAppToken })
+    const result = await provider.validateConfig(CREDS, 'socket')
+    expect(verifyBot).toHaveBeenCalledWith('xoxb-test')
+    expect(verifyAppToken).toHaveBeenCalledWith('xapp-1-A0TESTAPP-123-abc')
+    expect(result).toEqual({
+      ok: true,
+      identity: {
+        name: 'support-bot',
+        externalAppId: 'A0TESTAPP',
+        workspaceId: 'T0TESTTEAM',
+        workspaceName: 'Example Workspace'
+      }
+    })
+  })
+
+  it('refuses a rejected bot token with the route’s 400 copy', async () => {
+    const provider = createSlackCpProvider({ verifyBot: vi.fn(async () => ({ status: 'invalid' as const })) })
+    expect(await provider.validateConfig(CREDS, 'socket')).toEqual({
+      ok: false,
+      status: 400,
+      message: 'Slack rejected the bot token — check you pasted the Bot User OAuth Token (xoxb-…).'
+    })
+  })
+
+  it('refuses a rejected app-level token (socket only) with the route’s 400 copy', async () => {
+    const provider = createSlackCpProvider({
+      verifyBot: verifierOk(),
+      verifyAppToken: vi.fn(async () => 'invalid' as const)
+    })
+    expect(await provider.validateConfig(CREDS, 'socket')).toEqual({
+      ok: false,
+      status: 400,
+      message:
+        'Slack rejected the app-level token — check you pasted the App-Level Token (xapp-…) and gave it the connections:write scope.'
+    })
+  })
+
+  it('refuses a bot token and app-level token from different apps', async () => {
+    const provider = createSlackCpProvider({
+      verifyBot: verifierOk({ appId: 'A0OTHERAPP' }),
+      verifyAppToken: vi.fn(async () => 'ok' as const)
+    })
+    expect(await provider.validateConfig(CREDS, 'socket')).toEqual({
+      ok: false,
+      status: 400,
+      message: 'The Slack bot token and app-level token belong to different apps.'
+    })
+    // The same derivation the route runs (relocated helper).
+    expect(slackAppIdFromAppToken(CREDS.appToken!)).toBe('A0TESTAPP')
+  })
+
+  it('never refuses on reachability: unreachable checks proceed with no derived identity', async () => {
+    const provider = createSlackCpProvider({
+      verifyBot: vi.fn(async () => ({ status: 'unreachable' as const })),
+      verifyAppToken: vi.fn(async () => 'unreachable' as const)
+    })
+    expect(await provider.validateConfig(CREDS, 'socket')).toEqual({ ok: true, identity: {} })
+  })
+
+  it('skips validation entirely when no verifier is composed (route parity)', async () => {
+    const provider = createSlackCpProvider({})
+    expect(await provider.validateConfig(CREDS, 'socket')).toEqual({ ok: true, identity: {} })
+  })
+
+  it('runs no app-token check on the http path (relay availability stays core)', async () => {
+    const verifyAppToken = vi.fn(async () => 'invalid' as const)
+    const provider = createSlackCpProvider({ verifyBot: verifierOk(), verifyAppToken })
+    const result = await provider.validateConfig({ botToken: 'xoxb-test', signingSecret: 'shh' }, 'http')
+    expect(verifyAppToken).not.toHaveBeenCalled()
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('slack providerToolingCredentials (delegation to slack-user-config)', () => {
+  const NOW = new Date('2026-01-02T00:00:00Z')
+  const row = (over: Partial<SlackUserConfigRecord> = {}): SlackUserConfigRecord => ({
+    orgId: ORG,
+    userId: 'user-1',
+    accessToken: 'xoxe.xoxp-access',
+    refreshToken: null,
+    accessExpiresAt: new Date(NOW.getTime() + 60 * 60 * 1000), // fresh for an hour
+    updatedAt: NOW,
+    ...over
+  })
+  const userConfigDeps = (stored: SlackUserConfigRecord | null): SlackUserConfigDeps => ({
+    slackConfigApi: {
+      createApp: vi.fn(),
+      exportApp: vi.fn(),
+      updateApp: vi.fn(),
+      exchangeOAuth: vi.fn(),
+      rotateConfigToken: vi.fn(async () => ({ ok: false as const, error: 'invalid_refresh_token' }))
+    } as unknown as NonNullable<SlackUserConfigDeps['slackConfigApi']>,
+    repos: {
+      slackUserConfig: {
+        get: vi.fn(async () => stored),
+        put: vi.fn(async () => {}),
+        delete: vi.fn(async () => {})
+      }
+    }
+  })
+
+  it('resolves a fresh stored access token (resolveUserConfigAccessToken body)', async () => {
+    const provider = createSlackCpProvider({ userConfigs: userConfigDeps(row()) })
+    const tooling = provider.providerToolingCredentials!
+    expect(tooling.model).toBe('SlackUserConfig')
+    expect(await tooling.resolveAccessToken(ORG, 'user-1', NOW)).toEqual({
+      ok: true,
+      accessToken: 'xoxe.xoxp-access'
+    })
+    expect(await tooling.usableNow(ORG, 'user-1', NOW)).toBe(true)
+  })
+
+  it('reports not_configured / unusable when nothing is stored', async () => {
+    const provider = createSlackCpProvider({ userConfigs: userConfigDeps(null) })
+    const tooling = provider.providerToolingCredentials!
+    expect(await tooling.resolveAccessToken(ORG, 'user-1', NOW)).toEqual({ ok: false, reason: 'not_configured' })
+    expect(await tooling.usableNow(ORG, 'user-1', NOW)).toBe(false)
+  })
+
+  it('a lapsed access-only token is expired for installs and unusable for the wizard', async () => {
+    const lapsed = row({ accessExpiresAt: new Date(NOW.getTime() - 1000) })
+    const provider = createSlackCpProvider({ userConfigs: userConfigDeps(lapsed) })
+    const tooling = provider.providerToolingCredentials!
+    expect(await tooling.resolveAccessToken(ORG, 'user-1', NOW)).toEqual({ ok: false, reason: 'expired' })
+    expect(await tooling.usableNow(ORG, 'user-1', NOW)).toBe(false)
+  })
+
+  it('is absent when no user-config seam is composed', () => {
+    expect(createSlackCpProvider({}).providerToolingCredentials).toBeUndefined()
+  })
+})
+
+describe('slack projection equivalence with the live integrationToSpec path (direct/socket)', () => {
+  const provider = createSlackCpProvider({ verifyBot: verifierOk() })
+  const SOCKET_BOT = bot()
+
+  const cases: Array<{ label: string; channels: IntegrationChannelRecord[]; gated: boolean }> = [
+    { label: 'defaults (no channels)', channels: [], gated: false },
+    {
+      label: "ungated with 'any' + muted channels",
+      channels: [channel('C1', 'any'), channel('C2', 'mention'), channel('C3', 'off'), channel('D1', 'off', 'im')],
+      gated: false
+    },
+    {
+      label: 'gated conversation-scoped rules',
+      channels: [channel('C1', 'any'), channel('C2', 'mention'), channel('C3', 'off'), channel('D1', 'any', 'im')],
+      gated: true
+    }
+  ]
+
+  for (const { label, channels, gated } of cases) {
+    it(`emits exactly the live path's config — ${label}`, async () => {
+      const spec = integrationToSpec(INTEGRATION, SOCKET_SECRET, channels, gated)
+      const projected = await provider.projectIntegrationConfig(INTEGRATION, SOCKET_BOT, spec.core!, SOCKET_SECRET)
+      expect(projected).toEqual(spec.config)
+      // Both sides satisfy the daemon reader's wire schema (§6.4).
+      expect(IntegrationSlackConfig.parse(projected)).toEqual(IntegrationSlackConfig.parse(spec.config))
+    })
+  }
+
+  it('shares one implementation with placement.ts (the extracted helper)', () => {
+    const spec = integrationToSpec(INTEGRATION, SOCKET_SECRET, [channel('C1', 'any')], false)
+    expect(slackIntegrationConfig(spec.core!, SOCKET_SECRET)).toEqual(spec.config)
+  })
+})
+
+describe('slack projection equivalence with the live httpIntegrationToSpec path (shared/http)', () => {
+  const provider = createSlackCpProvider({ verifyBot: verifierOk() })
+
+  const cases: Array<{
+    label: string
+    bot: BotRecord
+    channels: IntegrationChannelRecord[]
+    gated: boolean
+  }> = [
+    {
+      label: 'shareable bot with a provider app id',
+      bot: bot({ transport: 'http', shareable: true, slackAppId: 'A0TESTAPP' }),
+      channels: [channel('C1', 'any'), channel('C2', 'off')],
+      gated: false
+    },
+    {
+      label: 'non-shareable manual-paste bot (no app id)',
+      bot: bot({ transport: 'http', shareable: false }),
+      channels: [],
+      gated: false
+    },
+    {
+      label: 'gated member (conversation-scoped rules ride the send-only spec)',
+      bot: bot({ transport: 'http', shareable: true, slackAppId: 'A0TESTAPP' }),
+      channels: [channel('C1', 'mention'), channel('D1', 'any', 'im'), channel('C2', 'off')],
+      gated: true
+    }
+  ]
+
+  for (const { label, bot: httpBot, channels, gated } of cases) {
+    it(`emits exactly the live path's config — ${label}`, async () => {
+      // The live call sites feed the bot row's fields positionally
+      // (`placement.ts` reconcile, `httpBot.ts` pushSpecs).
+      const spec = httpIntegrationToSpec(
+        INTEGRATION,
+        HTTP_SECRET,
+        httpBot.shareable,
+        channels,
+        gated,
+        httpBot.slackAppId ?? undefined,
+        httpBot.botUserId ?? undefined
+      )
+      const projected = await provider.projectIntegrationConfig(INTEGRATION, httpBot, spec.core!, HTTP_SECRET)
+      expect(projected).toEqual(spec.config)
+      expect(IntegrationSlackConfig.parse(projected)).toEqual(IntegrationSlackConfig.parse(spec.config))
+    })
+  }
+
+  it('shares one implementation with placement.ts (the extracted helper)', () => {
+    const spec = httpIntegrationToSpec(INTEGRATION, HTTP_SECRET, true, [], false, 'A0TESTAPP')
+    expect(slackSharedIntegrationConfig(spec.core!, HTTP_SECRET, true, 'A0TESTAPP')).toEqual(spec.config)
+  })
+})
+
+// ── projectBotAssign equivalence against the LIVE rc/bot-assign frame ────────
+// A minimal real HttpBotOrchestrator: one placed member, no channels, one
+// recording relay channel. `buildAssign` is private, so the frame captured off
+// the wire IS the live path's output.
+class FakeChannel implements RelayChannel {
+  sends: { type: RelayCpFrameType; payload: unknown }[] = []
+  constructor(readonly relayId: string) {}
+  send(type: RelayCpFrameType, payload: unknown): void {
+    this.sends.push({ type, payload })
+  }
+  close(): void {}
+}
+
+async function liveAssignFrame(botRow: BotRecord, secret: BotSecretMaterial): Promise<RcBotAssign> {
+  const ch = new FakeChannel('relay-1')
+  const relayReg = new RelayRegistry()
+  relayReg.add(ch)
+  const integration: IntegrationRecord = { ...INTEGRATION, platform: botRow.platform, botId: botRow.id }
+  const bots = { get: async () => botRow, listHttpActive: async () => [botRow] }
+  const orch = new HttpBotOrchestrator(
+    bots as unknown as BotRepo,
+    { get: async () => secret } as unknown as BotSecretStore,
+    // Never reached by syncBot; present to satisfy the constructor.
+    { install: async () => 1, revoke: async () => ({ applied: false, integrationIds: [] }) },
+    { listForBot: async () => [integration] } as unknown as IntegrationRepo,
+    { listForBot: async () => [] } as unknown as IntegrationChannelRepo,
+    {
+      get: async () => ({ id: integration.agentId, name: 'alice', daemonId: 'd1', visibility: 'org' })
+    } as unknown as AgentRepo,
+    relayReg,
+    { integrationUpsert: async () => {} } as never,
+    { upsert: async () => {}, get: async () => null, listForBot: async () => [] } as unknown as ThreadAffinityStore,
+    { findThreadOwner: async () => null } as unknown as SessionRepo,
+    { info() {}, warn() {}, debug() {} }
+  )
+  await orch.syncBot(botRow.id)
+  const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign | undefined
+  if (!assign) throw new Error('live path built no rc/bot-assign for the fixture')
+  return assign
+}
+
+describe('slack projectBotAssign equivalence with the live buildAssign frame (§6.7)', () => {
+  const provider = createSlackCpProvider({ verifyBot: verifierOk() })
+
+  it('manual-paste http bot (no xapp to parse): bare secrets bag, empty ingress bag', async () => {
+    const manualPaste = bot({ transport: 'http', shareable: true })
+    const frame = await liveAssignFrame(manualPaste, HTTP_SECRET)
+    const projected = await provider.projectBotAssign!(manualPaste, HTTP_SECRET)
+    expect(projected.secrets).toEqual(frame.secrets)
+    expect(projected.ingress).toEqual(frame.ingress)
+    expect(projected).toEqual({
+      secrets: { botToken: 'xoxb-test-token', signingSecret: 'shh-secret' },
+      ingress: {} // no app id persisted — the relay verify-scans instead
+    })
+  })
+
+  it('tenant-scoped platform-app install: composite (apiAppId, teamId) + botUserId demux', async () => {
+    const platformInstall = bot({
+      transport: 'http',
+      prebuilt: true,
+      slackAppId: 'A0PLATFORM',
+      teamId: 'T0TESTTEAM',
+      botUserId: 'U0BOT'
+    })
+    const frame = await liveAssignFrame(platformInstall, HTTP_SECRET)
+    const projected = await provider.projectBotAssign!(platformInstall, HTTP_SECRET)
+    expect(projected.secrets).toEqual(frame.secrets)
+    expect(projected.ingress).toEqual(frame.ingress)
+    expect(projected.ingress).toEqual({ apiAppId: 'A0PLATFORM', teamId: 'T0TESTTEAM', botUserId: 'U0BOT' })
+  })
+
+  it('shares one implementation with httpBot.ts (the extracted helper)', async () => {
+    const quickInstall = bot({ transport: 'http', slackAppId: 'A0TESTAPP' })
+    const frame = await liveAssignFrame(quickInstall, HTTP_SECRET)
+    expect(slackBotAssignBags(quickInstall, HTTP_SECRET)).toEqual({
+      secrets: frame.secrets,
+      ingress: frame.ingress
+    })
+  })
+})

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -1,0 +1,419 @@
+/**
+ * Slack's control-plane platform provider (integration-plugin-architecture.md
+ * §9, stage S3) — built against the merged contract (`../provider.ts`) beside
+ * the Telegram/Discord pair (#574), and the first provider with the FULL §9
+ * surface: two install funnels (the config-token quick install and the
+ * platform-published "Add to Slack" app), two pending-install models with TTL
+ * reapers, provider env keys, per-user provider tooling credentials
+ * (`SlackUserConfig`), a background convergence loop (the bot-identity
+ * reconciler), and an HTTP/relay path (`projectBotAssign`).
+ *
+ * Every behavioral member delegates to the SAME functions the live paths call
+ * today, injected through {@link SlackCpProviderDeps} so tests stay offline:
+ *
+ *  - `validateConfig` → `deps.verifyBot` / `deps.verifyAppToken` — the exact
+ *    checks of the create route's slack arm (`http/routes/integrations.ts`),
+ *    statuses and user-facing copy verbatim;
+ *  - `installRoutes` → the funnel plugins, injected PRE-BOUND to the route
+ *    deps by the composition root. They are deliberately not imported here:
+ *    the funnel route modules consume the create-DTO module
+ *    (`http/dto/index.ts`), which imports this provider's credential block —
+ *    binding the factories here would close a runtime import cycle;
+ *  - `providerToolingCredentials` → `resolveUserConfigAccessToken` /
+ *    `configUsable` (`http/slack-user-config.ts`), the same resolution the
+ *    funnel start and the Settings→Bots refresh flow call;
+ *  - the wire projections → {@link slackIntegrationConfig} /
+ *    {@link slackSharedIntegrationConfig} / {@link slackBotAssignBags}, called
+ *    by BOTH the live paths (`orchestrator/placement.ts`,
+ *    `orchestrator/httpBot.ts`) and the provider (one implementation).
+ *
+ * ADOPTION SEQUENCING: nothing consumes this provider yet beyond registry
+ * construction in `container.ts` — the create route, `placement.ts`,
+ * `httpBot.ts`, `server.ts` mounting, `loadConfig`'s schema fold, and
+ * `startBackground()` remain the live paths, sharing the implementations above.
+ */
+import { z } from 'zod'
+import type { ZodRawShape } from 'zod'
+import type { FastifyPluginAsync } from 'fastify'
+import type { IntegrationCoreEnvelope, IntegrationSlackConfig } from '@agentconnect.md/protocol'
+import type { BotRecord, BotSecretMaterial } from '../../persistence/ports.js'
+import type { SlackBotVerifier, SlackAppTokenVerifier } from '../../http/slack-identity.js'
+import { configUsable, resolveUserConfigAccessToken, type SlackUserConfigDeps } from '../../http/slack-user-config.js'
+import type { CpConfigValidation, CpInstallTransport, CpPlatformProvider } from '../provider.js'
+
+/** The `slack` credential block of the `POST /integrations` create body —
+ *  relocated from `http/dto/index.ts`, which imports it back (one
+ *  implementation for the live route and the provider's
+ *  {@link CpPlatformProvider.credentialBodySchema}). The bot token is always
+ *  required; the transport-conditional requirements (socket ⇒ `appToken`,
+ *  http ⇒ `signingSecret`) live in {@link refineSlackCreateBody}. */
+export const SlackCreateCredentials = z.object({
+  botToken: z.string().min(1),
+  appToken: z.string().min(1).optional(),
+  signingSecret: z.string().min(1).optional()
+})
+export type SlackCreateCredentials = z.infer<typeof SlackCreateCredentials>
+
+/**
+ * Transport-conditional credential requirements the flat schema cannot express
+ * (§9 `refineCreateBody`) — the slack arm of the create DTO's `superRefine`,
+ * extracted so `http/dto/index.ts` and the provider share ONE implementation:
+ * Socket Mode needs the app-level xapp token; Events-API http mode needs the
+ * signing secret the relay HMAC-verifies inbound POSTs with.
+ */
+export function refineSlackCreateBody(
+  body: { credentials: SlackCreateCredentials; transport: CpInstallTransport },
+  addIssue: (message: string) => void
+): void {
+  if (body.transport === 'http') {
+    if (!body.credentials.signingSecret) addIssue('http transport requires slack.signingSecret')
+  } else if (!body.credentials.appToken) {
+    addIssue('socket transport requires slack.appToken')
+  }
+}
+
+/** App-level tokens are structured `xapp-1-{APP_ID}-{epoch}-{hex}`. The id segment
+ *  (A…) is public metadata (it appears in every app-page URL) — stored on the bot so
+ *  the console can deep-link "manage / delete the app on Slack". An unexpected shape
+ *  just leaves it null. Relocated from `http/install-slack.ts` (which re-exports it):
+ *  the provider's `validateConfig` runs the same cross-app check as the create route,
+ *  and importing it FROM the install tail would close a runtime import cycle
+ *  (`install-slack.ts` → `placement.ts` → this module). */
+export function slackAppIdFromAppToken(appToken: string): string | undefined {
+  const seg = appToken.split('-')[2]
+  return seg && /^A[A-Z0-9]+$/.test(seg) ? seg : undefined
+}
+
+/**
+ * Env keys this provider owns (§9 `envSchema`) — spread into `AppConfigSchema`
+ * by `config/env.ts` until `loadConfig` folds the registry's schemas (S3
+ * adoption), so the live schema and the provider's declaration are ONE object.
+ *
+ *  - `SLACK_INSTALL_*` — the pending-install reaper knobs
+ *    (slack-install-smoothing.md §Tier B): a `slack_install` pending row the
+ *    operator never finishes (holding a client secret + bot token) is deleted
+ *    once older than `SLACK_INSTALL_TTL_SEC`; the sweep runs every
+ *    `SLACK_INSTALL_REAP_INTERVAL_SEC`. The platform-install rows share both.
+ *  - `SLACK_PLATFORM_*` — the platform-published (distributed) Slack app
+ *    (preset-agents.md §5.3), the deployment-level "Add to Slack" app. ALL
+ *    FOUR must be set to enable the feature; any unset ⇒ absent (the
+ *    self-hosted default: the console offers only the quick-install funnel).
+ *    MUST stay `.optional()` so an image bump never fail-fasts an existing
+ *    deploy. The all-or-none partial-set fail-fast lives in
+ *    `config/slack-platform.ts` (`resolveSlackPlatformAppConfig`). The install
+ *    path additionally hard-depends on core's `PUBLIC_CP_URL` (the OAuth
+ *    callback origin) + `PUBLIC_RELAY_URL` + a connected relay
+ *    (Events-API-only).
+ */
+export const SlackCpEnvSchema = {
+  SLACK_INSTALL_TTL_SEC: z.coerce.number().int().default(3600),
+  SLACK_INSTALL_REAP_INTERVAL_SEC: z.coerce.number().int().default(600),
+  SLACK_PLATFORM_APP_ID: z.string().optional(), // A… — the distributed app's id
+  SLACK_PLATFORM_CLIENT_ID: z.string().optional(),
+  SLACK_PLATFORM_CLIENT_SECRET: z.string().optional(),
+  SLACK_PLATFORM_SIGNING_SECRET: z.string().optional()
+} satisfies ZodRawShape
+
+/**
+ * The §6.4 opaque `IntegrationSpec.config` payload for a DIRECT (socket) Slack
+ * integration — the body of `integrationToSpec`'s slack arm
+ * (`orchestrator/placement.ts`), extracted so the live placement path and the
+ * provider's projector share ONE implementation. This daemon owns the Socket
+ * Mode connection, so the app-level token rides along; a socket bot is
+ * single-agent, so it is never shareable. The routing knobs are deliberately
+ * DUPLICATED from the core envelope (§6.4 tolerant-reader window).
+ * Token-bearing — NEVER log the result.
+ */
+export function slackIntegrationConfig(
+  core: IntegrationCoreEnvelope,
+  secret: Pick<BotSecretMaterial, 'botToken' | 'appToken'>
+): IntegrationSlackConfig {
+  return {
+    mode: 'direct',
+    shareable: false,
+    botToken: secret.botToken,
+    appToken: secret.appToken ?? '',
+    bindRules: core.bindRules,
+    mutedChannels: core.mutedChannels,
+    gated: core.gated
+  }
+}
+
+/**
+ * The §6.4 payload for a SHARED (http/relay) Slack integration — the slack arm
+ * of `httpIntegrationToSpec` (`orchestrator/placement.ts`), extracted for the
+ * same one-implementation reason. Send-only: xoxb but NO appToken (credential
+ * domaining — the daemon must not be able to subscribe the event stream).
+ * `shareable` gates the daemon's in-thread "Switch agent" control;
+ * `providerAppId` is the bot row's public Slack app id (the permission-update
+ * deep link). Token-bearing — NEVER log.
+ */
+export function slackSharedIntegrationConfig(
+  core: IntegrationCoreEnvelope,
+  secret: Pick<BotSecretMaterial, 'botToken'>,
+  shareable: boolean,
+  providerAppId?: string
+): IntegrationSlackConfig {
+  return {
+    mode: 'shared',
+    shareable,
+    botToken: secret.botToken,
+    ...(providerAppId ? { appId: providerAppId } : {}),
+    bindRules: core.bindRules,
+    mutedChannels: core.mutedChannels,
+    gated: core.gated
+  }
+}
+
+/**
+ * The two opaque `rc/bot-assign` bags for a Slack HTTP bot (§6.7) — the slack
+ * fork of `buildAssign` (`orchestrator/httpBot.ts`), extracted so the live
+ * frame assembly and the provider's {@link CpPlatformProvider.projectBotAssign}
+ * share ONE implementation.
+ *
+ *  - ingress `apiAppId` — the "A…" app id (== the Events API envelope
+ *    `api_app_id`), O(1) inbound demux. Absent on a manual-paste http bot (no
+ *    xapp to parse); the relay verify-scans instead.
+ *  - ingress `teamId` — workspace "T…", present only for a distributed
+ *    (platform) app's install, where the composite (api_app_id, team_id) is
+ *    the ONLY safe demux (all sibling installs share the app id AND the
+ *    signing secret).
+ *  - ingress `botUserId` — persisted at OAuth exchange; spares an auth.test
+ *    round-trip.
+ *  - secrets — the send token + the signing secret the relay HMAC-verifies
+ *    inbound POSTs with (core's completeness gate requires it before an
+ *    assign is built — `secretShape.httpAssignRequires`).
+ *
+ * Token-bearing — NEVER log the result.
+ */
+export function slackBotAssignBags(
+  bot: Pick<BotRecord, 'slackAppId' | 'teamId' | 'botUserId'>,
+  secret: Pick<BotSecretMaterial, 'botToken' | 'signingSecret'>
+): { secrets: Record<string, unknown>; ingress: Record<string, unknown> } {
+  return {
+    secrets: { botToken: secret.botToken, signingSecret: secret.signingSecret ?? '' },
+    ingress: {
+      ...(bot.slackAppId ? { apiAppId: bot.slackAppId } : {}),
+      ...(bot.teamId ? { teamId: bot.teamId } : {}),
+      ...(bot.botUserId ? { botUserId: bot.botUserId } : {})
+    }
+  }
+}
+
+/** The provider's injected seams — the same functions/objects `container.ts`
+ *  wires into the route deps and background lifecycle today, so the live paths
+ *  and the provider share one implementation and tests stay offline by faking
+ *  exactly these. Every slot is optional: a focused test composes only the
+ *  facet it exercises, and member presence follows slot presence. */
+export interface SlackCpProviderDeps {
+  /** Live `auth.test` check (`http/slack-identity.ts`). Absent ⇒ no bot-token
+   *  validation (the route's own fallback: name derivation is skipped and the
+   *  create tail falls back to the agent name). */
+  verifyBot?: SlackBotVerifier
+  /** Live `apps.connections.open` app-level token check. Absent ⇒ no app-token
+   *  validation (route parity). */
+  verifyAppToken?: SlackAppTokenVerifier
+  /**
+   * The funnel's Fastify plugins per mount scope, injected PRE-BOUND to the
+   * route deps (`slackInstallRoutes` / `slackPlatformInstallRoutes` /
+   * `slackConfigRoutes` at `'org'`; `slackOauthCallbackRoutes` /
+   * `slackPlatformCallbackRoutes` at `'public-callback'`). Injected rather
+   * than imported: the route modules consume the create-DTO module, which
+   * imports this provider's credential block — importing the factories here
+   * would close a runtime import cycle. Each plugin self-disables when its
+   * config is absent (contract §9). Absent ⇒ no funnel routes (focused tests).
+   */
+  funnelRoutes?: {
+    org: FastifyPluginAsync[]
+    publicCallback: FastifyPluginAsync[]
+  }
+  /** The per-user App Configuration token seam (`http/slack-user-config.ts`) —
+   *  store + rotation API. `HttpDeps` is structurally assignable, so the
+   *  composition root passes the same bundle the routes get. Absent ⇒ the
+   *  platform reports no provider tooling credentials. */
+  userConfigs?: SlackUserConfigDeps
+  /** Pending-install funnel state (§9 `pendingInstalls`): the two stores'
+   *  reap slices + the shared TTL/interval from this provider's env keys
+   *  (`SLACK_INSTALL_TTL_SEC` / `SLACK_INSTALL_REAP_INTERVAL_SEC`, ms).
+   *  Absent ⇒ no funnel state declared (focused tests). */
+  pendingInstalls?: {
+    installs: { reapExpired(staleBefore: Date): Promise<number> }
+    platformInstalls: { reapExpired(staleBefore: Date): Promise<number> }
+    ttlMs: number
+    intervalMs: number
+  }
+  /** The bot-identity reconciler's lifecycle
+   *  (`orchestrator/slackBotIdentityReconciler.ts`) — the SAME instance
+   *  `startBackground()`/`shutdown` drive today. Absent ⇒ no background loop
+   *  declared. */
+  identityReconciler?: { start(): void; stop(): void }
+}
+
+export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProvider<SlackCreateCredentials> {
+  const { verifyBot, verifyAppToken, funnelRoutes, userConfigs, pendingInstalls, identityReconciler } = deps
+  return {
+    platformId: 'slack',
+
+    // Both install funnels ride here (contract §9): org-scoped wizard + config
+    // routes, and the two unauthenticated browser OAuth callbacks core mounts
+    // twice (internal `/api/v1` + the public `/v1` alias — the double mount is
+    // core's, not the provider's).
+    installRoutes: (scope) => (scope === 'org' ? (funnelRoutes?.org ?? []) : (funnelRoutes?.publicCallback ?? [])),
+
+    credentialBodySchema: SlackCreateCredentials,
+
+    refineCreateBody: refineSlackCreateBody,
+
+    /**
+     * `auth.test` + (socket) the app-level token check + the same-app
+     * cross-check — the live checks the create route runs before anything is
+     * stored (`integrations.ts` slack arm), with the route's statuses and
+     * user-facing copy verbatim (none carries a machine code today).
+     * Reachability is best-effort by contract: an unreachable Slack refuses
+     * NOTHING here (the route proceeds with no derived identity) — only a
+     * definitive rejection blocks. The http-transport relay-availability check
+     * is a 409 and stays core (contract §9: core knows the relay pool).
+     */
+    async validateConfig(credentials, transport): Promise<CpConfigValidation> {
+      const botCheck = verifyBot ? await verifyBot(credentials.botToken) : null
+      if (botCheck?.status === 'invalid') {
+        return {
+          ok: false,
+          status: 400,
+          message: 'Slack rejected the bot token — check you pasted the Bot User OAuth Token (xoxb-…).'
+        }
+      }
+      if (transport === 'socket') {
+        // Socket Mode: the app-level xapp token is required + validated against
+        // Slack. `refineCreateBody` guarantees its presence for this transport.
+        const appCheck = verifyAppToken ? await verifyAppToken(credentials.appToken!) : null
+        if (appCheck === 'invalid') {
+          return {
+            ok: false,
+            status: 400,
+            message:
+              'Slack rejected the app-level token — check you pasted the App-Level Token (xapp-…) and gave it the connections:write scope.'
+          }
+        }
+        const appTokenAppId = slackAppIdFromAppToken(credentials.appToken!)
+        if (botCheck?.status === 'ok' && botCheck.appId && appTokenAppId && botCheck.appId !== appTokenAppId) {
+          return {
+            ok: false,
+            status: 400,
+            message: 'The Slack bot token and app-level token belong to different apps.'
+          }
+        }
+      }
+      // `name` is the middle rung of the create tail's name ladder (operator →
+      // auth.test-derived → owning agent); `externalAppId` is the "A…" app id
+      // auth.test resolved; workspaceId/workspaceName are the display-only
+      // tenant metadata the create tail persists (distinct from the DEMUX
+      // `Bot.teamId`, which only the platform-app OAuth funnel writes).
+      const identity =
+        botCheck?.status === 'ok'
+          ? {
+              ...(botCheck.name ? { name: botCheck.name } : {}),
+              ...(botCheck.appId ? { externalAppId: botCheck.appId } : {}),
+              ...(botCheck.teamId ? { workspaceId: botCheck.teamId } : {}),
+              ...(botCheck.teamName ? { workspaceName: botCheck.teamName } : {})
+            }
+          : {}
+      return { ok: true, identity }
+    },
+
+    // Slack stores the literal tokens in the shared row (`install-slack.ts`):
+    // the xapp (socket) / signing secret (http) stay CP-side for the relay —
+    // the daemon never receives them. An http assign is gated on the signing
+    // secret (`httpBot.ts`: an unverifiable Events API bot must not be placed).
+    secretShape: {
+      slots: {
+        botToken: 'Slack bot user OAuth token (xoxb-…)',
+        appToken: 'Slack app-level token (xapp-…; Socket Mode only)',
+        signingSecret: 'Slack signing secret (Events API verification; http only)'
+      },
+      httpAssignRequires: ['signingSecret']
+    },
+
+    // The two pending-install funnels (§9): the config-token quick install
+    // (`SlackInstall` — holds a client secret + bot token mid-funnel) and the
+    // platform-app install (`SlackPlatformInstall` — OAuth state → tenancy, no
+    // secrets). Core instantiates the ONE shared reaper class per declaration
+    // (`orchestrator/slackInstallReaper.ts`); both share this provider's env
+    // TTL knobs, exactly like today's two container instances.
+    ...(pendingInstalls
+      ? {
+          pendingInstalls: [
+            {
+              model: 'SlackInstall',
+              label: 'slack-install',
+              store: pendingInstalls.installs,
+              ttlMs: pendingInstalls.ttlMs,
+              intervalMs: pendingInstalls.intervalMs
+            },
+            {
+              model: 'SlackPlatformInstall',
+              label: 'slack-platform-install',
+              store: pendingInstalls.platformInstalls,
+              ttlMs: pendingInstalls.ttlMs,
+              intervalMs: pendingInstalls.intervalMs
+            }
+          ] as const
+        }
+      : {}),
+
+    envSchema: SlackCpEnvSchema,
+
+    // No install-time side effects: Slack renders per-message `icon_url` from
+    // the public CP endpoint instead of a pushed bot avatar, so there is no
+    // post-create push and no ongoing icon convergence member (contract §9 —
+    // member presence is the capability probe in `http/agent-bot-icon-sync.ts`).
+
+    // Per-user provider tooling credentials (§9): the caller's stored Slack
+    // App Configuration token, resolved/rotated by the SAME functions the
+    // funnel start and the Settings→Bots refresh call
+    // (`http/slack-user-config.ts`).
+    ...(userConfigs
+      ? {
+          providerToolingCredentials: {
+            model: 'SlackUserConfig',
+            resolveAccessToken: (orgId, userId, now) => resolveUserConfigAccessToken(userConfigs, orgId, userId, now),
+            usableNow: async (orgId, userId, now) =>
+              configUsable(await userConfigs.repos.slackUserConfig.get(orgId, userId), now)
+          }
+        }
+      : {}),
+
+    // The bot-identity reconciler (backfills app/workspace identity onto
+    // pre-capture Bot rows from the stored token) — declared so
+    // `startBackground()`/shutdown can drive it without naming platforms once
+    // the registry is adopted; today's container lifecycle calls remain the
+    // live path on the same instance.
+    ...(identityReconciler
+      ? {
+          backgroundLoops: [
+            {
+              label: 'slack-bot-identity',
+              start: () => identityReconciler.start(),
+              stop: () => identityReconciler.stop()
+            }
+          ] as const
+        }
+      : {}),
+
+    // §6.4 projection: `bot.transport` is the direct-vs-shared fork itself
+    // (`integrations.ts`) — the same bodies the live `integrationToSpec` /
+    // `httpIntegrationToSpec` slack arms call. Async by contract; Slack
+    // maintains no additional secret store to load from. Token-bearing — NEVER log.
+    async projectIntegrationConfig(integration, bot, core, secrets) {
+      return bot.transport === 'http'
+        ? slackSharedIntegrationConfig(core, secrets, bot.shareable, bot.slackAppId ?? undefined)
+        : slackIntegrationConfig(core, secrets)
+    },
+
+    // §6.7 projection: same body as the live `buildAssign` slack fork (both
+    // call {@link slackBotAssignBags}). Token-bearing — NEVER log.
+    async projectBotAssign(bot, secrets) {
+      return slackBotAssignBags(bot, secrets)
+    }
+  }
+}

--- a/packages/control-plane/src/platforms/telegram/provider.test.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.test.ts
@@ -113,6 +113,12 @@ describe('telegram provider identity + declarative facets', () => {
     expect(provider.providerToolingCredentials).toBeUndefined()
     expect(provider.backgroundLoops).toBeUndefined()
   })
+
+  it('declares no projectBotAssign — Telegram has no HTTP callback ingress (S3 erratum)', () => {
+    // The create route refuses `transport: 'http'` for telegram, so no bot row
+    // can reach core's assign builder; absence IS the "no relay path" signal.
+    expect(provider.projectBotAssign).toBeUndefined()
+  })
 })
 
 describe('telegram validateConfig (route parity: integrations.ts telegram arm)', () => {
@@ -208,12 +214,5 @@ describe('telegram projection equivalence with the live integrationToSpec path',
   it('shares one implementation with placement.ts (the extracted helper)', () => {
     const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'any')], false)
     expect(telegramIntegrationConfig(spec.core!, SECRET)).toEqual(spec.config)
-  })
-})
-
-describe('telegram projectBotAssign (no HTTP ingress)', () => {
-  it('refuses: the create route never mints an http-transport telegram bot', async () => {
-    const provider = createTelegramCpProvider({ verifyBot: verifierOk() })
-    await expect(provider.projectBotAssign(BOT, SECRET)).rejects.toThrow(/no HTTP callback ingress/)
   })
 })

--- a/packages/control-plane/src/platforms/telegram/provider.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.ts
@@ -147,16 +147,12 @@ export function createTelegramCpProvider(deps: TelegramCpProviderDeps): CpPlatfo
     // maintains no additional secret store to load from. Token-bearing — NEVER log.
     async projectIntegrationConfig(integration, bot, core, secrets) {
       return telegramIntegrationConfig(core, secrets)
-    },
-
-    // Telegram has no HTTP-bot path: the create route refuses
-    // `transport: 'http'` for it (`integrations.ts:392-400`), so no Telegram
-    // bot row can carry the http transport and core's assign builder
-    // (`orchestrator/httpBot.ts`) never sees one. The contract still declares
-    // the member as required, so this is a documented refusal stub — reaching
-    // it means a bug upstream, not a recoverable condition.
-    async projectBotAssign(): Promise<never> {
-      throw new Error('telegram has no HTTP callback ingress; rc/bot-assign is never built for a telegram bot')
     }
+
+    // `projectBotAssign` is DELIBERATELY absent: Telegram has no HTTP callback
+    // ingress — the create route refuses `transport: 'http'` for it
+    // (`integrations.ts:392-400`), so no telegram bot row can carry the http
+    // transport and core's assign builder (`orchestrator/httpBot.ts`) never
+    // sees one. Absence IS the "no relay path" signal (S3 contract erratum).
   }
 }


### PR DESCRIPTION
## What

Stage S3 of the integration-plugin refactor, control-plane host: the **Slack** and **Feishu/Lark** `CpPlatformProvider` instances against the merged §9 contract (#565), matching the #574 Telegram/Discord precedent (deps-injected factories, equivalence-test blocks, registry wiring). This is the funnel-bearing pair — both platforms carry install funnels, pending-install models, and HTTP-bot (shared/relay) paths — plus one contract erratum reported by the #574 agent.

## Providers (one implementation, extract-and-reuse — never duplication)

**`platforms/slack/provider.ts`**
- `credentialBodySchema` + `refineCreateBody`: the create-DTO slack block and its transport-conditional superRefine arm relocated here; `http/dto/index.ts` imports them back (socket ⇒ `appToken`, http ⇒ `signingSecret`, messages verbatim).
- `validateConfig`: delegates to the injected `verifySlackBot` / `verifySlackAppToken` — the create route's exact checks (bot-token 400, app-token 400, same-app cross-check via the relocated `slackAppIdFromAppToken`, best-effort reachability). The http relay-availability 409 stays core per contract.
- `secretShape`: three literal slots; `httpAssignRequires: ['signingSecret']` (today's `httpBot.ts` assign gate).
- `pendingInstalls`: `SlackInstall` + `SlackPlatformInstall` declared from the injected stores + the `SLACK_INSTALL_*` env TTLs.
- `envSchema` (`SlackCpEnvSchema`): install-reaper knobs + `SLACK_PLATFORM_*`, now **spread into `AppConfigSchema`** so the live schema and the declaration are one object.
- `providerToolingCredentials`: `SlackUserConfig`, delegating to `resolveUserConfigAccessToken` / `configUsable` (the deps parameter narrowed to a structural `SlackUserConfigDeps` slice; route call sites unchanged).
- `backgroundLoops`: wraps the same `SlackBotIdentityReconciler` instance `startBackground()`/shutdown drive.
- `projectIntegrationConfig` / `projectBotAssign`: fork on `bot.transport`; bodies are the extracted helpers below.

**`platforms/feishu/provider.ts`**
- Credential block + http `verificationToken` refine relocated the same way; `region` keeps its `'lark'` default.
- `validateConfig`: delegates to `verifyFeishuBot` (tenant-access-token exchange), 400 copy verbatim, and the http-transport `openId` resolution arm (503, inconclusive — never proof the credentials are bad). D6 fence + relay 409s stay core.
- `secretShape`: the audited two-slot overloading made data (`botToken`=app secret, `appToken`=app id); `httpAssignRequires: ['verificationToken', 'appToken']`.
- `pendingInstalls`: `FeishuAppRegistration` with the 10-minute constant `FEISHU_REGISTRATION_TTL_MS` — now also the container's live reaper TTL (was an inline literal).
- `envSchema` (`FeishuCpEnvSchema`): `FEISHU/LARK_PLATFORM_*`, spread into `AppConfigSchema`.
- `sideEffects.syncBotProfileIcon`: app id from `secrets.appToken ?? bot.feishuAppId`, region default, skip-when-absent — the `agent-bot-icon-sync.ts` feishu arm's semantics.

**Shared projection bodies (live paths now call the same functions):**
- `integrationToSpec` slack/feishu arms → `slackIntegrationConfig` / `feishuIntegrationConfig`; `httpIntegrationToSpec` arms → `slackSharedIntegrationConfig` / `feishuSharedIntegrationConfig` (placement tests untouched and green).
- `buildAssign`'s §6.7 secrets/ingress forks → `slackBotAssignBags` / `feishuBotAssignBags` (the feishu helper drops the old inline chain's fall-through to `bot.slackAppId`, unreachable for feishu rows — documented).

**Funnel routes** are injected pre-bound to `HttpDeps` (`installRoutes('org')` = quick-install + platform-install + config routes; `'public-callback'` = the two OAuth callbacks; feishu = registration funnel at org scope only). They are deliberately not imported by the provider modules: the route modules consume the create-DTO module, which imports the providers' credential blocks — importing the factories back would close a runtime import cycle.

## Contract erratum: `projectBotAssign` becomes optional

Telegram/Discord have no HTTP-bot path (the create route refuses `transport: 'http'` for them), yet the required member forced #574 into throwing refusal stubs. The member is now `projectBotAssign?:`; both stubs and their tests are deleted, and the contract documents absence as the "platform has no relay path" signal for core's adoption code. Slack and Feishu DO implement it.

## Registry

`container.ts` now registers **all four** providers (S3 exit criterion), constructed after `httpDeps` + the reconciler so the funnel plugins and background loop share the live instances. Nothing consumes the registry yet beyond construction — create-route/projector/mounting/schema-fold adoption stays a follow-up.

## Equivalence tests (the load-bearing blocks)

- `projectIntegrationConfig` vs `integrationToSpec` (direct) AND `httpIntegrationToSpec` (shared) outputs, per platform, across gated/muted/legacy-region variants — plus wire-schema parses on both sides.
- `projectBotAssign` vs the **live `rc/bot-assign` frame** captured off a real `HttpBotOrchestrator` (in-memory repos, recording relay channel): a socket-less manual-paste http Slack bot (empty ingress bag), a tenant-scoped platform-app install (`apiAppId`+`teamId`+`botUserId`), a Feishu http fixture (secrets bag never carries the app secret), and a plaintext-events Feishu app (`encryptKey` omitted, not empty).
- DTO parity: `CreateIntegrationBody` still rejects with the exact refine messages; schema instances are identity-shared; `AppConfigSchema.shape[key]` is identity-equal to the providers' env shapes.

## Verification

- `pnpm --filter @agentconnect.md/control-plane typecheck` — clean
- CP unit suite: 123 files / 1133 tests passed
- CP integration suite (Docker, 4 workers): 70 files / 955 tests passed
- eslint + prettier clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)