### PR TITLE
feat(web): refine worktree selector

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -787,6 +787,12 @@ and the stable worktree of any visible, unpurged session. Session details link b
 session-scoped Workspace view. A session worktree is browse-only in the console:
 file editing and pull remain actions on the primary workspace.
 
+The checkout selector and workspace source form one context card. Its `Viewing`
+row names the primary checkout or session worktree currently shown; the `Source`
+row directly beneath it names the repository or scratch workspace that provides
+those files. Worktree choices keep their Session link in the selector so changing
+the viewed files and opening the originating conversation remain distinct actions.
+
 Workspace changes are cold edits: active work is drained and existing cached
 credentials are cleared before the new definition becomes active. Any edit that removes
 write workspace authority for a repository must be rejected while an enabled GitHub

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -783,9 +783,12 @@ Playground may override `Worktree` before its first turn without changing the Ag
 automatic triggers use the Agent setting.
 
 The Workspace tab lets an authorized viewer switch between the primary checkout
-and the stable worktree of any visible, unpurged session. Session details link back to that
-session-scoped Workspace view. A session worktree is browse-only in the console:
-file editing and pull remain actions on the primary workspace.
+and the stable worktree of any visible, unpurged session. Session details place a
+Workspace link immediately before Details. For an unpurged session-scoped GitHub
+checkout, it opens that session's worktree; for a shared GitHub checkout or Scratch,
+it opens the Agent's primary workspace. Its git or folder icon reflects that source.
+A session worktree is browse-only in the console: file editing and pull remain actions
+on the primary workspace.
 
 The checkout selector and workspace source form one context card. Its `Viewing`
 row names the primary checkout or session worktree currently shown; the `Source`

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -24,7 +24,7 @@
 // (the design's inline add-expander is skipped — established precedent: the
 // modal owns the picker/tier/preflight flow).
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import { GithubMark, LoadingState } from '@/components/marks'
@@ -81,10 +81,14 @@ const SEG_OFF_LOCKED =
 export function WorkspaceCard({
   agent,
   header,
+  viewing,
   className
 }: {
   agent: Agent
   header?: WorkspaceHeaderInfo
+  /** Current checkout selector. It shares this context card with Source so the
+   *  first row answers what is being viewed and the second where it comes from. */
+  viewing?: ReactNode
   className?: string
 }) {
   const { activeOrg } = useOrgs()
@@ -158,7 +162,8 @@ export function WorkspaceCard({
     mode === ws.mode ? (canEdit ? SEG_ON : SEG_ON_LOCKED) : canEdit ? SEG_OFF : SEG_OFF_LOCKED
 
   return (
-    <div className={`card overflow-hidden max-desktop:rounded-lg ${className ?? ''}`}>
+    <div className={`card relative max-desktop:rounded-lg ${className ?? ''}`}>
+      {viewing}
       {/* Source row — conversion segment, then the workspace identity and its
           live git actions. Wraps on narrow viewports; nothing is truncated away. */}
       <div className="flex flex-wrap items-center gap-[10px] px-4 py-[9px]">

--- a/packages/web/src/components/console/WorkspaceScopePicker.test.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { children: ReactNode }) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  )
+}))
+
+import { WorkspaceScopePicker, worktreeIdentity } from './WorkspaceScopePicker'
+import type { Session } from '@/lib/data'
+
+let root: Root | undefined
+let container: HTMLDivElement | undefined
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+function session(overrides: Partial<Session>): Session {
+  return {
+    id: 'session-576',
+    title: 'PR #576: fix(auth): make selected visibility explicit',
+    time: '3:09 PM',
+    status: 'online',
+    platform: 'hook',
+    channel: 'GitHub',
+    user: 'GitHub',
+    duration: '1m',
+    tokens: '2.1K',
+    cost: '$0.01',
+    toolCount: '1',
+    statusLabel: 'completed',
+    steps: [],
+    workspaceIsolation: 'session',
+    ...overrides
+  }
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  container?.remove()
+  root = undefined
+  container = undefined
+})
+
+describe('WorkspaceScopePicker', () => {
+  it('separates a PR coordinate from its title', () => {
+    expect(worktreeIdentity(session({}), 'session-576')).toEqual({
+      context: 'PR #576',
+      title: 'fix(auth): make selected visibility explicit',
+      fullTitle: 'PR #576: fix(auth): make selected visibility explicit'
+    })
+  })
+
+  it('opens the worktree menu and keeps selection separate from Session navigation', async () => {
+    const onChange = vi.fn()
+    const onLoadMore = vi.fn()
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () =>
+      root?.render(
+        <WorkspaceScopePicker
+          sessions={[
+            session({}),
+            session({ id: 'session-568', title: 'PR #568: bind the conversation audience', time: '3:10 PM' }),
+            session({ id: 'session-shared', workspaceIsolation: 'shared' }),
+            session({ id: 'session-purged', contentPurgedAt: '2026-08-04T00:00:00.000Z' })
+          ]}
+          selectedSessionId="session-576"
+          selectedSession={session({})}
+          loading={false}
+          hasMore
+          loadingMore={false}
+          onChange={onChange}
+          onLoadMore={onLoadMore}
+          orgPath={(path) => `/agentconnect${path}`}
+        />
+      )
+    )
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-label^="Workspace checkout:"]')!
+    expect(trigger.textContent).toContain('PR #576')
+    expect(trigger.textContent).toContain('fix(auth): make selected visibility explicit')
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('/agentconnect/sessions/session-576')
+
+    await act(async () => trigger.click())
+
+    const menu = container.querySelector<HTMLElement>('[role="menu"]')!
+    expect(menu.textContent).toContain('Primary checkout')
+    expect(menu.textContent).toContain('Worktrees·2')
+    expect(menu.textContent).toContain('PR #568')
+    expect(menu.textContent).toContain('3:10 PM')
+    expect(menu.textContent).toContain('Showing 2 recent worktrees')
+
+    const other = Array.from(menu.querySelectorAll<HTMLButtonElement>('[data-workspace-choice]')).find((choice) =>
+      choice.textContent?.includes('PR #568')
+    )!
+    await act(async () => other.click())
+    expect(onChange).toHaveBeenCalledWith('session-568')
+    expect(container.querySelector('[role="menu"]')).toBeNull()
+
+    await act(async () => trigger.click())
+    const loadOlder = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent === 'Load older'
+    )!
+    await act(async () => loadOlder.click())
+    expect(onLoadMore).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/web/src/components/console/WorkspaceScopePicker.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.tsx
@@ -1,12 +1,31 @@
 'use client'
 
 import Link from 'next/link'
+import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
 import { Icon } from '@/components/ui'
 import type { Session } from '@/lib/data'
 
-function worktreeLabel(session: Pick<Session, 'id' | 'title' | 'time'>): string {
-  const title = session.title.trim() || `Session ${session.id.slice(0, 8)}`
-  return `Worktree · ${title}${session.time && session.time !== '—' ? ` · ${session.time}` : ''}`
+type WorktreeIdentity = {
+  context?: string
+  title: string
+  fullTitle: string
+}
+
+/** Split GitHub session titles such as `PR #576: fix(auth): …` into
+ *  the stable review coordinate and the human-authored title. Other session
+ *  titles stay intact instead of being guessed into GitHub-shaped fields. */
+export function worktreeIdentity(
+  session: Pick<Session, 'id' | 'title'> | undefined,
+  fallbackId: string
+): WorktreeIdentity {
+  const fullTitle = session?.title.trim() || `Session ${fallbackId.slice(0, 8)}`
+  const match = /^(PR|Issue)\s+((?:[\w.-]+\/[\w.-]+)?#\d+):?\s*(.*)$/i.exec(fullTitle)
+  if (!match) return { title: fullTitle, fullTitle }
+  return {
+    context: `${match[1]!.toLowerCase() === 'pr' ? 'PR' : 'Issue'} ${match[2]!}`,
+    title: match[3]!.trim(),
+    fullTitle
+  }
 }
 
 export function WorkspaceScopePicker({
@@ -30,61 +49,283 @@ export function WorkspaceScopePicker({
   onLoadMore: () => void
   orgPath: (path: string) => string
 }) {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const menuId = useId()
   const worktrees = sessions.filter(
     (session) => session.workspaceIsolation === 'session' && session.contentPurgedAt === undefined
   )
-  const selectedInList = selectedSessionId ? worktrees.some((session) => session.id === selectedSessionId) : true
+  const selectedWorktree = selectedSessionId
+    ? (worktrees.find((session) => session.id === selectedSessionId) ?? selectedSession)
+    : undefined
+  const menuWorktrees =
+    selectedWorktree && !worktrees.some((session) => session.id === selectedWorktree.id)
+      ? [selectedWorktree, ...worktrees]
+      : worktrees
+  const selectedIdentity = selectedSessionId ? worktreeIdentity(selectedWorktree, selectedSessionId) : undefined
+
+  useEffect(() => {
+    if (!open) return
+    const frame = requestAnimationFrame(() => {
+      menuRef.current?.querySelector<HTMLButtonElement>('[data-workspace-choice][aria-checked="true"]')?.focus()
+    })
+    const closeOnEscape = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      setOpen(false)
+      requestAnimationFrame(() => triggerRef.current?.focus())
+    }
+    document.addEventListener('keydown', closeOnEscape, true)
+    return () => {
+      cancelAnimationFrame(frame)
+      document.removeEventListener('keydown', closeOnEscape, true)
+    }
+  }, [open])
+
+  const openFromKeyboard = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+    event.preventDefault()
+    setOpen(true)
+  }
+
+  const moveChoiceFocus = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
+      if (event.key === 'Tab') setOpen(false)
+      return
+    }
+    event.preventDefault()
+    const choices = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('[data-workspace-choice]'))
+    if (choices.length === 0) return
+    const focused = choices.indexOf(document.activeElement as HTMLButtonElement)
+    const selected = choices.findIndex((choice) => choice.getAttribute('aria-checked') === 'true')
+    const current = focused >= 0 ? focused : Math.max(0, selected)
+    const next =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? choices.length - 1
+          : (current + (event.key === 'ArrowDown' ? 1 : -1) + choices.length) % choices.length
+    choices[next]?.focus()
+  }
+
+  const pick = (sessionId: string | null) => {
+    setOpen(false)
+    onChange(sessionId)
+    requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+
+  const sessionHref = (sessionId: string) => orgPath(`/sessions/${encodeURIComponent(sessionId)}`)
 
   return (
-    <div className="card flex flex-wrap items-center gap-[10px] px-4 py-[9px] max-desktop:rounded-lg">
+    <div
+      className={`relative flex flex-wrap items-center gap-[10px] border-b border-(--border-subtle) px-4 py-[9px] ${open ? 'z-30' : ''}`}
+    >
       <span className="eyebrow flex-none text-[10.5px]">Viewing</span>
-      <span className="flex h-7 min-w-0 flex-[1_1_260px] items-center gap-2 rounded-md border border-(--border-subtle) bg-(--surface-card) px-2 focus-within:border-(--brand)">
-        <Icon name={selectedSessionId ? 'git-branch' : 'folder-git-2'} size={13} className="flex-none" />
-        <select
-          value={selectedSessionId ?? ''}
-          aria-label="Workspace checkout"
-          onChange={(event) => onChange(event.target.value || null)}
-          className="min-w-0 flex-1 border-0 bg-transparent font-sans text-[12.5px] font-medium leading-normal text-(--text-primary) outline-none"
+      <div className="relative min-w-0 flex-[1_1_360px]">
+        <div
+          className={`flex h-8 min-w-0 items-center overflow-hidden rounded-md border bg-(--surface-card) ${
+            open
+              ? 'border-(--border-focus) ring-[3px] ring-(--brand-ring)'
+              : 'border-(--border-subtle) hover:border-(--border-strong) hover:bg-(--surface-hover) focus-within:border-(--border-focus) focus-within:ring-[3px] focus-within:ring-(--brand-ring)'
+          }`}
         >
-          <option value="">Primary checkout</option>
-          {!selectedInList && selectedSessionId ? (
-            <option value={selectedSessionId}>
-              {selectedSession ? worktreeLabel(selectedSession) : `Worktree · ${selectedSessionId.slice(0, 8)}`}
-            </option>
+          <button
+            ref={triggerRef}
+            type="button"
+            className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-2 border-0 bg-transparent px-2 text-left text-(--text-primary) outline-none"
+            aria-label={`Workspace checkout: ${selectedIdentity?.fullTitle ?? 'Primary checkout'}`}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            aria-controls={open ? menuId : undefined}
+            onClick={() => setOpen((current) => !current)}
+            onKeyDown={openFromKeyboard}
+          >
+            <Icon
+              name={selectedSessionId ? 'git-branch' : 'folder-git-2'}
+              size={14}
+              className="flex-none text-(--text-tertiary)"
+            />
+            {selectedIdentity ? (
+              <span className="flex min-w-0 flex-1 items-baseline gap-2" title={selectedIdentity.fullTitle}>
+                {selectedIdentity.context ? (
+                  <span className="flex-none font-sans text-[12.5px] font-semibold leading-normal">
+                    {selectedIdentity.context}
+                  </span>
+                ) : null}
+                {selectedIdentity.title ? (
+                  <span
+                    className={`truncate font-sans text-[12.5px] leading-normal ${
+                      selectedIdentity.context
+                        ? 'font-normal text-(--text-secondary)'
+                        : 'font-medium text-(--text-primary)'
+                    }`}
+                  >
+                    {selectedIdentity.title}
+                  </span>
+                ) : null}
+              </span>
+            ) : (
+              <>
+                <span className="truncate font-sans text-[12.5px] font-semibold leading-normal">Primary checkout</span>
+                <span className="mono ml-auto flex-none text-[11px] text-(--text-tertiary)">HEAD</span>
+              </>
+            )}
+          </button>
+
+          {selectedSessionId ? (
+            <Link
+              href={sessionHref(selectedSessionId)}
+              className="mx-1 inline-flex h-6 flex-none items-center gap-[5px] rounded-sm border border-(--border-default) bg-(--surface-card) px-[7px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) no-underline hover:border-(--border-strong) hover:bg-(--surface-hover) hover:text-(--text-primary)"
+              title="Open this session"
+              onClick={() => setOpen(false)}
+            >
+              <Icon name="messages-square" size={12} />
+              <span className="max-desktop:hidden">Session</span>
+              <Icon name="arrow-up-right" size={11} className="max-desktop:hidden" />
+            </Link>
           ) : null}
-          {worktrees.map((session) => (
-            <option key={session.id} value={session.id}>
-              {worktreeLabel(session)}
-            </option>
-          ))}
-        </select>
-      </span>
 
-      {selectedSessionId ? (
-        <Link
-          href={orgPath(`/sessions/${encodeURIComponent(selectedSessionId)}`)}
-          className="lnk flex-none text-[12px] text-(--text-secondary)"
-          title="Open this session"
-        >
-          <Icon name="messages-square" size={13} />
-          Session
-        </Link>
-      ) : null}
+          <button
+            type="button"
+            className="flex h-full w-9 flex-none cursor-pointer items-center justify-center border-0 border-l border-(--border-subtle) bg-transparent text-(--text-tertiary) outline-none hover:bg-(--surface-hover) hover:text-(--text-primary)"
+            aria-label={open ? 'Close workspace checkout menu' : 'Open workspace checkout menu'}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            aria-controls={open ? menuId : undefined}
+            title={open ? 'Close checkout menu' : 'Choose checkout'}
+            onClick={() => setOpen((current) => !current)}
+            onKeyDown={openFromKeyboard}
+          >
+            <Icon name="chevron-down" size={14} className={open ? 'rotate-180' : ''} />
+          </button>
+        </div>
 
-      {hasMore ? (
-        <button
-          type="button"
-          onClick={onLoadMore}
-          disabled={loadingMore}
-          className="lnk flex-none border-0 bg-transparent text-[12px] disabled:cursor-default disabled:opacity-50"
-        >
-          {loadingMore ? 'Loading…' : 'Load older'}
-        </button>
-      ) : loading && worktrees.length === 0 ? (
-        <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-          Loading worktrees…
-        </span>
-      ) : null}
+        {open ? (
+          <>
+            <span className="fixed inset-0 z-20" aria-hidden onClick={() => setOpen(false)} />
+            <div
+              ref={menuRef}
+              id={menuId}
+              role="menu"
+              aria-label="Workspace checkout"
+              className="fmenu right-0 left-auto z-30 w-full max-h-none min-w-0 overflow-hidden rounded-lg p-0 shadow-(--shadow-lg)"
+              onKeyDown={moveChoiceFocus}
+            >
+              <button
+                type="button"
+                role="menuitemradio"
+                aria-checked={selectedSessionId === null}
+                data-workspace-choice
+                className={`fopt min-h-11 rounded-none px-4 text-[12.5px] outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--brand) ${
+                  selectedSessionId === null ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)' : ''
+                }`}
+                onClick={() => pick(null)}
+              >
+                <Icon name={selectedSessionId === null ? 'check' : 'folder-git-2'} size={15} className="flex-none" />
+                <span className="flex-1 font-semibold">Primary checkout</span>
+                <span className="mono flex-none text-[11.5px] text-(--text-tertiary)">HEAD</span>
+              </button>
+
+              <div className="border-t border-(--border-subtle)">
+                <div className="eyebrow flex h-9 items-center gap-2 px-4 text-[10.5px]">
+                  <span>Worktrees</span>
+                  <span aria-hidden>·</span>
+                  <span>{menuWorktrees.length}</span>
+                </div>
+                <div className="max-h-[320px] overflow-y-auto">
+                  {menuWorktrees.map((session) => {
+                    const identity = worktreeIdentity(session, session.id)
+                    const selected = session.id === selectedSessionId
+                    return (
+                      <div
+                        key={session.id}
+                        className={`flex min-h-[52px] items-center ${
+                          selected
+                            ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
+                            : 'hover:bg-(--surface-hover)'
+                        }`}
+                      >
+                        <button
+                          type="button"
+                          role="menuitemradio"
+                          aria-checked={selected}
+                          data-workspace-choice
+                          className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 self-stretch border-0 bg-transparent px-4 py-2 text-left text-inherit outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--brand)"
+                          title={identity.fullTitle}
+                          onClick={() => pick(session.id)}
+                        >
+                          <Icon name={selected ? 'check' : 'git-branch'} size={15} className="flex-none" />
+                          <span className="flex min-w-0 flex-1 items-baseline gap-2">
+                            {identity.context ? (
+                              <span className="flex-none font-sans text-[12.5px] font-semibold leading-normal">
+                                {identity.context}
+                              </span>
+                            ) : null}
+                            {identity.title ? (
+                              <span
+                                className={`truncate font-sans text-[12.5px] leading-normal ${
+                                  selected
+                                    ? 'font-normal text-(--brand-soft-text)'
+                                    : identity.context
+                                      ? 'font-normal text-(--text-secondary)'
+                                      : 'font-medium text-(--text-primary)'
+                                }`}
+                              >
+                                {identity.title}
+                              </span>
+                            ) : null}
+                          </span>
+                          {session.time && session.time !== '—' ? (
+                            <span className="mono flex-none text-[11.5px] text-(--text-tertiary)">{session.time}</span>
+                          ) : null}
+                        </button>
+                        <Link
+                          href={sessionHref(session.id)}
+                          className="mr-3 inline-flex h-7 flex-none items-center gap-[5px] rounded-sm border border-(--border-default) bg-(--surface-card) px-2 font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) no-underline hover:border-(--border-strong) hover:bg-(--surface-hover) hover:text-(--text-primary)"
+                          title="Open this session"
+                          onClick={() => setOpen(false)}
+                        >
+                          <Icon name="messages-square" size={12} />
+                          <span className="max-desktop:hidden">Session</span>
+                          <Icon name="arrow-up-right" size={11} className="max-desktop:hidden" />
+                        </Link>
+                      </div>
+                    )
+                  })}
+                  {loading && menuWorktrees.length === 0 ? (
+                    <div className="px-4 py-5 text-center font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                      Loading worktrees…
+                    </div>
+                  ) : !hasMore && menuWorktrees.length === 0 ? (
+                    <div className="px-4 py-5 text-center font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                      No session worktrees yet.
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+
+              {(menuWorktrees.length > 0 || hasMore) && (
+                <div className="flex min-h-10 items-center gap-3 border-t border-(--border-subtle) bg-(--surface-app) px-4 py-2">
+                  <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                    Showing {menuWorktrees.length} recent worktree{menuWorktrees.length === 1 ? '' : 's'}
+                  </span>
+                  {hasMore ? (
+                    <button
+                      type="button"
+                      onClick={onLoadMore}
+                      disabled={loadingMore}
+                      className="lnk ml-auto flex-none text-[12px] disabled:cursor-default disabled:opacity-50"
+                    >
+                      {loadingMore ? 'Loading…' : 'Load older'}
+                    </button>
+                  ) : null}
+                </div>
+              )}
+            </div>
+          </>
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1624,28 +1624,6 @@ export default function AgentDetailView() {
       {tab === 'workspace' &&
         (!da.name.startsWith(MOCK_PREFIX) ? (
           <div className="flex flex-col gap-4 p-4 desktop:p-0">
-            {da.workspace.mode === 'github' &&
-              (da.workspace.worktree === true ||
-                selectedWorktreeSessionId !== null ||
-                workspaceSessionsNextCursor !== null ||
-                workspaceSessions.some((session) => session.workspaceIsolation === 'session')) && (
-                <WorkspaceScopePicker
-                  sessions={workspaceSessions}
-                  selectedSessionId={selectedWorktreeSessionId}
-                  selectedSession={selectedWorktreeSession}
-                  loading={workspaceSessionsLoading}
-                  hasMore={workspaceSessionsNextCursor !== null}
-                  loadingMore={workspaceSessionsLoadingMore}
-                  onLoadMore={() => void loadMoreWorkspaceSessions()}
-                  onChange={(sessionId) => {
-                    const next = new URLSearchParams(params)
-                    if (sessionId) next.set('worktree', sessionId)
-                    else next.delete('worktree')
-                    router.replace(`${orgPath(`/agents/${id}`)}?${next.toString()}`, { scroll: false })
-                  }}
-                  orgPath={orgPath}
-                />
-              )}
             {/* Keyed by workspace identity: the editor now lives in the card
                 this instance renders, so a replacement must remount the browser
                 instead of leaving the previous tree/preview/git state beneath a
@@ -1656,7 +1634,36 @@ export default function AgentDetailView() {
               {...(selectedWorktreeSessionId ? { sessionId: selectedWorktreeSessionId } : {})}
               workdir={da.workdir}
               canEdit={selectedWorktreeSessionId === null && da.workspace.mode === 'scratch' && da.canEdit}
-              renderHeader={(header) => <WorkspaceCard agent={da} header={header} />}
+              renderHeader={(header) => (
+                <WorkspaceCard
+                  agent={da}
+                  header={header}
+                  viewing={
+                    da.workspace.mode === 'github' &&
+                    (da.workspace.worktree === true ||
+                      selectedWorktreeSessionId !== null ||
+                      workspaceSessionsNextCursor !== null ||
+                      workspaceSessions.some((session) => session.workspaceIsolation === 'session')) ? (
+                      <WorkspaceScopePicker
+                        sessions={workspaceSessions}
+                        selectedSessionId={selectedWorktreeSessionId}
+                        selectedSession={selectedWorktreeSession}
+                        loading={workspaceSessionsLoading}
+                        hasMore={workspaceSessionsNextCursor !== null}
+                        loadingMore={workspaceSessionsLoadingMore}
+                        onLoadMore={() => void loadMoreWorkspaceSessions()}
+                        onChange={(sessionId) => {
+                          const next = new URLSearchParams(params)
+                          if (sessionId) next.set('worktree', sessionId)
+                          else next.delete('worktree')
+                          router.replace(`${orgPath(`/agents/${id}`)}?${next.toString()}`, { scroll: false })
+                        }}
+                        orgPath={orgPath}
+                      />
+                    ) : undefined
+                  }
+                />
+              )}
             />
           </div>
         ) : (

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2111,10 +2111,17 @@ export default function SessionDetailView() {
   const pgImage = getPgImage(session.id)
   const pgQueue = getPgQueue(session.id)
   const agentHref = session.agentId ? `/agents/${session.agentId}` : null
-  const workspaceHref =
-    currentSessionDetail?.workspaceIsolation === 'session' && !currentSessionDetail.contentPurgedAt && session.agentId
-      ? `/agents/${session.agentId}?tab=workspace&worktree=${encodeURIComponent(currentSessionDetail.id)}`
-      : null
+  const hasSessionWorktree =
+    owner?.workspace.mode === 'github' &&
+    currentSessionDetail?.workspaceIsolation === 'session' &&
+    !currentSessionDetail.contentPurgedAt
+  const workspaceHref = session.agentId
+    ? `/agents/${session.agentId}?tab=workspace${
+        hasSessionWorktree ? `&worktree=${encodeURIComponent(currentSessionDetail.id)}` : ''
+      }`
+    : null
+  const workspaceIcon = owner?.workspace.mode === 'github' ? 'git-branch' : 'folder'
+  const workspaceTitle = hasSessionWorktree ? 'Open this session’s worktree' : 'Open this agent’s workspace'
   const liveSteps = isWebchat ? getLiveSteps(session.id) : []
 
   // The conversation roster, for EVERY live surface — the synthetic playground and
@@ -2755,16 +2762,6 @@ export default function SessionDetailView() {
               <span className="truncate">{session.agentName}</span>
             </span>
           )}
-          {workspaceHref ? (
-            <Link
-              className="lnk flex-none text-[12.5px] text-(--text-secondary)"
-              href={orgPath(workspaceHref)}
-              title="Open this session’s worktree"
-            >
-              <Icon name="folder-git-2" size={13} />
-              Workspace
-            </Link>
-          ) : null}
           <span className="inline-flex min-w-0 flex-[0_1_auto] items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
             <span className="imark h-5 w-5 flex-none rounded-xs">
               <PlatformMark platform={channelDisplay.platform} />
@@ -2804,6 +2801,16 @@ export default function SessionDetailView() {
             </span>
           )}
           {visibilityControl}
+          {workspaceHref ? (
+            <Link
+              className="lnk flex-none text-[12.5px] text-(--text-secondary)"
+              href={orgPath(workspaceHref)}
+              title={workspaceTitle}
+            >
+              <Icon name={workspaceIcon} size={13} />
+              Workspace
+            </Link>
+          ) : null}
           {/* `flex` on the wrapper: an inline-flex button in a block div sits on a text
             baseline, and the descender gap under it pushed the button off the row's
             centre line. The transparent top padding bridges the trigger/panel gap so
@@ -2882,17 +2889,17 @@ export default function SessionDetailView() {
               </span>
             </span>
           )}
+          {visibilityControl}
           {workspaceHref ? (
             <Link
               href={orgPath(workspaceHref)}
               className="iconbtn flex h-[26px] w-[26px] flex-none items-center justify-center no-underline"
-              title="Open this session’s worktree"
-              aria-label="Open this session’s worktree"
+              title={workspaceTitle}
+              aria-label={workspaceTitle}
             >
-              <Icon name="folder-git-2" size={14} />
+              <Icon name={workspaceIcon} size={14} />
             </Link>
           ) : null}
-          {visibilityControl}
           <button
             type="button"
             onClick={toggleDetailTap}


### PR DESCRIPTION
## Summary

- merge the worktree checkout selector into the Workspace source card as a clear Viewing / Source context bar
- replace the native select with a richer menu showing PR or issue identity, title, time, selected state, pagination, and an independent Session link
- place the Session Workspace link immediately before Details, using a git or folder icon and falling back to the primary workspace for shared GitHub and Scratch sessions
- preserve keyboard navigation and responsive behavior, and document the Workspace context convention

## Validation

- `pnpm --filter @agentconnect.md/web test` (729 tests)
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm lint`
- `pnpm format:check`
- desktop and 390px mobile visual QA

Created by Codex . GPT-5.6
