### PR TITLE
fix(cp): a deleted daemon leaves its agents unplaced AND inactive

### DIFF
--- a/packages/control-plane/prisma/migrations/20260804110000_unplaced_agent_status_backfill/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260804110000_unplaced_agent_status_backfill/migration.sql
@@ -1,0 +1,11 @@
+-- `Agent.daemonId` and `Agent.status` are two columns that must agree: unplaced ⇒
+-- `inactive`. Only the repo's setPlacement/movePlacement wrote them as a pair, so
+-- deleting a daemon (whose FK is `ON DELETE SET NULL`) cleared the placement while
+-- leaving `status = 'active'` behind — the console then painted those agents online
+-- and the `status = 'active'` gates kept treating them as runnable.
+--
+-- The route now unplaces explicitly before the delete; this reconciles the rows that
+-- already drifted. `configRevision` is deliberately NOT bumped: these agents have no
+-- owning daemon, so there is no recipient whose applied revision could be confused.
+
+UPDATE "agent" SET "status" = 'inactive' WHERE "daemonId" IS NULL AND "status" = 'active';

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -316,6 +316,14 @@ export function daemonRoutes(deps: HttpDeps) {
         // Capture the placed agents BEFORE the delete: the agent FK is SetNull,
         // so their placement silently clears with the row.
         const placedAgents = await deps.repos.agent.listForDaemon(DaemonId(req.params.id))
+        // Unplace them EXPLICITLY first. The FK's SetNull clears `daemonId` in the DB
+        // but never touches `Agent.status` — `setPlacement` is the only writer that
+        // pairs the two — so a delete alone leaves `daemonId: null, status: 'active'`
+        // and every reader (console badge, `status !== 'active'` gates) sees a live
+        // agent with nowhere to run. Going through the repo also revokes the agents'
+        // webchat MCP delegations and bumps their hook dispatchRevision, exactly as an
+        // operator-initiated unplacement would.
+        for (const a of placedAgents) await deps.repos.agent.setPlacement(a.id, null)
         await deps.registry.remove(DaemonId(req.params.id))
         // The daemon (and its FK-cascaded keys) is gone — tell relays to drop it (§9).
         deps.relayControl.daemonRevoke(req.params.id)

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -477,6 +477,22 @@ describe('DELETE /daemons/:id — remove from fleet', () => {
     expect((await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).daemonId).toBeNull()
   })
 
+  it('marks the daemon’s agents inactive (the FK SetNull alone leaves a stale “active”)', async () => {
+    // `daemonId` and `status` must agree: unplaced ⇒ inactive. The FK's SetNull only
+    // clears the placement, so the route unplaces through the repo first — otherwise a
+    // deleted daemon leaves `daemonId: null, status: 'active'` and every reader (console
+    // badge, the `status === 'active'` routing gates) treats the agent as runnable.
+    await seedDaemon()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    await prisma.agent.update({ where: { id: agentId }, data: { status: 'active' } })
+    running = buildHttpApp(prisma)
+
+    expect((await running.app.inject({ method: 'DELETE', url: `${ORG}/daemons/${DAEMON}` })).statusCode).toBe(204)
+    const agent = await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })
+    expect({ daemonId: agent.daemonId, status: agent.status }).toEqual({ daemonId: null, status: 'inactive' })
+  })
+
   it('re-broadcasts the collaboration snapshot (its agents just left the peer directory)', async () => {
     // `Agent.daemonId` is SetNull, so the daemon's agents become UNPLACED and
     // `buildCollabSnapshot` drops them — but only for holders that receive a new snapshot.

--- a/packages/web/src/components/console/AgentReachabilityOverview.tsx
+++ b/packages/web/src/components/console/AgentReachabilityOverview.tsx
@@ -338,7 +338,7 @@ export function AgentReachabilityOverview({
               const agent = agentById.get(agentId)!
               const node = layout.nodes.get(agentId)!
               const owningDaemon = daemons.find((daemon) => daemon.daemonId === agent.daemon)
-              const agentStatus = status(effectiveAgentStatus(agent.status, owningDaemon))
+              const agentStatus = status(effectiveAgentStatus(agent, owningDaemon))
               const isFocus = focusAgentId === agentId
               const isFocusedCycleMember = focusedCycleAgentIds?.has(agentId) ?? false
               const dimmed = highlightedAgentIds !== null && !highlightedAgentIds.has(agentId)

--- a/packages/web/src/components/console/GlobalSearch.tsx
+++ b/packages/web/src/components/console/GlobalSearch.tsx
@@ -89,7 +89,7 @@ export function GlobalSearch({
       // Gate "online" on the owning daemon being connected (as the Agents view does),
       // and surface the daemon's display NAME — never its host.
       const owning = daemonById.get(a.daemon)
-      const s = status(effectiveAgentStatus(a.status, owning))
+      const s = status(effectiveAgentStatus(a, owning))
       return {
         key: `agent:${a.id}`,
         kind: 'agent',

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -409,7 +409,7 @@ export default function AgentDetailView() {
   // does (else a blank model reads "Default" here but its resolved default in the
   // editor). Falls back to the static labels when the daemon reports no catalog.
   const modelText = agentModelDisplay(owningDaemon, da.runtime, da.model)
-  const ds = status(effectiveAgentStatus(da.status, owningDaemon))
+  const ds = status(effectiveAgentStatus(da, owningDaemon))
   const ws = da.workspace
   // Demo agents have no daemon to read git state from, so the workspace card's
   // live half comes straight from their static mock workspace instead.

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -95,7 +95,7 @@ export default function AgentsView() {
   const onlineCount = agents.filter(
     (a) =>
       effectiveAgentStatus(
-        a.status,
+        a,
         daemons.find((d) => d.daemonId === a.daemon)
       ) === 'online'
   ).length
@@ -139,7 +139,7 @@ export default function AgentsView() {
     if (scope === 'mine' && (!me?.userId || a.createdBy !== me.userId)) return false
     if (seg === 'all') return true
     const eff = effectiveAgentStatus(
-      a.status,
+      a,
       daemons.find((d) => d.daemonId === a.daemon)
     )
     // A lifecycle transition is a temporary processing pause, not an outage.
@@ -152,7 +152,7 @@ export default function AgentsView() {
   const statusRank = (a: Agent) =>
     STATUS_RANK[
       effectiveAgentStatus(
-        a.status,
+        a,
         daemons.find((d) => d.daemonId === a.daemon)
       )
     ] ?? 3
@@ -379,7 +379,7 @@ export default function AgentsView() {
             {filtered.map((a, i) => {
               const owning = daemons.find((d) => d.daemonId === a.daemon)
               const runtimeMeta = acpRuntime(acpRegistry, a.runtime)
-              const s = status(effectiveAgentStatus(a.status, owning))
+              const s = status(effectiveAgentStatus(a, owning))
               const agentInts = integrations.filter((int) => int.agentId === a.id)
               const first = agentInts[0]
               const n24 = sessions24h(a.id)
@@ -541,7 +541,7 @@ export default function AgentsView() {
           visible.map((a) => {
             const owning = daemons.find((d) => d.daemonId === a.daemon)
             const runtimeMeta = acpRuntime(acpRegistry, a.runtime)
-            const s = status(effectiveAgentStatus(a.status, owning))
+            const s = status(effectiveAgentStatus(a, owning))
             const sessionCount = sessions24h(a.id)
             // Keep the resolved name for sorting, assistive text, and the avatar's hint.
             const creatorName = creatorText(a)

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -343,7 +343,7 @@ export default function DaemonDetailView() {
           {hosted.length > 0 ? (
             hosted.map((a, i) => {
               // Daemon status is known here, so gate the agent's effective online on it.
-              const as = status(effectiveAgentStatus(a.status, daemon))
+              const as = status(effectiveAgentStatus(a, daemon))
               return (
                 <button
                   key={a.id}
@@ -767,7 +767,7 @@ export default function DaemonDetailView() {
                 </div>
                 {hosted.map((a) => {
                   // On this page we know the daemon's status, so gate the agent's online.
-                  const as = status(effectiveAgentStatus(a.status, daemon))
+                  const as = status(effectiveAgentStatus(a, daemon))
                   return (
                     <div
                       key={a.id}

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -122,7 +122,7 @@ export default function HomeView() {
   // runtime is signed in (its last probe wasn't rejected with ACP auth-required).
   const isOnline = (a: Agent) =>
     effectiveAgentStatus(
-      a.status,
+      a,
       daemons.find((d) => d.daemonId === a.daemon)
     ) === 'online'
   const authRequiredFor = (a: Agent) =>

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -41,9 +41,17 @@ describe('planned daemon lifecycle status', () => {
     expect(lifecycleStatus({ op: 'upgrade', status: 'succeeded' })).toBeUndefined()
     const upgrading = { status: 'offline' as const, lifecycleStatus: 'upgrading' as const }
     expect(presentedDaemonStatus(upgrading)).toBe('upgrading')
-    expect(effectiveAgentStatus('online', upgrading)).toBe('upgrading')
-    expect(effectiveAgentStatus('online', { status: 'offline', lifecycleStatus: null })).toBe('offline')
-    expect(effectiveAgentStatus('paused', upgrading)).toBe('paused')
+    const placed = (status: 'online' | 'paused') => ({ status, daemon: 'daemon-1' })
+    expect(effectiveAgentStatus(placed('online'), upgrading)).toBe('upgrading')
+    expect(effectiveAgentStatus(placed('online'), { status: 'offline', lifecycleStatus: null })).toBe('offline')
+    expect(effectiveAgentStatus(placed('paused'), upgrading)).toBe('paused')
+  })
+
+  it('reads an unplaced agent as offline whatever its stored status says', () => {
+    // A deleted daemon clears the placement; a stale 'active'/'online' status must not
+    // survive that as a green dot on an agent with nothing hosting it.
+    expect(effectiveAgentStatus({ status: 'online', daemon: '—' }, undefined)).toBe('offline')
+    expect(effectiveAgentStatus({ status: 'online', daemon: 'daemon-1' }, undefined)).toBe('online')
   })
 
   it('uses the transition tone while a pending daemon is still connected', () => {

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -59,15 +59,24 @@ export function presentedDaemonStatus(daemon: Pick<DaemonRow, 'status' | 'lifecy
 // remain intact while the daemon drains and relaunches, so carry that explicit amber
 // transition onto the agent instead of flashing it red. When the owning daemon isn't
 // in the fleet (e.g. the demo agents' placeholder daemons), trust the stored status.
+//
+// An UNPLACED agent is offline regardless of what the stored status says: no daemon
+// means nothing is hosting it. That is a deliberate belt-and-braces read — the CP is
+// supposed to flip `status` on unplacement, but any path that clears the placement
+// without writing the status (a bare FK SetNull, say) would otherwise paint a green
+// dot on an agent that cannot run.
 export function effectiveAgentStatus(
-  agentStatus: StatusKey,
+  agent: Pick<Agent, 'status' | 'daemon'>,
   owningDaemon: Pick<DaemonRow, 'status' | 'lifecycleStatus'> | undefined
 ): StatusKey {
-  if (agentStatus === 'online' && owningDaemon !== undefined) {
-    if (owningDaemon.lifecycleStatus) return owningDaemon.lifecycleStatus
-    if (owningDaemon.status !== 'online') return 'offline'
+  if (agent.status === 'online') {
+    if (agent.daemon === '—') return 'offline'
+    if (owningDaemon !== undefined) {
+      if (owningDaemon.lifecycleStatus) return owningDaemon.lifecycleStatus
+      if (owningDaemon.status !== 'online') return 'offline'
+    }
   }
-  return agentStatus
+  return agent.status
 }
 
 // "Placed" = the agent has a daemon AND a runtime, so it can actually run. Every org


### PR DESCRIPTION
## The bug

Delete a daemon, and its agents kept reporting `status: 'active'` while their placement was gone — `GET /api/v1/agents` returned `daemonId: null, status: 'active'`, the console painted a green Online dot, and every `status === 'active'` routing gate kept treating the agent as runnable.

`Agent.daemonId` and `Agent.status` are two columns that must agree (unplaced ⇒ `inactive`), but only `AgentRepo.setPlacement` / `movePlacement` ever wrote them as a pair. The daemon delete path goes through the FK instead — `daemon Daemon? @relation(..., onDelete: SetNull)` — so Postgres cleared `daemonId` and never touched `status`. `registryService.remove()` is a bare `daemons.delete()`, and the route's existing post-delete work (collab snapshot re-broadcast, hook re-converge) didn't cover the status either.

## What changed

- **`http/routes/daemons.ts`** — unplace the daemon's agents through the repo *before* removing the row, so the pair is written together. Going through `setPlacement` also revokes their webchat MCP delegations and bumps their hook `dispatchRevision`, exactly as an operator-initiated unplacement would.
- **`prisma/migrations/20260804110000_unplaced_agent_status_backfill`** — reconciles the rows that already drifted (`daemon_id IS NULL AND status = 'active'`). `configRevision` is deliberately **not** bumped: these agents have no owning daemon, so there is no recipient whose applied revision could be confused.
- **`web/src/lib/data.ts`** — belt-and-braces. `effectiveAgentStatus` now takes the agent (not just its status) and reads an **unplaced** agent as `offline` whatever the stored status says. Its existing daemon-liveness downgrade only fires when the owning daemon is *found in the fleet*, so a deleted daemon fell through to "trust the stored status" and doubled the bug. 9 call sites updated across 6 components.

## Notes for the reviewer

- The unplace loop is one repo call per hosted agent rather than a single `updateMany`, to reuse the existing placement semantics (advisory lock, delegation revoke, hook revision) instead of re-implementing them next to the delete.
- Not done: a DB-level `CHECK (daemon_id IS NOT NULL OR status <> 'active')`. It would make any future write path that misses the pair a runtime error rather than silent drift — worth discussing, but it turns a data bug into a 500 and is out of scope here.

## Testing

- New integration test `marks the daemon's agents inactive (the FK SetNull alone leaves a stale "active")` in `daemons.route.test.ts` — 47/47 pass, which also exercises the new migration via the Testcontainers `migrate deploy`.
- New unit case in `data.test.ts` for unplaced ⇒ offline; web suite 728/728 pass.
- `pnpm typecheck` and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)