### PR TITLE
fix(telegram): retain inbound sender names

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3706,7 +3706,7 @@ export class Daemon {
         group,
         newTraceId: () => randomUUID(),
         onMessage: (msg) => {
-          this.channelNameResolver?.noteChannel(conn, msg.channel, msg.sender.id)
+          this.channelNameResolver?.noteMessage(conn, msg)
           this.onInbound(msg, this.srcIntegrationIds(conn))
         },
         onBotAddedToChat: (chat) => {

--- a/packages/daemon/src/messages/channel-name-resolver.ts
+++ b/packages/daemon/src/messages/channel-name-resolver.ts
@@ -70,8 +70,10 @@ export interface ChannelNameResolverOpts {
 }
 
 export class ChannelNameResolver {
-  /** channel id → epoch ms until which we won't re-attempt a lookup. */
+  /** Platform id → epoch ms until which we won't re-attempt a lookup. */
   private nextAttemptAt = new Map<string, number>()
+  /** Inline names use a separate TTL namespace because a channel and user may share an id. */
+  private observedNameNextSaveAt = new Map<string, number>()
   private saveScope?: (id: string, scope: ResolvedChannelScope) => void
   private saveAvatar?: (source: ChannelInfoSource, id: string, avatarUrl: string) => void
   private log?: Logger
@@ -109,24 +111,27 @@ export class ChannelNameResolver {
   ): void {
     void this.resolveChannel(src, msg.channel, msg.sender.id)
     if (!msg.sender.isBot) {
-      if (msg.sender.name) this.save(msg.sender.id, msg.sender.name)
-      else void this.resolveUser(src, msg.sender.id)
+      if (msg.sender.name) {
+        if (this.claim(msg.sender.id, this.observedNameNextSaveAt)) this.save(msg.sender.id, msg.sender.name)
+      } else {
+        void this.resolveUser(src, msg.sender.id)
+      }
     }
     for (const id of msg.mentionedUserIds ?? []) void this.resolveUser(src, id)
   }
 
-  private claim(id: string): boolean {
-    const at = this.nextAttemptAt.get(id)
+  private claim(id: string, attempts = this.nextAttemptAt): boolean {
+    const at = attempts.get(id)
     if (at !== undefined && this.now() < at) return false
     // Mark before the async call so concurrent messages dedup in-flight lookups.
     // Re-inserting moves the id to the tail so Map insertion order stays LRU-ish.
-    this.nextAttemptAt.delete(id)
-    this.nextAttemptAt.set(id, this.now() + OK_TTL_MS)
+    attempts.delete(id)
+    attempts.set(id, this.now() + OK_TTL_MS)
     // Bound the cache by evicting the oldest entries — never a full clear, which would
     // drop every TTL at once and burst-re-resolve against the platform API.
-    for (const key of this.nextAttemptAt.keys()) {
-      if (this.nextAttemptAt.size <= MAX_TRACKED_IDS) break
-      this.nextAttemptAt.delete(key)
+    for (const key of attempts.keys()) {
+      if (attempts.size <= MAX_TRACKED_IDS) break
+      attempts.delete(key)
     }
     return true
   }

--- a/packages/daemon/src/messages/channel-name-resolver.ts
+++ b/packages/daemon/src/messages/channel-name-resolver.ts
@@ -105,10 +105,13 @@ export class ChannelNameResolver {
    */
   noteMessage(
     src: ChannelInfoSource,
-    msg: { channel: string; sender: { id: string; isBot: boolean }; mentionedUserIds?: string[] }
+    msg: { channel: string; sender: { id: string; isBot: boolean; name?: string }; mentionedUserIds?: string[] }
   ): void {
     void this.resolveChannel(src, msg.channel, msg.sender.id)
-    if (!msg.sender.isBot) void this.resolveUser(src, msg.sender.id)
+    if (!msg.sender.isBot) {
+      if (msg.sender.name) this.save(msg.sender.id, msg.sender.name)
+      else void this.resolveUser(src, msg.sender.id)
+    }
     for (const id of msg.mentionedUserIds ?? []) void this.resolveUser(src, id)
   }
 

--- a/packages/daemon/test/name-resolver.test.ts
+++ b/packages/daemon/test/name-resolver.test.ts
@@ -160,13 +160,14 @@ describe('ChannelNameResolver', () => {
     expect(avatars.get('U7')).toBe('https://avatars.example.test/dana.png')
   })
 
-  it('noteMessage saves an observed sender name without a profile lookup', async () => {
-    const saved = new Map<string, string>()
+  it('noteMessage rate-limits an observed sender name without a profile lookup', async () => {
+    const save = vi.fn()
     const src = source({ id: 'C1', name: 'general' })
-    const r = new ChannelNameResolver((id, name) => saved.set(id, name))
+    const r = new ChannelNameResolver(save)
+    r.noteMessage(src, { channel: 'C1', sender: { id: 'U9', isBot: false, name: '@dana' } })
     r.noteMessage(src, { channel: 'C1', sender: { id: 'U9', isBot: false, name: '@dana' } })
     await flush()
-    expect(saved.get('U9')).toBe('@dana')
+    expect(save.mock.calls.filter(([id]) => id === 'U9')).toEqual([['U9', '@dana']])
     expect(src.getUserProfile).not.toHaveBeenCalled()
   })
 

--- a/packages/daemon/test/name-resolver.test.ts
+++ b/packages/daemon/test/name-resolver.test.ts
@@ -160,11 +160,21 @@ describe('ChannelNameResolver', () => {
     expect(avatars.get('U7')).toBe('https://avatars.example.test/dana.png')
   })
 
+  it('noteMessage saves an observed sender name without a profile lookup', async () => {
+    const saved = new Map<string, string>()
+    const src = source({ id: 'C1', name: 'general' })
+    const r = new ChannelNameResolver((id, name) => saved.set(id, name))
+    r.noteMessage(src, { channel: 'C1', sender: { id: 'U9', isBot: false, name: '@dana' } })
+    await flush()
+    expect(saved.get('U9')).toBe('@dana')
+    expect(src.getUserProfile).not.toHaveBeenCalled()
+  })
+
   it('noteMessage skips a bot sender (agent frames are labelled by agentId upstream)', async () => {
     const saved = new Map<string, string>()
     const src = source({ id: 'C1', name: 'general' })
     const r = new ChannelNameResolver((id, name) => saved.set(id, name))
-    r.noteMessage(src, { channel: 'C1', sender: { id: 'B1', isBot: true } })
+    r.noteMessage(src, { channel: 'C1', sender: { id: 'B1', isBot: true, name: '@bot' } })
     await flush()
     expect(src.getUserProfile).not.toHaveBeenCalled()
     expect(saved.has('B1')).toBe(false)

--- a/packages/daemon/test/telegram-normalize.test.ts
+++ b/packages/daemon/test/telegram-normalize.test.ts
@@ -22,7 +22,7 @@ describe('normalizeTelegramMessage', () => {
       source: 'user',
       platform: 'telegram',
       channel: '-100123',
-      sender: { id: '42', isBot: false },
+      sender: { id: '42', isBot: false, name: '@ada' },
       text: 'hello',
       mentionedBots: [],
       isDm: false
@@ -39,7 +39,15 @@ describe('normalizeTelegramMessage', () => {
 
   it('marks a bot sender as isBot', () => {
     const n = normalizeTelegramMessage(msg({ from: { id: 7, is_bot: true, username: 'somebot' } }), ctx)
-    expect(n.sender).toEqual({ id: '7', isBot: true })
+    expect(n.sender).toEqual({ id: '7', isBot: true, name: '@somebot' })
+  })
+
+  it('falls back to the sender first and last name when there is no username', () => {
+    const n = normalizeTelegramMessage(
+      msg({ from: { id: 42, is_bot: false, first_name: 'Ada', last_name: 'Lovelace' } }),
+      ctx
+    )
+    expect(n.sender).toEqual({ id: '42', isBot: false, name: 'Ada Lovelace' })
   })
 
   it('carries a forum-topic message_thread_id in the generic topicId (thread left to the daemon)', () => {

--- a/packages/message/src/telegram-message.ts
+++ b/packages/message/src/telegram-message.ts
@@ -116,6 +116,12 @@ function quotedSenderLabel(sender: TelegramUser | undefined): string | undefined
   return sender.username ? `@${sender.username}` : String(sender.id)
 }
 
+function telegramSenderName(sender: TelegramUser | undefined): string | undefined {
+  if (!sender) return undefined
+  if (sender.username) return `@${sender.username}`
+  return [sender.first_name, sender.last_name].filter(Boolean).join(' ') || undefined
+}
+
 export function quotedFromTelegramReply(message: TelegramMessage): QuotedMessage | undefined {
   const source = message.reply_to_message
   if (!source) return undefined
@@ -183,6 +189,7 @@ export function normalizeTelegramMessage(
   const isForumTopic = message.is_topic_message === true
   const replyTo = message.reply_to_message?.message_id != null ? String(message.reply_to_message.message_id) : undefined
   const quoted = quotedFromTelegramReply(message)
+  const senderName = telegramSenderName(message.from)
 
   return {
     msgId: `telegram:${message.chat.id}:${message.message_id}`,
@@ -201,7 +208,8 @@ export function normalizeTelegramMessage(
     ...(quoted !== undefined ? { quoted } : {}),
     sender: {
       id: message.from ? String(message.from.id) : 'unknown',
-      isBot: Boolean(message.from?.is_bot)
+      isBot: Boolean(message.from?.is_bot),
+      ...(senderName ? { name: senderName } : {})
     },
     text,
     mentionedBots: extractTelegramMentions(text, entities),

--- a/packages/protocol/src/normalized-message.ts
+++ b/packages/protocol/src/normalized-message.ts
@@ -105,6 +105,8 @@ export const NormalizedPlatformMessageSchema = z.object({
   sender: z.object({
     id: z.string(),
     isBot: z.boolean(),
+    /** Provider-observed public display label. Presentation only; never an identity or auth input. */
+    name: z.string().optional(),
     appId: z.string().optional(),
     /** Public provider-hosted profile image. Auth-gated file URLs must not be exposed here. */
     avatarUrl: z.string().url().optional()


### PR DESCRIPTION
## Summary

- preserve an optional provider-observed display label on normalized senders, explicitly presentation-only
- derive Telegram sender labels from `@username`, falling back to first and last name
- feed Telegram ingress through the shared name-resolution seam so session metadata and transcripts can label group senders without a standalone user lookup
- keep the fix within protocol/message/daemon; no Control Plane, Web, manifest, or storage migration changes

## Root cause

Telegram inbound events already include the sender's public username and name, but normalization discarded them. The Telegram Bot API has no standalone user-profile lookup, so group senders remained raw IDs unless a prior private chat happened to cache a name under the same ID.

## Impact

New Telegram messages now populate the existing display-name cache directly. Current and historical sessions on the same daemon can receive refreshed sender metadata after that user is observed again.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/telegram-normalize.test.ts test/name-resolver.test.ts` (36 tests)
- `pnpm --filter @agentconnect.md/daemon exec vitest run test/session-reader.test.ts` (19 tests)
- `pnpm --filter @agentconnect.md/protocol typecheck`
- `pnpm --filter @agentconnect.md/message typecheck`
- `pnpm --filter @agentconnect.md/daemon typecheck`
- targeted ESLint and Prettier checks
- pre-push `pnpm lint`

Created by Codex . GPT-5.6
