### PR TITLE
feat(daemons): console-configurable session expiry (7d/30d/90d/never)

### DIFF
--- a/packages/control-plane/prisma/migrations/20260804120000_daemon_session_retention/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260804120000_daemon_session_retention/migration.sql
@@ -1,0 +1,7 @@
+-- Console-set "Expire sessions" window for the daemon's LOCAL session store
+-- ('never' | '7d' | '30d' | '90d'). The CP stores and delivers the value
+-- (register/ok baseline + config/push hot update); the daemon's hourly retention
+-- sweep is what actually deletes expired finished sessions. Backfilling existing
+-- rows with '7d' matches the daemon-side config default, so behavior is unchanged
+-- for every daemon that never had the option set.
+ALTER TABLE "daemon" ADD COLUMN "sessionRetention" TEXT NOT NULL DEFAULT '7d';

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -325,6 +325,13 @@ model Daemon {
   visibility ResourceVisibility @default(org) // 'org' = all members; 'restricted' = the complete sharedWith audience
   sharedWith String[]           @default([]) // complete app_user.id audience when visibility='restricted'
 
+  // ── console-set daemon settings ──
+  // Retention window for FINISHED sessions on the daemon's LOCAL store (the console's
+  // "Expire sessions" option): 'never' | '7d' | '30d' | '90d'. The CP only stores and
+  // delivers it (register/ok baseline + config/push hot update); the daemon's hourly
+  // retention sweep is what actually deletes expired sessions.
+  sessionRetention String @default("7d")
+
   // ── fencing root ──
   sessionEpoch BigInt @default(0) @db.BigInt // bumped each successful (re)auth
   routingEpoch BigInt @default(0) @db.BigInt // version of THIS daemon's assignment set

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -207,6 +207,10 @@ export const DaemonViewDto = z.object({
   createdBy: z.string().nullable(), // creator's userId (web resolves to a name / "You"); null for CLI/self-registered
   lastModifiedAt: z.string(), // ISO-8601; last human edit, defaults to createdAt
   lastModifiedBy: z.string().nullable(), // editor's userId (web resolves to a name / "You"); null for system rows
+  /** Console-set finished-session retention window on the daemon's local store
+   *  ("Expire sessions"): how long finished sessions are kept before the daemon's
+   *  retention sweep deletes them; 'never' disables the sweep. */
+  sessionRetention: z.enum(['never', '7d', '30d', '90d']),
   // ── visibility / sharing (docs/designs/resource-visibility.md) ──
   visibility: ResourceVisibilityEnum,
   sharedWith: z.array(z.string()), // complete app_user.id audience when restricted
@@ -218,8 +222,18 @@ export const DaemonViewDto = z.object({
 })
 export const DaemonListDto = z.array(DaemonViewDto)
 
-/** `PATCH /daemons/:id` — assign a human-friendly display name. */
-export const RenameDaemonBody = z.object({ name: z.string().trim().min(1).max(64) })
+/** `PATCH /daemons/:id` — console daemon settings: a human-friendly display name
+ *  and/or the finished-session retention window ("Expire sessions"). */
+export const UpdateDaemonBody = z
+  .object({
+    name: z.string().trim().min(1).max(64).optional(),
+    /** How long the daemon keeps FINISHED sessions in its local store before its
+     *  retention sweep deletes them; 'never' disables the sweep. */
+    sessionRetention: z.enum(['never', '7d', '30d', '90d']).optional()
+  })
+  .refine((b) => b.name !== undefined || b.sessionRetention !== undefined, {
+    message: 'nothing to update'
+  })
 
 /** `POST /daemons/:id/upgrade` — the version the daemon should install + relaunch on. */
 // The version is forwarded to the daemon, which spawns the CLI with it as the

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -24,7 +24,7 @@ import {
   DaemonListDto,
   DaemonViewDto,
   DaemonLifecycleOpDto,
-  RenameDaemonBody,
+  UpdateDaemonBody,
   DaemonUpgradeBody,
   SetSharingBody,
   DaemonConnectDto,
@@ -111,6 +111,9 @@ function liveStatus(view: DaemonView, liveness: DaemonLiveness, graceMs: number,
   return 'connecting' // CONNECTING / AUTHENTICATING / REGISTERING
 }
 
+// The DTO's accepted retention values — mirrors UpdateDaemonBody.sessionRetention.
+const SESSION_RETENTIONS = new Set(['never', '7d', '30d', '90d'])
+
 function toDto(
   view: DaemonView,
   liveness: DaemonLiveness,
@@ -160,6 +163,12 @@ function toDto(
     lastModifiedAt: view.lastModifiedAt.toISOString(),
     lastModifiedBy:
       view.lastModifiedBy && !isSyntheticEmail(view.lastModifiedBy.email) ? view.lastModifiedBy.userId : null,
+    // Defensive read-time normalization: the PATCH route only writes enum values,
+    // so a fallback here just keeps an unexpected stored value from failing the
+    // whole response's schema serialization.
+    sessionRetention: SESSION_RETENTIONS.has(view.sessionRetention)
+      ? (view.sessionRetention as DaemonViewDtoT['sessionRetention'])
+      : '7d',
     visibility: view.visibility,
     sharedWith: view.sharedWith,
     canEdit: canEdit(view, ctx),
@@ -228,18 +237,20 @@ export function daemonRoutes(deps: HttpDeps) {
       return canView(view, ctxOf(req)) ? view : null
     }
 
-    // Assign a human-friendly display name. The row materializes on the WS `auth`
-    // handshake, so a missing id (Prisma P2025) maps to 404 via the error handler.
+    // Update console daemon settings (name / session retention). The row
+    // materializes on the WS `auth` handshake, so a missing id (Prisma P2025)
+    // maps to 404 via the error handler.
     r.patch(
       '/daemons/:id',
       {
         schema: {
           tags: [Tag.Daemons],
-          summary: 'Rename a daemon',
-          description: 'Assign a human-friendly console display name to a daemon.',
+          summary: 'Update a daemon',
+          description:
+            'Update console daemon settings: the human-friendly display name and/or the finished-session retention window ("Expire sessions"). A retention change is hot-pushed to a connected daemon and re-issued in the register/ok snapshot on reconnect.',
           operationId: 'updateDaemon',
           params: IdParam,
-          body: RenameDaemonBody,
+          body: UpdateDaemonBody,
           response: { 200: DaemonViewDto, 403: ErrorDto, 404: ErrorDto }
         }
       },
@@ -252,7 +263,21 @@ export function daemonRoutes(deps: HttpDeps) {
         if (!canEdit(existing, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this daemon' })
         }
-        const view = await deps.registry.rename(DaemonId(req.params.id), req.body.name, req.principal?.userId)
+        const { name, sessionRetention } = req.body
+        const did = DaemonId(req.params.id)
+        let view = existing
+        if (name !== undefined) view = await deps.registry.rename(did, name, req.principal?.userId)
+        if (sessionRetention !== undefined) {
+          view = await deps.registry.setSessionRetention(did, sessionRetention, req.principal?.userId)
+          // Hot-push the new window to the connected daemon (config/push EVT).
+          // Best-effort: an offline daemon converges from the register/ok
+          // snapshot on its next connect.
+          try {
+            deps.control.configPush(req.params.id, { 'sessions.retention': sessionRetention })
+          } catch {
+            // NoConnection — the reconnect snapshot is the backstop
+          }
+        }
         return dto(view, ctxOf(req))
       }
     )

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -179,6 +179,18 @@ export class ControlSender {
     }
   }
 
+  /**
+   * Push whitelisted non-secret config keys to a connected daemon (`config/push`
+   * EVT). Fire-and-forget: the daemon merges them into its running config
+   * (`mergeConfigPush` whitelist) without persisting; a durable setting must also
+   * ride the `register/ok` snapshot, which is the reconnect backstop for a push
+   * the daemon never saw. Throws {@link NoConnection} when the daemon is offline.
+   */
+  configPush(daemonId: string, keys: Record<string, unknown>): void {
+    const c = this.must(daemonId)
+    c.conn.send('config/push', { keys }, { epoch: c.sessionEpoch })
+  }
+
   /** Assign a session to a daemon (epoch-fenced REQ → ack). */
   async routeAssign(daemonId: string, a: RouteAssign): Promise<RouteAssignAck> {
     const c = this.must(daemonId)

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -36,7 +36,7 @@ import type {
   MemoryConnectionSpec,
   RelayRosterEntry
 } from '@agentconnect.md/protocol'
-import { RESERVED_MCP_SERVER_NAME } from '@agentconnect.md/protocol'
+import { RESERVED_MCP_SERVER_NAME, SessionRetentionSetting } from '@agentconnect.md/protocol'
 import type {
   AgentRepo,
   AgentRecord,
@@ -508,8 +508,15 @@ export class Placement implements ReconcileService {
       .filter((local) => local.origin === 'cp' || orgIntegrationIds.has(local.integrationId))
       .map((local) => local.integrationId)
 
+    // Console-set finished-session retention — the daemon's reconnect baseline for
+    // the config/push hot update. Parsed defensively: an unexpected stored value
+    // (never written by the validated PATCH route) is simply omitted, which the
+    // daemon reads as "keep local config".
+    const sessionRetention = SessionRetentionSetting.safeParse(daemon.sessionRetention)
+
     return {
       routingEpoch: Number(daemon.routingEpoch), // re-issue same — convergence, not bump
+      ...(sessionRetention.success ? { sessionRetention: sessionRetention.data } : {}),
       // Transport capabilities are connection-level and register.ts replaces
       // this neutral snapshot value immediately before register/ok is sent.
       serverFeatures: [],

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -169,6 +169,8 @@ export interface DaemonRecord {
   createdByUserId: string | null
   visibility: ResourceVisibility
   sharedWith: string[] // complete app_user.id audience when visibility='restricted'
+  /** Console-set finished-session retention window ('never' | '7d' | '30d' | '90d'). */
+  sessionRetention: string
   lastModifiedAt: Date // last human edit (provision/rename); defaults to createdAt
   lastModifiedBy: AgentCreator | null // WebUI user who last edited it; null ⇒ never edited by a human
 }
@@ -198,6 +200,9 @@ export interface DaemonRepo {
    *  audit). `byUserId` is the editing WebUI principal (absent under devAuth).
    *  Throws if the daemon row is absent. */
   rename(daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonRecord>
+  /** Set the console's finished-session retention window (a human edit — stamps
+   *  last-modified audit). Throws if the daemon row is absent. */
+  setSessionRetention(daemonId: DaemonId, sessionRetention: string, byUserId?: string): Promise<DaemonRecord>
   /** Set the visibility + share set (the dedicated `/sharing` write path). Stamps
    *  the last-modified audit; `byUserId` is the editing WebUI principal (absent
    *  under devAuth). Throws if the daemon row is absent. */

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -54,6 +54,7 @@ function toRecord(d: DaemonWithUsers): DaemonRecord {
     createdByUserId: d.createdByUserId,
     visibility: d.visibility,
     sharedWith: d.sharedWith,
+    sessionRetention: d.sessionRetention,
     lastModifiedAt: d.lastModifiedAt,
     lastModifiedBy: d.lastModifiedBy
       ? { userId: d.lastModifiedBy.id, displayName: d.lastModifiedBy.displayName, email: d.lastModifiedBy.email }
@@ -177,6 +178,17 @@ export class PgDaemonRepo implements DaemonRepo {
     const daemon = await this.db.daemon.update({
       where: { id: daemonId },
       data: { name, lastModifiedAt: new Date(), ...(byUserId ? { lastModifiedByUserId: byUserId } : {}) },
+      include: withUsers
+    })
+    return toRecord(daemon)
+  }
+
+  async setSessionRetention(daemonId: DaemonId, sessionRetention: string, byUserId?: string): Promise<DaemonRecord> {
+    // A retention change is a human edit — advance the last-modified audit
+    // (editor stamped when known; absent under devAuth ⇒ leave the prior editor).
+    const daemon = await this.db.daemon.update({
+      where: { id: daemonId },
+      data: { sessionRetention, lastModifiedAt: new Date(), ...(byUserId ? { lastModifiedByUserId: byUserId } : {}) },
       include: withUsers
     })
     return toRecord(daemon)

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -213,6 +213,8 @@ export interface DaemonView {
   visibility: ResourceVisibility
   /** Complete app_user.id audience when `visibility === 'restricted'`. */
   sharedWith: string[]
+  /** Console-set finished-session retention window ('never' | '7d' | '30d' | '90d'). */
+  sessionRetention: string
 }
 
 /**
@@ -258,6 +260,9 @@ export interface DaemonRegistry {
   /** Set the console-assigned display name; returns the updated read-model row.
    *  `byUserId` is the editing WebUI principal → stamps last-modified audit. */
   rename(daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonView>
+  /** Set the console's finished-session retention window ("Expire sessions");
+   *  returns the updated read-model row. `byUserId` stamps the last-modified audit. */
+  setSessionRetention(daemonId: DaemonId, sessionRetention: string, byUserId?: string): Promise<DaemonView>
   /** Set the daemon's visibility + share set (the dedicated `/sharing` write path);
    *  returns the updated read-model row. `byUserId` stamps the last-modified audit. */
   setSharing(

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -87,7 +87,8 @@ function toView(d: DaemonRecord, profiles: RuntimeProfileRecord[]): DaemonView {
     lastModifiedBy: d.lastModifiedBy,
     createdByUserId: d.createdByUserId,
     visibility: d.visibility,
-    sharedWith: d.sharedWith
+    sharedWith: d.sharedWith,
+    sessionRetention: d.sessionRetention
   }
 }
 
@@ -176,6 +177,11 @@ export class DaemonRegistryService implements DaemonRegistry {
 
   async rename(daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonView> {
     const d = await this.daemons.rename(daemonId, name, byUserId)
+    return toView(d, await this.runtimeProfiles.forDaemon(daemonId))
+  }
+
+  async setSessionRetention(daemonId: DaemonId, sessionRetention: string, byUserId?: string): Promise<DaemonView> {
+    const d = await this.daemons.setSessionRetention(daemonId, sessionRetention, byUserId)
     return toView(d, await this.runtimeProfiles.forDaemon(daemonId))
   }
 

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -413,6 +413,63 @@ describe('PATCH /daemons/:id — rename', () => {
     const res = await running.app.inject({ method: 'PATCH', url: `${ORG}/daemons/${DAEMON}`, payload: { name: '   ' } })
     expect(res.statusCode).toBe(400)
   })
+
+  it('400s on an empty body (nothing to update)', async () => {
+    await seedDaemon()
+    running = buildHttpApp(prisma)
+    const res = await running.app.inject({ method: 'PATCH', url: `${ORG}/daemons/${DAEMON}`, payload: {} })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('persists sessionRetention and hot-pushes it to the connected daemon (config/push)', async () => {
+    await seedDaemon()
+    const pushes: { id: string; keys: Record<string, unknown> }[] = []
+    const control = {
+      configPush: (id: string, keys: Record<string, unknown>) => {
+        pushes.push({ id, keys })
+      }
+    } as unknown as ControlSender
+    running = buildHttpApp(prisma, undefined, liveness({ [DAEMON]: { state: 'READY', reachable: true } }), control)
+
+    const res = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/daemons/${DAEMON}`,
+      payload: { sessionRetention: '90d' }
+    })
+    expect(res.statusCode).toBe(200)
+    const updated = res.json() as DaemonDto & { sessionRetention: string }
+    expect(updated.sessionRetention).toBe('90d')
+    // A retention change is a human edit — the last-modified audit advances.
+    expect(updated.lastModifiedBy).toBeTruthy()
+
+    // Durable (the register/ok baseline reads this column) + hot-pushed.
+    const row = await prisma.daemon.findUnique({ where: { id: DAEMON } })
+    expect(row?.sessionRetention).toBe('90d')
+    expect(pushes).toEqual([{ id: DAEMON, keys: { 'sessions.retention': '90d' } }])
+  })
+
+  it('still 200s a retention change when the daemon is offline (push is best-effort)', async () => {
+    await seedDaemon()
+    running = buildHttpApp(prisma) // empty liveness ⇒ configPush throws NoConnection internally
+    const res = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/daemons/${DAEMON}`,
+      payload: { sessionRetention: 'never' }
+    })
+    expect(res.statusCode).toBe(200)
+    expect((res.json() as { sessionRetention: string }).sessionRetention).toBe('never')
+  })
+
+  it('400s an unknown retention window', async () => {
+    await seedDaemon()
+    running = buildHttpApp(prisma)
+    const res = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/daemons/${DAEMON}`,
+      payload: { sessionRetention: '3d' }
+    })
+    expect(res.statusCode).toBe(400)
+  })
 })
 
 describe('DELETE /daemons/:id — remove from fleet', () => {

--- a/packages/control-plane/test/integration/ws-handshake.test.ts
+++ b/packages/control-plane/test/integration/ws-handshake.test.ts
@@ -96,6 +96,8 @@ describe('ws gateway — real socket handshake over agentconnect.v1', () => {
       expect(regOk.corr).toBe(regId)
       expect(regOk.payload.assignments).toEqual([])
       expect(regOk.payload.drop).toEqual({ assignments: [], crons: [], agents: [], integrations: [] })
+      // The console-set finished-session retention rides the snapshot (column default).
+      expect(regOk.payload.sessionRetention).toBe('7d')
 
       // The daemon row was persisted at READY with the registered capabilities.
       const row = await prisma.daemon.findUnique({ where: { id: DAEMON } })

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -180,7 +180,9 @@ export const ConfigSchema = z.object({
       // dirty/untracked files or commits unreachable from any remote ref is never
       // auto-deleted — the sweep reports it and keeps the session instead.
       // 'never' disables the sweep entirely.
-      retention: z.enum(['never', '7d', '2weeks', '1month']).default('7d')
+      // '30d'/'90d' are the console-facing windows (CP-set via register/ok +
+      // config/push); '2weeks'/'1month' are kept for existing local config files.
+      retention: z.enum(['never', '7d', '2weeks', '1month', '30d', '90d']).default('7d')
     })
     .default({ retention: '7d' }),
   limits: z
@@ -264,6 +266,9 @@ export function sessionRetentionMs(retention: SessionRetention): number | null {
     case '2weeks':
       return 14 * 24 * 3_600_000
     case '1month':
+    case '30d':
       return 30 * 24 * 3_600_000
+    case '90d':
+      return 90 * 24 * 3_600_000
   }
 }

--- a/packages/daemon/src/cp/config-apply.ts
+++ b/packages/daemon/src/cp/config-apply.ts
@@ -111,6 +111,7 @@ export interface ConfigApply {
 }
 
 const LOG_LEVELS = new Set(['trace', 'debug', 'info', 'warn', 'error'])
+const SESSION_RETENTIONS = new Set(['never', '7d', '2weeks', '1month', '30d', '90d'])
 
 /**
  * Merge a `config/push` payload into the running config — whitelist only, no
@@ -144,6 +145,12 @@ export function mergeConfigPush(cfg: Config, keys: Record<string, unknown>): { a
       case 'limits.agentIdleTimeoutMs':
         if (typeof value === 'number' && Number.isInteger(value)) {
           cfg.limits.agentIdleTimeoutMs = value
+          ok = true
+        }
+        break
+      case 'sessions.retention':
+        if (typeof value === 'string' && SESSION_RETENTIONS.has(value)) {
+          cfg.sessions.retention = value as Config['sessions']['retention']
           ok = true
         }
         break

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -17288,6 +17288,9 @@ export class Daemon {
       },
       applyReconcileSnapshot: async (snap: RegisterOk) => {
         this.gitCommitIdentity = snap.gitCommitIdentity
+        // Console-set finished-session retention — the reconnect baseline for the
+        // `config/push` hot update. Absent (older CP) ⇒ keep the local config value.
+        if (snap.sessionRetention) this.cfg.sessions.retention = snap.sessionRetention
         // Reserve every agent drop before ANY fallible snapshot convergence.
         // Otherwise an unrelated integration/memory write could abort the frame
         // while a CP-removed agent remains live with no gate or durable marker.

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -38,10 +38,14 @@ describe('loadConfig', () => {
       '1month'
     )
     expect(() => loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '3d' } }) })).toThrow()
+    expect(loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '90d' } }) }).sessions.retention).toBe('90d')
     expect(sessionRetentionMs('never')).toBeNull()
     expect(sessionRetentionMs('7d')).toBe(7 * 24 * 3_600_000)
     expect(sessionRetentionMs('2weeks')).toBe(14 * 24 * 3_600_000)
     expect(sessionRetentionMs('1month')).toBe(30 * 24 * 3_600_000)
+    // The console-facing windows (CP-set via register/ok + config/push).
+    expect(sessionRetentionMs('30d')).toBe(30 * 24 * 3_600_000)
+    expect(sessionRetentionMs('90d')).toBe(90 * 24 * 3_600_000)
   })
 
   it.skipIf(process.platform === 'win32')('repairs an existing config file to owner-only permissions', () => {

--- a/packages/daemon/test/cp/config-merge.test.ts
+++ b/packages/daemon/test/cp/config-merge.test.ts
@@ -23,6 +23,18 @@ describe('mergeConfigPush', () => {
     expect(r.ignored.sort()).toEqual(['controlPlane.key', 'logging.level'])
   })
 
+  it('applies sessions.retention (the console "Expire sessions" hot update) and rejects bad values', () => {
+    const cfg = baseCfg()
+    const r = mergeConfigPush(cfg, { 'sessions.retention': '90d' })
+    expect(cfg.sessions.retention).toBe('90d')
+    expect(r.applied).toEqual(['sessions.retention'])
+
+    const bad = mergeConfigPush(cfg, { 'sessions.retention': '3d' })
+    expect(cfg.sessions.retention).toBe('90d') // unchanged — not a known window
+    expect(bad.applied).toEqual([])
+    expect(bad.ignored).toEqual(['sessions.retention'])
+  })
+
   it('ignores controlPlane.heartbeatMs (CP-authoritative via auth/ok, not config/push)', () => {
     const cfg = baseCfg()
     const defaultMs = cfg.controlPlane.heartbeatMs

--- a/packages/protocol/src/frames/register.ts
+++ b/packages/protocol/src/frames/register.ts
@@ -87,6 +87,15 @@ export const RelayRosterUpdate = z.object({
 })
 export type RelayRosterUpdate = z.infer<typeof RelayRosterUpdate>
 
+/**
+ * Console-set retention window for FINISHED sessions on the daemon's LOCAL
+ * store (the daemon settings' "Expire sessions" option). CP-durable; the
+ * register/ok snapshot is the reconnect baseline and a `config/push` with
+ * `sessions.retention` is the hot update.
+ */
+export const SessionRetentionSetting = z.enum(['never', '7d', '30d', '90d'])
+export type SessionRetentionSetting = z.infer<typeof SessionRetentionSetting>
+
 export const RegisterOk = z.object({
   routingEpoch: z.number().int(), // version of the routing table this snapshot reflects
   // CP protocol capabilities. Default keeps a new daemon compatible with an
@@ -95,6 +104,9 @@ export const RegisterOk = z.object({
   // Public attribution for github-app workspace commits. Derived from this
   // deployment's App slug; optional so new daemons still accept an older CP.
   gitCommitIdentity: GitCommitIdentity.optional(),
+  // Console-set finished-session retention for this daemon's local store —
+  // optional so new daemons still accept an older CP (absent ⇒ keep local config).
+  sessionRetention: SessionRetentionSetting.optional(),
   // Authoritative reconcile snapshot — daemon converges its local cache to this:
   assignments: z.array(RouteAssign), // the route/assign set the daemon SHOULD own
   agents: z.array(AgentSpec.extend({ agentId: z.string().uuid() })).default([]), // spec set CP wants present; daemon converges

--- a/packages/web/src/components/console/SessionRetentionField.tsx
+++ b/packages/web/src/components/console/SessionRetentionField.tsx
@@ -1,0 +1,63 @@
+// No 'use client' here: imported only by client components (the daemon modals
+// under ModalProvider), so it's already in the client bundle — and keeping the
+// directive off avoids Next's "props must be serializable" check on onChange.
+
+/**
+ * The daemon's "Expire sessions" picker (Add/Edit daemon modals): how long the
+ * daemon keeps FINISHED sessions in its local store before its retention sweep
+ * deletes them (session row + per-session Git worktree). 'never' disables the
+ * sweep. Rendered as the standard `.inp` field with an invisible overlaid
+ * native <select> (same pattern as the lifecycle modal's version picker).
+ */
+import { Icon } from '@/components/ui'
+import type { DaemonSessionRetention } from '@/lib/api'
+
+export const SESSION_RETENTION_DEFAULT: DaemonSessionRetention = '7d'
+
+const OPTIONS: { value: DaemonSessionRetention; label: string }[] = [
+  { value: '7d', label: 'After 7 days' },
+  { value: '30d', label: 'After 30 days' },
+  { value: '90d', label: 'After 90 days' },
+  { value: 'never', label: 'Never' }
+]
+
+export function SessionRetentionField({
+  value,
+  onChange,
+  disabled
+}: {
+  value: DaemonSessionRetention
+  onChange: (value: DaemonSessionRetention) => void
+  disabled?: boolean
+}) {
+  const label = OPTIONS.find((o) => o.value === value)?.label ?? value
+  return (
+    <div className="fld mt-[14px]">
+      <span className="fldlbl">Expire sessions</span>
+      <div className={`inp relative ${disabled ? 'opacity-60' : ''}`}>
+        <span className="truncate font-sans text-[13px] text-(--text-primary)">
+          {label}
+          {value === SESSION_RETENTION_DEFAULT && <span className="text-(--text-tertiary)"> · default</span>}
+        </span>
+        <Icon name="chevron-down" size={15} color="var(--text-tertiary)" className="ml-auto" />
+        <select
+          value={value}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value as DaemonSessionRetention)}
+          className="absolute inset-0 cursor-pointer opacity-0 disabled:cursor-default"
+          aria-label="Expire sessions"
+        >
+          {OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+              {o.value === SESSION_RETENTION_DEFAULT ? ' (default)' : ''}
+            </option>
+          ))}
+        </select>
+      </div>
+      <span className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+        Finished sessions older than this are deleted from the daemon, including their workspaces.
+      </span>
+    </div>
+  )
+}

--- a/packages/web/src/components/console/modals/AddDaemonModal.tsx
+++ b/packages/web/src/components/console/modals/AddDaemonModal.tsx
@@ -8,6 +8,7 @@ import { daemonCommands } from '@/lib/daemon-commands'
 import { Button, Icon } from '@/components/ui'
 import { Spinner } from '@/components/marks'
 import { VisibilityField, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
+import { SessionRetentionField, SESSION_RETENTION_DEFAULT } from '@/components/console/SessionRetentionField'
 
 /** What the CP already gave the provisioned row — skip the /sharing write when the
  *  operator leaves it alone. */
@@ -95,14 +96,16 @@ export default function AddDaemonModal({
   onDone?: () => void
   registerDismiss: (handler: () => void) => () => void
 }) {
-  const { provisionDaemon, daemons, refresh, deleteDaemon, renameDaemon, saveSharing } = useConsoleData()
+  const { provisionDaemon, daemons, refresh, deleteDaemon, renameDaemon, setDaemonSessionRetention, saveSharing } =
+    useConsoleData()
   const { me } = useProfile()
   const [connect, setConnect] = useState<DaemonConnectDto | null>(null)
   const [err, setErr] = useState<string | null>(null)
   const [cancelling, setCancelling] = useState(false)
   // Optional overrides applied on Done: an empty name keeps the daemon's own
-  // reported one, and the default sharing skips the /sharing write entirely.
+  // reported one, and the default sharing/retention skip their writes entirely.
   const [name, setName] = useState('')
+  const [retention, setRetention] = useState(SESSION_RETENTION_DEFAULT)
   const [sharing, setSharing] = useState<SharingValue>(DEFAULT_SHARING)
   const [saving, setSaving] = useState(false)
   const [saveErr, setSaveErr] = useState<string | null>(null)
@@ -172,6 +175,7 @@ export default function AddDaemonModal({
     try {
       const next = name.trim()
       if (next && next !== row?.name) await renameDaemon(connect.daemonId, next)
+      if (retention !== SESSION_RETENTION_DEFAULT) await setDaemonSessionRetention(connect.daemonId, retention)
       if (!sameSharing(sharing, DEFAULT_SHARING)) await saveSharing('daemons', connect.daemonId, sharing)
       // A dialog dismissed while this was in flight must stay dismissed — closing
       // again is harmless, but chaining into Edit agent would reopen a surface the
@@ -256,6 +260,7 @@ export default function AddDaemonModal({
             }}
           />
         </div>
+        <SessionRetentionField value={retention} onChange={setRetention} />
         <VisibilityField value={sharing} onChange={setSharing} />
         {saveErr && (
           <div className="mt-[14px] flex items-start gap-2 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[11px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--status-error)">

--- a/packages/web/src/components/console/modals/EditDaemonModal.tsx
+++ b/packages/web/src/components/console/modals/EditDaemonModal.tsx
@@ -5,13 +5,16 @@ import type { DaemonRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Button, Icon } from '@/components/ui'
 import { VisibilityField, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
+import { SessionRetentionField } from '@/components/console/SessionRetentionField'
 
-// The daemon's rename + sharing editor (replaces the old inline rename + the
-// standalone sharing dialog). Name goes through renameDaemon; visibility rides the
-// separate /sharing endpoint (canManageSharing gate), only written when it changed.
+// The daemon's rename + retention + sharing editor (replaces the old inline rename
+// + the standalone sharing dialog). Name and session retention go through the PATCH
+// endpoint (canEdit gate); visibility rides the separate /sharing endpoint
+// (canManageSharing gate). Each write is skipped when its field is unchanged.
 export default function EditDaemonModal({ daemon, onClose }: { daemon: DaemonRow; onClose: () => void }) {
-  const { renameDaemon, saveSharing } = useConsoleData()
+  const { renameDaemon, setDaemonSessionRetention, saveSharing } = useConsoleData()
   const [name, setName] = useState(daemon.name)
+  const [retention, setRetention] = useState(daemon.sessionRetention)
   const [sharing, setSharing] = useState<SharingValue>({ visibility: daemon.visibility, sharedWith: daemon.sharedWith })
   const initialSharing = useRef<SharingValue>({ visibility: daemon.visibility, sharedWith: daemon.sharedWith })
   const [saving, setSaving] = useState(false)
@@ -24,6 +27,8 @@ export default function EditDaemonModal({ daemon, onClose }: { daemon: DaemonRow
     try {
       const next = name.trim()
       if (daemon.canEdit && next && next !== daemon.name) await renameDaemon(daemon.daemonId, next)
+      if (daemon.canEdit && retention !== daemon.sessionRetention)
+        await setDaemonSessionRetention(daemon.daemonId, retention)
       if (daemon.canManageSharing && !sameSharing(sharing, initialSharing.current))
         await saveSharing('daemons', daemon.daemonId, sharing)
       onClose()
@@ -61,6 +66,7 @@ export default function EditDaemonModal({ daemon, onClose }: { daemon: DaemonRow
             }}
           />
         </div>
+        <SessionRetentionField value={retention} onChange={setRetention} disabled={!daemon.canEdit} />
         <VisibilityField value={sharing} onChange={setSharing} disabled={!daemon.canManageSharing} />
         {err && (
           <div className="mt-[14px] flex items-start gap-2 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[11px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--status-error)">

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -980,6 +980,9 @@ export interface DaemonViewDto {
   createdBy: string | null // creator's userId (resolved to a name / "You" in the UI); null for CLI/self-registered
   lastModifiedAt: string // ISO-8601
   lastModifiedBy: string | null // editor's userId (resolved to a name / "You" in the UI); null for CLI/self-registered
+  /** How long the daemon keeps FINISHED sessions in its local store before its
+   *  retention sweep deletes them ("Expire sessions"); 'never' disables the sweep. */
+  sessionRetention: DaemonSessionRetention
   visibility: ResourceVisibility
   sharedWith: string[]
   canEdit: boolean
@@ -987,6 +990,9 @@ export interface DaemonViewDto {
   /** Whether the caller may command restart/upgrade on this daemon (org owner only). */
   canManageLifecycle: boolean
 }
+
+/** The console-settable "Expire sessions" windows (PATCH /daemons/:id). */
+export type DaemonSessionRetention = 'never' | '7d' | '30d' | '90d'
 
 /** A CP-commanded daemon restart/upgrade (cli-daemon-split.md §7). Returned by the
  *  upgrade/restart POSTs and embedded in each daemon's read model as its latest op. */
@@ -1950,6 +1956,7 @@ export function daemonFromDto(d: DaemonViewDto): DaemonRow {
     createdAt: fmtDate(d.createdAt),
     lastModifiedBy: d.lastModifiedBy ?? '', // editor userId; creatorLabel resolves it to a name / "You" at render
     lastModifiedAt: fmtDate(d.lastModifiedAt),
+    sessionRetention: d.sessionRetention ?? '7d', // absent from an older CP ⇒ the daemon-side default
     visibility: d.visibility,
     sharedWith: d.sharedWith,
     canEdit: d.canEdit,
@@ -2950,6 +2957,17 @@ export async function fetchDaemons(orgId?: string): Promise<DaemonRow[]> {
 // Assign a human-friendly display name to a connected daemon.
 export async function renameDaemon(daemonId: string, name: string): Promise<DaemonRow> {
   return daemonFromDto(await apiPatch<DaemonViewDto>(`${orgBase()}/daemons/${encodeURIComponent(daemonId)}`, { name }))
+}
+
+// Set how long the daemon keeps finished sessions before deleting them ("Expire
+// sessions"). The CP hot-pushes the window to a connected daemon.
+export async function updateDaemonSessionRetention(
+  daemonId: string,
+  sessionRetention: DaemonSessionRetention
+): Promise<DaemonRow> {
+  return daemonFromDto(
+    await apiPatch<DaemonViewDto>(`${orgBase()}/daemons/${encodeURIComponent(daemonId)}`, { sessionRetention })
+  )
 }
 
 // Set a daemon's visibility + share set (PUT /daemons/:id/sharing).

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -68,6 +68,8 @@ import {
   type ReconnectConnectorConnectionResult,
   provisionDaemon as apiProvisionDaemon,
   renameDaemon as apiRenameDaemon,
+  updateDaemonSessionRetention as apiUpdateDaemonSessionRetention,
+  type DaemonSessionRetention,
   deleteDaemon as apiDeleteDaemon,
   restartDaemon as apiRestartDaemon,
   upgradeDaemon as apiUpgradeDaemon,
@@ -222,6 +224,8 @@ interface ConsoleData {
   deleteCron: (id: string) => Promise<void>
   provisionDaemon: () => Promise<DaemonConnectDto>
   renameDaemon: (daemonId: string, name: string) => Promise<void>
+  /** Set the daemon's finished-session retention window ("Expire sessions"), then re-pull. */
+  setDaemonSessionRetention: (daemonId: string, retention: DaemonSessionRetention) => Promise<void>
   /** Mint a fresh key for an existing (offline) daemon — the reconnect command. */
   reconnectDaemon: (daemonId: string) => Promise<MintedKeyDto>
   /** Remove an offline daemon from the fleet, then re-pull. */
@@ -1355,6 +1359,15 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     [mutateDaemons]
   )
 
+  // Set the finished-session retention window ("Expire sessions"), then re-pull.
+  const setDaemonSessionRetention = useCallback(
+    async (daemonId: string, retention: DaemonSessionRetention) => {
+      await apiUpdateDaemonSessionRetention(daemonId, retention)
+      settleInBackground(mutateDaemons())
+    },
+    [mutateDaemons]
+  )
+
   // Reconnect: mint a new key + start command for an existing daemon. Like
   // provision, the row flips back to `online` via `refresh()` once it re-auths, so
   // the caller polls rather than this refreshing eagerly.
@@ -1468,6 +1481,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       deleteCron,
       provisionDaemon,
       renameDaemon,
+      setDaemonSessionRetention,
       reconnectDaemon,
       deleteDaemon,
       restartDaemon,
@@ -1535,6 +1549,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       deleteCron,
       provisionDaemon,
       renameDaemon,
+      setDaemonSessionRetention,
       reconnectDaemon,
       deleteDaemon,
       restartDaemon,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -2,7 +2,7 @@
 // Ported from the AgentConnect design (static demo content for the console UI).
 
 import type { AgentIcon } from '@/lib/agent-icon'
-import type { MemoryDreamingConfig } from '@/lib/api'
+import type { DaemonSessionRetention, MemoryDreamingConfig } from '@/lib/api'
 
 export type LifecycleStatusKey = 'upgrading' | 'restarting'
 export type ConnectionStatusKey = 'online' | 'paused' | 'offline'
@@ -1855,6 +1855,9 @@ export interface DaemonRow {
   /** Last editor's userId — resolved to a name / "You" at render via creatorLabel; '' for CLI/self-registered. */
   lastModifiedBy: string
   lastModifiedAt: string
+  /** How long the daemon keeps finished sessions before deleting them ("Expire
+   *  sessions"); 'never' disables the retention sweep. */
+  sessionRetention: DaemonSessionRetention
   /** 'org' = visible to all members; 'restricted' = the complete sharedWith audience. */
   visibility: ResourceVisibility
   /** Complete app_user.id audience when restricted. */


### PR DESCRIPTION
## Summary

Adds an **"Expire sessions"** option to the console's Add daemon / Edit daemon modals — how long a daemon keeps FINISHED sessions in its local store before its retention sweep deletes them: **After 7 days (default) / After 30 days / After 90 days / Never**.

The daemon-side mechanism already existed (`sessions.retention` local config + the hourly retention sweep, #485); this makes it console-configurable and CP-delivered.

## How it works

- **web**: new `SessionRetentionField` (the lifecycle modal's invisible-overlay `<select>` pattern) in both daemon modals. Both modals keep their "only write what changed" behavior — the write is skipped when left at the default.
- **cp**: new `daemon.sessionRetention` column (TEXT, default `'7d'`; migration backfills existing rows with the daemon-side default, so behavior is unchanged until an operator touches the option). `PATCH /daemons/:id` body becomes `{ name?, sessionRetention? }` (at least one required). A retention change is persisted, then **hot-pushed** to a connected daemon via `config/push` — the first real sender of that EVT (`ControlSender.configPush`). Offline daemons are fine: the push is best-effort.
- **protocol**: optional `RegisterOk.sessionRetention` — the authoritative **reconnect baseline**, so a push missed while the daemon was offline converges on the next register. Optional + zod unknown-key stripping keeps older CPs and older daemons mutually compatible.
- **daemon**: `sessions.retention` enum gains `'30d'`/`'90d'` (keeps `'2weeks'`/`'1month'` so existing local config files still parse); `mergeConfigPush` whitelists `sessions.retention`; `applyReconcileSnapshot` applies the snapshot value. The sweep reads the config live each run, so no sweep changes.

## Test plan

- [x] `pnpm typecheck` (protocol, daemon, control-plane, web)
- [x] daemon unit: retention enum/window mapping + `mergeConfigPush` accept/reject cases
- [x] CP unit suite (1132) + full integration suite (954) incl. new PATCH cases: persist + hot-push, offline best-effort 200, unknown window 400, empty body 400, and `register/ok` carrying `sessionRetention`
- [x] web: ModalProvider modal-write-sequence tests
- [x] `pnpm lint` + `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)