### PR TITLE
refactor(daemon): cursorOrdering becomes a platform strategy; routing knobs become an envelope read (S3 Appendix A)

### DIFF
--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -27,6 +27,7 @@ import { transcriptChannelKey, type LocalStore, type TranscriptEventCursor } fro
 import { legacyGithubEventActor } from '../messages/hook-message.js'
 import { mentionedUserIds, substituteUserMentions } from '../slack/mentions.js'
 import { slackThreadUrl } from '../slack/permalink.js'
+import { hasNativeMessageOrder } from '../platforms/message-ordering.js'
 
 /** Encoded-payload ceiling, leaving headroom under MAX_FRAME_BYTES for the
  *  envelope (id/ts/type/corr + fencing ext, well under 4 KiB). */
@@ -36,8 +37,9 @@ const REPLY_BUDGET = MAX_FRAME_BYTES - 4096
  *  valid-JSON preview + `bodyTruncated`; the full body is fetched via `toolBody`. */
 const PREVIEW_CAP = 32 * 1024
 
-/** New chronological Slack-history cursor. Numeric cursors remain the legacy
- * insertion-seq format so an in-flight page load survives a daemon upgrade. */
+/** New chronological history cursor, used by platforms whose message ids carry a
+ * native order. Numeric cursors remain the legacy insertion-seq format so an
+ * in-flight page load survives a daemon upgrade. */
 const EVENT_CURSOR_PREFIX = 'event-v1:'
 
 function encodeEventCursor(cursor: TranscriptEventCursor): string {
@@ -238,15 +240,17 @@ export function createSessionReader(
       const afterRevision = tailing ? Number(req.after) : null
       if (afterRevision !== null && (!Number.isSafeInteger(afterRevision) || afterRevision < 0))
         throw new Error('invalid transcript revision')
-      // Slack can append an older platform row during warm-thread backfill, so its
-      // authoritative history pages by normalized event time + seq tie-breaker. A
-      // plain numeric cursor came from a pre-upgrade daemon: finish that page walk in
-      // legacy seq order to avoid mixing cursor domains mid-request.
+      // A platform whose ids order natively can append an OLDER row during warm-thread
+      // backfill (Slack's, today — see platforms/message-ordering.ts), so its
+      // authoritative history pages by normalized event time + seq tie-breaker. Where
+      // ids are opaque, insertion seq IS the only order there is and stays the page
+      // walk. A plain numeric cursor came from a pre-upgrade daemon: finish that page
+      // walk in legacy seq order to avoid mixing cursor domains mid-request.
+      const nativeOrder = hasNativeMessageOrder(rec.platform)
       const eventCursor = decodeEventCursor(req.cursor)
       const numericCursor = req.cursor !== undefined ? Number(req.cursor) : Number.NaN
       const legacyBefore = Number.isSafeInteger(numericCursor) ? numericCursor : null
-      const chronologicalSlack =
-        rec.platform === 'slack' && (req.cursor === undefined || eventCursor !== null || legacyBefore === null)
+      const chronological = nativeOrder && (req.cursor === undefined || eventCursor !== null || legacyBefore === null)
       const transcriptChannel = transcriptChannelKey(rec.channel, rec.transportScope)
       // Scope to what THIS agent's session received + produced, not the whole shared
       // (channel, thread) thread — an agent-called session only ever saw the message handed
@@ -254,7 +258,7 @@ export function createSessionReader(
       const page =
         afterRevision !== null
           ? store.transcriptTailForAgent(transcriptChannel, rec.thread, rec.agentId, afterRevision, req.limit)
-          : chronologicalSlack
+          : chronological
             ? store.transcriptPageForAgentByEventTime(
                 transcriptChannel,
                 rec.thread,
@@ -345,12 +349,13 @@ export function createSessionReader(
           liveMore && lastMutationRow
             ? lastMutationRow.revision
             : (page as ReturnType<LocalStore['transcriptTailForAgent']>).cursor
-        // Mutation order and display order differ when a Slack warm-thread backfill
-        // inserts an older platform message. Return a chronological page while the
-        // revision cursor above remains anchored to mutation order.
+        // Mutation order and display order differ when a warm-thread backfill inserts
+        // an older platform message — possible only where message ids order natively.
+        // Return a chronological page while the revision cursor above remains anchored
+        // to mutation order.
         const rowBySeq = new Map(rows.map((row) => [row.seq, row]))
         kept.sort((a, b) => {
-          if (rec.platform !== 'slack') return a.seq - b.seq
+          if (!nativeOrder) return a.seq - b.seq
           const ar = rowBySeq.get(a.seq)
           const br = rowBySeq.get(b.seq)
           return (ar?.eventTimeUs ?? 0) - (br?.eventTimeUs ?? 0) || a.seq - b.seq
@@ -394,7 +399,7 @@ export function createSessionReader(
         ...(hasOlder && oldestKept
           ? {
               nextCursor:
-                chronologicalSlack && oldestRow
+                chronological && oldestRow
                   ? encodeEventCursor({ eventTimeUs: oldestRow.eventTimeUs, seq: oldestRow.seq })
                   : String(oldestKept.seq)
             }

--- a/packages/daemon/src/platforms/integration-config.ts
+++ b/packages/daemon/src/platforms/integration-config.ts
@@ -1,0 +1,82 @@
+/**
+ * The **integration envelope read** (audit Appendix A class b,
+ * `router/routing-rule.ts:46–68`, stage S3).
+ *
+ * §6.4 splits an `IntegrationSpec` into a CORE ENVELOPE that core owns and reads
+ * (`bindRules`, `mutedChannels`, `gated`, …) and an OPAQUE `config` that only the
+ * platform's own module understands. The router had the split backwards: it
+ * switched on the platform id four ways purely to reach three identically-named
+ * core fields, so every new platform had to edit the router to be routable at all.
+ *
+ * The knobs are already spelled the same in all four config schemas — the switch
+ * was never reading four different shapes, only four different property paths.
+ * Reading the block through the integration's own platform id collapses the four
+ * arms into one and survives §6.4's rename as a one-line change: today the block
+ * is nested under the platform id (`{ platform: 'slack', slack: {…} }`), after the
+ * emission flip it is `config`, and nothing else here moves.
+ *
+ * WHAT STAYS PER-PLATFORM: the bot's own id. §6.4 deliberately keeps it OUT of the
+ * core envelope because it is the platform's identity vocabulary, not a routing
+ * knob — a Feishu bot has an `open_id`, not a user id. So that one read is a
+ * registered strategy with a fail-safe default (the name the other three share),
+ * which is what the audit's class-b rows ask for: core keeps the envelope, the
+ * platform keeps its own words.
+ */
+import type { BindRuleConfig, Integration } from '../agents/agent-schema.js'
+
+/** The union of every platform's config block, derived from the `Integration`
+ *  union rather than re-listed — the block always lives at the integration's own
+ *  platform id, so the two can never drift apart. Written as an `infer` over
+ *  `Record<I['platform'], …>` because TypeScript will not let a generic index a
+ *  distributed member by its own discriminant. */
+export type IntegrationConfig<I extends Integration = Integration> =
+  I extends Record<I['platform'], infer C> ? C : never
+
+/** The core routing knobs core owns, whatever the platform (§6.4 `core`). */
+export interface IntegrationCore {
+  bindRules: BindRuleConfig[]
+  /** Channels the operator switched OFF. Post-dates the schema, so an integration
+   *  assembled by hand rather than parsed (a fixture, a caller mapping a partial
+   *  spec) can arrive without it; absent means "nothing muted" — the behaviour
+   *  before the field existed — and normalizing once here keeps every reader free
+   *  of the same defaulting. */
+  mutedChannels: string[]
+  gated: boolean
+}
+
+/** The integration's own config block — opaque to core under §6.4, and the only
+ *  place its core knobs and its platform-private credentials both live today. */
+export function integrationConfig(int: Integration): IntegrationConfig {
+  return (int as unknown as Record<string, unknown>)[int.platform] as IntegrationConfig
+}
+
+/** How one platform names the bot's own id inside its config block. */
+type SelfIdRead = (config: IntegrationConfig) => string | undefined
+
+const SELF_IDS = new Map<string, SelfIdRead>([
+  // Feishu identifies a bot by open_id; there is no "user id" in its vocabulary.
+  ['feishu', (config) => ('botOpenId' in config ? config.botOpenId : undefined)]
+])
+
+/** The bot's own id as CONFIGURED — what `mention` rules match against before a
+ *  live connection has resolved the real one. Total by construction: a platform
+ *  that registers no reader uses the core `botUserId` name, which is what Slack,
+ *  Telegram and Discord all call it, so a new platform is routable without
+ *  touching this file. */
+export function configuredBotSelfId(int: Integration): string | undefined {
+  const config = integrationConfig(int)
+  const read = SELF_IDS.get(int.platform)
+  if (read) return read(config)
+  return 'botUserId' in config ? config.botUserId : undefined
+}
+
+/** The core envelope of one integration: the routing knobs core reads for every
+ *  platform, with no knowledge of which platform it is. */
+export function integrationCore(int: Integration): IntegrationCore {
+  const config = integrationConfig(int)
+  return {
+    bindRules: config.bindRules,
+    mutedChannels: config.mutedChannels ?? [],
+    gated: config.gated
+  }
+}

--- a/packages/daemon/src/platforms/message-ordering.ts
+++ b/packages/daemon/src/platforms/message-ordering.ts
@@ -1,0 +1,102 @@
+/**
+ * The **message-ordering strategy** (`cursorOrdering`, audit Appendix A class c,
+ * stage S3).
+ *
+ * ONE question is asked in seven places across the session manager and the CP
+ * session reader: *does this platform's message id carry a native total order,
+ * and how do two ids compare under it?* Every one of those sites spelled the
+ * answer as `platform === 'slack'` next to a Slack-timestamp parser, so adding a
+ * platform with ordered ids meant finding all seven — and forgetting one leaves a
+ * read cursor that silently skips or re-delivers messages.
+ *
+ * WHY NOT THE MANIFEST. `messageIdOrdering` looks like a §5 manifest axis and is
+ * not one: the manifest's rule is that a field is earned by a PRE-DISPATCH read,
+ * and every read here happens inside a turn that already exists (assembling one
+ * activation's prompt, paging one session's transcript). It is a daemon strategy
+ * function (§7.4), registered per platform in the daemon's platform module layer,
+ * exactly like `threadKeyForPost` and `sessionLinkSourceFor`.
+ *
+ * FAIL-CLOSED BY ABSENCE. `messageOrderingFor` returns `undefined` for a platform
+ * with no native ordering — which is every platform but Slack today — and the
+ * type system then forces each call site to state what "no order" means there.
+ * There is deliberately NO neutral default object: a comparator that quietly
+ * answers 0 would turn "these ids are not comparable" into "these ids are equal",
+ * and the cursor bug that follows is invisible. Absence is the loud arm; every
+ * caller's `undefined` branch is today's non-Slack behavior, unchanged — ids are
+ * opaque, nothing is re-sorted, and the read cursor advances to the trigger.
+ *
+ * A PLATFORM SUPPLIES ONE THING: how to read a coordinate out of one of its
+ * message ids. The total order, the synthetic-coordinate rule and the cutoff test
+ * are shared, because they are DAEMON facts (legacy anchored cron/hook turns
+ * persisted a UUID as the read cursor regardless of platform), not platform ones.
+ */
+
+/** How one platform's native message ids order and compare. */
+export interface MessageOrdering {
+  /** This id's native ordering coordinate, or `null` when it carries none — a
+   *  synthetic or legacy coordinate (an anchored cron/hook UUID, a locally
+   *  minted transcript key) that the platform never issued. */
+  coordinate(id: string): bigint | null
+  /** Total order over this platform's ids. Coordinate-less ids sort BEFORE real
+   *  ones: a real follow-up must never look older than the synthetic cursor that
+   *  created its thread. Two coordinate-less ids fall back to a stable string
+   *  order so the comparator stays total. */
+  compare(a: string, b: string): number
+  /** Is `id` inside a wall-clock `cutoff` (at or before it)? A coordinate-less id
+   *  is always inside: it cannot be compared with a wall-clock marker safely, so
+   *  a snapshot must keep it rather than silently drop it. */
+  withinCutoff(id: string, cutoff: string): boolean
+}
+
+/** Derive a full ordering from the only per-platform fact — its coordinate
+ *  parser. Keeping the null rules here (rather than in each platform's arm)
+ *  means a second ordered platform inherits the legacy-cursor behavior the
+ *  daemon already depends on instead of re-deciding it. */
+function orderingByCoordinate(coordinate: (id: string) => bigint | null): MessageOrdering {
+  const compare = (a: string, b: string): number => {
+    const am = coordinate(a)
+    const bm = coordinate(b)
+    if (am === null && bm === null) return a.localeCompare(b)
+    if (am === null) return -1
+    if (bm === null) return 1
+    return am < bm ? -1 : am > bm ? 1 : 0
+  }
+  return {
+    coordinate,
+    compare,
+    withinCutoff: (id, cutoff) => coordinate(id) === null || compare(id, cutoff) <= 0
+  }
+}
+
+/** Slack's canonical message id is decimal seconds with microsecond precision
+ *  (`1700000000.123456`). Parsed to an integer microsecond count and compared as
+ *  BigInt, because `Number` cannot represent every microsecond at today's epoch —
+ *  and because lexical order over the raw string is wrong the moment two ids
+ *  differ in fractional digit count. */
+function slackTsMicros(id: string): bigint | null {
+  const m = /^(\d+)\.(\d{1,6})$/.exec(id)
+  if (!m) return null
+  return BigInt(m[1]!) * 1_000_000n + BigInt(m[2]!.padEnd(6, '0'))
+}
+
+/**
+ * A `Map`, not an object literal, so lookup is total for EVERY string rather than
+ * every string that is not an `Object.prototype` key — the same fail-closed
+ * reasoning the §5 manifest registry carries.
+ */
+const ORDERINGS = new Map<string, MessageOrdering>([['slack', orderingByCoordinate(slackTsMicros)]])
+
+/** The ordering strategy for `platform`, or `undefined` when its message ids
+ *  carry no native order. Callers must handle the `undefined` arm explicitly —
+ *  see the fail-closed note above. */
+export function messageOrderingFor(platform: string): MessageOrdering | undefined {
+  return ORDERINGS.get(platform)
+}
+
+/** Whether `platform`'s message ids order natively at all. For readers that only
+ *  need the boolean — the CP session reader pages a transcript chronologically
+ *  exactly when display order can diverge from mutation order, which is exactly
+ *  when the platform can hand the daemon an out-of-order id. */
+export function hasNativeMessageOrder(platform: string): boolean {
+  return ORDERINGS.has(platform)
+}

--- a/packages/daemon/src/router/routing-rule.ts
+++ b/packages/daemon/src/router/routing-rule.ts
@@ -8,6 +8,7 @@
  * previously-unservable rule servable). `agent.id` IS the CP `agentId`.
  */
 import type { Agent, BindMatch, BindRuleConfig, Integration } from '../agents/agent-schema.js'
+import { configuredBotSelfId, integrationCore } from '../platforms/integration-config.js'
 import type { RouteAssign, RouteUpdate } from '@agentconnect.md/protocol'
 
 export type RoutingMatch = BindMatch
@@ -31,45 +32,24 @@ export interface RoutingRule {
   platform?: string
 }
 
-/** Extract the platform-agnostic routing bits from a (discriminated) Integration.
- *  Exported for the daemon's conversation-gating ingress checks (§14). */
+/**
+ * The routing bits of an Integration, with no knowledge of which platform it is.
+ * Exported for the daemon's conversation-gating ingress checks (§14).
+ *
+ * This used to be a four-arm switch on `int.platform` that only ever reached
+ * identically-named fields. §6.4 says those knobs are the CORE ENVELOPE, so this
+ * is an envelope read (`platforms/integration-config.ts`) plus the one genuinely
+ * per-platform value — the bot's own id, which each platform names in its own
+ * vocabulary. Same values as before, and a new platform is now routable without
+ * editing the router.
+ */
 export function integrationRouting(int: Integration): {
   staticBotUserId?: string
   bindRules: BindRuleConfig[]
   mutedChannels: string[]
   gated: boolean
 } {
-  // `mutedChannels` post-dates the schema, so an integration assembled by hand rather
-  // than parsed (a fixture, a caller mapping a partial spec) can reach here without it.
-  // Absent means "nothing muted" — the behaviour before the field existed — and
-  // normalizing once here keeps every reader free of the same defaulting.
-  if (int.platform === 'slack')
-    return {
-      staticBotUserId: int.slack.botUserId,
-      bindRules: int.slack.bindRules,
-      mutedChannels: int.slack.mutedChannels ?? [],
-      gated: int.slack.gated
-    }
-  if (int.platform === 'discord')
-    return {
-      staticBotUserId: int.discord.botUserId,
-      bindRules: int.discord.bindRules,
-      mutedChannels: int.discord.mutedChannels ?? [],
-      gated: int.discord.gated
-    }
-  if (int.platform === 'feishu')
-    return {
-      staticBotUserId: int.feishu.botOpenId,
-      bindRules: int.feishu.bindRules,
-      mutedChannels: int.feishu.mutedChannels ?? [],
-      gated: int.feishu.gated
-    }
-  return {
-    staticBotUserId: int.telegram.botUserId,
-    bindRules: int.telegram.bindRules,
-    mutedChannels: int.telegram.mutedChannels ?? [],
-    gated: int.telegram.gated
-  }
+  return { staticBotUserId: configuredBotSelfId(int), ...integrationCore(int) }
 }
 
 /**
@@ -120,6 +100,11 @@ export function resolveAgentIntegration(
   // integration; otherwise the turn's output posts through the wrong platform's client
   // (e.g. a Telegram chat id sent via the Slack client → channel_not_found). Fall back to
   // the first integration only when the platform is unspecified or unmatched.
+  //
+  // This comparison STAYS platform-keyed on purpose (audit Appendix A,
+  // router/routing-rule.ts:124, classified "routing"): it is a platform-vs-platform
+  // equality with no literal in it, so it is already correct for every platform an
+  // open `PlatformId` can name and there is nothing here to extract.
   const int =
     (platform ? agent?.integrations.find((i) => i.platform === platform) : undefined) ?? agent?.integrations[0]
   if (!int) return null

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -11,6 +11,7 @@ import type { AcpHost } from '../acp/acp-host.js'
 import type { Agent } from '../agents/agent-schema.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import { stableTurnId, type Attachment, type NormalizedMessage } from '../messages/normalized.js'
+import { messageOrderingFor } from '../platforms/message-ordering.js'
 import { buildAttachmentBlocks, attachmentMention, transcriptImageAttachments } from './attachment-block.js'
 import { EXPLICIT_MENTION_REMINDER, NO_RESPONSE_RULE, NO_RESPONSE_REMINDER } from './no-response.js'
 
@@ -48,26 +49,13 @@ export type MemoryRecallLifecycleEvent =
 // so a long-quiet thread / large backfilled history can't blow up the prompt.
 const MAX_REPLAY_ENTRIES = 50
 
-/** Slack's canonical timestamp is decimal seconds with microsecond precision. Keep
- * comparison string-safe (Number cannot represent every microsecond at today's epoch). */
-function slackTsMicros(ts: string): bigint | null {
-  const m = /^(\d+)\.(\d{1,6})$/.exec(ts)
-  if (!m) return null
-  return BigInt(m[1]!) * 1_000_000n + BigInt(m[2]!.padEnd(6, '0'))
-}
-
-function compareSlackTs(a: string, b: string): number {
-  const am = slackTsMicros(a)
-  const bm = slackTsMicros(b)
-  // Legacy synthetic coordinates (notably pre-fix anchored cron UUIDs) sort
-  // before real Slack timestamps. A real follow-up must never look older than
-  // the synthetic cursor that created its thread.
-  if (am === null && bm === null) return a.localeCompare(b)
-  if (am === null) return -1
-  if (bm === null) return 1
-  return am < bm ? -1 : am > bm ? 1 : 0
-}
-
+/** Mint a Slack message id for a wall-clock instant. This is NOT part of the
+ * message-ordering strategy: its only callers are the warm-thread provider
+ * snapshot's cutoff and the daemon's final-fence checkpoint, both of which are
+ * `threadBackfill` — the Layer-1 read port — and both of which exist solely
+ * because Slack is the only platform with a thread-history adapter today. It
+ * moves into that port when the second adapter lands (audit row
+ * session-manager.ts:951), not with `cursorOrdering`. */
 export function slackTsForWallClock(ms: number): string {
   const whole = Math.floor(ms / 1_000)
   return `${whole}.${String(Math.floor(ms % 1_000) * 1_000).padStart(6, '0')}`
@@ -942,14 +930,17 @@ export class SessionManager {
       return { sessionId: rec.acpSessionId!, blocks: [], created, initializedOnly: true }
     }
 
-    // Older anchored cron/hook turns persisted their synthetic UUID as the Slack
-    // read cursor. Start one bounded catch-up from scratch instead of passing that
-    // non-timestamp through the Slack ordering/dedup path; this turn replaces it
-    // with the newest canonical timestamp below.
+    // This platform's message-ordering strategy (platforms/message-ordering.ts).
+    // `undefined` — every platform but Slack today — means the ids are OPAQUE:
+    // nothing below re-sorts them, no two are compared, and the read cursor simply
+    // advances to the trigger. That is the fail-closed arm and today's behaviour.
+    const ordering = messageOrderingFor(msg.platform)
+    // Older anchored cron/hook turns persisted their synthetic UUID as the read
+    // cursor. Start one bounded catch-up from scratch instead of passing an id the
+    // platform never issued through its ordering/dedup path; this turn replaces it
+    // with the newest canonical id below.
     const markerBefore =
-      msg.platform === 'slack' && rec.lastDeliveredTs !== null && slackTsMicros(rec.lastDeliveredTs) === null
-        ? null
-        : rec.lastDeliveredTs
+      rec.lastDeliveredTs !== null && ordering?.coordinate(rec.lastDeliveredTs) === null ? null : rec.lastDeliveredTs
     const firstPromptAfterOwnRootInitialization = markerBefore === null && rec.triggeredBy === agentId
     // §8.4/§8.5 authoritative warm-thread snapshot (#649): Socket Mode is the
     // low-latency trigger, not an ordered/complete unread source. Slack may deliver a
@@ -964,16 +955,23 @@ export class SessionManager {
       msg.platform === 'slack' && thread !== ts && this.deps.fetchThreadHistory
         ? slackTsForWallClock(Date.now())
         : undefined
+    // Is this id inside the turn's stable window? Provider history and locally
+    // recorded rows share one test: an id the platform issued must land at or
+    // before the wall-clock cutoff, while a synthetic / legacy coordinate — which
+    // cannot be compared with a wall-clock marker at all — is always kept, so it
+    // stays usable in tests and recovery. No cutoff (or no native ordering) means
+    // no window to fall outside of.
+    const withinSnapshot = (id: string): boolean =>
+      snapshotCutoffTs === undefined || ordering === undefined || ordering.withinCutoff(id, snapshotCutoffTs)
     if (snapshotCutoffTs !== undefined) {
       const history = await abortable(
         () => this.deps.fetchThreadHistory!(agentId, msg.channel, thread, snapshotCutoffTs, markerBefore),
         signal
       )
       for (const h of history) {
-        // Platform history has canonical decimal Slack timestamps. Keep synthetic /
-        // locally-recorded legacy coordinates usable in tests and recovery; a
-        // non-canonical value cannot be compared safely with a wall-clock cutoff.
-        if (slackTsMicros(h.ts) !== null && compareSlackTs(h.ts, snapshotCutoffTs) > 0) continue
+        // Provider history carries canonical platform ids; anything the provider
+        // issued after the cutoff belongs to the next turn.
+        if (!withinSnapshot(h.ts)) continue
         // Skip the agent's OWN messages: they're already recorded at the send boundary and
         // are always self-filtered from the model (participantGap below). Re-recording them
         // here is redundant — and in `minimal` mode it produces a DUPLICATE transcript row,
@@ -1005,15 +1003,11 @@ export class SessionManager {
     {
       const gap = this.deps.store
         .transcriptSince(transcriptChannel, thread, markerBefore)
-        .filter(
-          (e) =>
-            snapshotCutoffTs === undefined ||
-            slackTsMicros(e.ts) === null ||
-            compareSlackTs(e.ts, snapshotCutoffTs) <= 0
-        )
-      // SQLite's text order puts UUID-like legacy coordinates after decimal Slack
-      // timestamps. Keep those old rows as context, but before the real timeline.
-      if (msg.platform === 'slack') gap.sort((a, b) => compareSlackTs(a.ts, b.ts))
+        .filter((e) => withinSnapshot(e.ts))
+      // SQLite's text order puts UUID-like legacy coordinates after real platform
+      // ids. Keep those old rows as context, but before the real timeline — which
+      // only a platform whose ids carry a native order can express.
+      if (ordering !== undefined) gap.sort((a, b) => ordering.compare(a.ts, b.ts))
       // A session initialized from this agent's own channel-root post has never run a model
       // turn. Replay that one root exactly once, alongside the first real reply, so the new ACP
       // session understands what the thread is about. Ordinary own-authored rows stay filtered:
@@ -1047,21 +1041,25 @@ export class SessionManager {
       // Own authored rows are not repeated to the model, but they ARE first-class events
       // in the shared log and therefore may advance this agent's read cursor once the
       // surrounding stable window is consumed.
+      // With no native ordering there is no "newest row" to reason about, so the
+      // cursor advances to the trigger itself — the pre-seam non-Slack rule.
       const deliveredThrough =
-        msg.platform === 'slack'
-          ? slackTsMicros(ts) !== null
-            ? (gap.filter((e) => slackTsMicros(e.ts) !== null).at(-1)?.ts ?? markerBefore)
+        ordering !== undefined
+          ? ordering.coordinate(ts) !== null
+            ? (gap.filter((e) => ordering.coordinate(e.ts) !== null).at(-1)?.ts ?? markerBefore)
             : (participantGap.at(-1)?.ts ?? markerBefore)
           : ts
       const triggerWasAlreadyDelivered =
-        markerBefore !== null && msg.platform === 'slack' && compareSlackTs(ts, markerBefore) <= 0
+        markerBefore !== null && ordering !== undefined && ordering.compare(ts, markerBefore) <= 0
 
       // A stale Socket Mode event may be the wake-up signal even though the snapshot
       // contains newer instructions. In that case the old `context + current` shape is
       // actively wrong: it puts the obsolete trigger last. Deliver one chronological
       // unread batch so the newest human instruction is last and therefore salient.
+      // Only a natively ordered platform can tell "newer" from "older" at all; the
+      // rest keep the plain in-order shape below.
       const hasMessageAfterTrigger =
-        msg.platform === 'slack' && participantGap.some((e) => compareSlackTs(e.ts, ts) > 0)
+        ordering !== undefined && participantGap.some((e) => ordering.compare(e.ts, ts) > 0)
       if (hasMessageAfterTrigger || triggerWasAlreadyDelivered) {
         const { context, elided } = boundedReplay(participantGap)
         if (context.length === 0) {

--- a/packages/daemon/test/message-ordering.test.ts
+++ b/packages/daemon/test/message-ordering.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { hasNativeMessageOrder, messageOrderingFor } from '../src/platforms/message-ordering.js'
+
+describe('message-ordering strategy (cursorOrdering)', () => {
+  const slack = messageOrderingFor('slack')!
+
+  it('registers a native order for Slack only', () => {
+    expect(hasNativeMessageOrder('slack')).toBe(true)
+    for (const platform of ['telegram', 'discord', 'feishu', 'webchat', 'hook', 'github']) {
+      expect(hasNativeMessageOrder(platform)).toBe(false)
+      expect(messageOrderingFor(platform)).toBeUndefined()
+    }
+  })
+
+  it('is fail-closed for an unknown platform and for prototype keys', () => {
+    // The absence IS the default: no neutral comparator that could silently
+    // answer "equal" for ids it cannot order.
+    expect(messageOrderingFor('some-future-platform')).toBeUndefined()
+    expect(messageOrderingFor('constructor')).toBeUndefined()
+    expect(hasNativeMessageOrder('constructor')).toBe(false)
+    expect(hasNativeMessageOrder('toString')).toBe(false)
+  })
+
+  it('reads a Slack coordinate only from a canonical decimal ts', () => {
+    expect(slack.coordinate('1784098696.100000')).toBe(1784098696100000n)
+    // Short fractional parts are right-padded to microseconds, so '100.1' and
+    // '100.100000' are the SAME instant — both spellings appear on the wire.
+    expect(slack.coordinate('100.1')).toBe(slack.coordinate('100.100000'))
+    // Everything the platform never issued has no coordinate: anchored cron/hook
+    // UUIDs, bare epoch millis, and over-precise or malformed decimals.
+    for (const id of ['trace-1', 'cron:daily:trace-1', '1784098696', '100.1234567', '', '.5', '100.']) {
+      expect(slack.coordinate(id)).toBeNull()
+    }
+  })
+
+  it('orders Slack ids by microsecond, not lexically', () => {
+    // A plain string compare gets this backwards: lexically '1000.1' < '999.9',
+    // but 1000.1 is the LATER instant. Same divergence at the second boundary.
+    expect(slack.compare('1000.1', '999.9')).toBeGreaterThan(0)
+    expect(slack.compare('999.9', '1000.1')).toBeLessThan(0)
+    expect(slack.compare('99.999999', '100.000000')).toBeLessThan(0)
+    // Padding makes the two spellings of one instant compare equal.
+    expect(slack.compare('100.100000', '100.1')).toBe(0)
+    expect(slack.compare('100.10', '100.9')).toBeLessThan(0)
+    // BigInt, because microseconds at today's epoch exceed float precision.
+    expect(slack.compare('1784098696.100000', '1784098696.100001')).toBeLessThan(0)
+  })
+
+  it('sorts coordinate-less ids before every real one, and stays total', () => {
+    // A real follow-up must never look older than the synthetic cursor that
+    // created its thread (legacy anchored cron/hook turns persisted UUIDs).
+    expect(slack.compare('trace-1', '100.1')).toBeLessThan(0)
+    expect(slack.compare('100.1', 'trace-1')).toBeGreaterThan(0)
+    // Two synthetic ids still compare deterministically, so a sort is stable.
+    expect(slack.compare('trace-a', 'trace-b')).toBe('trace-a'.localeCompare('trace-b'))
+    expect(slack.compare('trace-a', 'trace-a')).toBe(0)
+    expect(['1000.1', 'trace-1', '100.10', '999.9'].sort(slack.compare)).toEqual([
+      'trace-1',
+      '100.10',
+      '999.9',
+      '1000.1'
+    ])
+  })
+
+  it('keeps coordinate-less ids inside any wall-clock cutoff', () => {
+    expect(slack.withinCutoff('100.1', '100.5')).toBe(true)
+    expect(slack.withinCutoff('100.5', '100.5')).toBe(true)
+    expect(slack.withinCutoff('100.6', '100.5')).toBe(false)
+    // A synthetic id cannot be compared with a wall-clock marker at all, so a
+    // snapshot keeps it rather than silently dropping it.
+    expect(slack.withinCutoff('trace-1', '100.5')).toBe(true)
+  })
+})

--- a/packages/daemon/test/routing-rule.test.ts
+++ b/packages/daemon/test/routing-rule.test.ts
@@ -4,9 +4,11 @@ import {
   resolveCpRule,
   resolveAgentIntegration,
   conversationAdmitted,
+  integrationRouting,
   type CpRule
 } from '../src/router/routing-rule.js'
-import type { Agent } from '../src/agents/agent-schema.js'
+import { configuredBotSelfId, integrationConfig, integrationCore } from '../src/platforms/integration-config.js'
+import type { Agent, Integration } from '../src/agents/agent-schema.js'
 
 function agent(over: Partial<Agent> = {}): Agent {
   return {
@@ -32,6 +34,84 @@ function agent(over: Partial<Agent> = {}): Agent {
     ...over
   } as Agent
 }
+
+describe('integrationRouting (§6.4 core-envelope read)', () => {
+  const bindRules = [{ channel: 'C1', match: { kind: 'mention' as const } }]
+  // One row per platform, each with the SAME core knobs but its own config block
+  // and its own name for the bot's id. The expected values are today's, read from
+  // the four arms this replaced.
+  const cases: { int: Integration; selfId: string }[] = [
+    {
+      int: {
+        id: 'i-slack',
+        platform: 'slack',
+        slack: { botToken: 'x', botUserId: 'U-SLACK', bindRules, mutedChannels: ['C9'], gated: true } as any
+      },
+      selfId: 'U-SLACK'
+    },
+    {
+      int: {
+        id: 'i-tg',
+        platform: 'telegram',
+        telegram: { botToken: 'x', botUserId: 'U-TG', bindRules, mutedChannels: ['C9'], gated: true } as any
+      },
+      selfId: 'U-TG'
+    },
+    {
+      int: {
+        id: 'i-dc',
+        platform: 'discord',
+        discord: { botToken: 'x', botUserId: 'U-DC', bindRules, mutedChannels: ['C9'], gated: true } as any
+      },
+      selfId: 'U-DC'
+    },
+    {
+      int: {
+        id: 'i-fs',
+        platform: 'feishu',
+        // Feishu's bot id is an open_id under a DIFFERENT field name — the one
+        // knob §6.4 deliberately leaves out of the core envelope.
+        feishu: {
+          appId: 'cli_x',
+          appSecret: 's',
+          botOpenId: 'OU-FS',
+          bindRules,
+          mutedChannels: ['C9'],
+          gated: true
+        } as any
+      },
+      selfId: 'OU-FS'
+    }
+  ]
+
+  it('extracts identical core knobs from every platform config block', () => {
+    for (const { int, selfId } of cases) {
+      expect(integrationRouting(int)).toEqual({
+        staticBotUserId: selfId,
+        bindRules,
+        mutedChannels: ['C9'],
+        gated: true
+      })
+      // The envelope read and the self-id strategy are separable: core owns one,
+      // the platform owns the other.
+      expect(integrationCore(int)).toEqual({ bindRules, mutedChannels: ['C9'], gated: true })
+      expect(configuredBotSelfId(int)).toBe(selfId)
+      expect(integrationConfig(int)).toBe((int as unknown as Record<string, unknown>)[int.platform])
+    }
+  })
+
+  it('normalizes an absent mutedChannels to empty and an unset bot id to undefined', () => {
+    // A hand-assembled integration (fixture / partial spec) never carried the
+    // post-hoc `mutedChannels` field; absent means "nothing muted".
+    const int = { id: 'i', platform: 'slack', slack: { botToken: 'x', bindRules: [] } } as unknown as Integration
+    expect(integrationRouting(int)).toEqual({
+      staticBotUserId: undefined,
+      bindRules: [],
+      mutedChannels: [],
+      gated: undefined
+    })
+  })
+})
 
 describe('rulesFromAgent', () => {
   it('derives one resolved RoutingRule per bindRule with the resolved botUserId', () => {

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -1336,6 +1336,111 @@ describe('SessionManager', () => {
     store.close()
   })
 
+  // ── cursorOrdering, per platform (platforms/message-ordering.ts) ──
+  // Both cases below run the SAME activation with the SAME message ids on two
+  // platforms, so the only variable is whether the platform's ids carry a native
+  // order. Slack's do; every other platform's are opaque, and the opaque arm is
+  // the fail-closed default a future platform inherits until it registers one.
+
+  /** One activation shape: open a session, plant two peer rows whose text order
+   *  disagrees with their instant order, then trigger. Returns the assembled
+   *  prompt and the read cursor the turn left behind. */
+  async function orderingRun(platform: string, channel: string, thread: string) {
+    const store = newStore()
+    const host = { newSession: vi.fn(async () => 'acp-1'), hasSession: vi.fn(() => true) } as any
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    const at = (ts: string, over: Record<string, unknown> = {}) =>
+      msg({ platform, channel, thread, ts, msgId: `${platform}:${channel}:${ts}`, ...over })
+
+    await sm.handle('bot-a', at('10.0', { text: 'opening request' }))
+    // '9.0' is the OLDER instant but sorts LAST as text, so the store hands the
+    // gap back in an order only a native comparator can fix.
+    for (const [ts, text] of [
+      ['11.0', 'later reply'],
+      ['9.0', 'earlier reply']
+    ]) {
+      store.appendTranscript({
+        channel,
+        thread,
+        ts: ts!,
+        sender: 'U2',
+        recipient: 'bot-a',
+        kind: 'text',
+        text: text!
+      })
+    }
+    const out = await sm.handle('bot-a', at('20.0', { text: 'trigger' }))
+    const cursor = store.getSession(sessionKey(platform, channel, thread, 'bot-a'))?.lastDeliveredTs
+    store.close()
+    return { prompt: out.blocks.map((b: any) => b.text ?? '').join('\n'), cursor }
+  }
+
+  it('re-sorts the replay gap into native order on Slack and leaves opaque ids alone', async () => {
+    const slack = await orderingRun('slack', 'C1', '100.1')
+    expect(slack.prompt.indexOf('earlier reply')).toBeLessThan(slack.prompt.indexOf('later reply'))
+    // Slack advances through the newest row of the stable window it just consumed.
+    expect(slack.cursor).toBe('20.0')
+
+    // No native order ⇒ nothing is re-sorted: the store's text order survives
+    // verbatim, and the cursor advances to the trigger itself.
+    const telegram = await orderingRun('telegram', '42', 'tg:1')
+    expect(telegram.prompt.indexOf('later reply')).toBeLessThan(telegram.prompt.indexOf('earlier reply'))
+    expect(telegram.cursor).toBe('20.0')
+  })
+
+  it('discards a coordinate-less read cursor only where ids order natively', async () => {
+    /** A cron turn persists its synthetic trace id as the cursor, then a real
+     *  follow-up arrives. `zzz-` makes the synthetic id sort AFTER every numeric
+     *  ts as text, so a cursor that is honoured hides the whole thread. */
+    const run = async (platform: string, channel: string, thread: string) => {
+      const store = newStore()
+      const host = { newSession: vi.fn(async () => 'acp-1'), hasSession: vi.fn(() => true) } as any
+      const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+      await sm.handle(
+        'bot-a',
+        msg({
+          platform,
+          channel,
+          thread,
+          msgId: 'cron:daily:zzz-trace',
+          traceId: 'zzz-trace',
+          source: 'cron',
+          text: 'scheduled task'
+        })
+      )
+      const key = sessionKey(platform, channel, thread, 'bot-a')
+      expect(store.getSession(key)?.lastDeliveredTs).toBe('zzz-trace')
+      store.appendTranscript({
+        channel,
+        thread,
+        ts: '5.0',
+        sender: 'U2',
+        recipient: 'bot-a',
+        kind: 'text',
+        text: 'context row'
+      })
+      const out = await sm.handle(
+        'bot-a',
+        msg({ platform, channel, thread, ts: '6.0', msgId: `${platform}:${channel}:6.0`, text: 'are you sure?' })
+      )
+      store.close()
+      return out.blocks.map((b: any) => b.text ?? '').join('\n')
+    }
+
+    // Slack: the persisted id is not one Slack ever issued, so the cursor is
+    // dropped and the turn runs one bounded catch-up from scratch.
+    const slack = await run('slack', 'C1', '100.100000')
+    expect(slack).toContain('scheduled task')
+    expect(slack).toContain('context row')
+
+    // Telegram: ids are opaque, so no id can be judged "not one this platform
+    // issued" — the cursor is honoured exactly as before this seam.
+    const telegram = await run('telegram', '42', 'tg:1')
+    expect(telegram).not.toContain('scheduled task')
+    expect(telegram).not.toContain('context row')
+    expect(telegram).toContain('are you sure?')
+  })
+
   it('a toAgent+channel wake dedups against the recorded post and keeps a canonical cursor', async () => {
     // Mirrors the real ops → delivery → SessionManager path for
     // `sendMessage({toAgent, channel, thread})`: ops posts a visible message (recordOutbound

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -731,6 +731,38 @@ describe('SessionReader', () => {
     s.close()
   })
 
+  it('tails in mutation order where message ids are opaque, in event order where they are not', () => {
+    // Same two rows, observed newest-first, on two platforms. Mutation order and
+    // display order can only diverge where the ids carry a native order — which is
+    // exactly what platforms/message-ordering.ts answers.
+    const tailFor = (platform: string): string[] => {
+      const s = store()
+      seedHistorySession(s, { platform, channel: 'chat-1', thread: 'T1' })
+      const reader = createSessionReader(s)
+      const initial = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
+      for (const [ts, text] of [
+        ['101', 'observed first'],
+        ['100', 'older, backfilled after']
+      ]) {
+        s.appendTranscript({
+          channel: 'chat-1',
+          thread: 'T1',
+          ts: ts!,
+          sender: 'user-1',
+          recipient: AGENT,
+          kind: 'text',
+          text: text!
+        })
+      }
+      const tail = reader.history({ agentId: AGENT, sessionId: 'acp-1', after: initial.liveCursor!, limit: 50 })
+      s.close()
+      return tail.messages.map((m) => m.text)
+    }
+
+    expect(tailFor('telegram')).toEqual(['observed first', 'older, backfilled after'])
+    expect(tailFor('slack')).toEqual(['older, backfilled after', 'observed first'])
+  })
+
   it('repairs chronological reads from a pre-upgrade transcript table', () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-reader-order-mig-')), 'local.sqlite')
     const legacy = new DatabaseSync(path)


### PR DESCRIPTION
## What

Two `integration-plugin-audit.md` Appendix-A clusters, both pure strategy
extractions. No behavior moves — see the verification note at the bottom.

### `cursorOrdering` (class c) → `platforms/message-ordering.ts`

Seven sites across `session/session-manager.ts` and `cp/session-reader.ts` asked
one question — *do this platform's message ids carry a native total order, and
how do two of them compare?* — and every one spelled the answer as
`platform === 'slack'` next to a Slack-timestamp parser. Adding a platform with
ordered ids meant finding all seven, and missing one leaves a read cursor that
silently skips or re-delivers messages.

A platform now supplies exactly one thing: how to read a coordinate out of one of
its ids. The total order, the synthetic-coordinate rule (a real follow-up must
never look older than the legacy anchored-cron UUID that created its thread) and
the wall-clock cutoff test are shared, because those are **daemon** facts, not
platform ones.

**Not a §5 manifest axis, deliberately.** The manifest's rule has teeth: a field
is earned by a PRE-DISPATCH read. Every read here happens inside a turn that
already exists — assembling one activation's prompt, paging one session's
transcript — so this is a §7.4 strategy function in the daemon's platform module
layer, registered exactly like `threadKeyForPost` and `sessionLinkSourceFor`.

**Fail-closed by ABSENCE.** `messageOrderingFor` returns `undefined` where ids
are opaque (every platform but Slack today), and the type system then forces each
call site to state what "no order" means there. There is no neutral default
object on purpose: a comparator that quietly answers `0` would turn "these ids
are not comparable" into "these ids are equal", and the cursor bug that follows
is invisible. Every `undefined` branch is today's non-Slack path — nothing
re-sorted, no two ids compared, cursor advances to the trigger.

`slackTsForWallClock` deliberately stays in `session-manager.ts`. Its only
callers are the warm-thread snapshot cutoff and the daemon's final-fence
checkpoint, which the audit assigns to `threadBackfill` (the Layer-1 read port,
row `session-manager.ts:951`) — a different strategy and a later PR. Leaving it
also keeps `daemon.ts` out of this diff, which matters while parallel tracks are
in flight.

### routing-rule core knobs (class b) → `platforms/integration-config.ts`

`integrationRouting` switched four ways on `int.platform` purely to reach three
**identically-named** fields, so a new platform had to edit the router before it
could be routed at all. §6.4 makes `bindRules` / `mutedChannels` / `gated` the
core envelope, so this becomes an envelope read plus one registered strategy for
the value §6.4 leaves out of the envelope on purpose: the bot's own id, which
Feishu spells `botOpenId` because its bots have an open_id, not a user id. A
platform that registers no reader falls back to the `botUserId` name the other
three share.

The config block is read at the integration's own platform id — the same read
after §6.4 renames the slot to `config`, so that flip is a one-line change here.
`IntegrationConfig` is derived from the `Integration` union rather than re-listed,
so the two cannot drift; the probe below confirms it resolves to a real union
(not `never`/`any`) and that `bindRules` stays fully typed.

`resolveAgentIntegration`'s same-platform reply preference (line ~124) **stays**
platform-keyed and now says so inline: it is a platform-vs-platform equality with
no literal in it, already correct for any platform an open `PlatformId` can name.

MCP Layer-1 rows (`mcp/ops.ts`, `mcp/tools.ts`, `daemon.ts:8858`) are out of
scope, as are `session-manager.ts:685` (`selfMentionId`) and `:951`
(`threadBackfill`).

## Tests

`GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/daemon test`
→ **172 files / 2919 passed**, 6 files / 46 skipped.

One pre-existing flake: `daemon-agent-mention-routing.test.ts >
"admits source depth 7 as 8…"` times out under full-suite load. It passes
standalone in this branch (`31/31`) and is a known load flake on clean main — not
touched here.

11 new assertions:

| Suite | + | Pins |
| --- | --- | --- |
| `test/message-ordering.test.ts` (new) | 6 | Slack registered / everything else and `constructor`/`toString` fail-closed; coordinate parsed only from a canonical decimal ts; microsecond (not lexical) order; coordinate-less ids sort first and stay total; cutoff keeps coordinate-less ids |
| `test/routing-rule.test.ts` | 2 | Identical core knobs extracted from all four platform config blocks, each with its own bot-id field name (`botUserId` ×3, `botOpenId`); absent `mutedChannels` still normalizes to `[]` |
| `test/session-manager.test.ts` | 2 | One activation shape run twice with **identical message ids**: Slack re-sorts the replay gap into native order and discards a coordinate-less cron cursor; an opaque-id platform leaves the store's text order verbatim, honours the cursor, and advances it to the trigger |
| `test/session-reader.test.ts` | 1 | Tail page: event order where ids order natively, mutation (seq) order where they are opaque |

**Mutation-checked.** Temporarily registering a second platform in `ORDERINGS`
fails exactly the new per-platform tests plus the pre-existing
`preserves insertion ordering for non-Slack platform message ids` — so none of
them pass vacuously. Reverted before commit.

Also green: `pnpm --filter @agentconnect.md/daemon exec tsc -p tsconfig.json
--noEmit`, `eslint` on the nine touched files, `prettier --write`.

## Behavior

None. Each rewritten predicate was checked against its predecessor arm by arm —
including the one asymmetry worth naming: `withinCutoff` treats a coordinate-less
id as inside the window (matching the two sites that had an explicit
`coordinate !== null &&` guard), while `triggerWasAlreadyDelivered` keeps a raw
`compare(...) <= 0` because its predecessor had no such guard and relied on
`compare`'s both-null `localeCompare` arm. Reusing `withinCutoff` there would
have changed the both-synthetic case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
