### PR TITLE
fix(web): place worktree selector in workspace header

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -801,11 +801,11 @@ it opens the Agent's primary workspace. Its git or folder icon reflects that sou
 A session worktree is browse-only in the console: file editing and pull remain actions
 on the primary workspace.
 
-The checkout selector and workspace source form one context card. Its `Viewing`
-row names the primary checkout or session worktree currently shown; the `Source`
-row directly beneath it names the repository or scratch workspace that provides
-those files. Worktree choices keep their Session link in the selector so changing
-the viewed files and opening the originating conversation remain distinct actions.
+The checkout selector sits at the right of the Workspace file browser header,
+opposite the current file breadcrumb. The Source card remains directly above the
+browser and names the repository or scratch workspace that provides those files.
+Worktree choices keep their Session link in the selector so changing the viewed
+files and opening the originating conversation remain distinct actions.
 
 Workspace changes are cold edits: active work is drained and existing cached
 credentials are cleared before the new definition becomes active. Any edit that removes

--- a/packages/web/src/components/console/FileBrowser.tsx
+++ b/packages/web/src/components/console/FileBrowser.tsx
@@ -93,12 +93,12 @@ export function FileBrowserShell({
   children: ReactNode
 }) {
   return (
-    <div className="card overflow-hidden max-desktop:rounded-lg">
+    <div className="card relative max-desktop:rounded-lg">
       <div className="cardhead min-h-[41px] min-w-0 justify-between py-[6px]">
         <div className="cardtitle min-w-0 flex-1">{title}</div>
         {headerEnd}
       </div>
-      {children}
+      <div className="overflow-hidden rounded-b-[inherit]">{children}</div>
     </div>
   )
 }

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -24,7 +24,7 @@
 // (the design's inline add-expander is skipped — established precedent: the
 // modal owns the picker/tier/preflight flow).
 
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import { GithubMark, LoadingState } from '@/components/marks'
@@ -81,14 +81,10 @@ const SEG_OFF_LOCKED =
 export function WorkspaceCard({
   agent,
   header,
-  viewing,
   className
 }: {
   agent: Agent
   header?: WorkspaceHeaderInfo
-  /** Current checkout selector. It shares this context card with Source so the
-   *  first row answers what is being viewed and the second where it comes from. */
-  viewing?: ReactNode
   className?: string
 }) {
   const { activeOrg } = useOrgs()
@@ -162,8 +158,7 @@ export function WorkspaceCard({
     mode === ws.mode ? (canEdit ? SEG_ON : SEG_ON_LOCKED) : canEdit ? SEG_OFF : SEG_OFF_LOCKED
 
   return (
-    <div className={`card relative max-desktop:rounded-lg ${className ?? ''}`}>
-      {viewing}
+    <div className={`card overflow-hidden max-desktop:rounded-lg ${className ?? ''}`}>
       {/* Source row — conversion segment, then the workspace identity and its
           live git actions. Wraps on narrow viewports; nothing is truncated away. */}
       <div className="flex flex-wrap items-center gap-[10px] px-4 py-[9px]">

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -116,6 +116,24 @@ it('uses configured edit access even before runtime Git status loads', () => {
   expect(html).toContain('Add file')
 })
 
+it('places the checkout selector in the file browser header', () => {
+  const html = renderToStaticMarkup(
+    <WorkspaceFiles
+      agentId="agent-a"
+      workdir="/workspace"
+      canEdit={false}
+      workspacePicker={<span data-testid="workspace-picker">Checkout</span>}
+      renderHeader={() => <div data-testid="source-card">Source</div>}
+    />
+  )
+  const host = document.createElement('div')
+  host.innerHTML = html
+  const picker = host.querySelector('[data-testid="workspace-picker"]')
+
+  expect(picker?.closest('.cardhead')).not.toBeNull()
+  expect(picker?.closest('.card')?.querySelector('[data-testid="source-card"]')).toBeNull()
+})
+
 // The workspace editor lives in the card this browser renders, so a replacement
 // has to remount the instance — otherwise the previous tree/preview/git state
 // survives underneath a refreshed source card (and GitHub → scratch turns the

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -158,6 +158,7 @@ export function WorkspaceFiles({
   sessionId,
   workdir,
   canEdit,
+  workspacePicker,
   renderHeader
 }: {
   agentId: string
@@ -166,6 +167,8 @@ export function WorkspaceFiles({
   sessionId?: string
   workdir?: string
   canEdit: boolean
+  /** Checkout selector rendered opposite the current file breadcrumb. */
+  workspacePicker?: ReactNode
   /** Renders the workspace card above the tree from the live git read model.
    *  Called on every render — including before the status lands (empty info) and
    *  for non-repo workspaces — so the card's own controls are never gated on a
@@ -729,7 +732,8 @@ export function WorkspaceFiles({
               }
             />
           ) : (
-            <div className="flex flex-none items-center gap-2">
+            <div className="flex min-w-0 flex-none items-center gap-2">
+              {workspacePicker}
               {deleteDraft ? (
                 <>
                   <Button

--- a/packages/web/src/components/console/WorkspaceScopePicker.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.tsx
@@ -119,10 +119,9 @@ export function WorkspaceScopePicker({
 
   return (
     <div
-      className={`relative flex flex-wrap items-center gap-[10px] border-b border-(--border-subtle) px-4 py-[9px] ${open ? 'z-30' : ''}`}
+      className={`relative w-[min(640px,58vw)] min-w-0 flex-none max-desktop:w-[min(210px,56vw)] ${open ? 'z-30' : ''}`}
     >
-      <span className="eyebrow flex-none text-[10.5px]">Viewing</span>
-      <div className="relative min-w-0 flex-[1_1_360px]">
+      <div className="relative min-w-0">
         <div
           className={`flex h-8 min-w-0 items-center overflow-hidden rounded-md border bg-(--surface-card) ${
             open

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1634,36 +1634,31 @@ export default function AgentDetailView() {
               {...(selectedWorktreeSessionId ? { sessionId: selectedWorktreeSessionId } : {})}
               workdir={da.workdir}
               canEdit={selectedWorktreeSessionId === null && da.workspace.mode === 'scratch' && da.canEdit}
-              renderHeader={(header) => (
-                <WorkspaceCard
-                  agent={da}
-                  header={header}
-                  viewing={
-                    da.workspace.mode === 'github' &&
-                    (da.workspace.worktree === true ||
-                      selectedWorktreeSessionId !== null ||
-                      workspaceSessionsNextCursor !== null ||
-                      workspaceSessions.some((session) => session.workspaceIsolation === 'session')) ? (
-                      <WorkspaceScopePicker
-                        sessions={workspaceSessions}
-                        selectedSessionId={selectedWorktreeSessionId}
-                        selectedSession={selectedWorktreeSession}
-                        loading={workspaceSessionsLoading}
-                        hasMore={workspaceSessionsNextCursor !== null}
-                        loadingMore={workspaceSessionsLoadingMore}
-                        onLoadMore={() => void loadMoreWorkspaceSessions()}
-                        onChange={(sessionId) => {
-                          const next = new URLSearchParams(params)
-                          if (sessionId) next.set('worktree', sessionId)
-                          else next.delete('worktree')
-                          router.replace(`${orgPath(`/agents/${id}`)}?${next.toString()}`, { scroll: false })
-                        }}
-                        orgPath={orgPath}
-                      />
-                    ) : undefined
-                  }
-                />
-              )}
+              workspacePicker={
+                da.workspace.mode === 'github' &&
+                (da.workspace.worktree === true ||
+                  selectedWorktreeSessionId !== null ||
+                  workspaceSessionsNextCursor !== null ||
+                  workspaceSessions.some((session) => session.workspaceIsolation === 'session')) ? (
+                  <WorkspaceScopePicker
+                    sessions={workspaceSessions}
+                    selectedSessionId={selectedWorktreeSessionId}
+                    selectedSession={selectedWorktreeSession}
+                    loading={workspaceSessionsLoading}
+                    hasMore={workspaceSessionsNextCursor !== null}
+                    loadingMore={workspaceSessionsLoadingMore}
+                    onLoadMore={() => void loadMoreWorkspaceSessions()}
+                    onChange={(sessionId) => {
+                      const next = new URLSearchParams(params)
+                      if (sessionId) next.set('worktree', sessionId)
+                      else next.delete('worktree')
+                      router.replace(`${orgPath(`/agents/${id}`)}?${next.toString()}`, { scroll: false })
+                    }}
+                    orgPath={orgPath}
+                  />
+                ) : undefined
+              }
+              renderHeader={(header) => <WorkspaceCard agent={da} header={header} />}
             />
           </div>
         ) : (


### PR DESCRIPTION
## Summary

- move the worktree selector into the Workspace file-browser header, opposite the breadcrumb
- keep the Source card independent above the browser
- let the selector menu overlay the file body without being clipped
- add a regression test for the selector's header placement

## Root cause

The selector was composed through the Source card's header renderer, so it appeared in the source context instead of the file-browser header shown in the design.

## Validation

- `pnpm --filter @agentconnect.md/web test` (96 files, 732 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm lint`
- `pnpm format:check`
- desktop and 390 px mobile visual verification

Created by Codex . GPT-5.6
