### PR TITLE
refactor(cp): the POST /integrations credential union comes from the platform registry (S3 §9)

### DIFF
--- a/packages/control-plane/scripts/generate-openapi.ts
+++ b/packages/control-plane/scripts/generate-openapi.ts
@@ -31,9 +31,22 @@ import { writeFileSync } from 'node:fs'
 import { buildHttpServer } from '../src/http/server.js'
 import type { HttpDeps } from '../src/http/deps.js'
 import { API_V1_PREFIX } from '../src/http/version.js'
+import { buildCpPlatformRegistry } from '../src/platforms/registry.js'
+import { createTelegramCpProvider } from '../src/platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../src/platforms/discord/provider.js'
+import { createSlackCpProvider } from '../src/platforms/slack/provider.js'
+import { createFeishuCpProvider } from '../src/platforms/feishu/provider.js'
 
-/** Only `config` is read at spec-build time; repos stay untouched (the docs/spec
- *  routes hit no DB-backed handler). Same stub shape as `openapi.test.ts`. */
+/** `config` plus the platform registry are read at spec-build time; repos stay
+ *  untouched (the docs/spec routes hit no DB-backed handler). Same stub shape as
+ *  `openapi.test.ts`.
+ *
+ *  The registry is REQUIRED, not decorative: `POST /integrations` folds each
+ *  provider's `credentialBodySchema` into its documented request body when the
+ *  route plugin registers (§9), so an absent registry fails `app.ready()` and a
+ *  provider missing HERE is a platform missing from the PUBLISHED spec. Keep the
+ *  set mirroring `container.ts`'s registration. The seams are offline stubs —
+ *  no handler runs, so none of them is ever called. */
 function stubDeps(): HttpDeps {
   const publicUrl = process.env.PUBLIC_CP_URL
   return {
@@ -42,7 +55,13 @@ function stubDeps(): HttpDeps {
       NODE_ENV: 'production',
       DEFAULT_OWNER_ID: '00000000-0000-4000-8000-000000000000',
       ...(publicUrl ? { PUBLIC_CP_URL: publicUrl } : {})
-    }
+    },
+    platforms: buildCpPlatformRegistry([
+      createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+      createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+      createSlackCpProvider({}),
+      createFeishuCpProvider({})
+    ])
   } as unknown as HttpDeps
 }
 

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -782,8 +782,19 @@ export function buildContainer(
   const syncDiscordBotProfile = createDiscordBotProfileSyncer(iconStore)
   const syncFeishuAppIcon = createFeishuAppIconSyncer(iconStore)
 
+  // LATE-BOUND on purpose: the providers below are constructed WITH `httpDeps`
+  // (their funnel plugins are route factories pre-bound to this very bundle), so
+  // the registry cannot exist before this object does. Every reader runs at
+  // Fastify `ready()` time or later — route plugins are registered lazily — by
+  // which point `buildContainer` has assigned it.
+  let platformRegistry: CpPlatformRegistry | undefined = undefined
+
   const httpDeps: HttpDeps = {
     clock,
+    get platforms(): CpPlatformRegistry {
+      if (!platformRegistry) throw new Error('platform registry read before composition')
+      return platformRegistry
+    },
     repos: {
       agent: repos.agent,
       assignment: repos.assignment,
@@ -1033,13 +1044,15 @@ export function buildContainer(
   // functions, route-dep bundle, funnel stores, and background-loop instances
   // the live paths use (one implementation; the providers add no second code
   // path). The Slack/Feishu funnel plugins are handed in PRE-BOUND to
-  // `httpDeps` — the very factories `server.ts` mounts — because the route
-  // modules consume the create-DTO module, which imports the providers'
-  // credential blocks (importing the factories from the provider modules would
-  // close a runtime import cycle). Nothing consumes the registry yet beyond
-  // construction — the create route, spec assembly, rc/bot-assign, route
-  // mounting, `loadConfig`'s schema fold, and `startBackground()` adopt it in
-  // follow-up PRs.
+  // `httpDeps` — the very factories `server.ts` mounts — keeping provider
+  // construction one-directional (a provider never reaches back for a route
+  // factory). That is also why the registry is published to `httpDeps` through
+  // the late-bound getter above rather than as a plain field.
+  //
+  // ADOPTED SO FAR: the `POST /integrations` create body + its live
+  // `validateConfig` dispatch read the registry through `httpDeps.platforms`.
+  // Spec assembly, rc/bot-assign, route mounting, `loadConfig`'s schema fold,
+  // and `startBackground()` adopt it in follow-up PRs.
   const platforms = buildCpPlatformRegistry([
     createTelegramCpProvider({ verifyBot: verifyTelegramBot, syncBotIcon: syncTelegramBotIcon }),
     createDiscordCpProvider({
@@ -1073,6 +1086,7 @@ export function buildContainer(
       }
     })
   ])
+  platformRegistry = platforms
 
   // ── daemon WS edge (mounted on the live http.Server after listen) ──────────
   const wsDeps: DaemonWsServerDeps = {

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -56,6 +56,7 @@ import type { GithubUserAuthzService } from '../github/user-authz.js'
 import type { LogtoIdentityService } from '../github/logto-identity.js'
 import type { HookService } from '../hooks/hook.service.js'
 import type { DaemonRegistry, DaemonAuth, ApiKeyAdmin, DaemonLiveness } from '../ports.js'
+import type { CpPlatformRegistry } from '../platforms/provider.js'
 import type { DaemonReleaseResolver } from '../registry/daemonRelease.js'
 import type { WebchatTokenService } from '../registry/webchatToken.js'
 import type { OrgInviteLinkService } from '../registry/orgInviteLinkService.js'
@@ -231,6 +232,12 @@ export interface HttpDeps {
     oauth: OAuthRepo
   }
   registry: DaemonRegistry
+  /** §9 platform-provider registry — the single platform-set authority. The
+   *  create route folds each provider's `credentialBodySchema` /
+   *  `refineCreateBody` into its request schema and dispatches the live
+   *  credential check through `validateConfig`, so no route file names a
+   *  platform to validate one. */
+  platforms: CpPlatformRegistry
   /** The ONE assembler of CP→daemon AgentSpecs (owns secret loading + icon bases) —
    *  every spec emission (upsert replicate, icon refresh, move activation) uses it. */
   agentSpecs: AgentSpecAssembler

--- a/packages/control-plane/src/http/dto/create-integration-body.test.ts
+++ b/packages/control-plane/src/http/dto/create-integration-body.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Equivalence suite for the REGISTRY-COMPOSED `POST /integrations` create body
+ * (integration-plugin-architecture.md §9).
+ *
+ * The fixtures below are written from the behavior of the hand-written closed
+ * union this composition replaces (four literal credential keys, a literal
+ * four-id mismatch loop, and a `b.platform === 'slack' | 'feishu'` refine
+ * dispatch): every body the old schema ACCEPTED must still be accepted, every
+ * body it REJECTED must still be rejected, with the same user-facing messages.
+ * That is the whole contract of the S3 refactor — the platform name stops being
+ * core knowledge, the wire does not move.
+ *
+ * The second suite pins the regression a dynamic composition can silently lose:
+ * `/api/v1/openapi.json` must still enumerate every registered platform's
+ * credential variant (a docs-only loss is invisible to a parse-level test).
+ */
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import type { FastifyInstance } from 'fastify'
+import { buildCreateIntegrationBody, credentialBlockOf } from './create-integration-body.js'
+import { buildHttpServer } from '../server.js'
+import type { HttpDeps } from '../deps.js'
+import { buildCpPlatformRegistry } from '../../platforms/registry.js'
+import type { CpPlatformProvider, CpPlatformRegistry } from '../../platforms/provider.js'
+import { createTelegramCpProvider } from '../../platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../../platforms/discord/provider.js'
+import { createSlackCpProvider } from '../../platforms/slack/provider.js'
+import { createFeishuCpProvider } from '../../platforms/feishu/provider.js'
+
+/** The four production providers, composed with offline seams — the same set
+ *  `buildContainer` registers, so the schema under test is the deployed one. */
+function offlinePlatforms(): CpPlatformRegistry {
+  return buildCpPlatformRegistry([
+    createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+    createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+    createSlackCpProvider({}),
+    createFeishuCpProvider({})
+  ])
+}
+
+const Body = buildCreateIntegrationBody(offlinePlatforms())
+const AGENT = '11111111-1111-4111-8111-111111111111'
+const BOT = '22222222-2222-4222-8222-222222222222'
+
+const messages = (input: unknown): string[] => {
+  const parsed = Body.safeParse(input)
+  return parsed.success ? [] : parsed.error.issues.map((issue) => issue.message)
+}
+const accepts = (input: unknown): boolean => Body.safeParse(input).success
+
+describe('composed create-integration body: accepts what the closed union accepted', () => {
+  it('registers a new bot from each platform’s credential block', () => {
+    expect(accepts({ platform: 'slack', agentId: AGENT, slack: { botToken: 'xoxb-1', appToken: 'xapp-1' } })).toBe(true)
+    expect(accepts({ platform: 'telegram', agentId: AGENT, telegram: { botToken: '123:abc' } })).toBe(true)
+    expect(accepts({ platform: 'discord', agentId: AGENT, discord: { botToken: 'MTA1.bot.token' } })).toBe(true)
+    expect(accepts({ platform: 'feishu', agentId: AGENT, feishu: { appId: 'cli_x', appSecret: 's' } })).toBe(true)
+  })
+
+  it('reuses an existing bot on every platform (no credential block)', () => {
+    for (const platform of ['slack', 'telegram', 'discord', 'feishu']) {
+      expect(accepts({ platform, agentId: AGENT, botId: BOT })).toBe(true)
+    }
+  })
+
+  it('keeps the optional core knobs and each block’s optional fields', () => {
+    expect(
+      accepts({
+        name: 'acme',
+        platform: 'slack',
+        agentId: AGENT,
+        shareable: true,
+        transport: 'http',
+        slack: { botToken: 'xoxb-1', signingSecret: 'sig' }
+      })
+    ).toBe(true)
+    expect(
+      accepts({ platform: 'discord', agentId: AGENT, discord: { botToken: 'MTA1.b.c', applicationId: 'A1' } })
+    ).toBe(true)
+    expect(
+      accepts({
+        platform: 'feishu',
+        agentId: AGENT,
+        transport: 'http',
+        feishu: { appId: 'cli_x', appSecret: 's', region: 'feishu', verificationToken: 'v', encryptKey: 'e' }
+      })
+    ).toBe(true)
+  })
+
+  it('defaults an omitted feishu region to Lark and drops unknown keys (non-strict)', () => {
+    const parsed = Body.parse({ platform: 'feishu', agentId: AGENT, feishu: { appId: 'cli_x', appSecret: 's' }, zz: 1 })
+    expect(parsed).toMatchObject({ platform: 'feishu', agentId: AGENT, feishu: { region: 'lark' } })
+    expect(parsed).not.toHaveProperty('zz')
+  })
+})
+
+describe('composed create-integration body: rejects what the closed union rejected', () => {
+  it('requires exactly one of botId or the platform’s credential block', () => {
+    expect(messages({ platform: 'slack', agentId: AGENT })).toContain('exactly one of botId or slack must be provided')
+    expect(messages({ platform: 'telegram', agentId: AGENT, botId: BOT, telegram: { botToken: '123:abc' } })).toContain(
+      'exactly one of botId or telegram must be provided'
+    )
+  })
+
+  it('rejects a credential block that belongs to another platform', () => {
+    expect(messages({ platform: 'telegram', agentId: AGENT, slack: { botToken: 'xoxb-1' } })).toContain(
+      'slack credentials given for a telegram integration'
+    )
+    // Both wrong blocks are reported, and the exactly-one-of rule still fires.
+    const both = messages({ platform: 'feishu', agentId: AGENT, discord: { botToken: 'd' }, slack: { botToken: 'x' } })
+    expect(both).toContain('discord credentials given for a feishu integration')
+    expect(both).toContain('slack credentials given for a feishu integration')
+    expect(both).toContain('exactly one of botId or feishu must be provided')
+  })
+
+  it('enforces the per-transport credential requirements of slack and feishu', () => {
+    const base = { platform: 'slack', agentId: AGENT }
+    expect(messages({ ...base, transport: 'http', slack: { botToken: 'xoxb-1' } })).toContain(
+      'http transport requires slack.signingSecret'
+    )
+    // An omitted transport is the create route's socket default.
+    expect(messages({ ...base, slack: { botToken: 'xoxb-1' } })).toContain('socket transport requires slack.appToken')
+    expect(messages({ ...base, transport: 'socket', slack: { botToken: 'xoxb-1' } })).toContain(
+      'socket transport requires slack.appToken'
+    )
+    expect(
+      messages({ platform: 'feishu', agentId: AGENT, transport: 'http', feishu: { appId: 'cli_x', appSecret: 's' } })
+    ).toContain('http transport requires feishu.verificationToken')
+  })
+
+  it('does not run the transport refinements when an existing bot is reused', () => {
+    expect(accepts({ platform: 'slack', agentId: AGENT, botId: BOT, transport: 'http' })).toBe(true)
+    expect(accepts({ platform: 'feishu', agentId: AGENT, botId: BOT, transport: 'http' })).toBe(true)
+  })
+
+  it('rejects a missing secret inside a credential block', () => {
+    expect(accepts({ platform: 'telegram', agentId: AGENT, telegram: {} })).toBe(false)
+    expect(accepts({ platform: 'telegram', agentId: AGENT, telegram: { botToken: '' } })).toBe(false)
+    expect(accepts({ platform: 'slack', agentId: AGENT, slack: { appToken: 'xapp-1' } })).toBe(false)
+    expect(accepts({ platform: 'feishu', agentId: AGENT, feishu: { appId: 'cli_x' } })).toBe(false)
+    expect(
+      accepts({ platform: 'feishu', agentId: AGENT, feishu: { appId: 'cli_x', appSecret: 's', region: 'qq' } })
+    ).toBe(false)
+  })
+
+  it('rejects an unregistered platform, a bad transport, and a missing agent', () => {
+    expect(accepts({ platform: 'mastodon', agentId: AGENT, mastodon: { botToken: 't' } })).toBe(false)
+    expect(accepts({ agentId: AGENT, botId: BOT })).toBe(false)
+    expect(accepts({ platform: 'slack', agentId: AGENT, botId: BOT, transport: 'websocket' })).toBe(false)
+    expect(accepts({ platform: 'slack', botId: BOT })).toBe(false)
+    expect(accepts({ platform: 'slack', agentId: '', botId: BOT })).toBe(false)
+    expect(accepts({ platform: 'slack', agentId: AGENT, botId: BOT, name: '' })).toBe(false)
+    expect(accepts({ platform: 'slack', agentId: AGENT, botId: BOT, shareable: 'yes' })).toBe(false)
+  })
+})
+
+describe('the composition IS the platform-set authority', () => {
+  /** A minimal fifth provider — only the members the composition reads are
+   *  meaningful; the rest satisfy the contract without being exercised. */
+  function mastodonProvider(): CpPlatformProvider<{ accessToken: string }> {
+    return {
+      platformId: 'mastodon',
+      installRoutes: () => [],
+      credentialBodySchema: z.object({ accessToken: z.string().min(1) }),
+      refineCreateBody: ({ credentials, transport }, addIssue) => {
+        if (transport === 'http' && !credentials.accessToken.startsWith('http-')) {
+          addIssue('http transport requires an http-scoped mastodon.accessToken')
+        }
+      },
+      validateConfig: async () => ({ ok: true, identity: {} }),
+      secretShape: { slots: { botToken: 'Mastodon access token' }, httpAssignRequires: [] },
+      projectIntegrationConfig: async () => ({})
+    }
+  }
+
+  it('extends the wire with a newly registered provider — no edit to the composition', () => {
+    const Extended = buildCreateIntegrationBody(
+      buildCpPlatformRegistry([createSlackCpProvider({}), mastodonProvider()])
+    )
+    expect(Extended.safeParse({ platform: 'mastodon', agentId: AGENT, mastodon: { accessToken: 'a' } }).success).toBe(
+      true
+    )
+    // The new platform inherits every cross-block rule for free…
+    const mismatch = Extended.safeParse({ platform: 'mastodon', agentId: AGENT, slack: { botToken: 'xoxb-1' } })
+    expect(mismatch.success).toBe(false)
+    expect(!mismatch.success && mismatch.error.issues.map((i) => i.message)).toEqual(
+      expect.arrayContaining([
+        'slack credentials given for a mastodon integration',
+        'exactly one of botId or mastodon must be provided'
+      ])
+    )
+    // …and contributes its own transport refinement through the same seam.
+    const badTransport = Extended.safeParse({
+      platform: 'mastodon',
+      agentId: AGENT,
+      transport: 'http',
+      mastodon: { accessToken: 'a' }
+    })
+    expect(!badTransport.success && badTransport.error.issues[0]?.message).toBe(
+      'http transport requires an http-scoped mastodon.accessToken'
+    )
+    // A platform the registry does NOT hold is not on the wire at all.
+    expect(Extended.safeParse({ platform: 'telegram', agentId: AGENT, botId: BOT }).success).toBe(false)
+  })
+
+  it('hands the chosen platform’s block back opaquely, and undefined when a bot is reused', () => {
+    expect(
+      credentialBlockOf(Body.parse({ platform: 'telegram', agentId: AGENT, telegram: { botToken: 't' } }))
+    ).toEqual({ botToken: 't' })
+    expect(credentialBlockOf(Body.parse({ platform: 'slack', agentId: AGENT, botId: BOT }))).toBeUndefined()
+  })
+
+  it('refuses to compose a body with no registered platform, or an id that shadows a core field', () => {
+    expect(() => buildCreateIntegrationBody(buildCpPlatformRegistry([]))).toThrow(/no platform provider is registered/)
+    const shadow: CpPlatformProvider = { ...mastodonProvider(), platformId: 'transport' }
+    expect(() => buildCreateIntegrationBody(buildCpPlatformRegistry([shadow]))).toThrow(/collides with a core/)
+  })
+})
+
+describe('the generated OpenAPI document still enumerates every platform variant', () => {
+  /** Only `config` is read at build time; the create route additionally folds
+   *  the registry into its body schema at plugin-registration time. */
+  function stubDeps(): HttpDeps {
+    return {
+      repos: { user: { provisionOidcUser: async () => ({ userId: 'u' }) } },
+      config: { NODE_ENV: 'test', DEFAULT_OWNER_ID: '00000000-0000-4000-8000-000000000000' },
+      platforms: offlinePlatforms()
+    } as unknown as HttpDeps
+  }
+
+  async function createIntegrationOperation(): Promise<Record<string, any>> {
+    const app: FastifyInstance = buildHttpServer(stubDeps())
+    try {
+      await app.ready()
+      const doc = (await app.inject({ method: 'GET', url: '/api/v1/openapi.json' })).json() as Record<string, any>
+      return doc.paths?.['/api/v1/orgs/{orgId}/integrations']?.post
+    } finally {
+      await app.close()
+    }
+  }
+
+  it('documents one request-body property per registered platform, with its own fields', async () => {
+    const op = await createIntegrationOperation()
+    const schema = op?.requestBody?.content?.['application/json']?.schema
+    expect(schema?.properties?.platform?.enum?.slice().sort()).toEqual(['discord', 'feishu', 'slack', 'telegram'])
+    expect(Object.keys(schema?.properties ?? {})).toEqual(
+      expect.arrayContaining(['slack', 'telegram', 'discord', 'feishu'])
+    )
+    expect(Object.keys(schema?.properties?.slack?.properties ?? {}).sort()).toEqual([
+      'appToken',
+      'botToken',
+      'signingSecret'
+    ])
+    expect(Object.keys(schema?.properties?.telegram?.properties ?? {})).toEqual(['botToken'])
+    expect(Object.keys(schema?.properties?.discord?.properties ?? {}).sort()).toEqual(['applicationId', 'botToken'])
+    expect(Object.keys(schema?.properties?.feishu?.properties ?? {}).sort()).toEqual([
+      'appId',
+      'appSecret',
+      'encryptKey',
+      'region',
+      'verificationToken'
+    ])
+    // Credentials are the only optional half: the core skeleton stays required.
+    expect(schema?.required?.slice().sort()).toEqual(['agentId', 'platform'])
+  })
+
+  it('keeps the repo’s OpenAPI conventions on the route (docs UI renders a named, grouped operation)', async () => {
+    const op = await createIntegrationOperation()
+    expect(op).toMatchObject({ operationId: 'createIntegration', tags: ['Integrations'] })
+    expect(op?.summary).toBeTruthy()
+    expect(op?.description).toBeTruthy()
+  })
+
+  it('tolerates the container’s LATE-BOUND registry — nothing reads `platforms` before ready()', async () => {
+    // `buildContainer` builds the Fastify instance BEFORE the providers exist
+    // (their funnel plugins close over the very dep bundle being assembled), so
+    // it publishes the registry through a getter that throws until composition
+    // finishes. Reproduce that exact ordering: an eager read anywhere between
+    // `buildHttpServer` and `ready()` would crash the CP at boot while every
+    // plain-field test harness — including the integration one — stayed green.
+    // Mirrors `container.ts`'s declaration exactly, guard and all.
+    let composed: CpPlatformRegistry | undefined = undefined
+    const lateBound = {
+      repos: { user: { provisionOidcUser: async () => ({ userId: 'u' }) } },
+      config: { NODE_ENV: 'test', DEFAULT_OWNER_ID: '00000000-0000-4000-8000-000000000000' },
+      get platforms(): CpPlatformRegistry {
+        if (!composed) throw new Error('platform registry read before composition')
+        return composed
+      }
+    } as unknown as HttpDeps
+
+    const app: FastifyInstance = buildHttpServer(lateBound) // must not touch `platforms`…
+    composed = offlinePlatforms() // …the container assigns here, before listen()
+    try {
+      await app.ready()
+      const doc = (await app.inject({ method: 'GET', url: '/api/v1/openapi.json' })).json() as Record<string, any>
+      const schema =
+        doc.paths?.['/api/v1/orgs/{orgId}/integrations']?.post?.requestBody?.content?.['application/json']?.schema
+      expect(schema?.properties?.platform?.enum?.slice().sort()).toEqual(['discord', 'feishu', 'slack', 'telegram'])
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/packages/control-plane/src/http/dto/create-integration-body.ts
+++ b/packages/control-plane/src/http/dto/create-integration-body.ts
@@ -1,0 +1,123 @@
+/**
+ * The `POST /integrations` create body, **composed from the platform registry**
+ * (integration-plugin-architecture.md §9).
+ *
+ * WHAT MOVED. The body used to be a hand-written closed union in
+ * `http/dto/index.ts`: four literal credential keys (`slack` / `telegram` /
+ * `discord` / `feishu`), a literal four-id loop for the mismatched-block guard,
+ * and a `b.platform === 'slack' | 'feishu'` dispatch into the two providers'
+ * transport refinements. Each platform now contributes its own block
+ * ({@link CpPlatformProvider.credentialBodySchema} +
+ * {@link CpPlatformProvider.refineCreateBody}) and core folds the registry's
+ * contributions in at container-build time — so registering a fifth provider
+ * extends the wire, `/docs`, and `openapi.json` with no edit here (§12), and
+ * the registry stays the single platform-set authority (S3 exit criterion).
+ *
+ * WHAT STAYED CORE (§9). The cross-block rules are platform-agnostic and belong
+ * to the composition: the `platform` discriminator itself, exactly-one-of
+ * `botId`/credentials, and the mismatched-block guard — the same rules, now
+ * expressed as loops over `platforms.ids()` instead of a copied literal list.
+ *
+ * SHAPE IS UNCHANGED. Same field names, same optionality, same non-strict
+ * object (unknown keys are stripped, never rejected), same user-facing issue
+ * messages. `src/http/dto/create-integration-body.test.ts` pins that
+ * equivalence against the closed union's audited behavior, and pins the
+ * OpenAPI enumeration a dynamic composition could otherwise lose silently.
+ */
+import { z } from 'zod'
+import type { CpPlatformProvider, CpPlatformRegistry } from '../../platforms/provider.js'
+
+/** Inbound transport chosen at install time; an omitted value is the create
+ *  route's `socket` default (which the refinements below reproduce). */
+const InstallTransport = z.enum(['socket', 'http'])
+
+/**
+ * Fold the registry's credential blocks into the create body.
+ *
+ * Called once per composition root (the create-route plugin builds it from
+ * `deps.platforms`), never per request: the schema is a pure function of the
+ * registered providers, and `@fastify/swagger` reads it at route-registration
+ * time to generate the documented request body.
+ */
+export function buildCreateIntegrationBody(platforms: CpPlatformRegistry) {
+  const ids = platforms.ids()
+  if (ids.length === 0) {
+    throw new Error('cannot compose POST /integrations: no platform provider is registered')
+  }
+
+  // The platform-agnostic skeleton. Declared first so the documented property
+  // order stays what the closed union produced (core knobs, then one block per
+  // platform in registration order).
+  const core = {
+    // Optional — the app already has a name; when omitted the CP derives it from
+    // the platform (the provider's validated identity), falling back to the owning
+    // agent's name. Ignored when reusing an existing bot (the bot keeps its name).
+    name: z.string().min(1).optional(),
+    /** Which registered platform this install is for — the registry's id set IS
+     *  the accepted vocabulary, so an unregistered platform is a 400 here. */
+    platform: z.enum(ids as [string, ...string[]]),
+    agentId: z.string().min(1), // owner ⇒ delivery daemon; must be placed on a daemon
+    /** Reuse an existing bot. A CLASSIC bot must be free; a SHAREABLE bot may
+     *  already serve other agents (this adds one more, shared-bot-relay.md §4.1). */
+    botId: z.string().min(1).optional(),
+    /** Opt the (new or reused) bot into multi-agent shared mode (default false).
+     *  Requires `transport: 'http'` (a socket bot is single-agent). */
+    shareable: z.boolean().optional(),
+    /** Inbound transport for the platforms that offer callback ingress. `socket`
+     *  uses the platform's daemon-owned long connection; `http` uses the relay. */
+    transport: InstallTransport.optional()
+  }
+
+  /** One optional credential block per registered platform — "register a new bot
+   *  from pasted credentials". Tokens go in, never come back. */
+  const credentialBlocks: Record<string, z.ZodOptional<z.ZodType<unknown>>> = {}
+  for (const provider of platforms.all()) {
+    if (provider.platformId in core) {
+      throw new Error(`platform id collides with a core create-body field: ${provider.platformId}`)
+    }
+    credentialBlocks[provider.platformId] = provider.credentialBodySchema.optional()
+  }
+
+  return z.object({ ...core, ...credentialBlocks }).superRefine((body, ctx) => {
+    const addIssue = (message: string) => ctx.addIssue({ code: z.ZodIssueCode.custom, message })
+    const blocks: Record<string, unknown> = body
+    // The credential block for the chosen platform (else reuse an existing bot).
+    const credentials = blocks[body.platform]
+    if ((body.botId !== undefined) === (credentials !== undefined)) {
+      addIssue(`exactly one of botId or ${body.platform} must be provided`)
+    }
+    // Guard against a mismatched credential block (e.g. platform:'telegram' + slack:{…}).
+    for (const id of ids) {
+      if (id !== body.platform && blocks[id] !== undefined) {
+        addIssue(`${id} credentials given for a ${body.platform} integration`)
+      }
+    }
+    // `shareable` is an http-only sub-flag, but it degrades gracefully rather than
+    // erroring: the console hides the toggle for socket, and `installNewSlackBot`
+    // coerces it off for a non-http bot (so a socket bot can never become shareable).
+    // No validation needed here.
+    // Per-transport credential requirements (only when registering a NEW bot) —
+    // the chosen provider's §9 `refineCreateBody`; an omitted transport is the
+    // create route's socket default.
+    if (body.botId === undefined && credentials !== undefined) {
+      const provider: CpPlatformProvider | undefined = platforms.get(body.platform)
+      provider?.refineCreateBody?.({ credentials, transport: body.transport ?? 'socket' }, addIssue)
+    }
+  })
+}
+
+/**
+ * The chosen platform's credential block of a parsed create body — `undefined`
+ * when the install reuses an existing bot (the exactly-one-of rule above makes
+ * those the only two shapes that parse).
+ *
+ * Opaque to core BY DESIGN (§9, the same stance as the relay contract's
+ * `TVerified`): the block was validated by the owning provider's
+ * `credentialBodySchema`, and only that platform's code — its `validateConfig`
+ * and, until the install funnels move, the create route's per-platform tail —
+ * knows the field names inside.
+ */
+export function credentialBlockOf(body: { platform: string }): unknown {
+  const blocks: Record<string, unknown> = body
+  return blocks[body.platform]
+}

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -29,10 +29,6 @@ import {
   normalizeRepoSubdir
 } from '@agentconnect.md/protocol'
 import { HEX_COLOR_RE, AGENT_ICON_GLYPHS } from '../../agents/agent-icon.js'
-import { TelegramCreateCredentials } from '../../platforms/telegram/provider.js'
-import { DiscordCreateCredentials } from '../../platforms/discord/provider.js'
-import { SlackCreateCredentials, refineSlackCreateBody } from '../../platforms/slack/provider.js'
-import { FeishuCreateCredentials, refineFeishuCreateBody } from '../../platforms/feishu/provider.js'
 
 // ── per-resource visibility / sharing (docs/designs/resource-visibility.md) ──
 /** 'org' = visible to every org member (default); 'restricted' = the complete
@@ -701,85 +697,10 @@ export const AgentCreatedDto = AgentDto.extend({
 })
 
 // ── bots + integrations ─────────────────────────────────────────────────────
-/**
- * `POST /integrations` — install a bot on an agent. Two shapes for the bot
- * identity: reuse an existing free bot (`botId`), or register a new one from
- * pasted Slack tokens (`slack`). Tokens go in, never come back.
- */
-export const CreateIntegrationBody = z
-  .object({
-    // Optional — the app already has a name; when omitted the CP derives it from the
-    // platform (Slack auth.test / Telegram getMe), falling back to the owning agent's
-    // name. Ignored when reusing an existing bot (the bot keeps its name).
-    name: z.string().min(1).optional(),
-    platform: z.enum(['slack', 'telegram', 'discord', 'feishu']),
-    agentId: z.string().min(1), // owner ⇒ delivery daemon; must be placed on a daemon
-    /** Reuse an existing bot. A CLASSIC bot must be free; a SHAREABLE bot may
-     *  already serve other agents (this adds one more, shared-bot-relay.md §4.1). */
-    botId: z.string().min(1).optional(),
-    /** Opt the (new or reused) bot into multi-agent shared mode (default false).
-     *  Requires `transport: 'http'` (a socket bot is single-agent). */
-    shareable: z.boolean().optional(),
-    /** Inbound transport for Slack and Feishu. `socket` uses the platform's
-     *  daemon-owned long connection; `http` uses callback ingress. */
-    transport: z.enum(['socket', 'http']).optional(),
-    /** Register a new Slack bot from its tokens. Socket transport needs the
-     *  app-level token (Socket Mode); http transport needs the signing secret
-     *  (Events API request verification — enforced in the superRefine below).
-     *  Schema relocated to the platform provider (§9 `credentialBodySchema`). */
-    slack: SlackCreateCredentials.optional(),
-    /** Register a new Telegram bot from its BotFather token (single token).
-     *  Schema relocated to the platform provider (§9 `credentialBodySchema`) —
-     *  one implementation for the live route and the registry. */
-    telegram: TelegramCreateCredentials.optional(),
-    /** Register a new Discord bot from its Gateway bot token (single token). The
-     *  optional applicationId is the public client id for the invite URL.
-     *  Schema relocated to the platform provider (§9 `credentialBodySchema`). */
-    discord: DiscordCreateCredentials.optional(),
-    /** Register a new Feishu / Lark self-built app from its appId + appSecret pair.
-     *  `region` picks the open-platform gateway (feishu.cn vs larksuite.com); it
-     *  defaults to international Lark for new create requests.
-     *  Schema relocated to the platform provider (§9 `credentialBodySchema`). */
-    feishu: FeishuCreateCredentials.optional()
-  })
-  .superRefine((b, ctx) => {
-    // The credential object for the chosen platform (else reuse an existing bot).
-    const creds =
-      b.platform === 'slack'
-        ? b.slack
-        : b.platform === 'telegram'
-          ? b.telegram
-          : b.platform === 'discord'
-            ? b.discord
-            : b.feishu
-    if ((b.botId !== undefined) === (creds !== undefined)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `exactly one of botId or ${b.platform} must be provided`
-      })
-    }
-    // Guard against a mismatched credential block (e.g. platform:'telegram' + slack:{…}).
-    const wrong: Array<'slack' | 'telegram' | 'discord' | 'feishu'> = (
-      ['slack', 'telegram', 'discord', 'feishu'] as const
-    ).filter((p) => p !== b.platform && b[p] !== undefined)
-    for (const p of wrong)
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `${p} credentials given for a ${b.platform} integration` })
-    // `shareable` is an http-only sub-flag, but it degrades gracefully rather than
-    // erroring: the console hides the toggle for socket, and `installNewSlackBot`
-    // coerces it off for a non-http bot (so a socket bot can never become shareable).
-    // No validation needed here.
-    // Per-transport credential requirements (only when registering a NEW bot) —
-    // the providers' §9 `refineCreateBody` bodies, called here so the live DTO
-    // and the registry share ONE implementation (an omitted transport is the
-    // create route's socket default).
-    const addIssue = (message: string) => ctx.addIssue({ code: z.ZodIssueCode.custom, message })
-    if (b.platform === 'slack' && b.botId === undefined && b.slack) {
-      refineSlackCreateBody({ credentials: b.slack, transport: b.transport ?? 'socket' }, addIssue)
-    }
-    if (b.platform === 'feishu' && b.botId === undefined && b.feishu) {
-      refineFeishuCreateBody({ credentials: b.feishu, transport: b.transport ?? 'socket' }, addIssue)
-    }
-  })
+/** The `POST /integrations` create body is COMPOSED from the platform registry
+ *  (§9) rather than declared here — see `dto/create-integration-body.ts`
+ *  (`buildCreateIntegrationBody`), which the create route folds from
+ *  `deps.platforms` at container-build time. */
 
 /** `POST /integrations/telegram/check` — preflight a pasted BotFather token
  * without storing it. */

--- a/packages/control-plane/src/http/plugins/openapi.test.ts
+++ b/packages/control-plane/src/http/plugins/openapi.test.ts
@@ -9,13 +9,26 @@ import { describe, it, expect } from 'vitest'
 import type { FastifyInstance } from 'fastify'
 import { buildHttpServer } from '../server.js'
 import type { HttpDeps } from '../deps.js'
+import { buildCpPlatformRegistry } from '../../platforms/registry.js'
+import { createTelegramCpProvider } from '../../platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../../platforms/discord/provider.js'
+import { createSlackCpProvider } from '../../platforms/slack/provider.js'
+import { createFeishuCpProvider } from '../../platforms/feishu/provider.js'
 
-/** Minimal stub deps: only `config` is read at build time; repos stay untouched
- *  because the tests hit only the docs/spec routes (no DB-backed handler). */
+/** Minimal stub deps: `config` plus the platform registry, which the create
+ *  route folds into its documented request body at registration time. Repos
+ *  stay untouched because the tests hit only the docs/spec routes (no DB-backed
+ *  handler), so the providers' offline seams are never called. */
 function stubDeps(): HttpDeps {
   return {
     repos: { user: { provisionOidcUser: async () => ({ userId: 'u' }) } },
-    config: { NODE_ENV: 'test', DEFAULT_OWNER_ID: '00000000-0000-4000-8000-000000000000' }
+    config: { NODE_ENV: 'test', DEFAULT_OWNER_ID: '00000000-0000-4000-8000-000000000000' },
+    platforms: buildCpPlatformRegistry([
+      createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+      createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+      createSlackCpProvider({}),
+      createFeishuCpProvider({})
+    ])
   } as unknown as HttpDeps
 }
 

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -29,13 +29,17 @@ import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js
 import { pickChannelOwner } from '../../orchestrator/httpBot.js'
 import { isDirectConversationKind } from '../../persistence/ports.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
-import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
+import { installNewSlackBot } from '../install-slack.js'
 import { installNewFeishuBot } from '../install-feishu.js'
 import { BotExternalIdentityTaken } from '../../persistence/errors.js'
-import { discordAppIdFromBotToken } from '../discord-identity.js'
-import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
+import { integrationPlatformAvailability, type IntegrationPlatform } from '../daemon-platform-capability.js'
+import { buildCreateIntegrationBody, credentialBlockOf } from '../dto/create-integration-body.js'
+import type { CpConfigRefusal, CpValidatedIdentity } from '../../platforms/provider.js'
+import type { SlackCreateCredentials } from '../../platforms/slack/provider.js'
+import type { TelegramCreateCredentials } from '../../platforms/telegram/provider.js'
+import type { DiscordCreateCredentials } from '../../platforms/discord/provider.js'
+import type { FeishuCreateCredentials } from '../../platforms/feishu/provider.js'
 import {
-  CreateIntegrationBody,
   TelegramBotCheckBody,
   TelegramBotCheckDto,
   UpdateIntegrationChannelBody,
@@ -79,6 +83,11 @@ function toDto(i: IntegrationRecord, channels: IntegrationChannelRecord[] = []):
 export function integrationRoutes(deps: HttpDeps) {
   return async function integrationRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
+    // §9: the create body is FOLDED from the platform registry (one optional
+    // credential block per registered provider + its transport refinements),
+    // once per composition root — `@fastify/swagger` reads the same object to
+    // document the request body.
+    const CreateIntegrationBody = buildCreateIntegrationBody(deps.platforms)
     // The caller's active org — every read/write below is scoped to it.
     const orgIdOf = (req: { orgCtx?: { orgId: OrgId } }) => req.orgCtx!.orgId
     const refreshMutationAgent = async (observed: AgentRecord): Promise<AgentRecord | null> => {
@@ -120,7 +129,7 @@ export function integrationRoutes(deps: HttpDeps) {
     const validateShareableInstall = async (
       bot: { agentIds: string[] },
       agentId: string,
-      platform: 'slack' | 'telegram' | 'discord' | 'feishu'
+      platform: string
     ): Promise<{ code: 400 | 409; body: { error: string; statusCode: number; message: string } } | null> => {
       if (platform !== 'slack') {
         return {
@@ -143,6 +152,18 @@ export function integrationRoutes(deps: HttpDeps) {
       }
       return null
     }
+
+    // A provider's refusal from `validateConfig` (§9), sent verbatim: 400 for a
+    // DEFINITIVE credential rejection, 503 when the provider was unreachable
+    // (inconclusive, never proof the credential is bad). `code` rides along only
+    // where the platform defines one — the console branches on it.
+    const sendConfigRefusal = (reply: FastifyReply, refusal: CpConfigRefusal) =>
+      reply.code(refusal.status).send({
+        error: refusal.status === 400 ? 'Bad Request' : 'Service Unavailable',
+        statusCode: refusal.status,
+        ...(refusal.code ? { code: refusal.code } : {}),
+        message: refusal.message
+      })
 
     const replicateRemove = async (integrationId: string, daemonId: string | null): Promise<void> => {
       if (!daemonId) return
@@ -197,6 +218,9 @@ export function integrationRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
         const orgId = orgIdOf(req)
+        // The composed body's `platform` enum IS the registry's id set, so a
+        // parsed body always names a registered provider.
+        const provider = deps.platforms.get(req.body.platform)!
         let agent = await deps.repos.agent.get(AgentId(req.body.agentId))
         // Derived visibility: installing an integration edits the agent's setup, so
         // a restricted agent the caller can't see 404s, and one they can see but not
@@ -217,7 +241,10 @@ export function integrationRoutes(deps: HttpDeps) {
           daemonId: agent.daemonId,
           orgId,
           viewer: ctxOf(req),
-          platform: req.body.platform
+          // The registry vouches for the id; the capability helper's closed
+          // union is one of the audit's remaining hand-copied platform unions
+          // (Appendix A) and converges in its own unit.
+          platform: req.body.platform as IntegrationPlatform
         })
         if (platformAvailability === 'not_found') {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
@@ -389,9 +416,12 @@ export function integrationRoutes(deps: HttpDeps) {
             return reply.code(201).send(toDto(integration))
           }
 
-          // HTTP callback ingress is implemented for Slack and Feishu. Telegram and
-          // Discord keep their daemon-owned long-lived transports.
-          if (req.body.transport === 'http' && req.body.platform !== 'slack' && req.body.platform !== 'feishu') {
+          // HTTP callback ingress exists only where the platform contributes a
+          // relay projection (§9: a missing `projectBotAssign` IS the "no relay
+          // path" signal). Telegram and Discord keep their daemon-owned
+          // long-lived transports.
+          const transport = req.body.transport ?? 'socket'
+          if (req.body.transport === 'http' && !provider.projectBotAssign) {
             return reply.code(400).send({
               error: 'Bad Request',
               statusCode: 400,
@@ -399,39 +429,22 @@ export function integrationRoutes(deps: HttpDeps) {
             })
           }
 
+          // The chosen platform's credential block: validated by the provider's OWN
+          // schema (§9) and guaranteed present here by the exactly-one-of refinement.
+          // Opaque to core — each create TAIL below is what still knows the platform's
+          // field names, until §9 moves the tails behind the provider too.
+          const credentials = credentialBlockOf(req.body)
+
           // Telegram: `getMe` validates the single BotFather token and confirms
           // Group Privacy Mode is disabled before anything is stored. Telegram exposes
           // that setting as read-only; the owner still changes it in @BotFather.
           if (req.body.platform === 'telegram') {
-            const tg = req.body.telegram! // superRefine guarantees it when botId is absent
-            const checked = await deps.verifyTelegramBot(tg.botToken)
-            if (checked.status === 'invalid') {
-              return reply.code(400).send({
-                error: 'Bad Request',
-                statusCode: 400,
-                code: 'TELEGRAM_BOT_TOKEN_INVALID',
-                message: 'Telegram rejected the bot token — copy it again from @BotFather.'
-              })
-            }
-            if (checked.status === 'unreachable') {
-              return reply.code(503).send({
-                error: 'Service Unavailable',
-                statusCode: 503,
-                code: 'TELEGRAM_BOT_CHECK_UNAVAILABLE',
-                message: 'AgentConnect could not reach Telegram to check this bot. Try again in a moment.'
-              })
-            }
-            if (!checked.privacyModeDisabled) {
-              return reply.code(400).send({
-                error: 'Bad Request',
-                statusCode: 400,
-                code: 'TELEGRAM_PRIVACY_MODE_ENABLED',
-                message:
-                  'Privacy Mode is still on. In @BotFather, send /setprivacy, select this bot, choose Disable, then try again.'
-              })
-            }
+            const tg = credentials as TelegramCreateCredentials
+            const validated = await provider.validateConfig(tg, transport)
+            if (!validated.ok) return sendConfigRefusal(reply, validated)
+            const identity: CpValidatedIdentity = validated.identity
             const provided = req.body.name?.trim()
-            const name = provided || checked.name || agent.name
+            const name = provided || identity.name || agent.name
             const botId = BotId(randomUUID())
             await deps.repos.bot.create({
               id: botId,
@@ -465,44 +478,19 @@ export function integrationRoutes(deps: HttpDeps) {
           // has Message Content enabled BEFORE storing anything. The flag update is
           // idempotent; a bot that already has limited or approved access is untouched.
           if (req.body.platform === 'discord') {
-            const discord = req.body.discord! // superRefine guarantees it when botId is absent
-            const check = deps.verifyDiscordBot ? await deps.verifyDiscordBot(discord.botToken) : null
-            if (check?.status === 'invalid') {
-              return reply.code(400).send({
-                error: 'Bad Request',
-                statusCode: 400,
-                message:
-                  'Discord rejected the bot token — check you pasted the Bot token from the Developer Portal (Bot → Reset Token).'
-              })
-            }
-            const intentSetup = await deps.ensureDiscordMessageContentIntent(discord.botToken)
-            if (intentSetup === 'rejected') {
-              return reply.code(400).send({
-                error: 'Bad Request',
-                statusCode: 400,
-                code: 'DISCORD_MESSAGE_CONTENT_INTENT_SETUP_FAILED',
-                message:
-                  'AgentConnect could not enable Message Content Intent automatically. Open the Discord Developer Portal → Bot → Privileged Gateway Intents, turn on Message Content Intent, save, then try again.'
-              })
-            }
-            if (intentSetup === 'unreachable') {
-              return reply.code(503).send({
-                error: 'Service Unavailable',
-                statusCode: 503,
-                code: 'DISCORD_MESSAGE_CONTENT_INTENT_CHECK_UNAVAILABLE',
-                message:
-                  'AgentConnect could not reach Discord to check or enable Message Content Intent. Try installing again in a moment.'
-              })
-            }
+            const discord = credentials as DiscordCreateCredentials
+            const validated = await provider.validateConfig(discord, transport)
+            if (!validated.ok) return sendConfigRefusal(reply, validated)
+            const identity: CpValidatedIdentity = validated.identity
             // Name: operator-typed → users/@me-derived (best-effort) → owning agent. The
-            // daemon needs only the bot token to open the Gateway, but we ALSO decode the
-            // application (client) id from the token and persist it — public metadata, not
-            // secret — so the console can later hand out a ready-made "Add to Discord"
-            // invite URL from Settings without re-parsing the (never-returned) token.
+            // daemon needs only the bot token to open the Gateway, but the provider ALSO
+            // decodes the application (client) id from the token and hands it back as the
+            // validated identity — public metadata, not secret — so the console can later
+            // hand out a ready-made "Add to Discord" invite URL from Settings without
+            // re-parsing the (never-returned) token.
             const provided = req.body.name?.trim()
-            const derived = check?.status === 'ok' ? check.name : null
-            const name = provided || derived || agent.name
-            const discordAppId = discordAppIdFromBotToken(discord.botToken)
+            const name = provided || identity.name || agent.name
+            const discordAppId = identity.externalAppId
             const botId = BotId(randomUUID())
             await deps.repos.bot.create({
               id: botId,
@@ -523,7 +511,12 @@ export function integrationRoutes(deps: HttpDeps) {
               ...(req.principal ? { createdByUserId: req.principal.userId } : {})
             })
             await replicateUpsert(integration, daemonId)
-            if (deps.syncDiscordBotProfile && check?.status !== 'unreachable') {
+            // Cosmetic and best-effort: a failure is logged and the install stands.
+            // (The pre-adoption code additionally skipped the push when the users/@me
+            // probe was unreachable; the provider's validated identity carries no
+            // reachability signal, and reaching this line means the intent ensure —
+            // the very next Discord round-trip — succeeded.)
+            if (deps.syncDiscordBotProfile) {
               try {
                 await deps.syncDiscordBotProfile(discord.botToken, profileAgent)
               } catch (err) {
@@ -546,9 +539,10 @@ export function integrationRoutes(deps: HttpDeps) {
           // two credentials reuse the two-slot bot_secret (botToken = appSecret, the secret;
           // appToken = appId, the identifier — appToken already nullable since Telegram).
           if (req.body.platform === 'feishu') {
-            const feishu = req.body.feishu! // superRefine guarantees it when botId is absent
+            const feishu = credentials as FeishuCreateCredentials
             const region = feishu.region // zod-defaulted to 'lark' for new installs
-            const transport = req.body.transport ?? 'socket'
+            // Relay availability is core's 409 and is checked BEFORE the provider
+            // round-trip on this platform (order preserved from the pre-adoption arm).
             if (transport === 'http' && !deps.httpBot.hasConnectedRelay()) {
               return reply.code(409).send({
                 error: 'Conflict',
@@ -556,28 +550,9 @@ export function integrationRoutes(deps: HttpDeps) {
                 message: 'HTTP callback delivery is unavailable on this deployment'
               })
             }
-            const check = deps.verifyFeishuBot
-              ? await deps.verifyFeishuBot(feishu.appId, feishu.appSecret, region)
-              : null
-            if (check?.status === 'invalid') {
-              return reply.code(400).send({
-                error: 'Bad Request',
-                statusCode: 400,
-                message:
-                  'Feishu rejected the credentials — check the App ID (cli_…) and App Secret from the Developer Console (Credentials & Basic Info).'
-              })
-            }
-            // HTTP ingress cannot call Feishu with the app secret, so the CP must
-            // resolve the bot's own open_id now. The relay uses it to distinguish
-            // @bot from mentions of ordinary users in group messages.
-            if (transport === 'http' && (check?.status !== 'ok' || !check.openId)) {
-              return reply.code(503).send({
-                error: 'Service Unavailable',
-                statusCode: 503,
-                message:
-                  'Could not resolve this app’s bot identity. Enable the bot capability in Feishu, then try again.'
-              })
-            }
+            const validated = await provider.validateConfig(feishu, transport)
+            if (!validated.ok) return sendConfigRefusal(reply, validated)
+            const identity: CpValidatedIdentity = validated.identity
             // D6 fence: one Bot per Feishu app. New rows write the tenant sentinel,
             // so the composite unique backstops the race below; this pre-check just
             // turns the common case into a clean 409 with reuse guidance.
@@ -591,8 +566,7 @@ export function integrationRoutes(deps: HttpDeps) {
               })
             }
             const provided = req.body.name?.trim()
-            const derived = check?.status === 'ok' ? check.name : null
-            const name = provided || derived || agent.name
+            const name = provided || identity.name || agent.name
             try {
               const integration = await installNewFeishuBot(deps, app.log, {
                 orgId,
@@ -602,7 +576,7 @@ export function integrationRoutes(deps: HttpDeps) {
                 appSecret: feishu.appSecret,
                 region,
                 transport,
-                ...(check?.status === 'ok' && check.openId ? { botUserId: check.openId } : {}),
+                ...(identity.botUserId ? { botUserId: identity.botUserId } : {}),
                 ...(feishu.verificationToken ? { verificationToken: feishu.verificationToken } : {}),
                 ...(feishu.encryptKey ? { encryptKey: feishu.encryptKey } : {}),
                 ...(req.principal ? { createdByUserId: req.principal.userId } : {})
@@ -622,43 +596,31 @@ export function integrationRoutes(deps: HttpDeps) {
             }
           }
 
+          // EXHAUSTIVENESS, restated. The create TAILS above are still per-platform
+          // (§9 moves them behind the provider next), but `platform` is no longer a
+          // closed union — it is whatever the registry registered, so the compiler
+          // no longer proves the fall-through below belongs to Slack. Registering a
+          // fifth provider without a tail must NOT mint a Slack bot out of that
+          // platform's credential block; refuse loudly instead. Unreachable today:
+          // the registry holds exactly the four platforms handled here.
+          if (req.body.platform !== 'slack') {
+            throw new Error(`no create tail for registered platform: ${req.body.platform}`)
+          }
+
           // Register a new Slack bot from pasted tokens. Validate against Slack BEFORE
           // we store them, so a stale / wrong-app / swapped token fails here (400)
           // instead of silently producing an integration whose socket never opens.
           // Best-effort about reachability: a network blip is inconclusive
           // (`unreachable`), NOT proof the token is bad — only a definitive rejection
           // blocks the install.
-          const slack = req.body.slack! // refine() guarantees it when botId is absent
-          const transport = req.body.transport ?? 'socket'
-          const botCheck = await deps.verifySlackBot?.(slack.botToken)
-          if (botCheck?.status === 'invalid') {
-            return reply.code(400).send({
-              error: 'Bad Request',
-              statusCode: 400,
-              message: 'Slack rejected the bot token — check you pasted the Bot User OAuth Token (xoxb-…).'
-            })
-          }
-          if (transport === 'socket') {
-            // Socket Mode: the app-level xapp token is required + validated against Slack.
-            const appCheck = await deps.verifySlackAppToken?.(slack.appToken!)
-            if (appCheck === 'invalid') {
-              return reply.code(400).send({
-                error: 'Bad Request',
-                statusCode: 400,
-                message:
-                  'Slack rejected the app-level token — check you pasted the App-Level Token (xapp-…) and gave it the connections:write scope.'
-              })
-            }
-            const appTokenAppId = slackAppIdFromAppToken(slack.appToken!)
-            if (botCheck?.status === 'ok' && botCheck.appId && appTokenAppId && botCheck.appId !== appTokenAppId) {
-              return reply.code(400).send({
-                error: 'Bad Request',
-                statusCode: 400,
-                message: 'The Slack bot token and app-level token belong to different apps.'
-              })
-            }
-          } else {
+          const slack = credentials as SlackCreateCredentials
+          const validated = await provider.validateConfig(slack, transport)
+          if (!validated.ok) return sendConfigRefusal(reply, validated)
+          const identity: CpValidatedIdentity = validated.identity
+          if (transport === 'http') {
             // HTTP mode: inbound arrives at the relay pool — a relay must be connected.
+            // Core's 409, checked AFTER the provider round-trip on this platform
+            // (order preserved from the pre-adoption arm).
             if (!deps.httpBot.hasConnectedRelay()) {
               return reply.code(409).send({
                 error: 'Conflict',
@@ -670,16 +632,15 @@ export function integrationRoutes(deps: HttpDeps) {
           // Name is optional: the app already has one. Prefer what the operator typed,
           // else the name auth.test derived, else fall back to the owning agent's name.
           const provided = req.body.name?.trim()
-          const derived = botCheck?.status === 'ok' ? botCheck.name : null
           const integration = await installNewSlackBot(deps, app.log, {
             orgId,
             agent,
-            name: provided || derived || agent.name,
+            name: provided || identity.name || agent.name,
             botToken: slack.botToken,
             transport,
-            ...(botCheck?.status === 'ok' && botCheck.appId ? { slackAppId: botCheck.appId } : {}),
-            ...(botCheck?.status === 'ok' && botCheck.teamId ? { workspaceId: botCheck.teamId } : {}),
-            ...(botCheck?.status === 'ok' && botCheck.teamName ? { workspaceName: botCheck.teamName } : {}),
+            ...(identity.externalAppId ? { slackAppId: identity.externalAppId } : {}),
+            ...(identity.workspaceId ? { workspaceId: identity.workspaceId } : {}),
+            ...(identity.workspaceName ? { workspaceName: identity.workspaceName } : {}),
             ...(slack.appToken ? { appToken: slack.appToken } : {}),
             ...(slack.signingSecret ? { signingSecret: slack.signingSecret } : {}),
             ...(req.body.shareable === true ? { shareable: true } : {}),

--- a/packages/control-plane/src/platforms/discord/provider.ts
+++ b/packages/control-plane/src/platforms/discord/provider.ts
@@ -24,12 +24,12 @@
  * `deps.ensureDiscordMessageContentIntent` / `deps.syncDiscordBotProfile`),
  * injected through {@link DiscordCpProviderDeps} so tests stay offline.
  *
- * ADOPTION SEQUENCING: nothing consumes this provider yet beyond registry
- * construction in `container.ts` — the create route and `placement.ts` remain
- * the live paths. The shareable pieces ARE shared: the create-DTO credential
- * block is defined here and imported by `http/dto/index.ts`, and the §6.4
- * wire projection body is {@link discordIntegrationConfig}, called by BOTH
- * `integrationToSpec`'s discord arm and
+ * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
+ * registry — its {@link DiscordCreateCredentials} block is folded into the
+ * create body and {@link CpPlatformProvider.validateConfig} IS the route's live
+ * token check + intent enablement. `placement.ts` remains a live path; the §6.4
+ * wire projection body is therefore {@link discordIntegrationConfig}, called by
+ * BOTH `integrationToSpec`'s discord arm and
  * {@link CpPlatformProvider.projectIntegrationConfig}.
  */
 import { z } from 'zod'

--- a/packages/control-plane/src/platforms/feishu/provider.test.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.test.ts
@@ -26,7 +26,8 @@ import {
 import { integrationToSpec, httpIntegrationToSpec } from '../../orchestrator/placement.js'
 import { HttpBotOrchestrator } from '../../orchestrator/httpBot.js'
 import { RelayRegistry, type RelayChannel } from '../../ws/relay-registry.js'
-import { CreateIntegrationBody } from '../../http/dto/index.js'
+import { buildCreateIntegrationBody } from '../../http/dto/create-integration-body.js'
+import { buildCpPlatformRegistry } from '../registry.js'
 import { AppConfigSchema } from '../../config/env.js'
 import type { FeishuBotVerification } from '../../http/feishu-identity.js'
 import type { BotProfileIconAgent } from '../../http/bot-profile-icon.js'
@@ -233,6 +234,9 @@ describe('feishu refineCreateBody (DTO parity: the create body superRefine feish
   })
 
   it('is the same rule the live create DTO enforces (one implementation)', () => {
+    // The live body is COMPOSED from the registry (§9), so the rule reaches the
+    // DTO through the provider's `refineCreateBody` — no second copy anywhere.
+    const CreateIntegrationBody = buildCreateIntegrationBody(buildCpPlatformRegistry([createFeishuCpProvider({})]))
     const base = { platform: 'feishu', agentId: AGENT_ID as string }
     const http = CreateIntegrationBody.safeParse({
       ...base,

--- a/packages/control-plane/src/platforms/feishu/provider.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.ts
@@ -15,19 +15,20 @@
  *    user-facing copy verbatim, including the http-transport `openId`
  *    resolution the relay needs for @-mention demux;
  *  - `installRoutes` → the registration funnel plugin, injected PRE-BOUND to
- *    the route deps by the composition root (not imported here: the route
- *    module consumes the create-DTO module, which imports this provider's
- *    credential block — binding the factory here would close a runtime import
- *    cycle);
+ *    the route deps by the composition root (not imported here: provider
+ *    construction stays one-directional, which is what keeps the create route
+ *    free to fold this provider's credential block into its body schema);
  *  - the wire projections → {@link feishuIntegrationConfig} /
  *    {@link feishuSharedIntegrationConfig} / {@link feishuBotAssignBags},
  *    called by BOTH the live paths (`orchestrator/placement.ts`,
  *    `orchestrator/httpBot.ts`) and the provider (one implementation).
  *
- * ADOPTION SEQUENCING: nothing consumes this provider yet beyond registry
- * construction in `container.ts` — the create route, `placement.ts`,
- * `httpBot.ts`, `server.ts` mounting, and `loadConfig`'s schema fold remain
- * the live paths, sharing the implementations above.
+ * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
+ * registry — its {@link FeishuCreateCredentials} block + {@link
+ * refineFeishuCreateBody} are folded into the create body, and {@link
+ * CpPlatformProvider.validateConfig} IS the route's live credential check.
+ * `placement.ts`, `httpBot.ts`, `server.ts` mounting, and `loadConfig`'s schema
+ * fold remain live paths, sharing the implementations above.
  */
 import { z } from 'zod'
 import type { ZodRawShape } from 'zod'

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -26,7 +26,8 @@ import {
 import { integrationToSpec, httpIntegrationToSpec } from '../../orchestrator/placement.js'
 import { HttpBotOrchestrator } from '../../orchestrator/httpBot.js'
 import { RelayRegistry, type RelayChannel } from '../../ws/relay-registry.js'
-import { CreateIntegrationBody } from '../../http/dto/index.js'
+import { buildCreateIntegrationBody } from '../../http/dto/create-integration-body.js'
+import { buildCpPlatformRegistry } from '../registry.js'
 import { AppConfigSchema } from '../../config/env.js'
 import type { SlackBotVerification } from '../../http/slack-identity.js'
 import type { SlackUserConfigDeps } from '../../http/slack-user-config.js'
@@ -242,6 +243,9 @@ describe('slack refineCreateBody (DTO parity: the create body superRefine slack 
   })
 
   it('is the same rule the live create DTO enforces (one implementation)', () => {
+    // The live body is COMPOSED from the registry (§9), so the rule reaches the
+    // DTO through the provider's `refineCreateBody` — no second copy anywhere.
+    const CreateIntegrationBody = buildCreateIntegrationBody(buildCpPlatformRegistry([createSlackCpProvider({})]))
     const base = { platform: 'slack', agentId: AGENT_ID as string }
     const http = CreateIntegrationBody.safeParse({ ...base, transport: 'http', slack: { botToken: 'xoxb-1' } })
     expect(http.success).toBe(false)

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -16,9 +16,9 @@
  *    statuses and user-facing copy verbatim;
  *  - `installRoutes` → the funnel plugins, injected PRE-BOUND to the route
  *    deps by the composition root. They are deliberately not imported here:
- *    the funnel route modules consume the create-DTO module
- *    (`http/dto/index.ts`), which imports this provider's credential block —
- *    binding the factories here would close a runtime import cycle;
+ *    provider construction stays one-directional (a provider never reaches back
+ *    for a route factory), which is what keeps the create route free to fold
+ *    this provider's credential block into its body schema;
  *  - `providerToolingCredentials` → `resolveUserConfigAccessToken` /
  *    `configUsable` (`http/slack-user-config.ts`), the same resolution the
  *    funnel start and the Settings→Bots refresh flow call;
@@ -27,10 +27,13 @@
  *    by BOTH the live paths (`orchestrator/placement.ts`,
  *    `orchestrator/httpBot.ts`) and the provider (one implementation).
  *
- * ADOPTION SEQUENCING: nothing consumes this provider yet beyond registry
- * construction in `container.ts` — the create route, `placement.ts`,
- * `httpBot.ts`, `server.ts` mounting, `loadConfig`'s schema fold, and
- * `startBackground()` remain the live paths, sharing the implementations above.
+ * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
+ * registry — its {@link SlackCreateCredentials} block + {@link
+ * refineSlackCreateBody} are folded into the create body, and {@link
+ * CpPlatformProvider.validateConfig} IS the route's live token check.
+ * `placement.ts`, `httpBot.ts`, `server.ts` mounting, `loadConfig`'s schema
+ * fold, and `startBackground()` remain live paths, sharing the implementations
+ * above.
  */
 import { z } from 'zod'
 import type { ZodRawShape } from 'zod'

--- a/packages/control-plane/src/platforms/telegram/provider.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.ts
@@ -12,11 +12,11 @@
  * `deps.syncTelegramBotIcon`), injected through {@link TelegramCpProviderDeps}
  * so tests fake the provider round-trips exactly like the route tests do.
  *
- * ADOPTION SEQUENCING: nothing consumes this provider yet beyond registry
- * construction in `container.ts` — the create route and `placement.ts` remain
- * the live paths. To keep ONE implementation while both exist, the pieces that
- * can be shared ARE shared: the create-DTO credential block is defined here
- * and imported by `http/dto/index.ts`, and the §6.4 wire projection body is
+ * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
+ * registry — its {@link TelegramCreateCredentials} block is folded into the
+ * create body and {@link CpPlatformProvider.validateConfig} IS the route's live
+ * token check. `placement.ts` remains a live path; to keep ONE implementation
+ * while both exist, the §6.4 wire projection body is
  * {@link telegramIntegrationConfig}, called by BOTH `integrationToSpec`'s
  * telegram arm and {@link CpPlatformProvider.projectIntegrationConfig}.
  */

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -87,6 +87,11 @@ import { InMemorySessionEventSink } from '../../src/events/sink.js'
 import { HookService } from '../../src/hooks/hook.service.js'
 import { buildHttpServer } from '../../src/http/server.js'
 import type { HttpDeps } from '../../src/http/deps.js'
+import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
+import { createTelegramCpProvider } from '../../src/platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../../src/platforms/discord/provider.js'
+import { createSlackCpProvider } from '../../src/platforms/slack/provider.js'
+import { createFeishuCpProvider } from '../../src/platforms/feishu/provider.js'
 import { createReadiness } from '../../src/http/readiness.js'
 import { McpRateLimiter } from '../../src/http/mcp/rate-limit.js'
 import { RemoteGrantAuthenticator } from '../../src/http/mcp/remote-grant-authenticator.js'
@@ -255,6 +260,32 @@ export function buildHttpApp(
       oauth: oauthRepo
     },
     registry: new DaemonRegistryService(daemonRepo, new PgRuntimeProfileRepo(prisma), daemonLifecycleOpRepo, clock),
+    // §9 platform-provider registry — the same four providers `buildContainer`
+    // registers, so the create route parses and validates exactly the deployed
+    // shapes. Their verify seams READ THROUGH to `deps` on every call instead of
+    // capturing it: tests routinely swap `app.deps.verifySlackBot` (and friends)
+    // AFTER the app is built, and an absent dep is passed through as the
+    // provider-unreachable outcome — which every provider treats exactly as
+    // today's route treated "no verifier injected" (inconclusive: no 400, no
+    // derived identity). Only the seams the create route now reaches through the
+    // provider are wired here; the icon/profile pushes remain live `deps` calls
+    // until §9 moves the create tails too.
+    platforms: buildCpPlatformRegistry([
+      createTelegramCpProvider({ verifyBot: (token) => deps.verifyTelegramBot(token) }),
+      createDiscordCpProvider({
+        verifyBot: async (token) => (deps.verifyDiscordBot ? deps.verifyDiscordBot(token) : { status: 'unreachable' }),
+        ensureMessageContentIntent: (token) => deps.ensureDiscordMessageContentIntent(token)
+      }),
+      createSlackCpProvider({
+        verifyBot: async (token) => (deps.verifySlackBot ? deps.verifySlackBot(token) : { status: 'unreachable' }),
+        verifyAppToken: async (token) =>
+          deps.verifySlackAppToken ? deps.verifySlackAppToken(token) : ('unreachable' as const)
+      }),
+      createFeishuCpProvider({
+        verifyBot: async (appId, appSecret, region) =>
+          deps.verifyFeishuBot ? deps.verifyFeishuBot(appId, appSecret, region) : { status: 'unreachable' }
+      })
+    ]),
     agentSpecs: new AgentSpecAssembler(
       agentSecretStore,
       {},


### PR DESCRIPTION
## What

`POST /integrations` validated its body against a **hand-written closed discriminated
union** — four literal credential keys (`slack`/`telegram`/`discord`/`feishu`), a literal
four-id loop for the mismatched-block guard, and a `platform === 'slack' | 'feishu'`
dispatch into the two transport refinements. Next to it, the handler ran the live
credential check as four inline per-platform arms.

§9 says each `CpPlatformProvider` contributes `credentialBodySchema` (+ its
`refineCreateBody`), and core folds the registry's contributions into the route schema at
container-build time. This lands that, and routes the live `validateConfig` through the
provider at the same site.

- **New `http/dto/create-integration-body.ts`.** `buildCreateIntegrationBody(registry)`
  folds one optional block per registered provider onto the platform-agnostic skeleton.
  The cross-block rules stay core, now as loops over `platforms.ids()`: the `platform`
  discriminator, exactly-one-of `botId`/credentials, and the mismatched-block guard.
  `credentialBlockOf` hands the chosen block back **opaquely** — the same stance as the
  relay contract's `TVerified`.
- **The route builds it from `deps.platforms`**, not from a module-level import of four
  provider objects, at plugin-registration time — so `@fastify/swagger` documents the
  composed object and `/docs` + `openapi.json` stay accurate per registered platform.
- **The four inline validation arms become `provider.validateConfig(...)`** plus one
  `sendConfigRefusal` helper. The providers already carried the audited statuses, codes
  and user-facing copy verbatim (#574/#580), so this is a call-site swap, not a rewrite.
- **The `transport: 'http'` refusal stops naming Slack and Feishu**: a missing
  `projectBotAssign` *is* the "no relay path" signal (§9 erratum).
- `http/dto/index.ts` keeps a pointer comment where the union used to be; nothing else
  referenced the old export.

**Why the registry is late-bound.** The providers are constructed *with* `httpDeps` (their
funnel plugins are route factories pre-bound to that bundle), so the registry cannot exist
before the dep object does. `container.ts` publishes it through a getter that throws until
composition finishes; every reader runs at Fastify `ready()` or later. That ordering is
production-only — both test harnesses use a plain field — so an eager read would boot-crash
the CP while every suite stayed green. It is now pinned by a test that rebuilds the same
getter and asserts the docs enumeration still comes out.

**Exhaustiveness, restated.** `platform` is no longer a closed union, so the compiler no
longer proves the route's trailing Slack tail belongs to Slack. A provider registered
without a create tail must not mint a Slack bot out of another platform's credential
block, so the fall-through is now guarded explicitly. Unreachable today — the registry
holds exactly the four platforms the tails handle.

## Behavior

**One deliberate change, cosmetic and unobservable in the response.** The Discord create
tail used to skip the best-effort profile/avatar push when the `users/@me` probe had come
back `unreachable` (`syncDiscordBotProfile && check?.status !== 'unreachable'`).
`CpValidatedIdentity` carries no reachability signal, and reaching that line now means the
Message-Content intent ensure — the very next Discord round-trip — succeeded, so the push
is attempted. It is wrapped in try/catch and logged; the install returns 201 either way.
No test pinned the old gate.

Everything else is byte-for-byte: same statuses, codes and copy; same provider-call
ordering (Feishu still checks relay availability **before** its round-trip, Slack still
**after**); same operator → provider-derived → agent name ladder; same D6 identity fence.

## Tests

`GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/control-plane test:unit`
→ **124 files / 1149 tests passed** (was 1145 on main; +4 from the new suite plus the
two provider suites re-pointed at the composed body).

`GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/control-plane test:int`
→ **70 files / 951 tests passed** (Docker was up locally; run twice, before and after the
final edits).

Also green: `tsc -p packages/control-plane/tsconfig.json --noEmit`, `eslint` on every
touched file, `prettier --check packages/control-plane`.

New `src/http/dto/create-integration-body.test.ts` (12 cases):

- **Equivalence, not tautology.** Fixtures are written from the OLD closed union's
  behavior: every body it accepted is still accepted (each platform's block, bot reuse on
  all four, the optional core knobs, the zod-defaulted Feishu region, non-strict unknown-key
  stripping) and every body it rejected is still rejected with the *same* messages —
  exactly-one-of, mismatched block (both wrong blocks reported), the Slack/Feishu
  per-transport requirements including the omitted-transport socket default, refinements
  skipped on bot reuse, missing secrets, bad enum values, unregistered platform.
- **The OpenAPI regression a dynamic composition loses silently**: the generated document
  must still enumerate every platform variant of the create body — the `platform` enum, one
  request-body property per platform with its own fields, the required/optional split — and
  keep the repo's conventions on the route (`operationId: createIntegration`, `tags`,
  `summary`, `description`).
- **The registry is the authority**: a throwaway fifth provider proves registration alone
  extends the wire and inherits every cross-block rule and its own transport refinement,
  and that composing with no provider — or one whose id shadows a core field — fails loudly.
- **The late-bound-getter ordering** described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
