### PR TITLE
fix(daemon): isolate invalid agent configs

### DIFF
--- a/packages/daemon/src/agents/load-agents.ts
+++ b/packages/daemon/src/agents/load-agents.ts
@@ -10,6 +10,16 @@ const DETACHED_DIR = '.detached'
 // Agent plus loader-derived data: the directory containing agent.json.
 export type LoadedAgent = Agent & { dir: string }
 
+export interface AgentDiscoveryFailure {
+  file: string
+  error: Error
+}
+
+export interface AgentDiscoveryResult {
+  agents: { agent: LoadedAgent; dir: string }[]
+  failures: AgentDiscoveryFailure[]
+}
+
 // Parse one agent.json, then resolve workspace.path relative to the agent dir.
 function parseAgentFile(file: string): LoadedAgent {
   protectAgentJson(file)
@@ -63,6 +73,27 @@ export function discoverAgents(agentsDir: string): { agent: LoadedAgent; dir: st
       throw new Error(`invalid agent.json at ${file}: ${(err as Error).message}`)
     }
   })
+}
+
+// Daemon fleet discovery is fault-isolated: one malformed agent must not keep
+// unrelated agents offline. Callers decide how to report each failure and, on a
+// live reconcile, whether to retain the last valid configuration for that path.
+// Strict consumers (chat, evaluation, and explicit validation) continue to use
+// discoverAgents()/selectAgent() above.
+export function discoverAgentsTolerant(agentsDir: string): AgentDiscoveryResult {
+  // Keep the detached-file permission convergence identical to strict discovery.
+  protectDetachedAgentFiles(agentsDir)
+  const agents: AgentDiscoveryResult['agents'] = []
+  const failures: AgentDiscoveryFailure[] = []
+  for (const file of findAgentFiles(agentsDir)) {
+    try {
+      agents.push({ agent: parseAgentFile(file), dir: dirname(file) })
+    } catch (err) {
+      const cause = err instanceof Error ? err : new Error(String(err))
+      failures.push({ file, error: new Error(`invalid agent.json at ${file}: ${cause.message}`, { cause }) })
+    }
+  }
+  return { agents, failures }
 }
 
 // Active agents only — the daemon's multi-agent path.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,12 +1,12 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { basename, isAbsolute, join, relative, sep } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { hostname, tmpdir } from 'node:os'
 import { existsSync, readFileSync, type Stats } from 'node:fs'
 import { mkdtemp } from 'node:fs/promises'
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
 import { loadConfig, persistDaemonId, persistRelays, type FlatOverrides } from './config/load-config.js'
 import { sessionRetentionMs, type RuntimeDef } from './config/config-schema.js'
-import { loadAgents, selectAgent, type LoadedAgent } from './agents/load-agents.js'
+import { discoverAgentsTolerant, type LoadedAgent } from './agents/load-agents.js'
 import { agentChildEnv } from './agents/agent-env.js'
 import { cpRuntimeEnv } from './agents/cp-overlay.js'
 import { diffAgents } from './reconciler/reconciler.js'
@@ -2492,7 +2492,8 @@ export class Daemon {
       [...this.moveStageMetadata].filter(([, metadata]) => metadata.state === 'staging').map(([agentId]) => agentId)
     )
     for (const agentId of this.moveStagedAgents) this.drainingAgents.add(agentId)
-    const discoveredAgents = this.loadAgentList()
+    const snapshot = this.loadAgentList()
+    const discoveredAgents = snapshot.agents
     const agents = discoveredAgents.filter(
       (agent) => !this.moveStagedAgents.has(agent.id) && !this.removedAgentTombstones.has(agent.id)
     )
@@ -2500,7 +2501,7 @@ export class Daemon {
     // workspace that the kernel sandbox would later reject or another local
     // agent could already hold writable.
     if (!this.opts.hostFactory) {
-      const activeFleet = this.opts.agentName ? loadAgents(this.agentsDir) : agents
+      const activeFleet = snapshot.activeFleet
       assertExclusiveAgentWorkspaces(
         mergeAgentWorkspaceAuthorities(
           activeFleet.filter(
@@ -3132,8 +3133,48 @@ export class Daemon {
 
   // Multi-agent: all active agents under agentsDir. Single-agent (--agent): just
   // the selected agent, regardless of status.
-  private loadAgentList(): LoadedAgent[] {
-    return this.opts.agentName ? [selectAgent(this.agentsDir, this.opts.agentName)] : loadAgents(this.agentsDir)
+  private loadAgentList(preserveInvalid = false): { agents: LoadedAgent[]; activeFleet: LoadedAgent[] } {
+    const discovery = discoverAgentsTolerant(this.agentsDir)
+    const validAgents = discovery.agents.map((entry) => entry.agent)
+    const activeFleet = validAgents.filter((agent) => agent.status === 'active')
+    const invalidDirs = new Set(discovery.failures.map((failure) => dirname(failure.file)))
+    const preserved = new Map<string, LoadedAgent>()
+
+    if (preserveInvalid) {
+      for (const agent of this.fileAgents.values()) {
+        if (invalidDirs.has(agent.dir)) preserved.set(agent.dir, agent)
+      }
+    }
+
+    for (const failure of discovery.failures) {
+      const previous = preserved.get(dirname(failure.file))
+      this.log.warn(
+        `${failure.error.message}; ${previous ? `keeping last valid config for agent "${previous.id}"` : 'skipping agent'}`
+      )
+    }
+
+    let agents: LoadedAgent[]
+    if (this.opts.agentName) {
+      const match = validAgents.find((agent) => agent.id === this.opts.agentName)
+      const previous = [...preserved.values()].find((agent) => agent.id === this.opts.agentName)
+      if (match) agents = [match]
+      else if (previous) agents = [previous]
+      else {
+        const available =
+          validAgents
+            .map((agent) => agent.id)
+            .sort()
+            .join(', ') || '(none)'
+        throw new Error(`agent "${this.opts.agentName}" not found in ${this.agentsDir}. Available: ${available}`)
+      }
+    } else {
+      agents = [...activeFleet]
+      for (const previous of preserved.values()) {
+        if (!agents.some((agent) => agent.dir === previous.dir)) agents.push(previous)
+      }
+    }
+
+    return { agents, activeFleet }
   }
 
   /**
@@ -3185,7 +3226,8 @@ export class Daemon {
   }
 
   private async runReconcile(): Promise<void> {
-    const files = this.loadAgentList()
+    const snapshot = this.loadAgentList(true)
+    const files = snapshot.agents
     const nextFileAgents = new Map(files.map((a) => [a.id, a]))
     const desired = [...nextFileAgents.values()].filter(
       (agent) => !this.moveStagedAgents.has(agent.id) && !this.removedAgentTombstones.has(agent.id)
@@ -3196,7 +3238,7 @@ export class Daemon {
       // Use the raw discovered list in multi-agent mode: constructing a Map has
       // last-writer-wins semantics and must not hide two directories that claim
       // the same active agent ID from authority validation.
-      const activeFleet = this.opts.agentName ? loadAgents(this.agentsDir) : files
+      const activeFleet = snapshot.activeFleet
       assertExclusiveAgentWorkspaces(
         // Include both old and desired authorities. A batched workspace swap or
         // transfer must not publish A's new config while B's old host still has

--- a/packages/daemon/test/agents.test.ts
+++ b/packages/daemon/test/agents.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { chmodSync, mkdtempSync, mkdirSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, isAbsolute } from 'node:path'
-import { loadAgents, discoverAgents, selectAgent } from '../src/agents/load-agents.js'
+import { loadAgents, discoverAgents, discoverAgentsTolerant, selectAgent } from '../src/agents/load-agents.js'
 import { AgentSchema } from '../src/agents/agent-schema.js'
 
 function writeAgent(dir: string, id: string, agent: unknown) {
@@ -87,6 +87,18 @@ describe('loadAgents', () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-agents-'))
     writeAgent(dir, 'bad', { id: 'bad' }) // missing required fields
     expect(() => loadAgents(dir)).toThrow(/bad/)
+  })
+
+  it('can isolate a malformed agent while returning the rest of the fleet', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-agents-'))
+    writeAgent(dir, 'bot-a', slackAgent('bot-a'))
+    writeAgent(dir, 'bad', { id: 'bad' })
+
+    const result = discoverAgentsTolerant(dir)
+
+    expect(result.agents.map(({ agent }) => agent.id)).toEqual(['bot-a'])
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.error.message).toMatch(/invalid agent\.json.*bad\/agent\.json/)
   })
 
   it.skipIf(process.platform === 'win32')('repairs a legacy detached agent.json without discovering it', () => {

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -115,6 +115,36 @@ describe('Daemon agent config watcher', () => {
 })
 
 describe('Daemon.reconcile', () => {
+  it('starts valid agents and skips a malformed agent config', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    const badDir = join(root, 'agents', 'bad')
+    mkdirSync(badDir, { recursive: true })
+    writeFileSync(join(badDir, 'agent.json'), '{ "id": "bad"')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const daemon = new Daemon({
+      root,
+      hostFactory: () =>
+        ({
+          __started: true,
+          start: vi.fn(),
+          newSession: vi.fn(),
+          prompt: vi.fn(),
+          cancel: vi.fn(),
+          stop: vi.fn()
+        }) as any
+    })
+
+    await expect(daemon.start()).resolves.toBeUndefined()
+
+    expect((daemon as any).agents.has('bot-a')).toBe(true)
+    expect((daemon as any).agents.has('bad')).toBe(false)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringMatching(/WARN.*invalid agent\.json.*bad.*skipping agent/))
+
+    errorSpy.mockRestore()
+    await daemon.stop()
+  })
+
   it('picks up a newly added agent from disk', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
@@ -279,9 +309,10 @@ describe('Daemon.reconcile per-dimension host eviction', () => {
 })
 
 describe('Daemon watcher resilience: corrupt agent.json', () => {
-  it('direct reconcile() rejects, but watcher-triggered reconcile does not cause unhandled rejection and logs to console.error', async () => {
+  it('keeps the last valid config and still reconciles unrelated agents', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
+    writeAgent(root, 'bot-b')
     const daemon = new Daemon({
       root,
       hostFactory: () =>
@@ -296,25 +327,19 @@ describe('Daemon watcher resilience: corrupt agent.json', () => {
     })
     await daemon.start()
 
-    // Corrupt agent.json so discovery throws
+    const originalAgent = (daemon as any).agents.get('bot-a')
     const agentJsonPath = join(root, 'agents', 'bot-a', 'agent.json')
     writeFileSync(agentJsonPath, '{ this is not valid json')
-
-    // Direct call to reconcile() must still reject (fix must not swallow errors in reconcile itself)
-    await expect(daemon.reconcile()).rejects.toThrow()
-
-    // Spy on console.error before triggering the debounced watcher path
+    writeAgentJson(root, 'bot-b', { output: { mode: 'high' } })
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    // Fire the debounced watcher handler (same pattern as existing test)
-    const debounced = (daemon as any).watcher.listeners('add')[0] as () => void
-    debounced()
+    await expect(daemon.reconcile()).resolves.toBeUndefined()
 
-    // Wait longer than the 300ms debounce window
-    await new Promise((resolve) => setTimeout(resolve, 400))
-
-    // The background path must have caught the error and logged it
-    expect(errorSpy).toHaveBeenCalledWith('agentconnect: reconcile failed:', expect.any(Error))
+    expect((daemon as any).agents.get('bot-a')).toBe(originalAgent)
+    expect((daemon as any).agents.get('bot-b').output.mode).toBe('high')
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/WARN.*invalid agent\.json.*bot-a.*keeping last valid config for agent "bot-a"/)
+    )
 
     errorSpy.mockRestore()
     await daemon.stop()


### PR DESCRIPTION
## Summary

- isolate malformed `agent.json` files during daemon fleet discovery
- keep starting valid agents while logging and skipping invalid configurations
- retain the last valid configuration for a running agent when a reconcile sees a malformed file
- keep strict discovery behavior for single-agent validation consumers

## Root cause

Fleet discovery parsed all `agent.json` files through one fail-fast map. A syntax or schema error in any one file threw out of daemon startup, preventing every otherwise valid local agent from loading. The same failure also blocked unrelated reconcile updates.

## Impact

A broken agent configuration no longer takes the whole daemon offline. Operators get a warning containing the invalid file path, while healthy agents continue to run. During hot reload, an already-running agent remains on its last valid configuration until the file is fixed.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/agents.test.ts test/reconcile-watch.test.ts` (54 tests)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- targeted ESLint and Prettier checks
- repository pre-push ESLint hook