### PR TITLE
refactor(daemon): the MCP tool surface reads Layer-1 capability ports (S3 Appendix A)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -141,6 +141,7 @@ import { isMalformedPlatformTurn } from './platforms/malformed-turn.js'
 import { registerThreadPromotion, threadPromotionFor } from './platforms/thread-promotion.js'
 import { discordThreadPromotion } from './platforms/discord/thread-promotion.js'
 import { sessionLinkSourceFor } from './platforms/link-source.js'
+import { offersReadPort } from './platforms/read-ports.js'
 import {
   observedChannelsFor,
   registerObservedChannels,
@@ -9865,11 +9866,15 @@ export class Daemon {
   ): (() => Promise<ThreadContextSnapshot>) | undefined {
     // Capability-gated on the Layer-1 read port: only connections with a thread
     // history adapter (`getThreadReplies` — Slack today) contribute a provider
-    // snapshot. NOTE for the second adapter: the checkpoint below is minted in
-    // Slack's ts format; when another platform implements the port, checkpoint
-    // minting moves into it.
-    const conn = this.replyConnFor(pending.agentId, pending.integrationId) as Partial<SlackConnection> | undefined
-    if (typeof conn?.getThreadReplies !== 'function') return undefined
+    // snapshot. The gate asks the port by name through `offersReadPort`, so it no
+    // longer needs a `Partial<SlackConnection>` cast to state "this looks Slack
+    // enough" — the cast WAS the platform branch (audit blind spot 3).
+    // NOTE for the second adapter: the checkpoint below is minted in Slack's ts
+    // format; when another platform implements the port, checkpoint minting moves
+    // into it.
+    if (!offersReadPort(this.replyConnFor(pending.agentId, pending.integrationId), 'getThreadReplies')) {
+      return undefined
+    }
     return async () => {
       const checkpoint = slackTsForWallClock(this.clock.now())
       const readState = { truncated: false }

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -1,6 +1,13 @@
 import type { ToolDescriptor } from './tools.js'
 import type { MemoryProvider } from '../agents/memory-provider.js'
 import { threadKeyForPost } from '../platforms/thread-keys.js'
+import {
+  directMessagePlatformFor,
+  directMessagePlatformList,
+  isAttachmentReadTool,
+  offersDirectMessages,
+  platformLabel
+} from '../platforms/read-ports.js'
 import type { ChannelAgentsReq, ChannelAgentsOk, KnowledgeSearchOk, Platform } from '@agentconnect.md/protocol'
 import { randomUUID } from 'node:crypto'
 import { MemoryPathError, MemoryTooLargeError } from '../agents/memory.js'
@@ -48,9 +55,11 @@ export interface SendIdentity {
 }
 
 export interface MessageGateway {
-  /** Resolve one platform user to the app's real direct-message conversation.
-   *  Slack needs this before posting with a customized agent identity: sending to
-   *  a raw U… id routes the message through Slack's system-notification DM. */
+  /** Layer-1 `openDirectMessage`: resolve one platform user to the app's real
+   *  direct-message conversation. Optional because it is a declared read port,
+   *  not a universal one — Slack needs it before posting with a customized agent
+   *  identity (sending to a raw U… id routes the message through Slack's
+   *  system-notification DM); a platform without the port has no `toUser` form. */
   openDirectMessage?(user: string): Promise<string>
   /** Post a message; returns the resulting message id (`ts` / message_id) so the
    *  daemon can record it. `identity` carries the agent's stable id and optional
@@ -910,9 +919,10 @@ export async function executeTool(
     // owning daemon); such a rare reject can still leave a post — an accepted residual.
     const wakeRejection = baseWakeReq !== undefined ? (deps.preflightWake?.(baseWakeReq) ?? null) : null
 
-    // (A) Post a visible IM at a platform channel's ROOT, or to a Slack user's DM. The
+    // (A) Post a visible IM at a platform channel's ROOT, or to a user's DM. The
     // destination is the `channel` for the channel-root form; the `toUser` DM form (no
-    // channel) first resolves the Slack member id to the app's real D… conversation.
+    // channel) first resolves the member id to the app's own 1:1 conversation through
+    // the platform's Layer-1 `openDirectMessage` read port.
     // Routing is by `platform` (+ optional `integrationId`) to ANY platform the agent is
     // connected to; identity is stamped from the trusted session.
     //
@@ -941,13 +951,23 @@ export async function executeTool(
     const requestedChannel = channel ?? toUsers?.[0]
     if (requestedChannel !== undefined && wakeRejection === null) {
       const directMessage = toUsers !== undefined && channel === undefined
-      const wantPlatform = optionalString(args, 'platform') ?? (directMessage ? 'slack' : ctx.platform)
+      // A DM has to land on a platform that can OPEN one, which is rarely the session's
+      // own: the caller may be answering in Telegram and DM-ing a colleague elsewhere.
+      // The default is therefore the DM-capable platform (Layer-1 `openDirectMessage`),
+      // preferring this session's when it qualifies — the generalization of the literal
+      // `'slack'` that used to sit here.
+      const wantPlatform =
+        optionalString(args, 'platform') ?? (directMessage ? directMessagePlatformFor(ctx.platform) : ctx.platform)
       const wantIntegrationId = optionalString(args, 'integrationId')
       const { gw, integrationId: targetId } = resolveGatewayForPlatform(ctx, deps, wantPlatform, wantIntegrationId)
       let body = message
       if (toUsers !== undefined) {
-        if (wantPlatform !== 'slack') {
-          throw new Error(`sendMessage: toUser is only supported on Slack (not ${wantPlatform}) yet`)
+        // Whole `toUser` mode — DM and the channel-root mention form alike — is gated on
+        // the DM read port: the mention syntax rendered below is the same platform's.
+        if (!offersDirectMessages(wantPlatform)) {
+          throw new Error(
+            `sendMessage: toUser is only supported on ${directMessagePlatformList()} (not ${wantPlatform}) yet`
+          )
         }
         // dm form: the one user id IS the destination and the body is unchanged; the
         // channel-root form @-mentions every named user inside the one visible post.
@@ -972,7 +992,7 @@ export async function executeTool(
         })
         if (address) body = `${address} ${message}`
       }
-      const postChannel = directMessage ? await openDirectMessage(gw, requestedChannel) : requestedChannel
+      const postChannel = directMessage ? await openDirectMessage(gw, requestedChannel, wantPlatform) : requestedChannel
       const identity: SendIdentity = {
         ...(ctx.agentName ? { username: ctx.agentName } : {}),
         ...(ctx.iconUrl ? { icon_url: ctx.iconUrl } : {}),
@@ -1279,40 +1299,44 @@ export async function executeTool(
   const gw = ctx.integrationId ? deps.gatewayFor(ctx.integrationId) : undefined
   if (!gw) throw new Error(`no live platform connection for integration ${ctx.integrationId ?? '(none)'}`)
 
+  // Any platform's CREDENTIALED attachment read (`readSlackFile`, `readTelegramFile`, …).
+  // ONE body for all of them: a platform contributes only the descriptor by declaring the
+  // read port, and the fetch itself is the Layer-1 `downloadFile` every connection has, on
+  // the gateway this session is already bound to.
+  if (isAttachmentReadTool(name)) {
+    const url = requireString(args, 'url')
+    const max = deps.maxAttachmentBytes ?? DEFAULT_MAX_ATTACHMENT_BYTES
+    const bytes = await gw.downloadFile(url, max)
+    if (!bytes) {
+      throw new Error(
+        `could not download the file at ${url} — it may be inaccessible, larger than ${max} bytes, or the bot ` +
+          `may lack permission to read it (e.g. the Slack files:read scope)`
+      )
+    }
+    const mimeType = optionalString(args, 'mimeType') ?? guessMimeFromUrl(url) ?? 'application/octet-stream'
+    if (mimeType.startsWith('image/')) {
+      const result: McpContentResult = {
+        mcpContent: [{ type: 'image', data: bytes.toString('base64'), mimeType }]
+      }
+      return result
+    }
+    if (mimeType.startsWith('text/') || mimeType === 'application/json' || mimeType === 'text/csv') {
+      const result: McpContentResult = { mcpContent: [{ type: 'text', text: bytes.toString('utf8') }] }
+      return result
+    }
+    // Non-image binary: don't inline a base64 blob as text; report what we got.
+    const result: McpContentResult = {
+      mcpContent: [
+        { type: 'text', text: `Downloaded ${bytes.byteLength} bytes of ${mimeType} (binary — not shown inline).` }
+      ]
+    }
+    return result
+  }
+
   switch (name) {
     case 'getCurrentChannel': {
       const info = await gw.getChannelInfo(ctx.channel).catch(() => undefined)
       return { channel: ctx.channel, thread: ctx.thread, name: info?.name ?? null, isIm: info?.isIm ?? null }
-    }
-    case 'readSlackFile':
-    case 'readTelegramFile': {
-      const url = requireString(args, 'url')
-      const max = deps.maxAttachmentBytes ?? DEFAULT_MAX_ATTACHMENT_BYTES
-      const bytes = await gw.downloadFile(url, max)
-      if (!bytes) {
-        throw new Error(
-          `could not download the file at ${url} — it may be inaccessible, larger than ${max} bytes, or the bot ` +
-            `may lack permission to read it (e.g. the Slack files:read scope)`
-        )
-      }
-      const mimeType = optionalString(args, 'mimeType') ?? guessMimeFromUrl(url) ?? 'application/octet-stream'
-      if (mimeType.startsWith('image/')) {
-        const result: McpContentResult = {
-          mcpContent: [{ type: 'image', data: bytes.toString('base64'), mimeType }]
-        }
-        return result
-      }
-      if (mimeType.startsWith('text/') || mimeType === 'application/json' || mimeType === 'text/csv') {
-        const result: McpContentResult = { mcpContent: [{ type: 'text', text: bytes.toString('utf8') }] }
-        return result
-      }
-      // Non-image binary: don't inline a base64 blob as text; report what we got.
-      const result: McpContentResult = {
-        mcpContent: [
-          { type: 'text', text: `Downloaded ${bytes.byteLength} bytes of ${mimeType} (binary — not shown inline).` }
-        ]
-      }
-      return result
     }
     default:
       throw new Error(`unknown tool: ${name}`)
@@ -1383,9 +1407,13 @@ function parseUserTargets(value: unknown): string[] | undefined {
   return ids
 }
 
-async function openDirectMessage(gateway: MessageGateway, user: string): Promise<string> {
+/** Resolve `user` to the app's own 1:1 conversation through the platform's Layer-1
+ *  `openDirectMessage` port. The platform already declared it (that gate ran before
+ *  the gateway was resolved); this is the LIVE probe on the connection actually
+ *  selected — a send-only or stubbed gateway can still lack the method. */
+async function openDirectMessage(gateway: MessageGateway, user: string, platform: string): Promise<string> {
   if (!gateway.openDirectMessage) {
-    throw new Error('sendMessage: the selected Slack integration cannot open direct messages')
+    throw new Error(`sendMessage: the selected ${platformLabel(platform)} integration cannot open direct messages`)
   }
   return gateway.openDirectMessage(user)
 }

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -2,6 +2,7 @@ import type { Integration } from '../agents/agent-schema.js'
 import type { MemoryPluginOperation } from '@agentconnect.md/protocol'
 import type { JSONValue } from '@modelcontextprotocol/server'
 import { SESSION_TITLE_TOOL_NAME } from './session-title-tool.js'
+import { allAttachmentReadTools, attachmentReadToolsFor } from '../platforms/read-ports.js'
 
 /**
  * A tool descriptor in MCP's `tools/list` shape: a name, a human/model-facing
@@ -314,8 +315,9 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
  * (so an agent handling a Telegram chat can discover Slack channel/user ids to
  * cross-post to). `platform` defaults to the current conversation's platform.
  * The enum is narrowed at build time to the agent's own platforms. Sending is
- * handled separately by {@link buildSendMessageTool}; per-platform file
- * downloads by {@link SLACK_FILE_TOOLS}/{@link TELEGRAM_FILE_TOOLS}.
+ * handled separately by {@link buildSendMessageTool}; per-platform credentialed
+ * file downloads by whichever platforms declare that read port
+ * ({@link attachmentReadToolsFor}).
  */
 function buildReadTools(platforms: string[]): ToolDescriptor[] {
   const platform = {
@@ -395,44 +397,6 @@ function buildReadTools(platforms: string[]): ToolDescriptor[] {
     }
   ]
 }
-
-/** Slack file-read helper, injected when an agent has a Slack integration. */
-const SLACK_FILE_TOOLS: ToolDescriptor[] = [
-  {
-    name: 'readSlackFile',
-    description:
-      'Fetch the contents of a file shared in Slack, using the bot credentials. You do NOT have direct network access ' +
-      "to Slack's private file URLs (they require the bot token) — use this tool instead of curl/fetch. Pass the file's " +
-      '`url` (the `url_private` / `uri` from a shared attachment or resource link). Images are returned as viewable image ' +
-      'content; text files as text. Supply `mimeType` when known for correct handling.',
-    inputSchema: obj(
-      {
-        url: { type: 'string', description: "The file's url_private (or url_private_download) / resource-link uri." },
-        mimeType: { type: 'string', description: 'Optional MIME type hint, e.g. image/png or text/plain.' }
-      },
-      ['url']
-    )
-  }
-]
-
-/** Telegram file-read helper, injected when an agent has a Telegram integration. */
-const TELEGRAM_FILE_TOOLS: ToolDescriptor[] = [
-  {
-    name: 'readTelegramFile',
-    description:
-      'Fetch the contents of a file shared in Telegram, using the bot credentials. You do NOT have direct network ' +
-      "access to Telegram's file storage — use this tool instead of curl/fetch. Pass the file's `url` (the `file_id` " +
-      'from a shared attachment or the `uri` of a resource link). Images are returned as viewable image content; text ' +
-      'files as text. Supply `mimeType` when known for correct handling.',
-    inputSchema: obj(
-      {
-        url: { type: 'string', description: "The shared file's Telegram file_id (or resource-link uri)." },
-        mimeType: { type: 'string', description: 'Optional MIME type hint, e.g. image/png or text/plain.' }
-      },
-      ['url']
-    )
-  }
-]
 
 /**
  * The agent's long-term memory tools — available to EVERY agent regardless of
@@ -799,8 +763,10 @@ export const ALL_TOOL_NAMES = [
       // are stable and belong in the permission auto-allow set.
       buildSendMessageTool([]),
       ...buildReadTools([]),
-      ...SLACK_FILE_TOOLS,
-      ...TELEGRAM_FILE_TOOLS,
+      // Every platform's credentialed attachment tool, whatever this agent has:
+      // the auto-allow set is about NAMES, and a name a platform can inject must
+      // be listed even for an agent that will never see it.
+      ...allAttachmentReadTools(),
       ...MEMORY_TOOLS,
       ...KNOWLEDGE_TOOLS,
       ...Object.values(EXTERNAL_MEMORY_TOOLS),
@@ -815,7 +781,8 @@ export const ALL_TOOL_NAMES = [
  * always present; the session-title fallback is opt-in for whitelisted runtimes,
  * and platform tools are gated by the agent's integrations. The channel/user
  * read helpers are platform-neutral (one set, routed by a `platform` argument);
- * only the per-platform file-read tools are gated per platform.
+ * only the per-platform file-read tools are gated per platform — and that gate
+ * is a declared Layer-1 read port, not a platform name.
  */
 export function toolsForIntegrations(
   integrations: Integration[],
@@ -848,7 +815,11 @@ export function toolsForIntegrations(
   if (platforms.length > 0) {
     add(buildReadTools(platforms))
   }
-  if (integrations.some((i) => i.platform === 'slack')) add(SLACK_FILE_TOOLS)
-  if (integrations.some((i) => i.platform === 'telegram')) add(TELEGRAM_FILE_TOOLS)
+  // Per-platform CREDENTIALED attachment reads. A platform contributes its own
+  // descriptor by declaring the read port (`platforms/read-ports.ts`); core does
+  // not know which platforms have one, or what they are called. Registry order,
+  // not integration order, so an agent's tool list does not reshuffle because its
+  // integrations happened to be stored the other way round.
+  add(attachmentReadToolsFor(platforms))
   return tools
 }

--- a/packages/daemon/src/platforms/read-ports.ts
+++ b/packages/daemon/src/platforms/read-ports.ts
@@ -1,0 +1,178 @@
+/**
+ * **Layer-1 read ports** — which optional facets of the connection contract a
+ * platform offers, and how core asks (integration-plugin-architecture.md §7.1 /
+ * §7.4, audit Appendix A class a, stage S3).
+ *
+ * `contract.ts` already declares the optional half of {@link PlatformConnection}
+ * — `getThreadReplies`, `openDirectMessage`, `listBotChannels`, … — and the audit
+ * calls the `typeof conn?.x === 'function'` probe over them "the sanctioned
+ * Layer-1 read-port mechanism". What was missing is the OTHER half of the same
+ * question, asked where no connection is in hand yet: *does this PLATFORM offer
+ * the port at all?* The MCP tool surface asks it in three places, and each
+ * spelled the answer as a platform name:
+ *
+ *  - which agent-facing attachment tool to inject (`platform === 'slack'` →
+ *    `readSlackFile`, `=== 'telegram'` → `readTelegramFile`) — decided at
+ *    `session/new` from the agent's CONFIGURED integrations, long before any
+ *    connection is resolved;
+ *  - which platform a `toUser` direct message defaults to (`?? 'slack'`);
+ *  - whether the selected platform can open a DM at all (`!== 'slack'` → throw).
+ *
+ * TWO ASKS, ON PURPOSE. {@link offersReadPort} probes a live bearer (a
+ * connection, or the `MessageGateway` slice the MCP tools hold); the registry
+ * below answers for a platform id before one exists. They are not redundant: the
+ * probe is the truth about THIS connection, the declaration is what core may
+ * assume while building a tool list for an agent whose bots may all be offline.
+ * Deciding tool injection by live probe would silently drop `readSlackFile` from
+ * a session opened while the socket was reconnecting — a behavior change this
+ * refactor is not allowed to make.
+ *
+ * FAIL-CLOSED BY ABSENCE, like `messageOrderingFor`. An unregistered platform
+ * declares no ports: no attachment tool is injected, no DM is attempted. That is
+ * exactly the old `else` arm of every branch above, and it means a new platform
+ * degrades quietly instead of inheriting a Slack-shaped path it cannot serve.
+ *
+ * TOOL NAMES ARE FROZEN. `readSlackFile` / `readTelegramFile` are names agents
+ * have learned and examples teach; the injection MECHANISM generalizes, the
+ * names do not move. They live in their platform's own module now, which is the
+ * whole point — core no longer knows that either name exists.
+ */
+import type { ToolDescriptor } from '../mcp/tools.js'
+import { SLACK_ATTACHMENT_TOOL } from './slack/attachments.js'
+import { TELEGRAM_ATTACHMENT_TOOL } from './telegram/attachments.js'
+
+/** The optional {@link import('./contract.js').PlatformConnection} facets core
+ *  branches on. Deliberately only the two this seam covers: a port earns a name
+ *  here when a branch retires onto it, never speculatively. */
+export type ReadPort = 'getThreadReplies' | 'openDirectMessage'
+
+/** Anything that MAY carry read ports: a real connection, the `MessageGateway`
+ *  slice the MCP tools hold, or a duck-typed test fake. Deliberately `object`
+ *  and not `Partial<Record<ReadPort, unknown>>` — the latter is a WEAK type, so
+ *  TypeScript rejects exactly the connections that implement no optional port
+ *  (`TelegramConnection` "has no properties in common"), which is the arm this
+ *  probe exists to answer `false` for. */
+export type ReadPortBearer = object
+
+/** Does this bearer implement `port`? The typed home for the
+ *  `typeof conn?.getThreadReplies === 'function'` probes core grew organically.
+ *  A missing bearer answers false, so callers keep their one-line gate. */
+export function offersReadPort(bearer: ReadPortBearer | undefined, port: ReadPort): boolean {
+  return typeof (bearer as Partial<Record<ReadPort, unknown>> | undefined)?.[port] === 'function'
+}
+
+/** One platform's read-port declaration — the pre-connection half of the ask. */
+export interface PlatformReadPorts {
+  /** Platform id this declaration answers for; never parsed. */
+  readonly platform: string
+  /** Human-facing name, for errors that must stay as informative as the
+   *  hardcoded ones they replace ("only supported on Slack"). */
+  readonly label: string
+  /** Layer-1 `openDirectMessage`: this platform's connections can resolve a user
+   *  id to the app's own 1:1 conversation, so `sendMessage`'s `toUser` form has
+   *  somewhere to post. */
+  readonly openDirectMessage?: boolean
+  /** The agent-facing tool that surfaces this platform's CREDENTIALED attachment
+   *  read. Present when the platform's file references cannot be fetched without
+   *  the bot token, so the agent needs a tool instead of its own network access.
+   *
+   *  Absent is not "no attachments": Discord hands out directly fetchable CDN
+   *  links, and Feishu simply never grew a tool. Giving Feishu one is now a
+   *  registration in its own module rather than a third `platform === …` arm in
+   *  `mcp/tools.ts`. */
+  readonly attachmentReadTool?: ToolDescriptor
+}
+
+/**
+ * A `Map`, not an object literal, so lookup is total for EVERY string rather
+ * than every string that is not an `Object.prototype` key — the same fail-closed
+ * reasoning the §5 manifest registry and `messageOrderingFor` carry.
+ *
+ * Insertion order is the ORDER CORE EMITS IN: `attachmentReadToolsFor` walks the
+ * registry, not the agent's integration list, so an agent's tool list does not
+ * reshuffle because its integrations were stored in a different order.
+ */
+const READ_PORTS = new Map<string, PlatformReadPorts>([
+  [
+    'slack',
+    {
+      platform: 'slack',
+      label: 'Slack',
+      openDirectMessage: true,
+      attachmentReadTool: SLACK_ATTACHMENT_TOOL
+    }
+  ],
+  [
+    'telegram',
+    {
+      platform: 'telegram',
+      label: 'Telegram',
+      attachmentReadTool: TELEGRAM_ATTACHMENT_TOOL
+    }
+  ]
+])
+
+/** `platform`'s declaration, or undefined when it declares no read ports. */
+export function readPortsFor(platform: string): PlatformReadPorts | undefined {
+  return READ_PORTS.get(platform)
+}
+
+/** `platform`'s human-facing name, falling back to the raw id so an unknown
+ *  platform still names itself in an error rather than reading as blank. */
+export function platformLabel(platform: string): string {
+  return READ_PORTS.get(platform)?.label ?? platform
+}
+
+/** Can `platform` open a direct message (Layer-1 `openDirectMessage`)? */
+export function offersDirectMessages(platform: string): boolean {
+  return READ_PORTS.get(platform)?.openDirectMessage === true
+}
+
+/**
+ * The platform a `toUser` send targets when the caller names none.
+ *
+ * Prefers the session's own platform when it can open a DM, else the first
+ * platform that can. With Slack the only DM-capable platform this is exactly the
+ * `directMessage ? 'slack' : ctx.platform` literal it replaces — including for a
+ * session on a platform that cannot DM, which still resolves to the DM-capable
+ * one and then fails on the caller's own "no Slack integration" error.
+ *
+ * A session platform that declares nothing and no DM-capable platform at all
+ * falls back to the session's platform: the caller's ordinary
+ * "not supported on X" error is the right report, not a silent redirect.
+ */
+export function directMessagePlatformFor(sessionPlatform: string): string {
+  if (offersDirectMessages(sessionPlatform)) return sessionPlatform
+  for (const decl of READ_PORTS.values()) if (decl.openDirectMessage) return decl.platform
+  return sessionPlatform
+}
+
+/** The DM-capable platforms, rendered for an error message ("Slack",
+ *  "Slack or Telegram"). Empty when no platform declares the port. */
+export function directMessagePlatformList(): string {
+  const labels = [...READ_PORTS.values()].filter((d) => d.openDirectMessage).map((d) => d.label)
+  return labels.join(' or ')
+}
+
+/** Every platform's attachment tool, in registry order — the permission
+ *  auto-allow set must list every injectable name, whatever the agent has. */
+export function allAttachmentReadTools(): ToolDescriptor[] {
+  return [...READ_PORTS.values()].flatMap((d) => (d.attachmentReadTool ? [d.attachmentReadTool] : []))
+}
+
+/** The attachment tools for exactly the platforms an agent is connected to, in
+ *  registry order. A platform that declares none contributes nothing. */
+export function attachmentReadToolsFor(platforms: Iterable<string>): ToolDescriptor[] {
+  const wanted = new Set(platforms)
+  return [...READ_PORTS.values()].flatMap((d) =>
+    wanted.has(d.platform) && d.attachmentReadTool ? [d.attachmentReadTool] : []
+  )
+}
+
+/** Is `name` some platform's attachment-read tool? The MCP dispatcher runs ONE
+ *  shared body for all of them — the platform contributes only the descriptor,
+ *  the download itself is the Layer-1 `downloadFile` every connection has. */
+export function isAttachmentReadTool(name: string): boolean {
+  for (const decl of READ_PORTS.values()) if (decl.attachmentReadTool?.name === name) return true
+  return false
+}

--- a/packages/daemon/src/platforms/slack/attachments.ts
+++ b/packages/daemon/src/platforms/slack/attachments.ts
@@ -1,0 +1,32 @@
+/**
+ * Slack's **credentialed attachment read**, as an agent-facing tool (§7.1 read
+ * port, stage S3).
+ *
+ * A Slack `url_private` is only fetchable with the bot token, which the agent
+ * never holds — so the platform contributes a tool that downloads through its
+ * own connection. Core injects it because Slack DECLARES it in
+ * `platforms/read-ports.ts`, not because core knows the word "slack".
+ *
+ * THE NAME IS FROZEN. `readSlackFile` is what agents have learned, what every
+ * shared resource_link points at, and what warm ACP sessions already carry in
+ * their descriptor list. The injection mechanism generalized; the name did not.
+ */
+import type { ToolDescriptor } from '../../mcp/tools.js'
+
+export const SLACK_ATTACHMENT_TOOL: ToolDescriptor = {
+  name: 'readSlackFile',
+  description:
+    'Fetch the contents of a file shared in Slack, using the bot credentials. You do NOT have direct network access ' +
+    "to Slack's private file URLs (they require the bot token) — use this tool instead of curl/fetch. Pass the file's " +
+    '`url` (the `url_private` / `uri` from a shared attachment or resource link). Images are returned as viewable image ' +
+    'content; text files as text. Supply `mimeType` when known for correct handling.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: "The file's url_private (or url_private_download) / resource-link uri." },
+      mimeType: { type: 'string', description: 'Optional MIME type hint, e.g. image/png or text/plain.' }
+    },
+    required: ['url'],
+    additionalProperties: false
+  }
+}

--- a/packages/daemon/src/platforms/telegram/attachments.ts
+++ b/packages/daemon/src/platforms/telegram/attachments.ts
@@ -1,0 +1,31 @@
+/**
+ * Telegram's **credentialed attachment read**, as an agent-facing tool (§7.1
+ * read port, stage S3).
+ *
+ * A Telegram `file_id` is not a URL at all — resolving it to bytes needs a
+ * `getFile` call with the bot token — so the platform contributes a tool that
+ * downloads through its own connection. Core injects it because Telegram
+ * DECLARES it in `platforms/read-ports.ts`, not because core knows the word
+ * "telegram".
+ *
+ * THE NAME IS FROZEN — see the note on Slack's sibling module.
+ */
+import type { ToolDescriptor } from '../../mcp/tools.js'
+
+export const TELEGRAM_ATTACHMENT_TOOL: ToolDescriptor = {
+  name: 'readTelegramFile',
+  description:
+    'Fetch the contents of a file shared in Telegram, using the bot credentials. You do NOT have direct network ' +
+    "access to Telegram's file storage — use this tool instead of curl/fetch. Pass the file's `url` (the `file_id` " +
+    'from a shared attachment or the `uri` of a resource link). Images are returned as viewable image content; text ' +
+    'files as text. Supply `mimeType` when known for correct handling.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: "The shared file's Telegram file_id (or resource-link uri)." },
+      mimeType: { type: 'string', description: 'Optional MIME type hint, e.g. image/png or text/plain.' }
+    },
+    required: ['url'],
+    additionalProperties: false
+  }
+}

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -517,11 +517,78 @@ describe('executeTool: sendMessage (channel post)', () => {
   it('rejects toUser off Slack before posting', async () => {
     const gw = fakeGateway()
     const { deps: d } = deps(gw)
-    // toUser is Slack-only for now — on another platform it throws (nothing posted).
+    // `toUser` needs the Layer-1 openDirectMessage read port, which only Slack
+    // declares — on another platform it throws (nothing posted). The error still
+    // NAMES the capable platform, which is the whole reason the declaration
+    // carries a label instead of core carrying the literal.
     const dual = { ...ctx, integrations: [...ctx.integrations!, { id: 'int-tg', platform: 'telegram' }] }
     await expect(
       executeTool(dual, 'sendMessage', { toUser: '42', platform: 'telegram', message: 'x' }, d)
-    ).rejects.toThrow(/only supported on Slack/)
+    ).rejects.toThrow('sendMessage: toUser is only supported on Slack (not telegram) yet')
+    expect(gw.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('rejects the toUser CHANNEL form off Slack too — the whole mode rides the port', async () => {
+    // Not just the DM form: the channel-root form renders `<@id>` mentions, which
+    // is the same platform's syntax. Both arms were behind one `!== 'slack'` gate
+    // and both stay behind the one port check.
+    const gw = fakeGateway()
+    const { deps: d } = deps(gw)
+    const dual = { ...ctx, integrations: [...ctx.integrations!, { id: 'int-tg', platform: 'telegram' }] }
+    await expect(
+      executeTool(dual, 'sendMessage', { toUser: '42', channel: '-100123', platform: 'telegram', message: 'x' }, d)
+    ).rejects.toThrow('sendMessage: toUser is only supported on Slack (not telegram) yet')
+    expect(gw.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('defaults a DM to the port-capable platform even from a session on another one', async () => {
+    // A Telegram-triggered session that also owns a Slack bot DMs through SLACK
+    // when the caller names no platform: the DM form defaults to the platform
+    // that can open one, not to the session's own.
+    const gw = fakeGateway()
+    const { deps: d } = deps(gw)
+    const fromTelegram = {
+      ...ctx,
+      platform: 'telegram',
+      integrationId: 'int-tg',
+      integrations: [
+        { id: 'int-tg', platform: 'telegram' },
+        { id: 'int-1', platform: 'slack' }
+      ]
+    }
+    const res = (await executeTool(fromTelegram, 'sendMessage', { toUser: 'U9', message: 'ping' }, d)) as {
+      post: Record<string, unknown>
+    }
+    expect(gw.openDirectMessage).toHaveBeenCalledWith('U9')
+    expect(res.post).toMatchObject({ platform: 'slack', integrationId: 'int-1', channel: 'D-U9' })
+  })
+
+  it('reports the missing integration first when the agent has no port-capable bot at all', async () => {
+    // Ordering is load-bearing and unchanged: the DM default resolves to Slack,
+    // gateway resolution runs BEFORE the port gate, so a Telegram-only agent gets
+    // "no slack integration" rather than "not supported on Slack".
+    const gw = fakeGateway()
+    const { deps: d } = deps(gw)
+    const telegramOnly = {
+      ...ctx,
+      platform: 'telegram',
+      integrationId: 'int-tg',
+      integrations: [{ id: 'int-tg', platform: 'telegram' }]
+    }
+    await expect(executeTool(telegramOnly, 'sendMessage', { toUser: '42', message: 'x' }, d)).rejects.toThrow(
+      'this agent has no slack integration'
+    )
+    expect(gw.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('reports a selected integration whose live connection cannot open a DM', async () => {
+    // The platform declares the port; THIS gateway does not implement it (a
+    // send-only connection). The live probe is the second, narrower gate.
+    const gw = fakeGateway({ openDirectMessage: undefined })
+    const { deps: d } = deps(gw)
+    await expect(executeTool(ctx, 'sendMessage', { toUser: 'U9', message: 'ping' }, d)).rejects.toThrow(
+      'sendMessage: the selected Slack integration cannot open direct messages'
+    )
     expect(gw.postMessage).not.toHaveBeenCalled()
   })
 })

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -14,6 +14,28 @@ const telegramInt: Integration = {
   telegram: { botToken: '123456:ABC', bindRules: [] }
 }
 
+// Connected platforms that declare NO credentialed-attachment read port — the
+// arm the file-tool matrix below would never exercise with Slack/Telegram alone.
+const discordInt: Integration = {
+  id: 'int-3',
+  platform: 'discord',
+  discord: { botToken: 'dc', bindRules: [], mutedChannels: [], gated: false }
+}
+
+const feishuInt: Integration = {
+  id: 'int-4',
+  platform: 'feishu',
+  feishu: {
+    mode: 'direct',
+    appId: 'cli_x',
+    appSecret: 's',
+    region: 'feishu',
+    bindRules: [],
+    mutedChannels: [],
+    gated: false
+  }
+}
+
 describe('toolsForIntegrations', () => {
   const sendTool = (ints: Integration[]) => toolsForIntegrations(ints).find((t) => t.name === 'sendMessage')
   type ObjectSchema = {
@@ -90,6 +112,39 @@ describe('toolsForIntegrations', () => {
     expect(names.filter((n) => n === 'sendMessage')).toHaveLength(1)
     expect(sendPlatformEnum([slackInt, telegramInt])).toEqual(['slack', 'telegram'])
     expect(names.filter((n) => n === 'getCurrentChannel')).toHaveLength(1)
+  })
+
+  /**
+   * The credentialed-attachment tools are injected because the platform DECLARES
+   * the Layer-1 read port (`platforms/read-ports.ts`), not because this file knows
+   * the words "slack" and "telegram". The matrix below is the behavioral contract
+   * that survived that change: same tools, same names, same order, for every
+   * combination of connected platforms.
+   */
+  it('injects each platform’s credentialed file tool for exactly the platforms that declare one', () => {
+    const fileTools = (ints: Integration[]) =>
+      toolsForIntegrations(ints)
+        .map((t) => t.name)
+        .filter((n) => n.startsWith('read') && n.endsWith('File'))
+
+    expect(fileTools([])).toEqual([])
+    expect(fileTools([slackInt])).toEqual(['readSlackFile'])
+    expect(fileTools([telegramInt])).toEqual(['readTelegramFile'])
+    expect(fileTools([slackInt, telegramInt])).toEqual(['readSlackFile', 'readTelegramFile'])
+    // Registry order, not integration order — a stored-the-other-way-round agent
+    // must not see its tool list reshuffle.
+    expect(fileTools([telegramInt, slackInt])).toEqual(['readSlackFile', 'readTelegramFile'])
+    // A connected platform that declares no such port contributes no tool, alone…
+    expect(fileTools([discordInt])).toEqual([])
+    expect(fileTools([feishuInt])).toEqual([])
+    // …and does not suppress the ones that do.
+    expect(fileTools([discordInt, slackInt, feishuInt])).toEqual(['readSlackFile'])
+    // Two bots on the same platform still yield ONE tool (the `seen` dedupe).
+    expect(fileTools([slackInt, { ...slackInt, id: 'int-1b' }])).toEqual(['readSlackFile'])
+    // The platform read helpers are unaffected — they were never port-gated.
+    expect(toolsForIntegrations([discordInt]).map((t) => t.name)).toEqual(
+      expect.arrayContaining(['getCurrentChannel', 'listChannels'])
+    )
   })
 
   it('exposes NO `thread` property in any send branch, on any integration set', () => {

--- a/packages/daemon/test/platform-read-ports.test.ts
+++ b/packages/daemon/test/platform-read-ports.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import {
+  allAttachmentReadTools,
+  attachmentReadToolsFor,
+  directMessagePlatformFor,
+  directMessagePlatformList,
+  isAttachmentReadTool,
+  offersDirectMessages,
+  offersReadPort,
+  platformLabel,
+  readPortsFor
+} from '../src/platforms/read-ports.js'
+import { SlackConnection } from '../src/slack/connection.js'
+import { TelegramConnection } from '../src/telegram/connection.js'
+import { DiscordConnection } from '../src/discord/connection.js'
+import { FeishuConnection } from '../src/feishu/connection.js'
+
+/**
+ * The Layer-1 read-port seam (integration-plugin-architecture.md §7.1/§7.4).
+ *
+ * Two asks with two answer sources, and the tests below hold BOTH honest:
+ * `offersReadPort` probes a live bearer, the registry declares for a platform id
+ * before a connection exists. A declaration that disagrees with its own adapter
+ * is the failure mode this seam introduces, so it gets its own test.
+ */
+
+const has = (ctor: { prototype: object }, member: string): boolean =>
+  typeof (ctor.prototype as Record<string, unknown>)[member] === 'function'
+
+describe('offersReadPort (live probe)', () => {
+  it('answers by method presence, and false for a bearer that is not there', () => {
+    expect(offersReadPort({ getThreadReplies: () => [] }, 'getThreadReplies')).toBe(true)
+    expect(offersReadPort({}, 'getThreadReplies')).toBe(false)
+    expect(offersReadPort(undefined, 'getThreadReplies')).toBe(false)
+    // A present-but-not-callable member is NOT the port: the probe replaced
+    // `typeof conn?.x === 'function'`, not `'x' in conn`.
+    expect(offersReadPort({ openDirectMessage: 'yes' }, 'openDirectMessage')).toBe(false)
+  })
+
+  it('reads each port independently on the same bearer', () => {
+    const slackish = { getThreadReplies: () => [], openDirectMessage: () => 'D1' }
+    const telegramish = {}
+    expect(offersReadPort(slackish, 'openDirectMessage')).toBe(true)
+    expect(offersReadPort(telegramish, 'getThreadReplies')).toBe(false)
+    expect(offersReadPort(telegramish, 'openDirectMessage')).toBe(false)
+  })
+
+  it('accepts a real connection of every platform, including ones with no optional port', () => {
+    // Regression guard for the WEAK-TYPE trap: typing the parameter as
+    // `Partial<Record<ReadPort, unknown>>` makes TypeScript reject exactly the
+    // connections that implement no optional port — the arm this must answer for.
+    expect(offersReadPort(SlackConnection.prototype, 'getThreadReplies')).toBe(true)
+    expect(offersReadPort(SlackConnection.prototype, 'openDirectMessage')).toBe(true)
+    for (const ctor of [TelegramConnection, DiscordConnection, FeishuConnection]) {
+      expect(offersReadPort(ctor.prototype, 'getThreadReplies')).toBe(false)
+      expect(offersReadPort(ctor.prototype, 'openDirectMessage')).toBe(false)
+    }
+  })
+})
+
+describe('the read-port registry', () => {
+  it('agrees with the adapters it declares for', () => {
+    // The declaration exists to answer BEFORE a connection is in hand; if it
+    // drifts from the connection it describes, every pre-connection decision
+    // (tool injection, DM default) silently lies. Pinned against the real class.
+    expect(offersDirectMessages('slack')).toBe(has(SlackConnection, 'openDirectMessage'))
+    expect(offersDirectMessages('telegram')).toBe(has(TelegramConnection, 'openDirectMessage'))
+    expect(offersDirectMessages('discord')).toBe(has(DiscordConnection, 'openDirectMessage'))
+    expect(offersDirectMessages('feishu')).toBe(has(FeishuConnection, 'openDirectMessage'))
+  })
+
+  it('is fail-closed for an unregistered platform', () => {
+    for (const unknownPlatform of ['webchat', 'hook', 'dream', 'github', 'constructor', 'toString', '']) {
+      expect(readPortsFor(unknownPlatform)).toBeUndefined()
+      expect(offersDirectMessages(unknownPlatform)).toBe(false)
+      expect(attachmentReadToolsFor([unknownPlatform])).toEqual([])
+      // A `Map`, not an object literal: `constructor` must not spread a function.
+      expect(platformLabel(unknownPlatform)).toBe(unknownPlatform)
+    }
+  })
+
+  it('labels the platforms whose errors name them', () => {
+    expect(platformLabel('slack')).toBe('Slack')
+    expect(platformLabel('telegram')).toBe('Telegram')
+  })
+})
+
+describe('the direct-message port', () => {
+  it('defaults a toUser send to the DM-capable platform, whatever the session is', () => {
+    // Exactly the `directMessage ? 'slack' : ctx.platform` literal it replaces:
+    // Slack is the only platform declaring the port, so every session resolves
+    // to it — including sessions on platforms that cannot DM at all.
+    expect(directMessagePlatformFor('slack')).toBe('slack')
+    expect(directMessagePlatformFor('telegram')).toBe('slack')
+    expect(directMessagePlatformFor('discord')).toBe('slack')
+    expect(directMessagePlatformFor('feishu')).toBe('slack')
+    expect(directMessagePlatformFor('webchat')).toBe('slack')
+  })
+
+  it('renders the capable platforms for the "not supported here" error', () => {
+    expect(directMessagePlatformList()).toBe('Slack')
+  })
+})
+
+describe('credentialed attachment tools', () => {
+  it('keeps the learned tool names — the mechanism generalized, the names did not', () => {
+    expect(attachmentReadToolsFor(['slack']).map((t) => t.name)).toEqual(['readSlackFile'])
+    expect(attachmentReadToolsFor(['telegram']).map((t) => t.name)).toEqual(['readTelegramFile'])
+  })
+
+  it('emits in registry order, not in the caller-supplied order', () => {
+    // An agent's tool list must not reshuffle because its integrations happened
+    // to be stored the other way round.
+    expect(attachmentReadToolsFor(['telegram', 'slack']).map((t) => t.name)).toEqual([
+      'readSlackFile',
+      'readTelegramFile'
+    ])
+    expect(attachmentReadToolsFor(['slack', 'telegram']).map((t) => t.name)).toEqual([
+      'readSlackFile',
+      'readTelegramFile'
+    ])
+  })
+
+  it('gives a platform that declares no tool nothing at all', () => {
+    // Discord's CDN links are fetchable without the bot credential and Feishu
+    // never grew a tool: both must stay toolless until their own module declares one.
+    expect(attachmentReadToolsFor(['discord', 'feishu'])).toEqual([])
+    expect(attachmentReadToolsFor([])).toEqual([])
+  })
+
+  it('lists every injectable name for the permission auto-allow set', () => {
+    expect(allAttachmentReadTools().map((t) => t.name)).toEqual(['readSlackFile', 'readTelegramFile'])
+  })
+
+  it('recognizes exactly the declared tool names at dispatch', () => {
+    expect(isAttachmentReadTool('readSlackFile')).toBe(true)
+    expect(isAttachmentReadTool('readTelegramFile')).toBe(true)
+    expect(isAttachmentReadTool('readDiscordFile')).toBe(false)
+    expect(isAttachmentReadTool('getCurrentChannel')).toBe(false)
+    expect(isAttachmentReadTool('')).toBe(false)
+  })
+
+  it('describes each tool with a JSON-Schema object input requiring `url`', () => {
+    for (const tool of allAttachmentReadTools()) {
+      expect(tool.inputSchema).toMatchObject({ type: 'object', additionalProperties: false, required: ['url'] })
+      expect(Object.keys(tool.inputSchema.properties as Record<string, unknown>)).toEqual(['url', 'mimeType'])
+      expect(tool.description).toContain('instead of curl/fetch')
+    }
+  })
+})

--- a/packages/daemon/test/turn-output-workflow.test.ts
+++ b/packages/daemon/test/turn-output-workflow.test.ts
@@ -72,6 +72,52 @@ function connect(daemon: Daemon, overrides: Record<string, unknown> = {}) {
 }
 
 describe('TurnOutputWorkflow', () => {
+  it('offers a final-fence provider snapshot only where the Layer-1 thread-history port exists', async () => {
+    // The gate is the read port (`getThreadReplies`), asked by name — not a
+    // `pending.platform !== 'slack'` test and not a `Partial<SlackConnection>`
+    // cast that only looks like one. A connection without the port contributes
+    // no provider snapshot and the fence falls back to daemon-observed rows.
+    const daemon = new Daemon({
+      root: scaffold(),
+      hostFactory: () =>
+        ({
+          start: vi.fn(async () => {}),
+          newSession: vi.fn(async () => 'acp-1'),
+          hasSession: vi.fn(() => true),
+          prompt: vi.fn(async () => ({ stopReason: 'end_turn' })),
+          cancel: vi.fn(async () => {}),
+          stop: vi.fn(async () => {})
+        }) as any
+    })
+    await daemon.start()
+    const pending = {
+      agentId: 'bot-a',
+      integrationId: 'int-a',
+      channel: 'C1',
+      statusThread: 'T1',
+      transcriptChannel: transcriptChannelKey('C1', undefined),
+      platform: 'slack'
+    }
+
+    connect(daemon)
+    expect((daemon as any).finalThreadSnapshot(pending)).toBeUndefined()
+
+    connect(daemon, { getThreadReplies: vi.fn(async () => []) })
+    expect(typeof (daemon as any).finalThreadSnapshot(pending)).toBe('function')
+
+    // Port presence, not platform identity: a NON-Slack pending whose connection
+    // answers the port still gets a snapshot, and a Slack one that doesn't, doesn't.
+    expect(typeof (daemon as any).finalThreadSnapshot({ ...pending, platform: 'telegram' })).toBe('function')
+    connect(daemon)
+    expect((daemon as any).finalThreadSnapshot({ ...pending, platform: 'telegram' })).toBeUndefined()
+
+    // No connection at all is the same fail-closed answer.
+    ;(daemon as any).connByIntegration.delete('int-a')
+    expect((daemon as any).finalThreadSnapshot(pending)).toBeUndefined()
+
+    await daemon.stop()
+  })
+
   it('discards a stale candidate, regenerates in the same ACP session, and publishes only the replacement', async () => {
     let onUpdate!: (sessionId: string, update: unknown) => void
     let releaseFirst!: () => void


### PR DESCRIPTION
Four Appendix-A rows, one seam. Same runtime behavior throughout — the platform
name stops being core knowledge.

## What

`platforms/contract.ts` already declares the OPTIONAL half of the connection
contract, and the audit calls the `typeof conn?.x === 'function'` probe over it
"the sanctioned Layer-1 read-port mechanism". What was missing is the other half
of the same question, asked where no connection exists yet: *does this PLATFORM
offer the port at all?* The MCP tool surface asked it three times and spelled
every answer as a platform name.

`platforms/read-ports.ts` now owns both asks, and they are deliberately **not one
ask**:

- `offersReadPort(bearer, port)` probes a LIVE bearer — a connection, the
  `MessageGateway` slice the MCP tools hold, a duck-typed test fake.
- the registry declares for a platform id BEFORE a connection is in hand.

Deciding tool injection by live probe instead would silently drop `readSlackFile`
from a session opened while the socket was reconnecting, so the pre-connection
declaration is load-bearing rather than a shortcut. Absence is the fail-closed
arm, exactly as with `messageOrderingFor`: an unregistered platform declares no
ports, which is what the old `else` of every branch did.

### Tool injection — `mcp/tools.ts:853/854`

`integrations.some(i => i.platform === 'slack'|'telegram')` becomes
`attachmentReadToolsFor(platforms)`. The two descriptors moved to
`platforms/slack/attachments.ts` and `platforms/telegram/attachments.ts`, so a
platform contributes its own tool by declaring the port and core no longer knows
either name exists. Emission walks the REGISTRY rather than the agent's
integration list, so an agent whose integrations happened to be stored the other
way round does not see its tool list reshuffle. `ALL_TOOL_NAMES` enumerates every
platform's tool the same way — the auto-allow set is about names, so a name a
platform can inject must be listed even for agents that will never see it. The
MCP dispatcher likewise stopped case-matching the two literal names and runs one
shared body for whatever is declared; the fetch itself is the Layer-1
`downloadFile` every connection already has.

**Tool names are frozen.** `readSlackFile` / `readTelegramFile` are what agents
have learned, what shared `resource_link`s point at, and what warm ACP sessions
already carry in their descriptor list. The injection mechanism generalized; the
names did not move.

### The `toUser` DM form — `mcp/ops.ts:842/848`

`directMessage ? 'slack' : ctx.platform` becomes
`directMessagePlatformFor(ctx.platform)`: the session's own platform when it can
open a DM, else the platform that can. With Slack the only declarer that is
bit-for-bit the old literal — including for a session on a platform that cannot
DM at all, which still resolves to Slack and still fails on the caller's own
"this agent has no slack integration" error, because gateway resolution runs
before the port gate.

`wantPlatform !== 'slack'` becomes `!offersDirectMessages(wantPlatform)`, gating
the whole `toUser` mode (the DM form and the channel-root `<@id>` mention form
alike, as before). The error keeps naming the capable platform — *"toUser is only
supported on Slack (not telegram) yet"* — which is why a declaration carries a
label instead of core carrying the literal. The narrower LIVE probe stays where
it was: a gateway that lacks the method still reports that this integration
cannot open direct messages.

### The final fence — `daemon.ts:8858`

Re-verified against current main: the gate had already collapsed to a duck-typed
probe, but reached it through a `Partial<SlackConnection>` cast — audit blind
spot 3, where the cast, not the test, is the coupling that blocks extraction. It
now asks `offersReadPort(conn, 'getThreadReplies')` and needs no Slack type at
all. `fetchThreadHistory`'s cast is left alone: it is the read BODY, not a gate,
and it needs the concrete attachment type to build the `[attached: …]` mention.

### One type note

`ReadPortBearer` is `object`, not `Partial<Record<ReadPort, unknown>>`. The
latter is a WEAK type, so TypeScript rejects exactly the connections that
implement no optional port (`TelegramConnection` "has no properties in common") —
the arm this probe exists to answer `false` for.

## Tests

- `test/platform-read-ports.test.ts` (new) — the probe (present / absent /
  missing bearer / present-but-not-callable), the fail-closed arm for
  unregistered ids including `constructor` and `toString`, the DM default for
  every session platform, the rendered capable-platform list, tool names and
  registry ordering, and the dispatcher's name recognition. One test pins the
  registry against the REAL connection classes: a declaration that drifts from
  its own adapter is the failure mode this seam introduces.
- `test/mcp-tools.test.ts` — the injection matrix for every combination of
  connected platforms: none, Slack, Telegram, both, both orders, two bots on one
  platform, and Discord/Feishu (connected, declare no such port ⇒ no tool, and
  they do not suppress the platforms that do).
- `test/mcp-ops.test.ts` — the DM path off Slack in both arms (DM and
  channel-mention) with the exact error text; the cross-platform default (a
  Telegram session that owns a Slack bot DMs through Slack); the
  missing-integration ordering; and the live-probe failure when the selected
  gateway cannot open a DM.
- `test/turn-output-workflow.test.ts` — the final-fence snapshot follows the PORT
  and not the platform: a non-Slack pending whose connection answers
  `getThreadReplies` gets a snapshot, a Slack pending whose connection does not
  gets none, and no connection at all is the same fail-closed answer.

`tsc --noEmit` and the daemon suite are green. `daemon-agent-mention-routing.test.ts`
timed out once under full-suite load (the known flake); it passes standalone —
31/31 — and is untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
