### PR TITLE
feat(github): clean worktrees after merge or issue close

### DIFF
--- a/packages/daemon/src/cp/relay-client.ts
+++ b/packages/daemon/src/cp/relay-client.ts
@@ -16,6 +16,7 @@ import {
   decodeRelayDaemonFrame,
   RD_HEADLESS_AGENT_DELIVERY_V1,
   RD_AGENT_IMPLICIT_ROUTING_V1,
+  RD_GITHUB_THREAD_WORKTREE_CLEANUP_V1,
   type RelayDaemonFrame,
   type RdHelloOk,
   type RdMsg,
@@ -39,7 +40,11 @@ const CLOSE_AUTH_FAILED = 4401
  * needs a capability the daemon did not list, rather than degrading it — so a
  * capability belongs here only once the corresponding behavior actually ships.
  */
-const DAEMON_RD_CAPABILITIES: readonly string[] = [RD_HEADLESS_AGENT_DELIVERY_V1, RD_AGENT_IMPLICIT_ROUTING_V1]
+const DAEMON_RD_CAPABILITIES: readonly string[] = [
+  RD_HEADLESS_AGENT_DELIVERY_V1,
+  RD_AGENT_IMPLICIT_ROUTING_V1,
+  RD_GITHUB_THREAD_WORKTREE_CLEANUP_V1
+]
 
 export type RelayClientState = 'CONNECTING' | 'HELLO' | 'READY' | 'CLOSED' | 'DEGRADED'
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -196,7 +196,8 @@ import {
   removeSessionWorktree,
   sessionWorktreePath,
   sessionWorktreeRoot,
-  type PrepareSessionWorkspaceRequest
+  type PrepareSessionWorkspaceRequest,
+  type SessionWorktreeRemoval
 } from './workspace/workspace-manager.js'
 import { ManagedSkillCache } from './skills/managed-skill-cache.js'
 import {
@@ -1059,6 +1060,23 @@ interface HookDispatchContext {
   reviewReportAttemptId?: string
   reviewReportResult?: HookReviewResult
 }
+
+type GithubThreadWorktreeCleanup = 'pull_request_merged' | 'issue_closed'
+
+/** Relay-authored lifecycle events that remove the isolated checkout without
+ * opening a model turn. Pair the normalized event with trusted subject metadata
+ * so an old or malformed frame cannot turn an ordinary hook into maintenance. */
+function githubThreadWorktreeCleanup(
+  hook: Pick<HookDispatchContext, 'event' | 'github'> | undefined
+): GithubThreadWorktreeCleanup | undefined {
+  if (hook?.event === 'pull_request:merged' && hook.github?.subjectKind === 'pull_request') {
+    return 'pull_request_merged'
+  }
+  if (hook?.event === 'issues:closed' && hook.github?.subjectKind === 'issue') return 'issue_closed'
+  return undefined
+}
+
+type SessionWorktreeCleanupResult = SessionWorktreeRemoval | { outcome: 'active' } | { outcome: 'not_applicable' }
 
 /** An ordinary comment is safe only when no formal attempt exists, or when the
  * latest/current attempt has a correlated, definite no-effect result. Any
@@ -9102,15 +9120,16 @@ export class Daemon {
    * the durable-inbox admission barrier; the model turn itself remains async.
    */
   private async dispatchRelayHook(msg: RdMsgHook): Promise<RdAck> {
+    const cleanup = githubThreadWorktreeCleanup(msg)
     if (!this.agents.has(msg.agentId)) {
       this.log.warn(`hook: no agent "${msg.agentId}" on this daemon — rejecting fire ${msg.msgId}`)
       return { msgId: msg.msgId, accepted: false, reason: 'no_agent' }
     }
-    if (this.paused(msg.agentId)) {
+    if (!cleanup && this.paused(msg.agentId)) {
       this.log.info(`hook: agent "${msg.agentId}" is paused — rejecting fire ${msg.msgId}`)
       return { msgId: msg.msgId, accepted: false, reason: 'paused' }
     }
-    if (this.safetyDrainingAgents.has(msg.agentId)) {
+    if (!cleanup && this.safetyDrainingAgents.has(msg.agentId)) {
       this.log.info(`hook: agent "${msg.agentId}" is stopping an interrupted turn — rejecting fire ${msg.msgId}`)
       return { msgId: msg.msgId, accepted: false, reason: 'busy' }
     }
@@ -9136,7 +9155,10 @@ export class Daemon {
    * without one the fire runs headless.
    */
   private async onHookFire(msg: RdMsgHook): Promise<{ accepted: boolean; reason?: string }> {
-    const nmsg = buildHookMessage(msg, randomUUID())
+    const cleanup = githubThreadWorktreeCleanup(msg)
+    // A lifecycle cleanup always addresses the stable GitHub thread session,
+    // never an optional IM anchor configured for ordinary hook output.
+    const nmsg = buildHookMessage(cleanup ? { ...msg, target: undefined } : msg, randomUUID())
     // The in-memory ACK cache closes same-process retransmits. This durable
     // probe closes the restart window *before* anchorTrigger posts externally:
     // a retained live row will replay, and a terminal row is already complete.
@@ -9154,6 +9176,23 @@ export class Daemon {
       ...(msg.event ? { event: msg.event } : {}),
       ...(snapshot ? { snapshot } : {}),
       ...(msg.github ? { github: msg.github } : {})
+    }
+    if (cleanup) {
+      const key = sessionKey(nmsg.platform, nmsg.channel, nmsg.thread ?? nmsg.msgId, msg.agentId, nmsg.transportScope)
+      const entry: QueueEntry = {
+        agentId: msg.agentId,
+        msg: nmsg,
+        initAbort: new AbortController(),
+        hookContext,
+        resolve: () => {},
+        reject: () => {}
+      }
+      // Keep the maintenance receipt outside the session's own inbox key so
+      // retention's active-session predicate does not mistake this cleanup
+      // obligation for a pending model turn.
+      const persistence = this.persistInbox(entry, `maintenance:${key}`, { required: true })
+      if (persistence !== 'existing') void this.completeGithubThreadWorktreeCleanup(hookContext, key, cleanup, entry)
+      return { accepted: true }
     }
     // P3 outbound: github fires on a NUMBERED thread publish their completed reply as
     // one comment (always on — design; push fires have no thread and stay silent).
@@ -9246,6 +9285,46 @@ export class Daemon {
       return { accepted: false, reason: admission.reason ?? 'durability' }
     }
     return { accepted: true }
+  }
+
+  private async completeGithubThreadWorktreeCleanup(
+    hook: HookDispatchContext,
+    key: string,
+    cleanup: GithubThreadWorktreeCleanup,
+    owner: HookCompletionOwner
+  ): Promise<void> {
+    try {
+      // A merge/close can race the last review turn. Let that exact dispatch
+      // settle before applying the same safety checks used by retention.
+      await this.activeDispatchDoneByKey.get(key)?.catch(() => undefined)
+      const rec = this.store.getSession(key)
+      if (!rec) {
+        this.log.info(`github lifecycle: ${cleanup} has no session worktree for ${key}`)
+        this.emitHookCompletion(hook, 'success', { reason: 'worktree_cleanup_no_session' }, owner)
+        return
+      }
+      const result = await this.cleanupSessionWorktree(rec)
+      if (result.outcome === 'failed') {
+        this.log.warn(`github lifecycle: ${cleanup} worktree cleanup failed for ${key} (${result.error})`)
+        this.emitHookCompletion(hook, 'failed', { reason: 'worktree_cleanup_failed' }, owner)
+        return
+      }
+      if (result.outcome === 'retained') {
+        this.log.info(`github lifecycle: ${cleanup} retained worktree for ${key} (${result.reason})`)
+        this.emitHookCompletion(hook, 'success', { reason: `worktree_cleanup_retained_${result.reason}` }, owner)
+        return
+      }
+      if (result.outcome === 'active') {
+        this.log.info(`github lifecycle: ${cleanup} deferred worktree cleanup for active session ${key}`)
+        this.emitHookCompletion(hook, 'success', { reason: 'worktree_cleanup_deferred_active' }, owner)
+        return
+      }
+      this.log.info(`github lifecycle: ${cleanup} worktree cleanup ${result.outcome} for ${key}`)
+      this.emitHookCompletion(hook, 'success', undefined, owner)
+    } catch (err) {
+      this.log.warn(`github lifecycle: ${cleanup} worktree cleanup failed for ${key} (${formatErr(err)})`)
+      this.emitHookCompletion(hook, 'failed', { reason: 'worktree_cleanup_failed' }, owner)
+    }
   }
 
   private githubFormalReviewEnabled(entry: QueueEntry): boolean {
@@ -16403,6 +16482,18 @@ export class Daemon {
     )
   }
 
+  /** The one safe per-session worktree deletion path shared by age retention
+   * and GitHub thread lifecycle cleanup. It deliberately preserves the current
+   * dirty/untracked and unique-commit protections in removeSessionWorktree(). */
+  private async cleanupSessionWorktree(rec: SessionRecord): Promise<SessionWorktreeCleanupResult> {
+    if (this.sessionRetentionActive(rec)) return { outcome: 'active' }
+    const agent = this.agents.get(rec.agentId)
+    if (!agent || agent.workspace.mode !== 'git-repo' || rec.workspaceIsolation === 'shared') {
+      return { outcome: 'not_applicable' }
+    }
+    return removeSessionWorktree(agent, rec.key)
+  }
+
   private async sweepSessionRetention(): Promise<void> {
     const windowMs = sessionRetentionMs(this.cfg.sessions.retention)
     if (windowMs === null) return
@@ -16423,30 +16514,24 @@ export class Daemon {
       let failed = 0
       for (const rec of expired) {
         if (this.draining) return
-        if (this.sessionRetentionActive(rec)) {
+        const res = await this.cleanupSessionWorktree(rec)
+        if (res.outcome === 'active') {
           active += 1
           continue
         }
-        const agent = this.agents.get(rec.agentId)
-        // Only a git-repo agent whose session pinned (or may have pinned — legacy
-        // NULL) Worktree isolation can own a worktree. A missing agent was removed
-        // together with its whole directory, worktrees included.
-        if (agent && agent.workspace.mode === 'git-repo' && rec.workspaceIsolation !== 'shared') {
-          const res = await removeSessionWorktree(agent, rec.key)
-          if (res.outcome === 'retained') {
-            retained += 1
-            this.log.info(
-              `retention: keeping session ${rec.key} — worktree has ${
-                res.reason === 'dirty' ? 'uncommitted/untracked changes' : 'commits not on any remote'
-              } (delete or push them to release it)`
-            )
-            continue
-          }
-          if (res.outcome === 'failed') {
-            failed += 1
-            this.log.warn(`retention: keeping session ${rec.key} — worktree cleanup failed (${res.error})`)
-            continue
-          }
+        if (res.outcome === 'retained') {
+          retained += 1
+          this.log.info(
+            `retention: keeping session ${rec.key} — worktree has ${
+              res.reason === 'dirty' ? 'uncommitted/untracked changes' : 'commits not on any remote'
+            } (delete or push them to release it)`
+          )
+          continue
+        }
+        if (res.outcome === 'failed') {
+          failed += 1
+          this.log.warn(`retention: keeping session ${rec.key} — worktree cleanup failed (${res.error})`)
+          continue
         }
         // Re-check synchronously after the git awaits: a message admitted mid-cleanup
         // owns the serial gate now, and deleting the row underneath its turn would
@@ -17238,6 +17323,7 @@ export class Daemon {
     }
     if (rows.length === 0) return
     let replayed = 0
+    let replayedMaintenance = 0
     const purgedPausedAgents = new Set<string>()
     const purgedLoopScopes = new Set<string>()
     for (const row of rows) {
@@ -17269,6 +17355,15 @@ export class Daemon {
         // completion target. Do not silently replay it as a generic turn.
         this.log.warn(`durable inbox: tombstoning legacy hook row ${row.id} without trusted context`)
         this.store.removeInbox(row.id)
+        continue
+      }
+      const cleanup = githubThreadWorktreeCleanup(hookContext)
+      if (hookContext && cleanup) {
+        const key = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, row.agentId, msg.transportScope)
+        const owner: HookCompletionOwner = { inboxId: row.id }
+        this.liveInboxIds.add(row.id)
+        void this.completeGithubThreadWorktreeCleanup(hookContext, key, cleanup, owner)
+        replayedMaintenance += 1
         continue
       }
       // A paused agent is an explicit operator stop, not a temporary startup
@@ -17336,6 +17431,9 @@ export class Daemon {
       replayed++
     }
     if (replayed) this.log.info(`durable inbox: replayed ${replayed} admitted message(s) through the serial gate`)
+    if (replayedMaintenance) {
+      this.log.info(`durable inbox: replayed ${replayedMaintenance} GitHub worktree cleanup(s)`)
+    }
   }
 
   /** Re-assert retained metadata-only hook completions whenever the CP socket

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2021,7 +2021,7 @@ export class Daemon {
   // Agent detach waits these leases before archiving/closing the last connection.
   private activeDispatchesByAgent = new Map<string, Set<Promise<void>>>()
   private activeDispatchDoneByKey = new Map<string, Promise<void>>()
-  private workspaceFileWrites = new Map<string, Promise<void>>()
+  private workspaceDispatchFences = new Map<string, Promise<void>>()
   /** Whole per-agent workspace-mutation tails. Preparation (managed-cache
    * resolution, clone/pull, immutable snapshots, skill reconciliation) and CP
    * editor/Dream/Git writes share this lane, so no two authorities mutate the
@@ -4647,11 +4647,11 @@ export class Daemon {
     }
   }
 
-  private async waitForWorkspaceFileWrites(agentId: string): Promise<void> {
+  private async waitForWorkspaceDispatchFence(agentId: string): Promise<void> {
     while (true) {
-      const write = this.workspaceFileWrites.get(agentId)
-      if (!write) return
-      await write
+      const fence = this.workspaceDispatchFences.get(agentId)
+      if (!fence) return
+      await fence
     }
   }
 
@@ -4670,9 +4670,9 @@ export class Daemon {
     await this.stopSelectedTurnHosts(selected)
     await this.stopHost(agentId)
     // A dispatch admitted before the drain may still be waiting for a workspace
-    // file-write lease. Release/join that lease first, then collect the dispatch
+    // workspace-mutation fence. Release/join that fence first, then collect the dispatch
     // it registers; reversing the order leaves a late active-dispatch join gap.
-    await this.waitForWorkspaceFileWrites(agentId)
+    await this.waitForWorkspaceDispatchFence(agentId)
     while (this.activeDispatchesByAgent.get(agentId)?.size) {
       await Promise.all([...this.activeDispatchesByAgent.get(agentId)!])
     }
@@ -11745,15 +11745,30 @@ export class Daemon {
   }
 
   private async admitActiveDispatch(agentId: string, key: string): Promise<() => void> {
-    while (this.workspaceFileWrites.has(agentId)) await this.workspaceFileWrites.get(agentId)
+    while (this.workspaceDispatchFences.has(agentId)) await this.workspaceDispatchFences.get(agentId)
     return this.beginActiveDispatch(agentId, key)
   }
 
-  private async withWorkspaceFileWrite<T>(agentId: string, write: () => Promise<T>): Promise<T> {
+  /** Publish a turn-admission fence synchronously, then serialize the mutation
+   * with every other operation that can prepare or rewrite this agent's roots. */
+  private withWorkspaceAdmissionFence<T>(agentId: string, operation: () => Promise<T>): Promise<T> {
+    const run = this.enqueueAgentWorkspaceMutation(agentId, operation)
+    const done = run.then(
+      () => undefined,
+      () => undefined
+    )
+    this.workspaceDispatchFences.set(agentId, done)
+    void done.then(() => {
+      if (this.workspaceDispatchFences.get(agentId) === done) this.workspaceDispatchFences.delete(agentId)
+    })
+    return run
+  }
+
+  private withWorkspaceFileWrite<T>(agentId: string, write: () => Promise<T>): Promise<T> {
     // Admission into the shared mutation tail is synchronous: a preparation or
     // second publication accepted in the next call stack can only run after this
     // complete stop+write operation, and vice versa.
-    const run = this.enqueueAgentWorkspaceMutation(agentId, async () => {
+    return this.withWorkspaceAdmissionFence(agentId, async () => {
       if (
         this.draining ||
         this.drainingAgents.has(agentId) ||
@@ -11766,15 +11781,6 @@ export class Daemon {
       await this.stopHost(agentId)
       return await write()
     })
-    const done = run.then(
-      () => undefined,
-      () => undefined
-    )
-    this.workspaceFileWrites.set(agentId, done)
-    void done.then(() => {
-      if (this.workspaceFileWrites.get(agentId) === done) this.workspaceFileWrites.delete(agentId)
-    })
-    return run
   }
 
   private holdReplyConnection(
@@ -15210,8 +15216,8 @@ export class Daemon {
   private async ensureHostAsync(agentId: string, opts: { allowAgentDrain?: boolean } = {}): Promise<AcpHost> {
     const assertStartAllowed = (): void => {
       if (this.draining) throw new Error(`host start blocked while daemon is draining (${agentId})`)
-      if (this.workspaceFileWrites.has(agentId)) {
-        throw new Error(`host start blocked while a workspace file is being written (${agentId})`)
+      if (this.workspaceDispatchFences.has(agentId)) {
+        throw new Error(`host start blocked while a workspace mutation is in progress (${agentId})`)
       }
       // Already-admitted work in another logical session may keep using the warm
       // host while a conversation-scoped interrupt drains. It may not allocate a
@@ -16491,7 +16497,26 @@ export class Daemon {
     if (!agent || agent.workspace.mode !== 'git-repo' || rec.workspaceIsolation === 'shared') {
       return { outcome: 'not_applicable' }
     }
-    return removeSessionWorktree(agent, rec.key)
+    return this.withWorkspaceAdmissionFence(rec.agentId, async () => {
+      // A turn may claim the session between the optimistic check above and this
+      // queued mutation boundary. In that case it owns the worktree, so defer.
+      if (this.sessionRetentionActive(rec)) return { outcome: 'active' }
+      const currentAgent = this.agents.get(rec.agentId)
+      if (!currentAgent || currentAgent.workspace.mode !== 'git-repo' || rec.workspaceIsolation === 'shared') {
+        return { outcome: 'not_applicable' }
+      }
+      const result = await removeSessionWorktree(currentAgent, rec.key)
+      if ((result.outcome === 'removed' || result.outcome === 'absent') && rec.acpSessionId) {
+        // The session row intentionally survives lifecycle cleanup. Evict only
+        // this stale warm binding so the next reopened/comment turn recreates
+        // the worktree and runs session/load/new before prompting in its cwd.
+        const current = this.store.getSession(rec.key)
+        if (current?.acpSessionId === rec.acpSessionId) {
+          this.hosts.get(rec.agentId)?.forgetSession(rec.acpSessionId)
+        }
+      }
+      return result
+    })
   }
 
   private async sweepSessionRetention(): Promise<void> {
@@ -19135,11 +19160,11 @@ export class Daemon {
     // hold this identity-tracked lease. The daemon-wide gate above rejects new
     // admissions; drain every already-admitted mutation before transport/store
     // teardown so none can outlive the authority that validated its root.
-    while (this.workspaceFileWrites.size > 0) {
-      await Promise.all([...this.workspaceFileWrites.values()])
+    while (this.workspaceDispatchFences.size > 0) {
+      await Promise.all([...this.workspaceDispatchFences.values()])
     }
     // A dispatch admitted before shutdown can be parked behind one of those
-    // writes and register its active lease only after drainForShutdown's first
+    // mutations and register its active lease only after drainForShutdown's first
     // snapshot. Rejoin until the identity-tracked sets are empty.
     while (this.activeDispatchesByAgent.size > 0) {
       await Promise.all([...this.activeDispatchesByAgent.values()].flatMap((active) => [...active]))

--- a/packages/daemon/test/cp/relay-client.test.ts
+++ b/packages/daemon/test/cp/relay-client.test.ts
@@ -3,6 +3,7 @@ import {
   buildRelayDaemonFrame,
   RD_HEADLESS_AGENT_DELIVERY_V1,
   RD_AGENT_IMPLICIT_ROUTING_V1,
+  RD_GITHUB_THREAD_WORKTREE_CLEANUP_V1,
   RELAY_DAEMON_SUBPROTOCOL,
   type RelayDaemonFrame,
   type RdMsgWebchat,
@@ -104,7 +105,7 @@ describe('RelayClient (daemon → one relay)', () => {
     expect(t.lastReq('rd/hello')!.payload).toEqual({
       apiKey: 'daemon-key',
       daemonId: DAEMON_ID,
-      capabilities: [RD_HEADLESS_AGENT_DELIVERY_V1, RD_AGENT_IMPLICIT_ROUTING_V1]
+      capabilities: [RD_HEADLESS_AGENT_DELIVERY_V1, RD_AGENT_IMPLICIT_ROUTING_V1, RD_GITHUB_THREAD_WORKTREE_CLEANUP_V1]
     })
     expect(client.state).toBe('READY')
     expect(client.isReady()).toBe(true)

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
@@ -27,6 +27,8 @@ import {
 } from '../src/messages/hook-message.js'
 import { GithubReplyCollector } from '../src/github/poster.js'
 import { transcriptCoords } from '../src/session/session-manager.js'
+import { sessionKey } from '../src/store/local-store.js'
+import { sessionWorktreePath } from '../src/workspace/workspace-manager.js'
 
 const AGENT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 const HOOK_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -1289,6 +1291,94 @@ describe('Daemon rd/msg hook fires', () => {
         truncated: false
       }
     })
+
+  it.each([
+    { event: 'pull_request:merged', subjectKind: 'pull_request' as const },
+    { event: 'issues:closed', subjectKind: 'issue' as const }
+  ])(
+    'removes the isolated worktree without starting a model turn on $event even while paused',
+    async ({ event, subjectKind }) => {
+      const root = scaffold()
+      const agentDir = join(root, 'agents', AGENT_ID)
+      const workspace = join(agentDir, 'workspace')
+      const agentConfigPath = join(agentDir, 'agent.json')
+      const config = JSON.parse(readFileSync(agentConfigPath, 'utf8')) as Record<string, unknown>
+      config.pause = true
+      config.workspace = {
+        mode: 'git-repo',
+        isolation: 'session',
+        path: workspace,
+        gitBranch: 'main',
+        pullOnNewSession: false
+      }
+      writeFileSync(agentConfigPath, JSON.stringify(config))
+      mkdirSync(workspace, { recursive: true })
+      execFileSync('git', ['init'], { cwd: workspace, stdio: 'ignore' })
+      execFileSync('git', ['config', 'user.name', 'AgentConnect Test'], { cwd: workspace })
+      execFileSync('git', ['config', 'user.email', 'test@example.invalid'], { cwd: workspace })
+      writeFileSync(join(workspace, 'README.md'), 'fixture\n')
+      execFileSync('git', ['add', 'README.md'], { cwd: workspace })
+      execFileSync('git', ['commit', '-m', 'fixture'], { cwd: workspace, stdio: 'ignore' })
+      execFileSync('git', ['update-ref', 'refs/remotes/origin/main', 'HEAD'], { cwd: workspace })
+
+      const { factory, host } = streamingHost()
+      const daemon = new Daemon({ root, hostFactory: factory })
+      await daemon.start()
+      const cp = fakeCpClient()
+      ;(daemon as never as { cpClient: unknown }).cpClient = cp
+      const agent = (daemon as any).agents.get(AGENT_ID)
+      const key = sessionKey('hook', 'acme/infra', '42', AGENT_ID, 'github:123')
+      const worktree = sessionWorktreePath(agent, key)
+      mkdirSync(join(agentDir, 'worktrees'), { recursive: true })
+      execFileSync('git', ['worktree', 'add', '--detach', worktree, 'HEAD'], { cwd: workspace, stdio: 'ignore' })
+      ;(daemon as any).store.upsertSession({
+        key,
+        agentId: AGENT_ID,
+        platform: 'hook',
+        channel: 'acme/infra',
+        thread: '42',
+        transportScope: 'github:123',
+        acpSessionId: 'acp-existing',
+        state: 'idle',
+        lastDeliveredTs: null,
+        updatedAt: Date.now(),
+        workspaceIsolation: 'session'
+      })
+
+      const ack = await (daemon as any).handleRelayMsg(
+        fire({
+          sessionKey: 'acme/infra#42',
+          event,
+          github: {
+            repoId: '123',
+            repoFullName: 'acme/infra',
+            sourceInstallationId: '456',
+            subjectKind,
+            ...(subjectKind === 'pull_request' ? { pullNumber: 42 } : {})
+          },
+          context: {
+            source: 'github',
+            event: subjectKind === 'pull_request' ? 'pull_request' : 'issues',
+            action: 'closed',
+            repo: 'acme/infra',
+            number: 42,
+            truncated: false
+          }
+        }),
+        () => {}
+      )
+
+      expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
+      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+      expect(cp.hookReports[0]).toMatchObject({ status: 'success', event })
+      expect(existsSync(worktree)).toBe(false)
+      expect((daemon as any).store.getSession(key)).toBeTruthy()
+      expect(host.newSession).not.toHaveBeenCalled()
+      expect(host.prompt).not.toHaveBeenCalled()
+      await daemon.stop()
+    },
+    15_000
+  )
 
   it('skips a GitHub deleted fire when the thread has no existing session — no session created, no turn', async () => {
     const { factory, host } = streamingHost()

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -74,6 +74,7 @@ function streamingHost() {
       return { stopReason: 'end_turn' }
     }),
     cancel: vi.fn(async () => {}),
+    forgetSession: vi.fn(),
     stop: vi.fn(async () => {})
   }
   const factory = (_agent: unknown, cb: (sid: string, u: unknown) => void) => {
@@ -1324,6 +1325,7 @@ describe('Daemon rd/msg hook fires', () => {
       const { factory, host } = streamingHost()
       const daemon = new Daemon({ root, hostFactory: factory })
       await daemon.start()
+      ;(daemon as any).hosts.set(AGENT_ID, host)
       const cp = fakeCpClient()
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
       const agent = (daemon as any).agents.get(AGENT_ID)
@@ -1344,6 +1346,16 @@ describe('Daemon rd/msg hook fires', () => {
         updatedAt: Date.now(),
         workspaceIsolation: 'session'
       })
+
+      let releaseWorkspaceMutation!: () => void
+      let markWorkspaceMutationStarted!: () => void
+      const workspaceMutationStarted = new Promise<void>((resolve) => (markWorkspaceMutationStarted = resolve))
+      const workspaceMutationRelease = new Promise<void>((resolve) => (releaseWorkspaceMutation = resolve))
+      const blockingMutation = (daemon as any).enqueueAgentWorkspaceMutation(AGENT_ID, async () => {
+        markWorkspaceMutationStarted()
+        await workspaceMutationRelease
+      })
+      await workspaceMutationStarted
 
       const ack = await (daemon as any).handleRelayMsg(
         fire({
@@ -1369,10 +1381,25 @@ describe('Daemon rd/msg hook fires', () => {
       )
 
       expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
+      await vi.waitFor(() => expect((daemon as any).workspaceDispatchFences.has(AGENT_ID)).toBe(true))
+      let admitted = false
+      const admission = (daemon as any).admitActiveDispatch(AGENT_ID, key).then((release: () => void) => {
+        admitted = true
+        return release
+      })
+      await Promise.resolve()
+      expect(admitted).toBe(false)
+      expect(existsSync(worktree)).toBe(true)
+
+      releaseWorkspaceMutation()
+      await blockingMutation
       await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+      const releaseDispatch = await admission
+      releaseDispatch()
       expect(cp.hookReports[0]).toMatchObject({ status: 'success', event })
       expect(existsSync(worktree)).toBe(false)
       expect((daemon as any).store.getSession(key)).toBeTruthy()
+      expect(host.forgetSession).toHaveBeenCalledWith('acp-existing')
       expect(host.newSession).not.toHaveBeenCalled()
       expect(host.prompt).not.toHaveBeenCalled()
       await daemon.stop()

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -470,7 +470,7 @@ describe('Daemon session lifecycle (#118)', () => {
     expect(laterPreparationEntered).toBe(true)
     await new Promise<void>((resolve) => setImmediate(resolve))
     expect((daemon as any).workspacePreparationTails.has('bot-a')).toBe(false)
-    expect((daemon as any).workspaceFileWrites.has('bot-a')).toBe(false)
+    expect((daemon as any).workspaceDispatchFences.has('bot-a')).toBe(false)
     await daemon.stop()
   }, 20_000)
 
@@ -1563,13 +1563,13 @@ describe('Daemon graceful shutdown drain (#109)', () => {
     await new Promise<void>((resolve) => setImmediate(resolve))
     expect(stopped).toBe(false)
     expect(close).not.toHaveBeenCalled()
-    expect((daemon as any).workspaceFileWrites.has('bot-a')).toBe(true)
+    expect((daemon as any).workspaceDispatchFences.has('bot-a')).toBe(true)
 
     releaseWrite()
     await writing
     await stopping
     expect(close).toHaveBeenCalledOnce()
-    expect((daemon as any).workspaceFileWrites.has('bot-a')).toBe(false)
+    expect((daemon as any).workspaceDispatchFences.has('bot-a')).toBe(false)
   }, 15_000)
 })
 

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -73,6 +73,17 @@ export const RD_HEADLESS_AGENT_DELIVERY_V1 = 'headless-agent-delivery-v1'
  */
 export const RD_AGENT_IMPLICIT_ROUTING_V1 = 'agent-implicit-routing-v1'
 
+/**
+ * `github-thread-worktree-cleanup-v1`: this daemon treats the relay-authored
+ * `pull_request:merged` and `issues:closed` hook events as maintenance only. It
+ * never opens a model turn and applies the existing safe retention deletion.
+ *
+ * A relay must not send those synthetic events to a daemon without this
+ * capability: an older daemon would otherwise interpret them as ordinary hook
+ * prompts during a mixed-version rollout.
+ */
+export const RD_GITHUB_THREAD_WORKTREE_CLEANUP_V1 = 'github-thread-worktree-cleanup-v1'
+
 // D→R REQ → rd/hello/ok. The daemon presents its EXISTING daemon API key; the
 // relay holds no database, so it delegates to the CP via `rc/verify` and caches
 // the verdict until this connection closes. Secret material — NEVER log.

--- a/packages/relay/src/hooks/github-ingress.test.ts
+++ b/packages/relay/src/hooks/github-ingress.test.ts
@@ -5,6 +5,7 @@ import { FakeClock } from '@agentconnect.md/connection'
 import {
   GITHUB_REQUEST_REVIEW_ACTION,
   HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED,
+  RD_GITHUB_THREAD_WORKTREE_CLEANUP_V1,
   type RcGithubCommentAuthz,
   type RcGithubInstallation,
   type RcGithubRerequest,
@@ -165,6 +166,7 @@ interface Harness {
   authzResult: boolean | ((request: RcGithubCommentAuthz) => boolean | Promise<boolean>)
   ack: RdAck | (() => Promise<RdAck>)
   offline: boolean
+  cleanupSupported: boolean
   onlineDaemons: Set<string>
 }
 
@@ -185,6 +187,7 @@ function makeHarness(authzCapacity = 20): Harness {
     rerequestResult: { allowed: false },
     ack: { msgId: 'x', accepted: true },
     offline: false,
+    cleanupSupported: true,
     onlineDaemons: new Set([DAEMON])
   }
   const app = Fastify()
@@ -195,6 +198,8 @@ function makeHarness(authzCapacity = 20): Harness {
       get: (daemonId: string) => {
         if (h.offline || !h.onlineDaemons.has(daemonId)) return undefined
         return {
+          supports: (capability: string) =>
+            capability !== RD_GITHUB_THREAD_WORKTREE_CLEANUP_V1 || h.cleanupSupported === true,
           sendMsg: async (msg: RdMsg) => {
             h.sent.push(msg)
             h.dispatches.push({ daemonId, msg })
@@ -1127,10 +1132,60 @@ describe('github ingress', () => {
       expect(h.sent).toHaveLength(1)
     })
 
-    it('silently ignores issue metadata edits and issue/PR close/reopen noise under family wildcards', async () => {
-      h.table.upsert(rule({}, { events: ['issues:*', 'pull_request:*'] }))
+    it('dispatches issue close and merged PR as workspace-cleanup lifecycle fires', async () => {
+      h.table.upsert(rule({}, { events: [] }))
+      const merged = pullPayload({ action: 'closed' })
+      ;(merged.pull_request as Record<string, unknown>).merged = true
+
+      expect(
+        (
+          await post('issues', issuesPayload({ action: 'closed' }), {
+            headers: { 'x-github-delivery': 'issue-closed' }
+          })
+        ).statusCode
+      ).toBe(202)
+      expect(
+        (
+          await post('pull_request', merged, {
+            headers: { 'x-github-delivery': 'pr-merged' }
+          })
+        ).statusCode
+      ).toBe(202)
+
+      await flush()
+      const hooks = h.sent.filter((msg) => msg.source === 'hook')
+      expect(hooks).toHaveLength(2)
+      expect(hooks[0]).toMatchObject({
+        sessionKey: 'acme/infra#42',
+        event: 'issues:closed',
+        github: { subjectKind: 'issue' },
+        context: { event: 'issues', action: 'closed' }
+      })
+      expect(hooks[1]).toMatchObject({
+        sessionKey: 'acme/infra#77',
+        event: 'pull_request:merged',
+        github: { subjectKind: 'pull_request', pullNumber: 77 },
+        context: { event: 'pull_request', action: 'closed' }
+      })
+      expect(h.authzRequests).toHaveLength(0)
+    })
+
+    it('does not send lifecycle cleanup to an older daemon that could start a model turn', async () => {
+      h.table.upsert(rule({}, { events: [] }))
+      h.cleanupSupported = false
 
       expect((await post('issues', issuesPayload({ action: 'closed' }))).statusCode).toBe(202)
+      await flush()
+
+      expect(h.sent).toHaveLength(0)
+      expect(h.reports).toContainEqual(
+        expect.objectContaining({ event: 'issues:closed', status: 'failed', reason: 'rejected:unsupported' })
+      )
+    })
+
+    it('silently ignores issue metadata edits/reopen and unmerged PR close/reopen noise', async () => {
+      h.table.upsert(rule({}, { events: ['issues:*', 'pull_request:*'] }))
+
       expect((await post('issues', issuesPayload({ action: 'reopened' }))).statusCode).toBe(202)
       expect(
         (await post('issues', issuesPayload({ action: 'edited', changes: { body: { from: 'old instructions' } } })))

--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -129,6 +129,7 @@ interface GithubSubject {
   head?: { sha?: string; repo?: { full_name?: string } | null }
   base?: { sha?: string; repo?: { full_name?: string } | null }
   merge_commit_sha?: string | null
+  merged?: boolean
   draft?: boolean
   /** Present on the `issue` object when an `issue_comment` belongs to a PR. */
   pull_request?: unknown
@@ -162,6 +163,17 @@ const EXTERNAL_PR_REVISION_EVENTS = new Set([
   'pull_request:ready_for_review',
   'pull_request:converted_to_draft'
 ])
+
+/** Lifecycle deliveries that close a GitHub thread's daemon-owned workspace.
+ * PR `closed` is cleanup only when GitHub also proves it was merged; an
+ * unmerged PR may still be reopened and keeps its session worktree. */
+function githubThreadWorktreeCleanupEvent(event: string, payload: GithubPayload): string | undefined {
+  if (event === 'issues' && payload.action === 'closed') return 'issues:closed'
+  if (event === 'pull_request' && payload.action === 'closed' && payload.pull_request?.merged === true) {
+    return 'pull_request:merged'
+  }
+  return undefined
+}
 
 /** A no-match failed a static rule gate; trusted is immediately dispatchable;
  *  needs-authz passed every static gate but needs live maintainer authorization. */
@@ -756,10 +768,11 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
       const thread = subject?.number !== undefined ? String(subject.number) : event === 'push' ? payload.ref : undefined
       if (rules.length === 0 || thread === undefined) return reply.code(202).send({ deliveryKey })
 
+      const cleanupEvent = githubThreadWorktreeCleanupEvent(event, payload)
       const ctx: GithubMatchCtx = {
         event,
         // Action-less events (push) stay bare — they only ever match `family:*`.
-        eventAction: payload.action ? `${event}:${payload.action}` : event,
+        eventAction: cleanupEvent ?? (payload.action ? `${event}:${payload.action}` : event),
         installationId: payload.installation?.id !== undefined ? String(payload.installation.id) : undefined,
         labels: (subject?.labels ?? []).map((l) => l.name ?? '').filter(Boolean),
         senderType: payload.sender?.type,
@@ -796,7 +809,7 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
         // Post-match per-hook budget: a drop is a skip + metadata log, never a 429
         // (GitHub treats non-2xx as a dead delivery) and never a run row (a storm
         // must not flood hook_run).
-        if (!deps.limiter.allow(rule.hookId)) {
+        if (!cleanupEvent && !deps.limiter.allow(rule.hookId)) {
           deps.log.info(`github ingress: rate-limited ${rule.hookId}:${deliveryKey} (${ctx.eventAction})`)
           return
         }
@@ -815,7 +828,7 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
           context,
           ...(rule.target ? { target: rule.target } : {})
         }
-        if (pullRequestNeedsMaintainer(ctx, prAuthorCanWrite)) {
+        if (!cleanupEvent && pullRequestNeedsMaintainer(ctx, prAuthorCanWrite)) {
           // No third-party-authored PR lifecycle payload reaches the daemon.
           // Revision events still create a durable, actionable informational
           // Check so a maintainer can request the first review explicitly.
@@ -835,6 +848,24 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
           msg
         )
         deps.log.info(`github ingress: queued ${rule.hookId}:${deliveryKey} (${ctx.eventAction} ${msg.sessionKey})`)
+      }
+
+      if (cleanupEvent) {
+        // Lifecycle cleanup is repository maintenance, not a model-trigger
+        // subscription. Fan it out to every currently assigned hook that the
+        // signed installation is allowed to address; the daemon no-ops when
+        // that hook never created a session for this thread.
+        for (const rule of rules) {
+          if (
+            rule.kind === 'github' &&
+            rule.github &&
+            ctx.installationId &&
+            rule.github.installationIds.includes(ctx.installationId)
+          ) {
+            dispatchRule(rule)
+          }
+        }
+        return reply.code(202).send({ deliveryKey })
       }
 
       const currentAuthorizedRule = (

--- a/packages/relay/src/hooks/ingress.ts
+++ b/packages/relay/src/hooks/ingress.ts
@@ -25,6 +25,7 @@ import type { Clock } from '@agentconnect.md/connection'
 import {
   HOOK_DELIVERY_REASON_DISPATCH_TIMEOUT,
   HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+  RD_GITHUB_THREAD_WORKTREE_CLEANUP_V1,
   type RcHookAssign,
   type RcRunReport,
   type RdMsgHook
@@ -54,6 +55,13 @@ export interface HookIngressDeps {
   limiter: HookRateLimiter
   clock: Clock
   log: Logger
+}
+
+function requiresGithubThreadWorktreeCleanup(msg: RdMsgHook): boolean {
+  return (
+    (msg.event === 'pull_request:merged' && msg.github?.subjectKind === 'pull_request') ||
+    (msg.event === 'issues:closed' && msg.github?.subjectKind === 'issue')
+  )
 }
 
 /** The relay-computed session-affinity key (design decision 7; webhook kind). */
@@ -173,6 +181,15 @@ export async function dispatchHookFire(
         }
         attemptIndex += 1
         deps.clock.setTimeout(attempt, HOOK_DISPATCH_RETRY_DELAYS_MS[attemptIndex]!)
+        return
+      }
+
+      // These event names are relay-authored maintenance commands. An older
+      // daemon would run them as model prompts, so fail closed until the target
+      // explicitly advertises maintenance-only handling.
+      if (requiresGithubThreadWorktreeCleanup(dispatchMsg) && !conn.supports(RD_GITHUB_THREAD_WORKTREE_CLEANUP_V1)) {
+        deps.report({ ...base, status: 'failed', reason: 'rejected:unsupported' })
+        resolve()
         return
       }
 


### PR DESCRIPTION
## Summary

- forward signed GitHub issue-close and merged-PR lifecycle deliveries to each matching daemon as maintenance-only hook events
- remove the session worktree through the exact deletion path shared with session retention, preserving active-session, dirty/untracked-file, and unique-commit safeguards
- keep session metadata/transcripts intact and avoid starting an ACP/model turn, including while the agent is paused
- advertise and require a relay capability so a mixed-version relay never sends maintenance events to an older daemon that could interpret them as prompts

## Why

Per-session worktrees can remain until age-based retention even after their GitHub thread is terminal. Dependency trees make those dormant checkouts expensive on long-lived review agents. A merged pull request or closed issue is an authoritative point to attempt the same safe cleanup immediately.

## Validation

- `pnpm --filter @agentconnect.md/protocol typecheck`
- `pnpm --filter @agentconnect.md/relay typecheck`
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec eslint .` (pre-push hook)
- protocol relay/daemon frame tests: 29 passed
- GitHub ingress tests: 92 passed
- relay-client tests: 7 passed
- focused daemon lifecycle cleanup tests: 2 passed
- session retention GC tests: 7 passed
- worktree removal safety tests: 9 passed

Created by Codex . GPT-5.6 Sol
