### PR TITLE
fix(daemon): keep Control Plane agent config in memory

### DIFF
--- a/docs/designs/daemon-centric-architecture.md
+++ b/docs/designs/daemon-centric-architecture.md
@@ -265,9 +265,9 @@ host to run sandboxed.
   credentials through the configured `SecretCipher`; the stored representation
   depends on the runtime-configured cipher. It sends assigned values to
   daemons or relays through `integration/*` control frames over encrypted
-  transport. A daemon persists assigned integration configuration in its local,
-  secret-bearing `agent.json` so established integrations can recover while the
-  Control Plane is unavailable. Credential values must never be logged. The
+  transport. A daemon holds assigned integration configuration in memory and
+  re-converges it after reconnect; CP credentials are never written to
+  `agent.json`. Credential values must never be logged. The
   protocol separately reserves lease-based `secrets/*` frames for
   secret-manager references.
 - **Least privilege**: a daemon receives credentials only for the workspaces and platforms for which it is responsible.

--- a/docs/designs/daemon-centric-detailed-design.md
+++ b/docs/designs/daemon-centric-detailed-design.md
@@ -194,9 +194,9 @@ over stdio; they do not create source-level coupling to TypeScript.
 
 ### D5. Local Scheduler
 
-- **Responsibilities**: trigger cron/loop **locally**, ensuring scheduled jobs run during a Control Plane outage instead of losing remote triggers while the daemon is offline. A cron schedule uses its trigger text to invoke a **specific agent**. The Web UI configures the definition, C3 delivers it to the owning daemon selected by `agentId`, and the daemon writes it into that agent's `agent.json.crons[]` (the single source of truth, matching the integrations model). At the scheduled time, if `target.channel` exists, the local scheduler first posts the trigger as a real channel message and attaches the agent session to the resulting thread for replies. Without a target, it runs headlessly.
+- **Responsibilities**: trigger cron/loop **locally**. A cron schedule uses its trigger text to invoke a **specific agent**. The Web UI configures the definition, C3 delivers it to the owning daemon selected by `agentId`, and the daemon keeps the CP-owned definition in memory alongside any hand-authored local crons. At the scheduled time, if `target.channel` exists, the local scheduler first posts the trigger as a real channel message and attaches the agent session to the resulting thread for replies. Without a target, it runs headlessly. An already-running daemon retains this state during a CP outage; after daemon restart the CP roster must re-converge it.
 - **Language/dependencies**: TypeScript; **`croner`** (pure JavaScript, dependency-free, supports time zones, and preferable to the aging `node-cron`); persist `last-run` in D11 for deduplication and catch-up.
-- **Key interfaces**: input: C3 sends `cron/upsert` and `cron/remove` (§6.1), which update `agent.json`; output: construct a `NormalizedMessage{ source: "cron" }` and dispatch it directly to the agent; reporting: execution results through D12.
+- **Key interfaces**: input: C3 sends `cron/upsert` and `cron/remove` (§6.1), which update the memory-only CP cron registry; output: construct a `NormalizedMessage{ source: "cron" }` and dispatch it directly to the agent; reporting: execution results through D12.
 
 ### D6. ACP Host (Local ACP Client)
 

--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -377,7 +377,10 @@ const CronUpsert = z.object({
 const CronRemove = z.object({ cronId: z.string().uuid() })
 ```
 
-On receipt the daemon persists the def into the owning agent's `agent.json` `crons[]` (marked `origin:"cp"`; the single source of truth, same model as integrations §5.6) — so crons survive a daemon restart with the CP down and the local Scheduler (D5) re-registers them from disk alone. `register/ok.crons[]` re-converges the CP-owned set on reconnect; `drop.crons[]` prunes stale ones.
+On receipt the daemon keeps the definition in its in-memory CP cron registry and
+reconciles the local Scheduler (D5). `register/ok.crons[]` re-converges the set
+after reconnect or daemon restart; `drop.crons[]` prunes stale entries. No CP cron
+definition is written to `agent.json`.
 
 On fire — **no CP round-trip**:
 
@@ -754,7 +757,7 @@ const AgentStop = z.object({ agentId: z.string().uuid(), launchId: z.string().uu
 
 ### 8.2a Live agent CRUD: `agent/upsert` · `agent/remove` (C→D, EVT)
 
-The console edited an agent's spec; the CP pushes it. `agent/upsert` carries the full new spec; `agent/remove` tears the agent down. The CP remains source of truth (REST C2) — these mirror the persisted spec onto the running daemon.
+The console edited an agent's spec; the CP pushes it. `agent/upsert` carries the full new spec; `agent/remove` tears the agent down. The CP remains source of truth (REST C2); the daemon applies the spec in memory and deletes only a same-id local `agent.json`. Other local agent files remain user-owned.
 
 ```ts
 const AgentUpsert = z.object({ agentId: z.string().uuid(), spec: AgentSpec }) // C→D, ControlExt(epoch,agentId)

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -177,7 +177,7 @@ This chapter, section 4 agents, and section 5 Reconciler form one theme:
 - CP agent specs, integrations, and crons are a separate **memory-only** desired-state source, re-converged by `register/ok` after each connection. Receiving a CP agent deletes only a same-id `agent.json`; every other local file remains untouched.
 - An already-running daemon continues using its in-memory CP state while disconnected. After a daemon restart, CP-managed agents resume only after the CP roster reconnects; local agents remain independently bootable from disk.
 
-The daemon persists only a secret-free `.cp-agent-id` data-root marker for CP agents, so workspace and memory directories can be reused without persisting CP configuration or credentials.
+The daemon persists only a secret-free `.cp-agent-id` marker in a dedicated child data root for CP agents, so workspace and memory directories can be reused without persisting CP configuration or credentials. Marker-only roots discovered after restart are reported as CP-owned replicas but are not activated; this lets the next roster reconciliation remove stale roots without reviving an agent whose in-memory spec was lost.
 
 ```
         +------------- Control Plane -------------+

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -114,7 +114,7 @@ The daemon does not implement these, but interacts with them through the section
 | `agentconnect status`               | Print service state (installed / running / PID / log path) and runtime state (CP connection, platform connections, active agents/sessions, degradation flag). Works even when no service is installed.                                                                                                                                                                                                                                                                                                          |
 | `agentconnect install-service`      | Generate/install a launchd plist or systemd unit and run `daemon-reload`; **do not start automatically**. Print the `agentconnect up` hint.                                                                                                                                                                                                                                                                                                                                                                     |
 | `agentconnect uninstall-service`    | Run `down`, then remove the unit file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `agentconnect agent list`           | **Read-only:** list agents found under `--agents-dir`, including id, status, runtime, name, and directory. CP or manual `agent.json` editing owns business configuration; daemon only converges disk state, so CLI has no local create/update/delete operations.                                                                                                                                                                                                                                                |
+| `agentconnect agent list`           | **Read-only:** list user-authored agents found under `--agents-dir`, including id, status, runtime, name, and directory. CP agents are memory-only and therefore are not part of this local-file listing.                                                                                                                                                                                                                                                                                                       |
 | `agentconnect login`                | **Interactive CP onboarding:** prompt/read CP URL + token, then probe auth through `probeAuth`, which sends only `auth`, never `register`. On failure, show the reason and allow one token retry; a second failure exits 1. **Persist credentials only after success.** Ask whether to install as a background service: yes -> `install-service` + `up` and exit; no -> foreground `run` until Ctrl-C. Non-TTY falls back to flags, still probes/persists and skips prompts; there is no separate `--no-input`. |
 | `agentconnect chat [message]`       | **Connect locally to one agent:** recursively discover agents under `--agents-dir`; use the only agent automatically, or require `--agent <name>` when several exist. Resolve its runtime, including registry defaults, launch the local ACP adapter, and converse over ACP. With `message`, send once, stream the reply, and exit; without it, enter a REPL. Do **not** start Slack, scheduler, store, CP, or the rest of daemon.                                                                              |
 
@@ -160,7 +160,7 @@ isInstalled()   Whether the unit file exists.
 - **Linux (systemd `--user`):** `~/.config/systemd/user/agentconnect.service`, with `[Service] ExecStart=execPath cliEntry run`, `Restart=always`, `Environment=AGENTCONNECT_ROOT=<root>`, and `[Install] WantedBy=default.target`. Run `systemctl --user daemon-reload` after writing. `up = enable --now`; `down = disable --now`; status uses `is-active`, `is-enabled`, and `show -p MainPID`.
 - **Service environment (login-shell launch):** service managers give user units a minimal `PATH` and never source shell profiles, so without repair npx-distributed ACP runtimes probe as "not installed". The unit therefore runs the **CLI run shell** (`ExecStart=<node> <cli-entry> run`), which in service mode launches the daemon through the user's interactive login shell (`$SHELL -l -i -c 'exec "$0" "$@"' …`, `packages/cli/src/service-spawn.ts` + `shell-exec.ts`) — the daemon inherits a fresh terminal-equivalent environment and tracks profile edits at every restart. Readiness is verified via `<root>/daemon.lock` (pid preserved by `exec`); a hanging or broken profile is killed at a deadline and the run shell falls back to direct spawns. Two static floors back this up: an install-time `PATH` snapshot baked into the unit (`InstallOpts.envPath`) and the daemon prepending `dirname(process.execPath)` on startup (`packages/daemon/src/runtimes/exec-path.ts`, covers legacy direct-ExecStart units). See cli-daemon-split.md §4.2 for the full contract.
 - **Testability:** Pure builders `buildPlist` / `buildSystemdUnit` generate unit contents for direct assertions. Every `launchctl` / `systemctl` call uses an injectable `exec(cmd,args)` dependency, replaced by test stubs with no real side effects.
-- **Credentials:** Unit files include only nonsensitive `AGENTCONNECT_ROOT`, and only when nondefault. The opaque CP API key and platform tokens currently live directly in `config.json` / `agent.json`, never the plist/unit. The key has no prefix and cannot be redacted by a content pattern; logs, telemetry, and error frames must structurally redact values of `--api-key`, `apiKey`, and `Bearer ...` before leaving the edge.
+- **Credentials:** Unit files include only nonsensitive `AGENTCONNECT_ROOT`, and only when nondefault. The opaque CP API key lives in `config.json`; hand-authored local integrations may carry platform tokens in `agent.json`, while CP-delivered tokens remain memory-only. None belongs in the plist/unit. The key has no prefix and cannot be redacted by a content pattern; logs, telemetry, and error frames must structurally redact values of `--api-key`, `apiKey`, and `Bearer ...` before leaving the edge.
 - The `run` process handles `SIGTERM` / `SIGINT`: stop accepting new messages, drain active turns to a deadline, close platform connections, close ACP adapter children, then exit.
 
 > The service-install branch of `login` invokes this controller. After successful auth probing and persistence, yes -> `install()` + `up()` and exit; no -> start foreground `run` using the same Daemon construction and signal handling.
@@ -169,15 +169,15 @@ isInstalled()   Whether the unit file exists.
 
 ## 3. Configuration File: `~/.agentconnect/config.json`
 
-### 3.1 Core Principle: Configuration Files Are Desired State
+### 3.1 Core Principle: Local Files and CP Memory Are Separate Desired-State Sources
 
 This chapter, section 4 agents, and section 5 Reconciler form one theme:
 
-- `~/.agentconnect/config.json` + `~/.agentconnect/agents/**` are the daemon's **single source of truth for desired state**: agents, platform connections, and channel bindings are written to disk.
-- **Control Plane is not another source of truth; it is the remote editor + orchestrator for these files.** CP sends changes over the control WebSocket, daemon persists them, and Reconciler converges disk desired state into process actual state.
-- Therefore, **the last desired state remains complete when CP is offline**, and daemon continues running it. After reconnect, CP resumes editing and orchestration.
+- Hand-authored `~/.agentconnect/config.json` and `agents/**/agent.json` files are the local desired-state source and remain user-owned.
+- CP agent specs, integrations, and crons are a separate **memory-only** desired-state source, re-converged by `register/ok` after each connection. Receiving a CP agent deletes only a same-id `agent.json`; every other local file remains untouched.
+- An already-running daemon continues using its in-memory CP state while disconnected. After a daemon restart, CP-managed agents resume only after the CP roster reconnects; local agents remain independently bootable from disk.
 
-This directly satisfies the requirement that CP can modify agent configuration while a disconnected daemon continues using existing configuration: **CP edits these persistent files, and they remain present.**
+The daemon persists only a secret-free `.cp-agent-id` data-root marker for CP agents, so workspace and memory directories can be reused without persisting CP configuration or credentials.
 
 ```
         +------------- Control Plane -------------+
@@ -186,10 +186,10 @@ This directly satisfies the requirement that CP can modify agent configuration w
                    control WS | agent/upsert, integration/upsert, route/assign, ...
                               v
    +---------------- Daemon (local) ----------------+
-   | CP-Client ----persist----> ~/.agentconnect/** desired |
-   |                                  | watch/change        |
-   |                                  v                     |
-   | Reconciler -- diff desired/actual --> converge          |
+   | CP-Client ----memory-----> CP desired-state registries  |
+   | local files ----watch----> local desired-state snapshot |
+   |                                  |                     |
+   | Reconciler -- merge/diff desired/actual --> converge    |
    |   |- ConnectionManager (platform connections)           |
    |   |- AgentManager (ACP adapter child processes)          |
    |   `- Scheduler (cron/loop)                               |
@@ -511,7 +511,7 @@ Workspace preparation is implemented by `packages/daemon/src/workspace/workspace
 
 ### 4.4 Agent Environment / Secrets: CP Configuration + Child-Process Injection
 
-Ordinary environment variables and write-only secrets are configured only through Console / CP `AgentSpec.env` and `AgentSpec.secrets`. Daemon persists them under `agent.json.runtimeOverrides.{env,secrets}`, and `agentChildEnv()` merges/injects them when starting an ACP child.
+Ordinary environment variables and write-only secrets can be configured through Console / CP `AgentSpec.env` and `AgentSpec.secrets`. The daemon keeps CP values in memory and `agentChildEnv()` merges/injects them when starting an ACP child; it never writes those values to `agent.json`.
 
 - Secret wins over ordinary env with the same name; daemon security/runtime injection remains higher priority.
 - Env/secrets changes affect host spawn. Reconcile evicts the old host so the next start uses the new values.
@@ -524,21 +524,21 @@ Ordinary environment variables and write-only secrets are configured only throug
 
 This implements requirement 4 using section 3.1 configuration-as-desired-state.
 
-### 5.1 CP Changes Agent Configuration by Changing Files
+### 5.1 CP Configuration Is Applied in Memory
 
-CP orchestration/configuration frames are persisted atomically under `~/.agentconnect/**` by CP-Client:
+CP agent, integration, and cron frames are applied to memory-only registries by CP-Client. Other control-plane state retains the persistence policy listed below:
 
-| CP delivery                                      | Daemon persistence action                                                                                        |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `agent/upsert{ agentId, spec }` / `agent/remove` | Write/create/delete `agents/<id>/agent.json`; `CpAgentRegistry` uses disk as truth, with no in-memory duplicate. |
-| `integration/upsert` / `integration/remove`      | Mutate owning `agent.json.integrations[]` through `CpIntegrationRegistry`, marked `origin:"cp"`.                 |
-| `register/ok` roster snapshot                    | Fully **converge** agents/integrations/crons/assignments to disk/local cache; explicit `drop.*` removes entries. |
-| `agent/stop{ agentId }`                          | Set `status:"inactive"` while keeping directory.                                                                 |
-| `route/assign` / `route/update`                  | Update local route table persisted in `state/local.sqlite`.                                                      |
-| `cron/upsert` / `cron/remove`                    | Mutate `agent.json.crons[]`.                                                                                     |
-| `config/push{ keys }` EVT                        | Apply allowlisted runtime knobs **in memory**, without persistence; see note below.                              |
+| CP delivery                                      | Daemon persistence action                                                                    |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `agent/upsert{ agentId, spec }` / `agent/remove` | Upsert/remove the in-memory CP agent; delete only a same-id local `agent.json`.              |
+| `integration/upsert` / `integration/remove`      | Upsert/remove the in-memory CP integration overlay.                                          |
+| `register/ok` roster snapshot                    | Fully **converge** memory-only agents/integrations/crons; explicit `drop.*` removes entries. |
+| `agent/stop{ agentId }`                          | Set `status:"inactive"` while keeping directory.                                             |
+| `route/assign` / `route/update`                  | Update local route table persisted in `state/local.sqlite`.                                  |
+| `cron/upsert` / `cron/remove`                    | Upsert/remove the in-memory CP cron overlay.                                                 |
+| `config/push{ keys }` EVT                        | Apply allowlisted runtime knobs **in memory**, without persistence; see note below.          |
 
-REQ commands such as `agent/upsert`, `agent/stop`, `cron/upsert`, `cron/remove`, and `route/assign` receive `ack{ refId, ok }` after persistence/convergence.
+REQ commands such as `agent/upsert`, `agent/stop`, `cron/upsert`, `cron/remove`, and `route/assign` receive `ack{ refId, ok }` after application/convergence.
 
 `config/push` has only `{ keys }` as an EVT with **no reply**. It merges
 allowlisted nonsensitive keys (`logging.level`, `limits.maxAgents`,
@@ -554,7 +554,7 @@ state is delivered through the dedicated upsert frames and the authoritative
 Changes from **CP**, an **agentconnect agent command**, or **manual file edits** all use one reconciler, driven by `chokidar` on `agents/**` plus explicit triggers:
 
 ```
-desired = read(config.json + every agent.json with status=active)
+desired = merge(local active agent.json files, CP agents/integrations/crons in memory)
 actual  = live platform connections / ACP adapters / registered crons
 plan    = diff(desired, actual)
 apply(plan):
@@ -1052,24 +1052,24 @@ Metrics and traces use the direct **OTLP side path** bootstrapped by `OTEL_*`,
 not the Control Plane WebSocket. Only `usage/report` and `facts/*` use the
 control channel.
 
-**Downstream, CP -> daemon:** Most persist then reconcile, except in-memory `config/push` and CP-route `route/*`.
+**Downstream, CP -> daemon:** Agent specs, integrations, crons, and `config/push` stay in memory; routes and the other explicitly durable control state follow their per-frame policies below.
 
-| Type                                        | Payload highlights                                                                                                                              | Daemon action                                                                                                                                                     |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `config/push` EVT                           | `{ keys }` only                                                                                                                                 | Merge allowlisted `logging.level`, `limits.*` into memory immediately; no disk/reply; ignore+log others.                                                          |
-| `webchat/mcp-grant/issued`                  | `{ grantId, authorityGeneration, descriptorInstanceId, grantRevision, token, expiresAt }`                                                       | CAS-stage only a newer persisted `(authorityGeneration, grantRevision)` fence; revision never resets across generations and raw token remains memory-only.        |
-| `webchat/mcp-grant/activate`                | Same exact grant/revision tuple as the accepted request                                                                                         | CAS-install only the activated full fence into the exact runtime session descriptor.                                                                              |
-| `agent/upsert` / `agent/remove`             | `{ agentId, spec }` / `{ agentId }`                                                                                                             | Write/delete `agents/<id>/agent.json`; hot reload.                                                                                                                |
-| `agent/launch`                              | `{ agentId, runtime, workspaceId, capabilities, spec, mode }` with launchId fence                                                               | CP-started agent; reply `agent/launched`.                                                                                                                         |
-| `agent/detach` / `agent/activate`           | `{ agentId, moveId, ... }`                                                                                                                      | Safe cold move: quiesce+archive local root / atomically apply authoritative bundle and resume.                                                                    |
-| `agent/stop`                                | `{ agentId }`                                                                                                                                   | Set inactive + drain.                                                                                                                                             |
-| `integration/upsert` / `integration/remove` | `{ integrationId, ... }`                                                                                                                        | Mutate owning `agent.json.integrations[]`.                                                                                                                        |
-| `route/assign`                              | `{ sessionKey:{platform,channel,thread}, agentId, bindRules }`                                                                                  | Persist CP assignment and return `route/assign/ack`.                                                                                                              |
-| `route/update`                              | `{ routingEpoch, rules:[...] }`                                                                                                                 | Replace CP global rules when epoch is current; EVT.                                                                                                               |
-| `register/ok` REP snapshot                  | `{ routingEpoch, agents[], integrations[], crons[], assignments[], leases[], mcpServers[], memoryConnections[], relays[], collabRoutes, drop }` | Authoritative full convergence: persist agents/integrations; upsert CP-origin crons and prune `drop.*`; converge assignments; persist/redial relays; adopt epoch. |
-| `cron/upsert` / `cron/remove`               | `{ cronId, agentId, schedule, target?, trigger, enabled }`                                                                                      | Mutate owning `agent.json.crons[]`, marked CP origin; Reconciler re-registers. On fire, post target anchor + thread reply, or execute headless.                   |
-| `daemon/drain`                              | `{ scope:{kind:"agent"\|"daemon"\|"session",...}, deadline }`                                                                                   | Graceful drain for scaling/rebalance; `drain/progress`, then `drain/done`.                                                                                        |
-| `daemon/restart` / `daemon/upgrade`         | `{ reason, drainFirst }` / `{ targetVersion, drainFirst }`                                                                                      | Fleet control: drain then exit for supervisor restart/upgrade.                                                                                                    |
+| Type                                        | Payload highlights                                                                                                                              | Daemon action                                                                                                                                              |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config/push` EVT                           | `{ keys }` only                                                                                                                                 | Merge allowlisted `logging.level`, `limits.*` into memory immediately; no disk/reply; ignore+log others.                                                   |
+| `webchat/mcp-grant/issued`                  | `{ grantId, authorityGeneration, descriptorInstanceId, grantRevision, token, expiresAt }`                                                       | CAS-stage only a newer persisted `(authorityGeneration, grantRevision)` fence; revision never resets across generations and raw token remains memory-only. |
+| `webchat/mcp-grant/activate`                | Same exact grant/revision tuple as the accepted request                                                                                         | CAS-install only the activated full fence into the exact runtime session descriptor.                                                                       |
+| `agent/upsert` / `agent/remove`             | `{ agentId, spec }` / `{ agentId }`                                                                                                             | Update the in-memory CP registry; delete only a same-id `agent.json`; hot reconcile.                                                                       |
+| `agent/launch`                              | `{ agentId, runtime, workspaceId, capabilities, spec, mode }` with launchId fence                                                               | CP-started agent; reply `agent/launched`.                                                                                                                  |
+| `agent/detach` / `agent/activate`           | `{ agentId, moveId, ... }`                                                                                                                      | Safe cold move: quiesce+archive local root / atomically apply authoritative bundle and resume.                                                             |
+| `agent/stop`                                | `{ agentId }`                                                                                                                                   | Set inactive + drain.                                                                                                                                      |
+| `integration/upsert` / `integration/remove` | `{ integrationId, ... }`                                                                                                                        | Update the in-memory CP integration overlay.                                                                                                               |
+| `route/assign`                              | `{ sessionKey:{platform,channel,thread}, agentId, bindRules }`                                                                                  | Persist CP assignment and return `route/assign/ack`.                                                                                                       |
+| `route/update`                              | `{ routingEpoch, rules:[...] }`                                                                                                                 | Replace CP global rules when epoch is current; EVT.                                                                                                        |
+| `register/ok` REP snapshot                  | `{ routingEpoch, agents[], integrations[], crons[], assignments[], leases[], mcpServers[], memoryConnections[], relays[], collabRoutes, drop }` | Authoritative full convergence of memory-only CP agent state; converge assignments, persist/redial relays, and adopt epoch.                                |
+| `cron/upsert` / `cron/remove`               | `{ cronId, agentId, schedule, target?, trigger, enabled }`                                                                                      | Update the in-memory CP cron overlay; Reconciler re-registers. On fire, post target anchor + thread reply, or execute headless.                            |
+| `daemon/drain`                              | `{ scope:{kind:"agent"\|"daemon"\|"session",...}, deadline }`                                                                                   | Graceful drain for scaling/rebalance; `drain/progress`, then `drain/done`.                                                                                 |
+| `daemon/restart` / `daemon/upgrade`         | `{ reason, drainFirst }` / `{ targetVersion, drainFirst }`                                                                                      | Fleet control: drain then exit for supervisor restart/upgrade.                                                                                             |
 
 ### 10.3 Register Payload (`RegisterReq`)
 

--- a/docs/designs/organization-secrets-and-variables.md
+++ b/docs/designs/organization-secrets-and-variables.md
@@ -29,9 +29,9 @@ configuration revision is added beside those maps so a daemon cannot apply
 resolved snapshots out of order.
 
 The feature is configuration distribution, not a new secret lease system. The
-Control Plane remains off the message hot path, and the daemon continues to
-start agents entirely from its locally persisted `agent.json` after receiving
-the resolved spec.
+Control Plane remains off the message hot path. The daemon holds resolved CP
+agent specs in memory and re-converges them after restart; resolved environment
+and secret values are not persisted to `agent.json`.
 
 ## 2. Terminology and non-goals
 
@@ -515,8 +515,8 @@ configRevision: z.string()
 ```
 
 The CP includes it in `agent/upsert`, `register/ok` roster entries, and
-`agent/activate`. The daemon persists the greatest applied revision and a digest
-of that revision's CP-owned spec beside `agent.json`:
+`agent/activate`. The daemon tracks the greatest applied revision and a digest
+of that revision's CP-owned spec in its in-memory registry:
 
 - a greater revision is applied normally;
 - an equal revision with the same digest is an idempotent retry;
@@ -526,9 +526,9 @@ of that revision's CP-owned spec beside `agent.json`:
   `writeAgentSpec`.
 
 The CP also coalesces live projection work per agent so ordinary bursts assemble
-only the newest pending revision, but that is a load optimization. The persisted
-daemon comparison is the correctness boundary across slow assembly, multiple CP
-publishers, retries, and reconnects.
+only the newest pending revision, but that is a load optimization. The daemon's
+in-process comparison is the correctness boundary across slow assembly, multiple
+CP publishers, retries, and reconnects; a new process receives a fresh authoritative roster.
 
 An organization-entry mutation computes the union of bindings affected before
 and after the transaction:

--- a/docs/designs/slack-integration-install.md
+++ b/docs/designs/slack-integration-install.md
@@ -135,10 +135,10 @@ The spec is sent only to the daemon that owns the integration's agent through:
 - live `integration/upsert` events; and
 - the daemon-filtered `register/ok.integrations` snapshot.
 
-The daemon's `CpIntegrationRegistry` writes the CP-owned spec into the matching
-agent's local `agent.json`, marked with `origin = cp`, and triggers
-reconciliation. Routing, tool injection, reply delivery, and Socket Mode
-startup all consume that consolidated on-disk view.
+The daemon's `CpIntegrationRegistry` keeps the CP-owned spec in memory and
+triggers reconciliation. Routing, tool injection, reply delivery, and Socket
+Mode startup consume the effective view formed from user-authored files plus
+the memory-only CP overlay.
 
 Per-channel trigger metadata contributes channel-scoped rules. The defaults
 respond to mentions and direct messages; channels configured for “any message”
@@ -180,7 +180,7 @@ On daemon registration:
 2. Open each bot secret through `BotSecretStore`.
 3. Build a direct or send-only spec from the bot transport.
 4. Return the complete desired set in `register/ok.integrations`.
-5. Persist each desired CP-owned integration into its agent file.
+5. Install each desired CP-owned integration in the daemon's memory-only registry.
 6. Explicitly drop stale Control Plane replicas that are not in the desired
    set, without deleting hand-authored local integrations.
 
@@ -190,10 +190,11 @@ This snapshot is the recovery backstop when:
 - a connection was interrupted during mutation; or
 - an agent moved between daemons.
 
-A restarted daemon first reconstructs effective integrations from local
-`agent.json` and can reconnect platform clients even while the Control Plane is
-unavailable. A later snapshot repairs any missed update or ownership change
-without asking the operator to enter credentials again.
+An already-running daemon retains effective integrations in memory while the
+Control Plane is unavailable. After daemon restart, user-authored integrations
+remain available from local `agent.json`; CP-owned integrations resume when the
+next snapshot re-converges them, without asking the operator to enter credentials
+again.
 
 ---
 
@@ -254,7 +255,7 @@ Tests cover:
 - bot and integration ownership and visibility;
 - secret-store sealing/opening and metadata-only reads;
 - absence of credentials from DTOs and logs;
-- CP-owned credential persistence only in the intended local agent file;
+- CP-owned credentials are absent from local agent files;
 - daemon-scoped snapshot filtering;
 - direct versus HTTP credential domaining;
 - live upsert/remove behavior and reconnect recovery;

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -153,8 +153,8 @@ export type CronDef = z.infer<typeof CronDefSchema>
 
 export const AgentSchema = z.object({
   id: z.string(),
-  // Added when a CP spec is persisted. Absence continues to mean a genuinely
-  // local agent (or a legacy replica, which the CP handles conservatively).
+  // Added to the in-memory effective representation of a CP-managed agent.
+  // A disk file carrying this legacy field is still treated as user-owned.
   origin: z.literal('cp').optional(),
   name: z.string(),
   // Optional human-facing bot name. `name` remains the stable agent identifier;
@@ -175,8 +175,8 @@ export const AgentSchema = z.object({
   // a soft-only reconcile change (no host/session teardown).
   pause: z.boolean().default(false),
   runtime: z.string(),
-  // System-prompt seed + runtime knobs. Settable in agent.json and overlaid by
-  // the CP spec (agent/upsert + register/ok roster) — see cp/cp-agent-registry.ts.
+  // System-prompt seed + runtime knobs. Settable in a local agent.json or supplied
+  // in memory by the CP (agent/upsert + register/ok roster).
   description: z.string().optional(),
   reasoningEffort: z.string().optional(),
   executionMode: z.string().optional(),

--- a/packages/daemon/src/agents/config-revision.ts
+++ b/packages/daemon/src/agents/config-revision.ts
@@ -8,8 +8,9 @@
  * optimization — slow assembly, several CP publishers, retries, and reconnects
  * can all still deliver snapshots out of order. This module is the correctness
  * boundary: the greatest applied revision plus a digest of that revision's
- * CP-owned spec is persisted beside `agent.json`, and every apply is decided
- * against it:
+ * CP-owned spec is tracked by the in-memory registry, and every apply is decided
+ * against it. The sidecar helpers below remain for legacy replica migration and
+ * low-level compatibility tests; current CP application does not call them:
  *
  *   - a GREATER revision      → apply normally;
  *   - an EQUAL revision, same digest    → idempotent retry, nothing to write;

--- a/packages/daemon/src/agents/cp-overlay.ts
+++ b/packages/daemon/src/agents/cp-overlay.ts
@@ -1,11 +1,10 @@
 /**
  * CP runtime env. The Control Plane owns the editable agent spec (prompt, model,
  * reasoning/execution knobs, env, workspace) and ships it over `agent/upsert` +
- * the `register/ok` reconcile roster. As of the agent.json-is-authoritative
- * change, those specs are written straight to disk (see agents/write-agent.ts),
- * so there is no in-memory overlay — the daemon reads the on-disk `agent.json`.
+ * the `register/ok` reconcile roster. Those specs remain in daemon memory and
+ * are combined with separately pushed integrations/crons in `effectiveAgents`.
  *
- * What remains here is the mapping from an agent's fields to the `AGENTCONNECT_*`
+ * This module maps the effective agent fields to the `AGENTCONNECT_*`
  * environment the daemon surfaces to the ACP child.
  */
 import type { Agent } from './agent-schema.js'

--- a/packages/daemon/src/agents/load-agents.ts
+++ b/packages/daemon/src/agents/load-agents.ts
@@ -6,6 +6,7 @@ import { protectAgentJson } from './agent-json-file.js'
 const IGNORED_DIRS = new Set(['node_modules', '.git'])
 const MAX_DEPTH = 4
 const DETACHED_DIR = '.detached'
+const CP_AGENT_ROOT_MARKER = '.cp-agent-id'
 
 // Agent plus loader-derived data: the directory containing agent.json.
 export type LoadedAgent = Agent & { dir: string }
@@ -42,6 +43,9 @@ export function findAgentFiles(dir: string, depth = 0): string[] {
   } catch {
     return []
   }
+  // A CP-managed data root intentionally has no agent.json. Treat it as a leaf
+  // so a checkout beneath workspace/ cannot masquerade as a local user agent.
+  if (entries.some((e) => e.isFile() && e.name === CP_AGENT_ROOT_MARKER)) return []
   if (entries.some((e) => e.isFile() && e.name === 'agent.json')) {
     return [join(dir, 'agent.json')]
   }

--- a/packages/daemon/src/agents/load-agents.ts
+++ b/packages/daemon/src/agents/load-agents.ts
@@ -45,7 +45,7 @@ export function findAgentFiles(dir: string, depth = 0): string[] {
   }
   // A CP-managed data root intentionally has no agent.json. Treat it as a leaf
   // so a checkout beneath workspace/ cannot masquerade as a local user agent.
-  if (entries.some((e) => e.isFile() && e.name === CP_AGENT_ROOT_MARKER)) return []
+  if (depth > 0 && entries.some((e) => e.isFile() && e.name === CP_AGENT_ROOT_MARKER)) return []
   if (entries.some((e) => e.isFile() && e.name === 'agent.json')) {
     return [join(dir, 'agent.json')]
   }

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -712,17 +712,18 @@ export function syncAgentReplica(agentsDir: string, agentId: string): void {
 }
 
 /**
- * Apply the CP-owned spec fields onto a parsed raw agent.json object IN PLACE.
+ * Apply the CP-owned spec fields onto an agent-shaped raw object IN PLACE.
+ * Used by both the legacy disk writer and the current in-memory registry.
  * `creating` controls whether workspace.path may be set (only on create — an
  * update never overwrites a path).
  */
-function applySpecFields(
+export function applySpecFields(
   raw: Record<string, unknown>,
   spec: AgentSpec,
   opts: { agentId: string; agentDir: string; creating: boolean }
 ): void {
-  // Persist replica ownership separately from the wire spec. The reconnect
-  // handshake reports this marker so the CP can prune only its own stale copy.
+  // Mark replica ownership separately from the wire spec. The reconnect
+  // handshake reports this field from the in-memory effective representation.
   raw.origin = 'cp'
   raw.name = spec.name
   // displayName follows PATCH semantics: value ⇒ set, null ⇒ clear, absent ⇒

--- a/packages/daemon/src/agents/write-cron.ts
+++ b/packages/daemon/src/agents/write-cron.ts
@@ -19,8 +19,8 @@ import { protectAgentJson, writeAgentJson } from './agent-json-file.js'
 import { findAgentFiles } from './load-agents.js'
 import { findAgentFileById } from './write-agent.js'
 
-/** Map the wire def to the agent.json `CronDef` shape (agent-schema). */
-function toCronDef(cron: CronUpsert): CronDef {
+/** Map the wire def to the daemon's `CronDef` shape (agent-schema). */
+export function toCronDef(cron: CronUpsert): CronDef {
   return {
     id: cron.cronId,
     schedule: cron.schedule,

--- a/packages/daemon/src/agents/write-integration.ts
+++ b/packages/daemon/src/agents/write-integration.ts
@@ -36,10 +36,10 @@ import { findAgentFileById } from './write-agent.js'
  * wherever present. An older CP's legacy nested block is stripped at the frame
  * layer; that CP dual-emitted `config` since §6.4 landed, so nothing is lost.
  * The wire envelope is folded back into today's on-disk shape, so everything
- * downstream of agent.json is unchanged. Returns null (reader-side rejection)
- * for a spec carrying no usable config.
+ * downstream consumers use. Returns null (reader-side rejection) for a spec
+ * carrying no usable config.
  */
-function toIntegration(spec: IntegrationSpec): Integration | null {
+export function toIntegration(spec: IntegrationSpec): Integration | null {
   const core = spec.core
   const knobs = (legacy: { bindRules: IntegrationBindRule[]; mutedChannels: string[]; gated: boolean }) => ({
     bindRules: core?.bindRules ?? legacy.bindRules,

--- a/packages/daemon/src/cli/agent-list.ts
+++ b/packages/daemon/src/cli/agent-list.ts
@@ -10,9 +10,9 @@ export interface RunAgentListOpts {
 
 // Read-only view of the local agent directory. Mutating agents (add/remove/
 // enable/disable) is intentionally not a CLI command — agent business config is
-// owned by the Control Plane (agent/upsert + register/ok roster, see
-// cp/cp-agent-registry.ts) or by hand-editing agent.json; the daemon only
-// reconciles what it finds on disk. This lists what that discovery sees.
+// supplied in memory by the Control Plane (agent/upsert + register/ok roster,
+// see cp/cp-agent-registry.ts) or by hand-editing agent.json. This command lists
+// only what local-file discovery sees.
 export async function runAgentList(opts: RunAgentListOpts): Promise<void> {
   const out = opts.out ?? process.stdout
   const cfg = loadConfig({

--- a/packages/daemon/src/cp/config-apply.ts
+++ b/packages/daemon/src/cp/config-apply.ts
@@ -42,7 +42,7 @@ export interface ConfigApply {
   applyConfigPush(keys: Record<string, unknown>): void
   /** Converge crons + agent specs (+ record leases) from the register/ok reconcile snapshot. */
   applyReconcileSnapshot(snap: RegisterOk): void | Promise<void>
-  /** Apply a CP agent spec and resolve after disk + live reconcile converge. */
+  /** Apply a memory-only CP agent spec and resolve after live reconcile converges. */
   applyAgentUpsert(upsert: AgentUpsert): Promise<Ack>
   /** Drop a CP agent spec (agent/remove EVT). */
   applyAgentRemove(agentId: string): void | Promise<void>

--- a/packages/daemon/src/cp/cp-agent-registry.ts
+++ b/packages/daemon/src/cp/cp-agent-registry.ts
@@ -10,7 +10,7 @@
  */
 import { createHash } from 'node:crypto'
 import { existsSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
-import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import type { AgentSpec } from '@agentconnect.md/protocol'
 import { AgentSchema } from '../agents/agent-schema.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
@@ -29,28 +29,56 @@ const MAX_DEPTH = 4
 
 export type AgentSpecApplyResult = ConfigRevisionDecision
 
-function markerRoot(dir: string, agentId: string, depth = 0): string | undefined {
-  if (depth > MAX_DEPTH || !existsSync(dir)) return undefined
+function safeLifecycleId(agentId: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/.test(agentId) && agentId !== '.' && agentId !== '..'
+}
+
+function strictChildRoot(agentsDir: string, dir: string): boolean {
+  const rel = relative(resolve(agentsDir), resolve(dir))
+  return rel !== '' && rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel)
+}
+
+function readRootMarker(dir: string): string | undefined {
+  try {
+    return readFileSync(join(dir, ROOT_MARKER), 'utf8').trim()
+  } catch {
+    return undefined
+  }
+}
+
+function markedRoots(
+  agentsDir: string,
+  dir = agentsDir,
+  depth = 0,
+  out = new Map<string, string[]>()
+): Map<string, string[]> {
+  if (depth > MAX_DEPTH || !existsSync(dir)) return out
   let entries
   try {
     entries = readdirSync(dir, { withFileTypes: true })
   } catch {
-    return undefined
+    return out
   }
   const marker = entries.find((entry) => entry.isFile() && entry.name === ROOT_MARKER)
-  if (marker) {
-    try {
-      if (readFileSync(join(dir, ROOT_MARKER), 'utf8').trim() === agentId) return dir
-    } catch {
-      // A malformed marker cannot claim a directory.
+  if (marker && strictChildRoot(agentsDir, dir)) {
+    const agentId = readRootMarker(dir)
+    if (agentId && safeLifecycleId(agentId)) {
+      const roots = out.get(agentId) ?? []
+      roots.push(dir)
+      out.set(agentId, roots)
     }
+    // A marked data root is a discovery leaf; never inspect its workspace.
+    return out
   }
   for (const entry of entries) {
     if (!entry.isDirectory() || entry.name === 'node_modules' || entry.name === '.git') continue
-    const found = markerRoot(join(dir, entry.name), agentId, depth + 1)
-    if (found) return found
+    markedRoots(agentsDir, join(dir, entry.name), depth + 1, out)
   }
-  return undefined
+  return out
+}
+
+function markerRoot(agentsDir: string, agentId: string): string | undefined {
+  return markedRoots(agentsDir).get(agentId)?.[0]
 }
 
 function fallbackDir(agentsDir: string, agentId: string): string {
@@ -58,19 +86,31 @@ function fallbackDir(agentsDir: string, agentId: string): string {
 }
 
 function assertSafeLifecycleId(agentId: string): void {
-  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/.test(agentId) || agentId === '.' || agentId === '..') {
+  if (!safeLifecycleId(agentId)) {
     throw new Error('agent id is unsafe for daemon-local lifecycle storage')
   }
 }
 
+function availableRoot(agentsDir: string, agentId: string, name: string): string {
+  const safeName = safeLifecycleId(name) && name !== 'node_modules'
+  const preferred = safeName ? join(agentsDir, name) : undefined
+  if (preferred && !existsSync(preferred)) return preferred
+
+  const fallback = fallbackDir(agentsDir, agentId)
+  if (!existsSync(fallback)) return fallback
+  for (let suffix = 2; suffix <= 10_000; suffix += 1) {
+    const candidate = `${fallback}-${suffix}`
+    if (!existsSync(candidate)) return candidate
+  }
+  throw new Error(`cannot allocate a private data root for agent "${agentId}"`)
+}
+
 function chooseRoot(agentsDir: string, agentId: string, spec: AgentSpec): { dir: string; file?: string } {
   const file = findAgentFileById(agentsDir, agentId)
-  if (file) return { dir: dirname(file), file }
   const marked = markerRoot(agentsDir, agentId)
-  if (marked) return { dir: marked }
-  const safeName = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/.test(spec.name) && spec.name !== '.' && spec.name !== '..'
-  const named = safeName ? join(agentsDir, spec.name) : undefined
-  return { dir: named && !existsSync(named) ? named : fallbackDir(agentsDir, agentId) }
+  if (marked) return { dir: marked, file }
+  if (file && strictChildRoot(agentsDir, dirname(file))) return { dir: dirname(file), file }
+  return { dir: availableRoot(agentsDir, agentId, spec.name), file }
 }
 
 function writeRootMarker(dir: string, agentId: string): void {
@@ -122,6 +162,11 @@ export class CpAgentRegistry {
     return [...this.active.values()]
   }
 
+  /** CP-owned data roots, including marker-only replicas after daemon restart. */
+  replicaIds(): string[] {
+    return [...new Set([...this.active.keys(), ...this.detached.keys(), ...markedRoots(this.agentsDir).keys()])]
+  }
+
   upsert(agentId: string, spec: AgentSpec): AgentSpecApplyResult {
     const decision = this.apply(agentId, spec)
     if (decision === 'apply') this.onChange()
@@ -131,10 +176,21 @@ export class CpAgentRegistry {
   remove(agentId: string): void {
     assertSafeLifecycleId(agentId)
     const agent = this.active.get(agentId) ?? this.detached.get(agentId)
+    const roots = markedRoots(this.agentsDir).get(agentId) ?? []
+    if (agent && existsSync(agent.dir) && !roots.some((root) => resolve(root) === resolve(agent.dir))) {
+      throw new Error(`refusing to remove agent "${agentId}": its data-root marker is missing or invalid`)
+    }
+    // Delete validated roots before clearing memory. A failure remains retryable;
+    // after restart the marker inventory supplies the same roots without config.
+    for (const root of roots) {
+      if (!strictChildRoot(this.agentsDir, root) || readRootMarker(root) !== agentId) {
+        throw new Error(`refusing to remove agent "${agentId}": its data root is unsafe or no longer owned`)
+      }
+      rmSync(root, { recursive: true, force: true })
+    }
     this.active.delete(agentId)
     this.detached.delete(agentId)
     this.revisions.delete(agentId)
-    if (agent) rmSync(agent.dir, { recursive: true, force: true })
     this.onChange()
   }
 
@@ -177,6 +233,7 @@ export class CpAgentRegistry {
   }
 
   private apply(agentId: string, spec: AgentSpec): AgentSpecApplyResult {
+    assertSafeLifecycleId(agentId)
     const revision = parseConfigRevision(spec)
     const digest = agentSpecDigest(spec)
     const decision = compareConfigRevision(this.revisions.get(agentId), { revision, digest })
@@ -193,11 +250,12 @@ export class CpAgentRegistry {
     if (decision === 'idempotent') return decision
 
     const located = chooseRoot(this.agentsDir, agentId, spec)
-    const previous =
-      this.active.get(agentId) ??
-      this.detached.get(agentId) ??
-      (located.file ? readLegacyAgent(located.file) : undefined)
-    if (previous) located.dir = previous.dir
+    const existing = this.active.get(agentId) ?? this.detached.get(agentId)
+    const previous = existing ?? (located.file ? readLegacyAgent(located.file) : undefined)
+    if (existing) located.dir = existing.dir
+    if (!strictChildRoot(this.agentsDir, located.dir)) {
+      throw new Error(`refusing to claim an unsafe data root for agent "${agentId}"`)
+    }
     const runtime = spec.runtime ?? previous?.runtime ?? this.deps.knownRuntimes[0]
     if (!runtime) throw new Error(`cannot create agent "${agentId}": spec has no runtime and no runtimes are known`)
     if (!spec.runtime && !previous) {
@@ -219,16 +277,27 @@ export class CpAgentRegistry {
     applySpecFields(raw, spec, { agentId, agentDir: located.dir, creating: !previous })
     const agent = { ...AgentSchema.parse(raw), dir: located.dir }
 
-    // Remove every local file claiming this id. Duplicate ids are invalid local
-    // state, but CP authority must not leave an arbitrary duplicate discoverable.
-    if (located.file) rmSync(located.file, { force: true })
-    for (let matching = findAgentFileById(this.agentsDir, agentId); matching;) {
-      rmSync(matching, { force: true })
-      matching = findAgentFileById(this.agentsDir, agentId)
+    const priorMarker = readRootMarker(located.dir)
+    if (priorMarker !== undefined && priorMarker !== agentId) {
+      throw new Error(`refusing to claim data root owned by agent "${priorMarker}"`)
     }
-    // Commit the memory representation only after its durable data-root marker
-    // succeeds. The marker contains no config or secret values.
+    const installedMarker = priorMarker === undefined
+    // Establish the secret-free durable identity before unlinking the local
+    // config. If an unlink fails, roll back a newly installed marker so the
+    // still-present local file remains discoverable and the apply can retry.
     writeRootMarker(located.dir, agentId)
+    try {
+      // Remove every local file claiming this id. Duplicate ids are invalid local
+      // state, but CP authority must not leave an arbitrary duplicate discoverable.
+      if (located.file) rmSync(located.file, { force: true })
+      for (let matching = findAgentFileById(this.agentsDir, agentId); matching;) {
+        rmSync(matching, { force: true })
+        matching = findAgentFileById(this.agentsDir, agentId)
+      }
+    } catch (error) {
+      if (installedMarker) rmSync(join(located.dir, ROOT_MARKER), { force: true })
+      throw error
+    }
     rmSync(join(located.dir, '.cp-config-revision.json'), { force: true })
     this.detached.delete(agentId)
     this.active.set(agentId, agent)

--- a/packages/daemon/src/cp/cp-agent-registry.ts
+++ b/packages/daemon/src/cp/cp-agent-registry.ts
@@ -1,48 +1,112 @@
 /**
- * `CpAgentRegistry` — applies CP-owned agent specs onto the daemon's on-disk
- * `agent.json` files, which are the SINGLE SOURCE OF TRUTH. The CP pushes deltas
- * over `agent/upsert` / `agent/remove` and the full set over the `register/ok`
- * reconcile roster; this writes each straight to disk (create-or-merge) keyed by
- * `agentId`. No spec is held in memory or in SQLite.
+ * In-memory registry for Control Plane agent specs.
  *
- * `converge` create-or-merges every roster entry. Reconnect pruning is explicit
- * through `register/ok.drop.agents`, after the CP has compared the daemon's
- * reported replica ownership with its authoritative placement.
- *
- * Every apply passes the monotonic `configRevision` fence first
- * (organization-secrets-and-variables.md §7): `env`/`secrets` are full resolved
- * maps, so an out-of-order snapshot would reinstate a rotated or deleted value.
- * A stale snapshot is acknowledged without ever reaching `writeAgentSpec`.
- *
- * Every mutation fires `onChange` so the daemon re-reconciles (re-loads agents
- * from disk; the reconciler is idempotent and only restarts a host on a real
- * config change).
+ * CP configuration is deliberately never persisted as `agent.json`. A matching
+ * hand-authored/legacy file is removed when the CP claims that id; every other
+ * `agent.json` remains untouched and is treated as user-owned. The agent's data
+ * directory remains durable and carries only a private id marker, allowing a
+ * reconnect after daemon restart to reuse workspace, memory, and session data
+ * without storing the CP spec or its secrets.
  */
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
 import type { AgentSpec } from '@agentconnect.md/protocol'
-import {
-  writeAgentSpec,
-  removeAgent,
-  archiveAgent,
-  restoreArchivedAgent,
-  pruneMovedAgentDependents,
-  findAgentFileById,
-  findReplicaFileById,
-  syncAgentReplica,
-  type WriteAgentDeps
-} from '../agents/write-agent.js'
+import { AgentSchema } from '../agents/agent-schema.js'
+import type { LoadedAgent } from '../agents/load-agents.js'
+import { ensurePrivateAgentDirectory } from '../agents/agent-json-file.js'
+import { applySpecFields, findAgentFileById, type WriteAgentDeps } from '../agents/write-agent.js'
 import {
   agentSpecDigest,
   compareConfigRevision,
   parseConfigRevision,
-  readAppliedConfigRevision,
-  writeAppliedConfigRevision,
+  type AppliedConfigRevision,
   type ConfigRevisionDecision
 } from '../agents/config-revision.js'
 
-/** What one apply did. `stale`/`idempotent` wrote nothing; `conflict` refused. */
+const ROOT_MARKER = '.cp-agent-id'
+const MAX_DEPTH = 4
+
 export type AgentSpecApplyResult = ConfigRevisionDecision
 
+function markerRoot(dir: string, agentId: string, depth = 0): string | undefined {
+  if (depth > MAX_DEPTH || !existsSync(dir)) return undefined
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return undefined
+  }
+  const marker = entries.find((entry) => entry.isFile() && entry.name === ROOT_MARKER)
+  if (marker) {
+    try {
+      if (readFileSync(join(dir, ROOT_MARKER), 'utf8').trim() === agentId) return dir
+    } catch {
+      // A malformed marker cannot claim a directory.
+    }
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === 'node_modules' || entry.name === '.git') continue
+    const found = markerRoot(join(dir, entry.name), agentId, depth + 1)
+    if (found) return found
+  }
+  return undefined
+}
+
+function fallbackDir(agentsDir: string, agentId: string): string {
+  return join(agentsDir, `agent-${createHash('sha256').update(agentId).digest('hex').slice(0, 32)}`)
+}
+
+function assertSafeLifecycleId(agentId: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/.test(agentId) || agentId === '.' || agentId === '..') {
+    throw new Error('agent id is unsafe for daemon-local lifecycle storage')
+  }
+}
+
+function chooseRoot(agentsDir: string, agentId: string, spec: AgentSpec): { dir: string; file?: string } {
+  const file = findAgentFileById(agentsDir, agentId)
+  if (file) return { dir: dirname(file), file }
+  const marked = markerRoot(agentsDir, agentId)
+  if (marked) return { dir: marked }
+  const safeName = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/.test(spec.name) && spec.name !== '.' && spec.name !== '..'
+  const named = safeName ? join(agentsDir, spec.name) : undefined
+  return { dir: named && !existsSync(named) ? named : fallbackDir(agentsDir, agentId) }
+}
+
+function writeRootMarker(dir: string, agentId: string): void {
+  ensurePrivateAgentDirectory(dir)
+  const file = join(dir, ROOT_MARKER)
+  const temp = `${file}.tmp`
+  try {
+    writeFileSync(temp, `${agentId}\n`, { mode: 0o600 })
+    renameSync(temp, file)
+  } catch (error) {
+    rmSync(temp, { force: true })
+    throw error
+  }
+}
+
+function rawAgent(agent: LoadedAgent): Record<string, unknown> {
+  const { dir: _dir, ...raw } = agent
+  return structuredClone(raw) as Record<string, unknown>
+}
+
+function readLegacyAgent(file: string): LoadedAgent | undefined {
+  try {
+    const dir = dirname(file)
+    const agent = AgentSchema.parse(JSON.parse(readFileSync(file, 'utf8')))
+    if (!isAbsolute(agent.workspace.path)) agent.workspace.path = resolve(dir, agent.workspace.path)
+    return { ...agent, dir }
+  } catch {
+    return undefined
+  }
+}
+
 export class CpAgentRegistry {
+  private readonly active = new Map<string, LoadedAgent>()
+  private readonly detached = new Map<string, LoadedAgent>()
+  private readonly revisions = new Map<string, AppliedConfigRevision>()
+
   constructor(
     private readonly agentsDir: string,
     private readonly deps: WriteAgentDeps,
@@ -50,63 +114,59 @@ export class CpAgentRegistry {
     private readonly warn?: (msg: string) => void
   ) {}
 
-  /**
-   * Add or merge one agent's spec onto disk (agent/upsert EVT), under the
-   * revision fence. Returns what the fence decided so the caller can ACK a stale
-   * snapshot as a no-op and refuse an equal-revision digest mismatch.
-   */
+  has(agentId: string): boolean {
+    return this.active.has(agentId)
+  }
+
+  agents(): LoadedAgent[] {
+    return [...this.active.values()]
+  }
+
   upsert(agentId: string, spec: AgentSpec): AgentSpecApplyResult {
     const decision = this.apply(agentId, spec)
     if (decision === 'apply') this.onChange()
     return decision
   }
 
-  /** Delete one agent's on-disk dir (agent/remove EVT). Unconditional. */
   remove(agentId: string): void {
-    removeAgent(this.agentsDir, agentId)
+    assertSafeLifecycleId(agentId)
+    const agent = this.active.get(agentId) ?? this.detached.get(agentId)
+    this.active.delete(agentId)
+    this.detached.delete(agentId)
+    this.revisions.delete(agentId)
+    if (agent) rmSync(agent.dir, { recursive: true, force: true })
     this.onChange()
   }
 
-  /** Non-destructively move an agent root out of the active discovery tree. */
   detach(agentId: string): 'archived' | 'already-detached' | 'missing' {
-    const result = archiveAgent(this.agentsDir, agentId)
-    if (result !== 'missing') this.onChange()
-    return result
+    assertSafeLifecycleId(agentId)
+    const agent = this.active.get(agentId)
+    if (!agent) return this.detached.has(agentId) ? 'already-detached' : 'missing'
+    this.active.delete(agentId)
+    this.detached.set(agentId, agent)
+    this.onChange()
+    return 'archived'
   }
 
-  /**
-   * Exact-prune locally persisted CP dependents while an external lifecycle
-   * gate still keeps the agent dark. Used by move activation and by removal-
-   * tombstone re-add so stale platform credentials can never revive.
-   */
-  exactDependents(agentId: string, desired: { integrationIds: string[]; cronIds: string[] }): boolean {
-    const changed = pruneMovedAgentDependents(this.agentsDir, agentId, desired)
-    syncAgentReplica(this.agentsDir, agentId)
-    return changed
+  /** CP dependents are held by their own in-memory registries. */
+  exactDependents(_agentId: string, _desired: { integrationIds: string[]; cronIds: string[] }): boolean {
+    return false
   }
 
-  /** Restore a detached root in place. Idempotent while already active. */
   activate(
     agentId: string,
-    desired: { integrationIds: string[]; cronIds: string[] }
+    _desired: { integrationIds: string[]; cronIds: string[] }
   ): 'restored' | 'already-active' | 'missing' {
-    const alreadyActive = !!findAgentFileById(this.agentsDir, agentId)
-    if (!alreadyActive && !restoreArchivedAgent(this.agentsDir, agentId)) return 'missing'
-    const pruned = this.exactDependents(agentId, desired)
-    if (!alreadyActive || pruned) this.onChange()
-    return alreadyActive ? 'already-active' : 'restored'
+    assertSafeLifecycleId(agentId)
+    if (this.active.has(agentId)) return 'already-active'
+    const agent = this.detached.get(agentId)
+    if (!agent) return 'missing'
+    this.detached.delete(agentId)
+    this.active.set(agentId, agent)
+    this.onChange()
+    return 'restored'
   }
 
-  /**
-   * Apply the register/ok reconcile roster: create-or-merge EACH entry and
-   * NOTHING else. The caller applies the separately-authorized drop list first;
-   * roster absence alone is never enough to prune a hand-authored local agent.
-   *
-   * Returns the ids actually written. A stale or refused entry is skipped
-   * INDIVIDUALLY — one bad revision must never fail the whole handshake — so the
-   * caller must not treat roster membership as proof that a replica was rewritten
-   * (e.g. before clearing a removal tombstone).
-   */
   converge(roster: Array<AgentSpec & { agentId: string }>): string[] {
     const applied: string[] = []
     for (const { agentId, ...spec } of roster) {
@@ -116,18 +176,10 @@ export class CpAgentRegistry {
     return applied
   }
 
-  /** The fenced write shared by `upsert` and `converge`. */
   private apply(agentId: string, spec: AgentSpec): AgentSpecApplyResult {
     const revision = parseConfigRevision(spec)
     const digest = agentSpecDigest(spec)
-    // Includes a cold-move archive: writeAgentSpec restores one before merging CP
-    // fields, so a stale fan-out that arrives after a move-away must not be able
-    // to both un-archive the root and downgrade its configuration.
-    const existingFile = findReplicaFileById(this.agentsDir, agentId)
-    // No local replica at all ⇒ nothing to compare against and nothing to reinstate.
-    const decision = existingFile
-      ? compareConfigRevision(readAppliedConfigRevision(existingFile), { revision, digest })
-      : 'apply'
+    const decision = compareConfigRevision(this.revisions.get(agentId), { revision, digest })
     if (decision === 'stale') {
       this.warn?.(`cp: agent "${agentId}" spec revision ${spec.configRevision} is older than the applied one; ignoring`)
       return decision
@@ -139,11 +191,48 @@ export class CpAgentRegistry {
       return decision
     }
     if (decision === 'idempotent') return decision
-    writeAgentSpec(this.agentsDir, agentId, spec, this.deps)
-    // AFTER the content: a crash in between re-applies on retry, whereas the
-    // reverse order would make an equal-revision retry look already-done.
-    const written = findAgentFileById(this.agentsDir, agentId)
-    if (written) writeAppliedConfigRevision(written, revision, digest)
-    return decision
+
+    const located = chooseRoot(this.agentsDir, agentId, spec)
+    const previous =
+      this.active.get(agentId) ??
+      this.detached.get(agentId) ??
+      (located.file ? readLegacyAgent(located.file) : undefined)
+    if (previous) located.dir = previous.dir
+    const runtime = spec.runtime ?? previous?.runtime ?? this.deps.knownRuntimes[0]
+    if (!runtime) throw new Error(`cannot create agent "${agentId}": spec has no runtime and no runtimes are known`)
+    if (!spec.runtime && !previous) {
+      this.deps.warn?.(`cp: agent "${agentId}" spec has no runtime; defaulting to "${runtime}"`)
+    }
+    const raw: Record<string, unknown> = previous
+      ? rawAgent(previous)
+      : {
+          id: agentId,
+          name: spec.name,
+          status: 'active',
+          runtime,
+          workspace: { mode: 'from-scratch', path: join(located.dir, 'workspace') }
+        }
+    raw.id = agentId
+    raw.runtime ??= runtime
+    raw.integrations = []
+    raw.crons = []
+    applySpecFields(raw, spec, { agentId, agentDir: located.dir, creating: !previous })
+    const agent = { ...AgentSchema.parse(raw), dir: located.dir }
+
+    // Remove every local file claiming this id. Duplicate ids are invalid local
+    // state, but CP authority must not leave an arbitrary duplicate discoverable.
+    if (located.file) rmSync(located.file, { force: true })
+    for (let matching = findAgentFileById(this.agentsDir, agentId); matching;) {
+      rmSync(matching, { force: true })
+      matching = findAgentFileById(this.agentsDir, agentId)
+    }
+    // Commit the memory representation only after its durable data-root marker
+    // succeeds. The marker contains no config or secret values.
+    writeRootMarker(located.dir, agentId)
+    rmSync(join(located.dir, '.cp-config-revision.json'), { force: true })
+    this.detached.delete(agentId)
+    this.active.set(agentId, agent)
+    if (revision !== undefined) this.revisions.set(agentId, { revision, digest })
+    return 'apply'
   }
 }

--- a/packages/daemon/src/cp/cp-cron.ts
+++ b/packages/daemon/src/cp/cp-cron.ts
@@ -1,48 +1,49 @@
-/**
- * `CpCronRegistry` — applies CP-owned crons onto the daemon's on-disk
- * `agent.json` files, which are the SINGLE SOURCE OF TRUTH (same model as
- * CpIntegrationRegistry). The CP pushes deltas over `cron/upsert` /
- * `cron/remove` and the full per-daemon set over the `register/ok` reconcile
- * snapshot; this writes each straight into the owning agent's `crons[]`
- * (upsert by cronId, marked `origin:"cp"`). Nothing is held in memory, so CP
- * crons survive a daemon restart with the CP down — the Scheduler registers
- * them from disk at start, and every mutation here fires `onChange` so the
- * daemon re-reconciles (diffAgents sees the crons change → Scheduler re-syncs).
- *
- * Pruning is explicit only: `cron/remove` and `register/ok.drop.crons[]` splice
- * entries out; `converge` upserts and never deletes. Hand-authored (no-origin)
- * entries are never touched.
- */
+/** CP cron definitions live only in daemon memory and are re-converged on reconnect. */
 import type { CronUpsert } from '@agentconnect.md/protocol'
-import { writeCronDef, removeCronDef, type WriteCronDeps } from '../agents/write-cron.js'
+import type { CronDef } from '../agents/agent-schema.js'
+import { toCronDef, type WriteCronDeps } from '../agents/write-cron.js'
+
+interface Entry {
+  agentId: string
+  cron: CronDef
+}
 
 export class CpCronRegistry {
+  private readonly entries = new Map<string, Entry>()
+
   constructor(
-    private readonly agentsDir: string,
-    private readonly deps: WriteCronDeps,
+    _agentsDir: string,
+    _deps: WriteCronDeps,
     private readonly onChange: () => void
   ) {}
 
-  /** Add or replace one CP cron on the owning agent's disk file (cron/upsert REQ). */
   upsert(cron: CronUpsert): void {
-    if (writeCronDef(this.agentsDir, cron, this.deps)) this.onChange()
+    this.entries.set(cron.cronId, { agentId: cron.agentId, cron: toCronDef(cron) })
+    this.onChange()
   }
 
-  /** Splice one CP cron out of whichever agent.json holds it (cron/remove REQ). */
   remove(cronId: string): void {
-    if (removeCronDef(this.agentsDir, cronId)) this.onChange()
+    if (this.entries.delete(cronId)) this.onChange()
   }
 
-  /**
-   * Apply the register/ok snapshot: upsert EACH entry (identical re-applies skip
-   * the write, so a reconnect with an unchanged set is a no-op). Stale ids
-   * arrive separately via `drop.crons[]` → {@link remove}.
-   */
   converge(crons: CronUpsert[]): void {
+    for (const cron of crons ?? []) this.entries.set(cron.cronId, { agentId: cron.agentId, cron: toCronDef(cron) })
+    this.onChange()
+  }
+
+  forAgent(agentId: string): CronDef[] {
+    return [...this.entries.values()].filter((entry) => entry.agentId === agentId).map((entry) => entry.cron)
+  }
+
+  retainForAgent(agentId: string, desiredIds: ReadonlySet<string>): boolean {
     let changed = false
-    for (const cron of crons ?? []) {
-      if (writeCronDef(this.agentsDir, cron, this.deps)) changed = true
+    for (const [id, entry] of this.entries) {
+      if (entry.agentId === agentId && !desiredIds.has(id)) {
+        this.entries.delete(id)
+        changed = true
+      }
     }
     if (changed) this.onChange()
+    return changed
   }
 }

--- a/packages/daemon/src/cp/cp-integration-registry.ts
+++ b/packages/daemon/src/cp/cp-integration-registry.ts
@@ -1,55 +1,58 @@
-/**
- * `CpIntegrationRegistry` — applies CP-owned platform integrations onto the
- * daemon's on-disk `agent.json` files, which are the SINGLE SOURCE OF TRUTH
- * (same model as CpAgentRegistry). The CP pushes deltas over
- * `integration/upsert` / `integration/remove` and the full per-daemon set over
- * the `register/ok` reconcile roster; this writes each straight to the owning
- * agent's `integrations[]` (upsert by integrationId). Nothing is held in memory,
- * so integrations — and their Slack tokens — survive a daemon restart with the
- * CP down: `daemon.start()` opens Socket Mode connections from disk alone.
- *
- * Tokens on disk share the daemon's trust boundary (hand-authored agents already
- * keep Slack tokens in agent.json). They still MUST NEVER be logged.
- *
- * `converge` upserts every roster entry. Reconnect pruning is explicit through
- * `register/ok.drop.integrations`, after ownership-aware CP reconciliation.
- *
- * Every mutation fires `onChange` so the daemon re-reconciles (re-loads agents
- * from disk; diffAgents flags the `integrations` dimension, which re-opens/binds
- * the Slack sockets).
- */
+/** CP platform integrations live only in daemon memory and are re-converged on reconnect. */
 import type { IntegrationSpec } from '@agentconnect.md/protocol'
-import { writeIntegrationSpec, removeIntegration, type WriteIntegrationDeps } from '../agents/write-integration.js'
+import type { Integration } from '../agents/agent-schema.js'
+import { toIntegration, type WriteIntegrationDeps } from '../agents/write-integration.js'
+
+interface Entry {
+  agentId: string
+  integration: Integration
+}
 
 export class CpIntegrationRegistry {
+  private readonly entries = new Map<string, Entry>()
+
   constructor(
-    private readonly agentsDir: string,
+    _agentsDir: string,
     private readonly deps: WriteIntegrationDeps,
     private readonly onChange: () => void
   ) {}
 
-  /** Add or replace one integration on the owning agent's disk file (integration/upsert EVT). */
   upsert(spec: IntegrationSpec): void {
-    writeIntegrationSpec(this.agentsDir, spec, this.deps)
+    const integration = toIntegration(spec)
+    if (!integration) {
+      this.deps.warn?.(`cp: integration ${spec.integrationId} carried no usable platform payload — ignored`)
+      return
+    }
+    this.entries.set(spec.integrationId, { agentId: spec.agentId, integration })
     this.onChange()
   }
 
-  /** Splice one integration out of whichever agent.json holds it (integration/remove EVT). */
   remove(integrationId: string): void {
-    removeIntegration(this.agentsDir, integrationId)
-    this.onChange()
+    if (this.entries.delete(integrationId)) this.onChange()
   }
 
-  /**
-   * Apply the register/ok reconcile roster: upsert EACH entry and NOTHING else.
-   * The caller applies the separately-authorized drop list first; roster
-   * absence alone is never enough to prune a hand-authored local integration.
-   */
   converge(specs: IntegrationSpec[]): void {
-    // Tolerate a snapshot without the field (older CP / hand-built) — treat as empty.
     for (const spec of specs ?? []) {
-      writeIntegrationSpec(this.agentsDir, spec, this.deps)
+      const integration = toIntegration(spec)
+      if (integration) this.entries.set(spec.integrationId, { agentId: spec.agentId, integration })
+      else this.deps.warn?.(`cp: integration ${spec.integrationId} carried no usable platform payload — ignored`)
     }
     this.onChange()
+  }
+
+  forAgent(agentId: string): Integration[] {
+    return [...this.entries.values()].filter((entry) => entry.agentId === agentId).map((entry) => entry.integration)
+  }
+
+  retainForAgent(agentId: string, desiredIds: ReadonlySet<string>): boolean {
+    let changed = false
+    for (const [id, entry] of this.entries) {
+      if (entry.agentId === agentId && !desiredIds.has(id)) {
+        this.entries.delete(id)
+        changed = true
+      }
+    }
+    if (changed) this.onChange()
+    return changed
   }
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1666,9 +1666,9 @@ export class Daemon {
   /** Spawn-time config warnings per agent (config-file secrets: pointer-var
    *  conflicts, write failures) — flushed into the next dispatched session. */
   private pendingSpawnNotices = new Map<string, string[]>()
-  // Effective agents = the on-disk agent.json files (the single source of truth;
-  // CP specs are written into them). Everything (routing, dispatch, hosts) reads
-  // `agents`; `fileAgents` mirrors the loaded files and is rebuilt each reconcile.
+  // Effective agents combine user-authored agent.json files with the in-memory CP
+  // registries. Everything (routing, dispatch, hosts) reads `agents`; `fileAgents`
+  // mirrors only the loaded local files and is rebuilt each reconcile.
   private agents = new Map<string, LoadedAgent>()
   private fileAgents = new Map<string, LoadedAgent>()
   private hosts = new Map<string, AcpHost>()
@@ -2708,9 +2708,9 @@ export class Daemon {
       },
       save: (s) => this.store.setCpRouting(s.routingEpoch, JSON.stringify(s.assignments), JSON.stringify(s.globalRules))
     })
-    // CP agent specs are written straight to the on-disk agent.json (the single
-    // source of truth) via create-or-merge keyed by agentId; a write re-reconciles
-    // (re-loads agents from disk; restarts a host only on a real config change).
+    // CP agent specs stay in memory and are re-converged on every CP connection.
+    // The registry removes a same-id agent.json and retains only a secret-free
+    // data-root marker on disk; unrelated local agent.json files remain user-owned.
     this.cpAgents = new CpAgentRegistry(
       this.agentsDir,
       { knownRuntimes: Object.keys(this.runtimeCatalog.runtimes), warn: (m) => this.log.warn(m) },
@@ -2720,10 +2720,7 @@ export class Daemon {
         ),
       (m) => this.log.warn(m)
     )
-    // CP integrations are written straight to the owning agent's on-disk agent.json
-    // `integrations[]` (the single source of truth) — so they survive a restart with
-    // the CP down and start() opens the Socket Mode sockets from disk alone. A write
-    // re-reconciles (diffAgents flags the integrations dimension → re-opens/binds).
+    // CP integrations are memory-only and overlaid onto the effective agent set.
     this.cpIntegrations = new CpIntegrationRegistry(
       this.agentsDir,
       { warn: (m) => this.log.warn(m) },
@@ -2732,10 +2729,7 @@ export class Daemon {
           this.log.error(`cp: integration reconcile failed: ${(err as Error).stack ?? err}`)
         )
     )
-    // CP crons are written straight into the owning agent's on-disk agent.json
-    // `crons[]` (the single source of truth, origin:"cp") — so they survive a
-    // restart with the CP down and the Scheduler registers them from disk alone.
-    // A write re-reconciles (diffAgents sees the crons change → Scheduler re-sync).
+    // CP crons are memory-only and overlaid onto the effective agent set.
     this.cpCrons = new CpCronRegistry(
       this.agentsDir,
       { warn: (m) => this.log.warn(m) },
@@ -3185,7 +3179,10 @@ export class Daemon {
     if (this.opts.agentName) {
       const match = validAgents.find((agent) => agent.id === this.opts.agentName)
       const previous = [...preserved.values()].find((agent) => agent.id === this.opts.agentName)
-      if (match) agents = [match]
+      // A CP upsert removes the selected same-id agent.json. Once that happens
+      // the memory registry, not file discovery, supplies the effective entry.
+      if (this.cpAgents?.has(this.opts.agentName)) agents = []
+      else if (match) agents = [match]
       else if (previous) agents = [previous]
       else {
         const available =
@@ -3205,22 +3202,32 @@ export class Daemon {
     return { agents, activeFleet }
   }
 
-  /**
-   * Effective agent set = the on-disk `agent.json` files, with the CP-owned
-   * integrations overlaid in memory. Agent SPECS are no longer overlaid — `agent/
-   * upsert` writes those straight to disk (cp/cp-agent-registry.ts). INTEGRATIONS,
-   * however, carry plaintext tokens and are kept in memory only (cp/cp-integration-
-   * registry.ts); they are merged onto the matching file agent's `integrations[]`
-   * HERE — the single seam so consolidate, routing rules, tool injection, and reply
-   * routing (all of which read `agent.integrations`) see one merged view.
-   */
-  private effectiveAgents(): LoadedAgent[] {
-    // Integrations live on disk in each agent.json (CP pushes are persisted by
-    // CpIntegrationRegistry before reconcile re-loads), so the file agents ARE
-    // the effective set — no in-memory overlay.
-    return [...this.fileAgents.values()].filter(
-      (agent) => !this.moveStagedAgents.has(agent.id) && !this.removedAgentTombstones.has(agent.id)
-    )
+  /** Build one effective view from user-authored files plus CP memory registries. */
+  private effectiveAgents(fileAgents: ReadonlyMap<string, LoadedAgent> = this.fileAgents): LoadedAgent[] {
+    const bases = new Map(fileAgents)
+    // CP authority wins an id collision. In practice the registry already
+    // unlinks the matching file, but this also closes the file-watcher race.
+    for (const agent of this.cpAgents?.agents() ?? []) bases.set(agent.id, agent)
+    return [...bases.values()]
+      .filter((agent) => !this.moveStagedAgents.has(agent.id) && !this.removedAgentTombstones.has(agent.id))
+      .map((agent) => {
+        const integrations = [...agent.integrations]
+        for (const integration of this.cpIntegrations?.forAgent(agent.id) ?? []) {
+          const index = integrations.findIndex((current) => current.id === integration.id)
+          if (index >= 0) integrations[index] = integration
+          else integrations.push(integration)
+        }
+        const crons = [...agent.crons]
+        for (const cron of this.cpCrons?.forAgent(agent.id) ?? []) {
+          // A user's same-id cron remains user-owned. CP entries replace only CP entries.
+          const localCollision = crons.some((current) => current.id === cron.id && current.origin !== 'cp')
+          if (localCollision) continue
+          const index = crons.findIndex((current) => current.id === cron.id && current.origin === 'cp')
+          if (index >= 0) crons[index] = cron
+          else crons.push(cron)
+        }
+        return { ...agent, integrations, crons }
+      })
   }
 
   /**
@@ -3257,9 +3264,7 @@ export class Daemon {
     const snapshot = this.loadAgentList(true)
     const files = snapshot.agents
     const nextFileAgents = new Map(files.map((a) => [a.id, a]))
-    const desired = [...nextFileAgents.values()].filter(
-      (agent) => !this.moveStagedAgents.has(agent.id) && !this.removedAgentTombstones.has(agent.id)
-    )
+    const desired = this.effectiveAgents(nextFileAgents)
     // Keep the previous live roster intact when an incoming config would create
     // an unsafe/aliased workspace authority.
     if (!this.opts.hostFactory) {
@@ -15893,15 +15898,20 @@ export class Daemon {
     return this.connForIntegration(intId)
   }
 
-  /** The CP-owned cron ids currently on disk (register `localState.crons` — the
-   *  CP computes `drop.crons` against this; hand-authored crons are not reported). */
+  /** CP-owned cron ids currently held in memory. */
   private cpCronIds(): string[] {
     const out: string[] = []
     for (const a of this.effectiveAgents()) for (const c of a.crons) if (c.origin === 'cp') out.push(c.id)
     return out
   }
 
-  /** Ownership-aware active disk state sent during register. Single-agent mode
+  /** Exact-prune stale CP-only dependents without touching local file entries. */
+  private exactCpDependents(agentId: string, desired: { integrationIds: string[]; cronIds: string[] }): void {
+    this.cpIntegrations?.retainForAgent(agentId, new Set(desired.integrationIds))
+    this.cpCrons?.retainForAgent(agentId, new Set(desired.cronIds))
+  }
+
+  /** Ownership-aware active state sent during register. Single-agent mode
    * cannot archive its selected root, so it deliberately opts out of replica
    * pruning while still reporting the older assignment/cron/lease state. */
   private cpLocalState(): RegisterReq['localState'] {
@@ -15909,7 +15919,7 @@ export class Daemon {
     const agentReplicas = new Map(
       agents.map((agent) => [
         agent.id,
-        { agentId: agent.id, origin: agent.origin === 'cp' ? ('cp' as const) : ('unknown' as const) }
+        { agentId: agent.id, origin: this.cpAgents?.has(agent.id) ? ('cp' as const) : ('unknown' as const) }
       ])
     )
     // A crash-tombstoned root is intentionally absent from effectiveAgents,
@@ -17564,11 +17574,11 @@ export class Daemon {
         // already admitted on the old connection. Join those per-agent lanes
         // before clearing a drop gate or republishing the whole desired set.
         await Promise.all(desiredAgents.map(({ agentId }) => this.queueAgentLifecycle(agentId, async () => undefined)))
-        // Write the authoritative replicas while any removal tombstone still
-        // excludes them from effectiveAgents. Only complete writes clear the
-        // durable latch and reopen their admission gate.
+        // Install the authoritative replicas in memory while any removal tombstone
+        // still excludes them from effectiveAgents. Only complete applications clear
+        // the durable latch and reopen their admission gate.
         const revivableAgents = desiredAgents.filter(({ agentId }) => !this.agentRemovalPending(agentId))
-        // Only entries the revision fence actually WROTE may clear a tombstone
+        // Only entries the revision fence actually applied may clear a tombstone
         // below: a stale or refused roster entry (organization-secrets-and-
         // variables.md §7) leaves the existing replica untouched, so it is not the
         // complete authority replacement that re-add requires.
@@ -17577,8 +17587,8 @@ export class Daemon {
           (integration) => !this.moveStagedAgents.has(integration.agentId)
         )
         this.cpIntegrations?.converge(desiredIntegrations)
-        // Crons AFTER agents: a cron def lands in its owning agent.json, which the
-        // roster may have just created. drop.crons prunes the stale CP entries.
+        // Crons AFTER agents: the owning in-memory agent must exist first.
+        // drop.crons prunes stale CP entries.
         for (const id of snap.drop.crons) this.cpCrons?.remove(id)
         const desiredCrons = (snap.crons ?? []).filter((cron) => !this.moveStagedAgents.has(cron.agentId))
         this.cpCrons?.converge(desiredCrons)
@@ -17589,7 +17599,7 @@ export class Daemon {
             // old root. Re-add is a complete authority replacement: exact-prune
             // every absent CP dependent and fsync the resulting bundle while the
             // tombstone gate is still closed.
-            this.cpAgents?.exactDependents(agentId, {
+            this.exactCpDependents(agentId, {
               integrationIds: desiredIntegrations
                 .filter((integration) => integration.agentId === agentId)
                 .map((integration) => integration.integrationId),
@@ -17628,13 +17638,13 @@ export class Daemon {
           if (this.moveStagedAgents.has(agentId)) return { ok: false, reason: 'agent is staged for a move' }
           if (this.agentRemovalPending(agentId)) return { ok: false, reason: 'agent is pending removal' }
           if (!this.cpAgents) return { ok: false, reason: 'agent registry is not ready' }
-          // Publish bytes first while a crash tombstone (if present) still keeps
-          // the old/new root outside the effective roster. Clearing it is the
+          // Publish the in-memory spec first while a crash tombstone (if present)
+          // still keeps the root outside the effective roster. Clearing it is the
           // authoritative re-add commit point.
           const replacingDroppedAuthority =
             this.removedAgentTombstones.has(agentId) || this.cpDroppedAgents.has(agentId)
           const applied = this.cpAgents.upsert(agentId, spec)
-          // The revision fence wrote nothing (organization-secrets-and-variables.md
+          // The revision fence applied nothing (organization-secrets-and-variables.md
           // §7). A stale/idempotent snapshot is ACKed as a no-op — a newer revision
           // already went through this same path and cleared any tombstone — while an
           // equal revision carrying different content is a CP invariant violation and
@@ -17646,7 +17656,7 @@ export class Daemon {
           if (replacingDroppedAuthority) {
             // A standalone upsert has no dependent bundle. Scrub every stale CP
             // integration/cron now; subsequent live frames may repopulate them.
-            this.cpAgents.exactDependents(agentId, { integrationIds: [], cronIds: [] })
+            this.exactCpDependents(agentId, { integrationIds: [], cronIds: [] })
           }
           if (replacingDroppedAuthority) this.clearRemovalForReadd(agentId)
           if (this.cpDroppedAgents.delete(agentId) && !this.agentDestructivePending(agentId)) {
@@ -17808,7 +17818,7 @@ export class Daemon {
               return { ok: false, reason: 'agent/activate: cron bundle contains a different agentId' }
             }
             // Apply the complete authoritative bundle synchronously while the staged
-            // agent is still excluded from effectiveAgents. Every write either lands
+            // agent is still excluded from effectiveAgents. Every update either lands
             // before the ACK or throws; retries remain safe behind the same gate.
             this.gitCreds?.clearDenied(agentId)
             // The target enforces the revision fence independently (organization-
@@ -17824,6 +17834,10 @@ export class Daemon {
             }
             for (const integration of activate.integrations) this.cpIntegrations?.upsert(integration)
             for (const cron of activate.crons) this.cpCrons?.upsert(cron)
+            this.exactCpDependents(agentId, {
+              integrationIds: activate.integrations.map((integration) => integration.integrationId),
+              cronIds: activate.crons.map((cron) => cron.cronId)
+            })
             const activation =
               this.cpAgents?.activate(agentId, {
                 integrationIds: activate.integrations.map((integration) => integration.integrationId),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -15922,6 +15922,13 @@ export class Daemon {
         { agentId: agent.id, origin: this.cpAgents?.has(agent.id) ? ('cp' as const) : ('unknown' as const) }
       ])
     )
+    // Marker-only roots stay inactive after a restart, but remain CP-owned
+    // replicas. Report them so an offline deletion can still converge.
+    if (!this.opts.agentName) {
+      for (const agentId of this.cpAgents?.replicaIds() ?? []) {
+        agentReplicas.set(agentId, { agentId, origin: 'cp' })
+      }
+    }
     // A crash-tombstoned root is intentionally absent from effectiveAgents,
     // but the CP must still see the replica ownership so reconnect can reissue
     // its interrupted remove/drop. Never report its stale integrations.

--- a/packages/daemon/test/agents.test.ts
+++ b/packages/daemon/test/agents.test.ts
@@ -152,6 +152,14 @@ describe('discoverAgents (recursive, bounded)', () => {
     writeFileSync(join(dir, 'agent.json'), JSON.stringify(slackAgent('solo')))
     expect(discoverAgents(dir).map((d) => d.agent.id)).toEqual(['solo'])
   })
+
+  it('does not let an unsafe root-level CP marker hide local child agents', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-discover-'))
+    writeFileSync(join(dir, '.cp-agent-id'), 'legacy-bad-root\n')
+    writeAgent(dir, 'bot-a', slackAgent('bot-a'))
+
+    expect(discoverAgents(dir).map((d) => d.agent.id)).toEqual(['bot-a'])
+  })
 })
 
 describe('selectAgent', () => {

--- a/packages/daemon/test/cp-agent-registry-revision.test.ts
+++ b/packages/daemon/test/cp-agent-registry-revision.test.ts
@@ -1,23 +1,14 @@
-/**
- * `CpAgentRegistry` under the monotonic `configRevision` fence
- * (organization-secrets-and-variables.md §7).
- *
- * These are the end-to-end daemon-side guarantees the CP relies on when it emits
- * FULL resolved `env`/`secrets` maps: deliberately reordered delivery must not
- * reinstate a rotated or deleted value, an equal-revision digest mismatch must be
- * refused rather than resolved in either direction, and a stale snapshot must
- * never reach `writeAgentSpec` at all.
- */
-import { describe, it, expect, vi } from 'vitest'
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+/** Monotonic configRevision fencing for the memory-only CP agent registry. */
+import { describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { AgentSpec } from '@agentconnect.md/protocol'
 import { CpAgentRegistry } from '../src/cp/cp-agent-registry.js'
-import { archiveAgent, findAgentFileById } from '../src/agents/write-agent.js'
+import { findAgentFileById } from '../src/agents/write-agent.js'
 
 const AGENT = '11111111-1111-4111-8111-111111111111'
-const deps = { knownRuntimes: ['claude'] }
+const OTHER = '22222222-2222-4222-8222-222222222222'
 
 function spec(overrides: Partial<AgentSpec> = {}): AgentSpec {
   return {
@@ -37,210 +28,135 @@ function fixture() {
   const dir = mkdtempSync(join(tmpdir(), 'ac-cp-registry-'))
   const onChange = vi.fn()
   const warn = vi.fn()
-  const registry = new CpAgentRegistry(dir, deps, onChange, warn)
-  const envOnDisk = (): Record<string, string> => {
-    const file = findAgentFileById(dir, AGENT)
-    if (!file) return {}
-    const raw = JSON.parse(readFileSync(file, 'utf8')) as {
-      runtimeOverrides?: { env?: Array<{ name: string; value: string }> }
-    }
-    return Object.fromEntries((raw.runtimeOverrides?.env ?? []).map((e) => [e.name, e.value]))
-  }
-  const secretsOnDisk = (): Record<string, string> => {
-    const file = findAgentFileById(dir, AGENT)
-    if (!file) return {}
-    const raw = JSON.parse(readFileSync(file, 'utf8')) as {
-      runtimeOverrides?: { secrets?: Array<{ name: string; value: string }> }
-    }
-    return Object.fromEntries((raw.runtimeOverrides?.secrets ?? []).map((e) => [e.name, e.value]))
-  }
-  return {
-    dir,
-    registry,
-    onChange,
-    warn,
-    envOnDisk,
-    secretsOnDisk,
-    cleanup: () => rmSync(dir, { recursive: true, force: true })
-  }
+  const registry = new CpAgentRegistry(dir, { knownRuntimes: ['claude'] }, onChange, warn)
+  const values = (kind: 'env' | 'secrets'): Record<string, string> =>
+    Object.fromEntries((registry.agents()[0]?.runtimeOverrides?.[kind] ?? []).map((entry) => [entry.name, entry.value]))
+  return { dir, registry, onChange, warn, values, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
 }
 
 describe('CpAgentRegistry configRevision fence', () => {
-  it('applies the first snapshot and every strictly greater one', () => {
+  it('applies the first snapshot and every strictly greater one in memory', () => {
     const f = fixture()
     try {
       expect(f.registry.upsert(AGENT, spec({ configRevision: '1', env: { REGION: 'eu' } }))).toBe('apply')
       expect(f.registry.upsert(AGENT, spec({ configRevision: '2', env: { REGION: 'us' } }))).toBe('apply')
-      expect(f.envOnDisk()).toEqual({ REGION: 'us' })
+      expect(f.values('env')).toEqual({ REGION: 'us' })
+      expect(findAgentFileById(f.dir, AGENT)).toBeUndefined()
     } finally {
       f.cleanup()
     }
   })
 
-  it('IGNORES a stale snapshot rather than reinstating the value it removed', () => {
+  it('ignores stale snapshots that would rotate backwards or resurrect a deleted key', () => {
     const f = fixture()
     try {
-      // Rotation: revision 2 replaces the secret. A revision-1 fan-out that
-      // completes afterwards must not put the old credential back.
-      f.registry.upsert(AGENT, spec({ configRevision: '1', secrets: { TOKEN: 'old' } }))
-      f.registry.upsert(AGENT, spec({ configRevision: '2', secrets: { TOKEN: 'rotated' } }))
-      expect(f.registry.upsert(AGENT, spec({ configRevision: '1', secrets: { TOKEN: 'old' } }))).toBe('stale')
-      expect(f.secretsOnDisk()).toEqual({ TOKEN: 'rotated' })
+      f.registry.upsert(AGENT, spec({ configRevision: '1', secrets: { TOKEN: 'old' }, env: { OLD: 'x' } }))
+      f.registry.upsert(AGENT, spec({ configRevision: '2', secrets: { TOKEN: 'rotated' }, env: {} }))
+      expect(
+        f.registry.upsert(AGENT, spec({ configRevision: '1', secrets: { TOKEN: 'old' }, env: { OLD: 'x' } }))
+      ).toBe('stale')
+      expect(f.values('secrets')).toEqual({ TOKEN: 'rotated' })
+      expect(f.values('env')).toEqual({})
     } finally {
       f.cleanup()
     }
   })
 
-  it('IGNORES a stale snapshot that would resurrect a DELETED key', () => {
+  it('treats an identical revision as idempotent and refuses equal-revision conflicts', () => {
     const f = fixture()
     try {
-      f.registry.upsert(AGENT, spec({ configRevision: '4', env: { REMOVED_ME: 'x' } }))
-      f.registry.upsert(AGENT, spec({ configRevision: '5', env: {} }))
-      expect(f.registry.upsert(AGENT, spec({ configRevision: '4', env: { REMOVED_ME: 'x' } }))).toBe('stale')
-      expect(f.envOnDisk()).toEqual({})
-    } finally {
-      f.cleanup()
-    }
-  })
-
-  it('treats a re-delivered identical snapshot as an idempotent no-op', () => {
-    const f = fixture()
-    try {
-      const s = spec({ configRevision: '3', env: { A: '1' } })
-      expect(f.registry.upsert(AGENT, s)).toBe('apply')
-      expect(f.registry.upsert(AGENT, s)).toBe('idempotent')
-      expect(f.envOnDisk()).toEqual({ A: '1' })
-    } finally {
-      f.cleanup()
-    }
-  })
-
-  it('REFUSES an equal revision carrying different content', () => {
-    const f = fixture()
-    try {
-      f.registry.upsert(AGENT, spec({ configRevision: '3', env: { A: '1' } }))
+      const current = spec({ configRevision: '3', env: { A: '1' } })
+      expect(f.registry.upsert(AGENT, current)).toBe('apply')
+      f.onChange.mockClear()
+      expect(f.registry.upsert(AGENT, current)).toBe('idempotent')
       expect(f.registry.upsert(AGENT, spec({ configRevision: '3', env: { A: '2' } }))).toBe('conflict')
-      // Neither value wins by accident — the on-disk replica is untouched.
-      expect(f.envOnDisk()).toEqual({ A: '1' })
+      expect(f.values('env')).toEqual({ A: '1' })
+      expect(f.onChange).not.toHaveBeenCalled()
       expect(f.warn).toHaveBeenCalled()
     } finally {
       f.cleanup()
     }
   })
 
-  it('does not fire onChange (and so does not re-reconcile) for a no-op apply', () => {
-    const f = fixture()
-    try {
-      f.registry.upsert(AGENT, spec({ configRevision: '1' }))
-      f.onChange.mockClear()
-      f.registry.upsert(AGENT, spec({ configRevision: '1' }))
-      f.registry.upsert(AGENT, spec({ configRevision: '0' }))
-      expect(f.onChange).not.toHaveBeenCalled()
-    } finally {
-      f.cleanup()
-    }
-  })
-
-  it('applies an UNFENCED snapshot without clearing the greatest applied revision', () => {
+  it('applies an unfenced snapshot without clearing the greatest revision', () => {
     const f = fixture()
     try {
       f.registry.upsert(AGENT, spec({ configRevision: '9', env: { A: '9' } }))
-      // An older CP omits the field entirely; it still applies.
       expect(f.registry.upsert(AGENT, spec({ env: { A: 'unfenced' } }))).toBe('apply')
-      expect(f.envOnDisk()).toEqual({ A: 'unfenced' })
-      // …and the marker still fences a stale fenced snapshot afterwards.
       expect(f.registry.upsert(AGENT, spec({ configRevision: '8', env: { A: 'stale' } }))).toBe('stale')
-      expect(f.envOnDisk()).toEqual({ A: 'unfenced' })
+      expect(f.values('env')).toEqual({ A: 'unfenced' })
     } finally {
       f.cleanup()
     }
   })
 
-  it('refuses a stale snapshot for a COLD-MOVE ARCHIVED agent instead of un-archiving it', () => {
-    const f = fixture()
-    try {
-      f.registry.upsert(AGENT, spec({ configRevision: '10', secrets: { TOKEN: 'current' } }))
-      expect(archiveAgent(f.dir, AGENT)).toBe('archived')
-      expect(findAgentFileById(f.dir, AGENT)).toBeUndefined()
-      // A fan-out from before the move-away arriving now: writeAgentSpec would
-      // restore the archive as a side effect, so the fence must see the ARCHIVED
-      // marker and refuse both the downgrade and the resurrection.
-      expect(f.registry.upsert(AGENT, spec({ configRevision: '9', secrets: { TOKEN: 'old' } }))).toBe('stale')
-      expect(findAgentFileById(f.dir, AGENT)).toBeUndefined()
-    } finally {
-      f.cleanup()
-    }
-  })
-
-  it('lets an authoritative NEWER bundle restore an archive on move-back', () => {
+  it('keeps a detached agent hidden from stale updates and restores it on a newer bundle', () => {
     const f = fixture()
     try {
       f.registry.upsert(AGENT, spec({ configRevision: '10', secrets: { TOKEN: 'a' } }))
-      archiveAgent(f.dir, AGENT)
+      expect(f.registry.detach(AGENT)).toBe('archived')
+      expect(f.registry.upsert(AGENT, spec({ configRevision: '9', secrets: { TOKEN: 'old' } }))).toBe('stale')
+      expect(f.registry.agents()).toEqual([])
       expect(f.registry.upsert(AGENT, spec({ configRevision: '11', secrets: { TOKEN: 'b' } }))).toBe('apply')
-      expect(findAgentFileById(f.dir, AGENT)).toBeDefined()
-      expect(f.secretsOnDisk()).toEqual({ TOKEN: 'b' })
+      expect(f.values('secrets')).toEqual({ TOKEN: 'b' })
+      expect(findAgentFileById(f.dir, AGENT)).toBeUndefined()
     } finally {
       f.cleanup()
     }
   })
 
-  it('converge returns only the ids it actually rewrote, skipping stale roster entries', () => {
+  it('converge returns only ids actually applied while skipping stale entries', () => {
     const f = fixture()
-    const OTHER = '22222222-2222-4222-8222-222222222222'
     try {
       f.registry.upsert(AGENT, spec({ configRevision: '5', env: { A: 'current' } }))
-      const applied = f.registry.converge([
-        // Stale for AGENT — a reconnect racing a just-committed edit.
-        { agentId: AGENT, ...spec({ configRevision: '4', env: { A: 'stale' } }) },
-        { agentId: OTHER, ...spec({ name: 'other-bot', configRevision: '1' }) }
-      ])
-      expect(applied).toEqual([OTHER])
-      // One bad revision must not fail the handshake, and must not overwrite.
-      expect(f.envOnDisk()).toEqual({ A: 'current' })
-      expect(findAgentFileById(f.dir, OTHER)).toBeDefined()
+      expect(
+        f.registry.converge([
+          { agentId: AGENT, ...spec({ configRevision: '4', env: { A: 'stale' } }) },
+          { agentId: OTHER, ...spec({ name: 'other-bot', configRevision: '1' }) }
+        ])
+      ).toEqual([OTHER])
+      expect(f.values('env')).toEqual({ A: 'current' })
+      expect(
+        f.registry
+          .agents()
+          .map((agent) => agent.id)
+          .sort()
+      ).toEqual([AGENT, OTHER])
     } finally {
       f.cleanup()
     }
   })
 
-  it('keeps the marker beside agent.json, out of the discovery path', () => {
+  it('persists only the secret-free root id marker', () => {
     const f = fixture()
     try {
-      f.registry.upsert(AGENT, spec({ configRevision: '1' }))
-      const file = findAgentFileById(f.dir, AGENT)!
-      expect(existsSync(join(file, '..', '.cp-config-revision.json'))).toBe(true)
+      f.registry.upsert(AGENT, spec({ configRevision: '1', secrets: { TOKEN: 'never-on-disk' } }))
+      const root = f.registry.agents()[0]!.dir
+      expect(readFileSync(join(root, '.cp-agent-id'), 'utf8').trim()).toBe(AGENT)
+      expect(existsSync(join(root, 'agent.json'))).toBe(false)
+      expect(existsSync(join(root, '.cp-config-revision.json'))).toBe(false)
     } finally {
       f.cleanup()
     }
   })
 
-  it('re-applies when the content landed but the marker write was lost (crash between)', () => {
+  it('deletes a hand-authored same-id file on first contact instead of persisting into it', () => {
     const f = fixture()
     try {
-      f.registry.upsert(AGENT, spec({ configRevision: '2', env: { A: '1' } }))
-      const file = findAgentFileById(f.dir, AGENT)!
-      rmSync(join(file, '..', '.cp-config-revision.json'))
-      // Unfenced-by-accident, so the retry applies rather than being dismissed as
-      // already-done — the reason the marker is written AFTER the content.
-      expect(f.registry.upsert(AGENT, spec({ configRevision: '2', env: { A: '2' } }))).toBe('apply')
-      expect(f.envOnDisk()).toEqual({ A: '2' })
-    } finally {
-      f.cleanup()
-    }
-  })
-
-  it('ignores a hand-authored agent root with no marker on first contact', () => {
-    const f = fixture()
-    try {
-      // A local agent the CP has never written: no marker, so nothing to fence.
-      mkdirSync(join(f.dir, 'local-bot'), { recursive: true })
+      const root = join(f.dir, 'local-bot')
+      mkdirSync(root, { recursive: true })
       writeFileSync(
-        join(f.dir, 'local-bot', 'agent.json'),
-        JSON.stringify({ id: AGENT, name: 'local-bot', runtime: 'claude' })
+        join(root, 'agent.json'),
+        JSON.stringify({
+          id: AGENT,
+          name: 'local-bot',
+          runtime: 'claude',
+          workspace: { mode: 'from-scratch', path: './workspace' }
+        })
       )
       expect(f.registry.upsert(AGENT, spec({ configRevision: '1', env: { A: '1' } }))).toBe('apply')
-      expect(f.envOnDisk()).toEqual({ A: '1' })
+      expect(existsSync(join(root, 'agent.json'))).toBe(false)
+      expect(f.values('env')).toEqual({ A: '1' })
     } finally {
       f.cleanup()
     }

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -174,6 +174,24 @@ describe('Daemon CP agent → memory + reconcile', () => {
     await daemon.stop()
   })
 
+  it('reports marker-only CP ownership after restart and accepts an offline remove', async () => {
+    const root = root1()
+    const first = makeDaemon(root).daemon
+    await first.start()
+    await seam(first).applyAgentUpsert({ agentId: 'stale-cp', spec: { name: 'stale-cp' } as AgentSpec })
+    writeFileSync(join(root, 'agents', 'stale-cp', 'workspace-data'), 'keep')
+    await first.stop()
+
+    const restarted = makeDaemon(root).daemon
+    await restarted.start()
+    expect((restarted as any).agents.has('stale-cp')).toBe(false)
+    expect((restarted as any).cpLocalState().agents).toContainEqual({ agentId: 'stale-cp', origin: 'cp' })
+
+    await seam(restarted).applyAgentRemove('stale-cp')
+    expect(existsSync(join(root, 'agents', 'stale-cp'))).toBe(false)
+    await restarted.stop()
+  })
+
   it('detach drains/stops, archives the whole root, invalidates git creds, and activate restores + warms it', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -73,7 +73,7 @@ function makeDaemon(root: string) {
 
 const seam = (d: Daemon) => (d as any).cpConfigApply()
 
-describe('Daemon CP agent → disk + reconcile', () => {
+describe('Daemon CP agent → memory + reconcile', () => {
   it('keeps a corrupt move tombstone fail-closed without poisoning reconnect registration', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
@@ -98,7 +98,7 @@ describe('Daemon CP agent → disk + reconcile', () => {
     await daemon.stop()
   })
 
-  it('writes a CP spec onto the matching file agent.json (merge), keeping file runtime/workspace', async () => {
+  it('deletes the matching agent.json and keeps the effective CP spec in memory', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
     const { daemon } = makeDaemon(root)
@@ -115,7 +115,8 @@ describe('Daemon CP agent → disk + reconcile', () => {
     expect(eff.runtimeOverrides.model).toBe('opus')
     expect(eff.runtime).toBe('claude') // file-supplied, preserved on merge
     expect(eff.workspace.path).toBe(join(root, 'agents', 'bot-a', 'ws')) // path preserved
-    expect(JSON.parse(readFileSync(join(root, 'agents', 'bot-a', 'agent.json'), 'utf8')).origin).toBe('cp')
+    expect(existsSync(join(root, 'agents', 'bot-a', 'agent.json'))).toBe(false)
+    expect(readFileSync(join(root, 'agents', 'bot-a', '.cp-agent-id'), 'utf8').trim()).toBe('bot-a')
     expect((daemon as any).cpLocalState().agents).toEqual([{ agentId: 'bot-a', origin: 'cp' }])
     await daemon.stop()
   })
@@ -152,15 +153,16 @@ describe('Daemon CP agent → disk + reconcile', () => {
     await daemon.stop()
   })
 
-  it('CREATES a new agent.json for a spec with no on-disk base; remove deletes it', async () => {
+  it('creates a runnable memory-only agent for a spec with no on-disk base; remove deletes its data root', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
     const { daemon } = makeDaemon(root)
     await daemon.start()
 
-    // A CP spec for an id with no on-disk base now creates a runnable agent.json.
+    // A CP spec creates only a secret-free data-root marker.
     await seam(daemon).applyAgentUpsert({ agentId: 'ghost', spec: { name: 'ghost' } as AgentSpec })
-    expect(existsSync(join(root, 'agents', 'ghost', 'agent.json'))).toBe(true)
+    expect(existsSync(join(root, 'agents', 'ghost', 'agent.json'))).toBe(false)
+    expect(readFileSync(join(root, 'agents', 'ghost', '.cp-agent-id'), 'utf8').trim()).toBe('ghost')
     expect((daemon as any).agents.has('ghost')).toBe(true) // runnable, not degraded
     expect((daemon as any).cpDegradedScopes()).not.toContain('ghost')
 
@@ -179,6 +181,10 @@ describe('Daemon CP agent → disk + reconcile', () => {
     writeFileSync(join(root, 'agents', 'bot-a', 'memory', 'keep.md'), 'local-memory')
     const { daemon, hosts } = makeDaemon(root)
     await daemon.start()
+    await seam(daemon).applyAgentUpsert({
+      agentId: 'bot-a',
+      spec: { name: 'bot-a', runtime: 'claude' } as AgentSpec
+    })
     await (daemon as any).ensureHostAsync('bot-a')
     const first = hosts.at(-1)!
     const removeCred = vi.spyOn((daemon as any).gitCreds, 'remove')
@@ -190,9 +196,7 @@ describe('Daemon CP agent → disk + reconcile', () => {
     expect((daemon as any).drainingAgents.has('bot-a')).toBe(true)
     expect(existsSync(stagedAgentDir(join(root, 'agents'), 'bot-a'))).toBe(true)
     expect((daemon as any).cpLocalState().stagedAgents).toEqual([{ agentId: 'bot-a', moveId: MOVE_ID }])
-    expect(
-      readFileSync(join(detachedAgentDir(join(root, 'agents'), 'bot-a'), 'agent', 'memory', 'keep.md'), 'utf8')
-    ).toBe('local-memory')
+    expect(readFileSync(join(root, 'agents', 'bot-a', 'memory', 'keep.md'), 'utf8')).toBe('local-memory')
 
     const staleIntegration = {
       integrationId: 'stale-int',
@@ -230,9 +234,7 @@ describe('Daemon CP agent → disk + reconcile', () => {
     })
     await daemon.reconcile()
     expect(existsSync(join(root, 'agents', 'bot-a', 'agent.json'))).toBe(false)
-    expect(
-      readFileSync(join(detachedAgentDir(join(root, 'agents'), 'bot-a'), 'agent', 'agent.json'), 'utf8')
-    ).not.toContain('must-not-return')
+    expect(existsSync(join(root, 'agents', 'bot-a', 'agent.json'))).toBe(false)
 
     const activation = {
       agentId: 'bot-a',
@@ -440,6 +442,10 @@ describe('Daemon CP agent → disk + reconcile', () => {
     writeAgent(root, 'bot-a')
     const { daemon } = makeDaemon(root)
     await daemon.start()
+    await seam(daemon).applyAgentUpsert({
+      agentId: 'bot-a',
+      spec: { name: 'bot-a', runtime: 'claude' } as AgentSpec
+    })
 
     const connection = {
       appToken: 'xapp-only',
@@ -469,7 +475,7 @@ describe('Daemon CP agent → disk + reconcile', () => {
     await new Promise((resolve) => setImmediate(resolve))
     expect(settled).toBe(false)
     expect(connection.stop).not.toHaveBeenCalled()
-    expect(existsSync(join(root, 'agents', 'bot-a', 'agent.json'))).toBe(true)
+    expect(existsSync(join(root, 'agents', 'bot-a', '.cp-agent-id'))).toBe(true)
 
     releaseDispatch()
     await expect(detach).resolves.toEqual({ ok: true })
@@ -677,7 +683,8 @@ describe('Daemon CP agent → disk + reconcile', () => {
     expect(staleHost.stop).toHaveBeenCalledTimes(1)
     expect((daemon as any).agents.has('stale-cp')).toBe(false)
     expect(existsSync(join(root, 'agents', 'stale-cp', 'agent.json'))).toBe(false)
-    expect(existsSync(join(detachedAgentDir(join(root, 'agents'), 'stale-cp'), 'agent', 'agent.json'))).toBe(true)
+    expect(existsSync(join(root, 'agents', 'stale-cp', '.cp-agent-id'))).toBe(true)
+    expect(existsSync(detachedAgentDir(join(root, 'agents'), 'stale-cp'))).toBe(false)
     expect(existsSync(join(root, 'agents', 'deleted-cp'))).toBe(false)
     expect(existsSync(detachedAgentDir(join(root, 'agents'), 'deleted-cp'))).toBe(false)
     expect((daemon as any).drainingAgents.has('deleted-cp')).toBe(true)
@@ -686,19 +693,22 @@ describe('Daemon CP agent → disk + reconcile', () => {
     await daemon.stop()
   })
 
-  it('does not revive archived CP crons after detach, restart, and roster re-add', async () => {
+  it('does not revive memory-only CP crons after detach, restart, and roster re-add', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
-    const file = join(root, 'agents', 'bot-a', 'agent.json')
-    const seeded = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>
-    seeded.crons = [
-      { id: 'stale-cp', schedule: '0 * * * *', trigger: 'stale', enabled: true, origin: 'cp' },
-      { id: 'local', schedule: '0 0 * * *', trigger: 'keep', enabled: true }
-    ]
-    writeFileSync(file, JSON.stringify(seeded))
-
     const first = makeDaemon(root).daemon
     await first.start()
+    await seam(first).applyAgentUpsert({
+      agentId: 'bot-a',
+      spec: { name: 'bot-a', runtime: 'claude' } as AgentSpec
+    })
+    seam(first).upsertCron({
+      cronId: 'stale-cp',
+      agentId: 'bot-a',
+      schedule: '0 * * * *',
+      trigger: 'stale',
+      enabled: true
+    })
     await seam(first).applyReconcileSnapshot({
       routingEpoch: 1,
       assignments: [],
@@ -727,12 +737,8 @@ describe('Daemon CP agent → disk + reconcile', () => {
       drop: { assignments: [], crons: [], agents: [], integrations: [] }
     })
 
-    const restored = findAgentFileById(join(root, 'agents'), 'bot-a')
-    expect(restored).toBe(file)
-    const crons = (JSON.parse(readFileSync(restored!, 'utf8')) as { crons: Array<{ id: string; origin?: string }> })
-      .crons
-    expect(crons.map((cron) => cron.id)).toEqual(['local'])
-    expect(crons[0]?.origin).toBeUndefined()
+    expect(findAgentFileById(join(root, 'agents'), 'bot-a')).toBeUndefined()
+    expect((reborn as any).agents.get('bot-a')?.crons).toEqual([])
     await reborn.stop()
   })
 
@@ -741,6 +747,10 @@ describe('Daemon CP agent → disk + reconcile', () => {
     writeAgent(root, 'bot-a')
     const { daemon } = makeDaemon(root)
     await daemon.start()
+    await seam(daemon).applyAgentUpsert({
+      agentId: 'bot-a',
+      spec: { name: 'bot-a', runtime: 'claude' } as AgentSpec
+    })
     vi.spyOn((daemon as any).cpIntegrations, 'remove').mockImplementationOnce(() => {
       throw new Error('integration drop failed')
     })
@@ -816,14 +826,15 @@ describe('Daemon CP agent → disk + reconcile', () => {
     await new Promise<void>((resolve) => setImmediate(resolve))
 
     expect(applied).toBe(false)
-    expect(existsSync(join(root, 'agents', 'bot-a', 'agent.json'))).toBe(true)
+    expect(existsSync(join(root, 'agents', 'bot-a', '.cp-agent-id'))).toBe(true)
     expect(existsSync(detachedAgentDir(join(root, 'agents'), 'bot-a'))).toBe(false)
 
     releasePreparation()
     await preparing
     await applying
     expect(existsSync(join(root, 'agents', 'bot-a', 'agent.json'))).toBe(false)
-    expect(existsSync(join(detachedAgentDir(join(root, 'agents'), 'bot-a'), 'agent', 'agent.json'))).toBe(true)
+    expect(existsSync(join(root, 'agents', 'bot-a', '.cp-agent-id'))).toBe(true)
+    expect(existsSync(detachedAgentDir(join(root, 'agents'), 'bot-a'))).toBe(false)
     await daemon.reconcile()
     await daemon.stop()
   })
@@ -913,7 +924,7 @@ describe('Daemon CP agent → disk + reconcile', () => {
     await new Promise<void>((resolve) => setImmediate(resolve))
 
     expect(removed).toBe(false)
-    expect(existsSync(join(agentDir, 'agent.json'))).toBe(true)
+    expect(existsSync(join(agentDir, '.cp-agent-id'))).toBe(true)
     expect(existsSync(join(agentDir, 'skills', 'early-publication'))).toBe(true)
     expect(removeAgent).not.toHaveBeenCalled()
 
@@ -970,9 +981,8 @@ describe('Daemon CP agent → disk + reconcile', () => {
     await writing
     await removing
     await expect(upserting).resolves.toEqual({ ok: true })
-    const newRoot = findAgentFileById(join(root, 'agents'), 'bot-a')
-    expect(newRoot).toBe(join(root, 'agents', 'new', 'agent.json'))
-    expect(JSON.parse(readFileSync(newRoot!, 'utf8')).name).toBe('new')
+    expect(findAgentFileById(join(root, 'agents'), 'bot-a')).toBeUndefined()
+    expect(readFileSync(join(root, 'agents', 'new', '.cp-agent-id'), 'utf8').trim()).toBe('bot-a')
     expect((daemon as any).agents.get('bot-a')?.name).toBe('new')
     expect((daemon as any).drainingAgents.has('bot-a')).toBe(false)
     expect((daemon as any).cpDroppedAgents.has('bot-a')).toBe(false)
@@ -1103,7 +1113,8 @@ describe('Daemon CP agent → disk + reconcile', () => {
     expect((daemon as any).drainingAgents.has('bot-a')).toBe(true)
     expect((daemon as any).cpDroppedAgents.has('bot-a')).toBe(true)
     expect((daemon as any).agentLifecycleFailures.get('bot-a')?.owner).toBe('remove')
-    expect(JSON.parse(readFileSync(join(root, 'agents', 'bot-a', 'agent.json'), 'utf8')).name).toBe('old')
+    expect(existsSync(join(root, 'agents', 'bot-a', 'agent.json'))).toBe(false)
+    expect((daemon as any).agents.get('bot-a')?.name).toBe('old')
     // A later destructive retry is the explicit recovery path.
     await expect(seam(daemon).applyAgentRemove('bot-a')).resolves.toBeUndefined()
     await daemon.stop()
@@ -1114,6 +1125,10 @@ describe('Daemon CP agent → disk + reconcile', () => {
     writeAgent(root, 'bot-a')
     const { daemon, hosts } = makeDaemon(root)
     await daemon.start()
+    await seam(daemon).applyAgentUpsert({
+      agentId: 'bot-a',
+      spec: { name: 'bot-a', runtime: 'claude' } as AgentSpec
+    })
     await (daemon as any).ensureHostAsync('bot-a')
     expect(hosts).toHaveLength(1)
     // Make the tombstone parent a regular file so its hashed child cannot be created.
@@ -1157,6 +1172,10 @@ describe('Daemon CP agent → disk + reconcile', () => {
     writeAgent(root, 'bot-a')
     const { daemon, hosts } = makeDaemon(root)
     await daemon.start()
+    await seam(daemon).applyAgentUpsert({
+      agentId: 'bot-a',
+      spec: { name: 'bot-a', runtime: 'claude' } as AgentSpec
+    })
     await (daemon as any).ensureHostAsync('bot-a')
     expect(hosts).toHaveLength(1)
     // Both reserved marker paths are regular files, so neither mirror can
@@ -1274,33 +1293,16 @@ describe('Daemon CP agent → disk + reconcile', () => {
     writeAgent(root, 'bot-a')
     const first = makeDaemon(root).daemon
     await first.start()
+    await seam(first).applyAgentUpsert({
+      agentId: 'bot-a',
+      spec: { name: 'bot-a', runtime: 'claude' } as AgentSpec
+    })
     vi.spyOn(first as any, 'quiesceAgentWorkspaceAuthority').mockRejectedValueOnce(new Error('cleanup failed'))
 
     await expect(seam(first).applyAgentRemove('bot-a')).rejects.toThrow('cleanup failed')
     expect(agentRemovalTombstones(join(root, 'agents'))).toEqual(new Set(['bot-a']))
-    expect(existsSync(join(root, 'agents', 'bot-a', 'agent.json'))).toBe(true)
+    expect(existsSync(join(root, 'agents', 'bot-a', 'agent.json'))).toBe(false)
     await first.stop()
-
-    // Model bytes left by the failed cleanup. Tombstoned localState deliberately
-    // omits these dependents, so authoritative re-add must scrub them as an
-    // exact empty set before reopening the agent.
-    const file = join(root, 'agents', 'bot-a', 'agent.json')
-    const stale = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>
-    stale.integrations = [
-      {
-        id: 'stale-int',
-        origin: 'cp',
-        platform: 'slack',
-        slack: {
-          mode: 'direct',
-          botToken: 'must-not-revive',
-          appToken: 'xapp-stale',
-          bindRules: []
-        }
-      }
-    ]
-    stale.crons = [{ id: 'stale-cron', origin: 'cp', schedule: '0 * * * *', trigger: 'stale', enabled: true }]
-    writeFileSync(file, JSON.stringify(stale))
 
     const reborn = makeDaemon(root).daemon
     await reborn.start()
@@ -1317,10 +1319,9 @@ describe('Daemon CP agent → disk + reconcile', () => {
     expect(agentRemovalTombstones(join(root, 'agents'))).toEqual(new Set())
     expect((reborn as any).agents.has('bot-a')).toBe(true)
     expect((reborn as any).drainingAgents.has('bot-a')).toBe(false)
-    const revived = JSON.parse(readFileSync(file, 'utf8')) as { integrations?: unknown[]; crons?: unknown[] }
-    expect(revived.integrations).toEqual([])
-    expect(revived.crons).toEqual([])
-    expect(readFileSync(file, 'utf8')).not.toContain('must-not-revive')
+    expect((reborn as any).agents.get('bot-a')?.integrations).toEqual([])
+    expect((reborn as any).agents.get('bot-a')?.crons).toEqual([])
+    expect(existsSync(join(root, 'agents', 'bot-a', 'agent.json'))).toBe(false)
     await reborn.stop()
   })
 
@@ -1389,6 +1390,10 @@ describe('Daemon CP agent → disk + reconcile', () => {
     writeAgent(root, 'bot-a')
     const { daemon } = makeDaemon(root)
     await daemon.start()
+    await seam(daemon).applyAgentUpsert({
+      agentId: 'bot-a',
+      spec: { name: 'bot-a', runtime: 'claude' } as AgentSpec
+    })
     vi.spyOn(daemon as any, 'stopAgent')
       .mockRejectedValueOnce(new Error('stop failed'))
       .mockResolvedValue(undefined)

--- a/packages/daemon/test/cp/cp-agent-registry.test.ts
+++ b/packages/daemon/test/cp/cp-agent-registry.test.ts
@@ -1,294 +1,131 @@
-import { describe, it, expect, vi } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { CpAgentRegistry } from '../../src/cp/cp-agent-registry.js'
 import type { AgentSpec } from '@agentconnect.md/protocol'
+import { CpAgentRegistry } from '../../src/cp/cp-agent-registry.js'
 
 const A1 = '11111111-1111-4111-8111-111111111111'
 const A2 = '22222222-2222-4222-8222-222222222222'
-const spec = (over: Partial<AgentSpec> = {}): AgentSpec => ({ name: 'helper', ...over })
+const spec = (over: Partial<AgentSpec> = {}): AgentSpec => ({ name: 'helper', runtime: 'claude', ...over })
 
-function agentsDir(): string {
-  return mkdtempSync(join(tmpdir(), 'ac-cpreg-'))
-}
-function readAgent(dir: string, id: string): Record<string, unknown> {
-  return JSON.parse(readFileSync(join(dir, id, 'agent.json'), 'utf8'))
-}
-function makeReg(dir: string) {
+function makeReg(dir = mkdtempSync(join(tmpdir(), 'ac-cpreg-'))) {
   const onChange = vi.fn()
   const reg = new CpAgentRegistry(dir, { knownRuntimes: ['claude'], warn: vi.fn() }, onChange)
-  return { reg, onChange }
+  return { dir, reg, onChange }
 }
 
-describe('CpAgentRegistry (filesystem-backed)', () => {
-  it('upsert CREATES a new agent.json when none exists and fires onChange', () => {
-    const dir = agentsDir()
-    const { reg, onChange } = makeReg(dir)
+function writeLocal(dir: string, folder: string, id: string, extra: Record<string, unknown> = {}): string {
+  const root = join(dir, folder)
+  mkdirSync(root, { recursive: true })
+  const file = join(root, 'agent.json')
+  writeFileSync(
+    file,
+    JSON.stringify({
+      id,
+      name: folder,
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: './workspace' },
+      ...extra
+    })
+  )
+  return file
+}
+
+describe('CpAgentRegistry (memory-only CP specs)', () => {
+  it('creates an effective agent without writing agent.json', () => {
+    const { dir, reg, onChange } = makeReg()
     reg.upsert(A1, spec({ description: 'be terse', model: 'opus' }))
-    const a = readAgent(dir, 'helper') // fresh dir named by the agent's slug (spec.name), not its id
-    expect(a.id).toBe(A1)
-    expect(a.name).toBe('helper')
-    expect(a.description).toBe('be terse')
-    expect(a.runtime).toBe('claude') // default from knownRuntimes
-    expect((a.runtimeOverrides as any).model).toBe('opus')
-    expect((a.workspace as any).mode).toBe('from-scratch')
-    expect((a.workspace as any).path).toBe(join(dir, 'helper', 'workspace')) // daemon-generated under the slug dir
-    expect(onChange).toHaveBeenCalledTimes(1)
-  })
 
-  it('upsert MERGES CP-owned fields into an existing agent.json, preserving local keys + relative path', () => {
-    const dir = agentsDir()
-    mkdirSync(join(dir, A1), { recursive: true })
-    writeFileSync(
-      join(dir, A1, 'agent.json'),
-      JSON.stringify({
-        id: A1,
-        name: 'local',
-        status: 'active',
-        runtime: 'codex',
-        workspace: { mode: 'from-scratch', path: './ws', pullOnNewSession: false, skills: ['git'] },
-        integrations: [{ id: 'i1', platform: 'slack' }],
-        runtimeOverrides: { model: 'old', env: [{ name: 'OLD', value: 'old-value' }] },
-        permissions: { policy: 'auto', autoApprove: ['fs'] }
-      })
-    )
-    const { reg } = makeReg(dir)
-    reg.upsert(A1, spec({ name: 'cp-name', model: 'opus', env: { NEW: 'v' } }))
-    const a = readAgent(dir, A1)
-    // CP-owned merged
-    expect(a.name).toBe('cp-name')
-    expect((a.runtimeOverrides as any).model).toBe('opus')
-    expect((a.runtimeOverrides as any).env).toEqual([{ name: 'NEW', value: 'v' }])
-    // locally-owned preserved untouched
-    expect(a.runtime).toBe('codex')
-    expect(a.status).toBe('active')
-    expect(a.integrations).toEqual([{ id: 'i1', platform: 'slack' }])
-    expect(a.permissions).toEqual({ policy: 'auto', autoApprove: ['fs'] })
-    // path stays relative (no absolute rewrite); pullOnNewSession + skills preserved
-    expect((a.workspace as any).path).toBe('./ws')
-    expect((a.workspace as any).pullOnNewSession).toBe(false)
-    expect((a.workspace as any).skills).toEqual(['git'])
-  })
-
-  it('upsert maps output and chat runtime controls, leaving them alone when the spec omits them', () => {
-    const dir = agentsDir()
-    mkdirSync(join(dir, A1), { recursive: true })
-    writeFileSync(
-      join(dir, A1, 'agent.json'),
-      JSON.stringify({
-        id: A1,
-        name: 'local',
-        runtime: 'claude',
-        workspace: { mode: 'from-scratch', path: './ws' },
-        output: { mode: 'high', showFooter: true, showStatusBar: true },
-        fastMode: true,
-        allowRuntimeChangesInChat: true
-      })
-    )
-    const { reg } = makeReg(dir)
-    // spec without the fields: hand-authored values survive the merge
-    reg.upsert(A1, spec({ model: 'opus' }))
-    let a = readAgent(dir, A1)
-    expect(a.output).toEqual({ mode: 'high', showFooter: true, showStatusBar: true })
-    expect(a.fastMode).toBe(true)
-    expect(a.allowRuntimeChangesInChat).toBe(true)
-    // spec with the fields: CP-owned now, overwritten
-    reg.upsert(
-      A1,
-      spec({
-        outputMode: 'medium',
-        showFooter: false,
-        showStatusBar: false,
-        fastMode: false,
-        allowRuntimeChangesInChat: false
-      })
-    )
-    a = readAgent(dir, A1)
-    expect(a.output).toEqual({ mode: 'medium', showFooter: false, showStatusBar: false })
-    expect(a.fastMode).toBe(false)
-    expect(a.allowRuntimeChangesInChat).toBe(false)
-  })
-
-  it('upsert maps mcpServers onto agent.json (CP-owned; replace including the clear)', () => {
-    const dir = agentsDir()
-    const { reg } = makeReg(dir)
-    reg.upsert(A1, spec({ mcpServers: ['files', 'search'] }))
-    expect(readAgent(dir, 'helper').mcpServers).toEqual(['files', 'search'])
-    // a later spec with an empty list clears the enablement (disable-all round-trips)
-    reg.upsert(A1, spec({ mcpServers: [] }))
-    expect(readAgent(dir, 'helper').mcpServers).toEqual([])
-  })
-
-  it('upsert replaces both directions of agent visibility, including cleared allow-lists', () => {
-    const dir = agentsDir()
-    const { reg } = makeReg(dir)
-    reg.upsert(
-      A1,
-      spec({
-        callPolicy: 'selected',
-        allowedCallerAgentIds: [A2],
-        outboundPolicy: 'selected',
-        allowedTargetAgentIds: [A2]
-      })
-    )
-    expect(readAgent(dir, 'helper')).toMatchObject({
-      callPolicy: 'selected',
-      allowedCallerAgentIds: [A2],
-      outboundPolicy: 'selected',
-      allowedTargetAgentIds: [A2]
+    expect(reg.agents()).toHaveLength(1)
+    expect(reg.agents()[0]).toMatchObject({
+      id: A1,
+      name: 'helper',
+      origin: 'cp',
+      description: 'be terse',
+      runtimeOverrides: { model: 'opus' }
     })
-
-    reg.upsert(
-      A1,
-      spec({ callPolicy: 'all', allowedCallerAgentIds: [], outboundPolicy: 'all', allowedTargetAgentIds: [] })
-    )
-    expect(readAgent(dir, 'helper')).toMatchObject({
-      callPolicy: 'all',
-      allowedCallerAgentIds: [],
-      outboundPolicy: 'all',
-      allowedTargetAgentIds: []
-    })
+    expect(existsSync(join(dir, 'helper', 'agent.json'))).toBe(false)
+    expect(readFileSync(join(dir, 'helper', '.cp-agent-id'), 'utf8').trim()).toBe(A1)
+    expect(onChange).toHaveBeenCalledOnce()
   })
 
-  it('preserves the complete outbound half when a legacy spec omits it', () => {
-    const dir = agentsDir()
-    const { reg } = makeReg(dir)
-    reg.upsert(A1, spec({ outboundPolicy: 'selected', allowedTargetAgentIds: [A2] }))
+  it('deletes only the same-id agent.json and preserves every other local file', () => {
+    const { dir, reg } = makeReg()
+    const matching = writeLocal(dir, 'custom', A1, { description: 'legacy' })
+    const duplicate = writeLocal(dir, 'duplicate', A1)
+    const other = writeLocal(dir, 'user-agent', A2, { origin: 'cp' })
+    writeFileSync(join(dir, 'custom', 'keep.txt'), 'workspace data')
 
-    reg.upsert(A1, spec({ callPolicy: 'all', allowedCallerAgentIds: [] }))
+    reg.upsert(A1, spec({ description: 'current' }))
 
-    expect(readAgent(dir, 'helper')).toMatchObject({
-      outboundPolicy: 'selected',
-      allowedTargetAgentIds: [A2]
-    })
+    expect(existsSync(matching)).toBe(false)
+    expect(existsSync(duplicate)).toBe(false)
+    expect(readFileSync(join(dir, 'custom', 'keep.txt'), 'utf8')).toBe('workspace data')
+    expect(existsSync(other)).toBe(true)
+    expect(JSON.parse(readFileSync(other, 'utf8')).id).toBe(A2)
+    expect(reg.agents()[0]).toMatchObject({ id: A1, description: 'current', dir: join(dir, 'custom') })
   })
 
-  it('upsert workspace github maps mode + git fields but PRESERVES the existing path on update', () => {
-    const dir = agentsDir()
-    mkdirSync(join(dir, A1), { recursive: true })
-    writeFileSync(
-      join(dir, A1, 'agent.json'),
-      JSON.stringify({
-        id: A1,
-        name: 'local',
-        runtime: 'claude',
-        workspace: { mode: 'from-scratch', path: './keep-me' }
-      })
-    )
-    const { reg } = makeReg(dir)
-    reg.upsert(A1, spec({ workspace: { mode: 'github', gitRepo: 'github.com/acme/x', branch: 'dev' } }))
-    const ws = readAgent(dir, A1).workspace as any
-    expect(ws.mode).toBe('git-repo')
-    // shorthand from a pre-normalization CP row is persisted as the full address
-    expect(ws.gitRepo).toBe('https://github.com/acme/x')
-    expect(ws.gitBranch).toBe('dev')
-    expect(ws.path).toBe('./keep-me') // never overwritten on update
+  it('keeps CP values in memory across partial updates and never recreates agent.json', () => {
+    const { dir, reg } = makeReg()
+    reg.upsert(A1, spec({ model: 'opus', outputMode: 'high', allowedCallerAgentIds: [A2] }))
+    reg.upsert(A1, spec({ model: null, showFooter: false }))
+
+    const agent = reg.agents()[0]!
+    expect(agent.runtimeOverrides?.model).toBeUndefined()
+    expect(agent.output).toEqual({ mode: 'high', showFooter: false, showStatusBar: true })
+    expect(agent.allowedCallerAgentIds).toEqual([A2])
+    expect(existsSync(join(agent.dir, 'agent.json'))).toBe(false)
   })
 
-  it('persists a valid custom origin for daemon-local authorization at execution time', () => {
-    const dir = agentsDir()
-    const { reg } = makeReg(dir)
+  it('reuses the secret-free root marker after a registry restart', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-cpreg-'))
+    const first = makeReg(dir).reg
+    first.upsert(A1, spec())
+    writeFileSync(join(dir, 'helper', 'workspace-data'), 'keep')
 
-    reg.upsert(
-      A1,
-      spec({
-        workspace: { mode: 'github', gitRepo: 'https://git.example/acme/repo.git', branch: 'main' }
-      })
-    )
-
-    expect((readAgent(dir, 'helper').workspace as any).gitRepo).toBe('https://git.example/acme/repo.git')
+    const second = makeReg(dir).reg
+    second.upsert(A1, spec({ name: 'renamed' }))
+    expect(second.agents()[0]?.dir).toBe(join(dir, 'helper'))
+    expect(readFileSync(join(dir, 'helper', 'workspace-data'), 'utf8')).toBe('keep')
+    expect(existsSync(join(dir, 'helper', 'agent.json'))).toBe(false)
   })
 
-  it('upsert MERGES by internal id into a custom-named dir (dir name != id), not a duplicate at <dir>/<id>', () => {
-    const dir = agentsDir()
-    // hand-authored agent: id A1 but living under a differently-named folder
-    mkdirSync(join(dir, 'my-cool-bot'), { recursive: true })
-    writeFileSync(
-      join(dir, 'my-cool-bot', 'agent.json'),
-      JSON.stringify({ id: A1, name: 'local', runtime: 'codex', workspace: { mode: 'from-scratch', path: './ws' } })
-    )
-    const { reg } = makeReg(dir)
-    reg.upsert(A1, spec({ name: 'cp-name', model: 'opus' }))
-    // merged in place — NO duplicate created at <dir>/<A1>/agent.json
-    expect(existsSync(join(dir, A1, 'agent.json'))).toBe(false)
-    const a = JSON.parse(readFileSync(join(dir, 'my-cool-bot', 'agent.json'), 'utf8'))
-    expect(a.name).toBe('cp-name')
-    expect((a.runtimeOverrides as any).model).toBe('opus')
-    expect(a.runtime).toBe('codex') // local key preserved
+  it('fences stale/equal revisions in memory', () => {
+    const { reg } = makeReg()
+    expect(reg.upsert(A1, spec({ configRevision: '2', description: 'new' }))).toBe('apply')
+    expect(reg.upsert(A1, spec({ configRevision: '1', description: 'old' }))).toBe('stale')
+    expect(reg.upsert(A1, spec({ configRevision: '2', description: 'new' }))).toBe('idempotent')
+    expect(reg.upsert(A1, spec({ configRevision: '2', description: 'different' }))).toBe('conflict')
+    expect(reg.agents()[0]?.description).toBe('new')
   })
 
-  it('remove deletes by internal id even when the dir name != id', () => {
-    const dir = agentsDir()
-    mkdirSync(join(dir, 'my-cool-bot'), { recursive: true })
-    writeFileSync(
-      join(dir, 'my-cool-bot', 'agent.json'),
-      JSON.stringify({ id: A1, name: 'local', runtime: 'codex', workspace: { mode: 'from-scratch', path: './ws' } })
-    )
-    const { reg } = makeReg(dir)
-    reg.remove(A1)
-    expect(existsSync(join(dir, 'my-cool-bot'))).toBe(false)
-  })
-
-  it('remove deletes the agent dir unconditionally and fires onChange', () => {
-    const dir = agentsDir()
-    const { reg, onChange } = makeReg(dir)
+  it('detach/activate changes only in-memory visibility and remove deletes its owned data root', () => {
+    const { dir, reg } = makeReg()
     reg.upsert(A1, spec())
-    expect(existsSync(join(dir, 'helper', 'agent.json'))).toBe(true) // created under the slug dir
-    onChange.mockClear()
+    expect(reg.detach(A1)).toBe('archived')
+    expect(reg.agents()).toEqual([])
+    expect(existsSync(join(dir, 'helper'))).toBe(true)
+    expect(reg.activate(A1, { integrationIds: [], cronIds: [] })).toBe('restored')
+    expect(reg.agents()).toHaveLength(1)
     reg.remove(A1)
     expect(existsSync(join(dir, 'helper'))).toBe(false)
-    expect(onChange).toHaveBeenCalledTimes(1)
-    // removing an absent agent is a no-op (still fires onChange; force:true tolerates missing)
-    reg.remove(A2)
-    expect(existsSync(join(dir, A2))).toBe(false)
   })
 
-  it('detach archives non-destructively and activate restores the original custom path', () => {
-    const dir = agentsDir()
-    const custom = join(dir, 'nested', 'custom-agent')
-    mkdirSync(join(custom, 'workspace'), { recursive: true })
-    writeFileSync(
-      join(custom, 'agent.json'),
-      JSON.stringify({
-        id: A1,
-        name: 'local',
-        status: 'active',
-        runtime: 'claude',
-        workspace: { mode: 'from-scratch', path: './workspace' }
-      })
-    )
-    writeFileSync(join(custom, 'workspace', 'keep.txt'), 'keep')
-    const { reg, onChange } = makeReg(dir)
-
-    expect(reg.detach(A1)).toBe('archived')
-    expect(reg.detach(A1)).toBe('already-detached')
-    expect(existsSync(custom)).toBe(false)
-    expect(onChange).toHaveBeenCalledTimes(2)
-
-    expect(reg.activate(A1, { integrationIds: [], cronIds: [] })).toBe('restored')
-    expect(reg.activate(A1, { integrationIds: [], cronIds: [] })).toBe('already-active')
-    expect(readFileSync(join(custom, 'workspace', 'keep.txt'), 'utf8')).toBe('keep')
-    // already-active is a no-op; only the restore fires another reconcile.
-    expect(onChange).toHaveBeenCalledTimes(3)
-  })
-
-  it('reports missing detach/activate without firing a reconcile', () => {
-    const dir = agentsDir()
-    const { reg, onChange } = makeReg(dir)
-    expect(reg.detach(A1)).toBe('missing')
-    expect(reg.activate(A1, { integrationIds: [], cronIds: [] })).toBe('missing')
-    expect(onChange).not.toHaveBeenCalled()
-  })
-
-  it('converge create-or-merges each roster entry and does NOT prune agents absent from the roster', () => {
-    const dir = agentsDir()
-    const { reg } = makeReg(dir)
-    reg.upsert(A1, spec({ model: 'old' })) // present on disk (slug dir "helper"), absent from the next roster
-    reg.converge([{ agentId: A2, name: 'assistant', model: 'opus' }]) // distinct slug — names are unique per org
-    // A2 created from roster under its own slug dir
-    expect((readAgent(dir, 'assistant').runtimeOverrides as any).model).toBe('opus')
-    // A1 NOT pruned (deletion only via agent/remove)
-    expect(existsSync(join(dir, 'helper', 'agent.json'))).toBe(true)
+  it('converge upserts roster entries without pruning unrelated local agent.json files', () => {
+    const { dir, reg } = makeReg()
+    const local = writeLocal(dir, 'local-only', 'local-only')
+    reg.converge([
+      { agentId: A1, ...spec() },
+      { agentId: A2, ...spec({ name: 'other' }) }
+    ])
+    expect(
+      reg
+        .agents()
+        .map((agent) => agent.id)
+        .sort()
+    ).toEqual([A1, A2])
+    expect(existsSync(local)).toBe(true)
   })
 })

--- a/packages/daemon/test/cp/cp-agent-registry.test.ts
+++ b/packages/daemon/test/cp/cp-agent-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { AgentSpec } from '@agentconnect.md/protocol'
@@ -67,6 +68,45 @@ describe('CpAgentRegistry (memory-only CP specs)', () => {
     expect(reg.agents()[0]).toMatchObject({ id: A1, description: 'current', dir: join(dir, 'custom') })
   })
 
+  it('never claims or removes agentsDir when the matching agent.json is at its root', () => {
+    const { dir, reg } = makeReg()
+    const matching = join(dir, 'agent.json')
+    writeFileSync(
+      matching,
+      JSON.stringify({
+        id: A1,
+        name: 'root-local',
+        runtime: 'claude',
+        workspace: { mode: 'from-scratch', path: './workspace' }
+      })
+    )
+    const other = writeLocal(dir, 'other-local', A2)
+
+    reg.upsert(A1, spec())
+
+    expect(existsSync(matching)).toBe(false)
+    expect(existsSync(join(dir, '.cp-agent-id'))).toBe(false)
+    expect(reg.agents()[0]?.dir).toBe(join(dir, 'helper'))
+    reg.remove(A1)
+    expect(existsSync(dir)).toBe(true)
+    expect(existsSync(other)).toBe(true)
+  })
+
+  it('allocates a new child when both the preferred and fallback roots are occupied', () => {
+    const { dir, reg } = makeReg()
+    const fallback = join(dir, `agent-${createHash('sha256').update(A1).digest('hex').slice(0, 32)}`)
+    mkdirSync(join(dir, 'helper'), { recursive: true })
+    mkdirSync(fallback, { recursive: true })
+    writeFileSync(join(dir, 'helper', 'keep'), 'preferred')
+    writeFileSync(join(fallback, 'keep'), 'fallback')
+
+    reg.upsert(A1, spec())
+
+    expect(reg.agents()[0]?.dir).toBe(`${fallback}-2`)
+    expect(readFileSync(join(dir, 'helper', 'keep'), 'utf8')).toBe('preferred')
+    expect(readFileSync(join(fallback, 'keep'), 'utf8')).toBe('fallback')
+  })
+
   it('keeps CP values in memory across partial updates and never recreates agent.json', () => {
     const { dir, reg } = makeReg()
     reg.upsert(A1, spec({ model: 'opus', outputMode: 'high', allowedCallerAgentIds: [A2] }))
@@ -111,6 +151,34 @@ describe('CpAgentRegistry (memory-only CP specs)', () => {
     expect(reg.agents()).toHaveLength(1)
     reg.remove(A1)
     expect(existsSync(join(dir, 'helper'))).toBe(false)
+  })
+
+  it('keeps removal retryable when deleting the owned root fails', () => {
+    const { dir, reg } = makeReg()
+    reg.upsert(A1, spec())
+    const root = join(dir, 'helper')
+    writeFileSync(join(root, 'keep'), 'data')
+    chmodSync(root, 0o500)
+    try {
+      expect(() => reg.remove(A1)).toThrow()
+      expect(reg.agents()).toHaveLength(1)
+    } finally {
+      chmodSync(root, 0o700)
+    }
+    expect(() => reg.remove(A1)).not.toThrow()
+    expect(existsSync(root)).toBe(false)
+  })
+
+  it('inventories and removes a marker-only root after registry restart', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-cpreg-'))
+    makeReg(dir).reg.upsert(A1, spec())
+
+    const restarted = makeReg(dir).reg
+    expect(restarted.agents()).toEqual([])
+    expect(restarted.replicaIds()).toEqual([A1])
+    restarted.remove(A1)
+    expect(existsSync(join(dir, 'helper'))).toBe(false)
+    expect(restarted.replicaIds()).toEqual([])
   })
 
   it('converge upserts roster entries without pruning unrelated local agent.json files', () => {

--- a/packages/daemon/test/cp/cp-cron.test.ts
+++ b/packages/daemon/test/cp/cp-cron.test.ts
@@ -1,161 +1,51 @@
-import { describe, it, expect, vi } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
+import { describe, expect, it, vi } from 'vitest'
+import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { CronUpsert } from '@agentconnect.md/protocol'
 import { CpCronRegistry } from '../../src/cp/cp-cron.js'
 
 const A1 = '11111111-1111-4111-8111-111111111111'
-const C1 = '66666666-6666-4666-8666-666666666666'
-const C2 = '77777777-7777-4777-8777-777777777777'
-
-const cron = (over: Partial<CronUpsert> = {}): CronUpsert => ({
-  cronId: C1,
-  agentId: A1,
+const A2 = '22222222-2222-4222-8222-222222222222'
+const cron = (id: string, agentId = A1, over: Partial<CronUpsert> = {}): CronUpsert => ({
+  cronId: id,
+  agentId,
   schedule: '0 9 * * *',
   timezone: 'Asia/Singapore',
-  target: { platform: 'slack', channel: 'C0TEAM' },
   trigger: 'post the daily report',
   enabled: true,
   ...over
 })
 
-function agentsDir(): string {
-  return mkdtempSync(join(tmpdir(), 'ac-cpcronreg-'))
-}
-function writeAgentFile(dir: string, folder: string, raw: Record<string, unknown>) {
-  mkdirSync(join(dir, folder), { recursive: true })
-  writeFileSync(join(dir, folder, 'agent.json'), JSON.stringify(raw))
-}
-function readAgent(dir: string, folder: string): Record<string, unknown> {
-  return JSON.parse(readFileSync(join(dir, folder, 'agent.json'), 'utf8'))
-}
-function makeReg(dir: string) {
+function makeReg() {
   const onChange = vi.fn()
-  const warn = vi.fn()
-  const reg = new CpCronRegistry(dir, { warn }, onChange)
-  return { reg, onChange, warn }
+  const reg = new CpCronRegistry(mkdtempSync(join(tmpdir(), 'ac-cpcron-')), { warn: vi.fn() }, onChange)
+  return { reg, onChange }
 }
 
-const AGENT_RAW = {
-  id: A1,
-  name: 'helper',
-  runtime: 'claude',
-  workspace: { mode: 'from-scratch', path: './ws' }
-}
-
-describe('CpCronRegistry (agent.json-backed)', () => {
-  it('upsert APPENDS the cron to the owning agent.json (origin:"cp") and fires onChange', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', AGENT_RAW)
-    const { reg, onChange } = makeReg(dir)
-    reg.upsert(cron())
-    const a = readAgent(dir, 'helper')
-    expect(a.crons).toEqual([
-      {
-        id: C1,
-        schedule: '0 9 * * *',
-        timezone: 'Asia/Singapore',
-        target: { platform: 'slack', channel: 'C0TEAM' },
-        trigger: 'post the daily report',
-        enabled: true,
-        origin: 'cp'
-      }
+describe('CpCronRegistry (memory-only)', () => {
+  it('upserts/replaces a cron without writing an owning agent.json', () => {
+    const { reg } = makeReg()
+    reg.upsert(cron('c1'))
+    reg.upsert(cron('c1', A1, { enabled: false }))
+    expect(reg.forAgent(A1)).toEqual([
+      expect.objectContaining({ id: 'c1', origin: 'cp', enabled: false, timezone: 'Asia/Singapore' })
     ])
-    expect(onChange).toHaveBeenCalledTimes(1)
   })
 
-  it('a target-less def persists without target (headless) and re-applying identically skips the write', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', AGENT_RAW)
-    const { reg, onChange } = makeReg(dir)
-    const def = cron({ target: undefined })
-    reg.upsert(def)
-    expect((readAgent(dir, 'helper').crons as any[])[0].target).toBeUndefined()
-    expect(onChange).toHaveBeenCalledTimes(1)
-    reg.upsert(def) // identical re-apply (every register/ok converge re-sends)
-    reg.converge([def])
-    expect(onChange).toHaveBeenCalledTimes(1) // no watcher churn
+  it('preserves platform/integration targets in the in-memory definition', () => {
+    const { reg } = makeReg()
+    reg.upsert(cron('c1', A1, { target: { platform: 'discord', channel: 'C1', integrationId: 'i1' } }))
+    expect(reg.forAgent(A1)[0]?.target).toEqual({ platform: 'discord', channel: 'C1', integrationId: 'i1' })
   })
 
-  it('a target with integrationId persists it — the anchor posts through that integration', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', AGENT_RAW)
-    const { reg } = makeReg(dir)
-    const I1 = '88888888-8888-4888-8888-888888888888'
-    reg.upsert(cron({ target: { platform: 'slack', channel: 'C0TEAM', integrationId: I1 } }))
-    expect((readAgent(dir, 'helper').crons as any[])[0].target).toEqual({
-      platform: 'slack',
-      channel: 'C0TEAM',
-      integrationId: I1
-    })
-  })
-
-  it('upsert REPLACES the same-id entry and preserves hand-authored crons', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', {
-      ...AGENT_RAW,
-      crons: [
-        { id: C1, schedule: '0 0 * * *', trigger: 'old', origin: 'cp' },
-        { id: 'hand-written', schedule: '*/5 * * * *', trigger: 'user cron' }
-      ]
-    })
-    const { reg } = makeReg(dir)
-    reg.upsert(cron({ enabled: false }))
-    const list = readAgent(dir, 'helper').crons as any[]
-    expect(list).toHaveLength(2)
-    expect(list[0]).toMatchObject({ id: C1, enabled: false, origin: 'cp' })
-    expect(list[1]).toEqual({ id: 'hand-written', schedule: '*/5 * * * *', trigger: 'user cron' })
-  })
-
-  it('upsert never overwrites a hand-authored cron sharing the id — warns and leaves it', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', {
-      ...AGENT_RAW,
-      crons: [{ id: C1, schedule: '*/5 * * * *', trigger: 'user cron' }] // NO origin
-    })
-    const { reg, onChange, warn } = makeReg(dir)
-    reg.upsert(cron()) // same id, origin:"cp"
-    const list = readAgent(dir, 'helper').crons as any[]
-    expect(list).toEqual([{ id: C1, schedule: '*/5 * * * *', trigger: 'user cron' }]) // untouched
-    expect(warn).toHaveBeenCalledOnce()
-    expect(onChange).not.toHaveBeenCalled()
-  })
-
-  it('remove splices out only the origin:"cp" entry with that id', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', {
-      ...AGENT_RAW,
-      crons: [
-        { id: C1, schedule: '0 0 * * *', trigger: 't', origin: 'cp' },
-        { id: C2, schedule: '0 1 * * *', trigger: 'user-owned same-shape' } // NO origin — never CP-deleted
-      ]
-    })
-    const { reg, onChange } = makeReg(dir)
-    reg.remove(C1)
-    expect((readAgent(dir, 'helper').crons as any[]).map((c) => c.id)).toEqual([C2])
-    reg.remove(C2) // user entry: not eligible
-    expect((readAgent(dir, 'helper').crons as any[]).map((c) => c.id)).toEqual([C2])
-    expect(onChange).toHaveBeenCalledTimes(1)
-  })
-
-  it('an orphan cron (agent not on disk) warns and is not persisted', () => {
-    const dir = agentsDir()
-    const { reg, onChange, warn } = makeReg(dir)
-    reg.upsert(cron())
-    expect(warn).toHaveBeenCalledOnce()
-    expect(onChange).not.toHaveBeenCalled()
-  })
-
-  it('converge upserts each entry across owning agents in one onChange', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', AGENT_RAW)
-    const A2 = '22222222-2222-4222-8222-222222222222'
-    writeAgentFile(dir, 'other', { ...AGENT_RAW, id: A2, name: 'other' })
-    const { reg, onChange } = makeReg(dir)
-    reg.converge([cron(), cron({ cronId: C2, agentId: A2, target: undefined })])
-    expect((readAgent(dir, 'helper').crons as any[]).map((c) => c.id)).toEqual([C1])
-    expect((readAgent(dir, 'other').crons as any[]).map((c) => c.id)).toEqual([C2])
-    expect(onChange).toHaveBeenCalledTimes(1)
+  it('converges, removes, and exact-prunes independently per agent', () => {
+    const { reg } = makeReg()
+    reg.converge([cron('c1'), cron('c2'), cron('c3', A2)])
+    reg.retainForAgent(A1, new Set(['c2']))
+    expect(reg.forAgent(A1).map((item) => item.id)).toEqual(['c2'])
+    expect(reg.forAgent(A2).map((item) => item.id)).toEqual(['c3'])
+    reg.remove('c3')
+    expect(reg.forAgent(A2)).toEqual([])
   })
 })

--- a/packages/daemon/test/cp/cp-integration-registry.test.ts
+++ b/packages/daemon/test/cp/cp-integration-registry.test.ts
@@ -1,144 +1,49 @@
-import { describe, it, expect, vi } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
+import { describe, expect, it, vi } from 'vitest'
+import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { CpIntegrationRegistry } from '../../src/cp/cp-integration-registry.js'
 import type { IntegrationSpec } from '@agentconnect.md/protocol'
+import { CpIntegrationRegistry } from '../../src/cp/cp-integration-registry.js'
 
 const A1 = '11111111-1111-4111-8111-111111111111'
-const I1 = '66666666-6666-4666-8666-666666666666'
-const I2 = '77777777-7777-4777-8777-777777777777'
-
-const spec = (over: Partial<IntegrationSpec> = {}): IntegrationSpec => ({
-  integrationId: I1,
-  agentId: A1,
+const A2 = '22222222-2222-4222-8222-222222222222'
+const integration = (id: string, agentId = A1, token = 'xoxb-one'): IntegrationSpec => ({
+  integrationId: id,
+  agentId,
   platform: 'slack',
-  core: { mode: 'direct', bindRules: [{ match: { kind: 'mention' } }], mutedChannels: [], gated: false },
-  config: {
-    botToken: 'xoxb-secret',
-    appToken: 'xapp-secret',
-    bindRules: [{ match: { kind: 'mention' } }]
-  },
-  ...over
+  config: { mode: 'direct', botToken: token, appToken: 'xapp-one', bindRules: [], mutedChannels: [], gated: false }
 })
 
-function agentsDir(): string {
-  return mkdtempSync(join(tmpdir(), 'ac-cpintreg-'))
-}
-function writeAgentFile(dir: string, folder: string, raw: Record<string, unknown>) {
-  mkdirSync(join(dir, folder), { recursive: true })
-  writeFileSync(join(dir, folder, 'agent.json'), JSON.stringify(raw))
-}
-function readAgent(dir: string, folder: string): Record<string, unknown> {
-  return JSON.parse(readFileSync(join(dir, folder, 'agent.json'), 'utf8'))
-}
-function makeReg(dir: string) {
+function makeReg() {
   const onChange = vi.fn()
   const warn = vi.fn()
-  const reg = new CpIntegrationRegistry(dir, { warn }, onChange)
+  const reg = new CpIntegrationRegistry(mkdtempSync(join(tmpdir(), 'ac-cpintreg-')), { warn }, onChange)
   return { reg, onChange, warn }
 }
 
-const AGENT_RAW = {
-  id: A1,
-  name: 'helper',
-  runtime: 'claude',
-  workspace: { mode: 'from-scratch', path: './ws' }
-}
-
-describe('CpIntegrationRegistry (filesystem-backed)', () => {
-  it('upsert APPENDS the integration to the owning agent.json (creating integrations[]) and fires onChange', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', AGENT_RAW)
-    const { reg, onChange } = makeReg(dir)
-    reg.upsert(spec())
-    const a = readAgent(dir, 'helper')
-    expect(a.integrations).toHaveLength(1)
-    const int = (a.integrations as any[])[0]
-    expect(int.id).toBe(I1)
-    expect(int.platform).toBe('slack')
-    expect(int.slack.botToken).toBe('xoxb-secret')
-    expect(int.slack.appToken).toBe('xapp-secret')
-    expect(int.slack.bindRules).toEqual([{ match: { kind: 'mention' } }])
-    expect(onChange).toHaveBeenCalledTimes(1)
+describe('CpIntegrationRegistry (memory-only)', () => {
+  it('upserts/replaces integrations by id without requiring an agent.json', () => {
+    const { reg } = makeReg()
+    reg.upsert(integration('i1'))
+    reg.upsert(integration('i1', A1, 'xoxb-two'))
+    expect(reg.forAgent(A1)).toHaveLength(1)
+    expect(reg.forAgent(A1)[0]).toMatchObject({ id: 'i1', origin: 'cp', slack: { botToken: 'xoxb-two' } })
   })
 
-  it('upsert REPLACES the same-id entry and preserves other integrations + literal strings + relative path', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', {
-      ...AGENT_RAW,
-      integrations: [
-        { id: I1, platform: 'slack', slack: { botToken: 'xoxb-old', appToken: 'xapp-old' } },
-        { id: 'local-1', platform: 'slack', slack: { botToken: '${MY_BOT}', appToken: '${MY_APP}' } }
-      ]
-    })
-    const { reg } = makeReg(dir)
-    reg.upsert(spec({ config: { botToken: 'xoxb-new', appToken: 'xapp-new', bindRules: [] } }))
-    const a = readAgent(dir, 'helper')
-    expect(a.integrations).toHaveLength(2)
-    const [cp, local] = a.integrations as any[]
-    expect(cp.id).toBe(I1)
-    expect(cp.slack.botToken).toBe('xoxb-new')
-    // Hand-authored placeholder-looking strings stay literal.
-    expect(local.slack.botToken).toBe('${MY_BOT}')
-    expect(local.slack.appToken).toBe('${MY_APP}')
-    // raw-JSON edit: relative workspace.path never absolutized
-    expect((a.workspace as any).path).toBe('./ws')
+  it('keeps agent ownership, removes by id, and exact-prunes one agent only', () => {
+    const { reg } = makeReg()
+    reg.converge([integration('i1'), integration('i2'), integration('i3', A2)])
+    reg.retainForAgent(A1, new Set(['i2']))
+    expect(reg.forAgent(A1).map((item) => item.id)).toEqual(['i2'])
+    expect(reg.forAgent(A2).map((item) => item.id)).toEqual(['i3'])
+    reg.remove('i3')
+    expect(reg.forAgent(A2)).toEqual([])
   })
 
-  it('upsert locates the owning agent by INTERNAL id (custom-named dir)', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'my-cool-bot', AGENT_RAW)
-    const { reg } = makeReg(dir)
-    reg.upsert(spec())
-    const a = readAgent(dir, 'my-cool-bot')
-    expect((a.integrations as any[])[0].id).toBe(I1)
-  })
-
-  it('upsert for a missing agent warns (ids only) and persists nothing, still fires onChange', () => {
-    const dir = agentsDir()
-    const { reg, onChange, warn } = makeReg(dir)
-    reg.upsert(spec())
-    expect(warn).toHaveBeenCalledTimes(1)
-    const msg = warn.mock.calls[0]![0] as string
-    expect(msg).toContain(I1)
-    expect(msg).toContain(A1)
-    expect(msg).not.toContain('xoxb') // never the token material
-    expect(onChange).toHaveBeenCalledTimes(1)
-  })
-
-  it('remove splices the entry out of whichever agent.json holds it; absent id is a no-op', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', {
-      ...AGENT_RAW,
-      integrations: [
-        { id: I1, platform: 'slack', slack: { botToken: 'xoxb-a', appToken: 'xapp-a' } },
-        { id: I2, platform: 'slack', slack: { botToken: 'xoxb-b', appToken: 'xapp-b' } }
-      ]
-    })
-    const { reg, onChange } = makeReg(dir)
-    reg.remove(I1)
-    const a = readAgent(dir, 'helper')
-    expect(a.integrations).toHaveLength(1)
-    expect((a.integrations as any[])[0].id).toBe(I2)
-    expect(onChange).toHaveBeenCalledTimes(1)
-    // removing an unknown id changes nothing (but still re-reconciles)
-    reg.remove('no-such-integration')
-    expect(readAgent(dir, 'helper').integrations).toHaveLength(1)
-    expect(onChange).toHaveBeenCalledTimes(2)
-  })
-
-  it('converge upserts each roster entry and does NOT prune integrations absent from the roster', () => {
-    const dir = agentsDir()
-    writeAgentFile(dir, 'helper', {
-      ...AGENT_RAW,
-      integrations: [{ id: I1, platform: 'slack', slack: { botToken: 'xoxb-a', appToken: 'xapp-a' } }]
-    })
-    const { reg, onChange } = makeReg(dir)
-    reg.converge([spec({ integrationId: I2, config: { botToken: 'xoxb-b', appToken: 'xapp-b', bindRules: [] } })])
-    const a = readAgent(dir, 'helper')
-    // I2 created from the roster; I1 NOT pruned (deletion only via integration/remove)
-    expect((a.integrations as any[]).map((i) => i.id).sort()).toEqual([I1, I2].sort())
-    expect(onChange).toHaveBeenCalledTimes(1)
+  it('rejects an unusable envelope without retaining secret material', () => {
+    const { reg, warn } = makeReg()
+    reg.upsert({ integrationId: 'bad', agentId: A1, platform: 'slack' } as IntegrationSpec)
+    expect(reg.forAgent(A1)).toEqual([])
+    expect(warn).toHaveBeenCalledOnce()
   })
 })

--- a/packages/daemon/test/cp/cp-integration.test.ts
+++ b/packages/daemon/test/cp/cp-integration.test.ts
@@ -87,8 +87,8 @@ const INTEGRATION: IntegrationSpec = {
   }
 }
 
-describe('Daemon CP integration → persisted to agent.json (disk is the source of truth)', () => {
-  it('writes a CP integration into agent.json integrations[] + opens a socket', async () => {
+describe('Daemon CP integration → memory-only effective config', () => {
+  it('keeps the CP integration out of agent.json and opens a socket', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
     const { daemon } = makeDaemon(root)
@@ -97,13 +97,9 @@ describe('Daemon CP integration → persisted to agent.json (disk is the source 
     apply(daemon).applyIntegrationUpsert(INTEGRATION)
     await daemon.reconcile()
 
-    // Persisted to disk — the single source of truth (survives restart, CP down).
+    // The user's local file is never rewritten with CP credentials.
     const onDisk = JSON.parse(readFileSync(join(root, 'agents', 'bot-a', 'agent.json'), 'utf8'))
-    expect(onDisk.integrations).toHaveLength(1)
-    expect(onDisk.integrations[0].id).toBe(INTEGRATION.integrationId)
-    expect(onDisk.integrations[0].origin).toBe('cp')
-    expect(onDisk.integrations[0].slack.botToken).toBe('xoxb-secret-abc')
-    expect(onDisk.integrations[0].slack.appToken).toBe('xapp-1-secret-def')
+    expect(onDisk.integrations).toEqual([])
 
     // Loaded into the live agent set (consolidate / routing / tools all read this).
     const eff = (
@@ -125,7 +121,7 @@ describe('Daemon CP integration → persisted to agent.json (disk is the source 
     await daemon.stop()
   })
 
-  it('survives a restart with the CP down: a fresh daemon opens the socket from disk alone', async () => {
+  it('does not survive a restart without CP reconvergence', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
     const { daemon } = makeDaemon(root)
@@ -134,18 +130,17 @@ describe('Daemon CP integration → persisted to agent.json (disk is the source 
     await daemon.reconcile()
     await daemon.stop()
 
-    // New process, same root, controlPlane disabled — must come up connected.
+    // A new process must not recover CP credentials from the local file.
     const { daemon: reborn } = makeDaemon(root)
     await reborn.start()
     const eff = (reborn as unknown as { agents: Map<string, { integrations: { id: string }[] }> }).agents.get('bot-a')!
-    expect(eff.integrations).toHaveLength(1)
-    expect(eff.integrations[0]!.id).toBe(INTEGRATION.integrationId)
+    expect(eff.integrations).toEqual([])
     const connByIntegration = (reborn as unknown as { connByIntegration: Map<string, unknown> }).connByIntegration
-    expect(connByIntegration.has(INTEGRATION.integrationId)).toBe(true)
+    expect(connByIntegration.has(INTEGRATION.integrationId)).toBe(false)
     await reborn.stop()
   })
 
-  it('applyIntegrationRemove splices it out of agent.json and the live set', async () => {
+  it('applyIntegrationRemove drops it from memory without rewriting agent.json', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
     const { daemon } = makeDaemon(root)
@@ -167,7 +162,7 @@ describe('Daemon CP integration → persisted to agent.json (disk is the source 
     await daemon.stop()
   })
 
-  it('register/ok integrations[] converge persists the daemon-scoped set to disk', async () => {
+  it('register/ok integrations[] converges the daemon-scoped set in memory', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
     const { daemon } = makeDaemon(root)
@@ -187,7 +182,7 @@ describe('Daemon CP integration → persisted to agent.json (disk is the source 
     const eff = (daemon as unknown as { agents: Map<string, { integrations: { id: string }[] }> }).agents.get('bot-a')!
     expect(eff.integrations[0]!.id).toBe(INTEGRATION.integrationId)
     const onDisk = JSON.parse(readFileSync(join(root, 'agents', 'bot-a', 'agent.json'), 'utf8'))
-    expect(onDisk.integrations[0].id).toBe(INTEGRATION.integrationId)
+    expect(onDisk.integrations).toEqual([])
 
     await daemon.stop()
   })


### PR DESCRIPTION
## Summary

- keep Control Plane agent specs, integrations, and crons in daemon memory instead of persisting them to `agent.json`
- delete every local `agent.json` with the same agent ID when CP claims that ID, while retaining all other local agent files as user-owned
- persist only a secret-free `.cp-agent-id` data-root marker so workspaces and memory can be reused after reconvergence
- merge local file agents with CP-owned in-memory state for routing, host reconciliation, integrations, and scheduling
- update architecture documentation and ownership/restart behavior tests

## Why

CP-delivered configuration could previously be written into local `agent.json` files. That blurred ownership between Control Plane replicas and hand-authored local agents, and persisted CP-provided configuration and credentials unnecessarily.

The daemon now treats local files and CP state as separate desired-state sources. CP authority wins only for the same agent ID and does not mutate unrelated local files.

## Impact

An already-running daemon retains its CP state during a Control Plane outage. After a daemon restart, CP-managed agents and dependents require the next CP roster convergence; user-authored local agents remain independently bootable from disk.

## Validation

- daemon typecheck
- ESLint and Prettier checks
- focused CP registry/reconciliation tests: 65 passed
- file discovery/watcher regression tests: 94 passed
- daemon full suite: 2957 passed, 7 skipped
- two unrelated environment-sensitive failures remain in `evaluation-runner.test.ts` (`infra_error`) and `git-injection.test.ts` (host `GIT_ASKPASS` changes the expected error text)