### PR TITLE
fix(web): compact workspace checkout control

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -810,7 +810,7 @@ on the primary workspace.
 
 The checkout control occupies about one quarter of the Workspace file browser
 header, opposite the current file breadcrumb. Its primary choice is named with
-the checkout's branch, never a generic "Primary checkout" label. With no available
+the main checkout's live branch, never a generic "Primary checkout" label. With no available
 session worktree it is a static branch label with no menu; otherwise it switches
 between that branch and the available worktrees. Worktree choices keep their
 Session link so changing the viewed files and opening the originating conversation

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -808,11 +808,14 @@ it opens the Agent's primary workspace. Its git or folder icon reflects that sou
 A session worktree is browse-only in the console: file editing and pull remain actions
 on the primary workspace.
 
-The checkout selector sits at the right of the Workspace file browser header,
-opposite the current file breadcrumb. The Source card remains directly above the
-browser and names the repository or scratch workspace that provides those files.
-Worktree choices keep their Session link in the selector so changing the viewed
-files and opening the originating conversation remain distinct actions.
+The checkout control occupies about one quarter of the Workspace file browser
+header, opposite the current file breadcrumb. Its primary choice is named with
+the checkout's branch, never a generic "Primary checkout" label. With no available
+session worktree it is a static branch label with no menu; otherwise it switches
+between that branch and the available worktrees. Worktree choices keep their
+Session link so changing the viewed files and opening the originating conversation
+remain distinct actions. The Source card remains directly above the browser and
+names only the repository or scratch workspace; it does not repeat the branch.
 
 Workspace changes are cold edits: active work is drained and existing cached
 credentials are cleared before the new definition becomes active. Any edit that removes

--- a/packages/web/src/components/console/FileBrowser.tsx
+++ b/packages/web/src/components/console/FileBrowser.tsx
@@ -95,7 +95,7 @@ export function FileBrowserShell({
   return (
     <div className="card relative max-desktop:rounded-lg">
       <div className="cardhead min-h-[41px] min-w-0 justify-between py-[6px]">
-        <div className="cardtitle min-w-0 flex-1">{title}</div>
+        <div className="cardtitle min-w-0 flex-1 overflow-hidden">{title}</div>
         {headerEnd}
       </div>
       <div className="overflow-hidden rounded-b-[inherit]">{children}</div>

--- a/packages/web/src/components/console/WorkspaceCard.test.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.test.tsx
@@ -40,6 +40,14 @@ const agent = (
 
 const GITHUB = { mode: 'github', repo: 'acme/infra', branch: 'main', agentDir: '/' }
 
+it('does not repeat the checkout branch in the Source card', () => {
+  repos.rows = []
+  const branch = 'release/source-should-not-render'
+  const html = renderToStaticMarkup(<WorkspaceCard agent={agent({ ...GITHUB, branch })} />)
+
+  expect(html).not.toContain(branch)
+})
+
 // Only an App-backed workspace has implicit authority over its own repository. A
 // manual checkout's effective access comes from an explicit agent-repo grant (or
 // is none), so an implicit chip there would claim authorization it does not have

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -6,7 +6,7 @@
 //
 // One compact card, two rows:
 //   1. Source — a segment that owns workspace conversion (scratch ⇄ GitHub),
-//      then the workspace identity (mark, repo/title, branch, status) and, on
+//      then the workspace identity (mark, repo/title, status) and, on
 //      the right, the HEAD commit plus the pull / view-on-remote / edit actions.
 //      Everything after the segment is supplied by the caller as
 //      `WorkspaceHeaderInfo` — live git state from <WorkspaceFiles> for real
@@ -48,13 +48,11 @@ export const REPO_ACCESS_BADGE: Record<RepoAccess, string> = {
 
 /**
  * The live half of the Source row. The card itself only knows the agent's
- * configured workspace; branch/status/commit and the pull action come from
+ * configured workspace; status/commit and the pull action come from
  * whoever holds the daemon read model (<WorkspaceFiles>) or, for demo agents,
  * straight from the mock workspace.
  */
 export interface WorkspaceHeaderInfo {
-  /** Branch chip. Omit to fall back to the agent's configured branch. */
-  branch?: string | null
   status?: WorkspaceStatusInfo | null
   /** HEAD summary, rendered `sha · time` with `title` as its tooltip. */
   commit?: { sha: string; time: string; title?: string } | null
@@ -127,7 +125,6 @@ export function WorkspaceCard({
   const repos = reposData ?? []
   const loadError = reposData === undefined && reposError
   const canEdit = agent.canEdit
-  const branch = header?.branch ?? (ws.mode === 'github' ? ws.branch : null)
   // A manual checkout has no App installation to mint a write token from, so its
   // effective workspace access is read regardless of the stored preference.
   const workspaceAccess =
@@ -196,12 +193,6 @@ export function WorkspaceCard({
         <span className="mono min-w-0 truncate text-[13px] font-semibold text-(--text-primary)">
           {ws.mode === 'github' ? ws.repo : 'Scratch workspace'}
         </span>
-        {isGithub && branch && (
-          <span className="scope inline-flex flex-none items-center gap-1">
-            <Icon name="git-branch" size={12} />
-            {branch}
-          </span>
-        )}
         {/* Effective workspace access stays visible next to the repository
             (product-conventions.md §Workspace navigation and repository access) —
             it is the blast radius of everything the agent pushes. */}

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -132,6 +132,7 @@ it('places the checkout selector in the file browser header', () => {
 
   expect(picker?.closest('.cardhead')).not.toBeNull()
   expect(picker?.closest('.card')?.querySelector('[data-testid="source-card"]')).toBeNull()
+  expect(picker?.parentElement?.className).toContain('w-1/4')
 })
 
 // The workspace editor lives in the card this browser renders, so a replacement

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -106,6 +106,22 @@ afterEach(async () => {
   vi.mocked(deleteWorkspaceFile).mockClear()
   vi.mocked(fetchWorkspaceFiles).mockClear()
   vi.mocked(fetchWorkspaceGitStatus).mockClear()
+  vi.mocked(fetchWorkspaceGitStatus).mockImplementation(() =>
+    Promise.resolve({
+      isRepo: false,
+      clean: true,
+      repo: null,
+      agentDir: null,
+      branch: null,
+      tracking: null,
+      ahead: null,
+      behind: null,
+      files: [],
+      truncated: false,
+      lastCommit: null,
+      lastFetchAt: null
+    })
+  )
   vi.mocked(writeWorkspaceFile).mockClear()
 })
 
@@ -122,7 +138,7 @@ it('places the checkout selector in the file browser header', () => {
       agentId="agent-a"
       workdir="/workspace"
       canEdit={false}
-      workspacePicker={<span data-testid="workspace-picker">Checkout</span>}
+      renderWorkspacePicker={() => <span data-testid="workspace-picker">Checkout</span>}
       renderHeader={() => <div data-testid="source-card">Source</div>}
     />
   )
@@ -133,6 +149,45 @@ it('places the checkout selector in the file browser header', () => {
   expect(picker?.closest('.cardhead')).not.toBeNull()
   expect(picker?.closest('.card')?.querySelector('[data-testid="source-card"]')).toBeNull()
   expect(picker?.parentElement?.className).toContain('w-1/4')
+})
+
+it('uses the primary checkout live branch while browsing a worktree', async () => {
+  vi.mocked(fetchWorkspaceGitStatus).mockImplementation((_agentId, sessionId) =>
+    Promise.resolve({
+      isRepo: true,
+      clean: true,
+      repo: 'https://github.com/acme/infra.git',
+      agentDir: '/',
+      branch: sessionId ? 'worktree-branch' : 'primary-live-branch',
+      tracking: null,
+      ahead: 0,
+      behind: 0,
+      files: [],
+      truncated: false,
+      lastCommit: null,
+      lastFetchAt: null
+    })
+  )
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(
+      <WorkspaceFiles
+        agentId="agent-a"
+        sessionId="session-a"
+        workdir="/workspace"
+        canEdit={false}
+        renderWorkspacePicker={(branch) => <span data-testid="primary-branch">{branch}</span>}
+        renderHeader={() => null}
+      />
+    )
+    await Promise.resolve()
+  })
+
+  expect(container.querySelector('[data-testid="primary-branch"]')?.textContent).toBe('primary-live-branch')
+  expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a', 'session-a')
+  expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a')
 })
 
 // The workspace editor lives in the card this browser renders, so a replacement

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -677,7 +677,6 @@ export function WorkspaceFiles({
   // status/commit/pull half of the card empty.
   const remote = git ? parseRemote(git.repo) : null
   const header: WorkspaceHeaderInfo = {
-    branch: git?.branch ?? null,
     status: git
       ? git.clean
         ? { dot: 'var(--status-online)', bg: 'var(--status-online-soft)', text: '#0f7a48', label: 'clean' }
@@ -732,7 +731,13 @@ export function WorkspaceFiles({
               }
             />
           ) : (
-            <div className="flex min-w-0 flex-none items-center gap-2">
+            <div
+              className={
+                workspacePicker
+                  ? 'flex w-1/4 min-w-0 flex-none items-center gap-2 max-desktop:w-[min(210px,56vw)]'
+                  : 'flex min-w-0 flex-none items-center gap-2'
+              }
+            >
               {workspacePicker}
               {deleteDraft ? (
                 <>

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -158,7 +158,7 @@ export function WorkspaceFiles({
   sessionId,
   workdir,
   canEdit,
-  workspacePicker,
+  renderWorkspacePicker,
   renderHeader
 }: {
   agentId: string
@@ -167,8 +167,9 @@ export function WorkspaceFiles({
   sessionId?: string
   workdir?: string
   canEdit: boolean
-  /** Checkout selector rendered opposite the current file breadcrumb. */
-  workspacePicker?: ReactNode
+  /** Checkout control rendered opposite the breadcrumb. The branch comes from
+   *  the primary checkout's live git status, even while browsing a worktree. */
+  renderWorkspacePicker?: (primaryBranch: string | null) => ReactNode
   /** Renders the workspace card above the tree from the live git read model.
    *  Called on every render — including before the status lands (empty info) and
    *  for non-repo workspaces — so the card's own controls are never gated on a
@@ -186,6 +187,7 @@ export function WorkspaceFiles({
   // loading, for a non-repo workspace, and when the owning daemon is offline —
   // the workspace card falls back to the agent's configured source in all three.
   const [git, setGit] = useState<WorkspaceGitStatusDto | null>(null)
+  const [primaryBranch, setPrimaryBranch] = useState<string | null>(null)
   const [gitPulling, setGitPulling] = useState(false)
   const [gitMsg, setGitMsg] = useState<string | null>(null)
   // Bumped after a pull to re-fetch both the git status and the tree.
@@ -382,12 +384,26 @@ export function WorkspaceFiles({
     let active = true
     fetchWorkspaceGitStatus(agentId, sessionId).then(
       (s) => {
-        if (active) setGit(s.isRepo ? s : null)
+        if (!active) return
+        setGit(s.isRepo ? s : null)
+        if (!sessionId) setPrimaryBranch(s.isRepo ? s.branch : null)
       },
       () => {
-        if (active) setGit(null)
+        if (!active) return
+        setGit(null)
+        if (!sessionId) setPrimaryBranch(null)
       }
     )
+    if (sessionId) {
+      fetchWorkspaceGitStatus(agentId).then(
+        (s) => {
+          if (active) setPrimaryBranch(s.isRepo ? s.branch : null)
+        },
+        () => {
+          if (active) setPrimaryBranch(null)
+        }
+      )
+    }
     return () => {
       active = false
     }
@@ -700,6 +716,7 @@ export function WorkspaceFiles({
     pulling: gitPulling,
     pullMsg: gitMsg
   }
+  const workspacePicker = renderWorkspacePicker?.(primaryBranch)
 
   return (
     <div className="flex flex-col gap-4">

--- a/packages/web/src/components/console/WorkspaceScopePicker.test.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.test.tsx
@@ -140,4 +140,30 @@ describe('WorkspaceScopePicker', () => {
     expect(container.querySelector('[aria-haspopup="menu"]')).toBeNull()
     expect(container.querySelector('button')).toBeNull()
   })
+
+  it('keeps older worktrees reachable when the current page has none', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () =>
+      root?.render(
+        <WorkspaceScopePicker
+          primaryBranch="main"
+          sessions={[]}
+          selectedSessionId={null}
+          loading={false}
+          hasMore
+          loadingMore={false}
+          onChange={vi.fn()}
+          onLoadMore={vi.fn()}
+          orgPath={(path) => `/agentconnect${path}`}
+        />
+      )
+    )
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-label="Workspace checkout: main"]')!
+    await act(async () => trigger.click())
+
+    expect(container.querySelector('[role="menu"]')?.textContent).toContain('Load older')
+  })
 })

--- a/packages/web/src/components/console/WorkspaceScopePicker.test.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.test.tsx
@@ -66,6 +66,7 @@ describe('WorkspaceScopePicker', () => {
     await act(async () =>
       root?.render(
         <WorkspaceScopePicker
+          primaryBranch="release/2026-08"
           sessions={[
             session({}),
             session({ id: 'session-568', title: 'PR #568: bind the conversation audience', time: '3:10 PM' }),
@@ -92,7 +93,8 @@ describe('WorkspaceScopePicker', () => {
     await act(async () => trigger.click())
 
     const menu = container.querySelector<HTMLElement>('[role="menu"]')!
-    expect(menu.textContent).toContain('Primary checkout')
+    expect(menu.textContent).toContain('release/2026-08')
+    expect(menu.textContent).not.toContain('Primary checkout')
     expect(menu.textContent).toContain('Worktrees·2')
     expect(menu.textContent).toContain('PR #568')
     expect(menu.textContent).toContain('3:10 PM')
@@ -112,5 +114,30 @@ describe('WorkspaceScopePicker', () => {
     await act(async () => loadOlder.click())
     expect(onLoadMore).toHaveBeenCalledOnce()
     expect(onChange).toHaveBeenCalledOnce()
+  })
+
+  it('shows the branch without a menu when no worktrees are available', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () =>
+      root?.render(
+        <WorkspaceScopePicker
+          primaryBranch="main"
+          sessions={[]}
+          selectedSessionId={null}
+          loading={false}
+          hasMore={false}
+          loadingMore={false}
+          onChange={vi.fn()}
+          onLoadMore={vi.fn()}
+          orgPath={(path) => `/agentconnect${path}`}
+        />
+      )
+    )
+
+    expect(container.textContent).toContain('main')
+    expect(container.querySelector('[aria-haspopup="menu"]')).toBeNull()
+    expect(container.querySelector('button')).toBeNull()
   })
 })

--- a/packages/web/src/components/console/WorkspaceScopePicker.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.tsx
@@ -67,7 +67,7 @@ export function WorkspaceScopePicker({
       : worktrees
   const selectedIdentity = selectedSessionId ? worktreeIdentity(selectedWorktree, selectedSessionId) : undefined
   const primaryBranchLabel = primaryBranch.trim() || 'HEAD'
-  const canChooseCheckout = selectedSessionId !== null || menuWorktrees.length > 0
+  const canChooseCheckout = selectedSessionId !== null || menuWorktrees.length > 0 || hasMore
 
   useEffect(() => {
     if (!open) return

--- a/packages/web/src/components/console/WorkspaceScopePicker.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.tsx
@@ -29,6 +29,7 @@ export function worktreeIdentity(
 }
 
 export function WorkspaceScopePicker({
+  primaryBranch,
   sessions,
   selectedSessionId,
   selectedSession,
@@ -39,6 +40,7 @@ export function WorkspaceScopePicker({
   onLoadMore,
   orgPath
 }: {
+  primaryBranch: string
   sessions: Session[]
   selectedSessionId: string | null
   selectedSession?: Session
@@ -64,6 +66,8 @@ export function WorkspaceScopePicker({
       ? [selectedWorktree, ...worktrees]
       : worktrees
   const selectedIdentity = selectedSessionId ? worktreeIdentity(selectedWorktree, selectedSessionId) : undefined
+  const primaryBranchLabel = primaryBranch.trim() || 'HEAD'
+  const canChooseCheckout = selectedSessionId !== null || menuWorktrees.length > 0
 
   useEffect(() => {
     if (!open) return
@@ -118,59 +122,63 @@ export function WorkspaceScopePicker({
   const sessionHref = (sessionId: string) => orgPath(`/sessions/${encodeURIComponent(sessionId)}`)
 
   return (
-    <div
-      className={`relative w-[min(640px,58vw)] min-w-0 flex-none max-desktop:w-[min(210px,56vw)] ${open ? 'z-30' : ''}`}
-    >
+    <div className={`relative w-full min-w-0 ${open ? 'z-30' : ''}`}>
       <div className="relative min-w-0">
         <div
           className={`flex h-8 min-w-0 items-center overflow-hidden rounded-md border bg-(--surface-card) ${
-            open
-              ? 'border-(--border-focus) ring-[3px] ring-(--brand-ring)'
-              : 'border-(--border-subtle) hover:border-(--border-strong) hover:bg-(--surface-hover) focus-within:border-(--border-focus) focus-within:ring-[3px] focus-within:ring-(--brand-ring)'
+            !canChooseCheckout
+              ? 'border-(--border-subtle)'
+              : open
+                ? 'border-(--border-focus) ring-[3px] ring-(--brand-ring)'
+                : 'border-(--border-subtle) hover:border-(--border-strong) hover:bg-(--surface-hover) focus-within:border-(--border-focus) focus-within:ring-[3px] focus-within:ring-(--brand-ring)'
           }`}
         >
-          <button
-            ref={triggerRef}
-            type="button"
-            className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-2 border-0 bg-transparent px-2 text-left text-(--text-primary) outline-none"
-            aria-label={`Workspace checkout: ${selectedIdentity?.fullTitle ?? 'Primary checkout'}`}
-            aria-haspopup="menu"
-            aria-expanded={open}
-            aria-controls={open ? menuId : undefined}
-            onClick={() => setOpen((current) => !current)}
-            onKeyDown={openFromKeyboard}
-          >
-            <Icon
-              name={selectedSessionId ? 'git-branch' : 'folder-git-2'}
-              size={14}
-              className="flex-none text-(--text-tertiary)"
-            />
-            {selectedIdentity ? (
-              <span className="flex min-w-0 flex-1 items-baseline gap-2" title={selectedIdentity.fullTitle}>
-                {selectedIdentity.context ? (
-                  <span className="flex-none font-sans text-[12.5px] font-semibold leading-normal">
-                    {selectedIdentity.context}
-                  </span>
-                ) : null}
-                {selectedIdentity.title ? (
-                  <span
-                    className={`truncate font-sans text-[12.5px] leading-normal ${
-                      selectedIdentity.context
-                        ? 'font-normal text-(--text-secondary)'
-                        : 'font-medium text-(--text-primary)'
-                    }`}
-                  >
-                    {selectedIdentity.title}
-                  </span>
-                ) : null}
+          {canChooseCheckout ? (
+            <button
+              ref={triggerRef}
+              type="button"
+              className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-2 border-0 bg-transparent px-2 text-left text-(--text-primary) outline-none"
+              aria-label={`Workspace checkout: ${selectedIdentity?.fullTitle ?? primaryBranchLabel}`}
+              aria-haspopup="menu"
+              aria-expanded={open}
+              aria-controls={open ? menuId : undefined}
+              onClick={() => setOpen((current) => !current)}
+              onKeyDown={openFromKeyboard}
+            >
+              <Icon name="git-branch" size={14} className="flex-none text-(--text-tertiary)" />
+              {selectedIdentity ? (
+                <span className="flex min-w-0 flex-1 items-baseline gap-2" title={selectedIdentity.fullTitle}>
+                  {selectedIdentity.context ? (
+                    <span className="flex-none font-sans text-[12.5px] font-semibold leading-normal">
+                      {selectedIdentity.context}
+                    </span>
+                  ) : null}
+                  {selectedIdentity.title ? (
+                    <span
+                      className={`truncate font-sans text-[12.5px] leading-normal ${
+                        selectedIdentity.context
+                          ? 'font-normal text-(--text-secondary)'
+                          : 'font-medium text-(--text-primary)'
+                      }`}
+                    >
+                      {selectedIdentity.title}
+                    </span>
+                  ) : null}
+                </span>
+              ) : (
+                <span className="truncate font-sans text-[12.5px] font-semibold leading-normal">
+                  {primaryBranchLabel}
+                </span>
+              )}
+            </button>
+          ) : (
+            <div className="flex h-full min-w-0 flex-1 items-center gap-2 px-2 text-(--text-primary)">
+              <Icon name="git-branch" size={14} className="flex-none text-(--text-tertiary)" />
+              <span className="truncate font-sans text-[12.5px] font-semibold leading-normal">
+                {primaryBranchLabel}
               </span>
-            ) : (
-              <>
-                <span className="truncate font-sans text-[12.5px] font-semibold leading-normal">Primary checkout</span>
-                <span className="mono ml-auto flex-none text-[11px] text-(--text-tertiary)">HEAD</span>
-              </>
-            )}
-          </button>
+            </div>
+          )}
 
           {selectedSessionId ? (
             <Link
@@ -185,22 +193,24 @@ export function WorkspaceScopePicker({
             </Link>
           ) : null}
 
-          <button
-            type="button"
-            className="flex h-full w-9 flex-none cursor-pointer items-center justify-center border-0 border-l border-(--border-subtle) bg-transparent text-(--text-tertiary) outline-none hover:bg-(--surface-hover) hover:text-(--text-primary)"
-            aria-label={open ? 'Close workspace checkout menu' : 'Open workspace checkout menu'}
-            aria-haspopup="menu"
-            aria-expanded={open}
-            aria-controls={open ? menuId : undefined}
-            title={open ? 'Close checkout menu' : 'Choose checkout'}
-            onClick={() => setOpen((current) => !current)}
-            onKeyDown={openFromKeyboard}
-          >
-            <Icon name="chevron-down" size={14} className={open ? 'rotate-180' : ''} />
-          </button>
+          {canChooseCheckout ? (
+            <button
+              type="button"
+              className="flex h-full w-9 flex-none cursor-pointer items-center justify-center border-0 border-l border-(--border-subtle) bg-transparent text-(--text-tertiary) outline-none hover:bg-(--surface-hover) hover:text-(--text-primary)"
+              aria-label={open ? 'Close workspace checkout menu' : 'Open workspace checkout menu'}
+              aria-haspopup="menu"
+              aria-expanded={open}
+              aria-controls={open ? menuId : undefined}
+              title={open ? 'Close checkout menu' : 'Choose checkout'}
+              onClick={() => setOpen((current) => !current)}
+              onKeyDown={openFromKeyboard}
+            >
+              <Icon name="chevron-down" size={14} className={open ? 'rotate-180' : ''} />
+            </button>
+          ) : null}
         </div>
 
-        {open ? (
+        {canChooseCheckout && open ? (
           <>
             <span className="fixed inset-0 z-20" aria-hidden onClick={() => setOpen(false)} />
             <div
@@ -221,9 +231,10 @@ export function WorkspaceScopePicker({
                 }`}
                 onClick={() => pick(null)}
               >
-                <Icon name={selectedSessionId === null ? 'check' : 'folder-git-2'} size={15} className="flex-none" />
-                <span className="flex-1 font-semibold">Primary checkout</span>
-                <span className="mono flex-none text-[11.5px] text-(--text-tertiary)">HEAD</span>
+                <Icon name={selectedSessionId === null ? 'check' : 'git-branch'} size={15} className="flex-none" />
+                <span className="min-w-0 flex-1 truncate font-semibold" title={primaryBranchLabel}>
+                  {primaryBranchLabel}
+                </span>
               </button>
 
               <div className="border-t border-(--border-subtle)">

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1633,10 +1633,10 @@ export default function AgentDetailView() {
               {...(selectedWorktreeSessionId ? { sessionId: selectedWorktreeSessionId } : {})}
               workdir={da.workdir}
               canEdit={selectedWorktreeSessionId === null && da.workspace.mode === 'scratch' && da.canEdit}
-              workspacePicker={
+              renderWorkspacePicker={(primaryBranch) =>
                 da.workspace.mode === 'github' ? (
                   <WorkspaceScopePicker
-                    primaryBranch={da.workspace.branch}
+                    primaryBranch={primaryBranch ?? da.workspace.branch}
                     sessions={workspaceSessions}
                     selectedSessionId={selectedWorktreeSessionId}
                     selectedSession={selectedWorktreeSession}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1663,7 +1663,25 @@ export default function AgentDetailView() {
 
             <FileBrowserShell
               title="Files"
-              headerEnd={<span className="mono text-[11px] text-(--text-tertiary)">{filesSummary}</span>}
+              headerEnd={
+                ws.mode === 'github' ? (
+                  <div className="flex w-1/4 min-w-0 flex-none items-center gap-2 max-desktop:w-[min(210px,56vw)]">
+                    <WorkspaceScopePicker
+                      primaryBranch={ws.branch}
+                      sessions={[]}
+                      selectedSessionId={null}
+                      loading={false}
+                      hasMore={false}
+                      loadingMore={false}
+                      onLoadMore={() => undefined}
+                      onChange={() => undefined}
+                      orgPath={orgPath}
+                    />
+                  </div>
+                ) : (
+                  <span className="mono text-[11px] text-(--text-tertiary)">{filesSummary}</span>
+                )
+              }
             >
               {ws.files.length > 0 ? (
                 <WorkspaceFilesMock files={ws.files} />

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -416,7 +416,6 @@ export default function AgentDetailView() {
   const mockWorkspaceHeader: WorkspaceHeaderInfo =
     ws.mode === 'github'
       ? {
-          branch: ws.branch,
           status: workspaceStatus(ws),
           ...(ws.commitMsg ? { commit: { sha: ws.commit, time: ws.commitTime, title: ws.commitMsg } } : {}),
           repoUrl: ws.repoUrl ?? `https://github.com/${ws.repo}`
@@ -1635,12 +1634,9 @@ export default function AgentDetailView() {
               workdir={da.workdir}
               canEdit={selectedWorktreeSessionId === null && da.workspace.mode === 'scratch' && da.canEdit}
               workspacePicker={
-                da.workspace.mode === 'github' &&
-                (da.workspace.worktree === true ||
-                  selectedWorktreeSessionId !== null ||
-                  workspaceSessionsNextCursor !== null ||
-                  workspaceSessions.some((session) => session.workspaceIsolation === 'session')) ? (
+                da.workspace.mode === 'github' ? (
                   <WorkspaceScopePicker
+                    primaryBranch={da.workspace.branch}
                     sessions={workspaceSessions}
                     selectedSessionId={selectedWorktreeSessionId}
                     selectedSession={selectedWorktreeSession}


### PR DESCRIPTION
## Summary

- constrain the Workspace checkout control to one quarter of the file-browser header
- show the main checkout's live branch name instead of a generic label
- render a static branch label with no dropdown when there are no worktrees
- preserve Load older when additional session pages may contain worktrees
- remove the duplicate branch badge from the Source card
- clip long breadcrumbs so the compact control does not cause mobile overflow

## Root cause

The checkout control owned its own viewport-based width and used a generic primary label, while the Source card repeated the active branch. That made the header oversized and split checkout context across two surfaces. The label also came from stored configuration rather than the daemon's live primary-checkout status.

## Validation

- `pnpm --filter @agentconnect.md/web test` (100 files, 761 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm lint`
- `pnpm format:check`
- desktop visual verification: checkout control measured 24.3% of the header
- 390 px mobile verification: no horizontal overflow; branch-only state has no menu button

Created by Codex . GPT-5.6
