### PR TITLE
fix: render exact Slack agent mention addresses

### DIFF
--- a/docs/designs/send-message-routing-rework.md
+++ b/docs/designs/send-message-routing-rework.md
@@ -140,13 +140,14 @@ ladder a human message takes, with the author removed from the candidate set:
   user id is standing context (`- Slack identity: bot user <@U…> is YOU`), sourced from
   the daemon's own live connection, so it can tell whether a message concerns it and
   decline with `NO_RESPONSE`.
-- Selecting recipients by PARSING the body was tried and removed. It made delivery
-  depend on mapping an opaque `<@U…>` back to an agent through the collaboration
-  directory, and that lookup is not dependable — observed in a live workspace with
-  `botUserId` absent for most agents and `botShared` derived from "the app is
-  shareable" rather than from a bot user genuinely backing several agents. A correct,
-  well-formed peer mention then resolved to nobody and the conversation stopped: the
-  more precisely a model addressed its peer, the more reliably it silenced the thread.
+- Selecting the EXCLUSIVE recipient by parsing the body was tried and removed. It made
+  delivery depend entirely on mapping an opaque `<@U…>` back to an agent through the
+  collaboration directory. A live workspace exposed two metadata bugs in that path:
+  `botUserId` was absent for most agents, and `botShared` meant "the app is shareable"
+  rather than "this bot user currently backs several agents in this conversation."
+  Mention metadata now converges from Slack identity and actual channel placements, but
+  it is used only to render addresses and JOIN named agents; existing participants never
+  disappear merely because an address cannot be resolved.
 - ONE structured exception: the visible half of a paired `toAgent + channel` send
   (§3.2). Its target came from the tool call as an agent id, and the activation
   rendezvous only converges when the visible observation and the internal wake name the

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1031,11 +1031,19 @@ export function buildContainer(
     async (botToken) => {
       const result = await verifySlackBot(botToken)
       return result.status === 'ok'
-        ? { appId: result.appId, workspaceId: result.teamId, workspaceName: result.teamName }
+        ? {
+            appId: result.appId,
+            botUserId: result.botUserId,
+            workspaceId: result.teamId,
+            workspaceName: result.teamName
+          }
         : null
     },
     clock,
-    { intervalMs: 15 * 60 * 1000 },
+    {
+      intervalMs: 15 * 60 * 1000,
+      onMentionIdentityChanged: (orgId) => collabRoutes.broadcast(orgId)
+    },
     http.log
   )
 

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -641,6 +641,7 @@ export function integrationRoutes(deps: HttpDeps) {
             ...(identity.externalAppId ? { slackAppId: identity.externalAppId } : {}),
             ...(identity.workspaceId ? { workspaceId: identity.workspaceId } : {}),
             ...(identity.workspaceName ? { workspaceName: identity.workspaceName } : {}),
+            ...(identity.botUserId ? { botUserId: identity.botUserId } : {}),
             ...(slack.appToken ? { appToken: slack.appToken } : {}),
             ...(slack.signingSecret ? { signingSecret: slack.signingSecret } : {}),
             ...(req.body.shareable === true ? { shareable: true } : {}),

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -398,6 +398,7 @@ export function slackInstallRoutes(deps: HttpDeps) {
             slackAppId: row.appId,
             ...(botCheck?.status === 'ok' && botCheck.teamId ? { workspaceId: botCheck.teamId } : {}),
             ...(botCheck?.status === 'ok' && botCheck.teamName ? { workspaceName: botCheck.teamName } : {}),
+            ...(botCheck?.status === 'ok' && botCheck.botUserId ? { botUserId: botCheck.botUserId } : {}),
             // socket: the pasted xapp; http: the signing secret captured at create. The
             // shareable choice rides the finalize body (installNewSlackBot coerces it off
             // for socket regardless).

--- a/packages/control-plane/src/http/slack-identity.test.ts
+++ b/packages/control-plane/src/http/slack-identity.test.ts
@@ -16,7 +16,14 @@ describe('verifySlackBot (auth.test)', () => {
     mockFetch(
       () =>
         new Response(
-          JSON.stringify({ ok: true, user: 'matrix_test', team: 'Acme', team_id: 'T0123', app_id: 'A0123' }),
+          JSON.stringify({
+            ok: true,
+            user: 'matrix_test',
+            user_id: 'U0123BOT',
+            team: 'Acme',
+            team_id: 'T0123',
+            app_id: 'A0123'
+          }),
           {
             status: 200,
             headers: { 'x-oauth-scopes': 'chat:write, channels:read, assistant:write' }
@@ -27,6 +34,7 @@ describe('verifySlackBot (auth.test)', () => {
       status: 'ok',
       name: 'matrix_test',
       appId: 'A0123',
+      botUserId: 'U0123BOT',
       teamId: 'T0123',
       teamName: 'Acme',
       scopes: ['chat:write', 'channels:read', 'assistant:write']
@@ -39,6 +47,7 @@ describe('verifySlackBot (auth.test)', () => {
       status: 'ok',
       name: 'Acme',
       appId: null,
+      botUserId: null,
       teamId: null,
       teamName: 'Acme',
       scopes: null
@@ -57,6 +66,7 @@ describe('verifySlackBot (auth.test)', () => {
       status: 'ok',
       name: 'matrix_test',
       appId: 'A0123',
+      botUserId: null,
       teamId: null,
       teamName: null,
       scopes: null
@@ -74,6 +84,7 @@ describe('verifySlackBot (auth.test)', () => {
       status: 'ok',
       name: null,
       appId: null,
+      botUserId: null,
       teamId: null,
       teamName: null,
       scopes: null

--- a/packages/control-plane/src/http/slack-identity.ts
+++ b/packages/control-plane/src/http/slack-identity.ts
@@ -25,6 +25,8 @@ export type SlackBotVerification =
       status: 'ok'
       name: string | null
       appId: string | null
+      /** Slack member id used by `<@...>` mentions (`auth.test.user_id`). */
+      botUserId?: string | null
       teamId: string | null
       teamName: string | null
       scopes: string[] | null
@@ -100,6 +102,7 @@ export const verifySlackBot: SlackBotVerifier = async (botToken) => {
       team_id?: string
       app_id?: string
       bot_id?: string
+      user_id?: string
     }
     if (!body.ok) return { status: rejectedCredential(body.error) }
     const scopeHeader = res.headers.get('x-oauth-scopes')
@@ -114,6 +117,7 @@ export const verifySlackBot: SlackBotVerifier = async (botToken) => {
       status: 'ok',
       name: body.user ?? body.team ?? null,
       appId,
+      botUserId: body.user_id ?? null,
       teamId: body.team_id ?? null,
       teamName: body.team ?? null,
       scopes

--- a/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
@@ -76,7 +76,7 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
     )
   })
 
-  it('carries the channel-scoped mention-address inputs, and omits them org-wide', () => {
+  it('derives channel-scoped mention sharing from actual identities, and omits mention inputs org-wide', () => {
     // send-message-routing-rework.md §8.5: an agent's `@mention` is only meaningful
     // inside a conversation — the bot user id resolves relative to that channel's
     // membership, and a shared bot needs the agent slug to be addressable at all. So the
@@ -86,7 +86,8 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
       DEFAULT_ORG_ID,
       [
         rec({ agentId: AGENT_1, botUserId: 'U01DEDICATED' }),
-        rec({ agentId: AGENT_2, botUserId: 'U09SHARED', botShared: true, name: 'reviewer' })
+        rec({ agentId: AGENT_2, botUserId: 'U09SHARED', name: 'reviewer' }),
+        rec({ agentId: AGENT_3, botUserId: 'U09SHARED', name: 'planner' })
       ],
       1,
       [orgAgent({ agentId: AGENT_1 })]
@@ -96,8 +97,24 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
     expect(byAgent.get(AGENT_1)).toMatchObject({ botUserId: 'U01DEDICATED' })
     expect(byAgent.get(AGENT_1)!.botShared).toBeUndefined()
     expect(byAgent.get(AGENT_2)).toMatchObject({ botUserId: 'U09SHARED', botShared: true, name: 'reviewer' })
+    expect(byAgent.get(AGENT_3)).toMatchObject({ botUserId: 'U09SHARED', botShared: true, name: 'planner' })
     expect(snap.agents[0]!.botUserId).toBeUndefined()
     expect(snap.agents[0]!.botShared).toBeUndefined()
+  })
+
+  it('does not confuse a bot sharing capability with sharing its identity in this channel', () => {
+    const snap = buildCollabSnapshot(
+      DEFAULT_ORG_ID,
+      [
+        rec({ channelId: 'C1', agentId: AGENT_1, botUserId: 'U09CAPABLE' }),
+        rec({ channelId: 'C2', agentId: AGENT_2, botUserId: 'U09CAPABLE' })
+      ],
+      1,
+      []
+    )
+    expect(snap.channels.flatMap((channel) => channel.agents).every((agent) => agent.botShared === undefined)).toBe(
+      true
+    )
   })
 
   it('drops unplaced agents (daemonId null) — they are not routable', () => {

--- a/packages/control-plane/src/orchestrator/collabSnapshot.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.ts
@@ -29,6 +29,20 @@ export function buildCollabSnapshot(
   generation: number,
   orgAgents: OrgAgentRecord[]
 ): CollabRoutesSnapshot {
+  // Sharing is an observed property of ONE conversation, not the bot's `shareable`
+  // capacity setting. A bot may be shareable while only one agent is present here;
+  // conversely duplicate legacy bot rows may expose the same member id. Count the
+  // actual placed agents behind each channel-scoped identity so old daemons receive a
+  // truthful compatibility flag.
+  const agentsByMentionIdentity = new Map<string, Set<string>>()
+  for (const p of placements) {
+    if (!p.daemonId || !p.botUserId) continue
+    const key = `${p.platform}\u0000${p.channelId}\u0000${p.botUserId}`
+    const agents = agentsByMentionIdentity.get(key) ?? new Set<string>()
+    agents.add(p.agentId)
+    agentsByMentionIdentity.set(key, agents)
+  }
+
   // (platform, channelId) → CollabChannelRoute
   const byChannel = new Map<string, CollabChannelRoute>()
   for (const p of placements) {
@@ -48,7 +62,10 @@ export function buildCollabSnapshot(
       // meaningful inside a conversation, which is also why the flat org directory below
       // omits them (an org-wide listing has no single conversation-specific address).
       ...(p.botUserId !== undefined ? { botUserId: p.botUserId } : {}),
-      ...(p.botShared ? { botShared: true } : {}),
+      ...(p.botUserId !== undefined &&
+      (agentsByMentionIdentity.get(`${p.platform}\u0000${p.channelId}\u0000${p.botUserId}`)?.size ?? 0) > 1
+        ? { botShared: true }
+        : {}),
       callPolicy: p.callPolicy,
       allowedCallerAgentIds: p.allowedCallerAgentIds,
       outboundPolicy: p.outboundPolicy,

--- a/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.test.ts
+++ b/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.test.ts
@@ -36,12 +36,14 @@ function bot(): BotRecord {
 }
 
 describe('SlackBotIdentityReconciler', () => {
-  it('resolves and backfills missing Slack app/workspace identity without exposing the token', async () => {
+  it('resolves and backfills missing Slack app/workspace/member identity without exposing the token', async () => {
     const setSlackAppIdIfMissing = vi.fn(async () => true)
+    const setSlackBotUserIdIfMissing = vi.fn(async () => true)
     const setWorkspaceMetadata = vi.fn(async () => {})
     const bots = {
       listSlackMissingIdentity: async () => [bot()],
       setSlackAppIdIfMissing,
+      setSlackBotUserIdIfMissing,
       setWorkspaceMetadata
     } as unknown as BotRepo
     const secrets = {
@@ -49,17 +51,19 @@ describe('SlackBotIdentityReconciler', () => {
     } as unknown as BotSecretStore
     const resolve = vi.fn(async () => ({
       appId: 'AHTTPBOT',
+      botUserId: 'UHTTPBOT',
       workspaceId: 'TWORKSPACE',
       workspaceName: 'Acme'
     }))
     const info = vi.fn()
+    const onMentionIdentityChanged = vi.fn(async () => {})
 
     await new SlackBotIdentityReconciler(
       bots,
       secrets,
       resolve,
       new FakeClock(),
-      { intervalMs: 60_000 },
+      { intervalMs: 60_000, onMentionIdentityChanged },
       {
         info,
         warn() {},
@@ -69,16 +73,20 @@ describe('SlackBotIdentityReconciler', () => {
 
     expect(resolve).toHaveBeenCalledWith('xoxb-secret')
     expect(setSlackAppIdIfMissing).toHaveBeenCalledWith(BOT, 'AHTTPBOT')
+    expect(setSlackBotUserIdIfMissing).toHaveBeenCalledWith(BOT, 'UHTTPBOT')
     expect(setWorkspaceMetadata).toHaveBeenCalledWith(BOT, 'TWORKSPACE', 'Acme')
+    expect(onMentionIdentityChanged).toHaveBeenCalledWith(bot().orgId)
     expect(JSON.stringify(info.mock.calls)).not.toContain('xoxb-secret')
   })
 
   it('keeps unresolved rows retryable and never stores a malformed id', async () => {
     const setSlackAppIdIfMissing = vi.fn(async () => true)
+    const setSlackBotUserIdIfMissing = vi.fn(async () => true)
     const setWorkspaceMetadata = vi.fn(async () => {})
     const bots = {
       listSlackMissingIdentity: async () => [bot()],
       setSlackAppIdIfMissing,
+      setSlackBotUserIdIfMissing,
       setWorkspaceMetadata
     } as unknown as BotRepo
     const secrets = {
@@ -88,12 +96,18 @@ describe('SlackBotIdentityReconciler', () => {
     await new SlackBotIdentityReconciler(
       bots,
       secrets,
-      async () => ({ appId: 'not-an-app-id', workspaceId: 'not-a-workspace', workspaceName: 'Nope' }),
+      async () => ({
+        appId: 'not-an-app-id',
+        botUserId: 'not-a-member-id',
+        workspaceId: 'not-a-workspace',
+        workspaceName: 'Nope'
+      }),
       new FakeClock(),
       { intervalMs: 60_000 }
     ).tick()
 
     expect(setSlackAppIdIfMissing).not.toHaveBeenCalled()
+    expect(setSlackBotUserIdIfMissing).not.toHaveBeenCalled()
     expect(setWorkspaceMetadata).not.toHaveBeenCalled()
   })
 

--- a/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.ts
+++ b/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.ts
@@ -7,10 +7,13 @@
  * Settings page must not fan out to Slack or turn a metadata read into a write.
  */
 import type { Clock, TimerHandle } from '../domain/clock.js'
+import type { OrgId } from '../domain/ids.js'
 import type { BotRepo, BotSecretStore } from '../persistence/ports.js'
 
 export interface SlackBotIdentityReconcilerConfig {
   intervalMs: number
+  /** Refresh conversation-scoped mention directories after a member id is repaired. */
+  onMentionIdentityChanged?: (orgId: OrgId) => Promise<void>
 }
 
 export interface SlackBotIdentityReconcilerLog {
@@ -21,6 +24,7 @@ export interface SlackBotIdentityReconcilerLog {
 
 export interface ResolvedSlackIdentity {
   appId: string | null
+  botUserId?: string | null
   workspaceId: string | null
   workspaceName: string | null
 }
@@ -28,12 +32,15 @@ export interface ResolvedSlackIdentity {
 export type ResolveSlackIdentity = (botToken: string) => Promise<ResolvedSlackIdentity | null>
 
 const SLACK_APP_ID = /^A[A-Z0-9]+$/
+const SLACK_MEMBER_ID = /^[A-Z][A-Z0-9]+$/
 const SLACK_WORKSPACE_ID = /^T[A-Z0-9]+$/
 
 export class SlackBotIdentityReconciler {
   private timer: TimerHandle | undefined
   private stopped = true
   private running = false
+  /** Retained across ticks so a transient broadcast failure cannot strand repaired data. */
+  private readonly pendingMentionIdentityOrgs = new Set<OrgId>()
 
   constructor(
     private readonly bots: BotRepo,
@@ -85,6 +92,15 @@ export class SlackBotIdentityReconciler {
               this.log?.info({ botId: bot.id, slackAppId: identity.appId }, 'slack-bot-identity: backfilled app id')
             }
           }
+          if (identity.botUserId && SLACK_MEMBER_ID.test(identity.botUserId)) {
+            if (await this.bots.setSlackBotUserIdIfMissing(bot.id, identity.botUserId)) {
+              this.log?.info(
+                { botId: bot.id, botUserId: identity.botUserId },
+                'slack-bot-identity: backfilled bot user id'
+              )
+              if (this.cfg.onMentionIdentityChanged) this.pendingMentionIdentityOrgs.add(bot.orgId)
+            }
+          }
           if (identity.workspaceId && SLACK_WORKSPACE_ID.test(identity.workspaceId)) {
             await this.bots.setWorkspaceMetadata(bot.id, identity.workspaceId, identity.workspaceName)
             this.log?.info(
@@ -94,6 +110,14 @@ export class SlackBotIdentityReconciler {
           }
         } catch (err) {
           this.log?.warn({ err, botId: bot.id }, 'slack-bot-identity: bot lookup failed')
+        }
+      }
+      for (const orgId of this.pendingMentionIdentityOrgs) {
+        try {
+          await this.cfg.onMentionIdentityChanged?.(orgId)
+          this.pendingMentionIdentityOrgs.delete(orgId)
+        } catch (err) {
+          this.log?.warn({ err, orgId }, 'slack-bot-identity: mention directory refresh failed')
         }
       }
     } catch (err) {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2472,10 +2472,12 @@ export interface BotRepo {
   /** Record workspace metadata learned from OAuth/auth.test. A missing name
    *  preserves the last known label. */
   setWorkspaceMetadata(id: BotId, workspaceId: string, workspaceName: string | null): Promise<void>
-  /** Slack bots missing public app/workspace identity metadata. */
+  /** Slack bots missing public app/workspace/member identity metadata. */
   listSlackMissingIdentity(): Promise<BotRecord[]>
   /** Backfill only a missing id; never replace an established Slack app identity. */
   setSlackAppIdIfMissing(id: BotId, slackAppId: string): Promise<boolean>
+  /** Backfill only a missing Slack member id; never replace an established identity. */
+  setSlackBotUserIdIfMissing(id: BotId, botUserId: string): Promise<boolean>
   /** Stamp the freed-bot display hints when its LAST integration is removed. */
   markFreed(id: BotId, at: Date, lastAgentName: string | null): Promise<void>
   /** Flip the shared-bot (multi-agent) opt-in (console toggle). Serialized on the
@@ -3129,14 +3131,10 @@ export interface ChannelPlacementRecord {
   /** Public platform app identity used to recognize messages from another
    *  AgentConnect-managed bot. Currently populated for Slack (`A…`). */
   botAppId?: string
-  /** Public member id this agent's bot posts as (Slack `U…`) — with {@link botShared}
-   *  and `name`, the mention-address input the daemon/relay need to render and resolve
-   *  an exact `@mention` for this agent in this channel
-   *  (send-message-routing-rework.md §8.5). */
+  /** Public member id this agent's bot posts as (Slack `U…`). Together with the
+   *  complete channel placement set and `name`, this lets the snapshot builder derive
+   *  an exact conversation-scoped `@mention` (send-message-routing-rework.md §8.5). */
   botUserId?: string
-  /** True when the bot identity backs more than one agent, so its address needs the
-   *  agent slug (`<@U_SHARED> reviewer`) and a bare mention selects no agent. */
-  botShared?: boolean
   callPolicy: AgentCallPolicy
   allowedCallerAgentIds: string[]
   outboundPolicy: AgentCallPolicy

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -199,7 +199,12 @@ export class PgBotRepo implements BotRepo {
     const rows = await this.db.bot.findMany({
       where: {
         platform: 'slack',
-        OR: [{ transport: 'http', slackAppId: null }, { workspaceId: null }, { workspaceName: null }]
+        OR: [
+          { transport: 'http', slackAppId: null },
+          { workspaceId: null },
+          { workspaceName: null },
+          { botUserId: null }
+        ]
       },
       include: botInclude,
       orderBy: { createdAt: 'asc' }
@@ -214,6 +219,14 @@ export class PgBotRepo implements BotRepo {
     const result = await this.db.bot.updateMany({
       where: { id, slackAppId: null },
       data: { slackAppId, externalAppId: slackAppId }
+    })
+    return result.count === 1
+  }
+
+  async setSlackBotUserIdIfMissing(id: BotId, botUserId: string): Promise<boolean> {
+    const result = await this.db.bot.updateMany({
+      where: { id, botUserId: null },
+      data: { botUserId }
     })
     return result.count === 1
   }
@@ -520,10 +533,10 @@ export class PgIntegrationRepo implements IntegrationRepo {
       select: {
         id: true,
         platform: true,
-        // `botUserId` + `shareable` are the §8.5 mention-address inputs: the member id a
-        // `<@…>` resolves to, and whether that identity backs more than one agent (so the
-        // address needs the agent slug). Both are public metadata already stored on the bot.
-        bot: { select: { slackAppId: true, botUserId: true, shareable: true } },
+        // `botUserId` is the public member id a `<@…>` resolves to. Whether it is
+        // shared is conversation-scoped and is derived from the complete placement set
+        // in `buildCollabSnapshot`; the bot's `shareable` capacity flag is not identity.
+        bot: { select: { slackAppId: true, botUserId: true } },
         agent: {
           select: {
             id: true,
@@ -555,7 +568,6 @@ export class PgIntegrationRepo implements IntegrationRepo {
           integrationId: IntegrationId(i.id),
           ...(platform === 'slack' && i.bot.slackAppId ? { botAppId: i.bot.slackAppId } : {}),
           ...(platform === 'slack' && i.bot.botUserId ? { botUserId: i.bot.botUserId } : {}),
-          ...(platform === 'slack' && i.bot.shareable ? { botShared: true } : {}),
           callPolicy: i.agent.callPolicy as ChannelPlacementRecord['callPolicy'],
           allowedCallerAgentIds: i.agent.allowedCallerAgentIds,
           outboundPolicy: i.agent.outboundPolicy as ChannelPlacementRecord['outboundPolicy'],

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -55,6 +55,7 @@ const verifierOk = (over: Partial<Extract<SlackBotVerification, { status: 'ok' }
         status: 'ok',
         name: 'support-bot',
         appId: 'A0TESTAPP',
+        botUserId: 'U0TESTBOT',
         teamId: 'T0TESTTEAM',
         teamName: 'Example Workspace',
         scopes: null,
@@ -272,6 +273,7 @@ describe('slack validateConfig (route parity: integrations.ts slack arm)', () =>
       identity: {
         name: 'support-bot',
         externalAppId: 'A0TESTAPP',
+        botUserId: 'U0TESTBOT',
         workspaceId: 'T0TESTTEAM',
         workspaceName: 'Example Workspace'
       }

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -311,14 +311,16 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
       // auth.test-derived → owning agent); `externalAppId` is the "A…" app id
       // auth.test resolved; workspaceId/workspaceName are the display-only
       // tenant metadata the create tail persists (distinct from the DEMUX
-      // `Bot.teamId`, which only the platform-app OAuth funnel writes).
+      // `Bot.teamId`, which only the platform-app OAuth funnel writes). `botUserId`
+      // is the public Slack member id used to render exact channel mentions.
       const identity =
         botCheck?.status === 'ok'
           ? {
               ...(botCheck.name ? { name: botCheck.name } : {}),
               ...(botCheck.appId ? { externalAppId: botCheck.appId } : {}),
               ...(botCheck.teamId ? { workspaceId: botCheck.teamId } : {}),
-              ...(botCheck.teamName ? { workspaceName: botCheck.teamName } : {})
+              ...(botCheck.teamName ? { workspaceName: botCheck.teamName } : {}),
+              ...(botCheck.botUserId ? { botUserId: botCheck.botUserId } : {})
             }
           : {}
       return { ok: true, identity }

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -151,6 +151,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       status: 'ok',
       name: 'http-bot',
       appId: 'AHTTPBOT',
+      botUserId: 'UHTTPBOT',
       teamId: 'T1',
       teamName: 'Acme',
       scopes: []
@@ -172,6 +173,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect(await prisma.bot.findUnique({ where: { id: dto.botId } })).toMatchObject({
       transport: 'http',
       slackAppId: 'AHTTPBOT',
+      botUserId: 'UHTTPBOT',
       workspaceId: 'T1',
       workspaceName: 'Acme'
     })
@@ -1011,6 +1013,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       app.deps.repos.botSecret,
       async () => ({
         appId: 'ALEGACYHTTP',
+        botUserId: 'ULEGACYHTTP',
         workspaceId: 'TLEGACY',
         workspaceName: 'Legacy workspace'
       }),
@@ -1020,6 +1023,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
 
     await reconciler.tick()
 
+    expect((await prisma.bot.findUnique({ where: { id: botId } }))?.botUserId).toBe('ULEGACYHTTP')
     const res = await app.app.inject({ method: 'GET', url: `${ORG}/bots` })
     expect(res.statusCode).toBe(200)
     expect(res.json()).toEqual([

--- a/packages/daemon/src/cp/cp-collab-routes.ts
+++ b/packages/daemon/src/cp/cp-collab-routes.ts
@@ -289,25 +289,29 @@ export class CpCollabRoutes {
   mentionDirectory(orgId: string, platform: string, channelId: string): AgentMentionIdentity[] {
     const members = this.channels.get(this.key(orgId, platform, channelId))
     if (!members) return []
-    return [...members.values()].map((a) => ({
+    const identities = [...members.values()].map((a) => ({
       agentId: a.agentId,
       ...(a.botUserId !== undefined ? { botUserId: a.botUserId } : {}),
-      ...(a.botShared ? { botShared: true } : {}),
       ...(a.name !== undefined ? { name: a.name } : {})
+    }))
+    const counts = new Map<string, number>()
+    for (const identity of identities) {
+      if (identity.botUserId) counts.set(identity.botUserId, (counts.get(identity.botUserId) ?? 0) + 1)
+    }
+    // Recompute instead of trusting the wire flag. This corrects an older CP that
+    // derived `botShared` from the bot's shareable CAPACITY rather than from the
+    // identities actually present in this conversation.
+    return identities.map((identity) => ({
+      ...identity,
+      ...(identity.botUserId && (counts.get(identity.botUserId) ?? 0) > 1 ? { botShared: true } : {})
     }))
   }
 
   /** The exact address for `agentId` in this conversation, or undefined when it has
    *  none there (no Slack presence, or a shared bot with no slug to disambiguate it). */
   mentionAddress(orgId: string, platform: string, channelId: string, agentId: string): string | undefined {
-    const placement = this.resolve(orgId, platform, channelId, agentId)
-    if (!placement) return undefined
-    return slackMentionAddress({
-      agentId,
-      ...(placement.botUserId !== undefined ? { botUserId: placement.botUserId } : {}),
-      ...(placement.botShared ? { botShared: true } : {}),
-      ...(placement.name !== undefined ? { name: placement.name } : {})
-    })
+    const identity = this.mentionDirectory(orgId, platform, channelId).find((agent) => agent.agentId === agentId)
+    return identity ? slackMentionAddress(identity) : undefined
   }
 
   /** True when an inbound app backs another AgentConnect agent in this channel.

--- a/packages/daemon/test/cp/cp-agent-directory.test.ts
+++ b/packages/daemon/test/cp/cp-agent-directory.test.ts
@@ -282,6 +282,43 @@ describe('CpCollabRoutes: org-scoped directory', () => {
   })
 })
 
+describe('CpCollabRoutes: conversation-scoped mention identities', () => {
+  it('corrects an old CP false-positive botShared flag for a sole channel member', () => {
+    const r = routes(
+      [agent('a')],
+      [
+        {
+          orgId: ORG,
+          platform: 'slack',
+          channelId: 'C1',
+          agents: [agent('a', { botUserId: 'U01ONLY', botShared: true, name: 'reviewer' })]
+        }
+      ]
+    )
+    expect(r.mentionDirectory(ORG, 'slack', 'C1')).toEqual([{ agentId: 'a', botUserId: 'U01ONLY', name: 'reviewer' }])
+    expect(r.mentionAddress(ORG, 'slack', 'C1', 'a')).toBe('<@U01ONLY>')
+  })
+
+  it('corrects a missing botShared flag when several agents use one channel identity', () => {
+    const r = routes(
+      [agent('a'), agent('b')],
+      [
+        {
+          orgId: ORG,
+          platform: 'slack',
+          channelId: 'C1',
+          agents: [
+            agent('a', { botUserId: 'U09SHARED', name: 'reviewer' }),
+            agent('b', { botUserId: 'U09SHARED', name: 'planner' })
+          ]
+        }
+      ]
+    )
+    expect(r.mentionAddress(ORG, 'slack', 'C1', 'a')).toBe('<@U09SHARED> reviewer')
+    expect(r.mentionAddress(ORG, 'slack', 'C1', 'b')).toBe('<@U09SHARED> planner')
+  })
+})
+
 /** Minimal daemon root — enough to boot and read the MCP deps bundle. */
 function scaffold(): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-daemon-directory-'))

--- a/packages/message/src/slack-mention-address.ts
+++ b/packages/message/src/slack-mention-address.ts
@@ -89,10 +89,10 @@ export function resolveSlackMentionedAgents(text: string, agents: readonly Agent
   for (const match of text.matchAll(MENTION_RE)) {
     const candidates = byUserId.get(match[1]!)
     if (!candidates) continue
-    // Treat the identity as shared when the SNAPSHOT says so, or when more than one
-    // agent sits behind the id — the second covers a stale/partial snapshot that forgot
-    // the flag, and erring toward "needs a slug" only ever resolves fewer agents.
-    const shared = candidates.length > 1 || candidates.some((c) => c.botShared)
+    // Sharing is a property of this complete conversation directory. Do not trust a
+    // stale `botShared` flag derived from bot configuration: one candidate is dedicated
+    // here; several candidates require the trailing agent slug.
+    const shared = candidates.length > 1
     let agent: AgentMentionIdentity | undefined
     if (!shared) {
       agent = candidates[0]

--- a/packages/message/test/slack-mention-address.test.ts
+++ b/packages/message/test/slack-mention-address.test.ts
@@ -90,6 +90,14 @@ describe('resolveSlackMentionedAgents (§5.1 / §6)', () => {
     expect(resolveSlackMentionedAgents('<@U09SHARED> planner hello', stale)).toEqual(['b'])
   })
 
+  it('ignores a stale shared flag when the conversation has only one candidate', () => {
+    expect(
+      resolveSlackMentionedAgents('<@U01ONLY> hello', [
+        { agentId: 'a', botUserId: 'U01ONLY', botShared: true, name: 'reviewer' }
+      ])
+    ).toEqual(['a'])
+  })
+
   it('is case-insensitive on the slug but not on the member id', () => {
     expect(resolveSlackMentionedAgents('<@U09SHARED> Planner go', directory)).toEqual(['agent-shared-b'])
   })


### PR DESCRIPTION
## Summary

- derive Slack shared mention addresses from the agents actually behind a `botUserId` in one channel, instead of the bot's `shareable` capacity setting
- normalize mention directories in the daemon so a new daemon corrects stale `botShared` metadata from an older control plane
- capture `auth.test.user_id` for new Slack installs, backfill it for legacy bots, and refresh collaboration snapshots after repair

## Why

`listAgents({ channel })` promises an exact platform-ready `mention`, but its renderer still depended on two unreliable snapshot inputs: `botShared` was copied from `Bot.shareable`, and legacy bot rows often had no `botUserId`. That could omit the address or render an address that ingress could not resolve back to the intended agent.

This PR keeps the conversation model unchanged: a mention joins an agent to the thread, while every existing participant still receives later messages. It only repairs address discovery and mention resolution.

## Compatibility

- new control planes emit a truthful `botShared` compatibility flag for older daemons
- new daemons recompute sharing from the complete channel directory, correcting older control-plane snapshots
- missing legacy Slack member IDs converge in the background and trigger a snapshot broadcast; failed broadcasts remain queued for a later retry

## Validation

- message mention tests: 31 passed
- daemon channel-directory tests: 29 passed
- control-plane focused unit tests: 59 passed
- control-plane Postgres integration tests: 2 passed
- message, daemon, and control-plane typechecks
- repository lint and format check
