### PR TITLE
fix(auth): explain reconnect account mismatch

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -538,6 +538,8 @@ and unclassified degradation keep the generic unavailable notice. Feishu versus 
 named from the session scope's verified regional app, never from a URL hint. Diagnostics
 may retain only the provider target, failure stage, HTTP status, and a bounded upstream
 error code — never account ids, bearer tokens, or upstream error messages.
+A reconnect that proves a different provider account must not replace the linked identity;
+the console tells the user to reconnect with the linked account or unlink before switching.
 
 Making a session private hides its transcript immediately, but agent memory is shared
 across the whole agent, so the guarantee about memory is narrower and must be stated

--- a/packages/web/src/lib/logto-account.test.ts
+++ b/packages/web/src/lib/logto-account.test.ts
@@ -78,6 +78,23 @@ describe('Logto Account API', () => {
     ).toBe('That Google account is already linked to another AgentConnect account.')
   })
 
+  it('explains that reconnecting with another provider account cannot replace the linked identity', async () => {
+    const { LogtoAccountError, accountErrorMessage } = await import('./logto-account')
+
+    expect(
+      accountErrorMessage(
+        new LogtoAccountError(
+          'The social identity does not exist in the current user.',
+          422,
+          'user.identity_not_exists_in_current_user'
+        ),
+        { providerName: 'Lark', operation: 'reauthorize' }
+      )
+    ).toBe(
+      'You authorized a different Lark account. Reconnect with the account already linked to this profile. To switch accounts, make sure another sign-in method is linked, then unlink Lark.'
+    )
+  })
+
   // Measured against a live tenant: a session opened before the deployment
   // granted the identities scope keeps working everywhere else, so "expired"
   // sends people to retry the same broken thing. Only a fresh sign-in helps.

--- a/packages/web/src/lib/logto-account.ts
+++ b/packages/web/src/lib/logto-account.ts
@@ -226,6 +226,10 @@ export function accountErrorMessage(
       : undefined
   if (!requestError) return 'Something went wrong. Try again.'
   if ((requestError.status === 409 || requestError.status === 422) && context?.operation) {
+    if (context.operation === 'reauthorize' && requestError.code === 'user.identity_not_exists_in_current_user') {
+      const providerName = context.providerName ?? 'social'
+      return `You authorized a different ${providerName} account. Reconnect with the account already linked to this profile. To switch accounts, make sure another sign-in method is linked, then unlink ${providerName}.`
+    }
     const reason = `${requestError.code ?? ''} ${requestError.message}`.toLowerCase()
     if (
       context.operation === 'link' &&


### PR DESCRIPTION
## Summary

- detect Logto's different-account error during social reauthorization
- explain that Reconnect must use the already-linked Lark or Feishu account
- direct intentional account switches through the explicit Unlink then Link flow
- document that reconnect never replaces the linked identity

## Root cause

The social callback collapsed every 409 or 422 reauthorization failure into a generic expired-authorization message. When the provider account picker returned a different account, Logto correctly rejected token renewal for the linked identity, but AgentConnect did not explain what happened or how to switch accounts safely.

## Impact

Users now get an actionable error without silently changing the identity that controls session visibility.

## Validation

- `pnpm --filter @agentconnect.md/web exec vitest run src/lib/logto-account.test.ts`
- `pnpm --filter @agentconnect.md/web test`
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web lint`
- `pnpm --filter @agentconnect.md/web build`
- focused Prettier check and `git diff --check`

Created by Codex . GPT-5.6
