### PR TITLE
refactor(cp): spec assembly and rc/bot-assign project through the platform providers (S3 §9)

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -528,6 +528,23 @@ export function buildContainer(
   // The single fencing site (allocates seq, stamps epoch/launchId on C→D frames).
   const sender = new ControlSender(connReg, repos.launch)
 
+  // LATE-BOUND platform registry (§9). The providers are constructed FAR below —
+  // they close over `httpDeps`, whose own route plugins do not exist yet — but the
+  // orchestrators built here already need to reach them (spec assembly,
+  // `rc/bot-assign`). `platforms` is a stable façade every holder can capture now;
+  // it forwards to the composed registry, and every read runs at reconcile /
+  // sync / request time, long after `buildContainer` has assigned it.
+  let composedPlatforms: CpPlatformRegistry | undefined = undefined
+  const requirePlatforms = (): CpPlatformRegistry => {
+    if (!composedPlatforms) throw new Error('platform registry read before composition')
+    return composedPlatforms
+  }
+  const platforms: CpPlatformRegistry = {
+    get: (platformId) => requirePlatforms().get(platformId),
+    all: () => requirePlatforms().all(),
+    ids: () => requirePlatforms().ids()
+  }
+
   // Per-session memory-capture gate convergence (session-visibility.md §5.1):
   // the CP is the authority on effective visibility; daemons only enforce it.
   const visibilityPush = new SessionVisibilityPushService({
@@ -566,7 +583,8 @@ export function buildContainer(
       info: (o, m) => http.log.info(o, m),
       warn: (o, m) => http.log.warn(o, m),
       debug: (o, m) => http.log.debug(o, m)
-    }
+    },
+    platforms
   )
   const stagedAgentMoves = new AgentMoveService({
     agents: repos.agent,
@@ -575,6 +593,7 @@ export function buildContainer(
     integrationChannels: repos.integrationChannel,
     bots: repos.bot,
     botSecrets: repos.botSecret,
+    platforms,
     specs: agentSpecs,
     crons: repos.cron,
     control: sender,
@@ -598,6 +617,7 @@ export function buildContainer(
     agentSpecs,
     repos.integrationChannel,
     repos.bot,
+    platforms,
     {
       registry: connReg,
       sender,
@@ -782,19 +802,14 @@ export function buildContainer(
   const syncDiscordBotProfile = createDiscordBotProfileSyncer(iconStore)
   const syncFeishuAppIcon = createFeishuAppIconSyncer(iconStore)
 
-  // LATE-BOUND on purpose: the providers below are constructed WITH `httpDeps`
-  // (their funnel plugins are route factories pre-bound to this very bundle), so
-  // the registry cannot exist before this object does. Every reader runs at
-  // Fastify `ready()` time or later — route plugins are registered lazily — by
-  // which point `buildContainer` has assigned it.
-  let platformRegistry: CpPlatformRegistry | undefined = undefined
-
   const httpDeps: HttpDeps = {
     clock,
-    get platforms(): CpPlatformRegistry {
-      if (!platformRegistry) throw new Error('platform registry read before composition')
-      return platformRegistry
-    },
+    // The same late-bound façade the orchestrators above hold (see its
+    // definition): the providers below are constructed WITH `httpDeps` — their
+    // funnel plugins are route factories pre-bound to this very bundle — so the
+    // registry cannot exist before this object does. Every reader runs at
+    // Fastify `ready()` time or later, by which point it has been assigned.
+    platforms,
     repos: {
       agent: repos.agent,
       assignment: repos.assignment,
@@ -1046,14 +1061,15 @@ export function buildContainer(
   // path). The Slack/Feishu funnel plugins are handed in PRE-BOUND to
   // `httpDeps` — the very factories `server.ts` mounts — keeping provider
   // construction one-directional (a provider never reaches back for a route
-  // factory). That is also why the registry is published to `httpDeps` through
-  // the late-bound getter above rather than as a plain field.
+  // factory). That is also why every holder captures the late-bound `platforms`
+  // façade defined near the top rather than this value directly.
   //
   // ADOPTED SO FAR: the `POST /integrations` create body + its live
-  // `validateConfig` dispatch read the registry through `httpDeps.platforms`.
-  // Spec assembly, rc/bot-assign, route mounting, `loadConfig`'s schema fold,
-  // and `startBackground()` adopt it in follow-up PRs.
-  const platforms = buildCpPlatformRegistry([
+  // `validateConfig` dispatch; and (§9) ALL wire projection — `IntegrationSpec.
+  // config` on every spec-assembly path and both `rc/bot-assign` bags. Route
+  // mounting, `loadConfig`'s schema fold, and `startBackground()` adopt it in
+  // follow-up PRs.
+  composedPlatforms = buildCpPlatformRegistry([
     createTelegramCpProvider({ verifyBot: verifyTelegramBot, syncBotIcon: syncTelegramBotIcon }),
     createDiscordCpProvider({
       verifyBot: verifyDiscordBot,
@@ -1086,7 +1102,6 @@ export function buildContainer(
       }
     })
   ])
-  platformRegistry = platforms
 
   // ── daemon WS edge (mounted on the live http.Server after listen) ──────────
   const wsDeps: DaemonWsServerDeps = {

--- a/packages/control-plane/src/http/install-feishu.ts
+++ b/packages/control-plane/src/http/install-feishu.ts
@@ -105,15 +105,19 @@ export async function installNewFeishuBot(
     return integration
   }
 
-  const [secret, channels] = await Promise.all([
+  // The bot row joins the reads: it is a required input of the §9 projector that
+  // now assembles the spec payload (`orchestrator/placement.ts`). It was created
+  // or matched above, so this read always hits.
+  const [secret, channels, botRow] = await Promise.all([
     deps.repos.botSecret.get(botId),
-    deps.repos.integrationChannel.listForIntegration(id)
+    deps.repos.integrationChannel.listForIntegration(id),
+    deps.repos.bot.get(botId)
   ])
-  if (secret) {
+  if (secret && botRow) {
     try {
       await deps.control.integrationUpsert(
         agent.daemonId!,
-        integrationToSpec(integration, secret, channels, isGatedAgent(agent))
+        await integrationToSpec(deps.platforms, integration, botRow, secret, channels, isGatedAgent(agent))
       )
     } catch (err) {
       if (!(err instanceof NoConnection)) throw err

--- a/packages/control-plane/src/http/install-slack.ts
+++ b/packages/control-plane/src/http/install-slack.ts
@@ -130,15 +130,19 @@ export async function installNewSlackBot(
   // the Socket Mode socket. Best-effort: an offline daemon picks it up from the
   // register/ok reconcile roster on reconnect. Never log the token-bearing spec.
   const daemonId = agent.daemonId! // caller guarantees placement for socket transport
-  const [secret, channels] = await Promise.all([
+  // The bot row joins the reads: it is a required input of the §9 projector that
+  // now assembles the spec payload (`orchestrator/placement.ts`). It was created
+  // above, so this read always hits.
+  const [secret, channels, botRow] = await Promise.all([
     deps.repos.botSecret.get(botId),
-    deps.repos.integrationChannel.listForIntegration(id)
+    deps.repos.integrationChannel.listForIntegration(id),
+    deps.repos.bot.get(botId)
   ])
-  if (secret) {
+  if (secret && botRow) {
     try {
       await deps.control.integrationUpsert(
         daemonId,
-        integrationToSpec(integration, secret, channels, isGatedAgent(agent))
+        await integrationToSpec(deps.platforms, integration, botRow, secret, channels, isGatedAgent(agent))
       )
     } catch (err) {
       if (!(err instanceof NoConnection)) throw err

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -935,6 +935,7 @@ export function agentRoutes(deps: HttpDeps) {
       integrationChannels: deps.repos.integrationChannel,
       bots: deps.repos.bot,
       botSecrets: deps.repos.botSecret,
+      platforms: deps.platforms,
       specs: deps.agentSpecs,
       crons: deps.repos.cron,
       control: deps.control,

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -106,16 +106,21 @@ export function integrationRoutes(deps: HttpDeps) {
     // daemon. Best-effort: if the daemon is offline the reconcile roster carries it
     // on the next connect. Token-bearing — never log the spec.
     const replicateUpsert = async (i: IntegrationRecord, daemonId: string): Promise<void> => {
-      const [secret, channels, owner] = await Promise.all([
+      // The bot row joins the reads: it is a required input of the §9 projector
+      // that now assembles the spec payload (`orchestrator/placement.ts`). Every
+      // caller here is already on the socket-transport arm, so the projector
+      // returns the same direct-mode payload this path emitted before.
+      const [secret, channels, owner, bot] = await Promise.all([
         deps.repos.botSecret.get(i.botId),
         deps.repos.integrationChannel.listForIntegration(i.id),
-        deps.repos.agent.get(i.agentId)
+        deps.repos.agent.get(i.agentId),
+        deps.repos.bot.get(i.botId)
       ])
-      if (!secret) return
+      if (!secret || !bot) return
       try {
         await deps.control.integrationUpsert(
           daemonId,
-          integrationToSpec(i, secret, channels, owner ? isGatedAgent(owner) : false)
+          await integrationToSpec(deps.platforms, i, bot, secret, channels, owner ? isGatedAgent(owner) : false)
         )
       } catch (err) {
         if (!(err instanceof NoConnection)) throw err

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -17,6 +17,20 @@ import type { CollabRoutesService } from './collabRoutes.service.js'
 import { AgentMoveConflict, AgentMoveFailed, AgentMoveService } from './agentMove.js'
 import { AgentSpecAssembler } from './agentSpecAssembler.js'
 import { AgentMutationGate } from './agentMutationGate.js'
+import { buildCpPlatformRegistry } from '../platforms/registry.js'
+import { createSlackCpProvider } from '../platforms/slack/provider.js'
+import { createTelegramCpProvider } from '../platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../platforms/discord/provider.js'
+import { createFeishuCpProvider } from '../platforms/feishu/provider.js'
+
+// §9: the move bundle's `IntegrationSpec.config` comes from the platform
+// provider. Offline stubs — the projectors reach no provider API.
+const PLATFORMS = buildCpPlatformRegistry([
+  createSlackCpProvider({}),
+  createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+  createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+  createFeishuCpProvider({})
+])
 
 const AGENT = AgentId('11111111-1111-4111-8111-111111111111')
 const SOURCE = DaemonId('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
@@ -234,6 +248,7 @@ function make(
     botSecrets: {
       get: async () => ({ botToken: 'xoxb-test', appToken: 'xapp-test' })
     } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['botSecrets'],
+    platforms: PLATFORMS,
     // The real assembler over a fake store — exercises project()/secretsOf() as prod does.
     specs: new AgentSpecAssembler({
       get: async () => ({}),

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -38,6 +38,7 @@ import type {
 import { AgentWorkspaceIntegrationConflict } from '../persistence/errors.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
 import { cronToUpsert, integrationToSpec, isGatedAgent, httpIntegrationToSpec } from './placement.js'
+import type { CpPlatformRegistry } from '../platforms/provider.js'
 import type { AgentSpecAssembler } from './agentSpecAssembler.js'
 import type { OrganizationEnvironmentValues } from './organizationEnvironment.js'
 import type { ControlSender } from './outbound.js'
@@ -78,6 +79,9 @@ export interface AgentMoveDeps {
   integrationChannels: IntegrationChannelRepo
   bots: BotRepo
   botSecrets: BotSecretStore
+  /** §9 platform providers — the projector behind every `IntegrationSpec.config`
+   *  in the move bundle (`orchestrator/placement.ts`). */
+  platforms: CpPlatformRegistry
   /** Owns AgentSpec assembly (secret loading + icon bases) for the activation definition. */
   specs: AgentSpecAssembler
   crons: CronRepo
@@ -594,8 +598,8 @@ export class AgentMoveService {
           botId: String(bot.id),
           http: isHttp,
           spec: isHttp
-            ? httpIntegrationToSpec(integration, secret, bot.shareable, channels, gated, bot.slackAppId ?? undefined)
-            : integrationToSpec(integration, secret, channels, gated)
+            ? await httpIntegrationToSpec(this.deps.platforms, integration, bot, secret, channels, gated)
+            : await integrationToSpec(this.deps.platforms, integration, bot, secret, channels, gated)
         }
       })
     )

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -18,6 +18,21 @@ import type {
   ThreadAffinityStore,
   SessionRepo
 } from '../persistence/ports.js'
+import type { CpPlatformProvider } from '../platforms/provider.js'
+import { buildCpPlatformRegistry } from '../platforms/registry.js'
+import { createSlackCpProvider } from '../platforms/slack/provider.js'
+import { createTelegramCpProvider } from '../platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../platforms/discord/provider.js'
+import { createFeishuCpProvider } from '../platforms/feishu/provider.js'
+
+// §9: both `rc/bot-assign` bags and every send-only spec payload come from the
+// platform provider. Offline stubs — the projectors reach no provider API.
+const PLATFORMS = buildCpPlatformRegistry([
+  createSlackCpProvider({}),
+  createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+  createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+  createFeishuCpProvider({})
+])
 
 // ── ids ──────────────────────────────────────────────────────────────────────
 const ORG = OrgId('11111111-1111-4111-8111-111111111111')
@@ -131,7 +146,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
   // a re-install landing between revokeBot's commit and its external effects.
   let bumpRevisionAfterFirstGet: boolean
 
-  function makeOrch(): HttpBotOrchestrator {
+  function makeOrch(platforms = PLATFORMS): HttpBotOrchestrator {
     const agents: Record<string, AgentRecord> = {
       [ALICE]: agent(ALICE, 'alice', unplacedAgents.has(ALICE) ? null : D1),
       [BOB]: agent(BOB, 'bob', unplacedAgents.has(BOB) ? null : D2)
@@ -294,7 +309,8 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       control as never,
       threads,
       sessions as SessionRepo,
-      { info() {}, warn() {}, debug() {} }
+      { info() {}, warn() {}, debug() {} },
+      platforms
     )
   }
 
@@ -361,6 +377,42 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         target: null,
         participants: [{ agentId: BOB, daemonId: D2 }]
       })
+    })
+  })
+
+  // §9 erratum: `projectBotAssign` is OPTIONAL — a platform whose inbound
+  // transport is a daemon-owned long-lived connection contributes no relay
+  // projection, and its ABSENCE is the "no relay path" signal. Core must neither
+  // fabricate an empty assign (the relay would arm an ingress it cannot verify)
+  // nor throw; it takes the same outcome as the other "cannot assign" guards.
+  describe('a platform with no projectBotAssign (§9 erratum)', () => {
+    /** The slack provider with its relay projection removed — a platform that
+     *  contributes a spec projector but no assign projector, like telegram and
+     *  discord (whose bots the create route refuses `transport: 'http'` for, on
+     *  exactly this signal, so this arm is unreachable in production). */
+    const noRelayPath = (): ReturnType<typeof buildCpPlatformRegistry> => {
+      const { projectBotAssign: _omitted, ...rest } = createSlackCpProvider({})
+      return buildCpPlatformRegistry([rest as CpPlatformProvider])
+    }
+
+    it('broadcasts no rc/bot-assign and does not throw', async () => {
+      await expect(makeOrch(noRelayPath()).syncBot(BOT)).resolves.toBeUndefined()
+      expect(ch.sends.filter((s) => s.type === 'rc/bot-assign')).toEqual([])
+      // Nothing was half-armed: no empty/partial frame of any kind went out.
+      expect(ch.sends).toEqual([])
+      // …and an unassignable bot gets no send-only spec either — it has no ingress.
+      expect(upserts).toEqual([])
+    })
+
+    it('skips the bot on the register replay instead of failing the whole replay', async () => {
+      const fresh = new FakeChannel('66666666-6666-4666-8666-666666666666')
+      await expect(makeOrch(noRelayPath()).replayTo(fresh)).resolves.toBeUndefined()
+      expect(fresh.sends).toEqual([])
+    })
+
+    it('still assigns once the platform DOES contribute a relay projection', async () => {
+      await makeOrch().syncBot(BOT)
+      expect(ch.sends.filter((s) => s.type === 'rc/bot-assign')).toHaveLength(1)
     })
   })
 

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -45,8 +45,7 @@ import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 import { ControlSender, NoConnection } from './outbound.js'
 import { isDirectConversationKind } from '../persistence/ports.js'
 import { isGatedAgent, httpIntegrationToSpec } from './placement.js'
-import { slackBotAssignBags } from '../platforms/slack/provider.js'
-import { feishuBotAssignBags } from '../platforms/feishu/provider.js'
+import type { CpPlatformRegistry } from '../platforms/provider.js'
 import { AgentId, BotId, DaemonId } from '../domain/ids.js'
 
 export interface HttpBotLog {
@@ -107,7 +106,12 @@ export class HttpBotOrchestrator {
     private readonly control: ControlSender,
     private readonly threads: ThreadAffinityStore,
     private readonly sessions: SessionRepo,
-    private readonly log: HttpBotLog
+    private readonly log: HttpBotLog,
+    /** §9 platform providers — the ONLY source of the `rc/bot-assign` credential
+     *  and demux bags, and (through `httpIntegrationToSpec`) of a send-only
+     *  spec's payload. Late-bound in the composition root; every read happens at
+     *  sync/replay time. */
+    private readonly platforms: CpPlatformRegistry
   ) {}
 
   /**
@@ -151,7 +155,13 @@ export class HttpBotOrchestrator {
       return
     }
 
-    const assign = this.buildAssign(bot, compiled, secret)
+    const assign = await this.buildAssign(bot, compiled, secret)
+    if (!assign) {
+      // No `projectBotAssign` ⇒ no relay path for this platform (§9). Nothing to
+      // broadcast, and no send-only spec either: an unassigned bot has no ingress.
+      this.log.warn({ botId, platform: bot.platform }, 'http-bot: platform contributes no relay ingress — skipping')
+      return
+    }
     this.broadcast((ch) => ch.send('rc/bot-assign', assign))
     this.log.info(
       { botId: bot.id, members: compiled.members.length, routes: compiled.routes.length },
@@ -310,8 +320,14 @@ export class HttpBotOrchestrator {
       if (!secret) continue
       if (bot.platform === 'slack' && !secret.signingSecret) continue
       if (bot.platform === 'feishu' && (!secret.verificationToken || !secret.appToken)) continue
+      // Built OUTSIDE the try on purpose: the catch below means "dead socket",
+      // and a projector rejection swallowed there would be a lost error rather
+      // than a dropped send. A null assign is the platform having no relay path
+      // (§9) — nothing to replay for this bot.
+      const assign = await this.buildAssign(bot, compiled, secret)
+      if (!assign) continue
       try {
-        ch.send('rc/bot-assign', this.buildAssign(bot, compiled, secret))
+        ch.send('rc/bot-assign', assign)
         for (const t of await this.threads.listForBot(bot.id)) {
           ch.send('rc/assign', { botId: bot.id, sessionKey: t.sessionKey, agentId: t.agentId, daemonId: t.daemonId })
         }
@@ -896,11 +912,7 @@ export class HttpBotOrchestrator {
 
   /** Deliver the HTTP-transport send-only spec to each member agent's daemon (best-effort).
    *  `shareable` rides each spec so the daemon knows whether to expose "Switch agent". */
-  private async pushSpecs(
-    compiled: Compiled,
-    secret: BotSecretMaterial,
-    bot: Pick<BotRecord, 'shareable' | 'slackAppId' | 'botUserId'>
-  ): Promise<void> {
+  private async pushSpecs(compiled: Compiled, secret: BotSecretMaterial, bot: BotRecord): Promise<void> {
     // A gated install's spec carries its conversation-scoped rules for the daemon's
     // last-hop admission backstop (§14.3), and EVERY install carries its Off channels
     // for the same backstop. The compile already read the bot's rows; they are keyed
@@ -910,15 +922,7 @@ export class HttpBotOrchestrator {
         const channels = compiled.botChannels.filter((c) => c.integrationId === integration.id)
         await this.control.integrationUpsert(
           daemonId,
-          httpIntegrationToSpec(
-            integration,
-            secret,
-            bot.shareable,
-            channels,
-            gated,
-            bot.slackAppId ?? undefined,
-            bot.botUserId ?? undefined
-          )
+          await httpIntegrationToSpec(this.platforms, integration, bot, secret, channels, gated)
         )
       } catch (err) {
         if (!(err instanceof NoConnection)) throw err
@@ -927,23 +931,40 @@ export class HttpBotOrchestrator {
     }
   }
 
-  /** Assemble the `rc/bot-assign` frame (credentials + attributed routing table).
-   *  Secret — NEVER log the result. */
-  private buildAssign(bot: BotRecord, compiled: Compiled, secret: BotSecretMaterial): RcBotAssign {
+  /**
+   * Assemble the `rc/bot-assign` frame (credentials + attributed routing table).
+   * Secret — NEVER log the result.
+   *
+   * `null` ⇒ **this platform has no relay path** and no frame exists to send.
+   * `projectBotAssign` is OPTIONAL by design (§9 erratum): a platform whose
+   * inbound transport is a daemon-owned long-lived connection simply does not
+   * declare it, and the create route already refuses `transport: 'http'` for
+   * exactly those platforms on exactly this signal
+   * (`http/routes/integrations.ts`). So no such bot row can carry the http
+   * transport and this arm is unreachable — which is why absence must neither
+   * fabricate an empty assign (the relay would arm an ingress it cannot verify)
+   * nor throw (a composition-shaped platform set would take down `syncBot` for
+   * every OTHER bot). It joins the two existing "cannot assign" outcomes below:
+   * the caller logs and moves on, and the next reconcile retries.
+   */
+  private async buildAssign(
+    bot: BotRecord,
+    compiled: Compiled,
+    secret: BotSecretMaterial
+  ): Promise<RcBotAssign | null> {
     // §6.7 emission flip (the last S1b dual-shape residue): the opaque ingress
     // bag is the ONE carrier of the demux identity — the relay's bag-preferring
     // reader shipped first (#545). The retired named top-level fields stay
     // OPTIONAL in the wire schema so an older relay's tolerant reader is not
     // broken by their absence; they leave the schema with the next cleanup.
     //
-    // §9 shared projection bodies (S3): the same functions the Slack/Feishu
-    // platform providers' `projectBotAssign` return — one implementation for
-    // the live frame and the provider seam (each helper documents its bag
-    // fields). Telegram/Discord bots never carry the http transport (the
-    // create route refuses it), so the slack-shaped arm is the effective
-    // default, exactly as the previous inline ternaries fell through.
-    const { secrets, ingress } =
-      bot.platform === 'feishu' ? feishuBotAssignBags(bot, secret) : slackBotAssignBags(bot, secret)
+    // §9 projector adoption (S3): the two bags come from the platform provider,
+    // so the four-way platform fork is gone — core assembles everything else on
+    // the frame (the compiled routing table, the member directory, the gating
+    // fences, `credentialRevision`) and merely awaits the provider's output.
+    const bags = await this.platforms.get(bot.platform)?.projectBotAssign?.(bot, secret)
+    if (!bags) return null
+    const { secrets, ingress } = bags
     return {
       botId: bot.id,
       platform: compiled.platform,

--- a/packages/control-plane/src/orchestrator/integrationPush.ts
+++ b/packages/control-plane/src/orchestrator/integrationPush.ts
@@ -15,6 +15,7 @@ import type {
 } from '../persistence/ports.js'
 import { NoConnection, type ControlSender } from './outbound.js'
 import { integrationToSpec, isGatedAgent } from './placement.js'
+import type { CpPlatformRegistry } from '../platforms/provider.js'
 import { AgentId } from '../domain/ids.js'
 
 export interface GatingPushDeps {
@@ -26,6 +27,10 @@ export interface GatingPushDeps {
   }
   control: ControlSender
   httpBot: { syncBot(botId: string): Promise<void> }
+  /** §9 platform providers — the projector behind the re-pushed spec's payload.
+   *  `HttpDeps` already carries this field, so the caller passes its bundle
+   *  unchanged. */
+  platforms: CpPlatformRegistry
 }
 
 export async function convergeIntegrationGating(
@@ -46,13 +51,20 @@ export async function convergeIntegrationGating(
         }
         continue
       }
+      // The bot row is a required projector input (§9). Unreachable — the
+      // integration→bot FK is non-null and `onDelete: Restrict` — but a spec
+      // without it would be a fabricated identity, so skip like a missing secret.
+      if (!bot) continue
       if (!agent.daemonId) continue
       const [secret, channels] = await Promise.all([
         deps.repos.botSecret.get(i.botId),
         deps.repos.integrationChannel.listForIntegration(i.id)
       ])
       if (!secret) continue
-      await deps.control.integrationUpsert(agent.daemonId, integrationToSpec(i, secret, channels, gated))
+      await deps.control.integrationUpsert(
+        agent.daemonId,
+        await integrationToSpec(deps.platforms, i, bot, secret, channels, gated)
+      )
     } catch (err) {
       if (err instanceof NoConnection) continue // offline daemon → reconcile roster carries it
       log?.warn({ integrationId: i.id, err: (err as Error).message }, 'gating converge: integration push failed')

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -8,14 +8,30 @@
 import { describe, it, expect } from 'vitest'
 import { integrationToSpec } from './placement.js'
 import { agentRecordToSpec } from './agentSpecAssembler.js'
-import type { AgentRecord, IntegrationChannelRecord, IntegrationRecord } from '../persistence/ports.js'
-import { AgentId, IntegrationId, OrgId } from '../domain/ids.js'
+import type { AgentRecord, BotRecord, IntegrationChannelRecord, IntegrationRecord } from '../persistence/ports.js'
+import { AgentId, BotId, IntegrationId, OrgId } from '../domain/ids.js'
+import { buildCpPlatformRegistry } from '../platforms/registry.js'
+import { createSlackCpProvider } from '../platforms/slack/provider.js'
+import { createTelegramCpProvider } from '../platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../platforms/discord/provider.js'
+import { createFeishuCpProvider } from '../platforms/feishu/provider.js'
 import {
   IntegrationSlackConfig,
   IntegrationTelegramConfig,
   IntegrationDiscordConfig,
   IntegrationFeishuConfig
 } from '@agentconnect.md/protocol'
+
+// The §9 projector seam: spec assembly now awaits the platform provider for the
+// opaque `config` payload, so every call needs the registry + the bot row. The
+// four providers are constructed with offline stubs — the projectors reach none
+// of them (they are pure functions of the row + the decrypted secret).
+const PLATFORMS = buildCpPlatformRegistry([
+  createSlackCpProvider({}),
+  createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+  createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+  createFeishuCpProvider({})
+])
 
 // §6.4 emission flip: the spec carries envelope (`core`) + opaque `config` only.
 // Tests validate the payload through the SAME wire schema the daemon reader uses.
@@ -35,6 +51,31 @@ const INTEGRATION: IntegrationRecord = {
 }
 const SECRET = { botToken: 'xoxb-abc', appToken: 'xapp-def' }
 
+/** A socket-transport bot row — the direct-mode fork the projector applies. Only
+ *  the fields the four projectors read are meaningful. */
+const bot = (over: Partial<BotRecord> = {}): BotRecord =>
+  ({
+    id: BotId('88888888-8888-4888-8888-888888888888'),
+    orgId: OrgId('org'),
+    platform: 'slack',
+    name: 'acme-bot',
+    transport: 'socket',
+    shareable: false,
+    slackAppId: null,
+    teamId: null,
+    botUserId: null,
+    ...over
+  }) as BotRecord
+
+/** `integrationToSpec` with the registry + the matching bot row pre-bound, so the
+ *  cases below keep reading as the trigger→bindRules fold they are testing. */
+const specOf = (
+  i: IntegrationRecord,
+  secret: Parameters<typeof integrationToSpec>[3],
+  channels: IntegrationChannelRecord[] = [],
+  gated = false
+) => integrationToSpec(PLATFORMS, i, bot({ platform: i.platform }), secret, channels, gated)
+
 const channel = (
   channelId: string,
   trigger: 'off' | 'mention' | 'any',
@@ -50,14 +91,14 @@ const channel = (
 })
 
 describe('integrationToSpec bindRules', () => {
-  it('defaults to mention + dm with no channels', () => {
-    const spec = integrationToSpec(INTEGRATION, SECRET)
+  it('defaults to mention + dm with no channels', async () => {
+    const spec = await specOf(INTEGRATION, SECRET)
     expect(slackCfg(spec).bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
     expect(slackCfg(spec).botToken).toBe(SECRET.botToken)
   })
 
-  it("adds one channel-scoped 'auto' rule per 'any message' channel; 'mention' channels add none", () => {
-    const spec = integrationToSpec(INTEGRATION, SECRET, [
+  it("adds one channel-scoped 'auto' rule per 'any message' channel; 'mention' channels add none", async () => {
+    const spec = await specOf(INTEGRATION, SECRET, [
       channel('C1', 'mention'),
       channel('C2', 'any'),
       channel('C3', 'any')
@@ -70,8 +111,8 @@ describe('integrationToSpec bindRules', () => {
     ])
   })
 
-  it('uses the DM default for a 1:1 row and scopes a group DM set to "any"', () => {
-    const spec = integrationToSpec(INTEGRATION, SECRET, [
+  it('uses the DM default for a 1:1 row and scopes a group DM set to "any"', async () => {
+    const spec = await specOf(INTEGRATION, SECRET, [
       channel('C1', 'any'),
       channel('D1', 'any', 'im'),
       channel('G1', 'any', 'mpim')
@@ -84,8 +125,8 @@ describe('integrationToSpec bindRules', () => {
     ])
   })
 
-  it('emits a telegram-shaped spec (single botToken, no appToken) for a telegram integration', () => {
-    const spec = integrationToSpec({ ...INTEGRATION, platform: 'telegram' }, { botToken: '123:abc', appToken: null }, [
+  it('emits a telegram-shaped spec (single botToken, no appToken) for a telegram integration', async () => {
+    const spec = await specOf({ ...INTEGRATION, platform: 'telegram' }, { botToken: '123:abc', appToken: null }, [
       channel('-100', 'any')
     ])
     if (spec.platform !== 'telegram') throw new Error('expected telegram spec')
@@ -100,8 +141,8 @@ describe('integrationToSpec bindRules', () => {
 })
 
 describe('integrationToSpec conversation gating (§14)', () => {
-  it('gated: emits ONLY conversation-scoped rules — no unscoped defaults', () => {
-    const spec = integrationToSpec(
+  it('gated: emits ONLY conversation-scoped rules — no unscoped defaults', async () => {
+    const spec = await specOf(
       INTEGRATION,
       SECRET,
       [channel('C1', 'mention'), channel('C2', 'any'), channel('C3', 'off'), channel('D1', 'any', 'im')],
@@ -116,15 +157,15 @@ describe('integrationToSpec conversation gating (§14)', () => {
     ])
   })
 
-  it('gated with no enabled conversations ships an EMPTY rule set (fail-closed)', () => {
-    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'off'), channel('D1', 'off', 'im')], true)
+  it('gated with no enabled conversations ships an EMPTY rule set (fail-closed)', async () => {
+    const spec = await specOf(INTEGRATION, SECRET, [channel('C1', 'off'), channel('D1', 'off', 'im')], true)
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
     expect(slackCfg(spec).bindRules).toEqual([])
     expect(slackCfg(spec).gated).toBe(true)
   })
 
-  it("non-gated: an 'off' channel keeps the defaults but is muted; gated is false", () => {
-    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'off'), channel('D1', 'any', 'im')])
+  it("non-gated: an 'off' channel keeps the defaults but is muted; gated is false", async () => {
+    const spec = await specOf(INTEGRATION, SECRET, [channel('C1', 'off'), channel('D1', 'any', 'im')])
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
     expect(slackCfg(spec).gated).toBe(false)
     // The defaults are unscoped, so Off cannot be expressed by withholding a rule —
@@ -136,8 +177,8 @@ describe('integrationToSpec conversation gating (§14)', () => {
 })
 
 describe('integrationToSpec mutedChannels', () => {
-  it('mutes every Off channel and nothing else', () => {
-    const spec = integrationToSpec(INTEGRATION, SECRET, [
+  it('mutes every Off channel and nothing else', async () => {
+    const spec = await specOf(INTEGRATION, SECRET, [
       channel('C1', 'off'),
       channel('C2', 'mention'),
       channel('C3', 'any'),
@@ -147,37 +188,73 @@ describe('integrationToSpec mutedChannels', () => {
     expect(spec.core?.mutedChannels).toEqual(['C1', 'C4'])
   })
 
-  it('mutes direct rows on a non-gated integration', () => {
-    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('D1', 'off', 'im'), channel('G1', 'off', 'mpim')])
+  it('mutes direct rows on a non-gated integration', async () => {
+    const spec = await specOf(INTEGRATION, SECRET, [channel('D1', 'off', 'im'), channel('G1', 'off', 'mpim')])
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
     expect(spec.core?.mutedChannels).toEqual(['D1', 'G1'])
   })
 
   // A gated integration says Off by having no rule for the conversation; stating it
   // twice would let the two representations drift apart.
-  it('stays empty for a gated integration, whose Off is the missing rule', () => {
-    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'off'), channel('C2', 'mention')], true)
+  it('stays empty for a gated integration, whose Off is the missing rule', async () => {
+    const spec = await specOf(INTEGRATION, SECRET, [channel('C1', 'off'), channel('C2', 'mention')], true)
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
     expect(spec.core?.mutedChannels).toEqual([])
     expect(spec.core?.bindRules).toEqual([{ channel: 'C2', match: { kind: 'mention' } }])
   })
 
-  it('rides every platform variant', () => {
-    const tg = integrationToSpec({ ...INTEGRATION, platform: 'telegram' }, { botToken: '1:a', appToken: null }, [
+  it('rides every platform variant', async () => {
+    const tg = await specOf({ ...INTEGRATION, platform: 'telegram' }, { botToken: '1:a', appToken: null }, [
       channel('-100', 'off')
     ])
     if (tg.platform !== 'telegram') throw new Error('expected telegram spec')
     expect(tg.core?.mutedChannels).toEqual(['-100'])
-    const dc = integrationToSpec({ ...INTEGRATION, platform: 'discord' }, { botToken: 'bot', appToken: null }, [
+    const dc = await specOf({ ...INTEGRATION, platform: 'discord' }, { botToken: 'bot', appToken: null }, [
       channel('999', 'off')
     ])
     if (dc.platform !== 'discord') throw new Error('expected discord spec')
     expect(dc.core?.mutedChannels).toEqual(['999'])
-    const fs = integrationToSpec({ ...INTEGRATION, platform: 'feishu' }, { botToken: 'sec', appToken: 'cli_x' }, [
+    const fs = await specOf({ ...INTEGRATION, platform: 'feishu' }, { botToken: 'sec', appToken: 'cli_x' }, [
       channel('oc_1', 'off')
     ])
     if (fs.platform !== 'feishu') throw new Error('expected feishu spec')
     expect(fs.core?.mutedChannels).toEqual(['oc_1'])
+  })
+})
+
+/**
+ * §9 projector seam: core owns the envelope and the two fail-closed fences; the
+ * opaque `config` is the provider's. Both fences are unreachable in production —
+ * every persistence write already passes `toDbPlatform`, and the create route
+ * admits only registered platform ids — but the previous code's unrecognized-
+ * platform arm silently FELL THROUGH to the slack branch, so pin that it does
+ * not any more.
+ */
+describe('integrationToSpec platform fences (§9)', () => {
+  const foreign = { ...INTEGRATION, platform: 'mastodon' }
+
+  it('refuses an id no provider is registered for instead of falling through to slack', async () => {
+    const withoutSlack = buildCpPlatformRegistry([
+      createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) })
+    ])
+    // A SERVED id (slack) whose provider is simply not composed — the case that
+    // reaches the provider fence rather than `toDbPlatform`'s served-set check.
+    await expect(integrationToSpec(withoutSlack, INTEGRATION, bot(), SECRET, [], false)).rejects.toThrow(
+      /no control-plane platform provider registered for slack/
+    )
+  })
+
+  it('refuses an id outside the served set (the persistence fence, reused on the wire)', async () => {
+    await expect(
+      integrationToSpec(PLATFORMS, foreign, bot({ platform: 'mastodon' }), SECRET, [], false)
+    ).rejects.toThrow(/unknown platform mastodon/)
+  })
+
+  it('refuses a session-identity id, which has no persisted integration at all', async () => {
+    const webchat = { ...INTEGRATION, platform: 'webchat' }
+    await expect(
+      integrationToSpec(PLATFORMS, webchat, bot({ platform: 'webchat' }), SECRET, [], false)
+    ).rejects.toThrow(/session-identity platform/)
   })
 })
 

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -32,6 +32,7 @@ import type {
   BindRule,
   IntegrationSpec,
   IntegrationBindRule,
+  IntegrationCoreEnvelope,
   McpServerSpec,
   MemoryConnectionSpec,
   RelayRosterEntry
@@ -51,6 +52,7 @@ import type {
   IntegrationRecord,
   BotSecretStore,
   BotSecretMaterial,
+  BotRecord,
   BotRepo,
   IntegrationChannelRepo,
   IntegrationChannelRecord,
@@ -61,10 +63,7 @@ import type {
   ExternalMemoryGrantRepo,
   MemoryPluginInstallationRepo
 } from '../persistence/ports.js'
-import { telegramIntegrationConfig } from '../platforms/telegram/provider.js'
-import { discordIntegrationConfig } from '../platforms/discord/provider.js'
-import { slackIntegrationConfig, slackSharedIntegrationConfig } from '../platforms/slack/provider.js'
-import { feishuIntegrationConfig, feishuSharedIntegrationConfig } from '../platforms/feishu/provider.js'
+import type { CpPlatformRegistry } from '../platforms/provider.js'
 import { mcpProxyDef, relayHttpOrigin } from './mcpProvider.js'
 import { memoryConnectionSpec, stdioMemoryConnectionSpec } from './memoryConnection.js'
 import type { DaemonId } from '../domain/ids.js'
@@ -230,12 +229,14 @@ function mutedChannelIds(channels: IntegrationChannelRecord[], gated: boolean): 
  * covers it. Gated (`gated`, derived from the owning agent's restricted
  * visibility): NO unscoped defaults — only {@link gatedBindRules}.
  */
-export function integrationToSpec(
+export async function integrationToSpec(
+  platforms: CpPlatformRegistry,
   i: IntegrationRecord,
+  bot: BotRecord,
   secret: BotSecretMaterial,
   channels: IntegrationChannelRecord[] = [],
   gated = false
-): IntegrationSpec {
+): Promise<IntegrationSpec> {
   // A 1:1 DM's On state is already covered by the unscoped dm default. A group DM
   // set to Any needs its own auto rule; Mention is covered by the default mention rule.
   const channelRules: IntegrationBindRule[] = channels
@@ -248,35 +249,14 @@ export function integrationToSpec(
   // opaque `config` against the same wire schema and takes the routing knobs
   // from `core`. The nested members stay OPTIONAL in the wire schema until the
   // legacy readers retire.
+  //
+  // 'direct' (transport==='socket') — this daemon owns the long-lived inbound
+  // connection (Slack Socket Mode, the Telegram long-poll, the Discord Gateway,
+  // the Feishu WSClient). The 'shared' envelope is assembled by
+  // {@link httpIntegrationToSpec}; the two differ ONLY in this envelope, which is
+  // why the fork stays core and the payload behind it does not.
   const core = { mode: 'direct' as const, bindRules, mutedChannels, gated }
-  if (i.platform === 'telegram') {
-    // §9 shared projection body — the same function the platform provider's
-    // `projectIntegrationConfig` calls (S3; provider adoption replaces this arm).
-    const telegram = telegramIntegrationConfig(core, secret)
-    return { integrationId: i.id, agentId: i.agentId, platform: 'telegram', core, config: telegram }
-  }
-  if (i.platform === 'discord') {
-    // Discord authenticates the Gateway with the single bot token (no appToken).
-    // §9 shared projection body — see the telegram arm above.
-    const discord = discordIntegrationConfig(core, secret)
-    return { integrationId: i.id, agentId: i.agentId, platform: 'discord', core, config: discord }
-  }
-  if (i.platform === 'feishu') {
-    // Feishu authenticates the WSClient with an appId + appSecret pair, stored in the
-    // two-slot bot_secret: botToken = appSecret (the secret), appToken = appId. The
-    // region (feishu.cn vs larksuite.com) rides on the integration row; NULL ⇒ 'feishu'.
-    // §9 shared projection body — see the telegram arm above.
-    const feishu = feishuIntegrationConfig(core, secret, i)
-    return { integrationId: i.id, agentId: i.agentId, platform: 'feishu', core, config: feishu }
-  }
-  // 'direct' (transport==='socket') — this daemon owns the Socket Mode connection.
-  // The 'shared' wire variant (transport==='http', xoxb-only, no appToken/bindRules)
-  // is assembled by the HTTP-bot path, which reads the bot's `transport`; this mapper
-  // is always direct. A socket bot is single-agent, so it is never shareable. Slack
-  // always stores an app-level token (Socket Mode).
-  // §9 shared projection body — see the telegram arm above.
-  const slack = slackIntegrationConfig(core, secret)
-  return { integrationId: i.id, agentId: i.agentId, platform: 'slack', core, config: slack }
+  return projectSpec(platforms, i, bot, core, secret)
 }
 
 /**
@@ -294,34 +274,67 @@ export function integrationToSpec(
  * same reason and for every install, gated or not: an Off channel must survive a
  * relay snapshot that has not caught up yet.
  */
-export function httpIntegrationToSpec(
+export async function httpIntegrationToSpec(
+  platforms: CpPlatformRegistry,
   i: IntegrationRecord,
+  bot: BotRecord,
   secret: BotSecretMaterial,
-  shareable: boolean,
   channels: IntegrationChannelRecord[] = [],
-  gated = false,
-  providerAppId?: string,
-  botUserId?: string
-): IntegrationSpec {
+  gated = false
+): Promise<IntegrationSpec> {
   // §6.4 emission flip (see integrationToSpec): envelope + opaque config only.
+  // The shared-mode payload's remaining inputs — `shareable` (the daemon's
+  // in-thread "Switch agent" control), the provider app id, the bot's own user
+  // id — all live on the BOT row, so the projector reads them there instead of
+  // taking them positionally from each call site (§9: the bot row is a required
+  // projector input, and passing it whole is what stopped three call sites from
+  // disagreeing about which of its fields to forward).
   const httpCore = {
     mode: 'shared' as const,
     bindRules: gated ? gatedBindRules(channels) : [],
     mutedChannels: mutedChannelIds(channels, gated),
     gated
   }
-  if (i.platform === 'feishu') {
-    // §9 shared projection body — the same function the platform provider's
-    // `projectIntegrationConfig` calls (S3; provider adoption replaces this arm).
-    const feishu = feishuSharedIntegrationConfig(httpCore, secret, i, botUserId)
-    return { integrationId: i.id, agentId: i.agentId, platform: 'feishu', core: httpCore, config: feishu }
-  }
-  // `shareable` gates the daemon's in-thread "Switch agent" control: an HTTP bot
-  // routes through the relay either way, but only a multi-agent (shareable) bot has
-  // something to switch to.
-  // §9 shared projection body — see the feishu arm above.
-  const slack = slackSharedIntegrationConfig(httpCore, secret, shareable, providerAppId)
-  return { integrationId: i.id, agentId: i.agentId, platform: 'slack', core: httpCore, config: slack }
+  return projectSpec(platforms, i, bot, httpCore, secret)
+}
+
+/**
+ * The §9 projector seam: core has finished the part it owns (the envelope — the
+ * routing compile, the gating fold, the ingress mode) and hands the row + the
+ * decrypted secrets to the platform's provider, which returns the opaque
+ * `config` payload (§6.4). ONE await, no platform branch — `bot.transport` is
+ * the direct-vs-shared fork the provider itself applies, and it always agrees
+ * with the envelope's `mode` because every call site picks the assembler from
+ * that same field.
+ *
+ * TWO fail-closed fences remain core's, and both are unreachable today:
+ *  - `toDbPlatform` narrows the open registry id back to the CLOSED wire union
+ *    (`IntegrationSpec` is still a discriminated union of the four literals;
+ *    collapsing it to one flat `platformId` object is the S3 protocol cleanup).
+ *    It throws for a session-identity id and for anything outside the served
+ *    set — the same fence every persistence write already passes through, so a
+ *    row that reached this function has already satisfied it.
+ *  - a registered provider is required. The previous code let an unrecognized
+ *    platform fall through to the slack arm, which would have shipped a
+ *    slack-shaped config (and `platform: 'slack'`) for a foreign row; that arm
+ *    was dead code — writes are fenced by `toDbPlatform` and the create route
+ *    admits only registered platform ids — so refusing is the fail-closed
+ *    reading of the same unreachable branch, not a new behavior.
+ *
+ * Token-bearing — NEVER log the result.
+ */
+async function projectSpec(
+  platforms: CpPlatformRegistry,
+  i: IntegrationRecord,
+  bot: BotRecord,
+  core: IntegrationCoreEnvelope,
+  secret: BotSecretMaterial
+): Promise<IntegrationSpec> {
+  const platform = toDbPlatform(i.platform)
+  const provider = platforms.get(i.platform)
+  if (!provider) throw new Error(`no control-plane platform provider registered for ${i.platform}`)
+  const config = await provider.projectIntegrationConfig(i, bot, core, secret)
+  return { integrationId: i.id, agentId: i.agentId, platform, core, config }
 }
 
 /** A session to re-home: its key + the agent/workspace that should own it. */
@@ -347,6 +360,11 @@ export class Placement implements ReconcileService {
     private readonly specs: AgentSpecAssembler,
     private readonly integrationChannels: IntegrationChannelRepo,
     private readonly bots: BotRepo,
+    /** §9 platform providers — the ONLY source of an `IntegrationSpec.config`
+     *  payload. Late-bound in the composition root (the providers are built
+     *  with the route-dep bundle, which does not exist yet when Placement is
+     *  constructed); every read happens at reconcile time. */
+    private readonly platforms: CpPlatformRegistry,
     orch?: PlacementOrchDeps
   ) {
     this.orch = orch
@@ -389,21 +407,20 @@ export class Placement implements ReconcileService {
             this.integrationChannels.listForIntegration(i.id),
             this.bots.get(i.botId)
           ])
-          if (!secret) return null
+          // A spec needs BOTH halves of its identity: the bot row (the projector's
+          // required input — credentials shape, transport, demux identity) and the
+          // decrypted secret. Either missing ⇒ no deliverable spec, and the roster
+          // prunes the replica below. The bot row cannot actually be absent (the
+          // integration→bot FK is non-null and `onDelete: Restrict`); the guard is
+          // the fail-closed statement of that, not a live branch.
+          if (!secret || !bot) return null
           // An http-transport bot's ingest is on the relay pool — the daemon
           // reconciles it send-only (no Socket Mode). Socket bots reconcile as direct.
+          // Both arms await the SAME provider projector; only the envelope differs.
           const gated = gatedAgentIds.has(i.agentId)
-          return bot?.transport === 'http'
-            ? httpIntegrationToSpec(
-                i,
-                secret,
-                bot.shareable,
-                channels,
-                gated,
-                bot.slackAppId ?? undefined,
-                bot.botUserId ?? undefined
-              )
-            : integrationToSpec(i, secret, channels, gated)
+          return bot.transport === 'http'
+            ? await httpIntegrationToSpec(this.platforms, i, bot, secret, channels, gated)
+            : await integrationToSpec(this.platforms, i, bot, secret, channels, gated)
         })
       )
     ])

--- a/packages/control-plane/src/platforms/discord/provider.test.ts
+++ b/packages/control-plane/src/platforms/discord/provider.test.ts
@@ -1,15 +1,17 @@
 /**
  * Discord CpPlatformProvider (§9, S3) — unit, no I/O.
  *
- * The load-bearing suite is the PROJECTION EQUIVALENCE block: while the live
- * spec assembly is still `integrationToSpec` (`orchestrator/placement.ts`),
- * the provider's `projectIntegrationConfig` must produce EXACTLY the `config`
- * payload that path emits for the same inputs — that equality is what makes
- * the eventual call-site flip a zero-behavior change.
+ * The load-bearing suite is the PROJECTION EQUIVALENCE block. Now that the live
+ * spec assembly (`integrationToSpec`, `orchestrator/placement.ts`) goes THROUGH
+ * this provider, comparing their output would prove nothing — so the pin is a
+ * GOLDEN LITERAL of the payload the pre-adoption discord arm emitted, plus,
+ * across the input permutations, equality with the extracted helper body that
+ * arm called (unchanged by the flip).
  */
 import { describe, it, expect, vi } from 'vitest'
 import { createDiscordCpProvider, discordIntegrationConfig, DiscordCreateCredentials } from './provider.js'
 import { integrationToSpec } from '../../orchestrator/placement.js'
+import { buildCpPlatformRegistry } from '../registry.js'
 import type { DiscordBotVerification, DiscordMessageContentIntentSetup } from '../../http/discord-identity.js'
 import type { BotProfileIconAgent } from '../../http/bot-profile-icon.js'
 import type { BotRecord, IntegrationChannelRecord, IntegrationRecord } from '../../persistence/ports.js'
@@ -233,9 +235,14 @@ describe('discord sideEffects (profile push delegation)', () => {
   })
 })
 
-describe('discord projection equivalence with the live integrationToSpec path', () => {
-  const provider = createDiscordCpProvider({ verifyBot: verifierOk(), ensureMessageContentIntent: intent() })
+// §9 adoption: the live spec path reaches this provider THROUGH the registry, so
+// the equivalence suite below drives the real registry rather than calling the
+// provider beside the live path.
+const PLATFORMS = buildCpPlatformRegistry([
+  createDiscordCpProvider({ verifyBot: verifierOk(), ensureMessageContentIntent: intent() })
+])
 
+describe('discord projection equivalence with the live integrationToSpec path', () => {
   const cases: Array<{ label: string; channels: IntegrationChannelRecord[]; gated: boolean }> = [
     { label: 'defaults (no channels)', channels: [], gated: false },
     {
@@ -250,18 +257,49 @@ describe('discord projection equivalence with the live integrationToSpec path', 
     }
   ]
 
+  // GOLDEN: the literal payload the PRE-ADOPTION `integrationToSpec` discord arm
+  // emitted — the Gateway authenticates with the single bot token (no appToken).
+  it('emits the byte-identical payload the pre-adoption discord arm produced', async () => {
+    const spec = await integrationToSpec(
+      PLATFORMS,
+      INTEGRATION,
+      BOT,
+      SECRET,
+      [channel('C1', 'any'), channel('C2', 'mention'), channel('C3', 'off')],
+      false
+    )
+    const bindRules = [
+      { match: { kind: 'mention' } },
+      { match: { kind: 'dm' } },
+      { channel: 'C1', match: { kind: 'auto' } }
+    ]
+    expect(spec).toEqual({
+      integrationId: INTEGRATION.id,
+      agentId: INTEGRATION.agentId,
+      platform: 'discord',
+      core: { mode: 'direct', bindRules, mutedChannels: ['C3'], gated: false },
+      config: { botToken: TOKEN_WITH_APP_ID, bindRules, mutedChannels: ['C3'], gated: false }
+    })
+  })
+
+  // Across the permutations the pin is the EXTRACTED helper — the unchanged body
+  // the pre-adoption arm called.
   for (const { label, channels, gated } of cases) {
-    it(`emits exactly the live path's config — ${label}`, async () => {
-      const spec = integrationToSpec(INTEGRATION, SECRET, channels, gated)
-      const projected = await provider.projectIntegrationConfig(INTEGRATION, BOT, spec.core!, SECRET)
-      expect(projected).toEqual(spec.config)
-      // Both sides satisfy the daemon reader's wire schema (§6.4).
-      expect(IntegrationDiscordConfig.parse(projected)).toEqual(IntegrationDiscordConfig.parse(spec.config))
+    it(`routes the live path through the discord projector unchanged — ${label}`, async () => {
+      const spec = await integrationToSpec(PLATFORMS, INTEGRATION, BOT, SECRET, channels, gated)
+      expect(spec.core!.mode).toBe('direct')
+      expect(spec.config).toEqual(discordIntegrationConfig(spec.core!, SECRET))
+      // The payload satisfies the daemon reader's wire schema (§6.4).
+      expect(() => IntegrationDiscordConfig.parse(spec.config)).not.toThrow()
     })
   }
 
-  it('shares one implementation with placement.ts (the extracted helper)', () => {
-    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'any')], false)
-    expect(discordIntegrationConfig(spec.core!, SECRET)).toEqual(spec.config)
+  // §9 erratum: no `projectBotAssign`, so an http-transport discord bot has no
+  // relay path at all — the create route refuses that transport on exactly this
+  // signal, which is why the assign builder never sees one.
+  it('contributes a spec projector but no relay assign projector', () => {
+    const provider = createDiscordCpProvider({ verifyBot: verifierOk(), ensureMessageContentIntent: intent() })
+    expect(typeof provider.projectIntegrationConfig).toBe('function')
+    expect(provider.projectBotAssign).toBeUndefined()
   })
 })

--- a/packages/control-plane/src/platforms/discord/provider.ts
+++ b/packages/control-plane/src/platforms/discord/provider.ts
@@ -27,10 +27,10 @@
  * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
  * registry — its {@link DiscordCreateCredentials} block is folded into the
  * create body and {@link CpPlatformProvider.validateConfig} IS the route's live
- * token check + intent enablement. `placement.ts` remains a live path; the §6.4
- * wire projection body is therefore {@link discordIntegrationConfig}, called by
- * BOTH `integrationToSpec`'s discord arm and
- * {@link CpPlatformProvider.projectIntegrationConfig}.
+ * token check + intent enablement, and spec assembly (`placement.ts`) awaits
+ * {@link CpPlatformProvider.projectIntegrationConfig} for the §6.4 payload.
+ * {@link discordIntegrationConfig} stays exported as the ONE implementation
+ * behind that projector and the equivalence tests.
  */
 import { z } from 'zod'
 import type { IntegrationCoreEnvelope, IntegrationDiscordConfig } from '@agentconnect.md/protocol'

--- a/packages/control-plane/src/platforms/feishu/provider.test.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.test.ts
@@ -1,15 +1,16 @@
 /**
  * Feishu / Lark CpPlatformProvider (§9, S3) — unit, no I/O.
  *
- * The load-bearing suites are the EQUIVALENCE blocks: while the live paths are
- * still `integrationToSpec` / `httpIntegrationToSpec`
- * (`orchestrator/placement.ts`) and `buildAssign` (`orchestrator/httpBot.ts`),
- * the provider's `projectIntegrationConfig` / `projectBotAssign` must produce
- * EXACTLY the payloads those paths emit for the same inputs — that equality is
- * what makes the eventual call-site flip a zero-behavior change. The
- * `projectBotAssign` block runs the REAL orchestrator (in-memory repos, a
- * recording relay channel) and compares the live `rc/bot-assign` frame's two
- * opaque bags against the provider's projection.
+ * The load-bearing suites are the EQUIVALENCE blocks. Now that the live paths
+ * (`integrationToSpec` / `httpIntegrationToSpec` in `orchestrator/placement.ts`
+ * and `buildAssign` in `orchestrator/httpBot.ts`) go THROUGH this provider,
+ * comparing their output to the provider's would prove nothing — so the pins are
+ * GOLDEN LITERALS of the payloads the pre-adoption per-platform arms emitted,
+ * plus, across the input permutations, equality with the extracted helper bodies
+ * those arms called (unchanged by the flip), which is what catches core
+ * threading the wrong envelope, secret, or bot row into the seam. The
+ * `projectBotAssign` block still runs the REAL orchestrator (in-memory repos, a
+ * recording relay channel) so the frame captured off the wire is the live one.
  */
 import { describe, it, expect, vi } from 'vitest'
 import type { FastifyPluginAsync } from 'fastify'
@@ -138,6 +139,11 @@ const channel = (
   trigger,
   agentId: null
 })
+
+// §9 adoption: the live spec/assign paths reach this provider THROUGH the
+// registry, so the equivalence suites below drive the real registry rather than
+// calling the provider beside the live path.
+const PLATFORMS = buildCpPlatformRegistry([createFeishuCpProvider({ verifyBot: verifierOk() })])
 
 describe('feishu provider identity + declarative facets', () => {
   const provider = createFeishuCpProvider({ verifyBot: verifierOk() })
@@ -335,7 +341,6 @@ describe('feishu sideEffects (icon push delegation)', () => {
 })
 
 describe('feishu projection equivalence with the live integrationToSpec path (direct/socket)', () => {
-  const provider = createFeishuCpProvider({ verifyBot: verifierOk() })
   const SOCKET_BOT = bot()
 
   const cases: Array<{
@@ -365,25 +370,59 @@ describe('feishu projection equivalence with the live integrationToSpec path (di
     }
   ]
 
+  // GOLDEN: the literal payload the PRE-ADOPTION `integrationToSpec` feishu arm
+  // emitted, including the two-slot overloading (appId ← the secret row's
+  // `appToken` slot, appSecret ← its `botToken` slot) and the row's region.
+  it('emits the byte-identical direct payload the pre-adoption feishu arm produced', async () => {
+    const spec = await integrationToSpec(
+      PLATFORMS,
+      INTEGRATION,
+      SOCKET_BOT,
+      SOCKET_SECRET,
+      [channel('oc_1', 'any'), channel('oc_2', 'mention'), channel('oc_3', 'off')],
+      false
+    )
+    const bindRules = [
+      { match: { kind: 'mention' } },
+      { match: { kind: 'dm' } },
+      { channel: 'oc_1', match: { kind: 'auto' } }
+    ]
+    expect(spec).toEqual({
+      integrationId: INTEGRATION.id,
+      agentId: INTEGRATION.agentId,
+      platform: 'feishu',
+      core: { mode: 'direct', bindRules, mutedChannels: ['oc_3'], gated: false },
+      config: {
+        mode: 'direct',
+        appId: 'cli_testapp',
+        appSecret: 'feishu-app-secret',
+        region: 'lark',
+        bindRules,
+        mutedChannels: ['oc_3'],
+        gated: false
+      }
+    })
+  })
+
+  it("defaults a legacy region-less row to 'feishu', exactly as the pre-adoption arm did", async () => {
+    const spec = await integrationToSpec(PLATFORMS, LEGACY_INTEGRATION, SOCKET_BOT, SOCKET_SECRET, [], false)
+    expect(spec.config).toMatchObject({ region: 'feishu' })
+  })
+
+  // Across the permutations the pin is the EXTRACTED helper — the unchanged body
+  // the pre-adoption arm called.
   for (const { label, integration, channels, gated } of cases) {
-    it(`emits exactly the live path's config — ${label}`, async () => {
-      const spec = integrationToSpec(integration, SOCKET_SECRET, channels, gated)
-      const projected = await provider.projectIntegrationConfig(integration, SOCKET_BOT, spec.core!, SOCKET_SECRET)
-      expect(projected).toEqual(spec.config)
-      // Both sides satisfy the daemon reader's wire schema (§6.4).
-      expect(IntegrationFeishuConfig.parse(projected)).toEqual(IntegrationFeishuConfig.parse(spec.config))
+    it(`routes the live path through the feishu projector unchanged — ${label}`, async () => {
+      const spec = await integrationToSpec(PLATFORMS, integration, SOCKET_BOT, SOCKET_SECRET, channels, gated)
+      expect(spec.core!.mode).toBe('direct')
+      expect(spec.config).toEqual(feishuIntegrationConfig(spec.core!, SOCKET_SECRET, integration))
+      // The payload satisfies the daemon reader's wire schema (§6.4).
+      expect(() => IntegrationFeishuConfig.parse(spec.config)).not.toThrow()
     })
   }
-
-  it('shares one implementation with placement.ts (the extracted helper)', () => {
-    const spec = integrationToSpec(INTEGRATION, SOCKET_SECRET, [channel('oc_1', 'any')], false)
-    expect(feishuIntegrationConfig(spec.core!, SOCKET_SECRET, INTEGRATION)).toEqual(spec.config)
-  })
 })
 
 describe('feishu projection equivalence with the live httpIntegrationToSpec path (shared/http)', () => {
-  const provider = createFeishuCpProvider({ verifyBot: verifierOk() })
-
   const cases: Array<{
     label: string
     bot: BotRecord
@@ -410,29 +449,50 @@ describe('feishu projection equivalence with the live httpIntegrationToSpec path
     }
   ]
 
+  // GOLDEN: the literal payload the PRE-ADOPTION `httpIntegrationToSpec` feishu
+  // arm emitted. The daemon keeps the REST credentials for send/download; the
+  // bot's own open_id rides as `botOpenId` so it can skip a `bot/info` call.
+  it('emits the byte-identical shared payload the pre-adoption feishu arm produced', async () => {
+    const httpBot = bot({ transport: 'http', botUserId: 'ou_bot' })
+    const spec = await httpIntegrationToSpec(
+      PLATFORMS,
+      INTEGRATION,
+      httpBot,
+      HTTP_SECRET,
+      [channel('oc_1', 'any'), channel('oc_2', 'off')],
+      false
+    )
+    expect(spec).toEqual({
+      integrationId: INTEGRATION.id,
+      agentId: INTEGRATION.agentId,
+      platform: 'feishu',
+      // Ungated shared installs ship NO bindRules — the relay arbitrates.
+      core: { mode: 'shared', bindRules: [], mutedChannels: ['oc_2'], gated: false },
+      config: {
+        mode: 'shared',
+        appId: 'cli_testapp',
+        appSecret: 'feishu-app-secret',
+        botOpenId: 'ou_bot',
+        region: 'lark',
+        bindRules: [],
+        mutedChannels: ['oc_2'],
+        gated: false
+      }
+    })
+  })
+
   for (const { label, bot: httpBot, channels, gated } of cases) {
-    it(`emits exactly the live path's config — ${label}`, async () => {
-      // The live call sites feed the bot row's fields positionally
-      // (`placement.ts` reconcile, `httpBot.ts` pushSpecs).
-      const spec = httpIntegrationToSpec(
-        INTEGRATION,
-        HTTP_SECRET,
-        httpBot.shareable,
-        channels,
-        gated,
-        httpBot.slackAppId ?? undefined,
-        httpBot.botUserId ?? undefined
+    it(`routes the live path through the feishu projector unchanged — ${label}`, async () => {
+      // The bot row is passed WHOLE now: `botUserId` is read off it by the
+      // projector instead of being forwarded positionally by each call site.
+      const spec = await httpIntegrationToSpec(PLATFORMS, INTEGRATION, httpBot, HTTP_SECRET, channels, gated)
+      expect(spec.core!.mode).toBe('shared')
+      expect(spec.config).toEqual(
+        feishuSharedIntegrationConfig(spec.core!, HTTP_SECRET, INTEGRATION, httpBot.botUserId ?? undefined)
       )
-      const projected = await provider.projectIntegrationConfig(INTEGRATION, httpBot, spec.core!, HTTP_SECRET)
-      expect(projected).toEqual(spec.config)
-      expect(IntegrationFeishuConfig.parse(projected)).toEqual(IntegrationFeishuConfig.parse(spec.config))
+      expect(() => IntegrationFeishuConfig.parse(spec.config)).not.toThrow()
     })
   }
-
-  it('shares one implementation with placement.ts (the extracted helper)', () => {
-    const spec = httpIntegrationToSpec(INTEGRATION, HTTP_SECRET, false, [], false, undefined, 'ou_bot')
-    expect(feishuSharedIntegrationConfig(spec.core!, HTTP_SECRET, INTEGRATION, 'ou_bot')).toEqual(spec.config)
-  })
 })
 
 // ── projectBotAssign equivalence against the LIVE rc/bot-assign frame ────────
@@ -468,7 +528,8 @@ async function liveAssignFrame(botRow: BotRecord, secret: BotSecretMaterial): Pr
     { integrationUpsert: async () => {} } as never,
     { upsert: async () => {}, get: async () => null, listForBot: async () => [] } as unknown as ThreadAffinityStore,
     { findThreadOwner: async () => null } as unknown as SessionRepo,
-    { info() {}, warn() {}, debug() {} }
+    { info() {}, warn() {}, debug() {} },
+    PLATFORMS
   )
   await orch.syncBot(botRow.id)
   const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign | undefined

--- a/packages/control-plane/src/platforms/feishu/provider.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.ts
@@ -26,9 +26,13 @@
  * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
  * registry — its {@link FeishuCreateCredentials} block + {@link
  * refineFeishuCreateBody} are folded into the create body, and {@link
- * CpPlatformProvider.validateConfig} IS the route's live credential check.
- * `placement.ts`, `httpBot.ts`, `server.ts` mounting, and `loadConfig`'s schema
- * fold remain live paths, sharing the implementations above.
+ * CpPlatformProvider.validateConfig} IS the route's live credential check. Spec
+ * assembly (`placement.ts`) and `rc/bot-assign` (`httpBot.ts`) now await
+ * {@link CpPlatformProvider.projectIntegrationConfig} / {@link
+ * CpPlatformProvider.projectBotAssign} — the helpers below stay exported as the
+ * ONE implementation both the projectors and the equivalence tests call.
+ * `server.ts` mounting and `loadConfig`'s schema fold remain live paths,
+ * sharing the implementations above.
  */
 import { z } from 'zod'
 import type { ZodRawShape } from 'zod'

--- a/packages/control-plane/src/platforms/registry.ts
+++ b/packages/control-plane/src/platforms/registry.ts
@@ -5,13 +5,13 @@
  * note promised ("the concrete registry lands with the first provider move,
  * not with the contract").
  *
- * One instance is composed at `buildContainer` time and will be threaded to
- * the create route, the spec/assign assembly, `loadConfig`'s schema fold, and
- * `startBackground()` as those call sites adopt it (follow-up PRs) — adding a
- * platform then registers one provider here and edits no core file beyond the
- * composition line (§12). Until adoption, construction itself is the value:
- * the registry is the platform-set authority the audit's six hand-copied
- * closed unions converge on (S3 exit criterion).
+ * One instance is composed at `buildContainer` time and threaded to its
+ * adopters — today the create route and ALL wire projection (spec assembly +
+ * `rc/bot-assign`); `loadConfig`'s schema fold, route mounting, and
+ * `startBackground()` follow — so adding a platform registers one provider here
+ * and edits no core file beyond the composition line (§12). The registry is
+ * also the platform-set authority the audit's six hand-copied closed unions
+ * converge on (S3 exit criterion).
  *
  * Deliberately dumb, mirroring the S2 registry precedents (`daemon/src/
  * platforms/registry.ts`, `relay/src/platforms/registry.ts`): a keyed map

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -1,15 +1,16 @@
 /**
  * Slack CpPlatformProvider (§9, S3) — unit, no I/O.
  *
- * The load-bearing suites are the EQUIVALENCE blocks: while the live paths are
- * still `integrationToSpec` / `httpIntegrationToSpec`
- * (`orchestrator/placement.ts`) and `buildAssign` (`orchestrator/httpBot.ts`),
- * the provider's `projectIntegrationConfig` / `projectBotAssign` must produce
- * EXACTLY the payloads those paths emit for the same inputs — that equality is
- * what makes the eventual call-site flip a zero-behavior change. The
- * `projectBotAssign` block runs the REAL orchestrator (in-memory repos, a
- * recording relay channel) and compares the live `rc/bot-assign` frame's two
- * opaque bags against the provider's projection.
+ * The load-bearing suites are the EQUIVALENCE blocks. Now that the live paths
+ * (`integrationToSpec` / `httpIntegrationToSpec` in `orchestrator/placement.ts`
+ * and `buildAssign` in `orchestrator/httpBot.ts`) go THROUGH this provider,
+ * comparing their output to the provider's would prove nothing — so the pins are
+ * GOLDEN LITERALS of the payloads the pre-adoption per-platform arms emitted,
+ * plus, across the input permutations, equality with the extracted helper bodies
+ * those arms called (unchanged by the flip), which is what catches core
+ * threading the wrong envelope, secret, or bot row into the seam. The
+ * `projectBotAssign` block still runs the REAL orchestrator (in-memory repos, a
+ * recording relay channel) so the frame captured off the wire is the live one.
  */
 import { describe, it, expect, vi } from 'vitest'
 import type { FastifyPluginAsync } from 'fastify'
@@ -130,6 +131,11 @@ const channel = (
   trigger,
   agentId: null
 })
+
+// §9 adoption: the live spec/assign paths reach this provider THROUGH the
+// registry, so the equivalence suites below drive the real registry rather than
+// calling the provider beside the live path.
+const PLATFORMS = buildCpPlatformRegistry([createSlackCpProvider({ verifyBot: verifierOk() })])
 
 describe('slack provider identity + declarative facets', () => {
   const provider = createSlackCpProvider({ verifyBot: verifierOk() })
@@ -396,7 +402,6 @@ describe('slack providerToolingCredentials (delegation to slack-user-config)', (
 })
 
 describe('slack projection equivalence with the live integrationToSpec path (direct/socket)', () => {
-  const provider = createSlackCpProvider({ verifyBot: verifierOk() })
   const SOCKET_BOT = bot()
 
   const cases: Array<{ label: string; channels: IntegrationChannelRecord[]; gated: boolean }> = [
@@ -413,25 +418,55 @@ describe('slack projection equivalence with the live integrationToSpec path (dir
     }
   ]
 
+  // GOLDEN: the literal payload the PRE-ADOPTION `integrationToSpec` slack arm
+  // emitted for these inputs — frozen here so the flip to the provider projector
+  // is provably byte-identical rather than merely self-consistent.
+  it('emits the byte-identical direct payload the pre-adoption slack arm produced', async () => {
+    const spec = await integrationToSpec(
+      PLATFORMS,
+      INTEGRATION,
+      SOCKET_BOT,
+      SOCKET_SECRET,
+      [channel('C1', 'any'), channel('C2', 'mention'), channel('C3', 'off')],
+      false
+    )
+    const bindRules = [
+      { match: { kind: 'mention' } },
+      { match: { kind: 'dm' } },
+      { channel: 'C1', match: { kind: 'auto' } }
+    ]
+    expect(spec).toEqual({
+      integrationId: INTEGRATION.id,
+      agentId: INTEGRATION.agentId,
+      platform: 'slack',
+      core: { mode: 'direct', bindRules, mutedChannels: ['C3'], gated: false },
+      config: {
+        mode: 'direct',
+        shareable: false, // a socket bot is single-agent by construction
+        botToken: 'xoxb-test-token',
+        appToken: 'xapp-1-A0TESTAPP-123-abc', // Socket Mode carries the app-level token
+        bindRules,
+        mutedChannels: ['C3'],
+        gated: false
+      }
+    })
+  })
+
+  // Across the channel/gating permutations the pin is the EXTRACTED helper — the
+  // unchanged body the pre-adoption arm called — which catches core threading the
+  // wrong envelope, the wrong secret, or the wrong direct/shared arm into the seam.
   for (const { label, channels, gated } of cases) {
-    it(`emits exactly the live path's config — ${label}`, async () => {
-      const spec = integrationToSpec(INTEGRATION, SOCKET_SECRET, channels, gated)
-      const projected = await provider.projectIntegrationConfig(INTEGRATION, SOCKET_BOT, spec.core!, SOCKET_SECRET)
-      expect(projected).toEqual(spec.config)
-      // Both sides satisfy the daemon reader's wire schema (§6.4).
-      expect(IntegrationSlackConfig.parse(projected)).toEqual(IntegrationSlackConfig.parse(spec.config))
+    it(`routes the live path through the slack projector unchanged — ${label}`, async () => {
+      const spec = await integrationToSpec(PLATFORMS, INTEGRATION, SOCKET_BOT, SOCKET_SECRET, channels, gated)
+      expect(spec.core!.mode).toBe('direct')
+      expect(spec.config).toEqual(slackIntegrationConfig(spec.core!, SOCKET_SECRET))
+      // The payload satisfies the daemon reader's wire schema (§6.4).
+      expect(() => IntegrationSlackConfig.parse(spec.config)).not.toThrow()
     })
   }
-
-  it('shares one implementation with placement.ts (the extracted helper)', () => {
-    const spec = integrationToSpec(INTEGRATION, SOCKET_SECRET, [channel('C1', 'any')], false)
-    expect(slackIntegrationConfig(spec.core!, SOCKET_SECRET)).toEqual(spec.config)
-  })
 })
 
 describe('slack projection equivalence with the live httpIntegrationToSpec path (shared/http)', () => {
-  const provider = createSlackCpProvider({ verifyBot: verifierOk() })
-
   const cases: Array<{
     label: string
     bot: BotRecord
@@ -458,29 +493,50 @@ describe('slack projection equivalence with the live httpIntegrationToSpec path 
     }
   ]
 
+  // GOLDEN: the literal payload the PRE-ADOPTION `httpIntegrationToSpec` slack
+  // arm emitted. Send-only by credential domaining — xoxb but NEVER the appToken.
+  it('emits the byte-identical shared payload the pre-adoption slack arm produced', async () => {
+    const httpBot = bot({ transport: 'http', shareable: true, slackAppId: 'A0TESTAPP' })
+    const spec = await httpIntegrationToSpec(
+      PLATFORMS,
+      INTEGRATION,
+      httpBot,
+      HTTP_SECRET,
+      [channel('C1', 'any'), channel('C2', 'off')],
+      false
+    )
+    expect(spec).toEqual({
+      integrationId: INTEGRATION.id,
+      agentId: INTEGRATION.agentId,
+      platform: 'slack',
+      // Ungated shared installs ship NO bindRules — the relay arbitrates.
+      core: { mode: 'shared', bindRules: [], mutedChannels: ['C2'], gated: false },
+      config: {
+        mode: 'shared',
+        shareable: true,
+        botToken: 'xoxb-test-token',
+        appId: 'A0TESTAPP',
+        bindRules: [],
+        mutedChannels: ['C2'],
+        gated: false
+      }
+    })
+    expect(spec.config).not.toHaveProperty('appToken')
+  })
+
   for (const { label, bot: httpBot, channels, gated } of cases) {
-    it(`emits exactly the live path's config — ${label}`, async () => {
-      // The live call sites feed the bot row's fields positionally
-      // (`placement.ts` reconcile, `httpBot.ts` pushSpecs).
-      const spec = httpIntegrationToSpec(
-        INTEGRATION,
-        HTTP_SECRET,
-        httpBot.shareable,
-        channels,
-        gated,
-        httpBot.slackAppId ?? undefined,
-        httpBot.botUserId ?? undefined
+    it(`routes the live path through the slack projector unchanged — ${label}`, async () => {
+      // The bot row is passed WHOLE now: `shareable` / the provider app id /
+      // `botUserId` are read off it by the projector instead of being forwarded
+      // positionally by each call site.
+      const spec = await httpIntegrationToSpec(PLATFORMS, INTEGRATION, httpBot, HTTP_SECRET, channels, gated)
+      expect(spec.core!.mode).toBe('shared')
+      expect(spec.config).toEqual(
+        slackSharedIntegrationConfig(spec.core!, HTTP_SECRET, httpBot.shareable, httpBot.slackAppId ?? undefined)
       )
-      const projected = await provider.projectIntegrationConfig(INTEGRATION, httpBot, spec.core!, HTTP_SECRET)
-      expect(projected).toEqual(spec.config)
-      expect(IntegrationSlackConfig.parse(projected)).toEqual(IntegrationSlackConfig.parse(spec.config))
+      expect(() => IntegrationSlackConfig.parse(spec.config)).not.toThrow()
     })
   }
-
-  it('shares one implementation with placement.ts (the extracted helper)', () => {
-    const spec = httpIntegrationToSpec(INTEGRATION, HTTP_SECRET, true, [], false, 'A0TESTAPP')
-    expect(slackSharedIntegrationConfig(spec.core!, HTTP_SECRET, true, 'A0TESTAPP')).toEqual(spec.config)
-  })
 })
 
 // ── projectBotAssign equivalence against the LIVE rc/bot-assign frame ────────
@@ -516,7 +572,8 @@ async function liveAssignFrame(botRow: BotRecord, secret: BotSecretMaterial): Pr
     { integrationUpsert: async () => {} } as never,
     { upsert: async () => {}, get: async () => null, listForBot: async () => [] } as unknown as ThreadAffinityStore,
     { findThreadOwner: async () => null } as unknown as SessionRepo,
-    { info() {}, warn() {}, debug() {} }
+    { info() {}, warn() {}, debug() {} },
+    PLATFORMS
   )
   await orch.syncBot(botRow.id)
   const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign | undefined

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -30,10 +30,13 @@
  * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
  * registry — its {@link SlackCreateCredentials} block + {@link
  * refineSlackCreateBody} are folded into the create body, and {@link
- * CpPlatformProvider.validateConfig} IS the route's live token check.
- * `placement.ts`, `httpBot.ts`, `server.ts` mounting, `loadConfig`'s schema
- * fold, and `startBackground()` remain live paths, sharing the implementations
- * above.
+ * CpPlatformProvider.validateConfig} IS the route's live token check. Spec
+ * assembly (`placement.ts`) and `rc/bot-assign` (`httpBot.ts`) now await
+ * {@link CpPlatformProvider.projectIntegrationConfig} / {@link
+ * CpPlatformProvider.projectBotAssign} — the helpers below stay exported as the
+ * ONE implementation both the projectors and the equivalence tests call.
+ * `server.ts` mounting, `loadConfig`'s schema fold, and `startBackground()`
+ * remain live paths, sharing the implementations above.
  */
 import { z } from 'zod'
 import type { ZodRawShape } from 'zod'

--- a/packages/control-plane/src/platforms/telegram/provider.test.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.test.ts
@@ -1,15 +1,17 @@
 /**
  * Telegram CpPlatformProvider (§9, S3) — unit, no I/O.
  *
- * The load-bearing suite is the PROJECTION EQUIVALENCE block: while the live
- * spec assembly is still `integrationToSpec` (`orchestrator/placement.ts`),
- * the provider's `projectIntegrationConfig` must produce EXACTLY the `config`
- * payload that path emits for the same inputs — that equality is what makes
- * the eventual call-site flip a zero-behavior change.
+ * The load-bearing suite is the PROJECTION EQUIVALENCE block. Now that the live
+ * spec assembly (`integrationToSpec`, `orchestrator/placement.ts`) goes THROUGH
+ * this provider, comparing their output would prove nothing — so the pin is a
+ * GOLDEN LITERAL of the payload the pre-adoption telegram arm emitted, plus,
+ * across the input permutations, equality with the extracted helper body that
+ * arm called (unchanged by the flip).
  */
 import { describe, it, expect, vi } from 'vitest'
 import { createTelegramCpProvider, telegramIntegrationConfig, TelegramCreateCredentials } from './provider.js'
 import { integrationToSpec } from '../../orchestrator/placement.js'
+import { buildCpPlatformRegistry } from '../registry.js'
 import type { TelegramBotVerification } from '../../http/telegram-identity.js'
 import type { BotProfileIconAgent } from '../../http/bot-profile-icon.js'
 import type { BotRecord, IntegrationChannelRecord, IntegrationRecord } from '../../persistence/ports.js'
@@ -79,6 +81,11 @@ const channel = (
   trigger,
   agentId: null
 })
+
+// §9 adoption: the live spec path reaches this provider THROUGH the registry, so
+// the equivalence suite below drives the real registry rather than calling the
+// provider beside the live path.
+const PLATFORMS = buildCpPlatformRegistry([createTelegramCpProvider({ verifyBot: verifierOk() })])
 
 describe('telegram provider identity + declarative facets', () => {
   const provider = createTelegramCpProvider({ verifyBot: verifierOk() })
@@ -185,8 +192,6 @@ describe('telegram sideEffects (icon push delegation)', () => {
 })
 
 describe('telegram projection equivalence with the live integrationToSpec path', () => {
-  const provider = createTelegramCpProvider({ verifyBot: verifierOk() })
-
   const cases: Array<{ label: string; channels: IntegrationChannelRecord[]; gated: boolean }> = [
     { label: 'defaults (no channels)', channels: [], gated: false },
     {
@@ -201,18 +206,54 @@ describe('telegram projection equivalence with the live integrationToSpec path',
     }
   ]
 
+  // GOLDEN: the literal payload the PRE-ADOPTION `integrationToSpec` telegram arm
+  // emitted — one BotFather token, no appToken, no shareable/appId members.
+  it('emits the byte-identical payload the pre-adoption telegram arm produced', async () => {
+    const spec = await integrationToSpec(
+      PLATFORMS,
+      INTEGRATION,
+      BOT,
+      SECRET,
+      [channel('-100', 'any'), channel('-200', 'mention'), channel('-300', 'off')],
+      false
+    )
+    const bindRules = [
+      { match: { kind: 'mention' } },
+      { match: { kind: 'dm' } },
+      { channel: '-100', match: { kind: 'auto' } }
+    ]
+    expect(spec).toEqual({
+      integrationId: INTEGRATION.id,
+      agentId: INTEGRATION.agentId,
+      platform: 'telegram',
+      core: { mode: 'direct', bindRules, mutedChannels: ['-300'], gated: false },
+      config: {
+        botToken: '123456:ABC-tg-token',
+        bindRules,
+        mutedChannels: ['-300'],
+        gated: false
+      }
+    })
+  })
+
+  // Across the permutations the pin is the EXTRACTED helper — the unchanged body
+  // the pre-adoption arm called.
   for (const { label, channels, gated } of cases) {
-    it(`emits exactly the live path's config — ${label}`, async () => {
-      const spec = integrationToSpec(INTEGRATION, SECRET, channels, gated)
-      const projected = await provider.projectIntegrationConfig(INTEGRATION, BOT, spec.core!, SECRET)
-      expect(projected).toEqual(spec.config)
-      // Both sides satisfy the daemon reader's wire schema (§6.4).
-      expect(IntegrationTelegramConfig.parse(projected)).toEqual(IntegrationTelegramConfig.parse(spec.config))
+    it(`routes the live path through the telegram projector unchanged — ${label}`, async () => {
+      const spec = await integrationToSpec(PLATFORMS, INTEGRATION, BOT, SECRET, channels, gated)
+      expect(spec.core!.mode).toBe('direct')
+      expect(spec.config).toEqual(telegramIntegrationConfig(spec.core!, SECRET))
+      // The payload satisfies the daemon reader's wire schema (§6.4).
+      expect(() => IntegrationTelegramConfig.parse(spec.config)).not.toThrow()
     })
   }
 
-  it('shares one implementation with placement.ts (the extracted helper)', () => {
-    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'any')], false)
-    expect(telegramIntegrationConfig(spec.core!, SECRET)).toEqual(spec.config)
+  // §9 erratum: no `projectBotAssign`, so an http-transport telegram bot has no
+  // relay path at all — the create route refuses that transport on exactly this
+  // signal, which is why the assign builder never sees one.
+  it('contributes a spec projector but no relay assign projector', () => {
+    const provider = createTelegramCpProvider({ verifyBot: verifierOk() })
+    expect(typeof provider.projectIntegrationConfig).toBe('function')
+    expect(provider.projectBotAssign).toBeUndefined()
   })
 })

--- a/packages/control-plane/src/platforms/telegram/provider.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.ts
@@ -15,10 +15,10 @@
  * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
  * registry — its {@link TelegramCreateCredentials} block is folded into the
  * create body and {@link CpPlatformProvider.validateConfig} IS the route's live
- * token check. `placement.ts` remains a live path; to keep ONE implementation
- * while both exist, the §6.4 wire projection body is
- * {@link telegramIntegrationConfig}, called by BOTH `integrationToSpec`'s
- * telegram arm and {@link CpPlatformProvider.projectIntegrationConfig}.
+ * token check, and spec assembly (`placement.ts`) awaits {@link
+ * CpPlatformProvider.projectIntegrationConfig} for the §6.4 payload.
+ * {@link telegramIntegrationConfig} stays exported as the ONE implementation
+ * behind that projector and the equivalence tests.
  */
 import { z } from 'zod'
 import type { IntegrationCoreEnvelope, IntegrationTelegramConfig } from '@agentconnect.md/protocol'

--- a/packages/control-plane/test/fakes/build-app.ts
+++ b/packages/control-plane/test/fakes/build-app.ts
@@ -33,6 +33,11 @@ import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import { EpochService } from '../../src/orchestrator/epoch.js'
 import { Placement } from '../../src/orchestrator/placement.js'
 import { AgentSpecAssembler } from '../../src/orchestrator/agentSpecAssembler.js'
+import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
+import { createSlackCpProvider } from '../../src/platforms/slack/provider.js'
+import { createTelegramCpProvider } from '../../src/platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../../src/platforms/discord/provider.js'
+import { createFeishuCpProvider } from '../../src/platforms/feishu/provider.js'
 import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
 import { ApiKeyCodec } from '../../src/registry/apiKey.js'
 import { DaemonAuthService } from '../../src/registry/authService.js'
@@ -95,7 +100,16 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
     repos.botSecret,
     new AgentSpecAssembler(repos.agentSecret),
     repos.integrationChannel,
-    repos.bot
+    repos.bot,
+    // §9: reconcile projects every `IntegrationSpec.config` through the platform
+    // registry, so compose the same four providers prod registers. Their verify
+    // seams are offline stubs — the projectors call none of them.
+    buildCpPlatformRegistry([
+      createSlackCpProvider({}),
+      createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+      createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+      createFeishuCpProvider({})
+    ])
   )
   const connReg = new ConnectionRegistry()
 

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -212,6 +212,35 @@ export function buildHttpApp(
     })
   const internalInvocationAuth = depsOverrides?.internalInvocationAuth ?? new InternalInvocationAuth()
 
+  // §9 platform-provider registry — the same four providers `buildContainer`
+  // registers, so the create route parses and validates exactly the deployed
+  // shapes, and spec assembly / `rc/bot-assign` project through the deployed
+  // projectors. Their verify seams READ THROUGH to `deps` on every call instead
+  // of capturing it: tests routinely swap `app.deps.verifySlackBot` (and
+  // friends) AFTER the app is built, and an absent dep is passed through as the
+  // provider-unreachable outcome — which every provider treats exactly as
+  // today's route treated "no verifier injected" (inconclusive: no 400, no
+  // derived identity). Only the seams the create route reaches through the
+  // provider are wired here; the icon/profile pushes remain live `deps` calls
+  // until §9 moves the create tails too. Hoisted above `deps` because the
+  // orchestrators inside the bundle take it as a constructor argument.
+  const platforms = buildCpPlatformRegistry([
+    createTelegramCpProvider({ verifyBot: (token) => deps.verifyTelegramBot(token) }),
+    createDiscordCpProvider({
+      verifyBot: async (token) => (deps.verifyDiscordBot ? deps.verifyDiscordBot(token) : { status: 'unreachable' }),
+      ensureMessageContentIntent: (token) => deps.ensureDiscordMessageContentIntent(token)
+    }),
+    createSlackCpProvider({
+      verifyBot: async (token) => (deps.verifySlackBot ? deps.verifySlackBot(token) : { status: 'unreachable' }),
+      verifyAppToken: async (token) =>
+        deps.verifySlackAppToken ? deps.verifySlackAppToken(token) : ('unreachable' as const)
+    }),
+    createFeishuCpProvider({
+      verifyBot: async (appId, appSecret, region) =>
+        deps.verifyFeishuBot ? deps.verifyFeishuBot(appId, appSecret, region) : { status: 'unreachable' }
+    })
+  ])
+
   const deps: HttpDeps = {
     clock,
     repos: {
@@ -260,32 +289,7 @@ export function buildHttpApp(
       oauth: oauthRepo
     },
     registry: new DaemonRegistryService(daemonRepo, new PgRuntimeProfileRepo(prisma), daemonLifecycleOpRepo, clock),
-    // §9 platform-provider registry — the same four providers `buildContainer`
-    // registers, so the create route parses and validates exactly the deployed
-    // shapes. Their verify seams READ THROUGH to `deps` on every call instead of
-    // capturing it: tests routinely swap `app.deps.verifySlackBot` (and friends)
-    // AFTER the app is built, and an absent dep is passed through as the
-    // provider-unreachable outcome — which every provider treats exactly as
-    // today's route treated "no verifier injected" (inconclusive: no 400, no
-    // derived identity). Only the seams the create route now reaches through the
-    // provider are wired here; the icon/profile pushes remain live `deps` calls
-    // until §9 moves the create tails too.
-    platforms: buildCpPlatformRegistry([
-      createTelegramCpProvider({ verifyBot: (token) => deps.verifyTelegramBot(token) }),
-      createDiscordCpProvider({
-        verifyBot: async (token) => (deps.verifyDiscordBot ? deps.verifyDiscordBot(token) : { status: 'unreachable' }),
-        ensureMessageContentIntent: (token) => deps.ensureDiscordMessageContentIntent(token)
-      }),
-      createSlackCpProvider({
-        verifyBot: async (token) => (deps.verifySlackBot ? deps.verifySlackBot(token) : { status: 'unreachable' }),
-        verifyAppToken: async (token) =>
-          deps.verifySlackAppToken ? deps.verifySlackAppToken(token) : ('unreachable' as const)
-      }),
-      createFeishuCpProvider({
-        verifyBot: async (appId, appSecret, region) =>
-          deps.verifyFeishuBot ? deps.verifyFeishuBot(appId, appSecret, region) : { status: 'unreachable' }
-      })
-    ]),
+    platforms,
     agentSpecs: new AgentSpecAssembler(
       agentSecretStore,
       {},
@@ -311,7 +315,8 @@ export function buildHttpApp(
       sender,
       new PgThreadAffinityStore(prisma),
       new PgSessionRepo(prisma),
-      { info() {}, warn() {}, debug() {} }
+      { info() {}, warn() {}, debug() {} },
+      platforms
     ),
     collabRoutes: new CollabRoutesService(daemonRepo, integrationRepo, agentRepo, relayControl, sender),
     agentMutations: new AgentMutationGate(),

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -56,6 +56,21 @@ import { DaemonId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { FakeClock } from './fake-clock.js'
 import { InMemoryDaemonStub } from './daemon-stub.js'
+import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
+import { createSlackCpProvider } from '../../src/platforms/slack/provider.js'
+import { createTelegramCpProvider } from '../../src/platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../../src/platforms/discord/provider.js'
+import { createFeishuCpProvider } from '../../src/platforms/feishu/provider.js'
+
+// §9: reconcile projects every `IntegrationSpec.config` through the platform
+// registry, so the WS fake composes the same four providers prod registers.
+// Their verify seams are offline stubs — the projectors call none of them.
+const PLATFORMS = buildCpPlatformRegistry([
+  createSlackCpProvider({}),
+  createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+  createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+  createFeishuCpProvider({})
+])
 
 export const TEST_API_KEY_PEPPER = 'test-api-key-pepper-0123456789abcdef'
 
@@ -140,6 +155,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     new AgentSpecAssembler(repos.agentSecret),
     repos.integrationChannel,
     repos.bot,
+    PLATFORMS,
     {
       registry: connReg,
       sender,

--- a/packages/control-plane/test/protocol/drain.test.ts
+++ b/packages/control-plane/test/protocol/drain.test.ts
@@ -44,6 +44,8 @@ import type { DaemonWsDeps } from '../../src/ws/deps.js'
 import { FakeClock } from '../fakes/fake-clock.js'
 import { InMemoryDaemonStub } from '../fakes/daemon-stub.js'
 import { DaemonId } from '../../src/domain/ids.js'
+import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
+import { createSlackCpProvider } from '../../src/platforms/slack/provider.js'
 
 const DAEMON_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const DAEMON_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
@@ -186,6 +188,9 @@ function build(): Built {
     new AgentSpecAssembler(agentSecretStore),
     integrationChannelRepo,
     botRepo,
+    // §9 spec projection. This suite seeds no integrations, so only the registry's
+    // presence matters; slack alone keeps the fixture minimal.
+    buildCpPlatformRegistry([createSlackCpProvider({})]),
     {
       registry: connReg,
       sender,


### PR DESCRIPTION
## What

§9 of the integration-plugin architecture says the CP "still assembles the wire
payloads (it holds the rows and the decrypted secrets), but through
`projectIntegrationConfig` / `projectBotAssign`, so `placement.ts` / `httpBot.ts`
stop branching per platform and merely await and forward provider output."
The providers and their equivalence tests landed in #574 (telegram/discord) and
#580 (slack/feishu); the create DTO adopted the registry in #592. This is the
flip on the reconcile path — the last place core knew a platform's field names.

- `orchestrator/placement.ts` — `integrationToSpec` / `httpIntegrationToSpec`
  lose their per-platform arms and gain the registry plus the **bot row**, which
  is a required projector input by contract. Passing the row whole retires the
  three positional bot fields the shared assembler used to take (`shareable`,
  the provider app id, `botUserId`) — the very fields three call sites had
  drifted apart on. Both assemblers funnel into one private `projectSpec`, so
  the only thing separating direct from shared is the core envelope core still
  owns; the payload behind it is entirely the provider's.
- `orchestrator/httpBot.ts` — `buildAssign`'s `feishu ? … : slack` ternary
  becomes one awaited `projectBotAssign`, and the method returns
  `RcBotAssign | null`. `projectBotAssign` is **optional by design** (the #580
  erratum): a platform whose inbound transport is a daemon-owned long-lived
  connection declares none, and the create route already refuses
  `transport: 'http'` on exactly that signal, so no such bot row can reach the
  assign builder. Absence therefore neither fabricates an empty assign (the
  relay would arm an ingress it cannot verify) nor throws (that would take down
  `syncBot` for every other bot) — it joins the two existing "cannot assign"
  outcomes: `syncBot` logs and returns, `replayTo` skips the bot.
- Everything on these paths is async, so every call site was audited for a
  missing `await` and a lost rejection. `reconcile` and `agentMove.snapshot`
  already mapped inside `Promise.all`; `pushSpecs` awaits inside the loop's
  existing `NoConnection` try, which re-throws a projector rejection instead of
  swallowing it. In `replayTo` the assign is built **outside** the dead-socket
  `try` on purpose: that catch means "the socket died", and a projector
  rejection swallowed there would be a lost error rather than a dropped send —
  outside, it propagates to the register handler's `.catch(log.error)`.
- No secret material moves. The projectors receive the decrypted
  `BotSecretMaterial` and return it inside the wire payload exactly as before;
  nothing is persisted into `platformConfig` JSON.

## Behavior

Two previously-unreachable arms tighten, and one inconsistency converges.

- An integration row whose platform has **no registered provider** is refused
  instead of falling through to the slack arm, which would have shipped a
  slack-shaped config under `platform: 'slack'` for a foreign row. Writes are
  fenced by `toDbPlatform` and the create route admits only registered ids, so
  that arm was dead code; `toDbPlatform` — the repo's existing persistence
  fence — now also narrows the open registry id back to the closed wire union
  (`IntegrationSpec` is still a four-literal discriminated union; collapsing it
  is the S3 protocol cleanup).
- A **missing bot row** skips the spec instead of emitting a direct-mode one.
  The integration→bot FK is non-null with `onDelete: Restrict`, so this cannot
  happen; the guard states it rather than fabricating an identity.
- `agentMove`'s move bundle now carries `botOpenId` on a shared Feishu spec. It
  alone omitted the bot's open_id while the reconcile roster and the live
  HTTP-bot push both sent it, so the bundle now equals what the daemon receives
  by every other route. Activation fingerprints are computed and compared
  in-process, never persisted, so no rollout window sees a mismatch.

Three call sites (`replicateUpsert`, `installNewSlackBot`, `installNewFeishuBot`)
add a `bot.get` to an existing `Promise.all` — parallel with the reads already
there, so no extra round-trip latency.

## Tests

`GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/control-plane test:unit` →
**124 files, 1163 tests passed**.
`… test:int` (Docker/Testcontainers) → **70 files, 955 tests passed**.
`tsc --noEmit` and `eslint` clean; prettier applied.

The four provider equivalence suites can no longer compare the live path to the
provider — the live path **is** the provider now, and that comparison would prove
nothing. Each grows a **golden literal** of the payload its pre-adoption arm
emitted (direct for all four; shared for slack and feishu), and the permutation
cases switch to equality with the extracted helper bodies those arms called,
unchanged by this PR — which is what catches core threading the wrong envelope,
secret, bot row, or direct/shared arm into the seam. Slack's shared golden also
asserts the appToken is absent (credential domaining); feishu's pins the region
default and the two-slot secret overloading.

`httpBot.test.ts` pins the absent-`projectBotAssign` path three ways: `syncBot`
resolves, broadcasts **nothing at all** (not an empty frame), and pushes no
send-only spec; `replayTo` skips that bot instead of failing the whole replay;
and a provider that does declare the member still assigns. `placement.test.ts`
pins all three fail-closed fences — unregistered provider, unserved platform id,
session-identity id. Telegram and discord each pin that they contribute a spec
projector but no relay assign projector.

Integration fakes (`build-app`, `build-http`, `build-ws`, `drain.test`) compose
the same four providers prod registers, with offline verify stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
