### PR TITLE
refactor(cp): the platform slot owns route mounting, the background lifecycle, env keys and the create tail (S3 §9)

### DIFF
--- a/packages/control-plane/src/config/env.ts
+++ b/packages/control-plane/src/config/env.ts
@@ -6,10 +6,12 @@
  * (`API_KEY_PEPPER`, `HEARTBEAT_SEC`).
  */
 import { z } from 'zod'
-import { SlackCpEnvSchema } from '../platforms/slack/provider.js'
-import { FeishuCpEnvSchema } from '../platforms/feishu/provider.js'
+import { composeCpPlatformEnv } from '../platforms/env.js'
 
-export const AppConfigSchema = z.object({
+/** The env keys CORE owns. Platform keys are folded in below — this object is
+ *  never exported: `AppConfigSchema` is the only schema, and it is the two
+ *  halves together. */
+const CoreConfigShape = {
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   PORT: z.coerce.number().int().default(8080),
   HOST: z.string().default('0.0.0.0'),
@@ -27,15 +29,6 @@ export const AppConfigSchema = z.object({
   // sweeps every CRON_RUN_REAP_INTERVAL_SEC.
   CRON_RUN_TTL_SEC: z.coerce.number().int().default(1800),
   CRON_RUN_REAP_INTERVAL_SEC: z.coerce.number().int().default(300),
-  // Slack + Feishu platform-provider env keys (§9 `envSchema`): the
-  // auto-install reaper knobs (SLACK_INSTALL_*), the platform-published Slack
-  // app (SLACK_PLATFORM_*), and the platform-owned Feishu/Lark apps
-  // (FEISHU/LARK_PLATFORM_*). Defined BY the providers and spread here —
-  // one implementation with each provider's declared `envSchema` — until
-  // `loadConfig` folds the registry's schemas (S3 adoption). Key docs live
-  // with the shapes (`platforms/slack/provider.ts`, `platforms/feishu/provider.ts`).
-  ...SlackCpEnvSchema,
-  ...FeishuCpEnvSchema,
   // HMAC pepper for `api_key.hash` (C4). Required, ≥32 chars. Effectively immutable —
   // rotating it invalidates every stored key hash. See daemon-api-key-auth.md.
   API_KEY_PEPPER: z.string().min(32),
@@ -186,6 +179,20 @@ export const AppConfigSchema = z.object({
   OPEN_CONNECTOR_PROVIDER_BLOCKLIST: z
     .string()
     .default('github,slack,telegram,discord,discordbot,feishu,feishu_app_bot,feishu_custom_bot')
+} as const
+
+/**
+ * Core keys + every platform provider's own (§9 `envSchema`, folded by
+ * `platforms/env.ts`): today the Slack auto-install reaper knobs
+ * (`SLACK_INSTALL_*`), the platform-published Slack app (`SLACK_PLATFORM_*`),
+ * and the platform-owned Feishu/Lark apps (`FEISHU/LARK_PLATFORM_*`). Each key's
+ * documentation lives with its provider's shape, and adding a platform with
+ * deployment configuration no longer edits this file. The fold throws on a key
+ * that shadows a core one, so the two halves cannot silently overlap.
+ */
+export const AppConfigSchema = z.object({
+  ...CoreConfigShape,
+  ...composeCpPlatformEnv(Object.keys(CoreConfigShape))
 })
 
 export type AppConfig = z.infer<typeof AppConfigSchema>

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -99,7 +99,6 @@ import { AgentSpecAssembler } from './orchestrator/agentSpecAssembler.js'
 import { Placement } from './orchestrator/placement.js'
 import { Watchdog } from './orchestrator/watchdog.js'
 import { CronRunReaper } from './orchestrator/cronRunReaper.js'
-import { SlackInstallReaper } from './orchestrator/slackInstallReaper.js'
 import { RelaySweeper } from './orchestrator/relaySweeper.js'
 import { RelayRoster } from './orchestrator/relayRoster.js'
 import { WebchatMcpOperationReaper } from './orchestrator/webchatMcpOperationReaper.js'
@@ -166,10 +165,11 @@ import { ensureDiscordMessageContentIntent, verifyDiscordBot } from './http/disc
 import { createDiscordBotProfileSyncer } from './http/discord-bot-profile.js'
 import type { CpPlatformRegistry } from './platforms/provider.js'
 import { buildCpPlatformRegistry } from './platforms/registry.js'
+import { buildPendingInstallReapers, platformBackgroundLoops } from './platforms/lifecycle.js'
 import { createTelegramCpProvider } from './platforms/telegram/provider.js'
 import { createDiscordCpProvider } from './platforms/discord/provider.js'
 import { createSlackCpProvider } from './platforms/slack/provider.js'
-import { createFeishuCpProvider, FEISHU_REGISTRATION_TTL_MS } from './platforms/feishu/provider.js'
+import { createFeishuCpProvider } from './platforms/feishu/provider.js'
 import { slackInstallRoutes, slackConfigRoutes, slackOauthCallbackRoutes } from './http/routes/slack-install.js'
 import { slackPlatformInstallRoutes, slackPlatformCallbackRoutes } from './http/routes/slack-platform-install.js'
 import { feishuRegistrationRoutes } from './http/routes/feishu-registration.js'
@@ -195,9 +195,10 @@ export interface Container {
   /** The single-tenant anchors the devAuth stub injects. */
   readonly defaults: { orgId: string; ownerId: string }
   /** §9 platform-provider registry (S3) — all four platforms (Telegram,
-   *  Discord, Slack, Feishu). Composed here so the graph is whole; the route /
-   *  spec-assembly / config / background-lifecycle call sites adopt it in
-   *  follow-up PRs (nothing consumes it yet). */
+   *  Discord, Slack, Feishu). Composed here so the graph is whole, and now the
+   *  authority for route mounting, the create body + its live credential check,
+   *  the pending-install reapers and the background convergence loops. Spec
+   *  assembly and `rc/bot-assign` adopt it in a follow-up PR. */
   readonly platforms: CpPlatformRegistry
   /** The process readiness gate — the bootstrap flips it at SIGTERM (`/readyz`). */
   readonly readiness: Readiness
@@ -971,37 +972,6 @@ export function buildContainer(
       )
     : undefined
 
-  // Sweeps abandoned Slack auto-install sessions (§Tier B) so a client secret + bot
-  // token never lingers past the funnel. Same lifecycle as the cron reaper.
-  const slackInstallReaper = new SlackInstallReaper(
-    repos.slackInstall,
-    clock,
-    { ttlMs: config.SLACK_INSTALL_TTL_SEC * 1000, intervalMs: config.SLACK_INSTALL_REAP_INTERVAL_SEC * 1000 },
-    http.log
-  )
-
-  // The platform-app install rows (state → tenancy, no secrets) age out on the
-  // same TTL — an abandoned "Add to Slack" tab must not leave a live state nonce.
-  const slackPlatformInstallReaper = new SlackInstallReaper(
-    repos.slackPlatformInstall,
-    clock,
-    { ttlMs: config.SLACK_INSTALL_TTL_SEC * 1000, intervalMs: config.SLACK_INSTALL_REAP_INTERVAL_SEC * 1000 },
-    http.log,
-    'slack-platform-install'
-  )
-
-  // Device code/App Secret are encrypted but deliberately short-lived. Retain
-  // a terminal status briefly for the browser, then clear the durable row.
-  // (The TTL constant lives with the Feishu provider — one implementation with
-  // its §9 `pendingInstalls` declaration.)
-  const feishuRegistrationReaper = new SlackInstallReaper(
-    repos.feishuAppRegistration,
-    clock,
-    { ttlMs: FEISHU_REGISTRATION_TTL_MS, intervalMs: config.SLACK_INSTALL_REAP_INTERVAL_SEC * 1000 },
-    http.log,
-    'feishu-registration'
-  )
-
   // One-time preset backfill (preset-agents.md §3.2): existing orgs receive the
   // `agentconnect` general preset; the preset_agent row is the per-org marker, so
   // the sweep converges to a no-op after its first complete run.
@@ -1072,11 +1042,14 @@ export function buildContainer(
   // factory). That is also why every holder captures the late-bound `platforms`
   // façade defined near the top rather than this value directly.
   //
-  // ADOPTED SO FAR: the `POST /integrations` create body + its live
-  // `validateConfig` dispatch; and (§9) ALL wire projection — `IntegrationSpec.
-  // config` on every spec-assembly path and both `rc/bot-assign` bags. Route
-  // mounting, `loadConfig`'s schema fold, and `startBackground()` adopt it in
-  // follow-up PRs.
+  // ADOPTED SO FAR: route mounting (`server.ts` asks each provider for its
+  // plugins per scope), the `POST /integrations` create body + its live
+  // `validateConfig` + `buildNewBotInstall` tail, the pending-install reapers and
+  // the background loops below, `loadConfig`'s env fold (through the static
+  // `platforms/env.ts` declaration — `loadConfig` runs before this registry can
+  // exist, since providers are constructed FROM the parsed config), and (§9) ALL
+  // wire projection: `IntegrationSpec.config` on every spec-assembly path and
+  // both `rc/bot-assign` bags.
   composedPlatforms = buildCpPlatformRegistry([
     createTelegramCpProvider({ verifyBot: verifyTelegramBot, syncBotIcon: syncTelegramBotIcon }),
     createDiscordCpProvider({
@@ -1110,6 +1083,13 @@ export function buildContainer(
       }
     })
   ])
+
+  // Pending-install TTL reapers + provider-owned convergence loops, from the
+  // providers' §9 declarations (`platforms/lifecycle.ts`) instead of the four
+  // hand-listed instances this used to hold. Same lifecycle as the cron reaper:
+  // built here so the graph is whole, armed only by `startBackground()`.
+  const pendingInstallReapers = buildPendingInstallReapers(platforms, clock, http.log)
+  const backgroundLoops = platformBackgroundLoops(platforms)
 
   // ── daemon WS edge (mounted on the live http.Server after listen) ──────────
   const wsDeps: DaemonWsServerDeps = {
@@ -1444,11 +1424,9 @@ export function buildContainer(
       webchatMcpOperationReaper.start()
       githubRunReporter?.start()
       hookRedeliveryReconciler?.start()
-      slackInstallReaper.start()
-      slackPlatformInstallReaper.start()
-      feishuRegistrationReaper.start()
+      for (const reaper of pendingInstallReapers) reaper.start()
       relaySweeper.start()
-      slackBotIdentityReconciler.start()
+      for (const loop of backgroundLoops) loop.start()
       // One-shot (not a re-arming loop): the worklist empties itself; a partially
       // failed boot resumes on the next one. Never blocks listen.
       void presetBackfill?.run().catch((err) => http.log.error({ err }, 'preset-backfill: sweep failed'))
@@ -1460,11 +1438,9 @@ export function buildContainer(
       githubRunReporter?.stop()
       hookRedeliveryReconciler?.stop()
       installationDoorbell?.stop()
-      slackInstallReaper.stop()
-      slackPlatformInstallReaper.stop()
-      feishuRegistrationReaper.stop()
+      for (const reaper of pendingInstallReapers) reaper.stop()
       relaySweeper.stop()
-      slackBotIdentityReconciler.stop()
+      for (const loop of backgroundLoops) loop.stop()
       visibilityPush.stop()
       await Promise.allSettled([
         webchatMcpOperationSettled,

--- a/packages/control-plane/src/http/daemon-platform-capability.ts
+++ b/packages/control-plane/src/http/daemon-platform-capability.ts
@@ -10,17 +10,24 @@ import type { ViewCtx } from '../persistence/ports.js'
 import type { HttpDeps } from './deps.js'
 import { canView } from '../authorization/policy.js'
 
-export type IntegrationPlatform = 'slack' | 'telegram' | 'discord' | 'feishu'
 export type DaemonPlatformAvailability = 'available' | 'not_found' | 'unsupported'
 
 /**
  * Resolve a visible daemon and check the capability it last registered. A
  * hidden/cross-org/missing daemon deliberately reads as not found to avoid an
  * existence oracle, following the rest of the HTTP resource guards.
+ *
+ * `platform` is an OPEN id (integration-plugin-architecture.md §9): the caller's
+ * value already came from `deps.platforms` — the registry is the single
+ * platform-set authority — and the daemon's advertised list is the authority for
+ * what it can actually run. The hand-copied closed union that used to live here
+ * (one of the audit's six, Appendix A) added no safety: it could only ever
+ * re-state the registry's ids, and a fifth registered platform would have needed
+ * an edit here to be checkable at all.
  */
 export async function integrationPlatformAvailability(
   deps: HttpDeps,
-  input: { daemonId: string; orgId: OrgId; viewer: ViewCtx; platform: IntegrationPlatform }
+  input: { daemonId: string; orgId: OrgId; viewer: ViewCtx; platform: string }
 ): Promise<DaemonPlatformAvailability> {
   const daemon = await deps.registry.get(DaemonId(input.daemonId))
   if (!daemon || daemon.orgId !== input.orgId || !canView(daemon, input.viewer)) return 'not_found'

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -232,11 +232,13 @@ export interface HttpDeps {
     oauth: OAuthRepo
   }
   registry: DaemonRegistry
-  /** §9 platform-provider registry — the single platform-set authority. The
-   *  create route folds each provider's `credentialBodySchema` /
-   *  `refineCreateBody` into its request schema and dispatches the live
-   *  credential check through `validateConfig`, so no route file names a
-   *  platform to validate one. */
+  /** §9 platform-provider registry — the single platform-set authority.
+   *  `server.ts` mounts each provider's `installRoutes(scope)` (so no core file
+   *  imports a funnel-route factory), and the create route folds each
+   *  provider's `credentialBodySchema` / `refineCreateBody` into its request
+   *  schema, dispatches the live credential check through `validateConfig`, and
+   *  writes its rows from `buildNewBotInstall` — so no route file names a
+   *  platform. */
   platforms: CpPlatformRegistry
   /** The ONE assembler of CP→daemon AgentSpecs (owns secret loading + icon bases) —
    *  every spec emission (upsert replicate, icon refresh, move activation) uses it. */

--- a/packages/control-plane/src/http/install-bot.ts
+++ b/packages/control-plane/src/http/install-bot.ts
@@ -1,0 +1,130 @@
+/**
+ * `installNewBot` — the ONE core skeleton that registers a new bot identity and
+ * pushes it live (integration-plugin-architecture.md §9, "the common create
+ * skeleton stays core").
+ *
+ * Before S3 this shape existed three times: `installNewSlackBot`,
+ * `installNewFeishuBot`, and two inline copies inside the `POST /integrations`
+ * telegram/discord tails. All four wrote the same rows in the same order and
+ * forked the same way on transport — they differed only in WHICH columns and
+ * secret slots the platform fills, which is exactly what
+ * {@link CpNewBotInstall} now declares. So the skeleton lands here once and the
+ * platform half arrives as data:
+ *
+ *   bot row → secret row → integration row → (http) relay assign | (socket)
+ *   best-effort `integration/upsert` to the owning daemon.
+ *
+ * The CALLER owns the policy that precedes this: the agent is visible, editable
+ * and (for socket) placed; the credentials are already validated; the D6 fence
+ * pre-check has run. Token-bearing — never log the spec.
+ */
+import { randomUUID } from 'node:crypto'
+import type { HttpDeps } from './deps.js'
+import type { AgentRecord, BotRecord, IntegrationRecord, SlackTransport } from '../persistence/ports.js'
+import { BotId, IntegrationId, type OrgId } from '../domain/ids.js'
+import { integrationToSpec, isGatedAgent } from '../orchestrator/placement.js'
+import { NoConnection } from '../orchestrator/outbound.js'
+import type { CpNewBotInstall } from '../platforms/provider.js'
+
+export interface InstallNewBotArgs extends CpNewBotInstall {
+  orgId: OrgId
+  /** The owning agent. For SOCKET transport it MUST already be placed
+   *  (`daemonId` non-null; the daemon owns the connection) — caller checks. An
+   *  http-transport install tolerates an unplaced agent: the relay assignment
+   *  defers until placement re-converges the HTTP bot (preset-agents.md §5.3). */
+  agent: AgentRecord
+  /** Registry platform id — the bot/integration rows' `platform` column. */
+  platform: string
+  name: string
+  /** Inbound transport. 'http' ⇒ relay-pool ingest (send-only daemon spec);
+   *  'socket' ⇒ the daemon's own long-lived connection. Default 'socket'. */
+  transport?: SlackTransport
+  /** Provisioned by AgentConnect (the platform app), not a console user. */
+  prebuilt?: boolean
+  createdByUserId?: string
+}
+
+/** Minimal log surface (Fastify logger in prod). */
+interface DebugLog {
+  debug(obj: unknown, msg?: string): void
+}
+
+export async function installNewBot(
+  deps: HttpDeps,
+  log: DebugLog,
+  args: InstallNewBotArgs
+): Promise<{ integration: IntegrationRecord; bot: BotRecord }> {
+  const { orgId, agent, platform, name, secrets, createdByUserId } = args
+  const transport: SlackTransport = args.transport ?? 'socket'
+  // Shareable (multi-agent) applies ONLY to the relay-ingress http transport.
+  // Coerce it off for socket at this single bot-create seam so a stray flag can
+  // never mint a shareable socket bot — which would break the ≤1-install cap
+  // (duplicate connections on one credential). The console already hides the
+  // toggle for socket; this is the load-bearing guarantee behind it.
+  const shareable = transport === 'http' && args.bot?.shareable === true
+
+  // Ids are minted HERE, not by the caller: the funnel that needs pre-reserved
+  // ids for restart-idempotency (Feishu's one-click registration) keeps its own
+  // tail, `install-feishu.ts`.
+  const botId = BotId(randomUUID())
+  const bot = await deps.repos.bot.create({
+    ...args.bot,
+    id: botId,
+    orgId,
+    platform,
+    name,
+    transport,
+    ...(args.prebuilt ? { prebuilt: true } : {}),
+    shareable,
+    ...(createdByUserId ? { createdByUserId } : {})
+  })
+  // Store credentials via the ONLY secret path. The configured SecretCipher is
+  // identity under `none` and encrypts with an encrypting provider. Slots the
+  // relay needs (Slack's signing secret, Feishu's verification token) stay
+  // CP-side; the daemon never receives them.
+  await deps.repos.botSecret.put(botId, secrets)
+
+  const id = IntegrationId(randomUUID())
+  const integration = await deps.repos.integration.create({
+    ...args.integration,
+    id,
+    orgId,
+    agentId: agent.id,
+    botId,
+    platform,
+    name,
+    ...(createdByUserId ? { createdByUserId } : {})
+  })
+
+  // HTTP transport: the relay pool owns the ingest — broadcast the bot assign and
+  // push the send-only spec to the daemon (HttpBotOrchestrator does both). No
+  // long-lived platform connection opens on the daemon.
+  if (transport === 'http') {
+    await deps.httpBot.syncBot(botId)
+    return { integration, bot }
+  }
+
+  // Classic: push the full spec (metadata + credentials) to the owning daemon so
+  // it opens its connection. Best-effort — an offline daemon picks it up from the
+  // register/ok reconcile roster. Never log the token-bearing spec.
+  const daemonId = agent.daemonId! // caller guarantees placement for socket transport
+  // The bot row joins the reads: it is a required input of the §9 projector that
+  // assembles the spec payload (`orchestrator/placement.ts`). `bot` was created
+  // above, so this is the same row, not a second fetch.
+  const [secret, channels] = await Promise.all([
+    deps.repos.botSecret.get(botId),
+    deps.repos.integrationChannel.listForIntegration(id)
+  ])
+  if (secret) {
+    try {
+      await deps.control.integrationUpsert(
+        daemonId,
+        await integrationToSpec(deps.platforms, integration, bot, secret, channels, isGatedAgent(agent))
+      )
+    } catch (err) {
+      if (!(err instanceof NoConnection)) throw err
+      log.debug({ integrationId: id, daemonId }, 'integration/upsert skipped: daemon offline')
+    }
+  }
+  return { integration, bot }
+}

--- a/packages/control-plane/src/http/install-slack.ts
+++ b/packages/control-plane/src/http/install-slack.ts
@@ -11,12 +11,10 @@
  * (`agent.daemonId` non-null), the caller may edit it, and the tokens are already
  * validated / obtained. Token-bearing — never log the spec.
  */
-import { randomUUID } from 'node:crypto'
 import type { HttpDeps } from './deps.js'
 import type { AgentRecord, IntegrationRecord, SlackTransport } from '../persistence/ports.js'
-import { BotId, IntegrationId, type OrgId } from '../domain/ids.js'
-import { integrationToSpec, isGatedAgent } from '../orchestrator/placement.js'
-import { NoConnection } from '../orchestrator/outbound.js'
+import type { OrgId } from '../domain/ids.js'
+import { installNewBot } from './install-bot.js'
 import { slackAppIdFromAppToken } from '../platforms/slack/provider.js'
 
 // Relocated to the Slack platform provider (§9, S3): its `validateConfig` runs
@@ -71,83 +69,36 @@ export async function installNewSlackBot(
 ): Promise<IntegrationRecord> {
   const { orgId, agent, name, botToken, appToken, signingSecret, createdByUserId } = args
   const transport: SlackTransport = args.transport ?? 'socket'
-  // Shareable (multi-agent) applies ONLY to the relay-ingress http transport. Coerce it
-  // off for socket at this single bot-create seam so a stray flag can never mint a
-  // shareable Socket Mode bot — which would break the ≤1-install cap (duplicate sockets
-  // on one appToken). The console already hides the toggle for socket; this is the
-  // load-bearing guarantee behind it (no 400 needed at the call sites).
-  const shareable = transport === 'http' && args.shareable === true
 
   // Socket mode can derive the id from xapp; HTTP mode receives it from the
   // config-token funnel or bot-token verification. Keep the derivation as the
   // authority when both are present (the caller already rejects a mismatch).
   const slackAppId = (appToken ? slackAppIdFromAppToken(appToken) : undefined) ?? args.slackAppId
-  const botId = BotId(randomUUID())
-  await deps.repos.bot.create({
-    id: botId,
+
+  // The row writes, the transport fork and the shareable coercion are core's ONE
+  // create skeleton (§9, `install-bot.ts`) — the same one `POST /integrations`
+  // drives from the provider's `buildNewBotInstall`. What stays here is the Slack
+  // funnels' argument shape: this function is the tail BOTH funnel paths call
+  // (config-token `finalize` and the platform app's OAuth callback).
+  const { integration } = await installNewBot(deps, log, {
     orgId,
+    agent,
     platform: 'slack',
     name,
     transport,
-    ...(slackAppId ? { slackAppId } : {}),
-    ...(args.teamId ? { teamId: args.teamId } : {}),
-    ...(args.workspaceId ? { workspaceId: args.workspaceId } : {}),
-    ...(args.workspaceName ? { workspaceName: args.workspaceName } : {}),
-    ...(args.botUserId ? { botUserId: args.botUserId } : {}),
     ...(args.prebuilt ? { prebuilt: true } : {}),
-    ...(shareable ? { shareable: true } : {}),
+    bot: {
+      ...(slackAppId ? { slackAppId } : {}),
+      ...(args.teamId ? { teamId: args.teamId } : {}),
+      ...(args.workspaceId ? { workspaceId: args.workspaceId } : {}),
+      ...(args.workspaceName ? { workspaceName: args.workspaceName } : {}),
+      ...(args.botUserId ? { botUserId: args.botUserId } : {}),
+      ...(args.shareable ? { shareable: true } : {})
+    },
+    // The xapp (socket) / signing secret (http) stay CP-side for the relay — the
+    // daemon never receives them.
+    secrets: { botToken, appToken: appToken ?? null, signingSecret: signingSecret ?? null },
     ...(createdByUserId ? { createdByUserId } : {})
   })
-  // Store tokens via the ONLY secret path. The configured SecretCipher is identity
-  // under `none` and encrypts with an encrypting provider. The xapp (socket) /
-  // signing secret (http) stay here for the relay — the daemon never receives them.
-  await deps.repos.botSecret.put(botId, {
-    botToken,
-    appToken: appToken ?? null,
-    signingSecret: signingSecret ?? null
-  })
-
-  const id = IntegrationId(randomUUID())
-  const integration = await deps.repos.integration.create({
-    id,
-    orgId,
-    agentId: agent.id,
-    botId,
-    platform: 'slack',
-    name,
-    ...(createdByUserId ? { createdByUserId } : {})
-  })
-
-  // HTTP transport: the relay pool owns the ingest — broadcast the bot assign and push
-  // the send-only spec to the daemon (HttpBotOrchestrator does both). No Socket Mode
-  // socket opens on the daemon.
-  if (transport === 'http') {
-    await deps.httpBot.syncBot(botId)
-    return integration
-  }
-
-  // Classic: push the full spec (metadata + tokens) to the owning daemon so it opens
-  // the Socket Mode socket. Best-effort: an offline daemon picks it up from the
-  // register/ok reconcile roster on reconnect. Never log the token-bearing spec.
-  const daemonId = agent.daemonId! // caller guarantees placement for socket transport
-  // The bot row joins the reads: it is a required input of the §9 projector that
-  // now assembles the spec payload (`orchestrator/placement.ts`). It was created
-  // above, so this read always hits.
-  const [secret, channels, botRow] = await Promise.all([
-    deps.repos.botSecret.get(botId),
-    deps.repos.integrationChannel.listForIntegration(id),
-    deps.repos.bot.get(botId)
-  ])
-  if (secret && botRow) {
-    try {
-      await deps.control.integrationUpsert(
-        daemonId,
-        await integrationToSpec(deps.platforms, integration, botRow, secret, channels, isGatedAgent(agent))
-      )
-    } catch (err) {
-      if (!(err instanceof NoConnection)) throw err
-      log.debug({ integrationId: id, daemonId }, 'integration/upsert skipped: daemon offline')
-    }
-  }
   return integration
 }

--- a/packages/control-plane/src/http/platform-route-mounts.test.ts
+++ b/packages/control-plane/src/http/platform-route-mounts.test.ts
@@ -1,0 +1,258 @@
+/**
+ * The PINNED platform mount table (integration-plugin-architecture.md §9).
+ *
+ * `server.ts` no longer imports the five funnel-route factories: it asks every
+ * registered provider for `installRoutes(scope)` and mounts what comes back, at
+ * the org scope and — twice — at the public-callback scope. That refactor is
+ * only safe if the URLs do not move: **the public callbacks are external
+ * contracts**. They are baked into a Slack app's OAuth redirect list and into
+ * the deployment gateway's routing, and this repo has already been bitten by a
+ * public-prefix/internal-prefix mismatch turning a live callback into a 404.
+ *
+ * So this suite pins paths × scopes × plugin, and it does it by ENUMERATION,
+ * never by re-stating the new code:
+ *
+ *  1. each plugin is mounted ALONE in a bare Fastify app to learn which routes
+ *     it declares (the plugin is the authority for its own paths);
+ *  2. the whole server is built and its complete route table captured through
+ *     an `onRoute` hook (Fastify is the authority for where they landed);
+ *  3. the table below — copied from the pre-refactor server's actual output —
+ *     is the pin, so a plugin that silently stops declaring a route, or lands
+ *     at one prefix instead of two, fails here.
+ *
+ * The funnels self-disable without their config, so the stub deps deliberately
+ * ENABLE every one of them (`slackConfigApi`, `slackPlatformApp`,
+ * `PUBLIC_CP_URL`) — otherwise the suite would happily pin an empty table. The
+ * last test covers the other silent loss a registry-driven mount can cause: the
+ * OpenAPI conventions on contributed routes.
+ */
+import { describe, it, expect } from 'vitest'
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from 'fastify'
+import { buildHttpServer } from './server.js'
+import { installZod } from './plugins/zod.js'
+import type { HttpDeps } from './deps.js'
+import type { CpPlatformRegistry, CpRouteScope } from '../platforms/provider.js'
+import { buildCpPlatformRegistry } from '../platforms/registry.js'
+import { createTelegramCpProvider } from '../platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../platforms/discord/provider.js'
+import { createSlackCpProvider } from '../platforms/slack/provider.js'
+import { createFeishuCpProvider } from '../platforms/feishu/provider.js'
+import { slackInstallRoutes, slackConfigRoutes, slackOauthCallbackRoutes } from './routes/slack-install.js'
+import { slackPlatformInstallRoutes, slackPlatformCallbackRoutes } from './routes/slack-platform-install.js'
+import { feishuRegistrationRoutes } from './routes/feishu-registration.js'
+
+/**
+ * TODAY'S TABLE — captured from the routing table the pre-refactor `server.ts`
+ * produced with these same deps. Paths are relative to their scope's prefix;
+ * `HEAD` (Fastify's automatic twin of every GET) is omitted.
+ */
+const EXPECTED_MOUNTS: Record<CpRouteScope, Record<string, string[]>> = {
+  org: {
+    slackInstallRoutesPlugin: [
+      'POST /integrations/slack/app',
+      'GET /integrations/slack/app/:id',
+      'POST /integrations/slack/app/:id/finalize'
+    ],
+    slackPlatformInstallRoutesPlugin: [
+      'POST /integrations/slack/platform-install',
+      'GET /integrations/slack/platform-install/:id'
+    ],
+    // The §9 `providerToolingCredentials` surface (Slack's App Configuration
+    // token): status, entry, removal.
+    slackConfigRoutesPlugin: ['GET /slack/config', 'PUT /slack/config', 'DELETE /slack/config'],
+    feishuRegistrationRoutesPlugin: ['POST /integrations/feishu/app', 'GET /integrations/feishu/app/:id']
+  },
+  'public-callback': {
+    slackOauthCallbackRoutesPlugin: ['GET /integrations/slack/oauth/callback'],
+    slackPlatformCallbackRoutesPlugin: ['GET /integrations/slack/platform/callback']
+  }
+}
+
+/** Where each scope is mounted. `public-callback` is mounted TWICE on purpose:
+ *  the internal versioned root and the public `/v1` alias the edge rewrites to
+ *  it, because a handed-out callback URL leaves the system in the public form. */
+const SCOPE_PREFIXES: Record<CpRouteScope, string[]> = {
+  org: ['/api/v1/orgs/:orgId'],
+  'public-callback': ['/api/v1', '/v1']
+}
+
+/** Minimal deps with every funnel's feature flag ON. Handlers are never invoked
+ *  (this suite only inspects the routing table and the generated spec), so the
+ *  repos and API clients can stay hollow. */
+function stubDeps(): { deps: HttpDeps; assignRegistry: (registry: CpPlatformRegistry) => void } {
+  let registry: CpPlatformRegistry | undefined
+  const deps = {
+    repos: { user: { provisionOidcUser: async () => ({ userId: 'u' }) } },
+    // Presence is the feature flag for the two Slack funnels.
+    slackConfigApi: {},
+    slackPlatformApp: { appId: 'A1', clientId: 'c', clientSecret: 's', signingSecret: 'sig' },
+    get platforms(): CpPlatformRegistry {
+      if (!registry) throw new Error('platform registry read before composition')
+      return registry
+    },
+    config: {
+      NODE_ENV: 'test',
+      DEFAULT_OWNER_ID: '00000000-0000-4000-8000-000000000000',
+      PUBLIC_CP_URL: 'https://cp.example.test',
+      PUBLIC_RELAY_URL: 'https://relay.example.test'
+    }
+  } as unknown as HttpDeps
+  return { deps, assignRegistry: (r) => (registry = r) }
+}
+
+/** The production provider set, with the funnel plugins pre-bound exactly as
+ *  `buildContainer` pre-binds them. */
+function productionPlatforms(deps: HttpDeps): CpPlatformRegistry {
+  return buildCpPlatformRegistry([
+    createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+    createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+    createSlackCpProvider({
+      funnelRoutes: {
+        org: [slackInstallRoutes(deps), slackPlatformInstallRoutes(deps), slackConfigRoutes(deps)],
+        publicCallback: [slackOauthCallbackRoutes(deps), slackPlatformCallbackRoutes(deps)]
+      }
+    }),
+    createFeishuCpProvider({ funnelRoutes: { org: [feishuRegistrationRoutes(deps)], publicCallback: [] } })
+  ])
+}
+
+/** Every `METHOD url` Fastify registered, captured from the instance itself. */
+async function routeTableOf(app: FastifyInstance): Promise<string[]> {
+  const seen: string[] = []
+  app.addHook('onRoute', (route) => {
+    const methods = Array.isArray(route.method) ? route.method : [route.method]
+    for (const method of methods) if (method !== 'HEAD') seen.push(`${method} ${route.url}`)
+  })
+  await app.ready()
+  return [...new Set(seen)].sort()
+}
+
+/** What ONE plugin declares, learned by mounting it alone. */
+async function routesDeclaredBy(plugin: FastifyPluginAsync): Promise<string[]> {
+  const app = Fastify({ logger: false })
+  installZod(app)
+  void app.register(plugin)
+  try {
+    return await routeTableOf(app)
+  } finally {
+    await app.close()
+  }
+}
+
+async function builtServer(): Promise<{ app: FastifyInstance; routes: string[]; platforms: CpPlatformRegistry }> {
+  const { deps, assignRegistry } = stubDeps()
+  const platforms = productionPlatforms(deps)
+  assignRegistry(platforms)
+  const app = buildHttpServer(deps)
+  const routes = await routeTableOf(app)
+  return { app, routes, platforms }
+}
+
+describe('platform route mounts', () => {
+  it('mounts every provider plugin at its pinned paths, and the callbacks at BOTH public prefixes', async () => {
+    const { app, routes, platforms } = await builtServer()
+    try {
+      for (const scope of ['org', 'public-callback'] as const) {
+        const plugins = platforms.all().flatMap((provider) => provider.installRoutes(scope))
+        const expected = EXPECTED_MOUNTS[scope]
+        // The registry contributes exactly the pinned plugins at this scope.
+        expect(plugins.map((plugin) => plugin.name).sort()).toEqual(Object.keys(expected).sort())
+
+        for (const plugin of plugins) {
+          // …and each one still DECLARES the pinned routes (asked of the plugin,
+          // not restated from the mount code).
+          const declared = await routesDeclaredBy(plugin)
+          expect(declared).toEqual([...expected[plugin.name]!].sort())
+
+          // …which land under every prefix this scope is mounted at.
+          for (const prefix of SCOPE_PREFIXES[scope]) {
+            for (const route of declared) {
+              const [method, path] = route.split(' ') as [string, string]
+              expect(routes).toContain(`${method} ${prefix}${path}`)
+            }
+          }
+        }
+      }
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('leaks no platform route to a prefix it was not mounted at', async () => {
+    const { app, routes, platforms } = await builtServer()
+    try {
+      const orgPaths = (
+        await Promise.all(
+          platforms.all().flatMap((provider) => provider.installRoutes('org').map((plugin) => routesDeclaredBy(plugin)))
+        )
+      ).flat()
+      const callbackPaths = (
+        await Promise.all(
+          platforms
+            .all()
+            .flatMap((provider) => provider.installRoutes('public-callback').map((plugin) => routesDeclaredBy(plugin)))
+        )
+      ).flat()
+
+      // The org funnels are behind humanAuth + the org guard, never at a public
+      // root: no `/v1/orgs/...` alias, no unprefixed twin.
+      for (const route of orgPaths) {
+        const [method, path] = route.split(' ') as [string, string]
+        expect(routes).not.toContain(`${method} /v1/orgs/:orgId${path}`)
+        expect(routes).not.toContain(`${method} ${path}`)
+      }
+      // The callbacks live at the two version roots and nowhere else — in
+      // particular NOT inside the org subtree (they are unauthenticated: the org
+      // rides the OAuth state).
+      for (const route of callbackPaths) {
+        const [method, path] = route.split(' ') as [string, string]
+        expect(routes).not.toContain(`${method} /api/v1/orgs/:orgId${path}`)
+        const mounted = routes.filter((route) => route.startsWith(`${method} `) && route.endsWith(path))
+        expect(mounted).toEqual([`${method} /api/v1${path}`, `${method} /v1${path}`])
+      }
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('a platform with no funnel contributes nothing at either scope', async () => {
+    const telegram = createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) })
+    const discord = createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' })
+    for (const provider of [telegram, discord]) {
+      expect(provider.installRoutes('org')).toEqual([])
+      expect(provider.installRoutes('public-callback')).toEqual([])
+    }
+  })
+
+  it('keeps the repo OpenAPI conventions on every contributed org route', async () => {
+    const { app } = await builtServer()
+    try {
+      const doc = (await app.inject({ method: 'GET', url: '/api/v1/openapi.json' })).json() as {
+        paths: Record<
+          string,
+          Record<string, { tags?: string[]; summary?: string; description?: string; operationId?: string }>
+        >
+      }
+      const documented = Object.values(EXPECTED_MOUNTS.org)
+        .flat()
+        .map((route) => {
+          const [method, path] = route.split(' ') as [string, string]
+          return { method: method.toLowerCase(), url: `/api/v1/orgs/{orgId}${path.replace(/:(\w+)/g, '{$1}')}` }
+        })
+
+      const operationIds: string[] = []
+      for (const { method, url } of documented) {
+        const op = doc.paths[url]?.[method]
+        expect(op, `${method.toUpperCase()} ${url} is missing from the OpenAPI document`).toBeTruthy()
+        expect(op!.tags?.length, `${url} has no tags`).toBeTruthy()
+        expect(op!.summary, `${url} has no summary`).toBeTruthy()
+        expect(op!.description, `${url} has no description`).toBeTruthy()
+        expect(op!.operationId, `${url} has no operationId`).toBeTruthy()
+        operationIds.push(op!.operationId!)
+      }
+      expect(new Set(operationIds).size).toBe(operationIds.length)
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -29,16 +29,11 @@ import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js
 import { pickChannelOwner } from '../../orchestrator/httpBot.js'
 import { isDirectConversationKind } from '../../persistence/ports.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
-import { installNewSlackBot } from '../install-slack.js'
-import { installNewFeishuBot } from '../install-feishu.js'
+import { installNewBot } from '../install-bot.js'
 import { BotExternalIdentityTaken } from '../../persistence/errors.js'
-import { integrationPlatformAvailability, type IntegrationPlatform } from '../daemon-platform-capability.js'
+import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
 import { buildCreateIntegrationBody, credentialBlockOf } from '../dto/create-integration-body.js'
-import type { CpConfigRefusal, CpValidatedIdentity } from '../../platforms/provider.js'
-import type { SlackCreateCredentials } from '../../platforms/slack/provider.js'
-import type { TelegramCreateCredentials } from '../../platforms/telegram/provider.js'
-import type { DiscordCreateCredentials } from '../../platforms/discord/provider.js'
-import type { FeishuCreateCredentials } from '../../platforms/feishu/provider.js'
+import type { CpConfigRefusal } from '../../platforms/provider.js'
 import {
   TelegramBotCheckBody,
   TelegramBotCheckDto,
@@ -246,10 +241,7 @@ export function integrationRoutes(deps: HttpDeps) {
           daemonId: agent.daemonId,
           orgId,
           viewer: ctxOf(req),
-          // The registry vouches for the id; the capability helper's closed
-          // union is one of the audit's remaining hand-copied platform unions
-          // (Appendix A) and converges in its own unit.
-          platform: req.body.platform as IntegrationPlatform
+          platform: req.body.platform
         })
         if (platformAvailability === 'not_found') {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
@@ -421,11 +413,19 @@ export function integrationRoutes(deps: HttpDeps) {
             return reply.code(201).send(toDto(integration))
           }
 
+          // ── Register a NEW bot from pasted credentials ────────────────────
+          // ONE tail for every platform (§9). What used to be four
+          // `req.body.platform === …` arms — each casting the opaque credential
+          // block back to its own type and writing its own rows — is now the
+          // core skeleton below plus two provider calls: the live credential
+          // check (`validateConfig`) and the pure row mapping
+          // (`buildNewBotInstall`). Nothing here names a platform.
+
+          const transport = req.body.transport ?? 'socket'
           // HTTP callback ingress exists only where the platform contributes a
           // relay projection (§9: a missing `projectBotAssign` IS the "no relay
           // path" signal). Telegram and Discord keep their daemon-owned
           // long-lived transports.
-          const transport = req.body.transport ?? 'socket'
           if (req.body.transport === 'http' && !provider.projectBotAssign) {
             return reply.code(400).send({
               error: 'Bad Request',
@@ -433,226 +433,100 @@ export function integrationRoutes(deps: HttpDeps) {
               message: 'HTTP callback delivery currently supports Slack and Feishu only'
             })
           }
+          // Relay availability is CORE's 409 (§9 — core, not the provider, knows
+          // the relay pool), and it now precedes the provider round-trip on every
+          // platform: a deployment that cannot serve http ingress at all is a
+          // deployment-level blocker, so there is no point spending a provider API
+          // call first. (Feishu already checked in this order; Slack checked after.
+          // The two refusals can only race when the credential is ALSO bad.)
+          if (transport === 'http' && !deps.httpBot.hasConnectedRelay()) {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              message: 'HTTP callback delivery is unavailable on this deployment'
+            })
+          }
 
           // The chosen platform's credential block: validated by the provider's OWN
           // schema (§9) and guaranteed present here by the exactly-one-of refinement.
-          // Opaque to core — each create TAIL below is what still knows the platform's
-          // field names, until §9 moves the tails behind the provider too.
+          // Opaque to core — it travels straight back into the provider, which is the
+          // only code that knows the field names inside.
           const credentials = credentialBlockOf(req.body)
 
-          // Telegram: `getMe` validates the single BotFather token and confirms
-          // Group Privacy Mode is disabled before anything is stored. Telegram exposes
-          // that setting as read-only; the owner still changes it in @BotFather.
-          if (req.body.platform === 'telegram') {
-            const tg = credentials as TelegramCreateCredentials
-            const validated = await provider.validateConfig(tg, transport)
-            if (!validated.ok) return sendConfigRefusal(reply, validated)
-            const identity: CpValidatedIdentity = validated.identity
-            const provided = req.body.name?.trim()
-            const name = provided || identity.name || agent.name
-            const botId = BotId(randomUUID())
-            await deps.repos.bot.create({
-              id: botId,
-              orgId,
-              platform: 'telegram',
-              name,
-              ...(req.principal ? { createdByUserId: req.principal.userId } : {})
-            })
-            await deps.repos.botSecret.put(botId, { botToken: tg.botToken, appToken: null, signingSecret: null })
-            const integration = await deps.repos.integration.create({
-              id: IntegrationId(randomUUID()),
-              orgId,
-              agentId: agent.id,
-              botId,
-              platform: 'telegram',
-              name,
-              ...(req.principal ? { createdByUserId: req.principal.userId } : {})
-            })
-            await replicateUpsert(integration, daemonId)
-            if (deps.syncTelegramBotIcon) {
-              try {
-                await deps.syncTelegramBotIcon(tg.botToken, profileAgent)
-              } catch (err) {
-                app.log.warn({ err, agentId: agent.id, botId }, 'telegram icon sync failed; integration remains active')
-              }
+          // Every provider round-trip that must precede persistence — token
+          // verification, and Discord's Message-Content intent enablement — so a
+          // stale / wrong / swapped credential fails the request instead of minting
+          // an integration whose transport never opens. Reachability stays
+          // best-effort by contract: only a DEFINITIVE rejection refuses with 400.
+          const validated = await provider.validateConfig(credentials, transport)
+          if (!validated.ok) return sendConfigRefusal(reply, validated)
+
+          // The platform half of the write: which bot/integration columns this
+          // platform fills, how it packs the shared secret row, and the D6 identity
+          // it claims. Pure — no I/O.
+          const install = provider.buildNewBotInstall({
+            credentials,
+            identity: validated.identity,
+            transport,
+            shareable: req.body.shareable === true
+          })
+          // Name: operator-typed → provider-derived → the owning agent's name.
+          const provided = req.body.name?.trim()
+          const name = provided || validated.identity.name || agent.name
+
+          // D6 fence, half one: one bot per external app identity. New rows write the
+          // tenant sentinel, so the composite unique backstops the race below; this
+          // pre-check just turns the common case into a clean 409 with reuse guidance.
+          const fence = install.externalIdentity
+          if (fence) {
+            const identityTaken = await deps.repos.bot.getByExternalIdentity(
+              req.body.platform,
+              fence.externalAppId,
+              fence.externalTenantId
+            )
+            if (identityTaken) {
+              return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: fence.conflictMessage })
             }
-            return reply.code(201).send(toDto(integration))
           }
 
-          // Discord: validate the single Gateway bot token, then ensure its application
-          // has Message Content enabled BEFORE storing anything. The flag update is
-          // idempotent; a bot that already has limited or approved access is untouched.
-          if (req.body.platform === 'discord') {
-            const discord = credentials as DiscordCreateCredentials
-            const validated = await provider.validateConfig(discord, transport)
-            if (!validated.ok) return sendConfigRefusal(reply, validated)
-            const identity: CpValidatedIdentity = validated.identity
-            // Name: operator-typed → users/@me-derived (best-effort) → owning agent. The
-            // daemon needs only the bot token to open the Gateway, but the provider ALSO
-            // decodes the application (client) id from the token and hands it back as the
-            // validated identity — public metadata, not secret — so the console can later
-            // hand out a ready-made "Add to Discord" invite URL from Settings without
-            // re-parsing the (never-returned) token.
-            const provided = req.body.name?.trim()
-            const name = provided || identity.name || agent.name
-            const discordAppId = identity.externalAppId
-            const botId = BotId(randomUUID())
-            await deps.repos.bot.create({
-              id: botId,
+          try {
+            const { integration, bot } = await installNewBot(deps, app.log, {
+              ...install,
               orgId,
-              platform: 'discord',
+              agent,
+              platform: req.body.platform,
               name,
-              ...(discordAppId ? { discordAppId } : {}),
+              transport,
               ...(req.principal ? { createdByUserId: req.principal.userId } : {})
             })
-            await deps.repos.botSecret.put(botId, { botToken: discord.botToken, appToken: null, signingSecret: null })
-            const integration = await deps.repos.integration.create({
-              id: IntegrationId(randomUUID()),
-              orgId,
-              agentId: agent.id,
-              botId,
-              platform: 'discord',
-              name,
-              ...(req.principal ? { createdByUserId: req.principal.userId } : {})
-            })
-            await replicateUpsert(integration, daemonId)
-            // Cosmetic and best-effort: a failure is logged and the install stands.
-            // (The pre-adoption code additionally skipped the push when the users/@me
-            // probe was unreachable; the provider's validated identity carries no
-            // reachability signal, and reaching this line means the intent ensure —
-            // the very next Discord round-trip — succeeded.)
-            if (deps.syncDiscordBotProfile) {
+            // Install-time side effects (§9 `sideEffects.postCreate`): the Telegram
+            // avatar push, the Discord profile/avatar push. Cosmetic and best-effort
+            // by contract — a failure is logged and the install stands (201 either
+            // way). An absent member ⇒ the platform pushes nothing.
+            if (provider.sideEffects?.postCreate) {
               try {
-                await deps.syncDiscordBotProfile(discord.botToken, profileAgent)
+                await provider.sideEffects.postCreate({
+                  integration,
+                  bot,
+                  secrets: install.secrets,
+                  agent: profileAgent
+                })
               } catch (err) {
                 app.log.warn(
-                  { err, agentId: agent.id, botId },
-                  'discord profile sync failed; integration remains active'
+                  { err, agentId: agent.id, botId: bot.id, platform: req.body.platform },
+                  'post-install profile sync failed; integration remains active'
                 )
               }
             }
             return reply.code(201).send(toDto(integration))
-          }
-
-          // Feishu / Lark: an appId + appSecret pair — no app-level token and no OAuth /
-          // verification funnel. Validate them against Feishu BEFORE storing (the
-          // tenant-access-token exchange validates both at once), so a stale / wrong app id
-          // or secret fails here (400) instead of silently producing an integration whose
-          // WSClient login never succeeds. That exchange also lets us derive the bot name
-          // (bot/v3/info) when the install omits one. Best-effort about reachability: only a
-          // definitive credential rejection blocks — a network blip is `unreachable`. The
-          // two credentials reuse the two-slot bot_secret (botToken = appSecret, the secret;
-          // appToken = appId, the identifier — appToken already nullable since Telegram).
-          if (req.body.platform === 'feishu') {
-            const feishu = credentials as FeishuCreateCredentials
-            const region = feishu.region // zod-defaulted to 'lark' for new installs
-            // Relay availability is core's 409 and is checked BEFORE the provider
-            // round-trip on this platform (order preserved from the pre-adoption arm).
-            if (transport === 'http' && !deps.httpBot.hasConnectedRelay()) {
-              return reply.code(409).send({
-                error: 'Conflict',
-                statusCode: 409,
-                message: 'HTTP callback delivery is unavailable on this deployment'
-              })
+          } catch (err) {
+            // D6 fence, half two: the composite unique fired between the pre-check
+            // above and the insert.
+            if (fence && err instanceof BotExternalIdentityTaken) {
+              return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: fence.conflictMessage })
             }
-            const validated = await provider.validateConfig(feishu, transport)
-            if (!validated.ok) return sendConfigRefusal(reply, validated)
-            const identity: CpValidatedIdentity = validated.identity
-            // D6 fence: one Bot per Feishu app. New rows write the tenant sentinel,
-            // so the composite unique backstops the race below; this pre-check just
-            // turns the common case into a clean 409 with reuse guidance.
-            const identityTaken = await deps.repos.bot.getByExternalIdentity('feishu', feishu.appId, '-')
-            if (identityTaken) {
-              return reply.code(409).send({
-                error: 'Conflict',
-                statusCode: 409,
-                message:
-                  'This Feishu app is already registered as a bot. Reuse that bot (pick it under "Existing") instead of registering the app again.'
-              })
-            }
-            const provided = req.body.name?.trim()
-            const name = provided || identity.name || agent.name
-            try {
-              const integration = await installNewFeishuBot(deps, app.log, {
-                orgId,
-                agent,
-                name,
-                appId: feishu.appId,
-                appSecret: feishu.appSecret,
-                region,
-                transport,
-                ...(identity.botUserId ? { botUserId: identity.botUserId } : {}),
-                ...(feishu.verificationToken ? { verificationToken: feishu.verificationToken } : {}),
-                ...(feishu.encryptKey ? { encryptKey: feishu.encryptKey } : {}),
-                ...(req.principal ? { createdByUserId: req.principal.userId } : {})
-              })
-              return reply.code(201).send(toDto(integration))
-            } catch (err) {
-              // Race backstop for the pre-check above: the composite unique fired.
-              if (err instanceof BotExternalIdentityTaken) {
-                return reply.code(409).send({
-                  error: 'Conflict',
-                  statusCode: 409,
-                  message:
-                    'This Feishu app is already registered as a bot. Reuse that bot (pick it under "Existing") instead of registering the app again.'
-                })
-              }
-              throw err
-            }
+            throw err
           }
-
-          // EXHAUSTIVENESS, restated. The create TAILS above are still per-platform
-          // (§9 moves them behind the provider next), but `platform` is no longer a
-          // closed union — it is whatever the registry registered, so the compiler
-          // no longer proves the fall-through below belongs to Slack. Registering a
-          // fifth provider without a tail must NOT mint a Slack bot out of that
-          // platform's credential block; refuse loudly instead. Unreachable today:
-          // the registry holds exactly the four platforms handled here.
-          if (req.body.platform !== 'slack') {
-            throw new Error(`no create tail for registered platform: ${req.body.platform}`)
-          }
-
-          // Register a new Slack bot from pasted tokens. Validate against Slack BEFORE
-          // we store them, so a stale / wrong-app / swapped token fails here (400)
-          // instead of silently producing an integration whose socket never opens.
-          // Best-effort about reachability: a network blip is inconclusive
-          // (`unreachable`), NOT proof the token is bad — only a definitive rejection
-          // blocks the install.
-          const slack = credentials as SlackCreateCredentials
-          const validated = await provider.validateConfig(slack, transport)
-          if (!validated.ok) return sendConfigRefusal(reply, validated)
-          const identity: CpValidatedIdentity = validated.identity
-          if (transport === 'http') {
-            // HTTP mode: inbound arrives at the relay pool — a relay must be connected.
-            // Core's 409, checked AFTER the provider round-trip on this platform
-            // (order preserved from the pre-adoption arm).
-            if (!deps.httpBot.hasConnectedRelay()) {
-              return reply.code(409).send({
-                error: 'Conflict',
-                statusCode: 409,
-                message: 'HTTP callback delivery is unavailable on this deployment'
-              })
-            }
-          }
-          // Name is optional: the app already has one. Prefer what the operator typed,
-          // else the name auth.test derived, else fall back to the owning agent's name.
-          const provided = req.body.name?.trim()
-          const integration = await installNewSlackBot(deps, app.log, {
-            orgId,
-            agent,
-            name: provided || identity.name || agent.name,
-            botToken: slack.botToken,
-            transport,
-            ...(identity.externalAppId ? { slackAppId: identity.externalAppId } : {}),
-            ...(identity.workspaceId ? { workspaceId: identity.workspaceId } : {}),
-            ...(identity.workspaceName ? { workspaceName: identity.workspaceName } : {}),
-            ...(identity.botUserId ? { botUserId: identity.botUserId } : {}),
-            ...(slack.appToken ? { appToken: slack.appToken } : {}),
-            ...(slack.signingSecret ? { signingSecret: slack.signingSecret } : {}),
-            ...(req.body.shareable === true ? { shareable: true } : {}),
-            ...(req.principal ? { createdByUserId: req.principal.userId } : {})
-          })
-          return reply.code(201).send(toDto(integration))
         } finally {
           release()
         }

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -9,7 +9,12 @@
  * graph, with the repos/registry/auth/events seams injected either real (Prisma)
  * or faked. No `@prisma/client` import here — only ports.
  */
-import Fastify, { type FastifyError, type FastifyInstance, type FastifyServerOptions } from 'fastify'
+import Fastify, {
+  type FastifyError,
+  type FastifyInstance,
+  type FastifyPluginAsync,
+  type FastifyServerOptions
+} from 'fastify'
 import cors from '@fastify/cors'
 import { hasZodFastifySchemaValidationErrors, isResponseSerializationError } from 'fastify-type-provider-zod'
 import type { HttpDeps } from './deps.js'
@@ -24,9 +29,6 @@ import { agentRepoRoutes } from './routes/agent-repos.js'
 import { webchatTokenRoutes } from './routes/webchat-token.js'
 import { webchatMcpOperationRoutes } from './routes/webchat-mcp-operations.js'
 import { integrationRoutes } from './routes/integrations.js'
-import { feishuRegistrationRoutes } from './routes/feishu-registration.js'
-import { slackInstallRoutes, slackConfigRoutes, slackOauthCallbackRoutes } from './routes/slack-install.js'
-import { slackPlatformInstallRoutes, slackPlatformCallbackRoutes } from './routes/slack-platform-install.js'
 import { botRoutes } from './routes/bots.js'
 import { mcpProviderRoutes } from './routes/mcp-providers.js'
 import { skillSourceRoutes } from './routes/skill-sources.js'
@@ -56,10 +58,31 @@ import { oauthConsentRoutes } from './oauth/consent.js'
 import { oauthMetadataRoutes } from './oauth/metadata.js'
 import { oauthRoutes } from './oauth/routes.js'
 import { API_V1_PREFIX } from './version.js'
+import type { CpRouteScope } from '../platforms/provider.js'
 import { controlPlaneOtelFastifyPlugin } from '../observability.js'
 
 export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {}): FastifyInstance {
   const app = Fastify({ logger: false, ...opts })
+
+  /**
+   * Every registered platform's route plugins for one mount scope
+   * (integration-plugin-architecture.md §9 `installRoutes`). Core mounts what
+   * the registry hands back and names no platform: the Slack quick-install and
+   * platform-app funnels, the Slack config-token surface and the Feishu
+   * one-click registration used to be five hand-listed imports here.
+   *
+   * Two scopes, and the PATHS ARE UNCHANGED BY CONSTRUCTION — a plugin declares
+   * its own routes, so mounting it from the registry instead of from an import
+   * moves nothing (`src/http/platform-route-mounts.test.ts` pins the table).
+   * The registration ORDER follows the registry rather than the old literal
+   * list; Fastify's radix router is order-independent for distinct paths.
+   *
+   * A plugin may still self-disable when its config is absent (the platform-app
+   * funnel returns early without SLACK_PLATFORM_* + PUBLIC_CP_URL) — "the routes
+   * 404" stays the feature flag.
+   */
+  const platformRoutes = (scope: CpRouteScope): FastifyPluginAsync[] =>
+    deps.platforms.all().flatMap((provider) => provider.installRoutes(scope))
 
   const otelPlugin = controlPlaneOtelFastifyPlugin()
   if (otelPlugin) void app.register(otelPlugin)
@@ -197,11 +220,14 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
       // Unauthenticated GitHub setup callback (browser redirect; org rides the
       // signed state) — version root, deliberately OUTSIDE the org subtree.
       await api.register(githubCallbackRoutes(deps))
-      // Unauthenticated Slack OAuth callback (browser redirect; the pending row
-      // rides the OAuth state) — same version-root placement as the GitHub one.
-      await api.register(slackOauthCallbackRoutes(deps))
-      // Its platform-app sibling (preset-agents.md §5.3) — same placement.
-      await api.register(slackPlatformCallbackRoutes(deps))
+      // Unauthenticated PLATFORM callbacks from the registry (§9
+      // `installRoutes('public-callback')`) — browser redirects whose state
+      // rides the OAuth exchange: today the Slack quick-install callback and its
+      // platform-app sibling (preset-agents.md §5.3). Same version-root
+      // placement as the GitHub one, and mounted AGAIN at the public `/v1`
+      // alias below, because a handed-out callback URL leaves the system in the
+      // public form.
+      for (const plugin of platformRoutes('public-callback')) await api.register(plugin)
       // Unauthenticated agent avatar PNG (Slack fetches it as the per-message
       // icon_url; no bearer, no org — only the agent UUID). Handed-out URL uses
       // the public `/v1` form, aliased below.
@@ -229,10 +255,10 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
           await scope.register(webchatTokenRoutes(deps))
           await scope.register(webchatMcpOperationRoutes(deps))
           await scope.register(integrationRoutes(deps))
-          await scope.register(feishuRegistrationRoutes(deps))
-          await scope.register(slackInstallRoutes(deps))
-          await scope.register(slackPlatformInstallRoutes(deps))
-          await scope.register(slackConfigRoutes(deps))
+          // Org-scoped platform routes from the registry (§9 `installRoutes('org')`):
+          // the install funnels' wizard endpoints and the per-user provider tooling
+          // credential surface (Slack's App Configuration token).
+          for (const plugin of platformRoutes('org')) await scope.register(plugin)
           await scope.register(botRoutes(deps))
           await scope.register(mcpProviderRoutes(deps))
           await scope.register(skillSourceRoutes(deps))
@@ -270,8 +296,10 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
   void app.register(
     async (pub) => {
       await pub.register(githubCallbackRoutes(deps))
-      await pub.register(slackOauthCallbackRoutes(deps))
-      await pub.register(slackPlatformCallbackRoutes(deps))
+      // The SAME platform callback plugins as the `/api/v1` mount above — the
+      // deliberate double mount (§9: "core mounts this scope twice"), so a
+      // callback URL handed out in the public form routes in both shapes.
+      for (const plugin of platformRoutes('public-callback')) await pub.register(plugin)
       await pub.register(agentIconRoutes(deps))
       await pub.register(orgIconRoutes(deps))
       await pub.register(mcpRoutes(deps))

--- a/packages/control-plane/src/platforms/discord/provider.ts
+++ b/packages/control-plane/src/platforms/discord/provider.ts
@@ -25,12 +25,14 @@
  * injected through {@link DiscordCpProviderDeps} so tests stay offline.
  *
  * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
- * registry — its {@link DiscordCreateCredentials} block is folded into the
- * create body and {@link CpPlatformProvider.validateConfig} IS the route's live
- * token check + intent enablement, and spec assembly (`placement.ts`) awaits
- * {@link CpPlatformProvider.projectIntegrationConfig} for the §6.4 payload.
- * {@link discordIntegrationConfig} stays exported as the ONE implementation
- * behind that projector and the equivalence tests.
+ * registry end to end — its {@link DiscordCreateCredentials} block is folded
+ * into the create body, {@link CpPlatformProvider.validateConfig} IS the route's
+ * live token check + intent enablement,
+ * {@link CpPlatformProvider.buildNewBotInstall} maps the rows, the profile push
+ * runs as the tail's `sideEffects.postCreate`, and spec assembly
+ * (`placement.ts`) awaits {@link CpPlatformProvider.projectIntegrationConfig}
+ * for the §6.4 payload. {@link discordIntegrationConfig} stays exported as the
+ * ONE implementation behind that projector and the equivalence tests.
  */
 import { z } from 'zod'
 import type { IntegrationCoreEnvelope, IntegrationDiscordConfig } from '@agentconnect.md/protocol'
@@ -149,6 +151,17 @@ export function createDiscordCpProvider(deps: DiscordCpProviderDeps): CpPlatform
         identity: { ...(name ? { name } : {}), ...(externalAppId ? { externalAppId } : {}) }
       }
     },
+
+    // The create tail's platform half (§9): one token into the shared row plus
+    // the application (client) id the token decoded to — public metadata the
+    // console turns into an "Add to Discord" invite URL, persisted as
+    // `Bot.discordAppId` exactly as the route's discord arm did inline. No D6
+    // identity to fence; Discord cannot share a bot across agents, so the
+    // requested `shareable` is dropped.
+    buildNewBotInstall: ({ credentials, identity }) => ({
+      ...(identity.externalAppId ? { bot: { discordAppId: identity.externalAppId } } : {}),
+      secrets: { botToken: credentials.botToken, appToken: null, signingSecret: null }
+    }),
 
     // One-slot packing of the shared two-slot bot_secret row
     // (`integrations.ts:515`: appToken/signingSecret stored null). No slot

--- a/packages/control-plane/src/platforms/env.test.ts
+++ b/packages/control-plane/src/platforms/env.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The platform env fold (§9 `envSchema`).
+ *
+ * `AppConfigSchema` used to spread two provider shapes by name. It now composes
+ * whatever `platforms/env.ts` declares — which is only safe if the composed
+ * schema still accepts EXACTLY what `loadConfig` accepted before, since every
+ * key here is a deployment contract: a key that quietly stops being parsed reads
+ * as "feature off" at boot, not as an error.
+ *
+ * So the first suite pins the full key set against the pre-refactor schema's
+ * (core keys + the two providers' declarations, read off `origin/main`), the
+ * second pins that the composition and the four PROVIDER instances agree — the
+ * drift a static list would otherwise hide — and the third pins the collision
+ * guards that make the spread safe.
+ */
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { AppConfigSchema, loadConfig } from '../config/env.js'
+import { CP_PLATFORM_ENV_SCHEMAS, composeCpPlatformEnv } from './env.js'
+import { buildCpPlatformRegistry } from './registry.js'
+import { createTelegramCpProvider } from './telegram/provider.js'
+import { createDiscordCpProvider } from './discord/provider.js'
+import { createSlackCpProvider } from './slack/provider.js'
+import { createFeishuCpProvider } from './feishu/provider.js'
+
+/** Every key `loadConfig` accepted BEFORE the fold. */
+const KEYS_BEFORE = [
+  'ACK_TIMEOUT_MS',
+  'API_KEY_PEPPER',
+  'CORS_ORIGIN',
+  'CRON_RUN_REAP_INTERVAL_SEC',
+  'CRON_RUN_TTL_SEC',
+  'DAEMON_DIST_TAG',
+  'DATABASE_URL',
+  'FEISHU_PLATFORM_APP_ID',
+  'FEISHU_PLATFORM_APP_SECRET',
+  'GITHUB_APP_CLIENT_ID',
+  'GITHUB_APP_ID',
+  'GITHUB_APP_PRIVATE_KEY_B64',
+  'GITHUB_APP_SLUG',
+  'HEARTBEAT_SEC',
+  'HOST',
+  'LARK_PLATFORM_APP_ID',
+  'LARK_PLATFORM_APP_SECRET',
+  'LOGTO_MGMT_APP_ID',
+  'LOGTO_MGMT_APP_SECRET',
+  'LOGTO_MGMT_ENDPOINT',
+  'LOGTO_MGMT_RESOURCE',
+  'MISSED_BEATS',
+  'NODE_ENV',
+  'OIDC_AUDIENCE',
+  'OIDC_ISSUER',
+  'OPEN_CONNECTOR_PROVIDER_BLOCKLIST',
+  'OPEN_CONNECTOR_PROVIDER_WHITELIST',
+  'OPEN_CONNECTOR_URL',
+  'PORT',
+  'PRESET_AGENTS_ENABLED',
+  'PUBLIC_CP_URL',
+  'PUBLIC_MCP_URL',
+  'PUBLIC_RELAY_URL',
+  'PUBLIC_WEB_URL',
+  'REASSIGN_GRACE_SEC',
+  'RELAY_REAP_INTERVAL_SEC',
+  'RELAY_STALE_SEC',
+  'RELAY_TOKEN',
+  'RELAY_WS_PATH',
+  'S3_ACCESS_KEY_ID',
+  'S3_BUCKET',
+  'S3_ENDPOINT',
+  'S3_PUBLIC_BASE_URL',
+  'S3_REGION',
+  'S3_SECRET_ACCESS_KEY',
+  'SECRETS_PROVIDER',
+  'SECRET_CIPHER',
+  'SLACK_INSTALL_REAP_INTERVAL_SEC',
+  'SLACK_INSTALL_TTL_SEC',
+  'SLACK_PLATFORM_APP_ID',
+  'SLACK_PLATFORM_CLIENT_ID',
+  'SLACK_PLATFORM_CLIENT_SECRET',
+  'SLACK_PLATFORM_SIGNING_SECRET',
+  'VAULT_ADDR',
+  'VAULT_AUTH_MOUNT',
+  'VAULT_JWT_PATH',
+  'VAULT_JWT_ROLE',
+  'VAULT_NAMESPACE',
+  'VAULT_TOKEN',
+  'VAULT_TRANSIT_KEY',
+  'VAULT_TRANSIT_MOUNT',
+  'WAITLIST_MODE',
+  'WS_PATH'
+] as const
+
+/** The minimum a boot needs; every other key is optional or defaulted. */
+const MINIMAL_ENV = {
+  DATABASE_URL: 'postgres://user:pass@db.example.test:5432/cp',
+  API_KEY_PEPPER: 'x'.repeat(32)
+}
+
+describe('composed AppConfigSchema', () => {
+  it('accepts exactly the keys loadConfig accepted before the fold', () => {
+    expect(Object.keys(AppConfigSchema.shape).sort()).toEqual([...KEYS_BEFORE].sort())
+  })
+
+  it('keeps each platform key parsing as its provider declared it', () => {
+    const config = loadConfig({
+      ...MINIMAL_ENV,
+      SLACK_INSTALL_TTL_SEC: '120',
+      SLACK_PLATFORM_APP_ID: 'A1',
+      SLACK_PLATFORM_CLIENT_ID: 'cid',
+      SLACK_PLATFORM_CLIENT_SECRET: 'csecret',
+      SLACK_PLATFORM_SIGNING_SECRET: 'sig',
+      FEISHU_PLATFORM_APP_ID: 'cli_feishu',
+      FEISHU_PLATFORM_APP_SECRET: 'fsecret',
+      LARK_PLATFORM_APP_ID: 'cli_lark',
+      LARK_PLATFORM_APP_SECRET: 'lsecret'
+    } as NodeJS.ProcessEnv)
+
+    // Coerced number + the reaper default that is NOT in the environment.
+    expect(config.SLACK_INSTALL_TTL_SEC).toBe(120)
+    expect(config.SLACK_INSTALL_REAP_INTERVAL_SEC).toBe(600)
+    expect(config.SLACK_PLATFORM_APP_ID).toBe('A1')
+    expect(config.FEISHU_PLATFORM_APP_SECRET).toBe('fsecret')
+    expect(config.LARK_PLATFORM_APP_ID).toBe('cli_lark')
+  })
+
+  it('leaves every platform key optional — an unset one never fail-fasts a boot', () => {
+    const config = loadConfig(MINIMAL_ENV as NodeJS.ProcessEnv)
+    expect(config.SLACK_PLATFORM_APP_ID).toBeUndefined()
+    expect(config.FEISHU_PLATFORM_APP_ID).toBeUndefined()
+    expect(config.SLACK_INSTALL_TTL_SEC).toBe(3600)
+  })
+})
+
+describe('platform env declarations', () => {
+  it('match what the production providers declare (no drift between list and provider)', () => {
+    const registry = buildCpPlatformRegistry([
+      createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+      createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+      createSlackCpProvider({}),
+      createFeishuCpProvider({})
+    ])
+    const fromProviders = registry
+      .all()
+      .flatMap((provider) => Object.keys(provider.envSchema ?? {}))
+      .sort()
+    const fromDeclaration = CP_PLATFORM_ENV_SCHEMAS.flatMap(({ envSchema }) => Object.keys(envSchema)).sort()
+
+    expect(fromDeclaration).toEqual(fromProviders)
+    // …and both are what the composed schema actually folded in.
+    expect(Object.keys(composeCpPlatformEnv([])).sort()).toEqual(fromProviders)
+  })
+
+  it('declares nothing for a platform with no deployment configuration', () => {
+    for (const platformId of ['telegram', 'discord']) {
+      expect(CP_PLATFORM_ENV_SCHEMAS.some((decl) => decl.platformId === platformId)).toBe(false)
+    }
+  })
+})
+
+describe('fold collision guards', () => {
+  it('refuses a platform key that shadows a core one', () => {
+    // The real declaration, folded against a core list that claims one of its keys.
+    expect(() => composeCpPlatformEnv(['SLACK_INSTALL_TTL_SEC'])).toThrow(
+      /platform slack env key shadows a core config key: SLACK_INSTALL_TTL_SEC/
+    )
+  })
+
+  it('refuses two platforms claiming one key', () => {
+    const claim = (platformId: string) => ({ platformId, envSchema: { SHARED_KEY: z.string().optional() } })
+    expect(() => composeCpPlatformEnv([], [claim('alpha'), claim('beta')])).toThrow(
+      /platform env key SHARED_KEY is declared by both alpha and beta/
+    )
+  })
+
+  it('folds a newly declared platform in with no core edit', () => {
+    const composed = composeCpPlatformEnv(Object.keys(AppConfigSchema.shape), [
+      { platformId: 'mastodon', envSchema: { MASTODON_INSTANCE_URL: z.string().url().optional() } }
+    ])
+    expect(Object.keys(composed)).toEqual(['MASTODON_INSTANCE_URL'])
+  })
+})

--- a/packages/control-plane/src/platforms/env.ts
+++ b/packages/control-plane/src/platforms/env.ts
@@ -1,0 +1,80 @@
+/**
+ * The platform slot's contribution to `AppConfigSchema`
+ * (integration-plugin-architecture.md §9 `envSchema`).
+ *
+ * WHY A STATIC DECLARATION AND NOT THE REGISTRY INSTANCE. `loadConfig()` runs
+ * BEFORE `buildContainer()` — and it must, because a provider is constructed
+ * FROM the parsed config (the Slack funnel's TTL knobs, the platform-app
+ * credentials). So the composition cannot read `CpPlatformRegistry.all()`
+ * without a cycle. What it can read is the same `envSchema` object each
+ * provider module exports and each provider instance hands back: the list below
+ * is that set, and `platforms/env.test.ts` pins it against what the four
+ * PROVIDERS declare, so a provider that grows a key and forgets this file fails
+ * a test instead of silently losing its env at boot.
+ *
+ * Resolution into typed config — including the all-or-none partial-set
+ * fail-fast of `config/slack-platform.ts` / `config/feishu-platform.ts` —
+ * happens inside the provider's factory. Core consumes only the schema shape.
+ */
+import type { ZodRawShape } from 'zod'
+import { SlackCpEnvSchema } from './slack/provider.js'
+import { FeishuCpEnvSchema } from './feishu/provider.js'
+
+/** Every platform's declared env keys. Telegram and Discord own none — their
+ *  whole install is the create-DTO path, with no deployment-level
+ *  configuration, so they are absent here rather than present-and-empty. */
+export const CP_PLATFORM_ENV_SCHEMAS = [
+  { platformId: 'slack', envSchema: SlackCpEnvSchema },
+  { platformId: 'feishu', envSchema: FeishuCpEnvSchema }
+] as const
+
+type EnvSchemaOf<T> = T extends { envSchema: infer S } ? S : never
+type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (k: infer I) => void ? I : never
+
+/** The composed shape's STATIC type, derived from the same list — so a provider
+ *  that adds a key gets it typed on `AppConfig` with no edit here, and adding a
+ *  platform is one list entry. */
+export type CpPlatformEnvShape = UnionToIntersection<EnvSchemaOf<(typeof CP_PLATFORM_ENV_SCHEMAS)[number]>>
+
+/**
+ * Fold every platform's env keys into one shape for `AppConfigSchema`.
+ *
+ * Fails LOUDLY on a collision — two platforms claiming one key, or a platform
+ * shadowing a core key. Either would silently change how a deployment's
+ * environment parses (the shadowing platform's schema would win the spread),
+ * which is precisely the class of boot-time surprise a fail-fast config module
+ * exists to prevent. `coreKeys` is passed in rather than imported to keep the
+ * dependency one-directional: `config/env.ts` reads this module, never the
+ * reverse.
+ */
+export function composeCpPlatformEnv(
+  coreKeys: readonly string[],
+  /** The declarations to fold. Defaults to the production list; a caller passes
+   *  another only to exercise the guards below on a synthetic pair (the return
+   *  TYPE always describes the production fold). */
+  decls: readonly { platformId: string; envSchema: ZodRawShape }[] = CP_PLATFORM_ENV_SCHEMAS
+): CpPlatformEnvShape {
+  const core = new Set(coreKeys)
+  // `ZodRawShape` is readonly-indexed in zod v4, so the accumulator names its
+  // value type rather than the shape itself.
+  const composed: Record<string, ZodRawShape[string]> = {}
+  const owner = new Map<string, string>()
+  for (const { platformId, envSchema } of decls) {
+    for (const [key, schema] of Object.entries(envSchema)) {
+      if (core.has(key)) {
+        throw new Error(`platform ${platformId} env key shadows a core config key: ${key}`)
+      }
+      const claimed = owner.get(key)
+      if (claimed) {
+        throw new Error(`platform env key ${key} is declared by both ${claimed} and ${platformId}`)
+      }
+      owner.set(key, platformId)
+      composed[key] = schema
+    }
+  }
+  // The ONE cast: the loop above builds the same object the type derives from
+  // {@link CP_PLATFORM_ENV_SCHEMAS} statically, and the collision guards are
+  // exactly what makes the two agree (a shadowed key is the only way a spread
+  // could drop one).
+  return composed as CpPlatformEnvShape
+}

--- a/packages/control-plane/src/platforms/feishu/provider.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.ts
@@ -23,16 +23,18 @@
  *    called by BOTH the live paths (`orchestrator/placement.ts`,
  *    `orchestrator/httpBot.ts`) and the provider (one implementation).
  *
- * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
- * registry — its {@link FeishuCreateCredentials} block + {@link
- * refineFeishuCreateBody} are folded into the create body, and {@link
- * CpPlatformProvider.validateConfig} IS the route's live credential check. Spec
- * assembly (`placement.ts`) and `rc/bot-assign` (`httpBot.ts`) now await
- * {@link CpPlatformProvider.projectIntegrationConfig} / {@link
- * CpPlatformProvider.projectBotAssign} — the helpers below stay exported as the
- * ONE implementation both the projectors and the equivalence tests call.
- * `server.ts` mounting and `loadConfig`'s schema fold remain live paths,
- * sharing the implementations above.
+ * ADOPTION SEQUENCING: core now reads this provider through the registry end to
+ * end — `server.ts` mounts the registration funnel from
+ * {@link CpPlatformProvider.installRoutes}, `POST /integrations` folds
+ * {@link FeishuCreateCredentials} + {@link refineFeishuCreateBody} into its body
+ * and runs {@link CpPlatformProvider.validateConfig} +
+ * {@link CpPlatformProvider.buildNewBotInstall} (D6 fence included) as its tail,
+ * `config/env.ts` folds {@link FeishuCpEnvSchema}, the container's background
+ * lifecycle drives the declared registration reaper, and spec assembly
+ * (`placement.ts`) / `rc/bot-assign` (`httpBot.ts`) await
+ * {@link CpPlatformProvider.projectIntegrationConfig} /
+ * {@link CpPlatformProvider.projectBotAssign}. The helpers below stay exported
+ * as the ONE implementation both the projectors and the equivalence tests call.
  */
 import { z } from 'zod'
 import type { ZodRawShape } from 'zod'
@@ -79,9 +81,9 @@ export function refineFeishuCreateBody(
 }
 
 /**
- * Env keys this provider owns (§9 `envSchema`) — spread into `AppConfigSchema`
- * by `config/env.ts` until `loadConfig` folds the registry's schemas (S3
- * adoption), so the live schema and the provider's declaration are ONE object.
+ * Env keys this provider owns (§9 `envSchema`) — folded into `AppConfigSchema`
+ * through `platforms/env.ts`, so the live schema and the provider's declaration
+ * are ONE object.
  *
  * Platform-owned Feishu/Lark apps: each region is independently all-or-none —
  * the same app id must back its Logto social connector so app-scoped open_id
@@ -290,6 +292,42 @@ export function createFeishuCpProvider(deps: FeishuCpProviderDeps): CpPlatformPr
         }
       }
     },
+
+    /**
+     * The create tail's platform half (§9) — the same rows `installNewFeishuBot`
+     * writes for a manual credential install (the one-click funnel keeps that
+     * function for its pre-reserved-id idempotency):
+     *
+     *  - the app id and the gateway region are durable on BOTH rows, so a freed
+     *    bot reinstalls against the region it was registered with;
+     *  - `botUserId` is the bot's own open_id where `validateConfig` resolved it
+     *    (http ingress demuxes @-mentions with it);
+     *  - the D6 fence declares the identity core checks BEFORE the write and the
+     *    copy core sends when either half of the fence fires. `'-'` is the
+     *    tenantless sentinel `BotRepo.getByExternalIdentity` documents;
+     *  - Feishu bots are single-agent — the requested `shareable` is dropped.
+     */
+    buildNewBotInstall: ({ credentials, identity }) => ({
+      bot: {
+        feishuAppId: credentials.appId,
+        feishuRegion: credentials.region,
+        ...(identity.botUserId ? { botUserId: identity.botUserId } : {})
+      },
+      integration: { feishuRegion: credentials.region },
+      secrets: {
+        botToken: credentials.appSecret,
+        appToken: credentials.appId,
+        signingSecret: null,
+        verificationToken: credentials.verificationToken ?? null,
+        encryptKey: credentials.encryptKey ?? null
+      },
+      externalIdentity: {
+        externalAppId: credentials.appId,
+        externalTenantId: '-',
+        conflictMessage:
+          'This Feishu app is already registered as a bot. Reuse that bot (pick it under "Existing") instead of registering the app again.'
+      }
+    }),
 
     // Feishu reuses the established two-slot shape (`install-feishu.ts`):
     // botToken = app SECRET (the credential), appToken = app ID (the

--- a/packages/control-plane/src/platforms/lifecycle.test.ts
+++ b/packages/control-plane/src/platforms/lifecycle.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The provider-driven background lifecycle (§9 `pendingInstalls` /
+ * `backgroundLoops`).
+ *
+ * `buildContainer` used to name four instances in three places each
+ * (construction, `startBackground()`, `shutdown()`), which is exactly the shape
+ * where a fifth funnel gets constructed and then never armed — or armed twice.
+ * These tests assert the fan-out against the PRODUCTION provider set: one reaper
+ * per declaration, each driving its own store on its own TTL, and every loop
+ * started and stopped exactly once.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { buildPendingInstallReapers, platformBackgroundLoops } from './lifecycle.js'
+import { buildCpPlatformRegistry } from './registry.js'
+import { createTelegramCpProvider } from './telegram/provider.js'
+import { createDiscordCpProvider } from './discord/provider.js'
+import { createSlackCpProvider } from './slack/provider.js'
+import { createFeishuCpProvider, FEISHU_REGISTRATION_TTL_MS } from './feishu/provider.js'
+import type { CpPlatformProvider } from './provider.js'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+
+const SLACK_TTL_MS = 3600 * 1000
+const SWEEP_MS = 600 * 1000
+
+function reapSpy() {
+  return { reapExpired: vi.fn(async () => 0) }
+}
+
+/** The four providers exactly as `buildContainer` composes them: the Slack
+ *  funnels' two stores + TTL knobs, the Feishu registration store, and the
+ *  bot-identity reconciler instance. */
+function productionRegistry() {
+  const installs = reapSpy()
+  const platformInstalls = reapSpy()
+  const registrations = reapSpy()
+  const identityReconciler = { start: vi.fn(), stop: vi.fn() }
+  const registry = buildCpPlatformRegistry([
+    createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+    createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+    createSlackCpProvider({
+      pendingInstalls: { installs, platformInstalls, ttlMs: SLACK_TTL_MS, intervalMs: SWEEP_MS },
+      identityReconciler
+    }),
+    createFeishuCpProvider({ pendingInstalls: { registrations, intervalMs: SWEEP_MS } })
+  ])
+  return { registry, installs, platformInstalls, registrations, identityReconciler }
+}
+
+describe('platform pending-install reapers', () => {
+  it('builds exactly one reaper per declaration, unarmed', () => {
+    const { registry } = productionRegistry()
+    const clock = new FakeClock(1_000_000)
+    const reapers = buildPendingInstallReapers(registry, clock)
+
+    // Today: slack-install, slack-platform-install, feishu-registration.
+    expect(reapers).toHaveLength(3)
+    // Nothing is armed until `startBackground()` — no timer exists yet, which is
+    // why a test that never calls it never sees a sweep.
+    expect(clock.pendingTimers()).toBe(0)
+  })
+
+  it('drives each declared store on its own TTL, once per interval', async () => {
+    const { registry, installs, platformInstalls, registrations } = productionRegistry()
+    const clock = new FakeClock(10_000_000)
+    const reapers = buildPendingInstallReapers(registry, clock)
+    for (const reaper of reapers) reaper.start()
+    expect(clock.pendingTimers()).toBe(3)
+
+    const sweepAt = clock.now() + SWEEP_MS
+    clock.advance(SWEEP_MS)
+    await Promise.resolve()
+
+    // Each store swept exactly once, with ITS OWN ttl — the Slack pair share the
+    // env knob; the Feishu registration uses its funnel-appropriate constant.
+    expect(installs.reapExpired).toHaveBeenCalledTimes(1)
+    expect(platformInstalls.reapExpired).toHaveBeenCalledTimes(1)
+    expect(registrations.reapExpired).toHaveBeenCalledTimes(1)
+    expect(installs.reapExpired.mock.calls[0]![0]).toEqual(new Date(sweepAt - SLACK_TTL_MS))
+    expect(platformInstalls.reapExpired.mock.calls[0]![0]).toEqual(new Date(sweepAt - SLACK_TTL_MS))
+    expect(registrations.reapExpired.mock.calls[0]![0]).toEqual(new Date(sweepAt - FEISHU_REGISTRATION_TTL_MS))
+
+    for (const reaper of reapers) reaper.stop()
+    expect(clock.pendingTimers()).toBe(0)
+  })
+
+  it('a provider that declares no funnel state contributes no reaper', () => {
+    const registry = buildCpPlatformRegistry([
+      createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+      createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+      // The same two funnel-bearing platforms, composed WITHOUT their stores
+      // (the focused-test composition): no declaration ⇒ no reaper.
+      createSlackCpProvider({}),
+      createFeishuCpProvider({})
+    ])
+    expect(buildPendingInstallReapers(registry, new FakeClock())).toEqual([])
+  })
+})
+
+describe('platform background loops', () => {
+  it('collects each provider loop once, and start/stop reach it exactly once', () => {
+    const { registry, identityReconciler } = productionRegistry()
+    const loops = platformBackgroundLoops(registry)
+
+    expect(loops.map((loop) => loop.label)).toEqual(['slack-bot-identity'])
+    for (const loop of loops) loop.start()
+    for (const loop of loops) loop.stop()
+    expect(identityReconciler.start).toHaveBeenCalledTimes(1)
+    expect(identityReconciler.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('is empty when no provider declares one', () => {
+    const registry = buildCpPlatformRegistry([createSlackCpProvider({}), createFeishuCpProvider({})])
+    expect(platformBackgroundLoops(registry)).toEqual([])
+  })
+
+  it('extends to a newly registered platform with no core edit', () => {
+    const started: string[] = []
+    const extra: CpPlatformProvider = {
+      ...createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+      platformId: 'mastodon',
+      pendingInstalls: [
+        { model: 'MastodonInstall', label: 'mastodon-install', store: reapSpy(), ttlMs: 60_000, intervalMs: 5_000 }
+      ],
+      backgroundLoops: [{ label: 'mastodon-sync', start: () => started.push('mastodon-sync'), stop: () => undefined }]
+    }
+    const { registry: production } = productionRegistry()
+    const registry = buildCpPlatformRegistry([...production.all(), extra])
+
+    expect(buildPendingInstallReapers(registry, new FakeClock())).toHaveLength(4)
+    const loops = platformBackgroundLoops(registry)
+    expect(loops.map((loop) => loop.label)).toEqual(['slack-bot-identity', 'mastodon-sync'])
+    for (const loop of loops) loop.start()
+    expect(started).toEqual(['mastodon-sync'])
+  })
+})

--- a/packages/control-plane/src/platforms/lifecycle.ts
+++ b/packages/control-plane/src/platforms/lifecycle.ts
@@ -1,0 +1,52 @@
+/**
+ * The platform slot's BACKGROUND lifecycle (integration-plugin-architecture.md
+ * §9 `pendingInstalls` / `backgroundLoops`).
+ *
+ * `buildContainer` used to hand-list three `SlackInstallReaper` instances and
+ * one reconciler by name, and `startBackground()` / `shutdown()` named each of
+ * them again. The reaper CLASS and the lifecycle are core — one clock-driven
+ * sweep, armed after `listen`, never in tests — but WHICH funnels have durable
+ * state, what their labels are, how long their rows may linger, and which
+ * convergence loops exist are the provider's declarations. So the fan-out lives
+ * here, takes the registry, and names no platform.
+ *
+ * Extracted from the container (rather than inlined there) so it is unit
+ * testable without Postgres: `lifecycle.test.ts` drives it with a FakeClock and
+ * stub stores and pins that every declaration gets exactly one reaper.
+ */
+import { SlackInstallReaper, type ReaperLog } from '../orchestrator/slackInstallReaper.js'
+import type { Clock } from '../domain/clock.js'
+import type { CpBackgroundLoop, CpPlatformRegistry } from './provider.js'
+
+/**
+ * One TTL reaper per declared pending-install funnel, in registry order. Today
+ * that is exactly the three the container used to construct by hand:
+ * `slack-install` (a client secret + bot token must not linger past an
+ * abandoned funnel), `slack-platform-install` (an abandoned "Add to Slack" tab
+ * must not leave a live state nonce) and `feishu-registration` (encrypted
+ * device code / app secret, deliberately short-lived).
+ *
+ * Returned UNARMED — the caller's `startBackground()` arms them, so no timer
+ * exists under a test's FakeClock unless the test asks for one.
+ */
+export function buildPendingInstallReapers(
+  platforms: CpPlatformRegistry,
+  clock: Clock,
+  log?: ReaperLog
+): SlackInstallReaper[] {
+  return platforms
+    .all()
+    .flatMap((provider) => provider.pendingInstalls ?? [])
+    .map(
+      (decl) =>
+        new SlackInstallReaper(decl.store, clock, { ttlMs: decl.ttlMs, intervalMs: decl.intervalMs }, log, decl.label)
+    )
+}
+
+/** Every provider-owned convergence loop, in registry order — today the Slack
+ *  bot-identity reconciler alone. The provider was constructed with the same
+ *  instance the container holds; this only collects them so the lifecycle can
+ *  drive start/stop without a per-platform field. */
+export function platformBackgroundLoops(platforms: CpPlatformRegistry): CpBackgroundLoop[] {
+  return platforms.all().flatMap((provider) => [...(provider.backgroundLoops ?? [])])
+}

--- a/packages/control-plane/src/platforms/new-bot-install.test.ts
+++ b/packages/control-plane/src/platforms/new-bot-install.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Equivalence suite for the create tail's PLATFORM half (§9
+ * `buildNewBotInstall`).
+ *
+ * `POST /integrations` used to carry four per-platform tails, each casting the
+ * opaque credential block back to its own type and writing its own rows; core
+ * now runs ONE skeleton (`http/install-bot.ts`) over what the provider returns.
+ * The fixtures below are written from those tails' audited behavior — the bot
+ * columns they filled, the two-slot secret packing (which Feishu OVERLOADS:
+ * `botToken` = app secret, `appToken` = app id), the integration columns, and
+ * the D6 identity fence — so a provider that maps a column differently fails
+ * here rather than in production.
+ *
+ * The route-level equivalence (statuses, copy, ordering) is pinned end-to-end by
+ * `test/integration/integrations.route.test.ts`; this suite pins the data.
+ */
+import { describe, it, expect } from 'vitest'
+import { createTelegramCpProvider } from './telegram/provider.js'
+import { createDiscordCpProvider } from './discord/provider.js'
+import { createSlackCpProvider } from './slack/provider.js'
+import { createFeishuCpProvider } from './feishu/provider.js'
+import type { CpValidatedIdentity } from './provider.js'
+
+const NO_IDENTITY: CpValidatedIdentity = {}
+
+describe('telegram buildNewBotInstall', () => {
+  const provider = createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) })
+
+  it('stores the single BotFather token with both other slots NULL, and no extra columns', () => {
+    expect(
+      provider.buildNewBotInstall({
+        credentials: { botToken: '123:abc' },
+        identity: { name: 'derived' },
+        transport: 'socket',
+        shareable: false
+      })
+    ).toEqual({ secrets: { botToken: '123:abc', appToken: null, signingSecret: null } })
+  })
+
+  it('never claims a D6 identity and never honors shareable', () => {
+    const install = provider.buildNewBotInstall({
+      credentials: { botToken: 't' },
+      identity: NO_IDENTITY,
+      transport: 'socket',
+      shareable: true
+    })
+    expect(install.externalIdentity).toBeUndefined()
+    expect(install.bot?.shareable).toBeUndefined()
+  })
+})
+
+describe('discord buildNewBotInstall', () => {
+  const provider = createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' })
+
+  it('persists the application id the token decoded to, as public metadata', () => {
+    expect(
+      provider.buildNewBotInstall({
+        credentials: { botToken: 'MTA1.bot.token' },
+        identity: { name: 'derived', externalAppId: '105' },
+        transport: 'socket',
+        shareable: false
+      })
+    ).toEqual({
+      bot: { discordAppId: '105' },
+      secrets: { botToken: 'MTA1.bot.token', appToken: null, signingSecret: null }
+    })
+  })
+
+  it('omits the column entirely when the token carried no decodable app id', () => {
+    const install = provider.buildNewBotInstall({
+      credentials: { botToken: 'opaque' },
+      identity: NO_IDENTITY,
+      transport: 'socket',
+      shareable: false
+    })
+    expect(install.bot).toBeUndefined()
+    expect(install.externalIdentity).toBeUndefined()
+  })
+})
+
+describe('slack buildNewBotInstall', () => {
+  const provider = createSlackCpProvider({})
+
+  it('keeps the xapp-derived app id as the authority, and carries the workspace + mention metadata', () => {
+    expect(
+      provider.buildNewBotInstall({
+        credentials: { botToken: 'xoxb-1', appToken: 'xapp-1-AXAPP-1-deadbeef' },
+        identity: {
+          name: 'acme',
+          externalAppId: 'AAUTHTEST',
+          workspaceId: 'T1',
+          workspaceName: 'Acme',
+          botUserId: 'U1'
+        },
+        transport: 'socket',
+        shareable: false
+      })
+    ).toEqual({
+      // `botUserId` is the member id exact channel mentions render (#601).
+      bot: { slackAppId: 'AXAPP', workspaceId: 'T1', workspaceName: 'Acme', botUserId: 'U1' },
+      secrets: { botToken: 'xoxb-1', appToken: 'xapp-1-AXAPP-1-deadbeef', signingSecret: null }
+    })
+  })
+
+  it('falls back to the auth.test app id when there is no xapp to parse (http install)', () => {
+    expect(
+      provider.buildNewBotInstall({
+        credentials: { botToken: 'xoxb-1', signingSecret: 'sig' },
+        identity: { externalAppId: 'AAUTHTEST' },
+        transport: 'http',
+        shareable: true
+      })
+    ).toEqual({
+      bot: { slackAppId: 'AAUTHTEST', shareable: true },
+      secrets: { botToken: 'xoxb-1', appToken: null, signingSecret: 'sig' }
+    })
+  })
+
+  it('omits every column the install did not learn, and never writes the demux teamId', () => {
+    const install = provider.buildNewBotInstall({
+      credentials: { botToken: 'xoxb-1' },
+      identity: NO_IDENTITY,
+      transport: 'socket',
+      shareable: false
+    })
+    // `Bot.teamId` marks a DISTRIBUTED platform-app install and participates in
+    // relay demux — a pasted-token install must never write one.
+    expect(install.bot).toEqual({})
+    expect(install.externalIdentity).toBeUndefined()
+  })
+})
+
+describe('feishu buildNewBotInstall', () => {
+  const provider = createFeishuCpProvider({})
+
+  it('writes the app id + region on both rows and OVERLOADS the two secret slots', () => {
+    expect(
+      provider.buildNewBotInstall({
+        credentials: { appId: 'cli_x', appSecret: 's3cret', region: 'lark' },
+        identity: { name: 'derived', externalAppId: 'cli_x', botUserId: 'ou_bot' },
+        transport: 'socket',
+        shareable: false
+      })
+    ).toEqual({
+      bot: { feishuAppId: 'cli_x', feishuRegion: 'lark', botUserId: 'ou_bot' },
+      integration: { feishuRegion: 'lark' },
+      secrets: {
+        // botToken = the app SECRET; appToken = the app ID (the audited
+        // overloading of the shared two-slot row).
+        botToken: 's3cret',
+        appToken: 'cli_x',
+        signingSecret: null,
+        verificationToken: null,
+        encryptKey: null
+      },
+      externalIdentity: {
+        externalAppId: 'cli_x',
+        externalTenantId: '-',
+        conflictMessage:
+          'This Feishu app is already registered as a bot. Reuse that bot (pick it under "Existing") instead of registering the app again.'
+      }
+    })
+  })
+
+  it('carries the callback credentials for an http install', () => {
+    const install = provider.buildNewBotInstall({
+      credentials: {
+        appId: 'cli_x',
+        appSecret: 's3cret',
+        region: 'feishu',
+        verificationToken: 'vt',
+        encryptKey: 'ek'
+      },
+      identity: { externalAppId: 'cli_x' },
+      transport: 'http',
+      shareable: true
+    })
+    expect(install.secrets.verificationToken).toBe('vt')
+    expect(install.secrets.encryptKey).toBe('ek')
+    expect(install.bot).toEqual({ feishuAppId: 'cli_x', feishuRegion: 'feishu' })
+    // Feishu has no multi-agent sharing — the requested flag is dropped.
+    expect(install.bot?.shareable).toBeUndefined()
+  })
+
+  it('fences the D6 identity with the tenantless sentinel', () => {
+    const install = provider.buildNewBotInstall({
+      credentials: { appId: 'cli_y', appSecret: 's', region: 'lark' },
+      identity: NO_IDENTITY,
+      transport: 'socket',
+      shareable: false
+    })
+    // The pre-check query and the `BotExternalIdentityTaken` backstop both run
+    // off this declaration, so the id and the sentinel must be exactly what the
+    // repo's dual-write puts on the row.
+    expect(install.externalIdentity?.externalAppId).toBe('cli_y')
+    expect(install.externalIdentity?.externalTenantId).toBe('-')
+  })
+})

--- a/packages/control-plane/src/platforms/provider.ts
+++ b/packages/control-plane/src/platforms/provider.ts
@@ -76,7 +76,13 @@
 import type { FastifyPluginAsync } from 'fastify'
 import type { ZodRawShape, ZodType } from 'zod'
 import type { IntegrationCoreEnvelope } from '@agentconnect.md/protocol'
-import type { BotRecord, BotSecretMaterial, IntegrationRecord } from '../persistence/ports.js'
+import type {
+  BotRecord,
+  BotSecretMaterial,
+  CreateBotInput,
+  CreateIntegrationInput,
+  IntegrationRecord
+} from '../persistence/ports.js'
 import type { BotProfileIconAgent } from '../http/bot-profile-icon.js'
 import type { OrgId } from '../domain/ids.js'
 
@@ -87,16 +93,18 @@ import type { OrgId } from '../domain/ids.js'
 export type CpInstallTransport = 'socket' | 'http'
 
 /** The two route mount scopes `http/server.ts` drives (§9):
- *  - `'org'` — behind humanAuth + the org guard under `/orgs/:orgId`
- *    (`server.ts:232-235`: today's `feishuRegistrationRoutes`,
- *    `slackInstallRoutes`, `slackPlatformInstallRoutes`, `slackConfigRoutes`);
+ *  - `'org'` — behind humanAuth + the org guard under `/api/v1/orgs/:orgId`
+ *    (today's `slackInstallRoutes`, `slackPlatformInstallRoutes`,
+ *    `slackConfigRoutes`, `feishuRegistrationRoutes`);
  *  - `'public-callback'` — unauthenticated at the version root, for browser
- *    redirects whose state rides the OAuth exchange (`server.ts:202-204`:
+ *    redirects whose state rides the OAuth exchange (today's
  *    `slackOauthCallbackRoutes`, `slackPlatformCallbackRoutes`). Core mounts
- *    this scope TWICE — internal `/api/v1` and the public `/v1` alias
- *    (`server.ts:270-280`) — because handed-out callback URLs leave the
- *    system in the public form; the double mount is core's, not the
- *    provider's. */
+ *    this scope TWICE — internal `/api/v1` and the public `/v1` alias —
+ *    because handed-out callback URLs leave the system in the public form; the
+ *    double mount is core's, not the provider's.
+ *
+ *  The resulting table is pinned path-by-path in
+ *  `http/platform-route-mounts.test.ts`: these URLs are external contracts. */
 export type CpRouteScope = 'org' | 'public-callback'
 
 /**
@@ -146,6 +154,63 @@ export interface CpConfigRefusal {
 }
 
 export type CpConfigValidation = { ok: true; identity: CpValidatedIdentity } | CpConfigRefusal
+
+/**
+ * The PLATFORM-SPECIFIC half of "register a new bot from pasted credentials" —
+ * everything core's one shared create tail (`http/install-bot.ts`) cannot know:
+ * which `bot` / `integration` columns this platform fills, how it packs the
+ * shared secret row, and whether it has a D6 external-identity to fence.
+ *
+ * The SKELETON around it stays core (§9): the id mint, the row writes in order,
+ * the socket `integration/upsert` vs http `syncBot` fork, and the shareable
+ * coercion. Before this existed, `http/routes/integrations.ts` carried four
+ * `req.body.platform === …` tails that each cast the opaque credential block
+ * back to a per-platform type — the last create-path platform branch in core.
+ */
+export interface CpNewBotInstall {
+  /** Platform-specific columns of the new `bot` row. Core owns `id`, `orgId`,
+   *  `platform`, `name`, `transport`, `prebuilt` and `createdByUserId`;
+   *  `shareable` is honored only by a platform that declares it here AND only
+   *  on the http transport (core coerces it off for socket at the single
+   *  bot-create seam). */
+  bot?: Readonly<
+    Partial<
+      Pick<
+        CreateBotInput,
+        | 'slackAppId'
+        | 'teamId'
+        | 'workspaceId'
+        | 'workspaceName'
+        | 'botUserId'
+        | 'discordAppId'
+        | 'feishuAppId'
+        | 'feishuRegion'
+        | 'shareable'
+      >
+    >
+  >
+  /** Platform-specific columns of the `integration` row (today: the Feishu
+   *  gateway region, carried so a freed bot reinstalls against it). */
+  integration?: Readonly<Partial<Pick<CreateIntegrationInput, 'feishuRegion'>>>
+  /** The shared two-slot `bot_secret` row as this platform packs it — see
+   *  {@link CpSecretShape}. Token-bearing; NEVER log. */
+  secrets: BotSecretMaterial
+  /**
+   * The D6 external-identity this install claims, when the platform has one.
+   * Core runs BOTH halves of the fence with it — the pre-check that turns the
+   * common case into a clean 409, and the `BotExternalIdentityTaken` race
+   * backstop from the composite unique — so the query and the copy stay one
+   * declaration (`integrations.ts`' feishu arm before adoption). Pass the `'-'`
+   * sentinel as `externalTenantId` on a tenantless platform, exactly as
+   * `BotRepo.getByExternalIdentity` documents.
+   */
+  externalIdentity?: {
+    externalAppId: string
+    externalTenantId: string
+    /** The 409 body's user-facing copy — platform-named reuse guidance. */
+    conflictMessage: string
+  }
+}
 
 /**
  * How this platform packs the shared two-slot `bot_secret` row (+ optional
@@ -333,6 +398,25 @@ export interface CpPlatformProvider<TCredentials = unknown> {
    * is 503, never proof the credential is bad.
    */
   validateConfig(credentials: TCredentials, transport: CpInstallTransport): Promise<CpConfigValidation>
+
+  /**
+   * Map a validated credential block onto the rows a NEW bot install writes —
+   * the platform-specific half of the create tail (see {@link CpNewBotInstall}).
+   * Pure: no I/O, no provider round-trip (those all belong to
+   * {@link validateConfig}, which runs first and hands its
+   * {@link CpValidatedIdentity} in here).
+   *
+   * `shareable` is the caller's REQUEST, not a decision: a platform that does
+   * not support multi-agent bots simply drops it (the §5 manifest is the
+   * eventual declarative home for that axis — until it carries the field, the
+   * platform that supports sharing is the one that echoes the flag back).
+   */
+  buildNewBotInstall(input: {
+    credentials: TCredentials
+    identity: CpValidatedIdentity
+    transport: CpInstallTransport
+    shareable: boolean
+  }): CpNewBotInstall
 
   /** How this platform packs the shared secret row + which slots gate an
    *  http assign. See {@link CpSecretShape}. */

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -27,16 +27,18 @@
  *    by BOTH the live paths (`orchestrator/placement.ts`,
  *    `orchestrator/httpBot.ts`) and the provider (one implementation).
  *
- * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
- * registry — its {@link SlackCreateCredentials} block + {@link
- * refineSlackCreateBody} are folded into the create body, and {@link
- * CpPlatformProvider.validateConfig} IS the route's live token check. Spec
- * assembly (`placement.ts`) and `rc/bot-assign` (`httpBot.ts`) now await
- * {@link CpPlatformProvider.projectIntegrationConfig} / {@link
- * CpPlatformProvider.projectBotAssign} — the helpers below stay exported as the
- * ONE implementation both the projectors and the equivalence tests call.
- * `server.ts` mounting, `loadConfig`'s schema fold, and `startBackground()`
- * remain live paths, sharing the implementations above.
+ * ADOPTION SEQUENCING: core now reads this provider through the registry end to
+ * end — `server.ts` mounts {@link CpPlatformProvider.installRoutes} at both
+ * scopes, `POST /integrations` folds {@link SlackCreateCredentials} +
+ * {@link refineSlackCreateBody} into its body and runs
+ * {@link CpPlatformProvider.validateConfig} +
+ * {@link CpPlatformProvider.buildNewBotInstall} as its tail, `config/env.ts`
+ * folds {@link SlackCpEnvSchema}, the container's background lifecycle drives
+ * the declared reapers and loops, and spec assembly (`placement.ts`) /
+ * `rc/bot-assign` (`httpBot.ts`) await
+ * {@link CpPlatformProvider.projectIntegrationConfig} /
+ * {@link CpPlatformProvider.projectBotAssign}. The helpers below stay exported
+ * as the ONE implementation both the projectors and the equivalence tests call.
  */
 import { z } from 'zod'
 import type { ZodRawShape } from 'zod'
@@ -91,9 +93,11 @@ export function slackAppIdFromAppToken(appToken: string): string | undefined {
 }
 
 /**
- * Env keys this provider owns (§9 `envSchema`) — spread into `AppConfigSchema`
- * by `config/env.ts` until `loadConfig` folds the registry's schemas (S3
- * adoption), so the live schema and the provider's declaration are ONE object.
+ * Env keys this provider owns (§9 `envSchema`) — folded into `AppConfigSchema`
+ * through `platforms/env.ts`, so the live schema and the provider's declaration
+ * are ONE object. (The fold reads the static declaration rather than the
+ * registry: `loadConfig` necessarily runs before a provider, which is
+ * constructed FROM the parsed config, can exist.)
  *
  *  - `SLACK_INSTALL_*` — the pending-install reaper knobs
  *    (slack-install-smoothing.md §Tier B): a `slack_install` pending row the
@@ -327,6 +331,39 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
             }
           : {}
       return { ok: true, identity }
+    },
+
+    /**
+     * The create tail's platform half (§9) — the same bot columns + secret row
+     * `installNewSlackBot` writes, which now shares core's one skeleton:
+     *
+     *  - `slackAppId` keeps the xapp DERIVATION as the authority when both are
+     *    present (`validateConfig` has already refused a mismatched pair), and
+     *    falls back to the "A…" id `auth.test` resolved;
+     *  - `workspaceId` / `workspaceName` are the display-only tenant metadata
+     *    (never `Bot.teamId`, which only the platform-app OAuth funnel writes);
+     *  - `botUserId` is the public Slack member id that renders exact channel
+     *    mentions (#601);
+     *  - `shareable` is echoed back — Slack is the one platform with multi-agent
+     *    bots — and core still coerces it off for a socket install.
+     */
+    buildNewBotInstall: ({ credentials, identity, shareable }) => {
+      const slackAppId =
+        (credentials.appToken ? slackAppIdFromAppToken(credentials.appToken) : undefined) ?? identity.externalAppId
+      return {
+        bot: {
+          ...(slackAppId ? { slackAppId } : {}),
+          ...(identity.workspaceId ? { workspaceId: identity.workspaceId } : {}),
+          ...(identity.workspaceName ? { workspaceName: identity.workspaceName } : {}),
+          ...(identity.botUserId ? { botUserId: identity.botUserId } : {}),
+          ...(shareable ? { shareable: true } : {})
+        },
+        secrets: {
+          botToken: credentials.botToken,
+          appToken: credentials.appToken ?? null,
+          signingSecret: credentials.signingSecret ?? null
+        }
+      }
     },
 
     // Slack stores the literal tokens in the shared row (`install-slack.ts`):

--- a/packages/control-plane/src/platforms/telegram/provider.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.ts
@@ -13,12 +13,13 @@
  * so tests fake the provider round-trips exactly like the route tests do.
  *
  * ADOPTION SEQUENCING: `POST /integrations` now reads this provider through the
- * registry — its {@link TelegramCreateCredentials} block is folded into the
- * create body and {@link CpPlatformProvider.validateConfig} IS the route's live
- * token check, and spec assembly (`placement.ts`) awaits {@link
- * CpPlatformProvider.projectIntegrationConfig} for the §6.4 payload.
- * {@link telegramIntegrationConfig} stays exported as the ONE implementation
- * behind that projector and the equivalence tests.
+ * registry end to end — its {@link TelegramCreateCredentials} block is folded
+ * into the create body, {@link CpPlatformProvider.validateConfig} IS the route's
+ * live token check, {@link CpPlatformProvider.buildNewBotInstall} maps the rows,
+ * the avatar push runs as the tail's `sideEffects.postCreate`, and spec assembly
+ * (`placement.ts`) awaits {@link CpPlatformProvider.projectIntegrationConfig}
+ * for the §6.4 payload. {@link telegramIntegrationConfig} stays exported as the
+ * ONE implementation behind that projector and the equivalence tests.
  */
 import { z } from 'zod'
 import type { IntegrationCoreEnvelope, IntegrationTelegramConfig } from '@agentconnect.md/protocol'
@@ -116,6 +117,14 @@ export function createTelegramCpProvider(deps: TelegramCpProviderDeps): CpPlatfo
       // (operator-typed → getMe-derived → owning agent's name).
       return { ok: true, identity: { ...(checked.name ? { name: checked.name } : {}) } }
     },
+
+    // The create tail's platform half (§9): one token into the shared row, no
+    // extra bot/integration columns, no D6 identity to fence — the same rows
+    // the route's telegram arm wrote inline before adoption. Telegram cannot
+    // share a bot across agents, so the requested `shareable` is dropped.
+    buildNewBotInstall: ({ credentials }) => ({
+      secrets: { botToken: credentials.botToken, appToken: null, signingSecret: null }
+    }),
 
     // One-slot packing of the shared two-slot bot_secret row
     // (`integrations.ts:443`: appToken/signingSecret stored null). No slot

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -88,10 +88,17 @@ import { HookService } from '../../src/hooks/hook.service.js'
 import { buildHttpServer } from '../../src/http/server.js'
 import type { HttpDeps } from '../../src/http/deps.js'
 import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
+import type { CpPlatformRegistry } from '../../src/platforms/provider.js'
 import { createTelegramCpProvider } from '../../src/platforms/telegram/provider.js'
 import { createDiscordCpProvider } from '../../src/platforms/discord/provider.js'
 import { createSlackCpProvider } from '../../src/platforms/slack/provider.js'
 import { createFeishuCpProvider } from '../../src/platforms/feishu/provider.js'
+import { slackInstallRoutes, slackConfigRoutes, slackOauthCallbackRoutes } from '../../src/http/routes/slack-install.js'
+import {
+  slackPlatformInstallRoutes,
+  slackPlatformCallbackRoutes
+} from '../../src/http/routes/slack-platform-install.js'
+import { feishuRegistrationRoutes } from '../../src/http/routes/feishu-registration.js'
 import { createReadiness } from '../../src/http/readiness.js'
 import { McpRateLimiter } from '../../src/http/mcp/rate-limit.js'
 import { RemoteGrantAuthenticator } from '../../src/http/mcp/remote-grant-authenticator.js'
@@ -212,34 +219,28 @@ export function buildHttpApp(
     })
   const internalInvocationAuth = depsOverrides?.internalInvocationAuth ?? new InternalInvocationAuth()
 
-  // §9 platform-provider registry — the same four providers `buildContainer`
-  // registers, so the create route parses and validates exactly the deployed
-  // shapes, and spec assembly / `rc/bot-assign` project through the deployed
-  // projectors. Their verify seams READ THROUGH to `deps` on every call instead
-  // of capturing it: tests routinely swap `app.deps.verifySlackBot` (and
-  // friends) AFTER the app is built, and an absent dep is passed through as the
-  // provider-unreachable outcome — which every provider treats exactly as
-  // today's route treated "no verifier injected" (inconclusive: no 400, no
-  // derived identity). Only the seams the create route reaches through the
-  // provider are wired here; the icon/profile pushes remain live `deps` calls
-  // until §9 moves the create tails too. Hoisted above `deps` because the
-  // orchestrators inside the bundle take it as a constructor argument.
-  const platforms = buildCpPlatformRegistry([
-    createTelegramCpProvider({ verifyBot: (token) => deps.verifyTelegramBot(token) }),
-    createDiscordCpProvider({
-      verifyBot: async (token) => (deps.verifyDiscordBot ? deps.verifyDiscordBot(token) : { status: 'unreachable' }),
-      ensureMessageContentIntent: (token) => deps.ensureDiscordMessageContentIntent(token)
-    }),
-    createSlackCpProvider({
-      verifyBot: async (token) => (deps.verifySlackBot ? deps.verifySlackBot(token) : { status: 'unreachable' }),
-      verifyAppToken: async (token) =>
-        deps.verifySlackAppToken ? deps.verifySlackAppToken(token) : ('unreachable' as const)
-    }),
-    createFeishuCpProvider({
-      verifyBot: async (appId, appSecret, region) =>
-        deps.verifyFeishuBot ? deps.verifyFeishuBot(appId, appSecret, region) : { status: 'unreachable' }
-    })
-  ])
+  // LATE-BOUND exactly as `buildContainer` binds it (§9): the providers below are
+  // constructed WITH this dep bundle, because their funnel plugins are route
+  // factories pre-bound to it, so the registry cannot exist before the object
+  // does. `platforms` is the same stable façade the container hands to the
+  // orchestrators, which take the registry BY VALUE at construction — every read
+  // through it runs at request / reconcile time, long after assignment. The
+  // providers' verify seams READ THROUGH to `deps` on every call instead of
+  // capturing it: suites routinely swap `app.deps.verifySlackBot` (and friends)
+  // AFTER the app is built, and an absent dep is passed through as the
+  // provider-unreachable outcome — which every provider treats exactly as the
+  // old route treated "no verifier injected" (inconclusive: no 400, no derived
+  // identity).
+  let platformRegistry: CpPlatformRegistry | undefined = undefined
+  const requirePlatforms = (): CpPlatformRegistry => {
+    if (!platformRegistry) throw new Error('platform registry read before composition')
+    return platformRegistry
+  }
+  const platforms: CpPlatformRegistry = {
+    get: (platformId) => requirePlatforms().get(platformId),
+    all: () => requirePlatforms().all(),
+    ids: () => requirePlatforms().ids()
+  }
 
   const deps: HttpDeps = {
     clock,
@@ -349,6 +350,47 @@ export function buildHttpApp(
     remoteGrantAuth,
     internalInvocationAuth
   }
+
+  // The same four providers `buildContainer` registers, so the create route
+  // parses/validates exactly the deployed shapes and `server.ts` mounts exactly
+  // the deployed funnel routes. Two deliberate test-composition traits:
+  //
+  //  - the verify/sync seams READ THROUGH to `deps` on every call instead of
+  //    capturing it — tests routinely swap `app.deps.verifySlackBot` (and
+  //    friends) AFTER the app is built. An absent dep is passed through as the
+  //    provider-unreachable outcome, which every provider treats exactly as
+  //    today's route treated "no verifier injected" (inconclusive: no 400, no
+  //    derived identity);
+  //  - the funnel plugins are pre-bound to `deps`, mirroring prod. Each still
+  //    self-disables on absent config (no `slackConfigApi` / `PUBLIC_CP_URL` ⇒
+  //    those routes 404), so a suite that wants them injects the config.
+  platformRegistry = buildCpPlatformRegistry([
+    createTelegramCpProvider({
+      verifyBot: (token) => deps.verifyTelegramBot(token),
+      syncBotIcon: async (token, agent) => deps.syncTelegramBotIcon?.(token, agent)
+    }),
+    createDiscordCpProvider({
+      verifyBot: async (token) => (deps.verifyDiscordBot ? deps.verifyDiscordBot(token) : { status: 'unreachable' }),
+      ensureMessageContentIntent: (token) => deps.ensureDiscordMessageContentIntent(token),
+      syncBotProfile: async (token, agent) => deps.syncDiscordBotProfile?.(token, agent)
+    }),
+    createSlackCpProvider({
+      verifyBot: async (token) => (deps.verifySlackBot ? deps.verifySlackBot(token) : { status: 'unreachable' }),
+      verifyAppToken: async (token) =>
+        deps.verifySlackAppToken ? deps.verifySlackAppToken(token) : ('unreachable' as const),
+      funnelRoutes: {
+        org: [slackInstallRoutes(deps), slackPlatformInstallRoutes(deps), slackConfigRoutes(deps)],
+        publicCallback: [slackOauthCallbackRoutes(deps), slackPlatformCallbackRoutes(deps)]
+      },
+      userConfigs: deps
+    }),
+    createFeishuCpProvider({
+      verifyBot: async (appId, appSecret, region) =>
+        deps.verifyFeishuBot ? deps.verifyFeishuBot(appId, appSecret, region) : { status: 'unreachable' },
+      funnelRoutes: { org: [feishuRegistrationRoutes(deps)], publicCallback: [] },
+      syncAppIcon: async (appId, appSecret, region, agent) => deps.syncFeishuAppIcon?.(appId, appSecret, region, agent)
+    })
+  ])
 
   const app = buildHttpServer(deps)
 

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -179,6 +179,45 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     })
   })
 
+  it('POST refuses an http install with 409 BEFORE the credential round-trip when no relay is connected', async () => {
+    // §9 create tail: relay availability is core's gate and now precedes the
+    // provider call on EVERY platform (Feishu already did; Slack checked after).
+    // The deployment-level blocker wins over the credential verdict, and no
+    // provider API call is spent on a request that cannot succeed.
+    const agentId = await placedAgent()
+    for (const payload of [
+      { platform: 'slack', slack: { botToken: SLACK.botToken, signingSecret: 'signing-secret' } },
+      { platform: 'feishu', feishu: { appId: 'cli_x', appSecret: 's', verificationToken: 'vt' } }
+    ]) {
+      const { app } = withSpy()
+      // No relay is registered on the fake app by default.
+      let verified = false
+      app.deps.verifySlackBot = async () => {
+        verified = true
+        return { status: 'invalid' }
+      }
+      app.deps.verifyFeishuBot = async () => {
+        verified = true
+        return { status: 'invalid' }
+      }
+
+      const res = await app.app.inject({
+        method: 'POST',
+        url: `${ORG}/integrations`,
+        payload: { ...payload, agentId, transport: 'http' }
+      })
+
+      expect(res.statusCode).toBe(409)
+      expect((res.json() as { message: string }).message).toBe(
+        'HTTP callback delivery is unavailable on this deployment'
+      )
+      expect(verified).toBe(false)
+      expect(await prisma.bot.count({ where: { orgId: DEFAULT_ORG_ID } })).toBe(0)
+      await app.close()
+      running = undefined
+    }
+  })
+
   it('POST telegram check reports Group Privacy Mode without storing the token', async () => {
     const { app } = withSpy()
     app.deps.verifyTelegramBot = async (botToken) => ({


### PR DESCRIPTION
## What

§9 calls the CP slot **behavioral, not declarative**, and lists what a descriptor cannot
express: Fastify route plugins at two mount scopes (some deliberately mounted twice),
pending-install models with TTL reapers, install-time side effects, background loops, env
keys, and a dozen per-platform DI members. #574/#580/#584 published the four providers; #592
moved the create **body** and the live credential check behind them. This moves the rest of
the behavior core was still holding by name.

- **Route mounting from the registry.** `server.ts` drops its five funnel-route imports and
  mounts `provider.installRoutes(scope)` — org scope under `/api/v1/orgs/:orgId`,
  public-callback scope at the version root **and again** at the public `/v1` alias. The
  double mount stays core's, exactly as the contract says.
- **Reapers + background loops.** The three hand-listed `SlackInstallReaper` instances and the
  reconciler's `start()`/`stop()` calls become a fan-out over the providers' `pendingInstalls`
  / `backgroundLoops` declarations (new `platforms/lifecycle.ts`, extracted from the container
  so it is testable without Postgres). Same three labels, same TTLs, same instances, same
  "armed only by `startBackground()`" lifecycle.
- **Env fold.** `AppConfigSchema` composes `platforms/env.ts` instead of spreading
  `SlackCpEnvSchema` / `FeishuCpEnvSchema` by name, with a fold that throws on a platform key
  shadowing a core one. The fold reads a **static** declaration, not the registry: `loadConfig`
  necessarily runs before a provider can exist (a provider is constructed *from* the parsed
  config), so the anti-drift guarantee is a test pinning the declaration against what the four
  provider instances declare.
- **The create tails (#592's explicit leftover).** The four `req.body.platform === …` arms —
  each casting the opaque credential block back to a per-platform type and writing its own rows
  — collapse into ONE core skeleton (`http/install-bot.ts`) driven by a new provider member,
  `buildNewBotInstall`: the bot/integration columns this platform fills, how it packs the
  shared secret row (Feishu's two-slot overloading included), and the D6 external identity it
  claims — id, tenant sentinel, and the 409 copy, so **core** runs both halves of the fence
  (pre-check + `BotExternalIdentityTaken` backstop) without naming Feishu. `installNewSlackBot`
  now delegates to the same skeleton, so Slack has one implementation across the manual install
  and both funnels; `installNewFeishuBot` keeps its pre-reserved-id idempotency for the
  one-click funnel. The post-create avatar/profile pushes run as `sideEffects.postCreate`. The
  exhaustiveness guard #592 added (`no create tail for registered platform`) is **deleted** —
  there is no tail left to be missing.
- **`http/daemon-platform-capability.ts`** drops its hand-copied closed `IntegrationPlatform`
  union (audit Appendix A) for the open id the registry vouches for. It could only ever
  re-state the registry's ids, and the daemon's advertised list was always the real authority.
- **Test harness mirrors prod.** `test/fakes/build-http.ts` now pre-binds the funnel plugins
  and publishes the registry through the same late-bound getter `buildContainer` uses, so the
  suites exercise the deployed mount graph rather than a second one.

**Rebase note.** #601 landed while this was in review and added one line to the Slack create
tail this PR deletes (`...(identity.botUserId ? { botUserId } : {})` — the member id exact
channel mentions render). It is carried forward inside the Slack provider's
`buildNewBotInstall`, with a fixture asserting the column, so the rebase preserves that fix
rather than reverting it. #601's other call site (`slack-install.ts`'s finalize) is untouched.

## Behavior

**One deliberate change.** The `transport: 'http'` relay-availability 409 now precedes the
provider round-trip on **every** platform. Feishu already checked in that order; Slack checked
after its `auth.test`. The two refusals can only race when the credential is *also* bad, and in
that case the deployment-level blocker ("HTTP callback delivery is unavailable on this
deployment", 409) is the more actionable answer — and no provider API call is spent on a
request that cannot succeed regardless. No test pinned the old order; a new one pins the new
one for both platforms.

Everything else is byte-for-byte: same statuses, codes and copy; same row writes per platform
(pinned field-by-field); same name ladder; same D6 fence and its message; same
`shareable`-off-for-socket coercion at the single bot-create seam; same best-effort,
201-either-way post-create push. Two log lines are now generic
(`post-install profile sync failed; integration remains active`, with a `platform` binding)
where they used to be Telegram- and Discord-named.

## Tests

`GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/control-plane test:unit`
→ **128 files / 1183 tests passed** (1154 on this base; +29 across three new suites).

`GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/control-plane test:int` (Docker up)
→ **70 files / 956 tests passed** (955 on this base; +1). Run three times: on the base, after
the create-tail collapse, and after the final edits.

Also green: `pnpm typecheck` (whole workspace), `eslint` on every touched file,
`prettier --check packages/control-plane`.

**`src/http/platform-route-mounts.test.ts` — the pinned mount table (4 cases).** Paths ×
scopes × plugin, by ENUMERATION rather than restatement: each plugin is mounted alone in a bare
Fastify app to learn what it declares, the whole server's route table is captured through an
`onRoute` hook, and the expected table is the pre-refactor server's actual output. It pins that
each plugin's routes land under every prefix its scope is mounted at (so a callback that
stopped being double-mounted fails), that no org route leaks to a public prefix and no callback
leaks into the org subtree, that a funnel-less platform contributes nothing, and that every
contributed org route still carries `tags` / `summary` / `description` / a unique `operationId`
in the generated OpenAPI document. The funnels self-disable without their config, so the stub
deps deliberately enable all of them — otherwise the suite would happily pin an empty table.

Beyond the suite: the complete 331-row route table was dumped before and after the refactor and
diffed — **identical**.

**`src/platforms/lifecycle.test.ts` (6 cases).** One reaper per declaration and no more; built
unarmed (no timer exists until `startBackground()`); each declared store swept exactly once per
interval with **its own** TTL (the Slack pair share the env knob, the Feishu registration uses
its funnel constant); each background loop collected once with start/stop reaching the
underlying instance exactly once; a focused composition without stores yields no reaper; a
throwaway fifth provider gets its reaper and loop with no core edit.

**`src/platforms/env.test.ts` (8 cases).** The composed `AppConfigSchema` accepts **exactly**
the 63 keys `loadConfig` accepted before (list read off `origin/main`); each platform key still
parses as its provider declared it (coercion, defaults, optionality — an unset platform key
never fail-fasts a boot); the static declaration matches what the four provider instances
declare; and both collision guards fire.

**`src/platforms/new-bot-install.test.ts` (10 cases).** Equivalence for the create tail's
platform half, written from the four old tails' audited behavior: Telegram's one-slot packing,
Discord's decoded application id (and its absence), Slack's xapp-derivation-wins app id +
display-only workspace metadata + never-a-demux-`teamId`, Feishu's two-slot overloading, region
on both rows, callback credentials, and the D6 fence with its tenantless sentinel.

**`test/integration/integrations.route.test.ts`** gains the ordering pin described under
Behavior (409 before any provider call, nothing stored) and keeps its 30-odd existing
create-tail cases — the row-write, D6-fence, icon-push and refusal assertions — green
unchanged.

## Deploy surface

**No change.** Nothing here alters a URL, an env var, or anything a gateway or secret store
must know.

**Public callback paths (before → after):**

| Path | Before | After |
| --- | --- | --- |
| `GET /api/v1/integrations/slack/oauth/callback` | mounted | unchanged |
| `GET /v1/integrations/slack/oauth/callback` | mounted | unchanged |
| `GET /api/v1/integrations/slack/platform/callback` | mounted | unchanged |
| `GET /v1/integrations/slack/platform/callback` | mounted | unchanged |

Both callbacks keep the deliberate **double mount** (internal `/api/v1` + the public `/v1`
alias the edge rewrites to it) — the arrangement that exists precisely because a handed-out
callback URL leaves the system in the public form.

**Org-scoped platform paths (all under `/api/v1/orgs/:orgId`, all unchanged):**
`POST /integrations/slack/app`, `GET /integrations/slack/app/:id`,
`POST /integrations/slack/app/:id/finalize`, `POST /integrations/slack/platform-install`,
`GET /integrations/slack/platform-install/:id`, `GET|PUT|DELETE /slack/config`,
`POST /integrations/feishu/app`, `GET /integrations/feishu/app/:id`.

**Env vars:** none added, renamed or removed. `SLACK_INSTALL_TTL_SEC`,
`SLACK_INSTALL_REAP_INTERVAL_SEC`, `SLACK_PLATFORM_*`, `FEISHU_PLATFORM_*` and
`LARK_PLATFORM_*` move *where they are declared*, not what they are called or how they parse;
each keeps `.optional()` / its default, so an image bump still cannot fail-fast an existing
deployment.

**Feature flags:** unchanged. A funnel plugin still self-disables when its config is absent (no
`slackConfigApi` / `SLACK_PLATFORM_*` / `PUBLIC_CP_URL` ⇒ those routes 404), so "the routes are
not there" remains the flag.

**Evidence:** the mount-table suite above, plus the before/after dump of the complete route
table.

## Deferred (and why)

- **`providerToolingCredentials` (partial).** The Slack App-Configuration-token routes now
  mount through the provider, and the facet already delegates to `resolveUserConfigAccessToken`
  / `configUsable`. Still calling those directly: `routes/slack-install.ts` (funnel start) and
  `routes/bots.ts` (Settings→Bots manifest refresh + the `slackAppLinks` deep links). Both are
  Slack-named code the design says migrates *with* the facet; moving them is a self-contained
  follow-up.
- **The named `HttpDeps` slots (partial DI collapse).** `container.ts`'s reaper/loop slots and
  the create route's two icon slots are gone from their consumers, but the twelve
  `verifySlackBot` / `syncTelegramBotIcon` / … fields stay: they are the injection seam the
  providers are constructed from, and `http/agent-bot-icon-sync.ts` still dispatches on
  `bot.platform` across three of them (that is the `sideEffects.syncBotProfileIcon` facet).
  Removing the fields means rewriting ~50 test sites that swap `app.deps.*` *after* the app is
  built — a mechanical PR that would swamp this diff's review.
- **`POST /integrations/telegram/check`** is still a per-platform route inside core
  `routes/integrations.ts`. Not in this unit's list; a natural `installRoutes('org')`
  contribution once the icon facet moves.
- **Wire projection** (`projectIntegrationConfig` / `projectBotAssign` adoption in
  `orchestrator/placement.ts` + `orchestrator/httpBot.ts`) is its own unit, and those two files
  were deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
