### PR TITLE
feat(web): add agent focus to session header

### DIFF
--- a/packages/web/src/components/console/SessionAgentFocusMenu.test.tsx
+++ b/packages/web/src/components/console/SessionAgentFocusMenu.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { act, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/ui', () => ({ Icon: () => <span data-testid="icon" /> }))
+
+import { SessionAgentFocusMenu, type SessionAgentFocusOption } from './SessionAgentFocusMenu'
+
+let root: Root | undefined
+let container: HTMLDivElement | undefined
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  container?.remove()
+  root = undefined
+  container = undefined
+})
+
+const options: SessionAgentFocusOption[] = [
+  { agentId: 'deploy', label: 'deploy-bot', href: '/agents/deploy', avatar: <span>DB</span> },
+  { agentId: 'review', label: 'review-bot', href: '/agents/review', avatar: <span>RB</span> }
+]
+
+function Harness() {
+  const [value, setValue] = useState('deploy')
+  return <SessionAgentFocusMenu options={options} value={value} onChange={setValue} />
+}
+
+describe('SessionAgentFocusMenu', () => {
+  it('switches the focused agent without navigating away', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => root?.render(<Harness />))
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]')!
+    expect(trigger.textContent).toContain('deploy-bot+1')
+
+    await act(async () => trigger.click())
+    expect(container.querySelector('[role="menu"]')?.textContent).toContain('Focus')
+
+    const review = [...container.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')].find((button) =>
+      button.textContent?.includes('review-bot')
+    )!
+    await act(async () => review.click())
+
+    expect(container.querySelector('[role="menu"]')).toBeNull()
+    expect(trigger.textContent).toContain('review-bot+1')
+  })
+})

--- a/packages/web/src/components/console/SessionAgentFocusMenu.tsx
+++ b/packages/web/src/components/console/SessionAgentFocusMenu.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useEffect, useId, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
+import Link from 'next/link'
+import { Icon } from '@/components/ui'
+
+export interface SessionAgentFocusOption {
+  agentId: string
+  label: string
+  href?: string
+  avatar: ReactNode
+}
+
+export function SessionAgentFocusMenu({
+  options,
+  value,
+  onChange
+}: {
+  options: SessionAgentFocusOption[]
+  value: string
+  onChange: (agentId: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuId = useId()
+  const headingId = useId()
+  const selected = options.find((option) => option.agentId === value) ?? options[0]
+
+  useEffect(() => {
+    if (!open) return
+    const close = (event: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', close)
+    return () => document.removeEventListener('mousedown', close)
+  }, [open])
+
+  if (!selected) return null
+
+  if (options.length === 1) {
+    return selected.href ? (
+      <Link className="lnk min-w-0 flex-[0_1_auto] text-[12.5px] text-(--text-secondary)" href={selected.href}>
+        <span className="av h-[18px] w-[18px] flex-none rounded-[5px]">{selected.avatar}</span>
+        <span className="truncate">{selected.label}</span>
+      </Link>
+    ) : (
+      <span className="lnk min-w-0 flex-[0_1_auto] cursor-default text-[12.5px] text-(--text-secondary)">
+        <span className="av h-[18px] w-[18px] flex-none rounded-[5px]">{selected.avatar}</span>
+        <span className="truncate">{selected.label}</span>
+      </span>
+    )
+  }
+
+  const closeAndFocus = () => {
+    setOpen(false)
+    requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+  const pick = (agentId: string) => {
+    onChange(agentId)
+    closeAndFocus()
+  }
+  const moveFocus = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      closeAndFocus()
+      return
+    }
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return
+    event.preventDefault()
+    const items = Array.from(event.currentTarget.querySelectorAll<HTMLElement>('[role^="menuitem"]'))
+    if (items.length === 0) return
+    const current = Math.max(0, items.indexOf(document.activeElement as HTMLElement))
+    const next =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? items.length - 1
+          : (current + (event.key === 'ArrowDown' ? 1 : -1) + items.length) % items.length
+    items[next]?.focus()
+  }
+
+  return (
+    <div ref={wrapRef} className="relative flex min-w-0 flex-[0_1_auto]">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={`Focused agent: ${selected.label}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        className="inline-flex h-[26px] min-w-0 cursor-pointer items-center gap-[7px] rounded-md border-0 bg-transparent px-1 font-sans text-[12.5px] font-semibold leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand)"
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={(event) => {
+          if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+          event.preventDefault()
+          setOpen(true)
+        }}
+      >
+        <span className="av h-[18px] w-[18px] flex-none rounded-[5px]">{selected.avatar}</span>
+        <span className="truncate">{selected.label}</span>
+        <span className="flex-none text-(--text-tertiary)">+{options.length - 1}</span>
+        <Icon name="chevron-down" size={13} color="var(--text-tertiary)" className="flex-none" />
+      </button>
+      {open && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-labelledby={headingId}
+          className="absolute top-[calc(100%+7px)] left-0 z-50 w-[280px] max-w-[calc(100vw-32px)] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
+          onKeyDown={moveFocus}
+        >
+          <div
+            id={headingId}
+            className="px-2 pt-[5px] pb-1 font-sans text-[10.5px] font-semibold leading-normal tracking-[0.06em] text-(--text-tertiary) uppercase"
+          >
+            Focus
+          </div>
+          <div className="max-h-[300px] overflow-y-auto overflow-x-hidden">
+            {options.map((option) => {
+              const active = option.agentId === selected.agentId
+              return (
+                <div
+                  key={option.agentId}
+                  role="none"
+                  className={`flex items-center rounded-md ${
+                    active
+                      ? 'bg-(--brand-soft) text-(--brand-soft-text)'
+                      : 'text-(--text-primary) hover:bg-(--surface-hover)'
+                  }`}
+                >
+                  <button
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={active}
+                    autoFocus={active}
+                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-[9px] border-0 bg-transparent px-2 py-[7px] text-left font-sans text-[13px] font-semibold leading-normal text-inherit"
+                    onClick={() => pick(option.agentId)}
+                  >
+                    <span className="av h-6 w-6 flex-none rounded-sm">{option.avatar}</span>
+                    <span className="truncate">{option.label}</span>
+                  </button>
+                  {option.href && (
+                    <Link
+                      href={option.href}
+                      role="menuitem"
+                      title={`Open ${option.label}`}
+                      aria-label={`Open ${option.label}`}
+                      className="iconbtn mr-[6px] flex h-7 w-7 flex-none items-center justify-center bg-(--surface-card) no-underline"
+                      onClick={() => setOpen(false)}
+                    >
+                      <Icon name="arrow-up-right" size={14} />
+                    </Link>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/SessionVisibilityControl.test.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.test.tsx
@@ -46,8 +46,11 @@ async function openTightenDialog(nativeMemory: boolean): Promise<string> {
     )
   })
   const everyone = [...container.querySelectorAll('button')].find((button) => button.textContent === 'Everyone')
-  expect(everyone?.title).toBe('Visible to everyone who can view the agent')
+  expect(everyone?.title).toBe('Visible to everyone in the org')
   expect(container.textContent).not.toContain('Org')
+  await act(async () => everyone?.click())
+  expect(container.textContent).toContain('Visible only to me')
+  expect(container.textContent).toContain('Visible to everyone in the org')
   const privateButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('Private'))
   await act(async () => privateButton?.click())
   return document.body.textContent ?? ''
@@ -89,8 +92,45 @@ describe('SessionVisibilityControl — tighten confirmation', () => {
       )
     })
     expect(container.textContent).toContain(`${brand} members`)
-    expect(container.querySelector('span')?.title).toBe(
-      `Visible to current members of the source ${brand} conversation`
-    )
+    expect(container.querySelector('span')?.title).toBe('Visible to everyone who can access the conversation')
+  })
+
+  it.each([
+    ['slack', 'Slack members', 'Visible to everyone who can access the channel'],
+    ['github', 'GitHub members', 'Visible to everyone who can access the repo']
+  ] as const)('explains the settled %s audience on hover', async (externalProvider, label, title) => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(
+        <SessionVisibilityControl
+          sessionId="acp-1"
+          visibility="external"
+          externalProvider={externalProvider}
+          externalResolution="settled"
+          canChange={false}
+          onChanged={() => {}}
+        />
+      )
+    })
+    expect(container.textContent).toContain(label)
+    expect(container.querySelector('span')?.title).toBe(title)
+  })
+
+  it.each([
+    ['org', 'Everyone', 'Visible to everyone in the org'],
+    ['private', 'Private', 'Visible only to me']
+  ] as const)('keeps the read-only %s audience tooltip concise', async (visibility, label, title) => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(
+        <SessionVisibilityControl sessionId="acp-1" visibility={visibility} canChange={false} onChanged={() => {}} />
+      )
+    })
+    expect(container.textContent).toContain(label)
+    expect(container.querySelector('span')?.title).toBe(title)
   })
 })

--- a/packages/web/src/components/console/SessionVisibilityControl.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.tsx
@@ -10,21 +10,22 @@
  * look without reusing its ResourceVisibility (`org` | `restricted`) types or
  * share-set machinery.
  *
- * - Read-only viewers see a lock badge on private sessions, a provider audience
- *   badge on external sessions, and nothing on org sessions.
+ * - Read-only viewers see the same bordered audience badge for private, org,
+ *   and provider-managed sessions.
  * - `canChange` (server-computed: the identity-matched session owner only)
- *   renders the two-option control instead. Tightening (org → private)
+ *   renders a two-option dropdown instead. Tightening (org → private)
  *   confirms through a dialog carrying the memory caveat; widening is immediate.
- * - `state === 'pending'` renders the spinner pill (DaemonLifecycleBadge
- *   pattern) until every affected daemon acks the change.
+ * - `state === 'pending'` replaces the chevron with a spinner until every
+ *   affected daemon acks the change.
  */
-import { useState } from 'react'
+import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
 import { Icon } from '@/components/ui'
 import { Spinner } from '@/components/marks'
 import { ConfirmationDialog } from '@/components/console/ConfirmationDialog'
 import { putSessionVisibility, type MutableSessionVisibility, type SessionVisibility } from '@/lib/api'
 
-export const SESSION_PRIVATE_TITLE = 'Private session — visible only to its owner'
+export const SESSION_PRIVATE_TITLE = 'Visible only to me'
+export const SESSION_EVERYONE_TITLE = 'Visible to everyone in the org'
 
 export function SessionVisibilityControl({
   sessionId,
@@ -56,7 +57,21 @@ export function SessionVisibilityControl({
   const [confirming, setConfirming] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLSpanElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuId = useId()
+  const headingId = useId()
   const effective: SessionVisibility = visibility ?? 'org'
+
+  useEffect(() => {
+    if (!open) return
+    const close = (event: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', close)
+    return () => document.removeEventListener('mousedown', close)
+  }, [open])
 
   const apply = async (next: MutableSessionVisibility) => {
     setBusy(true)
@@ -73,7 +88,9 @@ export function SessionVisibilityControl({
   }
 
   const pick = (next: MutableSessionVisibility) => {
-    if (busy || next === effective) return
+    if (busy) return
+    setOpen(false)
+    if (next === effective) return
     setError(null)
     // Tightening surfaces the memory caveat first; widening never cascades and
     // applies immediately.
@@ -83,89 +100,160 @@ export function SessionVisibilityControl({
 
   if (effective === 'external') {
     const github = externalProvider === 'github'
-    const provider =
-      externalProvider === 'slack'
-        ? 'Slack'
-        : github
-          ? 'GitHub'
-          : externalProvider === 'feishu'
-            ? feishuRegion === 'lark'
-              ? 'Lark'
-              : feishuRegion === 'feishu'
-                ? 'Feishu'
-                : 'Feishu / Lark'
-            : 'External'
+    const slack = externalProvider === 'slack'
+    const provider = slack
+      ? 'Slack'
+      : github
+        ? 'GitHub'
+        : externalProvider === 'feishu'
+          ? feishuRegion === 'lark'
+            ? 'Lark'
+            : feishuRegion === 'feishu'
+              ? 'Feishu'
+              : 'Feishu / Lark'
+          : 'External'
     const title =
       externalResolution === 'settled'
         ? github
-          ? "Visible according to the source GitHub repository's current visibility and access"
-          : `Visible to current members of the source ${provider} conversation`
+          ? 'Visible to everyone who can access the repo'
+          : slack
+            ? 'Visible to everyone who can access the channel'
+            : 'Visible to everyone who can access the conversation'
         : `${provider} access could not be verified; this session remains hidden`
     return (
       <span
         title={title}
-        className="inline-flex items-center gap-[5px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)"
+        className="inline-flex h-[26px] flex-none items-center gap-[6px] rounded-md border border-(--border-default) bg-(--surface-card) px-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)"
       >
         <Icon name="users" size={13} color="var(--text-tertiary)" />
-        {github ? 'GitHub access' : `${provider} members`}
+        {`${provider} members`}
         {state === 'pending' && <Spinner size={10} />}
       </span>
     )
   }
 
   if (!canChange) {
-    // Org sessions carry no badge — org is the unmarked default.
-    if (effective !== 'private') return null
+    const privateSession = effective === 'private'
     return (
       <span
-        title={SESSION_PRIVATE_TITLE}
-        className="inline-flex items-center gap-[5px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)"
+        title={privateSession ? SESSION_PRIVATE_TITLE : SESSION_EVERYONE_TITLE}
+        className="inline-flex h-[26px] flex-none items-center gap-[6px] rounded-md border border-(--border-default) bg-(--surface-card) px-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)"
       >
-        <Icon name="lock" size={13} color="var(--text-tertiary)" />
-        Private
+        <Icon name={privateSession ? 'lock' : 'globe'} size={13} color="var(--text-tertiary)" />
+        {privateSession ? 'Private' : 'Everyone'}
+        {state === 'pending' && <Spinner size={10} />}
       </span>
     )
   }
 
-  const segment = (v: MutableSessionVisibility, icon: string, label: string, title: string) => {
-    const on = effective === v
-    return (
-      <button
-        type="button"
-        title={title}
-        disabled={busy}
-        onClick={() => pick(v)}
-        className={
-          on
-            ? 'inline-flex items-center gap-1 border-0 bg-(--brand-soft) px-[9px] py-[3px] font-sans text-[11.5px] font-semibold leading-normal text-(--brand)'
-            : 'inline-flex cursor-pointer items-center gap-1 border-0 bg-(--surface-card) px-[9px] py-[3px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) transition-[background-color,color] hover:bg-(--surface-hover) hover:text-(--text-primary)'
-        }
-      >
-        <Icon name={icon} size={11} color={on ? 'var(--brand)' : 'var(--text-tertiary)'} />
-        {label}
-      </button>
-    )
+  const choices: Array<{
+    value: MutableSessionVisibility
+    icon: string
+    label: string
+    description: string
+  }> = [
+    { value: 'org', icon: 'globe', label: 'Everyone', description: SESSION_EVERYONE_TITLE },
+    { value: 'private', icon: 'lock', label: 'Private', description: SESSION_PRIVATE_TITLE }
+  ]
+  const current = choices.find((choice) => choice.value === effective) ?? choices[0]!
+  const closeAndFocus = () => {
+    setOpen(false)
+    requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+  const moveFocus = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      closeAndFocus()
+      return
+    }
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return
+    event.preventDefault()
+    const options = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'))
+    const index = Math.max(0, options.indexOf(document.activeElement as HTMLButtonElement))
+    const next =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? options.length - 1
+          : (index + (event.key === 'ArrowDown' ? 1 : -1) + options.length) % options.length
+    options[next]?.focus()
   }
 
   return (
     <span className="inline-flex items-center gap-[6px]">
-      <span className="inline-flex overflow-hidden rounded-full border border-(--border-default)">
-        {segment('org', 'globe', 'Everyone', 'Visible to everyone who can view the agent')}
-        {segment('private', 'lock', 'Private', SESSION_PRIVATE_TITLE)}
-      </span>
-      {state === 'pending' && (
-        <span
+      <span ref={wrapRef} className="relative inline-flex flex-none">
+        <button
+          ref={triggerRef}
+          type="button"
           title={
-            nativeMemory
-              ? 'Waiting for the owning daemon to confirm the change'
-              : 'Waiting for the owning daemon to confirm the change — capture stops at daemon acknowledgement'
+            state === 'pending'
+              ? nativeMemory
+                ? 'Waiting for the owning daemon to confirm the change'
+                : 'Waiting for the owning daemon to confirm the change — capture stops at daemon acknowledgement'
+              : current.description
           }
-          className="inline-flex flex-none items-center gap-1 rounded-full border border-(--brand) bg-(--surface-sunken) py-[1px] pr-[7px] pl-[5px] font-sans text-[10.5px] font-semibold leading-normal text-(--brand)"
+          disabled={busy}
+          aria-label={`Session visibility: ${current.label}`}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-controls={open ? menuId : undefined}
+          className="inline-flex h-[26px] cursor-pointer items-center gap-[6px] rounded-md border border-(--border-default) bg-(--surface-card) px-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-primary) hover:border-(--border-strong) hover:bg-(--surface-hover) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-default disabled:opacity-60"
+          onClick={() => setOpen((value) => !value)}
+          onKeyDown={(event) => {
+            if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+            event.preventDefault()
+            setOpen(true)
+          }}
         >
-          <Spinner size={10} />
-          Applying…
-        </span>
-      )}
+          <Icon name={current.icon} size={13} color="var(--text-tertiary)" />
+          {current.label}
+          {state === 'pending' ? (
+            <Spinner size={10} />
+          ) : (
+            <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
+          )}
+        </button>
+        {open && (
+          <div
+            id={menuId}
+            role="menu"
+            aria-labelledby={headingId}
+            className="absolute top-[calc(100%+7px)] right-0 z-50 w-[300px] max-w-[calc(100vw-32px)] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
+            onKeyDown={moveFocus}
+          >
+            <span id={headingId} className="sr-only">
+              Session visibility
+            </span>
+            {choices.map((choice) => {
+              const selected = choice.value === effective
+              return (
+                <button
+                  key={choice.value}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={selected}
+                  autoFocus={selected}
+                  className={`flex w-full cursor-pointer items-start gap-[10px] rounded-md border-0 px-3 py-[9px] text-left ${
+                    selected
+                      ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
+                      : 'bg-transparent text-(--text-primary) hover:bg-(--surface-hover)'
+                  }`}
+                  onClick={() => pick(choice.value)}
+                >
+                  <Icon name={choice.icon} size={16} color="var(--text-tertiary)" className="mt-[2px] flex-none" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-sans text-[13px] font-semibold leading-normal">{choice.label}</span>
+                    <span className="mt-[2px] block font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                      {choice.description}
+                    </span>
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </span>
       {error && !confirming && (
         <span role="alert" className="font-sans text-[11.5px] font-normal leading-normal text-(--status-error)">
           {error}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1488,7 +1488,10 @@ export default function SessionDetailView() {
       ]
     })
   }, [agentById, conversationMembers, orgPath, session])
-  const headerFocusScope = conversationKey ?? session?.id ?? id
+  // A client-side history change can update ?focus without remounting this view.
+  // Include that route target in the selection scope so it supersedes the last
+  // explicit menu choice, while ordinary rerenders keep the current selection.
+  const headerFocusScope = `${conversationKey ?? session?.id ?? id}?focus=${focusAgentId ?? ''}`
   const headerFocusOptionIds = headerFocusOptions.map((option) => option.agentId).join('|')
   const defaultHeaderFocusAgentId =
     (focusAgentId && headerFocusOptions.some((option) => option.agentId === focusAgentId)
@@ -2665,11 +2668,13 @@ export default function SessionDetailView() {
   // instead of it, so a partial record is never read as the whole record.
   const transcriptPartiallyPurged = !isPg && purgedMemberCount > 0 && !transcriptPurged
   const prompts = pgPrompts(session.agentId ?? '')
+  // Per-agent activity must use that session's rows before mergeConversation()
+  // deduplicates shared provider/human messages onto one canonical source.
   const focusedMessages =
-    conversationKey && headerFocusSessionId && visibleMsgs
-      ? visibleMsgs.filter(
-          (message) => conversationSourceSessionByMessageRef.current.get(message) === headerFocusSessionId
-        )
+    conversationKey && headerFocusSessionId
+      ? conversationLoadedKey === conversationKey
+        ? (conversationSourcesRef.current.rows.get(headerFocusSessionId) ?? [])
+        : null
       : visibleMsgs
   const stepsForFocusedAgent = (steps: SessionStep[]) =>
     headerFocusOptions.length <= 1

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -53,11 +53,11 @@ import {
   fetchSessionMessages,
   fetchSessionDetail,
   fetchToolBody,
-  fmtCost,
   fmtCountCompact,
   fmtDate,
   memberDisplayName,
   mergeSessionDetailUsage,
+  sessionFromDto,
   sessionFromDetailDto,
   type SessionProfileProvider,
   type SessionDetailDto,
@@ -95,6 +95,7 @@ import {
 } from '@/components/console/session-work'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
+import { SessionAgentFocusMenu, type SessionAgentFocusOption } from '@/components/console/SessionAgentFocusMenu'
 import { useCrumbSlot } from '@/components/console/Shell'
 import { SessionRail, SessionRailSlot } from '@/components/console/SessionRail'
 import {
@@ -1050,20 +1051,6 @@ export default function SessionDetailView() {
   // §5.3: the redirect carries whose perspective was linked; scroll to and
   // briefly flash that participant's first block once the merge renders.
   const focusAgentId = conversationKey ? searchParams.get('focus') : null
-  // Conversation-level usage roll-up (C3): the header sums the CURRENT member
-  // sessions rather than showing only the representative's share.
-  const conversationUsage = useMemo(() => {
-    if (!conversationKey || !conversationMembers || conversationMembers.length <= 1) return null
-    let tokens = 0
-    let cost = 0
-    let currency: string | undefined
-    for (const member of conversationMembers) {
-      tokens += member.usage?.totalTokens ?? 0
-      cost += member.usage?.costAmount ?? 0
-      currency ??= member.usage?.costCurrency ?? undefined
-    }
-    return { tokens: fmtCountCompact(tokens), cost: fmtCost(cost || undefined, currency) }
-  }, [conversationKey, conversationMembers])
   // Conversation-level lineage lift (merged-conversation-view.md §9.2): union
   // the members' parent/child links, keep only CROSS-conversation edges, and
   // link targets as /sessions/:id — the §5.3 self-redirect forwards
@@ -1442,7 +1429,119 @@ export default function SessionDetailView() {
         }
       : sessionBase
   const agentRuntime = session?.runtime || owner?.runtime || ''
-  const runtimeMeta = acpRuntime(acpRegistry, agentRuntime)
+
+  // Header focus is presentation-only: it selects which participant owns the
+  // Workspace, Visibility, and Details affordances without changing the merged
+  // transcript or the conversation-wide composer target.
+  const headerFocusOptions = useMemo<
+    Array<SessionAgentFocusOption & { sessionId?: string; snapshot?: Session }>
+  >(() => {
+    const candidates: Array<{ agentId: string; name?: string; sessionId?: string; snapshot?: Session }> = []
+    if (conversationMembers?.length) {
+      for (const member of conversationMembers) {
+        candidates.push({
+          agentId: member.agentId,
+          sessionId: member.sessionId,
+          snapshot: sessionFromDto(member)
+        })
+      }
+    } else if (session?.participants?.length) {
+      for (const participant of session.participants) {
+        candidates.push({
+          agentId: participant.agentId,
+          name: participant.name,
+          ...(participant.agentId === session.agentId
+            ? { sessionId: session.realSessionId ?? session.id, snapshot: session }
+            : {})
+        })
+      }
+    } else if (session?.agentId) {
+      candidates.push({
+        agentId: session.agentId,
+        name: session.agentName,
+        sessionId: session.realSessionId ?? session.id,
+        snapshot: session
+      })
+    }
+
+    const seen = new Set<string>()
+    return candidates.flatMap((candidate) => {
+      if (!candidate.agentId || seen.has(candidate.agentId)) return []
+      seen.add(candidate.agentId)
+      const agent = agentById.get(candidate.agentId)
+      const label = rosterParticipantName(candidate, agent)
+      return [
+        {
+          agentId: candidate.agentId,
+          label,
+          ...(agent ? { href: orgPath(`/agents/${candidate.agentId}`) } : {}),
+          avatar: (
+            <AgentIconView
+              icon={agent?.icon}
+              runtime={agent?.runtime || candidate.snapshot?.runtime || candidate.snapshot?.model || ''}
+              size={18}
+            />
+          ),
+          ...(candidate.sessionId ? { sessionId: candidate.sessionId } : {}),
+          ...(candidate.snapshot ? { snapshot: candidate.snapshot } : {})
+        }
+      ]
+    })
+  }, [agentById, conversationMembers, orgPath, session])
+  const headerFocusScope = conversationKey ?? session?.id ?? id
+  const headerFocusOptionIds = headerFocusOptions.map((option) => option.agentId).join('|')
+  const defaultHeaderFocusAgentId =
+    (focusAgentId && headerFocusOptions.some((option) => option.agentId === focusAgentId)
+      ? focusAgentId
+      : session?.agentId) ??
+    headerFocusOptions[0]?.agentId ??
+    ''
+  const [headerFocusSelection, setHeaderFocusSelection] = useState({ scope: '', agentId: '' })
+  const storedHeaderFocusValid =
+    headerFocusSelection.scope === headerFocusScope &&
+    headerFocusOptions.some((option) => option.agentId === headerFocusSelection.agentId)
+  const headerFocusAgentId = storedHeaderFocusValid ? headerFocusSelection.agentId : defaultHeaderFocusAgentId
+  useEffect(() => {
+    if (!defaultHeaderFocusAgentId) return
+    setHeaderFocusSelection((current) =>
+      current.scope === headerFocusScope && headerFocusOptionIds.split('|').includes(current.agentId)
+        ? current
+        : { scope: headerFocusScope, agentId: defaultHeaderFocusAgentId }
+    )
+  }, [defaultHeaderFocusAgentId, headerFocusOptionIds, headerFocusScope])
+  const headerFocusOption = headerFocusOptions.find((option) => option.agentId === headerFocusAgentId)
+  const headerFocusSessionId = headerFocusOption?.sessionId
+  const extraHeaderDetailId =
+    headerFocusSessionId && headerFocusSessionId !== currentSessionDetail?.id && !syntheticPlayground
+      ? headerFocusSessionId
+      : null
+  const { data: extraHeaderDetail, mutate: mutateExtraHeaderDetail } = useSWR<SessionDetailDto>(
+    consoleKeys.sessionDetail(activeOrg?.id, extraHeaderDetailId),
+    ([, orgId, , sessionId]) => fetchSessionDetail(sessionId as string, orgId as string),
+    { refreshInterval: 30_000 }
+  )
+  const focusedSessionDetail =
+    headerFocusSessionId === currentSessionDetail?.id
+      ? currentSessionDetail
+      : extraHeaderDetail?.id === headerFocusSessionId
+        ? extraHeaderDetail
+        : null
+  const focusedDetailSession = focusedSessionDetail ? sessionFromDetailDto(focusedSessionDetail) : null
+  const focusedSessionBase = headerFocusOption?.snapshot
+    ? mergeSessionDetailUsage(headerFocusOption.snapshot, focusedDetailSession)
+    : focusedDetailSession
+  const focusedAgent = headerFocusAgentId ? agentById.get(headerFocusAgentId) : undefined
+  const focusedSession = focusedSessionBase
+    ? {
+        ...focusedSessionBase,
+        agentName: focusedAgent ? agentLabel(focusedAgent) : headerFocusOption?.label,
+        model: focusedSessionBase.model ?? (focusedSessionBase.runtime ? '' : (focusedAgent?.model ?? '—')),
+        runtime: focusedSessionBase.runtime ?? focusedAgent?.runtime ?? '',
+        daemon: focusedSessionBase.daemon ?? focusedAgent?.daemon
+      }
+    : null
+  const focusedAgentRuntime = focusedSession?.runtime || focusedAgent?.runtime || ''
+  const focusedRuntimeMeta = acpRuntime(acpRegistry, focusedAgentRuntime)
 
   // Other sessions for the left rail, scoped by the rail's own agent filter — see
   // lib/session-rail-filter.ts for why an untouched filter follows the route and an
@@ -2068,27 +2167,29 @@ export default function SessionDetailView() {
   }
 
   // Session visibility (session-visibility.md §4.3/§6). Rendered in the desktop
-  // header and the mobile meta strip; null when there is nothing to show (an org
-  // session the caller cannot re-classify, or a mock/legacy row).
+  // header and the mobile meta strip; null only when no persisted visibility
+  // metadata is available (for example a synthetic Playground row).
   const visibilityControl =
-    currentSessionDetail && detailId ? (
+    headerFocusSessionId && (focusedSessionDetail || focusedSession?.visibility) ? (
       <SessionVisibilityControl
-        key={detailId}
-        sessionId={detailId}
-        visibility={currentSessionDetail.visibility ?? undefined}
-        state={currentSessionDetail.visibilityState}
-        canChange={currentSessionDetail.canChangeVisibility === true}
-        externalProvider={currentSessionDetail.externalProvider}
-        externalResolution={currentSessionDetail.externalResolution}
-        feishuRegion={currentSessionDetail.feishuRegion}
+        key={headerFocusSessionId}
+        sessionId={headerFocusSessionId}
+        visibility={focusedSessionDetail?.visibility ?? focusedSession?.visibility}
+        state={focusedSessionDetail?.visibilityState}
+        canChange={focusedSessionDetail?.canChangeVisibility === true}
+        externalProvider={focusedSessionDetail?.externalProvider}
+        externalResolution={focusedSessionDetail?.externalResolution}
+        feishuRegion={focusedSessionDetail?.feishuRegion}
         // Native runtime memory has no per-session gate, so the copy must not
         // promise a memory boundary this tier cannot deliver.
-        nativeMemory={owner?.memoryProvider === 'native'}
+        nativeMemory={focusedAgent?.memoryProvider === 'native'}
         onChanged={({ visibility, state }) => {
           // Reflect the new tier locally, then re-read: the detail row also
           // carries the authoritative pending/applied state, and the lists must
           // drop (or regain) the row for other members.
-          void mutateSessionDetail(
+          const mutateFocusedDetail =
+            headerFocusSessionId === currentSessionDetail?.id ? mutateSessionDetail : mutateExtraHeaderDetail
+          void mutateFocusedDetail(
             (current) => (current ? { ...current, visibility, visibilityState: state } : current),
             { revalidate: true }
           )
@@ -2110,18 +2211,21 @@ export default function SessionDetailView() {
   const pgBusy = sessionBusy
   const pgImage = getPgImage(session.id)
   const pgQueue = getPgQueue(session.id)
-  const agentHref = session.agentId ? `/agents/${session.agentId}` : null
   const hasSessionWorktree =
-    owner?.workspace.mode === 'github' &&
-    currentSessionDetail?.workspaceIsolation === 'session' &&
-    !currentSessionDetail.contentPurgedAt
-  const workspaceHref = session.agentId
-    ? `/agents/${session.agentId}?tab=workspace${
-        hasSessionWorktree ? `&worktree=${encodeURIComponent(currentSessionDetail.id)}` : ''
-      }`
-    : null
-  const workspaceIcon = owner?.workspace.mode === 'github' ? 'git-branch' : 'folder'
-  const workspaceTitle = hasSessionWorktree ? 'Open this session’s worktree' : 'Open this agent’s workspace'
+    focusedAgent?.workspace.mode === 'github' &&
+    (focusedSessionDetail?.workspaceIsolation ?? focusedSession?.workspaceIsolation) === 'session' &&
+    !(focusedSessionDetail?.contentPurgedAt ?? focusedSession?.contentPurgedAt)
+  const workspaceHref =
+    focusedAgent && headerFocusAgentId
+      ? `/agents/${headerFocusAgentId}?tab=workspace${
+          hasSessionWorktree && headerFocusSessionId ? `&worktree=${encodeURIComponent(headerFocusSessionId)}` : ''
+        }`
+      : null
+  const workspaceIcon = focusedAgent?.workspace.mode === 'github' ? 'git-branch' : 'folder'
+  const focusedAgentLabel = focusedAgent ? agentLabel(focusedAgent) : (headerFocusOption?.label ?? 'agent')
+  const workspaceTitle = hasSessionWorktree
+    ? `Open ${focusedAgentLabel}’s session worktree`
+    : `Open ${focusedAgentLabel}’s workspace`
   const liveSteps = isWebchat ? getLiveSteps(session.id) : []
 
   // The conversation roster, for EVERY live surface — the synthetic playground and
@@ -2512,9 +2616,13 @@ export default function SessionDetailView() {
   const owningDaemonId = session.daemon && session.daemon !== '—' ? session.daemon : owner?.daemon
   const owningDaemon =
     owningDaemonId && owningDaemonId !== '—' ? daemons.find((d) => d.daemonId === owningDaemonId) : undefined
-  const daemonName =
-    owningDaemonId && owningDaemonId !== '—'
-      ? (owningDaemon?.name ?? (owningDaemonId.length > 12 ? owningDaemonId.slice(0, 8) : owningDaemonId))
+  const focusedDaemonId =
+    focusedSession?.daemon && focusedSession.daemon !== '—' ? focusedSession.daemon : focusedAgent?.daemon
+  const focusedDaemon =
+    focusedDaemonId && focusedDaemonId !== '—' ? daemons.find((d) => d.daemonId === focusedDaemonId) : undefined
+  const focusedDaemonName =
+    focusedDaemonId && focusedDaemonId !== '—'
+      ? (focusedDaemon?.name ?? (focusedDaemonId.length > 12 ? focusedDaemonId.slice(0, 8) : focusedDaemonId))
       : ''
   // A cron-triggered session carries `user === "cron:<scheduleId>"`. When that's the
   // shown participant, render the chip as a link back to the owning schedule
@@ -2557,26 +2665,41 @@ export default function SessionDetailView() {
   // instead of it, so a partial record is never read as the whole record.
   const transcriptPartiallyPurged = !isPg && purgedMemberCount > 0 && !transcriptPurged
   const prompts = pgPrompts(session.agentId ?? '')
-  const loadedTranscriptStats = wantTranscript && visibleMsgs !== null ? activityStatsFromTranscript(visibleMsgs) : null
-  const liveActivityStats = isPg ? activityStatsFromSteps(session.steps) : activityStatsFromSteps(liveSteps)
-  const durationFirst = minTime(loadedTranscriptStats?.firstMs, liveActivityStats.firstMs)
+  const focusedMessages =
+    conversationKey && headerFocusSessionId && visibleMsgs
+      ? visibleMsgs.filter(
+          (message) => conversationSourceSessionByMessageRef.current.get(message) === headerFocusSessionId
+        )
+      : visibleMsgs
+  const stepsForFocusedAgent = (steps: SessionStep[]) =>
+    headerFocusOptions.length <= 1
+      ? steps
+      : steps.filter((step) =>
+          step.agentId ? step.agentId === headerFocusAgentId : headerFocusAgentId === session.agentId
+        )
+  const focusedTranscriptStats =
+    wantTranscript && focusedMessages !== null ? activityStatsFromTranscript(focusedMessages) : null
+  const focusedLiveActivityStats = isPg
+    ? activityStatsFromSteps(stepsForFocusedAgent(session.steps))
+    : activityStatsFromSteps(stepsForFocusedAgent(liveSteps))
+  const durationFirst = minTime(focusedTranscriptStats?.firstMs, focusedLiveActivityStats.firstMs)
   const durationLast = maxTime(
-    loadedTranscriptStats?.lastMs,
-    liveActivityStats.lastMs,
-    pgBusy && durationFirst != null ? nowMs : null
+    focusedTranscriptStats?.lastMs,
+    focusedLiveActivityStats.lastMs,
+    pgBusy && headerFocusAgentId === session.agentId && durationFirst != null ? nowMs : null
   )
   const displayDuration =
     durationFirst != null && durationLast != null
       ? fmtTranscriptDuration(durationLast - durationFirst)
-      : session.duration
-  const displayToolCount = loadedTranscriptStats
-    ? fmtCountCompact(loadedTranscriptStats.toolCalls + liveActivityStats.toolCalls)
-    : liveActivityStats.toolCalls > 0 || isPg
-      ? fmtCountCompact(liveActivityStats.toolCalls)
-      : session.toolCount
+      : (focusedSession?.duration ?? '—')
+  const displayToolCount = focusedTranscriptStats
+    ? fmtCountCompact(focusedTranscriptStats.toolCalls + focusedLiveActivityStats.toolCalls)
+    : focusedLiveActivityStats.toolCalls > 0 || isPg
+      ? fmtCountCompact(focusedLiveActivityStats.toolCalls)
+      : (focusedSession?.toolCount ?? '—')
 
   // Token-usage breakdown for the detail card — only the fields the runtime reported.
-  const u = session.usage
+  const u = focusedSession?.usage
   const fmtN = (n?: number) => (n == null ? null : fmtCountCompact(n))
   const usageEntries: { label: string; value: string }[] = []
   if (u) {
@@ -2663,14 +2786,23 @@ export default function SessionDetailView() {
   // factors read this one list (see detailPanel below).
   const headerFacts: { icon: string; label: string; value: string }[] = [
     { icon: 'clock', label: 'Duration', value: displayDuration },
-    { icon: 'coins', label: 'Tokens', value: conversationUsage?.tokens ?? session.tokens },
-    { icon: 'circle-dollar-sign', label: 'Cost', value: conversationUsage?.cost ?? session.cost },
+    { icon: 'coins', label: 'Tokens', value: focusedSession?.tokens ?? '—' },
+    { icon: 'circle-dollar-sign', label: 'Cost', value: focusedSession?.cost ?? '—' },
     { icon: 'wrench', label: 'Tool calls', value: String(displayToolCount) }
   ]
-  if (daemonName) headerFacts.push({ icon: 'server', label: 'Daemon', value: daemonName })
-  if (session.runtime)
-    headerFacts.push({ icon: 'cpu', label: 'Runtime', value: runtimeLabel(session.runtime, runtimeMeta?.name) })
-  if (session.model) headerFacts.push({ icon: 'box', label: 'Model', value: modelLabel(session.model) })
+  if (focusedDaemonName) headerFacts.push({ icon: 'server', label: 'Daemon', value: focusedDaemonName })
+  if (focusedAgentRuntime)
+    headerFacts.push({
+      icon: 'cpu',
+      label: 'Runtime',
+      value: runtimeLabel(focusedAgentRuntime, focusedRuntimeMeta?.name)
+    })
+  if (focusedSession?.model ?? focusedAgent?.model)
+    headerFacts.push({
+      icon: 'box',
+      label: 'Model',
+      value: modelLabel(focusedSession?.model ?? focusedAgent?.model ?? '')
+    })
 
   // The popover's contents — one definition behind both triggers (desktop hover,
   // mobile tap), so a fact can never show up on one form factor and not the other.
@@ -2740,28 +2872,6 @@ export default function SessionDetailView() {
               {headerStatusLabel}
             </span>
           )}
-        </div>
-        {/* DESKTOP META ROW — agent · channel · participants · visibility · Details
-          popover · copy-link. The old stat/usage cards moved into the Details popover. */}
-        <div className="mt-0 mb-[10px] hidden items-center gap-2 border-b border-(--border-subtle) pb-[7px] desktop:flex">
-          {agentHref ? (
-            <Link
-              className="lnk min-w-0 flex-[0_1_auto] text-[12.5px] text-(--text-secondary)"
-              href={orgPath(agentHref)}
-            >
-              <span className="av h-[18px] w-[18px] flex-none rounded-[5px]">
-                <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={18} />
-              </span>
-              <span className="truncate">{session.agentName}</span>
-            </Link>
-          ) : (
-            <span className="lnk min-w-0 flex-[0_1_auto] cursor-default text-[12.5px] text-(--text-secondary)">
-              <span className="av h-[18px] w-[18px] flex-none rounded-[5px]">
-                <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={18} />
-              </span>
-              <span className="truncate">{session.agentName}</span>
-            </span>
-          )}
           <span className="inline-flex min-w-0 flex-[0_1_auto] items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
             <span className="imark h-5 w-5 flex-none rounded-xs">
               <PlatformMark platform={channelDisplay.platform} />
@@ -2780,6 +2890,15 @@ export default function SessionDetailView() {
               <span className="mono truncate text-[12px]">{channelDisplay.label}</span>
             )}
           </span>
+        </div>
+        {/* DESKTOP META ROW — focused agent · participants · workspace · visibility · Details
+          popover · copy-link. The old stat/usage cards moved into the Details popover. */}
+        <div className="mt-0 mb-[10px] hidden items-center gap-2 border-b border-(--border-subtle) pb-[7px] desktop:flex">
+          <SessionAgentFocusMenu
+            options={headerFocusOptions}
+            value={headerFocusAgentId}
+            onChange={(agentId) => setHeaderFocusSelection({ scope: headerFocusScope, agentId })}
+          />
           {headerCron ? (
             <Link
               className="lnk min-w-0 flex-[0_1_auto] font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)"
@@ -2800,7 +2919,6 @@ export default function SessionDetailView() {
               <span className="truncate">{participantsLabel}</span>
             </span>
           )}
-          {visibilityControl}
           {workspaceHref ? (
             <Link
               className="lnk flex-none text-[12.5px] text-(--text-secondary)"
@@ -2811,6 +2929,7 @@ export default function SessionDetailView() {
               Workspace
             </Link>
           ) : null}
+          {visibilityControl}
           {/* `flex` on the wrapper: an inline-flex button in a block div sits on a text
             baseline, and the descender gap under it pushed the button off the row's
             centre line. The transparent top padding bridges the trigger/panel gap so
@@ -2858,38 +2977,20 @@ export default function SessionDetailView() {
           </div>
         )}
 
-        {/* MOBILE HEADER ROW — the desktop meta row's shape at 390px: the owning
-          agent (tap-through), visibility, and everything numeric collapsed behind
+        {/* MOBILE HEADER ROW — the desktop meta row's shape at 390px: the focused
+          agent, workspace, visibility, and everything numeric collapsed behind
           the SAME Details popover. It replaces the old 4-up stat strip and the
           daemon/runtime/model config line, both of which now live in the popover;
           three stacked bands of chrome above the transcript were the phone's whole
           first screen. Tap toggles (`tapped`) — there is no hover to lean on. */}
         <div className="relative flex items-center gap-2 border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[9px] desktop:hidden">
-          {agentHref ? (
-            <Link
-              href={orgPath(agentHref)}
-              className="flex min-w-0 flex-1 items-center gap-[7px] no-underline"
-              aria-label={`Open ${session.agentName}`}
-            >
-              <span className="av h-[22px] w-[22px] flex-none rounded-md">
-                <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={22} />
-              </span>
-              <span className="truncate font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                {session.agentName}
-              </span>
-              <Icon name="chevron-right" size={14} color="var(--text-tertiary)" className="flex-none" />
-            </Link>
-          ) : (
-            <span className="flex min-w-0 flex-1 items-center gap-[7px]">
-              <span className="av h-[22px] w-[22px] flex-none rounded-md">
-                <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={22} />
-              </span>
-              <span className="truncate font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                {session.agentName}
-              </span>
-            </span>
-          )}
-          {visibilityControl}
+          <span className="flex min-w-0 flex-1">
+            <SessionAgentFocusMenu
+              options={headerFocusOptions}
+              value={headerFocusAgentId}
+              onChange={(agentId) => setHeaderFocusSelection({ scope: headerFocusScope, agentId })}
+            />
+          </span>
           {workspaceHref ? (
             <Link
               href={orgPath(workspaceHref)}
@@ -2900,6 +3001,7 @@ export default function SessionDetailView() {
               <Icon name={workspaceIcon} size={14} />
             </Link>
           ) : null}
+          {visibilityControl}
           <button
             type="button"
             onClick={toggleDetailTap}


### PR DESCRIPTION
## Summary
- move the integration and channel beside session status, with an agent focus dropdown
- make Workspace, Visibility, and Details follow the focused participant's own session metadata
- unify Private, Everyone, Slack members, and GitHub members visibility controls and tooltip copy

## Validation
- pnpm --filter @agentconnect.md/web test
- pnpm --filter @agentconnect.md/web build
- pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json
- pnpm exec eslint on the changed session components
- desktop and mobile visual verification

Created by Codex . GPT-5