### PR TITLE
feat: session retention accepts any '<n>d' day count (default 7d)

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -17,6 +17,7 @@ import {
   MemoryPluginHistoryEvent,
   MemoryPluginOperation,
   RESERVED_MCP_SERVER_NAME,
+  SESSION_RETENTION_RE,
   GitCloneUrlError,
   RepoSubdirError,
   SessionImageAttachment,
@@ -205,8 +206,9 @@ export const DaemonViewDto = z.object({
   lastModifiedBy: z.string().nullable(), // editor's userId (web resolves to a name / "You"); null for system rows
   /** Console-set finished-session retention window on the daemon's local store
    *  ("Expire sessions"): how long finished sessions are kept before the daemon's
-   *  retention sweep deletes them; 'never' disables the sweep. */
-  sessionRetention: z.enum(['never', '7d', '30d', '90d']),
+   *  retention sweep deletes them — 'never' disables the sweep, otherwise an
+   *  integer day count as '<n>d' (e.g. '7d'). */
+  sessionRetention: z.string().regex(SESSION_RETENTION_RE),
   // ── visibility / sharing (docs/designs/resource-visibility.md) ──
   visibility: ResourceVisibilityEnum,
   sharedWith: z.array(z.string()), // complete app_user.id audience when restricted
@@ -224,8 +226,9 @@ export const UpdateDaemonBody = z
   .object({
     name: z.string().trim().min(1).max(64).optional(),
     /** How long the daemon keeps FINISHED sessions in its local store before its
-     *  retention sweep deletes them; 'never' disables the sweep. */
-    sessionRetention: z.enum(['never', '7d', '30d', '90d']).optional()
+     *  retention sweep deletes them — 'never' disables the sweep, otherwise an
+     *  integer day count as '<n>d' (e.g. '7d'). */
+    sessionRetention: z.string().regex(SESSION_RETENTION_RE).optional()
   })
   .refine((b) => b.name !== undefined || b.sessionRetention !== undefined, {
     message: 'nothing to update'

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -12,6 +12,7 @@
  */
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import { z } from 'zod'
+import { SESSION_RETENTION_RE } from '@agentconnect.md/protocol'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import type { DaemonView, DaemonLiveness, DaemonRegistry } from '../../ports.js'
@@ -111,9 +112,6 @@ function liveStatus(view: DaemonView, liveness: DaemonLiveness, graceMs: number,
   return 'connecting' // CONNECTING / AUTHENTICATING / REGISTERING
 }
 
-// The DTO's accepted retention values — mirrors UpdateDaemonBody.sessionRetention.
-const SESSION_RETENTIONS = new Set(['never', '7d', '30d', '90d'])
-
 function toDto(
   view: DaemonView,
   liveness: DaemonLiveness,
@@ -163,12 +161,10 @@ function toDto(
     lastModifiedAt: view.lastModifiedAt.toISOString(),
     lastModifiedBy:
       view.lastModifiedBy && !isSyntheticEmail(view.lastModifiedBy.email) ? view.lastModifiedBy.userId : null,
-    // Defensive read-time normalization: the PATCH route only writes enum values,
-    // so a fallback here just keeps an unexpected stored value from failing the
-    // whole response's schema serialization.
-    sessionRetention: SESSION_RETENTIONS.has(view.sessionRetention)
-      ? (view.sessionRetention as DaemonViewDtoT['sessionRetention'])
-      : '7d',
+    // Defensive read-time normalization: the PATCH route only writes validated
+    // values, so a fallback here just keeps an unexpected stored value from
+    // failing the whole response's schema serialization.
+    sessionRetention: SESSION_RETENTION_RE.test(view.sessionRetention) ? view.sessionRetention : '7d',
     visibility: view.visibility,
     sharedWith: view.sharedWith,
     canEdit: canEdit(view, ctx),

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -460,7 +460,7 @@ describe('PATCH /daemons/:id — rename', () => {
     expect((res.json() as { sessionRetention: string }).sessionRetention).toBe('never')
   })
 
-  it('400s an unknown retention window', async () => {
+  it("accepts any '<n>d' day count as a retention window", async () => {
     await seedDaemon()
     running = buildHttpApp(prisma)
     const res = await running.app.inject({
@@ -468,7 +468,21 @@ describe('PATCH /daemons/:id — rename', () => {
       url: `${ORG}/daemons/${DAEMON}`,
       payload: { sessionRetention: '3d' }
     })
-    expect(res.statusCode).toBe(400)
+    expect(res.statusCode).toBe(200)
+    expect((res.json() as { sessionRetention: string }).sessionRetention).toBe('3d')
+  })
+
+  it('400s a malformed retention window', async () => {
+    await seedDaemon()
+    running = buildHttpApp(prisma)
+    for (const bad of ['0d', '7', '2weeks', 'always']) {
+      const res = await running.app.inject({
+        method: 'PATCH',
+        url: `${ORG}/daemons/${DAEMON}`,
+        payload: { sessionRetention: bad }
+      })
+      expect(res.statusCode, bad).toBe(400)
+    }
   })
 })
 

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -2,7 +2,9 @@ import { z } from 'zod'
 import {
   DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
   normalizeWorkspaceGitOrigin,
-  RelayRosterEntry
+  RelayRosterEntry,
+  SESSION_RETENTION_RE,
+  type SessionRetentionSetting
 } from '@agentconnect.md/protocol'
 
 /** The `{name, value}[]` shape shared by runtime env, MCP env, and MCP headers. */
@@ -179,10 +181,17 @@ export const ConfigSchema = z.object({
       // store, together with its per-session Git worktree. A worktree holding
       // dirty/untracked files or commits unreachable from any remote ref is never
       // auto-deleted — the sweep reports it and keeps the session instead.
-      // 'never' disables the sweep entirely.
-      // '30d'/'90d' are the console-facing windows (CP-set via register/ok +
-      // config/push); '2weeks'/'1month' are kept for existing local config files.
-      retention: z.enum(['never', '7d', '2weeks', '1month', '30d', '90d']).default('7d')
+      // 'never' disables the sweep; any '<n>d' day count is accepted (CP-set via
+      // register/ok + config/push). Legacy '2weeks'/'1month' from existing local
+      // config files normalize to their day equivalents.
+      retention: z
+        .union([
+          z.custom<SessionRetentionSetting>((v) => typeof v === 'string' && SESSION_RETENTION_RE.test(v), {
+            message: "expected 'never' or '<days>d' (e.g. '7d')"
+          }),
+          z.enum(['2weeks', '1month']).transform((v): SessionRetentionSetting => (v === '2weeks' ? '14d' : '30d'))
+        ])
+        .default('7d')
     })
     .default({ retention: '7d' }),
   limits: z
@@ -255,20 +264,12 @@ export type Config = z.infer<typeof ConfigSchema>
 
 export type SessionRetention = Config['sessions']['retention']
 
-/** Retention keyword → sweep window in ms ('1month' = 30 days); null ⇒ retention
+/** Retention setting → sweep window in ms ('<n>d' = n days); null ⇒ retention
  * is disabled and the sweep never deletes anything. */
 export function sessionRetentionMs(retention: SessionRetention): number | null {
-  switch (retention) {
-    case 'never':
-      return null
-    case '7d':
-      return 7 * 24 * 3_600_000
-    case '2weeks':
-      return 14 * 24 * 3_600_000
-    case '1month':
-    case '30d':
-      return 30 * 24 * 3_600_000
-    case '90d':
-      return 90 * 24 * 3_600_000
-  }
+  if (retention === 'never') return null
+  const days = Number.parseInt(retention, 10)
+  // Schema-validated 'Nd' always parses; a malformed value fails open to 'never'
+  // (keep sessions) rather than sweeping with a NaN window.
+  return Number.isFinite(days) && days > 0 ? days * 24 * 3_600_000 : null
 }

--- a/packages/daemon/src/cp/config-apply.ts
+++ b/packages/daemon/src/cp/config-apply.ts
@@ -35,6 +35,7 @@ import type {
   AgentPermissionDecision,
   SessionVisibilityPush
 } from '@agentconnect.md/protocol'
+import { SESSION_RETENTION_RE } from '@agentconnect.md/protocol'
 import type { Config } from '../config/config-schema.js'
 
 export interface ConfigApply {
@@ -111,7 +112,6 @@ export interface ConfigApply {
 }
 
 const LOG_LEVELS = new Set(['trace', 'debug', 'info', 'warn', 'error'])
-const SESSION_RETENTIONS = new Set(['never', '7d', '2weeks', '1month', '30d', '90d'])
 
 /**
  * Merge a `config/push` payload into the running config — whitelist only, no
@@ -149,7 +149,7 @@ export function mergeConfigPush(cfg: Config, keys: Record<string, unknown>): { a
         }
         break
       case 'sessions.retention':
-        if (typeof value === 'string' && SESSION_RETENTIONS.has(value)) {
+        if (typeof value === 'string' && SESSION_RETENTION_RE.test(value)) {
           cfg.sessions.retention = value as Config['sessions']['retention']
           ok = true
         }

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -30,20 +30,26 @@ describe('loadConfig', () => {
     expect(cfg.sessions.retention).toBe('7d') // #485 session retention defaults on
   })
 
-  it('session retention accepts the full keyword set and maps to sweep windows', () => {
+  it("session retention accepts 'never' or any '<n>d' and maps to sweep windows", () => {
     expect(loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: 'never' } }) }).sessions.retention).toBe(
       'never'
     )
-    expect(loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '1month' } }) }).sessions.retention).toBe(
-      '1month'
-    )
-    expect(() => loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '3d' } }) })).toThrow()
+    // Any positive integer day count is a valid window.
+    expect(loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '3d' } }) }).sessions.retention).toBe('3d')
     expect(loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '90d' } }) }).sessions.retention).toBe('90d')
+    // Legacy keywords from existing local config files normalize to day counts.
+    expect(loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '2weeks' } }) }).sessions.retention).toBe(
+      '14d'
+    )
+    expect(loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '1month' } }) }).sessions.retention).toBe(
+      '30d'
+    )
+    // Zero / non-day shapes are rejected.
+    expect(() => loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '0d' } }) })).toThrow()
+    expect(() => loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '7' } }) })).toThrow()
     expect(sessionRetentionMs('never')).toBeNull()
     expect(sessionRetentionMs('7d')).toBe(7 * 24 * 3_600_000)
-    expect(sessionRetentionMs('2weeks')).toBe(14 * 24 * 3_600_000)
-    expect(sessionRetentionMs('1month')).toBe(30 * 24 * 3_600_000)
-    // The console-facing windows (CP-set via register/ok + config/push).
+    expect(sessionRetentionMs('3d')).toBe(3 * 24 * 3_600_000)
     expect(sessionRetentionMs('30d')).toBe(30 * 24 * 3_600_000)
     expect(sessionRetentionMs('90d')).toBe(90 * 24 * 3_600_000)
   })

--- a/packages/daemon/test/cp/config-merge.test.ts
+++ b/packages/daemon/test/cp/config-merge.test.ts
@@ -29,8 +29,12 @@ describe('mergeConfigPush', () => {
     expect(cfg.sessions.retention).toBe('90d')
     expect(r.applied).toEqual(['sessions.retention'])
 
-    const bad = mergeConfigPush(cfg, { 'sessions.retention': '3d' })
-    expect(cfg.sessions.retention).toBe('90d') // unchanged — not a known window
+    const custom = mergeConfigPush(cfg, { 'sessions.retention': '3d' })
+    expect(cfg.sessions.retention).toBe('3d') // any '<n>d' day count is a valid window
+    expect(custom.applied).toEqual(['sessions.retention'])
+
+    const bad = mergeConfigPush(cfg, { 'sessions.retention': '0d' })
+    expect(cfg.sessions.retention).toBe('3d') // unchanged — not a valid window
     expect(bad.applied).toEqual([])
     expect(bad.ignored).toEqual(['sessions.retention'])
   })

--- a/packages/protocol/src/frames/register.ts
+++ b/packages/protocol/src/frames/register.ts
@@ -92,9 +92,17 @@ export type RelayRosterUpdate = z.infer<typeof RelayRosterUpdate>
  * store (the daemon settings' "Expire sessions" option). CP-durable; the
  * register/ok snapshot is the reconnect baseline and a `config/push` with
  * `sessions.retention` is the hot update.
+ *
+ * `'never'` disables the sweep; otherwise an integer number of days as
+ * `'<n>d'` (e.g. `'7d'`) — n ≥ 1, capped at 4 digits so a typo can't encode
+ * a multi-millennium window.
  */
-export const SessionRetentionSetting = z.enum(['never', '7d', '30d', '90d'])
-export type SessionRetentionSetting = z.infer<typeof SessionRetentionSetting>
+export const SESSION_RETENTION_RE = /^(?:never|[1-9]\d{0,3}d)$/
+export type SessionRetentionSetting = 'never' | `${number}d`
+export const SessionRetentionSetting = z.custom<SessionRetentionSetting>(
+  (v) => typeof v === 'string' && SESSION_RETENTION_RE.test(v),
+  { message: "expected 'never' or '<days>d' (e.g. '7d')" }
+)
 
 export const RegisterOk = z.object({
   routingEpoch: z.number().int(), // version of the routing table this snapshot reflects

--- a/packages/web/src/components/console/SessionRetentionField.test.tsx
+++ b/packages/web/src/components/console/SessionRetentionField.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { SessionRetentionField, parseCustomDays } from './SessionRetentionField'
+
+describe('parseCustomDays', () => {
+  it('accepts only a complete integer day count', () => {
+    expect(parseCustomDays('1')).toBe(1)
+    expect(parseCustomDays('3')).toBe(3)
+    expect(parseCustomDays('45')).toBe(45)
+    expect(parseCustomDays('9999')).toBe(9999)
+    expect(parseCustomDays(' 14 ')).toBe(14) // number-input text is trimmed
+  })
+
+  it("rejects prefix-parsable text that parseInt would coerce ('1.5' → 1, '1e2' → 1)", () => {
+    // A prefix parse would silently save a window the operator didn't type.
+    expect(parseCustomDays('1.5')).toBeNull()
+    expect(parseCustomDays('1e2')).toBeNull()
+    expect(parseCustomDays('7d')).toBeNull()
+  })
+
+  it('rejects zero, negatives, and counts past the protocol cap', () => {
+    expect(parseCustomDays('0')).toBeNull()
+    expect(parseCustomDays('-3')).toBeNull()
+    expect(parseCustomDays('10000')).toBeNull() // shared SESSION_RETENTION_RE caps at 4 digits
+    expect(parseCustomDays('')).toBeNull()
+    expect(parseCustomDays('07')).toBeNull() // no leading zeros — mirrors the wire regex
+  })
+})
+
+describe('SessionRetentionField', () => {
+  it('renders presets and marks the 7d default', () => {
+    const html = renderToStaticMarkup(<SessionRetentionField value="7d" onChange={() => undefined} />)
+    expect(html).toContain('After 7 days')
+    expect(html).toContain('· default')
+    expect(html).toContain('Custom…')
+    // Preset value ⇒ the custom day input stays hidden.
+    expect(html).not.toContain('aria-label="Expire sessions after (days)"')
+  })
+
+  it('shows the bounded day input for a custom value', () => {
+    const html = renderToStaticMarkup(<SessionRetentionField value="45d" onChange={() => undefined} />)
+    expect(html).toContain('After 45 days')
+    const input = html.match(/<input[^>]*aria-label="Expire sessions after \(days\)"[^>]*>/)?.[0] ?? ''
+    expect(input).toContain('type="number"')
+    expect(input).toContain('min="1"')
+    expect(input).toContain('max="9999"') // client-side mirror of the protocol cap
+    expect(input).toContain('value="45"')
+  })
+
+  it("renders 'Never' without the day input", () => {
+    const html = renderToStaticMarkup(<SessionRetentionField value="never" onChange={() => undefined} />)
+    expect(html).toContain('Never')
+    expect(html).not.toContain('aria-label="Expire sessions after (days)"')
+  })
+})

--- a/packages/web/src/components/console/SessionRetentionField.tsx
+++ b/packages/web/src/components/console/SessionRetentionField.tsx
@@ -27,6 +27,21 @@ const PRESETS: { value: DaemonSessionRetention; label: string }[] = [
 // Sentinel for the overlaid native <select>; never leaves this component.
 const CUSTOM = '__custom'
 
+// Full-string day count, same 1–9999 bound as the protocol's SESSION_RETENTION_RE.
+const DAY_COUNT_RE = /^[1-9]\d{0,3}$/
+
+/**
+ * Parse the custom day input. The COMPLETE text must be an integer day count
+ * (1–9999): a prefix parse would silently save a window the operator didn't
+ * type ('1.5' → 1, '1e2' → 1), and anything past the protocol cap would only
+ * fail server-side with a generic 400 — this setting deletes sessions and
+ * workspaces, so an invalid entry must never coerce into a different value.
+ */
+export function parseCustomDays(text: string): number | null {
+  const trimmed = text.trim()
+  return DAY_COUNT_RE.test(trimmed) ? Number.parseInt(trimmed, 10) : null
+}
+
 function retentionDays(value: DaemonSessionRetention): number | null {
   if (value === 'never') return null
   const days = Number.parseInt(value, 10)
@@ -48,9 +63,15 @@ export function SessionRetentionField({
   const [custom, setCustom] = useState(() => !isPreset)
   const [customText, setCustomText] = useState(() => (isPreset ? '' : String(retentionDays(value) ?? '')))
   const showCustom = custom || !isPreset
+  const customInvalid = showCustom && parseCustomDays(customText) === null
 
+  // While the typed text is invalid the parent still holds the last valid
+  // value — show '…' rather than that stale window so the row never claims a
+  // setting the operator didn't enter.
   const label = showCustom
-    ? `After ${retentionDays(value) ?? '…'} day${retentionDays(value) === 1 ? '' : 's'}`
+    ? customInvalid
+      ? 'After … days'
+      : `After ${retentionDays(value)} day${retentionDays(value) === 1 ? '' : 's'}`
     : (PRESETS.find((o) => o.value === value)?.label ?? value)
 
   const selectPreset = (next: string) => {
@@ -66,10 +87,10 @@ export function SessionRetentionField({
 
   const typeDays = (text: string) => {
     setCustomText(text)
-    const days = Number.parseInt(text, 10)
-    // Only propagate a valid count; the parent keeps the last valid value while
-    // the field is mid-edit (empty / zero).
-    if (Number.isFinite(days) && days > 0) onChange(`${Math.floor(days)}d`)
+    // Only propagate a complete valid count; invalid text surfaces inline below
+    // and the parent keeps the last valid value.
+    const days = parseCustomDays(text)
+    if (days !== null) onChange(`${days}d`)
   }
 
   return (
@@ -100,20 +121,31 @@ export function SessionRetentionField({
         </select>
       </div>
       {showCustom && (
-        <div className={`inp mt-[6px] ${disabled ? 'opacity-60' : ''}`}>
-          <input
-            type="number"
-            min={1}
-            step={1}
-            value={customText}
-            disabled={disabled}
-            onChange={(e) => typeDays(e.target.value)}
-            className="w-full bg-transparent font-sans text-[13px] text-(--text-primary) outline-none"
-            aria-label="Expire sessions after (days)"
-            placeholder="Days"
-          />
-          <span className="ml-auto shrink-0 font-sans text-[12px] text-(--text-tertiary)">days</span>
-        </div>
+        <>
+          <div
+            className={`inp mt-[6px] ${disabled ? 'opacity-60' : ''} ${customInvalid ? 'border-(--status-error)' : ''}`}
+          >
+            <input
+              type="number"
+              min={1}
+              max={9999}
+              step={1}
+              value={customText}
+              disabled={disabled}
+              onChange={(e) => typeDays(e.target.value)}
+              className="w-full bg-transparent font-sans text-[13px] text-(--text-primary) outline-none"
+              aria-label="Expire sessions after (days)"
+              aria-invalid={customInvalid || undefined}
+              placeholder="Days"
+            />
+            <span className="ml-auto shrink-0 font-sans text-[12px] text-(--text-tertiary)">days</span>
+          </div>
+          {customInvalid && (
+            <span className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--status-error)">
+              Enter a whole number of days (1–9999).
+            </span>
+          )}
+        </>
       )}
       <span className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
         Finished sessions older than this are deleted from the daemon, including their workspaces.

--- a/packages/web/src/components/console/SessionRetentionField.tsx
+++ b/packages/web/src/components/console/SessionRetentionField.tsx
@@ -6,20 +6,32 @@
  * The daemon's "Expire sessions" picker (Add/Edit daemon modals): how long the
  * daemon keeps FINISHED sessions in its local store before its retention sweep
  * deletes them (session row + per-session Git worktree). 'never' disables the
- * sweep. Rendered as the standard `.inp` field with an invisible overlaid
- * native <select> (same pattern as the lifecycle modal's version picker).
+ * sweep; any other value is an integer day count ('<n>d') — the picker offers
+ * the common windows plus a custom day input. Rendered as the standard `.inp`
+ * field with an invisible overlaid native <select> (same pattern as the
+ * lifecycle modal's version picker).
  */
+import { useState } from 'react'
 import { Icon } from '@/components/ui'
 import type { DaemonSessionRetention } from '@/lib/api'
 
 export const SESSION_RETENTION_DEFAULT: DaemonSessionRetention = '7d'
 
-const OPTIONS: { value: DaemonSessionRetention; label: string }[] = [
+const PRESETS: { value: DaemonSessionRetention; label: string }[] = [
   { value: '7d', label: 'After 7 days' },
   { value: '30d', label: 'After 30 days' },
   { value: '90d', label: 'After 90 days' },
   { value: 'never', label: 'Never' }
 ]
+
+// Sentinel for the overlaid native <select>; never leaves this component.
+const CUSTOM = '__custom'
+
+function retentionDays(value: DaemonSessionRetention): number | null {
+  if (value === 'never') return null
+  const days = Number.parseInt(value, 10)
+  return Number.isFinite(days) && days > 0 ? days : null
+}
 
 export function SessionRetentionField({
   value,
@@ -30,31 +42,79 @@ export function SessionRetentionField({
   onChange: (value: DaemonSessionRetention) => void
   disabled?: boolean
 }) {
-  const label = OPTIONS.find((o) => o.value === value)?.label ?? value
+  const isPreset = PRESETS.some((o) => o.value === value)
+  // Sticky custom mode: once the operator picks "Custom…" the day input stays
+  // visible even while the typed count momentarily equals a preset (7 → 70).
+  const [custom, setCustom] = useState(() => !isPreset)
+  const [customText, setCustomText] = useState(() => (isPreset ? '' : String(retentionDays(value) ?? '')))
+  const showCustom = custom || !isPreset
+
+  const label = showCustom
+    ? `After ${retentionDays(value) ?? '…'} day${retentionDays(value) === 1 ? '' : 's'}`
+    : (PRESETS.find((o) => o.value === value)?.label ?? value)
+
+  const selectPreset = (next: string) => {
+    if (next === CUSTOM) {
+      setCustom(true)
+      setCustomText(String(retentionDays(value) ?? 14))
+      if (retentionDays(value) === null) onChange('14d')
+      return
+    }
+    setCustom(false)
+    onChange(next as DaemonSessionRetention)
+  }
+
+  const typeDays = (text: string) => {
+    setCustomText(text)
+    const days = Number.parseInt(text, 10)
+    // Only propagate a valid count; the parent keeps the last valid value while
+    // the field is mid-edit (empty / zero).
+    if (Number.isFinite(days) && days > 0) onChange(`${Math.floor(days)}d`)
+  }
+
   return (
     <div className="fld mt-[14px]">
       <span className="fldlbl">Expire sessions</span>
       <div className={`inp relative ${disabled ? 'opacity-60' : ''}`}>
         <span className="truncate font-sans text-[13px] text-(--text-primary)">
           {label}
-          {value === SESSION_RETENTION_DEFAULT && <span className="text-(--text-tertiary)"> · default</span>}
+          {!showCustom && value === SESSION_RETENTION_DEFAULT && (
+            <span className="text-(--text-tertiary)"> · default</span>
+          )}
         </span>
         <Icon name="chevron-down" size={15} color="var(--text-tertiary)" className="ml-auto" />
         <select
-          value={value}
+          value={showCustom ? CUSTOM : value}
           disabled={disabled}
-          onChange={(e) => onChange(e.target.value as DaemonSessionRetention)}
+          onChange={(e) => selectPreset(e.target.value)}
           className="absolute inset-0 cursor-pointer opacity-0 disabled:cursor-default"
           aria-label="Expire sessions"
         >
-          {OPTIONS.map((o) => (
+          {PRESETS.map((o) => (
             <option key={o.value} value={o.value}>
               {o.label}
               {o.value === SESSION_RETENTION_DEFAULT ? ' (default)' : ''}
             </option>
           ))}
+          <option value={CUSTOM}>Custom…</option>
         </select>
       </div>
+      {showCustom && (
+        <div className={`inp mt-[6px] ${disabled ? 'opacity-60' : ''}`}>
+          <input
+            type="number"
+            min={1}
+            step={1}
+            value={customText}
+            disabled={disabled}
+            onChange={(e) => typeDays(e.target.value)}
+            className="w-full bg-transparent font-sans text-[13px] text-(--text-primary) outline-none"
+            aria-label="Expire sessions after (days)"
+            placeholder="Days"
+          />
+          <span className="ml-auto shrink-0 font-sans text-[12px] text-(--text-tertiary)">days</span>
+        </div>
+      )}
       <span className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
         Finished sessions older than this are deleted from the daemon, including their workspaces.
       </span>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1000,8 +1000,9 @@ export interface DaemonViewDto {
   canManageLifecycle: boolean
 }
 
-/** The console-settable "Expire sessions" windows (PATCH /daemons/:id). */
-export type DaemonSessionRetention = 'never' | '7d' | '30d' | '90d'
+/** The console-settable "Expire sessions" window (PATCH /daemons/:id):
+ *  'never' disables the sweep, otherwise an integer day count as '<n>d'. */
+export type DaemonSessionRetention = 'never' | `${number}d`
 
 /** A CP-commanded daemon restart/upgrade (cli-daemon-split.md §7). Returned by the
  *  upgrade/restart POSTs and embedded in each daemon's read model as its latest op. */


### PR DESCRIPTION
## What

The console-set **"Expire sessions"** window (`sessionRetention`) was a fixed enum (`never | 7d | 30d | 90d`). It now accepts `never` **or any positive integer day count** as `'<n>d'` (1–9999), default unchanged at `7d`.

## How

- **protocol** — `SessionRetentionSetting` becomes `'never' | \`${number}d\`` validated by a shared `SESSION_RETENTION_RE`; every wire consumer (`register/ok` baseline, `config/push` hot update) picks it up from the one definition.
- **daemon** — `sessions.retention` in `config.json` accepts the new shape; legacy `'2weeks'`/`'1month'` in existing local config files normalize to `'14d'`/`'30d'` at parse time. `sessionRetentionMs` parses the day count; a malformed value fails open to `never` (keep sessions) rather than sweeping with a NaN window. The `config/push` whitelist validates with the same regex.
- **control plane** — `PATCH /daemons/:id` body + `DaemonViewDto` validate by pattern (OpenAPI carries it); the defensive read-time normalization in `toDto` keeps its `7d` fallback. No migration — the Prisma column default stays `"7d"`.
- **web** — the "Expire sessions" picker keeps the 7/30/90/Never presets and adds a **Custom…** option revealing a day-count input (≥1 integer; picking Custom seeds `14d` so there is never a valueless intermediate state).

Note: the CP API intentionally does **not** accept the legacy `'2weeks'`/`'1month'` keywords — only the daemon's local config parser normalizes them, for existing files.

## Testing

- `pnpm typecheck` green in protocol / daemon / control-plane / web
- daemon: `test/config.test.ts` + `test/cp/config-merge.test.ts` updated for the new semantics (`3d` valid; `0d`/`7` rejected; legacy keywords normalize) — 26 pass
- control plane: full `test:unit` (1154) and full `test:int` (956, Testcontainers) pass, including the updated `daemons.route` cases (`3d` → 200, `0d`/`7`/`2weeks`/`always` → 400)
- protocol (278) and web (757) suites pass; changed files lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)