### PR TITLE
fix(web): compact worktree menu rows

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -816,8 +816,12 @@ the main checkout's live branch, never a generic "Primary checkout" label. With 
 session worktree it is a static branch label with no menu; otherwise it switches
 between that branch and the available worktrees. Worktree choices keep their
 Session link so changing the viewed files and opening the originating conversation
-remain distinct actions. The Source card remains directly above the browser and
-names only the repository or scratch workspace; it does not repeat the branch.
+remain distinct actions. Menu choices match the closed control's compact height,
+while the menu itself may extend wider to keep titles legible. Their session time
+stays out of the row and appears in its tooltip instead. Session links use their
+message icon and label without a redundant external-link arrow. The Source card
+remains directly above the browser and names only the repository or scratch
+workspace; it does not repeat the branch.
 
 Workspace changes are cold edits: active work is drained and existing cached
 credentials are cleared before the new definition becomes active. Any edit that removes

--- a/packages/web/src/components/console/WorkspaceScopePicker.test.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.test.tsx
@@ -88,6 +88,9 @@ describe('WorkspaceScopePicker', () => {
     const trigger = container.querySelector<HTMLButtonElement>('[aria-label^="Workspace checkout:"]')!
     expect(trigger.textContent).toContain('PR #576')
     expect(trigger.textContent).toContain('fix(auth): make selected visibility explicit')
+    expect(trigger.querySelector('[title]')?.getAttribute('title')).toBe(
+      'PR #576: fix(auth): make selected visibility explicit · 3:09 PM'
+    )
     expect(container.querySelector('a')?.getAttribute('href')).toBe('/agentconnect/sessions/session-576')
 
     await act(async () => trigger.click())
@@ -97,12 +100,13 @@ describe('WorkspaceScopePicker', () => {
     expect(menu.textContent).not.toContain('Primary checkout')
     expect(menu.textContent).toContain('Worktrees·2')
     expect(menu.textContent).toContain('PR #568')
-    expect(menu.textContent).toContain('3:10 PM')
+    expect(menu.textContent).not.toContain('3:10 PM')
     expect(menu.textContent).toContain('Showing 2 recent worktrees')
 
     const other = Array.from(menu.querySelectorAll<HTMLButtonElement>('[data-workspace-choice]')).find((choice) =>
       choice.textContent?.includes('PR #568')
     )!
+    expect(other.title).toBe('PR #568: bind the conversation audience · 3:10 PM')
     await act(async () => other.click())
     expect(onChange).toHaveBeenCalledWith('session-568')
     expect(container.querySelector('[role="menu"]')).toBeNull()

--- a/packages/web/src/components/console/WorkspaceScopePicker.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.tsx
@@ -28,6 +28,10 @@ export function worktreeIdentity(
   }
 }
 
+function worktreeTooltip(identity: WorktreeIdentity, time: string | undefined): string {
+  return time && time !== '—' ? `${identity.fullTitle} · ${time}` : identity.fullTitle
+}
+
 export function WorkspaceScopePicker({
   primaryBranch,
   sessions,
@@ -125,7 +129,7 @@ export function WorkspaceScopePicker({
     <div className={`relative w-full min-w-0 ${open ? 'z-30' : ''}`}>
       <div className="relative min-w-0">
         <div
-          className={`flex h-8 min-w-0 items-center overflow-hidden rounded-md border bg-(--surface-card) ${
+          className={`flex h-7 min-w-0 items-center overflow-hidden rounded-md border bg-(--surface-card) ${
             !canChooseCheckout
               ? 'border-(--border-subtle)'
               : open
@@ -145,17 +149,20 @@ export function WorkspaceScopePicker({
               onClick={() => setOpen((current) => !current)}
               onKeyDown={openFromKeyboard}
             >
-              <Icon name="git-branch" size={14} className="flex-none text-(--text-tertiary)" />
+              <Icon name="git-branch" size={13} className="flex-none text-(--text-tertiary)" />
               {selectedIdentity ? (
-                <span className="flex min-w-0 flex-1 items-baseline gap-2" title={selectedIdentity.fullTitle}>
+                <span
+                  className="flex min-w-0 flex-1 items-baseline gap-1.5"
+                  title={worktreeTooltip(selectedIdentity, selectedWorktree?.time)}
+                >
                   {selectedIdentity.context ? (
-                    <span className="flex-none font-sans text-[12.5px] font-semibold leading-normal">
+                    <span className="flex-none font-sans text-[12px] font-semibold leading-normal">
                       {selectedIdentity.context}
                     </span>
                   ) : null}
                   {selectedIdentity.title ? (
                     <span
-                      className={`truncate font-sans text-[12.5px] leading-normal ${
+                      className={`truncate font-sans text-[12px] leading-normal ${
                         selectedIdentity.context
                           ? 'font-normal text-(--text-secondary)'
                           : 'font-medium text-(--text-primary)'
@@ -166,37 +173,34 @@ export function WorkspaceScopePicker({
                   ) : null}
                 </span>
               ) : (
-                <span className="truncate font-sans text-[12.5px] font-semibold leading-normal">
+                <span className="truncate font-sans text-[12px] font-semibold leading-normal">
                   {primaryBranchLabel}
                 </span>
               )}
             </button>
           ) : (
             <div className="flex h-full min-w-0 flex-1 items-center gap-2 px-2 text-(--text-primary)">
-              <Icon name="git-branch" size={14} className="flex-none text-(--text-tertiary)" />
-              <span className="truncate font-sans text-[12.5px] font-semibold leading-normal">
-                {primaryBranchLabel}
-              </span>
+              <Icon name="git-branch" size={13} className="flex-none text-(--text-tertiary)" />
+              <span className="truncate font-sans text-[12px] font-semibold leading-normal">{primaryBranchLabel}</span>
             </div>
           )}
 
           {selectedSessionId ? (
             <Link
               href={sessionHref(selectedSessionId)}
-              className="mx-1 inline-flex h-6 flex-none items-center gap-[5px] rounded-sm border border-(--border-default) bg-(--surface-card) px-[7px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) no-underline hover:border-(--border-strong) hover:bg-(--surface-hover) hover:text-(--text-primary)"
+              className="mx-1 inline-flex h-5 flex-none items-center gap-1 rounded-sm border border-(--border-default) bg-(--surface-card) px-1.5 font-sans text-[11px] font-medium leading-normal text-(--text-secondary) no-underline hover:border-(--border-strong) hover:bg-(--surface-hover) hover:text-(--text-primary)"
               title="Open this session"
               onClick={() => setOpen(false)}
             >
-              <Icon name="messages-square" size={12} />
+              <Icon name="messages-square" size={11} />
               <span className="max-desktop:hidden">Session</span>
-              <Icon name="arrow-up-right" size={11} className="max-desktop:hidden" />
             </Link>
           ) : null}
 
           {canChooseCheckout ? (
             <button
               type="button"
-              className="flex h-full w-9 flex-none cursor-pointer items-center justify-center border-0 border-l border-(--border-subtle) bg-transparent text-(--text-tertiary) outline-none hover:bg-(--surface-hover) hover:text-(--text-primary)"
+              className="flex h-full w-8 flex-none cursor-pointer items-center justify-center border-0 border-l border-(--border-subtle) bg-transparent text-(--text-tertiary) outline-none hover:bg-(--surface-hover) hover:text-(--text-primary)"
               aria-label={open ? 'Close workspace checkout menu' : 'Open workspace checkout menu'}
               aria-haspopup="menu"
               aria-expanded={open}
@@ -218,7 +222,7 @@ export function WorkspaceScopePicker({
               id={menuId}
               role="menu"
               aria-label="Workspace checkout"
-              className="fmenu right-0 left-auto z-30 w-full max-h-none min-w-0 overflow-hidden rounded-lg p-0 shadow-(--shadow-lg)"
+              className="fmenu right-0 left-auto z-30 w-[min(max(120%,360px),calc(100vw-32px))] max-h-none min-w-0 overflow-hidden rounded-lg p-0 shadow-(--shadow-lg)"
               onKeyDown={moveChoiceFocus}
             >
               <button
@@ -226,12 +230,12 @@ export function WorkspaceScopePicker({
                 role="menuitemradio"
                 aria-checked={selectedSessionId === null}
                 data-workspace-choice
-                className={`fopt min-h-11 rounded-none px-4 text-[12.5px] outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--brand) ${
+                className={`fopt h-7 min-h-7 rounded-none px-4 text-[12px] outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--brand) ${
                   selectedSessionId === null ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)' : ''
                 }`}
                 onClick={() => pick(null)}
               >
-                <Icon name={selectedSessionId === null ? 'check' : 'git-branch'} size={15} className="flex-none" />
+                <Icon name={selectedSessionId === null ? 'check' : 'git-branch'} size={14} className="flex-none" />
                 <span className="min-w-0 flex-1 truncate font-semibold" title={primaryBranchLabel}>
                   {primaryBranchLabel}
                 </span>
@@ -250,7 +254,7 @@ export function WorkspaceScopePicker({
                     return (
                       <div
                         key={session.id}
-                        className={`flex min-h-[52px] items-center ${
+                        className={`flex h-7 items-center ${
                           selected
                             ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
                             : 'hover:bg-(--surface-hover)'
@@ -261,20 +265,20 @@ export function WorkspaceScopePicker({
                           role="menuitemradio"
                           aria-checked={selected}
                           data-workspace-choice
-                          className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 self-stretch border-0 bg-transparent px-4 py-2 text-left text-inherit outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--brand)"
-                          title={identity.fullTitle}
+                          className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 self-stretch border-0 bg-transparent px-4 text-left text-inherit outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--brand)"
+                          title={worktreeTooltip(identity, session.time)}
                           onClick={() => pick(session.id)}
                         >
-                          <Icon name={selected ? 'check' : 'git-branch'} size={15} className="flex-none" />
+                          <Icon name={selected ? 'check' : 'git-branch'} size={14} className="flex-none" />
                           <span className="flex min-w-0 flex-1 items-baseline gap-2">
                             {identity.context ? (
-                              <span className="flex-none font-sans text-[12.5px] font-semibold leading-normal">
+                              <span className="flex-none font-sans text-[12px] font-semibold leading-normal">
                                 {identity.context}
                               </span>
                             ) : null}
                             {identity.title ? (
                               <span
-                                className={`truncate font-sans text-[12.5px] leading-normal ${
+                                className={`truncate font-sans text-[12px] leading-normal ${
                                   selected
                                     ? 'font-normal text-(--brand-soft-text)'
                                     : identity.context
@@ -286,19 +290,15 @@ export function WorkspaceScopePicker({
                               </span>
                             ) : null}
                           </span>
-                          {session.time && session.time !== '—' ? (
-                            <span className="mono flex-none text-[11.5px] text-(--text-tertiary)">{session.time}</span>
-                          ) : null}
                         </button>
                         <Link
                           href={sessionHref(session.id)}
-                          className="mr-3 inline-flex h-7 flex-none items-center gap-[5px] rounded-sm border border-(--border-default) bg-(--surface-card) px-2 font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) no-underline hover:border-(--border-strong) hover:bg-(--surface-hover) hover:text-(--text-primary)"
+                          className="mr-3 inline-flex h-5 flex-none items-center gap-1 rounded-sm border border-(--border-default) bg-(--surface-card) px-1.5 font-sans text-[11px] font-medium leading-normal text-(--text-secondary) no-underline hover:border-(--border-strong) hover:bg-(--surface-hover) hover:text-(--text-primary)"
                           title="Open this session"
                           onClick={() => setOpen(false)}
                         >
-                          <Icon name="messages-square" size={12} />
+                          <Icon name="messages-square" size={11} />
                           <span className="max-desktop:hidden">Session</span>
-                          <Icon name="arrow-up-right" size={11} className="max-desktop:hidden" />
                         </Link>
                       </div>
                     )


### PR DESCRIPTION
## Summary

- reduce the workspace checkout control and every checkout menu item to the same compact 28px height with 12px labels
- let the dropdown extend beyond the trigger width so worktree titles have more room
- remove visible session times from rows and include them in the existing title tooltip
- remove the redundant external-link arrow from Session buttons

## Why

The selector was taller than the design reference, while worktree rows were substantially taller again because they used a 52px minimum height and a separate time column. The dropdown also inherited the trigger width, leaving long titles unnecessarily constrained.

## Impact

The closed selector and its menu now share one compact vertical rhythm. A 300px trigger renders a 360px menu, timestamps remain available on hover, and Session actions stay clear with only the message icon and label.

## Validation

- `pnpm --filter @agentconnect.md/web test` — 100 files, 762 tests passed
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter @agentconnect.md/web build`
- browser QA confirmed 28px trigger and rows, 12px labels, wider dropdown, tooltip timestamps, and no Session arrows

Created by Codex . GPT-5.6
