### PR TITLE
refactor(web): transcript text rendering becomes a registry keyed by platformId (S3 §10/§14)

### DIFF
--- a/packages/web/src/components/console/MessageText.test.tsx
+++ b/packages/web/src/components/console/MessageText.test.tsx
@@ -1,0 +1,169 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { MessageText } from './MessageText'
+import { platformRegistry } from './platforms/registry'
+
+/**
+ * The renderer registry (§10) ships with the core Slack-mrkdwn renderer as the
+ * default for EVERY platform, so this file's job is to prove nothing moved: the
+ * markup below was captured from the pre-registry `MessageText` and must stay
+ * byte-identical while every platform still renders through the default. It is
+ * the regression that matters — a per-platform override (§14) is allowed to
+ * change its own platform's rows, and nothing else's.
+ *
+ * The pairs are (input, rendered markup). Inputs cover the Slack control syntax
+ * the normalizer rewrites — link forms, user/channel/special mentions, emoji —
+ * the code spans and fences that must shield it, and the CommonMark/GFM the
+ * pipeline is left to handle (emphasis, tables, task lists, soft breaks).
+ */
+const CORPUS: ReadonlyArray<readonly [name: string, input: string, html: string]> = [
+  [
+    'bare link',
+    'see <https://example.test/docs> for details',
+    '<div class="mdtxt"><p>see <a href="https://example.test/docs" target="_blank" rel="noopener noreferrer">https://example.test/docs</a> for details</p></div>'
+  ],
+  [
+    'labelled link',
+    'see <https://example.test/docs|the docs> for details',
+    '<div class="mdtxt"><p>see <a href="https://example.test/docs" target="_blank" rel="noopener noreferrer">the docs</a> for details</p></div>'
+  ],
+  [
+    'link label carrying markdown metacharacters is escaped, not parsed',
+    '<https://example.test/a|weird [name] *here*>',
+    '<div class="mdtxt"><p><a href="https://example.test/a" target="_blank" rel="noopener noreferrer">weird [name] *here*</a></p></div>'
+  ],
+  [
+    'mailto is a link, tel without a label is bare text',
+    '<mailto:ops@example.test|mail us> or <tel:+15550100>',
+    '<div class="mdtxt"><p><a href="mailto:ops@example.test" target="_blank" rel="noopener noreferrer">mail us</a> or tel:+15550100</p></div>'
+  ],
+  [
+    'a non-http(s) target is not a Slack link token',
+    'run <file:///etc/hosts> yourself',
+    '<div class="mdtxt"><p>run <a href="" target="_blank" rel="noopener noreferrer">file:///etc/hosts</a> yourself</p></div>'
+  ],
+  ['user mention with a name', 'ping <@U012ABC|ada> about it', '<div class="mdtxt"><p>ping @ada about it</p></div>'],
+  ['user mention without a name', 'ping <@U012ABC> about it', '<div class="mdtxt"><p>ping @U012ABC about it</p></div>'],
+  ['channel mention', 'moved to <#C012ABC|releases>', '<div class="mdtxt"><p>moved to #releases</p></div>'],
+  ['channel mention without a name', 'moved to <#C012ABC>', '<div class="mdtxt"><p>moved to #C012ABC</p></div>'],
+  [
+    'here / channel / subteam specials',
+    '<!here> and <!channel> and <!subteam^S123|@platform>',
+    '<div class="mdtxt"><p>@here and @channel and @@platform</p></div>'
+  ],
+  ['emoji shortcodes', ':alarm_clock: ship :rocket: :+1:', '<div class="mdtxt"><p>⏰ ship 🚀 👍</p></div>'],
+  [
+    'an unknown (workspace custom) shortcode stays literal',
+    ':agentconnect: stays',
+    '<div class="mdtxt"><p>:agentconnect: stays</p></div>'
+  ],
+  [
+    'inline code shields control tokens',
+    'literal `<@U012ABC>` and `:alarm_clock:` here',
+    '<div class="mdtxt"><p>literal <code>&lt;@U012ABC&gt;</code> and <code>:alarm_clock:</code> here</p></div>'
+  ],
+  [
+    'a fence shields control tokens',
+    '```\n<@U012ABC> <https://example.test|x> :rocket:\n```',
+    '<div class="mdtxt"><pre><code>&lt;@U012ABC&gt; &lt;https://example.test|x&gt; :rocket:\n</code></pre></div>'
+  ],
+  [
+    'a fence keeps its language',
+    '```ts\nconst a = 1 // <#C1|c>\n```',
+    '<div class="mdtxt"><pre><code class="language-ts">const a = 1 // &lt;#C1|c&gt;\n</code></pre></div>'
+  ],
+  [
+    'emphasis is left to CommonMark',
+    'this is **bold**, this is *single-star*, this is _under_',
+    '<div class="mdtxt"><p>this is <strong>bold</strong>, this is <em>single-star</em>, this is <em>under</em></p></div>'
+  ],
+  [
+    'gfm table',
+    '| a | b |\n| - | - |\n| 1 | 2 |',
+    '<div class="mdtxt"><table><thead><tr><th>a</th><th>b</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table></div>'
+  ],
+  [
+    'gfm strikethrough and task list',
+    '~~gone~~\n\n- [x] done\n- [ ] todo',
+    '<div class="mdtxt"><p><del>gone</del></p>\n<ul class="contains-task-list">\n<li class="task-list-item"><input type="checkbox" disabled="" checked=""/> done</li>\n<li class="task-list-item"><input type="checkbox" disabled=""/> todo</li>\n</ul></div>'
+  ],
+  [
+    'single newlines become breaks (remark-breaks)',
+    'line one\nline two\nline three',
+    '<div class="mdtxt"><p>line one<br/>\nline two<br/>\nline three</p></div>'
+  ],
+  [
+    'HTML entities decode after the token rewrites',
+    'a &lt;tag&gt; &amp; more',
+    '<div class="mdtxt"><p>a &lt;tag&gt; &amp; more</p></div>'
+  ],
+  [
+    'heading and blockquote',
+    '# Title\n\n> quoted\n\nafter',
+    '<div class="mdtxt"><h1>Title</h1>\n<blockquote>\n<p>quoted</p>\n</blockquote>\n<p>after</p></div>'
+  ],
+  [
+    'ordered list with inline code',
+    '1. first\n2. second `x`',
+    '<div class="mdtxt"><ol>\n<li>first</li>\n<li>second <code>x</code></li>\n</ol></div>'
+  ],
+  [
+    'a bare url autolinks',
+    'https://example.test/plain',
+    '<div class="mdtxt"><p><a href="https://example.test/plain" target="_blank" rel="noopener noreferrer">https://example.test/plain</a></p></div>'
+  ],
+  [
+    'everything at once',
+    'hi <@U1|ada> :rocket: see <https://example.test|docs> in <#C1|dev>\n`<@U2>` **bold**',
+    '<div class="mdtxt"><p>hi @ada 🚀 see <a href="https://example.test" target="_blank" rel="noopener noreferrer">docs</a> in #dev<br/>\n<code>&lt;@U2&gt;</code> <strong>bold</strong></p></div>'
+  ],
+  ['empty', '', '<div class="mdtxt"></div>'],
+  ['whitespace only', '   ', '<div class="mdtxt"></div>']
+]
+
+/** Every key a transcript row can arrive with: the registered platforms, the
+ *  core-owned session kinds that are not modules, ids no module claims, and the
+ *  absent key a single-session page passes when the session has no platform. */
+const PLATFORM_KEYS = [
+  undefined,
+  '',
+  ...platformRegistry.ids(),
+  'webchat',
+  'playground',
+  'hook',
+  'github',
+  'lark',
+  'linear',
+  'Slack',
+  'constructor',
+  '__proto__'
+]
+
+describe('MessageText', () => {
+  it.each(CORPUS)('renders %s exactly as the pre-registry renderer did', (_name, input, html) => {
+    expect(renderToStaticMarkup(<MessageText text={input} />)).toBe(html)
+  })
+
+  it('resolves the same default renderer for every platform key, registered or not', () => {
+    // No module publishes a `textRenderer` yet — §10 ships the registry with
+    // the Slack renderer as the default for all chat platforms and lands
+    // overrides separately. An unknown key must reach that default too, never
+    // throw and never fall through to nothing.
+    for (const [name, input, html] of CORPUS) {
+      for (const platform of PLATFORM_KEYS) {
+        expect(renderToStaticMarkup(<MessageText text={input} platform={platform} />), `${name} @ ${platform}`).toBe(
+          html
+        )
+      }
+    }
+  })
+
+  it('skips the parser above the size cap instead of rendering markdown', () => {
+    // The cheap pre-wrapped path is what keeps a pathological reasoning row
+    // affordable; it must survive the seam, and it must not rewrite tokens.
+    const huge = `<@U1|ada> **bold** ${'x'.repeat(100_001)}`
+    const markup = renderToStaticMarkup(<MessageText text={huge} platform="slack" />)
+    expect(markup.startsWith('<div class="mdtxt"><p class="whitespace-pre-wrap">&lt;@U1|ada&gt; **bold** x')).toBe(true)
+    expect(markup).not.toContain('<strong>')
+  })
+})

--- a/packages/web/src/components/console/MessageText.tsx
+++ b/packages/web/src/components/console/MessageText.tsx
@@ -1,21 +1,30 @@
 'use client'
 
 /**
- * Transcript message renderer. The daemon records the agent's verbatim markdown
- * (posted to Slack as a Block Kit `markdown` block), and user/inbound rows carry
- * Slack control syntax — `slackToMarkdown` normalizes both into CommonMark, then
- * react-markdown renders it. Single newlines become line breaks (remark-breaks) to
- * match how Slack renders a `markdown` block.
+ * Transcript message renderer — the host side of §10's `textRenderer` seam.
  *
- * Safety: react-markdown skips raw HTML and sanitizes URLs (drops `javascript:`)
- * by default; we only widen that to force external links into a new, opener-isolated
- * tab. Styling lives under `.mdtxt` (compact, inline — distinct from `.md-body`).
+ * ONE RENDERER PER ROW, RESOLVED FROM THE ROW'S PLATFORM. `platform` is the
+ * key the owning platform module is looked up under; a module that publishes a
+ * `textRenderer` renders its own platform's rows, and everything else — every
+ * module that publishes none, and every id no module claims — gets
+ * {@link SlackMrkdwnText}, the core default below. The lookup happens HERE,
+ * inside the per-row component, and not once per transcript: a merged
+ * conversation interleaves rows from several sources by event time
+ * (`MergedRow.sourcePlatform`), so a renderer hoisted out of the row loop
+ * would render one platform's rows with another's semantics.
+ *
+ * NO MODULE OVERRIDES IT TODAY, deliberately: §10 ships the registry with the
+ * Slack renderer as the default for all chat platforms and lands per-platform
+ * overrides separately, each with its own visual review. So this resolves to
+ * the same renderer for every row that reaches it — the seam is what changed,
+ * not a pixel.
  */
 
-import { memo } from 'react'
+import { memo, type ComponentType } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
+import { platformTextRenderer } from './platforms/registry'
 import { slackToMarkdown } from './slack-mrkdwn'
 
 // Transcript rows from ACP aren't section-split like Slack posts, so a pathological
@@ -23,11 +32,24 @@ import { slackToMarkdown } from './slack-mrkdwn'
 // large strings, so above this cap we skip parsing and render cheap pre-wrapped text.
 const MAX_PARSE = 100_000
 
-// memo: the transcript re-renders on every unrelated state change in
-// SessionDetailView (composer keystrokes, the 1s duration tick, expanding one turn's
-// work), and without this EVERY row re-runs slackToMarkdown + the remark pipeline.
-// The only prop is a string, so shallow compare is exact.
-export const MessageText = memo(function MessageText({ text }: { text: string }) {
+/**
+ * The core default renderer: Slack mrkdwn semantics over a CommonMark
+ * pipeline. The daemon records the agent's verbatim markdown (posted to Slack
+ * as a Block Kit `markdown` block), and user/inbound rows carry Slack control
+ * syntax — `slackToMarkdown` normalizes both into CommonMark, then
+ * react-markdown renders it. Single newlines become line breaks (remark-breaks)
+ * to match how Slack renders a `markdown` block.
+ *
+ * Core rather than the Slack module's `textRenderer` because three other
+ * platforms render through it: as Slack's member it would leave Telegram,
+ * Discord and Feishu reaching into another module. It moves into
+ * `platforms/slack/` on the day Slack's semantics stop being everyone's.
+ *
+ * Safety: react-markdown skips raw HTML and sanitizes URLs (drops `javascript:`)
+ * by default; we only widen that to force external links into a new, opener-isolated
+ * tab. Styling lives under `.mdtxt` (compact, inline — distinct from `.md-body`).
+ */
+export const SlackMrkdwnText: ComponentType<{ text: string }> = function SlackMrkdwnText({ text }) {
   if (text.length > MAX_PARSE) {
     return (
       <div className="mdtxt">
@@ -51,4 +73,15 @@ export const MessageText = memo(function MessageText({ text }: { text: string })
       </ReactMarkdown>
     </div>
   )
+}
+
+// memo: the transcript re-renders on every unrelated state change in
+// SessionDetailView (composer keystrokes, the 1s duration tick, expanding one turn's
+// work), and without this EVERY row re-runs the resolved renderer's whole pipeline.
+// Both props are plain strings, so shallow compare is exact — which is also why
+// `textRenderer` is a ComponentType and not a `(text, ctx) => ReactNode` function:
+// the memo boundary has to sit OUTSIDE the per-platform work.
+export const MessageText = memo(function MessageText({ text, platform }: { text: string; platform?: string }) {
+  const Renderer = platformTextRenderer(platform) ?? SlackMrkdwnText
+  return <Renderer text={text} />
 })

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -538,41 +538,63 @@ export interface WebPlatformModule<TApi = unknown> {
    *  noun, `#` glyph, `leave: 'none'`, generic copy. */
   channelList?: WebChannelListSemantics
   /**
-   * Per-platform transcript text renderer — the §14 defect-3 seam, DECLARED
-   * here and adopted separately. Today ONE global renderer applies Slack
-   * mrkdwn rewriting to every platform's rows (`MessageText`,
-   * components/console/MessageText.tsx:30-54 over `slackToMarkdown`,
-   * slack-mrkdwn.ts:64; call sites SessionDetailView.tsx:3022, :3104,
-   * :3154). NOTHING consults this member in this PR: adoption means a
-   * renderer registry keyed by platformId that ships the Slack renderer as
-   * the default for all chat platforms (preserving today's behavior), with
-   * per-platform overrides landing as their own explicitly-reviewed behavior
-   * changes (§10, §14). A component rather than a `(text, ctx) => ReactNode`
-   * function so the memoization that keeps the transcript affordable
-   * (MessageText.tsx:26-30) survives the seam.
+   * Per-platform transcript text renderer — the §14 defect-3 seam, ADOPTED:
+   * `MessageText` resolves it from the ROW's platform key
+   * (`MergedRow.sourcePlatform`, falling back to the session's platform) on
+   * every row it renders, through `platformTextRenderer` in the registry.
+   *
+   * NO MODULE DECLARES ONE TODAY, and that is the shipped state §10 asks for:
+   * "a renderer registry keyed by platformId ships with the Slack renderer as
+   * the default for all chat platforms, then per-platform overrides land
+   * separately (§14)". The default is core (`SlackMrkdwnText`,
+   * components/console/MessageText.tsx over `slackToMarkdown`,
+   * slack-mrkdwn.ts) rather than the Slack module's member, because three
+   * other platforms render through it: making it Slack's would leave Telegram,
+   * Discord and Feishu reading another module's internals. It moves into
+   * `platforms/slack/` on the day Slack's semantics stop being everyone's —
+   * i.e. with the first override, which is also the first change here with
+   * visible pixels.
+   *
+   * A component rather than §10's sketched `(text, ctx) => ReactNode` so the
+   * memoization that keeps the transcript affordable survives the seam: the
+   * transcript re-renders on every unrelated state change in
+   * SessionDetailView, and `MessageText` is `memo`ized over its plain-string
+   * props precisely so each row's remark pipeline does NOT re-run. A bare
+   * function returning a `ReactNode` cannot be memoized by the host, and no
+   * call site has a `ctx` to pass.
    */
   textRenderer?: ComponentType<{ text: string }>
   /**
    * Provider-native duplicate identity of one transcript row — the
-   * per-platform arms of the merged-conversation dedupe
-   * (`duplicateIdentity`, lib/conversation-merge.ts:115-122: Slack decimal
-   * ts, Discord snowflakes, Telegram short sequence ids, Feishu `om_` ids;
+   * per-platform arms of the merged-conversation dedupe (Slack decimal ts,
+   * Discord snowflakes, Telegram short sequence ids, Feishu `om_` ids;
    * platform selects the rule via `MergeSource.platform`,
-   * :14-19). `null` = this row never dedupes across sources. Absent ⇒ the
-   * merge never dedupes this platform's rows — its stated fail-closed
-   * direction ("toward a visible duplicate, never toward data loss",
-   * :108-110). Consumed by a CORE routine (audit Appendix D, ambiguous
-   * row 5): the merge algorithm stays host-owned; only the identity rule is
-   * the module's.
+   * lib/conversation-merge.ts). `null` = this row never dedupes across
+   * sources. Absent ⇒ the merge never dedupes this platform's rows — its
+   * stated fail-closed direction ("toward a visible duplicate, never toward
+   * data loss").
+   *
+   * Consumed by a CORE routine (audit Appendix D, ambiguous row 5): the merge
+   * algorithm stays host-owned, and so do the two rules that are not any
+   * platform's — only `kind === 'text'` rows dedupe at all, and `webchat`
+   * keys on its canonical `postId`. `webchat` is not a module (it has no bot
+   * identity to install), so its arm cannot move here. What the module owns is
+   * the id SHAPE of its own provider.
+   *
+   * ADOPTED, and the "absent ⇒ never" direction is now REAL rather than
+   * documentary: it used to be Slack's decimal-ts rule that ran for every
+   * unrecognized platform id, because Slack was the fall-through arm of an
+   * if-chain. Nothing is the fall-through now.
    */
   messageIdentity?(row: SessionMessageDto): string | null
   /**
    * Whether transcript pages re-sort by event time or trust the daemon
-   * sequence — today's `platform !== 'slack'` fork in `mergeSessionMessages`
-   * (lib/session-transcript.ts:8-20): Slack rows carry provider send-times
-   * that the display order must follow; everyone else orders by `seq`.
-   * Absent ⇒ `'seq'` (the conservative arm every non-Slack platform takes
-   * today).
+   * sequence — the `platform !== 'slack'` fork `mergeSessionMessages`
+   * (lib/session-transcript.ts) used to spell out: Slack rows carry provider
+   * send-times that the display order must follow; everyone else orders by
+   * `seq`. Absent ⇒ `'seq'`, which is both the conservative arm and the arm
+   * every non-Slack platform already took, so ADOPTING this member moved the
+   * fork without moving the behavior.
    */
   transcriptOrdering?: 'seq' | 'event-time'
 }

--- a/packages/web/src/components/console/platforms/discord/index.tsx
+++ b/packages/web/src/components/console/platforms/discord/index.tsx
@@ -10,6 +10,11 @@ import { discordSettingsFragments } from './settings'
  *  from the pasted token in the browser (`./invite.ts`). */
 const discordApi = {}
 
+/** Discord's provider-native message id: a snowflake, 16–20 digits (creation
+ *  ms in the top 42 bits). Long enough that a 13-digit daemon-local
+ *  millisecond stamp can never match it. */
+const DISCORD_SNOWFLAKE = /^\d{16,20}$/
+
 export const discordModule: WebPlatformModule<typeof discordApi> = {
   platformId: 'discord',
   Mark: DiscordMark,
@@ -34,5 +39,6 @@ export const discordModule: WebPlatformModule<typeof discordApi> = {
     cannotLeaveRowHint:
       'A Discord bot belongs to a server, not one channel — use Leave on the server heading above to take it out. If it is still in there, the row will come back.',
     footerNote: 'A Discord bot joins servers, not channels, so it can only leave a whole server.'
-  }
+  },
+  messageIdentity: (row) => (DISCORD_SNOWFLAKE.test(row.ts) ? `ts:${row.ts}` : null)
 }

--- a/packages/web/src/components/console/platforms/feishu/index.tsx
+++ b/packages/web/src/components/console/platforms/feishu/index.tsx
@@ -8,6 +8,10 @@ import { FeishuMark } from './mark'
 import { feishuBrand, feishuRegionOf } from './region'
 import { feishuSettingsFragments } from './settings'
 
+/** Lark / Feishu's provider-native message id: an `om_`-prefixed opaque id,
+ *  which no numeric daemon-local stamp can collide with. */
+const FEISHU_MESSAGE_ID = /^om_[A-Za-z0-9_-]+$/
+
 export const feishuModule: WebPlatformModule<FeishuApi> = {
   platformId: 'feishu',
   Mark: FeishuMark,
@@ -42,5 +46,6 @@ export const feishuModule: WebPlatformModule<FeishuApi> = {
     roomGlyph: '',
     // No console-driven leave: the bot is removed from a group in Lark itself.
     leave: 'none'
-  }
+  },
+  messageIdentity: (row) => (FEISHU_MESSAGE_ID.test(row.ts) ? `ts:${row.ts}` : null)
 }

--- a/packages/web/src/components/console/platforms/registry.ts
+++ b/packages/web/src/components/console/platforms/registry.ts
@@ -1,5 +1,7 @@
 // No 'use client' here: reached only from ModalProvider's tree (the client boundary).
 
+import type { ComponentType } from 'react'
+import type { SessionMessageDto } from '@/lib/api'
 import type { WebChannelListSemantics, WebPlatformModule, WebPlatformRegistry } from './contract'
 import { discordModule } from './discord'
 import { feishuModule } from './feishu'
@@ -44,4 +46,39 @@ export const DEFAULT_CHANNEL_LIST: WebChannelListSemantics = {
 /** One platform's channel-list display semantics, defaulted. */
 export function channelListSemantics(platformId?: string): WebChannelListSemantics {
   return (platformId ? platformRegistry.get(platformId)?.channelList : undefined) ?? DEFAULT_CHANNEL_LIST
+}
+
+/**
+ * This platform's transcript text renderer OVERRIDE, or `undefined` for the
+ * core default — which is every platform today (§10: the registry "ships with
+ * the Slack renderer as the default for all chat platforms, then per-platform
+ * overrides land separately").
+ *
+ * The default itself deliberately stays in `MessageText`, so this lookup does
+ * NOT return it: resolving it here would pull the markdown pipeline
+ * (react-markdown + remark-gfm + remark-breaks + node-emoji) into this module,
+ * and `ModalProvider` — mounted by the console shell on EVERY route — imports
+ * this registry through `AddIntegrationModal`. Only the session transcript
+ * renders message text; only it should carry the parser. Same reasoning that
+ * keeps `platforms/marks.ts` and `lib/platform-labels.ts` out of here.
+ */
+export function platformTextRenderer(platformId?: string): ComponentType<{ text: string }> | undefined {
+  return platformId ? platformRegistry.get(platformId)?.textRenderer : undefined
+}
+
+/**
+ * This row's provider-native duplicate identity under `platformId`'s rule, or
+ * `null` when it must never dedupe across sources — including every platform
+ * id no module claims. See {@link WebPlatformModule.messageIdentity}: the
+ * caller (`lib/conversation-merge.ts`) keeps the rules that are core rather
+ * than any platform's, and this resolves only the provider id SHAPE.
+ */
+export function platformMessageIdentity(platformId: string, row: SessionMessageDto): string | null {
+  return platformRegistry.get(platformId)?.messageIdentity?.(row) ?? null
+}
+
+/** This platform's transcript page ordering, defaulted to the conservative
+ *  daemon sequence. See {@link WebPlatformModule.transcriptOrdering}. */
+export function platformTranscriptOrdering(platformId: string): 'seq' | 'event-time' {
+  return platformRegistry.get(platformId)?.transcriptOrdering ?? 'seq'
 }

--- a/packages/web/src/components/console/platforms/slack/index.tsx
+++ b/packages/web/src/components/console/platforms/slack/index.tsx
@@ -8,6 +8,11 @@ import { SlackMark } from './mark'
 import { slackSettingsFragments } from './settings'
 import { useSlackPlatformInstall } from './use-platform-install'
 
+/** Slack's provider-native message id: epoch seconds with a sub-second part
+ *  (`1754123456.000200`). Chosen so a daemon-local 13-digit `monotonicTs()`
+ *  millisecond stamp can never match it. */
+const SLACK_NATIVE_TS = /^\d+\.\d+$/
+
 export const slackModule: WebPlatformModule<SlackApi> = {
   platformId: 'slack',
   Mark: SlackMark,
@@ -49,5 +54,10 @@ export const slackModule: WebPlatformModule<SlackApi> = {
     // removing the bot IN Slack clears the row by itself — hence the footer note.
     leave: 'none',
     footerNote: 'To remove the bot from a channel, do it in Slack — this list updates by itself.'
-  }
+  },
+  messageIdentity: (row) => (SLACK_NATIVE_TS.test(row.ts) ? `ts:${row.ts}` : null),
+  // Slack rows carry the workspace's own send-time, and a page must present
+  // them in it: the daemon `seq` is ingest order, which reorders a burst that
+  // arrived out of order. Every other platform trusts `seq`.
+  transcriptOrdering: 'event-time'
 }

--- a/packages/web/src/components/console/platforms/telegram/index.tsx
+++ b/packages/web/src/components/console/platforms/telegram/index.tsx
@@ -6,6 +6,11 @@ import { telegramApi, type TelegramApi } from './api'
 import { TelegramWizardBody } from './Body'
 import { TelegramMark } from './mark'
 
+/** Telegram's provider-native message id: a short per-chat sequence number.
+ *  Capped at 9 digits so neither the 10-digit legacy epoch-seconds era nor a
+ *  13-digit daemon-local millisecond stamp can be mistaken for one. */
+const TELEGRAM_MESSAGE_ID = /^\d{1,9}$/
+
 export const telegramModule: WebPlatformModule<TelegramApi> = {
   platformId: 'telegram',
   Mark: TelegramMark,
@@ -29,5 +34,6 @@ export const telegramModule: WebPlatformModule<TelegramApi> = {
     roomGlyph: '',
     // `leaveChat` needs no extra permission, so a row can be left from the console.
     leave: 'conversation'
-  }
+  },
+  messageIdentity: (row) => (TELEGRAM_MESSAGE_ID.test(row.ts) ? `ts:${row.ts}` : null)
 }

--- a/packages/web/src/components/console/platforms/text-renderer.test.tsx
+++ b/packages/web/src/components/console/platforms/text-renderer.test.tsx
@@ -1,0 +1,111 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { MessageText } from '@/components/console/MessageText'
+import { mergeConversation, type MergeSource } from '@/lib/conversation-merge'
+import type { SessionMessageDto } from '@/lib/api'
+
+/**
+ * The §10 renderer seam, exercised with OVERRIDES INSTALLED — which the shipped
+ * registry deliberately has none of, so the mechanism has to be tested against
+ * a stand-in. What is under test is that the lookup happens PER ROW: a merged
+ * conversation interleaves several sources by event time, so a renderer
+ * resolved once for the page (or once per turn) would render one platform's
+ * rows with another platform's semantics, silently, and only for users who
+ * merged two platforms into one conversation.
+ */
+const { overrides } = vi.hoisted(() => ({ overrides: new Map<string, unknown>() }))
+
+vi.mock('@/components/console/platforms/registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./registry')>()
+  return { ...actual, platformTextRenderer: (id?: string) => (id ? overrides.get(id) : undefined) }
+})
+
+function Marker({ text, tag }: { text: string; tag: string }) {
+  return <span data-renderer={tag}>{text}</span>
+}
+overrides.set('slack', ({ text }: { text: string }) => <Marker text={text} tag="slack" />)
+overrides.set('discord', ({ text }: { text: string }) => <Marker text={text} tag="discord" />)
+
+let seq = 0
+function row(over: Partial<SessionMessageDto>): SessionMessageDto {
+  return { seq: ++seq, sender: 'user-1', ts: '1000', kind: 'text', text: 'hi', ...over }
+}
+function src(sessionId: string, platform: string, rows: SessionMessageDto[]): MergeSource {
+  return { sessionId, agentId: `agent-${sessionId}`, platform, rows }
+}
+
+/** What SessionDetailView does per row: render the row's own text under the
+ *  row's own platform. Kept to one expression so the test cannot accidentally
+ *  hoist the lookup the production loop must not hoist either. */
+function renderTranscript(rows: ReadonlyArray<{ text: string; platform: string }>): string {
+  return renderToStaticMarkup(
+    <>
+      {rows.map((r, i) => (
+        <MessageText key={i} text={r.text} platform={r.platform} />
+      ))}
+    </>
+  )
+}
+
+describe('per-platform transcript text renderer', () => {
+  it('resolves one renderer per row when two platforms interleave in a merged conversation', () => {
+    // Two sources whose rows alternate on the normalized event-time axis, so
+    // the merged order is s1, d1, s2, d2 — never grouped by source.
+    const merged = mergeConversation([
+      src('sess-a', 'slack', [
+        row({ ts: '1754123456.000100', text: 's1' }),
+        row({ ts: '1754123458.000100', text: 's2' })
+      ]),
+      src('sess-b', 'discord', [row({ ts: '1754123457000', text: 'd1' }), row({ ts: '1754123459000', text: 'd2' })])
+    ])
+
+    // The key each row will be rendered under travels WITH the row out of the
+    // merge, so the view cannot pair a row with a neighbour's platform.
+    expect(merged.map((m) => [m.row.text, m.sourcePlatform])).toEqual([
+      ['s1', 'slack'],
+      ['d1', 'discord'],
+      ['s2', 'slack'],
+      ['d2', 'discord']
+    ])
+
+    const markup = renderTranscript(merged.map((m) => ({ text: m.row.text, platform: m.sourcePlatform })))
+    expect(markup).toBe(
+      '<span data-renderer="slack">s1</span>' +
+        '<span data-renderer="discord">d1</span>' +
+        '<span data-renderer="slack">s2</span>' +
+        '<span data-renderer="discord">d2</span>'
+    )
+  })
+
+  it('falls back to the core default for an unknown key sitting between overridden rows', () => {
+    // The fallback has to hold ROW-LOCALLY: an unrecognized platform in the
+    // middle of a conversation renders through the default, and leaves its
+    // neighbours on their own renderers.
+    const markup = renderTranscript([
+      { text: 'a', platform: 'slack' },
+      { text: 'b', platform: 'linear' },
+      { text: 'c', platform: 'discord' }
+    ])
+    expect(markup).toBe(
+      '<span data-renderer="slack">a</span>' +
+        '<div class="mdtxt"><p>b</p></div>' +
+        '<span data-renderer="discord">c</span>'
+    )
+  })
+
+  it('does not memoize one row’s renderer onto the next', () => {
+    // `MessageText` is memoized on its props; two rows with the SAME text and
+    // different platforms must still resolve separately.
+    expect(
+      renderTranscript([
+        { text: 'same', platform: 'slack' },
+        { text: 'same', platform: 'discord' },
+        { text: 'same', platform: 'telegram' }
+      ])
+    ).toBe(
+      '<span data-renderer="slack">same</span>' +
+        '<span data-renderer="discord">same</span>' +
+        '<div class="mdtxt"><p>same</p></div>'
+    )
+  })
+})

--- a/packages/web/src/components/console/platforms/transcript.test.ts
+++ b/packages/web/src/components/console/platforms/transcript.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionMessageDto } from '@/lib/api'
+import { platformMessageIdentity, platformRegistry, platformTextRenderer, platformTranscriptOrdering } from './registry'
+
+/**
+ * The three transcript-domain module members (§10) read through the registry
+ * rather than through an if-chain over platform ids. What these pin is the
+ * DEFAULTS — the answers for ids no module claims — because that is where the
+ * two shapes disagreed: the old chain made Slack the fall-through for
+ * everything unrecognized, while the contract says an absent member means the
+ * platform opts out.
+ */
+const UNCLAIMED = ['linear', 'hook', 'github', 'playground', 'webchat', 'lark', 'Slack', 'constructor', '__proto__', '']
+
+let seq = 0
+function row(over: Partial<SessionMessageDto>): SessionMessageDto {
+  return { seq: ++seq, sender: 'user-1', ts: '1000', kind: 'text', text: 'hi', ...over }
+}
+
+describe('transcript module members', () => {
+  it('gives no platform a text renderer of its own yet', () => {
+    // §10 ships the registry with the CORE Slack renderer as the default for
+    // all chat platforms and lands per-platform overrides separately, each
+    // with its own visual review. When one arrives this expectation changes
+    // WITH it — which is the point of asserting the empty state.
+    for (const module of platformRegistry.all()) {
+      expect(module.textRenderer, module.platformId).toBeUndefined()
+    }
+    for (const id of [...platformRegistry.ids(), ...UNCLAIMED]) {
+      expect(platformTextRenderer(id), id).toBeUndefined()
+    }
+    expect(platformTextRenderer(undefined)).toBeUndefined()
+  })
+
+  it('recognizes each registered platform’s native message id', () => {
+    const SNOWFLAKE = '1101111111111111111'
+    expect(platformMessageIdentity('slack', row({ ts: '1754123456.000200' }))).toBe('ts:1754123456.000200')
+    expect(platformMessageIdentity('discord', row({ ts: SNOWFLAKE }))).toBe(`ts:${SNOWFLAKE}`)
+    expect(platformMessageIdentity('telegram', row({ ts: '4821' }))).toBe('ts:4821')
+    expect(platformMessageIdentity('feishu', row({ ts: 'om_abc123' }))).toBe('ts:om_abc123')
+    // A daemon-local millisecond stamp is nobody's native id.
+    for (const id of platformRegistry.ids()) {
+      expect(platformMessageIdentity(id, row({ ts: '1754123457123' })), id).toBeNull()
+    }
+  })
+
+  it('dedupes nothing for a platform id no module claims', () => {
+    // Not even a Slack-SHAPED id: an unclaimed platform has no id rule, and
+    // borrowing another platform's would risk deleting a distinct row.
+    for (const id of UNCLAIMED) {
+      expect(platformMessageIdentity(id, row({ ts: '1754123456.000200' })), id).toBeNull()
+    }
+  })
+
+  it('orders by event time for Slack and by daemon sequence for everyone else', () => {
+    expect(platformTranscriptOrdering('slack')).toBe('event-time')
+    for (const id of [...platformRegistry.ids().filter((p) => p !== 'slack'), ...UNCLAIMED]) {
+      expect(platformTranscriptOrdering(id), id).toBe('seq')
+    }
+  })
+})

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -78,6 +78,7 @@ import { formatTranscriptRowTime, transcriptRowTimeMs } from '@/lib/transcript-t
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { consoleKeys } from '@/lib/swr-keys'
 import { sessionAttributionAgentAuthors, sessionAttributionAgentId, sessionSenderLabel } from '@/lib/session-trigger'
+import { platformTranscriptOrdering } from '@/components/console/platforms/registry'
 import { mergeSessionMessages } from '@/lib/session-transcript'
 import { useStickToBottom } from '@/lib/stick-to-bottom'
 import { socialLoginProviders } from '@/lib/social-login-providers'
@@ -237,7 +238,7 @@ function ComposerSendButton({
 
 // One agent-turn step rendered from a real transcript message. Maps the daemon
 // transcript kind (text | tool | reasoning) onto the existing lane styling.
-function msgStep(m: SessionMessageDto, toolSessionId?: string): FmtStep {
+function msgStep(m: SessionMessageDto, toolSessionId?: string, platform?: string): FmtStep {
   const k = (m.kind || 'text').toLowerCase()
   if (k === 'tool') {
     return {
@@ -251,6 +252,7 @@ function msgStep(m: SessionMessageDto, toolSessionId?: string): FmtStep {
       code: m.text,
       files: [],
       time: formatTranscriptRowTime(m),
+      ...(platform ? { platform } : {}),
       // Carry the raw message so the row can render the captured tool body (input /
       // output / content / diff / locations) below the title, on demand.
       ...(m.body ? { msg: m, ...(toolSessionId ? { toolSessionId } : {}) } : {})
@@ -267,7 +269,8 @@ function msgStep(m: SessionMessageDto, toolSessionId?: string): FmtStep {
       text: m.text,
       code: '',
       files: [],
-      time: formatTranscriptRowTime(m)
+      time: formatTranscriptRowTime(m),
+      ...(platform ? { platform } : {})
     }
   }
   return {
@@ -280,7 +283,8 @@ function msgStep(m: SessionMessageDto, toolSessionId?: string): FmtStep {
     text: m.text,
     code: '',
     files: [],
-    time: formatTranscriptRowTime(m)
+    time: formatTranscriptRowTime(m),
+    ...(platform ? { platform } : {})
   }
 }
 
@@ -306,14 +310,16 @@ function mergeConversationRows(
   sources: { sessionId: string; agentId: string; platform: string }[],
   rows: Map<string, SessionMessageDto[]>,
   sourceSessionByMessage: WeakMap<SessionMessageDto, string>,
-  sourceTurnByMessage: WeakMap<SessionMessageDto, string>
+  sourceTurnByMessage: WeakMap<SessionMessageDto, string>,
+  sourcePlatformByMessage: WeakMap<SessionMessageDto, string>
 ): SessionMessageDto[] {
   return mergeConversation(
     sources
       .filter((source) => rows.has(source.sessionId))
       .map((source) => ({ ...source, rows: rows.get(source.sessionId)! }) satisfies MergeSource)
-  ).map(({ row, sourceSessionId, sourceTurnKey }) => {
+  ).map(({ row, sourceSessionId, sourcePlatform, sourceTurnKey }) => {
     sourceSessionByMessage.set(row, sourceSessionId)
+    sourcePlatformByMessage.set(row, sourcePlatform)
     if (sourceTurnKey) sourceTurnByMessage.set(row, sourceTurnKey)
     return row
   })
@@ -337,11 +343,15 @@ interface FmtStep {
   // Conversation rows keep their owning session out-of-band so full-body reads
   // do not accidentally target the representative member.
   toolSessionId?: string
+  // The platform this row was authored on — the key `MessageText` resolves its
+  // renderer under (§10). Per STEP, not per turn or per page: a merged
+  // conversation interleaves sources, so neighbouring rows can differ.
+  platform?: string
 }
 
 // A bare text step (no lane chrome) — how a peer participant's message renders
 // inside its agent block.
-function plainStep(text: string, time?: string, image?: SessionImage): FmtStep {
+function plainStep(text: string, time?: string, image?: SessionImage, platform?: string): FmtStep {
   return {
     lane: '',
     laneColor: 'var(--text-tertiary)',
@@ -353,7 +363,8 @@ function plainStep(text: string, time?: string, image?: SessionImage): FmtStep {
     code: '',
     files: [],
     ...(time ? { time } : {}),
-    ...(image ? { image } : {})
+    ...(image ? { image } : {}),
+    ...(platform ? { platform } : {})
   }
 }
 
@@ -455,7 +466,7 @@ function maxTime(...values: Array<number | null | undefined>): number | null {
   return finite.length > 0 ? Math.max(...finite) : null
 }
 
-function fmtStep(stp: SessionStep): FmtStep {
+function fmtStep(stp: SessionStep, platform?: string): FmtStep {
   const L = lane(stp.kind)
   return {
     lane: L.lane,
@@ -467,7 +478,8 @@ function fmtStep(stp: SessionStep): FmtStep {
     text: stp.text,
     code: stp.code ?? '',
     files: (stp.files ?? []).map((f) => ({ tag: f.tag, path: f.path, color: fileColor(f.tag) })),
-    time: stp.time ?? ''
+    time: stp.time ?? '',
+    ...(platform ? { platform } : {})
   }
 }
 
@@ -707,6 +719,8 @@ type Turn =
       image?: SessionImage
       isCron: boolean
       cronId: string | null
+      /** The platform this message was authored on — see `FmtStep.platform`. */
+      platform?: string
     }
   | { kind: 'bot'; agentName: string; agentId?: string; model: string; time: string; steps: FmtStep[] }
 
@@ -1223,6 +1237,10 @@ export default function SessionDetailView() {
   }>({ rows: new Map(), cursors: new Map(), older: new Map() })
   const conversationSourceSessionByMessageRef = useRef(new WeakMap<SessionMessageDto, string>())
   const conversationSourceTurnByMessageRef = useRef(new WeakMap<SessionMessageDto, string>())
+  // Each merged row's OWN platform (§10) — the key its text renderer resolves
+  // under. Out-of-band like the two above so the row objects keep their
+  // identity, and per row because sources interleave by event time.
+  const conversationSourcePlatformByMessageRef = useRef(new WeakMap<SessionMessageDto, string>())
   const [conversationHasEarlier, setConversationHasEarlier] = useState(false)
   const [conversationPagingEarlier, setConversationPagingEarlier] = useState(false)
   // Which conversation key the CURRENT fan-out state belongs to — the focus
@@ -1675,7 +1693,8 @@ export default function SessionDetailView() {
             sources,
             rowsBySession,
             conversationSourceSessionByMessageRef.current,
-            conversationSourceTurnByMessageRef.current
+            conversationSourceTurnByMessageRef.current,
+            conversationSourcePlatformByMessageRef.current
           )
         )
         setMsgLoading(false)
@@ -1769,7 +1788,10 @@ export default function SessionDetailView() {
               })
               if (tailSessionRef.current !== sid) return
               const current = state.rows.get(src.sessionId) ?? []
-              state.rows.set(src.sessionId, mergeSessionMessages(current, page.messages, src.platform))
+              state.rows.set(
+                src.sessionId,
+                mergeSessionMessages(current, page.messages, platformTranscriptOrdering(src.platform))
+              )
               if (src.sessionId === sid) repRows.push(...page.messages)
               if (page.liveCursor !== null) {
                 cursor = page.liveCursor
@@ -1788,7 +1810,8 @@ export default function SessionDetailView() {
             sources,
             state.rows,
             conversationSourceSessionByMessageRef.current,
-            conversationSourceTurnByMessageRef.current
+            conversationSourceTurnByMessageRef.current,
+            conversationSourcePlatformByMessageRef.current
           )
         )
         if (tailSessionRef.current === sid && !sessionBusyRef.current && repRows.length > 0)
@@ -1817,7 +1840,7 @@ export default function SessionDetailView() {
         })
         if (tailSessionRef.current !== sid) return
         persisted.push(...page.messages)
-        setMsgs((current) => mergeSessionMessages(current ?? [], page.messages, platform))
+        setMsgs((current) => mergeSessionMessages(current ?? [], page.messages, platformTranscriptOrdering(platform)))
         if (page.liveCursor !== null) {
           cursor = page.liveCursor
           liveCursorRef.current = cursor
@@ -1867,7 +1890,8 @@ export default function SessionDetailView() {
           sources,
           state.rows,
           conversationSourceSessionByMessageRef.current,
-          conversationSourceTurnByMessageRef.current
+          conversationSourceTurnByMessageRef.current,
+          conversationSourcePlatformByMessageRef.current
         )
       )
       setConversationHasEarlier([...state.older.values()].some((cursor) => cursor !== null))
@@ -2287,6 +2311,9 @@ export default function SessionDetailView() {
     for (const m of visibleMsgs ?? []) {
       const toolSessionId = conversationSourceSessionByMessageRef.current.get(m)
       const sourceTurnKey = conversationSourceTurnByMessageRef.current.get(m)
+      // A merged conversation stamps every row with the platform of the source
+      // it came from; a single-session page has one platform for all of them.
+      const rowPlatform = conversationSourcePlatformByMessageRef.current.get(m) ?? session.platform
       if (m.sender === session.agentId) {
         let last = sourceTurnKey ? botTurnByKey.get(sourceTurnKey) : turns[turns.length - 1]
         const ownerName = session.agentName ?? ''
@@ -2302,7 +2329,7 @@ export default function SessionDetailView() {
           turns.push(last)
           if (sourceTurnKey) botTurnByKey.set(sourceTurnKey, last)
         }
-        const step = msgStep(m, toolSessionId)
+        const step = msgStep(m, toolSessionId, rowPlatform)
         last.steps.push(step)
         if (!last.time && step.time) last.time = step.time
       } else {
@@ -2316,7 +2343,7 @@ export default function SessionDetailView() {
           pushAgentTurn(
             senderAgent,
             {
-              ...msgStep(m, toolSessionId),
+              ...msgStep(m, toolSessionId, rowPlatform),
               ...(m.attachments?.[0] ? { image: m.attachments[0] } : {})
             },
             sourceTurnKey
@@ -2340,7 +2367,8 @@ export default function SessionDetailView() {
           text: m.text,
           image: m.attachments?.[0],
           isCron: !!cron,
-          cronId: cron?.id ?? null
+          cronId: cron?.id ?? null,
+          platform: rowPlatform
         })
       }
     }
@@ -2356,7 +2384,7 @@ export default function SessionDetailView() {
         if (senderAgent && !self) {
           pushAgentTurn(
             senderAgent,
-            plainStep(stp.text, stp.time ?? (firstMsg ? session.time : ''), stp.image),
+            plainStep(stp.text, stp.time ?? (firstMsg ? session.time : ''), stp.image, session.platform),
             liveBotTurnKey(stp.turnId, senderAgent.id)
           )
           firstMsg = false
@@ -2376,7 +2404,8 @@ export default function SessionDetailView() {
           text: stp.text,
           image: stp.image,
           isCron: !!cron,
-          cronId: cron?.id ?? null
+          cronId: cron?.id ?? null,
+          platform: session.platform
         })
         firstMsg = false
       } else {
@@ -2407,7 +2436,7 @@ export default function SessionDetailView() {
           // A tagged step continuing an untagged block names its author retroactively.
           last.agentId = stp.agentId
         }
-        const step = fmtStep(stp)
+        const step = fmtStep(stp, session.platform)
         last.steps.push(step)
         if (!last.time && step.time) last.time = step.time
       }
@@ -2426,7 +2455,7 @@ export default function SessionDetailView() {
         if (senderAgent && !self) {
           pushAgentTurn(
             senderAgent,
-            plainStep(stp.text, stp.time ?? '', stp.image),
+            plainStep(stp.text, stp.time ?? '', stp.image, session.platform),
             liveBotTurnKey(stp.turnId, senderAgent.id)
           )
           continue
@@ -2443,7 +2472,8 @@ export default function SessionDetailView() {
           text: stp.text,
           image: stp.image,
           isCron: false,
-          cronId: null
+          cronId: null,
+          platform: session.platform
         })
       } else {
         const stepAgent = stp.agentId ? agentById.get(stp.agentId) : undefined
@@ -2468,7 +2498,7 @@ export default function SessionDetailView() {
           // A tagged step continuing an untagged block names its author retroactively.
           last.agentId = stp.agentId
         }
-        const step = fmtStep(stp)
+        const step = fmtStep(stp, session.platform)
         last.steps.push(step)
         if (!last.time && step.time) last.time = step.time
       }
@@ -3070,7 +3100,7 @@ export default function SessionDetailView() {
                             className={`max-h-[360px] max-w-full rounded-md object-contain ${turn.text ? 'mb-[10px]' : ''}`}
                           />
                         )}
-                        {turn.text && <MessageText text={turn.text} />}
+                        {turn.text && <MessageText text={turn.text} platform={turn.platform} />}
                       </div>
                     </div>
                     <ParticipantAvatar
@@ -3152,7 +3182,7 @@ export default function SessionDetailView() {
                               )}
                               {st.text && (
                                 <div className="whitespace-pre-wrap">
-                                  <MessageText text={st.text} />
+                                  <MessageText text={st.text} platform={st.platform} />
                                 </div>
                               )}
                               <StepExtras step={st} sessionId={sid} />
@@ -3202,7 +3232,7 @@ export default function SessionDetailView() {
                                             className="font-sans text-[13px] leading-[1.5]"
                                             style={{ fontWeight: st.weight, color: st.textColor }}
                                           >
-                                            <MessageText text={st.text} />
+                                            <MessageText text={st.text} platform={st.platform} />
                                           </div>
                                         )}
                                         <StepExtras step={st} sessionId={sid} />

--- a/packages/web/src/lib/conversation-merge.test.ts
+++ b/packages/web/src/lib/conversation-merge.test.ts
@@ -50,6 +50,24 @@ describe('duplicateIdentity', () => {
     expect(duplicateIdentity('slack', row({ kind: 'tool', ts: '1754123456.000200' }))).toBeNull()
     expect(duplicateIdentity('webchat', row({ kind: 'reasoning', postId: POST }))).toBeNull()
   })
+
+  it('dedupes nothing under a platform id no module claims', () => {
+    // The rule used to be Slack's for every unrecognized id, because Slack was
+    // the fall-through arm of the if-chain. The published module contract says
+    // the opposite — absent `messageIdentity` ⇒ never dedupe — and dedupe is
+    // the only step here that can delete a row, so the guess goes the other
+    // way now. A Slack-SHAPED ts under an unknown id is the case that changed.
+    for (const platform of ['linear', 'hook', 'github', 'playground', 'Slack', '']) {
+      expect(duplicateIdentity(platform, row({ ts: '1754123456.000200' })), platform).toBeNull()
+      expect(duplicateIdentity(platform, row({ postId: POST })), platform).toBeNull()
+    }
+    // Prototype keys are ids like any other — the registry is a Map, so they
+    // resolve to no module rather than to `Object.prototype`.
+    expect(duplicateIdentity('constructor', row({ ts: '1754123456.000200' }))).toBeNull()
+    expect(duplicateIdentity('__proto__', row({ ts: '1754123456.000200' }))).toBeNull()
+    // The registered ids keep theirs.
+    expect(duplicateIdentity('slack', row({ ts: '1754123456.000200' }))).toBe('ts:1754123456.000200')
+  })
 })
 
 describe('mergeConversation', () => {
@@ -180,6 +198,37 @@ describe('mergeConversation', () => {
     ])
     expect(merged.filter((m) => m.row.text === 'thread msg')).toHaveLength(1)
     expect(merged.map((m) => m.row.text).filter((t) => t.startsWith('a2a'))).toHaveLength(2)
+  })
+
+  it('keeps both copies when the platform id is one no module claims', () => {
+    // The blast radius of the fall-through removal, end to end: two sources of
+    // an unrecognized platform carrying the same Slack-shaped ts used to
+    // collapse into one row, and now render as two. Fail-open by design —
+    // "toward a visible duplicate, never toward data loss" (§6).
+    const platformTs = '1754123456.000200'
+    const merged = mergeConversation([
+      src(A, 'linear', [row({ sender: 'U-HUMAN', ts: platformTs, text: 'hello' })]),
+      src(B, 'linear', [row({ sender: 'U-HUMAN', ts: platformTs, text: 'hello' })])
+    ])
+    expect(merged).toHaveLength(2)
+  })
+
+  it('carries each row’s own source platform out of the merge', () => {
+    // The transcript resolves its text renderer from this key (§10), so it has
+    // to survive the interleave that mixes the sources up.
+    const merged = mergeConversation([
+      src(A, 'slack', [row({ ts: '1754123456.000100', text: 's1' }), row({ ts: '1754123458.000100', text: 's2' })]),
+      src(B, 'telegram', [
+        row({ ts: '4821', eventTimeUs: 1_754_123_457_000_000, text: 't1' }),
+        row({ ts: '4822', eventTimeUs: 1_754_123_459_000_000, text: 't2' })
+      ])
+    ])
+    expect(merged.map((m) => [m.row.text, m.sourcePlatform])).toEqual([
+      ['s1', 'slack'],
+      ['t1', 'telegram'],
+      ['s2', 'slack'],
+      ['t2', 'telegram']
+    ])
   })
 
   it('keeps the human copy from the first source when no author copy exists', () => {

--- a/packages/web/src/lib/conversation-merge.ts
+++ b/packages/web/src/lib/conversation-merge.ts
@@ -2,7 +2,15 @@
 // (merged-conversation-view.md §6). Pure functions over per-member message
 // pages so union/dedupe/ordering are unit-testable, mirroring how
 // webchat-lanes.ts isolates lane resolution.
+//
+// The one non-pure-lib import is the platform registry, which the per-platform
+// duplicate-identity rule now lives behind (§10). It costs no route its bundle:
+// unlike `lib/data.ts` — the reason `lib/platform-labels.ts` keeps its own
+// table — this module is imported by SessionDetailView alone, and the console
+// shell already mounts `ModalProvider` → `AddIntegrationModal` → the registry
+// on every route it renders.
 
+import { platformMessageIdentity } from '@/components/console/platforms/registry'
 import type { SessionMessageDto } from '@/lib/api'
 
 /** One member session's transcript page, in the order the daemon served it
@@ -23,6 +31,12 @@ export interface MergedRow {
   row: SessionMessageDto
   sourceSessionId: string
   sourceAgentId: string
+  /** The platform of the source this copy came from — the key the transcript
+   *  resolves its text renderer with (§10). Carried out of the merge rather
+   *  than re-derived by the caller so a row can never be rendered under a
+   *  neighbour's platform: sources interleave by event time, so this varies
+   *  ROW BY ROW and any per-conversation shortcut would be wrong. */
+  sourcePlatform: string
   /** Maximal owner-authored run in the source transcript. Conversation rendering
    *  uses this to preserve the same bot blocks a single-session page would build,
    *  even after another participant's private work interleaves by event time. */
@@ -87,38 +101,35 @@ function safeEventTimeUs(value: number): number {
   return Number.isSafeInteger(value) && value >= 0 ? value : 0
 }
 
-/** Provider-native message-id shapes per platform — each is the identity a
- *  duplicate shares across every member's copy, chosen so a daemon-local
- *  13-digit `monotonicTs()` millisecond stamp can NEVER match:
- *  Slack decimal seconds; Discord 16–20-digit snowflakes; Telegram short
- *  per-chat sequence ids (≤9 digits — the 10-digit legacy-seconds era and
- *  13-digit local stamps are both excluded); Feishu om_ ids. */
-const SLACK_NATIVE_TS = /^\d+\.\d+$/
-const DISCORD_SNOWFLAKE = /^\d{16,20}$/
-const TELEGRAM_MESSAGE_ID = /^\d{1,9}$/
-const FEISHU_MESSAGE_ID = /^om_[A-Za-z0-9_-]+$/
-
 /**
  * The provenance-explicit duplicate identity of a row, or null when the row
- * must never dedupe across sources (§6 step 2):
+ * must never dedupe across sources (§6 step 2). Two rules are CORE — they
+ * belong to no platform — and the third is the platform module's:
  *
  * - only `kind === 'text'` rows dedupe — a coincidental `ts` collision with a
  *   work-lane row is inert by construction;
  * - webchat: the canonical `postId` — minted once at origin, identical on
  *   every copy regardless of a collision-bumped `ts`. Rows without one
  *   (daemon-local a2a report-backs, pre-upgrade rows) never dedupe: failing
- *   toward a visible duplicate, never toward data loss;
- * - everything else: the provider-native decimal `ts` only — daemon-local
- *   millisecond rows are single-source by construction, and two daemons can
- *   mint the same millisecond for distinct rows.
+ *   toward a visible duplicate, never toward data loss. Webchat has no bot
+ *   identity to install and therefore no platform module, so this arm is the
+ *   host's for good;
+ * - everything else: the owning module's `messageIdentity` (§10) — the
+ *   provider-native id shape, chosen so a daemon-local 13-digit
+ *   `monotonicTs()` millisecond stamp can never match it.
+ *
+ * AN UNREGISTERED PLATFORM ID NOW DEDUPES NOTHING. It used to take Slack's
+ * decimal-`ts` rule, purely because Slack sat in the fall-through arm of an
+ * if-chain; the published contract says the opposite (absent ⇒ never dedupe),
+ * and the contract is right. Deduping is the only step here that can DELETE a
+ * row from the transcript, so guessing that an unknown provider numbers its
+ * messages the way Slack does is a guess in the one direction §6 forbids —
+ * "toward a visible duplicate, never toward data loss".
  */
 export function duplicateIdentity(platform: string, row: SessionMessageDto): string | null {
   if (row.kind !== 'text') return null
   if (platform === 'webchat') return row.postId ? `post:${row.postId}` : null
-  if (platform === 'discord') return DISCORD_SNOWFLAKE.test(row.ts) ? `ts:${row.ts}` : null
-  if (platform === 'telegram') return TELEGRAM_MESSAGE_ID.test(row.ts) ? `ts:${row.ts}` : null
-  if (platform === 'feishu') return FEISHU_MESSAGE_ID.test(row.ts) ? `ts:${row.ts}` : null
-  return SLACK_NATIVE_TS.test(row.ts) ? `ts:${row.ts}` : null
+  return platformMessageIdentity(platform, row)
 }
 
 /**
@@ -147,6 +158,7 @@ export function mergeConversation(sources: MergeSource[]): MergedRow[] {
         row,
         sourceSessionId: source.sessionId,
         sourceAgentId: source.agentId,
+        sourcePlatform: source.platform,
         ...(authorCopy ? { sourceTurnKey: `${source.sessionId}\u0000${sourceTurn}` } : {}),
         authorCopy,
         // Prefer the daemon's stored axis (provider-authoritative for
@@ -183,10 +195,11 @@ export function mergeConversation(sources: MergeSource[]): MergedRow[] {
     if (a.sourceSessionId !== b.sourceSessionId) return a.sourceSessionId < b.sourceSessionId ? -1 : 1
     return a.order - b.order
   })
-  return kept.map(({ row, sourceSessionId, sourceAgentId, sourceTurnKey, authorCopy }) => ({
+  return kept.map(({ row, sourceSessionId, sourceAgentId, sourcePlatform, sourceTurnKey, authorCopy }) => ({
     row,
     sourceSessionId,
     sourceAgentId,
+    sourcePlatform,
     ...(sourceTurnKey ? { sourceTurnKey } : {}),
     authorCopy
   }))

--- a/packages/web/src/lib/session-transcript.test.ts
+++ b/packages/web/src/lib/session-transcript.test.ts
@@ -8,12 +8,12 @@ function message(seq: number, ts: string, text: string): SessionMessageDto {
 }
 
 describe('mergeSessionMessages', () => {
-  it('upserts stable rows and restores chronological Slack order after a backfill', () => {
+  it('upserts stable rows and restores chronological order after a backfill', () => {
     const current = [message(1, '1784098843.000000', 'trigger'), message(2, '1784098844000', 'running')]
     const merged = mergeSessionMessages(
       current,
       [message(2, '1784098844000', 'complete'), message(3, '1784098711.000000', 'backfilled')],
-      'slack'
+      'event-time'
     )
 
     expect(merged.map(({ seq, text }) => [seq, text])).toEqual([
@@ -21,6 +21,18 @@ describe('mergeSessionMessages', () => {
       [1, 'trigger'],
       [2, 'complete']
     ])
+  })
+
+  it('trusts the daemon sequence under the conservative ordering', () => {
+    // The arm every platform but Slack takes (§10 `transcriptOrdering`), and
+    // the one an unrecognized platform id resolves to. Same upsert, no re-sort.
+    const merged = mergeSessionMessages(
+      [message(1, '1784098843.000000', 'trigger')],
+      [message(3, '1784098711.000000', 'backfilled'), message(2, '1784098844000', 'running')],
+      'seq'
+    )
+
+    expect(merged.map(({ seq }) => seq)).toEqual([1, 2, 3])
   })
 })
 

--- a/packages/web/src/lib/session-transcript.ts
+++ b/packages/web/src/lib/session-transcript.ts
@@ -4,17 +4,32 @@ import { transcriptRowTimeMs } from '@/lib/transcript-time'
 
 const LIVE_TURN_CONFIRM_WINDOW_MS = 5 * 60_000
 
-/** Upsert stable transcript rows and restore the platform's display ordering. */
+/**
+ * Upsert stable transcript rows and restore the requested display ordering.
+ *
+ * `ordering` replaces the `platform !== 'slack'` literal this used to carry:
+ * it is the owning platform module's `transcriptOrdering` (§10), resolved by
+ * the caller through `platformTranscriptOrdering`. Same two arms and the same
+ * platforms in each — a module that declares nothing, and every id no module
+ * claims, takes `'seq'`.
+ *
+ * The RESOLUTION deliberately stays at the call site rather than moving in
+ * here: this module is shared with `PlaygroundProvider` (for
+ * `reconcilePersistedLiveSteps`), and a registry import would pull all four
+ * platform modules — wizard panes and CP bindings included — into the
+ * playground's graph for a value it never reads. Same trade `lib/data.ts`
+ * makes by keeping `lib/platform-labels.ts` out of the registry.
+ */
 export function mergeSessionMessages(
   current: SessionMessageDto[],
   incoming: SessionMessageDto[],
-  platform: string
+  ordering: 'seq' | 'event-time'
 ): SessionMessageDto[] {
   if (incoming.length === 0) return current
   const bySeq = new Map(current.map((message) => [message.seq, message]))
   for (const message of incoming) bySeq.set(message.seq, message)
   return [...bySeq.values()].sort((a, b) => {
-    if (platform !== 'slack') return a.seq - b.seq
+    if (ordering !== 'event-time') return a.seq - b.seq
     return (transcriptRowTimeMs(a) ?? 0) - (transcriptRowTimeMs(b) ?? 0) || a.seq - b.seq
   })
 }


### PR DESCRIPTION
## What

The last web unit of the S3 platform adoption (§10/§14). #604 moved marks, settings fragments, channel-list semantics, api bindings and the helper libs into `platforms/<id>/` and deliberately left the three transcript-domain members behind, because they live in the same module objects and need call-site work of their own. This lands all three.

**`textRenderer`** — `MessageText` now resolves its renderer from the **row's** platform key instead of hardcoding one global renderer, through `platformTextRenderer` in the registry. **No module declares an override**, which is the state §10 asks for: "a renderer registry keyed by platformId ships with the Slack renderer as the default for all chat platforms, then per-platform overrides land separately (§14)."

The lookup happens inside the memoized per-row component, not hoisted to the page or the turn. A merged conversation interleaves sources by event time, so a hoisted lookup would render one platform's rows with another platform's semantics — silently, and only for users who merged two platforms into one conversation. To make that unhoistable by construction, `mergeConversation` now carries each row's `sourcePlatform` out with it (alongside `sourceSessionId`), so the view cannot pair a row with a neighbour's key; the transcript threads it through `FmtStep` and the user turn to the three call sites.

The default renderer stays **core** rather than becoming the Slack module's member: three other platforms render through it, and as Slack's member it would leave Telegram, Discord and Feishu reaching into another module's internals. It moves into `platforms/slack/` with the first real override — which is also the first change here with visible pixels.

The member keeps the `ComponentType<{ text: string }>` shape #604 published rather than §10's sketched `(text, ctx) => ReactNode`. The memo boundary has to sit outside the per-platform work — the transcript re-renders on every unrelated state change in `SessionDetailView`, and without memo every row re-runs its whole remark pipeline — and no call site has a `ctx` to pass.

**`messageIdentity` and `transcriptOrdering`** — moved into the four modules the same way. One correction to #604's handoff note: **they are not test-only.** `mergeConversation` and `mergeSessionMessages` are both live through `SessionDetailView.tsx`, which contains a NUL byte, so plain `grep` reports "binary file" and silently omits it from results — `grep -a` shows the callers. Worth knowing for anyone auditing that file's call sites.

`session-transcript.ts` takes the resolved `'seq' | 'event-time'` instead of the platform id, and the caller resolves. It is shared with `PlaygroundProvider` (for `reconcilePersistedLiveSteps`), and a registry import there would pull all four platform modules — wizard panes and CP bindings included — into the playground's graph for a value it never reads. Same trade `lib/platform-labels.ts` documents. `conversation-merge.ts` does read the registry: its rule is applied per row inside the merge loop, and its only consumer is the transcript view.

## Tests

`GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/web test` — **105 files / 817 passed** (main: 102 / 778). `pnpm --filter @agentconnect.md/web exec tsc -p tsconfig.json --noEmit` clean; eslint clean on every touched file.

- **`MessageText.test.tsx`** (new, 28 tests) — a 26-entry mrkdwn corpus covering link rewriting (bare / labelled / metacharacter-escaped labels / mailto / non-http), user, channel and subteam mentions, emoji shortcodes, inline and fenced code shielding control tokens, emphasis, GFM tables and task lists, soft breaks, entity decoding, and the size-cap bypass. Each entry pins the **exact markup captured from the pre-registry renderer**, and a second case re-asserts every entry against 13 platform keys — the four registered ids, the core session kinds, unclaimed ids, prototype keys, `''` and `undefined`. Byte-identity was established by rendering the corpus through `origin/main`'s component side by side before the expectations were written down.
- **`platforms/text-renderer.test.tsx`** (new, 3 tests) — the per-row claim, with stand-in overrides installed since the shipped registry has none. Two sources interleave to `s1, d1, s2, d2` through the real `mergeConversation`; the assertion is that the rendered markup alternates renderers in that order. Plus an unknown key falling back to the default *between* two overridden rows, and two rows with identical text but different platforms resolving separately (memo does not leak one row's renderer onto the next).
- **`platforms/transcript.test.ts`** (new, 4 tests) — the three lookups against the real registry: no module has a `textRenderer` yet (this expectation changes with the first override, by design), each registered platform's native id shape, unclaimed ids deduping nothing, and Slack alone ordering by event time.
- **`conversation-merge.test.ts`** — the unknown-id arm at both levels (the predicate, and a merge that now keeps both copies), prototype-key ids, and `sourcePlatform` surviving the interleave. Existing known-id cases unchanged.
- **`session-transcript.test.ts`** — both ordering arms against the new parameter.

## Behavior

**Text rendering: nothing changes, deliberately.** Every platform still renders through the same Slack-mrkdwn pipeline, byte for byte — that is what the corpus test pins. What changed is where the renderer comes from. The day an override lands, exactly one platform's transcript rows change and every other platform's stay on the default; that PR gets its own visual review, and `platforms/transcript.test.ts`'s "no platform has a renderer yet" assertion is the tripwire that forces the change to be declared rather than absorbed.

**`duplicateIdentity`: unregistered platform ids stop deduping — a real, intended change.** Today Slack is the *fall-through* arm of the id chain, so a row under any unrecognized platform id gets Slack's decimal-`ts` rule; the published contract says the opposite, that an absent `messageIdentity` means the platform never dedupes. Those are opposite semantics and only one can survive the move.

The contract is right, and the deciding argument is asymmetry of harm. Deduping is the only step in the merge that can **remove** a row from the transcript, and §6 states its own direction for that: "toward a visible duplicate, never toward data loss." Keeping Slack as the fall-through means asserting that an unknown provider numbers its messages the way Slack does — a guess, in the one direction the merge forbids guessing. Losing the fall-through costs at most a duplicate row that is visibly a duplicate. It is also the only reading under which `messageIdentity` is a real module member: if the absent case silently means "use Slack's", then Slack is still the implicit default for every platform, which is §14 defect 3 wearing a registry.

Blast radius, precisely. A merged conversation containing a row whose source platform id is **not** `slack`/`telegram`/`discord`/`feishu`/`webchat` **and** whose `ts` is Slack-shaped (`^\d+\.\d+$`) previously collapsed duplicate copies of that row across member sessions; it now shows one copy per member. Everything else is untouched: the five known ids keep their exact rules, the `kind !== 'text'` guard and the `webchat`-`postId` rule stay core (webchat has no bot identity to install and therefore no module), and rows whose source platform is missing already default to `'slack'` at all three `MergeSource` construction sites, so they are unaffected. In practice only Slack mints decimal-seconds ids — daemon-local rows are 13-digit ms, hook rows carry a `|delivery-id` suffix, neither matches — so a row that satisfies both conditions today means a platform id the console does not know about, which is exactly the case where guessing an id shape is least defensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
