### PR TITLE
refactor(web): the Profile card and the two Slack-flavoured bot-row sentences move behind the contract (S3 §10)

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -84,11 +84,6 @@
   --blue-500: #2f6fed;
   --blue-50: #ebf1fe;
 
-  /* IM platform brand accents */
-  --slack: #4a154b;
-  --telegram: #229ed9;
-  --discord: #5865f2;
-
   /* Surfaces */
   --surface-app: var(--gray-25);
   --surface-card: var(--gray-0);
@@ -271,11 +266,6 @@
   /* Agent tones — lifted like the other hues so a 15% mix stays legible on dark. */
   --teal-500: #35c7ba;
   --indigo-500: #8b8df0;
-
-  /* IM platform soft accents re-tuned for dark chips */
-  --slack-soft: rgba(163, 92, 168, 0.22);
-  --telegram-soft: rgba(34, 158, 217, 0.2);
-  --discord-soft: rgba(96, 108, 245, 0.24);
 
   /* Shadows deepen on dark */
   --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.45);
@@ -2939,8 +2929,9 @@
   }
 }
 
-/* Slack manifest hover-preview: blink the highlighted "From a manifest" tile. */
-@keyframes slackHintBlink {
+/* Walkthrough previews: blink the highlighted step (the Slack manifest tile, the
+   Telegram setup row — one effect, no platform of its own). */
+@keyframes stepBlink {
   0%,
   100% {
     opacity: 1;
@@ -3072,9 +3063,6 @@
    CSS optimizer keeps them. Tailwind arbitrary `animate-[name_…]` utilities live in a
    separate output the optimizer can't see as a reference, so it would otherwise prune
    these @keyframes and the animations would silently not play. */
-.slack-hint-blink {
-  animation: slackHintBlink 1.1s ease-in-out infinite;
-}
 .cfg-scroll {
   animation: cfgScroll 4.6s ease-in-out infinite;
 }
@@ -3085,7 +3073,7 @@
   animation: cfgClickB 4.6s ease-in-out infinite;
 }
 .step-blink {
-  animation: slackHintBlink 1.1s ease-in-out infinite;
+  animation: stepBlink 1.1s ease-in-out infinite;
 }
 .step-pulse {
   animation: stepPulse 1.5s ease-in-out infinite;
@@ -3096,9 +3084,6 @@
    Copy-pulse rings are hidden, and the manifest tile keeps its (static) highlight. The
    bot-setup walkthroughs stop auto-advancing (see their interval) and keep a static highlight. */
 @media (prefers-reduced-motion: reduce) {
-  .slack-hint-blink {
-    animation: none;
-  }
   .step-blink {
     animation: none;
   }

--- a/packages/web/src/components/console/platforms/bot-card-copy.test.ts
+++ b/packages/web/src/components/console/platforms/bot-card-copy.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_BOT_CARD_COPY, botCardCopy, platformRegistry } from './registry'
+
+/**
+ * The two sentences the Settings → Bots card writes into chrome the HOST owns
+ * (§10 `settingsFragments.copy`). Both shipped as Slack's model rendered over
+ * EVERY platform's rows, so what these pin is the split: Slack's wording
+ * unchanged to the byte, and a provider-free default everywhere else.
+ */
+const UNCLAIMED = ['linear', 'hook', 'github', 'playground', 'webchat', 'lark', 'Slack', 'constructor', '__proto__', '']
+
+/** Captured from `SettingsView.tsx` before the member existed. */
+const SLACK_REVOKED = 'The Slack workspace uninstalled this app or revoked its tokens — re-install to reconnect'
+const SLACK_SHARE_AVAILABLE = 'Allow several agents to share this bot across channels'
+const SLACK_SHARE_UNAVAILABLE = 'HTTP transport required to share'
+
+const PLATFORM_WORDS = /slack|telegram|discord|feishu|lark/i
+
+describe('Settings → Bots row copy', () => {
+  it('leaves Slack’s two sentences byte-identical', () => {
+    // Slack is the only platform whose rows could reach either state, so it is
+    // the only one whose copy this refactor must not move.
+    const copy = botCardCopy('slack')
+    expect(copy.revokedHint).toBe(SLACK_REVOKED)
+    expect(copy.shareHint.available).toBe(SLACK_SHARE_AVAILABLE)
+    expect(copy.shareHint.unavailable).toBe(SLACK_SHARE_UNAVAILABLE)
+  })
+
+  it('gives every other registered platform the provider-free default', () => {
+    for (const id of platformRegistry.ids().filter((p) => p !== 'slack')) {
+      const copy = botCardCopy(id)
+      expect(copy.revokedHint, id).toBe(DEFAULT_BOT_CARD_COPY.revokedHint)
+      expect(copy.shareHint, id).toEqual(DEFAULT_BOT_CARD_COPY.shareHint)
+    }
+    // Named, so a module that starts declaring one is a visible diff here.
+    expect(
+      platformRegistry
+        .all()
+        .filter((m) => m.settingsFragments?.copy)
+        .map((m) => m.platformId)
+    ).toEqual(['slack'])
+  })
+
+  it('names no platform in either default', () => {
+    // The whole defect was a provider's vocabulary leaking onto other
+    // providers' rows; a default that names one would reintroduce it.
+    expect(DEFAULT_BOT_CARD_COPY.revokedHint).not.toMatch(PLATFORM_WORDS)
+    expect(DEFAULT_BOT_CARD_COPY.shareHint.available).not.toMatch(PLATFORM_WORDS)
+    expect(DEFAULT_BOT_CARD_COPY.shareHint.unavailable).not.toMatch(PLATFORM_WORDS)
+  })
+
+  it('collapses both share arms for a platform that cannot share at all', () => {
+    // The host still picks an arm by transport, but multi-agent bots are
+    // Slack-only at the CP — so on every other platform the arm the host lands
+    // on is not the reason, and one sentence must serve both rather than
+    // promising that switching transport would help.
+    expect(DEFAULT_BOT_CARD_COPY.shareHint.available).toBe(DEFAULT_BOT_CARD_COPY.shareHint.unavailable)
+    for (const id of ['telegram', 'discord', 'feishu']) {
+      const { available, unavailable } = botCardCopy(id).shareHint
+      expect(available, id).toBe(unavailable)
+    }
+    // Slack's two arms stay genuinely different — it is the one platform where
+    // the transport really is why the toggle is off.
+    expect(SLACK_SHARE_AVAILABLE).not.toBe(SLACK_SHARE_UNAVAILABLE)
+  })
+
+  it('answers for a platform id no module claims, and for none at all', () => {
+    // A bot row carries whatever platform the CP sent, so the lookup is total —
+    // the same reason `channelListSemantics` is.
+    for (const id of UNCLAIMED) {
+      expect(botCardCopy(id), id).toEqual(DEFAULT_BOT_CARD_COPY)
+    }
+    expect(botCardCopy(undefined)).toEqual(DEFAULT_BOT_CARD_COPY)
+  })
+
+  it('defaults each member on its own', () => {
+    // A module may name the revocation it can actually reach without also
+    // having to restate the share sentence, and vice versa.
+    const partial = platformRegistry.get('slack')!.settingsFragments!.copy!
+    expect(partial.revokedHint).toBeDefined()
+    expect(partial.shareHint).toBeDefined()
+    expect(Object.keys(DEFAULT_BOT_CARD_COPY).sort()).toEqual(['revokedHint', 'shareHint'])
+  })
+})

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -349,9 +349,51 @@ export interface WebWizardFacet {
 }
 
 /**
+ * Copy the Settings → Bots card writes into chrome the HOST owns — the two
+ * sentences on a bot row that describe a PROVIDER's model rather than
+ * AgentConnect's. Deliberately NOT {@link WebBotSettingsFragments.botCard}
+ * components: the host renders the `revoked` badge and the Sharable cell and
+ * owns the conditions under which each appears, so what a module supplies here
+ * is the wording, not the element.
+ *
+ * Both members are optional and both host defaults are provider-free, because
+ * both strings shipped as Slack's model rendered for EVERY platform: the badge
+ * tooltip named a "Slack workspace" over a Telegram bot, and the toggle told a
+ * Discord bot to switch to a transport Discord does not have.
+ */
+export interface WebBotCardCopy {
+  /**
+   * Tooltip on the `revoked` badge (SettingsView.tsx:1085-1092), rendered
+   * whenever `BotDto.revokedAt` is set.
+   *
+   * Absent ⇒ the host's provider-free sentence, which is the honest answer for
+   * every platform but Slack rather than a placeholder: `revokedAt` is written
+   * by exactly one path, `rc/bot-revoked`, whose reason enum IS Slack's app
+   * lifecycle (`app_uninstalled` / `tokens_revoked`,
+   * protocol/src/frames/relay-cp.ts). No other platform can reach the state
+   * today, so no other module should invent prose about how it got there.
+   */
+  revokedHint?: string
+  /**
+   * Tooltip on the Sharable toggle (:1095-1109), per arm — the HOST picks
+   * which arm by its own predicate (`(bot.transport ?? 'socket') === 'socket'`),
+   * exactly as {@link WebWizardFacet.identityCards} hands over both mode-card
+   * sentences and lets the host choose.
+   *
+   * Absent ⇒ ONE host sentence used for BOTH arms, and the collapse is the
+   * point rather than an economy: multi-agent bots are Slack-only at the
+   * server ("multi-agent bots currently support Slack only",
+   * control-plane http/routes/integrations.ts), so on every other platform the
+   * transport arm the host lands on is not the reason sharing is unavailable
+   * — and two different sentences would promise that switching transport helps.
+   */
+  shareHint?: { available: string; unavailable: string }
+}
+
+/**
  * Settings → Bots fragments (§10 `settingsFragments`), split along the real
- * division in `SettingsView.tsx`: pure per-bot adornments vs the stateful
- * maintenance machinery.
+ * division in `SettingsView.tsx`: pure per-bot adornments, the stateful
+ * maintenance machinery, and the copy the host renders into its own chrome.
  *
  * THE CARD STATE IS THE MODULE'S, NOT A HOST PROP. This interface was published
  * with a `TCardState` type parameter — `useCardState()` returning it and the
@@ -418,6 +460,9 @@ export interface WebBotSettingsFragments {
      *  guard, exactly where both sit today. */
     CardNotice?: ComponentType<{ bot: BotDto }>
   }
+  /** Wording for the two host-rendered row sentences. See
+   *  {@link WebBotCardCopy}; absent ⇒ both provider-free host defaults. */
+  copy?: WebBotCardCopy
 }
 
 /** One install-polling flow's public state — the exact shape of
@@ -526,12 +571,37 @@ export interface WebPlatformModule<TApi = unknown> {
    * `lib/api.ts` from "the typed CP client" to "a request kit any module may
    * build on", which is a bigger contract change than this member is asking
    * for. The seam is what matters: every module-side caller goes through here,
-   * so S4 can move the bodies without touching a call site. One direct caller
-   * remains outside a module — `SlackConfigCard`, which is a PROFILE-page card
-   * (the per-user Slack App Configuration token) and has no member here,
-   * because `settingsFragments` is scoped to Settings → Bots.
+   * so S4 can move the bodies without touching a call site. NO platform-named
+   * caller remains in core: the last one, `SlackConfigCard`, was a Profile-page
+   * card with nowhere to land while `settingsFragments` was the only settings
+   * member and it is scoped to Settings → Bots. It now lives behind
+   * {@link WebPlatformModule.ProfileCredentialCard} and reads the CP through
+   * these bindings like every other surface of its module.
    */
   apiBindings: TApi
+  /**
+   * The signed-in USER's own provider tooling credential, as a card on the
+   * Profile page — today Slack's App Configuration token
+   * (`platforms/slack/profile.tsx`, docs/designs/slack-install-smoothing.md
+   * §Tier B), which is what lets the install wizard create apps as YOU. The
+   * host renders these in registry order (`platforms/profile.tsx`, mounted by
+   * `ProfileView` in both its responsive branches); absent ⇒ the platform
+   * contributes no Profile card, which is every platform but Slack.
+   *
+   * A member of its own rather than a `settingsFragments` sibling because the
+   * two surfaces differ in SCOPE, not just in page: `settingsFragments` adorns
+   * the organization's durable bot identities, while this credential is
+   * per-USER (`GET/PUT/DELETE /slack/config` answers for the calling
+   * principal) and belongs to no bot row at all.
+   *
+   * Deliberately NOT solved by {@link apiBindings}: that member is opaque to
+   * the host by construction, so routing the card's three calls through it
+   * would have made the host the single caller of the one member no host code
+   * may call — and would have left the platform-named component itself sitting
+   * in `components/console/`. What this card was missing was a HOME, not a
+   * client seam.
+   */
+  ProfileCredentialCard?: ComponentType
   /** Out-of-wizard install polling (Slack today). */
   installPolling?: WebInstallPollingFacet
   /** Channel-list display semantics. Absent ⇒ the host defaults: `channel`

--- a/packages/web/src/components/console/platforms/profile.test.tsx
+++ b/packages/web/src/components/console/platforms/profile.test.tsx
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { WebPlatformModule } from './contract'
+import { PlatformCredentialCards } from './profile'
+
+/**
+ * `ProfileCredentialCard` (§10) — the member `SlackConfigCard` landed behind
+ * when it stopped being the last direct core caller of a platform-named
+ * `lib/api` export.
+ *
+ * The RENDER claims run against stand-ins, because the shipped registry has
+ * exactly one card and the thing worth pinning is what happens around it: a
+ * platform that declares none must contribute nothing at all — no wrapper, no
+ * separator, no empty card — which is precisely what the Profile page did
+ * before this list existed. The DECLARATION claim runs against the real
+ * registry.
+ */
+const { stubs } = vi.hoisted(() => ({ stubs: [] as WebPlatformModule[] }))
+
+vi.mock('@/components/console/platforms/registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./registry')>()
+  return { ...actual, platformRegistry: { ...actual.platformRegistry, all: () => stubs } }
+})
+
+/** Only `platformId` and the card are read; the rest of the module never
+ *  reaches this surface. */
+function stub(platformId: string, card?: () => React.ReactElement): WebPlatformModule {
+  return { platformId, ...(card ? { ProfileCredentialCard: card } : {}) } as unknown as WebPlatformModule
+}
+
+describe('per-platform Profile credential cards', () => {
+  it('renders nothing for a platform that declares no card', () => {
+    stubs.length = 0
+    stubs.push(stub('telegram'), stub('discord'))
+    expect(renderToStaticMarkup(<PlatformCredentialCards />)).toBe('')
+  })
+
+  it('renders nothing at all when no platform declares one', () => {
+    stubs.length = 0
+    expect(renderToStaticMarkup(<PlatformCredentialCards />)).toBe('')
+  })
+
+  it('renders the declared cards in registry order, skipping the rest', () => {
+    stubs.length = 0
+    stubs.push(
+      stub('slack', () => <i>slack-card</i>),
+      stub('telegram'),
+      stub('discord'),
+      stub('feishu', () => <i>feishu-card</i>)
+    )
+    expect(renderToStaticMarkup(<PlatformCredentialCards />)).toBe('<i>slack-card</i><i>feishu-card</i>')
+  })
+
+  it('declares the card on Slack alone in the shipped registry', async () => {
+    // Per-USER tooling credentials, not org bot identities: Slack's App
+    // Configuration token is the only one a platform asks its installer for.
+    const { platformRegistry } = await vi.importActual<typeof import('./registry')>('./registry')
+    expect(
+      platformRegistry
+        .all()
+        .filter((m) => m.ProfileCredentialCard)
+        .map((m) => m.platformId)
+    ).toEqual(['slack'])
+  })
+})

--- a/packages/web/src/components/console/platforms/profile.tsx
+++ b/packages/web/src/components/console/platforms/profile.tsx
@@ -1,0 +1,29 @@
+// No 'use client' here: rendered from ProfileView, which is already a client
+// component; the cards themselves declare their own boundary.
+
+import { platformRegistry } from './registry'
+
+/**
+ * Every platform module's Profile-page credential card
+ * ({@link WebPlatformModule.ProfileCredentialCard}), in registry order.
+ *
+ * Slack's App Configuration token is the only one today, and a platform that
+ * declares none contributes nothing — no heading, no empty card, no separator —
+ * which is exactly what the Profile page rendered before this list existed.
+ *
+ * Reading the registry from a Profile-page component costs no bundle: the
+ * console shell mounts `ModalProvider` on every route, and it already pulls
+ * `registry.ts` in through `AddIntegrationModal`. That is why this lookup can
+ * go through the registry while `platforms/marks.ts` and `lib/platform-labels.ts`
+ * deliberately cannot — those are reached from the signed-out routes, which
+ * have no modal tree.
+ */
+export function PlatformCredentialCards() {
+  return (
+    <>
+      {platformRegistry
+        .all()
+        .map(({ platformId, ProfileCredentialCard: Card }) => (Card ? <Card key={platformId} /> : null))}
+    </>
+  )
+}

--- a/packages/web/src/components/console/platforms/registry.ts
+++ b/packages/web/src/components/console/platforms/registry.ts
@@ -2,7 +2,7 @@
 
 import type { ComponentType } from 'react'
 import type { SessionMessageDto } from '@/lib/api'
-import type { WebChannelListSemantics, WebPlatformModule, WebPlatformRegistry } from './contract'
+import type { WebBotCardCopy, WebChannelListSemantics, WebPlatformModule, WebPlatformRegistry } from './contract'
 import { discordModule } from './discord'
 import { feishuModule } from './feishu'
 import { slackModule } from './slack'
@@ -46,6 +46,39 @@ export const DEFAULT_CHANNEL_LIST: WebChannelListSemantics = {
 /** One platform's channel-list display semantics, defaulted. */
 export function channelListSemantics(platformId?: string): WebChannelListSemantics {
   return (platformId ? platformRegistry.get(platformId)?.channelList : undefined) ?? DEFAULT_CHANNEL_LIST
+}
+
+/**
+ * The Settings → Bots row copy every platform gets unless its module says
+ * otherwise — provider-free by construction, because the strings these replace
+ * described Slack's model on every platform's rows.
+ *
+ * `shareHint`'s two arms are the SAME sentence here on purpose. The host picks
+ * an arm by transport, but multi-agent bots are Slack-only at the CP, so for a
+ * platform that declares nothing the transport arm is not the reason sharing is
+ * unavailable and a second sentence would promise a fix that does not exist.
+ */
+export const DEFAULT_BOT_CARD_COPY: Required<WebBotCardCopy> = {
+  revokedHint: 'This bot’s credentials were revoked — re-install to reconnect',
+  shareHint: {
+    available: 'Sharing one bot across several agents isn’t available on this platform',
+    unavailable: 'Sharing one bot across several agents isn’t available on this platform'
+  }
+}
+
+/**
+ * One platform's Settings → Bots row copy, defaulted member by member: a module
+ * may name the revocation it can actually reach without also having to restate
+ * the share sentence, and vice versa. `IntegrationChannelList`'s lookup is total
+ * for the same reason this one is — a bot row carries whatever platform the CP
+ * sent.
+ */
+export function botCardCopy(platformId?: string): Required<WebBotCardCopy> {
+  const copy = platformId ? platformRegistry.get(platformId)?.settingsFragments?.copy : undefined
+  return {
+    revokedHint: copy?.revokedHint ?? DEFAULT_BOT_CARD_COPY.revokedHint,
+    shareHint: copy?.shareHint ?? DEFAULT_BOT_CARD_COPY.shareHint
+  }
 }
 
 /**

--- a/packages/web/src/components/console/platforms/slack/api.ts
+++ b/packages/web/src/components/console/platforms/slack/api.ts
@@ -1,6 +1,7 @@
 // No 'use client' here: reached only from ModalProvider's tree (the client boundary).
 
 import {
+  deleteSlackConfig,
   fetchSlackConfig,
   getSlackInstall,
   getSlackPlatformInstall,
@@ -26,6 +27,11 @@ import {
  * `useConsoleData().finalizeSlackInstall`, which also refreshes the console's
  * integration/bot projections — the same reason a create commits through
  * {@link WizardHost.createIntegration}.
+ *
+ * `saveConfig`/`clearConfig` are the Profile card's writes
+ * ({@link WebPlatformModule.ProfileCredentialCard}, `./profile.tsx`): the same
+ * per-user config token the funnel reads, maintained on the page where its
+ * owner lives.
  */
 export const slackApi = {
   startInstall: startSlackInstall,
@@ -34,6 +40,7 @@ export const slackApi = {
   getPlatformInstall: getSlackPlatformInstall,
   readConfig: fetchSlackConfig,
   saveConfig: saveSlackConfig,
+  clearConfig: deleteSlackConfig,
   refreshBot: refreshSlackBot
 }
 

--- a/packages/web/src/components/console/platforms/slack/index.tsx
+++ b/packages/web/src/components/console/platforms/slack/index.tsx
@@ -5,6 +5,7 @@ import { inviteBotHint } from '../wizard-chrome'
 import { slackApi, type SlackApi } from './api'
 import { SlackWizardBody, SLACK_TRANSPORT_LABEL } from './Body'
 import { SlackMark } from './mark'
+import { SlackConfigCard } from './profile'
 import { slackSettingsFragments } from './settings'
 import { useSlackPlatformInstall } from './use-platform-install'
 
@@ -44,6 +45,9 @@ export const slackModule: WebPlatformModule<SlackApi> = {
   },
   settingsFragments: slackSettingsFragments,
   apiBindings: slackApi,
+  // The caller's OWN App Configuration token — per-user, so it lives on Profile
+  // rather than on any bot row. Slack is the only platform with one.
+  ProfileCredentialCard: SlackConfigCard,
   installPolling: { useInstallPoll: useSlackPlatformInstall },
   channelList: {
     roomNoun: 'channel',

--- a/packages/web/src/components/console/platforms/slack/previews.tsx
+++ b/packages/web/src/components/console/platforms/slack/previews.tsx
@@ -20,7 +20,7 @@ export function SlackManifestPreview() {
         </div>
         <div className="grid grid-cols-2 gap-2">
           <div className="relative rounded-lg bg-white p-2.5">
-            <span className="pointer-events-none absolute rounded-lg inset-0 slack-hint-blink rounded-[10px] ring-2 ring-[#1264a3]" />
+            <span className="pointer-events-none absolute rounded-lg inset-0 step-blink rounded-[10px] ring-2 ring-[#1264a3]" />
             <span className="mb-1.5 flex h-6 w-6 items-center justify-center rounded-md bg-[#f4f4f4] text-[#454545]">
               <Icon name="scroll-text" size={14} />
             </span>

--- a/packages/web/src/components/console/platforms/slack/profile.tsx
+++ b/packages/web/src/components/console/platforms/slack/profile.tsx
@@ -13,11 +13,17 @@
 // + normalizes on save and never returns them; this card only ever sees status.
 // Org-scoped (keyed by the active org), so the fetch waits for OrgProvider to resolve —
 // mirroring the org-gated pattern the rest of the console uses.
+//
+// The Slack module's `ProfileCredentialCard` (§10). It was the last direct core
+// caller of a platform-named `lib/api` export; the CP calls now go through the
+// module's own `slackApi` bindings, and `ProfileView` reaches it through the
+// registry instead of importing a Slack-named component.
 
 import { useEffect, useState } from 'react'
 import { Button, Icon } from '@/components/ui'
-import { fetchSlackConfig, saveSlackConfig, deleteSlackConfig, fmtDate, type SlackConfigDto } from '@/lib/api'
+import { fmtDate, type SlackConfigDto } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
+import { slackApi } from './api'
 
 const EMPTY: SlackConfigDto = {
   configured: false,
@@ -30,7 +36,7 @@ const EMPTY: SlackConfigDto = {
   updatedAt: null
 }
 
-export default function SlackConfigCard() {
+export function SlackConfigCard() {
   // Gate the org-scoped fetch on the active org: on a hard refresh `orgBase()` throws
   // "no active organization" until OrgProvider resolves it, so a bare mount-fetch would
   // catch → show "Not configured" even when it IS. Re-fetch when it resolves.
@@ -46,7 +52,8 @@ export default function SlackConfigCard() {
     if (!activeOrg) return
     let alive = true
     setStatus('loading')
-    fetchSlackConfig()
+    slackApi
+      .readConfig()
       .then((s) => alive && setStatus(s))
       .catch(() => alive && setStatus(EMPTY))
     return () => {
@@ -63,7 +70,7 @@ export default function SlackConfigCard() {
     try {
       const refreshTrim = refresh.trim()
       setStatus(
-        await saveSlackConfig({
+        await slackApi.saveConfig({
           accessToken: access.trim(),
           ...(refreshTrim ? { refreshToken: refreshTrim } : {})
         })
@@ -83,7 +90,7 @@ export default function SlackConfigCard() {
     setBusy(true)
     setErr(null)
     try {
-      await deleteSlackConfig()
+      await slackApi.clearConfig()
       setStatus(EMPTY)
       setEditing(false)
     } catch (e) {

--- a/packages/web/src/components/console/platforms/slack/settings.tsx
+++ b/packages/web/src/components/console/platforms/slack/settings.tsx
@@ -333,5 +333,19 @@ export const slackSettingsFragments: WebBotSettingsFragments = {
     CardProvider: SlackBotCardProvider,
     RowActions: SlackRowActions,
     CardNotice: SlackCardNotice
+  },
+  // The two host-rendered row sentences, which USED to be these exact strings
+  // for every platform. Slack is the only module that declares either, and both
+  // are unchanged: it is the only platform whose bots can be revoked
+  // (`rc/bot-revoked` carries Slack's own `app_uninstalled`/`tokens_revoked`),
+  // and the only one where sharing is real and gated on transport — the
+  // socket↔http axis is immutable post-create, so "switch to HTTP" means
+  // recreating the app, which is exactly what the CP's 409 says.
+  copy: {
+    revokedHint: 'The Slack workspace uninstalled this app or revoked its tokens — re-install to reconnect',
+    shareHint: {
+      available: 'Allow several agents to share this bot across channels',
+      unavailable: 'HTTP transport required to share'
+    }
   }
 }

--- a/packages/web/src/components/console/views/ProfileView.tsx
+++ b/packages/web/src/components/console/views/ProfileView.tsx
@@ -14,7 +14,7 @@ import { Avatar, Button, Icon } from '@/components/ui'
 import { useModal } from '@/components/console/ModalProvider'
 import ApiKeysCard from '@/components/console/ApiKeysCard'
 import SocialSignInCard from '@/components/console/SocialSignInCard'
-import SlackConfigCard from '@/components/console/SlackConfigCard'
+import { PlatformCredentialCards } from '@/components/console/platforms/profile'
 import { isAuthConfigured, logout } from '@/lib/auth'
 import { useProfile } from '@/lib/profile'
 import { MOCK_MODE } from '@/lib/data'
@@ -159,8 +159,9 @@ export default function ProfileView() {
           {/* Personal API keys — the caller's own REST credentials */}
           <ApiKeysCard orgs={orgs} defaultOrgId={activeOrg?.id} mobile />
 
-          {/* Your own Slack App Configuration token — powers one-click installs */}
-          <SlackConfigCard />
+          {/* Per-platform tooling credentials of your own — today Slack's App
+              Configuration token, which powers one-click installs */}
+          <PlatformCredentialCards />
 
           {/* Sign out */}
           <button
@@ -226,7 +227,7 @@ export default function ProfileView() {
 
       <ApiKeysCard orgs={orgs} defaultOrgId={activeOrg?.id} />
 
-      <SlackConfigCard />
+      <PlatformCredentialCards />
 
       <div className="mt-[22px] flex items-center justify-between">
         <span className="mono buildinfo text-[11.5px]">{buildStamp}</span>

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -46,7 +46,7 @@ import {
   type SessionAccessProvider
 } from '@/lib/api'
 import { agentLabel, isDirectConversation, type AgentCallPolicy, type IntegrationRow } from '@/lib/data'
-import { platformRegistry } from '@/components/console/platforms/registry'
+import { botCardCopy, platformRegistry } from '@/components/console/platforms/registry'
 import { consoleKeys } from '@/lib/swr-keys'
 import { inviteLinkStatus, inviteLinkUrl } from '@/lib/org-invite-link'
 import EditMemberModal, { type MemberTarget } from '@/components/console/modals/EditMemberModal'
@@ -985,6 +985,11 @@ function BotsCard({
   const RowActions = fragments?.lifecycleActions?.RowActions
   const CardNotice = fragments?.lifecycleActions?.CardNotice
   const CardProvider = fragments?.lifecycleActions?.CardProvider ?? PassThrough
+  // The two sentences the CARD writes into its own chrome (the revoked badge,
+  // the Sharable cell). Both used to be Slack's model rendered over every
+  // platform's rows; the module supplies the wording, the host still decides
+  // when and which arm to show.
+  const rowCopy = botCardCopy(platformTab.platform)
 
   return (
     <div className="card mt-[18px]">
@@ -1081,23 +1086,23 @@ function BotsCard({
                   <span className="mono min-w-0 flex-1 truncate text-[12.5px]">{b.name}</span>
                   {b.prebuilt && <span className="badge bg-(--surface-active) text-(--text-tertiary)">builtin</span>}
                   {/* Workspace uninstalled the app / revoked its tokens (rc/bot-revoked):
-                    the credential is dead until a re-install refreshes it. */}
+                    the credential is dead until a re-install refreshes it. The
+                    sentence is the module's (§10 `settingsFragments.copy`) — only
+                    Slack can name the lifecycle event that put the bot here. */}
                   {b.revokedAt && (
-                    <span
-                      className="badge bg-(--status-error-soft) text-(--danger)"
-                      title="The Slack workspace uninstalled this app or revoked its tokens — re-install to reconnect"
-                    >
+                    <span className="badge bg-(--status-error-soft) text-(--danger)" title={rowCopy.revokedHint}>
                       revoked
                     </span>
                   )}
                   {RowBadges && <RowBadges bot={b} />}
                 </div>
+                {/* The host picks the arm by transport; the module owns both
+                    sentences. A platform that declares none gets one sentence for
+                    both arms — its transport is not why sharing is unavailable. */}
                 <span
                   className="flex items-center justify-self-start"
                   title={
-                    (b.transport ?? 'socket') === 'socket'
-                      ? 'HTTP transport required to share'
-                      : 'Allow several agents to share this bot across channels'
+                    (b.transport ?? 'socket') === 'socket' ? rowCopy.shareHint.unavailable : rowCopy.shareHint.available
                   }
                   onClick={(e) => e.stopPropagation()}
                 >


### PR DESCRIPTION
## What

#591 made `AddIntegrationModal` a chassis; #604 moved marks, settings fragments, channel-list semantics, api bindings and the helper libs; #614 moved the three transcript members. This closes the three leftovers those PRs named, and sweeps `packages/web/src` for the rest.

| Leftover | Before | Now |
| --- | --- | --- |
| `SlackConfigCard` | the last direct core caller of a platform-named `lib/api` export | `platforms/slack/profile.tsx`, behind `WebPlatformModule.ProfileCredentialCard` |
| `revoked` badge tooltip | one Slack sentence on every platform's rows | `settingsFragments.copy.revokedHint` |
| Sharable toggle copy | one Slack transport sentence on every platform's rows | `settingsFragments.copy.shareHint` |

### `SlackConfigCard` lands behind a new member, not behind `apiBindings`

`apiBindings` was the other option on the table, and it is the smaller *diff* — but it does not do the job. The card's platform-shaped part is not only the API call: it is a ~230-line component whose title, placeholders (`xoxe.xoxp-…`), portal link and whole 12h-vs-durable rotation model are Slack's. Routing its three calls through `apiBindings` would have left the Slack-named component sitting in `components/console/`, importing `platforms/slack/api` instead of `lib/api` — the platform-named import is still in core, just re-pointed. It would also have made the host the single caller of the one member the contract documents as **opaque to the host** ("no host code calls through this member").

So the card moves, and `ProfileView` reaches it through the registry. It is a member of its own rather than a `settingsFragments` sibling because the two differ in **scope**, not just in page: `settingsFragments` adorns the org's durable bot identities, while this credential is per-USER (`GET/PUT/DELETE /slack/config` answers for the calling principal) and belongs to no bot row.

Reading the registry from a Profile-page component costs no bundle: `ConsoleShell` mounts `ModalProvider` on every console route and it already pulls `registry.ts` in through `AddIntegrationModal`. That is why this lookup *can* go through the registry while `platforms/marks.ts` and `lib/platform-labels.ts` deliberately cannot — those are reached from the signed-out routes, which have no modal tree.

### Only Slack declares either sentence — on purpose

Both strings are host chrome the module now supplies wording for; the host still owns the elements and the conditions. Slack's are byte-identical, and it is the **only** module that declares either, because it is the only platform that can reach either state:

- `revokedAt` is written by exactly one path, `rc/bot-revoked`, whose reason enum **is** Slack's own app lifecycle (`app_uninstalled` / `tokens_revoked`, `protocol/src/frames/relay-cp.ts`).
- Multi-agent bots are Slack-only at the server — the CP answers every other platform with *"multi-agent bots currently support Slack only"* (`http/routes/integrations.ts`).

So for Telegram, Discord and Feishu the honest copy **is** the generic sentence, and inventing provider-specific prose for a state they cannot reach would be fiction. The default `shareHint`'s two arms are deliberately the same string: the host still picks an arm by `(bot.transport ?? 'socket')`, but on a platform that cannot share at all, transport is not the reason — two different sentences would promise that switching it helps. A test asserts the collapse, and asserts neither default names a platform.

### Sweep

Every search used `grep -a`. `SessionDetailView.tsx` carries two raw NUL bytes in composite-key template literals (`:1622`, `:1624`), so plain `grep` reports it as binary and silently omits it — the trap #614 documented, still live.

**Fixed here** (beyond the three above): `globals.css` carried six **dead** custom properties — `--slack`/`--telegram`/`--discord` (`:88-90`) and `--slack-soft`/`--telegram-soft`/`--discord-soft` (`:276-278`) — with zero references anywhere in `src`. And `.slack-hint-blink` (`:3075`) was byte-identical to `.step-blink` (`:3087`), the generic twin Telegram's walkthrough already used; it collapses onto it, so `@keyframes slackHintBlink` → `stepBlink` and `platforms/slack/previews.tsx:23` uses the shared class. No visual change.

**Deliberately left**, with reasons:

| Site | Why it stays |
| --- | --- |
| `lib/data-context.tsx:33,197,1071,1469,1539` `finalizeSlackInstall` | The one remaining core caller of a platform-named api export, and the contract already states why: it commits through `useConsoleData()` so it can refresh the integration/bot projections — the same reason a create goes through `WizardHost.createIntegration`. Moving it is a commit-seam decision, not a file move. |
| `SettingsView.tsx:86-131` `SESSION_ACCESS_COPY` | Another feature's axis — `SessionAccessProvider` is `slack \| github \| feishu`, and GitHub is not a chat-platform module. |
| `SettingsView.tsx:364-368` `BOT_PLATFORM_TABS` | The contract names this a host projection OVER the registry (it also encodes the region axis). `platform-set.test.tsx` keeps the id set honest. |
| `lib/social-login-providers.ts`, `SocialLoginButtons.tsx`, `SocialSignInCard.tsx`, `marks.tsx:304-308` (`SocialLoginMark`) | The OIDC connector catalog — ids that coincide with chat-platform ids but belong to the sign-in axis. Contract: "DELIBERATELY ABSENT". |
| `LarkFeishuSwitcher.tsx:4-5` `BRAND_LABEL` | Dual-axis: the chat-platform region picker *and* the sign-in switcher. It cannot move into `feishu/` while `SocialLoginButtons` mounts it. |
| `lib/data.ts:1951` `if (x === '') return 'Slack'` | `platName`'s empty-id arm, pinned by `session-trigger.test.ts`; `lib/data.ts` deliberately does not read the registry (bundle). |
| `GettingStartedChecklist.tsx` `AddToSlackRow` (9 strings) | A Slack-only checklist step, not copy shown for other platforms. The contract already models it: `WebInstallPollingFacet` exists precisely for "host surfaces OUTSIDE the wizard". |
| `ScheduleDetailView.tsx:228,473` `slack.com/app_redirect` | Platform-conditional deep link. Genericising it needs a new "conversation deep link" member — a contract addition, not a leftover. |
| `AddCronModal.tsx:82` `HEADLESS = { platform: 'slack' }` | Legacy sentinel for headless fires — routing, not copy. |
| `globals.css` comments, `api.ts` (~44 lines), `IntegrationChannelList.tsx` (25 lines) | Comments only. `IntegrationChannelList` has **zero** platform literals in emitted code. |

**Not fixed, flagged as a real bug for its own PR:** `OutputModeField.tsx:82-83` renders *"Slack threads show model, context, usage, and session controls."* / *"Slack session status rows are hidden."* in the Add/Edit Agent modals for **every** agent, including Telegram- or Discord-only ones. It belongs to the output-mode feature rather than the §10 module surface, so genericising it is a separate decision.

## Behavior

Two user-visible copy changes, both on Settings → Bots. Slack is unchanged to the byte.

**`revoked` badge tooltip** (shown when `bot.revokedAt` is set):

| Platform | Before | After |
| --- | --- | --- |
| Slack | The Slack workspace uninstalled this app or revoked its tokens — re-install to reconnect | *(unchanged)* |
| Telegram / Discord / Feishu / Lark | The Slack workspace uninstalled this app or revoked its tokens — re-install to reconnect | This bot's credentials were revoked — re-install to reconnect |

**Sharable toggle tooltip:**

| Platform | State | Before | After |
| --- | --- | --- | --- |
| Slack | socket bot | HTTP transport required to share | *(unchanged)* |
| Slack | http bot | Allow several agents to share this bot across channels | *(unchanged)* |
| Telegram / Discord | always (no transport axis) | HTTP transport required to share | Sharing one bot across several agents isn't available on this platform |
| Feishu / Lark | socket bot | HTTP transport required to share | Sharing one bot across several agents isn't available on this platform |
| Feishu / Lark | http bot | Allow several agents to share this bot across channels | Sharing one bot across several agents isn't available on this platform |

The last row is the one that changes a *reachable, currently-misleading* state: a Feishu bot on HTTP transport gets an **enabled** toggle today (the host's predicate is transport-only) and was told it could be shared across "channels" — a noun Feishu does not use, for a capability the CP refuses. The toggle's enablement is unchanged here; only the sentence stops lying. Narrowing the predicate is a functional change and is left for its own PR.

Everything else is byte-identical: the Profile card renders exactly as before in both responsive branches, and the `.step-blink` collapse produces the identical animation.

## Tests

`GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/web test` — **108 files / 832 passed** (main: 106 / 822). `tsc -p tsconfig.json --noEmit` clean; eslint clean on every touched file; prettier written.

- **`platforms/bot-card-copy.test.ts`** (new, 6 tests) — Slack's three strings byte-identical against literals captured from `SettingsView` before the move; every other registered platform resolving to the provider-free default; that Slack is the only module declaring `copy` at all; that neither default matches `/slack|telegram|discord|feishu|lark/i`; that the default's two share arms collapse while Slack's stay distinct; and that the lookup is total — the ten `UNCLAIMED` ids (`hook`, `webchat`, `lark`, `__proto__`, `''`, …) and `undefined` all answer.
- **`platforms/profile.test.tsx`** (new, 4 tests) — the absent case is the point: a registry of platforms that declare no card renders the empty string, not a wrapper or separator; an empty registry likewise; declared cards render in registry order with the undeclared ones skipped. Stand-ins, following `text-renderer.test.tsx`'s precedent, plus one assertion against the **real** registry that `ProfileCredentialCard` is Slack's alone.
- `platform-set.test.tsx`, `transcript.test.ts`, `text-renderer.test.tsx` and the rest of #604/#614's coverage pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
