### PR TITLE
fix(web): explain reclaimed session workspaces

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -808,7 +808,9 @@ Workspace link immediately before Details. For an unpurged session-scoped GitHub
 checkout, it opens that session's worktree; for a shared GitHub checkout or Scratch,
 it opens the Agent's primary workspace. Its git or folder icon reflects that source.
 A session worktree is browse-only in the console: file editing and pull remain actions
-on the primary workspace.
+on the primary workspace. When a selected session's worktree has been cleaned up, the
+browser says that it will be recreated from the repository when the agent next works in
+that session; it must not present the missing worktree as a new workspace with no files.
 
 The checkout control occupies about one quarter of the Workspace file browser
 header, opposite the current file breadcrumb. Its primary choice is named with

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const mobile = vi.hoisted(() => ({ value: false }))
 const workspace = vi.hoisted(() => ({
+  exists: true,
   entries: [] as Array<{
     name: string
     type: 'file' | 'dir'
@@ -44,7 +45,7 @@ vi.mock('@/lib/api', () => ({
   fetchWorkspaceFiles: vi.fn((_agentId: string, opts: { path: string }) =>
     Promise.resolve({
       entries: opts.path ? (workspace.listings[opts.path] ?? []) : workspace.entries,
-      exists: true,
+      exists: workspace.exists,
       nextCursor: null
     })
   ),
@@ -101,6 +102,7 @@ afterEach(async () => {
   container = undefined
   root = undefined
   mobile.value = false
+  workspace.exists = true
   workspace.entries = []
   workspace.listings = {}
   vi.mocked(deleteWorkspaceFile).mockClear()
@@ -254,6 +256,29 @@ it('scopes file and git reads to the selected session worktree', async () => {
   expect(fetchWorkspaceFiles).toHaveBeenCalledWith('agent-a', { path: '', sessionId: 'session-a' })
   expect(fetchWorkspaceGitStatus).toHaveBeenCalledWith('agent-a', 'session-a')
   expect(container?.textContent).not.toContain('Add file')
+})
+
+it('explains when a selected session workspace has been cleaned up', async () => {
+  workspace.exists = false
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(
+      <WorkspaceFiles
+        agentId="agent-a"
+        sessionId="session-a"
+        workdir="/workspace"
+        canEdit={false}
+        renderHeader={() => null}
+      />
+    )
+    await Promise.resolve()
+  })
+
+  expect(container.textContent).toContain("This session's workspace has been cleaned up")
+  expect(container.textContent).toContain('it will be recreated from the repository')
+  expect(container.textContent).not.toContain('The workspace has no files yet')
 })
 
 it('keeps an inline new-file draft across the desktop-to-mobile breakpoint', async () => {

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -817,7 +817,13 @@ export function WorkspaceFiles({
         )}
 
         {!editor && root && !root.loading && !root.err && !root.exists && (
-          <EmptyNote text="The workspace has no files yet — the agent creates them as it works." />
+          <EmptyNote
+            text={
+              sessionId
+                ? "This session's workspace has been cleaned up — it will be recreated from the repository when the agent next works in this session."
+                : 'The workspace has no files yet — the agent creates them as it works.'
+            }
+          />
         )}
 
         {root?.entries && root.exists && root.entries.length === 0 && !editor && (


### PR DESCRIPTION
## Summary

- show a reclaimed-workspace explanation when a selected session worktree no longer exists
- preserve the existing empty states for an unmaterialized primary workspace and an existing empty directory
- document the session-worktree empty-state behavior and cover it with a UI regression test

## Why

The workspace API correctly returned `exists: false` after lifecycle cleanup, but the file browser treated every missing root as a brand-new workspace. That made a retained session whose worktree had been reclaimed look as though the agent had never created files.

## Validation

- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/WorkspaceFiles.test.tsx`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm exec eslint packages/web/src/components/console/WorkspaceFiles.tsx packages/web/src/components/console/WorkspaceFiles.test.tsx`
- pre-push `eslint .`

Created by Codex . GPT-5.6 Sol
