### PR TITLE
refactor(cp): the platform slot owns tooling credentials, the icon facet, the telegram probe and the assign gate (S3 §9)

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1034,7 +1034,13 @@ export function buildContainer(
     verifyBot: verifySlackBot,
     verifyAppToken: verifySlackAppToken,
     ...(slackPlatformApp ? { platformApp: slackPlatformApp } : {}),
-    toolingCredentials: createSlackToolingCredentials(httpDeps)
+    // Named arguments, NOT `httpDeps`: the bundle no longer carries a Slack API
+    // client, and passing it here type-checked while making every production
+    // resolution `unreachable`.
+    toolingCredentials: createSlackToolingCredentials({
+      configApi: slackConfigApi,
+      store: repos.slackUserConfig
+    })
   }
   const telegramSeams: TelegramRouteSeams = { verifyBot: verifyTelegramBot }
   const feishuSeams: FeishuRouteSeams = {

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -168,11 +168,14 @@ import { buildCpPlatformRegistry } from './platforms/registry.js'
 import { buildPendingInstallReapers, platformBackgroundLoops } from './platforms/lifecycle.js'
 import { createTelegramCpProvider } from './platforms/telegram/provider.js'
 import { createDiscordCpProvider } from './platforms/discord/provider.js'
-import { createSlackCpProvider } from './platforms/slack/provider.js'
+import { createSlackCpProvider, createSlackToolingCredentials } from './platforms/slack/provider.js'
 import { createFeishuCpProvider } from './platforms/feishu/provider.js'
 import { slackInstallRoutes, slackConfigRoutes, slackOauthCallbackRoutes } from './http/routes/slack-install.js'
 import { slackPlatformInstallRoutes, slackPlatformCallbackRoutes } from './http/routes/slack-platform-install.js'
 import { feishuRegistrationRoutes } from './http/routes/feishu-registration.js'
+import { slackBotRefreshRoutes } from './http/routes/slack-bot-refresh.js'
+import { telegramCheckRoutes } from './http/routes/telegram-check.js'
+import type { FeishuRouteSeams, SlackRouteSeams, TelegramRouteSeams } from './http/platform-route-seams.js'
 import { verifyFeishuBot } from './http/feishu-identity.js'
 import { createFeishuAppIconSyncer } from './http/feishu-app-icon.js'
 import { FeishuAppRegistrationService } from './http/feishu-registration.js'
@@ -888,19 +891,7 @@ export function buildContainer(
     sharedTx: <T>(fn: () => Promise<T>) => rootPrisma.$transaction((tx) => runWithSharedTx(tx, fn)),
     webchatMcpMetrics: defaultWebchatMcpMetrics,
     readiness,
-    verifySlackBot,
-    verifySlackAppToken,
-    slackConfigApi,
     searchSkillRegistry,
-    verifyTelegramBot,
-    syncTelegramBotIcon,
-    verifyDiscordBot,
-    ensureDiscordMessageContentIntent,
-    syncDiscordBotProfile,
-    verifyFeishuBot,
-    configureFeishuHttpApp,
-    syncFeishuAppIcon,
-    feishuAppRegistration: new FeishuAppRegistrationService(repos.feishuAppRegistration),
     ...(github ? { github } : {}),
     ...(githubUserAuthz ? { githubUserAuthz } : {}),
     ...(logtoIdentity ? { logtoIdentity } : {}),
@@ -911,7 +902,6 @@ export function buildContainer(
     feishuPlatformApps,
     ...(iconStore ? { iconStore } : {}),
     ...(connectors ? { connectors } : {}),
-    ...(slackPlatformApp ? { slackPlatformApp } : {}),
     config: httpServerConfigFrom(config, { DEFAULT_OWNER_ID, relayStaleMs })
   }
   const http = buildHttpServer(httpDeps, opts.fastify)
@@ -1032,6 +1022,27 @@ export function buildContainer(
     http.log
   )
 
+  // The per-platform INJECTION seams the provider-contributed route plugins take
+  // as their second argument (`http/platform-route-seams.ts`) — what used to be
+  // twelve platform-named fields on `httpDeps`. Built here, once, and shared with
+  // the providers below so the routes and the registry cannot hold different
+  // clients. The tooling-credential facet is a single instance for the same
+  // reason: the funnel start, the config status route, the Settings→Bots refresh
+  // and `provider.providerToolingCredentials` are all this one object.
+  const slackSeams: SlackRouteSeams = {
+    configApi: slackConfigApi,
+    verifyBot: verifySlackBot,
+    verifyAppToken: verifySlackAppToken,
+    ...(slackPlatformApp ? { platformApp: slackPlatformApp } : {}),
+    toolingCredentials: createSlackToolingCredentials(httpDeps)
+  }
+  const telegramSeams: TelegramRouteSeams = { verifyBot: verifyTelegramBot }
+  const feishuSeams: FeishuRouteSeams = {
+    verifyBot: verifyFeishuBot,
+    configureHttpApp: configureFeishuHttpApp,
+    registrations: new FeishuAppRegistrationService(repos.feishuAppRegistration)
+  }
+
   // §9 platform-provider registry (S3): the behavioral CpPlatformProvider
   // instances — all four platforms — constructed with the SAME verify/sync
   // functions, route-dep bundle, funnel stores, and background-loop instances
@@ -1047,11 +1058,19 @@ export function buildContainer(
   // `validateConfig` + `buildNewBotInstall` tail, the pending-install reapers and
   // the background loops below, `loadConfig`'s env fold (through the static
   // `platforms/env.ts` declaration — `loadConfig` runs before this registry can
-  // exist, since providers are constructed FROM the parsed config), and (§9) ALL
-  // wire projection: `IntegrationSpec.config` on every spec-assembly path and
-  // both `rc/bot-assign` bags.
+  // exist, since providers are constructed FROM the parsed config), (§9) ALL
+  // wire projection — `IntegrationSpec.config` on every spec-assembly path and
+  // both `rc/bot-assign` bags — the agent-icon fan-out's capability probe, the
+  // `rc/bot-assign` completeness gate, and the per-user tooling credentials. The
+  // twelve platform-named `httpDeps` slots this used to populate are gone: what
+  // core ASKS is answered by the registry, and what tests INJECT is the seams
+  // above.
   composedPlatforms = buildCpPlatformRegistry([
-    createTelegramCpProvider({ verifyBot: verifyTelegramBot, syncBotIcon: syncTelegramBotIcon }),
+    createTelegramCpProvider({
+      verifyBot: verifyTelegramBot,
+      syncBotIcon: syncTelegramBotIcon,
+      funnelRoutes: { org: [telegramCheckRoutes(httpDeps, telegramSeams)], publicCallback: [] }
+    }),
     createDiscordCpProvider({
       verifyBot: verifyDiscordBot,
       ensureMessageContentIntent: ensureDiscordMessageContentIntent,
@@ -1061,10 +1080,18 @@ export function buildContainer(
       verifyBot: verifySlackBot,
       verifyAppToken: verifySlackAppToken,
       funnelRoutes: {
-        org: [slackInstallRoutes(httpDeps), slackPlatformInstallRoutes(httpDeps), slackConfigRoutes(httpDeps)],
-        publicCallback: [slackOauthCallbackRoutes(httpDeps), slackPlatformCallbackRoutes(httpDeps)]
+        org: [
+          slackInstallRoutes(httpDeps, slackSeams),
+          slackPlatformInstallRoutes(httpDeps, slackSeams),
+          slackConfigRoutes(httpDeps, slackSeams),
+          slackBotRefreshRoutes(httpDeps, slackSeams)
+        ],
+        publicCallback: [
+          slackOauthCallbackRoutes(httpDeps, slackSeams),
+          slackPlatformCallbackRoutes(httpDeps, slackSeams)
+        ]
       },
-      userConfigs: httpDeps,
+      ...(slackSeams.toolingCredentials ? { toolingCredentials: slackSeams.toolingCredentials } : {}),
       pendingInstalls: {
         installs: repos.slackInstall,
         platformInstalls: repos.slackPlatformInstall,
@@ -1075,7 +1102,7 @@ export function buildContainer(
     }),
     createFeishuCpProvider({
       verifyBot: verifyFeishuBot,
-      funnelRoutes: { org: [feishuRegistrationRoutes(httpDeps)], publicCallback: [] },
+      funnelRoutes: { org: [feishuRegistrationRoutes(httpDeps, feishuSeams)], publicCallback: [] },
       syncAppIcon: syncFeishuAppIcon,
       pendingInstalls: {
         registrations: repos.feishuAppRegistration,

--- a/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
@@ -4,6 +4,37 @@ import { AgentId, BotId, IntegrationId, OrgId } from '../domain/ids.js'
 import type { AgentRecord, BotRecord, IntegrationRecord } from '../persistence/ports.js'
 import type { BotProfileIconAgent } from './bot-profile-icon.js'
 import { syncAgentBotIcons } from './agent-bot-icon-sync.js'
+import { buildCpPlatformRegistry } from '../platforms/registry.js'
+import { createTelegramCpProvider } from '../platforms/telegram/provider.js'
+import { createDiscordCpProvider } from '../platforms/discord/provider.js'
+import { createSlackCpProvider } from '../platforms/slack/provider.js'
+import { createFeishuCpProvider } from '../platforms/feishu/provider.js'
+
+/**
+ * The four production providers, composed with whichever icon pushers a case
+ * wants. `sideEffects.syncBotProfileIcon` IS the capability probe the fan-out
+ * reads, so a provider composed WITHOUT its syncer contributes no member and the
+ * bot is skipped — and Slack never declares one at all (it renders per-message
+ * `icon_url` from the public CP endpoint instead of pushing a bot avatar).
+ */
+function platformsWith(pushers: {
+  telegram?: (token: string, agent: BotProfileIconAgent) => Promise<void>
+  discord?: (token: string, agent: BotProfileIconAgent) => Promise<void>
+  feishu?: (appId: string, appSecret: string, region: 'feishu' | 'lark', agent: BotProfileIconAgent) => Promise<void>
+}) {
+  return buildCpPlatformRegistry([
+    createTelegramCpProvider({
+      verifyBot: async () => ({ status: 'unreachable' }),
+      ...(pushers.telegram ? { syncBotIcon: pushers.telegram } : {})
+    }),
+    createDiscordCpProvider({
+      ensureMessageContentIntent: async () => 'ready',
+      ...(pushers.discord ? { syncBotProfile: pushers.discord } : {})
+    }),
+    createSlackCpProvider({}),
+    createFeishuCpProvider({ ...(pushers.feishu ? { syncAppIcon: pushers.feishu } : {}) })
+  ])
+}
 
 const ORG_ID = OrgId('org_test')
 const AGENT_ID = AgentId('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
@@ -128,9 +159,7 @@ describe('syncAgentBotIcons', () => {
               }
             }
           },
-          syncTelegramBotIcon: telegramSync,
-          syncDiscordBotProfile: discordSync,
-          syncFeishuAppIcon: feishuSync
+          platforms: platformsWith({ telegram: telegramSync, discord: discordSync, feishu: feishuSync })
         },
         agent,
         { warn }
@@ -153,6 +182,37 @@ describe('syncAgentBotIcons', () => {
     expect(feishuSync.mock.calls[0]![3]).not.toHaveProperty('description')
     expect(secretGets.sort()).toEqual([telegramId, discordId, feishuId].sort())
     expect(warn).toHaveBeenCalledOnce()
+    // Slack declares NO `syncBotProfileIcon`, so its dedicated bot is skipped
+    // before its credential is even read — the same no-op the three-way
+    // `bot.platform === … && deps.syncX` conjunction produced.
+    expect(secretGets).not.toContain(slackId)
+  })
+
+  it('is a no-op for a platform whose provider declares no icon pusher', async () => {
+    const feishuId = '00000000-0000-4000-8000-000000000021'
+    const membership = integration(feishuId, 'feishu')
+    const secretGets: string[] = []
+    const warn = vi.fn()
+    const deps = {
+      repos: {
+        agent: { get: async () => agentRecord(agent.icon) },
+        integration: { listForAgent: async () => [membership], listForBot: async () => [membership] },
+        bot: { get: async () => bot(feishuId, 'feishu', { feishuAppId: 'cli_feishu' }) },
+        botSecret: {
+          get: async (id: string) => {
+            secretGets.push(id)
+            return { botToken: 'feishu-secret', appToken: 'cli_feishu', signingSecret: null }
+          }
+        }
+      },
+      // Feishu composed WITHOUT `syncAppIcon` ⇒ no `sideEffects.syncBotProfileIcon`
+      // member ⇒ the platform is not icon-capable, exactly like Slack.
+      platforms: platformsWith({})
+    }
+
+    await expect(syncAgentBotIcons(deps, agent, { warn })).resolves.toBeUndefined()
+    expect(secretGets).toEqual([])
+    expect(warn).not.toHaveBeenCalled()
   })
 
   it('repairs a delayed stale write with the latest Agent icon', async () => {
@@ -192,7 +252,7 @@ describe('syncAgentBotIcons', () => {
           get: async () => ({ botToken: 'discord-token', appToken: null, signingSecret: null })
         }
       },
-      syncDiscordBotProfile: discordSync
+      platforms: platformsWith({ discord: discordSync })
     }
     const warn = vi.fn()
 
@@ -247,7 +307,7 @@ describe('syncAgentBotIcons', () => {
           get: async () => ({ botToken: 'discord-token', appToken: null, signingSecret: null })
         }
       },
-      syncDiscordBotProfile: discordSync
+      platforms: platformsWith({ discord: discordSync })
     }
     const warn = vi.fn()
 

--- a/packages/control-plane/src/http/agent-bot-icon-sync.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.ts
@@ -7,9 +7,7 @@ import type {
   IntegrationRepo
 } from '../persistence/ports.js'
 import type { BotProfileIconAgent } from './bot-profile-icon.js'
-import type { DiscordBotProfileSyncer } from './discord-bot-profile.js'
-import type { FeishuAppIconSyncer } from './feishu-app-icon.js'
-import type { TelegramBotIconSyncer } from './telegram-bot-profile.js'
+import type { CpPlatformRegistry } from '../platforms/provider.js'
 
 interface AgentBotIconSyncDeps {
   repos: {
@@ -18,9 +16,19 @@ interface AgentBotIconSyncDeps {
     bot: Pick<BotRepo, 'get'>
     botSecret: Pick<BotSecretStore, 'get'>
   }
-  syncTelegramBotIcon?: TelegramBotIconSyncer
-  syncDiscordBotProfile?: DiscordBotProfileSyncer
-  syncFeishuAppIcon?: FeishuAppIconSyncer
+  /** §9 platform registry. `sideEffects.syncBotProfileIcon` IS the capability
+   *  probe this fan-out used to spell as three `bot.platform === … && deps.syncX`
+   *  conjunctions: a platform that declares no member is skipped, exactly as
+   *  Slack always was (it renders per-message `icon_url` from the public CP
+   *  endpoint instead of pushing a bot avatar). Read at CALL time — every reader
+   *  of the registry runs long after composition. */
+  platforms: CpPlatformRegistry
+}
+
+/** The platform's profile-icon pusher, or `undefined` when this platform has no
+ *  dedicated-bot avatar to converge. */
+function iconPusherFor(deps: AgentBotIconSyncDeps, platform: string) {
+  return deps.platforms.get(platform)?.sideEffects?.syncBotProfileIcon
 }
 
 interface AgentBotIconSyncLogger {
@@ -54,11 +62,7 @@ async function currentBotIconState(
   const bot = await deps.repos.bot.get(botId)
   if (!bot || bot.shareable || bot.revokedAt) return null
 
-  const supported =
-    (bot.platform === 'telegram' && deps.syncTelegramBotIcon) ||
-    (bot.platform === 'discord' && deps.syncDiscordBotProfile) ||
-    (bot.platform === 'feishu' && deps.syncFeishuAppIcon)
-  if (!supported) return null
+  if (!iconPusherFor(deps, bot.platform)) return null
 
   const memberships = await deps.repos.integration.listForBot(bot.id)
   if (memberships.length !== 1) return null
@@ -96,23 +100,10 @@ async function syncBotIconUntilCurrent(
         icon: state.agent.icon,
         runtime: state.agent.runtime
       }
-      if (state.bot.platform === 'telegram' && deps.syncTelegramBotIcon) {
-        await deps.syncTelegramBotIcon(secret.botToken, profileAgent)
-      } else if (state.bot.platform === 'discord' && deps.syncDiscordBotProfile) {
-        await deps.syncDiscordBotProfile(secret.botToken, profileAgent)
-      } else if (state.bot.platform === 'feishu' && deps.syncFeishuAppIcon) {
-        // The secret row keeps the credential pair together; public bot
-        // metadata is only the fallback for older rows.
-        const appId = secret.appToken ?? state.bot.feishuAppId
-        if (!appId) {
-          log.warn(
-            { agentId: state.agent.id, botId: state.bot.id, platform: state.bot.platform },
-            'agent bot icon sync skipped: Feishu App ID is missing'
-          )
-          return
-        }
-        await deps.syncFeishuAppIcon(appId, secret.botToken, state.bot.feishuRegion ?? 'feishu', profileAgent)
-      }
+      // One awaited provider call, no platform branch: which credential the push
+      // needs (Feishu resolves its app id from `secrets.appToken ?? bot.feishuAppId`
+      // and no-ops without one) is the provider's business, not this fan-out's.
+      await iconPusherFor(deps, state.bot.platform)?.(state.bot, secret, profileAgent)
     } catch (err) {
       log.warn(
         { err, agentId: state.agent.id, botId: state.bot.id },
@@ -126,8 +117,9 @@ async function syncBotIconUntilCurrent(
   }
 }
 
-/** Push one changed Agent icon to each dedicated Telegram/Discord/Feishu bot currently
- * installed on it. Shared identities are deliberately excluded: one platform
+/** Push one changed Agent icon to each dedicated bot currently installed on it
+ * whose platform declares `sideEffects.syncBotProfileIcon` (Telegram, Discord and
+ * Feishu today). Shared identities are deliberately excluded: one platform
  * avatar cannot represent several agents. After each provider call, re-read and
  * repair to the latest icon/current owner so detached requests are latest-wins.
  * Every failure stays cosmetic. */

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -70,17 +70,6 @@ import type { CollabRoutesService } from '../orchestrator/collabRoutes.service.j
 import type { AgentMutationGate } from '../orchestrator/agentMutationGate.js'
 import type { SessionEventSink } from '../events/sink.js'
 import type { HumanAuthConfig } from './plugins/auth.js'
-import type { SlackBotVerifier, SlackAppTokenVerifier } from './slack-identity.js'
-import type { SlackPlatformAppConfig } from '../config/slack-platform.js'
-import type { SlackConfigApi } from './slack-config-api.js'
-import type { TelegramBotVerifier } from './telegram-identity.js'
-import type { TelegramBotIconSyncer } from './telegram-bot-profile.js'
-import type { DiscordBotVerifier, DiscordMessageContentIntentEnsurer } from './discord-identity.js'
-import type { DiscordBotProfileSyncer } from './discord-bot-profile.js'
-import type { FeishuBotVerifier } from './feishu-identity.js'
-import type { FeishuAppIconSyncer } from './feishu-app-icon.js'
-import type { FeishuAppRegistrationService } from './feishu-registration.js'
-import type { FeishuHttpAppConfigurator } from './feishu-app-config.js'
 import type { SkillRegistrySearcher } from './skills-registry.js'
 import type { Readiness } from './readiness.js'
 import type { McpRateLimiter } from './mcp/rate-limit.js'
@@ -232,13 +221,31 @@ export interface HttpDeps {
     oauth: OAuthRepo
   }
   registry: DaemonRegistry
-  /** §9 platform-provider registry — the single platform-set authority.
-   *  `server.ts` mounts each provider's `installRoutes(scope)` (so no core file
-   *  imports a funnel-route factory), and the create route folds each
-   *  provider's `credentialBodySchema` / `refineCreateBody` into its request
-   *  schema, dispatches the live credential check through `validateConfig`, and
-   *  writes its rows from `buildNewBotInstall` — so no route file names a
-   *  platform. */
+  /**
+   * §9 platform-provider registry — the single platform-set authority, and the
+   * ONLY per-platform member of this bundle. `server.ts` mounts each provider's
+   * `installRoutes(scope)` (so no core file imports a funnel-route factory); the
+   * create route folds each provider's `credentialBodySchema` /
+   * `refineCreateBody` into its request schema, dispatches the live credential
+   * check through `validateConfig`, and writes its rows from
+   * `buildNewBotInstall`; the agent-icon fan-out probes
+   * `sideEffects.syncBotProfileIcon`; the Slack routes read the caller's stored
+   * App Configuration token through `providerToolingCredentials`; and
+   * `orchestrator/httpBot.ts` gates an `rc/bot-assign` on
+   * `secretShape.httpAssignRequires`. So no route file names a platform.
+   *
+   * The twelve platform-named slots this bundle used to carry (`verifySlackBot`,
+   * `slackConfigApi`, `verifyTelegramBot`, `syncTelegramBotIcon`,
+   * `verifyDiscordBot`, `ensureDiscordMessageContentIntent`,
+   * `syncDiscordBotProfile`, `verifyFeishuBot`, `configureFeishuHttpApp`,
+   * `syncFeishuAppIcon`, `feishuAppRegistration`, `verifySlackAppToken`, plus
+   * `slackPlatformApp`) are gone: the CAPABILITY questions they were probed for
+   * are answered here, and the INJECTION they provided moved to
+   * `http/platform-route-seams.ts`, which each provider's route factories take
+   * as a second argument. Everything is read THROUGH this registry at call time
+   * — never captured at construction — because the composition root publishes it
+   * late (a provider is built FROM this very bundle).
+   */
   platforms: CpPlatformRegistry
   /** The ONE assembler of CP→daemon AgentSpecs (owns secret loading + icon bases) —
    *  every spec emission (upsert replicate, icon refresh, move activation) uses it. */
@@ -307,53 +314,11 @@ export interface HttpDeps {
   webchatMcpMetrics?: Pick<WebchatMcpMetrics, 'invocation' | 'requestDuration'>
   /** Process readiness gate for `/readyz` (rolling-update drain, issue #240). */
   readiness: Readiness
-  /** Validates a pasted Slack bot token against `auth.test` (and derives the bot name
-   *  from it when the install omits one). Optional/injectable so tests stay offline
-   *  (absent ⇒ no validation, route falls back to the agent name). */
-  verifySlackBot?: SlackBotVerifier
-  /** Validates a pasted Slack app-level token against `apps.connections.open`.
-   *  Optional/injectable (absent ⇒ no app-token validation). */
-  verifySlackAppToken?: SlackAppTokenVerifier
-  /** Slack App-management + OAuth calls for the config-token auto-install funnel
-   *  (§Tier B). Optional/injectable; absent (with PUBLIC_CP_URL) ⇒ the funnel routes
-   *  404 and the console falls back to the manual manifest flow. */
-  slackConfigApi?: SlackConfigApi
   /** Reads the public skills.sh index for the Skills library's "Install from
    *  skills.sh" search. Optional/injectable so tests stay offline (absent ⇒ the
    *  search route reports the index unreachable and the console offers the GitHub
    *  import path instead). */
   searchSkillRegistry?: SkillRegistrySearcher
-  /** Validates a Telegram token, derives its bot name, and checks that Group Privacy
-   *  Mode is disabled before the integration is installed. */
-  verifyTelegramBot: TelegramBotVerifier
-  /** Applies an Agent icon to a Telegram bot profile.
-   *  Cosmetic and best-effort: install/icon updates survive a sync failure. */
-  syncTelegramBotIcon?: TelegramBotIconSyncer
-  /** Validates a pasted Discord bot token against `GET /users/@me` (and derives the bot
-   *  name from it when the install omits one). Optional/injectable so tests stay offline
-   *  (absent ⇒ no validation, route falls back to the agent name). */
-  verifyDiscordBot?: DiscordBotVerifier
-  /** Ensures the Discord application has Message Content enabled before credentials
-   *  are stored. Test composition injects an offline success stub. */
-  ensureDiscordMessageContentIntent: DiscordMessageContentIntentEnsurer
-  /** Applies an Agent icon and description to the Discord bot/application profile.
-   *  Cosmetic and best-effort: install/icon updates survive a sync failure. */
-  syncDiscordBotProfile?: DiscordBotProfileSyncer
-  /** Validates a pasted Feishu appId + appSecret via the tenant-access-token exchange
-   *  (and derives the bot name from `bot/v3/info` when the install omits one).
-   *  Optional/injectable so tests stay offline (absent ⇒ no validation, route falls
-   *  back to the agent name). */
-  verifyFeishuBot?: FeishuBotVerifier
-  /** Applies the sensitive delivery URL and verification keys that the official
-   *  one-click registration deeplink intentionally cannot carry. */
-  configureFeishuHttpApp: FeishuHttpAppConfigurator
-  /** Applies an Agent icon to a self-built Feishu/Lark app and submits the
-   *  updated application version. Cosmetic and best-effort. */
-  syncFeishuAppIcon?: FeishuAppIconSyncer
-  /** Owns the short-lived official Feishu/Lark device-registration poll. The
-   *  browser sees only a deeplink + opaque id; credentials are finalized through
-   *  BotSecretStore before the session becomes completed. */
-  feishuAppRegistration: FeishuAppRegistrationService
   /** github-app workspaces façade; absent ⇒ feature disabled (GITHUB_APP_* unset) and
    *  every github route 404s. */
   github?: GithubService
@@ -379,9 +344,5 @@ export interface HttpDeps {
   /** open-connector integration client (docs: connectors); absent ⇒ OPEN_CONNECTOR_URL
    *  unset, the connectors routes 404 and the console hides "Add connectors". */
   connectors?: ConnectorsClient
-  /** Platform-published (distributed) Slack app credentials (preset-agents.md §5.3);
-   *  absent ⇒ SLACK_PLATFORM_* unset, the install routes 404 and the console hides
-   *  "Add to Slack". Secret material — NEVER log or DTO. */
-  slackPlatformApp?: SlackPlatformAppConfig
   config: HttpServerConfig
 }

--- a/packages/control-plane/src/http/platform-route-mounts.test.ts
+++ b/packages/control-plane/src/http/platform-route-mounts.test.ts
@@ -40,6 +40,9 @@ import { createFeishuCpProvider } from '../platforms/feishu/provider.js'
 import { slackInstallRoutes, slackConfigRoutes, slackOauthCallbackRoutes } from './routes/slack-install.js'
 import { slackPlatformInstallRoutes, slackPlatformCallbackRoutes } from './routes/slack-platform-install.js'
 import { feishuRegistrationRoutes } from './routes/feishu-registration.js'
+import { slackBotRefreshRoutes } from './routes/slack-bot-refresh.js'
+import { telegramCheckRoutes } from './routes/telegram-check.js'
+import type { FeishuRouteSeams, SlackRouteSeams, TelegramRouteSeams } from './platform-route-seams.js'
 
 /**
  * TODAY'S TABLE — captured from the routing table the pre-refactor `server.ts`
@@ -60,6 +63,11 @@ const EXPECTED_MOUNTS: Record<CpRouteScope, Record<string, string[]>> = {
     // The §9 `providerToolingCredentials` surface (Slack's App Configuration
     // token): status, entry, removal.
     slackConfigRoutesPlugin: ['GET /slack/config', 'PUT /slack/config', 'DELETE /slack/config'],
+    // Moved OUT of core `routes/bots.ts` / `routes/integrations.ts` and into the
+    // owning provider — the paths are unchanged, which is the whole point of
+    // pinning them here (both core route sets register into this same scope).
+    slackBotRefreshRoutesPlugin: ['POST /bots/:id/slack/refresh'],
+    telegramCheckRoutesPlugin: ['POST /integrations/telegram/check'],
     feishuRegistrationRoutesPlugin: ['POST /integrations/feishu/app', 'GET /integrations/feishu/app/:id']
   },
   'public-callback': {
@@ -83,9 +91,6 @@ function stubDeps(): { deps: HttpDeps; assignRegistry: (registry: CpPlatformRegi
   let registry: CpPlatformRegistry | undefined
   const deps = {
     repos: { user: { provisionOidcUser: async () => ({ userId: 'u' }) } },
-    // Presence is the feature flag for the two Slack funnels.
-    slackConfigApi: {},
-    slackPlatformApp: { appId: 'A1', clientId: 'c', clientSecret: 's', signingSecret: 'sig' },
     get platforms(): CpPlatformRegistry {
       if (!registry) throw new Error('platform registry read before composition')
       return registry
@@ -100,19 +105,39 @@ function stubDeps(): { deps: HttpDeps; assignRegistry: (registry: CpPlatformRegi
   return { deps, assignRegistry: (r) => (registry = r) }
 }
 
-/** The production provider set, with the funnel plugins pre-bound exactly as
+/** Route seams with every funnel's feature flag ON: presence of `configApi` /
+ *  `platformApp` is what makes the two Slack funnels register at all. Handlers
+ *  are never invoked here, so they can stay hollow. */
+const SLACK_SEAMS = {
+  configApi: {},
+  platformApp: { appId: 'A1', clientId: 'c', clientSecret: 's', signingSecret: 'sig' }
+} as unknown as SlackRouteSeams
+const TELEGRAM_SEAMS = { verifyBot: async () => ({ status: 'unreachable' }) } as unknown as TelegramRouteSeams
+const FEISHU_SEAMS = { configureHttpApp: async () => {}, registrations: {} } as unknown as FeishuRouteSeams
+
+/** The production provider set, with the route plugins pre-bound exactly as
  *  `buildContainer` pre-binds them. */
 function productionPlatforms(deps: HttpDeps): CpPlatformRegistry {
   return buildCpPlatformRegistry([
-    createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+    createTelegramCpProvider({
+      verifyBot: async () => ({ status: 'unreachable' }),
+      funnelRoutes: { org: [telegramCheckRoutes(deps, TELEGRAM_SEAMS)], publicCallback: [] }
+    }),
     createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
     createSlackCpProvider({
       funnelRoutes: {
-        org: [slackInstallRoutes(deps), slackPlatformInstallRoutes(deps), slackConfigRoutes(deps)],
-        publicCallback: [slackOauthCallbackRoutes(deps), slackPlatformCallbackRoutes(deps)]
+        org: [
+          slackInstallRoutes(deps, SLACK_SEAMS),
+          slackPlatformInstallRoutes(deps, SLACK_SEAMS),
+          slackConfigRoutes(deps, SLACK_SEAMS),
+          slackBotRefreshRoutes(deps, SLACK_SEAMS)
+        ],
+        publicCallback: [slackOauthCallbackRoutes(deps, SLACK_SEAMS), slackPlatformCallbackRoutes(deps, SLACK_SEAMS)]
       }
     }),
-    createFeishuCpProvider({ funnelRoutes: { org: [feishuRegistrationRoutes(deps)], publicCallback: [] } })
+    createFeishuCpProvider({
+      funnelRoutes: { org: [feishuRegistrationRoutes(deps, FEISHU_SEAMS)], publicCallback: [] }
+    })
   ])
 }
 
@@ -215,12 +240,36 @@ describe('platform route mounts', () => {
     }
   })
 
-  it('a platform with no funnel contributes nothing at either scope', async () => {
+  it('a platform composed without route plugins contributes nothing at either scope', async () => {
     const telegram = createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) })
     const discord = createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' })
     for (const provider of [telegram, discord]) {
       expect(provider.installRoutes('org')).toEqual([])
       expect(provider.installRoutes('public-callback')).toEqual([])
+    }
+  })
+
+  it('serves the two relocated routes at their original core paths, and only there', async () => {
+    // §9 moved `POST /bots/:id/slack/refresh` out of `routes/bots.ts` and
+    // `POST /integrations/telegram/check` out of `routes/integrations.ts` into
+    // their owning providers. Both core route sets and the registry's org plugins
+    // register into the SAME `/api/v1/orgs/:orgId` scope, so the public paths are
+    // byte-identical — that is the deploy-surface claim, asserted against
+    // Fastify's own table rather than restated from the mount code.
+    const { app, routes } = await builtServer()
+    try {
+      for (const path of [
+        '/api/v1/orgs/:orgId/bots/:id/slack/refresh',
+        '/api/v1/orgs/:orgId/integrations/telegram/check'
+      ]) {
+        expect(routes.filter((route) => route.endsWith(` ${path}`))).toEqual([`POST ${path}`])
+      }
+      // Contributed exactly once — a double registration would 500 at boot, but
+      // pin the count so a stray second mount is caught here instead.
+      expect(routes.filter((route) => route.includes('/slack/refresh'))).toHaveLength(1)
+      expect(routes.filter((route) => route.includes('/integrations/telegram/check'))).toHaveLength(1)
+    } finally {
+      await app.close()
     }
   })
 

--- a/packages/control-plane/src/http/platform-route-seams.ts
+++ b/packages/control-plane/src/http/platform-route-seams.ts
@@ -1,0 +1,77 @@
+/**
+ * The per-platform seams the PROVIDER-CONTRIBUTED route plugins are constructed
+ * with (integration-plugin-architecture.md §9) — what used to be twelve
+ * platform-named fields on the core dep bundle (`http/deps.ts`:
+ * `verifySlackBot`, `slackConfigApi`, `verifyTelegramBot`,
+ * `syncTelegramBotIcon`, `verifyDiscordBot`,
+ * `ensureDiscordMessageContentIntent`, `syncDiscordBotProfile`,
+ * `verifyFeishuBot`, `configureFeishuHttpApp`, `syncFeishuAppIcon`,
+ * `feishuAppRegistration`, `verifySlackAppToken`, plus `slackPlatformApp`).
+ *
+ * WHY THEY MOVED. The audit's biggest CP blind spot (integration-plugin-audit.md
+ * Appendix C §5.1) is "optional-dependency presence as the branch": core code
+ * probing `if (deps.syncTelegramBotIcon)` to decide what a platform can do. Those
+ * probes are gone — the registry answers now (`provider.sideEffects
+ * ?.syncBotProfileIcon`, `provider.providerToolingCredentials`,
+ * `provider.secretShape`). What remains is pure INJECTION: a Slack route needs a
+ * Slack API client, and it must be swappable so suites stay offline. That is not
+ * a core concern, so it is not on core deps; each funnel-route factory takes its
+ * platform's seams as a second argument, and the composition root builds the
+ * seams, the routes and the provider from the SAME values.
+ *
+ * Every member stays optional exactly where the old dep slot was optional, and
+ * absence keeps meaning what it meant then (no verifier ⇒ inconclusive, never a
+ * refusal; no config API ⇒ the funnel routes never register and the console
+ * falls back to the manual manifest flow).
+ */
+import type { SlackConfigApi } from './slack-config-api.js'
+import type { SlackBotVerifier, SlackAppTokenVerifier } from './slack-identity.js'
+import type { SlackPlatformAppConfig } from '../config/slack-platform.js'
+import type { TelegramBotVerifier } from './telegram-identity.js'
+import type { FeishuBotVerifier } from './feishu-identity.js'
+import type { FeishuHttpAppConfigurator } from './feishu-app-config.js'
+import type { FeishuAppRegistrationService } from './feishu-registration.js'
+import type { CpProviderToolingCredentials } from '../platforms/provider.js'
+
+/** Seams for the Slack route plugins: the two install funnels, the config-token
+ *  routes, and the Settings→Bots manifest refresh. */
+export interface SlackRouteSeams {
+  /** Slack App-management + OAuth calls for the config-token auto-install funnel
+   *  and the manifest refresh (§Tier B). Absent (with `PUBLIC_CP_URL`) ⇒ the
+   *  funnel routes 404 and the console falls back to the manual manifest flow. */
+  configApi?: SlackConfigApi
+  /** Validates a bot token against `auth.test` (and derives name / app id /
+   *  workspace from it). Absent ⇒ no validation. */
+  verifyBot?: SlackBotVerifier
+  /** Validates an app-level token against `apps.connections.open`. Absent ⇒ no
+   *  app-token validation. */
+  verifyAppToken?: SlackAppTokenVerifier
+  /** Platform-published (distributed) Slack app credentials (preset-agents.md
+   *  §5.3); absent ⇒ `SLACK_PLATFORM_*` unset, the platform-install routes 404
+   *  and the console hides "Add to Slack". Secret material — NEVER log or DTO. */
+  platformApp?: SlackPlatformAppConfig
+  /** The §9 per-user tooling-credential facet — the SAME instance the provider
+   *  advertises as `providerToolingCredentials`, so the funnel start, the config
+   *  status route and the manifest refresh all read the one store the registry
+   *  vouches for. Absent ⇒ no stored-credential path (focused tests). */
+  toolingCredentials?: CpProviderToolingCredentials
+}
+
+/** Seams for the Telegram route plugin (the credential-probe route). */
+export interface TelegramRouteSeams {
+  /** Validates a pasted token, derives its bot name, and reports whether Group
+   *  Privacy Mode is disabled. */
+  verifyBot: TelegramBotVerifier
+}
+
+/** Seams for the Feishu/Lark one-click registration route plugin. */
+export interface FeishuRouteSeams {
+  /** Validates an appId + appSecret pair via the tenant-access-token exchange.
+   *  Absent ⇒ no validation. */
+  verifyBot?: FeishuBotVerifier
+  /** Applies the sensitive delivery URL and verification keys the official
+   *  one-click deeplink intentionally cannot carry. */
+  configureHttpApp: FeishuHttpAppConfigurator
+  /** Owns the short-lived official device-registration poll. */
+  registrations: FeishuAppRegistrationService
+}

--- a/packages/control-plane/src/http/routes/bots.ts
+++ b/packages/control-plane/src/http/routes/bots.ts
@@ -16,20 +16,8 @@ import { type BotRecord, isSyntheticEmail } from '../../persistence/ports.js'
 import { BotStillShared } from '../../persistence/errors.js'
 import { BotId } from '../../domain/ids.js'
 import { orgOf, denyViewerWrite } from '../rbac.js'
-import {
-  BotDto,
-  BotListDto,
-  SlackBotRefreshDto,
-  UpdateBotBody,
-  ErrorDto,
-  IdParam,
-  type BotDtoT,
-  type SlackBotRefreshDtoT
-} from '../dto/index.js'
+import { BotDto, BotListDto, UpdateBotBody, ErrorDto, IdParam, type BotDtoT } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
-import { resolveUserConfigAccessToken } from '../slack-user-config.js'
-import { mergeManagedSlackManifest, slackOAuthRedirectUri, SLACK_BOT_SCOPES } from '../slack-manifest.js'
-import { relayHttpBase } from './slack-install.js'
 
 function toDto(b: BotRecord): BotDtoT {
   return {
@@ -55,34 +43,6 @@ function toDto(b: BotRecord): BotDtoT {
     workspaceName: b.workspaceName,
     revokedAt: b.revokedAt?.toISOString() ?? null,
     createdAt: b.createdAt.toISOString()
-  }
-}
-
-const MANUAL_MANIFEST_ERRORS = new Set([
-  'app_not_eligible',
-  'app_not_found',
-  'app_not_owned_by_manager_app',
-  'invalid_app_id',
-  'no_permission'
-])
-
-export function slackAppLinks(
-  appId: string,
-  teamId: string | null
-): Pick<SlackBotRefreshDtoT, 'settingsUrl' | 'manifestUrl' | 'permissionsUrl' | 'reinstallUrl'> {
-  const encodedAppId = encodeURIComponent(appId)
-  const base = `https://api.slack.com/apps/${encodedAppId}`
-  const workspaceBase = teamId
-    ? `https://app.slack.com/app-settings/${encodeURIComponent(teamId)}/${encodedAppId}`
-    : null
-  return {
-    settingsUrl: base,
-    // Slack's current App Manifest and OAuth & Permissions editors both need the
-    // workspace id (from auth.test) and app id. Reinstall uses Slack's direct
-    // app-scoped install flow and therefore still works when auth.test fails.
-    manifestUrl: workspaceBase ? `${workspaceBase}/app-manifest` : base,
-    permissionsUrl: workspaceBase ? `${workspaceBase}/oauth` : base,
-    reinstallUrl: `${base}/install-on-team?`
   }
 }
 
@@ -126,112 +86,6 @@ export function botRoutes(deps: HttpDeps) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
         return toDto(bot)
-      }
-    )
-
-    r.post(
-      '/bots/:id/slack/refresh',
-      {
-        schema: {
-          tags: [Tag.Bots],
-          summary: 'Refresh a Slack app',
-          description:
-            "Sync AgentConnect's required configuration into an existing Slack app without deleting user-owned manifest fields, then check the workspace installation's granted bot scopes. Returns Slack settings links when manual permission updates or workspace reinstallation are required.",
-          operationId: 'refreshSlackBot',
-          params: IdParam,
-          response: { 200: SlackBotRefreshDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
-        }
-      },
-      async (req, reply) => {
-        if (denyViewerWrite(req, reply)) return
-        const bot = await deps.repos.bot.get(BotId(req.params.id))
-        if (!bot || bot.orgId !== req.orgCtx!.orgId) {
-          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
-        }
-        if (bot.platform !== 'slack') {
-          return reply
-            .code(409)
-            .send({ error: 'Conflict', statusCode: 409, message: 'only Slack apps can be refreshed' })
-        }
-        if (!bot.slackAppId) {
-          return reply.code(409).send({
-            error: 'Conflict',
-            statusCode: 409,
-            message: 'Slack app id is unavailable — update this app manually in Slack'
-          })
-        }
-        const secret = await deps.repos.botSecret.get(bot.id)
-        if (!secret) {
-          return reply
-            .code(409)
-            .send({ error: 'Conflict', statusCode: 409, message: 'Slack app credentials are unavailable' })
-        }
-
-        // Verify identity before mutating the manifest. A manually registered
-        // integration stores two independently pasted tokens; if the bot token
-        // belongs to another app, updating the app encoded by the xapp token would
-        // modify the wrong Slack app.
-        const checked = await deps.verifySlackBot?.(secret.botToken)
-        const appIdentityMatches = checked?.status === 'ok' && checked.appId === bot.slackAppId
-        if (appIdentityMatches && checked.teamId) {
-          await deps.repos.bot.setWorkspaceMetadata(bot.id, checked.teamId, checked.teamName)
-        }
-        // A built-in app's manifest is deployment-managed rather than owned by
-        // the signed-in user's Slack config token. Refresh still verifies its
-        // installed scopes so the Console can offer the platform OAuth reinstall.
-        let manifest: SlackBotRefreshDtoT['manifest'] = bot.prebuilt ? 'synced' : 'manual_update_required'
-        const api = deps.slackConfigApi
-        // Manifest sync needs a config token that owns THIS app — i.e. the caller's
-        // own (per-user). If they don't own it (or stored none), Slack rejects the
-        // export/update and `manifest` stays `manual_update_required` — the graceful
-        // fallback the DTO already surfaces via the Slack settings links.
-        if (!bot.prebuilt && api && appIdentityMatches && req.principal) {
-          const config = await resolveUserConfigAccessToken(deps, bot.orgId, req.principal.userId, new Date())
-          if (config.ok) {
-            const exported = await api.exportApp(config.accessToken, bot.slackAppId)
-            if (exported.ok) {
-              const redirectUrl = deps.config.PUBLIC_CP_URL
-                ? slackOAuthRedirectUri(deps.config.PUBLIC_CP_URL)
-                : undefined
-              // An HTTP-mode bot's manifest keeps Socket Mode off + the relay pool's
-              // request_urls (slack-http-mode §6); a socket bot's refresh is unchanged.
-              const httpRelayBase = bot.transport === 'http' ? relayHttpBase(deps.config.PUBLIC_RELAY_URL) : null
-              const updated = await api.updateApp(
-                config.accessToken,
-                bot.slackAppId,
-                mergeManagedSlackManifest(exported.manifest, bot.name, redirectUrl, httpRelayBase ?? undefined)
-              )
-              manifest = updated.ok
-                ? 'synced'
-                : MANUAL_MANIFEST_ERRORS.has(updated.error)
-                  ? 'manual_update_required'
-                  : 'unknown'
-            } else {
-              manifest = MANUAL_MANIFEST_ERRORS.has(exported.error) ? 'manual_update_required' : 'unknown'
-            }
-          } else if (config.reason === 'unreachable') {
-            manifest = 'unknown'
-          }
-        }
-
-        let authorization: SlackBotRefreshDtoT['authorization'] = 'unknown'
-        let missingScopes: string[] = []
-        if (checked?.status === 'invalid') {
-          authorization = 'invalid'
-        } else if (checked?.status === 'ok' && checked.appId && checked.appId !== bot.slackAppId) {
-          authorization = 'app_mismatch'
-        } else if (checked?.status === 'ok' && checked.scopes) {
-          const granted = new Set(checked.scopes)
-          missingScopes = SLACK_BOT_SCOPES.filter((scope) => !granted.has(scope))
-          authorization = missingScopes.length > 0 ? 'reinstall_required' : 'current'
-        }
-
-        return {
-          manifest,
-          authorization,
-          missingScopes,
-          ...slackAppLinks(bot.slackAppId, appIdentityMatches && checked?.status === 'ok' ? checked.teamId : null)
-        }
       }
     )
 

--- a/packages/control-plane/src/http/routes/feishu-registration.ts
+++ b/packages/control-plane/src/http/routes/feishu-registration.ts
@@ -23,6 +23,7 @@ import {
 import { installNewFeishuBot } from '../install-feishu.js'
 import { feishuEventsRequestUrl, type ConfigureFeishuHttpAppInput } from '../feishu-app-config.js'
 import { relayHttpBase } from './slack-install.js'
+import type { FeishuRouteSeams } from '../platform-route-seams.js'
 import {
   ErrorDto,
   FeishuAppRegistrationStartBody,
@@ -31,7 +32,7 @@ import {
   IdParam
 } from '../dto/index.js'
 
-export function feishuRegistrationRoutes(deps: HttpDeps) {
+export function feishuRegistrationRoutes(deps: HttpDeps, feishu: FeishuRouteSeams) {
   return async function feishuRegistrationRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
     const orgIdOf = (req: { orgCtx?: { orgId: OrgId } }) => req.orgCtx!.orgId
@@ -115,7 +116,7 @@ export function feishuRegistrationRoutes(deps: HttpDeps) {
           })
         }
         try {
-          const started = await deps.feishuAppRegistration.start({
+          const started = await feishu.registrations.start({
             orgId,
             agentId: targetAgentId,
             fallbackRegion: req.body.region,
@@ -163,9 +164,9 @@ export function feishuRegistrationRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         const orgId = orgIdOf(req)
-        const session = await deps.feishuAppRegistration.get(req.params.id, orgId, async (registration) => {
-          const check = deps.verifyFeishuBot
-            ? await deps.verifyFeishuBot(registration.appId, registration.appSecret, registration.region)
+        const session = await feishu.registrations.get(req.params.id, orgId, async (registration) => {
+          const check = feishu.verifyBot
+            ? await feishu.verifyBot(registration.appId, registration.appSecret, registration.region)
             : null
           if (check?.status === 'invalid') {
             throw new FeishuRegistrationSetupError('invalid_credentials')
@@ -245,7 +246,7 @@ export function feishuRegistrationRoutes(deps: HttpDeps) {
           // Provider configuration is independent of placement. Keep this network
           // round-trip outside the agent move fence; a failure leaves the durable
           // authorized registration retryable with the same callback credentials.
-          if (httpAppConfig) await deps.configureFeishuHttpApp(httpAppConfig)
+          if (httpAppConfig) await feishu.configureHttpApp(httpAppConfig)
         })
         if (!session) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'registration not found' })

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -35,8 +35,6 @@ import { integrationPlatformAvailability } from '../daemon-platform-capability.j
 import { buildCreateIntegrationBody, credentialBlockOf } from '../dto/create-integration-body.js'
 import type { CpConfigRefusal } from '../../platforms/provider.js'
 import {
-  TelegramBotCheckBody,
-  TelegramBotCheckDto,
   UpdateIntegrationChannelBody,
   LeaveIntegrationConversationBody,
   IntegrationDto,
@@ -174,33 +172,6 @@ export function integrationRoutes(deps: HttpDeps) {
         app.log.debug({ integrationId, daemonId }, 'integration/remove skipped: daemon offline')
       }
     }
-
-    r.post(
-      '/integrations/telegram/check',
-      {
-        schema: {
-          tags: [Tag.Integrations],
-          summary: 'Check a Telegram bot',
-          description:
-            'Validate a pasted Telegram bot token and report whether Group Privacy Mode is disabled, without storing the token.',
-          operationId: 'checkTelegramBot',
-          body: TelegramBotCheckBody,
-          response: { 200: TelegramBotCheckDto, 403: ErrorDto }
-        }
-      },
-      async (req, reply) => {
-        if (denyViewerWrite(req, reply)) return
-        const checked = await deps.verifyTelegramBot(req.body.botToken)
-        return {
-          status:
-            checked.status === 'ok'
-              ? checked.privacyModeDisabled
-                ? ('ready' as const)
-                : ('privacy_enabled' as const)
-              : checked.status
-        }
-      }
-    )
 
     r.post(
       '/integrations',

--- a/packages/control-plane/src/http/routes/slack-bot-refresh.test.ts
+++ b/packages/control-plane/src/http/routes/slack-bot-refresh.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { slackAppLinks } from './bots.js'
+import { slackAppLinks } from './slack-bot-refresh.js'
 
 describe('slackAppLinks', () => {
   it('opens the current Slack editors when the workspace id is known', () => {

--- a/packages/control-plane/src/http/routes/slack-bot-refresh.ts
+++ b/packages/control-plane/src/http/routes/slack-bot-refresh.ts
@@ -1,0 +1,180 @@
+/**
+ * `POST /bots/:id/slack/refresh` — sync AgentConnect's required configuration
+ * into an existing Slack app without deleting user-owned manifest fields, then
+ * report the workspace installation's granted bot scopes.
+ *
+ * A PROVIDER-CONTRIBUTED org route (integration-plugin-architecture.md §9
+ * `installRoutes('org')`), not core. It lived in `http/routes/bots.ts` — the
+ * generic durable-bot surface — where it was the last core file holding
+ * `deps.slackConfigApi` + `deps.verifySlackBot` and calling
+ * `resolveUserConfigAccessToken` directly. §9 names it explicitly as the flow
+ * that "migrates into the provider with" the `providerToolingCredentials`
+ * facet, together with the `slackAppLinks` console deep links below. The path
+ * is unchanged: `botRoutes` and the registry's org plugins register into the
+ * same `/api/v1/orgs/:orgId` scope (pinned in `http/platform-route-mounts.test.ts`).
+ *
+ * The caller's OWN App Configuration token is what can export/update the app,
+ * so the token is resolved through the platform facet. If they don't own the app
+ * (or stored nothing), Slack rejects the export/update and `manifest` stays
+ * `manual_update_required` — the graceful fallback the DTO surfaces via the
+ * settings links.
+ */
+import type { FastifyInstance } from 'fastify'
+import type { ZodTypeProvider } from '../plugins/zod.js'
+import type { HttpDeps } from '../deps.js'
+import type { SlackRouteSeams } from '../platform-route-seams.js'
+import { BotId } from '../../domain/ids.js'
+import { denyViewerWrite } from '../rbac.js'
+import { SlackBotRefreshDto, ErrorDto, IdParam, type SlackBotRefreshDtoT } from '../dto/index.js'
+import { Tag } from '../plugins/openapi.js'
+import { mergeManagedSlackManifest, slackOAuthRedirectUri, SLACK_BOT_SCOPES } from '../slack-manifest.js'
+import { relayHttpBase } from './slack-install.js'
+
+/** Slack errors from the manifest export/update that mean "this app is not
+ *  managed by the caller's config token" — a graceful `manual_update_required`,
+ *  not an outage. */
+const MANUAL_MANIFEST_ERRORS = new Set([
+  'app_not_eligible',
+  'app_not_found',
+  'app_not_owned_by_manager_app',
+  'invalid_app_id',
+  'no_permission'
+])
+
+/** The provider console deep links the refresh DTO carries (§9: they migrate
+ *  with the tooling-credential facet). */
+export function slackAppLinks(
+  appId: string,
+  teamId: string | null
+): Pick<SlackBotRefreshDtoT, 'settingsUrl' | 'manifestUrl' | 'permissionsUrl' | 'reinstallUrl'> {
+  const encodedAppId = encodeURIComponent(appId)
+  const base = `https://api.slack.com/apps/${encodedAppId}`
+  const workspaceBase = teamId
+    ? `https://app.slack.com/app-settings/${encodeURIComponent(teamId)}/${encodedAppId}`
+    : null
+  return {
+    settingsUrl: base,
+    // Slack's current App Manifest and OAuth & Permissions editors both need the
+    // workspace id (from auth.test) and app id. Reinstall uses Slack's direct
+    // app-scoped install flow and therefore still works when auth.test fails.
+    manifestUrl: workspaceBase ? `${workspaceBase}/app-manifest` : base,
+    permissionsUrl: workspaceBase ? `${workspaceBase}/oauth` : base,
+    reinstallUrl: `${base}/install-on-team?`
+  }
+}
+
+export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
+  return async function slackBotRefreshRoutesPlugin(app: FastifyInstance): Promise<void> {
+    const r = app.withTypeProvider<ZodTypeProvider>()
+
+    r.post(
+      '/bots/:id/slack/refresh',
+      {
+        schema: {
+          tags: [Tag.Bots],
+          summary: 'Refresh a Slack app',
+          description:
+            "Sync AgentConnect's required configuration into an existing Slack app without deleting user-owned manifest fields, then check the workspace installation's granted bot scopes. Returns Slack settings links when manual permission updates or workspace reinstallation are required.",
+          operationId: 'refreshSlackBot',
+          params: IdParam,
+          response: { 200: SlackBotRefreshDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return
+        const bot = await deps.repos.bot.get(BotId(req.params.id))
+        if (!bot || bot.orgId !== req.orgCtx!.orgId) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
+        }
+        if (bot.platform !== 'slack') {
+          return reply
+            .code(409)
+            .send({ error: 'Conflict', statusCode: 409, message: 'only Slack apps can be refreshed' })
+        }
+        if (!bot.slackAppId) {
+          return reply.code(409).send({
+            error: 'Conflict',
+            statusCode: 409,
+            message: 'Slack app id is unavailable — update this app manually in Slack'
+          })
+        }
+        const secret = await deps.repos.botSecret.get(bot.id)
+        if (!secret) {
+          return reply
+            .code(409)
+            .send({ error: 'Conflict', statusCode: 409, message: 'Slack app credentials are unavailable' })
+        }
+
+        // Verify identity before mutating the manifest. A manually registered
+        // integration stores two independently pasted tokens; if the bot token
+        // belongs to another app, updating the app encoded by the xapp token would
+        // modify the wrong Slack app.
+        const checked = await slack.verifyBot?.(secret.botToken)
+        const appIdentityMatches = checked?.status === 'ok' && checked.appId === bot.slackAppId
+        if (appIdentityMatches && checked.teamId) {
+          await deps.repos.bot.setWorkspaceMetadata(bot.id, checked.teamId, checked.teamName)
+        }
+        // A built-in app's manifest is deployment-managed rather than owned by
+        // the signed-in user's Slack config token. Refresh still verifies its
+        // installed scopes so the Console can offer the platform OAuth reinstall.
+        let manifest: SlackBotRefreshDtoT['manifest'] = bot.prebuilt ? 'synced' : 'manual_update_required'
+        const api = slack.configApi
+        // Manifest sync needs a config token that owns THIS app — i.e. the caller's
+        // own (per-user), resolved through the §9 tooling-credential facet: the SAME
+        // instance the registry advertises and the install funnel uses, so the two
+        // flows cannot disagree about which store answers or when a token is stale.
+        if (!bot.prebuilt && api && appIdentityMatches && req.principal) {
+          const config = (await slack.toolingCredentials?.resolveAccessToken(
+            bot.orgId,
+            req.principal.userId,
+            new Date()
+          )) ?? { ok: false as const, reason: 'unreachable' as const }
+          if (config.ok) {
+            const exported = await api.exportApp(config.accessToken, bot.slackAppId)
+            if (exported.ok) {
+              const redirectUrl = deps.config.PUBLIC_CP_URL
+                ? slackOAuthRedirectUri(deps.config.PUBLIC_CP_URL)
+                : undefined
+              // An HTTP-mode bot's manifest keeps Socket Mode off + the relay pool's
+              // request_urls (slack-http-mode §6); a socket bot's refresh is unchanged.
+              const httpRelayBase = bot.transport === 'http' ? relayHttpBase(deps.config.PUBLIC_RELAY_URL) : null
+              const updated = await api.updateApp(
+                config.accessToken,
+                bot.slackAppId,
+                mergeManagedSlackManifest(exported.manifest, bot.name, redirectUrl, httpRelayBase ?? undefined)
+              )
+              manifest = updated.ok
+                ? 'synced'
+                : MANUAL_MANIFEST_ERRORS.has(updated.error)
+                  ? 'manual_update_required'
+                  : 'unknown'
+            } else {
+              manifest = MANUAL_MANIFEST_ERRORS.has(exported.error) ? 'manual_update_required' : 'unknown'
+            }
+          } else if (config.reason === 'unreachable') {
+            manifest = 'unknown'
+          }
+        }
+
+        let authorization: SlackBotRefreshDtoT['authorization'] = 'unknown'
+        let missingScopes: string[] = []
+        if (checked?.status === 'invalid') {
+          authorization = 'invalid'
+        } else if (checked?.status === 'ok' && checked.appId && checked.appId !== bot.slackAppId) {
+          authorization = 'app_mismatch'
+        } else if (checked?.status === 'ok' && checked.scopes) {
+          const granted = new Set(checked.scopes)
+          missingScopes = SLACK_BOT_SCOPES.filter((scope) => !granted.has(scope))
+          authorization = missingScopes.length > 0 ? 'reinstall_required' : 'current'
+        }
+
+        return {
+          manifest,
+          authorization,
+          missingScopes,
+          ...slackAppLinks(bot.slackAppId, appIdentityMatches && checked?.status === 'ok' ? checked.teamId : null)
+        }
+      }
+    )
+  }
+}

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -30,7 +30,8 @@ import { resolveWebAppUrl } from '../../config/env.js'
 import { buildInstallManifest, slackOAuthRedirectUri } from '../slack-manifest.js'
 import { agentIconBackgroundColor } from '../../agents/agent-icon.js'
 import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
-import { CONFIG_ACCESS_TTL_MS, configUsable, resolveUserConfigAccessToken } from '../slack-user-config.js'
+import { CONFIG_ACCESS_TTL_MS } from '../slack-user-config.js'
+import type { SlackRouteSeams } from '../platform-route-seams.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
 import {
   SlackAppStartBody,
@@ -65,9 +66,9 @@ const SLACK_CONFIG_AUTH_ERRORS = new Set([
   'missing_scope'
 ])
 
-export function slackInstallRoutes(deps: HttpDeps) {
+export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
   return async function slackInstallRoutesPlugin(app: FastifyInstance): Promise<void> {
-    const api = deps.slackConfigApi
+    const api = slack.configApi
     const publicCpUrl = deps.config.PUBLIC_CP_URL
     if (!api || !publicCpUrl) return // feature off — routes 404, console uses the manual flow
     const redirectUri = slackOAuthRedirectUri(publicCpUrl)
@@ -132,7 +133,14 @@ export function slackInstallRoutes(deps: HttpDeps) {
 
         // The CALLER's own config token creates the app (rotated fresh if stale), so
         // the app is owned by them and only they can mint its app-level token.
-        const config = await resolveUserConfigAccessToken(deps, orgId, req.principal.userId, new Date())
+        // Resolved through the platform's §9 tooling-credential facet — the same
+        // instance the registry advertises — so the funnel and the provider can
+        // never disagree about which store answers or when a token is stale.
+        const config = (await slack.toolingCredentials?.resolveAccessToken(
+          orgId,
+          req.principal.userId,
+          new Date()
+        )) ?? { ok: false as const, reason: 'unreachable' as const }
         if (!config.ok) {
           if (config.reason === 'unreachable') {
             return reply.code(502).send({ error: 'Bad Gateway', statusCode: 502, message: 'could not reach Slack' })
@@ -320,7 +328,7 @@ export function slackInstallRoutes(deps: HttpDeps) {
               message: 'The app-level token belongs to a different Slack app.'
             })
           }
-          const appCheck = await deps.verifySlackAppToken?.(req.body.appToken)
+          const appCheck = await slack.verifyAppToken?.(req.body.appToken)
           if (appCheck === 'invalid') {
             return reply.code(400).send({
               error: 'Bad Request',
@@ -362,7 +370,7 @@ export function slackInstallRoutes(deps: HttpDeps) {
 
         // auth.test supplies display-only workspace metadata for the Settings
         // grouping. It also remains the fallback source for an omitted app name.
-        const botCheck = deps.verifySlackBot ? await deps.verifySlackBot(row.botToken) : null
+        const botCheck = slack.verifyBot ? await slack.verifyBot(row.botToken) : null
         const name = row.name || (botCheck?.status === 'ok' ? botCheck.name : null) || agent.name
         const release = deps.agentMutations.tryBeginMutation(agent.id)
         if (!release) {
@@ -437,9 +445,9 @@ export function slackInstallRoutes(deps: HttpDeps) {
  * API (used to validate the token on save). The tokens are secret material — GET
  * returns only status, never the token.
  */
-export function slackConfigRoutes(deps: HttpDeps) {
+export function slackConfigRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
   return async function slackConfigRoutesPlugin(app: FastifyInstance): Promise<void> {
-    const api = deps.slackConfigApi
+    const api = slack.configApi
     if (!api) return // no Slack API wired ⇒ routes 404, console shows the manual flow
     const r = app.withTypeProvider<ZodTypeProvider>()
     const orgIdOf = (req: { orgCtx?: { orgId: OrgId } }) => req.orgCtx!.orgId
@@ -454,6 +462,10 @@ export function slackConfigRoutes(deps: HttpDeps) {
       // Durable = a refresh token is stored (the pair auto-rotates). Usable now = durable
       // or the access-only token is still fresh; a lapsed access-only token forces re-entry.
       const durable = !!row?.refreshToken
+      // The credential half of "auto-install is offerable" comes from the §9
+      // facet (one authority for the stored token); the deployment half — a
+      // configured public callback origin — stays here, which is what knows it.
+      const credentialUsable = (await slack.toolingCredentials?.usableNow(orgId, userId, now)) ?? false
       // HTTP mode is offerable here: a public relay origin is configured AND ≥1 relay
       // is connected to receive the Events API POSTs.
       const relayAvailable = !!relayPublicUrl && deps.httpBot.hasConnectedRelay()
@@ -461,13 +473,13 @@ export function slackConfigRoutes(deps: HttpDeps) {
         configured: !!row,
         durable,
         funnelEnabled,
-        autoAvailable: funnelEnabled && configUsable(row, now),
+        autoAvailable: funnelEnabled && credentialUsable,
         accessExpiresAt: row ? row.accessExpiresAt.toISOString() : null,
         relayAvailable,
         relayPublicUrl,
         // The platform-published "Add to Slack" app (preset-agents.md §5.3): env
         // credentials + public callback + the relay pool, all present.
-        platformInstallAvailable: !!deps.slackPlatformApp && funnelEnabled && relayAvailable,
+        platformInstallAvailable: !!slack.platformApp && funnelEnabled && relayAvailable,
         updatedAt: row ? row.updatedAt.toISOString() : null
       }
     }
@@ -620,9 +632,9 @@ export function closePageHtml(note: SlackCallbackNote, consoleUrl?: string): str
  * bot token is stashed on the row and NEVER handed to the browser, and the
  * callback tab just self-closes (it carries no token).
  */
-export function slackOauthCallbackRoutes(deps: HttpDeps) {
+export function slackOauthCallbackRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
   return async function slackOauthCallbackRoutesPlugin(app: FastifyInstance): Promise<void> {
-    const api = deps.slackConfigApi
+    const api = slack.configApi
     const publicCpUrl = deps.config.PUBLIC_CP_URL
     if (!api || !publicCpUrl) return
     const redirectUri = slackOAuthRedirectUri(publicCpUrl)

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -30,7 +30,7 @@ import { resolveWebAppUrl } from '../../config/env.js'
 import { buildInstallManifest, slackOAuthRedirectUri } from '../slack-manifest.js'
 import { agentIconBackgroundColor } from '../../agents/agent-icon.js'
 import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
-import { CONFIG_ACCESS_TTL_MS } from '../slack-user-config.js'
+import { CONFIG_ACCESS_TTL_MS, configUsable } from '../slack-user-config.js'
 import type { SlackRouteSeams } from '../platform-route-seams.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
 import {
@@ -462,10 +462,17 @@ export function slackConfigRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
       // Durable = a refresh token is stored (the pair auto-rotates). Usable now = durable
       // or the access-only token is still fresh; a lapsed access-only token forces re-entry.
       const durable = !!row?.refreshToken
-      // The credential half of "auto-install is offerable" comes from the §9
-      // facet (one authority for the stored token); the deployment half — a
-      // configured public callback origin — stays here, which is what knows it.
-      const credentialUsable = (await slack.toolingCredentials?.usableNow(orgId, userId, now)) ?? false
+      // The credential half of "auto-install is offerable" is `configUsable` — the
+      // SAME pure predicate the §9 facet's `usableNow` applies, so this surface and
+      // the flows that call the facet cannot disagree about the rule. It is applied
+      // to the row already in hand rather than through `usableNow`, which would
+      // re-read it: this route IS the credential surface (§9 puts the store's
+      // entry/rotation/status routes on `installRoutes`, and the facet is what the
+      // platform's OTHER flows call back into), so a second round-trip would buy
+      // nothing and would split one response across two snapshots of one row.
+      // The deployment half — a configured public callback origin — stays here,
+      // which is what knows it.
+      const credentialUsable = configUsable(row, now)
       // HTTP mode is offerable here: a public relay origin is configured AND ≥1 relay
       // is connected to receive the Events API POSTs.
       const relayAvailable = !!relayPublicUrl && deps.httpBot.hasConnectedRelay()

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -39,6 +39,7 @@ import { resolveWebAppUrl } from '../../config/env.js'
 import { SLACK_BOT_SCOPES, slackPlatformOAuthRedirectUri } from '../slack-manifest.js'
 import { installNewSlackBot } from '../install-slack.js'
 import { closePageHtml, relayHttpBase } from './slack-install.js'
+import type { SlackRouteSeams } from '../platform-route-seams.js'
 import {
   SlackPlatformInstallStartBody,
   SlackPlatformInstallStartDto,
@@ -48,9 +49,9 @@ import {
 
 const SLACK_AUTHORIZE_URL = 'https://slack.com/oauth/v2/authorize'
 
-export function slackPlatformInstallRoutes(deps: HttpDeps) {
+export function slackPlatformInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
   return async function slackPlatformInstallRoutesPlugin(app: FastifyInstance): Promise<void> {
-    const platform = deps.slackPlatformApp
+    const platform = slack.platformApp
     const publicCpUrl = deps.config.PUBLIC_CP_URL
     if (!platform || !publicCpUrl) return // feature off — routes 404, console hides "Add to Slack"
     const redirectUri = slackPlatformOAuthRedirectUri(publicCpUrl)
@@ -180,10 +181,10 @@ export function slackPlatformInstallRoutes(deps: HttpDeps) {
  * created — or an uninstalled workspace's Bot is revived with the fresh token.
  * A workspace already bound to a DIFFERENT org is refused (`workspace_taken`).
  */
-export function slackPlatformCallbackRoutes(deps: HttpDeps) {
+export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
   return async function slackPlatformCallbackRoutesPlugin(app: FastifyInstance): Promise<void> {
-    const platform = deps.slackPlatformApp
-    const api = deps.slackConfigApi
+    const platform = slack.platformApp
+    const api = slack.configApi
     const publicCpUrl = deps.config.PUBLIC_CP_URL
     if (!platform || !api || !publicCpUrl) return
     const redirectUri = slackPlatformOAuthRedirectUri(publicCpUrl)

--- a/packages/control-plane/src/http/routes/telegram-check.ts
+++ b/packages/control-plane/src/http/routes/telegram-check.ts
@@ -1,0 +1,64 @@
+/**
+ * `POST /integrations/telegram/check` — the pre-install CREDENTIAL PROBE: report
+ * whether a pasted BotFather token is valid and whether Group Privacy Mode is
+ * disabled, WITHOUT storing anything. The console calls it while the operator is
+ * still typing, so the Privacy-Mode fix (a BotFather round-trip that cannot be
+ * automated) is surfaced before `POST /integrations` refuses the install.
+ *
+ * A PROVIDER-CONTRIBUTED org route (integration-plugin-architecture.md §9
+ * `installRoutes('org')`). It was the last per-platform route inside core
+ * `http/routes/integrations.ts` and the last core reader of
+ * `deps.verifyTelegramBot`. The path is unchanged: `integrationRoutes` and the
+ * registry's org plugins register into the same `/api/v1/orgs/:orgId` scope
+ * (pinned in `http/platform-route-mounts.test.ts`).
+ *
+ * NO OTHER PLATFORM HAS AN EQUIVALENT, and none should grow one by copying this
+ * shape. Telegram is the only platform whose credential carries an operator-
+ * fixable *account setting* that the install cannot repair for them: Discord's
+ * comparable gate (the Message-Content intent) is ENABLED by the CP during
+ * `validateConfig`, and Slack's / Feishu's checks only tell you the token is
+ * wrong — which the create call already tells you, with the same copy, one step
+ * later. A generic "probe these credentials" route would have to return the
+ * §9 `CpConfigValidation` union verbatim, which is the create route's own
+ * pre-store contract; that is a §15 consolidation, not this unit.
+ */
+import type { FastifyInstance } from 'fastify'
+import type { ZodTypeProvider } from '../plugins/zod.js'
+import type { HttpDeps } from '../deps.js'
+import type { TelegramRouteSeams } from '../platform-route-seams.js'
+import { denyViewerWrite } from '../rbac.js'
+import { TelegramBotCheckBody, TelegramBotCheckDto, ErrorDto } from '../dto/index.js'
+import { Tag } from '../plugins/openapi.js'
+
+export function telegramCheckRoutes(_deps: HttpDeps, telegram: TelegramRouteSeams) {
+  return async function telegramCheckRoutesPlugin(app: FastifyInstance): Promise<void> {
+    const r = app.withTypeProvider<ZodTypeProvider>()
+
+    r.post(
+      '/integrations/telegram/check',
+      {
+        schema: {
+          tags: [Tag.Integrations],
+          summary: 'Check a Telegram bot',
+          description:
+            'Validate a pasted Telegram bot token and report whether Group Privacy Mode is disabled, without storing the token.',
+          operationId: 'checkTelegramBot',
+          body: TelegramBotCheckBody,
+          response: { 200: TelegramBotCheckDto, 403: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return
+        const checked = await telegram.verifyBot(req.body.botToken)
+        return {
+          status:
+            checked.status === 'ok'
+              ? checked.privacyModeDisabled
+                ? ('ready' as const)
+                : ('privacy_enabled' as const)
+              : checked.status
+        }
+      }
+    )
+  }
+}

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -145,6 +145,10 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
   // When set, `bots.get` reports a BUMPED generation from its second call on —
   // a re-install landing between revokeBot's commit and its external effects.
   let bumpRevisionAfterFirstGet: boolean
+  // Operator-facing diagnostics the orchestrator emitted — the completeness
+  // gate's message and its bindings ARE the contract for an operator debugging
+  // "why is my bot not receiving anything".
+  let warns: { bindings: Record<string, unknown>; message: string }[]
 
   function makeOrch(platforms = PLATFORMS): HttpBotOrchestrator {
     const agents: Record<string, AgentRecord> = {
@@ -309,7 +313,13 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       control as never,
       threads,
       sessions as SessionRepo,
-      { info() {}, warn() {}, debug() {} },
+      {
+        info() {},
+        warn(bindings: Record<string, unknown>, message: string) {
+          warns.push({ bindings, message })
+        },
+        debug() {}
+      },
       platforms
     )
   }
@@ -333,6 +343,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     bumpRevisionAfterFirstGet = false
     botRevokedAt = null
     removals = []
+    warns = []
   })
 
   describe('lookupThread — SessionMeta fallback on affinity miss (§7.2 case 2a)', () => {
@@ -377,6 +388,108 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         target: null,
         participants: [{ agentId: BOB, daemonId: D2 }]
       })
+    })
+  })
+
+  /**
+   * §9 `secretShape.httpAssignRequires` — the completeness gate core runs before
+   * asking a provider to project the assign bags. It used to be two hand-written
+   * arms in this file (`bot.platform === 'slack' && !secret.signingSecret`,
+   * `bot.platform === 'feishu' && (!secret.verificationToken || !secret.appToken)`);
+   * the slots are now READ OFF the platform that owns them, so a fifth platform's
+   * requirement arrives with its provider and no core edit.
+   */
+  describe('incomplete callback credentials (§9 secretShape.httpAssignRequires)', () => {
+    const cases: {
+      platform: BotRecord['platform']
+      secret: BotSecretMaterial
+      missing: string[]
+    }[] = [
+      // Slack ⇒ signingSecret: an http-mode bot the relay cannot HMAC-verify.
+      {
+        platform: 'slack',
+        secret: { botToken: 'xoxb-x', appToken: 'xapp-x', signingSecret: null },
+        missing: ['signingSecret']
+      },
+      // Feishu ⇒ verificationToken + appToken (the app id lives in the appToken
+      // slot — the two-slot overloading), reported one at a time…
+      {
+        platform: 'feishu',
+        secret: { botToken: 'secret', appToken: 'cli_x', signingSecret: null, verificationToken: null },
+        missing: ['verificationToken']
+      },
+      {
+        platform: 'feishu',
+        secret: { botToken: 'secret', appToken: null, signingSecret: null, verificationToken: 'vt' },
+        missing: ['appToken']
+      },
+      // …and both together, which the old Feishu arm could not say.
+      {
+        platform: 'feishu',
+        secret: { botToken: 'secret', appToken: null, signingSecret: null, verificationToken: null },
+        missing: ['verificationToken', 'appToken']
+      }
+    ]
+
+    for (const { platform, secret, missing } of cases) {
+      it(`syncBot refuses a ${platform} bot missing ${missing.join(' + ')} and says which slots`, async () => {
+        botRow = bot({ platform })
+        for (const int of integrations) int.platform = platform
+        secretMaterial = secret
+
+        await expect(makeOrch().syncBot(BOT)).resolves.toBeUndefined()
+
+        // Nothing armed: no ingress the relay could not verify, and no send-only
+        // spec either (an unassigned bot has no inbound path).
+        expect(ch.sends).toEqual([])
+        expect(upserts).toEqual([])
+        expect(warns).toEqual([
+          {
+            bindings: { botId: BOT, platform, missing },
+            message: 'http-bot: incomplete callback credentials — cannot assign'
+          }
+        ])
+      })
+
+      it(`replayTo skips a ${platform} bot missing ${missing.join(' + ')} without failing the replay`, async () => {
+        botRow = bot({ platform })
+        for (const int of integrations) int.platform = platform
+        secretMaterial = secret
+        const fresh = new FakeChannel('66666666-6666-4666-8666-666666666667')
+
+        await expect(makeOrch().replayTo(fresh)).resolves.toBeUndefined()
+
+        // Silent by design (unchanged): the replay walks every http bot, and one
+        // incomplete row must not turn the seed into a log storm.
+        expect(fresh.sends).toEqual([])
+        expect(warns).toEqual([])
+      })
+    }
+
+    it('a platform declaring no required slots is never gated here', async () => {
+      // Telegram/Discord declare `httpAssignRequires: []`. Their bots cannot take
+      // the http transport at all (the create route refuses it on the missing
+      // `projectBotAssign`), so the absent-projector fence — not this gate — is
+      // what stops them, and it must still be what fires.
+      botRow = bot({ platform: 'telegram' })
+      for (const int of integrations) int.platform = 'telegram'
+      secretMaterial = { botToken: 'tg', appToken: null, signingSecret: null }
+
+      await expect(makeOrch().syncBot(BOT)).resolves.toBeUndefined()
+
+      expect(ch.sends).toEqual([])
+      expect(warns.map((w) => w.message)).toEqual(['http-bot: platform contributes no relay ingress — skipping'])
+    })
+
+    it('a complete Feishu credential assigns', async () => {
+      botRow = bot({ platform: 'feishu' })
+      for (const int of integrations) int.platform = 'feishu'
+      secretMaterial = { botToken: 'secret', appToken: 'cli_x', signingSecret: null, verificationToken: 'vt' }
+
+      await makeOrch().syncBot(BOT)
+
+      expect(ch.sends.filter((send) => send.type === 'rc/bot-assign')).toHaveLength(1)
+      expect(warns).toEqual([])
     })
   })
 

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -138,13 +138,15 @@ export class HttpBotOrchestrator {
       this.log.warn({ botId }, 'http-bot: no secret for http bot — cannot assign')
       return
     }
-    if (bot.platform === 'slack' && !secret.signingSecret) {
-      // An http-mode Slack bot with no signing secret can't be verified by the relay.
-      this.log.warn({ botId }, 'http-bot: no signing secret for http Slack bot — cannot assign')
-      return
-    }
-    if (bot.platform === 'feishu' && (!secret.verificationToken || !secret.appToken)) {
-      this.log.warn({ botId }, 'http-bot: incomplete Feishu callback credentials — cannot assign')
+    const missing = this.missingAssignSecrets(bot, secret)
+    if (missing.length > 0) {
+      // The relay would arm an ingress it cannot verify. Which slots are load-
+      // bearing is the platform's declaration (§9 `secretShape.httpAssignRequires`),
+      // not core's knowledge.
+      this.log.warn(
+        { botId, platform: bot.platform, missing },
+        'http-bot: incomplete callback credentials — cannot assign'
+      )
       return
     }
 
@@ -318,8 +320,7 @@ export class HttpBotOrchestrator {
       if (!compiled) continue
       const secret = await this.botSecret.get(bot.id)
       if (!secret) continue
-      if (bot.platform === 'slack' && !secret.signingSecret) continue
-      if (bot.platform === 'feishu' && (!secret.verificationToken || !secret.appToken)) continue
+      if (this.missingAssignSecrets(bot, secret).length > 0) continue
       // Built OUTSIDE the try on purpose: the catch below means "dead socket",
       // and a projector rejection swallowed there would be a lost error rather
       // than a dropped send. A null assign is the platform having no relay path
@@ -929,6 +930,24 @@ export class HttpBotOrchestrator {
         this.log.debug?.({ integrationId: integration.id, daemonId }, 'http-bot: spec push skipped — daemon offline')
       }
     }
+  }
+
+  /**
+   * The declared secret slots an `rc/bot-assign` needs that this bot's stored
+   * credential does not have (§9 `secretShape.httpAssignRequires`) — the
+   * completeness gate `syncBot` and `replayTo` run BEFORE asking the provider to
+   * project the bags. It replaces the two hand-written platform arms core used to
+   * hold (Slack ⇒ `signingSecret`, Feishu ⇒ `verificationToken` + `appToken`):
+   * same slots, now read off the platform that owns them, so a fifth platform's
+   * requirement arrives with its provider.
+   *
+   * A platform with no registered provider yields no requirements — exactly as
+   * the old two-arm form did for a foreign row; `buildAssign` is the fence that
+   * refuses it a moment later (no projector ⇒ no assign).
+   */
+  private missingAssignSecrets(bot: BotRecord, secret: BotSecretMaterial): string[] {
+    const required = this.platforms.get(bot.platform)?.secretShape.httpAssignRequires ?? []
+    return required.filter((slot) => !secret[slot])
   }
 
   /**

--- a/packages/control-plane/src/platforms/provider.ts
+++ b/packages/control-plane/src/platforms/provider.ts
@@ -22,16 +22,21 @@
  *
  * THE INSTANCE MODEL. A provider is per-platform and constructed once at
  * `buildContainer` time from its env slice + its own API clients. The audit's
- * biggest CP blind spot (integration-plugin-audit.md Appendix C §5.1) is
+ * biggest CP blind spot (integration-plugin-audit.md Appendix C §5.1) was
  * "optional-dependency presence as the branch": twelve per-platform named dep
- * slots on core deps (`http/deps.ts:301-347` — `verifySlackBot`,
- * `verifyTelegramBot`, `syncDiscordBotProfile`, `configureFeishuHttpApp`, …)
- * wired positionally in `container.ts:844-856`, consumed via `if
- * (deps.syncTelegramBotIcon)`-style probes. Those slots dissolve into the
- * provider instances; core keeps ONE registry of providers and asks the
- * registry, never a named field. Test composition keeps its offline stubs by
- * constructing providers with stub clients — the injectability the named
- * slots existed for.
+ * slots on core deps (`verifySlackBot`, `verifyTelegramBot`,
+ * `syncDiscordBotProfile`, `configureFeishuHttpApp`, …) wired positionally in
+ * `container.ts`, consumed via `if (deps.syncTelegramBotIcon)`-style probes.
+ * Those slots are GONE. They conflated two things: the CAPABILITY question,
+ * which core now asks this registry (`sideEffects.syncBotProfileIcon`,
+ * `providerToolingCredentials`, `secretShape`, `projectBotAssign`) and never a
+ * named field; and INJECTION, which is not a core concern at all — each
+ * platform's route factories take their own seams as a second argument
+ * (`http/platform-route-seams.ts`), and the composition root builds the seams,
+ * the routes and the provider from the SAME values. Test composition keeps its
+ * offline stubs by constructing providers and seams with stub clients — the
+ * injectability the named slots existed for — read THROUGH a mutable bag so a
+ * stub swapped after the app is built is still observed.
  *
  * WIRE PROJECTION IS TODAY'S WIRE, not the audit-era one. Since the §6.4
  * emission flip, `IntegrationSpec` is envelope-only — `core` routing knobs +
@@ -226,9 +231,12 @@ export interface CpSecretShape {
   slots: Readonly<Partial<Record<keyof BotSecretMaterial, string>>>
   /** Slots that must be non-empty before an `rc/bot-assign` can be built —
    *  core's completeness gate before it calls {@link
-   *  CpPlatformProvider.projectBotAssign} (today's per-platform guards at
-   *  `orchestrator/httpBot.ts:134-142` and the replay path `:308-309`:
-   *  Slack ⇒ `signingSecret`, Feishu ⇒ `verificationToken` + `appToken`). */
+   *  CpPlatformProvider.projectBotAssign}. `orchestrator/httpBot.ts` reads this
+   *  declaration in `syncBot` and on the register-replay path, replacing the two
+   *  hand-written arms it used to hold (Slack ⇒ `signingSecret`, Feishu ⇒
+   *  `verificationToken` + `appToken`): same slots, now owned by the platform,
+   *  and the operator-facing refusal names the missing ones. A platform
+   *  declaring none is never gated here. */
   httpAssignRequires: readonly (keyof BotSecretMaterial)[]
 }
 
@@ -270,11 +278,17 @@ export type CpToolingTokenResolution =
  * the pattern any platform with programmatic app-minting will reproduce, today
  * realized by Slack's App Configuration token (`SlackUserConfig`). The store,
  * entry/rotation/status routes ride {@link CpPlatformProvider.installRoutes}
- * (`'org'` scope); this facet is the piece OTHER flows call back into: the
- * quick-install funnel start and the Settings→Bots manifest-refresh flow
- * (`http/routes/bots.ts:151-233`, which also carries the provider console
- * deep links — `slackAppLinks`, `bots.ts:69-87` — into the refresh DTO; both
- * migrate into the provider with this facet).
+ * (`'org'` scope); this facet is the piece the platform's OTHER flows call back
+ * into — the quick-install funnel start, the config status projection, and the
+ * Settings→Bots manifest refresh, which moved into the provider WITH this facet
+ * (`http/routes/slack-bot-refresh.ts`, carrying the `slackAppLinks` console
+ * deep links into the refresh DTO).
+ *
+ * ONE INSTANCE, by construction: the composition root builds the facet and hands
+ * the same object to the provider and to those routes' seams, so "which store
+ * answers" and "when is a token stale" cannot drift between them. The facet
+ * answers only the CREDENTIAL question — deployment-level terms (the funnel's
+ * public callback origin, the relay pool) stay with the routes that know them.
  */
 export interface CpProviderToolingCredentials {
   /** Prisma model holding the per-user credential (`SlackUserConfig`). */
@@ -325,12 +339,13 @@ export interface CpInstallSideEffects {
     agent: BotProfileIconAgent
   }): Promise<void>
   /** Ongoing agent-icon convergence: push a CHANGED agent icon to this
-   *  platform's dedicated bot. Presence of the member is the capability —
-   *  today's three-way `supported` test + per-platform dispatch chain in
-   *  `http/agent-bot-icon-sync.ts:57-61,99-115` (Slack has no member here:
-   *  it renders per-message `icon_url` from the public CP endpoint instead).
-   *  Feishu resolves its app id from `secrets.appToken ?? bot.feishuAppId`
-   *  inside (`:106`). */
+   *  platform's dedicated bot. Presence of the member IS the capability —
+   *  `http/agent-bot-icon-sync.ts` probes for it and skips the bot when it is
+   *  absent, which replaced that file's three-way `bot.platform === … &&
+   *  deps.syncX` conjunction (Slack has no member here: it renders per-message
+   *  `icon_url` from the public CP endpoint instead). Which credential the push
+   *  needs is the provider's business — Feishu resolves its app id from
+   *  `secrets.appToken ?? bot.feishuAppId` inside and no-ops without one. */
   syncBotProfileIcon?(bot: BotRecord, secrets: BotSecretMaterial, agent: BotProfileIconAgent): Promise<void>
 }
 

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -356,25 +356,25 @@ describe('slack providerToolingCredentials (delegation to slack-user-config)', (
     updatedAt: NOW,
     ...over
   })
-  const userConfigDeps = (stored: SlackUserConfigRecord | null): SlackUserConfigDeps => ({
-    slackConfigApi: {
+  const userConfigSeams = (stored: SlackUserConfigRecord | null) => ({
+    configApi: {
       createApp: vi.fn(),
       exportApp: vi.fn(),
       updateApp: vi.fn(),
       exchangeOAuth: vi.fn(),
       rotateConfigToken: vi.fn(async () => ({ ok: false as const, error: 'invalid_refresh_token' }))
     } as unknown as NonNullable<SlackUserConfigDeps['slackConfigApi']>,
-    repos: {
-      slackUserConfig: {
-        get: vi.fn(async () => stored),
-        put: vi.fn(async () => {}),
-        delete: vi.fn(async () => {})
-      }
+    store: {
+      get: vi.fn(async () => stored),
+      put: vi.fn(async () => {}),
+      delete: vi.fn(async () => {})
     }
   })
 
   it('resolves a fresh stored access token (resolveUserConfigAccessToken body)', async () => {
-    const provider = createSlackCpProvider({ toolingCredentials: createSlackToolingCredentials(userConfigDeps(row())) })
+    const provider = createSlackCpProvider({
+      toolingCredentials: createSlackToolingCredentials(userConfigSeams(row()))
+    })
     const tooling = provider.providerToolingCredentials!
     expect(tooling.model).toBe('SlackUserConfig')
     expect(await tooling.resolveAccessToken(ORG, 'user-1', NOW)).toEqual({
@@ -385,7 +385,7 @@ describe('slack providerToolingCredentials (delegation to slack-user-config)', (
   })
 
   it('reports not_configured / unusable when nothing is stored', async () => {
-    const provider = createSlackCpProvider({ toolingCredentials: createSlackToolingCredentials(userConfigDeps(null)) })
+    const provider = createSlackCpProvider({ toolingCredentials: createSlackToolingCredentials(userConfigSeams(null)) })
     const tooling = provider.providerToolingCredentials!
     expect(await tooling.resolveAccessToken(ORG, 'user-1', NOW)).toEqual({ ok: false, reason: 'not_configured' })
     expect(await tooling.usableNow(ORG, 'user-1', NOW)).toBe(false)
@@ -394,7 +394,7 @@ describe('slack providerToolingCredentials (delegation to slack-user-config)', (
   it('a lapsed access-only token is expired for installs and unusable for the wizard', async () => {
     const lapsed = row({ accessExpiresAt: new Date(NOW.getTime() - 1000) })
     const provider = createSlackCpProvider({
-      toolingCredentials: createSlackToolingCredentials(userConfigDeps(lapsed))
+      toolingCredentials: createSlackToolingCredentials(userConfigSeams(lapsed))
     })
     const tooling = provider.providerToolingCredentials!
     expect(await tooling.resolveAccessToken(ORG, 'user-1', NOW)).toEqual({ ok: false, reason: 'expired' })
@@ -403,6 +403,21 @@ describe('slack providerToolingCredentials (delegation to slack-user-config)', (
 
   it('is absent when no user-config seam is composed', () => {
     expect(createSlackCpProvider({}).providerToolingCredentials).toBeUndefined()
+  })
+
+  it('reports unreachable — never a store read — when no config API is composed', async () => {
+    // Absent `configApi` is the funnel-off meaning `resolveUserConfigAccessToken`
+    // has always had. It must be an explicit omission: this facet's argument
+    // takes the client BY NAME precisely because a bundle that merely lacked the
+    // (optional) member used to satisfy the old parameter type silently.
+    const seams = userConfigSeams(row())
+    const tooling = createSlackToolingCredentials({ store: seams.store })
+    expect(await tooling.resolveAccessToken(ORG, 'user-1', NOW)).toEqual({ ok: false, reason: 'unreachable' })
+    expect(seams.store.get).not.toHaveBeenCalled()
+    // `usableNow` never needed the API — it reads the store directly, which is
+    // why the production regression this shape prevents was invisible to it.
+    expect(await tooling.usableNow(ORG, 'user-1', NOW)).toBe(true)
+    expect(seams.store.get).toHaveBeenCalledOnce()
   })
 })
 

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, vi } from 'vitest'
 import type { FastifyPluginAsync } from 'fastify'
 import {
   createSlackCpProvider,
+  createSlackToolingCredentials,
   slackAppIdFromAppToken,
   slackBotAssignBags,
   slackIntegrationConfig,
@@ -373,7 +374,7 @@ describe('slack providerToolingCredentials (delegation to slack-user-config)', (
   })
 
   it('resolves a fresh stored access token (resolveUserConfigAccessToken body)', async () => {
-    const provider = createSlackCpProvider({ userConfigs: userConfigDeps(row()) })
+    const provider = createSlackCpProvider({ toolingCredentials: createSlackToolingCredentials(userConfigDeps(row())) })
     const tooling = provider.providerToolingCredentials!
     expect(tooling.model).toBe('SlackUserConfig')
     expect(await tooling.resolveAccessToken(ORG, 'user-1', NOW)).toEqual({
@@ -384,7 +385,7 @@ describe('slack providerToolingCredentials (delegation to slack-user-config)', (
   })
 
   it('reports not_configured / unusable when nothing is stored', async () => {
-    const provider = createSlackCpProvider({ userConfigs: userConfigDeps(null) })
+    const provider = createSlackCpProvider({ toolingCredentials: createSlackToolingCredentials(userConfigDeps(null)) })
     const tooling = provider.providerToolingCredentials!
     expect(await tooling.resolveAccessToken(ORG, 'user-1', NOW)).toEqual({ ok: false, reason: 'not_configured' })
     expect(await tooling.usableNow(ORG, 'user-1', NOW)).toBe(false)
@@ -392,7 +393,9 @@ describe('slack providerToolingCredentials (delegation to slack-user-config)', (
 
   it('a lapsed access-only token is expired for installs and unusable for the wizard', async () => {
     const lapsed = row({ accessExpiresAt: new Date(NOW.getTime() - 1000) })
-    const provider = createSlackCpProvider({ userConfigs: userConfigDeps(lapsed) })
+    const provider = createSlackCpProvider({
+      toolingCredentials: createSlackToolingCredentials(userConfigDeps(lapsed))
+    })
     const tooling = provider.providerToolingCredentials!
     expect(await tooling.resolveAccessToken(ORG, 'user-1', NOW)).toEqual({ ok: false, reason: 'expired' })
     expect(await tooling.usableNow(ORG, 'user-1', NOW)).toBe(false)

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -19,9 +19,12 @@
  *    provider construction stays one-directional (a provider never reaches back
  *    for a route factory), which is what keeps the create route free to fold
  *    this provider's credential block into its body schema;
- *  - `providerToolingCredentials` → `resolveUserConfigAccessToken` /
- *    `configUsable` (`http/slack-user-config.ts`), the same resolution the
- *    funnel start and the Settings→Bots refresh flow call;
+ *  - `providerToolingCredentials` → {@link createSlackToolingCredentials}, over
+ *    `resolveUserConfigAccessToken` / `configUsable`
+ *    (`http/slack-user-config.ts`). The composition root builds ONE facet and
+ *    injects the same instance here AND into the routes that call back into it
+ *    (the funnel start, the config status projection, the Settings→Bots
+ *    refresh), so none of them can drift on which store answers;
  *  - the wire projections → {@link slackIntegrationConfig} /
  *    {@link slackSharedIntegrationConfig} / {@link slackBotAssignBags}, called
  *    by BOTH the live paths (`orchestrator/placement.ts`,
@@ -44,8 +47,9 @@ import { z } from 'zod'
 import type { ZodRawShape } from 'zod'
 import type { FastifyPluginAsync } from 'fastify'
 import type { IntegrationCoreEnvelope, IntegrationSlackConfig } from '@agentconnect.md/protocol'
-import type { BotRecord, BotSecretMaterial } from '../../persistence/ports.js'
+import type { BotRecord, BotSecretMaterial, SlackUserConfigStore } from '../../persistence/ports.js'
 import type { SlackBotVerifier, SlackAppTokenVerifier } from '../../http/slack-identity.js'
+import type { SlackConfigApi } from '../../http/slack-config-api.js'
 import { configUsable, resolveUserConfigAccessToken, type SlackUserConfigDeps } from '../../http/slack-user-config.js'
 import type {
   CpConfigValidation,
@@ -282,13 +286,34 @@ export interface SlackCpProviderDeps {
  *    only the credential question; deployment-level terms (the funnel's public
  *    callback origin, the relay pool) stay with the status route, which is what
  *    knows them.
+ *
+ * THE ARGUMENT IS EXPLICIT, NOT A BUNDLE, on purpose. `SlackUserConfigDeps` —
+ * what `resolveUserConfigAccessToken` takes — declares `slackConfigApi` OPTIONAL,
+ * so the route dep bundle satisfied it structurally, and kept satisfying it after
+ * the §9 DI collapse deleted that member: the compiler stayed silent while every
+ * production resolution silently became `unreachable`. Requiring a NAMED store
+ * here makes that mistake unrepresentable — no bundle in this codebase has a
+ * `store` member to donate — and forces the API client to be passed by name.
  */
-export function createSlackToolingCredentials(userConfigs: SlackUserConfigDeps): CpProviderToolingCredentials {
+export function createSlackToolingCredentials(seams: {
+  /** Slack App-management + OAuth calls (the rotate). Absent ⇒ the funnel is off
+   *  and every resolution is `unreachable`, which is the pre-existing meaning —
+   *  but it must now be an explicit choice, not an omission. Read per call so a
+   *  late-bound composition (the test harness) can swap it. */
+  readonly configApi?: SlackConfigApi
+  /** The `SlackUserConfig` store this facet is the sole authority over. */
+  readonly store: SlackUserConfigStore
+}): CpProviderToolingCredentials {
+  const userConfigs: SlackUserConfigDeps = {
+    get slackConfigApi() {
+      return seams.configApi
+    },
+    repos: { slackUserConfig: seams.store }
+  }
   return {
     model: 'SlackUserConfig',
     resolveAccessToken: (orgId, userId, now) => resolveUserConfigAccessToken(userConfigs, orgId, userId, now),
-    usableNow: async (orgId, userId, now) =>
-      configUsable(await userConfigs.repos.slackUserConfig.get(orgId, userId), now)
+    usableNow: async (orgId, userId, now) => configUsable(await seams.store.get(orgId, userId), now)
   }
 }
 

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -47,7 +47,12 @@ import type { IntegrationCoreEnvelope, IntegrationSlackConfig } from '@agentconn
 import type { BotRecord, BotSecretMaterial } from '../../persistence/ports.js'
 import type { SlackBotVerifier, SlackAppTokenVerifier } from '../../http/slack-identity.js'
 import { configUsable, resolveUserConfigAccessToken, type SlackUserConfigDeps } from '../../http/slack-user-config.js'
-import type { CpConfigValidation, CpInstallTransport, CpPlatformProvider } from '../provider.js'
+import type {
+  CpConfigValidation,
+  CpInstallTransport,
+  CpPlatformProvider,
+  CpProviderToolingCredentials
+} from '../provider.js'
 
 /** The `slack` credential block of the `POST /integrations` create body —
  *  relocated from `http/dto/index.ts`, which imports it back (one
@@ -237,11 +242,14 @@ export interface SlackCpProviderDeps {
     org: FastifyPluginAsync[]
     publicCallback: FastifyPluginAsync[]
   }
-  /** The per-user App Configuration token seam (`http/slack-user-config.ts`) —
-   *  store + rotation API. `HttpDeps` is structurally assignable, so the
-   *  composition root passes the same bundle the routes get. Absent ⇒ the
-   *  platform reports no provider tooling credentials. */
-  userConfigs?: SlackUserConfigDeps
+  /** The §9 per-user provider tooling-credential facet, built once by the
+   *  composition root with {@link createSlackToolingCredentials} and handed to
+   *  BOTH this provider and the Slack routes that call back into it (the
+   *  quick-install funnel start, the config status route, and the
+   *  Settings→Bots manifest refresh). One instance, so "which store answers"
+   *  cannot drift between the provider and its callers. Absent ⇒ the platform
+   *  reports no provider tooling credentials. */
+  toolingCredentials?: CpProviderToolingCredentials
   /** Pending-install funnel state (§9 `pendingInstalls`): the two stores'
    *  reap slices + the shared TTL/interval from this provider's env keys
    *  (`SLACK_INSTALL_TTL_SEC` / `SLACK_INSTALL_REAP_INTERVAL_SEC`, ms).
@@ -259,8 +267,33 @@ export interface SlackCpProviderDeps {
   identityReconciler?: { start(): void; stop(): void }
 }
 
+/**
+ * The §9 `providerToolingCredentials` facet over one `SlackUserConfig` store —
+ * the SINGLE authority for "the caller's Slack App Configuration token" that
+ * every flow now reads through: the provider itself, the quick-install funnel
+ * start, the `GET|PUT /slack/config` status projection, and the Settings→Bots
+ * manifest refresh. Both members delegate to the same
+ * `http/slack-user-config.ts` bodies those flows used to call directly, so this
+ * is a call-site swap, not a rewrite:
+ *
+ *  - `resolveAccessToken` → `resolveUserConfigAccessToken` (rotate-near-expiry
+ *    + the spent-refresh reload retry);
+ *  - `usableNow` → `configUsable` over a FRESH read of the same row. It answers
+ *    only the credential question; deployment-level terms (the funnel's public
+ *    callback origin, the relay pool) stay with the status route, which is what
+ *    knows them.
+ */
+export function createSlackToolingCredentials(userConfigs: SlackUserConfigDeps): CpProviderToolingCredentials {
+  return {
+    model: 'SlackUserConfig',
+    resolveAccessToken: (orgId, userId, now) => resolveUserConfigAccessToken(userConfigs, orgId, userId, now),
+    usableNow: async (orgId, userId, now) =>
+      configUsable(await userConfigs.repos.slackUserConfig.get(orgId, userId), now)
+  }
+}
+
 export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProvider<SlackCreateCredentials> {
-  const { verifyBot, verifyAppToken, funnelRoutes, userConfigs, pendingInstalls, identityReconciler } = deps
+  const { verifyBot, verifyAppToken, funnelRoutes, toolingCredentials, pendingInstalls, identityReconciler } = deps
   return {
     platformId: 'slack',
 
@@ -414,19 +447,12 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
     // member presence is the capability probe in `http/agent-bot-icon-sync.ts`).
 
     // Per-user provider tooling credentials (§9): the caller's stored Slack
-    // App Configuration token, resolved/rotated by the SAME functions the
-    // funnel start and the Settings→Bots refresh call
-    // (`http/slack-user-config.ts`).
-    ...(userConfigs
-      ? {
-          providerToolingCredentials: {
-            model: 'SlackUserConfig',
-            resolveAccessToken: (orgId, userId, now) => resolveUserConfigAccessToken(userConfigs, orgId, userId, now),
-            usableNow: async (orgId, userId, now) =>
-              configUsable(await userConfigs.repos.slackUserConfig.get(orgId, userId), now)
-          }
-        }
-      : {}),
+    // App Configuration token. The composition root builds ONE facet
+    // ({@link createSlackToolingCredentials}) and injects the same instance
+    // into the Slack routes that call back into it, so the funnel start, the
+    // config status route and the Settings→Bots refresh cannot drift from what
+    // the registry advertises.
+    ...(toolingCredentials ? { providerToolingCredentials: toolingCredentials } : {}),
 
     // The bot-identity reconciler (backfills app/workspace identity onto
     // pre-capture Bot rows from the stored token) — declared so

--- a/packages/control-plane/src/platforms/telegram/provider.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.ts
@@ -22,6 +22,7 @@
  * ONE implementation behind that projector and the equivalence tests.
  */
 import { z } from 'zod'
+import type { FastifyPluginAsync } from 'fastify'
 import type { IntegrationCoreEnvelope, IntegrationTelegramConfig } from '@agentconnect.md/protocol'
 import type { BotSecretMaterial } from '../../persistence/ports.js'
 import type { TelegramBotVerifier } from '../../http/telegram-identity.js'
@@ -66,16 +67,31 @@ export interface TelegramCpProviderDeps {
    *  pipeline) — presence of `sideEffects.syncBotProfileIcon` is the
    *  capability probe (`http/agent-bot-icon-sync.ts`). */
   syncBotIcon?: TelegramBotIconSyncer
+  /**
+   * Route plugins per mount scope, injected PRE-BOUND to the route deps
+   * (`telegramCheckRoutes` at `'org'`; no public callback — Telegram's inbound
+   * transport is the daemon's own long-lived connection). Injected rather than
+   * imported for the same reason as Slack's: the route module consumes the
+   * create-DTO module, which imports this provider's credential block, so
+   * importing the factory here would close a runtime import cycle. Absent ⇒ no
+   * contributed routes (focused tests).
+   */
+  funnelRoutes?: {
+    org: FastifyPluginAsync[]
+    publicCallback: FastifyPluginAsync[]
+  }
 }
 
 export function createTelegramCpProvider(deps: TelegramCpProviderDeps): CpPlatformProvider<TelegramCreateCredentials> {
-  const { syncBotIcon } = deps
+  const { syncBotIcon, funnelRoutes } = deps
   return {
     platformId: 'telegram',
 
-    // No install funnel: no org-scoped wizard routes, no public OAuth
-    // callbacks. The whole install is the create-DTO path (contract §9 note).
-    installRoutes: () => [],
+    // No install FUNNEL — the whole install is the create-DTO path, and there is
+    // no public OAuth callback (contract §9 note). One org-scoped route all the
+    // same: the pre-install credential probe `POST /integrations/telegram/check`,
+    // which surfaces Group Privacy Mode while the operator is still typing.
+    installRoutes: (scope) => (scope === 'org' ? (funnelRoutes?.org ?? []) : (funnelRoutes?.publicCallback ?? [])),
 
     credentialBodySchema: TelegramCreateCredentials,
 

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -91,7 +91,7 @@ import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
 import type { CpPlatformRegistry } from '../../src/platforms/provider.js'
 import { createTelegramCpProvider } from '../../src/platforms/telegram/provider.js'
 import { createDiscordCpProvider } from '../../src/platforms/discord/provider.js'
-import { createSlackCpProvider } from '../../src/platforms/slack/provider.js'
+import { createSlackCpProvider, createSlackToolingCredentials } from '../../src/platforms/slack/provider.js'
 import { createFeishuCpProvider } from '../../src/platforms/feishu/provider.js'
 import { slackInstallRoutes, slackConfigRoutes, slackOauthCallbackRoutes } from '../../src/http/routes/slack-install.js'
 import {
@@ -99,6 +99,19 @@ import {
   slackPlatformCallbackRoutes
 } from '../../src/http/routes/slack-platform-install.js'
 import { feishuRegistrationRoutes } from '../../src/http/routes/feishu-registration.js'
+import { slackBotRefreshRoutes } from '../../src/http/routes/slack-bot-refresh.js'
+import { telegramCheckRoutes } from '../../src/http/routes/telegram-check.js'
+import type { FeishuRouteSeams, SlackRouteSeams, TelegramRouteSeams } from '../../src/http/platform-route-seams.js'
+import type { SlackConfigApi } from '../../src/http/slack-config-api.js'
+import type { SlackBotVerifier, SlackAppTokenVerifier } from '../../src/http/slack-identity.js'
+import type { SlackPlatformAppConfig } from '../../src/config/slack-platform.js'
+import type { TelegramBotVerifier } from '../../src/http/telegram-identity.js'
+import type { TelegramBotIconSyncer } from '../../src/http/telegram-bot-profile.js'
+import type { DiscordBotVerifier, DiscordMessageContentIntentEnsurer } from '../../src/http/discord-identity.js'
+import type { DiscordBotProfileSyncer } from '../../src/http/discord-bot-profile.js'
+import type { FeishuBotVerifier } from '../../src/http/feishu-identity.js'
+import type { FeishuHttpAppConfigurator } from '../../src/http/feishu-app-config.js'
+import type { FeishuAppIconSyncer } from '../../src/http/feishu-app-icon.js'
 import { createReadiness } from '../../src/http/readiness.js'
 import { McpRateLimiter } from '../../src/http/mcp/rate-limit.js'
 import { RemoteGrantAuthenticator } from '../../src/http/mcp/remote-grant-authenticator.js'
@@ -112,9 +125,58 @@ import { FeishuAppRegistrationService } from '../../src/http/feishu-registration
 
 export const TEST_API_KEY_PEPPER = 'test-api-key-pepper-0123456789abcdef'
 
+/**
+ * The per-platform provider seams a suite may stub — the offline injectability
+ * that used to live as twelve platform-named fields on `HttpDeps` before the §9
+ * DI collapse. It is a TEST-COMPOSITION bag, not a production type: prod builds
+ * the same values in `container.ts` and hands them straight to the route
+ * factories and the providers.
+ *
+ * MUTABLE AND READ THROUGH, deliberately. Suites swap members AFTER `buildApp`
+ * (`app.platformStubs.verifySlackBot = …`), so every provider/route seam below
+ * closes over THIS OBJECT and dereferences the member per call — never captures
+ * the function. That is the same late-binding discipline the `platforms`
+ * registry façade uses, and it is what the DI collapse had to preserve.
+ */
+export interface PlatformStubs {
+  verifySlackBot?: SlackBotVerifier
+  verifySlackAppToken?: SlackAppTokenVerifier
+  slackConfigApi?: SlackConfigApi
+  slackPlatformApp?: SlackPlatformAppConfig
+  verifyTelegramBot: TelegramBotVerifier
+  syncTelegramBotIcon?: TelegramBotIconSyncer
+  verifyDiscordBot?: DiscordBotVerifier
+  ensureDiscordMessageContentIntent: DiscordMessageContentIntentEnsurer
+  syncDiscordBotProfile?: DiscordBotProfileSyncer
+  verifyFeishuBot?: FeishuBotVerifier
+  configureFeishuHttpApp: FeishuHttpAppConfigurator
+  syncFeishuAppIcon?: FeishuAppIconSyncer
+  feishuAppRegistration: FeishuAppRegistrationService
+}
+
+/** The keys `buildHttpApp` peels out of its overrides bag into
+ *  {@link PlatformStubs} — everything else stays a core dep override. */
+const PLATFORM_STUB_KEYS = [
+  'verifySlackBot',
+  'verifySlackAppToken',
+  'slackConfigApi',
+  'slackPlatformApp',
+  'verifyTelegramBot',
+  'syncTelegramBotIcon',
+  'verifyDiscordBot',
+  'ensureDiscordMessageContentIntent',
+  'syncDiscordBotProfile',
+  'verifyFeishuBot',
+  'configureFeishuHttpApp',
+  'syncFeishuAppIcon',
+  'feishuAppRegistration'
+] as const satisfies readonly (keyof PlatformStubs)[]
+
 export interface HttpApp {
   app: FastifyInstance
   deps: HttpDeps
+  /** Swap a platform seam here — before or AFTER the app is built. */
+  platformStubs: PlatformStubs
   events: InMemorySessionEventSink
   /** The relay registry — a test can `add` a fake {@link RelayChannel} so
    *  `hasConnectedRelay()` is true (e.g. to exercise the http-transport paths). */
@@ -130,10 +192,11 @@ export function buildHttpApp(
   configOverrides?: Partial<HttpDeps['config']>,
   liveness: DaemonLiveness = NO_LIVENESS,
   control?: ControlSender,
-  // TOP-LEVEL deps only (e.g. slackConfigApi, verifySlack*) — merged last so a
-  // test can register funnel routes that gate on these at plugin-registration time.
-  // Nested config goes through `configOverrides`, not here.
-  depsOverrides?: Partial<HttpDeps>
+  // TOP-LEVEL deps and/or platform stubs (e.g. slackConfigApi, verifySlack*) —
+  // the platform keys are peeled into `platformStubs` and the rest merged last, so
+  // a test can register funnel routes that gate on these at plugin-registration
+  // time. Nested config goes through `configOverrides`, not here.
+  depsOverrides?: Partial<HttpDeps> & Partial<PlatformStubs>
 ): HttpApp {
   const clock = systemClock
   // Mirror the prod graph: WAITLIST_MODE gates JIT personal-org creation and drives
@@ -176,6 +239,7 @@ export function buildHttpApp(
   const botSecretStore = new PgBotSecretStore(prisma, cipher)
   const botCredentialWriter = new PgBotCredentialWriter(prisma, cipher)
   const feishuAppRegistrationStore = new PgFeishuAppRegistrationStore(prisma, cipher)
+  const slackUserConfigStore = new PgSlackUserConfigStore(prisma, cipher)
   const integrationChannelRepo = new PgIntegrationChannelRepo(prisma)
   const agentRepo = new PgAgentRepo(prisma)
   const orgRepo = new PgOrgRepo(prisma)
@@ -225,9 +289,9 @@ export function buildHttpApp(
   // does. `platforms` is the same stable façade the container hands to the
   // orchestrators, which take the registry BY VALUE at construction — every read
   // through it runs at request / reconcile time, long after assignment. The
-  // providers' verify seams READ THROUGH to `deps` on every call instead of
-  // capturing it: suites routinely swap `app.deps.verifySlackBot` (and friends)
-  // AFTER the app is built, and an absent dep is passed through as the
+  // providers' verify seams READ THROUGH to `platformStubs` on every call instead
+  // of capturing it: suites routinely swap `app.platformStubs.verifySlackBot` (and
+  // friends) AFTER the app is built, and an absent stub is passed through as the
   // provider-unreachable outcome — which every provider treats exactly as the
   // old route treated "no verifier injected" (inconclusive: no 400, no derived
   // identity).
@@ -240,6 +304,24 @@ export function buildHttpApp(
     get: (platformId) => requirePlatforms().get(platformId),
     all: () => requirePlatforms().all(),
     ids: () => requirePlatforms().ids()
+  }
+
+  // Peel the platform seams out of the overrides bag: they are no longer core
+  // deps (§9 DI collapse), but suites still hand them in at build time so the
+  // funnel plugins that gate on them register.
+  const coreOverrides: Partial<HttpDeps> = { ...depsOverrides }
+  for (const key of PLATFORM_STUB_KEYS) delete (coreOverrides as Record<string, unknown>)[key]
+  const platformStubs: PlatformStubs = {
+    verifyTelegramBot: async () => ({ status: 'ok', name: null, privacyModeDisabled: true }),
+    ensureDiscordMessageContentIntent: async () => 'ready',
+    configureFeishuHttpApp: async () => {},
+    feishuAppRegistration: new FeishuAppRegistrationService(feishuAppRegistrationStore),
+    ...Object.fromEntries(
+      PLATFORM_STUB_KEYS.filter((key) => depsOverrides && key in depsOverrides).map((key) => [
+        key,
+        (depsOverrides as Record<string, unknown>)[key]
+      ])
+    )
   }
 
   const deps: HttpDeps = {
@@ -282,7 +364,7 @@ export function buildHttpApp(
       slackInstall: new PgSlackInstallStore(prisma, cipher),
       slackPlatformInstall: new PgSlackPlatformInstallStore(prisma),
       feishuAppRegistration: feishuAppRegistrationStore,
-      slackUserConfig: new PgSlackUserConfigStore(prisma, cipher),
+      slackUserConfig: slackUserConfigStore,
       presetAgent: presetAgentRepo,
       integrationChannel: integrationChannelRepo,
       audit: auditRepo,
@@ -341,54 +423,93 @@ export function buildHttpApp(
     mcpRateLimit: new McpRateLimiter(clock),
     sharedTx: <T>(fn: () => Promise<T>) => rootPrisma.$transaction((tx) => runWithSharedTx(tx, fn)),
     readiness: createReadiness(() => pingDb(prisma)),
-    verifyTelegramBot: async () => ({ status: 'ok', name: null, privacyModeDisabled: true }),
-    ensureDiscordMessageContentIntent: async () => 'ready',
-    configureFeishuHttpApp: async () => {},
-    feishuAppRegistration: new FeishuAppRegistrationService(feishuAppRegistrationStore),
     config: { DEFAULT_OWNER_ID, ...configOverrides },
-    ...depsOverrides,
+    ...coreOverrides,
     remoteGrantAuth,
     internalInvocationAuth
+  }
+
+  // The per-platform route seams, mirroring `buildContainer`'s — but every member
+  // reads THROUGH the mutable `platformStubs` bag rather than capturing its value,
+  // so a suite that swaps a stub after `buildApp` is still observed. `configApi`
+  // and `platformApp` are getters for exactly that reason: the funnel plugins read
+  // them once at plugin-registration time to decide whether to register at all
+  // (that IS the feature flag, so they must be set before the app is built), while
+  // the manifest-refresh handler reads `configApi` per REQUEST — which is what it
+  // did when it was core code reading `deps.slackConfigApi`.
+  const slackSeams: SlackRouteSeams = {
+    get configApi() {
+      return platformStubs.slackConfigApi
+    },
+    get platformApp() {
+      return platformStubs.slackPlatformApp
+    },
+    verifyBot: async (token) =>
+      platformStubs.verifySlackBot ? platformStubs.verifySlackBot(token) : { status: 'unreachable' },
+    verifyAppToken: async (token) =>
+      platformStubs.verifySlackAppToken ? platformStubs.verifySlackAppToken(token) : ('unreachable' as const),
+    toolingCredentials: createSlackToolingCredentials({
+      get slackConfigApi() {
+        return platformStubs.slackConfigApi
+      },
+      repos: { slackUserConfig: slackUserConfigStore }
+    })
+  }
+  const telegramSeams: TelegramRouteSeams = { verifyBot: (token) => platformStubs.verifyTelegramBot(token) }
+  const feishuSeams: FeishuRouteSeams = {
+    verifyBot: async (appId, appSecret, region) =>
+      platformStubs.verifyFeishuBot
+        ? platformStubs.verifyFeishuBot(appId, appSecret, region)
+        : { status: 'unreachable' },
+    configureHttpApp: (input) => platformStubs.configureFeishuHttpApp(input),
+    registrations: platformStubs.feishuAppRegistration
   }
 
   // The same four providers `buildContainer` registers, so the create route
   // parses/validates exactly the deployed shapes and `server.ts` mounts exactly
   // the deployed funnel routes. Two deliberate test-composition traits:
   //
-  //  - the verify/sync seams READ THROUGH to `deps` on every call instead of
-  //    capturing it — tests routinely swap `app.deps.verifySlackBot` (and
-  //    friends) AFTER the app is built. An absent dep is passed through as the
-  //    provider-unreachable outcome, which every provider treats exactly as
-  //    today's route treated "no verifier injected" (inconclusive: no 400, no
-  //    derived identity);
-  //  - the funnel plugins are pre-bound to `deps`, mirroring prod. Each still
-  //    self-disables on absent config (no `slackConfigApi` / `PUBLIC_CP_URL` ⇒
-  //    those routes 404), so a suite that wants them injects the config.
+  //  - the verify/sync seams READ THROUGH to `platformStubs` on every call
+  //    instead of capturing it — tests routinely swap
+  //    `app.platformStubs.verifySlackBot` (and friends) AFTER the app is built.
+  //    An absent stub is passed through as the provider-unreachable outcome,
+  //    which every provider treats exactly as today's route treated "no verifier
+  //    injected" (inconclusive: no 400, no derived identity);
+  //  - the route plugins are pre-bound to `deps` + the seams above, mirroring
+  //    prod. Each still self-disables on absent config (no `slackConfigApi` /
+  //    `PUBLIC_CP_URL` ⇒ those routes 404), so a suite that wants them injects
+  //    the config.
   platformRegistry = buildCpPlatformRegistry([
     createTelegramCpProvider({
-      verifyBot: (token) => deps.verifyTelegramBot(token),
-      syncBotIcon: async (token, agent) => deps.syncTelegramBotIcon?.(token, agent)
+      verifyBot: (token) => platformStubs.verifyTelegramBot(token),
+      syncBotIcon: async (token, agent) => platformStubs.syncTelegramBotIcon?.(token, agent),
+      funnelRoutes: { org: [telegramCheckRoutes(deps, telegramSeams)], publicCallback: [] }
     }),
     createDiscordCpProvider({
-      verifyBot: async (token) => (deps.verifyDiscordBot ? deps.verifyDiscordBot(token) : { status: 'unreachable' }),
-      ensureMessageContentIntent: (token) => deps.ensureDiscordMessageContentIntent(token),
-      syncBotProfile: async (token, agent) => deps.syncDiscordBotProfile?.(token, agent)
+      verifyBot: async (token) =>
+        platformStubs.verifyDiscordBot ? platformStubs.verifyDiscordBot(token) : { status: 'unreachable' },
+      ensureMessageContentIntent: (token) => platformStubs.ensureDiscordMessageContentIntent(token),
+      syncBotProfile: async (token, agent) => platformStubs.syncDiscordBotProfile?.(token, agent)
     }),
     createSlackCpProvider({
-      verifyBot: async (token) => (deps.verifySlackBot ? deps.verifySlackBot(token) : { status: 'unreachable' }),
-      verifyAppToken: async (token) =>
-        deps.verifySlackAppToken ? deps.verifySlackAppToken(token) : ('unreachable' as const),
+      verifyBot: slackSeams.verifyBot!,
+      verifyAppToken: slackSeams.verifyAppToken!,
       funnelRoutes: {
-        org: [slackInstallRoutes(deps), slackPlatformInstallRoutes(deps), slackConfigRoutes(deps)],
-        publicCallback: [slackOauthCallbackRoutes(deps), slackPlatformCallbackRoutes(deps)]
+        org: [
+          slackInstallRoutes(deps, slackSeams),
+          slackPlatformInstallRoutes(deps, slackSeams),
+          slackConfigRoutes(deps, slackSeams),
+          slackBotRefreshRoutes(deps, slackSeams)
+        ],
+        publicCallback: [slackOauthCallbackRoutes(deps, slackSeams), slackPlatformCallbackRoutes(deps, slackSeams)]
       },
-      userConfigs: deps
+      toolingCredentials: slackSeams.toolingCredentials!
     }),
     createFeishuCpProvider({
-      verifyBot: async (appId, appSecret, region) =>
-        deps.verifyFeishuBot ? deps.verifyFeishuBot(appId, appSecret, region) : { status: 'unreachable' },
-      funnelRoutes: { org: [feishuRegistrationRoutes(deps)], publicCallback: [] },
-      syncAppIcon: async (appId, appSecret, region, agent) => deps.syncFeishuAppIcon?.(appId, appSecret, region, agent)
+      verifyBot: feishuSeams.verifyBot!,
+      funnelRoutes: { org: [feishuRegistrationRoutes(deps, feishuSeams)], publicCallback: [] },
+      syncAppIcon: async (appId, appSecret, region, agent) =>
+        platformStubs.syncFeishuAppIcon?.(appId, appSecret, region, agent)
     })
   ])
 
@@ -397,6 +518,7 @@ export function buildHttpApp(
   return {
     app,
     deps,
+    platformStubs,
     events,
     relayReg,
     close: async () => {

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -437,9 +437,19 @@ export function buildHttpApp(
   // (that IS the feature flag, so they must be set before the app is built), while
   // the manifest-refresh handler reads `configApi` per REQUEST — which is what it
   // did when it was core code reading `deps.slackConfigApi`.
+  //
+  // ANTI-DRIFT (learned the hard way in review): this harness once handed the
+  // tooling facet an API client the container had stopped passing, so every suite
+  // was green against a composition production did not have. Both roots now call
+  // {@link createSlackToolingCredentials} with the SAME two named arguments, and
+  // the API client here comes from ONE source shared with `slackSeams.configApi`
+  // — the harness cannot give the facet a client the routes do not see. The
+  // container graph itself is exercised in
+  // `test/integration/slack-tooling-credentials.route.test.ts`.
+  const slackConfigApiSeam = () => platformStubs.slackConfigApi
   const slackSeams: SlackRouteSeams = {
     get configApi() {
-      return platformStubs.slackConfigApi
+      return slackConfigApiSeam()
     },
     get platformApp() {
       return platformStubs.slackPlatformApp
@@ -449,10 +459,10 @@ export function buildHttpApp(
     verifyAppToken: async (token) =>
       platformStubs.verifySlackAppToken ? platformStubs.verifySlackAppToken(token) : ('unreachable' as const),
     toolingCredentials: createSlackToolingCredentials({
-      get slackConfigApi() {
-        return platformStubs.slackConfigApi
+      get configApi() {
+        return slackConfigApiSeam()
       },
-      repos: { slackUserConfig: slackUserConfigStore }
+      store: slackUserConfigStore
     })
   }
   const telegramSeams: TelegramRouteSeams = { verifyBot: (token) => platformStubs.verifyTelegramBot(token) }

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -147,7 +147,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     const agentId = await placedAgent()
     const { app } = withSpy()
     app.relayReg.add({ relayId: 'r1', send() {}, close() {} } as RelayChannel)
-    app.deps.verifySlackBot = async () => ({
+    app.platformStubs.verifySlackBot = async () => ({
       status: 'ok',
       name: 'http-bot',
       appId: 'AHTTPBOT',
@@ -192,11 +192,11 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       const { app } = withSpy()
       // No relay is registered on the fake app by default.
       let verified = false
-      app.deps.verifySlackBot = async () => {
+      app.platformStubs.verifySlackBot = async () => {
         verified = true
         return { status: 'invalid' }
       }
-      app.deps.verifyFeishuBot = async () => {
+      app.platformStubs.verifyFeishuBot = async () => {
         verified = true
         return { status: 'invalid' }
       }
@@ -220,7 +220,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
 
   it('POST telegram check reports Group Privacy Mode without storing the token', async () => {
     const { app } = withSpy()
-    app.deps.verifyTelegramBot = async (botToken) => ({
+    app.platformStubs.verifyTelegramBot = async (botToken) => ({
       status: 'ok',
       name: 'acme-tg',
       privacyModeDisabled: botToken.endsWith('ready')
@@ -247,7 +247,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST telegram refuses an enabled Group Privacy Mode before storing credentials', async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
-    app.deps.verifyTelegramBot = async () => ({
+    app.platformStubs.verifyTelegramBot = async () => ({
       status: 'ok',
       name: 'acme-tg',
       privacyModeDisabled: false
@@ -274,7 +274,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
     let iconSync: { botToken: string; agentId: string } | undefined
-    app.deps.syncTelegramBotIcon = async (botToken, agent) => {
+    app.platformStubs.syncTelegramBotIcon = async (botToken, agent) => {
       iconSync = { botToken, agentId: agent.id }
       throw new Error('fixture rate limit')
     }
@@ -313,11 +313,11 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     const { app, spy } = withSpy()
     let profileSync: { botToken: string; agentId: string; hasDescription: boolean } | undefined
     let intentToken: string | undefined
-    app.deps.ensureDiscordMessageContentIntent = async (botToken) => {
+    app.platformStubs.ensureDiscordMessageContentIntent = async (botToken) => {
       intentToken = botToken
       return 'ready'
     }
-    app.deps.syncDiscordBotProfile = async (botToken, agent) => {
+    app.platformStubs.syncDiscordBotProfile = async (botToken, agent) => {
       profileSync = { botToken, agentId: agent.id, hasDescription: 'description' in agent }
       throw new Error('fixture rate limit')
     }
@@ -366,7 +366,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST rejects a discord bot token Discord refuses (400) and stores nothing', async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
-    app.deps.verifyDiscordBot = async () => ({ status: 'invalid' })
+    app.platformStubs.verifyDiscordBot = async () => ({ status: 'invalid' })
 
     const res = await app.app.inject({
       method: 'POST',
@@ -382,8 +382,8 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST stops before storing when Discord cannot enable Message Content Intent', async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
-    app.deps.verifyDiscordBot = async () => ({ status: 'ok', name: 'matrix' })
-    app.deps.ensureDiscordMessageContentIntent = async () => 'rejected'
+    app.platformStubs.verifyDiscordBot = async () => ({ status: 'ok', name: 'matrix' })
+    app.platformStubs.ensureDiscordMessageContentIntent = async () => 'rejected'
 
     const res = await app.app.inject({
       method: 'POST',
@@ -405,7 +405,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST asks the user to retry when Discord intent setup is unreachable', async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
-    app.deps.ensureDiscordMessageContentIntent = async () => 'unreachable'
+    app.platformStubs.ensureDiscordMessageContentIntent = async () => 'unreachable'
 
     const res = await app.app.inject({
       method: 'POST',
@@ -427,7 +427,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST discord derives the bot name from users/@me, and proceeds when Discord is unreachable', async () => {
     const agentId = await placedAgent()
     const { app } = withSpy()
-    app.deps.verifyDiscordBot = async () => ({ status: 'ok', name: 'matrix#4242' })
+    app.platformStubs.verifyDiscordBot = async () => ({ status: 'ok', name: 'matrix#4242' })
 
     const named = await app.app.inject({
       method: 'POST',
@@ -440,7 +440,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     // Unreachable is best-effort, not a gate: a second agent installs fine, name falls back.
     const agentId2 = randomUUID()
     await seedAgent(prisma, agentId2, { daemonId: DAEMON })
-    app.deps.verifyDiscordBot = async () => ({ status: 'unreachable' })
+    app.platformStubs.verifyDiscordBot = async () => ({ status: 'unreachable' })
     const unreachable = await app.app.inject({
       method: 'POST',
       url: `${ORG}/integrations`,
@@ -563,7 +563,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       send: (type: string, payload: unknown) => relaySends.push({ type, payload }),
       close() {}
     } as RelayChannel)
-    app.deps.verifyFeishuBot = async () => ({
+    app.platformStubs.verifyFeishuBot = async () => ({
       status: 'ok',
       name: 'HTTP Lark Bot',
       openId: 'ou_http_bot'
@@ -630,7 +630,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
     const verifierCalls: Array<string | undefined> = []
-    app.deps.verifyFeishuBot = async (_appId, _appSecret, region) => {
+    app.platformStubs.verifyFeishuBot = async (_appId, _appSecret, region) => {
       verifierCalls.push(region)
       return { status: 'ok', name: null, openId: 'ou_feishu_bot' }
     }
@@ -661,7 +661,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST rejects feishu credentials Feishu refuses (400) and stores nothing', async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
-    app.deps.verifyFeishuBot = async () => ({ status: 'invalid' })
+    app.platformStubs.verifyFeishuBot = async () => ({ status: 'invalid' })
 
     const res = await app.app.inject({
       method: 'POST',
@@ -678,7 +678,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST feishu derives the bot name from bot/v3/info, and proceeds when Feishu is unreachable', async () => {
     const agentId = await placedAgent()
     const { app } = withSpy()
-    app.deps.verifyFeishuBot = async () => ({ status: 'ok', name: 'Matrix Bot', openId: 'ou_matrix_bot' })
+    app.platformStubs.verifyFeishuBot = async () => ({ status: 'ok', name: 'Matrix Bot', openId: 'ou_matrix_bot' })
 
     const named = await app.app.inject({
       method: 'POST',
@@ -693,7 +693,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     // D6 external-identity fence, covered in its own test.)
     const agentId2 = randomUUID()
     await seedAgent(prisma, agentId2, { daemonId: DAEMON })
-    app.deps.verifyFeishuBot = async () => ({ status: 'unreachable' })
+    app.platformStubs.verifyFeishuBot = async () => ({ status: 'unreachable' })
     const unreachable = await app.app.inject({
       method: 'POST',
       url: `${ORG}/integrations`,
@@ -731,7 +731,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST rejects a bot token Slack refuses (400) and stores nothing', async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
-    app.deps.verifySlackBot = async () => ({ status: 'invalid' })
+    app.platformStubs.verifySlackBot = async () => ({ status: 'invalid' })
 
     const res = await app.app.inject({
       method: 'POST',
@@ -747,7 +747,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST rejects an app-level token Slack refuses (400) and stores nothing', async () => {
     const agentId = await placedAgent()
     const { app } = withSpy()
-    app.deps.verifySlackBot = async () => ({
+    app.platformStubs.verifySlackBot = async () => ({
       status: 'ok',
       name: null,
       appId: null,
@@ -755,7 +755,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       teamName: null,
       scopes: []
     })
-    app.deps.verifySlackAppToken = async () => 'invalid'
+    app.platformStubs.verifySlackAppToken = async () => 'invalid'
 
     const res = await app.app.inject({
       method: 'POST',
@@ -770,7 +770,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST rejects valid Slack tokens that belong to different apps', async () => {
     const agentId = await placedAgent()
     const { app } = withSpy()
-    app.deps.verifySlackBot = async () => ({
+    app.platformStubs.verifySlackBot = async () => ({
       status: 'ok',
       name: null,
       appId: 'AOTHER',
@@ -778,7 +778,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       teamName: null,
       scopes: []
     })
-    app.deps.verifySlackAppToken = async () => 'ok'
+    app.platformStubs.verifySlackAppToken = async () => 'ok'
 
     const res = await app.app.inject({
       method: 'POST',
@@ -798,7 +798,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST derives the bot name from auth.test when none is given', async () => {
     const agentId = await placedAgent()
     const { app } = withSpy()
-    app.deps.verifySlackBot = async () => ({
+    app.platformStubs.verifySlackBot = async () => ({
       status: 'ok',
       name: 'matrix_test',
       appId: null,
@@ -819,8 +819,8 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST proceeds when Slack is unreachable (verification is best-effort, not a gate)', async () => {
     const agentId = await placedAgent()
     const { app } = withSpy()
-    app.deps.verifySlackBot = async () => ({ status: 'unreachable' })
-    app.deps.verifySlackAppToken = async () => 'unreachable'
+    app.platformStubs.verifySlackBot = async () => ({ status: 'unreachable' })
+    app.platformStubs.verifySlackAppToken = async () => 'unreachable'
 
     const res = await app.app.inject({
       method: 'POST',
@@ -1161,7 +1161,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       accessExpiresAt: new Date(Date.now() + 60 * 60 * 1000)
     })
     let submitted: unknown
-    app.deps.slackConfigApi = {
+    app.platformStubs.slackConfigApi = {
       createApp: async () => ({ ok: false, error: 'unused' }),
       exportApp: async () => ({
         ok: true,
@@ -1179,7 +1179,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       exchangeOAuth: async () => ({ ok: false, error: 'unused' }),
       rotateConfigToken: async () => ({ ok: false, error: 'unused' })
     } satisfies SlackConfigApi
-    app.deps.verifySlackBot = async () => ({
+    app.platformStubs.verifySlackBot = async () => ({
       status: 'ok',
       name: 'refresh-me',
       appId: 'A0TESTAPP1',
@@ -1225,7 +1225,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
         }
       })
     ).json() as { botId: string }
-    app.deps.verifySlackBot = async () => ({
+    app.platformStubs.verifySlackBot = async () => ({
       status: 'ok',
       name: 'manual-app',
       appId: 'A0MANUAL01',
@@ -1269,7 +1269,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       accessExpiresAt: new Date(Date.now() + 60 * 60 * 1000)
     })
     let exportCalls = 0
-    app.deps.slackConfigApi = {
+    app.platformStubs.slackConfigApi = {
       createApp: async () => ({ ok: false, error: 'unused' }),
       exportApp: async () => {
         exportCalls += 1
@@ -1279,7 +1279,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       exchangeOAuth: async () => ({ ok: false, error: 'unused' }),
       rotateConfigToken: async () => ({ ok: false, error: 'unused' })
     } satisfies SlackConfigApi
-    app.deps.verifySlackBot = async () => ({
+    app.platformStubs.verifySlackBot = async () => ({
       status: 'ok',
       name: 'mismatched-app',
       appId: 'A0DIFFERENT',
@@ -1320,7 +1320,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
           }
         })
       ).json() as { botId: string }
-      app.deps.verifySlackBot = async () => ({
+      app.platformStubs.verifySlackBot = async () => ({
         status: 'ok',
         name: 'old-app',
         appId: 'A0OLDAPP01',

--- a/packages/control-plane/test/integration/slack-platform-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-platform-install.route.test.ts
@@ -210,7 +210,7 @@ describe('GET /integrations/slack/platform/callback', () => {
     expect(bot!.integrations).toHaveLength(1)
     expect(bot!.integrations[0]).toMatchObject({ agentId: preset!.id, status: 'active' })
 
-    app.deps.verifySlackBot = async () => ({
+    app.platformStubs.verifySlackBot = async () => ({
       status: 'ok',
       name: 'agentconnect',
       appId: PLATFORM.appId,

--- a/packages/control-plane/test/integration/slack-tooling-credentials.route.test.ts
+++ b/packages/control-plane/test/integration/slack-tooling-credentials.route.test.ts
@@ -31,6 +31,12 @@ import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { buildApp, type App } from '../../src/app.js'
+import { AppConfigSchema } from '../../src/config/env.js'
+import { MemorySecretsProvider } from '../../src/secrets/providers/memory.js'
+import { systemClock } from '../../src/domain/clock.js'
+import { PgSlackUserConfigStore } from '../../src/persistence/index.js'
+import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import type {
   SlackConfigApi,
   SlackAppCreateResult,
@@ -47,9 +53,12 @@ const DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
 const HOUR = 60 * 60 * 1000
 
 let running: HttpApp | undefined
+let runningApp: App | undefined
 afterEach(async () => {
   await running?.close()
   running = undefined
+  await runningApp?.shutdown()
+  runningApp = undefined
 })
 
 /** Records every call so a test can prove which resolution was taken (a rotate
@@ -300,7 +309,7 @@ describe('providerToolingCredentials — the Settings→Bots manifest refresh', 
 })
 
 describe('providerToolingCredentials — the config status projection', () => {
-  it('reports autoAvailable from the facet, and drops it the moment the store row goes', async () => {
+  it('reports autoAvailable from the shared configUsable rule, and drops it the moment the store row goes', async () => {
     const { app } = withFunnel()
     await storeConfig(app, {
       accessToken: 'xoxe.xoxp-fresh',
@@ -332,9 +341,10 @@ describe('providerToolingCredentials — the config status projection', () => {
     expect(res.json()).toMatchObject({ configured: true, durable: false, autoAvailable: false })
   })
 
-  it('keeps the deployment term out of the facet: no PUBLIC_CP_URL ⇒ no auto-install', async () => {
-    // The funnel's public callback origin is core's knowledge, not the credential
-    // store's — `usableNow` answers only "is the token usable".
+  it('keeps the deployment term separate from the credential: no PUBLIC_CP_URL ⇒ no auto-install', async () => {
+    // The funnel's public callback origin is the deployment's knowledge, not the
+    // credential store's — `configUsable` (and the facet's `usableNow` over it)
+    // answers only "is the token usable".
     const api = new CountingConfigApi()
     const app = buildHttpApp(prisma, undefined, undefined, undefined, { slackConfigApi: api })
     running = app
@@ -389,5 +399,91 @@ describe('the §9 DI collapse keeps its read-through seam', () => {
     expect((await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })).json()).toMatchObject({
       authorization: 'invalid'
     })
+  })
+})
+
+describe('the PRODUCTION composition wires a working facet', () => {
+  /**
+   * REGRESSION (caught in review, not by any focused test). The facet used to be
+   * built from the route dep bundle, whose `slackConfigApi` member this same unit
+   * deleted. `SlackUserConfigDeps` declares that member OPTIONAL, so the bundle
+   * kept satisfying the parameter type: the compiler stayed silent, every focused
+   * suite stayed green (the harness composes the facet from its own stubs), and
+   * every PRODUCTION resolution silently became `unreachable` — quick-install 502
+   * on a perfectly good stored token, refresh degraded to `unknown`, stale
+   * credentials unable to rotate.
+   *
+   * So this builds the app through `buildApp` — the REAL `buildContainer` graph,
+   * the one `src/index.ts` boots — and reads the facet through it. `container.test.ts`
+   * exists for the same reason ("every other test hand-builds `HttpDeps` … so a
+   * variable forgotten here reads as unset in production while every focused test
+   * still passes").
+   */
+  function realApp() {
+    const app = buildApp({
+      prisma,
+      config: AppConfigSchema.parse({
+        DATABASE_URL: 'postgresql://composition/ignored', // prisma is injected
+        API_KEY_PEPPER: 'composition-api-key-pepper-0123456789',
+        SECRETS_PROVIDER: 'memory',
+        PUBLIC_CP_URL: 'https://cp.example.test'
+      }),
+      clock: systemClock,
+      secretsProvider: new MemorySecretsProvider(),
+      secretCipher: new PlaintextSecretCipher()
+    })
+    runningApp = app
+    return app
+  }
+
+  it('resolves a MISSING credential as not_configured, not unreachable', async () => {
+    // The two outcomes are indistinguishable to a caller that only checks `ok`,
+    // and identical in effect here — but the route maps them to different
+    // statuses, so the status IS the probe, and it costs no Slack round-trip:
+    // both short-circuit before `apps.manifest.create`.
+    //   • wired correctly ⇒ `not_configured` ⇒ 409 + "you haven't stored…"
+    //   • API client missing ⇒ `unreachable`  ⇒ 502 "could not reach Slack"
+    const app = realApp()
+    await seedDaemon(prisma, 'd3d3d3d3-dddd-4ddd-8ddd-dddddddddddd', {
+      capabilities: { platforms: ['slack'], runtimes: ['claude'], acp: true, features: [] }
+    })
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: 'd3d3d3d3-dddd-4ddd-8ddd-dddddddddddd' })
+
+    const res = await app.http.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app`,
+      payload: { agentId, name: 'composition-probe' }
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.json().message).toContain('haven’t stored your Slack App Configuration token')
+  })
+
+  it('reads the credential the production store holds', async () => {
+    // Same graph, now with a row: the resolution gets past the store and reaches
+    // the Slack call, which the stub-free production client cannot complete
+    // offline — a 4xx/5xx either way, but NOT the 409 above. That transition is
+    // the proof the facet is reading the real store, with no network assertion.
+    const app = realApp()
+    await seedDaemon(prisma, 'd4d4d4d4-dddd-4ddd-8ddd-dddddddddddd', {
+      capabilities: { platforms: ['slack'], runtimes: ['claude'], acp: true, features: [] }
+    })
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: 'd4d4d4d4-dddd-4ddd-8ddd-dddddddddddd' })
+    await new PgSlackUserConfigStore(prisma, new PlaintextSecretCipher()).put(OrgId(DEFAULT_ORG_ID), DEFAULT_OWNER_ID, {
+      accessToken: 'xoxe.xoxp-production',
+      refreshToken: null,
+      accessExpiresAt: new Date(Date.now() + HOUR)
+    })
+
+    const res = await app.http.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app`,
+      payload: { agentId, name: 'composition-probe' }
+    })
+
+    expect(res.statusCode).not.toBe(409)
+    expect(res.json().message ?? '').not.toContain('haven’t stored')
   })
 })

--- a/packages/control-plane/test/integration/slack-tooling-credentials.route.test.ts
+++ b/packages/control-plane/test/integration/slack-tooling-credentials.route.test.ts
@@ -1,0 +1,393 @@
+/**
+ * The §9 `providerToolingCredentials` facet, end to end — the last leftover of
+ * the S3 CP adoption (#605 deferred it).
+ *
+ * Two flows call BACK INTO the Slack platform for the caller's stored App
+ * Configuration token, and until now each reached past the provider straight
+ * into `http/slack-user-config.ts`:
+ *
+ *  - the quick-install funnel start, `POST /integrations/slack/app`;
+ *  - the Settings→Bots manifest refresh, `POST /bots/:id/slack/refresh`
+ *    (which also lived in CORE `routes/bots.ts` and is now provider-contributed).
+ *
+ * A third — the config STATUS projection, `GET|PUT /slack/config` — computed the
+ * same "is it usable right now" verdict inline with `configUsable(row, now)`.
+ *
+ * WHAT THIS PINS. That all three now answer from ONE store through ONE facet
+ * instance, and that the three resolutions the store can return —
+ * `not_configured` / `expired` (stale access-only token) / rotated-fresh — reach
+ * each caller as the SAME outcome as before the migration. The store is proven
+ * to be the authority by writing to it directly (`repos.slackUserConfig`) and by
+ * counting the Slack API calls a resolution does or does not spend.
+ *
+ * It also pins the READ-THROUGH seam the DI collapse depended on: the twelve
+ * platform-named `HttpDeps` slots are gone, so suites stub platforms through
+ * `app.platformStubs` — and a stub swapped AFTER the app is built must still be
+ * observed, because the providers dereference the bag per call instead of
+ * capturing its members at composition time.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import type {
+  SlackConfigApi,
+  SlackAppCreateResult,
+  SlackManifestExportResult,
+  SlackManifestUpdateResult,
+  SlackOAuthExchangeResult,
+  SlackRotateResult
+} from '../../src/http/slack-config-api.js'
+import { OrgId } from '../../src/domain/ids.js'
+import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
+const HOUR = 60 * 60 * 1000
+
+let running: HttpApp | undefined
+afterEach(async () => {
+  await running?.close()
+  running = undefined
+})
+
+/** Records every call so a test can prove which resolution was taken (a rotate
+ *  spent vs. not) without reaching into the resolver. */
+class CountingConfigApi implements SlackConfigApi {
+  createCalls: string[] = []
+  exportCalls: string[] = []
+  updateCalls: string[] = []
+  rotateCalls: string[] = []
+  rotateResult: SlackRotateResult = {
+    ok: true,
+    rotated: {
+      accessToken: 'xoxe.xoxp-rotated',
+      refreshToken: 'xoxe-rotated-refresh',
+      accessExpiresAt: new Date(Date.now() + 12 * HOUR)
+    }
+  }
+  async createApp(configToken: string): Promise<SlackAppCreateResult> {
+    this.createCalls.push(configToken)
+    return {
+      ok: true,
+      app: {
+        appId: 'A1TOOL',
+        clientId: 'cid',
+        clientSecret: 'csecret',
+        signingSecret: 'ssecret',
+        oauthAuthorizeUrl: 'https://slack.com/oauth/v2/authorize?client_id=cid&scope=chat:write'
+      }
+    }
+  }
+  async exportApp(configToken: string): Promise<SlackManifestExportResult> {
+    this.exportCalls.push(configToken)
+    return { ok: true, manifest: { display_information: { name: 'Kept' } } }
+  }
+  async updateApp(configToken: string): Promise<SlackManifestUpdateResult> {
+    this.updateCalls.push(configToken)
+    return { ok: true, permissionsUpdated: true }
+  }
+  async exchangeOAuth(): Promise<SlackOAuthExchangeResult> {
+    return { ok: false, error: 'unused' }
+  }
+  async rotateConfigToken(refreshToken: string): Promise<SlackRotateResult> {
+    this.rotateCalls.push(refreshToken)
+    return this.rotateResult
+  }
+}
+
+function withFunnel(): { app: HttpApp; api: CountingConfigApi } {
+  const api = new CountingConfigApi()
+  const app = buildHttpApp(prisma, { PUBLIC_CP_URL: 'https://cp.example.test' }, undefined, undefined, {
+    slackConfigApi: api
+  })
+  running = app
+  return { app, api }
+}
+
+async function placedAgent(): Promise<string> {
+  await seedDaemon(prisma, DAEMON, {
+    capabilities: { platforms: ['slack', 'telegram'], runtimes: ['claude'], acp: true, features: [] }
+  })
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, { daemonId: DAEMON })
+  return agentId
+}
+
+/** Write the caller's credential straight into the store the facet must read. */
+async function storeConfig(
+  app: HttpApp,
+  row: { accessToken: string; refreshToken: string | null; accessExpiresAt: Date }
+): Promise<void> {
+  await app.deps.repos.slackUserConfig.put(OrgId(DEFAULT_ORG_ID), DEFAULT_OWNER_ID, row)
+}
+
+/** A Slack bot whose app id matches what `verifySlackBot` will claim, so the
+ *  refresh route reaches its credential resolution. */
+async function installedSlackBot(app: HttpApp, appId: string): Promise<string> {
+  const agentId = await placedAgent()
+  app.platformStubs.verifySlackBot = async () => ({
+    status: 'ok',
+    name: 'tooling-bot',
+    appId,
+    teamId: 'T1',
+    teamName: 'Acme',
+    scopes: []
+  })
+  const created = (await app.app.inject({
+    method: 'POST',
+    url: `${ORG}/integrations`,
+    payload: {
+      name: 'tooling-bot',
+      platform: 'slack',
+      agentId,
+      slack: { botToken: 'xoxb-tooling', appToken: `xapp-1-${appId}-123-abcdef` }
+    }
+  })) as { json(): { botId: string } }
+  return created.json().botId
+}
+
+describe('providerToolingCredentials — the funnel start (POST /integrations/slack/app)', () => {
+  it('resolves the caller row from the SlackUserConfig store and spends no rotate on a fresh token', async () => {
+    const { app, api } = withFunnel()
+    const agentId = await placedAgent()
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-fresh',
+      refreshToken: 'xoxe-refresh',
+      accessExpiresAt: new Date(Date.now() + HOUR)
+    })
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app`,
+      payload: { agentId, name: 'from-funnel' }
+    })
+
+    expect(res.statusCode).toBe(201)
+    // The store answered, and its ACCESS token is what created the app.
+    expect(api.createCalls).toEqual(['xoxe.xoxp-fresh'])
+    expect(api.rotateCalls).toEqual([])
+  })
+
+  it('rotates a stale access token through the facet and persists the fresh pair', async () => {
+    const { app, api } = withFunnel()
+    const agentId = await placedAgent()
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-stale',
+      refreshToken: 'xoxe-refresh',
+      // Inside ROTATE_MARGIN_MS ⇒ "stale" even though it has not technically lapsed.
+      accessExpiresAt: new Date(Date.now() + 60_000)
+    })
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app`,
+      payload: { agentId, name: 'rotated' }
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(api.rotateCalls).toEqual(['xoxe-refresh'])
+    expect(api.createCalls).toEqual(['xoxe.xoxp-rotated'])
+    // …and the rotated pair went BACK to the same store (rotation is single-use).
+    expect(await app.deps.repos.slackUserConfig.get(OrgId(DEFAULT_ORG_ID), DEFAULT_OWNER_ID)).toMatchObject({
+      accessToken: 'xoxe.xoxp-rotated',
+      refreshToken: 'xoxe-rotated-refresh'
+    })
+  })
+
+  it('refuses with 409 + the not-configured copy when the store holds nothing', async () => {
+    const { app, api } = withFunnel()
+    const agentId = await placedAgent()
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app`,
+      payload: { agentId, name: 'no-config' }
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.json().message).toContain('haven’t stored your Slack App Configuration token')
+    expect(api.createCalls).toEqual([])
+  })
+
+  it('refuses with 409 + the expired copy for a lapsed ACCESS-ONLY token (nothing to rotate)', async () => {
+    const { app, api } = withFunnel()
+    const agentId = await placedAgent()
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-lapsed',
+      refreshToken: null,
+      accessExpiresAt: new Date(Date.now() - HOUR)
+    })
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app`,
+      payload: { agentId, name: 'lapsed' }
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.json().message).toContain('expired')
+    expect(api.rotateCalls).toEqual([])
+    expect(api.createCalls).toEqual([])
+  })
+})
+
+describe('providerToolingCredentials — the Settings→Bots manifest refresh', () => {
+  it('resolves the same caller row and syncs the manifest with its access token', async () => {
+    const { app, api } = withFunnel()
+    const botId = await installedSlackBot(app, 'A0TOOL0001')
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-fresh',
+      refreshToken: 'xoxe-refresh',
+      accessExpiresAt: new Date(Date.now() + HOUR)
+    })
+
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().manifest).toBe('synced')
+    expect(api.exportCalls).toEqual(['xoxe.xoxp-fresh'])
+    expect(api.updateCalls).toEqual(['xoxe.xoxp-fresh'])
+    // The token never reaches the browser.
+    expect(JSON.stringify(res.json())).not.toContain('xoxe')
+  })
+
+  it('degrades to manual_update_required — never 5xx — when the store holds nothing', async () => {
+    const { app, api } = withFunnel()
+    const botId = await installedSlackBot(app, 'A0TOOL0002')
+
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().manifest).toBe('manual_update_required')
+    expect(api.exportCalls).toEqual([])
+  })
+
+  it('degrades to manual_update_required for a lapsed ACCESS-ONLY token', async () => {
+    const { app, api } = withFunnel()
+    const botId = await installedSlackBot(app, 'A0TOOL0003')
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-lapsed',
+      refreshToken: null,
+      accessExpiresAt: new Date(Date.now() - HOUR)
+    })
+
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().manifest).toBe('manual_update_required')
+    expect(api.rotateCalls).toEqual([])
+    expect(api.exportCalls).toEqual([])
+  })
+
+  it("reports 'unknown' (not a failed sync) when the rotate cannot reach Slack", async () => {
+    const { app, api } = withFunnel()
+    const botId = await installedSlackBot(app, 'A0TOOL0004')
+    api.rotateResult = { ok: false, error: 'unreachable' }
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-stale',
+      refreshToken: 'xoxe-refresh',
+      accessExpiresAt: new Date(Date.now() + 60_000)
+    })
+
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().manifest).toBe('unknown')
+    expect(api.exportCalls).toEqual([])
+  })
+})
+
+describe('providerToolingCredentials — the config status projection', () => {
+  it('reports autoAvailable from the facet, and drops it the moment the store row goes', async () => {
+    const { app } = withFunnel()
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-fresh',
+      refreshToken: 'xoxe-refresh',
+      accessExpiresAt: new Date(Date.now() + HOUR)
+    })
+
+    const usable = await app.app.inject({ method: 'GET', url: `${ORG}/slack/config` })
+    expect(usable.json()).toMatchObject({ configured: true, durable: true, funnelEnabled: true, autoAvailable: true })
+
+    await app.app.inject({ method: 'DELETE', url: `${ORG}/slack/config` })
+    const gone = await app.app.inject({ method: 'GET', url: `${ORG}/slack/config` })
+    expect(gone.json()).toMatchObject({ configured: false, durable: false, autoAvailable: false })
+  })
+
+  it('a lapsed access-only token is configured but NOT auto-available', async () => {
+    const { app } = withFunnel()
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-lapsed',
+      refreshToken: null,
+      accessExpiresAt: new Date(Date.now() - HOUR)
+    })
+
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/slack/config` })
+
+    // `configured` and `autoAvailable` are DIFFERENT questions, and only the
+    // second is the facet's: the console still shows the stored token, but the
+    // wizard falls back to the manual manifest path.
+    expect(res.json()).toMatchObject({ configured: true, durable: false, autoAvailable: false })
+  })
+
+  it('keeps the deployment term out of the facet: no PUBLIC_CP_URL ⇒ no auto-install', async () => {
+    // The funnel's public callback origin is core's knowledge, not the credential
+    // store's — `usableNow` answers only "is the token usable".
+    const api = new CountingConfigApi()
+    const app = buildHttpApp(prisma, undefined, undefined, undefined, { slackConfigApi: api })
+    running = app
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-fresh',
+      refreshToken: 'xoxe-refresh',
+      accessExpiresAt: new Date(Date.now() + HOUR)
+    })
+
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/slack/config` })
+
+    expect(res.json()).toMatchObject({ configured: true, durable: true, funnelEnabled: false, autoAvailable: false })
+  })
+})
+
+describe('the §9 DI collapse keeps its read-through seam', () => {
+  it('observes a platform stub swapped AFTER the app is built', async () => {
+    // The twelve platform-named `HttpDeps` slots are gone; the providers and their
+    // routes are composed from `platformStubs`, which suites mutate post-build.
+    // If any seam captured the member at composition time instead of dereferencing
+    // it per call, the second response below would still be the first stub's.
+    const { app } = withFunnel()
+    await placedAgent()
+
+    const probe = () =>
+      app.app.inject({ method: 'POST', url: `${ORG}/integrations/telegram/check`, payload: { botToken: '123:abc' } })
+
+    // The harness default: a valid token with Group Privacy Mode already off.
+    expect((await probe()).json()).toEqual({ status: 'ready' })
+
+    app.platformStubs.verifyTelegramBot = async () => ({
+      status: 'ok',
+      name: 'privacy-on',
+      privacyModeDisabled: false
+    })
+    expect((await probe()).json()).toEqual({ status: 'privacy_enabled' })
+
+    app.platformStubs.verifyTelegramBot = async () => ({ status: 'invalid' })
+    expect((await probe()).json()).toEqual({ status: 'invalid' })
+  })
+
+  it('observes a Slack verifier swapped AFTER the app is built, on a provider-contributed route', async () => {
+    const { app } = withFunnel()
+    const botId = await installedSlackBot(app, 'A0TOOL0005')
+
+    // `installedSlackBot` left a verifier claiming this exact app id + no scopes.
+    expect((await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })).json()).toMatchObject({
+      authorization: 'reinstall_required'
+    })
+
+    app.platformStubs.verifySlackBot = async () => ({ status: 'invalid' })
+    expect((await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })).json()).toMatchObject({
+      authorization: 'invalid'
+    })
+  })
+})


### PR DESCRIPTION
## What

#605 moved route mounting, the background lifecycle, the env fold and the create tail
behind `CpPlatformProvider`, and listed four things it deferred. This is those four. After
it, **no core file names a platform and no core dep slot IS a platform** — §9's CP side is
closed.

### 1. `providerToolingCredentials` stops being half-migrated

Three flows reached past the provider straight into `http/slack-user-config.ts`: the
quick-install funnel start (`POST /integrations/slack/app`), the config status projection
(`GET|PUT /slack/config`), and the Settings→Bots manifest refresh. They now call **one facet
instance** the composition root builds with a new `createSlackToolingCredentials(...)` and
hands to *both* the provider and its routes. `SlackCpProviderDeps.userConfigs` becomes
`toolingCredentials` so that single instance is the type-level truth rather than a
convention.

The refresh flow itself moves with the facet, as §9 says it must (*"both migrate into the
provider with this facet"*). It was the last core code holding `deps.slackConfigApi` +
`deps.verifySlackBot`, and it sat in the **generic** bot surface. It is now
`http/routes/slack-bot-refresh.ts`, contributed through `installRoutes('org')` — same path,
same handler, `slackAppLinks` carried along (its unit test moved with it).

The **status projection** keeps applying `configUsable(row, now)` to the row it already
holds rather than re-reading through `usableNow` (review feedback): the single-authority
property comes from that *pure predicate*, which `usableNow` is a thin wrapper over, so the
rule still has one implementation while the extra round-trip and the split-snapshot response
go away. §9 puts the store's entry/rotation/status routes on `installRoutes` and reserves the
facet for the platform's OTHER flows, which is where it stays.

**On the semantic-split check:** I looked for one and there is none to report. All three
callers and the provider read the same `SlackUserConfig` store through the same
`resolveUserConfigAccessToken` / `configUsable` bodies, with the same rotate-near-expiry
margin — the duplication was structural, not semantic. The one distinction worth stating is
that the credential verdict is **not** the whole of `autoAvailable`: the status route keeps
the deployment term (`PUBLIC_CP_URL`) that only it knows. That split is explicit in both the
code and a test.

**One regression, caught in review and fixed in `b25bc5cc`** — worth recording because of
*why* it was invisible. The facet was first built from the route dep bundle, whose
`slackConfigApi` member this same unit deletes. `SlackUserConfigDeps` declares that member
OPTIONAL, so the bundle kept satisfying the parameter type: the compiler stayed silent, every
suite stayed green, and the production graph resolved every token as `unreachable` before the
row was read. The suites missed it because `build-http.ts` composed the facet *differently*
from `container.ts`. The fix makes it unrepresentable rather than merely correct —
`createSlackToolingCredentials` now takes named `{ configApi?, store }`, and no dep object
here has a `store` member to donate — and adds a container-graph regression test (below).

### 2. The DI collapse

The twelve platform-named `HttpDeps` slots are deleted (plus `slackPlatformApp`). They
conflated two different things:

- **Capability probes** — `if (deps.syncTelegramBotIcon)`, the audit's "optional-dependency
  presence as the branch" (Appendix C §5.1). The registry answers these now.
- **Injection** — a Slack route needs a Slack API client, swappable so suites stay offline.
  That was never a core concern, so it is no longer on core deps: it moves to
  `http/platform-route-seams.ts`, one seams type per platform, taken by that platform's
  route factories as a second argument and built once in `container.ts` beside the provider.

`http/agent-bot-icon-sync.ts` loses its three-way `bot.platform === … && deps.syncX`
dispatch for `provider.sideEffects?.syncBotProfileIcon`. Member presence was already the
documented capability signal and all three providers already declared the member, so this is
a call-site swap.

**The read-through seam is the load-bearing part.** Suites swap platform stubs *after*
`buildApp`, so nothing may capture a stub at composition time. `test/fakes/build-http.ts`
grows a mutable `PlatformStubs` bag on the fixture; every provider and route seam
dereferences it per call. `configApi` / `platformApp` are **getters** for a specific reason:
the funnel plugins read them once at plugin-registration time (that IS the feature flag),
while the refresh handler reads `configApi` per *request* — which is what it did as core
code reading `deps.slackConfigApi`. Plain values there silently broke one existing test, and
the getter is what restores the old timing exactly.

~50 test sites move from `app.deps.x` to `app.platformStubs.x`. Build-time overrides keep
their existing call shape — `buildHttpApp`'s overrides bag now accepts both and peels the
platform keys out — so no `buildHttpApp(...)` call site changed.

### 3. `POST /integrations/telegram/check`

The last per-platform route in core `routes/integrations.ts`, and the last core reader of
`deps.verifyTelegramBot`. It becomes a Telegram `installRoutes('org')` contribution.

**No other platform has an equivalent, and the new file says so explicitly** so the next
platform does not add one out of symmetry. Telegram alone has a credential-adjacent
*account setting* the install cannot repair for the operator (Group Privacy Mode, a
BotFather round-trip). Discord's comparable gate — the Message-Content intent — is *enabled*
by the CP inside `validateConfig`; Slack's and Feishu's probes would only restate what the
create call already says, with the same copy, one step later. A generic "probe these
credentials" route would have to return the §9 `CpConfigValidation` union verbatim, which is
the create route's own pre-store contract — a §15 consolidation, not this unit.

### 4. The `rc/bot-assign` completeness gates

`syncBot` / `replayTo` read `secretShape.httpAssignRequires` instead of branching on
`bot.platform`. Same slots (Slack ⇒ `signingSecret`, Feishu ⇒ `verificationToken` +
`appToken`), now declared by the platform that owns them, so a fifth platform's requirement
arrives with its provider. A platform with no registered provider yields no requirements —
exactly as the old two-arm form did for a foreign row — and `buildAssign`'s absent-projector
fence is what refuses it a moment later.

## Behavior

**One deliberate change: the two operator-facing gate messages converge on one.** This is
the "say so explicitly" case from the unit brief — I did not preserve both, and here is why.

| | Before | After |
| --- | --- | --- |
| Slack | `http-bot: no signing secret for http Slack bot — cannot assign`<br>bindings `{ botId }` | `http-bot: incomplete callback credentials — cannot assign`<br>bindings `{ botId, platform: 'slack', missing: ['signingSecret'] }` |
| Feishu | `http-bot: incomplete Feishu callback credentials — cannot assign`<br>bindings `{ botId }` | `http-bot: incomplete callback credentials — cannot assign`<br>bindings `{ botId, platform: 'feishu', missing: ['verificationToken'] \| ['appToken'] \| ['verificationToken','appToken'] }` |

The generic form is strictly more informative for the operator debugging "why is my bot not
receiving anything": the platform is a binding (queryable, not embedded in prose), and the
missing slot NAMES are reported — which the Feishu message never did, even though its
condition covered two slots. Keeping the old strings would have meant a per-platform message
map, i.e. reintroducing the platform branch this change removes. Both messages and their
bindings are pinned per platform by new tests. `replayTo` stays **silent** (it always was —
the register replay walks every http bot and one incomplete row must not become a log
storm), and that silence is pinned too.

**One incidental diagnostic changes, pinned by no test:**

- The Feishu icon push's `agent bot icon sync skipped: Feishu App ID is missing` warn is
  gone. The provider's `syncBotProfileIcon` resolves `secrets.appToken ?? bot.feishuAppId`
  internally and no-ops without one, which core cannot narrate. The terminal outcome is
  unchanged (nothing is pushed, the fan-out returns); only the log line is lost, for a row
  that would need a Feishu bot with neither credential slot nor public app id.
Everything else is byte-for-byte: same statuses, codes and copy on every route; same
`manual_update_required` / `unknown` degradation ladder on the refresh; same install-funnel
force-rotate-and-drop behavior; same icon fan-out latest-wins repair loop.

## Deploy surface

**No change.** No public path, mount scope, env key or feature flag moves.

Both relocated routes register into the **same** `/api/v1/orgs/:orgId` scope their core
hosts did (`server.ts` registers `integrationRoutes`, the registry's org plugins, and
`botRoutes` into one `scope`), so every public path is byte-identical:

| Path | Before | After |
| --- | --- | --- |
| `POST /api/v1/orgs/:orgId/bots/:id/slack/refresh` | core `routes/bots.ts` | Slack provider `installRoutes('org')` — **same path** |
| `POST /api/v1/orgs/:orgId/integrations/telegram/check` | core `routes/integrations.ts` | Telegram provider `installRoutes('org')` — **same path** |

**Evidence** (reusing #605's mount-table apparatus):

1. `src/http/platform-route-mounts.test.ts` gains both routes to its pinned table and a new
   case asserting each appears **exactly once**, at its original full path, in Fastify's own
   captured route table — plus the existing case that every contributed org route still
   carries `tags` / `summary` / `description` / a unique `operationId` in the generated
   OpenAPI document (both new routes do; `refreshSlackBot` and `checkTelegramBot` keep their
   operationIds).
2. The **complete 239-row route table** was dumped from a fully-enabled server on
   `origin/main` and on this branch and diffed — **identical**.

**Env vars / feature flags:** none added, renamed or removed. A funnel plugin still
self-disables on absent config (no `slackConfigApi` / `PUBLIC_CP_URL` ⇒ those routes 404).
The two relocated routes register unconditionally, exactly as their core hosts did.

## Tests

`pnpm --filter @agentconnect.md/control-plane test:unit`
→ **128 files / 1205 tests passed** (1192 on this base; +13).

`pnpm --filter @agentconnect.md/control-plane test:int` (Docker up)
→ **71 files / 971 tests passed** (70 / 956 on this base; +1 file, +15). Run four times: on
the base, mid-refactor, on the first head, and after the review fix.

Also green: `tsc -p packages/control-plane/tsconfig.typecheck.json --noEmit` (src **and**
test), `eslint packages/control-plane/{src,test}` (0 errors, 0 new warnings),
`prettier --check packages/control-plane`.

**New `test/integration/slack-tooling-credentials.route.test.ts` (13 cases).** The store is
proven to be the authority by writing to `repos.slackUserConfig` directly and by counting
the Slack API calls a resolution does or does not spend:

- *funnel start* — a fresh token resolves and spends **no** rotate (the create call carries
  the stored access token verbatim); a stale token rotates once and the fresh pair is written
  **back to the same store**; an empty store 409s with the not-configured copy and calls
  nothing; a lapsed **access-only** token 409s with the expired copy and never attempts a
  rotate;
- *manifest refresh* — the same row resolves and both `exportApp`/`updateApp` receive that
  access token, and the token never reaches the response body; an empty store and a lapsed
  access-only token both degrade to `manual_update_required` (never 5xx) without touching
  Slack; a rotate that cannot reach Slack reports `unknown`, not a failed sync;
- *status projection* — `autoAvailable` follows the facet and drops the moment the row is
  deleted; a lapsed access-only token is `configured: true` but `autoAvailable: false`
  (different questions); and with no `PUBLIC_CP_URL` the credential is usable while
  `autoAvailable` is false — the deployment term the facet deliberately does not own.

**The production composition** (same file, 2 cases): the app is built through `buildApp` —
the real `buildContainer` graph, not the harness — and a MISSING credential must resolve as
`not_configured` (⇒ 409) rather than `unreachable` (⇒ 502); a companion case proves a stored
row is actually read. Neither spends a Slack round-trip: both short-circuit before
`apps.manifest.create`. **Verified to fail on the broken wiring** (`expected 502 to be 409`)
before the fix was applied. `container.test.ts` exists for this same failure mode — "every
other test hand-builds `HttpDeps` … so a variable forgotten here reads as unset in production
while every focused test still passes" — and this is its integration-scale sibling.

**The read-through seam** (same file, 2 cases): a stub swapped **after** `buildApp` is
observed on two provider-contributed routes — `verifyTelegramBot` walked through
ready → privacy_enabled → invalid, and `verifySlackBot` flipped mid-suite to turn a refresh
from `reinstall_required` into `invalid`. If any seam captured its member at composition
time, the second response would still be the first stub's.

**`src/http/agent-bot-icon-sync.test.ts`** now composes the four real providers and drives
dispatch through `sideEffects.syncBotProfileIcon`: Telegram/Discord/Feishu each pushed once
with the credential their provider resolves (Feishu's from `secrets.appToken`), a cosmetic
failure still isolated, plus two explicit no-op pins — **Slack** (declares no member; its
credential is not even read) and a **Feishu composed without its syncer** (no member ⇒ not
icon-capable, no credential read, no warn). The two latest-wins repair cases are unchanged
behaviorally.

**`src/orchestrator/httpBot.test.ts`** gains the completeness gate (10 cases): four
platform × missing-slot combinations, each asserting `syncBot` broadcasts **nothing at all**
(not an empty frame), pushes no send-only spec, and emits exactly the message + bindings in
the table above; the matching `replayTo` skips silently; a platform declaring
`httpAssignRequires: []` is never gated here (the absent-projector fence fires instead, with
its own message); and a complete Feishu credential assigns with no warn.

**`src/platforms/slack/provider.test.ts`** re-points its `providerToolingCredentials` cases
at `createSlackToolingCredentials(...)`, so the facet the container injects is the one under
test, and adds one pinning the asymmetry that hid the regression: an omitted `configApi`
yields `unreachable` **without touching the store**, while `usableNow` answers from the store
regardless — which is why the status projection never noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
