### PR TITLE
test(daemon): give daemon-backed vi.waitFor polls the 10s CI budget

### DIFF
--- a/packages/daemon/test/curated-runtime-daemon.test.ts
+++ b/packages/daemon/test/curated-runtime-daemon.test.ts
@@ -31,44 +31,48 @@ function catalog(): ResolvedRuntimeCatalog {
 }
 
 async function waitForProbe(daemon: Daemon, probe: ReturnType<typeof vi.fn>): Promise<void> {
-  await vi.waitFor(() => expect(probe).toHaveBeenCalled(), { timeout: 2_000 })
-  await vi.waitFor(() => expect((daemon as any).probing).toBe(false), { timeout: 2_000 })
+  await vi.waitFor(() => expect(probe).toHaveBeenCalled(), WAIT)
+  await vi.waitFor(() => expect((daemon as any).probing).toBe(false), WAIT)
 }
 
 describe('daemon curated runtime admission', () => {
   it.each([
     [true, ['explicit', 'hermes-agent']],
     [false, ['explicit']]
-  ])('runs while CP is disabled and exposes only admitted winners (ok=%s)', async (ok, expected) => {
-    const probe = vi.fn(async (runtimes: Record<string, unknown>, options: { curated?: boolean }) =>
-      Object.keys(runtimes).map((runtime) => ({
-        runtime,
-        ok: runtime === 'hermes-agent' ? ok : true,
-        models: [],
-        ...(!ok && runtime === 'hermes-agent' ? { error: 'initialize failed' } : {})
-      }))
-    )
-    const daemon = new Daemon({
-      root: root(),
-      resolveCatalog: async () => catalog(),
-      installed: (runtimes) => runtimes,
-      probeRuntimes: probe as never,
-      hostFactory: () => ({}) as never
-    })
+  ])(
+    'runs while CP is disabled and exposes only admitted winners (ok=%s)',
+    async (ok, expected) => {
+      const probe = vi.fn(async (runtimes: Record<string, unknown>, options: { curated?: boolean }) =>
+        Object.keys(runtimes).map((runtime) => ({
+          runtime,
+          ok: runtime === 'hermes-agent' ? ok : true,
+          models: [],
+          ...(!ok && runtime === 'hermes-agent' ? { error: 'initialize failed' } : {})
+        }))
+      )
+      const daemon = new Daemon({
+        root: root(),
+        resolveCatalog: async () => catalog(),
+        installed: (runtimes) => runtimes,
+        probeRuntimes: probe as never,
+        hostFactory: () => ({}) as never
+      })
 
-    try {
-      await daemon.start()
-      await waitForProbe(daemon, probe)
-      await vi.waitFor(() => expect(Object.keys((daemon as any).runtimes).sort()).toEqual(expected.sort()), WAIT)
-      expect(probe.mock.calls.some(([, options]) => options.curated === true)).toBe(true)
+      try {
+        await daemon.start()
+        await waitForProbe(daemon, probe)
+        await vi.waitFor(() => expect(Object.keys((daemon as any).runtimes).sort()).toEqual(expected.sort()), WAIT)
+        expect(probe.mock.calls.some(([, options]) => options.curated === true)).toBe(true)
 
-      const calls = probe.mock.calls.length
-      await (daemon as any).probeRuntimesAndEmit(false)
-      expect(probe).toHaveBeenCalledTimes(calls)
-    } finally {
-      await daemon.stop()
-    }
-  })
+        const calls = probe.mock.calls.length
+        await (daemon as any).probeRuntimesAndEmit(false)
+        expect(probe).toHaveBeenCalledTimes(calls)
+      } finally {
+        await daemon.stop()
+      }
+    },
+    15_000
+  )
 
   it('probes and admits a curated runtime UNSANDBOXED on a host with no sandbox mechanism (#36)', async () => {
     // Regression: the probe used to be skipped on a no-sandbox host, so curated
@@ -146,7 +150,7 @@ describe('daemon curated runtime admission', () => {
     } finally {
       await daemon.stop()
     }
-  })
+  }, 15_000)
 
   it('keeps a live-observed login-required mark through a successful probe sweep', async () => {
     const probe = vi.fn(async (runtimes: Record<string, unknown>) =>
@@ -224,7 +228,7 @@ describe('daemon curated runtime admission', () => {
       const timer = (daemon as any).runtimeProbeTimer
       if (timer !== undefined) clock.clearTimeout(timer)
     }
-  })
+  }, 15_000)
 
   it('does not arm a local probe timer when no curated source wins', () => {
     const daemon = new Daemon({ clock: new FakeClock(100), sandboxMechanism: null })
@@ -262,5 +266,5 @@ describe('daemon curated runtime admission', () => {
     await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2), WAIT)
     expect(Object.keys(probe.mock.calls[0]![0])).toEqual(['hermes-agent'])
     expect(Object.keys(probe.mock.calls[1]![0])).toEqual(['explicit'])
-  })
+  }, 15_000)
 })

--- a/packages/daemon/test/curated-runtime-daemon.test.ts
+++ b/packages/daemon/test/curated-runtime-daemon.test.ts
@@ -7,6 +7,11 @@ import { Daemon } from '../src/daemon.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 import { FakeClock } from './cp/fake-clock.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 function root(): string {
   const path = mkdtempSync(join(tmpdir(), 'ac-curated-daemon-'))
   writeFileSync(join(path, 'config.json'), JSON.stringify({ version: 1, controlPlane: { enabled: false } }))
@@ -54,7 +59,7 @@ describe('daemon curated runtime admission', () => {
     try {
       await daemon.start()
       await waitForProbe(daemon, probe)
-      await vi.waitFor(() => expect(Object.keys((daemon as any).runtimes).sort()).toEqual(expected.sort()))
+      await vi.waitFor(() => expect(Object.keys((daemon as any).runtimes).sort()).toEqual(expected.sort()), WAIT)
       expect(probe.mock.calls.some(([, options]) => options.curated === true)).toBe(true)
 
       const calls = probe.mock.calls.length
@@ -113,7 +118,7 @@ describe('daemon curated runtime admission', () => {
       await daemon.start()
       await waitForProbe(daemon, probe)
       // Not admitted: launch and placement still refuse it…
-      await vi.waitFor(() => expect(Object.keys((daemon as any).runtimes)).toEqual(['explicit']))
+      await vi.waitFor(() => expect(Object.keys((daemon as any).runtimes)).toEqual(['explicit']), WAIT)
       expect(() => (daemon as any).curatedRuntimeAdmission.assertLaunch('hermes-agent', 'curated')).toThrow(
         /Authentication required/
       )
@@ -210,8 +215,8 @@ describe('daemon curated runtime admission', () => {
       ;(daemon as any).armRuntimeProbeRefresh()
 
       clock.advance(5 * 60_000)
-      await vi.waitFor(() => expect(probe).toHaveBeenCalled())
-      await vi.waitFor(() => expect((daemon as any).probing).toBe(false))
+      await vi.waitFor(() => expect(probe).toHaveBeenCalled(), WAIT)
+      await vi.waitFor(() => expect((daemon as any).probing).toBe(false), WAIT)
       expect(Object.keys((daemon as any).runtimes).sort()).toEqual(['explicit', 'hermes-agent'])
       expect(Object.keys(probe.mock.calls[0]![0])).toEqual(['hermes-agent'])
     } finally {
@@ -249,12 +254,12 @@ describe('daemon curated runtime admission', () => {
     ;(daemon as any).refreshAdmittedRuntimes()
 
     const curated = (daemon as any).probeRuntimesAndEmit(false)
-    await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(1), WAIT)
     await (daemon as any).probeRuntimesAndEmit(true)
     releaseFirst()
     await curated
 
-    await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2), WAIT)
     expect(Object.keys(probe.mock.calls[0]![0])).toEqual(['hermes-agent'])
     expect(Object.keys(probe.mock.calls[1]![0])).toEqual(['explicit'])
   })

--- a/packages/daemon/test/curated-runtime-daemon.test.ts
+++ b/packages/daemon/test/curated-runtime-daemon.test.ts
@@ -198,7 +198,7 @@ describe('daemon curated runtime admission', () => {
     } finally {
       await daemon.stop()
     }
-  })
+  }, 15_000)
 
   it('refreshes curated admission after the TTL without requiring a CP reconnect', async () => {
     const clock = new FakeClock(100)

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -444,7 +444,7 @@ describe('Daemon in-conversation commands', () => {
     expect((daemon as any).store.isSessionMuted(muteKey)).toBe(false)
     blocked.release()
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('!queue buffers a message and dispatches it once the turn goes idle', async () => {
     const blocked = blockingHost()

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -14,6 +14,11 @@ import { Daemon } from '../src/daemon.js'
 import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 const AGENT_IDENTITY = {
   displayName: 'Review Bot',
   iconUrl: 'https://console.example.test/icons/bot-a'
@@ -435,7 +440,7 @@ describe('Daemon in-conversation commands', () => {
       msgId: 'm-mention',
       accepted: true
     })
-    await vi.waitFor(() => expect(blocked.prompts).toHaveLength(1))
+    await vi.waitFor(() => expect(blocked.prompts).toHaveLength(1), WAIT)
     expect((daemon as any).store.isSessionMuted(muteKey)).toBe(false)
     blocked.release()
     await daemon.stop()
@@ -449,7 +454,7 @@ describe('Daemon in-conversation commands', () => {
 
     // first message starts a turn whose prompt blocks
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
 
     // queue a follow-up while the turn is in flight
     ;(daemon as any).onInbound(dm('200', '!queue do it'))
@@ -461,7 +466,7 @@ describe('Daemon in-conversation commands', () => {
     // let the first turn finish → the queued message is released
     blocked.release()
     await turn
-    await vi.waitFor(() => expect(blocked.prompts.length).toBe(2))
+    await vi.waitFor(() => expect(blocked.prompts.length).toBe(2), WAIT)
     expect(blocked.prompts[1]).toContain('do it')
     expect((daemon as any).serialQueue.has(SESSION_KEY)).toBe(false)
 
@@ -476,7 +481,7 @@ describe('Daemon in-conversation commands', () => {
 
     // no in-flight turn for this thread → dispatch right away
     ;(daemon as any).onInbound(dm('100', '!queue start now'))
-    await vi.waitFor(() => expect(blocked.prompts.length).toBe(1))
+    await vi.waitFor(() => expect(blocked.prompts.length).toBe(1), WAIT)
     expect(blocked.prompts[0]).toContain('start now')
     expect((daemon as any).serialQueue.size).toBe(0)
 
@@ -491,7 +496,7 @@ describe('Daemon in-conversation commands', () => {
     const conn = makeRoutable(daemon)
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
 
     for (let i = 0; i < 10; i++) (daemon as any).onInbound(dm(`${200 + i}`, `!queue m${i}`))
     expect((daemon as any).serialQueue.get(SESSION_KEY)).toHaveLength(10)
@@ -511,7 +516,7 @@ describe('Daemon in-conversation commands', () => {
     const conn = makeRoutable(daemon)
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
 
     ;(daemon as any).onInbound(dm('200', '!stop'))
     expect(blocked.host.cancel).toHaveBeenCalledWith('acp-1')
@@ -543,7 +548,7 @@ describe('Daemon in-conversation commands', () => {
     const key = SESSION_KEY
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'cold'), 'int-a')
-    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalled())
+    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalled(), WAIT)
     expect((daemon as any).store.getSession(key)).toBeUndefined()
     ;(daemon as any).onInbound(dm('200', '!stop'))
     expect((daemon as any).isSessionMuted(key)).toBe(true)
@@ -598,7 +603,7 @@ describe('Daemon in-conversation commands', () => {
 
     const cold = { ...dm('100', 'cold T2'), thread: 'T2' }
     const turn = (daemon as any).dispatch('bot-a', cold, 'int-a')
-    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalled())
+    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalled(), WAIT)
     expect((daemon as any).store.getSession(coldKey)).toBeUndefined()
 
     ;(daemon as any).onInbound({ ...dm('200', '!stop'), thread: 'T2' })
@@ -618,7 +623,7 @@ describe('Daemon in-conversation commands', () => {
     const conn = makeRoutable(daemon)
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
 
     ;(daemon as any).onInbound(dm('200', '!cancel'))
     expect(blocked.host.cancel).toHaveBeenCalledWith('acp-1')
@@ -651,7 +656,7 @@ describe('Daemon in-conversation commands', () => {
     makeRoutable(daemon)
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
 
     ;(daemon as any).onInbound(dm('200', '!queue later')) // buffered behind the turn
     expect((daemon as any).serialQueue.get(SESSION_KEY)).toHaveLength(1)
@@ -676,7 +681,7 @@ describe('Daemon in-conversation commands', () => {
     const store = (daemon as any).store
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
 
     ;(daemon as any).onInbound(dm('200', '!stop'))
     expect(store.isSessionMuted(SESSION_KEY)).toBe(true)
@@ -696,13 +701,13 @@ describe('Daemon in-conversation commands', () => {
 
     // explicit @mention clears the mute and dispatches (with the missed context replayed)
     ;(daemon as any).onInbound({ ...dm('400', '<@UBOTA> resume please'), mentionedBots: ['UBOTA'] })
-    await vi.waitFor(() => expect(blocked.prompts.length).toBe(2))
+    await vi.waitFor(() => expect(blocked.prompts.length).toBe(2), WAIT)
     expect(store.isSessionMuted(SESSION_KEY)).toBe(false)
     expect(blocked.prompts[1]).toContain('humans talking amongst themselves')
 
     // thread affinity works again after the un-mute
     ;(daemon as any).onInbound(dm('500', 'carry on'))
-    await vi.waitFor(() => expect(blocked.prompts.length).toBe(3))
+    await vi.waitFor(() => expect(blocked.prompts.length).toBe(3), WAIT)
 
     await daemon.stop()
   }, 15_000)
@@ -908,7 +913,7 @@ describe('Daemon in-conversation commands', () => {
     expect(store.getPermissionModeOverride(key)).toBe('agent-full-access')
     await vi.waitFor(() => {
       expect(host.setSessionPermissionMode).toHaveBeenCalledWith('acp-1', 'agent-full-access')
-    })
+    }, WAIT)
     expect(conn.postMessage).toHaveBeenCalledWith(
       'C1',
       expect.stringContaining('Permission mode set to Full Access'),
@@ -920,7 +925,7 @@ describe('Daemon in-conversation commands', () => {
     expect(store.getPermissionModeOverride(key)).toBe('agent')
     await vi.waitFor(() => {
       expect(host.setSessionPermissionMode).toHaveBeenCalledWith('acp-1', 'agent')
-    })
+    }, WAIT)
     host.setSessionPermissionMode.mockClear()
     host.setSessionApprovalsReviewer.mockClear()
 
@@ -931,7 +936,7 @@ describe('Daemon in-conversation commands', () => {
     await vi.waitFor(() => {
       expect(host.setSessionPermissionMode).toHaveBeenCalledWith('acp-1', 'agent')
       expect(host.setSessionApprovalsReviewer).toHaveBeenCalledWith('acp-1', 'auto_review')
-    })
+    }, WAIT)
 
     await daemon.stop()
   }, 15_000)
@@ -1042,7 +1047,7 @@ describe('Daemon managed-agent bot ingress', () => {
     expect(host.prompt).not.toHaveBeenCalled()
 
     ;(daemon as any).onInbound(botMessage('external-mention', 'AEXTERNAL', ['UBOTA']))
-    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1), WAIT)
 
     await daemon.stop()
   }, 15_000)
@@ -1183,7 +1188,7 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
 
     // start a turn that blocks (simulating a long-running turn)
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
 
     // age the session record so the recency window alone would exclude it
     const rec = store.getSession(SESSION_KEY)
@@ -1293,7 +1298,7 @@ describe('Slack interactive status bar', () => {
 
     // Turn 1: the status bar posts up front (before the blocked prompt returns).
     const t1 = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
-    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1), WAIT)
     expect(host.prompt).toHaveBeenCalledTimes(1) // posted before the reply completes
     // The status line uses the selected agent identity even in DMs, and remains marked as
     // chrome so a peer daemon's thread backfill skips it.
@@ -1377,7 +1382,7 @@ describe('Slack interactive status bar', () => {
 
     // Turn is blocked mid-prompt: the session status bar (sb1) posts up front.
     const t1 = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
-    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1), WAIT)
     const p = [...(daemon as any).pending.values()][0]
     expect(p.statusBarTs).toBe('sb1')
 
@@ -1387,16 +1392,18 @@ describe('Slack interactive status bar', () => {
     await p.applyChain
     p.lastStatusBar = undefined // mimic a usage update that changes the visible header
     ;(daemon as any).emitStatusBar(p)
-    await vi.waitFor(() =>
-      expect(conn.updateBlocks).toHaveBeenCalledWith(
-        'C1',
-        'sb1',
-        expect.any(Array),
-        expect.any(String),
-        true,
-        undefined,
-        'bot-a'
-      )
+    await vi.waitFor(
+      () =>
+        expect(conn.updateBlocks).toHaveBeenCalledWith(
+          'C1',
+          'sb1',
+          expect.any(Array),
+          expect.any(String),
+          true,
+          undefined,
+          'bot-a'
+        ),
+      WAIT
     )
     expect(p.statusBarTs).toBe('sb1')
     expect((daemon as any).store.getStatusBarTs(p.sessionKey)).toBe('sb1')
@@ -1428,7 +1435,7 @@ describe('Slack interactive status bar', () => {
       mentionedBots: ['UBOTA']
     }
     const turn = (daemon as any).dispatch('bot-a', channelMessage, 'int-a')
-    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1), WAIT)
     const call = conn.postBlocks.mock.calls[0]!
     const blocks = call[1] as {
       type: string
@@ -1481,7 +1488,7 @@ describe('Slack interactive status bar', () => {
       mentionedBots: ['UBOTA']
     }
     const turn = (daemon as any).dispatch('bot-a', channelMessage, 'int-a')
-    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1), WAIT)
     const call = conn.postBlocks.mock.calls[0]!
     const blocks = call[1] as { type: string; block_id?: string; accessory?: any }[]
     const [section] = blocks
@@ -1803,16 +1810,18 @@ describe('Slack interactive status bar', () => {
     ])
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
-    await vi.waitFor(() =>
-      expect(conn.updateBlocks).toHaveBeenCalledWith(
-        'C1',
-        '111.1',
-        expect.any(Array),
-        expect.stringContaining('opus-4.8'),
-        true,
-        undefined,
-        'bot-a'
-      )
+    await vi.waitFor(
+      () =>
+        expect(conn.updateBlocks).toHaveBeenCalledWith(
+          'C1',
+          '111.1',
+          expect.any(Array),
+          expect.stringContaining('opus-4.8'),
+          true,
+          undefined,
+          'bot-a'
+        ),
+      WAIT
     )
     expect(conn.postBlocks).not.toHaveBeenCalled()
     expect((daemon as any).store.getStatusBarTs(SESSION_KEY)).toBe('111.1')
@@ -1845,7 +1854,7 @@ describe('Slack interactive status bar', () => {
     ])
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
-    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalled())
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalled(), WAIT)
     expect(conn.updateBlocks.mock.calls.some((call) => call[1] === '111.1')).toBe(false)
     expect((daemon as any).store.getStatusBarTs(SESSION_KEY)).not.toBe('111.1')
 
@@ -1873,7 +1882,7 @@ describe('Slack interactive status bar', () => {
     ])
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
-    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalled())
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalled(), WAIT)
     expect(conn.updateBlocks.mock.calls.some((call) => call[1] === '111.1')).toBe(false)
     expect(conn.postBlocks.mock.calls[0]?.[4]).toMatchObject({
       chrome: true,
@@ -1897,7 +1906,7 @@ describe('Slack interactive status bar', () => {
 
     // Turn 1: bar posted normally and its ts persisted.
     const turn1 = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
-    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1), WAIT)
     release()
     await turn1
     const posted = (daemon as any).store.getStatusBarTs(SESSION_KEY)
@@ -1908,20 +1917,22 @@ describe('Slack interactive status bar', () => {
     const second = modelHost()
     ;(daemon as any).opts.hostFactory = () => second.host as any
     const turn2 = (daemon as any).dispatch('bot-a', dm('101', 'hi again'), 'int-a')
-    await vi.waitFor(() =>
-      expect(conn.updateBlocks).toHaveBeenCalledWith(
-        'C1',
-        posted,
-        expect.anything(),
-        expect.anything(),
-        true,
-        undefined,
-        'bot-a'
-      )
+    await vi.waitFor(
+      () =>
+        expect(conn.updateBlocks).toHaveBeenCalledWith(
+          'C1',
+          posted,
+          expect.anything(),
+          expect.anything(),
+          true,
+          undefined,
+          'bot-a'
+        ),
+      WAIT
     )
     // The dead ts is dropped and a later emit in the same turn posts a fresh bar.
-    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(2))
-    await vi.waitFor(() => expect((daemon as any).store.getStatusBarTs(SESSION_KEY)).not.toBe(posted))
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(2), WAIT)
+    await vi.waitFor(() => expect((daemon as any).store.getStatusBarTs(SESSION_KEY)).not.toBe(posted), WAIT)
 
     second.release()
     await turn2
@@ -1968,7 +1979,7 @@ describe('Slack interactive status bar', () => {
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
     // Posted while the first prompt is STILL blocked — i.e. before any reply arrives.
-    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1), WAIT)
     const blocks = conn.postBlocks.mock.calls[0]![1] as { type: string; accessory?: any }[]
     expect(blocks.find((b) => b.type === 'section')!.accessory.action_id).toBe('ac_more')
 
@@ -1987,7 +1998,7 @@ describe('Slack interactive status bar', () => {
     ;(daemon as any).cpWebAppUrl = 'https://console.example.com'
 
     const t1 = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
-    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
     // The connection queries statusInfoForKey to build the modal; it resolves the deep link.
     const data = (daemon as any).statusInfoForKey(SESSION_KEY)
     expect(data.link).toBe('https://console.example.com/sessions/acp-1?source=slack')
@@ -2051,7 +2062,7 @@ describe('Slack interactive status bar', () => {
 
     const key = SESSION_KEY
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
-    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
     release()
     await turn
 
@@ -2082,7 +2093,7 @@ describe('Slack interactive status bar', () => {
     const key = SESSION_KEY
 
     const t1 = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
-    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
 
     // set-model: sticky override persisted + applied live to the running session.
     ;(daemon as any).handleStatusAction({ kind: 'set-model', sessionKey: key, model: 'sonnet-5' })
@@ -2098,7 +2109,7 @@ describe('Slack interactive status bar', () => {
         .reverse()
         .find((call) => statusActions(call[2] as any[]) !== undefined)
       expect(statusActions(settledStatus?.[2] as any[])).toEqual(['manage'])
-    })
+    }, WAIT)
 
     release()
     await t1

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -6,6 +6,11 @@ import { ORGANIZATION_SUGGESTION_REVIEW_FEATURE } from '@agentconnect.md/protoco
 import { Daemon } from '../src/daemon.js'
 import { EvaluationEventCollector } from '../src/evaluation/index.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 const AGENT_ID = 'evaluation-agent'
 
 function scaffold(opts: { runtimeCommand?: string; model?: string; autoAdopt?: boolean } = {}): string {
@@ -107,19 +112,21 @@ describe('Daemon evaluation surface', () => {
       usage: { used: 12 }
     })
     expect(host.prompt).toHaveBeenCalledOnce()
-    await vi.waitFor(() =>
-      expect(collector.events().map((event) => event.type)).toEqual(
-        expect.arrayContaining([
-          'turn.accepted',
-          'memory.recall.requested',
-          'memory.recall.completed',
-          'turn.started',
-          'acp.update',
-          'memory.capture.requested',
-          'memory.capture.completed',
-          'turn.completed'
-        ])
-      )
+    await vi.waitFor(
+      () =>
+        expect(collector.events().map((event) => event.type)).toEqual(
+          expect.arrayContaining([
+            'turn.accepted',
+            'memory.recall.requested',
+            'memory.recall.completed',
+            'turn.started',
+            'acp.update',
+            'memory.capture.requested',
+            'memory.capture.completed',
+            'turn.completed'
+          ])
+        ),
+      WAIT
     )
     const events = collector.events()
     expect(events.map((event) => event.sequence)).toEqual(events.map((_, index) => index + 1))
@@ -213,7 +220,7 @@ describe('Daemon evaluation surface', () => {
     await vi.waitFor(() => {
       dream = (daemon as any).store.getDream(AGENT_ID, started.dreamId)
       expect(dream?.status).toBe('adopted')
-    })
+    }, WAIT)
 
     expect(dream).toMatchObject({
       executionSessionId: 'dream-session-1',
@@ -336,7 +343,7 @@ describe('Daemon evaluation surface', () => {
     await vi.waitFor(() => {
       dream = (daemon as any).store.getDream(AGENT_ID, started.dreamId)
       expect(dream?.status).toBe('adopted')
-    })
+    }, WAIT)
 
     expect(dream).not.toHaveProperty('model')
     expect(dream?.usage).not.toHaveProperty('costAmount')
@@ -551,7 +558,7 @@ describe('Daemon evaluation surface', () => {
     }
 
     await (allowed as any).syncOrganizationSuggestions()
-    await vi.waitFor(() => expect(syncOrganizationSuggestions).toHaveBeenCalledTimes(3))
+    await vi.waitFor(() => expect(syncOrganizationSuggestions).toHaveBeenCalledTimes(3), WAIT)
 
     expect(allowedReview).toHaveBeenCalledOnce()
     expect(allowedReview).toHaveBeenCalledWith(decision)

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -30,6 +30,11 @@ import { transcriptCoords } from '../src/session/session-manager.js'
 import { sessionKey } from '../src/store/local-store.js'
 import { sessionWorktreePath } from '../src/workspace/workspace-manager.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 const AGENT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 const HOOK_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 
@@ -144,7 +149,7 @@ describe('Daemon rd/msg hook fires', () => {
     const ack = await (daemon as any).handleRelayMsg(fire(), () => {})
     expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
 
-    await vi.waitFor(() => expect(cp.hookReports.length).toBe(1))
+    await vi.waitFor(() => expect(cp.hookReports.length).toBe(1), WAIT)
     expect(cp.hookReports[0]).toMatchObject({
       hookId: HOOK_ID,
       agentId: AGENT_ID,
@@ -196,7 +201,7 @@ describe('Daemon rd/msg hook fires', () => {
     )
 
     expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
-    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
     expect((daemon as any).store.getSessionByAcpId('acp-hook-1')).toMatchObject({
       title: 'PR #144: perf(github): speed up review delivery',
       transportScope: 'github:123'
@@ -256,7 +261,7 @@ describe('Daemon rd/msg hook fires', () => {
         accepted: true
       })
 
-      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
       expect(cp.hookReports[0]).toMatchObject({
         hookId: HOOK_ID,
         deliveryKey: 'd-1',
@@ -368,7 +373,7 @@ describe('Daemon rd/msg hook fires', () => {
     )
 
     expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
-    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
     expect(cp.startHook).toHaveBeenCalledOnce()
     expect(activeReviewAuthorities).toBe(0)
     expect(submitError?.message).toContain('only available during the active PR hook turn')
@@ -780,7 +785,7 @@ describe('Daemon rd/msg hook fires', () => {
       const ack = await (daemon as any).handleRelayMsg(msg, () => {})
       expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
 
-      await vi.waitFor(() => expect(poster.publish).toHaveBeenCalledTimes(1))
+      await vi.waitFor(() => expect(poster.publish).toHaveBeenCalledTimes(1), WAIT)
       expect(makeGithubReply).toHaveBeenCalledWith(
         AGENT_ID,
         { hookId: HOOK_ID, repo: 'acme/infra', number },
@@ -818,7 +823,7 @@ describe('Daemon rd/msg hook fires', () => {
       // merely that the ACP prompt ended while its comment is still in flight.
       expect(cp.hookReports).toHaveLength(0)
       releasePublish()
-      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
       expect(cp.hookReports[0]).toMatchObject({
         hookId: HOOK_ID,
         deliveryKey: 'd-1',
@@ -931,7 +936,7 @@ describe('Daemon rd/msg hook fires', () => {
         () => {}
       )
 
-      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
       expect(poster.publish).toHaveBeenCalledTimes(publishes ? 1 : 0)
       if (publishes) expect(poster.publish).toHaveBeenCalledWith('Self-contained final.')
       else expect(hookState.mock.calls.some((call) => call[2] === 'settled')).toBe(true)
@@ -1164,7 +1169,7 @@ describe('Daemon rd/msg hook fires', () => {
     ;(restarted as any).makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
 
     await restarted.start()
-    await vi.waitFor(() => expect(hookReports).toHaveLength(1))
+    await vi.waitFor(() => expect(hookReports).toHaveLength(1), WAIT)
     expect(reconcile).toHaveBeenCalledOnce()
     expect(reviewStateDuringPrompt).toBe('idle')
     expect(cp.reportGithubReviewResult).toHaveBeenCalledWith(
@@ -1250,7 +1255,7 @@ describe('Daemon rd/msg hook fires', () => {
 
     await restarted.start()
 
-    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
     expect(makeGithubReply).toHaveBeenCalledWith(
       AGENT_ID,
       {
@@ -1383,7 +1388,7 @@ describe('Daemon rd/msg hook fires', () => {
       )
 
       expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
-      await vi.waitFor(() => expect((daemon as any).workspaceDispatchFences.has(AGENT_ID)).toBe(true))
+      await vi.waitFor(() => expect((daemon as any).workspaceDispatchFences.has(AGENT_ID)).toBe(true), WAIT)
       let admitted = false
       const admission = (daemon as any).admitActiveDispatch(AGENT_ID, key).then((release: () => void) => {
         admitted = true
@@ -1395,7 +1400,7 @@ describe('Daemon rd/msg hook fires', () => {
 
       releaseWorkspaceMutation()
       await blockingMutation
-      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
       const releaseDispatch = await admission
       releaseDispatch()
       expect(cp.hookReports[0]).toMatchObject({ status: 'success', event })
@@ -1428,7 +1433,7 @@ describe('Daemon rd/msg hook fires', () => {
     ;(restarted as never as { cpClient: unknown }).cpClient = cp
     await restarted.start()
 
-    await vi.waitFor(() => expect(cp.hookReports.length).toBe(1))
+    await vi.waitFor(() => expect(cp.hookReports.length).toBe(1), WAIT)
     expect(cp.hookReports[0]).toMatchObject({ status: 'success', reason: 'deleted_event_ignored' })
     expect(cp.hookReports[0]!.sessionId).toBeUndefined()
     expect(restartedHost.host.newSession).not.toHaveBeenCalled()
@@ -1449,12 +1454,12 @@ describe('Daemon rd/msg hook fires', () => {
 
     // 1) An `opened` fire creates the session for acme/infra#42.
     await (daemon as any).handleRelayMsg(ghFire('issues', 'opened', 'd-open'), () => {})
-    await vi.waitFor(() => expect(cp.hookReports.length).toBe(1))
+    await vi.waitFor(() => expect(cp.hookReports.length).toBe(1), WAIT)
     expect(host.newSession).toHaveBeenCalledTimes(1)
 
     // 2) Removing a comment is lifecycle noise even though the thread session exists.
     await (daemon as any).handleRelayMsg(ghFire('issue_comment', 'deleted', 'd-del'), () => {})
-    await vi.waitFor(() => expect(cp.hookReports.length).toBe(2))
+    await vi.waitFor(() => expect(cp.hookReports.length).toBe(2), WAIT)
     expect(host.prompt).toHaveBeenCalledTimes(1)
     expect(host.newSession).toHaveBeenCalledTimes(1)
     expect(cp.hookReports[1]).toMatchObject({ status: 'success', reason: 'deleted_event_ignored' })
@@ -1532,7 +1537,7 @@ describe('Daemon rd/msg hook fires', () => {
       () => {}
     )
     expect(ack.accepted).toBe(true)
-    await vi.waitFor(() => expect(cp.hookReports.length).toBe(1))
+    await vi.waitFor(() => expect(cp.hookReports.length).toBe(1), WAIT)
     expect(cp.hookReports[0]).toMatchObject({ status: 'success' })
     // The anchor uses the selected agent identity; the reply posted after it
     // threads under the anchor's ts.
@@ -1585,7 +1590,7 @@ describe('Daemon rd/msg hook fires', () => {
     const p2 = (daemon as any).handleRelayMsg(fire(), () => {}) // redelivery before admission settles
     const [a1, a2] = await Promise.all([p1, p2])
     expect(a2).toEqual(a1)
-    await vi.waitFor(() => expect(cp.hookReports.length).toBe(1))
+    await vi.waitFor(() => expect(cp.hookReports.length).toBe(1), WAIT)
     expect(host.prompt.mock.calls.length).toBe(1) // ONE turn, not two
     await daemon.stop()
   }, 15_000)
@@ -1621,7 +1626,7 @@ describe('Daemon rd/msg hook fires', () => {
     const first = fire({ sessionKey: HOOK_ID })
     const second = fire({ sessionKey: HOOK_ID, msgId: `${HOOK_ID}:d-2`, deliveryKey: 'd-2' })
     await expect((daemon as any).handleRelayMsg(first, () => {})).resolves.toMatchObject({ accepted: true })
-    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledOnce(), WAIT)
     expect([...(daemon as any).inflight]).toHaveLength(1)
     await expect((daemon as any).handleRelayMsg(second, () => {})).resolves.toMatchObject({ accepted: true })
 
@@ -1633,7 +1638,7 @@ describe('Daemon rd/msg hook fires', () => {
     ;(daemon as any).drainingAgents.add(AGENT_ID)
     expect((daemon as any).drainingAgents.has(AGENT_ID)).toBe(true)
     releasePrompt()
-    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(2))
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(2), WAIT)
     expect(cp.hookReports.filter((report) => report.deliveryKey === 'd-2')).toEqual([
       expect.objectContaining({ status: 'failed', reason: 'dropped' })
     ])
@@ -1689,12 +1694,12 @@ describe('Daemon rd/msg hook fires', () => {
       const first = fire({ sessionKey: HOOK_ID })
       const second = fire({ sessionKey: HOOK_ID, msgId: `${HOOK_ID}:d-2`, deliveryKey: 'd-2' })
       await expect((daemon as any).handleRelayMsg(first, () => {})).resolves.toMatchObject({ accepted: true })
-      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledOnce())
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledOnce(), WAIT)
       await expect((daemon as any).handleRelayMsg(second, () => {})).resolves.toMatchObject({ accepted: true })
 
       mutate(root)
       const reconciling = daemon.reconcile()
-      await vi.waitFor(() => expect(host.cancel).toHaveBeenCalled())
+      await vi.waitFor(() => expect(host.cancel).toHaveBeenCalled(), WAIT)
 
       const interrupted = (daemon as any).store.listInboxBySessionKeyFifo() as Array<{
         id: string
@@ -1719,7 +1724,7 @@ describe('Daemon rd/msg hook fires', () => {
         }>
         expect(rows).toHaveLength(2)
         expect(rows.every((row) => row.hookContext === null && row.terminalReport !== null)).toBe(true)
-      })
+      }, WAIT)
       expect(emitHookReport).toHaveBeenCalledTimes(2)
       await daemon.stop()
     },
@@ -1773,7 +1778,7 @@ describe('Daemon rd/msg hook fires', () => {
       { hookId: HOOK_ID, agentId: AGENT_ID, deliveryKey: 'cleanup', status: 'success' },
       `${HOOK_ID}:cleanup`
     )
-    await vi.waitFor(() => expect(retry).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(retry).toHaveBeenCalledTimes(2), WAIT)
     await daemon.stop()
   })
 
@@ -1813,7 +1818,7 @@ describe('Daemon rd/msg hook fires', () => {
     ;(daemon as any).emitHookCompletion(hook, 'success', {}, owner)
     ;(daemon as any).emitHookCompletion(hook, 'failed', { reason: 'late loser' }, owner)
 
-    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
     expect(cp.hookReports[0]).toMatchObject({ deliveryKey: 'double-terminal', status: 'success' })
     const receipt = (daemon as any).store.listInboxBySessionKeyFifo().find((row: { id: string }) => row.id === id)
     expect(JSON.parse(receipt.terminalReport)).toMatchObject({ status: 'success' })
@@ -1852,7 +1857,7 @@ describe('Daemon rd/msg hook fires', () => {
 
     ;(daemon as any).emitHookCompletion(hook, 'success', {}, { inboxId: id })
 
-    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
     await Promise.resolve()
     expect(acknowledge).not.toHaveBeenCalled()
     expect(store.listInboxBySessionKeyFifo().find((row: { id: string }) => row.id === id)).toMatchObject({
@@ -1879,8 +1884,8 @@ describe('Daemon rd/msg hook fires', () => {
     ;(first as any).connByIntegration.set('int-a', firstAnchor)
     const targeted = fire({ target: { platform: 'slack', channel: 'C-alerts', integrationId: 'int-a' } })
     await expect((first as any).handleRelayMsg(targeted, () => {})).resolves.toMatchObject({ accepted: true })
-    await vi.waitFor(() => expect(firstHost.host.prompt).toHaveBeenCalledOnce())
-    await vi.waitFor(() => expect(firstCp.hookReports).toHaveLength(1))
+    await vi.waitFor(() => expect(firstHost.host.prompt).toHaveBeenCalledOnce(), WAIT)
+    await vi.waitFor(() => expect(firstCp.hookReports).toHaveLength(1), WAIT)
     expect(firstAnchor.postMessage.mock.calls.filter(([, text]) => text === '🪝 Webhook delivery d-1')).toHaveLength(1)
     await first.stop()
 

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -1780,7 +1780,7 @@ describe('Daemon rd/msg hook fires', () => {
     )
     await vi.waitFor(() => expect(retry).toHaveBeenCalledTimes(2), WAIT)
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('keeps the first terminal owner as the only durable report writer', async () => {
     const { factory } = streamingHost()
@@ -1823,7 +1823,7 @@ describe('Daemon rd/msg hook fires', () => {
     const receipt = (daemon as any).store.listInboxBySessionKeyFifo().find((row: { id: string }) => row.id === id)
     expect(JSON.parse(receipt.terminalReport)).toMatchObject({ status: 'success' })
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('does not ACK-clean a live hook row when terminal redaction fails', async () => {
     const { factory } = streamingHost()
@@ -1866,7 +1866,7 @@ describe('Daemon rd/msg hook fires', () => {
       completedAt: null
     })
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('retains a terminal receipt so redelivery after restart does not rerun the model', async () => {
     const root = scaffold()

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -7,6 +7,11 @@ import { executeTool, type SessionContext } from '../src/mcp/ops.js'
 import { sessionKey } from '../src/store/local-store.js'
 import { FakeClock } from './cp/fake-clock.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 const AGENT_ID = 'bot-a'
 const CONV_1 = '11111111-1111-4111-8111-111111111111'
 const CONV_2 = '22222222-2222-4222-8222-222222222222'
@@ -116,14 +121,14 @@ describe('Daemon interrupt safety gates', () => {
       })
       ;(daemon as any).store.setModelOverride(key, 'blocked-model')
       const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'first', 'alice', stream.sink)
-      await vi.waitFor(() => expect(host.setSessionModel).toHaveBeenCalled())
+      await vi.waitFor(() => expect(host.setSessionModel).toHaveBeenCalled(), WAIT)
       expect(hasPending(daemon, 'acp-pre-prompt')).toBe(true)
 
       ;(daemon as any).handleWebchatCancel(CONV_1)
       expect(stream.dones).toEqual([expect.objectContaining({ turnId: ack.turnId, error: 'cancel' })])
       releaseOverride()
 
-      await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0))
+      await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
       expect(stream.dones).toHaveLength(1)
       expect(host.prompt).not.toHaveBeenCalled()
     } finally {
@@ -156,7 +161,7 @@ describe('Daemon interrupt safety gates', () => {
     try {
       const first = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'first', 'alice', stream.sink)
       expect(first.accepted).toBe(true)
-      await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+      await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
 
       ;(daemon as any).handleWebchatCancel(CONV_1)
       expect(host.cancel).toHaveBeenCalledWith('acp-1')
@@ -168,14 +173,16 @@ describe('Daemon interrupt safety gates', () => {
       expect(host.newSession).toHaveBeenCalledTimes(1)
 
       releaseFirst()
-      await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0))
+      await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
 
       const fresh = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_2, 'fresh', 'alice', stream.sink)
       expect(fresh.accepted).toBe(true)
-      await vi.waitFor(() =>
-        expect(stream.dones).toContainEqual(
-          expect.objectContaining({ conversationId: CONV_2, turnId: fresh.turnId, stopReason: 'end_turn' })
-        )
+      await vi.waitFor(
+        () =>
+          expect(stream.dones).toContainEqual(
+            expect.objectContaining({ conversationId: CONV_2, turnId: fresh.turnId, stopReason: 'end_turn' })
+          ),
+        WAIT
       )
       expect(host.prompt).toHaveBeenCalledTimes(2)
     } finally {
@@ -215,9 +222,9 @@ describe('Daemon interrupt safety gates', () => {
     let t2Queued: Promise<unknown> | undefined
 
     try {
-      await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
+      await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
       t2 = (daemon as any).dispatch(AGENT_ID, t2Msg)
-      await vi.waitFor(() => expect(hasPending(daemon, 'acp-2')).toBe(true))
+      await vi.waitFor(() => expect(hasPending(daemon, 'acp-2')).toBe(true), WAIT)
       // DMs start private. Model the CP publishing this unrelated session so
       // the memory assertion below tests cancellation isolation, not privacy.
       expect((daemon as any).store.applyCpCaptureGate('acp-2', false, 1)).toBe('applied')
@@ -287,7 +294,7 @@ describe('Daemon interrupt safety gates', () => {
     try {
       const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold', 'alice', stream.sink)
       expect(ack.accepted).toBe(true)
-      await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1))
+      await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
       expect((daemon as any).pending.size).toBe(0)
 
       ;(daemon as any).handleWebchatCancel(CONV_1)
@@ -295,8 +302,8 @@ describe('Daemon interrupt safety gates', () => {
       expect(stream.dones).toEqual([expect.objectContaining({ turnId: ack.turnId, error: 'cancel' })])
 
       clock.advance(30_000)
-      await vi.waitFor(() => expect(host.stop).toHaveBeenCalled())
-      await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0))
+      await vi.waitFor(() => expect(host.stop).toHaveBeenCalled(), WAIT)
+      await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
       expect(host.prompt).not.toHaveBeenCalled()
       expect(stream.dones).toHaveLength(1)
     } finally {
@@ -338,13 +345,13 @@ describe('Daemon interrupt safety gates', () => {
     expect((daemon as any).store.applyCpCaptureGate('acp-memory', false, 1)).toBe('applied')
 
     const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold memory', 'alice', stream.sink)
-    await vi.waitFor(() => expect(standingContext).toHaveBeenCalled())
+    await vi.waitFor(() => expect(standingContext).toHaveBeenCalled(), WAIT)
     ;(daemon as any).handleWebchatCancel(CONV_1)
     expect(stream.dones).toEqual([expect.objectContaining({ turnId: ack.turnId, error: 'cancel' })])
 
     clock.advance(30_000)
-    await vi.waitFor(() => expect(host.stop).toHaveBeenCalled())
-    await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0))
+    await vi.waitFor(() => expect(host.stop).toHaveBeenCalled(), WAIT)
+    await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
     expect(host.newSession).not.toHaveBeenCalled()
     expect(host.prompt).not.toHaveBeenCalled()
 
@@ -376,11 +383,11 @@ describe('Daemon interrupt safety gates', () => {
     try {
       const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold', 'alice', stream.sink)
       expect(ack.accepted).toBe(true)
-      await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1))
+      await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
 
       ;(daemon as any).handleWebchatCancel(CONV_1)
       clock.advance(30_000)
-      await vi.waitFor(() => expect(host.stop).toHaveBeenCalledTimes(1))
+      await vi.waitFor(() => expect(host.stop).toHaveBeenCalledTimes(1), WAIT)
       expect((daemon as any).inflight.size).toBe(1)
 
       expect((daemon as any).safetyDrainingAgents.has(AGENT_ID)).toBe(true)
@@ -429,7 +436,7 @@ describe('Daemon interrupt safety gates', () => {
     try {
       await expect((daemon as any).dispatch(AGENT_ID, dm('C1', 'T1', '100', 'warm'))).resolves.toBe('acp-old')
       priorStop = (daemon as any).stopHost(AGENT_ID)
-      await vi.waitFor(() => expect(host1.stop).toHaveBeenCalledTimes(1))
+      await vi.waitFor(() => expect(host1.stop).toHaveBeenCalledTimes(1), WAIT)
       // This already-admitted resource request is waiting on the first teardown
       // before reconcile installs its agent gate.
       staleEnsure = (daemon as any).ensureHostAsync(AGENT_ID)
@@ -438,7 +445,7 @@ describe('Daemon interrupt safety gates', () => {
         workspace: { mode: 'from-scratch', path: join(root, 'agents', AGENT_ID, 'workspace-new') }
       })
       reconciling = daemon.reconcile()
-      await vi.waitFor(() => expect((daemon as any).drainingAgents.has(AGENT_ID)).toBe(true))
+      await vi.waitFor(() => expect((daemon as any).drainingAgents.has(AGENT_ID)).toBe(true), WAIT)
 
       await expect((daemon as any).dispatch(AGENT_ID, dm('C2', 'T2', '200', 'during stop'))).resolves.toBeNull()
       await expect((daemon as any).ensureHostAsync(AGENT_ID)).rejects.toThrow(/draining/)
@@ -487,7 +494,7 @@ describe('Daemon interrupt safety gates', () => {
       await expect((daemon as any).dispatch(AGENT_ID, dm('C1', 'T1', '100', 'warm'))).resolves.toBe('acp-old')
       updateAgent(root, { status: 'inactive' })
       reconciling = daemon.reconcile()
-      await vi.waitFor(() => expect(host.stop).toHaveBeenCalledTimes(1))
+      await vi.waitFor(() => expect(host.stop).toHaveBeenCalledTimes(1), WAIT)
 
       expect((daemon as any).agents.has(AGENT_ID)).toBe(false)
       expect((daemon as any).drainingAgents.has(AGENT_ID)).toBe(true)
@@ -736,8 +743,8 @@ describe('Daemon interrupt safety gates', () => {
     let stopped = false
 
     try {
-      await vi.waitFor(() => expect(failedHost.start).toHaveBeenCalledTimes(1))
-      await vi.waitFor(() => expect(clock.pending()).toContain(60_000))
+      await vi.waitFor(() => expect(failedHost.start).toHaveBeenCalledTimes(1), WAIT)
+      await vi.waitFor(() => expect(clock.pending()).toContain(60_000), WAIT)
       await expect(daemon.stop()).resolves.toBeUndefined()
       stopped = true
       await expect(turn).resolves.toBeNull()
@@ -766,7 +773,7 @@ describe('Daemon interrupt safety gates', () => {
     await daemon.start()
 
     const ack = (daemon as any).dispatchWebchatTurn(AGENT_ID, CONV_1, 'cold shutdown', 'alice', stream.sink)
-    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
     await daemon.stop()
 
     expect(stream.dones).toEqual([

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -9,6 +9,11 @@ import { readSkillLedger, skillLedgerLocation } from '../src/skills/skill-instal
 import { sessionKey } from '../src/store/local-store.js'
 import { FakeClock } from './cp/fake-clock.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
 
 /** A daemon root with one DM-less agent (we attach routing + a fake conn by hand,
@@ -711,7 +716,7 @@ describe('Daemon session lifecycle (#118)', () => {
       }
     )
 
-    await vi.waitFor(() => expect(blocked.host.prompt).toHaveBeenCalledWith('acp-1', expect.any(Array)))
+    await vi.waitFor(() => expect(blocked.host.prompt).toHaveBeenCalledWith('acp-1', expect.any(Array)), WAIT)
     expect(emitCronReport).toHaveBeenCalledTimes(2)
     expect(emitCronReport.mock.calls[0]![0]).not.toHaveProperty('sessionId')
     expect(emitCronReport.mock.calls[1]![0]).toMatchObject({ sessionId: 'acp-1' })
@@ -731,7 +736,7 @@ describe('Daemon session lifecycle (#118)', () => {
     makeRoutable(daemon)
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined())
+    await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined(), WAIT)
 
     ;(daemon as any).onInbound(dm('200', '!stop'))
     expect(blocked.host.cancel).toHaveBeenCalledWith('acp-1')
@@ -739,9 +744,9 @@ describe('Daemon session lifecycle (#118)', () => {
 
     // agent ignores session/cancel → after cancelBackstopMs the host is force-stopped
     clock.advance(30_000)
-    await vi.waitFor(() => expect(blocked.host.stop).toHaveBeenCalled())
+    await vi.waitFor(() => expect(blocked.host.stop).toHaveBeenCalled(), WAIT)
     expect((daemon as any).hosts.has('bot-a')).toBe(false)
-    await vi.waitFor(() => expect((daemon as any).store.getSession(KEY)?.state).toBe('idle'))
+    await vi.waitFor(() => expect((daemon as any).store.getSession(KEY)?.state).toBe('idle'), WAIT)
 
     blocked.release()
     await turn.catch(() => {})
@@ -756,7 +761,7 @@ describe('Daemon session lifecycle (#118)', () => {
 
     const first = (daemon as any).dispatch('bot-a', dm('100', 'first', 'T1'))
     const second = (daemon as any).dispatch('bot-a', dm('200', 'second', 'T2'))
-    await vi.waitFor(() => expect((daemon as any).pending.size).toBe(2))
+    await vi.waitFor(() => expect((daemon as any).pending.size).toBe(2), WAIT)
     const queued = (daemon as any).dispatch('bot-a', dm('300', 'queued', 'T1'))
     expect((daemon as any).serialQueue.get(KEY)).toHaveLength(1)
 
@@ -795,7 +800,7 @@ describe('Daemon session lifecycle (#118)', () => {
     const conn = makeRoutable(daemon)
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'stream', 'T1'))
-    await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined())
+    await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined(), WAIT)
     const pending = pendingFor(daemon, 'acp-1')
     let releaseApply!: () => void
     pending.applyChain = new Promise<void>((resolve) => (releaseApply = resolve))
@@ -828,7 +833,7 @@ describe('Daemon session lifecycle (#118)', () => {
     await daemon.start()
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'cold', 'T1'))
-    await vi.waitFor(() => expect(cold.host.newSession).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(cold.host.newSession).toHaveBeenCalledTimes(1), WAIT)
     expect((daemon as any).pending.size).toBe(0)
 
     writePause(root, true)
@@ -847,7 +852,7 @@ describe('Daemon session lifecycle (#118)', () => {
     expect(cold.host.cancel).not.toHaveBeenCalled()
     expect((daemon as any).store.getSession(KEY)?.state).toBe('idle')
 
-    await vi.waitFor(() => expect((daemon as any).safetyDrainingAgents.has('bot-a')).toBe(false))
+    await vi.waitFor(() => expect((daemon as any).safetyDrainingAgents.has('bot-a')).toBe(false), WAIT)
     await expect((daemon as any).dispatch('bot-a', dm('200', 'fresh', 'T2'))).resolves.toBe('acp-cold')
     expect(cold.host.prompt).toHaveBeenCalledTimes(1)
 
@@ -880,7 +885,7 @@ describe('Daemon idle sweep (#111/#118)', () => {
 
     // advance past the TTL so the next sweep reaps the host + closes the session
     clock.advance(1001)
-    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
+    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false), WAIT)
     expect(host.stop).toHaveBeenCalled()
     expect((daemon as any).store.getSession(KEY)?.state).toBe('closed')
     expect((daemon as any).store.getSession(KEY)?.title).toBe('Final stopped title')
@@ -908,8 +913,8 @@ describe('Daemon idle sweep (#111/#118)', () => {
     clock.advance(1001)
     // The host leaves the map synchronously at the top of stopHost; the secret
     // files go away when the teardown settles — wait for that edge separately.
-    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
-    await vi.waitFor(() => expect(existsSync(secretsDir)).toBe(false))
+    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false), WAIT)
+    await vi.waitFor(() => expect(existsSync(secretsDir)).toBe(false), WAIT)
 
     await daemon.stop()
   }, 15_000)
@@ -964,7 +969,7 @@ describe('Daemon idle sweep (#111/#118)', () => {
     makeRoutable(daemon)
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(blocked.host.prompt).toHaveBeenCalled())
+    await vi.waitFor(() => expect(blocked.host.prompt).toHaveBeenCalled(), WAIT)
     const entry = (daemon as any).hostConfigFiles.get('bot-a')
     entry.childEnv = { KUBECONFIG_DATA: 'apiVersion: v1' }
     entry.materialized = true
@@ -1021,7 +1026,7 @@ describe('Daemon idle sweep (#111/#118)', () => {
     // Past the TTL measured from host start → now genuinely idle → reclaimed.
     clock.advance(600) // 1100ms since start > 1000ms TTL
     ;(daemon as any).sweepIdle()
-    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
+    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false), WAIT)
     expect(host.stop).toHaveBeenCalled()
 
     await daemon.stop()
@@ -1069,11 +1074,11 @@ describe('Daemon idle sweep — background-task lease', () => {
     // Wake fires and is delivered; the fence is held until that turn SETTLES, not until it is
     // dispatched, so wait on the count rather than on the timer set.
     clock.advance(4000)
-    await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false))
-    await vi.waitFor(() => expect((daemon as any).store.getSession(KEY)?.state).toBe('idle'))
+    await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false), WAIT)
+    await vi.waitFor(() => expect((daemon as any).store.getSession(KEY)?.state).toBe('idle'), WAIT)
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
-    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
+    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false), WAIT)
     expect(host.stop).toHaveBeenCalled()
     expect((daemon as any).store.getSession(KEY)?.state).toBe('closed')
 
@@ -1098,7 +1103,7 @@ describe('Daemon idle sweep — background-task lease', () => {
     ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
-    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
+    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false), WAIT)
 
     await daemon.stop()
   }, 15_000)
@@ -1125,10 +1130,10 @@ describe('Daemon idle sweep — background-task lease', () => {
     expect((daemon as any).hosts.has('bot-a')).toBe(true)
 
     clock.advance(4000)
-    await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false))
+    await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false), WAIT)
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
-    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
+    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false), WAIT)
 
     await daemon.stop()
   }, 15_000)
@@ -1152,7 +1157,7 @@ describe('Daemon idle sweep — background-task lease', () => {
     // Past the ceiling (from host start) → force reclaim despite the live task.
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
-    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
+    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false), WAIT)
     expect(host.stop).toHaveBeenCalled()
 
     await daemon.stop()
@@ -1238,7 +1243,7 @@ describe('Daemon idle sweep — background-task lease', () => {
       expect(host.prompt).toHaveBeenCalledTimes(1) // deferred, not immediate
 
       clock.advance(4000)
-      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
       const woken = JSON.stringify((host.prompt as any).mock.calls[1])
       expect(woken).toContain('background task finished')
       expect(woken).toContain('Sleep 30s then print the time')
@@ -1258,13 +1263,13 @@ describe('Daemon idle sweep — background-task lease', () => {
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
 
       clock.advance(4000) // re-armed, not abandoned
-      await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(1))
+      await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(1), WAIT)
       expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(1) // fence never dipped
       expect(host.prompt).toHaveBeenCalledTimes(1)
 
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
       clock.advance(4000)
-      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
       await daemon.stop()
     }, 15_000)
 
@@ -1299,7 +1304,7 @@ describe('Daemon idle sweep — background-task lease', () => {
 
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't2' }))
       clock.advance(4000)
-      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
       await daemon.stop()
     }, 15_000)
 
@@ -1318,7 +1323,7 @@ describe('Daemon idle sweep — background-task lease', () => {
       expect((daemon as any).agentHasLiveSdkWork('bot-a')).toBe(true)
 
       clock.advance(4000)
-      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false))
+      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false), WAIT)
       expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(true)
       await daemon.stop()
     }, 15_000)
@@ -1348,7 +1353,7 @@ describe('Daemon idle sweep — background-task lease', () => {
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1' }))
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
       clock.advance(4000)
-      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1)) // wake dispatched, stalled
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1), WAIT) // wake dispatched, stalled
 
       // Past the TTL, mid-initialization: the row is still `idle` and has no Pending, so only
       // the lease fence can keep the sweep off it.
@@ -1359,8 +1364,8 @@ describe('Daemon idle sweep — background-task lease', () => {
       expect(host.stop).not.toHaveBeenCalled()
 
       releaseRecall()
-      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
-      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false))
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
+      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false), WAIT)
       await daemon.stop()
     }, 15_000)
 
@@ -1397,7 +1402,7 @@ describe('Daemon idle sweep — background-task lease', () => {
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 'a' }))
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 'a' }))
       clock.advance(4000)
-      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
       // The model is done even though the turn is not — exactly what the SDK reports here.
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
 
@@ -1465,7 +1470,7 @@ describe('Daemon idle sweep — background-task lease', () => {
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
       clock.advance(4000)
       const lease = (daemon as any).sdkLease.get(LEASE_KEY)
-      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false))
+      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false), WAIT)
       expect(host.prompt).toHaveBeenCalledTimes(2)
       expect(lease.bgWakes).toBe(1) // a delivered wake is spent
 
@@ -1475,7 +1480,7 @@ describe('Daemon idle sweep — background-task lease', () => {
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't2' }))
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't2' }))
       clock.advance(4000)
-      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false)) // fence released, no wake
+      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false), WAIT) // fence released, no wake
       expect(host.prompt).toHaveBeenCalledTimes(2)
       expect(lease.bgWakes).toBe(20) // never spends past the cap
       await daemon.stop()
@@ -1524,7 +1529,7 @@ describe('Daemon graceful shutdown drain (#109)', () => {
     makeRoutable(daemon)
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined())
+    await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined(), WAIT)
 
     let stopped = false
     const stopping = daemon.stop().then(() => (stopped = true))
@@ -1583,7 +1588,7 @@ describe('Daemon CP drain (#109)', () => {
     makeRoutable(daemon)
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined())
+    await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined(), WAIT)
 
     const draining = (daemon as any).runDrain({ scope: { kind: 'daemon' }, deadline: farFuture }, () => {})
     blocked.release() // let the turn finish so the drain completes gracefully
@@ -1616,7 +1621,7 @@ describe('Daemon CP drain (#109)', () => {
       trigger: 'mention' as const
     }
     const turn = (daemon as any).dispatch('bot-a', root, 'int-a')
-    await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined())
+    await vi.waitFor(() => expect(pendingFor(daemon, 'acp-1')).toBeDefined(), WAIT)
 
     const draining = (daemon as any).runDrain({ scope: { kind: 'daemon' }, deadline: farFuture }, () => {})
     blocked.release()
@@ -1657,7 +1662,7 @@ describe('Daemon session retention GC (#485)', () => {
 
     // Past the default 7d retention window; the hourly gate inside sweepIdle opens too.
     clock.advance(8 * 24 * 3_600_000)
-    await vi.waitFor(() => expect((daemon as any).store.getSession('expired-closed')).toBeUndefined())
+    await vi.waitFor(() => expect((daemon as any).store.getSession('expired-closed')).toBeUndefined(), WAIT)
     expect((daemon as any).store.getSession('expired-idle')).toBeUndefined()
     expect((daemon as any).store.getSession('fresh-closed')).toBeDefined()
     expect((daemon as any).store.getSession('expired-prompting')).toBeDefined()
@@ -1691,7 +1696,7 @@ describe('Daemon session retention GC (#485)', () => {
     seedSession(daemon, 'expired-b', 'idle', 0)
     clock.advance(8 * 24 * 3_600_000)
     await (daemon as any).sweepSessionRetention()
-    await vi.waitFor(() => expect(emitSessionPurged).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(emitSessionPurged).toHaveBeenCalledOnce(), WAIT)
 
     // One frame per agent, carrying the ACP session ids — the only session
     // identity the CP knows.

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -7,6 +7,11 @@ import { executeTool, type MessageAgentReq } from '../src/mcp/ops.js'
 import { sessionKey } from '../src/store/local-store.js'
 import * as monotonic from '../src/store/monotonic-ts.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 const TEST_ORG = '00000000-0000-0000-0000-0000000000a1'
 /** Peers this suite wakes that are NOT on the daemon under test — they must still be in
  *  the org directory, exactly as a real CP snapshot would list them. */
@@ -1782,7 +1787,7 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
         state: 'idle',
         lastDeliveredTs: null
       })
-    })
+    }, WAIT)
     expect(host.newSession).toHaveBeenCalledOnce()
     expect(host.prompt).not.toHaveBeenCalled()
     await daemon.stop()

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -1791,7 +1791,7 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
     expect(host.newSession).toHaveBeenCalledOnce()
     expect(host.prompt).not.toHaveBeenCalled()
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('keys a Feishu spawn as feishu, not a folded fallback', async () => {
     const root = scaffold([{ id: 'bot-a' }])

--- a/packages/daemon/test/daemon-serial-gate.test.ts
+++ b/packages/daemon/test/daemon-serial-gate.test.ts
@@ -6,6 +6,11 @@ import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
 import type { WebchatOutput, WebchatDone } from '@agentconnect.md/protocol'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 /**
  * P4-gate: the per-sessionKey serial admission gate (design §4.3/§6.9). These drive
  * `dispatch` directly with a blocking ACP host so we can freeze a turn mid-prompt and
@@ -114,7 +119,7 @@ describe('P4 serial gate', () => {
     const p2 = (daemon as any).dispatch('bot-a', msg('200', 'second'), 'int-a')
 
     // The first claims ownership and starts its prompt; the second is queued behind it.
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     expect((daemon as any).inflight.has(key)).toBe(true)
     expect((daemon as any).serialQueue.get(key)).toHaveLength(1)
     // Only ONE pending entry for the single live ACP session — no concurrent overwrite.
@@ -127,7 +132,7 @@ describe('P4 serial gate', () => {
     // Release the head → the queued second now runs, in order.
     g.releaseOne()
     await p1
-    await vi.waitFor(() => expect(g.started.length).toBe(2))
+    await vi.waitFor(() => expect(g.started.length).toBe(2), WAIT)
     expect(g.started[1]).toContain('second')
     g.releaseOne()
     await p2
@@ -169,7 +174,7 @@ describe('P4 serial gate', () => {
     await daemon.start()
     const key = 'slack:C1:T1:bot-a'
     const active = (daemon as any).dispatch('bot-a', msg('100', 'active'), 'int-a')
-    await vi.waitFor(() => expect(g.started).toHaveLength(1))
+    await vi.waitFor(() => expect(g.started).toHaveLength(1), WAIT)
     const queued = (daemon as any).dispatch('bot-a', msg('200', 'queued'), 'int-a')
     expect((daemon as any).serialQueue.get(key)).toHaveLength(1)
 
@@ -195,7 +200,7 @@ describe('P4 serial gate', () => {
 
     g.releaseOne()
     await expect(active).resolves.toBe('acp-1')
-    await vi.waitFor(() => expect(g.started).toHaveLength(2))
+    await vi.waitFor(() => expect(g.started).toHaveLength(2), WAIT)
     expect(g.started[1]).toContain('queued')
     g.releaseOne()
     await expect(queued).resolves.toBe('acp-1')
@@ -261,7 +266,7 @@ describe('P4 serial gate', () => {
 
     // Establish the warm session at the root message.
     const root = (daemon as any).dispatch('bot-a', msg('100.1', 'root request', '100.1'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     g.releaseOne()
     await root
 
@@ -272,7 +277,7 @@ describe('P4 serial gate', () => {
       { sender: 'U1', ts: '100.4', text: 'D latest: merge it' }
     ])
     const staleWake = (daemon as any).dispatch('bot-a', msg('100.2', 'B stale trigger', '100.1'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(2))
+    await vi.waitFor(() => expect(g.started.length).toBe(2), WAIT)
     expect(g.started[1]).toContain('B stale trigger')
     expect(g.started[1]).toContain('C newer clarification')
     expect(g.started[1]).toContain('D latest: merge it')
@@ -297,7 +302,7 @@ describe('P4 serial gate', () => {
     const key = 'slack:C1:T1:bot-a'
 
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     // Queue the head-of-line follow-up while the first turn runs.
     const p2 = (daemon as any).dispatch('bot-a', msg('200', 'queued-head'), 'int-a')
     expect((daemon as any).serialQueue.get(key)).toHaveLength(1)
@@ -307,7 +312,7 @@ describe('P4 serial gate', () => {
     g.releaseOne()
     await p1
     // 'queued-head' is now the running turn; inject a NEW arrival in this window.
-    await vi.waitFor(() => expect(g.started.length).toBe(2))
+    await vi.waitFor(() => expect(g.started.length).toBe(2), WAIT)
     expect(g.started[1]).toContain('queued-head')
     const p3 = (daemon as any).dispatch('bot-a', msg('300', 'late-arrival'), 'int-a')
     // It is queued behind the running head (ownership was never released) — FIFO holds.
@@ -315,7 +320,7 @@ describe('P4 serial gate', () => {
 
     g.releaseOne() // finish queued-head
     await p2
-    await vi.waitFor(() => expect(g.started.length).toBe(3))
+    await vi.waitFor(() => expect(g.started.length).toBe(3), WAIT)
     expect(g.started[2]).toContain('late-arrival')
     g.releaseOne()
     await p3
@@ -329,14 +334,14 @@ describe('P4 serial gate', () => {
     const daemon = await boot(g.host)
 
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     const p2 = (daemon as any).dispatch('bot-a', msg('200', 'second'), 'int-a')
 
     // Head resolves with ITS sessionId; the queued entry resolves with its own (same
     // session here, but its OWN promise — settled when ITS turn ran, not the head's).
     g.releaseOne()
     await expect(p1).resolves.toBe('acp-1')
-    await vi.waitFor(() => expect(g.started.length).toBe(2))
+    await vi.waitFor(() => expect(g.started.length).toBe(2), WAIT)
     // p2 is still pending until its own turn completes.
     let p2Settled = false
     void p2.then(() => (p2Settled = true))
@@ -355,7 +360,7 @@ describe('P4 serial gate', () => {
     const key = 'slack:C1:T1:bot-a'
 
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     const p2 = (daemon as any).dispatch('bot-a', msg('200', 'second'), 'int-a')
     const p3 = (daemon as any).dispatch('bot-a', msg('300', 'third'), 'int-a')
     expect((daemon as any).serialQueue.get(key)).toHaveLength(2)
@@ -380,7 +385,7 @@ describe('P4 serial gate', () => {
     const key = 'slack:C1:T1:bot-a'
 
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
 
     // Fill the queue to the cap (10), then the 11th is rejected fast without buffering.
     const queued: Promise<unknown>[] = []
@@ -417,7 +422,7 @@ describe('P4 serial gate', () => {
     const key = 'slack:C1:T1:bot-a'
 
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     const p2 = (daemon as any).dispatch('bot-a', msg('200', 'second'), 'int-a')
     expect((daemon as any).serialQueue.get(key)).toHaveLength(1)
 
@@ -459,7 +464,7 @@ describe('P4 serial gate', () => {
 
     // Head turn (non-webchat) blocks in prompt; a WEBCHAT turn queues behind it.
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     const p2 = (daemon as any).dispatch('bot-a', msg('200', 'second'), 'int-a', {
       conversationId: 'conv-a',
       turnId,
@@ -489,7 +494,7 @@ describe('P4 serial gate', () => {
     const turnId = '99999999-9999-4999-8999-999999999999'
 
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     const p2 = (daemon as any).dispatch('bot-a', msg('200', 'second'), 'int-a', {
       conversationId: 'conv-b',
       turnId,

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -6,6 +6,11 @@ import { fileURLToPath } from 'node:url'
 import { Daemon } from '../src/daemon.js'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../src/cp/gitcred-server.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 function scaffold(displayName?: string, memoryProvider?: 'none' | 'managed', iconUrl?: string): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-daemon-'))
   writeFileSync(
@@ -670,7 +675,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     expect((daemon as any).store.getSessionByAcpId('acp-title-late')?.title).toBeNull()
     await (daemon as any).stopHost('bot-a')
 
-    await vi.waitFor(() => expect(connB.setTitle).toHaveBeenCalledWith('D1', '210.1', 'Fix session titles'))
+    await vi.waitFor(() => expect(connB.setTitle).toHaveBeenCalledWith('D1', '210.1', 'Fix session titles'), WAIT)
     expect(connA.setTitle).not.toHaveBeenCalled()
     expect((daemon as any).store.getSessionByAcpId('acp-title-late')?.title).toBe('Fix session titles')
     expect(emitEventSession.mock.calls.at(-1)?.[0]).toMatchObject({
@@ -738,7 +743,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     })
     const a = (daemon as any).dispatch('bot-a', message('bot-a'))
     const b = (daemon as any).dispatch('bot-b', message('bot-b'))
-    await vi.waitFor(() => expect((daemon as any).pending.size).toBe(2))
+    await vi.waitFor(() => expect((daemon as any).pending.size).toBe(2), WAIT)
 
     updates.get('bot-a')?.('shared-acp-id', { sessionUpdate: 'session_info_update', title: 'Agent A title' })
     updates.get('bot-b')?.('shared-acp-id', { sessionUpdate: 'session_info_update', title: 'Agent B title' })

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -7,6 +7,11 @@ import { Daemon } from '../src/daemon.js'
 import { transcriptChannelKey, type TranscriptEntry } from '../src/store/local-store.js'
 import { stableTurnId } from '../src/messages/normalized.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
 const TRANSCRIPT_CHANNEL = transcriptChannelKey('C1', TRANSPORT_SCOPE)
 
@@ -188,12 +193,12 @@ describe('Daemon transcript records the agent reply', () => {
     const capturedBinding = (daemon as any).agents.get('bot-a').memory
 
     const turn = (daemon as any).dispatch('bot-a', dm('200', 'shared follow-up'), 'int-a')
-    await vi.waitFor(() => expect(conn.postMessage).toHaveBeenCalled())
+    await vi.waitFor(() => expect(conn.postMessage).toHaveBeenCalled(), WAIT)
     expect(recordTurn).not.toHaveBeenCalled()
 
     releaseDelivery()
     await turn
-    await vi.waitFor(() => expect(recordTurn).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(recordTurn).toHaveBeenCalledOnce(), WAIT)
     expect(recordTurn).toHaveBeenCalledWith(
       { agentId: 'bot-a', sessionId: 'acp-1' },
       {
@@ -385,8 +390,9 @@ describe('Daemon transcript records the agent reply', () => {
       prompt: vi.fn(async (sid: string) => {
         onUpdate(sid, text('early answer'))
         onUpdate(sid, tool('t1', 'Read file.ts'))
-        await vi.waitFor(() =>
-          expect(conn.postMessage).toHaveBeenCalledWith('C1', 'early answer', 'T1', expect.anything())
+        await vi.waitFor(
+          () => expect(conn.postMessage).toHaveBeenCalledWith('C1', 'early answer', 'T1', expect.anything()),
+          WAIT
         )
         model = 'model-after-prompt'
         return 'end_turn'
@@ -483,13 +489,15 @@ describe('Daemon transcript records the agent reply', () => {
         // Segment 1 streams and settles into the single live reply (reply-1).
         onUpdate(sid, text('first part'))
         onUpdate(sid, tool('t1', 'Read one'))
-        await vi.waitFor(() =>
-          expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('first part'), 'T1', {
-            username: 'bot-a',
-            agentAuthorId: 'bot-a',
-            response: streamingResponse(),
-            trailingBlocks: [classicFooter()]
-          })
+        await vi.waitFor(
+          () =>
+            expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('first part'), 'T1', {
+              username: 'bot-a',
+              agentAuthorId: 'bot-a',
+              response: streamingResponse(),
+              trailingBlocks: [classicFooter()]
+            }),
+          WAIT
         )
         // A permission / elicitation card is posted mid-turn (its handler calls this). The
         // live reply (reply-1) now sits ABOVE the card, so the next segment must start a
@@ -499,13 +507,15 @@ describe('Daemon transcript records the agent reply', () => {
         await p.applyChain
         onUpdate(sid, text('second part'))
         onUpdate(sid, tool('t2', 'Read two'))
-        await vi.waitFor(() =>
-          expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('second part'), 'T1', {
-            username: 'bot-a',
-            agentAuthorId: 'bot-a',
-            response: streamingResponse(),
-            trailingBlocks: [classicFooter()]
-          })
+        await vi.waitFor(
+          () =>
+            expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('second part'), 'T1', {
+              username: 'bot-a',
+              agentAuthorId: 'bot-a',
+              response: streamingResponse(),
+              trailingBlocks: [classicFooter()]
+            }),
+          WAIT
         )
         return 'end_turn'
       }),
@@ -675,13 +685,15 @@ describe('Daemon transcript records the agent reply', () => {
       prompt: vi.fn(async (sid: string) => {
         onUpdate(sid, text('first section'))
         onUpdate(sid, tool('t1', 'Read one'))
-        await vi.waitFor(() =>
-          expect(conn.postMessage).toHaveBeenCalledWith('C1', 'first section', 'T1', expect.anything())
+        await vi.waitFor(
+          () => expect(conn.postMessage).toHaveBeenCalledWith('C1', 'first section', 'T1', expect.anything()),
+          WAIT
         )
         onUpdate(sid, text('second section'))
         onUpdate(sid, tool('t2', 'Read two'))
-        await vi.waitFor(() =>
-          expect(conn.postMessage).toHaveBeenCalledWith('C1', 'second section', 'T1', expect.anything())
+        await vi.waitFor(
+          () => expect(conn.postMessage).toHaveBeenCalledWith('C1', 'second section', 'T1', expect.anything()),
+          WAIT
         )
         throw new Error('runtime exploded')
       }),

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1222,7 +1222,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
       .filter((row: { sender: string }) => row.sender === AGENT_ID)
     expect(replies).toEqual([]) // no transcript reply row
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('releases held text the instant the body diverges from the sentinel prefix', async () => {
     const { factory } = streamingHost([text('AC_NO'), text(' — actually, here is the answer')])
@@ -1244,7 +1244,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     )
     expect(messages.join('')).toBe('AC_NO — actually, here is the answer')
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('a turn op preserves the browser turnId and streams rd/chat output→done', async () => {
     const { factory } = streamingHost([text('hi from agent')])

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -9,6 +9,11 @@ import { Daemon } from '../src/daemon.js'
 import { stableMessageId } from '../src/messages/normalized.js'
 import type { WebchatOutput, WebchatDone } from '@agentconnect.md/protocol'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 /**
  * §6.9 #353 durable inbox: an admitted-but-queued message is persisted to the node:sqlite
  * local store BEFORE the admission ACK and replayed FIFO-by-sessionKey on startup, so a hard
@@ -352,7 +357,7 @@ describe('daemon durable inbox', () => {
 
     // Head admitted (runs immediately) → row written before it even starts.
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     expect(inbox(root).map((r) => r.id)).toEqual(['slack:C1:100'])
 
     // Fill the queue to the cap (10) — each queued entry persists a row.
@@ -390,7 +395,7 @@ describe('daemon durable inbox', () => {
     const daemon = await boot(root, g.host)
 
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     expect(inbox(root)).toHaveLength(1)
 
     g.releaseOne()
@@ -410,7 +415,7 @@ describe('daemon durable inbox', () => {
 
     const pA = (daemon as any).dispatch('bot-a', botA, 'int-a')
     const pB = (daemon as any).dispatch('bot-a', botB, 'int-b')
-    await vi.waitFor(() => expect(g.blockedCount()).toBe(2))
+    await vi.waitFor(() => expect(g.blockedCount()).toBe(2), WAIT)
     expect((daemon as any).evaluationTurnIdFor('bot-a', botA)).not.toBe(
       (daemon as any).evaluationTurnIdFor('bot-a', botB)
     )
@@ -437,7 +442,7 @@ describe('daemon durable inbox', () => {
     const key = 'slack:C1:T1:bot-a'
 
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     const p2 = (daemon as any).dispatch('bot-a', msg('200', 'second'), 'int-a')
     expect(inbox(root)).toHaveLength(2)
 
@@ -492,7 +497,7 @@ describe('daemon durable inbox', () => {
 
     const daemon = await boot(root, g.host)
     // The head runs immediately; the other two queue behind it — all in FIFO enqueuedAt order.
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     expect(g.started[0]).toContain('first')
     expect((daemon as any).serialQueue.get(key)).toHaveLength(2)
     // Adopt the legacy raw ids instead of duplicating them under the new scoped identity.
@@ -501,13 +506,13 @@ describe('daemon durable inbox', () => {
     expect(inbox(root).every((row) => row.loopGuardCounted === 1)).toBe(true)
 
     g.releaseOne()
-    await vi.waitFor(() => expect(g.started.length).toBe(2))
+    await vi.waitFor(() => expect(g.started.length).toBe(2), WAIT)
     expect(g.started[1]).toContain('second')
     g.releaseOne()
-    await vi.waitFor(() => expect(g.started.length).toBe(3))
+    await vi.waitFor(() => expect(g.started.length).toBe(3), WAIT)
     expect(g.started[2]).toContain('third')
     g.releaseAll()
-    await vi.waitFor(() => expect((daemon as any).inflight.has(key)).toBe(false))
+    await vi.waitFor(() => expect((daemon as any).inflight.has(key)).toBe(false), WAIT)
     // All replayed rows removed once their turns completed.
     expect(inbox(root)).toHaveLength(0)
     await daemon.stop()
@@ -574,8 +579,8 @@ describe('daemon durable inbox', () => {
 
     const g = gatedHost()
     const daemon = await boot(root, g.host)
-    await vi.waitFor(() => expect(inbox(root)).toHaveLength(0))
-    await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0))
+    await vi.waitFor(() => expect(inbox(root)).toHaveLength(0), WAIT)
+    await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
     expect(g.host.prompt).not.toHaveBeenCalled()
     expect(loopGuard(root)).toMatchObject({ reason: 'automatic_turn_burst' })
     await daemon.stop()
@@ -609,8 +614,8 @@ describe('daemon durable inbox', () => {
 
     const g = gatedHost()
     const daemon = await boot(root, g.host)
-    await vi.waitFor(() => expect(inbox(root)).toHaveLength(0))
-    await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0))
+    await vi.waitFor(() => expect(inbox(root)).toHaveLength(0), WAIT)
+    await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
     expect(g.host.prompt).not.toHaveBeenCalled()
     expect(loopGuard(root)).toMatchObject({ automaticCount: 9, reason: 'automatic_turn_burst' })
     await daemon.stop()
@@ -657,17 +662,17 @@ describe('daemon durable inbox', () => {
 
     const g = coldReplayHost()
     const daemon = await boot(root, g.host)
-    await vi.waitFor(() => expect(g.host.newSession).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(g.host.newSession).toHaveBeenCalledTimes(1), WAIT)
     // The noisy scope is purged, but the other accepted row stays durable while
     // the host-wide cancel backstop makes new admission temporarily unsafe.
     expect(inbox(root).map((row) => row.id)).toEqual([healthy.msgId])
     expect(g.started).toHaveLength(0)
 
     g.releaseCold()
-    await vi.waitFor(() => expect(g.started).toHaveLength(1))
+    await vi.waitFor(() => expect(g.started).toHaveLength(1), WAIT)
     expect(g.started[0]).toContain('healthy replay')
     g.releasePrompt()
-    await vi.waitFor(() => expect(inbox(root)).toHaveLength(0))
+    await vi.waitFor(() => expect(inbox(root)).toHaveLength(0), WAIT)
 
     await daemon.stop()
   }, 15_000)
@@ -711,7 +716,7 @@ describe('daemon durable inbox', () => {
 
     const g = coldReplayHost()
     const daemon = await boot(root, g.host)
-    await vi.waitFor(() => expect(g.host.newSession).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(g.host.newSession).toHaveBeenCalledTimes(1), WAIT)
     expect(inbox(root).map((row) => row.id)).toEqual([deferred.msgId])
 
     writePause(root, true)
@@ -721,8 +726,8 @@ describe('daemon durable inbox', () => {
     await daemon.reconcile()
 
     g.releaseCold()
-    await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0))
-    await vi.waitFor(() => expect((daemon as any).safetyDrainingAgents.size).toBe(0))
+    await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
+    await vi.waitFor(() => expect((daemon as any).safetyDrainingAgents.size).toBe(0), WAIT)
     expect(g.started).toHaveLength(0)
 
     const fresh = (daemon as any).dispatch('bot-a', {
@@ -731,7 +736,7 @@ describe('daemon durable inbox', () => {
       traceId: '200',
       text: 'fresh after unpause'
     })
-    await vi.waitFor(() => expect(g.started).toHaveLength(1))
+    await vi.waitFor(() => expect(g.started).toHaveLength(1), WAIT)
     g.releasePrompt()
     await expect(fresh).resolves.toBe('acp-2')
     await daemon.stop()
@@ -766,7 +771,7 @@ describe('daemon durable inbox', () => {
     // Startup stays silent: the pre-pause row was terminally discarded, not deferred.
     expect(resumedHost.host.prompt).not.toHaveBeenCalled()
     const fresh = (resumed as any).dispatch('bot-a', msg('200', 'fresh after resume'), 'int-a')
-    await vi.waitFor(() => expect(resumedHost.host.prompt).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(resumedHost.host.prompt).toHaveBeenCalledTimes(1), WAIT)
     expect(resumedHost.started[0]).toContain('fresh after resume')
     resumedHost.releaseOne()
     await expect(fresh).resolves.toBe('acp-1')
@@ -860,7 +865,7 @@ describe('daemon durable inbox', () => {
     })
 
     const head = (daemon as any).dispatch('bot-a', automatic(1), 'int-a')
-    await vi.waitFor(() => expect(g.host.prompt).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(g.host.prompt).toHaveBeenCalledTimes(1), WAIT)
     const queued: Array<Promise<unknown>> = []
     // Eight automatic admissions are allowed. The ninth consecutive one opens the
     // circuit before admission and atomically discards the seven buffered turns.
@@ -898,8 +903,8 @@ describe('daemon durable inbox', () => {
 
     g.releaseOne()
     await expect(head).resolves.toBeNull()
-    await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0))
-    await vi.waitFor(() => expect((daemon as any).safetyDrainingAgents.size).toBe(0))
+    await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
+    await vi.waitFor(() => expect((daemon as any).safetyDrainingAgents.size).toBe(0), WAIT)
     ;(daemon as any).onInbound(msg('11', '!resume'))
     expect(loopGuard(root)).toBeUndefined()
     await daemon.stop()
@@ -945,8 +950,8 @@ describe('daemon durable inbox', () => {
 
     const headA = (daemon as any).dispatch('bot-a', echo(1), 'int-a')
     const headB = (daemon as any).dispatch('bot-b', echo(2), 'int-b')
-    await vi.waitFor(() => expect(a.host.prompt).toHaveBeenCalledTimes(1))
-    await vi.waitFor(() => expect(b.host.prompt).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(a.host.prompt).toHaveBeenCalledTimes(1), WAIT)
+    await vi.waitFor(() => expect(b.host.prompt).toHaveBeenCalledTimes(1), WAIT)
     const queued = [
       (daemon as any).dispatch('bot-a', echo(3), 'int-a'),
       (daemon as any).dispatch('bot-b', echo(4), 'int-b'),
@@ -967,7 +972,7 @@ describe('daemon durable inbox', () => {
     b.releaseOne()
     await expect(headA).resolves.toBeNull()
     await expect(headB).resolves.toBeNull()
-    await vi.waitFor(() => expect((daemon as any).safetyDrainingAgents.size).toBe(0))
+    await vi.waitFor(() => expect((daemon as any).safetyDrainingAgents.size).toBe(0), WAIT)
 
     // Same channel, different non-DM thread is a distinct conversation scope.
     const fresh = (daemon as any).dispatch('bot-a', {
@@ -975,7 +980,7 @@ describe('daemon durable inbox', () => {
       sender: { id: 'U1', isBot: false },
       text: 'fresh human turn'
     })
-    await vi.waitFor(() => expect(a.host.prompt).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(a.host.prompt).toHaveBeenCalledTimes(2), WAIT)
     a.releaseOne()
     await expect(fresh).resolves.toBe('acp-a')
     await daemon.stop()
@@ -988,7 +993,7 @@ describe('daemon durable inbox', () => {
 
     // Admit a message (persists a live row) and freeze its turn in prompt.
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     expect(inbox(root).map((r) => r.id)).toEqual(['slack:C1:100'])
 
     // Replay while that id is still live → it must be skipped, not re-dispatched.
@@ -1008,7 +1013,7 @@ describe('daemon durable inbox', () => {
     const daemon = await boot(root, g.host)
 
     const first = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
 
     // Simulates an ACK-cache loss/restart race: SQLite still owns the stable
     // delivery id, so INSERT OR IGNORE must also gate in-memory admission.
@@ -1117,7 +1122,7 @@ describe('daemon durable inbox', () => {
 
     // Head admitted + running (blocked in prompt); two more queued behind it. All persisted.
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(started.length).toBe(1))
+    await vi.waitFor(() => expect(started.length).toBe(1), WAIT)
     const p2 = (daemon as any).dispatch('bot-a', msg('200', 'second'), 'int-a')
     const p3 = (daemon as any).dispatch('bot-a', msg('300', 'third'), 'int-a')
     expect((daemon as any).serialQueue.get(key)).toHaveLength(2)
@@ -1156,7 +1161,7 @@ describe('daemon durable inbox', () => {
     // Head non-webchat turn runs; a webchat turn queues behind it. The webchat entry admits
     // into the gate but must NOT write a durable inbox row.
     const p1 = (daemon as any).dispatch('bot-a', msg('100', 'first'), 'int-a')
-    await vi.waitFor(() => expect(g.started.length).toBe(1))
+    await vi.waitFor(() => expect(g.started.length).toBe(1), WAIT)
     const p2 = (daemon as any).dispatch('bot-a', msg('200', 'wc'), 'int-a', {
       conversationId: 'conv-a',
       turnId,

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -789,7 +789,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
       authoritative: false
     })
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('folds observed Discord threads onto their enclosing channel (one row per channel)', async () => {
     const root = root1()

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -7,6 +7,11 @@ import { SlackConnection } from '../src/slack/connection.js'
 import { TelegramConnection } from '../src/telegram/connection.js'
 import { DiscordConnection } from '../src/discord/connection.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 // A SlackConnection backed by an inert fake Bolt app (no network), with a fixed
 // bot user id, so reconcileSlackConnections' existing-socket branch can be exercised.
 function fakeConn(appToken: string, botToken: string, botUserId: string): SlackConnection {
@@ -767,7 +772,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
       },
       'fs-int'
     )
-    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledOnce(), WAIT)
 
     // Model the Lark lookup finishing while cold ACP startup is still blocked: there
     // is a resolved name, but no session row for discovery to publish yet.

--- a/packages/daemon/test/turn-output-workflow.test.ts
+++ b/packages/daemon/test/turn-output-workflow.test.ts
@@ -7,6 +7,11 @@ import { sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import type { NormalizedMessage } from '../src/messages/normalized.js'
 import { FakeClock } from './cp/fake-clock.js'
 
+// vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
+// cold session boot (workspace + host + session/new) can stall well past a second.
+// Give every poll in this file the same generous budget instead.
+const WAIT = { timeout: 10_000 }
+
 function scaffold(): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-turn-output-'))
   writeFileSync(
@@ -159,7 +164,7 @@ describe('TurnOutputWorkflow', () => {
 
     const firstMessage = msg('100.1', 'original request')
     const first = (daemon as any).dispatch('bot-a', firstMessage, 'int-a')
-    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1), WAIT)
     expect(conn.postMessage).not.toHaveBeenCalled()
 
     const clarificationMessage = msg('100.2', 'important clarification')
@@ -173,7 +178,7 @@ describe('TurnOutputWorkflow', () => {
     expect((daemon as any).serialQueue.get(key)).toHaveLength(1)
     releaseFirst()
 
-    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
     await expect(first).resolves.toBe('acp-1')
     await expect(clarification).resolves.toBe('acp-1')
 
@@ -246,7 +251,7 @@ describe('TurnOutputWorkflow', () => {
     const second = (daemon as any).dispatch('bot-a', secondClarification, 'int-a')
     const key = sessionKey('slack', 'C1', 'T1', 'bot-a', firstMessage.transportScope)
 
-    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledOnce(), WAIT)
     expect(prompts[0]).toContain('original request')
     const firstQuote = prompts[0].indexOf('[U2] the deployment failed with ECONNRESET')
     const firstReply = prompts[0].indexOf('[U1] first pre-prompt clarification')

--- a/packages/daemon/test/webchat-turn-refresh.test.ts
+++ b/packages/daemon/test/webchat-turn-refresh.test.ts
@@ -156,7 +156,7 @@ describe('webchat turn-final context refresh', () => {
     expect(rows.find((r) => r.text === 'peer answer 1')?.postId).toBe(peerPost(1, 0).postId)
     expect(rows.find((r) => r.text === 'fresh replacement')?.postId).toBe(posts[0]!.post.postId)
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('a busy same-agent follow-up is visible to the running generation and coalesces into it', async () => {
     let onUpdate!: (sid: string, u: unknown) => void
@@ -234,7 +234,7 @@ describe('webchat turn-final context refresh', () => {
     expect(posts).toHaveLength(1)
     expect(posts[0]!.post.text).toBe('combined answer')
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('coalesces a busy follow-up even when its canonical millisecond was collision-bumped', async () => {
     let onUpdate!: (sid: string, u: unknown) => void
@@ -318,7 +318,7 @@ describe('webchat turn-final context refresh', () => {
     expect(posts).toHaveLength(1)
     expect(posts[0]!.post.text).toBe('combined answer')
     await daemon.stop()
-  })
+  }, 15_000)
 
   it('context-churn exhaustion closes the browser turn with stopReason context_churn and commits no post', async () => {
     let onUpdate!: (sid: string, u: unknown) => void
@@ -386,7 +386,7 @@ describe('webchat turn-final context refresh', () => {
       .filter((row: { sender: string }) => row.sender === AGENT_ID)
     expect(replies).toEqual([])
     await daemon.stop()
-  })
+  }, 15_000)
   it('distinct canonical posts sharing millisecond, sender, and text occupy separate slots', async () => {
     // The C2 dedupe prerequisite: `at` minting is connection-local, so two
     // tabs can mint distinct posts on the same millisecond — and a same-user


### PR DESCRIPTION
## Why

[Run 30912167589](https://github.com/agentconnect-md/agentconnect/actions/runs/30912167589/attempts/1) went red on a single test out of 3019:

```
FAIL packages/daemon test/daemon-commands.test.ts
  > !queue buffers a message and dispatches it once the turn goes idle
AssertionError: expected false to be true
  ❯ test/daemon-commands.test.ts:452:64
```

It was a flake, not a regression — the PR under test only touched a web component, and a re-run of the same commit went green.

The mechanism: `vi.waitFor` hardcodes a **1000ms** timeout (`{ interval = 50, timeout = 1e3 }` in vitest 4.1.10 — there is no config knob for it). In tests that drive a real `Daemon`, that poll is waiting on the **cold session boot** path: `dispatchOne()` awaits `sessions.handle()` for workspace init, host start and `session/new` before registering `pending`.

Instrumenting the 7 identical call sites locally, that wait resolves on the **first poll interval**:

```
__WAITFOR_MS__=51, 51, 51, 50, 52, 100, 51
```

So exceeding 1000ms in CI means a >20x stall — plausible when `maxWorkers: 4` saturates the 4 vCPU of a hosted runner and the tests are integration-shaped (real daemon, real tmpdir, real mcp unix socket).

## What

This is not a new idea — `daemon-webchat.test.ts` already reached the same diagnosis and fixed itself:

> `vi.waitFor` defaults to a 1000ms budget — too tight on a loaded CI runner draining N queued turns through the serial gate (the 11-turn poll flaked at ~7/11). Every test here already allows 15s, so give the polls a uniform, generous budget.

That file (and `webchat-turn-refresh.test.ts`) declare `const WAIT = { timeout: 10_000 }` and pass it everywhere. This PR extends the same constant to the remaining daemon-backed test files — **189 call sites across 13 files** — each with a short comment stating the rationale.

## Deliberately excluded

- **The two best-effort waits** in `finally` blocks of `daemon-interrupt-safety.test.ts` (`await vi.waitFor(...).catch(() => {})`). Those are cleanup, not synchronization points: on the failure path a 10s budget could outrun the enclosing 15s test timeout, turning "cleanup didn't settle" into "test timed out".
- **Files that never construct a `Daemon`** (`cp/memory-connection-registry`, `memory-capture-outbox`, …). 35 bare `waitFor` calls remain there by design — they don't touch the cold-boot path.

## Validation

- `prettier --check`, `eslint`, `tsc` — all clean.
- Full daemon unit suite: **3019 tests**.

One unrelated failure surfaced in the full local run: `daemon-agent-mention-routing.test.ts` hit `Test timed out in 5000ms`. That file contains **no `vi.waitFor`** and is untouched by this PR; re-run in isolation it passes 33/33. It is a *second, independent* timeout line — the `testTimeout` 5000ms default — which also explains the `session-manager.test.ts` failure in run 30908921426. Left alone here; worth its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
