### PR TITLE
fix(web): the output-mode status-bar tooltip stops naming Slack

### DIFF
--- a/packages/web/src/components/console/OutputModeField.test.tsx
+++ b/packages/web/src/components/console/OutputModeField.test.tsx
@@ -1,0 +1,95 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { OutputModeField } from './OutputModeField'
+import { OUTPUT_CHROME_COPY, OUTPUT_MODE_OPTIONS } from '@/lib/output-mode'
+
+/**
+ * The field's two chrome toggles. Both status-bar sentences shipped naming
+ * Slack — on a control that is agent-level, rendered from the Add/Edit agent
+ * modals with no platform in scope, so an agent installed only on Telegram or
+ * Discord read them too. What these pin is that the copy stays provider-free
+ * AND stays wired to the right arm of each toggle.
+ */
+
+/** The chat platforms the console registers, plus Lark (Feishu's other regional
+ *  brand). Hardcoded rather than read from `platforms/registry`: that module
+ *  pulls every wizard Body in with it, and this is a copy test. */
+const PLATFORM_WORDS = /slack|telegram|discord|feishu|lark/i
+
+/** Captured from `OutputModeField.tsx` before the copy moved. The footer pair
+ *  moved verbatim — only the status-bar pair was rewritten. */
+const FOOTER_ON = 'Replies show the agent, runtime, model, and session links.'
+const FOOTER_OFF = 'No footer is added to replies.'
+
+function render(props: { showFooter: boolean; showStatusBar: boolean }) {
+  return renderToStaticMarkup(
+    <OutputModeField
+      value="low"
+      onChange={() => undefined}
+      onShowFooterChange={() => undefined}
+      onShowStatusBarChange={() => undefined}
+      {...props}
+    />
+  )
+}
+
+describe('Output-mode chrome copy', () => {
+  it('describes the status row without naming a platform', () => {
+    // The defect: an agent with no Slack integration at all was told about
+    // "Slack threads" and "Slack session status rows".
+    expect(OUTPUT_CHROME_COPY.statusBar.on).toBe(
+      'Threads show model, context, usage, and session controls on platforms with a status row.'
+    )
+    expect(OUTPUT_CHROME_COPY.statusBar.off).toBe('Session status rows are hidden.')
+  })
+
+  it('qualifies the on-state instead of promising a row everywhere', () => {
+    // Only a platform whose daemon turn-chrome facet declares
+    // `statusSurface: 'turn-bar'` renders one (Slack today); Telegram, Discord
+    // and Feishu declare `'on-demand'` and post nothing, so an unqualified
+    // sentence would be the same defect with the brand filed off.
+    expect(OUTPUT_CHROME_COPY.statusBar.on).toMatch(/on platforms with a status row/)
+  })
+
+  it('names no platform anywhere in the output-mode vocabulary', () => {
+    const strings = [
+      ...Object.values(OUTPUT_CHROME_COPY).flatMap((toggle) => Object.values(toggle)),
+      ...OUTPUT_MODE_OPTIONS.flatMap((mode) => [mode.label, mode.description])
+    ]
+    for (const copy of strings) expect(copy, copy).not.toMatch(PLATFORM_WORDS)
+  })
+
+  it('leaves the footer sentences byte-identical', () => {
+    // They were already provider-free; extracting them alongside the status-bar
+    // pair must not have reworded them.
+    expect(OUTPUT_CHROME_COPY.footer.on).toBe(FOOTER_ON)
+    expect(OUTPUT_CHROME_COPY.footer.off).toBe(FOOTER_OFF)
+  })
+
+  it('renders each toggle’s on-arm and off-arm', () => {
+    const on = render({ showFooter: true, showStatusBar: true })
+    expect(on).toContain(OUTPUT_CHROME_COPY.footer.on)
+    expect(on).toContain(OUTPUT_CHROME_COPY.statusBar.on)
+    expect(on).not.toContain(OUTPUT_CHROME_COPY.footer.off)
+    expect(on).not.toContain(OUTPUT_CHROME_COPY.statusBar.off)
+
+    const off = render({ showFooter: false, showStatusBar: false })
+    expect(off).toContain(OUTPUT_CHROME_COPY.footer.off)
+    expect(off).toContain(OUTPUT_CHROME_COPY.statusBar.off)
+    expect(off).not.toContain(OUTPUT_CHROME_COPY.footer.on)
+    expect(off).not.toContain(OUTPUT_CHROME_COPY.statusBar.on)
+  })
+
+  it('keeps both details reachable as tooltips', () => {
+    // The copy is only ever read through `CompactFieldLabel`'s tooltip, so a
+    // sentence that renders without its describedby wiring is unreadable.
+    const html = render({ showFooter: true, showStatusBar: true })
+    expect(html).toContain('aria-label="About Show footer"')
+    expect(html).toContain('aria-label="About Show status bar"')
+    // Each sentence is the body of a `role="tooltip"` element, not loose text.
+    // (The third tooltip in this tree is `OutputModeHelp`'s mode comparison.)
+    for (const copy of [OUTPUT_CHROME_COPY.footer.on, OUTPUT_CHROME_COPY.statusBar.on]) {
+      expect(html, copy).toMatch(new RegExp(`role="tooltip"[^>]*>${copy.replace(/[.]/g, '\\.')}<`))
+    }
+  })
+})

--- a/packages/web/src/components/console/OutputModeField.tsx
+++ b/packages/web/src/components/console/OutputModeField.tsx
@@ -1,6 +1,6 @@
 import { CompactFieldLabel } from '@/components/console/CompactFieldLabel'
 import { OutputModeHelp } from '@/components/console/OutputModeHelp'
-import { OUTPUT_MODE_OPTIONS, type OutputMode } from '@/lib/output-mode'
+import { OUTPUT_CHROME_COPY, OUTPUT_MODE_OPTIONS, type OutputMode } from '@/lib/output-mode'
 
 export function OutputModeField({
   value,
@@ -50,9 +50,7 @@ export function OutputModeField({
         <CompactFieldLabel
           label="Show footer"
           tooltipAlign="right"
-          detail={
-            showFooter ? 'Replies show the agent, runtime, model, and session links.' : 'No footer is added to replies.'
-          }
+          detail={showFooter ? OUTPUT_CHROME_COPY.footer.on : OUTPUT_CHROME_COPY.footer.off}
         />
         <div className="pillbar self-start desktop:self-end">
           <button
@@ -77,11 +75,7 @@ export function OutputModeField({
         <CompactFieldLabel
           label="Show status bar"
           tooltipAlign="right"
-          detail={
-            showStatusBar
-              ? 'Slack threads show model, context, usage, and session controls.'
-              : 'Slack session status rows are hidden.'
-          }
+          detail={showStatusBar ? OUTPUT_CHROME_COPY.statusBar.on : OUTPUT_CHROME_COPY.statusBar.off}
         />
         <div className="pillbar self-start desktop:self-end">
           <button

--- a/packages/web/src/lib/output-mode.ts
+++ b/packages/web/src/lib/output-mode.ts
@@ -27,6 +27,36 @@ export const OUTPUT_MODE_OPTIONS: readonly OutputModeOption[] = [
   }
 ]
 
+/**
+ * Copy for the two chrome toggles `OutputModeField` renders beside the mode
+ * pills. Platform-free by rule, exactly like {@link OUTPUT_MODE_OPTIONS}:
+ * output mode is ONE agent-level setting every integration of that agent obeys,
+ * and the field is rendered from the Add/Edit agent modals, where no platform is
+ * in scope to resolve copy against — a brand-new agent has no integration yet.
+ * Both status-bar sentences used to open with "Slack", so an agent installed
+ * only on Telegram read about a product it does not touch.
+ *
+ * WHY THE "ON" SENTENCE IS QUALIFIED rather than promising a row everywhere.
+ * The status row IS per-platform behavior, but the axis lives in the daemon, not
+ * here: `packages/daemon/src/platforms/turn-chrome.ts` declares
+ * `statusSurface: 'turn-bar'` for Slack and `'on-demand'` for Telegram, Discord
+ * and Feishu — on those three the emit path records its dedup key and posts
+ * nothing, and session state is answered by the `status` command instead
+ * (daemon.ts `emitStatusBar`). So the toggle is honored where a platform has a
+ * status surface and is inert where none exists; the copy says that, and names
+ * no provider while saying it.
+ */
+export const OUTPUT_CHROME_COPY = {
+  footer: {
+    on: 'Replies show the agent, runtime, model, and session links.',
+    off: 'No footer is added to replies.'
+  },
+  statusBar: {
+    on: 'Threads show model, context, usage, and session controls on platforms with a status row.',
+    off: 'Session status rows are hidden.'
+  }
+} as const
+
 export function isOutputMode(value: string | null | undefined): value is OutputMode {
   return OUTPUT_MODE_OPTIONS.some((mode) => mode.key === value)
 }


### PR DESCRIPTION
## What

`OutputModeField` is an **agent-level** control mounted from both `AddAgentModal` and `EditAgentModal`, so its *Show status bar* tooltip renders for every agent. Both arms named Slack:

- `'Slack threads show model, context, usage, and session controls.'`
- `'Slack session status rows are hidden.'`

An agent installed only on Telegram or Discord read about a product it does not touch. Found during the S3 §10 platform-module sweep (#616) and deliberately left out of it — this is output-mode copy, not a §10 web platform-module surface.

## What the daemon actually does

The rewording depends on whether the behavior is platform-neutral, so I checked before choosing. It is **not** neutral — and it is also not Slack-only by nature:

- `packages/daemon/src/platforms/turn-chrome.ts` (§7.4) declares `statusSurface: 'turn-bar'` for **slack** and `'on-demand'` for **telegram / discord / feishu**.
- `daemon.ts` `emitStatusBar` honors `showStatusBar` only on the `'turn-bar'` arm. On the three on-demand platforms it records the dedup key, **posts nothing**, and session state is answered by the `status` command (`!status` on Slack, `/status` on Telegram/Discord — `commands/commands.ts`).

So the honest copy must do two things: name no provider, **and** not promise a status row everywhere.

| | before | after |
|---|---|---|
| on | Slack threads show model, context, usage, and session controls. | Threads show model, context, usage, and session controls on platforms with a status row. |
| off | Slack session status rows are hidden. | Session status rows are hidden. |

## Why not routed through the platform-module contract

The alternative in the brief was to publish this like #616 does for the Settings → Bots row copy (`settingsFragments.copy` → `botCardCopy()`). That resolution needs a `platformId`, and this field has none: it configures **one agent-wide setting every integration obeys**, and in the Add modal the agent has no integration yet. A registry member here would have nothing to resolve against — and naming the turn-bar platforms from the registry would reintroduce the same defect, just data-driven.

Instead the copy moves to `lib/output-mode.ts` beside `OUTPUT_MODE_OPTIONS` (whose mode descriptions were already platform-free), with the daemon fact recorded in the doc comment so the next editor does not re-add a brand. The **footer** pair moves verbatim — no wording change — so both toggles read from one place.

Independent of #616: no shared files, either can merge first.

## Test

New `OutputModeField.test.tsx` pins the chosen copy: the exact status-bar strings, that the on-arm stays qualified, that **no** string in the output-mode vocabulary (both toggles + every mode label/description) matches `/slack|telegram|discord|feishu|lark/i`, that the footer sentences are byte-identical to what shipped, and that each arm renders into a `role="tooltip"` element.

## Verification

- `pnpm --filter @agentconnect.md/web exec tsc -p tsconfig.json --noEmit` — clean
- `GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/web test` — 828 passed / 107 files
- prettier + eslint clean on the three files
- Browsed the Add agent modal in mock mode, desktop and mobile, both toggle states: the longer sentence wraps to three lines inside the 200px tooltip without overflowing the modal or the mobile sheet; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)