### PR TITLE
docs: teach CLAUDE.md the relay package and the platform-module structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,16 +42,41 @@ callback endpoint is required; the CP only orchestrates. Concretely:
 
 ## Monorepo (pnpm workspace, `packages/*`)
 
-| Package                          | Stack                              | Role                                                                                                                                                             |
-| -------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@agentconnect.md/message`       | TypeScript                         | Pure Slack, Lark, Telegram, and Discord normalization; depends on protocol types and contains no platform SDKs or I/O.                                           |
-| `@agentconnect.md/protocol`      | zod                                | Shared wire contract — frames, normalized message schemas, and fencing fields (`sessionEpoch`/`seq`/`launchId`). Single source of truth for every wire consumer. |
-| `@agentconnect.md/daemon`        | Node CLI (commander)               | The edge unit. Exposes the `agentconnect` CLI bin. Many CLI subcommands are still stubs (`run` and `chat` are the live ones).                                    |
-| `@agentconnect.md/control-plane` | Fastify + Prisma (Postgres)        | One Fastify process co-hosts the C2 BFF REST surface **and** the daemon WS endpoint on one port / one Postgres connection.                                       |
-| `@agentconnect.md/web`           | Next.js 16 + React 19 + Tailwind 4 | Config / monitoring console.                                                                                                                                     |
+| Package                          | Stack                              | Role                                                                                                                                                               |
+| -------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@agentconnect.md/message`       | TypeScript                         | Pure Slack, Lark, Telegram, and Discord normalization; depends on protocol types and contains no platform SDKs or I/O.                                             |
+| `@agentconnect.md/protocol`      | zod                                | Shared wire contract — frames, normalized message schemas, and fencing fields (`sessionEpoch`/`seq`/`launchId`). Single source of truth for every wire consumer.   |
+| `@agentconnect.md/daemon`        | Node CLI (commander)               | The edge unit. Exposes the `agentconnect` CLI bin. Many CLI subcommands are still stubs (`run` and `chat` are the live ones).                                      |
+| `@agentconnect.md/control-plane` | Fastify + Prisma (Postgres)        | One Fastify process co-hosts the C2 BFF REST surface **and** the daemon WS endpoint on one port / one Postgres connection.                                         |
+| `@agentconnect.md/relay`         | Fastify                            | Optional public ingress: Slack/Feishu HTTP callbacks, webhooks, webchat. Verifies, demuxes to the owning bot, forwards to the daemon. Persists no message content. |
+| `@agentconnect.md/web`           | Next.js 16 + React 19 + Tailwind 4 | Config / monitoring console.                                                                                                                                       |
 
 When you change a frame in `protocol`, both daemon and CP consume it — rebuild
 `protocol` (or rely on its `development` export → `./src/index.ts`) and check both sides.
+
+## Platform modules
+
+Chat-platform code (Slack, Telegram, Discord, Lark/Feishu) lives in **per-host
+modules behind published contracts**, not in branches spread through each host —
+see [`docs/designs/integration-plugin-architecture.md`](docs/designs/integration-plugin-architecture.md).
+Each host keeps its own `src/platforms/<id>/` directory plus a static
+`registry.ts`; the shared, pre-dispatch capability table is
+`packages/protocol/src/platform-manifest.ts` (§5).
+
+| Host          | Contract                                                      | What a module owns                                                                                                                              |
+| ------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| daemon        | three-facet adapter (connect/ingress/read port + turn output) | connection, normalization hand-off, renderers, strategy functions                                                                               |
+| relay         | `platforms/contract.ts` — `RelayPlatformIngressPlugin`        | `buildIngest` per bot, demux hints, `verify` → `handle`, optional `egress` facet                                                                |
+| control plane | `platforms/provider.ts` — `CpPlatformProvider`                | install routes at two mount scopes, credential schema + live validation, create tail, reapers, background loops, env keys, both wire projectors |
+| web           | `console/platforms/contract.ts` — `WebPlatformModule`         | wizard body, settings fragments, `Mark`, api bindings, channel semantics, text renderer                                                         |
+
+Two rules this refactor exists to enforce: **a platform name is never core
+knowledge** — core reads a capability, a manifest field, or a registry entry
+instead — and **a manifest field is earned by a pre-dispatch read**, or it is a
+capability flag with better branding and belongs in a host contract. Adding a
+platform should be implementing the four contracts plus one registry line per
+host; if you find yourself editing a `switch` in core, the seam is missing a
+member and that is the bug to fix.
 
 Web styling is Tailwind-utility-first over the CSS-variable design tokens —
 **read [`packages/web/STYLE.md`](packages/web/STYLE.md) before writing console

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,11 @@ Layer-2 turn-output surface, which is what removed the hardcoded `github` case
 from the dispatch path. Webchat is core-owned for the same kind of reason: it is
 the console's own surface and shares almost nothing with an external transport.
 Do not "finish the job" by forcing either into `WebPlatformModule` — §2 of the
-design records why that is the wrong shape.
+design records why that is the wrong shape. The code-host seam gets its own
+provider contract when GitLab arrives and makes it a two-implementer seam
+([`gitlab-com-integration.md`](docs/designs/gitlab-com-integration.md) §1.6,
+§8.1 `CodeHostRepository`); extracting it earlier, from one implementer, would
+be guessing at an interface.
 
 Two rules this refactor exists to enforce: **a platform name is never core
 knowledge** — core reads a capability, a manifest field, or a registry entry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,16 +59,27 @@ When you change a frame in `protocol`, both daemon and CP consume it — rebuild
 Chat-platform code (Slack, Telegram, Discord, Lark/Feishu) lives in **per-host
 modules behind published contracts**, not in branches spread through each host —
 see [`docs/designs/integration-plugin-architecture.md`](docs/designs/integration-plugin-architecture.md).
-Each host keeps its own `src/platforms/<id>/` directory plus a static
-`registry.ts`; the shared, pre-dispatch capability table is
+Each host keeps its own per-platform directory plus a static `registry.ts` —
+`src/platforms/<id>/` in daemon, relay and control-plane,
+`src/components/console/platforms/<id>/` in web (React code stays under
+`components/`). The shared, pre-dispatch capability table is
 `packages/protocol/src/platform-manifest.ts` (§5).
 
-| Host          | Contract                                                      | What a module owns                                                                                                                              |
-| ------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| daemon        | three-facet adapter (connect/ingress/read port + turn output) | connection, normalization hand-off, renderers, strategy functions                                                                               |
-| relay         | `platforms/contract.ts` — `RelayPlatformIngressPlugin`        | `buildIngest` per bot, demux hints, `verify` → `handle`, optional `egress` facet                                                                |
-| control plane | `platforms/provider.ts` — `CpPlatformProvider`                | install routes at two mount scopes, credential schema + live validation, create tail, reapers, background loops, env keys, both wire projectors |
-| web           | `console/platforms/contract.ts` — `WebPlatformModule`         | wizard body, settings fragments, `Mark`, api bindings, channel semantics, text renderer                                                         |
+| Host          | Contract                                                         | What a module owns                                                                                                                              |
+| ------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| daemon        | three-facet adapter (connect/ingress/read port + turn output)    | connection, normalization hand-off, renderers, strategy functions                                                                               |
+| relay         | `platforms/contract.ts` — `RelayPlatformIngressPlugin`           | `buildIngest` per bot, demux hints, `verify` → `handle`, optional `egress` facet                                                                |
+| control plane | `platforms/provider.ts` — `CpPlatformProvider`                   | install routes at two mount scopes, credential schema + live validation, create tail, reapers, background loops, env keys, both wire projectors |
+| web           | `components/console/platforms/contract.ts` — `WebPlatformModule` | wizard body, settings fragments, `Mark`, api bindings, channel semantics, text renderer                                                         |
+
+**GitHub and GitLab are deliberately NOT platform modules.** They have no chat
+ingress, so they stay on the webhook / code-host seam (`relay/src/hooks/`,
+`control-plane/src/github/`, the daemon poster) and implement only the narrower
+Layer-2 turn-output surface, which is what removed the hardcoded `github` case
+from the dispatch path. Webchat is core-owned for the same kind of reason: it is
+the console's own surface and shares almost nothing with an external transport.
+Do not "finish the job" by forcing either into `WebPlatformModule` — §2 of the
+design records why that is the wrong shape.
 
 Two rules this refactor exists to enforce: **a platform name is never core
 knowledge** — core reads a capability, a manifest field, or a registry entry


### PR DESCRIPTION
## What

`CLAUDE.md` was last touched in July and learned nothing from the integration-plugin refactor that restructured all four hosts. Two gaps:

1. **`@agentconnect.md/relay` was missing from the monorepo table.** It is the §8 ingress host — the package that terminates Slack/Feishu callbacks, webhooks and webchat — and a reader given that table would conclude it does not exist.
2. **New "Platform modules" section.** Where per-host platform code lives (`src/platforms/<id>/` plus a static registry per host), where the shared pre-dispatch capability table lives (`packages/protocol/src/platform-manifest.ts`), and one row per host naming its contract and what a module owns. It closes with the two rules the refactor exists to enforce — a platform name is never core knowledge, and a manifest field is earned by a pre-dispatch read — plus the practical tell: *if you are editing a `switch` in core, the seam is missing a member, and that is the bug to fix.*

## What this PR deliberately does NOT add

An earlier revision also "fixed" the control-plane test invocation, claiming a local run needs a `GITHUB_ACTIONS=true` prefix and that a positional path filter crashes. **Both claims are false on current `main`, and the revision was dropped after checking.** `scripts/vitest-github-reporters.ts` already returns a concrete `['default']` reporter outside CI, so `pnpm --filter @agentconnect.md/control-plane test:unit` runs clean locally (627 passing), and a name filter works — the "crash" was a nonexistent path in the example. The existing line about `-- -t "<name>"` was correct and stays.

A section on phantom type errors in an unbuilt worktree was also dropped: running the workspace build once is the obvious fix and does not need documenting.

## Tests

None — documentation only. Prettier-formatted. Every structural claim checked against `main` after the S3 series (`packages/*/src/platforms/`, `packages/protocol/src/platform-manifest.ts`, and the four contract files named in the table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)