### PR TITLE
test(web): pin the bare session→conversation redirect; drop stale ?focus prose

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -14,6 +14,7 @@ import {
 import Link from 'next/link'
 import { liveBotTurnKey, sameBotSpeaker } from '@/lib/bot-turn-grouping'
 import { mergeConversation, type MergeSource } from '@/lib/conversation-merge'
+import { selfConversationPath } from '@/lib/conversation-addressing'
 import { encodeConversationKey } from '@/lib/conversation-key'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
@@ -1412,10 +1413,12 @@ export default function SessionDetailView() {
     ([, orgId, key]) => fetchConversationByKey(key, orgId),
     { revalidateOnFocus: false }
   )
-  const selfConversationRedirect =
-    !flatView && selfKey && selfConversation && selfConversation.sessions.length > 1
-      ? orgPath(`/conversations/${encodeURIComponent(selfKey)}`)
-      : null
+  const selfConversationPathname = selfConversationPath({
+    flatView,
+    conversationKey: selfKey,
+    memberCount: selfConversation?.sessions.length ?? 0
+  })
+  const selfConversationRedirect = selfConversationPathname ? orgPath(selfConversationPathname) : null
   useEffect(() => {
     if (selfConversationRedirect) router.replace(selfConversationRedirect)
   }, [selfConversationRedirect, router])

--- a/packages/web/src/lib/conversation-addressing.test.ts
+++ b/packages/web/src/lib/conversation-addressing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveRoster, typedMentionIds, wireMentions } from './conversation-addressing'
+import { resolveRoster, selfConversationPath, typedMentionIds, wireMentions } from './conversation-addressing'
 
 const roster = [{ agentId: 'a-primary', primary: true }, { agentId: 'b-peer' }]
 
@@ -105,5 +105,35 @@ describe('typedMentionIds', () => {
 
   it('never narrows a single-agent conversation', () => {
     expect(typedMentionIds([{ agentId: 'solo', name: 'solo' }], '@solo hi')).toEqual([])
+  })
+})
+
+describe('selfConversationPath', () => {
+  const multi = { flatView: false, conversationKey: 'c2xhY2s', memberCount: 3 }
+
+  it('redirects a multi-participant session to the merged page', () => {
+    expect(selfConversationPath(multi)).toBe('/conversations/c2xhY2s')
+  })
+
+  it('carries no query — the landing has no ?focus scroll/highlight', () => {
+    // The regression this guards: the redirect used to append
+    // `?focus=<agentId>`, which scrolled that participant's first block into
+    // view, flashed its background, and auto-paged older windows hunting for
+    // it. A deep link opens the conversation, nothing more.
+    expect(selfConversationPath(multi)).not.toContain('?')
+  })
+
+  it('escapes a key that is not URL-safe', () => {
+    expect(selfConversationPath({ ...multi, conversationKey: 'a/b+c' })).toBe('/conversations/a%2Fb%2Bc')
+  })
+
+  it('stays on the session page for a single-participant conversation', () => {
+    expect(selfConversationPath({ ...multi, memberCount: 1 })).toBeNull()
+    expect(selfConversationPath({ ...multi, memberCount: 0 })).toBeNull()
+  })
+
+  it('never redirects an unresolved key or the view=flat diagnostic route', () => {
+    expect(selfConversationPath({ ...multi, conversationKey: null })).toBeNull()
+    expect(selfConversationPath({ ...multi, flatView: true })).toBeNull()
   })
 })

--- a/packages/web/src/lib/conversation-addressing.ts
+++ b/packages/web/src/lib/conversation-addressing.ts
@@ -91,3 +91,19 @@ export function typedMentionIds(
   const mentioned = new Set([...claims.values()].flatMap((c) => c.ids))
   return roster.filter((p) => mentioned.has(p.agentId)).map((p) => p.agentId)
 }
+
+/** Where a `/sessions/:id` deep link goes when its session turns out to belong
+ *  to a multi-participant conversation (merged-conversation-view.md §5.3).
+ *
+ *  The path is BARE. The landing carries no per-participant focus, so arriving
+ *  from a GitHub footer or a shared URL looks exactly like arriving from the
+ *  list — no scroll jump, no highlighted block. `view=flat` is the diagnostic
+ *  route and opts out of the redirect entirely. */
+export function selfConversationPath(input: {
+  flatView: boolean
+  conversationKey: string | null
+  memberCount: number
+}): string | null {
+  if (input.flatView || !input.conversationKey || input.memberCount <= 1) return null
+  return `/conversations/${encodeURIComponent(input.conversationKey)}`
+}

--- a/packages/web/src/lib/stick-to-bottom.test.tsx
+++ b/packages/web/src/lib/stick-to-bottom.test.tsx
@@ -193,7 +193,7 @@ describe('useStickToBottom self-inflicted scroll', () => {
   // "the next event": anything that moves the viewport first arrives as that same
   // single event. Swallowing by position rather than by turn is what keeps these
   // from being mistaken for the echo.
-  it('does not swallow the ?focus scrollIntoView that lands before the echo', () => {
+  it('does not swallow a programmatic scrollIntoView that lands before the echo', () => {
     setMetrics(2000)
     scroller.scrollTop = bottom()
     act(() => root.render(<Probe resetKey="s1" />))
@@ -203,12 +203,12 @@ describe('useStickToBottom self-inflicted scroll', () => {
     act(() => fireResize?.())
     expect(scroller.scrollTop).toBe(bottom())
 
-    // The ?focus effect centres the linked participant's block, then the single
-    // coalesced event is delivered from that new position.
+    // Something centres a row in the viewport, then the single coalesced event
+    // is delivered from that new position.
     scroller.scrollTop = 300
     act(() => scroller.dispatchEvent(new Event('scroll')))
 
-    setMetrics(3600) // more output must NOT drag the focused reader down
+    setMetrics(3600) // more output must NOT drag the reader back down
     act(() => fireResize?.())
     expect(scroller.scrollTop).toBe(300)
   })

--- a/packages/web/src/lib/stick-to-bottom.ts
+++ b/packages/web/src/lib/stick-to-bottom.ts
@@ -62,8 +62,8 @@ export function useStickToBottom(resetKey: string | null): () => void {
     //
     // Identified by POSITION, not by "the next event is mine": scroll events for
     // one scroller coalesce, so anything that moves the viewport before the
-    // pending echo is delivered — the `?focus` scrollIntoView, a quick flick of
-    // the wheel — arrives as that same single event. A bare flag would discard
+    // pending echo is delivered — a quick flick of the wheel, a programmatic
+    // scrollIntoView — arrives as that same single event. A bare flag would discard
     // it and leave the follow armed, dragging the reader back down on the next
     // row. Recording where the pin actually landed makes the echo verifiable:
     // if the viewport still sits there, nothing else moved it.


### PR DESCRIPTION
Review follow-ups to #623, which merged while these were being written. Nothing here changes behavior — it asserts the invariant #623 established and cleans up prose that outlived the code it described.

## Pin the redirect

#623 made the session→conversation redirect land on `/conversations/:key` with no query, but the invariant lived only in a comment. The target moves into a pure `selfConversationPath` in `conversation-addressing.ts`, and the four cases are now asserted:

- a multi-participant deep link redirects to the merged page,
- a single-participant one does not,
- an unresolved key or `view=flat` opts out entirely,
- **the path carries no `?`** — the regression guard. Anything that re-adds a landing parameter fails there instead of shipping.

The reviewer on #623 asked for a direct redirect regression test; this is it. A pure function is the seam the codebase already uses for this kind of route decision, and it keeps the test out of `SessionDetailView`'s SWR/router/org-context stack.

## Stale prose

`stick-to-bottom.ts`'s echo-swallowing comment and one test name cited the `?focus` `scrollIntoView` as their example of "something else moved the viewport before our pin's echo arrived". The mechanism is unchanged and still needed — any programmatic scroll coalesces into that same event, and swallowing by position rather than by turn is what tells them apart — but the cited example no longer exists, so both now name the general case.

## Verification

- `pnpm --filter @agentconnect.md/web typecheck` — clean
- eslint, prettier — clean
- `pnpm --filter @agentconnect.md/web test` — 108 files, 841 tests passing (5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)