### PR TITLE
feat(usage): add model breakdown to analytics

### DIFF
--- a/packages/control-plane/prisma/migrations/20260804130000_session_model_usage_ledger/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260804130000_session_model_usage_ledger/migration.sql
@@ -1,0 +1,49 @@
+ALTER TABLE "session_spend"
+  ADD COLUMN "model" TEXT,
+  ADD COLUMN "cumulativeTotalTokens" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "cumulativeInputTokens" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "cumulativeOutputTokens" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "cumulativeThoughtTokens" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "cumulativeCachedReadTokens" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "cumulativeCachedWriteTokens" INTEGER NOT NULL DEFAULT 0;
+
+-- Existing timelines predate model observations. Attribute their last known
+-- cumulative token snapshot to the honest unknown bucket; later reports diff
+-- from this baseline and can be attributed to their observed model without
+-- rewriting pre-upgrade usage.
+WITH latest AS (
+  SELECT DISTINCT ON ("agentId", "sessionId")
+    "agentId", "sessionId", "at"
+  FROM "session_spend"
+  ORDER BY "agentId", "sessionId", "at" DESC
+)
+UPDATE "session_spend" AS sp
+SET
+  "cumulativeTotalTokens" = u."totalTokens",
+  "cumulativeInputTokens" = u."inputTokens",
+  "cumulativeOutputTokens" = u."outputTokens",
+  "cumulativeThoughtTokens" = u."thoughtTokens",
+  "cumulativeCachedReadTokens" = u."cachedReadTokens",
+  "cumulativeCachedWriteTokens" = u."cachedWriteTokens"
+FROM latest l
+JOIN "session_usage" u
+  ON u."agentId" = l."agentId" AND u."sessionId" = l."sessionId"
+WHERE sp."agentId" = l."agentId"
+  AND sp."sessionId" = l."sessionId"
+  AND sp."at" = l."at";
+
+-- Defensive baseline for a historical snapshot whose spend sample is missing.
+INSERT INTO "session_spend" (
+  "agentId", "sessionId", "at", "cumulativeCost",
+  "cumulativeTotalTokens", "cumulativeInputTokens", "cumulativeOutputTokens",
+  "cumulativeThoughtTokens", "cumulativeCachedReadTokens", "cumulativeCachedWriteTokens"
+)
+SELECT
+  u."agentId", u."sessionId", u."lastActivityAt", u."costAmount",
+  u."totalTokens", u."inputTokens", u."outputTokens",
+  u."thoughtTokens", u."cachedReadTokens", u."cachedWriteTokens"
+FROM "session_usage" u
+WHERE NOT EXISTS (
+  SELECT 1 FROM "session_spend" sp
+  WHERE sp."agentId" = u."agentId" AND sp."sessionId" = u."sessionId"
+);

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1238,23 +1238,28 @@ model SessionUsage {
   @@map("session_usage")
 }
 
-// SessionSpend — spend timeline backing every range-scoped cost rollup: the
-// /usage spend-over-time chart AND the Total-spend / per-agent cards.
+// SessionSpend — cumulative usage timeline backing range-scoped spend and the
+// durable per-model breakdown.
 //
 // session_usage is a latest-wins lifetime snapshot, so it can't answer "how much
 // was spent inside this window": a long-lived session collapses its entire cost
 // into its newest report. This table records the session's CUMULATIVE cost at each
-// report time; readers derive per-window / per-bucket spend by DIFFING consecutive
-// cumulatives (see PgSessionUsageRepo.aggregate). Storing cumulative (not a delta)
-// makes writes a plain idempotent upsert on (agentId, sessionId, at) — a duplicate
-// or out-of-order delivery just re-asserts the same value, so replays and
-// concurrent reports never double-count, and a downward correction is a lower
-// cumulative that the diff reflects as negative spend in its bucket.
+// report time together with the model observed for that interval. Readers derive
+// token/cost deltas by diffing consecutive cumulatives and attribute each delta to
+// this row's model. Storing cumulatives keeps writes idempotent on
+// (agentId, sessionId, at); null model is an observed or legacy unknown.
 model SessionSpend {
-  agentId        String   @db.Uuid
-  sessionId      String // ACP session id (echo of the snapshot row)
-  at             DateTime @db.Timestamptz(6) // the report's lastActivityAt — the bucket time
-  cumulativeCost Float // session's cumulative cost as of `at`; window spend = diff of consecutive cumulatives
+  agentId                     String   @db.Uuid
+  sessionId                   String // ACP session id (echo of the snapshot row)
+  at                          DateTime @db.Timestamptz(6) // the report's lastActivityAt — the bucket time
+  model                       String?
+  cumulativeTotalTokens       Int      @default(0)
+  cumulativeInputTokens       Int      @default(0)
+  cumulativeOutputTokens      Int      @default(0)
+  cumulativeThoughtTokens     Int      @default(0)
+  cumulativeCachedReadTokens  Int      @default(0)
+  cumulativeCachedWriteTokens Int      @default(0)
+  cumulativeCost              Float // session's cumulative cost as of `at`; window spend = diff of consecutive cumulatives
 
   agent Agent @relation(fields: [agentId], references: [id], onDelete: Cascade)
 

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2928,6 +2928,9 @@ export const UsageAgentDto = z.object({
   cachedWriteTokens: z.number(),
   costAmount: z.number()
 })
+export const UsageModelDto = UsageAgentDto.omit({ agentId: true }).extend({
+  model: z.string().nullable()
+})
 export const UsageDto = z.object({
   range: UsageRange,
   accessSyncDegraded: z.boolean().optional(),
@@ -2939,6 +2942,7 @@ export const UsageDto = z.object({
     costCurrency: z.string().nullable()
   }),
   agents: z.array(UsageAgentDto),
+  models: z.array(UsageModelDto),
   // Spend-over-time chart: cost bucketed by hour (d1) or day (longer ranges),
   // empty buckets filled to 0. `start` is a UTC-aligned ISO instant.
   series: z.object({

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -222,7 +222,7 @@ export const MCP_TOOLS: McpToolDef[] = [
   },
   {
     name: 'getUsage',
-    description: 'Token/cost usage aggregates over a time window, totals plus per-agent breakdown.',
+    description: 'Token/cost usage aggregates over a time window, totals plus agent and model breakdowns.',
     schema: z
       .object({
         range: z.enum(['d1', 'd7', 'd30', 'd90']).optional().describe('Window: 1/7/30/90 days (default d7)')

--- a/packages/control-plane/src/http/routes/usage.ts
+++ b/packages/control-plane/src/http/routes/usage.ts
@@ -3,7 +3,7 @@
  *
  * `GET /usage?range=d1|d7|d30|d90` sums the persisted per-session token usage (the
  * `SessionUsage` store fed by the daemon's `usage/report` EVT) over the selected
- * time window, grouped by agent, plus workspace totals. Unlike `/sessions` (a
+ * time window, grouped by agent and effective model, plus workspace totals. Unlike `/sessions` (a
  * live fan-out to daemons), this reads the CP's own historical store — so it
  * survives TTL-closed sessions and daemon restarts. Org-scoped to the single-
  * tenant default org (as with `/agents`).
@@ -31,7 +31,7 @@ export function usageRoutes(deps: HttpDeps) {
           tags: [Tag.Usage],
           summary: 'Get token usage',
           description:
-            'Sums the persisted per-session token usage over the selected time window, grouped by agent, plus workspace totals.',
+            'Sums persisted per-session token usage over the selected time window, with agent and effective-model breakdowns plus workspace totals.',
           operationId: 'getUsage',
           querystring: UsageQueryDto,
           response: { 200: UsageDto }
@@ -56,6 +56,7 @@ export function usageRoutes(deps: HttpDeps) {
           accessIssues: access.accessIssues,
           totals: agg.totals,
           agents: agg.agents,
+          models: agg.models,
           series: agg.series
         }
       }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -886,10 +886,11 @@ export interface EventSessionInput {
   channelName?: string
   triggeredByName?: string
   threadUrl?: string
-  // Effective execution-config snapshot (what the session actually ran with);
-  // an absent value ⇒ the runtime's own default (never overwritten on update).
+  // Effective execution-config snapshot. `model: null` is an explicit runtime
+  // observation of an opaque/default model; absent keeps the prior value for
+  // mixed-version refreshes.
   runtime?: string
-  model?: string
+  model?: string | null
   effort?: string
   fastMode?: boolean
   permissionMode?: string
@@ -1542,6 +1543,8 @@ export interface SessionUsageInput {
   agentId: AgentId
   platform?: string | null
   channel?: string | null
+  /** Model observed for this cumulative report's delta; null/absent ⇒ unknown. */
+  model?: string | null
   lastActivityAt: Date
   usage: SessionUsageCounts
 }
@@ -1559,6 +1562,20 @@ export interface AgentUsageAggregate {
   costAmount: number
 }
 
+/** Per-model rollup over a time window. `null` is usage whose daemon did not
+ *  report an effective model (legacy/runtime-owned default). */
+export interface ModelUsageAggregate {
+  model: string | null
+  sessions: number
+  totalTokens: number
+  inputTokens: number
+  outputTokens: number
+  thoughtTokens: number
+  cachedReadTokens: number
+  cachedWriteTokens: number
+  costAmount: number
+}
+
 /** One spend-over-time bucket: total cost of sessions whose last activity fell in
  *  `[start, start + one bucket)`. `start` is a UTC-aligned ISO instant. */
 export interface SpendBucket {
@@ -1566,7 +1583,7 @@ export interface SpendBucket {
   costAmount: number
 }
 
-/** Org-wide usage aggregate for a range: workspace totals + the per-agent breakdown.
+/** Org-wide usage aggregate for a range: workspace totals + agent/model breakdowns.
  *  `costCurrency` is the single distinct currency across the range, or null when
  *  none/mixed (amounts are summed as-is).
  *  `series` is the spend-over-time chart data: cost bucketed by hour (d1) or day
@@ -1574,6 +1591,7 @@ export interface SpendBucket {
 export interface UsageAggregate {
   totals: { sessions: number; totalTokens: number; costAmount: number; costCurrency: string | null }
   agents: AgentUsageAggregate[]
+  models: ModelUsageAggregate[]
   series: { bucket: 'hour' | 'day'; points: SpendBucket[] }
 }
 
@@ -1584,7 +1602,7 @@ export interface SessionUsageRepo {
   get(agentId: AgentId, sessionId: string): Promise<SessionUsageCounts | null>
   /** Aggregate usage for an org over sessions active at/after `since` (range window).
    *  When a `viewer` is supplied, sessions of restricted agents they can't see are
-   *  excluded from both the totals and the per-agent breakdown (derived visibility,
+   *  excluded from the totals and every breakdown (derived visibility,
    *  via the `agent` relation — undefined alone is unfiltered).
    *  `tzOffsetMin` (UTC − local, as `getTimezoneOffset()` reports) aligns the spend
    *  `series` buckets to the viewer's local day/hour; 0 (default) ⇒ UTC. */

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -3,11 +3,11 @@
  * dashboard (see the `SessionUsage` model + `usage/report` EVT).
  *
  * `record` latest-wins upserts the `(agentId, sessionId)` snapshot AND upserts the
- * session's CUMULATIVE cost at this report time into the `SessionSpend` timeline —
+ * session's cumulative tokens/cost plus its observed model into the timeline —
  * both idempotent, so re-sending or racing the same numbers is a no-op.
  * `aggregate` reports tokens/session-counts from the snapshot but derives every
- * range-scoped COST figure (total, per-agent, and the spend-over-time chart) from
- * the timeline by diffing consecutive cumulatives, so the cards and chart agree
+ * range-scoped COST figure (total, per-agent/model, and the spend-over-time chart)
+ * from the timeline by diffing consecutive cumulatives, so the cards and chart agree
  * and pre-window spend is excluded. It is org-scoped through the `agent` relation.
  * Token columns are `Int` per row
  * (a single session won't exceed 2^31), but Postgres `SUM(int)` returns `bigint`;
@@ -22,6 +22,7 @@ import type {
   SessionUsageCounts,
   UsageAggregate,
   AgentUsageAggregate,
+  ModelUsageAggregate,
   ViewCtx,
   SessionFilterQuery
 } from '../ports.js'
@@ -69,14 +70,19 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       create: { agentId: input.agentId, sessionId: input.sessionId, ...fields },
       update: fields
     })
-    // Spend timeline: record this report's CUMULATIVE cost stamped at its activity
-    // time. Readers derive window/bucket spend by diffing consecutive cumulatives
-    // (aggregate), so storing cumulative — not a computed delta — makes this a pure
-    // idempotent upsert on (agentId, sessionId, at): a duplicate delivery, an
-    // out-of-order report, or two concurrent reports converge to the same rows
-    // with no read-then-write race and no double-count. A downward correction is
-    // just a lower cumulative here; the diff turns it into negative spend in its
-    // own bucket, which nets out correctly against later increases.
+    // Usage timeline: each report carries cumulative counters plus the model for
+    // the interval that just ended. Readers diff consecutive rows, so model
+    // switches retain their own deltas while duplicate deliveries stay idempotent.
+    const sample = {
+      model: input.model ?? null,
+      cumulativeTotalTokens: fields.totalTokens,
+      cumulativeInputTokens: fields.inputTokens,
+      cumulativeOutputTokens: fields.outputTokens,
+      cumulativeThoughtTokens: fields.thoughtTokens,
+      cumulativeCachedReadTokens: fields.cachedReadTokens,
+      cumulativeCachedWriteTokens: fields.cachedWriteTokens,
+      cumulativeCost: fields.costAmount
+    }
     await this.db.sessionSpend.upsert({
       where: {
         agentId_sessionId_at: { agentId: input.agentId, sessionId: input.sessionId, at: input.lastActivityAt }
@@ -85,9 +91,9 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
         agentId: input.agentId,
         sessionId: input.sessionId,
         at: input.lastActivityAt,
-        cumulativeCost: fields.costAmount
+        ...sample
       },
-      update: { cumulativeCost: fields.costAmount }
+      update: sample
     })
   }
 
@@ -182,6 +188,57 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
           cachedWriteTokens: BigInt(row._sum.cachedWriteTokens ?? 0)
         }))
 
+    // Attribute lifetime token deltas to the model observed on each report. The
+    // outer session_usage filter preserves the dashboard's established semantics:
+    // a session active in the range contributes its lifetime token totals. One
+    // session can legitimately count under multiple models after a sticky switch.
+    const modelGrouped = await this.db.$queryRaw<
+      Array<{
+        model: string | null
+        sessions: bigint
+        totalTokens: bigint
+        inputTokens: bigint
+        outputTokens: bigint
+        thoughtTokens: bigint
+        cachedReadTokens: bigint
+        cachedWriteTokens: bigint
+      }>
+    >(Prisma.sql`
+      WITH ordered AS (
+        SELECT sp."agentId", sp."sessionId", NULLIF(sp."model", '') AS model,
+               sp."cumulativeTotalTokens"::bigint
+                 - LAG(sp."cumulativeTotalTokens", 1, 0) OVER sample_order AS "totalTokens",
+               sp."cumulativeInputTokens"::bigint
+                 - LAG(sp."cumulativeInputTokens", 1, 0) OVER sample_order AS "inputTokens",
+               sp."cumulativeOutputTokens"::bigint
+                 - LAG(sp."cumulativeOutputTokens", 1, 0) OVER sample_order AS "outputTokens",
+               sp."cumulativeThoughtTokens"::bigint
+                 - LAG(sp."cumulativeThoughtTokens", 1, 0) OVER sample_order AS "thoughtTokens",
+               sp."cumulativeCachedReadTokens"::bigint
+                 - LAG(sp."cumulativeCachedReadTokens", 1, 0) OVER sample_order AS "cachedReadTokens",
+               sp."cumulativeCachedWriteTokens"::bigint
+                 - LAG(sp."cumulativeCachedWriteTokens", 1, 0) OVER sample_order AS "cachedWriteTokens"
+        FROM "session_spend" sp
+        JOIN "session_usage" u ON u."agentId" = sp."agentId" AND u."sessionId" = sp."sessionId"
+        JOIN "agent" a ON a."id" = sp."agentId"
+        LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
+        WHERE ${agentViewerSql(orgId, viewer)}
+          AND u."lastActivityAt" >= ${since}
+          AND ${sessionScope ?? Prisma.sql`TRUE`}
+        WINDOW sample_order AS (PARTITION BY sp."agentId", sp."sessionId" ORDER BY sp."at")
+      )
+      SELECT model,
+             COUNT(DISTINCT ("agentId", "sessionId"))::bigint AS sessions,
+             COALESCE(SUM("totalTokens"), 0)::bigint AS "totalTokens",
+             COALESCE(SUM("inputTokens"), 0)::bigint AS "inputTokens",
+             COALESCE(SUM("outputTokens"), 0)::bigint AS "outputTokens",
+             COALESCE(SUM("thoughtTokens"), 0)::bigint AS "thoughtTokens",
+             COALESCE(SUM("cachedReadTokens"), 0)::bigint AS "cachedReadTokens",
+             COALESCE(SUM("cachedWriteTokens"), 0)::bigint AS "cachedWriteTokens"
+      FROM ordered
+      GROUP BY model
+    `)
+
     // Bucket geometry: d1 buckets hourly, longer ranges daily. Buckets align to the
     // viewer's LOCAL day/hour: we shift into local time (subtract offMs), floor
     // there, shift back — so `start` is the UTC instant of a local boundary and the
@@ -215,43 +272,36 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // baseline row per session — fine for a workspace's report volume; move to a
     // SQL window function (LAG over cumulative) if a range ever returns 100k+ rows.
     const SEP = '\0'
-    const [inRange, baselineRows] = sessionScope
-      ? await Promise.all([
-          this.db.$queryRaw<Array<{ agentId: string; sessionId: string; at: Date; cumulativeCost: number }>>(Prisma.sql`
-            SELECT sp."agentId", sp."sessionId", sp."at", sp."cumulativeCost"
-            FROM "session_spend" sp
-            JOIN "agent" a ON a."id" = sp."agentId"
-            JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
-            WHERE ${agentViewerSql(orgId, viewer)} AND sp."at" >= ${since} AND ${sessionScope}
-            ORDER BY sp."at" ASC
-          `),
-          this.db.$queryRaw<Array<{ agentId: string; sessionId: string; cumulativeCost: number }>>(Prisma.sql`
-            SELECT DISTINCT ON (sp."agentId", sp."sessionId")
-                   sp."agentId", sp."sessionId", sp."cumulativeCost"
-            FROM "session_spend" sp
-            JOIN "agent" a ON a."id" = sp."agentId"
-            JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
-            WHERE ${agentViewerSql(orgId, viewer)} AND sp."at" < ${since} AND ${sessionScope}
-            ORDER BY sp."agentId", sp."sessionId", sp."at" DESC
-          `)
-        ])
-      : await Promise.all([
-          this.db.sessionSpend.findMany({
-            where: { agent: agentScope, at: { gte: since } },
-            select: { agentId: true, sessionId: true, at: true, cumulativeCost: true },
-            orderBy: { at: 'asc' }
-          }),
-          this.db.sessionSpend.findMany({
-            where: { agent: agentScope, at: { lt: since } },
-            distinct: ['agentId', 'sessionId'],
-            orderBy: [{ agentId: 'asc' }, { sessionId: 'asc' }, { at: 'desc' }],
-            select: { agentId: true, sessionId: true, cumulativeCost: true }
-          })
-        ])
+    const [inRange, baselineRows] = await Promise.all([
+      this.db.$queryRaw<
+        Array<{ agentId: string; sessionId: string; at: Date; cumulativeCost: number; model: string | null }>
+      >(Prisma.sql`
+        SELECT sp."agentId", sp."sessionId", sp."at", sp."cumulativeCost", NULLIF(sp."model", '') AS model
+        FROM "session_spend" sp
+        JOIN "agent" a ON a."id" = sp."agentId"
+        LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
+        WHERE ${agentViewerSql(orgId, viewer)}
+          AND sp."at" >= ${since}
+          AND ${sessionScope ?? Prisma.sql`TRUE`}
+        ORDER BY sp."at" ASC
+      `),
+      this.db.$queryRaw<Array<{ agentId: string; sessionId: string; cumulativeCost: number }>>(Prisma.sql`
+        SELECT DISTINCT ON (sp."agentId", sp."sessionId")
+               sp."agentId", sp."sessionId", sp."cumulativeCost"
+        FROM "session_spend" sp
+        JOIN "agent" a ON a."id" = sp."agentId"
+        LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
+        WHERE ${agentViewerSql(orgId, viewer)}
+          AND sp."at" < ${since}
+          AND ${sessionScope ?? Prisma.sql`TRUE`}
+        ORDER BY sp."agentId", sp."sessionId", sp."at" DESC
+      `)
+    ])
     // Per-session running cumulative, seeded from the last pre-window report so the
     // first in-window delta counts only spend incurred inside the window.
     const prevCost = new Map<string, number>(baselineRows.map((r) => [r.agentId + SEP + r.sessionId, r.cumulativeCost]))
     const perAgentCost = new Map<string, number>()
+    const perModelCost = new Map<string, number>()
     let totalCost = 0
     // `inRange` is globally at-ascending, so each session's rows are visited in
     // chronological order — exactly what the running diff needs.
@@ -261,6 +311,8 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       prevCost.set(skey, row.cumulativeCost)
       totalCost += delta
       perAgentCost.set(row.agentId, (perAgentCost.get(row.agentId) ?? 0) + delta)
+      const modelKey = row.model ?? ''
+      perModelCost.set(modelKey, (perModelCost.get(modelKey) ?? 0) + delta)
       const idx = Math.floor((row.at.getTime() - floorSince) / stepMs)
       if (idx >= 0 && idx < n) points[idx]!.costAmount += delta
     }
@@ -278,6 +330,19 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     }))
     // Sort by token spend so the console's "top agents" ordering is stable.
     agents.sort((a, b) => b.totalTokens - a.totalTokens)
+
+    const models: ModelUsageAggregate[] = modelGrouped.map((g) => ({
+      model: g.model,
+      sessions: Number(g.sessions),
+      totalTokens: Number(g.totalTokens),
+      inputTokens: Number(g.inputTokens),
+      outputTokens: Number(g.outputTokens),
+      thoughtTokens: Number(g.thoughtTokens),
+      cachedReadTokens: Number(g.cachedReadTokens),
+      cachedWriteTokens: Number(g.cachedWriteTokens),
+      costAmount: perModelCost.get(g.model ?? '') ?? 0
+    }))
+    models.sort((a, b) => b.totalTokens - a.totalTokens)
 
     const totals = agents.reduce(
       (acc, a) => ({
@@ -308,6 +373,6 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
         })
     const costCurrency = currencies.length === 1 ? currencies[0]!.costCurrency : null
 
-    return { totals: { ...totals, costAmount: totalCost, costCurrency }, agents, series: { bucket, points } }
+    return { totals: { ...totals, costAmount: totalCost, costCurrency }, agents, models, series: { bucket, points } }
   }
 }

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -819,7 +819,10 @@ export class PgSessionRepo implements SessionRepo {
         ),
         "threadUrl" = COALESCE(EXCLUDED."threadUrl", "session_meta"."threadUrl"),
         "runtime" = COALESCE(EXCLUDED."runtime", "session_meta"."runtime"),
-        "model" = COALESCE(EXCLUDED."model", "session_meta"."model"),
+        "model" = CASE
+          WHEN ${ev.model !== undefined} THEN EXCLUDED."model"
+          ELSE "session_meta"."model"
+        END,
         "effort" = COALESCE(EXCLUDED."effort", "session_meta"."effort"),
         "fastMode" = COALESCE(EXCLUDED."fastMode", "session_meta"."fastMode"),
         "permissionMode" = COALESCE(

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -95,6 +95,7 @@ describe('handleEventSession', () => {
     Object.assign(frame.payload as Record<string, unknown>, {
       runtime: 'claude',
       model: 'opus',
+      observedModel: null,
       effort: 'high',
       fastMode: true,
       permissionMode: 'acceptEdits',
@@ -106,7 +107,9 @@ describe('handleEventSession', () => {
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({
         runtime: 'claude',
-        model: 'opus',
+        // A runtime observation wins over the legacy/config snapshot; null is
+        // preserved so persistence can clear a previously named model.
+        model: null,
         effort: 'high',
         fastMode: true,
         permissionMode: 'acceptEdits',

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -177,7 +177,7 @@ export const handleEventSession: Handler = async (frame, conn, deps) => {
       ...(p.triggeredByName !== undefined ? { triggeredByName: p.triggeredByName } : {}),
       ...(p.threadUrl !== undefined ? { threadUrl: p.threadUrl } : {}),
       ...(p.runtime !== undefined ? { runtime: p.runtime } : {}),
-      ...(p.model !== undefined ? { model: p.model } : {}),
+      ...(p.observedModel !== undefined ? { model: p.observedModel } : p.model !== undefined ? { model: p.model } : {}),
       ...(p.effort !== undefined ? { effort: p.effort } : {}),
       ...(p.fastMode !== undefined ? { fastMode: p.fastMode } : {}),
       ...(p.permissionMode !== undefined ? { permissionMode: p.permissionMode } : {}),

--- a/packages/control-plane/src/ws/handlers/usage-report.ts
+++ b/packages/control-plane/src/ws/handlers/usage-report.ts
@@ -24,6 +24,7 @@ export const handleUsageReport: Handler = async (frame, conn, deps) => {
       agentId,
       platform: p.platform ?? null,
       channel: p.channel ?? null,
+      ...(p.observedModel !== undefined ? { model: p.observedModel } : {}),
       lastActivityAt: new Date(p.lastActivityAt),
       usage: p.usage
     })

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -97,6 +97,7 @@ export async function seedSessionMeta(
     channel?: string
     parentSessionId?: string
     lastActivityAt?: Date
+    model?: string
   } = {}
 ): Promise<string> {
   await prisma.sessionMeta.create({
@@ -111,7 +112,8 @@ export async function seedSessionMeta(
       ...(opts.visibility ? { visibility: opts.visibility } : {}),
       ...(opts.ownerIdentity ? { ownerIdentity: opts.ownerIdentity } : {}),
       ...(opts.daemonId ? { daemonId: opts.daemonId } : {}),
-      ...(opts.parentSessionId ? { parentSessionId: opts.parentSessionId } : {})
+      ...(opts.parentSessionId ? { parentSessionId: opts.parentSessionId } : {}),
+      ...(opts.model ? { model: opts.model } : {})
     }
   })
   return id

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -26,8 +26,13 @@ const AGENT_A = '11111111-1111-4111-8111-111111111111'
 const AGENT_B = '22222222-2222-4222-8222-222222222222'
 const DAY_MS = 24 * 60 * 60 * 1000
 
-async function seedVisibleSession(agentId: string, sessionId: string, lastActivityAt: Date): Promise<void> {
-  await seedSessionMeta(prisma, sessionId, agentId, { lastActivityAt })
+async function seedVisibleSession(
+  agentId: string,
+  sessionId: string,
+  lastActivityAt: Date,
+  model?: string
+): Promise<void> {
+  await seedSessionMeta(prisma, sessionId, agentId, { lastActivityAt, ...(model ? { model } : {}) })
 }
 
 function authPayload(token: string) {
@@ -62,6 +67,7 @@ describe('usage/report handler — persists per-session token usage', () => {
       agentId: AGENT_A,
       platform: 'slack',
       channel: '#deploys',
+      observedModel: 'claude-sonnet-4-5',
       lastActivityAt: new Date().toISOString(),
       usage: { totalTokens: 4820, inputTokens: 3600, outputTokens: 1220, cachedReadTokens: 512, costAmount: 0.41 }
     })
@@ -76,6 +82,9 @@ describe('usage/report handler — persists per-session token usage', () => {
     expect(row!.inputTokens).toBe(3600)
     expect(row!.cachedReadTokens).toBe(512)
     expect(row!.costAmount).toBeCloseTo(0.41)
+    expect(await prisma.sessionSpend.findFirst({ where: { agentId: AGENT_A, sessionId: 'acp-sess-1' } })).toMatchObject(
+      { model: 'claude-sonnet-4-5', cumulativeTotalTokens: 4820 }
+    )
 
     // A later turn reports the NEW cumulative total → overwrite, never sum.
     stub.inject('usage/report', {
@@ -138,6 +147,80 @@ describe('usage/report handler — persists per-session token usage', () => {
     }
   })
 
+  it('attributes cumulative deltas across mid-session model switches', async () => {
+    const h = buildWsHarness(prisma)
+    const { stub } = await connectReady(h)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    const now = Date.now()
+    await seedVisibleSession(AGENT_A, 'switching', new Date(now - 60_000), 'latest-metadata-is-not-the-ledger')
+
+    const reports = [
+      { minutes: 3, observedModel: 'model-a' as string | null, totalTokens: 100, costAmount: 1 },
+      { minutes: 2, observedModel: 'model-b' as string | null, totalTokens: 250, costAmount: 2.5 },
+      { minutes: 1, observedModel: null, totalTokens: 300, costAmount: 3 }
+    ]
+    for (const [index, report] of reports.entries()) {
+      stub.inject('usage/report', {
+        sessionId: 'switching',
+        agentId: AGENT_A,
+        observedModel: report.observedModel,
+        lastActivityAt: new Date(now - report.minutes * 60_000).toISOString(),
+        usage: { totalTokens: report.totalTokens, costAmount: report.costAmount, costCurrency: 'USD' }
+      })
+      await vi.waitFor(async () => {
+        expect(await prisma.sessionSpend.count({ where: { agentId: AGENT_A, sessionId: 'switching' } })).toBe(index + 1)
+      })
+    }
+
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?range=d1` })
+      expect(res.statusCode).toBe(200)
+      const models = (
+        res.json() as {
+          models: Array<{ model: string | null; sessions: number; totalTokens: number; costAmount: number }>
+        }
+      ).models
+      expect(models).toEqual([
+        {
+          model: 'model-b',
+          sessions: 1,
+          totalTokens: 150,
+          inputTokens: 0,
+          outputTokens: 0,
+          thoughtTokens: 0,
+          cachedReadTokens: 0,
+          cachedWriteTokens: 0,
+          costAmount: 1.5
+        },
+        {
+          model: 'model-a',
+          sessions: 1,
+          totalTokens: 100,
+          inputTokens: 0,
+          outputTokens: 0,
+          thoughtTokens: 0,
+          cachedReadTokens: 0,
+          cachedWriteTokens: 0,
+          costAmount: 1
+        },
+        {
+          model: null,
+          sessions: 1,
+          totalTokens: 50,
+          inputTokens: 0,
+          outputTokens: 0,
+          thoughtTokens: 0,
+          cachedReadTokens: 0,
+          cachedWriteTokens: 0,
+          costAmount: 0.5
+        }
+      ])
+    } finally {
+      await close()
+    }
+  })
+
   it('drops usage for an agent not placed on the reporting daemon', async () => {
     const h = buildWsHarness(prisma)
     const { stub } = await connectReady(h)
@@ -189,10 +272,10 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     const recent = (mins: number) => new Date(now.getTime() - Math.min(mins * 60_000, sinceUtcMidnight))
 
     await Promise.all([
-      seedVisibleSession(AGENT_A, 'a1', recent(10)),
-      seedVisibleSession(AGENT_A, 'a2', recent(20)),
-      seedVisibleSession(AGENT_A, 'a-old', new Date(now.getTime() - 100 * DAY_MS)),
-      seedVisibleSession(AGENT_B, 'b1', recent(30))
+      seedVisibleSession(AGENT_A, 'a1', recent(10), 'claude-sonnet-4-5'),
+      seedVisibleSession(AGENT_A, 'a2', recent(20), 'claude-sonnet-4-5'),
+      seedVisibleSession(AGENT_A, 'a-old', new Date(now.getTime() - 100 * DAY_MS), 'claude-opus-4-1'),
+      seedVisibleSession(AGENT_B, 'b1', recent(30), 'gpt-5.6')
     ])
 
     // Agent A: two in-range sessions + one stale (100 days old, excluded from d30/d90).
@@ -232,16 +315,43 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
         }
       ]
     })
-    // Cost rollups (total, per-agent, series) derive from the spend timeline, not
-    // the snapshot. Each of these is a single-report session, so its cumulative
-    // equals its cost. (Seeded directly; the record() path writes both — see the
-    // per-bucket and boundary regressions below.)
+    // Cost and model rollups derive from the cumulative timeline, not current
+    // session metadata. Each row is a single-report session, so its cumulative
+    // token/cost values belong entirely to the observed model.
     await prisma.sessionSpend.createMany({
       data: [
-        { agentId: AGENT_A, sessionId: 'a1', cumulativeCost: 0.1, at: recent(10) },
-        { agentId: AGENT_A, sessionId: 'a2', cumulativeCost: 0.2, at: recent(20) },
-        { agentId: AGENT_A, sessionId: 'a-old', cumulativeCost: 9.9, at: new Date(now.getTime() - 100 * DAY_MS) },
-        { agentId: AGENT_B, sessionId: 'b1', cumulativeCost: 0.05, at: recent(30) }
+        {
+          agentId: AGENT_A,
+          sessionId: 'a1',
+          model: 'claude-sonnet-4-5',
+          cumulativeTotalTokens: 1000,
+          cumulativeCost: 0.1,
+          at: recent(10)
+        },
+        {
+          agentId: AGENT_A,
+          sessionId: 'a2',
+          model: 'claude-sonnet-4-5',
+          cumulativeTotalTokens: 2000,
+          cumulativeCost: 0.2,
+          at: recent(20)
+        },
+        {
+          agentId: AGENT_A,
+          sessionId: 'a-old',
+          model: 'claude-opus-4-1',
+          cumulativeTotalTokens: 9999,
+          cumulativeCost: 9.9,
+          at: new Date(now.getTime() - 100 * DAY_MS)
+        },
+        {
+          agentId: AGENT_B,
+          sessionId: 'b1',
+          model: 'gpt-5.6',
+          cumulativeTotalTokens: 500,
+          cumulativeCost: 0.05,
+          at: recent(30)
+        }
       ]
     })
 
@@ -253,6 +363,7 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
         range: string
         totals: { sessions: number; totalTokens: number; costAmount: number; costCurrency: string | null }
         agents: { agentId: string; sessions: number; totalTokens: number; costAmount: number }[]
+        models: { model: string | null; sessions: number; totalTokens: number; costAmount: number }[]
         series: { bucket: 'hour' | 'day'; points: { start: string; costAmount: number }[] }
       }
 
@@ -290,6 +401,15 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
       expect(b.sessions).toBe(1)
       expect(b.totalTokens).toBe(500)
       expect(body.agents[0]!.agentId).toBe(AGENT_A)
+
+      // The per-report execution ledger drives Analytics; the stale Opus row
+      // stays outside d30 regardless of current session metadata.
+      expect(body.models.map(({ model, sessions, totalTokens }) => ({ model, sessions, totalTokens }))).toEqual([
+        { model: 'claude-sonnet-4-5', sessions: 2, totalTokens: 3000 },
+        { model: 'gpt-5.6', sessions: 1, totalTokens: 500 }
+      ])
+      expect(body.models[0]!.costAmount).toBeCloseTo(0.3)
+      expect(body.models[1]!.costAmount).toBeCloseTo(0.05)
     } finally {
       await close()
     }
@@ -439,10 +559,11 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     try {
       const res = await app.inject({ method: 'GET', url: `${ORG}/usage` })
       expect(res.statusCode).toBe(200)
-      const body = res.json() as { range: string; totals: { sessions: number }; agents: unknown[] }
+      const body = res.json() as { range: string; totals: { sessions: number }; agents: unknown[]; models: unknown[] }
       expect(body.range).toBe('d30')
       expect(body.totals.sessions).toBe(0)
       expect(body.agents).toEqual([])
+      expect(body.models).toEqual([])
     } finally {
       await close()
     }

--- a/packages/control-plane/test/repo/session.repo.test.ts
+++ b/packages/control-plane/test/repo/session.repo.test.ts
@@ -197,6 +197,12 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     const moved = await repo.get(SessionId(SESSION))
     expect(moved?.model).toBe('sonnet')
     expect(moved?.fastMode).toBe(false)
+
+    // Explicit observed unknown clears the named model. A later legacy refresh
+    // that omits model still preserves that null rather than reviving config.
+    await repo.recordMilestone(ev('end', { model: null }))
+    await repo.recordMilestone(ev('end'))
+    expect((await repo.get(SessionId(SESSION)))?.model).toBeNull()
   })
 
   it('advances phase on subsequent milestones (upsert on sessionId)', async () => {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5430,6 +5430,7 @@ export class Daemon {
       triggeredBy: context.trigger,
       memoryProvider: 'managed'
     })
+    this.store.setObservedModel(executionKey, model ?? null)
     this.store.setSessionTitle(executionKey, 'Memory dream')
     const dream = this.store.getDream(agentId, context.dreamId)
     if (dream) {
@@ -5457,7 +5458,7 @@ export class Daemon {
       thread: context.dreamId,
       status: 'running',
       runtime: agent.runtime,
-      ...(model ? { model } : {})
+      model: model ?? null
     })
     // On cancel, drive the ACP turn-cancel path so a hung/long prompt actually
     // stops instead of pinning the dream's one-in-flight reservation.
@@ -5589,7 +5590,7 @@ export class Daemon {
         thread: context.dreamId,
         status: promptCompleted ? 'completed' : signal.aborted ? 'canceled' : 'failed',
         runtime: agent.runtime,
-        ...(model ? { model } : {}),
+        model: model ?? null,
         ...(extractionMode ? { permissionMode: extractionMode } : {})
       })
       host.discardSession(sessionId)
@@ -12586,6 +12587,7 @@ export class Daemon {
           : advertisedModel === 'default'
             ? undefined
             : advertisedModel
+      this.store.setObservedModel(key, turnModel ?? null)
       // Prepare the linked footer before host.prompt can emit its first chunk. Reply
       // sections then include it in their initial chat.postMessage, where Slack's
       // unfurl controls are supported; onFinal normally observes the same footer and
@@ -13671,7 +13673,7 @@ export class Daemon {
     thread?: string
     status?: string
     runtime?: string
-    model?: string
+    model?: string | null
     permissionMode?: string
   }): void {
     if (!this.cpClient) return
@@ -13743,11 +13745,17 @@ export class Daemon {
     const sessionRecord = this.store.getSessionByAcpIdForAgent(input.agentId, input.sessionId)
     if (sessionRecord?.workspaceIsolation) event.workspaceIsolation = sessionRecord.workspaceIsolation
     const storeKey = sessionRecord?.key
-    const model =
+    const configuredModel =
       (allowRuntimeChangesInChat && storeKey ? this.store.getModelOverride(storeKey) : undefined) ??
       agent?.runtimeOverrides?.model
-    if (input.model !== undefined) event.model = input.model
-    else if (model !== undefined) event.model = model
+    const observedModel =
+      input.model !== undefined ? input.model : storeKey ? this.store.getObservedModel(storeKey) : undefined
+    if (observedModel !== undefined) {
+      event.observedModel = observedModel
+      if (observedModel !== null) event.model = observedModel
+    } else if (configuredModel !== undefined) {
+      event.model = configuredModel
+    }
     const effort =
       (allowRuntimeChangesInChat && storeKey ? this.store.getEffortOverride(storeKey) : undefined) ??
       agent?.reasoningEffort
@@ -14867,12 +14875,14 @@ export class Daemon {
   ): void {
     const usage = this.store.getUsage(key)
     if (Object.keys(usage).length === 0) return
+    const observedModel = this.store.getObservedModel(key)
     try {
       this.cpClient?.emitUsageReport({
         sessionId,
         agentId,
         platform,
         channel,
+        ...(observedModel !== undefined ? { observedModel } : {}),
         lastActivityAt: new Date(this.clock.now()).toISOString(),
         usage
       })

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -573,6 +573,7 @@ export class LocalStore {
         key TEXT PRIMARY KEY, agentId TEXT, platform TEXT, channel TEXT, thread TEXT,
         transportScope TEXT, acpSessionId TEXT, state TEXT, lastDeliveredTs TEXT, updatedAt INTEGER,
         usage TEXT, muted INTEGER, triggeredBy TEXT, title TEXT, modelOverride TEXT,
+        observedModel TEXT, observedModelSet INTEGER NOT NULL DEFAULT 0,
         effortOverride TEXT, permissionModeOverride TEXT, fastModeOverride INTEGER,
         outputModeOverride TEXT, statusBarTs TEXT, memoryProvider TEXT, workspaceIsolation TEXT,
         originSessionId TEXT, lastTurnOutcome TEXT, needsParentReply INTEGER,
@@ -1209,6 +1210,10 @@ export class LocalStore {
     if (!cols.some((c) => c.name === 'title')) this.db.exec('ALTER TABLE sessions ADD COLUMN title TEXT')
     if (!cols.some((c) => c.name === 'modelOverride'))
       this.db.exec('ALTER TABLE sessions ADD COLUMN modelOverride TEXT')
+    if (!cols.some((c) => c.name === 'observedModel'))
+      this.db.exec('ALTER TABLE sessions ADD COLUMN observedModel TEXT')
+    if (!cols.some((c) => c.name === 'observedModelSet'))
+      this.db.exec('ALTER TABLE sessions ADD COLUMN observedModelSet INTEGER NOT NULL DEFAULT 0')
     if (!cols.some((c) => c.name === 'effortOverride'))
       this.db.exec('ALTER TABLE sessions ADD COLUMN effortOverride TEXT')
     if (!cols.some((c) => c.name === 'permissionModeOverride'))
@@ -2123,6 +2128,21 @@ export class LocalStore {
     const row = this.db.prepare('SELECT modelOverride FROM sessions WHERE key = ?').get(key) as
       { modelOverride: string | null } | undefined
     return row?.modelOverride ?? undefined
+  }
+
+  /** Last model the runtime actually exposed for this session. `null` is an
+   *  explicit opaque/default observation; undefined means no turn observed yet. */
+  getObservedModel(key: string): string | null | undefined {
+    const row = this.db.prepare('SELECT observedModel, observedModelSet FROM sessions WHERE key = ?').get(key) as
+      { observedModel: string | null; observedModelSet: number } | undefined
+    if (!row || row.observedModelSet !== 1) return undefined
+    return row.observedModel
+  }
+
+  /** Persist the runtime observation so late usage corrections and metadata
+   *  re-emits retain a named model or an explicit unknown across turn teardown. */
+  setObservedModel(key: string, model: string | null): void {
+    this.db.prepare('UPDATE sessions SET observedModel = ?, observedModelSet = 1 WHERE key = ?').run(model, key)
   }
 
   /** Persist the session-scoped model override. No-op on an unknown key. */

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -346,7 +346,17 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       start: vi.fn(async () => {}),
       newSession: vi.fn(async () => 'acp-sess-1'),
       hasSession: (id: string) => id === 'acp-sess-1',
-      prompt: vi.fn(async () => 'end_turn'),
+      modelOptions: vi.fn(() => ({ current: 'claude-sonnet-4-5', models: ['claude-sonnet-4-5'] })),
+      prompt: vi
+        .fn()
+        .mockResolvedValueOnce({
+          stopReason: 'end_turn',
+          usage: { totalTokens: 100, inputTokens: 80, outputTokens: 20 }
+        })
+        .mockResolvedValueOnce({
+          stopReason: 'end_turn',
+          usage: { totalTokens: 200, inputTokens: 160, outputTokens: 40 }
+        }),
       cancel: vi.fn(),
       stop: vi.fn()
     }
@@ -354,7 +364,8 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     await daemon.start()
     // Inject a fake CP client so the fire-and-forget emit is observable (no real WS).
     const emitEventSession = vi.fn()
-    ;(daemon as any).cpClient = { emitEventSession, emitUsageReport: vi.fn(), stop: vi.fn() }
+    const emitUsageReport = vi.fn()
+    ;(daemon as any).cpClient = { emitEventSession, emitUsageReport, stop: vi.fn() }
 
     const mk = (ts: string, text: string) => ({
       msgId: `slack:C1:${ts}`,
@@ -370,6 +381,11 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     })
 
     await (daemon as any).dispatch('bot-a', mk('100.1', 'first'))
+    // The configured model is deliberately rejected by the runtime selector on
+    // the warm turn. The end snapshot/report must clear to observed unknown,
+    // never fabricate this configured value or retain the prior named model.
+    ;(daemon as any).agents.get('bot-a').runtimeOverrides = { model: 'configured-but-rejected' }
+    fakeHost.modelOptions.mockReturnValue({ current: 'default', models: ['default'] })
     // Second (warm) turn on the SAME session re-emits a start snapshot too: the
     // CP-stored state is the only active-turn signal a console watching a platform
     // session has, and the end snapshot fires only after the row resets to idle —
@@ -401,8 +417,8 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       // guessing from the legacy-compatible session key.
       sourceBindingKind: 'local',
       // Execution-config snapshot: the agent's runtime + schema-defaulted
-      // permission/output modes; no explicit model/effort/fast configured ⇒
-      // those fields are omitted (runtime default), never fabricated.
+      // permission/output modes. The actual runtime-selected model is not known
+      // until the host is ready, so the start snapshot leaves it absent.
       runtime: 'claude',
       permissionMode: 'default',
       outputMode: 'medium'
@@ -414,8 +430,19 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     expect(typeof start.lastActivityAt).toBe('string')
     expect(typeof start.ts).toBe('string')
     expect(start.launchId).toBeUndefined() // Slack/Discord path — no CP launch fence
+    const firstFinal = emitEventSession.mock.calls[1]![0]
+    expect(firstFinal).toMatchObject({
+      sessionId: 'acp-sess-1',
+      phase: 'end',
+      status: 'idle',
+      title: 'first',
+      model: 'claude-sonnet-4-5',
+      observedModel: 'claude-sonnet-4-5'
+    })
     const final = emitEventSession.mock.calls[3]![0]
-    expect(final).toMatchObject({ sessionId: 'acp-sess-1', phase: 'end', status: 'idle', title: 'first' })
+    expect(final).toMatchObject({ sessionId: 'acp-sess-1', phase: 'end', status: 'idle', observedModel: null })
+    expect(final.model).toBeUndefined()
+    expect(emitUsageReport.mock.calls.map(([report]) => report.observedModel)).toEqual(['claude-sonnet-4-5', null])
     await daemon.stop()
   }, 15_000)
 

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -1276,6 +1276,7 @@ describe('event/session sessionKey (session-metadata sync)', () => {
         channelName: 'deploys',
         triggeredByName: 'Dana Reyes',
         threadUrl: 'https://slack.example/archives/C123/pT9',
+        observedModel: null,
         ts: '2026-07-05T00:00:00.000Z'
       })
     )
@@ -1288,6 +1289,7 @@ describe('event/session sessionKey (session-metadata sync)', () => {
     expect(r.frame.payload.thread).toBe('T9')
     expect(r.frame.payload.title).toBe('Roll out api@1.4.2')
     expect(r.frame.payload.status).toBe('prompting')
+    expect(r.frame.payload.observedModel).toBeNull()
     expect(r.frame.payload.lastActivityAt).toBe('2026-07-05T00:00:01.000Z')
     expect(r.frame.payload.triggeredBy).toBe('U-DANA')
     expect(r.frame.payload.channelName).toBe('deploys')

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -125,6 +125,10 @@ export const EventSession = z.object({
   // NOT echoed here — the CP stamps it from the authenticated WS connection.
   runtime: z.string().optional(),
   model: z.string().optional(),
+  // Runtime observation for this milestone. `null` means the runtime exposed
+  // only an opaque/default model; absent is a legacy/config-only snapshot. New
+  // readers prioritize this over `model`, while old readers safely ignore it.
+  observedModel: z.string().nullable().optional(),
   effort: z.string().optional(), // reasoning effort level (runtime-owned vocabulary)
   fastMode: z.boolean().optional(),
   // Effective session permission preset. Usually the runtime-owned mode; Codex Auto
@@ -199,6 +203,9 @@ export const UsageReport = z.object({
   agentId: z.string().uuid(),
   platform: z.string().optional(), // denormalized sessionKey echo for dashboard filters
   channel: z.string().optional(),
+  // The model observed for the usage delta ending at this cumulative snapshot.
+  // `null` is an explicit runtime-owned default/unknown; absent is an old daemon.
+  observedModel: z.string().nullable().optional(),
   lastActivityAt: z.string(), // ISO ts of the session's last activity
   usage: SessionUsage
 })

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react'
 import useSWR from 'swr'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { fetchUsage, fmtCost, fmtCountCompact as fmtCompact, type UsageRange } from '@/lib/api'
-import { agentLabel, runtimeLabel } from '@/lib/data'
+import { agentLabel, modelLabel, runtimeLabel } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
-import { AgentIconView, Spinner } from '@/components/marks'
+import { AgentIconView, ModelMark, Spinner } from '@/components/marks'
 import { useOrgs } from '@/lib/org-context'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { consoleKeys } from '@/lib/swr-keys'
@@ -30,14 +30,14 @@ const MOBILE_RANGES: { key: UsageRange; label: string }[] = [
 const GRID = 'grid-cols-[2fr_1fr_1fr_1fr_1.4fr]'
 const USAGE_REFRESH_MS = 30_000
 
-// How the by-agent table is rolled up. `agent` is the raw per-agent breakdown
-// (rows tap through to the agent); `runtime` sums agents sharing a runtime —
-// grouped rows are inert. Both roll up the same per-agent aggregate client-side,
-// so adding a dimension is just another case here.
-type GroupBy = 'agent' | 'runtime'
+// How the usage table is broken down. Runtime is derived from the per-agent
+// aggregate; model comes from the server's per-session execution snapshots so
+// changing an Agent's current default cannot rewrite historical usage.
+type GroupBy = 'agent' | 'runtime' | 'model'
 const GROUPS: { key: GroupBy; label: string }[] = [
   { key: 'agent', label: 'By agent' },
-  { key: 'runtime', label: 'By runtime' }
+  { key: 'runtime', label: 'By runtime' },
+  { key: 'model', label: 'By model' }
 ]
 
 // Buckets are aligned to the viewer's local day/hour (the CP flooring uses the
@@ -106,28 +106,42 @@ export default function UsageView() {
     }
   })
 
-  // Roll up to the selected grouping. `agent` is the raw list; `runtime` sums agents
-  // sharing a runtime and drops the per-agent icon/nav (`navId` absent) so grouped
-  // rows are inert and show the runtime glyph.
+  // Roll up to the selected grouping. Grouped rows omit `navId`, so only raw
+  // Agent rows navigate. Model rows arrive pre-aggregated from session metadata.
   type Entry = {
     key: string
+    kind: GroupBy
     navId?: string
     name: string
     icon?: (typeof enriched)[number]['icon']
     runtime: string
+    model: string
     totalTokens: number
     sessions: number
     costAmount: number
   }
   let entries: Entry[]
-  if (groupBy === 'runtime') {
+  if (groupBy === 'model') {
+    entries = (data?.models ?? []).map((m) => ({
+      key: `model:${m.model ?? ''}`,
+      kind: 'model',
+      name: modelLabel(m.model ?? ''),
+      runtime: '',
+      model: m.model ?? '',
+      totalTokens: m.totalTokens,
+      sessions: m.sessions,
+      costAmount: m.costAmount
+    }))
+  } else if (groupBy === 'runtime') {
     const byRuntime = new Map<string, Entry>()
     for (const e of enriched) {
       const rt = e.runtime || 'unknown'
       const g = byRuntime.get(rt) ?? {
         key: `runtime:${rt}`,
+        kind: 'runtime',
         name: runtimeLabel(rt),
         runtime: rt,
+        model: '',
         totalTokens: 0,
         sessions: 0,
         costAmount: 0
@@ -139,7 +153,7 @@ export default function UsageView() {
     }
     entries = [...byRuntime.values()].sort((a, b) => b.totalTokens - a.totalTokens)
   } else {
-    entries = enriched.map((e) => ({ ...e, key: e.agentId, navId: e.agentId }))
+    entries = enriched.map((e) => ({ ...e, key: e.agentId, kind: 'agent', navId: e.agentId, model: '' }))
   }
 
   // Two bar geometries from one map: `pct` is the desktop share (percent of the
@@ -148,10 +162,12 @@ export default function UsageView() {
   const maxTok = Math.max(...entries.map((e) => e.totalTokens), 1)
   const rows = entries.map((e) => ({
     key: e.key,
+    kind: e.kind,
     navId: e.navId,
     name: e.name,
     icon: e.icon,
     runtime: e.runtime,
+    model: e.model,
     sessions: e.sessions.toLocaleString('en-US'),
     tokens: fmtCompact(e.totalTokens),
     spend: fmtCost(e.costAmount, currency),
@@ -316,12 +332,12 @@ export default function UsageView() {
           )
         })()}
 
-      {/* By-agent card. `card` supplies the desktop chrome; the mobile design is
+      {/* Usage-breakdown card. `card` supplies the desktop chrome; the mobile design is
           the same surface with a 12px radius, side margins and corner clipping
           (the utilities out-layer the `.card:has(.row)` overflow-x hack). */}
       <div className="card max-desktop:mx-4 max-desktop:overflow-hidden max-desktop:rounded-lg">
         {/* Group-by toolbar (both form factors): switch the rollup dimension. */}
-        <div className="flex items-center justify-between gap-3 border-b border-(--border-subtle) px-4 py-3 desktop:px-[18px] desktop:py-[10px]">
+        <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3 desktop:px-[18px] desktop:py-[10px]">
           <div className="pillbar">
             {GROUPS.map((g) => (
               <button key={g.key} className={groupBy === g.key ? 'pill on' : 'pill'} onClick={() => setGroupBy(g.key)}>
@@ -329,14 +345,11 @@ export default function UsageView() {
               </button>
             ))}
           </div>
-          <span className="font-mono text-[11px] font-normal leading-normal text-(--text-tertiary) desktop:hidden">
-            tokens share
-          </span>
         </div>
 
         {/* Desktop table header */}
         <div className={`row h hidden desktop:grid ${GRID}`}>
-          <span>{groupBy === 'runtime' ? 'Runtime' : 'Agent'}</span>
+          <span>{groupBy === 'agent' ? 'Agent' : groupBy === 'runtime' ? 'Runtime' : 'Model'}</span>
           <span className="text-right">Sessions</span>
           <span className="text-right">Tokens</span>
           <span className="text-right">Spend</span>
@@ -362,7 +375,7 @@ export default function UsageView() {
         )}
 
         {/* Mobile stacked rows: max-normalized bar. Per-agent rows tap through to
-            the agent detail; grouped (type) rows are inert (no navId). */}
+            the agent detail; grouped rows are inert (no navId). */}
         {data &&
           rows.map((r, i) => (
             <button
@@ -374,7 +387,11 @@ export default function UsageView() {
             >
               <span className="flex w-full items-center gap-[10px]">
                 <span className="flex h-6 w-6 flex-none items-center justify-center overflow-hidden rounded-sm">
-                  <AgentIconView icon={r.icon} runtime={r.runtime} size={24} />
+                  {r.kind === 'model' ? (
+                    <ModelMark model={r.model} fallbackRuntime={r.runtime} />
+                  ) : (
+                    <AgentIconView icon={r.icon} runtime={r.runtime} size={24} />
+                  )}
                 </span>
                 <span className="min-w-0 flex-1 truncate font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
                   {r.name}
@@ -401,7 +418,11 @@ export default function UsageView() {
             <div key={r.key} className={`row hidden desktop:grid ${GRID}`}>
               <div className="flex items-center gap-[10px]">
                 <span className="av h-7 w-7 rounded-[7px]">
-                  <AgentIconView icon={r.icon} runtime={r.runtime} size={28} />
+                  {r.kind === 'model' ? (
+                    <ModelMark model={r.model} fallbackRuntime={r.runtime} />
+                  ) : (
+                    <AgentIconView icon={r.icon} runtime={r.runtime} size={28} />
+                  )}
                 </span>
                 <span className="font-sans text-[13px] font-semibold leading-normal">{r.name}</span>
               </div>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2829,12 +2829,17 @@ export interface UsageAgentDto {
   costAmount: number
 }
 
+export interface UsageModelDto extends Omit<UsageAgentDto, 'agentId'> {
+  model: string | null
+}
+
 export interface UsageDto {
   range: UsageRange
   accessSyncDegraded?: boolean
   accessIssues?: SessionAccessIssue[]
   totals: { sessions: number; totalTokens: number; costAmount: number; costCurrency: string | null }
   agents: UsageAgentDto[]
+  models: UsageModelDto[]
   // Spend-over-time chart: cost bucketed by hour (d1) or day (longer ranges),
   // empty buckets filled to 0. `start` is a UTC-aligned ISO instant.
   series: { bucket: 'hour' | 'day'; points: { start: string; costAmount: number }[] }


### PR DESCRIPTION
## Summary

- add a server-backed `By model` breakdown to Analytics, exposed through REST/MCP and rendered responsively with provider marks
- persist the runtime-observed model with every cumulative usage report, then attribute token and cost deltas to the model that produced them
- preserve mid-session model switches and explicit runtime-default/unknown observations instead of rewriting history to the session's latest model
- migrate existing usage into an honest unknown-model baseline so future model deltas remain accurate without inventing historical attribution

## Validation

- Prisma schema validation and all 80 migrations on PostgreSQL
- Control Plane integration: 25 passed; event-session handler: 14 passed
- protocol codec: 74 passed; daemon model/default regression: 1 passed
- protocol, Control Plane, daemon, and web typechecks
- full pre-push ESLint and focused Prettier checks
- desktop and 390 px mobile Analytics visual QA

Created by Codex . GPT-5.6
