### PR TITLE
fix(collab): raise the hop cap to 20, let a report-back be seen, and make needsReply a rule

### DIFF
--- a/docs/designs/agent-collaboration-implementation.md
+++ b/docs/designs/agent-collaboration-implementation.md
@@ -745,7 +745,7 @@ For orchestration:
 
 This section lists collaboration-side mechanisms only. See [`loop-breaker-design.md`](loop-breaker-design.md) for unified platform feedback loops, durable latches, restart/replay, and recovery permissions.
 
-- **hopCount:** Increment every agent-to-agent delivery and reject above a threshold such as eight, preventing an A <-> B wake loop.
+- **hopCount:** Increment every agent-to-agent delivery and reject above the shared `MAX_AGENT_CALL_HOPS` threshold, preventing an A <-> B wake loop.
 - **Orchestration depth limit:** Bound nested orchestration when a worker acts as a main agent, preventing exponential fan-out.
 - **Self-delivery protection:** Reject `messageAgent(toAgentId == self)` to avoid self-wake loops.
 

--- a/docs/designs/agent-collaboration-implementation.md
+++ b/docs/designs/agent-collaboration-implementation.md
@@ -7,7 +7,8 @@
 > is implemented. Finalized AgentConnect-authored platform mentions are now routable
 > (through their own ladder, never through implicit routing), the visible in-thread
 > `sendMessage` forms are gone while `toAgent + channel` remains as a channel-root
-> send, and parent-session replies are session-only. Agent-to-agent activation is no
+> send, and a parent-session reply is injected into the parent session (never
+> published) while resuming it as an ordinary turn. Agent-to-agent activation is no
 > longer exclusively the internal `messageAgent` path — a verified explicit mention is a
 > second, equally hop-bounded path. Read that document for the verification, hop
 > transition, and activation rendezvous rules.
@@ -270,7 +271,8 @@ resetting chain depth.
   daemon automatically sets outbound `hopCount = current turn hopCount + 1`.
   It ignores any agent-supplied value.
 - Queue replay restores the persisted turn hop; compaction cannot reset it.
-- The daemon rejects delivery above a threshold such as eight hops.
+- The daemon rejects delivery above the shared `MAX_AGENT_CALL_HOPS` threshold
+  (currently 20).
 - **Test:** omitting hop arguments or explicitly passing `hopCount:0` cannot reset chain depth; the daemon uses turn-bound hop + 1.
 
 ### 2.5 Authorization: The Directional Call Policy, Org-Scoped
@@ -751,7 +753,7 @@ This section lists collaboration-side mechanisms only. See [`loop-breaker-design
 
 | Layer  | Current behavior                                                                                                                                                                                                        |
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Daemon | Atomic `sessionKey` admission serializes a conversation, caps its queue at 10, releases or fail-stops queued work on failure/cancel, enforces an eight-hop maximum, and rejects self-delivery.                          |
+| Daemon | Atomic `sessionKey` admission serializes a conversation, caps its queue at 10, releases or fail-stops queued work on failure/cancel, enforces the shared `MAX_AGENT_CALL_HOPS` maximum (20), and rejects self-delivery. |
 | Tool   | Peer delivery reports typed outcomes including offline, queue-full, policy denial, and hop-limit failures.                                                                                                              |
 | Config | `maxAgents` bounds placed agent capacity and `maxConcurrentSessions` is part of daemon config; neither supplies the missing collaboration-specific per-agent turn limit or orchestration fan-out width described above. |
 | Tests  | Cover concurrent cold-session admission, queue ordering and failure, queue-full reporting, hop-limit rejection, and self-delivery rejection.                                                                            |

--- a/docs/designs/loop-breaker-design.md
+++ b/docs/designs/loop-breaker-design.md
@@ -497,7 +497,7 @@ Opening a conversation does not automatically block a new `source:"agent"`
 delivery; agent calls rely on the self/hop guard. Unifying them under one causal
 root is an L3 goal and must not be described as a current capability.
 
-The current `MAX_AGENT_CALL_HOPS = 8`.
+The current `MAX_AGENT_CALL_HOPS = 20`.
 
 ### 7.2 Trusted Turn Context
 

--- a/docs/designs/send-message-routing-rework.md
+++ b/docs/designs/send-message-routing-rework.md
@@ -34,9 +34,9 @@ Two implementation notes, recorded where they will be looked for:
    routing ladder's decision, and whether to answer is the reader's.
 3. Keep `sendMessage` for postless agent calls, direct messages, channel-root
    posts, and parent-session replies.
-4. Make a parent-session reply session-only by default: its injected input and
-   ordinary resumed output do not go to IM, while an explicit visible
-   `sendMessage` remains an intentional, separately authorized outbound action.
+4. Make a parent-session reply an injection: the report itself is never published
+   to IM, while the parent it resumes runs an ordinary turn and may answer in its
+   own conversation.
 5. Preserve directional agent-call policy, loop protection, transcript
    consistency, and exactly-once activation.
 
@@ -430,34 +430,41 @@ The injected message is:
 { type: system, from: <child-agent> }: <message>
 ```
 
-The target parent session is resumed with `headless: true`. For this delivery
-kind, headless controls the automatic reply sink and delivery chrome:
+What must stay invisible is the REPORT, not the parent's turn. The child's body
+is injected into the parent session — recorded in its transcript, never
+published to a platform by any component, on either the local or the
+cross-daemon path. That is structural, not a flag: nothing in the daemon
+publishes inbound delivery content.
+
+The parent session is therefore resumed as an ORDINARY turn:
 
 - the parent agent processes the new input;
 - inbound content and resulting agent work are recorded in the session
   transcript;
-- no ordinary IM body, typing indicator, status message, status bar, footer,
-  permission card, or completion notification is emitted for that turn;
+- the turn keeps its ordinary reply sink and delivery chrome, so an answer the
+  parent writes lands in the parent's own conversation — where the humans who
+  delegated the work are waiting;
 - correlation, hop count, orchestration report recording, memory behavior, and
   the per-session serial gate remain unchanged.
 
-An explicit visible `sendMessage` from the resumed parent remains allowed and
-uses its normal authorization and delivery semantics. It is a new intentional
-outbound action, not an IM copy of the session reply. Postless `toAgent` and
-`sessionId` targets also remain available. Consequently, `headless: true` is not
-a turn-wide egress prohibition and the system promises zero IM gateway calls
-only when the agent does not explicitly choose a visible target.
+An earlier revision resumed the parent with `headless: true` to prevent a second
+copy of an answer the child had already delivered. That trade only holds when
+the child answered in the SAME conversation the parent would speak in. When the
+child answered somewhere else (its own channel-root thread) or nowhere at all (a
+postless child), muting the parent meant the delegated outcome reached nobody:
+the parent processed the report and answered into a dropped connection. The
+duplicate-copy concern is editorial and belongs to the standing "do not restate
+what the thread already shows" guidance, not to a transport-level mute.
 
-The current implementation already injects the child body rather than posting
-it directly, but the resumed parent turn still owns an ordinary IM reply
-connection. The new design removes that connection for this turn; it does not
-add a separate `sendMessage` egress gate.
+Postless `toAgent` deliveries keep their own headless stamp (§3.1) — a postless
+child has no visible conversation of its own by construction.
 
-Cross-daemon session replies carry a required-headless delivery flag. A relay
-must not forward such a reply to a daemon that has not advertised support for
-session-only automatic output; it returns an unsupported/retryable verdict
-instead of silently degrading the ordinary parent response to visible IM
-output.
+Cross-daemon session replies behave identically: the target dispatches them into
+the named parent session and resumes it as an ordinary turn. The relay still
+refuses to forward the kind to a daemon that has not advertised
+`headless-agent-delivery-v1`, because such a daemon predates the delivery kind
+entirely and would key the reply by coordinates instead of session id; that
+refusal is a compatibility fence, no longer a silence requirement.
 
 ## 8. Protocol and data changes
 
@@ -480,17 +487,18 @@ that frame value again.
 
 ### 8.3 Cross-daemon agent message
 
-Add a delivery kind or required-headless flag to `rd/agentmsg` and
-`rd/agentmsg/fwd`. The target stamps the resulting normalized message
-`headless: true` for postless calls and session replies. For session replies the
-flag suppresses automatic platform output but does not disable explicit visible
-tool sends.
+Add a delivery kind to `rd/agentmsg` and `rd/agentmsg/fwd`. The target stamps the
+resulting normalized message `headless: true` for postless calls. A
+`session-reply` is dispatched into the session named by `lineageReplyTo` and
+resumes it as an ordinary turn (§7); the injected report is never published
+regardless of the stamp.
 
 ### 8.4 Relay capability negotiation
 
-Add relay-daemon hello capabilities, including
-`headless-agent-delivery-v1`. Required-headless deliveries fail rather than
-becoming visible when the target daemon is too old.
+Add relay-daemon hello capabilities, including `headless-agent-delivery-v1`. A
+`session-reply` fails rather than being forwarded to a target daemon too old to
+advertise it — that daemon predates the delivery kind and would key the reply by
+coordinates instead of dispatching it into the named parent session.
 
 ### 8.5 Agent discovery
 
@@ -561,7 +569,7 @@ The main implementation surfaces are:
   joins to every relay, and return the full set on a relay affinity miss.
 - `packages/daemon/src/daemon.ts`: replace direct and relayed managed-agent
   suppression with verified routing, trusted hop propagation, durable activation
-  rendezvous records, and headless `replyToSession` dispatch.
+  rendezvous records, and parent-session `replyToSession` dispatch.
 - `packages/daemon/src/state-store.ts`: persist activation rendezvous state and
   make admission/retry transitions atomic with the durable inbox fence.
 - `packages/daemon/src/router/routing-table.ts`: admit verified agent traffic to
@@ -609,14 +617,16 @@ At minimum, cover:
 12. Splitting never cuts a dedicated mention or separates a shared bot mention
     from its agent slug; concatenating the physical sections preserves the exact
     logical response.
-13. Local and cross-daemon parent-session replies update the target session and
-    make no implicit IM gateway calls. An explicit visible `sendMessage` remains
-    allowed and is tested as a separate intentional action.
-14. A required-headless cross-daemon reply refuses an old target daemon instead
-    of leaking the ordinary parent response to IM.
-15. Direct and relay mention routing both admit source depth `7` as target depth
-    `8`, reject source depth `8` because the next hop is `9`, and reject invalid
-    or missing depth instead of resetting it to zero.
+13. Local and cross-daemon parent-session replies update the target session
+    without publishing the injected report, and resume the parent as an ordinary
+    turn whose own answer reaches the parent's conversation.
+14. A cross-daemon `session-reply` refuses a target daemon that never advertised
+    `headless-agent-delivery-v1` instead of letting it key the reply by
+    coordinates.
+15. Direct and relay mention routing both admit source depth `MAX_AGENT_CALL_HOPS
+    - 1`as target depth`MAX_AGENT_CALL_HOPS`, reject source depth
+`MAX_AGENT_CALL_HOPS` because the next hop overflows, and reject invalid or
+      missing depth instead of resetting it to zero.
 16. An A -> B -> A ordinary-mention chain installs and re-stamps monotonically
     increasing trusted depths, stops at the shared cap, and preserves its depth
     across queue replay/restart.
@@ -634,5 +644,5 @@ At minimum, cover:
    current-design documents to make this proposal authoritative.
 
 During a mixed-version rollout, older components may continue suppressing an
-agent-authored platform event, but no component may downgrade a required-headless
-session reply into an ordinary visible response.
+agent-authored platform event, and no component may deliver a `session-reply` to
+a daemon that cannot dispatch it into the named parent session.

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -226,23 +226,26 @@ transcript display. The first real reply in that thread receives the root as pre
 context before the new message. Session initialization itself produces no agent output,
 tool calls, memory recall or capture, turn evaluation, or token usage.
 
-## Parent-session replies are session-only
+## A parent-session reply is injected, and the parent answers normally
 
 `sendMessage({"sessionId":"<parent>", …})` injects an answer into the session that woke
-the caller. That delivery is **session-only by default**: the parent agent processes the
-input and its work is recorded in the session transcript, but the resumed turn emits no
-ordinary IM body, typing indicator, status message, status bar, footer, permission card,
-or completion notification. Relaying an answer upward is a hand-off, not a broadcast —
-publishing it into the parent's channel would usually duplicate what the child already
-delivered.
+the caller. What is invisible is the **report itself**: no component publishes the
+injected body to a platform, so relaying an answer upward is a hand-off rather than a
+broadcast.
 
-The parent may still choose to speak: an explicit visible `sendMessage` from the resumed
-turn is a new, separately authorized outbound action and behaves normally. So the promise
-is "no automatic IM output", not "no IM output at all".
+The parent session is then resumed as an **ordinary turn** — it keeps its reply sink and
+chrome, so what the parent decides to say lands in the parent's own conversation, where
+the humans who delegated the work are waiting. Delegated work that reports back is
+therefore visible to them, which is the point of reporting back at all.
 
-A reply whose parent lives on another daemon carries the same requirement. If that daemon
-is too old to run the turn silently, the reply **fails** rather than being downgraded —
-the alternative would leak the parent's entire ordinary response into its channel.
+The parent should not restate what its conversation already shows; that is the standing
+"be quiet about mechanics" rule, not a transport guarantee. An earlier revision muted the
+resumed turn to enforce it, and that silenced every report whose child had answered
+somewhere else (its own channel-root thread) or nowhere at all (a postless child).
+
+A reply whose parent lives on another daemon behaves identically. If that daemon is too
+old to understand the delivery kind, the reply **fails** rather than being dispatched into
+the wrong session.
 
 ## Per-channel trigger
 

--- a/evals/test/routing-acceptance.test.ts
+++ b/evals/test/routing-acceptance.test.ts
@@ -109,7 +109,7 @@ describe('case 1 — sendMessage {toAgent, channel}: one visible root post, one 
   }, 120_000)
 })
 
-describe('case 1b — sendMessage {sessionId: parent}: session-only parent resume', () => {
+describe('case 1b — sendMessage {sessionId: parent}: the report is injected, the parent answers', () => {
   function case1bScripts(resume: (ctx: RoutingScriptContext) => Promise<void> | void) {
     return {
       agent1: async (ctx: RoutingScriptContext) => {
@@ -161,13 +161,12 @@ describe('case 1b — sendMessage {sessionId: parent}: session-only parent resum
     return agent1Effects.filter((effect) => effect.sequence > boundary)
   }
 
-  // #503 §7: the parent session is resumed with headless: true — the injected
-  // input and the resumed turn's ORDINARY output stay in the session; no IM
-  // body, typing indicator, status chrome, footer, or completion notification
-  // is emitted for that turn. Flipped green when the rework landed (PR #503
-  // merged): the full accounting below (every effect attributable to the
-  // resumed turn, delivered or attempted) must stay empty.
-  it('parent resume produces ZERO new IM outbound while the parent still processes the reply (#503 §7)', async () => {
+  // §7: what stays invisible is the REPORT — no component publishes the injected
+  // body — while the resumed parent runs an ORDINARY turn and may answer in its own
+  // conversation. The earlier revision muted that turn, which silenced every
+  // report-back whose child had answered elsewhere (its own channel-root thread) or
+  // nowhere at all, leaving the humans who delegated the work with nothing.
+  it('the child’s report is never published, and the resumed parent answers in its own thread (§7)', async () => {
     fixture = await RoutingFixture.start({
       agents: ['agent1', 'agent2'],
       scripts: case1bScripts((ctx) => {
@@ -179,23 +178,28 @@ describe('case 1b — sendMessage {sessionId: parent}: session-only parent resum
     })
     await fixture.settle(trigger.handles)
 
-    // The parent DID process the child's reply (this half holds today too).
+    // The parent processed the child's reply.
     expect(fixture.activations('agent1')).toBe(2)
     const resumeInput = fixture.turnInputs('agent1')[1] ?? ''
     expect(resumeInput).toContain('RESULT R-42')
 
-    // INVARIANT UNDER #503 §7 — FULL accounting, not a body-string probe:
-    // the COMPLETE set of world effects attributable to the resumed turn is
-    // empty. Any body text, typing indicator, status message, footer, or
-    // other chrome — delivered OR merely attempted — fails this.
-    const resumeEffects = parentResumeEffects()
-    expect(resumeEffects.map((effect) => ({ kind: effect.kind, status: effect.status, text: effect.text }))).toEqual([])
+    // HALF ONE — the report itself never became a platform message. Not a body-string
+    // probe of one integration: NOTHING anyone attempted, delivered or rejected, carries
+    // the injected text. `replyToSession` makes no gateway call at all, so this is
+    // structural rather than a flag, and it is the property the design actually promises.
+    const published = fixture.world.allEffects().filter((effect) => /RESULT R-42/.test(effect.text ?? ''))
+    expect(published.map((effect) => ({ kind: effect.kind, status: effect.status, text: effect.text }))).toEqual([])
+
+    // HALF TWO — the resumed turn is ORDINARY: its own answer reaches the parent's
+    // conversation, where the humans who delegated the work are waiting.
+    const resumeReplies = parentResumeEffects().filter((effect) => effect.kind === 'reply')
+    expect(resumeReplies.map((effect) => effect.status)).toContain('delivered')
+    expect(resumeReplies.some((effect) => /thanks, result noted/.test(effect.text ?? ''))).toBe(true)
   }, 120_000)
 
-  // #503 §7: "An explicit visible sendMessage from the resumed parent remains
-  // allowed and uses its normal authorization and delivery semantics" —
-  // headless is not a turn-wide egress prohibition. This already holds today
-  // and must keep holding after the flip.
+  // §7: an explicit visible `sendMessage` from the resumed parent is an intentional
+  // outbound action with its normal authorization and delivery semantics — it was never
+  // gated by how the resumed turn's own reply sink was configured.
   it('an EXPLICIT visible sendMessage from the resumed parent is delivered', async () => {
     fixture = await RoutingFixture.start({
       agents: ['agent1', 'agent2'],

--- a/evals/test/routing-acceptance.test.ts
+++ b/evals/test/routing-acceptance.test.ts
@@ -19,8 +19,9 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { RoutingFixture, type RoutingScriptContext } from './routing-fixture.js'
 
-/** Mirrors the daemon's MAX_AGENT_CALL_HOPS (packages/daemon/src/daemon.ts). */
-const MAX_AGENT_CALL_HOPS = 8
+// The one shared cap every enforcement point reads — imported rather than mirrored so
+// this suite cannot pin a stale number after the budget is retuned.
+import { MAX_AGENT_CALL_HOPS } from '../../packages/protocol/src/consts.js'
 
 let fixture: RoutingFixture | undefined
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8813,7 +8813,8 @@ export class Daemon {
    * {@link MessageAgentResult}. The `claimedFromAgentId` is our trusted caller — the
    * relay re-validates it against our authenticated daemonId (a forged claim is
    * rejected there). `sourceHopCount` is the trusted source turn's depth; the relay
-   * increments it (+1, cap 8). The body never touches the CP — only the relay.
+   * increments it (+1, capped at MAX_AGENT_CALL_HOPS). The body never touches the CP —
+   * only the relay.
    */
   private async routeAgentMsgCrossDaemon(
     req: MessageAgentReq,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7699,6 +7699,11 @@ export class Daemon {
         origin.transportScope
       )
       if (origin.transportScope && !replyIntegrationId) return record(nak('not_found'))
+      // §7: a lineage reply IS the cross-daemon parent-session reply, so it behaves exactly
+      // like `replyToSession`'s local branch — no `headless` stamp. The injected report is
+      // transcript-only (nothing here publishes it) and the resumed parent runs an ordinary
+      // turn that can answer in its own thread. A parent living on another daemon must not
+      // differ from a local one, so neither branch stamps it.
       const reply: NormalizedMessage = {
         msgId: `agentcall:${origin.channel}:${msg.deliveryId}`,
         traceId: msg.deliveryId,
@@ -7713,14 +7718,12 @@ export class Daemon {
         text: msg.text,
         mentionedBots:
           replyIntegrationId && this.botUserIds[replyIntegrationId] ? [this.botUserIds[replyIntegrationId]!] : [],
-        isDm: false,
-        // send-message-routing-rework.md §7/§8.3: a lineage reply IS the cross-daemon
-        // parent-session reply, so it carries the same session-only contract as the local
-        // branch of `replyToSession`. This branch returns before the wake path below, so
-        // the stamp has to be here too — without it a parent that happens to live on
-        // another daemon would republish its whole ordinary response into its channel,
-        // which is the downgrade §8.4 exists to make impossible.
-        ...(msg.deliveryKind === 'session-reply' ? { headless: true } : {})
+        isDm: false
+        // §7: a lineage reply IS the cross-daemon parent-session reply, so it behaves like
+        // the local branch of `replyToSession` — the injected report is transcript-only
+        // (nothing here publishes it), and the resumed parent runs an ORDINARY turn that
+        // can answer in its own thread. A parent living on another daemon must not differ
+        // from a local one, so neither branch stamps `headless` any more.
       }
       void this.dispatch(msg.toAgentId, reply, replyIntegrationId, undefined, callMeta).catch((err) =>
         this.log.error(`relay lineage-reply dispatch failed for agent "${msg.toAgentId}": ${formatErr(err)}`)
@@ -7784,6 +7787,9 @@ export class Daemon {
         rowUpdatedAtAtAdmission: this.store.getSession(childSessionId)?.updatedAt ?? null
       })
     }
+    // No `headless` stamp for a `session-reply` reaching this path either (§7): the report it
+    // carries is transcript-only whatever the stamp says, and muting the resumed parent's own
+    // answer only hid delegated results from the humans in its thread.
     const normalized: NormalizedMessage = {
       msgId: childMsgId,
       traceId: msg.deliveryId,
@@ -7802,12 +7808,7 @@ export class Daemon {
       // A `toAgent`+`channel` wake was preceded by a visible post the SOURCE daemon made; carry
       // its real ts so this turn's transcript row collapses onto the post we fetch from the
       // shared thread (`conversations.replies`) instead of duplicating at the delivery id.
-      ...(msg.transcriptTs !== undefined ? { transcriptTs: msg.transcriptTs } : {}),
-      // §8.3: a `session-reply` is required-headless on the TARGET too — same contract as
-      // the same-daemon path in `replyToSession`, so a parent that happens to live on
-      // another daemon behaves identically. The relay has already refused to forward this
-      // kind to a daemon that cannot honor it (§8.4), so reaching here means we can.
-      ...(msg.deliveryKind === 'session-reply' ? { headless: true } : {})
+      ...(msg.transcriptTs !== undefined ? { transcriptTs: msg.transcriptTs } : {})
     }
 
     // send-message-routing-rework.md §3.2: the target daemon owns the rendezvous for a
@@ -8376,6 +8377,19 @@ export class Daemon {
         return { delivered: false, targetSession: local.key, reason: 'not_found' }
       }
       const resolved = this.resolveCpAgent(originOwner, originPlatform)
+      // §7: what stays invisible is the REPORT ITSELF — the child's body is injected into the
+      // parent session's transcript and is never published to the platform (this function
+      // makes no gateway call at all). That is structural, not a flag: nothing in the daemon
+      // publishes inbound delivery content.
+      //
+      // So the message below carries NO `headless` stamp and the resumed parent runs an
+      // ORDINARY turn, keeping its reply connection. Stamping it used to silence that turn,
+      // which only ever cost visibility: the humans watching the parent's own thread saw
+      // nothing at all — not even that the delegated work had come back — whenever the child
+      // had answered somewhere else (its own channel-root thread) or nowhere (a postless
+      // child). The original worry, a second copy of an answer the child already delivered
+      // into the SAME conversation, is editorial: the standing "don't restate" guidance owns
+      // it, and it is not worth muting every report-back to prevent.
       const normalized: NormalizedMessage = {
         msgId: `agentcall:${local.channel}:${deliveryId}`,
         traceId: deliveryId,
@@ -8398,22 +8412,7 @@ export class Daemon {
           : resolved?.botUserId
             ? [resolved.botUserId]
             : [],
-        isDm: false,
-        // send-message-routing-rework.md §7 — a parent-session reply is SESSION-ONLY by
-        // default. The parent still processes the input and records the work, but this
-        // turn emits no ordinary IM body, typing indicator, status message/bar, footer,
-        // permission card, or completion notification.
-        //
-        // Previously the resumed parent owned an ordinary IM reply connection, so relaying
-        // an answer upward also republished it into the parent's channel — a second copy
-        // of something the child had usually already delivered. Removing the connection is
-        // what makes the reply an injection rather than a broadcast.
-        //
-        // NOT a turn-wide egress prohibition: an explicit visible `sendMessage` from the
-        // resumed parent resolves its gateway from the daemon's integrations, not from
-        // this connection, so it remains available as a separately authorized, intentional
-        // outbound action (§7).
-        headless: true
+        isDm: false
       }
       void this.dispatch(originOwner, normalized, integrationId, undefined, callMeta).catch((err) =>
         this.log.error(`replyToSession dispatch failed for session "${req.sessionId}": ${formatErr(err)}`)
@@ -8456,11 +8455,10 @@ export class Daemon {
         // coordinate would otherwise be substituted and the reply would mint a
         // different synthetic session).
         lineageReplyTo: req.sessionId,
-        // send-message-routing-rework.md §7/§8.4: mark the delivery REQUIRED-HEADLESS so a
-        // relay refuses to hand it to a daemon too old to run the parent turn silently.
-        // Failing the reply is correct here and silently degrading is not: the alternative
-        // publishes the parent's whole ordinary response into its channel, which is
-        // exactly what §7 removes.
+        // send-message-routing-rework.md §7/§8.4: mark the delivery kind so the target
+        // dispatches into `lineageReplyTo`, and so a relay refuses to hand it to a daemon
+        // too old to understand it. Failing the reply is correct there: such a daemon would
+        // key it by coordinates and mint a different session instead.
         deliveryKind: 'session-reply'
       }
     )
@@ -8834,10 +8832,12 @@ export class Daemon {
       /** §5.3 lineage reply: the EXISTING target session (acpSessionId) this delivery
        *  replies into — the target dispatches into it instead of coordinate keying. */
       lineageReplyTo?: string
-      /** send-message-routing-rework.md §8.3. `session-reply` is REQUIRED-HEADLESS: the
-       *  relay refuses to forward it to a daemon that has not advertised
-       *  `headless-agent-delivery-v1` rather than letting the resumed parent's ordinary
-       *  response leak to IM. Absent ⇒ `wake`, an ordinary postless call. */
+      /** send-message-routing-rework.md §8.3. Marks the delivery as a parent-session reply
+       *  so the target dispatches it into `lineageReplyTo` instead of coordinate keying.
+       *  The relay still refuses to forward this kind to a daemon that has not advertised
+       *  `headless-agent-delivery-v1`; that gate is now a LEGACY fence — the resumed parent
+       *  runs an ordinary turn on every current daemon (§7). Absent ⇒ `wake`, an ordinary
+       *  postless call. */
       deliveryKind?: RdAgentMsgDeliveryKind
     }
   ): Promise<MessageAgentResult> {

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -191,7 +191,7 @@ export interface MessageAgentReq {
    * caller's channel, which is exactly the interruption the postless form exists to avoid.
    * The child keeps everything that makes it followable — origin lineage, hop count,
    * correlation, `needsReply`, and `viewSessionStatus` — and reports back through the
-   * (equally session-only) parent-session reply.
+   * parent-session reply, whose injected body is likewise never published.
    *
    * Set only by `sendMessage`'s agent target. Other internal callers (orchestration, the
    * intro fan-out) keep their existing visibility, which they express themselves.
@@ -271,10 +271,10 @@ export interface ReplyToSessionReq {
 
 /** The result of a SessionTarget reply. `delivered:false` carries a typed reason
  *  ('not_authorized' when the sessionId isn't the caller's origin; 'unsupported' when a
- *  cross-daemon reply reached a target too old to run the parent turn headlessly, which
- *  is REFUSED rather than downgraded to visible IM output — send-message-routing-rework.md
- *  §7/§8.4; the rest mirror the cross-daemon agent-msg verdicts for a reply that had to
- *  route over the relay). */
+ *  cross-daemon reply reached a target too old to advertise `headless-agent-delivery-v1`,
+ *  which is REFUSED rather than delivered — a legacy fence from when this delivery kind
+ *  muted the parent turn, send-message-routing-rework.md §7/§8.4; the rest mirror the
+ *  cross-daemon agent-msg verdicts for a reply that had to route over the relay). */
 export interface ReplyToSessionResult {
   delivered: boolean
   targetSession?: string

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -130,16 +130,21 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
       'to that agent with nothing posted anywhere; channel root ' +
       '(`{"toAgent":"<id>","channel":"<C>","message":"..."}`) also posts one visible message at the channel root, ' +
       '@-mentions the peer in it, and anchors the peer to that post. To reach an agent in the thread you are ' +
-      'ALREADY in, do not use this tool — @-mention it in your ordinary reply instead.',
+      'ALREADY in, do not use this tool — @-mention it in your ordinary reply instead. Either form takes ' +
+      '`needsReply` (see `toAgent`), and you need it whenever you expect an answer back: the peer answers in ITS ' +
+      'OWN conversation, so without `needsReply` nothing comes back to you.',
     ...obj(
       {
         toAgent: {
           description:
-            'The peer to wake. Either the bare AgentConnect agent id, or an object ' +
-            '`{"agentId":"<agent id>","needsReply":true}` when you need the peer to report back to you. Use ' +
-            '`needsReply` for delegated work you will wait on: the peer’s session is opened with a standing ' +
-            'instruction to reply into YOUR session when it finishes or fails, and you can poll it meanwhile with ' +
-            '`viewSessionStatus` on the returned `childSessionId`.',
+            'The peer to wake. Use the BARE agent id only for fire-and-forget work whose outcome you never need; ' +
+            'use `{"agentId":"<agent id>","needsReply":true}` whenever you expect anything back. Set `needsReply` ' +
+            'if your `message` asks a question or requests a result, if you were asked to relay the peer’s answer ' +
+            'to someone, or if you intend to act on the outcome — "reply to me", "tell me", "check X and report" ' +
+            'all qualify. A woken peer answers inside ITS OWN conversation, so without `needsReply` its answer ' +
+            'never reaches you or the humans waiting in yours, and you are not even told that it failed. With it, ' +
+            'the peer’s session carries a standing instruction to reply into YOUR session when it finishes or ' +
+            'fails, and you can poll it meanwhile with `viewSessionStatus` on the returned `childSessionId`.',
           oneOf: [
             {
               type: 'string',
@@ -163,8 +168,10 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
                   needsReply: {
                     type: 'boolean',
                     description:
-                      'When true, the woken session is told to report back into this session (done or failed) when ' +
-                      'it completes. Defaults to false — a plain fire-and-forget wake.'
+                      'Set true whenever you expect an answer, a result, or a completion signal: the woken session ' +
+                      'is told to report back into this session (done or failed) when it completes. Defaults to ' +
+                      'false, which is fire-and-forget — the peer’s answer stays in its own conversation and you ' +
+                      'learn nothing, not even that it failed.'
                   }
                 },
                 ['agentId']
@@ -280,8 +287,10 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
         '  • direct: `{"toAgent":"<agent id>","message":"..."}` — postless wake: nothing is posted anywhere.\n' +
         '  • channel root: `{"toAgent":"<agent id>","channel":"<channel id>","message":"..."}` — also posts one ' +
         'visible message at that channel’s ROOT, @-mentions the peer in it, and anchors the peer to that post.\n' +
-        '  Use `{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}` to have the peer report back ' +
-        'when it finishes or fails; pass the returned `childSessionId` to `viewSessionStatus` to check on it.\n' +
+        '  Use `{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}` WHENEVER you expect an answer ' +
+        'back — your message asks a question or requests a result, or someone asked you to relay the peer’s answer. ' +
+        'The peer replies in its own conversation, so without `needsReply` its answer never reaches you. Pass the ' +
+        'returned `childSessionId` to `viewSessionStatus` to check on it.\n' +
         '- toUser — reach human users (Slack only for now):\n' +
         '  • dm: `{"toUser":"<Slack user id>","message":"..."}` — direct message; do not set `channel`.\n' +
         '  • channel root: `{"toUser":["<user id 1>","<user id 2>"],"channel":"<channel id>","message":"..."}` — ' +

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -772,7 +772,11 @@ export class SessionManager {
         : `# Collaborating with other agents\n` +
           `- To reach a specific agent privately, call \`sendMessage\` with ` +
           `\`{"toAgent":"<agent id>","message":"..."}\` (dm form) — it wakes ONLY that agent, delivered directly to it ` +
-          `(nothing is posted to the channel). Add a \`channel\` ` +
+          `(nothing is posted to the channel). That bare form is FIRE-AND-FORGET: the peer answers inside its own ` +
+          `conversation and nothing comes back to you, not even a failure. Whenever you expect an answer — your ` +
+          `message asks a question or requests a result, or you were asked to relay that agent's answer to someone ` +
+          `— send \`{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}\` instead, which obliges ` +
+          `it to report into YOUR session when it finishes or fails. Add a \`channel\` ` +
           `(\`{"toAgent":"<agent id>","channel":"<channel id>","message":"..."}\`, channel-root form) ` +
           `to ALSO post a visible message there and thread that agent's reply under it; add ` +
           `\`"thread":"<thread id>"\` (in-thread form) to post into a specific thread instead. Use these when the ` +

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import { sessionKey } from '../src/store/local-store.js'
 
@@ -611,17 +612,18 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
     await daemon.stop()
   })
 
-  it('admits source depth 7 as 8, rejects 8, and rejects an unusable depth', async () => {
+  it('admits the last source depth under the cap, rejects the cap itself, and rejects an unusable depth', async () => {
     // §10 case 15 — the direct-daemon half of the boundary the relay test covers for the
     // relayed half. Both must agree, or a mention chain gets a different budget depending
-    // on which transport carried it.
+    // on which transport carried it. Expressed against MAX_AGENT_CALL_HOPS rather than a
+    // literal so retuning the budget cannot leave one transport pinned to the old number.
     const admitted = await boot([{ id: 'bot-a' }, { id: 'bot-b' }])
-    expect(route(admitted.daemon, agentMessage({}, { hopCount: 7 })).kind).toBe('dispatched')
-    expect(admitted.calls[0]!.callMeta).toMatchObject({ hopCount: 8 })
+    expect(route(admitted.daemon, agentMessage({}, { hopCount: MAX_AGENT_CALL_HOPS - 1 })).kind).toBe('dispatched')
+    expect(admitted.calls[0]!.callMeta).toMatchObject({ hopCount: MAX_AGENT_CALL_HOPS })
     await admitted.daemon.stop()
 
     const capped = await boot([{ id: 'bot-a' }, { id: 'bot-b' }])
-    expect(route(capped.daemon, agentMessage({}, { hopCount: 8 })).kind).toBe('rejected')
+    expect(route(capped.daemon, agentMessage({}, { hopCount: MAX_AGENT_CALL_HOPS })).kind).toBe('rejected')
     expect(capped.calls).toHaveLength(0)
     await capped.daemon.stop()
 
@@ -759,7 +761,9 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
       expect((daemon as any).handleRelayIm(imFrame({ trustedFromAgentId: 'bot-b' })).accepted).toBe(true)
       // Already-incremented depth past the cap, and a depth below 1 (which would mean the
       // relay never applied its transition).
-      expect((daemon as any).handleRelayIm(imFrame({ trustedDeliveryHopCount: 9 })).accepted).toBe(true)
+      expect(
+        (daemon as any).handleRelayIm(imFrame({ trustedDeliveryHopCount: MAX_AGENT_CALL_HOPS + 1 })).accepted
+      ).toBe(true)
       expect((daemon as any).handleRelayIm(imFrame({ trustedDeliveryHopCount: 0 })).accepted).toBe(true)
       expect(calls).toHaveLength(0)
       await daemon.stop()

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import { executeTool, type MessageAgentReq } from '../src/mcp/ops.js'
 import { sessionKey } from '../src/store/local-store.js'
@@ -647,11 +648,11 @@ describe('messageAgent: §6.7 daemon-managed auto-inheritance (hop/origin + repl
   it('hop cap is enforced across an inherited chain', async () => {
     const root = scaffold([{ id: 'main' }, { id: 'worker' }, { id: 'third' }])
     const { daemon, calls, call } = await bootWithDispatchSpy(root)
-    // inbound hop already at the cap (8) → next child would be 9 → rejected.
+    // inbound hop already AT the cap → the next child would exceed it → rejected.
     seedActiveTurn(
       daemon,
       { platform: 'slack', channel: 'C1', thread: '100.1', agentId: 'worker' },
-      { callFrom: 'main', hopCount: 8, deliveryId: 'd0' }
+      { callFrom: 'main', hopCount: MAX_AGENT_CALL_HOPS, deliveryId: 'd0' }
     )
     const res = await call(baseReq({ callerAgentId: 'worker', toAgentId: 'third' }))
     expect(res).toMatchObject({ delivered: false, reason: 'hop_limit' })
@@ -777,7 +778,7 @@ describe('messageAgent: cross-daemon routing (P2, source side)', () => {
     const { daemon, call } = await bootWithDispatchSpy(root)
     ;(daemon as any).activeTurnCallMeta.set('slack:C1:100.1:worker', {
       callFrom: 'main',
-      hopCount: 8,
+      hopCount: MAX_AGENT_CALL_HOPS,
       deliveryId: 'd0'
     })
     const sendAgentMsg = vi.fn()
@@ -954,13 +955,14 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     await daemon.stop()
   })
 
-  it('a lineage reply marked session-reply resumes the origin HEADLESS', async () => {
+  it('a lineage reply marked session-reply resumes the origin as an ORDINARY turn', async () => {
     // send-message-routing-rework.md §7/§8.3/§8.4. `replyToSession`'s cross-daemon leg
     // sends BOTH `lineageReplyTo` and `deliveryKind: 'session-reply'`, and the lineage
-    // branch builds its own message and returns before the wake path — so it needs its own
-    // headless stamp. Missing it is invisible in a textual merge and would republish the
-    // parent's entire ordinary response into its channel: precisely the downgrade the
-    // relay's capability gate exists to make impossible.
+    // branch builds its own message and returns before the wake path — so its stamp is set
+    // independently and must match the local branch. NOT headless: the report itself is
+    // transcript-only (nothing publishes an injected body), while muting the parent's own
+    // answer would hide the delegated outcome from the humans in its thread. A remote
+    // parent must not behave differently from a local one.
     const root = scaffold([{ id: 'bot-b' }])
     const { daemon, calls } = await bootWithDispatchSpy(root)
     withSnapshot(daemon)
@@ -984,7 +986,7 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
       })
     )
     expect(ack.delivered).toBe(true)
-    expect(calls[0]!.msg.headless).toBe(true)
+    expect(calls[0]!.msg.headless).toBeUndefined()
     await daemon.stop()
   })
 
@@ -1491,11 +1493,11 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
     // §5.3 step 3: replying into the origin inherits the origin turn's correlationId (so a
     // main-agent's N-of-N orchestration closes) and bumps the hop count.
     expect(callMeta).toMatchObject({ callFrom: 'bot-b', correlationId: 'orch-1', hopCount: 2 })
-    // send-message-routing-rework.md §7: the resumed parent turn is SESSION-ONLY. It
-    // processes the input and records its work, but emits no ordinary IM body, typing
-    // indicator, status message/bar, footer, permission card, or completion notification —
-    // relaying an answer upward must not republish it into the parent's channel.
-    expect(msg.headless).toBe(true)
+    // send-message-routing-rework.md §7: the REPORT is what stays invisible — an injected
+    // body is never published to a platform — while the resumed parent turn is ORDINARY and
+    // keeps its reply connection, so a delegated result can reach the humans waiting in the
+    // parent's own thread. Muting it made every report-back silent there.
+    expect(msg.headless).toBeUndefined()
     await daemon.stop()
   })
 
@@ -1671,11 +1673,11 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
     await daemon.stop()
   })
 
-  it('marks a cross-daemon reply required-headless, and surfaces a refusal instead of leaking it', async () => {
-    // send-message-routing-rework.md §8.3/§8.4. A parent on another daemon must get the
-    // same session-only treatment as a local one, so the delivery carries its KIND; a
-    // relay that finds the target too old answers `unsupported`, which the caller sees as
-    // a failed reply rather than as an answer quietly republished into the parent channel.
+  it('marks a cross-daemon reply session-reply, and surfaces a refusal instead of misrouting it', async () => {
+    // send-message-routing-rework.md §8.3/§8.4. A parent on another daemon must be resumed
+    // through the same path as a local one, so the delivery carries its KIND; a relay that
+    // finds the target too old answers `unsupported`, which the caller sees as a failed
+    // reply rather than as one quietly dispatched into some other session.
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
     const callerKey = sessionKey('slack', 'C2', '200.1', 'bot-b')

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -1825,6 +1825,24 @@ describe('SessionManager — collaboration preamble', () => {
     store.close()
   })
 
+  it('states the needsReply rule in the standing context, not only in the tool descriptor', async () => {
+    // The descriptor is one input among many; this context is ALWAYS present and used to
+    // present the bare `toAgent` form as the normal way to reach a peer privately, with no
+    // hint that an answer never comes back. A caller reading only that omitted `needsReply`
+    // for a question in production (#628) — so the rule has to be stated in both places, and
+    // in the SAME terms the descriptor uses.
+    const store = newStore()
+    const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    await sm.handle('bot-a', msg({ ts: '100.1', text: 'hi' }))
+    const metaArg = host.newSession.mock.calls[0][3] as string
+    expect(metaArg).toContain('{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}')
+    expect(metaArg).toContain('FIRE-AND-FORGET')
+    // The trigger, so the rule is actionable rather than a definition of the flag.
+    expect(metaArg).toMatch(/asks a question or requests a result/)
+    store.close()
+  })
+
   it('routes the collaboration guidance via _meta for Claude, never a user-turn block', async () => {
     const store = newStore()
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any

--- a/packages/protocol/src/consts.ts
+++ b/packages/protocol/src/consts.ts
@@ -19,8 +19,15 @@
  * could drift, and a relay that allowed one more hop than the daemon would let a relayed
  * chain outlive the budget an internal chain gets — a loop-safety hole that no single
  * package's tests would catch.
+ *
+ * The value is a runaway-loop backstop, not a conversation-length policy: a healthy
+ * exchange terminates because the agents are done, and every extra hop only costs one
+ * more turn. It was raised from 8 to 20 because 8 cut ordinary human-started relay games
+ * short (a thread rooted in one human message affords exactly this many agent→agent
+ * edges), while 20 is still far below anything a real collaboration needs and keeps a
+ * genuine A↔B ping-pong bounded within seconds.
  */
-export const MAX_AGENT_CALL_HOPS = 8
+export const MAX_AGENT_CALL_HOPS = 20
 
 /** The daemon↔CP WebSocket subprotocol negotiated on `ClientTransport.dial`. */
 export const CP_SUBPROTOCOL = 'agentconnect.v1'

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -362,14 +362,14 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     // points cannot drift — a relay allowing one more hop than the daemon would let a
     // relayed chain outlive the budget an internal chain gets, and no single package's
     // tests would catch that.
-    expect(MAX_AGENT_CALL_HOPS).toBe(8)
+    expect(MAX_AGENT_CALL_HOPS).toBe(20)
     expect(Number.isInteger(MAX_AGENT_CALL_HOPS)).toBe(true)
   })
 
   it('rd/hello advertises optional daemon capabilities, and an older daemon advertises none', () => {
-    // §8.4: the relay must be able to tell "supports headless session replies" from
-    // "never said", because the second one has to REFUSE a required-headless delivery
-    // rather than degrade it into visible IM output.
+    // §8.4: the relay must be able to tell "understands session replies" from "never
+    // said", because the second one has to REFUSE the delivery rather than let the target
+    // key it by coordinates and mint the wrong session.
     const withCaps = buildRelayDaemonFrame('rd/hello', {
       apiKey: 'k'.repeat(49),
       daemonId: DAEMON_ID,
@@ -386,9 +386,9 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     expect(older.frame.payload.capabilities).toBeUndefined()
   })
 
-  it('carries the required-headless delivery kind across both A2A wire legs', () => {
-    // §8.3: a parent-session reply is a distinct delivery KIND, not a flavor of wake —
-    // the target must suppress the resumed parent's automatic IM output for that turn.
+  it('carries the session-reply delivery kind across both A2A wire legs', () => {
+    // §8.3: a parent-session reply is a distinct delivery KIND, not a flavor of wake — the
+    // target dispatches it into the session named by `lineageReplyTo`.
     const base = {
       claimedFromAgentId: AGENT_ID,
       toAgentId: AUTHORITY_ID,

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -52,11 +52,11 @@ export const RELAY_DAEMON_WS_PATH = '/rd/ws'
  * (send-message-routing-rework.md §8.4). Unknown strings are ignored, so a newer
  * daemon may advertise capabilities an older relay has never heard of.
  *
- * `headless-agent-delivery-v1`: this daemon supports session-only automatic output
- * for a parent-session reply — it resumes the parent with `headless: true`, emitting
- * no ordinary IM body, typing indicator, status message/bar, footer, permission card,
- * or completion notification for that turn. Without it, a required-headless reply must
- * FAIL (retryable/unsupported) instead of leaking the parent's ordinary response to IM.
+ * `headless-agent-delivery-v1`: this daemon understands the `session-reply` delivery
+ * kind — it dispatches the reply into the parent session named by `lineageReplyTo`
+ * (which §7 then resumes as an ordinary turn) instead of keying by coordinates. Without
+ * it, such a reply must FAIL (retryable/unsupported) rather than land in the wrong
+ * session. The name is historical: the kind once also required muting the parent turn.
  */
 export const RD_HEADLESS_AGENT_DELIVERY_V1 = 'headless-agent-delivery-v1'
 
@@ -430,17 +430,18 @@ export type RdAck = z.infer<typeof RdAck>
  *  - `wake` — the ordinary postless `toAgent` call. The woken child is headless in the
  *    existing sense: nothing is posted to any channel on its behalf.
  *  - `session-reply` — a `sendMessage({sessionId})` injection into the caller's
- *    authorized parent session (§7). REQUIRED-HEADLESS: the target must resume the
- *    parent with `headless: true`, so the resumed turn emits no ordinary IM body,
- *    typing indicator, status message/bar, footer, permission card, or completion
- *    notification. This is NOT a turn-wide egress prohibition — the resumed parent may
- *    still make an explicit visible `sendMessage`, which is a new intentional outbound
- *    action rather than an IM copy of the session reply.
+ *    authorized parent session (§7). The target dispatches it into the named
+ *    `lineageReplyTo` session instead of keying by coordinates. What stays invisible is
+ *    the REPORT: no component publishes the injected body to a platform. The resumed
+ *    parent then runs an ORDINARY turn and may answer in its own thread — muting it hid
+ *    delegated outcomes from the humans watching that thread whenever the child had
+ *    answered elsewhere or nowhere.
  *
- * A relay MUST NOT forward `session-reply` to a daemon that has not advertised
- * {@link RD_HEADLESS_AGENT_DELIVERY_V1}; it returns `unsupported` instead of silently
- * degrading the parent's ordinary response into visible IM output (§8.4). Absent ⇒
- * `wake`, which is what every older daemon means.
+ * A relay still MUST NOT forward `session-reply` to a daemon that has not advertised
+ * {@link RD_HEADLESS_AGENT_DELIVERY_V1}, and returns `unsupported` (§8.4). That gate is
+ * now a LEGACY fence, kept because such a daemon predates the delivery kind entirely;
+ * it no longer guards a silence requirement. Absent ⇒ `wake`, which is what every older
+ * daemon means.
  */
 export const RdAgentMsgDeliveryKind = z.enum(['wake', 'session-reply'])
 export type RdAgentMsgDeliveryKind = z.infer<typeof RdAgentMsgDeliveryKind>
@@ -524,7 +525,8 @@ export const RdAgentMsg = z.object({
   // opens only on CP confirmation. Optional — old daemons omit it.
   parentPrivate: z.boolean().optional(),
   // send-message-routing-rework.md §8.3. Absent ⇒ `wake` (what every older daemon
-  // means). `session-reply` is REQUIRED-HEADLESS — see {@link RdAgentMsgDeliveryKind}.
+  // means). `session-reply` dispatches into `lineageReplyTo` — see
+  // {@link RdAgentMsgDeliveryKind}.
   deliveryKind: RdAgentMsgDeliveryKind.optional()
 })
 export type RdAgentMsg = z.infer<typeof RdAgentMsg>
@@ -623,8 +625,8 @@ export const RdAgentMsgFwd = z.object({
   parentPrivate: z.boolean().optional(),
   // Forwarded verbatim from RdAgentMsg (§8.3). The relay does not merely pass this
   // through: for `session-reply` it first checks the TARGET daemon advertised
-  // `headless-agent-delivery-v1` at hello, and refuses with `unsupported` when it did
-  // not — a required-headless reply must never be downgraded into a visible response.
+  // `headless-agent-delivery-v1` at hello, and refuses with `unsupported` when it did not
+  // — a legacy fence against a daemon that predates this delivery kind altogether.
   deliveryKind: RdAgentMsgDeliveryKind.optional()
 })
 export type RdAgentMsgFwd = z.infer<typeof RdAgentMsgFwd>
@@ -633,10 +635,10 @@ export type RdAgentMsgFwd = z.infer<typeof RdAgentMsgFwd>
  *  TARGET daemon durably admits/enqueues the turn (P4-gate) — NOT after the model turn.
  *  `reason` is only set when `delivered:false`. */
 // `unsupported` is the §8.4 refusal: the delivery required a capability the target
-// daemon has not advertised (today, required-headless session replies). It is
-// deliberately distinct from `offline` — the target IS reachable, it is simply too old
-// to honor this delivery kind, so the caller learns the reply was refused rather than
-// having it silently degraded into visible IM output.
+// daemon has not advertised (today, `session-reply`). It is deliberately distinct from
+// `offline` — the target IS reachable, it is simply too old to honor this delivery kind,
+// so the caller learns the reply was refused rather than having it land in the wrong
+// session.
 export const RdAgentMsgReason = z.enum([
   'busy',
   'offline',

--- a/packages/relay/src/agent-msg-router.test.ts
+++ b/packages/relay/src/agent-msg-router.test.ts
@@ -7,7 +7,7 @@ import type {
   RdAgentMsgFwd,
   RdAgentMsgAck
 } from '@agentconnect.md/protocol'
-import { RD_HEADLESS_AGENT_DELIVERY_V1 } from '@agentconnect.md/protocol'
+import { MAX_AGENT_CALL_HOPS, RD_HEADLESS_AGENT_DELIVERY_V1 } from '@agentconnect.md/protocol'
 import { CollaborationRouter } from './collaboration-router.js'
 import { createAgentMsgRouter } from './agent-msg-router.js'
 import type { RelayDaemonServer } from './relay-daemon-server.js'
@@ -146,9 +146,9 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     expect(forwards[0].integrationId).toBe(INT)
   })
 
-  it('forwards a required-headless session reply to a capable daemon', async () => {
+  it('forwards a session reply to a capable daemon', async () => {
     // send-message-routing-rework.md §8.3: the delivery KIND rides through so the target
-    // resumes the parent silently, exactly as the same-daemon path does.
+    // dispatches into the named parent session, exactly as the same-daemon path does.
     const router = new CollaborationRouter()
     router.replace(snap())
     const forwards: RdAgentMsgFwd[] = []
@@ -163,11 +163,11 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     expect(forwards[0].deliveryKind).toBe('session-reply')
   })
 
-  it('REFUSES a required-headless session reply to a daemon that cannot run it silently', async () => {
-    // §8.4 / §10 case 14. The failure mode this prevents is not a lost message but a
-    // LEAKED one: an old target would resume the parent with an ordinary IM connection
-    // and republish its entire response into the parent's channel. `unsupported` is
-    // deliberately distinct from `offline` — the daemon is reachable, just too old.
+  it('REFUSES a session reply to a daemon that does not understand the kind', async () => {
+    // §8.4 / §10 case 14. The failure mode this prevents is a MISROUTED reply: a target
+    // predating the kind ignores `lineageReplyTo` and keys the delivery by coordinates,
+    // minting a different session. `unsupported` is deliberately distinct from `offline` —
+    // the daemon is reachable, just too old.
     const router = new CollaborationRouter()
     router.replace(snap())
     const forwards: RdAgentMsgFwd[] = []
@@ -183,8 +183,8 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
   })
 
   it('still forwards an ordinary wake to a daemon advertising nothing', async () => {
-    // Only the required-headless kind is gated; a plain postless wake has always been
-    // safe against an older target, so the capability must not become a general fence.
+    // Only `session-reply` is gated; a plain postless wake has always been safe against
+    // an older target, so the capability must not become a general fence.
     const router = new CollaborationRouter()
     router.replace(snap())
     const forwards: RdAgentMsgFwd[] = []
@@ -924,7 +924,7 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
       daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
       log: noopLog
     })
-    const ack = await route(D1, baseMsg({ hopCount: 8, deliveryId: 'd-hop' }))
+    const ack = await route(D1, baseMsg({ hopCount: MAX_AGENT_CALL_HOPS, deliveryId: 'd-hop' }))
     expect(ack.delivered).toBe(false)
     expect(ack.reason).toBe('hop_limit')
     expect(forwards).toHaveLength(0)

--- a/packages/relay/src/agent-msg-router.ts
+++ b/packages/relay/src/agent-msg-router.ts
@@ -151,16 +151,16 @@ export function createAgentMsgRouter(deps: AgentMsgRouterDeps) {
     const conn = deps.daemons()?.get(target.daemonId)
     if (!conn) return nak(msg.deliveryId, 'offline')
 
-    // (f0) send-message-routing-rework.md §8.4 — capability gate for a REQUIRED-HEADLESS
-    // delivery. A `session-reply` must resume the parent SILENTLY (§7); a daemon too old
-    // to do that would instead publish the parent's whole ordinary response into its
-    // channel. That is precisely the behavior the design removes, so the reply is REFUSED
-    // — `unsupported`, distinct from `offline` because the target is reachable and the
-    // caller can act on the difference — rather than silently degraded.
+    // (f0) send-message-routing-rework.md §8.4 — capability gate for `session-reply`. A
+    // daemon that never advertised this predates the delivery kind entirely: it would key
+    // the reply by coordinates instead of dispatching into the named parent session. The
+    // reply is REFUSED — `unsupported`, distinct from `offline` because the target is
+    // reachable and the caller can act on the difference. (The gate was introduced when
+    // this kind ALSO required muting the resumed parent turn, which §7 no longer asks for.)
     if (msg.deliveryKind === 'session-reply' && !conn.supports(RD_HEADLESS_AGENT_DELIVERY_V1)) {
       deps.log.warn(
         `relay: rd/agentmsg refused — daemon ${target.daemonId} does not support ${RD_HEADLESS_AGENT_DELIVERY_V1}; ` +
-          `a session reply must not be downgraded to visible IM output`
+          `it cannot dispatch a reply into the named parent session`
       )
       return nak(msg.deliveryId, 'unsupported')
     }
@@ -200,9 +200,9 @@ export function createAgentMsgRouter(deps: AgentMsgRouterDeps) {
         // session-visibility.md §5.1 privacy hint — again the caller's own fact
         // about its own lineage, forwarded verbatim. The relay stores nothing.
         ...(msg.parentPrivate !== undefined ? { parentPrivate: msg.parentPrivate } : {}),
-        // §8.3: forwarded so the TARGET applies the same required-headless contract the
-        // same-daemon path applies locally. The capability check above already ran, so a
-        // target receiving `session-reply` is known to be able to honor it.
+        // §8.3: forwarded so the TARGET treats the delivery exactly as the same-daemon path
+        // does — dispatch into the named parent session. The capability check above already
+        // ran, so a target receiving `session-reply` is known to understand it.
         ...(msg.deliveryKind !== undefined ? { deliveryKind: msg.deliveryKind } : {})
       })
     } catch (err) {

--- a/packages/relay/src/agent-msg-router.ts
+++ b/packages/relay/src/agent-msg-router.ts
@@ -22,7 +22,7 @@
  *     coordinate for the woken session, not as an authorization input;
  *  d) check the caller's outbound policy AND the target's inbound policy
  *     (cross-org / either denial → typed NAK);
- *  e) increment hopCount (inbound+1, cap 8, §2.4);
+ *  e) increment hopCount (inbound+1, capped at MAX_AGENT_CALL_HOPS, §2.4);
  *  f) forward `rd/agentmsg/fwd` with a TRUSTED caller claim (trustedFromAgentId + org/
  *     channel assertion) to the owning daemon and relay its admission verdict back.
  *

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -10,6 +10,7 @@ import type {
   WireFeishuCardActionEvent,
   WireNormalizedMessage
 } from '@agentconnect.md/protocol'
+import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 import { FakeClock } from '@agentconnect.md/connection'
 import {
   RelayIngressManager,
@@ -955,14 +956,15 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       expect(second).not.toHaveBeenCalled()
     })
 
-    it('admits source depth 7 as delivery depth 8 and rejects 8 because the next hop is 9', async () => {
-      // §10 case 15 — the boundary the whole hop transition exists to hold.
+    it('admits the last source depth under the cap and rejects the cap because its next hop overflows', async () => {
+      // §10 case 15 — the boundary the whole hop transition exists to hold. Derived from
+      // MAX_AGENT_CALL_HOPS so retuning the budget cannot leave this transport behind.
       const admitted = managerWith()
-      await admitted.internals.forward(BOT_ID, agentFinal({ hopCount: 7 }))
-      expect(admitted.sendMsg.mock.calls[0]![0]).toMatchObject({ trustedDeliveryHopCount: 8 })
+      await admitted.internals.forward(BOT_ID, agentFinal({ hopCount: MAX_AGENT_CALL_HOPS - 1 }))
+      expect(admitted.sendMsg.mock.calls[0]![0]).toMatchObject({ trustedDeliveryHopCount: MAX_AGENT_CALL_HOPS })
 
       const rejected = managerWith()
-      await rejected.internals.forward(BOT_ID, agentFinal({ hopCount: 8 }))
+      await rejected.internals.forward(BOT_ID, agentFinal({ hopCount: MAX_AGENT_CALL_HOPS }))
       expect(rejected.sendMsg).not.toHaveBeenCalled()
     })
 


### PR DESCRIPTION
Three fixes to multi-agent collaboration, all found on one Slack thread in `#ai-playground` where two agents were asked to count to 30 and to relay a peer's answer — and neither worked.

## 1. `MAX_AGENT_CALL_HOPS` 8 → 20

The counting game stopped at **10**, which is exactly the budget: two human-woken turns (the human `@`-mentioned both agents) plus eight hops. Confirmed in the logs — daemon and both relays show `hop 1 … hop 8` and then nothing, and the relay received the Slack event for "10" and dropped it at `relay-ingress-manager.ts` `hop_limit: 8 + 1 exceeds 8` (a `log.debug`, so the humans saw only silence).

The cap is a runaway-loop backstop, not a conversation-length policy: every extra hop costs one turn, and a genuine A↔B ping-pong stays bounded within seconds either way. 20 is still far below what a real collaboration needs.

The three boundary tests (daemon mention routing, relay ingress, relay agent-msg router) now derive from the constant instead of pinning `8`, so retuning the budget can no longer leave one transport behind — which is the whole reason the constant lives in `protocol`.

## 2. A parent-session reply no longer mutes the parent's turn

`replyToSession` stamped the resumed parent `headless: true`. What that flag actually gates is **the woken turn's own output** (`daemon.ts`: `replyConn = msg.headless || webchat || mode === 'none' ? undefined : …`). The report it was supposed to keep quiet was never publishable in the first place: `replyToSession` makes no gateway call at all, and nothing in the daemon publishes inbound delivery content.

So the stamp bought nothing on the side it claimed and cost visibility on the other. Observed: `test2` reported back twice, `test` ran both turns (transcript shows its answers, timestamped **before** the human asked), and Slack showed nothing — the human had to ask "did you get a reply?" about an answer that already existed. Whenever the child answered in its own channel-root thread, or nowhere at all (a postless child), the delegated outcome reached nobody.

Now: the injected report stays transcript-only (structurally), and the parent is resumed as an **ordinary turn** that answers in its own conversation. Local and both cross-daemon legs agree, so a remote parent behaves like a local one.

The duplicate-copy worry the stamp addressed — a second copy of an answer the child already delivered into the *same* conversation — is editorial, and the standing "be quiet about mechanics / don't restate" guidance already owns it.

**Consequence worth knowing:** in a same-thread exchange the parent's answer is an ordinary agent-authored message again, so implicit routing can wake the child from it — bounded by the hop cap and the loop guard, like any other edge. `headless` used to suppress that echo entirely.

The relay's `headless-agent-delivery-v1` gate **stays**, re-described as what it now is: a compatibility fence against a daemon predating the `session-reply` kind, which would key the reply by coordinates and land it in the wrong session. Removing it is a separate compat call.

## 3. `needsReply` becomes a rule with a stated consequence

The caller above passed the bare-string `toAgent` form, so `needsReply` was never set (the child session's `needsParentReply` is `null`). The peer answered inside its own conversation, nothing came back, and the human had to tell it to use a parent-session reply.

The report-back half was already fully built — set the flag and the child's standing context carries a "# Reporting back to your parent session" directive. The missing half was the caller's: the tool text offered `needsReply` "for delegated work you will wait on", a description of a state that caller did not believe it was in (its reasoning was "Preparing Slack message sending"; it treated the job as done once the post existed).

The description now names the triggers — a message that asks a question or requests a result, relaying someone else's answer, intending to act on the outcome, `"reply to me" / "tell me" / "check X and report"` — and states the consequence plainly: without it the peer's answer never reaches you, and a failure is not reported either. Four touch points: the `toAgent` mode description, the `toAgent` property, the `needsReply` boolean, and the tool overview bullet.

## Docs

`send-message-routing-rework.md` §1/§7/§8.3/§8.4/§10 (cases 13–15), `product-conventions.md`, `agent-collaboration-implementation.md`, `loop-breaker-design.md`.

## Verification

- `pnpm typecheck` green (including `tsc -p evals/tsconfig.json`); prettier green.
- `protocol` 278, `relay` 430, and the four affected daemon files 252 tests — all green on this base.
- Full daemon suite before the rebase: 3022 passed, 1 failed — `evaluation-runner` › "records a raw ACP baseline…", which fails in isolation too because the `test/fixtures/scriptable-acp-agent.mjs` fixture is absent from the tree. Pre-existing and unrelated.

## Not in this PR

The same session exposed a second, independent bug: the visible half of a `toAgent + channel` send carried **no `@test2` mention**, because `mentionAddress` needs `Bot.botUserId` and every manually-created (custom-token) Slack bot in the test org has it `null` — `verifySlackBot` parses `user / team / team_id / app_id / bot_id` from `auth.test` and drops `user_id`. Only the OAuth platform-app install path persists it. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
