### PR TITLE
fix(web): gate the Sharable toggle on the platform, not just the transport

### DIFF
--- a/packages/control-plane/src/http/routes/bots.ts
+++ b/packages/control-plane/src/http/routes/bots.ts
@@ -18,6 +18,7 @@ import { BotId } from '../../domain/ids.js'
 import { orgOf, denyViewerWrite } from '../rbac.js'
 import { BotDto, BotListDto, UpdateBotBody, ErrorDto, IdParam, type BotDtoT } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
+import { MULTI_AGENT_UNSUPPORTED_MESSAGE, supportsMultiAgentBots } from '../../platforms/sharing.js'
 
 function toDto(b: BotRecord): BotDtoT {
   return {
@@ -124,14 +125,18 @@ export function botRoutes(deps: HttpDeps) {
 
     // Flip the HTTP bot's multi-agent capacity (`Bot.shareable`,
     // shared-bot-relay.md §4.1). Transport is immutable: relay ingress remains in
-    // place either way. Disabling is refused while >1 agent uses the bot.
+    // place either way. Enabling needs BOTH a platform that supports multi-agent
+    // bots (`supportsMultiAgentBots` — the same precondition the shareable
+    // install checks) and the http transport; disabling is refused while >1 agent
+    // uses the bot.
     r.patch(
       '/bots/:id',
       {
         schema: {
           tags: [Tag.Bots],
           summary: 'Update a bot',
-          description: 'Allow or disallow this HTTP bot from serving multiple agents. Relay ingress is unchanged.',
+          description:
+            'Allow or disallow this HTTP bot from serving multiple agents. Allowing requires a platform that supports multi-agent bots (Slack today); relay ingress is unchanged either way.',
           operationId: 'updateBot',
           params: IdParam,
           body: UpdateBotBody,
@@ -145,6 +150,22 @@ export function botRoutes(deps: HttpDeps) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
         if (req.body.shareable === bot.shareable) return toDto(bot) // no-op
+        // Multi-agent bots are a per-PLATFORM capability, and this route used to
+        // check only the transport — so any HTTP-transport bot on a platform the
+        // install path refuses (`validateShareableInstall`) could be flipped
+        // shareable here, leaving the flag on the row as a promise nothing
+        // honors. Only the ENABLE direction is refused: an already-flipped row
+        // from before this guard must stay repairable from the console.
+        //
+        // Checked before the mutation lease, unlike `shareable`/`agentIds`
+        // below: `platform` is immutable, so a locked re-read could not tell us
+        // anything the snapshot does not. 409 rather than the create route's
+        // 400 for the same rule — there the platform is the CLIENT's assertion
+        // in the request body, here it is the stored row's, exactly like the
+        // transport refusal this sits beside.
+        if (req.body.shareable && !supportsMultiAgentBots(bot.platform)) {
+          return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: MULTI_AGENT_UNSUPPORTED_MESSAGE })
+        }
         const observedAgentIds = [...bot.agentIds].sort()
         const release = deps.agentMutations.tryBeginMutation(observedAgentIds)
         if (!release) {

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -34,6 +34,7 @@ import { BotExternalIdentityTaken } from '../../persistence/errors.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
 import { buildCreateIntegrationBody, credentialBlockOf } from '../dto/create-integration-body.js'
 import type { CpConfigRefusal } from '../../platforms/provider.js'
+import { MULTI_AGENT_UNSUPPORTED_MESSAGE, supportsMultiAgentBots } from '../../platforms/sharing.js'
 import {
   UpdateIntegrationChannelBody,
   LeaveIntegrationConversationBody,
@@ -129,10 +130,10 @@ export function integrationRoutes(deps: HttpDeps) {
       agentId: string,
       platform: string
     ): Promise<{ code: 400 | 409; body: { error: string; statusCode: number; message: string } } | null> => {
-      if (platform !== 'slack') {
+      if (!supportsMultiAgentBots(platform)) {
         return {
           code: 400,
-          body: { error: 'Bad Request', statusCode: 400, message: 'multi-agent bots currently support Slack only' }
+          body: { error: 'Bad Request', statusCode: 400, message: MULTI_AGENT_UNSUPPORTED_MESSAGE }
         }
       }
       if (!deps.httpBot.hasConnectedRelay()) {

--- a/packages/control-plane/src/platforms/sharing.test.ts
+++ b/packages/control-plane/src/platforms/sharing.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The multi-agent platform fact (§5 `multiAgentShareable`) — unit, no I/O.
+ *
+ * Two routes read it and used to disagree: `POST /integrations` refused a
+ * shareable install on anything but Slack, while `PATCH /bots/:id` gated only on
+ * the transport, so a Feishu HTTP bot could be flipped `shareable` and carry a
+ * flag the install path never honors. What is worth pinning here is the fact
+ * itself against the SHIPPED provider set; the two routes' behavior is pinned
+ * where it happens (`test/integration/integrations.route.test.ts`).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { buildCpPlatformRegistry } from './registry.js'
+import { createTelegramCpProvider } from './telegram/provider.js'
+import { createDiscordCpProvider } from './discord/provider.js'
+import { createSlackCpProvider } from './slack/provider.js'
+import { createFeishuCpProvider } from './feishu/provider.js'
+import { MULTI_AGENT_UNSUPPORTED_MESSAGE, supportsMultiAgentBots } from './sharing.js'
+
+/** The container's composition, with offline stubs — the same construction
+ *  `registry.test.ts` uses. */
+const shippedPlatforms = () =>
+  buildCpPlatformRegistry([
+    createTelegramCpProvider({
+      verifyBot: vi.fn(async () => ({ status: 'ok' as const, name: null, privacyModeDisabled: true }))
+    }),
+    createDiscordCpProvider({ ensureMessageContentIntent: vi.fn(async () => 'ready' as const) }),
+    createSlackCpProvider({}),
+    createFeishuCpProvider({})
+  ])
+
+describe('supportsMultiAgentBots', () => {
+  it('is true for Slack alone across the shipped platform set', () => {
+    // Named against the REGISTRY rather than a hand-copied list, so a platform
+    // added to the composition without a decision here is a failing test — and
+    // a reminder that the console's `platformSupportsSharing` mirror
+    // (packages/web platform modules) has to move in the same change.
+    expect(
+      shippedPlatforms()
+        .ids()
+        .filter((id) => supportsMultiAgentBots(id))
+    ).toEqual(['slack'])
+  })
+
+  it('refuses ids no provider claims, and near-misses', () => {
+    // The callers pass a persisted `platform` column and a request body's
+    // platform — both open strings, so the predicate has to be total and
+    // exact-match.
+    for (const id of ['', 'lark', 'Slack', 'slack ', 'webhook', 'github', '__proto__']) {
+      expect(supportsMultiAgentBots(id), id).toBe(false)
+    }
+  })
+
+  it('sends copy that names the same set it decides', () => {
+    // Both routes send this one sentence; it goes stale the moment the
+    // predicate admits a second platform, so the coupling is worth a claim.
+    expect(MULTI_AGENT_UNSUPPORTED_MESSAGE).toContain('Slack')
+    expect(MULTI_AGENT_UNSUPPORTED_MESSAGE).not.toMatch(/telegram|discord|feishu|lark/i)
+  })
+})

--- a/packages/control-plane/src/platforms/sharing.ts
+++ b/packages/control-plane/src/platforms/sharing.ts
@@ -1,0 +1,29 @@
+/**
+ * Which platforms may serve SEVERAL agents from ONE bot identity
+ * (`Bot.shareable`, shared-bot-relay.md §4.1) — Slack alone today.
+ *
+ * CORE-OWNED, not a provider member. `multiAgentShareable` is one of the §5
+ * MANIFEST values the provider contract deliberately excludes (`provider.ts`,
+ * D2: manifest values are cross-host declarative data, not behavior); until that
+ * manifest lands in protocol the fact has to live somewhere core, and this is
+ * that somewhere. When the manifest arrives, this predicate is what it replaces
+ * — one call site per route, not a scattered literal.
+ *
+ * It is a module rather than a literal in each route because the two routes that
+ * read it had already drifted: the create path refused a multi-agent install
+ * outright (`http/routes/integrations.ts`'s `validateShareableInstall`), while
+ * `PATCH /bots/:id` gated only on transport. Any HTTP-transport bot on another
+ * platform could therefore be flipped `shareable` and the flag would sit on the
+ * row as a promise no install path ever honors.
+ */
+
+/** Whether `platform` supports multi-agent bots at all — the precondition BOTH
+ *  the shareable install and the sharing toggle check before anything else. */
+export function supportsMultiAgentBots(platform: string): boolean {
+  return platform === 'slack'
+}
+
+/** The user-facing refusal for a platform that does not. One string for both
+ *  routes: it names the same set {@link supportsMultiAgentBots} decides, so the
+ *  two move together. */
+export const MULTI_AGENT_UNSUPPORTED_MESSAGE = 'multi-agent bots currently support Slack only'

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -1342,3 +1342,120 @@ describe('bot roster (GET/DELETE /bots)', () => {
     }
   )
 })
+
+/**
+ * Multi-agent bots are a per-PLATFORM capability (`platforms/sharing.ts`), and
+ * the two routes that read it had drifted: the shareable install refused
+ * everything but Slack while `PATCH /bots/:id` gated only on the transport. So
+ * any HTTP-transport bot on another platform — Feishu is the one that exists,
+ * since it offers a transport choice of its own — could be flipped `shareable`,
+ * and the flag would sit on the row as a promise the install path never honors.
+ */
+describe('bot sharing capability (PATCH /bots/:id)', () => {
+  /** A durable bot row with no install — enough for the toggle, which reads
+   *  `platform`, `transport`, `shareable` and the membership count. */
+  async function seedBot(over: { platform: string; transport?: 'socket' | 'http'; shareable?: boolean }) {
+    const id = randomUUID()
+    await prisma.bot.create({
+      data: {
+        id,
+        orgId: DEFAULT_ORG_ID,
+        platform: over.platform,
+        name: `${over.platform}-bot`,
+        transport: over.transport ?? 'http',
+        shareable: over.shareable ?? false
+      }
+    })
+    return id
+  }
+
+  it('refuses enabling sharing on a platform without multi-agent bots', async () => {
+    const { app } = withSpy()
+    const botId = await seedBot({ platform: 'feishu', transport: 'http' })
+
+    const res = await app.app.inject({ method: 'PATCH', url: `${ORG}/bots/${botId}`, payload: { shareable: true } })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.json()).toMatchObject({ message: 'multi-agent bots currently support Slack only' })
+    expect((await prisma.bot.findUniqueOrThrow({ where: { id: botId } })).shareable).toBe(false)
+  })
+
+  it('names the platform rather than the transport when neither would help', async () => {
+    // Ordering claim: the platform gate runs FIRST. A Feishu socket bot used to
+    // be told to "recreate the bot in HTTP mode" — advice that would not have
+    // worked, because the install path refuses the platform either way.
+    const { app } = withSpy()
+    const botId = await seedBot({ platform: 'feishu', transport: 'socket' })
+
+    const res = await app.app.inject({ method: 'PATCH', url: `${ORG}/bots/${botId}`, payload: { shareable: true } })
+
+    expect(res.statusCode).toBe(409)
+    expect((res.json() as { message: string }).message).toBe('multi-agent bots currently support Slack only')
+  })
+
+  it('still lets a row flipped before the guard existed be turned back off', async () => {
+    // Only the ENABLE direction is refused. While the toggle was transport-gated
+    // only, this PATCH accepted the flip — so such rows may exist, and the
+    // console's repair has to keep working.
+    const { app } = withSpy()
+    const botId = await seedBot({ platform: 'feishu', transport: 'http', shareable: true })
+
+    const res = await app.app.inject({ method: 'PATCH', url: `${ORG}/bots/${botId}`, payload: { shareable: false } })
+
+    expect(res.statusCode).toBe(200)
+    expect((await prisma.bot.findUniqueOrThrow({ where: { id: botId } })).shareable).toBe(false)
+  })
+
+  it('leaves Slack’s HTTP bots shareable, and its socket bots refused on transport', async () => {
+    const { app } = withSpy()
+    const http = await seedBot({ platform: 'slack', transport: 'http' })
+    const socket = await seedBot({ platform: 'slack', transport: 'socket' })
+
+    const ok = await app.app.inject({ method: 'PATCH', url: `${ORG}/bots/${http}`, payload: { shareable: true } })
+    expect(ok.statusCode).toBe(200)
+    expect((await prisma.bot.findUniqueOrThrow({ where: { id: http } })).shareable).toBe(true)
+
+    const refused = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/bots/${socket}`,
+      payload: { shareable: true }
+    })
+    expect(refused.statusCode).toBe(409)
+    expect((refused.json() as { message: string }).message).toMatch(/HTTP-mode/)
+  })
+
+  it('refuses a second agent on a non-Slack HTTP bot — the rule this toggle now agrees with', async () => {
+    // The create path's half of the same predicate, pinned here so the two stay
+    // in one place: a reuse that would make the bot multi-agent is a 400 (there
+    // the platform is the client's assertion in the body; on the PATCH it is the
+    // stored row's, hence the 409 above).
+    const first = await placedAgent()
+    const second = randomUUID()
+    await seedAgent(prisma, second, { daemonId: DAEMON })
+    const { app } = withSpy()
+    app.relayReg.add({ relayId: 'r1', send() {}, close() {} } as RelayChannel)
+    app.platformStubs.verifyFeishuBot = async () => ({ status: 'ok', name: 'shared-lark', openId: 'ou_shared_bot' })
+
+    const created = (
+      await app.app.inject({
+        method: 'POST',
+        url: `${ORG}/integrations`,
+        payload: {
+          platform: 'feishu',
+          agentId: first,
+          transport: 'http',
+          feishu: { appId: 'cli_shared', appSecret: 'app-secret', verificationToken: 'vt', encryptKey: 'ek' }
+        }
+      })
+    ).json() as { botId: string }
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { platform: 'feishu', agentId: second, botId: created.botId }
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.json()).toMatchObject({ message: 'multi-agent bots currently support Slack only' })
+  })
+})

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -23,7 +23,7 @@ import {
   type FooterView,
   type IdentityChromeView
 } from '@/components/console/platforms/publish'
-import { platformRegistry } from '@/components/console/platforms/registry'
+import { platformRegistry, platformSupportsSharing } from '@/components/console/platforms/registry'
 import { agentLabel, MOCK_MODE, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { platformLabel } from '@/lib/platform-labels'
@@ -451,11 +451,14 @@ export default function AddIntegrationModal({
     setTransportPick(next)
     if (next === 'socket') setShared(false)
   }, [])
-  // Shared mode is http-only — a socket bot can never be shared. Create: gate on
-  // the chosen transport. Existing: gate on the reused bot's own transport (the
-  // selector isn't shown for reuse), so a socket bot never offers it.
+  // Shared mode needs a platform with multi-agent bots at all, and is http-only
+  // on top of that — a socket bot can never be shared. Create: gate on the chosen
+  // transport. Existing: gate on the reused bot's own transport (the selector
+  // isn't shown for reuse), so a socket bot never offers it. The platform half
+  // goes through `platformSupportsSharing` (registry.ts), the same lookup the
+  // Settings → Bots toggle makes, so the two surfaces cannot disagree.
   const shareToggleAvailable =
-    wizard?.affordances.share === true &&
+    platformSupportsSharing(platform) &&
     (mode === 'existing' ? (selectedBot?.transport ?? 'socket') === 'http' : transport === 'http')
   // Reusing an already-shared bot is implicitly a shared install.
   const wantShared = shareToggleAvailable && (shared || (mode === 'existing' && !!selectedBot?.shareable))

--- a/packages/web/src/components/console/platforms/bot-sharing.test.ts
+++ b/packages/web/src/components/console/platforms/bot-sharing.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment happy-dom
+
+/**
+ * Who may share a bot, and therefore who gets a live Sharable toggle.
+ *
+ * The Settings → Bots toggle shipped gated on TRANSPORT alone
+ * (`(bot.transport ?? 'socket') === 'socket'`), while multi-agent bots are
+ * Slack-only at the server ("multi-agent bots currently support Slack only",
+ * control-plane `platforms/sharing.ts`). Feishu is the one non-Slack platform
+ * whose bots can be `transport: 'http'` — it declares a transport affordance of
+ * its own — so a Feishu HTTP bot presented a fully clickable toggle for a
+ * capability the CP refuses.
+ *
+ * Nothing renders these predicates, so these assertions are the only thing that
+ * notices when the platform fact and its two readers drift apart again.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { BotDto } from '@/lib/api'
+import { botCardCopy, botSharingEditable, platformRegistry, platformSupportsSharing } from './registry'
+
+/** `platform`/`transport`/`shareable` are the only members either predicate
+ *  reads; the rest is here so the fixture stays a real `BotDto`. */
+function bot(over: Partial<BotDto> = {}): BotDto {
+  return {
+    id: 'bot-1',
+    name: 'support',
+    platform: 'slack',
+    prebuilt: false,
+    slackAppId: null,
+    discordAppId: null,
+    createdBy: null,
+    transport: 'socket',
+    shareable: false,
+    inUseByAgentId: null,
+    agentIds: [],
+    lastUsedAt: null,
+    freedFromAgent: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...over
+  }
+}
+
+/** Ids a bot row can carry that no module claims — core trigger kinds, a
+ *  platform not built yet, and the prototype-pollution shapes a `Map` lookup
+ *  must not answer for. */
+const UNCLAIMED = ['webhook', 'github', 'playground', 'webchat', 'linear', 'lark', 'Slack', '__proto__', '']
+
+describe('platformSupportsSharing', () => {
+  it('is true for Slack and false for every other registered platform', () => {
+    expect(platformSupportsSharing('slack')).toBe(true)
+    for (const id of platformRegistry.ids().filter((p) => p !== 'slack')) {
+      expect(platformSupportsSharing(id), id).toBe(false)
+    }
+  })
+
+  it('answers for an id no module claims, and for none at all', () => {
+    // A bot row carries whatever platform the CP sent — the lookup has to be
+    // total, and its total answer has to be the refusing one.
+    for (const id of UNCLAIMED) expect(platformSupportsSharing(id), id).toBe(false)
+    expect(platformSupportsSharing(undefined)).toBe(false)
+  })
+
+  it('reads the modules’ single declaration of the fact', () => {
+    // ONE declaration, so the wizard's shared opt-in and the Settings toggle
+    // cannot disagree about a platform. Named, so a module that starts declaring
+    // it is a visible diff here — and a reminder that the CP's own predicate has
+    // to move in the same change.
+    expect(
+      platformRegistry
+        .all()
+        .filter((m) => m.wizard.affordances.share === true)
+        .map((m) => m.platformId)
+    ).toEqual(['slack'])
+  })
+})
+
+describe('botSharingEditable', () => {
+  it('lets a Slack HTTP bot be shared', () => {
+    expect(botSharingEditable(bot({ platform: 'slack', transport: 'http' }))).toBe(true)
+  })
+
+  it('refuses a Feishu HTTP bot — the platform, not the transport, is the reason', () => {
+    // The defect: Feishu declares a transport affordance, so its bots reach
+    // `transport: 'http'` and cleared the old gate, but the CP refuses the
+    // install that flag promises. Both Feishu clouds share the platform id.
+    expect(botSharingEditable(bot({ platform: 'feishu', transport: 'http' }))).toBe(false)
+    expect(botSharingEditable(bot({ platform: 'feishu', transport: 'socket' }))).toBe(false)
+  })
+
+  it('refuses a socket bot on every platform, Slack included', () => {
+    // Transport is immutable post-create and relay ingress is what shared bots
+    // route over, so a socket bot can never be shared regardless of platform.
+    for (const id of platformRegistry.ids()) {
+      expect(botSharingEditable(bot({ platform: id, transport: 'socket' })), id).toBe(false)
+      // A platform with no transport affordance sends no transport at all.
+      expect(botSharingEditable(bot({ platform: id, transport: undefined })), id).toBe(false)
+    }
+  })
+
+  it('refuses a platform no module claims, whatever its transport', () => {
+    for (const id of UNCLAIMED) {
+      expect(botSharingEditable(bot({ platform: id, transport: 'http' })), id).toBe(false)
+    }
+  })
+
+  it('keeps an already-shared row editable so the flag can be turned back off', () => {
+    // Not defensive: while the toggle was transport-gated only, `PATCH /bots/:id`
+    // accepted the flip, so rows on a non-sharing platform may already carry
+    // `shareable: true`. The CP still honors turning those OFF (it refuses only
+    // the enable direction), so the console must keep the control that does it.
+    expect(botSharingEditable(bot({ platform: 'feishu', transport: 'http', shareable: true }))).toBe(true)
+    expect(botSharingEditable(bot({ platform: 'slack', transport: 'http', shareable: true }))).toBe(true)
+  })
+})
+
+describe('the disabled toggle and its tooltip agree', () => {
+  it('never disables a toggle under a sentence promising a transport fix', () => {
+    // The copy contract (§10 `settingsFragments.copy.shareHint`) collapses both
+    // arms for a platform that cannot share; this pins the two halves together,
+    // so a module cannot declare two different share sentences while the toggle
+    // it explains is dead for a reason no transport change repairs.
+    for (const id of platformRegistry.ids()) {
+      if (platformSupportsSharing(id)) continue
+      const { available, unavailable } = botCardCopy(id).shareHint
+      expect(available, id).toBe(unavailable)
+    }
+  })
+
+  it('keeps Slack’s transport sentence, where the transport really is the reason', () => {
+    const { available, unavailable } = botCardCopy('slack').shareHint
+    expect(available).not.toBe(unavailable)
+    expect(botSharingEditable(bot({ platform: 'slack', transport: 'http' }))).toBe(true)
+    expect(botSharingEditable(bot({ platform: 'slack', transport: 'socket' }))).toBe(false)
+  })
+})

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -283,10 +283,23 @@ export interface WebWizardAffordances {
    *  choice nor lets {@link WizardHost.transport} vary (Telegram/Discord,
    *  whose create DTOs carry no transport at all, api.ts:660-661). */
   transport?: WebTransportAffordance
-  /** The platform supports the shared-bot opt-in (§5 `multiAgentShareable`
-   *  mirror; Slack only today). The host still applies the http-only gate
-   *  itself — create mode on the chosen transport, reuse mode on the reused
-   *  bot's own (:1321-1326). */
+  /**
+   * The platform supports multi-agent bots (§5 `multiAgentShareable` mirror;
+   * Slack only today). The host still applies the http-only gate itself —
+   * create mode on the chosen transport, reuse mode on the reused bot's own
+   * (:1321-1326).
+   *
+   * Nested under `wizard` for where it is DECLARED, not for where it may be
+   * read: it is a platform fact, and the Settings → Bots Sharable toggle reads
+   * the same one through `platformSupportsSharing` (registry.ts). That toggle
+   * shipped gated on transport ALONE, which left a Feishu HTTP bot — the one
+   * non-Slack platform whose bots can be `transport: 'http'` — offering a live
+   * control for a capability the CP refuses ("multi-agent bots currently
+   * support Slack only", control-plane `platforms/sharing.ts`). The fix is this
+   * member, not a second one on {@link WebBotSettingsFragments}: a Settings-side
+   * mirror could disagree with the wizard's about the same platform, and one
+   * declaration cannot.
+   */
   share?: boolean
 }
 

--- a/packages/web/src/components/console/platforms/registry.ts
+++ b/packages/web/src/components/console/platforms/registry.ts
@@ -1,7 +1,7 @@
 // No 'use client' here: reached only from ModalProvider's tree (the client boundary).
 
 import type { ComponentType } from 'react'
-import type { SessionMessageDto } from '@/lib/api'
+import type { BotDto, SessionMessageDto } from '@/lib/api'
 import type { WebBotCardCopy, WebChannelListSemantics, WebPlatformModule, WebPlatformRegistry } from './contract'
 import { discordModule } from './discord'
 import { feishuModule } from './feishu'
@@ -79,6 +79,44 @@ export function botCardCopy(platformId?: string): Required<WebBotCardCopy> {
     revokedHint: copy?.revokedHint ?? DEFAULT_BOT_CARD_COPY.revokedHint,
     shareHint: copy?.shareHint ?? DEFAULT_BOT_CARD_COPY.shareHint
   }
+}
+
+/**
+ * Whether this platform supports multi-agent bots at all — the §5
+ * `multiAgentShareable` fact, read from the ONE place a module declares it
+ * (`WebWizardAffordances.share`). Total, like every lookup here: a bot row
+ * carries whatever platform the CP sent, and `webhook`/`github` are not modules.
+ *
+ * Read by BOTH surfaces that offer sharing — the install wizard's opt-in and the
+ * Settings → Bots toggle — rather than mirrored onto a second member of
+ * `WebBotSettingsFragments`. Two declarations of one platform fact can
+ * disagree, and there is no state in which they legitimately would: the CP
+ * refuses a multi-agent install and a `shareable: true` PATCH on exactly the
+ * platforms that do not declare it here.
+ */
+export function platformSupportsSharing(platformId?: string): boolean {
+  return (platformId ? platformRegistry.get(platformId)?.wizard.affordances.share : undefined) === true
+}
+
+/**
+ * Whether the Settings → Bots Sharable toggle may be OPERATED for this bot —
+ * the platform half of its `disabled` predicate (the viewer's write access and
+ * the in-flight PATCH stay the card's own).
+ *
+ * Both server preconditions, in the order the CP checks them
+ * (`http/routes/bots.ts`): the platform must support multi-agent bots, and the
+ * bot must be on the http transport (immutable post-create — a socket bot can
+ * never be shared). Gating on transport ALONE is what let a Feishu HTTP bot
+ * present a live toggle for a capability the CP refuses.
+ *
+ * The `shareable` escape hatch is deliberate rather than defensive: while the
+ * toggle was transport-gated only, the PATCH accepted the flip, so rows on a
+ * non-sharing platform may already carry `shareable: true`. The CP still honors
+ * turning those OFF, so the console must keep the control that does it.
+ */
+export function botSharingEditable(bot: Pick<BotDto, 'platform' | 'transport' | 'shareable'>): boolean {
+  if (bot.shareable) return true
+  return platformSupportsSharing(bot.platform) && (bot.transport ?? 'socket') === 'http'
 }
 
 /**

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -46,7 +46,7 @@ import {
   type SessionAccessProvider
 } from '@/lib/api'
 import { agentLabel, isDirectConversation, type AgentCallPolicy, type IntegrationRow } from '@/lib/data'
-import { botCardCopy, platformRegistry } from '@/components/console/platforms/registry'
+import { botCardCopy, botSharingEditable, platformRegistry } from '@/components/console/platforms/registry'
 import { consoleKeys } from '@/lib/swr-keys'
 import { inviteLinkStatus, inviteLinkUrl } from '@/lib/org-invite-link'
 import EditMemberModal, { type MemberTarget } from '@/components/console/modals/EditMemberModal'
@@ -1098,7 +1098,10 @@ function BotsCard({
                 </div>
                 {/* The host picks the arm by transport; the module owns both
                     sentences. A platform that declares none gets one sentence for
-                    both arms — its transport is not why sharing is unavailable. */}
+                    both arms — its transport is not why sharing is unavailable.
+                    Enablement asks the same question the CP does
+                    (`botSharingEditable`): transport ALONE left Feishu's HTTP bots
+                    with a live toggle for a capability the server refuses. */}
                 <span
                   className="flex items-center justify-self-start"
                   title={
@@ -1108,7 +1111,7 @@ function BotsCard({
                 >
                   <Toggle
                     checked={b.shareable}
-                    disabled={!canWrite || botBusyId === b.id || (b.transport ?? 'socket') === 'socket'}
+                    disabled={!canWrite || botBusyId === b.id || !botSharingEditable(b)}
                     onChange={(next) => void flipShareable(b, next)}
                   />
                 </span>


### PR DESCRIPTION
Follow-up to #616, which fixed the misleading *tooltip* for this case and deliberately left the enablement alone.

## The defect

Settings → Bots enabled the Sharable toggle purely by transport:

```
disabled={!canWrite || botBusyId === b.id || (b.transport ?? 'socket') === 'socket'}
```

But multi-agent bots are Slack-only at the control plane — `validateShareableInstall` refuses every other platform with `multi-agent bots currently support Slack only`. Feishu is the one non-Slack platform whose bots can be `transport: 'http'` (its wizard declares a transport affordance of its own), so a Feishu HTTP bot presented a fully clickable toggle for a capability the server will not honor. `PATCH /bots/:id` gated only on transport as well, so the flip itself appeared to succeed; installing a second agent on the bot then failed.

## Web — one declaration, two readers

`platformSupportsSharing(platformId)` reads the §5 `multiAgentShareable` fact from the one place a module declares it, `wizard.affordances.share`. Both surfaces that offer sharing now route through it: the wizard's shared opt-in (`AddIntegrationModal`) and the Settings toggle, via `botSharingEditable(bot)` — platform support **and** the http transport, the same pair the CP checks.

Read rather than mirrored onto a new `WebBotSettingsFragments` member: two declarations of one platform fact can disagree about a platform, and there is no state where they legitimately would. `WebWizardAffordances.share`'s doc now says it is nested under `wizard` for where it is *declared*, not for where it may be read.

`botSharingEditable` keeps an already-shared row editable. That is not defensive: while the toggle was transport-gated only, the PATCH accepted the flip, so rows on a non-sharing platform may already carry `shareable: true`, and the CP still honors turning those off.

## Control plane — refuse it at the source too

The Slack-only rule becomes `platforms/sharing.ts` (`supportsMultiAgentBots` + the one refusal string), read by both routes that had drifted. `PATCH /bots/:id` now refuses `shareable: true` on a platform without multi-agent bots:

- **before the transport check**, so a Feishu *socket* bot is no longer told to "recreate the bot in HTTP mode" — advice that would not have helped;
- **before the mutation lease**, since `platform` is immutable and a locked re-read tells us nothing more;
- **409, not the create route's 400** — there the platform is the client's assertion in the request body, here it is the stored row's, exactly like the transport refusal it sits beside;
- **enable direction only**, so the repair path above keeps working.

Core-owned rather than a `CpPlatformProvider` member: `multiAgentShareable` is one of the §5 manifest values the provider contract deliberately excludes (D2). When that manifest lands in protocol, this predicate is what it replaces.

## Tests

- `packages/web/src/components/console/platforms/bot-sharing.test.ts` — the fact and the row predicate: Slack only, total over unclaimed ids, socket refused everywhere, the Feishu HTTP case, the already-shared escape hatch, and a bridge to #616's copy contract (no platform both refuses sharing and offers two different share sentences).
- `packages/control-plane/src/platforms/sharing.test.ts` — the predicate against the **shipped provider registry**, so a platform added to the composition without a decision here fails.
- `packages/control-plane/test/integration/integrations.route.test.ts` — five route claims: the PATCH refusal, its ordering vs the transport message, the disable-still-works repair, Slack unaffected in both transports, and the create path's half of the same rule.

Both refusal tests were confirmed to fail with the guard removed (web: 2 failures; CP: 2 failures, and the Feishu flip returns 200 — the reported bug).

## Verification

- `pnpm --filter @agentconnect.md/web exec tsc -p tsconfig.json --noEmit` — clean
- `GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/web test` — 110 files / 857 tests pass
- `pnpm --filter @agentconnect.md/control-plane typecheck` — clean
- `GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/control-plane test:unit` — 129 files / 1200 tests pass
- `GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/control-plane test:int` — 70 files / 962 tests pass
- `pnpm lint`, `pnpm format:check` — clean
- Browser (mock mode, one mock Feishu bot temporarily set to `transport: 'http'`, reverted): the Feishu row's toggle renders `disabled` under "Sharing one bot across several agents isn't available on this platform"; the Slack tab is unchanged — socket bot disabled under "HTTP transport required to share", HTTP bot enabled under "Allow several agents to share this bot across channels".

🤖 Generated with [Claude Code](https://claude.com/claude-code)