### PR TITLE
fix(dream): preserve per-file memory mtime across adoption for unchanged files

### DIFF
--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -897,6 +897,21 @@ export class DreamRunner {
           }
           await fsp.writeFile(join(replacement, MEMORY_HISTORY_FILENAME), history, { encoding: 'utf8', mode: 0o600 })
 
+          // Preserve the "last meaningfully changed" time of files the dream left
+          // byte-for-byte unchanged. The whole store is rebuilt into `replacement`
+          // and swapped in, so without this EVERY topic would show the adoption
+          // time as its updated time even when the dream didn't touch it. Files
+          // whose content actually changed (or are new) keep the fresh mtime.
+          for (const [path, after] of afterByPath) {
+            if (beforeByPath.get(path) !== after) continue
+            try {
+              const liveStat = await fsp.stat(join(live, path))
+              await fsp.utimes(join(replacement, path), liveStat.atime, liveStat.mtime)
+            } catch {
+              // Live file gone or unstattable — leave the fresh adoption mtime.
+            }
+          }
+
           const backupsRoot = join(dir, BACKUPS_DIRNAME)
           await fsp.mkdir(backupsRoot, { recursive: true })
           const backup = join(backupsRoot, `${at.replace(/[:.]/g, '-')}-pre-${dreamId}`)

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, stat, utimes, writeFile } from 'node:fs/promises'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -471,6 +471,42 @@ describe('DreamRunner adoption', () => {
     const history = await readFile(join(memoryDir(dir), MEMORY_HISTORY_FILENAME), 'utf8')
     expect(history).toContain('"source":"dream"')
     expect(history).toContain('"source":"tool"') // pre-adoption rows preserved
+  })
+
+  it('preserves the mtime of files the dream left unchanged, refreshing only changed ones', async () => {
+    // A dream rebuilds the whole store and swaps it in, so without care every
+    // file would show the adoption time. Only files whose content actually
+    // changed should get a fresh updated-time.
+    const { dir, store, runner } = await setup({
+      extract: async () =>
+        JSON.stringify({
+          index: '# Memory\n- [keep](keep.md)\n- [prefs](prefs.md)',
+          files: [
+            { path: 'keep.md', content: 'unchanged body' },
+            { path: 'prefs.md', content: 'changed by the dream' }
+          ]
+        })
+    })
+    const started = await runner.start('a1', { trigger: 'manual' })
+    await settle(store, started.dreamId)
+
+    // Seed a live keep.md byte-identical to what the dream staged, and backdate
+    // every current file so "fresh" is unambiguous. Adopt with force since this
+    // live edit intentionally drifts from the dream's start snapshot.
+    const out = join(dir, 'memory-dreams', started.dreamId, 'output')
+    const stagedKeep = await readFile(join(out, 'keep.md'), 'utf8')
+    await writeMemoryFile(dir, 'keep.md', stagedKeep, undefined, 'tool')
+    const OLD = new Date('2020-01-01T00:00:00.000Z')
+    for (const name of ['keep.md', 'prefs.md', MEMORY_INDEX]) {
+      await utimes(join(memoryDir(dir), name), OLD, OLD).catch(() => {})
+    }
+
+    const adopted = await runner.adopt('a1', started.dreamId, true)
+    expect(adopted.status).toBe('adopted')
+
+    // keep.md was byte-identical → its old mtime survives; prefs.md changed → fresh.
+    expect((await stat(join(memoryDir(dir), 'keep.md'))).mtime.getTime()).toBe(OLD.getTime())
+    expect((await stat(join(memoryDir(dir), 'prefs.md'))).mtime.getTime()).toBeGreaterThan(OLD.getTime())
   })
 
   it('binds adoption to the reviewed staged bytes (same-bytes review fence)', async () => {


### PR DESCRIPTION
## Problem

On the agent memory page every file showed the **same** "updated" time. The page renders each file's on-disk mtime (correct), but dream **adoption** rebuilds the whole store into a replacement directory and swaps it in — so even byte-identical, untouched topic files received the adoption-instant mtime, erasing each file's real "last meaningfully changed" time.

(The `writeMemory` tool path is unaffected: it writes a temp file then renames it over the target, so a single edited file gets its own fresh mtime.)

## Fix

Under the adoption lock — right after the add/update/delete change-set is computed — restore the current live file's mtime onto any replacement file whose content is byte-identical to it. Files that actually changed (or are new) keep the fresh adoption mtime; deleted files are gone.

## Test

`preserves the mtime of files the dream left unchanged, refreshing only changed ones`: seeds a live file byte-identical to the staged one, backdates mtimes, adopts, and asserts the unchanged file keeps its old mtime while a changed file is refreshed.

## Verification

- daemon typecheck + eslint clean; dream-runner suite 63 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)