### PR TITLE
feat(auth): link without a code when the provider allows it

### DIFF
--- a/packages/control-plane/src/github/logto-identity.ts
+++ b/packages/control-plane/src/github/logto-identity.ts
@@ -78,6 +78,10 @@ const NEGATIVE_TTL_MS = 60_000
 // this hard lease.
 const PROVIDER_IDENTITY_TTL_MS = 120_000
 const TIMEOUT_MS = 10_000
+// How long a target's link mode is trusted. Short enough that a Logto upgrade
+// which fixes a connector is picked up the same day, long enough that the probe
+// is not per click.
+const LINK_MODE_TTL_MS = 60 * 60_000
 
 interface CachedLogin {
   login: string | null
@@ -177,6 +181,31 @@ interface LogtoUser {
   >
 }
 
+/**
+ * How a link must be driven for one provider.
+ *
+ *  - `direct`  — Logto built the authorization URI for us, so the whole link
+ *    runs server-side on the Management API. Nothing needs the end user to
+ *    re-prove anything: the M2M credential is the authority.
+ *  - `verified` — that connector cannot be driven without a session (it stores
+ *    state while building the URI), so the browser must drive it against the
+ *    Account API, where the user's own token is the authority and Logto demands
+ *    an ownership proof.
+ *
+ * Decided by ASKING Logto rather than from a list of provider names: Logto's
+ * own published list omitted Slack, and a wrong guess here is the 502 that
+ * linking Slack used to be.
+ */
+export type SocialLinkMode = 'direct' | 'verified'
+
+export type SocialAuthorization =
+  { mode: 'direct'; connectorId: string; authorizationUri: string } | { mode: 'verified'; connectorId: string }
+
+interface CachedLinkMode {
+  mode: SocialLinkMode
+  expiresAt: number
+}
+
 export class LogtoIdentityService {
   private token?: { value: string; expiresAt: number }
   private tokenInFlight?: Promise<string>
@@ -186,6 +215,9 @@ export class LogtoIdentityService {
   // fetch rather than one per projection. Kept separate from the login cache on
   // purpose: githubLoginFor sits on a live authorization gate, and display reads
   // must not be able to shift what that gate sees (or when it re-asks).
+  // Which way each target must be linked. Cached because the answer is a
+  // property of the connector, not of the user, and probing costs a round trip.
+  private readonly linkModes = new Map<string, CachedLinkMode>()
   private readonly users = new Map<string, CachedUser>()
   private readonly userInFlight = new Map<string, Promise<LogtoUser | null>>()
   // Invalidation fence. `slackIdentityFor` feeds an authorization decision
@@ -332,6 +364,54 @@ export class LogtoIdentityService {
       connector && typeof (connector as { id?: unknown }).id === 'string' ? (connector as { id: string }).id : undefined
     if (!connectorId) throw new LogtoApiError('social connector not found', 404, false)
     return connectorId
+  }
+
+  /**
+   * Start a link: resolve the connector, then find out whether Logto will build
+   * its authorization URI for us.
+   *
+   * A failure here is NOT reported as one. Every connector that cannot be
+   * driven server-side is still linkable through the browser, so the answer to
+   * "Logto refused" is `verified` — the caller falls back and the user gets a
+   * working link, just with an ownership check in front of it.
+   */
+  async socialAuthorizationFor(target: string, redirectUri: string, state: string): Promise<SocialAuthorization> {
+    const connectorId = await this.socialConnectorIdFor(target)
+    const cached = this.linkModes.get(target)
+    if (cached && cached.expiresAt > this.clock.now() && cached.mode === 'verified') {
+      return { mode: 'verified', connectorId }
+    }
+
+    let authorizationUri: string | undefined
+    try {
+      const res = await this.request(`/api/connectors/${encodeURIComponent(connectorId)}/authorization-uri`, {
+        method: 'POST',
+        body: JSON.stringify({ redirectUri, state })
+      })
+      if (res.ok) {
+        const body = (await res.json()) as { redirectTo?: unknown }
+        if (typeof body.redirectTo === 'string' && body.redirectTo.length > 0) authorizationUri = body.redirectTo
+      }
+    } catch {
+      // Unreachable upstream is indistinguishable from an unsupported connector
+      // here, and both have the same safe answer: drive it from the browser.
+    }
+
+    const mode: SocialLinkMode = authorizationUri ? 'direct' : 'verified'
+    this.linkModes.set(target, { mode, expiresAt: this.clock.now() + LINK_MODE_TTL_MS })
+    return authorizationUri ? { mode: 'direct', connectorId, authorizationUri } : { mode: 'verified', connectorId }
+  }
+
+  /** Link the provider identity proved by `connectorData`, server-side. Only
+   *  valid for a target that answered `direct`; a session-bound connector fails
+   *  here for the same reason it could not build its URI. */
+  async linkSocialIdentity(sub: string, connectorId: string, connectorData: Record<string, string>): Promise<void> {
+    const res = await this.request(`/api/users/${encodeURIComponent(sub)}/identities`, {
+      method: 'POST',
+      body: JSON.stringify({ connectorId, connectorData })
+    })
+    if (!res.ok) throw await this.responseError('logto social identity link', res)
+    this.invalidate(sub)
   }
 
   /** Remove one provider identity from this Logto user. */

--- a/packages/control-plane/src/github/slack-identity.test.ts
+++ b/packages/control-plane/src/github/slack-identity.test.ts
@@ -401,3 +401,66 @@ describe('LogtoIdentityService cache freshness after an external link', () => {
     expect(calls.user).toBe(2)
   })
 })
+
+describe('LogtoIdentityService.socialAuthorizationFor', () => {
+  /** Logto with a connector per target; `sessionBound` ones fail to build a URI
+   *  exactly as Slack's does (the connector calls setSession, Logto 500s). */
+  function fakeConnectors(sessionBound: string[]) {
+    const calls = { authorize: 0 }
+    const fetchImpl: FetchImpl = async (url, init) => {
+      if (url.endsWith('/oidc/token')) return Response.json({ access_token: 'tok', expires_in: 3600 })
+      const target = /target=([a-z]+)/.exec(url)?.[1]
+      if (target) return Response.json([{ id: `${target}-connector`, target, type: 'Social' }])
+      if (url.endsWith('/authorization-uri')) {
+        calls.authorize++
+        const connector = /connectors\/([a-z]+)-connector/.exec(url)?.[1] ?? ''
+        if (sessionBound.includes(connector)) return new Response('boom', { status: 500 })
+        return Response.json({ redirectTo: `https://${connector}.example.test/authorize` })
+      }
+      void init
+      return Response.json({})
+    }
+    return { fetchImpl, calls }
+  }
+
+  it('drives a session-free connector server-side, sparing the user a code', async () => {
+    const { fetchImpl } = fakeConnectors([])
+    const svc = svcOf(fetchImpl)
+    await expect(svc.socialAuthorizationFor('google', 'https://app.example.test/cb', 's')).resolves.toEqual({
+      mode: 'direct',
+      connectorId: 'google-connector',
+      authorizationUri: 'https://google.example.test/authorize'
+    })
+  })
+
+  it('falls back to the browser for a connector Logto cannot build a URI for', async () => {
+    // The failure is NOT surfaced as one: Slack is still linkable, just the
+    // other way. Reporting an error here is what the 502 bug used to do.
+    const { fetchImpl } = fakeConnectors(['slack'])
+    const svc = svcOf(fetchImpl)
+    await expect(svc.socialAuthorizationFor('slack', 'https://app.example.test/cb', 's')).resolves.toEqual({
+      mode: 'verified',
+      connectorId: 'slack-connector'
+    })
+  })
+
+  it('remembers that a connector needs the browser, instead of probing per click', async () => {
+    const { fetchImpl, calls } = fakeConnectors(['slack'])
+    const svc = svcOf(fetchImpl)
+
+    await svc.socialAuthorizationFor('slack', 'https://app.example.test/cb', 's')
+    await svc.socialAuthorizationFor('slack', 'https://app.example.test/cb', 's')
+    expect(calls.authorize).toBe(1)
+  })
+
+  it('keeps re-asking for a connector that works, so its URI is never stale', async () => {
+    // `direct` is not cached as a shortcut: each link needs its OWN state and
+    // redirect in the URI, so the round trip is the point, not overhead.
+    const { fetchImpl, calls } = fakeConnectors([])
+    const svc = svcOf(fetchImpl)
+
+    await svc.socialAuthorizationFor('google', 'https://app.example.test/cb', 's1')
+    await svc.socialAuthorizationFor('google', 'https://app.example.test/cb', 's2')
+    expect(calls.authorize).toBe(2)
+  })
+})

--- a/packages/control-plane/src/http/routes/me-social-identities.test.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.test.ts
@@ -9,6 +9,7 @@ describe('my social identities routes', () => {
   it('resolves a connector id and unlinks under the OIDC subject', async () => {
     const identity = {
       socialConnectorIdFor: vi.fn(async () => 'google-connector'),
+      linkSocialIdentity: vi.fn(async () => undefined),
       unlinkSocialIdentity: vi.fn(async () => undefined)
     }
     const deps = {
@@ -28,14 +29,22 @@ describe('my social identities routes', () => {
       expect(connector.json()).toEqual({ connectorId: 'google-connector' })
       expect(identity.socialConnectorIdFor).toHaveBeenCalledWith('google')
 
-      // Linking is not a CP operation any more: the browser drives it against
-      // the Account API, which is the only side with a connector session.
-      const removedLinkRoute = await app.inject({
+      // The `direct` link runs server-side, and the callback URI comes from
+      // config — never from the caller, who could otherwise point the provider
+      // response somewhere else.
+      const linked = await app.inject({
         method: 'POST',
         url: '/me/social-identities',
-        payload: { connectorId: 'google-connector', connectorData: { code: 'c' } }
+        payload: {
+          connectorId: 'google-connector',
+          connectorData: { code: 'c', redirectUri: 'https://attacker.example.test/callback' }
+        }
       })
-      expect(removedLinkRoute.statusCode).toBe(404)
+      expect(linked.statusCode).toBe(200)
+      expect(identity.linkSocialIdentity).toHaveBeenCalledWith('logto-user', 'google-connector', {
+        code: 'c',
+        redirectUri: 'https://app.example.test/auth/social/callback'
+      })
 
       const unlinked = await app.inject({ method: 'DELETE', url: '/me/social-identities/google' })
       expect(unlinked.statusCode).toBe(204)

--- a/packages/control-plane/src/http/routes/me-social-identities.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.ts
@@ -20,6 +20,7 @@
  */
 import type { FastifyInstance, FastifyReply } from 'fastify'
 import { z } from 'zod'
+import { resolveWebAppUrl } from '../../config/env.js'
 import { LogtoApiError } from '../../github/logto-identity.js'
 import type { HttpDeps } from '../deps.js'
 import { ErrorDto } from '../dto/index.js'
@@ -28,6 +29,19 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 
 const ConnectorId = z.string().trim().min(1).max(128)
 const ConnectorDto = z.object({ connectorId: ConnectorId })
+const State = z.string().min(32).max(256)
+const ConnectorData = z
+  .record(z.string().max(64), z.string().max(4096))
+  .refine((value) => Object.keys(value).length <= 32, 'too many connector response fields')
+
+/** `direct` carries the URI Logto built; `verified` says the browser has to
+ *  drive this connector itself, and hands it the id it needs to do so. */
+const AuthorizationDto = z.discriminatedUnion('mode', [
+  z.object({ mode: z.literal('direct'), connectorId: ConnectorId, authorizationUri: z.url() }),
+  z.object({ mode: z.literal('verified'), connectorId: ConnectorId })
+])
+const LinkBody = z.object({ connectorId: ConnectorId, connectorData: ConnectorData }).strict()
+const LinkDto = z.object({ linked: z.literal(true) })
 /** Unlink takes any stored target, including one this deployment has since
  *  stopped offering — you must always be able to remove what you linked. */
 const TargetParam = z.object({ target: z.string().trim().min(1).max(128) })
@@ -81,7 +95,12 @@ const SocialAccountDto = z.object({
 
 // No 'link': that runs in the browser against the Account API, so its provider
 // errors (422 "already in use" and friends) are mapped there, not here.
-type Operation = 'authorize' | 'unlink' | 'read'
+type Operation = 'authorize' | 'link' | 'unlink' | 'read'
+
+function socialCallbackUrl(deps: HttpDeps): string | undefined {
+  const webUrl = resolveWebAppUrl(deps.config)
+  return webUrl ? new URL('/auth/social/callback', webUrl).toString() : undefined
+}
 
 function logtoFailure(reply: FastifyReply, error: unknown, operation: Operation) {
   if (!(error instanceof LogtoApiError)) throw error
@@ -146,6 +165,7 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
       .max(64)
       .regex(/^[a-z0-9_-]+$/, 'not a connector target')
     const TargetParamStrict = z.object({ target: SocialTarget })
+    const AuthorizationBody = z.object({ target: SocialTarget, state: State }).strict()
     const unavailable = {
       error: 'Service Unavailable',
       statusCode: 503,
@@ -173,6 +193,77 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
         if (!identity) return reply.code(503).send(unavailable)
         identity.forgetUser(req.oidcSubject!)
         return reply.code(204).send(null)
+      }
+    )
+
+    // Where a link begins. The reply says which of the two ways this provider
+    // has to be linked; the console does not decide, and does not keep a list.
+    r.post(
+      '/me/social-identities/authorization-uri',
+      {
+        preHandler: app.oidcAuth,
+        schema: {
+          tags: [Tag.Profile],
+          summary: 'Start linking a social sign-in method',
+          description:
+            'Resolve the provider and report how it must be linked. `direct` returns an authorization URI Logto built, and the link completes server-side. `verified` means the connector cannot be driven without a session, so the browser drives it against the Account API and Logto requires an ownership proof.',
+          operationId: 'createMySocialIdentityAuthorization',
+          body: AuthorizationBody,
+          response: { 200: AuthorizationDto, 400: ErrorDto, 404: ErrorDto, 429: ErrorDto, 502: ErrorDto, 503: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const identity = deps.logtoIdentity
+        const redirectUri = socialCallbackUrl(deps)
+        if (!identity || !redirectUri) return reply.code(503).send(unavailable)
+        try {
+          return await identity.socialAuthorizationFor(req.body.target, redirectUri, req.body.state)
+        } catch (error) {
+          return logtoFailure(reply, error, 'authorize')
+        }
+      }
+    )
+
+    // The `direct` half of the link. Deliberately no ownership proof: the M2M
+    // credential is the authority on this path, which is the whole reason it
+    // spares the user a code.
+    r.post(
+      '/me/social-identities',
+      {
+        preHandler: app.oidcAuth,
+        schema: {
+          tags: [Tag.Profile],
+          summary: 'Link a social sign-in method',
+          description:
+            'Link the identity the provider just authenticated to the signed-in user. Only for providers that reported `direct`; existing accounts are not merged.',
+          operationId: 'linkMySocialIdentity',
+          body: LinkBody,
+          response: {
+            200: LinkDto,
+            400: ErrorDto,
+            404: ErrorDto,
+            409: ErrorDto,
+            429: ErrorDto,
+            502: ErrorDto,
+            503: ErrorDto
+          }
+        }
+      },
+      async (req, reply) => {
+        const identity = deps.logtoIdentity
+        const redirectUri = socialCallbackUrl(deps)
+        if (!identity || !redirectUri) return reply.code(503).send(unavailable)
+        try {
+          // redirectUri last: Logto exchanges the code against the URI it
+          // authorized with, and only the server knows that one.
+          await identity.linkSocialIdentity(req.oidcSubject!, req.body.connectorId, {
+            ...req.body.connectorData,
+            redirectUri
+          })
+          return { linked: true as const }
+        } catch (error) {
+          return logtoFailure(reply, error, 'link')
+        }
       }
     )
 

--- a/packages/web/src/app/auth/social/callback/page.tsx
+++ b/packages/web/src/app/auth/social/callback/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui'
 import { Spinner } from '@/components/marks'
-import { refreshMySocialIdentities } from '@/lib/api'
+import { linkMySocialIdentity, refreshMySocialIdentities } from '@/lib/api'
 import { forgetOwnershipProof } from '@/lib/ownership-proof'
 import {
   LogtoAccountError,
@@ -47,10 +47,24 @@ export default function SocialAccountCallback() {
       return
     }
 
+    const providerResponse = Object.fromEntries(params.entries())
+
+    // `direct`: the CP owns both legs, so hand it the provider's response and
+    // let it finish. Nothing here needs an ownership proof.
+    if (flow.mode === 'direct') {
+      linkMySocialIdentity(flow.connectorId, providerResponse)
+        .then(() => refreshMySocialIdentities().catch(() => undefined))
+        .then(() => window.location.replace(flow.returnTo))
+        .catch((caught) => {
+          setError(accountErrorMessage(caught, { providerName: flow.providerName, operation: 'link' }))
+        })
+      return
+    }
+
     // Logto exchanges the provider code against the exact URI it authorized
     // with, so echo it back alongside the provider's own response params.
-    const connectorData = { ...Object.fromEntries(params.entries()), redirectUri: flow.redirectUri }
-    verifySocialVerification(flow.verificationRecordId, connectorData)
+    const connectorData = { ...providerResponse, redirectUri: flow.redirectUri! }
+    verifySocialVerification(flow.verificationRecordId!, connectorData)
       .then((verified) =>
         (flow.purpose === 'reauthorize' && flow.target
           ? renewSocialIdentityToken(flow.target, verified)

--- a/packages/web/src/components/console/SocialSignInCard.test.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.test.tsx
@@ -13,7 +13,9 @@ const mocks = vi.hoisted(() => ({
 // or the import itself throws before render.
 vi.mock('@/lib/api', () => ({
   fetchMySocialAccount: vi.fn(),
+  createMySocialIdentityAuthorization: vi.fn(),
   resolveMySocialConnectorId: vi.fn(),
+  linkMySocialIdentity: vi.fn(),
   unlinkMySocialIdentity: vi.fn()
 }))
 
@@ -30,7 +32,7 @@ vi.mock('@/lib/logto-account', async (importOriginal) => {
 
 import SocialSignInCard from './SocialSignInCard'
 import { LogtoAccountError } from '@/lib/logto-account'
-import { fetchMySocialAccount, resolveMySocialConnectorId } from '@/lib/api'
+import { createMySocialIdentityAuthorization, fetchMySocialAccount, resolveMySocialConnectorId } from '@/lib/api'
 
 const ACCOUNT_KEY = 'logto-account-sign-in-methods'
 let root: Root | undefined
@@ -100,6 +102,10 @@ beforeEach(() => {
   mocks.requestEmailVerification.mockReset()
   vi.mocked(resolveMySocialConnectorId).mockReset()
   vi.mocked(resolveMySocialConnectorId).mockResolvedValue({ connectorId: 'connector' })
+  vi.mocked(createMySocialIdentityAuthorization).mockReset()
+  // Default to the path that needs the browser, so the existing expectations
+  // about the code dialog keep describing that path.
+  vi.mocked(createMySocialIdentityAuthorization).mockResolvedValue({ mode: 'verified', connectorId: 'connector' })
 })
 
 afterEach(async () => {
@@ -211,9 +217,10 @@ describe('SocialSignInCard account state', () => {
     await waitUntil(() => container?.textContent?.includes('Not linked') === true)
 
     await act(async () => button('Link')?.click())
+    await waitUntil(() => vi.mocked(createMySocialIdentityAuthorization).mock.calls.length === 1)
 
     expect(container?.querySelector('[role="dialog"]')).toBeNull()
-    expect(resolveMySocialConnectorId).toHaveBeenCalled()
+    expect(createMySocialIdentityAuthorization).toHaveBeenCalled()
   })
 
   it('continues a verified install through linking only when GitHub is unlinked', async () => {
@@ -221,7 +228,7 @@ describe('SocialSignInCard account state', () => {
     const onAutoAuthorizeHandled = vi.fn()
 
     await renderCard({ autoAuthorize: { target: 'github', purpose: 'link' }, onAutoAuthorizeHandled })
-    await waitUntil(() => vi.mocked(resolveMySocialConnectorId).mock.calls.length === 1)
+    await waitUntil(() => vi.mocked(createMySocialIdentityAuthorization).mock.calls.length === 1)
 
     expect(onAutoAuthorizeHandled).toHaveBeenCalledOnce()
   })
@@ -236,7 +243,7 @@ describe('SocialSignInCard account state', () => {
     await renderCard({ autoAuthorize: { target: 'github', purpose: 'link' }, onAutoAuthorizeHandled })
     await waitUntil(() => onAutoAuthorizeHandled.mock.calls.length === 1)
 
-    expect(resolveMySocialConnectorId).not.toHaveBeenCalled()
+    expect(createMySocialIdentityAuthorization).not.toHaveBeenCalled()
   })
 
   it('skips the code dialog for a second link while the ownership proof is fresh', async () => {
@@ -255,8 +262,34 @@ describe('SocialSignInCard account state', () => {
     await waitUntil(() => container?.textContent?.includes('Not linked') === true)
 
     await act(async () => button('Link')?.click())
+    await waitUntil(() => vi.mocked(createMySocialIdentityAuthorization).mock.calls.length === 1)
 
     expect(container?.querySelector('[role="dialog"]')).toBeNull()
-    expect(resolveMySocialConnectorId).toHaveBeenCalled()
+  })
+
+  it('asks for no code at all when the CP can complete the link itself', async () => {
+    // The account HAS a security verification method — under the browser-driven
+    // path that alone forces a code. It must not here: the CP finishes this
+    // link on its own credential, so there is nothing for the user to re-prove.
+    vi.mocked(fetchMySocialAccount).mockResolvedValue({
+      identities: [],
+      hasSecurityVerificationMethod: true,
+      primaryEmail: 'phil@example.test'
+    })
+    vi.mocked(createMySocialIdentityAuthorization).mockResolvedValue({
+      mode: 'direct',
+      connectorId: 'google-connector',
+      authorizationUri: 'https://accounts.example.test/authorize'
+    })
+
+    await renderCard()
+    await waitUntil(() => container?.textContent?.includes('Not linked') === true)
+
+    await act(async () => button('Link')?.click())
+    await waitUntil(() => vi.mocked(createMySocialIdentityAuthorization).mock.calls.length === 1)
+
+    expect(container?.querySelector('[role="dialog"]')).toBeNull()
+    // No Account API detour either — the CP owns both legs on this path.
+    expect(resolveMySocialConnectorId).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -7,6 +7,7 @@ import { SocialLoginMark } from '@/components/marks'
 import { initialsFrom } from '@/lib/auth'
 import {
   fetchMySocialAccount,
+  createMySocialIdentityAuthorization,
   resolveMySocialConnectorId,
   unlinkMySocialIdentity,
   type MySocialAccountDto,
@@ -20,6 +21,7 @@ import {
   requestEmailVerification,
   verifyEmailCode,
   writeSocialLinkFlow,
+  type SocialLinkFlow,
   type AccountNotice
 } from '@/lib/logto-account'
 import { rememberOwnershipProof, reusableOwnershipProof } from '@/lib/ownership-proof'
@@ -307,7 +309,7 @@ export default function SocialSignInCard({
     shouldRetryOnError: false
   })
   const [pendingUnlink, setPendingUnlink] = useState<SocialLoginProvider>()
-  const [pendingVerify, setPendingVerify] = useState<SocialLoginProvider>()
+  const [pendingVerify, setPendingVerify] = useState<{ provider: SocialLoginProvider; connectorId: string }>()
   const [busyProvider, setBusyProvider] = useState<SocialLoginProvider['target']>()
   const handledAutoAuthorize = useRef<string | undefined>(undefined)
   const currentAccount = error ? undefined : account
@@ -315,56 +317,88 @@ export default function SocialSignInCard({
     ? socialLoginProviders().filter((provider) => byTarget(currentAccount, provider.target)).length
     : 0
 
-  // Logto refuses an identity change the caller has not re-proven, so accounts
-  // with a security verification method take the code detour first.
-  const beginLink = (provider: SocialLoginProvider) => {
-    if (currentAccount?.hasSecurityVerificationMethod) {
-      // One code covers every link in its window, so a second provider in the
-      // same sitting reuses the proof instead of asking again.
-      const proof = reusableOwnershipProof()
-      if (proof) {
-        void startAuthorization(provider, 'link', proof)
+  /**
+   * Ask the CP how this provider links, then follow the answer.
+   *
+   * Only the `verified` path needs an ownership code, and which providers those
+   * are is not knowable here — Logto's own published list omitted Slack. So the
+   * console keeps no list: it does what the CP reports.
+   */
+  const beginLink = async (provider: SocialLoginProvider) => {
+    setBusyProvider(provider.target)
+    try {
+      const state = createSocialState()
+      const authorization = await createMySocialIdentityAuthorization(provider.target, state)
+      if (authorization.mode === 'direct') {
+        // The CP finishes this one, so there is nothing to prove and no code.
+        redirectToProvider(provider, authorization.authorizationUri, {
+          purpose: 'link',
+          target: provider.target,
+          state,
+          connectorId: authorization.connectorId,
+          mode: 'direct'
+        })
         return
       }
-      setPendingVerify(provider)
-      return
+      const proof = currentAccount?.hasSecurityVerificationMethod ? reusableOwnershipProof() : undefined
+      if (currentAccount?.hasSecurityVerificationMethod && !proof) {
+        setPendingVerify({ provider, connectorId: authorization.connectorId })
+        setBusyProvider(undefined)
+        return
+      }
+      await startAuthorization(provider, 'link', authorization.connectorId, proof)
+    } catch (caught) {
+      onNotice({ message: accountErrorMessage(caught, { providerName: provider.name, operation: 'link' }) })
+      setBusyProvider(undefined)
     }
-    void startAuthorization(provider, 'link')
+  }
+
+  /** Park what the callback will need, then leave for the provider. */
+  const redirectToProvider = (
+    provider: SocialLoginProvider,
+    authorizationUri: string,
+    flow: Omit<SocialLinkFlow, 'providerName' | 'returnTo' | 'createdAt'>
+  ) => {
+    const stored = writeSocialLinkFlow({
+      ...flow,
+      providerName: provider.name,
+      returnTo: `${window.location.pathname}${window.location.search}`,
+      createdAt: Date.now()
+    })
+    if (!stored) {
+      throw new LogtoAccountError('This browser blocked the temporary account-linking state.', 0)
+    }
+    window.location.assign(authorizationUri)
   }
 
   const beginReauthorize = (provider: SocialLoginProvider) => {
     void startAuthorization(provider, 'reauthorize')
   }
 
+  /** The browser-driven half: Logto's Account API is the side with a connector
+   *  session, so this is the only way a session-bound provider can be linked. */
   const startAuthorization = async (
     provider: SocialLoginProvider,
     purpose: 'link' | 'reauthorize',
+    knownConnectorId?: string,
     currentVerificationRecordId?: string
   ) => {
     setBusyProvider(provider.target)
     try {
       const state = createSocialState()
-      // Two hops on purpose: only the CP can name the connector, and only the
-      // browser can authorize it (the Account API is the side with a session).
-      const { connectorId } = await resolveMySocialConnectorId(provider.target)
+      const connectorId = knownConnectorId ?? (await resolveMySocialConnectorId(provider.target)).connectorId
       const redirectUri = `${window.location.origin}/auth/social/callback`
       const { authorizationUri, verificationRecordId } = await createSocialVerification(connectorId, redirectUri, state)
-      const stored = writeSocialLinkFlow({
+      redirectToProvider(provider, authorizationUri, {
         purpose,
         target: provider.target,
         state,
         connectorId,
+        mode: 'verified',
         verificationRecordId,
         redirectUri,
-        ...(currentVerificationRecordId ? { currentVerificationRecordId } : {}),
-        providerName: provider.name,
-        returnTo: `${window.location.pathname}${window.location.search}`,
-        createdAt: Date.now()
+        ...(currentVerificationRecordId ? { currentVerificationRecordId } : {})
       })
-      if (!stored) {
-        throw new LogtoAccountError('This browser blocked the temporary account-linking state.', 0)
-      }
-      window.location.assign(authorizationUri)
     } catch (caught) {
       onNotice({
         message: accountErrorMessage(caught, { providerName: provider.name, operation: purpose })
@@ -391,7 +425,7 @@ export default function SocialSignInCard({
     }
     const linked = byTarget(currentAccount, autoAuthorize.target)
     if (autoAuthorize.purpose === 'reauthorize' && linked) beginReauthorize(provider)
-    else if (!linked) beginLink(provider)
+    else if (!linked) void beginLink(provider)
   }, [autoAuthorize, currentAccount, onAutoAuthorizeHandled, onNotice])
 
   const unlink = async (provider: SocialLoginProvider) => {
@@ -525,7 +559,7 @@ export default function SocialSignInCard({
                         variant="secondary"
                         size="xs"
                         disabled={busyProvider !== undefined}
-                        onClick={() => beginLink(provider)}
+                        onClick={() => void beginLink(provider)}
                       >
                         <Icon name="link" size={14} />
                         {busyProvider === provider.target ? 'Linking…' : 'Link'}
@@ -550,13 +584,18 @@ export default function SocialSignInCard({
 
       {pendingVerify ? (
         <VerifyAccountDialog
-          key={pendingVerify.target}
-          provider={pendingVerify}
+          key={pendingVerify.provider.target}
+          provider={pendingVerify.provider}
           email={currentAccount?.primaryEmail}
           onVerified={async (currentVerificationRecordId, expiresAt) => {
             setPendingVerify(undefined)
             rememberOwnershipProof(currentVerificationRecordId, expiresAt)
-            await startAuthorization(pendingVerify, 'link', currentVerificationRecordId)
+            await startAuthorization(
+              pendingVerify.provider,
+              'link',
+              pendingVerify.connectorId,
+              currentVerificationRecordId
+            )
           }}
           onClose={() => setPendingVerify(undefined)}
         />

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3481,6 +3481,24 @@ export function resolveMySocialConnectorId(target: SocialLoginTarget): Promise<{
   return apiGet(`/me/social-identities/connectors/${encodeURIComponent(target)}`)
 }
 
+/** How this provider must be linked, decided by the CP asking Logto — never by
+ *  the console keeping a list of which connectors need a session. */
+export type MySocialAuthorizationDto =
+  { mode: 'direct'; connectorId: string; authorizationUri: string } | { mode: 'verified'; connectorId: string }
+
+export function createMySocialIdentityAuthorization(
+  target: SocialLoginTarget,
+  state: string
+): Promise<MySocialAuthorizationDto> {
+  return apiPost('/me/social-identities/authorization-uri', { target, state })
+}
+
+/** Complete a `direct` link server-side. No ownership proof: the CP's own
+ *  credential is the authority on this path. */
+export async function linkMySocialIdentity(connectorId: string, connectorData: Record<string, string>): Promise<void> {
+  await apiPost('/me/social-identities', { connectorId, connectorData })
+}
+
 export async function unlinkMySocialIdentity(target: string): Promise<void> {
   await apiDelete(`/me/social-identities/${encodeURIComponent(target)}`)
 }

--- a/packages/web/src/lib/logto-account.ts
+++ b/packages/web/src/lib/logto-account.ts
@@ -7,12 +7,18 @@ export interface SocialLinkFlow {
   target?: string
   state: string
   connectorId: string
+  /**
+   * Which side completes this link. `direct` means the CP does, on the
+   * Management API, where no ownership proof is required — so the fields below
+   * are absent. Flows written before this existed are `verified`.
+   */
+  mode?: 'direct' | 'verified'
   /** The Account API verification this flow is completing. The provider's
    *  response is only meaningful against the record that started it. */
-  verificationRecordId: string
+  verificationRecordId?: string
   /** Echoed back on verify: Logto exchanges the code against the SAME URI it
    *  authorized with, and the connectors that keep it in session need it too. */
-  redirectUri: string
+  redirectUri?: string
   /** Proof that the caller owns this account, collected BEFORE leaving for the
    *  provider — on return the identity is saved immediately, with no UI left to
    *  ask. Absent when the account has no security verification method. */
@@ -194,8 +200,11 @@ export function takeSocialLinkFlow(): SocialLinkFlow | undefined {
     if (
       typeof flow.state !== 'string' ||
       typeof flow.connectorId !== 'string' ||
-      typeof flow.verificationRecordId !== 'string' ||
-      typeof flow.redirectUri !== 'string' ||
+      (flow.mode !== undefined && flow.mode !== 'direct' && flow.mode !== 'verified') ||
+      // The Account API fields are the verified path's, and only it can finish
+      // without them being real.
+      (flow.mode !== 'direct' &&
+        (typeof flow.verificationRecordId !== 'string' || typeof flow.redirectUri !== 'string')) ||
       (flow.currentVerificationRecordId !== undefined && typeof flow.currentVerificationRecordId !== 'string') ||
       (flow.purpose !== undefined && flow.purpose !== 'link' && flow.purpose !== 'reauthorize') ||
       (flow.target !== undefined && typeof flow.target !== 'string') ||


### PR DESCRIPTION
## Why

Linking **any** provider currently asks for an emailed code. That was collateral damage from #243.

#243 moved every provider to the **Account API** to escape the Slack 502. On that API the *user's own token* is the authority, so Logto requires an ownership proof. On the **Management API** the CP's credential is the authority and no proof is needed — which is how #225 worked, before Slack broke it.

**Only Slack was ever broken.** Its connector stores state while building the authorization URI (`setSession({ redirectUri })`), and the Management API runs connectors with no session. Verified from connector source:

| connector | `setSession` in `getAuthorizationUri`? | |
|---|---|---|
| Google | no — builds a plain URL | never needed a code |
| GitHub | no — and `getUserInfo` reads no session either | never needed a code |
| Slack | **yes**, read back by `getUserInfo` | genuinely needs the browser |

## How

Rather than keep a list of which connectors need a session, **the CP asks**: it tries to have Logto build the URI, and reports the mode.

```
GitHub, Google  → direct   → no code, link completes server-side
Slack           → verified → browser drives it, ownership proof as today
```

This matters because **Logto's own published list omitted Slack** — a list that is wrong here is precisely the 502 this used to be. A failed probe is deliberately *not* an error: every connector is still linkable the other way, so the fallback is always correct and merely slower. A new provider lands on the right path without anyone classifying it.

The verdict is cached per target for an hour, so only the first attempt pays the probe. `direct` is deliberately **not** cached — each link needs its own `state` and redirect baked into the URI.

## Reviewer notes

- The callback URI stays server-owned on the `direct` path; a caller-supplied one would let the provider response be redirected elsewhere. Covered by a test that passes an attacker URI and asserts the config one is used.
- `reauthorize` stays on the browser path unchanged — different operation, not worth folding in here.
- The flow record gains `mode`; a flow written by the previous build has none and is treated as `verified`, so an in-flight link across a deploy still completes.
- This does reintroduce **two link paths**. That is a real maintenance cost, stated plainly — the alternative is charging every GitHub/Google user a code for a Slack-only limitation.

Verified: web **858 passing** (110 files), control-plane **1217 passing** (129 files), both typechecks 0 errors, lint clean, `format:check` clean.

New tests: probe returns `direct` for a session-free connector; falls back to `verified` (not an error) when Logto cannot build the URI; the `verified` verdict is cached while `direct` is re-asked; and the card asks for **no code** on `direct` even when the account has a security verification method — the case that would otherwise force one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)