### PR TITLE
fix(daemon): replay session metadata after reconnect

### DIFF
--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -538,8 +538,10 @@ export class CpClient {
    * EVT, fire-and-forget, latest-wins per `sessionId`). This is what lets the CP
    * store session metadata so a deep-link detail page (…/sessions/:id) resolves
    * even when the daemon is offline. Metadata only — never the message stream
-   * (that stays daemon-local, §1/§12). No-op unless READY/DRAINING; a dropped
-   * `start` is re-covered by the next milestone (the CP upsert is latest-wins).
+   * (that stays daemon-local, §1/§12). No-op unless READY/DRAINING; the next
+   * milestone normally re-covers a drop, and the daemon replays its durable
+   * latest snapshots after each register for sessions that finished entirely
+   * while this client was unavailable.
    */
   emitEventSession(event: EventSession): void {
     if (this.state !== 'READY' && this.state !== 'DRAINING') return

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13832,8 +13832,9 @@ export class Daemon {
       }
     }
 
+    const snapshot = this.convergedEventSessionSnapshot(sessionRecord, event)
     try {
-      this.store.setEventSessionSnapshot(input.agentId, input.sessionId, JSON.stringify(event))
+      this.store.setEventSessionSnapshot(input.agentId, input.sessionId, JSON.stringify(snapshot))
     } catch (err) {
       this.log.debug(`event/session snapshot persist failed (session ${input.sessionId}): ${(err as Error).message}`)
     }
@@ -13843,6 +13844,29 @@ export class Daemon {
     } catch (err) {
       this.log.debug(`event/session emit failed (session ${input.sessionId}): ${(err as Error).message}`)
     }
+  }
+
+  private storedEventSessionSnapshot(session: SessionRecord): EventSession | undefined {
+    if (!session.eventSessionSnapshot) return undefined
+    try {
+      const parsed = EventSessionSchema.safeParse(JSON.parse(session.eventSessionSnapshot))
+      if (parsed.success && parsed.data.agentId === session.agentId && parsed.data.sessionId === session.acpSessionId) {
+        return parsed.data
+      }
+    } catch {
+      // Corrupt/legacy local state is ignored and replaced by the next valid snapshot.
+    }
+    return undefined
+  }
+
+  /** Match the CP's terminal-phase convergence before persisting a replay
+   * snapshot. Metadata enrichment may arrive after a turn ends, but it must not
+   * replace the terminal phase or its endedAt timestamp with a later plan event. */
+  private convergedEventSessionSnapshot(session: SessionRecord | undefined, next: EventSession): EventSession {
+    if (!session) return next
+    const previous = this.storedEventSessionSnapshot(session)
+    if (previous?.phase !== 'end' && previous?.phase !== 'problem') return next
+    return { ...next, phase: previous.phase, ts: previous.ts }
   }
 
   /**
@@ -13858,22 +13882,7 @@ export class Daemon {
     const stored = this.store.listSessions()
     if (stored.length === 0) return
 
-    const replay = stored.map((session) => {
-      if (!session.eventSessionSnapshot) return { session }
-      try {
-        const parsed = EventSessionSchema.safeParse(JSON.parse(session.eventSessionSnapshot))
-        if (
-          parsed.success &&
-          parsed.data.agentId === session.agentId &&
-          parsed.data.sessionId === session.acpSessionId
-        ) {
-          return { session, event: parsed.data }
-        }
-      } catch {
-        // Corrupt/legacy local state falls through to the safe minimal snapshot.
-      }
-      return { session }
-    })
+    const replay = stored.map((session) => ({ session, event: this.storedEventSessionSnapshot(session) }))
     const needsFallback = replay.some((entry) => entry.event === undefined)
     const projectionBySession = needsFallback
       ? new Map(

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13711,10 +13711,15 @@ export class Daemon {
     runtime?: string
     model?: string | null
     permissionMode?: string
+    /** Reconnect replay uses the durable activity time rather than making an
+     * old missing session look newer than a replacement session. */
+    at?: number
+    /** Avoid re-projecting the full session list for every reconnect row. */
+    projection?: SessionListItem
   }): void {
     if (!this.cpClient) return
-    const now = new Date(this.clock.now()).toISOString()
-    const row = this.sessionListProjection(input.sessionId, input.agentId)
+    const now = new Date(input.at ?? this.clock.now()).toISOString()
+    const row = input.projection ?? this.sessionListProjection(input.sessionId, input.agentId)
     const key = row?.sessionKey
     const event: EventSession = {
       sessionId: input.sessionId,
@@ -13813,6 +13818,49 @@ export class Daemon {
       this.cpClient.emitEventSession(event)
     } catch (err) {
       this.log.debug(`event/session emit failed (session ${input.sessionId}): ${(err as Error).message}`)
+    }
+  }
+
+  /**
+   * Re-converge CP metadata from the daemon's durable session store after each
+   * register. Relay ingress remains local-first while the control client is
+   * CONNECTING/REGISTERING, so a whole turn can finish while every live
+   * milestone is a deliberate no-op. Without this replay its deep link stays a
+   * protected 404 forever.
+   */
+  private replaySessionMetadataSnapshots(): void {
+    const stored = this.store.listSessions()
+    if (stored.length === 0) return
+
+    const projections = createSessionReader(this.store, (session) => this.sessionThreadUrl(session)).list({}).sessions
+    const projectionBySession = new Map(
+      projections.map((session) => [`${session.agentId}\0${session.sessionId}`, session] as const)
+    )
+
+    // Replay oldest-first. A missing row uses its durable activity time as
+    // startedAt, so the CP's webchat current-session fence still selects the
+    // newest local session even when frame handlers complete out of order.
+    for (const session of stored.reverse()) {
+      const sessionId = session.acpSessionId
+      if (!sessionId) continue
+      const phase: EventSession['phase'] =
+        session.state === 'prompting' || session.state === 'cancelling' || session.state === 'resuming'
+          ? 'start'
+          : session.lastTurnOutcome === 'failed'
+            ? 'problem'
+            : session.lastTurnOutcome === 'done' || session.state === 'closed'
+              ? 'end'
+              : 'plan'
+      this.emitSessionMetadataSnapshot({
+        sessionId,
+        agentId: session.agentId,
+        phase,
+        platform: session.platform as SessionKey['platform'],
+        channel: session.channel,
+        thread: session.thread,
+        at: session.updatedAt,
+        projection: projectionBySession.get(`${session.agentId}\0${sessionId}`)
+      })
     }
   }
 
@@ -18755,15 +18803,15 @@ export class Daemon {
       // Daemon-configured MCP servers, derived from the effective def set (no
       // probing), riding the same facts frame with replace-on-register semantics.
       mcpServerFacts: (): FactsMcpServer[] => this.mcpServerFactsFromDefs(),
-      // On (re)connect, probe runtimes in the background and push refreshed profiles,
-      // and re-assert each integration's cached channel-membership snapshot (the CP
-      // may have missed emits while we were disconnected; latest-wins upsert).
+      // On (re)connect, probe runtimes in the background and re-assert the
+      // daemon-owned snapshots the CP may have missed while disconnected.
       onReady: () => {
         void this.probeRuntimesAndEmit()
         void this.syncOrganizationSuggestions().catch((err) =>
           this.log.warn(`cp: organization suggestion replay failed (${err instanceof Error ? err.name : 'unknown'})`)
         )
         this.cpClient?.emitMemoryConnectionFacts(this.memoryConnections?.facts() ?? [])
+        this.replaySessionMetadataSnapshots()
         this.hookReportConnectionId = randomUUID()
         this.replayHookTerminalReports()
         this.replayChannelSnapshots()

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -287,6 +287,7 @@ import {
   AGENT_CONFIG_REVISION_FEATURE,
   ORGANIZATION_KNOWLEDGE_FEATURE,
   ORGANIZATION_SUGGESTION_REVIEW_FEATURE,
+  EventSession as EventSessionSchema,
   SESSION_VISIBILITY_FEATURE,
   SLACK_SESSION_AUDIENCE_FEATURE,
   WORKSPACE_SESSION_READ_FEATURE,
@@ -13716,6 +13717,9 @@ export class Daemon {
     at?: number
     /** Avoid re-projecting the full session list for every reconnect row. */
     projection?: SessionListItem
+    /** A pre-snapshot legacy row can safely replay identity/classification, but
+     * must not reconstruct historical status or execution config. */
+    durableOnly?: boolean
   }): void {
     if (!this.cpClient) return
     const now = new Date(input.at ?? this.clock.now()).toISOString()
@@ -13777,8 +13781,7 @@ export class Daemon {
     if (row?.threadUrl !== undefined) event.threadUrl = row.threadUrl
     // Effective execution config: the session's sticky overrides (console/⚙-modal
     // in-session switches) win over the agent's configured values; absent ⇒ the
-    // runtime's own default. Snapshotted here so the CP records what this session
-    // actually ran with — the agent's config can change later without rewriting history.
+    // runtime's own default. The exact result is persisted below for reconnect.
     const agent = this.agents.get(input.agentId)
     const allowRuntimeChangesInChat = agent?.allowRuntimeChangesInChat === true
     if (input.runtime !== undefined) event.runtime = input.runtime
@@ -13813,53 +13816,92 @@ export class Daemon {
     else if (permissionMode !== undefined) event.permissionMode = permissionMode
     const outputMode = (storeKey ? this.store.getOutputModeOverride(storeKey) : undefined) ?? agent?.output?.mode
     if (outputMode !== undefined) event.outputMode = outputMode
+    if (input.durableOnly) {
+      for (const field of [
+        'status',
+        'runtime',
+        'model',
+        'observedModel',
+        'effort',
+        'fastMode',
+        'permissionMode',
+        'outputMode',
+        'workspaceIsolation'
+      ] as const) {
+        delete event[field]
+      }
+    }
 
     try {
-      this.cpClient.emitEventSession(event)
+      this.store.setEventSessionSnapshot(input.agentId, input.sessionId, JSON.stringify(event))
+    } catch (err) {
+      this.log.debug(`event/session snapshot persist failed (session ${input.sessionId}): ${(err as Error).message}`)
+    }
+
+    try {
+      this.cpClient?.emitEventSession(event)
     } catch (err) {
       this.log.debug(`event/session emit failed (session ${input.sessionId}): ${(err as Error).message}`)
     }
   }
 
   /**
-   * Re-converge CP metadata from the daemon's durable session store after each
-   * register. Relay ingress remains local-first while the control client is
-   * CONNECTING/REGISTERING, so a whole turn can finish while every live
-   * milestone is a deliberate no-op. Without this replay its deep link stays a
-   * protected 404 forever.
+   * Re-converge the exact latest metadata milestone after each register. Relay
+   * ingress remains local-first while the control client is unavailable, so a
+   * whole turn can otherwise finish without creating its CP row.
+   *
+   * Rows from an older daemon have no snapshot. Their fallback deliberately
+   * carries only durable identity/classification fields: reconstructing status
+   * or execution config from today's agent would rewrite history.
    */
   private replaySessionMetadataSnapshots(): void {
     const stored = this.store.listSessions()
     if (stored.length === 0) return
 
-    const projections = createSessionReader(this.store, (session) => this.sessionThreadUrl(session)).list({}).sessions
-    const projectionBySession = new Map(
-      projections.map((session) => [`${session.agentId}\0${session.sessionId}`, session] as const)
-    )
+    const replay = stored.map((session) => {
+      if (!session.eventSessionSnapshot) return { session }
+      try {
+        const parsed = EventSessionSchema.safeParse(JSON.parse(session.eventSessionSnapshot))
+        if (
+          parsed.success &&
+          parsed.data.agentId === session.agentId &&
+          parsed.data.sessionId === session.acpSessionId
+        ) {
+          return { session, event: parsed.data }
+        }
+      } catch {
+        // Corrupt/legacy local state falls through to the safe minimal snapshot.
+      }
+      return { session }
+    })
+    const needsFallback = replay.some((entry) => entry.event === undefined)
+    const projectionBySession = needsFallback
+      ? new Map(
+          createSessionReader(this.store, (session) => this.sessionThreadUrl(session))
+            .list({})
+            .sessions.map((session) => [`${session.agentId}\0${session.sessionId}`, session] as const)
+        )
+      : undefined
 
-    // Replay oldest-first. A missing row uses its durable activity time as
-    // startedAt, so the CP's webchat current-session fence still selects the
-    // newest local session even when frame handlers complete out of order.
-    for (const session of stored.reverse()) {
+    // Replay oldest-first so a legacy missing row's durable activity timestamp
+    // preserves the webchat current-session ordering.
+    for (const { session, event } of replay.reverse()) {
       const sessionId = session.acpSessionId
       if (!sessionId) continue
-      const phase: EventSession['phase'] =
-        session.state === 'prompting' || session.state === 'cancelling' || session.state === 'resuming'
-          ? 'start'
-          : session.lastTurnOutcome === 'failed'
-            ? 'problem'
-            : session.lastTurnOutcome === 'done' || session.state === 'closed'
-              ? 'end'
-              : 'plan'
+      if (event) {
+        this.cpClient?.emitEventSession(event)
+        continue
+      }
       this.emitSessionMetadataSnapshot({
         sessionId,
         agentId: session.agentId,
-        phase,
+        phase: 'plan',
         platform: session.platform as SessionKey['platform'],
         channel: session.channel,
         thread: session.thread,
         at: session.updatedAt,
-        projection: projectionBySession.get(`${session.agentId}\0${sessionId}`)
+        projection: projectionBySession?.get(`${session.agentId}\0${sessionId}`),
+        durableOnly: true
       })
     }
   }

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -70,6 +70,9 @@ export interface SessionRecord {
   /** Opaque physical-bot scope for transcript/session lookup isolation. */
   transportScope?: string | null
   acpSessionId: string | null
+  /** Last authoritative `event/session` payload, JSON-encoded. The daemon
+   * replays it after reconnect instead of reconstructing historical config. */
+  eventSessionSnapshot?: string | null
   // §7.3 session lifecycle. `prompting` ⇒ a turn is in flight; `cancelling` ⇒
   // a `!stop` was issued and we're awaiting the agent (with a force backstop);
   // `resuming` ⇒ re-attaching a persisted session after a restart/host eviction;
@@ -582,7 +585,7 @@ export class LocalStore {
         originSessionId TEXT, lastTurnOutcome TEXT, needsParentReply INTEGER,
         externalProvider TEXT, externalRealmKey TEXT, externalResourceKind TEXT,
         externalResourceKey TEXT, externalIntegrationId TEXT, externalOriginJson TEXT,
-        sourceBindingKind TEXT
+        sourceBindingKind TEXT, eventSessionSnapshot TEXT
       );
       -- A !stop can arrive while a cold session is still materializing, before the
       -- sessions row exists. Keep the mute independently keyed so that stop survives a
@@ -1260,6 +1263,8 @@ export class LocalStore {
       this.db.exec('ALTER TABLE sessions ADD COLUMN externalOriginJson TEXT')
     if (!cols.some((c) => c.name === 'sourceBindingKind'))
       this.db.exec('ALTER TABLE sessions ADD COLUMN sourceBindingKind TEXT')
+    if (!cols.some((c) => c.name === 'eventSessionSnapshot'))
+      this.db.exec('ALTER TABLE sessions ADD COLUMN eventSessionSnapshot TEXT')
   }
 
   /** Pre-visibility databases have no gate table; the CREATE above only runs on
@@ -1876,6 +1881,15 @@ export class LocalStore {
    *  No-op if the key is unknown (a turn that failed before the row existed). */
   setSessionTurnOutcome(key: string, outcome: 'done' | 'failed', updatedAt: number): void {
     this.db.prepare('UPDATE sessions SET lastTurnOutcome = ?, updatedAt = ? WHERE key = ?').run(outcome, updatedAt, key)
+  }
+
+  /** Keep the exact metadata milestone that was most recently produced for a
+   * session. This does not advance updatedAt: the snapshot records activity; it
+   * must not create activity of its own. */
+  setEventSessionSnapshot(agentId: string, acpSessionId: string, snapshot: string): void {
+    this.db
+      .prepare('UPDATE sessions SET eventSessionSnapshot = ? WHERE agentId = ? AND acpSessionId = ?')
+      .run(snapshot, agentId, acpSessionId)
   }
 
   /** Targeted state transition for an existing session (§7.3), stamping `updatedAt`

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -1090,7 +1090,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
   )
 
   it('re-emits session metadata when display names are resolved after the turn', async () => {
-    const root = scaffold()
+    const root = scaffold(undefined, undefined, undefined, DREAM_AGENT)
     const fakeHost = {
       __started: true,
       start: vi.fn(async () => {}),
@@ -1100,39 +1100,72 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       cancel: vi.fn(),
       stop: vi.fn()
     }
-    const daemon = new Daemon({ root, hostFactory: () => fakeHost as any })
-    await daemon.start()
-    const emitEventSession = vi.fn()
-    ;(daemon as any).cpClient = { emitEventSession, emitUsageReport: vi.fn(), stop: vi.fn() }
+    const first = new Daemon({ root, hostFactory: () => fakeHost as any })
+    let firstStopped = false
+    let restored: Daemon | undefined
+    try {
+      await first.start()
+      const emitEventSession = vi.fn()
+      ;(first as any).cpClient = { emitEventSession, emitUsageReport: vi.fn(), stop: vi.fn() }
 
-    await (daemon as any).dispatch('bot-a', {
-      msgId: 'slack:C1:300.1',
-      traceId: 'names',
-      source: 'cron',
-      platform: 'slack',
-      channel: 'C1',
-      thread: '300.1',
-      sender: { id: 'U1', isBot: false },
-      text: 'need names',
-      mentionedBots: [],
-      isDm: false
-    })
+      await (first as any).dispatch(DREAM_AGENT, {
+        msgId: 'slack:C1:300.1',
+        traceId: 'names',
+        source: 'cron',
+        platform: 'slack',
+        channel: 'C1',
+        thread: '300.1',
+        sender: { id: 'U1', isBot: false },
+        text: 'need names',
+        mentionedBots: [],
+        isDm: false
+      })
+      const terminal = emitEventSession.mock.calls.at(-1)![0]
+      expect(terminal).toMatchObject({ sessionId: 'acp-name-1', phase: 'end' })
 
-    ;(daemon as any).store.setDisplayName('C1', 'deploys', Date.now())
-    ;(daemon as any).store.setDisplayName('U1', 'Dana Reyes', Date.now())
-    ;(daemon as any).emitSessionMetadataSnapshotsForDisplayName('C1')
+      ;(first as any).store.setDisplayName('C1', 'deploys', Date.now())
+      ;(first as any).store.setDisplayName('U1', 'Dana Reyes', Date.now())
+      ;(first as any).emitSessionMetadataSnapshotsForDisplayName('C1')
 
-    const refresh = emitEventSession.mock.calls.at(-1)![0]
-    expect(refresh).toMatchObject({
-      sessionId: 'acp-name-1',
-      phase: 'plan',
-      title: 'need names',
-      status: 'idle',
-      channelName: 'deploys',
-      triggeredBy: 'U1',
-      triggeredByName: 'Dana Reyes'
-    })
-    await daemon.stop()
+      const refresh = emitEventSession.mock.calls.at(-1)![0]
+      expect(refresh).toMatchObject({
+        sessionId: 'acp-name-1',
+        phase: 'plan',
+        title: 'need names',
+        status: 'idle',
+        channelName: 'deploys',
+        triggeredBy: 'U1',
+        triggeredByName: 'Dana Reyes'
+      })
+      const stored = (first as any).store.getSessionByAcpIdForAgent(DREAM_AGENT, 'acp-name-1')
+      expect(JSON.parse(stored.eventSessionSnapshot)).toMatchObject({
+        phase: 'end',
+        ts: terminal.ts,
+        channelName: 'deploys',
+        triggeredByName: 'Dana Reyes'
+      })
+
+      await first.stop()
+      firstStopped = true
+      restored = new Daemon({ root, probeRuntimes: async () => [] })
+      await restored.start()
+      const replayed = vi.fn()
+      ;(restored as any).cpClient = { emitEventSession: replayed, stop: vi.fn() }
+      ;(restored as any).replaySessionMetadataSnapshots()
+
+      expect(replayed).toHaveBeenCalledTimes(1)
+      expect(replayed.mock.calls[0]![0]).toMatchObject({
+        sessionId: 'acp-name-1',
+        phase: 'end',
+        ts: terminal.ts,
+        channelName: 'deploys',
+        triggeredByName: 'Dana Reyes'
+      })
+    } finally {
+      if (restored) await restored.stop().catch(() => undefined)
+      if (!firstStopped) await first.stop().catch(() => undefined)
+      rmSync(root, { recursive: true, force: true })
+    }
   }, 15_000)
 
   it('pending map is cleaned up when host.prompt throws', async () => {

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -10,8 +10,14 @@ import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../src/cp/gitcred-ser
 // cold session boot (workspace + host + session/new) can stall well past a second.
 // Give every poll in this file the same generous budget instead.
 const WAIT = { timeout: 10_000 }
+const DREAM_AGENT = '11111111-1111-4111-8111-111111111111'
 
-function scaffold(displayName?: string, memoryProvider?: 'none' | 'managed', iconUrl?: string): string {
+function scaffold(
+  displayName?: string,
+  memoryProvider?: 'none' | 'managed',
+  iconUrl?: string,
+  agentId = 'bot-a'
+): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-daemon-'))
   writeFileSync(
     join(root, 'config.json'),
@@ -24,13 +30,13 @@ function scaffold(displayName?: string, memoryProvider?: 'none' | 'managed', ico
       runtimes: { claude: { command: 'node', args: ['unused'] } }
     })
   )
-  const adir = join(root, 'agents', 'bot-a')
+  const adir = join(root, 'agents', agentId)
   mkdirSync(adir, { recursive: true })
   writeFileSync(
     join(adir, 'agent.json'),
     JSON.stringify({
-      id: 'bot-a',
-      name: 'bot-a',
+      id: agentId,
+      name: agentId,
       ...(displayName !== undefined ? { displayName } : {}),
       ...(iconUrl !== undefined ? { iconUrl } : {}),
       status: 'active',
@@ -339,7 +345,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     await daemon.stop()
   }, 15_000)
 
-  it('emits session metadata snapshots on create, completion, and reconnect replay', async () => {
+  it('emits session metadata snapshots on create, completion, and safe legacy replay', async () => {
     const root = scaffold()
     const fakeHost = {
       __started: true,
@@ -444,19 +450,92 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     expect(final.model).toBeUndefined()
     expect(emitUsageReport.mock.calls.map(([report]) => report.observedModel)).toEqual(['claude-sonnet-4-5', null])
 
-    // Repair a CP row whose whole turn happened before the control client was
-    // READY. The replay is rebuilt from SQLite; no future user turn is needed.
+    // Simulate a row written by an older daemon. Its safe fallback can repair
+    // identity/access, but must not invent historical status or runtime config.
+    ;(daemon as any).store.setEventSessionSnapshot('bot-a', 'acp-sess-1', '')
     emitEventSession.mockClear()
     ;(daemon as any).replaySessionMetadataSnapshots()
     expect(emitEventSession).toHaveBeenCalledTimes(1)
-    expect(emitEventSession.mock.calls[0]![0]).toMatchObject({
+    const legacyReplay = emitEventSession.mock.calls[0]![0]
+    expect(legacyReplay).toMatchObject({
       sessionId: 'acp-sess-1',
-      phase: 'end',
-      status: 'idle',
-      sourceBindingKind: 'local',
-      observedModel: null
+      phase: 'plan',
+      sourceBindingKind: 'local'
     })
+    expect(legacyReplay.status).toBeUndefined()
+    expect(legacyReplay.runtime).toBeUndefined()
+    expect(legacyReplay.observedModel).toBeUndefined()
+    expect(legacyReplay.permissionMode).toBeUndefined()
+    expect(legacyReplay.outputMode).toBeUndefined()
     await daemon.stop()
+  }, 15_000)
+
+  it('replays exact persisted dream terminal metadata after a daemon restart', async () => {
+    const root = scaffold(undefined, 'managed', undefined, DREAM_AGENT)
+    const first = new Daemon({ root, probeRuntimes: async () => [] })
+    let firstStopped = false
+    let restored: Daemon | undefined
+    try {
+      await first.start()
+      const initialEmit = vi.fn()
+      ;(first as any).cpClient = { emitEventSession: initialEmit, stop: vi.fn() }
+      ;(first as any).store.upsertSession({
+        key: `dream:memory:dream-1:${DREAM_AGENT}`,
+        agentId: DREAM_AGENT,
+        platform: 'dream',
+        channel: 'memory',
+        thread: 'dream-1',
+        acpSessionId: 'dream-session-1',
+        state: 'idle',
+        lastDeliveredTs: null,
+        updatedAt: 1_785_849_600_000,
+        triggeredBy: 'manual',
+        memoryProvider: 'managed'
+      })
+      ;(first as any).emitSessionMetadataSnapshot({
+        sessionId: 'dream-session-1',
+        agentId: DREAM_AGENT,
+        phase: 'problem',
+        platform: 'dream',
+        channel: 'memory',
+        thread: 'dream-1',
+        status: 'canceled',
+        runtime: 'claude',
+        model: null,
+        permissionMode: 'read-only'
+      })
+      expect(initialEmit).toHaveBeenCalledTimes(1)
+
+      await first.stop()
+      firstStopped = true
+      restored = new Daemon({ root, probeRuntimes: async () => [] })
+      await restored.start()
+      // Current config deliberately differs from the historical dream snapshot.
+      const currentAgent = (restored as any).agents.get(DREAM_AGENT)
+      currentAgent.runtime = 'changed-runtime'
+      currentAgent.permissionMode = 'default'
+      currentAgent.output.mode = 'high'
+      const replayed = vi.fn()
+      ;(restored as any).cpClient = { emitEventSession: replayed, stop: vi.fn() }
+      ;(restored as any).replaySessionMetadataSnapshots()
+
+      expect(replayed).toHaveBeenCalledTimes(1)
+      expect(replayed.mock.calls[0]![0]).toMatchObject({
+        sessionId: 'dream-session-1',
+        agentId: DREAM_AGENT,
+        phase: 'problem',
+        platform: 'dream',
+        status: 'canceled',
+        runtime: 'claude',
+        observedModel: null,
+        permissionMode: 'read-only',
+        outputMode: 'medium'
+      })
+    } finally {
+      if (restored) await restored.stop().catch(() => undefined)
+      if (!firstStopped) await first.stop().catch(() => undefined)
+      rmSync(root, { recursive: true, force: true })
+    }
   }, 15_000)
 
   it('re-emits session metadata when a runtime session title update arrives', async () => {

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -339,7 +339,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     await daemon.stop()
   }, 15_000)
 
-  it('emits session metadata snapshots on create and turn completion', async () => {
+  it('emits session metadata snapshots on create, completion, and reconnect replay', async () => {
     const root = scaffold()
     const fakeHost = {
       __started: true,
@@ -443,6 +443,19 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     expect(final).toMatchObject({ sessionId: 'acp-sess-1', phase: 'end', status: 'idle', observedModel: null })
     expect(final.model).toBeUndefined()
     expect(emitUsageReport.mock.calls.map(([report]) => report.observedModel)).toEqual(['claude-sonnet-4-5', null])
+
+    // Repair a CP row whose whole turn happened before the control client was
+    // READY. The replay is rebuilt from SQLite; no future user turn is needed.
+    emitEventSession.mockClear()
+    ;(daemon as any).replaySessionMetadataSnapshots()
+    expect(emitEventSession).toHaveBeenCalledTimes(1)
+    expect(emitEventSession.mock.calls[0]![0]).toMatchObject({
+      sessionId: 'acp-sess-1',
+      phase: 'end',
+      status: 'idle',
+      sourceBindingKind: 'local',
+      observedModel: null
+    })
     await daemon.stop()
   }, 15_000)
 


### PR DESCRIPTION
## Summary

- persist each authoritative daemon event/session metadata snapshot beside its local session row
- replay converged snapshots after every successful Control Plane register, covering turns completed before the control client reaches READY
- retain terminal phase and timestamp when later asynchronous metadata enrichment arrives
- repair pre-upgrade rows with identity/classification-only metadata so historical status and execution config are never reconstructed from current agent settings

## Why

Relay ingress remains local-first while the Control Plane client is CONNECTING or REGISTERING. During that window, event/session is intentionally a no-op. A fast turn can therefore start and finish before READY, leaving no later milestone to create session_meta. The protected session deep link then stays a 404 and the visibility control never has persisted ownership metadata to render.

The replay sends metadata only. Transcript bodies remain daemon-local, and the Control Plane still performs the normal webchat owner classification and authorization checks. Persisted snapshots preserve nonstandard terminal sessions such as memory dreams across daemon restarts, while later display-name enrichment cannot downgrade a terminal snapshot to plan.

## Validation

- pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-smoke.test.ts -t "session metadata snapshots|dream terminal metadata|display names are resolved"
- pnpm --filter @agentconnect.md/daemon typecheck
- pnpm exec eslint packages/daemon/src/daemon.ts packages/daemon/src/store/local-store.ts packages/daemon/src/cp/client.ts packages/daemon/test/daemon-smoke.test.ts
- GitHub Actions: Build, Check, Unit Test, both Integration test shards, Sandbox (Linux), Semantic PR
- pre-push eslint .

Created by Codex . GPT-5
