### PR TITLE
fix(web): show session visibility while loading

### DIFF
--- a/packages/web/src/components/console/SessionVisibilityControl.test.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.test.tsx
@@ -57,6 +57,29 @@ async function openTightenDialog(nativeMemory: boolean): Promise<string> {
 }
 
 describe('SessionVisibilityControl — tighten confirmation', () => {
+  it('holds the fail-closed audience in place while session access is loading', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(
+        <SessionVisibilityControl
+          sessionId="pending-session"
+          visibility="private"
+          canChange={false}
+          loading
+          onChanged={() => {}}
+        />
+      )
+    })
+    expect(container.textContent).toContain('Private')
+    expect(container.querySelector('[data-testid="spinner"]')).not.toBeNull()
+    expect(container.querySelector<HTMLElement>('[aria-label="Session visibility: Private (loading)"]')?.title).toBe(
+      'Setting up session access'
+    )
+    expect(container.querySelector('button')).toBeNull()
+  })
+
   it('promises the memory boundary on an ordinary (gated) agent', async () => {
     const text = await openTightenDialog(false)
     expect(text).toContain('stops it from feeding shared agent memory')

--- a/packages/web/src/components/console/SessionVisibilityControl.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.tsx
@@ -32,6 +32,7 @@ export function SessionVisibilityControl({
   visibility,
   state,
   canChange,
+  loading = false,
   externalProvider,
   externalResolution,
   feishuRegion,
@@ -44,6 +45,10 @@ export function SessionVisibilityControl({
   /** §5.1 tighten cutover state; 'pending' renders the spinner pill. */
   state?: 'pending' | 'applied' | null
   canChange: boolean
+  /** The session exists locally, but its authoritative visibility row is not
+   *  readable yet. Keeps the fail-closed default in place without exposing a
+   *  control that would PUT against a session the server cannot resolve. */
+  loading?: boolean
   externalProvider?: string | null
   externalResolution?: 'pending' | 'settled' | 'invalid' | null
   feishuRegion?: 'feishu' | 'lark' | null
@@ -96,6 +101,21 @@ export function SessionVisibilityControl({
     // applies immediately.
     if (next === 'private') setConfirming(true)
     else void apply('org')
+  }
+
+  if (loading) {
+    const privateSession = effective === 'private'
+    return (
+      <span
+        title="Setting up session access"
+        aria-label={`Session visibility: ${privateSession ? 'Private' : 'Everyone'} (loading)`}
+        className="inline-flex h-[26px] flex-none items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)"
+      >
+        <Icon name={privateSession ? 'lock' : 'globe'} size={13} color="var(--text-tertiary)" />
+        {privateSession ? 'Private' : 'Everyone'}
+        <Spinner size={10} />
+      </span>
+    )
   }
 
   if (effective === 'external') {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2081,16 +2081,21 @@ export default function SessionDetailView() {
   }
 
   // Session visibility (session-visibility.md §4.3/§6). Rendered in the desktop
-  // header and the mobile meta strip; null only when no persisted visibility
-  // metadata is available (for example a synthetic Playground row).
+  // header and the mobile meta strip. Playground is fail-closed Private by
+  // contract, so hold that stable placeholder while its persisted detail row
+  // catches up instead of inserting the whole control later.
+  const visibilityLoading = focusedSession?.platform === 'playground' && !focusedSessionDetail
   const visibilityControl =
-    headerFocusSessionId && (focusedSessionDetail || focusedSession?.visibility) ? (
+    headerFocusSessionId && (focusedSessionDetail || focusedSession?.visibility || visibilityLoading) ? (
       <SessionVisibilityControl
         key={headerFocusSessionId}
         sessionId={headerFocusSessionId}
-        visibility={focusedSessionDetail?.visibility ?? focusedSession?.visibility}
+        visibility={
+          focusedSessionDetail?.visibility ?? focusedSession?.visibility ?? (visibilityLoading ? 'private' : undefined)
+        }
         state={focusedSessionDetail?.visibilityState}
         canChange={focusedSessionDetail?.canChangeVisibility === true}
+        loading={visibilityLoading}
         externalProvider={focusedSessionDetail?.externalProvider}
         externalResolution={focusedSessionDetail?.externalResolution}
         feishuRegion={focusedSessionDetail?.feishuRegion}


### PR DESCRIPTION
## Summary

- keep the fail-closed `Private` visibility indicator mounted as soon as a Playground session opens
- show a small loading state while the authoritative session detail is not readable yet
- enable the visibility dropdown in place once the server returns `canChangeVisibility`

## Root cause

The session header omitted the entire visibility control until persisted session metadata arrived. A new Playground conversation is already private by contract, but that safe default was not rendered, so the control appeared late and shifted the header after the chat was already usable.

The loading placeholder remains non-interactive and never derives edit authority in the browser; the server-provided session detail still exclusively decides when the dropdown is enabled.

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/SessionVisibilityControl.test.tsx` (9 tests)
- full web test suite (110 files, 859 tests)
- changed-file ESLint, Prettier, and `git diff --check`
- repository pre-push lint

Created by Codex . GPT-5
