### PR TITLE
fix(relay): drive ingest teardown and route mounting from the registry (audit F2–F7)

### DIFF
--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -19,8 +19,7 @@ import { createRelayDaemonServer, type RelayDaemonServer } from './relay-daemon-
 import { createRelayBrowserServer } from './relay-browser-server.js'
 import { WebchatRouter } from './webchat-router.js'
 import { RelayIngressManager } from './relay-ingress-manager.js'
-import { registerSlackHttpIngress } from './platforms/slack/http-ingress.js'
-import { registerFeishuHttpIngress } from './platforms/feishu/http-ingress.js'
+import { relayIngressPlugins } from './platforms/registry.js'
 import { CollaborationRouter } from './collaboration-router.js'
 import { createAgentMsgRouter } from './agent-msg-router.js'
 import { mapAgentDirectory, toBotAssignment } from './bot-arbitration.js'
@@ -195,8 +194,15 @@ async function main(): Promise<void> {
 
   // IM HTTP ingress. Each callback is demuxed, authenticated, deduplicated,
   // normalized, arbitrated, and forwarded. Routes must register before listen.
-  registerSlackHttpIngress(server, { manager: () => held.relayIngress, log })
-  registerFeishuHttpIngress(server, { manager: () => held.relayIngress, log })
+  //
+  // Mounted from the platform registry, not by name (audit F5): each plugin
+  // declares its own paths, so adding a platform never edits this file. The
+  // paths themselves are unchanged by construction and pinned by enumeration
+  // in `platforms/route-mounts.test.ts` — public callback URLs are external
+  // contracts.
+  for (const plugin of relayIngressPlugins) {
+    plugin.installRoutes(server, { manager: () => held.relayIngress, log })
+  }
 
   // Public webhook ingress (POST /webhooks/in/:token). Routes must register
   // before listen; the rd/* server only exists after it — hence the late bind.

--- a/packages/relay/src/platforms/contract.ts
+++ b/packages/relay/src/platforms/contract.ts
@@ -46,6 +46,7 @@
  * (`credentialRevision`), and event-identity dedup STORAGE — the plugin mints
  * the dedup id (it derives from parsed action semantics); core owns the table.
  */
+import type { FastifyInstance } from 'fastify'
 import type { RcBotChannels, RdAck, RdMsgPlatformAction, WireNormalizedMessage } from '@agentconnect.md/protocol'
 import type { BotAssignment, RouteTarget } from '../bot-arbitration.js'
 import type { Logger } from '../log.js'
@@ -74,7 +75,15 @@ export interface RelayBotIngress {
   /** Open long-lived resources (Slack resolves its bot user id lazily; a pure
    *  HTTP decoder has nothing to open). Absent ⇒ nothing to start. */
   start?(): Promise<void>
-  /** Release everything. Idempotent — assign rebuilds call it first. */
+  /**
+   * Release everything. Idempotent — assign rebuilds call it first.
+   *
+   * REQUIRED, not optional, and that is the point: teardown iterates the
+   * registry and cannot know which platforms have resources to release, so
+   * "nothing to stop, only to drop" is THIS method's business — a pure decoder
+   * implements it as a no-op. Core naming the platforms that need stopping is
+   * how a third platform's ingest came to leak (audit F2).
+   */
   stop(): Promise<void> | void
   /**
    * OPTIONAL relay-side egress/read facet (§8: "Slack performs relay-side
@@ -194,6 +203,27 @@ export interface HandledDelivery {
   syncResponse?: unknown
 }
 
+/** The relay-core INBOUND seam a platform's HTTP route drives: demux + verify
+ *  + handle in one core-owned ladder (satisfied by `RelayIngressManager`), with
+ *  the plugin owning the cryptography and everything after authentication.
+ *  `undefined` ⇒ no assigned bot owns the delivery, and the route answers 401. */
+export interface RelayInboundSeam {
+  handleInbound(
+    platformId: string,
+    rawBody: Buffer,
+    body: unknown,
+    headers: Record<string, string | string[] | undefined>
+  ): Promise<HandledDelivery | undefined>
+}
+
+/** What {@link RelayPlatformIngressPlugin.installRoutes} is handed. `manager` is
+ *  LATE-BOUND deliberately: routes must register before `listen()`, while the
+ *  manager is constructed alongside the rd/* server that comes after it. */
+export interface RelayIngressRouteDeps {
+  manager: () => RelayInboundSeam | undefined
+  log: Logger
+}
+
 /**
  * One platform's relay ingress plugin — stateless, per-platform, registered
  * once. Adding a platform registers one of these; no manager fork grows.
@@ -209,6 +239,27 @@ export interface HandledDelivery {
 export interface RelayPlatformIngressPlugin<TIngest extends RelayBotIngress = RelayBotIngress, TVerified = unknown> {
   /** Platform id (§6.1 vocabulary). Never parsed. */
   readonly platformId: string
+  /**
+   * Mount this platform's PUBLIC HTTP callback routes. Closes §6 item 12's
+   * "route mounting by name" blind spot (audit F5) the way the CP closed its
+   * twin in #605 (`installRoutes(scope)`): the bootstrap asks every registered
+   * plugin instead of calling `registerSlackHttpIngress` /
+   * `registerFeishuHttpIngress` by name, so adding a platform stops requiring
+   * an edit to `index.ts`.
+   *
+   * THE PLUGIN DECLARES ITS OWN PATHS, which is what makes the move a no-op:
+   * public callback URLs are EXTERNAL contracts — baked into a platform app's
+   * event-subscription config and into the deployment gateway's routing, and
+   * this repo has already been bitten by a public/internal prefix mismatch
+   * turning a live callback into a 404. `platforms/route-mounts.test.ts` pins
+   * the resulting table by enumeration.
+   *
+   * Called once, before `listen()`. The plugin owns its own isolated Fastify
+   * scope: both live ingests need raw-buffer content-type parsers (the HMAC is
+   * over the exact request bytes) that must never leak onto the relay's other
+   * JSON surfaces.
+   */
+  installRoutes(app: FastifyInstance, deps: RelayIngressRouteDeps): void
   /**
    * Validate the assignment's secrets / ingress identity and build the bot's
    * ingest instance. `undefined` = incomplete assignment (log-and-skip; the CP

--- a/packages/relay/src/platforms/feishu/http-ingress.test.ts
+++ b/packages/relay/src/platforms/feishu/http-ingress.test.ts
@@ -4,7 +4,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { WireFeishuCardActionEvent, WireNormalizedMessage } from '@agentconnect.md/protocol'
 import { FeishuHttpIngest, type FeishuCallbackHeaders } from './http-ingest.js'
 import { feishuIngressPlugin } from './ingress-plugin.js'
-import { registerFeishuHttpIngress, type FeishuIngestResolver } from './http-ingress.js'
+import { registerFeishuHttpIngress } from './http-ingress.js'
+import type { RelayInboundSeam } from '../contract.js'
 
 const NOW = 1_720_000_000_000
 const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
@@ -71,7 +72,7 @@ function makeApp(secrets: { verificationToken: string; encryptKey?: string } = {
     dedupSeen: () => false,
     clock: { now: () => NOW }
   } as unknown as import('../contract.js').RelayIngressHost
-  const resolver: FeishuIngestResolver = {
+  const resolver: RelayInboundSeam = {
     handleInbound: async (_platformId, rawBody, body, headers) => {
       const verified = feishuIngressPlugin.verify(
         ingest,

--- a/packages/relay/src/platforms/feishu/http-ingress.ts
+++ b/packages/relay/src/platforms/feishu/http-ingress.ts
@@ -1,34 +1,9 @@
 import type { FastifyInstance } from 'fastify'
-import type { Logger } from '../../log.js'
-import { type FeishuHttpIngest, type VerifiedFeishuCallback } from './http-ingest.js'
+import type { RelayIngressRouteDeps } from '../contract.js'
 
 export const FEISHU_BODY_LIMIT = 1024 * 1024
-const FEISHU_CARD_ACTION_RESPONSE_TIMEOUT_MS = 2_500
 
-export interface FeishuVerifiedDelivery {
-  ingest: FeishuHttpIngest
-  callback: VerifiedFeishuCallback
-}
-
-export interface FeishuIngestResolver {
-  handleInbound(
-    platformId: string,
-    rawBody: Buffer,
-    body: unknown,
-    headers: Record<string, string | string[] | undefined>
-  ): Promise<import('../contract.js').HandledDelivery | undefined>
-}
-
-export interface FeishuHttpIngressDeps {
-  manager: () => FeishuIngestResolver | undefined
-  log: Logger
-}
-
-function headerString(value: string | string[] | undefined): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined
-}
-
-export function registerFeishuHttpIngress(app: FastifyInstance, deps: FeishuHttpIngressDeps): void {
+export function registerFeishuHttpIngress(app: FastifyInstance, deps: RelayIngressRouteDeps): void {
   void app.register(async (scope) => {
     scope.addContentTypeParser(
       'application/json',

--- a/packages/relay/src/platforms/feishu/ingress-plugin.ts
+++ b/packages/relay/src/platforms/feishu/ingress-plugin.ts
@@ -29,6 +29,7 @@ import {
   type WireFeishuCardActionEvent
 } from '@agentconnect.md/protocol'
 import { FeishuHttpIngest, type FeishuCallbackHeaders, type VerifiedFeishuCallback } from './http-ingest.js'
+import { registerFeishuHttpIngress } from './http-ingress.js'
 import type { BotAssignment } from '../../bot-arbitration.js'
 import type { DemuxHints, HandledDelivery, RelayIngressHost, RelayPlatformIngressPlugin } from '../contract.js'
 
@@ -93,6 +94,10 @@ export async function forwardFeishuCardAction(
 
 export const feishuIngressPlugin: RelayPlatformIngressPlugin<FeishuHttpIngest, VerifiedFeishuCallback> = {
   platformId: 'feishu',
+
+  // `POST /feishu/events`, declared by the module that owns it — the bootstrap
+  // no longer imports this by name (audit F5).
+  installRoutes: registerFeishuHttpIngress,
 
   buildIngest(a: BotAssignment, host: RelayIngressHost): FeishuHttpIngest | undefined {
     if (!a.apiAppId || !('verificationToken' in a.secrets)) {

--- a/packages/relay/src/platforms/registry.ts
+++ b/packages/relay/src/platforms/registry.ts
@@ -1,5 +1,6 @@
 /**
- * The relay's **per-platform ingest pools + demux index store** (§8, stage S3)
+ * The relay's **platform registry** — the static plugin list (§8/§12) plus the
+ * **per-platform ingest pools + demux index store** (stage S3)
  * — the S2 registry precedent (#526) applied to the relay: a platform states
  * how its bots are keyed and built ONCE (the plugin), and the shared lifecycle
  * only ever works pools and indexes it cannot parse.
@@ -16,7 +17,27 @@
  * delivery (bounded, lazily evicted), because a legacy bot's CP row may not
  * carry the app id at all.
  */
-import type { RelayBotIngress } from './contract.js'
+import type { RelayBotIngress, RelayPlatformIngressPlugin } from './contract.js'
+import { slackIngressPlugin } from './slack/ingress-plugin.js'
+import { feishuIngressPlugin } from './feishu/ingress-plugin.js'
+
+/**
+ * **The one place a relay platform id is written down.** Adding a platform is
+ * one entry here plus its `platforms/<id>/` module directory; every core path
+ * — assign, inbound demux, teardown, shutdown, route mounting — iterates this
+ * list and names no platform (§12: "a platform name is never core knowledge").
+ *
+ * Entries are erased to the contract's default bound. Core never reads a
+ * `TIngest`'s internals (§8) — it starts it, stops it, and hands it back to
+ * the plugin that built it, and each plugin's pool holds only ingests that
+ * plugin built, so the erasure is the contract's own guarantee rather than a
+ * cast around it.
+ *
+ * ORDER IS INSERTION ORDER and is observable in exactly one place: teardown
+ * asks each pool in turn. That is the order the two hand-named pools were
+ * asked in before the registry drove it (audit F2/F4), so nothing moved.
+ */
+export const relayIngressPlugins: readonly RelayPlatformIngressPlugin[] = [slackIngressPlugin, feishuIngressPlugin]
 
 /** One platform's pool of live per-bot ingests. Purely keyed by botId — the
  *  identity questions live in {@link DemuxIndex}, not here. */

--- a/packages/relay/src/platforms/route-mounts.test.ts
+++ b/packages/relay/src/platforms/route-mounts.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The PINNED relay platform mount table (integration-plugin-architecture.md §8;
+ * audit F5).
+ *
+ * `index.ts` no longer imports `registerSlackHttpIngress` /
+ * `registerFeishuHttpIngress` by name: it asks every registered plugin for
+ * `installRoutes(app, deps)` and mounts what comes back. That refactor is only
+ * safe if the URLs do not move — **the public callbacks are external
+ * contracts**, baked into a platform app's event-subscription config and into
+ * the deployment gateway's routing, and this repo has already been bitten by a
+ * public-prefix/internal-prefix mismatch turning a live callback into a 404.
+ *
+ * So this suite pins paths × plugin, and it does it by ENUMERATION, never by
+ * re-stating the new code:
+ *
+ *  1. each plugin is mounted ALONE in a bare Fastify app to learn which routes
+ *     it declares (the plugin is the authority for its own paths);
+ *  2. the whole registry is mounted the way the bootstrap does it, and the
+ *     complete route table is captured through an `onRoute` hook (Fastify is
+ *     the authority for where they landed);
+ *  3. the table below — the routes the pre-refactor bootstrap actually
+ *     registered — is the pin, so a plugin that silently stops declaring a
+ *     route, or a registry entry that never gets mounted, fails here.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import { relayIngressPlugins } from './registry.js'
+import type { RelayIngressRouteDeps } from './contract.js'
+
+/** TODAY'S TABLE — the routes `index.ts` registered when it named the two
+ *  register functions itself. `HEAD` (Fastify's automatic twin of every GET) is
+ *  omitted; there are no GETs on this seam. */
+const EXPECTED_MOUNTS: Record<string, string[]> = {
+  slack: ['POST /slack/events', 'POST /slack/interactions'],
+  feishu: ['POST /feishu/events']
+}
+
+const routeDeps = (): RelayIngressRouteDeps => ({
+  // The bootstrap's accessor is late-bound and legitimately empty at mount
+  // time — routes register before the manager exists.
+  manager: () => undefined,
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+})
+
+/** Every route an app ends up serving, as `METHOD /path`, captured from
+ *  Fastify rather than from the code under test. */
+async function routesOf(mount: (app: FastifyInstance) => void): Promise<string[]> {
+  const app = Fastify()
+  const seen: string[] = []
+  app.addHook('onRoute', (route) => {
+    const methods = Array.isArray(route.method) ? route.method : [route.method]
+    for (const method of methods) if (method !== 'HEAD') seen.push(`${method} ${route.url}`)
+  })
+  mount(app)
+  await app.ready()
+  await app.close()
+  return seen.sort()
+}
+
+describe('relay platform route mounts', () => {
+  it.each(relayIngressPlugins.map((plugin) => plugin.platformId))('%s declares its own paths', async (platformId) => {
+    const plugin = relayIngressPlugins.find((p) => p.platformId === platformId)!
+    const expected = EXPECTED_MOUNTS[platformId]
+    // A new platform lands here first: add its row to the table above, having
+    // confirmed the paths are the ones its provider console is configured with.
+    expect(expected, `no pinned mount table for '${platformId}'`).toBeDefined()
+    expect(await routesOf((app) => plugin.installRoutes(app, routeDeps()))).toEqual([...expected!].sort())
+  })
+
+  it('mounting the whole registry lands exactly the pinned table', async () => {
+    const mounted = await routesOf((app) => {
+      for (const plugin of relayIngressPlugins) plugin.installRoutes(app, routeDeps())
+    })
+    expect(mounted).toEqual(Object.values(EXPECTED_MOUNTS).flat().sort())
+  })
+
+  it('every registered platform actually mounts something', async () => {
+    for (const plugin of relayIngressPlugins) {
+      expect(
+        await routesOf((app) => plugin.installRoutes(app, routeDeps())),
+        `'${plugin.platformId}' registered no routes`
+      ).not.toHaveLength(0)
+    }
+  })
+})

--- a/packages/relay/src/platforms/slack/http-ingress.test.ts
+++ b/packages/relay/src/platforms/slack/http-ingress.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import Fastify, { type FastifyInstance } from 'fastify'
 import { SHARED_AGENT_SELECT_ACTION_ID } from '@agentconnect.md/protocol'
-import { registerSlackHttpIngress, type SlackIngestResolver } from './http-ingress.js'
+import { registerSlackHttpIngress } from './http-ingress.js'
+import type { RelayInboundSeam } from '../contract.js'
 
 const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 
@@ -27,7 +28,7 @@ function makeHarness(): Harness {
     inboundCalls: []
   }
   const seenEventIds = new Set<string>()
-  const resolver: SlackIngestResolver = {
+  const resolver: RelayInboundSeam = {
     handleInbound: async (platformId, _rawBody, body, headers) => {
       const b = body as {
         type?: string

--- a/packages/relay/src/platforms/slack/http-ingress.ts
+++ b/packages/relay/src/platforms/slack/http-ingress.ts
@@ -23,38 +23,11 @@
  * Signing secrets + tokens are NEVER logged.
  */
 import type { FastifyInstance } from 'fastify'
-import type { Logger } from '../../log.js'
+import type { RelayIngressRouteDeps } from '../contract.js'
 import type { SlackInteractiveBody, SlackMessageEvent } from './http-ingest.js'
 
 /** Raw-body cap for the Slack endpoints (Slack payloads are well under 1 MiB). */
 export const SLACK_BODY_LIMIT = 1024 * 1024
-
-/** The §8 inbound seam the route drives (satisfied by `RelayIngressManager`):
- *  demux + verify + handle in one core-owned ladder; the plugin owns the
- *  cryptography and everything after authentication. `undefined` ⇒ 401. */
-export interface SlackIngestResolver {
-  handleInbound(
-    platformId: string,
-    rawBody: Buffer,
-    body: unknown,
-    headers: Record<string, string | string[] | undefined>
-  ): Promise<import('../contract.js').HandledDelivery | undefined>
-}
-
-export interface SlackHttpIngressDeps {
-  /** Late-bound — the manager is constructed alongside the rd/* server, after routes register. */
-  manager: () => SlackIngestResolver | undefined
-  log: Logger
-}
-
-function headerString(v: string | string[] | undefined): string | undefined {
-  return typeof v === 'string' && v.length > 0 ? v : undefined
-}
-
-function eventDedupKey(body: SlackEventEnvelope): string | undefined {
-  if (!body.event_id) return undefined
-  return `${body.api_app_id ?? ''}\0${body.team_id ?? ''}\0${body.event_id}`
-}
 
 /** The subset of a Slack Events API envelope the route reads for demux + dispatch. */
 interface SlackEventEnvelope {
@@ -72,7 +45,7 @@ interface SlackEventEnvelope {
   event?: SlackMessageEvent
 }
 
-export function registerSlackHttpIngress(app: FastifyInstance, deps: SlackHttpIngressDeps): void {
+export function registerSlackHttpIngress(app: FastifyInstance, deps: RelayIngressRouteDeps): void {
   void app.register(async (scope) => {
     // Raw bytes for the HMAC — one isolated scope for both Slack content types.
     scope.addContentTypeParser(
@@ -88,8 +61,6 @@ export function registerSlackHttpIngress(app: FastifyInstance, deps: SlackHttpIn
 
     scope.post('/slack/events', { bodyLimit: SLACK_BODY_LIMIT }, async (req, reply) => {
       const raw = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0)
-      const signature = headerString(req.headers['x-slack-signature'])
-      const timestamp = headerString(req.headers['x-slack-request-timestamp'])
 
       let body: SlackEventEnvelope
       try {
@@ -115,8 +86,6 @@ export function registerSlackHttpIngress(app: FastifyInstance, deps: SlackHttpIn
 
     scope.post('/slack/interactions', { bodyLimit: SLACK_BODY_LIMIT }, async (req, reply) => {
       const raw = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0)
-      const signature = headerString(req.headers['x-slack-signature'])
-      const timestamp = headerString(req.headers['x-slack-request-timestamp'])
 
       // The interaction payload is urlencoded `payload=<json>`. The HMAC is over the
       // RAW urlencoded bytes (not the decoded JSON).

--- a/packages/relay/src/platforms/slack/ingress-plugin.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.ts
@@ -27,6 +27,7 @@ import {
   type SlackInteractiveBody,
   type SlackMessageEvent
 } from './http-ingest.js'
+import { registerSlackHttpIngress } from './http-ingress.js'
 import { verifySlackSignature } from '../../hooks/signature.js'
 import { sessionKeyOf } from '../../bot-arbitration.js'
 import type { BotAssignment } from '../../bot-arbitration.js'
@@ -180,6 +181,10 @@ function headerString(v: string | string[] | undefined): string | undefined {
 
 export const slackIngressPlugin: RelayPlatformIngressPlugin<SlackHttpIngest, SlackVerifiedDelivery> = {
   platformId: 'slack',
+
+  // `POST /slack/events` + `POST /slack/interactions`, declared by the module
+  // that owns them — the bootstrap no longer imports this by name (audit F5).
+  installRoutes: registerSlackHttpIngress,
 
   buildIngest(a: BotAssignment, host: RelayIngressHost): SlackHttpIngest | undefined {
     if (!('botToken' in a.secrets)) {

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -12,15 +12,19 @@ import type {
 } from '@agentconnect.md/protocol'
 import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 import { FakeClock } from '@agentconnect.md/connection'
+import { RelayIngressManager, type RelayIngressManagerDeps } from './relay-ingress-manager.js'
+// The dedup-id minters belong to their platform plugins (§8: the plugin mints
+// the identity, core owns the table). This suite was the last importer of the
+// core re-export shim that outlived the #571 route migration (audit F7).
 import {
-  RelayIngressManager,
-  type RelayIngressManagerDeps,
-  httpFeishuActionMsgId,
+  forwardSessionAction,
+  forwardSessionShortcut,
   httpSlackActionMsgId,
   httpSlackShortcutMsgId
-} from './relay-ingress-manager.js'
-import { forwardSessionAction, forwardSessionShortcut } from './platforms/slack/ingress-plugin.js'
-import { forwardFeishuCardAction } from './platforms/feishu/ingress-plugin.js'
+} from './platforms/slack/ingress-plugin.js'
+import { forwardFeishuCardAction, httpFeishuActionMsgId } from './platforms/feishu/ingress-plugin.js'
+import { DemuxIndex, relayIngressPlugins } from './platforms/registry.js'
+import type { RelayBotIngress, RelayPlatformIngressPlugin } from './platforms/contract.js'
 import { BotArbitrationRouter, mapAgentDirectory, type BotAssignment } from './bot-arbitration.js'
 import type { HttpSlackSessionAction, HttpSlackSessionShortcut } from './platforms/slack/http-ingest.js'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
@@ -84,17 +88,22 @@ const action = (over: Partial<HttpSlackSessionAction> = {}): HttpSlackSessionAct
     ...over
   }) as HttpSlackSessionAction
 
+/** One platform's ingest pool, as the reach-in view exposes it. `set` is
+ *  deliberately permissive: these tests plant purpose-built stand-ins that
+ *  implement only the facets the path under test touches. */
+interface PoolView {
+  set(botId: string, ingest: object): void
+  get(botId: string): Record<string, unknown> | undefined
+}
+
 interface ManagerInternals {
   router: BotArbitrationRouter
-  slackPool: {
-    set(
-      botId: string,
-      ingest: {
-        lookupUserName(u: string): Promise<string | undefined>
-        postText(c: string, t: string, th?: string): Promise<void>
-      }
-    ): void
-  }
+  slackPool: PoolView
+  feishuPool: PoolView
+  slackDemux: DemuxIndex
+  /** Any registered platform's entry — the same lookup every lifecycle edge in
+   *  the manager now performs. */
+  entryFor(platformId: string): { pool: PoolView; demux: DemuxIndex }
   reportChannels(snapshot: RcBotChannels): void
   reportRevoked(m: { botId: string; reason: 'app_uninstalled' | 'tokens_revoked'; credentialRevision?: number }): void
   selectThreadAgent(botId: string, channelId: string, threadTs: string, agentId: string): void
@@ -102,12 +111,46 @@ interface ManagerInternals {
   forward(botId: string, msg: WireNormalizedMessage): Promise<void>
 }
 
+/**
+ * Reach-in view of the manager's privates.
+ *
+ * `slackPool` / `feishuPool` / `slackDemux` are the plugin REGISTRY's entries
+ * for those ids, not fields: the manager's hand-named twin pools went away with
+ * audit F2/F4/F6, which is what made teardown registry-driven. The tests now
+ * read exactly the structure the manager does.
+ */
+const internalsOf = (manager: RelayIngressManager): ManagerInternals => {
+  const priv = manager as unknown as {
+    ingressPlugins: Map<string, { pool: PoolView; demux: DemuxIndex }>
+  } & Omit<ManagerInternals, 'slackPool' | 'feishuPool' | 'slackDemux'>
+  const entry = (platformId: string) => {
+    const found = priv.ingressPlugins.get(platformId)
+    if (!found) throw new Error(`no relay ingress plugin registered for '${platformId}'`)
+    return found
+  }
+  return {
+    router: priv.router,
+    slackPool: entry('slack').pool,
+    feishuPool: entry('feishu').pool,
+    slackDemux: entry('slack').demux,
+    entryFor: entry,
+    reportChannels: (snapshot) => priv.reportChannels(snapshot),
+    reportRevoked: (m) => priv.reportRevoked(m),
+    selectThreadAgent: (botId, channelId, threadTs, agentId) =>
+      priv.selectThreadAgent(botId, channelId, threadTs, agentId),
+    get ingressHost() {
+      return priv.ingressHost
+    },
+    forward: (botId, msg) => priv.forward(botId, msg)
+  }
+}
+
 describe('RelayIngressManager HTTP Slack session actions', () => {
   it('rebinds the current thread immediately when the inline selector changes agent', () => {
     const setChannelAgent = vi.fn()
     const reportThreadAssign = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ setChannelAgent, reportThreadAssign }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const assigned = assignment()
     assigned.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
     assigned.agents.push({ agentId: OTHER_AGENT_ID, name: 'Review Agent' })
@@ -160,7 +203,7 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
     const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(assignment())
 
     const delivered = action()
@@ -190,7 +233,7 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
     const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(assignment())
     internals.router.setAffinity(BOT_ID, 'C123/T1', {
       agentId: AGENT_ID,
@@ -230,7 +273,7 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
     const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(assignment())
 
     const attributed = action({ userId: 'U-ALICE' })
@@ -267,7 +310,7 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
     const manager = new RelayIngressManager(
       deps({ getDaemon: () => ({ sendMsg }) as unknown as RelayDaemonConnection, log: { ...silentLog, warn } })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(assignment())
 
     forwardSessionAction(
@@ -301,7 +344,7 @@ describe('RelayIngressManager HTTP Lark / Feishu card actions', () => {
     const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert({
       botId: BOT_ID,
       platform: 'feishu',
@@ -369,7 +412,7 @@ describe('RelayIngressManager HTTP Lark / Feishu card actions', () => {
     const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert({
       botId: BOT_ID,
       platform: 'feishu',
@@ -437,7 +480,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     const reportThreadAssign = vi.fn(() => true)
     const { daemon, sendMsg } = online()
     const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, reportThreadAssign }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(channelOwned())
 
     // Root message is an @-mention (channel-owner rung) → reports + seeds affinity.
@@ -462,7 +505,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     const manager = new RelayIngressManager(
       deps({ getDaemon: () => daemon, reportThreadAssign, reportThreadParticipant })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(channelAutoOwned())
 
     await internals.forward(BOT_ID, followUp({ msgId: 'slack:C123:1720000000.000100' }))
@@ -489,7 +532,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
           id === DAEMON_ID ? daemon(first) : id === OTHER_DAEMON_ID ? daemon(second as typeof first) : undefined
       })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     // The named primary is selected by an AUTO owner, not a mention rule. A human
     // still addressed this bot explicitly, so that target must get mention semantics.
     const shared = channelAutoOwned()
@@ -528,7 +571,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       return appId === 'AMANAGED'
     })
     const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, reportThreadAssign, isAgentBotApp }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const shared = channelAutoOwned()
     shared.members[0]!.agentIds.push(OTHER_AGENT_ID)
     shared.agents.push({ agentId: OTHER_AGENT_ID, name: 'Other' })
@@ -607,7 +650,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
           ...over
         })
       )
-      const internals = manager as unknown as ManagerInternals
+      const internals = internalsOf(manager)
       internals.router.upsert(channelAutoOwned())
       return { internals, sendMsg }
     }
@@ -776,7 +819,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
           isAgentBotApp: vi.fn(() => true)
         })
       )
-      const internals = manager as unknown as ManagerInternals
+      const internals = internalsOf(manager)
       const shared = assignment()
       shared.botUserId = 'UBOT'
       shared.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
@@ -856,7 +899,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
           isAgentBotApp: vi.fn(() => true)
         })
       )
-      const internals = manager as unknown as ManagerInternals
+      const internals = internalsOf(manager)
       const shared = assignment()
       shared.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
       shared.agents.push({
@@ -913,7 +956,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
           reportThreadParticipant
         })
       )
-      const internals = manager as unknown as ManagerInternals
+      const internals = internalsOf(manager)
       const shared = assignment()
       shared.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
       shared.agents.push({
@@ -983,7 +1026,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     const reportThreadAssign = vi.fn(() => ready) // false ⇒ "link not READY, dropped"
     const { daemon } = online()
     const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, reportThreadAssign }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(channelOwned())
 
     // Link down: the root mention routes+delivers, but the report is dropped + stashed.
@@ -1002,7 +1045,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     let ready = false
     const reportBotChannels = vi.fn(() => ready)
     const manager = new RelayIngressManager(deps({ reportBotChannels }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const first = { botId: BOT_ID, channels: [{ id: 'C123', name: 'first' }] } satisfies RcBotChannels
     const latest = { botId: BOT_ID, channels: [{ id: 'C456', name: 'latest' }] } satisfies RcBotChannels
 
@@ -1029,7 +1072,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       let committed = false
       const reportBotRevoked = vi.fn(async () => committed)
       const manager = new RelayIngressManager(deps({ reportBotRevoked }))
-      const internals = manager as unknown as ManagerInternals
+      const internals = internalsOf(manager)
       const report = { botId: BOT_ID, reason: 'app_uninstalled' as const, credentialRevision: 3 }
 
       // The CP answers a retryable error (transient DB failure) but the socket
@@ -1063,7 +1106,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
         return commitNext
       })
       const manager = new RelayIngressManager(deps({ reportBotRevoked }))
-      const internals = manager as unknown as ManagerInternals
+      const internals = internalsOf(manager)
       const current = { botId: BOT_ID, reason: 'app_uninstalled' as const, credentialRevision: 2 }
       const delayed = { botId: BOT_ID, reason: 'app_uninstalled' as const, credentialRevision: 1 }
 
@@ -1098,7 +1141,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       let commitNext = false
       const reportBotRevoked = vi.fn(async () => commitNext)
       const manager = new RelayIngressManager(deps({ reportBotRevoked }))
-      const internals = manager as unknown as ManagerInternals
+      const internals = internalsOf(manager)
       // The auth.test dead-credential backstop: exact current revision, NO
       // eventAtMs — "dead NOW", unconditional on the CP's time arm.
       const probe = { botId: BOT_ID, reason: 'tokens_revoked' as const, credentialRevision: 2 }
@@ -1137,7 +1180,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     try {
       const reportBotRevoked = vi.fn(async () => false) // keep everything queued
       const manager = new RelayIngressManager(deps({ reportBotRevoked }))
-      const internals = manager as unknown as ManagerInternals
+      const internals = internalsOf(manager)
       const newer = { botId: BOT_ID, reason: 'tokens_revoked' as const, credentialRevision: 2, eventAtMs: 2_000 }
       const older = { botId: BOT_ID, reason: 'app_uninstalled' as const, credentialRevision: 2, eventAtMs: 1_000 }
 
@@ -1161,7 +1204,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       const resolvers: Array<(v: boolean) => void> = []
       const reportBotRevoked = vi.fn(() => new Promise<boolean>((resolve) => resolvers.push(resolve)))
       const manager = new RelayIngressManager(deps({ reportBotRevoked }))
-      const internals = manager as unknown as ManagerInternals
+      const internals = internalsOf(manager)
       const first = { botId: BOT_ID, reason: 'app_uninstalled' as const, credentialRevision: 1 }
       // A reinstall bumped the generation and a SECOND revoke observed it — this
       // replaces the queue entry while the first report is still in flight.
@@ -1201,7 +1244,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     }))
     const reportThreadAssign = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, lookupThread, reportThreadAssign }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(channelOwned())
     // Remove the channel-owner rule so an un-mentioned follow-up misses local arbitration.
     internals.router.updateRoutes(BOT_ID, {
@@ -1245,7 +1288,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
           id === DAEMON_ID ? daemon(first) : id === OTHER_DAEMON_ID ? daemon(second as typeof first) : undefined
       })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const shared = assignment()
     shared.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
     shared.agents.push({
@@ -1288,7 +1331,7 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     }))
     const { daemon, sendMsg } = online()
     const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, lookupThread }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(channelOwned())
     internals.router.updateRoutes(BOT_ID, {
       members: [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID] }],
@@ -1346,7 +1389,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
   it('reports an unrouted gated DM as a kind:im conversation and notices once per conversation', async () => {
     const reportBotConversation = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ reportBotConversation }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(gatedAssignment())
     const ingest = fakeIngest()
     internals.slackPool.set(BOT_ID, ingest)
@@ -1367,7 +1410,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
 
   it('a first gated DM on a NON-authority pod still posts (single event copy, receiving pod owns it)', async () => {
     const manager = new RelayIngressManager(deps({ selfRelayId: () => PEER_RELAY }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(gatedAssignment()) // noticeAuthority = SELF_RELAY, not this pod
     const ingest = fakeIngest()
     internals.slackPool.set(BOT_ID, ingest)
@@ -1378,7 +1421,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
 
   it('a DM whose notice was already DELIVERED (noticedDmConversations) is latched on EVERY pod', async () => {
     const manager = new RelayIngressManager(deps())
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const a = gatedAssignment()
     a.noticedDmConversations = ['D42'] // delivery reported + re-stamped by the CP
     internals.router.upsert(a)
@@ -1395,7 +1438,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     const manager = new RelayIngressManager(
       deps({ reportNoticePosted, getDaemon: () => daemon as unknown as RelayDaemonConnection })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const a = gatedAssignment()
     // Mixed bot: OTHER is org-visible and catches the DM as the group default.
     a.members = [
@@ -1440,7 +1483,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
   it('reports a gated DM even when a non-gated default agent WINS the routing (mixed bot)', async () => {
     const reportBotConversation = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ reportBotConversation }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const a = gatedAssignment()
     // OTHER is org-visible and catches every unslugged DM as the group default.
     a.members = [
@@ -1478,7 +1521,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
   it('resets the DM-report latch when the install set changes (new install needs its row)', async () => {
     const reportBotConversation = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ reportBotConversation }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const a = gatedAssignment()
     internals.router.upsert(a)
     internals.slackPool.set(BOT_ID, fakeIngest())
@@ -1521,7 +1564,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     let ready = false
     const reportBotConversation = vi.fn(() => ready)
     const manager = new RelayIngressManager(deps({ reportBotConversation }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(gatedAssignment())
     internals.slackPool.set(BOT_ID, fakeIngest())
 
@@ -1537,7 +1580,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
   it('an unrouted @mention in a channel gets the notice but NO conversation report', async () => {
     const reportBotConversation = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ reportBotConversation }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     internals.router.upsert(gatedAssignment())
     const ingest = fakeIngest()
     internals.slackPool.set(BOT_ID, ingest)
@@ -1556,7 +1599,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     const manager = new RelayIngressManager(
       deps({ getDaemon: () => ({ sendMsg }) as unknown as RelayDaemonConnection })
     )
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const assigned: BotAssignment = {
       botId: BOT_ID,
       platform: 'feishu',
@@ -1619,7 +1662,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
   /** Two manager instances = two relay pods; only the authority pod may post. */
   const pod = (authority: boolean) => {
     const manager = new RelayIngressManager(deps({ selfRelayId: () => (authority ? SELF_RELAY : PEER_RELAY) }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const ingest = fakeIngest()
     internals.router.upsert(gatedAssignment()) // noticeAuthority = SELF_RELAY
     internals.slackPool.set(BOT_ID, ingest)
@@ -1692,7 +1735,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     const sendMsg = vi.fn(async (msg: RdMsgIm): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
     const daemon = { sendMsg } as unknown as RelayDaemonConnection
     const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, selfRelayId: () => SELF_RELAY }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const ingest = fakeIngest()
     internals.slackPool.set(BOT_ID, ingest)
     internals.router.upsert({
@@ -1737,7 +1780,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
   it('no authority stamped (old CP / empty roster): no pod posts; DM discovery still reports', async () => {
     const reportBotConversation = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ reportBotConversation, selfRelayId: () => SELF_RELAY }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const a = gatedAssignment()
     delete a.noticeAuthority
     internals.router.upsert(a)
@@ -1754,7 +1797,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
   it('reports a public DM even when the bot has no gated members, without a notice', async () => {
     const reportBotConversation = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ reportBotConversation }))
-    const internals = manager as unknown as ManagerInternals
+    const internals = internalsOf(manager)
     const a = gatedAssignment()
     a.gatedAgentIds = []
     internals.router.upsert(a)
@@ -1794,19 +1837,6 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
   const sigFor = (secret: string, raw: Buffer) =>
     `v0=${createHmac('sha256', secret).update(`v0:${ts}:${raw}`).digest('hex')}`
 
-  interface DemuxInternals {
-    router: BotArbitrationRouter
-    slackPool: {
-      set(
-        botId: string,
-        ingest: { signingSecret: string; stop(): Promise<void>; handleEvent(e?: unknown, at?: number): Promise<void> }
-      ): void
-      get(botId: string): { signingSecret: string } | undefined
-    }
-    feishuPool: { get(botId: string): unknown }
-    slackDemux: import('./platforms/registry.js').DemuxIndex
-  }
-
   /** Register a bot the way `assign()` would, minus the network-touching ingest
    *  start: router assignment + a secret-bearing ingest stand-in + (for a
    *  team-scoped bot) the assign-derived composite index entries. */
@@ -1816,7 +1846,7 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     signingSecret: string,
     opts: { apiAppId?: string; teamId?: string; indexed?: boolean } = {}
   ) => {
-    const internals = manager as unknown as DemuxInternals
+    const internals = internalsOf(manager)
     internals.slackPool.set(botId, {
       signingSecret,
       stop: async () => {},
@@ -1863,7 +1893,7 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     addBot(manager, BOT_T1, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T1' })
     addBot(manager, BOT_T2, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T2' })
 
-    const internals = manager as unknown as DemuxInternals
+    const internals = internalsOf(manager)
     await expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T1' })).resolves.toBe(BOT_T1)
     await expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T2' })).resolves.toBe(BOT_T2)
   })
@@ -1876,7 +1906,7 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     addBot(manager, BOT_T1, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T1', indexed: false })
     addBot(manager, BOT_T2, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T2', indexed: false })
 
-    const internals = manager as unknown as DemuxInternals
+    const internals = internalsOf(manager)
     await expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T2' })).resolves.toBe(BOT_T2)
     // The scan hit must not poison the app-only learned map for a team-scoped bot.
     expect(internals.slackDemux.indexes.byApp.has(PLATFORM_APP)).toBe(false)
@@ -1895,7 +1925,7 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     addBot(manager, BOT_LEGACY, 'legacy-secret', {}) // no app id stamped — scan learns it
 
-    const internals = manager as unknown as DemuxInternals
+    const internals = internalsOf(manager)
     await expect(resolve(manager, { apiAppId: 'ALEGACY', secret: 'legacy-secret' })).resolves.toBe(BOT_LEGACY)
     expect(internals.slackDemux.indexes.byApp.get('ALEGACY')).toBe(BOT_LEGACY)
     // A team-scoped envelope still resolves the legacy bot (guard only skips
@@ -1910,7 +1940,7 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
   // release would tear down the ingest of a credential it never described.
   it('unassign carrying an OLDER generation than the held assignment is ignored', async () => {
     const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
-    const internals = manager as unknown as DemuxInternals
+    const internals = internalsOf(manager)
     internals.slackPool.set(BOT_T1, { signingSecret: SHARED_SECRET, stop: async () => {} })
     internals.router.upsert({
       ...assignment(),
@@ -1940,9 +1970,145 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     addBot(manager, BOT_T1, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T1' })
 
     await manager.unassign(BOT_T1)
-    const internals = manager as unknown as DemuxInternals
+    const internals = internalsOf(manager)
     expect(internals.slackDemux.indexes.byAppTenant.size).toBe(0)
     // The reverse map is DemuxIndex-internal now; an empty composite index IS the proof.
     await expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T1' })).resolves.toBeUndefined()
+  })
+})
+
+/**
+ * A THIRD platform, registered only here.
+ *
+ * The lifecycle findings (audit F2/F3/F4) were all hand lists of `slack` +
+ * `feishu` — and for exactly those two ids a hand list is COMPLETE, so a suite
+ * built from the real platforms passes against the broken code and proves
+ * nothing. Only an id the hand list does not name can tell the two versions
+ * apart. This fixture is that id: it implements the §8 contract and nothing
+ * else, with no credentials, no HTTP, and no I/O.
+ */
+const SYNTHETIC = 'synthetic'
+
+interface SyntheticIngest extends RelayBotIngress {
+  /** Bumped by `stop()`. Teardown must reach it, and reach it exactly once. */
+  stops: number
+}
+
+/** @param built Every ingest this plugin has been asked to build, in order. */
+const syntheticPlugin = (built: SyntheticIngest[]): RelayPlatformIngressPlugin => ({
+  platformId: SYNTHETIC,
+  installRoutes: () => {},
+  buildIngest: () => {
+    const ingest: SyntheticIngest = {
+      stops: 0,
+      stop: () => {
+        ingest.stops += 1
+      }
+    }
+    built.push(ingest)
+    return ingest
+  },
+  extractDemuxHints: () => ({}),
+  verify: () => undefined,
+  handle: async () => ({})
+})
+
+/** An assignment for the synthetic platform, carrying a tenant-scoped identity
+ *  so the COMPOSITE index entry — the one whose survival is the cross-tenant
+ *  delivery hazard `DemuxIndex` exists to prevent — actually gets written. */
+const syntheticAssignment = (over: Partial<BotAssignment> = {}): BotAssignment => ({
+  ...assignment(),
+  platform: SYNTHETIC,
+  secrets: { verificationToken: 'synthetic-token' },
+  apiAppId: 'SYNTH_APP',
+  teamId: 'SYNTH_TENANT',
+  ...over
+})
+
+describe('RelayIngressManager lifecycle is registry-driven (a third platform)', () => {
+  const build = () => {
+    const built: SyntheticIngest[] = []
+    const manager = new RelayIngressManager(deps(), [...relayIngressPlugins, syntheticPlugin(built)])
+    return { built, manager, internals: internalsOf(manager) }
+  }
+
+  it('registers beside the real platforms rather than replacing them', () => {
+    const { internals } = build()
+    expect(internals.entryFor('slack')).toBeDefined()
+    expect(internals.entryFor('feishu')).toBeDefined()
+    expect(internals.entryFor(SYNTHETIC)).toBeDefined()
+  })
+
+  it('unassign stops the ingest, drops the pool entry, and forgets the demux entries', async () => {
+    const { built, manager, internals } = build()
+    await manager.assign(syntheticAssignment())
+
+    const entry = internals.entryFor(SYNTHETIC)
+    expect(entry.pool.get(BOT_ID)).toBeDefined()
+    expect(entry.demux.indexes.byAppTenant.size).toBe(1)
+
+    await manager.unassign(BOT_ID)
+
+    // Named-pool teardown reached none of these: the ingest kept running, its
+    // pool entry leaked, and the composite entry outlived the assignment that
+    // derived it.
+    expect(built[0]?.stops).toBe(1)
+    expect(entry.pool.get(BOT_ID)).toBeUndefined()
+    expect(entry.demux.indexes.byAppTenant.size).toBe(0)
+    expect(entry.demux.indexes.byApp.size).toBe(0)
+  })
+
+  it('re-assign stops the previous ingest instead of rebuilding beside it', async () => {
+    const { built, manager, internals } = build()
+    await manager.assign(syntheticAssignment())
+    await manager.assign(syntheticAssignment({ credentialRevision: 2 }))
+
+    expect(built).toHaveLength(2)
+    expect(built[0]?.stops).toBe(1)
+    expect(built[1]?.stops).toBe(0)
+    // Exactly one live instance, and it is the rebuild.
+    expect(internals.entryFor(SYNTHETIC).pool.get(BOT_ID)).toBe(built[1])
+  })
+
+  it('re-assign forgets the previous identity before indexing the new one', async () => {
+    const { manager, internals } = build()
+    await manager.assign(syntheticAssignment())
+    // This install lost its tenant scope AND moved app id. Both old entries
+    // must go, or a stale one keeps resolving deliveries onto this bot.
+    await manager.assign(syntheticAssignment({ apiAppId: 'SYNTH_APP_2', teamId: undefined }))
+
+    const { demux } = internals.entryFor(SYNTHETIC)
+    expect(demux.indexes.byAppTenant.size).toBe(0)
+    expect(demux.resolve({ appId: 'SYNTH_APP' })).toBeUndefined()
+    expect(demux.resolve({ appId: 'SYNTH_APP_2' })).toBe(BOT_ID)
+  })
+
+  it('stopAll closes a third platform’s ingests', async () => {
+    const { built, manager, internals } = build()
+    await manager.assign(syntheticAssignment())
+
+    await manager.stopAll()
+
+    expect(built[0]?.stops).toBe(1)
+    expect(internals.entryFor(SYNTHETIC).pool.get(BOT_ID)).toBeUndefined()
+  })
+
+  it('leaves a real platform’s teardown unchanged', async () => {
+    const { manager, internals } = build()
+    // Feishu rides the same registry-driven teardown. Its ingest is a pure
+    // decoder, so "nothing to stop, only to drop" is now its own `stop()`'s
+    // business rather than a per-platform comment in core.
+    await manager.assign({
+      ...assignment(),
+      platform: 'feishu',
+      secrets: { verificationToken: 'verify-token' },
+      apiAppId: 'cli_example'
+    })
+    expect(internals.feishuPool.get(BOT_ID)).toBeDefined()
+    expect(internals.entryFor('feishu').demux.indexes.byApp.size).toBe(1)
+
+    await manager.unassign(BOT_ID)
+    expect(internals.feishuPool.get(BOT_ID)).toBeUndefined()
+    expect(internals.entryFor('feishu').demux.indexes.byApp.size).toBe(0)
   })
 })

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -29,9 +29,7 @@ import type {
 import type { Clock } from '@agentconnect.md/connection'
 import type { Logger } from './log.js'
 import { BotArbitrationRouter, sessionKeyOf, type BotAssignment, type RouteTarget } from './bot-arbitration.js'
-import { SlackHttpIngest } from './platforms/slack/http-ingest.js'
-import { FeishuHttpIngest } from './platforms/feishu/http-ingest.js'
-import { DemuxIndex, IngressPool } from './platforms/registry.js'
+import { DemuxIndex, IngressPool, relayIngressPlugins } from './platforms/registry.js'
 import type {
   HandledDelivery,
   RelayBotIngress,
@@ -39,8 +37,6 @@ import type {
   RelayPlatformIngressPlugin
 } from './platforms/contract.js'
 import { SlackEventDedup } from './slack-event-dedup.js'
-import { slackIngressPlugin } from './platforms/slack/ingress-plugin.js'
-import { feishuIngressPlugin } from './platforms/feishu/ingress-plugin.js'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
 
 /** Cap on the learned `api_app_id → botId` demux index before it is flushed. */
@@ -127,50 +123,36 @@ export interface RelayIngressManagerDeps {
   log: Logger
 }
 
-// The interaction dedup-id minters moved into their platform plugins (§8: the
-// plugin mints the dedup id; core owns the table). Re-exported for existing
-// importers until the route files migrate.
-export { httpSlackActionMsgId, httpSlackShortcutMsgId } from './platforms/slack/ingress-plugin.js'
-export { httpFeishuActionMsgId } from './platforms/feishu/ingress-plugin.js'
+/** One registered platform's live state: its plugin, its pool of per-bot
+ *  ingests, and its demux identity index. The pool holds ONLY ingests this
+ *  plugin built, which is what lets core hand a pooled ingest straight back to
+ *  `plugin.verify` / `plugin.handle` through the erased `RelayBotIngress`
+ *  bound — core never reads a `TIngest`'s internals (§8). */
+interface RelayPlatformEntry {
+  plugin: RelayPlatformIngressPlugin
+  pool: IngressPool<RelayBotIngress>
+  demux: DemuxIndex
+}
 
 export class RelayIngressManager {
   private readonly router = new BotArbitrationRouter()
-  /** §8 registry (S3): one pool of per-bot ingests per platform, and one demux
-   *  identity index beside each pool. The index owns the composite/app-only
-   *  decision per ASSIGNMENT shape (tenant-scoped ⇒ composite only, never
-   *  learned; app-only ⇒ learnable) — see platforms/registry.ts. */
-  private readonly slackPool = new IngressPool<SlackHttpIngest>('slack')
-  private readonly feishuPool = new IngressPool<FeishuHttpIngest>('feishu')
-  private readonly slackDemux = new DemuxIndex()
-  private readonly feishuDemux = new DemuxIndex()
-  /** §8 plugin registry: adding a platform adds one entry — assign() never
-   *  grows a branch. The typed pools above stay for the typed read sites
-   *  (resolveVerified pair), aliased into the entries here. */
-  private readonly ingressPlugins = new Map<
-    string,
-    {
-      plugin: RelayPlatformIngressPlugin<SlackHttpIngest | FeishuHttpIngest, unknown>
-      pool: IngressPool<SlackHttpIngest | FeishuHttpIngest>
-      demux: DemuxIndex
-    }
-  >([
-    [
-      'slack',
-      {
-        plugin: slackIngressPlugin as never,
-        pool: this.slackPool as IngressPool<SlackHttpIngest | FeishuHttpIngest>,
-        demux: this.slackDemux
-      }
-    ],
-    [
-      'feishu',
-      {
-        plugin: feishuIngressPlugin as never,
-        pool: this.feishuPool as IngressPool<SlackHttpIngest | FeishuHttpIngest>,
-        demux: this.feishuDemux
-      }
-    ]
-  ])
+  /**
+   * §8 registry (S3): one entry per REGISTERED platform — its plugin, one pool
+   * of per-bot ingests, and one demux identity index. Adding a platform adds
+   * one line to `platforms/registry.ts`; no method here grows a branch, and no
+   * method here names a platform.
+   *
+   * Every lifecycle edge reads this map: assign builds through it, inbound
+   * demuxes through it, and teardown/shutdown iterate it (audit F2/F3/F4 —
+   * before that, three of them named `slackPool`/`feishuPool` directly and a
+   * third platform's ingest was never stopped, its pool entry never dropped,
+   * and its demux entries never forgotten).
+   *
+   * The index owns the composite/app-only decision per ASSIGNMENT shape
+   * (tenant-scoped ⇒ composite only, never learned; app-only ⇒ learnable) —
+   * see platforms/registry.ts.
+   */
+  private readonly ingressPlugins: ReadonlyMap<string, RelayPlatformEntry>
   /** Core's side of the §8 contract — what a plugin's ingest may call back
    *  into. Every member maps onto the same manager/router machinery the
    *  pre-plugin callbacks used; nothing here is platform-shaped. */
@@ -262,7 +244,24 @@ export class RelayIngressManager {
     }
   }
 
-  constructor(private readonly deps: RelayIngressManagerDeps) {}
+  /**
+   * @param plugins The platform set this manager serves. Defaults to the static
+   *   registry — production never passes it. Tests inject a synthetic platform
+   *   to prove the lifecycle is registry-driven rather than slack+feishu-shaped,
+   *   which is the only way to catch an F2/F3/F4 regression: a suite built from
+   *   the two real platforms passes against the hand-named version too.
+   */
+  constructor(
+    private readonly deps: RelayIngressManagerDeps,
+    plugins: readonly RelayPlatformIngressPlugin[] = relayIngressPlugins
+  ) {
+    this.ingressPlugins = new Map(
+      plugins.map((plugin) => [
+        plugin.platformId,
+        { plugin, pool: new IngressPool<RelayBotIngress>(plugin.platformId), demux: new DemuxIndex() }
+      ])
+    )
+  }
 
   /** Emit a thread-assign report; on a non-READY CP link stash it for retry. */
   private report(m: RcThreadAssign): void {
@@ -405,8 +404,7 @@ export class RelayIngressManager {
     this.router.upsert(a)
     // Rebuild the ingest (secrets or transport may have rotated). Idempotent.
     await this.stopIngest(a.botId)
-    this.slackDemux.forget(a.botId)
-    this.feishuDemux.forget(a.botId)
+    this.forgetDemux(a.botId)
 
     // §8 plugin registry: the platform's plugin validates the assignment shape
     // and builds the per-bot ingest; the demux index derives the identity scope
@@ -467,8 +465,7 @@ export class RelayIngressManager {
       return
     }
     this.clearConversationReportLatches(botId)
-    this.slackDemux.forget(botId)
-    this.feishuDemux.forget(botId)
+    this.forgetDemux(botId)
     this.router.remove(botId)
     await this.stopIngest(botId)
   }
@@ -535,12 +532,6 @@ export class RelayIngressManager {
     return entry.plugin.handle(hit.ingest, hit.verified, this.ingressHost)
   }
 
-  /** Test/inspection view of the demux indexes (no secret material). */
-  get demuxIndexes(): { byApiApp: ReadonlyMap<string, string>; byAppTeam: ReadonlyMap<string, string> } {
-    const { byApp, byAppTenant } = this.slackDemux.indexes
-    return { byApiApp: byApp, byAppTeam: byAppTenant }
-  }
-
   /** Make the inline selector effective for the current Slack thread immediately.
    *  The CP channel-owner update remains the durable/default side of the same choice;
    *  local affinity closes the gap for ordinary, un-mentioned follow-up messages. */
@@ -558,20 +549,16 @@ export class RelayIngressManager {
     this.report({ botId, sessionKey, agentId: route.agentId, daemonId: route.daemonId })
   }
 
-  /** Close every ingest (relay shutdown). */
+  /** Close every ingest (relay shutdown) — across every REGISTERED platform,
+   *  not the union of two named pools (audit F4). */
   async stopAll(): Promise<void> {
     if (this.revokeRetryTimer) {
       clearTimeout(this.revokeRetryTimer)
       this.revokeRetryTimer = undefined
     }
-    await Promise.all(
-      [
-        ...new Set([
-          ...[...this.slackPool.entries()].map(([id]) => id),
-          ...[...this.feishuPool.entries()].map(([id]) => id)
-        ])
-      ].map((id) => this.stopIngest(id))
-    )
+    const bots = new Set<string>()
+    for (const { pool } of this.ingressPlugins.values()) for (const [botId] of pool.entries()) bots.add(botId)
+    await Promise.all([...bots].map((id) => this.stopIngest(id)))
   }
 
   /** The bot's live ingest, found through its ASSIGNMENT's platform entry —
@@ -583,14 +570,35 @@ export class RelayIngressManager {
     return entry?.pool.get(botId)
   }
 
+  /**
+   * Tear `botId`'s ingest down wherever it lives (audit F2).
+   *
+   * EVERY pool is asked rather than the one its assignment names, and that is
+   * required, not defensive: `unassign` removes the routing entry BEFORE
+   * calling this, so by now there is no assignment left to look the platform up
+   * from. It is also what the two hand-named pools did, in this same order.
+   *
+   * Per pool the order is unchanged — drop the entry FIRST, then stop — so a
+   * concurrent inbound delivery can never demux onto an ingest that is closing.
+   * "Nothing to stop, only to drop" stopped being core's business here: it is
+   * `RelayBotIngress.stop()`'s, and a pure decoder implements it as a no-op.
+   */
   private async stopIngest(botId: string): Promise<void> {
-    const cur = this.slackPool.get(botId)
-    if (cur) {
-      this.slackPool.delete(botId)
+    for (const { pool } of this.ingressPlugins.values()) {
+      const cur = pool.get(botId)
+      if (!cur) continue
+      pool.delete(botId)
       await cur.stop()
     }
-    // A Feishu ingest is a pure decoder — nothing to stop, only to drop.
-    this.feishuPool.delete(botId)
+  }
+
+  /** Drop every demux entry for `botId`, through the registry rather than a
+   *  hand list of two (audit F3). A surviving composite entry is exactly the
+   *  cross-tenant delivery hazard {@link DemuxIndex} exists to prevent, so no
+   *  platform may be left out of the sweep; `forget` evicts BOTH the composite
+   *  entry and every app-only entry pointing at the bot. */
+  private forgetDemux(botId: string): void {
+    for (const { demux } of this.ingressPlugins.values()) demux.forget(botId)
   }
 
   private isAgentBotMessage(botId: string, msg: import('@agentconnect.md/protocol').WireNormalizedMessage): boolean {


### PR DESCRIPTION
Closes the relay half of the S3 exit reconciliation's findings list
(`docs/designs/integration-plugin-audit.md` §10.6): **F2, F3, F4, F5, F6, F7**.
All six are fixed — none accepted.

The audit's verdict on the relay was "registry is the single platform-set
authority: **met with exceptions**", and every exception was on the *lifecycle*
path rather than the dispatch path. `assign()` and `handleInbound()` already
resolved through `ingressPlugins`; teardown, demux cleanup, shutdown and route
mounting still spelled `slack` and `feishu` out by hand.

## What

### F2 · `stopIngest` named `slackPool`/`feishuPool` (`relay-ingress-manager.ts:586-593`)

**Fixed.** Teardown iterates `ingressPlugins.values()`. A third platform's
ingest was previously never stopped and its pool entry never dropped, so a
rebuild on re-assign would run beside the stale instance.

Two things the new implementation has to get right, both written down in the
code:

- **Every pool is asked, not the one the assignment names.** `unassign` calls
  `this.router.remove(botId)` *before* `stopIngest`, so by then there is no
  assignment left to look the platform up from — `ingestFor()`'s assignment-based
  lookup is unusable here. This is also exactly what the two hand-named pools
  did.
- **Per-pool order is unchanged**: drop the entry first, *then* `await stop()`,
  so a concurrent inbound can never demux onto a closing ingest. Registry
  insertion order (slack, feishu) matches the old sequence.

The per-platform comment *"A Feishu ingest is a pure decoder — nothing to stop,
only to drop"* was core knowing a platform detail. It is now
`RelayBotIngress.stop()`'s own business; `FeishuHttpIngest.stop()` already
existed as a no-op, so Feishu behaviour is byte-identical.

### F3 · `assign`/`unassign` called `slackDemux.forget` + `feishuDemux.forget` (`:408-409, :470-471`)

**Fixed.** Both call one `forgetDemux(botId)` that sweeps every registry entry.
`DemuxIndex.forget` still evicts **both** the composite `(appId, tenantId)`
entry and every app-only entry pointing at the bot — the tenant-scope invariant
(composite-index-only, never learned, eagerly cleaned) is untouched; the fix is
that no platform can now be left out of the sweep. A surviving composite entry
is precisely the cross-tenant delivery hazard `DemuxIndex` exists to prevent.

Call-site ordering is preserved as-is, including the fact that the two differ:
`assign` forgets *after* `stopIngest`, `unassign` *before* it.

### F4 · `stopAll` unioned two named pools (`:570-571`)

**Fixed.** The bot-id set is collected across every registry entry's pool, then
each is torn down through the same `stopIngest`.

### F5 · HTTP ingress routes mounted by name (`index.ts:198-199`)

**Fixed, not accepted** — the contract gains the route facet.

`RelayPlatformIngressPlugin` now has `installRoutes(app, deps)`, the relay's
twin of the member the CP adopted in #605 (`installRoutes(scope)`), and the
bootstrap loops over `relayIngressPlugins` instead of calling
`registerSlackHttpIngress` / `registerFeishuHttpIngress` by name.

**Why fix rather than accept.** The accept option would have to argue that the
relay's route surface is not a real seam — but it has two implementers with a
*byte-identical* dependency shape (`{ manager: () => …, log }`) and an
identical resolver interface, both duplicated per platform. That is a seam that
already exists and is simply unnamed. The CP faced the same shape and closed it;
leaving the relay's open would mean a third platform implements the whole
contract and still silently receives no traffic until someone edits `index.ts`,
which is the failure mode §12's rule exists to prevent.

**Why it is safe.** Both implementations are a *reference to the existing
register function* (`installRoutes: registerSlackHttpIngress`), so the plugin
declares the same paths it always did and the move cannot relocate a URL. That
matters more here than in most refactors: public callback URLs are external
contracts, baked into a platform app's event-subscription config and into the
deployment gateway's routing, and this repo has already been bitten by a
public/internal prefix mismatch turning a live callback into a 404. The new
`platforms/route-mounts.test.ts` pins paths × plugin by enumeration, following
the CP's `platform-route-mounts.test.ts` precedent — it asks Fastify what
landed rather than restating the new code.

The two identical per-platform resolver interfaces (`SlackIngestResolver` /
`FeishuIngestResolver`) collapse into one `RelayInboundSeam` in the contract,
with `RelayIngressRouteDeps` beside it.

### F6 · stale rationale for the typed twin pools (`:146-148`)

**Fixed.** The comment defended keeping `slackPool`/`feishuPool` "for the typed
read sites (`resolveVerified` pair)"; that pair was deleted in #575. The comment
and the fields both go — the registry builds one `IngressPool<RelayBotIngress>`
per entry.

Forced by the same removal: the `demuxIndexes` getter, which read `slackDemux`
and returned Slack-named keys (`byApiApp`/`byAppTeam`). It had **zero callers**
repo-wide — its last one went with the `resolveVerified` pair — so it is
deleted rather than re-expressed.

### F7 · stale re-export shim for the dedup-id minters (`:130-134`)

**Fixed.** `httpSlackActionMsgId`, `httpSlackShortcutMsgId` and
`httpFeishuActionMsgId` are no longer re-exported from core. The route files
migrated in #571; the last importer was `relay-ingress-manager.test.ts`, which
now imports them from the plugins that own them.

### Incidental, in files this PR already rewrites

The `platforms/registry.ts` module gains `relayIngressPlugins` — the static
plugin list the host convention already calls for, previously built inline as a
private field in the manager with two `as never` casts. Erasing entries to the
contract's default bound turns out to need no casts at all.

Dead residue removed from the two route files while their imports were being
rewritten, all of it left behind by #575's deletion of `resolveVerified`: the
Slack route's `signature`/`timestamp` locals (assigned, never read — the
plugin's `verify` reads the headers itself) with the `headerString` helper they
were the only users of, an unreferenced `eventDedupKey`, Feishu's unused
`FEISHU_CARD_ACTION_RESPONSE_TIMEOUT_MS` (the plugin owns the live one) and its
unreferenced `FeishuVerifiedDelivery`.

## Tests

`pnpm --filter @agentconnect.md/relay test` — **439 passed, 25 files** (up from
429 / 24 at the audit's pinned SHA, re-baselined on current `main`).
`tsc --noEmit`, `eslint`, `prettier --check` all clean.

**A synthetic third platform** (`relay-ingress-manager.test.ts`, 6 new cases).
This is the point of the suite rather than a nicety: F2/F3/F4 are hand lists of
`slack` + `feishu`, and *for those two ids a hand list is complete* — a suite
built from the real platforms passes against the broken code and proves nothing.
Only an id the hand list does not name can tell the two versions apart. The
fixture implements the §8 contract and nothing else: no credentials, no HTTP, no
I/O, injected through a new optional second constructor argument that production
never passes.

Cases: registers beside the real two · unassign stops the ingest, drops the pool
entry and forgets the demux entries · re-assign stops the previous ingest
instead of rebuilding beside it · re-assign forgets the previous identity before
indexing the new one · `stopAll` closes it · a real platform's teardown is
unchanged.

**Verified these fail against the old behaviour.** Temporarily reverting the
three loops to `[get('slack'), get('feishu')]` fails exactly the four
behavioural cases (`expected +0 to be 1` on the stop counter, on the leaked
composite entry, and on the surviving pool entry); the two structural cases pass
in both, as guards should.

**`platforms/route-mounts.test.ts`** (4 new cases) pins the mount table by
enumeration: each plugin mounted alone into a bare Fastify app, then the whole
registry mounted the way the bootstrap does it, both captured through an
`onRoute` hook and compared against the routes the pre-refactor bootstrap
actually registered — `POST /slack/events`, `POST /slack/interactions`,
`POST /feishu/events`. A registered platform that mounts nothing also fails.

The existing suite's reach-ins to `internals.slackPool` / `internals.slackDemux`
now resolve through one `internalsOf()` helper that reads the registry entry, so
the assertions themselves are untouched.

## Behavior

None intended, and none for slack or feishu:

- `stopIngest` now calls `stop()` on a Feishu ingest where it previously only
  dropped the pool entry. `FeishuHttpIngest.stop()` is an existing no-op, so
  the only difference is one awaited microtask inside an already-async method.
- Route paths are unchanged by construction and pinned by the new test.
- Everything else is a rename or a deletion of code with no callers.

The behaviour that *does* change is for a hypothetical third platform, which is
the defect: its ingest is now stopped, its pool entry dropped, its demux entries
forgotten, and it is closed at shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
