### PR TITLE
refactor(control-plane): retire the CP's six hand-copied platform sets (audit F8–F13)

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -165,6 +165,7 @@ import { ensureDiscordMessageContentIntent, verifyDiscordBot } from './http/disc
 import { createDiscordBotProfileSyncer } from './http/discord-bot-profile.js'
 import type { CpPlatformRegistry } from './platforms/provider.js'
 import { buildCpPlatformRegistry } from './platforms/registry.js'
+import { botIdentityProjector } from './platforms/bot-identity.js'
 import { buildPendingInstallReapers, platformBackgroundLoops } from './platforms/lifecycle.js'
 import { createTelegramCpProvider } from './platforms/telegram/provider.js'
 import { createDiscordCpProvider } from './platforms/discord/provider.js'
@@ -267,6 +268,24 @@ export function buildContainer(
   // instance — and therefore the one configured cipher.
   const organizationEnvironmentSecrets = new PgOrganizationEnvironmentSecretStore(prisma, secretCipher)
 
+  // LATE-BOUND platform registry (§9). The providers are constructed FAR below —
+  // they close over `httpDeps`, whose own route plugins do not exist yet — but
+  // holders built here (the bot repo's D6 identity projection, the orchestrators'
+  // spec assembly and `rc/bot-assign`) already need to reach them. `platforms` is
+  // a stable façade every holder can capture now; it forwards to the composed
+  // registry, and every read runs at write / reconcile / sync / request time,
+  // long after `buildContainer` has assigned it.
+  let composedPlatforms: CpPlatformRegistry | undefined = undefined
+  const requirePlatforms = (): CpPlatformRegistry => {
+    if (!composedPlatforms) throw new Error('platform registry read before composition')
+    return composedPlatforms
+  }
+  const platforms: CpPlatformRegistry = {
+    get: (platformId) => requirePlatforms().get(platformId),
+    all: () => requirePlatforms().all(),
+    ids: () => requirePlatforms().ids()
+  }
+
   // ── C6 repositories (the ONLY @prisma/client importers) ───────────────────
   const repos = {
     daemon: new PgDaemonRepo(prisma),
@@ -286,7 +305,9 @@ export function buildContainer(
     lease: new PgSecretLeaseRepo(prisma),
     integration: new PgIntegrationRepo(prisma),
     integrationChannel: new PgIntegrationChannelRepo(prisma),
-    bot: new PgBotRepo(prisma),
+    // §11 D6 dual-write: which columns carry this bot's demux identity is the
+    // provider's declaration, read at write time through the façade above.
+    bot: new PgBotRepo(prisma, botIdentityProjector(platforms)),
     botSecret: new PgBotSecretStore(prisma, secretCipher),
     // Owns its transaction: install/revoke each write two tables behind the
     // credential-generation fence, and serialize on the bot row (§5.3).
@@ -531,23 +552,6 @@ export function buildContainer(
 
   // The single fencing site (allocates seq, stamps epoch/launchId on C→D frames).
   const sender = new ControlSender(connReg, repos.launch)
-
-  // LATE-BOUND platform registry (§9). The providers are constructed FAR below —
-  // they close over `httpDeps`, whose own route plugins do not exist yet — but the
-  // orchestrators built here already need to reach them (spec assembly,
-  // `rc/bot-assign`). `platforms` is a stable façade every holder can capture now;
-  // it forwards to the composed registry, and every read runs at reconcile /
-  // sync / request time, long after `buildContainer` has assigned it.
-  let composedPlatforms: CpPlatformRegistry | undefined = undefined
-  const requirePlatforms = (): CpPlatformRegistry => {
-    if (!composedPlatforms) throw new Error('platform registry read before composition')
-    return composedPlatforms
-  }
-  const platforms: CpPlatformRegistry = {
-    get: (platformId) => requirePlatforms().get(platformId),
-    all: () => requirePlatforms().all(),
-    ids: () => requirePlatforms().ids()
-  }
 
   // Per-session memory-capture gate convergence (session-visibility.md §5.1):
   // the CP is the authority on effective visibility; daemons only enforce it.

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -30,6 +30,7 @@ import {
   normalizeRepoSubdir
 } from '@agentconnect.md/protocol'
 import { HEX_COLOR_RE, AGENT_ICON_GLYPHS } from '../../agents/agent-icon.js'
+import { CP_PLATFORM_IDS } from '../../platforms/ids.js'
 
 // ── per-resource visibility / sharing (docs/designs/resource-visibility.md) ──
 /** 'org' = visible to every org member (default); 'restricted' = the complete
@@ -1805,10 +1806,23 @@ export const MeAccessDto = z.object({
 export const WaitlistJoinBody = z.object({
   name: z.string().trim().min(1).max(120),
   company: z.string().trim().min(1).max(120),
-  platform: z
-    .array(z.enum(['slack', 'telegram', 'discord']))
-    .min(1)
-    .max(3),
+  /**
+   * DECIDED (audit F11): marketing intake TRACKS THE REGISTRY.
+   *
+   * The question this answers is "which of the platforms AgentConnect serves
+   * will your team use", so its vocabulary is the served set — there is no
+   * separate marketing vocabulary here, no demand-signal option for a platform
+   * we do not run, and no served platform deliberately withheld. The hand copy
+   * proved that by drifting: it stayed at three ids after Feishu shipped, so a
+   * Feishu team simply could not say so, and the `.max(3)` cap was a second
+   * spelling of the same count. Both now come from the registry declaration.
+   *
+   * Widening is the safe direction for an intake enum — the server accepts a
+   * superset of what any client sends, so a console still offering three
+   * chips keeps working. (The console's own chip list is web-owned and is
+   * still three; that is a display gap, not a rejection.)
+   */
+  platform: z.array(z.enum(CP_PLATFORM_IDS)).min(1).max(CP_PLATFORM_IDS.length),
   teamSize: z.string().trim().min(1).max(40),
   useCase: z.string().trim().max(2000).optional()
 })
@@ -2034,7 +2048,13 @@ export const UpdateOrgBody = z
   )
 
 // ── crons ────────────────────────────────────────────────────────────────
-export const Platform = z.enum(['slack', 'telegram', 'discord', 'feishu'])
+/** The cron/hook OUTPUT-ANCHOR vocabulary: which platform a scheduled or
+ *  webhook-triggered run may post its anchor into. That is the set of platforms
+ *  this build can deliver to, so it tracks the platform registry (through its
+ *  static declaration — this schema is built at module load, before any
+ *  container exists) instead of a fourth hand-written union. `hooks.ts` and
+ *  `mcp/tools.ts` read the same declaration; nothing re-spells it. */
+export const Platform = z.enum(CP_PLATFORM_IDS)
 
 /** `schedule` must parse as a croner expression — the documented field contract
  *  (§3.11 "croner expr"). Rejecting here keeps a def no daemon could ever
@@ -2081,6 +2101,12 @@ export const UpsertCronBody = z.object({
   // Omitted on create ⇒ the CP process timezone; edits from the console always
   // resend the stored value so a non-default timezone is never reset silently.
   timezone: ianaTimezone.optional(),
+  // The MEMBERS track the registry; the DEFAULT does not, and must not. A cron
+  // created before `targetPlatform` existed reads back as Slack, so `'slack'`
+  // here is an envelope legacy value (audit §6.8 / ambiguous row 7) that names
+  // the historical shape of stored rows — not a statement that Slack is first
+  // among platforms. Deriving it from the registry would make an unrelated
+  // registration order silently rewrite what a legacy row means.
   targetPlatform: Platform.default('slack'),
   // Optional output routing: post the trigger there and thread the agent's
   // replies under it. Absent/empty ⇒ headless fire.
@@ -2158,6 +2184,8 @@ const HookBodyBase = z.object({
   name: z.string().trim().min(1).max(120),
   enabled: z.boolean().default(true),
   // Optional output anchoring (same trio as crons; absent ⇒ headless fire).
+  // `'slack'` is the same envelope legacy default the cron body carries — a
+  // stored-row compatibility value, not a registry read (audit §6.8).
   targetPlatform: Platform.default('slack'),
   targetChannel: z.string().min(1).optional(),
   targetIntegrationId: z.string().uuid().optional()

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -18,6 +18,7 @@
 import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
 import { ApprovalsReviewer } from '@agentconnect.md/protocol'
+import { CP_PLATFORM_IDS } from '../../platforms/ids.js'
 
 /** What a tool needs to execute: the caller's org and credentialed requests
  *  against the versioned REST surface (`/api/v1`-relative paths). */
@@ -364,7 +365,9 @@ export const MCP_TOOLS: McpToolDef[] = [
         schedule: z.string().min(1).describe('Cron expression, croner syntax (e.g. "0 9 * * MON-FRI")'),
         timezone: z.string().min(1).optional().describe('IANA timezone name (e.g. "Asia/Shanghai")'),
         trigger: z.string().min(1).describe('The prompt sent to the agent on each firing'),
-        targetPlatform: z.enum(['slack', 'telegram', 'discord', 'feishu']).optional(),
+        // Same cron target vocabulary the REST body accepts (`dto/index.ts`
+        // `Platform`), from the one registry declaration rather than a fourth copy.
+        targetPlatform: z.enum(CP_PLATFORM_IDS).optional(),
         targetChannel: z.string().min(1).optional().describe('Channel to deliver into; omit for a headless run'),
         targetIntegrationId: z
           .string()

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -22,7 +22,7 @@ import { GitCredDeniedError, type ResolvedAgentRepoAuthorization } from '../../g
 import { AgentId, HookId, IntegrationId, OrgId } from '../../domain/ids.js'
 import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView } from '../../authorization/policy.js'
-import { toDbPlatform } from '../../persistence/platform.js'
+import { toDbPlatform, type DbPlatform } from '../../persistence/platform.js'
 import { AgentWorkspaceIntegrationConflict } from '../../persistence/errors.js'
 import { Tag } from '../plugins/openapi.js'
 import {
@@ -283,15 +283,15 @@ export function hookRoutes(deps: HttpDeps) {
     const resolveTarget = async (
       orgId: string,
       agentId: string,
+      // `DbPlatform` is the served set the anchor may target — the same registry
+      // declaration `Platform` (the request body's own enum) and `toDbPlatform`
+      // (the value returned below) read, instead of a third inline spelling.
       body: {
-        targetPlatform: 'slack' | 'telegram' | 'discord' | 'feishu'
+        targetPlatform: DbPlatform
         targetChannel?: string
         targetIntegrationId?: string
       }
-    ): Promise<
-      | { ok: true; targetPlatform: 'slack' | 'telegram' | 'discord' | 'feishu'; targetIntegrationId?: IntegrationId }
-      | { ok: false }
-    > => {
+    ): Promise<{ ok: true; targetPlatform: DbPlatform; targetIntegrationId?: IntegrationId } | { ok: false }> => {
       if (!(body.targetIntegrationId && body.targetChannel)) return { ok: true, targetPlatform: body.targetPlatform }
       const integ = await deps.repos.integration.get(IntegrationId(body.targetIntegrationId))
       if (!integ || integ.orgId !== orgId || integ.agentId !== agentId) return { ok: false }

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -18,6 +18,7 @@
 import type { FastifyInstance, FastifyReply } from 'fastify'
 import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
+import { manifestFor } from '@agentconnect.md/protocol'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
@@ -643,15 +644,20 @@ export function integrationRoutes(deps: HttpDeps) {
      * Does this platform need a durable suppression at all?
      *
      * Only the ones whose conversation list is rebuilt from session history — the
-     * daemon's `refreshObservedChannels` set. Slack re-lists its membership
-     * authoritatively, so its rows are governed by that listing and a tombstone would
-     * add nothing; demanding one would just make Forget fail whenever a Slack daemon
-     * is offline, for no gain. This is also why the multi-install fan-out below can
-     * never span several daemons today: a bot may only gain a second agent when it is
-     * shareable, and shareable is Slack-only.
+     * daemon's `refreshObservedChannels` set, which is exactly the manifest's
+     * `membershipEnumeration: 'observed'` arm (§5). A platform that re-lists its
+     * membership authoritatively has its rows governed by that listing and a
+     * tombstone would add nothing; demanding one would just make Forget fail
+     * whenever its daemon is offline, for no gain. This is also why the
+     * multi-install fan-out below can never span several daemons today: a bot may
+     * only gain a second agent when it is shareable, and shareable is Slack-only.
+     *
+     * Reading the manifest rather than naming the three observed platforms also
+     * makes the miss arm fail-closed: an id this build does not know gets
+     * `DEFAULT_MANIFEST` (`'observed'`) and is asked for a suppression, instead of
+     * being silently treated as authoritative.
      */
-    const needsSuppression = (platform: string): boolean =>
-      platform === 'telegram' || platform === 'discord' || platform === 'feishu'
+    const needsSuppression = (platform: string): boolean => manifestFor(platform).membershipEnumeration === 'observed'
 
     const pushForget = async (
       integration: IntegrationRecord,
@@ -1008,18 +1014,28 @@ export function integrationRoutes(deps: HttpDeps) {
         if (!admitted) return
         const { integration, agent, bot } = admitted
         const target = req.body.target
-        if (target.kind === 'space' && integration.platform !== 'discord') {
+        // Which target shape this platform can actually serve — the §5 manifest's
+        // `leaveGranularity`, earned by this branch (it is a genuine PRE-DISPATCH
+        // read: the shape is validated before an owner resolves, before the
+        // mutation lease, and before any daemon is reached). The same axis is the
+        // daemon's two leave members and the web module's
+        // `WebChannelListSemantics.leave`; core now reads the declaration those
+        // two describe instead of re-spelling "Discord is the one with servers".
+        // Fail-closed on an unknown id: `'conversation'`, exactly the arm the
+        // `!== 'discord'` comparison took.
+        const leaves = manifestFor(integration.platform).leaveGranularity
+        if (target.kind === 'space' && leaves !== 'space') {
           return reply.code(400).send({
             error: 'Bad Request',
             statusCode: 400,
-            message: 'only Discord has a server to leave; leave the conversation instead'
+            message: 'this platform has no space to leave; leave the conversation instead'
           })
         }
-        if (target.kind === 'conversation' && integration.platform === 'discord') {
+        if (target.kind === 'conversation' && leaves === 'space') {
           return reply.code(400).send({
             error: 'Bad Request',
             statusCode: 400,
-            message: 'a Discord bot joins servers, not channels; leave the server instead'
+            message: 'on this platform the bot joins a space, not individual conversations; leave the space instead'
           })
         }
         const scope =

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -1050,6 +1050,41 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     expect(ch.sends.some((send) => send.type === 'rc/routes')).toBe(true)
   })
 
+  /**
+   * F9 — the gate on this path is the §5 manifest's
+   * `membershipEnumeration: 'authoritative'`, not `platform === 'slack'`.
+   *
+   * It is load-bearing in the destructive direction: `replaceChannels` REPLACES
+   * the stored set, so applying it to a platform whose rows are discovered from
+   * traffic would delete conversations no snapshot can restore. Slack is the one
+   * platform that declares an authoritative snapshot today, so these cases also
+   * pin that the rewrite did not widen the arm.
+   */
+  it('applies the snapshot only for a platform declaring authoritative membership', async () => {
+    for (const platform of ['telegram', 'discord', 'feishu', 'mastodon']) {
+      channels = [channel({ integrationId: INT_A, channelId: 'C-known', name: 'known', agentId: ALICE })]
+      botRow = bot({ platform })
+      await makeOrch().replaceChannels(BOT, [{ id: 'C1', name: 'deploys' }])
+      // Untouched: no row added, none dropped, no route push.
+      expect(
+        channels.map((c) => c.channelId),
+        platform
+      ).toEqual(['C-known'])
+      expect(
+        ch.sends.some((send) => send.type === 'rc/routes'),
+        platform
+      ).toBe(false)
+    }
+
+    channels = [channel({ integrationId: INT_A, channelId: 'C-known', name: 'known', agentId: ALICE })]
+    botRow = bot({ platform: 'slack' })
+    await makeOrch().replaceChannels(BOT, [{ id: 'C1', name: 'deploys' }])
+    // Slack alone declares the authoritative snapshot: the stale row is dropped
+    // and the reported one is fanned across both installs.
+    expect([...new Set(channels.map((c) => c.channelId))]).toEqual(['C1'])
+    expect(ch.sends.some((send) => send.type === 'rc/routes')).toBe(true)
+  })
+
   it('seeds a newly-invited channel with the creating (earliest) agent as its default owner', async () => {
     channels = [channel({ integrationId: INT_B, channelId: 'C1', agentId: BOB, trigger: 'mention' })]
     await makeOrch().replaceChannels(BOT, [

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -24,6 +24,7 @@ import type {
   RcThreadLookup,
   RcThreadLookupOk
 } from '@agentconnect.md/protocol'
+import { manifestFor } from '@agentconnect.md/protocol'
 import type {
   BotRepo,
   BotRecord,
@@ -448,10 +449,17 @@ export class HttpBotOrchestrator {
     return this.relayReg.all().length > 0
   }
 
-  /** Apply the authoritative channel-membership snapshot reported by the Slack
-   *  HTTP ingest. Every active integration of the bot represents the same Slack
-   *  app membership, so fan the snapshot across them, preserving per-install
+  /** Apply the authoritative channel-membership snapshot reported by an HTTP
+   *  ingest. Every active integration of the bot represents the same app-level
+   *  membership, so fan the snapshot across them, preserving per-install
    *  trigger/owner fields in the repository, then hot-refresh relay routes.
+   *
+   *  Gated on the §5 manifest's `membershipEnumeration: 'authoritative'` — the
+   *  declaration that a platform HAS one cheap whole-bot membership snapshot —
+   *  rather than on the platform name. A platform whose set is discovered from
+   *  traffic (`'observed'`) has no snapshot to apply and its rows must not be
+   *  replaced wholesale; an unknown id gets the fail-closed default and is
+   *  ignored, exactly as the retired `!== 'slack'` did.
    *
    *  For an HTTP bot, route compilation converges every reported channel to
    *  exactly one owner. A new or ownerless channel is assigned to the bot's
@@ -459,8 +467,11 @@ export class HttpBotOrchestrator {
    */
   async replaceChannels(botId: string, channels: ReportedChannel[]): Promise<void> {
     const bot = await this.bots.get(BotId(botId))
-    if (!bot || bot.platform !== 'slack' || bot.transport !== 'http') {
-      this.log.warn({ botId }, 'http-bot: channel snapshot for a non-http/unknown Slack bot — ignored')
+    if (!bot || manifestFor(bot.platform).membershipEnumeration !== 'authoritative' || bot.transport !== 'http') {
+      this.log.warn(
+        { botId },
+        'http-bot: channel snapshot for an unknown bot, a non-http transport, or a platform without authoritative membership — ignored'
+      )
       return
     }
     const installs = await this.integrations.listForBot(bot.id)

--- a/packages/control-plane/src/persistence/platform.ts
+++ b/packages/control-plane/src/persistence/platform.ts
@@ -8,11 +8,19 @@
  * the dropped `Platform` enum's closed set lives on HERE, as the application-level
  * guard asserted when a protocol platform is about to be written to Postgres: a
  * `webchat` value (or an id this deployment does not serve) reaching a persistence
- * write is a programming error, not data. The platform registry replaces this list
- * when providers land (S3).
+ * write is a programming error, not data.
+ *
+ * The FENCE stays here; the LIST it consults does not. Since S3 the served set is
+ * the platform registry's, and this module reads it through the registry's static
+ * declaration (`platforms/ids.ts`) rather than its own copy — `toDbPlatform` is a
+ * free function called from eight repositories and the placement compiler, so it
+ * cannot hold the composed registry instance, but it must not disagree with it
+ * either. A platform registered in the container and unknown here would throw on
+ * its first persisted row.
  */
 import type { Platform as ProtocolPlatform } from '@agentconnect.md/protocol'
 import { isSessionIdentityPlatform } from '@agentconnect.md/protocol'
+import { CP_PLATFORM_IDS, type CpPlatformId } from '../platforms/ids.js'
 
 /** True for the session-identity-only platforms, which have no persisted row. Lets a
  *  caller decide BEFORE reaching persistence — a read whose answer is "nothing is
@@ -22,9 +30,9 @@ import { isSessionIdentityPlatform } from '@agentconnect.md/protocol'
 export { isSessionIdentityPlatform }
 
 /** The chat platforms this deployment currently serves — the closed set the dropped
- *  DB enum used to enforce. */
-const DB_PLATFORMS = ['slack', 'telegram', 'discord', 'feishu'] as const
-export type DbPlatform = (typeof DB_PLATFORMS)[number]
+ *  DB enum used to enforce, now the platform registry's own set. */
+const DB_PLATFORMS = CP_PLATFORM_IDS
+export type DbPlatform = CpPlatformId
 
 /** Narrow a protocol platform to a persisted (DB) platform, or throw on the
  *  session-identity-only members (`webchat`, `hook`, `dream`) and on any id outside

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2418,6 +2418,51 @@ export interface CreateBotInput {
   createdByUserId?: string
 }
 
+/** Tenant sentinel for NEW rows of tenantless platforms (D6/§11): a real value —
+ *  unlike NULL — participates in the composite unique, so it is what makes
+ *  `(platform, externalAppId)` enforceable. NULL stays reserved for legacy rows. */
+export const TENANTLESS_SENTINEL = '-'
+
+/**
+ * The GENERIC identity columns of a `bot` row (D6/§11) — the platform-neutral
+ * home for what used to live only in per-platform columns.
+ *
+ *  - `externalAppId` / `externalTenantId` are the composite-unique pair the D6
+ *    fence enforces. A platform with no tenant axis writes
+ *    {@link TENANTLESS_SENTINEL} rather than leaving the tenant NULL, because a
+ *    NULL never participates in a composite unique and would silently disable
+ *    the fence. NULL is reserved for LEGACY rows written before D6.
+ *  - `platformConfig` is the generic bag for a platform's public row metadata
+ *    (its console-link app id, its gateway region), carried so the legacy
+ *    per-platform columns can eventually be dropped.
+ *
+ * Every value here is PUBLIC metadata — no token or secret ever belongs in it.
+ */
+export interface BotIdentityColumns {
+  externalAppId?: string
+  externalTenantId?: string
+  platformConfig?: Record<string, string>
+}
+
+/**
+ * How {@link BotRepo.create} learns a new row's {@link BotIdentityColumns}
+ * (audit F13).
+ *
+ * WHY A PORT AND NOT A `switch (input.platform)`. Which columns carry a bot's
+ * demux identity — and which platform has no tenant axis and so writes the
+ * sentinel — is per-platform knowledge, and it sat in shared persistence as a
+ * four-arm switch that a fifth platform would have had to edit
+ * (integration-plugin-architecture.md §12). It is now
+ * `CpPlatformProvider.projectBotIdentity`, wired in at the composition root;
+ * persistence keeps the WRITE (and therefore the §11 invariant that every new
+ * row gets its generic pair) and names no platform.
+ *
+ * Total by contract: a platform that declares nothing projects `{}`, which is
+ * what a platform with no external app identity at all (Telegram — a bot token
+ * and nothing else) legitimately has.
+ */
+export type BotIdentityProjector = (input: CreateBotInput) => BotIdentityColumns
+
 /** Domain view of a `bot` row + its current installs (joined). NEVER carries tokens. */
 export interface BotRecord {
   id: BotId
@@ -2509,9 +2554,10 @@ export interface BotRepo {
   /** The Bot backing one workspace install of a distributed app — CROSS-ORG lookup
    *  by the composite demux key (a workspace binds to exactly one org). */
   getBySlackAppTeam(slackAppId: string, teamId: string): Promise<BotRecord | null>
-  /** CROSS-ORG lookup by the generic demux identity (D6). Pass the `'-'` sentinel
-   *  as `externalTenantId` for tenantless platforms. Legacy rows (NULL identity)
-   *  are unreachable here by design. */
+  /** CROSS-ORG lookup by the generic demux identity (D6). Pass
+   *  {@link TENANTLESS_SENTINEL} as `externalTenantId` for tenantless platforms —
+   *  the same value {@link BotIdentityProjector} writes. Legacy rows (NULL
+   *  identity) are unreachable here by design. */
   getByExternalIdentity(platform: string, externalAppId: string, externalTenantId: string): Promise<BotRecord | null>
   /**
    * A fresh credential landed on an EXISTING bot (platform re-install / token

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -15,6 +15,7 @@ import { withAmbientTx, type PrismaLike } from '../prisma.js'
 import { BotExternalIdentityTaken, BotStillShared } from '../errors.js'
 import type {
   BotRepo,
+  BotIdentityProjector,
   BotRecord,
   CreateBotInput,
   BotSecretStore,
@@ -86,52 +87,33 @@ function toBotRecord(b: BotJoined): BotRecord {
   }
 }
 
-/** Tenant sentinel for NEW rows of tenantless platforms (D6/§11): a real value —
- *  unlike NULL — participates in the composite unique, so it is what makes
- *  `(platform, externalAppId)` enforceable. NULL stays reserved for legacy rows. */
-export const TENANTLESS_SENTINEL = '-'
-
-/** Derive the D6 generic identity dual-write from the legacy per-platform input
- *  fields. Reads stay on the legacy columns during the dual-write window; this
- *  only keeps the generic columns in lockstep for every NEW row. */
-function botExternalIdentity(input: CreateBotInput): {
-  externalAppId?: string
-  externalTenantId?: string
-  platformConfig?: Record<string, string>
-} {
-  switch (input.platform) {
-    case 'slack':
-      // Tenant-scoped: the pair mirrors (slackAppId, teamId) verbatim. A manual
-      // single-workspace install without a captured identity keeps NULLs — the
-      // same pre-capture semantics the legacy fence has today.
-      return {
-        ...(input.slackAppId ? { externalAppId: input.slackAppId } : {}),
-        ...(input.teamId ? { externalTenantId: input.teamId } : {})
-      }
-    case 'feishu': {
-      const bag = {
-        ...(input.feishuAppId ? { feishuAppId: input.feishuAppId } : {}),
-        ...(input.feishuRegion ? { feishuRegion: input.feishuRegion } : {})
-      }
-      return {
-        // App-scoped identity (no tenant axis): the cli_ app id + the sentinel,
-        // which turns the composite unique into a one-bot-per-Feishu-app fence.
-        ...(input.feishuAppId ? { externalAppId: input.feishuAppId, externalTenantId: TENANTLESS_SENTINEL } : {}),
-        ...(Object.keys(bag).length ? { platformConfig: bag } : {})
-      }
-    }
-    case 'discord':
-      // Display-only app id; Discord has no ingress demux identity today.
-      return input.discordAppId ? { platformConfig: { discordAppId: input.discordAppId } } : {}
-    default:
-      return {}
-  }
-}
-
 export class PgBotRepo implements BotRepo {
-  constructor(private readonly db: PrismaLike) {}
+  /**
+   * @param projectIdentity The per-platform D6 identity projection
+   *   ({@link BotIdentityProjector}). The composition root wires it from the
+   *   platform registry; the four-arm `switch (input.platform)` it replaced was
+   *   the last piece of per-platform knowledge in this file (audit F13).
+   *
+   *   Defaulted so the transaction-scoped instances that only bump or revoke a
+   *   credential (`bot-credential.writer.ts`) need not carry it. A `create`
+   *   through an unwired repo is a composition bug, not a row with a quietly
+   *   absent identity, so it THROWS rather than writing the NULLs §11 reserves
+   *   for legacy rows.
+   */
+  constructor(
+    private readonly db: PrismaLike,
+    private readonly projectIdentity: BotIdentityProjector = () => {
+      throw new Error('PgBotRepo.create needs a bot-identity projector (wire it from the platform registry)')
+    }
+  ) {}
 
   async create(input: CreateBotInput): Promise<BotRecord> {
+    // The D6 generic dual-write (§11). Reads stay on the legacy columns during
+    // the dual-write window; this keeps the generic pair (and the metadata bag)
+    // in lockstep for every NEW row, whichever platform and whichever install
+    // path wrote it. Resolved BEFORE the write so an unwired projector surfaces
+    // as itself rather than as something the P2002 mapping below has to survive.
+    const identity = this.projectIdentity(input)
     try {
       const b = await this.db.bot.create({
         data: {
@@ -142,7 +124,7 @@ export class PgBotRepo implements BotRepo {
           ...(input.prebuilt !== undefined ? { prebuilt: input.prebuilt } : {}),
           ...(input.slackAppId ? { slackAppId: input.slackAppId } : {}),
           ...(input.teamId ? { teamId: input.teamId } : {}),
-          ...botExternalIdentity(input),
+          ...identity,
           ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
           ...(input.workspaceName ? { workspaceName: input.workspaceName } : {}),
           ...(input.botUserId ? { botUserId: input.botUserId } : {}),

--- a/packages/control-plane/src/platforms/bot-identity.test.ts
+++ b/packages/control-plane/src/platforms/bot-identity.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The D6 identity projection (§11; audit F13).
+ *
+ * `PgBotRepo.create`'s four-arm `switch (input.platform)` decided which columns
+ * carry a bot's demux identity and which write the tenantless sentinel — the
+ * per-platform knowledge in shared persistence that §12 names. The switch is now
+ * `CpPlatformProvider.projectBotIdentity`, and what these tests protect is the
+ * INVARIANT the fence rests on, not the refactor: §11 reserves NULL for legacy
+ * rows, so a new row of a platform that HAS an app identity must carry both
+ * halves of the composite-unique pair, and a platform with no tenant axis must
+ * write the sentinel rather than a NULL that would silently opt out of the
+ * unique.
+ *
+ * Every case below is a projection of the SAME `CreateBotInput` the repository
+ * receives, through the SAME four providers the container composes, asserted
+ * with `toEqual` — an extra column is a failure, not a pass.
+ */
+import { describe, it, expect } from 'vitest'
+import { botIdentityProjector } from './bot-identity.js'
+import { buildCpPlatformRegistry } from './registry.js'
+import { createTelegramCpProvider } from './telegram/provider.js'
+import { createDiscordCpProvider } from './discord/provider.js'
+import { createSlackCpProvider } from './slack/provider.js'
+import { createFeishuCpProvider } from './feishu/provider.js'
+import { TENANTLESS_SENTINEL, type CreateBotInput } from '../persistence/ports.js'
+import { BotId, OrgId } from '../domain/ids.js'
+
+const project = botIdentityProjector(
+  buildCpPlatformRegistry([
+    createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+    createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+    createSlackCpProvider({}),
+    createFeishuCpProvider({})
+  ])
+)
+
+/** The core-owned half of every bot write; the platform columns are the point. */
+const row = (platform: string, columns: Partial<CreateBotInput> = {}): CreateBotInput => ({
+  id: BotId('00000000-0000-4000-8000-0000000000b0'),
+  orgId: OrgId('00000000-0000-4000-8000-0000000000a0'),
+  platform,
+  name: 'acme-bot',
+  ...columns
+})
+
+describe('slack — tenant-scoped', () => {
+  it('mirrors (slackAppId, teamId) into the generic pair', () => {
+    // A platform-app OAuth install: both halves captured, so the pair is the
+    // same key the legacy unique fences on. Lockstep, not a second opinion.
+    expect(project(row('slack', { slackAppId: 'A123', teamId: 'T999' }))).toEqual({
+      externalAppId: 'A123',
+      externalTenantId: 'T999'
+    })
+  })
+
+  it('keeps each half independent — a manual install captures no workspace', () => {
+    // Pasting tokens into the create form runs no OAuth exchange, so there is no
+    // teamId to write. That is the pre-capture NULL the legacy fence has always
+    // tolerated, and the reason Slack declares no 409 pre-check.
+    expect(project(row('slack', { slackAppId: 'A123' }))).toEqual({ externalAppId: 'A123' })
+    expect(project(row('slack', { teamId: 'T999' }))).toEqual({ externalTenantId: 'T999' })
+    expect(project(row('slack'))).toEqual({})
+  })
+
+  it('never writes the tenantless sentinel — Slack HAS a tenant axis', () => {
+    // Writing `'-'` here would collapse every workspace of one app onto a single
+    // unique key and refuse the second workspace's install.
+    expect(project(row('slack', { slackAppId: 'A123' })).externalTenantId).toBeUndefined()
+  })
+})
+
+describe('feishu — app-scoped, no tenant axis', () => {
+  it('writes the app id plus the tenantless sentinel', () => {
+    // The sentinel is what makes `(platform, externalAppId)` enforceable: a NULL
+    // never participates in a composite unique, so a NULL tenant would silently
+    // disable the one-bot-per-Feishu-app fence.
+    expect(project(row('feishu', { feishuAppId: 'cli_abc', feishuRegion: 'lark' }))).toEqual({
+      externalAppId: 'cli_abc',
+      externalTenantId: TENANTLESS_SENTINEL,
+      platformConfig: { feishuAppId: 'cli_abc', feishuRegion: 'lark' }
+    })
+    expect(TENANTLESS_SENTINEL).toBe('-')
+  })
+
+  it('carries the gateway region in the generic bag even alone', () => {
+    // The region is the durable home that lets a freed bot reinstall against the
+    // same gateway; it must survive the legacy columns being dropped.
+    expect(project(row('feishu', { feishuRegion: 'feishu' }))).toEqual({
+      platformConfig: { feishuRegion: 'feishu' }
+    })
+  })
+
+  it('claims no identity without an app id', () => {
+    expect(project(row('feishu'))).toEqual({})
+  })
+})
+
+describe('discord — display metadata only', () => {
+  it('writes the bag and leaves the fenced pair unset', () => {
+    // The application id is a console deep link, not a demux key: Discord has no
+    // HTTP callback ingress, so claiming uniqueness on it would fence nothing
+    // and could refuse a legitimate second install.
+    expect(project(row('discord', { discordAppId: '123456789012345678' }))).toEqual({
+      platformConfig: { discordAppId: '123456789012345678' }
+    })
+  })
+
+  it('writes nothing when the token carried no app id', () => {
+    expect(project(row('discord'))).toEqual({})
+  })
+})
+
+describe('telegram — no external identity at all', () => {
+  it('projects nothing, declaring nothing', () => {
+    // A bot token and nothing else. Absence of the provider member IS the
+    // declaration; core must not invent an identity for it.
+    expect(project(row('telegram'))).toEqual({})
+  })
+
+  it('ignores another platform’s columns if they ever arrive', () => {
+    // Total by contract: the projection is the OWNING platform's, so a stray
+    // column cannot leak a foreign identity onto the row.
+    expect(project(row('telegram', { slackAppId: 'A123', discordAppId: '1' }))).toEqual({})
+  })
+})
+
+describe('an unregistered platform', () => {
+  it('projects nothing rather than guessing', () => {
+    // The repository still WRITES (and still fences the row through
+    // `toDbPlatform`); it simply has no identity to record.
+    expect(project(row('mastodon', { slackAppId: 'A123' }))).toEqual({})
+  })
+})

--- a/packages/control-plane/src/platforms/bot-identity.ts
+++ b/packages/control-plane/src/platforms/bot-identity.ts
@@ -1,0 +1,28 @@
+/**
+ * The D6 identity projection, read through the platform registry
+ * (integration-plugin-architecture.md §9/§11; audit F13).
+ *
+ * `PgBotRepo.create` performs the generic identity dual-write for EVERY caller —
+ * the shared create tail (`http/install-bot.ts`), the Feishu one-click funnel
+ * (`http/install-feishu.ts`), and anything added later. It used to decide WHAT
+ * to write with a four-arm `switch (input.platform)`: per-platform knowledge in
+ * shared persistence, the exact shape §12 names ("if you find yourself editing a
+ * `switch` in core, the seam is missing a member"). The member is now
+ * {@link CpPlatformProvider.projectBotIdentity}; this is the one adapter between
+ * it and the repository's {@link BotIdentityProjector} port.
+ *
+ * TOTAL AND FAIL-SAFE. An unregistered platform, or a registered one that
+ * declares no projection (Telegram — a bot token and nothing else), projects
+ * `{}`: the row carries no generic identity, which is what "this platform has no
+ * external app identity" means. It is NOT a licence to skip the projector —
+ * `PgBotRepo` throws when it was never wired, so a composition that forgets this
+ * fails loudly rather than writing the NULLs §11 reserves for legacy rows.
+ */
+import type { BotIdentityProjector } from '../persistence/ports.js'
+import type { CpPlatformRegistry } from './provider.js'
+
+/** Bind `platforms` as the repository's identity projector. Every read runs at
+ *  bot-row WRITE time, so a late-bound registry façade is a valid argument. */
+export function botIdentityProjector(platforms: CpPlatformRegistry): BotIdentityProjector {
+  return (input) => platforms.get(input.platform)?.projectBotIdentity?.(input) ?? {}
+}

--- a/packages/control-plane/src/platforms/discord/provider.ts
+++ b/packages/control-plane/src/platforms/discord/provider.ts
@@ -160,6 +160,17 @@ export function createDiscordCpProvider(deps: DiscordCpProviderDeps): CpPlatform
       secrets: { botToken: credentials.botToken, appToken: null, signingSecret: null }
     }),
 
+    /**
+     * D6 identity (§11): Discord claims NO external app identity. The
+     * application id decoded from the bot token is display-only — it deep-links
+     * the console to the Developer Portal — and Discord has no HTTP callback
+     * ingress, so there is nothing to demux on and nothing the composite unique
+     * should fence. It therefore rides the generic bag alone, leaving the
+     * `(externalAppId, externalTenantId)` pair unset rather than claiming a
+     * uniqueness this platform has not earned.
+     */
+    projectBotIdentity: (input) => (input.discordAppId ? { platformConfig: { discordAppId: input.discordAppId } } : {}),
+
     // One-slot packing of the shared two-slot bot_secret row
     // (`integrations.ts:515`: appToken/signingSecret stored null). No slot
     // gates an http assign — Discord has no HTTP callback ingress at all.

--- a/packages/control-plane/src/platforms/feishu/provider.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.ts
@@ -42,6 +42,7 @@ import type { FastifyPluginAsync } from 'fastify'
 import { FeishuRegion } from '@agentconnect.md/protocol'
 import type { IntegrationFeishuConfig } from '@agentconnect.md/protocol'
 import type { BotRecord, BotSecretMaterial, IntegrationRecord } from '../../persistence/ports.js'
+import { TENANTLESS_SENTINEL } from '../../persistence/ports.js'
 import type { FeishuBotVerifier } from '../../http/feishu-identity.js'
 import type { FeishuAppIconSyncer } from '../../http/feishu-app-icon.js'
 import type { CpConfigValidation, CpInstallTransport, CpPlatformProvider } from '../provider.js'
@@ -313,11 +314,33 @@ export function createFeishuCpProvider(deps: FeishuCpProviderDeps): CpPlatformPr
       },
       externalIdentity: {
         externalAppId: credentials.appId,
-        externalTenantId: '-',
+        externalTenantId: TENANTLESS_SENTINEL,
         conflictMessage:
           'This Feishu app is already registered as a bot. Reuse that bot (pick it under "Existing") instead of registering the app again.'
       }
     }),
+
+    /**
+     * D6 identity (§11): Feishu is APP-scoped with NO tenant axis, so the pair
+     * is the `cli_…` app id plus {@link TENANTLESS_SENTINEL} — a real value, so
+     * the composite unique actually fires and becomes a one-bot-per-Feishu-app
+     * fence. (Writing NULL there would silently disable it: a NULL never
+     * participates in a composite unique.)
+     *
+     * The gateway region has no generic column, so it rides the generic bag
+     * beside the app id — the durable home that lets a freed bot reinstall
+     * against the same gateway once the legacy columns are dropped.
+     */
+    projectBotIdentity: (input) => {
+      const bag = {
+        ...(input.feishuAppId ? { feishuAppId: input.feishuAppId } : {}),
+        ...(input.feishuRegion ? { feishuRegion: input.feishuRegion } : {})
+      }
+      return {
+        ...(input.feishuAppId ? { externalAppId: input.feishuAppId, externalTenantId: TENANTLESS_SENTINEL } : {}),
+        ...(Object.keys(bag).length ? { platformConfig: bag } : {})
+      }
+    },
 
     // Feishu reuses the established two-slot shape (`install-feishu.ts`):
     // botToken = app SECRET (the credential), appToken = app ID (the

--- a/packages/control-plane/src/platforms/ids.test.ts
+++ b/packages/control-plane/src/platforms/ids.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The platform-set authority (S3 exit criterion; audit F8, F10, F11).
+ *
+ * Before this, the served set was spelled SIX times in the control plane: the
+ * persistence fence's `DB_PLATFORMS`, the cron/hook `Platform` enum, the MCP
+ * `upsertCron` enum, two inline unions in `hooks.ts`, and the waitlist intake —
+ * which had already drifted, sitting at three ids after Feishu shipped. Each
+ * consumer now reads {@link CP_PLATFORM_IDS}, and the load-bearing claim of the
+ * whole arrangement is the FIRST test below: the static declaration is what the
+ * production providers register, so adding a platform is one entry plus a
+ * provider and no consumer edit at all.
+ *
+ * The rest pin the consumers to that declaration. They are deliberately written
+ * as "this surface's vocabulary EQUALS the declaration", not as "…contains
+ * feishu": a re-introduced hand list that happens to be correct today still
+ * fails, because it is the copy that is the defect.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Platform as ProtocolPlatform } from '@agentconnect.md/protocol'
+import { CP_PLATFORM_IDS } from './ids.js'
+import { buildCpPlatformRegistry } from './registry.js'
+import { createTelegramCpProvider } from './telegram/provider.js'
+import { createDiscordCpProvider } from './discord/provider.js'
+import { createSlackCpProvider } from './slack/provider.js'
+import { createFeishuCpProvider } from './feishu/provider.js'
+import { toDbPlatform } from '../persistence/platform.js'
+import { Platform, UpsertCronBody, WaitlistJoinBody } from '../http/dto/index.js'
+import { findTool } from '../http/mcp/tools.js'
+
+/** The four providers `container.ts` composes, with offline stub seams — the
+ *  same construction `env.test.ts` uses to read declarations off the real
+ *  provider objects. */
+const productionRegistry = buildCpPlatformRegistry([
+  createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+  createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+  createSlackCpProvider({}),
+  createFeishuCpProvider({})
+])
+
+const sorted = [...CP_PLATFORM_IDS].sort()
+
+describe('CP_PLATFORM_IDS', () => {
+  it('is exactly the set the production providers register', () => {
+    // The whole point: a provider added to the container and forgotten here (or
+    // an id left here after its provider went away) fails HERE, not silently in
+    // the cron vocabulary, the waitlist intake, and the persistence fence.
+    expect([...productionRegistry.ids()].sort()).toEqual(sorted)
+  })
+
+  it('excludes the session-identity-only platforms', () => {
+    // `webchat`, `hook` and `dream` are protocol platforms with no provider, no
+    // persisted integration row and no install funnel. They must never reach a
+    // surface keyed on this list.
+    for (const p of ['webchat', 'hook', 'dream']) {
+      expect(CP_PLATFORM_IDS as readonly string[]).not.toContain(p)
+    }
+  })
+})
+
+describe('the persistence fence (F8)', () => {
+  it('serves exactly the declared set', () => {
+    for (const id of CP_PLATFORM_IDS) expect(toDbPlatform(id)).toBe(id)
+  })
+
+  it('still throws — the fence survived the list swap', () => {
+    // Two distinct refusals, both load-bearing: the DB columns are open TEXT, so
+    // this helper is the only thing standing between a stray id and a row.
+    expect(() => toDbPlatform('webchat' as ProtocolPlatform)).toThrow(/session-identity platform/)
+    expect(() => toDbPlatform('mastodon' as ProtocolPlatform)).toThrow(/unknown platform/)
+  })
+})
+
+describe('the cron / hook target vocabulary (F10)', () => {
+  it('is the declaration, in the REST body', () => {
+    expect([...Platform.options].sort()).toEqual(sorted)
+  })
+
+  it('is the declaration, in the MCP upsertCron tool', () => {
+    // Read behaviorally rather than by introspecting the tool's zod internals:
+    // every declared id parses, and an unregistered one does not.
+    const tool = findTool('upsertCron')
+    if (!tool) throw new Error('upsertCron tool missing')
+    const args = (targetPlatform: string) => ({
+      agentId: '00000000-0000-4000-8000-000000000001',
+      schedule: '0 9 * * *',
+      trigger: 'go',
+      targetPlatform
+    })
+    for (const id of CP_PLATFORM_IDS) expect(tool.schema.safeParse(args(id)).success).toBe(true)
+    expect(tool.schema.safeParse(args('mastodon')).success).toBe(false)
+  })
+
+  it('keeps the `slack` default an envelope legacy value, not a registry read', () => {
+    // Audit §6.8 / ambiguous row 7: a cron stored before `targetPlatform`
+    // existed reads back as Slack. The MEMBERS track the registry; this DEFAULT
+    // describes the historical shape of stored rows and must not move when a
+    // platform is registered ahead of Slack.
+    const parsed = UpsertCronBody.parse({
+      agentId: '00000000-0000-4000-8000-000000000001',
+      schedule: '0 9 * * *',
+      trigger: 'go'
+    })
+    expect(parsed.targetPlatform).toBe('slack')
+  })
+})
+
+describe('the waitlist intake set (F11)', () => {
+  const intake = (platform: string[]) => ({
+    name: 'Ada',
+    company: 'Northwind Ops',
+    platform,
+    teamSize: '2-10'
+  })
+
+  it('tracks the registry — every served platform is selectable', () => {
+    // DECIDED in F11: intake asks "which of the platforms we serve will you
+    // use", so its vocabulary IS the served set. The old hand copy proved the
+    // point by drifting one id behind.
+    for (const id of CP_PLATFORM_IDS) expect(WaitlistJoinBody.safeParse(intake([id])).success).toBe(true)
+    expect(WaitlistJoinBody.safeParse(intake(['mastodon'])).success).toBe(false)
+  })
+
+  it('caps the selection at the registry size, not a hand-written count', () => {
+    // The `.max(3)` this replaced was a second spelling of the same list length
+    // and would have rejected an all-platforms answer the moment a fourth id
+    // became selectable.
+    expect(WaitlistJoinBody.safeParse(intake([...CP_PLATFORM_IDS])).success).toBe(true)
+    expect(WaitlistJoinBody.safeParse(intake([])).success).toBe(false)
+  })
+})

--- a/packages/control-plane/src/platforms/ids.ts
+++ b/packages/control-plane/src/platforms/ids.ts
@@ -1,0 +1,45 @@
+/**
+ * The control plane's **static platform-id declaration** — the S3 exit
+ * criterion's "registry is the single platform-set authority" for the readers
+ * that cannot hold the registry INSTANCE.
+ *
+ * WHY A STATIC DECLARATION AND NOT `CpPlatformRegistry.ids()`. Same reason
+ * `platforms/env.ts` exists: some core readers run before, or entirely without,
+ * `buildContainer()`.
+ *
+ *  - `http/dto/index.ts` builds its zod schemas at MODULE LOAD. `z.enum(...)`
+ *    needs its members while the module is being evaluated, long before a
+ *    container exists — and the OpenAPI document generated from those schemas
+ *    is a published contract, so the set has to be knowable statically.
+ *  - `persistence/platform.ts`'s `toDbPlatform` is a free function called from
+ *    eight repositories, the placement compiler, and two route files. Threading
+ *    a registry through all of them to answer "is this id served?" would put the
+ *    platform seam inside every persistence call signature for one membership
+ *    test.
+ *
+ * What keeps this from being the SIXTH hand-copied union the audit counted is
+ * `ids.test.ts`: it pins this list against the ids the four PRODUCTION
+ * providers register, so a provider added to the container and forgotten here
+ * fails a test instead of silently dropping out of the cron target vocabulary,
+ * the waitlist intake, and the persistence fence. Adding a platform is one
+ * entry here plus the provider — the same two-line shape `env.ts` documents,
+ * and no edit to any consumer.
+ *
+ * Deliberately DEPENDENCY-FREE. Persistence imports this module, so it must not
+ * reach the provider modules (which would invert the layering and risk an
+ * import cycle through the repositories those providers' seams are built from).
+ */
+
+/**
+ * Every chat platform this build serves — the id set `CpPlatformRegistry.ids()`
+ * returns at runtime.
+ *
+ * `webchat`, `hook` and `dream` are NOT here: they are session-identity-only
+ * protocol platforms with no provider, no persisted integration row, and no
+ * install funnel (`persistence/platform.ts`, `isSessionIdentityPlatform`).
+ */
+export const CP_PLATFORM_IDS = ['slack', 'telegram', 'discord', 'feishu'] as const
+
+/** One served chat platform. The closed static type behind `DbPlatform` and the
+ *  cron/hook target vocabulary. */
+export type CpPlatformId = (typeof CP_PLATFORM_IDS)[number]

--- a/packages/control-plane/src/platforms/manifest-reads.test.ts
+++ b/packages/control-plane/src/platforms/manifest-reads.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The control plane's §5 manifest reads (audit F9, F12).
+ *
+ * The CP imported `manifestFor` ZERO times before this: the one fact the daemon
+ * and the relay read declaratively was re-spelled here as platform names. Three
+ * predicates were involved, and all three are pinned below as EQUIVALENCES —
+ * the retired expression on one side, the manifest read on the other, evaluated
+ * over every registered id plus the ids that are not registered at all. An
+ * equivalence is the right shape because these are not new decisions: the whole
+ * claim of the change is that behavior did not move.
+ *
+ * The route- and orchestrator-level behavior these feed is pinned where it
+ * lives — `orchestrator/httpBot.test.ts` for the snapshot gate,
+ * `test/integration/integration-channels.test.ts` for the two leave refusals
+ * and the Forget suppression.
+ */
+import { describe, it, expect } from 'vitest'
+import { manifestFor } from '@agentconnect.md/protocol'
+import { CP_PLATFORM_IDS } from './ids.js'
+
+/** Ids no build serves — the miss arm every predicate below must keep taking
+ *  the conservative way. `webchat`/`hook`/`dream` are real protocol platforms
+ *  with no manifest entry; the last two are simply unknown. */
+const UNREGISTERED = ['webchat', 'hook', 'dream', 'mastodon', 'constructor'] as const
+
+const ALL = [...CP_PLATFORM_IDS, ...UNREGISTERED]
+
+describe('F9 — Forget needs a durable suppression', () => {
+  it('is the observed-membership arm, for every id', () => {
+    for (const p of ALL) {
+      // What `http/routes/integrations.ts` spelled before: the three platforms
+      // whose conversation list is rebuilt from session history.
+      const retired = p === 'telegram' || p === 'discord' || p === 'feishu'
+      const viaManifest = manifestFor(p).membershipEnumeration === 'observed'
+      // Registered ids: identical. Unregistered ids: the manifest DEMANDS a
+      // suppression where the hand list silently skipped one — the fail-closed
+      // direction, and unreachable in practice (a persisted integration's
+      // platform has already passed `toDbPlatform`).
+      if ((CP_PLATFORM_IDS as readonly string[]).includes(p)) expect(viaManifest, p).toBe(retired)
+      else expect(viaManifest, p).toBe(true)
+    }
+  })
+})
+
+describe('F9 — the authoritative channel-snapshot gate', () => {
+  it('is the authoritative-membership arm, for every id, with no exception', () => {
+    for (const p of ALL) {
+      // `orchestrator/httpBot.ts` spelled this `bot.platform !== 'slack'`.
+      const retired = p !== 'slack'
+      expect(manifestFor(p).membershipEnumeration !== 'authoritative', p).toBe(retired)
+    }
+  })
+})
+
+describe('F12 — what a leave request may target', () => {
+  it('refuses a space target exactly where the platform has no space', () => {
+    for (const p of ALL) {
+      const retired = p !== 'discord' // `integrations.ts` before the manifest read
+      expect(manifestFor(p).leaveGranularity !== 'space', p).toBe(retired)
+    }
+  })
+
+  it('refuses a conversation target exactly where membership is space-scoped', () => {
+    for (const p of ALL) {
+      const retired = p === 'discord'
+      expect(manifestFor(p).leaveGranularity === 'space', p).toBe(retired)
+    }
+  })
+
+  it('leaves exactly one platform space-scoped', () => {
+    // The manifest field earned by that branch. Pin the set so a later edit
+    // cannot quietly widen a refusal that costs an operator a working action.
+    expect(CP_PLATFORM_IDS.filter((p) => manifestFor(p).leaveGranularity === 'space')).toEqual(['discord'])
+  })
+
+  it('fails closed on an id this build does not serve', () => {
+    // Conservative arm = `conversation`: a space-targeted leave is refused
+    // rather than dispatched at a platform that cannot perform it. Same arm the
+    // `!== 'discord'` comparison took.
+    for (const p of UNREGISTERED) expect(manifestFor(p).leaveGranularity, p).toBe('conversation')
+  })
+})

--- a/packages/control-plane/src/platforms/provider.ts
+++ b/packages/control-plane/src/platforms/provider.ts
@@ -82,6 +82,7 @@ import type { FastifyPluginAsync } from 'fastify'
 import type { ZodRawShape, ZodType } from 'zod'
 import type { IntegrationCoreEnvelope } from '@agentconnect.md/protocol'
 import type {
+  BotIdentityColumns,
   BotRecord,
   BotSecretMaterial,
   CreateBotInput,
@@ -436,6 +437,33 @@ export interface CpPlatformProvider<TCredentials = unknown> {
   /** How this platform packs the shared secret row + which slots gate an
    *  http assign. See {@link CpSecretShape}. */
   secretShape: CpSecretShape
+
+  /**
+   * Project a NEW bot row's generic D6 identity columns from the platform
+   * columns of the same write (§11; audit F13) — which value is this platform's
+   * external APP id, whether it has a TENANT axis or writes the tenantless
+   * sentinel, and what public metadata rides the generic `platformConfig` bag.
+   *
+   * An AT-WRITE read, and the reason it is a member rather than a repository
+   * `switch`: `PgBotRepo.create` performs the D6 dual-write for EVERY caller —
+   * the shared create tail, the Feishu one-click funnel, and anything added
+   * later — so the decision has to be reachable from persistence, but it is not
+   * persistence's to make. Core keeps the write (and so keeps §11's guarantee
+   * that a new row never leaves the pair NULL, which is reserved for legacy
+   * rows); the platform keeps the mapping.
+   *
+   * DISTINCT from {@link CpNewBotInstall.externalIdentity}, which is the create
+   * ROUTE's 409 pre-check and applies only to a platform that wants a clean
+   * conflict message on the credential-paste path. This member describes what is
+   * PERSISTED, on every path, and a platform may project an identity here
+   * without claiming a route-level fence (Slack does exactly that: its rows
+   * carry the pair whenever an app id and workspace were captured, while the
+   * legacy `(slackAppId, teamId)` unique remains its fence).
+   *
+   * Pure: no I/O. Absent ⇒ this platform persists no external identity
+   * (Telegram — a bot token and nothing else). PUBLIC metadata only.
+   */
+  projectBotIdentity?(input: CreateBotInput): BotIdentityColumns
 
   /** Pending-install funnel state models + their TTL reapers. Absent ⇒ the
    *  platform has no funnel (Telegram/Discord). */

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -414,6 +414,23 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
       }
     },
 
+    /**
+     * D6 identity (§11): Slack is TENANT-SCOPED, so the generic pair mirrors
+     * `(slackAppId, teamId)` verbatim — the same two values the legacy unique
+     * fences on, which is what makes the dual-write a lockstep copy rather than
+     * a second opinion.
+     *
+     * Each half is conditional and neither implies the other: a manual
+     * single-workspace install pastes tokens without an OAuth exchange, so it
+     * captures no `teamId` (and sometimes no app id either) and keeps NULLs —
+     * the pre-capture semantics the legacy fence has always had, and the reason
+     * Slack declares no `externalIdentity` 409 pre-check.
+     */
+    projectBotIdentity: (input) => ({
+      ...(input.slackAppId ? { externalAppId: input.slackAppId } : {}),
+      ...(input.teamId ? { externalTenantId: input.teamId } : {})
+    }),
+
     // Slack stores the literal tokens in the shared row (`install-slack.ts`):
     // the xapp (socket) / signing secret (http) stay CP-side for the relay —
     // the daemon never receives them. An http assign is gated on the signing

--- a/packages/control-plane/src/platforms/telegram/provider.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.ts
@@ -138,6 +138,10 @@ export function createTelegramCpProvider(deps: TelegramCpProviderDeps): CpPlatfo
       secrets: { botToken: credentials.botToken, appToken: null, signingSecret: null }
     }),
 
+    // No `projectBotIdentity` (§11): a Telegram install is a bot token and
+    // nothing else — no app id, no tenant, no public row metadata — so there is
+    // no identity to persist. Absence is the declaration; core projects `{}`.
+
     // One-slot packing of the shared two-slot bot_secret row
     // (`integrations.ts:443`: appToken/signingSecret stored null). No slot
     // gates an http assign — Telegram has no HTTP callback ingress at all.

--- a/packages/control-plane/src/registry/waitlistService.ts
+++ b/packages/control-plane/src/registry/waitlistService.ts
@@ -7,6 +7,7 @@ import type {
   WaitlistRedeemResult,
   WaitlistRepo
 } from '../persistence/ports.js'
+import type { CpPlatformId } from '../platforms/ids.js'
 import { WaitlistJoinTokenCodec } from './waitlistJoinToken.js'
 
 /** The derived admission status surfaced by `GET /me/access` (§5). `active` = may
@@ -18,7 +19,10 @@ export type WaitlistAccessStatus = 'active' | 'approved' | 'pending' | 'none'
 export interface WaitlistIntake {
   name: string
   company: string
-  platform: ('slack' | 'telegram' | 'discord')[]
+  /** The served platforms the applicant picked. Typed from the registry
+   *  declaration, not re-spelled: this used to be a second hand copy of the DTO's
+   *  enum and had already drifted apart from it by one id (audit F11). */
+  platform: CpPlatformId[]
   teamSize: string
   useCase?: string
 }

--- a/packages/control-plane/test/fakes/build-app.ts
+++ b/packages/control-plane/test/fakes/build-app.ts
@@ -34,6 +34,7 @@ import { EpochService } from '../../src/orchestrator/epoch.js'
 import { Placement } from '../../src/orchestrator/placement.js'
 import { AgentSpecAssembler } from '../../src/orchestrator/agentSpecAssembler.js'
 import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
+import { botIdentityProjector } from '../../src/platforms/bot-identity.js'
 import { createSlackCpProvider } from '../../src/platforms/slack/provider.js'
 import { createTelegramCpProvider } from '../../src/platforms/telegram/provider.js'
 import { createDiscordCpProvider } from '../../src/platforms/discord/provider.js'
@@ -61,6 +62,17 @@ export interface DaemonApp {
   close(): Promise<void>
 }
 
+// §9: reconcile projects every `IntegrationSpec.config` through the platform
+// registry, and the bot repo projects every new row's D6 identity through it,
+// so compose the same four providers prod registers. Their verify seams are
+// offline stubs — neither projector calls one.
+const PLATFORMS = buildCpPlatformRegistry([
+  createSlackCpProvider({}),
+  createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
+  createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
+  createFeishuCpProvider({})
+])
+
 export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
   const clock = systemClock
   const app = Fastify({ logger: false })
@@ -78,7 +90,7 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
     hook: new PgHookRepo(prisma),
     lease: new PgSecretLeaseRepo(prisma),
     integration: new PgIntegrationRepo(prisma),
-    bot: new PgBotRepo(prisma),
+    bot: new PgBotRepo(prisma, botIdentityProjector(PLATFORMS)),
     botSecret: new PgBotSecretStore(prisma, cipher),
     integrationChannel: new PgIntegrationChannelRepo(prisma),
     runtimeProfile: new PgRuntimeProfileRepo(prisma),
@@ -101,15 +113,7 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
     new AgentSpecAssembler(repos.agentSecret),
     repos.integrationChannel,
     repos.bot,
-    // §9: reconcile projects every `IntegrationSpec.config` through the platform
-    // registry, so compose the same four providers prod registers. Their verify
-    // seams are offline stubs — the projectors call none of them.
-    buildCpPlatformRegistry([
-      createSlackCpProvider({}),
-      createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
-      createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
-      createFeishuCpProvider({})
-    ])
+    PLATFORMS
   )
   const connReg = new ConnectionRegistry()
 

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -88,6 +88,7 @@ import { HookService } from '../../src/hooks/hook.service.js'
 import { buildHttpServer } from '../../src/http/server.js'
 import type { HttpDeps } from '../../src/http/deps.js'
 import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
+import { botIdentityProjector } from '../../src/platforms/bot-identity.js'
 import type { CpPlatformRegistry } from '../../src/platforms/provider.js'
 import { createTelegramCpProvider } from '../../src/platforms/telegram/provider.js'
 import { createDiscordCpProvider } from '../../src/platforms/discord/provider.js'
@@ -235,7 +236,10 @@ export function buildHttpApp(
   const cipher = new PlaintextSecretCipher()
   const agentSecretStore = new PgAgentSecretStore(prisma, cipher)
   const integrationRepo = new PgIntegrationRepo(prisma)
-  const botRepo = new PgBotRepo(prisma)
+  // The D6 identity projection reads the registry at bot-row WRITE time; the
+  // façade it reads through is bound further down (see the LATE-BOUND note), so
+  // the extra arrow defers the `platforms` reference past its declaration.
+  const botRepo = new PgBotRepo(prisma, (input) => botIdentityProjector(platforms)(input))
   const botSecretStore = new PgBotSecretStore(prisma, cipher)
   const botCredentialWriter = new PgBotCredentialWriter(prisma, cipher)
   const feishuAppRegistrationStore = new PgFeishuAppRegistrationStore(prisma, cipher)

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -57,6 +57,7 @@ import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { FakeClock } from './fake-clock.js'
 import { InMemoryDaemonStub } from './daemon-stub.js'
 import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
+import { botIdentityProjector } from '../../src/platforms/bot-identity.js'
 import { createSlackCpProvider } from '../../src/platforms/slack/provider.js'
 import { createTelegramCpProvider } from '../../src/platforms/telegram/provider.js'
 import { createDiscordCpProvider } from '../../src/platforms/discord/provider.js'
@@ -109,7 +110,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     hook: new PgHookRepo(prisma),
     lease: new PgSecretLeaseRepo(prisma),
     integration: new PgIntegrationRepo(prisma),
-    bot: new PgBotRepo(prisma),
+    bot: new PgBotRepo(prisma, botIdentityProjector(PLATFORMS)),
     botSecret: new PgBotSecretStore(prisma, cipher),
     integrationChannel: new PgIntegrationChannelRepo(prisma),
     runtimeProfile: new PgRuntimeProfileRepo(prisma),

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -102,6 +102,27 @@ async function installTelegram(app: HttpApp): Promise<string> {
   return (res.json() as { id: string }).id
 }
 
+/** Install a DISCORD integration — the one platform whose bot joins a SPACE
+ *  rather than individual conversations (§5 `leaveGranularity: 'space'`), so the
+ *  only one whose leave requests take the mirror-image arms of the two refusals
+ *  below. */
+async function installDiscord(app: HttpApp): Promise<string> {
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, { daemonId: DAEMON, createdByUserId: DEFAULT_OWNER_ID })
+  const res = await app.app.inject({
+    method: 'POST',
+    url: `${ORG}/integrations`,
+    payload: {
+      name: 'acme-dc',
+      platform: 'discord',
+      agentId,
+      discord: { botToken: 'MTIzNDU2Nzg5MDEyMzQ1Njc4.fixture.not-a-secret' }
+    }
+  })
+  expect(res.statusCode).toBe(201)
+  return (res.json() as { id: string }).id
+}
+
 /** Dispatch a hand-built `integration/channels` EVT through the real handler. */
 async function report(
   daemonId: string,
@@ -1214,7 +1235,11 @@ describe('DELETE …/channels/:channelId (forget) and POST …/leave (platform)'
     expect(spy.forgets).toEqual([{ daemonId: DAEMON, f: { integrationId: id, channels: ['-100123'] } }])
   })
 
-  it('refuses a server-scoped leave on a platform that has no server', async () => {
+  // The two arms below are one rule read off the §5 manifest's
+  // `leaveGranularity` (audit F12): a request whose target shape the platform
+  // cannot serve is refused HERE — before an owner resolves, before the mutation
+  // lease, before any daemon is reached — so neither ever dispatches.
+  it('refuses a space-scoped leave on a platform whose bot leaves conversations', async () => {
     await seedDaemon(prisma, DAEMON)
     const spy = new SpyControl()
     running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
@@ -1228,5 +1253,39 @@ describe('DELETE …/channels/:channelId (forget) and POST …/leave (platform)'
 
     expect(res.statusCode).toBe(400)
     expect(spy.leaves).toEqual([]) // never reached the daemon
+  })
+
+  it('refuses a conversation-scoped leave on a platform whose bot joins a space', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await installDiscord(running)
+
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/${id}/leave`,
+      payload: { target: { kind: 'conversation', channel: 'C1' } }
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(spy.leaves).toEqual([])
+  })
+
+  it('dispatches a space-scoped leave on the platform that has one', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await installDiscord(running)
+
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/${id}/leave`,
+      payload: { target: { kind: 'space', spaceId: 'G1' } }
+    })
+
+    expect(res.statusCode).toBe(204)
+    expect(spy.leaves).toEqual([
+      { daemonId: DAEMON, l: { integrationId: id, target: { kind: 'space', spaceId: 'G1' } } }
+    ])
   })
 })

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -291,6 +291,12 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
 
     const secret = await prisma.botSecret.findUnique({ where: { botId: dto.botId as string } })
     expect(secret).toMatchObject({ botToken: '123456:AAE-xyz', appToken: null })
+    // D6 (§11): a Telegram install is a bot token and nothing else — no app id,
+    // no tenant, no public row metadata — so the row claims no external
+    // identity. Completes the four-platform pin the discord / feishu / slack
+    // cases in this file carry.
+    const bot = await prisma.bot.findUnique({ where: { id: dto.botId as string } })
+    expect(bot).toMatchObject({ externalAppId: null, externalTenantId: null, platformConfig: null })
 
     // The daemon got a telegram-shaped spec (single botToken, no slack block).
     expect(spy.upserts).toHaveLength(1)

--- a/packages/protocol/src/platform-manifest.ts
+++ b/packages/protocol/src/platform-manifest.ts
@@ -40,6 +40,16 @@
  */
 export type MembershipEnumeration = 'authoritative' | 'observed'
 
+/** What a bot can actually withdraw from, once it is in a conversation (§5).
+ *
+ *  - `conversation` — the bot is a member of the individual chat and leaves it
+ *    on its own (Slack `conversations.leave`, Telegram `leaveChat`).
+ *  - `space` — membership is granted at the enclosing space and the bot has no
+ *    per-conversation membership to drop, so the only withdrawal is leaving the
+ *    whole space (Discord: a bot joins a guild, not a channel).
+ */
+export type LeaveGranularity = 'conversation' | 'space'
+
 /** One platform's pre-dispatch capability declaration. */
 export interface PlatformManifest {
   /** Diagnostic label; never parsed. */
@@ -59,12 +69,25 @@ export interface PlatformManifest {
    *  separately); on a `false` platform bot senders never route. Fail-closed:
    *  an unknown platform admits no bot senders. */
   readonly botSenderRouting: boolean
+  /** What a leave request may target on this platform (§5). A PRE-DISPATCH
+   *  read: the control plane validates the SHAPE of a leave request — space vs
+   *  conversation — before it resolves an owner, takes the mutation lease, or
+   *  reaches the daemon that would perform the leave, so there is no adapter or
+   *  turn to ask. The same axis is the daemon's two leave members
+   *  (`leaveConversation` / `leaveSpace`) and the web module's
+   *  `WebChannelListSemantics.leave`; this is the declaration all three read
+   *  instead of re-spelling "Discord is the one with servers". */
+  readonly leaveGranularity: LeaveGranularity
 }
 
 /** The conservative arm of every axis — see the fail-closed note above. */
 export const DEFAULT_MANIFEST: Omit<PlatformManifest, 'platform'> = {
   membershipEnumeration: 'observed',
-  botSenderRouting: false
+  botSenderRouting: false,
+  // The arm the retired branch took for every non-Discord id: an unknown
+  // platform is assumed to have no space to leave, so a space-targeted request
+  // is refused rather than dispatched at a platform that cannot serve it.
+  leaveGranularity: 'conversation'
 }
 
 /**
@@ -78,10 +101,20 @@ const MANIFESTS = new Map<string, Omit<PlatformManifest, 'platform'>>([
   // is why the branches this replaces read "Slack does X, everyone else does Y".
   // It is also the only platform whose normalizer attributes bot authorship AND
   // explicit @-mentions well enough to admit third-party bot messages safely.
-  ['slack', { membershipEnumeration: 'authoritative', dmChannelPattern: /^D/, botSenderRouting: true }],
-  ['telegram', { membershipEnumeration: 'observed', botSenderRouting: false }],
-  ['discord', { membershipEnumeration: 'observed', botSenderRouting: false }],
-  ['feishu', { membershipEnumeration: 'observed', botSenderRouting: false }]
+  [
+    'slack',
+    {
+      membershipEnumeration: 'authoritative',
+      dmChannelPattern: /^D/,
+      botSenderRouting: true,
+      leaveGranularity: 'conversation'
+    }
+  ],
+  ['telegram', { membershipEnumeration: 'observed', botSenderRouting: false, leaveGranularity: 'conversation' }],
+  // A Discord bot is added to a GUILD, not to a channel — there is no
+  // per-channel membership to drop, so the only withdrawal is the whole server.
+  ['discord', { membershipEnumeration: 'observed', botSenderRouting: false, leaveGranularity: 'space' }],
+  ['feishu', { membershipEnumeration: 'observed', botSenderRouting: false, leaveGranularity: 'conversation' }]
 ])
 
 /** The manifest for `platform`. Total by construction: an unregistered id gets


### PR DESCRIPTION
Retires the six control-plane survivors of the S3 exit reconciliation
(`docs/designs/integration-plugin-audit.md` §10.6, F8–F13). The CP was the one
host that never adopted the §5 manifest — it imported `manifestFor` **zero**
times — and the one host whose closed platform unions never routed through the
provider registry.

## What

**F8 — `persistence/platform.ts` `DB_PLATFORMS`.** Its own doc comment said "the
platform registry replaces this list when providers land (S3)". `toDbPlatform`
stays the persistence fence and keeps both throws; the *list* it consults is now
the registry's. `toDbPlatform` is a free function called from eight repositories
and the placement compiler, so it cannot hold the composed registry instance —
it reads the registry's **static declaration**, new file
`platforms/ids.ts` (`CP_PLATFORM_IDS`), pinned by test against what the four
production providers register. Same shape, and same stated reason, as the
existing `platforms/env.ts`.

**F9 — the CP now reads the manifest.** `needsSuppression = p === 'telegram' ||
'discord' || 'feishu'` is `manifestFor(p).membershipEnumeration === 'observed'`;
the `replaceChannels` gate (`bot.platform !== 'slack'`) is its `'authoritative'`
twin. Both rewritten. The snapshot gate is exactly equivalent for every string.
The suppression predicate is equivalent for every *registered* id and
fail-**closed** for unregistered ones (it now demands a suppression instead of
silently skipping it) — unreachable in practice, since a persisted integration's
platform has already passed `toDbPlatform`.

**F10 — cron/hook target vocabulary, four copies → one.** `dto/index.ts`'s
`Platform` enum, `mcp/tools.ts`'s `upsertCron` enum and the two inline unions in
`routes/hooks.ts` (now `DbPlatform`) all read the one declaration. Per the
audit's caveat, the `.default('slack')` at both `targetPlatform` sites is
**preserved as an envelope legacy value** (§6.8 / ambiguous row 7) — it names the
historical shape of stored rows, not a capability — with the reason written at
both sites and pinned by a test.

**F11 — waitlist intake.** *Decided: marketing intake tracks the registry.* See
`## Behavior`.

**F12 — the `leaveGranularity` gate.** *Decided: earn the manifest field.* It is a
genuine pre-dispatch read (the CP validates the request's target *shape* before
an owner resolves, before the mutation lease, before any daemon is reached), the
same axis is already a documented facet in two other hosts (`WebChannelList
Semantics.leave`; the daemon's `leaveConversation`/`leaveSpace`), and
`platforms/provider.ts` already names `leaveGranularity` as one of the values
that are "manifest fields per D2, NOT members here". So the field lands in
`protocol/src/platform-manifest.ts` **in the same PR as the branch it retires**,
per §5.2's earned-field rule, with `'conversation'` as the fail-closed default
(the arm the retired `!== 'discord'` took for every other id). Nothing else in
protocol is touched; the daemon/relay/web reads stay as they are.

**F13 — the D6 identity dual-write.** *Decided: the member is earned.* See
`## Decisions`.

## Decisions

**F11 — intake tracks the registry.** The question is "which of the platforms
AgentConnect serves will your team use", so its vocabulary *is* the served set:
there is no demand-signal option for a platform we do not run, and no served
platform deliberately withheld. The hand copy proved that by drifting — it stayed
at three ids after Feishu shipped, so a Feishu team could not say so — and the
`.max(3)` cap was a second spelling of the same count. Both now come from the
declaration, and the reason is written on the schema.

**F13 — a provider member, not a repository switch.** `botExternalIdentity`'s
four arms decided which columns carry a bot's demux identity and which write the
tenantless sentinel: per-platform knowledge in shared persistence, the exact
shape §12 names. It is now `CpPlatformProvider.projectBotIdentity` (Slack:
`(slackAppId, teamId)`, each half independent; Feishu: app id + sentinel +
region bag; Discord: display bag only; Telegram: **absent** — absence is the
declaration).

The read stays inside `PgBotRepo.create` rather than moving to the call sites,
because §11's "NULL is reserved for legacy rows" is a *persistence* invariant:
the repo performs the dual-write for every caller (the shared create tail, the
Feishu one-click funnel, anything added later), so no future write site can
forget it. The registry itself never enters persistence — only a
`BotIdentityProjector` function typed in `ports.ts` and wired at the composition
root, the same shape as `PgMcpGrantRepo(prisma, secretCipher)`. `container.ts`'s
late-bound registry façade moved above the repo map (unchanged otherwise) so the
repo can capture it. A `create` through an unwired repo **throws** rather than
writing the NULLs §11 reserves — the transaction-scoped instances in
`bot-credential.writer.ts` never create, so they keep the bare constructor.
`TENANTLESS_SENTINEL` moved to `ports.ts` so a provider can reference it without
importing a Prisma module.

## Tests

`test:unit` **1246 passed / 132 files** (+3 files, +26 tests) · `test:int`
**980 passed / 71 files** (Docker was up; F13 touches persistence, so the
integration run matters and it is green) · protocol **280 passed / 17 files** ·
`tsc --noEmit` clean for control-plane and protocol · eslint and prettier clean.

- `platforms/ids.test.ts` (new) — F8/F10/F11 drift. The load-bearing case is
  "`CP_PLATFORM_IDS` is exactly what the production providers register"; the rest
  assert each consumer's vocabulary **equals** the declaration (a re-introduced
  hand list that happens to be correct today still fails), plus the fence's two
  throws and the preserved `'slack'` default.
- `platforms/manifest-reads.test.ts` (new) — F9 and F12 as **equivalences**: the
  retired expression on one side, the manifest read on the other, over every
  registered id plus five unregistered ones.
- `platforms/bot-identity.test.ts` (new) — F13, per platform, `toEqual` so an
  extra column fails: which columns are written, which get the sentinel, that
  Slack never writes it, that Telegram and an unknown id project nothing.
- `orchestrator/httpBot.test.ts` — the snapshot gate's behavior: four
  non-authoritative platforms leave the stored set untouched and push no routes;
  Slack applies and fans.
- `test/integration/integration-channels.test.ts` — both F12 refusals plus the
  Discord space-leave that must still dispatch.
- `test/integration/integrations.route.test.ts` — the Telegram D6 row assertion,
  completing the four-platform pin the discord/feishu/slack cases already had.

## Behavior

**`POST /waitlist` now accepts `feishu`** (and any future registered platform) in
`platform`, and the array cap is the registry size rather than a literal `3`.
Widening is the safe direction for an intake enum — the server accepts a superset
of what any client sends. The console's own chip list is web-owned and still
offers three; that is a display gap, not a rejection, and is out of scope here.

**Two 400 messages on `POST /integrations/:id/leave` are reworded** from
Discord-by-name to the axis they now test ("this platform has no space to leave…"
/ "on this platform the bot joins a space, not individual conversations…").
Status codes, conditions and per-platform outcomes are unchanged; the old copy
named Discord in a message that fires for every *other* platform.

**Nothing else moves.** The suppression predicate's only divergence is on
unregistered ids, in the fail-closed direction, on a path a persisted row cannot
reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
