### PR TITLE
refactor(web): derive the console's platform tables from the registry (audit F14/F15/F18)

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -2941,8 +2941,28 @@
   }
 }
 
-/* Config-token hover popover (design: .cfgtok / .cfgtok-pop) — sits above the
-   "Open Slack app config tokens" button with a downward caret. */
+/* ─── OWNED BY THE SLACK PLATFORM MODULE ──────────────────────────────────────
+   `.cfgtok`, `.cfgtok-pop`, the `cfgScroll` / `cfgClickA` / `cfgClickB`
+   keyframes and their `.cfg-scroll` / `.cfg-click-a` / `.cfg-click-b` classes
+   further down have exactly ONE consumer between them:
+   `components/console/platforms/slack/{Body,previews}.tsx`. Nothing else in the
+   console references them, so they belong to that module — change them with it,
+   delete them with it.
+
+   They sit in the HOST stylesheet anyway, and that is deliberate rather than
+   leftover: the console has one stylesheet by design (D1 keeps modules inside
+   the web tree precisely so Tailwind v4's automatic content detection covers
+   them without per-directory `@source` bookkeeping), and a module-local
+   stylesheet would reintroduce exactly that bookkeeping for five rules. The
+   audit records this as a documentation gap, not a relocation
+   (integration-plugin-audit.md §10.6 F18) — this note IS the fix.
+
+   NOT in this set: `.step-blink` / `.step-pulse` below. Four modules share that
+   pair, so it is host-owned like the rest of this file.
+
+   Config-token hover popover (design: .cfgtok / .cfgtok-pop) — sits above the
+   "Open Slack app config tokens" button with a downward caret.
+   ─────────────────────────────────────────────────────────────────────────── */
 .cfgtok {
   position: relative;
 }
@@ -3062,7 +3082,11 @@
 /* Plain animation classes — reference the keyframes above from WITHIN this file so the
    CSS optimizer keeps them. Tailwind arbitrary `animate-[name_…]` utilities live in a
    separate output the optimizer can't see as a reference, so it would otherwise prune
-   these @keyframes and the animations would silently not play. */
+   these @keyframes and the animations would silently not play.
+
+   The three `.cfg-*` classes are the Slack module's (see the ownership note on
+   `.cfgtok` above); `.step-blink` / `.step-pulse` are shared by four modules and
+   stay host-owned. */
 .cfg-scroll {
   animation: cfgScroll 4.6s ease-in-out infinite;
 }

--- a/packages/web/src/components/LarkFeishuSwitcher.tsx
+++ b/packages/web/src/components/LarkFeishuSwitcher.tsx
@@ -5,6 +5,18 @@ const BRAND_LABEL: Record<LarkFeishuTarget, 'Lark' | 'Feishu'> = {
   feishu: 'Feishu'
 }
 
+/**
+ * One cloud's brand word. This is the REGION axis's vocabulary, not the
+ * platform's: `lib/platform-labels.ts` answers for the platform id `feishu`
+ * with the international brand ("Lark") on purpose, so a surface that renders
+ * one row PER CLOUD cannot get its words from there. It gets them from here —
+ * beside the switcher that is the region axis's host chrome — rather than
+ * re-spelling them (Settings → Bots' platform tabs, audit §10.6 F14).
+ */
+export function larkFeishuBrand(target: LarkFeishuTarget): string {
+  return BRAND_LABEL[target]
+}
+
 export default function LarkFeishuSwitcher({
   value,
   onSwitch,

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -24,9 +24,9 @@ import {
   type IdentityChromeView
 } from '@/components/console/platforms/publish'
 import { platformRegistry, platformSupportsSharing } from '@/components/console/platforms/registry'
+import { BOT_PLATFORMS, PLATFORMS } from '@/components/console/platforms/host-projections'
 import { agentLabel, MOCK_MODE, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
-import { platformLabel } from '@/lib/platform-labels'
 import { useOrgs } from '@/lib/org-context'
 import { useProfile } from '@/lib/profile'
 import { consoleKeys } from '@/lib/swr-keys'
@@ -82,37 +82,35 @@ import {
 // Each chat platform's create pane is a fragment behind `WizardHost`
 // (`components/console/platforms/<id>/`). The chassis knows no platform name
 // except where §5 manifest data has nowhere else to live yet (the picker labels
-// and the Lark/Feishu region switcher — see D2 in the contract).
+// and the Lark/Feishu region switcher — see D2 in the contract); the tile lists
+// themselves are registry projections in `platforms/host-projections.ts`.
 
-// `webhook` and `github` are not bot platforms: picking them mints an inbound
-// trigger (a hook) instead of installing a bot identity — webhook is
-// agent-fired-by-URL, github subscribes a repo's issue/PR/commit events. Both
-// live on the relay pool, so neither is gated by the daemon's adapter
-// capabilities.
-export type BotPlatform = 'slack' | 'telegram' | 'discord' | 'feishu'
-export type Platform = BotPlatform | 'webhook' | 'github'
+/**
+ * One picker choice: a chat-platform id the registry knows, or one of the two
+ * CORE trigger kinds. `webhook` and `github` are not bot platforms — picking
+ * either mints an inbound trigger (a hook) instead of installing a bot
+ * identity: webhook is agent-fired-by-URL, github subscribes a repo's
+ * issue/PR/commit events. Both live on the relay pool, so neither is gated by
+ * the daemon's adapter capabilities.
+ *
+ * OPEN by design (audit §10.6 F15). This was a closed union of the four chat
+ * ids plus the two trigger kinds, and the registry-derived tile list was CAST
+ * into it — a type asserting a platform set the runtime no longer has, which is
+ * the one thing the registry was made the single authority for. It is widened
+ * rather than GENERATED from the registry because generating it would mean
+ * re-closing an axis the contract deliberately keeps open: `platformId` is a
+ * `string` that is "never parsed", `WebPlatformRegistry.ids()` answers
+ * `readonly string[]`, and every host lookup over it is total by construction.
+ * A literal union would additionally have to survive the registry's erasure of
+ * its modules to one homogeneous array — the same erasure that already defeated
+ * the `TCardState` parameter (see `WebBotSettingsFragments` in the contract).
+ * Nothing reads this type to DECIDE anything; every consumer compares to a
+ * literal or asks the registry, and both still work on a string.
+ */
+export type Platform = string
 export type FeishuRegion = LarkFeishuTarget
 
 type GithubRepoChoice = GithubRepoDto & { installationId: string }
-
-// Bot platforms are gated on the owning daemon's advertised adapters; the agent
-// page's empty-integrations tiles filter this same list so a tile can never
-// promise a platform this modal would refuse.
-//
-// The tile labels are the console's one display-name table
-// (`lib/platform-labels.ts`) projected OVER the registry's id set: §5's
-// `displayName` is manifest data shared with the daemon/relay/CP, deliberately
-// NOT a web-module member (contract D2), while the registry stays the single
-// authority for WHICH platforms exist and in what order.
-export const BOT_PLATFORMS: { key: BotPlatform; label: string }[] = platformRegistry
-  .ids()
-  .map((id) => ({ key: id as BotPlatform, label: platformLabel(id)?.picker ?? id }))
-
-export const PLATFORMS: { key: Platform; label: string }[] = [
-  ...BOT_PLATFORMS,
-  { key: 'webhook', label: 'Webhook' },
-  { key: 'github', label: 'GitHub' }
-]
 
 /** The trigger cadences (design vocabulary: "when created / updated / mention only"
  *  — the stored event patterns + the mentionOnly flag encode the choice).

--- a/packages/web/src/components/console/platforms/bot-card-copy.test.ts
+++ b/packages/web/src/components/console/platforms/bot-card-copy.test.ts
@@ -41,12 +41,13 @@ describe('Settings → Bots row copy', () => {
     ).toEqual(['slack'])
   })
 
-  it('names no platform in either default', () => {
+  it('names no platform in any default', () => {
     // The whole defect was a provider's vocabulary leaking onto other
     // providers' rows; a default that names one would reintroduce it.
     expect(DEFAULT_BOT_CARD_COPY.revokedHint).not.toMatch(PLATFORM_WORDS)
     expect(DEFAULT_BOT_CARD_COPY.shareHint.available).not.toMatch(PLATFORM_WORDS)
     expect(DEFAULT_BOT_CARD_COPY.shareHint.unavailable).not.toMatch(PLATFORM_WORDS)
+    expect(DEFAULT_BOT_CARD_COPY.identityNoun).not.toMatch(PLATFORM_WORDS)
   })
 
   it('collapses both share arms for a platform that cannot share at all', () => {
@@ -79,6 +80,6 @@ describe('Settings → Bots row copy', () => {
     const partial = platformRegistry.get('slack')!.settingsFragments!.copy!
     expect(partial.revokedHint).toBeDefined()
     expect(partial.shareHint).toBeDefined()
-    expect(Object.keys(DEFAULT_BOT_CARD_COPY).sort()).toEqual(['revokedHint', 'shareHint'])
+    expect(Object.keys(DEFAULT_BOT_CARD_COPY).sort()).toEqual(['identityNoun', 'revokedHint', 'shareHint'])
   })
 })

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -362,15 +362,15 @@ export interface WebWizardFacet {
 }
 
 /**
- * Copy the Settings → Bots card writes into chrome the HOST owns — the two
- * sentences on a bot row that describe a PROVIDER's model rather than
- * AgentConnect's. Deliberately NOT {@link WebBotSettingsFragments.botCard}
- * components: the host renders the `revoked` badge and the Sharable cell and
- * owns the conditions under which each appears, so what a module supplies here
- * is the wording, not the element.
+ * Copy the Settings → Bots card writes into chrome the HOST owns — the words on
+ * a bot row that describe a PROVIDER's model rather than AgentConnect's.
+ * Deliberately NOT {@link WebBotSettingsFragments.botCard} components: the host
+ * renders the `revoked` badge, the Sharable cell and the card's own headings,
+ * and owns the conditions under which each appears, so what a module supplies
+ * here is the wording, not the element.
  *
- * Both members are optional and both host defaults are provider-free, because
- * both strings shipped as Slack's model rendered for EVERY platform: the badge
+ * Every member is optional and every host default is provider-free, because
+ * these strings shipped as Slack's model rendered for EVERY platform: the badge
  * tooltip named a "Slack workspace" over a Telegram bot, and the toggle told a
  * Discord bot to switch to a transport Discord does not have.
  */
@@ -401,6 +401,18 @@ export interface WebBotCardCopy {
    * — and two different sentences would promise that switching transport helps.
    */
   shareHint?: { available: string; unavailable: string }
+  /**
+   * What this platform calls the identity a bot row IS: Slack installs an
+   * "app", every other platform registers a "bot". The host writes it into its
+   * own card chrome — the first column's heading, the delete button's tooltip
+   * and the empty-state sentence (SettingsView) — which is why it is copy here
+   * and not a fragment.
+   *
+   * Lower-case singular: the heading uppercases through `.row.h`, and the
+   * sentences read "Delete app" / "No apps yet". Absent ⇒ `'bot'`, the noun
+   * four of the console's five bot tabs already used.
+   */
+  identityNoun?: string
 }
 
 /**

--- a/packages/web/src/components/console/platforms/host-projections.ts
+++ b/packages/web/src/components/console/platforms/host-projections.ts
@@ -1,0 +1,132 @@
+// No 'use client' here: reached only from the console's client trees
+// (ModalProvider and the views), exactly like `registry.ts`.
+
+import { larkFeishuBrand, type LarkFeishuTarget } from '@/components/LarkFeishuSwitcher'
+import type { BotDto } from '@/lib/api'
+import { platformLabel } from '@/lib/platform-labels'
+import { platformRegistry } from './registry'
+
+/**
+ * The console's HOST PROJECTIONS over the platform axis — the surfaces whose
+ * ROW SET is "one entry per platform" but whose CONTENT the registry cannot
+ * answer for: the install picker's tiles, the agent page's
+ * empty-integrations tiles, and the Settings → Bots tab strip.
+ *
+ * Every row set here derives from `platformRegistry.ids()` (audit §10.6 F14 —
+ * the Bots tab strip used to be a hand-written five-row table with its own
+ * labels and nouns, so adding a platform silently left a tab missing). What the
+ * host adds on top is projection, not membership:
+ *
+ *  - **display names** come from the console's one display-name table
+ *    (`lib/platform-labels.ts`), never re-spelled here. §5's `displayName` is
+ *    manifest data shared with the daemon/relay/CP and deliberately NOT a
+ *    web-module member (contract D2);
+ *  - the two **core trigger kinds** (`webhook`, `github`) are not platform
+ *    modules at all — picking either mints an inbound hook rather than a bot
+ *    identity — so the chassis lists them itself;
+ *  - the **region axis** ({@link BOT_PLATFORM_TABS}), for the same D2 reason.
+ *
+ * The rule these exist to keep: adding a platform is ONE registry line. Nothing
+ * in this file may become a second list of WHICH platforms exist —
+ * `platform-set.test.tsx` fails if one does.
+ */
+
+/** One picker/tile row. `key` is an OPEN string — the platform axis is the
+ *  registry's, and a closed union over it is a type-level lie the runtime does
+ *  not back (audit §10.6 F15). See `Platform` in `AddIntegrationModal`. */
+export interface PlatformTile {
+  readonly key: string
+  readonly label: string
+}
+
+/**
+ * Project a set of platform ids onto picker tiles. Pure and exported so the
+ * drift test can push an id through it that no module claims: an unregistered
+ * id renders as ITSELF rather than being cast into a union that never had it.
+ */
+export function platformTiles(ids: readonly string[]): PlatformTile[] {
+  return ids.map((id) => ({ key: id, label: platformLabel(id)?.picker ?? id }))
+}
+
+/**
+ * The install picker's chat-platform tiles, in registry (picker) order. Gated
+ * at the call site on the owning daemon's advertised adapters, so a tile can
+ * never promise a platform the modal would refuse.
+ */
+export const BOT_PLATFORMS: readonly PlatformTile[] = platformTiles(platformRegistry.ids())
+
+/** Every picker choice: the chat platforms plus the two core trigger kinds.
+ *  Neither trigger is gated by daemon adapters — both live on the relay pool. */
+export const PLATFORMS: readonly PlatformTile[] = [
+  ...BOT_PLATFORMS,
+  { key: 'webhook', label: 'Webhook' },
+  { key: 'github', label: 'GitHub' }
+]
+
+/**
+ * One-liners for the agent page's empty-integrations tiles, keyed by picker
+ * choice. An open record rather than an exhaustive one for the same reason
+ * {@link PlatformTile.key} is an open string; totality is kept by the drift
+ * test instead of by a union the registry cannot produce.
+ */
+export const INTEGRATION_BLURB: Record<string, string> = {
+  slack: 'Reply in channels & DMs',
+  telegram: 'Reply in groups & chats',
+  discord: 'Reply in servers',
+  feishu: 'Reply in groups & chats',
+  github: 'React to issues & PRs',
+  webhook: 'Trigger by posting a URL'
+}
+
+/** One tab of the Settings → Bots card: a platform, or one cloud of a platform
+ *  with regional clouds. */
+export interface BotPlatformTab {
+  /** Stable tab identity — internal (component state + lookup), never shown.
+   *  Compound on a region row so two platforms' regions can never collide. */
+  readonly key: string
+  /** The registry platform id this tab reads modules and copy for. */
+  readonly platform: string
+  /** The cloud this tab is filtered to, or null on a regionless platform. */
+  readonly region: LarkFeishuTarget | null
+  /** The tab's display word. */
+  readonly label: string
+}
+
+/**
+ * The one platform with regional clouds, expanded to a tab per cloud — the
+ * SAME chassis carve-out the install wizard makes (`platform === 'feishu' ?
+ * feishuRegion : undefined`, AddIntegrationModal, plus the switcher on its
+ * picker tile). §5's `regions` is manifest data the web module deliberately
+ * does not carry (contract D2): inventing a web-only `regions` member would
+ * create the second authority that note exists to prevent, so the region axis
+ * stays the chassis's and lives in exactly these two places.
+ */
+const REGION_CLOUDS: Readonly<Record<string, readonly LarkFeishuTarget[]>> = {
+  feishu: ['lark', 'feishu']
+}
+
+/**
+ * The Settings → Bots tab strip, in registry (picker) order. The row SET is the
+ * registry's; the labels are the display-name table's, except on a region row,
+ * whose word is the cloud's brand rather than the platform's ({@link
+ * larkFeishuBrand} — `platformLabel('feishu').name` is "Lark" on purpose).
+ */
+export const BOT_PLATFORM_TABS: readonly BotPlatformTab[] = platformRegistry
+  .ids()
+  .flatMap((platform): BotPlatformTab[] => {
+    const clouds = REGION_CLOUDS[platform]
+    if (!clouds) return [{ key: platform, platform, region: null, label: platformLabel(platform)?.name ?? platform }]
+    return clouds.map((region) => ({
+      key: `${platform}:${region}`,
+      platform,
+      region,
+      label: larkFeishuBrand(region)
+    }))
+  })
+
+/** Whether a bot row belongs under this tab. `feishuRegion` is the only region
+ *  a `BotDto` carries; a row predating the axis is Feishu. */
+export function botMatchesPlatformTab(bot: Pick<BotDto, 'platform' | 'feishuRegion'>, tab: BotPlatformTab): boolean {
+  if (bot.platform !== tab.platform) return false
+  return tab.region === null || (bot.feishuRegion ?? 'feishu') === tab.region
+}

--- a/packages/web/src/components/console/platforms/platform-set.test.tsx
+++ b/packages/web/src/components/console/platforms/platform-set.test.tsx
@@ -1,9 +1,18 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import { larkFeishuBrand } from '@/components/LarkFeishuSwitcher'
 import { PlatformMark } from '@/components/marks'
 import { PLATFORM_LABEL_IDS, platformLabel } from '@/lib/platform-labels'
+import {
+  BOT_PLATFORMS,
+  BOT_PLATFORM_TABS,
+  INTEGRATION_BLURB,
+  PLATFORMS,
+  botMatchesPlatformTab,
+  platformTiles
+} from './host-projections'
 import { PLATFORM_MARK_IDS, platformMark } from './marks'
-import { platformRegistry } from './registry'
+import { botCardCopy, platformRegistry } from './registry'
 
 /**
  * The registry is the single platform-set authority (§10), but two lookups
@@ -14,8 +23,18 @@ import { platformRegistry } from './registry'
  * time, so this file is what keeps the copies honest: adding a module without
  * adding its mark or its label fails here rather than shipping a plug glyph and a
  * capitalized id into production.
+ *
+ * It also covers the host PROJECTIONS over that id set (`host-projections.ts`) —
+ * the install picker's tiles, the agent page's tile blurbs and the Settings →
+ * Bots tab strip. The strip in particular was a hand-written five-row table with
+ * its own labels and nouns, uncovered here, and therefore free to drift
+ * (integration-plugin-audit.md §10.6 F14).
  */
 const ALIASES = ['lark']
+
+/** Not a module and never will be: picking either mints an inbound trigger, not
+ *  a bot identity (contract, registry doc). The picker still offers them. */
+const CORE_TRIGGER_KINDS = ['webhook', 'github']
 
 describe('platform set', () => {
   it('gives every registered module a mark and a label', () => {
@@ -40,6 +59,96 @@ describe('platform set', () => {
       const label = platformLabel(id)!
       expect(label.name, id).toBe(label.picker)
     }
+  })
+
+  it('offers exactly the registered platforms as picker tiles, plus the two core triggers', () => {
+    // The tile SET is the registry's, in registry order; the two trigger kinds
+    // are appended by the chassis because they are not modules.
+    expect(BOT_PLATFORMS.map((tile) => tile.key)).toEqual([...platformRegistry.ids()])
+    expect(PLATFORMS.map((tile) => tile.key)).toEqual([...platformRegistry.ids(), ...CORE_TRIGGER_KINDS])
+  })
+
+  it('labels every picker tile from the display-name table and blurbs every choice', () => {
+    for (const tile of BOT_PLATFORMS) {
+      expect(tile.label, tile.key).toBe(platformLabel(tile.key)?.picker)
+    }
+    // A choice with no one-liner is a tile with no tooltip — the drift a
+    // registry-derived list makes easy and an exhaustive record used to catch.
+    for (const tile of PLATFORMS) {
+      expect(INTEGRATION_BLURB[tile.key], tile.key).toBeTruthy()
+    }
+    expect(Object.keys(INTEGRATION_BLURB).sort()).toEqual([...platformRegistry.ids(), ...CORE_TRIGGER_KINDS].sort())
+  })
+
+  it('passes an id no module claims straight through the tile projection', () => {
+    // F15: the tile list used to be CAST into a closed union, so an id the
+    // registry could legitimately grow was a type-level lie. It is a plain
+    // string now — an unknown id renders as itself rather than as a claim that
+    // it is one of four.
+    expect(platformTiles(['zulip', 'slack'])).toEqual([
+      { key: 'zulip', label: 'zulip' },
+      { key: 'slack', label: 'Slack' }
+    ])
+  })
+
+  it('gives every registered platform a Settings → Bots tab', () => {
+    // Adding a module without a tab used to hide its bots from the card
+    // entirely. The strip is region-EXPANDED, so compare the platforms it
+    // covers, not its row count.
+    expect([...new Set(BOT_PLATFORM_TABS.map((tab) => tab.platform))]).toEqual([...platformRegistry.ids()])
+    expect(new Set(BOT_PLATFORM_TABS.map((tab) => tab.key)).size).toBe(BOT_PLATFORM_TABS.length)
+  })
+
+  it('takes every tab label from the display-name table, or from the cloud on a region row', () => {
+    for (const tab of BOT_PLATFORM_TABS) {
+      if (tab.region === null) {
+        expect(tab.label, tab.key).toBe(platformLabel(tab.platform)?.name)
+      } else {
+        // The one platform with regional clouds: the row is per CLOUD, and
+        // `platformLabel('feishu').name` is deliberately the international
+        // brand ("Lark"), so a region row's word comes from the region axis's
+        // own vocabulary instead of being re-spelled here.
+        expect(tab.label, tab.key).toBe(larkFeishuBrand(tab.region))
+      }
+    }
+    expect(BOT_PLATFORM_TABS.map((tab) => tab.label)).toEqual(['Slack', 'Telegram', 'Discord', 'Lark', 'Feishu'])
+  })
+
+  it('routes each bot to exactly one tab, region rows included', () => {
+    const bots = [
+      { platform: 'slack', feishuRegion: null },
+      { platform: 'telegram', feishuRegion: null },
+      { platform: 'discord', feishuRegion: null },
+      { platform: 'feishu', feishuRegion: 'lark' as const },
+      { platform: 'feishu', feishuRegion: 'feishu' as const },
+      // Rows predating the region axis belong to Feishu, not to Lark.
+      { platform: 'feishu', feishuRegion: null }
+    ]
+    for (const bot of bots) {
+      const matched = BOT_PLATFORM_TABS.filter((tab) => botMatchesPlatformTab(bot, tab))
+      expect(
+        matched.map((tab) => tab.label),
+        `${bot.platform}/${bot.feishuRegion}`
+      ).toHaveLength(1)
+    }
+    const legacyFeishu = BOT_PLATFORM_TABS.filter((tab) =>
+      botMatchesPlatformTab({ platform: 'feishu', feishuRegion: null }, tab)
+    )
+    expect(legacyFeishu[0]?.label).toBe('Feishu')
+    // A platform the console has not been taught lands on no tab at all rather
+    // than under whichever one happens to be first.
+    expect(BOT_PLATFORM_TABS.filter((tab) => botMatchesPlatformTab({ platform: 'zulip' }, tab))).toEqual([])
+  })
+
+  it('names the bot identity from the module, not from the tab table', () => {
+    // The noun was the tab table's own column ('app' for Slack, 'bot' for the
+    // rest). It is module copy now, so the card's heading, delete tooltip and
+    // empty state read one declaration.
+    expect(botCardCopy('slack').identityNoun).toBe('app')
+    for (const id of platformRegistry.ids().filter((p) => p !== 'slack')) {
+      expect(botCardCopy(id).identityNoun, id).toBe('bot')
+    }
+    expect(botCardCopy('zulip').identityNoun).toBe('bot')
   })
 
   it('renders the same mark through the module and through PlatformMark', () => {

--- a/packages/web/src/components/console/platforms/registry.ts
+++ b/packages/web/src/components/console/platforms/registry.ts
@@ -63,7 +63,8 @@ export const DEFAULT_BOT_CARD_COPY: Required<WebBotCardCopy> = {
   shareHint: {
     available: 'Sharing one bot across several agents isn’t available on this platform',
     unavailable: 'Sharing one bot across several agents isn’t available on this platform'
-  }
+  },
+  identityNoun: 'bot'
 }
 
 /**
@@ -77,7 +78,8 @@ export function botCardCopy(platformId?: string): Required<WebBotCardCopy> {
   const copy = platformId ? platformRegistry.get(platformId)?.settingsFragments?.copy : undefined
   return {
     revokedHint: copy?.revokedHint ?? DEFAULT_BOT_CARD_COPY.revokedHint,
-    shareHint: copy?.shareHint ?? DEFAULT_BOT_CARD_COPY.shareHint
+    shareHint: copy?.shareHint ?? DEFAULT_BOT_CARD_COPY.shareHint,
+    identityNoun: copy?.identityNoun ?? DEFAULT_BOT_CARD_COPY.identityNoun
   }
 }
 

--- a/packages/web/src/components/console/platforms/slack/settings.tsx
+++ b/packages/web/src/components/console/platforms/slack/settings.tsx
@@ -341,11 +341,17 @@ export const slackSettingsFragments: WebBotSettingsFragments = {
   // and the only one where sharing is real and gated on transport — the
   // socket↔http axis is immutable post-create, so "switch to HTTP" means
   // recreating the app, which is exactly what the CP's 409 says.
+  //
+  // `identityNoun` is Slack's for the same reason its wizard says "manifest":
+  // what you install in a Slack workspace is an APP. It was the `noun: 'app'`
+  // column of the host's hand-written tab table until the table became a
+  // registry projection (audit §10.6 F14).
   copy: {
     revokedHint: 'The Slack workspace uninstalled this app or revoked its tokens — re-install to reconnect',
     shareHint: {
       available: 'Allow several agents to share this bot across channels',
       unavailable: 'HTTP transport required to share'
-    }
+    },
+    identityNoun: 'app'
   }
 }

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -61,7 +61,8 @@ import { VisibilityValue } from '@/components/console/VisibilityField'
 import LarkFeishuSwitcher from '@/components/LarkFeishuSwitcher'
 import { AgentMark, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
 import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
-import { PLATFORMS, type Platform } from '@/components/console/modals/AddIntegrationModal'
+import type { Platform } from '@/components/console/modals/AddIntegrationModal'
+import { INTEGRATION_BLURB, PLATFORMS } from '@/components/console/platforms/host-projections'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
 import { BuiltinBadge } from '@/components/console/BuiltinBadge'
 import { NotFound } from '@/components/console/NotFound'
@@ -99,18 +100,11 @@ import {
 type DetailTab = 'config' | 'integrations' | 'workspace' | 'memory' | 'tools'
 const HOOK_REFRESH_MS = 30_000
 
-// One-liners for the empty-integrations tiles. The tile SET is derived from the
-// owning daemon's advertised adapters (below) — never hard-coded — so a tile
-// can't promise a platform the Add-integration modal would swap out from under
-// the click. webhook/github are relay/CP-backed triggers: always offered.
-const INTEGRATION_BLURB: Record<Platform, string> = {
-  slack: 'Reply in channels & DMs',
-  telegram: 'Reply in groups & chats',
-  discord: 'Reply in servers',
-  feishu: 'Reply in groups & chats',
-  github: 'React to issues & PRs',
-  webhook: 'Trigger by posting a URL'
-}
+// The tile SET is derived from the owning daemon's advertised adapters (below)
+// — never hard-coded — so a tile can't promise a platform the Add-integration
+// modal would swap out from under the click. webhook/github are relay/CP-backed
+// triggers: always offered. Their one-liners (`INTEGRATION_BLURB`) are a host
+// projection over the same axis, drift-tested beside the picker's tiles.
 const HOOK_RUN_REFRESH_MS = 10_000
 
 function FeishuRegionBadge({ integration }: { integration: Pick<IntegrationRow, 'platform' | 'region'> }) {

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/lib/api'
 import { agentLabel, isDirectConversation, type AgentCallPolicy, type IntegrationRow } from '@/lib/data'
 import { botCardCopy, botSharingEditable, platformRegistry } from '@/components/console/platforms/registry'
+import { BOT_PLATFORM_TABS, botMatchesPlatformTab } from '@/components/console/platforms/host-projections'
 import { consoleKeys } from '@/lib/swr-keys'
 import { inviteLinkStatus, inviteLinkUrl } from '@/lib/org-invite-link'
 import EditMemberModal, { type MemberTarget } from '@/components/console/modals/EditMemberModal'
@@ -360,21 +361,6 @@ const MEMBER_GRID = 'grid-cols-[2fr_1.4fr_auto]'
 // actions. The 100px action track fits refresh + platform link + delete and stays
 // identical across rows; below 480px "Created by" is dropped to preserve space.
 const BOT_GRID = 'grid-cols-[3fr_1.1fr_1fr_100px] min-[480px]:grid-cols-[2fr_0.9fr_1.5fr_1fr_100px]'
-const BOT_PLATFORM_TABS = [
-  { key: 'slack', platform: 'slack', feishuRegion: null, label: 'Slack', noun: 'app' },
-  { key: 'discord', platform: 'discord', feishuRegion: null, label: 'Discord', noun: 'bot' },
-  { key: 'telegram', platform: 'telegram', feishuRegion: null, label: 'Telegram', noun: 'bot' },
-  { key: 'lark', platform: 'feishu', feishuRegion: 'lark', label: 'Lark', noun: 'bot' },
-  { key: 'feishu', platform: 'feishu', feishuRegion: 'feishu', label: 'Feishu', noun: 'bot' }
-] as const
-type BotPlatformTab = (typeof BOT_PLATFORM_TABS)[number]
-type BotPlatformTabKey = BotPlatformTab['key']
-
-function botMatchesPlatformTab(bot: BotDto, tab: BotPlatformTab): boolean {
-  if (bot.platform !== tab.platform) return false
-  return tab.feishuRegion === null || (bot.feishuRegion ?? 'feishu') === tab.feishuRegion
-}
-
 type BotRosterRow = { kind: 'workspace'; key: string; label: string } | { kind: 'bot'; key: string; bot: BotDto }
 
 // Preserve the server's bot order within each workspace. The heading is rendered
@@ -934,7 +920,7 @@ function BotsCard({
     refresh,
     loading: dataLoading
   } = useConsoleData()
-  const [platformTabKey, setPlatformTabKey] = useState<BotPlatformTabKey>('slack')
+  const [platformTabKey, setPlatformTabKey] = useState<string>(BOT_PLATFORM_TABS[0]?.key ?? '')
   // Bot row expanded to its channel roster (one at a time), the bot whose
   // shareable PATCH is in flight, and the last toggle denial to surface (the CP
   // 409s with a reason: no relay connected / still shared by several agents).
@@ -946,8 +932,11 @@ function BotsCard({
   const targetBotPlatformTabKey = targetBot
     ? BOT_PLATFORM_TABS.find((tab) => botMatchesPlatformTab(targetBot, tab))?.key
     : undefined
-  const platformTab = BOT_PLATFORM_TABS.find((tab) => tab.key === platformTabKey)!
-  const { label, noun } = platformTab
+  // The registry always registers modules, so the strip is never empty; falling
+  // back to the first tab is what keeps this lookup total, where the hand-written
+  // table simply assumed the key resolved.
+  const platformTab = (BOT_PLATFORM_TABS.find((tab) => tab.key === platformTabKey) ?? BOT_PLATFORM_TABS[0])!
+  const { label } = platformTab
   const platformBots = bots.filter((bot) => botMatchesPlatformTab(bot, platformTab))
   const rosterRows = botRosterRows(platformBots)
 
@@ -985,11 +974,13 @@ function BotsCard({
   const RowActions = fragments?.lifecycleActions?.RowActions
   const CardNotice = fragments?.lifecycleActions?.CardNotice
   const CardProvider = fragments?.lifecycleActions?.CardProvider ?? PassThrough
-  // The two sentences the CARD writes into its own chrome (the revoked badge,
-  // the Sharable cell). Both used to be Slack's model rendered over every
-  // platform's rows; the module supplies the wording, the host still decides
-  // when and which arm to show.
+  // The words the CARD writes into its own chrome (the revoked badge, the
+  // Sharable cell, and `noun` — the "app"/"bot" heading, delete tooltip and
+  // empty-state sentence). All of them used to be Slack's model rendered over
+  // every platform's rows; the module supplies the wording, the host still
+  // decides when and which arm to show.
   const rowCopy = botCardCopy(platformTab.platform)
+  const noun = rowCopy.identityNoun
 
   return (
     <div className="card mt-[18px]">
@@ -1022,7 +1013,9 @@ function BotsCard({
       </div>
       {/* gap must match the data rows' or the narrow tracks drift out of line. */}
       <div className={`row h ${BOT_GRID} gap-[11px]`}>
-        <span>{noun === 'app' ? 'App' : 'Bot'}</span>
+        {/* `.row.h` uppercases, so the module's lower-case noun renders as the
+            heading did when the host picked between two literals. */}
+        <span>{noun}</span>
         <span>Sharable</span>
         <span>Agents</span>
         <span className="whitespace-nowrap max-[479px]:hidden">Created by</span>


### PR DESCRIPTION
## What

Three `packages/web` findings from the S3 exit reconciliation
(`docs/designs/integration-plugin-audit.md` §10.6). Each is a
"registry is the single platform-set authority" exception sitting next to the
dispatch path, not on it. No docs are touched — the audit's own dispositions
are implemented here.

### F14 — `BOT_PLATFORM_TABS` was a hand-written platform×region table

`views/SettingsView.tsx` carried five literal rows (`key`, `platform`,
`feishuRegion`, `label`, `noun`), not derived from `platformRegistry`, not
covered by `platform-set.test.tsx`, and re-spelling names `lib/platform-labels.ts`
already owns. Adding a platform meant editing it, and forgetting to meant that
platform's bots had no tab at all.

The rows are now projected from `platformRegistry.ids()` in a new
`components/console/platforms/host-projections.ts`:

- **row set** ← the registry, in registry (picker) order;
- **labels** ← `lib/platform-labels.ts` (`platformLabel(id).name`);
- **region rows** ← still a chassis concern, per §10.1: §5's `regions` is
  manifest scope and a web-only `regions` member would create the second
  authority D2 forbids. The one platform with regional clouds is expanded here
  with the reason in code, mirroring the wizard's own carve-out. A cloud row's
  word comes from the region axis's vocabulary (new `larkFeishuBrand`, exported
  beside the switcher that owns those words) because `platformLabel('feishu').name`
  is deliberately the international brand, "Lark".
- **`noun`** ← module copy. New optional `WebBotCardCopy.identityNoun`, host
  default `'bot'`, Slack declares `'app'`. It lands on the existing
  "module supplies the wording, host owns the element" seam rather than becoming
  a sixth column of a host table.

### F15 — the `BotPlatform` closed union the tile list was cast into

`export type BotPlatform = 'slack' | 'telegram' | 'discord' | 'feishu'` with
`id as BotPlatform` at the tile projection: a type asserting a closed set the
runtime no longer has.

**Chosen: widen to `string` at the boundary**, not generate the union.
Generating it would re-close an axis the contract deliberately keeps open —
`WebPlatformModule.platformId` is a `string` that is "never parsed",
`WebPlatformRegistry.ids()` answers `readonly string[]`, and every host lookup
over it is total by construction — and a literal union would additionally have
to survive the registry's erasure of its modules to one homogeneous
`WebPlatformModule[]`, which is exactly the variance failure #604 hit and wrote
up on `WebBotSettingsFragments` (`ComponentType<{card: SlackBotCardState}>` is
not assignable to `ComponentType<{card: void}>` under `strictFunctionTypes`).
Nothing reads the type to decide anything: every consumer compares to a literal
or asks the registry, and both work on a string.

Consequence handled in the same change: `INTEGRATION_BLURB` in
`AgentDetailView` was `Record<Platform, string>`, i.e. it was silently relying
on the union for exhaustiveness. It moves next to the tile lists in
`host-projections.ts` and is drift-tested instead, so widening does not trade
one silent hole for another.

### F18 — Slack-wizard-only CSS with no ownership note (docs only)

`.cfgtok`, `.cfgtok-pop`, `.cfg-scroll`, `.cfg-click-a/b` and their keyframes
have one consumer, `platforms/slack/{Body,previews}.tsx`. **The rules do not
move** — D1 keeps modules in the web tree so Tailwind v4 content detection
covers them without `@source` bookkeeping, and a module-local stylesheet would
reintroduce it for five rules. They get the ownership note they were missing,
including the boundary the audit did not state: `.step-blink` / `.step-pulse`
sit in the same neighbourhood but are shared by four modules and stay
host-owned.

## Tests

`packages/web`: **110 files, 865 tests, all passing** (858 at the audit's pin —
main has moved; the 7 new tests are all in `platform-set.test.tsx`).
`tsc --noEmit` clean, `eslint .` clean, `prettier --check` clean, `next build`
succeeds.

`platform-set.test.tsx` now also pins:

- picker tiles == registry ids (+ the two core trigger kinds, in that order);
- every tile label comes from `platform-labels.ts`; every picker choice has a blurb;
- an id no module claims flows through the tile projection as itself (F15);
- every registered platform has a Settings → Bots tab, keys unique;
- every tab label comes from the display-name table, or from the cloud on a
  region row — plus the exact strip `[Slack, Telegram, Discord, Lark, Feishu]`;
- every bot routes to exactly one tab (legacy region-less Feishu rows land on
  Feishu, not Lark; an unknown platform lands on no tab);
- `identityNoun` is `app` for Slack and `bot` everywhere else, including
  unclaimed ids.

Verified these bite rather than pass vacuously: temporarily renaming a
registered module's `platformId` to an id the host tables don't know fails 6 of
the 11 assertions in the file (label/mark parity, tile labels + blurbs, tab
labels, bot routing).

Also verified in the browser (mock mode, `NEXT_PUBLIC_MOCK=1`): the Bots card
tab strip renders all five tabs with their marks; switching tabs filters rows;
the Lark and Feishu tabs show different bots (region filter live); the column
heading renders `APP` on Slack and `BOT` elsewhere; the agent page's
empty-integrations tiles keep their labels and blurb tooltips; the
Add-integration picker renders Slack / Telegram / Discord / Lark·Feishu /
Webhook / GitHub and opens the selected module's pane.

## Behavior

One user-visible change, from deriving the rows instead of listing them:

| surface | before | after |
| --- | --- | --- |
| Settings → Bots tab order | Slack, **Discord, Telegram**, Lark, Feishu | Slack, **Telegram, Discord**, Lark, Feishu |

The strip now follows registry (picker) order, so it matches the
Add-integration picker and the agent page's tile grid, which already used it.

Everything else is byte-identical: all five labels unchanged (Slack, Telegram,
Discord, Lark, Feishu); the column heading still renders `APP` on Slack and
`BOT` elsewhere (the noun is lower-case now and `.row.h` uppercases it); the
"Delete app/bot" tooltips and the "No apps/bots yet — A Slack app is registered
when you add a Slack integration…" empty state are unchanged; picker tile
labels and tile blurbs are unchanged.

Internal-only: tab `key`s become `platform` or `platform:region`
(`feishu:lark` / `feishu:feishu`); they are component state and a lookup, never
displayed or persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
