### PR TITLE
fix(daemon): close the four daemon.ts audit findings (F1, F16, F17, F19)

### DIFF
--- a/docs/designs/integration-plugin-audit.md
+++ b/docs/designs/integration-plugin-audit.md
@@ -345,13 +345,29 @@ code reached only through a platform-specific entry point, i.e. a FILE-MOVE
 candidate (the mechanical relocation to `platforms/<id>/` that class (a)
 prescribes), not a dispatch fork:
 
-| sites                                                         | what                                                                                 | reached via                                                                                                           |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
-| 5 in `handleRelaySlackAction`                                 | shared-mode integration lookup, delivery-binding validation, foreign-session rejects | `platformActionDecoders['slack']` only                                                                                |
-| 1 in `handleRelayFeishuAction`                                | shared-mode integration lookup                                                       | `platformActionDecoders['feishu']` only                                                                               |
-| 2 in `isHttpSlackIntegration` / `isShareableSlackIntegration` | Slack shared-mode predicates over the frozen (#516) disk shape                       | Slack-only flows (relay-owned action ids, switch-agent gate)                                                          |
-| 2 in `setSlackTitleForBinding`                                | the Slack DM-title binding writer's own validation                                   | `dmSessionTitle` turn-chrome gate                                                                                     |
-| 1 in `isAgentBotMessage`                                      | managed-Slack-bot echo identity (`botSenderRouting`)                                 | ingress trust check, entangled with the CP collab snapshot's Slack app-id index — moves with the Slack ingress module |
+| sites                                                         | what                                                                                 | reached via                                                                                        |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| 5 in `handleRelaySlackAction`                                 | shared-mode integration lookup, delivery-binding validation, foreign-session rejects | `platformActionDecoders['slack']` only                                                             |
+| 1 in `handleRelayFeishuAction`                                | shared-mode integration lookup                                                       | `platformActionDecoders['feishu']` only                                                            |
+| 2 in `isHttpSlackIntegration` / `isShareableSlackIntegration` | Slack shared-mode predicates over the frozen (#516) disk shape                       | Slack-only flows (relay-owned action ids, switch-agent gate)                                       |
+| 2 in `setSlackTitleForBinding`                                | the Slack DM-title binding writer's own validation                                   | `dmSessionTitle` turn-chrome gate                                                                  |
+| 1 in `fetchThreadHistory`                                     | which app-id index vouches for a backfilled bot frame                                | the `getThreadReplies` duck-type gate — Slack is the only platform with a thread-history read port |
+
+**Amended (F19 fix).** §10.6 F19 found seven Slack-only branches this table did
+not account for — the agent-authorship cluster, compound-mention address
+extraction, and the collaboration close-response. All seven are now closed: the
+two authorship gates read the §5 manifest's `botSenderRouting`, the three
+directory keys (`isAgentBotApp`, the collaboration placement lookup, the
+verified target's integration lookup) come from the message's own platform,
+compound addresses are a §7.4 strategy (`platforms/mention-address.ts`), and
+the close-response is a `closeResponse` member on the §7.3 turn-output surface.
+
+One of the seven — `isAgentBotMessage` — was the eleventh row of this table,
+and it is gone. Its slot is taken by the one literal that fix RELOCATED rather
+than removed: `isManagedAgentBotIdentity` is now platform-parameterized, so its
+Slack-only caller `fetchThreadHistory` states `'slack'` itself. The count is
+still eleven, and the new row is the same file-move class as every other one
+here, not a dispatch fork.
 
 Non-branch platform code still in shared files, likewise pending file moves,
 not extraction: the per-platform connect/consolidate loops (`slackRetryTimers`

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -147,7 +147,13 @@ import { consolidateDiscord, discordConnKey, DiscordConnection } from './discord
 import { consolidateFeishu, feishuConnKey, FeishuConnection } from './feishu/connection.js'
 import { SlackNameResolver } from './slack/name-resolver.js'
 import { loopGuardScopesFor } from './platforms/loop-guard.js'
-import { integrationConfig, integrationCore, platformIntegrationConfig } from './platforms/integration-config.js'
+import {
+  integrationConfig,
+  integrationCore,
+  platformIds,
+  platformIntegrationConfig
+} from './platforms/integration-config.js'
+import { compoundMentionAddressesFor } from './platforms/mention-address.js'
 import { isPlatformMemberId } from './platforms/member-id.js'
 import { threadKeyForPost } from './platforms/thread-keys.js'
 import { isMalformedPlatformTurn } from './platforms/malformed-turn.js'
@@ -158,6 +164,7 @@ import { sessionThreadUrlFor } from './platforms/session-links.js'
 import { offersReadPort } from './platforms/read-ports.js'
 import {
   observedChannelsFor,
+  observedMembershipPlatforms,
   registerObservedChannels,
   type ObservedChannelsHost
 } from './platforms/observed-channels.js'
@@ -177,7 +184,6 @@ import { feishuCommandChrome } from './platforms/feishu/command-chrome.js'
 import {
   resolveSlackMentionedAgents,
   slackTextAddressesAnyone,
-  slackMentionAddress,
   SLACK_RESPONSE_FINAL_EVENT_TAG
 } from '@agentconnect.md/message'
 import {
@@ -1818,6 +1824,8 @@ export class Daemon {
         createConverger: (ctx) => new OutputConverger(ctx.mode as never, ctx.protectedAddresses ?? []),
         initialTurnState: (): SlackTurnState => ({}),
         apply: (p, action) => this.applySlackAction(p, action as SlackAction),
+        // §5.5: re-stamp the delivered answer as this response's one `final` event.
+        closeResponse: (p) => this.closeSlackResponse(p),
         // Terminal settlement: retry stale footer removals the final attribution
         // action may have bypassed on failure/suppression.
         onSettle: async (p) => {
@@ -4103,9 +4111,10 @@ export class Daemon {
   }
 
   /**
-   * Observed-conversation discovery for Telegram, Discord, and Feishu. These platforms do
-   * not give us an authoritative set of chats the bot is engaged in, so stored
-   * session history is merged with explicitly-addressed Off conversations already
+   * Observed-conversation discovery for every platform the §5 manifest marks
+   * `membershipEnumeration: 'observed'` — today Telegram, Discord and Feishu. These
+   * platforms do not give us an authoritative set of chats the bot is engaged in, so
+   * stored session history is merged with explicitly-addressed Off conversations already
    * cached for the integration. Reports carry `authoritative:false`: the CP upserts
    * what we know but never treats an absent row as a leave.
    *
@@ -4119,7 +4128,7 @@ export class Daemon {
    */
   private refreshObservedChannels(): void {
     for (const agent of this.agents.values()) {
-      for (const platform of ['telegram', 'discord', 'feishu'] as const) {
+      for (const platform of observedMembershipPlatforms()) {
         const integrations = agent.integrations.filter((i) => i.platform === platform)
         if (integrations.length === 0) continue
         for (const integ of integrations) {
@@ -4971,6 +4980,23 @@ export class Daemon {
     return { host, configFileState }
   }
 
+  /**
+   * The platform half of the CP registration capability set — DERIVED from this
+   * daemon's platform registry, never hand-listed.
+   *
+   * It is load-bearing rather than diagnostic: the CP's pre-install gate
+   * (`integrationPlatformAvailability`) and the console's tile gating both read it, so
+   * a platform this daemon can serve but forgot to advertise is silently uninstallable.
+   * Derivation removes the forgetting.
+   *
+   * Order is the registry's, so the advertised value is unchanged from the hand list it
+   * replaces. Extracted as its own method so the drift test can read exactly what the
+   * handshake sends (see test/platform-registry-drift.test.ts).
+   */
+  private registrationPlatforms(): string[] {
+    return platformIds()
+  }
+
   private registrationFeatures(): string[] {
     // Remote-MCP eligibility is (validated adapter provenance) AND (probed HTTP
     // transport): the capability bit alone proves descriptor transport, not that
@@ -5807,21 +5833,37 @@ export class Daemon {
   // route an inbound Slack message
   private seenMsgIds = new Set<string>()
 
-  /** Platform messages from AgentConnect-managed Slack apps carry an AgentConnect
-   *  identity. Same-daemon bots use their resolved Slack identities; cross-daemon bots
-   *  use the CP collaboration snapshot's public Slack app ids. This says the SENDING APP
-   *  belongs to AgentConnect — it does not identify WHICH agent authored the message,
-   *  which is why {@link verifyAgentAuthor} needs the metadata claim as well. */
-  private isManagedSlackBotIdentity(channel: string, senderId: string, appId?: string): boolean {
+  /** Platform messages from AgentConnect-managed apps carry an AgentConnect identity.
+   *  Same-daemon bots use their resolved connection identities; cross-daemon bots use
+   *  the CP collaboration snapshot's public app ids, which are indexed per
+   *  (platform, channel) — so the caller states which platform's index to consult. This
+   *  says the SENDING APP belongs to AgentConnect — it does not identify WHICH agent
+   *  authored the message, which is why {@link verifyAgentAuthor} needs the metadata
+   *  claim as well. */
+  private isManagedAgentBotIdentity(platform: string, channel: string, senderId: string, appId?: string): boolean {
     const localIdentity = [...this.connByIntegration.values()].some(
       (conn) => (!!conn.botUserId && senderId === conn.botUserId) || (!!conn.botId && senderId === conn.botId)
     )
-    return localIdentity || (!!appId && this.cpCollab.isAgentBotApp('slack', channel, appId))
+    return localIdentity || (!!appId && this.cpCollab.isAgentBotApp(platform, channel, appId))
   }
 
+  /**
+   * Is this inbound a message one of OUR bots posted?
+   *
+   * Gated on the §5 manifest's `botSenderRouting`, the pre-dispatch fact for "may a
+   * bot-authored message enter the routing ladder on this platform at all" — the same
+   * field relay arbitration reads for third-party bots. Fail-closed by construction: an
+   * unknown platform admits no bot senders, so it can never take this Slack-shaped path.
+   * Only Slack answers `true` today, exactly the set the `platform !== 'slack'` literal
+   * this replaces admitted.
+   *
+   * Admission is NOT widened by the generalization: the identity check below still
+   * requires the sender to be a live local bot or a CP-advertised AgentConnect app in
+   * this conversation, which no third-party bot can satisfy.
+   */
   private isAgentBotMessage(msg: NormalizedMessage): boolean {
-    if (msg.source !== 'user' || msg.platform !== 'slack') return false
-    return this.isManagedSlackBotIdentity(msg.channel, msg.sender.id, msg.sender.appId)
+    if (msg.source !== 'user' || !manifestFor(msg.platform).botSenderRouting) return false
+    return this.isManagedAgentBotIdentity(msg.platform, msg.channel, msg.sender.id, msg.sender.appId)
   }
 
   /**
@@ -5833,7 +5875,7 @@ export class Daemon {
    *   1. the provider event is authentic (the transport verified it: Socket Mode's
    *      authenticated socket, or the relay's HMAC before it forwarded);
    *   2. the sending app/bot identity belongs to AgentConnect in this org and
-   *      conversation ({@link isManagedSlackBotIdentity});
+   *      conversation ({@link isManagedAgentBotIdentity});
    *   3. the claimed author is one of the agents THAT identity represents — checked
    *      against the collaboration snapshot's placement for this exact channel, so an
    *      AgentConnect app cannot claim authorship for an agent it does not back; and
@@ -5855,17 +5897,20 @@ export class Daemon {
     addressedAnyone: boolean
     agentCallDeliveryId?: string
   } | null {
-    if (msg.platform !== 'slack') return null
+    // Same pre-dispatch gate as {@link isAgentBotMessage}: a platform that admits no
+    // bot senders can produce no verified agent author either (§5 `botSenderRouting`,
+    // fail-closed for ids this build does not know).
+    if (!manifestFor(msg.platform).botSenderRouting) return null
     const claim = msg.agentAuthorship
     if (!claim || claim.deliveryState !== 'final') return null
-    if (!this.isManagedSlackBotIdentity(msg.channel, msg.sender.id, msg.sender.appId)) return null
+    if (!this.isManagedAgentBotIdentity(msg.platform, msg.channel, msg.sender.id, msg.sender.appId)) return null
     const orgId = this.cpCollab.orgForAgent(claim.authorAgentId)
     if (!orgId) return null
     // Condition 3. A SHARED app backs several agents, so "this app is ours" is not
     // enough — the author must be placed in THIS conversation under an app identity that
     // matches the sender. Without the placement check, one agent behind a shared bot
     // could author messages as any of its co-tenants.
-    const placement = this.cpCollab.resolve(orgId, 'slack', msg.channel, claim.authorAgentId)
+    const placement = this.cpCollab.resolve(orgId, msg.platform, msg.channel, claim.authorAgentId)
     if (!placement) return null
     if (msg.sender.appId !== undefined && placement.botAppId !== undefined && placement.botAppId !== msg.sender.appId) {
       return null
@@ -6023,22 +6068,21 @@ export class Daemon {
    * The splitter protects every self-delimiting `<…>` token on its own; it cannot know
    * that a bare word following a mention belongs to the address, because in any other
    * message it is ordinary prose. These are the ones the daemon can name from its own
-   * directory. Only compound (shared-bot) addresses are worth carrying — a dedicated
-   * bot's `<@U…>` is already indivisible by construction.
+   * directory. Which directory entries form a compound address — and how one is spelled —
+   * is the platform's own knowledge ({@link compoundMentionAddressesFor}); core supplies
+   * the conversation's directory and nothing else.
    *
-   * Empty off Slack, and empty with no collaboration snapshot: over-protecting nothing is
-   * the same behavior the splitter had before, whereas guessing would risk refusing to
-   * split a message for a boundary that is not really an address.
+   * Empty on a platform with no compound-address shape, and empty with no collaboration
+   * snapshot: over-protecting nothing is the same behavior the splitter had before,
+   * whereas guessing would risk refusing to split a message for a boundary that is not
+   * really an address.
    */
   private compoundMentionAddresses(agentId: string, msg: { platform: string; channel: string }): string[] {
-    if (msg.platform !== 'slack') return []
+    const compound = compoundMentionAddressesFor(msg.platform)
+    if (!compound) return []
     const orgId = this.cpCollab.orgForAgent(agentId)
     if (!orgId) return []
-    return this.cpCollab
-      .mentionDirectory(orgId, msg.platform, msg.channel)
-      .filter((entry) => entry.botShared)
-      .map((entry) => slackMentionAddress(entry))
-      .filter((address): address is string => address !== undefined)
+    return compound(this.cpCollab.mentionDirectory(orgId, msg.platform, msg.channel))
   }
 
   private agentConversationAdmits(agentId: string, msg: NormalizedMessage): boolean {
@@ -6092,7 +6136,7 @@ export class Daemon {
       return undefined
     }
     const platformMessageId = slackTsFromMsgId(msg.msgId)
-    const integrationId = this.resolveCpAgent(targetAgentId, 'slack')?.integrationId
+    const integrationId = this.resolveCpAgent(targetAgentId, msg.platform)?.integrationId
     if (!integrationId) return undefined
     // The key's transport component is the TARGET's own reply scope — NOT the scope of
     // the connection that happened to observe the post. Both halves of a paired delivery
@@ -10202,8 +10246,11 @@ export class Daemon {
           reply,
           // Slack metadata event names and payloads are app-defined. Trust AgentConnect
           // authorship/chrome only when the provider identity belongs to one of our local
-          // bots or to a CP-advertised AgentConnect app in this channel.
-          trustedAgentBot: reply.isBot && this.isManagedSlackBotIdentity(channel, reply.sender, reply.appId)
+          // bots or to a CP-advertised AgentConnect app in this channel. The platform is
+          // `'slack'` by construction — the `getThreadReplies` duck-type above is the
+          // Slack-only gate, so this literal is Slack-gated flow code (§9.2 file-move
+          // class), not a core branch.
+          trustedAgentBot: reply.isBot && this.isManagedAgentBotIdentity('slack', channel, reply.sender, reply.appId)
         }))
         // Skip daemon CHROME (status bar, progress/plan/reasoning, notices, cards). It is not
         // conversation and must not be re-ingested as a transcript text row. The legacy
@@ -13024,38 +13071,11 @@ export class Daemon {
       // Every section has now been delivered, so the complete logical response exists and
       // exactly one of its messages can be marked final (§5.5). Must run AFTER applyChain:
       // before it, the message being closed might not be the last one posted.
-      // §5.5: close the response with one content-preserving edit. Recipients come from
-      // the COMPLETE response and are resolved against the CONVERSATION's directory — the
-      // same bidirectional mapping the target will use — so author and target cannot
-      // disagree about who was addressed.
-      if (p.platform === 'slack' && p.conn) {
-        const orgId = this.cpCollab.orgForAgent(p.agentId)
-        const recipients = orgId
-          ? resolveSlackMentionedAgents(
-              p.replyText,
-              this.cpCollab.mentionDirectory(orgId, p.platform, p.channel)
-            ).filter((id) => id !== p.agentId)
-          : []
-        // Whether the answer addressed ANYONE is read from the complete reply text, not
-        // from the final section: §2.3 makes any address binding, and the splitter may
-        // have put the only mention in section one. Without this the same answer would
-        // wake a peer or not depending on where the cut landed.
-        const addressedAnyone = slackTextAddressesAnyone(p.replyText)
-        // What this response RESOLVED to, at the one place the author still knows it.
-        // Everything downstream (relay arbitration, the target's ladder) sees only the
-        // outcome, so without this a response that addressed a peer but resolved to no
-        // agent — a stale or unpopulated mention directory — is indistinguishable from
-        // one that addressed nobody, on either side of the wire.
-        const mentionDir = orgId ? this.cpCollab.mentionDirectory(orgId, p.platform, p.channel) : []
-        this.log.debug(
-          `slack: finalizing response ${p.responseId} for "${p.agentId}" — recipients=[${recipients.join(',')}] ` +
-            `addressedAnyone=${addressedAnyone} text=${JSON.stringify(p.replyText.slice(0, 120))} ` +
-            `directory=[${mentionDir
-              .map((e) => `${e.agentId.slice(0, 8)}:${e.botUserId ?? 'NO-BOT-USER-ID'}${e.botShared ? '(shared)' : ''}`)
-              .join(' ')}]`
-        )
-        await finalizeSlackResponse(p.conn as SlackConnection, p, recipients, addressedAnyone, (m) => this.log.debug(m))
-      }
+      //
+      // §7.3 `closeResponse`: exact lookup, so a webchat / hook / dream turn rendering
+      // through the core surface does not inherit its platform's closure, and a platform
+      // that cannot amend a sent message simply registers none.
+      await this.turnSurfaces.exact(p.platform)?.closeResponse?.(p)
       // The user-visible reply is now delivered. Enqueue provider work without
       // awaiting it: managed may distill, while external only commits its durable
       // capture outbox. Webchat carries the canonical per-turn id separately from
@@ -13542,6 +13562,44 @@ export class Daemon {
       kind: 'text',
       text
     })
+  }
+
+  /**
+   * Slack's §7.3 `closeResponse`: close this turn's logical response with one
+   * content-preserving edit (send-message-routing-rework.md §5.5). Reached only through
+   * the Slack turn-output surface, so the platform is Slack by construction.
+   *
+   * Recipients come from the COMPLETE response and are resolved against the
+   * CONVERSATION's directory — the same bidirectional mapping the target will use — so
+   * author and target cannot disagree about who was addressed.
+   */
+  private async closeSlackResponse(p: Pending): Promise<void> {
+    if (!p.conn) return
+    const orgId = this.cpCollab.orgForAgent(p.agentId)
+    const recipients = orgId
+      ? resolveSlackMentionedAgents(p.replyText, this.cpCollab.mentionDirectory(orgId, p.platform, p.channel)).filter(
+          (id) => id !== p.agentId
+        )
+      : []
+    // Whether the answer addressed ANYONE is read from the complete reply text, not
+    // from the final section: §2.3 makes any address binding, and the splitter may
+    // have put the only mention in section one. Without this the same answer would
+    // wake a peer or not depending on where the cut landed.
+    const addressedAnyone = slackTextAddressesAnyone(p.replyText)
+    // What this response RESOLVED to, at the one place the author still knows it.
+    // Everything downstream (relay arbitration, the target's ladder) sees only the
+    // outcome, so without this a response that addressed a peer but resolved to no
+    // agent — a stale or unpopulated mention directory — is indistinguishable from
+    // one that addressed nobody, on either side of the wire.
+    const mentionDir = orgId ? this.cpCollab.mentionDirectory(orgId, p.platform, p.channel) : []
+    this.log.debug(
+      `slack: finalizing response ${p.responseId} for "${p.agentId}" — recipients=[${recipients.join(',')}] ` +
+        `addressedAnyone=${addressedAnyone} text=${JSON.stringify(p.replyText.slice(0, 120))} ` +
+        `directory=[${mentionDir
+          .map((e) => `${e.agentId.slice(0, 8)}:${e.botUserId ?? 'NO-BOT-USER-ID'}${e.botShared ? '(shared)' : ''}`)
+          .join(' ')}]`
+    )
+    await finalizeSlackResponse(p.conn as SlackConnection, p, recipients, addressedAnyone, (m) => this.log.debug(m))
   }
 
   /** Slack's turn output lives in its platform module (§7.3) — and doubles as the
@@ -16890,7 +16948,11 @@ export class Daemon {
       // case is still a single frame per agent per pass.
       const groups = new Map<string, SessionPurgeRow[]>()
       for (const row of owed) {
-        const key = `${row.agentId} ${row.reason} ${row.purgedAt}`
+        // NUL separates the three parts because no field can contain it. Written as
+        // an escape, never as a literal NUL byte: one raw NUL anywhere in this file
+        // makes ripgrep treat the whole of it as binary and print no matches at all,
+        // which silently turns every `rg`-based sweep over daemon.ts into a pass.
+        const key = `${row.agentId}\0${row.reason}\0${row.purgedAt}`
         const bucket = groups.get(key)
         if (bucket) bucket.push(row)
         else groups.set(key, [row])
@@ -18871,7 +18933,7 @@ export class Daemon {
       heartbeatDefaultMs: cp.heartbeatMs,
       maxAgents: this.cfg.limits.maxAgents,
       capabilities: () => ({
-        platforms: ['slack', 'telegram', 'discord', 'feishu'],
+        platforms: this.registrationPlatforms(),
         // Report the human-facing tool name (e.g. "Claude Agent"), not the
         // registry id ("claude-acp"); fall back to the id for user-defined or
         // unnamed runtimes.

--- a/packages/daemon/src/platforms/command-chrome.ts
+++ b/packages/daemon/src/platforms/command-chrome.ts
@@ -109,4 +109,11 @@ export class CommandChromeRegistry<TMsg, TInfo> {
   threadIdentifiesSession(platform: string): boolean {
     return this.surfaces.get(platform)?.threadIdentifiesSession ?? false
   }
+
+  /** Every registered platform id, registration order. Exists so the daemon's
+   *  platform set can be CHECKED against this registry rather than re-listed —
+   *  see the capability-drift test. */
+  ids(): string[] {
+    return [...this.surfaces.keys()]
+  }
 }

--- a/packages/daemon/src/platforms/integration-config.ts
+++ b/packages/daemon/src/platforms/integration-config.ts
@@ -45,6 +45,24 @@ const CONFIG_SCHEMAS = {
  *  rather than re-listed — the two cannot drift apart. */
 export type IntegrationConfig = z.infer<(typeof CONFIG_SCHEMAS)[keyof typeof CONFIG_SCHEMAS]>
 
+/**
+ * Every chat platform this daemon has a module for, in registry order.
+ *
+ * THIS registry is the authority rather than one of the other per-platform tables
+ * because absence here is TOTAL: {@link integrationConfig} returns `undefined` for an
+ * unregistered id and every consumer fails closed on that (skip the integration, open
+ * no connection). A platform missing from the turn-output or command-chrome registries
+ * merely renders through the core fallback; a platform missing from this one cannot be
+ * served at all.
+ *
+ * Read by the CP registration handshake, whose advertised `capabilities.platforms` is
+ * what the CP's pre-install gate and the console's tile gating consume — so a platform
+ * added here becomes installable without a second edit anywhere.
+ */
+export function platformIds(): string[] {
+  return Object.keys(CONFIG_SCHEMAS)
+}
+
 /** The core routing knobs core owns, whatever the platform (§6.4 `core`). */
 export interface IntegrationCore {
   mode: 'direct' | 'shared'

--- a/packages/daemon/src/platforms/mention-address.ts
+++ b/packages/daemon/src/platforms/mention-address.ts
@@ -1,0 +1,49 @@
+/**
+ * The **compound mention-address strategy** (§7.4 strategy table, stage S3).
+ *
+ * WHAT IT PROTECTS. The reply splitter must never cut an address in half
+ * (send-message-routing-rework.md §5.3/§8.5). It protects every self-delimiting
+ * token on its own, but it cannot know that a bare word FOLLOWING a mention
+ * belongs to the address — in any other message that word is ordinary prose. So
+ * core asks the platform which COMPOUND addresses this conversation can contain.
+ *
+ * Only Slack has any today: a shared bot's `<@U_SHARED> reviewer`, where the bot
+ * user id names the app and the trailing slug selects the agent, so the two
+ * halves are one address though only the first is self-delimiting. A dedicated
+ * bot's `<@U…>` is already indivisible and is deliberately NOT reported — over-
+ * protecting a boundary that is not really an address would make the splitter
+ * refuse to split.
+ *
+ * The default is therefore "no compound addresses", which is exactly the
+ * behavior every non-Slack platform already had (the branch this replaces read
+ * `if (msg.platform !== 'slack') return []`). Unknown ids get it too: guessing an
+ * address shape for a platform this build does not know is the fail-OPEN
+ * direction.
+ */
+import { slackMentionAddress, type AgentMentionIdentity } from '@agentconnect.md/message'
+
+/** Given the conversation's mention directory, the addresses in it that the
+ *  splitter must not cut. */
+export type CompoundMentionAddressReader = (directory: readonly AgentMentionIdentity[]) => string[]
+
+const READERS = new Map<string, CompoundMentionAddressReader>([
+  [
+    'slack',
+    (directory) =>
+      directory
+        // Shared-bot entries only: those are the ones whose address carries a
+        // trailing slug and is therefore splittable.
+        .filter((entry) => entry.botShared)
+        .map((entry) => slackMentionAddress(entry))
+        .filter((address): address is string => address !== undefined)
+  ]
+])
+
+/**
+ * The platform's compound-address reader, or `undefined` when it has none — the
+ * caller then skips the directory lookup entirely and reports no protected
+ * addresses, every non-Slack platform's behavior.
+ */
+export function compoundMentionAddressesFor(platform: string): CompoundMentionAddressReader | undefined {
+  return READERS.get(platform)
+}

--- a/packages/daemon/src/platforms/observed-channels.ts
+++ b/packages/daemon/src/platforms/observed-channels.ts
@@ -15,7 +15,34 @@
  * Telegram and Feishu chats have neither notion; their rows pass through. That
  * is the default: no collapse, no spaces — any platform without a registered
  * strategy reports observed rows exactly as collected.
+ *
+ * WHICH platforms get rebuilt this way is {@link observedMembershipPlatforms} —
+ * a derived set, not a hand list, so the "no authoritative snapshot" fact has one
+ * spelling in the daemon rather than two.
  */
+import { manifestFor } from '@agentconnect.md/protocol'
+import { platformIds } from './integration-config.js'
+
+/**
+ * The platforms whose reachable-conversation set core must rebuild from OBSERVED
+ * traffic — this daemon's registered platforms (integration-config.ts) filtered by
+ * the §5 manifest's `membershipEnumeration`. Today: Telegram, Discord, Feishu.
+ *
+ * BOUNDED BY THE REGISTRY, not by the manifest alone. `manifestFor` is total and its
+ * fail-closed default is `observed`, so an id this build has never heard of would
+ * answer "observed" — correct as a per-message capability read, wrong as an
+ * ENUMERATION. Core can only rebuild a platform it has a module for, so the registry
+ * supplies the universe and the manifest supplies the filter.
+ *
+ * Computed once: both inputs are static module tables.
+ */
+const OBSERVED_MEMBERSHIP_PLATFORMS: readonly string[] = Object.freeze(
+  platformIds().filter((platform) => manifestFor(platform).membershipEnumeration === 'observed')
+)
+
+export function observedMembershipPlatforms(): readonly string[] {
+  return OBSERVED_MEMBERSHIP_PLATFORMS
+}
 
 /** One observed conversation row, as the snapshot pipeline carries it. */
 export interface ObservedChannelRow {

--- a/packages/daemon/src/platforms/turn-output.ts
+++ b/packages/daemon/src/platforms/turn-output.ts
@@ -90,6 +90,25 @@ export interface TurnOutputSurface<TTurn, TAction, TConv, TMessage> {
    *  (Slack retries stale footer removals). Exact-lookup only, like
    *  {@link onSuppress}. */
   onSettle?(turn: TTurn): Promise<void>
+  /**
+   * Close this turn's logical RESPONSE, once the complete answer has been
+   * delivered (send-message-routing-rework.md §5.5). Distinct from
+   * {@link onSettle}, and not foldable into it: this runs on the SUCCESS path
+   * only, before post-turn work, whereas settlement is cleanup in the turn's
+   * `finally` and also runs after a failure.
+   *
+   * The platform fact is whether a delivered answer can be RE-STAMPED at all —
+   * Slack edits its last message to carry the `final` delivery state plus the
+   * recipients resolved from the whole response, which is what lets a peer
+   * distinguish a finished answer from a streamed prefix. A platform that cannot
+   * amend a sent message registers nothing and the turn simply ends, which is
+   * every non-Slack platform's behavior today.
+   *
+   * Exact-lookup only, like {@link onSuppress}: a webchat / hook / dream turn
+   * renders through the core surface but must not inherit its platform's
+   * response closure.
+   */
+  closeResponse?(turn: TTurn): Promise<void>
 }
 
 /**
@@ -155,5 +174,12 @@ export class TurnOutputRegistry<TTurn, TAction, TConv, TMessage> {
    *  surface, but they must not inherit its platform's teardown. */
   exact(platform: string): TurnOutputSurface<TTurn, TAction, TConv, TMessage> | undefined {
     return this.surfaces.get(platform)
+  }
+
+  /** Every registered platform id, registration order. Exists so the daemon's
+   *  platform set can be CHECKED against this registry rather than re-listed —
+   *  see the capability-drift test. */
+  ids(): string[] {
+    return [...this.surfaces.keys()]
   }
 }

--- a/packages/daemon/test/daemon-platform-authorship.test.ts
+++ b/packages/daemon/test/daemon-platform-authorship.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { manifestFor } from '@agentconnect.md/protocol'
+import { Daemon } from '../src/daemon.js'
+
+/**
+ * integration-plugin-audit.md §10.6 F19 — the seven Slack-only core branches the S2
+ * survivor table missed, now closed. These are the behavioral pins.
+ *
+ * The dangerous direction is admission: the bot-authorship cluster decides whether a
+ * message a BOT posted may be trusted as an agent's own words and routed. Generalizing
+ * `platform !== 'slack'` to the §5 manifest's `botSenderRouting` must not widen that by
+ * one message, so every gate is exercised on all four platforms plus an id this build
+ * has never heard of, and the third-party-bot case is pinned explicitly.
+ */
+
+const TEST_ORG = 'org_test0000000000000000000'
+const OUR_APP = 'AAGENTCONNECT'
+
+/** Every platform the daemon serves, with a config its own module schema accepts. */
+const CONFIGS: Record<string, Record<string, unknown>> = {
+  slack: { botToken: 'xoxb', appToken: 'xapp' },
+  telegram: { botToken: '123:ABC' },
+  discord: { botToken: 'disc' },
+  feishu: { appId: 'cli_x', appSecret: 's' }
+}
+const PLATFORMS = Object.keys(CONFIGS)
+
+const integrationEntry = (agentId: string, platform: string) => ({
+  id: `int-${agentId}-${platform}`,
+  platform,
+  core: { mode: 'direct', bindRules: [{ match: { kind: 'auto' }, channel: 'C1' }], mutedChannels: [], gated: false },
+  config: CONFIGS[platform]
+})
+
+/** Agents are scaffolded SLACK-ONLY on disk: `start()` opens a real connection per
+ *  configured platform, and only Slack's failed handshake is cheap. Extra platforms are
+ *  spliced in afterwards with {@link installIntegration}. */
+function scaffold(agentIds: string[]): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-authorship-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  for (const id of agentIds) {
+    const adir = join(root, 'agents', id)
+    mkdirSync(adir, { recursive: true })
+    writeFileSync(
+      join(adir, 'agent.json'),
+      JSON.stringify({
+        id,
+        name: id,
+        status: 'active',
+        runtime: 'claude',
+        workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+        integrations: [integrationEntry(id, 'slack')],
+        output: { mode: 'low' }
+      })
+    )
+  }
+  return root
+}
+
+/** Add a live integration to a booted agent without opening its platform connection —
+ *  enough for the routing-side lookups under test, which read `agent.integrations`. */
+function installIntegration(daemon: Daemon, agentId: string, platform: string): void {
+  ;(daemon as any).agents.get(agentId).integrations.push(integrationEntry(agentId, platform))
+}
+
+const fakeHost = () => ({
+  __started: true,
+  start: vi.fn(async () => {}),
+  newSession: vi.fn(async () => 'acp-1'),
+  prompt: vi.fn(async () => 'end_turn'),
+  cancel: vi.fn(),
+  stop: vi.fn()
+})
+
+/**
+ * Boot with a collaboration snapshot that places both agents in channel `C1` on EVERY
+ * platform under the same AgentConnect app id. That is deliberately generous: if any gate
+ * were platform-blind, a non-Slack message would find a placement waiting for it and
+ * verify. The gates are what keep it out, not a missing snapshot row.
+ */
+async function boot(agentIds: string[], over: { botShared?: boolean; platforms?: string[] } = {}) {
+  const daemon = new Daemon({ root: scaffold(agentIds), hostFactory: () => fakeHost() as any })
+  await daemon.start()
+  const placements = agentIds.map((id) => ({
+    agentId: id,
+    daemonId: 'local-daemon',
+    integrationId: `int-${id}-slack`,
+    name: id,
+    botAppId: OUR_APP,
+    // `botShared` is RECOMPUTED by the snapshot from the identities actually present in
+    // the conversation, so a shared bot is modeled the way it really is: one bot user id
+    // backing several agents, told apart by the slug.
+    botUserId: over.botShared ? 'USHARED' : `U${id.replace(/[^a-z0-9]/gi, '').toUpperCase()}`,
+    callPolicy: 'all' as const,
+    allowedCallerAgentIds: [],
+    outboundPolicy: 'all' as const,
+    allowedTargetAgentIds: []
+  }))
+  ;(daemon as any).cpCollab.replace({
+    generation: 1,
+    channels: (over.platforms ?? PLATFORMS).map((platform) => ({
+      orgId: TEST_ORG,
+      platform,
+      channelId: 'C1',
+      agents: placements
+    })),
+    agents: placements.map((p) => ({ ...p, orgId: TEST_ORG }))
+  })
+  return daemon
+}
+
+/** One finalized agent-authored message, as ingress sees it after normalization. */
+const agentMessage = (platform: string, over: Record<string, unknown> = {}) => ({
+  msgId: `${platform}:C1:1720000000.000200:final`,
+  traceId: 't',
+  source: 'user' as const,
+  platform,
+  channel: 'C1',
+  thread: '1720000000.000100',
+  sender: { id: 'UBOT', isBot: true, appId: OUR_APP },
+  text: 'please verify the rollout',
+  mentionedBots: [] as string[],
+  isDm: false,
+  agentAuthorship: {
+    authorAgentId: 'bot-a',
+    responseId: 'r-1',
+    deliveryState: 'final' as const,
+    hopCount: 0,
+    mentionedAgentIds: ['bot-b']
+  },
+  ...over
+})
+
+describe('bot-authorship admission is a manifest read (audit F19, sites 1–4)', () => {
+  it('admits a managed bot message only where the manifest admits bot senders', async () => {
+    const daemon = await boot(['bot-a', 'bot-b'])
+    for (const platform of [...PLATFORMS, 'some-future-platform']) {
+      const admitted = (daemon as any).isAgentBotMessage(agentMessage(platform))
+      // The gate and the manifest are the same fact, checked two ways so a manifest flip
+      // and a code change cannot silently disagree.
+      expect(admitted).toBe(manifestFor(platform).botSenderRouting)
+      expect(admitted).toBe(platform === 'slack')
+    }
+    await daemon.stop()
+  })
+
+  it('verifies an author only where the manifest admits bot senders', async () => {
+    const daemon = await boot(['bot-a', 'bot-b'])
+    for (const platform of [...PLATFORMS, 'some-future-platform']) {
+      const verified = (daemon as any).verifyAgentAuthor(agentMessage(platform))
+      expect(verified === null).toBe(!manifestFor(platform).botSenderRouting)
+    }
+    expect((daemon as any).verifyAgentAuthor(agentMessage('slack'))).toMatchObject({
+      authorAgentId: 'bot-a',
+      orgId: TEST_ORG,
+      sourceHopCount: 0
+    })
+    await daemon.stop()
+  })
+
+  it('still drops a THIRD-PARTY bot on the admitting platform', async () => {
+    // The regression that a careless generalization would introduce. `botSenderRouting`
+    // says "bot messages may be considered here", never "this bot is ours" — the app
+    // identity check is what decides that, and it must still reject a foreign app.
+    const daemon = await boot(['bot-a', 'bot-b'])
+    const foreign = agentMessage('slack', { sender: { id: 'UOTHER', isBot: true, appId: 'ASOMEONEELSE' } })
+    expect((daemon as any).isAgentBotMessage(foreign)).toBe(false)
+    expect((daemon as any).verifyAgentAuthor(foreign)).toBeNull()
+    // …and with no app id at all (a bot whose event carries none).
+    const anonymous = agentMessage('slack', { sender: { id: 'UNOBODY', isBot: true } })
+    expect((daemon as any).isAgentBotMessage(anonymous)).toBe(false)
+    await daemon.stop()
+  })
+
+  it('consults the app-identity and placement indexes under the MESSAGE’s platform', async () => {
+    // Sites 1 and 4 were literal `'slack'` directory keys. The collaboration snapshot is
+    // keyed per (platform, channel), so a snapshot that knows this app on Telegram only
+    // must not vouch for a Slack message — nor the reverse.
+    const daemon = await boot(['bot-a', 'bot-b'], {
+      platforms: ['telegram']
+    })
+    // Slack admits bot senders, but the app is indexed under Telegram, so nothing vouches
+    // for the sender and the message is not ours.
+    expect((daemon as any).isAgentBotMessage(agentMessage('slack'))).toBe(false)
+    expect((daemon as any).verifyAgentAuthor(agentMessage('slack'))).toBeNull()
+    // A hardcoded `'slack'` key would have read the wrong index here in both directions.
+    expect((daemon as any).cpCollab.isAgentBotApp('telegram', 'C1', OUR_APP)).toBe(true)
+    expect((daemon as any).cpCollab.isAgentBotApp('slack', 'C1', OUR_APP)).toBe(false)
+    await daemon.stop()
+  })
+})
+
+describe('compound mention addresses are a platform strategy (audit F19, site 5)', () => {
+  it('reports a shared bot’s compound address on Slack and nothing elsewhere', async () => {
+    const daemon = await boot(['bot-a', 'bot-b'], {
+      botShared: true
+    })
+    const addresses = (platform: string): string[] =>
+      (daemon as any).compoundMentionAddresses('bot-a', { platform, channel: 'C1' })
+    expect(addresses('slack').sort()).toEqual(['<@USHARED> bot-a', '<@USHARED> bot-b'])
+    for (const platform of ['telegram', 'discord', 'feishu', 'some-future-platform']) {
+      // Every platform has the same directory row here — only Slack has an address
+      // SHAPE that the splitter could cut, so only Slack reports one.
+      expect(addresses(platform)).toEqual([])
+    }
+    await daemon.stop()
+  })
+
+  it('reports nothing for a dedicated bot, whose mention is already indivisible', async () => {
+    const daemon = await boot(['bot-a', 'bot-b'])
+    expect((daemon as any).compoundMentionAddresses('bot-a', { platform: 'slack', channel: 'C1' })).toEqual([])
+    await daemon.stop()
+  })
+})
+
+describe('verified-target integration lookup follows the message (audit F19, site 6)', () => {
+  it('resolves the target’s integration on the message’s own platform', async () => {
+    // The literal was `resolveCpAgent(targetAgentId, 'slack')`. `bot-b` is installed on
+    // every platform, so a wrong key would still find AN integration — just the wrong
+    // one, keying the activation rendezvous under a transport scope the internal wake
+    // could never compute.
+    const daemon = await boot(['bot-a', 'bot-b'])
+    for (const platform of PLATFORMS.filter((p) => p !== 'slack')) installIntegration(daemon, 'bot-b', platform)
+    for (const platform of PLATFORMS) {
+      expect((daemon as any).resolveCpAgent('bot-b', platform)).toMatchObject({
+        integrationId: `int-bot-b-${platform}`,
+        platform
+      })
+    }
+    await daemon.stop()
+  })
+
+  it('wakes the peer through its Slack integration for a Slack-authored mention', async () => {
+    const daemon = await boot(['bot-a', 'bot-b'])
+    // The peer bridges several platforms; the Slack-authored message must select its
+    // SLACK integration, which is what `msg.platform` (not a literal) delivers.
+    for (const platform of PLATFORMS.filter((p) => p !== 'slack')) installIntegration(daemon, 'bot-b', platform)
+    const calls: { agentId: string; integrationId?: string }[] = []
+    ;(daemon as any).dispatch = vi.fn(async (agentId: string, msg: any, integrationId?: string) => {
+      calls.push({ agentId, integrationId })
+      return 'acp-1'
+    })
+    const outcome = (daemon as any).onInboundOutcome(agentMessage('slack'), ['int-bot-b-slack'])
+    expect(outcome.kind).toBe('dispatched')
+    expect(calls.map((c) => c.agentId)).toEqual(['bot-b'])
+    await daemon.stop()
+  })
+})
+
+describe('response closure is a turn-output surface member (audit F19, site 7)', () => {
+  it('is registered for Slack only, and never inherited by a core-rendered origin', async () => {
+    const daemon = await boot(['bot-a'])
+    const surfaces = (daemon as any).turnSurfaces
+    expect(typeof surfaces.exact('slack')?.closeResponse).toBe('function')
+    for (const platform of ['telegram', 'discord', 'feishu']) {
+      expect(surfaces.exact(platform)?.closeResponse).toBeUndefined()
+    }
+    // webchat / hook / dream render through the CORE surface (which is Slack's) but
+    // must not inherit its closure — `exact` is what enforces that.
+    for (const origin of ['webchat', 'hook', 'dream', 'github', 'some-future-platform']) {
+      expect(surfaces.exact(origin)).toBeUndefined()
+    }
+    await daemon.stop()
+  })
+
+  it('re-stamps the delivered Slack answer as final, with the resolved recipients', async () => {
+    const daemon = await boot(['bot-a', 'bot-b'])
+    const finalizeResponse = vi.fn(async () => true)
+    const turn = {
+      platform: 'slack',
+      agentId: 'bot-a',
+      channel: 'C1',
+      replyText: 'done <@UBOTB>',
+      responseId: 'r-1',
+      sourceHopCount: 1,
+      lastResponse: { ts: '1720000000.000300', text: 'done <@UBOTB>' },
+      conn: { finalizeResponse }
+    }
+    await (daemon as any).turnSurfaces.exact('slack').closeResponse(turn)
+    expect(finalizeResponse).toHaveBeenCalledOnce()
+    const [channel, ts, , , agentId, response] = finalizeResponse.mock.calls[0] as unknown as any[]
+    expect({ channel, ts, agentId }).toEqual({ channel: 'C1', ts: '1720000000.000300', agentId: 'bot-a' })
+    expect(response).toMatchObject({
+      responseId: 'r-1',
+      deliveryState: 'final',
+      hopCount: 1,
+      // Resolved from the COMPLETE reply text against the conversation directory, with
+      // the author removed.
+      mentionedAgentIds: ['bot-b'],
+      addressedAnyone: true
+    })
+    await daemon.stop()
+  })
+
+  it('is a no-op for a turn with no live connection', async () => {
+    const daemon = await boot(['bot-a'])
+    await expect(
+      (daemon as any).turnSurfaces.exact('slack').closeResponse({ platform: 'slack', agentId: 'bot-a', channel: 'C1' })
+    ).resolves.toBeUndefined()
+    await daemon.stop()
+  })
+})

--- a/packages/daemon/test/daemon-source-hygiene.test.ts
+++ b/packages/daemon/test/daemon-source-hygiene.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * integration-plugin-audit.md §10.6 F1 — the NUL trap.
+ *
+ * `daemon.ts` used two RAW NUL characters as separators in a composite key. One NUL
+ * anywhere in a file makes ripgrep classify the WHOLE file as binary: it prints
+ * `binary file matches` and no lines, for every pattern. That silently turned every
+ * `rg`-based sweep over `daemon.ts` into a pass — including the S2 exit criterion's own
+ * "zero platform conditionals in daemon.ts" check, whose entire subject is this file.
+ *
+ * The trap is invisible by construction (the byte does not render), so it is pinned
+ * mechanically rather than left to reviewer attention.
+ */
+
+const SRC = fileURLToPath(new URL('../src', import.meta.url))
+/** U+0000, spelled so this file never contains the byte it is guarding against. */
+const NUL = String.fromCharCode(0)
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry)
+    if (statSync(path).isDirectory()) sourceFiles(path, out)
+    else if (entry.endsWith('.ts')) out.push(path)
+  }
+  return out
+}
+
+describe('daemon source hygiene', () => {
+  it('has no raw NUL byte in any source file, so `rg` reads them all as text', () => {
+    // Exactly ripgrep's binary trigger: a single 0x00 in the buffer. Checking the byte
+    // rather than shelling out to `rg` keeps the guard working on a runner that has no
+    // ripgrep installed, while pinning the same condition.
+    const offenders = sourceFiles(SRC)
+      .map((path) => ({ path, at: readFileSync(path).indexOf(0) }))
+      .filter(({ at }) => at !== -1)
+      .map(({ path, at }) => `${path.slice(SRC.length + 1)} (offset ${at})`)
+    expect(offenders).toEqual([])
+  })
+
+  it('keeps the session-purge grouping key on NUL, written as an escape', () => {
+    // The VALUE must not change: the key groups purge receipts into one CP frame per
+    // (agent, reason, purge time), and NUL is the separator because no component can
+    // contain it. This pins the spelling, so swapping the separator for something a
+    // component COULD contain has to be a deliberate, visible edit. The grouping
+    // behavior itself is pinned by daemon-lifecycle.test.ts ("never reports a session
+    // under another purge time or agent").
+    const source = readFileSync(join(SRC, 'daemon.ts'), 'utf8')
+    expect(source).toContain('const key = `${row.agentId}\\0${row.reason}\\0${row.purgedAt}`')
+    // …and the escape really is U+0000, not a two-character sequence — so the key the
+    // source produces now is character-for-character the key it produced before.
+    expect(`a\0b`).toBe(`a${NUL}b`)
+    expect(`a\0b`).toHaveLength(3)
+  })
+})

--- a/packages/daemon/test/platform-registry-drift.test.ts
+++ b/packages/daemon/test/platform-registry-drift.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { manifestFor } from '@agentconnect.md/protocol'
+import { Daemon } from '../src/daemon.js'
+import { platformIds } from '../src/platforms/integration-config.js'
+import { observedMembershipPlatforms } from '../src/platforms/observed-channels.js'
+
+/**
+ * integration-plugin-audit.md §10.6 F16 / F17 — the two hand-copied platform lists that
+ * sat beside registries already holding the same set.
+ *
+ * F16 is the load-bearing one: `capabilities.platforms` in the CP registration handshake
+ * is what the CP's pre-install gate (`integrationPlatformAvailability`) and the console's
+ * tile gating consume, so a platform the daemon can serve but forgot to advertise is
+ * silently uninstallable. Both lists are now derived; these pin that the derivations stay
+ * tied to the registries, and that adding a platform to one registry and not another
+ * fails here rather than in production.
+ */
+
+function bareRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-platform-drift-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  return root
+}
+
+describe('daemon platform registry (audit F16)', () => {
+  it('advertises exactly the platforms it has a module for', () => {
+    // The pin on today's true set. A fifth platform makes this fail — deliberately: the
+    // reviewer should confirm the CP/console gating is what they intended, not discover
+    // it from a failed install.
+    expect(platformIds()).toEqual(['slack', 'telegram', 'discord', 'feishu'])
+  })
+
+  it('sends the derived list, not a copy, in the CP registration handshake', () => {
+    const daemon = new Daemon({ root: bareRoot() })
+    expect((daemon as any).registrationPlatforms()).toEqual(platformIds())
+  })
+
+  it('agrees with every other platform-keyed registry in the daemon', () => {
+    // The drift half. These four tables are independently written and independently
+    // consulted (config validation, Layer-2 turn output, §7.4 command chrome, §7.5
+    // connection pools); a platform added to one and forgotten in another is a
+    // half-served platform, which is what this catches.
+    const daemon = new Daemon({ root: bareRoot() }) as any
+    const sorted = (ids: string[]): string[] => [...ids].sort()
+
+    expect(sorted(daemon.turnSurfaces.ids())).toEqual(sorted(platformIds()))
+    expect(sorted(daemon.commandChrome.ids())).toEqual(sorted(platformIds()))
+    // Pools are per (platform, MODE) — Slack runs a socket pool beside a send-only
+    // shared one — so the mode suffix is dropped before comparing.
+    const poolPlatforms = [
+      daemon.slackPool,
+      daemon.slackSharedPool,
+      daemon.telegramPool,
+      daemon.discordPool,
+      daemon.feishuPool
+    ].map((pool: { name: string }) => pool.name.split('/')[0])
+    expect(sorted([...new Set(poolPlatforms)])).toEqual(sorted(platformIds()))
+  })
+})
+
+describe('observed-membership platforms (audit F17)', () => {
+  it('is the registry filtered by the manifest, not a hand list', () => {
+    expect([...observedMembershipPlatforms()]).toEqual(['telegram', 'discord', 'feishu'])
+    for (const platform of platformIds()) {
+      expect(observedMembershipPlatforms().includes(platform)).toBe(
+        manifestFor(platform).membershipEnumeration === 'observed'
+      )
+    }
+  })
+
+  it('excludes Slack, whose membership snapshot is authoritative', () => {
+    expect(manifestFor('slack').membershipEnumeration).toBe('authoritative')
+    expect(observedMembershipPlatforms()).not.toContain('slack')
+  })
+
+  it('excludes a platform this build has no module for, despite the fail-closed manifest', () => {
+    // The subtle half. `manifestFor` is TOTAL and its conservative default is
+    // `observed`, so a manifest-only derivation would enumerate every unknown string.
+    // Core can only rebuild a channel list for a platform it has a module for, so the
+    // registry bounds the set and the manifest only filters it.
+    expect(manifestFor('some-future-platform').membershipEnumeration).toBe('observed')
+    expect(observedMembershipPlatforms()).not.toContain('some-future-platform')
+    expect(observedMembershipPlatforms().every((platform) => platformIds().includes(platform))).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes the four `packages/daemon/src/daemon.ts` findings from
[`integration-plugin-audit.md` §10.6](docs/designs/integration-plugin-audit.md):
**F1, F16, F17, F19**. F1 first, because it is why the other three went
unnoticed.

## What

### F1 — two raw NUL bytes made every `rg` sweep over `daemon.ts` a false pass

`daemon.ts:16759` used two literal NUL characters as separators in the
session-purge grouping key. One NUL anywhere in a file makes ripgrep classify
the whole file as binary: it prints `binary file matches` and **no lines**, for
every pattern. So the S2 exit criterion's own check — "zero platform
conditionals in `daemon.ts`" — silently read as a pass, which is exactly how
F16/F17/F19 survived.

Fixed by writing the separators as `\0` escapes. **The key's runtime value is
unchanged** (`\0` in a template literal *is* U+0000), so no producer or consumer
moved; the key is also purely in-memory — a `Map` local to one call of
`drainSessionPurges` — and is never persisted or sent on the wire.

Evidence, at the tip of this branch:

```console
$ grep -rlP '\x00' packages/*/src
                                      # (before: packages/daemon/src/daemon.ts)

$ rg -n "row.reason" packages/daemon/src/daemon.ts
16897:        const key = `${row.agentId}\0${row.reason}\0${row.purgedAt}`
17241:        const reason = WebchatMcpGrantRevoke.shape.reason.safeParse(row.reason)
```

Before this change that same `rg` printed only
`binary file matches (found "\0" byte around offset 841499)` — note line 17241
was invisible too.

### F16 — the CP-registration capability list was a hand copy

`platforms: ['slack','telegram','discord','feishu']` sat beside four in-file
registries that already know the true set, and it is what the CP's pre-install
gate (`integrationPlatformAvailability`) and the console's tile gating consume —
so a platform registered in the daemon but forgotten here is silently
uninstallable.

Now derived from `platformIds()` (new, in `platforms/integration-config.ts`).
That registry is the authority rather than one of the others because **absence
there is total**: `integrationConfig()` returns `undefined` for an unregistered
id and every consumer fails closed on it, so a platform missing from it cannot
be served at all — whereas one missing from the turn-output or command-chrome
registries merely renders through the core fallback. `Object.keys` preserves
insertion order, so the advertised value is byte-identical to the hand list.

### F17 — the observed-platform loop restated a manifest read

`for (const platform of ['telegram','discord','feishu'])` is
`membershipEnumeration === 'observed'`, which the same file already reads via
`manifestFor` elsewhere. Now `observedMembershipPlatforms()` —
**the registry's ids filtered by the manifest**, computed once.

The bound matters: `manifestFor` is total and its fail-closed default *is*
`observed`, so a manifest-only derivation would enumerate every unknown string.
Correct as a per-message capability read, wrong as an enumeration. The registry
supplies the universe; the manifest only filters it.

### F19 — seven Slack-only core branches, site by site

Classified under D2 first. No new manifest field was needed, so nothing in
`packages/protocol` was touched.

| # | site (old line) | classification | disposition |
| - | --------------- | -------------- | ----------- |
| 1 | `5803` `isAgentBotApp('slack', …)` in `isManagedSlackBotIdentity` | literal directory key | method renamed `isManagedAgentBotIdentity` and given a `platform` parameter; the collab snapshot's app-id index is keyed per `(platform, channel)`, so the caller states which index to read |
| 2 | `5807` `msg.platform !== 'slack'` in `isAgentBotMessage` | **D2 → `botSenderRouting`** | reads the shipped §5 manifest field — the same one relay arbitration reads for third-party bots |
| 3 | `5842` `msg.platform !== 'slack'` in `verifyAgentAuthor` | **D2 → `botSenderRouting`** | same gate: a platform that admits no bot senders can produce no verified agent author |
| 4 | `5852` `cpCollab.resolve(orgId, 'slack', …)` | literal directory key | `msg.platform` |
| 5 | `6018` `msg.platform !== 'slack'` in `compoundMentionAddresses` | **§7.4 strategy, not a manifest field** | new `platforms/mention-address.ts`; core passes the conversation's directory and the platform's reader returns the addresses the splitter must not cut. Deliberately *not* a manifest field: the read happens at turn setup, i.e. post-dispatch, which §5 says does not earn one |
| 6 | `6079` `resolveCpAgent(targetAgentId, 'slack')` | literal directory key | `msg.platform` |
| 7 | `13015` `p.platform === 'slack' && p.conn` (collaboration close-response) | **missing host-contract member** | new optional `closeResponse` on `TurnOutputSurface` (`platforms/turn-output.ts`), invoked through `exact(p.platform)`; the body moved verbatim to `closeSlackResponse` |

On #7, `onSettle` was the obvious home and is the wrong one: it is cleanup in
the turn's `finally` and also runs after a failure, while this runs on the
success path only, before post-turn work. Folding them would have moved
observable behavior, so the surface got a second member instead. `exact()`
lookup preserves the old fail-closed shape exactly — webchat / hook / dream
render through the core (Slack) surface but do not inherit its closure, and
telegram / discord / feishu register no `closeResponse`.

**One literal was relocated, not removed.** Parameterizing #1 means its third
caller has to state a platform, and `fetchThreadHistory` has none in scope — it
is Slack-only by the `getThreadReplies` duck-type gate ("Only Slack can pull
thread history"), so it passes `'slack'` itself. That is the §9.2 file-move
class (platform code behind a platform-only entry point), not a core branch, and
it is now recorded as such: §9.2's survivor table listed `isAgentBotMessage` as
its eleventh site, that row is gone, and this one takes its place. The table's
count stays eleven and is honest again. `docs/designs/integration-plugin-audit.md`
§9.2 is the only doc changed.

## Tests

New: `packages/daemon/test/daemon-source-hygiene.test.ts` (2),
`platform-registry-drift.test.ts` (6),
`daemon-platform-authorship.test.ts` (11).

- **F1** — no source file under `packages/daemon/src` contains byte `0x00`
  (ripgrep's exact binary trigger, checked directly so the guard works on a
  runner without ripgrep); plus a pin on the key's spelling, so changing the
  separator has to be a deliberate visible edit. The grouping *behavior* was
  already pinned by `daemon-lifecycle.test.ts` ("never reports a session under
  another purge time or agent"), which still passes unchanged.
- **F16** — the advertised list equals `platformIds()`, and `platformIds()`
  agrees with the turn-output registry, the command-chrome registry and the
  connection pools. Adding a platform to one registry and not another now fails
  here. (`ids()` was added to the two registries for this.)
- **F17** — the observed set equals the manifest's verdict for every registered
  platform, excludes Slack, and **excludes a platform this build has no module
  for** even though `manifestFor` answers `observed` for it.
- **F19** — per-site pins on all four platforms plus an unknown id:
  - both authorship gates admit exactly where `manifestFor(p).botSenderRouting`
    is true, asserted against the manifest *and* against `p === 'slack'`;
  - **a third-party bot on Slack is still dropped** — with a foreign app id and
    with no app id at all. This is the regression a careless generalization
    would introduce, so it is pinned explicitly;
  - the app-identity and placement indexes are read under the *message's*
    platform: a snapshot that knows the app on Telegram only does not vouch for
    a Slack message, which a hardcoded key would have got wrong both ways;
  - compound addresses appear for a shared Slack bot and for nothing else,
    given the identical directory row on every platform;
  - the verified target's integration resolves per platform for a peer bridging
    all four, and a Slack-authored mention still wakes it through Slack;
  - `closeResponse` is registered for Slack only, is not reachable for
    webchat / hook / dream / github / an unknown id, and re-stamps the delivered
    answer `final` with the recipients resolved from the complete reply.

Commands:

```
pnpm --filter @agentconnect.md/daemon exec tsc -p tsconfig.json --noEmit   # clean
pnpm --filter @agentconnect.md/daemon test
#   Test Files  178 passed | 6 skipped (184)
#        Tests  2995 passed | 51 skipped (3046)
```

`pnpm lint` and `prettier --check` clean on everything touched.

Note on a known flake: `daemon-agent-mention-routing.test.ts` timed out once
under full-suite load on an earlier run of this branch and passed standalone
(33/33); it passed in the full run reported above. Not touched by this PR.

## Behavior

Nothing observable moved. Every replaced branch admits exactly the same set
today — only Slack has `botSenderRouting: true`, only Slack is
`membershipEnumeration: 'authoritative'`, only Slack registers a
compound-address reader and a `closeResponse` — and every fail-closed default
stays fail-closed: an unknown platform gets `DEFAULT_MANIFEST`, is absent from
the registries, and therefore cannot take a Slack-shaped path in any of the
seven places.

Two derivations are strictly registry-bounded rather than manifest-only for
that reason (F17 and the compound-address reader), since `manifestFor`'s
conservative default would otherwise enumerate unknown ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
