### PR TITLE
docs: close out the audit — §6.4 errata, the relay/CP contract rows, and the finding dispositions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,12 +65,12 @@ Each host keeps its own per-platform directory plus a static `registry.ts` —
 `components/`). The shared, pre-dispatch capability table is
 `packages/protocol/src/platform-manifest.ts` (§5).
 
-| Host          | Contract                                                         | What a module owns                                                                                                                              |
-| ------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| daemon        | three-facet adapter (connect/ingress/read port + turn output)    | connection, normalization hand-off, renderers, strategy functions                                                                               |
-| relay         | `platforms/contract.ts` — `RelayPlatformIngressPlugin`           | `buildIngest` per bot, demux hints, `verify` → `handle`, optional `egress` facet                                                                |
-| control plane | `platforms/provider.ts` — `CpPlatformProvider`                   | install routes at two mount scopes, credential schema + live validation, create tail, reapers, background loops, env keys, both wire projectors |
-| web           | `components/console/platforms/contract.ts` — `WebPlatformModule` | wizard body, settings fragments, `Mark`, api bindings, channel semantics, text renderer                                                         |
+| Host          | Contract                                                         | What a module owns                                                                                                                                                                                                                   |
+| ------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| daemon        | three-facet adapter (connect/ingress/read port + turn output)    | connection, normalization hand-off, renderers, strategy functions                                                                                                                                                                    |
+| relay         | `platforms/contract.ts` — `RelayPlatformIngressPlugin`           | `buildIngest` per bot, `installRoutes`, demux hints, `verify` → `handle`, optional `egress` facet                                                                                                                                    |
+| control plane | `platforms/provider.ts` — `CpPlatformProvider`                   | install routes at two mount scopes, credential schema + live validation, create tail, identity projection, reapers, background loops, env keys, the spec projector (bot-assign projector is optional — relay-ingress platforms only) |
+| web           | `components/console/platforms/contract.ts` — `WebPlatformModule` | wizard body, settings fragments, `Mark`, api bindings, channel semantics, text renderer                                                                                                                                              |
 
 **GitHub and GitLab are deliberately NOT platform modules.** They have no chat
 ingress, so they stay on the webhook / code-host seam (`relay/src/hooks/`,

--- a/docs/designs/integration-plugin-architecture.md
+++ b/docs/designs/integration-plugin-architecture.md
@@ -333,17 +333,35 @@ and threads the raw platform string through session keying.
 interface IntegrationSpec {
   integrationId: string
   agentId: string
-  platformId: string
+  platform: string // open; `platformId` in an earlier draft of this section
   core: { bindRules; allowedUserIds; mutedChannels; gated; mode } // owned & read by core
-  config: unknown // opaque on the wire; validated by the platform module on the daemon
+  config?: unknown // opaque on the wire; validated by the platform module on the daemon
 }
 ```
 
-A legacy-emission shim (same pattern as the existing `codec.ts` down-level
-encodings) keeps old daemons receiving the nested per-platform shape until
-the fleet gate passes. The daemon-side agent-config schema
-(`agents/agent-schema.ts`) and the protocol `AgentSpec` union migrate
-together — they are the same closed union in two places today.
+The daemon-side agent-config schema (`agents/agent-schema.ts`) migrates with
+it — the same closed union lived in two places.
+
+**As shipped (#634), with three corrections to the sketch above.** The field
+is `platform`, not `platformId`: the wire spells this axis `platform`
+everywhere else, and renaming it here would have bought a second name for one
+concept. `core` is **required** and a core-less spec fails the frame — by the
+time this landed, an absent envelope could only come from a stale writer, and
+defaulting it would silently mint a rule-less integration. `config` is
+optional and is validated by the **reader**, not the frame: a spec whose
+config is missing or malformed is skipped with a warning rather than failing
+the whole `register/ok` snapshot it rides in. On the daemon side the migrated
+schema is `IntegrationSchema` in `agents/agent-schema.ts`; the protocol's
+`AgentSpec` is a different object and was not the union in question.
+
+**The legacy-emission shim was never built and is no longer reachable.** This
+section originally paired the flatten with a down-level encoding (the
+`codec.ts` pattern) so old daemons would keep receiving the nested
+per-platform shape until a fleet gate passed. That staging was overtaken: the
+deployment is pre-release with a self-controlled fleet, so #634 shipped a
+single-release cutover instead — a new CP skips specs an old daemon cannot
+read, and an old CP fails the handshake against a new daemon. See that PR's
+compatibility notes for the enumerated at-rest cases.
 
 ### 6.5 `NormalizedMessage`: generic thread coordinates + adapter extension
 

--- a/docs/designs/integration-plugin-audit.md
+++ b/docs/designs/integration-plugin-audit.md
@@ -1762,6 +1762,13 @@ authority the contract's D2 note exists to prevent. The remaining literals in
 the file are the initial-platform default (`:196`) and the closed `BotPlatform`
 type the registry-derived list is cast into (`:92` — F15).
 
+> **Post-reconciliation note.** The nine surviving set enumerations behind the
+> "with exceptions" verdicts were closed by the four follow-up PRs listed in
+> §10.6, so the exceptions those verdicts name no longer hold as written. The
+> verdicts themselves are left at the pinned SHA rather than restated: re-earning
+> "met" is a claim about a tree nobody has re-swept, and this section's value is
+> that every sentence in it was verified once, at one commit.
+
 ### 10.2 Survivor table — all six packages
 
 Classes: **(i)** legitimate per-platform module code; **(ii)** documented host
@@ -1994,8 +2001,32 @@ equal by `platform-set.test.tsx`).
 
 ### 10.6 Findings
 
-Code defects and unearned survivors. **None of these were fixed** — this is a
-docs-only reconciliation.
+Code defects and unearned survivors. **None of these were fixed in this
+reconciliation** — it is docs-only. Each finding is left below exactly as it
+was written at the pinned SHA, so the disposition can be checked against the
+claim it answers.
+
+> **Disposition — all nineteen closed, 2026-08-05.** Four follow-up PRs, split
+> by file boundary so they could run in parallel: **#643** relay (F2–F7),
+> **#644** control plane (F8–F13), **#645** web (F14, F15, F18), **#646**
+> daemon (F1, F16, F17, F19). Three of them earned a new contract member rather
+> than a rewiring, each landing with the branch it retires per §5.2:
+> `RelayPlatformIngressPlugin.installRoutes` (F5 — the route surface already had
+> two implementers with an identical dep shape, so it was an unnamed seam, not a
+> missing one), the §5 manifest field `leaveGranularity` (F12 — a genuine
+> pre-dispatch read: the CP validates a leave request's shape before an owner
+> resolves), and `CpPlatformProvider.projectBotIdentity` (F13 — the D6 identity
+> dual-write, with Telegram's **absence** of the member as its declaration).
+> Two dispositions differ from the suggestion recorded here: F16 derives the
+> capability list from the config-schema registry rather than "the daemon's
+> platform registries" generally, because absence there is _total_ (an
+> unregistered id cannot be served at all) while absence from the turn-output
+> registry only falls back to the core surface; and F19's compound-mention site
+> became a §7.4 strategy rather than a manifest read, since that read happens at
+> turn setup and is therefore post-dispatch. F11 was decided in the widening
+> direction — waitlist intake now tracks the registry, so `POST /waitlist`
+> accepts `feishu`. F1's fix surfaced a line in `daemon.ts` that no `rg`-based
+> sweep had ever been able to see.
 
 1. **`packages/daemon/src/daemon.ts:16759` — literal NUL bytes make `rg` suppress
    every match in the file.** Two raw NUL characters are used as separators in a


### PR DESCRIPTION
## What

Documentation-only. Three gaps left by the S3 closeout, all the same kind: prose a reader would act on that the code has since contradicted.

**§6.4 `IntegrationSpec` — three errata against what #634 shipped.**
- The field is `platform`, not `platformId`. The wire spells this axis `platform` everywhere else; renaming it here would have bought a second name for one concept.
- `core` is **required** — a core-less spec fails the frame. By the time the flatten landed, an absent envelope could only come from a stale writer, and defaulting it would silently mint a rule-less integration. `config` is optional and validated by the **reader**, so one malformed spec is skipped with a warning instead of failing the whole `register/ok` snapshot it rides in.
- The daemon-side schema that migrated with it is `IntegrationSchema` (`agents/agent-schema.ts`). The protocol's `AgentSpec` is a different object and was never the union in question.

**§6.4 — the legacy-emission shim was never built and is now unreachable.** The section promised a `codec.ts`-style down-level encoding so old daemons would keep receiving the nested shape until a fleet gate passed. That staging was overtaken: the deployment is pre-release with a self-controlled fleet, so #634 shipped a single-release cutover (new CP skips specs an old daemon cannot read; an old CP fails the handshake against a new daemon), with the at-rest cases enumerated in that PR.

**CLAUDE.md contract table.** The relay row gains `installRoutes` (added in #643). The CP row gains the identity projector (#644) and states that the bot-assign projector is **optional** by design — a reader following that row would otherwise implement a member relay-less platforms do not have.

**Audit §10.6 — disposition block.** All nineteen findings closed across #643 (relay F2–F7), #644 (CP F8–F13), #645 (web F14/F15/F18), #646 (daemon F1/F16/F17/F19). The block calls out the three that earned a **new contract member** rather than a rewiring — `installRoutes`, the §5 manifest field `leaveGranularity`, and `CpPlatformProvider.projectBotIdentity` — and the two whose disposition deliberately differs from the suggestion recorded in the finding (F16's registry choice; F19's compound-mention site becoming a §7.4 strategy because that read is post-dispatch).

The findings are left **verbatim at the pinned SHA** so each disposition can be checked against the claim it answers, and §10.1's verdicts are annotated rather than restated — re-earning "met" would be a claim about a tree nobody has re-swept, and the section's value is that every sentence in it was verified once, at one commit.

## Tests

None — documentation only. Every corrected claim was read out of the merged code (`packages/protocol/src/frames/integration.ts`, `packages/daemon/src/agents/agent-schema.ts`, the four contract files named in the table), not recalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)