### PR TITLE
feat(dream): automatic session window + skip when nothing new since the last dream

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -211,9 +211,16 @@ interface DreamRecord {
 
 1. **Snapshot.** Copy `<agent-root>/memory/` (excluding `.history`) into
    `memory-dreams/<dreamId>/input/`; record `snapshotDigest`.
-2. **Gather signal.** Pull the last `sessionWindow` sessions' transcripts for
-   this agent from the daemon store. Every session the agent itself participated
-   in is mined — channel, DM, webchat, external (GitHub), A2A, and launched alike;
+2. **Gather signal.** Pull the relevant sessions' transcripts for this agent from
+   the daemon store. The window is sized **automatically** (no operator config):
+   the sessions with activity since the last successful dream — each one's
+   `updatedAt` is newer than that dream's start — capped at 100; the first dream
+   (no baseline) takes the current corpus up to the cap. A scheduled tick with no
+   such session is skipped (nothing new to consolidate). An explicit
+   `sessionWindow` (a per-run manual override, or a legacy configured policy
+   value) instead pins a fixed newest-N window. Every session the agent itself
+   participated in is eligible — channel, DM, webchat, external (GitHub), A2A, and
+   launched alike;
    the per-turn capture-visibility gate is deliberately **not** applied here (see
    session-visibility.md §5.1 dream-path carve-out). Peer isolation stays with the
    source: sourcing is `agentId`-scoped and each transcript returns only the rows

--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -137,7 +137,8 @@ managed-only constraint structural:
 export const MemoryDreamingPolicy = z
   .object({
     enabled: z.boolean(),
-    /** How many recent sessions to mine (default 20, max 100). */
+    /** Optional override pinning a fixed newest-N session window (max 100). When
+     *  absent (the norm), the window is sized automatically — see "Gather signal". */
     sessionWindow: z.number().int().min(1).max(100).optional(),
     /** Optional cron for scheduled dreams (same syntax as agent crons). */
     schedule: z.string().min(1).max(128).optional(),
@@ -214,11 +215,15 @@ interface DreamRecord {
 2. **Gather signal.** Pull the relevant sessions' transcripts for this agent from
    the daemon store. The window is sized **automatically** (no operator config):
    the sessions with activity since the last successful dream — each one's
-   `updatedAt` is newer than that dream's start — capped at 100; the first dream
-   (no baseline) takes the current corpus up to the cap. A scheduled tick with no
-   such session is skipped (nothing new to consolidate). An explicit
-   `sessionWindow` (a per-run manual override, or a legacy configured policy
-   value) instead pins a fixed newest-N window. Every session the agent itself
+   `updatedAt` is at or after that dream's baseline — capped at 100; the first dream
+   (no baseline) takes the current corpus up to the cap. The baseline is stamped
+   **before** the source query and the comparison is inclusive (`>=`), so at
+   millisecond resolution a session written in the same millisecond as the
+   baseline is re-mined once rather than silently dropped: the invariant is
+   "duplicates possible, gaps never". A scheduled tick with no such session is
+   skipped (nothing new to consolidate). An explicit `sessionWindow` (a per-run
+   manual override, or a legacy configured policy value) instead pins a fixed
+   newest-N window. Every session the agent itself
    participated in is eligible — channel, DM, webchat, external (GitHub), A2A, and
    launched alike;
    the per-turn capture-visibility gate is deliberately **not** applied here (see

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -341,12 +341,13 @@ export class DreamRunner {
    * last SUCCESSFUL dream (completed or adopted) did not consolidate. Scheduled
    * dreams consult this to skip re-dreaming an unchanged corpus — running a fresh
    * host + burning model tokens to re-derive the same proposal is pure waste.
-   * Returns true when the agent has never completed a dream (so the first
-   * scheduled run always proceeds). Manual dreams never call this: an explicit
-   * request always runs.
+   * When the agent has never completed a dream there is no baseline, so any
+   * session at all makes this true; an agent with no sessions yet has nothing to
+   * consolidate and skips even its first scheduled run. Manual dreams never call
+   * this: an explicit request always runs.
    *
    * "New" is by activity, not just session identity: a session counts when its
-   * `updatedAt` is newer than the last successful dream's baseline — so a
+   * `updatedAt` is at or after the last successful dream's baseline — so a
    * brand-new session AND fresh messages in an already-mined session both
    * re-trigger (new messages bump `updatedAt`). This mirrors the automatic window
    * in {@link selectSessionSources}: true iff that selection is non-empty.
@@ -366,11 +367,20 @@ export class DreamRunner {
   /**
    * The sessions a dream should mine, chosen AUTOMATICALLY — no operator config.
    * Default: every session with activity since the last successful dream (its
-   * `updatedAt` is newer than that dream's start), capped at
+   * `updatedAt` is at or after that dream's baseline), capped at
    * {@link MAX_AUTO_SESSION_WINDOW}. The first dream (no baseline) mines the
    * current corpus up to the cap. An explicit `sessionWindow` (a per-run manual
    * override, or a legacy configured policy value) still pins a fixed newest-N
    * window instead.
+   *
+   * The comparison is inclusive (`>=`) on purpose. Both the baseline and
+   * `updatedAt` have millisecond resolution, so a session written just after the
+   * source query but in the same millisecond as the baseline has
+   * `updatedAt === cutoff`; a strict `>` would drop it from this dream (query
+   * already ran) and every later one — a permanent gap. `>=` instead re-mines the
+   * boundary sessions once (a harmless duplicate the pipeline already tolerates)
+   * and self-heals: the next dream's baseline moves past them. The invariant is
+   * "duplicates possible, gaps never".
    *
    * The cap is an intentional bound, not a paging cursor: it takes the newest N
    * active sessions by `updatedAt`. If more than N sessions changed since the last
@@ -390,7 +400,7 @@ export class DreamRunner {
     if (!lastSuccessful) return recent
     const cutoff = Date.parse(lastSuccessful.createdAt)
     if (!Number.isFinite(cutoff)) return recent
-    return recent.filter((s) => s.updatedAt > cutoff)
+    return recent.filter((s) => s.updatedAt >= cutoff)
   }
 
   async start(

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -337,16 +337,19 @@ export class DreamRunner {
    *  is already in flight. Returns immediately with the `pending` record; the
    *  pipeline runs asynchronously (poll via get/list, as the console does). */
   /**
-   * Whether a scheduled dream would mine at least one session the last
-   * SUCCESSFUL dream (completed or adopted) did not. Scheduled dreams consult
-   * this to skip re-dreaming an unchanged corpus — running a fresh host + burning
-   * model tokens to re-derive the same proposal is pure waste. Returns true when
-   * the agent has never completed a dream (so the first scheduled run always
-   * proceeds). Manual dreams never call this: an explicit request always runs.
+   * Whether a scheduled dream would mine at least one session with activity the
+   * last SUCCESSFUL dream (completed or adopted) did not consolidate. Scheduled
+   * dreams consult this to skip re-dreaming an unchanged corpus — running a fresh
+   * host + burning model tokens to re-derive the same proposal is pure waste.
+   * Returns true when the agent has never completed a dream (so the first
+   * scheduled run always proceeds). Manual dreams never call this: an explicit
+   * request always runs.
    *
-   * "New" is by session id: a brand-new session the last dream never saw. New
-   * *messages* inside an already-mined session don't re-trigger — the last dream
-   * already consolidated that session's thread — which matches "no new sessions".
+   * "New" is by activity, not just session identity: a session counts when its
+   * `updatedAt` is newer than the last successful dream's baseline — so a
+   * brand-new session AND fresh messages in an already-mined session both
+   * re-trigger (new messages bump `updatedAt`). This mirrors the automatic window
+   * in {@link selectSessionSources}: true iff that selection is non-empty.
    */
   hasNewSessionsSinceLastDream(agentId: string): boolean {
     return this.selectSessionSources(agentId).length > 0
@@ -368,6 +371,14 @@ export class DreamRunner {
    * current corpus up to the cap. An explicit `sessionWindow` (a per-run manual
    * override, or a legacy configured policy value) still pins a fixed newest-N
    * window instead.
+   *
+   * The cap is an intentional bound, not a paging cursor: it takes the newest N
+   * active sessions by `updatedAt`. If more than N sessions changed since the last
+   * dream (a large backlog in one interval), the oldest of that changed set are
+   * not consolidated in this run, and because the baseline advances they are not
+   * revisited later either. N=100 is a deliberately large corpus; consolidating an
+   * unbounded backlog in a single host/prompt is the worse failure. Scheduled
+   * dreams run often enough that this bound is not normally reached.
    */
   private selectSessionSources(
     agentId: string,
@@ -409,6 +420,17 @@ export class DreamRunner {
       // AUTOMATICALLY (sessions active since the last successful dream, capped).
       const explicitWindow = opts.sessionWindow ?? policy.sessionWindow
       const instructions = opts.instructions ?? policy.instructions
+      // Capture this dream's baseline watermark BEFORE selecting sources. This
+      // timestamp becomes the dream's `createdAt`, which the NEXT automatic dream
+      // uses as its cutoff (`updatedAt > cutoff`). If it were stamped after the
+      // source query instead, a session whose `updatedAt` fell between the query
+      // and the stamp would be in neither this dream (query already ran) nor any
+      // future one (its `updatedAt` < the new baseline) — a permanent drop. Taken
+      // first, the baseline is <= the query time, so the worst case is a thin band
+      // of sessions mined twice (safe), never a gap. better-sqlite3 is synchronous
+      // and single-threaded, so no session write can interleave between here and
+      // the query below.
+      const createdAt = this.nowIso()
       // A dream distills EVERY session this agent participated in — channel, DM,
       // webchat, external (GitHub), A2A, or launched alike. We deliberately do NOT
       // apply the per-turn capture-visibility gate here: an agent's own transcript
@@ -439,7 +461,7 @@ export class DreamRunner {
         snapshotDigest: storeDigest(files),
         snapshotWrites: writes,
         ...(instructions ? { instructions } : {}),
-        createdAt: this.nowIso()
+        createdAt
       }
       this.deps.store.insertDream(dream)
       this.emitLifecycle({ type: 'memory.dream.started', dream })

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -119,7 +119,7 @@ export interface DreamStorePort {
   dreamSessionSources(
     agentId: string,
     limit: number
-  ): { sessionId: string; channel: string; thread: string; transportScope?: string | null }[]
+  ): { sessionId: string; channel: string; thread: string; transportScope?: string | null; updatedAt: number }[]
   /** Chronological text rows of one session thread, scoped to the agent. */
   dreamTranscriptText(
     channel: string,
@@ -198,13 +198,15 @@ export interface DreamRunnerDeps {
   onStaged?(agentId: string, dreamId: string): void | Promise<void>
 }
 
-const DEFAULT_SESSION_WINDOW = 20
 const TRANSCRIPT_ROWS_PER_SESSION = 200
-// How far back to scan an agent's dreams for the last SUCCESSFUL one when
-// deciding whether a scheduled dream has new sessions to mine. Generous enough
-// that a run of failed dreams after a success never hides the baseline; if it is
-// somehow exceeded the check fails open (the scheduled dream runs).
+// How far back to scan an agent's dreams for the last SUCCESSFUL one when sizing
+// the automatic session window. Generous enough that a run of failed dreams
+// after a success never hides the baseline.
 const LAST_SUCCESSFUL_DREAM_SCAN = 50
+// Safety cap on the automatic window: the dream self-sizes to "sessions with
+// activity since the last successful dream" (no operator config), but a first
+// dream — or a long-idle agent — must not mine an unbounded corpus.
+const MAX_AUTO_SESSION_WINDOW = 100
 const DREAMS_DIRNAME = 'memory-dreams'
 const BACKUPS_DIRNAME = 'memory-backups'
 /** Staged file names are the validator's own outputs; anything else is a violation. */
@@ -347,14 +349,37 @@ export class DreamRunner {
    * already consolidated that session's thread — which matches "no new sessions".
    */
   hasNewSessionsSinceLastDream(agentId: string): boolean {
-    const sessionWindow = this.deps.dreamingPolicyFor(agentId)?.sessionWindow ?? DEFAULT_SESSION_WINDOW
-    const currentIds = this.deps.store.dreamSessionSources(agentId, sessionWindow).map((s) => s.sessionId)
-    const lastSuccessful = this.deps.store
+    return this.selectSessionSources(agentId).length > 0
+  }
+
+  /** The most recent dream that successfully mined its sessions (completed or
+   *  adopted) — the baseline the automatic window measures "new activity" from. */
+  private lastSuccessfulDream(agentId: string): DreamInfo | undefined {
+    return this.deps.store
       .listDreams(agentId, LAST_SUCCESSFUL_DREAM_SCAN)
       .find((d) => d.status === 'completed' || d.status === 'adopted')
-    if (!lastSuccessful) return true
-    const mined = new Set(lastSuccessful.sessionIds)
-    return currentIds.some((id) => !mined.has(id))
+  }
+
+  /**
+   * The sessions a dream should mine, chosen AUTOMATICALLY — no operator config.
+   * Default: every session with activity since the last successful dream (its
+   * `updatedAt` is newer than that dream's start), capped at
+   * {@link MAX_AUTO_SESSION_WINDOW}. The first dream (no baseline) mines the
+   * current corpus up to the cap. An explicit `sessionWindow` (a per-run manual
+   * override, or a legacy configured policy value) still pins a fixed newest-N
+   * window instead.
+   */
+  private selectSessionSources(
+    agentId: string,
+    explicitWindow?: number
+  ): { sessionId: string; channel: string; thread: string; transportScope?: string | null; updatedAt: number }[] {
+    if (explicitWindow !== undefined) return this.deps.store.dreamSessionSources(agentId, explicitWindow)
+    const recent = this.deps.store.dreamSessionSources(agentId, MAX_AUTO_SESSION_WINDOW)
+    const lastSuccessful = this.lastSuccessfulDream(agentId)
+    if (!lastSuccessful) return recent
+    const cutoff = Date.parse(lastSuccessful.createdAt)
+    if (!Number.isFinite(cutoff)) return recent
+    return recent.filter((s) => s.updatedAt > cutoff)
   }
 
   async start(
@@ -379,7 +404,10 @@ export class DreamRunner {
       if (this.active.has(agentId)) {
         throw new DreamStateError('a dream is already in flight for this agent')
       }
-      const sessionWindow = opts.sessionWindow ?? policy.sessionWindow ?? DEFAULT_SESSION_WINDOW
+      // An explicit sessionWindow (per-run manual override, or a legacy configured
+      // policy value) pins a fixed newest-N window; otherwise the window is chosen
+      // AUTOMATICALLY (sessions active since the last successful dream, capped).
+      const explicitWindow = opts.sessionWindow ?? policy.sessionWindow
       const instructions = opts.instructions ?? policy.instructions
       // A dream distills EVERY session this agent participated in — channel, DM,
       // webchat, external (GitHub), A2A, or launched alike. We deliberately do NOT
@@ -392,7 +420,7 @@ export class DreamRunner {
       // now handled by the dream policy prompt: it must not surface a person's
       // private/personal conversation as shared organization knowledge
       // (session-visibility.md §5.1, #36 follow-up).
-      const sources = this.deps.store.dreamSessionSources(agentId, sessionWindow)
+      const sources = this.selectSessionSources(agentId, explicitWindow)
 
       // Snapshot the live store — the digest is the adoption fence. Taken under
       // the shared memory-dir lock so it cannot tear against a concurrent

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -200,6 +200,11 @@ export interface DreamRunnerDeps {
 
 const DEFAULT_SESSION_WINDOW = 20
 const TRANSCRIPT_ROWS_PER_SESSION = 200
+// How far back to scan an agent's dreams for the last SUCCESSFUL one when
+// deciding whether a scheduled dream has new sessions to mine. Generous enough
+// that a run of failed dreams after a success never hides the baseline; if it is
+// somehow exceeded the check fails open (the scheduled dream runs).
+const LAST_SUCCESSFUL_DREAM_SCAN = 50
 const DREAMS_DIRNAME = 'memory-dreams'
 const BACKUPS_DIRNAME = 'memory-backups'
 /** Staged file names are the validator's own outputs; anything else is a violation. */
@@ -329,6 +334,29 @@ export class DreamRunner {
   /** Start a dream. Rejects when dreaming is not enabled for the agent or one
    *  is already in flight. Returns immediately with the `pending` record; the
    *  pipeline runs asynchronously (poll via get/list, as the console does). */
+  /**
+   * Whether a scheduled dream would mine at least one session the last
+   * SUCCESSFUL dream (completed or adopted) did not. Scheduled dreams consult
+   * this to skip re-dreaming an unchanged corpus — running a fresh host + burning
+   * model tokens to re-derive the same proposal is pure waste. Returns true when
+   * the agent has never completed a dream (so the first scheduled run always
+   * proceeds). Manual dreams never call this: an explicit request always runs.
+   *
+   * "New" is by session id: a brand-new session the last dream never saw. New
+   * *messages* inside an already-mined session don't re-trigger — the last dream
+   * already consolidated that session's thread — which matches "no new sessions".
+   */
+  hasNewSessionsSinceLastDream(agentId: string): boolean {
+    const sessionWindow = this.deps.dreamingPolicyFor(agentId)?.sessionWindow ?? DEFAULT_SESSION_WINDOW
+    const currentIds = this.deps.store.dreamSessionSources(agentId, sessionWindow).map((s) => s.sessionId)
+    const lastSuccessful = this.deps.store
+      .listDreams(agentId, LAST_SUCCESSFUL_DREAM_SCAN)
+      .find((d) => d.status === 'completed' || d.status === 'adopted')
+    if (!lastSuccessful) return true
+    const mined = new Set(lastSuccessful.sessionIds)
+    return currentIds.some((id) => !mined.has(id))
+  }
+
   async start(
     agentId: string,
     opts: { trigger: DreamTrigger; sessionWindow?: number; instructions?: string }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -18729,6 +18729,13 @@ export class Daemon {
       this.log.info(`scheduled dream skipped for agent "${agentId}": ${DREAM_MODEL_READABLE_CREDENTIALS_REASON}`)
       return
     }
+    // Nothing to consolidate if no new session has appeared since the last
+    // successful dream — re-dreaming an unchanged corpus just burns a host + model
+    // tokens to re-derive the same proposal. A manual dream bypasses this.
+    if (!this.dreamRunner().hasNewSessionsSinceLastDream(agentId)) {
+      this.log.info(`scheduled dream skipped for agent "${agentId}": no new sessions since the last dream`)
+      return
+    }
     void this.dreamRunner()
       .start(agentId, { trigger: 'schedule' })
       .then((dream) => this.log.info(`dream ${dream.dreamId} started on schedule for agent "${agentId}"`))

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -18729,11 +18729,11 @@ export class Daemon {
       this.log.info(`scheduled dream skipped for agent "${agentId}": ${DREAM_MODEL_READABLE_CREDENTIALS_REASON}`)
       return
     }
-    // Nothing to consolidate if no new session has appeared since the last
+    // Nothing to consolidate if no session has had activity since the last
     // successful dream — re-dreaming an unchanged corpus just burns a host + model
     // tokens to re-derive the same proposal. A manual dream bypasses this.
     if (!this.dreamRunner().hasNewSessionsSinceLastDream(agentId)) {
-      this.log.info(`scheduled dream skipped for agent "${agentId}": no new sessions since the last dream`)
+      this.log.info(`scheduled dream skipped for agent "${agentId}": no session activity since the last dream`)
       return
     }
     void this.dreamRunner()

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2736,10 +2736,10 @@ export class LocalStore {
   dreamSessionSources(
     agentId: string,
     limit: number
-  ): { sessionId: string; channel: string; thread: string; transportScope?: string | null }[] {
+  ): { sessionId: string; channel: string; thread: string; transportScope?: string | null; updatedAt: number }[] {
     const rows = this.db
       .prepare(
-        `SELECT acpSessionId AS sessionId, channel, thread, transportScope FROM sessions
+        `SELECT acpSessionId AS sessionId, channel, thread, transportScope, updatedAt FROM sessions
          WHERE agentId = ? AND acpSessionId IS NOT NULL AND platform <> 'dream'
          ORDER BY updatedAt DESC LIMIT ?`
       )
@@ -2748,6 +2748,7 @@ export class LocalStore {
       channel: string
       thread: string
       transportScope: string | null
+      updatedAt: number
     }[]
     return rows.map(({ transportScope, ...row }) => (transportScope ? { ...row, transportScope } : row))
   }

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -169,6 +169,13 @@ describe('DreamRunner pipeline', () => {
     store.insertDream(dream('completed', ['sess-1'], 'd1'))
     expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(false)
 
+    // Millisecond boundary: a session whose updatedAt EQUALS the baseline (e.g.
+    // written in the same ms as the dream's createdAt, after the source query)
+    // counts as new. The comparison is inclusive (>=) so this is re-mined once
+    // rather than dropped forever — "duplicates possible, gaps never".
+    store.sources = [{ sessionId: 'sess-1', channel: 'C1', thread: 'T1', updatedAt: cutoff }]
+    expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(true)
+
     // A session with activity AFTER the last dream → run.
     store.sources = [
       { sessionId: 'sess-2', channel: 'C2', thread: 'T2', updatedAt: cutoff + 1000 },

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -103,6 +103,7 @@ async function setup(opts: {
   onOrganizationSuggestions?: () => void | Promise<void>
   withSkillAcceptance?: (agentId: string, publish: () => Promise<void>) => Promise<void>
   operationPolicy?: NonNullable<ConstructorParameters<typeof DreamRunner>[0]['operationPolicy']>
+  now?: () => Date
 }) {
   const dir = await mkdtemp(join(tmpdir(), 'ac-dream-'))
   ensureMemory(dir, 'bot')
@@ -124,6 +125,7 @@ async function setup(opts: {
     ...(opts.onOrganizationSuggestions ? { onOrganizationSuggestions: opts.onOrganizationSuggestions } : {}),
     ...(opts.withSkillAcceptance ? { withSkillAcceptance: opts.withSkillAcceptance } : {}),
     ...(opts.cancelGraceMs !== undefined ? { cancelGraceMs: opts.cancelGraceMs } : {}),
+    ...(opts.now ? { now: opts.now } : {}),
     log: silent
   })
   return { dir, store, runner, prompts }
@@ -179,6 +181,27 @@ describe('DreamRunner pipeline', () => {
     store.insertDream(dream('failed', ['sess-1', 'sess-2'], 'd2'))
     store.sources = [{ sessionId: 'sess-1', channel: 'C1', thread: 'T1', updatedAt: cutoff - 5000 }]
     expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(true)
+  })
+
+  it('stamps the dream baseline before selecting sources (no cutoff-race drop)', async () => {
+    // Regression: the dream's createdAt is the cutoff the NEXT automatic dream
+    // filters on (updatedAt > cutoff). If it were stamped AFTER the source query,
+    // a session that became active between the query and the stamp would be in
+    // neither this dream (query already ran) nor any future one (its updatedAt <
+    // the new baseline) — a permanent drop. Capturing it first keeps the baseline
+    // <= the query time, so such a session is still selectable next time.
+    let clock = 1_000
+    let queriedAt: number | undefined
+    const { store, runner } = await setup({ now: () => new Date(clock++) })
+    const realQuery = store.dreamSessionSources.bind(store)
+    store.dreamSessionSources = ((agentId: string, limit: number) => {
+      queriedAt = clock // the monotonic clock value at the moment sources are read
+      return realQuery(agentId, limit)
+    }) as typeof store.dreamSessionSources
+
+    const started = await runner.start('a1', { trigger: 'schedule' })
+    expect(queriedAt).toBeDefined()
+    expect(Date.parse(started.createdAt)).toBeLessThan(queriedAt!)
   })
 
   it('stages a validated proposal without touching the live store', async () => {

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -34,7 +34,10 @@ const silent = { info() {}, warn() {} }
 
 class FakeStore implements DreamStorePort {
   dreams = new Map<string, DreamInfo>()
-  sources: { sessionId: string; channel: string; thread: string }[] = [
+  // `updatedAt` is optional in fixtures; dreamSessionSources defaults it to "now"
+  // so a source without an explicit time reads as recent (newer than any dream
+  // created earlier in a test). Auto-window tests set it explicitly.
+  sources: { sessionId: string; channel: string; thread: string; updatedAt?: number }[] = [
     { sessionId: 'sess-1', channel: 'C1', thread: 'T1' }
   ]
   rows: { sender: string; text: string }[] = [{ sender: 'user-1', text: 'please use tabs' }]
@@ -70,8 +73,9 @@ class FakeStore implements DreamStorePort {
   supersededDreams(): DreamInfo[] {
     return [...this.dreams.values()].filter((d) => d.status === 'superseded')
   }
-  dreamSessionSources(): { sessionId: string; channel: string; thread: string }[] {
-    return this.sources
+  dreamSessionSources(): { sessionId: string; channel: string; thread: string; updatedAt: number }[] {
+    const now = Date.now()
+    return this.sources.map((s) => ({ ...s, updatedAt: s.updatedAt ?? now }))
   }
   toolRows: { sender: string; text: string; kind?: string }[] = []
   dreamTranscriptText(
@@ -141,8 +145,10 @@ async function settle(store: FakeStore, dreamId: string): Promise<DreamInfo> {
 }
 
 describe('DreamRunner pipeline', () => {
-  it('hasNewSessionsSinceLastDream: only new session ids past the last successful dream count', async () => {
+  it('auto window: only sessions active since the last successful dream count (else skip)', async () => {
     const { store, runner } = await setup({})
+    const dreamAt = '2026-01-02T00:00:00.000Z'
+    const cutoff = Date.parse(dreamAt)
     const dream = (status: DreamInfo['status'], sessionIds: string[], dreamId: string): DreamInfo => ({
       dreamId,
       agentId: 'a1',
@@ -150,34 +156,28 @@ describe('DreamRunner pipeline', () => {
       trigger: 'schedule',
       sessionIds,
       snapshotDigest: 'sha256:x',
-      createdAt: new Date().toISOString()
+      createdAt: dreamAt
     })
 
-    // Never dreamed → the first scheduled run always proceeds.
-    store.sources = [{ sessionId: 'sess-1', channel: 'C1', thread: 'T1' }]
+    // Never dreamed → the first scheduled run always proceeds (no baseline).
+    store.sources = [{ sessionId: 'sess-1', channel: 'C1', thread: 'T1', updatedAt: cutoff - 1000 }]
     expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(true)
 
-    // Last successful dream already mined the only current session → skip.
+    // Last successful dream at `dreamAt`; the only session predates it → skip.
     store.insertDream(dream('completed', ['sess-1'], 'd1'))
     expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(false)
 
-    // A brand-new session appears → run.
+    // A session with activity AFTER the last dream → run.
     store.sources = [
-      { sessionId: 'sess-2', channel: 'C2', thread: 'T2' },
-      { sessionId: 'sess-1', channel: 'C1', thread: 'T1' }
+      { sessionId: 'sess-2', channel: 'C2', thread: 'T2', updatedAt: cutoff + 1000 },
+      { sessionId: 'sess-1', channel: 'C1', thread: 'T1', updatedAt: cutoff - 1000 }
     ]
     expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(true)
 
-    // An adopted dream that already saw both sessions → skip again. (Clear first:
-    // the fake's listDreams is insertion-ordered, so a single baseline keeps the
-    // "most recent successful" unambiguous — the real store orders by createdAt.)
+    // Only a FAILED dream exists → no successful baseline → mine everything (run).
     store.dreams.clear()
-    store.insertDream(dream('adopted', ['sess-1', 'sess-2'], 'd2'))
-    expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(false)
-
-    // Only a FAILED dream covers the current sessions → no successful baseline → run (retry).
-    store.dreams.clear()
-    store.insertDream(dream('failed', ['sess-1', 'sess-2'], 'd3'))
+    store.insertDream(dream('failed', ['sess-1', 'sess-2'], 'd2'))
+    store.sources = [{ sessionId: 'sess-1', channel: 'C1', thread: 'T1', updatedAt: cutoff - 5000 }]
     expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(true)
   })
 

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -141,6 +141,46 @@ async function settle(store: FakeStore, dreamId: string): Promise<DreamInfo> {
 }
 
 describe('DreamRunner pipeline', () => {
+  it('hasNewSessionsSinceLastDream: only new session ids past the last successful dream count', async () => {
+    const { store, runner } = await setup({})
+    const dream = (status: DreamInfo['status'], sessionIds: string[], dreamId: string): DreamInfo => ({
+      dreamId,
+      agentId: 'a1',
+      status,
+      trigger: 'schedule',
+      sessionIds,
+      snapshotDigest: 'sha256:x',
+      createdAt: new Date().toISOString()
+    })
+
+    // Never dreamed → the first scheduled run always proceeds.
+    store.sources = [{ sessionId: 'sess-1', channel: 'C1', thread: 'T1' }]
+    expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(true)
+
+    // Last successful dream already mined the only current session → skip.
+    store.insertDream(dream('completed', ['sess-1'], 'd1'))
+    expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(false)
+
+    // A brand-new session appears → run.
+    store.sources = [
+      { sessionId: 'sess-2', channel: 'C2', thread: 'T2' },
+      { sessionId: 'sess-1', channel: 'C1', thread: 'T1' }
+    ]
+    expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(true)
+
+    // An adopted dream that already saw both sessions → skip again. (Clear first:
+    // the fake's listDreams is insertion-ordered, so a single baseline keeps the
+    // "most recent successful" unambiguous — the real store orders by createdAt.)
+    store.dreams.clear()
+    store.insertDream(dream('adopted', ['sess-1', 'sess-2'], 'd2'))
+    expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(false)
+
+    // Only a FAILED dream covers the current sessions → no successful baseline → run (retry).
+    store.dreams.clear()
+    store.insertDream(dream('failed', ['sess-1', 'sess-2'], 'd3'))
+    expect(runner.hasNewSessionsSinceLastDream('a1')).toBe(true)
+  })
+
   it('stages a validated proposal without touching the live store', async () => {
     const { dir, store, runner, prompts } = await setup({})
     const started = await runner.start('a1', { trigger: 'manual' })

--- a/packages/daemon/test/dream-scheduler.test.ts
+++ b/packages/daemon/test/dream-scheduler.test.ts
@@ -125,13 +125,19 @@ describe('scheduled dream lifecycle gates (daemon)', () => {
     let started = false
     const inner = daemon as unknown as {
       onDreamScheduleFire(id: string): void
-      dreamRunner(): { start(id: string, opts: unknown): Promise<unknown> }
+      dreamRunner(): {
+        start(id: string, opts: unknown): Promise<unknown>
+        hasNewSessionsSinceLastDream(id: string): boolean
+      }
     }
     inner.dreamRunner = () => ({
       start: async () => {
         started = true
         return { dreamId: 'drm-test' }
-      }
+      },
+      // Isolate the lifecycle gates from the "new sessions" gate — that gate has
+      // its own unit coverage; here we only assert whether the gates let a tick through.
+      hasNewSessionsSinceLastDream: () => true
     })
     inner.onDreamScheduleFire(agentId)
     await new Promise((r) => setTimeout(r, 20))

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -130,7 +130,9 @@ describe('LocalStore', () => {
       updatedAt: 2
     })
 
-    expect(s.dreamSessionSources('bot-a', 20)).toEqual([{ sessionId: 'source-session', channel: 'C1', thread: 'T1' }])
+    expect(s.dreamSessionSources('bot-a', 20)).toEqual([
+      { sessionId: 'source-session', channel: 'C1', thread: 'T1', updatedAt: 1 }
+    ])
     s.close()
   })
 

--- a/packages/protocol/src/frames/memory-connection.ts
+++ b/packages/protocol/src/frames/memory-connection.ts
@@ -50,7 +50,10 @@ export type MemoryCapturePolicy = z.infer<typeof MemoryCapturePolicy>
 export const MemoryDreamingPolicy = z
   .object({
     enabled: z.boolean(),
-    /** How many recent sessions to mine (default 20). */
+    /** Optional override pinning a fixed newest-N session window to mine. When
+     *  absent (the norm), the daemon sizes the window automatically — every
+     *  session active since the last successful dream, capped at 100 — so this
+     *  normally needs no configuration. */
     sessionWindow: z.number().int().min(1).max(100).optional(),
     /** Cron expression for scheduled dreams (same syntax as agent crons). A tick
      *  that lands while a dream is already in flight is skipped, not queued. */


### PR DESCRIPTION
## Why

The dream's session window was a config knob (`sessionWindow`, default 20) with no console UI — confusing and unnecessary. Per owner feedback it should be **automatic**. Re-running a scheduled dream over an unchanged corpus also just burns a host + tokens re-deriving the same proposal.

## Change

- **Automatic window** (`dream-runner.selectSessionSources`): the default corpus is the sessions with activity **since the last successful dream** (each session's `updatedAt` is newer than that dream's start), capped at 100; the first dream (no baseline) takes the current corpus up to the cap. No operator config needed.
- **Skip when nothing new**: `onDreamScheduleFire` skips a scheduled tick when the automatic selection is empty (`hasNewSessionsSinceLastDream` = the selection is non-empty). A **manual** dream always runs.
- **Legacy override kept**: an explicit `sessionWindow` (per-run manual override, or a previously-configured policy value) still pins a fixed newest-N window.
- store `dreamSessionSources` now returns each session's `updatedAt`; removed the fixed `DEFAULT_SESSION_WINDOW`.

A failed dream is not a baseline, so a transient failure still retries on the next tick.

## Tests

- Auto-window truth table: never-dreamed → run; last-success covered everything (all sessions predate it) → skip; a session active since the last dream → run; failed-only baseline → run.
- Scheduler stub extended for the gate; store fake returns `updatedAt`.

## Verification

- daemon typecheck + eslint clean; dream-runner + dream-scheduler + daemon-evaluation + daemon-smoke suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)