### PR TITLE
fix(daemon): replay retained inbox after reconcile

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3324,6 +3324,9 @@ export class Daemon {
    */
   private reconcileRun?: Promise<void>
   private reconcilePending = false
+  // Register snapshots publish agents before integrations. Carry newly-owned
+  // inbox rows across coalesced passes and retry only after convergence is idle.
+  private readonly pendingInboxReplayAgents = new Set<string>()
   async reconcile(): Promise<void> {
     if (this.reconcileRun) {
       this.reconcilePending = true
@@ -3338,6 +3341,11 @@ export class Daemon {
     if (this.reconcilePending) {
       this.reconcilePending = false
       await this.reconcile()
+    }
+    if (!this.reconcileRun && !this.reconcilePending && this.pendingInboxReplayAgents.size > 0) {
+      const agentIds = new Set(this.pendingInboxReplayAgents)
+      this.pendingInboxReplayAgents.clear()
+      this.replayInbox(agentIds)
     }
   }
 
@@ -3502,6 +3510,7 @@ export class Daemon {
       // already paused is still an explicit operator stop, so terminally discard that
       // old backlog now rather than letting a later unpause+restart resurrect it.
       if (a.pause) this.purgeAgentInbox(a.id)
+      else this.pendingInboxReplayAgents.add(a.id)
       // New agent: warm its git-repo checkout in the background now (e.g. on daemon
       // start every agent is a toStart), so the repo is cloned ahead of the first message.
       this.prefetchClone(a as LoadedAgent)
@@ -17665,7 +17674,7 @@ export class Daemon {
    * may hold that agent; we neither drop the row nor block on it). Webchat turns were never
    * persisted, so none appear here.
    */
-  private replayInbox(): void {
+  private replayInbox(agentIds?: ReadonlySet<string>): void {
     let rows: InboxRow[]
     try {
       rows = this.store.listInboxBySessionKeyFifo()
@@ -17679,6 +17688,7 @@ export class Daemon {
     const purgedPausedAgents = new Set<string>()
     const purgedLoopScopes = new Set<string>()
     for (const row of rows) {
+      if (agentIds && !agentIds.has(row.agentId)) continue
       // A completed hook row is a redacted durable receipt, not work. It is
       // re-emitted from onReady (when the CP socket is actually writable) and
       // remains here to absorb relay redelivery without another model turn.

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -1019,16 +1019,17 @@ describe('daemon durable inbox', () => {
     await daemon.stop()
   }, 15_000)
 
-  it('rows for an unknown agent are skipped (left) on replay', async () => {
+  it('replays an unknown-agent row only after its CP integration binding converges', async () => {
     const g = gatedHost()
     const root = scaffold(['bot-a']) // only bot-a exists on this daemon
+    const integrationId = '66666666-6666-4666-8666-666666666666'
     const s = new LocalStore(statePath(root))
     s.appendInbox({
       id: 'slack:C1:100',
       sessionKey: sessionKey('slack', 'C1', 'T1', 'ghost'),
       agentId: 'ghost',
-      msg: JSON.stringify(msg('100', 'orphan')),
-      integrationId: 'int-a',
+      msg: JSON.stringify({ ...msg('100', 'orphan'), isDm: false, trigger: 'mention' }),
+      integrationId,
       callMeta: null,
       isQueueCmd: null,
       enqueuedAt: '100'
@@ -1040,6 +1041,41 @@ describe('daemon durable inbox', () => {
     // Never dispatched; the row is LEFT for another owner.
     expect(g.started.length).toBe(0)
     expect(inbox(root).map((r) => r.id)).toEqual(['slack:C1:100'])
+
+    const conn = {
+      workspaceId: vi.fn(() => 'T_READY'),
+      setStatus: vi.fn(async () => {}),
+      postMessage: vi.fn(async () => {})
+    }
+    vi.spyOn(daemon as any, 'reconcileSlackConnections').mockImplementation(async () => {
+      const integration = (daemon as any).agents
+        .get('ghost')
+        ?.integrations.find((candidate: { id: string }) => candidate.id === integrationId)
+      if (integration) (daemon as any).connByIntegration.set(integrationId, conn)
+    })
+    await (daemon as any).cpConfigApply().applyReconcileSnapshot({
+      routingEpoch: 1,
+      assignments: [],
+      agents: [{ agentId: 'ghost', name: 'ghost', runtime: 'claude' }],
+      integrations: [
+        {
+          integrationId,
+          agentId: 'ghost',
+          platform: 'slack',
+          core: { mode: 'direct', bindRules: [{ match: { kind: 'mention' } }], mutedChannels: [], gated: false },
+          config: { botToken: 'xoxb-test', appToken: 'xapp-test' }
+        }
+      ],
+      crons: [],
+      leases: [],
+      drop: { assignments: [], agents: [], integrations: [], crons: [] }
+    })
+    await vi.waitFor(() => expect(g.started).toHaveLength(1), WAIT)
+    expect((daemon as any).connByIntegration.get(integrationId)).toBe(conn)
+    expect(g.started[0]).toContain('orphan')
+
+    g.releaseOne()
+    await vi.waitFor(() => expect(inbox(root)).toHaveLength(0), WAIT)
     await daemon.stop()
   }, 15_000)
 


### PR DESCRIPTION
## What changed

- Replay retained durable inbox rows when a previously unknown agent is added during daemon reconciliation.
- Scope that replay to agents newly added by the current roster update, after their platform connections are ready.
- Extend the durable inbox regression test through the unknown-agent to owned-agent transition.

## Root cause

Startup inbox replay runs before the Control Plane roster arrives. After a daemon restart, a retained turn for a Control Plane-owned agent was therefore skipped as unknown and deliberately left in SQLite. Reconciliation later installed the agent, but never retried the retained row, so work such as a GitHub review could remain stranded until the Control Plane reaper closed the run.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/durable-inbox.test.ts` (28 passed)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- Prettier and ESLint
- Pre-push repository lint

Created by Codex . GPT-5
