### PR TITLE
fix(daemon): activate paired self channel calls

### DIFF
--- a/docs/designs/send-message-routing-rework.md
+++ b/docs/designs/send-message-routing-rework.md
@@ -155,9 +155,11 @@ ladder a human message takes, with the author removed from the candidate set:
 - Each peer is an INDEPENDENT delivery: its own session, `!stop` mute, Off fence, and
   inbox row. A muted participant stays muted — `!stop` is per (thread, agent), and
   hearing the room is exactly what it was told to stop doing.
-- **The author can never be the target.** This is the one absolute. An agent's own
-  reply always matches its own rule, so self-activation is not a loop the hop cap
-  slows down — it is unconditional. The author is excluded once, before any rung.
+- **An ordinary platform reply can never target its author.** An agent's own reply
+  always matches its own rule, so echo-based self-activation is not a loop the hop cap
+  slows down — it is unconditional. The author is excluded once, before any ordinary
+  routing rung. The paired `toAgent + channel` exception above is driven by its internal
+  envelope, not by routing the author's platform echo.
 - A third-party bot keeps its existing behavior: where supported, it may activate
   an agent only through an explicit mention. The difference is verification, not
   bot-ness — we know exactly which agent wrote a verified message and have already
@@ -416,6 +418,11 @@ recipient: existing participants still receive their independent implicit copies
 shared bot's address therefore still needs its agent slug when an agent wants to write
 one; a bare `<@U_SHARED>` joins only the routes that token can actually resolve.
 
+The author-removal rule applies to ordinary platform replies. An explicit paired
+`toAgent` channel-root delivery may target its own author: the internal envelope activates
+the new child once, while the platform echo remains only the paired observation. The
+postless form still rejects self-targets because it has no new conversation boundary.
+
 Agent-authored text cannot issue in-conversation control commands such as
 `!stop`, `!resume`, or configuration actions.
 
@@ -605,12 +612,13 @@ At minimum, cover:
 8. Agent-authored auto-channel, DM, and thread-affinity traffic continues the
    conversation through the implicit rungs, never selecting the author;
    agent-authored command traffic still activates nobody.
-9. The author is never the target on any connection, and a body naming the author,
-   a human, or an unresolvable peer does not change delivery. An agent-authored
+9. An ordinary platform reply never targets its author on any connection, and a body
+   naming the author, a human, or an unresolvable peer does not change delivery. An agent-authored
    delivery obeys a `!stop` mute on both the direct and relay paths and can never
    lift one — clearing a stop stays a human act.
 10. A paired `toAgent + channel` delivery reaches the exact agent the tool named,
-    on both ladders, so its rendezvous halves converge.
+    including the caller itself, on both ladders, so its rendezvous halves converge
+    and activate one child exactly once.
 11. Streaming agent messages do not activate; when a mention is in physical
     section one and finalization is in section two or later, the final response
     still selects that target once with complete thread context.

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -140,9 +140,10 @@ ladder as any other message**, with the author removed from the candidate set:
 - each participant is an independent delivery with its own session and its own `!stop`.
   A participant you stopped stays stopped, and still records the conversation for
   catch-up;
-- **an author is never the target**, on any path. This is the one absolute: an agent's
-  own reply always matches its own rule, so self-activation would be unconditional
-  rather than merely loop-prone;
+- **an ordinary reply never targets its author.** An agent's own reply always matches its
+  own rule, so routing provider echoes back to the author would be unconditional rather
+  than merely loop-prone. The explicit `toAgent` channel-root form below is the bounded
+  exception: its one paired internal wake activates the new child exactly once;
 - agent-authored text cannot issue control commands (`!stop`, `!resume`, configuration
   actions);
 - a third-party bot is unchanged: where supported, it may activate an agent only through
@@ -207,7 +208,7 @@ visible in-thread form** — every visible send lands at the channel **root**:
   or addressing a human, as in case 2a / case 3.
 
 The visible post is suppressed when the wake would be refused for a locally-decidable
-reason (capability disabled, invalid target id, self, hop limit, or a local target that
+reason (capability disabled, invalid target id, a postless self-call, hop limit, or a local target that
 disallows the caller), so a rejected hand-off leaves no misleading post. One accepted
 best-effort edge: a target on another daemon whose call policy terminally rejects the
 caller can still leave a visible post, because that policy verdict is only known on the
@@ -225,6 +226,12 @@ The session starts idle, retains its parent-session lineage, and records the roo
 transcript display. The first real reply in that thread receives the root as preceding
 context before the new message. Session initialization itself produces no agent output,
 tool calls, memory recall or capture, turn evaluation, or token usage.
+
+When the post instead carries `toAgent`, it is an explicit activation even when the
+target is the posting agent itself. The visible root and internal wake remain one paired
+delivery, so the new child runs exactly once; the platform's echo is only the second
+observation of that delivery. A postless self-call remains invalid because it has no new
+conversation boundary and can recurse without producing a user-visible hand-off.
 
 ## A parent-session reply is injected, and the parent answers normally
 

--- a/packages/daemon/src/cp/cp-collab-routes.ts
+++ b/packages/daemon/src/cp/cp-collab-routes.ts
@@ -159,7 +159,8 @@ export class CpCollabRoutes {
     if (caller.orgId !== target.orgId) return false
     // A caller always resolves ITSELF: an agent with outboundPolicy 'selected' does
     // not normally list itself in its own allow-list, yet it must still see itself in
-    // a directory listing. (A self-WAKE is rejected earlier, with reason 'self'.)
+    // a directory listing. Postless self-wakes are rejected by the delivery path; a
+    // paired channel-root self-wake intentionally uses this self admission.
     if (callerAgentId === targetAgentId) return true
     if (caller.outboundPolicy === 'selected' && !caller.allowedTargetAgentIds.includes(targetAgentId)) return false
     if (target.callPolicy === 'selected' && !target.allowedCallerAgentIds.includes(callerAgentId)) return false

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8018,7 +8018,13 @@ export class Daemon {
    */
   private localWakeDecision(req: MessageAgentReq): { rejection: string } | { rejection: null; channel: string } {
     const caller = this.agents.get(req.callerAgentId)
-    if (!caller || (caller.outboundPolicy === 'selected' && !caller.allowedTargetAgentIds.includes(req.toAgentId))) {
+    const channelRootSelfWake = req.toAgentId === req.callerAgentId && req.postless !== true
+    if (
+      !caller ||
+      (!channelRootSelfWake &&
+        caller.outboundPolicy === 'selected' &&
+        !caller.allowedTargetAgentIds.includes(req.toAgentId))
+    ) {
       return { rejection: 'not_allowed' }
     }
 
@@ -8029,7 +8035,13 @@ export class Daemon {
     // BEFORE the local-target lookup so it also decides a REMOTE target and an id that is
     // in no directory at all (previously the latter fell through to a misleading
     // 'offline'). Fails closed on an absent/stale snapshot, as before.
-    if (!this.cpCollab.admits(req.callerAgentId, req.toAgentId)) return { rejection: 'not_allowed' }
+    // A visible channel-root self wake is not an inter-agent policy edge. The successful
+    // platform post proves the caller can write the named conversation; coordinate integrity
+    // below still proves the resulting child may be keyed there. Postless self calls never
+    // reach this branch — the explicit self guard rejects those before authorization.
+    if (!channelRootSelfWake && !this.cpCollab.admits(req.callerAgentId, req.toAgentId)) {
+      return { rejection: 'not_allowed' }
+    }
 
     // COORDINATE INTEGRITY — the SAME decision the relay's ingress and this daemon's
     // `rd/agentmsg` terminal-verify apply, so all three wake paths enforce one rule. Channel
@@ -8052,7 +8064,11 @@ export class Daemon {
     if (coords.verdict === 'reject') return { rejection: 'not_allowed' }
 
     const target = this.agents.get(req.toAgentId)
-    if (target?.callPolicy === 'selected' && !target.allowedCallerAgentIds.includes(req.callerAgentId)) {
+    if (
+      !channelRootSelfWake &&
+      target?.callPolicy === 'selected' &&
+      !target.allowedCallerAgentIds.includes(req.callerAgentId)
+    ) {
       return { rejection: 'not_allowed' }
     }
     // Branch 3 substitutes the coordinate rather than refusing the wake; branch 1 hands back
@@ -8067,7 +8083,10 @@ export class Daemon {
     if (isPlatformMemberId(platform, req.toAgentId)) {
       return 'invalid_target'
     }
-    if (req.toAgentId === req.callerAgentId) return 'self'
+    // `sendMessage(toAgent=self, channel=...)` preflights before the root post exists, so
+    // absence of the postless marker is the trusted indication that this is the visible form.
+    // messageAgent performs the stronger post-ts + pairing-id check before dispatch.
+    if (req.toAgentId === req.callerAgentId && req.postless === true) return 'self'
     const callerKey = sessionKey(
       platform,
       req.callerChannel,
@@ -8136,8 +8155,15 @@ export class Daemon {
         reason: 'invalid_target'
       })
     }
-    // Self-message guard (§4.5): an agent waking itself is a loop — reject before publish.
-    if (req.toAgentId === req.callerAgentId) {
+    // A self wake is valid only when `sendMessage` has already published the paired channel-root
+    // post and can anchor the child to its real provider coordinate. Postless self calls — and
+    // any internal caller that merely omits the marker without proving a post — remain loops.
+    const pairedChannelRootSelfWake =
+      req.toAgentId === req.callerAgentId &&
+      req.postless !== true &&
+      req.transcriptTs !== undefined &&
+      req.agentCallDeliveryId !== undefined
+    if (req.toAgentId === req.callerAgentId && !pairedChannelRootSelfWake) {
       const fallbackThread = req.thread ?? `agentcall:${req.channel}:self`
       return observe('collaboration.delivery.rejected', {
         delivered: false,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5966,8 +5966,8 @@ export class Daemon {
     // rendezvous only converges if both halves name the SAME target. Route it to exactly
     // that agent — picking a different one implicitly would strand the internal wake.
     if (verified.agentCallDeliveryId) {
-      const paired = verified.recipients.filter((id) => id !== verified.authorAgentId)
-      if (paired.length === 0) return transcriptOnly('paired agent call named no other agent')
+      const paired = verified.recipients
+      if (paired.length === 0) return transcriptOnly('paired agent call named no agent')
       let firstPaired: { kind: 'rejected'; reason: DeliveryRejectionReason } | undefined
       for (const targetAgentId of paired) {
         const outcome = this.activateVerifiedAgentTarget(msg, verified, targetAgentId, deliveryHopCount, 'mention')
@@ -6125,13 +6125,14 @@ export class Daemon {
     // ladder returns before `onInboundOutcome`'s own mute gate; without it `!stop` would
     // silence humans while agents kept waking each other, which is the one situation the
     // command exists for now that the loop protections are the ordinary terminator.
-    if (targetAgentId === verified.authorAgentId) return undefined
+    const pairedSelfObservation = targetAgentId === verified.authorAgentId && verified.agentCallDeliveryId !== undefined
+    if (targetAgentId === verified.authorAgentId && !pairedSelfObservation) return undefined
     if (!this.agents.has(targetAgentId) || this.drainingAgents.has(targetAgentId)) return undefined
-    if (!this.cpCollab.admits(verified.authorAgentId, targetAgentId)) {
+    if (!pairedSelfObservation && !this.cpCollab.admits(verified.authorAgentId, targetAgentId)) {
       this.log.debug(`routing: agent edge ${verified.authorAgentId} → ${targetAgentId} denied by call policy`)
       return undefined
     }
-    if (!this.agentConversationAdmits(targetAgentId, msg)) {
+    if (!pairedSelfObservation && !this.agentConversationAdmits(targetAgentId, msg)) {
       this.log.debug(`routing: agent edge ${verified.authorAgentId} → ${targetAgentId} is off in this conversation`)
       return undefined
     }
@@ -7276,7 +7277,8 @@ export class Daemon {
     // The relay minted this claim, so the target must be one the relay actually named —
     // never a recipient inferred from the (untrusted) provider metadata riding along.
     if (msg.trustedRecipientAgentIds !== undefined && !msg.trustedRecipientAgentIds.includes(msg.agentId)) return false
-    if (authorAgentId === msg.agentId) return false
+    const pairedSelfObservation = authorAgentId === msg.agentId && msg.trustedAgentCallDeliveryId !== undefined
+    if (authorAgentId === msg.agentId && !pairedSelfObservation) return false
     // §4.1 step 4: TERMINAL-VERIFY the forwarded depth's range without re-incrementing.
     // A relay that forwarded an out-of-range or malformed depth is a bug or a compromise;
     // either way this daemon does not activate on it.
@@ -7286,13 +7288,13 @@ export class Daemon {
     }
     const orgId = this.cpCollab.orgForAgent(msg.agentId)
     if (!orgId || this.cpCollab.orgForAgent(authorAgentId) !== orgId) return false
-    if (!this.cpCollab.admits(authorAgentId, msg.agentId)) {
+    if (!pairedSelfObservation && !this.cpCollab.admits(authorAgentId, msg.agentId)) {
       this.log.info(`relay: agent mention ${msg.msgId} denied by call policy (${authorAgentId} → ${msg.agentId})`)
       return false
     }
     // The same conversation fence the human path applies at its last hop (`gatedAdmission`
     // below): Off means no activation, explicitly including an @-mention.
-    if (!this.gatedAdmission(msg.integrationId, normalized)) {
+    if (!pairedSelfObservation && !this.gatedAdmission(msg.integrationId, normalized)) {
       this.log.debug(`relay: agent mention ${msg.msgId} is off in this conversation`)
       return false
     }
@@ -8162,6 +8164,7 @@ export class Daemon {
       req.toAgentId === req.callerAgentId &&
       req.postless !== true &&
       req.transcriptTs !== undefined &&
+      !req.transcriptTs.startsWith('local-') &&
       req.agentCallDeliveryId !== undefined
     if (req.toAgentId === req.callerAgentId && !pairedChannelRootSelfWake) {
       const fallbackThread = req.thread ?? `agentcall:${req.channel}:self`

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -992,6 +992,10 @@ export async function executeTool(
     // (undefined if no real ts came back — the peer then falls back to messageAgent's
     // default thread).
     let postedThread: string | undefined
+    // A provider-issued id proves that the visible root has a stable conversation
+    // boundary. `post.ts` may still use a synthetic local id for display/recording when
+    // a best-effort gateway returns no id; that fallback must not authorize a paired wake.
+    let providerPostId: string | undefined
     // §3.2: the daemon-minted id that makes the visible post and the internal wake ONE
     // logical delivery. Minted before the post so both halves carry it, and only for the
     // paired form — an ordinary channel post has no wake to pair with, and stamping one
@@ -1069,7 +1073,8 @@ export async function executeTool(
             }
           : {})
       }
-      const ts = (await gw.postMessage(postChannel, body, undefined, identity)) ?? `local-${deps.now()}`
+      providerPostId = await gw.postMessage(postChannel, body, undefined, identity)
+      const ts = providerPostId ?? `local-${deps.now()}`
       // Whether the target is a DM decides the thread key on the platforms that keep a DM as one
       // continuous conversation, and no id carries that — ask the platform, once, and only where
       // the answer can change the key. A failed lookup falls back to the non-DM conversation
@@ -1078,7 +1083,10 @@ export async function executeTool(
         wantPlatform === 'telegram' || wantPlatform === 'feishu'
           ? ((await gw.getChannelInfo(postChannel).catch(() => undefined))?.isIm ?? false)
           : false
-      postedThread = ts.startsWith('local-') ? undefined : threadKeyForPost(wantPlatform, postChannel, ts, isDmTarget)
+      postedThread =
+        providerPostId === undefined
+          ? undefined
+          : threadKeyForPost(wantPlatform, postChannel, providerPostId, isDmTarget)
       // Record the post in the thread it BELONGS to — the one it just created for a root post,
       // not the caller's own thread (the daemon's fallback, which for a cross-channel post keys a
       // row to coords that match no session at all). It is also what resolves a later reply to
@@ -1168,10 +1176,10 @@ export async function executeTool(
       wake = await deps.messageAgent({
         ...baseWakeReq,
         ...(threadForWake !== undefined ? { thread: threadForWake } : {}),
-        ...(channel !== undefined && post !== undefined ? { transcriptTs: post.ts } : {}),
+        ...(channel !== undefined && providerPostId !== undefined ? { transcriptTs: providerPostId } : {}),
         // §3.2: the SAME id the visible post carries, so the target's rendezvous can
         // recognize the two as one delivery whichever arrives first.
-        ...(agentCallDeliveryId !== undefined && post !== undefined ? { agentCallDeliveryId } : {})
+        ...(agentCallDeliveryId !== undefined && providerPostId !== undefined ? { agentCallDeliveryId } : {})
       })
     }
 

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -438,7 +438,7 @@ export interface OpsDeps {
   messageAgent: (req: MessageAgentReq) => Promise<MessageAgentResult>
   /** Side-effect-free preflight for a peer wake: returns a typed rejection reason if
    *  {@link messageAgent} would refuse this wake for a locally-decidable reason (capability
-   *  disabled, invalid target id, self, hop-limit, caller outbound policy, or a LOCAL
+   *  disabled, invalid target id, a postless self-call, hop-limit, caller outbound policy, or a LOCAL
    *  target's inbound policy/channel membership), else null. `sendMessage` uses it to skip the visible channel post for a
    *  `toAgent`+`channel` wake that will not be delivered. Absent in the chat CLI / tests with
    *  no daemon ⇒ the post is not gated (treated as null). */
@@ -962,8 +962,8 @@ export async function executeTool(
           }
         : undefined
     // PREFLIGHT (side-effect-free): would messageAgent refuse this wake for a locally-decidable
-    // reason (capability off / bad target id / self / hop-limit / a local target that disallows
-    // this caller)? If so we must NOT leave a misleading public post for a peer that is never
+    // reason (capability off / bad target id / postless self-call / hop-limit / a local target
+    // that disallows this caller)? If so we must NOT leave a misleading public post for a peer that is never
     // woken — so the post below is gated on `wakeRejection === null`. The wake itself still runs
     // through messageAgent (it re-checks, emits the evaluation event, and returns the typed
     // reason). A REMOTE target's call-policy can't be preflighted here (that verdict lives on the

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -502,7 +502,7 @@ export interface SubtaskRow {
   text: string
   status: 'pending' | 'sending' | 'delivered' | 'succeeded' | 'worker_error' | 'timed_out'
   result?: string | null
-  /** Typed reason on a failed delivery (self/not_allowed/not_local/no_agent/offline). */
+  /** Typed reason on a failed delivery (postless self/not_allowed/not_local/no_agent/offline). */
   deliveryReason?: string | null
   updatedAt: string
 }

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -502,7 +502,7 @@ export interface SubtaskRow {
   text: string
   status: 'pending' | 'sending' | 'delivered' | 'succeeded' | 'worker_error' | 'timed_out'
   result?: string | null
-  /** Typed reason on a failed delivery (postless self/not_allowed/not_local/no_agent/offline). */
+  /** Typed reason on a failed delivery (`self` for postless/unpaired self-wakes, or not_allowed/not_local/no_agent/offline). */
   deliveryReason?: string | null
   updatedAt: string
 }

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -820,6 +820,48 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
       expect(calls).toHaveLength(0)
       await daemon.stop()
     })
+
+    it('relay platform event first: a paired self observation survives until its internal wake', async () => {
+      const { daemon, calls } = await boot([{ id: 'bot-a' }])
+      const ack = (daemon as any).handleRelayIm(
+        imFrame({
+          agentId: 'bot-a',
+          integrationId: 'int-bot-a',
+          msgId: 'slack:C1:1720000000.000200:final#bot-a',
+          trustedFromAgentId: 'bot-a',
+          trustedRecipientAgentIds: ['bot-a'],
+          trustedAgentCallDeliveryId: 'd-self-relay',
+          payload: agentMessage({}, { mentionedAgentIds: ['bot-a'], agentCallDeliveryId: 'd-self-relay' })
+        })
+      )
+      expect(ack.accepted).toBe(true)
+      expect(calls).toHaveLength(0)
+      expect((daemon as any).store.getActivation(pairingKey(daemon, 'bot-a'))).toMatchObject({
+        state: 'pending',
+        agentCallDeliveryId: 'd-self-relay'
+      })
+
+      const res = await (daemon as any).messageAgent({
+        callerAgentId: 'bot-a',
+        platform: 'slack',
+        callerChannel: 'C1',
+        callerThread: '1720000000.000100',
+        toAgentId: 'bot-a',
+        text: 'continue here',
+        channel: 'C1',
+        thread: '1720000000.000200',
+        transcriptTs: '1720000000.000200',
+        agentCallDeliveryId: 'd-self-relay'
+      })
+      expect(res.delivered).toBe(true)
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toMatchObject({ agentId: 'bot-a', callMeta: { callFrom: 'bot-a' } })
+      expect((daemon as any).store.getActivation(pairingKey(daemon, 'bot-a'))).toMatchObject({
+        state: 'admitted',
+        childSessionId: res.targetSession
+      })
+      await daemon.stop()
+    })
   })
 
   // §10 case 4 — the two halves of a paired `toAgent + channel` delivery may arrive in
@@ -890,6 +932,38 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
         // The visible observation survives the transition, so the two collapse onto one
         // transcript row instead of duplicating the hand-off.
         platformMessageId: '1720000000.000200'
+      })
+      await daemon.stop()
+    })
+
+    it('direct platform event first: a paired self observation survives until its internal wake', async () => {
+      const { daemon, calls } = await boot([{ id: 'bot-a' }])
+      const visible = agentMessage(
+        {},
+        {
+          authorAgentId: 'bot-a',
+          mentionedAgentIds: ['bot-a'],
+          agentCallDeliveryId: 'd-self-direct'
+        }
+      )
+
+      expect(route(daemon, visible, ['int-bot-a']).kind).toBe('rejected')
+      expect(calls).toHaveLength(0)
+      expect((daemon as any).store.getActivation(pairingKey(daemon, 'bot-a'))).toMatchObject({
+        state: 'pending',
+        agentCallDeliveryId: 'd-self-direct'
+      })
+
+      const res = await wake(daemon, {
+        toAgentId: 'bot-a',
+        agentCallDeliveryId: 'd-self-direct'
+      })
+      expect(res.delivered).toBe(true)
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toMatchObject({ agentId: 'bot-a', callMeta: { callFrom: 'bot-a' } })
+      expect((daemon as any).store.getActivation(pairingKey(daemon, 'bot-a'))).toMatchObject({
+        state: 'admitted',
+        childSessionId: res.targetSession
       })
       await daemon.stop()
     })

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -258,12 +258,75 @@ describe('messageAgent: same-daemon delivery', () => {
     await daemon.stop()
   })
 
-  it('rejects a self-message before any lookup', async () => {
+  it('rejects a postless self-message before any lookup', async () => {
     const root = scaffold([{ id: 'bot-a' }])
     const { daemon, calls, call } = await bootWithDispatchSpy(root)
-    const res = await call(baseReq({ toAgentId: 'bot-a' }))
+    const res = await call(baseReq({ toAgentId: 'bot-a', postless: true }))
     expect(res).toMatchObject({ delivered: false, reason: 'self' })
     expect(calls.length).toBe(0)
+    await daemon.stop()
+  })
+
+  it('admits a paired channel-root self wake into a new child session exactly once', async () => {
+    const root = scaffold([
+      {
+        id: 'bot-a',
+        callPolicy: 'selected',
+        allowedCallerAgentIds: [],
+        outboundPolicy: 'selected',
+        allowedTargetAgentIds: []
+      }
+    ])
+    const { daemon, calls, call } = await bootWithDispatchSpy(root)
+    const callerKey = sessionKey('slack', 'C1', '100.1', 'bot-a')
+    ;(daemon as any).store.upsertSession({
+      key: callerKey,
+      agentId: 'bot-a',
+      platform: 'slack',
+      channel: 'C1',
+      thread: '100.1',
+      acpSessionId: 'acp-parent-1',
+      state: 'prompting',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+
+    const req = baseReq({
+      toAgentId: 'bot-a',
+      thread: '200.2',
+      transcriptTs: '200.2',
+      agentCallDeliveryId: 'paired-self-1'
+    })
+    expect(
+      (daemon as any).wakeRejectionReason({ ...req, transcriptTs: undefined, agentCallDeliveryId: undefined })
+    ).toBeNull()
+
+    const res = await call(req)
+    expect(res).toMatchObject({ delivered: true, targetSession: 'slack:C1:200.2:bot-a' })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      agentId: 'bot-a',
+      msg: {
+        channel: 'C1',
+        thread: '200.2',
+        transcriptTs: '200.2',
+        sender: { id: 'bot-a', isBot: true }
+      },
+      callMeta: {
+        callFrom: 'bot-a',
+        originSessionId: 'acp-parent-1',
+        originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
+      }
+    })
+    await daemon.stop()
+  })
+
+  it('rejects an unpaired self wake that only omits the postless marker', async () => {
+    const root = scaffold([{ id: 'bot-a' }])
+    const { daemon, calls, call } = await bootWithDispatchSpy(root)
+    const res = await call(baseReq({ toAgentId: 'bot-a', thread: '200.2' }))
+    expect(res).toMatchObject({ delivered: false, reason: 'self' })
+    expect(calls).toHaveLength(0)
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -330,6 +330,22 @@ describe('messageAgent: same-daemon delivery', () => {
     await daemon.stop()
   })
 
+  it('rejects a self wake anchored only to a synthetic local timestamp', async () => {
+    const root = scaffold([{ id: 'bot-a' }])
+    const { daemon, calls, call } = await bootWithDispatchSpy(root)
+    const res = await call(
+      baseReq({
+        toAgentId: 'bot-a',
+        thread: 'local-0',
+        transcriptTs: 'local-0',
+        agentCallDeliveryId: 'synthetic-self-1'
+      })
+    )
+    expect(res).toMatchObject({ delivered: false, reason: 'self' })
+    expect(calls).toHaveLength(0)
+    await daemon.stop()
+  })
+
   it.each(['U1122334455', '<@U1122334455>', ' U1122334455 ', '\t<@U1122334455>\n'])(
     'rejects Slack target %s before publishing a misleading visible message',
     async (toAgentId) => {

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -1006,6 +1006,29 @@ describe('executeTool: sendMessage (wake / reply)', () => {
     expect(calls[0]!.agentCallDeliveryId).toBe(postedIdentity.response?.agentCallDeliveryId)
   })
 
+  it('does not authorize a self wake when the gateway returns no provider message id', async () => {
+    const gw = fakeGateway({ postMessage: vi.fn(async () => undefined) })
+    const { deps: d, calls } = wakeDeps({ gatewayFor: () => gw })
+    d.messageAgent = async (req) => {
+      calls.push(req)
+      return { delivered: false, reason: 'self' }
+    }
+
+    const res = (await executeTool(
+      ctx,
+      'sendMessage',
+      { toAgent: 'bot-a', channel: 'C_X', message: 'continue here' },
+      d
+    )) as { wake?: { delivered: boolean; reason?: string }; post?: { ts: string } }
+
+    expect(res.post?.ts).toBe('local-0')
+    expect(res.wake).toEqual({ delivered: false, reason: 'self' })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).not.toHaveProperty('thread')
+    expect(calls[0]).not.toHaveProperty('transcriptTs')
+    expect(calls[0]).not.toHaveProperty('agentCallDeliveryId')
+  })
+
   it('mints NO pairing id for a postless wake or a bare channel post', async () => {
     // §3.2: the id means "a visible post accompanies this wake". Stamping it on a bare
     // channel post would make ingress hold that post for an internal envelope that is

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -970,6 +970,42 @@ describe('executeTool: sendMessage (wake / reply)', () => {
     expect(calls[0]!.agentCallDeliveryId).toBe(postedId.response?.agentCallDeliveryId)
   })
 
+  it('channel + toAgent self posts a paired ROOT message and wakes the caller without allowSelf', async () => {
+    const { deps: d, calls, gw } = wakeDeps()
+    const res = (await executeTool(
+      ctx,
+      'sendMessage',
+      { toAgent: 'bot-a', channel: 'C_X', message: 'continue here' },
+      d
+    )) as {
+      ok: boolean
+      wake?: { delivered: boolean }
+      post?: { channel: string; thread: string | null; ts: string }
+    }
+
+    expect(res).toMatchObject({
+      ok: true,
+      wake: { delivered: true },
+      post: { channel: 'C_X', thread: null, ts: 'ts-123' }
+    })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      callerAgentId: 'bot-a',
+      toAgentId: 'bot-a',
+      channel: 'C_X',
+      thread: 'ts-123',
+      transcriptTs: 'ts-123'
+    })
+    expect(calls[0]).not.toHaveProperty('postless')
+
+    const postedIdentity = (gw.postMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]![3] as {
+      response?: { mentionedAgentIds?: string[]; agentCallDeliveryId?: string }
+    }
+    expect(postedIdentity.response?.mentionedAgentIds).toEqual(['bot-a'])
+    expect(postedIdentity.response?.agentCallDeliveryId).toBeTruthy()
+    expect(calls[0]!.agentCallDeliveryId).toBe(postedIdentity.response?.agentCallDeliveryId)
+  })
+
   it('mints NO pairing id for a postless wake or a bare channel post', async () => {
     // §3.2: the id means "a visible post accompanies this wake". Stamping it on a bare
     // channel post would make ingress hold that post for an internal envelope that is

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -788,6 +788,29 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
       })
     })
 
+    it('forwards a PAIRED self observation before ordinary author exclusion', async () => {
+      const { internals, sendMsg } = managerWith({ admitsAgentCall: vi.fn(() => false) })
+      const selfOwned = channelAutoOwned()
+      selfOwned.routes[selfOwned.routes.length - 1]!.agentId = AUTHOR_ID
+      internals.router.upsert(selfOwned)
+
+      await internals.forward(
+        BOT_ID,
+        agentFinal(
+          { mentionedAgentIds: [AUTHOR_ID], agentCallDeliveryId: 'd-self' },
+          { text: 'continue here', mentionedBots: [] }
+        )
+      )
+
+      expect(sendMsg).toHaveBeenCalledTimes(1)
+      expect(sendMsg.mock.calls[0]![0]).toMatchObject({
+        agentId: AUTHOR_ID,
+        trustedFromAgentId: AUTHOR_ID,
+        trustedRecipientAgentIds: [AUTHOR_ID],
+        trustedAgentCallDeliveryId: 'd-self'
+      })
+    })
+
     it('always reports the delivery as implicitly selected', async () => {
       // Every agent-authored forward is arbitration-selected now, mention in the body or
       // not — the target needs that fact to apply its `!stop` gate correctly.

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -678,8 +678,8 @@ export class RelayIngressManager {
     const paired = claim.agentCallDeliveryId !== undefined
     let deliveries: Array<{ targetAgentId: string; routeVia: 'mention' | 'implicit' }>
     if (paired) {
-      const targets = claim.mentionedAgentIds.filter((id) => id !== claim.authorAgentId)
-      if (targets.length === 0) return drop('paired agent call named no other agent')
+      const targets = claim.mentionedAgentIds
+      if (targets.length === 0) return drop('paired agent call named no agent')
       deliveries = targets.map((targetAgentId) => ({ targetAgentId, routeVia: 'mention' }))
     } else {
       const primary = this.router.routeAgentAuthored(botId, msg, claim.authorAgentId)
@@ -705,7 +705,8 @@ export class RelayIngressManager {
         drop(`target ${targetAgentId} is not a member of this bot`)
         continue
       }
-      if (!this.deps.admitsAgentCall(claim.authorAgentId, targetAgentId)) {
+      const pairedSelfObservation = paired && claim.authorAgentId === targetAgentId
+      if (!pairedSelfObservation && !this.deps.admitsAgentCall(claim.authorAgentId, targetAgentId)) {
         drop(`call policy excludes ${claim.authorAgentId} -> ${targetAgentId}`)
         continue
       }


### PR DESCRIPTION
## What changed

- Allow `sendMessage({ toAgent: self, channel })` to activate a child turn after the visible channel-root post succeeds.
- Require the real provider timestamp and pairing delivery ID before dispatch, so merely omitting `postless` cannot bypass the self-call guard.
- Keep postless self-calls rejected and bypass inter-agent allowlists only for the paired channel-root self wake.
- Update product/design conventions and add daemon plus MCP tool regression coverage.

## Why

An agent-authored channel-root message with `toAgent` was initialized for transcript continuity but skipped the model turn because every self-target was rejected. The explicit paired delivery already has a bounded conversation boundary and echo-deduplication identity, so it can safely activate the target once.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-message-agent.test.ts test/mcp-ops.test.ts test/session-manager.test.ts` — 294 passed
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec prettier --check` on all changed files
- Pre-push repository lint

The full daemon suite also completed with 3039 passing and 2 unrelated environment-dependent failures: the external ACP evaluation baseline returned `infra_error`, and the git-injection fixture observed the host `GIT_ASKPASS` variable before its expected pager variable.
