### PR TITLE
fix(sessions): read history from recorded daemon

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -74,6 +74,16 @@ copies daemon-local workspace, memory, transcripts, or attachments. A source tha
 reconnects after a force reassign is told to detach the stale local copy during
 placement reconciliation.
 
+Historical session content remains owned by the daemon that created the session.
+Session transcript and tool-detail reads use that recorded daemon, not the Agent's
+current placement, so moving an Agent does not make its old sessions appear empty.
+Those reads remain available while the recorded daemon is online. A webchat session
+cannot resume after its Agent moves because the ACP state did not move with it; the
+Console keeps the transcript readable but replaces the composer with a disabled
+explanation. In a multi-Agent webchat conversation, every participating Agent must
+still be on the daemon that owns its corresponding session or the shared composer is
+disabled.
+
 ## Where a streamed reply may be split
 
 A long reply may be delivered as more than one chat message, but a split must always fall

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -909,7 +909,7 @@ model SessionMeta {
   fastMode            Boolean?
   permissionMode      String? // runtime permission/approval mode
   outputMode          String? // daemon-side output verbosity (low/medium/high)
-  daemonId            String?             @db.Uuid // daemon that reported the session — stamped by the CP from the authenticated WS conn, never daemon-echoed
+  daemonId            String?             @db.Uuid // first daemon that reported the session; immutable content owner, stamped by the CP from the authenticated WS conn, never daemon-echoed
   // Session-pinned checkout choice. Null is a legacy row whose daemon never
   // reported it; `session` identifies a daemon-local worktree eligible for the
   // authorized Workspace viewer.

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -779,8 +779,9 @@ export function sessionRoutes(deps: HttpDeps) {
     )
 
     // Replay view: proxy a page of the session's chat history live from the
-    // owning daemon. CP stores list/detail metadata only, not transcript bodies.
-    // 503 if the agent is unplaced or its daemon is offline (the list still works).
+    // session-recorded daemon. CP stores list/detail metadata only, not transcript
+    // bodies. Agent placement may have changed since this session ran; content
+    // stays on its original daemon and does not follow that move.
     r.get(
       '/sessions/:id/messages',
       {
@@ -788,7 +789,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get session messages',
           description:
-            "Proxies a page of the session's chat history live from the owning daemon (resolved via the row's agentId); 503 if the agent is unplaced or its daemon is offline.",
+            "Proxies a page of the session's chat history live from the daemon recorded on the session; 503 if that daemon is unknown or offline.",
           operationId: 'getSessionMessages',
           params: IdParam,
           querystring: SessionHistoryQueryDto,
@@ -800,7 +801,7 @@ export function sessionRoutes(deps: HttpDeps) {
         if (!owned) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
         }
-        const { session, agent } = owned
+        const { session } = owned
         // Retention GC (#485): the daemon deleted this session's local content, so
         // there is provably nothing to proxy. Answer the empty page directly rather
         // than round-tripping to a daemon that would return the same thing — and
@@ -810,14 +811,14 @@ export function sessionRoutes(deps: HttpDeps) {
         if (session.contentPurgedAt) {
           return { sessionId: session.id, messages: [], nextCursor: null, liveCursor: null, liveMore: false }
         }
-        if (!agent.daemonId) {
+        if (!session.daemonId) {
           return reply
             .code(503)
-            .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
+            .send({ error: 'Service Unavailable', statusCode: 503, message: 'session has no recorded daemon' })
         }
 
         try {
-          const page = await deps.control.sessionHistory(agent.daemonId, {
+          const page = await deps.control.sessionHistory(session.daemonId, {
             agentId: session.agentId,
             sessionId: session.id,
             ...(req.query.cursor !== undefined ? { cursor: req.query.cursor } : {}),
@@ -847,10 +848,9 @@ export function sessionRoutes(deps: HttpDeps) {
       }
     )
 
-    // Full-body view: proxy one byte slice of a tool call's untruncated ToolBody
-    // JSON live from the owning daemon (resolved from SessionMeta, same as /messages).
-    // The console pages by offset until nextOffset is null. 503 if the agent is
-    // unplaced or its daemon is offline.
+    // Full-body view follows the same immutable session-content owner as history.
+    // The console pages by offset until nextOffset is null. 503 if the recorded
+    // daemon is unknown or offline.
     r.get(
       '/sessions/:id/tool-body',
       {
@@ -858,7 +858,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get a tool-call body',
           description:
-            "Proxies one byte slice of a tool call's untruncated ToolBody JSON live from the owning daemon; the console pages by offset until nextOffset is null. 503 if the agent is unplaced or its daemon is offline.",
+            "Proxies one byte slice of a tool call's untruncated ToolBody JSON live from the daemon recorded on the session; the console pages by offset until nextOffset is null. 503 if that daemon is unknown or offline.",
           operationId: 'getSessionToolBody',
           params: IdParam,
           querystring: SessionToolBodyQueryDto,
@@ -870,15 +870,15 @@ export function sessionRoutes(deps: HttpDeps) {
         if (!owned) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
         }
-        const { session, agent } = owned
-        if (!agent.daemonId) {
+        const { session } = owned
+        if (!session.daemonId) {
           return reply
             .code(503)
-            .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
+            .send({ error: 'Service Unavailable', statusCode: 503, message: 'session has no recorded daemon' })
         }
 
         try {
-          const chunk = await deps.control.sessionToolBody(agent.daemonId, {
+          const chunk = await deps.control.sessionToolBody(session.daemonId, {
             agentId: session.agentId,
             sessionId: session.id,
             toolCallId: req.query.toolCallId,

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -830,7 +830,10 @@ export class PgSessionRepo implements SessionRepo {
           "session_meta"."permissionMode"
         ),
         "outputMode" = COALESCE(EXCLUDED."outputMode", "session_meta"."outputMode"),
-        "daemonId" = COALESCE(EXCLUDED."daemonId", "session_meta"."daemonId"),
+        -- Content ownership is pinned by the first authenticated daemon that
+        -- reports the session. A later milestone must not move daemon-local
+        -- transcript/worktree provenance when the agent itself is reassigned.
+        "daemonId" = COALESCE("session_meta"."daemonId", EXCLUDED."daemonId"),
         "workspaceIsolation" = COALESCE(
           EXCLUDED."workspaceIsolation",
           "session_meta"."workspaceIsolation"

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -31,6 +31,7 @@ afterEach(async () => {
 })
 
 const DAEMON = 'd0d0d0d0-dddd-4ddd-8ddd-dddddddddddd'
+const OTHER_DAEMON = 'e0e0e0e0-eeee-4eee-8eee-eeeeeeeeeeee'
 const AGENT = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const SESSION = '50505050-5555-4555-8555-555555555555'
 
@@ -59,11 +60,12 @@ class SpyControl {
 
 const emptyHist: SessionHistoryPage = { sessionId: SESSION, messages: [] }
 
-async function seedSession(agentId = AGENT): Promise<void> {
+async function seedSession(agentId = AGENT, daemonId?: string): Promise<void> {
   await prisma.sessionMeta.create({
     data: {
       id: SESSION,
       agentId,
+      ...(daemonId ? { daemonId } : {}),
       orgId: DEFAULT_ORG_ID,
       platform: 'slack',
       channel: '#deploys',
@@ -563,11 +565,11 @@ describe('GET /sessions (metadata list from CP DB)', () => {
   })
 })
 
-describe('GET /sessions/:id/messages (history pull via the owning agent)', () => {
-  it('resolves the owner from SessionMeta and proxies a page', async () => {
+describe('GET /sessions/:id/messages (history pull via the session daemon)', () => {
+  it('resolves the content owner from SessionMeta and proxies a page', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT, { daemonId: DAEMON })
-    await seedSession()
+    await seedSession(AGENT, DAEMON)
     const spy = new SpyControl(
       { sessions: [] },
       {
@@ -633,18 +635,33 @@ describe('GET /sessions/:id/messages (history pull via the owning agent)', () =>
     expect(res.statusCode).toBe(404)
   })
 
-  it('503s when the agent is unplaced (no live daemon)', async () => {
-    await seedAgent(prisma, AGENT) // no daemonId
+  it('reads from the recorded daemon after the agent moves elsewhere', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, OTHER_DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: OTHER_DAEMON })
+    await seedSession(AGENT, DAEMON)
+    const spy = new SpyControl({ sessions: [] }, emptyHist)
+    running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
+
+    expect(res.statusCode).toBe(200)
+    expect(spy.histCalls).toEqual([{ daemonId: DAEMON, req: { agentId: AGENT, sessionId: SESSION, limit: 50 } }])
+  })
+
+  it('503s when legacy session metadata has no recorded daemon', async () => {
+    await seedAgent(prisma, AGENT)
     await seedSession()
     running = buildHttpApp(prisma)
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
     expect(res.statusCode).toBe(503)
+    expect(res.json()).toMatchObject({ message: 'session has no recorded daemon' })
   })
 
   it('503s when the owning daemon is offline (NoConnection → 503)', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT, { daemonId: DAEMON })
-    await seedSession()
+    await seedSession(AGENT, DAEMON)
     const offline = new ControlSender(
       { get: () => undefined } as unknown as ConstructorParameters<typeof ControlSender>[0],
       { currentLaunch: async () => undefined } as unknown as ConstructorParameters<typeof ControlSender>[1]

--- a/packages/control-plane/test/repo/session.repo.test.ts
+++ b/packages/control-plane/test/repo/session.repo.test.ts
@@ -176,6 +176,18 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     expect(got?.daemonId).toBe(DAEMON)
   })
 
+  it('keeps the first reporting daemon as the immutable content owner', async () => {
+    await fixtures()
+    await seedDaemon(prisma, OTHER_DAEMON)
+    const repo = new PgSessionRepo(prisma)
+
+    await repo.recordMilestone(ev('start', { daemonId: DaemonId(DAEMON) }))
+    await repo.recordMilestone(ev('end', { daemonId: DaemonId(OTHER_DAEMON) }))
+
+    const row = await prisma.sessionMeta.findUnique({ where: { id: SESSION } })
+    expect(row?.daemonId).toBe(DAEMON)
+  })
+
   it('keeps the recorded execution config when a later milestone omits it', async () => {
     await fixtures()
     const repo = new PgSessionRepo(prisma)

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -65,7 +65,7 @@ import { NotFound } from '@/components/console/NotFound'
 import { Avatar, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 import { formatTranscriptRowTime, transcriptRowTimeMs } from '@/lib/transcript-time'
-import { sessionResumeState } from '@/lib/session-resume'
+import { sessionResumeMembers, sessionResumeState } from '@/lib/session-resume'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { consoleKeys } from '@/lib/swr-keys'
 import { sessionAttributionAgentAuthors, sessionAttributionAgentId, sessionSenderLabel } from '@/lib/session-trigger'
@@ -1349,9 +1349,10 @@ export default function SessionDetailView() {
       : sessionMerged
   // Session mode: does this session belong to a multi-participant conversation?
   // One bounded resolver probe per detail view (same SWR cache family as
-  // conversation mode); a hit redirects to the merged page (§5.3).
+  // conversation mode). A normal route redirects on a hit (§5.3); the diagnostic
+  // flat route stays put but still needs the full roster for safe resume gating.
   const selfKey = useMemo(() => {
-    if (flatView || conversationKey || !currentSessionDetail || currentSessionDetail.platform === 'playground') {
+    if (conversationKey || !currentSessionDetail || currentSessionDetail.platform === 'playground') {
       return null
     }
     return encodeConversationKey({
@@ -1360,8 +1361,8 @@ export default function SessionDetailView() {
       channel: currentSessionDetail.channel,
       thread: currentSessionDetail.thread
     })
-  }, [flatView, conversationKey, currentSessionDetail])
-  const { data: selfConversation } = useSWR(
+  }, [conversationKey, currentSessionDetail])
+  const { data: selfConversation, isLoading: selfConversationLoading } = useSWR(
     selfKey && activeOrg?.id ? (['conversation-by-key', activeOrg.id, selfKey] as const) : null,
     ([, orgId, key]) => fetchConversationByKey(key, orgId),
     { revalidateOnFocus: false }
@@ -2129,12 +2130,20 @@ export default function SessionDetailView() {
   const currentDaemonByAgent = new Map(
     agents.map((agent) => [agent.id, agent.daemon === '—' ? undefined : agent.daemon])
   )
+  const resumeConversationMembers = conversationKey ? conversationMembers : selfConversation?.sessions
+  const resumeConversationLookupPending = conversationKey
+    ? conversationLoading
+    : Boolean(selfKey && selfConversationLoading)
+  const resumeConversationLookupRequired = Boolean(conversationKey || selfKey)
   const persistedResumeMembers = isWebchat
-    ? conversationMembers
-      ? conversationMembers.map((member) => ({ agentId: member.agentId, daemonId: member.daemonId }))
-      : currentSessionDetail
-        ? [{ agentId: currentSessionDetail.agentId, daemonId: currentSessionDetail.daemonId }]
-        : null
+    ? sessionResumeMembers(
+        resumeConversationMembers?.map((member) => ({ agentId: member.agentId, daemonId: member.daemonId })),
+        currentSessionDetail
+          ? { agentId: currentSessionDetail.agentId, daemonId: currentSessionDetail.daemonId }
+          : null,
+        resumeConversationLookupRequired,
+        resumeConversationLookupPending
+      )
     : []
   const resumeState = isPg ? 'available' : sessionResumeState(persistedResumeMembers, currentDaemonByAgent)
   const resumeDisabled = isWebchat && resumeState !== 'available'

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -65,6 +65,7 @@ import { NotFound } from '@/components/console/NotFound'
 import { Avatar, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 import { formatTranscriptRowTime, transcriptRowTimeMs } from '@/lib/transcript-time'
+import { sessionResumeState } from '@/lib/session-resume'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { consoleKeys } from '@/lib/swr-keys'
 import { sessionAttributionAgentAuthors, sessionAttributionAgentId, sessionSenderLabel } from '@/lib/session-trigger'
@@ -2125,6 +2126,18 @@ export default function SessionDetailView() {
   const channelDisplay = sessionChannelDisplay(session, (id) => crons.find((c) => c.id === id)?.name)
   const usesIntegrationAvatar = session.platform === 'hook' && sessionIntegration === 'github'
   const isLive = isPg || isWebchat
+  const currentDaemonByAgent = new Map(
+    agents.map((agent) => [agent.id, agent.daemon === '—' ? undefined : agent.daemon])
+  )
+  const persistedResumeMembers = isWebchat
+    ? conversationMembers
+      ? conversationMembers.map((member) => ({ agentId: member.agentId, daemonId: member.daemonId }))
+      : currentSessionDetail
+        ? [{ agentId: currentSessionDetail.agentId, daemonId: currentSessionDetail.daemonId }]
+        : null
+    : []
+  const resumeState = isPg ? 'available' : sessionResumeState(persistedResumeMembers, currentDaemonByAgent)
+  const resumeDisabled = isWebchat && resumeState !== 'available'
   // Composer state is per-session in the provider — bind it to THIS session's id so a
   // different live conversation streaming in the background can't disable or clear it.
   const pgBusy = sessionBusy
@@ -2166,6 +2179,12 @@ export default function SessionDetailView() {
       ).map((p) => ({ ...p, name: rosterParticipantName(p, agentById.get(p.agentId)) }))
     : []
   const multiLive = liveRoster.length > 1
+  const resumePlaceholder =
+    resumeState === 'checking'
+      ? 'Checking whether this conversation can continue…'
+      : multiLive
+        ? 'This conversation can’t continue because one or more agents moved to another daemon.'
+        : 'This conversation can’t continue because the agent moved to another daemon.'
 
   // Resume the webchat conversation by its id (session.channelId == the conversationId);
   // a synthetic playground turn omits it (the CP mints a fresh id).
@@ -3347,12 +3366,22 @@ export default function SessionDetailView() {
                   Details popover, not here. */}
                 <div
                   className="relative min-w-0 rounded-[11px] border border-(--border-default) bg-(--surface-card) shadow-(--shadow-xs) transition-[border-color,box-shadow] focus-within:border-(--brand) focus-within:[box-shadow:0_0_0_3px_var(--brand-ring)]"
+                  inert={resumeDisabled}
+                  aria-disabled={resumeDisabled}
                   onKeyDown={(event) => {
                     if (event.key !== 'Escape') return
                     setAttachMenuOpen(false)
                     setComposerMenuOpen(null)
                   }}
                 >
+                  {resumeDisabled && (
+                    <textarea
+                      className="absolute inset-0 z-10 block h-full min-h-[92px] w-full resize-none rounded-[10px] border-0 bg-(--surface-sunken) px-[15px] py-[13px] font-sans text-[14px] font-normal leading-[1.55] text-(--text-tertiary) outline-none placeholder:text-(--text-tertiary) disabled:cursor-not-allowed"
+                      aria-label="Conversation unavailable"
+                      placeholder={resumePlaceholder}
+                      disabled
+                    />
+                  )}
                   <input
                     ref={imageInputRef}
                     type="file"

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2190,9 +2190,8 @@ export function putSessionExternalAccess(
   return apiPut<SessionExternalAccessDto>(`${orgBase(orgId)}/session-access/${provider}`, { enabled })
 }
 
-// One page of a session's transcript, proxied live from the owning daemon. The
-// CP resolves the owner and daemon from its SessionMeta row; 503 if that daemon
-// is offline or the owning agent is unplaced.
+// One page of a session's transcript, proxied live from the daemon recorded on
+// SessionMeta. Content ownership stays pinned there when the agent moves.
 export async function fetchSessionMessages(
   sessionId: string,
   options: { cursor?: string; after?: string; limit?: number } = {}

--- a/packages/web/src/lib/session-resume.test.ts
+++ b/packages/web/src/lib/session-resume.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sessionResumeState } from './session-resume'
+import { sessionResumeMembers, sessionResumeState } from './session-resume'
 
 describe('sessionResumeState', () => {
   const placements = new Map([
@@ -30,5 +30,26 @@ describe('sessionResumeState', () => {
 
   it('reports checking while detail metadata is loading', () => {
     expect(sessionResumeState(null, placements)).toBe('checking')
+  })
+
+  it('checks every conversation member on a flat session route', () => {
+    const selected = { agentId: 'agent-a', daemonId: 'daemon-1' }
+    const members = sessionResumeMembers(
+      [selected, { agentId: 'agent-b', daemonId: 'daemon-old' }],
+      selected,
+      true,
+      false
+    )
+
+    expect(sessionResumeState(members, placements)).toBe('unavailable')
+  })
+
+  it('fails closed while flat-route conversation membership is loading', () => {
+    expect(sessionResumeMembers(undefined, { agentId: 'agent-a', daemonId: 'daemon-1' }, true, true)).toBeNull()
+  })
+
+  it('stays unavailable when a required conversation lookup fails', () => {
+    const members = sessionResumeMembers(undefined, { agentId: 'agent-a', daemonId: 'daemon-1' }, true, false)
+    expect(sessionResumeState(members, placements)).toBe('unavailable')
   })
 })

--- a/packages/web/src/lib/session-resume.test.ts
+++ b/packages/web/src/lib/session-resume.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { sessionResumeState } from './session-resume'
+
+describe('sessionResumeState', () => {
+  const placements = new Map([
+    ['agent-a', 'daemon-1'],
+    ['agent-b', 'daemon-2']
+  ])
+
+  it('allows resume while every agent remains on its session daemon', () => {
+    expect(
+      sessionResumeState(
+        [
+          { agentId: 'agent-a', daemonId: 'daemon-1' },
+          { agentId: 'agent-b', daemonId: 'daemon-2' }
+        ],
+        placements
+      )
+    ).toBe('available')
+  })
+
+  it('disables resume after an agent moves', () => {
+    expect(sessionResumeState([{ agentId: 'agent-a', daemonId: 'daemon-old' }], placements)).toBe('unavailable')
+  })
+
+  it('fails closed for missing session ownership or current placement', () => {
+    expect(sessionResumeState([{ agentId: 'agent-a', daemonId: null }], placements)).toBe('unavailable')
+    expect(sessionResumeState([{ agentId: 'agent-c', daemonId: 'daemon-3' }], placements)).toBe('unavailable')
+  })
+
+  it('reports checking while detail metadata is loading', () => {
+    expect(sessionResumeState(null, placements)).toBe('checking')
+  })
+})

--- a/packages/web/src/lib/session-resume.ts
+++ b/packages/web/src/lib/session-resume.ts
@@ -1,0 +1,28 @@
+export type SessionResumeState = 'available' | 'checking' | 'unavailable'
+
+export interface SessionResumeMember {
+  agentId: string
+  /** Daemon that owns this session's local content. */
+  daemonId: string | null | undefined
+}
+
+/**
+ * A persisted conversation can resume only while every participating agent is
+ * still placed on the daemon that owns its session. Agent moves do not copy ACP
+ * state, transcripts, or worktrees to the new daemon.
+ *
+ * `null` members means session detail/roster metadata is still loading. Once the
+ * metadata is present, missing ownership or placement fails closed.
+ */
+export function sessionResumeState(
+  members: readonly SessionResumeMember[] | null,
+  currentDaemonByAgent: ReadonlyMap<string, string | undefined>
+): SessionResumeState {
+  if (members === null) return 'checking'
+  if (members.length === 0) return 'unavailable'
+  return members.every(
+    (member) => Boolean(member.daemonId) && currentDaemonByAgent.get(member.agentId) === member.daemonId
+  )
+    ? 'available'
+    : 'unavailable'
+}

--- a/packages/web/src/lib/session-resume.ts
+++ b/packages/web/src/lib/session-resume.ts
@@ -7,6 +7,24 @@ export interface SessionResumeMember {
 }
 
 /**
+ * Select the ownership rows used by the resume gate. A session route may still
+ * represent a multi-agent conversation (notably the diagnostic `view=flat`
+ * route), so resolved conversation membership takes precedence over the
+ * selected session. While that lookup is pending, fail closed.
+ */
+export function sessionResumeMembers(
+  conversationMembers: readonly SessionResumeMember[] | null | undefined,
+  currentSession: SessionResumeMember | null,
+  lookupRequired: boolean,
+  lookupPending: boolean
+): readonly SessionResumeMember[] | null {
+  if (lookupPending) return null
+  if (conversationMembers?.length) return conversationMembers
+  if (lookupRequired) return []
+  return currentSession ? [currentSession] : null
+}
+
+/**
  * A persisted conversation can resume only while every participating agent is
  * still placed on the daemon that owns its session. Agent moves do not copy ACP
  * state, transcripts, or worktrees to the new daemon.


### PR DESCRIPTION
## What changed

- pin each session's content ownership to the first authenticated daemon that reports it
- proxy transcript and tool-body reads to the session's recorded daemon instead of the agent's current placement
- disable persisted webchat resume when any participating agent has moved away from its session-owning daemon
- document the invariant and add route, repository, and UI-state regression coverage

## Why

Moving an agent does not copy daemon-local ACP state, transcripts, worktrees, or attachments. The session read routes followed the agent's current placement, so the destination daemon returned an empty transcript for sessions created on the source daemon. The webchat composer also remained available even though that historical ACP session could not be resumed on the new placement.

## Impact

Historical session transcripts remain readable from their creating daemon after an agent move. The console keeps those records visible while preventing an invalid resume attempt.

## Validation

- control-plane TypeScript check
- web TypeScript check and ESLint
- Prisma schema validation
- 30 focused control-plane integration tests
- 870 web tests
- formatting and diff checks