### PR TITLE
fix(daemon): show platform images in the session transcript

### DIFF
--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -77,14 +77,29 @@ function transcriptAttachments(raw: string | null | undefined): NonNullable<Sess
   }
 }
 
-/** The persisted text keeps this synthetic suffix for prompt replay; the console
- * receives the real image instead, matching the live turn. The label is matched by
- * shape, not rebuilt from the attachment: the row may have been written by the
- * observer before a download settled the real image type (a Feishu image event
- * declares none), or the message may have carried files the transcript can't inline. */
+/**
+ * The persisted text keeps a synthetic `[attached: name (mimeType), …]` suffix for
+ * prompt replay, listing EVERY file on the message; the console instead receives the
+ * one image the daemon inlined. Drop only that image's entry and keep the rest as
+ * their label, so a second image, an over-cap image, or a plain file stays visible.
+ *
+ * Entries are matched on the name, not rebuilt from the attachment: the row may have
+ * been written by the observer before a download settled the real image type (a
+ * Feishu image event declares none). Nothing recognized ⇒ the row is left alone.
+ */
 function withoutAttachmentMention(text: string, attachments: NonNullable<SessionMessage['attachments']>): string {
   if (attachments.length === 0) return text
-  return text.replace(/(?:^|\n)\[attached: [^\]\n]*\]$/, '').trim()
+  const label = /(?:^|\n)\[attached: ([^\]\n]*)\]$/.exec(text)
+  if (!label) return text
+  let list = label[1]!
+  for (const { name } of attachments) {
+    const entry = new RegExp(`(, )?${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} \\([^()]*\\)(, )?`).exec(list)
+    if (entry)
+      list = list.slice(0, entry.index) + (entry[1] && entry[2] ? ', ' : '') + list.slice(entry.index + entry[0].length)
+  }
+  if (list === label[1]) return text
+  const head = text.slice(0, label.index).trimEnd()
+  return (list ? `${head}\n[attached: ${list}]` : head).trim()
 }
 
 /** Largest index ≤ `len` that lands on a UTF-8 character boundary — never cuts a

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -78,13 +78,13 @@ function transcriptAttachments(raw: string | null | undefined): NonNullable<Sess
 }
 
 /** The persisted text keeps this synthetic suffix for prompt replay; the console
- * receives the real image instead, matching the live turn. */
+ * receives the real image instead, matching the live turn. The label is matched by
+ * shape, not rebuilt from the attachment: the row may have been written by the
+ * observer before a download settled the real image type (a Feishu image event
+ * declares none), or the message may have carried files the transcript can't inline. */
 function withoutAttachmentMention(text: string, attachments: NonNullable<SessionMessage['attachments']>): string {
   if (attachments.length === 0) return text
-  const mention = `[attached: ${attachments.map((attachment) => `${attachment.name} (${attachment.mimeType})`).join(', ')}]`
-  if (text === mention) return ''
-  const suffix = `\n${mention}`
-  return text.endsWith(suffix) ? text.slice(0, -suffix.length) : text
+  return text.replace(/(?:^|\n)\[attached: [^\]\n]*\]$/, '').trim()
 }
 
 /** Largest index ≤ `len` that lands on a UTF-8 character boundary — never cuts a

--- a/packages/daemon/src/session/attachment-block.ts
+++ b/packages/daemon/src/session/attachment-block.ts
@@ -1,7 +1,6 @@
 import type { ContentBlock } from '@agentclientprotocol/sdk'
 import {
   SessionImageAttachment as SessionImageAttachmentSchema,
-  WEBCHAT_IMAGE_MAX_BYTES,
   type SessionImageAttachment
 } from '@agentconnect.md/protocol'
 import type { Attachment } from '../messages/normalized.js'
@@ -85,27 +84,56 @@ export async function buildAttachmentBlocks(attachments: Attachment[], deps: Att
   )
 }
 
+/** The transcript-renderable formats, identified from their magic bytes. A declared
+ *  MIME type is not enough to decide: Feishu's `im.message.receive_v1` image event
+ *  carries only an `image_key`, so normalization types it `application/octet-stream`
+ *  (feishu-message.ts). Sniffing also corrects a provider that declares the wrong
+ *  format — the console renders these bytes directly, so the label has to be true. */
+export function sniffImageMimeType(bytes: Buffer): SessionImageAttachment['mimeType'] | undefined {
+  if (bytes.subarray(0, 8).equals(Buffer.from('89504e470d0a1a0a', 'hex'))) return 'image/png'
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return 'image/jpeg'
+  const riff = bytes.subarray(0, 12)
+  if (
+    riff.length === 12 &&
+    riff.subarray(0, 4).toString('latin1') === 'RIFF' &&
+    riff.subarray(8).toString('latin1') === 'WEBP'
+  )
+    return 'image/webp'
+  return undefined
+}
+
 /**
- * Fetch the bytes of the first inline-able image so its transcript row can carry
- * it for console replay. Webchat images arrive inline already; a platform
- * attachment (Slack/Telegram/Discord/Feishu) is only an auth-gated URL, so
- * without this the console can render nothing but the `[attached: …]` label.
- * The bytes are memoized onto the attachment, so `buildAttachmentBlocks` reuses
- * them and the turn still downloads the file exactly once.
+ * Fetch the bytes of the first candidate image so its transcript row can carry it
+ * for console replay. Webchat images arrive inline already; a platform attachment
+ * (Slack/Telegram/Discord/Feishu) is only an auth-gated URL, so without this the
+ * console can render nothing but the `[attached: …]` label. A provider that
+ * declares no usable type is settled by the bytes, and the corrected `mimeType`
+ * rides along so the mention, the transcript row and the ACP block all agree.
  *
- * ponytail: one image, capped at the daemon→CP history-frame ceiling
- * (WEBCHAT_IMAGE_MAX_BYTES). A bigger image (or a second one) keeps the label;
- * showing those needs chunked/off-frame image reads, not a bigger cap.
+ * The bytes are memoized onto the attachment, so `buildAttachmentBlocks` reuses
+ * them: one download serves the transcript and the prompt. `maxBytes` is the
+ * caller's prompt cap, mirroring `buildAttachmentBlocks`, so an over-cap file is
+ * skipped identically here; the tighter transcript ceiling is enforced by the
+ * `SessionImageAttachment` schema in `transcriptImageAttachments`.
+ *
+ * ponytail: one image per message. A second one keeps the label; showing more
+ * needs chunked/off-frame image reads, not a bigger cap.
  */
 export async function hydrateTranscriptImage(
   attachments: Attachment[] | undefined,
-  download: (att: Attachment) => Promise<Buffer | null>
+  deps: Pick<AttachmentDeps, 'download' | 'maxBytes'>
 ): Promise<void> {
-  const image = attachments?.find((att) => att.mimeType.startsWith('image/'))
+  const image = attachments?.find(
+    (att) => att.mimeType.startsWith('image/') || att.mimeType === 'application/octet-stream'
+  )
   if (!image || image.inlineData) return
-  if (typeof image.size === 'number' && image.size > WEBCHAT_IMAGE_MAX_BYTES) return
-  const bytes = await download(image).catch(() => null)
-  if (bytes && bytes.byteLength <= WEBCHAT_IMAGE_MAX_BYTES) image.inlineData = bytes
+  const cap = deps.maxBytes ?? Infinity
+  if (typeof image.size === 'number' && image.size > cap) return
+  const bytes = await deps.download(image).catch(() => null)
+  if (!bytes || bytes.byteLength > cap) return
+  image.inlineData = bytes
+  const sniffed = sniffImageMimeType(bytes)
+  if (sniffed) image.mimeType = sniffed
 }
 
 /** Keep a validated bounded inline image beside its daemon-local transcript row. */

--- a/packages/daemon/src/session/attachment-block.ts
+++ b/packages/daemon/src/session/attachment-block.ts
@@ -1,6 +1,7 @@
 import type { ContentBlock } from '@agentclientprotocol/sdk'
 import {
   SessionImageAttachment as SessionImageAttachmentSchema,
+  WEBCHAT_IMAGE_MAX_BYTES,
   type SessionImageAttachment
 } from '@agentconnect.md/protocol'
 import type { Attachment } from '../messages/normalized.js'
@@ -82,6 +83,29 @@ export async function buildAttachmentBlocks(attachments: Attachment[], deps: Att
       return attachmentToBlock(att, bytes, deps.supports)
     })
   )
+}
+
+/**
+ * Fetch the bytes of the first inline-able image so its transcript row can carry
+ * it for console replay. Webchat images arrive inline already; a platform
+ * attachment (Slack/Telegram/Discord/Feishu) is only an auth-gated URL, so
+ * without this the console can render nothing but the `[attached: …]` label.
+ * The bytes are memoized onto the attachment, so `buildAttachmentBlocks` reuses
+ * them and the turn still downloads the file exactly once.
+ *
+ * ponytail: one image, capped at the daemon→CP history-frame ceiling
+ * (WEBCHAT_IMAGE_MAX_BYTES). A bigger image (or a second one) keeps the label;
+ * showing those needs chunked/off-frame image reads, not a bigger cap.
+ */
+export async function hydrateTranscriptImage(
+  attachments: Attachment[] | undefined,
+  download: (att: Attachment) => Promise<Buffer | null>
+): Promise<void> {
+  const image = attachments?.find((att) => att.mimeType.startsWith('image/'))
+  if (!image || image.inlineData) return
+  if (typeof image.size === 'number' && image.size > WEBCHAT_IMAGE_MAX_BYTES) return
+  const bytes = await download(image).catch(() => null)
+  if (bytes && bytes.byteLength <= WEBCHAT_IMAGE_MAX_BYTES) image.inlineData = bytes
 }
 
 /** Keep a validated bounded inline image beside its daemon-local transcript row. */

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -13,7 +13,12 @@ import type { Agent } from '../agents/agent-schema.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import { stableTurnId, type Attachment, type NormalizedMessage } from '../messages/normalized.js'
 import { messageOrderingFor } from '../platforms/message-ordering.js'
-import { buildAttachmentBlocks, attachmentMention, transcriptImageAttachments } from './attachment-block.js'
+import {
+  buildAttachmentBlocks,
+  attachmentMention,
+  hydrateTranscriptImage,
+  transcriptImageAttachments
+} from './attachment-block.js'
 import { EXPLICIT_MENTION_REMINDER, NO_RESPONSE_RULE, NO_RESPONSE_REMINDER } from './no-response.js'
 
 /** Metadata-only semantic lifecycle for one provider-neutral recall attempt. Query
@@ -446,7 +451,13 @@ export class SessionManager {
     const transcriptChannel = transcriptChannelKey(msg.channel, transportScope)
 
     // record the triggering message in the transcript (with an attachment mention
-    // for prompt replay; bounded inline webchat images remain daemon-local for UI replay)
+    // for prompt replay; a bounded inline image stays daemon-local for UI replay).
+    // A platform image is only an auth-gated URL, so fetch it here — the bytes are
+    // memoized on the attachment and reused by the prompt blocks below (one fetch).
+    await hydrateTranscriptImage(
+      msg.attachments,
+      (att) => this.deps.downloadAttachment?.(agentId, att) ?? Promise.resolve(null)
+    )
     const mention = attachmentMention(msg.attachments)
     const transcriptAttachments = transcriptImageAttachments(msg.attachments)
     const transcriptText = mention ? `${msg.text}\n${mention}`.trim() : msg.text

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -454,10 +454,10 @@ export class SessionManager {
     // for prompt replay; a bounded inline image stays daemon-local for UI replay).
     // A platform image is only an auth-gated URL, so fetch it here — the bytes are
     // memoized on the attachment and reused by the prompt blocks below (one fetch).
-    await hydrateTranscriptImage(
-      msg.attachments,
-      (att) => this.deps.downloadAttachment?.(agentId, att) ?? Promise.resolve(null)
-    )
+    await hydrateTranscriptImage(msg.attachments, {
+      download: (att) => this.deps.downloadAttachment?.(agentId, att) ?? Promise.resolve(null),
+      ...(this.deps.attachmentMaxBytes !== undefined ? { maxBytes: this.deps.attachmentMaxBytes } : {})
+    })
     const mention = attachmentMention(msg.attachments)
     const transcriptAttachments = transcriptImageAttachments(msg.attachments)
     const transcriptText = mention ? `${msg.text}\n${mention}`.trim() : msg.text

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2915,6 +2915,19 @@ export class LocalStore {
             )
             .run(e.eventTimeUs, e.channel, e.thread, e.ts, e.eventTimeUs)
         : undefined
+    // The observer often wins the INSERT race against SessionManager's authoritative
+    // append, and only that append has fetched the image bytes — upgrade the row in
+    // place instead of leaving attachmentsJson pinned to NULL (the console would then
+    // show only the `[attached: …]` label).
+    const attachmentsUpgraded =
+      Number(inserted.changes) === 0 && attachments?.length
+        ? this.db
+            .prepare(
+              `UPDATE transcript SET attachmentsJson = ?
+               WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text' AND attachmentsJson IS NULL`
+            )
+            .run(JSON.stringify(attachments), e.channel, e.thread, e.ts)
+        : undefined
     // A later duplicate can be the first copy that carries provider reply metadata
     // (or a corrected selected passage). Upgrade it without ever clearing a quote when
     // a provider snapshot subsequently re-appends the same text row without metadata.
@@ -2942,6 +2955,7 @@ export class LocalStore {
       this.notifyTranscriptMutation(e.channel, e.thread, [e.sender, e.recipient], revision)
     } else if (
       Number(provenanceUpgraded?.changes ?? 0) === 1 ||
+      Number(attachmentsUpgraded?.changes ?? 0) === 1 ||
       Number(quoteUpgraded?.changes ?? 0) === 1 ||
       Number(postIdUpgraded?.changes ?? 0) === 1 ||
       Number(eventTimeUpgraded?.changes ?? 0) === 1 ||

--- a/packages/daemon/test/attachment-block.test.ts
+++ b/packages/daemon/test/attachment-block.test.ts
@@ -7,6 +7,7 @@ import {
   hydrateTranscriptImage,
   transcriptImageAttachments
 } from '../src/session/attachment-block.js'
+import { feishuEventToMessageLike, normalizeFeishuMessage } from '../src/feishu/normalize.js'
 import type { Attachment } from '../src/messages/normalized.js'
 
 const att = (over: Partial<Attachment> = {}): Attachment => ({
@@ -118,7 +119,7 @@ describe('hydrateTranscriptImage', () => {
     const bytes = Buffer.from('IMG')
     const download = vi.fn(async () => bytes)
     const attachments = [att({ size: bytes.length })]
-    await hydrateTranscriptImage(attachments, download)
+    await hydrateTranscriptImage(attachments, { download })
     expect(transcriptImageAttachments(attachments)).toEqual([
       { name: 'a.png', mimeType: 'image/png', data: bytes.toString('base64') }
     ])
@@ -127,25 +128,65 @@ describe('hydrateTranscriptImage', () => {
     expect(download).toHaveBeenCalledOnce()
   })
 
-  it('leaves an oversized or non-image attachment alone (label-only replay)', async () => {
-    const download = vi.fn(async () => Buffer.alloc(WEBCHAT_IMAGE_MAX_BYTES + 1))
-    const big = [att({ size: WEBCHAT_IMAGE_MAX_BYTES + 1 })]
-    await hydrateTranscriptImage(big, download)
+  it('carries a raw Feishu image event (no provider MIME) through to the transcript', async () => {
+    // Feishu's im.message.receive_v1 image event has only an image_key, so
+    // normalization types it application/octet-stream — the bytes are what settle it.
+    const png = Buffer.concat([Buffer.from('89504e470d0a1a0a', 'hex'), Buffer.from('pixels')])
+    const msg = normalizeFeishuMessage(
+      feishuEventToMessageLike({
+        sender: { sender_id: { open_id: 'ou_1' }, sender_type: 'user' },
+        message: {
+          message_id: 'om_1',
+          chat_id: 'oc_1',
+          chat_type: 'p2p',
+          message_type: 'image',
+          content: JSON.stringify({ image_key: 'img_v3_abc' })
+        }
+      }),
+      { traceId: 't1' }
+    )
+    const attachments = msg.attachments as Attachment[]
+    expect(attachments[0]).toMatchObject({ mimeType: 'application/octet-stream', sourceUrl: 'om_1:image:img_v3_abc' })
+
+    const download = vi.fn(async () => png)
+    await hydrateTranscriptImage(attachments, { download })
+    expect(transcriptImageAttachments(attachments)).toEqual([
+      { name: 'img_v3_abc', mimeType: 'image/png', data: png.toString('base64') }
+    ])
+    // The corrected type also unlocks the inline ACP image block (it was a
+    // resource_link while the attachment claimed application/octet-stream).
+    const blocks = await buildAttachmentBlocks(attachments, { download, supports: supportsAll })
+    expect(blocks[0]).toEqual({ type: 'image', data: png.toString('base64'), mimeType: 'image/png' })
+    expect(download).toHaveBeenCalledOnce()
+  })
+
+  it('skips a declared non-image and a file over the caller’s cap', async () => {
+    const download = vi.fn(async () => Buffer.from('IMG'))
+    const big = [att({ size: 9_000 })]
+    await hydrateTranscriptImage(big, { download, maxBytes: 8_000 })
     expect(download).not.toHaveBeenCalled() // known size over the cap ⇒ never fetched
     const doc = [att({ name: 'd.pdf', mimeType: 'application/pdf' })]
-    await hydrateTranscriptImage(doc, download)
+    await hydrateTranscriptImage(doc, { download })
     expect(download).not.toHaveBeenCalled()
-    // A file whose size the platform did not report is fetched, then rejected by size.
-    const unknown = [att()]
-    await hydrateTranscriptImage(unknown, download)
+  })
+
+  it('memoizes an image too big for the transcript, so the prompt still fetches once', async () => {
+    // No reported size (Feishu never reports one), bytes over the transcript ceiling:
+    // the schema drops it from the transcript, but the download must not repeat.
+    const download = vi.fn(async () => Buffer.alloc(WEBCHAT_IMAGE_MAX_BYTES + 1))
+    const attachments = [att()]
+    await hydrateTranscriptImage(attachments, { download })
+    expect(transcriptImageAttachments(attachments)).toEqual([])
+    await buildAttachmentBlocks(attachments, { download, supports: supportsAll })
     expect(download).toHaveBeenCalledOnce()
-    expect(transcriptImageAttachments(unknown)).toEqual([])
   })
 
   it('survives a failed download', async () => {
     const attachments = [att()]
-    await hydrateTranscriptImage(attachments, async () => {
-      throw new Error('network')
+    await hydrateTranscriptImage(attachments, {
+      download: async () => {
+        throw new Error('network')
+      }
     })
     expect(transcriptImageAttachments(attachments)).toEqual([])
   })

--- a/packages/daemon/test/attachment-block.test.ts
+++ b/packages/daemon/test/attachment-block.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
-import { attachmentToBlock, buildAttachmentBlocks, attachmentMention } from '../src/session/attachment-block.js'
+import { WEBCHAT_IMAGE_MAX_BYTES } from '@agentconnect.md/protocol'
+import {
+  attachmentToBlock,
+  buildAttachmentBlocks,
+  attachmentMention,
+  hydrateTranscriptImage,
+  transcriptImageAttachments
+} from '../src/session/attachment-block.js'
 import type { Attachment } from '../src/messages/normalized.js'
 
 const att = (over: Partial<Attachment> = {}): Attachment => ({
@@ -103,6 +110,44 @@ describe('buildAttachmentBlocks', () => {
       supports: supportsAll
     })
     expect(blocks[0]).toMatchObject({ type: 'resource_link' })
+  })
+})
+
+describe('hydrateTranscriptImage', () => {
+  it('fetches a platform image once and memoizes it for the prompt blocks', async () => {
+    const bytes = Buffer.from('IMG')
+    const download = vi.fn(async () => bytes)
+    const attachments = [att({ size: bytes.length })]
+    await hydrateTranscriptImage(attachments, download)
+    expect(transcriptImageAttachments(attachments)).toEqual([
+      { name: 'a.png', mimeType: 'image/png', data: bytes.toString('base64') }
+    ])
+    // The prompt build reuses the memoized bytes rather than downloading again.
+    await buildAttachmentBlocks(attachments, { download, supports: supportsAll })
+    expect(download).toHaveBeenCalledOnce()
+  })
+
+  it('leaves an oversized or non-image attachment alone (label-only replay)', async () => {
+    const download = vi.fn(async () => Buffer.alloc(WEBCHAT_IMAGE_MAX_BYTES + 1))
+    const big = [att({ size: WEBCHAT_IMAGE_MAX_BYTES + 1 })]
+    await hydrateTranscriptImage(big, download)
+    expect(download).not.toHaveBeenCalled() // known size over the cap ⇒ never fetched
+    const doc = [att({ name: 'd.pdf', mimeType: 'application/pdf' })]
+    await hydrateTranscriptImage(doc, download)
+    expect(download).not.toHaveBeenCalled()
+    // A file whose size the platform did not report is fetched, then rejected by size.
+    const unknown = [att()]
+    await hydrateTranscriptImage(unknown, download)
+    expect(download).toHaveBeenCalledOnce()
+    expect(transcriptImageAttachments(unknown)).toEqual([])
+  })
+
+  it('survives a failed download', async () => {
+    const attachments = [att()]
+    await hydrateTranscriptImage(attachments, async () => {
+      throw new Error('network')
+    })
+    expect(transcriptImageAttachments(attachments)).toEqual([])
   })
 })
 

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1110,6 +1110,36 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
     await daemon.stop()
   }, 15_000)
 
+  it('keeps a shared Slack image on its transcript row so the console can replay it', async () => {
+    // Slack hands out an auth-gated file URL, so the row can only carry the image if the
+    // daemon fetches it — without that the console showed just `[attached: …]`. The fetch
+    // is independent of the agent's image capability (quietHost advertises none).
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    await daemon.start()
+    const conn = makeRoutable(daemon) as any
+    const bytes = Buffer.from('PNGBYTES')
+    conn.downloadFile = vi.fn(async () => bytes)
+
+    await (daemon as any).dispatch(
+      'bot-a',
+      {
+        ...dm('100', 'look at this'),
+        attachments: [{ id: 'F1', name: 'shot.png', mimeType: 'image/png', size: bytes.length, sourceUrl: 'u' }]
+      },
+      'int-a'
+    )
+
+    const rows = (daemon as any).store.transcriptSince(transcriptChannelKey('C1', TRANSPORT_SCOPE), 'T1', null)
+    const row = rows.find((r: any) => r.sender === 'U1')
+    expect(row.text).toBe('look at this\n[attached: shot.png (image/png)]')
+    expect(JSON.parse(row.attachmentsJson)).toEqual([
+      { name: 'shot.png', mimeType: 'image/png', data: bytes.toString('base64') }
+    ])
+    expect(conn.downloadFile).toHaveBeenCalledOnce() // one fetch serves transcript + prompt
+
+    await daemon.stop()
+  }, 15_000)
+
   it('backfill preserves a remote agent author carried by an HTTP Slack bot', async () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
     await daemon.start()

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -1457,6 +1457,29 @@ describe('LocalStore webchat MCP grant ledger', () => {
     const after = s.transcriptSince('C1', 'T', null)[0] as { eventTimeUs?: number }
     expect(after.eventTimeUs).toBe(1_754_123_458_000_000)
   })
+
+  it('a later append with the fetched image upgrades the observer-written row', () => {
+    // The observer records a platform message before the bytes are downloaded, so the
+    // authoritative append is INSERT-OR-IGNOREd — without an in-place upgrade the row's
+    // attachmentsJson stays NULL and the console shows only the `[attached: …]` label.
+    const s = store()
+    const text = 'look\n[attached: shot.png (image/png)]'
+    s.appendTranscript({ channel: 'C1', thread: 'T', ts: '99', sender: 'U1', kind: 'text', text })
+    s.appendTranscript({
+      channel: 'C1',
+      thread: 'T',
+      ts: '99',
+      sender: 'U1',
+      kind: 'text',
+      text,
+      attachments: [{ name: 'shot.png', mimeType: 'image/png', data: 'aW1n' }]
+    })
+    const row = s.transcriptSince('C1', 'T', null)[0] as { attachmentsJson?: string | null }
+    expect(JSON.parse(row.attachmentsJson ?? 'null')).toEqual([
+      { name: 'shot.png', mimeType: 'image/png', data: 'aW1n' }
+    ])
+    s.close()
+  })
 })
 
 describe('LocalStore activation rendezvous (send-message-routing-rework.md §3.2/§8.6)', () => {

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -412,6 +412,52 @@ describe('SessionReader', () => {
     s.close()
   })
 
+  it('keeps the label for files it could not inline beside the one image it did', () => {
+    // Only the first small image is stored; the PDF and the over-cap second image must
+    // still be visible as their labels rather than vanishing with the whole suffix.
+    const s = store()
+    seedHistorySession(s)
+    s.appendTranscript({
+      channel: 'C1',
+      thread: 'T1',
+      ts: '1',
+      sender: 'U1',
+      recipient: AGENT,
+      kind: 'text',
+      text: 'review these\n[attached: small.png (image/png), report, final.pdf (application/pdf), huge.png (image/png)]',
+      attachments: [{ name: 'small.png', mimeType: 'image/png', data: 'aW1hZ2U=' }]
+    })
+
+    expect(createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+      // The comma inside `report, final.pdf` is part of the file NAME, not a separator.
+      expect.objectContaining({
+        text: 'review these\n[attached: report, final.pdf (application/pdf), huge.png (image/png)]',
+        attachments: [{ name: 'small.png', mimeType: 'image/png', data: 'aW1hZ2U=' }]
+      })
+    ])
+    s.close()
+  })
+
+  it('leaves the row alone when the label names nothing the attachment matches', () => {
+    const s = store()
+    seedHistorySession(s)
+    s.appendTranscript({
+      channel: 'C1',
+      thread: 'T1',
+      ts: '1',
+      sender: 'U1',
+      recipient: AGENT,
+      kind: 'text',
+      text: 'see\n[attached: other.pdf (application/pdf)]',
+      attachments: [{ name: 'shot.png', mimeType: 'image/png', data: 'aW1hZ2U=' }]
+    })
+
+    expect(createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+      expect.objectContaining({ text: 'see\n[attached: other.pdf (application/pdf)]' })
+    ])
+    s.close()
+  })
+
   it('carries daemon-verified Slack bot provenance to the session DTO', () => {
     const s = store()
     seedHistorySession(s)

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -387,6 +387,31 @@ describe('SessionReader', () => {
     s.close()
   })
 
+  it('strips a label the row does not literally agree with (observer wrote it pre-download)', () => {
+    // recordObservedInbound recorded the Feishu label before any download settled the
+    // type, so the row says application/octet-stream while the stored image is a PNG.
+    const s = store()
+    seedHistorySession(s, { platform: 'feishu', channel: 'oc_1', thread: 'oc_1' })
+    s.appendTranscript({
+      channel: 'oc_1',
+      thread: 'oc_1',
+      ts: '1',
+      sender: 'ou_1',
+      recipient: AGENT,
+      kind: 'text',
+      text: 'look\n[attached: img_v3_abc (application/octet-stream)]',
+      attachments: [{ name: 'img_v3_abc', mimeType: 'image/png', data: 'aW1hZ2U=' }]
+    })
+
+    expect(createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+      expect.objectContaining({
+        text: 'look',
+        attachments: [{ name: 'img_v3_abc', mimeType: 'image/png', data: 'aW1hZ2U=' }]
+      })
+    ])
+    s.close()
+  })
+
   it('carries daemon-verified Slack bot provenance to the session DTO', () => {
     const s = store()
     seedHistorySession(s)


### PR DESCRIPTION
## Problem

An image shared through the Slack integration rendered in the console session page as bare text:

```
[attached: image.png (image/png), image.png (image/png)]
```

Webchat images render properly, so the console side already works — the gap is daemon-side. A webchat image arrives as bounded inline bytes, but a Slack/Telegram/Discord/Feishu attachment is only an auth-gated URL. `transcriptImageAttachments()` requires `attachment.inlineData`, so the transcript row's `attachmentsJson` stayed NULL, and `SessionReader` could then neither strip the `[attached: …]` prompt-replay suffix nor hand the console an image.

## What changed

- **`session/attachment-block.ts`** — new `hydrateTranscriptImage()`: fetch the first inline-able image and memoize the bytes onto the attachment. `buildAttachmentBlocks()` already prefers `inlineData`, so the turn still downloads the file exactly once (asserted in the test).
- **`session/session-manager.ts`** — hydrate just before the transcript append, so the existing `transcriptImageAttachments` → `attachmentsJson` → session-reader path now covers platform attachments too.
- **`store/local-store.ts`** — upgrade `attachmentsJson` in place in `appendTranscript`, alongside the existing postId / eventTime / quote upgrades. The observer usually wins the INSERT race (recorded before any download happened) and `INSERT OR IGNORE` would drop the authoritative copy carrying the image — the same failure webchat fixed in #510 by putting the image on its admission write.

No protocol, CP, or web change: the console already renders `message.attachments[0]` (`SessionDetailView`).

## Reviewer notes

- **Bound:** `WEBCHAT_IMAGE_MAX_BYTES` (160 KiB) — the daemon→CP history-frame ceiling, since base64 expansion has to fit one 256 KiB frame. A larger image, or a second image on the same message, still degrades to the `[attached: …]` label; showing those needs chunked/off-frame image reads rather than a bigger constant. Marked with a `ponytail:` comment naming the ceiling and the upgrade path.
- **No extra download:** a file whose reported size already exceeds the cap is never fetched; a fetch failure is swallowed and degrades to the label.
- **Capability-independent:** the transcript image lands even when the agent advertises no image prompt capability (the test's host advertises none) — it is a console concern, not a prompt one.
- The Slack **thread-backfill** path (`fetchThreadHistory`) still produces label-only rows; it never had bytes and is out of scope here.

## Tests

- `test/attachment-block.test.ts` — one fetch shared by transcript + prompt blocks; over-cap / non-image / failed-download all degrade.
- `test/local-store.test.ts` — the observer-first race upgrades the row in place.
- `test/daemon-commands.test.ts` — end-to-end Slack DM with an image: the row carries the base64 and `downloadFile` is called once.

Full daemon suite passes (3005 tests). `daemon-agent-mention-routing.test.ts` timed out once under full-suite parallelism at its 5s budget and passes on its own (35/35) — load flake, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)