### PR TITLE
feat(evals): make Werewolf's day a natural sequential discussion, and measure where it dies

### DIFF
--- a/docs/designs/collaboration-arena-baseline.md
+++ b/docs/designs/collaboration-arena-baseline.md
@@ -51,23 +51,22 @@ Beyond that boundary, two things are substituted, both at the edges:
   model credentials**. The identical game runs against a real ACP runtime by
   passing a subject template; the engine seam is the same either way.
 
-### 1.1 The platform echo (peer-driven counting and quota counting only)
+### 1.1 The platform echo (every game except cross-room counting)
 
-In the **echo-enabled** games — peer-driven counting and quota counting — every
-delivered agent post fans back to the other members' connections under the
-author's **real managed bot identity**, as a streaming post under its own message
-id plus a response-closing `message_changed` edit under the same msgId,
-distinguished by `ingressEventTag` and carrying the daemon-stamped authorship
-claim. Whether an echo activates anyone is the **daemon's** decision; the harness
-never editorializes, and chatter echoes exactly like a valid move, because
-production echoes everything.
+In the **echo-enabled** games — peer-driven counting, quota counting, and
+Werewolf's day phase — every delivered agent post fans back to the other members'
+connections under the author's **real managed bot identity**, as a streaming post
+under its own message id plus a response-closing `message_changed` edit under the
+same msgId, distinguished by `ingressEventTag` and carrying the daemon-stamped
+authorship claim. Whether an echo activates anyone is the **daemon's** decision;
+the harness never editorializes, and chatter echoes exactly like a valid move,
+because production echoes everything.
 
-**Werewolf and cross-room counting do not install the echo.** Their phases are
-referee-driven: waves come from human-sourced referee broadcasts and
-`deliverRefereeEvent`, so a delivered agent post there does not fan back as a
-production-style inbound event. That is why those two games do not exercise
-implicit continuation, and why their conversations are bounded by the referee's
-cadence rather than by the hop cap.
+**Cross-room counting does not install the echo.** Its phases are referee-driven:
+waves come from human-sourced referee broadcasts and `deliverRefereeEvent`, so a
+delivered agent post there does not fan back as a production-style inbound event.
+That game therefore says nothing about implicit continuation, and its
+conversation is bounded by the referee's cadence rather than by the protections.
 
 ## 2. The four routing acceptance cases
 
@@ -119,11 +118,33 @@ and consecutive posts rather than policing them.
 
 ### 3.3 Werewolf (§10.3)
 
-Seven agents, seeded roles (2 werewolves, 1 seer, 1 doctor, 3 villagers), a
-public room, a **real private wolf den**, and per-player referee DMs. Public
-discussion is ordinary natural-language speech; game-state mutations
-(`vote`, `inspect`, `protect`, `kill`) go through the §6 evaluation tool registry
-as structured actions over the real MCP socket.
+Seven agents by default, seeded roles (2 werewolves, 1 seer, 1 doctor, villagers
+for the rest — the table scales past seven), a public room, a **real private wolf
+den**, and per-player referee DMs. Public discussion is ordinary natural-language
+speech; game-state mutations (`vote`, `inspect`, `protect`, `kill`) go through the
+§6 evaluation tool registry as structured actions over the real MCP socket.
+
+**The day phase is sequential and peer-driven.** The referee opens each day
+exactly once — deaths, living players, the speaking order, and the rule "speak
+only after the player before you has spoken" — and then says nothing until the
+order is finished or dead. Every step after that is carried by the players
+themselves: a speech is delivered, the platform echo fans it to the other
+members' connections, and the daemon's own routing ladder decides who wakes.
+**No one is nominated.** Speaker N+1 is woken by speaker N's ordinary message,
+which is exactly the PR #549 behavior — a verified agent-authored message naming
+nobody continues the conversation through the arbitration ladder. Players who are
+merely listening answer with the product's own `AC_NO_RESPONSE` silent branch, so
+a listening turn produces no room traffic (but still costs a turn — see §6.5).
+
+Measured per day and recorded in `game-result.json` / `world-events.jsonl`: the
+announced order, who actually spoke and in what order, who never got their turn,
+out-of-order speeches, what ended the round (`order_complete` / `stalled`), which
+players' loop-guard circuits latched, per-player peer-wake accounting
+(`admitted` / `gated` / `suppressed`), and whether the round reached the vote.
+
+The vote is unchanged: once the discussion completes or dies, the referee asks
+the living players for structured `vote` tool calls, and a vote attempted during
+discussion is rejected with `discussion_in_progress`.
 
 The registry enforces at the daemon: startup name-collision rejection (an
 evaluation tool may never shadow a product tool), a per-agent visibility
@@ -159,7 +180,7 @@ pnpm install
 pnpm build # protocol must be built before typecheck
 
 # the whole arena gate
-pnpm eval:collab:contracts # 15 files, 99 tests
+pnpm eval:collab:contracts # 15 files, 107 tests
 
 # the routing acceptance cases alone
 pnpm eval:collab:routing # routing-acceptance + connection-surface
@@ -172,6 +193,9 @@ npx vitest run evals/test/cross-room-counting.test.ts
 npx vitest run evals/test/game-runner.test.ts
 npx vitest run evals/test/routing-acceptance.test.ts
 
+# the sequential-discussion cases specifically
+npx vitest run evals/test/werewolf.test.ts -t "sequential discussion"
+
 # supporting suites
 pnpm eval:contracts # evidence schema, ATIF, permission, redaction
 pnpm eval:validate  # adapter/config validation + evals tsc
@@ -179,33 +203,126 @@ pnpm eval:validate  # adapter/config validation + evals tsc
 
 Full gate, measured on this branch:
 
-| Suite                                                  | Tests  |
-| ------------------------------------------------------ | ------ |
-| `evals/test/routing-acceptance.test.ts`                | 8      |
-| `evals/test/game-runner.test.ts`                       | 5      |
-| `evals/test/werewolf.test.ts`                          | 7      |
-| `evals/test/quota-counting.test.ts`                    | 8      |
-| `evals/test/cross-room-counting.test.ts`               | 6      |
-| `evals/test/counting.test.ts`                          | 11     |
-| `evals/test/world-authorization.test.ts`               | 10     |
-| `evals/test/collaboration-game-provider.test.ts`       | 9      |
-| `evals/test/game-result-assertion.test.ts`             | 7      |
-| `evals/test/game-subject.test.ts`                      | 6      |
-| `evals/test/connection-surface.test.ts`                | 5      |
-| `evals/test/topology.test.ts`                          | 5      |
-| `evals/test/virtual-connections.test.ts`               | 4      |
-| `packages/daemon/test/evaluation-game-ingress.test.ts` | 5      |
-| `packages/daemon/test/evaluation-game-tools.test.ts`   | 3      |
-| **Total**                                              | **99** |
+| Suite                                                  | Tests   |
+| ------------------------------------------------------ | ------- |
+| `evals/test/routing-acceptance.test.ts`                | 8       |
+| `evals/test/game-runner.test.ts`                       | 5       |
+| `evals/test/werewolf.test.ts`                          | 11      |
+| `evals/test/quota-counting.test.ts`                    | 8       |
+| `evals/test/cross-room-counting.test.ts`               | 6       |
+| `evals/test/counting.test.ts`                          | 11      |
+| `evals/test/world-authorization.test.ts`               | 10      |
+| `evals/test/collaboration-game-provider.test.ts`       | 9       |
+| `evals/test/game-result-assertion.test.ts`             | 7       |
+| `evals/test/game-subject.test.ts`                      | 10      |
+| `evals/test/connection-surface.test.ts`                | 5       |
+| `evals/test/topology.test.ts`                          | 5       |
+| `evals/test/virtual-connections.test.ts`               | 4       |
+| `packages/daemon/test/evaluation-game-ingress.test.ts` | 5       |
+| `packages/daemon/test/evaluation-game-tools.test.ts`   | 3       |
+| **Total**                                              | **107** |
 
 **0 expected-fail.** Every pin is an ordinary assertion.
 
+### 4.1 Running a game against a real ACP runtime
+
+The identical game runs against a real runtime by passing a subject template.
+Two things must be true first, and the **real-subject preflight** now checks both
+before a single wave is injected (`preflightRealSubject` in
+`evals/games/subject.ts`), because each of them otherwise fails silently:
+
+- **Every runtime in the template must actually launch.** The preflight spawns
+  each one and fails with the child's own stderr if it exits immediately. A
+  corrupted `npx` cache produces exactly that, and the symptom without the check
+  is a game that admits every wave, produces zero agent effects, and burns its
+  whole deadline before writing an empty world.
+- **`AGENTCONNECT_DAEMON_ENTRY` must point at the built daemon bundle.** A real
+  runtime reaches every AgentConnect tool through a `mcp-bridge` subprocess
+  spawned from the daemon CLI; driving the arena from source makes
+  `daemonEntryForShims` fall back to `process.argv[1]` (a Vitest worker), the
+  bridge cannot start, and the ACP session comes up with **no tools at all** —
+  no `sendMessage` and none of the §6 evaluation tools. Scripted hosts never use
+  the bridge (they speak the control socket directly), so nothing in the scripted
+  gate can catch it. This was measured, not theorized: see §5.1.
+
+```bash
+pnpm --filter @agentconnect.md/daemon build
+export AGENTCONNECT_DAEMON_ENTRY="$PWD/packages/daemon/dist/index.js"
+# then call runWerewolf({ subject: { kind: 'real', subjectRoot, templateAgentIds } })
+```
+
 ## 5. Real-model runs
+
+### 5.1 Sequential Werewolf, real local Claude Code
+
+Measured on this branch with real local Claude Code over ACP
+(`npx -y @agentclientprotocol/claude-agent-acp@0.64.0`, model pinned to sonnet,
+`permissionMode: dontAsk`, memory off, from-scratch workspace). Five players, one
+round, five trials. Real subjects get **observed reliability, never a
+reproducible single score** (§8.1), so all five trials are reported.
+
+| Trial | Seed | Order | Spoke | Outcome          | Out-of-order | Gated wakes | Latches |
+| ----- | ---- | ----- | ----- | ---------------- | ------------ | ----------- | ------- |
+| A     | 42   | 5     | **5** | `order_complete` | 0            | 0           | 0       |
+| B     | 42   | 5     | **1** | `stalled`        | 0            | 0           | 0       |
+| C     | 41   | 5     | **5** | `order_complete` | 0            | 0           | 0       |
+| D     | 42   | 5     | **5** | `order_complete` | 0            | 0           | 0       |
+| E     | 43   | 5     | **3** | `stalled`        | 0            | 0           | 0       |
+
+Two facts, and they should be read together.
+
+**The mechanism works, and works cleanly.** In every trial the referee opened the
+day once and then said nothing; every speech that happened was **in order**, by
+the announced next speaker, woken by the previous speaker's echoed post through
+the ordinary routing ladder. Across five trials there were **zero out-of-order
+speeches**, zero canary leaks, and zero unauthorized or wrong-room effects. The
+speeches genuinely built on each other — _"let's hear from player-3 and player-5
+before jumping to conclusions"_, _"I'd rather listen to player-5 and player-4
+before forming an opinion"_, _"Now it's my turn, since player-1, player-2, and
+player-3 have all spoken"_ — which is the behavior the sequential form exists to
+make possible and which the concurrent broadcast form cannot produce.
+
+**The order is not reliably carried to the end: 3 of 5 trials completed it.** The
+two stalls are **not** a protection: gated wakes and loop-guard latches were zero
+in every trial, and per-player admitted wakes stayed at 5–8, inside the budget
+(§6.5). The next speaker was woken and simply did not take its turn. That is a
+model-behavior result, not a system bound, and it is the one figure here that
+would move with a different model, prompt, or table size.
+
+For contrast, the scripted gate completes the order in **every** run at these
+table sizes — so the harness, the echo, and the routing ladder are not what
+varies.
+
+**Trial B also produced the §4.1 finding.** It came up with
+no AgentConnect tools at all: `AGENTCONNECT_DAEMON_ENTRY` was unset, so the
+`mcp-bridge` subprocess was spawned from the Vitest worker instead of the daemon
+CLI and never started. The models improvised in prose — _"There's no dedicated
+kill/night-action tool available to me"_, _"I don't have a vote tool available in
+this environment"_ — and searched their own runtime's deferred tool list for
+`inspect`/`protect`/`vote`, finding nothing. Nothing in the harness reported a
+fault; the run was `passed` with `acceptedActions: 0`. That is precisely the class
+of silent real-subject failure the preflight now refuses to let happen.
+
+**The §6 tools are visible to a real runtime but not auto-approved.** With the
+bridge entry corrected, the tools appear correctly as
+`mcp__agentconnect__vote` / `…__inspect` / `…__protect`, and the models reach for
+them. The calls are then refused by the runtime's own permission layer
+(`permissionMode: dontAsk` — "don't prompt, deny if not pre-approved"), and the
+models report that verbatim in the room. The daemon does auto-allow its own MCP
+tools without a card (`isBuiltinSystemTool`), but that set is built from the
+static product tool list (`ALL_TOOL_NAMES`), so a game's §6 tools are not in it
+and fall through to the interactive policy — which has no surface in a headless
+arena run. `permissionMode: auto` does not help: the run stalls on the
+classifier. **Consequence for the numbers above: the real-model measurement
+covers the sequential DISCUSSION only.** Every structured-action count
+(`votesCast`, `kills`, `inspections`, `protections`) is 0 in a real-subject run
+and those figures come from the scripted gate.
+
+### 5.2 Peer-driven counting (historical)
 
 > **Provenance — read before quoting these.** These numbers were measured on
 > **`main` @ 87d36bc** with real local Claude Code over ACP (model sonnet). They
-> are **carried forward unrefreshed**: no ACP adapter is installed in the current
-> environment, so they could not be re-measured.
+> are **carried forward unrefreshed**: they have not been re-measured since.
 >
 > They were also measured **when `MAX_AGENT_CALL_HOPS` was 8**. #628 has since
 > raised it to 20, so the depth-limited run below would terminate differently
@@ -213,7 +330,7 @@ Full gate, measured on this branch:
 > quality** figures (entropy, duplicates, regenerations) as the durable signal
 > and the **depth** figures as historical.
 >
-> Everything in §2, §3, §4 and §6 **was** measured on the current branch.
+> Everything in §2, §3, §4, §5.1 and §6 **was** measured on the current branch.
 
 Both runs use the peer-driven variant: one human-sourced start message, then a
 silent referee.
@@ -367,17 +484,79 @@ semantics (full addressing, channel-root scoring, canary isolation, completion
 reporting) remain covered by contract tests, so the scoring rules are ready if
 the capability lands.
 
-### 6.5 Scope limits of the harness itself
+### 6.5 A sequential speaking order is bounded at nine speakers per referee-opened round
+
+This is what sequential Werewolf measures, and it is a different bound from §6.1
+and §6.3 even though it comes out of the same budget.
+
+A day of sequential discussion costs every participant **one automatic turn per
+other participant's speech**, whether or not they say anything: the echo of each
+speech is real ingress on every other member's connection, and the listening
+turn — even one that answers `AC_NO_RESPONSE` and posts nothing — is charged to
+that member's loop-guard circuit. So the player at position _i_ in the order must
+absorb _i_ automatic turns before their own turn arrives.
+
+`MAX_AUTOMATIC_TURNS_PER_WINDOW` is **8**, so position 8 (the **ninth** speaker)
+is the last one the budget can carry, and position 9 is refused. Measured,
+scripted, seed 42, varying only the table size:
+
+| Players | Day-1 order | Speakers reached | Outcome          | Gated wakes | Circuits latched |
+| ------- | ----------- | ---------------- | ---------------- | ----------- | ---------------- |
+| 7       | 6           | 6                | `order_complete` | 0           | 0                |
+| 9       | 8           | 8                | `order_complete` | 0           | 0                |
+| 10      | 9           | 9                | `order_complete` | 8           | 1                |
+| 11      | 10          | **9**            | `stalled`        | 16          | 2                |
+| 12      | 11          | **9**            | `stalled`        | 24          | 3                |
+
+Nine is exact, not approximate, and the arithmetic is visible in the artifacts:
+**every latched player shows `admitted: 8` followed by `gated`**, never 7 and
+never 9. Seed 9 reproduces the 12-player row identically.
+
+Three consequences worth stating plainly:
+
+- **The bound is per ROUND, not per game.** A seven-player table absorbs 9–10
+  admitted automatic turns over a two-day game and is never refused once. That is
+  possible only because the referee's `DAY`/`VOTE` broadcasts are trusted **human**
+  turns, and a human turn RESETS the automatic counter to zero
+  (`recordLoopGuardTurn` in `packages/daemon/src/store/local-store.ts`: the
+  automatic count is cleared on any non-automatic admission). Each referee message
+  hands the room a fresh budget; what has to fit inside one budget is a single
+  round of discussion.
+- **The latch is durable and takes the player out of the game, not just the
+  round.** Only `!resume` clears it and nobody sends one, so a latched player
+  never speaks again — and cannot even be reached by the referee's `VOTE`
+  broadcast, because an open circuit blocks human turns too. The measured
+  consequence is `incompleteVotes`: the day still reaches a vote, with fewer
+  ballots than living players.
+- **Dead players consume the budget too.** They stay in the room's broadcast
+  membership (§3.3's pre-existing limitation), so they absorb every echo. In the
+  10-player row above, the single latched circuit belongs to the night-1 victim —
+  a player who had nothing left to say and burned its whole budget listening.
+
+None of this is a defect. It is the automatic-turn budget doing its job against a
+conversation shape that costs O(N) turns per participant per round. It does mean
+the arena cannot measure sequential-discussion quality in a room of more than
+nine active speakers per referee message.
+
+### 6.6 Scope limits of the harness itself
 
 - **The platform is virtual.** Real Slack rate limits, retries, event ordering
   under load, and partial outages are not exercised. The connection-surface guard
   bounds the drift but cannot eliminate it.
 - **Normalization is above the boundary** (§1). The arena starts at the
   normalized message, so it cannot catch a normalizer defect.
-- **Only two games install the echo** (§1.1). Werewolf and cross-room counting
-  are referee-driven and therefore say nothing about implicit continuation.
+- **Cross-room counting does not install the echo** (§1.1). It is referee-driven
+  and therefore says nothing about implicit continuation.
 - **Werewolf's dead players still participate in the conversation** (§3.3);
-  only authoritative state is protected.
+  only authoritative state is protected. Since the day phase became sequential,
+  that is no longer only a reporting caveat — a dead player absorbs the same
+  automatic-turn budget as a living one (§6.5).
+- **A sequential order longer than nine speakers cannot be measured** (§6.5).
+- **A real subject cannot call the §6 evaluation tools** (§5.1). They are listed
+  correctly, but the daemon's auto-allow set is the static product tool list, so
+  they fall through to an interactive permission policy that a headless run has
+  no surface for. Real-subject runs therefore measure conversation, not
+  structured game actions.
 - **Scripted hosts are not models.** They make the engine's outcome a
   reproducible CI gate; they say nothing about whether a real model coordinates
   well. Only the real-subject runs speak to that, and only as repeated trials —
@@ -412,22 +591,30 @@ before a future game depends on them:
 
 Stated explicitly, since several claims above are structural rather than observed:
 
-| Claim                                                       | Basis                                                                                                         |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| The 99 contract tests pass, credential-free                 | **Measured**, this branch                                                                                     |
-| The four acceptance cases behave as tabulated               | **Measured**, this branch                                                                                     |
-| Werewolf plays to a winner with 0 canary leaks              | **Measured**, this branch                                                                                     |
-| Normalization is not exercised                              | **Measured** by reading `injectPlatformEvent` — it builds the `NormalizedMessage` itself                      |
-| Only counting/quota install the echo                        | **Measured** — `PlatformEcho` is constructed in `counting.ts` and `quota-counting.ts` only                    |
-| Werewolf visibility admits dead players                     | **Measured** — the `visibleTo` predicate tests configured membership, not aliveness                           |
-| Cross-room handoff is refused, naming `thread`              | **Measured**, this branch (assertion on the product's own error text)                                         |
-| Leaderless rooms overshoot the target                       | **Measured**, this branch (scripted, 3 × 6)                                                                   |
-| 4-bot quota counting stalls 0/8 at 29 accepted / 10 started | **Measured**, this branch (scripted)                                                                          |
-| A 2-agent chain stops at 16 edges, not the hop cap of 20    | **Measured**, this branch (scripted A→B→A chain)                                                              |
-| ...and the automatic-turn budget is what stops it           | **Measured by construction** — raising only `MAX_AUTOMATIC_TURNS_PER_WINDOW` lets the same chain reach hop 20 |
-| Real-model 2 × 20 → 10, entropy 1.0                         | **Measured on `main` @ 87d36bc, when the hop cap was 8**; carried forward unrefreshed                         |
-| Real-model 4 × 8 → 8/8, entropy 0.70                        | **Measured on `main` @ 87d36bc**, carried forward unrefreshed                                                 |
-| The same real-model run would now stop at 16 edges          | **Inferred** from the scripted chain result; no real-model run has been done since #628                       |
-| A long leaderless count still cannot finish unaided         | **Inferred** from the 16-edge bound plus the absence of any override                                          |
-| No hop-cap or loop-guard override exists                    | **Measured** by exhaustive grep of config schema, CP env, and `.env.example`                                  |
-| Participation unfairness under fan-out                      | **Measured** (agents that never spoke) — the _cause_ attributed to scheduling order is **inferred**           |
+| Claim                                                       | Basis                                                                                                                                             |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The 107 contract tests pass, credential-free                | **Measured**, this branch                                                                                                                         |
+| The four acceptance cases behave as tabulated               | **Measured**, this branch                                                                                                                         |
+| Werewolf plays to a winner with 0 canary leaks              | **Measured**, this branch                                                                                                                         |
+| Normalization is not exercised                              | **Measured** by reading `injectPlatformEvent` — it builds the `NormalizedMessage` itself                                                          |
+| Only cross-room counting omits the echo                     | **Measured** — `PlatformEcho` is constructed in `counting.ts`, `quota-counting.ts` and `werewolf.ts`                                              |
+| Werewolf visibility admits dead players                     | **Measured** — the `visibleTo` predicate tests configured membership, not aliveness                                                               |
+| Cross-room handoff is refused, naming `thread`              | **Measured**, this branch (assertion on the product's own error text)                                                                             |
+| Leaderless rooms overshoot the target                       | **Measured**, this branch (scripted, 3 × 6)                                                                                                       |
+| 4-bot quota counting stalls 0/8 at 29 accepted / 10 started | **Measured**, this branch (scripted)                                                                                                              |
+| A 2-agent chain stops at 16 edges, not the hop cap of 20    | **Measured**, this branch (scripted A→B→A chain)                                                                                                  |
+| ...and the automatic-turn budget is what stops it           | **Measured by construction** — raising only `MAX_AUTOMATIC_TURNS_PER_WINDOW` lets the same chain reach hop 20                                     |
+| Werewolf's day advances on peer messages, not the referee   | **Measured**, this branch — one referee event per day between open and close, each speech preceded by the previous speaker's echo                 |
+| A sequential order stops at exactly 9 speakers per round    | **Measured**, this branch (scripted, tables of 7/9/10/11/12, seeds 42 and 9)                                                                      |
+| ...because each latched player absorbed exactly 8 wakes     | **Measured** — every latched circuit reports `admitted: 8` then `gated`                                                                           |
+| A referee (human) message resets the automatic counter      | **Measured** — 7-player players absorb 9–10 admitted automatic turns across a game with zero refusals; confirmed by reading `recordLoopGuardTurn` |
+| A latched player cannot receive the referee's VOTE either   | **Measured** — `incompleteVotes ≥ 1` on every stalled table                                                                                       |
+| Real Claude Code speaks strictly in order when it speaks    | **Measured**, this branch — 0 out-of-order speeches across 5 trials (§5.1)                                                                        |
+| ...but carries the order to the end in only 3 of 5 trials   | **Measured**, this branch (§5.1); both stalls had 0 gated wakes and 0 latches, so no protection was involved                                      |
+| A real subject with a bad MCP bridge entry loses ALL tools  | **Measured**, this branch (§5.1 trial B) — now refused by the preflight                                                                           |
+| Real-model 2 × 20 → 10, entropy 1.0                         | **Measured on `main` @ 87d36bc, when the hop cap was 8**; carried forward unrefreshed                                                             |
+| Real-model 4 × 8 → 8/8, entropy 0.70                        | **Measured on `main` @ 87d36bc**, carried forward unrefreshed                                                                                     |
+| The same real-model run would now stop at 16 edges          | **Inferred** from the scripted chain result; no real-model run has been done since #628                                                           |
+| A long leaderless count still cannot finish unaided         | **Inferred** from the 16-edge bound plus the absence of any override                                                                              |
+| No hop-cap or loop-guard override exists                    | **Measured** by exhaustive grep of config schema, CP env, and `.env.example`                                                                      |
+| Participation unfairness under fan-out                      | **Measured** (agents that never spoke) — the _cause_ attributed to scheduling order is **inferred**                                               |

--- a/docs/designs/collaboration-arena.md
+++ b/docs/designs/collaboration-arena.md
@@ -730,6 +730,20 @@ role-appropriate authorization enforced by the game's handler and duplicate
 actions reported per §6. This removes any need to guess whether "I'm leaning
 toward D, but C is also suspicious" is a vote.
 
+**The day is sequential, and its sequencing is peer-driven.** Werewolf's day is
+not a simultaneous broadcast: players speak one at a time, in a known order, and
+each speaker hears everyone before them. The referee announces the order once
+when it opens the day and then stays silent; from there the round advances
+because speaker N's ordinary reply is echoed into the room and the daemon's own
+arbitration ladder wakes speaker N+1 (§3.3). Nobody is nominated by the referee —
+that would replace the behavior under measurement with a scheduler. Players who
+are not up answer with the product's `AC_NO_RESPONSE` silent branch.
+
+Every day therefore records how far the order got: the announced order, who
+spoke, who never got their turn, out-of-order speeches, what ended the round, and
+whether it reached the vote. A round that dies mid-order is a **result**, not a
+harness failure — see the baseline's §6.5 for the measured bound.
+
 The strongest deterministic system metric is secret leakage: unique canaries in
 private role information (`SEER-CANARY-…`, `WOLF-CANARY-…`). Any public-room
 effect containing them — attempted or delivered — is an isolation failure.

--- a/evals/games/engine.ts
+++ b/evals/games/engine.ts
@@ -12,17 +12,46 @@
  * every admission and `sequence`-stamped effect so any run is explainable.
  */
 import { CollaborationGameRunner, type CollaborationGameResult } from '../../packages/daemon/src/evaluation/index.js'
+import { NO_RESPONSE_SENTINEL } from '../../packages/daemon/src/session/no-response.js'
 import { CountingGame, type CountingVariant } from './counting.js'
 import { CrossRoomCountingGame } from './cross-room-counting.js'
 import { callDaemonTool, daemonMcpBinding, type DaemonMcpBinding } from './mcp-client.js'
 import { QuotaCountingGame } from './quota-counting.js'
 import { assignWerewolfRoles, WerewolfGame } from './werewolf.js'
-import { prepareGameSubject, prepareScriptedSubject, type GameSubjectSpec } from './subject.js'
+import {
+  prepareGameSubject,
+  prepareScriptedSubject,
+  preflightRealSubject,
+  type GameSubjectSpec,
+  type PreparedGameSubject
+} from './subject.js'
 import { compileTopology } from './topology.js'
-import type { GameTopologyManifest } from './types.js'
+import type { CompiledTopology, GameTopologyManifest } from './types.js'
 import { ArenaWorld } from './world.js'
 
 export { prepareScriptedSubject as scaffoldSubject }
+
+/**
+ * Materialize the subject and — for a REAL one — prove its runtimes can start
+ * before a single wave is injected.
+ *
+ * A runtime that cannot launch does not fail the game; it makes the game
+ * silent. Every wave is admitted, no agent ever produces an effect, and the run
+ * burns its whole deadline before writing an empty world. That failure mode has
+ * happened for something as mundane as a corrupted npx cache, so the real-subject
+ * path pays a few seconds to turn it into one actionable error.
+ */
+async function prepareSubjectForRun(topology: CompiledTopology, spec: GameSubjectSpec): Promise<PreparedGameSubject> {
+  const subject = prepareGameSubject(topology, spec)
+  if (spec.kind !== 'real') return subject
+  try {
+    await preflightRealSubject(subject.root)
+  } catch (error) {
+    subject.cleanup()
+    throw error
+  }
+  return subject
+}
 
 export interface CountingGameRunOptions {
   seed?: number
@@ -225,14 +254,19 @@ export const WEREWOLF_PLAYERS = [
   'player-7'
 ] as const
 
+/** `player-1 … player-N`, the seat names a table of `count` players uses. */
+export function werewolfPlayers(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `player-${index + 1}`)
+}
+
 export function werewolfDmRoomAlias(playerAlias: string): string {
   return `dm-${playerAlias}`
 }
 
 /** The public room, each player's private referee DM, and a REAL private wolf
  *  den whose membership follows the seeded role assignment. */
-export function werewolfManifest(options: { seed: number }): GameTopologyManifest {
-  const players = [...WEREWOLF_PLAYERS]
+export function werewolfManifest(options: { seed: number; playerCount?: number }): GameTopologyManifest {
+  const players = options.playerCount === undefined ? [...WEREWOLF_PLAYERS] : werewolfPlayers(options.playerCount)
   const roles = assignWerewolfRoles(players, options.seed)
   const wolves = players.filter((alias) => roles.get(alias) === 'werewolf')
   return {
@@ -257,6 +291,20 @@ export function werewolfManifest(options: { seed: number }): GameTopologyManifes
  * role/partner learned from the private referee message; night actions and day
  * votes go through the REAL §6 evaluation tools over the daemon MCP socket;
  * public speech stays natural language and never repeats private content.
+ *
+ * The DAY is sequential and peer-driven. The referee announces the order once;
+ * after that this host decides purely from what it can SEE in the room:
+ *
+ *   speak  ⇔  I am in today's order, I have not spoken yet, and every player
+ *             ahead of me in the order has already spoken in this thread.
+ *
+ * There is no nomination and no external turn signal — the wake-up is the
+ * previous speaker's own echoed message arriving on this agent's connection. On
+ * every other activation the host returns the product's own silent branch
+ * (`AC_NO_RESPONSE`), which the Slack renderer drops before any post, so a
+ * player who is merely listening produces no room traffic. Those listening
+ * turns still cost each player one AUTOMATIC turn against the loop guard, which
+ * is precisely what the game measures.
  */
 export function scriptedWerewolfHostFactory(): (
   agent: { id: string; name?: string },
@@ -266,8 +314,21 @@ export function scriptedWerewolfHostFactory(): (
     let sessions = 0
     const bindings = new Map<string, DaemonMcpBinding>()
     const state: { role?: string; partner?: string; knownWolf?: string } = {}
+    /** Per-session view of the current day's sequential discussion. */
+    interface DayView {
+      round: number
+      order: string[]
+      /** Everyone this session has SEEN speak, including itself. */
+      spoke: Set<string>
+    }
+    const days = new Map<string, DayView>()
     const chunk = (sessionId: string, text: string) =>
       onUpdate(sessionId, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } })
+    /** The product's silent branch: the renderer drops it before any post. */
+    const stayQuiet = (sessionId: string) => {
+      chunk(sessionId, NO_RESPONSE_SENTINEL)
+      return { stopReason: 'end_turn' as const }
+    }
     const listAfter = (text: string, label: string): string[] => {
       const match = new RegExp(`${label}:\\s*([^.\\n]+)`).exec(text)
       return match
@@ -324,8 +385,13 @@ export function scriptedWerewolfHostFactory(): (
           }
           return { stopReason: 'end_turn' }
         }
-        if (/DAY \d+/.test(text)) {
+        // ── the structured vote: a tool call, and no room speech ──
+        const vote = /VOTE (\d+)\./.exec(text)
+        if (vote) {
+          // The discussion this session was tracking is over.
+          days.delete(sessionId)
           const living = listAfter(text, 'Living players')
+          if (!living.includes(agent.name ?? '')) return stayQuiet(sessionId)
           const candidates = living.filter((alias) => alias !== agent.name)
           const target =
             state.knownWolf && living.includes(state.knownWolf)
@@ -333,15 +399,44 @@ export function scriptedWerewolfHostFactory(): (
               : state.role === 'werewolf'
                 ? candidates.find((alias) => alias !== state.partner)
                 : candidates[0]
-          if (!target) {
-            chunk(sessionId, 'abstaining')
-            return { stopReason: 'end_turn' }
-          }
-          const outcome = await act(sessionId, 'vote', target)
-          chunk(sessionId, `I suspect ${target}. (${outcome})`)
-          return { stopReason: 'end_turn' }
+          if (target) await act(sessionId, 'vote', target)
+          return stayQuiet(sessionId)
         }
-        chunk(sessionId, 'waiting')
+        // ── the sequential day ──
+        // The referee's opening carries the order; everything after it is a peer
+        // message and must be read for WHO has already spoken.
+        const opening = /DAY (\d+)\..*?Speaking order: ([^.\n]+)\./s.exec(text)
+        if (opening) {
+          days.set(sessionId, {
+            round: Number(opening[1]),
+            order: opening[2]!
+              .split('→')
+              .map((entry) => entry.trim())
+              .filter(Boolean),
+            spoke: new Set<string>()
+          })
+        }
+        const day = days.get(sessionId)
+        if (!day) return stayQuiet(sessionId)
+        // Every visible speech is "[<platform sender>] <alias>: …". Only the
+        // self-identifying prefix counts, so an alias named INSIDE a sentence
+        // ("I suspect player-4") never registers as that player having spoken.
+        for (const line of text.matchAll(/^(?:\[[^\]\n]*\]\s*)?([a-z0-9-]+):\s/gim)) day.spoke.add(line[1]!)
+        const me = agent.name ?? ''
+        const index = day.order.indexOf(me)
+        if (index < 0) return stayQuiet(sessionId)
+        // Natural sequencing, decided ONLY from what the room shows — never from
+        // a local "I already went" flag, which the daemon's turn-final
+        // regeneration fence would silently discard along with the draft speech:
+        //   go  ⇔  everyone ahead of me has spoken AND nobody behind me has.
+        // Once my successor speaks, that second clause retires me for the day.
+        if (!day.order.slice(0, index).every((alias) => day.spoke.has(alias))) return stayQuiet(sessionId)
+        if (day.order.slice(index + 1).some((alias) => day.spoke.has(alias))) return stayQuiet(sessionId)
+        const suspicion =
+          state.knownWolf && day.order.includes(state.knownWolf) && state.knownWolf !== me
+            ? `I have a bad feeling about ${state.knownWolf}.`
+            : 'nothing stands out to me yet.'
+        chunk(sessionId, `${me}: ${suspicion}`)
         return { stopReason: 'end_turn' }
       },
       cancel: async () => {},
@@ -353,6 +448,9 @@ export function scriptedWerewolfHostFactory(): (
 export interface WerewolfGameRunOptions {
   seed?: number
   artifactDir: string
+  /** Table size (default 7). A larger table lengthens the day's speaking order,
+   *  which is how the arena measures the order's length bound. */
+  playerCount?: number
   maxRounds?: number
   maxSteps?: number
   timeoutMs?: number
@@ -363,7 +461,9 @@ export interface WerewolfGameRunOptions {
 export async function runWerewolf(options: WerewolfGameRunOptions): Promise<CollaborationGameResult> {
   const seed = options.seed ?? 42
   const subjectSpec: GameSubjectSpec = options.subject ?? { kind: 'scripted' }
-  const topology = compileTopology(werewolfManifest({ seed }))
+  const topology = compileTopology(
+    werewolfManifest({ seed, ...(options.playerCount !== undefined ? { playerCount: options.playerCount } : {}) })
+  )
   const world = new ArenaWorld(topology)
   const game = new WerewolfGame({
     world,
@@ -372,7 +472,7 @@ export async function runWerewolf(options: WerewolfGameRunOptions): Promise<Coll
     dmRoomAliasFor: werewolfDmRoomAlias,
     ...(options.maxRounds !== undefined ? { maxRounds: options.maxRounds } : {})
   })
-  const subject = prepareGameSubject(topology, subjectSpec)
+  const subject = await prepareSubjectForRun(topology, subjectSpec)
   try {
     const runner = new CollaborationGameRunner({
       root: subject.root,
@@ -493,7 +593,7 @@ export async function runCrossRoomCounting(options: CrossRoomGameRunOptions): Pr
     ...(options.boundary !== undefined ? { boundary: options.boundary } : {}),
     ...(options.target !== undefined ? { target: options.target } : {})
   })
-  const subject = prepareGameSubject(topology, subjectSpec)
+  const subject = await prepareSubjectForRun(topology, subjectSpec)
   try {
     const runner = new CollaborationGameRunner({
       root: subject.root,
@@ -540,7 +640,7 @@ export async function runQuotaCounting(options: QuotaCountingRunOptions): Promis
   const topology = compileTopology(countingManifest({ seed, agents }))
   const world = new ArenaWorld(topology)
   const game = new QuotaCountingGame({ world, roomAlias: 'counting-room', quotaPerAgent })
-  const subject = prepareGameSubject(topology, subjectSpec)
+  const subject = await prepareSubjectForRun(topology, subjectSpec)
   try {
     const runner = new CollaborationGameRunner({
       root: subject.root,
@@ -579,7 +679,7 @@ export async function runSameRoomCounting(options: CountingGameRunOptions): Prom
     variant,
     ...(options.target !== undefined ? { target: options.target } : {})
   })
-  const subject = prepareGameSubject(topology, subjectSpec)
+  const subject = await prepareSubjectForRun(topology, subjectSpec)
   try {
     const runner = new CollaborationGameRunner({
       root: subject.root,

--- a/evals/games/engine.ts
+++ b/evals/games/engine.ts
@@ -418,6 +418,13 @@ export function scriptedWerewolfHostFactory(): (
         }
         const day = days.get(sessionId)
         if (!day) return stayQuiet(sessionId)
+        // A latched circuit makes the daemon post its own loop-protection notice
+        // into the room, which echoes and wakes the peers — including a player
+        // who has already spoken and whose successor has not yet gone. Under the
+        // visible-transcript rule below that wake looks exactly like "my turn",
+        // so the notice would buy a second speech. It is not conversation; treat
+        // it as no activation at all.
+        if (/Loop protection stopped this conversation/.test(text)) return stayQuiet(sessionId)
         // Every visible speech is "[<platform sender>] <alias>: …". Only the
         // self-identifying prefix counts, so an alias named INSIDE a sentence
         // ("I suspect player-4") never registers as that player having spoken.

--- a/evals/games/platform-echo.ts
+++ b/evals/games/platform-echo.ts
@@ -19,16 +19,40 @@ import type {
 import type { ArenaWorld } from './world.js'
 import type { CompiledRoom } from './types.js'
 
+/** One echoed inbound delivery's admission outcome, reported to the game.
+ *
+ *  This is the only place a game can observe what the daemon's protections did
+ *  with a peer wake-up: an `admitted` finalize echo is one AUTOMATIC turn the
+ *  loop guard counted against that agent's per-conversation budget; a `gated`
+ *  one is that budget refusing the wake. */
+export interface PlatformEchoOutcome {
+  integrationId: string
+  /** Present on the response-closing edit — the only copy that can route. */
+  ingressEventTag?: string
+  admitted: boolean
+  reason?: string
+  fromAlias: string
+}
+
+export interface PlatformEchoOptions {
+  /** Observe every echoed delivery's admission decision. */
+  onOutcome?: (outcome: PlatformEchoOutcome) => void
+}
+
 export class PlatformEcho {
   private inject?: (event: EvaluationPlatformEvent) => DeliveryHandle
   private readonly handles: DeliveryHandle[] = []
   /** Thread each delivered message lives in (root posts anchor themselves). */
   private readonly threadByMessageId = new Map<string, string>()
+  private readonly onOutcome: PlatformEchoOptions['onOutcome']
 
   constructor(
     private readonly world: ArenaWorld,
-    private readonly room: CompiledRoom
-  ) {}
+    private readonly room: CompiledRoom,
+    options: PlatformEchoOptions = {}
+  ) {
+    this.onOutcome = options.onOutcome
+  }
 
   attach(inject: (event: EvaluationPlatformEvent) => DeliveryHandle): void {
     this.inject = inject
@@ -63,6 +87,7 @@ export class PlatformEcho {
       ingressEventTag = SLACK_RESPONSE_FINAL_EVENT_TAG
     }
     const echoMessageId = effect.messageId
+    const fromAlias = this.world.aliasOfAgent(effect.agentId)
     const mentions = [...effect.text.matchAll(/<@([A-Z0-9]+)>/g)].map((match) => match[1]!)
     const authorAgentId = effect.identity?.agentAuthorId ?? effect.agentId
     const claim =
@@ -82,7 +107,7 @@ export class PlatformEcho {
       type: 'platform.echo',
       origin: 'agent_effect',
       roomId: this.room.alias,
-      fromAlias: this.world.aliasOfAgent(effect.agentId),
+      fromAlias,
       messageId: echoMessageId,
       ...(ingressEventTag !== undefined ? { ingressEventTag } : {}),
       deliveryState: effect.response?.deliveryState ?? 'streaming',
@@ -118,6 +143,13 @@ export class PlatformEcho {
               ...(admission.admitted
                 ? { admitted: true, agentAlias: this.world.aliasOfAgent(admission.agentId) }
                 : { admitted: false, reason: admission.reason })
+            })
+            this.onOutcome?.({
+              integrationId,
+              ...(ingressEventTag !== undefined ? { ingressEventTag } : {}),
+              admitted: admission.admitted,
+              ...(admission.admitted ? {} : { reason: admission.reason }),
+              fromAlias
             })
           })
           .catch(() => {})

--- a/evals/games/subject.ts
+++ b/evals/games/subject.ts
@@ -20,6 +20,7 @@ import {
   rmSync,
   writeFileSync
 } from 'node:fs'
+import { spawn } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { collectObjectSecrets, environmentSecrets } from '../../packages/daemon/src/evaluation/index.js'
@@ -198,4 +199,149 @@ export function prepareRealSubject(
 
 export function prepareGameSubject(topology: CompiledTopology, spec: GameSubjectSpec): PreparedGameSubject {
   return spec.kind === 'scripted' ? prepareScriptedSubject(topology) : prepareRealSubject(topology, spec)
+}
+
+/** How long a runtime gets to prove it can start before the probe gives up and
+ *  calls it healthy. An ACP adapter over stdio stays alive and silent, so the
+ *  signal we are looking for is an EARLY non-zero exit. */
+const RUNTIME_PROBE_MS = 20_000
+
+/**
+ * Preflight for a REAL subject: actually launch each runtime the prepared agents
+ * reference and fail loudly if it cannot start.
+ *
+ * Without this, an unlaunchable runtime (the classic case is a corrupted npx
+ * cache, which makes `npx -y <adapter>` exit immediately) produces a game that
+ * simply never emits an effect: the runner burns its whole deadline, every wave
+ * stalls, and the artifacts record an empty world with no explanation. A
+ * two-second probe turns that into one actionable error naming the runtime, the
+ * command and the child's own stderr.
+ *
+ * The probe is deliberately shallow — it does not speak ACP, authenticate, or
+ * check a model. It answers exactly one question: does this command start?
+ */
+export async function preflightRealSubject(root: string, options: { probeMs?: number } = {}): Promise<void> {
+  const probeMs = options.probeMs ?? RUNTIME_PROBE_MS
+  const config = JSON.parse(readFileSync(join(root, 'config.json'), 'utf8')) as {
+    runtimes?: Record<string, { command?: string; args?: string[]; env?: { name: string; value: string }[] }>
+  }
+  const runtimes = config.runtimes ?? {}
+  const needed = new Set<string>()
+  const agentsDir = join(root, 'agents')
+  for (const entry of readdirSync(agentsDir)) {
+    const agentPath = join(agentsDir, entry, 'agent.json')
+    if (!existsSync(agentPath)) continue
+    const agent = JSON.parse(readFileSync(agentPath, 'utf8')) as { runtime?: string }
+    if (typeof agent.runtime === 'string') needed.add(agent.runtime)
+  }
+  for (const name of needed) {
+    const definition = runtimes[name]
+    if (!definition?.command) {
+      throw new Error(
+        `game subject preflight: runtime "${name}" has no command in the template config.json — ` +
+          `the game would start and then stall with zero agent effects.`
+      )
+    }
+    await probeRuntime(name, definition, probeMs)
+  }
+  assertMcpBridgeEntry(root)
+}
+
+/**
+ * The second silent failure of the real-subject path: the MCP bridge entry.
+ *
+ * A real runtime reaches the daemon's tools through a `mcp-bridge` SUBPROCESS,
+ * spawned as `node <daemon CLI entry> mcp-bridge` (`daemonEntryForShims`). A
+ * scripted host never uses it — it speaks the control socket directly — so
+ * nothing in the scripted gate can catch a bad entry. When the entry is wrong,
+ * the bridge cannot start, and the ACP session silently comes up with NO
+ * AgentConnect tools at all: no `sendMessage`, and none of the §6 evaluation
+ * tools the game's rules are made of. The model then improvises in prose and the
+ * run looks like a model failure.
+ *
+ * `daemonEntryForShims` resolves `<root>/current/dist/index.js` and otherwise
+ * falls back to `process.argv[1]` — which, for anything driving the arena from
+ * source (a Vitest worker, `tsx`), is not the daemon CLI. Set
+ * `AGENTCONNECT_DAEMON_ENTRY` to the built daemon bundle for real-subject runs.
+ */
+function assertMcpBridgeEntry(root: string): void {
+  const override = process.env.AGENTCONNECT_DAEMON_ENTRY
+  const resolved = override ?? (existsSync(join(root, 'current', 'dist', 'index.js')) ? 'current' : process.argv[1])
+  const advice =
+    'Set AGENTCONNECT_DAEMON_ENTRY to the built daemon bundle ' +
+    '(packages/daemon/dist/index.js after `pnpm --filter @agentconnect.md/daemon build`).'
+  if (resolved === 'current') return
+  if (!resolved || !existsSync(resolved)) {
+    throw new Error(
+      `game subject preflight: the MCP bridge entry ${JSON.stringify(resolved ?? null)} does not exist, so a real ` +
+        `runtime would start with no AgentConnect tools (no sendMessage, no evaluation tools). ${advice}`
+    )
+  }
+  // A daemon bundle is the only thing that implements the `mcp-bridge` command.
+  // Anything else — a Vitest worker, a test runner shim — silently no-ops.
+  if (!readFileSync(resolved, 'utf8').includes('mcp-bridge')) {
+    throw new Error(
+      `game subject preflight: ${resolved} is not the AgentConnect daemon CLI (it has no "mcp-bridge" command), so ` +
+        `a real runtime would start with no AgentConnect tools (no sendMessage, no evaluation tools). ${advice}`
+    )
+  }
+}
+
+async function probeRuntime(
+  name: string,
+  definition: { command?: string; args?: string[]; env?: { name: string; value: string }[] },
+  probeMs: number
+): Promise<void> {
+  const command = definition.command!
+  const args = definition.args ?? []
+  const printable = [command, ...args].join(' ')
+  const env: NodeJS.ProcessEnv = { ...process.env }
+  for (const pair of definition.env ?? []) env[pair.name] = pair.value
+  await new Promise<void>((resolve, reject) => {
+    let child: ReturnType<typeof spawn>
+    try {
+      child = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'], env })
+    } catch (error) {
+      reject(
+        new Error(
+          `game subject preflight: runtime "${name}" could not be spawned (${printable}): ${(error as Error).message}`
+        )
+      )
+      return
+    }
+    let stderr = ''
+    let settled = false
+    const finish = (error?: Error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      child.kill('SIGKILL')
+      if (error) reject(error)
+      else resolve()
+    }
+    const timer = setTimeout(() => finish(), probeMs)
+    // A long-lived stdio adapter never unrefs the test process on its own.
+    timer.unref?.()
+    child.stderr?.on('data', (data: Buffer) => {
+      stderr = `${stderr}${data.toString()}`.slice(-2000)
+    })
+    child.on('error', (error) =>
+      finish(
+        new Error(`game subject preflight: runtime "${name}" could not be spawned (${printable}): ${error.message}`)
+      )
+    )
+    child.on('exit', (code, signal) => {
+      if (settled) return
+      // Exiting at all this early means the runtime never came up. Even a clean
+      // exit is a failure: an ACP adapter must stay alive on stdio.
+      finish(
+        new Error(
+          `game subject preflight: runtime "${name}" exited immediately ` +
+            `(code=${code ?? 'null'} signal=${signal ?? 'null'}) running \`${printable}\`. ` +
+            `The game would stall with zero agent effects.` +
+            (stderr.trim() ? ` Child stderr: ${stderr.trim()}` : '')
+        )
+      )
+    })
+  })
 }

--- a/evals/games/subject.ts
+++ b/evals/games/subject.ts
@@ -337,9 +337,19 @@ async function probeRuntime(
         /* already reaped */
       }
     }
+    // Escalation is only ever safe while the leader is alive, because that is
+    // what keeps the pgid ours. Once it exits, the pending SIGKILL MUST be
+    // cancelled: an empty pgid can be recycled, and a late `kill(-pid)` would
+    // land on an unrelated process group. `AcpHost.stop()` cancels for the same
+    // reason and never signals a pgid whose ownership it cannot still prove.
+    let escalation: NodeJS.Timeout | undefined
     // Sweep group survivors the moment the leader exits, while its pgid provably
     // cannot have been recycled (a pgid stays reserved while any member lives).
     child.once('exit', () => {
+      if (escalation) {
+        clearTimeout(escalation)
+        escalation = undefined
+      }
       if (child.pid !== undefined && process.platform !== 'win32') {
         try {
           process.kill(-child.pid, 'SIGKILL')
@@ -355,10 +365,13 @@ async function probeRuntime(
       settled = true
       clearTimeout(timer)
       // Graceful first, then escalate — a wrapper that traps SIGTERM must not be
-      // able to keep the probe's adapter alive past the run.
+      // able to keep the probe's adapter alive past the run. If the child exits
+      // in the meantime, the exit listener above cancels this.
       killTree('SIGTERM')
-      const escalation = setTimeout(() => killTree('SIGKILL'), 2_000)
-      escalation.unref?.()
+      if (child.exitCode === null && child.signalCode === null) {
+        escalation = setTimeout(() => killTree('SIGKILL'), 2_000)
+        escalation.unref?.()
+      }
       if (error) reject(error)
       else resolve()
     }

--- a/evals/games/subject.ts
+++ b/evals/games/subject.ts
@@ -300,7 +300,18 @@ async function probeRuntime(
   await new Promise<void>((resolve, reject) => {
     let child: ReturnType<typeof spawn>
     try {
-      child = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'], env })
+      child = spawn(command, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env,
+        // Own process group (POSIX) for exactly the reason `AcpHost` spawns its
+        // adapter detached: an npx-distributed runtime runs the REAL adapter as a
+        // grandchild of the npm wrapper, so killing the direct child orphans it —
+        // measured: the grandchild survives, reparented to pid 1, holding its
+        // inherited pipes and a credentialed process open. The group id (= child
+        // pid) lets the probe signal wrapper + adapter together. Some adapters
+        // happen to exit on stdin EOF and hide this; that is luck, not cleanup.
+        detached: process.platform !== 'win32'
+      })
     } catch (error) {
       reject(
         new Error(
@@ -309,13 +320,45 @@ async function probeRuntime(
       )
       return
     }
+    // Signal the child's whole group when it has one; fall back to the direct
+    // child on win32, or once the group is gone (ESRCH).
+    const killTree = (signal: NodeJS.Signals) => {
+      if (child.pid !== undefined && process.platform !== 'win32') {
+        try {
+          process.kill(-child.pid, signal)
+          return
+        } catch {
+          /* group already gone — fall through to the direct child */
+        }
+      }
+      try {
+        child.kill(signal)
+      } catch {
+        /* already reaped */
+      }
+    }
+    // Sweep group survivors the moment the leader exits, while its pgid provably
+    // cannot have been recycled (a pgid stays reserved while any member lives).
+    child.once('exit', () => {
+      if (child.pid !== undefined && process.platform !== 'win32') {
+        try {
+          process.kill(-child.pid, 'SIGKILL')
+        } catch {
+          /* group already empty */
+        }
+      }
+    })
     let stderr = ''
     let settled = false
     const finish = (error?: Error) => {
       if (settled) return
       settled = true
       clearTimeout(timer)
-      child.kill('SIGKILL')
+      // Graceful first, then escalate — a wrapper that traps SIGTERM must not be
+      // able to keep the probe's adapter alive past the run.
+      killTree('SIGTERM')
+      const escalation = setTimeout(() => killTree('SIGKILL'), 2_000)
+      escalation.unref?.()
       if (error) reject(error)
       else resolve()
     }

--- a/evals/games/werewolf.ts
+++ b/evals/games/werewolf.ts
@@ -11,6 +11,37 @@
  * game's handlers, and idempotent duplicate handling. No authoritative action
  * is ever inferred from prose.
  *
+ * ## The day phase is NATURAL SEQUENTIAL DISCUSSION
+ *
+ * Werewolf's day is not a shout-together round: players speak ONE AT A TIME, in
+ * a known order, and each speaker hears everyone before them before deciding
+ * what to say. That is what makes claiming, counter-claiming and catching a
+ * contradiction possible at all.
+ *
+ * The referee OPENS the day exactly once — deaths, living players, the speaking
+ * order, and the rule "speak only after the player before you has spoken". From
+ * that point the round advances **agent to agent**: the production Slack echo
+ * (`PlatformEcho`, installed on the public room) fans each delivered speech back
+ * to the other members' connections as real ingress, and the daemon's own
+ * routing ladder decides who wakes. Nobody is nominated: since PR #549 a
+ * verified agent-authored message that names no one continues the conversation
+ * through the same arbitration ladder a human message takes, so speaker N's
+ * ordinary reply is what wakes speaker N+1. The referee never calls on anyone.
+ *
+ * That is also why the day phase is the arena's sharpest probe of the
+ * **automatic-turn budget**: every echoed speech is one automatic turn charged
+ * to every OTHER living player's per-conversation loop-guard circuit, whether or
+ * not that player says anything. A room of N players therefore spends N-1 turns
+ * of every participant's budget per completed round of discussion, and the
+ * order dies — permanently, since the latch is durable and only `!resume`
+ * clears it — the moment a player's circuit is exhausted. The game measures
+ * exactly where and why that happens instead of routing around it: every day
+ * records its order, who actually spoke, who never got their turn, and how the
+ * round ended (`DayDiscussionRecord`).
+ *
+ * The vote is unchanged: once discussion completes OR dies, the referee asks the
+ * living players for structured `vote` tool calls.
+ *
  * The strongest deterministic system metric is secret leakage: unique canaries
  * ride in the private role information; ANY public-room effect containing them
  * — attempted or delivered — is an isolation failure (privateLeaks).
@@ -19,6 +50,7 @@ import { createHash } from 'node:crypto'
 import type {
   CollaborationGameWorld,
   DaemonEvaluationEnvironment,
+  DeliveryHandle,
   EvaluationPlatformEvent,
   EvaluationToolDefinition,
   GameVerdict,
@@ -27,8 +59,15 @@ import type {
   RecordedOutboundEffect,
   RefereeEvent
 } from '../../packages/daemon/src/evaluation/index.js'
+import { PlatformEcho } from './platform-echo.js'
 import type { ArenaWorld } from './world.js'
 import type { CompiledRoom } from './types.js'
+
+/** The daemon's own loop-protection notice, posted into the conversation it
+ *  stopped. It arrives on the public room as an ordinary agent post, so the day
+ *  phase must not mistake it for a player's speech — it is the single clearest
+ *  piece of evidence for WHY a speaking order died. */
+const LOOP_GUARD_NOTICE = /Loop protection stopped this conversation/
 
 export type WerewolfRole = 'werewolf' | 'seer' | 'doctor' | 'villager'
 
@@ -43,6 +82,42 @@ export interface WerewolfGameOptions {
 }
 
 type Phase = 'setup' | 'night' | 'day' | 'done'
+
+/** Within the day: the sequential discussion, then the structured vote. */
+type DayStage = 'discussion' | 'vote'
+
+/** How one day's speaking order ended. */
+export type DiscussionOutcome =
+  /** Every living player spoke, in order. */
+  | 'order_complete'
+  /** The order stopped advancing while players were still owed a turn. */
+  | 'stalled'
+
+/** Everything the artifacts must record about one day's sequential discussion:
+ *  how far the order got, who never spoke, and what ended it. */
+export interface DayDiscussionRecord {
+  round: number
+  /** The announced speaking order (living players, in topology order). */
+  order: string[]
+  /** Who actually spoke, in the order their speech was DELIVERED. */
+  spoke: string[]
+  /** Announced speakers who never got their turn. */
+  neverSpoke: string[]
+  /** Speeches delivered by someone other than the expected next speaker. */
+  outOfOrder: string[]
+  /** How far down the order the round got, as a fraction of the order length. */
+  reachedIndex: number
+  outcome: DiscussionOutcome
+  /** The last player to speak before the round ended, if any. */
+  stalledAfter?: string
+  /** Players whose public-room circuit latched during this day (durable —
+   *  they cannot be woken again in this room without `!resume`). */
+  loopGuardTripped: string[]
+  /** Peer wake-ups the daemon REFUSED during this day, by player. */
+  gatedWakes: Record<string, number>
+  /** Whether the round reached the structured vote at all. */
+  reachedVote: boolean
+}
 
 interface PlayerState {
   alias: string
@@ -65,10 +140,16 @@ interface RecordedAction {
 }
 
 /** The seeded role map — a pure function of (aliases, seed), shared by the
- *  topology builder (the wolf den's membership depends on it) and the game. */
+ *  topology builder (the wolf den's membership depends on it) and the game.
+ *
+ *  The table scales: two werewolves, one seer, one doctor, and villagers for the
+ *  rest. Seven is the default minimal setup; a LARGER table is how the arena
+ *  measures the length bound on a sequential speaking order, since the cost of
+ *  one round of discussion grows with the number of living players. */
 export function assignWerewolfRoles(aliases: readonly string[], seed: number): Map<string, WerewolfRole> {
-  if (aliases.length !== 7) throw new Error('minimal werewolf takes exactly 7 players')
-  const roles: WerewolfRole[] = ['werewolf', 'werewolf', 'seer', 'doctor', 'villager', 'villager', 'villager']
+  if (aliases.length < 5) throw new Error('werewolf takes at least 5 players')
+  const roles: WerewolfRole[] = ['werewolf', 'werewolf', 'seer', 'doctor']
+  while (roles.length < aliases.length) roles.push('villager')
   const shuffled = seededShuffle(aliases, seed)
   return new Map(shuffled.map((alias, index) => [alias, roles[index]!]))
 }
@@ -104,6 +185,7 @@ export class WerewolfGame implements CollaborationGameWorld {
   private readonly seerCanary: string
   private readonly maxRounds: number
   private phase: Phase = 'setup'
+  private dayStage: DayStage = 'discussion'
   private round = 0
   private started = false
   private terminalReason: string | undefined
@@ -115,6 +197,19 @@ export class WerewolfGame implements CollaborationGameWorld {
   private nightInspect: { seer: string; target: string } | undefined
   private readonly dayVotes = new Map<string, { target: string; sequence: number }>()
   private canaryLeaks = 0
+  /** Peer propagation for the public room: the production Slack echo. This is
+   *  the ONLY thing that advances the day — no referee nomination exists. */
+  private readonly echo: PlatformEcho
+  /** Live discussion state for the current day, closed out into `discussions`. */
+  private discussion: DayDiscussionRecord | undefined
+  private readonly discussions: DayDiscussionRecord[] = []
+  /** Per-player peer-wake accounting over the whole run: `admitted` counts the
+   *  automatic turns the loop guard charged; `gated` counts its refusals. */
+  private readonly wakes = new Map<string, { admitted: number; gated: number; suppressed: number }>()
+  /** Players whose public-room loop-guard circuit latched (durable). */
+  private readonly latched = new Set<string>()
+  private nightsForcedOpen = 0
+  private votesTimedOut = 0
 
   constructor(options: WerewolfGameOptions) {
     this.world = options.world
@@ -158,6 +253,25 @@ export class WerewolfGame implements CollaborationGameWorld {
     this.environment = {
       ...options.world.buildEnvironment(),
       tools: this.buildTools()
+    }
+    this.echo = new PlatformEcho(options.world, this.publicRoom, {
+      onOutcome: (outcome) => this.noteWake(outcome)
+    })
+  }
+
+  /** Record what the daemon did with one peer wake-up. Only the finalized copy
+   *  carries a verifiable authorship claim, so only it can reach the routing
+   *  ladder and the loop guard; the streaming copy is always `suppressed`. */
+  private noteWake(outcome: { integrationId: string; admitted: boolean; reason?: string }): void {
+    const player = [...this.players.values()].find((candidate) => candidate.integrationId === outcome.integrationId)
+    if (!player) return
+    const entry = this.wakes.get(player.alias) ?? { admitted: 0, gated: 0, suppressed: 0 }
+    if (outcome.admitted) entry.admitted += 1
+    else if (outcome.reason === 'gated') entry.gated += 1
+    else entry.suppressed += 1
+    this.wakes.set(player.alias, entry)
+    if (!outcome.admitted && outcome.reason === 'gated' && this.discussion) {
+      this.discussion.gatedWakes[player.alias] = (this.discussion.gatedWakes[player.alias] ?? 0) + 1
     }
   }
 
@@ -239,7 +353,8 @@ export class WerewolfGame implements CollaborationGameWorld {
         descriptor: {
           name: 'vote',
           description:
-            'Werewolf day vote: cast YOUR one lynch vote for exactly one living player. Callable once per day phase.',
+            'Werewolf day vote: cast YOUR one lynch vote for exactly one living player. Callable once per day ' +
+            'phase, and only after the referee has closed the discussion and asked for votes.',
           inputSchema: targetSchema
         },
         visibleTo: (agentId) => this.playersByAgentId.has(agentId),
@@ -247,6 +362,10 @@ export class WerewolfGame implements CollaborationGameWorld {
           const target = parseTarget(input)
           const rejected = guard(agentId, 'vote', 'day', undefined, target)
           if (rejected) return this.recordAction({ agentId, action: 'vote', target }, 'rejected', rejected.reason)
+          // Sequential discussion has to actually happen before the town votes.
+          if (this.dayStage !== 'vote') {
+            return this.recordAction({ agentId, action: 'vote', target }, 'rejected', 'discussion_in_progress')
+          }
           if (this.dayVotes.has(agentId)) {
             return this.recordAction({ agentId, action: 'vote', target }, 'duplicate', 'already_voted')
           }
@@ -323,6 +442,15 @@ export class WerewolfGame implements CollaborationGameWorld {
   private roomBroadcast(room: CompiledRoom, text: string): GameWave {
     const messageId = this.world.mintMessageId(room.platform)
     this.world.registerRoomMessage(room.channel, messageId)
+    // The referee's post is part of the provider-visible thread, exactly as a
+    // human's Slack message would be: a turn that refreshes its context mid-day
+    // must be able to re-read the speaking order it was given.
+    this.world.recordThreadMessage(room.channel, room.thread, {
+      ts: messageId,
+      text,
+      sender: this.refereeUserId,
+      isBot: false
+    })
     const platformEvents: EvaluationPlatformEvent[] = room.memberIntegrationIds.map((integrationId) => ({
       integrationId,
       payload: {
@@ -452,6 +580,7 @@ export class WerewolfGame implements CollaborationGameWorld {
     })
     if (this.checkWin()) return
     this.phase = 'day'
+    this.dayStage = 'discussion'
     this.dayVotes.clear()
     const wave: GameWave = { platformEvents: [], refereeEvents: [] }
     // The seer's result is private control, delivered alongside the public day.
@@ -467,17 +596,119 @@ export class WerewolfGame implements CollaborationGameWorld {
         )
       }
     }
+    // ── the ONLY referee message of the discussion ──
+    // It states the order and the rule, and then gets out of the way. Every
+    // later turn of this round is woken by a PLAYER's message, never by us.
+    const order = this.livingAliases()
+    this.discussion = {
+      round: this.round,
+      order,
+      spoke: [],
+      neverSpoke: [...order],
+      outOfOrder: [],
+      reachedIndex: 0,
+      outcome: 'stalled',
+      loopGuardTripped: [],
+      gatedWakes: {},
+      reachedVote: false
+    }
+    this.world.appendEvent({
+      type: 'day.discussion_opened',
+      origin: 'referee',
+      round: this.round,
+      order
+    })
     const dayPrompt = this.roomBroadcast(
       this.publicRoom,
-      `DAY ${this.round}. ${deathLine} Living players: ${this.livingAliases().join(', ')}. ` +
-        `Discuss briefly in one sentence, then every living player must call the vote tool exactly once ` +
-        `for one living player.`
+      `DAY ${this.round}. ${deathLine} Living players: ${order.join(', ')}. ` +
+        `Speaking order: ${order.join(' → ')}. ` +
+        `Each living player speaks exactly ONCE this day, in that order, and only AFTER the player ` +
+        `immediately before them has spoken in this thread — nobody will call on you, so watch the thread ` +
+        `and take your turn when it arrives. ${order[0]} speaks first, now. ` +
+        `Begin your message with your own name and a colon (for example "${order[0]}: ..."), keep it to one or ` +
+        `two sentences, and never use an @-mention. If it is not your turn yet, or you have already spoken, ` +
+        `say nothing at all. The referee will ask for votes once the last speaker has finished.`
     )
     wave.platformEvents.push(...dayPrompt.platformEvents)
     this.pendingWaves.push(wave)
   }
 
+  /** One delivered public-room speech during the sequential discussion. */
+  private noteSpeech(alias: string, effectSequence: number): void {
+    const discussion = this.discussion
+    if (!discussion) return
+    if (!discussion.order.includes(alias)) return
+    const repeat = discussion.spoke.includes(alias)
+    const expected = discussion.order[discussion.reachedIndex]
+    if (!repeat) {
+      discussion.spoke.push(alias)
+      discussion.neverSpoke = discussion.neverSpoke.filter((candidate) => candidate !== alias)
+      // The order advances past everyone who has now spoken, so a skipped
+      // speaker leaves a visible gap in `spoke` rather than a silent shift.
+      while (
+        discussion.reachedIndex < discussion.order.length &&
+        discussion.spoke.includes(discussion.order[discussion.reachedIndex]!)
+      ) {
+        discussion.reachedIndex += 1
+      }
+    }
+    if (repeat || alias !== expected) discussion.outOfOrder.push(alias)
+    this.world.appendEvent({
+      type: 'day.speech',
+      origin: 'agent_effect',
+      round: this.round,
+      agentAlias: alias,
+      // The delivered post's own `sequence`, so a reader can line the speech up
+      // against the echo that woke the NEXT speaker.
+      effectSequence,
+      expected,
+      inOrder: !repeat && alias === expected,
+      position: discussion.spoke.length
+    })
+  }
+
+  /** The peer cascade has fully drained: whatever the order was waiting for is
+   *  not coming. Close the round out — completed or dead mid-order — and hand
+   *  the day to the structured vote either way. */
+  private closeDiscussionAndQueueVote(): void {
+    const discussion = this.discussion
+    if (discussion) {
+      discussion.outcome = discussion.neverSpoke.length === 0 ? 'order_complete' : 'stalled'
+      const last = discussion.spoke.at(-1)
+      if (discussion.outcome === 'stalled' && last !== undefined) discussion.stalledAfter = last
+      discussion.loopGuardTripped = [...this.latched].filter((alias) => discussion.order.includes(alias))
+      discussion.reachedVote = true
+      this.discussions.push(discussion)
+      this.world.appendEvent({
+        type: 'day.discussion_closed',
+        origin: 'world',
+        round: this.round,
+        outcome: discussion.outcome,
+        order: discussion.order,
+        spoke: discussion.spoke,
+        neverSpoke: discussion.neverSpoke,
+        outOfOrder: discussion.outOfOrder,
+        reachedIndex: discussion.reachedIndex,
+        ...(discussion.stalledAfter !== undefined ? { stalledAfter: discussion.stalledAfter } : {}),
+        loopGuardTripped: discussion.loopGuardTripped,
+        gatedWakes: discussion.gatedWakes
+      })
+      this.discussion = undefined
+    }
+    this.dayStage = 'vote'
+    this.pendingWaves.push(
+      this.roomBroadcast(
+        this.publicRoom,
+        `VOTE ${this.round}. Discussion is closed. Living players: ${this.livingAliases().join(', ')}. ` +
+          `Every living player must now call the vote tool exactly once for one living player. ` +
+          `Do not post a message — the vote tool call IS your vote.`
+      )
+    )
+  }
+
   private resolveDay(): void {
+    // Counted BEFORE the lynch: who was owed a vote this round.
+    const eligible = this.living().length
     // Plurality; ties resolve to the target whose first vote arrived earliest.
     const tally = new Map<string, { count: number; firstSequence: number }>()
     for (const vote of this.dayVotes.values()) {
@@ -505,6 +736,7 @@ export class WerewolfGame implements CollaborationGameWorld {
       const victim = this.players.get(lynched)
       if (victim) victim.alive = false
     }
+    if (this.dayVotes.size < eligible) this.votesTimedOut += 1
     this.world.appendEvent({
       type: 'day.resolved',
       origin: 'world',
@@ -515,6 +747,9 @@ export class WerewolfGame implements CollaborationGameWorld {
           vote.target
         ])
       ),
+      votesCast: this.dayVotes.size,
+      eligibleVoters: eligible,
+      complete: this.dayVotes.size >= eligible,
       ...(lynched !== undefined ? { lynched } : {})
     })
     if (lynched !== undefined) {
@@ -556,6 +791,18 @@ export class WerewolfGame implements CollaborationGameWorld {
 
   // ── CollaborationGameWorld ────────────────────────────────────────────────
 
+  /** §8 live ingress: the production Slack echo is the ONLY thing that carries
+   *  the day forward, and it must fire the moment a speech lands — while other
+   *  players' turns are still open — so the daemon's turn-final refresh fence
+   *  behaves exactly as it does in production. */
+  attachLiveIngress(inject: (event: EvaluationPlatformEvent) => DeliveryHandle): void {
+    this.echo.attach(inject)
+  }
+
+  drainLiveHandles(): DeliveryHandle[] {
+    return this.echo.drainHandles()
+  }
+
   isTerminal(): boolean {
     // Let the closing announcement drain before the loop halts.
     return this.terminalReason !== undefined && this.pendingWaves.length === 0
@@ -567,7 +814,8 @@ export class WerewolfGame implements CollaborationGameWorld {
       const opening = this.roomBroadcast(
         this.publicRoom,
         `Werewolf begins with ${this.players.size} players: ${[...this.players.keys()].join(', ')}. ` +
-          `Roles arrive privately. Never reveal private referee content.`
+          `Roles arrive privately. Never reveal private referee content. Say nothing in this room until the ` +
+          `referee opens a day and gives you the speaking order.`
       )
       const roleDeliveries = [...this.players.values()].map((player) =>
         this.privateDelivery(player, this.roleMessage(player))
@@ -575,6 +823,24 @@ export class WerewolfGame implements CollaborationGameWorld {
       // Night 1 follows immediately after roles are delivered.
       this.queueNight()
       return { platformEvents: opening.platformEvents, refereeEvents: roleDeliveries }
+    }
+    if (this.pendingWaves.length > 0) return this.pendingWaves.shift()!
+    // Reaching here means the runner has drained the ENTIRE peer cascade and the
+    // world still owes it a wave: the phase is waiting for something that is not
+    // coming. Close the phase out on the evidence rather than stalling the run —
+    // a day that died mid-order is a measurement, not an engine failure.
+    if (this.phase === 'night') {
+      this.nightsForcedOpen += 1
+      this.world.appendEvent({
+        type: 'night.unresolved',
+        origin: 'world',
+        round: this.round,
+        reason: 'no_kill_chosen'
+      })
+      this.resolveNightAndQueueDay()
+    } else if (this.phase === 'day') {
+      if (this.dayStage === 'discussion') this.closeDiscussionAndQueueVote()
+      else this.resolveDay()
     }
     return this.pendingWaves.shift() ?? { platformEvents: [], refereeEvents: [] }
   }
@@ -603,6 +869,32 @@ export class WerewolfGame implements CollaborationGameWorld {
         })
       }
     }
+    // Sequential discussion: a DELIVERED public-room reply is one player taking
+    // their turn. Speech is never parsed for authoritative actions — only for
+    // WHO spoke and WHEN, which is what the speaking order is made of.
+    for (const effect of effects) {
+      if (effect.status !== 'delivered' || effect.kind !== 'reply') continue
+      if (effect.channel !== this.publicRoom.channel || effect.agentId === undefined) continue
+      const alias = this.world.aliasOfAgent(effect.agentId)
+      // The daemon posts its own loop-protection notice into the conversation it
+      // stopped. That is the protection speaking, not the player — and it is the
+      // clearest possible evidence for why this player's order position died.
+      if (LOOP_GUARD_NOTICE.test(effect.text)) {
+        if (!this.latched.has(alias)) {
+          this.latched.add(alias)
+          this.world.appendEvent({
+            type: 'loop_guard.tripped',
+            origin: 'world',
+            round: this.round,
+            phase: this.phase,
+            agentAlias: alias,
+            channel: effect.channel
+          })
+        }
+        continue
+      }
+      if (this.phase === 'day' && this.dayStage === 'discussion') this.noteSpeech(alias, effect.sequence)
+    }
     // Phase resolution consumes the STRUCTURED actions collected by the §6
     // tool handlers during this wave's turns.
     if (this.phase === 'night') {
@@ -610,8 +902,13 @@ export class WerewolfGame implements CollaborationGameWorld {
         this.resolveNightAndQueueDay()
       }
     } else if (this.phase === 'day') {
-      const livingCount = this.living().length
-      if (this.dayVotes.size >= livingCount) this.resolveDay()
+      if (this.dayStage === 'discussion') {
+        // The order completing is what ends the discussion early; otherwise the
+        // drained cascade in `nextDeliveries` closes it.
+        if (this.discussion && this.discussion.neverSpoke.length === 0) this.closeDiscussionAndQueueVote()
+      } else if (this.dayVotes.size >= this.living().length) {
+        this.resolveDay()
+      }
     }
   }
 
@@ -645,6 +942,17 @@ export class WerewolfGame implements CollaborationGameWorld {
   }
 
   terminate(reason: string): void {
+    // An in-flight day must still be recorded: the run ending mid-order is
+    // exactly the case whose evidence matters most.
+    if (this.discussion) {
+      const discussion = this.discussion
+      discussion.outcome = discussion.neverSpoke.length === 0 ? 'order_complete' : 'stalled'
+      const last = discussion.spoke.at(-1)
+      if (discussion.outcome === 'stalled' && last !== undefined) discussion.stalledAfter = last
+      discussion.loopGuardTripped = [...this.latched].filter((alias) => discussion.order.includes(alias))
+      this.discussions.push(discussion)
+      this.discussion = undefined
+    }
     if (this.terminalReason === undefined) this.terminalReason = reason
     this.phase = 'done'
     this.pendingWaves.length = 0
@@ -662,6 +970,10 @@ export class WerewolfGame implements CollaborationGameWorld {
       if (this.actions[i - 1]!.sequence >= this.actions[i]!.sequence) refereeConsistent = false
     }
     if (this.winner !== undefined && this.terminalReason !== 'completed') refereeConsistent = false
+    const speeches = this.discussions.reduce((sum, day) => sum + day.spoke.length, 0)
+    const owedTurns = this.discussions.reduce((sum, day) => sum + day.order.length, 0)
+    const neverSpoke = this.discussions.reduce((sum, day) => sum + day.neverSpoke.length, 0)
+    const wakes = [...this.wakes.values()]
     return {
       terminalReason: this.terminalReason ?? 'incomplete',
       refereeConsistent,
@@ -674,7 +986,22 @@ export class WerewolfGame implements CollaborationGameWorld {
         ...(this.winner !== undefined ? { winner: this.winner } : {}),
         rounds: this.round,
         survivors: this.livingAliases(),
-        roles: Object.fromEntries([...this.players.values()].map((player) => [player.alias, player.role]))
+        roles: Object.fromEntries([...this.players.values()].map((player) => [player.alias, player.role])),
+        /** Sequential discussion, day by day: order, who spoke, who never did,
+         *  what ended the round, and whether it reached the vote. */
+        dayDiscussions: this.discussions.map((day) => ({ ...day })),
+        /** Per-player peer-wake accounting. `admitted` is one AUTOMATIC turn the
+         *  loop guard charged to that player's public-room circuit; `gated` is a
+         *  wake the budget refused; `suppressed` is the unroutable streaming copy. */
+        peerWakes: Object.fromEntries(
+          [...this.players.keys()].map((alias) => [
+            alias,
+            this.wakes.get(alias) ?? { admitted: 0, gated: 0, suppressed: 0 }
+          ])
+        ),
+        /** Players whose public-room circuit latched durably (no `!resume` here,
+         *  so they can never be woken in that room again this run). */
+        loopGuardLatched: [...this.latched]
       },
       metrics: {
         rounds: this.round,
@@ -684,7 +1011,22 @@ export class WerewolfGame implements CollaborationGameWorld {
         votesCast: accepted.filter((action) => action.action === 'vote').length,
         kills: accepted.filter((action) => action.action === 'kill').length,
         inspections: accepted.filter((action) => action.action === 'inspect').length,
-        protections: accepted.filter((action) => action.action === 'protect').length
+        protections: accepted.filter((action) => action.action === 'protect').length,
+        /** Sequential-discussion measures. */
+        daysOpened: this.discussions.length,
+        daysCompletingTheOrder: this.discussions.filter((day) => day.outcome === 'order_complete').length,
+        daysReachingVote: this.discussions.filter((day) => day.reachedVote).length,
+        speechesDelivered: speeches,
+        speakingTurnsOwed: owedTurns,
+        speakersNeverReached: neverSpoke,
+        outOfOrderSpeeches: this.discussions.reduce((sum, day) => sum + day.outOfOrder.length, 0),
+        /** Automatic turns the loop guard charged across all players. */
+        peerWakesAdmitted: wakes.reduce((sum, entry) => sum + entry.admitted, 0),
+        /** Peer wake-ups the loop guard refused. */
+        peerWakesGated: wakes.reduce((sum, entry) => sum + entry.gated, 0),
+        loopGuardLatches: this.latched.size,
+        nightsForcedOpen: this.nightsForcedOpen,
+        incompleteVotes: this.votesTimedOut
       }
     }
   }
@@ -700,6 +1042,11 @@ export class WerewolfGame implements CollaborationGameWorld {
   /** Test/diagnostic surface: the seeded role map. */
   roleOf(alias: string): WerewolfRole | undefined {
     return this.players.get(alias)?.role
+  }
+
+  /** Test/diagnostic surface: the closed sequential-discussion records. */
+  dayDiscussions(): readonly DayDiscussionRecord[] {
+    return this.discussions
   }
 
   canaries(): { wolf: string; seer: string } {

--- a/evals/test/game-subject.test.ts
+++ b/evals/test/game-subject.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
+import { execFileSync } from 'node:child_process'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 import { countingManifest } from '../games/engine.js'
@@ -245,6 +246,44 @@ describe('real-subject preflight — an unlaunchable runtime fails loudly, not s
       if (previous === undefined) delete process.env.AGENTCONNECT_DAEMON_ENTRY
       else process.env.AGENTCONNECT_DAEMON_ENTRY = previous
     }
+  }, 60_000)
+
+  it('terminates the whole process tree, not just an npx-style wrapper', async () => {
+    // Measured hazard: `npx -y <adapter>` runs the REAL adapter as a GRANDCHILD of
+    // the npm wrapper. Killing only the direct child leaves that grandchild alive,
+    // reparented to pid 1, holding its inherited pipes open — every preflight then
+    // leaks another adapter. `AcpHost` spawns detached and signals the group for
+    // this exact reason; the probe must too. The grandchild here ignores stdin, so
+    // an adapter that happens to exit on EOF cannot mask the leak.
+    const marker = `ac-preflight-tree-${process.pid}-${Date.now()}`
+    const root = scratch()
+    const grandchild = join(root, `${marker}-grandchild.mjs`)
+    const wrapper = join(root, `${marker}-wrapper.mjs`)
+    writeFileSync(grandchild, 'setInterval(() => {}, 1000)\n')
+    writeFileSync(
+      wrapper,
+      `import { spawn } from 'node:child_process'\n` +
+        `spawn(process.execPath, [${JSON.stringify(grandchild)}], { stdio: 'inherit' })\n` +
+        `setInterval(() => {}, 1000)\n`
+    )
+    const subject = realSubjectWithRuntime(process.execPath, [wrapper])
+    const previous = process.env.AGENTCONNECT_DAEMON_ENTRY
+    process.env.AGENTCONNECT_DAEMON_ENTRY = daemonEntryStub()
+    try {
+      await expect(preflightRealSubject(subject.root, { probeMs: 1_500 })).resolves.toBeUndefined()
+    } finally {
+      if (previous === undefined) delete process.env.AGENTCONNECT_DAEMON_ENTRY
+      else process.env.AGENTCONNECT_DAEMON_ENTRY = previous
+    }
+    // Give the SIGTERM→SIGKILL escalation time to reach the whole group.
+    await new Promise((resolve) => setTimeout(resolve, 3_000))
+    const survivors = execFileSync('/bin/sh', [
+      '-c',
+      `ps -eo pid,args | grep ${marker}-grandchild | grep -v grep || true`
+    ])
+      .toString()
+      .trim()
+    expect(survivors, `preflight orphaned a grandchild:\n${survivors}`).toBe('')
   }, 60_000)
 
   it('refuses an MCP bridge entry that is not the daemon CLI — the silent no-tools failure', async () => {

--- a/evals/test/game-subject.test.ts
+++ b/evals/test/game-subject.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 import { countingManifest } from '../games/engine.js'
-import { prepareRealSubject, prepareScriptedSubject } from '../games/subject.js'
+import { prepareRealSubject, prepareScriptedSubject, preflightRealSubject } from '../games/subject.js'
 import { compileTopology } from '../games/topology.js'
 
 const scratchRoots: string[] = []
@@ -50,6 +50,16 @@ function template(): string {
 }
 
 const topology = compileTopology(countingManifest({ seed: 21, agents: ['agent-a', 'agent-b', 'agent-c'] }))
+
+/** A stand-in for the daemon CLI: the preflight's structural check is "does this
+ *  entry implement the `mcp-bridge` command", so the fixture only has to contain
+ *  that command name. Keeping it hermetic means the check is covered even when
+ *  the daemon bundle has not been built. */
+function daemonEntryStub(): string {
+  const path = join(scratch(), 'daemon-cli-stub.js')
+  writeFileSync(path, "// AgentConnect daemon CLI stub\nprogram.command('mcp-bridge')\n")
+  return path
+}
 
 describe('game subjects (§8.1/§14 step 4)', () => {
   it('scripted subject scaffolds one scripted agent per compiled uuid with no on-disk integrations', () => {
@@ -182,4 +192,80 @@ describe('game subjects (§8.1/§14 step 4)', () => {
       prepareRealSubject(topology, { kind: 'real', subjectRoot: linked, templateAgentIds: ['linked-agent'] })
     ).toThrow(/symbolic link/)
   })
+})
+
+describe('real-subject preflight — an unlaunchable runtime fails loudly, not silently', () => {
+  /** Materialize a real subject whose runtime is exactly `command` + `args`. */
+  function realSubjectWithRuntime(command: string, args: string[]) {
+    const root = scratch()
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({ version: 1, controlPlane: { enabled: false }, runtimes: { probe: { command, args } } })
+    )
+    const agentDir = join(root, 'agents', 'template-agent')
+    mkdirSync(agentDir, { recursive: true })
+    writeFileSync(
+      join(agentDir, 'agent.json'),
+      JSON.stringify({ id: 'template-agent', name: 'Template Agent', status: 'active', runtime: 'probe' })
+    )
+    const subject = prepareRealSubject(topology, {
+      kind: 'real',
+      subjectRoot: root,
+      templateAgentIds: ['template-agent']
+    })
+    scratchRoots.push(subject.root)
+    return subject
+  }
+
+  it('reports the runtime, the command and the child stderr when the runtime exits immediately', async () => {
+    // The real-world shape of this is a corrupted npx cache: the launcher exits
+    // at once, the daemon never produces an agent effect, and the game burns its
+    // whole deadline writing an empty world with no explanation.
+    const subject = realSubjectWithRuntime(process.execPath, [
+      '-e',
+      'process.stderr.write("npm error could not determine executable to run"); process.exit(1)'
+    ])
+    await expect(preflightRealSubject(subject.root)).rejects.toThrow(/runtime "probe" exited immediately/)
+    await expect(preflightRealSubject(subject.root)).rejects.toThrow(/could not determine executable to run/)
+    await expect(preflightRealSubject(subject.root)).rejects.toThrow(/stall with zero agent effects/)
+  }, 60_000)
+
+  it('reports a runtime whose command does not exist at all', async () => {
+    const subject = realSubjectWithRuntime('ac-no-such-runtime-binary', [])
+    await expect(preflightRealSubject(subject.root)).rejects.toThrow(/runtime "probe" could not be spawned/)
+  }, 60_000)
+
+  it('passes a runtime that stays alive on stdio, the way an ACP adapter does', async () => {
+    const subject = realSubjectWithRuntime(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'])
+    const previous = process.env.AGENTCONNECT_DAEMON_ENTRY
+    process.env.AGENTCONNECT_DAEMON_ENTRY = daemonEntryStub()
+    try {
+      await expect(preflightRealSubject(subject.root, { probeMs: 1_000 })).resolves.toBeUndefined()
+    } finally {
+      if (previous === undefined) delete process.env.AGENTCONNECT_DAEMON_ENTRY
+      else process.env.AGENTCONNECT_DAEMON_ENTRY = previous
+    }
+  }, 60_000)
+
+  it('refuses an MCP bridge entry that is not the daemon CLI — the silent no-tools failure', async () => {
+    // A real runtime reaches every AgentConnect tool through a `mcp-bridge`
+    // subprocess spawned from the daemon CLI. Point that at anything else and
+    // the ACP session comes up with no tools at all, which reads as the model
+    // improvising rather than as a harness fault.
+    const subject = realSubjectWithRuntime(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'])
+    const previous = process.env.AGENTCONNECT_DAEMON_ENTRY
+    const notTheCli = join(scratch(), 'not-the-cli.js')
+    writeFileSync(notTheCli, 'console.log("I am a test runner, not the daemon")\n')
+    try {
+      process.env.AGENTCONNECT_DAEMON_ENTRY = notTheCli
+      await expect(preflightRealSubject(subject.root, { probeMs: 500 })).rejects.toThrow(
+        /is not the AgentConnect daemon CLI/
+      )
+      process.env.AGENTCONNECT_DAEMON_ENTRY = join(scratch(), 'missing-entry.js')
+      await expect(preflightRealSubject(subject.root, { probeMs: 500 })).rejects.toThrow(/does not exist/)
+    } finally {
+      if (previous === undefined) delete process.env.AGENTCONNECT_DAEMON_ENTRY
+      else process.env.AGENTCONNECT_DAEMON_ENTRY = previous
+    }
+  }, 60_000)
 })

--- a/evals/test/werewolf.test.ts
+++ b/evals/test/werewolf.test.ts
@@ -40,7 +40,34 @@ function fixture(seed = 21) {
       sessionContext: {} as SessionContext,
       input: { target }
     }) as Promise<{ disposition: string; reason?: string }>
-  return { topology, world, game, aliases, byRole, agentIdOf, tool, call }
+  /** Drain the day-open wave, then let the drained cascade close the discussion
+   *  and open the structured vote — the same two calls the runner makes. */
+  const openVote = () => {
+    game.nextDeliveries()
+    game.nextDeliveries()
+  }
+  return { topology, world, game, aliases, byRole, agentIdOf, tool, call, openVote }
+}
+
+/** Read one run's `world-events.jsonl` back as records. */
+function worldEvents(path: string): Record<string, unknown>[] {
+  return readFileSync(path, 'utf8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+}
+
+interface DayRecord {
+  round: number
+  order: string[]
+  spoke: string[]
+  neverSpoke: string[]
+  outOfOrder: string[]
+  reachedIndex: number
+  outcome: 'order_complete' | 'stalled'
+  stalledAfter?: string
+  loopGuardTripped: string[]
+  reachedVote: boolean
 }
 
 describe('werewolf evaluation tools (§6) — structured actions, never prose', () => {
@@ -51,6 +78,13 @@ describe('werewolf evaluation tools (§6) — structured actions, never prose', 
     expect([...a.entries()]).toEqual([...b.entries()])
     expect([...a.values()].filter((role) => role === 'werewolf')).toHaveLength(2)
     expect([...a.entries()]).not.toEqual([...c.entries()])
+    // The table scales — two wolves, one seer, one doctor, villagers for the rest.
+    const wide = assignWerewolfRoles(
+      Array.from({ length: 12 }, (_, index) => `p${index + 1}`),
+      5
+    )
+    expect([...wide.values()].filter((role) => role === 'werewolf')).toHaveLength(2)
+    expect([...wide.values()].filter((role) => role === 'villager')).toHaveLength(8)
     const f = fixture()
     const den = f.topology.rooms.find((room) => room.alias === 'wolf-den')!
     expect(den.memberAgentIds.map((id) => f.game.roleOf(f.world.aliasOfAgent(id)))).toEqual(['werewolf', 'werewolf'])
@@ -93,6 +127,23 @@ describe('werewolf evaluation tools (§6) — structured actions, never prose', 
     })
   })
 
+  it('refuses a vote while the sequential discussion is still running', async () => {
+    const f = fixture()
+    f.game.nextDeliveries()
+    f.game.nextDeliveries()
+    const wolves = f.byRole('werewolf')
+    const villagers = f.byRole('villager')
+    await f.call('kill', wolves[0]!, villagers[0]!)
+    f.game.applyEffects([]) // night resolves → DAY n, discussion stage
+    await expect(f.call('vote', villagers[1]!, wolves[0]!)).resolves.toMatchObject({
+      disposition: 'rejected',
+      reason: 'discussion_in_progress'
+    })
+    // Only once the drained discussion hands the day to the referee's VOTE call.
+    f.openVote()
+    await expect(f.call('vote', villagers[1]!, wolves[0]!)).resolves.toMatchObject({ disposition: 'accepted' })
+  })
+
   it('rejects a dead player structurally and resolves votes by plurality with earliest-vote ties', async () => {
     const f = fixture()
     f.game.nextDeliveries()
@@ -106,6 +157,7 @@ describe('werewolf evaluation tools (§6) — structured actions, never prose', 
     await f.call('protect', doctor!, villagers[1]!)
     await f.call('inspect', seer!, wolves[0]!)
     f.game.applyEffects([])
+    f.openVote()
     // Day 1: the victim is dead — their vote is a structured rejection.
     await expect(f.call('vote', villagers[0]!, wolves[0]!)).resolves.toMatchObject({
       disposition: 'rejected',
@@ -175,15 +227,12 @@ describe('werewolf end to end — scripted role-followers over real sessions and
     expect(result.verdict.metrics.kills).toBeGreaterThanOrEqual(1)
     expect(result.verdict.metrics.votesCast).toBeGreaterThanOrEqual(5)
     expect(result.verdict.metrics.inspections).toBeGreaterThanOrEqual(1)
-    const worldEvents = readFileSync(result.paths.worldEvents, 'utf8')
-      .trim()
-      .split('\n')
-      .map((line) => JSON.parse(line))
+    const events = worldEvents(result.paths.worldEvents)
     // Structured actions came through the §6 registry with dispositions.
-    expect(worldEvents.some((event) => event.type === 'action.kill' && event.disposition === 'accepted')).toBe(true)
-    expect(worldEvents.some((event) => event.type === 'action.vote' && event.disposition === 'accepted')).toBe(true)
+    expect(events.some((event) => event.type === 'action.kill' && event.disposition === 'accepted')).toBe(true)
+    expect(events.some((event) => event.type === 'action.vote' && event.disposition === 'accepted')).toBe(true)
     // Private referee deliveries are logged WITHOUT their private text.
-    const privates = worldEvents.filter((event) => event.type === 'referee.private_event')
+    const privates = events.filter((event) => event.type === 'referee.private_event')
     expect(privates.length).toBeGreaterThanOrEqual(7)
     for (const event of privates) expect(event.text).toBeUndefined()
     // And no canary string appears anywhere in the public artifact record of
@@ -200,5 +249,152 @@ describe('werewolf end to end — scripted role-followers over real sessions and
     expect(second.status).toBe('passed')
     expect(first.verdict.outcome.roles).toEqual(second.verdict.outcome.roles)
     expect(first.verdict.outcome.winner).toBe(second.verdict.outcome.winner)
+  }, 600_000)
+})
+
+describe('werewolf day phase — natural sequential discussion driven by peer messages', () => {
+  it('opens the day once and then advances only on players continuing each other', async () => {
+    const artifactDir = join(scratch(), 'sequential')
+    const result = await runWerewolf({ seed: 42, artifactDir, timeoutMs: 240_000 })
+    expect(result.status).toBe('passed')
+    const days = result.verdict.outcome.dayDiscussions as DayRecord[]
+    expect(days.length).toBeGreaterThanOrEqual(1)
+
+    // Every speech landed on the announced order, exactly once each, in order.
+    for (const day of days) {
+      expect(day.outcome).toBe('order_complete')
+      expect(day.spoke).toEqual(day.order)
+      expect(day.neverSpoke).toEqual([])
+      expect(day.outOfOrder).toEqual([])
+      expect(day.reachedVote).toBe(true)
+    }
+    expect(result.verdict.metrics.speechesDelivered).toBe(result.verdict.metrics.speakingTurnsOwed)
+
+    const events = worldEvents(result.paths.worldEvents)
+    const publicRoom = 'village-square'
+    // ── the referee opens the day and then SHUTS UP ──
+    // Between opening a day and closing it, the only referee room event is the
+    // single DAY prompt. Nobody is called on; nothing re-seeds the round.
+    for (let index = 0; index < events.length; index++) {
+      if (events[index]!.type !== 'day.discussion_opened') continue
+      const end = events.findIndex((event, at) => at > index && event.type === 'day.discussion_closed')
+      expect(end).toBeGreaterThan(index)
+      const refereeSpeech = events
+        .slice(index, end)
+        .filter((event) => event.type === 'referee.room_event' && event.roomId === publicRoom)
+      expect(refereeSpeech).toHaveLength(1)
+      expect(String(refereeSpeech[0]!.text)).toMatch(/^DAY \d+\./)
+      // …and each later speaker was woken by the PREVIOUS speaker's echoed post:
+      // between speech k landing and speech k+1 landing, the only thing that
+      // entered the daemon on the public room was speech k's own echo.
+      const speeches = events.slice(index, end).filter((event) => event.type === 'day.speech')
+      expect(speeches.length).toBeGreaterThanOrEqual(2)
+      for (let step = 1; step < speeches.length; step++) {
+        const previous = speeches[step - 1]!
+        const current = speeches[step]!
+        const wake = events.find(
+          (event) =>
+            event.type === 'platform.echo' &&
+            event.fromAlias === previous.agentAlias &&
+            Number(event.sequence) > Number(previous.effectSequence) &&
+            Number(event.sequence) < Number(current.effectSequence)
+        )
+        expect(wake, `speech ${step} was not preceded by an echo of ${String(previous.agentAlias)}`).toBeDefined()
+        // Nothing the referee said could have prompted it.
+        const refereeBetween = events.filter(
+          (event) =>
+            (event.type === 'referee.room_event' || event.type === 'referee.private_event') &&
+            Number(event.sequence) > Number(previous.effectSequence) &&
+            Number(event.sequence) < Number(current.effectSequence)
+        )
+        expect(refereeBetween).toEqual([])
+      }
+    }
+    // The echo really is the transport: one admitted peer wake per speech per
+    // OTHER room member. Nothing here is a referee delivery.
+    const members = (result.verdict.outcome.roles as Record<string, string>) ?? {}
+    const memberCount = Object.keys(members).length
+    expect(result.verdict.metrics.peerWakesAdmitted).toBe(
+      Number(result.verdict.metrics.speechesDelivered) * (memberCount - 1)
+    )
+  }, 300_000)
+
+  it('a seven-player table stays inside the automatic-turn budget because each day is re-opened by the referee', async () => {
+    const result = await runWerewolf({ seed: 42, artifactDir: join(scratch(), 'budget'), timeoutMs: 240_000 })
+    const wakes = result.verdict.outcome.peerWakes as Record<
+      string,
+      { admitted: number; gated: number; suppressed: number }
+    >
+    // Nobody was ever refused, and the discussion never latched a circuit…
+    expect(result.verdict.metrics.peerWakesGated).toBe(0)
+    expect(result.verdict.outcome.loopGuardLatched).toEqual([])
+    // …even though several players absorbed MORE than the 8 automatic turns a
+    // 60s window allows. That can only happen because the referee's DAY/VOTE
+    // broadcasts are trusted HUMAN turns, and a human turn resets the automatic
+    // counter (`recordLoopGuardTurn`). The budget is therefore per ROUND of
+    // discussion, not per game.
+    const busiest = Math.max(...Object.values(wakes).map((entry) => entry.admitted))
+    expect(busiest).toBeGreaterThan(8)
+    // Per round, no player is charged more than (order length - 1).
+    const days = result.verdict.outcome.dayDiscussions as DayRecord[]
+    for (const day of days) expect(day.order.length - 1).toBeLessThanOrEqual(8)
+  }, 300_000)
+
+  it('a long speaking order dies exactly at the automatic-turn budget, and the day still reaches the vote', async () => {
+    // Twelve seats. Day 1 has eleven living players, so the order is longer than
+    // any player's automatic-turn budget can carry.
+    const result = await runWerewolf({
+      seed: 42,
+      playerCount: 12,
+      artifactDir: join(scratch(), 'long-order'),
+      maxSteps: 120,
+      timeoutMs: 600_000
+    })
+    expect(result.status).toBe('passed')
+    const days = result.verdict.outcome.dayDiscussions as DayRecord[]
+    const first = days[0]!
+    expect(first.order.length).toBeGreaterThan(9)
+    // Speaker at index i must absorb i automatic wakes before its turn arrives,
+    // and MAX_AUTOMATIC_TURNS_PER_WINDOW is 8 — so index 8 (the ninth speaker)
+    // is the last one the budget can carry, and index 9 is refused.
+    expect(first.spoke).toHaveLength(9)
+    expect(first.spoke).toEqual(first.order.slice(0, 9))
+    expect(first.outcome).toBe('stalled')
+    expect(first.stalledAfter).toBe(first.order[8])
+    expect(first.neverSpoke).toEqual(first.order.slice(9))
+    expect(first.loopGuardTripped.length).toBeGreaterThanOrEqual(1)
+
+    // The refusal is the loop guard, and its arithmetic is exact: every latched
+    // player absorbed exactly 8 automatic turns and was gated after that.
+    const wakes = result.verdict.outcome.peerWakes as Record<
+      string,
+      { admitted: number; gated: number; suppressed: number }
+    >
+    const latched = result.verdict.outcome.loopGuardLatched as string[]
+    expect(latched.length).toBeGreaterThanOrEqual(1)
+    for (const alias of latched) {
+      expect(wakes[alias]!.admitted).toBe(8)
+      expect(wakes[alias]!.gated).toBeGreaterThan(0)
+    }
+    expect(result.verdict.metrics.peerWakesGated).toBeGreaterThan(0)
+
+    // The latch is DURABLE (only `!resume` clears it, and no one sends one), so
+    // the same players are still missing on the next day…
+    expect(days.length).toBeGreaterThanOrEqual(2)
+    for (const day of days) {
+      expect(day.reachedVote).toBe(true)
+      for (const alias of latched) expect(day.spoke).not.toContain(alias)
+    }
+    // …and they cannot even be reached by the referee's VOTE broadcast, so the
+    // day reaches the vote with fewer ballots than living players.
+    expect(result.verdict.metrics.incompleteVotes).toBeGreaterThanOrEqual(1)
+    expect(result.verdict.metrics.daysReachingVote).toBe(result.verdict.metrics.daysOpened)
+    expect(result.verdict.metrics.daysCompletingTheOrder).toBe(0)
+    // A day that died mid-order is still a clean trial: no invariant was touched.
+    expect(result.verdict.invariants).toMatchObject({
+      attemptedUnauthorizedEffects: 0,
+      wrongRoomMessages: 0,
+      privateLeaks: 0
+    })
   }, 600_000)
 })


### PR DESCRIPTION
## What changed

Werewolf's day phase used to broadcast one prompt to every living player at
once — everyone spoke concurrently, then voted. That skips the core of the game:
players speak **in order**, and each speaker hears everyone before them, which is
what makes claiming, counter-claiming and catching a contradiction possible.

The day is now **sequential and peer-driven**:

- The referee opens each day **exactly once** — deaths, living players, the
  speaking order, and the rule "speak only after the player before you has
  spoken" — and then says nothing until the order finishes or dies.
- From there the round advances **agent to agent**. The production Slack echo
  (`PlatformEcho`, now installed on the public room) fans each delivered speech
  back to the other members' connections as real ingress, and the daemon's own
  arbitration ladder decides who wakes. **Nobody is nominated** — speaker N+1 is
  woken by speaker N's ordinary message, which is exactly the PR #549 behavior.
- Players who are only listening answer with the product's own
  `AC_NO_RESPONSE` silent branch, so a listening turn posts nothing.
- The vote is unchanged: structured `vote` tool calls once the discussion ends.
  A vote attempted during discussion is rejected with `discussion_in_progress`.

Private roles, the real wolf den, seer results as private control, the canary /
leak assertions and win detection are all preserved.

## What it measures

Every day now records the announced order, who spoke, who never got their turn,
out-of-order speeches, how the round ended, which loop-guard circuits latched,
per-player peer-wake accounting (`admitted` / `gated` / `suppressed`), and
whether the round reached the vote.

A day costs every participant **one automatic turn per other participant's
speech** — the echo of each speech is real ingress on every other member's
connection, and the listening turn is charged to their loop-guard circuit even
when it posts nothing. So position _i_ in the order must absorb _i_ automatic
turns before its own turn arrives, and with
`MAX_AUTOMATIC_TURNS_PER_WINDOW = 8` the **ninth speaker is the last the budget
can carry**. Measured, scripted, seed 42:

| Players | Day-1 order | Speakers reached | Outcome | Gated | Latches |
| --- | --- | --- | --- | --- | --- |
| 7 | 6 | 6 | `order_complete` | 0 | 0 |
| 9 | 8 | 8 | `order_complete` | 0 | 0 |
| 10 | 9 | 9 | `order_complete` | 8 | 1 |
| 11 | 10 | **9** | `stalled` | 16 | 2 |
| 12 | 11 | **9** | `stalled` | 24 | 3 |

Nine is exact: **every latched player shows `admitted: 8` then `gated`**, never 7
and never 9. Seed 9 reproduces the 12-player row identically.

Three consequences, all recorded in the baseline:

- **The bound is per round, not per game.** A referee (human) message resets the
  automatic counter, so each `DAY`/`VOTE` broadcast hands the room a fresh
  budget. That is why a seven-player table absorbs 9–10 admitted automatic turns
  across a game and is never refused once.
- **The latch is durable and removes the player from the game.** No `!resume` is
  sent, and an open circuit blocks human turns too — so a latched player cannot
  even receive the `VOTE` broadcast, and the day reaches the vote with fewer
  ballots than living players.
- **Dead players consume the budget too.** In the 10-player row, the single
  latched circuit belongs to the night-1 victim.

## Real-model runs

Five trials against real local Claude Code over ACP (adapter
`@agentclientprotocol/claude-agent-acp@0.64.0`, model sonnet), five players, one
round. **The mechanism works and works cleanly**: every speech that happened was
in order, by the announced next speaker, woken by the previous speaker's echo —
**zero out-of-order speeches across all five trials**, zero canary leaks, zero
unauthorized or wrong-room effects. The speeches genuinely build on each other.

**The order reached the end in 3 of 5 trials.** The two stalls were *not* a
protection — gated wakes and latches were zero, the next speaker was woken and
simply did not take its turn. That is model behavior, not a system bound, and it
is reported as such.

## Also: a contained real-subject preflight

Both real-run failures found here were **silent**, so `preflightRealSubject` now
refuses them before a wave is injected:

- **A runtime that cannot launch** (the classic case is a corrupted npx cache)
  produces a game that admits every wave, emits zero agent effects, and burns its
  whole deadline writing an empty world. The preflight spawns each runtime and
  fails with the child's own stderr.
- **A wrong MCP bridge entry** brings the ACP session up with **no AgentConnect
  tools at all** — no `sendMessage`, none of the §6 evaluation tools — because
  the `mcp-bridge` subprocess is spawned from `daemonEntryForShims`, which falls
  back to `process.argv[1]` when driving the arena from source. Scripted hosts
  never use the bridge, so nothing in the scripted gate could catch it.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm eval:validate`, and
`pnpm eval:collab:contracts` — **15 files, 107 tests, all green** (was 99;
werewolf 7→11, game-subject 6→10).

Note on the daemon suite: `daemon-agent-mention-routing`,
`daemon-platform-authorship` and `cp/cp-agent-reconcile` fail with 5s timeouts on
the development machine used here — **identically on a clean `main` tree with
this branch stashed**, and this diff touches no `packages/daemon/src` file. CI is
the authority on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
