### PR TITLE
fix(memory): let Slack/Feishu channel sessions use memory

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -569,12 +569,18 @@ the guarantee is "private hides the transcript at CP commit and stops
 feeding shared memory once every affected daemon has acked (`applied`)",
 not retroactive amnesia.
 
-Shared external sessions are always excluded from managed shared-memory
-capture and recall, even while the provider access-sync switch is disabled. This
-prevents a provider-scoped conversation from feeding a broader organization
-memory namespace. The gate covers AgentConnect-managed and external memory
-paths; a runtime's own opaque/native memory cannot be isolated per session by
-AgentConnect and must not be presented as covered by this guarantee.
+External-source (Slack/Feishu channel) sessions are **not** excluded from managed
+shared-memory capture merely for being external — they behave like any other
+channel (Discord/Telegram already did), so agents remember what happens in the
+channels they work in. Only an explicitly `private` session is excluded; the
+external audience is still tracked for console access and source-binding, but no
+longer forces a memory hard-deny. The product tradeoff (an external channel may
+seat non-org members whose words then enter agent-scoped memory) is accepted by
+default; set a session `private` to exclude it. DM / webchat / A2A-child /
+launch-correlated sessions stay excluded as before. The gate covers
+AgentConnect-managed and external memory paths; a runtime's own opaque/native
+memory cannot be isolated per session by AgentConnect and must not be presented as
+covered by this guarantee.
 
 Per-owner memory namespaces are a possible future relaxation, but the
 exclusion gate is the shipping requirement — the `private` tier's guarantee

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -124,9 +124,10 @@ describe('notifySessions', () => {
     await current.push.notifySessions([
       session({ visibility: 'external', externalProvider: 'slack', ownerIdentity: null })
     ])
+    // External sessions capture like org now — only `private` excludes memory.
     expect(current.sessionVisibility).toHaveBeenCalledWith(
       DAEMON,
-      expect.objectContaining({ visibility: 'external', sharedMemoryExcluded: true })
+      expect.objectContaining({ visibility: 'external', sharedMemoryExcluded: false })
     )
   })
 

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -57,7 +57,11 @@ function toPush(s: SessionMetaRecord): SessionVisibilityPush {
   return {
     sessionId: s.id,
     visibility: s.visibility,
-    sharedMemoryExcluded: s.visibility !== 'org' || s.externalProvider != null,
+    // An external-source session (Slack/Feishu channel) is no longer memory-
+    // excluded just for being external — `external` visibility now captures like
+    // `org`. Only an explicitly `private` session excludes memory
+    // (session-visibility.md §5.1).
+    sharedMemoryExcluded: s.visibility === 'private',
     visibilityRev: s.visibilityRev
   }
 }

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -1594,7 +1594,10 @@ export class PgSessionRepo implements SessionRepo {
     return rows.map((r) => ({
       sessionId: SessionId(r.id),
       visibility: r.visibility as SessionVisibility,
-      sharedMemoryExcluded: r.visibility !== 'org' || r.externalProvider !== null,
+      // External-source sessions are no longer memory-excluded just for being
+      // external; only an explicitly `private` session excludes memory
+      // (session-visibility.md §5.1). Keep this in step with `toPush`.
+      sharedMemoryExcluded: r.visibility === 'private',
       visibilityRev: r.visibilityRev
     }))
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5150,10 +5150,11 @@ export class Daemon {
   ): void {
     if (this.evaluationProfile.memory === 'off') return
     if (!output.trim()) return
-    // Agent memory is agent-scoped and shared across users, so an isolated
-    // private or external session's turn must never be distilled into it. The
-    // gate is checked HERE — before both the managed distillation and the
-    // external capture outbox — and fails closed on unknown state.
+    // Agent memory is agent-scoped and shared across users, so a memory-excluded
+    // session's turn (a `private` session, or a DM / webchat / A2A-child /
+    // launch-correlated one) must never be distilled into it. The gate is checked
+    // HERE — before both the managed distillation and the external capture outbox
+    // — and fails closed on unknown state.
     if (this.store.isCaptureExcluded(sessionId)) return
     const provider = binding?.provider ?? 'managed'
     const observableCapture = provider === 'managed' || provider === 'external'

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12386,8 +12386,7 @@ export class Daemon {
               : callMeta !== undefined ||
                 msg.isDm ||
                 msg.platform === 'webchat' ||
-                this.pendingLaunchCorrelation.has(agentId) ||
-                this.conversationExternalSource(agentId, msg, callMeta !== undefined) !== undefined),
+                this.pendingLaunchCorrelation.has(agentId)),
           ...(remoteMcpServer ? { additionalMcpServers: [remoteMcpServer] } : {}),
           ...(webchat?.worktree !== undefined
             ? { workspaceIsolation: webchat.worktree ? ('session' as const) : ('shared' as const) }
@@ -16044,13 +16043,12 @@ export class Daemon {
       sourceBindingKind: externalSource ? 'external' : 'local',
       ...(externalSource ?? {})
     })
+    // An external-source binding (Slack/Feishu channel) no longer marks the
+    // session private for memory — such channels behave like any other channel
+    // (session-visibility.md §5.1). DM / webchat / A2A / launch-correlated turns
+    // stay private.
     const locallyPrivate =
-      !isEvaluation &&
-      (isA2aChild ||
-        msg.isDm ||
-        msg.platform === 'webchat' ||
-        launchCorrelationId !== undefined ||
-        externalSource !== undefined)
+      !isEvaluation && (isA2aChild || msg.isDm || msg.platform === 'webchat' || launchCorrelationId !== undefined)
     this.store.setLocalCaptureGate(acpSessionId, locallyPrivate)
   }
 
@@ -18605,7 +18603,11 @@ export class Daemon {
       // capture gate. Ordering is by the CP's durable revision, so retransmits
       // and out-of-order delivery are safe.
       applySessionVisibility: (p: SessionVisibilityPush): 'applied' | 'superseded' =>
-        this.store.applyCpCaptureGate(p.sessionId, p.sharedMemoryExcluded ?? p.visibility !== 'org', p.visibilityRev)
+        this.store.applyCpCaptureGate(
+          p.sessionId,
+          p.sharedMemoryExcluded ?? p.visibility === 'private',
+          p.visibilityRev
+        )
     }
   }
 

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1972,13 +1972,12 @@ export class LocalStore {
    */
   isCaptureExcluded(acpSessionId: string | undefined): boolean {
     if (!acpSessionId) return true
-    // A trusted external source binding is a daemon-local hard deny. It must
-    // win even if an older CP `org` ack is still present while a legacy session
-    // is being bound, and it remains true when provider sync is disabled.
-    const external = this.db
-      .prepare('SELECT 1 FROM sessions WHERE acpSessionId = ? AND externalProvider IS NOT NULL LIMIT 1')
-      .get(acpSessionId)
-    if (external) return true
+    // External-source binding (a Slack/Feishu channel = external identity domain)
+    // no longer forces memory exclusion: such channels behave like any other
+    // channel (Discord/Telegram already did), gated only by the local verdict and
+    // the CP-confirmed visibility below (#653 follow-up; session-visibility.md
+    // §5.1). DM / webchat / A2A / launch-correlated sessions stay private through
+    // those same layers.
     const row = this.db
       .prepare('SELECT localExcluded, cpPrivate FROM session_gates WHERE acpSessionId = ?')
       .get(acpSessionId) as { localExcluded: number; cpPrivate: number | null } | undefined

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -215,7 +215,10 @@ describe('Daemon transcript records the agent reply', () => {
     await daemon.stop()
   }, 15_000)
 
-  it('never captures post-turn memory from a shared Slack input', async () => {
+  // A Slack/Feishu channel (external identity domain) is no longer memory-excluded
+  // just for being external — it captures like any other channel. DMs stay private
+  // (see the DM test below).
+  it('captures post-turn memory from a Slack channel input', async () => {
     const { factory } = replyingHost('here is my answer')
     const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
     await daemon.start()
@@ -225,8 +228,8 @@ describe('Daemon transcript records the agent reply', () => {
 
     await (daemon as any).dispatch('bot-a', channelMsg('100', 'question?'), 'int-a')
 
-    expect((daemon as any).store.isCaptureExcluded('acp-1')).toBe(true)
-    expect(recordTurn).not.toHaveBeenCalled()
+    expect((daemon as any).store.isCaptureExcluded('acp-1')).toBe(false)
+    await vi.waitFor(() => expect(recordTurn).toHaveBeenCalledOnce(), WAIT)
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/session-capture-gate.test.ts
+++ b/packages/daemon/test/session-capture-gate.test.ts
@@ -49,7 +49,7 @@ describe('capture gate — local state', () => {
     expect(store.isCaptureExcluded('acp-early')).toBe(false)
   })
 
-  it('keeps a locally bound external session isolated despite an older org ack', () => {
+  it('lets an external (Slack/Feishu channel) session capture, following the gate not a hard deny', () => {
     const store = newStore()
     store.upsertSession({
       key: 'slack:C1:T1:bot-a',
@@ -81,7 +81,13 @@ describe('capture gate — local state', () => {
       sourceBindingKind: 'external'
     })
 
+    // External is no longer a hard deny: an org-confirmed external session captures.
+    expect(store.isCaptureExcluded('acp-external')).toBe(false)
+    // A private push still excludes it, proving it follows the gate.
+    expect(store.applyCpCaptureGate('acp-external', true, 2)).toBe('applied')
     expect(store.isCaptureExcluded('acp-external')).toBe(true)
+    // Source-binding integrity is unchanged: the first-bound realm/resource wins;
+    // only the optional integration id is backfilled.
     expect(store.getSessionClassification('bot-a', 'acp-external')).toMatchObject({
       externalRealmKey: 'W1',
       externalResourceKey: 'C1',


### PR DESCRIPTION
Reported by @pchsu: an agent has content in memory but "调用 memory 失败" (memory calls fail) on Slack channels.

## Root cause

Slack/Feishu channels are classified as an **external identity domain** (their channels can seat non-org members), which fail-closed excluded those sessions from managed memory: no index injection, no per-turn capture, and the memory MCP tools gated off (`memoryAccessAllowed = !isCaptureExcluded`). Discord/Telegram channels have no such audience, so they already worked — switching an agent to Slack silently broke its memory.

The escape hatch some assumed (set session visibility → `org`) did **not** work: `isCaptureExcluded` hard-denied any session with `externalProvider != null` *before* checking the CP visibility, and the CP push itself computed `sharedMemoryExcluded = visibility !== 'org' || externalProvider != null`, so an external session stayed excluded regardless.

## Change (owner decision)

Remove the external-identity memory exclusion so these channels behave like any other channel. An external-source binding no longer forces a memory hard-deny; memory is excluded only for an explicitly **`private`** session. DM / webchat / A2A-child / launch-correlated sessions stay private, and the external classification is still tracked for console access + source-binding.

- daemon `isCaptureExcluded`: drop the `externalProvider IS NOT NULL` hard-deny.
- daemon classification: drop `externalSource` from `locallyPrivate`.
- daemon new-session injection fallback: drop the `conversationExternalSource` term.
- CP `toPush` + `session.repo` snapshot: `sharedMemoryExcluded = visibility === 'private'` (so `external` captures like `org`); daemon apply fallback matched.

## Tradeoff (owner-accepted)

An external channel may include non-org members whose words then enter agent-scoped memory; set a session **private** to exclude it. `session-visibility.md` §5.1 updated.

## Tests

- `session-capture-gate` + `daemon-transcript` updated: external channels now capture and follow the gate (org→captures, private→excluded); DM stays private.
- CP `session-visibility` integration suite green (private/org semantics unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)