### PR TITLE
fix(daemon): allow sandboxed Codex Git writes

### DIFF
--- a/packages/daemon/src/acp/codex-permission-profiles.ts
+++ b/packages/daemon/src/acp/codex-permission-profiles.ts
@@ -13,6 +13,13 @@ export interface CodexPermissionProfileConfig {
   modeProfiles: Record<keyof typeof PROFILE_IDS, string>
 }
 
+export interface CodexPermissionProfileOptions {
+  protectedRoots: readonly string[]
+  writableGitMetadataRoots?: readonly string[]
+  allowModelToolUnixSockets?: boolean
+  disableUnifiedExec?: boolean
+}
+
 /** Prevent session config from redefining the daemon-owned profiles selected by
  * the adapter. Invalid/non-object input remains the adapter's responsibility. */
 export function codexConfigWithoutPermissionOverrides(raw: string | undefined): string | undefined {
@@ -44,36 +51,45 @@ export function codexConfigWithoutPermissionOverrides(raw: string | undefined): 
 
 /** Build the complete inner-tool policy from daemon-owned canonical paths. */
 export function codexPermissionProfileConfig(
-  protectedRoots: readonly string[],
-  allowModelToolUnixSockets = false
+  opts: CodexPermissionProfileOptions
 ): CodexPermissionProfileConfig | undefined {
-  const roots = [...new Set(protectedRoots.map((root) => normalize(root)))]
-  if (roots.length === 0 && !allowModelToolUnixSockets) return undefined
-  if (roots.some((root) => !isAbsolute(root))) {
-    throw new Error('Codex protected permission roots must be absolute paths')
+  const protectedRoots = [...new Set(opts.protectedRoots.map((root) => normalize(root)))]
+  const writableGitMetadataRoots = [...new Set((opts.writableGitMetadataRoots ?? []).map((root) => normalize(root)))]
+  const policyRoots = [...protectedRoots, ...writableGitMetadataRoots]
+  if (policyRoots.length === 0 && !opts.allowModelToolUnixSockets && !opts.disableUnifiedExec) return undefined
+  if (policyRoots.some((root) => !isAbsolute(root))) {
+    throw new Error('Codex permission roots must be absolute paths')
   }
 
-  const deny = tomlInlineTable(roots.map((root): [string, string] => [root, 'deny']))
-  const protectedFilesystem =
-    roots.length > 0
+  const readOnlyFilesystem =
+    protectedRoots.length > 0
       ? [
-          `permissions.${PROFILE_IDS['read-only']}.filesystem=${deny}`,
-          `permissions.${PROFILE_IDS.agent}.filesystem=${deny}`
+          `permissions.${PROFILE_IDS['read-only']}.filesystem=${tomlInlineTable(
+            protectedRoots.map((root): [string, string] => [root, 'deny'])
+          )}`
         ]
+      : []
+  const agentFilesystemEntries: Array<[string, string]> = [
+    ...writableGitMetadataRoots.map((root): [string, string] => [root, 'write']),
+    ...protectedRoots.map((root): [string, string] => [root, 'deny'])
+  ]
+  const agentFilesystem =
+    agentFilesystemEntries.length > 0
+      ? [`permissions.${PROFILE_IDS.agent}.filesystem=${tomlInlineTable(agentFilesystemEntries)}`]
       : []
   const fullAccess = tomlInlineTable([
     [':root', 'write'],
     ['/.git', 'write'],
     ['/.agents', 'write'],
     ['/.codex', 'write'],
-    ...roots.map((root): [string, string] => [root, 'deny'])
+    ...protectedRoots.map((root): [string, string] => [root, 'deny'])
   ])
   // On Linux Codex's restricted network seccomp permits AF_UNIX socket()
   // creation but rejects connect(). Enable the inner network layer only when
   // the daemon deliberately provides the agent-scoped GitHub credential
   // channel. When enabled, outer SRT remains the boundary; when disabled by the
   // operator, the launch is already explicitly unconfined.
-  const credentialChannelNetwork = allowModelToolUnixSockets
+  const credentialChannelNetwork = opts.allowModelToolUnixSockets
     ? [
         `permissions.${PROFILE_IDS['read-only']}.network.enabled=true`,
         `permissions.${PROFILE_IDS.agent}.network.enabled=true`
@@ -85,8 +101,12 @@ export function codexPermissionProfileConfig(
       `default_permissions="${PROFILE_IDS.agent}"`,
       `permissions.${PROFILE_IDS['read-only']}.extends=":read-only"`,
       `permissions.${PROFILE_IDS.agent}.extends=":workspace"`,
-      ...protectedFilesystem,
+      ...readOnlyFilesystem,
+      ...agentFilesystem,
       ...credentialChannelNetwork,
+      // Temporary until the bundled Codex includes the openai/codex#34115 fix:
+      // Guardian approval can otherwise hide the canonical unified-exec process.
+      ...(opts.disableUnifiedExec ? ['features.unified_exec=false'] : []),
       `permissions.${PROFILE_IDS['agent-full-access']}.filesystem=${fullAccess}`,
       `permissions.${PROFILE_IDS['agent-full-access']}.network.enabled=true`,
       `permissions.${PROFILE_IDS['agent-full-access']}.network.allow_local_binding=true`,

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -17,16 +17,16 @@ import {
 import {
   CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV,
   codexConfigWithoutPermissionOverrides,
-  codexPermissionProfileConfig
+  codexPermissionProfileConfig,
+  type CodexPermissionProfileOptions
 } from './codex-permission-profiles.js'
 
 function applyCodexPermissionProfile(
   env: Record<string, string>,
-  protectedRoots: readonly string[],
-  allowModelToolUnixSockets: boolean,
+  opts: CodexPermissionProfileOptions,
   inheritedCodexConfig?: string
 ): void {
-  const profileConfig = codexPermissionProfileConfig(protectedRoots, allowModelToolUnixSockets)
+  const profileConfig = codexPermissionProfileConfig(opts)
   if (!profileConfig) return
 
   const codexConfig = codexConfigWithoutPermissionOverrides(env.CODEX_CONFIG ?? inheritedCodexConfig)
@@ -172,7 +172,11 @@ export function prepareRuntimeLaunch(opts: {
   if (!opts.runInSandbox && !opts.isolateHome) {
     const env = { ...(opts.explicitEnv ?? {}) }
     if (credentialProfile === 'codex' && opts.allowModelToolUnixSockets) {
-      applyCodexPermissionProfile(env, [], true, (opts.hostEnv ?? process.env).CODEX_CONFIG)
+      applyCodexPermissionProfile(
+        env,
+        { protectedRoots: [], allowModelToolUnixSockets: true },
+        (opts.hostEnv ?? process.env).CODEX_CONFIG
+      )
     }
     return { env, inheritProcessEnv: true }
   }
@@ -287,7 +291,10 @@ export function prepareRuntimeLaunch(opts: {
   if (!opts.runInSandbox) {
     if (credentialProfile === 'codex' && opts.allowModelToolUnixSockets) {
       const privateCodex = join(runtimeHome, '.codex')
-      applyCodexPermissionProfile(env, existsSync(privateCodex) ? [realpathSync(privateCodex)] : [], true)
+      applyCodexPermissionProfile(env, {
+        protectedRoots: existsSync(privateCodex) ? [realpathSync(privateCodex)] : [],
+        allowModelToolUnixSockets: true
+      })
     }
     return { env, inheritProcessEnv: false, runtimeHome }
   }
@@ -399,7 +406,21 @@ export function prepareRuntimeLaunch(opts: {
     ...privateCodexStateRoots
   ])
   if (credentialProfile === 'codex') {
-    applyCodexPermissionProfile(env, protectedCredentialRoots, opts.allowModelToolUnixSockets === true)
+    // Codex's :workspace profile protects `.git`. Re-open only the canonical
+    // metadata directory already covered by the outer sandbox's writable root;
+    // session worktree indexes and refs live below this main checkout directory.
+    const writableGitMetadataRoots = boundary.gitSafeDirectories.flatMap((workspaceRoot) => {
+      const gitDir = join(workspaceRoot, '.git')
+      if (!existsSync(gitDir) || !lstatSync(gitDir).isDirectory()) return []
+      const canonical = realpathSync(gitDir)
+      return boundary.writable.some((root) => inside(root, canonical)) ? [canonical] : []
+    })
+    applyCodexPermissionProfile(env, {
+      protectedRoots: protectedCredentialRoots,
+      writableGitMetadataRoots,
+      allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true,
+      disableUnifiedExec: true
+    })
   }
   return {
     env,

--- a/packages/daemon/test/codex-permission-profiles.test.ts
+++ b/packages/daemon/test/codex-permission-profiles.test.ts
@@ -3,7 +3,9 @@ import { codexPermissionProfileConfig } from '../src/acp/codex-permission-profil
 
 describe('Codex permission profile launch config', () => {
   it('keeps daemon-owned denies in every ACP mode', () => {
-    const config = codexPermissionProfileConfig(['/agent/home/.codex', '/host/.codex/auth.json'])!
+    const config = codexPermissionProfileConfig({
+      protectedRoots: ['/agent/home/.codex', '/host/.codex/auth.json']
+    })!
 
     expect(config.modeProfiles).toEqual({
       'read-only': 'agentconnect-protected-read-only',
@@ -21,14 +23,17 @@ describe('Codex permission profile launch config', () => {
   })
 
   it('opens the inner network layer only for a daemon-provided credential channel', () => {
-    const config = codexPermissionProfileConfig(['/agent/home/.codex'], true)!
+    const config = codexPermissionProfileConfig({
+      protectedRoots: ['/agent/home/.codex'],
+      allowModelToolUnixSockets: true
+    })!
 
     expect(config.configOverrides).toContain('permissions.agentconnect-protected-workspace.network.enabled=true')
     expect(config.configOverrides).toContain('permissions.agentconnect-protected-read-only.network.enabled=true')
   })
 
   it('can open the credential channel without adding empty filesystem overrides', () => {
-    const config = codexPermissionProfileConfig([], true)!
+    const config = codexPermissionProfileConfig({ protectedRoots: [], allowModelToolUnixSockets: true })!
 
     expect(config.configOverrides).toContain('permissions.agentconnect-protected-workspace.network.enabled=true')
     expect(config.configOverrides).toContain('permissions.agentconnect-protected-read-only.network.enabled=true')
@@ -42,6 +47,24 @@ describe('Codex permission profile launch config', () => {
   })
 
   it('rejects non-absolute policy roots', () => {
-    expect(() => codexPermissionProfileConfig(['relative/auth.json'])).toThrow('must be absolute')
+    expect(() => codexPermissionProfileConfig({ protectedRoots: ['relative/auth.json'] })).toThrow('must be absolute')
+  })
+
+  it('opens only the agent Git metadata root and can disable unified exec', () => {
+    const config = codexPermissionProfileConfig({
+      protectedRoots: ['/agent/home/.codex'],
+      writableGitMetadataRoots: ['/agent/workspace/.git'],
+      disableUnifiedExec: true
+    })!
+
+    expect(config.configOverrides).toContain('features.unified_exec=false')
+    expect(config.configOverrides).toContain(
+      'permissions.agentconnect-protected-workspace.filesystem={ "/agent/workspace/.git" = "write", "/agent/home/.codex" = "deny" }'
+    )
+    expect(
+      config.configOverrides.find((value) =>
+        value.startsWith('permissions.agentconnect-protected-read-only.filesystem=')
+      )
+    ).not.toContain('/agent/workspace/.git')
   })
 })

--- a/packages/daemon/test/runtime-credentials.test.ts
+++ b/packages/daemon/test/runtime-credentials.test.ts
@@ -37,6 +37,37 @@ function settings(path: string): { filesystem: { allowWrite: string[] } } {
 }
 
 describe('Linux shared runtime login', () => {
+  it('opens only the canonical Git metadata directory to the inner Codex agent', () => {
+    const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
+    const gitDir = join(cwd, '.git')
+    mkdirSync(gitDir)
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      scopeDir,
+      cwd,
+      daemonRoot,
+      agentsRoot: join(daemonRoot, 'agents'),
+      runInSandbox: true,
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const profileConfig = JSON.parse(launch.env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]!) as {
+      configOverrides: string[]
+    }
+    const agentFilesystem = profileConfig.configOverrides.find((value) =>
+      value.startsWith('permissions.agentconnect-protected-workspace.filesystem=')
+    )
+    const readOnlyFilesystem = profileConfig.configOverrides.find((value) =>
+      value.startsWith('permissions.agentconnect-protected-read-only.filesystem=')
+    )
+    expect(agentFilesystem).toContain(`${JSON.stringify(realpathSync(gitDir))} = "write"`)
+    expect(readOnlyFilesystem).not.toContain(realpathSync(gitDir))
+    expect(profileConfig.configOverrides).toContain('features.unified_exec=false')
+  })
+
   it('opens the Codex credential channel even when the outer sandbox is disabled', () => {
     const { scopeDir, cwd } = fixture()
     const launch = prepareRuntimeLaunch({


### PR DESCRIPTION
## Summary

- grant the sandboxed Codex `agent` profile write access to the canonical Git metadata directory already covered by AgentConnect's outer writable boundary
- keep read-only mode and daemon-owned credential roots protected
- temporarily disable `unified_exec` for sandboxed Codex launches until the bundled Codex includes the `openai/codex#34115` Guardian lifecycle fix

## Root cause

Codex's built-in `:workspace` profile protects `.git`. AgentConnect extended that profile but only overlaid credential denies, so ordinary `git fetch`, `git add`, and `git commit` operations required approval even though the outer AgentConnect sandbox already allowed the checkout. Guardian-approved unified exec can then lose the canonical process event and leave the command appearing in progress.

The new write carve-back is limited to a real, canonical `.git` directory that remains inside an outer sandbox writable root. The outer sandbox continues to reject repository Git config and hooks.

## Validation

- daemon focused tests: 17 passed
- daemon typecheck
- target-file ESLint and Prettier
- full pre-push repository lint
- daemon build and self-contained bundle check
- Codex 0.145.0 accepted the permission and `features.unified_exec=false` overrides
- full daemon suite: 3017 passed, 51 skipped; one unrelated 5-second mention-routing timeout passed on focused retry

Created by Codex . GPT-5.6 Sol
