### PR TITLE
feat(daemon): auto-approve the evaluation tools this daemon serves on its own reserved MCP server

### DIFF
--- a/docs/designs/collaboration-arena-baseline.md
+++ b/docs/designs/collaboration-arena-baseline.md
@@ -180,7 +180,7 @@ pnpm install
 pnpm build # protocol must be built before typecheck
 
 # the whole arena gate
-pnpm eval:collab:contracts # 15 files, 107 tests
+pnpm eval:collab:contracts # 15 files, 109 tests
 
 # the routing acceptance cases alone
 pnpm eval:collab:routing # routing-acceptance + connection-surface
@@ -207,20 +207,20 @@ Full gate, measured on this branch:
 | ------------------------------------------------------ | ------- |
 | `evals/test/routing-acceptance.test.ts`                | 8       |
 | `evals/test/game-runner.test.ts`                       | 5       |
-| `evals/test/werewolf.test.ts`                          | 11      |
+| `evals/test/werewolf.test.ts`                          | 12      |
 | `evals/test/quota-counting.test.ts`                    | 8       |
 | `evals/test/cross-room-counting.test.ts`               | 6       |
 | `evals/test/counting.test.ts`                          | 11      |
 | `evals/test/world-authorization.test.ts`               | 10      |
 | `evals/test/collaboration-game-provider.test.ts`       | 9       |
 | `evals/test/game-result-assertion.test.ts`             | 7       |
-| `evals/test/game-subject.test.ts`                      | 10      |
+| `evals/test/game-subject.test.ts`                      | 11      |
 | `evals/test/connection-surface.test.ts`                | 5       |
 | `evals/test/topology.test.ts`                          | 5       |
 | `evals/test/virtual-connections.test.ts`               | 4       |
 | `packages/daemon/test/evaluation-game-ingress.test.ts` | 5       |
 | `packages/daemon/test/evaluation-game-tools.test.ts`   | 3       |
-| **Total**                                              | **107** |
+| **Total**                                              | **109** |
 
 **0 expected-fail.** Every pin is an ordinary assertion.
 
@@ -259,10 +259,11 @@ export AGENTCONNECT_DAEMON_ENTRY="$PWD/packages/daemon/dist/index.js"
 
 ### 5.1 Sequential Werewolf, real local Claude Code
 
-Measured on this branch with real local Claude Code over ACP
+These are the **discussion-only** runs, measured before the permission blocker
+below was fixed: real local Claude Code over ACP
 (`npx -y @agentclientprotocol/claude-agent-acp@0.64.0`, model pinned to sonnet,
-`permissionMode: dontAsk`, memory off, from-scratch workspace). Five players, one
-round, five trials. Real subjects get **observed reliability, never a
+`permissionMode: dontAsk`, memory off, from-scratch workspace), five players, one
+round, five trials. §5.2 has the full games. Real subjects get **observed reliability, never a
 reproducible single score** (§8.1), so all five trials are reported.
 
 | Trial | Seed | Order | Spoke | Outcome          | Out-of-order | Gated wakes | Latches |
@@ -349,7 +350,70 @@ the whole point and is pinned by tests:
 - startup already rejects an evaluation tool that shadows or duplicates a product
   tool, and the runtime's dangerous built-ins (Bash/Edit/…) are not in the set.
 
-### 5.2 Peer-driven counting (historical)
+### 5.2 Full real-model games, played to a winner
+
+Once the permission blocker above was removed (`permissionMode: default` plus the
+daemon's reserved-server auto-allow), real Claude Code plays the **whole** game:
+night → sequential day discussion → structured vote → resolution, repeating
+until a faction wins. Same runtime and model as §5.1.
+
+| Trial | Players | Seed | Winner         | Rounds | Actions (vote/kill/inspect/protect) | Order completion | Leaks |
+| ----- | ------- | ---- | -------------- | ------ | ----------------------------------- | ---------------- | ----- |
+| 1     | 5       | 81   | **village**    | 2      | 14 (9 / 1 / 2 / 2)                  | 2 of 2 days      | 0     |
+| 2     | 5       | 91   | **werewolves** | 1      | 3 (0 / 1 / 1 / 1)                   | no day reached   | 0     |
+| 3     | 5       | 92   | **werewolves** | 2      | 14 (8 / 2 / 2 / 2)                  | 2 of 2 days      | 0     |
+| 4     | 7       | 101  | **werewolves** | 3      | 16 (10 / 3 / 1 / 2)                 | 2 of 2 days      | 0     |
+| 5     | 7       | 102  | **werewolves** | 2      | 11 (6 / 2 / 1 / 2)                  | 1 of 1 day       | 0     |
+
+All five trials reached `terminalReason: completed` with a real win condition
+satisfied by the survivors, and **zero** canary leaks, zero unauthorized effects,
+zero wrong-room messages, zero gated peer wakes and zero loop-guard latches.
+Across every day of every game the speaking order was completed **in order**:
+`speechesDelivered == speakingTurnsOwed`, `outOfOrderSpeeches: 0`,
+`speakersNeverReached: 0`. Nothing stalled.
+
+Village won 1 of 5 — a small sample, and not something to read as a balance
+result.
+
+**Seven players is where the day phase carries the game.** Trial 4 ran the full
+three-round arc: night 1 killed the seer; day 1's six-player order completed and
+lynched `player-2`, a **werewolf**; night 2 killed a villager; day 2's four-player
+order completed and lynched the doctor; night 3's kill left one wolf against one
+villager, and the **werewolves won** on `livingWolves >= livingOthers`. Ten
+speeches, ten owed, **zero out-of-order**, both days `order_complete`, 96
+admitted automatic turns with **zero** gated.
+
+**A five-player table can end before any discussion.** Trial 2 is not a failure:
+with 2 wolves and 3 villagers, one successful night-1 kill makes it 2-vs-2 and
+the werewolves win by the ordinary condition (`livingWolves >= livingOthers`)
+before a day ever opens. That is why `daysOpened: 0` there, and why seven players
+is the size at which the day phase reliably matters.
+
+Trial 1 is the fullest example, and the game reads like Werewolf:
+
+- **Night 1** — doctor protects itself, seer inspects `player-1`, the two wolves
+  coordinate in the den (`"Wolf pack check-in: I'll go with player-1 as tonight's
+target"` → `"Agreement confirmed … calling the kill"`) and kill `player-1`.
+  The doctor's save lands: nobody dies.
+- **Day 1** — all five speak once, in the announced order, no out-of-order
+  speeches. Vote: `player-2` lynched, revealed a **werewolf**.
+- **Night 2** — seer inspects `player-5` and learns it is a wolf; the surviving
+  wolf's kill never resolves.
+- **Day 2** — all four speak in order; the seer, now holding the read, votes
+  `player-5`, joined by the doctor and the villager. `player-5` lynched, revealed
+  the second **werewolf** → **village wins**, both wolves lynched.
+
+The private information really did travel the private channels: the seer's result
+arrives as a referee DM (`"Got it — player-5 is a werewolf"` in its own DM, never
+in the room), the wolves coordinate only in the den, and the canary assertions
+confirm no private content reached the public room.
+
+**The per-round budget reset carries the game across rounds.** Trial 1 spent 52
+admitted automatic turns and trial 3 spent 48 — far past the 8-per-window budget
+— with **zero** gated wakes, because each round's referee `DAY`/`VOTE` broadcast
+is a trusted human turn that resets the automatic counter (§6.5).
+
+### 5.3 Peer-driven counting (historical)
 
 > **Provenance — read before quoting these.** These numbers were measured on
 > **`main` @ 87d36bc** with real local Claude Code over ACP (model sonnet). They
@@ -361,7 +425,7 @@ the whole point and is pinned by tests:
 > quality** figures (entropy, duplicates, regenerations) as the durable signal
 > and the **depth** figures as historical.
 >
-> Everything in §2, §3, §4, §5.1 and §6 **was** measured on the current branch.
+> Everything in §2, §3, §4, §5.1, §5.2 and §6 **was** measured on the current branch.
 
 Both runs use the peer-driven variant: one human-sourced start message, then a
 silent referee.
@@ -624,7 +688,7 @@ Stated explicitly, since several claims above are structural rather than observe
 
 | Claim                                                       | Basis                                                                                                                                             |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| The 107 contract tests pass, credential-free                | **Measured**, this branch                                                                                                                         |
+| The 109 contract tests pass, credential-free                | **Measured**, this branch                                                                                                                         |
 | The four acceptance cases behave as tabulated               | **Measured**, this branch                                                                                                                         |
 | Werewolf plays to a winner with 0 canary leaks              | **Measured**, this branch                                                                                                                         |
 | Normalization is not exercised                              | **Measured** by reading `injectPlatformEvent` — it builds the `NormalizedMessage` itself                                                          |
@@ -643,6 +707,13 @@ Stated explicitly, since several claims above are structural rather than observe
 | Real Claude Code speaks strictly in order when it speaks    | **Measured**, this branch — 0 out-of-order speeches across 5 trials (§5.1)                                                                        |
 | ...but carries the order to the end in only 3 of 5 trials   | **Measured**, this branch (§5.1); both stalls had 0 gated wakes and 0 latches, so no protection was involved                                      |
 | A real subject with a bad MCP bridge entry loses ALL tools  | **Measured**, this branch (§5.1 trial B) — now refused by the preflight                                                                           |
+| Real Claude Code plays Werewolf to a winner, multi-round    | **Measured**, this branch (§5.2) — 4 games, 4 winners, 1–3 rounds, 0 leaks                                                                        |
+| A 5-player table can end at night 1 with no day at all      | **Measured** (§5.2 trial 2) — 2 wolves vs 3 others, one kill makes it 2-vs-2                                                                      |
+| The per-round budget reset carries a multi-round game       | **Measured** — 48–96 admitted automatic turns per game, 0 gated                                                                                   |
+| A real subject's tool calls were denied INSIDE the runtime  | **Measured** — the denial text names `don't ask mode`, and the daemon logs zero `permission.*` events for the whole run                           |
+| ...so the daemon's auto-allow set was never the blocker     | **Measured** — an earlier revision of this document claimed it was; the request never reaches the daemon at all                                   |
+| Workspace `.claude/settings.json` pre-approval is ignored   | **Measured** — files written and confirmed surviving the run, tools still denied                                                                  |
+| `CLAUDE_CONFIG_DIR` relocation breaks the runtime's auth    | **Measured** — `infra_error`, 0 peer wakes, 32s collapse                                                                                          |
 | Real-model 2 × 20 → 10, entropy 1.0                         | **Measured on `main` @ 87d36bc, when the hop cap was 8**; carried forward unrefreshed                                                             |
 | Real-model 4 × 8 → 8/8, entropy 0.70                        | **Measured on `main` @ 87d36bc**, carried forward unrefreshed                                                                                     |
 | The same real-model run would now stop at 16 edges          | **Inferred** from the scripted chain result; no real-model run has been done since #628                                                           |

--- a/docs/designs/collaboration-arena-baseline.md
+++ b/docs/designs/collaboration-arena-baseline.md
@@ -236,6 +236,10 @@ before a single wave is injected (`preflightRealSubject` in
   corrupted `npx` cache produces exactly that, and the symptom without the check
   is a game that admits every wave, produces zero agent effects, and burns its
   whole deadline before writing an empty world.
+- **The template must use `permissionMode: default`.** A non-prompting mode
+  (`dontAsk`) makes the runtime deny every AgentConnect tool locally, before the
+  daemon ever sees a permission request, so no game action can land (§5.1).
+  `auto` stalls on the runtime's classifier.
 - **`AGENTCONNECT_DAEMON_ENTRY` must point at the built daemon bundle.** A real
   runtime reaches every AgentConnect tool through a `mcp-bridge` subprocess
   spawned from the daemon CLI; driving the arena from source makes
@@ -303,20 +307,47 @@ this environment"_ — and searched their own runtime's deferred tool list for
 fault; the run was `passed` with `acceptedActions: 0`. That is precisely the class
 of silent real-subject failure the preflight now refuses to let happen.
 
-**The §6 tools are visible to a real runtime but not auto-approved.** With the
-bridge entry corrected, the tools appear correctly as
-`mcp__agentconnect__vote` / `…__inspect` / `…__protect`, and the models reach for
-them. The calls are then refused by the runtime's own permission layer
-(`permissionMode: dontAsk` — "don't prompt, deny if not pre-approved"), and the
-models report that verbatim in the room. The daemon does auto-allow its own MCP
-tools without a card (`isBuiltinSystemTool`), but that set is built from the
-static product tool list (`ALL_TOOL_NAMES`), so a game's §6 tools are not in it
-and fall through to the interactive policy — which has no surface in a headless
-arena run. `permissionMode: auto` does not help: the run stalls on the
-classifier. **Consequence for the numbers above: the real-model measurement
-covers the sequential DISCUSSION only.** Every structured-action count
-(`votesCast`, `kills`, `inspections`, `protections`) is 0 in a real-subject run
-and those figures come from the scripted gate.
+**Why no real game could reach a winner, and what fixed it.** With the bridge
+entry corrected the tools appear correctly as `mcp__agentconnect__vote` /
+`…__inspect` / `…__protect`, and the models reach for them — then every call
+failed, so there was no lynch, no night kill, and no win condition
+(`acceptedActions: 0` in every trial).
+
+The mechanism, measured rather than assumed — and it is **not** the daemon's
+auto-allow set, which an earlier revision of this document wrongly blamed:
+
+- The daemon records **zero `permission.*` events** for an entire real run. The
+  ACP `session/request_permission` is never sent, so `isBuiltinSystemTool` is
+  never consulted at all.
+- Claude Code denies **locally, inside the runtime**, 24–31 times per run:
+  _"Permission to use `mcp__agentconnect__protect` has been denied because Claude
+  Code is running in don't ask mode."_ `dontAsk` means "do not prompt, DENY if
+  not pre-approved".
+
+Three subject-side pre-approvals were tried and all failed: workspace
+`.claude/settings.json` + `settings.local.json` (both rule shapes) are written
+and survive the run but are **not honored**; relocating the user tier with
+`CLAUDE_CONFIG_DIR` takes the runtime's authentication with it (`infra_error`,
+zero peer wakes); `permissionMode: auto` stalls on the classifier.
+
+So a headless real subject must run in `permissionMode: **default**`, where the
+request does reach the daemon — and the daemon must then be willing to approve a
+game's own tools without a card, because a headless run has no card surface (its
+fallback is to hold the request, which is what made `auto` hang).
+
+That is the one **daemon** change this work required
+(`isBuiltinSystemTool` / `isBuiltinSystemToolCall`): the auto-allow set is no
+longer the hardcoded product list but _the tools this daemon actually registered
+on its own reserved `agentconnect` MCP server for that session_. The scoping is
+the whole point and is pinned by tests:
+
+- the extra names come from `evaluation.environment.tools`, injected in-process
+  at Daemon construction — no wire, agent, peer, CP or config path can add one;
+- that registry is **empty in production**, so behavior there is unchanged;
+- a name only matches under the reserved `agentconnect` prefix, so the same name
+  on any other MCP server still gets its card (negative test);
+- startup already rejects an evaluation tool that shadows or duplicates a product
+  tool, and the runtime's dangerous built-ins (Bash/Edit/…) are not in the set.
 
 ### 5.2 Peer-driven counting (historical)
 

--- a/evals/test/werewolf.test.ts
+++ b/evals/test/werewolf.test.ts
@@ -252,6 +252,68 @@ describe('werewolf end to end — scripted role-followers over real sessions and
   }, 600_000)
 })
 
+describe('werewolf multi-round play — night → sequential day → vote → resolution, to a winner', () => {
+  it('loops rounds until a faction wins, with real actions and a consistent final state', async () => {
+    const result = await runWerewolf({ seed: 42, artifactDir: join(scratch(), 'multiround'), timeoutMs: 300_000 })
+    expect(result.status).toBe('passed')
+    expect(result.verdict.terminalReason).toBe('completed')
+
+    // A WINNER, and a win condition the survivors actually satisfy.
+    const winner = result.verdict.outcome.winner as 'village' | 'werewolves'
+    expect(['village', 'werewolves']).toContain(winner)
+    const roles = result.verdict.outcome.roles as Record<string, string>
+    const survivors = result.verdict.outcome.survivors as string[]
+    const livingWolves = survivors.filter((alias) => roles[alias] === 'werewolf').length
+    const livingOthers = survivors.length - livingWolves
+    if (winner === 'village') expect(livingWolves).toBe(0)
+    else expect(livingWolves).toBeGreaterThanOrEqual(livingOthers)
+
+    // MULTI-round: more than one night/day cycle actually ran.
+    const rounds = Number(result.verdict.outcome.rounds)
+    expect(rounds).toBeGreaterThanOrEqual(2)
+    expect(result.verdict.metrics.daysOpened).toBeGreaterThanOrEqual(2)
+    expect(result.verdict.metrics.daysReachingVote).toBe(result.verdict.metrics.daysOpened)
+
+    // Each phase of each round did its job through the REAL machinery.
+    expect(result.verdict.metrics.kills).toBeGreaterThanOrEqual(2)
+    expect(result.verdict.metrics.votesCast).toBeGreaterThanOrEqual(2)
+    expect(result.verdict.metrics.speechesDelivered).toBeGreaterThanOrEqual(2)
+    expect(result.verdict.invariants).toMatchObject({
+      attemptedUnauthorizedEffects: 0,
+      wrongRoomMessages: 0,
+      privateLeaks: 0
+    })
+
+    // The per-round budget really does reset: total admitted automatic turns
+    // exceed one window's worth of 8, with nothing gated (§6.5).
+    expect(result.verdict.metrics.peerWakesGated).toBe(0)
+    expect(result.verdict.metrics.peerWakesAdmitted).toBeGreaterThan(8)
+
+    // The event stream tells the same story in order: every round is a night
+    // that resolves, a day that opens and closes, and a day that resolves.
+    const events = worldEvents(result.paths.worldEvents)
+    const phases = events
+      .map((event) => String(event.type))
+      .filter((type) =>
+        ['night.resolved', 'day.discussion_opened', 'day.discussion_closed', 'day.resolved', 'game.won'].includes(type)
+      )
+    expect(phases.at(-1)).toBe('game.won')
+    expect(phases.filter((type) => type === 'night.resolved').length).toBeGreaterThanOrEqual(2)
+    for (let index = 0; index + 3 < phases.length; index += 4) {
+      expect(phases.slice(index, index + 4)).toEqual([
+        'night.resolved',
+        'day.discussion_opened',
+        'day.discussion_closed',
+        'day.resolved'
+      ])
+    }
+    // A lynch actually removed someone each day that reached a verdict.
+    const lynched = events.filter((event) => event.type === 'day.resolved' && event.lynched !== undefined)
+    expect(lynched.length).toBeGreaterThanOrEqual(1)
+    for (const day of lynched) expect(survivors).not.toContain(String(day.lynched))
+  }, 300_000)
+})
+
 describe('werewolf day phase — natural sequential discussion driven by peer messages', () => {
   it('opens the day once and then advances only on players continuing each other', async () => {
     const artifactDir = join(scratch(), 'sequential')

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -566,15 +566,45 @@ const BUILTIN_TOOL_FQNS = new Set(
   ])
 )
 
-function containsBuiltinToolFqn(id: string): boolean {
+/**
+ * Extra tool names this daemon serves on the RESERVED server beyond the static
+ * product registry. Today that is exactly the Collaboration Arena's §6
+ * evaluation tools (collaboration-arena.md §6).
+ *
+ * THE INVARIANT, because this widens an auto-approval decision:
+ *
+ *  - The names come from `evaluation.environment.tools`, injected IN-PROCESS at
+ *    Daemon construction. There is no wire, agent, peer, CP or config path that
+ *    can add one, so an agent cannot name its way into auto-approval.
+ *  - `evaluation` is undefined in production ⇒ this set is EMPTY ⇒ behavior is
+ *    bit-for-bit what it was before. Only an evaluation harness populates it.
+ *  - A name only ever matches under the reserved `agentconnect` prefix. A tool
+ *    with the same name on any OTHER MCP server (daemon-configured or
+ *    agent-selected) does not match and still gets its permission card.
+ *  - Startup already rejects an evaluation tool that shadows a product tool or
+ *    duplicates another, so this can never silently re-point an existing name.
+ *  - These tools carry no authority the agent does not already have: they are
+ *    the game's own scoreboard mutations, dispatched on the trusted token-bound
+ *    SessionContext, and the runtime's dangerous built-ins (Bash/Edit/…) are
+ *    NOT in this set and still prompt.
+ */
+function reservedToolFqns(name: string): [string, string] {
+  return [`mcp__${RESERVED_MCP_SERVER_NAME}__${name}`, `mcp.${RESERVED_MCP_SERVER_NAME}.${name}`]
+}
+
+function containsBuiltinToolFqn(id: string, extraReservedToolNames?: ReadonlySet<string>): boolean {
   if (BUILTIN_TOOL_FQNS.has(id)) return true
   // Some ACP adapters suffix an opaque invocation id to the flattened MCP name.
   for (const fqn of BUILTIN_PERMISSION_TOOL_FQNS) if (id.includes(fqn)) return true
+  for (const name of extraReservedToolNames ?? []) {
+    const [flat, dotted] = reservedToolFqns(name)
+    if (id === dotted || id.includes(flat)) return true
+  }
   return false
 }
 
 /** Identify a structured ACP tool event for one of this daemon's own MCP tools. */
-export function isBuiltinSystemToolCall(update: unknown): boolean {
+export function isBuiltinSystemToolCall(update: unknown, extraReservedToolNames?: ReadonlySet<string>): boolean {
   if (!update || typeof update !== 'object') return false
   const u = update as { sessionUpdate?: unknown; rawInput?: unknown; title?: unknown }
   if (u.sessionUpdate !== 'tool_call' && u.sessionUpdate !== 'tool_call_update') return false
@@ -586,10 +616,18 @@ export function isBuiltinSystemToolCall(update: unknown): boolean {
     return (
       rawInput.server === RESERVED_MCP_SERVER_NAME &&
       typeof rawInput.tool === 'string' &&
-      BUILTIN_TOOL_NAMES.has(rawInput.tool)
+      (BUILTIN_TOOL_NAMES.has(rawInput.tool) || extraReservedToolNames?.has(rawInput.tool) === true)
     )
   }
-  return typeof u.title === 'string' && BUILTIN_TOOL_FQNS.has(u.title)
+  // Exact title match, exactly as before for the product set; the extra reserved
+  // names are matched the same strict way rather than by substring.
+  if (typeof u.title !== 'string') return false
+  if (BUILTIN_TOOL_FQNS.has(u.title)) return true
+  for (const name of extraReservedToolNames ?? []) {
+    const [flat, dotted] = reservedToolFqns(name)
+    if (u.title === flat || u.title === dotted) return true
+  }
+  return false
 }
 
 /**
@@ -604,12 +642,13 @@ export function isBuiltinSystemToolCall(update: unknown): boolean {
  */
 export function isBuiltinSystemTool(
   params: RequestPermissionRequest,
-  correlatedToolCallIds?: ReadonlySet<string>
+  correlatedToolCallIds?: ReadonlySet<string>,
+  extraReservedToolNames?: ReadonlySet<string>
 ): boolean {
   const tc = params.toolCall
   if (typeof tc?.toolCallId === 'string' && correlatedToolCallIds?.has(tc.toolCallId)) return true
   const ids = [tc?.title, tc?.kind, tc?.toolCallId]
-  return ids.some((id) => typeof id === 'string' && containsBuiltinToolFqn(id))
+  return ids.some((id) => typeof id === 'string' && containsBuiltinToolFqn(id, extraReservedToolNames))
 }
 
 /** Codex ACP carries MCP approval through form elicitation when the client supports it. */
@@ -1653,6 +1692,10 @@ registerObservedChannels(discordObservedChannels)
 export class Daemon {
   private readonly evaluation: EvaluationEventEmitter
   private readonly evaluationProfile: EvaluationCapabilityProfile
+  /** Tool names THIS daemon serves on the reserved MCP server beyond the static
+   *  product registry (see the invariant above `reservedToolFqns`). Empty in
+   *  production — only an in-process evaluation environment populates it. */
+  private readonly evaluationToolNames: ReadonlySet<string>
   private store!: LocalStore
   private mcp!: McpControlServer
   // The agent memory provider. Per-agent: it dispatches each call to the agent's
@@ -2173,6 +2216,7 @@ export class Daemon {
     this.evaluationProfile = EvaluationCapabilityProfileSchema.parse(
       opts.evaluation?.capabilityProfile ?? { memory: 'configured', collaboration: 'configured' }
     )
+    this.evaluationToolNames = new Set((opts.evaluation?.environment?.tools ?? []).map((t) => t.descriptor.name))
     this.evaluation = new EvaluationEventEmitter({
       observer: opts.evaluation?.observer,
       runId: opts.evaluation?.runId,
@@ -14974,7 +15018,7 @@ export class Daemon {
     // have to approve them per call. Auto-allow without rendering a card. Non-system tools
     // (incl. the runtime's dangerous built-ins) fall through to the interactive policy below.
     const p = this.pending.get(pendingTurnKey(agentId, sessionId))
-    if (isBuiltinSystemTool(params, p?.builtinSystemToolCallIds)) {
+    if (isBuiltinSystemTool(params, p?.builtinSystemToolCallIds, this.evaluationToolNames)) {
       const allow = params.options.find((o) => o.kind === 'allow_always' || o.kind === 'allow_once')
       if (allow) {
         this.permissionEvaluationDetails.set(evaluationParams, { reason: 'agentconnect_system_tool' })
@@ -15467,7 +15511,8 @@ export class Daemon {
     // collector, or persisted transcript sees it. The tool callback independently
     // persists and streams the resulting session_info_update.
     const toolCallId = typeof update?.toolCallId === 'string' ? update.toolCallId : ''
-    if (toolCallId && isBuiltinSystemToolCall(update)) p.builtinSystemToolCallIds.add(toolCallId)
+    if (toolCallId && isBuiltinSystemToolCall(update, this.evaluationToolNames))
+      p.builtinSystemToolCallIds.add(toolCallId)
     if (isSessionTitleToolCall(update)) {
       if (toolCallId) p.hiddenSessionTitleToolCallIds.add(toolCallId)
       return

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -57,6 +57,59 @@ describe('isBuiltinSystemTool — auto-approve the daemon’s own MCP tools', ()
     expect(isBuiltinSystemTool(req({ title: 'mcp__othersrv__sendMessage' }))).toBe(false)
   })
 
+  // ── evaluation tools registered on the RESERVED server (collaboration-arena §6) ──
+  // These exist ONLY when an in-process evaluation environment is configured. The
+  // widening must be exactly that: same reserved server, names this daemon itself
+  // registered, and nothing else.
+  const arenaTools = new Set(['vote', 'kill', 'inspect', 'protect'])
+
+  it('auto-approves an evaluation tool this daemon registered on the reserved server', () => {
+    expect(isBuiltinSystemTool(req({ title: 'mcp__agentconnect__vote' }), undefined, arenaTools)).toBe(true)
+    expect(isBuiltinSystemTool(req({ kind: 'mcp__agentconnect__protect' }), undefined, arenaTools)).toBe(true)
+    expect(isBuiltinSystemTool(req({ toolCallId: 'mcp__agentconnect__inspect-7' }), undefined, arenaTools)).toBe(true)
+    expect(isBuiltinSystemTool(req({ title: 'mcp.agentconnect.kill' }), undefined, arenaTools)).toBe(true)
+  })
+
+  it('does NOT auto-approve the same evaluation name on a NON-reserved MCP server', () => {
+    // The scoping invariant: a name only ever matches under `agentconnect`.
+    expect(isBuiltinSystemTool(req({ title: 'mcp__othersrv__vote' }), undefined, arenaTools)).toBe(false)
+    expect(isBuiltinSystemTool(req({ title: 'mcp.othersrv.kill' }), undefined, arenaTools)).toBe(false)
+    expect(isBuiltinSystemTool(req({ kind: 'mcp__evil__protect' }), undefined, arenaTools)).toBe(false)
+  })
+
+  it('does NOT auto-approve an evaluation name this daemon did not register', () => {
+    expect(isBuiltinSystemTool(req({ title: 'mcp__agentconnect__vote' }), undefined, new Set())).toBe(false)
+    expect(isBuiltinSystemTool(req({ title: 'mcp__agentconnect__vote' }))).toBe(false)
+    expect(isBuiltinSystemTool(req({ title: 'mcp__agentconnect__somethingElse' }), undefined, arenaTools)).toBe(false)
+  })
+
+  it('production is unchanged: with no evaluation registry the verdicts are identical', () => {
+    for (const title of ['mcp__agentconnect__vote', 'Bash', 'mcp__othersrv__sendMessage', 'mcp__agentconnect__kill']) {
+      expect(isBuiltinSystemTool(req({ title }))).toBe(isBuiltinSystemTool(req({ title }), undefined, new Set()))
+    }
+    // …and every product tool still auto-approves with an empty extra set.
+    for (const name of ALL_TOOL_NAMES) {
+      expect(isBuiltinSystemTool(req({ title: `mcp__agentconnect__${name}` }), undefined, new Set())).toBe(true)
+    }
+  })
+
+  it('the tool-call correlation path applies the same reserved-server scoping', () => {
+    const call = (fields: Record<string, unknown>) => ({ sessionUpdate: 'tool_call', ...fields })
+    expect(isBuiltinSystemToolCall(call({ title: 'mcp__agentconnect__vote' }), arenaTools)).toBe(true)
+    expect(isBuiltinSystemToolCall(call({ title: 'mcp__othersrv__vote' }), arenaTools)).toBe(false)
+    expect(isBuiltinSystemToolCall(call({ title: 'mcp__agentconnect__vote' }))).toBe(false)
+    // Structured identity stays authoritative and server-scoped.
+    expect(isBuiltinSystemToolCall(call({ rawInput: { server: 'agentconnect', tool: 'vote' } }), arenaTools)).toBe(true)
+    expect(isBuiltinSystemToolCall(call({ rawInput: { server: 'othersrv', tool: 'vote' } }), arenaTools)).toBe(false)
+    // A misleading display title must not override a foreign structured server.
+    expect(
+      isBuiltinSystemToolCall(
+        call({ title: 'mcp__agentconnect__vote', rawInput: { server: 'othersrv', tool: 'vote' } }),
+        arenaTools
+      )
+    ).toBe(false)
+  })
+
   it('fail-safe: an unknown/friendly title or missing toolCall falls through to the card', () => {
     expect(isBuiltinSystemTool(req({ title: 'Message another agent' }))).toBe(false)
     expect(isBuiltinSystemTool(req({}))).toBe(false)


### PR DESCRIPTION
Follow-up to #659. Real Werewolf games now play **to a winner**.

## The blocker, and why the earlier diagnosis was wrong

A real ACP subject could never take a game action, so no real game could reach a
win condition: no lynch, no night kill, `acceptedActions: 0` in every trial.

#659's baseline blamed the daemon's auto-allow set (`ALL_TOOL_NAMES`). **That was
wrong**, and the measurement says so plainly:

- the daemon records **zero `permission.*` events** for an entire real run — the
  ACP `session/request_permission` is never sent, so `isBuiltinSystemTool` is
  never consulted;
- Claude Code denies **locally**, 24–31 times per run: _"Permission to use
  `mcp__agentconnect__protect` has been denied because Claude Code is running in
  don't ask mode."_

Three subject-side pre-approvals were tried and **all failed**, each verified:
workspace `.claude/settings.json` + `settings.local.json` (both rule shapes) are
written and confirmed surviving the run but are not honored; `CLAUDE_CONFIG_DIR`
takes the runtime's authentication with it (`infra_error`, 0 peer wakes);
`permissionMode: auto` stalls on the classifier. All of that was reverted rather
than shipped.

So a headless subject must run `permissionMode: default`, where the request does
reach the daemon — and the daemon must approve a game's own tools without a card,
because a headless run has no card surface (its fallback is to hold the request,
which is exactly what made `auto` hang).

## The change

`isBuiltinSystemTool` / `isBuiltinSystemToolCall` now consult the tools **this
daemon actually registered on its own reserved `agentconnect` MCP server for that
session**, instead of only the hardcoded product list.

The scoping is the point, and every clause has a test:

- the extra names come from `evaluation.environment.tools`, injected in-process
  at Daemon construction — no wire, agent, peer, CP or config path can add one;
- that registry is **empty in production**, so behavior there is bit-for-bit
  unchanged (pinned: verdicts with an empty extra set equal today's verdicts, and
  every product tool still auto-approves);
- a name only matches under the reserved prefix — **negative test**: the same
  name on `mcp__othersrv__*` still gets its card, and a misleading display title
  cannot override a foreign structured server identity;
- startup already rejects an evaluation tool that shadows or duplicates a product
  tool; the runtime's dangerous built-ins are not in the set and still prompt.

The product path is deliberately untouched: `isBuiltinSystemToolCall` still
requires an **exact** title match, and the extra names are matched the same strict
way rather than by substring.

## Full real games (local Claude Code, sonnet)

| Trial | Players | Seed | Winner | Rounds | Actions (vote/kill/inspect/protect) | Order completion | Leaks |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 5 | 81 | **village** | 2 | 14 (9/1/2/2) | 2 of 2 days | 0 |
| 2 | 5 | 91 | **werewolves** | 1 | 3 (0/1/1/1) | no day reached | 0 |
| 3 | 5 | 92 | **werewolves** | 2 | 14 (8/2/2/2) | 2 of 2 days | 0 |
| 4 | 7 | 101 | **werewolves** | 3 | 16 (10/3/1/2) | 2 of 2 days | 0 |
| 5 | 7 | 102 | **werewolves** | 2 | 11 (6/2/1/2) | 1 of 1 day | 0 |

All five `completed` with a real win condition satisfied by the survivors; every
day's order completed **in order** (`outOfOrderSpeeches: 0`,
`speakersNeverReached: 0`); zero leaks, zero unauthorized/wrong-room effects,
zero gated wakes, zero latches. Nothing stalled.

Trial 1 reads like Werewolf: night 1 the doctor's self-save cancels the wolves'
kill; day 1 lynches `player-2`, a **werewolf**; night 2 the seer learns `player-5`
is the other wolf; day 2 the seer, doctor and villager vote it out → **village
wins**. Private information stayed private — the seer's result arrives in its DM,
the wolves coordinate only in the den, canary assertions clean.

Trial 2 is not a failure: with 5 players one night-1 kill makes it 2-vs-2, so the
werewolves win before a day opens. **Seven is the size where the day carries the
game** — trial 4 ran the full three-round arc.

Multi-round works because each round's referee `DAY`/`VOTE` broadcast is a
trusted human turn that resets the automatic-turn counter: 48–96 admitted
automatic turns per game with **zero** gated.

## Tests

New scripted CI test pinning multi-round play to a winner (night → sequential day
→ vote → resolution, repeating), asserting the win condition against the
survivors, the per-round phase order, and that the budget reset carries the game.

`pnpm eval:collab:contracts` — **15 files, 109 tests**. Daemon
permission/evaluation suites — **60 tests**. Plus typecheck, lint, format,
`eval:validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
