### PR TITLE
feat(usage): stacked spend-over-time chart grouped by agent/runtime/model

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2973,10 +2973,19 @@ export const UsageDto = z.object({
   agents: z.array(UsageAgentDto),
   models: z.array(UsageModelDto),
   // Spend-over-time chart: cost bucketed by hour (d1) or day (longer ranges),
-  // empty buckets filled to 0. `start` is a UTC-aligned ISO instant.
+  // empty buckets filled to 0. `start` is a UTC-aligned ISO instant. `byAgent`/
+  // `byModel` split each bucket's total for the grouped/stacked chart (model
+  // key ''=unreported; only non-zero deltas get a key).
   series: z.object({
     bucket: z.enum(['hour', 'day']),
-    points: z.array(z.object({ start: z.string(), costAmount: z.number() }))
+    points: z.array(
+      z.object({
+        start: z.string(),
+        costAmount: z.number(),
+        byAgent: z.record(z.string(), z.number()),
+        byModel: z.record(z.string(), z.number())
+      })
+    )
   })
 })
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1577,10 +1577,14 @@ export interface ModelUsageAggregate {
 }
 
 /** One spend-over-time bucket: total cost of sessions whose last activity fell in
- *  `[start, start + one bucket)`. `start` is a UTC-aligned ISO instant. */
+ *  `[start, start + one bucket)`. `start` is a UTC-aligned ISO instant.
+ *  `byAgent`/`byModel` split the same total for the console's grouped/stacked
+ *  chart (model key ''=unreported); only non-zero deltas get a key. */
 export interface SpendBucket {
   start: string
   costAmount: number
+  byAgent: Record<string, number>
+  byModel: Record<string, number>
 }
 
 /** Org-wide usage aggregate for a range: workspace totals + agent/model breakdowns.

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -23,6 +23,7 @@ import type {
   UsageAggregate,
   AgentUsageAggregate,
   ModelUsageAggregate,
+  SpendBucket,
   ViewCtx,
   SessionFilterQuery
 } from '../ports.js'
@@ -254,9 +255,11 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // Floor `since` to the start of its local bucket, expressed as a UTC instant.
     const floorSince = Math.floor((since.getTime() - offMs) / stepMs) * stepMs + offMs
     const n = Math.floor((now - floorSince) / stepMs) + 1
-    const points: { start: string; costAmount: number }[] = Array.from({ length: n }, (_, i) => ({
+    const points: SpendBucket[] = Array.from({ length: n }, (_, i) => ({
       start: new Date(floorSince + i * stepMs).toISOString(),
-      costAmount: 0
+      costAmount: 0,
+      byAgent: {},
+      byModel: {}
     }))
 
     // Spend timeline → range spend by DIFFING consecutive cumulatives per session.
@@ -314,7 +317,14 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       const modelKey = row.model ?? ''
       perModelCost.set(modelKey, (perModelCost.get(modelKey) ?? 0) + delta)
       const idx = Math.floor((row.at.getTime() - floorSince) / stepMs)
-      if (idx >= 0 && idx < n) points[idx]!.costAmount += delta
+      if (idx >= 0 && idx < n) {
+        const pt = points[idx]!
+        pt.costAmount += delta
+        if (delta !== 0) {
+          pt.byAgent[row.agentId] = (pt.byAgent[row.agentId] ?? 0) + delta
+          pt.byModel[modelKey] = (pt.byModel[modelKey] ?? 0) + delta
+        }
+      }
     }
 
     const agents: AgentUsageAggregate[] = grouped.map((g) => ({

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -110,6 +110,17 @@
   --border-inverse: rgba(255, 255, 255, 0.1);
   --border-focus: var(--magenta-500);
 
+  /* Chart categorical series (usage stacked bars) — fixed assignment order,
+     CVD-validated against the light card surface; dark theme remaps its own
+     steps below. --chart-other is the fold-the-tail bucket (never a hue). */
+  --chart-1: var(--magenta-500);
+  --chart-2: var(--gold-500);
+  --chart-3: var(--indigo-500);
+  --chart-4: var(--teal-500);
+  --chart-5: var(--coral-500);
+  --chart-6: var(--purple-500);
+  --chart-other: var(--gray-400);
+
   /* Brand / primary actions */
   --brand: var(--magenta-500);
   --brand-hover: var(--magenta-600);
@@ -214,6 +225,15 @@
   --border-strong: #493a5d;
   --border-inverse: rgba(255, 255, 255, 0.09);
   --border-focus: #c62a78;
+
+  /* Chart categorical series — dark-surface steps (validated vs --surface-card). */
+  --chart-1: #d6488d;
+  --chart-2: #b8840a;
+  --chart-3: #6f72e8;
+  --chart-4: #0f9c93;
+  --chart-5: #e05a41;
+  --chart-6: #9d6ad8;
+  --chart-other: #58616d;
 
   /* Brand / primary actions */
   --brand: #c62a78;

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -359,7 +359,9 @@ export default function UsageView() {
                   {unit} / {data.series.bucket}
                 </span>
               </div>
-              {hasBreakdown && stackKeys.length >= 2 && (
+              {/* Legend shows even for a single key — the card title doesn't name
+                  the series, and touch users can't reach the hover tooltip. */}
+              {hasBreakdown && stackKeys.length > 0 && (
                 <div className="flex flex-wrap gap-x-3 gap-y-1 px-[18px] pt-3">
                   {stackKeys.map((k) => (
                     <span
@@ -393,10 +395,17 @@ export default function UsageView() {
                     >
                       {/* Stack renders DOM top→bottom = reverse of stackKeys, so the
                           largest key sits on the baseline. flex-grow splits the
-                          bucket height after the 2px surface gaps between segments. */}
+                          bucket height after the 2px surface gaps between segments.
+                          A tiny bar can be all gap (2px × segments ≥ its height),
+                          so gaps only apply once every segment can keep visible
+                          color (~127px usable plot height at 100%). */}
                       <div
-                        className="flex w-full max-w-[46px] flex-col gap-[2px] overflow-hidden rounded-t-[5px]"
-                        style={{ height: `${maxSpend > 0 ? (total / maxSpend) * 100 : 0}%`, minHeight: 4 }}
+                        className="flex w-full max-w-[46px] flex-col overflow-hidden rounded-t-[5px]"
+                        style={{
+                          height: `${maxSpend > 0 ? (total / maxSpend) * 100 : 0}%`,
+                          minHeight: 4,
+                          gap: maxSpend > 0 && (total / maxSpend) * 127 > segs.length * 6 ? 2 : 0
+                        }}
                       >
                         {segs.length === 0 ? (
                           <div className="h-full w-full bg-(--surface-active)" />

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -287,7 +287,6 @@ export default function UsageView() {
       {data?.series &&
         (() => {
           const pts = data.series.points
-          const maxSpend = Math.max(...pts.map((p) => p.costAmount), 0)
           const labelEvery = Math.max(1, Math.ceil(pts.length / 8))
           const gap = pts.length > 40 ? 2 : pts.length > 14 ? 4 : 10
           const unit = (currency ?? 'USD').toUpperCase()
@@ -295,6 +294,62 @@ export default function UsageView() {
           // this zone, so tell the viewer. Client-only: the chart never renders on
           // the server (data is client-fetched), so no hydration mismatch.
           const tzName = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+
+          // Stacked breakdown, following the table's group-by. Buckets carry
+          // byAgent/byModel from the CP; runtime rolls byAgent through the
+          // console's agent list. Absent on an older CP → flat brand bars.
+          const hasBreakdown = pts.some((p) => p.byAgent || p.byModel)
+          const agentMeta = new Map(enriched.map((e) => [e.agentId, e]))
+          const recs = pts.map((p) => {
+            if (!hasBreakdown) return { '': p.costAmount }
+            if (groupBy === 'model') return p.byModel ?? {}
+            if (groupBy === 'agent') return p.byAgent ?? {}
+            const rec: Record<string, number> = {}
+            for (const [id, v] of Object.entries(p.byAgent ?? {})) {
+              const rt = agentMeta.get(id)?.runtime || 'unknown'
+              rec[rt] = (rec[rt] ?? 0) + v
+            }
+            return rec
+          })
+          // Fixed hue assignment: top-6 keys by range spend get --chart-1..6 in
+          // order, the tail folds into a gray "Other" (hues are never cycled).
+          const OTHER = '\0other'
+          const totalsByKey = new Map<string, number>()
+          for (const rec of recs)
+            for (const [k, v] of Object.entries(rec)) totalsByKey.set(k, (totalsByKey.get(k) ?? 0) + v)
+          const rankedKeys = [...totalsByKey.entries()].sort((a, b) => b[1] - a[1]).map(([k]) => k)
+          const topKeys = rankedKeys.slice(0, 6)
+          const stackKeys = rankedKeys.length > 6 ? [...topKeys, OTHER] : topKeys
+          const keyName = (k: string) => {
+            if (k === OTHER) return 'Other'
+            if (!hasBreakdown) return ''
+            if (groupBy === 'model') return modelLabel(k)
+            if (groupBy === 'runtime') return runtimeLabel(k)
+            const meta = agentMeta.get(k)
+            return meta ? meta.name : k.length > 12 ? k.slice(0, 8) : k
+          }
+          const keyColor = (k: string) =>
+            !hasBreakdown
+              ? 'var(--brand)'
+              : k === OTHER
+                ? 'var(--chart-other)'
+                : `var(--chart-${topKeys.indexOf(k) + 1})`
+          // Per-bucket stack, bottom-up in stackKeys order. Negative deltas
+          // (downward corrections) can't render as height — clamp to 0; the
+          // bucket's tooltip total still reports the true net figure.
+          const stacks = recs.map((rec) => {
+            const segs = stackKeys
+              .map((k) => ({
+                k,
+                v:
+                  k === OTHER
+                    ? Object.entries(rec).reduce((s, [kk, vv]) => (topKeys.includes(kk) ? s : s + Math.max(0, vv)), 0)
+                    : Math.max(0, rec[k] ?? 0)
+              }))
+              .filter((s) => s.v > 0)
+            return { segs, total: segs.reduce((s, x) => s + x.v, 0) }
+          })
+          const maxSpend = Math.max(...stacks.map((s) => s.total), 0)
           return (
             <div className="card mb-[18px] max-desktop:mx-4 max-desktop:mb-3 max-desktop:rounded-lg">
               <div className="cardhead">
@@ -304,19 +359,59 @@ export default function UsageView() {
                   {unit} / {data.series.bucket}
                 </span>
               </div>
+              {hasBreakdown && stackKeys.length >= 2 && (
+                <div className="flex flex-wrap gap-x-3 gap-y-1 px-[18px] pt-3">
+                  {stackKeys.map((k) => (
+                    <span
+                      key={k}
+                      className="flex items-center gap-[5px] font-sans text-[11px] leading-normal text-(--text-secondary)"
+                    >
+                      <span
+                        className="h-[9px] w-[9px] flex-none rounded-[3px]"
+                        style={{ backgroundColor: keyColor(k) }}
+                      />
+                      {keyName(k)}
+                    </span>
+                  ))}
+                </div>
+              )}
               <div className="flex h-[180px] items-end px-[18px] pb-[14px] pt-5" style={{ gap }}>
                 {pts.map((p, i) => {
                   const label = bucketLabel(p.start, data.series.bucket)
+                  const { segs, total } = stacks[i]!
+                  const tip = hasBreakdown
+                    ? [
+                        `${label} · ${fmtCost(p.costAmount, currency)}`,
+                        ...[...segs].reverse().map((s) => `${keyName(s.k)}: ${fmtCost(s.v, currency)}`)
+                      ].join('\n')
+                    : `${label} · ${fmtCost(p.costAmount, currency)}`
                   return (
                     <div
                       key={p.start}
                       className="flex h-full min-w-0 flex-1 flex-col items-center justify-end gap-2"
-                      title={`${label} · ${fmtCost(p.costAmount, currency)}`}
+                      title={tip}
                     >
+                      {/* Stack renders DOM top→bottom = reverse of stackKeys, so the
+                          largest key sits on the baseline. flex-grow splits the
+                          bucket height after the 2px surface gaps between segments. */}
                       <div
-                        className="w-full max-w-[46px] rounded-t-[5px] bg-(--brand)"
-                        style={{ height: `${maxSpend > 0 ? (p.costAmount / maxSpend) * 100 : 0}%`, minHeight: 4 }}
-                      />
+                        className="flex w-full max-w-[46px] flex-col gap-[2px] overflow-hidden rounded-t-[5px]"
+                        style={{ height: `${maxSpend > 0 ? (total / maxSpend) * 100 : 0}%`, minHeight: 4 }}
+                      >
+                        {segs.length === 0 ? (
+                          <div className="h-full w-full bg-(--surface-active)" />
+                        ) : (
+                          [...segs].reverse().map((s) => (
+                            <div
+                              key={s.k}
+                              className="min-h-0 w-full"
+                              // grow values normalized to sum 1 — raw costs can sum
+                              // below 1, which would leave the bar under-filled.
+                              style={{ flexGrow: s.v / total, backgroundColor: keyColor(s.k) }}
+                            />
+                          ))
+                        )}
+                      </div>
                       <span
                         className={`mono whitespace-nowrap text-[10.5px] leading-none text-(--text-tertiary) ${
                           i % labelEvery === 0 ? '' : 'select-none'

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2843,8 +2843,18 @@ export interface UsageDto {
   agents: UsageAgentDto[]
   models: UsageModelDto[]
   // Spend-over-time chart: cost bucketed by hour (d1) or day (longer ranges),
-  // empty buckets filled to 0. `start` is a UTC-aligned ISO instant.
-  series: { bucket: 'hour' | 'day'; points: { start: string; costAmount: number }[] }
+  // empty buckets filled to 0. `start` is a UTC-aligned ISO instant. `byAgent`/
+  // `byModel` split each bucket's total for the grouped/stacked view (model key
+  // ''=unreported); optional so a CP predating them degrades to flat bars.
+  series: {
+    bucket: 'hour' | 'day'
+    points: {
+      start: string
+      costAmount: number
+      byAgent?: Record<string, number>
+      byModel?: Record<string, number>
+    }[]
+  }
 }
 
 export async function fetchUsage(range: UsageRange, orgId?: string): Promise<UsageDto> {


### PR DESCRIPTION
## What

The Analytics page's **Spend over time** bar chart now follows the breakdown table's **By agent / By runtime / By model** selector and renders a stacked bar chart with a legend and per-segment tooltips.

- **Control plane**: the `/usage` spend series adds `byAgent` / `byModel` records to each bucket, accumulated inside the existing spend-diff loop — no extra queries, no schema changes, no backfill. DTO + port types updated.
- **Web**: the chart reads the same `groupBy` state as the table. Runtime stacks are derived client-side by rolling `byAgent` through the console's agent metadata (same current-runtime semantics as the table). Top-6 keys by range spend get fixed hues; any tail folds into a gray "Other".
- **Design tokens**: new `--chart-1..6` / `--chart-other` categorical series tokens in `globals.css`, with separate light and dark steps — both palettes pass CVD-separation/contrast validation against their card surfaces.

## Why

The chart previously showed only the total per bucket; there was no way to see which agent, runtime, or model drove a spike without cross-referencing the table.

## Reviewer notes

- **Backward compatible both ways**: a CP predating the new fields → the web falls back to the old flat brand bars (fields are optional in the client type); old clients ignore the extra fields.
- **Historical data**: by-agent and by-runtime work retroactively (the spend timeline always carried `agentId`). By-model groups pre-model-reporting history under the "—" segment, matching the existing By model table behavior.
- Negative spend deltas (downward corrections) are clamped to 0 for segment heights; the bucket tooltip still reports the true net total.
- Verified end-to-end locally: CP unit (1246) + integration (982) suites pass, both packages typecheck, and the chart was exercised in the browser across all three groupings, light/dark themes, and the mobile layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)