### PR TITLE
fix(cli): repair daemon sandbox helper modes

### DIFF
--- a/packages/cli/src/install.ts
+++ b/packages/cli/src/install.ts
@@ -6,11 +6,26 @@
  * for a corrupt bundle). Must run inside the version lock (version-lock.ts).
  */
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync } from 'node:fs'
 import { nodeSatisfies } from './node-engines.js'
 import { versionDir, versionsDir } from './paths.js'
 import { downloadTarball, resolveDaemonTarget, verifyTarball, type ResolvedTarget } from './registry.js'
 import { isInstalled, type Channel } from './version-store.js'
+
+const SECCOMP_HELPER_PATHS = [
+  'dist/vendor/seccomp/x64/apply-seccomp',
+  'dist/vendor/seccomp/arm64/apply-seccomp'
+] as const
+
+/** npm normalizes non-`bin` payload files to 0644 while packing, including the
+ * native sandbox-runtime helpers staged by the daemon build. Restore their
+ * executable mode after the integrity-verified tarball is extracted. */
+export function repairDaemonBundleModes(root: string): void {
+  for (const relative of SECCOMP_HELPER_PATHS) {
+    const path = `${root}/${relative}`
+    if (existsSync(path)) chmodSync(path, 0o755)
+  }
+}
 
 /**
  * A pinned `--to` version. Rejects anything that is not a plain version token —
@@ -76,6 +91,7 @@ export async function installTarget(
     if (!existsSync(`${tmp}/dist/index.js`)) {
       throw new Error(`daemon ${target.version} tarball has no dist/index.js — refusing to install`)
     }
+    repairDaemonBundleModes(tmp)
 
     // Atomic publish. A racing install that already produced `dest` wins; drop
     // tmp — except a forced re-install, whose point is replacing the existing dir.

--- a/packages/cli/src/run-shell.ts
+++ b/packages/cli/src/run-shell.ts
@@ -1,5 +1,7 @@
 import { RESERVED_RESTART_CODE } from '@agentconnect.md/protocol'
 import { exitAsChild, resolveDaemonEntry, spawnDaemon, type ChildResult } from './delegate.js'
+import { repairDaemonBundleModes } from './install.js'
+import { versionDir } from './paths.js'
 import { runRecoveryFlow, shouldOfferRecovery } from './run-recovery.js'
 import { spawnDaemonViaLoginShell } from './service-spawn.js'
 import { versionInstall } from './version-commands.js'
@@ -10,9 +12,9 @@ import { currentVersion, readMeta } from './version-store.js'
  * through here): if no daemon version is active yet — a fresh host where the user
  * ran `run`/`login` without a prior `agentconnect install` — pull the channel's
  * latest and activate it, so the daemon starts out of the box instead of erroring
- * with "no active daemon". Two short-circuits: an already-active `current`, and
- * dev mode (`AGENTCONNECT_DAEMON_ENTRY` points the CLI at an in-repo entry,
- * bypassing the version store entirely).
+ * with "no active daemon". An already-active `current` only needs its known
+ * native payload modes self-healed; dev mode (`AGENTCONNECT_DAEMON_ENTRY` points
+ * the CLI at an in-repo entry) bypasses the version store entirely.
  *
  * Channel resolution is delegated to `versionInstall`, which reads `readMeta` — a
  * stored channel preference wins, else the CLI-derived default (`defaultChannel`).
@@ -24,7 +26,11 @@ import { currentVersion, readMeta } from './version-store.js'
  */
 export async function ensureDaemonInstalled(root: string): Promise<void> {
   if (process.env.AGENTCONNECT_DAEMON_ENTRY) return
-  if (currentVersion(root)) return
+  const current = currentVersion(root)
+  if (current) {
+    repairDaemonBundleModes(versionDir(root, current))
+    return
+  }
   console.error(`agentconnect: no daemon installed — installing the latest ${readMeta(root).channel} version…`)
   await versionInstall(root, {})
 }

--- a/packages/cli/test/ensure-daemon.test.ts
+++ b/packages/cli/test/ensure-daemon.test.ts
@@ -14,12 +14,18 @@ vi.mock('../src/version-store.js', () => ({
   readMeta: (root: string) => readMeta(root)
 }))
 
+const repairDaemonBundleModes = vi.fn()
+vi.mock('../src/install.js', () => ({
+  repairDaemonBundleModes: (root: string) => repairDaemonBundleModes(root)
+}))
+
 const { ensureDaemonInstalled } = await import('../src/run-shell.js')
 
 const ENTRY = 'AGENTCONNECT_DAEMON_ENTRY'
 
 beforeEach(() => {
   versionInstall.mockClear()
+  repairDaemonBundleModes.mockClear()
   currentVersion.mockReset().mockReturnValue(null)
   delete process.env[ENTRY]
 })
@@ -39,6 +45,7 @@ describe('ensureDaemonInstalled', () => {
     currentVersion.mockReturnValue('1.2.3')
     await ensureDaemonInstalled('/root')
     expect(versionInstall).not.toHaveBeenCalled()
+    expect(repairDaemonBundleModes).toHaveBeenCalledWith('/root/versions/1.2.3')
   })
 
   it('skips in dev mode (AGENTCONNECT_DAEMON_ENTRY set)', async () => {

--- a/packages/cli/test/install.test.ts
+++ b/packages/cli/test/install.test.ts
@@ -1,0 +1,30 @@
+import { chmodSync, mkdirSync, mkdtempSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { repairDaemonBundleModes } from '../src/install.js'
+
+describe('repairDaemonBundleModes', () => {
+  it('restores executable mode on npm-normalized seccomp helpers', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentconnect-daemon-modes-'))
+    for (const arch of ['x64', 'arm64']) {
+      const dir = join(root, 'dist', 'vendor', 'seccomp', arch)
+      const helper = join(dir, 'apply-seccomp')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(helper, 'helper')
+      chmodSync(helper, 0o644)
+    }
+
+    repairDaemonBundleModes(root)
+
+    for (const arch of ['x64', 'arm64']) {
+      const helper = join(root, 'dist', 'vendor', 'seccomp', arch, 'apply-seccomp')
+      expect(statSync(helper).mode & 0o777).toBe(0o755)
+    }
+  })
+
+  it('allows bundles without the optional Linux helpers', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentconnect-daemon-modes-'))
+    expect(() => repairDaemonBundleModes(root)).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- restore executable modes on bundled sandbox-runtime `apply-seccomp` helpers after daemon tarball extraction
- self-heal already-installed active daemon bundles when `agentconnect run` starts
- add regression coverage for both helper architectures and the active-version startup path

## Root cause

npm normalizes non-`bin` payload files to mode `0644` while packing. The daemon build stages the native `apply-seccomp` helpers as executable, but the published tarball loses those executable bits. Preset skill installation then enters the offline sandbox and fails with exit status 126 (`Permission denied`), leaving the agent's managed-skill ledger empty.

## Impact

Fresh installs and existing active daemon versions recover the helper modes automatically before daemon startup, allowing preset and managed skills to install normally.

## Validation

- `pnpm --filter @agentconnect.md/cli test` (155 tests)
- `pnpm --filter @agentconnect.md/cli typecheck`
- Pre-push repository lint hook (`eslint .`)
- Prettier check and `git diff --check`