### PR TITLE
fix(memory): every session can read shared memory; only writes stay gated

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2987,10 +2987,13 @@ export class Daemon {
       cancelOrchestration: (req) => Promise.resolve(this.cancelOrchestrationForOwner(req)),
       submitGithubReview: (req) => this.submitGithubReview(req),
       memory: this.memory,
-      // The same isolation verdict gates explicit recall and mutation of shared
-      // agent memory. Resolve it from trusted session coords at call time so a
-      // policy change takes effect for an already-running ACP session.
-      memoryAccessAllowed: (ctx) => !this.store.isCaptureExcluded(this.acpSessionIdForToolCall(ctx)),
+      // Every session may READ shared agent memory; only a non-isolated session
+      // may WRITE it, so a private DM/A2A turn can use existing memory but cannot
+      // push its own content into the cross-user store (#653; capture stays gated
+      // like post-turn distillation). Resolved from trusted session coords at call
+      // time so a policy change takes effect for an already-running ACP session.
+      memoryAccessAllowed: (ctx, mode) =>
+        mode === 'read' || !this.store.isCaptureExcluded(this.acpSessionIdForToolCall(ctx)),
       recordOutbound: (ctx, channel, thread, text, ts, integrationId) =>
         this.store.appendTranscript({
           channel: transcriptChannelKey(channel, this.transportScopeForIntegrationIds([integrationId])),
@@ -12380,14 +12383,10 @@ export class Daemon {
         callMeta?.needsReply,
         {
           initializeOnly,
-          sharedMemoryExcluded:
-            webchat?.evaluation !== true &&
-            (persistedSessionId != null
-              ? this.store.isCaptureExcluded(persistedSessionId)
-              : callMeta !== undefined ||
-                msg.isDm ||
-                msg.platform === 'webchat' ||
-                this.pendingLaunchCorrelation.has(agentId)),
+          // Memory READS (index injection + auto-recall) are no longer session-
+          // gated — every session may use shared memory (#653). WRITES stay gated
+          // (memory write tools via memoryAccessAllowed; post-turn distillation via
+          // isCaptureExcluded at recordTurnForBinding).
           ...(remoteMcpServer ? { additionalMcpServers: [remoteMcpServer] } : {}),
           ...(webchat?.worktree !== undefined
             ? { workspaceIsolation: webchat.worktree ? ('session' as const) : ('shared' as const) }

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -525,12 +525,15 @@ export interface OpsDeps {
   /** The agent memory provider — backs the `readMemory`/`writeMemory` tools.
    *  Universal (every agent has memory), independent of the platform. */
   memory: MemoryProvider
-  /** Session-isolation gate for the explicit memory-tool path. Agent memory is
-   *  shared across users, so an isolated session may neither recall nor mutate
-   *  it. Automatic recall, post-turn capture, and Dream selection are gated at
-   *  their own boundaries. Checked at CALL time so a mid-session policy change
-   *  takes effect immediately. Absent ⇒ allowed (e.g. in unit fixtures). */
-  memoryAccessAllowed?: (ctx: SessionContext) => boolean
+  /** Session-isolation gate for the explicit memory-tool path, by operation
+   *  (#653). Agent memory is shared across users: every session may READ it
+   *  (read/search/get), but only a non-isolated session may WRITE it
+   *  (write/save/update/delete), so a private DM/A2A turn cannot push its content
+   *  into shared memory. Automatic recall is always allowed; post-turn capture and
+   *  Dream selection are gated at their own boundaries. Checked at CALL time so a
+   *  mid-session policy change takes effect immediately. Absent ⇒ allowed (e.g. in
+   *  unit fixtures). */
+  memoryAccessAllowed?: (ctx: SessionContext, mode: 'read' | 'write') => boolean
   /** Collaboration Arena §6: resolve + execute an evaluation-registry tool.
    *  Returns undefined when `name` is not an evaluation tool. Visibility and
    *  role-aware authorization live behind this seam (the daemon guarantees
@@ -680,7 +683,8 @@ export async function executeTool(
   // Memory tools are universal (every agent has memory) and daemon-local — handle
   // them before the platform-gateway gate so an agent with no platform integration works.
   if (name === 'readMemory' || name === 'writeMemory') {
-    if (deps.memoryAccessAllowed?.(ctx) === false) throw new Error(MEMORY_ACCESS_BLOCKED)
+    const mode = name === 'writeMemory' ? 'write' : 'read'
+    if (deps.memoryAccessAllowed?.(ctx, mode) === false) throw new Error(MEMORY_ACCESS_BLOCKED)
     const scope = { agentId: ctx.agentId }
     try {
       if (name === 'readMemory') {
@@ -734,7 +738,8 @@ export async function executeTool(
   // provider on every call so a stale session tool cannot cross a provider or
   // capability change. The trusted agent scope is always ctx.agentId.
   if (['searchMemory', 'saveMemory', 'getMemory', 'updateMemory', 'deleteMemory'].includes(name)) {
-    if (deps.memoryAccessAllowed?.(ctx) === false) throw new Error(MEMORY_ACCESS_BLOCKED)
+    const mode = name === 'searchMemory' || name === 'getMemory' ? 'read' : 'write'
+    if (deps.memoryAccessAllowed?.(ctx, mode) === false) throw new Error(MEMORY_ACCESS_BLOCKED)
     const surface = deps.memory.adminSurfaceForAgent?.(ctx.agentId) ?? deps.memory.adminSurface()
     if (!surface || surface.shape !== 'records') throw new Error('record memory is not available for this agent')
     const scope = { agentId: ctx.agentId }

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -384,10 +384,6 @@ export class SessionManager {
       /** Extra descriptors bound to the exact overridden host (for example the
        * cell-private AgentConnect admin MCP bridge). */
       additionalMcpServers?: McpServer[]
-      /** Trusted source gate: this runtime must not read agent/org shared
-       * memory. Computed by the daemon before any transcript or prompt body is
-       * handed to this method. */
-      sharedMemoryExcluded?: boolean
       /** Product Worktree override for a brand-new logical session. Existing
        * sessions keep their persisted choice unless the trusted review path
        * explicitly forces an exact workspace migration. */
@@ -685,10 +681,12 @@ export class SessionManager {
     // a fresh session (a resumed session already carries it from its first turn).
     // Routed to exactly one place: Claude carries it via `_meta.systemPrompt` (metaContext,
     // passed to newSession); other runtimes get it folded into the inline system block below.
-    const memoryIndex =
-      memoryEnabled && options.sharedMemoryExcluded !== true
-        ? (await abortable(() => this.deps.memory.standingContextAtSessionStart({ agentId }), signal)).trim()
-        : ''
+    // Every session may READ shared memory (#653): the index is injected whenever
+    // memory is enabled, regardless of session isolation. Only WRITES (the memory
+    // write tools + post-turn distillation) stay gated for private sessions.
+    const memoryIndex = memoryEnabled
+      ? (await abortable(() => this.deps.memory.standingContextAtSessionStart({ agentId }), signal)).trim()
+      : ''
     const memoryAppend = memoryIndex
       ? `# Persistent memory\n` +
         `You keep a persistent memory across sessions. Your context is periodically ` +
@@ -1218,7 +1216,7 @@ export class SessionManager {
     const turnId = stableTurnId(agentId, msg)
     const recallScope = { agentId, sessionId: rec.acpSessionId! }
     const recallPolicy = memoryEnabled ? this.deps.memory.recallPolicy(recallScope) : undefined
-    if (captureInput && options.sharedMemoryExcluded !== true && recallPolicy?.mode === 'auto') {
+    if (captureInput && recallPolicy?.mode === 'auto') {
       const recallAbort = new AbortController()
       const recallReq = {
         turnId,

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -301,7 +301,10 @@ describe('Daemon transcript records the agent reply', () => {
     await daemon.stop()
   }, 15_000)
 
-  it('resumes automatic recall after the CP publishes a private DM to the org', async () => {
+  // Reads are always allowed (#653): automatic recall runs even for a private DM
+  // or an A2A child. Only WRITES (memory write tools + post-turn distillation) stay
+  // gated for isolated sessions.
+  it('runs automatic recall for a private DM (reads are always allowed, #653)', async () => {
     const { factory } = replyingHost('here is my answer')
     const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
     await daemon.start()
@@ -309,16 +312,12 @@ describe('Daemon transcript records the agent reply', () => {
     const recallForTurn = vi.spyOn((daemon as any).memory, 'recallForTurn').mockResolvedValue([])
 
     await (daemon as any).dispatch('bot-a', dm('100', 'private question'), 'int-a')
-    expect(recallForTurn).not.toHaveBeenCalled()
-    expect((daemon as any).store.applyCpCaptureGate('acp-1', false, 1)).toBe('applied')
-
-    await (daemon as any).dispatch('bot-a', dm('200', 'shared follow-up'), 'int-a')
 
     expect(recallForTurn).toHaveBeenCalledOnce()
     await daemon.stop()
   }, 15_000)
 
-  it('resumes automatic recall after the CP confirms an A2A child is org-visible', async () => {
+  it('runs automatic recall for an A2A child (reads are always allowed, #653)', async () => {
     const { factory } = replyingHost('here is my answer')
     const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
     await daemon.start()
@@ -327,10 +326,6 @@ describe('Daemon transcript records the agent reply', () => {
     const callMeta = (deliveryId: string) => ({ callFrom: 'caller-agent', hopCount: 1, deliveryId })
 
     await (daemon as any).dispatch('bot-a', agentMsg('100', 'delegated task'), 'int-a', undefined, callMeta('d1'))
-    expect(recallForTurn).not.toHaveBeenCalled()
-    expect((daemon as any).store.applyCpCaptureGate('acp-1', false, 1)).toBe('applied')
-
-    await (daemon as any).dispatch('bot-a', agentMsg('200', 'delegated follow-up'), 'int-a', undefined, callMeta('d2'))
 
     expect(recallForTurn).toHaveBeenCalledOnce()
     await daemon.stop()

--- a/packages/daemon/test/memory-write-gate.test.ts
+++ b/packages/daemon/test/memory-write-gate.test.ts
@@ -1,10 +1,12 @@
 /**
- * The tool half of the shared-memory isolation gate.
+ * The tool half of the shared-memory isolation gate (#653).
  *
- * Automatic post-turn distillation is gated in the daemon, but agent memory is
- * shared across users and the agent can also write it EXPLICITLY — the session
- * prompt actively encourages recording durable facts. A private session must not
- * be able to reach shared memory by either route.
+ * Agent memory is shared across users. Every session may READ it (the agent can
+ * use what it already knows anywhere), but only a non-isolated session may WRITE
+ * it — automatic post-turn distillation is gated in the daemon, and the explicit
+ * write tools are gated here, so a private session cannot push its content into
+ * shared memory by either route. The gate is queried per operation (`read` vs
+ * `write`); this suite mirrors the daemon wiring where reads are always allowed.
  */
 import { describe, it, expect, vi } from 'vitest'
 import { executeTool, MEMORY_ACCESS_BLOCKED, type OpsDeps, type SessionContext } from '../src/mcp/ops.js'
@@ -18,13 +20,15 @@ const ctx = (): SessionContext => ({
   tools: []
 })
 
-function deps(allowed: boolean, over: Partial<OpsDeps> = {}): OpsDeps {
+// Mirror the daemon: reads are always allowed; writes are gated on the session's
+// isolation verdict.
+function deps(writeAllowed: boolean, over: Partial<OpsDeps> = {}): OpsDeps {
   return {
     memory: {
       read: vi.fn(async () => ({ content: 'existing' })),
       write: vi.fn(async () => ({ ok: true }))
     },
-    memoryAccessAllowed: () => allowed,
+    memoryAccessAllowed: (_ctx, mode) => mode === 'read' || writeAllowed,
     ...over
   } as unknown as OpsDeps
 }
@@ -36,10 +40,10 @@ describe('file memory under the session-isolation gate', () => {
     expect(d.memory.write).not.toHaveBeenCalled()
   })
 
-  it('refuses reads from an isolated session, without touching the provider', async () => {
+  it('allows a read from an isolated session — every session can use shared memory (#653)', async () => {
     const d = deps(false)
-    await expect(executeTool(ctx(), 'readMemory', {}, d)).rejects.toThrow(MEMORY_ACCESS_BLOCKED)
-    expect(d.memory.read).not.toHaveBeenCalled()
+    await executeTool(ctx(), 'readMemory', {}, d)
+    expect(d.memory.read).toHaveBeenCalled()
   })
 
   it('allows the write when the session is org-visible', async () => {
@@ -56,7 +60,7 @@ describe('file memory under the session-isolation gate', () => {
 })
 
 describe('record-memory mutations under the same gate', () => {
-  const recordDeps = (allowed: boolean): OpsDeps => {
+  const recordDeps = (writeAllowed: boolean): OpsDeps => {
     const surface = {
       shape: 'records' as const,
       capabilities: new Set(['recall', 'create', 'update', 'delete', 'get']),
@@ -67,19 +71,17 @@ describe('record-memory mutations under the same gate', () => {
     }
     return {
       memory: { adminSurface: () => surface, adminSurfaceForAgent: () => surface },
-      memoryAccessAllowed: () => allowed
+      memoryAccessAllowed: (_ctx: SessionContext, mode: 'read' | 'write') => mode === 'read' || writeAllowed
     } as unknown as OpsDeps
   }
 
-  it('refuses saveMemory from a private session', async () => {
+  it('refuses saveMemory (a write) from a private session', async () => {
     await expect(
       executeTool(ctx(), 'saveMemory', { content: 'secret', metadata: {} }, recordDeps(false))
     ).rejects.toThrow(MEMORY_ACCESS_BLOCKED)
   })
 
-  it('refuses searchMemory from an isolated session', async () => {
-    await expect(executeTool(ctx(), 'searchMemory', { query: 'deploys' }, recordDeps(false))).rejects.toThrow(
-      MEMORY_ACCESS_BLOCKED
-    )
+  it('allows searchMemory (a read) from an isolated session (#653)', async () => {
+    await expect(executeTool(ctx(), 'searchMemory', { query: 'deploys' }, recordDeps(false))).resolves.toBeDefined()
   })
 })


### PR DESCRIPTION
Follow-up to #662, per @pchsu: memory should be usable from **every** session — including `private`, DM, A2A, webchat, launch-correlated — with proper scoping deferred to a future per-channel-memory feature. Previously the single isolation gate blocked reads too, so those sessions got no memory-index injection, no auto-recall, and the memory tools threw.

## Change — split the gate into read vs write (option A)

- **Reads always allowed:** memory-index injection and per-turn auto-recall no longer depend on session isolation (`session-manager`); the read tools (`readMemory`, `searchMemory`, `getMemory`) are ungated.
- **Writes stay gated:** a private/isolated session must not push its content into the cross-user shared store. The write tools (`writeMemory`, `saveMemory`, `updateMemory`, `deleteMemory`) go through `memoryAccessAllowed(ctx, 'write')` (= `!isCaptureExcluded`), and automatic post-turn distillation keeps its existing `isCaptureExcluded` gate at `recordTurnForBinding`.

`memoryAccessAllowed` gains a `mode: 'read' | 'write'` param; the daemon wires it as `mode === 'read' || !isCaptureExcluded(...)`. The now-dead daemon-local `sharedMemoryExcluded` session option is removed (reads are unconditional).

## Why reads are safe

Reading shared, **agent-scoped** memory into a private session leaks nothing — it's the agent using its own knowledge with whoever it's talking to. The only concern was ever writing *private content INTO* shared memory (readable cross-user), and that stays blocked by both routes (write tools + distillation).

## Tests

- `memory-write-gate` split into read-allowed / write-gated (file + record surfaces).
- `daemon-transcript` recall tests now assert auto-recall runs for a private DM and an A2A child (reads open), replacing the old "blocked until CP publishes org" assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)