### PR TITLE
fix(web): compact the webchat MCP approval card and float it above the composer

### DIFF
--- a/packages/web/src/components/console/WebchatMcpApprovalCard.tsx
+++ b/packages/web/src/components/console/WebchatMcpApprovalCard.tsx
@@ -8,6 +8,7 @@ import {
   listWebchatMcpOperations,
   type WebchatMcpOperationDto
 } from '@/lib/api'
+import { Button } from '@/components/ui'
 
 /** A decided (or decision-lost) operation the owner must still be able to see.
  *  `outcome` is the last DTO the CP returned; `null` means the decision response
@@ -50,11 +51,13 @@ function outcomeNote(entry: SettledOperation): string | null {
 export function WebchatMcpApprovalCard({
   orgId,
   agentId,
-  conversationId
+  conversationId,
+  className = ''
 }: {
   orgId: string
   agentId: string
   conversationId: string
+  className?: string
 }) {
   const { data, mutate } = useSWR(
     ['webchat-mcp-operations', orgId, agentId, conversationId] as const,
@@ -123,40 +126,52 @@ export function WebchatMcpApprovalCard({
   const dismiss = (entry: SettledOperation) => setSettled((current) => current.filter((existing) => existing !== entry))
 
   return (
-    <div className="grid gap-2" aria-live="polite">
+    // Capped so a pile of operations can never push the composer off-screen. The strip
+    // scrolls on Y only: an overflow-y-auto box computes overflow-x from visible to
+    // auto, which is how a wide row used to grow a scrollbar across the whole card.
+    <div className={`grid max-h-[34vh] gap-1.5 overflow-y-auto overflow-x-hidden ${className}`} aria-live="polite">
       {pending.map((operation) => (
+        // min-w-0: a grid item's auto min-width is its min-content width, so one long
+        // unbreakable arg string would widen the row past the strip — and the strip's
+        // overflow-y-auto turns that into a card-wide x scrollbar.
         <section
           key={operation.operationId}
-          className="rounded-lg border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-xs)"
+          className="min-w-0 rounded-lg border border-(--border-default) bg-(--surface-card) px-3 py-2 shadow-(--shadow-xs)"
         >
-          <div className="font-mono text-[10.5px] font-semibold uppercase leading-normal tracking-[.08em] text-(--text-tertiary)">
-            Approval required
+          {/* Buttons drop below the text on mobile (same as ApprovalRequestsCard): kept
+            on one row, their fixed width would be a min-content floor the strip has to
+            clip. */}
+          <div className="flex flex-col gap-2 desktop:flex-row desktop:items-center">
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-x-2">
+                <span className="font-mono text-[10px] font-semibold uppercase leading-normal tracking-[.08em] text-(--amber-600)">
+                  Approval required
+                </span>
+                <span className="font-sans text-[12px] font-semibold leading-normal text-(--text-primary)">
+                  {operation.toolName}
+                </span>
+              </div>
+              <div className="mt-[2px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+                The agent requested this change. Only your approval can execute it.
+              </div>
+            </div>
+            <div className="flex flex-none items-center gap-2">
+              <Button
+                variant="secondary"
+                size="xs"
+                disabled={busy !== null}
+                onClick={() => void decide(operation, 'deny')}
+              >
+                {busy === `${operation.operationId}:deny` ? 'Denying…' : 'Deny'}
+              </Button>
+              <Button size="xs" disabled={busy !== null} onClick={() => void decide(operation, 'approve')}>
+                {busy === `${operation.operationId}:approve` ? 'Approving…' : 'Approve and run'}
+              </Button>
+            </div>
           </div>
-          <div className="mt-1 font-sans text-[14px] font-semibold leading-normal text-(--text-primary)">
-            {operation.toolName}
-          </div>
-          <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md bg-(--surface-sunken) p-3 font-mono text-[11px] leading-[1.5] text-(--text-secondary)">
+          <pre className="mt-1 max-h-24 overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-all rounded-md bg-(--surface-sunken) p-2 font-mono text-[10.5px] leading-[1.45] text-(--text-secondary)">
             {JSON.stringify(operation.arguments, null, 2)}
           </pre>
-          <p className="mt-2 font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-            The agent requested this change. Only your approval can execute it.
-          </p>
-          <div className="mt-3 flex justify-end gap-2">
-            <button
-              className="dsbtn dsbtn-secondary"
-              disabled={busy !== null}
-              onClick={() => void decide(operation, 'deny')}
-            >
-              {busy === `${operation.operationId}:deny` ? 'Denying…' : 'Deny'}
-            </button>
-            <button
-              className="dsbtn dsbtn-primary"
-              disabled={busy !== null}
-              onClick={() => void decide(operation, 'approve')}
-            >
-              {busy === `${operation.operationId}:approve` ? 'Approving…' : 'Approve and run'}
-            </button>
-          </div>
         </section>
       ))}
       {settled.map((entry) => {
@@ -165,34 +180,41 @@ export function WebchatMcpApprovalCard({
         return (
           <section
             key={entry.operation.operationId}
-            className="rounded-lg border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-xs)"
+            className="min-w-0 rounded-lg border border-(--border-default) bg-(--surface-card) px-3 py-2 shadow-(--shadow-xs)"
           >
-            <div className="font-mono text-[10.5px] font-semibold uppercase leading-normal tracking-[.08em] text-(--text-tertiary)">
-              {outcomeLabel(entry)}
-            </div>
-            <div className="mt-1 font-sans text-[14px] font-semibold leading-normal text-(--text-primary)">
-              {entry.operation.toolName}
+            <div className="flex flex-col gap-2 desktop:flex-row desktop:items-center">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-x-2">
+                  <span className="font-mono text-[10px] font-semibold uppercase leading-normal tracking-[.08em] text-(--text-tertiary)">
+                    {outcomeLabel(entry)}
+                  </span>
+                  <span className="font-sans text-[12px] font-semibold leading-normal text-(--text-primary)">
+                    {entry.operation.toolName}
+                  </span>
+                </div>
+                {note && (
+                  <div className="mt-[2px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+                    {note}
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-none items-center gap-2">
+                {unresolved ? (
+                  <Button variant="secondary" size="xs" disabled={busy !== null} onClick={() => void recheck(entry)}>
+                    {busy === `${entry.operation.operationId}:recheck` ? 'Checking…' : 'Check status'}
+                  </Button>
+                ) : (
+                  <Button variant="secondary" size="xs" onClick={() => dismiss(entry)}>
+                    Dismiss
+                  </Button>
+                )}
+              </div>
             </div>
             {entry.outcome?.result !== undefined && (
-              <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md bg-(--surface-sunken) p-3 font-mono text-[11px] leading-[1.5] text-(--text-secondary)">
+              <pre className="mt-1 max-h-24 overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-all rounded-md bg-(--surface-sunken) p-2 font-mono text-[10.5px] leading-[1.45] text-(--text-secondary)">
                 {JSON.stringify(entry.outcome.result, null, 2)}
               </pre>
             )}
-            {note && (
-              <p className="mt-2 font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">{note}</p>
-            )}
-            <div className="mt-3 flex justify-end gap-2">
-              {unresolved && (
-                <button className="dsbtn dsbtn-secondary" disabled={busy !== null} onClick={() => void recheck(entry)}>
-                  {busy === `${entry.operation.operationId}:recheck` ? 'Checking…' : 'Check status'}
-                </button>
-              )}
-              {!unresolved && (
-                <button className="dsbtn dsbtn-secondary" onClick={() => dismiss(entry)}>
-                  Dismiss
-                </button>
-              )}
-            </div>
           </section>
         )
       })}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -3410,14 +3410,6 @@ export default function SessionDetailView() {
           {/* Playground / resumed webchat: typing indicator, starter prompts, composer. */}
           {isLive && (
             <>
-              {activeOrg && session.agentId && webchatConversationId && (
-                <WebchatMcpApprovalCard
-                  key={webchatConversationId}
-                  orgId={activeOrg.id}
-                  agentId={session.agentId}
-                  conversationId={webchatConversationId}
-                />
-              )}
               {pgBusy &&
                 (() => {
                   // Multi-agent conversations attribute the typing indicator to
@@ -3480,6 +3472,17 @@ export default function SessionDetailView() {
                   className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-b from-transparent to-(--surface-app)"
                 />
                 {approvalCard('mb-2 max-desktop:rounded-lg')}
+                {/* Webchat MCP write approvals ride the same sticky footer as permission
+                  requests: always above the input, never scrolled away. */}
+                {activeOrg && session.agentId && webchatConversationId && (
+                  <WebchatMcpApprovalCard
+                    key={webchatConversationId}
+                    orgId={activeOrg.id}
+                    agentId={session.agentId}
+                    conversationId={webchatConversationId}
+                    className="mb-2"
+                  />
+                )}
                 {/* Queued messages (Claude Code-style): sends accepted while a turn was
                   still streaming wait here, dispatch in order as turns finish, and can
                   be cancelled individually before they go out. */}


### PR DESCRIPTION
## What changed

The webchat MCP approval card (`WebchatMcpApprovalCard`) was a full-size block rendered **inline in the transcript**, so a streaming agent scrolled it out of view — the one thing the user must answer was the easiest thing to lose.

1. **Moved into the sticky composer footer**, right next to `ApprovalRequestsCard`, so it always floats above the input and is never scrolled away.
2. **Compacted to match that sibling**: `Button size="xs"` on the title row instead of full-width `dsbtn`s below, 10–12px labels, `px-3 py-2` instead of `p-4`, argument JSON capped at `max-h-24` with 10.5px mono. The strip itself is capped at `max-h-[34vh]` so a pile of operations can never push the composer off-screen.
3. **Fixed the horizontal scrollbar** the compact layout exposed (details below).

## Why the x scrollbar happened

Not what it looks like — the `<pre>` was not scrolling itself, it was **widening the whole card**:

- `break-words` (`overflow-wrap: break-word`) does **not** reduce an element's min-content width per spec, so a long unbroken argument string (URL, sha) kept the `<pre>`'s min-content at the full string width.
- The `<section>` is a **grid item**, and a grid item's `auto` min-width *is* its min-content width — so the row grew past the strip (measured 534px inside a 360px container).
- The strip sets `overflow-y-auto`, and the spec computes the other axis from `visible` to `auto` — so that overflow surfaced as a scrollbar across **the entire card**.

The fix attacks all three links: `break-all` on the `<pre>` (drops min-content to one character), `min-w-0` on the `<section>` (breaks the grid-item min-width chain), and explicit `overflow-x-hidden` on the strip.

Because `overflow-x` is now hidden, a `flex-none` button group would get *clipped* on a narrow row instead of overflowing, so the header row stacks on mobile and only becomes `flex-row` at `desktop:` — the same pattern `ApprovalRequestsCard` already uses.

## Verification

Measured in the browser with the project's real Tailwind build (probe page reproducing the markup at a 360px-wide strip, both class sets side by side):

| | card `clientWidth` | `scrollWidth` | x overflow |
| --- | --- | --- | --- |
| before | 360 | 560 | **200px** |
| after | 360 | 360 | 0 |

Visually confirmed too: before, the buttons were pushed out of the visible area and the JSON was cut off; after, everything wraps inside the card. `pnpm typecheck`, eslint and prettier all pass.

## Reviewer notes

- The card renders only when a live webchat session has a pending MCP operation, so it can't be exercised from a plain dev-server page — the layout verification above was done against the compiled utility classes rather than a live pending op. Worth a sanity check next time someone triggers a real MCP write approval.
- No behavioral change: the fetch/decide/recheck/dismiss logic and the settled-vs-pending state machine are untouched. This is placement + styling only, plus a new optional `className` prop for the caller to pass spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)