### PR TITLE
fix(feishu): stop session access quota churn

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -655,11 +655,12 @@ member list with the viewer's sign-in `union_id`; provider failures fail closed.
 No browser Account API token, federated user token, Login App credential, or
 user-token refresh loop participates in Session reads. One bounded member-list
 snapshot is shared per Bot App and chat across viewers, and concurrent reads are
-coalesced. The Console refreshes Session lists from SSE, focus/reconnect, and
-explicit actions instead of polling live membership every minute. Bot tenant
-token exchanges remain deduplicated within one authorization read. A provider
-quota response fails closed, pauses further checks for that organization and
-region, and gives the operator a specific recovery action.
+coalesced. Console reads that resolve Session access (lists, facets, details,
+transcripts, and usage) refresh from SSE where available, focus/reconnect, and
+explicit actions instead of timers. Bot tenant-token exchanges remain
+deduplicated within one authorization read. A provider quota response fails
+closed, pauses further checks for that organization and region, and gives the
+operator a specific recovery action.
 
 Every installation enforces the deployment tenant before storing a Bot. The
 Control Plane resolves the configured regional Login App's `tenant_key`,

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -660,7 +660,9 @@ transcripts, and usage) refresh from SSE where available, focus/reconnect, and
 explicit actions instead of timers. Bot tenant-token exchanges remain
 deduplicated within one authorization read. A provider quota response fails
 closed, pauses further checks for that organization and region, and gives the
-operator a specific recovery action.
+operator a specific recovery action. Planned OIDC token rotation reopens the SSE
+stream without invoking gap recovery; a failed reopen restores the normal
+reconnect invalidation.
 
 Every installation enforces the deployment tenant before storing a Bot. The
 Control Plane resolves the configured regional Login App's `tenant_key`,

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -653,9 +653,13 @@ ID/Secret for a tenant token and calls `chats/:chat_id/members` with
 `member_id_type=union_id`. Group and Bot p2p sessions compare that current
 member list with the viewer's sign-in `union_id`; provider failures fail closed.
 No browser Account API token, federated user token, Login App credential, or
-user-token refresh loop participates in Session reads. Only bounded
-allow/deny/error verdicts are cached across requests; Bot tenant token exchanges
-are deduplicated within one authorization read.
+user-token refresh loop participates in Session reads. One bounded member-list
+snapshot is shared per Bot App and chat across viewers, and concurrent reads are
+coalesced. The Console refreshes Session lists from SSE, focus/reconnect, and
+explicit actions instead of polling live membership every minute. Bot tenant
+token exchanges remain deduplicated within one authorization read. A provider
+quota response fails closed, pauses further checks for that organization and
+region, and gives the operator a specific recovery action.
 
 Every installation enforces the deployment tenant before storing a Bot. The
 Control Plane resolves the configured regional Login App's `tenant_key`,

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2434,7 +2434,7 @@ export const ConversationDto = z.object({
 export const SessionAccessIssueDto = z.object({
   provider: z.string().min(1),
   region: z.string().min(1).optional(),
-  reason: z.enum(['authorization', 'unavailable'])
+  reason: z.enum(['authorization', 'quota', 'unavailable'])
 })
 
 export const SessionListPageDto = z.object({

--- a/packages/control-plane/src/http/feishu-session-access.test.ts
+++ b/packages/control-plane/src/http/feishu-session-access.test.ts
@@ -103,6 +103,28 @@ describe('FeishuSessionAccessService', () => {
     expect(new Headers(fetchImpl.mock.calls[1]?.[1]?.headers).get('authorization')).toBe('Bearer tenant-token')
   })
 
+  it('coalesces concurrent viewers into one shared Bot chat member snapshot', async () => {
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.endsWith('/tenant_access_token/internal')
+        ? json({ code: 0, tenant_access_token: 'tenant-token' })
+        : json({
+            code: 0,
+            data: { items: [{ member_id: 'on_member' }, { member_id: 'on_other' }], has_more: false }
+          })
+    )
+    const resolver = service(fetchImpl)
+
+    const [member, other] = await Promise.all([
+      resolver.resolve([scope()], viewer(['on_member'])),
+      resolver.resolve([scope()], viewer(['on_other']))
+    ])
+    await resolver.resolve([scope()], viewer(['on_member']))
+
+    expect(member.allowedScopes).toHaveLength(1)
+    expect(other.allowedScopes).toHaveLength(1)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
   it('denies when the viewer union_id is not in the chat', async () => {
     await expect(
       service(async (url) =>
@@ -135,6 +157,32 @@ describe('FeishuSessionAccessService', () => {
       degraded: true,
       accessIssues: [{ provider: 'feishu', region: 'lark', reason: 'unavailable' }]
     })
+  })
+
+  it('classifies exhausted tenant quota and backs off other chats in the same organization', async () => {
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.endsWith('/tenant_access_token/internal')
+        ? json({ code: 0, tenant_access_token: 'tenant-token' })
+        : json({ code: 99991403, msg: "This month's API call quota has been exceeded" }, 429)
+    )
+    const resolver = service(fetchImpl)
+    const anotherScope = {
+      ...scope(),
+      id: '22222222-2222-4222-8222-222222222222',
+      resourceKey: 'oc_another_chat'
+    }
+
+    await expect(resolver.resolve([scope()], viewer())).resolves.toEqual({
+      allowedScopes: [],
+      degraded: true,
+      accessIssues: [{ provider: 'feishu', region: 'lark', reason: 'quota' }]
+    })
+    await expect(resolver.resolve([anotherScope], viewer())).resolves.toEqual({
+      allowedScopes: [],
+      degraded: true,
+      accessIssues: [{ provider: 'feishu', region: 'lark', reason: 'quota' }]
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
 
   it('rejects a scope whose realm does not match its custom Bot app', async () => {

--- a/packages/control-plane/src/http/feishu-session-access.ts
+++ b/packages/control-plane/src/http/feishu-session-access.ts
@@ -15,16 +15,22 @@ const REGION_ORIGIN: Record<FeishuRegion, string> = {
   feishu: 'https://open.feishu.cn',
   lark: 'https://open.larksuite.com'
 }
-const ALLOW_TTL_MS = 120_000
+const MEMBER_LIST_TTL_MS = 120_000
 const DENY_TTL_MS = 30_000
 const UNKNOWN_TTL_MS = 5_000
+const QUOTA_RETRY_MS = 60 * 60_000
 const MAX_CACHE_ENTRIES = 10_000
 const SCOPES_PER_BATCH = 200
 const SCOPE_CONCURRENCY = 6
 const TIMEOUT_MS = 5_000
+const QUOTA_EXHAUSTED_CODE = 99991403
 
 type Decision = 'allow' | 'deny' | 'unknown'
 type ScopeDecision = { decision: Decision; issue?: SessionAccessIssue }
+type MembershipResult =
+  | { status: 'members'; unionIds: ReadonlySet<string> }
+  | { status: 'deny' }
+  | { status: 'unknown'; issue: SessionAccessIssue }
 
 const DEFINITIVE_DENIALS = new Set([232006, 232009, 232010, 232011])
 
@@ -47,7 +53,9 @@ async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value:
  * No request-bound user token is fetched or retained. */
 export class FeishuSessionAccessService implements SessionAccessPlugin {
   readonly provider = 'feishu'
-  private readonly cache = new Map<string, { result: ScopeDecision; expiresAt: number }>()
+  private readonly membershipCache = new Map<string, { result: MembershipResult; expiresAt: number }>()
+  private readonly pendingMembership = new Map<string, Promise<MembershipResult>>()
+  private readonly quotaBlockedUntil = new Map<string, number>()
 
   constructor(
     private readonly deps: {
@@ -161,32 +169,69 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
     if (unionIds.length === 0) {
       return { decision: 'unknown', issue: { provider: 'feishu', region, reason: 'authorization' } }
     }
-    const key = [scope.id, scope.aclRevision.toString(), bot.credentialRevision, ...unionIds].join(':')
-    const cached = this.cache.get(key)
-    let result = cached && cached.expiresAt > this.deps.clock.now() ? cached.result : undefined
-    if (!result) {
-      result = await this.checkMembership(region, scope.resourceKey, bot, unionIds, tokenFor, signal)
-      this.putCache(key, result)
+    const membership = await this.membershipFor(
+      [bot.id, bot.credentialRevision, scope.resourceKey].join(':'),
+      `${scope.orgId}:${region}`,
+      region,
+      scope.resourceKey,
+      bot,
+      tokenFor,
+      signal
+    )
+    if (membership.status === 'members') {
+      return { decision: unionIds.some((unionId) => membership.unionIds.has(unionId)) ? 'allow' : 'deny' }
     }
-    return result
+    if (membership.status === 'deny') return { decision: 'deny' }
+    return { decision: 'unknown', issue: membership.issue }
   }
 
-  private async checkMembership(
+  private membershipFor(
+    key: string,
+    quotaKey: string,
     region: FeishuRegion,
     chatId: string,
     bot: BotRecord,
-    unionIds: readonly string[],
     tokenFor: (bot: BotRecord, signal: AbortSignal) => Promise<string>,
     signal: AbortSignal
-  ): Promise<ScopeDecision> {
+  ): Promise<MembershipResult> {
+    const now = this.deps.clock.now()
+    const cached = this.membershipCache.get(key)
+    if (cached && cached.expiresAt > now) return Promise.resolve(cached.result)
+    if ((this.quotaBlockedUntil.get(quotaKey) ?? 0) > now) {
+      return Promise.resolve({
+        status: 'unknown',
+        issue: { provider: 'feishu', region, reason: 'quota' }
+      })
+    }
+    const existing = this.pendingMembership.get(key)
+    if (existing) return existing
+
+    const pending = this.listMembers(region, chatId, bot, tokenFor, signal, quotaKey)
+      .then((result) => {
+        if (!(result.status === 'unknown' && result.issue.reason === 'quota')) this.putMembershipCache(key, result)
+        return result
+      })
+      .finally(() => this.pendingMembership.delete(key))
+    this.pendingMembership.set(key, pending)
+    return pending
+  }
+
+  private async listMembers(
+    region: FeishuRegion,
+    chatId: string,
+    bot: BotRecord,
+    tokenFor: (bot: BotRecord, signal: AbortSignal) => Promise<string>,
+    signal: AbortSignal,
+    quotaKey: string
+  ): Promise<MembershipResult> {
     let token: string
     try {
       token = await tokenFor(bot, signal)
     } catch {
-      return { decision: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
+      return { status: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
     }
     try {
-      const wanted = new Set(unionIds)
+      const unionIds = new Set<string>()
       const seenPageTokens = new Set<string>()
       let pageToken: string | undefined
       for (;;) {
@@ -202,23 +247,27 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
         }>(region, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}/members?${query}`, token, signal)
         const code = typeof body.code === 'number' ? body.code : Number(body.code)
         if (code !== 0) {
+          if (code === QUOTA_EXHAUSTED_CODE) {
+            this.quotaBlockedUntil.set(quotaKey, this.deps.clock.now() + QUOTA_RETRY_MS)
+            return { status: 'unknown', issue: { provider: 'feishu', region, reason: 'quota' } }
+          }
           return DEFINITIVE_DENIALS.has(code)
-            ? { decision: 'deny' }
-            : { decision: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
+            ? { status: 'deny' }
+            : { status: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
         }
-        if (body.data?.items?.some((item) => typeof item.member_id === 'string' && wanted.has(item.member_id))) {
-          return { decision: 'allow' }
+        for (const item of body.data?.items ?? []) {
+          if (typeof item.member_id === 'string') unionIds.add(item.member_id)
         }
-        if (body.data?.has_more !== true) return { decision: 'deny' }
+        if (body.data?.has_more !== true) return { status: 'members', unionIds }
         const next = typeof body.data.page_token === 'string' ? body.data.page_token : undefined
         if (!next || seenPageTokens.has(next)) {
-          return { decision: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
+          return { status: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
         }
         seenPageTokens.add(next)
         pageToken = next
       }
     } catch {
-      return { decision: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
+      return { status: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
     }
   }
 
@@ -259,16 +308,19 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
       signal
     })
     const body = (await response.json()) as T
-    if (!response.ok) throw new Error(`Feishu request failed: ${response.status}`)
+    if (!response.ok && (typeof body !== 'object' || body === null || !('code' in body))) {
+      throw new Error(`Feishu request failed: ${response.status}`)
+    }
     return body
   }
 
-  private putCache(key: string, result: ScopeDecision): void {
-    if (this.cache.size >= MAX_CACHE_ENTRIES) {
-      const oldest = this.cache.keys().next().value as string | undefined
-      if (oldest) this.cache.delete(oldest)
+  private putMembershipCache(key: string, result: MembershipResult): void {
+    if (this.membershipCache.size >= MAX_CACHE_ENTRIES) {
+      const oldest = this.membershipCache.keys().next().value as string | undefined
+      if (oldest) this.membershipCache.delete(oldest)
     }
-    const ttl = result.decision === 'allow' ? ALLOW_TTL_MS : result.decision === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
-    this.cache.set(key, { result, expiresAt: this.deps.clock.now() + ttl })
+    const ttl =
+      result.status === 'members' ? MEMBER_LIST_TTL_MS : result.status === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
+    this.membershipCache.set(key, { result, expiresAt: this.deps.clock.now() + ttl })
   }
 }

--- a/packages/control-plane/src/http/session-access-plugin.ts
+++ b/packages/control-plane/src/http/session-access-plugin.ts
@@ -5,7 +5,7 @@ import type { ExternalScopeRecord } from '../persistence/ports.js'
 export interface SessionAccessIssue {
   provider: string
   region?: string
-  reason: 'authorization' | 'unavailable'
+  reason: 'authorization' | 'quota' | 'unavailable'
 }
 
 export interface SessionAccessViewer {

--- a/packages/web/src/components/console/SessionAccessNotice.test.tsx
+++ b/packages/web/src/components/console/SessionAccessNotice.test.tsx
@@ -30,4 +30,18 @@ describe('SessionAccessNotice', () => {
     expect(html).toContain('Affected sessions are hidden until access can be verified.')
     expect(html).not.toContain('Reconnect')
   })
+
+  it('turns exhausted Lark quota into an administrator action', () => {
+    const html = renderToStaticMarkup(
+      <SessionAccessNotice
+        degraded
+        issues={[{ provider: 'feishu', region: 'lark', reason: 'quota' }]}
+        impact="sessions"
+      />
+    )
+
+    expect(html).toContain('Lark API quota is exhausted.')
+    expect(html).toContain('Open Lark Admin')
+    expect(html).toContain('https://www.larksuite.com/admin')
+  })
 })

--- a/packages/web/src/components/console/SessionAccessNotice.tsx
+++ b/packages/web/src/components/console/SessionAccessNotice.tsx
@@ -4,6 +4,25 @@ import Link from 'next/link'
 import type { SessionAccessIssue } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 
+const FEISHU_ADMIN_URL = {
+  feishu: 'https://www.feishu.cn/admin',
+  lark: 'https://www.larksuite.com/admin'
+} as const
+
+function feishuRegions(issues: readonly SessionAccessIssue[], reason: SessionAccessIssue['reason']) {
+  const regions = new Set<keyof typeof FEISHU_ADMIN_URL>()
+  for (const issue of issues) {
+    if (
+      issue.provider === 'feishu' &&
+      issue.reason === reason &&
+      (issue.region === 'feishu' || issue.region === 'lark')
+    ) {
+      regions.add(issue.region)
+    }
+  }
+  return [...regions]
+}
+
 export default function SessionAccessNotice({
   degraded,
   issues = [],
@@ -16,26 +35,22 @@ export default function SessionAccessNotice({
   const { orgPath } = useOrgs()
   if (!degraded) return null
 
-  const regions = [
-    ...new Set(
-      issues.flatMap((issue) =>
-        issue.provider === 'feishu' &&
-        issue.reason === 'authorization' &&
-        (issue.region === 'feishu' || issue.region === 'lark')
-          ? [issue.region]
-          : []
-      )
-    )
-  ]
-  const names = regions.map((region) => (region === 'feishu' ? 'Feishu' : 'Lark')).join(' and ')
-  const message = names
-    ? `Your ${names} sign-in ${regions.length === 1 ? 'identity needs' : 'identities need'} to be refreshed. Refresh ${regions.length === 1 ? 'it' : 'them'} in Profile to restore ${impact === 'sessions' ? 'access to affected sessions' : 'usage from affected sessions'}.`
-    : impact === 'sessions'
-      ? 'Some external access checks are unavailable. Affected sessions are hidden until access can be verified.'
-      : 'Some external access checks are unavailable. Usage is temporarily under-counted rather than exposing inaccessible sessions.'
+  const quotaRegions = feishuRegions(issues, 'quota')
+  const authorizationRegions = feishuRegions(issues, 'authorization')
+  const quotaNames = quotaRegions.map((region) => (region === 'feishu' ? 'Feishu' : 'Lark')).join(' and ')
+  const authorizationNames = authorizationRegions
+    .map((region) => (region === 'feishu' ? 'Feishu' : 'Lark'))
+    .join(' and ')
+  const message = quotaNames
+    ? `${quotaNames} API quota is exhausted. ${impact === 'sessions' ? 'Affected sessions are hidden' : 'Usage from affected sessions is temporarily under-counted'} until an administrator increases the allowance or the monthly quota resets.`
+    : authorizationNames
+      ? `Your ${authorizationNames} sign-in ${authorizationRegions.length === 1 ? 'identity needs' : 'identities need'} to be refreshed. Refresh ${authorizationRegions.length === 1 ? 'it' : 'them'} in Profile to restore ${impact === 'sessions' ? 'access to affected sessions' : 'usage from affected sessions'}.`
+      : impact === 'sessions'
+        ? 'Some external access checks are unavailable. Affected sessions are hidden until access can be verified.'
+        : 'Some external access checks are unavailable. Usage is temporarily under-counted rather than exposing inaccessible sessions.'
   const href =
-    regions.length === 1
-      ? orgPath(`/profile?reauthorize=${regions[0]}#sign-in-methods`)
+    authorizationRegions.length === 1
+      ? orgPath(`/profile?reauthorize=${authorizationRegions[0]}#sign-in-methods`)
       : orgPath('/profile#sign-in-methods')
 
   return (
@@ -44,9 +59,14 @@ export default function SessionAccessNotice({
       role="status"
     >
       <span className="min-w-0 flex-1">{message}</span>
-      {names ? (
+      {quotaRegions.map((region) => (
+        <a key={region} className="lnk flex-none" href={FEISHU_ADMIN_URL[region]} rel="noreferrer" target="_blank">
+          Open {region === 'feishu' ? 'Feishu' : 'Lark'} Admin
+        </a>
+      ))}
+      {authorizationNames && quotaRegions.length === 0 ? (
         <Link className="lnk flex-none" href={href}>
-          {regions.length === 1 ? `Refresh ${names}` : 'Open Profile'}
+          {authorizationRegions.length === 1 ? `Refresh ${authorizationNames}` : 'Open Profile'}
         </Link>
       ) : null}
     </div>

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1054,13 +1054,7 @@ export default function SessionDetailView() {
     isLoading: conversationLoading
   } = useSWR(
     conversationKey && activeOrg?.id ? (['conversation-by-key', activeOrg.id, conversationKey] as const) : null,
-    ([, orgId, key]) => fetchConversationByKey(key, orgId),
-    {
-      // A just-created conversation can beat the CP's event/session sync —
-      // poll fast until members resolve, then settle to the normal cadence.
-      refreshInterval: (latest) => (latest ? 30_000 : 5_000),
-      revalidateOnFocus: false
-    }
+    ([, orgId, key]) => fetchConversationByKey(key, orgId)
   )
   const conversationMembers = conversationKey ? (conversationRoster?.sessions ?? null) : null
   const id = conversationKey ? (conversationMembers?.[0]?.sessionId ?? '') : (routeId ?? '')
@@ -1308,10 +1302,8 @@ export default function SessionDetailView() {
     error: sessionDetailError,
     isLoading: sessionDetailLoading,
     mutate: mutateSessionDetail
-  } = useSWR<SessionDetailDto>(
-    consoleKeys.sessionDetail(activeOrg?.id, detailId),
-    ([, orgId, , sessionId]) => fetchSessionDetail(sessionId as string, orgId as string),
-    { refreshInterval: 30_000 }
+  } = useSWR<SessionDetailDto>(consoleKeys.sessionDetail(activeOrg?.id, detailId), ([, orgId, , sessionId]) =>
+    fetchSessionDetail(sessionId as string, orgId as string)
   )
   // Provider-rendered links use `source`; links opened from the Sessions list
   // can also retain its `integration` filter. Both are caller-known hints only:
@@ -1512,8 +1504,7 @@ export default function SessionDetailView() {
       : null
   const { data: extraHeaderDetail, mutate: mutateExtraHeaderDetail } = useSWR<SessionDetailDto>(
     consoleKeys.sessionDetail(activeOrg?.id, extraHeaderDetailId),
-    ([, orgId, , sessionId]) => fetchSessionDetail(sessionId as string, orgId as string),
-    { refreshInterval: 30_000 }
+    ([, orgId, , sessionId]) => fetchSessionDetail(sessionId as string, orgId as string)
   )
   const focusedSessionDetail =
     headerFocusSessionId === currentSessionDetail?.id
@@ -1926,8 +1917,8 @@ export default function SessionDetailView() {
       if (tailSessionRef.current === sid && !sessionBusyRef.current) reconcileLiveSteps(sid, persisted, aid)
     })()
       .catch(() => {
-        // Keep the last good transcript. The next SSE signal, reconnect, or
-        // safety poll retries without replacing visible history with an error.
+        // Keep the last good transcript. The next SSE signal or reconnect
+        // retries without replacing visible history with an error.
       })
       .finally(() => {
         if (tailInFlightRef.current !== run) return
@@ -1981,12 +1972,6 @@ export default function SessionDetailView() {
     if (!visibleTailReady || sessionBusy) return
     void refreshTranscriptTail()
   }, [visibleTailReady, sessionBusy, sessionActivityVersion, sessionStreamGeneration, refreshTranscriptTail])
-
-  useEffect(() => {
-    if (!visibleTailReady) return
-    const timer = window.setInterval(() => void refreshTranscriptTail(), 15_000)
-    return () => window.clearInterval(timer)
-  }, [visibleTailReady, refreshTranscriptTail])
 
   // Everything above only APPENDS rows; nothing ever moved the viewport, so a
   // live session's newest output landed below the fold. Follow it — but only for

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -28,7 +28,6 @@ const MOBILE_RANGES: { key: UsageRange; label: string }[] = [
 ]
 
 const GRID = 'grid-cols-[2fr_1fr_1fr_1fr_1.4fr]'
-const USAGE_REFRESH_MS = 30_000
 
 // How the usage table is broken down. Runtime is derived from the per-agent
 // aggregate; model comes from the server's per-session execution snapshots so
@@ -68,10 +67,8 @@ export default function UsageView() {
   const { agents } = useConsoleData()
   const waitingForOrg = orgLoading || (!activeOrg && orgs.length > 0)
   const usageKey = consoleKeys.usage(waitingForOrg ? null : activeOrg?.id, range)
-  const { data, error, isLoading } = useSWR(
-    usageKey,
-    ([, orgId, , requestedRange]) => fetchUsage(requestedRange, orgId),
-    { refreshInterval: USAGE_REFRESH_MS }
+  const { data, error, isLoading } = useSWR(usageKey, ([, orgId, , requestedRange]) =>
+    fetchUsage(requestedRange, orgId)
   )
   const loading = waitingForOrg || isLoading
   const err = orgError ?? (error ? (error instanceof Error ? error.message : String(error)) : null)

--- a/packages/web/src/lib/api-sse.test.ts
+++ b/packages/web/src/lib/api-sse.test.ts
@@ -99,9 +99,46 @@ describe('subscribeSessionEvents', () => {
     expect(requestSignals[0]?.aborted).toBe(true)
     expect((fetchMock.mock.calls[0]![1]!.headers as Record<string, string>).authorization).toBe('Bearer oidc-token-1')
     expect((fetchMock.mock.calls[1]![1]!.headers as Record<string, string>).authorization).toBe('Bearer oidc-token-2')
-    expect(onConnect).toHaveBeenCalledTimes(2)
+    expect(onConnect).toHaveBeenCalledTimes(1)
     expect(onError).not.toHaveBeenCalled()
 
     unsubscribe()
+  })
+
+  it('invalidates after a token-rotation reopen fails and creates a gap', async () => {
+    vi.useFakeTimers()
+    const requestSignals: AbortSignal[] = []
+    let attempt = 0
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      attempt++
+      if (attempt === 2) throw new Error('reopen failed')
+      const signal = init?.signal as AbortSignal
+      requestSignals.push(signal)
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          signal.addEventListener('abort', () => controller.error(new DOMException('aborted', 'AbortError')), {
+            once: true
+          })
+        }
+      })
+      return new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const onConnect = vi.fn()
+    const onError = vi.fn()
+
+    const unsubscribe = subscribeSessionEvents('org-1', { onConnect, onSession: vi.fn(), onActivity: vi.fn() }, onError)
+    await vi.waitFor(() => expect(onConnect).toHaveBeenCalledTimes(1))
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000)
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(onError).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(onConnect).toHaveBeenCalledTimes(2)
+
+    unsubscribe()
+    expect(requestSignals.at(-1)?.aborted).toBe(true)
   })
 })

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1269,7 +1269,8 @@ function waitBeforeReconnect(ms: number, signal: AbortSignal): Promise<void> {
 async function readSessionEventStream(
   orgId: string,
   signal: AbortSignal,
-  handlers: SessionEventHandlers
+  handlers: SessionEventHandlers,
+  recoverGap: boolean
 ): Promise<'ended' | 'reauth'> {
   const request = new AbortController()
   let reauth = false
@@ -1290,10 +1291,9 @@ async function readSessionEventStream(
     if (!res.ok) throw new ApiError(`GET ${path} → ${res.status} ${res.statusText}`, res.status)
     if (!res.body) throw new Error('session event stream is not readable')
 
-    // The sink has no replay/event ids, so every successful (re)connect invalidates
-    // the list once. This closes both a disconnect gap and the initial GET→subscribe
-    // race without requiring a polling cache layer.
-    handlers.onConnect()
+    // The sink has no replay/event ids, so an initial or recovered connection
+    // invalidates cached reads once. Planned token rotation is not a gap recovery.
+    if (recoverGap) handlers.onConnect()
 
     const reader = res.body.getReader()
     const decoder = new TextDecoder()
@@ -1314,7 +1314,7 @@ async function readSessionEventStream(
         )
           handlers.onActivity(activity)
       } catch {
-        // A malformed optional invalidation is ignored; reconnect/fallback polling heals it.
+        // A malformed optional invalidation is ignored; reconnect/focus refresh heals it.
       }
     })
 
@@ -1350,17 +1350,22 @@ export function subscribeSessionEvents(
 ): () => void {
   const ctrl = new AbortController()
   let retryMs = 1000
+  let recoverGap = true
 
   void (async () => {
     while (!ctrl.signal.aborted) {
       try {
-        const ended = await readSessionEventStream(orgId, ctrl.signal, handlers)
+        const ended = await readSessionEventStream(orgId, ctrl.signal, handlers, recoverGap)
         retryMs = 1000
-        if (ended === 'reauth') continue
+        if (ended === 'reauth') {
+          recoverGap = false
+          continue
+        }
       } catch (error) {
         if (ctrl.signal.aborted) return
         onError?.(error)
       }
+      recoverGap = true
       if (ctrl.signal.aborted) return
       await waitBeforeReconnect(retryMs, ctrl.signal)
       retryMs = Math.min(retryMs * 2, 30_000)

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -423,7 +423,7 @@ export interface ConversationDto {
 export interface SessionAccessIssue {
   provider: string
   region?: string
-  reason: 'authorization' | 'unavailable'
+  reason: 'authorization' | 'quota' | 'unavailable'
 }
 
 export interface SessionListPageDto {

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -109,7 +109,6 @@ import {
   type MintedKeyDto,
   type SessionFacets
 } from '@/lib/api'
-import { SESSION_FACET_REFRESH_MS } from '@/lib/use-session-facets'
 
 interface ConsoleData {
   agents: Agent[]
@@ -125,8 +124,8 @@ interface ConsoleData {
   sessionActivityVersionById: Record<string, number>
   /** Advances on every SSE (re)connect so views close any disconnect gap. */
   sessionStreamGeneration: number
-  /** Re-fetch every session list/facet page — used after a mutation that can
-   *  change which sessions a caller may see (e.g. a visibility change). */
+  /** Re-fetch cached Session reads — used after a mutation that can change
+   *  which sessions a caller may see (e.g. a visibility change). */
   revalidateSessionLists: () => Promise<unknown>
   crons: CronDto[]
   integrations: IntegrationRow[]
@@ -235,8 +234,8 @@ interface ConsoleData {
   /** Command a daemon to install `version` + relaunch onto it; returns the opened op. */
   upgradeDaemon: (daemonId: string, version: string) => Promise<DaemonLifecycleOpDto>
   refresh: () => void
-  /** Revalidate ONLY the session lists — for after an action known to mint a session
-   *  (e.g. a Playground send), without re-pulling every console read model. */
+  /** Revalidate only Session-derived reads — for after an action known to mint
+   *  a session, without re-pulling every console read model. */
   refreshSessions: () => void
   /** Revalidate ONLY the daemon fleet and resolve once the fresh list is committed —
    *  for flows that must observe the post-refresh fleet before acting (e.g. the
@@ -259,7 +258,6 @@ const Ctx = createContext<ConsoleData | null>(null)
 const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 500
 const DAEMON_REFRESH_MS = 15_000
 const RESOURCE_REFRESH_MS = 30_000
-const USAGE_REFRESH_MS = 30_000
 const EMPTY_SESSION_FACETS: SessionFacets = { agentIds: [], integrations: [], channels: [], triggers: [] }
 function settleInBackground(...tasks: Promise<unknown>[]): void {
   void Promise.allSettled(tasks)
@@ -794,10 +792,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     data: usage24hData,
     isLoading: usage24hIsLoading,
     mutate: mutateUsage24h
-  } = useSWR<UsageDto>(
-    consoleKeys.usage(orgKey, 'd1'),
-    ([, orgId, , range]) => fetchUsage(range as UsageRange, orgId as string),
-    { refreshInterval: USAGE_REFRESH_MS }
+  } = useSWR<UsageDto>(consoleKeys.usage(orgKey, 'd1'), ([, orgId, , range]) =>
+    fetchUsage(range as UsageRange, orgId as string)
   )
 
   const {
@@ -813,10 +809,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     data: sessionFacets = EMPTY_SESSION_FACETS,
     error: sessionFacetsError,
     isLoading: sessionFacetsIsLoading
-  } = useSWR<SessionFacets>(
-    consoleKeys.sessionFacets(orgKey, '', '', '', '', '', ''),
-    ([, orgId]) => fetchSessionFacets(orgId as string),
-    { refreshInterval: SESSION_FACET_REFRESH_MS }
+  } = useSWR<SessionFacets>(consoleKeys.sessionFacets(orgKey, '', '', '', '', '', ''), ([, orgId]) =>
+    fetchSessionFacets(orgId as string)
   )
 
   const revalidateSessionLists = useCallback(() => {
@@ -824,9 +818,10 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     return mutateCache(
       (key) =>
         Array.isArray(key) &&
-        key[0] === 'console' &&
-        key[1] === orgKey &&
-        (key[2] === 'sessions' || key[2] === 'session-facets')
+        ((key[0] === 'console' &&
+          key[1] === orgKey &&
+          (key[2] === 'sessions' || key[2] === 'session-facets' || key[2] === 'session-detail')) ||
+          (key[0] === 'conversation-by-key' && key[1] === orgKey))
     )
   }, [mutateCache, orgKey])
 

--- a/packages/web/src/lib/use-session-facets.ts
+++ b/packages/web/src/lib/use-session-facets.ts
@@ -4,7 +4,6 @@ import { consoleKeys } from './swr-keys'
 import { sessionFilterAgentKey } from './use-session-list'
 
 type SessionFacetKey = NonNullable<ReturnType<typeof consoleKeys.sessionFacets>>
-export const SESSION_FACET_REFRESH_MS = 60_000
 
 export function useSessionFacets(
   orgId: string | null | undefined,
@@ -32,6 +31,6 @@ export function useSessionFacets(
         ...(keyGithubRepoId ? { githubRepoId: keyGithubRepoId } : {})
       })
     },
-    { fallbackData, refreshInterval: SESSION_FACET_REFRESH_MS }
+    { fallbackData }
   )
 }

--- a/packages/web/src/lib/use-session-list.ts
+++ b/packages/web/src/lib/use-session-list.ts
@@ -6,7 +6,6 @@ import { fetchConversations, fetchSessions, type SessionListFilters, type Sessio
 import { consoleKeys } from '@/lib/swr-keys'
 
 const SESSION_PAGE_LIMIT = 50
-const SESSION_FALLBACK_REFRESH_MS = 60_000
 type SessionPageKey = NonNullable<ReturnType<typeof consoleKeys.sessions>>
 
 /** The agent filter as one scalar SWR key part. Sorted so the same set of agents
@@ -97,9 +96,9 @@ export function useSessionList(
       // so a session moving to the top cannot leave stale cursor boundaries.
       revalidateAll: true,
       persistSize: false,
-      parallel: false,
-      // SSE is the immediate path; this safety net covers buffering proxies.
-      refreshInterval: SESSION_FALLBACK_REFRESH_MS
+      // SSE is the immediate path. Focus, reconnect and explicit refresh retain
+      // the fallback without polling live provider authorization every minute.
+      parallel: false
     }
   )
 


### PR DESCRIPTION
## Summary

- stop the Console from periodically polling access-resolving Session lists, facets, usage, metadata, and transcript tails; planned SSE token rotation no longer invokes gap recovery, while actual reconnects still do
- cache one Feishu/Lark member snapshot per Bot App and chat, shared across viewers, and coalesce concurrent reads
- recognize Lark quota exhaustion, back off further checks for one hour, and show an actionable Lark/Feishu Admin link instead of the generic unavailable warning

## Root cause

Lark server logs showed the Login App repeatedly calling `members/is_in_chat` for the same three chats roughly every 30 seconds, with occasional duplicate bursts. Those authorization reads—not normal bot messages—consumed the tenant-wide monthly API allowance.

The Console also had periodic Usage, facet, detail, conversation-roster, and transcript-tail reads that reached the same access resolver. Its planned five-minute SSE token rotation additionally triggered the same recovery invalidation as an actual disconnect. This PR removes that time-based amplification without lengthening the two-minute membership snapshot window; SSE events, real reconnects, focus, and explicit refresh remain the freshness paths.

## Validation

- `pnpm --filter @agentconnect.md/control-plane test:unit` (130 files, 1240 tests)
- focused Control Plane and Web Vitest suites
- full Web Vitest suite (111 files, 874 tests)
- focused SSE token-rotation and failed-reconnect regression tests
- Control Plane and Web typechecks
- ESLint on changed files and the pre-push full lint hook

Created by Codex . GPT-5
