### PR TITLE
feat(web): support password-only sign-in deployments

### DIFF
--- a/compose.env.example
+++ b/compose.env.example
@@ -54,6 +54,14 @@
 # lands on Logto's error page. When both lark and feishu are listed, put the
 # preferred default first.
 # SOCIAL_PROVIDERS=github
+# Local username/password sign-in (Logto's built-in account system, stored in
+# your Logto database). PASSWORD_LOGIN=true renders a "Continue with password"
+# entry that opens Logto's hosted sign-in page — enable the password method in
+# the tenant's Sign-in experience. Pair with SOCIAL_PROVIDERS=none to run
+# without any social connector, and disable Logto self-signup for closed
+# internal deployments (admins create accounts in User management).
+# PASSWORD_LOGIN=true
+# SOCIAL_PROVIDERS=none
 # OIDC_ISSUER=https://tenant.example.com/oidc
 # OIDC_AUDIENCE=https://api.example.com
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -165,9 +165,13 @@ services:
       - LOGTO_APP_ID
       - LOGTO_API_RESOURCE
       # Which social sign-in methods to offer (comma-separated Logto connector
-      # targets; unset => all of them). The console owns this decision; the
-      # control plane gates on whether the tenant has that connector.
+      # targets; unset => all of them; `none` => no social login). The console
+      # owns this decision; the control plane gates on whether the tenant has
+      # that connector.
       - SOCIAL_PROVIDERS
+      # Opt-in local username/password sign-in entry (Logto's built-in account
+      # system; the tenant's sign-in experience must enable the password method).
+      - PASSWORD_LOGIN
     healthcheck:
       test:
         - CMD

--- a/packages/web/src/components/Auth.tsx
+++ b/packages/web/src/components/Auth.tsx
@@ -3,8 +3,9 @@
 import { useRouter } from 'next/navigation'
 import { LogoMark, Wordmark } from '@/components/marks'
 import SocialLoginButtons from '@/components/SocialLoginButtons'
-import { isAuthConfigured, login } from '@/lib/auth'
-import { socialLoginProviders, type SocialLoginTarget } from '@/lib/social-login-providers'
+import { Icon } from '@/components/ui'
+import { isAuthConfigured, login, passwordLoginEnabled } from '@/lib/auth'
+import { selectEnabledProviders, socialLoginProviders, type SocialLoginTarget } from '@/lib/social-login-providers'
 
 function BrandPanel() {
   return (
@@ -38,7 +39,16 @@ export default function Auth() {
   // With an OIDC issuer configured, the SSO buttons start a real redirect; with
   // auth disabled (the OSS default) they just enter the app.
   const authOn = isAuthConfigured()
+  const passwordOn = passwordLoginEnabled()
+  // `SOCIAL_PROVIDERS=none` is only valid alongside the password entry — with
+  // PASSWORD_LOGIN unset it would render a sign-in page with no way in at all,
+  // so that misconfiguration falls back to the default social set (same
+  // never-dead-end stance as the typo fallback in selectEnabledProviders).
+  const configured = socialLoginProviders()
+  const providers = configured.length === 0 && !passwordOn ? selectEnabledProviders(undefined) : configured
   const sso = (provider: SocialLoginTarget) => (authOn ? void login(provider) : router.push('/'))
+  // Plain hosted-experience sign-in — Logto shows its local account form there.
+  const passwordSignIn = () => (authOn ? void login() : router.push('/'))
 
   return (
     <div className="authpage">
@@ -49,10 +59,22 @@ export default function Auth() {
             <h1 className="atitle">Sign in</h1>
             <p className="asub">Welcome back. Continue to your workspace.</p>
             <div className="mt-[26px] flex flex-col gap-[10px]">
-              <SocialLoginButtons providers={socialLoginProviders()} onContinue={sso} />
+              <SocialLoginButtons providers={providers} onContinue={sso} />
+              {passwordOn && (
+                <button type="button" className="sso" onClick={passwordSignIn}>
+                  <span className="grid w-[220px] grid-cols-[18px_minmax(0,1fr)] items-center gap-2.5 text-left">
+                    <span className="flex h-[18px] w-[18px] items-center justify-center">
+                      <Icon name="lock" size={18} />
+                    </span>
+                    <span className="whitespace-nowrap">Continue with password</span>
+                  </span>
+                </button>
+              )}
             </div>
             <p className="mt-5 text-center font-sans text-[12.5px] font-normal leading-[1.6] text-(--text-tertiary)">
-              Single sign-on only. AgentConnect never stores a password.
+              {passwordOn
+                ? 'Accounts live in your identity provider — AgentConnect never sees your password.'
+                : 'Single sign-on only. AgentConnect never stores a password.'}
               <br />
               First time here? Signing in creates your account.
             </p>

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -374,6 +374,10 @@ export default function SocialSignInCard({
     setPendingUnlink(undefined)
   }
 
+  // A deployment with no social login at all (`SOCIAL_PROVIDERS=none`) has
+  // nothing to link — drop the card instead of rendering an empty shell.
+  if (socialLoginProviders().length === 0) return null
+
   const shell = mobile
     ? 'overflow-hidden rounded-lg border border-(--border-subtle) bg-(--surface-card) shadow-(--shadow-xs)'
     : 'card mt-[22px]'

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -57,6 +57,17 @@ export function isAuthConfigured(): boolean {
   return Boolean(endpoint && appId)
 }
 
+/** True when this deployment offers Logto's local username/password sign-in
+ *  (`PASSWORD_LOGIN=true|1`). Renders a password entry that starts the plain
+ *  hosted-experience flow — the tenant must have the password method enabled.
+ *  Pairs with `SOCIAL_PROVIDERS=none` for deployments without any social
+ *  connector. */
+export function passwordLoginEnabled(): boolean {
+  const src = typeof window === 'undefined' ? process.env : (window.__AC_ENV ?? {})
+  const raw = (src.PASSWORD_LOGIN || process.env.NEXT_PUBLIC_PASSWORD_LOGIN || '').trim().toLowerCase()
+  return raw === 'true' || raw === '1'
+}
+
 /** Public tenant values used by the browser-side Logto Account API client. */
 export function getLogtoPublicConfig(): { endpoint: string; appId: string } | undefined {
   const { endpoint, appId } = readConfig()

--- a/packages/web/src/lib/public-env.tsx
+++ b/packages/web/src/lib/public-env.tsx
@@ -17,9 +17,13 @@ const KEYS = [
   'LOGTO_APP_ID',
   'LOGTO_API_RESOURCE',
   // Which social sign-in methods this deployment offers (comma-separated Logto
-  // connector targets; unset/`*` ⇒ all). The console is the only side that reads
-  // it — see lib/social-login-providers.
+  // connector targets; unset/`*` ⇒ all; `none` ⇒ no social login). The console is
+  // the only side that reads it — see lib/social-login-providers.
   'SOCIAL_PROVIDERS',
+  // Opt-in local username/password sign-in entry ('true'/'1'). The Logto
+  // tenant's sign-in experience must have the password method enabled — see
+  // lib/auth passwordLoginEnabled.
+  'PASSWORD_LOGIN',
   'CP_URL',
   'RELAY_URL',
   // Dedicated MCP origin (mirrors the CP's PUBLIC_MCP_URL). Unset ⇒ the console

--- a/packages/web/src/lib/social-login-providers.test.ts
+++ b/packages/web/src/lib/social-login-providers.test.ts
@@ -29,6 +29,12 @@ describe('social login provider selection', () => {
     expect(targets(',,')).toEqual(['github', 'google', 'slack'])
   })
 
+  it('renders no social buttons for an explicit `none` (password-only deployments)', () => {
+    expect(parseEnabledTargets('none')).toEqual(new Set())
+    expect(targets('none')).toEqual([])
+    expect(targets('  none  ')).toEqual([])
+  })
+
   // The invariant this variable exists for: whatever the console offers must be
   // linkable. The CP deliberately does NOT re-derive this set -- it accepts any
   // connector slug and lets the tenant's connector list be the gate -- so no

--- a/packages/web/src/lib/social-login-providers.ts
+++ b/packages/web/src/lib/social-login-providers.ts
@@ -19,9 +19,12 @@
 // Unset keeps the original GitHub / Google / Slack set. New providers are
 // opt-in because adding one to this catalog must not make an upgraded deployment
 // offer a button for a connector its Logto tenant does not have. `*` explicitly
-// opts into the whole catalog. A target whose connector the tenant has not
-// configured lands the user on Logto's error page, so deployments should name
-// exactly the connectors they offer.
+// opts into the whole catalog, and `none` explicitly opts out of social login
+// entirely (password-only deployments pair it with `PASSWORD_LOGIN=true`, which
+// renders the local-account entry instead — see lib/auth `passwordLoginEnabled`).
+// A target whose connector the tenant has not configured lands the user on
+// Logto's error page, so deployments should name exactly the connectors they
+// offer.
 
 /** Every target this console can render. Order is display order. */
 export const SOCIAL_LOGIN_CATALOG = [
@@ -43,11 +46,13 @@ const isRegionalProvider = (
 
 const DEFAULT_SOCIAL_LOGIN_TARGETS = new Set<SocialLoginTarget>(['github', 'google', 'slack'])
 
-/** Parse the configured target list. Unset / blank ⇒ legacy defaults; `*` ⇒ all. */
+/** Parse the configured target list. Unset / blank ⇒ legacy defaults; `*` ⇒ all;
+ * `none` ⇒ explicitly no social login (distinct from a typo, which falls back). */
 export function parseEnabledTargets(raw: string | undefined): Set<string> | null {
   const trimmed = raw?.trim()
   if (!trimmed) return new Set(DEFAULT_SOCIAL_LOGIN_TARGETS)
   if (trimmed === '*') return null
+  if (trimmed === 'none') return new Set()
   const entries = trimmed
     .split(',')
     .map((entry) => entry.trim())
@@ -61,6 +66,8 @@ export function parseEnabledTargets(raw: string | undefined): Set<string> | null
 export function selectEnabledProviders(raw: string | undefined): readonly SocialLoginProvider[] {
   const enabled = parseEnabledTargets(raw)
   if (!enabled) return SOCIAL_LOGIN_CATALOG
+  // Explicit `none` — the deployment offers another way in (password login).
+  if (enabled.size === 0) return []
   const selected = SOCIAL_LOGIN_CATALOG.filter((provider) => enabled.has(provider.target))
   // A value naming only unknown targets would otherwise leave the sign-in page
   // with no way in at all; retain the pre-Lark/Feishu defaults without assuming


### PR DESCRIPTION
### Summary

Lets a deployment choose its sign-in composition entirely by configuration: adds an
opt-in "Continue with password" entry (Logto's built-in local accounts, via the
plain hosted-experience flow) and an explicit `SOCIAL_PROVIDERS=none` sentinel to
run with no social connectors at all. Closed internal deployments can now run on
admin-provisioned username/password accounts with zero external IdP apps.

**Zero behavior change for existing deployments**: with `PASSWORD_LOGIN` unset the
entry does not render, and every pre-existing `SOCIAL_PROVIDERS` value (unset, `*`,
target lists, typo fallback) selects exactly the same providers as before.

### Motivation

The sign-in page was social-only: `lib/auth.login()` already supported the plain
hosted-experience flow (where Logto's password method lives), but no UI entry
called it, so Logto's local accounts were unreachable. Deployments wanting
admin-created accounts (Logto `sign_in_mode = SignIn` + User management) had no
way in without registering an external IdP app.

### Changes

- **`lib/social-login-providers.ts`** — `SOCIAL_PROVIDERS=none` parses to an empty
  set and renders zero social buttons. Deliberately distinct from the typo
  fallback: unknown-only values still fall back to the default trio; only the
  explicit `none` opts out.
- **`lib/auth.ts`** — new `passwordLoginEnabled()` reading runtime-injected
  `PASSWORD_LOGIN` (`true`/`1`), same `window.__AC_ENV` → SSR-env pattern as
  `readConfig()`.
- **`components/Auth.tsx`** — password entry (`<Icon name="lock">`, the repo's
  lucide primitive used by every other generic glyph; same `sso` layout as
  `ProviderContent`) calling the provider-less `login()`; footer copy switches
  accordingly. Never-dead-end guard: `none` with `PASSWORD_LOGIN` unset falls
  back to the default social set instead of rendering a sign-in page with no way
  in (same stance as the typo fallback).
- **`components/console/SocialSignInCard.tsx`** — the Profile sign-in-methods card
  hides itself when the deployment offers no social login (nothing to link).
- **`lib/public-env.tsx`** — `PASSWORD_LOGIN` added to the runtime-injected keys
  (same image serves every mode; flipping needs no rebuild).
- **`compose.yaml` / `compose.env.example`** — env passthrough + operator docs,
  including the recommendation to disable Logto self-signup for closed deployments.
- **`lib/social-login-providers.test.ts`** — dedicated `none` cases (parse to the
  empty set, zero buttons, whitespace-tolerant). The catalog-linkability
  invariant test is untouched — a `none` vector there would be assertion-free
  (empty `every` is vacuous) and the dedicated test is strictly stronger.

### Config matrix

| `SOCIAL_PROVIDERS` | `PASSWORD_LOGIN` | Sign-in page renders |
| --- | --- | --- |
| unset / list / `*` | unset | social buttons only (unchanged) |
| unset / list / `*` | `true` | social buttons + password entry |
| `none` | `true` | password entry only |
| `none` | unset (misconfig) | default social set (never-dead-end guard) |

### Non-goals / audited untouched surfaces

- **CP**: no changes. `me-social-identities` validates shape only and explicitly
  does not re-derive the offered set; `none` never reaches the wire.
- **Waitlist**: untouched. It is gated by `WAITLIST_MODE` (cloud), unreachable in
  the deployments `none` targets; its social-only auth step keeps current behavior.
- Sign-up policy stays a Logto tenant concern (`sign_in_mode`, User management,
  Management API provisioning) — documented in `compose.env.example`.

### Test plan

- Unit: web `src/lib` suite passes (includes new `none` vectors and the updated
  invariant).
- `tsc --noEmit`, ESLint, Prettier clean on all touched files.
- Live E2E on a local compose stack (locally built images) + self-hosted Logto
  1.42 with a `SignIn`-only tenant: password sign-in → JIT user + personal org →
  daemon onboarding → containerized daemon → agent session round-trip.
- Adversarial multi-agent review pass over the final diff (minimality /
  regression / house-style lenses); confirmed findings applied (assertion-free
  test vector removed; lock glyph moved to the repo's `Icon` primitive).

### Known nit (deliberately not fixed here)

The password button repeats `ProviderContent`'s private layout literals
(`w-[220px]` grid) from `SocialLoginButtons.tsx`. Extracting a shared
entry-content component would touch a third file for a cosmetic dedup; kept out
to hold the diff minimal. Happy to do it in this PR if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
