### PR TITLE
feat(web): render usage spend-over-time chart with recharts

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,6 +43,7 @@
     "react-dom": "^19.2.8",
     "react-icons": "^5.7.0",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.10.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "swr": "^2.4.2"

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -42,9 +42,16 @@ const SEG_FILL = [
   '[&_.seg-6_path]:fill-(--chart-other)',
   '[&_.seg-flat_path]:fill-(--brand)',
   // recharts' accessibility layer makes the chart surface focusable, so clicking a
-  // bar leaves a UA focus ring around the whole plot — suppress it.
+  // bar leaves a UA focus ring around the whole plot. Drop the default outline but
+  // keep a themed one for :focus-visible, so keyboard users still see where focus is.
   '[&_.recharts-wrapper]:outline-none',
-  '[&_.recharts-surface]:outline-none'
+  '[&_.recharts-surface]:outline-none',
+  '[&_.recharts-wrapper:focus-visible]:outline-2',
+  '[&_.recharts-wrapper:focus-visible]:outline-offset-2',
+  '[&_.recharts-wrapper:focus-visible]:outline-(--border-focus)',
+  '[&_.recharts-surface:focus-visible]:outline-2',
+  '[&_.recharts-surface:focus-visible]:outline-offset-2',
+  '[&_.recharts-surface:focus-visible]:outline-(--border-focus)'
 ].join(' ')
 
 const GRID = 'grid-cols-[2fr_1fr_1fr_1fr_1.4fr]'
@@ -380,7 +387,11 @@ export default function UsageView() {
           // Legend-driven filter. A hidden key stays in `stackKeys` (its hue never
           // shifts onto another series) — the Bar is just `hide`den, so the stack and
           // the y-scale recompute from the visible series only.
-          const hidden = new Set(hiddenKeys)
+          // Intersected with the current stackKeys — a key hidden under a prior
+          // range/group-by can otherwise survive in `hiddenKeys` after that key
+          // disappears from view, permanently flipping the tooltip into the
+          // filtered-total branch with nothing left for the legend to un-hide.
+          const hidden = new Set(hiddenKeys.filter((k) => stackKeys.includes(k)))
           const toggleKey = (k: string) =>
             setHiddenKeys((prev) => (prev.includes(k) ? prev.filter((x) => x !== k) : [...prev, k]))
           const visibleKeys = stackKeys.filter((k) => !hidden.has(k))
@@ -470,8 +481,11 @@ export default function UsageView() {
                     <Tooltip content={<Tip />} cursor={{ fill: 'var(--surface-hover)' }} />
                     {/* Legend shows even for a single key — the card title doesn't name
                         the series. Click a key to filter it out of the stack. */}
+                    {/* No fixed `height` — recharts measures the rendered legend box
+                        (which wraps to 2+ rows for 7 keys at mobile widths) and
+                        reduces the plot by that real height instead of a guess. */}
                     {hasBreakdown && stackKeys.length > 0 && (
-                      <Legend verticalAlign="top" align="left" height={32} content={<LegendKeys />} />
+                      <Legend verticalAlign="top" align="left" content={<LegendKeys />} />
                     )}
                     {stackKeys.map((k, i) => (
                       <Bar

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import useSWR from 'swr'
+import { Bar, BarChart, Legend, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { fetchUsage, fmtCost, fmtCountCompact as fmtCompact, type UsageRange } from '@/lib/api'
 import { agentLabel, modelLabel, runtimeLabel } from '@/lib/data'
@@ -26,6 +27,25 @@ const MOBILE_RANGES: { key: UsageRange; label: string }[] = [
   { key: 'd7', label: '7 days' },
   { key: 'd30', label: '30 days' }
 ]
+
+// SVG `fill` can't take a `var()` presentation attribute, so the stacked-bar hues
+// are applied as descendant CSS rules on the chart wrapper (a real declaration
+// out-ranks recharts' own `fill` attribute) — that keeps the bars theme-reactive
+// with no JS reading computed styles. Literal strings so Tailwind can see them.
+const SEG_FILL = [
+  '[&_.seg-0_path]:fill-(--chart-1)',
+  '[&_.seg-1_path]:fill-(--chart-2)',
+  '[&_.seg-2_path]:fill-(--chart-3)',
+  '[&_.seg-3_path]:fill-(--chart-4)',
+  '[&_.seg-4_path]:fill-(--chart-5)',
+  '[&_.seg-5_path]:fill-(--chart-6)',
+  '[&_.seg-6_path]:fill-(--chart-other)',
+  '[&_.seg-flat_path]:fill-(--brand)',
+  // recharts' accessibility layer makes the chart surface focusable, so clicking a
+  // bar leaves a UA focus ring around the whole plot — suppress it.
+  '[&_.recharts-wrapper]:outline-none',
+  '[&_.recharts-surface]:outline-none'
+].join(' ')
 
 const GRID = 'grid-cols-[2fr_1fr_1fr_1fr_1.4fr]'
 const USAGE_REFRESH_MS = 30_000
@@ -64,6 +84,13 @@ export default function UsageView() {
   const range: UsageRange = isMobile && parsed === 'd90' ? 'd30' : parsed
 
   const [groupBy, setGroupBy] = useState<GroupBy>('agent')
+  // Chart-legend series filter. Keys are group-specific (agent ids vs model names),
+  // so switching the rollup clears it rather than stranding a hidden key.
+  const [hiddenKeys, setHiddenKeys] = useState<string[]>([])
+  const selectGroup = (k: GroupBy) => {
+    setGroupBy(k)
+    setHiddenKeys([])
+  }
 
   const { agents } = useConsoleData()
   const waitingForOrg = orgLoading || (!activeOrg && orgs.length > 0)
@@ -255,9 +282,8 @@ export default function UsageView() {
         </div>
       </div>
 
-      {/* Spend over time. Pure-CSS bar chart (flex columns), matching the design —
-          no chart library needed. Bars are max-normalized; empty buckets render as
-          the 4px baseline. Hidden by graceful fallback if the CP predates `series`. */}
+      {/* Spend over time — recharts stacked bars. Hidden by graceful fallback if the
+          CP predates `series`. */}
 
       {/* First-load skeleton: same card + 180px body footprint as the real chart so
           the swap to data causes no layout shift. Deterministic bar heights (no
@@ -269,7 +295,7 @@ export default function UsageView() {
             <span className="ml-auto h-[11px] w-12 rounded-full bg-(--surface-active)" />
           </div>
           <div
-            className="flex h-[180px] animate-pulse items-end px-[18px] pb-[14px] pt-5"
+            className="flex h-[212px] animate-pulse items-end px-[18px] pb-[22px] pt-9"
             style={{ gap: skelBars > 40 ? 2 : skelBars > 14 ? 4 : 10 }}
           >
             {Array.from({ length: skelBars }, (_, i) => (
@@ -288,7 +314,6 @@ export default function UsageView() {
         (() => {
           const pts = data.series.points
           const labelEvery = Math.max(1, Math.ceil(pts.length / 8))
-          const gap = pts.length > 40 ? 2 : pts.length > 14 ? 4 : 10
           const unit = (currency ?? 'USD').toUpperCase()
           // Full IANA zone name (e.g. "Asia/Shanghai") — the buckets are aligned to
           // this zone, so tell the viewer. Client-only: the chart never renders on
@@ -334,22 +359,91 @@ export default function UsageView() {
               : k === OTHER
                 ? 'var(--chart-other)'
                 : `var(--chart-${topKeys.indexOf(k) + 1})`
-          // Per-bucket stack, bottom-up in stackKeys order. Negative deltas
-          // (downward corrections) can't render as height — clamp to 0; the
-          // bucket's tooltip total still reports the true net figure.
-          const stacks = recs.map((rec) => {
-            const segs = stackKeys
-              .map((k) => ({
-                k,
-                v:
-                  k === OTHER
-                    ? Object.entries(rec).reduce((s, [kk, vv]) => (topKeys.includes(kk) ? s : s + Math.max(0, vv)), 0)
-                    : Math.max(0, rec[k] ?? 0)
-              }))
-              .filter((s) => s.v > 0)
-            return { segs, total: segs.reduce((s, x) => s + x.v, 0) }
+          // One recharts row per bucket. Series are `s<i>` (index into stackKeys) so a
+          // model/agent id can never collide with `label`/`__total`. Negative deltas
+          // (downward corrections) can't render as height — clamp to 0; `__total` in
+          // the tooltip still reports the true net figure.
+          const chartData = recs.map((rec, i) => {
+            const row: Record<string, number | string> = {
+              label: bucketLabel(pts[i]!.start, data.series!.bucket),
+              __total: pts[i]!.costAmount
+            }
+            stackKeys.forEach((k, si) => {
+              row[`s${si}`] =
+                k === OTHER
+                  ? Object.entries(rec).reduce((s, [kk, vv]) => (topKeys.includes(kk) ? s : s + Math.max(0, vv)), 0)
+                  : Math.max(0, rec[k] ?? 0)
+            })
+            return row
           })
-          const maxSpend = Math.max(...stacks.map((s) => s.total), 0)
+
+          // Legend-driven filter. A hidden key stays in `stackKeys` (its hue never
+          // shifts onto another series) — the Bar is just `hide`den, so the stack and
+          // the y-scale recompute from the visible series only.
+          const hidden = new Set(hiddenKeys)
+          const toggleKey = (k: string) =>
+            setHiddenKeys((prev) => (prev.includes(k) ? prev.filter((x) => x !== k) : [...prev, k]))
+          const visibleKeys = stackKeys.filter((k) => !hidden.has(k))
+
+          // Legend content is our own markup (recharts' default swatches can't take a
+          // `var()` color) rendered inside recharts' <Legend> slot, so the plot area
+          // reserves room for it instead of the card doing its own layout.
+          const LegendKeys = () => (
+            <div className="flex flex-wrap gap-x-3 gap-y-1 px-[8px]">
+              {stackKeys.map((k) => {
+                const off = hidden.has(k)
+                return (
+                  <button
+                    key={k}
+                    type="button"
+                    onClick={() => toggleKey(k)}
+                    aria-pressed={!off}
+                    title={off ? `Show ${keyName(k)}` : `Hide ${keyName(k)}`}
+                    className={`flex cursor-pointer items-center gap-[5px] border-0 bg-transparent p-0 font-sans text-[11px] leading-normal ${
+                      off ? 'text-(--text-disabled)' : 'text-(--text-secondary)'
+                    }`}
+                  >
+                    <span
+                      className="h-[9px] w-[9px] flex-none rounded-[3px]"
+                      style={{ backgroundColor: off ? 'var(--surface-active)' : keyColor(k) }}
+                    />
+                    {keyName(k)}
+                  </button>
+                )
+              })}
+            </div>
+          )
+
+          type TipSeg = { dataKey: string; name: string; value: number; payload: Record<string, number> }
+          const Tip = ({ active, payload, label }: { active?: boolean; payload?: TipSeg[]; label?: string }) => {
+            if (!active || !payload?.length) return null
+            const segs = [...payload].reverse().filter((s) => s.value > 0)
+            // Unfiltered, report the bucket's true net cost (`__total` keeps negative
+            // corrections the clamped segments drop); filtered, report what's shown.
+            const total = hidden.size
+              ? payload.reduce((s, x) => s + (x.value || 0), 0)
+              : (payload[0]!.payload.__total ?? 0)
+            return (
+              <div className="rounded-md border border-(--border-subtle) bg-(--surface-card) px-2.5 py-2 shadow-(--shadow-md)">
+                <div className="mono text-[11px] font-semibold text-(--text-primary)">
+                  {label} · {fmtCost(total, currency)}
+                </div>
+                {hasBreakdown &&
+                  segs.map((s) => (
+                    <div
+                      key={s.dataKey}
+                      className="mt-1 flex items-center gap-[6px] font-sans text-[11px] leading-normal text-(--text-secondary)"
+                    >
+                      <span
+                        className="h-[8px] w-[8px] flex-none rounded-[2px]"
+                        style={{ backgroundColor: keyColor(stackKeys[Number(s.dataKey.slice(1))]!) }}
+                      />
+                      {s.name}: <span className="mono text-(--text-primary)">{fmtCost(s.value, currency)}</span>
+                    </div>
+                  ))}
+              </div>
+            )
+          }
           return (
             <div className="card mb-[18px] max-desktop:mx-4 max-desktop:mb-3 max-desktop:rounded-lg">
               <div className="cardhead">
@@ -359,78 +453,41 @@ export default function UsageView() {
                   {unit} / {data.series.bucket}
                 </span>
               </div>
-              {/* Legend shows even for a single key — the card title doesn't name
-                  the series, and touch users can't reach the hover tooltip. */}
-              {hasBreakdown && stackKeys.length > 0 && (
-                <div className="flex flex-wrap gap-x-3 gap-y-1 px-[18px] pt-3">
-                  {stackKeys.map((k) => (
-                    <span
-                      key={k}
-                      className="flex items-center gap-[5px] font-sans text-[11px] leading-normal text-(--text-secondary)"
-                    >
-                      <span
-                        className="h-[9px] w-[9px] flex-none rounded-[3px]"
-                        style={{ backgroundColor: keyColor(k) }}
+              {/* stackKeys order is bottom-up (largest series on the baseline), which is
+                  also recharts' render order, so `seg-<i>` lines up with SEG_FILL. */}
+              <div className={`h-[212px] px-[10px] pb-[6px] pt-3 text-(--text-tertiary) ${SEG_FILL}`}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={chartData} margin={{ top: 0, right: 8, bottom: 0, left: 8 }} barCategoryGap="18%">
+                    <XAxis
+                      dataKey="label"
+                      interval={labelEvery - 1}
+                      tickLine={false}
+                      axisLine={false}
+                      tickMargin={6}
+                      tick={{ fill: 'currentColor', fontSize: 10.5 }}
+                      className="mono"
+                    />
+                    <Tooltip content={<Tip />} cursor={{ fill: 'var(--surface-hover)' }} />
+                    {/* Legend shows even for a single key — the card title doesn't name
+                        the series. Click a key to filter it out of the stack. */}
+                    {hasBreakdown && stackKeys.length > 0 && (
+                      <Legend verticalAlign="top" align="left" height={32} content={<LegendKeys />} />
+                    )}
+                    {stackKeys.map((k, i) => (
+                      <Bar
+                        key={k}
+                        dataKey={`s${i}`}
+                        name={keyName(k)}
+                        stackId="spend"
+                        className={hasBreakdown ? `seg-${i}` : 'seg-flat'}
+                        maxBarSize={46}
+                        hide={hidden.has(k)}
+                        // Round only the top of the visible stack.
+                        radius={k === visibleKeys[visibleKeys.length - 1] ? [5, 5, 0, 0] : undefined}
                       />
-                      {keyName(k)}
-                    </span>
-                  ))}
-                </div>
-              )}
-              <div className="flex h-[180px] items-end px-[18px] pb-[14px] pt-5" style={{ gap }}>
-                {pts.map((p, i) => {
-                  const label = bucketLabel(p.start, data.series.bucket)
-                  const { segs, total } = stacks[i]!
-                  const tip = hasBreakdown
-                    ? [
-                        `${label} · ${fmtCost(p.costAmount, currency)}`,
-                        ...[...segs].reverse().map((s) => `${keyName(s.k)}: ${fmtCost(s.v, currency)}`)
-                      ].join('\n')
-                    : `${label} · ${fmtCost(p.costAmount, currency)}`
-                  return (
-                    <div
-                      key={p.start}
-                      className="flex h-full min-w-0 flex-1 flex-col items-center justify-end gap-2"
-                      title={tip}
-                    >
-                      {/* Stack renders DOM top→bottom = reverse of stackKeys, so the
-                          largest key sits on the baseline. flex-grow splits the
-                          bucket height after the 2px surface gaps between segments.
-                          A tiny bar can be all gap (2px × segments ≥ its height),
-                          so gaps only apply once every segment can keep visible
-                          color (~127px usable plot height at 100%). */}
-                      <div
-                        className="flex w-full max-w-[46px] flex-col overflow-hidden rounded-t-[5px]"
-                        style={{
-                          height: `${maxSpend > 0 ? (total / maxSpend) * 100 : 0}%`,
-                          minHeight: 4,
-                          gap: maxSpend > 0 && (total / maxSpend) * 127 > segs.length * 6 ? 2 : 0
-                        }}
-                      >
-                        {segs.length === 0 ? (
-                          <div className="h-full w-full bg-(--surface-active)" />
-                        ) : (
-                          [...segs].reverse().map((s) => (
-                            <div
-                              key={s.k}
-                              className="min-h-0 w-full"
-                              // grow values normalized to sum 1 — raw costs can sum
-                              // below 1, which would leave the bar under-filled.
-                              style={{ flexGrow: s.v / total, backgroundColor: keyColor(s.k) }}
-                            />
-                          ))
-                        )}
-                      </div>
-                      <span
-                        className={`mono whitespace-nowrap text-[10.5px] leading-none text-(--text-tertiary) ${
-                          i % labelEvery === 0 ? '' : 'select-none'
-                        }`}
-                      >
-                        {i % labelEvery === 0 ? label : ' '}
-                      </span>
-                    </div>
-                  )
-                })}
+                    ))}
+                  </BarChart>
+                </ResponsiveContainer>
               </div>
             </div>
           )
@@ -444,7 +501,7 @@ export default function UsageView() {
         <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3 desktop:px-[18px] desktop:py-[10px]">
           <div className="pillbar">
             {GROUPS.map((g) => (
-              <button key={g.key} className={groupBy === g.key ? 'pill on' : 'pill'} onClick={() => setGroupBy(g.key)}>
+              <button key={g.key} className={groupBy === g.key ? 'pill on' : 'pill'} onClick={() => selectGroup(g.key)}>
                 {g.label}
               </button>
             ))}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,7 +274,7 @@ importers:
         version: 0.0.67
       '@larksuiteoapi/node-sdk':
         specifier: ^1.71.1
-        version: 1.71.1(debug@4.3.4)
+        version: 1.71.1
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0
@@ -556,6 +556,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.8)
+      recharts:
+        specifier: ^3.10.1
+        version: 3.10.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.8)(react@19.2.8)(redux@5.0.1)
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1940,13 +1943,6 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@napi-rs/wasm-runtime@1.2.1':
-    resolution: {integrity: sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
-      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
-
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
@@ -2658,6 +2654,17 @@ packages:
     peerDependencies:
       '@redis/client': ^5.12.1
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
     engines: {node: '>= 10'}
@@ -3030,6 +3037,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@swc/core-darwin-arm64@1.15.46':
     resolution: {integrity: sha512-IsISIT22EfktVJrlvIpnAxG2u/A9aob9l99HMlx80x72WlFmFPk1V3UhkEzx86eJP8hw049KTFv/RISho2cq2Q==}
     engines: {node: '>=10'}
@@ -3252,6 +3262,9 @@ packages:
   '@types/d3-delaunay@6.0.1':
     resolution: {integrity: sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==}
 
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
   '@types/d3-format@3.0.1':
     resolution: {integrity: sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==}
 
@@ -3275,6 +3288,9 @@ packages:
 
   '@types/d3-time@3.0.0':
     resolution: {integrity: sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -3400,6 +3416,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
@@ -4292,6 +4311,10 @@ packages:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
@@ -4516,6 +4539,10 @@ packages:
     resolution: {integrity: sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==}
     engines: {node: '>=12'}
 
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
   d3-format@3.1.0:
     resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
     engines: {node: '>=12'}
@@ -4546,6 +4573,10 @@ packages:
 
   d3-time@3.1.0:
     resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
 
   data-uri-to-buffer@4.0.1:
@@ -4585,6 +4616,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -4935,6 +4969,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -5650,6 +5687,9 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
+  immer@11.1.15:
+    resolution: {integrity: sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -5980,8 +6020,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -5992,8 +6044,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -6004,8 +6068,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -6018,8 +6095,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -6032,14 +6123,33 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
   lightningcss-win32-x64-msvc@1.32.0:
     resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
@@ -7310,11 +7420,26 @@ packages:
     peerDependencies:
       react: '*'
 
+  react-is@19.2.8:
+    resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
+
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
@@ -7365,9 +7490,25 @@ packages:
   real-require@1.0.0:
     resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
+  recharts@3.10.1:
+    resolution: {integrity: sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redis@5.12.1:
     resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
     engines: {node: '>= 18.19.0'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   registry-auth-token@5.1.1:
     resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
@@ -7405,6 +7546,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -7956,6 +8100,9 @@ packages:
   tiny-emitter@2.1.0:
     resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -8284,6 +8431,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -9919,9 +10069,9 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@larksuiteoapi/node-sdk@1.71.1(debug@4.3.4)':
+  '@larksuiteoapi/node-sdk@1.71.1':
     dependencies:
-      axios: 1.18.1(debug@4.3.4)
+      axios: 1.18.1
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -10120,7 +10270,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
@@ -10961,6 +11111,18 @@ snapshots:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
     optional: true
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.8)(redux@5.0.1))(react@19.2.8)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.15
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 19.2.8
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.8)(redux@5.0.1)
+
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     optional: true
 
@@ -11071,7 +11233,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.1.4':
@@ -11247,7 +11409,7 @@ snapshots:
       '@slack/types': 2.22.0
       '@types/node': 24.13.3
       '@types/retry': 0.12.0
-      axios: 1.18.1(debug@4.3.4)
+      axios: 1.18.1
       eventemitter3: 5.0.4
       form-data: 4.0.6
       is-electron: 2.2.2
@@ -11347,6 +11509,8 @@ snapshots:
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/core-darwin-arm64@1.15.46':
     optional: true
@@ -11533,6 +11697,8 @@ snapshots:
 
   '@types/d3-delaunay@6.0.1': {}
 
+  '@types/d3-ease@3.0.2': {}
+
   '@types/d3-format@3.0.1': {}
 
   '@types/d3-geo@3.1.0':
@@ -11556,6 +11722,8 @@ snapshots:
   '@types/d3-time-format@2.1.0': {}
 
   '@types/d3-time@3.0.0': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/debug@4.1.12':
     dependencies:
@@ -11698,6 +11866,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/webidl-conversions@7.0.3':
     optional: true
@@ -12255,7 +12425,7 @@ snapshots:
       - supports-color
     optional: true
 
-  axios@1.18.1(debug@4.3.4):
+  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0(debug@4.3.4)
       form-data: 4.0.6
@@ -12563,6 +12733,8 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  clsx@2.1.1: {}
+
   cluster-key-slot@1.1.2:
     optional: true
 
@@ -12766,6 +12938,8 @@ snapshots:
     dependencies:
       delaunator: 5.1.0
 
+  d3-ease@3.0.1: {}
+
   d3-format@3.1.0: {}
 
   d3-geo@3.1.0:
@@ -12798,6 +12972,8 @@ snapshots:
     dependencies:
       d3-array: 3.2.4
 
+  d3-timer@3.0.1: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@8.0.0: {}
@@ -12816,6 +12992,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -13092,6 +13270,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
+
+  es-toolkit@1.50.0: {}
 
   es6-error@4.1.1:
     optional: true
@@ -14030,6 +14210,8 @@ snapshots:
 
   image-size@2.0.2: {}
 
+  immer@11.1.15: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -14344,34 +14526,67 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.32.0:
@@ -14393,6 +14608,18 @@ snapshots:
   lightningcss@1.33.0:
     dependencies:
       detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   lines-and-columns@1.2.4: {}
 
@@ -15977,6 +16204,8 @@ snapshots:
     dependencies:
       react: 19.2.8
 
+  react-is@19.2.8: {}
+
   react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.8):
     dependencies:
       '@types/hast': 3.0.5
@@ -15994,6 +16223,15 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react-redux@9.3.0(@types/react@19.2.17)(react@19.2.8)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      redux: 5.0.1
 
   react@19.2.8: {}
 
@@ -16066,6 +16304,26 @@ snapshots:
 
   real-require@1.0.0: {}
 
+  recharts@3.10.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.8)(react@19.2.8)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.8)(redux@5.0.1))(react@19.2.8)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.50.0
+      eventemitter3: 5.0.4
+      immer: 11.1.15
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 19.2.8
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.8)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.8)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redis@5.12.1(@opentelemetry/api@1.9.1):
     dependencies:
       '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
@@ -16077,6 +16335,12 @@ snapshots:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
     optional: true
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   registry-auth-token@5.1.1:
     dependencies:
@@ -16137,6 +16401,8 @@ snapshots:
 
   requires-port@1.0.0:
     optional: true
+
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -16870,6 +17136,8 @@ snapshots:
 
   tiny-emitter@2.1.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -17177,6 +17445,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.0.3
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.1
+      '@types/d3-scale': 4.0.2
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.0
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
## Summary
- Replace the hand-rolled CSS flex-bar "Spend over time" chart in `UsageView` with a recharts stacked `BarChart`.
- The legend is now a recharts `<Legend>` (custom content, since recharts' default swatches can't take `var()` colors) — clicking a key hides/shows that series in the stack and the y-scale recomputes from the visible series only.
- Removed the focus ring recharts' accessibility layer puts around the plot surface on click.

## Why
Consolidates on a real charting library instead of maintaining bespoke flex/height-percentage bar math, and adds series filtering that the old DOM-only chart couldn't support.

## Notes for reviewer
- Colors are applied via descendant CSS rules (`[&_.seg-0_path]:fill-(--chart-1)` etc.) on the chart wrapper rather than inline `fill`, since SVG `fill` won't accept a `var()` presentation attribute — this keeps bars theme-reactive across light/dark with no JS reading computed styles.
- Hidden legend keys stay in `stackKeys` (just `hide`den on the `Bar`) so remaining series never shift hue.
- Tooltip total reports the bucket's true net cost (`__total`, unaffected by clamped-negative segments) when nothing is filtered, and the sum of visible segments when a filter is active.
- Verified via `tsc --noEmit`, `eslint`, `prettier --check`, a production `next build`, and a headless happy-dom render check (not committed) confirming legend clicks toggle the corresponding `.seg-N` paths.
- Did not manually screenshot in a browser this session — the console's SSE connection kept the automated browser from reaching `document_idle`. Worth a manual look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)