### PR TITLE
test(daemon): run runtime matrix against local agents

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -32,6 +32,7 @@
     "prepack": "pnpm run build",
     "start": "node dist/index.js run",
     "test": "vitest run",
+    "test:runtime-matrix": "vitest run test/acp-matrix/acp-matrix.test.ts",
     "test:unit": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.typecheck.json"

--- a/packages/daemon/test/acp-matrix/README.md
+++ b/packages/daemon/test/acp-matrix/README.md
@@ -23,6 +23,13 @@ AC_RUNTIME_MATRIX_TARGETS=codex-acp,opencode \
   pnpm --filter @agentconnect.md/daemon test:runtime-matrix
 ```
 
+To rerun only the sandbox probe and show child-runtime diagnostics:
+
+```bash
+AC_RUNTIME_MATRIX_TARGETS=claude-acp AC_RUNTIME_MATRIX_ONLY=sandbox \
+  AC_RUNTIME_MATRIX_DEBUG=1 pnpm --filter @agentconnect.md/daemon test:runtime-matrix
+```
+
 An installed adapter whose provider is logged out, rate-limited, or out of quota
 is shown as `U` (provider unavailable), not as a fabricated pass. A feature is
 marked `✓` only after the real adapter/provider path completes. A real behavioral

--- a/packages/daemon/test/acp-matrix/README.md
+++ b/packages/daemon/test/acp-matrix/README.md
@@ -1,0 +1,29 @@
+# Local live runtime support matrix
+
+`acp-matrix.test.ts` is a local-machine compatibility suite. It discovers the
+runtimes admitted by this daemon installation, launches their real ACP adapters,
+and sends real prompts to their configured model providers. It does not use the
+scriptable ACP fixture and it does not require Slack.
+
+The suite exercises real lifecycle and memory replies, model and permission-mode
+configuration, native resume, interactive permission requests, usage, a sandboxed
+provider turn, an HTTP MCP tool call, and a skill installed by the exact bundled
+skills CLI.
+
+CI skips this suite. Run it locally with:
+
+```bash
+pnpm --filter @agentconnect.md/daemon test:runtime-matrix
+```
+
+To limit a diagnostic rerun:
+
+```bash
+AC_RUNTIME_MATRIX_TARGETS=codex-acp,opencode \
+  pnpm --filter @agentconnect.md/daemon test:runtime-matrix
+```
+
+An installed adapter whose provider is logged out, rate-limited, or out of quota
+is shown as `U` (provider unavailable), not as a fabricated pass. A feature is
+marked `✓` only after the real adapter/provider path completes. A real behavioral
+failure is `✗` and fails the test command.

--- a/packages/daemon/test/acp-matrix/acp-matrix.test.ts
+++ b/packages/daemon/test/acp-matrix/acp-matrix.test.ts
@@ -1,334 +1,531 @@
-import { describe, it, expect } from 'vitest'
-import { turnFailureCode } from '../../src/acp/acp-host.js'
-import { detectSandbox } from '../../src/acp/sandbox.js'
-import { PROFILES, profileById } from './profiles.js'
-import { verdictFor } from './support-matrix.js'
-import { bootHost, runDaemonTurn } from './harness.js'
-
 /**
- * daemon ↔ ACP integration matrix.
+ * LOCAL-ONLY live runtime support matrix.
  *
- * A grid of {daemon ACP feature} × {ACP agent profile}, every cell run against a REAL
- * subprocess (the scenario-driven fixture). Each profile emulates one real ACP-registry
- * agent's capability surface (profiles.ts); each feature asserts either the working
- * behavior ('run') or graceful degradation ('degrade') depending on whether the profile
- * advertises the capability (support-matrix.ts).
+ * This suite discovers the runtimes installed on this machine, starts their real
+ * ACP adapters, and sends real prompts to their configured model providers. It is
+ * intentionally skipped in CI: results are facts about this host's installation,
+ * authentication, sandbox, and provider access, not deterministic unit contracts.
  *
- * The point this makes that a single-fixture test can't: the daemon's ACP handling is
- * correct across the VARIETY of runtimes it targets — a capability one agent has and
- * another lacks is either used or degrades cleanly, never crashes or hangs.
+ * Run explicitly with:
+ *   pnpm --filter @agentconnect.md/daemon test:runtime-matrix
  */
+import { beforeAll, describe, expect, it } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { AddressInfo } from 'node:net'
+import type { McpServer } from '@agentclientprotocol/sdk'
+import { AcpHost } from '../../src/acp/acp-host.js'
+import { detectSandbox } from '../../src/acp/sandbox.js'
+import { loadConfig } from '../../src/config/load-config.js'
+import type { RuntimeDef } from '../../src/config/config-schema.js'
+import { resolveRoot } from '../../src/paths.js'
+import { installSkills } from '../../src/skills/install-skills.js'
+import { composeRuntimeLaunch } from '../../src/runtimes/launch-policy.js'
+import { installedRuntimeCatalog } from '../../src/runtimes/probe.js'
+import { resolveRuntimeCatalog, type ResolvedRuntimeEntry } from '../../src/runtimes/registry.js'
+import { FEATURES, type FeatureId } from './support-matrix.js'
 
-const TIMEOUT = 20_000
+const IS_CI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS)
+const TURN_TIMEOUT = 180_000
+const SUITE_TIMEOUT = 30 * 60_000
+const SKILL_NAME = 'runtime-matrix-probe'
 
-describe.each(PROFILES)('ACP matrix · $id ($registryId)', (profile) => {
-  it(
-    'capabilities: initialize + session/new advertise the expected surface',
-    async () => {
-      const h = await bootHost(profile)
+type Status = 'ok' | 'degrade' | 'na' | 'unavailable' | 'fail'
+interface Outcome {
+  status: Status
+  detail: string
+}
+interface RuntimeResult {
+  id: string
+  reachable: boolean
+  features: Partial<Record<FeatureId, Outcome>>
+  error?: string
+  models: string[]
+  modes: string[]
+  mcp: { http: boolean; sse: boolean }
+}
+
+interface RuntimeTarget {
+  id: string
+  runtime: RuntimeDef
+  entry: ResolvedRuntimeEntry
+}
+
+interface ProbeEndpoint {
+  server: Server
+  url: string
+  calls: () => number
+}
+
+function withTimeout<T>(promise: Promise<T>, label: string, timeout = TURN_TIMEOUT): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      const timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeout}ms`)), timeout)
+      timer.unref?.()
+    })
+  ])
+}
+
+function textChunks(updates: unknown[], from = 0): string[] {
+  return updates
+    .slice(from)
+    .filter(
+      (update: any) =>
+        update?.sessionUpdate === 'agent_message_chunk' &&
+        update?.content?.type === 'text' &&
+        typeof update.content.text === 'string'
+    )
+    .map((update: any) => update.content.text as string)
+}
+
+function mcpProbeEndpoint(): Promise<ProbeEndpoint> {
+  let toolCalls = 0
+  const server = createServer((req, res) => {
+    let body = ''
+    req.on('data', (chunk: Buffer) => (body += chunk.toString('utf8')))
+    req.on('end', () => {
+      let rpc: { id?: string | number; method?: string } = {}
       try {
-        expect(h.host.loadSupported()).toBe(profile.caps.loadSession)
-        expect(h.host.mcpCapabilities()).toEqual(profile.caps.mcp)
-        expect(h.host.promptSupports('image')).toBe(profile.caps.promptImage)
-        await h.host.newSession('/tmp')
-        expect(h.host.modelOptions()?.models ?? null).toEqual(profile.caps.models)
-        expect(h.host.permissionModeOptions()?.modes ?? null).toEqual(profile.caps.permissionModes)
-      } finally {
-        await h.stop()
+        rpc = JSON.parse(body) as typeof rpc
+      } catch {
+        // A malformed request is still a real compatibility failure: answer 400.
+        res.writeHead(400).end()
+        return
       }
-    },
-    TIMEOUT
-  )
-
-  it(
-    'lifecycle: session/new → prompt streams a reply and ends the turn',
-    async () => {
-      const h = await bootHost(profile)
-      try {
-        const sid = await h.host.newSession('/tmp')
-        const res = await h.host.prompt(sid, [{ type: 'text', text: 'hi' }])
-        expect(res.stopReason).toBe('end_turn')
-        expect(h.texts().some((t) => t.includes('echo:hi'))).toBe(true)
-      } finally {
-        await h.stop()
+      if (req.method !== 'POST') {
+        res.writeHead(405).end()
+        return
       }
-    },
-    TIMEOUT
-  )
-
-  it(
-    `model-switch [${verdictFor('model-switch', profile)}]`,
-    async () => {
-      const h = await bootHost(profile)
-      try {
-        const sid = await h.host.newSession('/tmp')
-        if (verdictFor('model-switch', profile) === 'run') {
-          const target = profile.caps.models!.find((m) => m !== h.host.modelOptions()?.current)!
-          expect(await h.host.setSessionModel(sid, target)).toBe(true)
-          expect(h.host.modelOptions()?.current).toBe(target)
-        } else {
-          // No model selector — the daemon reports "not applied" rather than throwing.
-          expect(await h.host.setSessionModel(sid, 'anything')).toBe(false)
-        }
-      } finally {
-        await h.stop()
+      if (rpc.id === undefined) {
+        res.writeHead(202).end()
+        return
       }
-    },
-    TIMEOUT
-  )
-
-  it(
-    `permission-mode-switch [${verdictFor('permission-mode-switch', profile)}]`,
-    async () => {
-      const h = await bootHost(profile)
-      try {
-        const sid = await h.host.newSession('/tmp')
-        if (verdictFor('permission-mode-switch', profile) === 'run') {
-          const target = profile.caps.permissionModes!.find((m) => m !== h.host.permissionModeOptions()?.current)!
-          expect(await h.host.setSessionPermissionMode(sid, target)).toBe(true)
-          expect(h.host.permissionModeOptions()?.current).toBe(target)
-        } else {
-          expect(await h.host.setSessionPermissionMode(sid, 'anything')).toBe(false)
-        }
-      } finally {
-        await h.stop()
-      }
-    },
-    TIMEOUT
-  )
-
-  it(
-    `load-resume [${verdictFor('load-resume', profile)}]`,
-    async () => {
-      const h = await bootHost(profile)
-      try {
-        if (verdictFor('load-resume', profile) === 'run') {
-          expect(h.host.loadSupported()).toBe(true)
-          await h.host.loadSession('persisted-1', '/tmp')
-          // Restored-title metadata is forwarded…
-          expect(h.updates.some((u) => u.update?.sessionUpdate === 'session_info_update')).toBe(true)
-          // …but replayed conversation output is suppressed.
-          expect(h.texts().some((t) => t.includes('historical output'))).toBe(false)
-        } else {
-          // Unsupported: the daemon sees loadSession=false and would recreate instead.
-          expect(h.host.loadSupported()).toBe(false)
-        }
-      } finally {
-        await h.stop()
-      }
-    },
-    TIMEOUT
-  )
-
-  it(
-    'interactive-permission: resolver choice wins; absent resolver auto-allows (never hangs)',
-    async () => {
-      const permOptions = {
-        options: [
-          { optionId: 'yes', name: 'Allow', kind: 'allow_once' },
-          { optionId: 'no', name: 'Deny', kind: 'reject_once' }
-        ]
-      }
-      // (a) No resolver → daemon auto-allows the first allow option.
-      const auto = await bootHost(profile, { override: { prompt: { requestPermission: permOptions } } })
-      try {
-        const sid = await auto.host.newSession('/tmp')
-        await auto.host.prompt(sid, [{ type: 'text', text: 'hi' }])
-        expect(auto.texts().some((t) => t.includes('"outcome":"selected"') && t.includes('"yes"'))).toBe(true)
-        expect(auto.permissionEvents.map(({ event }) => event)).toEqual([
-          { kind: 'requested' },
-          expect.objectContaining({
-            kind: 'resolved',
-            source: 'fallback',
-            fallbackReason: 'no_resolver',
-            response: { outcome: { outcome: 'selected', optionId: 'yes' } }
+      if (rpc.method === 'tools/call') {
+        toolCalls += 1
+        res.writeHead(200, { 'content-type': 'application/json' }).end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: rpc.id,
+            result: { content: [{ type: 'text', text: 'MATRIX_MCP_OK' }], isError: false }
           })
-        ])
-      } finally {
-        await auto.stop()
+        )
+        return
       }
-      // (b) Interactive resolver → the user's explicit choice is forwarded.
-      const interactive = await bootHost(profile, {
-        override: { prompt: { requestPermission: permOptions } },
-        onPermission: async () => ({ outcome: { outcome: 'selected', optionId: 'no' } })
-      })
-      try {
-        const sid = await interactive.host.newSession('/tmp')
-        await interactive.host.prompt(sid, [{ type: 'text', text: 'hi' }])
-        expect(interactive.texts().some((t) => t.includes('"no"'))).toBe(true)
-        expect(interactive.permissionEvents.map(({ event }) => event)).toEqual([
-          { kind: 'requested' },
+      const result =
+        rpc.method === 'initialize'
+          ? {
+              protocolVersion: '2025-06-18',
+              capabilities: { tools: {} },
+              serverInfo: { name: 'agentconnect-runtime-matrix', version: '1' }
+            }
+          : rpc.method === 'tools/list'
+            ? {
+                tools: [
+                  {
+                    name: 'runtime_matrix_probe',
+                    description: 'Returns MATRIX_MCP_OK. Use only for the AgentConnect runtime matrix.',
+                    inputSchema: { type: 'object', properties: {}, additionalProperties: false }
+                  }
+                ]
+              }
+            : {}
+      res
+        .writeHead(200, { 'content-type': 'application/json' })
+        .end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id, result }))
+    })
+  })
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo
+      resolve({ server, url: `http://127.0.0.1:${port}/mcp`, calls: () => toolCalls })
+    })
+  })
+}
+
+function selectAllowOption(params: any): { outcome: { outcome: 'selected'; optionId: string } } | undefined {
+  const options = Array.isArray(params?.options) ? params.options : []
+  const selected = options.find((option: any) => String(option?.kind ?? '').startsWith('allow')) ?? options[0]
+  return selected?.optionId ? { outcome: { outcome: 'selected', optionId: String(selected.optionId) } } : undefined
+}
+
+function providerUnavailable(error: unknown): boolean {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase()
+  return [
+    'authentication required',
+    'authenticate first',
+    'credit usage limit',
+    'weekly limit',
+    'usage limit',
+    'quota',
+    'high demand',
+    'rate limit'
+  ].some((part) => message.includes(part))
+}
+
+async function installProbeSkill(
+  target: RuntimeTarget,
+  root: string,
+  agentDir: string,
+  cwd: string,
+  token: string
+): Promise<Outcome> {
+  if (!target.entry.skillsAgentId) {
+    return { status: 'degrade', detail: 'runtime has no audited skills CLI identity' }
+  }
+  const sourceDir = join(root, 'skill-source')
+  mkdirSync(sourceDir, { recursive: true })
+  writeFileSync(
+    join(sourceDir, 'SKILL.md'),
+    `---\nname: ${SKILL_NAME}\ndescription: Use only when the user says ACTIVATE_SKILL_PROBE.\n---\n\n# Runtime matrix probe\n\nWhen invoked, reply with exactly: ${token}\n`
+  )
+  const result = await installSkills({ id: 'runtime-matrix', runtime: target.id, skills: [], dir: agentDir }, cwd, {
+    stateDir: join(root, 'skill-state'),
+    skillsAgentId: target.entry.skillsAgentId,
+    localSkills: [{ kind: 'managed', key: `matrix:${target.id}`, name: SKILL_NAME, sourceDir }]
+  })
+  if (result.errors.length > 0 || result.installed.length === 0) {
+    return { status: 'fail', detail: result.errors.map((error) => error.error).join('; ') || 'skill was not installed' }
+  }
+  return { status: 'ok', detail: `installed via skills CLI identity ${target.entry.skillsAgentId}` }
+}
+
+async function runSandboxProbe(target: RuntimeTarget, root: string, token: string): Promise<Outcome> {
+  const mechanism = detectSandbox()
+  if (!mechanism) return { status: 'degrade', detail: 'no supported sandbox mechanism on this host' }
+
+  const scopeDir = join(root, 'sandbox-agent')
+  const sandboxCwd = join(scopeDir, 'workspace')
+  mkdirSync(sandboxCwd, { recursive: true })
+  const composed = composeRuntimeLaunch({
+    runtimeId: target.id,
+    runtime: target.runtime,
+    provider: 'managed',
+    scopeDir,
+    cwd: sandboxCwd,
+    runInSandbox: true,
+    daemonRoot: root,
+    sandboxMechanism: mechanism,
+    hostEnv: process.env,
+    stateSourceEnv: process.env
+  })
+  const updates: unknown[] = []
+  const host = new AcpHost(composed.runtime, {
+    runtimeId: target.id,
+    suppressChildStderr: true,
+    onUpdate: (_sessionId, update) => updates.push(update),
+    env: composed.launch.env,
+    inheritProcessEnv: composed.launch.inheritProcessEnv,
+    sandbox: composed.launch.sandbox
+  })
+  try {
+    await withTimeout(host.start(), `${target.id}/sandbox start`)
+    const sessionId = await withTimeout(host.newSession(sandboxCwd), `${target.id}/sandbox session`)
+    await withTimeout(
+      host.prompt(sessionId, [{ type: 'text', text: `Reply with exactly ${token} and nothing else.` }]),
+      `${target.id}/sandbox prompt`
+    )
+    const output = textChunks(updates).join('')
+    return output.includes(token)
+      ? { status: 'ok', detail: `real model turn completed inside ${mechanism}` }
+      : { status: 'fail', detail: `sandboxed model reply did not contain ${token}` }
+  } finally {
+    await host.stop().catch(() => {})
+  }
+}
+
+async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
+  const result: RuntimeResult = {
+    id: target.id,
+    reachable: false,
+    features: {},
+    models: [],
+    modes: [],
+    mcp: { http: false, sse: false }
+  }
+  const root = mkdtempSync(join(tmpdir(), `ac-runtime-matrix-${target.id.replace(/[^a-z0-9-]/gi, '-')}-`))
+  const agentDir = join(root, 'agent')
+  const cwd = join(agentDir, 'workspace')
+  mkdirSync(cwd, { recursive: true })
+  const nonce = `${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+  const memoryToken = `MATRIX_MEMORY_OK_${nonce}`
+  const skillToken = `MATRIX_SKILL_OK_${nonce}`
+  const sandboxToken = `MATRIX_SANDBOX_OK_${nonce}`
+  const updates: unknown[] = []
+  let permissionRequested = false
+  let host: AcpHost | undefined
+  let endpoint: ProbeEndpoint | undefined
+
+  try {
+    const skillInstall = await installProbeSkill(target, root, agentDir, cwd, skillToken).catch((error): Outcome => ({
+      status: 'fail',
+      detail: `skills install: ${(error as Error).message}`
+    }))
+
+    host = new AcpHost(target.runtime, {
+      runtimeId: target.id,
+      suppressChildStderr: true,
+      onUpdate: (_sessionId, update) => updates.push(update),
+      onPermission: async (_sessionId, params) => {
+        permissionRequested = true
+        return selectAllowOption(params)
+      }
+    })
+    await withTimeout(host.start(), `${target.id}/start`)
+    result.reachable = true
+    result.mcp = host.mcpCapabilities() ?? { http: false, sse: false }
+
+    const usesMeta = host.usesMetaSystemPrompt()
+    const sessionId = await withTimeout(
+      host.newSession(cwd, [], undefined, usesMeta ? memoryToken : undefined),
+      `${target.id}/session`
+    )
+    result.models = host.modelOptions()?.models ?? []
+    result.modes = host.permissionModeOptions()?.modes ?? []
+    result.features.capabilities = {
+      status: 'ok',
+      detail: `${result.models.length} models, ${result.modes.length} modes, load=${host.loadSupported()}, mcp=http:${result.mcp.http}/sse:${result.mcp.sse}`
+    }
+    const lifecycleStart = updates.length
+    const lifecyclePrompt = usesMeta
+      ? `The standing context contains a token beginning MATRIX_MEMORY_OK_. Reply with that exact token only.`
+      : `# Memory\n${memoryToken}\n\nReply with the exact memory token above and nothing else.`
+    const lifecycle = await withTimeout(
+      host.prompt(sessionId, [{ type: 'text', text: lifecyclePrompt }]),
+      `${target.id}/lifecycle`
+    )
+    const lifecycleText = textChunks(updates, lifecycleStart).join('')
+    result.features.lifecycle = lifecycleText.trim()
+      ? { status: 'ok', detail: `real provider replied (${lifecycle.stopReason})` }
+      : { status: 'fail', detail: 'real provider returned no agent message' }
+    result.features.memory = lifecycleText.includes(memoryToken)
+      ? { status: 'ok', detail: `real model recalled session-start index via ${usesMeta ? '_meta' : 'inline block'}` }
+      : { status: 'fail', detail: `real model reply did not contain ${memoryToken}` }
+    result.features['usage-fold'] = lifecycle.usage
+      ? { status: 'ok', detail: `${lifecycle.usage.used}/${lifecycle.usage.size} tokens` }
+      : { status: 'degrade', detail: 'runtime returned no ACP usage object' }
+
+    if (result.models.length >= 2) {
+      const from = host.modelOptions()?.current
+      const to = result.models.find((model) => model !== from)!
+      const applied = await host.setSessionModel(sessionId, to)
+      result.features['model-switch'] = applied
+        ? { status: 'ok', detail: `${from ?? '?'} -> ${to}` }
+        : { status: 'fail', detail: `runtime rejected model switch to ${to}` }
+    } else {
+      result.features['model-switch'] = { status: 'degrade', detail: `${result.models.length} model(s)` }
+    }
+
+    if (result.modes.length >= 2) {
+      const from = host.permissionModeOptions()?.current
+      const to = result.modes.find((mode) => mode !== from)!
+      const applied = await host.setSessionPermissionMode(sessionId, to)
+      result.features['permission-mode-switch'] = applied
+        ? { status: 'ok', detail: `${from ?? '?'} -> ${to}` }
+        : { status: 'fail', detail: `runtime rejected permission-mode switch to ${to}` }
+    } else {
+      result.features['permission-mode-switch'] = { status: 'degrade', detail: `${result.modes.length} mode(s)` }
+    }
+
+    if (result.mcp.http) {
+      endpoint = await mcpProbeEndpoint()
+      const descriptor: McpServer = {
+        type: 'http',
+        name: 'runtime-matrix',
+        url: endpoint.url,
+        headers: []
+      }
+      const mcpSession = await withTimeout(host.newSession(cwd, [descriptor]), `${target.id}/mcp session`)
+      const mcpStart = updates.length
+      await withTimeout(
+        host.prompt(mcpSession, [
           {
-            kind: 'resolved',
-            source: 'resolver',
-            response: { outcome: { outcome: 'selected', optionId: 'no' } }
+            type: 'text',
+            text: 'Call the MCP tool runtime_matrix_probe now. Reply with exactly the text returned by the tool.'
           }
-        ])
-      } finally {
-        await interactive.stop()
+        ]),
+        `${target.id}/mcp prompt`
+      )
+      const mcpText = textChunks(updates, mcpStart).join('')
+      result.features.mcp =
+        endpoint.calls() > 0 && mcpText.includes('MATRIX_MCP_OK')
+          ? { status: 'ok', detail: `${endpoint.calls()} real HTTP MCP tools/call request(s)` }
+          : { status: 'fail', detail: `toolCalls=${endpoint.calls()}, reply=${JSON.stringify(mcpText.slice(0, 120))}` }
+    } else {
+      result.features.mcp = {
+        status: 'degrade',
+        detail: result.mcp.sse ? 'SSE advertised; HTTP live probe unavailable' : 'HTTP/SSE not advertised'
       }
-    },
-    TIMEOUT
-  )
+    }
 
-  it(
-    'elicitation: absent resolver declines (never hangs); resolver accepts',
-    async () => {
-      // ACP elicitation/create (form mode): mode + message + requestedSchema; the fixture
-      // adds the session scope. Absent an onElicit resolver the daemon declines.
-      const elicit = { mode: 'form', message: 'Pick one', requestedSchema: { type: 'object', properties: {} } }
-      const declined = await bootHost(profile, { override: { prompt: { elicit } } })
-      try {
-        const sid = await declined.host.newSession('/tmp')
-        await declined.host.prompt(sid, [{ type: 'text', text: 'hi' }])
-        expect(declined.texts().some((t) => t.includes('"action":"decline"'))).toBe(true)
-      } finally {
-        await declined.stop()
-      }
-      const accepted = await bootHost(profile, {
-        override: { prompt: { elicit } },
-        onElicit: async () => ({ action: 'accept', content: { choice: 'a' } })
-      })
-      try {
-        const sid = await accepted.host.newSession('/tmp')
-        await accepted.host.prompt(sid, [{ type: 'text', text: 'hi' }])
-        expect(accepted.texts().some((t) => t.includes('"action":"accept"'))).toBe(true)
-      } finally {
-        await accepted.stop()
-      }
-    },
-    TIMEOUT
-  )
+    if (skillInstall.status === 'ok') {
+      const skillStart = updates.length
+      await withTimeout(
+        host.prompt(sessionId, [
+          {
+            type: 'text',
+            text: `ACTIVATE_SKILL_PROBE. Use the ${SKILL_NAME} skill now and follow its instructions exactly.`
+          }
+        ]),
+        `${target.id}/skills prompt`
+      )
+      const skillText = textChunks(updates, skillStart).join('')
+      result.features.skills = skillText.includes(skillToken)
+        ? { status: 'ok', detail: `${skillInstall.detail}; real model discovered and followed it` }
+        : {
+            status: 'fail',
+            detail: `installed skill was not followed; reply=${JSON.stringify(skillText.slice(0, 120))}`
+          }
+    } else {
+      result.features.skills = skillInstall
+    }
 
-  it(
-    `usage-fold [${verdictFor('usage-fold', profile)}]`,
-    async () => {
-      const h = await bootHost(profile)
-      try {
-        const sid = await h.host.newSession('/tmp')
-        const res = await h.host.prompt(sid, [{ type: 'text', text: 'hi' }])
-        if (verdictFor('usage-fold', profile) === 'run') {
-          expect(res.usage).toBeDefined()
-          expect(typeof res.usage!.used).toBe('number')
-          expect(res.usage!.size).toBeGreaterThan(0)
-        } else {
-          expect(res.usage).toBeUndefined()
+    const permissionStart = updates.length
+    await withTimeout(
+      host.prompt(sessionId, [
+        {
+          type: 'text',
+          text: 'Using your file tool, create matrix-permission.txt in the current workspace containing OK, then reply done.'
         }
-      } finally {
-        await h.stop()
-      }
-    },
-    TIMEOUT
-  )
-
-  it(
-    `memory: fresh-session index routing [${verdictFor('memory', profile)}]`,
-    async () => {
-      const h = await bootHost(profile, { override: { prompt: { echoSysMeta: true } } })
-      try {
-        // The routing decision the daemon makes per runtime.
-        expect(h.host.usesMetaSystemPrompt()).toBe(verdictFor('memory', profile) === 'run')
-        // `systemAppend` is the fresh-session memory index the daemon threads in.
-        const sid = await h.host.newSession('/tmp', [], undefined, 'MEMORY-INDEX')
-        await h.host.prompt(sid, [{ type: 'text', text: 'hi' }])
-        const sysmeta = h.texts().find((t) => t.startsWith('sysmeta:'))
-        expect(sysmeta).toBeDefined()
-        if (verdictFor('memory', profile) === 'run') {
-          // Claude: the index rides _meta.systemPrompt.append on session/new — standing
-          // context, NOT a user turn.
-          expect(sysmeta).toContain('MEMORY-INDEX')
-        } else {
-          // Others: nothing is smuggled via _meta; the daemon routes the index as a
-          // leading inline block instead (outside AcpHost's scope).
-          expect(sysmeta).toBe('sysmeta:null')
+      ]),
+      `${target.id}/permission prompt`
+    )
+    result.features['interactive-permission'] = permissionRequested
+      ? { status: 'ok', detail: 'real runtime requested permission and received an allow decision' }
+      : {
+          status: 'degrade',
+          detail: `runtime completed without an ACP permission request (${textChunks(updates, permissionStart).join('').slice(0, 80)})`
         }
-      } finally {
-        await h.stop()
-      }
-    },
-    TIMEOUT
-  )
-})
 
-// ── Cross-cutting ACP behaviors (not capability-gated per profile) ────────────────
+    // Run this independently before the resume/restart phase so a runtime-specific
+    // session/load failure cannot masquerade as a sandbox failure.
+    result.features.sandbox = await runSandboxProbe(target, root, sandboxToken).catch((error): Outcome => ({
+      status: 'fail',
+      detail: (error as Error).message
+    }))
 
-describe('ACP host: turn-failure classification', () => {
-  it(
-    'maps a provider quota error to provider_quota_exhausted',
-    async () => {
-      const claude = profileById('claude')
-      const h = await bootHost(claude, {
-        override: { prompt: { error: { message: 'You have exceeded your current quota.' } } }
+    if (host.loadSupported()) {
+      await host.stop()
+      host = new AcpHost(target.runtime, {
+        runtimeId: target.id,
+        suppressChildStderr: true,
+        onUpdate: (_sessionId, update) => updates.push(update)
       })
-      try {
-        const sid = await h.host.newSession('/tmp')
-        const err = await h.host.prompt(sid, [{ type: 'text', text: 'hi' }]).then(
-          () => null,
-          (e) => e
+      await withTimeout(host.start(), `${target.id}/resume start`)
+      await withTimeout(host.loadSession(sessionId, cwd), `${target.id}/session load`)
+      const resumeToken = `MATRIX_RESUME_OK_${nonce}`
+      const resumeStart = updates.length
+      await withTimeout(
+        host.prompt(sessionId, [{ type: 'text', text: `Reply with exactly ${resumeToken}.` }]),
+        `${target.id}/resume prompt`
+      )
+      result.features['load-resume'] = textChunks(updates, resumeStart).join('').includes(resumeToken)
+        ? { status: 'ok', detail: 'real adapter restarted, loaded session, and completed a provider turn' }
+        : { status: 'fail', detail: 'loaded session produced no matching provider reply' }
+    } else {
+      result.features['load-resume'] = { status: 'degrade', detail: 'runtime does not advertise session/load' }
+    }
+  } catch (error) {
+    result.error = error instanceof Error ? error.message : String(error)
+    const status: Status = providerUnavailable(error) ? 'unavailable' : 'fail'
+    for (const feature of FEATURES) {
+      result.features[feature] ??= { status, detail: result.error }
+    }
+  } finally {
+    endpoint?.server.close()
+    await host?.stop().catch(() => {})
+    rmSync(root, { recursive: true, force: true })
+  }
+  return result
+}
+
+const SHORT: Record<FeatureId, string> = {
+  capabilities: 'caps',
+  lifecycle: 'life',
+  'model-switch': 'model',
+  'permission-mode-switch': 'pmode',
+  'load-resume': 'load',
+  'interactive-permission': 'perm',
+  'usage-fold': 'usage',
+  memory: 'memory',
+  sandbox: 'sbox',
+  mcp: 'mcp',
+  skills: 'skills'
+}
+const CELL: Record<Status, string> = { ok: '✓', degrade: '·', na: '~', unavailable: 'U', fail: '✗' }
+
+function grid(results: RuntimeResult[]): string {
+  const idWidth = Math.max(7, ...results.map((result) => result.id.length))
+  const widths = FEATURES.map((feature) => Math.max(3, SHORT[feature].length))
+  const head = 'runtime'.padEnd(idWidth) + ' | ' + FEATURES.map((f, i) => SHORT[f].padStart(widths[i]!)).join(' ')
+  const separator = '-'.repeat(idWidth) + '-+-' + widths.map((width) => '-'.repeat(width)).join('-')
+  const rows = results.map(
+    (result) =>
+      result.id.padEnd(idWidth) +
+      ' | ' +
+      FEATURES.map((feature, index) => CELL[result.features[feature]?.status ?? 'na'].padStart(widths[index]!)).join(
+        ' '
+      )
+  )
+  return [head, separator, ...rows, '', 'legend: ✓ real pass · degrade ~ n/a U provider unavailable ✗ fail'].join('\n')
+}
+
+describe.skipIf(IS_CI)('local live ACP runtime support matrix', () => {
+  let targets: RuntimeTarget[] = []
+
+  beforeAll(async () => {
+    const daemonRoot = resolveRoot()
+    const config = loadConfig({ root: daemonRoot, optional: true })
+    const catalog = await resolveRuntimeCatalog(config, daemonRoot, { mode: 'cache-first' })
+    const installed = installedRuntimeCatalog(catalog)
+    const requested = new Set(
+      (process.env.AC_RUNTIME_MATRIX_TARGETS ?? '')
+        .split(',')
+        .map((id) => id.trim())
+        .filter(Boolean)
+    )
+    targets = Object.entries(installed.entries)
+      .filter(([id]) => id !== 'qoder-cli-cn' && (requested.size === 0 || requested.has(id)))
+      .map(([id, entry]) => ({ id, runtime: entry.runtime, entry }))
+      .sort((a, b) => a.id.localeCompare(b.id))
+  })
+
+  it(
+    'starts every installed runtime and exercises its real model/provider',
+    async () => {
+      expect(targets.length, 'no installed ACP runtimes were discovered on this host').toBeGreaterThan(0)
+      const results: RuntimeResult[] = []
+      for (const target of targets) {
+        const result = await runRuntime(target)
+        results.push(result)
+        console.info(
+          `[runtime-matrix] ${target.id}: ${result.reachable ? 'reachable' : 'unavailable'}${result.error ? ` — ${result.error}` : ''}`
         )
-        expect(err).not.toBeNull()
-        expect(turnFailureCode(err)).toBe('provider_quota_exhausted')
-      } finally {
-        await h.stop()
       }
-    },
-    TIMEOUT
-  )
 
-  it(
-    'leaves a generic failure as turn_failed',
-    async () => {
-      const claude = profileById('claude')
-      const h = await bootHost(claude, { override: { prompt: { error: { message: 'something broke' } } } })
-      try {
-        const sid = await h.host.newSession('/tmp')
-        const err = await h.host.prompt(sid, [{ type: 'text', text: 'hi' }]).then(
-          () => null,
-          (e) => e
+      console.info(`\nREAL local runtime matrix (${results.length} installed):\n${grid(results)}\n`)
+      for (const result of results) {
+        for (const feature of FEATURES) {
+          const outcome = result.features[feature]
+          if (outcome?.status === 'fail')
+            console.info(`[runtime-matrix] FAIL ${result.id}/${feature}: ${outcome.detail}`)
+        }
+      }
+
+      const failures = results.flatMap((result) =>
+        FEATURES.filter((feature) => result.features[feature]?.status === 'fail').map(
+          (feature) => `${result.id}/${feature}: ${result.features[feature]!.detail}`
         )
-        expect(turnFailureCode(err)).toBe('turn_failed')
-      } finally {
-        await h.stop()
-      }
+      )
+      expect(
+        results.some((result) => result.features.lifecycle?.status === 'ok'),
+        'no installed runtime completed a real model/provider turn'
+      ).toBe(true)
+      expect(failures, `real runtime failures:\n${failures.join('\n')}`).toEqual([])
     },
-    TIMEOUT
-  )
-})
-
-describe('ACP host: stop() escalation', () => {
-  it(
-    'a well-behaved agent stops on graceful EOF + SIGTERM',
-    async () => {
-      const h = await bootHost(profileById('claude'))
-      await expect(h.host.stop(5000)).resolves.toBeUndefined()
-    },
-    TIMEOUT
-  )
-
-  it(
-    'a SIGTERM-ignoring agent is reaped by the SIGKILL fallback (never hangs)',
-    async () => {
-      const h = await bootHost(profileById('claude'), { override: { ignoreSigterm: true } })
-      // Must resolve via the SIGKILL fallback rather than hang past the deadline.
-      await expect(h.host.stop(500)).resolves.toBeUndefined()
-    },
-    TIMEOUT
-  )
-})
-
-describe.skipIf(!detectSandbox())('daemon end-to-end: webchat turn through a real ACP subprocess', () => {
-  // A representative slice: full-featured, no-loadSession, and bare-minimum agents.
-  it.each([profileById('claude'), profileById('codex'), profileById('pi')])(
-    'streams the reply and closes the turn ($id)',
-    async (profile) => {
-      const { reply, stop } = await runDaemonTurn(profile, 'go')
-      try {
-        expect(reply.texts.some((t) => t.includes('go'))).toBe(true)
-        expect(reply.dones.at(-1)?.stopReason).toBe('end_turn')
-      } finally {
-        await stop()
-      }
-    },
-    30_000
+    SUITE_TIMEOUT
   )
 })

--- a/packages/daemon/test/acp-matrix/acp-matrix.test.ts
+++ b/packages/daemon/test/acp-matrix/acp-matrix.test.ts
@@ -31,6 +31,7 @@ const IS_CI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS)
 const TURN_TIMEOUT = 180_000
 const SUITE_TIMEOUT = 30 * 60_000
 const SKILL_NAME = 'runtime-matrix-probe'
+const DEBUG_CHILD = process.env.AC_RUNTIME_MATRIX_DEBUG === '1'
 
 type Status = 'ok' | 'degrade' | 'na' | 'unavailable' | 'fail'
 interface Outcome {
@@ -215,7 +216,7 @@ async function runSandboxProbe(target: RuntimeTarget, root: string, token: strin
   const updates: unknown[] = []
   const host = new AcpHost(composed.runtime, {
     runtimeId: target.id,
-    suppressChildStderr: true,
+    suppressChildStderr: !DEBUG_CHILD,
     onUpdate: (_sessionId, update) => updates.push(update),
     env: composed.launch.env,
     inheritProcessEnv: composed.launch.inheritProcessEnv,
@@ -457,24 +458,25 @@ const SHORT: Record<FeatureId, string> = {
 }
 const CELL: Record<Status, string> = { ok: '✓', degrade: '·', na: '~', unavailable: 'U', fail: '✗' }
 
-function grid(results: RuntimeResult[]): string {
+function grid(results: RuntimeResult[], features: FeatureId[] = FEATURES): string {
   const idWidth = Math.max(7, ...results.map((result) => result.id.length))
-  const widths = FEATURES.map((feature) => Math.max(3, SHORT[feature].length))
-  const head = 'runtime'.padEnd(idWidth) + ' | ' + FEATURES.map((f, i) => SHORT[f].padStart(widths[i]!)).join(' ')
+  const widths = features.map((feature) => Math.max(3, SHORT[feature].length))
+  const head = 'runtime'.padEnd(idWidth) + ' | ' + features.map((f, i) => SHORT[f].padStart(widths[i]!)).join(' ')
   const separator = '-'.repeat(idWidth) + '-+-' + widths.map((width) => '-'.repeat(width)).join('-')
   const rows = results.map(
     (result) =>
       result.id.padEnd(idWidth) +
       ' | ' +
-      FEATURES.map((feature, index) => CELL[result.features[feature]?.status ?? 'na'].padStart(widths[index]!)).join(
-        ' '
-      )
+      features
+        .map((feature, index) => CELL[result.features[feature]?.status ?? 'na'].padStart(widths[index]!))
+        .join(' ')
   )
   return [head, separator, ...rows, '', 'legend: ✓ real pass · degrade ~ n/a U provider unavailable ✗ fail'].join('\n')
 }
 
 describe.skipIf(IS_CI)('local live ACP runtime support matrix', () => {
   let targets: RuntimeTarget[] = []
+  let features: FeatureId[] = FEATURES
 
   beforeAll(async () => {
     const daemonRoot = resolveRoot()
@@ -491,6 +493,7 @@ describe.skipIf(IS_CI)('local live ACP runtime support matrix', () => {
       .filter(([id]) => id !== 'qoder-cli-cn' && (requested.size === 0 || requested.has(id)))
       .map(([id, entry]) => ({ id, runtime: entry.runtime, entry }))
       .sort((a, b) => a.id.localeCompare(b.id))
+    if (process.env.AC_RUNTIME_MATRIX_ONLY === 'sandbox') features = ['sandbox']
   })
 
   it(
@@ -499,16 +502,38 @@ describe.skipIf(IS_CI)('local live ACP runtime support matrix', () => {
       expect(targets.length, 'no installed ACP runtimes were discovered on this host').toBeGreaterThan(0)
       const results: RuntimeResult[] = []
       for (const target of targets) {
-        const result = await runRuntime(target)
+        const result =
+          features.length === 1 && features[0] === 'sandbox'
+            ? await (async (): Promise<RuntimeResult> => {
+                const root = mkdtempSync(join(tmpdir(), `ac-runtime-matrix-sandbox-${target.id}-`))
+                try {
+                  const outcome = await runSandboxProbe(
+                    target,
+                    root,
+                    `MATRIX_SANDBOX_OK_${Date.now().toString(36)}`
+                  ).catch((error): Outcome => ({ status: 'fail', detail: (error as Error).message }))
+                  return {
+                    id: target.id,
+                    reachable: true,
+                    features: { sandbox: outcome },
+                    models: [],
+                    modes: [],
+                    mcp: { http: false, sse: false }
+                  }
+                } finally {
+                  rmSync(root, { recursive: true, force: true })
+                }
+              })()
+            : await runRuntime(target)
         results.push(result)
         console.info(
           `[runtime-matrix] ${target.id}: ${result.reachable ? 'reachable' : 'unavailable'}${result.error ? ` — ${result.error}` : ''}`
         )
       }
 
-      console.info(`\nREAL local runtime matrix (${results.length} installed):\n${grid(results)}\n`)
+      console.info(`\nREAL local runtime matrix (${results.length} installed):\n${grid(results, features)}\n`)
       for (const result of results) {
-        for (const feature of FEATURES) {
+        for (const feature of features) {
           const outcome = result.features[feature]
           if (outcome?.status === 'fail')
             console.info(`[runtime-matrix] FAIL ${result.id}/${feature}: ${outcome.detail}`)
@@ -516,14 +541,16 @@ describe.skipIf(IS_CI)('local live ACP runtime support matrix', () => {
       }
 
       const failures = results.flatMap((result) =>
-        FEATURES.filter((feature) => result.features[feature]?.status === 'fail').map(
-          (feature) => `${result.id}/${feature}: ${result.features[feature]!.detail}`
-        )
+        features
+          .filter((feature) => result.features[feature]?.status === 'fail')
+          .map((feature) => `${result.id}/${feature}: ${result.features[feature]!.detail}`)
       )
-      expect(
-        results.some((result) => result.features.lifecycle?.status === 'ok'),
-        'no installed runtime completed a real model/provider turn'
-      ).toBe(true)
+      if (features.includes('lifecycle')) {
+        expect(
+          results.some((result) => result.features.lifecycle?.status === 'ok'),
+          'no installed runtime completed a real model/provider turn'
+        ).toBe(true)
+      }
       expect(failures, `real runtime failures:\n${failures.join('\n')}`).toEqual([])
     },
     SUITE_TIMEOUT

--- a/packages/daemon/test/acp-matrix/acp-matrix.test.ts
+++ b/packages/daemon/test/acp-matrix/acp-matrix.test.ts
@@ -16,7 +16,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { AddressInfo } from 'node:net'
 import type { McpServer } from '@agentclientprotocol/sdk'
-import { AcpHost } from '../../src/acp/acp-host.js'
+import { AcpHost, turnFailureCode, turnFailureReason } from '../../src/acp/acp-host.js'
 import { detectSandbox } from '../../src/acp/sandbox.js'
 import { loadConfig } from '../../src/config/load-config.js'
 import type { RuntimeDef } from '../../src/config/config-schema.js'
@@ -154,7 +154,8 @@ function selectAllowOption(params: any): { outcome: { outcome: 'selected'; optio
 }
 
 function providerUnavailable(error: unknown): boolean {
-  const message = (error instanceof Error ? error.message : String(error)).toLowerCase()
+  if (turnFailureCode(error) !== 'turn_failed') return true
+  const message = turnFailureReason(error).toLowerCase()
   return [
     'authentication required',
     'authenticate first',
@@ -165,6 +166,13 @@ function providerUnavailable(error: unknown): boolean {
     'high demand',
     'rate limit'
   ].some((part) => message.includes(part))
+}
+
+function runtimeErrorOutcome(error: unknown): Outcome {
+  return {
+    status: providerUnavailable(error) ? 'unavailable' : 'fail',
+    detail: turnFailureReason(error)
+  }
 }
 
 async function installProbeSkill(
@@ -312,10 +320,12 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
     if (result.models.length >= 2) {
       const from = host.modelOptions()?.current
       const to = result.models.find((model) => model !== from)!
-      const applied = await host.setSessionModel(sessionId, to)
-      result.features['model-switch'] = applied
-        ? { status: 'ok', detail: `${from ?? '?'} -> ${to}` }
-        : { status: 'fail', detail: `runtime rejected model switch to ${to}` }
+      const sent = await host.setSessionModel(sessionId, to)
+      const current = host.modelOptions()?.current
+      result.features['model-switch'] =
+        sent && current === to
+          ? { status: 'ok', detail: `${from ?? '?'} -> ${to}` }
+          : { status: 'fail', detail: `requested ${to}; rpcSent=${sent}, current=${current ?? '?'}` }
     } else {
       result.features['model-switch'] = { status: 'degrade', detail: `${result.models.length} model(s)` }
     }
@@ -323,10 +333,12 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
     if (result.modes.length >= 2) {
       const from = host.permissionModeOptions()?.current
       const to = result.modes.find((mode) => mode !== from)!
-      const applied = await host.setSessionPermissionMode(sessionId, to)
-      result.features['permission-mode-switch'] = applied
-        ? { status: 'ok', detail: `${from ?? '?'} -> ${to}` }
-        : { status: 'fail', detail: `runtime rejected permission-mode switch to ${to}` }
+      const sent = await host.setSessionPermissionMode(sessionId, to)
+      const current = host.permissionModeOptions()?.current
+      result.features['permission-mode-switch'] =
+        sent && current === to
+          ? { status: 'ok', detail: `${from ?? '?'} -> ${to}` }
+          : { status: 'fail', detail: `requested ${to}; rpcSent=${sent}, current=${current ?? '?'}` }
     } else {
       result.features['permission-mode-switch'] = { status: 'degrade', detail: `${result.modes.length} mode(s)` }
     }
@@ -384,9 +396,13 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
       result.features.skills = skillInstall
     }
 
+    // Keep this independent of the permission-mode switch above: modes such as
+    // read-only, plan, or full-access can suppress the permission request itself.
+    const permissionSession = await withTimeout(host.newSession(cwd), `${target.id}/permission session`)
+    permissionRequested = false
     const permissionStart = updates.length
     await withTimeout(
-      host.prompt(sessionId, [
+      host.prompt(permissionSession, [
         {
           type: 'text',
           text: 'Using your file tool, create matrix-permission.txt in the current workspace containing OK, then reply done.'
@@ -403,10 +419,7 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
 
     // Run this independently before the resume/restart phase so a runtime-specific
     // session/load failure cannot masquerade as a sandbox failure.
-    result.features.sandbox = await runSandboxProbe(target, root, sandboxToken).catch((error): Outcome => ({
-      status: 'fail',
-      detail: (error as Error).message
-    }))
+    result.features.sandbox = await runSandboxProbe(target, root, sandboxToken).catch(runtimeErrorOutcome)
 
     if (host.loadSupported()) {
       await host.stop()
@@ -430,7 +443,7 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
       result.features['load-resume'] = { status: 'degrade', detail: 'runtime does not advertise session/load' }
     }
   } catch (error) {
-    result.error = error instanceof Error ? error.message : String(error)
+    result.error = turnFailureReason(error)
     const status: Status = providerUnavailable(error) ? 'unavailable' : 'fail'
     for (const feature of FEATURES) {
       result.features[feature] ??= { status, detail: result.error }
@@ -511,7 +524,7 @@ describe.skipIf(IS_CI)('local live ACP runtime support matrix', () => {
                     target,
                     root,
                     `MATRIX_SANDBOX_OK_${Date.now().toString(36)}`
-                  ).catch((error): Outcome => ({ status: 'fail', detail: (error as Error).message }))
+                  ).catch(runtimeErrorOutcome)
                   return {
                     id: target.id,
                     reachable: true,

--- a/packages/daemon/test/acp-matrix/live/README.md
+++ b/packages/daemon/test/acp-matrix/live/README.md
@@ -20,7 +20,7 @@ send path** — so the daemon itself renders and posts the agent's output into t
      "Permission resolved");
    - **native session resume** is exercised by evicting the live host and dispatching
      again.
-     All 9 matrix feature dimensions, with the agent's REAL data.
+     All 11 matrix feature dimensions, with the agent's REAL data.
 3. Beneath the daemon's own messages, the test posts a structured per-agent verdict
    summary, then a summary table.
 
@@ -30,10 +30,10 @@ hand-posted on the agent's behalf.
 
 ### Feature coverage
 
-`caps · life · model · pmode · load · perm · usage · mem` are driven end-to-end through
-the daemon's Slack path. **elicitation** stays ⚪ n/a — real agents don't emit
-`elicitation/create` on cue; that card path is covered by the scriptable-fixture matrix in
-[`../acp-matrix.test.ts`](../acp-matrix.test.ts). `perm` shows ✓ when an agent actually
+`caps · life · model · pmode · load · perm · usage · mem · sbox · mcp · skills` are
+driven through the daemon's Slack path. `sbox` runs the lifecycle turn inside the
+daemon sandbox when this host supports it; `mcp` records remote transport admission;
+`skills` checks the audited bundled-CLI identity. `perm` shows ✓ when an agent actually
 requested a gated tool (card rendered + resolved) and `·` when it completed without one.
 
 ### Pass/fail

--- a/packages/daemon/test/acp-matrix/live/drive-daemon.ts
+++ b/packages/daemon/test/acp-matrix/live/drive-daemon.ts
@@ -89,6 +89,7 @@ function scaffold(id: string, rt: RuntimeDef, creds: SlackCreds, runInSandbox: b
       status: 'active',
       runtime: id,
       runInSandbox,
+      allowRuntimeChangesInChat: true,
       workspace: { mode: 'from-scratch', path: join(adir, 'ws') },
       output: { mode: 'medium' },
       // Shared mode → the daemon opens a send-only Web-API client (no Socket Mode, no

--- a/packages/daemon/test/acp-matrix/live/drive-daemon.ts
+++ b/packages/daemon/test/acp-matrix/live/drive-daemon.ts
@@ -1,5 +1,5 @@
 // Drive a REAL installed agent through a full Daemon over the daemon's REAL Slack send
-// path, and collect what the daemon observes for each of the 9 matrix feature dimensions.
+// path, and collect what the daemon observes for each matrix feature dimension.
 //
 // Nothing here talks to AcpHost directly and nothing hand-posts the agent's words: the
 // agent is bound to a shared-mode Slack integration (send-only Web-API client, no socket),
@@ -15,10 +15,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { WebClient } from '@slack/web-api'
 import { Daemon } from '../../../src/daemon.js'
+import { detectSandbox } from '../../../src/acp/sandbox.js'
 import { sessionKey } from '../../../src/store/local-store.js'
 import { normalizeSlackEvent } from '../../../src/slack/normalize.js'
 import { decodePermValue, PERMISSION_ACTION_PREFIX } from '../../../src/slack/render.js'
 import type { RuntimeDef } from '../../../src/config/config-schema.js'
+import { skillsAgentIdForRuntime } from '../../../src/runtimes/skills-capability.js'
 import type { FeatureId } from '../support-matrix.js'
 import type { SlackCreds } from './slack-live-harness.js'
 
@@ -71,7 +73,7 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
   ])
 }
 
-function scaffold(id: string, rt: RuntimeDef, creds: SlackCreds): string {
+function scaffold(id: string, rt: RuntimeDef, creds: SlackCreds, runInSandbox: boolean): string {
   const dir = mkdtempSync(join(tmpdir(), `ac-live-${id}-`))
   writeFileSync(
     join(dir, 'config.json'),
@@ -86,6 +88,7 @@ function scaffold(id: string, rt: RuntimeDef, creds: SlackCreds): string {
       name: AGENT,
       status: 'active',
       runtime: id,
+      runInSandbox,
       workspace: { mode: 'from-scratch', path: join(adir, 'ws') },
       output: { mode: 'medium' },
       // Shared mode → the daemon opens a send-only Web-API client (no Socket Mode, no
@@ -107,8 +110,9 @@ function scaffold(id: string, rt: RuntimeDef, creds: SlackCreds): string {
  *  real Slack send path (the daemon posts the agent's replies + status bars to the thread). */
 export async function driveAgentThroughDaemon(id: string, rt: RuntimeDef, ctx: SlackCtx): Promise<AgentResult> {
   const res: AgentResult = { id, reachable: false, features: {} }
+  const sandboxMechanism = detectSandbox()
   const daemon = new Daemon({
-    root: scaffold(id, rt, ctx.creds),
+    root: scaffold(id, rt, ctx.creds, sandboxMechanism !== undefined),
     probeRuntimes: async () => []
   })
   const d = daemon as any
@@ -188,6 +192,17 @@ export async function driveAgentThroughDaemon(id: string, rt: RuntimeDef, ctx: S
       status: 'ok',
       detail: `${models.length} models, ${modes.length} permission modes, loadSession=${res.loadSession}, mcp=http:${res.mcp.http}/sse:${res.mcp.sse}`
     }
+    res.features.sandbox = sandboxMechanism
+      ? { status: 'ok', detail: `lifecycle turn completed inside the daemon ${sandboxMechanism} sandbox` }
+      : { status: 'degrade', detail: 'host has no supported sandbox mechanism; daemon ran unconfined' }
+    res.features.mcp =
+      res.mcp.http || res.mcp.sse
+        ? { status: 'ok', detail: `remote transports: http=${res.mcp.http}, sse=${res.mcp.sse}` }
+        : { status: 'degrade', detail: 'no remote MCP transport advertised; stdio remains available' }
+    const skillsAgentId = skillsAgentIdForRuntime(id, rt)
+    res.features.skills = skillsAgentId
+      ? { status: 'ok', detail: `audited skills CLI identity: ${skillsAgentId}` }
+      : { status: 'degrade', detail: 'runtime has not passed skills CLI compatibility admission' }
     const used = cap?.totalTokens
     res.usageTokens = used
     res.usageCost = cap?.costAmount
@@ -259,13 +274,6 @@ export async function driveAgentThroughDaemon(id: string, rt: RuntimeDef, ctx: S
         status: 'na',
         detail: `perm turn: ${(e as Error).message.slice(0, 80)}`
       }
-    }
-
-    // ── elicitation: real agents don't emit elicitation/create on cue; the daemon's
-    //    Slack elicitation card path is covered by the fixture matrix. ─────────────
-    res.features.elicitation = {
-      status: 'na',
-      detail: 'agents do not elicit on cue — card path covered by fixture matrix'
     }
 
     // ── load-resume: evict the live host, then dispatch again; the daemon resumes

--- a/packages/daemon/test/acp-matrix/live/slack-live.test.ts
+++ b/packages/daemon/test/acp-matrix/live/slack-live.test.ts
@@ -19,14 +19,10 @@ import { FEATURES, type FeatureId } from '../support-matrix.js'
  * the thread; `handleStatusAction`/`statusInfoForKey` do the real model + permission-mode
  * switching (the new model shows up in the daemon's status bar); a tool-triggering turn
  * makes the daemon post a real Allow/Deny CARD which we resolve via `handlePermissionChoice`;
- * and native session resume is exercised by evicting the host. All 9 matrix feature
+ * and native session resume is exercised by evicting the host. All matrix feature
  * dimensions, with the agent's REAL data. Each agent's structured verdicts are posted as a
  * summary reply beneath the daemon's own messages; a table follows. Skipped unless
  * AC_LIVE_SLACK_* are set.
- *
- * Elicitation stays ⚪ n/a — real agents don't emit elicitation/create on cue; that card
- * path is covered by the scriptable-fixture matrix in ../acp-matrix.test.ts.
- *
  * Run: GITHUB_ACTIONS=true pnpm --filter @agentconnect.md/daemon exec \
  *        vitest run test/acp-matrix/live/slack-live.test.ts
  */
@@ -38,9 +34,11 @@ const SHORT: Record<FeatureId, string> = {
   'permission-mode-switch': 'pmode',
   'load-resume': 'load',
   'interactive-permission': 'perm',
-  elicitation: 'elicit',
   'usage-fold': 'usage',
-  memory: 'mem'
+  memory: 'mem',
+  sandbox: 'sbox',
+  mcp: 'mcp',
+  skills: 'skills'
 }
 const CELL: Record<FeatureOutcome['status'], string> = { ok: '✓', degrade: '·', na: '~', fail: '✗' }
 const sw = (s?: { from?: string; to?: string; applied: boolean }) =>
@@ -94,7 +92,7 @@ function agentDetail(r: AgentResult): string {
     `• *usage:* ${r.usageTokens !== undefined ? `${r.usageTokens} tokens${r.usageCost ? ` ($${r.usageCost.toFixed(4)})` : ''}` : 'none'}  ·  *loadSession:* ${r.loadSession}  ·  *mcp:* http=${r.mcp?.http}/sse=${r.mcp?.sse}`
   )
   L.push(
-    `• *resume:* ${resumed(r) ? '✅' : '❌'}  ·  *permission:* ${perm}  ·  *elicitation:* n/a  ·  *memory:* ${r.memoryViaMeta ? '_meta.systemPrompt (Claude)' : 'inlined block'}`
+    `• *resume:* ${resumed(r) ? '✅' : '❌'}  ·  *permission:* ${perm}  ·  *memory:* ${r.memoryViaMeta ? '_meta.systemPrompt (Claude)' : 'inlined block'}`
   )
   return L.join('\n')
 }
@@ -121,7 +119,7 @@ function summaryBlocks(results: AgentResult[]): unknown[] {
 }
 
 describe.skipIf(!creds)('live e2e: real installed ACP agents driven through the daemon → Slack', () => {
-  it('launches every installed agent through the daemon, exercises all 9 features, reports to the thread', async () => {
+  it('launches every installed agent through the daemon, exercises the support matrix, reports to the thread', async () => {
     const thread = new SlackThread(creds!)
     const threadTs = await thread.open(`acp integration tests - ${new Date().toISOString()}`)
     // Real user id stamped on each injected trigger, so the daemon treats it as a

--- a/packages/daemon/test/acp-matrix/profiles.ts
+++ b/packages/daemon/test/acp-matrix/profiles.ts
@@ -70,6 +70,8 @@ export interface ExpectedCaps {
   permissionModes: string[] | null
   /** Whether `prompt()` should return a `usage` object. */
   usage: boolean
+  /** Audited identity accepted by the daemon's exact bundled skills CLI. */
+  skillsAgentId: string | null
 }
 
 export interface Profile {
@@ -118,7 +120,8 @@ export const PROFILES: Profile[] = [
       promptImage: true,
       models: ['opus', 'sonnet', 'haiku'],
       permissionModes: ['default', 'plan'],
-      usage: true
+      usage: true,
+      skillsAgentId: 'claude-code'
     }
   },
   {
@@ -143,7 +146,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: ['gpt-5-codex', 'gpt-5'],
       permissionModes: ['agent', 'read-only'],
-      usage: true
+      usage: true,
+      skillsAgentId: 'codex'
     }
   },
   {
@@ -161,7 +165,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: null,
       permissionModes: null,
-      usage: false
+      usage: false,
+      skillsAgentId: 'pi'
     }
   },
   {
@@ -183,7 +188,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: ['cursor-fast', 'cursor-max'],
       permissionModes: null,
-      usage: true
+      usage: true,
+      skillsAgentId: 'cursor'
     }
   },
   {
@@ -207,7 +213,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: ['anthropic/sonnet', 'openai/gpt-5'],
       permissionModes: ['build', 'plan'],
-      usage: false
+      usage: false,
+      skillsAgentId: 'opencode'
     }
   },
   {
@@ -228,7 +235,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: ['claude-sonnet', 'deepseek'],
       permissionModes: null,
-      usage: false
+      usage: false,
+      skillsAgentId: 'cline'
     }
   },
   {
@@ -255,7 +263,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: null,
       permissionModes: null,
-      usage: false
+      usage: false,
+      skillsAgentId: 'devin'
     }
   },
   {
@@ -277,7 +286,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: ['grok-code', 'grok-4'],
       permissionModes: null,
-      usage: true
+      usage: true,
+      skillsAgentId: 'grok'
     }
   },
   {
@@ -298,7 +308,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: ['claude-sonnet', 'openrouter/auto'],
       permissionModes: null,
-      usage: false
+      usage: false,
+      skillsAgentId: 'hermes-agent'
     }
   },
   {
@@ -319,7 +330,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: ['openai/gpt-5', 'anthropic/sonnet'],
       permissionModes: null,
-      usage: false
+      usage: false,
+      skillsAgentId: null
     }
   },
   {
@@ -342,7 +354,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: ['auto', 'claude-sonnet'],
       permissionModes: null,
-      usage: false
+      usage: false,
+      skillsAgentId: 'kiro-cli'
     }
   },
   {
@@ -361,7 +374,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: null,
       permissionModes: null,
-      usage: false
+      usage: false,
+      skillsAgentId: null
     }
   },
   {
@@ -379,7 +393,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: null,
       permissionModes: null,
-      usage: false
+      usage: false,
+      skillsAgentId: null
     }
   },
   {
@@ -405,7 +420,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: ['anthropic/sonnet', 'openai/gpt-5'],
       permissionModes: ['default', 'plan'],
-      usage: true
+      usage: true,
+      skillsAgentId: null
     }
   },
   {
@@ -425,26 +441,8 @@ export const PROFILES: Profile[] = [
       promptImage: false,
       models: null,
       permissionModes: null,
-      usage: false
-    }
-  },
-  {
-    // Qoder CN CLI (@qodercn-ai/qoderclicn) — same fork/brand for the China
-    // region via `qoderclicn --acp`; identical managed-only contract.
-    id: 'qoder-cli-cn',
-    registryId: 'qoder-cli-cn',
-    memory: {
-      runtime: runtime('qoderclicn', ['--acp']),
-      expected: { managed: true, none: false, native: false }
-    },
-    scenario: { agentCapabilities: {}, prompt: {} },
-    caps: {
-      loadSession: false,
-      mcp: { http: false, sse: false },
-      promptImage: false,
-      models: null,
-      permissionModes: null,
-      usage: false
+      usage: false,
+      skillsAgentId: 'qoder'
     }
   }
 ]

--- a/packages/daemon/test/acp-matrix/support-matrix.ts
+++ b/packages/daemon/test/acp-matrix/support-matrix.ts
@@ -16,9 +16,11 @@ export type FeatureId =
   | 'permission-mode-switch'
   | 'load-resume'
   | 'interactive-permission'
-  | 'elicitation'
   | 'usage-fold'
   | 'memory'
+  | 'sandbox'
+  | 'mcp'
+  | 'skills'
 
 export function verdictFor(feature: FeatureId, p: Profile): Verdict {
   switch (feature) {
@@ -26,7 +28,8 @@ export function verdictFor(feature: FeatureId, p: Profile): Verdict {
     case 'capabilities':
     case 'lifecycle':
     case 'interactive-permission':
-    case 'elicitation':
+    case 'sandbox':
+    case 'memory':
       return 'run'
     case 'model-switch':
       return (p.caps.models?.length ?? 0) >= 2 ? 'run' : 'degrade'
@@ -36,10 +39,10 @@ export function verdictFor(feature: FeatureId, p: Profile): Verdict {
       return p.caps.loadSession ? 'run' : 'degrade'
     case 'usage-fold':
       return p.caps.usage ? 'run' : 'degrade'
-    case 'memory':
-      // Claude carries the fresh-session memory index via _meta.systemPrompt; other
-      // runtimes have no such channel and the daemon inlines it instead ('degrade').
-      return p.claudeRuntime ? 'run' : 'degrade'
+    case 'mcp':
+      return p.caps.mcp.http || p.caps.mcp.sse ? 'run' : 'degrade'
+    case 'skills':
+      return p.caps.skillsAgentId ? 'run' : 'degrade'
   }
 }
 
@@ -50,7 +53,9 @@ export const FEATURES: FeatureId[] = [
   'permission-mode-switch',
   'load-resume',
   'interactive-permission',
-  'elicitation',
   'usage-fold',
-  'memory'
+  'memory',
+  'sandbox',
+  'mcp',
+  'skills'
 ]


### PR DESCRIPTION
## What changed

- replace the fixture-driven ACP support matrix with a local-only live matrix that launches installed runtimes and calls their configured model providers
- add real probes for lifecycle, model and permission-mode switching, resume, permission requests, usage, memory, sandboxing, HTTP MCP, and skills
- exclude `qoder-cli-cn`, add sandbox/MCP/skills coverage to the Slack live matrix, and remove the non-deterministic elicitation column
- add target filtering plus a sandbox-only diagnostic mode with optional child-runtime stderr
- skip the live runtime matrix in CI while keeping it available in normal local runs and through `test:runtime-matrix`

## Why

The previous matrix exercised scriptable fixtures, so its output described expected profiles rather than the actual runtimes, credentials, sandboxes, and model providers installed on a developer machine. The new matrix reports only observed live behavior and fails on genuine runtime errors.

## Impact

Developers can generate an evidence-based compatibility matrix locally. Logged-out, quota-limited, and rate-limited providers are reported as unavailable instead of fabricated passes. CI remains deterministic and does not launch external runtimes or consume model usage.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- Prettier and `git diff --check`
- pre-commit formatting hooks
- pre-push `eslint .`
- CI-mode Vitest check: live matrix skipped
- full live run across 11 installed runtimes
- focused live retries for Claude ACP and Qoder CLI
- isolated Claude sandbox diagnostic retry (reproduces a provider prompt timeout inside the nested sandbox/proxy path)
