### PR TITLE
fix: report A2A sessions and replies

### DIFF
--- a/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.test.ts
+++ b/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AgentId } from '../../domain/ids.js'
+import { PgWebchatConversationRepo } from './webchat-conversation.repo.js'
+
+describe('PgWebchatConversationRepo synthetic coordinates', () => {
+  it('treats an A2A channel as absent instead of querying UUID-backed tables', async () => {
+    const findMany = vi.fn()
+    const findFirst = vi.fn()
+    const repo = new PgWebchatConversationRepo({
+      webchatConversationAgent: { findMany },
+      webchatConversation: { findFirst }
+    } as never)
+    const channel = 'a2a:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+    await expect(repo.participants(channel)).resolves.toEqual([])
+    await expect(repo.findOwner(channel, AgentId('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'))).resolves.toBeNull()
+    expect(findMany).not.toHaveBeenCalled()
+    expect(findFirst).not.toHaveBeenCalled()
+  })
+})

--- a/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.ts
@@ -11,6 +11,12 @@ import type { PrismaLike } from '../prisma.js'
 import type { WebchatConversationBinding, WebchatConversationRepo, WebchatParticipant } from '../ports.js'
 import { AgentId, type OrgId } from '../../domain/ids.js'
 
+/** CP-minted webchat conversation ids are UUIDs. Daemon-local A2A children can
+ * retain `platform: webchat` while using an `a2a:<caller>` channel; repository
+ * reads must treat that synthetic coordinate as a miss instead of handing it to
+ * a UUID-backed Prisma column. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export class PgWebchatConversationRepo implements WebchatConversationRepo {
   constructor(private readonly db: PrismaLike) {}
 
@@ -51,6 +57,7 @@ export class PgWebchatConversationRepo implements WebchatConversationRepo {
   }
 
   async participants(conversationId: string): Promise<WebchatParticipant[]> {
+    if (!UUID_RE.test(conversationId)) return []
     const rows = await this.db.webchatConversationAgent.findMany({
       where: { conversationId },
       orderBy: { ord: 'asc' },
@@ -81,6 +88,7 @@ export class PgWebchatConversationRepo implements WebchatConversationRepo {
   }
 
   async findOwner(conversationId: string, agentId: AgentId): Promise<string | null> {
+    if (!UUID_RE.test(conversationId)) return null
     const row = await this.db.webchatConversation.findFirst({
       where: {
         id: conversationId,

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -175,6 +175,36 @@ describe('handleEventSession', () => {
     )
   })
 
+  it('inherits an A2A webchat child without treating its synthetic channel as a conversation UUID', async () => {
+    const recordMilestone = vi
+      .fn()
+      .mockResolvedValue(recorded({ parentSessionId: 'parent-session', visibilitySource: 'inherited_pending' }))
+    const findOwner = vi.fn().mockRejectedValue(new Error('must not query a synthetic A2A channel'))
+    const deps = scopedDeps({
+      session: { recordMilestone },
+      webchatConversation: { findOwner },
+      events: { publish: vi.fn() }
+    })
+    const frame = eventSessionFrame()
+    Object.assign(frame.payload as Record<string, unknown>, {
+      platform: 'webchat',
+      channel: `a2a:${AGENT_ID}`,
+      parentSessionId: 'parent-session'
+    })
+
+    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(findOwner).not.toHaveBeenCalled()
+    expect(recordMilestone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentSessionId: 'parent-session',
+        platform: 'webchat',
+        channel: `a2a:${AGENT_ID}`,
+        classification: { inherit: true }
+      })
+    )
+  })
+
   it('binds a Slack audience only after validating its integration and workspace', async () => {
     const recordMilestone = vi.fn().mockResolvedValue(recorded())
     const deps = scopedDeps({

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -32,7 +32,12 @@ import { runForReportingAgent } from './reporting-agent.js'
  */
 async function classifyMilestone(p: EventSession, agentId: AgentId, deps: DaemonWsDeps) {
   const webchatOwnerUserId =
-    p.platform === 'webchat' && p.channel
+    // An A2A child uses a daemon-minted `a2a:<caller>` channel even when the
+    // parent transport is webchat. Its audience comes exclusively from the
+    // parent lineage, so treating that synthetic coordinate as a CP-minted
+    // webchat UUID both adds no authority and can make the UUID-backed lookup
+    // reject the whole durable metadata snapshot.
+    !p.parentSessionId && p.platform === 'webchat' && p.channel
       ? ((await deps.webchatConversation?.findOwner(p.channel, agentId)) ?? null)
       : null
   const launchOwnerUserId = p.launchCorrelationId

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7941,7 +7941,7 @@ export class Daemon {
       channel: sessionChannel,
       ...(thread !== undefined ? { thread } : {}),
       sender: { id: msg.trustedFromAgentId, isBot: true },
-      // The forwarded text already names the caller (`@caller: …`, built on the caller's
+      // The forwarded text already names the caller (`From <caller>: …`, built on the caller's
       // daemon in prepareAgentDelivery) — deliver it as-is. Re-wrapping it here would
       // double-frame it AND leak the caller's raw agentId, which the caller can't resolve
       // for a remote peer anyway.
@@ -8028,7 +8028,10 @@ export class Daemon {
     text: string
   } {
     const callerLabel = this.agentDisplayLabel(req.callerAgentId)
-    const deliverText = `@${callerLabel}: ${req.text}`
+    // `@Caller:` reads like an instruction addressed TO the caller and can make
+    // the callee's no-response rule suppress a legitimate direct call. Use an
+    // explicit sender label instead; trusted CallMeta remains the authority.
+    const deliverText = `From ${callerLabel}: ${req.text}`
     const deliveryId = monotonicTs()
     const thread = req.thread ?? deliveryId
     return { deliveryId, thread, text: deliverText }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12386,6 +12386,9 @@ export class Daemon {
         callMeta?.needsReply,
         {
           initializeOnly,
+          // CallMeta is the trusted distinction between a real A2A delivery and
+          // synthetic `source: agent` wakes (background task/orchestration).
+          directAgentCall: callMeta !== undefined,
           // Memory READS (index injection + auto-recall) are no longer session-
           // gated — every session may use shared memory (#653). WRITES stay gated
           // (memory write tools via memoryAccessAllowed; post-turn distillation via

--- a/packages/daemon/src/session/no-response.ts
+++ b/packages/daemon/src/session/no-response.ts
@@ -53,6 +53,16 @@ export const EXPLICIT_MENTION_REMINDER =
   `do not return ${NO_RESPONSE_SENTINEL} merely because of that ID mismatch.\n` +
   `</system-reminder>`
 
+/** Trusted routing context for a daemon-delivered agent call. The payload may
+ * quote or discuss any agent, so the model must not reinterpret names in the
+ * body as evidence that the activation belongs to someone else. */
+export const DIRECT_AGENT_CALL_REMINDER =
+  `<system-reminder>\n` +
+  `Routing fact: This activation is a trusted direct agent call addressed to you. A leading ` +
+  `\`From <agent>:\` label identifies the caller; it does not address that agent. Follow the request and respond ` +
+  `normally. Do not return ${NO_RESPONSE_SENTINEL} merely because the body names or discusses another agent.\n` +
+  `</system-reminder>`
+
 /** True while `trimmedBody` could still become the bare sentinel as more chunks stream
  *  in — i.e. it is a prefix of (or exactly) the sentinel. Convergers use this to HOLD
  *  buffered body instead of posting it, so a streamed sentinel never leaks a partial

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -19,7 +19,12 @@ import {
   hydrateTranscriptImage,
   transcriptImageAttachments
 } from './attachment-block.js'
-import { EXPLICIT_MENTION_REMINDER, NO_RESPONSE_RULE, NO_RESPONSE_REMINDER } from './no-response.js'
+import {
+  DIRECT_AGENT_CALL_REMINDER,
+  EXPLICIT_MENTION_REMINDER,
+  NO_RESPONSE_RULE,
+  NO_RESPONSE_REMINDER
+} from './no-response.js'
 
 /** Metadata-only semantic lifecycle for one provider-neutral recall attempt. Query
  * and recalled record bodies deliberately stay out of this observer contract. */
@@ -1187,7 +1192,7 @@ export class SessionManager {
         // trigger in the same `[sender] text` shape as thread context — otherwise the agent has
         // no idea WHO is speaking and must guess from ambient account context. Synthetic
         // (cron/hook) triggers stay bare, and an agent delivery already names its caller in the
-        // forwarded text (`@caller: …` from prepareAgentDelivery).
+        // forwarded text (`From <caller>: …` from prepareAgentDelivery).
         blocks.push({ type: 'text', text: msg.source === 'user' ? `[${msg.sender.id}] ${msg.text}` : msg.text })
         contextEventTs = [...context.map((entry) => entry.ts), ts]
       }
@@ -1332,6 +1337,12 @@ export class SessionManager {
       // carries the full rule (the `created` branch / Claude's system-prompt append), so this
       // fires only on later turns. Placed first, ahead of the catch-up context + message.
       promptPrelude.push({ type: 'text', text: NO_RESPONSE_REMINDER })
+    }
+    // A trusted direct agent call is addressed to this agent regardless of names
+    // or quoted mentions in its body. State that routing fact per turn so the
+    // generic no-response rule cannot mistake the caller label for an addressee.
+    if (msg.source === 'agent') {
+      promptPrelude.push({ type: 'text', text: DIRECT_AGENT_CALL_REMINDER })
     }
     // The router has already matched the raw platform token against THIS integration's
     // resolved bot identity. Preserve that trusted fact for the model: an opaque Slack

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -383,6 +383,10 @@ export class SessionManager {
      *  It is already recorded in the transcript and must not become a model activation. */
     options: {
       initializeOnly?: boolean
+      /** True only when the daemon attached trusted CallMeta for this turn.
+       * `source: agent` alone is insufficient: background-task and orchestration
+       * wakes deliberately use that source without being direct agent calls. */
+      directAgentCall?: boolean
       /** Trusted daemon-owned host override for a conversation-isolated webchat
        * cell. Never derived from model/session input. */
       host?: AcpHost
@@ -1341,7 +1345,7 @@ export class SessionManager {
     // A trusted direct agent call is addressed to this agent regardless of names
     // or quoted mentions in its body. State that routing fact per turn so the
     // generic no-response rule cannot mistake the caller label for an addressee.
-    if (msg.source === 'agent') {
+    if (options.directAgentCall === true) {
       promptPrelude.push({ type: 'text', text: DIRECT_AGENT_CALL_REMINDER })
     }
     // The router has already matched the raw platform token against THIS integration's

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -248,7 +248,7 @@ describe('messageAgent: same-daemon delivery', () => {
     expect(msg.thread).toBe('100.1')
     expect(msg.sender).toEqual({ id: 'bot-a', isBot: true })
     // The delivered text names the caller (an isolated callee sees only this).
-    expect(msg.text).toBe('@bot-a: do the thing')
+    expect(msg.text).toBe('From bot-a: do the thing')
     expect(msg.msgId).toMatch(/^agentcall:C1:\d+$/)
     expect(callMeta).toMatchObject({ callFrom: 'bot-a' })
     expect(callMeta.deliveryId).toBe(msg.msgId.split(':').pop())

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -2009,6 +2009,25 @@ describe('SessionManager — collaboration preamble', () => {
     }
   })
 
+  it('marks every trusted direct agent call as addressed to the current agent', async () => {
+    const store = newStore()
+    const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    const { blocks } = await sm.handle(
+      'bot-a',
+      msg({ ts: '100.1', source: 'agent', sender: { id: 'bot-b', isBot: true }, text: 'From bot-b: hello' })
+    )
+
+    expect(blocks).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('trusted direct agent call addressed to you')
+      }),
+      { type: 'text', text: 'From bot-b: hello' }
+    ])
+    store.close()
+  })
+
   it('marks a raw platform self-mention as explicitly addressed to this agent', async () => {
     const store = newStore()
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -2015,7 +2015,13 @@ describe('SessionManager — collaboration preamble', () => {
     const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
     const { blocks } = await sm.handle(
       'bot-a',
-      msg({ ts: '100.1', source: 'agent', sender: { id: 'bot-b', isBot: true }, text: 'From bot-b: hello' })
+      msg({ ts: '100.1', source: 'agent', sender: { id: 'bot-b', isBot: true }, text: 'From bot-b: hello' }),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { directAgentCall: true }
     )
 
     expect(blocks).toEqual([
@@ -2025,6 +2031,24 @@ describe('SessionManager — collaboration preamble', () => {
       }),
       { type: 'text', text: 'From bot-b: hello' }
     ])
+    store.close()
+  })
+
+  it('does not mark a synthetic agent-source wake as a direct agent call', async () => {
+    const store = newStore()
+    const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    const { blocks } = await sm.handle(
+      'bot-a',
+      msg({
+        ts: '100.1',
+        source: 'agent',
+        sender: { id: 'background-task:task-1', isBot: true },
+        text: '[background task finished] task-1'
+      })
+    )
+
+    expect(blocks).toEqual([{ type: 'text', text: '[background task finished] task-1' }])
     store.close()
   })
 


### PR DESCRIPTION
## Summary

- keep A2A webchat child-session metadata sync from querying synthetic channels as UUID conversation IDs
- treat synthetic A2A coordinates as absent in webchat conversation repository reads
- make direct agent-call framing unambiguous and remind the callee that trusted agent calls are addressed to it

## Root cause

Agent B was successfully launched and completed locally, but its durable session metadata remained in the daemon outbox. The control plane attempted a webchat owner lookup using the child session's `a2a:<caller>` channel against a UUID column, so the snapshot was rejected and never ACKed. Separately, the forwarded `@Agent A:` label looked like an addressee instead of a sender, causing Agent B to choose the no-response sentinel.

## Validation

- control-plane focused tests: 18 passed
- daemon focused tests: 203 passed
- control-plane and daemon typecheck passed
- ESLint passed for all changed files
