### PR TITLE
fix(web): include related agents in session focus

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -68,7 +68,12 @@ import { formatTranscriptRowTime, transcriptRowTimeMs } from '@/lib/transcript-t
 import { sessionResumeMembers, sessionResumeState } from '@/lib/session-resume'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { consoleKeys } from '@/lib/swr-keys'
-import { sessionAttributionAgentAuthors, sessionAttributionAgentId, sessionSenderLabel } from '@/lib/session-trigger'
+import {
+  sessionAttributionAgentAuthors,
+  sessionAttributionAgentId,
+  sessionSenderLabel,
+  sessionTranscriptAgentIds
+} from '@/lib/session-trigger'
 import { platformTranscriptOrdering } from '@/components/console/platforms/registry'
 import { mergeSessionMessages } from '@/lib/session-transcript'
 import { useStickToBottom } from '@/lib/stick-to-bottom'
@@ -1419,6 +1424,18 @@ export default function SessionDetailView() {
       : sessionBase
   const agentRuntime = session?.runtime || owner?.runtime || ''
 
+  // A non-flat single-session transcript can contain messages from visible A2A
+  // relatives without becoming a same-coordinate merged conversation. Surface
+  // only related Agents that actually authored a row here; unrelated lineage
+  // stays out of the focus menu, while `view=flat` keeps the owning Agent alone.
+  const relatedTranscriptAgentIds = useMemo(
+    () =>
+      !flatView && !conversationKey && transcriptSessionId === id && msgs
+        ? sessionTranscriptAgentIds(session?.platform ?? '', msgs, agentById)
+        : new Set<string>(),
+    [agentById, conversationKey, flatView, id, msgs, session?.platform, transcriptSessionId]
+  )
+
   // Header focus is presentation-only: it selects which participant owns the
   // Workspace, Visibility, and Details affordances without changing the merged
   // transcript or the conversation-wide composer target.
@@ -1453,6 +1470,18 @@ export default function SessionDetailView() {
       })
     }
 
+    if (!flatView && !conversationKey && currentSessionDetail) {
+      const related = [
+        currentSessionDetail.parentSession,
+        ...(currentSessionDetail.siblingSessions ?? []),
+        ...currentSessionDetail.childSessions
+      ]
+      for (const relation of related) {
+        if (!relation || !relatedTranscriptAgentIds.has(relation.agentId)) continue
+        candidates.push({ agentId: relation.agentId, sessionId: relation.id })
+      }
+    }
+
     const seen = new Set<string>()
     return candidates.flatMap((candidate) => {
       if (!candidate.agentId || seen.has(candidate.agentId)) return []
@@ -1476,7 +1505,16 @@ export default function SessionDetailView() {
         }
       ]
     })
-  }, [agentById, conversationMembers, orgPath, session])
+  }, [
+    agentById,
+    conversationKey,
+    conversationMembers,
+    currentSessionDetail,
+    flatView,
+    orgPath,
+    relatedTranscriptAgentIds,
+    session
+  ])
   // The persistent layout survives route-to-route navigation without remounting
   // this view. Scope the selection to the current route target so it supersedes
   // the last explicit menu choice, while ordinary rerenders keep the selection.

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -12,6 +12,7 @@ import {
   sessionAttributionAgentAuthors,
   sessionAttributionAgentId,
   sessionSenderLabel,
+  sessionTranscriptAgentIds,
   sessionTriggerFilterValue,
   sessionTriggerKind
 } from './session-trigger'
@@ -288,6 +289,24 @@ describe('legacy Slack Agent attribution', () => {
     expect(authors.get('U0BOTUSER')).toBe('review-id')
     expect(authors.has('B0SHARED')).toBe(false)
     expect(authors.has('B0UNTRUSTED')).toBe(false)
+  })
+
+  it('finds visible transcript authors from direct ids and trusted Slack attribution', () => {
+    const agents = new Set(['direct-id', 'review-id'])
+    const reviewFooter =
+      'done\nsent by <https://test.example.test/team/agents/review-id|review-bot> (Codex) · <https://test.example.test/sessions/1|open in session>'
+
+    expect([
+      ...sessionTranscriptAgentIds(
+        'slack',
+        [
+          { sender: 'direct-id', text: 'Direct A2A reply' },
+          { sender: 'B0REVIEW', text: reviewFooter, trustedAgentBot: true },
+          { sender: 'hidden-id', text: 'Not in the visible Agent directory' }
+        ],
+        agents
+      )
+    ]).toEqual(['direct-id', 'review-id'])
   })
 })
 

--- a/packages/web/src/lib/session-trigger.ts
+++ b/packages/web/src/lib/session-trigger.ts
@@ -46,6 +46,24 @@ export function sessionAttributionAgentAuthors(
   return new Map([...candidates].flatMap(([sender, ids]) => (ids.size === 1 ? [[sender, [...ids][0]!] as const] : [])))
 }
 
+/** Visible Agents that authored rows in this transcript. Direct A2A deliveries
+ * carry the Agent id as `sender`; legacy Slack rows recover it from the same
+ * trusted attribution used by the message renderer. */
+export function sessionTranscriptAgentIds(
+  platform: string,
+  messages: readonly { sender: string; text: string; trustedAgentBot?: boolean }[],
+  agentIds: IdLookup
+): ReadonlySet<string> {
+  const attributed = sessionAttributionAgentAuthors(platform, messages, agentIds)
+  const authors = new Set<string>()
+  for (const message of messages) {
+    if (agentIds.has(message.sender)) authors.add(message.sender)
+    const attributedId = attributed.get(message.sender)
+    if (attributedId) authors.add(attributedId)
+  }
+  return authors
+}
+
 export function sessionTriggerFilterValue(trigger: {
   value: string
   hookKind?: 'webhook' | 'github'


### PR DESCRIPTION
## Summary

- include visible A2A-related agents in the non-flat session focus menu when they authored the displayed transcript
- resolve each added agent to its related session so Workspace, visibility, and Details continue to follow the focused agent
- preserve `view=flat` as an owner-only diagnostic view and leave unrelated lineage out of the menu

## Root cause

The session header built its focus options only from same-coordinate conversation members or the durable webchat roster. Postless A2A children are represented through session lineage instead, so Agent B could appear correctly in Agent A's transcript without appearing in the non-flat header.

## Validation

- `pnpm --filter @agentconnect.md/web test` (111 files, 876 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web build`
- pre-push `eslint .`

Created by Codex . GPT-5.6
