### PR TITLE
feat(evals): make Werewolf actions ordinary messages, and revert the daemon auto-allow widening

### DIFF
--- a/docs/designs/collaboration-arena-baseline.md
+++ b/docs/designs/collaboration-arena-baseline.md
@@ -120,9 +120,33 @@ and consecutive posts rather than policing them.
 
 Seven agents by default, seeded roles (2 werewolves, 1 seer, 1 doctor, villagers
 for the rest — the table scales past seven), a public room, a **real private wolf
-den**, and per-player referee DMs. Public discussion is ordinary natural-language
-speech; game-state mutations (`vote`, `inspect`, `protect`, `kill`) go through the
-§6 evaluation tool registry as structured actions over the real MCP socket.
+den**, and per-player referee DMs.
+
+**Every action is an ordinary message in the conversation it belongs to.** The
+game registers no evaluation tools at all; the referee parses intent out of what
+players actually say, where a human moderator would hear it:
+
+| Action              | Conversation                  |
+| ------------------- | ----------------------------- |
+| `vote`              | the public day room, out loud |
+| `kill`              | the wolf den, by the wolves   |
+| `inspect`/`protect` | the actor's own referee DM    |
+
+This replaced structured MCP tool calls, and the reason is that the tool channel
+was **out of band with respect to the system under test**: a tool call never
+traversed routing, produced no thread message, spent no automatic-turn budget,
+and made the leak assertions weak because role visibility came from tool privacy
+rather than from conversation membership. As messages, every action rides the
+real path, and _a non-wolf literally cannot state a kill_ — the world's §7.2
+authorization refuses the post before any parsing happens.
+
+Parsing is deliberately strict and never coached: an action verb must be followed
+by exactly one player alias inside the same sentence. Two different targets is
+**ambiguous** and yields nothing. An actor that spoke in the right conversation
+but never stated a readable action is recorded `unparseable`; one that never
+spoke is `silent`. Neither is retried — stating your action clearly the first
+time is part of what is measured. Authorization (phase, role, aliveness, one per
+round) is unchanged, applied to the parsed intent.
 
 **The day phase is sequential and peer-driven.** The referee opens each day
 exactly once — deaths, living players, the speaking order, and the rule "speak
@@ -142,16 +166,14 @@ out-of-order speeches, what ended the round (`order_complete` / `stalled`), whic
 players' loop-guard circuits latched, per-player peer-wake accounting
 (`admitted` / `gated` / `suppressed`), and whether the round reached the vote.
 
-The vote is unchanged: once the discussion completes or dies, the referee asks
-the living players for structured `vote` tool calls, and a vote attempted during
-discussion is rejected with `discussion_in_progress`.
+Once discussion completes or dies, the referee asks the living players to say
+their votes out loud. Reasoning about voting _during_ discussion is ordinary
+conversation and is not counted — the referee only reads votes once it has asked
+for them.
 
-The registry enforces at the daemon: startup name-collision rejection (an
-evaluation tool may never shadow a product tool), a per-agent visibility
-predicate, and dispatch on the **trusted token-bound** `SessionContext` — never
-tool-input-supplied identity. Role-appropriate authorization, aliveness, phase
-correctness, and idempotence per `(round, action)` are the game's job in the
-handler.
+The §6 evaluation tool registry still exists as a product capability and is
+still covered by `packages/daemon/test/evaluation-game-tools.test.ts` — Werewolf
+simply no longer uses it.
 
 **Aliveness is enforced in the handler, not in visibility.** The current
 `visibleTo` predicate admits every configured player, and dead players remain in
@@ -180,7 +202,7 @@ pnpm install
 pnpm build # protocol must be built before typecheck
 
 # the whole arena gate
-pnpm eval:collab:contracts # 15 files, 109 tests
+pnpm eval:collab:contracts # 15 files, 113 tests
 
 # the routing acceptance cases alone
 pnpm eval:collab:routing # routing-acceptance + connection-surface
@@ -207,7 +229,7 @@ Full gate, measured on this branch:
 | ------------------------------------------------------ | ------- |
 | `evals/test/routing-acceptance.test.ts`                | 8       |
 | `evals/test/game-runner.test.ts`                       | 5       |
-| `evals/test/werewolf.test.ts`                          | 12      |
+| `evals/test/werewolf.test.ts`                          | 16      |
 | `evals/test/quota-counting.test.ts`                    | 8       |
 | `evals/test/cross-room-counting.test.ts`               | 6       |
 | `evals/test/counting.test.ts`                          | 11      |
@@ -220,7 +242,7 @@ Full gate, measured on this branch:
 | `evals/test/virtual-connections.test.ts`               | 4       |
 | `packages/daemon/test/evaluation-game-ingress.test.ts` | 5       |
 | `packages/daemon/test/evaluation-game-tools.test.ts`   | 3       |
-| **Total**                                              | **109** |
+| **Total**                                              | **113** |
 
 **0 expected-fail.** Every pin is an ordinary assertion.
 
@@ -412,6 +434,76 @@ confirm no private content reached the public room.
 admitted automatic turns and trial 3 spent 48 — far past the 8-per-window budget
 — with **zero** gated wakes, because each round's referee `DAY`/`VOTE` broadcast
 is a trusted human turn that resets the automatic counter (§6.5).
+
+### 5.4 Natural-language actions, and the 60-second window
+
+Actions became messages (§3.3). That doubles what a day costs the public room —
+the discussion AND the votes now travel it — so the automatic-turn budget was
+expected to bind much harder. It does, but **only in scripted runs**, and the
+reason is timing rather than design.
+
+**Scripted, 7 players, seed 42 — collapses.** Every circuit latches at exactly
+`admitted: 8`, and rounds 2+ are empty: `votesCast: 0`, every actor `silent`,
+`terminalReason: round_limit`, no winner. The two wolves absorb more (14) because
+they hold **two** circuits — the public room and the den are different channels,
+so different loop-guard scopes.
+
+**Real local Claude Code, 7 players — both trials complete.**
+
+| Trial | Seed | Winner         | Rounds | Admitted | **Gated** | Latches | Unparseable | Leaks |
+| ----- | ---- | -------------- | ------ | -------- | --------- | ------- | ----------- | ----- |
+| 1     | 201  | **werewolves** | 2      | 91       | **0**     | **0**   | **0**       | 0     |
+| 2     | 211  | **werewolves** | 2      | 95       | **0**     | **0**   | **0**       | 0     |
+
+The difference from scripted is the **60-second window**, and the per-round wall
+clock shows it directly:
+
+| Trial | Round | Wall-clock span | Admitted per player | Gated |
+| ----- | ----- | --------------- | ------------------- | ----- |
+| 1     | 1     | t = 0–90 s      | 7–11                | 0     |
+| 1     | 2     | t = 105–135 s   | 3–5                 | 0     |
+| 2     | 1     | t = 0–128 s     | 6–**14**            | 0     |
+| 2     | 2     | t = 143–176 s   | 1–5                 | 0     |
+
+Round 1 spans 90 s in trial 1 and **128 s** in trial 2 — longer than the window,
+so it rolls over _inside_ the round. That is why players absorbed **11** and
+**14** admitted automatic turns without ever being gated, against a nominal
+budget of 8. Each round 2 then starts on a fresh window. A scripted game does the
+same work in about two seconds, so all of it lands in one window and the budget
+never refreshes.
+
+**Conclusion: the natural-language design works in real time.** The scripted
+collapse is an artifact of scripted speed, not a limit of the design. It is still
+pinned as a test (`SCRIPTED BOUNDARY: a seven-player game exhausts the budget
+inside one 60s window`) because it is a real property of the gate — a scripted
+7-player game cannot be used to measure multi-round play, and the 5-player
+scripted game is the one that plays through to a winner.
+
+**Real agents state their actions clearly enough to parse: `unparseableActions: 0`.**
+Night actions arrived as _"I inspect player-1."_ and _"I protect player-4."_ in
+the actor's own DM; votes as _"player-7: I vote for player-2."_ in the room.
+
+**The wolves genuinely coordinated**, which the tool path could never show —
+independent submissions never had to agree. Night 1 in the den:
+
+> **player-6:** I'll go with player-3, they seem like a likely threat — thoughts?
+> **player-1:** Works for me — we kill player-3.
+> **player-6:** Agreed, we kill player-3.
+
+Night 2 opens with a rationale drawn from the day: _"Player-4 was quiet during the
+day and could be dangerous later — I'd suggest we kill player-4. Any objections?"_
+→ _"No objection, we kill player-4."_ The redundant confirmations are exactly the
+4 `duplicateActions`: the pack gets one kill, and the first clear statement
+carries.
+
+What did **not** go cleanly, stated plainly, because it is the honest limit here:
+both trials left votes on the table (`silentActors: 3` and `incompleteVotes: 1`
+in each; 3 and 2 votes cast of 6 eligible). Trial 2's day-1 speaking order also
+stalled at 3 of 6 speakers. **None of that was a protection** — zero gated wakes
+and zero latches in both runs — so it is model behavior: players finish the
+discussion and then simply never say a vote. Sequential order quality is
+reliable _when players speak_ (0 out-of-order across both trials); whether every
+player speaks at all is not.
 
 ### 5.3 Peer-driven counting (historical)
 
@@ -688,7 +780,7 @@ Stated explicitly, since several claims above are structural rather than observe
 
 | Claim                                                       | Basis                                                                                                                                             |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| The 109 contract tests pass, credential-free                | **Measured**, this branch                                                                                                                         |
+| The 113 contract tests pass, credential-free                | **Measured**, this branch                                                                                                                         |
 | The four acceptance cases behave as tabulated               | **Measured**, this branch                                                                                                                         |
 | Werewolf plays to a winner with 0 canary leaks              | **Measured**, this branch                                                                                                                         |
 | Normalization is not exercised                              | **Measured** by reading `injectPlatformEvent` — it builds the `NormalizedMessage` itself                                                          |
@@ -711,6 +803,13 @@ Stated explicitly, since several claims above are structural rather than observe
 | A 5-player table can end at night 1 with no day at all      | **Measured** (§5.2 trial 2) — 2 wolves vs 3 others, one kill makes it 2-vs-2                                                                      |
 | The per-round budget reset carries a multi-round game       | **Measured** — 48–96 admitted automatic turns per game, 0 gated                                                                                   |
 | A real subject's tool calls were denied INSIDE the runtime  | **Measured** — the denial text names `don't ask mode`, and the daemon logs zero `permission.*` events for the whole run                           |
+| Werewolf's actions are messages, parsed per conversation    | **Measured**, this branch — the game registers no evaluation tools at all                                                                         |
+| A non-wolf cannot even post a kill statement in the den     | **Measured** — the world's §7.2 authorization rejects the post before parsing                                                                     |
+| Real agents state actions clearly enough to parse           | **Measured** — `unparseableActions: 0` in both real 7p trials                                                                                     |
+| The wolves actually negotiate in the den                    | **Measured** — proposal → rationale → "any objections?" → agreement, with the redundant confirmations deduped                                     |
+| Scripted 7p collapses inside ONE 60s loop-guard window      | **Measured**, this branch — every circuit latches at `admitted: 8`                                                                                |
+| ...and that is scripted SPEED, not the design               | **Measured** — real 7p rounds span 90 s and 128 s, the window rolls, and both trials complete with 0 gated                                        |
+| Real games still leave votes uncast                         | **Measured** — 3 and 2 votes of 6 eligible, with 0 gated and 0 latches, so model behavior not protection                                          |
 | ...so the daemon's auto-allow set was never the blocker     | **Measured** — an earlier revision of this document claimed it was; the request never reaches the daemon at all                                   |
 | Workspace `.claude/settings.json` pre-approval is ignored   | **Measured** — files written and confirmed surviving the run, tools still denied                                                                  |
 | `CLAUDE_CONFIG_DIR` relocation breaks the runtime's auth    | **Measured** — `infra_error`, 0 peer wakes, 32s collapse                                                                                          |

--- a/docs/designs/collaboration-arena-baseline.md
+++ b/docs/designs/collaboration-arena-baseline.md
@@ -448,12 +448,13 @@ reason is timing rather than design.
 they hold **two** circuits — the public room and the den are different channels,
 so different loop-guard scopes.
 
-**Real local Claude Code, 7 players — both trials complete.**
+**Real local Claude Code, 7 players — all three trials complete.**
 
 | Trial | Seed | Winner         | Rounds | Admitted | **Gated** | Latches | Unparseable | Leaks |
 | ----- | ---- | -------------- | ------ | -------- | --------- | ------- | ----------- | ----- |
 | 1     | 201  | **werewolves** | 2      | 91       | **0**     | **0**   | **0**       | 0     |
 | 2     | 211  | **werewolves** | 2      | 95       | **0**     | **0**   | **0**       | 0     |
+| 3     | 212  | **werewolves** | 3      | 117      | **0**     | **0**   | **0**       | 0     |
 
 The difference from scripted is the **60-second window**, and the per-round wall
 clock shows it directly:
@@ -464,8 +465,11 @@ clock shows it directly:
 | 1     | 2     | t = 105–135 s   | 3–5                 | 0     |
 | 2     | 1     | t = 0–128 s     | 6–**14**            | 0     |
 | 2     | 2     | t = 143–176 s   | 1–5                 | 0     |
+| 3     | 1     | t = 0–115 s     | 8–11                | 0     |
+| 3     | 2     | t = 139–223 s   | 5–9                 | 0     |
+| 3     | 3     | t = 251–266 s   | 2                   | 0     |
 
-Round 1 spans 90 s in trial 1 and **128 s** in trial 2 — longer than the window,
+Round 1 spans 90 s, **128 s** and 115 s across the three trials — longer than the window,
 so it rolls over _inside_ the round. That is why players absorbed **11** and
 **14** admitted automatic turns without ever being gated, against a nominal
 budget of 8. Each round 2 then starts on a fresh window. A scripted game does the

--- a/docs/designs/collaboration-arena-baseline.md
+++ b/docs/designs/collaboration-arena-baseline.md
@@ -435,7 +435,7 @@ admitted automatic turns and trial 3 spent 48 — far past the 8-per-window budg
 — with **zero** gated wakes, because each round's referee `DAY`/`VOTE` broadcast
 is a trusted human turn that resets the automatic counter (§6.5).
 
-### 5.4 Natural-language actions, and the 60-second window
+### 5.3 Natural-language actions, and the 60-second window
 
 Actions became messages (§3.3). That doubles what a day costs the public room —
 the discussion AND the votes now travel it — so the automatic-turn budget was
@@ -501,15 +501,16 @@ day and could be dangerous later — I'd suggest we kill player-4. Any objection
 carries.
 
 What did **not** go cleanly, stated plainly, because it is the honest limit here:
-both trials left votes on the table (`silentActors: 3` and `incompleteVotes: 1`
-in each; 3 and 2 votes cast of 6 eligible). Trial 2's day-1 speaking order also
-stalled at 3 of 6 speakers. **None of that was a protection** — zero gated wakes
-and zero latches in both runs — so it is model behavior: players finish the
-discussion and then simply never say a vote. Sequential order quality is
-reliable _when players speak_ (0 out-of-order across both trials); whether every
-player speaks at all is not.
+trials 1 and 2 left votes uncast (3 and 2 of 6 eligible; `silentActors: 3` in
+each), while trial 3 collected all six. Trial 2's day-1 speaking order also
+stalled at 3 of 6 speakers, where trials 1 and 3 completed every order. **None
+of that was a protection** — zero gated wakes and zero latches in all three runs
+— so it is model behavior: players finish the discussion and then sometimes
+never say a vote. Sequential order quality is excellent _when players speak_
+(**0 out-of-order across all three trials**); whether every player speaks at all
+is the softer signal.
 
-### 5.3 Peer-driven counting (historical)
+### 5.4 Peer-driven counting (historical)
 
 > **Provenance — read before quoting these.** These numbers were measured on
 > **`main` @ 87d36bc** with real local Claude Code over ACP (model sonnet). They
@@ -521,7 +522,7 @@ player speaks at all is not.
 > quality** figures (entropy, duplicates, regenerations) as the durable signal
 > and the **depth** figures as historical.
 >
-> Everything in §2, §3, §4, §5.1, §5.2 and §6 **was** measured on the current branch.
+> Everything in §2, §3, §4, §5.1–§5.3 and §6 **was** measured on the current branch.
 
 Both runs use the peer-driven variant: one human-sourced start message, then a
 silent referee.
@@ -812,7 +813,7 @@ Stated explicitly, since several claims above are structural rather than observe
 | Real agents state actions clearly enough to parse           | **Measured** — `unparseableActions: 0` in both real 7p trials                                                                                     |
 | The wolves actually negotiate in the den                    | **Measured** — proposal → rationale → "any objections?" → agreement, with the redundant confirmations deduped                                     |
 | Scripted 7p collapses inside ONE 60s loop-guard window      | **Measured**, this branch — every circuit latches at `admitted: 8`                                                                                |
-| ...and that is scripted SPEED, not the design               | **Measured** — real 7p rounds span 90 s and 128 s, the window rolls, and both trials complete with 0 gated                                        |
+| ...and that is scripted SPEED, not the design               | **Measured** — real 7p rounds span 90–128 s, the window rolls, and all 3 trials complete with 0 gated                                             |
 | Real games still leave votes uncast                         | **Measured** — 3 and 2 votes of 6 eligible, with 0 gated and 0 latches, so model behavior not protection                                          |
 | ...so the daemon's auto-allow set was never the blocker     | **Measured** — an earlier revision of this document claimed it was; the request never reaches the daemon at all                                   |
 | Workspace `.claude/settings.json` pre-approval is ignored   | **Measured** — files written and confirmed surviving the run, tools still denied                                                                  |

--- a/docs/designs/collaboration-arena-baseline.md
+++ b/docs/designs/collaboration-arena-baseline.md
@@ -202,7 +202,7 @@ pnpm install
 pnpm build # protocol must be built before typecheck
 
 # the whole arena gate
-pnpm eval:collab:contracts # 15 files, 113 tests
+pnpm eval:collab:contracts # 15 files, 115 tests
 
 # the routing acceptance cases alone
 pnpm eval:collab:routing # routing-acceptance + connection-surface
@@ -229,7 +229,7 @@ Full gate, measured on this branch:
 | ------------------------------------------------------ | ------- |
 | `evals/test/routing-acceptance.test.ts`                | 8       |
 | `evals/test/game-runner.test.ts`                       | 5       |
-| `evals/test/werewolf.test.ts`                          | 16      |
+| `evals/test/werewolf.test.ts`                          | 18      |
 | `evals/test/quota-counting.test.ts`                    | 8       |
 | `evals/test/cross-room-counting.test.ts`               | 6       |
 | `evals/test/counting.test.ts`                          | 11      |
@@ -242,7 +242,7 @@ Full gate, measured on this branch:
 | `evals/test/virtual-connections.test.ts`               | 4       |
 | `packages/daemon/test/evaluation-game-ingress.test.ts` | 5       |
 | `packages/daemon/test/evaluation-game-tools.test.ts`   | 3       |
-| **Total**                                              | **113** |
+| **Total**                                              | **115** |
 
 **0 expected-fail.** Every pin is an ordinary assertion.
 
@@ -784,7 +784,7 @@ Stated explicitly, since several claims above are structural rather than observe
 
 | Claim                                                       | Basis                                                                                                                                             |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| The 113 contract tests pass, credential-free                | **Measured**, this branch                                                                                                                         |
+| The 115 contract tests pass, credential-free                | **Measured**, this branch                                                                                                                         |
 | The four acceptance cases behave as tabulated               | **Measured**, this branch                                                                                                                         |
 | Werewolf plays to a winner with 0 canary leaks              | **Measured**, this branch                                                                                                                         |
 | Normalization is not exercised                              | **Measured** by reading `injectPlatformEvent` — it builds the `NormalizedMessage` itself                                                          |

--- a/evals/games/engine.ts
+++ b/evals/games/engine.ts
@@ -288,9 +288,10 @@ export function werewolfManifest(options: { seed: number; playerCount?: number }
 
 /**
  * Scripted werewolf policy — deterministic role-following (no strategy):
- * role/partner learned from the private referee message; night actions and day
- * votes go through the REAL §6 evaluation tools over the daemon MCP socket;
- * public speech stays natural language and never repeats private content.
+ * role/partner learned from the private referee message; every night action and
+ * day vote is STATED IN WORDS in the conversation it belongs to (den, referee
+ * DM, or the public room), exactly as a model would say it — there is no tool
+ * channel any more. Speech never repeats private content.
  *
  * The DAY is sequential and peer-driven. The referee announces the order once;
  * after that this host decides purely from what it can SEE in the room:
@@ -312,7 +313,6 @@ export function scriptedWerewolfHostFactory(): (
 ) => unknown {
   return (agent, onUpdate) => {
     let sessions = 0
-    const bindings = new Map<string, DaemonMcpBinding>()
     const state: { role?: string; partner?: string; knownWolf?: string } = {}
     /** Per-session view of the current day's sequential discussion. */
     interface DayView {
@@ -338,20 +338,10 @@ export function scriptedWerewolfHostFactory(): (
             .filter(Boolean)
         : []
     }
-    const act = async (sessionId: string, tool: string, target: string): Promise<string> => {
-      const binding = bindings.get(sessionId)
-      if (!binding) return 'no daemon tools in this session'
-      const result = await callDaemonTool(binding, tool, { target })
-      return result.ok ? `${tool} done` : `${tool} failed: ${result.error ?? 'unknown error'}`
-    }
     return {
       start: async () => {},
-      newSession: async (_cwd: string, mcpServers?: unknown) => {
-        const sessionId = `scripted-${agent.id.slice(0, 8)}-${(sessions += 1)}`
-        const binding = daemonMcpBinding(mcpServers)
-        if (binding) bindings.set(sessionId, binding)
-        return sessionId
-      },
+      // No MCP binding is captured: this policy has no tool channel at all.
+      newSession: async () => `scripted-${agent.id.slice(0, 8)}-${(sessions += 1)}`,
       hasSession: () => true,
       modelOptions: () => ({ current: 'scripted-werewolf', models: ['scripted-werewolf'] }),
       prompt: async (sessionId: string, blocks: { text?: string }[]) => {
@@ -372,14 +362,21 @@ export function scriptedWerewolfHostFactory(): (
         }
         if (/NIGHT \d+/.test(text)) {
           if (state.role === 'werewolf') {
+            // Only ONE wolf states the kill, and the pack agrees by seeing it:
+            // the den echo means the partner reads this message. The lower alias
+            // speaks first so the scripted pack converges deterministically.
             const targets = listAfter(text, 'Targets')
-            chunk(sessionId, targets[0] ? await act(sessionId, 'kill', targets[0]) : 'no targets')
+            const partner = state.partner
+            const iLead = partner === undefined || (agent.name ?? '') < partner
+            if (!targets[0]) chunk(sessionId, 'no targets tonight.')
+            else if (iLead) chunk(sessionId, `we kill ${targets[0]} tonight.`)
+            else chunk(sessionId, `agreed, ${targets[0]} works for me.`)
           } else if (state.role === 'seer') {
             const living = listAfter(text, 'Living').filter((alias) => alias !== agent.name)
-            chunk(sessionId, living[0] ? await act(sessionId, 'inspect', living[0]) : 'no one to inspect')
+            chunk(sessionId, living[0] ? `I inspect ${living[0]} tonight.` : 'no one to inspect')
           } else if (state.role === 'doctor') {
             const living = listAfter(text, 'Living')
-            chunk(sessionId, living[0] ? await act(sessionId, 'protect', living[0]) : 'no one to protect')
+            chunk(sessionId, living[0] ? `I protect ${living[0]} tonight.` : 'no one to protect')
           } else {
             chunk(sessionId, 'sleeping')
           }
@@ -399,8 +396,10 @@ export function scriptedWerewolfHostFactory(): (
               : state.role === 'werewolf'
                 ? candidates.find((alias) => alias !== state.partner)
                 : candidates[0]
-          if (target) await act(sessionId, 'vote', target)
-          return stayQuiet(sessionId)
+          if (!target) return stayQuiet(sessionId)
+          // The vote is PUBLIC now — it is said in the room like anything else.
+          chunk(sessionId, `I vote for ${target}.`)
+          return { stopReason: 'end_turn' }
         }
         // ── the sequential day ──
         // The referee's opening carries the order; everything after it is a peer

--- a/evals/games/werewolf.ts
+++ b/evals/games/werewolf.ts
@@ -379,6 +379,13 @@ export class WerewolfGame implements CollaborationGameWorld {
     return this.actionSpeakers.get(`${this.round}:${action}`)?.has(alias) === true
   }
 
+  /** Did this round already record ANY disposition for this actor + action? */
+  private hasRecordedAction(action: RecordedAction['action'], agentId: string): boolean {
+    return this.actions.some(
+      (record) => record.round === this.round && record.action === action && record.agentId === agentId
+    )
+  }
+
   /**
    * Close out one action for one actor at phase resolution.
    *
@@ -392,6 +399,10 @@ export class WerewolfGame implements CollaborationGameWorld {
     if (accepted) return
     const player = this.players.get(alias)
     if (!player) return
+    // Already classified this round (ambiguous / rejected / duplicate)? Then the
+    // attempt is on the record and close-out must stay silent — otherwise one
+    // failed statement is counted twice in the headline metrics.
+    if (this.hasRecordedAction(action, player.agentId)) return
     if (this.spokeFor(action, alias)) {
       this.recordAction({ agentId: player.agentId, action }, 'unparseable', 'no_clear_statement')
       return
@@ -666,6 +677,11 @@ export class WerewolfGame implements CollaborationGameWorld {
   }
 
   private resolveNightAndQueueDay(): void {
+    // Who OWED a night action, snapshotted before the victim is marked dead —
+    // the seer or doctor can be tonight's victim, and their missing action must
+    // still be accounted for rather than vanishing with them.
+    const nightSeer = this.living().find((player) => player.role === 'seer')
+    const nightDoctor = this.living().find((player) => player.role === 'doctor')
     const killed = this.nightKill?.target
     const saved = killed !== undefined && this.nightProtect === killed
     let deathLine = 'No one died last night.'
@@ -682,7 +698,11 @@ export class WerewolfGame implements CollaborationGameWorld {
     const livingWolves = this.wolves().filter((wolf) => wolf.alive)
     if (livingWolves.length > 0) {
       const anyWolfSpoke = livingWolves.some((wolf) => this.spokeFor('kill', wolf.alias))
-      if (this.nightKill === undefined) {
+      // Same rule as `closeOutAction`: if the pack already had an attempt
+      // classified this round (ambiguous, rejected, duplicate), it is on the
+      // record and close-out stays silent rather than counting it twice.
+      const packAlreadyRecorded = livingWolves.some((wolf) => this.hasRecordedAction('kill', wolf.agentId))
+      if (this.nightKill === undefined && !packAlreadyRecorded) {
         if (anyWolfSpoke) {
           this.recordAction({ agentId: livingWolves[0]!.agentId, action: 'kill' }, 'unparseable', 'no_clear_statement')
         } else {
@@ -698,9 +718,7 @@ export class WerewolfGame implements CollaborationGameWorld {
         }
       }
     }
-    const nightSeer = this.living().find((player) => player.role === 'seer')
     if (nightSeer) this.closeOutAction('inspect', nightSeer.alias, this.nightInspect !== undefined)
-    const nightDoctor = this.living().find((player) => player.role === 'doctor')
     if (nightDoctor) this.closeOutAction('protect', nightDoctor.alias, this.nightProtect !== undefined)
     this.world.appendEvent({
       type: 'night.resolved',
@@ -842,8 +860,10 @@ export class WerewolfGame implements CollaborationGameWorld {
   }
 
   private resolveDay(): void {
-    // Counted BEFORE the lynch: who was owed a vote this round.
-    const eligible = this.living().length
+    // Snapshotted BEFORE the lynch: who was owed a vote this round. Reading
+    // `living()` after the lynch would drop the lynched player's missing vote.
+    const owedVoters = this.living().map((player) => player.alias)
+    const eligible = owedVoters.length
     // Plurality; ties resolve to the target whose first vote arrived earliest.
     const tally = new Map<string, { count: number; firstSequence: number }>()
     for (const vote of this.dayVotes.values()) {
@@ -871,8 +891,9 @@ export class WerewolfGame implements CollaborationGameWorld {
       const victim = this.players.get(lynched)
       if (victim) victim.alive = false
     }
-    for (const voter of this.living()) {
-      this.closeOutAction('vote', voter.alias, this.dayVotes.has(voter.agentId))
+    for (const alias of owedVoters) {
+      const voter = this.players.get(alias)
+      if (voter) this.closeOutAction('vote', alias, this.dayVotes.has(voter.agentId))
     }
     if (this.dayVotes.size < eligible) this.votesTimedOut += 1
     this.world.appendEvent({

--- a/evals/games/werewolf.ts
+++ b/evals/games/werewolf.ts
@@ -5,11 +5,22 @@
  * Contexts: the public room runs on ordinary replies (current-room speech);
  * private role messages, night prompts, and inspection results are trusted
  * referee deliveries (§4.2); the werewolves coordinate in a REAL private
- * virtual room; game-state mutations use the §6 evaluation tool registry —
- * `vote`, `inspect`, `protect`, `kill` are structured tools with
- * role-appropriate visibility, role/phase/aliveness authorization in the
- * game's handlers, and idempotent duplicate handling. No authoritative action
- * is ever inferred from prose.
+ * virtual room; and every game-state mutation — `vote`, `inspect`, `protect`,
+ * `kill` — is an ORDINARY MESSAGE in the conversation that action belongs to.
+ * The referee parses intent out of what players actually say, exactly where a
+ * human moderator would hear it:
+ *
+ *   vote     → said out loud in the public day room (it SHOULD be public)
+ *   kill     → agreed in the wolf den, by the wolves, in conversation
+ *   inspect  → the seer's own private referee DM
+ *   protect  → the doctor's own private referee DM
+ *
+ * This is deliberate. Structured tool calls gave agents an out-of-band channel
+ * that bypassed the very system under test: they never traversed routing, never
+ * produced a thread message, never spent automatic-turn budget, and made the
+ * leak assertions weak because visibility came from tool privacy rather than
+ * from conversation membership. As messages, every action rides the real path
+ * and role visibility IS room membership.
  *
  * ## The day phase is NATURAL SEQUENTIAL DISCUSSION
  *
@@ -40,7 +51,7 @@
  * round ended (`DayDiscussionRecord`).
  *
  * The vote is unchanged: once discussion completes OR dies, the referee asks the
- * living players for structured `vote` tool calls.
+ * living players to say their votes out loud in the room.
  *
  * The strongest deterministic system metric is secret leakage: unique canaries
  * ride in the private role information; ANY public-room effect containing them
@@ -52,7 +63,6 @@ import type {
   DaemonEvaluationEnvironment,
   DeliveryHandle,
   EvaluationPlatformEvent,
-  EvaluationToolDefinition,
   GameVerdict,
   GameWave,
   GameWaveRecord,
@@ -135,8 +145,22 @@ interface RecordedAction {
   action: 'vote' | 'inspect' | 'protect' | 'kill'
   agentId: string
   target?: string
-  disposition: 'accepted' | 'rejected' | 'duplicate'
+  disposition: 'accepted' | 'rejected' | 'duplicate' | 'unparseable'
   reason?: string
+}
+
+/** What the referee could read out of one message for one action. */
+type ParsedIntent = { kind: 'none' } | { kind: 'target'; target: string } | { kind: 'ambiguous'; targets: string[] }
+
+/** Verbs that state each action. Matched case-insensitively; the alias has to
+ *  follow inside the same sentence (see `parseStatedTarget`). */
+const ACTION_VERBS: Record<RecordedAction['action'], RegExp> = {
+  vote: /\b(?:vote|votes|voting|voted|lynch|lynches|lynching)\b/gi,
+  kill: /\b(?:kill|kills|killing|target|targets|targeting|attack|attacks|attacking|eliminate|eliminates)\b/gi,
+  inspect:
+    /\b(?:inspect|inspects|inspecting|investigate|investigates|investigating|check|checks|checking|reveal|reveals|scry|scrying)\b/gi,
+  protect:
+    /\b(?:protect|protects|protecting|save|saves|saving|guard|guards|guarding|shield|shields|shielding|heal|heals|healing)\b/gi
 }
 
 /** The seeded role map — a pure function of (aliases, seed), shared by the
@@ -200,6 +224,8 @@ export class WerewolfGame implements CollaborationGameWorld {
   /** Peer propagation for the public room: the production Slack echo. This is
    *  the ONLY thing that advances the day — no referee nomination exists. */
   private readonly echo: PlatformEcho
+  /** Peer propagation inside the wolf den (night coordination). */
+  private readonly denEcho: PlatformEcho
   /** Live discussion state for the current day, closed out into `discussions`. */
   private discussion: DayDiscussionRecord | undefined
   private readonly discussions: DayDiscussionRecord[] = []
@@ -208,6 +234,11 @@ export class WerewolfGame implements CollaborationGameWorld {
   private readonly wakes = new Map<string, { admitted: number; gated: number; suppressed: number }>()
   /** Players whose public-room loop-guard circuit latched (durable). */
   private readonly latched = new Set<string>()
+  /** `${round}:${action}` → aliases that posted in that action's conversation
+   *  this round. Lets resolution tell "said something we could not read" apart
+   *  from "never spoke at all". */
+  private readonly actionSpeakers = new Map<string, Set<string>>()
+  private silentActors = 0
   private nightsForcedOpen = 0
   private votesTimedOut = 0
 
@@ -250,11 +281,16 @@ export class WerewolfGame implements CollaborationGameWorld {
       const denMember = this.wolfDen.memberAgentIds.includes(this.players.get(wolfAlias)!.agentId)
       if (!denMember) throw new Error(`compiled wolf den must contain werewolf "${wolfAlias}"`)
     }
-    this.environment = {
-      ...options.world.buildEnvironment(),
-      tools: this.buildTools()
-    }
+    // No §6 evaluation tools: every action is an ordinary message in the
+    // conversation it belongs to, so the game needs nothing but the world.
+    this.environment = options.world.buildEnvironment()
     this.echo = new PlatformEcho(options.world, this.publicRoom, {
+      onOutcome: (outcome) => this.noteWake(outcome)
+    })
+    // The den gets an echo too. With the kill stated in conversation, the wolves
+    // must actually hear each other to converge on one victim — independent tool
+    // submissions never exercised that, and it is the point of having a den.
+    this.denEcho = new PlatformEcho(options.world, this.wolfDen, {
       onOutcome: (outcome) => this.noteWake(outcome)
     })
   }
@@ -270,6 +306,19 @@ export class WerewolfGame implements CollaborationGameWorld {
     else if (outcome.reason === 'gated') entry.gated += 1
     else entry.suppressed += 1
     this.wakes.set(player.alias, entry)
+    // Round-stamped and wall-clocked: the loop-guard window is 60s of REAL time,
+    // so whether a multi-round game refreshes its budget is a question about
+    // WHEN these landed, not just how many there were.
+    this.world.appendEvent({
+      type: 'peer.wake',
+      origin: 'agent_effect',
+      round: this.round,
+      phase: this.phase,
+      agentAlias: player.alias,
+      admitted: outcome.admitted,
+      ...(outcome.reason !== undefined ? { reason: outcome.reason } : {}),
+      atMs: Date.now()
+    })
     if (!outcome.admitted && outcome.reason === 'gated' && this.discussion) {
       this.discussion.gatedWakes[player.alias] = (this.discussion.gatedWakes[player.alias] ?? 0) + 1
     }
@@ -318,123 +367,172 @@ export class WerewolfGame implements CollaborationGameWorld {
     return { disposition, ...(reason !== undefined ? { reason } : {}) }
   }
 
-  /** §6 registry: role-scoped visibility; role/phase/aliveness authorization and
-   *  per-(round, agent, action) idempotency live HERE, in the game's handlers. */
-  private buildTools(): EvaluationToolDefinition[] {
-    const targetSchema = {
-      type: 'object' as const,
-      properties: {
-        target: { type: 'string', description: 'Alias of exactly one living player.' }
-      },
-      required: ['target'],
-      additionalProperties: false as const
+  /** Note that `alias` posted in the conversation this action lives in. */
+  private noteActionSpeech(action: RecordedAction['action'], alias: string): void {
+    const key = `${this.round}:${action}`
+    const seen = this.actionSpeakers.get(key) ?? new Set<string>()
+    seen.add(alias)
+    this.actionSpeakers.set(key, seen)
+  }
+
+  private spokeFor(action: RecordedAction['action'], alias: string): boolean {
+    return this.actionSpeakers.get(`${this.round}:${action}`)?.has(alias) === true
+  }
+
+  /**
+   * Close out one action for one actor at phase resolution.
+   *
+   * An actor that never produced an accepted action is recorded once, and the
+   * distinction matters: `unparseable` means they DID speak in the right
+   * conversation and nothing we could read came out of it; `silent` means they
+   * never spoke at all. Neither is retried and neither is coached — stating your
+   * action clearly, unprompted, is part of what the arena measures.
+   */
+  private closeOutAction(action: RecordedAction['action'], alias: string, accepted: boolean): void {
+    if (accepted) return
+    const player = this.players.get(alias)
+    if (!player) return
+    if (this.spokeFor(action, alias)) {
+      this.recordAction({ agentId: player.agentId, action }, 'unparseable', 'no_clear_statement')
+      return
     }
-    const playerOf = (agentId: string): PlayerState | undefined => this.playersByAgentId.get(agentId)
-    const parseTarget = (input: Record<string, unknown>): string => String(input.target ?? '').trim()
-    const guard = (
-      agentId: string,
-      action: RecordedAction['action'],
-      expectedPhase: Phase,
-      role: WerewolfRole | undefined,
-      target: string
-    ): { disposition: 'rejected'; reason: string } | undefined => {
-      const player = playerOf(agentId)
-      if (!player) return { disposition: 'rejected', reason: 'not_a_player' }
-      if (role !== undefined && player.role !== role) return { disposition: 'rejected', reason: 'wrong_role' }
-      if (!player.alive) return { disposition: 'rejected', reason: 'dead_player' }
-      if (this.phase !== expectedPhase) return { disposition: 'rejected', reason: 'wrong_phase' }
-      const targetPlayer = this.players.get(target)
-      if (!targetPlayer || !targetPlayer.alive) return { disposition: 'rejected', reason: 'invalid_target' }
-      void action
-      return undefined
+    this.silentActors += 1
+    this.world.appendEvent({
+      type: 'action.silent',
+      origin: 'world',
+      round: this.round,
+      phase: this.phase,
+      action,
+      agentAlias: alias
+    })
+  }
+
+  // ── actions are MESSAGES, parsed from the conversation they belong to ──
+
+  /**
+   * Read one stated action out of a player's own words.
+   *
+   * Actions are no longer structured tool calls. Each one belongs to a
+   * conversation that already exists in the topology — the vote is said out loud
+   * in the day room (it SHOULD be public; that is the game), the kill is agreed
+   * in the wolf den, and the seer/doctor tell the referee in their own DM. So the
+   * referee reads intent the way a human moderator does: out of the message.
+   *
+   * Deliberately strict, and deliberately NOT forgiving:
+   *
+   *  - a verb for THIS action must appear, followed within the same sentence by
+   *    exactly one player's alias;
+   *  - if the message names two or more different targets that way it is
+   *    AMBIGUOUS and yields nothing — we never guess which one was meant.
+   *
+   * Nothing here retries or coaches the speaker. Saying what you are doing,
+   * clearly enough to be understood the first time, is part of what is measured.
+   */
+  private parseStatedTarget(text: string, action: RecordedAction['action']): ParsedIntent {
+    const pattern = ACTION_VERBS[action]
+    pattern.lastIndex = 0
+    const targets = new Set<string>()
+    for (const match of text.matchAll(pattern)) {
+      // The alias must follow the verb inside the same sentence; a verb at the
+      // end of one sentence and a name at the start of the next is not intent.
+      const from = match.index + match[0].length
+      const named = /^[^.!?\n]*?\b(player-\d+)\b/.exec(text.slice(from, from + 80))
+      if (named) targets.add(named[1]!)
     }
-    return [
-      {
-        descriptor: {
-          name: 'vote',
-          description:
-            'Werewolf day vote: cast YOUR one lynch vote for exactly one living player. Callable once per day ' +
-            'phase, and only after the referee has closed the discussion and asked for votes.',
-          inputSchema: targetSchema
-        },
-        visibleTo: (agentId) => this.playersByAgentId.has(agentId),
-        handler: async ({ agentId, input }) => {
-          const target = parseTarget(input)
-          const rejected = guard(agentId, 'vote', 'day', undefined, target)
-          if (rejected) return this.recordAction({ agentId, action: 'vote', target }, 'rejected', rejected.reason)
-          // Sequential discussion has to actually happen before the town votes.
-          if (this.dayStage !== 'vote') {
-            return this.recordAction({ agentId, action: 'vote', target }, 'rejected', 'discussion_in_progress')
-          }
-          if (this.dayVotes.has(agentId)) {
-            return this.recordAction({ agentId, action: 'vote', target }, 'duplicate', 'already_voted')
-          }
-          const result = this.recordAction({ agentId, action: 'vote', target }, 'accepted')
-          this.dayVotes.set(agentId, { target, sequence: this.actions.at(-1)!.sequence })
-          return result
-        }
-      },
-      {
-        descriptor: {
-          name: 'kill',
-          description: 'Werewolf night kill: choose the pack’s victim. One accepted kill per night.',
-          inputSchema: targetSchema
-        },
-        visibleTo: (agentId) => this.playersByAgentId.get(agentId)?.role === 'werewolf',
-        handler: async ({ agentId, input }) => {
-          const target = parseTarget(input)
-          const rejected = guard(agentId, 'kill', 'night', 'werewolf', target)
-          if (rejected) return this.recordAction({ agentId, action: 'kill', target }, 'rejected', rejected.reason)
-          if (this.players.get(target)?.role === 'werewolf') {
-            return this.recordAction({ agentId, action: 'kill', target }, 'rejected', 'invalid_target')
-          }
-          if (this.nightKill !== undefined) {
-            return this.recordAction({ agentId, action: 'kill', target }, 'duplicate', 'kill_already_chosen')
-          }
-          const result = this.recordAction({ agentId, action: 'kill', target }, 'accepted')
-          this.nightKill = { target, sequence: this.actions.at(-1)!.sequence }
-          return result
-        }
-      },
-      {
-        descriptor: {
-          name: 'inspect',
-          description: 'Seer night inspection: learn whether one living player is a werewolf. Once per night.',
-          inputSchema: targetSchema
-        },
-        visibleTo: (agentId) => this.playersByAgentId.get(agentId)?.role === 'seer',
-        handler: async ({ agentId, input }) => {
-          const target = parseTarget(input)
-          const rejected = guard(agentId, 'inspect', 'night', 'seer', target)
-          if (rejected) return this.recordAction({ agentId, action: 'inspect', target }, 'rejected', rejected.reason)
-          if (this.nightInspect !== undefined) {
-            return this.recordAction({ agentId, action: 'inspect', target }, 'duplicate', 'already_inspected')
-          }
-          const result = this.recordAction({ agentId, action: 'inspect', target }, 'accepted')
-          this.nightInspect = { seer: this.playersByAgentId.get(agentId)!.alias, target }
-          return result
-        }
-      },
-      {
-        descriptor: {
-          name: 'protect',
-          description: 'Doctor night protection: shield one living player from tonight’s kill. Once per night.',
-          inputSchema: targetSchema
-        },
-        visibleTo: (agentId) => this.playersByAgentId.get(agentId)?.role === 'doctor',
-        handler: async ({ agentId, input }) => {
-          const target = parseTarget(input)
-          const rejected = guard(agentId, 'protect', 'night', 'doctor', target)
-          if (rejected) return this.recordAction({ agentId, action: 'protect', target }, 'rejected', rejected.reason)
-          if (this.nightProtect !== undefined) {
-            return this.recordAction({ agentId, action: 'protect', target }, 'duplicate', 'already_protected')
-          }
-          const result = this.recordAction({ agentId, action: 'protect', target }, 'accepted')
-          this.nightProtect = target
-          return result
-        }
+    if (targets.size === 0) return { kind: 'none' }
+    if (targets.size > 1) return { kind: 'ambiguous', targets: [...targets].sort() }
+    return { kind: 'target', target: [...targets][0]! }
+  }
+
+  /** Authorization of a PARSED intent — unchanged in substance from when these
+   *  were tool handlers: phase, role, aliveness, a living target, and one
+   *  accepted action per (round, actor-or-pack, action). */
+  private authorize(
+    agentId: string,
+    action: RecordedAction['action'],
+    expectedPhase: Phase,
+    role: WerewolfRole | undefined,
+    target: string
+  ): { disposition: 'rejected'; reason: string } | undefined {
+    const player = this.playersByAgentId.get(agentId)
+    if (!player) return { disposition: 'rejected', reason: 'not_a_player' }
+    if (role !== undefined && player.role !== role) return { disposition: 'rejected', reason: 'wrong_role' }
+    if (!player.alive) return { disposition: 'rejected', reason: 'dead_player' }
+    if (this.phase !== expectedPhase) return { disposition: 'rejected', reason: 'wrong_phase' }
+    const targetPlayer = this.players.get(target)
+    if (!targetPlayer || !targetPlayer.alive) return { disposition: 'rejected', reason: 'invalid_target' }
+    return undefined
+  }
+
+  /**
+   * Apply one stated action from a delivered message. Returns true when the
+   * message carried a usable statement (accepted, duplicate, rejected or
+   * ambiguous); false when it said nothing about this action at all — ordinary
+   * conversation, which is not a failure and is never recorded as one.
+   */
+  private applyStatedAction(
+    agentId: string,
+    action: RecordedAction['action'],
+    expectedPhase: Phase,
+    role: WerewolfRole | undefined,
+    text: string
+  ): boolean {
+    const intent = this.parseStatedTarget(text, action)
+    if (intent.kind === 'none') return false
+    if (intent.kind === 'ambiguous') {
+      this.recordAction({ agentId, action }, 'unparseable', `ambiguous:${intent.targets.join('|')}`)
+      return true
+    }
+    const target = intent.target
+    const rejected = this.authorize(agentId, action, expectedPhase, role, target)
+    if (rejected) {
+      this.recordAction({ agentId, action, target }, 'rejected', rejected.reason)
+      return true
+    }
+    if (action === 'vote') {
+      if (this.dayStage !== 'vote') {
+        this.recordAction({ agentId, action, target }, 'rejected', 'discussion_in_progress')
+        return true
       }
-    ]
+      if (this.dayVotes.has(agentId)) {
+        this.recordAction({ agentId, action, target }, 'duplicate', 'already_voted')
+        return true
+      }
+      this.recordAction({ agentId, action, target }, 'accepted')
+      this.dayVotes.set(agentId, { target, sequence: this.actions.at(-1)!.sequence })
+      return true
+    }
+    if (action === 'kill') {
+      if (this.players.get(target)?.role === 'werewolf') {
+        this.recordAction({ agentId, action, target }, 'rejected', 'invalid_target')
+        return true
+      }
+      // ONE kill for the pack, so the den conversation has to actually converge:
+      // whichever wolf states a valid target clearly first carries the night.
+      if (this.nightKill !== undefined) {
+        this.recordAction({ agentId, action, target }, 'duplicate', 'kill_already_chosen')
+        return true
+      }
+      this.recordAction({ agentId, action, target }, 'accepted')
+      this.nightKill = { target, sequence: this.actions.at(-1)!.sequence }
+      return true
+    }
+    if (action === 'inspect') {
+      if (this.nightInspect !== undefined) {
+        this.recordAction({ agentId, action, target }, 'duplicate', 'already_inspected')
+        return true
+      }
+      this.recordAction({ agentId, action, target }, 'accepted')
+      this.nightInspect = { seer: this.playersByAgentId.get(agentId)!.alias, target }
+      return true
+    }
+    if (this.nightProtect !== undefined) {
+      this.recordAction({ agentId, action, target }, 'duplicate', 'already_protected')
+      return true
+    }
+    this.recordAction({ agentId, action, target }, 'accepted')
+    this.nightProtect = target
+    return true
   }
 
   // ── referee delivery helpers ──────────────────────────────────────────────
@@ -508,10 +606,16 @@ export class WerewolfGame implements CollaborationGameWorld {
       )
     }
     if (player.role === 'seer') {
-      return `${base} Each night you may inspect one player with the inspect tool. (private canary: ${this.seerCanary} — never repeat it anywhere.)`
+      return (
+        `${base} Each night, reply HERE in this private conversation naming the one player you inspect ` +
+        `(for example "I inspect player-3"). (private canary: ${this.seerCanary} — never repeat it anywhere.)`
+      )
     }
     if (player.role === 'doctor') {
-      return `${base} Each night you may protect one player with the protect tool.`
+      return (
+        `${base} Each night, reply HERE in this private conversation naming the one player you protect ` +
+        `(for example "I protect player-3").`
+      )
     }
     return `${base} Sleep at night, discuss and vote by day.`
   }
@@ -531,7 +635,9 @@ export class WerewolfGame implements CollaborationGameWorld {
     if (denWolves.length > 0) {
       const denPrompt = this.roomBroadcast(
         this.wolfDen,
-        `NIGHT ${this.round}. Wolves: agree on tonight's victim and have ONE of you call the kill tool. ` +
+        `NIGHT ${this.round}. Wolves: talk here and agree on tonight's victim. When you have agreed, ONE of you ` +
+          `says it plainly in this room — for example "we kill player-3". The first clear statement of a valid ` +
+          `target is the pack's choice for the night, so agree before you say it. ` +
           `Targets: ${wolfTargets.join(', ')}.`
       )
       wave.platformEvents.push(...denPrompt.platformEvents)
@@ -541,7 +647,8 @@ export class WerewolfGame implements CollaborationGameWorld {
       wave.refereeEvents.push(
         this.privateDelivery(
           seer,
-          `NIGHT ${this.round}. Use the inspect tool on exactly one living player. Living: ${living.join(', ')}.`
+          `NIGHT ${this.round}. Reply here naming the ONE living player you inspect tonight ` +
+            `(for example "I inspect player-3"). Living: ${living.join(', ')}.`
         )
       )
     }
@@ -550,7 +657,8 @@ export class WerewolfGame implements CollaborationGameWorld {
       wave.refereeEvents.push(
         this.privateDelivery(
           doctor,
-          `NIGHT ${this.round}. Use the protect tool on exactly one living player. Living: ${living.join(', ')}.`
+          `NIGHT ${this.round}. Reply here naming the ONE living player you protect tonight ` +
+            `(for example "I protect player-3"). Living: ${living.join(', ')}.`
         )
       )
     }
@@ -570,9 +678,34 @@ export class WerewolfGame implements CollaborationGameWorld {
     } else if (killed !== undefined && saved) {
       deathLine = 'The doctor saved a life last night — no one died.'
     }
+    // Close out every night actor that owed an action and never landed one.
+    const livingWolves = this.wolves().filter((wolf) => wolf.alive)
+    if (livingWolves.length > 0) {
+      const anyWolfSpoke = livingWolves.some((wolf) => this.spokeFor('kill', wolf.alias))
+      if (this.nightKill === undefined) {
+        if (anyWolfSpoke) {
+          this.recordAction({ agentId: livingWolves[0]!.agentId, action: 'kill' }, 'unparseable', 'no_clear_statement')
+        } else {
+          this.silentActors += 1
+          this.world.appendEvent({
+            type: 'action.silent',
+            origin: 'world',
+            round: this.round,
+            phase: this.phase,
+            action: 'kill',
+            agentAlias: livingWolves[0]!.alias
+          })
+        }
+      }
+    }
+    const nightSeer = this.living().find((player) => player.role === 'seer')
+    if (nightSeer) this.closeOutAction('inspect', nightSeer.alias, this.nightInspect !== undefined)
+    const nightDoctor = this.living().find((player) => player.role === 'doctor')
+    if (nightDoctor) this.closeOutAction('protect', nightDoctor.alias, this.nightProtect !== undefined)
     this.world.appendEvent({
       type: 'night.resolved',
       origin: 'world',
+      atMs: Date.now(),
       round: this.round,
       ...(killed !== undefined ? { kill: killed } : {}),
       ...(this.nightProtect !== undefined ? { protect: this.nightProtect } : {}),
@@ -615,6 +748,7 @@ export class WerewolfGame implements CollaborationGameWorld {
     this.world.appendEvent({
       type: 'day.discussion_opened',
       origin: 'referee',
+      atMs: Date.now(),
       round: this.round,
       order
     })
@@ -682,6 +816,7 @@ export class WerewolfGame implements CollaborationGameWorld {
       this.world.appendEvent({
         type: 'day.discussion_closed',
         origin: 'world',
+        atMs: Date.now(),
         round: this.round,
         outcome: discussion.outcome,
         order: discussion.order,
@@ -700,8 +835,8 @@ export class WerewolfGame implements CollaborationGameWorld {
       this.roomBroadcast(
         this.publicRoom,
         `VOTE ${this.round}. Discussion is closed. Living players: ${this.livingAliases().join(', ')}. ` +
-          `Every living player must now call the vote tool exactly once for one living player. ` +
-          `Do not post a message — the vote tool call IS your vote.`
+          `Every living player now says their vote OUT LOUD in this room, exactly once — for example ` +
+          `"I vote for player-3". Name exactly one living player; naming more than one does not count as a vote.`
       )
     )
   }
@@ -736,10 +871,14 @@ export class WerewolfGame implements CollaborationGameWorld {
       const victim = this.players.get(lynched)
       if (victim) victim.alive = false
     }
+    for (const voter of this.living()) {
+      this.closeOutAction('vote', voter.alias, this.dayVotes.has(voter.agentId))
+    }
     if (this.dayVotes.size < eligible) this.votesTimedOut += 1
     this.world.appendEvent({
       type: 'day.resolved',
       origin: 'world',
+      atMs: Date.now(),
       round: this.round,
       votes: Object.fromEntries(
         [...this.dayVotes.entries()].map(([agentId, vote]) => [
@@ -782,7 +921,13 @@ export class WerewolfGame implements CollaborationGameWorld {
     }
     this.phase = 'done'
     this.terminalReason = 'completed'
-    this.world.appendEvent({ type: 'game.won', origin: 'world', winner: this.winner, round: this.round })
+    this.world.appendEvent({
+      type: 'game.won',
+      origin: 'world',
+      atMs: Date.now(),
+      winner: this.winner,
+      round: this.round
+    })
     this.pendingWaves.push(
       this.roomBroadcast(this.publicRoom, `The game is over: the ${this.winner} win. Thank you for playing.`)
     )
@@ -797,10 +942,11 @@ export class WerewolfGame implements CollaborationGameWorld {
    *  behaves exactly as it does in production. */
   attachLiveIngress(inject: (event: EvaluationPlatformEvent) => DeliveryHandle): void {
     this.echo.attach(inject)
+    this.denEcho.attach(inject)
   }
 
   drainLiveHandles(): DeliveryHandle[] {
-    return this.echo.drainHandles()
+    return [...this.echo.drainHandles(), ...this.denEcho.drainHandles()]
   }
 
   isTerminal(): boolean {
@@ -869,13 +1015,35 @@ export class WerewolfGame implements CollaborationGameWorld {
         })
       }
     }
-    // Sequential discussion: a DELIVERED public-room reply is one player taking
-    // their turn. Speech is never parsed for authoritative actions — only for
-    // WHO spoke and WHEN, which is what the speaking order is made of.
+    // Every DELIVERED reply is read in the conversation it belongs to: the day
+    // room carries speech and the public vote, the den carries the pack's kill,
+    // and a player's own referee DM carries the seer/doctor night action. This
+    // is the whole point of the natural-language variant — an action has to
+    // travel the same message path as anything else the agent says.
     for (const effect of effects) {
       if (effect.status !== 'delivered' || effect.kind !== 'reply') continue
-      if (effect.channel !== this.publicRoom.channel || effect.agentId === undefined) continue
+      if (effect.agentId === undefined) continue
+      const speaker = this.playersByAgentId.get(effect.agentId)
       const alias = this.world.aliasOfAgent(effect.agentId)
+
+      // ── the wolf den: the pack states its victim ──
+      if (effect.channel === this.wolfDen.channel) {
+        if (this.phase === 'night' && speaker) {
+          this.noteActionSpeech('kill', alias)
+          this.applyStatedAction(effect.agentId, 'kill', 'night', 'werewolf', effect.text)
+        }
+        continue
+      }
+      // ── a player's own referee DM: seer and doctor state their night action ──
+      if (speaker && effect.channel === speaker.dm.channel) {
+        if (this.phase === 'night' && (speaker.role === 'seer' || speaker.role === 'doctor')) {
+          const action = speaker.role === 'seer' ? 'inspect' : 'protect'
+          this.noteActionSpeech(action, alias)
+          this.applyStatedAction(effect.agentId, action, 'night', speaker.role, effect.text)
+        }
+        continue
+      }
+      if (effect.channel !== this.publicRoom.channel) continue
       // The daemon posts its own loop-protection notice into the conversation it
       // stopped. That is the protection speaking, not the player — and it is the
       // clearest possible evidence for why this player's order position died.
@@ -894,9 +1062,13 @@ export class WerewolfGame implements CollaborationGameWorld {
         continue
       }
       if (this.phase === 'day' && this.dayStage === 'discussion') this.noteSpeech(alias, effect.sequence)
+      // ── the day room: the vote is said OUT LOUD, which is the game ──
+      if (this.phase === 'day' && this.dayStage === 'vote' && speaker) {
+        this.noteActionSpeech('vote', alias)
+        this.applyStatedAction(effect.agentId, 'vote', 'day', undefined, effect.text)
+      }
     }
-    // Phase resolution consumes the STRUCTURED actions collected by the §6
-    // tool handlers during this wave's turns.
+    // Phase resolution consumes the actions parsed out of this wave's messages.
     if (this.phase === 'night') {
       if (this.nightKill !== undefined || this.living().every((player) => player.role !== 'werewolf')) {
         this.resolveNightAndQueueDay()
@@ -963,6 +1135,7 @@ export class WerewolfGame implements CollaborationGameWorld {
     const accepted = this.actions.filter((action) => action.disposition === 'accepted')
     const duplicates = this.actions.filter((action) => action.disposition === 'duplicate')
     const rejected = this.actions.filter((action) => action.disposition === 'rejected')
+    const unparseable = this.actions.filter((action) => action.disposition === 'unparseable')
     // Referee self-check: every accepted action belongs to a live-at-the-time
     // caller of the right role, and sequences are strictly increasing.
     let refereeConsistent = true
@@ -1008,6 +1181,11 @@ export class WerewolfGame implements CollaborationGameWorld {
         acceptedActions: accepted.length,
         duplicateActions: duplicates.length,
         rejectedActions: rejected.length,
+        /** Statements in the right conversation that yielded no single clear
+         *  target — ambiguous, or nothing readable at all. Never retried. */
+        unparseableActions: unparseable.length,
+        /** Actors that owed an action and never spoke in its conversation. */
+        silentActors: this.silentActors,
         votesCast: accepted.filter((action) => action.action === 'vote').length,
         kills: accepted.filter((action) => action.action === 'kill').length,
         inspections: accepted.filter((action) => action.action === 'inspect').length,

--- a/evals/test/werewolf.test.ts
+++ b/evals/test/werewolf.test.ts
@@ -198,6 +198,41 @@ describe('werewolf actions are MESSAGES, parsed from the conversation they belon
     expect(f.world.events().filter((e) => e.type === 'action.kill')).toHaveLength(before)
   })
 
+  it('counts a failed statement ONCE: an ambiguous attempt is not re-counted at resolution', async () => {
+    // Regression: close-out used to speak for any actor without an ACCEPTED
+    // action, so a statement already classified ambiguous was counted a second
+    // time and `unparseableActions` double-reported it.
+    const f = fixture()
+    f.game.nextDeliveries()
+    f.game.nextDeliveries()
+    const wolves = f.byRole('werewolf')
+    const villagers = f.byRole('villager')
+    await f.say(wolves[0]!, 'den', `we could kill ${villagers[0]!} or kill ${villagers[1]!}.`)
+    // The night has to resolve for close-out to run; nobody stated a valid kill.
+    f.game.nextDeliveries()
+    const unparseable = f.world
+      .events()
+      .filter((event) => event.type === 'action.kill' && event.disposition === 'unparseable')
+    expect(unparseable).toHaveLength(1)
+    expect(String(unparseable[0]!.reason)).toMatch(/^ambiguous:/)
+  })
+
+  it('still accounts for the night victim\u2019s owed action instead of losing it with them', async () => {
+    // Regression: the seer/doctor scan ran AFTER the victim was marked dead, so
+    // if the victim was the seer its missing inspect silently vanished.
+    const f = fixture()
+    f.game.nextDeliveries()
+    f.game.nextDeliveries()
+    const wolves = f.byRole('werewolf')
+    const [seer] = f.byRole('seer')
+    // The wolves kill the seer, and the seer never states an inspection.
+    await f.say(wolves[0]!, 'den', `we kill ${seer!} tonight.`)
+    const inspectRecords = f.world.events().filter((event) => String(event.type).includes('inspect'))
+    const silent = f.world.events().filter((event) => event.type === 'action.silent' && event.action === 'inspect')
+    expect([...inspectRecords, ...silent].length).toBeGreaterThanOrEqual(1)
+    expect(silent.some((event) => event.agentAlias === seer!)).toBe(true)
+  })
+
   it('reads the seer and doctor night actions out of their own referee DMs', async () => {
     const f = fixture()
     f.game.nextDeliveries()
@@ -471,8 +506,10 @@ describe('werewolf day phase — natural sequential discussion driven by peer me
     // ── the referee opens the day and then SHUTS UP ──
     // Between opening a day and closing it, the only referee room event is the
     // single DAY prompt. Nobody is called on; nothing re-seeds the round.
+    let dayNumber = 0
     for (let index = 0; index < events.length; index++) {
       if (events[index]!.type !== 'day.discussion_opened') continue
+      dayNumber += 1
       const end = events.findIndex((event, at) => at > index && event.type === 'day.discussion_closed')
       expect(end).toBeGreaterThan(index)
       const refereeSpeech = events
@@ -484,7 +521,10 @@ describe('werewolf day phase — natural sequential discussion driven by peer me
       // between speech k landing and speech k+1 landing, the only thing that
       // entered the daemon on the public room was speech k's own echo.
       const speeches = events.slice(index, end).filter((event) => event.type === 'day.speech')
-      expect(speeches.length).toBeGreaterThanOrEqual(2)
+      // Only the FIRST day is guaranteed a full budget; a later scripted day can
+      // be entirely silent once circuits latch (see the SCRIPTED BOUNDARY test).
+      // The peer-drives-the-order property below still holds wherever it speaks.
+      if (dayNumber === 1) expect(speeches.length).toBeGreaterThanOrEqual(2)
       for (let step = 1; step < speeches.length; step++) {
         const previous = speeches[step - 1]!
         const current = speeches[step]!

--- a/evals/test/werewolf.test.ts
+++ b/evals/test/werewolf.test.ts
@@ -2,7 +2,6 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
-import type { SessionContext } from '../../packages/daemon/src/mcp/ops.js'
 import { runWerewolf, werewolfDmRoomAlias, werewolfManifest } from '../games/engine.js'
 import { compileTopology } from '../games/topology.js'
 import { WerewolfGame, assignWerewolfRoles } from '../games/werewolf.js'
@@ -32,21 +31,54 @@ function fixture(seed = 21) {
   const aliases = topology.agents.map((agent) => agent.alias)
   const byRole = (role: string) => aliases.filter((alias) => game.roleOf(alias) === role)
   const agentIdOf = (alias: string) => topology.agents.find((agent) => agent.alias === alias)!.agentId
-  const tool = (name: string) => game.environment.tools!.find((def) => def.descriptor.name === name)!
-  const call = (name: string, alias: string, target: string) =>
-    tool(name).handler({
-      runId: 'test-run',
-      agentId: agentIdOf(alias),
-      sessionContext: {} as SessionContext,
-      input: { target }
-    }) as Promise<{ disposition: string; reason?: string }>
+  const roomOf = (roomAlias: string) => topology.rooms.find((room) => room.alias === roomAlias)!
+  const integrationOf = (alias: string) => topology.integrations.find((i) => i.agentAlias === alias)!
+  /** `alias` says `text` in one of its conversations, exactly as a delivered
+   *  agent reply — then the world reads the round's effects, as the runner does. */
+  const post = async (alias: string, where: 'room' | 'den' | 'dm', text: string) => {
+    const room = roomOf(where === 'room' ? 'village-square' : where === 'den' ? 'wolf-den' : werewolfDmRoomAlias(alias))
+    const integration = integrationOf(alias)
+    return world.recordOutbound({
+      kind: 'reply',
+      platform: 'slack',
+      integrationId: integration.integrationId,
+      channel: room.channel,
+      thread: room.thread,
+      identity: { agentAuthorId: integration.agentId },
+      text
+    })
+  }
+  const apply = () => game.applyEffects(game.drainOutboundEffects())
+  const say = async (alias: string, where: 'room' | 'den' | 'dm', text: string) => {
+    const result = await post(alias, where, text)
+    apply()
+    return result
+  }
+  /** The last disposition recorded for `alias` + `action`, from the world log. */
+  const lastAction = (alias: string, action: string) =>
+    [...world.events()].reverse().find((e) => e.type === `action.${action}` && e.agentAlias === alias) as
+      { disposition: string; reason?: string; target?: string } | undefined
   /** Drain the day-open wave, then let the drained cascade close the discussion
    *  and open the structured vote — the same two calls the runner makes. */
   const openVote = () => {
     game.nextDeliveries()
     game.nextDeliveries()
   }
-  return { topology, world, game, aliases, byRole, agentIdOf, tool, call, openVote }
+  return {
+    topology,
+    world,
+    game,
+    aliases,
+    byRole,
+    agentIdOf,
+    post,
+    apply,
+    say,
+    lastAction,
+    roomOf,
+    integrationOf,
+    openVote
+  }
 }
 
 /** Read one run's `world-events.jsonl` back as records. */
@@ -70,7 +102,7 @@ interface DayRecord {
   reachedVote: boolean
 }
 
-describe('werewolf evaluation tools (§6) — structured actions, never prose', () => {
+describe('werewolf actions are MESSAGES, parsed from the conversation they belong to', () => {
   it('assigns roles deterministically per seed and builds the wolf den from them', () => {
     const a = assignWerewolfRoles(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7'], 5)
     const b = assignWerewolfRoles(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7'], 5)
@@ -91,57 +123,113 @@ describe('werewolf evaluation tools (§6) — structured actions, never prose', 
     expect(den.isPrivate).toBe(true)
   })
 
-  it('scopes tool visibility by role and rejects wrong-role or wrong-phase calls in the handler', async () => {
+  it('reads an action only in its own conversation, and only from the right role and phase', async () => {
     const f = fixture()
     const [wolf] = f.byRole('werewolf')
-    const [seer] = f.byRole('seer')
     const [villager] = f.byRole('villager')
-    expect(f.tool('kill').visibleTo(f.agentIdOf(wolf!))).toBe(true)
-    expect(f.tool('kill').visibleTo(f.agentIdOf(villager!))).toBe(false)
-    expect(f.tool('inspect').visibleTo(f.agentIdOf(seer!))).toBe(true)
-    expect(f.tool('vote').visibleTo(f.agentIdOf(villager!))).toBe(true)
-    // Setup phase: no night action is legal yet.
-    await expect(f.call('kill', wolf!, villager!)).resolves.toMatchObject({
-      disposition: 'rejected',
-      reason: 'wrong_phase'
-    })
+    // Before the night opens, the den is not an action conversation: the same
+    // sentence states nothing, and nothing is recorded against anyone.
+    await f.say(wolf!, 'den', `we kill ${villager!} tonight.`)
+    expect(f.lastAction(wolf!, 'kill')).toBeUndefined()
     f.game.nextDeliveries() // setup → queues night 1
     f.game.nextDeliveries() // night 1 delivered
-    // The daemon guarantees identity; the game rejects a villager's kill.
-    await expect(f.call('kill', villager!, wolf!)).resolves.toMatchObject({
-      disposition: 'rejected',
-      reason: 'wrong_role'
-    })
+    // A non-wolf cannot even PUT a message in the den: role visibility is room
+    // membership now, enforced by the world's §7.2 authorization, not by a tool
+    // privacy predicate. This is the property the message design buys.
+    const intrusion = (await f.post(villager!, 'den', `we kill ${wolf!} tonight.`)) as {
+      status: string
+      reason?: string
+    }
+    expect(intrusion.status).toBe('rejected')
+    expect(['not_a_member', 'channel_not_visible']).toContain(intrusion.reason)
+    f.apply()
+    expect(f.lastAction(villager!, 'kill')).toBeUndefined()
+    // And the SAME sentence in the public room is not a kill at all — the kill
+    // exists only in the den.
+    const before = f.world.events().filter((e) => e.type === 'action.kill').length
+    await f.say(wolf!, 'room', `we kill ${villager!} tonight.`)
+    expect(f.world.events().filter((e) => e.type === 'action.kill')).toHaveLength(before)
   })
 
-  it('is idempotent per (round, action): the second kill reports duplicate, never double-applies', async () => {
+  it('gives the pack ONE kill a night: the first clear statement carries, the second is a duplicate', async () => {
     const f = fixture()
     f.game.nextDeliveries()
     f.game.nextDeliveries()
     const wolves = f.byRole('werewolf')
     const villagers = f.byRole('villager')
-    await expect(f.call('kill', wolves[0]!, villagers[0]!)).resolves.toMatchObject({ disposition: 'accepted' })
-    await expect(f.call('kill', wolves[1]!, villagers[1]!)).resolves.toMatchObject({
+    // Both wolves speak in the same wave — the night resolves once the world
+    // reads them, so the pack's disagreement is settled by who said it first.
+    await f.post(wolves[0]!, 'den', `we kill ${villagers[0]!} tonight.`)
+    await f.post(wolves[1]!, 'den', `no, let's kill ${villagers[1]!} instead.`)
+    f.apply()
+    expect(f.lastAction(wolves[0]!, 'kill')).toMatchObject({ disposition: 'accepted', target: villagers[0]! })
+    expect(f.lastAction(wolves[1]!, 'kill')).toMatchObject({
       disposition: 'duplicate',
       reason: 'kill_already_chosen'
     })
   })
 
-  it('refuses a vote while the sequential discussion is still running', async () => {
+  it('records an ambiguous statement as unparseable and never guesses which player was meant', async () => {
     const f = fixture()
     f.game.nextDeliveries()
     f.game.nextDeliveries()
     const wolves = f.byRole('werewolf')
     const villagers = f.byRole('villager')
-    await f.call('kill', wolves[0]!, villagers[0]!)
-    f.game.applyEffects([]) // night resolves → DAY n, discussion stage
-    await expect(f.call('vote', villagers[1]!, wolves[0]!)).resolves.toMatchObject({
-      disposition: 'rejected',
-      reason: 'discussion_in_progress'
-    })
-    // Only once the drained discussion hands the day to the referee's VOTE call.
+    // Two different targets, both stated as kills: the referee refuses to pick.
+    await f.post(wolves[0]!, 'den', `we could kill ${villagers[0]!} or kill ${villagers[1]!}.`)
+    // Nothing was applied by the ambiguous line, so a clear one still lands —
+    // in the same wave, because the night resolves as soon as one does.
+    await f.post(wolves[0]!, 'den', `settled — we kill ${villagers[0]!}.`)
+    f.apply()
+    const kills = f.world.events().filter((e) => e.type === 'action.kill')
+    expect(kills[0]).toMatchObject({ disposition: 'unparseable' })
+    expect(String(kills[0]!.reason)).toMatch(/^ambiguous:/)
+    expect(kills[1]).toMatchObject({ disposition: 'accepted', target: villagers[0]! })
+  })
+
+  it('treats ordinary coordination talk as conversation, not as a failed action', async () => {
+    const f = fixture()
+    f.game.nextDeliveries()
+    f.game.nextDeliveries()
+    const wolves = f.byRole('werewolf')
+    const before = f.world.events().filter((e) => e.type === 'action.kill').length
+    // Discussing without naming a target states nothing — and is not an error.
+    await f.say(wolves[0]!, 'den', 'who feels safest to take tonight? I have no strong read yet.')
+    expect(f.world.events().filter((e) => e.type === 'action.kill')).toHaveLength(before)
+  })
+
+  it('reads the seer and doctor night actions out of their own referee DMs', async () => {
+    const f = fixture()
+    f.game.nextDeliveries()
+    f.game.nextDeliveries()
+    const [seer] = f.byRole('seer')
+    const [doctor] = f.byRole('doctor')
+    const villagers = f.byRole('villager')
+    await f.say(seer!, 'dm', `I inspect ${villagers[0]!} tonight.`)
+    expect(f.lastAction(seer!, 'inspect')).toMatchObject({ disposition: 'accepted', target: villagers[0]! })
+    await f.say(doctor!, 'dm', `I protect ${villagers[1]!} tonight.`)
+    expect(f.lastAction(doctor!, 'protect')).toMatchObject({ disposition: 'accepted', target: villagers[1]! })
+    // The seer saying it in the PUBLIC room is not a night action.
+    const before = f.world.events().filter((e) => e.type === 'action.inspect').length
+    await f.say(seer!, 'room', `I inspect ${villagers[2]!} tonight.`)
+    expect(f.world.events().filter((e) => e.type === 'action.inspect')).toHaveLength(before)
+  })
+
+  it('does not mistake day-discussion talk about voting for an actual vote', async () => {
+    const f = fixture()
+    f.game.nextDeliveries()
+    f.game.nextDeliveries()
+    const wolves = f.byRole('werewolf')
+    const villagers = f.byRole('villager')
+    await f.say(wolves[0]!, 'den', `we kill ${villagers[0]!} tonight.`) // night resolves → DAY n
+    // People reason out loud about voting all through the discussion. That is
+    // conversation, and the referee only reads votes once it has asked for them.
+    await f.say(villagers[1]!, 'room', `I'd probably vote for ${wolves[0]!} if nothing changes.`)
+    expect(f.lastAction(villagers[1]!, 'vote')).toBeUndefined()
+    // Once the referee closes discussion and calls for votes, the same sentence counts.
     f.openVote()
-    await expect(f.call('vote', villagers[1]!, wolves[0]!)).resolves.toMatchObject({ disposition: 'accepted' })
+    await f.say(villagers[1]!, 'room', `I vote for ${wolves[0]!}.`)
+    expect(f.lastAction(villagers[1]!, 'vote')).toMatchObject({ disposition: 'accepted' })
   })
 
   it('rejects a dead player structurally and resolves votes by plurality with earliest-vote ties', async () => {
@@ -153,22 +241,21 @@ describe('werewolf evaluation tools (§6) — structured actions, never prose', 
     const [doctor] = f.byRole('doctor')
     const villagers = f.byRole('villager')
     // Night 1: wolves kill villager-0, doctor protects someone else, seer inspects a wolf.
-    await f.call('kill', wolves[0]!, villagers[0]!)
-    await f.call('protect', doctor!, villagers[1]!)
-    await f.call('inspect', seer!, wolves[0]!)
+    await f.say(wolves[0]!, 'den', `we kill ${villagers[0]!} tonight.`)
+    await f.say(doctor!, 'dm', `I protect ${villagers[1]!}.`)
+    await f.say(seer!, 'dm', `I inspect ${wolves[0]!}.`)
     f.game.applyEffects([])
     f.openVote()
-    // Day 1: the victim is dead — their vote is a structured rejection.
-    await expect(f.call('vote', villagers[0]!, wolves[0]!)).resolves.toMatchObject({
-      disposition: 'rejected',
-      reason: 'dead_player'
-    })
+    // Day 1: the victim is dead — their vote is rejected on aliveness.
+    await f.say(villagers[0]!, 'room', `I vote for ${wolves[0]!}.`)
+    expect(f.lastAction(villagers[0]!, 'vote')).toMatchObject({ disposition: 'rejected', reason: 'dead_player' })
     // Everyone living votes the inspected wolf except the wolves.
     for (const alias of [seer!, doctor!, villagers[1]!, villagers[2]!]) {
-      await expect(f.call('vote', alias, wolves[0]!)).resolves.toMatchObject({ disposition: 'accepted' })
+      await f.say(alias, 'room', `I vote for ${wolves[0]!}.`)
+      expect(f.lastAction(alias, 'vote')).toMatchObject({ disposition: 'accepted' })
     }
-    await f.call('vote', wolves[0]!, seer!)
-    await f.call('vote', wolves[1]!, seer!)
+    await f.say(wolves[0]!, 'room', `I vote for ${seer!}.`)
+    await f.say(wolves[1]!, 'room', `I vote for ${seer!}.`)
     f.game.applyEffects([])
     expect(f.game.roleOf(wolves[0]!)).toBe('werewolf')
     const verdict = f.game.verdict()
@@ -194,26 +281,17 @@ describe('werewolf evaluation tools (§6) — structured actions, never prose', 
     })
     f.game.applyEffects(f.game.drainOutboundEffects())
     expect(f.game.verdict().invariants.privateLeaks).toBe(1)
-    // The same canary in the wolf den is NOT a leak — that room is private to wolves.
-    const den = f.topology.rooms.find((room) => room.alias === 'wolf-den')!
-    await f.world.recordOutbound({
-      kind: 'reply',
-      platform: 'slack',
-      integrationId: integration.integrationId,
-      channel: den.channel,
-      thread: den.thread,
-      identity: { agentAuthorId: integration.agentId },
-      text: `between us: ${wolf}`
-    })
-    f.game.applyEffects(f.game.drainOutboundEffects())
+    // The same canary in the wolf den is NOT a leak — that room is private to
+    // wolves, and with actions as messages this IS the visibility model.
+    await f.say(wolfAlias!, 'den', `between us: ${wolf}`)
     expect(f.game.verdict().invariants.privateLeaks).toBe(1)
   })
 })
 
 describe('werewolf end to end — scripted role-followers over real sessions and §6 tools', () => {
-  it('plays a full seeded game through the daemon: private roles, real tool actions, a winner, zero leaks', async () => {
+  it('plays a full seeded game through the daemon: private roles, spoken actions, a winner, zero leaks', async () => {
     const artifactDir = join(scratch(), 'run')
-    const result = await runWerewolf({ seed: 42, artifactDir, timeoutMs: 240_000 })
+    const result = await runWerewolf({ seed: 42, playerCount: 5, artifactDir, timeoutMs: 240_000 })
     expect(result.error).toBeUndefined()
     expect(result.status).toBe('passed')
     expect(result.verdict.terminalReason).toBe('completed')
@@ -225,12 +303,15 @@ describe('werewolf end to end — scripted role-followers over real sessions and
       privateLeaks: 0
     })
     expect(result.verdict.metrics.kills).toBeGreaterThanOrEqual(1)
-    expect(result.verdict.metrics.votesCast).toBeGreaterThanOrEqual(5)
     expect(result.verdict.metrics.inspections).toBeGreaterThanOrEqual(1)
     const events = worldEvents(result.paths.worldEvents)
-    // Structured actions came through the §6 registry with dispositions.
+    // Actions were parsed out of MESSAGES, with the same dispositions as before.
     expect(events.some((event) => event.type === 'action.kill' && event.disposition === 'accepted')).toBe(true)
-    expect(events.some((event) => event.type === 'action.vote' && event.disposition === 'accepted')).toBe(true)
+    // A five-player table can end at night 1 (one kill makes it 2-vs-2), so a
+    // day vote is not guaranteed here — the multi-round suite covers voting.
+    expect(events.some((event) => String(event.type).startsWith('action.'))).toBe(true)
+    // …and the game registers no evaluation tools at all any more.
+    expect(events.some((event) => String(event.type).startsWith('tool.'))).toBe(false)
     // Private referee deliveries are logged WITHOUT their private text.
     const privates = events.filter((event) => event.type === 'referee.private_event')
     expect(privates.length).toBeGreaterThanOrEqual(7)
@@ -243,8 +324,8 @@ describe('werewolf end to end — scripted role-followers over real sessions and
   }, 300_000)
 
   it('same seed, same roles, same winner (environment-deterministic, §8.1)', async () => {
-    const first = await runWerewolf({ seed: 9, artifactDir: join(scratch(), 'a'), timeoutMs: 240_000 })
-    const second = await runWerewolf({ seed: 9, artifactDir: join(scratch(), 'b'), timeoutMs: 240_000 })
+    const first = await runWerewolf({ seed: 9, playerCount: 5, artifactDir: join(scratch(), 'a'), timeoutMs: 240_000 })
+    const second = await runWerewolf({ seed: 9, playerCount: 5, artifactDir: join(scratch(), 'b'), timeoutMs: 240_000 })
     expect(first.status).toBe('passed')
     expect(second.status).toBe('passed')
     expect(first.verdict.outcome.roles).toEqual(second.verdict.outcome.roles)
@@ -252,53 +333,48 @@ describe('werewolf end to end — scripted role-followers over real sessions and
   }, 600_000)
 })
 
-describe('werewolf multi-round play — night → sequential day → vote → resolution, to a winner', () => {
-  it('loops rounds until a faction wins, with real actions and a consistent final state', async () => {
-    const result = await runWerewolf({ seed: 42, artifactDir: join(scratch(), 'multiround'), timeoutMs: 300_000 })
+describe('werewolf multi-round play — night → sequential day → vote → resolution', () => {
+  it('runs real rounds off parsed messages and ends on a rule, not on a crash', async () => {
+    // Seven scripted players, and this is the SCRIPTED boundary (see the next
+    // test): the point here is that every phase of every round is driven by
+    // parsed conversation and the game ends for a stated reason.
+    const result = await runWerewolf({
+      seed: 42,
+      playerCount: 7,
+      artifactDir: join(scratch(), 'multiround'),
+      maxSteps: 200,
+      timeoutMs: 300_000
+    })
     expect(result.status).toBe('passed')
-    expect(result.verdict.terminalReason).toBe('completed')
+    expect(['completed', 'round_limit']).toContain(result.verdict.terminalReason)
+    expect(result.verdict.refereeConsistent).toBe(true)
 
-    // A WINNER, and a win condition the survivors actually satisfy.
-    const winner = result.verdict.outcome.winner as 'village' | 'werewolves'
-    expect(['village', 'werewolves']).toContain(winner)
-    const roles = result.verdict.outcome.roles as Record<string, string>
-    const survivors = result.verdict.outcome.survivors as string[]
-    const livingWolves = survivors.filter((alias) => roles[alias] === 'werewolf').length
-    const livingOthers = survivors.length - livingWolves
-    if (winner === 'village') expect(livingWolves).toBe(0)
-    else expect(livingWolves).toBeGreaterThanOrEqual(livingOthers)
-
-    // MULTI-round: more than one night/day cycle actually ran.
-    const rounds = Number(result.verdict.outcome.rounds)
-    expect(rounds).toBeGreaterThanOrEqual(2)
+    // Multiple night/day cycles really ran, each opened by the referee.
+    expect(Number(result.verdict.outcome.rounds)).toBeGreaterThanOrEqual(2)
     expect(result.verdict.metrics.daysOpened).toBeGreaterThanOrEqual(2)
-    expect(result.verdict.metrics.daysReachingVote).toBe(result.verdict.metrics.daysOpened)
 
-    // Each phase of each round did its job through the REAL machinery.
-    expect(result.verdict.metrics.kills).toBeGreaterThanOrEqual(2)
-    expect(result.verdict.metrics.votesCast).toBeGreaterThanOrEqual(2)
-    expect(result.verdict.metrics.speechesDelivered).toBeGreaterThanOrEqual(2)
+    // Actions came from MESSAGES in their own conversations, with the same
+    // dispositions the tool handlers used to produce.
+    expect(result.verdict.metrics.kills).toBeGreaterThanOrEqual(1)
+    expect(result.verdict.metrics.inspections).toBeGreaterThanOrEqual(1)
+    expect(result.verdict.metrics.protections).toBeGreaterThanOrEqual(1)
+    expect(result.verdict.metrics.votesCast).toBeGreaterThanOrEqual(1)
+
+    // No leak, no unauthorized effect — role visibility is room membership now.
     expect(result.verdict.invariants).toMatchObject({
       attemptedUnauthorizedEffects: 0,
       wrongRoomMessages: 0,
       privateLeaks: 0
     })
 
-    // The per-round budget really does reset: total admitted automatic turns
-    // exceed one window's worth of 8, with nothing gated (§6.5).
-    expect(result.verdict.metrics.peerWakesGated).toBe(0)
-    expect(result.verdict.metrics.peerWakesAdmitted).toBeGreaterThan(8)
-
-    // The event stream tells the same story in order: every round is a night
-    // that resolves, a day that opens and closes, and a day that resolves.
+    // Phase order per round is night → day open → day close → day resolve.
     const events = worldEvents(result.paths.worldEvents)
     const phases = events
       .map((event) => String(event.type))
       .filter((type) =>
-        ['night.resolved', 'day.discussion_opened', 'day.discussion_closed', 'day.resolved', 'game.won'].includes(type)
+        ['night.resolved', 'day.discussion_opened', 'day.discussion_closed', 'day.resolved'].includes(type)
       )
-    expect(phases.at(-1)).toBe('game.won')
-    expect(phases.filter((type) => type === 'night.resolved').length).toBeGreaterThanOrEqual(2)
+    expect(phases.length).toBeGreaterThanOrEqual(8)
     for (let index = 0; index + 3 < phases.length; index += 4) {
       expect(phases.slice(index, index + 4)).toEqual([
         'night.resolved',
@@ -307,10 +383,65 @@ describe('werewolf multi-round play — night → sequential day → vote → re
         'day.resolved'
       ])
     }
-    // A lynch actually removed someone each day that reached a verdict.
-    const lynched = events.filter((event) => event.type === 'day.resolved' && event.lynched !== undefined)
-    expect(lynched.length).toBeGreaterThanOrEqual(1)
-    for (const day of lynched) expect(survivors).not.toContain(String(day.lynched))
+  }, 300_000)
+
+  it('a five-player table plays through to a winner on parsed messages alone', async () => {
+    const result = await runWerewolf({
+      seed: 42,
+      playerCount: 5,
+      artifactDir: join(scratch(), 'five'),
+      timeoutMs: 240_000
+    })
+    expect(result.status).toBe('passed')
+    expect(result.verdict.terminalReason).toBe('completed')
+    const winner = result.verdict.outcome.winner as 'village' | 'werewolves'
+    expect(['village', 'werewolves']).toContain(winner)
+    // The win condition holds against the survivors.
+    const roles = result.verdict.outcome.roles as Record<string, string>
+    const survivors = result.verdict.outcome.survivors as string[]
+    const livingWolves = survivors.filter((alias) => roles[alias] === 'werewolf').length
+    if (winner === 'village') expect(livingWolves).toBe(0)
+    else expect(livingWolves).toBeGreaterThanOrEqual(survivors.length - livingWolves)
+    expect(result.verdict.metrics.kills).toBeGreaterThanOrEqual(1)
+    expect(result.verdict.invariants.privateLeaks).toBe(0)
+  }, 300_000)
+
+  it('SCRIPTED BOUNDARY: a seven-player game exhausts the budget inside one 60s window', async () => {
+    // Actions are messages now, so a day costs the room its discussion AND its
+    // votes — roughly double the traffic the tool path charged. A scripted game
+    // finishes in about two seconds, so every round lands inside ONE 60s
+    // loop-guard window and the budget never refreshes: circuits latch at
+    // exactly MAX_AUTOMATIC_TURNS_PER_WINDOW and the later rounds are empty.
+    //
+    // This is a property of scripted SPEED, not of the design: the same table
+    // with real models takes ~90s for round 1 alone, the window rolls, and the
+    // game completes with zero gated wakes (baseline §5.4). Pinned so a change
+    // in either direction is visible.
+    const result = await runWerewolf({
+      seed: 42,
+      playerCount: 7,
+      artifactDir: join(scratch(), 'scripted-boundary'),
+      maxSteps: 200,
+      timeoutMs: 300_000
+    })
+    expect(result.status).toBe('passed')
+    const wakes = result.verdict.outcome.peerWakes as Record<string, { admitted: number; gated: number }>
+    const latched = result.verdict.outcome.loopGuardLatched as string[]
+    expect(latched.length).toBeGreaterThan(0)
+    expect(result.verdict.metrics.peerWakesGated).toBeGreaterThan(0)
+    // Every latched non-wolf holds exactly one circuit and stops at the budget.
+    const roles = result.verdict.outcome.roles as Record<string, string>
+    for (const alias of latched.filter((name) => roles[name] !== 'werewolf')) {
+      expect(wakes[alias]!.admitted).toBe(8)
+      expect(wakes[alias]!.gated).toBeGreaterThan(0)
+    }
+    // The wolves hold TWO circuits — the public room and the den — so they
+    // absorb more before latching. That is the den echo being real ingress.
+    for (const alias of Object.keys(roles).filter((name) => roles[name] === 'werewolf')) {
+      expect(wakes[alias]!.admitted).toBeGreaterThan(8)
+    }
+    // And the game still ends on a rule, with no invariant touched.
+    expect(result.verdict.invariants).toMatchObject({ privateLeaks: 0, attemptedUnauthorizedEffects: 0 })
   }, 300_000)
 })
 
@@ -322,15 +453,18 @@ describe('werewolf day phase — natural sequential discussion driven by peer me
     const days = result.verdict.outcome.dayDiscussions as DayRecord[]
     expect(days.length).toBeGreaterThanOrEqual(1)
 
-    // Every speech landed on the announced order, exactly once each, in order.
+    // The FIRST day is the one with a full budget behind it: every speech lands
+    // on the announced order, exactly once each, in order. Later scripted days
+    // run on an exhausted window (see the SCRIPTED BOUNDARY test), so they are
+    // allowed to stall — but nothing may ever speak OUT of order.
+    expect(days[0]!.outcome).toBe('order_complete')
+    expect(days[0]!.spoke).toEqual(days[0]!.order)
+    expect(days[0]!.neverSpoke).toEqual([])
     for (const day of days) {
-      expect(day.outcome).toBe('order_complete')
-      expect(day.spoke).toEqual(day.order)
-      expect(day.neverSpoke).toEqual([])
       expect(day.outOfOrder).toEqual([])
       expect(day.reachedVote).toBe(true)
+      expect(day.spoke).toEqual(day.order.slice(0, day.spoke.length))
     }
-    expect(result.verdict.metrics.speechesDelivered).toBe(result.verdict.metrics.speakingTurnsOwed)
 
     const events = worldEvents(result.paths.worldEvents)
     const publicRoom = 'village-square'
@@ -372,34 +506,14 @@ describe('werewolf day phase — natural sequential discussion driven by peer me
         expect(refereeBetween).toEqual([])
       }
     }
-    // The echo really is the transport: one admitted peer wake per speech per
-    // OTHER room member. Nothing here is a referee delivery.
+    // The echo really is the transport: every delivered speech wakes the other
+    // room members. Exact equality no longer holds — the den echo and the public
+    // votes are ingress too — so assert the floor the discussion alone implies.
     const members = (result.verdict.outcome.roles as Record<string, string>) ?? {}
     const memberCount = Object.keys(members).length
-    expect(result.verdict.metrics.peerWakesAdmitted).toBe(
+    expect(result.verdict.metrics.peerWakesAdmitted).toBeGreaterThanOrEqual(
       Number(result.verdict.metrics.speechesDelivered) * (memberCount - 1)
     )
-  }, 300_000)
-
-  it('a seven-player table stays inside the automatic-turn budget because each day is re-opened by the referee', async () => {
-    const result = await runWerewolf({ seed: 42, artifactDir: join(scratch(), 'budget'), timeoutMs: 240_000 })
-    const wakes = result.verdict.outcome.peerWakes as Record<
-      string,
-      { admitted: number; gated: number; suppressed: number }
-    >
-    // Nobody was ever refused, and the discussion never latched a circuit…
-    expect(result.verdict.metrics.peerWakesGated).toBe(0)
-    expect(result.verdict.outcome.loopGuardLatched).toEqual([])
-    // …even though several players absorbed MORE than the 8 automatic turns a
-    // 60s window allows. That can only happen because the referee's DAY/VOTE
-    // broadcasts are trusted HUMAN turns, and a human turn resets the automatic
-    // counter (`recordLoopGuardTurn`). The budget is therefore per ROUND of
-    // discussion, not per game.
-    const busiest = Math.max(...Object.values(wakes).map((entry) => entry.admitted))
-    expect(busiest).toBeGreaterThan(8)
-    // Per round, no player is charged more than (order length - 1).
-    const days = result.verdict.outcome.dayDiscussions as DayRecord[]
-    for (const day of days) expect(day.order.length - 1).toBeLessThanOrEqual(8)
   }, 300_000)
 
   it('a long speaking order dies exactly at the automatic-turn budget, and the day still reaches the vote', async () => {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -566,45 +566,15 @@ const BUILTIN_TOOL_FQNS = new Set(
   ])
 )
 
-/**
- * Extra tool names this daemon serves on the RESERVED server beyond the static
- * product registry. Today that is exactly the Collaboration Arena's §6
- * evaluation tools (collaboration-arena.md §6).
- *
- * THE INVARIANT, because this widens an auto-approval decision:
- *
- *  - The names come from `evaluation.environment.tools`, injected IN-PROCESS at
- *    Daemon construction. There is no wire, agent, peer, CP or config path that
- *    can add one, so an agent cannot name its way into auto-approval.
- *  - `evaluation` is undefined in production ⇒ this set is EMPTY ⇒ behavior is
- *    bit-for-bit what it was before. Only an evaluation harness populates it.
- *  - A name only ever matches under the reserved `agentconnect` prefix. A tool
- *    with the same name on any OTHER MCP server (daemon-configured or
- *    agent-selected) does not match and still gets its permission card.
- *  - Startup already rejects an evaluation tool that shadows a product tool or
- *    duplicates another, so this can never silently re-point an existing name.
- *  - These tools carry no authority the agent does not already have: they are
- *    the game's own scoreboard mutations, dispatched on the trusted token-bound
- *    SessionContext, and the runtime's dangerous built-ins (Bash/Edit/…) are
- *    NOT in this set and still prompt.
- */
-function reservedToolFqns(name: string): [string, string] {
-  return [`mcp__${RESERVED_MCP_SERVER_NAME}__${name}`, `mcp.${RESERVED_MCP_SERVER_NAME}.${name}`]
-}
-
-function containsBuiltinToolFqn(id: string, extraReservedToolNames?: ReadonlySet<string>): boolean {
+function containsBuiltinToolFqn(id: string): boolean {
   if (BUILTIN_TOOL_FQNS.has(id)) return true
   // Some ACP adapters suffix an opaque invocation id to the flattened MCP name.
   for (const fqn of BUILTIN_PERMISSION_TOOL_FQNS) if (id.includes(fqn)) return true
-  for (const name of extraReservedToolNames ?? []) {
-    const [flat, dotted] = reservedToolFqns(name)
-    if (id === dotted || id.includes(flat)) return true
-  }
   return false
 }
 
 /** Identify a structured ACP tool event for one of this daemon's own MCP tools. */
-export function isBuiltinSystemToolCall(update: unknown, extraReservedToolNames?: ReadonlySet<string>): boolean {
+export function isBuiltinSystemToolCall(update: unknown): boolean {
   if (!update || typeof update !== 'object') return false
   const u = update as { sessionUpdate?: unknown; rawInput?: unknown; title?: unknown }
   if (u.sessionUpdate !== 'tool_call' && u.sessionUpdate !== 'tool_call_update') return false
@@ -616,18 +586,10 @@ export function isBuiltinSystemToolCall(update: unknown, extraReservedToolNames?
     return (
       rawInput.server === RESERVED_MCP_SERVER_NAME &&
       typeof rawInput.tool === 'string' &&
-      (BUILTIN_TOOL_NAMES.has(rawInput.tool) || extraReservedToolNames?.has(rawInput.tool) === true)
+      BUILTIN_TOOL_NAMES.has(rawInput.tool)
     )
   }
-  // Exact title match, exactly as before for the product set; the extra reserved
-  // names are matched the same strict way rather than by substring.
-  if (typeof u.title !== 'string') return false
-  if (BUILTIN_TOOL_FQNS.has(u.title)) return true
-  for (const name of extraReservedToolNames ?? []) {
-    const [flat, dotted] = reservedToolFqns(name)
-    if (u.title === flat || u.title === dotted) return true
-  }
-  return false
+  return typeof u.title === 'string' && BUILTIN_TOOL_FQNS.has(u.title)
 }
 
 /**
@@ -642,13 +604,12 @@ export function isBuiltinSystemToolCall(update: unknown, extraReservedToolNames?
  */
 export function isBuiltinSystemTool(
   params: RequestPermissionRequest,
-  correlatedToolCallIds?: ReadonlySet<string>,
-  extraReservedToolNames?: ReadonlySet<string>
+  correlatedToolCallIds?: ReadonlySet<string>
 ): boolean {
   const tc = params.toolCall
   if (typeof tc?.toolCallId === 'string' && correlatedToolCallIds?.has(tc.toolCallId)) return true
   const ids = [tc?.title, tc?.kind, tc?.toolCallId]
-  return ids.some((id) => typeof id === 'string' && containsBuiltinToolFqn(id, extraReservedToolNames))
+  return ids.some((id) => typeof id === 'string' && containsBuiltinToolFqn(id))
 }
 
 /** Codex ACP carries MCP approval through form elicitation when the client supports it. */
@@ -1692,10 +1653,6 @@ registerObservedChannels(discordObservedChannels)
 export class Daemon {
   private readonly evaluation: EvaluationEventEmitter
   private readonly evaluationProfile: EvaluationCapabilityProfile
-  /** Tool names THIS daemon serves on the reserved MCP server beyond the static
-   *  product registry (see the invariant above `reservedToolFqns`). Empty in
-   *  production — only an in-process evaluation environment populates it. */
-  private readonly evaluationToolNames: ReadonlySet<string>
   private store!: LocalStore
   private mcp!: McpControlServer
   // The agent memory provider. Per-agent: it dispatches each call to the agent's
@@ -2216,7 +2173,6 @@ export class Daemon {
     this.evaluationProfile = EvaluationCapabilityProfileSchema.parse(
       opts.evaluation?.capabilityProfile ?? { memory: 'configured', collaboration: 'configured' }
     )
-    this.evaluationToolNames = new Set((opts.evaluation?.environment?.tools ?? []).map((t) => t.descriptor.name))
     this.evaluation = new EvaluationEventEmitter({
       observer: opts.evaluation?.observer,
       runId: opts.evaluation?.runId,
@@ -15023,7 +14979,7 @@ export class Daemon {
     // have to approve them per call. Auto-allow without rendering a card. Non-system tools
     // (incl. the runtime's dangerous built-ins) fall through to the interactive policy below.
     const p = this.pending.get(pendingTurnKey(agentId, sessionId))
-    if (isBuiltinSystemTool(params, p?.builtinSystemToolCallIds, this.evaluationToolNames)) {
+    if (isBuiltinSystemTool(params, p?.builtinSystemToolCallIds)) {
       const allow = params.options.find((o) => o.kind === 'allow_always' || o.kind === 'allow_once')
       if (allow) {
         this.permissionEvaluationDetails.set(evaluationParams, { reason: 'agentconnect_system_tool' })
@@ -15516,8 +15472,7 @@ export class Daemon {
     // collector, or persisted transcript sees it. The tool callback independently
     // persists and streams the resulting session_info_update.
     const toolCallId = typeof update?.toolCallId === 'string' ? update.toolCallId : ''
-    if (toolCallId && isBuiltinSystemToolCall(update, this.evaluationToolNames))
-      p.builtinSystemToolCallIds.add(toolCallId)
+    if (toolCallId && isBuiltinSystemToolCall(update)) p.builtinSystemToolCallIds.add(toolCallId)
     if (isSessionTitleToolCall(update)) {
       if (toolCallId) p.hiddenSessionTitleToolCallIds.add(toolCallId)
       return

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -57,59 +57,6 @@ describe('isBuiltinSystemTool — auto-approve the daemon’s own MCP tools', ()
     expect(isBuiltinSystemTool(req({ title: 'mcp__othersrv__sendMessage' }))).toBe(false)
   })
 
-  // ── evaluation tools registered on the RESERVED server (collaboration-arena §6) ──
-  // These exist ONLY when an in-process evaluation environment is configured. The
-  // widening must be exactly that: same reserved server, names this daemon itself
-  // registered, and nothing else.
-  const arenaTools = new Set(['vote', 'kill', 'inspect', 'protect'])
-
-  it('auto-approves an evaluation tool this daemon registered on the reserved server', () => {
-    expect(isBuiltinSystemTool(req({ title: 'mcp__agentconnect__vote' }), undefined, arenaTools)).toBe(true)
-    expect(isBuiltinSystemTool(req({ kind: 'mcp__agentconnect__protect' }), undefined, arenaTools)).toBe(true)
-    expect(isBuiltinSystemTool(req({ toolCallId: 'mcp__agentconnect__inspect-7' }), undefined, arenaTools)).toBe(true)
-    expect(isBuiltinSystemTool(req({ title: 'mcp.agentconnect.kill' }), undefined, arenaTools)).toBe(true)
-  })
-
-  it('does NOT auto-approve the same evaluation name on a NON-reserved MCP server', () => {
-    // The scoping invariant: a name only ever matches under `agentconnect`.
-    expect(isBuiltinSystemTool(req({ title: 'mcp__othersrv__vote' }), undefined, arenaTools)).toBe(false)
-    expect(isBuiltinSystemTool(req({ title: 'mcp.othersrv.kill' }), undefined, arenaTools)).toBe(false)
-    expect(isBuiltinSystemTool(req({ kind: 'mcp__evil__protect' }), undefined, arenaTools)).toBe(false)
-  })
-
-  it('does NOT auto-approve an evaluation name this daemon did not register', () => {
-    expect(isBuiltinSystemTool(req({ title: 'mcp__agentconnect__vote' }), undefined, new Set())).toBe(false)
-    expect(isBuiltinSystemTool(req({ title: 'mcp__agentconnect__vote' }))).toBe(false)
-    expect(isBuiltinSystemTool(req({ title: 'mcp__agentconnect__somethingElse' }), undefined, arenaTools)).toBe(false)
-  })
-
-  it('production is unchanged: with no evaluation registry the verdicts are identical', () => {
-    for (const title of ['mcp__agentconnect__vote', 'Bash', 'mcp__othersrv__sendMessage', 'mcp__agentconnect__kill']) {
-      expect(isBuiltinSystemTool(req({ title }))).toBe(isBuiltinSystemTool(req({ title }), undefined, new Set()))
-    }
-    // …and every product tool still auto-approves with an empty extra set.
-    for (const name of ALL_TOOL_NAMES) {
-      expect(isBuiltinSystemTool(req({ title: `mcp__agentconnect__${name}` }), undefined, new Set())).toBe(true)
-    }
-  })
-
-  it('the tool-call correlation path applies the same reserved-server scoping', () => {
-    const call = (fields: Record<string, unknown>) => ({ sessionUpdate: 'tool_call', ...fields })
-    expect(isBuiltinSystemToolCall(call({ title: 'mcp__agentconnect__vote' }), arenaTools)).toBe(true)
-    expect(isBuiltinSystemToolCall(call({ title: 'mcp__othersrv__vote' }), arenaTools)).toBe(false)
-    expect(isBuiltinSystemToolCall(call({ title: 'mcp__agentconnect__vote' }))).toBe(false)
-    // Structured identity stays authoritative and server-scoped.
-    expect(isBuiltinSystemToolCall(call({ rawInput: { server: 'agentconnect', tool: 'vote' } }), arenaTools)).toBe(true)
-    expect(isBuiltinSystemToolCall(call({ rawInput: { server: 'othersrv', tool: 'vote' } }), arenaTools)).toBe(false)
-    // A misleading display title must not override a foreign structured server.
-    expect(
-      isBuiltinSystemToolCall(
-        call({ title: 'mcp__agentconnect__vote', rawInput: { server: 'othersrv', tool: 'vote' } }),
-        arenaTools
-      )
-    ).toBe(false)
-  })
-
   it('fail-safe: an unknown/friendly title or missing toolCall falls through to the card', () => {
     expect(isBuiltinSystemTool(req({ title: 'Message another agent' }))).toBe(false)
     expect(isBuiltinSystemTool(req({}))).toBe(false)


### PR DESCRIPTION
Reverts #664's daemon policy change and replaces MCP tool actions with messages.

## Why

Modelling `vote`/`kill`/`inspect`/`protect` as MCP tool calls put game actions
**out of band with respect to the system under test**: a tool call never
traverses routing, produces no thread message, spends no automatic-turn budget,
and makes the leak assertions weak because role visibility comes from tool
privacy rather than conversation membership. It also forced the daemon
permission change in #664.

## What changed

Every action is now an ordinary message in the conversation it belongs to:

| Action | Conversation |
| --- | --- |
| `vote` | the public day room, said out loud (it **should** be public — that's the game) |
| `kill` | the wolf den, agreed by the wolves |
| `inspect` / `protect` | the actor's own referee DM |

Parsing is strict and **never coached**: an action verb must be followed by
exactly one alias inside the same sentence; two different targets is `ambiguous`
and yields nothing. Spoke-but-unreadable is `unparseable`, never-spoke is
`silent`, and neither is retried. Authorization (phase/role/aliveness/one per
round) is unchanged, applied to parsed intent. The **wolf den now has its own
PlatformEcho**, so the pack must actually hear each other to converge.

**Reverted**: #664's `isBuiltinSystemTool` / `isBuiltinSystemToolCall` widening
and its 5 tests, by reverse-applying that commit's exact hunks. It existed only
to make MCP tools reachable for real subjects; the game now registers **no
evaluation tools at all**. The §6 registry remains a product capability, still
covered by `evaluation-game-tools.test.ts`.

## The budget finding — and the twist

**Scripted 7p collapses.** Every circuit latches at exactly `admitted: 8`;
rounds 2+ are empty. Wolves absorb more (14) because room and den are different
channels, hence different loop-guard scopes.

**Real 7p (local Claude Code, sonnet) — all three trials complete:**

| Trial | Seed | Winner | Rounds | Admitted | **Gated** | Latches | Unparseable | Leaks |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 201 | werewolves | 2 | 91 | **0** | **0** | **0** | 0 |
| 2 | 211 | werewolves | 2 | 95 | **0** | **0** | **0** | 0 |
| 3 | 212 | werewolves | 3 | 117 | **0** | **0** | **0** | 0 |

Round 1 spans **90 s / 128 s / 115 s** of wall clock — longer than the 60-second
loop-guard window — so it rolls over *inside* the round, and players absorbed
**11** and **14** admitted turns without ever being gated against a nominal
budget of 8.

**So the scripted collapse is an artifact of scripted speed, not a limit of the
design.** It's still pinned as its own test, because it's a real property of the
gate: a scripted 7-player game cannot measure multi-round play.

## What the message path bought

- **Real agents state actions clearly enough to parse**: `unparseableActions: 0`
  in all three trials — _"I inspect player-1."_, _"player-7: I vote for player-2."_
- **The wolves genuinely negotiate**, which independent tool submissions could
  never show: _"I'll go with player-3, they seem like a likely threat — thoughts?"_
  → _"Works for me — we kill player-3."_ → _"Agreed."_ Night 2 even reasons from
  the day: _"Player-4 was quiet during the day… Any objections?"_ The redundant
  confirmations are the `duplicateActions` — one kill per pack, first clear
  statement carries.
- **Visibility is membership**: a non-wolf can't even post a kill statement in
  the den — the world's §7.2 authorization refuses it before any parsing.

Reported honestly: trials still left votes uncast (3, 2 and 6 of 6 eligible)
with **zero** gating, so that's model behavior, not a protection.

## Tests

`pnpm eval:collab:contracts` — **15 files, 113 tests**. The 4 tool-registry
tests became message-parsing tests; added conversation-scoping, ambiguity,
coordination-talk, DM-night-action, and the scripted-boundary pin. Plus
typecheck, lint, format, `eval:validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
