### PR TITLE
fix(daemon): preserve warm sandbox config mount

### DIFF
--- a/packages/daemon/src/agents/config-file-env.ts
+++ b/packages/daemon/src/agents/config-file-env.ts
@@ -28,7 +28,7 @@
  * can read both. Cluster/registry-side scoping (per-agent ServiceAccounts,
  * least-privilege tokens) remains the real permission boundary.
  */
-import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 
 export interface ConfigFileConvention {
@@ -114,21 +114,27 @@ export interface MaterializeResult {
 /**
  * Materialize the planned config files under `configFilesDir(agentDir)`.
  *
- * The dir is wiped and rebuilt every call, so a removed/renamed secret
- * converges to file deletion on the next host spawn. A write failure keeps
- * that convention's env untouched (the raw data var stays visible to the
- * child — degraded, but strictly more usable than losing both) and reports a
- * notice.
+ * Existing contents are replaced every call, so a removed/renamed secret
+ * converges to file deletion on the next host spawn. The root directory itself
+ * is retained when it already exists: a warm Linux sandbox bind-mounts that
+ * directory inode, so replacing it would strand the child on the removed mount.
+ * A write failure keeps that convention's env untouched (the raw data var stays
+ * visible to the child — degraded, but strictly more usable than losing both)
+ * and reports a notice.
  */
 export function materializeConfigFiles(agentDir: string, env: Record<string, string | undefined>): MaterializeResult {
   const plan = planConfigFiles(env)
   const out: MaterializeResult = { env: {}, strip: [], notices: [...plan.notices] }
   const dir = configFilesDir(agentDir)
+  const clearError = clearConfigFiles(agentDir)
+  if (clearError) {
+    if (plan.materialize.length === 0) return out
+    out.notices.push(`${clearError} — secrets left as env vars.`)
+    return out
+  }
   try {
-    rmSync(dir, { recursive: true, force: true })
     if (plan.materialize.length > 0) mkdirPrivate(dir)
   } catch (err) {
-    if (plan.materialize.length === 0) return out
     out.notices.push(`config-files dir could not be prepared (${(err as Error).message}) — secrets left as env vars.`)
     return out
   }
@@ -159,13 +165,28 @@ export function materializeConfigFiles(agentDir: string, env: Record<string, str
 }
 
 /**
- * Remove an agent's materialized config files. Runs when the agent's host
- * stops (idle reap, removal, respawn, daemon shutdown) and as a boot sweep
- * after a non-graceful exit, so secret material does not rest in a second
- * on-disk copy while no child process can use it — the next spawn
- * re-materializes from the agent's secrets. Never throws: teardown must not
- * fail on a leftover file; a problem comes back as a message for the caller
- * to log.
+ * Remove materialized files while retaining the root directory inode. A live
+ * sandbox may have that directory bind-mounted read-only; keeping it in place
+ * lets a later materialization become visible inside the same warm child.
+ */
+export function clearConfigFiles(agentDir: string): string | undefined {
+  const dir = configFilesDir(agentDir)
+  try {
+    for (const entry of readdirSync(dir)) {
+      rmSync(join(dir, entry), { recursive: true, force: true })
+    }
+    return undefined
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    return `config-files contents could not be removed (${(err as Error).message})`
+  }
+}
+
+/**
+ * Remove an agent's materialized config-file directory after its host stops,
+ * and during the boot sweep after a non-graceful exit. With no live bind mount,
+ * teardown can remove the root too. Never throws: a problem comes back as a
+ * message for the caller to log.
  */
 export function cleanupConfigFiles(agentDir: string): string | undefined {
   try {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -78,7 +78,12 @@ import type {
   SubmitGithubReviewReq
 } from './mcp/ops.js'
 import { GitCredentialCache } from './cp/git-credential.js'
-import { CONFIG_FILE_CONVENTIONS, cleanupConfigFiles, materializeConfigFiles } from './agents/config-file-env.js'
+import {
+  CONFIG_FILE_CONVENTIONS,
+  cleanupConfigFiles,
+  clearConfigFiles,
+  materializeConfigFiles
+} from './agents/config-file-env.js'
 import { writeGhShim } from './cp/gh-shim.js'
 import { GitCredServer, gitcredShimPath, gitcredSocketPath, writeGitcredShim } from './cp/gitcred-server.js'
 import {
@@ -1738,7 +1743,7 @@ export class Daemon {
   // Recorded at spawn because the reconcile remove path drops the roster entry BEFORE
   // stopping the host — the agent dir can't be re-resolved there. `childEnv` is the
   // merged spawn env snapshot the materialization was planned from: the idle sweep
-  // deletes the files once the agent goes quiet (`materialized` → false) and
+  // clears the files once the agent goes quiet (`materialized` → false) and
   // rematerializeConfigFiles() re-writes them from this snapshot before the next
   // turn — the pointer env vars fixed at spawn always reference the same paths, so
   // the warm child never notices.
@@ -17171,7 +17176,10 @@ export class Daemon {
       // The lease also covers the settle→followup gap of a background task: a
       // task-drain turn flips sdkState to running before any tool can fire.
       if (this.agentHasLiveSdkWork(agentId)) continue
-      const err = cleanupConfigFiles(entry.agentDir)
+      // Keep the root inode: a warm bwrap child has this directory bind-mounted.
+      // Removing and recreating the path would leave that mount on the old,
+      // empty inode, so rematerialized files would still be invisible inside it.
+      const err = clearConfigFiles(entry.agentDir)
       if (err) {
         this.log.warn(`config-files: idle cleanup for agent "${agentId}" failed — ${err}`)
         continue

--- a/packages/daemon/test/config-file-env.test.ts
+++ b/packages/daemon/test/config-file-env.test.ts
@@ -88,15 +88,19 @@ describe('materializeConfigFiles', () => {
   it('rewrites a rotated value in place', () => {
     const dir = tmpAgentDir()
     materializeConfigFiles(dir, { KUBECONFIG_DATA: KUBE })
+    const rootInode = statSync(configFilesDir(dir)).ino
     materializeConfigFiles(dir, { KUBECONFIG_DATA: 'rotated' })
     expect(readFileSync(join(configFilesDir(dir), 'kubeconfig'), 'utf8')).toBe('rotated')
+    expect(statSync(configFilesDir(dir)).ino).toBe(rootInode)
   })
 
-  it('cleans up files with nothing planned and stays silent', () => {
+  it('clears files with nothing planned without replacing the root', () => {
     const dir = tmpAgentDir()
     materializeConfigFiles(dir, { KUBECONFIG_DATA: KUBE })
+    const rootInode = statSync(configFilesDir(dir)).ino
     const res = materializeConfigFiles(dir, {})
-    expect(existsSync(configFilesDir(dir))).toBe(false)
+    expect(existsSync(join(configFilesDir(dir), 'kubeconfig'))).toBe(false)
+    expect(statSync(configFilesDir(dir)).ino).toBe(rootInode)
     expect(res).toEqual({ env: {}, strip: [], notices: [] })
   })
 

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { createHash } from 'node:crypto'
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
@@ -944,17 +944,21 @@ describe('Daemon idle sweep (#111/#118)', () => {
     entry.materialized = true
     mkdirSync(configFilesDir(adir), { recursive: true })
     writeFileSync(kubeFile, 'apiVersion: v1')
+    const configRootInode = statSync(configFilesDir(adir)).ino
 
-    // Quiet past configFilesIdleMs → the files go, the host stays warm.
+    // Quiet past configFilesIdleMs → the files go, the host and its bind-mounted
+    // config root stay warm.
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
     expect(existsSync(kubeFile)).toBe(false)
+    expect(statSync(configFilesDir(adir)).ino).toBe(configRootInode)
     expect((daemon as any).hosts.has('bot-a')).toBe(true)
 
     // The next turn re-writes the file BEFORE the prompt reaches the child.
     await (daemon as any).dispatch('bot-a', dm('101', 'again'), 'int-a')
     expect(sawFileAtPrompt.at(-1)).toBe(true)
     expect(readFileSync(kubeFile, 'utf8')).toBe('apiVersion: v1')
+    expect(statSync(configFilesDir(adir)).ino).toBe(configRootInode)
 
     await daemon.stop()
   }, 15_000)

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -6,6 +6,7 @@ import { createServer } from 'node:net'
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -18,6 +19,7 @@ import {
 import { SandboxManager, SandboxRuntimeConfigSchema } from '@anthropic-ai/sandbox-runtime'
 import { sandboxWrap, sandboxBoundary, SandboxError, detectSandbox, writeSandboxSettings } from '../src/acp/sandbox.js'
 import { claudeInnerSandboxSettings } from '../src/acp/claude-runtime.js'
+import { clearConfigFiles, configFilesDir, materializeConfigFiles } from '../src/agents/config-file-env.js'
 
 // Ordinary ACP hosts launch through one SRT provider process with an immutable,
 // daemon-written policy rather than assembling bwrap arguments themselves.
@@ -197,6 +199,68 @@ describe('bwrap PID isolation', () => {
     })
     const out = execFileSync(cmd, args, { encoding: 'utf8', env: { ...process.env, HOME: home } }).trim()
     expect(out).toBe('OK')
+  })
+})
+
+// A warm bwrap process binds the config-files directory once. Idle cleanup must
+// retain that inode so files written for the next turn appear through the live
+// mount rather than at a new host path the sandbox cannot see.
+describe('bwrap config-file rematerialization', () => {
+  const hasBwrap = detectSandbox() === 'bwrap'
+
+  it.skipIf(!hasBwrap)('keeps a rematerialized kubeconfig visible inside the warm sandbox', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-sbx-config-'))
+    const agentDir = join(root, 'agent')
+    const workspace = join(agentDir, 'workspace')
+    const home = join(agentDir, 'home')
+    mkdirSync(workspace, { recursive: true })
+    mkdirSync(home)
+    materializeConfigFiles(agentDir, { KUBECONFIG_DATA: 'first' })
+    const kubeconfig = join(configFilesDir(agentDir), 'kubeconfig')
+    const configRootInode = statSync(configFilesDir(agentDir)).ino
+    const settingsPath = writeSandboxSettings(
+      agentDir,
+      sandboxBoundary({ agentDir, cwd: workspace, runtimeHome: home })
+    )
+    const { cmd, args } = sandboxWrap(
+      'sh',
+      [
+        '-c',
+        'printf "before:"; cat "$KUBECONFIG"; printf "\\n"; read _; printf "after:"; cat "$KUBECONFIG"; printf "\\n"'
+      ],
+      { mechanism: 'bwrap', writable: [workspace, home], settingsPath, cwd: workspace }
+    )
+    const child = spawn(cmd, args, {
+      cwd: workspace,
+      env: { ...process.env, HOME: home, KUBECONFIG: kubeconfig },
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8').on('data', (chunk) => (stdout += chunk))
+    child.stderr.setEncoding('utf8').on('data', (chunk) => (stderr += chunk))
+    const closed = new Promise<number | null>((resolve, reject) => {
+      child.once('error', reject)
+      child.once('close', resolve)
+    })
+    const timeout = setTimeout(() => child.kill('SIGKILL'), 10_000)
+
+    try {
+      await expect.poll(() => stdout, { timeout: 5_000 }).toContain('before:first\n')
+      expect(clearConfigFiles(agentDir)).toBeUndefined()
+      expect(existsSync(kubeconfig)).toBe(false)
+      expect(statSync(configFilesDir(agentDir)).ino).toBe(configRootInode)
+      materializeConfigFiles(agentDir, { KUBECONFIG_DATA: 'second' })
+      expect(statSync(configFilesDir(agentDir)).ino).toBe(configRootInode)
+      child.stdin.end('continue\n')
+
+      expect(await closed, stderr).toBe(0)
+      expect(stdout).toBe('before:first\nafter:second\n')
+    } finally {
+      clearTimeout(timeout)
+      if (child.exitCode === null) child.kill('SIGKILL')
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

- keep the materialized `config-files` root inode stable for the lifetime of a warm ACP host
- clear only secret file contents during the short idle sweep, while retaining full directory removal after host teardown and at startup
- cover the lifecycle invariant locally and exercise rematerialization through a live bwrap mount in the dedicated Linux sandbox lane

## Root cause

The idle secret sweep recursively removed the directory that SRT/bwrap had already bind-mounted into a warm sandbox. Rematerialization recreated the same host path, but the live mount still referenced the removed directory inode, so tools such as kubectl could not see the new kubeconfig until the ACP host was rebuilt.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/config-file-env.test.ts test/daemon-lifecycle.test.ts test/sandbox.test.ts --reporter=dot --silent` (79 passed, 3 Linux-only tests skipped locally)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- focused ESLint and Prettier checks
- full repository ESLint via the pre-push hook

Created by Codex . GPT-5.6