### PR TITLE
fix(sessions): decouple access from agent visibility

### DIFF
--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -540,7 +540,7 @@ The CP stores **session metadata only** — `session_meta` rows synced by the
 while transcripts, tool payloads, and attachment bytes live solely in the
 daemon's local store. The two console views therefore split:
 
-- **The list** (`GET /sessions`) is a **CP database read** of the stored metadata — cursor-paginated (activity-ordered), filtered to the agents the caller may see (visibility inherits from the owning agent) — with no daemon round-trip; it works with every daemon offline.
+- **The list** (`GET /sessions`) is a **CP database read** of the stored metadata — cursor-paginated (activity-ordered) and filtered by each Session's audience, independently from owning-Agent Team visibility — with no daemon round-trip; it works with every daemon offline.
 - **The transcript** (`GET /sessions/:id/messages`, plus large tool bodies) remains an on-demand pull from the owning daemon over `session/history` / `session/tool-body`, proxied to the UI and never persisted. `session/list` is a daemon-side read-back frame and does not serve the console list.
 
 ```ts
@@ -588,11 +588,12 @@ separately.
 
 **List** (`GET /sessions`): a **CP database read** of the
 `event/session`-synced metadata — cursor-paginated, ordered by last activity,
-scoped to the caller's visible agents; `agentId`/`platform`/`channel` filters
-narrow the set. No daemon is contacted.
+scoped by each Session's audience; `agentId`/`platform`/`channel` filters narrow
+the set. An Agent id is only a storage/filter key here and its Team visibility
+does not hide an otherwise readable Session. No daemon is contacted.
 
 **History** (`GET /sessions/:id/messages?cursor=&limit=`): the CP loads the
-`session_meta` row, authorizes its owning agent, and resolves that agent's
+`session_meta` row, authorizes its Session audience, and resolves its recorded
 daemon; `session/history` carries the owner `agentId` so the daemon can verify
 the `(agentId, sessionId)` binding before returning content. Cursor-based,
 newest-first. If the agent is unplaced or its daemon is offline → 503 (the list

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -38,11 +38,11 @@ This design adds **per-resource visibility**:
 
 ### Decided policy semantics
 
-| Decision                                   | Choice                                                                                                                                                                                 | Meaning                                                                                                               |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| How is the access level determined?        | **Visibility first, then organization role**                                                                                                                                           | Everyone/Selected controls who can see a resource. Existing roles determine editing. There is no per-grant edit flag. |
-| Does an owner have a governance exception? | **No**                                                                                                                                                                                 | Organization ownership grants org administration, never access to another member's restricted resource.               |
-| Which resource types carry visibility?     | **Agent, Daemon, Cron, MCP provider, and skill source are independent.** Integration, Session, Usage, CronRun, and daemon API keys derive from a parent. Bot is shared infrastructure. | See the taxonomy in section 2.                                                                                        |
+| Decision                                   | Choice                                                                                                                                                                                                                                                                                                              | Meaning                                                                                                               |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| How is the access level determined?        | **Visibility first, then organization role**                                                                                                                                                                                                                                                                        | Everyone/Selected controls who can see a resource. Existing roles determine editing. There is no per-grant edit flag. |
+| Does an owner have a governance exception? | **No**                                                                                                                                                                                                                                                                                                              | Organization ownership grants org administration, never access to another member's restricted resource.               |
+| Which resource types carry visibility?     | **Agent, Daemon, Cron, MCP provider, and skill source carry Team visibility independently.** Session has a separate audience boundary. Integration derives from Agent; Usage intersects Agent visibility with Session audience; CronRun and daemon API keys derive from their parent. Bot is shared infrastructure. | See the taxonomy in section 2.                                                                                        |
 
 ### Authoritative predicates
 
@@ -87,14 +87,15 @@ Both are accepted under a model of collaborator trust within an organization.
 
 ## 2. Resource taxonomy
 
-| Category               | Resource                                                   | Own `visibility` and `sharedWith`? | Source                                               |
-| ---------------------- | ---------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------- |
-| **Visibility carrier** | `Agent`, `Daemon`, `CronDef`, `McpProvider`, `SkillSource` | Yes, independent columns           | Itself                                               |
-| **Derived**            | `Integration`                                              | No                                 | Its `Agent`                                          |
-| **Derived**            | `SessionMeta`, `SessionUsage`                              | No                                 | Its `Agent`                                          |
-| **Derived**            | `CronRun`                                                  | No                                 | Its `CronDef`                                        |
-| **Derived**            | daemon `ApiKey`                                            | No                                 | Its `Daemon`; key minting is a credential operation  |
-| **Infrastructure**     | `Bot`                                                      | No                                 | Always organization-visible and cannot be restricted |
+| Category                 | Resource                                                   | Own audience fields?                                        | Source                                               |
+| ------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------- |
+| **Visibility carrier**   | `Agent`, `Daemon`, `CronDef`, `McpProvider`, `SkillSource` | `ResourceVisibility` + `sharedWith`                         | Itself                                               |
+| **Independent audience** | `SessionMeta`                                              | `SessionVisibility` + owner/external scope; no `sharedWith` | Itself; see `session-visibility.md`                  |
+| **Derived**              | `Integration`                                              | No                                                          | Its `Agent`                                          |
+| **Derived intersection** | `SessionUsage`                                             | No                                                          | Its `Agent` and `SessionMeta`                        |
+| **Derived**              | `CronRun`                                                  | No                                                          | Its `CronDef`                                        |
+| **Derived**              | daemon `ApiKey`                                            | No                                                          | Its `Daemon`; key minting is a credential operation  |
+| **Infrastructure**       | `Bot`                                                      | No                                                          | Always organization-visible and cannot be restricted |
 
 **Agent and daemon visibility are independent.** An agent may be visible while
 its hosting daemon is not; see section 7.
@@ -371,8 +372,12 @@ human principal.
 
 ## 7. Derived visibility and cascading rules
 
-- **Integration, Session, and Usage derive from Agent** and are filtered by a
-  parent relation or route-level `canView`.
+- **Integration derives from Agent** and is filtered by a parent relation or
+  route-level `canView`.
+- **Session is independent from Agent Team visibility** for human reads and
+  uses its own audience plus the active organization boundary.
+- **Usage is a resource-scoped intersection:** Agent visibility and the
+  corresponding Session audience both apply to session-backed aggregates.
 - **CronRun derives from CronDef** through `getOrgCron` or a nested relation.
 - **Daemon API keys derive from Daemon** through `canView` and `canEdit` in
   `keys.ts`.
@@ -597,7 +602,8 @@ handler.
 - **Locations:** agent creation in `AddAgentModal`; agent edit and detail in
   `EditAgentModal` and the General card; cron in `AddCronModal`, which is also
   the edit modal through its `cron?` prop and is opened by `ScheduleDetailView`;
-  daemon in the Details card. Sessions derive visibility and have no control.
+  daemon in the Details card. Sessions are outside these Team-sharing controls
+  and use the independent audience UI in `session-visibility.md`.
 - **Mobile:** modals use one responsive JSX tree, but the General and Details
   cards in `AgentDetailView` and `DaemonDetailView` have separate desktop and
   `isMobile` JSX branches; see `AgentDetailView.tsx:34,49` and `useIsMobile`.
@@ -623,16 +629,17 @@ while `visibilityWhere(undefined)` equals `{}`.
 3. An unshared organization owner receives the same hidden result as any other role.
 4. An authorized viewer gets 200 from GET and 403 from PATCH.
 5. A shared collaborator can edit content and sharing; a shared viewer cannot.
-6. Sessions from the **real fan-out route** and usage for a restricted agent do
-   not appear for a non-viewer; a restricted cron gates `CronRun` history.
+6. Session list/detail/body reads follow the Session audience even when the
+   owning Agent is restricted; usage for that Agent remains absent to an
+   unshared viewer, and a restricted cron gates `CronRun` history.
 7. SQL WHERE results equal `.filter(canView)` for a mixed viewer.
 8. After `migrate deploy`, existing rows have `visibility='org'` and
    `sharedWith=[]`.
 9. Unauthorized users get 404 from workspace `gitstatus` and `gitpull`.
 10. Removing a member repairs all five Selected audiences, preserves creator
     audit, and removes their ID from every `sharedWith` in the same transaction.
-11. `tool-body` returns 404 for both a cross-organization agent ID and a hidden
-    restricted agent in the same organization.
+11. `tool-body` returns 404 for both a cross-organization Session and a Session
+    outside the caller's audience.
 12. A restricted but active agent remains in the daemon reconciliation roster;
     `listForDaemon` and `reconcile` do not filter.
 13. Exercise Prisma `has:` against real Postgres for
@@ -641,8 +648,8 @@ while `visibilityWhere(undefined)` equals `{}`.
 14. `POST /api/v1/orgs/:orgId/agents/:agentId/webchat/token` returns 404 to an
     unauthorized collaborator for a restricted agent; no relay WebSocket
     credential is minted.
-15. A restricted agent's milestone does not appear in an unauthorized viewer's
-    SSE stream.
+15. SSE forwards a visible Session milestone even when its Agent is restricted,
+    while a Session outside the caller's audience remains absent.
 16. Cron-upsert `agentId`, integration-create `agentId`, and agent-create
     `daemonId` reject invisible targets in a way indistinguishable from missing
     IDs.

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -260,47 +260,15 @@ install routes. Every route derives visibility from the parent agent.
   parent agent rather than checking only the organization at
   `integrations.ts:116-118`.
 
-### 5.5 Session: daemon fan-out, not `SessionRepo.list`
+### 5.5 Session: an independent audience boundary
 
-The Control Plane does not store sessions. `GET /sessions` at
-`sessions.ts:52-96` fans out to online daemons through
-`deps.control.sessionList` at `sessions.ts:71` and merges results in memory by
-platform and channel. `SessionRepo.list` at `session.repo.ts:69-80` had zero
-callers, so putting a filter there would be dead code.
-
-- Filter fan-out results **at the route**. After merging, parse each session's
-  `agentId`, load the corresponding records in one `agent.list(orgId)` call,
-  and discard rows for which `canView(agent, ctxOf(req))` is false. For
-  `?agentId=`, validate `canView` before the query so a client cannot enumerate
-  UUIDs.
-- Apply the same gate before proxying the transcript from
-  `GET /sessions/:id/messages`, whose organization check is at
-  `sessions.ts:116-119`, and `GET /sessions/:id/tool-body`.
-- **Transcript body boundary:** `getOrgSessionAgent(req, agentId)` requires both
-  `agent.orgId === req.orgCtx.orgId` and `canView`, closing the cross-tenant
-  leak.
-- **SSE `GET /orgs/:orgId/stream`:** filter every `event/session` milestone by
-  agent visibility, not only by daemon organization. An envelope
-  includes `agentId`, `phase`, `link`, and a short human-readable,
-  content-derived `summary`; see `protocol/src/frames/telemetry.ts:25-33`. Both
-  the existence of a restricted agent's session and its summary would leak.
-
-Three filtering options were considered:
-
-1. **Drop the entire envelope, recommended for existence hiding.** Resolve
-   `agentId -> canView` per envelope and omit an invisible event. This reveals
-   not even activity and matches list/get 404 semantics. Following the existing
-   per-connection `daemonOrg` memo at `stream.ts:51-59`, memoize
-   `agentId -> canView` so each connection loads an agent only once.
-2. **Forward without `summary`, exposing existence but hiding content.** The
-   observer still sees `agentId`, `phase`, `link`, and timing. This blocks the
-   human-readable milestone but leaks the restricted resource and activity.
-3. **Organization-wide, with no filtering.** This is unacceptable because
-   `summary` derives from content.
-
-**Decision: option 1, drop the whole envelope.** It is consistent with
-"restricted means invisible" and costs one `AgentRepo.get` per agent ID per
-connection.
+Sessions now have their own persisted audience and are not child resources of
+the owning Agent for human reads. The current contract is authoritative in
+[`session-visibility.md`](session-visibility.md): list, detail, transcript,
+tool-body, relationships, and SSE all use the Session predicate plus the active
+organization boundary. A readable Session may project its owning Agent's name,
+but it does not make a restricted Agent resource, configuration, or workspace
+readable. Analytics remains resource-scoped and keeps the Agent intersection.
 
 ### 5.6 Usage: `usage.ts -> sessionUsage.aggregate`
 

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -110,9 +110,9 @@ Consequences:
 - When identity linking ships for a platform, those sessions become visible
   to the mapped user **automatically**, with no backfill: the stored
   `ownerIdentity` is already correct; only the viewer's identity set grows.
-- The predicate is always additionally scoped by `orgId` and by agent
-  visibility, so an identity match can never reach across orgs; the workspace
-  segment above closes the remaining same-org, cross-tenant collision.
+- The predicate is always additionally scoped by `orgId`, but never by Agent
+  Team visibility. The organization boundary prevents cross-org access; the
+  workspace segment above closes the remaining same-org, cross-tenant collision.
 
 ## 3. Data-model changes (`packages/control-plane/prisma/schema.prisma`)
 
@@ -466,6 +466,11 @@ Session read surfaces use the Session predicate as their authorization boundary:
 | Usage                         | `http/routes/usage.ts`                                                                    | keep the resource-scoped analytics intersection: Agent visibility plus the Session predicate on every session-backed aggregate                                                       |
 
 Invariants preserved:
+
+- Agent facets return Session-scoped display labels only for Agents represented
+  by the visible facet result. A hidden Agent can therefore filter readable
+  Sessions without gaining an Agent link or exposing Agents with no readable
+  Session.
 
 - Console **authorization** stays a CP concern: internal/daemon read paths
   keep the deliberate fail-open (`visibilityWhere(undefined)` semantics), and

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -28,9 +28,10 @@ This design gives every session its own visibility:
   webchat** sessions, and sessions launched through the **Web API**. A
   Feishu/Lark custom-Bot p2p ownership matches through the user's cross-App
   `union_id`.
-- **`org`** — visible to every org member who can view the owning agent.
-  Default for automation-originated sessions and shared IM sessions when the
-  corresponding external-audience policy is disabled.
+- **`org`** — visible to every organization member, independently from the
+  owning Agent's Team visibility. Default for automation-originated sessions
+  and shared IM sessions when the corresponding external-audience policy is
+  disabled.
 - **`external`** — visible only when the viewer currently has provider access
   to the immutable external source scope recorded when the session was created.
   Slack stores `(workspace, conversation)`: public channels admit linked,
@@ -48,9 +49,12 @@ This design gives every session its own visibility:
   link is readable by anyone holding the link. Deliberately **not** a member of
   the visibility enum; see §8.
 
-Session visibility **composes with** agent visibility: a session is visible iff
-the viewer can view the owning agent **and** passes the session-level
-predicate. It never widens agent visibility.
+Session visibility is **independent from** Agent Team visibility. Passing the
+session-level predicate grants access only to that Session's metadata,
+transcript, and Session-scoped live updates. It does not grant access to the
+owning Agent resource, configuration, workspace, or invocation controls. The
+Console may project the Agent's display name as Session context, but links it
+only when the Agent resource is independently visible.
 
 ## 2. The owner identity problem
 
@@ -451,16 +455,15 @@ transport failure — is `unknown`: deny plus `degraded`, which is what raises
 "external access checks are unavailable" and is re-asked on the short unknown
 TTL.
 
-All of these already gate on agent visibility; each additionally applies the
-session predicate:
+Session read surfaces use the Session predicate as their authorization boundary:
 
-| Surface                       | Where                                                                                     | Change                                                                                                                                                                                               |
-| ----------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| List + facets                 | `persistence/repositories/session.repo.ts` (`pageWhereSql` — raw SQL, not Prisma `where`) | `AND (visibility = 'org' OR owner_identity = ANY(:identitySet))`, applied to every viewer (no org-owner bypass)                                                                                      |
-| Detail / messages / tool-body | `http/routes/sessions.ts` `getOrgViewableSession`                                         | apply `canViewSession` after the agent gate; fail as 404                                                                                                                                             |
-| Children                      | `session.repo.ts` `listChildren`                                                          | same predicate; invisible parent already renders `null`                                                                                                                                              |
-| SSE                           | `http/routes/stream.ts`                                                                   | applies the predicate to every session-scoped envelope (`event/session` milestones and `event/session-activity` invalidations), and rechecks live org membership and agent visibility for each event |
-| Usage                         | `http/routes/usage.ts`                                                                    | same predicate on every session-backed aggregate                                                                                                                                                     |
+| Surface                       | Where                                                                                     | Change                                                                                                                                                                               |
+| ----------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| List + facets                 | `persistence/repositories/session.repo.ts` (`pageWhereSql` — raw SQL, not Prisma `where`) | enumerate the org's Agent ids only as a storage scope, then apply `AND (visibility = 'org' OR owner_identity = ANY(:identitySet))` to every viewer (no org-owner bypass)             |
+| Detail / messages / tool-body | `http/routes/sessions.ts` `getOrgViewableSession`                                         | require the row's `orgId` plus `canViewSession`; fail as 404 without consulting Agent Team visibility                                                                                |
+| Children                      | `session.repo.ts` `listChildren`                                                          | same predicate; an invisible parent renders `null`, while a visible child is retained even when its owning Agent is hidden                                                           |
+| SSE                           | `http/routes/stream.ts`                                                                   | apply the predicate to every session-scoped envelope (`event/session` milestones and `event/session-activity` invalidations) and recheck live organization membership for each event |
+| Usage                         | `http/routes/usage.ts`                                                                    | keep the resource-scoped analytics intersection: Agent visibility plus the Session predicate on every session-backed aggregate                                                       |
 
 Invariants preserved:
 
@@ -609,8 +612,7 @@ learned from it"); silence is not an option.
   uses the viewer's own profile status to offer `Link <provider> profile` when
   unlinked or `Review <provider> profile` when linked. The unavailable state lists
   those possible reasons explicitly: the session may not exist or may have been
-  removed, the required profile may be absent or linked to another workspace, or the
-  owning Agent may not be shared with the viewer.
+  removed, or the required profile may be absent or linked to another workspace.
   Unsupported providers and ordinary/handwritten URLs get no provider action. The
   hint is intentionally forgeable and never consulted for authorization, so none
   of this guidance can confirm whether the session exists; the protected session
@@ -696,9 +698,10 @@ link ends public access without touching the session row.
   `conversationKind`; the §4.5 state machine — pending settlement is
   one-time and conditional (never overwrites `explicit`), tightening
   cascades transitively, widening never cascades.
-- **Integration (`test:int`):** list/detail/SSE visibility for a two-member
-  org (each member sees identity-owned private + org sessions; the owner role
-  does not widen private visibility);
+- **Integration (`test:int`):** list/detail/messages/SSE visibility for a
+  two-member org (each member sees identity-owned private + org sessions; the
+  owner role does not widen private visibility), plus a handoff child whose
+  Session remains readable while its restricted owning Agent stays 404;
   SSE assertion that **neither** `event/session` nor `event/session-activity`
   for a private session reaches an unauthorized subscriber; keyset pagination
   stability under the new predicate; migration backfill (`org` + `orgId`) on

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -542,7 +542,9 @@ Every session carries its own audience, independent from the Team visibility of 
 that owns it. Passing the Session audience grants access to that Session's metadata and
 transcript; it does not grant access to the Agent's page, configuration, workspace, or
 invocation controls. The Console may show the owning Agent's display name as Session
-context, but makes it a link only when the viewer can also see that Agent.
+context and as a Session-filter label, but makes it an Agent link only when the viewer
+can also see that Agent. Selecting the label scopes Session results; it grants no Agent
+access.
 
 Platform direct messages, Playground and webchat conversations, and sessions launched
 through the Web API default to **private**: only their owner can see them — deliberately no

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -538,20 +538,27 @@ visibility grant.
 
 ## Session visibility
 
-Every session carries its own visibility, composed with — never widening — the visibility
-of the agent that owns it. Platform direct messages, Playground and webchat conversations,
-and sessions launched through the Web API default to **private**: only their owner can see
-them — deliberately no role exception, org owners included. Channel sessions, group direct
-messages, and automation-originated sessions (cron, hook, dream, agent-to-agent) default
-to **org**, visible to every member who can already view the agent. A session's initiator
-is recorded regardless of tier, and re-classification belongs to that recorded initiator
-alone: the person who started a channel conversation may later pull it private, and only a
-private session's owner may publish it back. Roles grant no re-classification rights — an
-org owner cannot flip someone else's session in either direction.
+Every session carries its own audience, independent from the Team visibility of the Agent
+that owns it. Passing the Session audience grants access to that Session's metadata and
+transcript; it does not grant access to the Agent's page, configuration, workspace, or
+invocation controls. The Console may show the owning Agent's display name as Session
+context, but makes it a link only when the viewer can also see that Agent.
+
+Platform direct messages, Playground and webchat conversations, and sessions launched
+through the Web API default to **private**: only their owner can see them — deliberately no
+role exception, org owners included. Channel sessions, group direct messages, and
+automation-originated sessions (cron, hook, dream, agent-to-agent) default to **org**,
+visible to every organization member. A session's initiator is recorded regardless of
+tier, and re-classification belongs to that recorded initiator alone: the person who
+started a channel conversation may later pull it private, and only a private session's
+owner may publish it back. Roles grant no re-classification rights — an org owner cannot
+flip someone else's session in either direction.
 
 An agent-to-agent child inherits its parent's visibility, because a delegation copies the
 parent's prompt into the child's transcript. Tightening a session therefore cascades to its
 descendants; publishing one never does — widening a child stays that child's own decision.
+The child remains readable to everyone in that inherited audience even when its target
+Agent is hidden from them.
 
 A session the caller may not see is reported as missing, not as forbidden: the console must
 not reveal that it exists.

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -843,10 +843,10 @@ enum ActivityState {
 }
 
 // Per-session visibility tier (docs/designs/session-visibility.md §1): 'org'
-// (default) = visible to every member who can view the owning agent; 'private'
-// = session owner (identity match) ONLY — no role override, org owners included;
-// 'external' = current provider audience. Composes with agent visibility — it
-// never widens it. Share-by-link is deliberately NOT a member of this enum (§8).
+// (default) = visible to every organization member; 'private' = session owner
+// (identity match) ONLY — no role override, org owners included; 'external' =
+// current provider audience. Session reads are independent from owning-Agent
+// Team visibility. Share-by-link is deliberately NOT a member of this enum (§8).
 enum SessionVisibility {
   private
   org

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2389,6 +2389,9 @@ export const SessionDto = z.object({
 export const SessionListDto = z.array(SessionDto)
 export const SessionFacetsDto = z.object({
   agents: z.array(z.string()),
+  /** Session-scoped labels for the returned facet ids. They do not imply that
+   *  the corresponding Agent resource is visible. */
+  agentNames: z.record(z.string(), z.string()),
   integrations: z.array(z.string()),
   channels: z.array(
     z.object({

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2348,6 +2348,8 @@ export const SessionDto = z.object({
   sessionId: z.string(),
   sessionKey: SessionKeyDto,
   agentId: z.string(),
+  /** Session-scoped display projection. It does not grant access to the Agent. */
+  agentName: z.string().nullable(),
   title: z.string().nullable(),
   status: z.string().nullable(),
   lastActivityAt: z.string().nullable(),
@@ -2460,6 +2462,8 @@ export const SessionListPageDto = z.object({
 export const SessionRelationDto = z.object({
   id: z.string(),
   agentId: z.string(),
+  /** Session-scoped display projection. It does not grant access to the Agent. */
+  agentName: z.string().nullable(),
   platform: z.string(),
   title: z.string().nullable()
 })
@@ -2470,6 +2474,8 @@ export const SessionDetailDto = z.object({
   siblingSessions: z.array(SessionRelationDto),
   childSessions: z.array(SessionRelationDto),
   agentId: z.string(),
+  /** Session-scoped display projection. It does not grant access to the Agent. */
+  agentName: z.string().nullable(),
   launchId: z.string().nullable(),
   platform: z.string().nullable(),
   channel: z.string().nullable(),
@@ -2514,8 +2520,8 @@ export const SessionDetailDto = z.object({
   /** Multi-agent webchat conversation roster, in pick order (webchat-multi-agents.md
    *  §3.1). Adopted/refreshed sessions have no live relay socket to deliver the
    *  verified roster, so the composer and header read it from here. Null for
-   *  single-agent conversations and for every other platform; `name` is null when
-   *  the caller cannot view that participant's agent. */
+   *  single-agent conversations and for every other platform; `name` is null only
+   *  when the Agent no longer has a resolvable display record. */
   participants: z
     .array(z.object({ agentId: z.string(), name: z.string().nullable(), primary: z.boolean() }))
     .nullable(),

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -205,8 +205,13 @@ function sessionDisplayMetadata(
   }
 }
 
-function sessionFacets(index: SessionFacetIndex, hookMetadata: Map<string, HookSessionMetadata>) {
+function sessionFacets(
+  index: SessionFacetIndex,
+  hookMetadata: Map<string, HookSessionMetadata>,
+  agentNames: ReadonlyMap<string, string>
+) {
   const integrations = new Set<string>()
+  const facetAgentNames: Record<string, string> = {}
   const channels = new Map<
     string,
     { value: string; platform: string; integration: string; name: string | null; triggeredByName: string | null }
@@ -228,6 +233,10 @@ function sessionFacets(index: SessionFacetIndex, hookMetadata: Map<string, HookS
       b.startedAt.getTime() - a.startedAt.getTime() ||
       b.id.localeCompare(a.id)
   )
+  for (const agentId of index.agents) {
+    const name = agentNames.get(agentId)
+    if (name) facetAgentNames[agentId] = name
+  }
   for (const session of integrationRows) {
     const hook = hookMetadataForSession(hookMetadata, session)
     integrations.add(sessionIntegration(session, hook))
@@ -260,6 +269,7 @@ function sessionFacets(index: SessionFacetIndex, hookMetadata: Map<string, HookS
 
   return {
     agents: index.agents,
+    agentNames: facetAgentNames,
     integrations: [...integrations],
     channels: [...channels.values()],
     triggers: [...triggers.values()]
@@ -452,10 +462,12 @@ export function sessionRoutes(deps: HttpDeps) {
         }
       },
       async (req) => {
-        const orgAgentIds = (await deps.repos.agent.list(orgOf(req))).map((agent) => agent.id)
+        const orgAgents = await deps.repos.agent.list(orgOf(req))
+        const orgAgentIds = orgAgents.map((agent) => agent.id)
+        const agentNames = new Map(orgAgents.map((agent) => [agent.id, agentDisplayName(agent)]))
         const requested = requestedAgentIds(req.query)
         if (requested.some((id) => !new Set<string>(orgAgentIds).has(id))) {
-          return { agents: [], integrations: [], channels: [], triggers: [] }
+          return { agents: [], agentNames: {}, integrations: [], channels: [], triggers: [] }
         }
         const { githubHookIds, repoHookIds } = await githubHookFilters(deps, orgOf(req), req.query, true)
         // A multi-agent request narrows to the qualifying CONVERSATIONS and then
@@ -479,7 +491,7 @@ export function sessionRoutes(deps: HttpDeps) {
         const index = await deps.repos.session.listFacets({ ...query, viewer })
         const metadataRows = [...index.integrations, ...index.channels, ...index.triggers]
         const hookMetadata = await hookMetadataForSessions(deps, metadataRows, orgOf(req))
-        return sessionFacets(index, hookMetadata)
+        return sessionFacets(index, hookMetadata, agentNames)
       }
     )
 

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -18,7 +18,7 @@ import type { HttpDeps } from '../deps.js'
 import { AgentId, HookId, OrgId, SessionId } from '../../domain/ids.js'
 import { orgOf, ctxOf, denyNonOwner } from '../rbac.js'
 import { decodeConversationKey, encodeConversationKey } from '../conversation-key.js'
-import { canChangeSessionVisibility, canView, canViewSession } from '../../authorization/policy.js'
+import { canChangeSessionVisibility, canViewSession } from '../../authorization/policy.js'
 import { makeSessionAccessResolver } from '../session-access.js'
 import { Tag } from '../plugins/openapi.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
@@ -120,8 +120,21 @@ function hookIdForSession(s: HookSessionRow): string | null {
   return HookIdString.safeParse(id).success ? id : null
 }
 
-function sessionRelation(s: { id: string; agentId: string; platform: string | null; title: string | null }) {
-  return { id: s.id, agentId: s.agentId, platform: s.platform ?? 'slack', title: s.title }
+function agentDisplayName(agent: { name: string; displayName?: string | null }): string {
+  return agent.displayName?.trim() || agent.name
+}
+
+function sessionRelation(
+  s: { id: string; agentId: string; platform: string | null; title: string | null },
+  agentNames: ReadonlyMap<string, string>
+) {
+  return {
+    id: s.id,
+    agentId: s.agentId,
+    agentName: agentNames.get(s.agentId) ?? null,
+    platform: s.platform ?? 'slack',
+    title: s.title
+  }
 }
 
 function hookMetadataForSession(metadata: Map<string, HookSessionMetadata>, session: HookSessionRow) {
@@ -253,7 +266,11 @@ function sessionFacets(index: SessionFacetIndex, hookMetadata: Map<string, HookS
   }
 }
 
-function sessionDto(s: SessionPageRow, hookMetadata: Map<string, HookSessionMetadata>) {
+function sessionDto(
+  s: SessionPageRow,
+  hookMetadata: Map<string, HookSessionMetadata>,
+  agentNames: ReadonlyMap<string, string>
+) {
   const hook = hookMetadataForSession(hookMetadata, s)
   const display = sessionDisplayMetadata(s, hook)
   return {
@@ -264,6 +281,7 @@ function sessionDto(s: SessionPageRow, hookMetadata: Map<string, HookSessionMeta
       ...(s.thread !== null ? { thread: s.thread } : {})
     },
     agentId: s.agentId,
+    agentName: agentNames.get(s.agentId) ?? null,
     title: s.title ?? null,
     status: s.status ?? null,
     lastActivityAt: s.lastActivityAt.toISOString(),
@@ -316,20 +334,12 @@ export function sessionRoutes(deps: HttpDeps) {
   return async function sessionRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
 
-    // Fetch an agent AND verify it's in the caller's org AND visible to them — a
-    // cross-org id OR a restricted agent they can't see both read as absent (404).
-    // Sessions/usage/tool-bodies all derive their visibility from the owning agent.
-    const getOrgViewableAgent = async (req: FastifyRequest, agentId: string) => {
-      const agent = await deps.repos.agent.get(AgentId(agentId))
-      if (!agent || agent.orgId !== req.orgCtx!.orgId) return null
-      return canView(agent, ctxOf(req)) ? agent : null
-    }
-
-    // Session visibility (session-visibility.md §5) COMPOSES with the agent gate
-    // above: a session is visible iff its agent is visible AND the caller passes
-    // the session predicate. The repo arm and this in-app check must stay two
-    // spellings of one rule — both come from `canViewSession`, fed the SAME
-    // identity set: console identity plus provider-plugin contributions.
+    // Session reads are authorized by the Session audience, independently from
+    // the owning Agent's Team visibility. Passing this gate grants transcript
+    // access only; Agent configuration and workspace routes keep their own Agent
+    // resource gate. The repo arm and this in-app check must stay two spellings
+    // of one rule — both come from `canViewSession`, fed the SAME identity set:
+    // console identity plus provider-plugin contributions.
     const sessionAccess = makeSessionAccessResolver(deps)
     const viewerForQuery = async (req: FastifyRequest, query: Parameters<typeof sessionAccess.forQuery>[1]) => {
       const access = await sessionAccess.forQuery(req, query)
@@ -345,11 +355,10 @@ export function sessionRoutes(deps: HttpDeps) {
 
     const getOrgViewableSession = async (req: FastifyRequest, sessionId: string) => {
       const session = await deps.repos.session.get(SessionId(sessionId))
-      if (!session) return null
+      if (!session || session.orgId !== orgOf(req)) return null
       const access = await sessionAccess.forSessions(req, [session])
       if (!canViewSession(session, ctxOf(req), access.identitySet, access.externalAccess)) return null
-      const agent = await getOrgViewableAgent(req, session.agentId)
-      return agent ? { session, agent, access } : null
+      return { session, access }
     }
 
     type ExternalAccessProvider = 'slack' | 'github' | 'feishu'
@@ -443,9 +452,9 @@ export function sessionRoutes(deps: HttpDeps) {
         }
       },
       async (req) => {
-        const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctxOf(req))).map((agent) => agent.id)
+        const orgAgentIds = (await deps.repos.agent.list(orgOf(req))).map((agent) => agent.id)
         const requested = requestedAgentIds(req.query)
-        if (requested.some((id) => !new Set<string>(visibleAgentIds).has(id))) {
+        if (requested.some((id) => !new Set<string>(orgAgentIds).has(id))) {
           return { agents: [], integrations: [], channels: [], triggers: [] }
         }
         const { githubHookIds, repoHookIds } = await githubHookFilters(deps, orgOf(req), req.query, true)
@@ -454,7 +463,7 @@ export function sessionRoutes(deps: HttpDeps) {
         // the selected agents' rows: a facet answers "what else can I narrow by",
         // and a conversation's channel is the same whichever member you read.
         const query = {
-          agentIds: visibleAgentIds,
+          agentIds: orgAgentIds,
           ...(requested.length === 1 ? { agentId: AgentId(requested[0]!) } : {}),
           ...(requested.length > 1 ? { conversationAgentIds: requested.map(AgentId) } : {}),
           ...(req.query.platform ? { platform: req.query.platform } : {}),
@@ -465,8 +474,8 @@ export function sessionRoutes(deps: HttpDeps) {
           ...(repoHookIds ? { hookTriggerIds: repoHookIds } : {})
         }
         // Each facet drops its own active filter, so its external-audience
-        // snapshot must span the same visible-agent superset.
-        const { viewer } = await viewerForQuery(req, { agentIds: visibleAgentIds.map(AgentId) })
+        // snapshot must span the same org-agent superset.
+        const { viewer } = await viewerForQuery(req, { agentIds: orgAgentIds.map(AgentId) })
         const index = await deps.repos.session.listFacets({ ...query, viewer })
         const metadataRows = [...index.integrations, ...index.channels, ...index.triggers]
         const hookMetadata = await hookMetadataForSessions(deps, metadataRows, orgOf(req))
@@ -502,22 +511,22 @@ export function sessionRoutes(deps: HttpDeps) {
           return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: 'invalid conversation key' })
         }
 
-        // The set of agents THIS caller may see under the resource policy. Roles
-        // never widen visibility, so restricted-agent rows are hidden before any
-        // title/channel/usage metadata reaches the caller.
-        const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctxOf(req))).map((agent) => agent.id)
-        const visibleAgentIdSet = new Set<string>(visibleAgentIds)
-        // Every requested agent must be visible. One the caller cannot see makes
-        // the whole answer empty rather than being quietly dropped: silently
-        // widening a two-agent question to a one-agent one would answer a
-        // question they did not ask with rows they may not have wanted.
+        // Agent Team visibility does not narrow Session reads. Agent names are a
+        // session-scoped display projection only; the Agent endpoints remain
+        // resource-gated, so a hidden owner still has no Agent/Workspace link.
+        const orgAgents = await deps.repos.agent.list(orgOf(req))
+        const orgAgentIds = orgAgents.map((agent) => agent.id)
+        const orgAgentIdSet = new Set<string>(orgAgentIds)
+        const agentNames = new Map(orgAgents.map((agent) => [agent.id, agentDisplayName(agent)]))
+        // Every requested id must still name an Agent in this org. Unknown and
+        // cross-org ids make the whole answer empty rather than being dropped.
         const requested = requestedAgentIds(req.query)
         const selectedAgentIds =
           requested.length > 0
-            ? requested.every((id) => visibleAgentIdSet.has(id))
+            ? requested.every((id) => orgAgentIdSet.has(id))
               ? requested.map(AgentId)
               : []
-            : visibleAgentIds
+            : orgAgentIds
         // Org-level "any session exists" boolean (first page only). Computed over the
         // FULL org — including sessions the caller can't see — which is safe precisely
         // because it is a bare boolean; the getting-started conversation step derives
@@ -545,7 +554,7 @@ export function sessionRoutes(deps: HttpDeps) {
         // still names the participants an agent filter kept out of its `sessions`.
         // It reaches the query before the viewer is resolved, because the scopes
         // that authorize those extra members have to be resolved with it.
-        const memberAgentIds = requested.length > 0 ? visibleAgentIds : undefined
+        const memberAgentIds = requested.length > 0 ? orgAgentIds : undefined
         const query = {
           agentIds: selectedAgentIds,
           ...(conversationAgentIds ? { conversationAgentIds } : {}),
@@ -588,7 +597,7 @@ export function sessionRoutes(deps: HttpDeps) {
                       platform: conversationKey.platform,
                       channel: conversationKey.channel,
                       thread: conversationKey.thread,
-                      sessions: rows.map((session) => sessionDto(session, hookMetadata)),
+                      sessions: rows.map((session) => sessionDto(session, hookMetadata, agentNames)),
                       memberSessionIds: members.map((session) => session.id)
                     }
                   ]
@@ -605,7 +614,7 @@ export function sessionRoutes(deps: HttpDeps) {
           const hookMetadata = await hookMetadataForSessions(deps, page.sessions, orgOf(req))
           const nextCursor = page.hasMore ? encodeSessionCursor(page.sessions[page.sessions.length - 1]!) : null
           return {
-            sessions: page.sessions.map((session) => sessionDto(session, hookMetadata)),
+            sessions: page.sessions.map((session) => sessionDto(session, hookMetadata, agentNames)),
             total: page.total,
             nextCursor,
             accessSyncDegraded: access.degraded,
@@ -627,7 +636,7 @@ export function sessionRoutes(deps: HttpDeps) {
             platform: c.key.platform,
             channel: c.key.channel,
             thread: c.key.thread,
-            sessions: c.sessions.map((session) => sessionDto(session, hookMetadata)),
+            sessions: c.sessions.map((session) => sessionDto(session, hookMetadata, agentNames)),
             memberSessionIds: c.memberSessionIds
           })),
           total: page.total,
@@ -642,7 +651,7 @@ export function sessionRoutes(deps: HttpDeps) {
     // Deep-link detail (…/sessions/:id): served from CP-stored SessionMeta (synced
     // via the `event/session` EVT), so the page resolves even when the daemon is
     // offline. Metadata only — the transcript stays a `/messages` daemon pull.
-    // 404 for an unknown session OR one whose owning agent this caller can't see.
+    // 404 for an unknown session OR one outside the Session's own audience.
     r.get(
       '/sessions/:id',
       {
@@ -662,17 +671,18 @@ export function sessionRoutes(deps: HttpDeps) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
         }
         const { session: s, access } = owned
-        // Relationships may cross agents (and daemons), so apply the same
-        // owning-agent visibility rule to every linked session. A hidden parent
-        // is indistinguishable from no parent; hidden children are omitted.
-        const visibleAgents = await deps.repos.agent.list(orgOf(req), ctxOf(req))
-        const visibleAgentIds = visibleAgents.map((a) => a.id)
-        const visibleAgentIdSet = new Set<string>(visibleAgentIds)
+        // Relationships may cross agents (and daemons). Enumerate Agents only to
+        // keep the metadata query org-scoped and to project display names; each
+        // linked Session is independently filtered by its own audience below.
+        const orgAgents = await deps.repos.agent.list(orgOf(req))
+        const orgAgentIds = orgAgents.map((agent) => agent.id)
+        const orgAgentIdSet = new Set<string>(orgAgentIds)
+        const agentNames = new Map(orgAgents.map((agent) => [agent.id, agentDisplayName(agent)]))
         const ctx = ctxOf(req)
         const [parent, children, siblingCandidates, usage, webchatRoster, hookMetadata] = await Promise.all([
           s.parentSessionId ? deps.repos.session.get(s.parentSessionId) : Promise.resolve(null),
-          deps.repos.session.listChildren(SessionId(s.id), visibleAgentIds),
-          s.parentSessionId ? deps.repos.session.listChildren(s.parentSessionId, visibleAgentIds) : Promise.resolve([]),
+          deps.repos.session.listChildren(SessionId(s.id), orgAgentIds),
+          s.parentSessionId ? deps.repos.session.listChildren(s.parentSessionId, orgAgentIds) : Promise.resolve([]),
           deps.repos.sessionUsage.get(s.agentId, s.id),
           // A webchat session's channel IS its conversation id; the roster feeds
           // the adopted-session composer/header, which has no relay socket.
@@ -688,7 +698,7 @@ export function sessionRoutes(deps: HttpDeps) {
         const relatedAccess = await sessionAccess.forSessions(req, related)
         const parentVisible =
           parent !== null &&
-          visibleAgentIdSet.has(parent.agentId) &&
+          orgAgentIdSet.has(parent.agentId) &&
           canViewSession(parent, ctx, relatedAccess.identitySet, relatedAccess.externalAccess)
         // A hidden parent is indistinguishable from no parent. Keep its sibling
         // branch hidden too, otherwise the response would still reveal the
@@ -711,10 +721,11 @@ export function sessionRoutes(deps: HttpDeps) {
         ]
         return {
           id: s.id,
-          parentSession: parentVisible ? sessionRelation(parent) : null,
-          siblingSessions: visibleSiblings.map(sessionRelation),
-          childSessions: visibleChildren.map(sessionRelation),
+          parentSession: parentVisible ? sessionRelation(parent, agentNames) : null,
+          siblingSessions: visibleSiblings.map((session) => sessionRelation(session, agentNames)),
+          childSessions: visibleChildren.map((session) => sessionRelation(session, agentNames)),
           agentId: s.agentId,
+          agentName: agentNames.get(s.agentId) ?? null,
           launchId: s.launchId,
           platform: s.platform,
           channel: s.channel,
@@ -736,7 +747,7 @@ export function sessionRoutes(deps: HttpDeps) {
             webchatRoster.length > 1
               ? webchatRoster.map((p) => ({
                   agentId: p.agentId,
-                  name: visibleAgents.find((a) => a.id === p.agentId)?.name ?? null,
+                  name: agentNames.get(p.agentId) ?? null,
                   primary: p.role === 'primary'
                 }))
               : null,

--- a/packages/control-plane/src/http/routes/sessions.viewer-identity.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.viewer-identity.test.ts
@@ -18,8 +18,9 @@ const SLACK_OWNER = 'slack:T024BE7LD:U0123ABCD'
 
 const agent = {
   id: 'agent-1',
+  name: 'hidden-agent',
   orgId: ORG_ID,
-  visibility: 'org',
+  visibility: 'restricted',
   sharedWith: []
 }
 
@@ -67,7 +68,10 @@ function slackDmSession() {
   }
 }
 
-function fakeDeps(overrides: { slackIdentityFor?: () => Promise<{ teamId: string; userId: string } | null> }) {
+function fakeDeps(overrides: {
+  slackIdentityFor?: () => Promise<{ teamId: string; userId: string } | null>
+  session?: ReturnType<typeof slackDmSession>
+}) {
   const listPage = vi.fn(async () => ({ sessions: [], total: 0, hasMore: false }))
   const listConversationPage = vi.fn(async () => ({ conversations: [], total: 0, hasMore: false }))
   const deps = {
@@ -77,7 +81,7 @@ function fakeDeps(overrides: { slackIdentityFor?: () => Promise<{ teamId: string
         get: vi.fn(async () => agent)
       },
       session: {
-        get: vi.fn(async () => slackDmSession()),
+        get: vi.fn(async () => overrides.session ?? slackDmSession()),
         orgHasAny: vi.fn(async () => true),
         listExternalScopes: vi.fn(async () => []),
         getExternalScopes: vi.fn(async () => []),
@@ -158,7 +162,7 @@ describe('session routes × viewer identity', () => {
     }
   })
 
-  it('serves the detail of a private Slack DM session to its linked owner', async () => {
+  it('serves the detail of a private Slack DM session to its linked owner even when the Agent is hidden', async () => {
     const { deps } = fakeDeps({
       slackIdentityFor: async () => ({ teamId: 'T024BE7LD', userId: 'U0123ABCD' })
     })
@@ -166,7 +170,8 @@ describe('session routes × viewer identity', () => {
     try {
       const res = await app.inject({ method: 'GET', url: '/sessions/sess-1' })
       expect(res.statusCode).toBe(200)
-      const body = res.json() as { visibility: string; canChangeVisibility: boolean }
+      const body = res.json() as { agentName: string; visibility: string; canChangeVisibility: boolean }
+      expect(body.agentName).toBe('hidden-agent')
       expect(body.visibility).toBe('private')
       // Identity match also grants §4.3 re-classification, exactly like a
       // `user:<id>`-owned row.
@@ -184,6 +189,21 @@ describe('session routes × viewer identity', () => {
     try {
       const res = await app.inject({ method: 'GET', url: '/sessions/sess-1' })
       expect(res.statusCode).toBe(404)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('still 404s a matching Session audience from another organization', async () => {
+    const session = slackDmSession()
+    session.orgId = 'org-2'
+    const { deps } = fakeDeps({
+      session,
+      slackIdentityFor: async () => ({ teamId: 'T024BE7LD', userId: 'U0123ABCD' })
+    })
+    const app = await appAs(deps, { userId: 'u-1', oidcSubject: 'logto-sub' })
+    try {
+      expect((await app.inject({ method: 'GET', url: '/sessions/sess-1' })).statusCode).toBe(404)
     } finally {
       await app.close()
     }

--- a/packages/control-plane/src/http/routes/stream.test.ts
+++ b/packages/control-plane/src/http/routes/stream.test.ts
@@ -1,34 +1,48 @@
 import { describe, expect, it } from 'vitest'
-import type { Shareable, ViewCtx } from '../../authorization/policy.js'
+import type { SessionViewable, ViewCtx } from '../../authorization/policy.js'
 import { OrgId } from '../../domain/ids.js'
-import { canStreamAgent } from './stream.js'
+import { canStreamSession } from './stream.js'
 
 const ORG_A = OrgId('11111111-1111-4111-8111-111111111111')
 const ORG_B = OrgId('22222222-2222-4222-8222-222222222222')
 
-function agent(orgId: typeof ORG_A, sharing: Partial<Shareable> = {}): Shareable & { orgId: typeof ORG_A } {
+function session(
+  orgId: typeof ORG_A,
+  overrides: Partial<SessionViewable> = {}
+): SessionViewable & { orgId: typeof ORG_A } {
   return {
     orgId,
     visibility: 'org',
-    createdByUserId: null,
-    sharedWith: [],
-    ...sharing
+    ownerIdentity: null,
+    ...overrides
   }
 }
 
-describe('canStreamAgent', () => {
+describe('canStreamSession', () => {
   const owner: ViewCtx = { userId: 'owner-a', role: 'owner' }
   const collaborator: ViewCtx = { userId: 'collaborator-a', role: 'collaborator' }
 
-  it('rejects an agent outside the path org even for an owner', () => {
-    expect(canStreamAgent(agent(ORG_B), ORG_A, owner)).toBe(false)
+  it('rejects a session outside the path org even for an owner', () => {
+    expect(canStreamSession(session(ORG_B), ORG_A, owner, new Set())).toBe(false)
   })
 
-  it('applies resource visibility inside the path org', () => {
-    expect(canStreamAgent(agent(ORG_A), ORG_A, collaborator)).toBe(true)
-    expect(canStreamAgent(agent(ORG_A, { visibility: 'restricted' }), ORG_A, collaborator)).toBe(false)
+  it('applies only the Session audience inside the path org', () => {
+    expect(canStreamSession(session(ORG_A), ORG_A, collaborator, new Set())).toBe(true)
     expect(
-      canStreamAgent(agent(ORG_A, { visibility: 'restricted', sharedWith: [collaborator.userId] }), ORG_A, collaborator)
+      canStreamSession(
+        session(ORG_A, { visibility: 'private', ownerIdentity: 'user:session-owner' }),
+        ORG_A,
+        collaborator,
+        new Set()
+      )
+    ).toBe(false)
+    expect(
+      canStreamSession(
+        session(ORG_A, { visibility: 'private', ownerIdentity: 'user:session-owner' }),
+        ORG_A,
+        collaborator,
+        new Set(['user:session-owner'])
+      )
     ).toBe(true)
   })
 })

--- a/packages/control-plane/src/http/routes/stream.ts
+++ b/packages/control-plane/src/http/routes/stream.ts
@@ -13,24 +13,12 @@ import type { HttpDeps } from '../deps.js'
 import type { SessionEventEnvelope } from '../../events/sink.js'
 import { Tag } from '../plugins/openapi.js'
 import { ctxOf } from '../rbac.js'
-import {
-  canView,
-  canViewSession,
-  type SessionViewable,
-  type Shareable,
-  type ViewCtx
-} from '../../authorization/policy.js'
+import { canViewSession, type SessionViewable, type ViewCtx } from '../../authorization/policy.js'
 import type { SessionExternalAccessSnapshot } from '../../persistence/ports.js'
 import { makeSessionAccessResolver } from '../session-access.js'
-import { AgentId, DaemonId, SessionId, type OrgId } from '../../domain/ids.js'
+import { DaemonId, SessionId, type OrgId } from '../../domain/ids.js'
 
 const KEEPALIVE_MS = 25_000
-
-export function canStreamAgent(agent: (Shareable & { orgId: OrgId }) | null, orgId: OrgId, ctx: ViewCtx): boolean {
-  // `canView` assumes its caller already selected the current tenant. This org
-  // check applies before the resource policy for every role.
-  return !!agent && agent.orgId === orgId && canView(agent, ctx)
-}
 
 /**
  * Session-level gate for the live feed (session-visibility.md §5). BOTH envelope
@@ -39,15 +27,16 @@ export function canStreamAgent(agent: (Shareable & { orgId: OrgId }) | null, org
  * session's existence, revision, and live activity.
  *
  * A row that cannot be read is dropped — an activity event whose milestone never
- * committed has no visibility to check, so fail closed like the agent arm does.
+ * committed has no visibility to check, so it fails closed.
  */
 export function canStreamSession(
-  session: SessionViewable | null,
+  session: (SessionViewable & { orgId: OrgId }) | null,
+  orgId: OrgId,
   ctx: ViewCtx,
   identitySet: ReadonlySet<string>,
   externalAccess?: SessionExternalAccessSnapshot
 ): boolean {
-  return !!session && canViewSession(session, ctx, identitySet, externalAccess)
+  return !!session && session.orgId === orgId && canViewSession(session, ctx, identitySet, externalAccess)
 }
 
 function writeEvent(reply: FastifyReply, envelope: SessionEventEnvelope): void {
@@ -101,16 +90,12 @@ export function streamRoutes(deps: HttpDeps) {
           daemonOrg.set(daemonId, ok)
           return ok
         }
-        // Membership and agent visibility are live authorization inputs. Do not
-        // pin either to connection-open state: a member removal or a sharing
-        // tighten must stop this already-open stream on its next event.
+        // Organization membership is a live authorization input. Do not pin it
+        // to connection-open state: removing a member must stop this already-open
+        // stream on its next event.
         const currentCtx = async (): Promise<ViewCtx | null> => {
           const role = await deps.repos.org.roleOf(orgId, connectedCtx.userId).catch(() => null)
           return role ? { userId: connectedCtx.userId, role } : null
-        }
-        const canSeeAgent = async (agentId: string, ctx: ViewCtx): Promise<boolean> => {
-          const agent = await deps.repos.agent.get(AgentId(agentId)).catch(() => null)
-          return canStreamAgent(agent, orgId, ctx)
         }
 
         // Session visibility is deliberately NOT memoized: a §4.3 tightening must
@@ -123,11 +108,11 @@ export function streamRoutes(deps: HttpDeps) {
         // read in the common case (LogtoIdentityService caches per subject,
         // single-flight) and the unlink path invalidates that cache, so the
         // revocation lands on the next event, not the next connection.
-        const canSeeSession = async (sessionId: string, ctx: ViewCtx): Promise<boolean> => {
+        const canSeeSession = async (agentId: string, sessionId: string, ctx: ViewCtx): Promise<boolean> => {
           const session = await deps.repos.session.get(SessionId(sessionId)).catch(() => null)
-          if (!session) return false
+          if (!session || session.agentId !== agentId) return false
           const access = await sessionAccess.forSessions(req, [session]).catch(() => null)
-          return !!access && canStreamSession(session, ctx, access.identitySet, access.externalAccess)
+          return !!access && canStreamSession(session, orgId, ctx, access.identitySet, access.externalAccess)
         }
 
         const unsubscribe = deps.events.subscribe((envelope) => {
@@ -136,9 +121,8 @@ export function streamRoutes(deps: HttpDeps) {
             const ctx = await currentCtx()
             if (!ctx) return
             const agentId = envelope.activity?.agentId ?? envelope.event?.agentId
-            if (!agentId || !(await canSeeAgent(agentId, ctx))) return
             const sessionId = envelope.activity?.sessionId ?? envelope.event?.sessionId
-            if (!sessionId || !(await canSeeSession(sessionId, ctx))) return
+            if (!agentId || !sessionId || !(await canSeeSession(agentId, sessionId, ctx))) return
             writeEvent(reply, envelope)
           })()
         })

--- a/packages/control-plane/src/http/routes/stream.viewer-identity.test.ts
+++ b/packages/control-plane/src/http/routes/stream.viewer-identity.test.ts
@@ -14,10 +14,9 @@ import { streamRoutes } from './stream.js'
 const ORG_ID = 'org-1'
 const SLACK_OWNER = 'slack:T024BE7LD:U0123ABCD'
 
-const agent = { id: 'agent-1', orgId: ORG_ID, visibility: 'org', sharedWith: [] }
 const sessions: Record<string, unknown> = {
-  'sess-dm': { visibility: 'private', ownerIdentity: SLACK_OWNER },
-  'sess-org': { visibility: 'org', ownerIdentity: null }
+  'sess-dm': { orgId: ORG_ID, agentId: 'agent-1', visibility: 'private', ownerIdentity: SLACK_OWNER },
+  'sess-org': { orgId: ORG_ID, agentId: 'agent-1', visibility: 'org', ownerIdentity: null }
 }
 
 function envelope(sessionId: string): SessionEventEnvelope {
@@ -69,7 +68,6 @@ describe('stream route × viewer identity (live unlink)', () => {
       registry: { get: async () => ({ orgId: ORG_ID }) },
       repos: {
         org: { roleOf: async () => 'collaborator' },
-        agent: { get: async () => agent },
         session: {
           get: async (id: string) => sessions[id] ?? null,
           getExternalScopes: async () => [],

--- a/packages/control-plane/src/http/session-access-plugin.ts
+++ b/packages/control-plane/src/http/session-access-plugin.ts
@@ -21,8 +21,9 @@ export interface SessionAccessResult {
   accessIssues?: SessionAccessIssue[]
 }
 
-/** Provider-owned half of Session visibility. Core only composes Agent
- * visibility with the result returned here. */
+/** Provider-owned half of Session visibility. Core combines the provider
+ * audience with the Session's own classification; Agent Team visibility is a
+ * separate resource boundary. */
 export interface SessionAccessPlugin {
   provider: string
   available: boolean

--- a/packages/control-plane/test/integration/session-conversations.route.test.ts
+++ b/packages/control-plane/test/integration/session-conversations.route.test.ts
@@ -163,12 +163,11 @@ describe('GET /sessions — grouped conversations', () => {
     expect(secondBody.nextCursor).toBeNull()
   })
 
-  it('omits invisible members with no count or placeholder', async () => {
+  it('includes Session-audience members even when their Agent is hidden', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
-    // Restricted agent owned by another user — invisible to the caller. Its
-    // participation must leave NO trace on the grouped row (§7: hidden
-    // sessions' existence is itself hidden).
+    // Restricted Agent owned by another user — invisible to the caller. The
+    // channel Session still follows its own org audience and remains readable.
     const stranger = await prisma.user.create({
       data: { id: randomUUID(), email: `stranger-${randomUUID().slice(0, 8)}@example.com`, displayName: 'Stranger' }
     })
@@ -184,11 +183,11 @@ describe('GET /sessions — grouped conversations', () => {
 
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions` })
     const body = res.json() as ConversationsBody
+    expect((await running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT_B}` })).statusCode).toBe(404)
     expect(body.conversations).toHaveLength(1)
     const conv = body.conversations[0]!
-    expect(conv.sessions.map((s) => s.sessionId)).toEqual(['sess-vis'])
-    expect(JSON.stringify(body)).not.toContain('sess-hidden')
-    expect(JSON.stringify(body)).not.toContain(AGENT_B)
+    expect(conv.sessions.map((s) => s.sessionId)).toEqual(['sess-hidden', 'sess-vis'])
+    expect(JSON.stringify(body)).toContain(AGENT_B)
   })
 
   it('resolves one conversation by key, and a webchat conversation by its id', async () => {
@@ -327,7 +326,7 @@ describe('GET /sessions — multi-agent conversation filter', () => {
     expect(unfiltered.memberSessionIds).toEqual(['sess-b', 'sess-a'])
   })
 
-  it('keeps a member the caller cannot see out of the membership it reports', async () => {
+  it('reports Session membership independently from Agent visibility', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
     const stranger = await prisma.user.create({
@@ -341,11 +340,12 @@ describe('GET /sessions — multi-agent conversation filter', () => {
 
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?agentId=${AGENT_A}` })
     const body = res.json() as ConversationsBody
-    expect(body.conversations[0]!.memberSessionIds).toEqual(['sess-vis'])
-    expect(JSON.stringify(body)).not.toContain('sess-hidden')
+    expect((await running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT_B}` })).statusCode).toBe(404)
+    expect(body.conversations[0]!.sessions.map((session) => session.sessionId)).toEqual(['sess-vis'])
+    expect(body.conversations[0]!.memberSessionIds).toEqual(['sess-hidden', 'sess-vis'])
   })
 
-  it('never lets an invisible participant qualify a conversation', async () => {
+  it("lets a hidden Agent's visible Session qualify a conversation", async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
     const stranger = await prisma.user.create({
@@ -357,17 +357,18 @@ describe('GET /sessions — multi-agent conversation filter', () => {
     await slackReport('sess-vis', AGENT_A, 1_000)
     await slackReport('sess-hidden', AGENT_B, 2_000)
 
-    // Asking for a thread shared with an agent the caller cannot see must not
-    // confirm that the thread exists — the answer is empty, not A's row.
+    // Agent filters identify Session owners but do not grant Agent access. The
+    // two visible Sessions qualify their shared conversation even though B's
+    // Agent resource remains hidden.
     const res = await running.app.inject({
       method: 'GET',
       url: `${ORG}/sessions?view=flat&agentId=${AGENT_A}&agentId=${AGENT_B}`
     })
     expect(res.statusCode).toBe(200)
-    const body = res.json() as { sessions: unknown[]; total: number | null }
-    expect(body.sessions).toHaveLength(0)
-    expect(body.total).toBe(0)
-    expect(JSON.stringify(body)).not.toContain('sess-hidden')
+    expect((await running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT_B}` })).statusCode).toBe(404)
+    const body = res.json() as { sessions: Array<{ sessionId: string }>; total: number | null }
+    expect(body.sessions.map((session) => session.sessionId).sort()).toEqual(['sess-hidden', 'sess-vis'])
+    expect(body.total).toBe(2)
   })
 
   it('excludes rows with no groupable key — a conversation of one holds no second agent', async () => {
@@ -446,7 +447,7 @@ describe('GET /sessions — multi-agent conversation filter', () => {
     expect(conv.memberSessionIds).toEqual(['sess-shared-b', 'sess-shared-a'])
   })
 
-  it('answers empty when any requested agent is not visible to the caller', async () => {
+  it('answers empty when any requested agent does not belong to the organization', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
     running = buildHttpApp(prisma)

--- a/packages/control-plane/test/integration/session-conversations.route.test.ts
+++ b/packages/control-plane/test/integration/session-conversations.route.test.ts
@@ -188,6 +188,13 @@ describe('GET /sessions — grouped conversations', () => {
     const conv = body.conversations[0]!
     expect(conv.sessions.map((s) => s.sessionId)).toEqual(['sess-hidden', 'sess-vis'])
     expect(JSON.stringify(body)).toContain(AGENT_B)
+
+    const facets = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/facets` })
+    expect(facets.statusCode).toBe(200)
+    expect(facets.json()).toMatchObject({
+      agents: expect.arrayContaining([AGENT_A, AGENT_B]),
+      agentNames: { [AGENT_A]: 'agent-a1a1', [AGENT_B]: 'agent-b1b1' }
+    })
   })
 
   it('resolves one conversation by key, and a webchat conversation by its id', async () => {
@@ -452,13 +459,21 @@ describe('GET /sessions — multi-agent conversation filter', () => {
     await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
     running = buildHttpApp(prisma)
     await slackReport('sess-a', AGENT_A, 1_000)
+    const missingAgent = randomUUID()
 
     const res = await running.app.inject({
       method: 'GET',
-      url: `${ORG}/sessions?view=flat&agentId=${AGENT_A}&agentId=${randomUUID()}`
+      url: `${ORG}/sessions?view=flat&agentId=${AGENT_A}&agentId=${missingAgent}`
     })
     expect(res.statusCode).toBe(200)
     expect((res.json() as { sessions: unknown[]; total: number | null }).sessions).toHaveLength(0)
+
+    const facets = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions/facets?agentId=${missingAgent}`
+    })
+    expect(facets.statusCode).toBe(200)
+    expect(facets.json()).toMatchObject({ agents: [], agentNames: {} })
   })
 
   it('pages the grouped list without re-emitting a filtered conversation', async () => {

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -278,8 +278,8 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
         }
       ).childSessions
     ).toEqual([
-      { id: firstChild, agentId: AGENT, platform: 'telegram', title: 'Check the database' },
-      { id: secondChild, agentId: AGENT, platform: 'discord', title: 'Check the API' }
+      { id: firstChild, agentId: AGENT, agentName: 'agent-a0a0', platform: 'telegram', title: 'Check the database' },
+      { id: secondChild, agentId: AGENT, agentName: 'agent-a0a0', platform: 'discord', title: 'Check the API' }
     ])
     expect((parentRes.json() as { parentSession: unknown }).parentSession).toBeNull()
     expect((parentRes.json() as { siblingSessions: unknown[] }).siblingSessions).toEqual([])
@@ -292,11 +292,12 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     ).toEqual({
       id: parent,
       agentId: AGENT,
+      agentName: 'agent-a0a0',
       platform: 'slack',
       title: 'Coordinate the rollout'
     })
     expect((childRes.json() as { siblingSessions: unknown[] }).siblingSessions).toEqual([
-      { id: secondChild, agentId: AGENT, platform: 'discord', title: 'Check the API' }
+      { id: secondChild, agentId: AGENT, agentName: 'agent-a0a0', platform: 'discord', title: 'Check the API' }
     ])
     expect((childRes.json() as { childSessions: unknown[] }).childSessions).toEqual([])
   })

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -42,6 +42,50 @@ const sessionIds = (body: unknown): string[] =>
   (body as { sessions: Array<{ sessionId: string }> }).sessions.map((s) => s.sessionId)
 
 describe('session visibility — list & detail', () => {
+  it('shows a handoff Session across a hidden Agent boundary without exposing the Agent', async () => {
+    const viewer = await makeUser(`sv-hidden-agent-${randomUUID()}`, 'collaborator')
+    const selectedViewer = await makeUser(`sv-selected-agent-${randomUUID()}`, 'collaborator')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const supportAgent = await seedAgent(prisma, randomUUID(), { daemonId, name: 'support-agent' })
+    const paymentsAgent = await seedAgent(prisma, randomUUID(), {
+      daemonId,
+      name: 'payments-agent',
+      visibility: 'restricted',
+      sharedWith: [selectedViewer]
+    })
+    const parent = await seedSessionMeta(prisma, `s-support-${randomUUID()}`, supportAgent, {})
+    const child = await seedSessionMeta(prisma, `s-payments-${randomUUID()}`, paymentsAgent, {
+      parentSessionId: parent
+    })
+    const app = appAs(viewer)
+
+    // The Agent resource stays hidden, including its configuration/workspace.
+    expect((await app.app.inject({ method: 'GET', url: `${ORG}/agents/${paymentsAgent}` })).statusCode).toBe(404)
+
+    // The Session audience is independent. A direct hidden-Agent filter remains
+    // valid and returns only Session-scoped metadata, including a display name.
+    const list = (
+      await app.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&agentId=${paymentsAgent}` })
+    ).json() as { sessions: Array<{ sessionId: string; agentName: string | null }> }
+    expect(list.sessions).toEqual([expect.objectContaining({ sessionId: child, agentName: 'payments-agent' })])
+
+    const childDetail = await app.app.inject({ method: 'GET', url: `${ORG}/sessions/${child}` })
+    expect(childDetail.statusCode).toBe(200)
+    expect(childDetail.json()).toMatchObject({
+      id: child,
+      agentId: paymentsAgent,
+      agentName: 'payments-agent',
+      parentSession: { id: parent, agentId: supportAgent, agentName: 'support-agent' }
+    })
+
+    const parentDetail = (await app.app.inject({ method: 'GET', url: `${ORG}/sessions/${parent}` })).json() as {
+      childSessions: Array<{ id: string; agentId: string; agentName: string | null }>
+    }
+    expect(parentDetail.childSessions).toEqual([
+      expect.objectContaining({ id: child, agentId: paymentsAgent, agentName: 'payments-agent' })
+    ])
+  })
+
   it('a collaborator sees org sessions and their own private ones, never another member’s', async () => {
     const mine = await makeUser('sv-mine', 'collaborator')
     const theirs = await makeUser('sv-theirs', 'collaborator')

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -3,9 +3,9 @@
  *
  * - `GET /sessions` reads CP-stored metadata synced from daemon `event/session`
  *   snapshots; transcript bodies remain daemon-local.
- * - `GET /sessions/:id/messages` resolves and authorizes the owning agent from
- *   SessionMeta, then proxies one history page; 404 unknown/hidden session,
- *   503 unplaced/offline.
+ * - `GET /sessions/:id/messages` authorizes the Session audience independently
+ *   from owning-Agent Team visibility, then proxies one history page; 404 for
+ *   an unknown/hidden Session, 503 unplaced/offline.
  *
  * Driven with `app.inject`, a spy `ControlSender`, and a liveness override that
  * marks the seeded daemon connected.
@@ -16,6 +16,7 @@ import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import type { DaemonLiveness } from '../../src/ports.js'
 import type { SessionListReq, SessionListPage, SessionHistoryReq, SessionHistoryPage } from '@agentconnect.md/protocol'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
@@ -78,7 +79,7 @@ async function seedSession(agentId = AGENT, daemonId?: string): Promise<void> {
 describe('GET /sessions (metadata list from CP DB)', () => {
   it('lists CP-stored session metadata and maps the row shape', async () => {
     await seedDaemon(prisma, DAEMON)
-    await seedAgent(prisma, AGENT, { daemonId: DAEMON }) // sessions filter by owning-agent visibility
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
     await prisma.sessionMeta.create({
       data: {
         id: SESSION,
@@ -527,7 +528,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
 
   it('filters the metadata set by channel', async () => {
     await seedDaemon(prisma, DAEMON)
-    await seedAgent(prisma, AGENT, { daemonId: DAEMON }) // sessions filter by owning-agent visibility
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
     await prisma.sessionMeta.createMany({
       data: [
         {
@@ -566,9 +567,21 @@ describe('GET /sessions (metadata list from CP DB)', () => {
 })
 
 describe('GET /sessions/:id/messages (history pull via the session daemon)', () => {
-  it('resolves the content owner from SessionMeta and proxies a page', async () => {
+  it('proxies a visible Session even when its owning Agent is hidden', async () => {
     await seedDaemon(prisma, DAEMON)
-    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    const users = new PgUserRepo(prisma)
+    const selectedEmail = `history-selected-${randomUUID()}@acme.dev`
+    const { userId: selectedViewer } = await users.provisionOidcUser({
+      oidcSubject: `history-selected-${randomUUID()}`,
+      email: selectedEmail,
+      emailVerified: true
+    })
+    await users.addMemberByEmail(DEFAULT_ORG_ID, selectedEmail, 'collaborator')
+    await seedAgent(prisma, AGENT, {
+      daemonId: DAEMON,
+      visibility: 'restricted',
+      sharedWith: [selectedViewer]
+    })
     await seedSession(AGENT, DAEMON)
     const spy = new SpyControl(
       { sessions: [] },
@@ -591,6 +604,9 @@ describe('GET /sessions/:id/messages (history pull via the session daemon)', () 
       }
     )
     running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
+
+    // Agent Team visibility still protects Agent configuration/workspace routes.
+    expect((await running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}` })).statusCode).toBe(404)
 
     const res = await running.app.inject({
       method: 'GET',

--- a/packages/control-plane/test/integration/visibility.route.test.ts
+++ b/packages/control-plane/test/integration/visibility.route.test.ts
@@ -706,14 +706,12 @@ describe('reference-write cannot target an invisible daemon', () => {
 })
 
 describe('derived visibility — session bodies, usage', () => {
-  it('caller-supplied agentId cannot authorize another agent’s session bodies', async () => {
+  it('Session body access follows the Session audience even when its Agent is hidden', async () => {
     const other = await makeUser('session-body-other', 'collaborator')
     const daemon = randomUUID()
     await seedDaemon(prisma, daemon)
-    const visible = randomUUID()
     const R = randomUUID()
     const session = randomUUID()
-    await seedAgent(prisma, visible, { daemonId: daemon })
     await seedAgent(prisma, R, { daemonId: daemon, visibility: 'restricted', sharedWith: [DEFAULT_OWNER_ID] })
     await prisma.sessionMeta.create({
       data: {
@@ -728,11 +726,11 @@ describe('derived visibility — session bodies, usage', () => {
     })
 
     const app = appAs(other).app
-    for (const path of [
-      `/sessions/${session}/messages?agentId=${visible}`,
-      `/sessions/${session}/tool-body?agentId=${visible}&toolCallId=t1`
-    ]) {
-      expect((await app.inject({ method: 'GET', url: `${ORG}${path}` })).statusCode).toBe(404)
+    expect((await app.inject({ method: 'GET', url: `${ORG}/agents/${R}` })).statusCode).toBe(404)
+    for (const path of [`/sessions/${session}/messages`, `/sessions/${session}/tool-body?toolCallId=t1`]) {
+      const response = await app.inject({ method: 'GET', url: `${ORG}${path}` })
+      expect(response.statusCode).toBe(503)
+      expect(response.json()).toMatchObject({ message: 'session has no recorded daemon' })
     }
   })
 

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -858,7 +858,7 @@ function SessionRelationLink({
   bordered?: boolean
 }) {
   const title = relation.title?.trim() || `Session ${relation.id.slice(0, 8)}`
-  const agentName = agent ? agentLabel(agent) : relation.agentId
+  const agentName = agent ? agentLabel(agent) : (relation.agentName ?? relation.agentId)
   return (
     <Link
       href={orgPath(`/sessions/${encodeURIComponent(relation.id)}${flatView ? '?view=flat' : ''}`)}
@@ -1016,26 +1016,20 @@ function SessionDetailFrame({ children, withRail = true }: { children: ReactNode
 
 function sessionUnavailableReasons(providerName: string | undefined, profileLinked: boolean | undefined): string[] {
   if (!providerName) {
-    return ['The session doesn’t exist or has been removed.', 'The Agent isn’t shared with you.']
+    return ['The session doesn’t exist or has been removed.']
   }
   if (profileLinked === false) {
-    return [
-      'The session doesn’t exist or has been removed.',
-      `Your ${providerName} profile isn’t linked.`,
-      'The Agent’s Team visibility doesn’t include you.'
-    ]
+    return ['The session doesn’t exist or has been removed.', `Your ${providerName} profile isn’t linked.`]
   }
   if (profileLinked === true) {
     return [
       'The session doesn’t exist or has been removed.',
-      `Your linked ${providerName} profile belongs to a different workspace.`,
-      'The Agent’s Team visibility doesn’t include you.'
+      `Your linked ${providerName} profile belongs to a different workspace.`
     ]
   }
   return [
     'The session doesn’t exist or has been removed.',
-    `Your ${providerName} profile isn’t linked or belongs to a different workspace.`,
-    'The Agent’s Team visibility doesn’t include you.'
+    `Your ${providerName} profile isn’t linked or belongs to a different workspace.`
   ]
 }
 
@@ -1416,7 +1410,7 @@ export default function SessionDetailView() {
     sessionBase && !localSession
       ? {
           ...sessionBase,
-          agentName: owner ? agentLabel(owner) : sessionBase.agentId,
+          agentName: owner ? agentLabel(owner) : (sessionBase.agentName ?? sessionBase.agentId),
           model: sessionBase.model ?? (sessionBase.runtime ? '' : (owner?.model ?? '—')),
           runtime: sessionBase.runtime ?? owner?.runtime ?? '',
           daemon: sessionBase.daemon ?? owner?.daemon
@@ -1447,6 +1441,7 @@ export default function SessionDetailView() {
       for (const member of conversationMembers) {
         candidates.push({
           agentId: member.agentId,
+          name: member.agentName ?? undefined,
           sessionId: member.sessionId,
           snapshot: sessionFromDto(member)
         })
@@ -1478,7 +1473,11 @@ export default function SessionDetailView() {
       ]
       for (const relation of related) {
         if (!relation || !relatedTranscriptAgentIds.has(relation.agentId)) continue
-        candidates.push({ agentId: relation.agentId, sessionId: relation.id })
+        candidates.push({
+          agentId: relation.agentId,
+          name: relation.agentName ?? undefined,
+          sessionId: relation.id
+        })
       }
     }
 

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -251,8 +251,11 @@ export default function SessionsView() {
     ])
   )
   const facetAgentIds = new Set(sessionFacets.agentIds)
+  const facetAgentNames = new Map(Object.entries(sessionFacets.agentNames))
   for (const session of localFacetSessions.agents) {
-    if (session.agentId) facetAgentIds.add(session.agentId)
+    if (!session.agentId) continue
+    facetAgentIds.add(session.agentId)
+    if (session.agentName?.trim()) facetAgentNames.set(session.agentId, session.agentName.trim())
   }
   // Playground and demo sessions are not part of the CP index. Merge each
   // facet from local rows that already satisfy the other three active filters.
@@ -368,6 +371,15 @@ export default function SessionsView() {
         v: a.id,
         label: agentLabel(a),
         face: <AgentIconView icon={a.icon} runtime={a.runtime} size={18} />
+      })),
+    // A Session facet may name an Agent outside the caller-visible Agent
+    // roster. It remains a plain Session filter with no Agent navigation.
+    ...[...facetAgentIds]
+      .filter((agentId) => !agentById.has(agentId) && facetAgentNames.has(agentId))
+      .map((agentId) => ({
+        v: agentId,
+        label: facetAgentNames.get(agentId)!,
+        face: catFace('bot')
       }))
   ]
   const integrationOpts: FilterOption[] = [

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -9,6 +9,7 @@ import {
   deleteOrgIcon,
   fetchAllGithubRepos,
   fetchConversations,
+  fetchSessionFacets,
   fetchGithubRepoRoster,
   fetchMySessionIdentity,
   fetchMemoryAdminSurface,
@@ -36,6 +37,37 @@ import {
   uploadMyProfilePicture,
   uploadOrgIcon
 } from './api'
+
+describe('session facet Agent labels', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('keeps Session-scoped labels for Agents outside the visible Agent roster', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              agents: ['agent-hidden'],
+              agentNames: { 'agent-hidden': 'Payments Agent' },
+              integrations: [],
+              channels: [],
+              triggers: []
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+      )
+    )
+
+    await expect(fetchSessionFacets('org-1')).resolves.toEqual({
+      agentIds: ['agent-hidden'],
+      agentNames: { 'agent-hidden': 'Payments Agent' },
+      integrations: [],
+      channels: [],
+      triggers: []
+    })
+  })
+})
 
 describe('fmtCountCompact', () => {
   it.each([

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -340,8 +340,9 @@ export interface SessionUsageDto {
 }
 
 // Session-level visibility (docs/designs/session-visibility.md): 'private' rows are
-// visible only to the session owner (no role override, org owners included); 'org' to every member who can view
-// the owning agent. Deliberately NOT ResourceVisibility ('org' | 'restricted').
+// visible only to the session owner (no role override, org owners included); 'org'
+// to every organization member. It is independent from the owning Agent's Team
+// visibility and deliberately NOT ResourceVisibility ('org' | 'restricted').
 export type SessionVisibility = 'private' | 'org' | 'external'
 export type MutableSessionVisibility = 'private' | 'org'
 
@@ -349,6 +350,8 @@ export interface SessionDto {
   sessionId: string
   sessionKey: { platform: string; channel: string; thread?: string }
   agentId: string
+  /** Session-scoped display projection; does not imply Agent access. */
+  agentName?: string | null
   title: string | null
   status: string | null
   lastActivityAt: string | null
@@ -476,6 +479,8 @@ export interface SessionListPage {
 export interface SessionRelationDto {
   id: string
   agentId: string
+  /** Session-scoped display projection; absent on older Control Planes. */
+  agentName?: string | null
   platform: string
   title: string | null
 }
@@ -487,6 +492,8 @@ export interface SessionDetailDto {
   siblingSessions?: SessionRelationDto[]
   childSessions: SessionRelationDto[]
   agentId: string
+  /** Session-scoped display projection; absent on older Control Planes. */
+  agentName?: string | null
   platform: string | null
   channel: string | null
   thread: string | null
@@ -525,7 +532,7 @@ export interface SessionDetailDto {
   accessIssues?: SessionAccessIssue[]
   /** Multi-agent webchat conversation roster, in pick order. Null for single-agent
    *  conversations and other platforms; absent on a CP that predates the feature.
-   *  `name` is null when the caller cannot view that participant's agent. */
+   *  `name` is null only when no Agent display record can be resolved. */
   participants?: Array<{ agentId: string; name: string | null; primary: boolean }> | null
   /** Durable workspace/tenant scope (merged-conversation-view.md §5.1) — part of
    *  the conversation key. Absent on a CP that predates the feature. */
@@ -1820,6 +1827,7 @@ export function sessionFromDto(d: SessionDto): Session {
     // list row carries no bodies, so steps start empty.
     steps: [],
     agentId: d.agentId,
+    ...(d.agentName?.trim() ? { agentName: d.agentName.trim() } : {}),
     // Session-recorded execution config (what this session actually ran with).
     // Omitted on legacy rows — data-context then falls back to the agent's
     // current config when flattening. `daemon` carries the daemonId (the views
@@ -1861,6 +1869,7 @@ export function sessionFromDetailDto(d: SessionDetailDto): Session {
       ...(d.thread !== null ? { thread: d.thread } : {})
     },
     agentId: d.agentId,
+    agentName: d.agentName ?? null,
     title: d.title,
     status: d.status,
     lastActivityAt: d.lastActivityAt,
@@ -2065,9 +2074,9 @@ export async function fetchConversations(
       ...rep,
       ...identity,
       ...purge,
-      // The members the FILTER returned, which is what the row can name. Names
-      // resolve at render time from the org agent list (the DTO carries ids only);
-      // the placeholder keeps the field shape valid.
+      // The members the FILTER returned, which is what the row can name. Each
+      // Session DTO carries a safe display projection even when the owning Agent
+      // itself is hidden from the caller.
       participants: members.map((member, i) => ({
         agentId: member.agentId ?? '',
         name: member.agentName ?? member.agentId ?? '',
@@ -2123,7 +2132,7 @@ export async function fetchSessionFacets(orgId?: string, filters: SessionListFil
 }
 
 /** CP-stored detail metadata used for session-family navigation. The linked
- *  rows are already filtered by the caller's agent visibility on the server. */
+ *  rows are already filtered by each Session's audience on the server. */
 export function fetchSessionDetail(sessionId: string, orgId?: string): Promise<SessionDetailDto> {
   return apiGet<SessionDetailDto>(`${orgBase(orgId)}/sessions/${encodeURIComponent(sessionId)}`)
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -389,6 +389,8 @@ export interface SessionDto {
 
 export interface SessionFacetsDto {
   agents: string[]
+  /** Session-scoped labels keyed by facet Agent id; absent on older CPs. */
+  agentNames?: Record<string, string>
   integrations: string[]
   channels: Array<{
     value: string
@@ -456,6 +458,7 @@ export interface SessionListFilters {
 
 export interface SessionFacets {
   agentIds: string[]
+  agentNames: Record<string, string>
   integrations: string[]
   channels: Array<{ value: string; label: string; platform: string }>
   triggers: Array<{
@@ -2115,6 +2118,7 @@ export async function fetchSessionFacets(orgId?: string, filters: SessionListFil
   const facets = await apiGet<SessionFacetsDto>(`${orgBase(orgId)}/sessions/facets${suffix}`)
   return {
     agentIds: facets.agents,
+    agentNames: facets.agentNames ?? {},
     integrations: facets.integrations,
     channels: facets.channels.map((channel) => ({
       value: channel.value,

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -258,7 +258,13 @@ const Ctx = createContext<ConsoleData | null>(null)
 const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 500
 const DAEMON_REFRESH_MS = 15_000
 const RESOURCE_REFRESH_MS = 30_000
-const EMPTY_SESSION_FACETS: SessionFacets = { agentIds: [], integrations: [], channels: [], triggers: [] }
+const EMPTY_SESSION_FACETS: SessionFacets = {
+  agentIds: [],
+  agentNames: {},
+  integrations: [],
+  channels: [],
+  triggers: []
+}
 function settleInBackground(...tasks: Promise<unknown>[]): void {
   void Promise.allSettled(tasks)
 }

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -215,6 +215,12 @@ describe('enrichSessionWithAgent', () => {
       daemon: 'daemon-recorded'
     })
   })
+
+  it('keeps the Session-projected name when the Agent itself is hidden', () => {
+    expect(enrichSessionWithAgent({ ...session, agentName: 'Payments Agent' })).toMatchObject({
+      agentName: 'Payments Agent'
+    })
+  })
 })
 
 const catalog = (over: Partial<RuntimeModelCatalog> = {}): RuntimeModelCatalog => ({

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1044,7 +1044,7 @@ export function enrichSessionWithAgent(
 ): Session {
   return {
     ...session,
-    agentName: agent ? agentLabel(agent) : session.agentId,
+    agentName: agent ? agentLabel(agent) : (session.agentName ?? session.agentId),
     model: session.model ?? (session.runtime ? '' : (agent?.model ?? '—')),
     runtime: session.runtime ?? agent?.runtime ?? '',
     daemon: session.daemon ?? agent?.daemon


### PR DESCRIPTION
## Summary

- authorize Session list, detail, transcript, tool-body, relationships, and SSE reads from the Session audience without intersecting owning-Agent Team visibility
- expose Session-scoped Agent names in Session rows, relations, and filters while keeping Agent pages, configuration, workspaces, invocation controls, and navigation independently gated
- update unavailable guidance and product/design contracts for handoff Sessions

## Tests

- Control Plane and Web typechecks
- ESLint, Prettier, and git diff checks
- focused Control Plane unit and Web tests
- 92 targeted Control Plane Postgres integration tests; the final facet suite was rerun after the last change (14/14)
- exact-head Build, Check, Unit Test, Sandbox, both integration shards, and both review bots

Created by Codex . GPT-5.6
