### PR TITLE
fix(daemon): expose channel roots to agent tools

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -227,10 +227,11 @@ visible in-thread form** — every visible send lands at the channel **root**:
   `platform`) — publishes a visible message at the channel root without waking an agent
   or addressing a human, as in case 2a / case 3.
 
-When the current conversation is itself a child thread (for example, a Discord thread),
-the agent context and `getCurrentChannel` expose its trusted `parentChannel`. An explicit
-channel-root form must use that parent id. Passing the current thread id as `channel` is
-rejected with an actionable error naming the parent; it is never silently redirected.
+`Channel` in the agent context and `getCurrentChannel.channel` always identify the root
+destination accepted by visible `sendMessage` forms. When the current conversation is a
+child thread (for example, a Discord thread), `Thread` / `getCurrentChannel.thread`
+identifies that child only as context. Passing it as `channel` is rejected with an
+actionable error naming `Channel`; it is never silently redirected.
 
 The visible post is suppressed when the wake would be refused for a locally-decidable
 reason (capability disabled, invalid target id, a postless self-call, hop limit, or a local target that

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -227,6 +227,11 @@ visible in-thread form** — every visible send lands at the channel **root**:
   `platform`) — publishes a visible message at the channel root without waking an agent
   or addressing a human, as in case 2a / case 3.
 
+When the current conversation is itself a child thread (for example, a Discord thread),
+the agent context and `getCurrentChannel` expose its trusted `parentChannel`. An explicit
+channel-root form must use that parent id. Passing the current thread id as `channel` is
+rejected with an actionable error naming the parent; it is never silently redirected.
+
 The visible post is suppressed when the wake would be refused for a locally-decidable
 reason (capability disabled, invalid target id, a postless self-call, hop limit, or a local target that
 disallows the caller), so a rejected hand-off leaves no misleading post. One accepted

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3066,7 +3066,7 @@ export class Daemon {
       // ACP session to its exact channel/thread/delivery integration.
       // The agent's enabled daemon-configured MCP servers are appended AFTER the bridge entry, gated
       // on the runtime's probed transport caps.
-      mcpServersFor: ({ agent, platform, channel, thread, integrationId, transportScope, isDm }) => {
+      mcpServersFor: ({ agent, platform, channel, parentChannel, thread, integrationId, transportScope, isDm }) => {
         const servers: McpServer[] = []
         let tools = toolsForIntegrations(agent.integrations, {
           collaboration: this.evaluationProfile.collaboration === 'configured',
@@ -3101,6 +3101,7 @@ export class Daemon {
             ...(transportScope ? { transportScope } : {}),
             isDm,
             channel,
+            ...(parentChannel !== undefined ? { parentChannel } : {}),
             thread,
             tools,
             // Full integration set so sendPlatformMessage can route to ANY connected

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2954,8 +2954,9 @@ export class Daemon {
       // same source `messageAgent` uses) rather than snapshotted onto the session — a
       // session outlives the turn whose depth this is.
       currentHopCount: (ctx) =>
-        this.activeTurnCallMeta.get(sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope))
-          ?.hopCount ?? 0,
+        this.activeTurnCallMeta.get(
+          sessionKey(ctx.platform, ctx.sessionChannel, ctx.thread, ctx.agentId, ctx.transportScope)
+        )?.hopCount ?? 0,
       mentionAddressFor: ({ agentId, platform, channel }) => {
         const orgId = this.cpCollab.orgForAgent(agentId)
         // The RAW platform (S1a removed the narrowing fold): snapshot channel rows are
@@ -3066,7 +3067,7 @@ export class Daemon {
       // ACP session to its exact channel/thread/delivery integration.
       // The agent's enabled daemon-configured MCP servers are appended AFTER the bridge entry, gated
       // on the runtime's probed transport caps.
-      mcpServersFor: ({ agent, platform, channel, parentChannel, thread, integrationId, transportScope, isDm }) => {
+      mcpServersFor: ({ agent, platform, channel, sessionChannel, thread, integrationId, transportScope, isDm }) => {
         const servers: McpServer[] = []
         let tools = toolsForIntegrations(agent.integrations, {
           collaboration: this.evaluationProfile.collaboration === 'configured',
@@ -3101,7 +3102,7 @@ export class Daemon {
             ...(transportScope ? { transportScope } : {}),
             isDm,
             channel,
-            ...(parentChannel !== undefined ? { parentChannel } : {}),
+            sessionChannel,
             thread,
             tools,
             // Full integration set so sendPlatformMessage can route to ANY connected
@@ -5321,14 +5322,14 @@ export class Daemon {
   private toolTurnRunnable(ctx: {
     agentId: string
     platform: string
-    channel: string
+    sessionChannel: string
     thread: string
     transportScope?: string
   }): boolean {
     if (this.paused(ctx.agentId)) return false
     if (ctx.platform === 'dream') return true
     const active = this.activeGateEntries.get(
-      sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
+      sessionKey(ctx.platform, ctx.sessionChannel, ctx.thread, ctx.agentId, ctx.transportScope)
     )
     // A transient safety drain only gates NEW admissions while an interrupted
     // turn unwinds; it must not break MCP tools in an already-running turn.
@@ -5482,6 +5483,7 @@ export class Daemon {
       platform: 'dream',
       isDm: false,
       channel: 'memory',
+      sessionChannel: 'memory',
       thread: context.dreamId,
       tools: KNOWLEDGE_TOOLS
     })
@@ -16070,11 +16072,11 @@ export class Daemon {
   private acpSessionIdForToolCall(ctx: {
     agentId: string
     platform: string
-    channel: string
+    sessionChannel: string
     thread: string
     transportScope?: string
   }): string | undefined {
-    const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
+    const key = sessionKey(ctx.platform, ctx.sessionChannel, ctx.thread, ctx.agentId, ctx.transportScope)
     return this.store.getSession(key)?.acpSessionId ?? undefined
   }
 

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -108,10 +108,11 @@ export interface SessionContext {
   /** Whether the trusted source conversation is a direct message. Slack native
    *  thread titles are valid only for app-DM sessions. */
   isDm: boolean
+  /** Channel root exposed to the agent and accepted by visible send forms. */
   channel: string
-  /** Trusted enclosing channel when `channel` is itself a child conversation
-   *  (for example a Discord thread). Never supplied by the model. */
-  parentChannel?: string
+  /** Exact platform channel coordinate used to key this session. This differs
+   *  from `channel` when a platform models the current thread as a channel. */
+  sessionChannel: string
   thread: string
   tools: ToolDescriptor[]
   /** Snapshot of the agent's integrations (id + platform) at session/new. Lets the
@@ -154,7 +155,7 @@ export interface MessageAgentReq {
   callerIntegrationId?: string
   /** Trusted physical-bot scope of the caller session. */
   callerTransportScope?: string
-  /** Trusted caller session coords (== the caller's {@link SessionContext} channel/thread).
+  /** Trusted caller session coords (== the caller's {@link SessionContext} sessionChannel/thread).
    *  Never a tool input. The daemon uses these + `callerAgentId` to recompute the caller's
    *  logical sessionKey and resolve the CURRENT turn's trusted call metadata (§6.7), so a
    *  nested `messageAgent` can auto-inherit hop/origin (all calls) and correlationId (replies
@@ -674,7 +675,7 @@ export async function executeTool(
       ...(ctx.integrationId !== undefined ? { integrationId: ctx.integrationId } : {}),
       ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
       isDm: ctx.isDm,
-      channel: ctx.channel,
+      channel: ctx.sessionChannel,
       thread: ctx.thread,
       title
     })
@@ -819,7 +820,7 @@ export async function executeTool(
       ...(channel !== undefined ? { channel } : {}),
       // Trusted coordinates, not a scope request — see ChannelAgentsRequest (they carry the
       // old-CP fallback channel and identify THIS turn for a daemon-fixed discovery scope).
-      currentChannel: ctx.channel,
+      currentChannel: ctx.sessionChannel,
       currentThread: ctx.thread,
       ...(ctx.transportScope !== undefined ? { currentTransportScope: ctx.transportScope } : {}),
       requesterAgentId: ctx.agentId
@@ -923,7 +924,7 @@ export async function executeTool(
         callerAgentId: ctx.agentId,
         platform: ctx.platform,
         ...(ctx.transportScope !== undefined ? { callerTransportScope: ctx.transportScope } : {}),
-        callerChannel: ctx.channel,
+        callerChannel: ctx.sessionChannel,
         callerThread: ctx.thread,
         sessionId,
         text: message,
@@ -966,15 +967,12 @@ export async function executeTool(
     if (toUsers !== undefined && channel === undefined && Array.isArray(args.toUser)) {
       throw new Error('sendMessage: a `toUser` array requires `channel` — direct messages accept exactly one user id')
     }
-    // A Discord thread is itself the live delivery channel, so its id appears as
-    // `ctx.channel`. It is not, however, the enclosing channel ROOT that an explicit
-    // `sendMessage(..., channel)` targets. Silently replacing it with the parent would
-    // send the model's message somewhere other than it asked; failing with the trusted
-    // parent id lets it repair the call without weakening unknown-channel failures.
-    if (channel !== undefined && ctx.parentChannel !== undefined && channel === ctx.channel) {
+    // `Channel` is always the root destination. `Thread` is context only and cannot be
+    // smuggled into a visible send through the string-valued `channel` argument.
+    if (channel !== undefined && channel === ctx.thread && channel !== ctx.channel) {
       throw new Error(
         `sendMessage: channel ${JSON.stringify(channel)} is the current thread, not a channel root. ` +
-          `Use parent channel ${JSON.stringify(ctx.parentChannel)} for a channel-root send. To speak in the current ` +
+          `Use Channel ${JSON.stringify(ctx.channel)} for a channel-root send. To speak in the current ` +
           'thread, write an ordinary reply instead; for a postless agent call, omit `channel`.'
       )
     }
@@ -989,11 +987,11 @@ export async function executeTool(
             platform: ctx.platform,
             ...(ctx.integrationId !== undefined ? { callerIntegrationId: ctx.integrationId } : {}),
             ...(ctx.transportScope !== undefined ? { callerTransportScope: ctx.transportScope } : {}),
-            callerChannel: ctx.channel,
+            callerChannel: ctx.sessionChannel,
             callerThread: ctx.thread,
             toAgentId: toAgent,
             text: message,
-            channel: channel ?? ctx.channel,
+            channel: channel ?? ctx.sessionChannel,
             ...(needsReply ? { needsReply: true } : {}),
             // §3.1: no `channel` ⇒ the postless form, whose child is headless.
             ...(channel === undefined ? { postless: true } : {})
@@ -1147,7 +1145,7 @@ export async function executeTool(
           text: body,
           originPlatform: ctx.platform,
           ...(ctx.transportScope !== undefined ? { originTransportScope: ctx.transportScope } : {}),
-          originChannel: ctx.channel,
+          originChannel: ctx.sessionChannel,
           originThread: ctx.thread
         })
         // A root post is a legitimate way to open a new topic, so this is never blocked — but
@@ -1169,7 +1167,7 @@ export async function executeTool(
                 callerAgentId: ctx.agentId,
                 platform: ctx.platform,
                 ...(ctx.transportScope !== undefined ? { callerTransportScope: ctx.transportScope } : {}),
-                callerChannel: ctx.channel,
+                callerChannel: ctx.sessionChannel,
                 callerThread: ctx.thread,
                 targetPlatform: wantPlatform,
                 targetChannel: postChannel,
@@ -1245,7 +1243,7 @@ export async function executeTool(
     const status = await deps.viewSessionStatus({
       callerAgentId: ctx.agentId,
       platform: ctx.platform,
-      callerChannel: ctx.channel,
+      callerChannel: ctx.sessionChannel,
       callerThread: ctx.thread,
       ...(ctx.transportScope !== undefined ? { callerTransportScope: ctx.transportScope } : {}),
       sessionId
@@ -1282,7 +1280,7 @@ export async function executeTool(
     return await deps.startOrchestration({
       mainAgentId: ctx.agentId,
       platform: ctx.platform,
-      channel: ctx.channel,
+      channel: ctx.sessionChannel,
       thread: ctx.thread,
       ...(ctx.integrationId !== undefined ? { integrationId: ctx.integrationId } : {}),
       ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
@@ -1297,7 +1295,7 @@ export async function executeTool(
     const req: OrchestrationOwnerReq = {
       mainAgentId: ctx.agentId,
       platform: ctx.platform,
-      channel: ctx.channel,
+      channel: ctx.sessionChannel,
       thread: ctx.thread,
       ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
       orchestrationId
@@ -1324,7 +1322,7 @@ export async function executeTool(
     return deps.submitGithubReview({
       agentId: ctx.agentId,
       platform: ctx.platform,
-      channel: ctx.channel,
+      channel: ctx.sessionChannel,
       thread: ctx.thread,
       ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
       event,
@@ -1436,7 +1434,6 @@ export async function executeTool(
       return {
         channel: ctx.channel,
         thread: ctx.thread,
-        ...(ctx.parentChannel !== undefined ? { parentChannel: ctx.parentChannel } : {}),
         name: info?.name ?? null,
         isIm: info?.isIm ?? null
       }

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -109,6 +109,9 @@ export interface SessionContext {
    *  thread titles are valid only for app-DM sessions. */
   isDm: boolean
   channel: string
+  /** Trusted enclosing channel when `channel` is itself a child conversation
+   *  (for example a Discord thread). Never supplied by the model. */
+  parentChannel?: string
   thread: string
   tools: ToolDescriptor[]
   /** Snapshot of the agent's integrations (id + platform) at session/new. Lets the
@@ -963,6 +966,18 @@ export async function executeTool(
     if (toUsers !== undefined && channel === undefined && Array.isArray(args.toUser)) {
       throw new Error('sendMessage: a `toUser` array requires `channel` — direct messages accept exactly one user id')
     }
+    // A Discord thread is itself the live delivery channel, so its id appears as
+    // `ctx.channel`. It is not, however, the enclosing channel ROOT that an explicit
+    // `sendMessage(..., channel)` targets. Silently replacing it with the parent would
+    // send the model's message somewhere other than it asked; failing with the trusted
+    // parent id lets it repair the call without weakening unknown-channel failures.
+    if (channel !== undefined && ctx.parentChannel !== undefined && channel === ctx.channel) {
+      throw new Error(
+        `sendMessage: channel ${JSON.stringify(channel)} is the current thread, not a channel root. ` +
+          `Use parent channel ${JSON.stringify(ctx.parentChannel)} for a channel-root send. To speak in the current ` +
+          'thread, write an ordinary reply instead; for a postless agent call, omit `channel`.'
+      )
+    }
 
     // The trusted wake request (built once) — also fed to the preflight below. `thread` and
     // `transcriptTs` are filled AFTER the post (they depend on the post's ts), so this base copy
@@ -1418,7 +1433,13 @@ export async function executeTool(
   switch (name) {
     case 'getCurrentChannel': {
       const info = await gw.getChannelInfo(ctx.channel).catch(() => undefined)
-      return { channel: ctx.channel, thread: ctx.thread, name: info?.name ?? null, isIm: info?.isIm ?? null }
+      return {
+        channel: ctx.channel,
+        thread: ctx.thread,
+        ...(ctx.parentChannel !== undefined ? { parentChannel: ctx.parentChannel } : {}),
+        name: info?.name ?? null,
+        isIm: info?.isIm ?? null
+      }
     }
     default:
       throw new Error(`unknown tool: ${name}`)

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -117,8 +117,7 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
     description:
       'Channel-root form: the target channel / chat id (Slack `C0123ABC`, Telegram/Discord/Feishu chat id). The post ' +
       'always lands at the channel ROOT, which opens a new conversation there — to speak in the thread you are ' +
-      'already in, just write your ordinary reply. If the # Agent block lists an Enclosing channel, use that ID ' +
-      'for a channel-root send; the current Channel is a child thread and is rejected here.'
+      'already in, just write your ordinary reply. Use `Channel` from the # Agent block, never `Thread`.'
   }
 
   // Mode 1 — toAgent: wake one AgentConnect agent. Two forms: postless (no channel, peers
@@ -357,9 +356,8 @@ function buildReadTools(platforms: string[]): ToolDescriptor[] {
     {
       name: 'getCurrentChannel',
       description:
-        'Return the channel/chat (and thread/topic) THIS conversation is bound to, including its name when available. ' +
-        'When the current channel is itself a child conversation, `parentChannel` is the enclosing channel ID required ' +
-        'by `sendMessage` channel-root forms.',
+        'Return the root channel/chat and current thread/topic for THIS conversation, including the root channel name ' +
+        'when available. `channel` is a valid `sendMessage` channel-root destination; `thread` is context only.',
       inputSchema: obj({})
     },
     {

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -117,7 +117,8 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
     description:
       'Channel-root form: the target channel / chat id (Slack `C0123ABC`, Telegram/Discord/Feishu chat id). The post ' +
       'always lands at the channel ROOT, which opens a new conversation there — to speak in the thread you are ' +
-      'already in, just write your ordinary reply.'
+      'already in, just write your ordinary reply. If the # Agent block lists an Enclosing channel, use that ID ' +
+      'for a channel-root send; the current Channel is a child thread and is rejected here.'
   }
 
   // Mode 1 — toAgent: wake one AgentConnect agent. Two forms: postless (no channel, peers
@@ -356,7 +357,9 @@ function buildReadTools(platforms: string[]): ToolDescriptor[] {
     {
       name: 'getCurrentChannel',
       description:
-        'Return the channel/chat (and thread/topic) THIS conversation is bound to, including its name when available.',
+        'Return the channel/chat (and thread/topic) THIS conversation is bound to, including its name when available. ' +
+        'When the current channel is itself a child conversation, `parentChannel` is the enclosing channel ID required ' +
+        'by `sendMessage` channel-root forms.',
       inputSchema: obj({})
     },
     {

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -295,6 +295,8 @@ export class SessionManager {
         agent: Agent
         platform: string
         channel: string
+        /** Enclosing channel when `channel` is itself a child conversation. */
+        parentChannel?: string
         thread: string
         integrationId?: string
         transportScope?: string
@@ -763,6 +765,12 @@ export class SessionManager {
         ? [`- Slack identity: bot user <@${slackSelfId}> is YOU — a message mentioning this ID is addressed to you`]
         : []),
       `- Channel: ${msg.channel}`,
+      ...(msg.parentChannel
+        ? [
+            `- Enclosing channel: ${msg.parentChannel} — use this ID, not the current thread ID, for ` +
+              '`sendMessage` channel-root sends'
+          ]
+        : []),
       ...(channelName ? [`- Channel name: ${channelName}`] : []),
       // session-concept §2.3: standing locator lines. `Thread` is this session's thread
       // segment; `Session` is its own stable id (only once minted — a brand-new session
@@ -904,6 +912,7 @@ export class SessionManager {
           agent,
           platform: msg.platform,
           channel: msg.channel,
+          ...(msg.parentChannel !== undefined ? { parentChannel: msg.parentChannel } : {}),
           thread,
           ...(integrationId !== undefined ? { integrationId } : {}),
           ...(transportScope !== undefined ? { transportScope } : {}),
@@ -970,6 +979,7 @@ export class SessionManager {
           agent,
           platform: msg.platform,
           channel: msg.channel,
+          ...(msg.parentChannel !== undefined ? { parentChannel: msg.parentChannel } : {}),
           thread,
           ...(integrationId !== undefined ? { integrationId } : {}),
           ...(transportScope !== undefined ? { transportScope } : {}),

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -294,9 +294,10 @@ export class SessionManager {
       mcpServersFor?: (ctx: {
         agent: Agent
         platform: string
+        /** Channel root exposed to the agent and accepted by visible sends. */
         channel: string
-        /** Enclosing channel when `channel` is itself a child conversation. */
-        parentChannel?: string
+        /** Exact platform channel coordinate used to key the current session. */
+        sessionChannel: string
         thread: string
         integrationId?: string
         transportScope?: string
@@ -726,7 +727,8 @@ export class SessionManager {
     // it can be absent for a brand-new channel until resolution catches up — then the id
     // line alone stands. Stored bare for a group/channel, `@name` for a DM (same value
     // the console labels with), surfaced as-is.
-    const channelName = this.deps.store.getDisplayNames([msg.channel]).get(msg.channel)
+    const channel = msg.parentChannel ?? msg.channel
+    const channelName = this.deps.store.getDisplayNames([channel]).get(channel)
     // Key NAMES (never values) of the agent's write-only secrets. The values are merged
     // into the child process env (agents/agent-env.ts) so the agent's commands can USE
     // them; this notice is what distinguishes them from plain env vars in the agent's
@@ -764,13 +766,7 @@ export class SessionManager {
       ...(slackSelfId
         ? [`- Slack identity: bot user <@${slackSelfId}> is YOU — a message mentioning this ID is addressed to you`]
         : []),
-      `- Channel: ${msg.channel}`,
-      ...(msg.parentChannel
-        ? [
-            `- Enclosing channel: ${msg.parentChannel} — use this ID, not the current thread ID, for ` +
-              '`sendMessage` channel-root sends'
-          ]
-        : []),
+      `- Channel: ${channel}`,
       ...(channelName ? [`- Channel name: ${channelName}`] : []),
       // session-concept §2.3: standing locator lines. `Thread` is this session's thread
       // segment; `Session` is its own stable id (only once minted — a brand-new session
@@ -911,8 +907,8 @@ export class SessionManager {
         this.deps.mcpServersFor?.({
           agent,
           platform: msg.platform,
-          channel: msg.channel,
-          ...(msg.parentChannel !== undefined ? { parentChannel: msg.parentChannel } : {}),
+          channel,
+          sessionChannel: msg.channel,
           thread,
           ...(integrationId !== undefined ? { integrationId } : {}),
           ...(transportScope !== undefined ? { transportScope } : {}),
@@ -978,8 +974,8 @@ export class SessionManager {
         this.deps.mcpServersFor?.({
           agent,
           platform: msg.platform,
-          channel: msg.channel,
-          ...(msg.parentChannel !== undefined ? { parentChannel: msg.parentChannel } : {}),
+          channel,
+          sessionChannel: msg.channel,
           thread,
           ...(integrationId !== undefined ? { integrationId } : {}),
           ...(transportScope !== undefined ? { transportScope } : {}),

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -244,6 +244,7 @@ describe('Daemon interrupt safety gates', () => {
         platform: 'slack',
         isDm: false,
         channel: 'C2',
+        sessionChannel: 'C2',
         thread: 'T2',
         tools: []
       }

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -128,12 +128,22 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       // A dream never populates activeGateEntries (it runs off the chat-turn
       // queue), so without the carve-out its read-only tools would be gated shut.
       expect(
-        (daemon as any).toolTurnRunnable({ agentId: 'bot-a', platform: 'dream', channel: 'memory', thread: 'drm-1' })
+        (daemon as any).toolTurnRunnable({
+          agentId: 'bot-a',
+          platform: 'dream',
+          sessionChannel: 'memory',
+          thread: 'drm-1'
+        })
       ).toBe(true)
       // An ordinary session with no admitted turn still fails closed — a
       // session-static MCP token must not outlive its turn.
       expect(
-        (daemon as any).toolTurnRunnable({ agentId: 'bot-a', platform: 'slack', channel: 'C1', thread: 'T1' })
+        (daemon as any).toolTurnRunnable({
+          agentId: 'bot-a',
+          platform: 'slack',
+          sessionChannel: 'C1',
+          thread: 'T1'
+        })
       ).toBe(false)
     } finally {
       await daemon.stop().catch(() => undefined)

--- a/packages/daemon/test/mcp-bridge-e2e.test.ts
+++ b/packages/daemon/test/mcp-bridge-e2e.test.ts
@@ -75,6 +75,7 @@ describe('mcp-bridge end-to-end (real stdio MCP handshake)', () => {
       integrationId: 'int-1',
       isDm: false,
       channel: 'C9',
+      sessionChannel: 'C9',
       thread: '5.5',
       tools
     })

--- a/packages/daemon/test/mcp-control-server.test.ts
+++ b/packages/daemon/test/mcp-control-server.test.ts
@@ -41,6 +41,7 @@ const ctx = (over: Partial<SessionContext> = {}): SessionContext => ({
   integrationId: 'int-1',
   isDm: false,
   channel: 'C1',
+  sessionChannel: 'C1',
   thread: '1.1',
   tools,
   ...over

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -17,6 +17,7 @@ const ctx: SessionContext = {
   integrationId: 'int-1',
   isDm: false,
   channel: 'C_CURRENT',
+  sessionChannel: 'C_CURRENT',
   thread: '111.1',
   tools: toolsForIntegrations([
     { id: 'int-1', platform: 'slack', core: { bindRules: [] }, config: { botToken: 'x', appToken: 'y' } }
@@ -254,6 +255,7 @@ describe('executeTool: sendMessage (channel post)', () => {
         platform: 'telegram',
         integrationId: 'int-tg',
         channel: '-100123',
+        sessionChannel: '-100123',
         thread: 'tg:100',
         integrations: [{ id: 'int-tg', platform: 'telegram' }]
       }
@@ -594,26 +596,27 @@ describe('executeTool: sendMessage (channel post)', () => {
 })
 
 describe('executeTool: read tools', () => {
-  it('getCurrentChannel returns the bound channel + thread', async () => {
+  it('getCurrentChannel returns the root channel + thread', async () => {
     const { deps: d } = deps(fakeGateway())
     const res = (await executeTool(ctx, 'getCurrentChannel', {}, d)) as Record<string, unknown>
     expect(res).toMatchObject({ channel: 'C_CURRENT', thread: '111.1', name: 'general' })
   })
 
-  it('getCurrentChannel exposes the trusted enclosing channel for a child thread', async () => {
-    const { deps: d } = deps(fakeGateway())
+  it('getCurrentChannel keeps the root channel when the session is bound to a child thread', async () => {
+    const gw = fakeGateway()
+    const { deps: d } = deps(gw)
     const res = (await executeTool(
-      { ...ctx, platform: 'discord', channel: 'T_CURRENT', parentChannel: 'C_PARENT', thread: 'T_CURRENT' },
+      { ...ctx, platform: 'discord', channel: 'C_PARENT', sessionChannel: 'T_CURRENT', thread: 'T_CURRENT' },
       'getCurrentChannel',
       {},
       d
     )) as Record<string, unknown>
     expect(res).toMatchObject({
-      channel: 'T_CURRENT',
+      channel: 'C_PARENT',
       thread: 'T_CURRENT',
-      parentChannel: 'C_PARENT',
       name: 'general'
     })
+    expect(gw.getChannelInfo).toHaveBeenCalledWith('C_PARENT')
   })
 
   it('listChannelMembers defaults to the current channel', async () => {
@@ -952,26 +955,36 @@ describe('executeTool: sendMessage (wake / reply)', () => {
     })
   })
 
-  it('rejects the current child thread as a channel root and directs the caller to its trusted parent', async () => {
+  it('rejects the current thread as a channel root and directs the caller to Channel', async () => {
     const { deps: d, calls, gw } = wakeDeps()
     const threadCtx: SessionContext = {
       ...ctx,
       platform: 'discord',
-      channel: 'T_CURRENT',
-      parentChannel: 'C_PARENT',
+      channel: 'C_PARENT',
+      sessionChannel: 'T_CURRENT',
       thread: 'T_CURRENT',
       integrations: [{ id: 'int-1', platform: 'discord' }]
     }
 
     await expect(
       executeTool(threadCtx, 'sendMessage', { toAgent: 'peer-1', channel: 'T_CURRENT', message: 'over to you' }, d)
-    ).rejects.toThrow('channel "T_CURRENT" is the current thread, not a channel root. Use parent channel "C_PARENT"')
+    ).rejects.toThrow('channel "T_CURRENT" is the current thread, not a channel root. Use Channel "C_PARENT"')
     expect(gw.postMessage).not.toHaveBeenCalled()
     expect(calls).toEqual([])
 
+    await executeTool(threadCtx, 'sendMessage', { toAgent: 'peer-1', message: 'private handoff' }, d)
+    expect(gw.postMessage).not.toHaveBeenCalled()
+    expect(calls[0]).toMatchObject({
+      callerChannel: 'T_CURRENT',
+      callerThread: 'T_CURRENT',
+      channel: 'T_CURRENT',
+      thread: 'T_CURRENT',
+      postless: true
+    })
+
     await executeTool(threadCtx, 'sendMessage', { toAgent: 'peer-1', channel: 'C_PARENT', message: 'over to you' }, d)
     expect(gw.postMessage).toHaveBeenCalledWith('C_PARENT', 'over to you', undefined, pairedAuthorIdentity)
-    expect(calls[0]).toMatchObject({ channel: 'C_PARENT', thread: 'C_PARENT', toAgentId: 'peer-1' })
+    expect(calls[1]).toMatchObject({ channel: 'C_PARENT', thread: 'C_PARENT', toAgentId: 'peer-1' })
   })
 
   it('channel + toAgent (no thread) posts a ROOT message and lands the peer in that post’s thread', async () => {

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -600,6 +600,22 @@ describe('executeTool: read tools', () => {
     expect(res).toMatchObject({ channel: 'C_CURRENT', thread: '111.1', name: 'general' })
   })
 
+  it('getCurrentChannel exposes the trusted enclosing channel for a child thread', async () => {
+    const { deps: d } = deps(fakeGateway())
+    const res = (await executeTool(
+      { ...ctx, platform: 'discord', channel: 'T_CURRENT', parentChannel: 'C_PARENT', thread: 'T_CURRENT' },
+      'getCurrentChannel',
+      {},
+      d
+    )) as Record<string, unknown>
+    expect(res).toMatchObject({
+      channel: 'T_CURRENT',
+      thread: 'T_CURRENT',
+      parentChannel: 'C_PARENT',
+      name: 'general'
+    })
+  })
+
   it('listChannelMembers defaults to the current channel', async () => {
     const gw = fakeGateway()
     const { deps: d } = deps(gw)
@@ -934,6 +950,28 @@ describe('executeTool: sendMessage (wake / reply)', () => {
       // still land in the caller's channel, which is the interruption this form avoids.
       postless: true
     })
+  })
+
+  it('rejects the current child thread as a channel root and directs the caller to its trusted parent', async () => {
+    const { deps: d, calls, gw } = wakeDeps()
+    const threadCtx: SessionContext = {
+      ...ctx,
+      platform: 'discord',
+      channel: 'T_CURRENT',
+      parentChannel: 'C_PARENT',
+      thread: 'T_CURRENT',
+      integrations: [{ id: 'int-1', platform: 'discord' }]
+    }
+
+    await expect(
+      executeTool(threadCtx, 'sendMessage', { toAgent: 'peer-1', channel: 'T_CURRENT', message: 'over to you' }, d)
+    ).rejects.toThrow('channel "T_CURRENT" is the current thread, not a channel root. Use parent channel "C_PARENT"')
+    expect(gw.postMessage).not.toHaveBeenCalled()
+    expect(calls).toEqual([])
+
+    await executeTool(threadCtx, 'sendMessage', { toAgent: 'peer-1', channel: 'C_PARENT', message: 'over to you' }, d)
+    expect(gw.postMessage).toHaveBeenCalledWith('C_PARENT', 'over to you', undefined, pairedAuthorIdentity)
+    expect(calls[0]).toMatchObject({ channel: 'C_PARENT', thread: 'C_PARENT', toAgentId: 'peer-1' })
   })
 
   it('channel + toAgent (no thread) posts a ROOT message and lands the peer in that post’s thread', async () => {

--- a/packages/daemon/test/memory-write-gate.test.ts
+++ b/packages/daemon/test/memory-write-gate.test.ts
@@ -15,6 +15,7 @@ const ctx = (): SessionContext => ({
   agentId: 'bot-a',
   platform: 'slack',
   channel: 'C1',
+  sessionChannel: 'C1',
   thread: 'T1',
   isDm: true,
   tools: []

--- a/packages/daemon/test/memory.test.ts
+++ b/packages/daemon/test/memory.test.ts
@@ -588,6 +588,7 @@ describe('memory MCP tools (executeTool)', () => {
     integrationId: 'int-x',
     isDm: false,
     channel: 'C1',
+    sessionChannel: 'C1',
     thread: 'T1',
     tools: []
   }

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -644,23 +644,46 @@ describe('SessionManager', () => {
   it('the agent meta object carries identity, description and the channel source', async () => {
     const store = newStore()
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
+    const mcpServersFor = vi.fn(() => [])
     const withDesc = { ...agent, name: 'matrixtest', id: 'bot-a', description: 'be helpful' }
-    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => withDesc, memory })
-    await sm.handle('bot-a', msg({ ts: '100.1', text: 'hi', platform: 'discord', channel: 'C42' }))
+    const sm = new SessionManager({
+      store,
+      hostFor: async () => host,
+      agentById: () => withDesc,
+      memory,
+      mcpServersFor
+    })
+    await sm.handle(
+      'bot-a',
+      msg({
+        ts: '100.1',
+        text: 'hi',
+        platform: 'discord',
+        channel: 'T42',
+        parentChannel: 'C42',
+        thread: 'T42'
+      })
+    )
     const metaArg = host.newSession.mock.calls[0][3] as string
     expect(metaArg).toContain('- Name: matrixtest')
     expect(metaArg).toContain('- ID: bot-a')
     expect(metaArg).toContain('- Source: discord')
-    expect(metaArg).toContain('- Channel: C42')
+    expect(metaArg).toContain('- Channel: T42')
+    expect(metaArg).toContain(
+      '- Enclosing channel: C42 — use this ID, not the current thread ID, for `sendMessage` channel-root sends'
+    )
     expect(metaArg).toContain('be helpful')
-    // No resolved display name for C42 → the channel-name line is omitted.
+    // No resolved display name for T42 → the channel-name line is omitted.
     expect(metaArg).not.toContain('- Channel name:')
     // session-concept §2.3 standing locators: Thread is always rendered; Session is
     // absent on a brand-new session's FIRST turn (its acpSessionId is minted AFTER this
     // block is composed); Parent session is absent when this session has no parent.
-    expect(metaArg).toContain('- Thread: 100.1')
+    expect(metaArg).toContain('- Thread: T42')
     expect(metaArg).not.toContain('- Session:')
     expect(metaArg).not.toContain('- Parent session:')
+    expect(mcpServersFor).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: 'discord', channel: 'T42', parentChannel: 'C42', thread: 'T42' })
+    )
     store.close()
   })
 

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -590,6 +590,7 @@ describe('SessionManager', () => {
         agent: codexAgent,
         platform: 'slack',
         channel: 'C1',
+        sessionChannel: 'C1',
         thread: '100.1',
         integrationId: 'int-b',
         isDm: true
@@ -668,12 +669,10 @@ describe('SessionManager', () => {
     expect(metaArg).toContain('- Name: matrixtest')
     expect(metaArg).toContain('- ID: bot-a')
     expect(metaArg).toContain('- Source: discord')
-    expect(metaArg).toContain('- Channel: T42')
-    expect(metaArg).toContain(
-      '- Enclosing channel: C42 — use this ID, not the current thread ID, for `sendMessage` channel-root sends'
-    )
+    expect(metaArg).toContain('- Channel: C42')
+    expect(metaArg).not.toContain('- Enclosing channel:')
     expect(metaArg).toContain('be helpful')
-    // No resolved display name for T42 → the channel-name line is omitted.
+    // No resolved display name for C42 → the channel-name line is omitted.
     expect(metaArg).not.toContain('- Channel name:')
     // session-concept §2.3 standing locators: Thread is always rendered; Session is
     // absent on a brand-new session's FIRST turn (its acpSessionId is minted AFTER this
@@ -682,7 +681,7 @@ describe('SessionManager', () => {
     expect(metaArg).not.toContain('- Session:')
     expect(metaArg).not.toContain('- Parent session:')
     expect(mcpServersFor).toHaveBeenCalledWith(
-      expect.objectContaining({ platform: 'discord', channel: 'T42', parentChannel: 'C42', thread: 'T42' })
+      expect.objectContaining({ platform: 'discord', channel: 'C42', sessionChannel: 'T42', thread: 'T42' })
     )
     store.close()
   })


### PR DESCRIPTION
## Summary

- Make `Channel` in the standing Agent context and `getCurrentChannel.channel` always identify the root destination accepted by visible `sendMessage` forms.
- Keep `Thread` as contextual information only; reject the current thread ID when it is passed as `sendMessage.channel`, with an error that names `Channel` and never silently redirects.
- Preserve the exact platform coordinate separately as daemon-internal `sessionChannel`, so Discord thread replies, session keys, cancellation, lineage, orchestration, and postless A2A calls remain bound to the existing thread.
- Keep Slack behavior unchanged because its root channel and session channel are already the same coordinate.

## Root cause

Discord models a thread as a channel, so normalization correctly uses the Discord thread ID as the session delivery channel. AgentConnect was also presenting that internal delivery coordinate as `Channel`, even though visible `sendMessage` forms only accept channel roots. That leaked two different meanings through one field and led the model to pass the thread ID into a root-only send. This is a coordinate-contract issue, not an agent-visibility or call-policy issue.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- 305 tests passed across the seven directly affected daemon suites
- 213 focused tests passed again after rebasing onto the latest `origin/main`
- Changed-file ESLint and repository-wide pre-push ESLint
- Prettier and `git diff --check`

Created by Codex . GPT-5.6