### PR TITLE
refactor(setup): share provider app integrations

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -176,6 +176,7 @@ ENV NEXT_PUBLIC_CP_URL=/cp/api/v1 \
   BUILD_TIME=$BUILD_TIME
 # Keep the runtime copy stable when an application has no public assets yet.
 RUN mkdir -p packages/web/public \
+  && pnpm --filter "@agentconnect.md/protocol" build \
   && pnpm --filter "@agentconnect.md/web" build
 
 # ───────────────────────────── web: runtime ─────────────────────────────────

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -22,6 +22,30 @@
       "import": "./dist/http/feishu-registration-provider.js",
       "default": "./dist/http/feishu-registration-provider.js"
     },
+    "./feishu-identity": {
+      "development": "./src/http/feishu-identity.ts",
+      "types": "./dist/http/feishu-identity.d.ts",
+      "import": "./dist/http/feishu-identity.js",
+      "default": "./dist/http/feishu-identity.js"
+    },
+    "./github-app-api": {
+      "development": "./src/github/setup-api.ts",
+      "types": "./dist/github/setup-api.d.ts",
+      "import": "./dist/github/setup-api.js",
+      "default": "./dist/github/setup-api.js"
+    },
+    "./slack-config-api": {
+      "development": "./src/http/slack-config-api.ts",
+      "types": "./dist/http/slack-config-api.d.ts",
+      "import": "./dist/http/slack-config-api.js",
+      "default": "./dist/http/slack-config-api.js"
+    },
+    "./slack-manifest": {
+      "development": "./src/http/slack-manifest.ts",
+      "types": "./dist/http/slack-manifest.d.ts",
+      "import": "./dist/http/slack-manifest.js",
+      "default": "./dist/http/slack-manifest.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",
@@ -67,6 +91,7 @@
     "@prisma/adapter-pg": "^7.9.0",
     "@prisma/client": "^7.9.0",
     "@resvg/resvg-js": "^2.6.2",
+    "@slack/web-api": "^8.0.0",
     "aws4fetch": "^1.0.20",
     "croner": "^10.0.1",
     "fastify": "^5.10.0",

--- a/packages/control-plane/src/github/setup-api.ts
+++ b/packages/control-plane/src/github/setup-api.ts
@@ -1,0 +1,24 @@
+import { githubRequest, mintAppJwt } from './api.js'
+import { resolveGithubAppConfig, type GithubAppConfig } from './config.js'
+
+export interface GithubSetupAppIdentity {
+  appId: number
+  slug: string
+  clientId: string | null
+  privateKeyBase64: string
+}
+
+/** Adapt persisted deployment credentials to the same validated App config used by the Control Plane. */
+export function resolveGithubSetupAppConfig(identity: GithubSetupAppIdentity): GithubAppConfig {
+  const config = resolveGithubAppConfig({
+    GITHUB_APP_ID: identity.appId,
+    GITHUB_APP_SLUG: identity.slug,
+    GITHUB_APP_PRIVATE_KEY_B64: identity.privateKeyBase64,
+    ...(identity.clientId ? { GITHUB_APP_CLIENT_ID: identity.clientId } : {})
+  })
+  if (!config) throw new Error('GitHub App credentials are not configured')
+  return config
+}
+
+export { githubRequest, mintAppJwt }
+export type { FetchLike, GithubRequestOpts } from './api.js'

--- a/packages/control-plane/src/http/feishu-identity.ts
+++ b/packages/control-plane/src/http/feishu-identity.ts
@@ -68,10 +68,11 @@ const FEISHU_TIMEOUT_MS = 5000
 async function tenantAccessToken(
   appId: string,
   appSecret: string,
-  region: FeishuRegion
+  region: FeishuRegion,
+  fetcher: typeof fetch = fetch
 ): Promise<{ status: 'ok'; token: string } | { status: 'invalid' | 'unavailable' }> {
   try {
-    const res = await fetch(`${REGION_BASE[region]}/auth/v3/tenant_access_token/internal`, {
+    const res = await fetcher(`${REGION_BASE[region]}/auth/v3/tenant_access_token/internal`, {
       method: 'POST',
       headers: { 'content-type': 'application/json; charset=utf-8' },
       body: JSON.stringify({ app_id: appId, app_secret: appSecret }),
@@ -84,6 +85,21 @@ async function tenantAccessToken(
       : { status: 'invalid' }
   } catch {
     return { status: 'unavailable' }
+  }
+}
+
+export type FeishuAppCredentialVerification = { status: 'ok' | 'invalid' | 'unavailable' }
+export type FeishuAppCredentialVerifier = (
+  appId: string,
+  appSecret: string,
+  region: FeishuRegion
+) => Promise<FeishuAppCredentialVerification>
+
+/** Lightweight credential check shared by the runtime installer and Tenant Admin. */
+export function createFeishuAppCredentialVerifier(fetcher?: typeof fetch): FeishuAppCredentialVerifier {
+  return async (appId, appSecret, region) => {
+    const result = await tenantAccessToken(appId, appSecret, region, fetcher ?? fetch)
+    return { status: result.status }
   }
 }
 

--- a/packages/control-plane/src/http/platform-app-description.ts
+++ b/packages/control-plane/src/http/platform-app-description.ts
@@ -1,3 +1,3 @@
 /** Public platform profile copy. Never derive this from an Agent description:
  * that field is model context and may contain private operating instructions. */
-export const PLATFORM_APP_DESCRIPTION = 'AI agent powered by AgentConnect.'
+export { PLATFORM_APP_DESCRIPTION } from '@agentconnect.md/protocol/slack-app-manifest'

--- a/packages/control-plane/src/http/slack-config-api.test.ts
+++ b/packages/control-plane/src/http/slack-config-api.test.ts
@@ -69,7 +69,7 @@ describe('slackConfigApi.exportApp (apps.manifest.export)', () => {
     expect(await slackConfigApi.exportApp('xoxe.xoxp-token', 'A012ABCD0A0')).toEqual({ ok: true, manifest })
     const request = vi.mocked(globalThis.fetch).mock.calls[0]!
     expect(request[0]).toBe('https://slack.com/api/apps.manifest.export')
-    const body = request[1]?.body as URLSearchParams
+    const body = new URLSearchParams(String(request[1]?.body))
     expect(body.get('token')).toBe('xoxe.xoxp-token')
     expect(body.get('app_id')).toBe('A012ABCD0A0')
   })
@@ -99,7 +99,7 @@ describe('slackConfigApi.updateApp (apps.manifest.update)', () => {
     })
     const request = vi.mocked(globalThis.fetch).mock.calls[0]!
     expect(request[0]).toBe('https://slack.com/api/apps.manifest.update')
-    const body = request[1]?.body as URLSearchParams
+    const body = new URLSearchParams(String(request[1]?.body))
     expect(body.get('app_id')).toBe('A012ABCD0A0')
     expect(JSON.parse(body.get('manifest')!)).toEqual(manifest)
   })

--- a/packages/control-plane/src/http/slack-config-api.ts
+++ b/packages/control-plane/src/http/slack-config-api.ts
@@ -9,6 +9,7 @@
  *
  * Contracts confirmed against docs.slack.dev (apps.manifest.create, oauth.v2.access).
  */
+import { WebAPIPlatformError, WebClient, type AppsManifestCreateArguments, type WebClientOptions } from '@slack/web-api'
 
 const SLACK_TIMEOUT_MS = 10_000
 
@@ -70,123 +71,124 @@ export interface SlackConfigApi {
   rotateConfigToken(refreshToken: string): Promise<SlackRotateResult>
 }
 
-async function postForm(url: string, form: Record<string, string>): Promise<{ ok: boolean; body: unknown } | null> {
-  try {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams(form),
-      signal: AbortSignal.timeout(SLACK_TIMEOUT_MS)
+function slackError(error: unknown): string {
+  return error instanceof WebAPIPlatformError ? error.data.error : 'unreachable'
+}
+
+export interface SlackConfigApiOptions {
+  fetch?: WebClientOptions['fetch']
+}
+
+/** Slack's official client owns transport, encoding, API errors, and response types. */
+export function createSlackConfigApi(options: SlackConfigApiOptions = {}): SlackConfigApi {
+  const client = () =>
+    new WebClient(undefined, {
+      fetch: options.fetch ?? (globalThis.fetch as WebClientOptions['fetch']),
+      timeout: SLACK_TIMEOUT_MS,
+      retryConfig: { retries: 0 },
+      rejectRateLimitedCalls: true
     })
-    if (!res.ok) return null
-    return { ok: true, body: await res.json() }
-  } catch {
-    return null
+
+  return {
+    async createApp(configToken, manifest) {
+      try {
+        const body = await client().apps.manifest.create({
+          token: configToken,
+          manifest: manifest as AppsManifestCreateArguments['manifest']
+        })
+        const credentials = body.credentials ?? {}
+        if (
+          !body.app_id ||
+          !credentials.client_id ||
+          !credentials.client_secret ||
+          !credentials.signing_secret ||
+          !body.oauth_authorize_url
+        ) {
+          return { ok: false, error: 'malformed_response' }
+        }
+        return {
+          ok: true,
+          app: {
+            appId: body.app_id,
+            clientId: credentials.client_id,
+            clientSecret: credentials.client_secret,
+            signingSecret: credentials.signing_secret,
+            oauthAuthorizeUrl: body.oauth_authorize_url
+          }
+        }
+      } catch (error) {
+        return { ok: false, error: slackError(error) }
+      }
+    },
+
+    async exportApp(configToken, appId) {
+      try {
+        const body = await client().apps.manifest.export({ token: configToken, app_id: appId })
+        if (body.manifest === null || typeof body.manifest !== 'object' || Array.isArray(body.manifest)) {
+          return { ok: false, error: 'malformed_response' }
+        }
+        return { ok: true, manifest: body.manifest as Record<string, unknown> }
+      } catch (error) {
+        return { ok: false, error: slackError(error) }
+      }
+    },
+
+    async updateApp(configToken, appId, manifest) {
+      try {
+        const body = await client().apps.manifest.update({
+          token: configToken,
+          app_id: appId,
+          manifest: manifest as AppsManifestCreateArguments['manifest']
+        })
+        if (typeof body.permissions_updated !== 'boolean') return { ok: false, error: 'malformed_response' }
+        return { ok: true, permissionsUpdated: body.permissions_updated }
+      } catch (error) {
+        return { ok: false, error: slackError(error) }
+      }
+    },
+
+    async exchangeOAuth({ clientId, clientSecret, code, redirectUri }) {
+      try {
+        const body = await client().oauth.v2.access({
+          client_id: clientId,
+          client_secret: clientSecret,
+          code,
+          redirect_uri: redirectUri
+        })
+        if (!body.access_token || !body.app_id) return { ok: false, error: 'malformed_response' }
+        return {
+          ok: true,
+          result: {
+            botToken: body.access_token,
+            appId: body.app_id,
+            teamId: body.team?.id ?? null,
+            teamName: body.team?.name ?? null,
+            botUserId: body.bot_user_id ?? null
+          }
+        }
+      } catch (error) {
+        return { ok: false, error: slackError(error) }
+      }
+    },
+
+    async rotateConfigToken(refreshToken) {
+      try {
+        const body = await client().tooling.tokens.rotate({ refresh_token: refreshToken })
+        if (!body.token || !body.refresh_token || !body.exp) return { ok: false, error: 'malformed_response' }
+        return {
+          ok: true,
+          rotated: {
+            accessToken: body.token,
+            refreshToken: body.refresh_token,
+            accessExpiresAt: new Date(body.exp * 1000)
+          }
+        }
+      } catch (error) {
+        return { ok: false, error: slackError(error) }
+      }
+    }
   }
 }
 
 /** The live implementation (the container wires this; tests inject a stub). */
-export const slackConfigApi: SlackConfigApi = {
-  async createApp(configToken, manifest) {
-    const r = await postForm('https://slack.com/api/apps.manifest.create', {
-      token: configToken,
-      manifest: JSON.stringify(manifest)
-    })
-    if (!r) return { ok: false, error: 'unreachable' }
-    const body = r.body as {
-      ok?: boolean
-      error?: string
-      app_id?: string
-      credentials?: { client_id?: string; client_secret?: string; signing_secret?: string }
-      oauth_authorize_url?: string
-    }
-    if (!body.ok) return { ok: false, error: body.error ?? 'unknown_error' }
-    const c = body.credentials ?? {}
-    if (!body.app_id || !c.client_id || !c.client_secret || !body.oauth_authorize_url) {
-      return { ok: false, error: 'malformed_response' }
-    }
-    return {
-      ok: true,
-      app: {
-        appId: body.app_id,
-        clientId: c.client_id,
-        clientSecret: c.client_secret,
-        signingSecret: c.signing_secret ?? '',
-        oauthAuthorizeUrl: body.oauth_authorize_url
-      }
-    }
-  },
-
-  async exportApp(configToken, appId) {
-    const r = await postForm('https://slack.com/api/apps.manifest.export', {
-      token: configToken,
-      app_id: appId
-    })
-    if (!r) return { ok: false, error: 'unreachable' }
-    const body = r.body as { ok?: boolean; error?: string; manifest?: unknown }
-    if (!body.ok) return { ok: false, error: body.error ?? 'unknown_error' }
-    if (body.manifest === null || typeof body.manifest !== 'object' || Array.isArray(body.manifest)) {
-      return { ok: false, error: 'malformed_response' }
-    }
-    return { ok: true, manifest: body.manifest as Record<string, unknown> }
-  },
-
-  async updateApp(configToken, appId, manifest) {
-    const r = await postForm('https://slack.com/api/apps.manifest.update', {
-      token: configToken,
-      app_id: appId,
-      manifest: JSON.stringify(manifest)
-    })
-    if (!r) return { ok: false, error: 'unreachable' }
-    const body = r.body as { ok?: boolean; error?: string; permissions_updated?: boolean }
-    if (!body.ok) return { ok: false, error: body.error ?? 'unknown_error' }
-    if (typeof body.permissions_updated !== 'boolean') return { ok: false, error: 'malformed_response' }
-    return { ok: true, permissionsUpdated: body.permissions_updated }
-  },
-
-  async exchangeOAuth({ clientId, clientSecret, code, redirectUri }) {
-    const r = await postForm('https://slack.com/api/oauth.v2.access', {
-      client_id: clientId,
-      client_secret: clientSecret,
-      code,
-      redirect_uri: redirectUri
-    })
-    if (!r) return { ok: false, error: 'unreachable' }
-    const body = r.body as {
-      ok?: boolean
-      error?: string
-      access_token?: string
-      app_id?: string
-      bot_user_id?: string
-      team?: { id?: string; name?: string }
-    }
-    if (!body.ok) return { ok: false, error: body.error ?? 'unknown_error' }
-    if (!body.access_token || !body.app_id) return { ok: false, error: 'malformed_response' }
-    return {
-      ok: true,
-      result: {
-        botToken: body.access_token,
-        appId: body.app_id,
-        teamId: body.team?.id ?? null,
-        teamName: body.team?.name ?? null,
-        botUserId: body.bot_user_id ?? null
-      }
-    }
-  },
-
-  async rotateConfigToken(refreshToken) {
-    const r = await postForm('https://slack.com/api/tooling.tokens.rotate', { refresh_token: refreshToken })
-    if (!r) return { ok: false, error: 'unreachable' }
-    const body = r.body as { ok?: boolean; error?: string; token?: string; refresh_token?: string; exp?: number }
-    if (!body.ok) return { ok: false, error: body.error ?? 'unknown_error' }
-    if (!body.token || !body.refresh_token || !body.exp) return { ok: false, error: 'malformed_response' }
-    return {
-      ok: true,
-      rotated: {
-        accessToken: body.token,
-        refreshToken: body.refresh_token,
-        accessExpiresAt: new Date(body.exp * 1000) // `exp` is unix seconds
-      }
-    }
-  }
-}
+export const slackConfigApi = createSlackConfigApi()

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -3,76 +3,32 @@
  * (docs/designs/slack-install-smoothing.md §Tier B).
  *
  * In the MANUAL flow the console builds the manifest and deep-links the user to
- * Slack (packages/web/src/lib/slack-manifest.ts). In the AUTO flow the CP creates
- * the app itself via `apps.manifest.create`, so it must build the same manifest —
+ * Slack (packages/web/src/components/console/platforms/slack/manifest.ts). In the
+ * AUTO flow the CP creates the app itself via `apps.manifest.create`, so it must build the same manifest —
  * PLUS `oauth_config.redirect_urls` pointing at the CP's own OAuth callback. The
  * CP owns that field on purpose: a client-supplied redirect URL would be an
  * open-redirect / token-theft hole.
  *
- * The scopes/events MUST stay in lock-step with the manual manifest AND with what
- * the daemon's Slack adapter actually uses (packages/daemon/src/slack/*). The two
- * lists below are pinned by a drift-guard test (slack-manifest.test.ts); when you
- * change them here, change them in packages/web/src/lib/slack-manifest.ts too.
+ * The shared protocol module owns the canonical desired state. This module adds
+ * Control Plane URL helpers and merge rules for already-installed Apps.
  */
-import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
-import { PLATFORM_APP_DESCRIPTION } from './platform-app-description.js'
+import {
+  buildSlackAppManifest,
+  DEFAULT_SLACK_APP_NAME,
+  PLATFORM_APP_DESCRIPTION,
+  SLACK_BOT_EVENTS,
+  SLACK_BOT_SCOPES,
+  slackEventsRequestUrl,
+  slackInteractionsRequestUrl
+} from '@agentconnect.md/protocol/slack-app-manifest'
 
-/**
- * Bot token scopes the Slack app requests. Widening this list later forces every
- * workspace that already installed the app to re-authorize, so it covers group
- * DMs (`mpim:*`) and agent-initiated DMs (`im:write`) alongside the channel and
- * thread surfaces the adapter reads today.
- *
- * Deliberately NO channel-write scope. `conversations.leave` would need
- * `channels:manage` (or `groups:write` for private channels), and Slack offers no
- * leave-only scope — `channels:manage` also grants create, archive, kick, rename and
- * unarchive, none of which this app uses. Taking four unused powers AND forcing every
- * installed workspace to re-authorize buys very little here: Slack reports its own
- * membership authoritatively, so removing the bot in Slack makes the console row
- * disappear by itself. The console offers Off and Forget for Slack instead, and
- * leaving is done in Slack. A deployment that grants these scopes on its own app can
- * still call the leave API; only the manifest and the console affordance omit it.
- */
-export const SLACK_BOT_SCOPES = [
-  'files:read',
-  'app_mentions:read',
-  'channels:history',
-  'channels:read',
-  'commands',
-  'chat:write',
-  'chat:write.customize',
-  'files:write',
-  'groups:history',
-  'groups:read',
-  'im:history',
-  'im:write',
-  'mpim:history',
-  'mpim:read',
-  'reactions:write',
-  'assistant:write',
-  'users:read'
-] as const
-
-/** Bot events the daemon subscribes to. The two `app_*` lifecycle events carry no
- *  OAuth grant (event additions never force a workspace re-auth); the relay-pool
- *  ingest turns them into `rc/bot-revoked` (preset-agents.md §5.3), while a
- *  socket-mode daemon has no handler and Bolt drops them silently. */
-export const SLACK_BOT_EVENTS = [
-  'app_mention',
-  'app_uninstalled',
-  'assistant_thread_started',
-  'message.channels',
-  'message.groups',
-  'message.im',
-  'message.mpim',
-  'member_joined_channel',
-  'channel_left',
-  'group_left',
-  'tokens_revoked'
-] as const
-
-/** Fallback app name so the manifest is always valid before the user types one. */
-export const DEFAULT_SLACK_APP_NAME = 'agentconnect'
+export {
+  DEFAULT_SLACK_APP_NAME,
+  SLACK_BOT_EVENTS,
+  SLACK_BOT_SCOPES,
+  slackEventsRequestUrl,
+  slackInteractionsRequestUrl
+}
 
 type ManifestRecord = Record<string, unknown>
 
@@ -97,15 +53,6 @@ function mergeManagedShortcuts(current: unknown, managed: unknown): unknown[] {
   return [...required, ...existing]
 }
 
-/** The relay pool's Events API endpoints, derived from its public HTTPS base
- *  (slack-http-mode §6): the manifest's `request_url`s Slack POSTs inbound to. */
-export function slackEventsRequestUrl(relayHttpBase: string): string {
-  return `${relayHttpBase.replace(/\/$/, '')}/slack/events`
-}
-export function slackInteractionsRequestUrl(relayHttpBase: string): string {
-  return `${relayHttpBase.replace(/\/$/, '')}/slack/interactions`
-}
-
 /** AgentConnect-owned defaults without an OAuth redirect URL. Existing-app refresh
  *  adds the current CP callback only when one is configured, while create always
  *  supplies it through `buildInstallManifest` below.
@@ -120,55 +67,14 @@ export function slackInteractionsRequestUrl(relayHttpBase: string): string {
 export interface SlackManifestOptions {
   httpRelayBase?: string
   backgroundColor?: string
+  additionalRedirectUrls?: readonly string[]
 }
 
 function buildManagedManifest(name: string, options: SlackManifestOptions = {}): ManifestRecord {
-  const displayName = name.trim() || DEFAULT_SLACK_APP_NAME
-  const http = !!options.httpRelayBase
-  return {
-    display_information: {
-      name: displayName,
-      ...(options.backgroundColor ? { background_color: options.backgroundColor } : {})
-    },
-    features: {
-      bot_user: { display_name: displayName, always_online: true },
-      app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false },
-      agent_view: {
-        agent_description: PLATFORM_APP_DESCRIPTION,
-        suggested_prompts: []
-      },
-      shortcuts: [
-        {
-          name: 'Manage session',
-          type: 'message',
-          callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
-          description: 'View or update the AgentConnect session for this conversation'
-        }
-      ]
-    },
-    oauth_config: {
-      scopes: { bot: [...SLACK_BOT_SCOPES] }
-    },
-    settings: {
-      event_subscriptions: {
-        bot_events: [...SLACK_BOT_EVENTS],
-        ...(http ? { request_url: slackEventsRequestUrl(options.httpRelayBase!) } : {})
-      },
-      interactivity: {
-        is_enabled: true,
-        ...(http
-          ? {
-              request_url: slackInteractionsRequestUrl(options.httpRelayBase!),
-              message_menu_options_url: slackInteractionsRequestUrl(options.httpRelayBase!)
-            }
-          : {})
-      },
-      org_deploy_enabled: false,
-      socket_mode_enabled: !http,
-      token_rotation_enabled: false,
-      is_mcp_enabled: false
-    }
-  }
+  return buildSlackAppManifest(name, {
+    ...(options.httpRelayBase ? { relayUrl: options.httpRelayBase } : {}),
+    ...(options.backgroundColor ? { backgroundColor: options.backgroundColor } : {})
+  })
 }
 
 /**
@@ -189,7 +95,7 @@ export function buildInstallManifest(
     ...managed,
     oauth_config: {
       ...asRecord(managed.oauth_config),
-      redirect_urls: [redirectUrl]
+      redirect_urls: [...new Set([redirectUrl, ...(options.additionalRedirectUrls ?? [])])]
     }
   }
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -11,6 +11,12 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./slack-app-manifest": {
+      "development": "./src/slack-app-manifest.ts",
+      "types": "./dist/slack-app-manifest.d.ts",
+      "import": "./dist/slack-app-manifest.js",
+      "default": "./dist/slack-app-manifest.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",

--- a/packages/protocol/src/slack-app-manifest.ts
+++ b/packages/protocol/src/slack-app-manifest.ts
@@ -1,0 +1,141 @@
+import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from './frames/relay-cp.js'
+
+export { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID }
+
+/** Public platform profile copy. Never derive this from an Agent description. */
+export const PLATFORM_APP_DESCRIPTION = 'AI agent powered by AgentConnect.'
+
+export const SLACK_BOT_SCOPES = [
+  'files:read',
+  'app_mentions:read',
+  'channels:history',
+  'channels:read',
+  'commands',
+  'chat:write',
+  'chat:write.customize',
+  'files:write',
+  'groups:history',
+  'groups:read',
+  'im:history',
+  'im:write',
+  'mpim:history',
+  'mpim:read',
+  'reactions:write',
+  'assistant:write',
+  'users:read'
+] as const
+
+export const SLACK_BOT_EVENTS = [
+  'app_mention',
+  'app_uninstalled',
+  'assistant_thread_started',
+  'message.channels',
+  'message.groups',
+  'message.im',
+  'message.mpim',
+  'member_joined_channel',
+  'channel_left',
+  'group_left',
+  'tokens_revoked'
+] as const
+
+export const DEFAULT_SLACK_APP_NAME = 'agentconnect'
+
+export interface SlackAppManifest extends Record<string, unknown> {
+  display_information: { name: string; background_color?: string }
+  features: {
+    bot_user: { display_name: string; always_online: boolean }
+    app_home: { home_tab_enabled: boolean; messages_tab_enabled: boolean; messages_tab_read_only_enabled: boolean }
+    agent_view: { agent_description: string; suggested_prompts: { title: string; message: string }[] }
+    shortcuts: { name: string; type: 'message'; callback_id: string; description: string }[]
+  }
+  oauth_config: {
+    scopes: { bot: string[] }
+    redirect_urls?: string[]
+    pkce_enabled?: boolean
+  }
+  settings: {
+    event_subscriptions: { request_url?: string; bot_events: string[] }
+    interactivity: { is_enabled: boolean; request_url?: string; message_menu_options_url?: string }
+    org_deploy_enabled: boolean
+    socket_mode_enabled: boolean
+    token_rotation_enabled: boolean
+    is_mcp_enabled: boolean
+  }
+}
+
+export interface SlackAppManifestOptions {
+  displayName?: string
+  relayUrl?: string
+  backgroundColor?: string
+  redirectUrls?: readonly string[]
+  pkceEnabled?: boolean
+}
+
+export function slackEventsRequestUrl(relayUrl: string): string {
+  return `${normalizeSlackRelayUrl(relayUrl)}/slack/events`
+}
+
+export function slackInteractionsRequestUrl(relayUrl: string): string {
+  return `${normalizeSlackRelayUrl(relayUrl)}/slack/interactions`
+}
+
+function normalizeSlackRelayUrl(relayUrl: string): string {
+  return relayUrl.replace(/^ws(s?):\/\//i, 'http$1://').replace(/\/+$/, '')
+}
+
+/** One canonical Slack manifest shared by browser, Control Plane, and Tenant Admin. */
+export function buildSlackAppManifest(name: string, options: SlackAppManifestOptions = {}): SlackAppManifest {
+  const appName = name.trim() || DEFAULT_SLACK_APP_NAME
+  const displayName = options.displayName?.trim() || appName
+  const relayUrl = options.relayUrl ? normalizeSlackRelayUrl(options.relayUrl) : undefined
+  const http = Boolean(relayUrl)
+  const redirectUrls = [...new Set(options.redirectUrls ?? [])]
+
+  return {
+    display_information: {
+      name: appName,
+      ...(options.backgroundColor ? { background_color: options.backgroundColor } : {})
+    },
+    features: {
+      bot_user: { display_name: displayName, always_online: true },
+      app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false },
+      agent_view: {
+        agent_description: PLATFORM_APP_DESCRIPTION,
+        suggested_prompts: []
+      },
+      shortcuts: [
+        {
+          name: 'Manage session',
+          type: 'message',
+          callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+          description: 'View or update the AgentConnect session for this conversation'
+        }
+      ]
+    },
+    oauth_config: {
+      scopes: { bot: [...SLACK_BOT_SCOPES] },
+      ...(redirectUrls.length > 0 ? { redirect_urls: redirectUrls } : {}),
+      ...(options.pkceEnabled !== undefined ? { pkce_enabled: options.pkceEnabled } : {})
+    },
+    settings: {
+      event_subscriptions: {
+        bot_events: [...SLACK_BOT_EVENTS],
+        ...(relayUrl ? { request_url: slackEventsRequestUrl(relayUrl) } : {})
+      },
+      interactivity: {
+        is_enabled: true,
+        ...(relayUrl
+          ? {
+              request_url: slackInteractionsRequestUrl(relayUrl),
+              message_menu_options_url: slackInteractionsRequestUrl(relayUrl)
+            }
+          : {})
+      },
+      org_deploy_enabled: false,
+      socket_mode_enabled: !http,
+      token_rotation_enabled: false,
+      is_mcp_enabled: false
+    }
+  }
+}

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -347,8 +347,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
     const tokenKey = 'agentconnect.tenant-admin.token';
     const verifierKey = 'agentconnect.tenant-admin.pkce';
     const stateKey = 'agentconnect.tenant-admin.state';
-    const googleConnectorId = 'agentconnect-google';
-    const githubConnectorId = 'agentconnect-github';
     let currentRevision = 0;
     let currentStatus = null;
     let bootstrapInfo = null;
@@ -369,7 +367,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
     };
     const base64url = (bytes) => btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
     const random = () => base64url(crypto.getRandomValues(new Uint8Array(32)));
-    const join = (base, path) => String(base || '').replace(/\/+$/, '') + '/' + path.replace(/^\/+/, '');
     const same = (a, b) => JSON.stringify([...(a || [])].sort()) === JSON.stringify([...(b || [])].sort());
     const configured = (byKey, key) => Boolean(byKey.get(key) && byKey.get(key).configured);
 
@@ -482,43 +479,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       return { owner: 'organization', organization };
     }
 
-    function githubExpected(values) {
-      const services = bootstrapInfo.services;
-      const browser = values.logto && values.logto.browser;
-      const callbacks = values.logto && values.logto.githubConnector && browser ? [
-        join(bootstrapInfo.logtoEndpoint, '/callback/' + githubConnectorId),
-        join(bootstrapInfo.logtoEndpoint, '/account/callback/social/' + githubConnectorId)
-      ] : [];
-      return {
-        externalUrl: services.web,
-        setupUrl: join(services.controlPlane, '/v1/github/setup/callback'),
-        webhookUrl: join(services.relay, '/webhooks/github'),
-        webhookActive: String(services.relay || '').startsWith('https://'),
-        callbackUrls: callbacks
-      };
-    }
-
-    function slackExpected(values) {
-      const services = bootstrapInfo.services;
-      const expected = {
-        oauthRedirectUrl: join(services.controlPlane, '/v1/integrations/slack/platform/callback'),
-        eventsUrl: join(services.relay, '/slack/events'),
-        interactionsUrl: join(services.relay, '/slack/interactions')
-      };
-      const browser = values.logto && values.logto.browser;
-      return values.logto && values.logto.slackConnector && browser
-        ? { ...expected, loginRedirectUrl: join(bootstrapInfo.logtoEndpoint, '/callback/agentconnect-slack') }
-        : expected;
-    }
-
-    function googleExpected(values) {
-      const endpoint = values.logto && values.logto.browser && bootstrapInfo.logtoEndpoint;
-      return endpoint ? {
-        origins: [endpoint],
-        redirects: [join(endpoint, '/callback/' + googleConnectorId), join(endpoint, '/account/callback/social/' + googleConnectorId)]
-      } : { origins: [], redirects: [] };
-    }
-
     function fieldsChanged(actual, expected) {
       if (!actual) return Object.keys(expected);
       return Object.keys(expected).filter((key) => Array.isArray(expected[key]) ? !same(actual[key], expected[key]) : actual[key] !== expected[key]);
@@ -549,6 +509,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       currentStatus = status;
       const byKey = new Map((status.secrets || []).map((item) => [item.key, item]));
       const values = status.values;
+      const expected = status.providerExpectations || { github: null, slack: null, google: { origins: [], redirects: [] } };
       renderStartupEnvironment();
 
       const logto = values.logto;
@@ -585,14 +546,14 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         ? github.slug + ' is configured. Webhook secret: ' + (webhookStored ? 'stored' : webhookInactive ? 'not required yet' : 'missing') + '.' +
           (webhookInactive ? ' Webhook delivery is not registered until HTTPS ingress is configured.' : '')
         : 'Creates the complete App used for repository installation, webhooks, and optional GitHub sign-in.';
-      const githubDrift = github ? fieldsChanged(github.configuredUrls, githubExpected(values)) : [];
+      const githubDrift = github ? (expected.github ? fieldsChanged(github.configuredUrls, expected.github) : ['startup public URLs']) : [];
       match('github-match', !github ? '' : githubDrift.length ? 'warn' : '', !github ? 'Not configured' : githubDrift.length ? 'Update required' : 'Ready to check');
       el('github-create-controls').hidden = Boolean(github);
       el('create-github').hidden = Boolean(github);
       el('clear-github').hidden = !github;
       el('connect-github-login').hidden = !github || !values.logto || Boolean(values.logto.githubConnector);
       el('check-github').hidden = !github;
-      if (github) showDrift('github-drift', githubDrift, githubExpected(values));
+      if (github) showDrift('github-drift', githubDrift, expected.github || {});
       else el('github-drift').hidden = true;
 
       const slack = values.slack;
@@ -606,7 +567,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         ? 'Enabled; reuses the Slack client secret above.'
         : 'Not enabled.';
       el('slack-status').textContent = slack ? slack.appId + ' is configured.' : 'Creates the default AgentConnect integration manifest.';
-      const slackDrift = slack ? fieldsChanged(slack.configuredUrls, slackExpected(values)) : [];
+      const slackDrift = slack ? (expected.slack ? fieldsChanged(slack.configuredUrls, expected.slack) : ['startup public URLs']) : [];
       match('slack-match', !slack ? '' : slackDrift.length ? 'warn' : '', !slack ? 'Not configured' : slackDrift.length ? 'Update required' : 'Ready to check');
       el('slack-name-field').hidden = Boolean(slack);
       el('create-slack').hidden = Boolean(slack);
@@ -616,12 +577,12 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       el('slack-settings').hidden = !slack;
       if (slack) {
         el('slack-settings').href = 'https://api.slack.com/apps/' + encodeURIComponent(slack.appId);
-        showDrift('slack-drift', slackDrift, slackExpected(values));
+        showDrift('slack-drift', slackDrift, expected.slack || {});
       } else el('slack-drift').hidden = true;
 
       const google = values.logto && values.logto.googleConnector;
       const googleSecret = configured(byKey, 'logto.googleConnectorClientSecret');
-      const expectedGoogle = googleExpected(values);
+      const expectedGoogle = expected.google;
       renderUriList('google-origins', expectedGoogle.origins);
       renderUriList('google-redirects', expectedGoogle.redirects);
       text('google-client-id', google && google.clientId);
@@ -1112,7 +1073,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const report = await checkLogto();
       const connector = report.findings.find((finding) => finding.id === 'logto.connectors');
       const google = currentStatus && currentStatus.values.logto && currentStatus.values.logto.googleConnector;
-      const expected = currentStatus ? googleExpected(currentStatus.values) : { redirects: [] };
+      const expected = currentStatus ? currentStatus.providerExpectations.google : { redirects: [] };
       const callbacksMatch = google && same(google.configuredRedirectUris, expected.redirects);
       const passed = connector && connector.status === 'pass' && callbacksMatch;
       match('google-match', passed ? 'pass' : 'warn', passed ? 'Matches' : 'Update required');

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -11,6 +11,11 @@ import {
   type FeishuRegistrationProvider
 } from '@agentconnect.md/control-plane/feishu-registration-provider'
 import {
+  createFeishuAppCredentialVerifier,
+  type FeishuAppCredentialVerifier
+} from '@agentconnect.md/control-plane/feishu-identity'
+import { createSlackConfigApi, type SlackConfigApi } from '@agentconnect.md/control-plane/slack-config-api'
+import {
   DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1,
   DEPLOYMENT_CONFIG_SCHEMA_VERSION,
   DEPLOYMENT_SECRET_KEYS,
@@ -44,12 +49,10 @@ import {
 import {
   auditSlackManifest,
   buildSlackDeploymentManifest,
-  createSlackApp,
-  exportSlackManifest,
   requireProviderAppEndpoints,
-  slackConfiguredUrls,
-  type ProviderAppConfig
+  slackConfiguredUrls
 } from '../slack-app.js'
+import type { ProviderAppConfig } from '../provider-app.js'
 import {
   TenantAdminAuthError,
   TenantAdminAuthenticator,
@@ -147,6 +150,8 @@ export interface TenantAdminServerDeps {
   ) => Pick<LogtoAdminClaimClient, 'verifyClientCredentials' | 'inspectAdminRole' | 'inspectSetup'>
   makeLogtoSetupClient?: (config: LogtoManagementConfig) => Pick<LogtoAdminClaimClient, 'reconcileSetup'>
   feishuRegistrationProvider?: Pick<FeishuRegistrationProvider, 'begin' | 'poll'>
+  verifyFeishuAppCredentials?: FeishuAppCredentialVerifier
+  slackConfigApi?: Pick<SlackConfigApi, 'createApp' | 'exportApp'>
   localAuthBootstrap?: {
     issuer: string
     managementEndpoint?: string
@@ -367,6 +372,8 @@ export function buildTenantAdminServer(
 ): FastifyInstance {
   const app = Fastify({ logger: false, ...options })
   const fetchImpl = deps.fetch ?? fetch
+  const verifyFeishuAppCredentials = deps.verifyFeishuAppCredentials ?? createFeishuAppCredentialVerifier(fetchImpl)
+  const slackConfigApi = deps.slackConfigApi ?? createSlackConfigApi({ fetch: fetchImpl })
   const requireLocal = localOnly(deps.publicUrl, deps.allowContainerLoopbackProxy)
   const authenticator = new TenantAdminAuthenticator(
     { get: async () => oidcOf(await deps.store.getAdmin(), localAuthBootstrap.issuer) },
@@ -432,6 +439,43 @@ export function buildTenantAdminServer(
           }
         : undefined
     )
+  }
+
+  const expectedSlackManifest = (values: DeploymentConfigValuesV1): Record<string, unknown> => {
+    const browser = values.logto?.browser
+    return buildSlackDeploymentManifest(
+      slackProviderAppConfig(localAuthBootstrap.services),
+      'AgentConnect',
+      values.logto?.slackConnector && browser ? { logtoEndpoint, connectorId: LOGTO_SLACK_CONNECTOR_ID } : undefined
+    )
+  }
+
+  const providerExpectations = (values: DeploymentConfigValuesV1) => {
+    let github: ReturnType<typeof githubConfiguredUrls> | null = null
+    let slack: ReturnType<typeof slackConfiguredUrls> | null = null
+    try {
+      const manifest = expectedGithubManifest(values)
+      github = githubConfiguredUrls(providerAppConfig(localAuthBootstrap.services), manifest)
+    } catch {
+      // Invalid startup URLs are surfaced as an unavailable expectation in the UI.
+    }
+    try {
+      slack = slackConfiguredUrls(expectedSlackManifest(values))
+    } catch {
+      // Slack requires HTTPS startup URLs; the UI keeps creation/check disabled.
+    }
+    return {
+      github,
+      slack,
+      google: values.logto?.browser
+        ? { origins: [logtoEndpoint], redirects: googleRedirectUris(logtoEndpoint) }
+        : { origins: [], redirects: [] }
+    }
+  }
+
+  const statusWithExpectations = (record: DeploymentConfigAdmin | null) => {
+    const status = toStatus(record)
+    return { ...status, providerExpectations: providerExpectations(status.values) }
   }
 
   app.addHook('onClose', async () => {
@@ -575,7 +619,7 @@ export function buildTenantAdminServer(
   })
 
   app.get('/api/v1/deployment-config', { preHandler: requireConfigurationAccess }, async () =>
-    toStatus(await deps.store.getAdmin())
+    statusWithExpectations(await deps.store.getAdmin())
   )
 
   app.put('/api/v1/deployment-config', { preHandler: requireConfigurationAccess }, async (request, reply) => {
@@ -588,7 +632,7 @@ export function buildTenantAdminServer(
       values: parsed.data.values
     })
     return {
-      ...toStatus(saved),
+      ...statusWithExpectations(saved),
       restartRequired: true as const
     }
   })
@@ -610,7 +654,7 @@ export function buildTenantAdminServer(
         }
       )
       const saved = await deps.store.replace({ expectedRevision: current?.revision ?? 0, ...put })
-      return { ...toStatus(saved), restartRequired: true as const }
+      return { ...statusWithExpectations(saved), restartRequired: true as const }
     })
   })
 
@@ -785,37 +829,22 @@ export function buildTenantAdminServer(
         return problem(reply, 409, `${region === 'feishu' ? 'Feishu' : 'Lark'} App credentials are not configured`)
       }
 
-      const origin = region === 'feishu' ? 'https://open.feishu.cn' : 'https://open.larksuite.com'
-      let response: Response
-      try {
-        response = await fetchImpl(`${origin}/open-apis/auth/v3/tenant_access_token/internal`, {
-          method: 'POST',
-          headers: { 'content-type': 'application/json; charset=utf-8' },
-          body: JSON.stringify({ app_id: regionalApp.loginAppId, app_secret: appSecret }),
-          signal: AbortSignal.timeout(5_000)
-        })
-      } catch {
-        return {
-          provider: region,
-          status: 'unknown' as const,
-          message: `${region === 'feishu' ? 'Feishu' : 'Lark'} could not be reached.`
-        }
-      }
-      const body = (await response.json().catch(() => ({}))) as { code?: number; tenant_access_token?: string }
-      if (!response.ok) {
-        return {
-          provider: region,
-          status: 'unknown' as const,
-          message: `${region === 'feishu' ? 'Feishu' : 'Lark'} returned HTTP ${response.status}.`
-        }
-      }
-      const matches = body.code === 0 && typeof body.tenant_access_token === 'string'
+      const result = await verifyFeishuAppCredentials(regionalApp.loginAppId, appSecret, region)
+      const label = region === 'feishu' ? 'Feishu' : 'Lark'
       return {
         provider: region,
-        status: matches ? ('pass' as const) : ('fail' as const),
-        message: matches
-          ? `${region === 'feishu' ? 'Feishu' : 'Lark'} accepted the saved App ID and secret.`
-          : `${region === 'feishu' ? 'Feishu' : 'Lark'} rejected the saved App ID or secret.`
+        status:
+          result.status === 'ok'
+            ? ('pass' as const)
+            : result.status === 'invalid'
+              ? ('fail' as const)
+              : ('unknown' as const),
+        message:
+          result.status === 'ok'
+            ? `${label} accepted the saved App ID and secret.`
+            : result.status === 'invalid'
+              ? `${label} rejected the saved App ID or secret.`
+              : `${label} could not be reached.`
       }
     }
   )
@@ -947,18 +976,16 @@ export function buildTenantAdminServer(
         return problem(reply, 409, error instanceof Error ? error.message : 'Slack App configuration is incomplete')
       }
 
-      let credentials: Awaited<ReturnType<typeof createSlackApp>>
-      try {
-        credentials = await createSlackApp(parsed.data.configToken, manifest, { fetch: fetchImpl })
-      } catch (error) {
-        return problem(reply, 502, error instanceof Error ? error.message : 'Slack App creation failed')
-      }
+      const created = await slackConfigApi.createApp(parsed.data.configToken, manifest)
+      if (!created.ok) return problem(reply, 502, `Slack App creation failed: ${created.error}`)
+      const credentials = created.app
       const put = slackDeploymentPut(current, credentials, slackConfiguredUrls(manifest), parsed.data.connectLogto)
       const saved = await deps.store.replace({ expectedRevision: current.revision, ...put })
 
       try {
-        const exported = await exportSlackManifest(parsed.data.configToken, credentials.appId, { fetch: fetchImpl })
-        const missing = auditSlackManifest(exported, manifest)
+        const exported = await slackConfigApi.exportApp(parsed.data.configToken, credentials.appId)
+        if (!exported.ok) throw new Error(exported.error)
+        const missing = auditSlackManifest(exported.manifest, manifest)
         if (missing.length > 0) throw new Error(`missing ${missing.join(', ')}`)
       } catch (error) {
         return problem(
@@ -1055,23 +1082,13 @@ export function buildTenantAdminServer(
       if (!current || !slack) return problem(reply, 409, 'the deployment Slack App is not configured')
       let manifest: Record<string, unknown>
       try {
-        const browser = current.values.logto?.browser
-        manifest = buildSlackDeploymentManifest(
-          slackProviderAppConfig(localAuthBootstrap.services),
-          'AgentConnect',
-          current.values.logto?.slackConnector && browser
-            ? { logtoEndpoint, connectorId: LOGTO_SLACK_CONNECTOR_ID }
-            : undefined
-        )
+        manifest = expectedSlackManifest(current.values)
       } catch (error) {
         return problem(reply, 409, error instanceof Error ? error.message : 'Slack App configuration is incomplete')
       }
-      let actual: Record<string, unknown>
-      try {
-        actual = await exportSlackManifest(parsed.data.configToken, slack.appId, { fetch: fetchImpl })
-      } catch (error) {
-        return problem(reply, 502, error instanceof Error ? error.message : 'Slack App settings could not be checked')
-      }
+      const exported = await slackConfigApi.exportApp(parsed.data.configToken, slack.appId)
+      if (!exported.ok) return problem(reply, 502, `Slack App settings could not be checked: ${exported.error}`)
+      const actual = exported.manifest
       const missing = auditSlackManifest(actual, manifest)
       const expected = slackConfiguredUrls(manifest)
       let revision = current.revision

--- a/packages/setup/src/github-app.ts
+++ b/packages/setup/src/github-app.ts
@@ -1,8 +1,8 @@
-import { createPrivateKey, randomBytes, timingSafeEqual } from 'node:crypto'
+import { randomBytes, timingSafeEqual } from 'node:crypto'
 import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { SignJWT } from 'jose'
-import type { ProviderAppConfig } from './slack-app.js'
+import { githubRequest, mintAppJwt, resolveGithubSetupAppConfig } from '@agentconnect.md/control-plane/github-app-api'
+import type { ProviderAppConfig } from './provider-app.js'
 
 export interface GithubAppCredentials {
   appId: string
@@ -213,48 +213,19 @@ function sameStringSet(left: unknown, right: readonly string[]): boolean {
   return JSON.stringify([...left].sort()) === JSON.stringify([...right].sort())
 }
 
-async function githubAppJwt(appId: number, clientId: string | null, privateKeyBase64: string): Promise<string> {
-  const pem = Buffer.from(privateKeyBase64, 'base64').toString('utf8')
-  const privateKey = createPrivateKey(pem)
-  const now = Math.floor(Date.now() / 1_000)
-  return new SignJWT({})
-    .setProtectedHeader({ alg: 'RS256' })
-    .setIssuedAt(now - 60)
-    .setExpirationTime(now + 9 * 60)
-    .setIssuer(clientId ?? String(appId))
-    .sign(privateKey)
-}
-
-async function githubJson<T>(path: string, jwt: string, fetchImpl: typeof fetch): Promise<T> {
-  let response: Response
-  try {
-    response = await fetchImpl(`https://api.github.com${path}`, {
-      headers: {
-        accept: 'application/vnd.github+json',
-        authorization: `Bearer ${jwt}`,
-        'x-github-api-version': '2022-11-28'
-      },
-      signal: AbortSignal.timeout(10_000)
-    })
-  } catch {
-    throw new Error('GitHub App settings are unreachable')
-  }
-  if (!response.ok) throw new Error(`GitHub App settings returned HTTP ${response.status}`)
-  return (await response.json()) as T
-}
-
 export async function auditGithubApp(
   identity: { appId: number; slug: string; clientId: string | null },
   privateKeyBase64: string,
   expectedManifest: Record<string, unknown>,
   fetchImpl: typeof fetch = fetch
 ): Promise<GithubAppAuditResult> {
-  const jwt = await githubAppJwt(identity.appId, identity.clientId, privateKeyBase64)
+  const config = resolveGithubSetupAppConfig({ ...identity, privateKeyBase64 })
+  const jwt = await mintAppJwt(config)
   const expectedHook = asRecord(expectedManifest.hook_attributes)
   const [app, hook] = await Promise.all([
-    githubJson<GithubAppApiResponse>('/app', jwt, fetchImpl),
+    githubRequest<GithubAppApiResponse>('/app', { auth: jwt, fetchImpl }),
     typeof expectedHook.url === 'string'
-      ? githubJson<GithubWebhookApiResponse>('/app/hook/config', jwt, fetchImpl)
+      ? githubRequest<GithubWebhookApiResponse>('/app/hook/config', { auth: jwt, fetchImpl })
       : Promise.resolve(undefined)
   ])
   const missing: string[] = []

--- a/packages/setup/src/provider-app.ts
+++ b/packages/setup/src/provider-app.ts
@@ -1,0 +1,7 @@
+export interface ProviderAppConfig {
+  services: {
+    web?: string
+    controlPlane: string
+    relay?: string
+  }
+}

--- a/packages/setup/src/slack-app.ts
+++ b/packages/setup/src/slack-app.ts
@@ -1,59 +1,9 @@
-export const SLACK_BOT_SCOPES = [
-  'files:read',
-  'app_mentions:read',
-  'channels:history',
-  'channels:read',
-  'commands',
-  'chat:write',
-  'chat:write.customize',
-  'files:write',
-  'groups:history',
-  'groups:read',
-  'im:history',
-  'im:write',
-  'mpim:history',
-  'mpim:read',
-  'reactions:write',
-  'assistant:write',
-  'users:read'
-] as const
-
-export const SLACK_BOT_EVENTS = [
-  'app_mention',
-  'app_uninstalled',
-  'assistant_thread_started',
-  'message.channels',
-  'message.groups',
-  'message.im',
-  'message.mpim',
-  'member_joined_channel',
-  'channel_left',
-  'group_left',
-  'tokens_revoked'
-] as const
+import { buildInstallManifest, slackPlatformOAuthRedirectUri } from '@agentconnect.md/control-plane/slack-manifest'
+import type { ProviderAppConfig } from './provider-app.js'
 
 type SlackManifest = Record<string, unknown>
-export interface ProviderAppConfig {
-  services: {
-    web?: string
-    controlPlane: string
-    relay?: string
-  }
-}
 type ProviderAppConfigWithRelay = ProviderAppConfig & {
   services: ProviderAppConfig['services'] & { relay: string; web: string }
-}
-
-export interface SlackAppCredentials {
-  appId: string
-  clientId: string
-  clientSecret: string
-  signingSecret: string
-}
-
-export interface SlackAppCreateOptions {
-  fetch?: typeof fetch
-  timeoutMs?: number
 }
 
 export interface SlackConfiguredUrls {
@@ -92,50 +42,15 @@ export function buildSlackDeploymentManifest(
   login?: SlackLoginAppConfig
 ): SlackManifest {
   requireProviderAppEndpoints(config)
-  const displayName = name.trim() || 'AgentConnect'
-  const redirectUrl = appendPath(config.services.controlPlane, '/v1/integrations/slack/platform/callback')
+  const redirectUrl = slackPlatformOAuthRedirectUri(config.services.controlPlane)
   const loginRedirectUrl = login ? appendPath(login.logtoEndpoint, `/callback/${login.connectorId}`) : undefined
   if (loginRedirectUrl && new URL(loginRedirectUrl).protocol !== 'https:') {
     throw new Error('Slack sign-in requires an HTTPS Logto endpoint')
   }
-  const eventsUrl = appendPath(config.services.relay, '/slack/events')
-  const interactionsUrl = appendPath(config.services.relay, '/slack/interactions')
-
-  return {
-    display_information: { name: displayName },
-    features: {
-      bot_user: { display_name: displayName, always_online: true },
-      app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false },
-      agent_view: {
-        agent_description: 'AI agent powered by AgentConnect.',
-        suggested_prompts: []
-      },
-      shortcuts: [
-        {
-          name: 'Manage session',
-          type: 'message',
-          callback_id: 'ac_manage_session',
-          description: 'View or update the AgentConnect session for this conversation'
-        }
-      ]
-    },
-    oauth_config: {
-      scopes: { bot: [...SLACK_BOT_SCOPES] },
-      redirect_urls: [redirectUrl, ...(loginRedirectUrl ? [loginRedirectUrl] : [])]
-    },
-    settings: {
-      event_subscriptions: { bot_events: [...SLACK_BOT_EVENTS], request_url: eventsUrl },
-      interactivity: {
-        is_enabled: true,
-        request_url: interactionsUrl,
-        message_menu_options_url: interactionsUrl
-      },
-      org_deploy_enabled: false,
-      socket_mode_enabled: false,
-      token_rotation_enabled: false,
-      is_mcp_enabled: false
-    }
-  }
+  return buildInstallManifest(name, redirectUrl, {
+    httpRelayBase: config.services.relay,
+    ...(loginRedirectUrl ? { additionalRedirectUrls: [loginRedirectUrl] } : {})
+  })
 }
 
 export function slackConfiguredUrls(manifest: SlackManifest): SlackConfiguredUrls {
@@ -165,79 +80,6 @@ function asRecord(value: unknown): Record<string, unknown> {
 
 function asStrings(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
-}
-
-function slackError(body: unknown): string {
-  const candidate = asRecord(body).error
-  return typeof candidate === 'string' && /^[a-z0-9_]+$/i.test(candidate) ? candidate : 'unknown_error'
-}
-
-async function postSlack(
-  method: 'apps.manifest.create' | 'apps.manifest.export',
-  form: Record<string, string>,
-  options: SlackAppCreateOptions
-): Promise<Record<string, unknown>> {
-  const fetcher = options.fetch ?? fetch
-  let response: Response
-  try {
-    response = await fetcher(`https://slack.com/api/${method}`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams(form),
-      signal: AbortSignal.timeout(options.timeoutMs ?? 10_000)
-    })
-  } catch {
-    throw new Error(`Slack ${method} is unreachable`)
-  }
-
-  if (!response.ok) throw new Error(`Slack ${method} returned HTTP ${response.status}`)
-  let body: unknown
-  try {
-    body = await response.json()
-  } catch {
-    throw new Error(`Slack ${method} returned an invalid response`)
-  }
-  const record = asRecord(body)
-  if (record.ok !== true) throw new Error(`Slack ${method} failed: ${slackError(body)}`)
-  return record
-}
-
-export async function createSlackApp(
-  configToken: string,
-  manifest: SlackManifest,
-  options: SlackAppCreateOptions = {}
-): Promise<SlackAppCredentials> {
-  const body = await postSlack(
-    'apps.manifest.create',
-    { token: configToken, manifest: JSON.stringify(manifest) },
-    options
-  )
-  const credentials = asRecord(body.credentials)
-  if (
-    typeof body.app_id !== 'string' ||
-    typeof credentials.client_id !== 'string' ||
-    typeof credentials.client_secret !== 'string' ||
-    typeof credentials.signing_secret !== 'string'
-  ) {
-    throw new Error('Slack apps.manifest.create returned incomplete credentials')
-  }
-  return {
-    appId: body.app_id,
-    clientId: credentials.client_id,
-    clientSecret: credentials.client_secret,
-    signingSecret: credentials.signing_secret
-  }
-}
-
-export async function exportSlackManifest(
-  configToken: string,
-  appId: string,
-  options: SlackAppCreateOptions = {}
-): Promise<SlackManifest> {
-  const body = await postSlack('apps.manifest.export', { token: configToken, app_id: appId }, options)
-  const manifest = asRecord(body.manifest)
-  if (Object.keys(manifest).length === 0) throw new Error('Slack apps.manifest.export returned an invalid manifest')
-  return manifest
 }
 
 /** Returns stable field names only; it never includes provider response values. */

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@agentconnect.md/protocol": "workspace:*",
     "@iconify-icons/logos": "^1.2.36",
     "@iconify-icons/ph": "^1.2.5",
     "@iconify/react": "^6.0.2",

--- a/packages/web/src/components/console/platforms/slack/manifest.ts
+++ b/packages/web/src/components/console/platforms/slack/manifest.ts
@@ -25,82 +25,23 @@
 // agent_view turns on Slack's Agent experience for newly-created apps (side panel,
 // app threads, and agent-oriented thread affordances).
 
-/** Kept in lock-step with the protocol callback consumed by daemon + relay. */
-export const SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID = 'ac_manage_session'
+import {
+  buildSlackAppManifest,
+  DEFAULT_SLACK_APP_NAME,
+  PLATFORM_APP_DESCRIPTION,
+  SLACK_BOT_EVENTS,
+  SLACK_BOT_SCOPES,
+  SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+  type SlackAppManifest
+} from '@agentconnect.md/protocol/slack-app-manifest'
 
-/** Bot token scopes the Slack app requests. Widening this list later forces every
- *  workspace that already installed the app to re-authorize, so it covers group DMs
- *  (`mpim:*`) and agent-initiated DMs (`im:write`) alongside the channel and thread
- *  surfaces the adapter reads today.
- *
- *  Deliberately NO channel-write scope: `conversations.leave` would need
- *  `channels:manage`, which also grants create/archive/kick/rename and would force
- *  every installed workspace to re-authorize. Slack re-lists membership
- *  authoritatively, so removing the bot in Slack clears the console row by itself.
- *  Keep in lock-step with the control plane's copy. */
-export const SLACK_BOT_SCOPES = [
-  'files:read',
-  'app_mentions:read',
-  'channels:history',
-  'channels:read',
-  'commands',
-  'chat:write',
-  'chat:write.customize',
-  'files:write',
-  'groups:history',
-  'groups:read',
-  'im:history',
-  'im:write',
-  'mpim:history',
-  'mpim:read',
-  'reactions:write',
-  'assistant:write',
-  'users:read'
-] as const
-
-/** Bot events the daemon subscribes to: message.* / app_mention drive inbound
- *  delivery, assistant_thread_started preserves Agent/assistant DM thread roots,
- *  membership events drive the console's per-channel trigger config, and the two
- *  `app_*`/token lifecycle events feed the uninstall/revocation surfacing. */
-export const SLACK_BOT_EVENTS = [
-  'app_mention',
-  'app_uninstalled',
-  'assistant_thread_started',
-  'message.channels',
-  'message.groups',
-  'message.im',
-  'message.mpim',
-  'member_joined_channel',
-  'channel_left',
-  'group_left',
-  'tokens_revoked'
-] as const
-
-/** Fallback name so the manifest / deep link are always valid before the user types one. */
-export const DEFAULT_SLACK_APP_NAME = 'agentconnect'
-export const PLATFORM_APP_DESCRIPTION = 'AI agent powered by AgentConnect.'
-
-export interface SlackAppManifest {
-  display_information: { name: string; background_color?: string }
-  features: {
-    bot_user: { display_name: string; always_online: boolean }
-    app_home: { home_tab_enabled: boolean; messages_tab_enabled: boolean; messages_tab_read_only_enabled: boolean }
-    agent_view: { agent_description: string; suggested_prompts: { title: string; message: string }[] }
-    shortcuts: { name: string; type: 'message'; callback_id: string; description: string }[]
-  }
-  oauth_config: { scopes: { bot: string[] }; pkce_enabled: boolean }
-  settings: {
-    // `request_url` is present only for the http (Events API) transport.
-    event_subscriptions: { request_url?: string; bot_events: string[] }
-    // `request_url` / `message_menu_options_url` are present only for http; both
-    // point at the relay's interactions endpoint (block_suggestion options are
-    // answered synchronously there).
-    interactivity: { is_enabled: boolean; request_url?: string; message_menu_options_url?: string }
-    org_deploy_enabled: boolean
-    socket_mode_enabled: boolean
-    token_rotation_enabled: boolean
-    is_mcp_enabled: boolean
-  }
+export {
+  DEFAULT_SLACK_APP_NAME,
+  PLATFORM_APP_DESCRIPTION,
+  SLACK_BOT_EVENTS,
+  SLACK_BOT_SCOPES,
+  SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+  type SlackAppManifest
 }
 
 /** Transport-aware manifest options. `mode` selects Socket Mode (default) vs HTTP
@@ -129,51 +70,12 @@ export interface SlackAppNames {
  *  aim the request_urls at (missing ⇒ falls back to the socket shape rather than
  *  emit an http manifest with an empty request_url). */
 export function buildSlackManifest(names: SlackAppNames, opts?: SlackManifestOpts): SlackAppManifest {
-  const name = names.name.trim() || DEFAULT_SLACK_APP_NAME
-  const displayName = names.displayName?.trim() || name
-  // Normalize a ws(s):// relay base to http(s):// and strip a trailing slash — the
-  // manifest request_url must be an https origin (mirror of api.ts's http→ws flip).
-  const relayUrl = opts?.relayUrl?.replace(/^ws/, 'http').replace(/\/+$/, '')
-  const http = opts?.mode === 'http' && !!relayUrl
-  return {
-    display_information: { name, ...(opts?.backgroundColor ? { background_color: opts.backgroundColor } : {}) },
-    features: {
-      bot_user: { display_name: displayName, always_online: true },
-      app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false },
-      agent_view: {
-        agent_description: PLATFORM_APP_DESCRIPTION,
-        suggested_prompts: []
-      },
-      shortcuts: [
-        {
-          name: 'Manage session',
-          type: 'message',
-          callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
-          description: 'View or update the AgentConnect session for this conversation'
-        }
-      ]
-    },
-    oauth_config: { scopes: { bot: [...SLACK_BOT_SCOPES] }, pkce_enabled: false },
-    settings: {
-      event_subscriptions: {
-        ...(http ? { request_url: `${relayUrl}/slack/events` } : {}),
-        bot_events: [...SLACK_BOT_EVENTS]
-      },
-      interactivity: {
-        is_enabled: true,
-        ...(http
-          ? {
-              request_url: `${relayUrl}/slack/interactions`,
-              message_menu_options_url: `${relayUrl}/slack/interactions`
-            }
-          : {})
-      },
-      org_deploy_enabled: false,
-      socket_mode_enabled: !http,
-      token_rotation_enabled: false,
-      is_mcp_enabled: false
-    }
-  }
+  return buildSlackAppManifest(names.name, {
+    ...(names.displayName ? { displayName: names.displayName } : {}),
+    ...(opts?.mode === 'http' && opts.relayUrl ? { relayUrl: opts.relayUrl } : {}),
+    ...(opts?.backgroundColor ? { backgroundColor: opts.backgroundColor } : {}),
+    pkceEnabled: false
+  })
 }
 
 /** Pretty-printed manifest JSON — for the "Copy manifest" affordance. */

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["dom", "dom.iterable", "ES2022"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "customConditions": ["development"],
     "jsx": "preserve",
     "allowJs": true,
     "noEmit": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
+      '@slack/web-api':
+        specifier: ^8.0.0
+        version: 8.0.0
       aws4fetch:
         specifier: ^1.0.20
         version: 1.0.20
@@ -518,6 +521,9 @@ importers:
 
   packages/web:
     dependencies:
+      '@agentconnect.md/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       '@iconify-icons/logos':
         specifier: ^1.2.36
         version: 1.2.36


### PR DESCRIPTION
## Summary

- make one canonical Slack App manifest serve the Web wizard, Control Plane install flow, and Tenant Admin
- use Slack's official Web API client for manifest create/export/update, OAuth exchange, and config-token rotation
- reuse the Control Plane GitHub App JWT/REST client and Feishu/Lark credential verifier from Tenant Admin
- return canonical provider callback expectations from the Tenant Admin server instead of reconstructing them in browser JavaScript

## Why

The setup surface had copied provider scopes, events, callback URL construction, and low-level API calls. Those copies could drift from the runtime integration configuration and report misleading match status.

## Impact

Provider-specific browser creation flows remain in Tenant Admin, but desired configuration and API transport now have one implementation. Existing saved deployment configuration and secrets are unchanged.

## Validation

- protocol, control-plane, setup, and web typechecks
- focused Slack manifest/API and Feishu identity tests
- setup package tests
- self-contained Tenant Admin production bundle
- Next.js production build
- repository pre-push lint

Created by Codex . GPT-5.6
