### PR TITLE
fix(config): allow internal HTTP Vault origins

### DIFF
--- a/packages/control-plane/src/config/env.ts
+++ b/packages/control-plane/src/config/env.ts
@@ -8,21 +8,28 @@
 import { z } from 'zod'
 import { composeCpPlatformEnv } from '../platforms/env.js'
 
-const SecureOriginSchema = z
+const HttpOriginSchema = z
   .string()
   .url()
   .superRefine((value, ctx) => {
     const url = new URL(value)
-    const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase()
-    const loopback =
-      hostname === 'localhost' || hostname.endsWith('.localhost') || hostname === '127.0.0.1' || hostname === '::1'
-    if (url.protocol !== 'https:' && !loopback) {
-      ctx.addIssue({ code: 'custom', message: 'must use HTTPS unless it is loopback' })
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      ctx.addIssue({ code: 'custom', message: 'must use HTTP or HTTPS' })
     }
     if (url.username || url.password || url.search || url.hash || url.pathname !== '/') {
       ctx.addIssue({ code: 'custom', message: 'must be an origin without credentials, path, query, or fragment' })
     }
   })
+
+const SecureOriginSchema = HttpOriginSchema.superRefine((value, ctx) => {
+  const url = new URL(value)
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  const loopback =
+    hostname === 'localhost' || hostname.endsWith('.localhost') || hostname === '127.0.0.1' || hostname === '::1'
+  if (url.protocol !== 'https:' && !loopback) {
+    ctx.addIssue({ code: 'custom', message: 'must use HTTPS unless it is loopback' })
+  }
+})
 
 /** The env keys CORE owns. Platform keys are folded in below — this object is
  *  never exported: `AppConfigSchema` is the only schema, and it is the two
@@ -76,7 +83,7 @@ const CoreConfigShape = {
   // ONLINE: open() passes existing plaintext rows through unchanged and the
   // next write re-seals them (lazy migration, no backfill required).
   SECRET_CIPHER: z.enum(['none', 'vault-transit']).default('none'),
-  VAULT_ADDR: SecureOriginSchema.optional(), // Vault origin, e.g. https://vault.example.com:8200
+  VAULT_ADDR: HttpOriginSchema.optional(), // Vault origin, e.g. http://vault.vault.svc:8200
   VAULT_TRANSIT_KEY: z.string().default('agentconnect-cp'), // transit key name
   VAULT_TRANSIT_MOUNT: z.string().default('transit'), // transit engine mount path
   VAULT_NAMESPACE: z.string().optional(), // Vault Enterprise namespace (sent as X-Vault-Namespace)

--- a/packages/setup/src/admin/config.ts
+++ b/packages/setup/src/admin/config.ts
@@ -9,21 +9,28 @@
  */
 import { z } from 'zod'
 
-const SecureOriginSchema = z
+const HttpOriginSchema = z
   .string()
   .url()
   .superRefine((value, ctx) => {
     const url = new URL(value)
-    const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase()
-    const loopback =
-      hostname === 'localhost' || hostname.endsWith('.localhost') || hostname === '127.0.0.1' || hostname === '::1'
-    if (url.protocol !== 'https:' && !loopback) {
-      ctx.addIssue({ code: 'custom', message: 'must use HTTPS unless it is loopback' })
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      ctx.addIssue({ code: 'custom', message: 'must use HTTP or HTTPS' })
     }
     if (url.username || url.password || url.search || url.hash || url.pathname !== '/') {
       ctx.addIssue({ code: 'custom', message: 'must be an origin without credentials, path, query, or fragment' })
     }
   })
+
+const SecureOriginSchema = HttpOriginSchema.superRefine((value, ctx) => {
+  const url = new URL(value)
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  const loopback =
+    hostname === 'localhost' || hostname.endsWith('.localhost') || hostname === '127.0.0.1' || hostname === '::1'
+  if (url.protocol !== 'https:' && !loopback) {
+    ctx.addIssue({ code: 'custom', message: 'must use HTTPS unless it is loopback' })
+  }
+})
 
 export const TenantAdminProcessConfigSchema = z
   .object({
@@ -41,7 +48,7 @@ export const TenantAdminProcessConfigSchema = z
     // Keep this startup-only slice aligned with the CP's SecretCipher. The
     // cipher key/address cannot be stored beside the ciphertext it unlocks.
     SECRET_CIPHER: z.enum(['none', 'vault-transit']).default('none'),
-    VAULT_ADDR: SecureOriginSchema.optional(),
+    VAULT_ADDR: HttpOriginSchema.optional(),
     VAULT_TRANSIT_KEY: z.string().default('agentconnect-cp'),
     VAULT_TRANSIT_MOUNT: z.string().default('transit'),
     VAULT_NAMESPACE: z.string().optional(),

--- a/packages/setup/test/admin-config.test.ts
+++ b/packages/setup/test/admin-config.test.ts
@@ -27,14 +27,14 @@ describe('tenant-admin process config', () => {
         VAULT_JWT_ROLE: 'role'
       })
     ).toThrow(/exactly one/)
-    expect(() =>
+    expect(
       loadTenantAdminProcessConfig({
         DATABASE_URL,
         SECRET_CIPHER: 'vault-transit',
         VAULT_ADDR: 'http://vault.example.test',
         VAULT_TOKEN: 'token'
       })
-    ).toThrow(/HTTPS/)
+    ).toMatchObject({ VAULT_ADDR: 'http://vault.example.test' })
   })
 
   it('requires HTTPS for a non-loopback Tenant Admin URL', () => {


### PR DESCRIPTION
## Summary

- accept HTTP or HTTPS origins for `VAULT_ADDR`, including cluster-local Vault services
- keep Tenant Admin, Logto, and other externally reachable origins on the existing HTTPS-or-loopback policy
- update the existing Tenant Admin config expectation for an internal HTTP Vault origin

## Root cause

The public-origin validator was reused for `VAULT_ADDR`. The test cluster uses an internal Vault service over HTTP, so both the new Control Plane pod and Tenant Admin pod failed startup validation before contacting Vault.

## Validation

- `pnpm --filter @agentconnect.md/protocol build`
- `pnpm --filter @agentconnect.md/setup --filter @agentconnect.md/control-plane build`
- pre-push `eslint .`
