### PR TITLE
fix(setup): reconcile provider App configuration

### DIFF
--- a/packages/control-plane/src/persistence/deployment-config.test.ts
+++ b/packages/control-plane/src/persistence/deployment-config.test.ts
@@ -32,7 +32,12 @@ describe('deploymentSecretsRequiringRefresh', () => {
         ...base,
         logto: {
           ...base.logto!,
-          githubConnector: { appId: 3, slug: 'agentconnect-login', clientId: 'Iv1.login' }
+          githubConnector: {
+            connectorId: 'agentconnect-github',
+            appId: 3,
+            slug: 'agentconnect-login',
+            clientId: 'Iv1.login'
+          }
         }
       })
     ).toEqual(['logto.githubConnectorClientSecret'])
@@ -42,6 +47,7 @@ describe('deploymentSecretsRequiringRefresh', () => {
         logto: {
           ...base.logto!,
           googleConnector: {
+            connectorId: 'agentconnect-google',
             clientId: 'google-client',
             configuredRedirectUris: ['https://login.example.test/callback/agentconnect-google']
           }
@@ -53,7 +59,7 @@ describe('deploymentSecretsRequiringRefresh', () => {
         ...base,
         logto: {
           ...base.logto!,
-          slackConnector: { appId: 'A1', clientId: '1.1' }
+          slackConnector: { connectorId: 'agentconnect-slack', appId: 'A1', clientId: '1.1' }
         }
       })
     ).toEqual([])

--- a/packages/control-plane/src/persistence/deployment-config.ts
+++ b/packages/control-plane/src/persistence/deployment-config.ts
@@ -70,18 +70,21 @@ const LogtoBrowserSchema = z.strictObject({
 })
 
 const LogtoGithubConnectorSchema = z.strictObject({
+  connectorId: z.string().trim().min(1).default('agentconnect-github'),
   appId: z.number().int().positive(),
   slug: z.string().trim().min(1),
   clientId: z.string().trim().min(1)
 })
 
 const LogtoGoogleConnectorSchema = z.strictObject({
+  connectorId: z.string().trim().min(1).default('agentconnect-google'),
   clientId: z.string().trim().min(1),
   /** Provider-console callbacks last confirmed by the operator. */
   configuredRedirectUris: z.array(SecureHttpUrlSchema).min(1)
 })
 
 const LogtoSlackConnectorSchema = z.strictObject({
+  connectorId: z.string().trim().min(1).default('agentconnect-slack'),
   appId: z.string().trim().min(1),
   clientId: z.string().trim().min(1)
 })

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -40,6 +40,13 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
     textarea { width: min(720px, 100%); min-height: 100px; padding: 7px; box-sizing: border-box; }
     .uris { margin: 8px 0; padding-left: 20px; } .uris code { user-select: all; }
     .notice { border-left: 4px solid #d99b13; padding: 8px 12px; background: #d99b1315; }
+    .diff-title { display: block; margin-bottom: 8px; }
+    .config-diff { display: grid; gap: 1px; border: 1px solid #8884; border-radius: 6px; overflow: hidden; background: #8884; }
+    .diff-row { display: grid; grid-template-columns: minmax(140px, .8fr) minmax(0, 1.2fr) minmax(0, 1.2fr); background: Canvas; }
+    .diff-row > * { min-width: 0; padding: 7px 9px; overflow-wrap: anywhere; white-space: pre-wrap; }
+    .diff-head { font-size: 12px; font-weight: 600; color: #777; }
+    .diff-field { font-weight: 600; }
+    .diff-value { font-family: ui-monospace, monospace; font-size: 13px; }
     pre { padding: 12px; border-radius: 6px; background: #8881; overflow-x: auto; user-select: all; }
     #message { white-space: pre-wrap; padding: 10px 0; min-height: 1.5em; }
     .error { color: #c33; } .ok { color: #198754; } .warn { color: #a66b00; }
@@ -56,6 +63,11 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       .admin-nav { position: static; display: flex; overflow-x: auto; }
       .credentials { grid-template-columns: 1fr; gap: 2px; }
       .credentials dd { margin-bottom: 8px; }
+      .diff-row { grid-template-columns: 1fr; }
+      .diff-head { display: none; }
+      .diff-value::before { display: block; margin-bottom: 2px; color: #777; font: 11px/1.4 system-ui, sans-serif; }
+      .diff-current::before { content: 'Current'; }
+      .diff-expected::before { content: 'Expected'; }
     }
     [hidden] { display: none !important; }
   </style>
@@ -171,6 +183,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <div class="row"><button id="save-logto-configuration">Save configuration</button><button id="cancel-logto-configuration">Cancel</button></div>
         </div>
         <p id="logto-status" class="muted">Checking redirects and sign-in settings…</p>
+        <div id="logto-drift" class="notice" hidden></div>
         <div class="row">
           <button id="check-logto">Check match</button>
           <button id="reconcile-logto">Apply expected settings</button>
@@ -190,6 +203,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <dt>App ID</dt><dd class="value-line"><code id="github-app-id">Not configured</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
           <dt>App slug</dt><dd class="value-line"><code id="github-app-slug">Not configured</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
           <dt>Client ID</dt><dd class="value-line"><code id="github-client-id">Not configured</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
+          <dt>Logto connector ID</dt><dd class="value-line"><code id="github-logto-connector-id">Not enabled</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
           <dt>Client secret</dt><dd class="secret-line"><span id="github-client-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="github.clientSecret" data-secret-display="github-client-secret-display">Edit</button></dd>
           <dt>Private key</dt><dd class="secret-line"><span id="github-private-key-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="github.privateKeyB64" data-secret-display="github-private-key-display">Edit</button></dd>
           <dt>Webhook secret</dt><dd class="secret-line"><span id="github-webhook-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="github.webhookSecret" data-secret-display="github-webhook-secret-display">Edit</button></dd>
@@ -202,6 +216,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <label class="field">App ID<input id="github-edit-app-id" inputmode="numeric" autocomplete="off"></label>
           <label class="field">App slug<input id="github-edit-slug" autocomplete="off"></label>
           <label class="field">Client ID<input id="github-edit-client-id" autocomplete="off"></label>
+          <label id="github-edit-connector-id-field" class="field" hidden>Logto connector ID<input id="github-edit-connector-id" autocomplete="off"></label>
           <label class="field">New client secret<input id="github-edit-client-secret" type="password" autocomplete="new-password" placeholder="Required when App or Client ID changes"></label>
           <label class="field">New private key (base64)<textarea id="github-edit-private-key" autocomplete="off" placeholder="Required when App ID changes"></textarea></label>
           <label class="field">New webhook secret<input id="github-edit-webhook-secret" type="password" autocomplete="new-password" placeholder="Required when an active webhook App ID changes"></label>
@@ -233,6 +248,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         <dl class="credentials">
           <dt>App ID</dt><dd class="value-line"><code id="slack-app-id">Not configured</code><button class="edit-configuration" data-provider="slack">Edit</button></dd>
           <dt>Client ID</dt><dd class="value-line"><code id="slack-client-id">Not configured</code><button class="edit-configuration" data-provider="slack">Edit</button></dd>
+          <dt>Logto connector ID</dt><dd class="value-line"><code id="slack-logto-connector-id">Not enabled</code><button class="edit-configuration" data-provider="slack">Edit</button></dd>
           <dt>Client secret</dt><dd class="secret-line"><span id="slack-client-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="slack.clientSecret" data-secret-display="slack-client-secret-display">Edit</button></dd>
           <dt>Signing secret</dt><dd class="secret-line"><span id="slack-signing-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="slack.signingSecret" data-secret-display="slack-signing-secret-display">Edit</button></dd>
           <dt>Logto sign-in</dt><dd id="slack-logto-status">Not configured</dd>
@@ -243,6 +259,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <h3>Edit Slack App identity</h3>
           <label class="field">App ID<input id="slack-edit-app-id" autocomplete="off"></label>
           <label class="field">Client ID<input id="slack-edit-client-id" autocomplete="off"></label>
+          <label id="slack-edit-connector-id-field" class="field" hidden>Logto connector ID<input id="slack-edit-connector-id" autocomplete="off"></label>
           <label class="field">New client secret<input id="slack-edit-client-secret" type="password" autocomplete="new-password" placeholder="Required when identity changes"></label>
           <label class="field">New signing secret<input id="slack-edit-signing-secret" type="password" autocomplete="new-password" placeholder="Required when identity changes"></label>
           <div class="row"><button id="save-slack-configuration">Save configuration</button><button id="cancel-slack-configuration">Cancel</button></div>
@@ -267,6 +284,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         </div>
         <dl class="credentials">
           <dt>Client ID</dt><dd class="value-line"><code id="google-client-id">Not configured</code><button class="edit-configuration" data-provider="google">Edit</button></dd>
+          <dt>Logto connector ID</dt><dd class="value-line"><code id="google-connector-id">Not configured</code><button class="edit-configuration" data-provider="google">Edit</button></dd>
           <dt>Client secret</dt><dd class="secret-line"><span id="google-client-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="logto.googleConnectorClientSecret" data-secret-display="google-client-secret-display">Edit</button></dd>
         </dl>
         <p id="google-status" class="muted"></p>
@@ -276,6 +294,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         <div class="row"><a class="button" href="https://console.cloud.google.com/auth/clients" target="_blank" rel="noopener">Open Google Auth Platform</a></div>
         <div id="google-config-controls" class="subsection">
           <label class="field">Client ID<input id="google-id" autocomplete="off"></label>
+          <label class="field">Logto connector ID<input id="google-connector-id-input" autocomplete="off"></label>
           <label id="google-initial-secret-field" class="field">Client secret<input id="google-secret" type="password" autocomplete="new-password" placeholder="Required when Client ID changes"></label>
         </div>
         <div class="row"><button id="save-google">Save Google client</button><button id="cancel-google-configuration" hidden>Cancel</button><button id="check-google" hidden>Check match</button><button id="clear-google" class="danger" hidden>Clear configuration</button></div>
@@ -479,15 +498,55 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       return { owner: 'organization', organization };
     }
 
-    function fieldsChanged(actual, expected) {
-      if (!actual) return Object.keys(expected);
-      return Object.keys(expected).filter((key) => Array.isArray(expected[key]) ? !same(actual[key], expected[key]) : actual[key] !== expected[key]);
+    function valuesMatch(current, expected) {
+      if (Array.isArray(expected)) return same(current, expected);
+      return JSON.stringify(current) === JSON.stringify(expected);
     }
 
-    function showDrift(id, fields, expected) {
+    function objectDiff(current, expected, labels = {}) {
+      if (!expected) return [];
+      return Object.keys(expected)
+        .filter((key) => !current || !valuesMatch(current[key], expected[key]))
+        .map((key) => ({
+          field: labels[key] || key,
+          current: current ? current[key] : 'Not verified',
+          expected: expected[key]
+        }));
+    }
+
+    function formatDiffValue(value) {
+      if (value === null || value === undefined || value === '') return 'Not configured';
+      if (Array.isArray(value)) return value.length ? value.map(formatDiffValue).join('\n') : '[]';
+      if (typeof value === 'object') {
+        return Object.entries(value).map(([key, item]) => key + ': ' + (Array.isArray(item) ? item.join(', ') : formatDiffValue(item))).join('\n');
+      }
+      return String(value);
+    }
+
+    function showDiff(id, rows, label = 'Update required') {
       const box = el(id);
-      box.hidden = fields.length === 0;
-      box.textContent = fields.length === 0 ? '' : 'Update required: ' + fields.join(', ') + '. Expected values: ' + JSON.stringify(expected);
+      box.hidden = rows.length === 0;
+      box.replaceChildren();
+      if (rows.length === 0) return;
+      const title = document.createElement('strong');
+      title.className = 'diff-title';
+      title.textContent = label;
+      const grid = document.createElement('div');
+      grid.className = 'config-diff';
+      const head = document.createElement('div');
+      head.className = 'diff-row diff-head';
+      for (const text of ['Field', 'Current', 'Expected']) {
+        const cell = document.createElement('span'); cell.textContent = text; head.append(cell);
+      }
+      grid.append(head);
+      for (const item of rows) {
+        const row = document.createElement('div'); row.className = 'diff-row';
+        const field = document.createElement('span'); field.className = 'diff-field'; field.textContent = item.field;
+        const current = document.createElement('span'); current.className = 'diff-value diff-current'; current.textContent = formatDiffValue(item.current);
+        const expected = document.createElement('span'); expected.className = 'diff-value diff-expected'; expected.textContent = formatDiffValue(item.expected);
+        row.append(field, current, expected); grid.append(row);
+      }
+      box.append(title, grid);
     }
 
     function renderStartupEnvironment() {
@@ -536,6 +595,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       text('github-app-id', github && github.appId);
       text('github-app-slug', github && github.slug);
       text('github-client-id', github && github.clientId);
+      text('github-logto-connector-id', values.logto && values.logto.githubConnector && values.logto.githubConnector.connectorId);
       el('github-edit-controls').hidden = true;
       showIdentityEditors('github', Boolean(github));
       secretText('github-client-secret-display', byKey, 'github.clientSecret', Boolean(github));
@@ -546,19 +606,28 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         ? github.slug + ' is configured. Webhook secret: ' + (webhookStored ? 'stored' : webhookInactive ? 'not required yet' : 'missing') + '.' +
           (webhookInactive ? ' Webhook delivery is not registered until HTTPS ingress is configured.' : '')
         : 'Creates the complete App used for repository installation, webhooks, and optional GitHub sign-in.';
-      const githubDrift = github ? (expected.github ? fieldsChanged(github.configuredUrls, expected.github) : ['startup public URLs']) : [];
-      match('github-match', !github ? '' : githubDrift.length ? 'warn' : '', !github ? 'Not configured' : githubDrift.length ? 'Update required' : 'Ready to check');
+      const githubDrift = github
+        ? expected.github
+          ? objectDiff(github.configuredUrls, expected.github, {
+              externalUrl: 'Homepage URL', setupUrl: 'Setup URL', webhookUrl: 'Webhook URL',
+              webhookActive: 'Webhook active', callbackUrls: 'Callback URLs'
+            })
+          : [{ field: 'Startup public URLs', current: 'Unavailable', expected: 'Valid Web, API, and ingress URLs' }]
+        : [];
+      const githubVerified = Boolean(github && github.configuredUrls);
+      match('github-match', !github ? '' : !githubVerified || githubDrift.length ? 'warn' : '', !github ? 'Not configured' : !githubVerified ? 'Not verified' : githubDrift.length ? 'Update required' : 'Ready to check');
       el('github-create-controls').hidden = Boolean(github);
       el('create-github').hidden = Boolean(github);
       el('clear-github').hidden = !github;
       el('connect-github-login').hidden = !github || !values.logto || Boolean(values.logto.githubConnector);
       el('check-github').hidden = !github;
-      if (github) showDrift('github-drift', githubDrift, expected.github || {});
+      if (github) showDiff('github-drift', githubDrift, githubVerified ? 'Update required' : 'Not verified');
       else el('github-drift').hidden = true;
 
       const slack = values.slack;
       text('slack-app-id', slack && slack.appId);
       text('slack-client-id', slack && slack.clientId);
+      text('slack-logto-connector-id', values.logto && values.logto.slackConnector && values.logto.slackConnector.connectorId);
       el('slack-edit-controls').hidden = true;
       showIdentityEditors('slack', Boolean(slack));
       secretText('slack-client-secret-display', byKey, 'slack.clientSecret', Boolean(slack));
@@ -567,8 +636,16 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         ? 'Enabled; reuses the Slack client secret above.'
         : 'Not enabled.';
       el('slack-status').textContent = slack ? slack.appId + ' is configured.' : 'Creates the default AgentConnect integration manifest.';
-      const slackDrift = slack ? (expected.slack ? fieldsChanged(slack.configuredUrls, expected.slack) : ['startup public URLs']) : [];
-      match('slack-match', !slack ? '' : slackDrift.length ? 'warn' : '', !slack ? 'Not configured' : slackDrift.length ? 'Update required' : 'Ready to check');
+      const slackDrift = slack
+        ? expected.slack
+          ? objectDiff(slack.configuredUrls, expected.slack, {
+              oauthRedirectUrl: 'OAuth redirect URL', eventsUrl: 'Events request URL',
+              interactionsUrl: 'Interactivity request URL', loginRedirectUrl: 'Logto redirect URL'
+            })
+          : [{ field: 'Startup public URLs', current: 'Unavailable', expected: 'HTTPS Web, API, and ingress URLs' }]
+        : [];
+      const slackVerified = Boolean(slack && slack.configuredUrls);
+      match('slack-match', !slack ? '' : !slackVerified || slackDrift.length ? 'warn' : '', !slack ? 'Not configured' : !slackVerified ? 'Not verified' : slackDrift.length ? 'Update required' : 'Ready to check');
       el('slack-name-field').hidden = Boolean(slack);
       el('create-slack').hidden = Boolean(slack);
       el('connect-slack-login').hidden = !slack || !values.logto || Boolean(values.logto.slackConnector) || !bootstrapInfo?.slackAvailable;
@@ -577,7 +654,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       el('slack-settings').hidden = !slack;
       if (slack) {
         el('slack-settings').href = 'https://api.slack.com/apps/' + encodeURIComponent(slack.appId);
-        showDrift('slack-drift', slackDrift, expected.slack || {});
+        showDiff('slack-drift', slackDrift, slackVerified ? 'Update required' : 'Not verified');
       } else el('slack-drift').hidden = true;
 
       const google = values.logto && values.logto.googleConnector;
@@ -586,12 +663,16 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       renderUriList('google-origins', expectedGoogle.origins);
       renderUriList('google-redirects', expectedGoogle.redirects);
       text('google-client-id', google && google.clientId);
+      text('google-connector-id', google && google.connectorId);
       secretText('google-client-secret-display', byKey, 'logto.googleConnectorClientSecret', Boolean(google));
       showIdentityEditors('google', Boolean(google));
       el('google-id').value = google ? google.clientId : '';
+      el('google-connector-id-input').value = google ? google.connectorId : bootstrapInfo.googleConnectorId;
       el('google-status').textContent = google ? 'Google OAuth client is configured.' : 'Create a Web application OAuth client manually, then save it here.';
-      const googleDrift = google && !same(google.configuredRedirectUris, expectedGoogle.redirects) ? ['authorized redirect URIs'] : [];
-      showDrift('google-drift', googleDrift, expectedGoogle);
+      const googleDrift = google && !same(google.configuredRedirectUris, expectedGoogle.redirects)
+        ? [{ field: 'Authorized redirect URIs', current: google.configuredRedirectUris, expected: expectedGoogle.redirects }]
+        : [];
+      showDiff('google-drift', googleDrift);
       match('google-match', !google || !googleSecret ? '' : googleDrift.length ? 'warn' : '', !google ? 'Not configured' : !googleSecret ? 'Missing secret' : googleDrift.length ? 'Update required' : 'Ready to check');
       el('google-initial-secret-field').hidden = googleSecret;
       el('save-google').textContent = google ? 'Confirm callback settings' : 'Save Google client';
@@ -671,6 +752,9 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         el('github-edit-app-id').value = String(github.appId);
         el('github-edit-slug').value = github.slug;
         el('github-edit-client-id').value = github.clientId || '';
+        const githubConnector = values.logto && values.logto.githubConnector;
+        el('github-edit-connector-id').value = githubConnector ? githubConnector.connectorId : '';
+        el('github-edit-connector-id-field').hidden = !githubConnector;
         for (const id of ['github-edit-client-secret', 'github-edit-private-key', 'github-edit-webhook-secret', 'github-edit-logto-secret']) el(id).value = '';
         el('github-edit-logto-secret-field').hidden = !githubConnectorUsesDeployment(values);
         el('github-edit-controls').hidden = false;
@@ -681,6 +765,9 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         if (!slack) return;
         el('slack-edit-app-id').value = slack.appId;
         el('slack-edit-client-id').value = slack.clientId;
+        const slackConnector = values.logto && values.logto.slackConnector;
+        el('slack-edit-connector-id').value = slackConnector ? slackConnector.connectorId : '';
+        el('slack-edit-connector-id-field').hidden = !slackConnector;
         el('slack-edit-client-secret').value = '';
         el('slack-edit-signing-secret').value = '';
         el('slack-edit-controls').hidden = false;
@@ -690,6 +777,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         const google = values.logto && values.logto.googleConnector;
         if (!google) return;
         el('google-id').value = google.clientId;
+        el('google-connector-id-input').value = google.connectorId;
         el('google-secret').value = '';
         el('google-config-controls').hidden = false;
         el('google-initial-secret-field').hidden = false;
@@ -766,6 +854,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const appChanged = appId !== previous.appId;
       const clientChanged = clientId !== previous.clientId;
       const connectorReused = githubConnectorUsesDeployment(values);
+      const connectorId = connectorReused ? requiredInput('github-edit-connector-id', 'the Logto connector ID') : null;
       const clientSecret = el('github-edit-client-secret').value;
       const privateKey = el('github-edit-private-key').value.trim();
       const webhookSecret = el('github-edit-webhook-secret').value;
@@ -780,7 +869,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       if (webhookSecret) secrets['github.webhookSecret'] = webhookSecret;
       if (connectorSecret) secrets['logto.githubConnectorClientSecret'] = connectorSecret;
       const nextLogto = connectorReused && values.logto
-        ? { ...values.logto, githubConnector: { appId, slug, clientId } }
+        ? { ...values.logto, githubConnector: { ...values.logto.githubConnector, connectorId, appId, slug, clientId } }
         : values.logto;
       await replaceConfiguration(
         {
@@ -800,6 +889,9 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const appId = requiredInput('slack-edit-app-id', 'the Slack App ID');
       const clientId = requiredInput('slack-edit-client-id', 'the Slack Client ID');
       const changed = appId !== previous.appId || clientId !== previous.clientId;
+      const connectorId = values.logto && values.logto.slackConnector
+        ? requiredInput('slack-edit-connector-id', 'the Logto connector ID')
+        : null;
       const clientSecret = el('slack-edit-client-secret').value;
       const signingSecret = el('slack-edit-signing-secret').value;
       if (changed && (!clientSecret || !signingSecret)) throw new Error('Enter both the new Slack client secret and signing secret');
@@ -807,7 +899,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       if (clientSecret) secrets['slack.clientSecret'] = clientSecret;
       if (signingSecret) secrets['slack.signingSecret'] = signingSecret;
       const nextLogto = values.logto && values.logto.slackConnector
-        ? { ...values.logto, slackConnector: { appId, clientId } }
+        ? { ...values.logto, slackConnector: { ...values.logto.slackConnector, connectorId, appId, clientId } }
         : values.logto;
       await replaceConfiguration(
         {
@@ -1010,10 +1102,12 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const result = await json(await fetch(api + '/check/github', { headers: bearer() }));
       el('github-settings').href = result.settingsUrl;
       el('github-settings').hidden = false;
-      el('confirm-github').hidden = !result.missing.some((field) => field === 'callback_urls' || field === 'setup_url' || field === 'webhook_active');
-      showDrift('github-drift', result.missing, result.expected);
-      match('github-match', result.status === 'pass' ? 'pass' : 'warn', result.status === 'pass' ? 'Matches' : 'Update required');
-      message(result.status === 'pass' ? 'GitHub App matches the expected integration manifest.' : 'GitHub App settings need an update.', result.status !== 'pass');
+      const confirmationFields = result.unverified || [];
+      el('confirm-github').hidden = ![...result.missing, ...confirmationFields].some((field) => field === 'callback_urls' || field === 'setup_url' || field === 'webhook_active');
+      const label = result.missing.length ? 'Update required' : 'Not verified';
+      showDiff('github-drift', result.diff || [], label);
+      match('github-match', result.status === 'pass' ? 'pass' : 'warn', result.status === 'pass' ? 'Matches' : label);
+      message(result.status === 'pass' ? 'GitHub App matches the expected integration manifest.' : result.missing.length ? 'GitHub App settings need an update.' : 'Confirm the callback, setup, and webhook-active settings in GitHub.', result.status === 'fail');
     }
 
     async function connectGithubLogin() {
@@ -1038,7 +1132,11 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
             browser: logto.browser
               ? { ...logto.browser, socialProviders: [...new Set([...logto.browser.socialProviders, 'slack'])] }
               : logto.browser,
-            slackConnector: { appId: slack.appId, clientId: slack.clientId }
+            slackConnector: {
+              connectorId: bootstrapInfo.slackConnectorId,
+              appId: slack.appId,
+              clientId: slack.clientId
+            }
           }
         },
         undefined,
@@ -1057,14 +1155,14 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
     }
 
     async function checkSlack() {
-      const token = el('slack-token').value;
+      const token = requiredInput('slack-token', 'the temporary Slack App configuration token');
       const result = await json(await fetch(api + '/check/slack', {
         method: 'POST', headers: { 'content-type': 'application/json', ...bearer() },
         body: JSON.stringify({ configToken: token })
       }));
       el('slack-token').value = '';
       if (result.status === 'pass') await load();
-      showDrift('slack-drift', result.missing, result.expected);
+      showDiff('slack-drift', result.diff || []);
       match('slack-match', result.status === 'pass' ? 'pass' : 'warn', result.status === 'pass' ? 'Matches' : 'Update required');
       message(result.status === 'pass' ? 'Slack App matches the default integration manifest.' : 'Slack App settings need an update.', result.status !== 'pass');
     }
@@ -1076,6 +1174,18 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const expected = currentStatus ? currentStatus.providerExpectations.google : { redirects: [] };
       const callbacksMatch = google && same(google.configuredRedirectUris, expected.redirects);
       const passed = connector && connector.status === 'pass' && callbacksMatch;
+      const connectorDiff = connector && connector.diff
+        ? connector.diff.filter((item) => item.field.toLowerCase().startsWith('google'))
+        : [];
+      showDiff(
+        'google-drift',
+        [
+          ...connectorDiff,
+          ...(callbacksMatch || !google
+            ? []
+            : [{ field: 'Authorized redirect URIs', current: google.configuredRedirectUris, expected: expected.redirects }])
+        ]
+      );
       match('google-match', passed ? 'pass' : 'warn', passed ? 'Matches' : 'Update required');
       message(passed ? 'Google callbacks and the Logto connector match.' : 'Google or its Logto connector needs an update.', !passed);
     }
@@ -1091,7 +1201,11 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const secret = el('google-secret').value;
       await json(await fetch(api + '/configure/google', {
         method: 'POST', headers: { 'content-type': 'application/json', ...bearer() },
-        body: JSON.stringify({ clientId: el('google-id').value, ...(secret ? { clientSecret: secret } : {}) })
+        body: JSON.stringify({
+          connectorId: requiredInput('google-connector-id-input', 'the Logto connector ID'),
+          clientId: el('google-id').value,
+          ...(secret ? { clientSecret: secret } : {})
+        })
       }));
       el('google-secret').value = '';
       await reconcileLogto();
@@ -1155,6 +1269,12 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         : failures.map((finding) => finding.message).join(' ');
       el('logto-status').className = failures.length === 0 ? 'ok' : 'warn';
       match('logto-match', failures.length === 0 ? 'pass' : 'warn', failures.length === 0 ? 'Matches' : 'Update required');
+      showDiff(
+        'logto-drift',
+        failures.flatMap((finding) => finding.diff && finding.diff.length
+          ? finding.diff
+          : [{ field: finding.id.replace(/^logto\./, '').replaceAll('_', ' '), current: finding.message, expected: 'Matches expected configuration' }])
+      );
       el('logto-settings').hidden = failures.length === 0;
       return report;
     }

--- a/packages/setup/src/admin/logto-management.ts
+++ b/packages/setup/src/admin/logto-management.ts
@@ -1,10 +1,6 @@
 /** Minimal Logto Management API client for setup reconciliation and ADMIN claim. */
 import { ADMIN_ROLE } from './auth.js'
 
-export const LOGTO_GITHUB_CONNECTOR_ID = 'agentconnect-github'
-export const LOGTO_GOOGLE_CONNECTOR_ID = 'agentconnect-google'
-export const LOGTO_SLACK_CONNECTOR_ID = 'agentconnect-slack'
-
 const MANAGED_APP_TAG = 'agentconnectSetup'
 const MANAGED_APP_TAG_VALUE = { version: 1, resource: 'browser' } as const
 
@@ -22,9 +18,9 @@ export interface LogtoSetupDesired {
   postLogoutRedirectUris: readonly string[]
   corsAllowedOrigins: readonly string[]
   socialProviders: readonly string[]
-  github?: { clientId: string; clientSecret: string }
-  google?: { clientId: string; clientSecret: string }
-  slack?: { clientId: string; clientSecret: string; scope: string }
+  github?: { connectorId: string; clientId: string; clientSecret: string }
+  google?: { connectorId: string; clientId: string; clientSecret: string }
+  slack?: { connectorId: string; clientId: string; clientSecret: string; scope: string }
 }
 
 interface LogtoRole {
@@ -58,16 +54,35 @@ interface LogtoSignInExperience {
   signInMode: unknown
 }
 
+type ManagedConnectorTarget = 'github' | 'google' | 'slack'
+
+function isManagedConnectorTarget(target: string): target is ManagedConnectorTarget {
+  return target === 'github' || target === 'google' || target === 'slack'
+}
+
 export interface LogtoAdminRoleInspection {
   exists: boolean
   type: LogtoRole['type'] | null
   isDefault: boolean | null
 }
 
+export interface LogtoConfigurationDiff {
+  field: string
+  current: unknown
+  expected: unknown
+}
+
 export interface LogtoSetupInspection {
-  application: { id: string | null; exists: boolean; matches: boolean }
-  connectors: Array<{ target: string; id: string | null; exists: boolean; matches: boolean }>
+  application: { id: string | null; exists: boolean; matches: boolean; diff: LogtoConfigurationDiff[] }
+  connectors: Array<{
+    target: string
+    id: string | null
+    exists: boolean
+    matches: boolean
+    diff: LogtoConfigurationDiff[]
+  }>
   signInExperienceMatches: boolean
+  signInExperienceDiff: LogtoConfigurationDiff[]
 }
 
 export interface LogtoSetupReconcileResult {
@@ -110,6 +125,16 @@ function sameStrings(left: unknown, right: readonly string[]): boolean {
   return JSON.stringify(stringArray(left)) === JSON.stringify(right)
 }
 
+function addDiff(
+  diff: LogtoConfigurationDiff[],
+  field: string,
+  current: unknown,
+  expected: unknown,
+  matches: boolean = JSON.stringify(current) === JSON.stringify(expected)
+): void {
+  if (!matches) diff.push({ field, current: current ?? null, expected: expected ?? null })
+}
+
 function hasManagedTag(application: LogtoApplication): boolean {
   const tag = asRecord(application.customData[MANAGED_APP_TAG])
   return tag.version === MANAGED_APP_TAG_VALUE.version && tag.resource === MANAGED_APP_TAG_VALUE.resource
@@ -139,7 +164,7 @@ function parseConnector(value: unknown): LogtoConnector | null {
 }
 
 function desiredConnector(
-  target: string,
+  target: ManagedConnectorTarget,
   desired: LogtoSetupDesired
 ): { id: string; connectorId: string; config: Record<string, string> } {
   if (target === 'github') {
@@ -149,7 +174,8 @@ function desiredConnector(
         'the Logto GitHub connector needs the deployment GitHub App client id and secret'
       )
     }
-    return { id: LOGTO_GITHUB_CONNECTOR_ID, connectorId: 'github-universal', config: desired.github }
+    const { connectorId: id, ...config } = desired.github
+    return { id, connectorId: 'github-universal', config }
   }
   if (target === 'google') {
     if (!desired.google) {
@@ -158,7 +184,8 @@ function desiredConnector(
         'the Logto Google connector needs a Google OAuth client id and secret'
       )
     }
-    return { id: LOGTO_GOOGLE_CONNECTOR_ID, connectorId: 'google-universal', config: desired.google }
+    const { connectorId: id, ...config } = desired.google
+    return { id, connectorId: 'google-universal', config }
   }
   if (target === 'slack') {
     if (!desired.slack) {
@@ -167,12 +194,10 @@ function desiredConnector(
         'the Logto Slack connector needs the deployment Slack App client id and secret'
       )
     }
-    return { id: LOGTO_SLACK_CONNECTOR_ID, connectorId: 'slack-universal', config: desired.slack }
+    const { connectorId: id, ...config } = desired.slack
+    return { id, connectorId: 'slack-universal', config }
   }
-  throw new LogtoManagementError(
-    'SOCIAL_CONNECTOR_UNSUPPORTED',
-    `automatic creation is not supported for the missing Logto social connector ${target}`
-  )
+  throw new Error(`unsupported managed Logto connector target: ${target}`)
 }
 
 function connectorMatches(connector: LogtoConnector, desired: ReturnType<typeof desiredConnector>): boolean {
@@ -222,11 +247,63 @@ export class LogtoAdminClaimClient {
     const application = await this.findApplication(desired.applicationId)
     const connectors = await this.listConnectors()
     const signInExperience = await this.getSignInExperience()
+    const applicationDiff: LogtoConfigurationDiff[] = []
+    if (!application) {
+      applicationDiff.push({
+        field: 'SPA application',
+        current: 'Missing',
+        expected: desired.applicationId ?? desired.applicationName
+      })
+    } else {
+      addDiff(
+        applicationDiff,
+        'Redirect URIs',
+        stringArray(application.oidcClientMetadata.redirectUris),
+        desired.redirectUris,
+        sameStrings(application.oidcClientMetadata.redirectUris, desired.redirectUris)
+      )
+      addDiff(
+        applicationDiff,
+        'Post sign-out redirect URIs',
+        stringArray(application.oidcClientMetadata.postLogoutRedirectUris),
+        desired.postLogoutRedirectUris,
+        sameStrings(application.oidcClientMetadata.postLogoutRedirectUris, desired.postLogoutRedirectUris)
+      )
+      addDiff(
+        applicationDiff,
+        'CORS allowed origins',
+        stringArray(application.customClientMetadata.corsAllowedOrigins),
+        desired.corsAllowedOrigins,
+        sameStrings(application.customClientMetadata.corsAllowedOrigins, desired.corsAllowedOrigins)
+      )
+      addDiff(applicationDiff, 'AgentConnect managed application', hasManagedTag(application), true)
+    }
+    const signInExperienceDiff: LogtoConfigurationDiff[] = []
+    addDiff(signInExperienceDiff, 'Sign-in methods', signInExperience.signIn.methods ?? null, [])
+    addDiff(signInExperienceDiff, 'Sign-up identifiers', signInExperience.signUp.identifiers ?? null, [])
+    addDiff(signInExperienceDiff, 'Secondary identifiers', signInExperience.signUp.secondaryIdentifiers ?? [], [])
+    addDiff(signInExperienceDiff, 'Password sign-up', signInExperience.signUp.password ?? null, false)
+    addDiff(signInExperienceDiff, 'Sign-up verification', signInExperience.signUp.verify ?? null, false)
+    addDiff(
+      signInExperienceDiff,
+      'Skip required identifiers',
+      signInExperience.socialSignIn.skipRequiredIdentifiers ?? null,
+      true
+    )
+    addDiff(
+      signInExperienceDiff,
+      'Social providers',
+      signInExperience.socialSignInConnectorTargets,
+      desired.socialProviders,
+      sameStrings(signInExperience.socialSignInConnectorTargets, desired.socialProviders)
+    )
+    addDiff(signInExperienceDiff, 'Sign-in mode', signInExperience.signInMode ?? null, 'SignInAndRegister')
     return {
       application: {
         id: application?.id ?? null,
         exists: application !== undefined,
-        matches: application ? this.applicationMatches(application, desired) : false
+        matches: application ? this.applicationMatches(application, desired) : false,
+        diff: applicationDiff
       },
       connectors: desired.socialProviders.map((target) => {
         const matches = connectors.filter((connector) => connector.target === target)
@@ -237,14 +314,40 @@ export class LogtoAdminClaimClient {
           )
         }
         const connector = matches[0]
+        if (!isManagedConnectorTarget(target)) {
+          return {
+            target,
+            id: connector?.id ?? null,
+            exists: connector !== undefined,
+            matches: connector !== undefined,
+            diff: connector ? [] : [{ field: `${target} connector`, current: 'Missing', expected: 'Configured' }]
+          }
+        }
+        const expected = desiredConnector(target, desired)
+        const diff: LogtoConfigurationDiff[] = []
+        if (!connector) {
+          diff.push({ field: `${target} connector`, current: 'Missing', expected: expected.id })
+        } else {
+          addDiff(diff, `${target} connector ID`, connector.id, expected.id)
+          addDiff(diff, `${target} connector type`, connector.connectorId, expected.connectorId)
+          addDiff(diff, `${target} client ID`, connector.config.clientId ?? null, expected.config.clientId ?? null)
+          if (target === 'slack') {
+            addDiff(diff, 'Slack OIDC scope', connector.config.scope ?? null, expected.config.scope ?? null)
+          }
+          if (!connectorMatches(connector, expected) && diff.length === 0) {
+            diff.push({ field: `${target} OAuth client settings`, current: '*** (different)', expected: '***' })
+          }
+        }
         return {
           target,
           id: connector?.id ?? null,
           exists: connector !== undefined,
-          matches: connector ? connectorMatches(connector, desiredConnector(target, desired)) : false
+          matches: connector ? connector.id === expected.id && connectorMatches(connector, expected) : false,
+          diff
         }
       }),
-      signInExperienceMatches: this.signInExperienceMatches(signInExperience, desired.socialProviders)
+      signInExperienceMatches: this.signInExperienceMatches(signInExperience, desired.socialProviders),
+      signInExperienceDiff
     }
   }
 
@@ -422,6 +525,16 @@ export class LogtoAdminClaimClient {
           'SOCIAL_CONNECTOR_AMBIGUOUS',
           `Logto has more than one social connector for target ${target}`
         )
+      }
+      if (!isManagedConnectorTarget(target)) {
+        if (!matches[0]) {
+          throw new LogtoManagementError(
+            'SOCIAL_CONNECTOR_UNSUPPORTED',
+            `automatic creation is not supported for the missing Logto social connector ${target}`
+          )
+        }
+        result.push({ target, id: matches[0].id, created: false, changed: false })
+        continue
       }
       const expected = desiredConnector(target, desired)
       if (matches[0] && connectorMatches(matches[0], expected)) {

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -703,8 +703,7 @@ export function buildTenantAdminServer(
           managementAppId: parsed.data.managementAppId,
           managementAppSecret: parsed.data.managementAppSecret,
           socialProvider: parsed.data.socialProvider
-        },
-        logtoManagementEndpoint
+        }
       )
       const saved = await deps.store.replace({ expectedRevision: current?.revision ?? 0, ...put })
       return { ...statusWithExpectations(saved), restartRequired: true as const }

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -32,6 +32,7 @@ import {
   type DeploymentConfigValuesV1
 } from '@agentconnect.md/control-plane/deployment-config-store'
 import { loadDeploymentEnvironment } from '../deployment-environment.js'
+import { LOGTO_GITHUB_CONNECTOR_ID, LOGTO_GOOGLE_CONNECTOR_ID, LOGTO_SLACK_CONNECTOR_ID } from '../logto-connectors.js'
 import {
   githubDeploymentPut,
   localAuthLogtoPut,
@@ -49,6 +50,7 @@ import {
 import {
   auditSlackManifest,
   buildSlackDeploymentManifest,
+  diffSlackManifest,
   requireProviderAppEndpoints,
   slackConfiguredUrls
 } from '../slack-app.js'
@@ -63,9 +65,6 @@ import {
 import { loadTenantAdminProcessConfig } from './config.js'
 import { TENANT_ADMIN_HTML } from './html.js'
 import {
-  LOGTO_GITHUB_CONNECTOR_ID,
-  LOGTO_GOOGLE_CONNECTOR_ID,
-  LOGTO_SLACK_CONNECTOR_ID,
   LogtoAdminClaimClient,
   LogtoManagementError,
   type LogtoManagementConfig,
@@ -109,6 +108,7 @@ const CreateSlackBody = z.strictObject({
 })
 
 const ConfigureGoogleBody = z.strictObject({
+  connectorId: z.string().trim().min(1).max(500).optional(),
   clientId: z.string().trim().min(1).max(500),
   clientSecret: z.string().min(1).max(10_000).optional()
 })
@@ -244,6 +244,7 @@ interface CheckFinding {
   id: string
   status: 'pass' | 'fail' | 'unknown'
   message: string
+  diff?: Array<{ field: string; current: unknown; expected: unknown }>
 }
 
 function checkReport(findings: CheckFinding[], now: () => Date) {
@@ -286,10 +287,10 @@ function appendPath(origin: string, path: string): string {
   return new URL(path, `${origin.replace(/\/+$/, '')}/`).toString()
 }
 
-function googleRedirectUris(endpoint: string): string[] {
+function googleRedirectUris(endpoint: string, connectorId: string): string[] {
   return [
-    appendPath(endpoint, `/callback/${LOGTO_GOOGLE_CONNECTOR_ID}`),
-    appendPath(endpoint, `/account/callback/social/${LOGTO_GOOGLE_CONNECTOR_ID}`)
+    appendPath(endpoint, `/callback/${connectorId}`),
+    appendPath(endpoint, `/account/callback/social/${connectorId}`)
   ]
 }
 
@@ -347,19 +348,58 @@ function logtoSetup(
       corsAllowedOrigins: [...new Set([webOrigin, adminOrigin])],
       socialProviders: [...browser.socialProviders],
       ...(logto.githubConnector && githubSecret
-        ? { github: { clientId: logto.githubConnector.clientId, clientSecret: githubSecret } }
+        ? {
+            github: {
+              connectorId: logto.githubConnector.connectorId,
+              clientId: logto.githubConnector.clientId,
+              clientSecret: githubSecret
+            }
+          }
         : {}),
       ...(logto.googleConnector && googleSecret
-        ? { google: { clientId: logto.googleConnector.clientId, clientSecret: googleSecret } }
+        ? {
+            google: {
+              connectorId: logto.googleConnector.connectorId,
+              clientId: logto.googleConnector.clientId,
+              clientSecret: googleSecret
+            }
+          }
         : {}),
       ...(logto.slackConnector && slackSecret
         ? {
             slack: {
+              connectorId: logto.slackConnector.connectorId,
               clientId: logto.slackConnector.clientId,
               clientSecret: slackSecret,
               scope: 'openid profile email'
             }
           }
+        : {})
+    }
+  }
+}
+
+function withResolvedConnectorIds(
+  values: DeploymentConfigValuesV1,
+  connectors: readonly { target: string; id: string }[]
+): DeploymentConfigValuesV1 {
+  if (!values.logto) return values
+  const connectorIds = new Map(connectors.map((connector) => [connector.target, connector.id]))
+  const githubId = connectorIds.get('github')
+  const googleId = connectorIds.get('google')
+  const slackId = connectorIds.get('slack')
+  return {
+    ...values,
+    logto: {
+      ...values.logto,
+      ...(values.logto.githubConnector && githubId
+        ? { githubConnector: { ...values.logto.githubConnector, connectorId: githubId } }
+        : {}),
+      ...(values.logto.googleConnector && googleId
+        ? { googleConnector: { ...values.logto.googleConnector, connectorId: googleId } }
+        : {}),
+      ...(values.logto.slackConnector && slackId
+        ? { slackConnector: { ...values.logto.slackConnector, connectorId: slackId } }
         : {})
     }
   }
@@ -435,7 +475,7 @@ export function buildTenantAdminServer(
         ? {
             webUrl: localAuthBootstrap.services.web,
             logtoEndpoint,
-            connectorId: LOGTO_GITHUB_CONNECTOR_ID
+            connectorId: values.logto!.githubConnector!.connectorId
           }
         : undefined
     )
@@ -446,7 +486,9 @@ export function buildTenantAdminServer(
     return buildSlackDeploymentManifest(
       slackProviderAppConfig(localAuthBootstrap.services),
       'AgentConnect',
-      values.logto?.slackConnector && browser ? { logtoEndpoint, connectorId: LOGTO_SLACK_CONNECTOR_ID } : undefined
+      values.logto?.slackConnector && browser
+        ? { logtoEndpoint, connectorId: values.logto.slackConnector.connectorId }
+        : undefined
     )
   }
 
@@ -468,7 +510,13 @@ export function buildTenantAdminServer(
       github,
       slack,
       google: values.logto?.browser
-        ? { origins: [logtoEndpoint], redirects: googleRedirectUris(logtoEndpoint) }
+        ? {
+            origins: [logtoEndpoint],
+            redirects: googleRedirectUris(
+              logtoEndpoint,
+              values.logto.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID
+            )
+          }
         : { origins: [], redirects: [] }
     }
   }
@@ -575,8 +623,10 @@ export function buildTenantAdminServer(
   })
 
   app.get('/api/v1/bootstrap-info', { preHandler: requireLocal }, async () => {
-    const redirectUris = googleRedirectUris(logtoEndpoint)
     const current = await deps.store.getAdmin()
+    const googleConnectorId = current?.values.logto?.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID
+    const slackConnectorId = current?.values.logto?.slackConnector?.connectorId ?? LOGTO_SLACK_CONNECTOR_ID
+    const redirectUris = googleRedirectUris(logtoEndpoint, googleConnectorId)
     const logtoConfigured = Boolean(
       current?.values.logto?.managementAppId &&
       current.secrets.some((secret) => secret.key === 'logto.managementAppSecret' && secret.configured)
@@ -610,11 +660,13 @@ export function buildTenantAdminServer(
       logtoAdminEndpoint,
       logtoConfigured,
       logtoManagementAppId: current?.values.logto?.managementAppId ?? null,
+      googleConnectorId,
       google: { javascriptOrigins: [logtoEndpoint], redirectUris },
       githubAvailable,
       githubWebhookActive,
       slackAvailable,
-      slackLoginRedirectUrl: appendPath(slackLoginEndpoint, `/callback/${LOGTO_SLACK_CONNECTOR_ID}`)
+      slackConnectorId,
+      slackLoginRedirectUrl: appendPath(slackLoginEndpoint, `/callback/${slackConnectorId}`)
     }
   })
 
@@ -651,7 +703,8 @@ export function buildTenantAdminServer(
           managementAppId: parsed.data.managementAppId,
           managementAppSecret: parsed.data.managementAppSecret,
           socialProvider: parsed.data.socialProvider
-        }
+        },
+        logtoManagementEndpoint
       )
       const saved = await deps.store.replace({ expectedRevision: current?.revision ?? 0, ...put })
       return { ...statusWithExpectations(saved), restartRequired: true as const }
@@ -775,8 +828,11 @@ export function buildTenantAdminServer(
     return serializeMutation(async () => {
       const current = await deps.store.getAdmin()
       if (!current?.values.logto?.browser) return problem(reply, 409, 'save Logto browser configuration first')
-      const redirectUris = googleRedirectUris(logtoEndpoint)
+      const connectorId =
+        parsed.data.connectorId ?? current.values.logto.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID
+      const redirectUris = googleRedirectUris(logtoEndpoint, connectorId)
       const put = logtoGoogleConnectorPut(current, {
+        ...(parsed.data.connectorId ? { connectorId: parsed.data.connectorId } : {}),
         clientId: parsed.data.clientId,
         ...(parsed.data.clientSecret ? { clientSecret: parsed.data.clientSecret } : {}),
         configuredRedirectUris: redirectUris
@@ -1027,16 +1083,38 @@ export function buildTenantAdminServer(
     const expectedUrls = githubConfiguredUrls(providerAppConfig(localAuthBootstrap.services), manifest)
     const confirmed = github.configuredUrls
     const missing = [...audited.missing]
-    if (confirmed?.setupUrl !== expectedUrls.setupUrl) missing.push('setup_url')
-    if (!sameStrings(confirmed?.callbackUrls, expectedUrls.callbackUrls)) missing.push('callback_urls')
-    if (confirmed?.webhookActive !== expectedUrls.webhookActive) missing.push('webhook_active')
+    const unverified: string[] = []
+    const diff = audited.diff.map(({ field, current, expected }) => ({ field, current, expected }))
+    if (!confirmed) {
+      unverified.push('setup_url', 'callback_urls', 'webhook_active')
+      diff.push(
+        { field: 'Setup URL', current: 'Not verified', expected: expectedUrls.setupUrl },
+        { field: 'Callback URLs', current: 'Not verified', expected: expectedUrls.callbackUrls },
+        { field: 'Webhook active', current: 'Not verified', expected: expectedUrls.webhookActive }
+      )
+    } else {
+      if (confirmed.setupUrl !== expectedUrls.setupUrl) {
+        missing.push('setup_url')
+        diff.push({ field: 'Setup URL', current: confirmed.setupUrl, expected: expectedUrls.setupUrl })
+      }
+      if (!sameStrings(confirmed.callbackUrls, expectedUrls.callbackUrls)) {
+        missing.push('callback_urls')
+        diff.push({ field: 'Callback URLs', current: confirmed.callbackUrls, expected: expectedUrls.callbackUrls })
+      }
+      if (confirmed.webhookActive !== expectedUrls.webhookActive) {
+        missing.push('webhook_active')
+        diff.push({ field: 'Webhook active', current: confirmed.webhookActive, expected: expectedUrls.webhookActive })
+      }
+    }
     return {
       provider: 'github' as const,
-      status: missing.length === 0 ? ('pass' as const) : ('fail' as const),
+      status: missing.length > 0 ? ('fail' as const) : unverified.length > 0 ? ('unknown' as const) : ('pass' as const),
       missing: [...new Set(missing)],
+      unverified,
+      diff,
       expected: expectedUrls,
       settingsUrl: audited.app.settingsUrl,
-      note: 'GitHub exposes permissions, events, and webhook URL to this check. Callback, setup, and webhook-active settings require operator confirmation after editing the App.'
+      note: 'GitHub exposes permissions, events, external URL, and webhook URL to this check. Callback, setup, and webhook-active settings require operator confirmation.'
     }
   })
 
@@ -1089,8 +1167,15 @@ export function buildTenantAdminServer(
       const exported = await slackConfigApi.exportApp(parsed.data.configToken, slack.appId)
       if (!exported.ok) return problem(reply, 502, `Slack App settings could not be checked: ${exported.error}`)
       const actual = exported.manifest
+      const manifestDiff = diffSlackManifest(actual, manifest)
       const missing = auditSlackManifest(actual, manifest)
       const expected = slackConfiguredUrls(manifest)
+      let observed: ReturnType<typeof slackConfiguredUrls> | null = null
+      try {
+        observed = slackConfiguredUrls(actual)
+      } catch {
+        // The stable missing field names still explain malformed exported URLs.
+      }
       let revision = current.revision
       if (missing.length === 0 && JSON.stringify(slack.configuredUrls) !== JSON.stringify(expected)) {
         const saved = await deps.store.replace({
@@ -1103,6 +1188,8 @@ export function buildTenantAdminServer(
         provider: 'slack' as const,
         status: missing.length === 0 ? ('pass' as const) : ('fail' as const),
         missing,
+        diff: manifestDiff.map(({ field, current, expected }) => ({ field, current, expected })),
+        actual: observed,
         expected,
         settingsUrl: `https://api.slack.com/apps/${encodeURIComponent(slack.appId)}`,
         revision,
@@ -1169,7 +1256,7 @@ export function buildTenantAdminServer(
         },
         socialProviders: setup.socialProviders
       }
-      const nextValues = { ...runtime.values, auth }
+      const nextValues = withResolvedConnectorIds({ ...runtime.values, auth }, reconciled.connectors)
       const configChanged = JSON.stringify(runtime.values) !== JSON.stringify(nextValues)
       const saved = configChanged
         ? await deps.store.replace({
@@ -1206,7 +1293,8 @@ export function buildTenantAdminServer(
       findings.push({
         id: 'logto.configuration',
         status: 'fail',
-        message: 'Deployment configuration has not been saved.'
+        message: 'Deployment configuration has not been saved.',
+        diff: [{ field: 'Logto configuration', current: 'Missing', expected: 'Configured' }]
       })
       return report()
     }
@@ -1214,7 +1302,8 @@ export function buildTenantAdminServer(
       findings.push({
         id: 'logto.configuration',
         status: 'fail',
-        message: 'Logto Management API configuration is missing.'
+        message: 'Logto Management API configuration is missing.',
+        diff: [{ field: 'Management API configuration', current: 'Missing', expected: 'Configured' }]
       })
       return report()
     }
@@ -1222,7 +1311,8 @@ export function buildTenantAdminServer(
       findings.push({
         id: 'logto.configuration',
         status: 'fail',
-        message: 'Logto Management API application secret is missing.'
+        message: 'Logto Management API application secret is missing.',
+        diff: [{ field: 'Management App secret', current: 'Not configured', expected: '***' }]
       })
       return report()
     }
@@ -1252,7 +1342,14 @@ export function buildTenantAdminServer(
         message:
           status === 'fail'
             ? `Logto rejected the Management API client_credentials grant (HTTP ${upstreamStatus}).`
-            : 'The Management API client_credentials grant could not be verified because Logto or the network is unavailable.'
+            : 'The Management API client_credentials grant could not be verified because Logto or the network is unavailable.',
+        diff: [
+          {
+            field: 'Management API credentials',
+            current: status === 'fail' ? `Rejected (HTTP ${upstreamStatus})` : 'Could not check',
+            expected: 'Accepted'
+          }
+        ]
       })
       return report()
     }
@@ -1274,7 +1371,14 @@ export function buildTenantAdminServer(
         message:
           status === 'fail'
             ? `The Management API application cannot read Logto roles (HTTP ${upstreamStatus}).`
-            : 'The Logto roles permission could not be verified because Logto or the network is unavailable.'
+            : 'The Logto roles permission could not be verified because Logto or the network is unavailable.',
+        diff: [
+          {
+            field: 'Management API roles access',
+            current: status === 'fail' ? `Denied (HTTP ${upstreamStatus})` : 'Could not check',
+            expected: 'Allowed'
+          }
+        ]
       })
       return report()
     }
@@ -1291,14 +1395,22 @@ export function buildTenantAdminServer(
             status: 'fail',
             message: adminRole.exists
               ? 'A role named ADMIN exists, but it is not a non-default User role.'
-              : 'The exact global User role ADMIN does not exist; the first Tenant Admin sign-in will create it.'
+              : 'The exact global User role ADMIN does not exist; the first Tenant Admin sign-in will create it.',
+            diff: [
+              {
+                field: 'ADMIN role',
+                current: adminRole.exists ? { type: adminRole.type, default: adminRole.isDefault } : 'Missing',
+                expected: { type: 'User', default: false }
+              }
+            ]
           }
     )
     if (!setup) {
       findings.push({
         id: 'logto.setup_configuration',
         status: 'fail',
-        message: 'Logto browser desired state is missing.'
+        message: 'Logto browser desired state is missing.',
+        diff: [{ field: 'Browser application configuration', current: 'Missing', expected: 'Configured' }]
       })
       return report()
     }
@@ -1313,7 +1425,14 @@ export function buildTenantAdminServer(
         message:
           status === 'fail'
             ? 'Logto browser resources are invalid or ambiguous.'
-            : 'Logto browser resources could not be checked because Logto or the network is unavailable.'
+            : 'Logto browser resources could not be checked because Logto or the network is unavailable.',
+        diff: [
+          {
+            field: 'Browser resources',
+            current: status === 'fail' ? 'Invalid or ambiguous' : 'Could not check',
+            expected: 'Configured once'
+          }
+        ]
       })
       return report()
     }
@@ -1329,7 +1448,8 @@ export function buildTenantAdminServer(
             status: 'fail',
             message: setupInspection.application.exists
               ? 'The selected Logto SPA does not match the expected redirects and CORS origins.'
-              : 'The AgentConnect Logto SPA does not exist.'
+              : 'The AgentConnect Logto SPA does not exist.',
+            diff: setupInspection.application.diff
           }
     )
     const invalidConnectors = setupInspection.connectors
@@ -1345,7 +1465,10 @@ export function buildTenantAdminServer(
         : {
             id: 'logto.connectors',
             status: 'fail',
-            message: `Missing or mismatched Logto social connectors: ${invalidConnectors.join(', ')}.`
+            message: `Missing or mismatched Logto social connectors: ${invalidConnectors.join(', ')}.`,
+            diff: setupInspection.connectors
+              .filter((connector) => !connector.exists || !connector.matches)
+              .flatMap((connector) => connector.diff)
           }
     )
     findings.push(
@@ -1358,7 +1481,8 @@ export function buildTenantAdminServer(
         : {
             id: 'logto.sign_in_experience',
             status: 'fail',
-            message: 'Logto sign-in methods do not match the deployment configuration.'
+            message: 'Logto sign-in methods do not match the deployment configuration.',
+            diff: setupInspection.signInExperienceDiff
           }
     )
     return report()

--- a/packages/setup/src/deployment-config-client.ts
+++ b/packages/setup/src/deployment-config-client.ts
@@ -5,6 +5,7 @@ import {
   type DeploymentConfigValuesV1
 } from '@agentconnect.md/control-plane/deployment-config-store'
 import { z } from 'zod'
+import { LOGTO_GITHUB_CONNECTOR_ID, LOGTO_GOOGLE_CONNECTOR_ID, LOGTO_SLACK_CONNECTOR_ID } from './logto-connectors.js'
 
 export const DeploymentConfigPutSchema = z.strictObject({
   values: DeploymentConfigValuesV1Schema,
@@ -58,7 +59,12 @@ export function githubDeploymentPut(
                     socialProviders: [...new Set([...connectLogto.browser.socialProviders, 'github'])]
                   }
                 : connectLogto.browser,
-              githubConnector: { appId, slug: credentials.slug, clientId: credentials.clientId }
+              githubConnector: {
+                connectorId: LOGTO_GITHUB_CONNECTOR_ID,
+                appId,
+                slug: credentials.slug,
+                clientId: credentials.clientId
+              }
             }
           }
         : {})
@@ -88,7 +94,8 @@ export interface LocalAuthLogtoBootstrap {
 /** Fill the local Logto defaults without replacing existing provider state. */
 export function localAuthLogtoPut(
   current: CurrentDeploymentConfig,
-  bootstrap: LocalAuthLogtoBootstrap
+  bootstrap: LocalAuthLogtoBootstrap,
+  managementEndpoint: string
 ): DeploymentConfigPut {
   const existing = current.values.logto
   const managementAppId = bootstrap.managementAppId ?? existing?.managementAppId
@@ -98,7 +105,7 @@ export function localAuthLogtoPut(
       ...current.values,
       logto: {
         managementAppId,
-        managementResource: existing?.managementResource ?? 'https://default.logto.app/api',
+        managementResource: existing?.managementResource ?? new URL('/api', managementEndpoint).toString(),
         browser:
           existing?.browser ??
           ({
@@ -135,7 +142,12 @@ export function logtoGithubConnectorPut(
               socialProviders: [...new Set([...current.values.logto.browser.socialProviders, 'github'])]
             }
           : current.values.logto.browser,
-        githubConnector: { appId, slug: credentials.slug, clientId: credentials.clientId }
+        githubConnector: {
+          connectorId: current.values.logto.githubConnector?.connectorId ?? LOGTO_GITHUB_CONNECTOR_ID,
+          appId,
+          slug: credentials.slug,
+          clientId: credentials.clientId
+        }
       }
     },
     secrets: { 'logto.githubConnectorClientSecret': credentials.clientSecret }
@@ -181,7 +193,11 @@ export function slackDeploymentPut(
                     socialProviders: [...new Set([...logto.browser.socialProviders, 'slack'])]
                   }
                 : logto.browser,
-              slackConnector: { appId: credentials.appId, clientId: credentials.clientId }
+              slackConnector: {
+                connectorId: logto.slackConnector?.connectorId ?? LOGTO_SLACK_CONNECTOR_ID,
+                appId: credentials.appId,
+                clientId: credentials.clientId
+              }
             }
           }
         : {})
@@ -194,6 +210,7 @@ export function slackDeploymentPut(
 }
 
 export interface LogtoGoogleConnectorCredentials {
+  connectorId?: string
   clientId: string
   clientSecret?: string
   configuredRedirectUris: string[]
@@ -219,6 +236,8 @@ export function logtoGoogleConnectorPut(
             }
           : current.values.logto.browser,
         googleConnector: {
+          connectorId:
+            credentials.connectorId ?? current.values.logto.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID,
           clientId: credentials.clientId,
           configuredRedirectUris: credentials.configuredRedirectUris
         }

--- a/packages/setup/src/deployment-config-client.ts
+++ b/packages/setup/src/deployment-config-client.ts
@@ -94,8 +94,7 @@ export interface LocalAuthLogtoBootstrap {
 /** Fill the local Logto defaults without replacing existing provider state. */
 export function localAuthLogtoPut(
   current: CurrentDeploymentConfig,
-  bootstrap: LocalAuthLogtoBootstrap,
-  managementEndpoint: string
+  bootstrap: LocalAuthLogtoBootstrap
 ): DeploymentConfigPut {
   const existing = current.values.logto
   const managementAppId = bootstrap.managementAppId ?? existing?.managementAppId
@@ -105,7 +104,7 @@ export function localAuthLogtoPut(
       ...current.values,
       logto: {
         managementAppId,
-        managementResource: existing?.managementResource ?? new URL('/api', managementEndpoint).toString(),
+        managementResource: existing?.managementResource ?? 'https://default.logto.app/api',
         browser:
           existing?.browser ??
           ({

--- a/packages/setup/src/github-app.ts
+++ b/packages/setup/src/github-app.ts
@@ -41,6 +41,7 @@ export const GITHUB_APP_PERMISSIONS = {
   pull_requests: 'write',
   actions: 'write',
   checks: 'write',
+  packages: 'write',
   workflows: 'write',
   email_addresses: 'read'
 } as const
@@ -50,9 +51,11 @@ export const GITHUB_APP_EVENTS = [
   'issues',
   'issue_comment',
   'pull_request',
+  'pull_request_review',
   'pull_request_review_comment',
   'check_run',
-  'check_suite'
+  'release',
+  'repository'
 ] as const
 
 const GITHUB_ORG = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
@@ -192,6 +195,7 @@ interface GithubWebhookApiResponse {
 export interface GithubAppAuditResult {
   app: { id: number; slug: string; owner: string | null; settingsUrl: string }
   missing: string[]
+  diff: Array<{ id: string; field: string; current: unknown; expected: unknown }>
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -205,6 +209,12 @@ function sameRecord(left: unknown, right: Record<string, string>): boolean {
   return (
     JSON.stringify(actualKeys) === JSON.stringify(expectedKeys) &&
     expectedKeys.every((key) => actual[key] === right[key])
+  )
+}
+
+function githubApiPermissions(manifestPermissions: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(manifestPermissions).map(([key, value]) => [key === 'email_addresses' ? 'emails' : key, value])
   )
 }
 
@@ -228,21 +238,35 @@ export async function auditGithubApp(
       ? githubRequest<GithubWebhookApiResponse>('/app/hook/config', { auth: jwt, fetchImpl })
       : Promise.resolve(undefined)
   ])
-  const missing: string[] = []
+  const diff: GithubAppAuditResult['diff'] = []
+  const addDiff = (id: string, field: string, current: unknown, expected: unknown) => {
+    diff.push({ id, field, current, expected })
+  }
+  const currentIdentity = { appId: app.id, slug: app.slug, clientId: app.client_id ?? null }
+  const expectedIdentity = { appId: identity.appId, slug: identity.slug, clientId: identity.clientId }
   if (
     app.id !== identity.appId ||
     app.slug !== identity.slug ||
     (identity.clientId !== null && app.client_id !== identity.clientId)
   ) {
-    missing.push('identity')
+    addDiff('identity', 'App identity', currentIdentity, expectedIdentity)
   }
-  if (app.external_url !== expectedManifest.url) missing.push('external_url')
-  if (!sameRecord(app.permissions, GITHUB_APP_PERMISSIONS)) missing.push('permissions')
+  if (app.external_url !== expectedManifest.url) {
+    addDiff('external_url', 'Homepage URL', app.external_url ?? null, expectedManifest.url ?? null)
+  }
+  const expectedPermissions = githubApiPermissions(GITHUB_APP_PERMISSIONS)
+  if (!sameRecord(app.permissions, expectedPermissions)) {
+    addDiff('permissions', 'Repository permissions', asRecord(app.permissions), expectedPermissions)
+  }
   const expectedEvents = Array.isArray(expectedManifest.default_events)
     ? expectedManifest.default_events.filter((event): event is string => typeof event === 'string')
     : []
-  if (!sameStringSet(app.events, expectedEvents)) missing.push('events')
-  if (typeof expectedHook.url === 'string' && hook?.url !== expectedHook.url) missing.push('webhook_url')
+  if (!sameStringSet(app.events, expectedEvents)) {
+    addDiff('events', 'Webhook events', Array.isArray(app.events) ? app.events : [], expectedEvents)
+  }
+  if (typeof expectedHook.url === 'string' && hook?.url !== expectedHook.url) {
+    addDiff('webhook_url', 'Webhook URL', hook?.url ?? null, expectedHook.url)
+  }
 
   const owner = asRecord(app.owner)
   const ownerLogin = typeof owner.login === 'string' ? owner.login : null
@@ -251,7 +275,11 @@ export async function auditGithubApp(
     ownerType === 'Organization' && ownerLogin
       ? `https://github.com/organizations/${encodeURIComponent(ownerLogin)}/settings/apps/${encodeURIComponent(identity.slug)}`
       : `https://github.com/settings/apps/${encodeURIComponent(identity.slug)}`
-  return { app: { id: identity.appId, slug: identity.slug, owner: ownerLogin, settingsUrl }, missing }
+  return {
+    app: { id: identity.appId, slug: identity.slug, owner: ownerLogin, settingsUrl },
+    missing: [...new Set(diff.map((item) => item.id))],
+    diff
+  }
 }
 
 function closeServer(server: Server): Promise<void> {

--- a/packages/setup/src/github-app.ts
+++ b/packages/setup/src/github-app.ts
@@ -41,7 +41,6 @@ export const GITHUB_APP_PERMISSIONS = {
   pull_requests: 'write',
   actions: 'write',
   checks: 'write',
-  packages: 'write',
   workflows: 'write',
   email_addresses: 'read'
 } as const
@@ -54,6 +53,7 @@ export const GITHUB_APP_EVENTS = [
   'pull_request_review',
   'pull_request_review_comment',
   'check_run',
+  'check_suite',
   'release',
   'repository'
 ] as const

--- a/packages/setup/src/logto-connectors.ts
+++ b/packages/setup/src/logto-connectors.ts
@@ -1,0 +1,3 @@
+export const LOGTO_GITHUB_CONNECTOR_ID = 'agentconnect-github'
+export const LOGTO_GOOGLE_CONNECTOR_ID = 'agentconnect-google'
+export const LOGTO_SLACK_CONNECTOR_ID = 'agentconnect-slack'

--- a/packages/setup/src/slack-app.ts
+++ b/packages/setup/src/slack-app.ts
@@ -82,9 +82,20 @@ function asStrings(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
 }
 
-/** Returns stable field names only; it never includes provider response values. */
-export function auditSlackManifest(actual: SlackManifest, expected: SlackManifest): string[] {
-  const missing: string[] = []
+function sameStrings(left: unknown, right: unknown): boolean {
+  return JSON.stringify([...asStrings(left)].sort()) === JSON.stringify([...asStrings(right)].sort())
+}
+
+export interface SlackManifestDiff {
+  id: string
+  field: string
+  current: unknown
+  expected: unknown
+}
+
+/** Returns only public App settings; secrets never appear in this diff. */
+export function diffSlackManifest(actual: SlackManifest, expected: SlackManifest): SlackManifestDiff[] {
+  const diff: SlackManifestDiff[] = []
   const actualOauth = asRecord(actual.oauth_config)
   const expectedOauth = asRecord(expected.oauth_config)
   const actualScopes = asRecord(actualOauth.scopes)
@@ -97,29 +108,46 @@ export function auditSlackManifest(actual: SlackManifest, expected: SlackManifes
   const expectedInteractivity = asRecord(expectedSettings.interactivity)
 
   for (const scope of asStrings(asRecord(expectedScopes).bot)) {
-    if (!asStrings(asRecord(actualScopes).bot).includes(scope)) missing.push(`scope:${scope}`)
+    if (!asStrings(asRecord(actualScopes).bot).includes(scope)) {
+      diff.push({ id: `scope:${scope}`, field: `Bot scope: ${scope}`, current: 'Missing', expected: 'Required' })
+    }
   }
   for (const event of asStrings(expectedEvents.bot_events)) {
-    if (!asStrings(actualEvents.bot_events).includes(event)) missing.push(`event:${event}`)
+    if (!asStrings(actualEvents.bot_events).includes(event)) {
+      diff.push({ id: `event:${event}`, field: `Bot event: ${event}`, current: 'Missing', expected: 'Required' })
+    }
   }
-  for (const [field, expectedValue] of [
-    ['oauth_config.redirect_urls', expectedOauth.redirect_urls],
-    ['settings.event_subscriptions.request_url', expectedEvents.request_url],
-    ['settings.interactivity.request_url', expectedInteractivity.request_url],
-    ['settings.interactivity.message_menu_options_url', expectedInteractivity.message_menu_options_url],
-    ['settings.socket_mode_enabled', expectedSettings.socket_mode_enabled]
+  for (const [id, field, expectedValue] of [
+    ['oauth_config.redirect_urls', 'OAuth redirect URLs', expectedOauth.redirect_urls],
+    ['settings.event_subscriptions.request_url', 'Events request URL', expectedEvents.request_url],
+    ['settings.interactivity.request_url', 'Interactivity request URL', expectedInteractivity.request_url],
+    [
+      'settings.interactivity.message_menu_options_url',
+      'Message menu options URL',
+      expectedInteractivity.message_menu_options_url
+    ],
+    ['settings.socket_mode_enabled', 'Socket Mode enabled', expectedSettings.socket_mode_enabled]
   ] as const) {
     const actualValue =
-      field === 'oauth_config.redirect_urls'
+      id === 'oauth_config.redirect_urls'
         ? actualOauth.redirect_urls
-        : field === 'settings.event_subscriptions.request_url'
+        : id === 'settings.event_subscriptions.request_url'
           ? actualEvents.request_url
-          : field === 'settings.interactivity.request_url'
+          : id === 'settings.interactivity.request_url'
             ? actualInteractivity.request_url
-            : field === 'settings.interactivity.message_menu_options_url'
+            : id === 'settings.interactivity.message_menu_options_url'
               ? actualInteractivity.message_menu_options_url
               : actualSettings.socket_mode_enabled
-    if (JSON.stringify(actualValue) !== JSON.stringify(expectedValue)) missing.push(field)
+    const matches =
+      id === 'oauth_config.redirect_urls'
+        ? sameStrings(actualValue, expectedValue)
+        : JSON.stringify(actualValue) === JSON.stringify(expectedValue)
+    if (!matches) diff.push({ id, field, current: actualValue ?? null, expected: expectedValue ?? null })
   }
-  return missing
+  return diff
+}
+
+/** Returns stable field names only; it never includes provider response values. */
+export function auditSlackManifest(actual: SlackManifest, expected: SlackManifest): string[] {
+  return diffSlackManifest(actual, expected).map((item) => item.id)
 }

--- a/packages/setup/test/admin-logto-management.test.ts
+++ b/packages/setup/test/admin-logto-management.test.ts
@@ -212,9 +212,14 @@ describe('Logto setup reconciliation', () => {
       postLogoutRedirectUris: ['http://localhost:3000/login'],
       corsAllowedOrigins: ['http://localhost:3000', 'http://localhost:8091'],
       socialProviders: ['github', 'google', 'slack'],
-      github: { clientId: 'github-client', clientSecret: 'github-secret' },
-      google: { clientId: 'google-client', clientSecret: 'google-secret' },
-      slack: { clientId: 'slack-client', clientSecret: 'slack-secret', scope: 'openid profile email' }
+      github: { connectorId: 'agentconnect-github', clientId: 'github-client', clientSecret: 'github-secret' },
+      google: { connectorId: 'agentconnect-google', clientId: 'google-client', clientSecret: 'google-secret' },
+      slack: {
+        connectorId: 'agentconnect-slack',
+        clientId: 'slack-client',
+        clientSecret: 'slack-secret',
+        scope: 'openid profile email'
+      }
     }
 
     await expect(client.reconcileSetup(desired)).resolves.toMatchObject({


### PR DESCRIPTION
## Summary

- persist the real Logto connector instance IDs used by GitHub, Google, and Slack
- align GitHub and Slack App audits with the deployment integration manifests
- show field-level Current / Expected differences for Logto and provider configuration drift
- keep provider identities editable and secrets masked inside their owning Tenant Admin sections

## Why

Tenant Admin previously mixed hardcoded connector IDs with provider-returned IDs and reduced drift to field names plus raw JSON. That could leave correctly configured Apps looking mismatched and made callback, permission, event, and sign-in differences difficult to review.

## Impact

Operators can now see exactly which public provider setting differs, update or clear the saved identity, and reconcile Logto without exposing stored secrets. Saved deployment configuration still takes effect only after service restart.

## Validation

- `pnpm --filter @agentconnect.md/setup typecheck`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/setup build`
- pre-push `eslint .`
- `git diff --check`
