### PR TITLE
fix(web): preserve deployment-owned public routes

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -224,8 +224,8 @@ services:
     environment:
       - PORT=8080
       - HOSTNAME=0.0.0.0
-      # Topology-only bootstrap. Public browser settings are read once from the
-      # Control Plane's DB-backed startup snapshot and still require a restart.
+      # Topology-only bootstrap for the DB-backed browser auth snapshot. Public
+      # service routes remain owned by this Web container's startup environment.
       - CP_INTERNAL_URL=http://control-plane:8080/api/v1
       - CP_URL=${AGENTCONNECT_PUBLIC_CP_URL:-http://api.agentconnect.localhost:${AGENTCONNECT_CP_PORT:-8080}}/api/v1
       - RELAY_URL=${AGENTCONNECT_PUBLIC_RELAY_URL:-http://relay.agentconnect.localhost:${AGENTCONNECT_RELAY_PORT:-8090}}

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -817,10 +817,6 @@ export function buildContainer(
       ? {
           deploymentRevision: opts.deploymentConfig.revision,
           publicRuntimeConfig: {
-            apiUrl: config.PUBLIC_CP_URL ? `${config.PUBLIC_CP_URL.replace(/\/$/, '')}/api/v1` : null,
-            relayUrl: config.PUBLIC_RELAY_URL ?? null,
-            webUrl: config.PUBLIC_WEB_URL ?? null,
-            mcpUrl: config.PUBLIC_MCP_URL ?? null,
             auth:
               opts.deploymentConfig.values.auth.mode === 'oidc' && config.OIDC_ISSUER
                 ? {

--- a/packages/control-plane/src/http/routes/runtime-config.test.ts
+++ b/packages/control-plane/src/http/routes/runtime-config.test.ts
@@ -4,17 +4,13 @@ import { installZod } from '../plugins/zod.js'
 import { runtimeConfigRoutes } from './runtime-config.js'
 
 describe('runtime config route', () => {
-  it('returns only the explicit secret-free startup projection', async () => {
+  it('returns only the explicit secret-free auth projection', async () => {
     const app = Fastify()
     installZod(app)
     await app.register(
       runtimeConfigRoutes({
         deploymentRevision: 7,
         publicRuntimeConfig: {
-          apiUrl: 'https://api.example.test/api/v1',
-          relayUrl: 'https://relay.example.test',
-          webUrl: 'https://console.example.test',
-          mcpUrl: null,
           auth: {
             endpoint: 'https://login.example.test',
             issuer: 'https://login.example.test/oidc',
@@ -33,10 +29,6 @@ describe('runtime config route', () => {
       schemaVersion: '1',
       revision: 7,
       config: {
-        apiUrl: 'https://api.example.test/api/v1',
-        relayUrl: 'https://relay.example.test',
-        webUrl: 'https://console.example.test',
-        mcpUrl: null,
         auth: {
           endpoint: 'https://login.example.test',
           issuer: 'https://login.example.test/oidc',

--- a/packages/control-plane/src/http/routes/runtime-config.ts
+++ b/packages/control-plane/src/http/routes/runtime-config.ts
@@ -19,10 +19,6 @@ export const RuntimeConfigDto = z
     revision: z.number().int().positive().nullable(),
     config: z
       .object({
-        apiUrl: z.string().url().nullable(),
-        relayUrl: z.string().url().nullable(),
-        webUrl: z.string().url().nullable(),
-        mcpUrl: z.string().url().nullable(),
         auth: PublicBrowserAuth.nullable()
       })
       .strict()
@@ -33,12 +29,12 @@ export const RuntimeConfigDto = z
 export type RuntimeConfigDto = z.infer<typeof RuntimeConfigDto>
 
 export interface RuntimeConfigRouteDeps {
-  /** One immutable public projection from the process startup snapshot. */
+  /** Immutable DB-owned browser auth state loaded at process startup. */
   publicRuntimeConfig?: RuntimeConfigDto['config']
   deploymentRevision?: number
 }
 
-/** Public, secret-free config consumed by the prebuilt Web image at startup. */
+/** Public, secret-free auth config consumed by the prebuilt Web image at startup. */
 export function runtimeConfigRoutes(deps: RuntimeConfigRouteDeps) {
   return async function runtimeConfigRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
@@ -49,7 +45,7 @@ export function runtimeConfigRoutes(deps: RuntimeConfigRouteDeps) {
           tags: [Tag.Deployment],
           summary: 'Get public runtime configuration',
           description:
-            'Returns the secret-free browser configuration loaded for this process. A deployment change takes effect after restart.',
+            'Returns the secret-free browser authentication configuration loaded for this process. A deployment change takes effect after restart.',
           operationId: 'getRuntimeConfig',
           response: { 200: RuntimeConfigDto }
         }

--- a/packages/web/src/lib/public-env.tsx
+++ b/packages/web/src/lib/public-env.tsx
@@ -53,10 +53,6 @@ interface RuntimeConfigResponse {
   schemaVersion: '1'
   revision: number | null
   config: null | {
-    apiUrl: string | null
-    relayUrl: string | null
-    webUrl: string | null
-    mcpUrl: string | null
     auth: null | {
       endpoint: string
       issuer: string
@@ -79,9 +75,6 @@ async function loadDeploymentEnv(): Promise<Record<string, string> | null> {
   if (body.schemaVersion !== '1' || body.config === null) return null
 
   const env: Record<string, string> = {}
-  if (body.config.apiUrl) env.CP_URL = body.config.apiUrl
-  if (body.config.relayUrl) env.RELAY_URL = body.config.relayUrl
-  if (body.config.mcpUrl) env.MCP_URL = body.config.mcpUrl
   if (body.config.auth) {
     env.LOGTO_ENDPOINT = body.config.auth.endpoint
     env.LOGTO_APP_ID = body.config.auth.appId
@@ -102,24 +95,17 @@ async function resolve(): Promise<Record<string, string>> {
   const relayUrl = process.env.RELAY_URL ?? process.env.PUBLIC_RELAY_URL ?? process.env.NEXT_PUBLIC_RELAY_URL
   if (relayUrl) env.RELAY_URL = relayUrl
 
-  // The internal URL is deployment topology and therefore remains a bootstrap
-  // env value. The public settings themselves come from the CP's immutable
-  // startup snapshot. Cache the first attempt (including absence or failure)
-  // for this Web process so configuration never hot-reloads between requests;
-  // a restart applies it.
+  // CP_INTERNAL_URL is deployment topology and remains a bootstrap env value.
+  // The CP snapshot supplies only DB-owned auth state. Browser-facing service
+  // routes stay owned by this Web process because their public path can differ
+  // from the CP's daemon/control origin (for example apiHost /v1 rewrites to
+  // the CP's internal /api/v1 mount). Cache the first attempt, including absence
+  // or failure, so configuration never hot-reloads between requests.
   if (process.env.CP_INTERNAL_URL) {
     deploymentEnv ??= loadDeploymentEnv().catch(() => null)
     const persisted = await deploymentEnv
     if (persisted) {
-      for (const key of [
-        'LOGTO_ENDPOINT',
-        'LOGTO_APP_ID',
-        'LOGTO_API_RESOURCE',
-        'SOCIAL_PROVIDERS',
-        'CP_URL',
-        'RELAY_URL',
-        'MCP_URL'
-      ]) {
+      for (const key of ['LOGTO_ENDPOINT', 'LOGTO_APP_ID', 'LOGTO_API_RESOURCE', 'SOCIAL_PROVIDERS']) {
         delete env[key]
       }
       Object.assign(env, persisted)


### PR DESCRIPTION
## Summary

- keep browser API, ingress, and MCP routes owned by the Web deployment environment
- limit the Control Plane runtime snapshot to database-owned authentication settings
- prevent an internal Control Plane origin from replacing the externally routed browser API path

## Root cause

The Web process treated every value returned by the Control Plane runtime snapshot as authoritative. In deployments where the external API uses a routed path different from the Control Plane's internal mount, that replaced the correct Web `CP_URL` with an invalid public path. Browser requests then failed before normal API handling and appeared as CORS errors.

## Impact

Prebuilt Web images still receive restart-bound Logto configuration from the deployment database, while public service routing continues to follow the Web pod's startup environment. This restores the configured external API path without introducing hot reload behavior.

## Validation

- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web build`
- pre-push `eslint .`
- `git diff --check`
