### PR TITLE
fix(discord): isolate root affinity to native threads

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -242,6 +242,11 @@ returned platform message creates the agent's session for that new thread but do
 a model turn. The root is already the agent's own output, not a new request: treating it
 as an activation can make the agent post it again recursively.
 
+On Discord, publishing that root must immediately open a native thread from the posted
+message. The initialized session uses `{channel: parent channel, thread: created thread}`;
+it must never use the parent channel itself as the thread-affinity key. If Discord cannot
+create the thread, the post remains visible but no follow-up session is initialized.
+
 The session starts idle, retains its parent-session lineage, and records the root for
 transcript display. The first real reply in that thread receives the root as preceding
 context before the new message. Session initialization itself produces no agent output,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -159,7 +159,7 @@ import {
 } from './platforms/integration-config.js'
 import { compoundMentionAddressesFor } from './platforms/mention-address.js'
 import { isPlatformMemberId } from './platforms/member-id.js'
-import { threadKeyForPost } from './platforms/thread-keys.js'
+import { rootPostNeedsThreadMaterialization, rootPostThreadName, threadKeyForPost } from './platforms/thread-keys.js'
 import { isMalformedPlatformTurn } from './platforms/malformed-turn.js'
 import { registerThreadPromotion, threadPromotionFor } from './platforms/thread-promotion.js'
 import { discordThreadPromotion } from './platforms/discord/thread-promotion.js'
@@ -18671,7 +18671,7 @@ export class Daemon {
               await (conn as { getChannelInfo?: (ch: string) => Promise<{ isIm?: boolean } | undefined> })
                 .getChannelInfo?.(target.channel)
                 .catch(() => undefined)
-            )?.isIm ?? false
+            )?.isIm ?? msg.isDm
           if (isDmTarget) msg = { ...msg, isDm: true }
           // slackAgentPostOptions guards on the platform internally: a non-Slack
           // target (or an unresolved agent) yields undefined and the anchor posts
@@ -18688,13 +18688,37 @@ export class Daemon {
           const ts = options
             ? await (conn as SlackConnection).postMessage(target.channel, anchorText, undefined, options)
             : await conn.postMessage(target.channel, anchorText)
-          // The posted anchor is both the thread root and the authoritative
-          // transcript/read cursor. Keep the synthetic msgId as the durable turn id.
-          // §6.8: the SESSION key must follow the platform's own conversation model
-          // (threadKeyForPost — Slack and Discord guild threads key off the post,
-          // Telegram replies resolve to `tg:<root>`, while supported DMs remain
-          // continuous), or the anchored session and its replies mint different keys.
-          if (ts) msg = { ...msg, thread: threadKeyForPost(msg.platform, msg.channel, ts, msg.isDm), transcriptTs: ts }
+          if (ts) {
+            const mustMaterializeThread = !isDmTarget && rootPostNeedsThreadMaterialization(msg.platform)
+            let thread: string | undefined
+            if (mustMaterializeThread) {
+              try {
+                thread = await (
+                  conn as {
+                    createThread?: (channel: string, messageId: string, name: string) => Promise<string | undefined>
+                  }
+                ).createThread?.(target.channel, ts, rootPostThreadName(anchorText))
+              } catch (err) {
+                this.log.warn(
+                  `${label}: posted trigger to ${target.channel}, but failed to create its required thread (${formatErr(err)}) — session not started`
+                )
+                return null
+              }
+              if (!thread) {
+                this.log.warn(
+                  `${label}: posted trigger to ${target.channel}, but its required thread was not created — session not started`
+                )
+                return null
+              }
+            } else {
+              thread = threadKeyForPost(msg.platform, target.channel, ts, isDmTarget)
+            }
+            // The posted anchor is both the thread root and the authoritative
+            // transcript/read cursor. Keep the synthetic msgId as the durable turn id.
+            // The session is created only after any required provider thread exists,
+            // so every follow-up resolves to these exact coordinates.
+            msg = { ...msg, channel: target.channel, thread, transcriptTs: ts }
+          }
         } catch (err) {
           this.log.warn(
             `${label}: failed to post trigger to ${target.channel} (${formatErr(err)}) — running without anchor`

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8814,10 +8814,10 @@ export class Daemon {
     const targetScope = this.transportScopeForIntegrationIds(
       req.targetIntegrationId !== undefined ? [req.targetIntegrationId] : undefined
     )
-    // Same conversation AND a different thread: only then did the post FORK it. Where a platform
-    // has no separate thread to open — Discord, and Telegram / Feishu DMs, whose post key IS the
-    // conversation ({@link threadKeyForPost}) — the message simply landed in it, and there is
-    // nothing to warn about.
+    // Same conversation AND a different thread: only then did the post FORK it. Discord guild
+    // roots are materialized as native threads before reaching this comparison. In continuous
+    // DMs whose post key IS the conversation ({@link threadKeyForPost}), the message simply
+    // landed in it and there is nothing to warn about.
     const isForkOf = (platform: string, channel: string, thread: string, scope?: string | null): boolean =>
       platform === req.targetPlatform &&
       channel === req.targetChannel &&
@@ -18691,9 +18691,9 @@ export class Daemon {
           // The posted anchor is both the thread root and the authoritative
           // transcript/read cursor. Keep the synthetic msgId as the durable turn id.
           // §6.8: the SESSION key must follow the platform's own conversation model
-          // (threadKeyForPost — Slack threads off the ts, Telegram replies resolve
-          // to `tg:<root>`, Discord conversations ARE the channel), or the anchored
-          // session and the replies underneath it mint different keys.
+          // (threadKeyForPost — Slack and Discord guild threads key off the post,
+          // Telegram replies resolve to `tg:<root>`, while supported DMs remain
+          // continuous), or the anchored session and its replies mint different keys.
           if (ts) msg = { ...msg, thread: threadKeyForPost(msg.platform, msg.channel, ts, msg.isDm), transcriptTs: ts }
         } catch (err) {
           this.log.warn(

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -2,6 +2,7 @@ import type { ToolDescriptor } from './tools.js'
 import type { MemoryProvider } from '../agents/memory-provider.js'
 import {
   rootPostNeedsThreadMaterialization,
+  rootPostThreadName,
   threadKeyForPost,
   threadKeyNeedsDmClassification
 } from '../platforms/thread-keys.js'
@@ -1115,11 +1116,7 @@ export async function executeTool(
       const mustMaterializeThread = !isDmTarget && rootPostNeedsThreadMaterialization(wantPlatform)
       const materializedThread =
         providerPostId !== undefined && mustMaterializeThread
-          ? await gw.createThread?.(
-              postChannel,
-              providerPostId,
-              body.replace(/\s+/g, ' ').trim().slice(0, 90) || 'Agent thread'
-            )
+          ? await gw.createThread?.(postChannel, providerPostId, rootPostThreadName(body))
           : undefined
       const canonicalPostThread =
         providerPostId === undefined
@@ -1133,7 +1130,7 @@ export async function executeTool(
       // this post back onto this thread, so it must be the same canonical key the session uses.
       deps.recordOutbound(ctx, postChannel, postedThread ?? canonicalPostThread, body, ts, targetId)
       post = { platform: wantPlatform, integrationId: targetId, channel: postChannel, thread: null, ts }
-      if (mustMaterializeThread && postedThread === undefined) {
+      if (providerPostId !== undefined && mustMaterializeThread && postedThread === undefined) {
         throw new Error(
           `sendMessage: posted root message ${ts}, but its required thread could not be created; no session was started`
         )

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -1,6 +1,10 @@
 import type { ToolDescriptor } from './tools.js'
 import type { MemoryProvider } from '../agents/memory-provider.js'
-import { threadKeyForPost } from '../platforms/thread-keys.js'
+import {
+  rootPostNeedsThreadMaterialization,
+  threadKeyForPost,
+  threadKeyNeedsDmClassification
+} from '../platforms/thread-keys.js'
 import {
   directMessagePlatformFor,
   directMessagePlatformList,
@@ -71,6 +75,9 @@ export interface MessageGateway {
    *  daemon can record it. `identity` carries the agent's stable id and optional
    *  visual identity; other platforms may ignore it. */
   postMessage(channel: string, text: string, threadTs?: string, identity?: SendIdentity): Promise<string | undefined>
+  /** Materialize a provider-native thread from a root message when that platform
+   *  requires one before the post can own a follow-up session (Discord). */
+  createThread?(channel: string, messageId: string, name: string): Promise<string | undefined>
   getChannelInfo(channel: string): Promise<{ id: string; name?: string; isIm?: boolean; isPrivate?: boolean }>
   listMembers(channel: string): Promise<{ id: string; name?: string; isBot?: boolean }[]>
   listChannels(): Promise<{ id: string; name?: string; isPrivate?: boolean }[]>
@@ -466,9 +473,9 @@ export interface OpsDeps {
     targetPlatform: string
     targetChannel: string
     /** The post's own session-thread key ({@link threadKeyForPost}). A conversation is only
-     *  FORKED when this differs from the thread that conversation lives on — on Discord and in
-     *  Telegram / Feishu DMs a root post maps back onto the continuous conversation, so it forks
-     *  nothing and the reader did receive it. */
+     *  FORKED when this differs from the thread that conversation lives on. Discord guild roots
+     *  are materialized as native threads; Telegram / Feishu / Discord DMs map back onto their
+     *  continuous conversation, so they fork nothing and the reader did receive the post. */
     targetThread: string
     targetIntegrationId?: string
   }) => { kind: 'parent'; sessionId: string } | { kind: 'self' } | undefined
@@ -1102,20 +1109,35 @@ export async function executeTool(
       // continuous conversation, and no id carries that — ask the platform, once, and only where
       // the answer can change the key. A failed lookup falls back to the non-DM conversation
       // rather than failing the send that already happened.
-      const isDmTarget =
-        wantPlatform === 'telegram' || wantPlatform === 'feishu'
-          ? ((await gw.getChannelInfo(postChannel).catch(() => undefined))?.isIm ?? false)
-          : false
-      postedThread =
+      const isDmTarget = threadKeyNeedsDmClassification(wantPlatform)
+        ? ((await gw.getChannelInfo(postChannel).catch(() => undefined))?.isIm ?? false)
+        : false
+      const mustMaterializeThread = !isDmTarget && rootPostNeedsThreadMaterialization(wantPlatform)
+      const materializedThread =
+        providerPostId !== undefined && mustMaterializeThread
+          ? await gw.createThread?.(
+              postChannel,
+              providerPostId,
+              body.replace(/\s+/g, ' ').trim().slice(0, 90) || 'Agent thread'
+            )
+          : undefined
+      const canonicalPostThread =
         providerPostId === undefined
           ? undefined
           : threadKeyForPost(wantPlatform, postChannel, providerPostId, isDmTarget)
+      postedThread =
+        providerPostId === undefined ? undefined : mustMaterializeThread ? materializedThread : canonicalPostThread
       // Record the post in the thread it BELONGS to — the one it just created for a root post,
       // not the caller's own thread (the daemon's fallback, which for a cross-channel post keys a
       // row to coords that match no session at all). It is also what resolves a later reply to
       // this post back onto this thread, so it must be the same canonical key the session uses.
-      deps.recordOutbound(ctx, postChannel, postedThread, body, ts, targetId)
+      deps.recordOutbound(ctx, postChannel, postedThread ?? canonicalPostThread, body, ts, targetId)
       post = { platform: wantPlatform, integrationId: targetId, channel: postChannel, thread: null, ts }
+      if (mustMaterializeThread && postedThread === undefined) {
+        throw new Error(
+          `sendMessage: posted root message ${ts}, but its required thread could not be created; no session was started`
+        )
+      }
       // session-concept case 2a: a root post with NO peer wake seeds a NEW session owned by
       // this agent, keyed by the post's own thread, origin = the current session. When there
       // IS a `toAgent`, the woken peer owns that thread instead (see (B)) — so skip the
@@ -1144,10 +1166,10 @@ export async function executeTool(
         //
         // Gated twice, because both claims can be false. `seeded` — the daemon declines outright
         // at the hop limit, and nothing may then say a context opened. And `targetThread`, which
-        // the daemon compares against the conversation's own thread: on Discord and in Telegram /
-        // Feishu DMs a "root" post has no separate thread to land in ({@link threadKeyForPost}
-        // maps it back onto the continuous conversation), so it forks nothing and the message DID
-        // reach the reader — saying otherwise would talk an agent into sending twice.
+        // the daemon compares against the conversation's own thread: in Telegram / Feishu /
+        // Discord DMs a "root" post maps back onto the continuous conversation, so it forks
+        // nothing and the message DID reach the reader — saying otherwise would talk an agent
+        // into sending twice. Discord guild posts have already materialized a native thread.
         const relation =
           seeded && postedThread !== undefined
             ? deps.rootPostRelation?.({

--- a/packages/daemon/src/platforms/discord/thread-promotion.ts
+++ b/packages/daemon/src/platforms/discord/thread-promotion.ts
@@ -10,14 +10,14 @@
  * `discordTopLevel` named twin retired with the S1b cleanup.
  */
 import type { DiscordConnection } from '../../discord/connection.js'
+import { rootPostThreadName } from '../thread-keys.js'
 import type { ThreadPromotion, ThreadPromotionHost, ThreadPromotionMessage } from '../thread-promotion.js'
 
 /** Name for the opened thread: the first line of the prompt, collapsed to one
  *  line and clamped under Discord's 100-char thread-name cap (createThread also
  *  clamps). Empty prompts (e.g. attachment-only) get a default. */
 export function discordThreadName(text: string): string {
-  const oneLine = text.replace(/\s+/g, ' ').trim().slice(0, 90)
-  return oneLine || 'Agent thread'
+  return rootPostThreadName(text)
 }
 
 export const discordThreadPromotion: ThreadPromotion<ThreadPromotionMessage> = {

--- a/packages/daemon/src/platforms/thread-keys.ts
+++ b/packages/daemon/src/platforms/thread-keys.ts
@@ -62,6 +62,12 @@ export function rootPostNeedsThreadMaterialization(platform: string): boolean {
   return STRATEGIES.get(platform)?.materializeRootThread ?? false
 }
 
+/** Provider-safe title for a native thread opened from a root post. */
+export function rootPostThreadName(text: string): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim().slice(0, 90)
+  return oneLine || 'Agent thread'
+}
+
 /** The session-thread key for a message this daemon just posted at a channel
  *  ROOT. Total by construction: an unregistered platform threads off the post's
  *  own ts, the Slack/core rule. */

--- a/packages/daemon/src/platforms/thread-keys.ts
+++ b/packages/daemon/src/platforms/thread-keys.ts
@@ -14,8 +14,10 @@
  *    numeric forum-TOPIC namespace. (A root post into a forum lands in General,
  *    whose messages carry no `is_topic_message`, so replies there resolve
  *    through the same `tg:` ladder rather than to a topic id.)
- *  - Discord conversations are the CHANNEL — every inbound message there keys
- *    the channel id, so a post cannot open a thread of its own.
+ *  - A Discord guild root post keys on its own message id. If a native thread is
+ *    opened from that post, Discord gives the thread channel the same id, so the
+ *    first in-thread reply reaches the initialized session. Discord DMs remain
+ *    one continuous conversation keyed by their channel id.
  *  - A DM is one continuous conversation, keyed `dm` on Telegram and by the
  *    chat on Feishu. A post into one joins it; it never starts a second.
  *
@@ -31,21 +33,38 @@
  * registered per platform rather than inferred.
  */
 
-type ThreadKeyStrategy = (channel: string, ts: string, isDm: boolean) => string
+interface ThreadKeyStrategy {
+  key(channel: string, ts: string, isDm: boolean): string
+  /** Whether callers must classify a root target as DM before deriving its key. */
+  dmSensitive: boolean
+  /** Whether a non-DM root post must be turned into a native thread before its
+   *  session can be initialized. */
+  materializeRootThread?: boolean
+}
 
 const STRATEGIES = new Map<string, ThreadKeyStrategy>([
-  // Conversations ARE the channel; a post cannot open a thread of its own.
-  ['discord', (channel) => channel],
+  // Guild threads use the starter message id; DMs are continuous.
+  ['discord', { key: (channel, ts, isDm) => (isDm ? channel : ts), dmSensitive: true, materializeRootThread: true }],
   // Reply-based threading: numeric message ids enter the `tg:` reply-root
   // namespace; DMs are one continuous conversation.
-  ['telegram', (_channel, ts, isDm) => (isDm ? 'dm' : /^\d+$/.test(ts) ? `tg:${ts}` : ts)],
+  ['telegram', { key: (_channel, ts, isDm) => (isDm ? 'dm' : /^\d+$/.test(ts) ? `tg:${ts}` : ts), dmSensitive: true }],
   // Group chats thread off the post; a DM is keyed by the chat itself.
-  ['feishu', (channel, ts, isDm) => (isDm ? channel : ts)]
+  ['feishu', { key: (channel, ts, isDm) => (isDm ? channel : ts), dmSensitive: true }]
 ])
+
+/** Whether the platform's root-post session key depends on DM classification. */
+export function threadKeyNeedsDmClassification(platform: string): boolean {
+  return STRATEGIES.get(platform)?.dmSensitive ?? false
+}
+
+/** Whether a non-DM root post needs a provider thread before it can own a session. */
+export function rootPostNeedsThreadMaterialization(platform: string): boolean {
+  return STRATEGIES.get(platform)?.materializeRootThread ?? false
+}
 
 /** The session-thread key for a message this daemon just posted at a channel
  *  ROOT. Total by construction: an unregistered platform threads off the post's
  *  own ts, the Slack/core rule. */
 export function threadKeyForPost(platform: string, channel: string, ts: string, isDm = false): string {
-  return STRATEGIES.get(platform)?.(channel, ts, isDm) ?? ts
+  return STRATEGIES.get(platform)?.key(channel, ts, isDm) ?? ts
 }

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -643,9 +643,8 @@ describe('Daemon session lifecycle (#118)', () => {
   }, 15_000)
 
   it('§6.8: a discord DM anchored fire classifies as a private DM session', async () => {
-    // Discord thread keys are DM-insensitive (the conversation IS the channel), but
-    // `conversationKind` and the daemon-local capture gate are not: a DM fire that
-    // reports isDm:false is stored as a non-private CHANNEL session.
+    // A Discord DM is one continuous conversation keyed by its channel. The same
+    // classification also drives `conversationKind` and the private-capture gate.
     const host = quietHost()
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
     await daemon.start()
@@ -683,6 +682,86 @@ describe('Daemon session lifecycle (#118)', () => {
     expect(rec?.conversationKind).toBe('dm')
     // The private-capture gate follows the same bit.
     expect((daemon as any).store.isCaptureExcluded(rec?.acpSessionId)).toBe(true)
+    await daemon.stop()
+  }, 15_000)
+
+  it('§6.8: a discord guild anchored fire materializes its native thread before dispatch', async () => {
+    const host = quietHost()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    await daemon.start()
+    makeRoutable(daemon)
+    const postMessage = vi.fn(async () => 'msg-1')
+    const getChannelInfo = vi.fn(async () => ({ id: 'C-1', isIm: false }))
+    const createThread = vi.fn(async () => 'msg-1')
+    ;(daemon as any).connByIntegration.delete('int-a')
+    ;(daemon as any).dcConnByIntegration.set('int-a', {
+      postMessage,
+      getChannelInfo,
+      createThread,
+      postChrome: vi.fn(async () => {}),
+      updateMessage: vi.fn(async () => {})
+    })
+
+    await (daemon as any).fireTrigger(
+      'bot-a',
+      {
+        ...dm('ignored', 'scheduled', 'cron:cron-dc-guild:trace-1'),
+        msgId: 'cron:cron-dc-guild:trace-1',
+        traceId: 'trace-1',
+        source: 'cron',
+        trigger: 'cron',
+        platform: 'discord',
+        channel: 'C-1',
+        isDm: false
+      },
+      { channel: 'C-1', integrationId: 'int-a' },
+      '⏰ scheduled',
+      'cron "cron-dc-guild"'
+    )
+
+    expect(createThread).toHaveBeenCalledWith('C-1', 'msg-1', '⏰ scheduled')
+    const key = sessionKey('discord', 'C-1', 'msg-1', 'bot-a', TRANSPORT_SCOPE)
+    expect((daemon as any).store.getSession(key)).toBeTruthy()
+    await daemon.stop()
+  }, 15_000)
+
+  it('§6.8: a discord guild anchored fire starts no session when thread creation fails', async () => {
+    const host = quietHost()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    await daemon.start()
+    makeRoutable(daemon)
+    const createThread = vi.fn(async () => undefined)
+    ;(daemon as any).connByIntegration.delete('int-a')
+    ;(daemon as any).dcConnByIntegration.set('int-a', {
+      postMessage: vi.fn(async () => 'msg-1'),
+      getChannelInfo: vi.fn(async () => ({ id: 'C-1', isIm: false })),
+      createThread,
+      postChrome: vi.fn(async () => {}),
+      updateMessage: vi.fn(async () => {})
+    })
+
+    const result = await (daemon as any).fireTrigger(
+      'bot-a',
+      {
+        ...dm('ignored', 'scheduled', 'cron:cron-dc-failed:trace-1'),
+        msgId: 'cron:cron-dc-failed:trace-1',
+        traceId: 'trace-1',
+        source: 'cron',
+        trigger: 'cron',
+        platform: 'discord',
+        channel: 'C-1',
+        isDm: false
+      },
+      { channel: 'C-1', integrationId: 'int-a' },
+      '⏰ scheduled',
+      'cron "cron-dc-failed"'
+    )
+
+    expect(result).toBeNull()
+    expect(
+      (daemon as any).store.getSession(sessionKey('discord', 'C-1', 'msg-1', 'bot-a', TRANSPORT_SCOPE))
+    ).toBeUndefined()
+    expect(host.prompt).not.toHaveBeenCalled()
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -2163,7 +2163,7 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
     await daemon.stop()
   })
 
-  it('says nothing where a root post cannot fork: Discord, and Telegram / Feishu DMs', async () => {
+  it('says nothing where a root post cannot fork: Telegram / Feishu DMs', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
     // These platforms have no separate thread for a root post to open: threadKeyForPost maps it
@@ -2171,7 +2171,6 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
     // would tell an agent its answer went nowhere when the reader already has it — and talk it
     // into sending a second copy.
     const continuous = [
-      { platform: 'discord', channel: 'D42', thread: 'D42' },
       { platform: 'telegram', channel: '777', thread: 'dm' },
       { platform: 'feishu', channel: 'oc_42', thread: 'oc_42' }
     ]

--- a/packages/daemon/test/discord-normalize.test.ts
+++ b/packages/daemon/test/discord-normalize.test.ts
@@ -28,7 +28,7 @@ const base: DiscordMessageLike = {
 }
 
 describe('normalizeDiscordMessage', () => {
-  it('maps a top-level guild message keyed on the channel id, flagged for auto-threading', () => {
+  it('maps a top-level guild message without thread affinity, flagged for auto-threading', () => {
     const m = normalizeDiscordMessage(base, { traceId: 't1' })
     expect(m).toMatchObject({
       msgId: 'discord:C777:111',
@@ -42,7 +42,7 @@ describe('normalizeDiscordMessage', () => {
       isDm: false
     })
     // Before promotion there is no separate thread id yet.
-    expect(m.thread).toBe('C777')
+    expect(m.thread).toBeUndefined()
     // §6.5 emission flip: the generic coordinate only — discordTopLevel retired.
     expect(m.promoteToThread).toBe(true)
     expect(m.discordTopLevel).toBeUndefined()
@@ -62,6 +62,7 @@ describe('normalizeDiscordMessage', () => {
   it('flags a non-guild message as a DM and does not auto-thread it', () => {
     const m = normalizeDiscordMessage({ ...base, inGuild: false }, { traceId: 't' })
     expect(m.isDm).toBe(true)
+    expect(m.thread).toBe('C777')
     expect(m.promoteToThread).toBeUndefined()
   })
 

--- a/packages/daemon/test/ingress-coordinate-strategies.test.ts
+++ b/packages/daemon/test/ingress-coordinate-strategies.test.ts
@@ -9,8 +9,10 @@ describe('outbound thread keys (threadKeyForPost)', () => {
   it('keeps each platform aligned with its inbound canonicalization', () => {
     // Slack (and core): the post's own ts IS the thread segment.
     expect(threadKeyForPost('slack', 'C1', '1700.1')).toBe('1700.1')
-    // Discord: conversations are the channel; a post cannot open a thread.
-    expect(threadKeyForPost('discord', 'chan9', '999')).toBe('chan9')
+    // Discord guild: the starter message id becomes the native thread id.
+    expect(threadKeyForPost('discord', 'chan9', '999')).toBe('999')
+    // Discord DM: one continuous conversation keyed by the channel id.
+    expect(threadKeyForPost('discord', 'dm9', '999', true)).toBe('dm9')
     // Telegram: numeric ids enter the tg: reply-root namespace…
     expect(threadKeyForPost('telegram', '-100', '42')).toBe('tg:42')
     // …non-numeric anchors (already-canonical keys) pass through…

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -269,18 +269,34 @@ describe('executeTool: sendMessage (channel post)', () => {
       expect(slack.spawns[0]).toMatchObject({ thread: 'ts-123', postTs: 'ts-123' })
     })
 
-    it('keys a Discord post by its channel, which is what a Discord conversation is', async () => {
-      // Every inbound Discord message keys the channel id (discord-message.ts), so a post there
-      // cannot open a thread of its own — keying it by the message id made a session unreachable.
-      const discord = tgDeps({}, { postMessage: vi.fn(async () => '900') })
+    it('keys a Discord guild root post by its message id', async () => {
+      // A native Discord thread opened from this post receives the same id as its
+      // starter message, so later in-thread replies meet this initialized session.
+      const createThread = vi.fn(async () => '900')
+      const discord = tgDeps({}, { postMessage: vi.fn(async () => '900'), createThread })
       await executeTool(
         withIntegration('discord', 'int-dc'),
         'sendMessage',
         { platform: 'discord', channel: 'C42', message: 'hi' },
         discord.d
       )
-      expect(discord.spawns[0]).toMatchObject({ thread: 'C42', postTs: '900' })
-      expect(discord.recorded[0]).toMatchObject({ thread: 'C42', ts: '900' })
+      expect(discord.spawns[0]).toMatchObject({ thread: '900', postTs: '900' })
+      expect(discord.recorded[0]).toMatchObject({ thread: '900', ts: '900' })
+      expect(createThread).toHaveBeenCalledWith('C42', '900', 'hi')
+    })
+
+    it('does not initialize a Discord root session when its native thread cannot be created', async () => {
+      const discord = tgDeps({}, { postMessage: vi.fn(async () => '900'), createThread: vi.fn(async () => undefined) })
+      await expect(
+        executeTool(
+          withIntegration('discord', 'int-dc'),
+          'sendMessage',
+          { platform: 'discord', channel: 'C42', message: 'hi' },
+          discord.d
+        )
+      ).rejects.toThrow(/required thread could not be created/)
+      expect(discord.spawns).toHaveLength(0)
+      expect(discord.recorded[0]).toMatchObject({ thread: '900', ts: '900' })
     })
 
     it('joins a DM instead of forking it, on each platform that keeps DMs continuous', async () => {
@@ -299,6 +315,17 @@ describe('executeTool: sendMessage (channel post)', () => {
         feishuDm.d
       )
       expect(feishuDm.spawns[0]).toMatchObject({ thread: 'oc_42', postTs: '172' })
+
+      const createThread = vi.fn(async () => '900')
+      const discordDm = tgDeps({}, { ...asDm, postMessage: vi.fn(async () => '900'), createThread })
+      await executeTool(
+        withIntegration('discord', 'int-dc'),
+        'sendMessage',
+        { platform: 'discord', channel: 'D42', message: 'hi' },
+        discordDm.d
+      )
+      expect(discordDm.spawns[0]).toMatchObject({ thread: 'D42', postTs: '900' })
+      expect(createThread).not.toHaveBeenCalled()
 
       // A Feishu GROUP threads off the message, like Slack.
       const feishuGroup = tgDeps()

--- a/packages/daemon/test/route-rules.test.ts
+++ b/packages/daemon/test/route-rules.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mentionedAgents, participantAgents, routeRules } from '../src/router/routing-table.js'
 import { rulesFromAgent, resolveAgentIntegration, type RoutingRule } from '../src/router/routing-rule.js'
 import type { NormalizedMessage } from '../src/messages/normalized.js'
@@ -118,6 +118,14 @@ describe('routeRules ladder', () => {
     const rules = [rule({ agentId: 'owner', match: { kind: 'auto' }, scope: { channel: 'C1' } })]
     const r = routeRules(msg({ thread: 'T1' }), rules, (c, t) => (c === 'C1' && t === 'T1' ? 'owner' : null))
     expect(r?.agentId).toBe('owner')
+  })
+
+  it('does not let a Discord channel-root session claim unrelated channel messages', () => {
+    const rules = [rule({ agentId: 'owner', botUserId: 'B9', match: { kind: 'mention' }, scope: { channel: 'C1' } })]
+    const threadOwner = vi.fn(() => 'owner')
+
+    expect(routeRules(msg({ platform: 'discord', thread: undefined }), rules, threadOwner)).toBeNull()
+    expect(threadOwner).not.toHaveBeenCalled()
   })
 
   it('kind precedence: mention > dm > keyword > auto within a layer', () => {

--- a/packages/message/src/discord-message.ts
+++ b/packages/message/src/discord-message.ts
@@ -94,10 +94,13 @@ export function normalizeDiscordMessage(
     platform: 'discord',
     channel,
     ...(message.url ? { threadUrl: message.url } : {}),
-    // For an in-thread message `message.channelId` is the Discord thread channel id.
-    // For a top-level message/DM this temporarily equals `channel`; successful
-    // top-level promotion replaces it with the newly-created thread id.
-    thread: message.channelId,
+    // An actual Discord thread carries its concrete channel id. A DM is one
+    // continuous conversation, so its channel id is also its session thread.
+    // A guild channel root has NO thread yet: using the parent channel id here
+    // would make one root session claim every later message in that channel via
+    // thread affinity. Successful top-level promotion fills this with the newly
+    // created thread id before dispatch.
+    ...(isDm || message.isThread ? { thread: message.channelId } : {}),
     sender: {
       id: message.authorId,
       isBot: message.authorIsBot,


### PR DESCRIPTION
## Summary

- normalize Discord guild channel-root messages without a `thread` coordinate, preventing channel-wide thread affinity
- immediately create a native Discord thread after an agent publishes a guild root message
- initialize the follow-up session only after thread creation succeeds, using `{ channel: parentChannelId, thread: createdThreadId }`
- keep Discord DMs as continuous channel-keyed conversations
- document the invariant and add regression coverage for normalization, routing, root posting, thread creation failure, and DMs

## Root cause

PR #683 correctly changed Discord's normalized `channel` to the configurable parent channel, but top-level guild messages still set `thread` to that same channel ID. Once an agent-created root session existed at `{ channel: C, thread: C }`, every later root message in `C` matched the session through thread affinity, causing the agent to respond across the channel.

The outbound root-post path also initialized a Discord session without materializing a native thread, so the session boundary was the parent channel rather than a concrete Discord thread.

## Behavior after this fix

- inbound guild root: `{ channel: C, thread: undefined }`
- inbound native thread: `{ channel: C, thread: T }`
- agent guild root post: post root → create native thread `T` → initialize `{ channel: C, thread: T }`
- Discord DM: `{ channel: D, thread: D }`
- thread creation failure: the root remains visible, but no unreachable or channel-wide session is initialized

## Validation

- message package: 31 tests passed
- targeted daemon Discord/routing/root-session suite: 281 tests passed
- full repository typecheck passed
- ESLint, Prettier, and `git diff --check` passed