### PR TITLE
fix(setup): adopt existing provider configuration

### DIFF
--- a/packages/control-plane/src/persistence/deployment-config.ts
+++ b/packages/control-plane/src/persistence/deployment-config.ts
@@ -354,8 +354,6 @@ export function deploymentSecretsRequiringRefresh(
   const githubClientChanged =
     next.github !== null && next.github.clientId !== null && previous?.github?.clientId !== next.github.clientId
   const githubWebhookEnabled = next.github !== null && next.github.webhookEnabled !== false
-  const githubWebhookActivated =
-    next.github !== null && githubWebhookEnabled && previous?.github?.webhookEnabled === false
   const slackIdentityChanged =
     next.slack && (previous?.slack?.appId !== next.slack.appId || previous?.slack?.clientId !== next.slack.clientId)
   const feishuIdentityChanged = next.feishu && previous?.feishu?.loginAppId !== next.feishu.loginAppId
@@ -369,9 +367,7 @@ export function deploymentSecretsRequiringRefresh(
     next.logto?.googleConnector && previous?.logto?.googleConnector?.clientId !== next.logto.googleConnector.clientId
   return [
     ...(githubAppChanged ? (['github.privateKeyB64'] as const) : []),
-    ...(next.github && githubWebhookEnabled && (githubAppChanged || githubWebhookActivated)
-      ? (['github.webhookSecret'] as const)
-      : []),
+    ...(next.github && githubWebhookEnabled && githubAppChanged ? (['github.webhookSecret'] as const) : []),
     ...(githubClientChanged ? (['github.clientSecret'] as const) : []),
     ...(slackIdentityChanged ? (['slack.clientSecret', 'slack.signingSecret'] as const) : []),
     ...(feishuIdentityChanged ? (['feishu.loginAppSecret'] as const) : []),

--- a/packages/control-plane/src/persistence/deployment-config.ts
+++ b/packages/control-plane/src/persistence/deployment-config.ts
@@ -118,7 +118,7 @@ export const DeploymentConfigValuesV1Schema = z
         appId: z.number().int().positive(),
         slug: z.string().trim().min(1),
         clientId: z.string().trim().min(1).nullable(),
-        /** Provider settings last created or explicitly confirmed by setup. */
+        /** Provider URL settings submitted by setup during GitHub App Manifest creation. Never live verification. */
         configuredUrls: GithubAppConfiguredUrlsSchema.optional()
       })
       .nullable(),

--- a/packages/control-plane/src/persistence/deployment-config.ts
+++ b/packages/control-plane/src/persistence/deployment-config.ts
@@ -118,6 +118,8 @@ export const DeploymentConfigValuesV1Schema = z
         appId: z.number().int().positive(),
         slug: z.string().trim().min(1),
         clientId: z.string().trim().min(1).nullable(),
+        /** Whether Relay should accept GitHub webhook delivery for this App. Omitted means enabled. */
+        webhookEnabled: z.boolean().optional(),
         /** Provider URL settings submitted by setup during GitHub App Manifest creation. Never live verification. */
         configuredUrls: GithubAppConfiguredUrlsSchema.optional()
       })
@@ -351,9 +353,9 @@ export function deploymentSecretsRequiringRefresh(
   const githubAppChanged = next.github && previous?.github?.appId !== next.github.appId
   const githubClientChanged =
     next.github !== null && next.github.clientId !== null && previous?.github?.clientId !== next.github.clientId
-  const githubWebhookEnabled = next.github?.configuredUrls?.webhookActive !== false
+  const githubWebhookEnabled = next.github !== null && next.github.webhookEnabled !== false
   const githubWebhookActivated =
-    next.github !== null && githubWebhookEnabled && previous?.github?.configuredUrls?.webhookActive === false
+    next.github !== null && githubWebhookEnabled && previous?.github?.webhookEnabled === false
   const slackIdentityChanged =
     next.slack && (previous?.slack?.appId !== next.slack.appId || previous?.slack?.clientId !== next.slack.clientId)
   const feishuIdentityChanged = next.feishu && previous?.feishu?.loginAppId !== next.feishu.loginAppId
@@ -383,9 +385,7 @@ export function deploymentSecretsRequiringRefresh(
 function requiredSecrets(values: DeploymentConfigValuesV1): DeploymentSecretKey[] {
   return [
     ...(values.github ? (['github.privateKeyB64'] as const) : []),
-    ...(values.github && values.github.configuredUrls?.webhookActive !== false
-      ? (['github.webhookSecret'] as const)
-      : []),
+    ...(values.github && values.github.webhookEnabled !== false ? (['github.webhookSecret'] as const) : []),
     ...(values.slack ? (['slack.clientSecret', 'slack.signingSecret'] as const) : []),
     ...(values.feishu ? (['feishu.loginAppSecret'] as const) : []),
     ...(values.lark ? (['lark.loginAppSecret'] as const) : []),

--- a/packages/control-plane/src/persistence/deployment-config.ts
+++ b/packages/control-plane/src/persistence/deployment-config.ts
@@ -101,7 +101,8 @@ const SlackAppConfiguredUrlsSchema = z.strictObject({
   oauthRedirectUrl: SecureHttpUrlSchema,
   eventsUrl: SecureHttpUrlSchema,
   interactionsUrl: SecureHttpUrlSchema,
-  loginRedirectUrl: SecureHttpUrlSchema.optional()
+  loginRedirectUrl: SecureHttpUrlSchema.optional(),
+  socialLinkRedirectUrl: SecureHttpUrlSchema.optional()
 })
 
 const RegionalLoginAppSchema = z.strictObject({

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -640,7 +640,8 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         ? expected.slack
           ? objectDiff(slack.configuredUrls, expected.slack, {
               oauthRedirectUrl: 'OAuth redirect URL', eventsUrl: 'Events request URL',
-              interactionsUrl: 'Interactivity request URL', loginRedirectUrl: 'Logto redirect URL'
+              interactionsUrl: 'Interactivity request URL', loginRedirectUrl: 'Logto redirect URL',
+              socialLinkRedirectUrl: 'Account linking redirect URL'
             })
           : [{ field: 'Startup public URLs', current: 'Unavailable', expected: 'HTTPS Web, API, and ingress URLs' }]
         : [];
@@ -1104,10 +1105,10 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       el('github-settings').hidden = false;
       const confirmationFields = result.unverified || [];
       el('confirm-github').hidden = ![...result.missing, ...confirmationFields].some((field) => field === 'callback_urls' || field === 'setup_url' || field === 'webhook_active');
-      const label = result.missing.length ? 'Update required' : 'Not verified';
+      const label = result.missing.length ? 'Update required' : "Can't verify automatically";
       showDiff('github-drift', result.diff || [], label);
       match('github-match', result.status === 'pass' ? 'pass' : 'warn', result.status === 'pass' ? 'Matches' : label);
-      message(result.status === 'pass' ? 'GitHub App matches the expected integration manifest.' : result.missing.length ? 'GitHub App settings need an update.' : 'Confirm the callback, setup, and webhook-active settings in GitHub.', result.status === 'fail');
+      message(result.status === 'pass' ? 'GitHub App matches the expected integration manifest.' : result.missing.length ? 'GitHub App settings need an update.' : "GitHub can't expose callback, setup, or webhook-active settings through its API; check them in GitHub.", result.status === 'fail');
     }
 
     async function connectGithubLogin() {
@@ -1263,6 +1264,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
 
     async function checkLogto() {
       const report = await json(await fetch(api + '/check/logto', { headers: bearer() }));
+      await load();
       const failures = report.findings.filter((finding) => finding.status !== 'pass');
       el('logto-status').textContent = failures.length === 0
         ? 'SPA redirects, CORS, connectors, and social-only sign-in match.'

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -203,6 +203,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <dt>App ID</dt><dd class="value-line"><code id="github-app-id">Not configured</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
           <dt>App slug</dt><dd class="value-line"><code id="github-app-slug">Not configured</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
           <dt>Client ID</dt><dd class="value-line"><code id="github-client-id">Not configured</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
+          <dt>Webhook delivery</dt><dd class="value-line"><code id="github-webhook-enabled">Not configured</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
           <dt>Logto connector ID</dt><dd class="value-line"><code id="github-logto-connector-id">Not enabled</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
           <dt>Client secret</dt><dd class="secret-line"><span id="github-client-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="github.clientSecret" data-secret-display="github-client-secret-display">Edit</button></dd>
           <dt>Private key</dt><dd class="secret-line"><span id="github-private-key-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="github.privateKeyB64" data-secret-display="github-private-key-display">Edit</button></dd>
@@ -216,6 +217,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <label class="field">App ID<input id="github-edit-app-id" inputmode="numeric" autocomplete="off"></label>
           <label class="field">App slug<input id="github-edit-slug" autocomplete="off"></label>
           <label class="field">Client ID<input id="github-edit-client-id" autocomplete="off"></label>
+          <label><input id="github-edit-webhook-enabled" type="checkbox"> Enable Relay webhook delivery</label>
           <label id="github-edit-connector-id-field" class="field" hidden>Logto connector ID<input id="github-edit-connector-id" autocomplete="off"></label>
           <label class="field">New client secret<input id="github-edit-client-secret" type="password" autocomplete="new-password" placeholder="Required when App or Client ID changes"></label>
           <label class="field">New private key (base64)<textarea id="github-edit-private-key" autocomplete="off" placeholder="Required when App ID changes"></textarea></label>
@@ -590,10 +592,11 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
 
       const github = values.github;
       const webhookStored = byKey.get('github.webhookSecret') && byKey.get('github.webhookSecret').configured;
-      const webhookInactive = github && github.configuredUrls && github.configuredUrls.webhookActive === false;
+      const webhookInactive = github && github.webhookEnabled === false;
       text('github-app-id', github && github.appId);
       text('github-app-slug', github && github.slug);
       text('github-client-id', github && github.clientId);
+      text('github-webhook-enabled', github && (github.webhookEnabled === false ? 'Disabled' : 'Enabled'));
       text('github-logto-connector-id', values.logto && values.logto.githubConnector && values.logto.githubConnector.connectorId);
       el('github-edit-controls').hidden = true;
       showIdentityEditors('github', Boolean(github));
@@ -603,7 +606,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       secretText('github-logto-secret-display', byKey, 'logto.githubConnectorClientSecret', Boolean(values.logto && values.logto.githubConnector));
       el('github-status').textContent = github
         ? github.slug + ' is configured. Webhook secret: ' + (webhookStored ? 'stored' : webhookInactive ? 'not required yet' : 'missing') + '.' +
-          (webhookInactive ? ' Webhook delivery is not registered until HTTPS ingress is configured.' : '')
+          (webhookInactive ? ' Relay webhook delivery is disabled.' : '')
         : 'Creates the complete App used for repository installation, webhooks, and optional GitHub sign-in.';
       const githubSubmitted = Boolean(github && github.configuredUrls);
       const githubDrift = github
@@ -752,6 +755,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         el('github-edit-app-id').value = String(github.appId);
         el('github-edit-slug').value = github.slug;
         el('github-edit-client-id').value = github.clientId || '';
+        el('github-edit-webhook-enabled').checked = github.webhookEnabled !== false;
         const githubConnector = values.logto && values.logto.githubConnector;
         el('github-edit-connector-id').value = githubConnector ? githubConnector.connectorId : '';
         el('github-edit-connector-id-field').hidden = !githubConnector;
@@ -853,15 +857,18 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const clientId = requiredInput('github-edit-client-id', 'the GitHub Client ID');
       const appChanged = appId !== previous.appId;
       const clientChanged = clientId !== previous.clientId;
+      const webhookEnabled = el('github-edit-webhook-enabled').checked;
+      const webhookEnabling = webhookEnabled && previous.webhookEnabled === false;
       const connectorReused = githubConnectorUsesDeployment(values);
       const connectorId = connectorReused ? requiredInput('github-edit-connector-id', 'the Logto connector ID') : null;
       const clientSecret = el('github-edit-client-secret').value;
       const privateKey = el('github-edit-private-key').value.trim();
       const webhookSecret = el('github-edit-webhook-secret').value;
       const connectorSecret = el('github-edit-logto-secret').value;
+      const webhookSecretStored = currentStatus.secrets.some((secret) => secret.key === 'github.webhookSecret' && secret.configured);
       if ((appChanged || clientChanged) && !clientSecret) throw new Error('Enter the new GitHub client secret');
       if (appChanged && !privateKey) throw new Error('Enter the new GitHub private key as base64');
-      if (appChanged && previous.configuredUrls?.webhookActive !== false && !webhookSecret) throw new Error('Enter the new GitHub webhook secret');
+      if (webhookEnabled && ((appChanged && !webhookSecret) || (webhookEnabling && !webhookSecret && !webhookSecretStored))) throw new Error('Enter the new GitHub webhook secret');
       if (connectorReused && (appChanged || clientChanged) && !connectorSecret) throw new Error('Enter the new Logto connector client secret');
       const secrets = {};
       if (clientSecret) secrets['github.clientSecret'] = clientSecret;
@@ -874,7 +881,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       await replaceConfiguration(
         {
           ...values,
-          github: { ...previous, appId, slug, clientId, ...(appChanged ? { configuredUrls: undefined } : {}) },
+          github: { ...previous, appId, slug, clientId, webhookEnabled, ...(appChanged ? { configuredUrls: undefined } : {}) },
           ...(nextLogto ? { logto: nextLogto } : {})
         },
         Object.keys(secrets).length ? secrets : undefined,

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -234,7 +234,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <button id="create-github">Create GitHub App</button>
           <button id="connect-github-login" hidden>Use for Logto sign-in</button>
           <button id="check-github" hidden>Check match</button>
-          <button id="confirm-github" hidden>I updated callback/setup URLs</button>
           <button id="clear-github" class="danger" hidden>Clear configuration</button>
           <a id="github-settings" class="button" target="_blank" rel="noopener" hidden>Open GitHub settings</a>
         </div>
@@ -606,22 +605,22 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         ? github.slug + ' is configured. Webhook secret: ' + (webhookStored ? 'stored' : webhookInactive ? 'not required yet' : 'missing') + '.' +
           (webhookInactive ? ' Webhook delivery is not registered until HTTPS ingress is configured.' : '')
         : 'Creates the complete App used for repository installation, webhooks, and optional GitHub sign-in.';
+      const githubSubmitted = Boolean(github && github.configuredUrls);
       const githubDrift = github
         ? expected.github
-          ? objectDiff(github.configuredUrls, expected.github, {
+          ? githubSubmitted ? objectDiff(github.configuredUrls, expected.github, {
               externalUrl: 'Homepage URL', setupUrl: 'Setup URL', webhookUrl: 'Webhook URL',
               webhookActive: 'Webhook active', callbackUrls: 'Callback URLs'
-            })
+            }) : []
           : [{ field: 'Startup public URLs', current: 'Unavailable', expected: 'Valid Web, API, and ingress URLs' }]
         : [];
-      const githubVerified = Boolean(github && github.configuredUrls);
-      match('github-match', !github ? '' : !githubVerified || githubDrift.length ? 'warn' : '', !github ? 'Not configured' : !githubVerified ? 'Not verified' : githubDrift.length ? 'Update required' : 'Ready to check');
+      match('github-match', !github ? '' : githubDrift.length ? 'warn' : '', !github ? 'Not configured' : githubDrift.length ? 'Expected URLs changed' : 'Ready to check');
       el('github-create-controls').hidden = Boolean(github);
       el('create-github').hidden = Boolean(github);
       el('clear-github').hidden = !github;
       el('connect-github-login').hidden = !github || !values.logto || Boolean(values.logto.githubConnector);
       el('check-github').hidden = !github;
-      if (github) showDiff('github-drift', githubDrift, githubVerified ? 'Update required' : 'Not verified');
+      if (github) showDiff('github-drift', githubDrift, 'Expected URLs changed since App creation');
       else el('github-drift').hidden = true;
 
       const slack = values.slack;
@@ -1103,8 +1102,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const result = await json(await fetch(api + '/check/github', { headers: bearer() }));
       el('github-settings').href = result.settingsUrl;
       el('github-settings').hidden = false;
-      const confirmationFields = result.unverified || [];
-      el('confirm-github').hidden = ![...result.missing, ...confirmationFields].some((field) => field === 'callback_urls' || field === 'setup_url' || field === 'webhook_active');
       const label = result.missing.length ? 'Update required' : "Can't verify automatically";
       showDiff('github-drift', result.diff || [], label);
       match('github-match', result.status === 'pass' ? 'pass' : 'warn', result.status === 'pass' ? 'Matches' : label);
@@ -1146,13 +1143,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       await reconcileLogto();
       await load();
       message('The deployment Slack App is now also used for Logto sign-in.');
-    }
-
-    async function confirmGithub() {
-      await json(await fetch(api + '/confirm/github-urls', { method: 'POST', headers: bearer() }));
-      el('confirm-github').hidden = true;
-      await load();
-      await checkGithub();
     }
 
     async function checkSlack() {
@@ -1438,7 +1428,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
     el('clear-github').onclick = () => clearProvider('github').catch((error) => message(error.message, true));
     el('connect-github-login').onclick = () => connectGithubLogin().catch((error) => message(error.message, true));
     el('check-github').onclick = () => checkGithub().catch((error) => message(error.message, true));
-    el('confirm-github').onclick = () => confirmGithub().catch((error) => message(error.message, true));
     el('create-slack').onclick = () => createSlack('slack').catch((error) => message(error.message, true));
     el('connect-slack-login').onclick = () => connectSlackLogin().catch((error) => message(error.message, true));
     el('save-slack-configuration').onclick = () => saveSlackConfiguration().catch((error) => message(error.message, true));

--- a/packages/setup/src/admin/logto-management.ts
+++ b/packages/setup/src/admin/logto-management.ts
@@ -206,6 +206,21 @@ function connectorMatches(connector: LogtoConnector, desired: ReturnType<typeof 
   )
 }
 
+function selectConnector(
+  connectors: readonly LogtoConnector[],
+  target: string,
+  preferredId?: string
+): LogtoConnector | undefined {
+  const matches = connectors.filter((connector) => connector.target === target)
+  if (matches.length <= 1) return matches[0]
+  const preferred = preferredId ? matches.find((connector) => connector.id === preferredId) : undefined
+  if (preferred) return preferred
+  throw new LogtoManagementError(
+    'SOCIAL_CONNECTOR_AMBIGUOUS',
+    `Logto has more than one social connector for target ${target}`
+  )
+}
+
 export class LogtoAdminClaimClient {
   private readonly base: string
   private readonly resource: string
@@ -276,7 +291,6 @@ export class LogtoAdminClaimClient {
         desired.corsAllowedOrigins,
         sameStrings(application.customClientMetadata.corsAllowedOrigins, desired.corsAllowedOrigins)
       )
-      addDiff(applicationDiff, 'AgentConnect managed application', hasManagedTag(application), true)
     }
     const signInExperienceDiff: LogtoConfigurationDiff[] = []
     addDiff(signInExperienceDiff, 'Sign-in methods', signInExperience.signIn.methods ?? null, [])
@@ -306,15 +320,8 @@ export class LogtoAdminClaimClient {
         diff: applicationDiff
       },
       connectors: desired.socialProviders.map((target) => {
-        const matches = connectors.filter((connector) => connector.target === target)
-        if (matches.length > 1) {
-          throw new LogtoManagementError(
-            'SOCIAL_CONNECTOR_AMBIGUOUS',
-            `Logto has more than one social connector for target ${target}`
-          )
-        }
-        const connector = matches[0]
         if (!isManagedConnectorTarget(target)) {
+          const connector = selectConnector(connectors, target)
           return {
             target,
             id: connector?.id ?? null,
@@ -324,11 +331,11 @@ export class LogtoAdminClaimClient {
           }
         }
         const expected = desiredConnector(target, desired)
+        const connector = selectConnector(connectors, target, expected.id)
         const diff: LogtoConfigurationDiff[] = []
         if (!connector) {
           diff.push({ field: `${target} connector`, current: 'Missing', expected: expected.id })
         } else {
-          addDiff(diff, `${target} connector ID`, connector.id, expected.id)
           addDiff(diff, `${target} connector type`, connector.connectorId, expected.connectorId)
           addDiff(diff, `${target} client ID`, connector.config.clientId ?? null, expected.config.clientId ?? null)
           if (target === 'slack') {
@@ -342,7 +349,7 @@ export class LogtoAdminClaimClient {
           target,
           id: connector?.id ?? null,
           exists: connector !== undefined,
-          matches: connector ? connector.id === expected.id && connectorMatches(connector, expected) : false,
+          matches: connector ? connectorMatches(connector, expected) : false,
           diff
         }
       }),
@@ -494,7 +501,7 @@ export class LogtoAdminClaimClient {
   private applicationMatches(application: LogtoApplication, desired: LogtoSetupDesired): boolean {
     return (
       application.type === 'SPA' &&
-      hasManagedTag(application) &&
+      (application.id === desired.applicationId || hasManagedTag(application)) &&
       sameStrings(application.oidcClientMetadata.redirectUris, desired.redirectUris) &&
       sameStrings(application.oidcClientMetadata.postLogoutRedirectUris, desired.postLogoutRedirectUris) &&
       sameStrings(application.customClientMetadata.corsAllowedOrigins, desired.corsAllowedOrigins)
@@ -519,40 +526,35 @@ export class LogtoAdminClaimClient {
     const existing = await this.listConnectors()
     const result: Array<{ target: string; id: string; created: boolean; changed: boolean }> = []
     for (const target of desired.socialProviders) {
-      const matches = existing.filter((connector) => connector.target === target)
-      if (matches.length > 1) {
-        throw new LogtoManagementError(
-          'SOCIAL_CONNECTOR_AMBIGUOUS',
-          `Logto has more than one social connector for target ${target}`
-        )
-      }
       if (!isManagedConnectorTarget(target)) {
-        if (!matches[0]) {
+        const connector = selectConnector(existing, target)
+        if (!connector) {
           throw new LogtoManagementError(
             'SOCIAL_CONNECTOR_UNSUPPORTED',
             `automatic creation is not supported for the missing Logto social connector ${target}`
           )
         }
-        result.push({ target, id: matches[0].id, created: false, changed: false })
+        result.push({ target, id: connector.id, created: false, changed: false })
         continue
       }
       const expected = desiredConnector(target, desired)
-      if (matches[0] && connectorMatches(matches[0], expected)) {
-        result.push({ target, id: matches[0].id, created: false, changed: false })
+      const connector = selectConnector(existing, target, expected.id)
+      if (connector && connectorMatches(connector, expected)) {
+        result.push({ target, id: connector.id, created: false, changed: false })
         continue
       }
-      if (matches[0]) {
-        const response = await this.request(`/api/connectors/${encodeURIComponent(matches[0].id)}`, {
+      if (connector) {
+        const response = await this.request(`/api/connectors/${encodeURIComponent(connector.id)}`, {
           method: 'PATCH',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ config: expected.config, syncProfile: true })
         })
-        const connector = parseConnector(await response.json().catch(() => null))
-        if (!connector || connector.target !== target) {
+        const updated = parseConnector(await response.json().catch(() => null))
+        if (!updated || updated.target !== target) {
           throw new LogtoManagementError('LOGTO_UNAVAILABLE', `Logto returned an invalid ${target} connector`)
         }
-        existing.splice(existing.indexOf(matches[0]), 1, connector)
-        result.push({ target, id: connector.id, created: false, changed: true })
+        existing.splice(existing.indexOf(connector), 1, updated)
+        result.push({ target, id: updated.id, created: false, changed: true })
         continue
       }
       const response = await this.request('/api/connectors', {
@@ -565,16 +567,16 @@ export class LogtoAdminClaimClient {
           syncProfile: true
         })
       })
-      const connector = parseConnector(await response.json().catch(() => null))
-      if (!connector || connector.target !== target) {
+      const created = parseConnector(await response.json().catch(() => null))
+      if (!created || created.target !== target) {
         throw new LogtoManagementError(
           'LOGTO_UNAVAILABLE',
           `Logto returned an invalid ${target} connector`,
           response.status
         )
       }
-      existing.push(connector)
-      result.push({ target, id: connector.id, created: true, changed: true })
+      existing.push(created)
+      result.push({ target, id: created.id, created: true, changed: true })
     }
     return result
   }

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -287,10 +287,11 @@ function appendPath(origin: string, path: string): string {
   return new URL(path, `${origin.replace(/\/+$/, '')}/`).toString()
 }
 
-function googleRedirectUris(endpoint: string, connectorId: string): string[] {
+function googleRedirectUris(endpoint: string, connectorId: string, webUrl: string): string[] {
   return [
     appendPath(endpoint, `/callback/${connectorId}`),
-    appendPath(endpoint, `/account/callback/social/${connectorId}`)
+    appendPath(endpoint, `/account/callback/social/${connectorId}`),
+    appendPath(webUrl, '/auth/social/callback')
   ]
 }
 
@@ -514,7 +515,8 @@ export function buildTenantAdminServer(
             origins: [logtoEndpoint],
             redirects: googleRedirectUris(
               logtoEndpoint,
-              values.logto.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID
+              values.logto.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID,
+              localAuthBootstrap.services.web
             )
           }
         : { origins: [], redirects: [] }
@@ -626,7 +628,7 @@ export function buildTenantAdminServer(
     const current = await deps.store.getAdmin()
     const googleConnectorId = current?.values.logto?.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID
     const slackConnectorId = current?.values.logto?.slackConnector?.connectorId ?? LOGTO_SLACK_CONNECTOR_ID
-    const redirectUris = googleRedirectUris(logtoEndpoint, googleConnectorId)
+    const redirectUris = googleRedirectUris(logtoEndpoint, googleConnectorId, localAuthBootstrap.services.web)
     const logtoConfigured = Boolean(
       current?.values.logto?.managementAppId &&
       current.secrets.some((secret) => secret.key === 'logto.managementAppSecret' && secret.configured)
@@ -829,7 +831,7 @@ export function buildTenantAdminServer(
       if (!current?.values.logto?.browser) return problem(reply, 409, 'save Logto browser configuration first')
       const connectorId =
         parsed.data.connectorId ?? current.values.logto.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID
-      const redirectUris = googleRedirectUris(logtoEndpoint, connectorId)
+      const redirectUris = googleRedirectUris(logtoEndpoint, connectorId, localAuthBootstrap.services.web)
       const put = logtoGoogleConnectorPut(current, {
         ...(parsed.data.connectorId ? { connectorId: parsed.data.connectorId } : {}),
         clientId: parsed.data.clientId,
@@ -1087,9 +1089,9 @@ export function buildTenantAdminServer(
     if (!confirmed) {
       unverified.push('setup_url', 'callback_urls', 'webhook_active')
       diff.push(
-        { field: 'Setup URL', current: 'Not verified', expected: expectedUrls.setupUrl },
-        { field: 'Callback URLs', current: 'Not verified', expected: expectedUrls.callbackUrls },
-        { field: 'Webhook active', current: 'Not verified', expected: expectedUrls.webhookActive }
+        { field: 'Setup URL', current: "Can't verify automatically", expected: expectedUrls.setupUrl },
+        { field: 'Callback URLs', current: "Can't verify automatically", expected: expectedUrls.callbackUrls },
+        { field: 'Webhook active', current: "Can't verify automatically", expected: expectedUrls.webhookActive }
       )
     } else {
       if (confirmed.setupUrl !== expectedUrls.setupUrl) {
@@ -1113,7 +1115,7 @@ export function buildTenantAdminServer(
       diff,
       expected: expectedUrls,
       settingsUrl: audited.app.settingsUrl,
-      note: 'GitHub exposes permissions, events, external URL, and webhook URL to this check. Callback, setup, and webhook-active settings require operator confirmation.'
+      note: "GitHub exposes permissions, events, external URL, and webhook URL to this check. Callback, setup, and webhook-active settings can't be verified automatically."
     }
   })
 
@@ -1434,6 +1436,20 @@ export function buildTenantAdminServer(
         ]
       })
       return report()
+    }
+    const resolvedValues = withResolvedConnectorIds(
+      runtime.values,
+      setupInspection.connectors.flatMap((connector) =>
+        connector.id ? [{ target: connector.target, id: connector.id }] : []
+      )
+    )
+    if (JSON.stringify(resolvedValues) !== JSON.stringify(runtime.values)) {
+      await serializeMutation(() => deps.store.replace({ expectedRevision: runtime.revision, values: resolvedValues }))
+      findings.push({
+        id: 'logto.connector_references',
+        status: 'pass',
+        message: 'Tenant Admin adopted the existing Logto connector IDs.'
+      })
     }
     findings.push(
       setupInspection.application.exists && setupInspection.application.matches

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -1082,31 +1082,32 @@ export function buildTenantAdminServer(
       return problem(reply, 502, error instanceof Error ? error.message : 'GitHub App settings could not be checked')
     }
     const expectedUrls = githubConfiguredUrls(providerAppConfig(localAuthBootstrap.services), manifest)
-    const confirmed = github.configuredUrls
+    const lastSubmitted = github.configuredUrls
     const missing = [...audited.missing]
-    const unverified: string[] = []
+    const unverified = ['setup_url', 'callback_urls', 'webhook_active']
     const diff = audited.diff.map(({ field, current, expected }) => ({ field, current, expected }))
-    if (!confirmed) {
-      unverified.push('setup_url', 'callback_urls', 'webhook_active')
-      diff.push(
-        { field: 'Setup URL', current: "Can't verify automatically", expected: expectedUrls.setupUrl },
-        { field: 'Callback URLs', current: "Can't verify automatically", expected: expectedUrls.callbackUrls },
-        { field: 'Webhook active', current: "Can't verify automatically", expected: expectedUrls.webhookActive }
-      )
-    } else {
-      if (confirmed.setupUrl !== expectedUrls.setupUrl) {
-        missing.push('setup_url')
-        diff.push({ field: 'Setup URL', current: confirmed.setupUrl, expected: expectedUrls.setupUrl })
+    const setupUrlChanged = Boolean(lastSubmitted && lastSubmitted.setupUrl !== expectedUrls.setupUrl)
+    const callbackUrlsChanged = Boolean(
+      lastSubmitted && !sameStrings(lastSubmitted.callbackUrls, expectedUrls.callbackUrls)
+    )
+    const webhookActiveChanged = Boolean(lastSubmitted && lastSubmitted.webhookActive !== expectedUrls.webhookActive)
+    diff.push(
+      {
+        field: setupUrlChanged ? 'Setup URL (last submitted)' : 'Setup URL',
+        current: setupUrlChanged ? lastSubmitted!.setupUrl : "Can't verify automatically",
+        expected: expectedUrls.setupUrl
+      },
+      {
+        field: callbackUrlsChanged ? 'Callback URLs (last submitted)' : 'Callback URLs',
+        current: callbackUrlsChanged ? lastSubmitted!.callbackUrls : "Can't verify automatically",
+        expected: expectedUrls.callbackUrls
+      },
+      {
+        field: webhookActiveChanged ? 'Webhook active (last submitted)' : 'Webhook active',
+        current: webhookActiveChanged ? lastSubmitted!.webhookActive : "Can't verify automatically",
+        expected: expectedUrls.webhookActive
       }
-      if (!sameStrings(confirmed.callbackUrls, expectedUrls.callbackUrls)) {
-        missing.push('callback_urls')
-        diff.push({ field: 'Callback URLs', current: confirmed.callbackUrls, expected: expectedUrls.callbackUrls })
-      }
-      if (confirmed.webhookActive !== expectedUrls.webhookActive) {
-        missing.push('webhook_active')
-        diff.push({ field: 'Webhook active', current: confirmed.webhookActive, expected: expectedUrls.webhookActive })
-      }
-    }
+    )
     return {
       provider: 'github' as const,
       status: missing.length > 0 ? ('fail' as const) : unverified.length > 0 ? ('unknown' as const) : ('pass' as const),
@@ -1118,39 +1119,6 @@ export function buildTenantAdminServer(
       note: "GitHub exposes permissions, events, external URL, and webhook URL to this check. Callback, setup, and webhook-active settings can't be verified automatically."
     }
   })
-
-  app.post('/api/v1/confirm/github-urls', { preHandler: requireConfigurationAccess }, async (_request, reply) =>
-    serializeMutation(async () => {
-      const runtime = await deps.store.getRuntime(['github.privateKeyB64'])
-      const github = runtime?.values.github
-      const privateKey = runtime?.secrets['github.privateKeyB64']
-      if (!runtime || !github || !privateKey) {
-        return problem(reply, 409, 'the deployment GitHub App is not fully configured')
-      }
-      let manifest: Record<string, unknown>
-      let audited: Awaited<ReturnType<typeof auditGithubApp>>
-      try {
-        manifest = expectedGithubManifest(runtime.values)
-        audited = await auditGithubApp(github, privateKey, manifest, fetchImpl)
-      } catch (error) {
-        return problem(reply, 502, error instanceof Error ? error.message : 'GitHub App settings could not be checked')
-      }
-      if (audited.missing.length > 0) {
-        return problem(
-          reply,
-          409,
-          `GitHub App still differs in: ${audited.missing.join(', ')}`,
-          'GITHUB_APP_MANIFEST_DRIFT'
-        )
-      }
-      const configuredUrls = githubConfiguredUrls(providerAppConfig(localAuthBootstrap.services), manifest)
-      const saved = await deps.store.replace({
-        expectedRevision: runtime.revision,
-        values: { ...runtime.values, github: { ...github, configuredUrls } }
-      })
-      return { revision: saved.revision, configuredUrls, restartRequired: false as const }
-    })
-  )
 
   app.post('/api/v1/check/slack', { preHandler: requireDiagnosticAccess }, async (request, reply) => {
     const parsed = CheckSlackBody.safeParse(request.body)

--- a/packages/setup/src/deployment-config-client.ts
+++ b/packages/setup/src/deployment-config-client.ts
@@ -47,6 +47,7 @@ export function githubDeploymentPut(
         appId,
         slug: credentials.slug,
         clientId: credentials.clientId,
+        webhookEnabled: options.configuredUrls?.webhookActive ?? true,
         ...(options.configuredUrls ? { configuredUrls: options.configuredUrls } : {})
       },
       ...(connectLogto

--- a/packages/setup/src/deployment-config-client.ts
+++ b/packages/setup/src/deployment-config-client.ts
@@ -165,6 +165,7 @@ export interface SlackConfiguredUrls {
   eventsUrl: string
   interactionsUrl: string
   loginRedirectUrl?: string
+  socialLinkRedirectUrl?: string
 }
 
 export function slackDeploymentPut(

--- a/packages/setup/src/github-app.ts
+++ b/packages/setup/src/github-app.ts
@@ -117,7 +117,8 @@ export function buildGithubAppManifest(
       ? {
           callback_urls: [
             appendPath(login.logtoEndpoint, `/callback/${login.connectorId}`),
-            appendPath(login.logtoEndpoint, `/account/callback/social/${login.connectorId}`)
+            appendPath(login.logtoEndpoint, `/account/callback/social/${login.connectorId}`),
+            appendPath(login.webUrl, '/auth/social/callback')
           ]
         }
       : {}),

--- a/packages/setup/src/slack-app.ts
+++ b/packages/setup/src/slack-app.ts
@@ -11,6 +11,7 @@ export interface SlackConfiguredUrls {
   eventsUrl: string
   interactionsUrl: string
   loginRedirectUrl?: string
+  socialLinkRedirectUrl?: string
 }
 
 export interface SlackLoginAppConfig {
@@ -44,12 +45,15 @@ export function buildSlackDeploymentManifest(
   requireProviderAppEndpoints(config)
   const redirectUrl = slackPlatformOAuthRedirectUri(config.services.controlPlane)
   const loginRedirectUrl = login ? appendPath(login.logtoEndpoint, `/callback/${login.connectorId}`) : undefined
+  const socialLinkRedirectUrl = login ? appendPath(config.services.web, '/auth/social/callback') : undefined
   if (loginRedirectUrl && new URL(loginRedirectUrl).protocol !== 'https:') {
     throw new Error('Slack sign-in requires an HTTPS Logto endpoint')
   }
   return buildInstallManifest(name, redirectUrl, {
     httpRelayBase: config.services.relay,
-    ...(loginRedirectUrl ? { additionalRedirectUrls: [loginRedirectUrl] } : {})
+    ...(loginRedirectUrl && socialLinkRedirectUrl
+      ? { additionalRedirectUrls: [loginRedirectUrl, socialLinkRedirectUrl] }
+      : {})
   })
 }
 
@@ -60,7 +64,7 @@ export function slackConfiguredUrls(manifest: SlackManifest): SlackConfiguredUrl
   const interactivity = asRecord(settings.interactivity)
   const redirects = asStrings(oauth.redirect_urls)
   if (
-    (redirects.length !== 1 && redirects.length !== 2) ||
+    (redirects.length !== 1 && redirects.length !== 3) ||
     typeof events.request_url !== 'string' ||
     typeof interactivity.request_url !== 'string'
   ) {
@@ -70,7 +74,8 @@ export function slackConfiguredUrls(manifest: SlackManifest): SlackConfiguredUrl
     oauthRedirectUrl: redirects[0]!,
     eventsUrl: events.request_url,
     interactionsUrl: interactivity.request_url,
-    ...(redirects[1] ? { loginRedirectUrl: redirects[1] } : {})
+    ...(redirects[1] ? { loginRedirectUrl: redirects[1] } : {}),
+    ...(redirects[2] ? { socialLinkRedirectUrl: redirects[2] } : {})
   }
 }
 


### PR DESCRIPTION
## What changed

- adopt an existing Logto connector's real instance ID instead of treating a generated ID as drift
- use a saved connector ID only to disambiguate when Logto has multiple connectors for the same provider
- accept an explicitly selected existing Logto SPA without requiring AgentConnect's internal discovery tag
- label GitHub settings that its API cannot read as `Can't verify automatically`
- include the Console account-linking callback in GitHub, Google, and Slack OAuth expectations

## Why

Tenant Admin previously compared provider-generated connector IDs with the default IDs used only when creating new connectors. That produced false `Update required` states and caused Slack callback expectations to use the wrong connector path. It also omitted the callback used by the Console's account-linking flow.

## Impact

Existing deployments keep their current Logto resources. Checking Logto adopts their connector IDs locally; it does not rename or recreate connectors. GitHub's API-readable settings still fail on real drift, while callback/setup/webhook-active fields are presented as manual checks.

The added Slack configured-URL field is optional in the existing JSON deployment document and requires no database migration.

## Validation

- `pnpm --filter @agentconnect.md/setup typecheck`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/setup test`
- `pnpm --filter @agentconnect.md/setup build`
- focused ESLint on the changed files
- pre-push `eslint .`
- `git diff --check`
