### PR TITLE
fix(web): surface live webchat tool-call detail and retitles

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -15554,13 +15554,19 @@ export class Daemon {
           status: String(update.status ?? 'pending')
         })
         return
-      case 'tool_call_update':
+      case 'tool_call_update': {
+        // A later update can retitle the call (e.g. Codex web_search starts generic,
+        // then reports the actual query) — forward it so the live view retitles in
+        // place instead of being stuck on the first `tool_call`'s placeholder title.
+        const title = typeof update.title === 'string' ? update.title : undefined
         emit({
           kind: 'tool_update',
           toolCallId: String(update.toolCallId ?? ''),
-          status: String(update.status ?? '')
+          status: String(update.status ?? ''),
+          ...(title !== undefined ? { title } : {})
         })
         return
+      }
       case 'session_info_update': {
         // The runtime's auto-generated title (already persisted via setSessionTitle
         // above). Stream it so the live playground session renames in place. Slack

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -74,7 +74,16 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('message'), text: z.string() }), // from agent_message_chunk
   z.object({ kind: z.literal('thinking'), text: z.string() }), // from agent_thought_chunk
   z.object({ kind: z.literal('tool_call'), toolCallId: z.string(), title: z.string(), status: z.string() }),
-  z.object({ kind: z.literal('tool_update'), toolCallId: z.string(), status: z.string() }),
+  // `title` is set only when this update refines the initial `tool_call` title (e.g.
+  // Codex web_search names itself generically first, then retitles with the actual
+  // query once known) — mirrors the ACP field so the live view can retitle in place
+  // the same way the persisted transcript already does (TranscriptRecorder.titles).
+  z.object({
+    kind: z.literal('tool_update'),
+    toolCallId: z.string(),
+    status: z.string(),
+    title: z.string().optional()
+  }),
   // The runtime's auto-generated session title (from ACP session_info_update). The
   // daemon persists it (session/list surfaces it on the persisted row); this streams
   // the same value so the LIVE playground session renames itself in place, matching

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -295,6 +295,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // same tick openPlayground staged the session — so state-based lookups there
   // would read a stale snapshot and stamp every step without a name.
   const rosterNames = useRef<Map<string, Map<string, string>>>(new Map())
+  // Per-participant daemon session ids (conversation id → agentId → acp sessionId),
+  // from each lane's status frames. The session row's `realSessionId` only tracks
+  // the PRIMARY participant (applyStatus fences the rest out), but every member
+  // owns its own daemon session — a member's tool step must carry ITS session so
+  // the on-demand tool-body read targets the daemon that recorded the call.
+  const agentSessionIds = useRef<Map<string, Map<string, string>>>(new Map())
   // One ordering cursor per stream LANE — a multi-agent turn runs one lane per
   // targeted participant (webchat-multi-agents.md §5.3); keys from lib/webchat-lanes.ts.
   const streamCursors = useRef<Map<string, OrderedWebchatCursor<WebchatOutput, WebchatDone>>>(new Map())
@@ -489,9 +495,22 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           return [...steps, lane({ kind: 'plan', text: ev.text })]
         }
         if (ev.kind === 'tool_call') {
+          // The owning participant's daemon session (recorded from its status
+          // lane) — the tool-body read must target the session that logged this
+          // call, not the conversation's primary. Falls back through the sole/
+          // primary lane key; absent until that lane's first status frame lands,
+          // in which case the detail view falls back to the row's realSessionId.
+          const toolSessionId =
+            agentSessionIds.current.get(id)?.get(agentId ?? '') ?? agentSessionIds.current.get(id)?.get('')
           return [
             ...steps,
-            lane({ kind: 'tool', text: ev.title || 'tool call', toolCallId: ev.toolCallId, toolStatus: ev.status })
+            lane({
+              kind: 'tool',
+              text: ev.title || 'tool call',
+              toolCallId: ev.toolCallId,
+              toolStatus: ev.status,
+              ...(toolSessionId ? { toolSessionId } : {})
+            })
           ]
         }
         if (ev.kind === 'tool_update') {
@@ -528,6 +547,15 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
    *  model or the last token total. Playground sessions only (adopted webchat rows carry
    *  their own persisted headline). */
   const applyStatus = useCallback((id: string, st: WebchatStatus, agentId?: string): void => {
+    // Record every participant's session id BEFORE the primary fence below —
+    // member lanes never reach the session-row merge, but their tool steps need
+    // the owning session for the live tool-body read (keyed '' for the sole/
+    // primary lane, whose frames may omit agentId).
+    if (st.sessionId) {
+      const perAgent = agentSessionIds.current.get(id) ?? new Map<string, string>()
+      perAgent.set(agentId ?? '', st.sessionId)
+      agentSessionIds.current.set(id, perAgent)
+    }
     setPgSessions((cur) => {
       const s = cur[id]
       if (!s) return cur

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -494,15 +494,29 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             lane({ kind: 'tool', text: ev.title || 'tool call', toolCallId: ev.toolCallId, toolStatus: ev.status })
           ]
         }
-        if (ev.kind === 'tool_update' && last?.kind === 'tool') {
-          return replaceAt(laneIndex, {
-            ...last,
-            toolStatus: ev.status,
-            ...(ev.title ? { text: ev.title } : {}),
-            observedAtMs
-          })
+        if (ev.kind === 'tool_update') {
+          // Address the update to ITS call, not the lane tail: ACP allows parallel
+          // tool calls, so the most recent tool step may belong to a different call.
+          // Same fences as the lane scan above — never cross a user message, a
+          // foreign turn, or the supersession boundary.
+          for (let i = steps.length - 1; i >= 0; i--) {
+            const step = steps[i]!
+            if (step.kind === 'msg' && step.agentId === undefined) break
+            if ((step.agentId ?? undefined) !== agentId) continue
+            if (step.turnId !== turnId) break
+            if (step.boundary) break
+            if (step.kind === 'tool' && step.toolCallId === ev.toolCallId) {
+              return replaceAt(i, {
+                ...step,
+                toolStatus: ev.status,
+                ...(ev.title ? { text: ev.title } : {}),
+                observedAtMs
+              })
+            }
+          }
+          return steps // no matching call in this lane (e.g. suppressed tool_call)
         }
-        return steps // tool_update: status-only, nothing to render for now
+        return steps
       })
     },
     [mutateSteps, participantName]

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -198,7 +198,7 @@ type WebchatEvent =
   | { kind: 'message'; text: string }
   | { kind: 'thinking'; text: string }
   | { kind: 'tool_call'; toolCallId: string; title: string; status: string }
-  | { kind: 'tool_update'; toolCallId: string; status: string }
+  | { kind: 'tool_update'; toolCallId: string; status: string; title?: string }
   | { kind: 'session_info'; title: string }
   | { kind: 'superseded'; generation: number }
 
@@ -489,10 +489,18 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           return [...steps, lane({ kind: 'plan', text: ev.text })]
         }
         if (ev.kind === 'tool_call') {
-          return [...steps, lane({ kind: 'tool', text: ev.title || 'tool call' })]
+          return [
+            ...steps,
+            lane({ kind: 'tool', text: ev.title || 'tool call', toolCallId: ev.toolCallId, toolStatus: ev.status })
+          ]
         }
         if (ev.kind === 'tool_update' && last?.kind === 'tool') {
-          return replaceAt(laneIndex, { ...last, observedAtMs })
+          return replaceAt(laneIndex, {
+            ...last,
+            toolStatus: ev.status,
+            ...(ev.title ? { text: ev.title } : {}),
+            observedAtMs
+          })
         }
         return steps // tool_update: status-only, nothing to render for now
       })

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -505,7 +505,24 @@ function fmtStep(stp: SessionStep, platform?: string): FmtStep {
     code: stp.code ?? '',
     files: (stp.files ?? []).map((f) => ({ tag: f.tag, path: f.path, color: fileColor(f.tag) })),
     time: stp.time ?? '',
-    ...(platform ? { platform } : {})
+    ...(platform ? { platform } : {}),
+    // The live wire frame carries no body (kept off the hot path); attach just
+    // enough of a SessionMessageDto shape for ToolBodyDetail to pull the same
+    // full body a history row shows, via `fetchToolBody` (no inline preview yet,
+    // so it fetches on open rather than rendering one immediately).
+    ...(stp.kind === 'tool' && stp.toolCallId
+      ? {
+          msg: {
+            seq: 0,
+            sender: '',
+            ts: '',
+            kind: 'tool',
+            text: stp.text,
+            toolCallId: stp.toolCallId,
+            toolStatus: stp.toolStatus
+          } satisfies SessionMessageDto
+        }
+      : {})
   }
 }
 
@@ -598,9 +615,12 @@ function ToolBodyDetail({ msg, sessionId }: { msg: SessionMessageDto; sessionId:
   const [loading, setLoading] = useState(false)
   const [err, setErr] = useState<string | null>(null)
 
-  // A same-seq live update replaces `msg`; associate the fetched body with the
-  // exact source row so an older full response can never mask the new preview.
-  const fullBody = full?.source === msg ? full.body : null
+  // A same-seq live update replaces `msg` with a fresher preview; fence the fetched
+  // full body against the (toolCallId, preview) it was fetched under so an older
+  // full response can never mask the new preview. Compared by CONTENT, not object
+  // identity: a live-streamed step rebuilds its `msg` on every render (fmtStep), so
+  // an identity fence would discard the fetch the moment the next chunk repaints.
+  const fullBody = full && full.source.toolCallId === msg.toolCallId && full.source.body === msg.body ? full.body : null
   const bodyStr = fullBody ?? msg.body ?? null
   let body: ToolBody | null = null
   let parseErr = false
@@ -636,16 +656,49 @@ function ToolBodyDetail({ msg, sessionId }: { msg: SessionMessageDto; sessionId:
 
   const kb = (n: number) => (n < 1024 ? `${n} B` : `${(n / 1024).toFixed(1)} KB`)
 
+  // Live-only refresh: a fetched body is a point-in-time snapshot of a still-running
+  // call (rawOutput lands only on completion). The streamed tool_update flips
+  // `msg.toolStatus`; use that as the refetch signal so an open panel fills in the
+  // OUTPUT without waiting for the turn-end transcript reconciliation. Persisted
+  // rows (msg.body present) keep their own preview lifecycle and never refetch here.
+  const liveStale =
+    open &&
+    !loading &&
+    msg.body == null &&
+    full != null &&
+    full.source.toolCallId === msg.toolCallId &&
+    full.source.toolStatus !== msg.toolStatus
+  useEffect(() => {
+    if (liveStale) loadFull()
+    // loadFull is redefined per render (plain closure); liveStale already gates the
+    // refetch to one flip per status change, so it is deliberately the only dep.
+  }, [liveStale])
+
+  // A live step carries no inline preview at all (the hot-path frame never ships
+  // one) — opening it has nothing to show yet, so fetch the full body the same
+  // way the "View full" affordance does for a truncated persisted preview.
+  const toggle = () => {
+    if (!open && bodyStr == null) {
+      loadFull()
+      return
+    }
+    setOpen((o) => !o)
+  }
+
   return (
     <div className="mt-[6px]">
       <div className="flex flex-wrap items-center gap-2">
         <button
-          onClick={() => setOpen((o) => !o)}
+          onClick={toggle}
+          disabled={loading}
           className="inline-flex cursor-pointer items-center gap-[5px] border-0 bg-transparent p-0 font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary)"
         >
-          <Icon name={open ? 'chevron-down' : 'chevron-right'} size={13} />
+          {loading ? <Spinner size={13} /> : <Icon name={open ? 'chevron-down' : 'chevron-right'} size={13} />}
           {open ? 'Hide detail' : 'View detail'}
         </button>
+        {err && bodyStr == null && (
+          <span className="font-sans text-[10.5px] font-medium leading-normal text-(--red-600)">{err}</span>
+        )}
         {kind && <span className="scope text-[10.5px]">{kind}</span>}
         {badge && (
           <span className="badge text-[10px]" style={{ background: badge.bg, color: badge.text }}>
@@ -1692,6 +1745,13 @@ export default function SessionDetailView() {
   // separate on-demand pull from the owning daemon. Playground + mock sessions
   // carry their own steps, so they never fetch.
   const sid = session?.id
+  // The CP-resolvable id: a playground/webchat session starts under its synthetic
+  // local id (`pg_...`) and only gets a `realSessionId` once the daemon creates the
+  // real ACP session — `fetchToolBody` targets the CP, which never knows the
+  // synthetic id, so a live tool row's full-body fetch must key off this instead of
+  // `sid` (matches the `session.realSessionId ?? session.id` idiom used elsewhere
+  // in this file for the same daemon-proxied reads).
+  const toolSid = session?.realSessionId ?? sid
   const aid = session?.agentId
   const wantTranscript = !!session && session.platform !== 'playground' && session.steps.length === 0 && !!aid
   // This component now survives id changes. Do not paint session A's transcript
@@ -3347,7 +3407,7 @@ export default function SessionDetailView() {
                                     <MessageText text={st.text} platform={st.platform} />
                                   </div>
                                 )}
-                                <StepExtras step={st} sessionId={sid} />
+                                <StepExtras step={st} sessionId={toolSid} />
                               </div>
                             ))}
                             {workSteps.length > 0 && (
@@ -3367,9 +3427,19 @@ export default function SessionDetailView() {
                                 </button>
                                 {openWork && (
                                   <div className="mt-2 overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
-                                    {workSteps.map((st, si) => (
+                                    {/* While the turn is still streaming, the panel is a
+                                    progress ticker: only the LATEST work step shows (the
+                                    list would grow unboundedly mid-run). The full list
+                                    appears once the turn completes. */}
+                                    {(streaming ? workSteps.slice(-1) : workSteps).map((st, si) => (
                                       <div
-                                        key={si}
+                                        // Keyed by tool identity + index: the streaming
+                                        // ticker renders index 0 for every successive step,
+                                        // and a bare index key would carry one tool's open
+                                        // detail state over to the next; the index keeps
+                                        // keys unique when a merged conversation repeats a
+                                        // session-local toolCallId across agents.
+                                        key={`${st.msg?.toolCallId ?? ''}:${si}`}
                                         className={`flex items-start gap-[11px] px-[14px] py-[10px] ${
                                           si > 0 ? 'border-t border-(--border-subtle)' : ''
                                         }`}
@@ -3397,7 +3467,7 @@ export default function SessionDetailView() {
                                               <MessageText text={st.text} platform={st.platform} />
                                             </div>
                                           )}
-                                          <StepExtras step={st} sessionId={sid} />
+                                          <StepExtras step={st} sessionId={toolSid} />
                                         </div>
                                       </div>
                                     ))}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -520,7 +520,10 @@ function fmtStep(stp: SessionStep, platform?: string): FmtStep {
             text: stp.text,
             toolCallId: stp.toolCallId,
             toolStatus: stp.toolStatus
-          } satisfies SessionMessageDto
+          } satisfies SessionMessageDto,
+          // A member participant's call lives in ITS daemon session, not the
+          // row's primary — carry it so StepExtras targets the right session.
+          ...(stp.toolSessionId ? { toolSessionId: stp.toolSessionId } : {})
         }
       : {})
   }
@@ -3433,13 +3436,15 @@ export default function SessionDetailView() {
                                     appears once the turn completes. */}
                                     {(streaming ? workSteps.slice(-1) : workSteps).map((st, si) => (
                                       <div
-                                        // Keyed by tool identity + index: the streaming
-                                        // ticker renders index 0 for every successive step,
-                                        // and a bare index key would carry one tool's open
-                                        // detail state over to the next; the index keeps
-                                        // keys unique when a merged conversation repeats a
-                                        // session-local toolCallId across agents.
-                                        key={`${st.msg?.toolCallId ?? ''}:${si}`}
+                                        // Keyed by tool identity where there is one, so the
+                                        // key survives the streaming→completed transition
+                                        // (the ticker's slice(-1) renders index 0, the full
+                                        // list the original index — an index-bearing key
+                                        // would remount ToolBodyDetail at turn end and slam
+                                        // an expanded panel shut). Steps without a tool id
+                                        // (THINK rows) fall back to the index; within one
+                                        // agent's turn a toolCallId appears once.
+                                        key={st.msg?.toolCallId ?? `i:${si}`}
                                         className={`flex items-start gap-[11px] px-[14px] py-[10px] ${
                                           si > 0 ? 'border-t border-(--border-subtle)' : ''
                                         }`}

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -864,6 +864,13 @@ export interface SessionStep {
   /** Client-side timestamp for live playground/webchat steps. Persisted transcripts
    *  carry their own message `ts`; this only keeps in-memory live stats moving. */
   observedAtMs?: number
+  /** Live-webchat tool-call identity + latest ACP status, mirrored straight off the
+   *  WebchatEvent. The live wire frame never carries input/output/content (kept off
+   *  the hot path — see protocol webchat.ts) but the daemon persists the full body
+   *  unconditionally as it streams, so this id is enough to pull the same detail a
+   *  history view gets, via the existing `fetchToolBody` read. */
+  toolCallId?: string
+  toolStatus?: string
 }
 
 // Per-session token accounting (protocol `SessionUsage`), metered by the daemon.

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -871,6 +871,10 @@ export interface SessionStep {
    *  history view gets, via the existing `fetchToolBody` read. */
   toolCallId?: string
   toolStatus?: string
+  /** The daemon session that recorded this tool call — set on live multi-agent
+   *  steps where the owning participant's session differs from the row's
+   *  primary `realSessionId`; the on-demand tool-body read targets it. */
+  toolSessionId?: string
 }
 
 // Per-session token accounting (protocol `SessionUsage`), metered by the daemon.


### PR DESCRIPTION
## What

While a webchat session is streaming, tool rows in the console showed only the initial title — no command/input/output — and the whole work list rendered as an ever-growing list. Opening the same session later as history showed full detail. This PR makes the live view match history:

- **Live tool detail on demand.** The live `WebchatEvent` stays thin by design (no body on the hot path), but the daemon already persists the full `ToolBody` as the call streams. The console now threads `toolCallId`/`status` from live events onto the step, and `ToolBodyDetail` fetches the body on expand via the existing `GET /sessions/:id/tool-body` read — keyed off `realSessionId`, since the CP never knows the synthetic `pg_` playground id (that mismatch was a straight 404 "session not found").
- **Title refinements stream through.** ACP `tool_call_update` can retitle a call (Codex names `web_search` generically first, then reports the actual query). The daemon now forwards `title` on the live `tool_update` event (new optional field on the protocol schema), and the console retitles the step in place — matching what the persisted transcript already records.
- **Fetched-body fence fixed.** `ToolBodyDetail` fenced its fetched full body by object identity (`full.source === msg`). Live steps rebuild `msg` every render, so each fetch was discarded on the next streamed chunk and the panel showed "No body captured". The fence now compares content (`toolCallId` + preview snapshot), and an open panel refetches when the streamed status flips — so OUTPUT fills in the moment the call completes instead of waiting for turn-end reconciliation.
- **Streaming work panel is a ticker.** While a turn streams, the work panel shows only the latest step; the full step list appears once the turn completes. Rows are keyed by tool identity so one call's open detail state can't leak into the next.

## Why

Live webchat sessions were unusable for following what an agent is actually doing — you saw "Web Search" with no query and no results until the whole turn ended.

## Reviewer notes

- The protocol change is additive (`title?` on `tool_update`); older browsers ignore the extra field, and the daemon only sets it when ACP supplies one.
- No relay or CP changes — the relay forwards events verbatim, and the tool-body read reuses the existing daemon-proxied BFF route.
- Verified: protocol build, daemon typecheck + test suite (2873 passed; the one acp-matrix failure is missing runtime credentials in the local env, unrelated), web typecheck/lint and full test suite (876 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)