### PR TITLE
docs(designs): add webchat cross-integration continuation design

### DIFF
--- a/docs/designs/webchat-cross-integration-continuation.md
+++ b/docs/designs/webchat-cross-integration-continuation.md
@@ -1,0 +1,456 @@
+# Webchat Continuation of Other Integrations' Sessions
+
+**Status:** Proposed design
+**Owner:** console/web + control plane + relay + daemon
+**Related:** issue #180 (webchat could continue other integration's session),
+[webchat-multi-agents.md](webchat-multi-agents.md),
+[merged-conversation-view.md](merged-conversation-view.md),
+[session-concept.md](session-concept.md),
+[session-visibility.md](session-visibility.md),
+[shared-bot-relay.md](shared-bot-relay.md),
+[product-conventions.md](../product-conventions.md)
+
+> This document designs **cross-surface session continuation**: the console's
+> webchat composer sending a human turn into an existing agent session that was
+> created by another integration (a Slack thread, a Telegram chat, a Discord
+> thread, a Feishu conversation). Today those sessions render read-only in the
+> console — the composer exists only for `playground`/`webchat` sessions, and
+> [merged-conversation-view.md](merged-conversation-view.md) §9 explicitly
+> records "the console is an observer of IM platforms, not a poster" as the
+> shipped state and defers a console→platform composer as "a separate product
+> question". Issue #180 is that product question. This design answers it.
+
+---
+
+## 1. Summary
+
+A session is an agent-scoped four-tuple `platform:channel:thread:agentId`
+([session-concept.md](session-concept.md) §1.1). The webchat pipeline is built
+on the assumption that **the conversation is the session**: the browser only
+ever names a `conversationId`, the token binds it, the wire frame carries
+`sessionKey == chatId` (`packages/protocol/src/frames/relay-daemon.ts:186-193`),
+and the daemon _derives_ the local session key from the conversation id
+(`packages/daemon/src/daemon.ts:6791` —
+`webchat:<cid>:webchat:<cid>:<agentId>`). Nothing in the chain can express
+"deliver this browser turn into the session at `slack:C123:1712.34:agentA`".
+
+This design adds a **session-targeted webchat conversation** — a webchat
+conversation whose durable target is an existing session's coordinates instead
+of a fresh webchat-owned channel:
+
+- The CP mints a webchat token whose conversation row **adopts** a target
+  session, after checking the caller may continue it and the owning agent is
+  still placed on the daemon that owns the session's content.
+- The relay forwards turns unchanged; the verified verdict carries the target
+  coordinates so the daemon never trusts a browser-supplied session id.
+- The daemon dispatches the turn **onto the target session's own coordinates**
+  — the same synthesis the `replyToSession` local branch already performs for
+  agent-initiated cross-session delivery (`daemon.ts:8514-8573`) — while
+  attaching the webchat stream sink so the browser sees the live reply.
+- The turn and its reply are **mirrored to the originating platform thread**
+  (§5.2), so platform participants watching the Slack thread see the same
+  conversation the console user is having. The session remains the single
+  source of truth; both surfaces are projections
+  ([product-conventions.md](../product-conventions.md), "the session is the
+  complete truth; IM is one projection").
+
+Architecture invariants are preserved: the CP stays off the message hot path
+(it only mints and verifies tokens and stores the adoption tuple), the relay
+persists no content, message bodies remain daemon-local, and rolling
+deployments fail closed behind a daemon capability feature flag.
+
+## 2. Goals and non-goals
+
+### 2.1 Goals
+
+1. From the console session detail page, a user who may continue an
+   integration-origin session gets a live composer; sending a turn resumes the
+   **same logical and ACP session** — full context, same worktree, same memory.
+2. The reply streams into the console with the full webchat surface (message,
+   thought, tool-call lanes) and is simultaneously delivered to the origin
+   platform thread under the session's normal output rules.
+3. Later platform-side messages continue the same session seamlessly — the
+   webchat exchange is ordinary session history, not a fork.
+4. Authorization is CP-checked at mint time and daemon-enforced by construction
+   (the browser can never name an arbitrary session; only the signed verdict
+   carries the target).
+5. Mixed-version deployments fail closed: an old daemon or relay simply makes
+   the CP refuse to mint, and the console keeps today's read-only view.
+
+### 2.2 Non-goals (v1)
+
+- **No multi-agent adoption.** A session-targeted conversation has exactly one
+  participant: the session's owner agent. Continuing one agent's session of a
+  multi-agent Slack thread is in scope; a merged multi-agent continuation
+  composer is not (it composes with
+  [merged-conversation-view.md](merged-conversation-view.md) later).
+- **No continuation of `hook`/`dream`/`a2a` sessions.** v1 targets chat-origin
+  sessions (`originKindOf(platform) === 'chat'`,
+  `packages/protocol/src/frames/route.ts:43-60`). Headless-origin sessions have
+  no human conversation surface to mirror to and different ownership semantics.
+- **No continuation after an agent move.** Same rule as webchat resume today
+  ([product-conventions.md](../product-conventions.md)): content ownership is
+  daemon-local and does not migrate.
+- **No new CP↔daemon frames.** The CP WS `session/*` family stays read-only;
+  the content path rides the existing relay webchat plane.
+- **No platform-side identity impersonation.** The mirrored human turn is
+  posted by the bot, clearly attributed (§5.2); we do not attempt per-user
+  platform identities.
+
+## 3. Why this is impossible today
+
+Each blocker, with its exact site:
+
+1. **Addressing.** The browser passes only `orgId + agentId + conversationId`
+   (`packages/web/src/lib/api.ts:133,180`); token claims are
+   `{userId, user, agentId, orgId, conversationId}`
+   (`packages/control-plane/src/http/routes/webchat-token.ts:116-122`); the
+   relay frame carries `sessionKey == chatId`
+   (`packages/protocol/src/frames/relay-daemon.ts:190`); the daemon derives
+   `webchat:<cid>:webchat:<cid>:<agentId>` (`daemon.ts:6791`). No field in the
+   chain can carry a foreign session coordinate.
+2. **Authorization.** `webchat_conversation` proves `(conversationId, userId,
+agentId, orgId)` ownership of webchat-born conversations only
+   (`packages/control-plane/prisma/schema.prisma:1058-1091`). The session read
+   policy (`session-visibility`) is view-only; nothing authorizes a _human
+   writing into_ a platform session.
+3. **Source-binding immutability.** A session row is bound first-wins to its
+   external source; `bindSessionSource` returns `'mismatch'` for a turn whose
+   attributed source differs (`daemon.ts:15932-15988`). A turn synthesized on
+   `platform:'webchat'` coordinates can never enter a Slack-bound row.
+4. **Output routing.** A turn dispatched into a platform session resolves its
+   reply transport from the session's own platform + transportScope
+   (`integrationIdForSessionTransport`, used at `daemon.ts:8527`), while the
+   webchat stream sink is attached only when the pending turn is webchat-shaped
+   (`daemon.ts:12558-12574`). Neither path knows how to do both.
+5. **Console UI.** `isLive = isPg || isWebchat` gates the composer
+   (`packages/web/src/components/console/views/SessionDetailView.tsx:2195-2203`);
+   integration sessions render read-only with a `threadUrl` deep link, and
+   `channelId` is only populated for webchat/hook/named-channel rows
+   (`packages/web/src/lib/api.ts:1816`).
+
+And the seam that makes the daemon side tractable: the `replyToSession` local
+branch (`daemon.ts:8514-8573`) already implements "inject a synthesized
+message into an arbitrary existing session on its own coordinates, resolving
+the reply transport from that session's platform". Continuation reuses that
+shape with a human sender and an attached webchat sink.
+
+## 4. Design overview
+
+```mermaid
+sequenceDiagram
+    participant B as Browser (console)
+    participant CP as Control Plane
+    participant R as Relay
+    participant D as Daemon (owns session)
+    participant P as Platform (Slack)
+
+    B->>CP: POST /orgs/:orgId/sessions/:sessionId/webchat/token
+    CP->>CP: canContinueSession(user, session)?<br/>agent on session.daemonId? daemon READY?<br/>daemon advertises webchat_session_continuation_v1?
+    CP-->>B: { token, relayUrl, conversationId }
+    B->>R: WS /webchat?token=…
+    R->>CP: rc/verify(webchat-token)
+    CP-->>R: verdict { …, target: {sessionId, platform, channel, thread, transportScope?} }
+    B->>R: { text, turnId }
+    R->>D: rd/msg { source:'webchat', chatId, payload:{op:'turn'…}, target }
+    D->>D: resolve session row by target coords,<br/>synthesize turn ON origin coordinates,<br/>dispatch through per-session serial gate
+    D-->>R: rd/chat stream (message/thought/tool events)
+    R-->>B: live reply stream
+    D->>P: mirror human turn + deliver reply to origin thread<br/>(session's normal output rules)
+```
+
+The design principle: **continuation is a new ingress for an existing session,
+not a new kind of session.** The session keeps its key, its source binding,
+its output rules, and its platform identity. Webchat becomes a second door
+into the room rather than a second room.
+
+## 5. Product decisions
+
+### 5.1 Who may continue a session
+
+Mint-time check, CP-enforced (`canContinueSession`):
+
+- The caller must pass the existing session **view** policy
+  (`session-visibility.md`) — private sessions (platform DMs, sessions with
+  `ownerIdentity`) only for their owner; org-visible sessions for org members
+  the visibility rules admit.
+- Additionally the caller must be able to `canView` the owning **agent** (same
+  gate the webchat mint applies today, `webchat-token.ts:100`).
+
+Rationale: for org-visible channel sessions this is not an escalation — any
+member of the Slack channel can already talk to the agent in that thread, and
+the mirrored delivery (§5.2) keeps the platform audience fully informed. For
+private sessions the owner-only rule matches webchat conversations' existing
+ownership semantics. A stricter owner-only-everywhere variant was considered
+and rejected: it would make the feature useless for the ops use case (continue
+a teammate-triggered channel session from the console), which is the
+motivating scenario.
+
+### 5.2 Where the turn and the reply are delivered
+
+**Mirror to the platform (dual delivery), always.**
+
+- The **human turn** is posted to the origin thread by the bot, attributed:
+  `[<user> via console] <text>` (exact rendering per-platform via the existing
+  turn-output renderers). This uses the same integration client the session's
+  replies use.
+- The **agent reply** is delivered exactly as if the turn had arrived from the
+  platform: the session's output mode and splitting rules apply unchanged
+  ([product-conventions.md](../product-conventions.md)). The webchat stream is
+  an _additional_ sink, not a replacement.
+
+Rationale: a silent console side-channel into a shared thread would make the
+platform transcript lie — later Slack messages would show the agent "knowing"
+things nobody in the channel said. Mirroring keeps both projections honest and
+is what lets §2.1 goal 3 (seamless platform-side continuation) hold for the
+humans as well as for the agent. The suppress-platform-post alternative is
+recorded as rejected for shared conversations; it may return later as an
+explicit per-turn option for DM-origin sessions where the console user _is_
+the platform-side human.
+
+Failure mode: if the integration is disconnected at dispatch time, the turn is
+refused at admission (`reason: 'integration_offline'`) rather than accepted
+into a session that cannot mirror — fail closed, no divergent transcript.
+
+### 5.3 Placement gate
+
+Same invariant as webchat resume: continuation requires the owner agent to be
+currently placed on `session_meta.daemonId` (the immutable content owner,
+`schema.prisma:946`) and that daemon READY and feature-capable. Checked at
+mint time and re-checked at `rc/verify` time (the verify path already
+re-resolves live placement, `registry/webchatVerification.ts:37`).
+
+## 6. Changes by package
+
+### 6.1 `@agentconnect.md/protocol`
+
+- New capability constant in `src/consts.ts`:
+  `WEBCHAT_SESSION_CONTINUATION_FEATURE = 'webchat_session_continuation_v1'`,
+  advertised in the daemon hello capabilities like
+  `WEBCHAT_MULTI_AGENT_FEATURE` (`consts.ts:92`).
+- `RdMsgWebchat` (`frames/relay-daemon.ts:186`) gains an optional
+  `target` object:
+
+  ```ts
+  target?: {
+    sessionId: string        // CP session_meta.id == ACP session id
+    platform: string         // origin coordinates, verbatim from session_meta
+    channel: string
+    thread?: string
+    transportScope?: string
+  }
+  ```
+
+  Absent ⇒ today's behavior (conversation-derived webchat session). The relay
+  copies it verbatim from the verified verdict; it never originates in the
+  browser.
+
+- `RcVerifyResult` for `webchat-token` gains the same optional `target`
+  (populated by the CP from the conversation row at verify time).
+- The webchat status frame (`frames/webchat.ts:100-128`) already carries
+  `sessionId` back to the browser; unchanged.
+
+### 6.2 `@agentconnect.md/control-plane`
+
+- **Schema:** `WebchatConversation` gains a nullable
+  `targetSessionId String? @db.Text` → `SessionMeta.id` (SetNull), plus an
+  index. A conversation with `targetSessionId` set is a **session-targeted
+  conversation**: it has no roster growth (mid-conversation join returns 409),
+  and its `currentSessionId` fence points at the adopted session from the
+  first milestone.
+- **Mint:** new route in `http/routes/webchat-token.ts`:
+
+  ```
+  POST /orgs/:orgId/sessions/:sessionId/webchat/token
+  ```
+
+  Flow: load the session (`getOrgViewableSession` semantics), run
+  `canContinueSession` (§5.1), require `session.platform` chat-origin (§2.2),
+  require the owner agent placed on `session.daemonId`, daemon READY and
+  advertising `webchat_session_continuation_v1`; then find-or-create the
+  caller's session-targeted conversation row for `(userId, targetSessionId)`
+  and mint the standard token (claims unchanged — the target is resolved
+  server-side at verify time, never claimed by the browser). Response shape is
+  the existing `WebchatTokenDto`. OpenAPI `tags`/`summary`/`description`/
+  `operationId` per the repo convention.
+
+- **Verify:** `registry/webchatVerification.ts` — when the conversation row
+  has `targetSessionId`, load the session row, re-check placement
+  (`agent.daemonId === session.daemonId`, READY, feature-capable — otherwise
+  `{ok:false}`), and emit `target` on the verdict with the session's
+  `platform/channel/thread/tenant-scoped transport` columns.
+- **Milestone upsert:** `session.repo.ts:693` `upsertMilestone` already
+  maintains `currentSessionId` under the conversation-row lock; a
+  session-targeted conversation sets it to the adopted session id (the
+  continuation turn reports milestones on the _origin_ session, so the
+  existing upsert path needs the conversation⇄session join taught to it).
+- **Remote MCP:** the delegated-admin machinery keys its current-session fence
+  on the conversation row; a session-targeted conversation **does not offer
+  remote MCP** in v1 (`remoteMcp` never minted for it) — one less authority
+  surface to reason about.
+
+### 6.3 `@agentconnect.md/relay`
+
+- `relay-browser-server.ts`: cache `target` from the verdict on the connection
+  deps next to `chatId` (`:101-111`).
+- `relay-browser-connection.ts` `sendToParticipant` (`:322-353`): stamp
+  `target` onto every `rd/msg` for this conversation. Dedup key stays
+  `(sessionKey == chatId, msgId)` — the conversation id remains the browser
+  stream identity; only the daemon-side dispatch target changes.
+- Routing already follows the verdict's `daemonId`; the CP guarantees it is
+  the session's content owner (§5.3). No `context` fan-out (roster size is 1).
+
+### 6.4 `@agentconnect.md/daemon`
+
+The core change, concentrated in `dispatchWebchatTurn` (`daemon.ts:6628`) plus
+the op handlers keyed off `chatId` (`daemon.ts:9986-10057`):
+
+- **Advertise** `webchat_session_continuation_v1` in hello capabilities.
+- **Target resolution.** When `RdMsgWebchat.target` is present: resolve the
+  local session row by `sessionKey(target.platform, target.channel,
+target.thread, agentId, target.transportScope)`
+  (`store/local-store.ts:279`), cross-checked against
+  `getSessionByAcpId(target.sessionId)`. Missing row or acp-id mismatch ⇒
+  reject (`reason: 'not_found'`) — the verdict may be stale after a purge.
+- **Turn synthesis on origin coordinates** (the `replyToSession` shape,
+  `daemon.ts:8545-8568`, with a human sender):
+
+  ```ts
+  {
+    msgId: `webchat-cont:${chatId}:${turnId}`,   // per-turn: origin thread identity comes from
+    traceId: turnId,                              // target coords, not from a stable msgId
+    source: 'user',
+    platform: target.platform, channel: target.channel,
+    thread: target.thread, transportScope: target.transportScope,
+    transcriptTs: monotonicTs(),
+    sender: { id: user, isBot: false },
+    text, mentionedBots: [botUserId], isDm: <from session row's conversationKind>,
+    trigger: 'dm' | 'mention'                      // per conversationKind, so the agent is addressed
+  }
+  ```
+
+  Because the message rides the origin's own platform/channel/transportScope
+  and `source:'user'`, `conversationExternalSource` (`daemon.ts:15881`)
+  attributes it to the **same** external scope the row is bound to, and
+  `bindSessionSource` (`daemon.ts:15932`) returns `'unchanged'` — the
+  immutability guard holds without a special case. This must be pinned by
+  tests; if the integration is offline the incomplete attribution fails closed
+  (`'unavailable'`), which surfaces as the §5.2 `integration_offline` refusal.
+
+- **Session continuation is then automatic:** `SessionManager.handle` builds
+  the same key, finds the row (`session-manager.ts:447-449,514`), and resumes
+  the ACP session via the existing `loadSession`/recreate ladder
+  (`session-manager.ts:890-1016`).
+- **Dual sinks.** Dispatch with the resolved
+  `integrationIdForSessionTransport(...)` (platform delivery, unchanged rules)
+  **and** the webchat turn stream (`createWebchatTurnStream`) attached, so
+  `Pending.webchat` streams to the browser while turn output posts to the
+  platform. The `webchatRefresh` predicate (`daemon.ts:12574`) and the
+  admission-time transcript append (`daemon.ts:6744-6774`, which writes into
+  the webchat-keyed transcript) are conditioned on "conversation-owned webchat"
+  — a continuation turn's transcript rows land on the origin session's
+  coordinates via the normal SessionManager path instead.
+- **Mirror the human turn** to the origin thread through the integration
+  client before dispatch (§5.2), rendered per-platform.
+- **Keying of the aux ops.** The serial/queue preflight key
+  (`daemon.ts:6718`), `set_model`/`set_effort`/`set_permission_mode`/
+  `set_fast` (`key()` at `daemon.ts:10034-10049`), and `cancel` resolve to the
+  **target session key** when the frame carries `target`; the webchat stream
+  replay map stays keyed by `(turnId, agentId)` (`daemon.ts:6798`) and needs
+  no change. Runtime-set ops stay gated by `allowRuntimeChangesInChat`.
+- **Store:** no schema change. The continuation turn is ordinary session
+  history on existing coordinates.
+
+### 6.5 `@agentconnect.md/web`
+
+- `lib/api.ts`: new binding `mintWebchatSessionToken(orgId, sessionId)`;
+  `webchatWsUrl` accepts the session-target mint as an alternative source.
+  Session DTO mapping: expose enough addressing for integration rows (the
+  session `id` suffices — no need to widen `channelId`).
+- `SessionDetailView.tsx`: introduce `isContinuable` — platform is
+  chat-origin, not webchat/playground, and a **continuation gate** passes:
+  agent still on `session.daemonId` (reuse `lib/session-resume.ts`
+  `sessionResumeState` with the single-member shape) and the daemon advertises
+  the feature (surfaced on the session detail DTO or the agent DTO). `isLive`
+  grows to include `isContinuable`; the composer, typing indicator, and stream
+  lanes bind through the existing `PlaygroundProvider` with the minted
+  session-target conversation. Disabled-state placeholders mirror the existing
+  resume wording ("this session can't continue because the agent moved…",
+  plus "…because its daemon doesn't support continuation yet" and
+  "…because the <platform> integration is offline").
+- `PlaygroundProvider.tsx`: `connect` accepts the session-target mint;
+  everything downstream (streams keyed by `turnId`, `ready` frame carrying the
+  conversation id) is unchanged.
+- The read-only `threadUrl` deep link stays — "continue here" and "open in
+  Slack" are complementary.
+- Runtime pills follow the existing `allowRuntimeChangesInChat` gating
+  unchanged; a continuation shows them only when the agent allows it, exactly
+  like an adopted webchat session.
+
+### 6.6 Documentation
+
+- [product-conventions.md](../product-conventions.md): extend the webchat
+  resume section with the continuation gate and the §5.2 mirroring rule (the
+  user-facing invariant: _continuing a platform session from the console
+  always posts both sides to the platform thread_).
+- [merged-conversation-view.md](merged-conversation-view.md) §9: replace
+  "composer: none — separate product question" with a pointer here; the merged
+  Slack view's composer becomes this feature's multi-agent follow-up.
+- [session-concept.md](session-concept.md) §2.1: note that a `human` turn may
+  enter a platform session via the console ingress, carrying the same source
+  metadata shape.
+
+## 7. Rollout and compatibility
+
+Fail-closed gating at three points, all before any content moves:
+
+1. **CP mint** refuses unless the owning daemon's live capabilities include
+   `webchat_session_continuation_v1` (same pattern as the multi-agent gate,
+   `webchat-token.ts:193-206`).
+2. **CP verify** re-checks the same capability + placement, so a daemon
+   downgrade or agent move between mint and dial invalidates the token.
+3. **Daemon** treats `target` on a frame as mandatory-understood: a daemon
+   that advertises the feature handles it; one that doesn't never receives it
+   (the CP wouldn't have minted). A stale relay that drops the unknown
+   `target` field would silently create a fresh webchat session — to prevent
+   that, the relay echoes the feature in its CP hello and the CP mint also
+   requires a capable relay pool.
+
+No data migration: the new Prisma column is nullable and absent rows behave
+exactly as today. The console feature-detects per session and keeps the
+read-only view otherwise.
+
+## 8. Testing
+
+- **CP unit (`test:unit`):** `canContinueSession` matrix (private/org
+  visibility × owner/member/outsider), placement + capability refusals,
+  chat-origin-only rule, mint/verify round-trip emitting `target`.
+- **CP integration (`test:int`):** conversation adoption row lifecycle,
+  milestone upsert maintaining `currentSessionId` for a session-targeted
+  conversation, mid-conversation join returning 409.
+- **Daemon:** continuation turn into an existing Slack-keyed session resumes
+  the same logical + ACP session (no new row); `bindSessionSource` returns
+  `'unchanged'` for the synthesized turn and `'unavailable'`→refusal when the
+  integration is offline; dual delivery (webchat stream events + platform post
+  through the session transport); serial-gate and cancel keyed on the target
+  session; a platform message arriving mid-continuation queues behind it.
+- **Relay:** `target` passthrough verbatim from verdict to `rd/msg`; no
+  context fan-out for a session-targeted conversation.
+- **Web:** `isContinuable` gating (feature flag off, agent moved, integration
+  offline, hook/dream platforms), composer send path minting the
+  session-target token.
+
+## 9. Open questions
+
+1. **Mirror rendering** — the exact per-platform rendering of the attributed
+   human turn (`[<user> via console]`) belongs to each platform module's
+   renderer; needs per-platform review (Slack blocks vs Telegram plain text).
+2. **DM-origin sessions** — when the console user is provably the same human
+   as the platform DM peer, is the mirror redundant? v1 keeps it (simple,
+   honest); a per-turn "don't post to platform" option is future work.
+3. **Multi-agent threads** — continuing one participant's session of a
+   multi-bot Slack thread mirrors only into that thread; the other bots see
+   the mirrored posts as ordinary thread messages. Whether they should
+   _activate_ on them follows the existing thread-arbitration rules; needs a
+   test to pin the non-activation of the mirrored human turn's `[via console]`
+   form if it @mentions nobody.

--- a/docs/designs/webchat-cross-integration-continuation.md
+++ b/docs/designs/webchat-cross-integration-continuation.md
@@ -47,17 +47,18 @@ of a fresh webchat-owned channel:
   — the same synthesis the `replyToSession` local branch already performs for
   agent-initiated cross-session delivery (`daemon.ts:8514-8573`) — while
   attaching the webchat stream sink so the browser sees the live reply.
-- The turn and its reply are **mirrored to the originating platform thread**
-  (§5.2), so platform participants watching the Slack thread see the same
-  conversation the console user is having. The session remains the single
-  source of truth; both surfaces are projections
+- The human turn is **mirrored to the originating platform thread before ACP
+  dispatch** (§5.2); the reply follows that session's existing output mode.
+  Platform participants therefore never miss input that changed the agent's
+  context, while `none`/muted output keeps its established meaning. The session
+  remains the single source of truth; both surfaces are projections
   ([product-conventions.md](../product-conventions.md), "the session is the
   complete truth; IM is one projection").
 
 Architecture invariants are preserved: the CP stays off the message hot path
 (it only mints and verifies tokens and stores the adoption tuple), the relay
 persists no content, message bodies remain daemon-local, and rolling
-deployments fail closed behind a daemon capability feature flag.
+deployments fail closed behind daemon and relay capability gates.
 
 ## 2. Goals and non-goals
 
@@ -67,13 +68,14 @@ deployments fail closed behind a daemon capability feature flag.
    integration-origin session gets a live composer; sending a turn resumes the
    **same logical and ACP session** — full context, same worktree, same memory.
 2. The reply streams into the console with the full webchat surface (message,
-   thought, tool-call lanes) and is simultaneously delivered to the origin
-   platform thread under the session's normal output rules.
+   thought, tool-call lanes). Its platform projection follows the origin
+   session's normal output rules; the human input is always mirrored first.
 3. Later platform-side messages continue the same session seamlessly — the
    webchat exchange is ordinary session history, not a fork.
-4. Authorization is CP-checked at mint time and daemon-enforced by construction
-   (the browser can never name an arbitrary session; only the signed verdict
-   carries the target).
+4. Authorization is CP-checked at mint time through a distinct
+   `session.continue` action and daemon-enforced by construction (the browser
+   can never name an arbitrary session; only the signed verdict carries the
+   target).
 5. Mixed-version deployments fail closed: an old daemon or relay simply makes
    the CP refuse to mint, and the console keeps today's read-only view.
 
@@ -156,7 +158,8 @@ sequenceDiagram
     D->>D: resolve session row by target coords,<br/>synthesize turn ON origin coordinates,<br/>dispatch through per-session serial gate
     D-->>R: rd/chat stream (message/thought/tool events)
     R-->>B: live reply stream
-    D->>P: mirror human turn + deliver reply to origin thread<br/>(session's normal output rules)
+    D->>P: mirror human turn before dispatch
+    D->>P: project reply when the session output mode allows it
 ```
 
 The design principle: **continuation is a new ingress for an existing session,
@@ -170,25 +173,34 @@ into the room rather than a second room.
 
 Mint-time check, CP-enforced (`canContinueSession`):
 
-- The caller must pass the existing session **view** policy
-  (`session-visibility.md`) — private sessions (platform DMs, sessions with
-  `ownerIdentity`) only for their owner; org-visible sessions for org members
-  the visibility rules admit.
+- Add `AuthorizationAction.SessionContinue` rather than reusing
+  `SessionView`. Continuation is an organization write: `viewer` is refused;
+  `collaborator`/`owner` may continue a shared session only when the ordinary
+  session-view policy also admits them. This is an explicit AgentConnect
+  operator grant to post through the organization's bot — it does not pretend
+  the caller has a platform identity or is a member of the origin channel.
+- Private sessions remain owner-only: the caller's resolved identity set must
+  match `ownerIdentity`; organization role never widens a private audience.
 - Additionally the caller must be able to `canView` the owning **agent** (same
   gate the webchat mint applies today, `webchat-token.ts:100`).
 
-Rationale: for org-visible channel sessions this is not an escalation — any
-member of the Slack channel can already talk to the agent in that thread, and
-the mirrored delivery (§5.2) keeps the platform audience fully informed. For
-private sessions the owner-only rule matches webchat conversations' existing
-ownership semantics. A stricter owner-only-everywhere variant was considered
-and rejected: it would make the feature useless for the ops use case (continue
-a teammate-triggered channel session from the console), which is the
-motivating scenario.
+Rationale: viewing a transcript is not authority to make the bot speak in an
+external system. The distinct write action keeps read-only organization members
+read-only while preserving the motivating ops case for collaborators and
+owners. Provider membership can tighten this action later without changing the
+route; it is not required or inferred in v1.
+
+The grant covers sending a human turn. A targeted conversation does **not**
+offer runtime-setting operations in v1. `set_model`, `set_effort`,
+`set_permission_mode`, and `set_fast` are rejected even when
+`allowRuntimeChangesInChat` is true. `cancel` is accepted only for a `turnId`
+owned by that same targeted conversation's live webchat stream; it is not a
+session-global stop capability.
 
 ### 5.2 Where the turn and the reply are delivered
 
-**Mirror to the platform (dual delivery), always.**
+**Mirror human input to the platform before dispatch; project the reply under
+the existing output rules.**
 
 - The **human turn** is posted to the origin thread by the bot, attributed:
   `[<user> via console] <text>` (exact rendering per-platform via the existing
@@ -197,7 +209,8 @@ motivating scenario.
 - The **agent reply** is delivered exactly as if the turn had arrived from the
   platform: the session's output mode and splitting rules apply unchanged
   ([product-conventions.md](../product-conventions.md)). The webchat stream is
-  an _additional_ sink, not a replacement.
+  an _additional_ sink, not a replacement. In `none` mode the reply remains in
+  the session and webchat stream but is not posted to the platform.
 
 Rationale: a silent console side-channel into a shared thread would make the
 platform transcript lie — later Slack messages would show the agent "knowing"
@@ -208,9 +221,25 @@ recorded as rejected for shared conversations; it may return later as an
 explicit per-turn option for DM-origin sessions where the console user _is_
 the platform-side human.
 
-Failure mode: if the integration is disconnected at dispatch time, the turn is
-refused at admission (`reason: 'integration_offline'`) rather than accepted
-into a session that cannot mirror — fail closed, no divergent transcript.
+This is not a cross-system transaction. The daemon uses the smallest ordering
+that prevents a hidden console input:
+
+1. Resolve the target, run every synchronous admission check, and reserve one
+   slot under the target session's serial key without starting ACP dispatch.
+2. Post the attributed human turn and await the platform acknowledgement. The
+   stable id `webchat-cont:<chatId>:<turnId>` is reused as the provider
+   idempotency key where the provider supports one.
+3. On post failure, release the reservation and refuse the browser turn with
+   `reason: 'integration_delivery_failed'`. On success, commit the reserved
+   dispatch and return the ordinary accepted ack.
+
+A process crash between steps 2 and 3 can leave an attributed platform input
+without an agent reply, but never lets the agent consume input hidden from the
+platform. Retrying the same `turnId` is idempotent at daemon admission and at
+providers that expose idempotency; providers without it may show a duplicate
+attributed input after retry. This is the same projection-failure boundary as
+ordinary platform output and is explicitly not claimed to be atomic. A
+disconnected integration fails at step 1 as `integration_offline`.
 
 ### 5.3 Placement gate
 
@@ -228,6 +257,11 @@ re-resolves live placement, `registry/webchatVerification.ts:37`).
   `WEBCHAT_SESSION_CONTINUATION_FEATURE = 'webchat_session_continuation_v1'`,
   advertised in the daemon hello capabilities like
   `WEBCHAT_MULTI_AGENT_FEATURE` (`consts.ts:92`).
+- `RcRegister` (`frames/relay-cp.ts`) gains
+  `features: z.array(z.string()).default([])` and relays advertise the same
+  feature when they preserve the session target end to end. The default keeps
+  old relays register-compatible. The CP stores the advertised set on the relay
+  row and live relay channel; an absent list means no continuation support.
 - `RdMsgWebchat` (`frames/relay-daemon.ts:186`) gains an optional
   `target` object:
 
@@ -252,12 +286,22 @@ re-resolves live placement, `registry/webchatVerification.ts:37`).
 
 ### 6.2 `@agentconnect.md/control-plane`
 
-- **Schema:** `WebchatConversation` gains a nullable
-  `targetSessionId String? @db.Text` → `SessionMeta.id` (SetNull), plus an
-  index. A conversation with `targetSessionId` set is a **session-targeted
-  conversation**: it has no roster growth (mid-conversation join returns 409),
-  and its `currentSessionId` fence points at the adopted session from the
-  first milestone.
+- **Schema:** `WebchatConversation` gains an immutable
+  `kind WebchatConversationKind @default(STANDARD)` and a nullable
+  `targetSessionId String? @db.Text` → `SessionMeta.id` (`SetNull`).
+  `SESSION_TARGETED` rows require a non-null target at creation; `STANDARD`
+  rows require null. Add `@@unique([userId, targetSessionId])` rather than a
+  plain target index, so concurrent mints for one user/session converge on one
+  browser conversation (Postgres still permits all standard rows because the
+  target is null). A targeted row has no roster growth (mid-conversation join
+  returns 409), and its `currentSessionId` fence points at the adopted session
+  immediately.
+
+  `kind`, not nullability, is the type discriminator. If the target session is
+  purged, `SetNull` leaves a `SESSION_TARGETED` tombstone that can never become
+  an ordinary webchat conversation. Existing rows backfill/default to
+  `STANDARD`.
+
 - **Mint:** new route in `http/routes/webchat-token.ts`:
 
   ```
@@ -267,23 +311,28 @@ re-resolves live placement, `registry/webchatVerification.ts:37`).
   Flow: load the session (`getOrgViewableSession` semantics), run
   `canContinueSession` (§5.1), require `session.platform` chat-origin (§2.2),
   require the owner agent placed on `session.daemonId`, daemon READY and
-  advertising `webchat_session_continuation_v1`; then find-or-create the
-  caller's session-targeted conversation row for `(userId, targetSessionId)`
-  and mint the standard token (claims unchanged — the target is resolved
+  advertising `webchat_session_continuation_v1`; require every live relay in
+  the public pool to advertise the same feature; then upsert the caller's
+  session-targeted conversation row on the `(userId, targetSessionId)` unique
+  key and mint the standard token (claims unchanged — the target is resolved
   server-side at verify time, never claimed by the browser). Response shape is
   the existing `WebchatTokenDto`. OpenAPI `tags`/`summary`/`description`/
   `operationId` per the repo convention.
 
-- **Verify:** `registry/webchatVerification.ts` — when the conversation row
-  has `targetSessionId`, load the session row, re-check placement
-  (`agent.daemonId === session.daemonId`, READY, feature-capable — otherwise
-  `{ok:false}`), and emit `target` on the verdict with the session's
+- **Verify:** `registry/webchatVerification.ts` first requires the conversation
+  row to exist. The legacy empty-roster fallback remains only for an existing
+  `STANDARD` row. For `SESSION_TARGETED`, require a non-null target and a live
+  session row, then re-check placement (`agent.daemonId === session.daemonId`,
+  READY, feature-capable — otherwise `{ok:false}`). A purge therefore makes
+  every outstanding token fail instead of stripping `target` and silently
+  creating a fresh webchat session. A valid verdict carries the session's
   `platform/channel/thread/tenant-scoped transport` columns.
-- **Milestone upsert:** `session.repo.ts:693` `upsertMilestone` already
-  maintains `currentSessionId` under the conversation-row lock; a
-  session-targeted conversation sets it to the adopted session id (the
-  continuation turn reports milestones on the _origin_ session, so the
-  existing upsert path needs the conversation⇄session join taught to it).
+- **Current-session fence:** set `targetSessionId` and `currentSessionId` to the
+  adopted session atomically when the targeted conversation is created.
+  Continuation milestones are ordinary origin-session milestones and carry no
+  webchat conversation id, so `upsertMilestone` needs no new join or special
+  case. Purging the session nulls both FKs while immutable `kind` keeps the row
+  an unusable targeted tombstone.
 - **Remote MCP:** the delegated-admin machinery keys its current-session fence
   on the conversation row; a session-targeted conversation **does not offer
   remote MCP** in v1 (`remoteMcp` never minted for it) — one less authority
@@ -291,6 +340,12 @@ re-resolves live placement, `registry/webchatVerification.ts:37`).
 
 ### 6.3 `@agentconnect.md/relay`
 
+- `relay-cp-client.ts`: include
+  `features: [webchat_session_continuation_v1]` in `rc/register`. The CP's
+  public-pool contract is that every relay which can pass readiness behind
+  `PUBLIC_RELAY_URL` is represented by a live relay row; mint is refused if
+  the live set is empty or any member lacks the feature. During rollout the
+  feature therefore remains off until the last old relay leaves readiness.
 - `relay-browser-server.ts`: cache `target` from the verdict on the connection
   deps next to `chatId` (`:101-111`).
 - `relay-browser-connection.ts` `sendToParticipant` (`:322-353`): stamp
@@ -351,13 +406,17 @@ target.thread, agentId, target.transportScope)`
   — a continuation turn's transcript rows land on the origin session's
   coordinates via the normal SessionManager path instead.
 - **Mirror the human turn** to the origin thread through the integration
-  client before dispatch (§5.2), rendered per-platform.
+  client after reserving admission and before starting dispatch (§5.2),
+  rendered per-platform. A failed post releases the reservation and NAKs the
+  turn; the stable continuation message id drives provider idempotency where
+  available.
 - **Keying of the aux ops.** The serial/queue preflight key
-  (`daemon.ts:6718`), `set_model`/`set_effort`/`set_permission_mode`/
-  `set_fast` (`key()` at `daemon.ts:10034-10049`), and `cancel` resolve to the
-  **target session key** when the frame carries `target`; the webchat stream
-  replay map stays keyed by `(turnId, agentId)` (`daemon.ts:6798`) and needs
-  no change. Runtime-set ops stay gated by `allowRuntimeChangesInChat`.
+  (`daemon.ts:6718`) resolves to the **target session key** when the frame
+  carries `target`. Stream replay stays keyed by `(turnId, agentId)`
+  (`daemon.ts:6798`). `cancel` reaches the target key only after the stream map
+  proves the requested turn belongs to this targeted conversation;
+  `set_model`/`set_effort`/`set_permission_mode`/`set_fast` are refused for a
+  targeted conversation in v1.
 - **Store:** no schema change. The continuation turn is ordinary session
   history on existing coordinates.
 
@@ -384,15 +443,16 @@ target.thread, agentId, target.transportScope)`
 - The read-only `threadUrl` deep link stays — "continue here" and "open in
   Slack" are complementary.
 - Runtime pills follow the existing `allowRuntimeChangesInChat` gating
-  unchanged; a continuation shows them only when the agent allows it, exactly
-  like an adopted webchat session.
+  for ordinary webchat only. A continuation hides them in v1; this ingress may
+  add human input but does not gain session-global runtime administration.
 
 ### 6.6 Documentation
 
 - [product-conventions.md](../product-conventions.md): extend the webchat
   resume section with the continuation gate and the §5.2 mirroring rule (the
   user-facing invariant: _continuing a platform session from the console
-  always posts both sides to the platform thread_).
+  posts the attributed human input before dispatch; the agent reply keeps the
+  session's existing output mode_).
 - [merged-conversation-view.md](merged-conversation-view.md) §9: replace
   "composer: none — separate product question" with a pointer here; the merged
   Slack view's composer becomes this feature's multi-agent follow-up.
@@ -405,40 +465,50 @@ target.thread, agentId, target.transportScope)`
 Fail-closed gating at three points, all before any content moves:
 
 1. **CP mint** refuses unless the owning daemon's live capabilities include
-   `webchat_session_continuation_v1` (same pattern as the multi-agent gate,
-   `webchat-token.ts:193-206`).
+   `webchat_session_continuation_v1` and every live relay behind the public
+   pool advertises it (same daemon pattern as the multi-agent gate,
+   `webchat-token.ts:193-206`). `rc/register.features` is persisted with each
+   relay heartbeat; an empty pool or one old live member keeps the feature off.
 2. **CP verify** re-checks the same capability + placement, so a daemon
-   downgrade or agent move between mint and dial invalidates the token.
+   downgrade or agent move between mint and dial invalidates the token. It also
+   requires the durable conversation row and, for `SESSION_TARGETED`, its live
+   target; deletion never degrades into standard webchat.
 3. **Daemon** treats `target` on a frame as mandatory-understood: a daemon
    that advertises the feature handles it; one that doesn't never receives it
-   (the CP wouldn't have minted). A stale relay that drops the unknown
-   `target` field would silently create a fresh webchat session — to prevent
-   that, the relay echoes the feature in its CP hello and the CP mint also
-   requires a capable relay pool.
+   (the CP wouldn't have minted). A relay advertises the feature only when it
+   preserves `target`; the all-live-relays mint gate prevents a stale relay
+   from silently creating a fresh webchat session during rolling deployment.
 
-No data migration: the new Prisma column is nullable and absent rows behave
-exactly as today. The console feature-detects per session and keeps the
-read-only view otherwise.
+The Prisma migration adds the enum/discriminator, nullable FK, relay feature
+list, and compound unique constraint. Existing conversations backfill/default
+to `STANDARD`; no content backfill is required. The console feature-detects per
+session and keeps the read-only view otherwise.
 
 ## 8. Testing
 
 - **CP unit (`test:unit`):** `canContinueSession` matrix (private/org
-  visibility × owner/member/outsider), placement + capability refusals,
-  chat-origin-only rule, mint/verify round-trip emitting `target`.
+  visibility × owner/collaborator/viewer/outsider), placement + daemon/relay
+  capability refusals, chat-origin-only rule, mint/verify round-trip emitting
+  `target`; a deleted target and a missing conversation row both invalidate an
+  outstanding token instead of returning a standard verdict.
 - **CP integration (`test:int`):** conversation adoption row lifecycle,
-  milestone upsert maintaining `currentSessionId` for a session-targeted
-  conversation, mid-conversation join returning 409.
+  concurrent mints converging on the `(userId, targetSessionId)` unique row,
+  creation atomically installing `currentSessionId`, purge leaving an unusable
+  `SESSION_TARGETED` tombstone, and mid-conversation join returning 409.
 - **Daemon:** continuation turn into an existing Slack-keyed session resumes
   the same logical + ACP session (no new row); `bindSessionSource` returns
-  `'unchanged'` for the synthesized turn and `'unavailable'`→refusal when the
-  integration is offline; dual delivery (webchat stream events + platform post
-  through the session transport); serial-gate and cancel keyed on the target
-  session; a platform message arriving mid-continuation queues behind it.
+  `'unchanged'` for the synthesized turn; admission reservation is released on
+  offline/failed human-mirror delivery and ACP dispatch has not started; a
+  successful mirror commits one target-keyed turn; agent output mode `none`
+  still streams to webchat without a platform reply; cancel is limited to the
+  conversation's own turn and runtime-set ops are refused; a platform message
+  arriving mid-continuation queues behind the reservation/turn.
 - **Relay:** `target` passthrough verbatim from verdict to `rd/msg`; no
-  context fan-out for a session-targeted conversation.
+  context fan-out for a session-targeted conversation; mixed live relay
+  capabilities keep mint disabled until the pool is homogeneous.
 - **Web:** `isContinuable` gating (feature flag off, agent moved, integration
   offline, hook/dream platforms), composer send path minting the
-  session-target token.
+  session-target token, no runtime pills for targeted conversations.
 
 ## 9. Open questions
 

--- a/docs/designs/webchat-cross-integration-continuation.md
+++ b/docs/designs/webchat-cross-integration-continuation.md
@@ -35,15 +35,17 @@ and the daemon _derives_ the local session key from the conversation id
 "deliver this browser turn into the session at `slack:C123:1712.34:agentA`".
 
 This design adds a **session-targeted webchat conversation** — a webchat
-conversation whose durable target is an existing session's coordinates instead
-of a fresh webchat-owned channel:
+conversation whose durable target is an existing session instead of a fresh
+webchat-owned channel:
 
 - The CP mints a webchat token whose conversation row **adopts** a target
   session, after checking the caller may continue it and the owning agent is
   still placed on the daemon that owns the session's content.
-- The relay forwards turns unchanged; the verified verdict carries the target
-  coordinates so the daemon never trusts a browser-supplied session id.
-- The daemon dispatches the turn **onto the target session's own coordinates**
+- The relay forwards turns unchanged; the verified verdict carries the
+  server-selected target session id so the daemon never trusts a
+  browser-supplied session id.
+- The daemon resolves that id in the named agent's local session store and
+  dispatches the turn **onto the target session's own local coordinates**
   — the same synthesis the `replyToSession` local branch already performs for
   agent-initiated cross-session delivery (`daemon.ts:8514-8573`) — while
   attaching the webchat stream sink so the browser sees the live reply.
@@ -72,10 +74,10 @@ deployments fail closed behind daemon and relay capability gates.
    session's normal output rules; the human input is always mirrored first.
 3. Later platform-side messages continue the same session seamlessly — the
    webchat exchange is ordinary session history, not a fork.
-4. Authorization is CP-checked at mint time through a distinct
-   `session.continue` action and daemon-enforced by construction (the browser
-   can never name an arbitrary session; only the signed verdict carries the
-   target).
+4. Authorization is CP-checked at mint time and re-checked at token
+   verification through a distinct `session.continue` action, then
+   daemon-enforced by construction (the browser can never name an arbitrary
+   session; only the signed verdict carries the target).
 5. Mixed-version deployments fail closed: an old daemon or relay simply makes
    the CP refuse to mint, and the console keeps today's read-only view.
 
@@ -85,7 +87,9 @@ deployments fail closed behind daemon and relay capability gates.
   participant: the session's owner agent. Continuing one agent's session of a
   multi-agent Slack thread is in scope; a merged multi-agent continuation
   composer is not (it composes with
-  [merged-conversation-view.md](merged-conversation-view.md) later).
+  [merged-conversation-view.md](merged-conversation-view.md) later). Ordinary
+  platform-side activation of agents already participating in that thread is
+  not adoption and follows §5.2.
 - **No continuation of `hook`/`dream`/`a2a` sessions.** v1 targets chat-origin
   sessions (`originKindOf(platform) === 'chat'`,
   `packages/protocol/src/frames/route.ts:43-60`). Headless-origin sessions have
@@ -152,10 +156,10 @@ sequenceDiagram
     CP-->>B: { token, relayUrl, conversationId }
     B->>R: WS /webchat?token=…
     R->>CP: rc/verify(webchat-token)
-    CP-->>R: verdict { …, target: {sessionId, platform, channel, thread, transportScope?} }
+    CP-->>R: verdict { …, target: {sessionId, platform, channel, thread, tenantScope?} }
     B->>R: { text, turnId }
     R->>D: rd/msg { source:'webchat', chatId, payload:{op:'turn'…}, target }
-    D->>D: resolve session row by target coords,<br/>synthesize turn ON origin coordinates,<br/>dispatch through per-session serial gate
+    D->>D: resolve agent-scoped local row by sessionId,<br/>synthesize turn ON its coordinates,<br/>dispatch through per-session serial gate
     D-->>R: rd/chat stream (message/thought/tool events)
     R-->>B: live reply stream
     D->>P: mirror human turn before dispatch
@@ -171,7 +175,7 @@ into the room rather than a second room.
 
 ### 5.1 Who may continue a session
 
-Mint-time check, CP-enforced (`canContinueSession`):
+Mint-time and verify-time check, CP-enforced (`canContinueSession`):
 
 - Add `AuthorizationAction.SessionContinue` rather than reusing
   `SessionView`. Continuation is an organization write: `viewer` is refused;
@@ -183,6 +187,13 @@ Mint-time check, CP-enforced (`canContinueSession`):
   match `ownerIdentity`; organization role never widens a private audience.
 - Additionally the caller must be able to `canView` the owning **agent** (same
   gate the webchat mint applies today, `webchat-token.ts:100`).
+
+`rc/verify` resolves the signed `userId` to its current organization role and
+identity set and runs the same predicate again. A role, membership, visibility,
+or agent-access change between mint and dial therefore invalidates the token.
+Once the relay accepts a socket, its authorization lifetime follows the
+existing webchat connection model; this design does not add mid-socket
+revocation.
 
 Rationale: viewing a transcript is not authority to make the bot speak in an
 external system. The distinct write action keeps read-only organization members
@@ -206,6 +217,14 @@ the existing output rules.**
   `[<user> via console] <text>` (exact rendering per-platform via the existing
   turn-output renderers). This uses the same integration client the session's
   replies use.
+- The mirror is an ordinary authenticated platform message. Existing thread
+  participants therefore receive it under today's routing rules: the posting
+  agent is excluded as the author and receives the console turn through the
+  targeted dispatch, while other agents already participating in the thread
+  may activate from the mirror. Their turns, hop budget, and loop guard are
+  unchanged. The targeted webchat conversation itself still has one
+  participant and streams only the target agent; v1 does not create a second
+  routing policy for mirrored posts.
 - The **agent reply** is delivered exactly as if the turn had arrived from the
   platform: the session's output mode and splitting rules apply unchanged
   ([product-conventions.md](../product-conventions.md)). The webchat stream is
@@ -268,10 +287,10 @@ re-resolves live placement, `registry/webchatVerification.ts:37`).
   ```ts
   target?: {
     sessionId: string        // CP session_meta.id == ACP session id
-    platform: string         // origin coordinates, verbatim from session_meta
+    platform: string         // validation snapshot from session_meta
     channel: string
     thread?: string
-    transportScope?: string
+    tenantScope?: string     // durable scope; never a daemon transportScope
   }
   ```
 
@@ -297,10 +316,11 @@ re-resolves live placement, `registry/webchatVerification.ts:37`).
   returns 409), and its `currentSessionId` fence points at the adopted session
   immediately.
 
-  `kind`, not nullability, is the type discriminator. If the target session is
-  purged, `SetNull` leaves a `SESSION_TARGETED` tombstone that can never become
-  an ordinary webchat conversation. Existing rows backfill/default to
-  `STANDARD`.
+  `kind`, not nullability, is the type discriminator. Retention purge preserves
+  the target `SessionMeta` row and stamps `contentPurgedAt`, so both FKs remain
+  populated but every continuation gate rejects the row. Actual metadata
+  deletion uses `SetNull`. In either case `SESSION_TARGETED` can never become an
+  ordinary webchat conversation. Existing rows backfill/default to `STANDARD`.
 
 - **Mint:** new route in `http/routes/webchat-token.ts`:
 
@@ -309,8 +329,9 @@ re-resolves live placement, `registry/webchatVerification.ts:37`).
   ```
 
   Flow: load the session (`getOrgViewableSession` semantics), run
-  `canContinueSession` (§5.1), require `session.platform` chat-origin (§2.2),
-  require the owner agent placed on `session.daemonId`, daemon READY and
+  `canContinueSession` (§5.1), require `contentPurgedAt === null`, require
+  `session.platform` chat-origin (§2.2), require the owner agent placed on
+  `session.daemonId`, daemon READY and
   advertising `webchat_session_continuation_v1`; require every live relay in
   the public pool to advertise the same feature; then upsert the caller's
   session-targeted conversation row on the `(userId, targetSessionId)` unique
@@ -321,18 +342,22 @@ re-resolves live placement, `registry/webchatVerification.ts:37`).
 
 - **Verify:** `registry/webchatVerification.ts` first requires the conversation
   row to exist. The legacy empty-roster fallback remains only for an existing
-  `STANDARD` row. For `SESSION_TARGETED`, require a non-null target and a live
-  session row, then re-check placement (`agent.daemonId === session.daemonId`,
-  READY, feature-capable — otherwise `{ok:false}`). A purge therefore makes
-  every outstanding token fail instead of stripping `target` and silently
-  creating a fresh webchat session. A valid verdict carries the session's
-  `platform/channel/thread/tenant-scoped transport` columns.
+  `STANDARD` row. For `SESSION_TARGETED`, require a non-null target, a session
+  row with `contentPurgedAt === null`, and a fresh `canContinueSession` verdict
+  for the signed user, then re-check placement (`agent.daemonId ===
+session.daemonId`, READY, feature-capable — otherwise `{ok:false}`). A
+  retention purge or metadata deletion therefore makes every outstanding token
+  fail instead of stripping `target` and silently creating a fresh webchat
+  session. A valid verdict carries `sessionId` plus the session's
+  `platform/channel/thread/tenantScope` snapshot; it never claims to know the
+  daemon's credential-derived `transportScope`.
 - **Current-session fence:** set `targetSessionId` and `currentSessionId` to the
   adopted session atomically when the targeted conversation is created.
   Continuation milestones are ordinary origin-session milestones and carry no
   webchat conversation id, so `upsertMilestone` needs no new join or special
-  case. Purging the session nulls both FKs while immutable `kind` keeps the row
-  an unusable targeted tombstone.
+  case. Retention purge leaves both FKs intact but `contentPurgedAt` makes the
+  row unusable; actual metadata deletion nulls the FKs. Immutable `kind`
+  prevents either case from degrading into an ordinary webchat conversation.
 - **Remote MCP:** the delegated-admin machinery keys its current-session fence
   on the conversation row; a session-targeted conversation **does not offer
   remote MCP** in v1 (`remoteMcp` never minted for it) — one less authority
@@ -361,22 +386,26 @@ The core change, concentrated in `dispatchWebchatTurn` (`daemon.ts:6628`) plus
 the op handlers keyed off `chatId` (`daemon.ts:9986-10057`):
 
 - **Advertise** `webchat_session_continuation_v1` in hello capabilities.
-- **Target resolution.** When `RdMsgWebchat.target` is present: resolve the
-  local session row by `sessionKey(target.platform, target.channel,
-target.thread, agentId, target.transportScope)`
-  (`store/local-store.ts:279`), cross-checked against
-  `getSessionByAcpId(target.sessionId)`. Missing row or acp-id mismatch ⇒
-  reject (`reason: 'not_found'`) — the verdict may be stale after a purge.
+- **Target resolution.** When `RdMsgWebchat.target` is present, resolve with
+  `getSessionByAcpIdForAgent(agentId, target.sessionId)`; ACP ids are
+  runtime-owned and are not assumed globally unique across agents. Use the
+  returned row's existing `key`, platform/channel/thread, and
+  credential-derived `transportScope` for every local lookup and dispatch.
+  Cross-check the verdict's platform/channel/thread and durable `tenantScope`
+  snapshot against that row and its session classification, but never use the
+  CP snapshot to construct a local session key. Missing row or snapshot
+  mismatch ⇒ reject (`reason: 'not_found'`) — the verdict may be stale after
+  retention GC or metadata replacement.
 - **Turn synthesis on origin coordinates** (the `replyToSession` shape,
   `daemon.ts:8545-8568`, with a human sender):
 
   ```ts
   {
     msgId: `webchat-cont:${chatId}:${turnId}`,   // per-turn: origin thread identity comes from
-    traceId: turnId,                              // target coords, not from a stable msgId
+    traceId: turnId,                              // the local row, not from a stable msgId
     source: 'user',
-    platform: target.platform, channel: target.channel,
-    thread: target.thread, transportScope: target.transportScope,
+    platform: local.platform, channel: local.channel,
+    thread: local.thread, transportScope: local.transportScope,
     transcriptTs: monotonicTs(),
     sender: { id: user, isBot: false },
     text, mentionedBots: [botUserId], isDm: <from session row's conversationKind>,
@@ -384,7 +413,7 @@ target.thread, agentId, target.transportScope)`
   }
   ```
 
-  Because the message rides the origin's own platform/channel/transportScope
+  Because the message rides the local row's own platform/channel/transportScope
   and `source:'user'`, `conversationExternalSource` (`daemon.ts:15881`)
   attributes it to the **same** external scope the row is bound to, and
   `bindSessionSource` (`daemon.ts:15932`) returns `'unchanged'` — the
@@ -426,17 +455,22 @@ target.thread, agentId, target.transportScope)`
   `webchatWsUrl` accepts the session-target mint as an alternative source.
   Session DTO mapping: expose enough addressing for integration rows (the
   session `id` suffices — no need to widen `channelId`).
-- `SessionDetailView.tsx`: introduce `isContinuable` — platform is
-  chat-origin, not webchat/playground, and a **continuation gate** passes:
-  agent still on `session.daemonId` (reuse `lib/session-resume.ts`
-  `sessionResumeState` with the single-member shape) and the daemon advertises
-  the feature (surfaced on the session detail DTO or the agent DTO). `isLive`
-  grows to include `isContinuable`; the composer, typing indicator, and stream
-  lanes bind through the existing `PlaygroundProvider` with the minted
-  session-target conversation. Disabled-state placeholders mirror the existing
-  resume wording ("this session can't continue because the agent moved…",
-  plus "…because its daemon doesn't support continuation yet" and
-  "…because the <platform> integration is offline").
+- The session detail DTO exposes a server-computed `canContinue` and a bounded
+  `continuationUnavailableReason`. It is produced by the same
+  `canContinueSession` predicate and state checks used by mint, covering caller
+  authorization, private ownership, `contentPurgedAt`, chat-origin support,
+  placement, capability, and known integration availability. As with
+  `canChangeVisibility`, the console never re-derives authorization from roles
+  or identities.
+- `SessionDetailView.tsx`: introduce `isContinuable = session.canContinue ===
+true`; structural client checks are display-only and cannot widen the server
+  verdict. `isLive` grows to include `isContinuable`; the composer, typing
+  indicator, and stream lanes bind through the existing `PlaygroundProvider`
+  with the minted session-target conversation. The bounded reason selects
+  product-language disabled copy such as "this session can't continue because
+  the agent moved", "this session can't continue here yet", or "the
+  <platform> connection is offline"; UI copy does not expose Control Plane,
+  Relay, or daemon component names.
 - `PlaygroundProvider.tsx`: `connect` accepts the session-target mint;
   everything downstream (streams keyed by `turnId`, `ready` frame carrying the
   conversation id) is unchanged.
@@ -452,7 +486,8 @@ target.thread, agentId, target.transportScope)`
   resume section with the continuation gate and the §5.2 mirroring rule (the
   user-facing invariant: _continuing a platform session from the console
   posts the attributed human input before dispatch; the agent reply keeps the
-  session's existing output mode_).
+  session's existing output mode; agents already participating in the origin
+  thread receive the mirror under its ordinary routing rules_).
 - [merged-conversation-view.md](merged-conversation-view.md) §9: replace
   "composer: none — separate product question" with a pointer here; the merged
   Slack view's composer becomes this feature's multi-agent follow-up.
@@ -469,10 +504,11 @@ Fail-closed gating at three points, all before any content moves:
    pool advertises it (same daemon pattern as the multi-agent gate,
    `webchat-token.ts:193-206`). `rc/register.features` is persisted with each
    relay heartbeat; an empty pool or one old live member keeps the feature off.
-2. **CP verify** re-checks the same capability + placement, so a daemon
-   downgrade or agent move between mint and dial invalidates the token. It also
-   requires the durable conversation row and, for `SESSION_TARGETED`, its live
-   target; deletion never degrades into standard webchat.
+2. **CP verify** re-checks `canContinueSession`, `contentPurgedAt`, capability,
+   and placement, so an authorization change, retention purge, downgrade, or
+   agent move between mint and dial invalidates the token. It also requires the
+   durable conversation row and, for `SESSION_TARGETED`, its usable target;
+   purge or deletion never degrades into standard webchat.
 3. **Daemon** treats `target` on a frame as mandatory-understood: a daemon
    that advertises the feature handles it; one that doesn't never receives it
    (the CP wouldn't have minted). A relay advertises the feature only when it
@@ -489,25 +525,32 @@ session and keeps the read-only view otherwise.
 - **CP unit (`test:unit`):** `canContinueSession` matrix (private/org
   visibility × owner/collaborator/viewer/outsider), placement + daemon/relay
   capability refusals, chat-origin-only rule, mint/verify round-trip emitting
-  `target`; a deleted target and a missing conversation row both invalidate an
-  outstanding token instead of returning a standard verdict.
+  `target`; a role/access change between mint and verify, `contentPurgedAt`, a
+  deleted target, and a missing conversation row each invalidate an outstanding
+  token instead of returning a standard verdict.
 - **CP integration (`test:int`):** conversation adoption row lifecycle,
   concurrent mints converging on the `(userId, targetSessionId)` unique row,
-  creation atomically installing `currentSessionId`, purge leaving an unusable
-  `SESSION_TARGETED` tombstone, and mid-conversation join returning 409.
+  creation atomically installing `currentSessionId`, retention stamping leaving
+  an explicitly unusable `SESSION_TARGETED` row with intact FKs, metadata
+  deletion leaving a `SetNull` tombstone, and mid-conversation join returning 409.
 - **Daemon:** continuation turn into an existing Slack-keyed session resumes
   the same logical + ACP session (no new row); `bindSessionSource` returns
-  `'unchanged'` for the synthesized turn; admission reservation is released on
-  offline/failed human-mirror delivery and ACP dispatch has not started; a
-  successful mirror commits one target-keyed turn; agent output mode `none`
-  still streams to webchat without a platform reply; cancel is limited to the
-  conversation's own turn and runtime-set ops are refused; a platform message
-  arriving mid-continuation queues behind the reservation/turn.
+  `'unchanged'` for the synthesized turn; agent-scoped ACP-id lookup uses the
+  local row's real key and rejects a mismatched CP snapshot; admission
+  reservation is released on offline/failed human-mirror delivery and ACP
+  dispatch has not started; a successful mirror commits one target-keyed turn;
+  agent output mode `none` still streams to webchat without a platform reply;
+  cancel is limited to the conversation's own turn and runtime-set ops are
+  refused; a platform message arriving mid-continuation queues behind the
+  reservation/turn; the posting agent's provider echo does not duplicate its
+  targeted dispatch, while other existing thread participants follow ordinary
+  activation rules.
 - **Relay:** `target` passthrough verbatim from verdict to `rd/msg`; no
   context fan-out for a session-targeted conversation; mixed live relay
   capabilities keep mint disabled until the pool is homogeneous.
-- **Web:** `isContinuable` gating (feature flag off, agent moved, integration
-  offline, hook/dream platforms), composer send path minting the
+- **Web:** server-computed `canContinue` gating (unauthorized caller, purged
+  content, feature flag off, agent moved, integration offline, hook/dream
+  platforms), product-language disabled reasons, composer send path minting the
   session-target token, no runtime pills for targeted conversations.
 
 ## 9. Open questions
@@ -518,9 +561,3 @@ session and keeps the read-only view otherwise.
 2. **DM-origin sessions** — when the console user is provably the same human
    as the platform DM peer, is the mirror redundant? v1 keeps it (simple,
    honest); a per-turn "don't post to platform" option is future work.
-3. **Multi-agent threads** — continuing one participant's session of a
-   multi-bot Slack thread mirrors only into that thread; the other bots see
-   the mirrored posts as ordinary thread messages. Whether they should
-   _activate_ on them follows the existing thread-arbitration rules; needs a
-   test to pin the non-activation of the mirrored human turn's `[via console]`
-   form if it @mentions nobody.


### PR DESCRIPTION
## Intent

Update PR #692's English cross-integration webchat continuation design to resolve the latest review findings, then commit and push it. The design must resolve the target through the agent-scoped ACP session id and use daemon-local coordinates and transport scope; reject content-purged targets at mint, verify, and UI gates; recheck SessionContinue at token verification; expose server-computed continuation availability to the console; and explicitly preserve existing multi-agent thread activation semantics for mirrored platform posts. Keep the Control Plane off the message hot path, preserve the minimal reservation -> mirror -> dispatch ordering, avoid new transaction or marker infrastructure, make only document changes, and preserve unrelated user edits in .claude/launch.json and packages/web/next.config.mjs.

## What Changed

- Adds `docs/designs/webchat-cross-integration-continuation.md`, a design for letting webchat continue sessions originally started on other integrations, resolving the target through the agent-scoped ACP session id with daemon-local coordinates and transport scope.
- Specifies content-purged targets are rejected at mint, verify, and UI gates, with `SessionContinue` rechecked at token verification and server-computed continuation availability exposed to the console.
- Keeps the Control Plane off the message hot path, preserves the reserve → mirror → dispatch ordering (and existing multi-agent thread activation semantics for mirrored posts), and adds no new transaction or marker infrastructure. Follow-up commits address review feedback (`995b7d62`, `888b11de`).

## Risk Assessment

✅ Low: Documentation-only change adding a single proposed design doc that satisfies every required intent constraint and leaves unrelated files untouched; the only issues are a diagram-vs-prose ordering mismatch and cosmetic line-citation drift, neither affecting product code.

## Testing

This is a documentation-only PR (single new design doc), so there is no runnable code path; the end-user surface is the rendered doc a reviewer reads. Baseline: the diff range touches only docs/designs/webchat-cross-integration-continuation.md and leaves .claude/launch.json and packages/web/next.config.mjs untouched. I verified all internal cross-doc links resolve, rendered the full markdown and the §4 Mermaid sequence diagram to PNG screenshots via headless Chrome (the diagram parses/renders cleanly), and grep-traced all 13 required intent constraints to concrete text in the doc — every one is present. Worktree left clean with all evidence in the evidence directory.

- Evidence: Rendered design doc (marked.js, headless Chrome) (local file: <code>/var/folders/h7/d89rpdxx79zcnvsrmgz_vkw80000gp/T/no-mistakes-evidence/01KZN7T0AR71T5S8F435A4A9MV/full-doc.png</code>)
- Evidence: §4 Mermaid sequence diagram rendered (validates syntax) (local file: <code>/var/folders/h7/d89rpdxx79zcnvsrmgz_vkw80000gp/T/no-mistakes-evidence/01KZN7T0AR71T5S8F435A4A9MV/sequence-diagram.png</code>)
<details>
<summary>Evidence: Acceptance-criteria → doc-text trace</summary>

```text
agent-scoped ACP session id resolution: PRESENT (getSessionByAcpIdForAgent)
daemon-local coords + credential transportScope: PRESENT
reject content-purged at mint/verify/UI: PRESENT (contentPurgedAt === null; every continuation gate rejects)
recheck SessionContinue at verify: PRESENT (fresh canContinueSession verdict)
server-computed console availability + bounded reason: PRESENT (canContinue, continuationUnavailableReason)
preserve multi-agent activation of mirror: PRESENT (may activate from the mirror; hop budget, and loop guard unchanged)
CP off message hot path: PRESENT
reserve->mirror->dispatch ordering, no transaction/schema infra: PRESENT (not a cross-system transaction; no schema change)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `docs/designs/webchat-cross-integration-continuation.md:165` - The §4 sequence diagram places the human-turn mirror (line 165, `D-&gt;&gt;P: mirror human turn before dispatch`) AFTER the ACP dispatch and reply-stream steps (lines 162-164), yet its own label says &#34;before dispatch&#34; and §5.2 is emphatic that the ordering is reserve → mirror → dispatch (&#34;Mirror human input to the platform before dispatch&#34;). The diagram contradicts the authoritative prose and would mislead an implementer reading the flow top-to-bottom. Reorder so the mirror line precedes the `D-&gt;&gt;D: ...dispatch` and `D--&gt;&gt;R: rd/chat stream` lines.
- ℹ️ `docs/designs/webchat-cross-integration-continuation.md:385` - Several exact code citations have drifted from current HEAD: `dispatchWebchatTurn` is at daemon.ts:6670 (doc says 6628), `replyToSession` local branch at ~8521 (doc cites 8514-8573), `bindSessionSource` at 16109 (doc says 15932). The referenced symbols all exist and are substantively accurate, but the line anchors are stale by 40-180 lines, weakening the &#34;exact site&#34; precision the doc claims in §3 and §6.4.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-status cbe431a..888b11de` — confirms one added markdown file, no code/unrelated files changed</code>
- <code>`git diff --name-only ... -- .claude/launch.json packages/web/next.config.mjs` — empty, unrelated user edits preserved</code>
- `Verified all 6 referenced sibling docs (webchat-multi-agents/merged-conversation-view/session-concept/session-visibility/shared-bot-relay/product-conventions) exist so internal links resolve`
- <code>Rendered full markdown to PNG via headless Chrome (marked.js) — `full-doc.png`</code>
- <code>Rendered the §4 Mermaid sequence diagram in isolation — parses and renders without error — `sequence-diagram.png`</code>
- `grep trace mapping each of the 13 required intent constraints to concrete doc text (all present)`
- <code>`git status --porcelain` clean — no transient files left in the worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
