### PR TITLE
fix(setup): correct Tenant Admin configuration audits

### DIFF
--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -1259,12 +1259,22 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       return json(await fetch(api + '/reconcile/logto', { method: 'POST', headers: bearer() }));
     }
 
+    async function refreshDeploymentConfig() {
+      const status = await json(await fetch(api + '/deployment-config', { headers: bearer() }));
+      el('access').hidden = true;
+      el('admin').hidden = false;
+      el('editor').hidden = false;
+      currentRevision = status.revision;
+      renderApps(status);
+      return status;
+    }
+
     async function checkLogto() {
       const report = await json(await fetch(api + '/check/logto', { headers: bearer() }));
-      await load();
+      await refreshDeploymentConfig();
       const failures = report.findings.filter((finding) => finding.status !== 'pass');
       el('logto-status').textContent = failures.length === 0
-        ? 'SPA redirects, CORS, connectors, and social-only sign-in match.'
+        ? 'SPA redirects, connectors, and social-only sign-in match.'
         : failures.map((finding) => finding.message).join(' ');
       el('logto-status').className = failures.length === 0 ? 'ok' : 'warn';
       match('logto-match', failures.length === 0 ? 'pass' : 'warn', failures.length === 0 ? 'Matches' : 'Update required');
@@ -1346,12 +1356,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       }
       try {
         await loadBootstrapInfo();
-        const status = await json(await fetch(api + '/deployment-config', { headers: bearer() }));
-        el('access').hidden = true;
-        el('admin').hidden = false;
-        el('editor').hidden = false;
-        currentRevision = status.revision;
-        renderApps(status);
+        await refreshDeploymentConfig();
         message(notice);
         checkLogto().catch((error) => {
           el('logto-status').textContent = error.message;

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -303,7 +303,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
 
       <section id="feishu-section" class="panel admin-section" aria-labelledby="feishu-heading">
         <div class="provider-head">
-          <div><h3 id="feishu-heading">Feishu</h3><p class="muted">Tenant App used to admit Feishu Bot Apps.</p></div>
+          <div><h3 id="feishu-heading">Feishu</h3><p class="muted">Validates the App ID and secret only. API permissions, event subscriptions, and the published version are not audited.</p></div>
           <span id="feishu-match" class="badge">Not configured</span>
         </div>
         <dl class="credentials">
@@ -327,7 +327,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
 
       <section id="lark-section" class="panel admin-section" aria-labelledby="lark-heading">
         <div class="provider-head">
-          <div><h3 id="lark-heading">Lark</h3><p class="muted">Tenant App used to admit Lark Bot Apps.</p></div>
+          <div><h3 id="lark-heading">Lark</h3><p class="muted">Validates the App ID and secret only. API permissions, event subscriptions, and the published version are not audited.</p></div>
           <span id="lark-match" class="badge">Not configured</span>
         </div>
         <dl class="credentials">
@@ -1191,7 +1191,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
     async function checkRegionalLoginApp(region) {
       const result = await json(await fetch(api + '/check/regional-login-app/' + region, { headers: bearer() }));
       const label = region === 'feishu' ? 'Feishu' : 'Lark';
-      match(region + '-match', result.status === 'pass' ? 'pass' : result.status === 'fail' ? 'fail' : 'warn', result.status === 'pass' ? 'Credentials match' : result.status === 'fail' ? 'Invalid credentials' : 'Could not check');
+      match(region + '-match', result.status === 'pass' ? 'pass' : result.status === 'fail' ? 'fail' : 'warn', result.status === 'pass' ? 'Credentials valid' : result.status === 'fail' ? 'Invalid credentials' : 'Could not check');
       message(result.message || (label + ' credential check completed.'), result.status === 'fail');
     }
 

--- a/packages/setup/src/admin/logto-management.ts
+++ b/packages/setup/src/admin/logto-management.ts
@@ -16,7 +16,6 @@ export interface LogtoSetupDesired {
   applicationName: string
   redirectUris: readonly string[]
   postLogoutRedirectUris: readonly string[]
-  corsAllowedOrigins: readonly string[]
   socialProviders: readonly string[]
   github?: { connectorId: string; clientId: string; clientSecret: string }
   google?: { connectorId: string; clientId: string; clientSecret: string }
@@ -35,7 +34,6 @@ interface LogtoApplication {
   name: string
   type: string
   oidcClientMetadata: Record<string, unknown>
-  customClientMetadata: Record<string, unknown>
   customData: Record<string, unknown>
 }
 
@@ -49,7 +47,6 @@ interface LogtoConnector {
 interface LogtoSignInExperience {
   signIn: Record<string, unknown>
   signUp: Record<string, unknown>
-  socialSignIn: Record<string, unknown>
   socialSignInConnectorTargets: string[]
   signInMode: unknown
 }
@@ -125,6 +122,15 @@ function sameStrings(left: unknown, right: readonly string[]): boolean {
   return JSON.stringify(stringArray(left)) === JSON.stringify(right)
 }
 
+function containsStrings(current: unknown, required: readonly string[]): boolean {
+  const values = new Set(stringArray(current))
+  return required.every((value) => values.has(value))
+}
+
+function mergeStrings(current: unknown, required: readonly string[]): string[] {
+  return [...new Set([...stringArray(current), ...required])]
+}
+
 function addDiff(
   diff: LogtoConfigurationDiff[],
   field: string,
@@ -150,7 +156,6 @@ function parseApplication(value: unknown): LogtoApplication {
     name: row.name,
     type: row.type,
     oidcClientMetadata: asRecord(row.oidcClientMetadata),
-    customClientMetadata: asRecord(row.customClientMetadata),
     customData: asRecord(row.customData)
   }
 }
@@ -275,21 +280,14 @@ export class LogtoAdminClaimClient {
         'Redirect URIs',
         stringArray(application.oidcClientMetadata.redirectUris),
         desired.redirectUris,
-        sameStrings(application.oidcClientMetadata.redirectUris, desired.redirectUris)
+        containsStrings(application.oidcClientMetadata.redirectUris, desired.redirectUris)
       )
       addDiff(
         applicationDiff,
         'Post sign-out redirect URIs',
         stringArray(application.oidcClientMetadata.postLogoutRedirectUris),
         desired.postLogoutRedirectUris,
-        sameStrings(application.oidcClientMetadata.postLogoutRedirectUris, desired.postLogoutRedirectUris)
-      )
-      addDiff(
-        applicationDiff,
-        'CORS allowed origins',
-        stringArray(application.customClientMetadata.corsAllowedOrigins),
-        desired.corsAllowedOrigins,
-        sameStrings(application.customClientMetadata.corsAllowedOrigins, desired.corsAllowedOrigins)
+        containsStrings(application.oidcClientMetadata.postLogoutRedirectUris, desired.postLogoutRedirectUris)
       )
     }
     const signInExperienceDiff: LogtoConfigurationDiff[] = []
@@ -298,12 +296,6 @@ export class LogtoAdminClaimClient {
     addDiff(signInExperienceDiff, 'Secondary identifiers', signInExperience.signUp.secondaryIdentifiers ?? [], [])
     addDiff(signInExperienceDiff, 'Password sign-up', signInExperience.signUp.password ?? null, false)
     addDiff(signInExperienceDiff, 'Sign-up verification', signInExperience.signUp.verify ?? null, false)
-    addDiff(
-      signInExperienceDiff,
-      'Skip required identifiers',
-      signInExperience.socialSignIn.skipRequiredIdentifiers ?? null,
-      true
-    )
     addDiff(
       signInExperienceDiff,
       'Social providers',
@@ -437,7 +429,6 @@ export class LogtoAdminClaimClient {
             redirectUris: desired.redirectUris,
             postLogoutRedirectUris: desired.postLogoutRedirectUris
           },
-          customClientMetadata: { corsAllowedOrigins: desired.corsAllowedOrigins },
           customData: { [MANAGED_APP_TAG]: MANAGED_APP_TAG_VALUE }
         })
       })
@@ -453,12 +444,11 @@ export class LogtoAdminClaimClient {
       body: JSON.stringify({
         oidcClientMetadata: {
           ...existing.oidcClientMetadata,
-          redirectUris: desired.redirectUris,
-          postLogoutRedirectUris: desired.postLogoutRedirectUris
-        },
-        customClientMetadata: {
-          ...existing.customClientMetadata,
-          corsAllowedOrigins: desired.corsAllowedOrigins
+          redirectUris: mergeStrings(existing.oidcClientMetadata.redirectUris, desired.redirectUris),
+          postLogoutRedirectUris: mergeStrings(
+            existing.oidcClientMetadata.postLogoutRedirectUris,
+            desired.postLogoutRedirectUris
+          )
         },
         customData: { ...existing.customData, [MANAGED_APP_TAG]: MANAGED_APP_TAG_VALUE }
       })
@@ -502,9 +492,8 @@ export class LogtoAdminClaimClient {
     return (
       application.type === 'SPA' &&
       (application.id === desired.applicationId || hasManagedTag(application)) &&
-      sameStrings(application.oidcClientMetadata.redirectUris, desired.redirectUris) &&
-      sameStrings(application.oidcClientMetadata.postLogoutRedirectUris, desired.postLogoutRedirectUris) &&
-      sameStrings(application.customClientMetadata.corsAllowedOrigins, desired.corsAllowedOrigins)
+      containsStrings(application.oidcClientMetadata.redirectUris, desired.redirectUris) &&
+      containsStrings(application.oidcClientMetadata.postLogoutRedirectUris, desired.postLogoutRedirectUris)
     )
   }
 
@@ -589,13 +578,12 @@ export class LogtoAdminClaimClient {
 
   private async getSignInExperience(): Promise<LogtoSignInExperience> {
     const value = asRecord(await this.getJson('/api/sign-in-exp'))
-    if (!Array.isArray(value.socialSignInConnectorTargets) || !value.signIn || !value.signUp || !value.socialSignIn) {
+    if (!Array.isArray(value.socialSignInConnectorTargets) || !value.signIn || !value.signUp) {
       throw new LogtoManagementError('LOGTO_UNAVAILABLE', 'Logto returned an invalid sign-in experience')
     }
     return {
       signIn: asRecord(value.signIn),
       signUp: asRecord(value.signUp),
-      socialSignIn: asRecord(value.socialSignIn),
       socialSignInConnectorTargets: stringArray(value.socialSignInConnectorTargets),
       signInMode: value.signInMode
     }
@@ -614,7 +602,6 @@ export class LogtoAdminClaimClient {
       current.signUp.verify === false &&
       (secondaryIdentifiers === undefined ||
         (Array.isArray(secondaryIdentifiers) && secondaryIdentifiers.length === 0)) &&
-      current.socialSignIn.skipRequiredIdentifiers === true &&
       current.signInMode === 'SignInAndRegister' &&
       sameStrings(current.socialSignInConnectorTargets, targets)
     )
@@ -629,7 +616,6 @@ export class LogtoAdminClaimClient {
       body: JSON.stringify({
         signIn: { methods: [] },
         signUp: { identifiers: [], password: false, verify: false, secondaryIdentifiers: [] },
-        socialSignIn: { ...current.socialSignIn, skipRequiredIdentifiers: true },
         socialSignInConnectorTargets: targets,
         signInMode: 'SignInAndRegister'
       })

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -897,7 +897,7 @@ export function buildTenantAdminServer(
               : ('unknown' as const),
         message:
           result.status === 'ok'
-            ? `${label} accepted the saved App ID and secret.`
+            ? `${label} accepted the saved App ID and secret. API permissions, event subscriptions, and the published version were not checked.`
             : result.status === 'invalid'
               ? `${label} rejected the saved App ID or secret.`
               : `${label} could not be reached.`

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -346,7 +346,6 @@ function logtoSetup(
       applicationName: browser.applicationName,
       redirectUris: [appendPath(webOrigin, '/auth/callback'), appendPath(adminOrigin, '/auth/callback')],
       postLogoutRedirectUris: [appendPath(webOrigin, '/login')],
-      corsAllowedOrigins: [...new Set([webOrigin, adminOrigin])],
       socialProviders: [...browser.socialProviders],
       ...(logto.githubConnector && githubSecret
         ? {
@@ -1424,13 +1423,13 @@ export function buildTenantAdminServer(
         ? {
             id: 'logto.application',
             status: 'pass',
-            message: `Logto SPA ${setupInspection.application.id} has the expected redirects and CORS origins.`
+            message: `Logto SPA ${setupInspection.application.id} has all required redirects.`
           }
         : {
             id: 'logto.application',
             status: 'fail',
             message: setupInspection.application.exists
-              ? 'The selected Logto SPA does not match the expected redirects and CORS origins.'
+              ? 'The selected Logto SPA is missing one or more required redirects.'
               : 'The AgentConnect Logto SPA does not exist.',
             diff: setupInspection.application.diff
           }

--- a/packages/setup/test/admin-logto-management.test.ts
+++ b/packages/setup/test/admin-logto-management.test.ts
@@ -210,7 +210,6 @@ describe('Logto setup reconciliation', () => {
       applicationName: 'AgentConnect',
       redirectUris: ['http://localhost:3000/auth/callback', 'http://localhost:8091/auth/callback'],
       postLogoutRedirectUris: ['http://localhost:3000/login'],
-      corsAllowedOrigins: ['http://localhost:3000', 'http://localhost:8091'],
       socialProviders: ['github', 'google', 'slack'],
       github: { connectorId: 'agentconnect-github', clientId: 'github-client', clientSecret: 'github-secret' },
       google: { connectorId: 'agentconnect-google', clientId: 'google-client', clientSecret: 'google-secret' },
@@ -247,7 +246,7 @@ describe('Logto setup reconciliation', () => {
     expect(signInExperience).toMatchObject({
       signIn: { methods: [] },
       signUp: { identifiers: [], password: false, verify: false, secondaryIdentifiers: [] },
-      socialSignIn: { automaticAccountLinking: false, skipRequiredIdentifiers: true },
+      socialSignIn: { automaticAccountLinking: false, skipRequiredIdentifiers: false },
       socialSignInConnectorTargets: ['github', 'google', 'slack'],
       signInMode: 'SignInAndRegister'
     })


### PR DESCRIPTION
## What changed

- Stop managing or auditing Logto CORS allowed origins because redirect URI origins are allowed automatically.
- Treat required redirect and post-logout URLs as a subset, preserving additional valid URLs.
- Stop requiring or mutating the no-op social missing-identifier switch when no sign-up identifiers are configured.
- Break the Tenant Admin Logto check/reload loop that caused the page to flash continuously.
- Label Feishu and Lark checks as credential validation and state that permissions, event subscriptions, and published versions are not audited.

## Why

Tenant Admin treated harmless Logto state as a required update and would overwrite valid configuration. Its check flow also recursively triggered itself after refreshing deployment state. Feishu and Lark token exchange checks could also be mistaken for full permission audits.

## Impact

Working Logto deployments no longer show false update warnings or receive unnecessary configuration writes. Missing required callback URLs are still detected and appended without deleting existing URLs. Feishu and Lark statuses now describe only what the check actually verifies.

## Validation

- pnpm --filter @agentconnect.md/setup typecheck
- pnpm --filter @agentconnect.md/setup build
- pnpm --filter @agentconnect.md/setup exec vitest run test/admin-logto-management.test.ts
- targeted ESLint for the changed setup files
- pre-push full-repository lint