### PR TITLE
fix(setup): derive Logto connector identities

### DIFF
--- a/packages/control-plane/src/persistence/deployment-config.test.ts
+++ b/packages/control-plane/src/persistence/deployment-config.test.ts
@@ -33,7 +33,6 @@ describe('deploymentSecretsRequiringRefresh', () => {
         logto: {
           ...base.logto!,
           githubConnector: {
-            connectorId: 'agentconnect-github',
             appId: 3,
             slug: 'agentconnect-login',
             clientId: 'Iv1.login'
@@ -47,7 +46,6 @@ describe('deploymentSecretsRequiringRefresh', () => {
         logto: {
           ...base.logto!,
           googleConnector: {
-            connectorId: 'agentconnect-google',
             clientId: 'google-client',
             configuredRedirectUris: ['https://login.example.test/callback/agentconnect-google']
           }
@@ -59,7 +57,7 @@ describe('deploymentSecretsRequiringRefresh', () => {
         ...base,
         logto: {
           ...base.logto!,
-          slackConnector: { connectorId: 'agentconnect-slack', appId: 'A1', clientId: '1.1' }
+          slackConnector: { appId: 'A1', clientId: '1.1' }
         }
       })
     ).toEqual([])

--- a/packages/control-plane/src/persistence/deployment-config.ts
+++ b/packages/control-plane/src/persistence/deployment-config.ts
@@ -69,25 +69,37 @@ const LogtoBrowserSchema = z.strictObject({
   socialProviders: z.array(z.string().trim().min(1)).default([])
 })
 
-const LogtoGithubConnectorSchema = z.strictObject({
-  connectorId: z.string().trim().min(1).default('agentconnect-github'),
-  appId: z.number().int().positive(),
-  slug: z.string().trim().min(1),
-  clientId: z.string().trim().min(1)
-})
+function withoutDerivedConnectorId(value: unknown): unknown {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return value
+  const { connectorId: _connectorId, ...stored } = value as Record<string, unknown>
+  return stored
+}
 
-const LogtoGoogleConnectorSchema = z.strictObject({
-  connectorId: z.string().trim().min(1).default('agentconnect-google'),
-  clientId: z.string().trim().min(1),
-  /** Provider-console callbacks last confirmed by the operator. */
-  configuredRedirectUris: z.array(SecureHttpUrlSchema).min(1)
-})
+const LogtoGithubConnectorSchema = z.preprocess(
+  withoutDerivedConnectorId,
+  z.strictObject({
+    appId: z.number().int().positive(),
+    slug: z.string().trim().min(1),
+    clientId: z.string().trim().min(1)
+  })
+)
 
-const LogtoSlackConnectorSchema = z.strictObject({
-  connectorId: z.string().trim().min(1).default('agentconnect-slack'),
-  appId: z.string().trim().min(1),
-  clientId: z.string().trim().min(1)
-})
+const LogtoGoogleConnectorSchema = z.preprocess(
+  withoutDerivedConnectorId,
+  z.strictObject({
+    clientId: z.string().trim().min(1),
+    /** Provider-console callbacks last confirmed by the operator. */
+    configuredRedirectUris: z.array(SecureHttpUrlSchema).min(1)
+  })
+)
+
+const LogtoSlackConnectorSchema = z.preprocess(
+  withoutDerivedConnectorId,
+  z.strictObject({
+    appId: z.string().trim().min(1),
+    clientId: z.string().trim().min(1)
+  })
+)
 
 const GithubAppConfiguredUrlsSchema = z.strictObject({
   externalUrl: SecureOriginUrlSchema,

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -204,7 +204,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <dt>App slug</dt><dd class="value-line"><code id="github-app-slug">Not configured</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
           <dt>Client ID</dt><dd class="value-line"><code id="github-client-id">Not configured</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
           <dt>Webhook delivery</dt><dd class="value-line"><code id="github-webhook-enabled">Not configured</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
-          <dt>Logto connector ID</dt><dd class="value-line"><code id="github-logto-connector-id">Not enabled</code><button class="edit-configuration" data-provider="github">Edit</button></dd>
           <dt>Client secret</dt><dd class="secret-line"><span id="github-client-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="github.clientSecret" data-secret-display="github-client-secret-display">Edit</button></dd>
           <dt>Private key</dt><dd class="secret-line"><span id="github-private-key-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="github.privateKeyB64" data-secret-display="github-private-key-display">Edit</button></dd>
           <dt>Webhook secret</dt><dd class="secret-line"><span id="github-webhook-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="github.webhookSecret" data-secret-display="github-webhook-secret-display">Edit</button></dd>
@@ -218,7 +217,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <label class="field">App slug<input id="github-edit-slug" autocomplete="off"></label>
           <label class="field">Client ID<input id="github-edit-client-id" autocomplete="off"></label>
           <label><input id="github-edit-webhook-enabled" type="checkbox"> Enable Relay webhook delivery</label>
-          <label id="github-edit-connector-id-field" class="field" hidden>Logto connector ID<input id="github-edit-connector-id" autocomplete="off"></label>
           <label class="field">New client secret<input id="github-edit-client-secret" type="password" autocomplete="new-password" placeholder="Required when App or Client ID changes"></label>
           <label class="field">New private key (base64)<textarea id="github-edit-private-key" autocomplete="off" placeholder="Required when App ID changes"></textarea></label>
           <label class="field">New webhook secret<input id="github-edit-webhook-secret" type="password" autocomplete="new-password" placeholder="Required when an active webhook App ID changes"></label>
@@ -249,7 +247,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         <dl class="credentials">
           <dt>App ID</dt><dd class="value-line"><code id="slack-app-id">Not configured</code><button class="edit-configuration" data-provider="slack">Edit</button></dd>
           <dt>Client ID</dt><dd class="value-line"><code id="slack-client-id">Not configured</code><button class="edit-configuration" data-provider="slack">Edit</button></dd>
-          <dt>Logto connector ID</dt><dd class="value-line"><code id="slack-logto-connector-id">Not enabled</code><button class="edit-configuration" data-provider="slack">Edit</button></dd>
           <dt>Client secret</dt><dd class="secret-line"><span id="slack-client-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="slack.clientSecret" data-secret-display="slack-client-secret-display">Edit</button></dd>
           <dt>Signing secret</dt><dd class="secret-line"><span id="slack-signing-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="slack.signingSecret" data-secret-display="slack-signing-secret-display">Edit</button></dd>
           <dt>Logto sign-in</dt><dd id="slack-logto-status">Not configured</dd>
@@ -260,7 +257,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <h3>Edit Slack App identity</h3>
           <label class="field">App ID<input id="slack-edit-app-id" autocomplete="off"></label>
           <label class="field">Client ID<input id="slack-edit-client-id" autocomplete="off"></label>
-          <label id="slack-edit-connector-id-field" class="field" hidden>Logto connector ID<input id="slack-edit-connector-id" autocomplete="off"></label>
           <label class="field">New client secret<input id="slack-edit-client-secret" type="password" autocomplete="new-password" placeholder="Required when identity changes"></label>
           <label class="field">New signing secret<input id="slack-edit-signing-secret" type="password" autocomplete="new-password" placeholder="Required when identity changes"></label>
           <div class="row"><button id="save-slack-configuration">Save configuration</button><button id="cancel-slack-configuration">Cancel</button></div>
@@ -285,7 +281,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         </div>
         <dl class="credentials">
           <dt>Client ID</dt><dd class="value-line"><code id="google-client-id">Not configured</code><button class="edit-configuration" data-provider="google">Edit</button></dd>
-          <dt>Logto connector ID</dt><dd class="value-line"><code id="google-connector-id">Not configured</code><button class="edit-configuration" data-provider="google">Edit</button></dd>
           <dt>Client secret</dt><dd class="secret-line"><span id="google-client-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="logto.googleConnectorClientSecret" data-secret-display="google-client-secret-display">Edit</button></dd>
         </dl>
         <p id="google-status" class="muted"></p>
@@ -295,7 +290,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         <div class="row"><a class="button" href="https://console.cloud.google.com/auth/clients" target="_blank" rel="noopener">Open Google Auth Platform</a></div>
         <div id="google-config-controls" class="subsection">
           <label class="field">Client ID<input id="google-id" autocomplete="off"></label>
-          <label class="field">Logto connector ID<input id="google-connector-id-input" autocomplete="off"></label>
           <label id="google-initial-secret-field" class="field">Client secret<input id="google-secret" type="password" autocomplete="new-password" placeholder="Required when Client ID changes"></label>
         </div>
         <div class="row"><button id="save-google">Save Google client</button><button id="cancel-google-configuration" hidden>Cancel</button><button id="check-google" hidden>Check match</button><button id="clear-google" class="danger" hidden>Clear configuration</button></div>
@@ -597,7 +591,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       text('github-app-slug', github && github.slug);
       text('github-client-id', github && github.clientId);
       text('github-webhook-enabled', github && (github.webhookEnabled === false ? 'Disabled' : 'Enabled'));
-      text('github-logto-connector-id', values.logto && values.logto.githubConnector && values.logto.githubConnector.connectorId);
       el('github-edit-controls').hidden = true;
       showIdentityEditors('github', Boolean(github));
       secretText('github-client-secret-display', byKey, 'github.clientSecret', Boolean(github));
@@ -629,7 +622,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const slack = values.slack;
       text('slack-app-id', slack && slack.appId);
       text('slack-client-id', slack && slack.clientId);
-      text('slack-logto-connector-id', values.logto && values.logto.slackConnector && values.logto.slackConnector.connectorId);
       el('slack-edit-controls').hidden = true;
       showIdentityEditors('slack', Boolean(slack));
       secretText('slack-client-secret-display', byKey, 'slack.clientSecret', Boolean(slack));
@@ -666,11 +658,9 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       renderUriList('google-origins', expectedGoogle.origins);
       renderUriList('google-redirects', expectedGoogle.redirects);
       text('google-client-id', google && google.clientId);
-      text('google-connector-id', google && google.connectorId);
       secretText('google-client-secret-display', byKey, 'logto.googleConnectorClientSecret', Boolean(google));
       showIdentityEditors('google', Boolean(google));
       el('google-id').value = google ? google.clientId : '';
-      el('google-connector-id-input').value = google ? google.connectorId : bootstrapInfo.googleConnectorId;
       el('google-status').textContent = google ? 'Google OAuth client is configured.' : 'Create a Web application OAuth client manually, then save it here.';
       const googleDrift = google && !same(google.configuredRedirectUris, expectedGoogle.redirects)
         ? [{ field: 'Authorized redirect URIs', current: google.configuredRedirectUris, expected: expectedGoogle.redirects }]
@@ -756,9 +746,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         el('github-edit-slug').value = github.slug;
         el('github-edit-client-id').value = github.clientId || '';
         el('github-edit-webhook-enabled').checked = github.webhookEnabled !== false;
-        const githubConnector = values.logto && values.logto.githubConnector;
-        el('github-edit-connector-id').value = githubConnector ? githubConnector.connectorId : '';
-        el('github-edit-connector-id-field').hidden = !githubConnector;
         for (const id of ['github-edit-client-secret', 'github-edit-private-key', 'github-edit-webhook-secret', 'github-edit-logto-secret']) el(id).value = '';
         el('github-edit-logto-secret-field').hidden = !githubConnectorUsesDeployment(values);
         el('github-edit-controls').hidden = false;
@@ -769,9 +756,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         if (!slack) return;
         el('slack-edit-app-id').value = slack.appId;
         el('slack-edit-client-id').value = slack.clientId;
-        const slackConnector = values.logto && values.logto.slackConnector;
-        el('slack-edit-connector-id').value = slackConnector ? slackConnector.connectorId : '';
-        el('slack-edit-connector-id-field').hidden = !slackConnector;
         el('slack-edit-client-secret').value = '';
         el('slack-edit-signing-secret').value = '';
         el('slack-edit-controls').hidden = false;
@@ -781,7 +765,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         const google = values.logto && values.logto.googleConnector;
         if (!google) return;
         el('google-id').value = google.clientId;
-        el('google-connector-id-input').value = google.connectorId;
         el('google-secret').value = '';
         el('google-config-controls').hidden = false;
         el('google-initial-secret-field').hidden = false;
@@ -860,7 +843,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const webhookEnabled = el('github-edit-webhook-enabled').checked;
       const webhookEnabling = webhookEnabled && previous.webhookEnabled === false;
       const connectorReused = githubConnectorUsesDeployment(values);
-      const connectorId = connectorReused ? requiredInput('github-edit-connector-id', 'the Logto connector ID') : null;
       const clientSecret = el('github-edit-client-secret').value;
       const privateKey = el('github-edit-private-key').value.trim();
       const webhookSecret = el('github-edit-webhook-secret').value;
@@ -876,7 +858,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       if (webhookSecret) secrets['github.webhookSecret'] = webhookSecret;
       if (connectorSecret) secrets['logto.githubConnectorClientSecret'] = connectorSecret;
       const nextLogto = connectorReused && values.logto
-        ? { ...values.logto, githubConnector: { ...values.logto.githubConnector, connectorId, appId, slug, clientId } }
+        ? { ...values.logto, githubConnector: { ...values.logto.githubConnector, appId, slug, clientId } }
         : values.logto;
       await replaceConfiguration(
         {
@@ -887,6 +869,10 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         Object.keys(secrets).length ? secrets : undefined,
         'GitHub App identity saved. Restart AgentConnect to apply it.'
       );
+      if (connectorSecret) {
+        await reconcileLogto(true);
+        await load();
+      }
     }
 
     async function saveSlackConfiguration() {
@@ -896,9 +882,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const appId = requiredInput('slack-edit-app-id', 'the Slack App ID');
       const clientId = requiredInput('slack-edit-client-id', 'the Slack Client ID');
       const changed = appId !== previous.appId || clientId !== previous.clientId;
-      const connectorId = values.logto && values.logto.slackConnector
-        ? requiredInput('slack-edit-connector-id', 'the Logto connector ID')
-        : null;
       const clientSecret = el('slack-edit-client-secret').value;
       const signingSecret = el('slack-edit-signing-secret').value;
       if (changed && (!clientSecret || !signingSecret)) throw new Error('Enter both the new Slack client secret and signing secret');
@@ -906,7 +889,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       if (clientSecret) secrets['slack.clientSecret'] = clientSecret;
       if (signingSecret) secrets['slack.signingSecret'] = signingSecret;
       const nextLogto = values.logto && values.logto.slackConnector
-        ? { ...values.logto, slackConnector: { ...values.logto.slackConnector, connectorId, appId, clientId } }
+        ? { ...values.logto, slackConnector: { ...values.logto.slackConnector, appId, clientId } }
         : values.logto;
       await replaceConfiguration(
         {
@@ -917,6 +900,10 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         Object.keys(secrets).length ? secrets : undefined,
         'Slack App identity saved. Restart AgentConnect to apply it.'
       );
+      if (clientSecret && nextLogto && nextLogto.slackConnector) {
+        await reconcileLogto(true);
+        await load();
+      }
     }
 
     async function clearProvider(provider) {
@@ -1070,12 +1057,13 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
     }
 
     async function bootstrapGoogle() {
+      const secret = el('bootstrap-google-secret').value;
       await json(await fetch(api + '/configure/google', {
         method: 'POST', headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ clientId: el('bootstrap-google-id').value, clientSecret: el('bootstrap-google-secret').value })
+        body: JSON.stringify({ clientId: el('bootstrap-google-id').value, clientSecret: secret })
       }));
       el('bootstrap-google-secret').value = '';
-      await reconcileLogto();
+      await reconcileLogto(true);
       await load();
     }
 
@@ -1138,7 +1126,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
               ? { ...logto.browser, socialProviders: [...new Set([...logto.browser.socialProviders, 'slack'])] }
               : logto.browser,
             slackConnector: {
-              connectorId: bootstrapInfo.slackConnectorId,
               appId: slack.appId,
               clientId: slack.clientId
             }
@@ -1200,13 +1187,12 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       await json(await fetch(api + '/configure/google', {
         method: 'POST', headers: { 'content-type': 'application/json', ...bearer() },
         body: JSON.stringify({
-          connectorId: requiredInput('google-connector-id-input', 'the Logto connector ID'),
           clientId: el('google-id').value,
           ...(secret ? { clientSecret: secret } : {})
         })
       }));
       el('google-secret').value = '';
-      await reconcileLogto();
+      await reconcileLogto(Boolean(secret));
       await load();
       message('Google OAuth client and Logto connector are configured. Restart AgentConnect to apply the saved settings.');
     }
@@ -1255,8 +1241,12 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       }
     }
 
-    async function reconcileLogto() {
-      return json(await fetch(api + '/reconcile/logto', { method: 'POST', headers: bearer() }));
+    async function reconcileLogto(refreshConnectorSecrets) {
+      return json(await fetch(api + '/reconcile/logto', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...bearer() },
+        body: JSON.stringify({ refreshConnectorSecrets: Boolean(refreshConnectorSecrets) })
+      }));
     }
 
     async function refreshDeploymentConfig() {
@@ -1376,12 +1366,24 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
     async function saveSecretReplacement(key, value) {
       if (!currentStatus) throw new Error('Deployment configuration is not loaded');
       if (!value) throw new Error('Enter the replacement secret');
-      const saved = await json(await fetch(api + '/deployment-config', {
+      const refreshLogto =
+        (key === 'logto.githubConnectorClientSecret' && currentStatus.values.logto && currentStatus.values.logto.githubConnector) ||
+        (key === 'logto.googleConnectorClientSecret' && currentStatus.values.logto && currentStatus.values.logto.googleConnector) ||
+        (key === 'slack.clientSecret' && currentStatus.values.logto && currentStatus.values.logto.slackConnector);
+      await json(await fetch(api + '/deployment-config', {
         method: 'PUT', headers: { 'content-type': 'application/json', ...bearer() },
         body: JSON.stringify({ expectedRevision: currentRevision, values: currentStatus.values, secrets: { [key]: value } })
       }));
-      await load();
-      message('Secret replaced. Restart AgentConnect to apply it.');
+      try {
+        if (refreshLogto) await reconcileLogto(true);
+      } finally {
+        await load();
+      }
+      if (refreshLogto) {
+        message('Secret replaced and applied to the Logto connector. Restart AgentConnect to apply deployment changes.');
+      } else {
+        message('Secret replaced. Restart AgentConnect to apply it.');
+      }
     }
 
     function editSecret(button) {

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -1146,7 +1146,11 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         body: JSON.stringify({ configToken: token })
       }));
       el('slack-token').value = '';
-      if (result.status === 'pass') await load();
+      if (result.status === 'pass' && currentStatus && currentStatus.values.slack) {
+        currentRevision = result.revision;
+        currentStatus.revision = result.revision;
+        currentStatus.values.slack = { ...currentStatus.values.slack, configuredUrls: result.expected };
+      }
       showDiff('slack-drift', result.diff || []);
       match('slack-match', result.status === 'pass' ? 'pass' : 'warn', result.status === 'pass' ? 'Matches' : 'Update required');
       message(result.status === 'pass' ? 'Slack App matches the default integration manifest.' : 'Slack App settings need an update.', result.status !== 'pass');

--- a/packages/setup/src/admin/logto-management.ts
+++ b/packages/setup/src/admin/logto-management.ts
@@ -1,4 +1,5 @@
 /** Minimal Logto Management API client for setup reconciliation and ADMIN claim. */
+import { LOGTO_GITHUB_CONNECTOR_ID, LOGTO_GOOGLE_CONNECTOR_ID, LOGTO_SLACK_CONNECTOR_ID } from '../logto-connectors.js'
 import { ADMIN_ROLE } from './auth.js'
 
 const MANAGED_APP_TAG = 'agentconnectSetup'
@@ -17,9 +18,9 @@ export interface LogtoSetupDesired {
   redirectUris: readonly string[]
   postLogoutRedirectUris: readonly string[]
   socialProviders: readonly string[]
-  github?: { connectorId: string; clientId: string; clientSecret: string }
-  google?: { connectorId: string; clientId: string; clientSecret: string }
-  slack?: { connectorId: string; clientId: string; clientSecret: string; scope: string }
+  github?: { clientId: string; clientSecret: string }
+  google?: { clientId: string; clientSecret: string }
+  slack?: { clientId: string; clientSecret: string; scope: string }
 }
 
 interface LogtoRole {
@@ -88,6 +89,11 @@ export interface LogtoSetupReconcileResult {
   connectors: Array<{ target: string; id: string; created: boolean; changed: boolean }>
   signInExperienceChanged: boolean
   adminRoleCreated: boolean
+}
+
+export interface LogtoSetupReconcileOptions {
+  /** Explicit secret replacement cannot be verified through Logto's masked read response. */
+  refreshConnectorSecrets?: boolean
 }
 
 export class LogtoManagementError extends Error {
@@ -179,8 +185,7 @@ function desiredConnector(
         'the Logto GitHub connector needs the deployment GitHub App client id and secret'
       )
     }
-    const { connectorId: id, ...config } = desired.github
-    return { id, connectorId: 'github-universal', config }
+    return { id: LOGTO_GITHUB_CONNECTOR_ID, connectorId: 'github-universal', config: desired.github }
   }
   if (target === 'google') {
     if (!desired.google) {
@@ -189,8 +194,7 @@ function desiredConnector(
         'the Logto Google connector needs a Google OAuth client id and secret'
       )
     }
-    const { connectorId: id, ...config } = desired.google
-    return { id, connectorId: 'google-universal', config }
+    return { id: LOGTO_GOOGLE_CONNECTOR_ID, connectorId: 'google-universal', config: desired.google }
   }
   if (target === 'slack') {
     if (!desired.slack) {
@@ -199,27 +203,22 @@ function desiredConnector(
         'the Logto Slack connector needs the deployment Slack App client id and secret'
       )
     }
-    const { connectorId: id, ...config } = desired.slack
-    return { id, connectorId: 'slack-universal', config }
+    return { id: LOGTO_SLACK_CONNECTOR_ID, connectorId: 'slack-universal', config: desired.slack }
   }
   throw new Error(`unsupported managed Logto connector target: ${target}`)
 }
 
 function connectorMatches(connector: LogtoConnector, desired: ReturnType<typeof desiredConnector>): boolean {
   return (
-    connector.connectorId === desired.connectorId && JSON.stringify(connector.config) === JSON.stringify(desired.config)
+    connector.connectorId === desired.connectorId &&
+    connector.config.clientId === desired.config.clientId &&
+    (desired.connectorId !== 'slack-universal' || connector.config.scope === desired.config.scope)
   )
 }
 
-function selectConnector(
-  connectors: readonly LogtoConnector[],
-  target: string,
-  preferredId?: string
-): LogtoConnector | undefined {
+function selectConnector(connectors: readonly LogtoConnector[], target: string): LogtoConnector | undefined {
   const matches = connectors.filter((connector) => connector.target === target)
   if (matches.length <= 1) return matches[0]
-  const preferred = preferredId ? matches.find((connector) => connector.id === preferredId) : undefined
-  if (preferred) return preferred
   throw new LogtoManagementError(
     'SOCIAL_CONNECTOR_AMBIGUOUS',
     `Logto has more than one social connector for target ${target}`
@@ -253,6 +252,17 @@ export class LogtoAdminClaimClient {
   /** Validate only the M2M grant. Never returns the access token. */
   async verifyClientCredentials(): Promise<void> {
     await this.accessToken()
+  }
+
+  /** Resolve provider callback IDs from Logto. These are remote identities, not deployment configuration. */
+  async resolveConnectorIds(targets: readonly string[]): Promise<Record<string, string>> {
+    const connectors = await this.listConnectors()
+    return Object.fromEntries(
+      targets.flatMap((target) => {
+        const connector = selectConnector(connectors, target)
+        return connector ? [[target, connector.id]] : []
+      })
+    )
   }
 
   /** Read roles without mutating Logto and report the exact ADMIN role. */
@@ -323,7 +333,7 @@ export class LogtoAdminClaimClient {
           }
         }
         const expected = desiredConnector(target, desired)
-        const connector = selectConnector(connectors, target, expected.id)
+        const connector = selectConnector(connectors, target)
         const diff: LogtoConfigurationDiff[] = []
         if (!connector) {
           diff.push({ field: `${target} connector`, current: 'Missing', expected: expected.id })
@@ -350,9 +360,12 @@ export class LogtoAdminClaimClient {
     }
   }
 
-  async reconcileSetup(desired: LogtoSetupDesired): Promise<LogtoSetupReconcileResult> {
+  async reconcileSetup(
+    desired: LogtoSetupDesired,
+    options: LogtoSetupReconcileOptions = {}
+  ): Promise<LogtoSetupReconcileResult> {
     const application = await this.ensureApplication(desired)
-    const connectors = await this.ensureConnectors(desired)
+    const connectors = await this.ensureConnectors(desired, options.refreshConnectorSecrets ?? false)
     const signInExperienceChanged = await this.ensureSignInExperience(desired.socialProviders)
     const adminRoleCreated = (await this.ensureAdminRole()).created
     return {
@@ -510,7 +523,8 @@ export class LogtoAdminClaimClient {
   }
 
   private async ensureConnectors(
-    desired: LogtoSetupDesired
+    desired: LogtoSetupDesired,
+    refreshSecrets: boolean
   ): Promise<Array<{ target: string; id: string; created: boolean; changed: boolean }>> {
     const existing = await this.listConnectors()
     const result: Array<{ target: string; id: string; created: boolean; changed: boolean }> = []
@@ -527,8 +541,8 @@ export class LogtoAdminClaimClient {
         continue
       }
       const expected = desiredConnector(target, desired)
-      const connector = selectConnector(existing, target, expected.id)
-      if (connector && connectorMatches(connector, expected)) {
+      const connector = selectConnector(existing, target)
+      if (connector && connectorMatches(connector, expected) && !refreshSecrets) {
         result.push({ target, id: connector.id, created: false, changed: false })
         continue
       }

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -108,7 +108,6 @@ const CreateSlackBody = z.strictObject({
 })
 
 const ConfigureGoogleBody = z.strictObject({
-  connectorId: z.string().trim().min(1).max(500).optional(),
   clientId: z.string().trim().min(1).max(500),
   clientSecret: z.string().min(1).max(10_000).optional()
 })
@@ -132,6 +131,10 @@ const CreateRegionalLoginAppBody = z.strictObject({
 
 const CheckSlackBody = z.strictObject({
   configToken: z.string().trim().min(1).max(10_000)
+})
+
+const ReconcileLogtoBody = z.strictObject({
+  refreshConnectorSecrets: z.boolean().optional().default(false)
 })
 
 interface OidcDiscovery {
@@ -350,7 +353,6 @@ function logtoSetup(
       ...(logto.githubConnector && githubSecret
         ? {
             github: {
-              connectorId: logto.githubConnector.connectorId,
               clientId: logto.githubConnector.clientId,
               clientSecret: githubSecret
             }
@@ -359,7 +361,6 @@ function logtoSetup(
       ...(logto.googleConnector && googleSecret
         ? {
             google: {
-              connectorId: logto.googleConnector.connectorId,
               clientId: logto.googleConnector.clientId,
               clientSecret: googleSecret
             }
@@ -368,38 +369,11 @@ function logtoSetup(
       ...(logto.slackConnector && slackSecret
         ? {
             slack: {
-              connectorId: logto.slackConnector.connectorId,
               clientId: logto.slackConnector.clientId,
               clientSecret: slackSecret,
               scope: 'openid profile email'
             }
           }
-        : {})
-    }
-  }
-}
-
-function withResolvedConnectorIds(
-  values: DeploymentConfigValuesV1,
-  connectors: readonly { target: string; id: string }[]
-): DeploymentConfigValuesV1 {
-  if (!values.logto) return values
-  const connectorIds = new Map(connectors.map((connector) => [connector.target, connector.id]))
-  const githubId = connectorIds.get('github')
-  const googleId = connectorIds.get('google')
-  const slackId = connectorIds.get('slack')
-  return {
-    ...values,
-    logto: {
-      ...values.logto,
-      ...(values.logto.githubConnector && githubId
-        ? { githubConnector: { ...values.logto.githubConnector, connectorId: githubId } }
-        : {}),
-      ...(values.logto.googleConnector && googleId
-        ? { googleConnector: { ...values.logto.googleConnector, connectorId: googleId } }
-        : {}),
-      ...(values.logto.slackConnector && slackId
-        ? { slackConnector: { ...values.logto.slackConnector, connectorId: slackId } }
         : {})
     }
   }
@@ -464,7 +438,19 @@ export function buildTenantAdminServer(
     return result
   }
 
-  const expectedGithubManifest = (values: DeploymentConfigValuesV1): Record<string, unknown> => {
+  type ManagedConnectorIds = Partial<Record<'github' | 'google' | 'slack', string>>
+
+  const resolveLogtoConnectorIds = async (): Promise<ManagedConnectorIds> => {
+    const runtime = await deps.store.getRuntime(['logto.managementAppSecret'])
+    const config = logtoConfig(runtime, logtoManagementEndpoint)
+    if (!config) return {}
+    return new LogtoAdminClaimClient(config, fetchImpl).resolveConnectorIds(['github', 'google', 'slack'])
+  }
+
+  const expectedGithubManifest = (
+    values: DeploymentConfigValuesV1,
+    connectorIds: ManagedConnectorIds
+  ): Record<string, unknown> => {
     const browser = values.logto?.browser
     const connectLogto = Boolean(values.logto?.githubConnector && browser)
     return buildGithubAppManifest(
@@ -475,34 +461,37 @@ export function buildTenantAdminServer(
         ? {
             webUrl: localAuthBootstrap.services.web,
             logtoEndpoint,
-            connectorId: values.logto!.githubConnector!.connectorId
+            connectorId: connectorIds.github ?? LOGTO_GITHUB_CONNECTOR_ID
           }
         : undefined
     )
   }
 
-  const expectedSlackManifest = (values: DeploymentConfigValuesV1): Record<string, unknown> => {
+  const expectedSlackManifest = (
+    values: DeploymentConfigValuesV1,
+    connectorIds: ManagedConnectorIds
+  ): Record<string, unknown> => {
     const browser = values.logto?.browser
     return buildSlackDeploymentManifest(
       slackProviderAppConfig(localAuthBootstrap.services),
       'AgentConnect',
       values.logto?.slackConnector && browser
-        ? { logtoEndpoint, connectorId: values.logto.slackConnector.connectorId }
+        ? { logtoEndpoint, connectorId: connectorIds.slack ?? LOGTO_SLACK_CONNECTOR_ID }
         : undefined
     )
   }
 
-  const providerExpectations = (values: DeploymentConfigValuesV1) => {
+  const providerExpectations = (values: DeploymentConfigValuesV1, connectorIds: ManagedConnectorIds) => {
     let github: ReturnType<typeof githubConfiguredUrls> | null = null
     let slack: ReturnType<typeof slackConfiguredUrls> | null = null
     try {
-      const manifest = expectedGithubManifest(values)
+      const manifest = expectedGithubManifest(values, connectorIds)
       github = githubConfiguredUrls(providerAppConfig(localAuthBootstrap.services), manifest)
     } catch {
       // Invalid startup URLs are surfaced as an unavailable expectation in the UI.
     }
     try {
-      slack = slackConfiguredUrls(expectedSlackManifest(values))
+      slack = slackConfiguredUrls(expectedSlackManifest(values, connectorIds))
     } catch {
       // Slack requires HTTPS startup URLs; the UI keeps creation/check disabled.
     }
@@ -514,7 +503,7 @@ export function buildTenantAdminServer(
             origins: [logtoEndpoint],
             redirects: googleRedirectUris(
               logtoEndpoint,
-              values.logto.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID,
+              connectorIds.google ?? LOGTO_GOOGLE_CONNECTOR_ID,
               localAuthBootstrap.services.web
             )
           }
@@ -522,9 +511,15 @@ export function buildTenantAdminServer(
     }
   }
 
-  const statusWithExpectations = (record: DeploymentConfigAdmin | null) => {
+  const statusWithExpectations = async (record: DeploymentConfigAdmin | null) => {
     const status = toStatus(record)
-    return { ...status, providerExpectations: providerExpectations(status.values) }
+    let connectorIds: ManagedConnectorIds = {}
+    try {
+      connectorIds = await resolveLogtoConnectorIds()
+    } catch {
+      // Logto availability is reported by the dedicated check. Fixed IDs remain correct for connectors we create.
+    }
+    return { ...status, providerExpectations: providerExpectations(status.values, connectorIds) }
   }
 
   app.addHook('onClose', async () => {
@@ -625,8 +620,14 @@ export function buildTenantAdminServer(
 
   app.get('/api/v1/bootstrap-info', { preHandler: requireLocal }, async () => {
     const current = await deps.store.getAdmin()
-    const googleConnectorId = current?.values.logto?.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID
-    const slackConnectorId = current?.values.logto?.slackConnector?.connectorId ?? LOGTO_SLACK_CONNECTOR_ID
+    let connectorIds: ManagedConnectorIds = {}
+    try {
+      connectorIds = await resolveLogtoConnectorIds()
+    } catch {
+      // The setup check reports Logto errors; new connectors still use the fixed IDs below.
+    }
+    const googleConnectorId = connectorIds.google ?? LOGTO_GOOGLE_CONNECTOR_ID
+    const slackConnectorId = connectorIds.slack ?? LOGTO_SLACK_CONNECTOR_ID
     const redirectUris = googleRedirectUris(logtoEndpoint, googleConnectorId, localAuthBootstrap.services.web)
     const logtoConfigured = Boolean(
       current?.values.logto?.managementAppId &&
@@ -661,18 +662,18 @@ export function buildTenantAdminServer(
       logtoAdminEndpoint,
       logtoConfigured,
       logtoManagementAppId: current?.values.logto?.managementAppId ?? null,
-      googleConnectorId,
       google: { javascriptOrigins: [logtoEndpoint], redirectUris },
       githubAvailable,
       githubWebhookActive,
       slackAvailable,
-      slackConnectorId,
       slackLoginRedirectUrl: appendPath(slackLoginEndpoint, `/callback/${slackConnectorId}`)
     }
   })
 
-  app.get('/api/v1/deployment-config', { preHandler: requireConfigurationAccess }, async () =>
-    statusWithExpectations(await deps.store.getAdmin())
+  app.get(
+    '/api/v1/deployment-config',
+    { preHandler: requireConfigurationAccess },
+    async () => await statusWithExpectations(await deps.store.getAdmin())
   )
 
   app.put('/api/v1/deployment-config', { preHandler: requireConfigurationAccess }, async (request, reply) => {
@@ -685,7 +686,7 @@ export function buildTenantAdminServer(
       values: parsed.data.values
     })
     return {
-      ...statusWithExpectations(saved),
+      ...(await statusWithExpectations(saved)),
       restartRequired: true as const
     }
   })
@@ -707,7 +708,7 @@ export function buildTenantAdminServer(
         }
       )
       const saved = await deps.store.replace({ expectedRevision: current?.revision ?? 0, ...put })
-      return { ...statusWithExpectations(saved), restartRequired: true as const }
+      return { ...(await statusWithExpectations(saved)), restartRequired: true as const }
     })
   })
 
@@ -728,6 +729,7 @@ export function buildTenantAdminServer(
         !current.values.logto?.githubConnector &&
         (parsed.data.connectLogto || browser.socialProviders.includes('github'))
       )
+      const connectorIds = connectLogto ? await resolveLogtoConnectorIds() : {}
       manifest = buildGithubAppManifest(
         providerAppConfig(localAuthBootstrap.services),
         parsed.data.name,
@@ -736,7 +738,7 @@ export function buildTenantAdminServer(
           ? {
               webUrl: localAuthBootstrap.services.web,
               logtoEndpoint,
-              connectorId: LOGTO_GITHUB_CONNECTOR_ID
+              connectorId: connectorIds.github ?? LOGTO_GITHUB_CONNECTOR_ID
             }
           : undefined
       )
@@ -828,11 +830,10 @@ export function buildTenantAdminServer(
     return serializeMutation(async () => {
       const current = await deps.store.getAdmin()
       if (!current?.values.logto?.browser) return problem(reply, 409, 'save Logto browser configuration first')
-      const connectorId =
-        parsed.data.connectorId ?? current.values.logto.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID
+      const connectorIds = await resolveLogtoConnectorIds()
+      const connectorId = connectorIds.google ?? LOGTO_GOOGLE_CONNECTOR_ID
       const redirectUris = googleRedirectUris(logtoEndpoint, connectorId, localAuthBootstrap.services.web)
       const put = logtoGoogleConnectorPut(current, {
-        ...(parsed.data.connectorId ? { connectorId: parsed.data.connectorId } : {}),
         clientId: parsed.data.clientId,
         ...(parsed.data.clientSecret ? { clientSecret: parsed.data.clientSecret } : {}),
         configuredRedirectUris: redirectUris
@@ -1026,7 +1027,12 @@ export function buildTenantAdminServer(
         manifest = buildSlackDeploymentManifest(
           slackProviderAppConfig(localAuthBootstrap.services),
           parsed.data.name,
-          parsed.data.connectLogto && browser ? { logtoEndpoint, connectorId: LOGTO_SLACK_CONNECTOR_ID } : undefined
+          parsed.data.connectLogto && browser
+            ? {
+                logtoEndpoint,
+                connectorId: (await resolveLogtoConnectorIds()).slack ?? LOGTO_SLACK_CONNECTOR_ID
+              }
+            : undefined
         )
       } catch (error) {
         return problem(reply, 409, error instanceof Error ? error.message : 'Slack App configuration is incomplete')
@@ -1070,7 +1076,7 @@ export function buildTenantAdminServer(
     }
     let manifest: Record<string, unknown>
     try {
-      manifest = expectedGithubManifest(runtime.values)
+      manifest = expectedGithubManifest(runtime.values, await resolveLogtoConnectorIds())
     } catch (error) {
       return problem(reply, 409, error instanceof Error ? error.message : 'GitHub App configuration is incomplete')
     }
@@ -1128,7 +1134,7 @@ export function buildTenantAdminServer(
       if (!current || !slack) return problem(reply, 409, 'the deployment Slack App is not configured')
       let manifest: Record<string, unknown>
       try {
-        manifest = expectedSlackManifest(current.values)
+        manifest = expectedSlackManifest(current.values, await resolveLogtoConnectorIds())
       } catch (error) {
         return problem(reply, 409, error instanceof Error ? error.message : 'Slack App configuration is incomplete')
       }
@@ -1166,8 +1172,10 @@ export function buildTenantAdminServer(
     })
   })
 
-  app.post('/api/v1/reconcile/logto', { preHandler: requireConfigurationAccess }, async (_request, reply) =>
+  app.post('/api/v1/reconcile/logto', { preHandler: requireConfigurationAccess }, async (request, reply) =>
     serializeMutation(async () => {
+      const parsed = ReconcileLogtoBody.safeParse(request.body ?? {})
+      if (!parsed.success) return problem(reply, 400, 'invalid Logto reconciliation options')
       const secretKeys = [
         'logto.managementAppSecret',
         'logto.githubConnectorClientSecret',
@@ -1214,7 +1222,9 @@ export function buildTenantAdminServer(
       }
 
       const client = deps.makeLogtoSetupClient?.(config) ?? new LogtoAdminClaimClient(config)
-      const reconciled = await client.reconcileSetup(setup.desired)
+      const reconciled = await client.reconcileSetup(setup.desired, {
+        refreshConnectorSecrets: parsed.data.refreshConnectorSecrets
+      })
       const auth = {
         mode: 'oidc' as const,
         audience: setup.apiResource ?? reconciled.application.id,
@@ -1224,7 +1234,7 @@ export function buildTenantAdminServer(
         },
         socialProviders: setup.socialProviders
       }
-      const nextValues = withResolvedConnectorIds({ ...runtime.values, auth }, reconciled.connectors)
+      const nextValues = { ...runtime.values, auth }
       const configChanged = JSON.stringify(runtime.values) !== JSON.stringify(nextValues)
       const saved = configChanged
         ? await deps.store.replace({
@@ -1403,20 +1413,6 @@ export function buildTenantAdminServer(
         ]
       })
       return report()
-    }
-    const resolvedValues = withResolvedConnectorIds(
-      runtime.values,
-      setupInspection.connectors.flatMap((connector) =>
-        connector.id ? [{ target: connector.target, id: connector.id }] : []
-      )
-    )
-    if (JSON.stringify(resolvedValues) !== JSON.stringify(runtime.values)) {
-      await serializeMutation(() => deps.store.replace({ expectedRevision: runtime.revision, values: resolvedValues }))
-      findings.push({
-        id: 'logto.connector_references',
-        status: 'pass',
-        message: 'Tenant Admin adopted the existing Logto connector IDs.'
-      })
     }
     findings.push(
       setupInspection.application.exists && setupInspection.application.matches

--- a/packages/setup/src/deployment-config-client.ts
+++ b/packages/setup/src/deployment-config-client.ts
@@ -5,7 +5,6 @@ import {
   type DeploymentConfigValuesV1
 } from '@agentconnect.md/control-plane/deployment-config-store'
 import { z } from 'zod'
-import { LOGTO_GITHUB_CONNECTOR_ID, LOGTO_GOOGLE_CONNECTOR_ID, LOGTO_SLACK_CONNECTOR_ID } from './logto-connectors.js'
 
 export const DeploymentConfigPutSchema = z.strictObject({
   values: DeploymentConfigValuesV1Schema,
@@ -61,7 +60,6 @@ export function githubDeploymentPut(
                   }
                 : connectLogto.browser,
               githubConnector: {
-                connectorId: LOGTO_GITHUB_CONNECTOR_ID,
                 appId,
                 slug: credentials.slug,
                 clientId: credentials.clientId
@@ -143,7 +141,6 @@ export function logtoGithubConnectorPut(
             }
           : current.values.logto.browser,
         githubConnector: {
-          connectorId: current.values.logto.githubConnector?.connectorId ?? LOGTO_GITHUB_CONNECTOR_ID,
           appId,
           slug: credentials.slug,
           clientId: credentials.clientId
@@ -195,7 +192,6 @@ export function slackDeploymentPut(
                   }
                 : logto.browser,
               slackConnector: {
-                connectorId: logto.slackConnector?.connectorId ?? LOGTO_SLACK_CONNECTOR_ID,
                 appId: credentials.appId,
                 clientId: credentials.clientId
               }
@@ -211,7 +207,6 @@ export function slackDeploymentPut(
 }
 
 export interface LogtoGoogleConnectorCredentials {
-  connectorId?: string
   clientId: string
   clientSecret?: string
   configuredRedirectUris: string[]
@@ -237,8 +232,6 @@ export function logtoGoogleConnectorPut(
             }
           : current.values.logto.browser,
         googleConnector: {
-          connectorId:
-            credentials.connectorId ?? current.values.logto.googleConnector?.connectorId ?? LOGTO_GOOGLE_CONNECTOR_ID,
           clientId: credentials.clientId,
           configuredRedirectUris: credentials.configuredRedirectUris
         }

--- a/packages/setup/test/admin-logto-management.test.ts
+++ b/packages/setup/test/admin-logto-management.test.ts
@@ -211,10 +211,9 @@ describe('Logto setup reconciliation', () => {
       redirectUris: ['http://localhost:3000/auth/callback', 'http://localhost:8091/auth/callback'],
       postLogoutRedirectUris: ['http://localhost:3000/login'],
       socialProviders: ['github', 'google', 'slack'],
-      github: { connectorId: 'agentconnect-github', clientId: 'github-client', clientSecret: 'github-secret' },
-      google: { connectorId: 'agentconnect-google', clientId: 'google-client', clientSecret: 'google-secret' },
+      github: { clientId: 'github-client', clientSecret: 'github-secret' },
+      google: { clientId: 'google-client', clientSecret: 'google-secret' },
       slack: {
-        connectorId: 'agentconnect-slack',
         clientId: 'slack-client',
         clientSecret: 'slack-secret',
         scope: 'openid profile email'


### PR DESCRIPTION
## What changed

- derive GitHub, Google, and Slack connector instance IDs from Logto instead of persisting or editing them as deployment configuration
- use deterministic connector instance IDs only when Tenant Admin creates a missing connector
- compare only readable OAuth fields during connector audits, so Logto's masked client secrets do not produce false drift
- explicitly push connector secrets to Logto when an operator replaces one

## Why

The deployment document called the remote Logto connector instance `id` a `connectorId`, even though Logto uses `connectorId` for the connector factory. That made a derived remote identity look like editable tenant configuration. Connector audits also compared the complete returned configuration against a plaintext desired secret, even though Logto masks confidential values on reads.

Existing pre-release documents that contain the derived field are accepted and normalized without a database migration.

## Validation

- `pnpm --filter @agentconnect.md/setup build`
- `pnpm --filter @agentconnect.md/setup typecheck`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/setup exec vitest run test/admin-logto-management.test.ts`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run src/persistence/deployment-config.test.ts`
- parsed the embedded Tenant Admin browser script with `new Function(...)`
- pre-push repository lint
