### PR TITLE
fix(setup): remove unverifiable provider URL snapshots

### DIFF
--- a/packages/control-plane/src/persistence/deployment-config.test.ts
+++ b/packages/control-plane/src/persistence/deployment-config.test.ts
@@ -46,8 +46,7 @@ describe('deploymentSecretsRequiringRefresh', () => {
         logto: {
           ...base.logto!,
           googleConnector: {
-            clientId: 'google-client',
-            configuredRedirectUris: ['https://login.example.test/callback/agentconnect-google']
+            clientId: 'google-client'
           }
         }
       })

--- a/packages/control-plane/src/persistence/deployment-config.ts
+++ b/packages/control-plane/src/persistence/deployment-config.ts
@@ -32,18 +32,6 @@ const HttpUrlSchema = z
     }
   })
 
-function isSecureHttpUrl(value: string): boolean {
-  const url = new URL(value)
-  const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase()
-  const loopback =
-    hostname === 'localhost' || hostname.endsWith('.localhost') || hostname === '127.0.0.1' || hostname === '::1'
-  return url.protocol === 'https:' || loopback
-}
-const SecureHttpUrlSchema = HttpUrlSchema.refine(isSecureHttpUrl, 'must use HTTPS unless it is loopback')
-const SecureOriginUrlSchema = SecureHttpUrlSchema.refine(
-  (value) => new URL(value).pathname === '/',
-  'must be an origin without a path'
-)
 const NullableUrlSchema = HttpUrlSchema.nullable()
 
 const AuthSchema = z.discriminatedUnion('mode', [
@@ -85,6 +73,12 @@ function withoutGoogleProviderSnapshot(value: unknown): unknown {
   return stored
 }
 
+function withoutProviderUrlSnapshot(value: unknown): unknown {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return value
+  const { configuredUrls: _configuredUrls, ...stored } = value as Record<string, unknown>
+  return stored
+}
+
 const LogtoGithubConnectorSchema = z.preprocess(
   withoutDerivedConnectorId,
   z.strictObject({
@@ -109,49 +103,35 @@ const LogtoSlackConnectorSchema = z.preprocess(
   })
 )
 
-const GithubAppConfiguredUrlsSchema = z.strictObject({
-  externalUrl: SecureOriginUrlSchema,
-  setupUrl: SecureHttpUrlSchema,
-  webhookUrl: SecureHttpUrlSchema,
-  webhookActive: z.boolean().optional(),
-  callbackUrls: z.array(SecureHttpUrlSchema)
-})
-
-const SlackAppConfiguredUrlsSchema = z.strictObject({
-  oauthRedirectUrl: SecureHttpUrlSchema,
-  eventsUrl: SecureHttpUrlSchema,
-  interactionsUrl: SecureHttpUrlSchema,
-  loginRedirectUrl: SecureHttpUrlSchema.optional(),
-  socialLinkRedirectUrl: SecureHttpUrlSchema.optional()
-})
-
 const RegionalLoginAppSchema = z.strictObject({
   loginAppId: z.string().trim().min(1)
 })
+
+const GithubAppSchema = z.preprocess(
+  withoutProviderUrlSnapshot,
+  z.strictObject({
+    appId: z.number().int().positive(),
+    slug: z.string().trim().min(1),
+    clientId: z.string().trim().min(1).nullable(),
+    /** Whether Relay should accept GitHub webhook delivery for this App. Omitted means enabled. */
+    webhookEnabled: z.boolean().optional()
+  })
+)
+
+const SlackAppSchema = z.preprocess(
+  withoutProviderUrlSnapshot,
+  z.strictObject({
+    appId: z.string().trim().min(1),
+    clientId: z.string().trim().min(1)
+  })
+)
 
 /** Version 1 of the JSONB document persisted in `deployment_config.values`. */
 export const DeploymentConfigValuesV1Schema = z
   .strictObject({
     auth: AuthSchema,
-    github: z
-      .strictObject({
-        appId: z.number().int().positive(),
-        slug: z.string().trim().min(1),
-        clientId: z.string().trim().min(1).nullable(),
-        /** Whether Relay should accept GitHub webhook delivery for this App. Omitted means enabled. */
-        webhookEnabled: z.boolean().optional(),
-        /** Provider URL settings submitted by setup during GitHub App Manifest creation. Never live verification. */
-        configuredUrls: GithubAppConfiguredUrlsSchema.optional()
-      })
-      .nullable(),
-    slack: z
-      .strictObject({
-        appId: z.string().trim().min(1),
-        clientId: z.string().trim().min(1),
-        /** Provider settings last verified through Slack's manifest API. */
-        configuredUrls: SlackAppConfiguredUrlsSchema.optional()
-      })
-      .nullable(),
+    github: GithubAppSchema.nullable(),
+    slack: SlackAppSchema.nullable(),
     /** Regional Login Apps used as the tenant anchor for Bot App admission. */
     feishu: RegionalLoginAppSchema.nullable().optional(),
     lark: RegionalLoginAppSchema.nullable().optional(),

--- a/packages/control-plane/src/persistence/deployment-config.ts
+++ b/packages/control-plane/src/persistence/deployment-config.ts
@@ -75,6 +75,16 @@ function withoutDerivedConnectorId(value: unknown): unknown {
   return stored
 }
 
+function withoutGoogleProviderSnapshot(value: unknown): unknown {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return value
+  const {
+    connectorId: _connectorId,
+    configuredRedirectUris: _configuredRedirectUris,
+    ...stored
+  } = value as Record<string, unknown>
+  return stored
+}
+
 const LogtoGithubConnectorSchema = z.preprocess(
   withoutDerivedConnectorId,
   z.strictObject({
@@ -85,11 +95,9 @@ const LogtoGithubConnectorSchema = z.preprocess(
 )
 
 const LogtoGoogleConnectorSchema = z.preprocess(
-  withoutDerivedConnectorId,
+  withoutGoogleProviderSnapshot,
   z.strictObject({
-    clientId: z.string().trim().min(1),
-    /** Provider-console callbacks last confirmed by the operator. */
-    configuredRedirectUris: z.array(SecureHttpUrlSchema).min(1)
+    clientId: z.string().trim().min(1)
   })
 )
 

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -287,6 +287,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         <div id="google-drift" class="notice" hidden></div>
         <p>Authorized JavaScript origin:</p><ul id="google-origins" class="uris"></ul>
         <p>Authorized redirect URIs:</p><ul id="google-redirects" class="uris"></ul>
+        <p class="muted">Google does not expose OAuth client redirect settings through an API. Copy these required values into Google Auth Platform; Tenant Admin can verify only the Logto connector.</p>
         <div class="row"><a class="button" href="https://console.cloud.google.com/auth/clients" target="_blank" rel="noopener">Open Google Auth Platform</a></div>
         <div id="google-config-controls" class="subsection">
           <label class="field">Client ID<input id="google-id" autocomplete="off"></label>
@@ -662,11 +663,8 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       showIdentityEditors('google', Boolean(google));
       el('google-id').value = google ? google.clientId : '';
       el('google-status').textContent = google ? 'Google OAuth client is configured.' : 'Create a Web application OAuth client manually, then save it here.';
-      const googleDrift = google && !same(google.configuredRedirectUris, expectedGoogle.redirects)
-        ? [{ field: 'Authorized redirect URIs', current: google.configuredRedirectUris, expected: expectedGoogle.redirects }]
-        : [];
-      showDiff('google-drift', googleDrift);
-      match('google-match', !google || !googleSecret ? '' : googleDrift.length ? 'warn' : '', !google ? 'Not configured' : !googleSecret ? 'Missing secret' : googleDrift.length ? 'Update required' : 'Ready to check');
+      showDiff('google-drift', []);
+      match('google-match', google && googleSecret ? 'warn' : '', !google ? 'Not configured' : !googleSecret ? 'Missing secret' : "Can't verify automatically");
       el('google-initial-secret-field').hidden = googleSecret;
       el('save-google').textContent = google ? 'Confirm callback settings' : 'Save Google client';
       el('google-config-controls').hidden = Boolean(google);
@@ -1160,23 +1158,18 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const report = await checkLogto();
       const connector = report.findings.find((finding) => finding.id === 'logto.connectors');
       const google = currentStatus && currentStatus.values.logto && currentStatus.values.logto.googleConnector;
-      const expected = currentStatus ? currentStatus.providerExpectations.google : { redirects: [] };
-      const callbacksMatch = google && same(google.configuredRedirectUris, expected.redirects);
-      const passed = connector && connector.status === 'pass' && callbacksMatch;
       const connectorDiff = connector && connector.diff
         ? connector.diff.filter((item) => item.field.toLowerCase().startsWith('google'))
         : [];
-      showDiff(
-        'google-drift',
-        [
-          ...connectorDiff,
-          ...(callbacksMatch || !google
-            ? []
-            : [{ field: 'Authorized redirect URIs', current: google.configuredRedirectUris, expected: expected.redirects }])
-        ]
+      const passed = Boolean(google && connector && connectorDiff.length === 0);
+      showDiff('google-drift', connectorDiff);
+      match('google-match', passed ? 'pass' : 'warn', passed ? 'Logto matches' : 'Update required');
+      message(
+        passed
+          ? "The Logto Google connector matches. Google OAuth redirect settings can't be verified automatically."
+          : 'The Logto Google connector needs an update.',
+        !passed
       );
-      match('google-match', passed ? 'pass' : 'warn', passed ? 'Matches' : 'Update required');
-      message(passed ? 'Google callbacks and the Logto connector match.' : 'Google or its Logto connector needs an update.', !passed);
     }
 
     async function checkRegionalLoginApp(region) {

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -382,7 +382,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
     };
     const base64url = (bytes) => btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
     const random = () => base64url(crypto.getRandomValues(new Uint8Array(32)));
-    const same = (a, b) => JSON.stringify([...(a || [])].sort()) === JSON.stringify([...(b || [])].sort());
     const configured = (byKey, key) => Boolean(byKey.get(key) && byKey.get(key).configured);
 
     function showIdentityEditors(provider, show) {
@@ -494,22 +493,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       return { owner: 'organization', organization };
     }
 
-    function valuesMatch(current, expected) {
-      if (Array.isArray(expected)) return same(current, expected);
-      return JSON.stringify(current) === JSON.stringify(expected);
-    }
-
-    function objectDiff(current, expected, labels = {}) {
-      if (!expected) return [];
-      return Object.keys(expected)
-        .filter((key) => !current || !valuesMatch(current[key], expected[key]))
-        .map((key) => ({
-          field: labels[key] || key,
-          current: current ? current[key] : 'Not verified',
-          expected: expected[key]
-        }));
-    }
-
     function formatDiffValue(value) {
       if (value === null || value === undefined || value === '') return 'Not configured';
       if (Array.isArray(value)) return value.length ? value.map(formatDiffValue).join('\n') : '[]';
@@ -602,13 +585,9 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         ? github.slug + ' is configured. Webhook secret: ' + (webhookStored ? 'stored' : webhookInactive ? 'not required yet' : 'missing') + '.' +
           (webhookInactive ? ' Relay webhook delivery is disabled.' : '')
         : 'Creates the complete App used for repository installation, webhooks, and optional GitHub sign-in.';
-      const githubSubmitted = Boolean(github && github.configuredUrls);
       const githubDrift = github
         ? expected.github
-          ? githubSubmitted ? objectDiff(github.configuredUrls, expected.github, {
-              externalUrl: 'Homepage URL', setupUrl: 'Setup URL', webhookUrl: 'Webhook URL',
-              webhookActive: 'Webhook active', callbackUrls: 'Callback URLs'
-            }) : []
+          ? []
           : [{ field: 'Startup public URLs', current: 'Unavailable', expected: 'Valid Web, API, and ingress URLs' }]
         : [];
       match('github-match', !github ? '' : githubDrift.length ? 'warn' : '', !github ? 'Not configured' : githubDrift.length ? 'Expected URLs changed' : 'Ready to check');
@@ -633,15 +612,10 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       el('slack-status').textContent = slack ? slack.appId + ' is configured.' : 'Creates the default AgentConnect integration manifest.';
       const slackDrift = slack
         ? expected.slack
-          ? objectDiff(slack.configuredUrls, expected.slack, {
-              oauthRedirectUrl: 'OAuth redirect URL', eventsUrl: 'Events request URL',
-              interactionsUrl: 'Interactivity request URL', loginRedirectUrl: 'Logto redirect URL',
-              socialLinkRedirectUrl: 'Account linking redirect URL'
-            })
+          ? []
           : [{ field: 'Startup public URLs', current: 'Unavailable', expected: 'HTTPS Web, API, and ingress URLs' }]
         : [];
-      const slackVerified = Boolean(slack && slack.configuredUrls);
-      match('slack-match', !slack ? '' : !slackVerified || slackDrift.length ? 'warn' : '', !slack ? 'Not configured' : !slackVerified ? 'Not verified' : slackDrift.length ? 'Update required' : 'Ready to check');
+      match('slack-match', !slack ? '' : slackDrift.length ? 'warn' : '', !slack ? 'Not configured' : slackDrift.length ? 'Update required' : 'Ready to check');
       el('slack-name-field').hidden = Boolean(slack);
       el('create-slack').hidden = Boolean(slack);
       el('connect-slack-login').hidden = !slack || !values.logto || Boolean(values.logto.slackConnector) || !bootstrapInfo?.slackAvailable;
@@ -650,7 +624,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       el('slack-settings').hidden = !slack;
       if (slack) {
         el('slack-settings').href = 'https://api.slack.com/apps/' + encodeURIComponent(slack.appId);
-        showDiff('slack-drift', slackDrift, slackVerified ? 'Update required' : 'Not verified');
+        showDiff('slack-drift', slackDrift);
       } else el('slack-drift').hidden = true;
 
       const google = values.logto && values.logto.googleConnector;
@@ -861,7 +835,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       await replaceConfiguration(
         {
           ...values,
-          github: { ...previous, appId, slug, clientId, webhookEnabled, ...(appChanged ? { configuredUrls: undefined } : {}) },
+          github: { ...previous, appId, slug, clientId, webhookEnabled },
           ...(nextLogto ? { logto: nextLogto } : {})
         },
         Object.keys(secrets).length ? secrets : undefined,
@@ -892,7 +866,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       await replaceConfiguration(
         {
           ...values,
-          slack: { ...previous, appId, clientId, ...(changed ? { configuredUrls: undefined } : {}) },
+          slack: { ...previous, appId, clientId },
           ...(nextLogto ? { logto: nextLogto } : {})
         },
         Object.keys(secrets).length ? secrets : undefined,
@@ -1144,11 +1118,6 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         body: JSON.stringify({ configToken: token })
       }));
       el('slack-token').value = '';
-      if (result.status === 'pass' && currentStatus && currentStatus.values.slack) {
-        currentRevision = result.revision;
-        currentStatus.revision = result.revision;
-        currentStatus.values.slack = { ...currentStatus.values.slack, configuredUrls: result.expected };
-      }
       showDiff('slack-drift', result.diff || []);
       match('slack-match', result.status === 'pass' ? 'pass' : 'warn', result.status === 'pass' ? 'Matches' : 'Update required');
       message(result.status === 'pass' ? 'Slack App matches the default integration manifest.' : 'Slack App settings need an update.', result.status !== 'pass');

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -298,10 +298,6 @@ function googleRedirectUris(endpoint: string, connectorId: string, webUrl: strin
   ]
 }
 
-function sameStrings(left: readonly string[] | undefined, right: readonly string[]): boolean {
-  return JSON.stringify([...(left ?? [])].sort()) === JSON.stringify([...right].sort())
-}
-
 type ServiceTopology = { web: string; controlPlane: string; relay: string }
 
 function providerAppConfig(services: ServiceTopology): ProviderAppConfig {
@@ -411,7 +407,7 @@ export function buildTenantAdminServer(
     {
       expectedRevision: number
       connectLogto: boolean
-      configuredUrls: ReturnType<typeof githubConfiguredUrls>
+      webhookEnabled: boolean
       expires: ReturnType<typeof setTimeout>
     }
   >()
@@ -753,7 +749,7 @@ export function buildTenantAdminServer(
     githubFlows.set(state, {
       expectedRevision: current.revision,
       connectLogto,
-      configuredUrls: githubConfiguredUrls(providerAppConfig(localAuthBootstrap.services), manifest),
+      webhookEnabled: githubConfiguredUrls(providerAppConfig(localAuthBootstrap.services), manifest).webhookActive,
       expires
     })
     return {
@@ -789,7 +785,7 @@ export function buildTenantAdminServer(
       }
       try {
         const put = githubDeploymentPut(current, credentials, {
-          configuredUrls: pending.configuredUrls,
+          webhookEnabled: pending.webhookEnabled,
           connectLogto: pending.connectLogto
         })
         await deps.store.replace({ expectedRevision: current.revision, ...put })
@@ -1040,7 +1036,7 @@ export function buildTenantAdminServer(
       const created = await slackConfigApi.createApp(parsed.data.configToken, manifest)
       if (!created.ok) return problem(reply, 502, `Slack App creation failed: ${created.error}`)
       const credentials = created.app
-      const put = slackDeploymentPut(current, credentials, slackConfiguredUrls(manifest), parsed.data.connectLogto)
+      const put = slackDeploymentPut(current, credentials, parsed.data.connectLogto)
       const saved = await deps.store.replace({ expectedRevision: current.revision, ...put })
 
       try {
@@ -1086,29 +1082,23 @@ export function buildTenantAdminServer(
       return problem(reply, 502, error instanceof Error ? error.message : 'GitHub App settings could not be checked')
     }
     const expectedUrls = githubConfiguredUrls(providerAppConfig(localAuthBootstrap.services), manifest)
-    const lastSubmitted = github.configuredUrls
     const missing = [...audited.missing]
     const unverified = ['setup_url', 'callback_urls', 'webhook_active']
     const diff = audited.diff.map(({ field, current, expected }) => ({ field, current, expected }))
-    const setupUrlChanged = Boolean(lastSubmitted && lastSubmitted.setupUrl !== expectedUrls.setupUrl)
-    const callbackUrlsChanged = Boolean(
-      lastSubmitted && !sameStrings(lastSubmitted.callbackUrls, expectedUrls.callbackUrls)
-    )
-    const webhookActiveChanged = Boolean(lastSubmitted && lastSubmitted.webhookActive !== expectedUrls.webhookActive)
     diff.push(
       {
-        field: setupUrlChanged ? 'Setup URL (last submitted)' : 'Setup URL',
-        current: setupUrlChanged ? lastSubmitted!.setupUrl : "Can't verify automatically",
+        field: 'Setup URL',
+        current: "Can't verify automatically",
         expected: expectedUrls.setupUrl
       },
       {
-        field: callbackUrlsChanged ? 'Callback URLs (last submitted)' : 'Callback URLs',
-        current: callbackUrlsChanged ? lastSubmitted!.callbackUrls : "Can't verify automatically",
+        field: 'Callback URLs',
+        current: "Can't verify automatically",
         expected: expectedUrls.callbackUrls
       },
       {
-        field: webhookActiveChanged ? 'Webhook active (last submitted)' : 'Webhook active',
-        current: webhookActiveChanged ? lastSubmitted!.webhookActive : "Can't verify automatically",
+        field: 'Webhook active',
+        current: "Can't verify automatically",
         expected: expectedUrls.webhookActive
       }
     )
@@ -1127,48 +1117,37 @@ export function buildTenantAdminServer(
   app.post('/api/v1/check/slack', { preHandler: requireDiagnosticAccess }, async (request, reply) => {
     const parsed = CheckSlackBody.safeParse(request.body)
     if (!parsed.success) return problem(reply, 400, 'a Slack App configuration token is required')
-    return serializeMutation(async () => {
-      const current = await deps.store.getAdmin()
-      const slack = current?.values.slack
-      if (!current || !slack) return problem(reply, 409, 'the deployment Slack App is not configured')
-      let manifest: Record<string, unknown>
-      try {
-        manifest = expectedSlackManifest(current.values, await resolveLogtoConnectorIds())
-      } catch (error) {
-        return problem(reply, 409, error instanceof Error ? error.message : 'Slack App configuration is incomplete')
-      }
-      const exported = await slackConfigApi.exportApp(parsed.data.configToken, slack.appId)
-      if (!exported.ok) return problem(reply, 502, `Slack App settings could not be checked: ${exported.error}`)
-      const actual = exported.manifest
-      const manifestDiff = diffSlackManifest(actual, manifest)
-      const missing = auditSlackManifest(actual, manifest)
-      const expected = slackConfiguredUrls(manifest)
-      let observed: ReturnType<typeof slackConfiguredUrls> | null = null
-      try {
-        observed = slackConfiguredUrls(actual)
-      } catch {
-        // The stable missing field names still explain malformed exported URLs.
-      }
-      let revision = current.revision
-      if (missing.length === 0 && JSON.stringify(slack.configuredUrls) !== JSON.stringify(expected)) {
-        const saved = await deps.store.replace({
-          expectedRevision: current.revision,
-          values: { ...current.values, slack: { ...slack, configuredUrls: expected } }
-        })
-        revision = saved.revision
-      }
-      return {
-        provider: 'slack' as const,
-        status: missing.length === 0 ? ('pass' as const) : ('fail' as const),
-        missing,
-        diff: manifestDiff.map(({ field, current, expected }) => ({ field, current, expected })),
-        actual: observed,
-        expected,
-        settingsUrl: `https://api.slack.com/apps/${encodeURIComponent(slack.appId)}`,
-        revision,
-        restartRequired: false as const
-      }
-    })
+    const current = await deps.store.getAdmin()
+    const slack = current?.values.slack
+    if (!current || !slack) return problem(reply, 409, 'the deployment Slack App is not configured')
+    let manifest: Record<string, unknown>
+    try {
+      manifest = expectedSlackManifest(current.values, await resolveLogtoConnectorIds())
+    } catch (error) {
+      return problem(reply, 409, error instanceof Error ? error.message : 'Slack App configuration is incomplete')
+    }
+    const exported = await slackConfigApi.exportApp(parsed.data.configToken, slack.appId)
+    if (!exported.ok) return problem(reply, 502, `Slack App settings could not be checked: ${exported.error}`)
+    const actual = exported.manifest
+    const manifestDiff = diffSlackManifest(actual, manifest)
+    const missing = auditSlackManifest(actual, manifest)
+    const expected = slackConfiguredUrls(manifest)
+    let observed: ReturnType<typeof slackConfiguredUrls> | null = null
+    try {
+      observed = slackConfiguredUrls(actual)
+    } catch {
+      // The stable missing field names still explain malformed exported URLs.
+    }
+    return {
+      provider: 'slack' as const,
+      status: missing.length === 0 ? ('pass' as const) : ('fail' as const),
+      missing,
+      diff: manifestDiff.map(({ field, current, expected }) => ({ field, current, expected })),
+      actual: observed,
+      expected,
+      settingsUrl: `https://api.slack.com/apps/${encodeURIComponent(slack.appId)}`,
+      restartRequired: false as const
+    }
   })
 
   app.post('/api/v1/reconcile/logto', { preHandler: requireConfigurationAccess }, async (request, reply) =>

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -835,8 +835,7 @@ export function buildTenantAdminServer(
       const redirectUris = googleRedirectUris(logtoEndpoint, connectorId, localAuthBootstrap.services.web)
       const put = logtoGoogleConnectorPut(current, {
         clientId: parsed.data.clientId,
-        ...(parsed.data.clientSecret ? { clientSecret: parsed.data.clientSecret } : {}),
-        configuredRedirectUris: redirectUris
+        ...(parsed.data.clientSecret ? { clientSecret: parsed.data.clientSecret } : {})
       })
       const saved = await deps.store.replace({ expectedRevision: current.revision, ...put })
       return { revision: saved.revision, redirectUris, restartRequired: true as const }

--- a/packages/setup/src/deployment-config-client.ts
+++ b/packages/setup/src/deployment-config-client.ts
@@ -21,20 +21,12 @@ export interface GithubDeploymentCredentials {
   webhookSecret?: string
 }
 
-export interface GithubConfiguredUrls {
-  externalUrl: string
-  setupUrl: string
-  webhookUrl: string
-  webhookActive: boolean
-  callbackUrls: string[]
-}
-
 type CurrentDeploymentConfig = { values: DeploymentConfigValuesV1 }
 
 export function githubDeploymentPut(
   current: CurrentDeploymentConfig,
   credentials: GithubDeploymentCredentials,
-  options: { configuredUrls?: GithubConfiguredUrls; connectLogto?: boolean } = {}
+  options: { webhookEnabled?: boolean; connectLogto?: boolean } = {}
 ): DeploymentConfigPut {
   const appId = Number(credentials.appId)
   if (!Number.isSafeInteger(appId) || appId <= 0) throw new Error('GitHub App creation returned an invalid app id')
@@ -46,8 +38,7 @@ export function githubDeploymentPut(
         appId,
         slug: credentials.slug,
         clientId: credentials.clientId,
-        webhookEnabled: options.configuredUrls?.webhookActive ?? true,
-        ...(options.configuredUrls ? { configuredUrls: options.configuredUrls } : {})
+        webhookEnabled: options.webhookEnabled ?? true
       },
       ...(connectLogto
         ? {
@@ -158,18 +149,9 @@ export interface SlackDeploymentCredentials {
   signingSecret: string
 }
 
-export interface SlackConfiguredUrls {
-  oauthRedirectUrl: string
-  eventsUrl: string
-  interactionsUrl: string
-  loginRedirectUrl?: string
-  socialLinkRedirectUrl?: string
-}
-
 export function slackDeploymentPut(
   current: CurrentDeploymentConfig,
   credentials: SlackDeploymentCredentials,
-  configuredUrls?: SlackConfiguredUrls,
   connectLogto = false
 ): DeploymentConfigPut {
   const logto = connectLogto && current.values.logto
@@ -178,8 +160,7 @@ export function slackDeploymentPut(
       ...current.values,
       slack: {
         appId: credentials.appId,
-        clientId: credentials.clientId,
-        ...(configuredUrls ? { configuredUrls } : {})
+        clientId: credentials.clientId
       },
       ...(logto
         ? {

--- a/packages/setup/src/deployment-config-client.ts
+++ b/packages/setup/src/deployment-config-client.ts
@@ -209,7 +209,6 @@ export function slackDeploymentPut(
 export interface LogtoGoogleConnectorCredentials {
   clientId: string
   clientSecret?: string
-  configuredRedirectUris: string[]
 }
 
 export function logtoGoogleConnectorPut(
@@ -232,8 +231,7 @@ export function logtoGoogleConnectorPut(
             }
           : current.values.logto.browser,
         googleConnector: {
-          clientId: credentials.clientId,
-          configuredRedirectUris: credentials.configuredRedirectUris
+          clientId: credentials.clientId
         }
       }
     },


### PR DESCRIPTION
## Summary
- remove persisted Google redirect-URI snapshots and show only dynamically derived required callbacks
- remove GitHub and Slack URL snapshots from deployment configuration
- make Slack checks read-only against its live exported manifest
- make GitHub show API-readable fields live and label callback, setup, and webhook-active fields as not automatically verifiable
- ignore obsolete pre-release snapshot fields when reading existing deployment documents

## Validation
- pnpm --filter @agentconnect.md/setup build
- pnpm --filter @agentconnect.md/setup typecheck
- pnpm --filter @agentconnect.md/control-plane typecheck
- eslint on changed files and full pre-push lint
- parsed the embedded Tenant Admin browser script