### PR TITLE
fix(setup): audit Feishu and Lark apps

### DIFF
--- a/packages/control-plane/src/http/feishu-app-template.ts
+++ b/packages/control-plane/src/http/feishu-app-template.ts
@@ -10,6 +10,7 @@ import { PLATFORM_APP_DESCRIPTION } from './platform-app-description.js'
 
 export const AGENTCONNECT_FEISHU_SCOPES = [
   'application:application:patch',
+  'application:application:self_manage',
   'contact:contact.base:readonly',
   'contact:user.base:readonly',
   'im:chat:read',

--- a/packages/control-plane/src/http/feishu-identity.ts
+++ b/packages/control-plane/src/http/feishu-identity.ts
@@ -18,6 +18,7 @@
  * This is the only spot the CP touches the appSecret to reach Feishu; it NEVER logs it.
  */
 import type { FeishuRegion } from '@agentconnect.md/protocol'
+import { AGENTCONNECT_FEISHU_EVENTS, AGENTCONNECT_FEISHU_SCOPES } from './feishu-app-template.js'
 
 /** tenant-access-token exchange outcome: valid creds (with the derived bot name), creds
  *  Feishu rejected, or an inconclusive reachability failure. */
@@ -94,6 +95,186 @@ export type FeishuAppCredentialVerifier = (
   appSecret: string,
   region: FeishuRegion
 ) => Promise<FeishuAppCredentialVerification>
+
+export interface FeishuAppSetupDiff {
+  field: string
+  current: unknown
+  expected: unknown
+}
+
+export interface FeishuAppSetupAudit {
+  status: 'ok' | 'mismatch' | 'invalid' | 'unavailable'
+  appName: string | null
+  version: string | null
+  diff: FeishuAppSetupDiff[]
+  message?: string
+}
+
+export type FeishuAppSetupAuditor = (
+  appId: string,
+  appSecret: string,
+  region: FeishuRegion
+) => Promise<FeishuAppSetupAudit>
+
+type JsonRecord = Record<string, unknown>
+
+function record(value: unknown): JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? (value as JsonRecord) : {}
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function scopeNames(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.flatMap((item) => {
+        const scope = record(item).scope
+        return typeof scope === 'string' ? [scope] : []
+      })
+    : []
+}
+
+async function responseJson(response: Response): Promise<JsonRecord> {
+  try {
+    return record(await response.json())
+  } catch {
+    return {}
+  }
+}
+
+function applicationReadPermissionMissing(body: JsonRecord): boolean {
+  const code = body.code
+  const message = typeof body.msg === 'string' ? body.msg : ''
+  return (
+    code === 210508 ||
+    code === 99991672 ||
+    message.includes('application:application:self_manage') ||
+    message.toLowerCase().includes('insufficient permission')
+  )
+}
+
+/** Audit the actual published regional App instead of treating a successful
+ * credential exchange as proof that its Bot, scopes, events and release are ready. */
+export function createFeishuAppSetupAuditor(fetcher: typeof fetch = fetch): FeishuAppSetupAuditor {
+  return async (appId, appSecret, region) => {
+    const base = REGION_BASE[region]
+    const token = await tenantAccessToken(appId, appSecret, region, fetcher)
+    if (token.status !== 'ok') {
+      return {
+        status: token.status === 'invalid' ? 'invalid' : 'unavailable',
+        appName: null,
+        version: null,
+        diff: []
+      }
+    }
+
+    try {
+      const headers = { authorization: `Bearer ${token.token}` }
+      const appResponse = await fetcher(`${base}/application/v6/applications/${encodeURIComponent(appId)}?lang=en_us`, {
+        headers,
+        signal: AbortSignal.timeout(FEISHU_TIMEOUT_MS)
+      })
+      const appBody = await responseJson(appResponse)
+      if (!appResponse.ok || appBody.code !== 0) {
+        if (applicationReadPermissionMissing(appBody)) {
+          return {
+            status: 'mismatch',
+            appName: null,
+            version: null,
+            diff: [
+              {
+                field: 'API permission: application:application:self_manage',
+                current: 'Missing',
+                expected: 'Required for setup audit'
+              }
+            ]
+          }
+        }
+        return {
+          status: 'unavailable',
+          appName: null,
+          version: null,
+          diff: [],
+          ...(typeof appBody.msg === 'string' ? { message: appBody.msg } : {})
+        }
+      }
+
+      const app = record(record(appBody.data).app)
+      const appName = typeof app.app_name === 'string' ? app.app_name : null
+      const onlineVersionId = typeof app.online_version_id === 'string' ? app.online_version_id.trim() : ''
+      const diff: FeishuAppSetupDiff[] = []
+      if (app.status !== 1) diff.push({ field: 'App status', current: 'Disabled', expected: 'Enabled' })
+      if (!onlineVersionId) {
+        diff.push({ field: 'Published version', current: 'None', expected: 'Published' })
+        return { status: 'mismatch', appName, version: null, diff }
+      }
+
+      const versionResponse = await fetcher(
+        `${base}/application/v6/applications/${encodeURIComponent(appId)}/app_versions/${encodeURIComponent(onlineVersionId)}?lang=en_us`,
+        { headers, signal: AbortSignal.timeout(FEISHU_TIMEOUT_MS) }
+      )
+      const versionBody = await responseJson(versionResponse)
+      if (!versionResponse.ok || versionBody.code !== 0) {
+        return {
+          status: 'unavailable',
+          appName,
+          version: null,
+          diff,
+          ...(typeof versionBody.msg === 'string' ? { message: versionBody.msg } : {})
+        }
+      }
+
+      const appVersion = record(record(versionBody.data).app_version)
+      const version = typeof appVersion.version === 'string' ? appVersion.version : null
+      if (appVersion.status !== 1 || !appVersion.publish_time) {
+        diff.push({ field: 'Published version', current: version ?? 'Not published', expected: 'Published' })
+      }
+
+      const publishedScopes = new Set(scopeNames(appVersion.scopes))
+      for (const scope of AGENTCONNECT_FEISHU_SCOPES) {
+        if (!publishedScopes.has(scope)) {
+          diff.push({ field: `API permission: ${scope}`, current: 'Missing', expected: 'Required' })
+        }
+      }
+
+      const publishedEvents = new Set([
+        ...strings(appVersion.events),
+        ...(Array.isArray(appVersion.event_infos)
+          ? appVersion.event_infos.flatMap((item) => {
+              const eventType = record(item).event_type
+              return typeof eventType === 'string' ? [eventType] : []
+            })
+          : [])
+      ])
+      for (const event of AGENTCONNECT_FEISHU_EVENTS) {
+        if (!publishedEvents.has(event)) {
+          diff.push({ field: `Event subscription: ${event}`, current: 'Missing', expected: 'Required' })
+        }
+      }
+
+      if (!Object.hasOwn(record(appVersion.ability), 'bot')) {
+        diff.push({ field: 'Bot capability', current: 'Disabled', expected: 'Enabled' })
+      } else {
+        const botResponse = await fetcher(`${base}/bot/v3/info`, {
+          headers,
+          signal: AbortSignal.timeout(FEISHU_TIMEOUT_MS)
+        })
+        const botBody = await responseJson(botResponse)
+        if (!botResponse.ok) {
+          return { status: 'unavailable', appName, version, diff }
+        }
+        if (botBody.code !== 0) {
+          diff.push({ field: 'Bot capability', current: 'Unavailable', expected: 'Enabled' })
+        }
+      }
+
+      return { status: diff.length ? 'mismatch' : 'ok', appName, version, diff }
+    } catch {
+      return { status: 'unavailable', appName: null, version: null, diff: [] }
+    }
+  }
+}
 
 /** Lightweight credential check shared by the runtime installer and Tenant Admin. */
 export function createFeishuAppCredentialVerifier(fetcher?: typeof fetch): FeishuAppCredentialVerifier {

--- a/packages/control-plane/src/http/feishu-identity.ts
+++ b/packages/control-plane/src/http/feishu-identity.ts
@@ -89,13 +89,6 @@ async function tenantAccessToken(
   }
 }
 
-export type FeishuAppCredentialVerification = { status: 'ok' | 'invalid' | 'unavailable' }
-export type FeishuAppCredentialVerifier = (
-  appId: string,
-  appSecret: string,
-  region: FeishuRegion
-) => Promise<FeishuAppCredentialVerification>
-
 export interface FeishuAppSetupDiff {
   field: string
   current: unknown
@@ -273,14 +266,6 @@ export function createFeishuAppSetupAuditor(fetcher: typeof fetch = fetch): Feis
     } catch {
       return { status: 'unavailable', appName: null, version: null, diff: [] }
     }
-  }
-}
-
-/** Lightweight credential check shared by the runtime installer and Tenant Admin. */
-export function createFeishuAppCredentialVerifier(fetcher?: typeof fetch): FeishuAppCredentialVerifier {
-  return async (appId, appSecret, region) => {
-    const result = await tenantAccessToken(appId, appSecret, region, fetcher ?? fetch)
-    return { status: result.status }
   }
 }
 

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -297,7 +297,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
 
       <section id="feishu-section" class="panel admin-section" aria-labelledby="feishu-heading">
         <div class="provider-head">
-          <div><h3 id="feishu-heading">Feishu</h3><p class="muted">Validates the App ID and secret only. API permissions, event subscriptions, and the published version are not audited.</p></div>
+          <div><h3 id="feishu-heading">Feishu</h3><p class="muted">Audits the published Bot capability, API permissions, and message event subscription.</p></div>
           <span id="feishu-match" class="badge">Not configured</span>
         </div>
         <dl class="credentials">
@@ -305,6 +305,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <dt>App secret</dt><dd class="secret-line"><span id="feishu-app-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="feishu.loginAppSecret" data-secret-display="feishu-app-secret-display">Edit</button></dd>
         </dl>
         <p id="feishu-login-status" class="muted"></p>
+        <div id="feishu-drift" class="notice" hidden></div>
         <div id="feishu-config-controls" class="subsection">
           <label id="feishu-create-name-field" class="field">New App name<input id="feishu-create-name" value="AgentConnect"></label>
           <label class="field">Existing App ID<input id="feishu-login-id" autocomplete="off"></label>
@@ -314,14 +315,14 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <button id="create-feishu-login-app">Create Feishu App</button>
           <button id="save-feishu-login-app">Save existing App</button>
           <button id="cancel-feishu-configuration" hidden>Cancel</button>
-          <button id="check-feishu-login-app" hidden>Check credentials</button>
+          <button id="check-feishu-login-app" hidden>Check setup</button>
           <button id="clear-feishu" class="danger" hidden>Clear configuration</button>
         </div>
       </section>
 
       <section id="lark-section" class="panel admin-section" aria-labelledby="lark-heading">
         <div class="provider-head">
-          <div><h3 id="lark-heading">Lark</h3><p class="muted">Validates the App ID and secret only. API permissions, event subscriptions, and the published version are not audited.</p></div>
+          <div><h3 id="lark-heading">Lark</h3><p class="muted">Audits the published Bot capability, API permissions, and message event subscription.</p></div>
           <span id="lark-match" class="badge">Not configured</span>
         </div>
         <dl class="credentials">
@@ -329,6 +330,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <dt>App secret</dt><dd class="secret-line"><span id="lark-app-secret-display" class="redacted">Not configured</span><button class="edit-secret" data-secret-key="lark.loginAppSecret" data-secret-display="lark-app-secret-display">Edit</button></dd>
         </dl>
         <p id="lark-login-status" class="muted"></p>
+        <div id="lark-drift" class="notice" hidden></div>
         <div id="lark-config-controls" class="subsection">
           <label id="lark-create-name-field" class="field">New App name<input id="lark-create-name" value="AgentConnect"></label>
           <label class="field">Existing App ID<input id="lark-login-id" autocomplete="off"></label>
@@ -338,7 +340,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <button id="create-lark-login-app">Create Lark App</button>
           <button id="save-lark-login-app">Save existing App</button>
           <button id="cancel-lark-configuration" hidden>Cancel</button>
-          <button id="check-lark-login-app" hidden>Check credentials</button>
+          <button id="check-lark-login-app" hidden>Check setup</button>
           <button id="clear-lark" class="danger" hidden>Clear configuration</button>
         </div>
       </section>
@@ -693,6 +695,8 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         : 'No Lark tenant App is configured.';
       match('feishu-match', values.feishu && configured(byKey, 'feishu.loginAppSecret') ? '' : '', values.feishu && configured(byKey, 'feishu.loginAppSecret') ? 'Ready to check' : 'Not configured');
       match('lark-match', values.lark && configured(byKey, 'lark.loginAppSecret') ? '' : '', values.lark && configured(byKey, 'lark.loginAppSecret') ? 'Ready to check' : 'Not configured');
+      showDiff('feishu-drift', []);
+      showDiff('lark-drift', []);
       el('feishu-config-controls').hidden = Boolean(values.feishu);
       el('lark-config-controls').hidden = Boolean(values.lark);
       el('feishu-create-name-field').hidden = Boolean(values.feishu);
@@ -1182,7 +1186,8 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
     async function checkRegionalLoginApp(region) {
       const result = await json(await fetch(api + '/check/regional-login-app/' + region, { headers: bearer() }));
       const label = region === 'feishu' ? 'Feishu' : 'Lark';
-      match(region + '-match', result.status === 'pass' ? 'pass' : result.status === 'fail' ? 'fail' : 'warn', result.status === 'pass' ? 'Credentials valid' : result.status === 'fail' ? 'Invalid credentials' : 'Could not check');
+      showDiff(region + '-drift', result.diff || []);
+      match(region + '-match', result.status === 'pass' ? 'pass' : result.status === 'fail' ? 'fail' : 'warn', result.status === 'pass' ? 'Matches' : result.status === 'fail' ? 'Update required' : 'Could not check');
       message(result.message || (label + ' credential check completed.'), result.status === 'fail');
     }
 

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -10,10 +10,7 @@ import {
   OfficialFeishuRegistrationProvider,
   type FeishuRegistrationProvider
 } from '@agentconnect.md/control-plane/feishu-registration-provider'
-import {
-  createFeishuAppCredentialVerifier,
-  type FeishuAppCredentialVerifier
-} from '@agentconnect.md/control-plane/feishu-identity'
+import { createFeishuAppSetupAuditor, type FeishuAppSetupAuditor } from '@agentconnect.md/control-plane/feishu-identity'
 import { createSlackConfigApi, type SlackConfigApi } from '@agentconnect.md/control-plane/slack-config-api'
 import {
   DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1,
@@ -153,7 +150,7 @@ export interface TenantAdminServerDeps {
   ) => Pick<LogtoAdminClaimClient, 'verifyClientCredentials' | 'inspectAdminRole' | 'inspectSetup'>
   makeLogtoSetupClient?: (config: LogtoManagementConfig) => Pick<LogtoAdminClaimClient, 'reconcileSetup'>
   feishuRegistrationProvider?: Pick<FeishuRegistrationProvider, 'begin' | 'poll'>
-  verifyFeishuAppCredentials?: FeishuAppCredentialVerifier
+  auditFeishuAppSetup?: FeishuAppSetupAuditor
   slackConfigApi?: Pick<SlackConfigApi, 'createApp' | 'exportApp'>
   localAuthBootstrap?: {
     issuer: string
@@ -386,7 +383,7 @@ export function buildTenantAdminServer(
 ): FastifyInstance {
   const app = Fastify({ logger: false, ...options })
   const fetchImpl = deps.fetch ?? fetch
-  const verifyFeishuAppCredentials = deps.verifyFeishuAppCredentials ?? createFeishuAppCredentialVerifier(fetchImpl)
+  const auditFeishuAppSetup = deps.auditFeishuAppSetup ?? createFeishuAppSetupAuditor(fetchImpl)
   const slackConfigApi = deps.slackConfigApi ?? createSlackConfigApi({ fetch: fetchImpl })
   const requireLocal = localOnly(deps.publicUrl, deps.allowContainerLoopbackProxy)
   const authenticator = new TenantAdminAuthenticator(
@@ -886,22 +883,25 @@ export function buildTenantAdminServer(
         return problem(reply, 409, `${region === 'feishu' ? 'Feishu' : 'Lark'} App credentials are not configured`)
       }
 
-      const result = await verifyFeishuAppCredentials(regionalApp.loginAppId, appSecret, region)
+      const result = await auditFeishuAppSetup(regionalApp.loginAppId, appSecret, region)
       const label = region === 'feishu' ? 'Feishu' : 'Lark'
       return {
         provider: region,
         status:
           result.status === 'ok'
             ? ('pass' as const)
-            : result.status === 'invalid'
+            : result.status === 'invalid' || result.status === 'mismatch'
               ? ('fail' as const)
               : ('unknown' as const),
+        diff: result.diff,
         message:
           result.status === 'ok'
-            ? `${label} accepted the saved App ID and secret. API permissions, event subscriptions, and the published version were not checked.`
+            ? `${label} published App${result.version ? ` version ${result.version}` : ''} has the required Bot capability, API permissions, and event subscription.`
             : result.status === 'invalid'
               ? `${label} rejected the saved App ID or secret.`
-              : `${label} could not be reached.`
+              : result.status === 'mismatch'
+                ? `${label} App setup needs an update.`
+                : `${label} setup could not be audited${result.message ? `: ${result.message}` : '.'}`
       }
     }
   )


### PR DESCRIPTION
## Summary

- replace the Feishu/Lark credential-only check with an audit of the actual published App version
- compare the published Bot capability, required API permissions, and message event subscription against the canonical AgentConnect template
- add the self-management scope required to inspect an App's own published configuration
- show each missing setup item in Tenant Admin instead of reporting only that credentials are valid

## Root cause

Tenant Admin previously stopped after exchanging the App ID and secret for a tenant access token. That proved only that the credentials worked; it did not inspect whether the App could receive or send messages in production.

## Validation

- built `@agentconnect.md/protocol`
- typechecked and built `@agentconnect.md/control-plane`
- typechecked and built the self-contained `@agentconnect.md/setup` bundle
- ran ESLint on the changed files
- ran the existing focused Feishu identity tests
- smoke-checked both matching and missing-configuration provider responses
