### PR TITLE
feat(cp): org-fence the agent data layer

### DIFF
--- a/docs/designs/org-scoped-data-layer.md
+++ b/docs/designs/org-scoped-data-layer.md
@@ -1,0 +1,189 @@
+# Org-Scoped Data Layer
+
+> **Status:** M1 implemented (convention + Agent exemplar); M2 rollout tracked in §7
+>
+> **Scope:** Control-plane persistence ports and their HTTP/MCP consumers.
+> Related: [`authorization-policy.md`](authorization-policy.md) (the policy layer
+> this deliberately does not absorb), [`control-plane-implementation.md`](control-plane-implementation.md)
+> §3.2 (the `/orgs/:orgId` path scope and its "cross-org reads as 404" rule),
+> [`resource-visibility.md`](resource-visibility.md) (intra-org sharing).
+
+## 1. Problem
+
+The HTTP edge is structurally org-scoped: every `/orgs/:orgId/…` route runs
+behind `humanAuth` + `makeOrgScope`, non-members read 404, personal API keys
+bind to one organization, OAuth scopes are confined (`http/org-scope.ts`).
+
+The data layer is not. Repository ports address rows by bare id —
+`AgentRepo.get(agentId)`, `update(agentId, …)`, `delete(agentId)` — and every
+organization fence between the edge and the row is a hand-written route check:
+
+```ts
+const agent = await deps.repos.agent.get(AgentId(id))
+if (!agent || agent.orgId !== req.orgCtx!.orgId) return null
+```
+
+There are ~80 such comparisons across route files. Each is correct today, and
+each is a convention, not a structure: one omitted line in a new route handler
+silently yields cross-organization read or write on an ID-addressable
+resource, with no compile-time or database-level backstop. Lists already take
+the organization (`list(orgId, viewer?)`); point reads and mutations are the
+gap.
+
+This matters beyond hosted multi-org deployments: a self-hosted instance with
+two organizations has the same boundary, and the same one-line failure mode.
+
+## 2. Decision
+
+**Repository port methods that address an org-owned row by id take `orgId` as
+their first parameter, and the repository fences the query itself** — the row
+is looked up `WHERE id AND orgId` (or the mutation's opening row-lock read is
+so filtered), inside the same transaction as the write it guards. A cross-org
+id becomes observably identical to a missing row.
+
+**Internal trust domains keep an explicit escape hatch.** Orchestration,
+reconciliation, WS handlers, and platform machinery legitimately resolve rows
+from system state (a run row, an integration row, signed claims) where the
+organization is derived from the row itself. Those callers use reads whose
+names end in `Unscoped` (`getUnscoped(agentId)`). The name is the audit
+marker: it makes "this read crosses the tenancy axis on purpose" grep-able and
+reviewable, and an ESLint fence (§6) keeps it out of the HTTP surface.
+
+Route-level checks thereby become defense-in-depth; the repository is the
+authority. The route keeps only what is genuinely policy-layer: visibility
+(`canView` / `visibilityWhere`), role checks, and session-tier rules stay in
+`authorization/policy.ts` exactly as [`authorization-policy.md`](authorization-policy.md)
+§2 drew the boundary.
+
+### 2.1 Alternatives considered
+
+- **Org-scoped repository facade** (`repos.forOrg(orgId)` handed to routes):
+  cleaner call sites, but structural only if routes lose access to the raw
+  repos, which is a much larger DI surgery — and until then it is discipline,
+  not structure. Signature tightening gets the same guarantee from the type
+  checker with a mechanical diff.
+- **Prisma client extension / AsyncLocalStorage tenant context**: implicit,
+  breaks the internal trust domains that genuinely read across organizations,
+  and hides the fence from the reader. Rejected for the same reason the
+  codebase prefers explicit DI.
+- **Postgres RLS**: complementary, not competing — a DB-level backstop under
+  the application fence. Out of scope here (§8); the port convention is a
+  prerequisite for it either way.
+
+## 3. The convention
+
+For every repository whose rows carry `orgId` (directly or via an owning
+parent):
+
+1. **Point read**: `get(orgId, id)` returns `null` for a cross-org id exactly
+   as for a missing row. No caller can distinguish the two (the §1 rule:
+   cross-org reads as 404).
+2. **Mutations**: `(orgId, id, …)` first parameters. The fence lives inside
+   the mutation's transaction — on its opening row-lock read where one exists,
+   as an added filter where the write is a single statement (`updateMany`-and-
+   count where no composite unique is available). A fence miss surfaces as the
+   port's existing missing-row behavior (`null` return for CAS-shaped methods,
+   a `<Resource>Missing` error for throw-shaped ones).
+3. **Internal reads**: `getUnscoped(id)` (and, where genuinely needed,
+   `listUnscoped…`). Every call site sits in an internal trust domain and
+   should be obvious about why.
+4. **System-tier methods stay system-tier.** Methods already fenced by a
+   different axis — the daemon roster (`listForDaemon(daemonId)`), CAS fences
+   (`movePlacement(expectedDaemonId, …)`, workspace-compensation), placement
+   writes driven by the orchestrator — do not grow a tautological `orgId`.
+   Each port documents which of its methods are system-tier and why.
+5. **Lists are already right**: `list(orgId, viewer?)` is unchanged, and stays
+   the pattern for new list methods.
+6. **Child rows fence through their parent**: resources without their own
+   `orgId` column (agent secrets, assignments, session children) are reached
+   through a parent whose method is fenced, or filter with a relational
+   `where: { agent: { orgId } }`.
+
+New repositories must follow the convention from their first method; this
+document is the review reference.
+
+## 4. Trust domains
+
+Mirrors [`authorization-policy.md`](authorization-policy.md) §2 — the fence a
+method carries depends on who is allowed to call it:
+
+| Caller domain                                                      | Org source                           | Data-layer surface                                                                                                      |
+| ------------------------------------------------------------------ | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Console REST / SSE (human)                                         | `req.orgCtx` from path + membership  | scoped methods only                                                                                                     |
+| MCP surface                                                        | the credential's org binding         | scoped methods only                                                                                                     |
+| Daemon WS handlers                                                 | the connection's ApiKey row          | daemon-fenced methods (`listForDaemon`, `agent.daemonId === conn.daemonId` guards) — already stronger than an org check |
+| Orchestrator / reconciliation / platform machinery                 | derived from the row being processed | `*Unscoped` reads, system-tier mutations                                                                                |
+| Public-by-design endpoints (e.g. agent icon PNG, fetched by Slack) | none — intentionally unauthenticated | `*Unscoped` with an inline lint exemption and a justification comment                                                   |
+
+## 5. Exemplar migration: Agent (M1, this change)
+
+`AgentRepo` is the largest and most-referenced port; it sets the pattern.
+
+| Method                                                                   | Callers today                                                      | New shape                                                                                   |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `create(input, …)`                                                       | routes (org inside `CreateAgentInput`)                             | unchanged — already org-carrying                                                            |
+| `get(id)`                                                                | routes (via per-file fetch-and-check helpers) + ~30 internal sites | `get(orgId, id)` + `getUnscoped(id)`                                                        |
+| `update(id, patch, opts)`                                                | routes only                                                        | `update(orgId, id, …)`; fence replaces the transaction's existing `orgIdOfAgent` derivation |
+| `setWorkspace` / `restoreWorkspace`                                      | routes + workspace-move orchestration                              | `(orgId, …)`; the orchestrator passes the org of the record it holds                        |
+| `setSharing`, `setCallPolicy`                                            | routes only                                                        | `(orgId, id, …)`                                                                            |
+| `delete(id)`                                                             | routes only                                                        | `delete(orgId, id)`; fence on the opening row read                                          |
+| `setPlacement`, `movePlacement`, `setWorkspaceRepoId`                    | orchestrator / repair machinery                                    | unchanged (system-tier: CAS- or repair-fenced)                                              |
+| `list(orgId, viewer?)`, `orgDirectory(orgId)`, `listForDaemon(daemonId)` | —                                                                  | unchanged                                                                                   |
+
+`AgentConfigWriter` (the row+secrets unit of work behind REST create/PATCH)
+follows `AgentRepo`: `update(orgId, id, …)`.
+
+Route consequences: the per-file helper keeps only the policy half —
+
+```ts
+const agent = await deps.repos.agent.get(orgOf(req), AgentId(id)) // fence in the repo
+return agent && canView(agent, ctxOf(req)) ? agent : null // policy stays here
+```
+
+`GET /v1/agents/:id/icon` (public by design — chat platforms fetch it) moves
+to `getUnscoped` with the lint exemption and a comment saying exactly that.
+
+## 6. Enforcement
+
+Two structural guards, so the convention cannot silently erode:
+
+1. **ESLint fence.** `no-restricted-syntax` forbids any `*Unscoped` member
+   call in `packages/control-plane/src/http/routes/**` and
+   `packages/control-plane/src/http/mcp/**`. Public-by-design endpoints carry
+   an inline `eslint-disable-next-line` with a justification — the exemption
+   is the documentation.
+2. **Tenant-isolation contract tests.**
+   `test/integration/tenant-isolation.route.test.ts` boots the real app
+   against Postgres with a two-organization fixture and asserts, per migrated
+   resource: point-GET of the foreign id → 404; PATCH/PUT/DELETE of the
+   foreign id → 404 (and the foreign row provably unmodified); list → foreign
+   rows absent. The suite is the acceptance gate for every M2 batch: migrating
+   a repository adds its resource block here in the same PR.
+
+## 7. Rollout
+
+- **M1 (this change):** the convention; `AgentRepo` + `AgentConfigWriter`
+  migrated end-to-end; ESLint fence; contract-suite foundation with the Agent
+  block.
+- **M2 (mechanical batches, same recipe per repo):** `DaemonRepo`, `BotRepo`,
+  `IntegrationRepo`, `CronRepo`, `HookRepo`, `McpProviderRepo`,
+  `SkillSourceRepo`, `SessionRepo` (+ session children via parent),
+  `WebchatConversationRepo`, `MemoryConnectionRepo`, `OrganizationKnowledge` /
+  `ManagedSkill` repos, `GithubInstallationRepo`, API-key/user-facing stores.
+  Each batch: tighten signatures → follow the type errors → classify each
+  internal caller (`Unscoped` or org-threaded) → delete the now-redundant
+  route comparisons → extend the contract suite.
+- **M3 (separate design):** Postgres row-level security as the DB-level
+  backstop beneath this fence.
+
+## 8. Non-goals
+
+- **Visibility and role policy** — stays in `authorization/policy.ts`; this
+  seam is tenancy only.
+- **Wire or DTO changes** — none; this is a pure internal seam.
+- **Postgres RLS** — deliberately separate (M3): it wants the port convention
+  in place first, and carries its own Prisma/transaction ergonomics
+  trade-offs.
+- **The daemon WS trust domain** — its fences (connection identity, roster
+  scoping, mutation leases) are already stronger than an org parameter and are
+  not reshaped here.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,5 +61,22 @@ export default defineConfig([
       'import-x/no-unresolved': ['off'],
       'unused-imports/no-unused-imports': 'error'
     }
+  },
+  {
+    // Tenancy fence (docs/designs/org-scoped-data-layer.md §6): the HTTP
+    // surface resolves resources through org-fenced repo methods only; the
+    // `*Unscoped` escape hatches belong to internal trust domains. A
+    // public-by-design endpoint may disable this inline with a justification.
+    files: ['packages/control-plane/src/http/routes/**/*.ts', 'packages/control-plane/src/http/mcp/**/*.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'CallExpression[callee.property.name=/Unscoped$/]',
+          message:
+            'Tenancy-unscoped reads are forbidden on the HTTP surface — use the org-fenced method with the request org (docs/designs/org-scoped-data-layer.md §6).'
+        }
+      ]
+    }
   }
 ])

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1341,7 +1341,7 @@ export function buildContainer(
               Promise.all([
                 ...hooks.map((hook) => hookService.broadcast(hook)),
                 ...agentIds.map(async (agentId) => {
-                  const agent = await repos.agent.get(agentId)
+                  const agent = await repos.agent.getUnscoped(agentId)
                   if (!agent?.daemonId) return
                   try {
                     await sender.agentUpsert(agent.daemonId, {

--- a/packages/control-plane/src/github/review-broker.service.test.ts
+++ b/packages/control-plane/src/github/review-broker.service.test.ts
@@ -129,7 +129,7 @@ function setup(overrides: Partial<GithubReviewBrokerDeps> = {}) {
   }
   const deps = {
     hook: hookRepo,
-    agent: { get: vi.fn(async () => agent) },
+    agent: { getUnscoped: vi.fn(async () => agent) },
     github: {
       mintReviewForAgent: vi.fn(async () => ({
         token: 'broker-secret',

--- a/packages/control-plane/src/github/review-broker.service.ts
+++ b/packages/control-plane/src/github/review-broker.service.ts
@@ -45,7 +45,7 @@ export class GithubReviewBrokerError extends Error {
 
 export interface GithubReviewBrokerDeps {
   hook: Pick<HookRepo, 'get' | 'getRun' | 'recordStart' | 'reserveReviewAttempt' | 'recordReviewResult'>
-  agent: Pick<AgentRepo, 'get'>
+  agent: Pick<AgentRepo, 'getUnscoped'>
   github: Pick<GithubService, 'mintReviewForAgent' | 'validateReviewForAgent'>
   clock: Pick<Clock, 'now'>
 }
@@ -330,7 +330,7 @@ export class GithubReviewBrokerService {
       { started: recovering }
     )
     requireCurrentHookForStart(await this.deps.hook.get(hookId), run, reportingDaemonId)
-    const agent = await this.deps.agent.get(run.agentId!)
+    const agent = await this.deps.agent.getUnscoped(run.agentId!)
     if (!agent || agent.status !== 'active' || agent.daemonId !== reportingDaemonId) {
       denied('agent is no longer active on the accepted dispatch daemon')
     }
@@ -355,7 +355,7 @@ export class GithubReviewBrokerService {
     const target = requireTrustedPullTarget(initial)
     const current = requireCurrentActionAuthority(
       await this.deps.hook.get(hookId),
-      await this.deps.agent.get(initial.agentId),
+      await this.deps.agent.getUnscoped(initial.agentId),
       initial,
       reportingDaemonId,
       input.requestedEvent
@@ -408,7 +408,7 @@ export class GithubReviewBrokerService {
     try {
       const finalAuthority = requireCurrentActionAuthority(
         await this.deps.hook.get(hookId),
-        await this.deps.agent.get(initial.agentId),
+        await this.deps.agent.getUnscoped(initial.agentId),
         finalRun,
         reportingDaemonId,
         input.requestedEvent
@@ -436,7 +436,7 @@ export class GithubReviewBrokerService {
       )
       requireCurrentActionAuthority(
         await this.deps.hook.get(hookId),
-        await this.deps.agent.get(initial.agentId),
+        await this.deps.agent.getUnscoped(initial.agentId),
         exposureRun,
         reportingDaemonId,
         input.requestedEvent

--- a/packages/control-plane/src/github/run-reporter.test.ts
+++ b/packages/control-plane/src/github/run-reporter.test.ts
@@ -162,7 +162,7 @@ describe('GithubRunCoordinator', () => {
         | 'setProjectionDesired'
         | 'upsertReviewSubject'
       >,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW),
       kick
     })
@@ -201,7 +201,7 @@ describe('GithubRunCoordinator', () => {
     const kick = vi.fn()
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW),
       kick
     })
@@ -225,7 +225,7 @@ describe('GithubRunCoordinator', () => {
     }
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW)
     })
     await coordinator.afterAccepted(hookId, 'delivery-1')
@@ -255,7 +255,7 @@ describe('GithubRunCoordinator', () => {
     }
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW)
     })
 
@@ -285,7 +285,7 @@ describe('GithubRunCoordinator', () => {
     }
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW)
     })
     await coordinator.afterReport(hookId, row.deliveryKey)
@@ -318,7 +318,7 @@ describe('GithubRunCoordinator', () => {
     }
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW)
     })
 
@@ -358,7 +358,7 @@ describe('GithubRunCoordinator', () => {
     }
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW)
     })
 
@@ -385,7 +385,7 @@ describe('GithubRunCoordinator', () => {
     }
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW)
     })
 
@@ -422,7 +422,7 @@ describe('GithubRunCoordinator', () => {
     const kick = vi.fn()
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW),
       kick
     })
@@ -453,7 +453,7 @@ describe('GithubRunCoordinator', () => {
     }
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW)
     })
 
@@ -482,7 +482,7 @@ describe('GithubRunCoordinator', () => {
     }
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW)
     })
 
@@ -504,7 +504,7 @@ describe('GithubRunCoordinator', () => {
     }
     const coordinator = new GithubRunCoordinator({
       hooks: hooks as never,
-      agents: { get: vi.fn(async () => agent()) },
+      agents: { getUnscoped: vi.fn(async () => agent()) },
       clock: new FakeClock(NOW)
     })
 
@@ -585,7 +585,7 @@ describe('GithubRunReporter', () => {
         | 'listReviewSubjects'
         | 'getRunById'
       >,
-      agents: { get: vi.fn(async () => currentAgent) },
+      agents: { getUnscoped: vi.fn(async () => currentAgent) },
       orgs: { slugById: vi.fn(async () => 'acme') },
       webAppUrl: 'https://console.example.com/',
       ...(appSlug ? { appSlug } : {}),

--- a/packages/control-plane/src/github/run-reporter.ts
+++ b/packages/control-plane/src/github/run-reporter.ts
@@ -124,7 +124,7 @@ export interface GithubRunCoordinatorDeps {
     | 'setProjectionDesired'
     | 'upsertReviewSubject'
   >
-  agents: Pick<AgentRepo, 'get'>
+  agents: Pick<AgentRepo, 'getUnscoped'>
   clock: Clock
   /** Immediate wake-up only; the worker's periodic scan is authoritative. */
   kick?: () => void
@@ -218,7 +218,7 @@ export class GithubRunCoordinator {
     )
       return
 
-    const agent = await this.deps.agents.get(run.agentId)
+    const agent = await this.deps.agents.getUnscoped(run.agentId)
     if (!agent) return
     const now = new Date(this.deps.clock.now())
     const projection = await this.deps.hooks.upsertReviewProjection({
@@ -289,7 +289,7 @@ export interface GithubRunReporterDeps {
     | 'refreshReviewProjectionTarget'
     | 'getRunById'
   >
-  agents: Pick<AgentRepo, 'get'>
+  agents: Pick<AgentRepo, 'getUnscoped'>
   orgs?: Pick<OrgRepo, 'slugById'>
   /** Console origin used for Check Run links; unset keeps GitHub's default App link. */
   webAppUrl?: string
@@ -475,7 +475,7 @@ export class GithubRunReporter {
       return
     }
 
-    const agent = await this.deps.agents.get(projection.agentId)
+    const agent = await this.deps.agents.getUnscoped(projection.agentId)
     let token: string
     let repoFullName: string
     let resolvedRepoId: bigint

--- a/packages/control-plane/src/hooks/hook.service.test.ts
+++ b/packages/control-plane/src/hooks/hook.service.test.ts
@@ -78,7 +78,7 @@ function make(
   } = {}
 ) {
   const agents: HookAgentReads = {
-    get: vi.fn(async () =>
+    getUnscoped: vi.fn(async () =>
       opts.daemonId === null
         ? null
         : ({ id: AGENT, name: 'review-agent', daemonId: opts.daemonId ?? DAEMON } as AgentRecord)
@@ -233,7 +233,7 @@ describe('HookService.replayTo', () => {
       repoFullName: 'acme/infra',
       events: ['issues:*']
     })
-    const agents: HookAgentReads = { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON }) as AgentRecord) }
+    const agents: HookAgentReads = { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON }) as AgentRecord) }
     const secrets = { get: vi.fn(async () => null) } as unknown as HookSecretStore
     const hooks = { listEnabled: vi.fn(async () => [github, webhook]) } as unknown as HookRepo
     const installations = {

--- a/packages/control-plane/src/hooks/hook.service.ts
+++ b/packages/control-plane/src/hooks/hook.service.ts
@@ -31,7 +31,7 @@ import { toDbPlatform } from '../persistence/platform.js'
 
 /** The narrow agent read the compiler needs (placement lookup). */
 export interface HookAgentReads {
-  get(agentId: AgentId): Promise<AgentRecord | null>
+  getUnscoped(agentId: AgentId): Promise<AgentRecord | null>
 }
 
 export interface HookServiceLog {
@@ -62,7 +62,7 @@ export class HookService {
    */
   async compile(hook: HookRecord): Promise<RcHookAssign | null> {
     if (!hook.enabled || !hook.agentId) return null
-    const agent = await this.agents.get(hook.agentId)
+    const agent = await this.agents.getUnscoped(hook.agentId)
     if (!agent?.daemonId) return null
     const snapshot =
       typeof hook.configRevision === 'bigint' &&

--- a/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
@@ -139,7 +139,7 @@ describe('syncAgentBotIcons', () => {
       syncAgentBotIcons(
         {
           repos: {
-            agent: { get: async () => currentAgent },
+            agent: { getUnscoped: async () => currentAgent },
             integration: {
               listForAgent: async () => integrations,
               listForBot: async (id) => {
@@ -195,7 +195,7 @@ describe('syncAgentBotIcons', () => {
     const warn = vi.fn()
     const deps = {
       repos: {
-        agent: { get: async () => agentRecord(agent.icon) },
+        agent: { getUnscoped: async () => agentRecord(agent.icon) },
         integration: { listForAgent: async () => [membership], listForBot: async () => [membership] },
         bot: { get: async () => bot(feishuId, 'feishu', { feishuAppId: 'cli_feishu' }) },
         botSecret: {
@@ -242,7 +242,7 @@ describe('syncAgentBotIcons', () => {
     })
     const deps = {
       repos: {
-        agent: { get: async () => currentAgent },
+        agent: { getUnscoped: async () => currentAgent },
         integration: {
           listForAgent: async () => [membership],
           listForBot: async () => [membership]
@@ -297,7 +297,7 @@ describe('syncAgentBotIcons', () => {
     })
     const deps = {
       repos: {
-        agent: { get: async () => currentAgent },
+        agent: { getUnscoped: async () => currentAgent },
         integration: {
           listForAgent: async () => [membership],
           listForBot: async () => [membership]

--- a/packages/control-plane/src/http/agent-bot-icon-sync.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.ts
@@ -11,7 +11,7 @@ import type { CpPlatformRegistry } from '../platforms/provider.js'
 
 interface AgentBotIconSyncDeps {
   repos: {
-    agent: Pick<AgentRepo, 'get'>
+    agent: Pick<AgentRepo, 'getUnscoped'>
     integration: Pick<IntegrationRepo, 'listForAgent' | 'listForBot'>
     bot: Pick<BotRepo, 'get'>
     botSecret: Pick<BotSecretStore, 'get'>
@@ -69,7 +69,7 @@ async function currentBotIconState(
   const membership = memberships[0]!
   if (membership.platform !== bot.platform) return null
 
-  const agent = await deps.repos.agent.get(membership.agentId)
+  const agent = await deps.repos.agent.getUnscoped(membership.agentId)
   if (!agent || agent.orgId !== bot.orgId) return null
   return {
     bot,

--- a/packages/control-plane/src/http/routes/agent-icon.ts
+++ b/packages/control-plane/src/http/routes/agent-icon.ts
@@ -29,7 +29,11 @@ export function agentIconRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply): Promise<FastifyReply> => {
-        const agent = await deps.repos.agent.get(AgentId(req.params.id)).catch(() => null)
+        // Public by design: chat platforms (Slack icon_url, Lark's launcher)
+        // fetch this PNG with no credentials, so there is no org principal to
+        // fence on — the raw agent UUID is the capability.
+        // eslint-disable-next-line no-restricted-syntax -- org-scoped-data-layer.md §4: public-by-design endpoint
+        const agent = await deps.repos.agent.getUnscoped(AgentId(req.params.id)).catch(() => null)
         if (!agent) return reply.code(404).send()
         // Lark's app launcher loads this with `crossOrigin = "anonymous"` before
         // rasterizing it on a canvas, so the public image response must allow CORS.

--- a/packages/control-plane/src/http/routes/agent-repos.ts
+++ b/packages/control-plane/src/http/routes/agent-repos.ts
@@ -52,8 +52,8 @@ export function agentRepoRoutes(deps: HttpDeps) {
     // Same no-oracle rule as `GET /agents/:agentId/hooks`: cross-org, unknown,
     // and not-viewable agents all read 404.
     const getViewableAgent = async (req: FastifyRequest, agentId: string): Promise<AgentRecord | null> => {
-      const agent = await deps.repos.agent.get(AgentId(agentId))
-      if (!agent || agent.orgId !== orgOf(req) || !canView(agent, ctxOf(req))) return null
+      const agent = await deps.repos.agent.get(orgOf(req), AgentId(agentId))
+      if (!agent || !canView(agent, ctxOf(req))) return null
       return agent
     }
     /** Lazily pin a legacy github workspace to its rename-proof numeric id.
@@ -71,7 +71,7 @@ export function agentRepoRoutes(deps: HttpDeps) {
       const ref = await deps.github.repoRefFor(installation, owner, repo)
       if (!ref) return undefined
       if (await deps.repos.agent.setWorkspaceRepoId(agent.id, ref.repoId)) return ref.repoId
-      return (await deps.repos.agent.get(agent.id))?.workspaceRepoId
+      return (await deps.repos.agent.get(agent.orgId, agent.id))?.workspaceRepoId
     }
     const agentNotFound = (reply: FastifyReply) =>
       reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -505,8 +505,8 @@ export function agentRoutes(deps: HttpDeps) {
     // to them — a cross-org id OR a restricted agent they can't see both read as
     // absent (404), never as someone else's resource.
     const getOrgAgent = async (req: FastifyRequest, id: string): Promise<AgentRecord | null> => {
-      const agent = await deps.repos.agent.get(AgentId(id))
-      if (!agent || agent.orgId !== req.orgCtx!.orgId) return null
+      const agent = await deps.repos.agent.get(orgOf(req), AgentId(id))
+      if (!agent) return null
       return canView(agent, ctxOf(req)) ? agent : null
     }
 
@@ -947,7 +947,8 @@ export function agentRoutes(deps: HttpDeps) {
       log: app.log
     })
     const refreshMutationAgent = async (observed: AgentRecord): Promise<AgentRecord | null> => {
-      const current = await deps.repos.agent.get(observed.id)
+      // `observed` came through an org-fenced read, so its own org scopes the refresh.
+      const current = await deps.repos.agent.get(observed.orgId, observed.id)
       if (
         !current ||
         current.daemonId !== observed.daemonId ||
@@ -1667,6 +1668,7 @@ export function agentRoutes(deps: HttpDeps) {
               req.body.mcpServers,
               (authorizeMcpServers) =>
                 deps.repos.agentConfig.update(
+                  orgOf(req),
                   AgentId(req.params.id),
                   {
                     ...bodyPatch,
@@ -2162,7 +2164,7 @@ export function agentRoutes(deps: HttpDeps) {
           // AgentRepo holds the shared agent lifecycle lock while it captures
           // every HookDef, tombstones their durable review projections, and
           // cascades the Agent/HookDef rows in one transaction.
-          const removedHooks = await deps.repos.agent.delete(AgentId(req.params.id))
+          const removedHooks = await deps.repos.agent.delete(orgOf(req), AgentId(req.params.id))
           // WITHDRAW it from the peer directory now, the mirror of the create path above.
           // Discovery (`channel/agents`) reads the DB live while a peer WAKE is authorized
           // against the pushed snapshot, so without this every daemon in the org keeps a flat
@@ -2244,6 +2246,7 @@ export function agentRoutes(deps: HttpDeps) {
           }
           const sharedWith = await resolveShareSet(deps.repos.user, orgOf(req), req.body.sharedWith)
           const agent = await deps.repos.agent.setSharing(
+            orgOf(req),
             AgentId(req.params.id),
             { visibility: req.body.visibility, sharedWith },
             req.principal?.userId
@@ -2318,6 +2321,7 @@ export function agentRoutes(deps: HttpDeps) {
               ? await resolvePolicyAgentIds(req, req.params.id, requestedTargetAgentIds, current.allowedTargetAgentIds)
               : []
           const agent = await deps.repos.agent.setCallPolicy(
+            orgOf(req),
             AgentId(req.params.id),
             {
               callPolicy: req.body.callPolicy,

--- a/packages/control-plane/src/http/routes/crons.ts
+++ b/packages/control-plane/src/http/routes/crons.ts
@@ -68,7 +68,7 @@ export function cronRoutes(deps: HttpDeps) {
   return async function cronRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
     const refreshMutationAgent = async (observed: AgentRecord): Promise<AgentRecord | null> => {
-      const current = await deps.repos.agent.get(observed.id)
+      const current = await deps.repos.agent.get(observed.orgId, observed.id)
       if (
         !current ||
         current.daemonId !== observed.daemonId ||
@@ -141,8 +141,8 @@ export function cronRoutes(deps: HttpDeps) {
         // defines both the fire target and the owning daemon. A restricted agent they
         // can't see is rejected identically to a nonexistent id (no existence oracle,
         // and no binding-then-firing a restricted agent). Mirrors integrations create.
-        let agent = await deps.repos.agent.get(AgentId(req.body.agentId))
-        if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+        let agent = await deps.repos.agent.get(orgOf(req), AgentId(req.body.agentId))
+        if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: 'unknown agentId' })
         }
         // The target rides one of THIS agent's integrations — the anchor is
@@ -174,7 +174,9 @@ export function cronRoutes(deps: HttpDeps) {
         try {
           const current = await refreshMutationAgent(agent)
           const previousAgent =
-            existing?.agentId && existing.agentId !== agent.id ? await deps.repos.agent.get(existing.agentId) : current
+            existing?.agentId && existing.agentId !== agent.id
+              ? await deps.repos.agent.get(orgOf(req), existing.agentId)
+              : current
           if (!current || !previousAgent) {
             return reply.code(409).send({
               error: 'Conflict',
@@ -335,7 +337,7 @@ export function cronRoutes(deps: HttpDeps) {
         if (!canEdit(cron, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot run this cron' })
         }
-        let agent = cron.agentId ? await deps.repos.agent.get(cron.agentId) : null
+        let agent = cron.agentId ? await deps.repos.agent.get(orgOf(req), cron.agentId) : null
         if (!agent?.daemonId) {
           return reply
             .code(503)
@@ -409,7 +411,7 @@ export function cronRoutes(deps: HttpDeps) {
             .code(409)
             .send({ error: 'Conflict', statusCode: 409, message: 'cron has no agent; refresh and retry' })
         }
-        let agent = await deps.repos.agent.get(existingAgentId)
+        let agent = await deps.repos.agent.get(orgOf(req), existingAgentId)
         if (!agent) {
           return reply
             .code(409)
@@ -486,7 +488,7 @@ export function cronRoutes(deps: HttpDeps) {
             .code(409)
             .send({ error: 'Conflict', statusCode: 409, message: 'cron has no agent; refresh and retry' })
         }
-        const observedAgent = await deps.repos.agent.get(existingAgentId)
+        const observedAgent = await deps.repos.agent.get(orgOf(req), existingAgentId)
         if (!observedAgent) {
           return reply
             .code(409)

--- a/packages/control-plane/src/http/routes/feishu-registration.ts
+++ b/packages/control-plane/src/http/routes/feishu-registration.ts
@@ -12,7 +12,7 @@ import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import { AgentId, OrgId } from '../../domain/ids.js'
 import { resolveAgentIconUrl } from '../../agents/agent-icon.js'
-import { denyViewerWrite, ctxOf } from '../rbac.js'
+import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canEdit, canView } from '../../authorization/policy.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
 import {
@@ -64,8 +64,8 @@ export function feishuRegistrationRoutes(deps: HttpDeps, feishu: FeishuRouteSeam
           return reply.code(401).send({ error: 'Unauthorized', statusCode: 401, message: 'authentication required' })
         }
         const orgId = orgIdOf(req)
-        const agent = await deps.repos.agent.get(AgentId(req.body.agentId))
-        if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+        const agent = await deps.repos.agent.get(orgOf(req), AgentId(req.body.agentId))
+        if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         }
         if (!canEdit(agent, ctxOf(req))) {
@@ -213,14 +213,8 @@ export function feishuRegistrationRoutes(deps: HttpDeps, feishu: FeishuRouteSeam
           if (!release) throw new FeishuRegistrationRetryError()
           let httpAppConfig: ConfigureFeishuHttpAppInput | undefined
           try {
-            const current = await deps.repos.agent.get(registration.agentId)
-            if (
-              !current ||
-              current.orgId !== registration.orgId ||
-              !current.daemonId ||
-              !canView(current, ctxOf(req)) ||
-              !canEdit(current, ctxOf(req))
-            ) {
+            const current = await deps.repos.agent.get(orgOf(req), registration.agentId)
+            if (!current || !current.daemonId || !canView(current, ctxOf(req)) || !canEdit(current, ctxOf(req))) {
               throw new FeishuRegistrationSetupError('agent_unavailable')
             }
             const availability = await integrationPlatformAvailability(deps, {

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -92,8 +92,8 @@ export function hookRoutes(deps: HttpDeps) {
     const getOrgHook = async (req: FastifyRequest, id: string): Promise<HookRecord | null> => {
       const hook = await deps.repos.hook.get(HookId(id))
       if (!hook || hook.orgId !== req.orgCtx!.orgId || !hook.agentId) return null
-      const agent = await deps.repos.agent.get(hook.agentId)
-      if (!agent || agent.orgId !== req.orgCtx!.orgId || !canView(agent, ctxOf(req))) return null
+      const agent = await deps.repos.agent.get(orgOf(req), hook.agentId)
+      if (!agent || !canView(agent, ctxOf(req))) return null
       return hook
     }
 
@@ -204,7 +204,9 @@ export function hookRoutes(deps: HttpDeps) {
             const ref = await deps.github.repoRefFor(ins, owner!, repo)
             if (ref?.repoId === repoId) {
               if (await deps.repos.agent.setWorkspaceRepoId(agent.id, repoId)) return { ok: true }
-              return (await deps.repos.agent.get(agent.id))?.workspaceRepoId === repoId ? { ok: true } : denied
+              return (await deps.repos.agent.get(agent.orgId, agent.id))?.workspaceRepoId === repoId
+                ? { ok: true }
+                : denied
             }
           } catch (e) {
             if (!(e instanceof GithubApiError)) throw e
@@ -320,8 +322,8 @@ export function hookRoutes(deps: HttpDeps) {
         }
         // The hook's agent must exist IN THIS ORG and be VISIBLE to the caller —
         // same no-oracle rule as cron create (no binding a restricted agent).
-        const agent = await deps.repos.agent.get(AgentId(req.body.agentId))
-        if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+        const agent = await deps.repos.agent.get(orgOf(req), AgentId(req.body.agentId))
+        if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: 'unknown agentId' })
         }
         const target = await resolveTarget(orgId, agent.id, req.body)
@@ -450,8 +452,8 @@ export function hookRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await deps.repos.agent.get(AgentId(req.params.agentId))
-        if (!agent || agent.orgId !== orgOf(req) || !canView(agent, ctxOf(req))) {
+        const agent = await deps.repos.agent.get(orgOf(req), AgentId(req.params.agentId))
+        if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         }
         const rows = await deps.repos.hook.listForAgent(agent.id)
@@ -519,8 +521,8 @@ export function hookRoutes(deps: HttpDeps) {
             message: 'kind is immutable — delete and re-create to change it'
           })
         }
-        const agent = await deps.repos.agent.get(AgentId(req.body.agentId))
-        if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+        const agent = await deps.repos.agent.get(orgOf(req), AgentId(req.body.agentId))
+        if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: 'unknown agentId' })
         }
         const target = await resolveTarget(orgId, agent.id, req.body)

--- a/packages/control-plane/src/http/routes/icon-upload.ts
+++ b/packages/control-plane/src/http/routes/icon-upload.ts
@@ -20,9 +20,9 @@ import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
-import { AgentId } from '../../domain/ids.js'
+import { AgentId, type OrgId } from '../../domain/ids.js'
 import { canEdit } from '../../authorization/policy.js'
-import { ctxOf, denyNonOwner } from '../rbac.js'
+import { ctxOf, denyNonOwner, orgOf } from '../rbac.js'
 import { Tag } from '../plugins/openapi.js'
 import { AgentIconDto, ErrorDto } from '../dto/index.js'
 import { agentIconKey, orgIconKey } from '../../icons/icon-store.js'
@@ -58,8 +58,8 @@ export function iconUploadRoutes(deps: HttpDeps) {
 
     // Best-effort: replicate the agent's new icon to its owning daemon so the Slack
     // per-message avatar refreshes now (the reconnect roster is the backstop).
-    const replicateAgent = async (agentId: string): Promise<void> => {
-      const agent = await deps.repos.agent.get(AgentId(agentId))
+    const replicateAgent = async (orgId: OrgId, agentId: string): Promise<void> => {
+      const agent = await deps.repos.agent.get(orgId, AgentId(agentId))
       if (!agent?.daemonId) return
       try {
         await deps.control.agentUpsert(agent.daemonId, {
@@ -90,8 +90,8 @@ export function iconUploadRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await deps.repos.agent.get(AgentId(req.params.agentId))
-        if (!agent || agent.orgId !== req.orgCtx!.orgId) {
+        const agent = await deps.repos.agent.get(orgOf(req), AgentId(req.params.agentId))
+        if (!agent) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         }
         if (!canEdit(agent, ctxOf(req))) {
@@ -109,11 +109,11 @@ export function iconUploadRoutes(deps: HttpDeps) {
 
         await iconStore.put(agentIconKey(agent.id), bytes, v.contentType)
         const imageIcon = { kind: 'image' as const, generation: randomUUID() }
-        const updated = await deps.repos.agent.update(AgentId(agent.id), {
+        const updated = await deps.repos.agent.update(orgOf(req), AgentId(agent.id), {
           icon: imageIcon,
           ...(req.principal?.userId ? { lastModifiedByUserId: req.principal.userId } : {})
         })
-        void replicateAgent(agent.id)
+        void replicateAgent(agent.orgId, agent.id)
         void syncAgentBotIcons(deps, updated, app.log)
         return reply.send({
           icon: { kind: 'image' as const },
@@ -135,8 +135,8 @@ export function iconUploadRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await deps.repos.agent.get(AgentId(req.params.agentId))
-        if (!agent || agent.orgId !== req.orgCtx!.orgId) {
+        const agent = await deps.repos.agent.get(orgOf(req), AgentId(req.params.agentId))
+        if (!agent) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         }
         if (!canEdit(agent, ctxOf(req))) {
@@ -149,14 +149,14 @@ export function iconUploadRoutes(deps: HttpDeps) {
             .send({ error: 'Forbidden', statusCode: 403, message: 'built-in agent icon cannot be changed' })
         }
         const glyph = randomGlyphIcon()
-        const updated = await deps.repos.agent.update(AgentId(agent.id), {
+        const updated = await deps.repos.agent.update(orgOf(req), AgentId(agent.id), {
           icon: glyph,
           ...(req.principal?.userId ? { lastModifiedByUserId: req.principal.userId } : {})
         })
         await iconStore.delete(agentIconKey(agent.id)).catch((err) => {
           app.log.warn({ err, agentId: agent.id }, 'icon store delete failed (row already reset)')
         })
-        void replicateAgent(agent.id)
+        void replicateAgent(agent.orgId, agent.id)
         void syncAgentBotIcons(deps, updated, app.log)
         return reply.send({ icon: glyph, iconUrl: null })
       }

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -24,7 +24,7 @@ import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import type { AgentRecord, BotRecord, IntegrationRecord, IntegrationChannelRecord } from '../../persistence/ports.js'
 import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
-import { denyViewerWrite, ctxOf } from '../rbac.js'
+import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
 import { pickChannelOwner } from '../../orchestrator/httpBot.js'
@@ -86,7 +86,7 @@ export function integrationRoutes(deps: HttpDeps) {
     // The caller's active org — every read/write below is scoped to it.
     const orgIdOf = (req: { orgCtx?: { orgId: OrgId } }) => req.orgCtx!.orgId
     const refreshMutationAgent = async (observed: AgentRecord): Promise<AgentRecord | null> => {
-      const current = await deps.repos.agent.get(observed.id)
+      const current = await deps.repos.agent.get(observed.orgId, observed.id)
       if (
         !current ||
         current.daemonId !== observed.daemonId ||
@@ -108,7 +108,7 @@ export function integrationRoutes(deps: HttpDeps) {
       const [secret, channels, owner, bot] = await Promise.all([
         deps.repos.botSecret.get(i.botId),
         deps.repos.integrationChannel.listForIntegration(i.id),
-        deps.repos.agent.get(i.agentId),
+        deps.repos.agent.get(i.orgId, i.agentId),
         deps.repos.bot.get(i.botId)
       ])
       if (!secret || !bot) return
@@ -194,11 +194,11 @@ export function integrationRoutes(deps: HttpDeps) {
         // The composed body's `platform` enum IS the registry's id set, so a
         // parsed body always names a registered provider.
         const provider = deps.platforms.get(req.body.platform)!
-        let agent = await deps.repos.agent.get(AgentId(req.body.agentId))
+        let agent = await deps.repos.agent.get(orgOf(req), AgentId(req.body.agentId))
         // Derived visibility: installing an integration edits the agent's setup, so
         // a restricted agent the caller can't see 404s, and one they can see but not
         // edit 403s.
-        if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+        if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         }
         if (!canEdit(agent, ctxOf(req))) {
@@ -561,7 +561,7 @@ export function integrationRoutes(deps: HttpDeps) {
               channels[0]
             if (channel) {
               const persistedOwner = channels.some((row) => row.agentId === owner.agentId)
-              const ownerAgent = persistedOwner ? null : await deps.repos.agent.get(owner.agentId)
+              const ownerAgent = persistedOwner ? null : await deps.repos.agent.get(orgOf(req), owner.agentId)
               effective.set(`${state.botId}\u0000${channelId}`, {
                 ...channel,
                 agentId: owner.agentId,
@@ -601,7 +601,7 @@ export function integrationRoutes(deps: HttpDeps) {
         reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'integration not found' })
         return null
       }
-      const agent = await deps.repos.agent.get(integration.agentId)
+      const agent = await deps.repos.agent.get(orgIdOf(req as never), integration.agentId)
       if (!agent || !canView(agent, ctxOf(req as never))) {
         reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'integration not found' })
         return null
@@ -719,7 +719,7 @@ export function integrationRoutes(deps: HttpDeps) {
         installs,
         channelRows.filter((candidate) => candidate.kind === 'channel' && candidate.channelId === channelId)
       )
-      const ownerAgent = owner ? await deps.repos.agent.get(owner.agentId) : null
+      const ownerAgent = owner ? await deps.repos.agent.get(owner.orgId, owner.agentId) : null
       if (!ownerAgent) {
         return {
           ok: false,
@@ -762,7 +762,7 @@ export function integrationRoutes(deps: HttpDeps) {
         // Derived visibility: gate on the parent agent — a restricted agent the
         // caller can't see 404s (hiding the integration too), one they can see but
         // not edit 403s.
-        let agent = await deps.repos.agent.get(integration.agentId)
+        let agent = await deps.repos.agent.get(orgIdOf(req as never), integration.agentId)
         if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'integration not found' })
         }
@@ -798,9 +798,11 @@ export function integrationRoutes(deps: HttpDeps) {
             installs,
             channelRows.filter((channel) => channel.kind === 'channel' && channel.channelId === req.params.channelId)
           )
-          effectiveOwner = owner ? await deps.repos.agent.get(owner.agentId) : null
+          effectiveOwner = owner ? await deps.repos.agent.get(orgOf(req), owner.agentId) : null
           selectedOwner =
-            req.body.agentId !== undefined ? await deps.repos.agent.get(AgentId(req.body.agentId)) : effectiveOwner
+            req.body.agentId !== undefined
+              ? await deps.repos.agent.get(orgOf(req), AgentId(req.body.agentId))
+              : effectiveOwner
           if (!effectiveOwner || !selectedOwner) {
             return reply.code(409).send({
               error: 'Conflict',
@@ -1145,7 +1147,7 @@ export function integrationRoutes(deps: HttpDeps) {
         }
         // Derived visibility: gate on the parent agent (a restricted agent the caller
         // can't see 404s; can-see-but-not-edit 403s) before removing its integration.
-        let agent = await deps.repos.agent.get(existing.agentId)
+        let agent = await deps.repos.agent.get(orgOf(req), existing.agentId)
         if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'integration not found' })
         }

--- a/packages/control-plane/src/http/routes/organization-knowledge.ts
+++ b/packages/control-plane/src/http/routes/organization-knowledge.ts
@@ -165,6 +165,7 @@ function unavailable(reply: FastifyReply) {
 
 async function suggestionReviewAvailable(
   deps: HttpDeps,
+  orgId: OrgId,
   sourceDaemonId: string | null,
   sourceAgentId: string
 ): Promise<boolean> {
@@ -173,7 +174,7 @@ async function suggestionReviewAvailable(
   if (live?.reachable !== true || live.state !== 'READY') return false
   const [daemon, agent] = await Promise.all([
     deps.registry.get(DaemonId(sourceDaemonId)),
-    deps.repos.agent.get(AgentId(sourceAgentId))
+    deps.repos.agent.get(orgId, AgentId(sourceAgentId))
   ])
   return (
     agent?.daemonId === sourceDaemonId &&
@@ -471,7 +472,7 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
         const names = new Map<string, string | null>()
         await Promise.all(
           [...new Set(rows.map((row) => row.sourceAgentId))].map(async (id) => {
-            const agent = await deps.repos.agent.get(AgentId(id))
+            const agent = await deps.repos.agent.get(orgOf(req), AgentId(id))
             names.set(id, agent?.displayName ?? agent?.name ?? null)
           })
         )
@@ -485,7 +486,10 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
               )
             ).entries()
           ].map(async ([key, row]) => {
-            availability.set(key, await suggestionReviewAvailable(deps, row.sourceDaemonId, row.sourceAgentId))
+            availability.set(
+              key,
+              await suggestionReviewAvailable(deps, orgOf(req), row.sourceDaemonId, row.sourceAgentId)
+            )
           })
         )
         return rows.map((row) =>
@@ -527,7 +531,7 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
           return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: 'suggestion is already reviewed' })
         }
         if (!suggestion.sourceDaemonId) return unavailable(reply)
-        if (!(await suggestionReviewAvailable(deps, suggestion.sourceDaemonId, suggestion.sourceAgentId))) {
+        if (!(await suggestionReviewAvailable(deps, orgOf(req), suggestion.sourceDaemonId, suggestion.sourceAgentId))) {
           return unavailable(reply)
         }
         try {
@@ -600,7 +604,9 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
 
         if (req.body.decision === 'reject') {
           if (!suggestion.sourceDaemonId) return unavailable(reply)
-          if (!(await suggestionReviewAvailable(deps, suggestion.sourceDaemonId, suggestion.sourceAgentId))) {
+          if (
+            !(await suggestionReviewAvailable(deps, orgOf(req), suggestion.sourceDaemonId, suggestion.sourceAgentId))
+          ) {
             return unavailable(reply)
           }
           const rejected = await repo.rejectSuggestion(suggestion.id, ctxOf(req).userId, req.body.reason)
@@ -624,7 +630,7 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
                 'organization suggestion decision convergence deferred'
               )
             )
-          const agent = await deps.repos.agent.get(AgentId(suggestion.sourceAgentId))
+          const agent = await deps.repos.agent.get(orgOf(req), AgentId(suggestion.sourceAgentId))
           return suggestionDto(rejected, agent?.displayName ?? agent?.name ?? null, false)
         }
 
@@ -637,7 +643,7 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
         }
 
         if (!suggestion.sourceDaemonId) return unavailable(reply)
-        if (!(await suggestionReviewAvailable(deps, suggestion.sourceDaemonId, suggestion.sourceAgentId))) {
+        if (!(await suggestionReviewAvailable(deps, orgOf(req), suggestion.sourceDaemonId, suggestion.sourceAgentId))) {
           return unavailable(reply)
         }
         let content
@@ -726,7 +732,7 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
               'organization suggestion decision convergence deferred'
             )
           )
-        const agent = await deps.repos.agent.get(AgentId(suggestion.sourceAgentId))
+        const agent = await deps.repos.agent.get(orgOf(req), AgentId(suggestion.sourceAgentId))
         return suggestionDto(result.suggestion, agent?.displayName ?? agent?.name ?? null, false)
       }
     )

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -24,7 +24,7 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import { AgentId, OrgId } from '../../domain/ids.js'
-import { denyViewerWrite, ctxOf } from '../rbac.js'
+import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { resolveWebAppUrl } from '../../config/env.js'
 import { buildInstallManifest, slackOAuthRedirectUri } from '../slack-manifest.js'
@@ -102,8 +102,8 @@ export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
           return reply.code(401).send({ error: 'Unauthorized', statusCode: 401, message: 'authentication required' })
         }
         const orgId = orgIdOf(req)
-        const agent = await deps.repos.agent.get(AgentId(req.body.agentId))
-        if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+        const agent = await deps.repos.agent.get(orgOf(req), AgentId(req.body.agentId))
+        if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         }
         if (!canEdit(agent, ctxOf(req))) {
@@ -339,8 +339,8 @@ export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
           }
         }
         // Re-check the agent: it could have been deleted / unplaced during the funnel.
-        let agent = await deps.repos.agent.get(row.agentId)
-        if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+        let agent = await deps.repos.agent.get(orgOf(req), row.agentId)
+        if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         }
         if (!canEdit(agent, ctxOf(req))) {
@@ -384,7 +384,7 @@ export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
           // Token verification and capability checks above can take long enough
           // for placement to change. Re-read after taking the mutation side of
           // the move gate so the bot cannot be installed onto a stale daemon.
-          const current = await deps.repos.agent.get(agent.id)
+          const current = await deps.repos.agent.get(orgOf(req), agent.id)
           if (
             !current ||
             current.daemonId !== agent.daemonId ||

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -33,7 +33,7 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
-import { denyViewerWrite, ctxOf } from '../rbac.js'
+import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { resolveWebAppUrl } from '../../config/env.js'
 import { SLACK_BOT_SCOPES, slackPlatformOAuthRedirectUri } from '../slack-manifest.js'
@@ -117,8 +117,8 @@ export function slackPlatformInstallRoutes(deps: HttpDeps, slack: SlackRouteSeam
               message: 'no target agent: pass agentId (the agentconnect preset is absent in this org)'
             })
           }
-          const agent = await deps.repos.agent.get(AgentId(requestedAgentId))
-          if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+          const agent = await deps.repos.agent.get(orgOf(req), AgentId(requestedAgentId))
+          if (!agent || !canView(agent, ctxOf(req))) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
           }
           if (!canEdit(agent, ctxOf(req))) {
@@ -275,8 +275,10 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
           return fail('workspace_mismatch')
         }
 
-        const agent = row.agentId ? await deps.repos.agent.get(row.agentId) : null
-        if (row.agentId && (!agent || agent.orgId !== row.orgId)) {
+        // Unauthenticated callback: no request org context — the pending-install
+        // row (minted org-scoped; its id is the OAuth state) carries the tenancy.
+        const agent = row.agentId ? await deps.repos.agent.get(row.orgId, row.agentId) : null
+        if (row.agentId && !agent) {
           // Target deleted while the tab was open — nothing sane to bind to.
           return fail('error')
         }

--- a/packages/control-plane/src/http/routes/webchat-mcp-operations.ts
+++ b/packages/control-plane/src/http/routes/webchat-mcp-operations.ts
@@ -79,7 +79,7 @@ export function webchatMcpOperationRoutes(deps: HttpDeps) {
       principal?: { userId: string }
       orgCtx?: { orgId: OrgId; userId: string; role: 'owner' | 'collaborator' | 'viewer' }
     }) => {
-      const agent = await deps.repos.agent.get(AgentId(req.params.agentId))
+      const agent = await deps.repos.agent.get(req.orgCtx!.orgId, AgentId(req.params.agentId))
       const userId = req.principal!.userId
       if (!agent || !agent.daemonId || agent.orgId !== req.params.orgId || !canView(agent, ctxOf(req as never)))
         return null

--- a/packages/control-plane/src/http/routes/webchat-token.ts
+++ b/packages/control-plane/src/http/routes/webchat-token.ts
@@ -17,9 +17,9 @@ import { z } from 'zod'
 import { WEBCHAT_MULTI_AGENT_FEATURE } from '@agentconnect.md/protocol'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
-import { AgentId } from '../../domain/ids.js'
+import { AgentId, type OrgId } from '../../domain/ids.js'
 import { canView } from '../../authorization/policy.js'
-import { ctxOf } from '../rbac.js'
+import { ctxOf, orgOf } from '../rbac.js'
 import { ErrorDto } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
 
@@ -62,13 +62,13 @@ export function webchatTokenRoutes(deps: HttpDeps) {
      *  since the minted token exposes and targets the full roster. */
     const allParticipantsViewable = async (
       conversationId: string,
-      orgId: string,
+      orgId: OrgId,
       ctx: ReturnType<typeof ctxOf>
     ): Promise<boolean> => {
       const roster = await deps.repos.webchatConversation.participants(conversationId)
       for (const p of roster) {
-        const member = await deps.repos.agent.get(p.agentId)
-        if (!member || member.orgId !== orgId || !canView(member, ctx)) return false
+        const member = await deps.repos.agent.get(orgId, p.agentId)
+        if (!member || !canView(member, ctx)) return false
       }
       return true
     }
@@ -96,8 +96,8 @@ export function webchatTokenRoutes(deps: HttpDeps) {
             .send({ error: 'Service Unavailable', statusCode: 503, message: 'webchat relay pool not configured' })
         }
         // Cross-org id OR a restricted agent the caller can't see both read as absent.
-        const agent = await deps.repos.agent.get(AgentId(req.params.agentId))
-        if (!agent || agent.orgId !== req.orgCtx!.orgId || !canView(agent, ctxOf(req))) {
+        const agent = await deps.repos.agent.get(orgOf(req), AgentId(req.params.agentId))
+        if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         }
         const userId = req.principal!.userId
@@ -162,7 +162,7 @@ export function webchatTokenRoutes(deps: HttpDeps) {
           // EVERY participant must still be viewable — the minted token exposes
           // and targets the full roster, so losing access to one restricted
           // member revokes resume for the whole conversation.
-          const primary = await deps.repos.agent.get(owned.primaryAgentId)
+          const primary = await deps.repos.agent.get(orgOf(req), owned.primaryAgentId)
           if (
             !primary ||
             primary.orgId !== orgId ||
@@ -184,8 +184,8 @@ export function webchatTokenRoutes(deps: HttpDeps) {
         const agentIds = [...new Set(req.body.agentIds!)]
         const agents = []
         for (const id of agentIds) {
-          const agent = await deps.repos.agent.get(AgentId(id))
-          if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+          const agent = await deps.repos.agent.get(orgOf(req), AgentId(id))
+          if (!agent || !canView(agent, ctxOf(req))) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
           }
           agents.push(agent)
@@ -250,8 +250,8 @@ export function webchatTokenRoutes(deps: HttpDeps) {
         if (!owned) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'conversation not found' })
         }
-        const agent = await deps.repos.agent.get(AgentId(req.body.agentId))
-        if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+        const agent = await deps.repos.agent.get(orgOf(req), AgentId(req.body.agentId))
+        if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         }
         const roster = await deps.repos.webchatConversation.participants(conversationId)
@@ -273,7 +273,7 @@ export function webchatTokenRoutes(deps: HttpDeps) {
         // (webchat-multi-agents.md §6.3, enforced at each growth point).
         const rosterAgents = [agent]
         for (const p of roster) {
-          const existing = await deps.repos.agent.get(p.agentId)
+          const existing = await deps.repos.agent.get(orgOf(req), p.agentId)
           if (existing) rosterAgents.push(existing)
         }
         for (const member of rosterAgents) {

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -156,9 +156,16 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
         message: 'response does not match schema'
       })
     }
-    // Prisma "record to delete/update does not exist", or a membership-dependent
-    // mutation whose required membership disappeared while it was queued.
-    if ((err as { code?: string }).code === 'P2025' || (err as { code?: string }).code === 'ORG_MEMBERSHIP_MISSING') {
+    // Prisma "record to delete/update does not exist", a membership-dependent
+    // mutation whose required membership disappeared while it was queued, or an
+    // org-fenced agent mutation whose row vanished (or never belonged to the
+    // caller's org) between the route's pre-read and the write — the fence
+    // deliberately makes those indistinguishable (org-scoped-data-layer.md §3).
+    if (
+      (err as { code?: string }).code === 'P2025' ||
+      (err as { code?: string }).code === 'ORG_MEMBERSHIP_MISSING' ||
+      (err as { code?: string }).code === 'AGENT_MISSING'
+    ) {
       return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'resource not found' })
     }
     // Prisma unique-constraint violation (e.g. duplicate agent slug in an org).

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -165,8 +165,9 @@ function make(
   const releasedLive: (typeof SESSION_KEY)[] = []
   const mutations = new AgentMutationGate()
   const repo = {
-    get: async () => current,
+    getUnscoped: async () => current,
     setWorkspace: async (
+      _orgId: string,
       _id: string,
       _expected: Date,
       _expectedMode: 'scratch' | 'github',
@@ -184,6 +185,7 @@ function make(
       return current
     },
     restoreWorkspace: async (
+      _orgId: string,
       _id: string,
       _expected: Date,
       _expectedWorkspace: AgentWorkspace,

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -209,7 +209,7 @@ export class AgentMoveService {
   }
 
   private async reloadAfterGate(observed: AgentRecord): Promise<AgentRecord> {
-    const current = await this.deps.agents.get(observed.id)
+    const current = await this.deps.agents.getUnscoped(observed.id)
     if (!current) throw new AgentMoveConflict('agent was deleted while preparing the move; refresh and retry')
     if (
       current.daemonId !== observed.daemonId ||
@@ -233,7 +233,7 @@ export class AgentMoveService {
   private async recoverStagedOnce(agentId: AgentId, daemonId: DaemonId, moveId: string): Promise<void> {
     const release = await this.deps.mutations.beginMoveWhenIdle(agentId)
     try {
-      const current = await this.deps.agents.get(agentId)
+      const current = await this.deps.agents.getUnscoped(agentId)
       if (!current || current.daemonId !== daemonId) return
 
       const candidate = await this.snapshotOwned(agentId, daemonId)
@@ -247,7 +247,7 @@ export class AgentMoveService {
       if (resumed.ok) {
         const observed = await this.snapshotOwned(agentId, daemonId)
         if (candidate.fingerprint === observed.fingerprint) {
-          const confirmed = await this.deps.agents.get(agentId)
+          const confirmed = await this.deps.agents.getUnscoped(agentId)
           if (!confirmed || confirmed.daemonId !== daemonId) return this.failClosedOwnership(agentId, daemonId)
           stable = { ...observed, agent: confirmed }
         } else {
@@ -311,6 +311,7 @@ export class AgentMoveService {
       let converted: AgentRecord | null = null
       try {
         converted = await this.deps.agents.setWorkspace(
+          agent.orgId,
           agent.id,
           agent.lastModifiedAt,
           agent.workspace.mode,
@@ -319,7 +320,7 @@ export class AgentMoveService {
           editor
         )
       } catch (err) {
-        const observed = await this.deps.agents.get(agent.id).catch(() => null)
+        const observed = await this.deps.agents.getUnscoped(agent.id).catch(() => null)
         if (observed?.daemonId === null && sameWorkspace(observed, workspace, workspaceRepoId)) {
           converted = observed
         } else if (err instanceof AgentWorkspaceIntegrationConflict) {
@@ -353,6 +354,7 @@ export class AgentMoveService {
     let persistenceError: unknown
     try {
       converted = await this.deps.agents.setWorkspace(
+        agent.orgId,
         agent.id,
         agent.lastModifiedAt,
         agent.workspace.mode,
@@ -366,7 +368,7 @@ export class AgentMoveService {
     if (!converted) {
       let observed: AgentRecord | null
       try {
-        observed = await this.deps.agents.get(agent.id)
+        observed = await this.deps.agents.getUnscoped(agent.id)
       } catch (readError) {
         // The write may have committed even though its response was lost. Keep
         // the daemon fenced until a retry can prove which definition owns it.
@@ -528,6 +530,7 @@ export class AgentMoveService {
     let restored: AgentRecord | null
     try {
       restored = await this.deps.agents.restoreWorkspace(
+        converted.orgId,
         converted.id,
         converted.lastModifiedAt,
         converted.workspace,
@@ -639,7 +642,7 @@ export class AgentMoveService {
   }
 
   private async snapshotOwned(agentId: AgentId, targetDaemonId: DaemonId): Promise<ActivationSnapshot> {
-    const agent = await this.deps.agents.get(agentId)
+    const agent = await this.deps.agents.getUnscoped(agentId)
     if (!agent || agent.daemonId !== targetDaemonId) {
       return this.failClosedOwnership(agentId, targetDaemonId)
     }
@@ -672,7 +675,7 @@ export class AgentMoveService {
       if (candidate.fingerprint === observed.fingerprint) {
         // Explicit final ownership read: an agent deleted or re-placed after the
         // ACK must never leave this target serving an orphaned copy.
-        const confirmed = await this.deps.agents.get(agentId)
+        const confirmed = await this.deps.agents.getUnscoped(agentId)
         if (!confirmed || confirmed.daemonId !== targetDaemonId) {
           return this.failClosedOwnership(agentId, targetDaemonId)
         }
@@ -747,7 +750,7 @@ export class AgentMoveService {
     bundle: MoveBundle
   ): Promise<void> {
     if (!sourceDaemonId) return
-    const current = await this.deps.agents.get(agent.id).catch(() => null)
+    const current = await this.deps.agents.getUnscoped(agent.id).catch(() => null)
     if (current?.daemonId !== sourceDaemonId) return
     await this.bestEffortBootstrap('source bootstrap after CAS failure', sourceDaemonId, agent, bundle)
   }

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -266,8 +266,8 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         return row
       }
     }
-    const agentRepo: Pick<AgentRepo, 'get'> = {
-      get: async (id) => {
+    const agentRepo: Pick<AgentRepo, 'getUnscoped'> = {
+      getUnscoped: async (id) => {
         const a = agents[id]
         if (!a) return null
         return { ...a, visibility: gatedAgents.has(id) ? 'restricted' : 'org' } as AgentRecord

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -286,7 +286,7 @@ export class HttpBotOrchestrator {
     // assignment, so a stale teardown can never kill a live ingest.
     await this.unassign(bot, { credentialRevision: bot.credentialRevision })
     for (const integration of installs) {
-      const agent = await this.agents.get(integration.agentId)
+      const agent = await this.agents.getUnscoped(integration.agentId)
       if (!agent?.daemonId) continue
       try {
         await this.control.integrationRemove(agent.daemonId, { integrationId: integration.id })
@@ -432,7 +432,7 @@ export class HttpBotOrchestrator {
    *  target is always allowed; a gated target needs its install's row for this
    *  conversation to be enabled (trigger ≠ off). Fail-closed on missing rows. */
   private async threadTargetAllowed(botId: string, channel: string, agentId: string): Promise<boolean> {
-    const agent = await this.agents.get(AgentId(agentId))
+    const agent = await this.agents.getUnscoped(AgentId(agentId))
     if (!agent) return false
     if (!isGatedAgent(agent)) return true
     const installs = await this.integrations.listForBot(BotId(botId))
@@ -478,7 +478,7 @@ export class HttpBotOrchestrator {
     for (const integration of installs) {
       // Conversation gating (§14): a gated install's fresh channels start Off — an
       // editor must enable them in the console before the compiler emits a route.
-      const owner = await this.agents.get(integration.agentId)
+      const owner = await this.agents.getUnscoped(integration.agentId)
       const defaultTrigger = owner && isGatedAgent(owner) ? ('off' as const) : undefined
       await this.channels.replaceSnapshot(integration.id, channels, defaultTrigger ? { defaultTrigger } : undefined)
     }
@@ -536,7 +536,7 @@ export class HttpBotOrchestrator {
     }
     const installs = await this.integrations.listForBot(bot.id)
     for (const install of installs) {
-      const agent = await this.agents.get(install.agentId)
+      const agent = await this.agents.getUnscoped(install.agentId)
       if (!agent) continue
       const kind = conversation.kind === 'mpim' ? ('mpim' as const) : ('im' as const)
       await this.channels.upsertConversation(
@@ -591,7 +591,7 @@ export class HttpBotOrchestrator {
         ? (rows.find((row) => row.agentId === currentOwner.agentId) ??
           rows.find((row) => row.integrationId === currentOwner.id))
         : undefined
-      const targetAgent = options.source === 'slack' ? await this.agents.get(owner.agentId) : null
+      const targetAgent = options.source === 'slack' ? await this.agents.getUnscoped(owner.agentId) : null
       let updated = await this.persistChannelOwner(installs, channelId, owner)
       const trigger =
         targetAgent && isGatedAgent(targetAgent)
@@ -644,7 +644,7 @@ export class HttpBotOrchestrator {
     channelId: string,
     owner: IntegrationRecord
   ): Promise<IntegrationChannelRecord> {
-    const ownerAgent = await this.agents.get(owner.agentId)
+    const ownerAgent = await this.agents.getUnscoped(owner.agentId)
     const defaultTrigger = ownerAgent && isGatedAgent(ownerAgent) ? ('off' as const) : undefined
     const updated = await this.channels.upsertAgent(
       owner.id,
@@ -713,7 +713,7 @@ export class HttpBotOrchestrator {
         channelRows.find((row) => row.integrationId === owner.id)?.trigger ??
         channelRows[0]?.trigger
       if (!persistedOwner) {
-        const ownerAgent = await this.agents.get(owner.agentId)
+        const ownerAgent = await this.agents.getUnscoped(owner.agentId)
         if (ownerAgent && isGatedAgent(ownerAgent)) trigger = 'off'
       }
       const canonical = channelRows.some((row) => row.integrationId === owner.id && row.agentId === owner.agentId)
@@ -732,7 +732,7 @@ export class HttpBotOrchestrator {
     await this.ensureChannelOwners(bot.id, integrations)
     const agentById = new Map<string, AgentRecord>()
     for (const i of integrations) {
-      const a = await this.agents.get(i.agentId)
+      const a = await this.agents.getUnscoped(i.agentId)
       if (a) agentById.set(i.agentId, a)
     }
     // Only agents currently PLACED on a daemon can receive traffic.

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -85,7 +85,7 @@ function deps(
           countUnackedVisibility,
           get: vi.fn(async () => null)
         } as never,
-        agent: { get: vi.fn(async () => (daemonId ? { id: AGENT, daemonId } : { id: AGENT })) } as never
+        agent: { getUnscoped: vi.fn(async () => (daemonId ? { id: AGENT, daemonId } : { id: AGENT })) } as never
       },
       control: { sessionVisibility, sessionVisibilitySnapshot } as never,
       connReg: over.connReg ?? connReg(),
@@ -218,7 +218,7 @@ describe('replayTo — register-time convergence', () => {
             countUnackedVisibility,
             get: vi.fn(async () => null)
           } as never,
-          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
         connReg: connReg(),
@@ -260,7 +260,7 @@ describe('replayTo — register-time convergence', () => {
             countUnackedVisibility: vi.fn(async () => 0),
             get: vi.fn(async () => null)
           } as never,
-          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
         connReg: connReg(),
@@ -291,7 +291,7 @@ describe('replayTo — register-time convergence', () => {
             countUnackedVisibility: vi.fn(async () => 5_000),
             get: vi.fn(async () => null)
           } as never,
-          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot: vi.fn(async () => ({ ok: true })) } as never,
         connReg: connReg(),
@@ -329,7 +329,7 @@ describe('replayTo — register-time convergence', () => {
             countUnackedVisibility: vi.fn(async () => 0),
             get: vi.fn(async () => null)
           } as never,
-          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
         connReg: connReg(),
@@ -359,7 +359,7 @@ describe('replayTo — register-time convergence', () => {
             countUnackedVisibility: vi.fn(async () => 0),
             get: vi.fn(async () => null)
           } as never,
-          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
         connReg: connReg(),
@@ -392,7 +392,7 @@ describe('replayTo — register-time convergence', () => {
             countUnackedVisibility: vi.fn(async () => 10),
             get: vi.fn(async () => null)
           } as never,
-          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+          agent: { getUnscoped: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
         },
         control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
         connReg: connReg(),

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -117,7 +117,7 @@ export class SessionVisibilityPushService {
     const byAgent = new Map<string, string | null>()
     for (const s of sessions) {
       if (!byAgent.has(s.agentId)) {
-        const agent = await this.deps.repos.agent.get(s.agentId)
+        const agent = await this.deps.repos.agent.getUnscoped(s.agentId)
         byAgent.set(s.agentId, agent?.daemonId ?? null)
       }
       const daemonId = byAgent.get(s.agentId)
@@ -283,7 +283,7 @@ export class SessionVisibilityPushService {
     for (const s of sessions) {
       if (s.visibilitySource === 'default' && s.visibilityRev === 0) continue // initial classification — nothing staged
       if (s.visibilityAckedRev >= s.visibilityRev) continue
-      const agent = await this.deps.repos.agent.get(s.agentId)
+      const agent = await this.deps.repos.agent.getUnscoped(s.agentId)
       if (!agent?.daemonId) continue // unplaced: no daemon runs it, nothing to stop
       return false
     }

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -27,6 +27,21 @@ export class OwnerConflict extends Error {
 export const PG_UNIQUE_VIOLATION = '23505'
 
 /**
+ * Thrown by org-fenced agent mutations (docs/designs/org-scoped-data-layer.md
+ * §3) when the addressed row does not exist in the caller's organization — a
+ * cross-org id is deliberately indistinguishable from a missing row. Routes
+ * pre-check with the org-fenced `get`, so reaching this mid-request means a
+ * delete race (previously Prisma's P2025) or a bypassed pre-check.
+ */
+export class AgentMissing extends Error {
+  readonly code = 'AGENT_MISSING' as const
+  constructor(readonly agentId: string) {
+    super(`agent ${agentId} not found in this organization`)
+    this.name = 'AgentMissing'
+  }
+}
+
+/**
  * Thrown by `BotRepo.setShareable(false)` when the row-locked recount still sees
  * more than one ACTIVE install — disabling sharing then would orphan the others'
  * routes. The recount runs under the same bot-row lock `IntegrationRepo.

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -714,7 +714,16 @@ export interface AgentRepo {
    *  re-verifies the connection inside the transaction — MemoryConnectionBusy /
    *  MemoryConnectionMissing abort it. */
   create(input: CreateAgentInput, opts?: AgentCreateOpts): Promise<AgentRecord>
-  get(agentId: AgentId): Promise<AgentRecord | null>
+  /** Org-fenced point read (docs/designs/org-scoped-data-layer.md §3): a
+   *  cross-org id reads as absent, exactly like a missing row. This is the
+   *  only agent read the HTTP/MCP surface may use. */
+  get(orgId: OrgId, agentId: AgentId): Promise<AgentRecord | null>
+  /** Tenancy-UNSCOPED read for internal trust domains — orchestration,
+   *  reconciliation, WS handlers, platform machinery — which resolve an agent
+   *  from system state (a run row, an integration row, signed claims) and
+   *  derive the org from the returned record. Never call this from the HTTP
+   *  surface; lint enforces it (org-scoped-data-layer.md §6). */
+  getUnscoped(agentId: AgentId): Promise<AgentRecord | null>
   /** `opts.authorizeMcpServers` / `opts.skillSources.authorize` (only
    *  meaningful when the patch includes `mcpServers` / `skills`) run INSIDE the
    *  row-locked transaction, right after the committed runtimeOverrides read,
@@ -724,11 +733,16 @@ export interface AgentRepo {
    *  transaction. A patch touching the external-memory binding additionally
    *  try-locks the old+new connections' advisory mutation scopes and
    *  re-verifies a newly bound connection inside the transaction
-   *  (MemoryConnectionBusy / MemoryConnectionMissing). */
-  update(agentId: AgentId, patch: UpdateAgentInput, opts?: AgentUpdateOpts): Promise<AgentRecord>
+   *  (MemoryConnectionBusy / MemoryConnectionMissing).
+   *
+   *  Org-fenced: throws {@link AgentMissing} when `agentId` does not exist in
+   *  `orgId` — a cross-org id is indistinguishable from a missing row. */
+  update(orgId: OrgId, agentId: AgentId, patch: UpdateAgentInput, opts?: AgentUpdateOpts): Promise<AgentRecord>
   /** Compare-and-set a workspace edit. The caller has already drained/proved
-   *  an owning daemon when one exists. */
+   *  an owning daemon when one exists. Org-fenced: a cross-org id misses the
+   *  CAS exactly like a stale expectation (null). */
   setWorkspace(
+    orgId: OrgId,
     agentId: AgentId,
     expectedLastModifiedAt: Date,
     expectedMode: AgentWorkspace['mode'],
@@ -736,8 +750,11 @@ export interface AgentRepo {
     workspaceRepoId?: bigint,
     byUserId?: string
   ): Promise<AgentRecord | null>
-  /** Compensation for a daemon NACK whose non-activation is known. */
+  /** Compensation for a daemon NACK whose non-activation is known.
+   *  Org-fenced like {@link AgentRepo.setWorkspace}; the orchestrator passes
+   *  the org of the record it holds. */
   restoreWorkspace(
+    orgId: OrgId,
     agentId: AgentId,
     expectedLastModifiedAt: Date,
     expectedWorkspace: AgentWorkspace,
@@ -754,15 +771,19 @@ export interface AgentRepo {
   /** Set the visibility + share set (the dedicated `/sharing` write path, kept
    *  separate from content `update`). An org→restricted transition atomically
    *  closes known direct-conversation rows. Stamps the last-modified audit;
-   *  `byUserId` is the editing WebUI principal (absent under devAuth). */
+   *  `byUserId` is the editing WebUI principal (absent under devAuth).
+   *  Org-fenced: a cross-org id surfaces as the missing-row error. */
   setSharing(
+    orgId: OrgId,
     agentId: AgentId,
     sharing: { visibility: ResourceVisibility; sharedWith: string[] },
     byUserId?: string
   ): Promise<AgentRecord>
   /** Set both directions of the agent-call policy. Stamps last-modified audit
-   *  because it is a human configuration edit. */
+   *  because it is a human configuration edit. Org-fenced: a cross-org id
+   *  surfaces as the missing-row error. */
   setCallPolicy(
+    orgId: OrgId,
     agentId: AgentId,
     policy: {
       callPolicy: AgentCallPolicy
@@ -790,8 +811,9 @@ export interface AgentRepo {
   ): Promise<AgentRecord | null>
   /** Atomically enumerate the agent's HookDefs, tombstone their durable review
    *  projections, and delete the Agent (cascading the HookDefs). The returned
-   *  snapshots let the route remove the corresponding relay rules. */
-  delete(agentId: AgentId): Promise<HookRecord[]>
+   *  snapshots let the route remove the corresponding relay rules.
+   *  Org-fenced: a cross-org id preserves the missing-row error semantics. */
+  delete(orgId: OrgId, agentId: AgentId): Promise<HookRecord[]>
   /** The org's agents. Every supplied human principal is resource-filtered;
    *  undefined is reserved for unfiltered internal reads
    *  (authorization/policy.ts#visibilityWhere). */
@@ -2804,8 +2826,10 @@ export interface AgentConfigWriter {
    *  (fenced per {@link AgentRepo.create}). */
   create(input: CreateAgentInput, secrets?: Record<string, string>, opts?: AgentCreateOpts): Promise<AgentRecord>
   /** Apply a PATCH: secret merge (see {@link AgentSecretStore.merge} semantics)
-   *  + row update in one transaction (fenced per {@link AgentRepo.update}). */
+   *  + row update in one transaction (fenced per {@link AgentRepo.update},
+   *  including its org fence). */
   update(
+    orgId: OrgId,
     agentId: AgentId,
     patch: UpdateAgentInput,
     secrets?: Record<string, string | null>,

--- a/packages/control-plane/src/persistence/repositories/agent-config.writer.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-config.writer.ts
@@ -40,7 +40,7 @@ import type {
   UpdateAgentInput
 } from '../ports.js'
 import type { SecretCipher } from '../../secrets/cipher.js'
-import type { AgentId } from '../../domain/ids.js'
+import type { AgentId, OrgId } from '../../domain/ids.js'
 import { PgAgentRepo } from './agent.repo.js'
 import { applySealedSecretPatch, sealSecretPatch } from './agent-secret.repo.js'
 import { assertEnvironmentAdmissible, snapshotAgentEnvironments } from './organization-environment-fence.js'
@@ -76,6 +76,7 @@ export class PgAgentConfigWriter implements AgentConfigWriter {
   }
 
   async update(
+    orgId: OrgId,
     agentId: AgentId,
     patch: UpdateAgentInput,
     secrets?: Record<string, string | null>,
@@ -98,8 +99,9 @@ export class PgAgentConfigWriter implements AgentConfigWriter {
       // The row update last: it stamps lastModifiedAt, advances configRevision, and
       // runs the fence over the definition INCLUDING the secrets above — so the
       // audit advance, the secret rows, and the validation commit (or roll back) as
-      // one edit.
-      return new PgAgentRepo(tx).update(agentId, patch, opts)
+      // one edit. Its org fence also unwinds the secret rows above for a
+      // cross-org id (AgentMissing aborts the transaction).
+      return new PgAgentRepo(tx).update(orgId, agentId, patch, opts)
     })
   }
 }

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -32,7 +32,12 @@ import { lockSkillSourceNameScopes } from '../skill-source-lock.js'
 import { tryLockMemoryConnectionScopes } from '../memory-connection-lock.js'
 import { PgHookRepo } from './hook.repo.js'
 import { fenceAgentLocalConfigWrite, lockOrgForConfigWrite, orgIdOfAgent } from './organization-environment-fence.js'
-import { AgentWorkspaceIntegrationConflict, MemoryConnectionBusy, MemoryConnectionMissing } from '../errors.js'
+import {
+  AgentMissing,
+  AgentWorkspaceIntegrationConflict,
+  MemoryConnectionBusy,
+  MemoryConnectionMissing
+} from '../errors.js'
 
 /**
  * Enter an agent write's skill-source fence: take the (orgId, name) advisory
@@ -402,17 +407,25 @@ export class PgAgentRepo implements AgentRepo {
     })
   }
 
-  async get(agentId: AgentId): Promise<AgentRecord | null> {
+  async get(orgId: OrgId, agentId: AgentId): Promise<AgentRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const a = await this.db.agent.findUnique({ where: { id: agentId, orgId }, include: withUsers })
+    return a ? toRecord(a) : null
+  }
+
+  async getUnscoped(agentId: AgentId): Promise<AgentRecord | null> {
     const a = await this.db.agent.findUnique({ where: { id: agentId }, include: withUsers })
     return a ? toRecord(a) : null
   }
 
-  async update(agentId: AgentId, patch: UpdateAgentInput, opts?: AgentUpdateOpts): Promise<AgentRecord> {
-    return this.transaction(async (tx) => this.updateInTx(tx, agentId, patch, opts))
+  async update(orgId: OrgId, agentId: AgentId, patch: UpdateAgentInput, opts?: AgentUpdateOpts): Promise<AgentRecord> {
+    return this.transaction(async (tx) => this.updateInTx(tx, orgId, agentId, patch, opts))
   }
 
   private async updateInTx(
     tx: Prisma.TransactionClient,
+    orgId: OrgId,
     agentId: AgentId,
     patch: UpdateAgentInput,
     opts?: AgentUpdateOpts
@@ -436,7 +449,12 @@ export class PgAgentRepo implements AgentRepo {
     // holding that name scope while waiting on the org row). `create` DOES take it,
     // because a not-yet-inserted row is invisible to a concurrent `all` enrollment
     // scan — see the comment there.
-    const orgId = await orgIdOfAgent(tx, agentId)
+    // Tenancy fence (org-scoped-data-layer.md §3): the caller's org must own
+    // the row. An agent's orgId is immutable, so this unlocked read cannot be
+    // invalidated by a concurrent write — a row deleted after it just reaches
+    // the update below and keeps its missing-row error semantics.
+    const rowOrgId = await orgIdOfAgent(tx, agentId)
+    if (rowOrgId !== orgId) throw new AgentMissing(agentId)
     // The skill-source fence opens BEFORE the agent row lock (its blocking
     // name scopes wrap the rest of this transaction, mirroring how the old
     // per-name chains wrapped the whole write); the visibility set it returns
@@ -578,11 +596,12 @@ export class PgAgentRepo implements AgentRepo {
     // above. This is also where an agent-local secret that would sit beneath an
     // assigned organization variable is refused — the write direction the design
     // rejects from both sides (§3.2).
-    if (orgId) await fenceAgentLocalConfigWrite(tx, orgId, agentId, patch.lastModifiedByUserId)
+    await fenceAgentLocalConfigWrite(tx, orgId, agentId, patch.lastModifiedByUserId)
     return toRecord(a)
   }
 
   async setWorkspace(
+    orgId: OrgId,
     agentId: AgentId,
     expectedLastModifiedAt: Date,
     expectedMode: AgentWorkspace['mode'],
@@ -597,8 +616,10 @@ export class PgAgentRepo implements AgentRepo {
         // this edit with HookDef configuration and projection/grant writes, so a
         // concurrent write-requiring integration cannot race a read downgrade.
         await lockHookReviewAgentLifecycleScope(tx, agentId)
+        // Org fence rides the CAS read + write: a cross-org id misses exactly
+        // like a stale expectation (org-scoped-data-layer.md §3).
         const current = await tx.agent.findUnique({
-          where: { id: agentId },
+          where: { id: agentId, orgId },
           select: { workspaceMode: true, workspaceRepoId: true, lastModifiedAt: true }
         })
         if (
@@ -616,7 +637,7 @@ export class PgAgentRepo implements AgentRepo {
         }
         await assertWorkspaceIntegrationCompatible(tx, agentId, affectedRepoIds, workspace, workspaceRepoId)
         const a = await tx.agent.update({
-          where: { id: agentId, workspaceMode: expectedMode, lastModifiedAt: expectedLastModifiedAt },
+          where: { id: agentId, orgId, workspaceMode: expectedMode, lastModifiedAt: expectedLastModifiedAt },
           data: {
             workspaceMode: workspace.mode,
             workspaceIsolation: workspace.mode === 'github' ? (workspace.isolation ?? 'session') : 'shared',
@@ -643,6 +664,7 @@ export class PgAgentRepo implements AgentRepo {
   }
 
   async restoreWorkspace(
+    orgId: OrgId,
     agentId: AgentId,
     expectedLastModifiedAt: Date,
     expectedWorkspace: AgentWorkspace,
@@ -664,6 +686,7 @@ export class PgAgentRepo implements AgentRepo {
         const a = await tx.agent.update({
           where: {
             id: agentId,
+            orgId,
             workspaceMode: expectedWorkspace.mode,
             workspaceRepoId: expectedWorkspaceRepoId ?? null,
             lastModifiedAt: expectedLastModifiedAt
@@ -724,13 +747,15 @@ export class PgAgentRepo implements AgentRepo {
   }
 
   async setSharing(
+    orgId: OrgId,
     agentId: AgentId,
     sharing: { visibility: AgentRecord['visibility']; sharedWith: string[] },
     byUserId?: string
   ): Promise<AgentRecord> {
     return this.transaction(async (tx) => {
+      // Org fence: a cross-org id throws the same P2025 as a missing row.
       const existing = await tx.agent.findUniqueOrThrow({
-        where: { id: agentId },
+        where: { id: agentId, orgId },
         select: { orgId: true, visibility: true }
       })
       const memberships = await lockResourceWriteMemberships(tx, {
@@ -772,6 +797,7 @@ export class PgAgentRepo implements AgentRepo {
   }
 
   async setCallPolicy(
+    orgId: OrgId,
     agentId: AgentId,
     policy: {
       callPolicy: AgentCallPolicy
@@ -781,8 +807,9 @@ export class PgAgentRepo implements AgentRepo {
     },
     byUserId?: string
   ): Promise<AgentRecord> {
+    // Org fence: a cross-org id throws the same P2025 as a missing row.
     const a = await this.db.agent.update({
-      where: { id: agentId },
+      where: { id: agentId, orgId },
       data: {
         callPolicy: policy.callPolicy,
         allowedCallerAgentIds: policy.allowedCallerAgentIds,
@@ -865,7 +892,7 @@ export class PgAgentRepo implements AgentRepo {
     }
   }
 
-  async delete(agentId: AgentId): Promise<HookRecord[]> {
+  async delete(orgId: OrgId, agentId: AgentId): Promise<HookRecord[]> {
     return this.transaction(async (tx) => {
       // Keep the agent-owned hook set stable from enumeration through cleanup
       // and the cascading delete. Hook create/rebind/remove takes this same lock
@@ -880,8 +907,11 @@ export class PgAgentRepo implements AgentRepo {
       // connection's advisory mutation scope with connection/grant mutations —
       // an in-flight one fail-fasts this delete to 409 rather than tearing down
       // an agent whose connection state is mid-change.
+      // Org fence on the read AND the delete below: a cross-org id skips the
+      // side-effects here and reaches the fenced Prisma delete, preserving the
+      // missing-row error semantics the comment above documents.
       const row = await tx.agent.findUnique({
-        where: { id: agentId },
+        where: { id: agentId, orgId },
         select: { orgId: true, runtimeOverrides: true }
       })
       if (row) {
@@ -898,7 +928,7 @@ export class PgAgentRepo implements AgentRepo {
       // Deleting a preset is the explicit opt-out — settle BEFORE the delete
       // (the FK SetNull would orphan the row from this agentId lookup).
       await settlePresetPlacement(tx, agentId)
-      await tx.agent.delete({ where: { id: agentId } })
+      await tx.agent.delete({ where: { id: agentId, orgId } })
       return removedHooks
     })
   }

--- a/packages/control-plane/src/platforms/feishu/provider.test.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.test.ts
@@ -541,7 +541,7 @@ async function liveAssignFrame(botRow: BotRecord, secret: BotSecretMaterial): Pr
     { listForBot: async () => [integration] } as unknown as IntegrationRepo,
     { listForBot: async () => [] } as unknown as IntegrationChannelRepo,
     {
-      get: async () => ({ id: integration.agentId, name: 'alice', daemonId: 'd1', visibility: 'org' })
+      getUnscoped: async () => ({ id: integration.agentId, name: 'alice', daemonId: 'd1', visibility: 'org' })
     } as unknown as AgentRepo,
     relayReg,
     { integrationUpsert: async () => {} } as never,

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -580,7 +580,7 @@ async function liveAssignFrame(botRow: BotRecord, secret: BotSecretMaterial): Pr
     { listForBot: async () => [integration] } as unknown as IntegrationRepo,
     { listForBot: async () => [] } as unknown as IntegrationChannelRepo,
     {
-      get: async () => ({ id: integration.agentId, name: 'alice', daemonId: 'd1', visibility: 'org' })
+      getUnscoped: async () => ({ id: integration.agentId, name: 'alice', daemonId: 'd1', visibility: 'org' })
     } as unknown as AgentRepo,
     relayReg,
     { integrationUpsert: async () => {} } as never,

--- a/packages/control-plane/src/registry/webchatMcpAuthority.ts
+++ b/packages/control-plane/src/registry/webchatMcpAuthority.ts
@@ -22,7 +22,7 @@ interface LiveDaemon {
 export interface LiveWebchatMcpAuthorityDeps {
   conversations: Pick<WebchatConversationRepo, 'findOwner' | 'owns' | 'participants'>
   orgs: Pick<OrgRepo, 'roleOf'>
-  agents: Pick<AgentRepo, 'get'>
+  agents: Pick<AgentRepo, 'getUnscoped'>
   presets: Pick<PresetAgentStore, 'get'>
   daemons: { get(daemonId: string): LiveDaemon | undefined }
 }
@@ -66,7 +66,7 @@ export async function resolveLiveWebchatMcpAuthority(
   const role = await deps.orgs.roleOf(input.orgId, owner)
   if (!role) return { ok: false, reason: 'membership_missing' }
 
-  const agent = await deps.agents.get(AgentId(input.agentId))
+  const agent = await deps.agents.getUnscoped(AgentId(input.agentId))
   if (!agent || agent.id !== input.agentId || agent.orgId !== input.orgId || !canView(agent, { userId: owner, role })) {
     return { ok: false, reason: 'agent_not_visible' }
   }

--- a/packages/control-plane/src/registry/webchatVerification.ts
+++ b/packages/control-plane/src/registry/webchatVerification.ts
@@ -15,7 +15,7 @@ interface VerificationDaemon {
 
 export interface WebchatVerificationDeps {
   tokens: Pick<WebchatTokenService, 'verify'>
-  agents: { get(agentId: AgentId): Promise<{ orgId: string; daemonId: string | null } | null> }
+  agents: { getUnscoped(agentId: AgentId): Promise<{ orgId: string; daemonId: string | null } | null> }
   daemons: { get(daemonId: string): VerificationDaemon | undefined }
   /** Roster reads for multi-agent conversations (webchat-multi-agents.md §6.2). */
   conversations: {
@@ -38,7 +38,7 @@ export function createWebchatTokenVerifier(deps: WebchatVerificationDeps): (toke
   return async (token) => {
     const claims = await deps.tokens.verify(token)
     if (!claims) return { ok: false, reason: 'invalid token' }
-    const agent = await deps.agents.get(AgentId(claims.agentId))
+    const agent = await deps.agents.getUnscoped(AgentId(claims.agentId))
     if (!agent || agent.orgId !== claims.orgId) return { ok: false, reason: 'invalid token' }
     if (!agent.daemonId) return { ok: false, reason: 'agent unplaced' }
     const daemon = deps.daemons.get(agent.daemonId)
@@ -54,7 +54,7 @@ export function createWebchatTokenVerifier(deps: WebchatVerificationDeps): (toke
         participants.push({ agentId: p.agentId, daemonId: agent.daemonId, primary: true })
         continue
       }
-      const member = await deps.agents.get(p.agentId)
+      const member = await deps.agents.getUnscoped(p.agentId)
       const memberDaemon =
         member && member.orgId === claims.orgId && member.daemonId ? deps.daemons.get(member.daemonId) : undefined
       participants.push({

--- a/packages/control-plane/src/ws/handlers/child-session-status.test.ts
+++ b/packages/control-plane/src/ws/handlers/child-session-status.test.ts
@@ -65,7 +65,7 @@ function fakeDeps(
           'parent' in over ? over.parent : { id: PARENT_SESSION, daemonId: ASKING_DAEMON, agentId: CHILD_AGENT }
       },
       agent: {
-        get: async () =>
+        getUnscoped: async () =>
           'childAgent' in over ? over.childAgent : { id: CHILD_AGENT, orgId: ORG, daemonId: OWNING_DAEMON }
       },
       connReg: { get: () => owner }

--- a/packages/control-plane/src/ws/handlers/child-session-status.ts
+++ b/packages/control-plane/src/ws/handlers/child-session-status.ts
@@ -47,7 +47,7 @@ export const handleChildSessionStatus: Handler = async (frame, conn, deps) => {
 
   // (b) Resolve the child agent's placement. Cross-org is refused outright: a status read must
   // never cross an org boundary even when both daemons are reachable.
-  const childAgent = await deps.agent.get(AgentId(childAgentId))
+  const childAgent = await deps.agent.getUnscoped(AgentId(childAgentId))
   if (!childAgent || childAgent.orgId !== daemon.orgId || !childAgent.daemonId) {
     conn.replyTo(frame, 'session/child-status/ok', NOT_FOUND)
     return

--- a/packages/control-plane/src/ws/handlers/event-session-activity.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session-activity.test.ts
@@ -27,7 +27,7 @@ describe('handleSessionActivity', () => {
     const publishActivity = vi.fn()
     const release = vi.fn()
     const deps = {
-      agent: { get: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
+      agent: { getUnscoped: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
       agentMutations: { tryBeginMutation: vi.fn(() => release) },
       events: { publishActivity }
     } as unknown as DaemonWsDeps
@@ -42,7 +42,7 @@ describe('handleSessionActivity', () => {
   it('drops activity from a daemon that does not own the agent', async () => {
     const publishActivity = vi.fn()
     const deps = {
-      agent: { get: vi.fn().mockResolvedValue({ daemonId: crypto.randomUUID() }) },
+      agent: { getUnscoped: vi.fn().mockResolvedValue({ daemonId: crypto.randomUUID() }) },
       agentMutations: { tryBeginMutation: vi.fn(() => vi.fn()) },
       events: { publishActivity }
     } as unknown as DaemonWsDeps

--- a/packages/control-plane/src/ws/handlers/event-session-purged.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session-purged.test.ts
@@ -30,7 +30,7 @@ function depsWith(
 ): { deps: DaemonWsDeps; release: ReturnType<typeof vi.fn> } {
   const release = vi.fn()
   const deps = {
-    agent: { get: vi.fn().mockResolvedValue(placedOn === null ? null : { daemonId: placedOn }) },
+    agent: { getUnscoped: vi.fn().mockResolvedValue(placedOn === null ? null : { daemonId: placedOn }) },
     agentMutations: { tryBeginMutation: vi.fn(() => (lease === 'free' ? release : null)) },
     session: { markContentPurged }
   } as unknown as DaemonWsDeps

--- a/packages/control-plane/src/ws/handlers/event-session-purged.ts
+++ b/packages/control-plane/src/ws/handlers/event-session-purged.ts
@@ -38,7 +38,7 @@ export const handleSessionPurged: Handler = async (frame, conn, deps) => {
     return
   }
   try {
-    const agent = await deps.agent.get(agentId)
+    const agent = await deps.agent.getUnscoped(agentId)
     if (agent?.daemonId === DaemonId(conn.daemonId)) {
       await deps.session.markContentPurged(
         agentId,

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -15,7 +15,7 @@ const GITHUB_INSTALLATION_ROW_ID = '44444444-4444-4444-8444-444444444444'
 
 function scopedDeps(extra: Record<string, unknown>): DaemonWsDeps {
   return {
-    agent: { get: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
+    agent: { getUnscoped: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
     agentMutations: { tryBeginMutation: vi.fn(() => vi.fn()) },
     hook: { get: vi.fn().mockResolvedValue(null) },
     ...extra
@@ -604,7 +604,7 @@ describe('handleEventSession', () => {
     const recordMilestone = vi.fn()
     const publish = vi.fn()
     const deps = scopedDeps({
-      agent: { get: vi.fn().mockResolvedValue({ daemonId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee' }) },
+      agent: { getUnscoped: vi.fn().mockResolvedValue({ daemonId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee' }) },
       agentMutations: { tryBeginMutation: vi.fn(() => release) },
       session: { recordMilestone },
       events: { publish }

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -237,7 +237,7 @@ export const handleEventSessionSync: Handler = async (frame, conn, deps) => {
     return
   }
   try {
-    const agent = await deps.agent.get(agentId)
+    const agent = await deps.agent.getUnscoped(agentId)
     if (agent?.daemonId === daemonId) await recordEventSession(p, agentId, daemonId, deps)
     // ACK only after recordEventSession's transaction has committed. An agent
     // placed elsewhere (or deleted) can never accept this daemon's stale row, so

--- a/packages/control-plane/src/ws/handlers/gitcred.test.ts
+++ b/packages/control-plane/src/ws/handlers/gitcred.test.ts
@@ -40,7 +40,7 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
       access: 'read' as const
     }))
     const deps = {
-      agent: { get: async () => PLACED_AGENT },
+      agent: { getUnscoped: async () => PLACED_AGENT },
       github: { mintForAgent }
     } as unknown as DaemonWsDeps
     const conn = fakeConn()
@@ -79,7 +79,7 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
       access: 'read' as const
     }))
     const deps = {
-      agent: { get: async () => PLACED_AGENT },
+      agent: { getUnscoped: async () => PLACED_AGENT },
       hook: {
         get: async () => ({
           agentId: AGENT_ID,
@@ -122,7 +122,7 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
   it('denies a GithubPoster mint when no enabled hook watches the requested repo', async () => {
     const mintForHookReply = vi.fn()
     const deps = {
-      agent: { get: async () => PLACED_AGENT },
+      agent: { getUnscoped: async () => PLACED_AGENT },
       hook: { get: async () => null },
       github: { mintForHookReply }
     } as unknown as DaemonWsDeps
@@ -147,7 +147,7 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
 
   it('denies a malformed GithubPoster capability request before minting', async () => {
     const deps = {
-      agent: { get: async () => PLACED_AGENT },
+      agent: { getUnscoped: async () => PLACED_AGENT },
       github: { mintForHookReply: vi.fn() }
     } as unknown as DaemonWsDeps
     const conn = fakeConn()
@@ -170,7 +170,7 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
 
   it('maps a GitCredDeniedError onto a correlated error REP (code + retryable preserved)', async () => {
     const deps = {
-      agent: { get: async () => PLACED_AGENT },
+      agent: { getUnscoped: async () => PLACED_AGENT },
       github: {
         mintForAgent: vi.fn(async () => {
           throw new GitCredDeniedError('acme/tools is not authorized for this agent', 'SCOPE_DENIED', false)

--- a/packages/control-plane/src/ws/handlers/gitcred.ts
+++ b/packages/control-plane/src/ws/handlers/gitcred.ts
@@ -33,7 +33,7 @@ export const handleGitCredRequest: Handler = async (frame, conn, deps) => {
   // Placement scope: the agent must currently live on the REQUESTING daemon.
   // A daemon that lost the agent (re-placement while offline) gets a terminal
   // SCOPE_DENIED — its cache layer clears the entry and stops asking.
-  const agent = await deps.agent.get(AgentId(agentId))
+  const agent = await deps.agent.getUnscoped(AgentId(agentId))
   if (!agent || agent.daemonId !== conn.daemonId) {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'agent is not placed on this daemon', false)
     return

--- a/packages/control-plane/src/ws/handlers/integration-channels.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.ts
@@ -42,7 +42,7 @@ export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
     // Conversation gating (resource-visibility.md §14): a gated (restricted-agent)
     // integration's fresh conversations start Off — an editor must enable them in
     // the console. Known rows keep their operator-chosen trigger either way.
-    const owner = await deps.agent.get(AgentId(integration.agentId))
+    const owner = await deps.agent.getUnscoped(AgentId(integration.agentId))
     const defaultTrigger = owner && isGatedAgent(owner) ? ('off' as const) : undefined
     await deps.integrationChannel.replaceSnapshot(
       integration.id,

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
@@ -64,7 +64,7 @@ describe('handleKnowledgeSearch', () => {
     ])
     const deps = {
       registry: featureRegistry,
-      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
+      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
       organizationKnowledge: { searchKnowledge }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -98,7 +98,7 @@ describe('handleKnowledgeSearch', () => {
       const searchKnowledge = vi.fn()
       const deps = {
         registry: featureRegistry,
-        agent: { get: async () => requester },
+        agent: { getUnscoped: async () => requester },
         organizationKnowledge: { searchKnowledge }
       } as unknown as DaemonWsDeps
       const connection = conn()
@@ -128,7 +128,7 @@ describe('handleKnowledgeList', () => {
     ])
     const deps = {
       registry: featureRegistry,
-      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
+      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
       organizationKnowledge: { listKnowledge }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -161,7 +161,7 @@ describe('handleKnowledgeList', () => {
     const listKnowledge = vi.fn()
     const deps = {
       registry: featureRegistry,
-      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: 'another-daemon' }) },
+      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: 'another-daemon' }) },
       organizationKnowledge: { listKnowledge }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -197,7 +197,7 @@ describe('handleKnowledgeList', () => {
     ])
     const deps = {
       registry: featureRegistry,
-      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
+      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
       organizationKnowledge: { listKnowledge }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -235,7 +235,7 @@ describe('handleOrgSkills', () => {
     const listManagedSkills = vi.fn(async () => rows)
     const deps = {
       registry: featureRegistry,
-      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
+      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
       organizationKnowledge: { listManagedSkills }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -268,7 +268,7 @@ describe('handleOrgSkills', () => {
     const listManagedSkills = vi.fn(async () => rows)
     const deps = {
       registry: featureRegistry,
-      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
+      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON }) },
       organizationKnowledge: { listManagedSkills }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -394,7 +394,7 @@ describe('handleManagedSkillRead', () => {
     const archive = new Uint8Array([0, 1, 2, 3, 4, 5])
     const deps = {
       registry: featureRegistry,
-      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON, managedSkills: [SKILL] }) },
+      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON, managedSkills: [SKILL] }) },
       organizationKnowledge: {
         getManagedSkill: async () => ({ id: SKILL, orgId: ORG, archivedAt: null }),
         getManagedSkillRevision: async () => ({
@@ -436,7 +436,7 @@ describe('handleManagedSkillRead', () => {
     const getManagedSkillRevision = vi.fn()
     const deps = {
       registry: featureRegistry,
-      agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON, managedSkills: [] }) },
+      agent: { getUnscoped: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON, managedSkills: [] }) },
       organizationKnowledge: { getManagedSkillRevision }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -461,7 +461,7 @@ describe('handleManagedSkillRead', () => {
     const searchKnowledge = vi.fn()
     const deps = {
       registry: { get: async () => ({ id: DAEMON, orgId: ORG, capabilities: { features: [] } }) },
-      agent: { get: vi.fn() },
+      agent: { getUnscoped: vi.fn() },
       organizationKnowledge: { searchKnowledge }
     } as unknown as DaemonWsDeps
     const connection = conn()
@@ -474,7 +474,7 @@ describe('handleManagedSkillRead', () => {
 
     expect(connection.sendError).toHaveBeenCalledWith(expect.any(String), 'SCOPE_DENIED', expect.any(String), false)
     expect(searchKnowledge).not.toHaveBeenCalled()
-    expect(deps.agent.get).not.toHaveBeenCalled()
+    expect(deps.agent.getUnscoped).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.ts
@@ -39,7 +39,7 @@ export const handleKnowledgeSearch: Handler = async (frame, conn, deps) => {
     conn.sendError(frame.id, 'INTERNAL', 'organization knowledge is unavailable', true)
     return
   }
-  const requester = await deps.agent.get(AgentId(frame.payload.requesterAgentId))
+  const requester = await deps.agent.getUnscoped(AgentId(frame.payload.requesterAgentId))
   if (!requester || requester.daemonId !== DaemonId(conn.daemonId)) {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'requesting agent is not placed on this daemon', false)
     return
@@ -81,7 +81,7 @@ export const handleKnowledgeList: Handler = async (frame, conn, deps) => {
     conn.sendError(frame.id, 'INTERNAL', 'organization knowledge is unavailable', true)
     return
   }
-  const requester = await deps.agent.get(AgentId(frame.payload.requesterAgentId))
+  const requester = await deps.agent.getUnscoped(AgentId(frame.payload.requesterAgentId))
   if (!requester || requester.daemonId !== DaemonId(conn.daemonId)) {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'requesting agent is not placed on this daemon', false)
     return
@@ -121,7 +121,7 @@ export const handleOrgSkills: Handler = async (frame, conn, deps) => {
     conn.sendError(frame.id, 'INTERNAL', 'organization skills are unavailable', true)
     return
   }
-  const requester = await deps.agent.get(AgentId(frame.payload.requesterAgentId))
+  const requester = await deps.agent.getUnscoped(AgentId(frame.payload.requesterAgentId))
   if (!requester || requester.daemonId !== DaemonId(conn.daemonId)) {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'requesting agent is not placed on this daemon', false)
     return
@@ -184,7 +184,7 @@ export const handleManagedSkillRead: Handler = async (frame, conn, deps) => {
     conn.sendError(frame.id, 'INTERNAL', 'managed skills are unavailable', true)
     return
   }
-  const requester = await deps.agent.get(AgentId(frame.payload.requesterAgentId))
+  const requester = await deps.agent.getUnscoped(AgentId(frame.payload.requesterAgentId))
   if (
     !requester ||
     requester.daemonId !== DaemonId(conn.daemonId) ||

--- a/packages/control-plane/src/ws/handlers/reporting-agent.ts
+++ b/packages/control-plane/src/ws/handlers/reporting-agent.ts
@@ -15,7 +15,7 @@ export async function runForReportingAgent(
   const release = deps.agentMutations.tryBeginMutation(agentId)
   if (!release) return false
   try {
-    const agent = await deps.agent.get(agentId)
+    const agent = await deps.agent.getUnscoped(agentId)
     if (agent?.daemonId !== daemonId) return false
     await write()
     return true

--- a/packages/control-plane/src/ws/relay-connection.test.ts
+++ b/packages/control-plane/src/ws/relay-connection.test.ts
@@ -236,7 +236,7 @@ function buildWebchatVerifier(
     establish,
     verifier: createWebchatTokenVerifier({
       tokens: { verify },
-      agents: { get: getAgent },
+      agents: { getUnscoped: getAgent },
       daemons: { get: getDaemon },
       // Default: pre-participant conversation — the empty roster degrades to the
       // token's primary (single-agent shape), keeping the remote-MCP gate reachable.

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -539,8 +539,8 @@ describe('PUT /agents/:id/daemon', () => {
     const moveAfterFirstRead = (app: HttpApp) => {
       const original = app.deps.repos.agent.get.bind(app.deps.repos.agent)
       let first = true
-      app.deps.repos.agent.get = async (id) => {
-        const observed = await original(id)
+      app.deps.repos.agent.get = async (orgId, id) => {
+        const observed = await original(orgId, id)
         if (first && observed?.id === agentId) {
           first = false
           await prisma.agent.update({ where: { id: agentId }, data: { daemonId: TARGET } })

--- a/packages/control-plane/test/integration/channel-agents.route.test.ts
+++ b/packages/control-plane/test/integration/channel-agents.route.test.ts
@@ -32,7 +32,7 @@ import type { DaemonWsDeps } from '../../src/ws/deps.js'
 import type { ControlSender } from '../../src/orchestrator/outbound.js'
 import { isFrame, type AnyFrame, type IntegrationChannel } from '@agentconnect.md/protocol'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
-import { AgentId } from '../../src/domain/ids.js'
+import { AgentId, OrgId } from '../../src/domain/ids.js'
 import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -239,7 +239,7 @@ describe('channel/agents (agent collaboration directory)', () => {
 
     // private-peer only allows some OTHER agent to call it — not `caller`.
     const agentRepo = new PgAgentRepo(prisma)
-    await agentRepo.setCallPolicy(AgentId(privatePeer.agentId), {
+    await agentRepo.setCallPolicy(OrgId(DEFAULT_ORG_ID), AgentId(privatePeer.agentId), {
       callPolicy: 'selected',
       allowedCallerAgentIds: [randomUUID()]
     })
@@ -260,7 +260,7 @@ describe('channel/agents (agent collaboration directory)', () => {
     await reportChannels(DAEMON, privatePeer.integrationId, [{ id: 'C1', name: 'deploys' }])
 
     const agentRepo = new PgAgentRepo(prisma)
-    await agentRepo.setCallPolicy(AgentId(privatePeer.agentId), {
+    await agentRepo.setCallPolicy(OrgId(DEFAULT_ORG_ID), AgentId(privatePeer.agentId), {
       callPolicy: 'selected',
       allowedCallerAgentIds: [caller.agentId]
     })
@@ -282,7 +282,7 @@ describe('channel/agents (agent collaboration directory)', () => {
     }
 
     const agentRepo = new PgAgentRepo(prisma)
-    await agentRepo.setCallPolicy(AgentId(caller.agentId), {
+    await agentRepo.setCallPolicy(OrgId(DEFAULT_ORG_ID), AgentId(caller.agentId), {
       callPolicy: 'all',
       allowedCallerAgentIds: [],
       outboundPolicy: 'selected',
@@ -358,13 +358,13 @@ describe('channel/agents — ORG-WIDE scope (no channel)', () => {
     const unlistedPeer = await createAgent(running, DAEMON, { name: 'unlisted-peer' })
 
     // Inbound: refusing-peer admits somebody else, not the caller.
-    await agentRepo.setCallPolicy(AgentId(refusingPeer), {
+    await agentRepo.setCallPolicy(OrgId(DEFAULT_ORG_ID), AgentId(refusingPeer), {
       callPolicy: 'selected',
       allowedCallerAgentIds: [randomUUID()]
     })
     // Outbound: the caller only targets open-peer + refusing-peer, so unlisted-peer is
     // invisible even though ITS inbound policy is open.
-    await agentRepo.setCallPolicy(AgentId(caller), {
+    await agentRepo.setCallPolicy(OrgId(DEFAULT_ORG_ID), AgentId(caller), {
       callPolicy: 'all',
       allowedCallerAgentIds: [],
       outboundPolicy: 'selected',

--- a/packages/control-plane/test/integration/mcp-providers.route.test.ts
+++ b/packages/control-plane/test/integration/mcp-providers.route.test.ts
@@ -403,8 +403,8 @@ describe('DELETE /mcp-providers/:id — serialized against agent enable-list wri
     let notifyParked!: () => void
     const parked = new Promise<void>((r) => (notifyParked = r))
     let calls = 0
-    repo.get = async (id) => {
-      const row = await realGet(id)
+    repo.get = async (orgId, id) => {
+      const row = await realGet(orgId, id)
       if (++calls === 2) {
         notifyParked()
         await gate

--- a/packages/control-plane/test/integration/organization-knowledge.route.test.ts
+++ b/packages/control-plane/test/integration/organization-knowledge.route.test.ts
@@ -846,7 +846,7 @@ describe('managed organization skills', () => {
     expect(createdAgent.statusCode).toBe(201)
     const agentDto = createdAgent.json() as { id: string; managedSkills: string[] }
     expect(agentDto.managedSkills).toEqual([skillId])
-    const agent = await owner.deps.repos.agent.get(AgentId(agentDto.id))
+    const agent = await owner.deps.repos.agent.get(DEF_ORG, AgentId(agentDto.id))
     expect((await owner.deps.agentSpecs.assemble(agent!)).managedSkills).toEqual([
       {
         id: skillId,
@@ -953,7 +953,8 @@ describe('managed organization skills', () => {
       ).statusCode
     ).toBe(200)
     expect(
-      (await owner.deps.agentSpecs.assemble((await owner.deps.repos.agent.get(AgentId(agentDto.id)))!)).managedSkills
+      (await owner.deps.agentSpecs.assemble((await owner.deps.repos.agent.get(DEF_ORG, AgentId(agentDto.id)))!))
+        .managedSkills
     ).toEqual([])
     expect(
       (

--- a/packages/control-plane/test/integration/preset-agents.test.ts
+++ b/packages/control-plane/test/integration/preset-agents.test.ts
@@ -21,7 +21,7 @@ import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { ensurePersonalOrg } from '../../src/persistence/repositories/user.repo.js'
 import { ensureDefaultTenant } from '../../src/persistence/ensure-default-tenant.js'
 import type { PrismaClient } from '../../src/generated/prisma/client.js'
-import { AgentId, DaemonId } from '../../src/domain/ids.js'
+import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
 
 const silentLog = { info() {}, warn() {} }
 
@@ -266,7 +266,7 @@ describe('one-time backfill', () => {
     expect(kept?.runtime).toBe('claude')
 
     // Delete the clean org's preset, run again: the state row stops resurrection.
-    await new PgAgentRepo(prisma).delete(AgentId(provisioned!.id))
+    await new PgAgentRepo(prisma).delete(OrgId(clean.id), AgentId(provisioned!.id))
     const second = await backfill.run()
     expect(second.provisioned).toBe(0)
     expect(second.skipped).toBe(0)

--- a/packages/control-plane/test/integration/skill-sources.route.test.ts
+++ b/packages/control-plane/test/integration/skill-sources.route.test.ts
@@ -396,8 +396,8 @@ describe('DELETE /skill-sources/:id — serialized against agent enable-list wri
     let notifyParked!: () => void
     const parked = new Promise<void>((r) => (notifyParked = r))
     let calls = 0
-    repo.get = async (id) => {
-      const row = await realGet(id)
+    repo.get = async (orgId, id) => {
+      const row = await realGet(orgId, id)
       if (++calls === 2) {
         notifyParked()
         await gate

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tenant-isolation contract suite (docs/designs/org-scoped-data-layer.md §6).
+ *
+ * Two organizations share one Postgres; the caller (devAuth = seeded owner of
+ * the DEFAULT org) addresses the FOREIGN org's resources by raw id through the
+ * caller's own `/orgs/:orgId` subtree. The org fence now lives in the
+ * repository layer, so every point read, mutation, and list must behave as if
+ * the foreign row does not exist — 404 on the wire, `null`/missing-row errors
+ * at the repo — and the foreign row must be provably unmodified afterwards.
+ *
+ * This file is the acceptance gate for the org-scoped data-layer rollout:
+ * migrating a repository (§7 M2) adds its resource block here in the same PR.
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { seedAgent } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { AgentMissing } from '../../src/persistence/errors.js'
+import { AgentId, OrgId } from '../../src/domain/ids.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const CALLER_ORG = OrgId(DEFAULT_ORG_ID)
+
+let running: HttpApp | undefined
+let foreignOrgId: string
+let foreignAgentId: string
+let ownAgentId: string
+
+afterEach(async () => {
+  await running?.close()
+  running = undefined
+})
+
+beforeEach(async () => {
+  // The caller's own agent (DEFAULT org) and a foreign org holding one agent.
+  ownAgentId = randomUUID()
+  await seedAgent(prisma, ownAgentId, { name: 'own-bot' })
+  foreignOrgId = `org-foreign-${randomUUID().slice(0, 8)}`
+  foreignAgentId = randomUUID()
+  await prisma.org.create({ data: { id: foreignOrgId, slug: foreignOrgId } })
+  await prisma.agent.create({
+    data: { id: foreignAgentId, orgId: foreignOrgId, name: 'foreign-bot', runtime: 'claude' }
+  })
+})
+
+function build(): HttpApp {
+  const app = buildHttpApp(prisma)
+  running = app
+  return app
+}
+
+async function foreignRowUnmodified(): Promise<void> {
+  const row = await prisma.agent.findUnique({ where: { id: foreignAgentId } })
+  expect(row).not.toBeNull()
+  expect(row!.orgId).toBe(foreignOrgId)
+  expect(row!.name).toBe('foreign-bot')
+}
+
+describe('tenant isolation — Agent over the REST surface', () => {
+  it('point-GET of a foreign agent id reads as absent (404), never as someone else’s resource', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/agents/${foreignAgentId}` })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('PATCH of a foreign agent id is 404 and provably writes nothing', async () => {
+    const app = build()
+    const res = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${foreignAgentId}`,
+      payload: { description: 'hijacked' }
+    })
+    expect(res.statusCode).toBe(404)
+    await foreignRowUnmodified()
+  })
+
+  it('DELETE of a foreign agent id is 404 and the row survives', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'DELETE', url: `${ORG}/agents/${foreignAgentId}` })
+    expect(res.statusCode).toBe(404)
+    await foreignRowUnmodified()
+  })
+
+  it('sharing and call-policy writes on a foreign agent id are 404 and write nothing', async () => {
+    const app = build()
+    const sharing = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${foreignAgentId}/sharing`,
+      payload: { visibility: 'org', sharedWith: [] }
+    })
+    expect(sharing.statusCode).toBe(404)
+    const policy = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${foreignAgentId}/call-policy`,
+      payload: { callPolicy: 'all', allowedCallerAgentIds: [] }
+    })
+    expect(policy.statusCode).toBe(404)
+    await foreignRowUnmodified()
+  })
+
+  it('the agents list never contains a foreign row', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/agents` })
+    expect(res.statusCode).toBe(200)
+    const ids = (res.json() as Array<{ id: string }>).map((a) => a.id)
+    expect(ids).toContain(ownAgentId)
+    expect(ids).not.toContain(foreignAgentId)
+  })
+})
+
+describe('tenant isolation — AgentRepo fences under the routes', () => {
+  it('org-fenced reads and mutations treat a cross-org id exactly like a missing row', async () => {
+    const repo = new PgAgentRepo(prisma)
+
+    // Point read: cross-org id and unknown id are indistinguishable.
+    expect(await repo.get(CALLER_ORG, AgentId(foreignAgentId))).toBeNull()
+    expect(await repo.get(CALLER_ORG, AgentId(randomUUID()))).toBeNull()
+    expect(await repo.get(CALLER_ORG, AgentId(ownAgentId))).not.toBeNull()
+
+    // update: the fence throws the typed missing-row error before any write.
+    await expect(repo.update(CALLER_ORG, AgentId(foreignAgentId), { description: 'hijacked' })).rejects.toBeInstanceOf(
+      AgentMissing
+    )
+
+    // delete: the fenced Prisma delete keeps its missing-row error semantics.
+    await expect(repo.delete(CALLER_ORG, AgentId(foreignAgentId))).rejects.toThrow()
+
+    // CAS-shaped workspace edit: a cross-org id misses like a stale expectation.
+    expect(
+      await repo.setWorkspace(CALLER_ORG, AgentId(foreignAgentId), new Date(), 'scratch', { mode: 'scratch' })
+    ).toBeNull()
+
+    await foreignRowUnmodified()
+
+    // The unscoped read is the internal-trust-domain escape hatch — it does
+    // resolve the row, which is exactly why lint keeps it off the HTTP surface.
+    expect(await repo.getUnscoped(AgentId(foreignAgentId))).not.toBeNull()
+  })
+})

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -101,6 +101,28 @@ describe('tenant isolation — Agent over the REST surface', () => {
     await foreignRowUnmodified()
   })
 
+  it('a PATCH losing the delete race still reads as 404 (AgentMissing → not-found mapping)', async () => {
+    const app = build()
+    // Delete the row right after the route's SECOND read — the post-lease
+    // optimistic-CAS refresh — returns it. An earlier delete is absorbed by the
+    // route's own "agent changed" 409 guard; this interleaving is the one only
+    // the repo-level update fence can refuse, and it must surface as 404.
+    const repo = app.deps.repos.agent
+    const realGet = repo.get.bind(repo)
+    let reads = 0
+    repo.get = async (orgId, id) => {
+      const row = await realGet(orgId, id)
+      if (row?.id === ownAgentId && ++reads === 2) await prisma.agent.delete({ where: { id: ownAgentId } })
+      return row
+    }
+    const res = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${ownAgentId}`,
+      payload: { description: 'race' }
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
   it('the agents list never contains a foreign row', async () => {
     const app = build()
     const res = await app.app.inject({ method: 'GET', url: `${ORG}/agents` })

--- a/packages/control-plane/test/repo/agent-secret.repo.test.ts
+++ b/packages/control-plane/test/repo/agent-secret.repo.test.ts
@@ -88,13 +88,18 @@ describe('AgentConfigWriter — agent row + secret rows commit atomically (real 
     await seedAgent(prisma, AGENT)
     const writer = new PgAgentConfigWriter(prisma, new PlaintextSecretCipher())
     const store = new PgAgentSecretStore(prisma, new PlaintextSecretCipher())
-    await writer.update(AgentId(AGENT), {}, { API_KEY: 'sk-1' })
+    await writer.update(OrgId(DEFAULT_ORG_ID), AgentId(AGENT), {}, { API_KEY: 'sk-1' })
 
     // The secret merge applies FIRST inside the transaction; the row update then
     // fails on the app_user FK (unknown editor id), which must take the already-
     // applied merge down with it.
     await expect(
-      writer.update(AgentId(AGENT), { lastModifiedByUserId: 'no-such-user' }, { API_KEY: 'sk-2' })
+      writer.update(
+        OrgId(DEFAULT_ORG_ID),
+        AgentId(AGENT),
+        { lastModifiedByUserId: 'no-such-user' },
+        { API_KEY: 'sk-2' }
+      )
     ).rejects.toThrow()
     expect(await store.get(AgentId(AGENT))).toEqual({ API_KEY: 'sk-1' })
   })

--- a/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
+++ b/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
@@ -425,11 +425,12 @@ describe('R1/R2a persistence foundation', () => {
       gitAccess: 'write'
     })
     await prisma.agent.update({ where: { id: agentId }, data: { workspaceRepoId: repoId } })
-    const original = await agents.get(agentId)
+    const original = await agents.get(OrgId(DEFAULT_ORG_ID), agentId)
     if (!original || original.workspace.mode !== 'github') throw new Error('expected GitHub workspace fixture')
 
     const settled = await Promise.allSettled([
       agents.setWorkspace(
+        OrgId(DEFAULT_ORG_ID),
         agentId,
         original.lastModifiedAt,
         'github',
@@ -628,7 +629,7 @@ describe('R1/R2a persistence foundation', () => {
       const hookId = HookId(randomUUID())
       await seedAgent(prisma, agentId)
       const [deleted] = await Promise.allSettled([
-        agents.delete(agentId),
+        agents.delete(OrgId(DEFAULT_ORG_ID), agentId),
         hooks.upsert(hookInput(agentId, hookId, `create-race-${i}`))
       ])
       expect(deleted.status).toBe('fulfilled')
@@ -658,7 +659,7 @@ describe('R1/R2a persistence foundation', () => {
         nextAttemptAt: new Date('2026-07-11T00:00:00.000Z')
       })
       const [deleted] = await Promise.allSettled([
-        agents.delete(agentId),
+        agents.delete(OrgId(DEFAULT_ORG_ID), agentId),
         hooks.upsert(hookInput(agentId, hookId, `update-race-${i}`))
       ])
       expect(deleted.status).toBe('fulfilled')
@@ -680,7 +681,7 @@ describe('R1/R2a persistence foundation', () => {
     await seedAgent(prisma, deletedOwner)
     await seedAgent(prisma, liveTarget)
     await hooks.upsert(hookInput(deletedOwner, reboundHookId, 'before-owner-delete'))
-    await agents.delete(deletedOwner)
+    await agents.delete(OrgId(DEFAULT_ORG_ID), deletedOwner)
     await expect(
       hooks.upsert({
         ...hookInput(liveTarget, reboundHookId, 'must-not-resurrect'),
@@ -1526,7 +1527,7 @@ describe('R1/R2a persistence foundation', () => {
       workspace: { mode: 'github', gitRepo: 'github.com/acme/infra', installationId: randomUUID() },
       workspaceRepoId: 987654321n
     })
-    expect((await agents.get(agentId))?.workspaceRepoId).toBe(987654321n)
+    expect((await agents.get(OrgId(DEFAULT_ORG_ID), agentId))?.workspaceRepoId).toBe(987654321n)
 
     const hookId = HookId(randomUUID())
     await hooks.upsert({
@@ -1681,12 +1682,12 @@ describe('R1/R2a persistence foundation', () => {
         select: { repoFullName: true }
       })
     ).toEqual({ repoFullName: 'acme/new-name' })
-    expect(await agents.get(workspaceAgentId)).toMatchObject({
+    expect(await agents.get(OrgId(DEFAULT_ORG_ID), workspaceAgentId)).toMatchObject({
       workspace: { mode: 'github', gitRepo: 'https://github.com/acme/new-name' },
       workspaceRepoId: 44n,
       lastModifiedAt: workspaceBefore.lastModifiedAt
     })
-    expect(await agents.get(manualWorkspaceAgentId)).toMatchObject({
+    expect(await agents.get(OrgId(DEFAULT_ORG_ID), manualWorkspaceAgentId)).toMatchObject({
       workspace: { mode: 'github', gitRepo: 'git@github.com:acme/old-name.git' },
       workspaceRepoId: 44n
     })


### PR DESCRIPTION
## What

First slice of the **org-scoped data layer** ([design doc included](docs/designs/org-scoped-data-layer.md)): repository port methods that address an org-owned row by id now take `orgId` as their first parameter, and the repository fences the query itself — a cross-org id is indistinguishable from a missing row. The ~80 hand-written `row.orgId !== orgOf(req)` route checks stop being the only line of defense.

- **Design doc** `docs/designs/org-scoped-data-layer.md`: the convention (scoped point reads/mutations, `*Unscoped` reads for internal trust domains, system-tier methods stay system-tier), trust-domain table, rejected alternatives, per-repo rollout plan (M2), RLS explicitly deferred (M3).
- **Exemplar migration: `AgentRepo` + `AgentConfigWriter`** end-to-end — `get/update/delete/setSharing/setCallPolicy/setWorkspace/restoreWorkspace` are org-fenced inside their existing transactions (new typed `AgentMissing` for the throw-shaped path; CAS-shaped methods miss like a stale expectation). `getUnscoped` is the explicit escape hatch; ~45 internal call sites (orchestrator, WS handlers, GitHub machinery, platform compile) now say so in their own code.
- **ESLint fence**: `*Unscoped` calls are an error under `http/routes/**` and `http/mcp/**`; the public-by-design agent-icon PNG endpoint carries the one inline exemption with its justification.
- **Tenant-isolation contract suite** `test/integration/tenant-isolation.route.test.ts`: two-org fixture; foreign-id GET/PATCH/DELETE/sharing/call-policy read as 404 with the foreign row provably unmodified, lists exclude foreign rows, and repo-level fences are asserted directly. This file is the acceptance gate: every M2 repo migration adds its resource block here.
- Now-redundant route org comparisons removed where the read is fenced; `canView` (visibility policy) stays route-side per `authorization-policy.md` §2.

## Worth reviewer attention

- `http/routes/slack-platform-install.ts`: the unauthenticated OAuth callback resolves the agent through the pending-install row's org (`row.orgId`) — it has no request org context. Naive `orgOf(req)` threading there would have been a runtime crash; the fence now rides the state row, which is where tenancy already lived.
- Helpers without a request in scope (`refreshMutationAgent`, integration spec replication, workspace repo-id repair) scope by the org of the record they already hold — same fence, no tautology through the request.

## Verification

- `pnpm typecheck` — all packages green.
- `pnpm lint` — green (new fence rule active).
- CP unit suite: 1255/1255.
- CP integration suite (Testcontainers Postgres): full pass, including the new contract suite.

## Follow-ups (tracked in the design doc §7)

M2 batches migrate the remaining repos (`DaemonRepo`, `BotRepo`, `IntegrationRepo`, `CronRepo`, `HookRepo`, MCP/skill/session/webchat/memory/knowledge stores) with the same recipe, extending the contract suite per resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
