### PR TITLE
docs(config): make Tenant Admin the configuration source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,33 +39,11 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # CRON_RUN_REAP_INTERVAL_SEC=300 # how often the CronRunReaper sweeps
 # SECRETS_PROVIDER=memory
 
-# ── Preset agents (docs/designs/preset-agents.md) ───────────────────────────
-# Every org is born with the `agentconnect` general preset agent, and existing
-# orgs are backfilled once at boot. Set `false` to turn both off (self-hosted
-# fleets that don't want provisioned agents). Literal 'true'/'false' only.
-# PRESET_AGENTS_ENABLED=true
-
-# ── Platform-published "Add to Slack" app (preset-agents.md §5.3, optional) ──
-# One deployment-level distributed Slack app every org can install into its own
-# workspace via OAuth. This bot app is separate from the `slack` Logto social
-# connector. ALL FOUR must be set to enable the feature; unset ⇒ the console
-# offers only the per-app quick-install funnel. Also requires PUBLIC_CP_URL
-# (the OAuth callback origin: register
-#   <PUBLIC_CP_URL>/v1/integrations/slack/platform/callback
-# as the app's redirect URL) + PUBLIC_RELAY_URL and a running relay (the app is
-# Events-API-only; point Event Subscriptions at
-# <PUBLIC_RELAY_URL>/slack/events and Interactivity at
-# <PUBLIC_RELAY_URL>/slack/interactions).
-# SLACK_PLATFORM_APP_ID=
-# SLACK_PLATFORM_CLIENT_ID=
-# SLACK_PLATFORM_CLIENT_SECRET=
-# SLACK_PLATFORM_SIGNING_SECRET=
-
-# ── Feishu/Lark deployment tenant anchors ────────────────────────────────────
-# Create or configure either regional tenant App (or both) in Tenant Admin.
-# Their App IDs live in the typed deployment document and their App Secrets are
-# sealed in the deployment secret store. Publish tenant:tenant:readonly on each
-# App. New deployments do not put these credentials in `.env`.
+# ── Deployment-owned authentication and provider Apps ──────────────────────
+# Configure browser authentication, provider Apps, displayed sign-in methods,
+# the browser API Resource, regional tenant anchors, and preset-agent behavior
+# in Tenant Admin. Their identities live in the typed deployment document and
+# their write-only values live in the deployment secret store, not this file.
 
 # ── open-connector integration (optional) ───────────────────────────────────
 # OPEN_CONNECTOR_URL=                 # unset ⇒ Add connectors is hidden
@@ -93,25 +71,10 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # VAULT_JWT_PATH=/var/run/secrets/kubernetes.io/serviceaccount/token
 # VAULT_AUTH_MOUNT=kubernetes     # or e.g. `jwt` outside k8s
 
-# OIDC_ISSUER=            # unset ⇒ devAuth stub (admits all WebUI REST calls).
-#                         # Set to any OIDC issuer to require a verified bearer JWT;
-#                         # the CP resolves the JWKS via OIDC discovery and
-#                         # JIT-provisions the local user from the token's `sub` on
-#                         # first call. (Logto note: use the `/oidc` issuer URL,
-#                         # e.g. https://tenant.example.com/oidc)
-# OIDC_AUDIENCE=          # required `aud` on the token. With a Logto API resource:
-#                         # the resource indicator (= NEXT_PUBLIC_LOGTO_API_RESOURCE).
-#                         # Without one (id-token fallback): the Logto app id
-#                         # (= NEXT_PUBLIC_LOGTO_APP_ID).
-# Logto Management API access for server-side identity metadata, connector
-# lookup, and safe Profile unlinking. Profile linking itself uses Logto's
-# Account API with the current user's token. Configure an M2M app with
-# Management API access; all three values are required together. For a custom
-# login domain, ENDPOINT and RESOURCE usually use the tenant's canonical host.
+# OIDC and Logto service locations are startup topology. Tenant Admin owns the
+# browser application, audience, Management API application, and credentials.
+# OIDC_ISSUER=https://login.example.test/oidc
 # LOGTO_MGMT_ENDPOINT=https://tenant-id.logto.app
-# LOGTO_MGMT_APP_ID=
-# LOGTO_MGMT_APP_SECRET=
-# LOGTO_MGMT_RESOURCE=https://tenant-id.logto.app/api
 # CORS_ORIGIN=            # Web UI origin(s), comma-separated, or `*`. Unset ⇒
 #                         # reflect any origin in dev, disabled in production.
 
@@ -140,37 +103,9 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # WEB_TITLE_ENV=
 # Static bearer token (CI/service). Leave unset when the CP runs the devAuth stub.
 # NEXT_PUBLIC_CP_TOKEN=
-# Social login via Logto (opt-in). Login and Profile share one static
-# social-provider list. Set ENDPOINT + APP_ID to enable it; unset ⇒
-# no-auth (the login buttons just enter the app). Add a matching Logto social
-# connector for every target selected below.
-# Register `https://<console-origin>/auth/callback` on the Logto SPA app.
-# To show and link social accounts in AgentConnect's Profile UI, enable Logto's
-# Account API and give Social identities `Edit` access. Linking uses the current
-# user's Account API token and may require an email verification code; unlinking
-# uses the CP-side LOGTO_MGMT_* app to preserve the last sign-in method.
-# For that ownership check, configure a Logto email connector with the
-# `UserPermissionValidation` template. The current Profile UI also requires the
-# account to have a verified primary email before it can send the code.
-# Also register `https://<console-origin>/auth/social/callback` directly with
-# every provider, alongside its Logto connector callback. Google and Slack accept
-# multiple redirect URLs. For GitHub, use a GitHub App (multiple callback URLs);
-# a GitHub OAuth App has only one callback URL.
-# NEXT_PUBLIC_LOGTO_ENDPOINT=https://tenant.example.com/
-# NEXT_PUBLIC_LOGTO_APP_ID=
-# Optional: the CP API resource registered in Logto, for a JWT access token. When
-# unset the console sends the id token (whose `aud` is the app id — set the CP's
-# OIDC_AUDIENCE to the app id then). Must equal the CP's OIDC_AUDIENCE.
-# NEXT_PUBLIC_LOGTO_API_RESOURCE=https://api.example.com
-# Which social sign-in methods the console offers, as comma-separated Logto
-# connector targets. Available: github, google, slack, lark, feishu. Unset keeps
-# github, google, and slack; `*` opts into the whole catalog. Set this to match
-# the connectors your tenant actually has, so nobody is offered a button that
-# lands on Logto's error page. Read by the console only — the CP does not gate
-# on it, so there is one place this decision lives; what it permits in the end
-# is whether your tenant has that connector configured. When both lark and
-# feishu are listed, put the preferred default first.
-# SOCIAL_PROVIDERS=github
+# Browser authentication is loaded at request time from the Control Plane's
+# DB-backed runtime snapshot. Do not duplicate its application or provider
+# settings in the Web process environment.
 
 # ── Compose + Tenant Admin bootstrap locators ───────────────────────────────
 # Docker Compose and the Tenant Admin process read `.env`; already-exported
@@ -196,10 +131,8 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # origin and reconciles the AgentConnect SPA after the one-time M2M bootstrap:
 # LOGTO_ENDPOINT=http://login.agentconnect.localhost:3001
 # LOGTO_ADMIN_ENDPOINT=http://admin.agentconnect.localhost:3002
-# LOGTO_APP_ID=
 # OIDC_ISSUER=http://login.agentconnect.localhost:3001/oidc
-# OIDC_AUDIENCE=             # same as LOGTO_APP_ID when no API resource is used
-# SOCIAL_PROVIDERS=github    # deliberately does not default local auth to Google
+# LOGTO_MGMT_ENDPOINT=http://login.agentconnect.localhost:3001
 # LOGTO_POSTGRES_PASSWORD=logto
 
 # Rail-footer Help menu links. Unset ⇒ the agentconnect.md defaults; override to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,18 +191,23 @@ Tests never call `index.ts`; they call `buildApp(...)` with the Testcontainers
 
 ## Human auth (Web UI) — opt-in OIDC
 
-Console sign-in is **opt-in social login** (GitHub/Google via Logto), off by default.
+Console sign-in is optional social login through Logto. Tenant Admin owns the
+browser application, API Resource, enabled sign-in methods, Management API
+application, and provider connectors in the typed deployment document; provider
+secrets are write-only entries in the deployment secret store.
 
 - **CP** is a provider-agnostic OIDC resource server: `http/plugins/auth.ts` verifies the
   bearer JWT (JWKS via OIDC discovery) and JIT-provisions a local user from the token's
-  `sub` (`persistence/repositories/user.repo.ts`). **Unset `OIDC_ISSUER` ⇒ devAuth stub
-  (admits all)** — the no-auth default; `OIDC_AUDIENCE` must match the token `aud`.
+  `sub` (`persistence/repositories/user.repo.ts`). The issuer and service origins are
+  startup topology; the required token audience comes from the persisted browser auth
+  configuration. The base Compose stack stays in loopback-only no-auth mode until
+  Tenant Admin bootstraps sign-in.
 - **Web** uses `@logto/browser` (`src/lib/auth.ts`); the login UI is social-only
   (`src/components/Auth.tsx`), redirect landing at `src/app/auth/callback`.
-- **Runtime config (gotcha):** `NEXT_PUBLIC_*` is inlined at `next build`, so Logto config
-  is injected at request time instead — the server reads plain `LOGTO_*` env in
-  `src/lib/public-env.tsx` (root layout is `force-dynamic`) and emits `window.__AC_ENV`;
-  `src/lib/auth.ts` reads that, with `NEXT_PUBLIC_*` as a local-dev fallback.
+- **Runtime config:** `src/lib/public-env.tsx` reads the Control Plane's
+  `/api/v1/runtime-config` snapshot at request time and emits `window.__AC_ENV`, so a
+  prebuilt Web image receives the persisted auth state without build-time tenant
+  configuration. `CP_INTERNAL_URL` and public service routes remain process topology.
 
 ## OpenAPI docs
 

--- a/compose.env.example
+++ b/compose.env.example
@@ -24,81 +24,14 @@
 # AGENTCONNECT_API_KEY_PEPPER=replace-with-a-stable-random-32-char-secret
 # AGENTCONNECT_RELAY_TOKEN=replace-with-a-stable-random-32-char-secret
 
-# Optional built-in `agentconnect` agent. It is created for new organizations
-# and backfilled for existing ones by default. `false` prevents future
-# provisioning; it does not delete an agent that already exists.
-# PRESET_AGENTS_ENABLED=true
+# Browser authentication, provider Apps, displayed sign-in methods, the browser
+# API Resource, and preset-agent behavior are configured in Tenant Admin and
+# stored in the deployment database. They are not Compose overrides.
 
-# Optional Logto-backed sign-in. The base stack does not start Logto; add
-# `compose.logto.yaml` for the local-auth profile described in packages/setup.
-# The issuer is the Logto endpoint with `/oidc`; the audience is the API
-# resource when set, otherwise the app id. Register this redirect URI on the
-# Logto Web application:
-#   <AGENTCONNECT_PUBLIC_WEB_URL>/auth/callback
-# SOCIAL_PROVIDERS controls which buttons AgentConnect renders; it does not
-# discover or create Logto connectors. Set it to match the connector targets
-# configured in your tenant.
-# To link additional social accounts from Profile, enable Account API in Logto
-# Account Center with Social identities set to `Edit`. Each account also needs a
-# verified primary email and an email connector with the
-# `UserPermissionValidation` template. Register this AgentConnect callback
-# directly with each social provider, alongside the callback shown by its Logto
-# connector:
-#   <AGENTCONNECT_PUBLIC_WEB_URL>/auth/social/callback
-# LOGTO_ENDPOINT=https://tenant.example.com/
-# LOGTO_APP_ID=
-# LOGTO_API_RESOURCE=https://api.example.com
-# Which social sign-in methods the console offers, as comma-separated Logto
-# connector targets. Available: github, google, slack, lark, feishu. Unset keeps
-# github, google, and slack; `*` opts into the whole catalog. Set this to match
-# the connectors your tenant actually has, so nobody is offered a button that
-# lands on Logto's error page. When both lark and feishu are listed, put the
-# preferred default first.
-# SOCIAL_PROVIDERS=github
-# OIDC_ISSUER=https://tenant.example.com/oidc
-# OIDC_AUDIENCE=https://api.example.com
-
-# Optional Logto Management API integration for identity metadata, social
-# connector lookup, and safe unlinking. Profile linking itself uses Account API
-# with the signed-in user's token.
-# LOGTO_MGMT_ENDPOINT=https://tenant.example.com
-# LOGTO_MGMT_APP_ID=
-# LOGTO_MGMT_APP_SECRET=
-# LOGTO_MGMT_RESOURCE=https://tenant.example.com/api
-
-# Optional deployment-wide "Add to Slack" bot app. This is separate from the
-# `slack` Logto social-login connector above. Set all four values or none.
-# Configure the Slack app with AgentConnect's current HTTP manifest and these
-# public URLs:
-#   OAuth redirect:
-#     <AGENTCONNECT_PUBLIC_CP_URL>/v1/integrations/slack/platform/callback
-#   Events API:     <AGENTCONNECT_PUBLIC_RELAY_URL>/slack/events
-#   Interactivity:  <AGENTCONNECT_PUBLIC_RELAY_URL>/slack/interactions
-# It requires a connected Relay. Without it, users can still create their own
-# Slack apps through AgentConnect's quick-install or manifest flow.
-# SLACK_PLATFORM_APP_ID=
-# SLACK_PLATFORM_CLIENT_ID=
-# SLACK_PLATFORM_CLIENT_SECRET=
-# SLACK_PLATFORM_SIGNING_SECRET=
-
-# Optional Login with Feishu/Lark Apps. Use the same credentials as the
-# matching Logto connector. AgentConnect uses them as the deployment tenant
-# anchor when accepting Bot Apps; no human access or refresh token is stored.
-# Publish tenant:tenant:readonly on the Login App. Configure each regional App
-# from its provider card in Tenant Admin.
-
-# Optional GitHub App for private GitHub workspaces and GitHub event
-# integrations. Configure these GitHub App URLs with your public origins:
-#   Setup URL:   https://cp.example.com/v1/github/setup/callback
-#   Webhook URL: https://relay.example.com/webhooks/github
-# Generate a private key in the GitHub App settings, then base64-encode the PEM
-# as one line. Use the same webhook secret here and in the GitHub App settings.
-# App ID, private key, and slug must be set together. Client ID is optional.
-# GITHUB_APP_ID=
-# GITHUB_APP_PRIVATE_KEY_B64=
-# GITHUB_APP_SLUG=
-# GITHUB_APP_CLIENT_ID=
-# GITHUB_APP_WEBHOOK_SECRET=
-# Tenant Admin preserves the manifest flow's one-time OAuth client secret in the
-# deployment secret store so the same GitHub App can serve the Logto connector.
-# GITHUB_APP_CLIENT_SECRET=
+# External Logto service locations are process topology because Tenant Admin
+# needs them before it can open the deployment configuration. The bundled Logto
+# overlay supplies local defaults, so set these only for an external tenant.
+# LOGTO_ENDPOINT=https://login.example.test
+# LOGTO_ADMIN_ENDPOINT=https://admin.example.test
+# OIDC_ISSUER=https://login.example.test/oidc
+# LOGTO_MGMT_ENDPOINT=https://tenant-id.logto.app

--- a/docs/designs/api-versioning.md
+++ b/docs/designs/api-versioning.md
@@ -65,9 +65,8 @@ or `https://api.example.com/v1` behind the rewrite) rather than hard-coding `/ap
 in the client (§5.4). So a host can present the API as `api.example.com/v1/…` and the
 console follows, with no rebuild.
 
-> Note: `NEXT_PUBLIC_LOGTO_API_RESOURCE=https://api.example.com` in `.env.example`
-> is an **OIDC audience identifier URI**, not a routable host — unrelated to this
-> design.
+> Note: the browser API Resource configured in Tenant Admin is an **OIDC audience
+> identifier URI**, not a routable host — unrelated to this design.
 
 ## 4. Surface inventory — what is versioned, what is not
 

--- a/docs/designs/github-app-git-credentials.md
+++ b/docs/designs/github-app-git-credentials.md
@@ -15,7 +15,7 @@
 >
 > Configure the GitHub App Setup URL as
 > `<PUBLIC_CP_URL>/v1/github/setup/callback`. The origin and edge routing are
-> supplied through runtime configuration.
+> supplied by startup topology.
 >
 > Credential-degradation telemetry and the corresponding web warnings remain
 > planned; the rest of this document states the current security contract.
@@ -96,15 +96,15 @@ stale until a network fetch succeeds.
 
 ## Decisions
 
-| #   | Decision                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Rationale                                                                                                                                                                                                                                                                                                                                                                       |
-| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | **Reuse the GitHub App used for sign-in as instance-level configuration:** CP environment variables `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY_B64` (base64 of the PEM) / `GITHUB_APP_SLUG` (and optional `GITHUB_APP_CLIENT_ID`). The fields are `.optional()`; if they are not configured, the entire feature is disabled (the picker is hidden and only public-URL mode remains).                                                                                                                                                                                                                       | This mirrors the OIDC opt-in model (unset `OIDC_ISSUER` means the devAuth stub). An instance can use distinct Apps for separate trust boundaries, while a single entry point for sign-in and repository authorization is natural for users. Self-hosted installations can configure their own App. **Do not** create Apps through a per-organization manifest; defer that work. |
-| 2   | **The private key exists only in the CP process environment**, supplied through the operator's secret-management channel; it is not stored in PG and never sent over WS.                                                                                                                                                                                                                                                                                                                                                                                                                                  | Long-lived credentials never leave the CP or reach the database. The daemon sees only a short-lived installation token.                                                                                                                                                                                                                                                         |
-| 3   | **Pull tokens on demand:** the daemon sends the D->C REQ `gitcred/request`; after minting, the CP returns the REP `gitcred/grant` containing the token itself.                                                                                                                                                                                                                                                                                                                                                                                                                                            | Pulling aligns credential delivery with the operation that needs it and avoids placing an expiring token in a long-lived registration snapshot.                                                                                                                                                                                                                                 |
-| 4   | **Minimize token scope:** mint for one authorized repository and only the requested capability subset. Read access excludes write operations; write access admits the current contents/issues/pull-request/actions matrix, with metadata read always available. See `installation-token.service.ts` for the authoritative matrix.                                                                                                                                                                                                                                                                         | A coding agent needs only the capabilities required for the current Git or GitHub operation. Per-repository, per-capability minting keeps unrelated repositories and actions out of each token. Sensitive use cases can switch to read-only with one control.                                                                                                                   |
-| 5   | **Use git credential-helper injection uniformly on the daemon, through two channels:** (1) repository-local `credential.helper` points to `agentconnect git-credential`, which asks the daemon for a token through a local Unix socket; (2) the agent session process environment injects the same helper at host scope, covering submodules/nested repositories and preventing personal-credential leakage (see "Subrepositories"). Operations such as clone, where repository config does not yet exist, use `GIT_CONFIG_*` environment injection. The token never enters argv, disk, or `.git/config`. | This is the only clean solution that covers git operations initiated by both the **daemon** and the **agent**. The helper script itself contains no secret and is not a credential.                                                                                                                                                                                             |
-| 6   | **Two layers of token caches plus two layers of single-flight in the CP and daemon, with nested TTL thresholds**; see "TTL and Idempotency" for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Controls GitHub token-minting API traffic and rate-limit pressure, absorbs retransmissions and thundering herds, and ensures the token handed to git has sufficient remaining lifetime.                                                                                                                                                                                         |
-| 7   | **Resolve the installation dynamically at mint time:** the agent record does not separately store the repository's full name; derive `owner/repo` from `gitRepo`. `installationId` records the selection observation but is not an authoritative binding. At mint time, find a live installation in the organization for the repository owner. The daemon does not need to know the installation; the wire adds only a `gitCredential?: 'github-app'` marker.                                                                                                                                             | Uninstalling and reinstalling an App produces a **new** installation ID. Dynamic resolution lets an existing agent recover without retargeting its workspace. Repository ownership resolution stays in the CP, minimizing the wire surface.                                                                                                                                     |
+| #   | Decision                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Rationale                                                                                                                                                                                                                                                     |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Reuse one deployment-wide GitHub App for repository access and sign-in.** Tenant Admin creates or adopts the App and stores its identity in the typed deployment configuration. Without that provider configuration, the picker is hidden and only public-URL mode remains.                                                                                                                                                                                                                                                                                                                             | An instance can use its own App as a trust boundary, while one entry point for sign-in and repository authorization is natural for users. The App is deployment-wide rather than per organization.                                                            |
+| 2   | **Store the private key as a write-only deployment secret.** Ordinary admin reads expose only configured state and a fingerprint. The Control Plane opens the key when assembling the GitHub service and never sends it to a daemon.                                                                                                                                                                                                                                                                                                                                                                      | The database-backed configuration gives self-hosters one managed setup surface while the deployment's `SecretCipher` policy controls protection at rest. Daemons still receive only short-lived installation tokens.                                          |
+| 3   | **Pull tokens on demand:** the daemon sends the D->C REQ `gitcred/request`; after minting, the CP returns the REP `gitcred/grant` containing the token itself.                                                                                                                                                                                                                                                                                                                                                                                                                                            | Pulling aligns credential delivery with the operation that needs it and avoids placing an expiring token in a long-lived registration snapshot.                                                                                                               |
+| 4   | **Minimize token scope:** mint for one authorized repository and only the requested capability subset. Read access excludes write operations; write access admits the current contents/issues/pull-request/actions matrix, with metadata read always available. See `installation-token.service.ts` for the authoritative matrix.                                                                                                                                                                                                                                                                         | A coding agent needs only the capabilities required for the current Git or GitHub operation. Per-repository, per-capability minting keeps unrelated repositories and actions out of each token. Sensitive use cases can switch to read-only with one control. |
+| 5   | **Use git credential-helper injection uniformly on the daemon, through two channels:** (1) repository-local `credential.helper` points to `agentconnect git-credential`, which asks the daemon for a token through a local Unix socket; (2) the agent session process environment injects the same helper at host scope, covering submodules/nested repositories and preventing personal-credential leakage (see "Subrepositories"). Operations such as clone, where repository config does not yet exist, use `GIT_CONFIG_*` environment injection. The token never enters argv, disk, or `.git/config`. | This is the only clean solution that covers git operations initiated by both the **daemon** and the **agent**. The helper script itself contains no secret and is not a credential.                                                                           |
+| 6   | **Two layers of token caches plus two layers of single-flight in the CP and daemon, with nested TTL thresholds**; see "TTL and Idempotency" for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Controls GitHub token-minting API traffic and rate-limit pressure, absorbs retransmissions and thundering herds, and ensures the token handed to git has sufficient remaining lifetime.                                                                       |
+| 7   | **Resolve the installation dynamically at mint time:** the agent record does not separately store the repository's full name; derive `owner/repo` from `gitRepo`. `installationId` records the selection observation but is not an authoritative binding. At mint time, find a live installation in the organization for the repository owner. The daemon does not need to know the installation; the wire adds only a `gitCredential?: 'github-app'` marker.                                                                                                                                             | Uninstalling and reinstalling an App produces a **new** installation ID. Dynamic resolution lets an existing agent recover without retargeting its workspace. Repository ownership resolution stays in the CP, minimizing the wire surface.                   |
 
 ## Security Boundary
 
@@ -161,7 +161,7 @@ stale until a network fetch succeeds.
 
 | Material                            | Location                                                                                               | Lifetime                                                                                        | Notes                                                                                                                                                              |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| App private key (PEM)               | CP process environment only (`GITHUB_APP_PRIVATE_KEY_B64`)                                             | Long-lived; keys can be added, removed, or rotated in GitHub (the App supports multiple keys)   | Never enters PG, any HTTP response, WS, or logs; supplied through the operator's secret-management channel                                                         |
+| App private key (PEM)               | Write-only `github.privateKeyB64` deployment secret at rest → CP memory                                | Long-lived; keys can be added, removed, or rotated in GitHub (the App supports multiple keys)   | Admin reads return only configured state and a fingerprint; `SecretCipher` controls at-rest protection; the value never enters HTTP responses, daemon WS, or logs  |
 | App JWT (RS256, exp <= 10 min)      | CP memory only                                                                                         | Minutes                                                                                         | Used only to call the GitHub App API (mint tokens and query installations)                                                                                         |
 | Installation access token (`ghs_…`) | CP memory cache -> TLS WS (`gitcred/grant`) -> daemon memory cache -> helper stdout pipe -> git memory | Fixed 1 hour, nonrenewable; **GitHub immediately revokes existing tokens on uninstall/suspend** | **Single-repository scope + narrowed permissions**; never log it or place it in argv, `.git/config`, or any file on disk                                           |
 | Local helper capability             | Daemon memory -> managed runtime/git subprocess environment for the corresponding agent                | Daemon lifetime; revoked on agent remove/detach                                                 | Bound to an agent; never enters the shim, config, logs, or disk; prevents a normal shell from invoking the hidden helper directly or connecting to the bare socket |
@@ -203,30 +203,22 @@ stale until a network fetch succeeds.
 
 ## Configuration and Data Model
 
-**CP configuration** (`config/env.ts`; the first three values must all be
-configured to enable the feature, following the `OIDC_ISSUER` opt-in model):
+The singleton deployment document is the source of truth. Tenant Admin stores:
 
-```text
-GITHUB_APP_ID=<github-app-id>
-GITHUB_APP_PRIVATE_KEY_B64=<base64-encoded-pem>
-GITHUB_APP_SLUG=<github-app-slug>
-GITHUB_APP_CLIENT_ID=<github-app-client-id> # Optional; when absent, App JWT uses GITHUB_APP_ID
-# (Reuse PUBLIC_WEB_URL/resolveWebAppUrl for the 302 back to the console;
-#  do not add configuration. If unset, ensure CORS_ORIGIN
-#  already contains the console origin.)
-```
+- App ID, slug, optional client ID, and webhook state in `values.github`;
+- the base64-encoded private key in the write-only `github.privateKeyB64` deployment
+  secret; and
+- the webhook and OAuth client secrets as separate write-only deployment secrets.
 
-- **The fields are optional as a group.** Missing values disable the feature
-  and hide the picker; a partially configured group fails validation.
-- **Base64 is the canonical PEM encoding.** It keeps multiline key material
-  unambiguous across environment-injection mechanisms. At startup, decode the
-  value, validate that it is a valid RSA key, and fail fast without logging
-  the key.
-- Operators supply these variables through runtime configuration.
+Clearing the GitHub provider removes its stored identity and secrets, disables
+the module, and hides the picker. The private key is decoded and validated when
+the Control Plane assembles the GitHub service, without logging the key. Public
+Web, Control Plane, and Relay origins remain startup topology because Tenant
+Admin uses them to build the App manifest callbacks.
 
-App identity is not stored in the database. `GithubInstallation` stores App
-installation metadata; repository lists are fetched from GitHub on demand. An
-installation is organization-scoped infrastructure and has no
+`GithubInstallation` separately stores App installation metadata; repository
+lists are fetched from GitHub on demand. An installation is
+organization-scoped infrastructure and has no
 `visibility`/`sharedWith` columns. A restricted agent's `gitRepo` remains part
 of the visibility-gated `AgentDto.workspace`.
 
@@ -326,8 +318,8 @@ gitCredential: z.enum(['github-app']).optional(), // Absent means anonymous, pre
 ### GitHub Module: `src/github/`
 
 - `api.ts`: use `@octokit/auth-app` to sign an App JWT from the configured PEM
-  (`iss = GITHUB_APP_CLIENT_ID ?? GITHUB_APP_ID`, RS256, lifetime no longer
-  than 10 minutes), with a very thin fetch wrapper for
+  (`iss` is the client ID when configured, otherwise the App ID; RS256,
+  lifetime no longer than 10 minutes), with a very thin fetch wrapper for
   `Accept: application/vnd.github+json`, timeouts, and rate-limit response
   parsing. Inject `fetch` so integration tests can stub it.
 - `installation-token.service.ts`: minting + cache + **single-flight**:
@@ -358,9 +350,9 @@ gitCredential: z.enum(['github-app']).optional(), // Absent means anonymous, pre
     exceeded. The daemon's 5-second retransmission must honor that backoff and
     cannot bypass it. `src/github/rate-limit.ts` owns this limit and is wired
     into the mint path.
-- When `GITHUB_APP_*` is not configured, do not assemble the module at all.
-  Treat it as an optional dependency in `buildContainer`; related routes return
-  404 and the picker is hidden.
+- When the persisted GitHub provider configuration is absent, do not assemble
+  the module at all. Treat it as an optional dependency in `buildContainer`;
+  related routes return 404 and the picker is hidden.
 
 ### Persistence Layer
 
@@ -812,7 +804,7 @@ Injection uses **two channels**:
      `[include] path=<original ~/.gitconfig>` to preserve other host settings,
      then reset `credential.https://github.com.helper=`, point it at the shim,
      and set `useHttpPath=true`. The CP queries the numeric user ID of the
-     `<slug>[bot]` corresponding to the configured `GITHUB_APP_SLUG` and
+     `<slug>[bot]` corresponding to the deployment-configured App slug and
      caches it in-process; if the query fails, do not deliver an identity. It
      then delivers the public bot identity in
      `ID+<slug>[bot]@users.noreply.github.com` form through
@@ -1162,13 +1154,12 @@ the cache and stops requesting.
 
    **Configuration and enforcement:**
 
-   - **Configuration gateway:**
-     `LOGTO_MGMT_ENDPOINT / LOGTO_MGMT_APP_ID / LOGTO_MGMT_APP_SECRET`
-     must be configured all together or not at all. `LOGTO_MGMT_RESOURCE` is
-     optional and defaults to `${endpoint}/api`. Assemble the authorization
+   - **Configuration gateway:** the persisted Logto Management connection must
+     contain its application identity, write-only secret, and API Resource. Its
+     service origin remains startup topology. Assemble the authorization
      service only when all three conditions hold:
-     **GitHub-App is enabled + Logto Management is configured + `OIDC_ISSUER`
-     is set**. A devAuth principal has no real identity to attest. If the
+     **GitHub App is enabled + Logto Management is configured + OIDC auth is
+     enabled**. A devAuth principal has no real identity to attest. If the
      gateway is disabled, selection uses the organization-level installation
      authorization set. This authorization path in
      `github/logto-identity.ts` reads only identity metadata, specifically the
@@ -1229,5 +1220,6 @@ the cache and stops requesting.
      Read without write pins "Allow push" to read-only and submits
      `gitAccess: 'read'`. `GITHUB_IDENTITY_REQUIRED` points to the existing
      Profile GitHub-linking action.
-   - Identity-provider application IDs and `LOGTO_MGMT_*` values are supplied
-     through runtime configuration.
+   - Identity-provider application IDs and Logto Management credentials are
+     loaded from the deployment configuration; secret values are never exposed
+     to the Web client.

--- a/docs/designs/preset-agents.md
+++ b/docs/designs/preset-agents.md
@@ -3,7 +3,7 @@
 **Status:** M0 implemented (reserved slugs, nullable `Agent.runtime`, org-creation
 seam + one-time backfill + `preset_agent` state, the `agentconnect` general preset,
 console tolerance for unplaced agents), together with §5.3 Fulfillment B — the
-platform-published "Add to Slack" app (env credentials, state-bound install route,
+platform-published "Add to Slack" app (deployment credentials, state-bound install route,
 `Bot.teamId` + composite relay demux, uninstall/revocation lifecycle) — pulled
 forward from M4 so the preset agent is Slack-connectable from day one. M1–M2 remain
 proposed. The dedicated assistant agent is **cancelled** (§4) — see the direction
@@ -172,8 +172,7 @@ from that moment on, owned and editable like any other. Auto-placement writes an
 audit row carrying the daemon and the affected agent.
 
 **Opt-out.** An org-level setting (default on) checked by the creation seam and the
-backfill. Self-hosted fleets that want it off globally can set the org default at
-deploy time.
+backfill. Tenant Admin controls the deployment default for self-hosted fleets.
 
 ### 3.3 Reserved slugs and collisions
 
@@ -259,10 +258,10 @@ checklist wiring. Token storage, rotation, server-side OAuth, and finalize all e
 The true "just click Install" path: a platform-published, distributable Slack app
 installed via standard OAuth v2. Verified gaps against current code:
 
-- **Platform credentials.** No platform-level Slack credentials exist (`config/env.ts`
-  has the `GITHUB_APP_*` precedent but no `SLACK_*`). Add
-  `SLACK_PLATFORM_CLIENT_ID/_CLIENT_SECRET/_SIGNING_SECRET/_APP_ID`; unset ⇒ the
-  feature is absent (self-hosted default). Values live only in deployment config.
+- **Platform credentials.** The distributed Slack App identity and its write-only
+  client and signing secrets live in the DB-backed deployment configuration and
+  are edited through Tenant Admin. Without that provider configuration, the
+  one-click platform App is absent and the per-agent setup paths remain available.
 - **Install starts from the console.** The OAuth callback strictly requires a `state`
   resolving to a pending-install row (`routes/slack-install.ts` renders denied/expired
   otherwise), and a bare share URL cannot carry org/agent tenancy. A new route mints

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -186,7 +186,7 @@ installation from GitHub and updates stored facts from that authenticated API
 response. The webhook payload is not the source of truth.
 
 The route accepts JSON with a 1 MiB request limit and never logs the payload.
-If the webhook secret is absent, the route is not registered.
+If the webhook secret is absent, the handler returns 404.
 
 ### Supported Events and Matching
 

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -165,9 +165,11 @@ agent environment.
 
 ### Signature and Attribution
 
-`POST /webhooks/github` is registered only when
-`GITHUB_APP_WEBHOOK_SECRET` is configured on the relay. Every request requires a
-valid timing-safe `X-Hub-Signature-256` comparison over the raw body.
+`POST /webhooks/github` returns 404 unless the Relay's startup snapshot contains
+the webhook secret opened from the deployment-wide GitHub App configuration.
+The Control Plane supplies that snapshot when the Relay connects. Every enabled
+request requires a valid timing-safe `X-Hub-Signature-256` comparison over the raw
+body.
 
 After signature verification:
 

--- a/packages/setup/README.md
+++ b/packages/setup/README.md
@@ -2,7 +2,7 @@
 
 Browser-based Tenant Admin for AgentConnect self-hosting. It configures Logto,
 GitHub, Slack, Google, Feishu, and Lark through one authenticated local admin
-surface. Provider identities and encrypted credentials are stored in the
+surface. Provider identities and write-only credentials are stored in the
 deployment database; the UI never returns stored secret values.
 
 This package has no command-line setup interface. Provider creation, match


### PR DESCRIPTION
## Summary

- remove browser auth, provider App, API Resource, sign-in method, and preset-agent settings from the environment templates
- update authoritative designs to use the DB-backed deployment document and write-only deployment secrets
- document GitHub webhook delivery through the Control Plane startup snapshot and align internal setup guidance
- keep the root README unchanged because it already routes self-hosters through Tenant Admin and the OSS guide

## Why

Tenant Admin is the supported configuration surface for deployment-owned product and provider settings. The previous templates and designs still described legacy environment-based configuration that is being removed.

## Validation

- `pnpm format:check`
- `docker compose config --quiet`
- `docker compose -f compose.yaml -f compose.logto.yaml config --quiet`
- `git diff --check`
- verified that managed configuration variable names remain only in the historical integration audit among the reviewed documentation surfaces

Created by Codex . GPT-5.6