### PR TITLE
fix(setup): audit regional Logto OAuth connectors

### DIFF
--- a/packages/control-plane/src/http/feishu-identity.ts
+++ b/packages/control-plane/src/http/feishu-identity.ts
@@ -103,10 +103,15 @@ export interface FeishuAppSetupAudit {
   message?: string
 }
 
+export interface FeishuAppSetupExpectation {
+  redirectUris?: readonly string[]
+}
+
 export type FeishuAppSetupAuditor = (
   appId: string,
   appSecret: string,
-  region: FeishuRegion
+  region: FeishuRegion,
+  expectation?: FeishuAppSetupExpectation
 ) => Promise<FeishuAppSetupAudit>
 
 type JsonRecord = Record<string, unknown>
@@ -150,7 +155,7 @@ function applicationReadPermissionMissing(body: JsonRecord): boolean {
 /** Audit the actual published regional App instead of treating a successful
  * credential exchange as proof that its Bot, scopes, events and release are ready. */
 export function createFeishuAppSetupAuditor(fetcher: typeof fetch = fetch): FeishuAppSetupAuditor {
-  return async (appId, appSecret, region) => {
+  return async (appId, appSecret, region, expectation = {}) => {
     const base = REGION_BASE[region]
     const token = await tenantAccessToken(appId, appSecret, region, fetcher)
     if (token.status !== 'ok') {
@@ -197,6 +202,10 @@ export function createFeishuAppSetupAuditor(fetcher: typeof fetch = fetch): Feis
       const appName = typeof app.app_name === 'string' ? app.app_name : null
       const onlineVersionId = typeof app.online_version_id === 'string' ? app.online_version_id.trim() : ''
       const diff: FeishuAppSetupDiff[] = []
+      const redirectUris = strings(app.redirect_urls)
+      if (expectation.redirectUris?.some((redirectUri) => !redirectUris.includes(redirectUri))) {
+        diff.push({ field: 'OAuth redirect URLs', current: redirectUris, expected: expectation.redirectUris })
+      }
       if (app.status !== 1) diff.push({ field: 'App status', current: 'Disabled', expected: 'Enabled' })
       if (!onlineVersionId) {
         diff.push({ field: 'Published version', current: 'None', expected: 'Published' })

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -103,7 +103,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <p class="muted">Create a Web application client in Google Auth Platform, then paste its credentials here.</p>
           <p>Authorized JavaScript origin:</p><ul id="bootstrap-google-origins" class="uris"></ul>
           <p>Authorized redirect URIs:</p><ul id="bootstrap-google-redirects" class="uris"></ul>
-          <a class="button" href="https://console.cloud.google.com/auth/clients" target="_blank" rel="noopener">Open Google Auth Platform</a>
+          <a class="button" href="https://console.cloud.google.com/auth/clients" target="_blank" rel="noopener">Open Google settings</a>
           <label class="field">Client ID<input id="bootstrap-google-id" autocomplete="off"></label>
           <label class="field">Client Secret<input id="bootstrap-google-secret" type="password" autocomplete="new-password"></label>
           <button id="bootstrap-google-submit">Save Google OAuth and configure Logto</button>
@@ -288,7 +288,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         <p>Authorized JavaScript origin:</p><ul id="google-origins" class="uris"></ul>
         <p>Authorized redirect URIs:</p><ul id="google-redirects" class="uris"></ul>
         <p class="muted">Google does not expose OAuth client redirect settings through an API. Copy these required values into Google Auth Platform; Tenant Admin can verify only the Logto connector.</p>
-        <div class="row"><a class="button" href="https://console.cloud.google.com/auth/clients" target="_blank" rel="noopener">Open Google Auth Platform</a></div>
+        <div class="row"><a class="button" href="https://console.cloud.google.com/auth/clients" target="_blank" rel="noopener">Open Google settings</a></div>
         <div id="google-config-controls" class="subsection">
           <label class="field">Client ID<input id="google-id" autocomplete="off"></label>
           <label id="google-initial-secret-field" class="field">Client secret<input id="google-secret" type="password" autocomplete="new-password" placeholder="Required when Client ID changes"></label>
@@ -318,6 +318,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <button id="cancel-feishu-configuration" hidden>Cancel</button>
           <button id="check-feishu-login-app" hidden>Check setup</button>
           <button id="clear-feishu" class="danger" hidden>Clear configuration</button>
+          <a id="feishu-settings" class="button" target="_blank" rel="noopener" hidden>Open Feishu settings</a>
         </div>
       </section>
 
@@ -343,6 +344,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
           <button id="cancel-lark-configuration" hidden>Cancel</button>
           <button id="check-lark-login-app" hidden>Check setup</button>
           <button id="clear-lark" class="danger" hidden>Clear configuration</button>
+          <a id="lark-settings" class="button" target="_blank" rel="noopener" hidden>Open Lark settings</a>
         </div>
       </section>
     </div>
@@ -683,6 +685,10 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       el('clear-lark').hidden = !values.lark;
       el('check-feishu-login-app').hidden = !values.feishu || !configured(byKey, 'feishu.loginAppSecret');
       el('check-lark-login-app').hidden = !values.lark || !configured(byKey, 'lark.loginAppSecret');
+      el('feishu-settings').hidden = !values.feishu;
+      el('lark-settings').hidden = !values.lark;
+      if (values.feishu) el('feishu-settings').href = 'https://open.feishu.cn/app/' + encodeURIComponent(values.feishu.loginAppId);
+      if (values.lark) el('lark-settings').href = 'https://open.larksuite.com/app/' + encodeURIComponent(values.lark.loginAppId);
     }
 
     function requiredInput(id, label) {

--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -298,7 +298,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
 
       <section id="feishu-section" class="panel admin-section" aria-labelledby="feishu-heading">
         <div class="provider-head">
-          <div><h3 id="feishu-heading">Feishu</h3><p class="muted">Audits the published Bot capability, API permissions, and message event subscription.</p></div>
+          <div><h3 id="feishu-heading">Feishu</h3><p class="muted">Matches the Logto OAuth 2.0 connector named Feishu, OAuth callbacks, and published App setup.</p></div>
           <span id="feishu-match" class="badge">Not configured</span>
         </div>
         <dl class="credentials">
@@ -323,7 +323,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
 
       <section id="lark-section" class="panel admin-section" aria-labelledby="lark-heading">
         <div class="provider-head">
-          <div><h3 id="lark-heading">Lark</h3><p class="muted">Audits the published Bot capability, API permissions, and message event subscription.</p></div>
+          <div><h3 id="lark-heading">Lark</h3><p class="muted">Matches the Logto OAuth 2.0 connector named Lark, OAuth callbacks, and published App setup.</p></div>
           <span id="lark-match" class="badge">Not configured</span>
         </div>
         <dl class="credentials">
@@ -1150,6 +1150,8 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       const label = region === 'feishu' ? 'Feishu' : 'Lark';
       showDiff(region + '-drift', result.diff || []);
       match(region + '-match', result.status === 'pass' ? 'pass' : result.status === 'fail' ? 'fail' : 'warn', result.status === 'pass' ? 'Matches' : result.status === 'fail' ? 'Update required' : 'Could not check');
+      el(region + '-login-status').textContent = result.message;
+      el(region + '-login-status').className = result.status === 'pass' ? 'ok' : result.status === 'fail' ? 'warn' : 'muted';
       message(result.message || (label + ' credential check completed.'), result.status === 'fail');
     }
 

--- a/packages/setup/src/admin/logto-management.ts
+++ b/packages/setup/src/admin/logto-management.ts
@@ -42,6 +42,7 @@ interface LogtoConnector {
   id: string
   connectorId: string
   target: string
+  name: string | null
   config: Record<string, unknown>
 }
 
@@ -62,6 +63,14 @@ export interface LogtoAdminRoleInspection {
   exists: boolean
   type: LogtoRole['type'] | null
   isDefault: boolean | null
+}
+
+export interface LogtoNamedConnector {
+  id: string
+  connectorId: string
+  target: string
+  name: string
+  clientId: string | null
 }
 
 export interface LogtoConfigurationDiff {
@@ -171,7 +180,14 @@ function parseConnector(value: unknown): LogtoConnector | null {
   const metadata = asRecord(row.metadata)
   const target = typeof row.target === 'string' ? row.target : metadata.target
   if (typeof row.id !== 'string' || typeof row.connectorId !== 'string' || typeof target !== 'string') return null
-  return { id: row.id, connectorId: row.connectorId, target, config: asRecord(row.config) }
+  const name = asRecord(row.name).en ?? asRecord(metadata.name).en
+  return {
+    id: row.id,
+    connectorId: row.connectorId,
+    target,
+    name: typeof name === 'string' ? name : null,
+    config: asRecord(row.config)
+  }
 }
 
 function desiredConnector(
@@ -225,6 +241,13 @@ function selectConnector(connectors: readonly LogtoConnector[], target: string):
   )
 }
 
+function selectConnectorByName(connectors: readonly LogtoConnector[], name: string): LogtoConnector | undefined {
+  const normalized = name.trim().toLocaleLowerCase('en-US')
+  const matches = connectors.filter((connector) => connector.name?.trim().toLocaleLowerCase('en-US') === normalized)
+  if (matches.length <= 1) return matches[0]
+  throw new LogtoManagementError('SOCIAL_CONNECTOR_AMBIGUOUS', `Logto has more than one social connector named ${name}`)
+}
+
 export class LogtoAdminClaimClient {
   private readonly base: string
   private readonly resource: string
@@ -261,6 +284,29 @@ export class LogtoAdminClaimClient {
       targets.flatMap((target) => {
         const connector = selectConnector(connectors, target)
         return connector ? [[target, connector.id]] : []
+      })
+    )
+  }
+
+  /** Resolve standard OAuth connectors whose targets are not unique. */
+  async resolveConnectorsByName(names: readonly string[]): Promise<Record<string, LogtoNamedConnector>> {
+    const connectors = await this.listConnectors()
+    return Object.fromEntries(
+      names.flatMap((name) => {
+        const connector = selectConnectorByName(connectors, name)
+        if (!connector) return []
+        return [
+          [
+            name,
+            {
+              id: connector.id,
+              connectorId: connector.connectorId,
+              target: connector.target,
+              name,
+              clientId: typeof connector.config.clientId === 'string' ? connector.config.clientId : null
+            }
+          ]
+        ]
       })
     )
   }

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -65,6 +65,7 @@ import {
   LogtoAdminClaimClient,
   LogtoManagementError,
   type LogtoManagementConfig,
+  type LogtoNamedConnector,
   type LogtoSetupDesired
 } from './logto-management.js'
 
@@ -287,13 +288,15 @@ function appendPath(origin: string, path: string): string {
   return new URL(path, `${origin.replace(/\/+$/, '')}/`).toString()
 }
 
-function googleRedirectUris(endpoint: string, connectorId: string, webUrl: string): string[] {
+function socialRedirectUris(endpoint: string, connectorId: string, webUrl: string): string[] {
   return [
     appendPath(endpoint, `/callback/${connectorId}`),
     appendPath(endpoint, `/account/callback/social/${connectorId}`),
     appendPath(webUrl, '/auth/social/callback')
   ]
 }
+
+const REGIONAL_LOGTO_CONNECTOR_NAMES = { feishu: 'Feishu', lark: 'Lark' } as const
 
 type ServiceTopology = { web: string; controlPlane: string; relay: string }
 
@@ -440,6 +443,14 @@ export function buildTenantAdminServer(
     return new LogtoAdminClaimClient(config, fetchImpl).resolveConnectorIds(['github', 'google', 'slack'])
   }
 
+  const resolveRegionalLogtoConnector = async (region: 'feishu' | 'lark'): Promise<LogtoNamedConnector | undefined> => {
+    const runtime = await deps.store.getRuntime(['logto.managementAppSecret'])
+    const config = logtoConfig(runtime, logtoManagementEndpoint)
+    if (!config) return undefined
+    const name = REGIONAL_LOGTO_CONNECTOR_NAMES[region]
+    return (await new LogtoAdminClaimClient(config, fetchImpl).resolveConnectorsByName([name]))[name]
+  }
+
   const expectedGithubManifest = (
     values: DeploymentConfigValuesV1,
     connectorIds: ManagedConnectorIds
@@ -494,7 +505,7 @@ export function buildTenantAdminServer(
       google: values.logto?.browser
         ? {
             origins: [logtoEndpoint],
-            redirects: googleRedirectUris(
+            redirects: socialRedirectUris(
               logtoEndpoint,
               connectorIds.google ?? LOGTO_GOOGLE_CONNECTOR_ID,
               localAuthBootstrap.services.web
@@ -621,7 +632,7 @@ export function buildTenantAdminServer(
     }
     const googleConnectorId = connectorIds.google ?? LOGTO_GOOGLE_CONNECTOR_ID
     const slackConnectorId = connectorIds.slack ?? LOGTO_SLACK_CONNECTOR_ID
-    const redirectUris = googleRedirectUris(logtoEndpoint, googleConnectorId, localAuthBootstrap.services.web)
+    const redirectUris = socialRedirectUris(logtoEndpoint, googleConnectorId, localAuthBootstrap.services.web)
     const logtoConfigured = Boolean(
       current?.values.logto?.managementAppId &&
       current.secrets.some((secret) => secret.key === 'logto.managementAppSecret' && secret.configured)
@@ -825,7 +836,7 @@ export function buildTenantAdminServer(
       if (!current?.values.logto?.browser) return problem(reply, 409, 'save Logto browser configuration first')
       const connectorIds = await resolveLogtoConnectorIds()
       const connectorId = connectorIds.google ?? LOGTO_GOOGLE_CONNECTOR_ID
-      const redirectUris = googleRedirectUris(logtoEndpoint, connectorId, localAuthBootstrap.services.web)
+      const redirectUris = socialRedirectUris(logtoEndpoint, connectorId, localAuthBootstrap.services.web)
       const put = logtoGoogleConnectorPut(current, {
         clientId: parsed.data.clientId,
         ...(parsed.data.clientSecret ? { clientSecret: parsed.data.clientSecret } : {})
@@ -878,25 +889,71 @@ export function buildTenantAdminServer(
         return problem(reply, 409, `${region === 'feishu' ? 'Feishu' : 'Lark'} App credentials are not configured`)
       }
 
-      const result = await auditFeishuAppSetup(regionalApp.loginAppId, appSecret, region)
       const label = region === 'feishu' ? 'Feishu' : 'Lark'
+      const connectorDiff: Array<{ field: string; current: unknown; expected: unknown }> = []
+      let connector: LogtoNamedConnector | undefined
+      let connectorStatus: 'ok' | 'mismatch' | 'unavailable' = 'ok'
+      try {
+        connector = await resolveRegionalLogtoConnector(region)
+        if (!connector) {
+          connectorStatus = 'mismatch'
+          connectorDiff.push({
+            field: 'Logto connector',
+            current: 'Missing',
+            expected: `OAuth 2.0 connector named ${REGIONAL_LOGTO_CONNECTOR_NAMES[region]}`
+          })
+        } else {
+          if (connector.connectorId !== 'oauth2') {
+            connectorStatus = 'mismatch'
+            connectorDiff.push({
+              field: 'Logto connector type',
+              current: connector.connectorId,
+              expected: 'oauth2'
+            })
+          }
+          if (connector.clientId !== regionalApp.loginAppId) {
+            connectorStatus = 'mismatch'
+            connectorDiff.push({
+              field: 'Logto connector client ID',
+              current: connector.clientId,
+              expected: regionalApp.loginAppId
+            })
+          }
+        }
+      } catch (error) {
+        connectorStatus =
+          error instanceof LogtoManagementError && error.code === 'LOGTO_UNAVAILABLE' ? 'unavailable' : 'mismatch'
+        connectorDiff.push({
+          field: 'Logto connector',
+          current: error instanceof Error ? error.message : 'Could not query Logto',
+          expected: `One OAuth 2.0 connector named ${REGIONAL_LOGTO_CONNECTOR_NAMES[region]}`
+        })
+      }
+
+      const result = await auditFeishuAppSetup(regionalApp.loginAppId, appSecret, region, {
+        ...(connector
+          ? { redirectUris: socialRedirectUris(logtoEndpoint, connector.id, localAuthBootstrap.services.web) }
+          : {})
+      })
+      const diff = [...connectorDiff, ...result.diff]
+      const mismatch = connectorStatus === 'mismatch' || result.status === 'invalid' || result.status === 'mismatch'
+      const unavailable = connectorStatus === 'unavailable' || result.status === 'unavailable'
+      const status = mismatch ? ('fail' as const) : unavailable ? ('unknown' as const) : ('pass' as const)
       return {
         provider: region,
-        status:
-          result.status === 'ok'
-            ? ('pass' as const)
-            : result.status === 'invalid' || result.status === 'mismatch'
-              ? ('fail' as const)
-              : ('unknown' as const),
-        diff: result.diff,
+        status,
+        connector: connector
+          ? { id: connector.id, name: connector.name, type: connector.connectorId, clientId: connector.clientId }
+          : null,
+        diff,
         message:
-          result.status === 'ok'
-            ? `${label} published App${result.version ? ` version ${result.version}` : ''} has the required Bot capability, API permissions, and event subscription.`
+          status === 'pass'
+            ? `${label} Logto connector ${connector!.id} and published App${result.version ? ` version ${result.version}` : ''} match.`
             : result.status === 'invalid'
               ? `${label} rejected the saved App ID or secret.`
-              : result.status === 'mismatch'
-                ? `${label} App setup needs an update.`
-                : `${label} setup could not be audited${result.message ? `: ${result.message}` : '.'}`
+              : status === 'fail'
+                ? `${label} App or Logto OAuth 2.0 connector needs an update.`
+                : `${label} App or Logto connector could not be audited${result.message ? `: ${result.message}` : '.'}`
       }
     }
   )


### PR DESCRIPTION
## What changed

- Resolve the Feishu and Lark Logto OAuth 2.0 connectors by their configured English names instead of assuming a unique OAuth target.
- Reject duplicate same-name connectors, and verify the selected connector type and Client ID against the saved regional App.
- Derive all provider callback URLs from the connector's actual remote ID and include callback drift in the Feishu/Lark App audit.
- Keep the resolved connector ID visible in the persistent Tenant Admin check result.
- Add provider settings links for Google and direct App links for configured Feishu/Lark Apps.

## Why

The regional App check previously audited only the provider-side published App. It could report `Matches` without resolving the Logto connector or checking OAuth callbacks. Generic OAuth 2.0 connectors are not unique, so target-based discovery is insufficient; the deployment convention uses connector names `Feishu` and `Lark` as the stable selectors.

## Impact

Feishu/Lark now report `Matches` only when the named Logto connector, OAuth Client ID, required callbacks, published version, Bot capability, API scopes, and message event all agree. Missing, duplicate, or mismatched connectors are shown as an explicit diff and connector IDs remain remote Logto state rather than deployment database fields.

## Validation

- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/setup typecheck`
- ESLint on all changed files
- `pnpm --filter @agentconnect.md/control-plane build`
- `pnpm --filter @agentconnect.md/setup build`
- focused existing Feishu identity tests: 4 passed
- focused existing Tenant Admin Logto tests: 8 passed
- manual name-resolution smoke for distinct and duplicate OAuth 2.0 connectors
- manual callback-audit smoke for matching and missing callback sets
- embedded Tenant Admin browser script parse check
- `git diff --check`
