### PR TITLE
fix(web): unify workspace repository access

### DIFF
--- a/docs/designs/agent-multi-repo-authorization.md
+++ b/docs/designs/agent-multi-repo-authorization.md
@@ -402,14 +402,17 @@ mismatch.
    - Every change uses the cold lifecycle to clear daemon credential cache.
      Return 409 when it would remove workspace write authority required by an
      enabled formal review or Check.
-   - Beside it, list each additional repository with `repoFullName`, its access
-     tier, and delete. The workspace repository itself appears here only when the
+   - Beside it, summarize each additional repository with `repoFullName` and its
+     access tier. The workspace repository itself appears here only when the
      workspace is App-backed, where the installation makes it implicit; a manual
      checkout is represented solely by its explicit grant, if one exists.
-   - "Add repository" reuses the installation/repository picker and list
-     filtering, offers three access options defaulting to read, describes each
-     level, warns on write blast radius, and reuses `/access` preflight.
-     Comment preflights as read.
+   - The same Edit workspace dialog lists, adds, and deletes additional repository
+     grants. Card and hook-editor shortcuts open that dialog directly at its
+     authorization step, so every context keeps the fast path without creating a
+     second repository-management surface.
+   - "Authorize repository" reuses the installation/repository picker and list
+     filtering, offers access options defaulting to read, describes each level,
+     warns on write blast radius, and reuses `/access` preflight.
    - The card is visible under `canView`; add and delete require `canEdit` and a
      non-viewer role.
 2. **GitHub hook editor:** candidates are workspace plus additional

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -852,6 +852,14 @@ workspace files and cannot be undone. Use an explicit `Replace workspace` save l
 for that destructive case. A working-subdirectory or access-only edit preserves the
 current checkout.
 
+The same Edit workspace dialog owns additional repository access for both GitHub and
+scratch workspaces: it lists current grants, adds another repository, and revokes an
+existing grant. The Workspace card and contextual authorization prompts may keep
+direct shortcuts for discoverability, but those shortcuts open this shared dialog at
+the additional-repository step and return to the calling flow after authorization.
+There must not be a second standalone repository-management surface with different
+options or vocabulary.
+
 GitHub workspace settings expose one boolean named `Worktree`. When enabled, each
 logical session runs in its own stable Git worktree under the Agent directory, so one
 Agent can work on several sessions concurrently without sharing branch or file state.

--- a/packages/web/src/components/console/WorkspaceCard.test.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.test.tsx
@@ -8,7 +8,6 @@ vi.mock('swr', () => ({
 }))
 vi.mock('@/lib/api', () => ({
   creatorLabel: () => 'Dana Reyes',
-  deleteAgentRepo: vi.fn(),
   fetchAgentRepos: vi.fn()
 }))
 vi.mock('next/navigation', () => ({
@@ -20,7 +19,6 @@ vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ activeOrg: { id: 'org-1'
 vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
 vi.mock('@/lib/data-context', () => ({ useConsoleData: () => ({ refresh: vi.fn() }) }))
 vi.mock('@/lib/swr-keys', () => ({ consoleKeys: { agentRepos: () => ['repos'] } }))
-vi.mock('@/components/console/modals/AddAgentRepoModal', () => ({ default: () => null }))
 vi.mock('@/components/console/modals/EditWorkspaceModal', () => ({ default: () => null }))
 
 import { WorkspaceCard } from './WorkspaceCard'
@@ -68,13 +66,13 @@ describe('workspace repository authority', () => {
     expect(html).toContain('None explicitly authorized')
   })
 
-  it('renders a manual checkout through its explicit grant, without duplicating it', () => {
+  it('renders a manual checkout through its explicit grant summary', () => {
     repos.rows = [{ id: 'g1', repoFullName: 'acme/infra', access: 'comment', createdBy: 'u1' }]
     const html = renderToStaticMarkup(<WorkspaceCard agent={agent(GITHUB)} />)
     expect(html).not.toContain('authorized implicitly')
-    // Exactly one chip for the repo — the explicit, revocable one, carrying its
-    // real tier. A second, non-removable implicit chip would show no Revoke.
-    expect(html.match(/Revoke access/g)).toHaveLength(1)
+    // The card summarizes the real explicit tier; edits and revocation live in
+    // the shared Edit workspace dialog rather than a second inline flow.
+    expect(html).not.toContain('Revoke access')
     expect(html).toContain('comment access')
   })
 

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -18,11 +18,9 @@
 //      repo; manual GitHub workspaces may list only an explicit grant for their
 //      own repo so CP-owned effects can run.
 //
-// Grant rows are visible to anyone who can view the agent; conversion,
-// authorize and revoke require canEdit (viewers see a read-only card).
-// "Authorize repository" opens AddAgentRepoModal
-// (the design's inline add-expander is skipped — established precedent: the
-// modal owns the picker/tier/preflight flow).
+// Grant rows are visible to anyone who can view the agent. Every editing entry
+// point opens the same Edit workspace surface; the card stays a discoverable
+// summary instead of owning a second add/revoke flow.
 
 import { useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -30,21 +28,13 @@ import useSWR from 'swr'
 import { GithubMark, LoadingState } from '@/components/marks'
 import { Icon } from '@/components/ui'
 import type { Agent, WorkspaceStatusInfo } from '@/lib/data'
-import { creatorLabel, deleteAgentRepo, fetchAgentRepos, type AgentRepoAuthDto, type RepoAccess } from '@/lib/api'
+import { creatorLabel, fetchAgentRepos } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { useProfile } from '@/lib/profile'
 import { consoleKeys } from '@/lib/swr-keys'
 import { useConsoleData } from '@/lib/data-context'
-import AddAgentRepoModal from '@/components/console/modals/AddAgentRepoModal'
 import EditWorkspaceModal from '@/components/console/modals/EditWorkspaceModal'
-
-// Tier badges — complete literal class strings (the Tailwind scanner needs the
-// full text in source; never assemble from fragments).
-export const REPO_ACCESS_BADGE: Record<RepoAccess, string> = {
-  read: 'badge flex-none bg-(--surface-active) text-(--text-tertiary)',
-  comment: 'badge flex-none bg-(--brand-soft) text-(--brand-soft-text)',
-  write: 'badge flex-none bg-(--status-paused-soft) text-(--amber-500)'
-}
+import { REPOSITORY_ACCESS_BADGE } from '@/components/console/WorkspaceFormFields'
 
 /**
  * The live half of the Source row. The card itself only knows the agent's
@@ -88,11 +78,12 @@ export function WorkspaceCard({
   const { activeOrg } = useOrgs()
   const { me } = useProfile()
   const { refresh } = useConsoleData()
-  const [addOpen, setAddOpen] = useState(false)
-  // Non-null ⇒ the workspace editor is open, preselected on that mode.
-  const [editMode, setEditMode] = useState<'scratch' | 'github' | null>(null)
-  const [removing, setRemoving] = useState<string | null>(null)
-  const [err, setErr] = useState<string | null>(null)
+  // Non-null ⇒ the unified workspace editor is open. The authorization
+  // shortcut starts it directly in its additional-repository subview.
+  const [editState, setEditState] = useState<{
+    mode: 'scratch' | 'github'
+    authorizeRepository?: true
+  } | null>(null)
 
   const ws = agent.workspace
 
@@ -107,7 +98,7 @@ export function WorkspaceCard({
     const mode = searchParams.get('editws')
     if (autoEdited.current || !mode) return
     autoEdited.current = true
-    if (agent.canEdit) setEditMode(mode === 'scratch' ? 'scratch' : 'github')
+    if (agent.canEdit) setEditState({ mode: mode === 'scratch' ? 'scratch' : 'github' })
     const sp = new URLSearchParams(searchParams)
     sp.delete('editws')
     router.replace(`${pathname}${sp.size ? `?${sp}` : ''}`, { scroll: false })
@@ -125,31 +116,21 @@ export function WorkspaceCard({
   const repos = reposData ?? []
   const loadError = reposData === undefined && reposError
   const canEdit = agent.canEdit
+  const manualWorkspaceAuthorized =
+    ws.mode === 'github' &&
+    !isGithubApp &&
+    repos.some((authorization) => authorization.repoFullName.toLowerCase() === ws.repo.toLowerCase())
   // A manual checkout has no App installation to mint a write token from, so its
   // effective workspace access is read regardless of the stored preference.
   const workspaceAccess =
     ws.mode === 'github' ? (ws.installationId ? (ws.gitAccess ?? 'write') : ('read' as const)) : null
   const remoteLabel = header?.remoteLabel ?? 'GitHub'
 
-  const remove = async (row: AgentRepoAuthDto) => {
-    if (removing) return
-    setRemoving(row.id)
-    setErr(null)
-    try {
-      await deleteAgentRepo(agent.id, row.id)
-      void mutate((rows) => rows?.filter((r) => r.id !== row.id), { revalidate: false })
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e))
-    } finally {
-      setRemoving(null)
-    }
-  }
-
   // The segment is the conversion entry point; picking the mode the agent is
   // already on is a no-op (the pencil edits the current source's settings).
   const pickMode = (next: 'scratch' | 'github') => {
     if (!canEdit || next === ws.mode) return
-    setEditMode(next)
+    setEditState({ mode: next })
   }
   const segClass = (mode: 'scratch' | 'github') =>
     mode === ws.mode ? (canEdit ? SEG_ON : SEG_ON_LOCKED) : canEdit ? SEG_OFF : SEG_OFF_LOCKED
@@ -196,7 +177,7 @@ export function WorkspaceCard({
         {/* Effective workspace access stays visible next to the repository
             (product-conventions.md §Workspace navigation and repository access) —
             it is the blast radius of everything the agent pushes. */}
-        {workspaceAccess && <span className={REPO_ACCESS_BADGE[workspaceAccess]}>{workspaceAccess}</span>}
+        {workspaceAccess && <span className={REPOSITORY_ACCESS_BADGE[workspaceAccess]}>{workspaceAccess}</span>}
         {header?.status && (
           <span className="badge flex-none" style={{ background: header.status.bg, color: header.status.text }}>
             <span className="dot h-[6px] w-[6px]" style={{ background: header.status.dot }} />
@@ -235,7 +216,11 @@ export function WorkspaceCard({
           </a>
         )}
         {canEdit && (
-          <button className="iconbtn h-6 w-6 flex-none" title="Edit workspace" onClick={() => setEditMode(ws.mode)}>
+          <button
+            className="iconbtn h-6 w-6 flex-none"
+            title="Edit workspace"
+            onClick={() => setEditState({ mode: ws.mode })}
+          >
             <Icon name="pencil" size={13} />
           </button>
         )}
@@ -285,15 +270,7 @@ export function WorkspaceCard({
                   <GithubMark />
                 </span>
                 <span className="mono text-[11.5px] text-(--text-primary)">{r.repoFullName}</span>
-                {canEdit && (
-                  <button
-                    className={`iconbtn h-[18px] w-[18px] flex-none ${removing === r.id ? 'pointer-events-none opacity-50' : ''}`}
-                    title="Revoke access"
-                    onClick={() => void remove(r)}
-                  >
-                    <Icon name="x" size={11} />
-                  </button>
-                )}
+                <span className={REPOSITORY_ACCESS_BADGE[r.access]}>{r.access}</span>
               </span>
             ))}
             {repos.length === 0 && !isGithubApp && (
@@ -307,39 +284,32 @@ export function WorkspaceCard({
         {canEdit && (
           <button
             className="inline-flex h-6 flex-none cursor-pointer items-center gap-[5px] rounded-[5px] border border-dashed border-(--border-default) bg-transparent px-[9px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) hover:border-(--brand) hover:text-(--brand)"
-            onClick={() => setAddOpen(true)}
+            onClick={() =>
+              setEditState({
+                mode: ws.mode,
+                ...(!manualWorkspaceAuthorized ? { authorizeRepository: true as const } : {})
+              })
+            }
           >
-            <Icon name="plus" size={12} />
-            Authorize repository
+            <Icon name={manualWorkspaceAuthorized ? 'settings-2' : 'plus'} size={12} />
+            {manualWorkspaceAuthorized ? 'Manage repository' : 'Authorize repository'}
           </button>
         )}
-
-        {err && <span className="font-sans text-[12px] font-normal leading-normal text-(--status-error)">{err}</span>}
       </div>
 
-      {addOpen && (
-        <AddAgentRepoModal
-          agent={agent}
-          workspaceRepo={isGithubApp ? ws.repo : null}
-          authorized={repos}
-          {...(ws.mode === 'github' && !isGithubApp ? { fixedRepo: ws.repo } : {})}
-          onClose={() => setAddOpen(false)}
-          onCreated={(row) => {
-            void mutate((rows) => (rows ? [...rows, row] : [row]), { revalidate: false })
-            setAddOpen(false)
-          }}
-        />
-      )}
-
-      {editMode && (
+      {editState && (
         <EditWorkspaceModal
           agent={agent}
           authorized={repos}
-          initialMode={editMode}
-          onClose={() => setEditMode(null)}
+          initialMode={editState.mode}
+          {...(editState.authorizeRepository ? { initialRepositoryAuthorization: {} } : {})}
+          onAuthorizedChange={(rows) => {
+            void mutate(rows, { revalidate: false })
+          }}
+          onClose={() => setEditState(null)}
           onChanged={() => {
             void mutate()
-            setEditMode(null)
+            setEditState(null)
             refresh()
           }}
         />

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -3,10 +3,19 @@ import { createPortal } from 'react-dom'
 import type { KeyboardEvent, ReactNode } from 'react'
 import { GithubMark } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
+import type { RepoAccess } from '@/lib/api'
 
 export type WorkspaceMode = 'scratch' | 'github'
 export type WorkspaceRepoAccess = 'read' | 'write'
 type RepositoryMenuStyle = { left: number; top: number; width: number; maxHeight: number }
+
+// Complete literal class strings keep access badges consistent anywhere the
+// workspace or one of its additional repositories is shown.
+export const REPOSITORY_ACCESS_BADGE: Record<RepoAccess, string> = {
+  read: 'badge flex-none bg-(--surface-active) text-(--text-tertiary)',
+  comment: 'badge flex-none bg-(--brand-soft) text-(--brand-soft-text)',
+  write: 'badge flex-none bg-(--status-paused-soft) text-(--amber-500)'
+}
 
 export function WorkspaceModeField({
   value,

--- a/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
@@ -2,13 +2,13 @@
 
 // Authorize a repository for one agent (issue #457,
 // agent-multi-repo-authorization.md §web 1): repo picker over the org's GitHub
-// App installations + a three-tier access choice, preflighted against the
+// App installations + an access choice, preflighted against the
 // per-user identity-assertion gate when the deployment has one.
 //
-// Unlike the ModalProvider dialogs this renders its OWN scrim/modal overlay:
-// the github hook editor opens it NESTED (authorize, then continue creating the
-// hook), which the one-at-a-time provider can't host. Escape closes only this
-// layer (capture-phase listener) so a nested open never tears down the parent.
+// This renders its own scrim/modal overlay because Edit workspace can expose it
+// as a preserved-state subview while another editor (such as GitHub hook setup)
+// remains underneath. Escape closes only this layer (capture-phase listener),
+// so a nested open never tears down the caller.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { GithubMark } from '@/components/marks'
@@ -54,7 +54,10 @@ export default function AddAgentRepoModal({
   initialRepo,
   fixedRepo,
   initialAccess,
+  workspaceContext = false,
+  showBack = false,
   onClose,
+  onExit,
   onCreated
 }: {
   agent: Agent
@@ -68,6 +71,12 @@ export default function AddAgentRepoModal({
   fixedRepo?: string
   /** Default access tier — the review/hook flow opens this dialog at `write`. */
   initialAccess?: RepoAccess
+  /** Present this authorization step as part of the Edit workspace surface. */
+  workspaceContext?: boolean
+  /** The parent workspace form is preserved behind this step. */
+  showBack?: boolean
+  /** Close the whole parent editor while `onClose` returns to its prior view. */
+  onExit?: () => void
   onClose: () => void
   onCreated: (row: AgentRepoAuthDto) => void
 }) {
@@ -247,18 +256,27 @@ export default function AddAgentRepoModal({
     <div className="scrim">
       <div className="modal">
         <div className="modalhead">
-          <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-subtle) bg-(--surface-sunken)">
-            <span className="flex h-[17px] w-[17px] items-center justify-center">
-              <GithubMark color="var(--text-secondary)" />
+          {showBack ? (
+            <button className="iconbtn" title="Back to workspace settings" onClick={onClose}>
+              <Icon name="arrow-left" size={16} />
+            </button>
+          ) : (
+            <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-subtle) bg-(--surface-sunken)">
+              <span className="flex h-[17px] w-[17px] items-center justify-center">
+                <GithubMark color="var(--text-secondary)" />
+              </span>
             </span>
-          </span>
+          )}
           <div className="min-w-0 flex-1">
-            <div className="font-sans text-[16px] font-semibold leading-normal">Add repository</div>
+            <div className="font-sans text-[16px] font-semibold leading-normal">
+              {workspaceContext ? 'Edit workspace' : 'Add repository'}
+            </div>
             <div className="mt-[1px] truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-              authorize a GitHub repository for <span className="mono">{agentLabel(agent)}</span>
+              {workspaceContext ? 'authorize an additional repository for ' : 'authorize a GitHub repository for '}
+              <span className="mono">{agentLabel(agent)}</span>
             </div>
           </div>
-          <button className="iconbtn" onClick={onClose}>
+          <button className="iconbtn" onClick={onExit ?? onClose}>
             <Icon name="x" size={16} />
           </button>
         </div>
@@ -272,8 +290,8 @@ export default function AddAgentRepoModal({
             <div className="mb-4 flex items-start gap-[10px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
               <Icon name="info" size={15} className="mt-[1px] flex-none" />
               <span>
-                The GitHub App isn&rsquo;t configured on this deployment — set the{' '}
-                <span className="mono">GITHUB_APP_*</span> control-plane env to enable repository grants.
+                The GitHub App isn&rsquo;t configured for this deployment. Ask a deployment owner to configure it before
+                authorizing repositories.
               </span>
             </div>
           ) : gh.installations.length === 0 ? (
@@ -282,7 +300,7 @@ export default function AddAgentRepoModal({
                 Connect GitHub to grant repos
               </div>
               <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
-                Install the AgentConnect GitHub app — repository grants are minted through its installations.
+                Install the AgentConnect GitHub app, then choose which repositories this agent can access.
               </div>
               <div className="mt-3 flex flex-wrap items-center gap-3">
                 <Button size="sm" onClick={() => void openGhInstall()}>
@@ -519,7 +537,7 @@ export default function AddAgentRepoModal({
         </div>
         <div className="modalfoot">
           <span className="flex-1 font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-            Tokens are minted per repository at this tier — revoke any time.
+            Access applies only to this repository and can be revoked at any time.
           </span>
           <Button variant="ghost" onClick={onClose}>
             Cancel

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -6,7 +6,7 @@ import LarkFeishuSwitcher, { type LarkFeishuTarget } from '@/components/LarkFeis
 import { GithubMark, PlatformMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { GithubReviewSettings } from '@/components/console/GithubReviewSettings'
-import { GithubPrivateReposNotice } from '@/components/console/WorkspaceFormFields'
+import { GithubPrivateReposNotice, REPOSITORY_ACCESS_BADGE } from '@/components/console/WorkspaceFormFields'
 import type {
   WebWizardTransport,
   WizardFooterState,
@@ -46,8 +46,7 @@ import {
   type GithubRepoDto,
   type RepoAccess
 } from '@/lib/api'
-import { REPO_ACCESS_BADGE } from '@/components/console/WorkspaceCard'
-import AddAgentRepoModal from './AddAgentRepoModal'
+import EditWorkspaceModal from './EditWorkspaceModal'
 import {
   GH_DEFAULT_FAMILIES,
   GH_DEFAULT_TRIGGER_MODE,
@@ -269,8 +268,8 @@ export default function AddIntegrationModal({
   )
   const authorizedRepos = useMemo(() => agentReposData ?? [], [agentReposData])
   const canEditAgent = agent.canEdit
-  // Non-null ⇒ the nested authorize-repo dialog is open, prefilled with this
-  // owner/repo + the minimum review/reporting tier ('' = no repo prefill).
+  // Non-null ⇒ the unified workspace dialog is open at repository
+  // authorization, prefilled with this owner/repo + minimum required tier.
   const [authRepoFor, setAuthRepoFor] = useState<{ repo: string; access: RepoAccess } | null>(null)
   const ghSelectedRepo = ghRepos?.find((repo) => repo.fullName.toLowerCase() === ghRepoPick?.toLowerCase())
   const ghSelectedAuthorization = authorizedRepos.find(
@@ -1274,7 +1273,7 @@ export default function AddIntegrationModal({
                                               workspace
                                             </span>
                                           ) : authTier ? (
-                                            <span className={REPO_ACCESS_BADGE[authTier]}>{authTier}</span>
+                                            <span className={REPOSITORY_ACCESS_BADGE[authTier]}>{authTier}</span>
                                           ) : blockedNoEdit ? null : (
                                             <span className="badge flex-none bg-(--surface-app) text-(--brand-soft-text)">
                                               authorize
@@ -1651,18 +1650,22 @@ export default function AddIntegrationModal({
           </Button>
         )}
       </div>
-      {/* Nested authorize-repo dialog (its own fixed overlay): grant the typed
-          repo, then continue creating the hook with it pre-picked. */}
+      {/* Repository shortcuts share the Workspace card's editor, then return to
+          hook creation with the new grant pre-picked. */}
       {authRepoFor !== null && (
-        <AddAgentRepoModal
+        <EditWorkspaceModal
           agent={agent}
-          workspaceRepo={isGithubAppWs ? wsRepo : null}
           authorized={authorizedRepos}
-          initialAccess={authRepoFor.access}
-          {...(!isGithubAppWs && wsRepo ? { fixedRepo: wsRepo } : {})}
-          {...(authRepoFor.repo ? { initialRepo: authRepoFor.repo } : {})}
+          initialRepositoryAuthorization={{
+            access: authRepoFor.access,
+            ...(authRepoFor.repo ? { repo: authRepoFor.repo } : {})
+          }}
           onClose={() => setAuthRepoFor(null)}
-          onCreated={(row) => {
+          onChanged={() => {
+            void refresh()
+            setAuthRepoFor(null)
+          }}
+          onRepositoryCreated={(row) => {
             void mutateAgentRepos((rows) => (rows ? [...rows, row] : [row]), { revalidate: false })
             setGhRepoPick(row.repoFullName)
             setGhQ('')

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.test.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+const repositoryModal = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }))
+
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (path: string) => path }) }))
+vi.mock('@/components/console/modals/AddAgentRepoModal', () => ({
+  default: (props: Record<string, unknown>) => {
+    repositoryModal.props = props
+    return <div>repository authorization step</div>
+  }
+}))
+
+import EditWorkspaceModal from './EditWorkspaceModal'
+import type { Agent } from '@/lib/data'
+
+const agent = {
+  id: 'agent-a',
+  name: 'build-agent',
+  canEdit: true,
+  workspace: { mode: 'scratch' }
+} as unknown as Agent
+
+describe('EditWorkspaceModal repository access', () => {
+  it('manages additional repositories in the main workspace editor', () => {
+    const html = renderToStaticMarkup(
+      <EditWorkspaceModal
+        agent={agent}
+        authorized={[
+          {
+            id: 'repo-auth-1',
+            repoFullName: 'acme/shared-tools',
+            access: 'write',
+            createdBy: 'user-1',
+            createdAt: '2026-08-06T00:00:00.000Z'
+          }
+        ]}
+        onClose={() => undefined}
+        onChanged={() => undefined}
+      />
+    )
+
+    expect(html).toContain('Additional repositories')
+    expect(html).toContain('Authorize repository')
+    expect(html).toContain('acme/shared-tools')
+    expect(html).toContain('Revoke repository access')
+  })
+
+  it('opens contextual shortcuts at the workspace authorization step', () => {
+    const html = renderToStaticMarkup(
+      <EditWorkspaceModal
+        agent={agent}
+        authorized={[]}
+        initialRepositoryAuthorization={{ repo: 'acme/service', access: 'write' }}
+        onClose={() => undefined}
+        onChanged={() => undefined}
+      />
+    )
+
+    expect(html).toContain('repository authorization step')
+    expect(repositoryModal.props).toMatchObject({
+      initialRepo: 'acme/service',
+      initialAccess: 'write',
+      workspaceContext: true
+    })
+  })
+})

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 // One workspace editor owns mode, repository, branch, working directory, and
-// access. The server drains active work, replaces daemon-local files only when
-// mode/repo/branch changes, and rejects edits that conflict with enabled GitHub
-// review or Check actions.
+// both workspace and additional-repository access. The server drains active
+// work, replaces daemon-local files only when mode/repo/branch changes, and
+// rejects edits that conflict with enabled GitHub review or Check actions.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { GithubMark } from '@/components/marks'
@@ -12,6 +12,7 @@ import { agentLabel, type Agent } from '@/lib/data'
 import { useOrgs } from '@/lib/org-context'
 import {
   ApiError,
+  deleteAgentRepo,
   setAgentWorkspace,
   fetchGithubBranches,
   fetchGithubInstallations,
@@ -23,7 +24,8 @@ import {
   type AgentRepoAuthDto,
   type GithubInstallationDto,
   type GithubRepoAccess,
-  type GithubRepoDto
+  type GithubRepoDto,
+  type RepoAccess
 } from '@/lib/api'
 import { agentDirInputValue, normalizeAgentDir } from '@/lib/repo-subdir'
 import {
@@ -33,25 +35,41 @@ import {
   GithubRepositoryField,
   GithubRepositoryOption,
   RepositoryAccessField,
+  REPOSITORY_ACCESS_BADGE,
   WorktreeField,
   WorkingSubdirectoryField,
   WorkspaceBranchField,
   WorkspaceModeField
 } from '@/components/console/WorkspaceFormFields'
+import AddAgentRepoModal from '@/components/console/modals/AddAgentRepoModal'
+
+export interface InitialRepositoryAuthorization {
+  repo?: string
+  access?: RepoAccess
+}
 
 export default function EditWorkspaceModal({
   agent,
   authorized,
   initialMode,
+  initialRepositoryAuthorization,
+  onAuthorizedChange,
+  onRepositoryCreated,
   onClose,
   onChanged
 }: {
   agent: Agent
-  /** Existing grants — pre-picked and badged, but any covered repo converts. */
+  /** Existing grants — managed here and badged in the workspace picker. */
   authorized: AgentRepoAuthDto[]
   /** Preselected mode — the workspace card's Source segment opens the editor
    *  already switched to the mode the user picked. Defaults to the current one. */
   initialMode?: 'scratch' | 'github'
+  /** Open directly at the additional-repository step for contextual shortcuts. */
+  initialRepositoryAuthorization?: InitialRepositoryAuthorization
+  /** Keep the caller's shared repository cache synchronized after add/revoke. */
+  onAuthorizedChange?: (rows: AgentRepoAuthDto[]) => void
+  /** Resume a contextual flow, such as GitHub integration setup, after adding. */
+  onRepositoryCreated?: (row: AgentRepoAuthDto) => void
   onClose: () => void
   onChanged: () => void
 }) {
@@ -77,6 +95,18 @@ export default function EditWorkspaceModal({
   const [agentDir, setAgentDir] = useState(currentAgentDir)
   const [worktree, setWorktree] = useState(githubWorkspace ? githubWorkspace.worktree === true : true)
   const [write, setWrite] = useState(currentWrite ?? (authorized[0] ? authorized[0].access === 'write' : true))
+  const [authorizations, setAuthorizations] = useState(authorized)
+  const [repositoryEditor, setRepositoryEditor] = useState<{
+    repo?: string
+    access?: RepoAccess
+    returnToWorkspace: boolean
+  } | null>(() =>
+    initialRepositoryAuthorization !== undefined
+      ? { ...initialRepositoryAuthorization, returnToWorkspace: false }
+      : null
+  )
+  const [removingAuthorization, setRemovingAuthorization] = useState<string | null>(null)
+  const [repositoryError, setRepositoryError] = useState<string | null>(null)
   // Per-user authz preflight for the picked repo. null = unknown/loading —
   // never blocks; the server re-checks when the edit is submitted.
   const [probe, setProbe] = useState<GithubRepoAccess | null>(null)
@@ -86,17 +116,22 @@ export default function EditWorkspaceModal({
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape' || saving) return
+      if (event.key !== 'Escape' || saving || repositoryEditor !== null) return
       event.stopPropagation()
       onClose()
     }
     window.addEventListener('keydown', onKey, true)
     return () => window.removeEventListener('keydown', onKey, true)
-  }, [onClose, saving])
+  }, [onClose, repositoryEditor, saving])
+
+  useEffect(() => {
+    setAuthorizations(authorized)
+  }, [authorized])
 
   // Probe installations on open; re-probe on focus ("Install GitHub app"
   // finishes in another tab, coming back should light the picker up).
   useEffect(() => {
+    if (repositoryEditor !== null) return
     let alive = true
     const probeInstalls = () =>
       fetchGithubInstallations().then(
@@ -110,10 +145,10 @@ export default function EditWorkspaceModal({
       alive = false
       window.removeEventListener('focus', onFocus)
     }
-  }, [])
+  }, [repositoryEditor])
 
   useEffect(() => {
-    if (!gh?.enabled || gh.installations.length === 0) return
+    if (repositoryEditor !== null || !gh?.enabled || gh.installations.length === 0) return
     let alive = true
     const ctrl = new AbortController()
     setPrivateReposHidden(false)
@@ -131,7 +166,7 @@ export default function EditWorkspaceModal({
       alive = false
       ctrl.abort()
     }
-  }, [gh, reposNonce])
+  }, [gh, repositoryEditor, reposNonce])
 
   const openGhInstall = async () => {
     const url = await fetchGithubInstallUrl().catch(() => null)
@@ -156,10 +191,12 @@ export default function EditWorkspaceModal({
   }
 
   const authorizedByName = useMemo(
-    () => new Map(authorized.map((r) => [r.repoFullName.toLowerCase(), r])),
-    [authorized]
+    () => new Map(authorizations.map((r) => [r.repoFullName.toLowerCase(), r])),
+    [authorizations]
   )
   const grantOf = (fullName: string) => authorizedByName.get(fullName.toLowerCase())
+  const manualWorkspaceAuthorization =
+    githubWorkspace && !githubWorkspace.installationId ? grantOf(githubWorkspace.repo) : undefined
 
   const picked = repos?.find((r) => r.fullName.toLowerCase() === pick.toLowerCase())
   const pickOwner = pick.split('/')[0] ?? ''
@@ -175,7 +212,7 @@ export default function EditWorkspaceModal({
   // assertion deployments): read access needs ≥read, push access ≥write.
   useEffect(() => {
     setProbe(null)
-    if (mode !== 'github' || !pick || !pickInstallationId) return
+    if (repositoryEditor !== null || mode !== 'github' || !pick || !pickInstallationId) return
     const [owner, repo] = pick.split('/')
     if (!owner || !repo) return
     let alive = true
@@ -185,12 +222,12 @@ export default function EditWorkspaceModal({
     return () => {
       alive = false
     }
-  }, [mode, pick, pickInstallationId])
+  }, [mode, pick, pickInstallationId, repositoryEditor])
 
   useEffect(() => {
     setBranches(null)
     setBranchOpen(false)
-    if (mode !== 'github' || !pick || !pickInstallationId) return
+    if (repositoryEditor !== null || mode !== 'github' || !pick || !pickInstallationId) return
     const [owner, repo] = pick.split('/')
     if (!owner || !repo) return
     let alive = true
@@ -200,7 +237,7 @@ export default function EditWorkspaceModal({
     return () => {
       alive = false
     }
-  }, [mode, pick, pickInstallationId])
+  }, [mode, pick, pickInstallationId, repositoryEditor])
 
   const probeDenies = !!probe?.gated && (write ? !probe.canWrite : !probe.canRead)
   const probeNote = probeDenies
@@ -301,6 +338,48 @@ export default function EditWorkspaceModal({
       setSaving(false)
       busyRef.current = false
     }
+  }
+
+  const removeAuthorization = async (row: AgentRepoAuthDto) => {
+    if (removingAuthorization) return
+    setRemovingAuthorization(row.id)
+    setRepositoryError(null)
+    try {
+      await deleteAgentRepo(agent.id, row.id)
+      const next = authorizations.filter((authorization) => authorization.id !== row.id)
+      setAuthorizations(next)
+      onAuthorizedChange?.(next)
+    } catch (error) {
+      setRepositoryError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setRemovingAuthorization(null)
+    }
+  }
+
+  if (repositoryEditor) {
+    const closeRepositoryEditor = repositoryEditor.returnToWorkspace ? () => setRepositoryEditor(null) : onClose
+    return (
+      <AddAgentRepoModal
+        agent={agent}
+        workspaceRepo={githubWorkspace?.installationId ? githubWorkspace.repo : null}
+        authorized={authorizations}
+        {...(githubWorkspace && !githubWorkspace.installationId ? { fixedRepo: githubWorkspace.repo } : {})}
+        {...(repositoryEditor.repo ? { initialRepo: repositoryEditor.repo } : {})}
+        {...(repositoryEditor.access ? { initialAccess: repositoryEditor.access } : {})}
+        workspaceContext
+        showBack={repositoryEditor.returnToWorkspace}
+        onClose={closeRepositoryEditor}
+        onExit={onClose}
+        onCreated={(row) => {
+          const next = [...authorizations, row]
+          setAuthorizations(next)
+          onAuthorizedChange?.(next)
+          onRepositoryCreated?.(row)
+          if (repositoryEditor.returnToWorkspace) setRepositoryEditor(null)
+          else onClose()
+        }}
+      />
+    )
   }
 
   return (
@@ -511,7 +590,85 @@ export default function EditWorkspaceModal({
               </div>
             ))}
 
-          {err && <div className="font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">{err}</div>}
+          <div className="mt-1 border-t border-(--border-subtle) pt-4">
+            <div className="flex flex-wrap items-start gap-3">
+              <div className="min-w-0 flex-1">
+                <div className="font-sans text-[13.5px] font-semibold leading-normal text-(--text-primary)">
+                  Additional repositories
+                </div>
+                <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+                  {githubWorkspace && !githubWorkspace.installationId
+                    ? 'This manual checkout can authorize only its workspace repository. Changes here apply immediately.'
+                    : 'Authorize repositories this agent can use in addition to its workspace. Changes here apply immediately.'}
+                </div>
+              </div>
+              {!manualWorkspaceAuthorization && (
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    setRepositoryError(null)
+                    setRepositoryEditor({ returnToWorkspace: true })
+                  }}
+                >
+                  <Icon name="plus" size={13} />
+                  Authorize repository
+                </Button>
+              )}
+            </div>
+
+            {mode === 'scratch' && gh?.enabled && gh.installations.length > 0 && (
+              <div className="mt-3">
+                <GithubConnectedBanner onManage={() => void openGhInstall()} />
+              </div>
+            )}
+
+            <div className="mt-3 flex flex-col gap-2">
+              {authorizations.length === 0 ? (
+                <div className="flex items-center gap-2 rounded-md border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[10px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                  <Icon name="info" size={14} className="flex-none" />
+                  No additional repositories authorized.
+                </div>
+              ) : (
+                authorizations.map((authorization) => (
+                  <div
+                    key={authorization.id}
+                    className="flex min-w-0 items-center gap-[10px] rounded-md border border-(--border-subtle) bg-(--surface-card) px-3 py-[9px]"
+                  >
+                    <span className="imark h-4 w-4 flex-none border-0 bg-transparent">
+                      <GithubMark />
+                    </span>
+                    <span
+                      className="mono min-w-0 flex-1 truncate text-[12.5px] font-semibold text-(--text-primary)"
+                      title={authorization.repoFullName}
+                    >
+                      {authorization.repoFullName}
+                    </span>
+                    <span className={REPOSITORY_ACCESS_BADGE[authorization.access]}>{authorization.access}</span>
+                    <button
+                      type="button"
+                      className={`iconbtn h-6 w-6 flex-none ${
+                        removingAuthorization === authorization.id ? 'pointer-events-none opacity-50' : ''
+                      }`}
+                      title="Revoke repository access"
+                      disabled={removingAuthorization !== null}
+                      onClick={() => void removeAuthorization(authorization)}
+                    >
+                      <Icon name={removingAuthorization === authorization.id ? 'loader' : 'trash-2'} size={13} />
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+            {repositoryError && (
+              <div className="mt-2 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
+                {repositoryError}
+              </div>
+            )}
+          </div>
+
+          {err && (
+            <div className="mt-3 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">{err}</div>
+          )}
         </div>
 
         <div className="modalfoot">

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1892,7 +1892,7 @@ function UnauthorizedWatchBadge() {
   return (
     <span
       className="badge flex-none bg-(--status-paused-soft) text-(--amber-500)"
-      title="This repo isn't authorized for the agent — events still trigger it, but replies and pushes back to GitHub have no credentials. Authorize the repo in the Workspace card."
+      title="This repo isn't authorized for the agent — events still trigger it, but replies and pushes back to GitHub have no credentials. Open Edit workspace to authorize it."
     >
       <Icon name="triangle-alert" size={11} />
       write-back unauthorized


### PR DESCRIPTION
## Summary

- Make Edit workspace the single management surface for workspace and additional-repository access.
- Route Workspace card and GitHub integration authorization shortcuts through the shared flow while preserving their context.
- Keep Scratch, GitHub App, and manual-checkout states discoverable and update the product convention.

## Why

Additional repository authorization was split across the Workspace card and GitHub integration flows, while workspace repository settings lived in Edit workspace. This made the correct entry point depend on where the user noticed the missing access.

The shared editor now owns the list, add, and revoke flows. Contextual shortcuts still open directly at authorization and return to their calling flow.

## Verification

- `pnpm --filter @agentconnect.md/web test` (113 files, 885 tests)
- `pnpm --filter @agentconnect.md/web build`
- Focused TypeScript, ESLint, formatting, and diff checks

Created by Codex . GPT-5
