### PR TITLE
feat(cp): org-fence the daemon and bot data layers

### DIFF
--- a/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
@@ -147,7 +147,7 @@ describe('syncAgentBotIcons', () => {
                 return membership ? [membership] : []
               }
             },
-            bot: { get: async (id) => bots.get(id) ?? null },
+            bot: { getUnscoped: async (id) => bots.get(id) ?? null },
             botSecret: {
               get: async (id) => {
                 secretGets.push(id)
@@ -197,7 +197,7 @@ describe('syncAgentBotIcons', () => {
       repos: {
         agent: { getUnscoped: async () => agentRecord(agent.icon) },
         integration: { listForAgent: async () => [membership], listForBot: async () => [membership] },
-        bot: { get: async () => bot(feishuId, 'feishu', { feishuAppId: 'cli_feishu' }) },
+        bot: { getUnscoped: async () => bot(feishuId, 'feishu', { feishuAppId: 'cli_feishu' }) },
         botSecret: {
           get: async (id: string) => {
             secretGets.push(id)
@@ -247,7 +247,7 @@ describe('syncAgentBotIcons', () => {
           listForAgent: async () => [membership],
           listForBot: async () => [membership]
         },
-        bot: { get: async () => discordBot },
+        bot: { getUnscoped: async () => discordBot },
         botSecret: {
           get: async () => ({ botToken: 'discord-token', appToken: null, signingSecret: null })
         }
@@ -302,7 +302,7 @@ describe('syncAgentBotIcons', () => {
           listForAgent: async () => [membership],
           listForBot: async () => [membership]
         },
-        bot: { get: async () => discordBot },
+        bot: { getUnscoped: async () => discordBot },
         botSecret: {
           get: async () => ({ botToken: 'discord-token', appToken: null, signingSecret: null })
         }

--- a/packages/control-plane/src/http/agent-bot-icon-sync.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.ts
@@ -13,7 +13,7 @@ interface AgentBotIconSyncDeps {
   repos: {
     agent: Pick<AgentRepo, 'getUnscoped'>
     integration: Pick<IntegrationRepo, 'listForAgent' | 'listForBot'>
-    bot: Pick<BotRepo, 'get'>
+    bot: Pick<BotRepo, 'getUnscoped'>
     botSecret: Pick<BotSecretStore, 'get'>
   }
   /** §9 platform registry. `sideEffects.syncBotProfileIcon` IS the capability
@@ -59,7 +59,10 @@ async function currentBotIconState(
   deps: AgentBotIconSyncDeps,
   botId: BotRecord['id']
 ): Promise<CurrentBotIconState | null> {
-  const bot = await deps.repos.bot.get(botId)
+  // Background convergence, not the HTTP surface: both sides of the ownership
+  // edge are re-read from system state, exactly like the agent read below
+  // (org-scoped-data-layer.md §4).
+  const bot = await deps.repos.bot.getUnscoped(botId)
   if (!bot || bot.shareable || bot.revokedAt) return null
 
   if (!iconPusherFor(deps, bot.platform)) return null

--- a/packages/control-plane/src/http/daemon-platform-capability.ts
+++ b/packages/control-plane/src/http/daemon-platform-capability.ts
@@ -29,7 +29,9 @@ export async function integrationPlatformAvailability(
   deps: HttpDeps,
   input: { daemonId: string; orgId: OrgId; viewer: ViewCtx; platform: string }
 ): Promise<DaemonPlatformAvailability> {
-  const daemon = await deps.registry.get(DaemonId(input.daemonId))
-  if (!daemon || daemon.orgId !== input.orgId || !canView(daemon, input.viewer)) return 'not_found'
+  // Org-fenced read (org-scoped-data-layer.md §3): a cross-org daemon id reads
+  // as absent, so only the visibility policy check remains here.
+  const daemon = await deps.registry.get(input.orgId, DaemonId(input.daemonId))
+  if (!daemon || !canView(daemon, input.viewer)) return 'not_found'
   return daemon.capabilities.platforms.includes(input.platform) ? 'available' : 'unsupported'
 }

--- a/packages/control-plane/src/http/feishu-session-access.test.ts
+++ b/packages/control-plane/src/http/feishu-session-access.test.ts
@@ -38,7 +38,7 @@ function json(body: unknown, status = 200): Response {
 
 function service(fetchImpl: (url: string, init?: RequestInit) => Promise<Response>) {
   return new FeishuSessionAccessService({
-    bots: { get: async () => bot() } as never,
+    bots: { getUnscoped: async () => bot() } as never,
     botSecrets: {
       get: async () => ({
         botToken: 'app-secret',

--- a/packages/control-plane/src/http/feishu-session-access.ts
+++ b/packages/control-plane/src/http/feishu-session-access.ts
@@ -142,7 +142,10 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
     ) {
       return { decision: 'deny' }
     }
-    const bot = await this.deps.bots.get(BotId(scope.credentialId)).catch(() => null)
+    // The credential behind a session's recorded external scope — system state,
+    // resolved without an org (org-scoped-data-layer.md §4). The scope row is
+    // itself reached through the session, which the caller already fenced.
+    const bot = await this.deps.bots.getUnscoped(BotId(scope.credentialId)).catch(() => null)
     const region = bot?.platform === 'feishu' ? (bot.feishuRegion ?? 'feishu') : undefined
     const appId = bot?.feishuAppId ?? undefined
     if (

--- a/packages/control-plane/src/http/install-feishu.ts
+++ b/packages/control-plane/src/http/install-feishu.ts
@@ -55,7 +55,7 @@ export async function installNewFeishuBot(
     throw new Error('reserved Feishu integration id is already in use')
   }
   if (!integration) {
-    const bot = await deps.repos.bot.get(botId)
+    const bot = await deps.repos.bot.get(orgId, botId)
     if (!bot) {
       await deps.repos.bot.create({
         id: botId,
@@ -111,7 +111,7 @@ export async function installNewFeishuBot(
   const [secret, channels, botRow] = await Promise.all([
     deps.repos.botSecret.get(botId),
     deps.repos.integrationChannel.listForIntegration(id),
-    deps.repos.bot.get(botId)
+    deps.repos.bot.get(orgId, botId)
   ])
   if (secret && botRow) {
     try {

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -298,7 +298,8 @@ function toDto(
  * Unplaced or vanished daemons are unavailable. */
 async function sandboxPolicyFor(deps: HttpDeps, a: AgentRecord): Promise<SandboxPolicy> {
   if (!a.daemonId) return UNAVAILABLE_SANDBOX
-  return sandboxPolicyOf(await deps.registry.get(a.daemonId))
+  // `a` came through an org-fenced read, so its own org scopes the daemon read.
+  return sandboxPolicyOf(await deps.registry.get(a.orgId, a.daemonId))
 }
 
 /** The dto's hook-kind marks for ONE agent (single-agent reads/writes). */
@@ -534,11 +535,12 @@ export function agentRoutes(deps: HttpDeps) {
 
     const requireSessionWorkspaceRead = async (
       reply: FastifyReply,
+      orgId: OrgId,
       daemonId: DaemonId,
       sessionId: string | undefined
     ): Promise<boolean> => {
       if (!sessionId) return true
-      const daemon = await deps.registry.get(daemonId)
+      const daemon = await deps.registry.get(orgId, daemonId)
       if (daemon?.capabilities.features.includes(WORKSPACE_SESSION_READ_FEATURE)) return true
       reply.code(409).send({
         error: 'Conflict',
@@ -991,9 +993,9 @@ export function agentRoutes(deps: HttpDeps) {
         // restricted daemons). A cross-org id and a restricted-and-invisible one
         // both read as absent (same 404). Mirrors integrations/cron referential writes.
         const placedDaemon =
-          req.body.daemonId !== undefined ? await deps.registry.get(DaemonId(req.body.daemonId)) : null
+          req.body.daemonId !== undefined ? await deps.registry.get(orgOf(req), DaemonId(req.body.daemonId)) : null
         if (req.body.daemonId !== undefined) {
-          if (!placedDaemon || placedDaemon.orgId !== req.orgCtx!.orgId || !canView(placedDaemon, ctxOf(req))) {
+          if (!placedDaemon || !canView(placedDaemon, ctxOf(req))) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
           }
         }
@@ -1306,7 +1308,9 @@ export function agentRoutes(deps: HttpDeps) {
         const daemonIds = [...new Set(rows.flatMap((a) => (a.daemonId ? [a.daemonId] : [])))]
         const policies = new Map(
           await Promise.all(
-            daemonIds.map(async (daemonId) => [daemonId, sandboxPolicyOf(await deps.registry.get(daemonId))] as const)
+            daemonIds.map(
+              async (daemonId) => [daemonId, sandboxPolicyOf(await deps.registry.get(orgOf(req), daemonId))] as const
+            )
           )
         )
         return rows.map((a) =>
@@ -1638,7 +1642,7 @@ export function agentRoutes(deps: HttpDeps) {
             Array.isArray(req.body.managedSkills) &&
             req.body.managedSkills.some((id) => !existing.managedSkills.includes(id))
           if (addsManagedSkill && existing.daemonId) {
-            const daemon = await deps.registry.get(existing.daemonId)
+            const daemon = await deps.registry.get(orgOf(req), existing.daemonId)
             if (!organizationKnowledgeSupportedOn(daemon)) {
               return reply.code(409).send({
                 error: 'Conflict',
@@ -1767,7 +1771,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
         const conflict = (message: string) => reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
         if (existing.daemonId) {
-          const daemon = await deps.registry.get(existing.daemonId)
+          const daemon = await deps.registry.get(orgOf(req), existing.daemonId)
           const live = deps.liveness.get(existing.daemonId)
           if (!daemon || live?.reachable !== true || live.state !== 'READY') {
             return conflict('the agent must be online and ready to edit its workspace')
@@ -1903,8 +1907,8 @@ export function agentRoutes(deps: HttpDeps) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
         }
 
-        const target = await deps.registry.get(DaemonId(req.body.daemonId))
-        if (!target || target.orgId !== req.orgCtx!.orgId || !canView(target, ctxOf(req))) {
+        const target = await deps.registry.get(orgOf(req), DaemonId(req.body.daemonId))
+        if (!target || !canView(target, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
         }
 
@@ -1984,7 +1988,7 @@ export function agentRoutes(deps: HttpDeps) {
         // but there is no separate source to gate before ensureActive below.
         if (existing.daemonId !== target.daemonId) {
           if (existing.daemonId) {
-            const source = await deps.registry.get(existing.daemonId)
+            const source = await deps.registry.get(orgOf(req), existing.daemonId)
             const sourceLive = source ? deps.liveness.get(source.daemonId) : undefined
             const sourceReady = sourceLive?.reachable === true && sourceLive.state === 'READY'
             if (force) {
@@ -2378,7 +2382,7 @@ export function agentRoutes(deps: HttpDeps) {
             .code(503)
             .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
         }
-        if (!(await requireSessionWorkspaceRead(reply, agent.daemonId, req.query.sessionId))) return
+        if (!(await requireSessionWorkspaceRead(reply, agent.orgId, agent.daemonId, req.query.sessionId))) return
 
         try {
           const page = await deps.control.workspaceList(agent.daemonId, {
@@ -2464,7 +2468,7 @@ export function agentRoutes(deps: HttpDeps) {
             .code(503)
             .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
         }
-        if (!(await requireSessionWorkspaceRead(reply, agent.daemonId, req.query.sessionId))) return
+        if (!(await requireSessionWorkspaceRead(reply, agent.orgId, agent.daemonId, req.query.sessionId))) return
 
         try {
           const rep = await deps.control.workspaceRead(agent.daemonId, {
@@ -2536,7 +2540,7 @@ export function agentRoutes(deps: HttpDeps) {
             .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
         }
 
-        const daemon = await deps.registry.get(agent.daemonId)
+        const daemon = await deps.registry.get(orgOf(req), agent.daemonId)
         if (!daemon?.capabilities.features.includes('workspace-file-edit-v1')) {
           return reply.code(409).send({
             error: 'Conflict',
@@ -2613,7 +2617,7 @@ export function agentRoutes(deps: HttpDeps) {
             .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
         }
 
-        const daemon = await deps.registry.get(agent.daemonId)
+        const daemon = await deps.registry.get(orgOf(req), agent.daemonId)
         if (!daemon?.capabilities.features.includes('workspace-file-delete-v1')) {
           return reply.code(409).send({
             error: 'Conflict',
@@ -3342,7 +3346,7 @@ export function agentRoutes(deps: HttpDeps) {
         return null
       }
       // Version skew: refuse before we send a frame the daemon would drop.
-      if (!dreamingSupportedOn(await deps.registry.get(agent.daemonId))) {
+      if (!dreamingSupportedOn(await deps.registry.get(agent.orgId, agent.daemonId))) {
         await reply.code(409).send({
           error: 'Conflict',
           statusCode: 409,
@@ -3755,7 +3759,7 @@ export function agentRoutes(deps: HttpDeps) {
             .code(503)
             .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
         }
-        if (!(await requireSessionWorkspaceRead(reply, agent.daemonId, req.query.sessionId))) return
+        if (!(await requireSessionWorkspaceRead(reply, agent.orgId, agent.daemonId, req.query.sessionId))) return
 
         try {
           const rep = await deps.control.workspaceGitStatus(agent.daemonId, {

--- a/packages/control-plane/src/http/routes/bots.ts
+++ b/packages/control-plane/src/http/routes/bots.ts
@@ -82,8 +82,10 @@ export function botRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const bot = await deps.repos.bot.get(BotId(req.params.id))
-        if (!bot || bot.orgId !== req.orgCtx!.orgId) {
+        // The read is org-fenced (org-scoped-data-layer.md §3): a cross-org id
+        // reads as absent, so no route-level org comparison is needed.
+        const bot = await deps.repos.bot.get(orgOf(req), BotId(req.params.id))
+        if (!bot) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
         return toDto(bot)
@@ -107,8 +109,8 @@ export function botRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const bot = await deps.repos.bot.get(BotId(req.params.id))
-        if (!bot || bot.orgId !== req.orgCtx!.orgId) {
+        const bot = await deps.repos.bot.get(orgOf(req), BotId(req.params.id))
+        if (!bot) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
         // Any active install blocks deletion (a shareable bot may have many; the FK
@@ -118,7 +120,7 @@ export function botRoutes(deps: HttpDeps) {
             .code(409)
             .send({ error: 'Conflict', statusCode: 409, message: 'bot is installed on an agent — uninstall first' })
         }
-        await deps.repos.bot.delete(bot.id)
+        await deps.repos.bot.delete(orgOf(req), bot.id)
         return reply.code(204).send(null)
       }
     )
@@ -145,8 +147,8 @@ export function botRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        let bot = await deps.repos.bot.get(BotId(req.params.id))
-        if (!bot || bot.orgId !== req.orgCtx!.orgId) {
+        let bot = await deps.repos.bot.get(orgOf(req), BotId(req.params.id))
+        if (!bot) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
         if (req.body.shareable === bot.shareable) return toDto(bot) // no-op
@@ -176,7 +178,7 @@ export function botRoutes(deps: HttpDeps) {
           })
         }
         try {
-          const current = await deps.repos.bot.get(bot.id)
+          const current = await deps.repos.bot.get(bot.orgId, bot.id)
           if (
             !current ||
             current.shareable !== bot.shareable ||
@@ -213,7 +215,7 @@ export function botRoutes(deps: HttpDeps) {
             })
           }
           try {
-            await deps.repos.bot.setShareable(bot.id, req.body.shareable)
+            await deps.repos.bot.setShareable(bot.orgId, bot.id, req.body.shareable)
           } catch (err) {
             if (err instanceof BotStillShared) {
               return reply.code(409).send({
@@ -227,7 +229,7 @@ export function botRoutes(deps: HttpDeps) {
           // Multi-agent capacity change only — recompile the relay pool's routes (no
           // ingest re-open; the transport, hence the ingest, is unchanged).
           await deps.httpBot.syncRoutes(bot.id)
-          const updated = await deps.repos.bot.get(bot.id)
+          const updated = await deps.repos.bot.get(bot.orgId, bot.id)
           return toDto(updated!)
         } finally {
           release()

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -224,12 +224,14 @@ export function daemonRoutes(deps: HttpDeps) {
       }
     )
 
-    // Fetch + org-check + visibility: a cross-org id OR a restricted daemon the
-    // caller can't see both read as absent (404). The console reaches daemons only
-    // through the registry service, so the canView gate lives here (and in list).
+    // Tenancy is the repository's job now (org-scoped-data-layer.md §3): the read
+    // is org-fenced, so a cross-org id reads as absent. What stays here is the
+    // POLICY half — a restricted daemon the caller can't see is 404 too. The
+    // console reaches daemons only through the registry service, so the canView
+    // gate lives here (and in list).
     const getOrgDaemon = async (req: FastifyRequest, id: string) => {
-      const view = await deps.registry.get(DaemonId(id))
-      if (!view || view.orgId !== req.orgCtx!.orgId) return null
+      const view = await deps.registry.get(orgOf(req), DaemonId(id))
+      if (!view) return null
       return canView(view, ctxOf(req)) ? view : null
     }
 
@@ -262,9 +264,9 @@ export function daemonRoutes(deps: HttpDeps) {
         const { name, sessionRetention } = req.body
         const did = DaemonId(req.params.id)
         let view = existing
-        if (name !== undefined) view = await deps.registry.rename(did, name, req.principal?.userId)
+        if (name !== undefined) view = await deps.registry.rename(orgOf(req), did, name, req.principal?.userId)
         if (sessionRetention !== undefined) {
-          view = await deps.registry.setSessionRetention(did, sessionRetention, req.principal?.userId)
+          view = await deps.registry.setSessionRetention(orgOf(req), did, sessionRetention, req.principal?.userId)
           // Hot-push the new window to the connected daemon (config/push EVT).
           // Best-effort: an offline daemon converges from the register/ok
           // snapshot on its next connect.
@@ -345,7 +347,7 @@ export function daemonRoutes(deps: HttpDeps) {
         // webchat MCP delegations and bumps their hook dispatchRevision, exactly as an
         // operator-initiated unplacement would.
         for (const a of placedAgents) await deps.repos.agent.setPlacement(a.id, null)
-        await deps.registry.remove(DaemonId(req.params.id))
+        await deps.registry.remove(orgOf(req), DaemonId(req.params.id))
         // The daemon (and its FK-cascaded keys) is gone — tell relays to drop it (§9).
         deps.relayControl.daemonRevoke(req.params.id)
         // Its agents just became UNPLACED (Agent.daemonId is SetNull), so they leave the
@@ -406,6 +408,7 @@ export function daemonRoutes(deps: HttpDeps) {
         }
         const sharedWith = await resolveShareSet(deps.repos.user, orgOf(req), req.body.sharedWith)
         const view = await deps.registry.setSharing(
+          orgOf(req),
           DaemonId(req.params.id),
           { visibility: req.body.visibility, sharedWith },
           req.principal?.userId

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -109,7 +109,7 @@ export function integrationRoutes(deps: HttpDeps) {
         deps.repos.botSecret.get(i.botId),
         deps.repos.integrationChannel.listForIntegration(i.id),
         deps.repos.agent.get(i.orgId, i.agentId),
-        deps.repos.bot.get(i.botId)
+        deps.repos.bot.get(i.orgId, i.botId)
       ])
       if (!secret || !bot) return
       try {
@@ -229,11 +229,8 @@ export function integrationRoutes(deps: HttpDeps) {
 
         // Reusing/promoting a classic bot can change the wire mode for agents
         // already using it, so their placement moves share this same boundary.
-        const observedBot = req.body.botId === undefined ? null : await deps.repos.bot.get(BotId(req.body.botId))
-        if (
-          req.body.botId !== undefined &&
-          (!observedBot || observedBot.orgId !== orgId || observedBot.platform !== req.body.platform)
-        ) {
+        const observedBot = req.body.botId === undefined ? null : await deps.repos.bot.get(orgId, BotId(req.body.botId))
+        if (req.body.botId !== undefined && (!observedBot || observedBot.platform !== req.body.platform)) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
         const observedBotAgentIds = [...(observedBot?.agentIds ?? [])].sort()
@@ -268,7 +265,7 @@ export function integrationRoutes(deps: HttpDeps) {
           // Reuse an existing bot: mint an integration for it. A SHAREABLE bot may
           // already serve other agents (this adds one more); a CLASSIC bot must be free.
           if (req.body.botId !== undefined) {
-            const bot = await deps.repos.bot.get(BotId(req.body.botId))
+            const bot = await deps.repos.bot.get(orgId, BotId(req.body.botId))
             if (
               !bot ||
               !observedBot ||
@@ -316,7 +313,7 @@ export function integrationRoutes(deps: HttpDeps) {
               if (bot.agentIds.length > 0) {
                 const shareableErr = await validateShareableInstall(bot, agent.id, req.body.platform)
                 if (shareableErr) return reply.code(shareableErr.code).send(shareableErr.body)
-                if (!bot.shareable) await deps.repos.bot.setShareable(bot.id, true)
+                if (!bot.shareable) await deps.repos.bot.setShareable(orgId, bot.id, true)
               } else if (!deps.httpBot.hasConnectedRelay()) {
                 return reply.code(409).send({
                   error: 'Conflict',
@@ -610,7 +607,7 @@ export function integrationRoutes(deps: HttpDeps) {
         reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
         return null
       }
-      const bot = await deps.repos.bot.get(integration.botId)
+      const bot = await deps.repos.bot.get(orgIdOf(req as never), integration.botId)
       if (!bot) {
         reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         return null
@@ -775,7 +772,7 @@ export function integrationRoutes(deps: HttpDeps) {
         if (!existingChannel) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'channel not found' })
         }
-        const bot = await deps.repos.bot.get(integration.botId)
+        const bot = await deps.repos.bot.get(orgIdOf(req), integration.botId)
         if (!bot) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
@@ -1172,7 +1169,7 @@ export function integrationRoutes(deps: HttpDeps) {
             })
           }
           agent = current
-          const botBefore = await deps.repos.bot.get(existing.botId)
+          const botBefore = await deps.repos.bot.get(orgIdOf(req), existing.botId)
           if (botBefore?.transport === 'http') {
             await deps.httpBot.prepareIntegrationRemoval(existing.botId)
           }
@@ -1181,7 +1178,7 @@ export function integrationRoutes(deps: HttpDeps) {
           // serve other agents — don't stamp it freed while it does, §6).
           const remaining = await deps.repos.integration.listForBot(existing.botId)
           if (remaining.length === 0) {
-            await deps.repos.bot.markFreed(existing.botId, new Date(), agent.name ?? null)
+            await deps.repos.bot.markFreed(orgIdOf(req), existing.botId, new Date(), agent.name ?? null)
           }
           // Tell the removed agent's daemon to drop the spec either way.
           await replicateRemove(existing.id, agent.daemonId ?? null)

--- a/packages/control-plane/src/http/routes/keys.ts
+++ b/packages/control-plane/src/http/routes/keys.ts
@@ -14,7 +14,7 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import type { ApiKeyView } from '../../ports.js'
 import { DaemonId } from '../../domain/ids.js'
-import { denyViewerWrite, ctxOf } from '../rbac.js'
+import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { ApiKeyListDto, MintedKeyDto, ApiKeyDto, IdParam, ErrorDto, type ApiKeyDtoT } from '../dto/index.js'
 import { daemonStartCommand, daemonWsUrl } from '../onboarding.js'
@@ -44,8 +44,8 @@ export function keyRoutes(deps: HttpDeps) {
     // revoking a daemon's enrollment credential is a credential write, so the
     // handlers additionally gate on canEdit.
     const getOrgDaemon = async (req: FastifyRequest, id: string) => {
-      const view = await deps.registry.get(DaemonId(id))
-      if (!view || view.orgId !== req.orgCtx!.orgId) return null
+      const view = await deps.registry.get(orgOf(req), DaemonId(id))
+      if (!view) return null
       return canView(view, ctxOf(req)) ? view : null
     }
 
@@ -94,7 +94,7 @@ export function keyRoutes(deps: HttpDeps) {
         if (!canEdit(view, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this daemon' })
         }
-        const minted = await deps.apiKeys.mintForDaemon(DaemonId(req.params.id))
+        const minted = await deps.apiKeys.mintForDaemon(orgOf(req), DaemonId(req.params.id))
         const command = daemonStartCommand(daemonWsUrl(deps.config), minted.token, deps.config.DAEMON_DIST_TAG)
         return reply.code(201).send({
           apiKeyId: minted.apiKeyId,

--- a/packages/control-plane/src/http/routes/organization-environment.ts
+++ b/packages/control-plane/src/http/routes/organization-environment.ts
@@ -139,9 +139,9 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
      *  unplaced agent is always fine (placement re-checks the feature), and an
      *  unknown/never-registered daemon cannot be proven compatible — the gate
      *  never relies on lenient behavior from an unverified daemon. */
-    const onCompatibleDaemon = async (daemonId: DaemonId | null): Promise<boolean> => {
+    const onCompatibleDaemon = async (orgId: OrgId, daemonId: DaemonId | null): Promise<boolean> => {
       if (daemonId === null) return true
-      const daemon = await deps.registry.get(daemonId)
+      const daemon = await deps.registry.get(orgId, daemonId)
       return !!daemon?.capabilities.features.includes(AGENT_CONFIG_REVISION_FEATURE)
     }
 
@@ -159,7 +159,7 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
       const placed = (await deps.repos.agent.list(orgId)).filter((agent) => wanted.has(agent.id))
       const out: string[] = []
       for (const agent of placed) {
-        if (!(await onCompatibleDaemon(agent.daemonId))) out.push(agent.id)
+        if (!(await onCompatibleDaemon(orgId, agent.daemonId))) out.push(agent.id)
       }
       return out
     }
@@ -201,7 +201,7 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
       // what keeps the refusal indistinguishable from a missing agent.
       const inScope = mode === 'requested' ? agents.filter((agent) => canEdit(agent, ctx)) : agents
       for (const agent of inScope) {
-        if (!(await onCompatibleDaemon(agent.daemonId))) {
+        if (!(await onCompatibleDaemon(orgId, agent.daemonId))) {
           // Naming is safe only for an agent the caller can already see.
           return canView(agent, ctx)
             ? `agent ${agent.name} runs on a daemon that does not yet support organization environment entries; upgrade it first`

--- a/packages/control-plane/src/http/routes/organization-knowledge.ts
+++ b/packages/control-plane/src/http/routes/organization-knowledge.ts
@@ -173,7 +173,7 @@ async function suggestionReviewAvailable(
   const live = deps.liveness.get(sourceDaemonId)
   if (live?.reachable !== true || live.state !== 'READY') return false
   const [daemon, agent] = await Promise.all([
-    deps.registry.get(DaemonId(sourceDaemonId)),
+    deps.registry.get(orgId, DaemonId(sourceDaemonId)),
     deps.repos.agent.get(orgId, AgentId(sourceAgentId))
   ])
   return (

--- a/packages/control-plane/src/http/routes/slack-bot-refresh.ts
+++ b/packages/control-plane/src/http/routes/slack-bot-refresh.ts
@@ -24,7 +24,7 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import type { SlackRouteSeams } from '../platform-route-seams.js'
 import { BotId } from '../../domain/ids.js'
-import { denyViewerWrite } from '../rbac.js'
+import { denyViewerWrite, orgOf } from '../rbac.js'
 import { SlackBotRefreshDto, ErrorDto, IdParam, type SlackBotRefreshDtoT } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
 import { mergeManagedSlackManifest, slackOAuthRedirectUri, SLACK_BOT_SCOPES } from '../slack-manifest.js'
@@ -82,8 +82,8 @@ export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const bot = await deps.repos.bot.get(BotId(req.params.id))
-        if (!bot || bot.orgId !== req.orgCtx!.orgId) {
+        const bot = await deps.repos.bot.get(orgOf(req), BotId(req.params.id))
+        if (!bot) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
         if (bot.platform !== 'slack') {
@@ -112,7 +112,7 @@ export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
         const checked = await slack.verifyBot?.(secret.botToken)
         const appIdentityMatches = checked?.status === 'ok' && checked.appId === bot.slackAppId
         if (appIdentityMatches && checked.teamId) {
-          await deps.repos.bot.setWorkspaceMetadata(bot.id, checked.teamId, checked.teamName)
+          await deps.repos.bot.setWorkspaceMetadata(bot.orgId, bot.id, checked.teamId, checked.teamName)
         }
         // A built-in app's manifest is deployment-managed rather than owned by
         // the signed-in user's Slack config token. Refresh still verifies its

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -90,8 +90,8 @@ export function slackPlatformInstallRoutes(deps: HttpDeps, slack: SlackRouteSeam
           // Settings reauthorization: fence the callback to this exact
           // platform-app workspace. No target agent is stored, so a freed bot
           // remains free and an active bot keeps its existing memberships.
-          const bot = await deps.repos.bot.get(BotId(req.body.botId))
-          if (!bot || bot.orgId !== orgId) {
+          const bot = await deps.repos.bot.get(orgId, BotId(req.body.botId))
+          if (!bot) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
           }
           if (bot.platform !== 'slack' || !bot.prebuilt || bot.slackAppId !== platform.appId || !bot.teamId) {
@@ -254,11 +254,12 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
         // A Settings refresh puts its expected Bot id in the pending state. Its
         // durable platform-app teamId is the workspace fence: authorizing any
         // other workspace must fail before credentials or memberships change.
-        const expectedBot = row.botId ? await deps.repos.bot.get(BotId(row.botId)) : null
+        // Unauthenticated callback: no request org context — the pending-install
+        // row (minted org-scoped; its id is the OAuth state) carries the tenancy.
+        const expectedBot = row.botId ? await deps.repos.bot.get(row.orgId, BotId(row.botId)) : null
         if (
           row.botId &&
           (!expectedBot ||
-            expectedBot.orgId !== row.orgId ||
             expectedBot.platform !== 'slack' ||
             !expectedBot.prebuilt ||
             expectedBot.slackAppId !== platform.appId ||
@@ -305,7 +306,9 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
           // rotate to the fresh token, clear any uninstall marker, and make sure
           // the target agent has an active install; then reconverge the pool.
           botId = existing.id
-          await deps.repos.bot.setWorkspaceMetadata(existing.id, result.teamId, result.teamName)
+          // Same-org re-install (the cross-org claim was refused above), so the
+          // pending row's org is this bot's org.
+          await deps.repos.bot.setWorkspaceMetadata(row.orgId, existing.id, result.teamId, result.teamName)
           // ONE transition: the fresh token and the generation it belongs to
           // commit together, so no reader (notably restart reconciliation, which
           // does not filter on `revokedAt`) can broadcast the new credential

--- a/packages/control-plane/src/http/routes/stream.ts
+++ b/packages/control-plane/src/http/routes/stream.ts
@@ -80,13 +80,14 @@ export function streamRoutes(deps: HttpDeps) {
         const orgId = req.orgCtx!.orgId
         const connectedCtx = ctxOf(req)
         // daemonId → belongs-to-this-org, memoized per connection (events arrive
-        // in bursts from the same few daemons; one registry lookup each).
+        // in bursts from the same few daemons; one registry lookup each). The read
+        // is org-fenced (org-scoped-data-layer.md §3), so "resolves" IS "in org".
         const daemonOrg = new Map<string, boolean>()
         const inOrg = async (daemonId: string): Promise<boolean> => {
           const cached = daemonOrg.get(daemonId)
           if (cached !== undefined) return cached
-          const view = await deps.registry.get(DaemonId(daemonId)).catch(() => null)
-          const ok = !!view && view.orgId === orgId
+          const view = await deps.registry.get(orgId, DaemonId(daemonId)).catch(() => null)
+          const ok = !!view
           daemonOrg.set(daemonId, ok)
           return ok
         }

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -158,13 +158,15 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
     }
     // Prisma "record to delete/update does not exist", a membership-dependent
     // mutation whose required membership disappeared while it was queued, or an
-    // org-fenced agent mutation whose row vanished (or never belonged to the
-    // caller's org) between the route's pre-read and the write — the fence
-    // deliberately makes those indistinguishable (org-scoped-data-layer.md §3).
+    // org-fenced mutation whose row vanished (or never belonged to the caller's
+    // org) between the route's pre-read and the write — the fence deliberately
+    // makes those indistinguishable (org-scoped-data-layer.md §3). Every
+    // `<Resource>Missing` code the data layer can raise belongs in this list.
     if (
       (err as { code?: string }).code === 'P2025' ||
       (err as { code?: string }).code === 'ORG_MEMBERSHIP_MISSING' ||
-      (err as { code?: string }).code === 'AGENT_MISSING'
+      (err as { code?: string }).code === 'AGENT_MISSING' ||
+      (err as { code?: string }).code === 'BOT_MISSING'
     ) {
       return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'resource not found' })
     }

--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -42,7 +42,7 @@ function bot(): BotRecord {
 
 function service(fetchImpl: (url: string, init?: RequestInit) => Promise<Response>) {
   return new SlackSessionAccessService({
-    bots: { get: async () => bot() } as never,
+    bots: { getUnscoped: async () => bot() } as never,
     botSecrets: { get: async () => ({ botToken: 'xoxb-test' }) } as never,
     clock: { now: () => 1_000 } as never,
     fetchImpl

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -134,7 +134,10 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     ) {
       return 'deny'
     }
-    const bot = await this.deps.bots.get(BotId(scope.credentialId)).catch(() => null)
+    // The credential behind a session's recorded external scope — system state,
+    // resolved without an org (org-scoped-data-layer.md §4). The scope row is
+    // itself reached through the session, which the caller already fenced.
+    const bot = await this.deps.bots.getUnscoped(BotId(scope.credentialId)).catch(() => null)
     const realm = bot?.workspaceId ?? bot?.teamId
     if (
       !bot ||

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -246,7 +246,7 @@ function make(
     integrationChannels: { listForIntegration: async () => [] } as unknown as ConstructorParameters<
       typeof AgentMoveService
     >[0]['integrationChannels'],
-    bots: { get: async () => bot } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['bots'],
+    bots: { getUnscoped: async () => bot } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['bots'],
     botSecrets: {
       get: async () => ({ botToken: 'xoxb-test', appToken: 'xapp-test' })
     } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['botSecrets'],

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -590,7 +590,9 @@ export class AgentMoveService {
     const specs = await Promise.all(
       integrations.map(async (integration) => {
         const [bot, secret, channels] = await Promise.all([
-          this.deps.bots.get(integration.botId),
+          // Orchestration: the bot behind an integration row of the agent being
+          // moved — org derived from the record in hand (org-scoped-data-layer.md §4).
+          this.deps.bots.getUnscoped(integration.botId),
           this.deps.botSecrets.get(integration.botId),
           this.deps.integrationChannels.listForIntegration(integration.id)
         ])

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -156,8 +156,8 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       [BOB]: agent(BOB, 'bob', unplacedAgents.has(BOB) ? null : D2)
     }
     let getCalls = 0
-    const bots: Pick<BotRepo, 'get' | 'listHttpActive' | 'revokeIfCurrent'> = {
-      get: async () => {
+    const bots: Pick<BotRepo, 'getUnscoped' | 'listHttpActive' | 'revokeIfCurrent'> = {
+      getUnscoped: async () => {
         getCalls += 1
         if (bumpRevisionAfterFirstGet && getCalls > 1) {
           return { ...botRow, credentialRevision: botRow.credentialRevision + 1 }

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -100,6 +100,11 @@ export class HttpBotOrchestrator {
   private readonly channelMutationChains = new Map<string, Promise<unknown>>()
 
   constructor(
+    /** Every bot read here is `getUnscoped`: this is the orchestration trust
+     *  domain (org-scoped-data-layer.md §4) — convergence is driven by a bot id
+     *  that arrived from relay ingress, a relay-reported lifecycle event, or a
+     *  route that already resolved the row through its own org fence, and the
+     *  organization is derived from the row itself. */
     private readonly bots: BotRepo,
     private readonly botSecret: BotSecretStore,
     private readonly botCredential: BotCredentialWriter,
@@ -126,7 +131,7 @@ export class HttpBotOrchestrator {
    * the release check).
    */
   async syncBot(botId: string): Promise<void> {
-    const bot = await this.bots.get(BotId(botId))
+    const bot = await this.bots.getUnscoped(BotId(botId))
     if (!bot) return
     if (bot.transport !== 'http' || bot.agentIds.length === 0) {
       await this.unassign(bot)
@@ -183,7 +188,7 @@ export class HttpBotOrchestrator {
    * connected relay yet.
    */
   async syncRoutes(botId: string): Promise<void> {
-    const bot = await this.bots.get(BotId(botId))
+    const bot = await this.bots.getUnscoped(BotId(botId))
     if (!bot || bot.transport !== 'http' || bot.agentIds.length === 0) return this.syncBot(botId)
     if (this.relayReg.all().length === 0) return this.syncBot(botId) // nobody connected → defer
     const compiled = await this.compile(bot)
@@ -249,7 +254,7 @@ export class HttpBotOrchestrator {
     reason: 'app_uninstalled' | 'tokens_revoked',
     fence: { revision?: number; eventAtMs?: number } = {}
   ): Promise<{ applied: boolean }> {
-    const bot = await this.bots.get(BotId(botId))
+    const bot = await this.bots.getUnscoped(BotId(botId))
     // Unknown bot: nothing to apply and nothing that will ever change that, so
     // this is terminal for the reporting relay — not a reason to keep retrying.
     if (!bot) return { applied: false }
@@ -270,7 +275,7 @@ export class HttpBotOrchestrator {
     // moment we released it, in which case IT owns the live state and has
     // already broadcast a fresh assign. Emitting the teardown now would tear
     // down a credential we no longer describe.
-    const after = await this.bots.get(bot.id)
+    const after = await this.bots.getUnscoped(bot.id)
     if (after && after.credentialRevision !== bot.credentialRevision) {
       this.log.info(
         { botId: bot.id, reason, from: bot.credentialRevision, to: after.credentialRevision },
@@ -466,7 +471,7 @@ export class HttpBotOrchestrator {
    *  creating (earliest active) agent, while an existing owner is preserved.
    */
   async replaceChannels(botId: string, channels: ReportedChannel[]): Promise<void> {
-    const bot = await this.bots.get(BotId(botId))
+    const bot = await this.bots.getUnscoped(BotId(botId))
     if (!bot || manifestFor(bot.platform).membershipEnumeration !== 'authoritative' || bot.transport !== 'http') {
       this.log.warn(
         { botId },
@@ -525,7 +530,7 @@ export class HttpBotOrchestrator {
    * recompiled because a newly observed public row is immediately active.
    */
   async reportConversation(botId: string, conversation: ReportedChannel): Promise<void> {
-    const bot = await this.bots.get(BotId(botId))
+    const bot = await this.bots.getUnscoped(BotId(botId))
     // A conversation report can only originate from relay ingress, so the gate is
     // the same §9 signal the assign builder runs on: a platform with no
     // `projectBotAssign` has no relay path and no relay can be reporting for it.
@@ -563,7 +568,7 @@ export class HttpBotOrchestrator {
     options: { expectedOwnerAgentId?: string; source?: 'console' | 'slack' } = {}
   ): Promise<IntegrationChannelRecord | null> {
     return this.serializeChannelMutation(botId, channelId, async () => {
-      const bot = await this.bots.get(BotId(botId))
+      const bot = await this.bots.getUnscoped(BotId(botId))
       if (bot?.transport !== 'http') {
         this.log.warn({ botId }, 'http-bot: update-channel for a non-http/unknown bot — ignored')
         return null
@@ -612,7 +617,7 @@ export class HttpBotOrchestrator {
 
   /** Preserve bot-scoped channel state before an owner integration is deleted. */
   async prepareIntegrationRemoval(botId: string): Promise<void> {
-    const bot = await this.bots.get(BotId(botId))
+    const bot = await this.bots.getUnscoped(BotId(botId))
     if (bot?.transport !== 'http') return
     const installs = await this.integrations.listForBot(bot.id)
     await this.ensureChannelOwners(bot.id, installs)

--- a/packages/control-plane/src/orchestrator/integrationPush.ts
+++ b/packages/control-plane/src/orchestrator/integrationPush.ts
@@ -43,7 +43,8 @@ export async function convergeIntegrationGating(
   const syncedBots = new Set<string>()
   for (const i of integrations) {
     try {
-      const bot = await deps.repos.bot.get(i.botId)
+      // Orchestration: the bot behind one of this agent's integration rows.
+      const bot = await deps.repos.bot.getUnscoped(i.botId)
       if (bot?.transport === 'http') {
         if (!syncedBots.has(String(bot.id))) {
           syncedBots.add(String(bot.id))

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -368,7 +368,9 @@ export class Placement implements ReconcileService {
   }
 
   async reconcile(daemonId: DaemonId, req: RegisterReq): Promise<RegisterOk> {
-    const daemon = await this.daemons.get(daemonId)
+    // Daemon trust domain: reconcile runs for the registering connection's own
+    // daemon (org-scoped-data-layer.md §4).
+    const daemon = await this.daemons.getUnscoped(daemonId)
     if (!daemon) {
       // Should not happen — auth created the row — but stay defensive.
       throw new Error(`reconcile: unknown daemon ${daemonId}`)
@@ -397,7 +399,8 @@ export class Placement implements ReconcileService {
           const [secret, channels, bot] = await Promise.all([
             this.botSecrets.get(i.botId),
             this.integrationChannels.listForIntegration(i.id),
-            this.bots.get(i.botId)
+            // The bot behind one of the reconciling daemon's integration rows.
+            this.bots.getUnscoped(i.botId)
           ])
           // A spec needs BOTH halves of its identity: the bot row (the projector's
           // required input — credentials shape, transport, demux identity) and the

--- a/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.test.ts
+++ b/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.test.ts
@@ -74,7 +74,9 @@ describe('SlackBotIdentityReconciler', () => {
     expect(resolve).toHaveBeenCalledWith('xoxb-secret')
     expect(setSlackAppIdIfMissing).toHaveBeenCalledWith(BOT, 'AHTTPBOT')
     expect(setSlackBotUserIdIfMissing).toHaveBeenCalledWith(BOT, 'UHTTPBOT')
-    expect(setWorkspaceMetadata).toHaveBeenCalledWith(BOT, 'TWORKSPACE', 'Acme')
+    // Org-fenced write (org-scoped-data-layer.md §3): the reconciler passes the
+    // org of the row its fleet-wide worklist yielded, ahead of the bot id.
+    expect(setWorkspaceMetadata).toHaveBeenCalledWith(bot().orgId, BOT, 'TWORKSPACE', 'Acme')
     expect(onMentionIdentityChanged).toHaveBeenCalledWith(bot().orgId)
     expect(JSON.stringify(info.mock.calls)).not.toContain('xoxb-secret')
   })

--- a/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.ts
+++ b/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.ts
@@ -102,7 +102,8 @@ export class SlackBotIdentityReconciler {
             }
           }
           if (identity.workspaceId && SLACK_WORKSPACE_ID.test(identity.workspaceId)) {
-            await this.bots.setWorkspaceMetadata(bot.id, identity.workspaceId, identity.workspaceName)
+            // The org comes from the row this fleet-wide worklist already yielded.
+            await this.bots.setWorkspaceMetadata(bot.orgId, bot.id, identity.workspaceId, identity.workspaceName)
             this.log?.info(
               { botId: bot.id, workspaceId: identity.workspaceId },
               'slack-bot-identity: refreshed workspace metadata'

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -42,6 +42,21 @@ export class AgentMissing extends Error {
 }
 
 /**
+ * Thrown by org-fenced bot mutations whose fence sits on a row-lock read rather
+ * than on the write's own `where` (docs/designs/org-scoped-data-layer.md §3) —
+ * today `BotRepo.setShareable`, where refusing BEFORE the install recount is
+ * what keeps a foreign bot's occupancy from leaking as a `BotStillShared` 409.
+ * A cross-org id is deliberately indistinguishable from a missing row.
+ */
+export class BotMissing extends Error {
+  readonly code = 'BOT_MISSING' as const
+  constructor(readonly botId: string) {
+    super(`bot ${botId} not found in this organization`)
+    this.name = 'BotMissing'
+  }
+}
+
+/**
  * Thrown by `BotRepo.setShareable(false)` when the row-locked recount still sees
  * more than one ACTIVE install — disabling sharing then would orphan the others'
  * routes. The recount runs under the same bot-row lock `IntegrationRepo.

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -199,15 +199,22 @@ export interface DaemonRepo {
   markUnreachable(daemonId: DaemonId, at: Date): Promise<void>
   /** Set the console-assigned display name (a human edit — stamps last-modified
    *  audit). `byUserId` is the editing WebUI principal (absent under devAuth).
-   *  Throws if the daemon row is absent. */
-  rename(daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonRecord>
+   *  Org-fenced (docs/designs/org-scoped-data-layer.md §3): a cross-org id
+   *  throws the same missing-row error as an absent row. */
+  rename(orgId: OrgId, daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonRecord>
   /** Set the console's finished-session retention window (a human edit — stamps
-   *  last-modified audit). Throws if the daemon row is absent. */
-  setSessionRetention(daemonId: DaemonId, sessionRetention: string, byUserId?: string): Promise<DaemonRecord>
+   *  last-modified audit). Org-fenced like {@link DaemonRepo.rename}. */
+  setSessionRetention(
+    orgId: OrgId,
+    daemonId: DaemonId,
+    sessionRetention: string,
+    byUserId?: string
+  ): Promise<DaemonRecord>
   /** Set the visibility + share set (the dedicated `/sharing` write path). Stamps
    *  the last-modified audit; `byUserId` is the editing WebUI principal (absent
-   *  under devAuth). Throws if the daemon row is absent. */
+   *  under devAuth). Org-fenced like {@link DaemonRepo.rename}. */
   setSharing(
+    orgId: OrgId,
     daemonId: DaemonId,
     sharing: { visibility: ResourceVisibility; sharedWith: string[] },
     byUserId?: string
@@ -215,14 +222,26 @@ export interface DaemonRepo {
   /**
    * Hard-delete a daemon (DELETE /daemons/:id). FK referential actions cascade its
    * api-keys / leases / launches / runtime-profiles and null out agents/assignments
-   * (those become unplaced). Throws Prisma P2025 if the row is absent (→ 404).
+   * (those become unplaced). Org-fenced: a cross-org id throws Prisma P2025
+   * exactly like an absent row (→ 404).
    */
-  delete(daemonId: DaemonId): Promise<void>
-  /** Bump THIS daemon's `routingEpoch` atomically; returns the new value (§4.11). */
+  delete(orgId: OrgId, daemonId: DaemonId): Promise<void>
+  /** Bump THIS daemon's `routingEpoch` atomically; returns the new value (§4.11).
+   *  System-tier: the orchestrator drives it from a routing decision it already
+   *  resolved, so an org parameter would be tautological (§3.4). */
   bumpRoutingEpoch(daemonId: DaemonId): Promise<bigint>
-  /** Daemons unreachable for longer than `graceSec` — reassignment candidates (§4.9). */
+  /** Daemons unreachable for longer than `graceSec` — reassignment candidates (§4.9).
+   *  System-tier: the watchdog's worklist is deliberately fleet-wide. */
   findReassignable(graceSec: number, now: Date): Promise<DaemonRecord[]>
-  get(daemonId: DaemonId): Promise<DaemonRecord | null>
+  /** Org-fenced point read (org-scoped-data-layer.md §3): a cross-org id reads
+   *  as absent, exactly like a missing row. The only daemon read the HTTP/MCP
+   *  surface may use. */
+  get(orgId: OrgId, daemonId: DaemonId): Promise<DaemonRecord | null>
+  /** Tenancy-UNSCOPED read for internal trust domains — WS handlers resolving
+   *  their own connection's daemon, orchestration/placement resolving a daemon
+   *  from a routing row, the watchdog. Never call this from the HTTP surface;
+   *  lint enforces it (org-scoped-data-layer.md §6). */
+  getUnscoped(daemonId: DaemonId): Promise<DaemonRecord | null>
   /** The fleet, optionally filtered to one org (console reads pass the org). Every
    *  supplied human principal is resource-filtered; undefined is reserved for
    *  unfiltered internal reads (authorization/policy.ts#visibilityWhere). */
@@ -2560,26 +2579,44 @@ export interface BotRecord {
 
 export interface BotRepo {
   create(input: CreateBotInput): Promise<BotRecord>
-  get(id: BotId): Promise<BotRecord | null>
+  /** Org-fenced point read (docs/designs/org-scoped-data-layer.md §3): a
+   *  cross-org id reads as absent, exactly like a missing row. The only bot read
+   *  the HTTP/MCP surface may use. */
+  get(orgId: OrgId, id: BotId): Promise<BotRecord | null>
+  /** Tenancy-UNSCOPED read for internal trust domains — the shared-bot
+   *  orchestrator converging a relay assignment, integration/placement push
+   *  resolving the bot behind an integration row, WS-reported credential
+   *  lifecycle. Never call this from the HTTP surface; lint enforces it (§6). */
+  getUnscoped(id: BotId): Promise<BotRecord | null>
   listForOrg(orgId: OrgId): Promise<BotRecord[]>
   /** Record workspace metadata learned from OAuth/auth.test. A missing name
-   *  preserves the last known label. */
-  setWorkspaceMetadata(id: BotId, workspaceId: string, workspaceName: string | null): Promise<void>
-  /** Slack bots missing public app/workspace/member identity metadata. */
+   *  preserves the last known label. Org-fenced: a cross-org id writes nothing
+   *  (the row is filtered out of the update). */
+  setWorkspaceMetadata(orgId: OrgId, id: BotId, workspaceId: string, workspaceName: string | null): Promise<void>
+  /** Slack bots missing public app/workspace/member identity metadata.
+   *  System-tier: the identity reconciler's worklist is deliberately fleet-wide. */
   listSlackMissingIdentity(): Promise<BotRecord[]>
-  /** Backfill only a missing id; never replace an established Slack app identity. */
+  /** Backfill only a missing id; never replace an established Slack app identity.
+   *  System-tier: reconciler-only, driven off {@link BotRepo.listSlackMissingIdentity}
+   *  and fenced by its own `slackAppId IS NULL` CAS predicate, so an org
+   *  parameter re-derived from that worklist would be tautological (§3.4). */
   setSlackAppIdIfMissing(id: BotId, slackAppId: string): Promise<boolean>
-  /** Backfill only a missing Slack member id; never replace an established identity. */
+  /** Backfill only a missing Slack member id; never replace an established identity.
+   *  System-tier like {@link BotRepo.setSlackAppIdIfMissing}. */
   setSlackBotUserIdIfMissing(id: BotId, botUserId: string): Promise<boolean>
-  /** Stamp the freed-bot display hints when its LAST integration is removed. */
-  markFreed(id: BotId, at: Date, lastAgentName: string | null): Promise<void>
+  /** Stamp the freed-bot display hints when its LAST integration is removed.
+   *  Org-fenced: a cross-org id writes nothing. */
+  markFreed(orgId: OrgId, id: BotId, at: Date, lastAgentName: string | null): Promise<void>
   /** Flip the shared-bot (multi-agent) opt-in (console toggle). Serialized on the
    *  bot row with {@link IntegrationRepo.addBotMembership}; disabling recounts the
    *  ACTIVE installs under that lock and throws `BotStillShared` when >1 remain,
-   *  so a concurrent admission can never slip past the route's optimistic check. */
-  setShareable(id: BotId, shareable: boolean): Promise<void>
+   *  so a concurrent admission can never slip past the route's optimistic check.
+   *  Org-fenced: the lock read is filtered, so a cross-org id throws the same
+   *  missing-row error ({@link BotMissing}) as an absent one. */
+  setShareable(orgId: OrgId, id: BotId, shareable: boolean): Promise<void>
   /** Every http-transport bot with ≥1 active integration, across all orgs — the
-   *  shared-bot orchestrator's convergence worklist (relay register / failover). */
+   *  shared-bot orchestrator's convergence worklist (relay register / failover).
+   *  System-tier: fleet-wide by design. */
   listHttpActive(): Promise<BotRecord[]>
   /** The Bot backing one workspace install of a distributed app — CROSS-ORG lookup
    *  by the composite demux key (a workspace binds to exactly one org). */
@@ -2599,6 +2636,11 @@ export interface BotRepo {
    * This is also the ONLY way to un-revoke a bot — there is deliberately no bare
    * `setRevoked(id, null)`: reviving a credential without advancing its
    * generation would leave a delayed uninstall from the dead one able to kill it.
+   *
+   * System-tier (§3.4): reached only through {@link BotCredentialWriter}, whose
+   * install arm runs after the platform callback has resolved the row by its
+   * external demux identity — a deliberately cross-org lookup that already
+   * settles which organization owns the credential.
    */
   bumpCredential(id: BotId, at: Date): Promise<number>
   /**
@@ -2615,10 +2657,14 @@ export interface BotRepo {
    *    relay already received the newer assignment and would echo its revision).
    * Both are optional: a report carrying neither still applies (fail-open — an
    * uninstall must eventually take effect).
+   *
+   * System-tier (§3.4): relay-reported lifecycle, already fenced by the
+   * credential generation CAS above — a stronger axis than the owning org.
    */
   revokeIfCurrent(id: BotId, at: Date, fence: { revision?: number; eventAt?: Date }): Promise<boolean>
-  /** Callers must refuse while the bot is installed (FK Restrict backstops). */
-  delete(id: BotId): Promise<void>
+  /** Callers must refuse while the bot is installed (FK Restrict backstops).
+   *  Org-fenced: a cross-org id throws the same Prisma P2025 as an absent row. */
+  delete(orgId: OrgId, id: BotId): Promise<void>
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -172,22 +172,30 @@ export class PgDaemonRepo implements DaemonRepo {
     })
   }
 
-  async rename(daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonRecord> {
+  async rename(orgId: OrgId, daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonRecord> {
     // A rename is a human edit — advance the last-modified audit (editor stamped
     // when known; absent under devAuth ⇒ leave the prior editor as-is).
+    // The org filter rides the unique update (extended where): a cross-org id
+    // throws the same P2025 as a missing row (org-scoped-data-layer.md §3).
     const daemon = await this.db.daemon.update({
-      where: { id: daemonId },
+      where: { id: daemonId, orgId },
       data: { name, lastModifiedAt: new Date(), ...(byUserId ? { lastModifiedByUserId: byUserId } : {}) },
       include: withUsers
     })
     return toRecord(daemon)
   }
 
-  async setSessionRetention(daemonId: DaemonId, sessionRetention: string, byUserId?: string): Promise<DaemonRecord> {
+  async setSessionRetention(
+    orgId: OrgId,
+    daemonId: DaemonId,
+    sessionRetention: string,
+    byUserId?: string
+  ): Promise<DaemonRecord> {
     // A retention change is a human edit — advance the last-modified audit
     // (editor stamped when known; absent under devAuth ⇒ leave the prior editor).
+    // Org-fenced on the update, like `rename`.
     const daemon = await this.db.daemon.update({
-      where: { id: daemonId },
+      where: { id: daemonId, orgId },
       data: { sessionRetention, lastModifiedAt: new Date(), ...(byUserId ? { lastModifiedByUserId: byUserId } : {}) },
       include: withUsers
     })
@@ -195,13 +203,16 @@ export class PgDaemonRepo implements DaemonRepo {
   }
 
   async setSharing(
+    orgId: OrgId,
     daemonId: DaemonId,
     sharing: { visibility: DaemonRecord['visibility']; sharedWith: string[] },
     byUserId?: string
   ): Promise<DaemonRecord> {
     return withAmbientTx(this.db, async (tx) => {
+      // Org fence on the opening read: a cross-org id throws the same P2025 as
+      // a missing row, before the membership lock or any write.
       const existing = await tx.daemon.findUniqueOrThrow({
-        where: { id: daemonId },
+        where: { id: daemonId, orgId },
         select: { orgId: true }
       })
       const memberships = await lockResourceWriteMemberships(tx, {
@@ -213,7 +224,7 @@ export class PgDaemonRepo implements DaemonRepo {
       // A sharing change is a human edit — advance the last-modified audit
       // (editor stamped when known; absent under devAuth ⇒ leave it unchanged).
       const daemon = await tx.daemon.update({
-        where: { id: daemonId },
+        where: { id: daemonId, orgId },
         data: {
           visibility: sharing.visibility,
           sharedWith: memberships.sharedWith ?? [],
@@ -226,10 +237,12 @@ export class PgDaemonRepo implements DaemonRepo {
     })
   }
 
-  async delete(daemonId: DaemonId): Promise<void> {
+  async delete(orgId: OrgId, daemonId: DaemonId): Promise<void> {
     // One DELETE; the DB FKs cascade api-keys/leases/launches/runtime-profiles and
-    // SET NULL agents/assignments (§3.3). Throws P2025 if absent → 404 at the edge.
-    await this.db.daemon.delete({ where: { id: daemonId } })
+    // SET NULL agents/assignments (§3.3). Throws P2025 if absent → 404 at the edge;
+    // the org fence rides the same statement, so a cross-org id is refused with
+    // exactly that error (org-scoped-data-layer.md §3).
+    await this.db.daemon.delete({ where: { id: daemonId, orgId } })
   }
 
   async bumpRoutingEpoch(daemonId: DaemonId): Promise<bigint> {
@@ -250,7 +263,14 @@ export class PgDaemonRepo implements DaemonRepo {
     return rows.map(toRecord)
   }
 
-  async get(daemonId: DaemonId): Promise<DaemonRecord | null> {
+  async get(orgId: OrgId, daemonId: DaemonId): Promise<DaemonRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const d = await this.db.daemon.findUnique({ where: { id: daemonId, orgId }, include: withUsers })
+    return d ? toRecord(d) : null
+  }
+
+  async getUnscoped(daemonId: DaemonId): Promise<DaemonRecord | null> {
     const d = await this.db.daemon.findUnique({ where: { id: daemonId }, include: withUsers })
     return d ? toRecord(d) : null
   }

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -12,7 +12,7 @@
 import type { Platform, FeishuRegion } from '@agentconnect.md/protocol'
 import type { Bot, Integration, IntegrationChannel, User } from '../../generated/prisma/client.js'
 import { withAmbientTx, type PrismaLike } from '../prisma.js'
-import { BotExternalIdentityTaken, BotStillShared } from '../errors.js'
+import { BotExternalIdentityTaken, BotMissing, BotStillShared } from '../errors.js'
 import type {
   BotRepo,
   BotIdentityProjector,
@@ -157,7 +157,14 @@ export class PgBotRepo implements BotRepo {
     }
   }
 
-  async get(id: BotId): Promise<BotRecord | null> {
+  async get(orgId: OrgId, id: BotId): Promise<BotRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const b = await this.db.bot.findUnique({ where: { id, orgId }, include: botInclude })
+    return b ? toBotRecord(b) : null
+  }
+
+  async getUnscoped(id: BotId): Promise<BotRecord | null> {
     const b = await this.db.bot.findUnique({ where: { id }, include: botInclude })
     return b ? toBotRecord(b) : null
   }
@@ -167,9 +174,17 @@ export class PgBotRepo implements BotRepo {
     return rows.map(toBotRecord)
   }
 
-  async setWorkspaceMetadata(id: BotId, workspaceId: string, workspaceName: string | null): Promise<void> {
+  async setWorkspaceMetadata(
+    orgId: OrgId,
+    id: BotId,
+    workspaceId: string,
+    workspaceName: string | null
+  ): Promise<void> {
+    // Org fence rides the unique update (extended where): a cross-org id throws
+    // the same P2025 as a missing row (org-scoped-data-layer.md §3), preserving
+    // this method's existing missing-row behaviour rather than inventing a new one.
     await this.db.bot.update({
-      where: { id },
+      where: { id, orgId },
       data: {
         workspaceId,
         ...(workspaceName ? { workspaceName } : {})
@@ -213,23 +228,31 @@ export class PgBotRepo implements BotRepo {
     return result.count === 1
   }
 
-  async markFreed(id: BotId, at: Date, lastAgentName: string | null): Promise<void> {
-    await this.db.bot.update({ where: { id }, data: { lastUsedAt: at, lastAgentName } })
+  async markFreed(orgId: OrgId, id: BotId, at: Date, lastAgentName: string | null): Promise<void> {
+    // Org-fenced like `setWorkspaceMetadata`: cross-org and missing are the same P2025.
+    await this.db.bot.update({ where: { id, orgId }, data: { lastUsedAt: at, lastAgentName } })
   }
 
-  async setShareable(id: BotId, shareable: boolean): Promise<void> {
+  async setShareable(orgId: OrgId, id: BotId, shareable: boolean): Promise<void> {
     // Serialized on the bot row: membership admission (addBotMembership) takes
     // the same lock, so a disable can never commit alongside a concurrent
     // second-agent admission — whichever wins, the loser observes the winner's
     // committed state. The capacity recount lives HERE (not only in the route's
     // optimistic pre-check) because only under the lock is it authoritative.
     await withAmbientTx(this.db, async (tx) => {
-      await tx.$queryRaw`SELECT id FROM bot WHERE id = ${id} FOR UPDATE`
+      // The org fence rides the row-lock read and refuses BEFORE the recount:
+      // reaching the recount with a foreign id would answer `BotStillShared`
+      // (a 409 carrying the foreign bot's occupancy) instead of the missing-row
+      // 404 the tenancy fence owes (org-scoped-data-layer.md §3).
+      const locked = await tx.$queryRaw<
+        { id: string }[]
+      >`SELECT id FROM bot WHERE id = ${id} AND "orgId" = ${orgId} FOR UPDATE`
+      if (locked.length === 0) throw new BotMissing(id)
       if (!shareable) {
         const active = await tx.integration.count({ where: { botId: id, status: 'active' } })
         if (active > 1) throw new BotStillShared(active)
       }
-      await tx.bot.update({ where: { id }, data: { shareable } })
+      await tx.bot.update({ where: { id, orgId }, data: { shareable } })
     })
   }
 
@@ -299,8 +322,10 @@ export class PgBotRepo implements BotRepo {
     return count > 0
   }
 
-  async delete(id: BotId): Promise<void> {
-    await this.db.bot.delete({ where: { id } }) // FK cascade drops bot_secret; Restrict blocks while installed
+  async delete(orgId: OrgId, id: BotId): Promise<void> {
+    // Org-fenced delete: FK cascade drops bot_secret, Restrict blocks while
+    // installed, and a cross-org id throws the same P2025 as an absent row.
+    await this.db.bot.delete({ where: { id, orgId } })
   }
 }
 

--- a/packages/control-plane/src/platforms/feishu/provider.test.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.test.ts
@@ -532,7 +532,7 @@ async function liveAssignFrame(botRow: BotRecord, secret: BotSecretMaterial): Pr
   const relayReg = new RelayRegistry()
   relayReg.add(ch)
   const integration: IntegrationRecord = { ...INTEGRATION, botId: botRow.id }
-  const bots = { get: async () => botRow, listHttpActive: async () => [botRow] }
+  const bots = { getUnscoped: async () => botRow, listHttpActive: async () => [botRow] }
   const orch = new HttpBotOrchestrator(
     bots as unknown as BotRepo,
     { get: async () => secret } as unknown as BotSecretStore,

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -571,7 +571,7 @@ async function liveAssignFrame(botRow: BotRecord, secret: BotSecretMaterial): Pr
   const relayReg = new RelayRegistry()
   relayReg.add(ch)
   const integration: IntegrationRecord = { ...INTEGRATION, platform: botRow.platform, botId: botRow.id }
-  const bots = { get: async () => botRow, listHttpActive: async () => [botRow] }
+  const bots = { getUnscoped: async () => botRow, listHttpActive: async () => [botRow] }
   const orch = new HttpBotOrchestrator(
     bots as unknown as BotRepo,
     { get: async () => secret } as unknown as BotSecretStore,

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -91,8 +91,12 @@ export interface UserKeyPrincipal {
 export interface ApiKeyAdmin {
   /** Provision a new daemon (provisioned row + first key) in `orgId` — the onboarding flow. */
   provisionDaemon(opts: { orgId: string; createdByUserId?: string }): Promise<ProvisionedDaemon>
-  /** Mint an additional key for an existing daemon (rotate / regenerate). */
-  mintForDaemon(daemonId: DaemonId, opts?: { createdByUserId?: string }): Promise<MintedKeyView>
+  /** Mint an additional key for an existing daemon (rotate / regenerate).
+   *  Org-fenced (docs/designs/org-scoped-data-layer.md §3): the daemon is
+   *  resolved inside `orgId`, so minting an enrolment credential for another
+   *  organization's daemon fails as a missing row rather than relying on the
+   *  route's pre-check. */
+  mintForDaemon(orgId: OrgId, daemonId: DaemonId, opts?: { createdByUserId?: string }): Promise<MintedKeyView>
   /** Mint a relay key (`principalType='relay'`, org-less deployment infra, non-expiring)
    *  — the per-relay `rc/auth` `method:'apikey'` credential (shared-bot-relay.md §8).
    *  Plaintext is returned exactly once; minting a relay key is granting relay trust. */
@@ -258,25 +262,41 @@ export interface DaemonRegistry {
   ): Promise<void>
   markUnreachable(daemonId: DaemonId): Promise<void>
   /** Set the console-assigned display name; returns the updated read-model row.
-   *  `byUserId` is the editing WebUI principal → stamps last-modified audit. */
-  rename(daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonView>
+   *  `byUserId` is the editing WebUI principal → stamps last-modified audit.
+   *  Org-fenced in the repository (docs/designs/org-scoped-data-layer.md §3). */
+  rename(orgId: OrgId, daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonView>
   /** Set the console's finished-session retention window ("Expire sessions");
-   *  returns the updated read-model row. `byUserId` stamps the last-modified audit. */
-  setSessionRetention(daemonId: DaemonId, sessionRetention: string, byUserId?: string): Promise<DaemonView>
+   *  returns the updated read-model row. `byUserId` stamps the last-modified audit.
+   *  Org-fenced like {@link DaemonRegistry.rename}. */
+  setSessionRetention(
+    orgId: OrgId,
+    daemonId: DaemonId,
+    sessionRetention: string,
+    byUserId?: string
+  ): Promise<DaemonView>
   /** Set the daemon's visibility + share set (the dedicated `/sharing` write path);
-   *  returns the updated read-model row. `byUserId` stamps the last-modified audit. */
+   *  returns the updated read-model row. `byUserId` stamps the last-modified audit.
+   *  Org-fenced like {@link DaemonRegistry.rename}. */
   setSharing(
+    orgId: OrgId,
     daemonId: DaemonId,
     sharing: { visibility: ResourceVisibility; sharedWith: string[] },
     byUserId?: string
   ): Promise<DaemonView>
-  /** Hard-delete a daemon from the fleet (DELETE /daemons/:id). Throws if absent. */
-  remove(daemonId: DaemonId): Promise<void>
+  /** Hard-delete a daemon from the fleet (DELETE /daemons/:id). Org-fenced:
+   *  throws for an absent row and for a cross-org id alike. */
+  remove(orgId: OrgId, daemonId: DaemonId): Promise<void>
   /** The org's fleet (console read model). Every supplied human principal filters
    *  out restricted daemons they cannot see; undefined keeps internal reads unfiltered. */
   list(orgId: OrgId, viewer?: ViewCtx): Promise<DaemonView[]>
-  /** One daemon (org checks on rename/delete/keys); null when absent. */
-  get(daemonId: DaemonId): Promise<DaemonView | null>
+  /** One daemon of `orgId` (the read behind rename/delete/keys); null when absent
+   *  OR when the id belongs to another organization — the two are deliberately
+   *  indistinguishable (org-scoped-data-layer.md §3). */
+  get(orgId: OrgId, daemonId: DaemonId): Promise<DaemonView | null>
+  /** Tenancy-UNSCOPED read model for internal trust domains: WS handlers reading
+   *  their own connection's daemon, and daemon-derived platform capability
+   *  checks. Never call this from the HTTP surface; lint enforces it (§6). */
+  getUnscoped(daemonId: DaemonId): Promise<DaemonView | null>
 }
 
 /**

--- a/packages/control-plane/src/registry/apiKeyService.ts
+++ b/packages/control-plane/src/registry/apiKeyService.ts
@@ -57,15 +57,20 @@ export class ApiKeyService implements ApiKeyAdmin {
     const daemonId = DaemonId(randomUUID())
     // Insert the provisioned row FIRST so the ApiKey FK has a parent (§4.1).
     await this.daemons.provision(daemonId, orgId, opts.createdByUserId)
-    const minted = await this.mintForDaemon(daemonId, opts)
+    const minted = await this.mintForDaemon(orgId, daemonId, opts)
     return { daemonId, ...minted }
   }
 
-  async mintForDaemon(daemonId: DaemonId, opts: { createdByUserId?: string } = {}): Promise<MintedKeyView> {
+  async mintForDaemon(
+    orgId: OrgId,
+    daemonId: DaemonId,
+    opts: { createdByUserId?: string } = {}
+  ): Promise<MintedKeyView> {
     // Keys inherit the daemon's org — rotation can't move a daemon across tenants.
-    const daemon = await this.daemons.get(daemonId)
+    // The read is org-fenced (org-scoped-data-layer.md §3), so a daemon outside
+    // the caller's organization is refused here and not only at the route.
+    const daemon = await this.daemons.get(orgId, daemonId)
     if (!daemon) throw Object.assign(new Error('daemon not found'), { code: 'P2025' })
-    const orgId = daemon.orgId
     const minted = this.codec.mint()
     const rec = await this.apiKeys.create({
       principalType: 'daemon',

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -137,7 +137,9 @@ export class DaemonRegistryService implements DaemonRegistry {
     // reconnect / duplicate register between open() and the ACK — NOT our command
     // completing. Leaving it pending prevents a false success (the ACK may still decline).
     if (!op.acceptedAt) return
-    const daemon = await this.daemons.get(daemonId)
+    // Lifecycle settlement runs off the daemon's own connection — the internal
+    // trust domain resolves the row without an org (org-scoped-data-layer.md §4).
+    const daemon = await this.daemons.getUnscoped(daemonId)
     if (!daemon) return
     // Require a re-auth since the command was sent (STRICTLY greater sessionEpoch): a
     // same-epoch duplicate register is the same connection, not the daemon coming back
@@ -175,31 +177,46 @@ export class DaemonRegistryService implements DaemonRegistry {
     await this.daemons.markUnreachable(daemonId, new Date(this.clock.now()))
   }
 
-  async rename(daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonView> {
-    const d = await this.daemons.rename(daemonId, name, byUserId)
+  async rename(orgId: OrgId, daemonId: DaemonId, name: string, byUserId?: string): Promise<DaemonView> {
+    const d = await this.daemons.rename(orgId, daemonId, name, byUserId)
     return toView(d, await this.runtimeProfiles.forDaemon(daemonId))
   }
 
-  async setSessionRetention(daemonId: DaemonId, sessionRetention: string, byUserId?: string): Promise<DaemonView> {
-    const d = await this.daemons.setSessionRetention(daemonId, sessionRetention, byUserId)
+  async setSessionRetention(
+    orgId: OrgId,
+    daemonId: DaemonId,
+    sessionRetention: string,
+    byUserId?: string
+  ): Promise<DaemonView> {
+    const d = await this.daemons.setSessionRetention(orgId, daemonId, sessionRetention, byUserId)
     return toView(d, await this.runtimeProfiles.forDaemon(daemonId))
   }
 
   async setSharing(
+    orgId: OrgId,
     daemonId: DaemonId,
     sharing: { visibility: ResourceVisibility; sharedWith: string[] },
     byUserId?: string
   ): Promise<DaemonView> {
-    const d = await this.daemons.setSharing(daemonId, sharing, byUserId)
+    const d = await this.daemons.setSharing(orgId, daemonId, sharing, byUserId)
     return toView(d, await this.runtimeProfiles.forDaemon(daemonId))
   }
 
-  async remove(daemonId: DaemonId): Promise<void> {
-    await this.daemons.delete(daemonId)
+  async remove(orgId: OrgId, daemonId: DaemonId): Promise<void> {
+    await this.daemons.delete(orgId, daemonId)
   }
 
-  async get(daemonId: DaemonId): Promise<DaemonView | null> {
-    const d = await this.daemons.get(daemonId)
+  /** Org-fenced (org-scoped-data-layer.md §3): the repo read is filtered, so a
+   *  cross-org id yields null exactly like an unknown one. The runtime-profile
+   *  fetch below is reached only after that fence admits the row. */
+  async get(orgId: OrgId, daemonId: DaemonId): Promise<DaemonView | null> {
+    const d = await this.daemons.get(orgId, daemonId)
+    if (!d) return null
+    return toView(d, await this.runtimeProfiles.forDaemon(daemonId))
+  }
+
+  async getUnscoped(daemonId: DaemonId): Promise<DaemonView | null> {
+    const d = await this.daemons.getUnscoped(daemonId)
     if (!d) return null
     return toView(d, await this.runtimeProfiles.forDaemon(daemonId))
   }

--- a/packages/control-plane/src/ws/handlers/channel-agents.test.ts
+++ b/packages/control-plane/src/ws/handlers/channel-agents.test.ts
@@ -143,7 +143,7 @@ function fakeDeps(placedOn: string | null, channelExtra?: ChannelAgentRecord) {
   ])
   return {
     deps: {
-      registry: { get: async () => ({ id: ASKING_DAEMON, orgId: ORG }) },
+      registry: { getUnscoped: async () => ({ id: ASKING_DAEMON, orgId: ORG }) },
       agent: {
         // `orgDirectory` never returns an unplaced row (see PgAgentRepo), so a
         // `placedOn: null` caller is simply absent from it.

--- a/packages/control-plane/src/ws/handlers/channel-agents.ts
+++ b/packages/control-plane/src/ws/handlers/channel-agents.ts
@@ -72,7 +72,9 @@ export const handleChannelAgents: Handler = async (frame, conn, deps) => {
   if (!isFrame('channel/agents')(frame)) return
   const { platform, channel, requesterAgentId } = frame.payload
 
-  const daemon = await deps.registry.get(DaemonId(conn.daemonId))
+  // Daemon trust domain: the connection's own daemon, resolved without an org
+  // (org-scoped-data-layer.md §4).
+  const daemon = await deps.registry.getUnscoped(DaemonId(conn.daemonId))
   if (!daemon) return // unknown daemon (should not happen post-auth) — drop silently
 
   const roster: ChannelAgentRecord[] = await (async () => {

--- a/packages/control-plane/src/ws/handlers/child-session-status.test.ts
+++ b/packages/control-plane/src/ws/handlers/child-session-status.test.ts
@@ -59,7 +59,7 @@ function fakeDeps(
       : { daemonId: OWNING_DAEMON, reachable: true, sessionEpoch: 7, conn: { request } }
   return {
     deps: {
-      registry: { get: async () => ({ id: ASKING_DAEMON, orgId: ORG }) },
+      registry: { getUnscoped: async () => ({ id: ASKING_DAEMON, orgId: ORG }) },
       session: {
         get: async () =>
           'parent' in over ? over.parent : { id: PARENT_SESSION, daemonId: ASKING_DAEMON, agentId: CHILD_AGENT }

--- a/packages/control-plane/src/ws/handlers/child-session-status.ts
+++ b/packages/control-plane/src/ws/handlers/child-session-status.ts
@@ -33,7 +33,8 @@ export const handleChildSessionStatus: Handler = async (frame, conn, deps) => {
   if (!isFrame('session/child-status')(frame)) return
   const { parentSessionId, childSessionId, childAgentId } = frame.payload
 
-  const daemon = await deps.registry.get(DaemonId(conn.daemonId))
+  // Daemon trust domain: the connection's own daemon (org-scoped-data-layer.md §4).
+  const daemon = await deps.registry.getUnscoped(DaemonId(conn.daemonId))
   if (!daemon) return // unknown daemon (should not happen post-auth) — drop silently
 
   // (a) Prove the asking daemon owns the parent session it is asking AS. `daemonId` on the session

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -220,7 +220,7 @@ describe('handleEventSession', () => {
         })
       },
       bot: {
-        get: vi.fn().mockResolvedValue({
+        getUnscoped: vi.fn().mockResolvedValue({
           id: BOT_ID,
           orgId: 'org-1',
           platform: 'slack',
@@ -276,7 +276,7 @@ describe('handleEventSession', () => {
         })
       },
       bot: {
-        get: vi.fn().mockResolvedValue({
+        getUnscoped: vi.fn().mockResolvedValue({
           id: BOT_ID,
           orgId: 'org-1',
           platform: 'feishu',
@@ -334,7 +334,7 @@ describe('handleEventSession', () => {
         })
       },
       bot: {
-        get: vi.fn().mockResolvedValue({
+        getUnscoped: vi.fn().mockResolvedValue({
           id: BOT_ID,
           orgId: 'org-1',
           platform: 'feishu',
@@ -428,7 +428,7 @@ describe('handleEventSession', () => {
         })
       },
       bot: {
-        get: vi.fn().mockResolvedValue({
+        getUnscoped: vi.fn().mockResolvedValue({
           id: BOT_ID,
           orgId: 'org-1',
           platform: 'slack',

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -124,7 +124,9 @@ async function externalCandidate(p: EventSession, agentId: AgentId, deps: Daemon
   ) {
     return { provider: origin.provider, resolution: 'invalid' as const }
   }
-  const bot = await deps.bot?.get(BotId(integration.botId))
+  // Daemon trust domain: the bot behind an integration row this resolver already
+  // matched against the reporting agent (org-scoped-data-layer.md §4).
+  const bot = await deps.bot?.getUnscoped(BotId(integration.botId))
   const feishuRegion = bot?.platform === 'feishu' ? (bot.feishuRegion ?? 'feishu') : undefined
   const feishuAppId = bot?.feishuAppId ?? undefined
   const realmKey =

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.test.ts
@@ -42,7 +42,7 @@ function conn() {
 }
 
 const featureRegistry = {
-  get: async () => ({
+  getUnscoped: async () => ({
     id: DAEMON,
     orgId: ORG,
     capabilities: { features: [ORGANIZATION_KNOWLEDGE_FEATURE, ORGANIZATION_SUGGESTION_REVIEW_FEATURE] }
@@ -354,7 +354,7 @@ describe('handleOrganizationSuggestionsSync', () => {
     ])
     const deps = {
       registry: {
-        get: async () => ({
+        getUnscoped: async () => ({
           id: DAEMON,
           orgId: ORG,
           capabilities: { features: [ORGANIZATION_KNOWLEDGE_FEATURE] }
@@ -460,7 +460,7 @@ describe('handleManagedSkillRead', () => {
   it('refuses organization frames from a daemon that omitted the feature', async () => {
     const searchKnowledge = vi.fn()
     const deps = {
-      registry: { get: async () => ({ id: DAEMON, orgId: ORG, capabilities: { features: [] } }) },
+      registry: { getUnscoped: async () => ({ id: DAEMON, orgId: ORG, capabilities: { features: [] } }) },
       agent: { getUnscoped: vi.fn() },
       organizationKnowledge: { searchKnowledge }
     } as unknown as DaemonWsDeps

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.ts
@@ -12,7 +12,8 @@ async function featureDaemon(
   conn: Parameters<Handler>[1],
   deps: Parameters<Handler>[2]
 ): Promise<DaemonView | null> {
-  const daemon = await deps.registry.get(DaemonId(conn.daemonId))
+  // Daemon trust domain: the connection's own daemon (org-scoped-data-layer.md §4).
+  const daemon = await deps.registry.getUnscoped(DaemonId(conn.daemonId))
   if (!daemon || !daemon.capabilities.features.includes(ORGANIZATION_KNOWLEDGE_FEATURE)) {
     conn.sendError(frameId, 'SCOPE_DENIED', 'daemon did not advertise organization knowledge support', false)
     return null

--- a/packages/control-plane/test/fakes/build-app.ts
+++ b/packages/control-plane/test/fakes/build-app.ts
@@ -153,7 +153,7 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
     },
     mintToken: async (daemonId: string) => {
       const org = OrgId(DEFAULT_ORG_ID)
-      if (!(await repos.daemon.get(DaemonId(daemonId)))) await repos.daemon.provision(DaemonId(daemonId), org)
+      if (!(await repos.daemon.getUnscoped(DaemonId(daemonId)))) await repos.daemon.provision(DaemonId(daemonId), org)
       const minted = codec.mint()
       await repos.apiKey.create({
         principalType: 'daemon',

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -209,7 +209,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     clock,
     codec,
     mintToken: async (daemonId: string) => {
-      if (!(await repos.daemon.get(DaemonId(daemonId)))) await repos.daemon.provision(DaemonId(daemonId), org)
+      if (!(await repos.daemon.getUnscoped(DaemonId(daemonId)))) await repos.daemon.provision(DaemonId(daemonId), org)
       const minted = codec.mint()
       await repos.apiKey.create({
         principalType: 'daemon',

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -14,11 +14,13 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedAgent } from '../fixtures/seed.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
-import { AgentMissing } from '../../src/persistence/errors.js'
-import { AgentId, OrgId } from '../../src/domain/ids.js'
+import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
+import { PgBotRepo } from '../../src/persistence/repositories/integration.repo.js'
+import { AgentMissing, BotMissing } from '../../src/persistence/errors.js'
+import { AgentId, BotId, DaemonId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -28,6 +30,10 @@ let running: HttpApp | undefined
 let foreignOrgId: string
 let foreignAgentId: string
 let ownAgentId: string
+let foreignDaemonId: string
+let ownDaemonId: string
+let foreignBotId: string
+let ownBotId: string
 
 afterEach(async () => {
   await running?.close()
@@ -44,6 +50,38 @@ beforeEach(async () => {
   await prisma.agent.create({
     data: { id: foreignAgentId, orgId: foreignOrgId, name: 'foreign-bot', runtime: 'claude' }
   })
+
+  // The same two-org shape for the daemon fleet and the bot directory.
+  ownDaemonId = randomUUID()
+  await seedDaemon(prisma, ownDaemonId)
+  foreignDaemonId = randomUUID()
+  await prisma.daemon.create({
+    data: {
+      id: foreignDaemonId,
+      orgId: foreignOrgId,
+      name: 'foreign-daemon',
+      sessionEpoch: 1n,
+      status: 'ready',
+      // Deliberately off the column default, so the PATCH below (which sends the
+      // default) would be observable if the fence ever let it through.
+      sessionRetention: '30d'
+    }
+  })
+  ownBotId = randomUUID()
+  await prisma.bot.create({
+    data: { id: ownBotId, orgId: DEFAULT_ORG_ID, platform: 'slack', name: 'own-slack-bot' }
+  })
+  foreignBotId = randomUUID()
+  await prisma.bot.create({
+    data: {
+      id: foreignBotId,
+      orgId: foreignOrgId,
+      platform: 'slack',
+      name: 'foreign-slack-bot',
+      transport: 'http',
+      slackAppId: `A${randomUUID().replace(/-/g, '').slice(0, 9).toUpperCase()}`
+    }
+  })
 })
 
 function build(): HttpApp {
@@ -57,6 +95,23 @@ async function foreignRowUnmodified(): Promise<void> {
   expect(row).not.toBeNull()
   expect(row!.orgId).toBe(foreignOrgId)
   expect(row!.name).toBe('foreign-bot')
+}
+
+async function foreignDaemonUnmodified(): Promise<void> {
+  const row = await prisma.daemon.findUnique({ where: { id: foreignDaemonId } })
+  expect(row).not.toBeNull()
+  expect(row!.orgId).toBe(foreignOrgId)
+  expect(row!.name).toBe('foreign-daemon')
+  expect(row!.visibility).toBe('org')
+  expect(row!.sessionRetention).toBe('30d')
+}
+
+async function foreignBotUnmodified(): Promise<void> {
+  const row = await prisma.bot.findUnique({ where: { id: foreignBotId } })
+  expect(row).not.toBeNull()
+  expect(row!.orgId).toBe(foreignOrgId)
+  expect(row!.name).toBe('foreign-slack-bot')
+  expect(row!.shareable).toBe(false)
 }
 
 describe('tenant isolation — Agent over the REST surface', () => {
@@ -160,5 +215,148 @@ describe('tenant isolation — AgentRepo fences under the routes', () => {
     // The unscoped read is the internal-trust-domain escape hatch — it does
     // resolve the row, which is exactly why lint keeps it off the HTTP surface.
     expect(await repo.getUnscoped(AgentId(foreignAgentId))).not.toBeNull()
+  })
+})
+
+describe('tenant isolation — Daemon over the REST surface', () => {
+  it('point-GET of a foreign daemon id reads as absent (404)', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/daemons/${foreignDaemonId}` })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('PATCH of a foreign daemon id is 404 and provably writes nothing', async () => {
+    const app = build()
+    const res = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/daemons/${foreignDaemonId}`,
+      payload: { name: 'hijacked', sessionRetention: '7d' }
+    })
+    expect(res.statusCode).toBe(404)
+    await foreignDaemonUnmodified()
+  })
+
+  it('DELETE of a foreign daemon id is 404 and the row survives', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'DELETE', url: `${ORG}/daemons/${foreignDaemonId}` })
+    expect(res.statusCode).toBe(404)
+    await foreignDaemonUnmodified()
+  })
+
+  it('a sharing write on a foreign daemon id is 404 and writes nothing', async () => {
+    const app = build()
+    const res = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/daemons/${foreignDaemonId}/sharing`,
+      payload: { visibility: 'restricted', sharedWith: [] }
+    })
+    expect(res.statusCode).toBe(404)
+    await foreignDaemonUnmodified()
+  })
+
+  it('a foreign daemon mints no enrolment credential — its key surface reads as absent', async () => {
+    const app = build()
+    const list = await app.app.inject({ method: 'GET', url: `${ORG}/daemons/${foreignDaemonId}/keys` })
+    expect(list.statusCode).toBe(404)
+    const mint = await app.app.inject({ method: 'POST', url: `${ORG}/daemons/${foreignDaemonId}/keys` })
+    expect(mint.statusCode).toBe(404)
+    expect(await prisma.apiKey.count({ where: { daemonId: foreignDaemonId } })).toBe(0)
+  })
+
+  it('the daemons list never contains a foreign row', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/daemons` })
+    expect(res.statusCode).toBe(200)
+    const ids = (res.json() as Array<{ daemonId: string }>).map((d) => d.daemonId)
+    expect(ids).toContain(ownDaemonId)
+    expect(ids).not.toContain(foreignDaemonId)
+  })
+})
+
+describe('tenant isolation — Bot over the REST surface', () => {
+  it('point-GET of a foreign bot id reads as absent (404)', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/bots/${foreignBotId}` })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('PATCH of a foreign bot id is 404 and the shareable flag is untouched', async () => {
+    const app = build()
+    const res = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/bots/${foreignBotId}`,
+      payload: { shareable: true }
+    })
+    expect(res.statusCode).toBe(404)
+    await foreignBotUnmodified()
+  })
+
+  it('DELETE of a foreign bot id is 404 and the row survives', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'DELETE', url: `${ORG}/bots/${foreignBotId}` })
+    expect(res.statusCode).toBe(404)
+    await foreignBotUnmodified()
+  })
+
+  it('the Slack refresh action on a foreign bot id is 404', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${foreignBotId}/slack/refresh` })
+    expect(res.statusCode).toBe(404)
+    await foreignBotUnmodified()
+  })
+
+  it('the bots list never contains a foreign row', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/bots` })
+    expect(res.statusCode).toBe(200)
+    const ids = (res.json() as Array<{ id: string }>).map((b) => b.id)
+    expect(ids).toContain(ownBotId)
+    expect(ids).not.toContain(foreignBotId)
+  })
+})
+
+describe('tenant isolation — DaemonRepo and BotRepo fences under the routes', () => {
+  it('daemon reads and mutations treat a cross-org id exactly like a missing row', async () => {
+    const repo = new PgDaemonRepo(prisma)
+
+    expect(await repo.get(CALLER_ORG, DaemonId(foreignDaemonId))).toBeNull()
+    expect(await repo.get(CALLER_ORG, DaemonId(randomUUID()))).toBeNull()
+    expect(await repo.get(CALLER_ORG, DaemonId(ownDaemonId))).not.toBeNull()
+
+    // Every throw-shaped mutation keeps its missing-row error for a foreign id.
+    await expect(repo.rename(CALLER_ORG, DaemonId(foreignDaemonId), 'hijacked')).rejects.toThrow()
+    await expect(repo.setSessionRetention(CALLER_ORG, DaemonId(foreignDaemonId), '7d')).rejects.toThrow()
+    await expect(
+      repo.setSharing(CALLER_ORG, DaemonId(foreignDaemonId), { visibility: 'restricted', sharedWith: [] })
+    ).rejects.toThrow()
+    await expect(repo.delete(CALLER_ORG, DaemonId(foreignDaemonId))).rejects.toThrow()
+
+    await foreignDaemonUnmodified()
+
+    // The unscoped read is the internal-trust-domain escape hatch (WS handlers
+    // resolve their own connection's daemon) — lint keeps it off the HTTP surface.
+    expect(await repo.getUnscoped(DaemonId(foreignDaemonId))).not.toBeNull()
+  })
+
+  it('bot reads and mutations treat a cross-org id exactly like a missing row', async () => {
+    const repo = new PgBotRepo(prisma)
+
+    expect(await repo.get(CALLER_ORG, BotId(foreignBotId))).toBeNull()
+    expect(await repo.get(CALLER_ORG, BotId(randomUUID()))).toBeNull()
+    expect(await repo.get(CALLER_ORG, BotId(ownBotId))).not.toBeNull()
+
+    // setShareable refuses at the row-lock read, BEFORE the install recount that
+    // would otherwise answer BotStillShared and disclose a foreign bot's occupancy.
+    await expect(repo.setShareable(CALLER_ORG, BotId(foreignBotId), true)).rejects.toBeInstanceOf(BotMissing)
+    await expect(repo.markFreed(CALLER_ORG, BotId(foreignBotId), new Date(), 'hijacked')).rejects.toThrow()
+    await expect(repo.setWorkspaceMetadata(CALLER_ORG, BotId(foreignBotId), 'THIJACK', 'Hijacked')).rejects.toThrow()
+    await expect(repo.delete(CALLER_ORG, BotId(foreignBotId))).rejects.toThrow()
+
+    await foreignBotUnmodified()
+    expect((await prisma.bot.findUnique({ where: { id: foreignBotId } }))!.workspaceId).toBeNull()
+
+    // The unscoped read is the orchestration escape hatch (relay convergence
+    // resolves a bot by the id relay ingress reported).
+    expect(await repo.getUnscoped(BotId(foreignBotId))).not.toBeNull()
   })
 })

--- a/packages/control-plane/test/protocol/auth.handler.test.ts
+++ b/packages/control-plane/test/protocol/auth.handler.test.ts
@@ -61,7 +61,7 @@ describe('auth handler — valid key mints next epoch; invalid key closes 4401',
     expect(stub.closed).toBeUndefined()
 
     // Persisted epoch advanced to 2.
-    const row = await repo.get(DaemonId(DAEMON))
+    const row = await repo.getUnscoped(DaemonId(DAEMON))
     expect(row?.sessionEpoch).toBe(2n)
   })
 
@@ -90,7 +90,7 @@ describe('auth handler — valid key mints next epoch; invalid key closes 4401',
     expect(stub.lastSent('auth/ok')).toBeUndefined()
 
     // Crucially: the epoch did NOT bump (still 1).
-    const row = await repo.get(DaemonId(DAEMON))
+    const row = await repo.getUnscoped(DaemonId(DAEMON))
     expect(row?.sessionEpoch).toBe(1n)
   })
 
@@ -110,7 +110,7 @@ describe('auth handler — valid key mints next epoch; invalid key closes 4401',
       if (!stub.closed) throw new Error('not closed yet')
     })
     expect(stub.closed?.code).toBe(4401)
-    expect(await repo.get(DaemonId(DAEMON))).toBeNull() // never created
+    expect(await repo.getUnscoped(DaemonId(DAEMON))).toBeNull() // never created
   })
 
   it("key-only auth (no daemonId in the frame) → auth/ok with daemonId = the key's daemon", async () => {
@@ -131,7 +131,7 @@ describe('auth handler — valid key mints next epoch; invalid key closes 4401',
     expect(stub.closed).toBeUndefined()
 
     // The daemon row keeps the key's daemonId; first auth advanced epoch 0 → 1.
-    const row = await repo.get(DaemonId(DAEMON))
+    const row = await repo.getUnscoped(DaemonId(DAEMON))
     expect(row?.sessionEpoch).toBe(1n)
   })
 })

--- a/packages/control-plane/test/repo/daemon.repo.test.ts
+++ b/packages/control-plane/test/repo/daemon.repo.test.ts
@@ -42,11 +42,11 @@ describe('DaemonRepo.upsertOnAuth — monotonic sessionEpoch (real Postgres)', (
   it('first auth creates the row; the row persists with the latest epoch', async () => {
     const repo = new PgDaemonRepo(prisma)
 
-    expect(await repo.get(DaemonId(DAEMON_A))).toBeNull()
+    expect(await repo.getUnscoped(DaemonId(DAEMON_A))).toBeNull()
     await repo.upsertOnAuth(authInput(DAEMON_A))
     await repo.upsertOnAuth(authInput(DAEMON_A))
 
-    const got = await repo.get(DaemonId(DAEMON_A))
+    const got = await repo.getUnscoped(DaemonId(DAEMON_A))
     expect(got).not.toBeNull()
     expect(got?.sessionEpoch).toBe(2n)
   })


### PR DESCRIPTION
Second batch of the org-scoped data-layer rollout
(`docs/designs/org-scoped-data-layer.md` §7 M2), applying the M1 `AgentRepo`
recipe to `DaemonRepo` and `BotRepo`: point reads and mutations take `orgId`
first and the repository fences the query itself, so a cross-org id is
observably identical to a missing row.

## Migrated methods

### `DaemonRepo`

| Method | New shape | Why |
| --- | --- | --- |
| `get(id)` | `get(orgId, id)` + `getUnscoped(id)` | org filter rides the unique lookup |
| `rename(id, …)` | `rename(orgId, id, …)` | fence on the update's `where` (P2025 → 404) |
| `setSessionRetention(id, …)` | `setSessionRetention(orgId, id, …)` | same |
| `setSharing(id, …)` | `setSharing(orgId, id, …)` | fence on the transaction's opening row read, before the membership lock |
| `delete(id)` | `delete(orgId, id)` | fence rides the DELETE |
| `provision`, `upsertOnAuth`, `applyRegister`, `setCapabilities`, `setMcpServers`, `touchHeartbeat`, `markUnreachable` | unchanged | already org-carrying, or the daemon-connection trust domain (§4) |
| `bumpRoutingEpoch`, `findReassignable`, `list` | unchanged | system-tier: orchestrator-driven / deliberately fleet-wide worklists / already `list(orgId, viewer?)` |

The console never touches `DaemonRepo` directly — it goes through the C4
`DaemonRegistry` service — so `rename` / `setSessionRetention` / `setSharing` /
`remove` / `get` on that port take the org too, plus a `getUnscoped` for the WS
handlers. `ApiKeyAdmin.mintForDaemon` gains the same leading `orgId`: it is
addressed by daemon id from the HTTP surface, and re-deriving the org from an
unscoped read of the row it is about to mint a credential for is exactly the
one-line failure mode this design removes.

### `BotRepo`

| Method | New shape | Why |
| --- | --- | --- |
| `get(id)` | `get(orgId, id)` + `getUnscoped(id)` | org filter rides the unique lookup |
| `setWorkspaceMetadata(id, …)` | `setWorkspaceMetadata(orgId, id, …)` | fence on the update's `where`; keeps its existing missing-row error |
| `markFreed(id, …)` | `markFreed(orgId, id, …)` | same |
| `setShareable(id, …)` | `setShareable(orgId, id, …)` | fence on the row-lock read, **before** the install recount |
| `delete(id)` | `delete(orgId, id)` | fence rides the DELETE |
| `create`, `listForOrg` | unchanged | already org-carrying |
| `listSlackMissingIdentity`, `listHttpActive` | unchanged | system-tier: fleet-wide reconciler / orchestrator worklists |
| `setSlackAppIdIfMissing`, `setSlackBotUserIdIfMissing` | unchanged | system-tier (§3.4): reconciler-only, driven off `listSlackMissingIdentity` and fenced by their own `IS NULL` CAS predicate — an org re-derived from that worklist would be tautological |
| `getBySlackAppTeam`, `getByExternalIdentity` | unchanged | deliberately CROSS-ORG lookups by the global demux key; a second org's claim must find the row to refuse it |
| `bumpCredential`, `revokeIfCurrent` | unchanged | system-tier: reached only through `BotCredentialWriter`, and `revokeIfCurrent` is already fenced by the credential-generation CAS — a stronger axis than the owning org |

`setShareable` is the one method that needed a new typed error. Its fence cannot
ride the write's `where`, because the `active > 1` recount runs first: a foreign
id reaching that recount would answer `BotStillShared` — a 409 carrying another
organization's bot occupancy — instead of the 404 the tenancy fence owes. It now
refuses at the row-lock read with `BotMissing`, whose code is registered in the
`http/server.ts` not-found mapping alongside `AGENT_MISSING`.

## Caller classification

- **Route handlers** thread `orgOf(req)` (or `orgIdOf(req)` where the file
  already uses that local helper), and their now-dead `row.orgId !== req.orgCtx!.orgId`
  comparisons are deleted. `canView` / `canEdit` / `canManageSharing` stay — the
  seam is tenancy only (§8).
- **Helpers without a request** use the `.orgId` of the already-fenced record in
  hand (`sandboxPolicyFor`, `replicateUpsert`, `admitChannelAction`), or gained an
  `orgId` parameter (`requireSessionWorkspaceRead`, `onCompatibleDaemon`).
- **The unauthenticated Slack platform callback** has no request org context, so
  it reads the tenancy off the pending-install row whose id is the OAuth state —
  the same pattern M1 documented for the agent lookup in that file.
- **`getUnscoped`**: WS handlers resolving their own connection's daemon
  (`channel-agents`, `child-session-status`, `organization-knowledge`), the bot
  behind an integration row in `event-session`, the shared-bot orchestrator
  (`httpBot.ts`, every read), placement/reconcile, `agentMove`, `integrationPush`,
  the dedicated-bot icon converger, and the session external-access resolvers.
  All sit in the §4 orchestration/daemon trust domains; the ESLint fence keeps
  them off `http/routes/**` and `http/mcp/**`.

## Acceptance gate

`test/integration/tenant-isolation.route.test.ts` grows a Daemon block and a Bot
block (§6): point-GET, PATCH, DELETE, sharing, the daemon key surface and the
Slack refresh action against a foreign id all 404 with the foreign row provably
unmodified; neither list contains a foreign row; and repo-level assertions prove
each fenced method treats a cross-org id exactly like a missing row while
`getUnscoped` still resolves it. The daemon fixture is seeded off the column
default so the PATCH would be observable if the fence ever let it through.

Green: full-repo `typecheck` and `lint`, CP `test:unit` (1255) and `test:int` (1007).
