### PR TITLE
docs: align repository authorization vocabulary

### DIFF
--- a/docs/designs/agent-multi-repo-authorization.md
+++ b/docs/designs/agent-multi-repo-authorization.md
@@ -421,7 +421,7 @@ mismatch.
    resumes hook creation.
 3. **Grandfathered out-of-bound hook badge:** if the watched repository is
    outside authorization, show a yellow "write-back unauthorized" badge with a
-   tooltip pointing to Repositories.
+   tooltip pointing to Edit workspace.
 4. Keep mobile branches synchronized.
 5. Scratch conversion needs no prior explicit grant. The picker may select any
    installation-covered repository for which the user has target access.
@@ -443,10 +443,10 @@ authorizing any other repository.
 
 **A. Cross-account repository authorization**
 
-On an agent whose workspace is `acme/primary-service`, open Repositories, add
-`example-co/shared-library` from the installation claimed by the
-organization, choose comment access, attest that the operator has at least read
-access, and persist the row.
+On an agent whose workspace is `acme/primary-service`, open Edit workspace,
+choose "Authorize repository", add `example-co/shared-library` from the
+installation claimed by the organization, choose read access, attest that the
+operator has at least read access, and persist the row.
 
 **B. Hook trigger and write-back**
 
@@ -461,11 +461,13 @@ gitcred/request {
 }
 ```
 
-The Control Plane confirms placement, matches the comment grant, resolves the
-`example-co` installation, and mints a single-repository token with
-contents read, issues write, and pull requests write. The wrapper executes `gh`
-with that token, which reads the issue and comments. **Every invocation fetches
-as needed, with no one-hour stale window.**
+The Control Plane confirms placement, matches the read grant, resolves the
+`example-co` installation, and mints a single-repository token with contents,
+issues, and pull requests read and no actions permission. The wrapper executes
+`gh` with that token, which reads the issue and its existing comments but cannot
+post to either. Any reply uses the separate daemon-owned `github_hook_reply`
+poster token, not this agent-visible grant. **Every invocation fetches as needed,
+with no one-hour stale window.**
 
 **C. Git transport to a secondary repository**
 


### PR DESCRIPTION
## Summary

- Point grandfathered hook guidance to `Edit workspace`.
- Update the cross-account authorization flow to use `Authorize repository` and the current `read` access tier.
- Clarify that read grants mint read-only issue and pull-request permissions, while replies use the separate daemon-owned poster token.

## Why

PR #703 introduced the shared workspace repository-management surface, but its design examples still mixed the retired `Repositories` entry point and `comment` access tier with the new read-only flow. This follow-up keeps the authoritative design internally consistent with the shipped UI and capability clamp.

## Impact

Documentation only; there are no runtime behavior changes.

## Verification

- `pnpm exec prettier --check docs/designs/agent-multi-repo-authorization.md`
- `git diff --check origin/main...HEAD`
- Pre-push `eslint .`

Created by Codex . GPT-5
