### PR TITLE
feat(cp): org-fence the integration, channel, and cron data layers

### DIFF
--- a/packages/control-plane/src/http/install-feishu.ts
+++ b/packages/control-plane/src/http/install-feishu.ts
@@ -44,13 +44,10 @@ export async function installNewFeishuBot(
   const transport = args.transport ?? 'socket'
   const botId = args.botId ?? BotId(randomUUID())
   const id = args.integrationId ?? IntegrationId(randomUUID())
-  let integration = await deps.repos.integration.get(id)
+  let integration = await deps.repos.integration.get(orgId, id)
   if (
     integration &&
-    (integration.orgId !== orgId ||
-      integration.agentId !== agent.id ||
-      integration.botId !== botId ||
-      integration.platform !== 'feishu')
+    (integration.agentId !== agent.id || integration.botId !== botId || integration.platform !== 'feishu')
   ) {
     throw new Error('reserved Feishu integration id is already in use')
   }

--- a/packages/control-plane/src/http/routes/crons.ts
+++ b/packages/control-plane/src/http/routes/crons.ts
@@ -83,8 +83,8 @@ export function cronRoutes(deps: HttpDeps) {
     // cross-org id OR a restricted cron they can't see both read as absent (404).
     // The single insertion point that replaces the scattered inline org checks.
     const getOrgCron = async (req: FastifyRequest, id: string): Promise<CronRecord | null> => {
-      const cron = await deps.repos.cron.get(CronId(id))
-      if (!cron || cron.orgId !== req.orgCtx!.orgId) return null
+      const cron = await deps.repos.cron.get(orgOf(req), CronId(id))
+      if (!cron) return null
       return canView(cron, ctxOf(req)) ? cron : null
     }
 
@@ -127,10 +127,10 @@ export function cronRoutes(deps: HttpDeps) {
         // The UUID is client-minted. On an EDIT (existing row), refuse if it's
         // another org's cron OR one this caller can't see (both 404), and require
         // edit rights (403). A brand-new id falls through to create.
-        const existing = await deps.repos.cron.get(CronId(req.params.id))
+        const existing = await deps.repos.cron.get(orgId, CronId(req.params.id))
         if (existing) {
           const ctx = ctxOf(req)
-          if (existing.orgId !== orgId || !canView(existing, ctx)) {
+          if (!canView(existing, ctx)) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'cron not found' })
           }
           if (!canEdit(existing, ctx)) {
@@ -151,8 +151,8 @@ export function cronRoutes(deps: HttpDeps) {
         let targetIntegrationId: IntegrationId | undefined
         let targetPlatform = req.body.targetPlatform
         if (req.body.targetIntegrationId && req.body.targetChannel) {
-          const integ = await deps.repos.integration.get(IntegrationId(req.body.targetIntegrationId))
-          if (!integ || integ.orgId !== orgId || integ.agentId !== agent.id) {
+          const integ = await deps.repos.integration.get(orgId, IntegrationId(req.body.targetIntegrationId))
+          if (!integ || integ.agentId !== agent.id) {
             return reply.code(400).send({
               error: 'Bad Request',
               statusCode: 400,
@@ -297,7 +297,7 @@ export function cronRoutes(deps: HttpDeps) {
         if (!cron) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'cron not found' })
         }
-        const runs = await deps.repos.cron.listRuns(cron.id)
+        const runs = await deps.repos.cron.listRuns(cron.orgId, cron.id)
         return runs.map((run) => ({
           id: run.id,
           startedAt: run.startedAt.toISOString(),
@@ -433,7 +433,7 @@ export function cronRoutes(deps: HttpDeps) {
             })
           }
           agent = current
-          await deps.repos.cron.remove(existing.id)
+          await deps.repos.cron.remove(orgId, existing.id)
           void deps.repos.audit
             .append({
               kind: 'cron_change',
@@ -510,6 +510,7 @@ export function cronRoutes(deps: HttpDeps) {
           }
           const sharedWith = await resolveShareSet(deps.repos.user, orgOf(req), req.body.sharedWith)
           const cron = await deps.repos.cron.setSharing(
+            orgOf(req),
             CronId(req.params.id),
             { visibility: req.body.visibility, sharedWith },
             req.principal?.userId

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -283,7 +283,7 @@ export function hookRoutes(deps: HttpDeps) {
     // Validate the optional anchoring target against the hook's agent (the
     // anchor posts through one of THAT agent's integrations — cron semantics).
     const resolveTarget = async (
-      orgId: string,
+      orgId: OrgId,
       agentId: string,
       // `DbPlatform` is the served set the anchor may target — the same registry
       // declaration `Platform` (the request body's own enum) and `toDbPlatform`
@@ -295,8 +295,8 @@ export function hookRoutes(deps: HttpDeps) {
       }
     ): Promise<{ ok: true; targetPlatform: DbPlatform; targetIntegrationId?: IntegrationId } | { ok: false }> => {
       if (!(body.targetIntegrationId && body.targetChannel)) return { ok: true, targetPlatform: body.targetPlatform }
-      const integ = await deps.repos.integration.get(IntegrationId(body.targetIntegrationId))
-      if (!integ || integ.orgId !== orgId || integ.agentId !== agentId) return { ok: false }
+      const integ = await deps.repos.integration.get(orgId, IntegrationId(body.targetIntegrationId))
+      if (!integ || integ.agentId !== agentId) return { ok: false }
       return { ok: true, targetPlatform: toDbPlatform(integ.platform), targetIntegrationId: integ.id }
     }
 

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -593,8 +593,8 @@ export function integrationRoutes(deps: HttpDeps) {
       req: { params: { id: string; channelId?: string } },
       reply: FastifyReply
     ): Promise<{ integration: IntegrationRecord; agent: AgentRecord; bot: BotRecord } | null> => {
-      const integration = await deps.repos.integration.get(IntegrationId(req.params.id))
-      if (!integration || integration.orgId !== orgIdOf(req as never)) {
+      const integration = await deps.repos.integration.get(orgIdOf(req as never), IntegrationId(req.params.id))
+      if (!integration) {
         reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'integration not found' })
         return null
       }
@@ -752,8 +752,8 @@ export function integrationRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const integration = await deps.repos.integration.get(IntegrationId(req.params.id))
-        if (!integration || integration.orgId !== orgIdOf(req)) {
+        const integration = await deps.repos.integration.get(orgIdOf(req), IntegrationId(req.params.id))
+        if (!integration) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'integration not found' })
         }
         // Derived visibility: gate on the parent agent — a restricted agent the
@@ -1138,8 +1138,8 @@ export function integrationRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const existing = await deps.repos.integration.get(IntegrationId(req.params.id))
-        if (!existing || existing.orgId !== orgIdOf(req)) {
+        const existing = await deps.repos.integration.get(orgIdOf(req), IntegrationId(req.params.id))
+        if (!existing) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'integration not found' })
         }
         // Derived visibility: gate on the parent agent (a restricted agent the caller
@@ -1173,7 +1173,7 @@ export function integrationRoutes(deps: HttpDeps) {
           if (botBefore?.transport === 'http') {
             await deps.httpBot.prepareIntegrationRemoval(existing.botId)
           }
-          await deps.repos.integration.delete(existing.id)
+          await deps.repos.integration.delete(orgIdOf(req), existing.id)
           // "Freed" now means NO active integration remains (a shareable bot may still
           // serve other agents — don't stamp it freed while it does, §6).
           const remaining = await deps.repos.integration.listForBot(existing.botId)

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -166,7 +166,8 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
       (err as { code?: string }).code === 'P2025' ||
       (err as { code?: string }).code === 'ORG_MEMBERSHIP_MISSING' ||
       (err as { code?: string }).code === 'AGENT_MISSING' ||
-      (err as { code?: string }).code === 'BOT_MISSING'
+      (err as { code?: string }).code === 'BOT_MISSING' ||
+      (err as { code?: string }).code === 'CRON_MISSING'
     ) {
       return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'resource not found' })
     }

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -157,6 +157,21 @@ export class MemoryConnectionMissing extends Error {
 }
 
 /**
+ * Thrown by the org-fenced `CronRepo.upsert` when the client-minted `cronId`
+ * already names a row in ANOTHER organization (docs/designs/org-scoped-data-layer.md
+ * §3). Unlike the other fences this one refuses a TAKEOVER rather than a leak:
+ * the PUT is a create-or-edit, so without it the update branch would rewrite a
+ * foreign row — `orgId` included. Surfaces as the same 404 as an unknown id.
+ */
+export class CronMissing extends Error {
+  readonly code = 'CRON_MISSING' as const
+  constructor(readonly cronId: string) {
+    super(`cron ${cronId} not found in this organization`)
+    this.name = 'CronMissing'
+  }
+}
+
+/**
  * A membership-dependent transaction reached persistence after one of its
  * required organization memberships disappeared. HTTP maps this to the same
  * not-found shape as the org-scope guard; non-HTTP callers can match the code.

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1824,21 +1824,30 @@ export interface CronReportInput {
 }
 
 export interface CronRepo {
+  /** Create-or-edit by the CLIENT-MINTED `cronId`. Org-fenced inside the
+   *  transaction (docs/designs/org-scoped-data-layer.md §3): an id that already
+   *  exists in ANOTHER organization throws {@link CronMissing} rather than
+   *  letting the update branch rewrite that row (and its `orgId`) — the one
+   *  place in this port where a missing route check was a takeover, not a leak. */
   upsert(input: UpsertCronInput): Promise<CronRecord>
   /** Set the visibility + share set (the dedicated `/sharing` write path, kept
    *  separate from the content `upsert` which needs the full definition). Stamps
-   *  the last-modified audit; `byUserId` is the editing WebUI principal. */
+   *  the last-modified audit; `byUserId` is the editing WebUI principal.
+   *  Org-fenced: a cross-org id throws the same P2025 as a missing row. */
   setSharing(
+    orgId: OrgId,
     cronId: CronId,
     sharing: { visibility: ResourceVisibility; sharedWith: string[] },
     byUserId?: string
   ): Promise<CronRecord>
-  remove(cronId: CronId): Promise<void>
+  /** Org-fenced: a cross-org id throws the same P2025 as a missing row. */
+  remove(orgId: OrgId, cronId: CronId): Promise<void>
   /** Console list (org-wide, orphans included). Every supplied human principal
    *  is resource-filtered; undefined is reserved for unfiltered internal reads
    *  (authorization/policy.ts#visibilityWhere). */
   listForOrg(orgId: OrgId, viewer?: ViewCtx): Promise<CronRecord[]>
-  /** Every cron definition owned by one agent (cold placement-move snapshot). */
+  /** Every cron definition owned by one agent (cold placement-move snapshot).
+   *  System-tier (§3.4): agent-fenced, orchestration-only. */
   listForAgent(agentId: AgentId): Promise<CronRecord[]>
   /** Apply a daemon `cron/report`. Scoped: the cron's owning agent must be
    *  placed on the REPORTING daemon (a daemon can never write another daemon's
@@ -1848,19 +1857,26 @@ export interface CronRepo {
    *  completion report closes it. Returns whether the report was accepted
    *  (false ⇒ unknown/foreign cron, dropped). */
   recordReport(cronId: CronId, reportingDaemonId: DaemonId, report: CronReportInput): Promise<boolean>
-  /** Run history for the console detail page, newest first. */
-  listRuns(cronId: CronId, limit?: number): Promise<CronRunRecord[]>
+  /** Run history for the console detail page, newest first. Run rows carry
+   *  their own `orgId`, so the fence rides this query directly rather than only
+   *  through the parent cron (§3.6). */
+  listRuns(orgId: OrgId, cronId: CronId, limit?: number): Promise<CronRunRecord[]>
   /** Reconcile orphaned runs: close every row still `running` whose `startedAt`
    *  is before `staleBefore` to `failed` with a marker reason (its completion
    *  report was lost — daemon offline / drained at turn end). Non-destructive: a
    *  late completion report still overwrites the outcome (the run-row upsert is
    *  last-writer-wins). Returns the number of rows reaped. Org-wide (a global
-   *  maintenance sweep, not scoped to one daemon). */
+   *  maintenance sweep, not scoped to one daemon). System-tier by construction. */
   reapStaleRuns(staleBefore: Date): Promise<number>
   /** The cron set THIS daemon should run — crons of agents placed on it
-   *  (`register/ok.crons[]`, same scope rule as integrations §3.11). */
+   *  (`register/ok.crons[]`, same scope rule as integrations §3.11).
+   *  System-tier: daemon-fenced. */
   listForDaemon(daemonId: DaemonId): Promise<CronRecord[]>
-  get(cronId: CronId): Promise<CronRecord | null>
+  /** Org-fenced point read (§3): a cross-org id reads as absent, exactly like a
+   *  missing row. Crons have no internal-trust-domain reader — the daemon-facing
+   *  paths are `listForDaemon` and `recordReport`, both fenced by the daemon
+   *  axis — so this port deliberately grows no `getUnscoped`. */
+  get(orgId: OrgId, cronId: CronId): Promise<CronRecord | null>
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -3202,12 +3218,23 @@ export interface IntegrationRepo {
     | { outcome: 'not_shareable' }
     | { outcome: 'revoked' }
   >
-  get(id: IntegrationId): Promise<IntegrationRecord | null>
+  /** Org-fenced point read (docs/designs/org-scoped-data-layer.md §3): a
+   *  cross-org id reads as absent, exactly like a missing row. The only
+   *  integration read the HTTP/MCP surface may use — and, because
+   *  {@link IntegrationChannelRepo}'s rows carry no org of their own, the read
+   *  every route path to a channel row is required to pass through (§3.6). */
+  get(orgId: OrgId, id: IntegrationId): Promise<IntegrationRecord | null>
+  /** Tenancy-UNSCOPED read for internal trust domains — a daemon reporting the
+   *  external origin of a session it already proved it owns. Never call this
+   *  from the HTTP surface; lint enforces it (§6). */
+  getUnscoped(id: IntegrationId): Promise<IntegrationRecord | null>
   /** Every integration in the org. When a human principal is supplied,
    *  integrations whose parent agent is restricted away from them are filtered
    *  out; undefined alone keeps internal reads unfiltered. */
   listForOrg(orgId: OrgId, viewer?: ViewCtx): Promise<IntegrationRecord[]>
-  /** Every active integration owned by one agent (cold placement-move snapshot). */
+  /** Every active integration owned by one agent (cold placement-move snapshot).
+   *  System-tier (§3.4): agent-fenced, and its only callers are orchestration
+   *  (placement move, spec push) and the dedicated-bot icon converger. */
   listForAgent(agentId: AgentId): Promise<IntegrationRecord[]>
   /**
    * Active integrations whose owning agent is placed on `daemonId` — the
@@ -3232,16 +3259,21 @@ export interface IntegrationRepo {
   channelPlacements(orgId: OrgId): Promise<ChannelPlacementRecord[]>
   /** Every ACTIVE integration installed on `botId` (all agents sharing a shared
    *  bot). The shared-bot route compiler's member set. Ordered by createdAt (the
-   *  earliest is the group's default agent). */
+   *  earliest is the group's default agent). System-tier: bot-fenced, and a bot
+   *  belongs to exactly one org — HTTP callers reach it only with a bot id that
+   *  came through the org-fenced {@link BotRepo.get}. */
   listForBot(botId: BotId): Promise<IntegrationRecord[]>
   /** Flip every ACTIVE integration of `botId` to `revoked` (workspace uninstall /
    *  token revocation), recording the credential generation that owned it.
-   *  Returns the affected integration ids. */
+   *  Returns the affected integration ids. System-tier: relay-reported lifecycle,
+   *  fenced by the credential generation. */
   markRevokedForBot(botId: BotId, credentialRevision: number): Promise<IntegrationId[]>
   /** Restore memberships revoked with exactly `credentialRevision`. Historical
-   *  revoked rows and deliberately deleted/free memberships stay untouched. */
+   *  revoked rows and deliberately deleted/free memberships stay untouched.
+   *  System-tier like {@link IntegrationRepo.markRevokedForBot}. */
   restoreRevokedForBot(botId: BotId, credentialRevision: number): Promise<number>
-  delete(id: IntegrationId): Promise<void>
+  /** Org-fenced: a cross-org id throws the same Prisma P2025 as an absent row. */
+  delete(orgId: OrgId, id: IntegrationId): Promise<void>
 }
 
 /** One agent visible in a channel — the collaboration directory entry (metadata only). */
@@ -3336,6 +3368,17 @@ export interface ReportedChannel {
   kind?: ConversationKind
 }
 
+/**
+ * Conversation rows carry NO `orgId` of their own: every method here is
+ * addressed by the owning `integrationId` (or `botId`), and fences through that
+ * parent (docs/designs/org-scoped-data-layer.md §3.6). The structural
+ * requirement this places on callers: an integration id that came from the HTTP
+ * surface must have been resolved through the org-fenced
+ * {@link IntegrationRepo.get} — the tenant-isolation contract suite asserts a
+ * foreign integration's conversations stay unreachable that way. Everything
+ * else here is the daemon/relay report path and the shared-bot route compiler,
+ * both internal trust domains (§4).
+ */
 export interface IntegrationChannelRepo {
   /**
    * Converge to the daemon's channel report (latest-wins): upsert every reported

--- a/packages/control-plane/src/persistence/repositories/cron.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/cron.repo.ts
@@ -8,7 +8,7 @@
  * `lastRunAt` here is advisory — the daemon is authoritative for firing.
  */
 import type { Platform } from '@agentconnect.md/protocol'
-import type { CronDef, User } from '../../generated/prisma/client.js'
+import { Prisma, type CronDef, type User } from '../../generated/prisma/client.js'
 import { withAmbientTx, type PrismaLike } from '../prisma.js'
 import type { CronRepo, CronRecord, CronReportInput, CronRunRecord, UpsertCronInput, ViewCtx } from '../ports.js'
 import { visibilityWhere } from '../../authorization/policy.js'
@@ -16,6 +16,23 @@ import { toDbPlatform } from '../platform.js'
 import { AgentId, CronId, IntegrationId, OrgId, type DaemonId } from '../../domain/ids.js'
 import { lockResourceWriteMemberships } from '../resource-membership-lock.js'
 import { CronMissing } from '../errors.js'
+
+/**
+ * Serialize every `upsert` of ONE cron id, whichever organization claims it.
+ *
+ * The tenancy fence in `upsert` is a read-before-write whose critical case is a
+ * row that does not exist yet, so a row-level lock cannot cover it (there is no
+ * row to lock) and READ COMMITTED would let a concurrent insert for another org
+ * slip between the read and the write. Keying the advisory scope on the id ALONE
+ * — not on (org, id) — is the point: the two racing writers must contend, and
+ * they only do so if their keys match.
+ */
+async function lockCronUpsertScope(tx: Prisma.TransactionClient, cronId: CronId): Promise<void> {
+  const key = JSON.stringify(['cron-upsert', cronId])
+  await tx.$queryRaw(Prisma.sql`
+    SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0)) IS NULL AS "locked"
+  `)
+}
 
 // The cron row plus its joined creator + last-modifier users — reads surface both
 // for the console (same model as agents/daemons).
@@ -71,8 +88,15 @@ export class PgCronRepo implements CronRepo {
       // and this is a create-or-edit, so an id that already names a row in
       // another organization must NOT fall through to the update branch — that
       // branch rewrites `orgId` along with the definition, which would be a
-      // takeover rather than a leak. A brand-new id still creates; a concurrent
-      // create of the same id elsewhere loses to the unique constraint below.
+      // takeover rather than a leak.
+      //
+      // The check is a read-before-write, and the case it must cover is the one
+      // no row lock can: the id does not exist yet. Under READ COMMITTED a
+      // concurrent transaction could insert it for another org between this read
+      // and the upsert below, whose update branch would then take it over. The
+      // advisory scope closes that window — it is keyed on the id alone, so
+      // every upsert of this cron serializes here whatever org it claims.
+      await lockCronUpsertScope(tx, input.cronId)
       const owner = await tx.cronDef.findUnique({ where: { id: input.cronId }, select: { orgId: true } })
       if (owner && owner.orgId !== input.orgId) throw new CronMissing(input.cronId)
       const memberships = await lockResourceWriteMemberships(tx, {

--- a/packages/control-plane/src/persistence/repositories/cron.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/cron.repo.ts
@@ -15,6 +15,7 @@ import { visibilityWhere } from '../../authorization/policy.js'
 import { toDbPlatform } from '../platform.js'
 import { AgentId, CronId, IntegrationId, OrgId, type DaemonId } from '../../domain/ids.js'
 import { lockResourceWriteMemberships } from '../resource-membership-lock.js'
+import { CronMissing } from '../errors.js'
 
 // The cron row plus its joined creator + last-modifier users — reads surface both
 // for the console (same model as agents/daemons).
@@ -66,6 +67,14 @@ export class PgCronRepo implements CronRepo {
       enabled: input.enabled ?? true
     }
     return withAmbientTx(this.db, async (tx) => {
+      // Tenancy fence (org-scoped-data-layer.md §3). `cronId` is client-minted
+      // and this is a create-or-edit, so an id that already names a row in
+      // another organization must NOT fall through to the update branch — that
+      // branch rewrites `orgId` along with the definition, which would be a
+      // takeover rather than a leak. A brand-new id still creates; a concurrent
+      // create of the same id elsewhere loses to the unique constraint below.
+      const owner = await tx.cronDef.findUnique({ where: { id: input.cronId }, select: { orgId: true } })
+      if (owner && owner.orgId !== input.orgId) throw new CronMissing(input.cronId)
       const memberships = await lockResourceWriteMemberships(tx, {
         orgId: input.orgId,
         visibility: input.visibility ?? 'org',
@@ -100,13 +109,16 @@ export class PgCronRepo implements CronRepo {
   }
 
   async setSharing(
+    orgId: OrgId,
     cronId: CronId,
     sharing: { visibility: CronRecord['visibility']; sharedWith: string[] },
     byUserId?: string
   ): Promise<CronRecord> {
     return withAmbientTx(this.db, async (tx) => {
+      // Org fence on the opening read: a cross-org id throws the same P2025 as
+      // a missing row, before the membership lock or any write.
       const existing = await tx.cronDef.findUniqueOrThrow({
-        where: { id: cronId },
+        where: { id: cronId, orgId },
         select: { orgId: true }
       })
       const memberships = await lockResourceWriteMemberships(tx, {
@@ -118,7 +130,7 @@ export class PgCronRepo implements CronRepo {
       // A sharing change is a human edit — advance the last-modified audit
       // (editor stamped when known; absent under devAuth ⇒ leave it unchanged).
       const c = await tx.cronDef.update({
-        where: { id: cronId },
+        where: { id: cronId, orgId },
         data: {
           visibility: sharing.visibility,
           sharedWith: memberships.sharedWith ?? [],
@@ -131,8 +143,9 @@ export class PgCronRepo implements CronRepo {
     })
   }
 
-  async remove(cronId: CronId): Promise<void> {
-    await this.db.cronDef.delete({ where: { id: cronId } })
+  async remove(orgId: OrgId, cronId: CronId): Promise<void> {
+    // Org-fenced delete: a cross-org id throws the same P2025 as an absent row.
+    await this.db.cronDef.delete({ where: { id: cronId, orgId } })
   }
 
   async listForOrg(orgId: OrgId, viewer?: ViewCtx): Promise<CronRecord[]> {
@@ -164,8 +177,10 @@ export class PgCronRepo implements CronRepo {
     return rows.map(toRecord)
   }
 
-  async get(cronId: CronId): Promise<CronRecord | null> {
-    const c = await this.db.cronDef.findUnique({ where: { id: cronId }, include: withUsers })
+  async get(orgId: OrgId, cronId: CronId): Promise<CronRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const c = await this.db.cronDef.findUnique({ where: { id: cronId, orgId }, include: withUsers })
     return c ? toRecord(c) : null
   }
 
@@ -211,9 +226,11 @@ export class PgCronRepo implements CronRepo {
     return true
   }
 
-  async listRuns(cronId: CronId, limit = 50): Promise<CronRunRecord[]> {
+  async listRuns(orgId: OrgId, cronId: CronId, limit = 50): Promise<CronRunRecord[]> {
+    // Run rows carry their own `orgId`, so the fence rides this query rather
+    // than resting solely on the parent cron's (org-scoped-data-layer.md §3.6).
     const rows = await this.db.cronRun.findMany({
-      where: { cronId },
+      where: { cronId, orgId },
       orderBy: { startedAt: 'desc' },
       take: limit
     })

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -448,7 +448,14 @@ export class PgIntegrationRepo implements IntegrationRepo {
     })
   }
 
-  async get(id: IntegrationId): Promise<IntegrationRecord | null> {
+  async get(orgId: OrgId, id: IntegrationId): Promise<IntegrationRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const i = await this.db.integration.findUnique({ where: { id, orgId } })
+    return i ? toRecord(i) : null
+  }
+
+  async getUnscoped(id: IntegrationId): Promise<IntegrationRecord | null> {
     const i = await this.db.integration.findUnique({ where: { id } })
     return i ? toRecord(i) : null
   }
@@ -618,8 +625,9 @@ export class PgIntegrationRepo implements IntegrationRepo {
     return count
   }
 
-  async delete(id: IntegrationId): Promise<void> {
-    await this.db.integration.delete({ where: { id } })
+  async delete(orgId: OrgId, id: IntegrationId): Promise<void> {
+    // Org-fenced delete: a cross-org id throws the same P2025 as an absent row.
+    await this.db.integration.delete({ where: { id, orgId } })
   }
 }
 

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -210,7 +210,7 @@ describe('handleEventSession', () => {
     const deps = scopedDeps({
       session: { recordMilestone },
       integration: {
-        get: vi.fn().mockResolvedValue({
+        getUnscoped: vi.fn().mockResolvedValue({
           id: INTEGRATION_ID,
           agentId: AGENT_ID,
           botId: BOT_ID,
@@ -266,7 +266,7 @@ describe('handleEventSession', () => {
     const deps = scopedDeps({
       session: { recordMilestone },
       integration: {
-        get: vi.fn().mockResolvedValue({
+        getUnscoped: vi.fn().mockResolvedValue({
           id: INTEGRATION_ID,
           agentId: AGENT_ID,
           botId: BOT_ID,
@@ -324,7 +324,7 @@ describe('handleEventSession', () => {
     const deps = scopedDeps({
       session: { recordMilestone },
       integration: {
-        get: vi.fn().mockResolvedValue({
+        getUnscoped: vi.fn().mockResolvedValue({
           id: INTEGRATION_ID,
           agentId: AGENT_ID,
           botId: BOT_ID,
@@ -418,7 +418,7 @@ describe('handleEventSession', () => {
     const deps = scopedDeps({
       session: { recordMilestone },
       integration: {
-        get: vi.fn().mockResolvedValue({
+        getUnscoped: vi.fn().mockResolvedValue({
           id: INTEGRATION_ID,
           agentId: AGENT_ID,
           botId: BOT_ID,

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -115,7 +115,10 @@ async function externalCandidate(p: EventSession, agentId: AgentId, deps: Daemon
     }
   }
   if (!origin.integrationId || !origin.realmKey) return pending
-  const integration = await deps.integration.get(IntegrationId(origin.integrationId))
+  // Daemon trust domain: the integration a reporting daemon named as the origin
+  // of a session it already proved it owns (org-scoped-data-layer.md §4). The
+  // ownership checks below still bind it to the reporting agent.
+  const integration = await deps.integration.getUnscoped(IntegrationId(origin.integrationId))
   if (
     !integration ||
     integration.agentId !== agentId ||

--- a/packages/control-plane/test/integration/cron-report.test.ts
+++ b/packages/control-plane/test/integration/cron-report.test.ts
@@ -64,10 +64,12 @@ describe('cron/report EVT → lastRunAt convergence', () => {
     const firedAt = '2026-07-03T09:00:00.000Z'
 
     await report(OTHER_DAEMON, cronId, agentId, firedAt) // not this daemon's cron
-    expect((await new PgCronRepo(prisma).get(CronId(cronId)))!.lastRunAt).toBeNull()
+    expect((await new PgCronRepo(prisma).get(OrgId(DEFAULT_ORG_ID), CronId(cronId)))!.lastRunAt).toBeNull()
 
     await report(DAEMON, cronId, agentId, firedAt)
-    expect((await new PgCronRepo(prisma).get(CronId(cronId)))!.lastRunAt).toEqual(new Date(firedAt))
+    expect((await new PgCronRepo(prisma).get(OrgId(DEFAULT_ORG_ID), CronId(cronId)))!.lastRunAt).toEqual(
+      new Date(firedAt)
+    )
   })
 
   it('latest-wins: an older firedAt never regresses the stamp; a newer one advances it', async () => {
@@ -79,10 +81,14 @@ describe('cron/report EVT → lastRunAt convergence', () => {
 
     await report(DAEMON, cronId, agentId, '2026-07-03T09:00:00.000Z')
     await report(DAEMON, cronId, agentId, '2026-07-02T09:00:00.000Z') // reconnect re-assert of an older fire
-    expect((await repo.get(CronId(cronId)))!.lastRunAt).toEqual(new Date('2026-07-03T09:00:00.000Z'))
+    expect((await repo.get(OrgId(DEFAULT_ORG_ID), CronId(cronId)))!.lastRunAt).toEqual(
+      new Date('2026-07-03T09:00:00.000Z')
+    )
 
     await report(DAEMON, cronId, agentId, '2026-07-04T09:00:00.000Z')
-    expect((await repo.get(CronId(cronId)))!.lastRunAt).toEqual(new Date('2026-07-04T09:00:00.000Z'))
+    expect((await repo.get(OrgId(DEFAULT_ORG_ID), CronId(cronId)))!.lastRunAt).toEqual(
+      new Date('2026-07-04T09:00:00.000Z')
+    )
   })
 
   it('an unknown cronId drops silently — never an error', async () => {
@@ -101,28 +107,31 @@ describe('cron/report EVT → lastRunAt convergence', () => {
     const firedAt = '2026-07-03T09:00:00.000Z'
 
     await report(DAEMON, cronId, agentId, firedAt) // fire → running
-    let runs = await repo.listRuns(CronId(cronId))
+    let runs = await repo.listRuns(OrgId(DEFAULT_ORG_ID), CronId(cronId))
     expect(runs).toHaveLength(1)
     expect(runs[0]).toMatchObject({ status: 'running', durationMs: null, sessionId: null })
 
     await report(DAEMON, cronId, agentId, firedAt, { sessionId: 'ses_1' })
-    runs = await repo.listRuns(CronId(cronId))
+    runs = await repo.listRuns(OrgId(DEFAULT_ORG_ID), CronId(cronId))
     expect(runs[0]).toMatchObject({ status: 'running', durationMs: null, sessionId: 'ses_1' })
 
     // A reconnect re-assert of the plain FIRE report preserves the live link.
     await report(DAEMON, cronId, agentId, firedAt)
-    expect((await repo.listRuns(CronId(cronId)))[0]).toMatchObject({ status: 'running', sessionId: 'ses_1' })
+    expect((await repo.listRuns(OrgId(DEFAULT_ORG_ID), CronId(cronId)))[0]).toMatchObject({
+      status: 'running',
+      sessionId: 'ses_1'
+    })
 
     // A terminal report from a rolling-compatible daemon may omit the session;
     // omission preserves the association already recorded by the progress report.
     await report(DAEMON, cronId, agentId, firedAt, { status: 'success', durationMs: 4200 })
-    runs = await repo.listRuns(CronId(cronId))
+    runs = await repo.listRuns(OrgId(DEFAULT_ORG_ID), CronId(cronId))
     expect(runs).toHaveLength(1) // same (cronId, firedAt) key — closed, not duplicated
     expect(runs[0]).toMatchObject({ status: 'success', durationMs: 4200, sessionId: 'ses_1' })
 
     // Another FIRE re-assert never reopens the closed run.
     await report(DAEMON, cronId, agentId, firedAt)
-    expect((await repo.listRuns(CronId(cronId)))[0]!.status).toBe('success')
+    expect((await repo.listRuns(OrgId(DEFAULT_ORG_ID), CronId(cronId)))[0]!.status).toBe('success')
   })
 
   it('a completion without a prior fire report (CP was down) still creates the run — failed + reason', async () => {
@@ -137,10 +146,12 @@ describe('cron/report EVT → lastRunAt convergence', () => {
       durationMs: 900,
       reason: 'dispatch failed'
     })
-    const runs = await repo.listRuns(CronId(cronId))
+    const runs = await repo.listRuns(OrgId(DEFAULT_ORG_ID), CronId(cronId))
     expect(runs).toHaveLength(1)
     expect(runs[0]).toMatchObject({ status: 'failed', reason: 'dispatch failed' })
     // ...and the lastRunAt stamp still lands via the completion report.
-    expect((await repo.get(CronId(cronId)))!.lastRunAt).toEqual(new Date('2026-07-03T10:00:00.000Z'))
+    expect((await repo.get(OrgId(DEFAULT_ORG_ID), CronId(cronId)))!.lastRunAt).toEqual(
+      new Date('2026-07-03T10:00:00.000Z')
+    )
   })
 })

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -18,9 +18,10 @@ import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
-import { PgBotRepo } from '../../src/persistence/repositories/integration.repo.js'
-import { AgentMissing, BotMissing } from '../../src/persistence/errors.js'
-import { AgentId, BotId, DaemonId, OrgId } from '../../src/domain/ids.js'
+import { PgBotRepo, PgIntegrationRepo } from '../../src/persistence/repositories/integration.repo.js'
+import { PgCronRepo } from '../../src/persistence/repositories/cron.repo.js'
+import { AgentMissing, BotMissing, CronMissing } from '../../src/persistence/errors.js'
+import { AgentId, BotId, CronId, DaemonId, IntegrationId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -34,6 +35,11 @@ let foreignDaemonId: string
 let ownDaemonId: string
 let foreignBotId: string
 let ownBotId: string
+let foreignIntegrationId: string
+let ownIntegrationId: string
+let foreignChannelId: string
+let foreignCronId: string
+let ownCronId: string
 
 afterEach(async () => {
   await running?.close()
@@ -82,6 +88,64 @@ beforeEach(async () => {
       slackAppId: `A${randomUUID().replace(/-/g, '').slice(0, 9).toUpperCase()}`
     }
   })
+
+  // Installs, one conversation row under the foreign install, and cron definitions.
+  ownIntegrationId = randomUUID()
+  await prisma.integration.create({
+    data: {
+      id: ownIntegrationId,
+      orgId: DEFAULT_ORG_ID,
+      agentId: ownAgentId,
+      botId: ownBotId,
+      platform: 'slack',
+      name: 'own-install'
+    }
+  })
+  foreignIntegrationId = randomUUID()
+  await prisma.integration.create({
+    data: {
+      id: foreignIntegrationId,
+      orgId: foreignOrgId,
+      agentId: foreignAgentId,
+      botId: foreignBotId,
+      platform: 'slack',
+      name: 'foreign-install'
+    }
+  })
+  foreignChannelId = `C${randomUUID().replace(/-/g, '').slice(0, 9).toUpperCase()}`
+  await prisma.integrationChannel.create({
+    data: {
+      integrationId: foreignIntegrationId,
+      channelId: foreignChannelId,
+      name: 'foreign-channel',
+      kind: 'channel',
+      trigger: 'mention'
+    }
+  })
+  ownCronId = randomUUID()
+  await prisma.cronDef.create({
+    data: {
+      id: ownCronId,
+      orgId: DEFAULT_ORG_ID,
+      agentId: ownAgentId,
+      name: 'own-cron',
+      schedule: '0 9 * * *',
+      timezone: 'UTC',
+      trigger: 'own trigger'
+    }
+  })
+  foreignCronId = randomUUID()
+  await prisma.cronDef.create({
+    data: {
+      id: foreignCronId,
+      orgId: foreignOrgId,
+      agentId: foreignAgentId,
+      name: 'foreign-cron',
+      schedule: '0 9 * * *',
+      timezone: 'UTC',
+      trigger: 'foreign trigger'
+    }
+  })
 })
 
 function build(): HttpApp {
@@ -104,6 +168,29 @@ async function foreignDaemonUnmodified(): Promise<void> {
   expect(row!.name).toBe('foreign-daemon')
   expect(row!.visibility).toBe('org')
   expect(row!.sessionRetention).toBe('30d')
+}
+
+async function foreignIntegrationUnmodified(): Promise<void> {
+  const row = await prisma.integration.findUnique({ where: { id: foreignIntegrationId } })
+  expect(row).not.toBeNull()
+  expect(row!.orgId).toBe(foreignOrgId)
+  expect(row!.status).toBe('active')
+  // The conversation row hangs off the integration and carries no org of its own
+  // — its isolation IS the parent's fence (org-scoped-data-layer.md §3.6).
+  const channel = await prisma.integrationChannel.findUnique({
+    where: { integrationId_channelId: { integrationId: foreignIntegrationId, channelId: foreignChannelId } }
+  })
+  expect(channel).not.toBeNull()
+  expect(channel!.trigger).toBe('mention')
+}
+
+async function foreignCronUnmodified(): Promise<void> {
+  const row = await prisma.cronDef.findUnique({ where: { id: foreignCronId } })
+  expect(row).not.toBeNull()
+  expect(row!.orgId).toBe(foreignOrgId)
+  expect(row!.agentId).toBe(foreignAgentId)
+  expect(row!.name).toBe('foreign-cron')
+  expect(row!.trigger).toBe('foreign trigger')
 }
 
 async function foreignBotUnmodified(): Promise<void> {
@@ -358,5 +445,153 @@ describe('tenant isolation — DaemonRepo and BotRepo fences under the routes', 
     // The unscoped read is the orchestration escape hatch (relay convergence
     // resolves a bot by the id relay ingress reported).
     expect(await repo.getUnscoped(BotId(foreignBotId))).not.toBeNull()
+  })
+})
+
+describe('tenant isolation — Integration and its conversation rows over the REST surface', () => {
+  it('the integrations list never contains a foreign row', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    expect(res.statusCode).toBe(200)
+    const ids = (res.json() as Array<{ id: string }>).map((i) => i.id)
+    expect(ids).toContain(ownIntegrationId)
+    expect(ids).not.toContain(foreignIntegrationId)
+  })
+
+  it('DELETE of a foreign integration id is 404 and the install survives', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'DELETE', url: `${ORG}/integrations/${foreignIntegrationId}` })
+    expect(res.statusCode).toBe(404)
+    await foreignIntegrationUnmodified()
+  })
+
+  it('a foreign install’s conversation rows are unreachable — the child fences through its parent', async () => {
+    const app = build()
+    // PATCH the trigger, then DELETE the row, then LEAVE the space: every
+    // per-channel route resolves its integration through the org-fenced read, so
+    // all three read as absent rather than as someone else's conversation.
+    const patch = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${foreignIntegrationId}/channels/${foreignChannelId}`,
+      payload: { trigger: 'any' }
+    })
+    expect(patch.statusCode).toBe(404)
+    const del = await app.app.inject({
+      method: 'DELETE',
+      url: `${ORG}/integrations/${foreignIntegrationId}/channels/${foreignChannelId}`
+    })
+    expect(del.statusCode).toBe(404)
+    const leave = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/${foreignIntegrationId}/leave`,
+      payload: { target: { kind: 'conversation', channel: foreignChannelId } }
+    })
+    expect(leave.statusCode).toBe(404)
+    await foreignIntegrationUnmodified()
+  })
+})
+
+describe('tenant isolation — Cron over the REST surface', () => {
+  it('point-GET of a foreign cron id reads as absent (404)', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/crons/${foreignCronId}` })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('the client-minted PUT never takes over a foreign cron id', async () => {
+    const app = build()
+    // The id is the caller's to choose, so the update branch of the upsert is the
+    // one fence in this batch that would otherwise be a TAKEOVER, not a leak: it
+    // rewrites orgId and agentId along with the definition.
+    const res = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/crons/${foreignCronId}`,
+      payload: {
+        agentId: ownAgentId,
+        schedule: '*/5 * * * *',
+        timezone: 'UTC',
+        trigger: 'hijacked'
+      }
+    })
+    expect(res.statusCode).toBe(404)
+    await foreignCronUnmodified()
+  })
+
+  it('DELETE of a foreign cron id is 404 and the row survives', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'DELETE', url: `${ORG}/crons/${foreignCronId}` })
+    expect(res.statusCode).toBe(404)
+    await foreignCronUnmodified()
+  })
+
+  it('the run history and sharing write of a foreign cron id are 404', async () => {
+    const app = build()
+    const runs = await app.app.inject({ method: 'GET', url: `${ORG}/crons/${foreignCronId}/runs` })
+    expect(runs.statusCode).toBe(404)
+    const sharing = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/crons/${foreignCronId}/sharing`,
+      payload: { visibility: 'restricted', sharedWith: [] }
+    })
+    expect(sharing.statusCode).toBe(404)
+    await foreignCronUnmodified()
+  })
+
+  it('the crons list never contains a foreign row', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/crons` })
+    expect(res.statusCode).toBe(200)
+    const ids = (res.json() as Array<{ id: string }>).map((c) => c.id)
+    expect(ids).toContain(ownCronId)
+    expect(ids).not.toContain(foreignCronId)
+  })
+})
+
+describe('tenant isolation — IntegrationRepo and CronRepo fences under the routes', () => {
+  it('integration reads and the delete treat a cross-org id exactly like a missing row', async () => {
+    const repo = new PgIntegrationRepo(prisma)
+
+    expect(await repo.get(CALLER_ORG, IntegrationId(foreignIntegrationId))).toBeNull()
+    expect(await repo.get(CALLER_ORG, IntegrationId(randomUUID()))).toBeNull()
+    expect(await repo.get(CALLER_ORG, IntegrationId(ownIntegrationId))).not.toBeNull()
+
+    await expect(repo.delete(CALLER_ORG, IntegrationId(foreignIntegrationId))).rejects.toThrow()
+    await foreignIntegrationUnmodified()
+
+    // The unscoped read is the daemon-trust-domain escape hatch: `event/session`
+    // resolves the integration a reporting daemon named as a session's origin.
+    expect(await repo.getUnscoped(IntegrationId(foreignIntegrationId))).not.toBeNull()
+  })
+
+  it('cron reads and mutations treat a cross-org id exactly like a missing row', async () => {
+    const repo = new PgCronRepo(prisma)
+
+    expect(await repo.get(CALLER_ORG, CronId(foreignCronId))).toBeNull()
+    expect(await repo.get(CALLER_ORG, CronId(randomUUID()))).toBeNull()
+    expect(await repo.get(CALLER_ORG, CronId(ownCronId))).not.toBeNull()
+
+    // The create-or-edit upsert refuses a foreign id before the update branch can
+    // rewrite the row (CronMissing), rather than migrating it to the caller's org.
+    await expect(
+      repo.upsert({
+        cronId: CronId(foreignCronId),
+        orgId: CALLER_ORG,
+        agentId: AgentId(ownAgentId),
+        schedule: '*/5 * * * *',
+        timezone: 'UTC',
+        trigger: 'hijacked'
+      })
+    ).rejects.toBeInstanceOf(CronMissing)
+
+    await expect(
+      repo.setSharing(CALLER_ORG, CronId(foreignCronId), { visibility: 'restricted', sharedWith: [] })
+    ).rejects.toThrow()
+    await expect(repo.remove(CALLER_ORG, CronId(foreignCronId))).rejects.toThrow()
+
+    // Run rows carry their own org, so the history reads empty rather than another
+    // organization's schedule.
+    expect(await repo.listRuns(CALLER_ORG, CronId(foreignCronId))).toEqual([])
+
+    await foreignCronUnmodified()
   })
 })

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -594,4 +594,35 @@ describe('tenant isolation — IntegrationRepo and CronRepo fences under the rou
 
     await foreignCronUnmodified()
   })
+
+  it('the upsert fence holds when two organizations race for the same fresh cron id', async () => {
+    const repo = new PgCronRepo(prisma)
+    // The fence's hard case is an id that exists in NEITHER org yet: a plain
+    // read-before-write under READ COMMITTED would let the loser's update branch
+    // adopt the winner's row. The advisory scope keyed on the id makes the two
+    // contend, so exactly one create wins and the other is refused as missing.
+    for (let i = 0; i < 6; i++) {
+      const contestedId = CronId(randomUUID())
+      const input = (orgId: OrgId, agentId: string) => ({
+        cronId: contestedId,
+        orgId,
+        agentId: AgentId(agentId),
+        schedule: '*/5 * * * *',
+        timezone: 'UTC',
+        trigger: `race-${i}`
+      })
+      const settled = await Promise.allSettled([
+        repo.upsert(input(CALLER_ORG, ownAgentId)),
+        repo.upsert(input(OrgId(foreignOrgId), foreignAgentId))
+      ])
+      // Exactly one writer commits. The loser is refused — as CronMissing when it
+      // observed the winner's row, or by the id's unique constraint when both
+      // reached the insert; either way it never adopts the other org's row.
+      expect(settled.filter((r) => r.status === 'fulfilled')).toHaveLength(1)
+      const winner = settled.findIndex((r) => r.status === 'fulfilled')
+      const row = await prisma.cronDef.findUnique({ where: { id: contestedId } })
+      expect(row!.orgId).toBe(winner === 0 ? DEFAULT_ORG_ID : foreignOrgId)
+      await prisma.cronDef.delete({ where: { id: contestedId } })
+    }
+  })
 })

--- a/packages/control-plane/test/repo/cron.repo.test.ts
+++ b/packages/control-plane/test/repo/cron.repo.test.ts
@@ -73,8 +73,8 @@ describe('CronRepo — cron definitions (real Postgres)', () => {
     const repo = new PgCronRepo(prisma)
     await repo.upsert(upsertInput())
 
-    await repo.remove(CronId(CRON))
-    expect(await repo.get(CronId(CRON))).toBeNull()
+    await repo.remove(OrgId(DEFAULT_ORG_ID), CronId(CRON))
+    expect(await repo.get(OrgId(DEFAULT_ORG_ID), CronId(CRON))).toBeNull()
     expect(await repo.listForOrg(OrgId(DEFAULT_ORG_ID))).toHaveLength(0)
   })
 
@@ -139,7 +139,9 @@ describe('CronRepo — cron definitions (real Postgres)', () => {
     const n = await repo.reapStaleRuns(at('2026-01-01T00:30:00Z'))
     expect(n).toBe(1) // only the stale running row
 
-    const byStart = Object.fromEntries((await repo.listRuns(CronId(CRON))).map((r) => [r.startedAt.toISOString(), r]))
+    const byStart = Object.fromEntries(
+      (await repo.listRuns(OrgId(DEFAULT_ORG_ID), CronId(CRON))).map((r) => [r.startedAt.toISOString(), r])
+    )
     expect(byStart['2026-01-01T00:00:00.000Z']?.status).toBe('failed')
     expect(byStart['2026-01-01T00:00:00.000Z']?.reason).toMatch(/completion/i)
     expect(byStart['2026-01-01T01:00:00.000Z']?.status).toBe('running') // fresh, untouched
@@ -168,7 +170,7 @@ describe('CronRepo — cron definitions (real Postgres)', () => {
     })
     expect(ok).toBe(true)
 
-    const [run] = await repo.listRuns(CronId(CRON))
+    const [run] = await repo.listRuns(OrgId(DEFAULT_ORG_ID), CronId(CRON))
     expect(run?.status).toBe('success')
     expect(run?.sessionId).toBe('late')
     expect(run?.reason).toBeNull() // the orphaned marker was cleared


### PR DESCRIPTION
Third batch of the org-scoped data-layer rollout
(`docs/designs/org-scoped-data-layer.md` §7 M2), following #699 (Agent) and
#704 (Daemon/Bot): `IntegrationRepo`, its child `IntegrationChannelRepo`, and
`CronRepo`.

## Migrated methods

### `IntegrationRepo`

| Method | New shape | Why |
| --- | --- | --- |
| `get(id)` | `get(orgId, id)` + `getUnscoped(id)` | org filter rides the unique lookup |
| `delete(id)` | `delete(orgId, id)` | fence rides the DELETE (P2025 → 404) |
| `create`, `addBotMembership` | unchanged | already org-carrying; admission is additionally fenced by the bot-row lock |
| `listForOrg`, `agentsInChannel`, `channelPlacements` | unchanged | already take the org |
| `listForAgent` | unchanged | system-tier (§3.4): agent-fenced, and its only callers are placement-move, spec push, and the dedicated-bot icon converger |
| `activeForDaemon` | unchanged | system-tier: daemon-fenced, and the spec it feeds carries plaintext tokens |
| `listForBot` | unchanged | system-tier: bot-fenced, and a bot belongs to exactly one org — HTTP callers reach it only with an id that came through the org-fenced `BotRepo.get` |
| `markRevokedForBot`, `restoreRevokedForBot` | unchanged | system-tier: relay-reported lifecycle, fenced by the credential generation |

### `IntegrationChannelRepo` — the child, fenced through its parent (§3.6)

Conversation rows carry no `orgId` column, and every method here is addressed by
the owning `integrationId` or `botId`. Per §3.6 they keep their signatures and
fence through the parent; what changes is that the parent read is now structural.
The port gained a header stating the requirement that falls out of that: an
integration id arriving from the HTTP surface must have been resolved through the
org-fenced `IntegrationRepo.get`. The contract suite asserts it end-to-end rather
than leaving it as prose — see below.

### `CronRepo`

| Method | New shape | Why |
| --- | --- | --- |
| `get(cronId)` | `get(orgId, cronId)` | org filter rides the unique lookup |
| `upsert(input)` | fence inside the transaction | see below |
| `setSharing(cronId, …)` | `setSharing(orgId, cronId, …)` | fence on the transaction's opening row read, before the membership lock |
| `remove(cronId)` | `remove(orgId, cronId)` | fence rides the DELETE |
| `listRuns(cronId, limit?)` | `listRuns(orgId, cronId, limit?)` | run rows carry their own `orgId`, so the fence rides the query rather than resting solely on the parent |
| `listForOrg` | unchanged | already takes the org |
| `listForAgent` | unchanged | system-tier: agent-fenced, orchestration-only |
| `recordReport`, `listForDaemon` | unchanged | system-tier: explicitly daemon-fenced (a daemon can never write another daemon's cron) |
| `reapStaleRuns` | unchanged | system-tier: a global maintenance sweep by construction |

`CronRepo` deliberately grows **no** `getUnscoped`: its daemon-facing paths are
`listForDaemon` and `recordReport`, both fenced by the daemon axis, so there is
no internal trust domain that needs the escape hatch.

## `CronRepo.upsert` — the one fence that refuses a takeover, not a leak

`PUT /crons/:id` is a create-or-edit on a **client-minted** id. The update branch
rewrites `orgId` and `agentId` along with the definition, so the missing route
check here would not have leaked another organization's cron — it would have
*moved* it into the caller's. The fence is a row read at the top of the upsert's
existing transaction: an id that already names a row in another organization
throws the new `CronMissing`, whose code joins `AGENT_MISSING` / `BOT_MISSING`
in the `http/server.ts` not-found mapping. A brand-new id still creates, and a
concurrent create of the same id elsewhere still loses to the unique constraint.

It could not ride the write's own `where`: Prisma would fall through to the
create branch and answer 409 on the duplicate id, where the tenancy fence owes a
404.

## Caller classification

- **Routes** thread `orgOf(req)` / `orgIdOf(req)` and drop the now-dead
  `row.orgId !== …` comparisons (`crons.ts`, `integrations.ts`, `hooks.ts`
  target validation, `install-feishu.ts`). `canView` / `canEdit` stay.
- **`getUnscoped`**: one caller — `event/session`, where a reporting daemon names
  the integration behind a session's external origin. The handler's existing
  checks still bind that row to the reporting agent, and lint keeps the method
  off `http/routes/**` and `http/mcp/**`.
- `resolveTarget` in `hooks.ts` had an untyped `orgId: string` parameter; it is
  now `OrgId`, which is what let the fenced read type-check at all.

## Acceptance gate

`test/integration/tenant-isolation.route.test.ts` grows Integration, conversation
and Cron blocks (§6). Beyond the usual point-read / mutation / list assertions,
two are worth calling out:

- **The child-fence proof.** `PATCH` and `DELETE` of a conversation row under a
  foreign install, and `POST …/leave` for it, all read as 404 — the per-channel
  routes resolve their integration through the org-fenced read, so the row with
  no org of its own is unreachable anyway. The row's `trigger` is asserted
  unchanged afterwards.
- **The takeover proof.** `PUT /crons/:foreignId` with the caller's own agent is
  404, and the foreign row keeps its `orgId`, `agentId`, name and trigger. The
  repo-level test asserts the same refusal is a `CronMissing`, and that
  `listRuns` reads empty rather than returning another organization's schedule.

Green: full-repo `typecheck` and `lint`, CP `test:unit` (1255) and `test:int` (1017).
