### PR TITLE
fix(cp): keep Logto management API opt-in

### DIFF
--- a/packages/control-plane/src/config/env.test.ts
+++ b/packages/control-plane/src/config/env.test.ts
@@ -18,7 +18,7 @@ describe('loadBootstrapConfig', () => {
 })
 
 describe('loadConfig', () => {
-  it('derives canonical Logto topology from the documented trailing-slash endpoint', () => {
+  it('derives login topology without enabling an unconfigured Management API', () => {
     const config = loadConfig({
       DATABASE_URL: 'postgresql://agentconnect:agentconnect@localhost:5432/agentconnect',
       API_KEY_PEPPER: 'a'.repeat(32),
@@ -26,6 +26,18 @@ describe('loadConfig', () => {
     })
 
     expect(config.OIDC_ISSUER).toBe('https://tenant.example.com/oidc')
+    expect(config.LOGTO_MGMT_ENDPOINT).toBeUndefined()
+  })
+
+  it('derives the Management API endpoint when its credentials are configured', () => {
+    const config = loadConfig({
+      DATABASE_URL: 'postgresql://agentconnect:agentconnect@localhost:5432/agentconnect',
+      API_KEY_PEPPER: 'a'.repeat(32),
+      LOGTO_ENDPOINT: 'https://tenant.example.com/',
+      LOGTO_MGMT_APP_ID: 'client-id',
+      LOGTO_MGMT_APP_SECRET: 'client-secret'
+    })
+
     expect(config.LOGTO_MGMT_ENDPOINT).toBe('https://tenant.example.com')
   })
 })

--- a/packages/control-plane/src/config/env.ts
+++ b/packages/control-plane/src/config/env.ts
@@ -277,10 +277,12 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
   if (!logtoEndpoint) return AppConfigChecked.parse(env)
 
   const logtoOrigin = new URL(SecureOriginSchema.parse(logtoEndpoint)).origin
+  const logtoMgmtEndpoint = env.LOGTO_MGMT_ENDPOINT?.trim()
+  const hasLogtoMgmtCredentials = Boolean(env.LOGTO_MGMT_APP_ID?.trim() || env.LOGTO_MGMT_APP_SECRET?.trim())
   return AppConfigChecked.parse({
     ...env,
     OIDC_ISSUER: env.OIDC_ISSUER?.trim() || `${logtoOrigin}/oidc`,
-    LOGTO_MGMT_ENDPOINT: env.LOGTO_MGMT_ENDPOINT?.trim() || logtoOrigin
+    LOGTO_MGMT_ENDPOINT: logtoMgmtEndpoint || (hasLogtoMgmtCredentials ? logtoOrigin : undefined)
   })
 }
 


### PR DESCRIPTION
## Summary

- keep the Logto login endpoint responsible for OIDC issuer derivation without implicitly enabling the Management API
- infer the Management API endpoint only when its credentials are being configured
- cover both login-only bootstrap and credential-backed Management API configuration

## Root cause

The bundled Logto Compose override provides `LOGTO_ENDPOINT` before Tenant Admin provisions a Management API M2M application. `loadConfig()` always derived `LOGTO_MGMT_ENDPOINT`, so the all-or-none Management API validator saw a partial configuration and restarted the Control Plane indefinitely on a fresh deployment.

## Validation

- `packages/control-plane/node_modules/.bin/vitest run src/config/env.test.ts` (11 tests)
- Prettier and `git diff --check`
- Control Plane Docker image build
- fresh-volume `docker compose -f compose.yaml -f compose.logto.yaml up -d`
- HTTP 200 from Control Plane, Relay, Web, Tenant Admin, and Logto
- pre-push ESLint

Created by Codex . GPT-5
