### PR TITLE
feat(cp): org-fence the hook data layer

### DIFF
--- a/packages/control-plane/src/github/comment-authz.service.test.ts
+++ b/packages/control-plane/src/github/comment-authz.service.test.ts
@@ -100,7 +100,7 @@ function make(
       opts.permissions?.[username] ?? opts.permission ?? 'write'
   )
   const service = new GithubCommentAuthzService({
-    hooks: { getMany } as unknown as Pick<HookRepo, 'getMany'>,
+    hooks: { getManyUnscoped: getMany } as unknown as Pick<HookRepo, 'getManyUnscoped'>,
     installations: { getByInstallationId } as unknown as Pick<GithubInstallationRepo, 'getByInstallationId'>,
     github: { repoRefForCommentAuthz, userRepoPermissionForCommentAuthz } as unknown as Pick<
       GithubService,

--- a/packages/control-plane/src/github/comment-authz.service.ts
+++ b/packages/control-plane/src/github/comment-authz.service.ts
@@ -4,7 +4,7 @@ import type { GithubInstallationRepo, HookRecord, HookRepo } from '../persistenc
 import type { GithubService } from './service.js'
 
 export interface GithubCommentAuthzDeps {
-  hooks: Pick<HookRepo, 'getMany'>
+  hooks: Pick<HookRepo, 'getManyUnscoped'>
   installations: Pick<GithubInstallationRepo, 'getByInstallationId'>
   github: Pick<GithubService, 'repoRefForCommentAuthz' | 'userRepoPermissionForCommentAuthz'>
   /** Test override; production stays below the relay's 5 second correlator. */
@@ -51,7 +51,10 @@ export class GithubCommentAuthzService {
     ]
     if (new Set(fences.map((fence) => fence.hookId)).size !== fences.length) return false
 
-    const hooks = await this.deps.hooks.getMany(fences.map((fence) => HookId(fence.hookId)))
+    // GitHub machinery (org-scoped-data-layer.md §4): the fences arrive on a
+    // durable run row, which already fixes the organization; the repo/fence
+    // matching below is the authority.
+    const hooks = await this.deps.hooks.getManyUnscoped(fences.map((fence) => HookId(fence.hookId)))
     const currentById = new Map<string, HookRecord>(hooks.map((hook) => [hook.id, hook]))
     const authorized = fences.map((fence) => {
       const hook = currentById.get(fence.hookId) ?? null
@@ -91,7 +94,7 @@ export class GithubCommentAuthzService {
     // The GitHub calls above can take seconds. Re-read immediately before the
     // allow verdict so a concurrent disable, retarget, or reassignment cannot
     // authorize any fan-out sibling whose durable snapshot is no longer current.
-    const refreshed = await this.deps.hooks.getMany(fences.map((fence) => HookId(fence.hookId)))
+    const refreshed = await this.deps.hooks.getManyUnscoped(fences.map((fence) => HookId(fence.hookId)))
     const refreshedById = new Map<string, HookRecord>(refreshed.map((candidate) => [candidate.id, candidate]))
     return fences.every((fence, index) => {
       const expected = authorizedHooks[index]

--- a/packages/control-plane/src/github/rerequest.service.test.ts
+++ b/packages/control-plane/src/github/rerequest.service.test.ts
@@ -142,12 +142,16 @@ function make(
     hooks: {
       findReviewProjectionByCheckRunId,
       listReviewProjectionsForSuiteRerequest,
-      get,
-      getMany,
+      getUnscoped: get,
+      getManyUnscoped: getMany,
       getRunById
     } as Pick<
       HookRepo,
-      'findReviewProjectionByCheckRunId' | 'listReviewProjectionsForSuiteRerequest' | 'get' | 'getMany' | 'getRunById'
+      | 'findReviewProjectionByCheckRunId'
+      | 'listReviewProjectionsForSuiteRerequest'
+      | 'getUnscoped'
+      | 'getManyUnscoped'
+      | 'getRunById'
     >,
     appId: APP_ID
   })

--- a/packages/control-plane/src/github/rerequest.service.ts
+++ b/packages/control-plane/src/github/rerequest.service.ts
@@ -4,7 +4,11 @@ import type { HookRecord, HookRepo, HookReviewProjectionRecord, HookRunRecord } 
 export interface GithubRerequestDeps {
   hooks: Pick<
     HookRepo,
-    'findReviewProjectionByCheckRunId' | 'listReviewProjectionsForSuiteRerequest' | 'get' | 'getMany' | 'getRunById'
+    | 'findReviewProjectionByCheckRunId'
+    | 'listReviewProjectionsForSuiteRerequest'
+    | 'getUnscoped'
+    | 'getManyUnscoped'
+    | 'getRunById'
   >
   appId: number
 }
@@ -36,7 +40,8 @@ export class GithubRerequestService {
     if (!this.matchesProjection(projection, req)) return { allowed: false }
 
     const [hook, run] = await Promise.all([
-      this.deps.hooks.get(projection.hookId),
+      // The hook behind a durable Check projection this resolver already matched.
+      this.deps.hooks.getUnscoped(projection.hookId),
       this.deps.hooks.getRunById(projection.currentHookRunId)
     ])
     if (!this.matchesCurrentHook(hook, projection) || !this.matchesCurrentRun(run, projection)) {
@@ -71,7 +76,7 @@ export class GithubRerequestService {
 
     const current = projections as Array<HookReviewProjectionRecord & { checkRunId: string; currentHookRunId: string }>
     const [hooks, runs] = await Promise.all([
-      this.deps.hooks.getMany(current.map((projection) => projection.hookId)),
+      this.deps.hooks.getManyUnscoped(current.map((projection) => projection.hookId)),
       Promise.all(current.map((projection) => this.deps.hooks.getRunById(projection.currentHookRunId)))
     ])
     const hooksById = new Map(hooks.map((hook) => [hook.id, hook]))

--- a/packages/control-plane/src/github/review-broker.service.test.ts
+++ b/packages/control-plane/src/github/review-broker.service.test.ts
@@ -110,7 +110,7 @@ function authorizeInput(
 function setup(overrides: Partial<GithubReviewBrokerDeps> = {}) {
   let currentRun = run()
   const hookRepo = {
-    get: vi.fn(async () => hook()),
+    getUnscoped: vi.fn(async () => hook()),
     getRun: vi.fn(async () => currentRun),
     recordStart: vi.fn(async () => true),
     reserveReviewAttempt: vi.fn(async (_hookId, _daemonId, input) => {
@@ -273,7 +273,7 @@ describe('GithubReviewBrokerService', () => {
 
   it('takes the lower of the fire snapshot and current policy before reserving', async () => {
     const { service, hookRepo } = setup()
-    hookRepo.get.mockResolvedValue(hook({ reviewPolicy: 'comment' }))
+    hookRepo.getUnscoped.mockResolvedValue(hook({ reviewPolicy: 'comment' }))
     await expect(service.authorize(authorizeInput('APPROVE'), DAEMON)).rejects.toMatchObject({
       code: 'SCOPE_DENIED'
     })
@@ -401,7 +401,7 @@ describe('GithubReviewBrokerService', () => {
 
   it('rejects an accepted turn after its hook is retargeted to another repository', async () => {
     const { service, hookRepo } = setup()
-    hookRepo.get.mockResolvedValue(hook({ repoId: 999n, repoFullName: 'acme/other' }))
+    hookRepo.getUnscoped.mockResolvedValue(hook({ repoId: 999n, repoFullName: 'acme/other' }))
 
     await expect(service.authorize(authorizeInput(), DAEMON)).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
     expect(hookRepo.reserveReviewAttempt).not.toHaveBeenCalled()
@@ -412,7 +412,7 @@ describe('GithubReviewBrokerService', () => {
     ['dispatch placement', { dispatchRevision: 10n }]
   ] as const)('rejects an old turn after a same-value %s ABA', async (_label, changed) => {
     const { service, hookRepo } = setup()
-    hookRepo.get.mockResolvedValue(hook(changed))
+    hookRepo.getUnscoped.mockResolvedValue(hook(changed))
 
     await expect(service.authorize(authorizeInput(), DAEMON)).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
     expect(hookRepo.reserveReviewAttempt).not.toHaveBeenCalled()
@@ -420,7 +420,7 @@ describe('GithubReviewBrokerService', () => {
 
   it('does not expose a token when the review lifecycle epoch changes during mint', async () => {
     const { service, hookRepo } = setup()
-    hookRepo.get.mockResolvedValueOnce(hook()).mockResolvedValue(hook({ projectionEpoch: 2n }))
+    hookRepo.getUnscoped.mockResolvedValueOnce(hook()).mockResolvedValue(hook({ projectionEpoch: 2n }))
 
     await expect(service.authorize(authorizeInput(), DAEMON)).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
     expect(hookRepo.recordReviewResult).toHaveBeenCalledWith(HOOK, DAEMON, {
@@ -458,7 +458,7 @@ describe('GithubReviewBrokerService', () => {
     const { service, hookRepo, setRun } = setup()
     setRun(run({ reviewAttemptId: ATTEMPT, reviewAttemptState: 'blocked', reviewEvent: 'APPROVE', verdict: 'pass' }))
     hookRepo.reserveReviewAttempt.mockResolvedValue('idempotent')
-    hookRepo.get.mockResolvedValueOnce(hook()).mockResolvedValueOnce(hook({ reviewPolicy: 'off' }))
+    hookRepo.getUnscoped.mockResolvedValueOnce(hook()).mockResolvedValueOnce(hook({ reviewPolicy: 'off' }))
 
     await expect(service.authorize(authorizeInput(), DAEMON)).rejects.toMatchObject({ code: 'SCOPE_DENIED' })
     expect(hookRepo.recordReviewResult).not.toHaveBeenCalled()

--- a/packages/control-plane/src/github/review-broker.service.ts
+++ b/packages/control-plane/src/github/review-broker.service.ts
@@ -44,7 +44,7 @@ export class GithubReviewBrokerError extends Error {
 }
 
 export interface GithubReviewBrokerDeps {
-  hook: Pick<HookRepo, 'get' | 'getRun' | 'recordStart' | 'reserveReviewAttempt' | 'recordReviewResult'>
+  hook: Pick<HookRepo, 'getUnscoped' | 'getRun' | 'recordStart' | 'reserveReviewAttempt' | 'recordReviewResult'>
   agent: Pick<AgentRepo, 'getUnscoped'>
   github: Pick<GithubService, 'mintReviewForAgent' | 'validateReviewForAgent'>
   clock: Pick<Clock, 'now'>
@@ -329,7 +329,7 @@ export class GithubReviewBrokerService {
       reportingDaemonId,
       { started: recovering }
     )
-    requireCurrentHookForStart(await this.deps.hook.get(hookId), run, reportingDaemonId)
+    requireCurrentHookForStart(await this.deps.hook.getUnscoped(hookId), run, reportingDaemonId)
     const agent = await this.deps.agent.getUnscoped(run.agentId!)
     if (!agent || agent.status !== 'active' || agent.daemonId !== reportingDaemonId) {
       denied('agent is no longer active on the accepted dispatch daemon')
@@ -354,7 +354,7 @@ export class GithubReviewBrokerService {
     }
     const target = requireTrustedPullTarget(initial)
     const current = requireCurrentActionAuthority(
-      await this.deps.hook.get(hookId),
+      await this.deps.hook.getUnscoped(hookId),
       await this.deps.agent.getUnscoped(initial.agentId),
       initial,
       reportingDaemonId,
@@ -407,7 +407,7 @@ export class GithubReviewBrokerService {
     )
     try {
       const finalAuthority = requireCurrentActionAuthority(
-        await this.deps.hook.get(hookId),
+        await this.deps.hook.getUnscoped(hookId),
         await this.deps.agent.getUnscoped(initial.agentId),
         finalRun,
         reportingDaemonId,
@@ -435,7 +435,7 @@ export class GithubReviewBrokerService {
         'review attempt reservation changed while authorizing'
       )
       requireCurrentActionAuthority(
-        await this.deps.hook.get(hookId),
+        await this.deps.hook.getUnscoped(hookId),
         await this.deps.agent.getUnscoped(initial.agentId),
         exposureRun,
         reportingDaemonId,

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -90,8 +90,8 @@ export function hookRoutes(deps: HttpDeps) {
     // agent the caller can't see, and any legacy orphaned hook all read as absent
     // (404, no existence oracle).
     const getOrgHook = async (req: FastifyRequest, id: string): Promise<HookRecord | null> => {
-      const hook = await deps.repos.hook.get(HookId(id))
-      if (!hook || hook.orgId !== req.orgCtx!.orgId || !hook.agentId) return null
+      const hook = await deps.repos.hook.get(orgOf(req), HookId(id))
+      if (!hook || !hook.agentId) return null
       const agent = await deps.repos.agent.get(orgOf(req), hook.agentId)
       if (!agent || !canView(agent, ctxOf(req))) return null
       return hook
@@ -430,7 +430,7 @@ export function hookRoutes(deps: HttpDeps) {
           })
           .catch(() => {})
         // Re-read so hmacConfigured reflects the secret written above.
-        const fresh = (await deps.repos.hook.get(hookId)) ?? hook
+        const fresh = (await deps.repos.hook.get(orgId, hookId)) ?? hook
         converge(fresh)
         return { ...toDto(fresh, deps.config.PUBLIC_RELAY_URL), hmacSecret }
       }
@@ -692,7 +692,7 @@ export function hookRoutes(deps: HttpDeps) {
         }
         // remove() atomically tombstones the current projection epoch under the
         // same hook lifecycle lock before deleting the definition.
-        await deps.repos.hook.remove(existing.id, existing.agentId!)
+        await deps.repos.hook.remove(orgOf(req), existing.id, existing.agentId!)
         void deps.repos.audit
           .append({
             kind: 'hook_change',
@@ -728,7 +728,7 @@ export function hookRoutes(deps: HttpDeps) {
         if (!hook) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'hook not found' })
         }
-        const runs = await deps.repos.hook.listRuns(hook.id)
+        const runs = await deps.repos.hook.listRuns(orgOf(req), hook.id)
         return runs.map((run) => ({
           id: run.id,
           deliveryKey: run.deliveryKey,

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -144,12 +144,13 @@ function hookMetadataForSession(metadata: Map<string, HookSessionMetadata>, sess
 async function hookMetadataForSessions(
   deps: HttpDeps,
   sessions: HookSessionRow[],
-  orgId: string
+  orgId: OrgId
 ): Promise<Map<string, HookSessionMetadata>> {
   const ids = [...new Set(sessions.map(hookIdForSession).filter((id): id is string => Boolean(id)))]
   const metadata = new Map<string, HookSessionMetadata>()
-  for (const hook of await deps.repos.hook.getMany(ids.map(HookId))) {
-    if (hook.orgId !== orgId) continue
+  // The batch read is org-fenced (org-scoped-data-layer.md §3), so foreign ids
+  // are simply absent — no post-filter needed.
+  for (const hook of await deps.repos.hook.getMany(orgId, ids.map(HookId))) {
     metadata.set(hook.id, { agentId: hook.agentId, kind: hook.kind, name: hook.name, repoId: hook.repoId })
   }
   return metadata

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -167,7 +167,8 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
       (err as { code?: string }).code === 'ORG_MEMBERSHIP_MISSING' ||
       (err as { code?: string }).code === 'AGENT_MISSING' ||
       (err as { code?: string }).code === 'BOT_MISSING' ||
-      (err as { code?: string }).code === 'CRON_MISSING'
+      (err as { code?: string }).code === 'CRON_MISSING' ||
+      (err as { code?: string }).code === 'HOOK_MISSING'
     ) {
       return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'resource not found' })
     }

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -157,6 +157,22 @@ export class MemoryConnectionMissing extends Error {
 }
 
 /**
+ * Thrown by org-fenced hook mutations whose fence sits on a transaction-time row
+ * read rather than on the write's own `where` (docs/designs/org-scoped-data-layer.md
+ * §3) — `HookRepo.upsert` (whose update branch would otherwise rewrite a foreign
+ * row's `orgId`) and `HookRepo.remove`, which must refuse before it tombstones
+ * the hook's durable review projections. A cross-org id is deliberately
+ * indistinguishable from a missing row.
+ */
+export class HookMissing extends Error {
+  readonly code = 'HOOK_MISSING' as const
+  constructor(readonly hookId: string) {
+    super(`hook ${hookId} not found in this organization`)
+    this.name = 'HookMissing'
+  }
+}
+
+/**
  * Thrown by the org-fenced `CronRepo.upsert` when the client-minted `cronId`
  * already names a row in ANOTHER organization (docs/designs/org-scoped-data-layer.md
  * §3). Unlike the other fences this one refuses a TAKEOVER rather than a leak:

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2258,15 +2258,39 @@ export interface ProjectionWriteResultInput {
 }
 
 export interface HookRepo {
+  /** Create-or-edit. `hookId` is minted server-side on create, so the update
+   *  branch is only ever reached with an id the route already resolved — but the
+   *  fence is structural anyway (docs/designs/org-scoped-data-layer.md §3): an id
+   *  that exists in ANOTHER organization throws {@link HookMissing} inside the
+   *  same transaction rather than letting the update rewrite that row's `orgId`. */
   upsert(input: UpsertHookInput): Promise<HookRecord>
-  remove(hookId: HookId, expectedAgentId?: AgentId): Promise<void>
-  get(hookId: HookId): Promise<HookRecord | null>
-  getMany(hookIds: HookId[]): Promise<HookRecord[]>
-  /** Every enabled hook, all orgs — the relay-register full-replay source. */
+  /** Org-fenced: a cross-org id throws the same missing-row error as an absent
+   *  one. `expectedAgentId` is the independent owner CAS (a rebind loser), kept. */
+  remove(orgId: OrgId, hookId: HookId, expectedAgentId?: AgentId): Promise<void>
+  /** Org-fenced point read (§3): a cross-org id reads as absent, exactly like a
+   *  missing row. The only hook read the HTTP/MCP surface may use. */
+  get(orgId: OrgId, hookId: HookId): Promise<HookRecord | null>
+  /** Tenancy-UNSCOPED read for internal trust domains — the GitHub review broker
+   *  and rerequest machinery resolving the hook behind a run/projection row, and
+   *  WS handlers resolving the hook a reporting daemon named. Never call this
+   *  from the HTTP surface; lint enforces it (§6). */
+  getUnscoped(hookId: HookId): Promise<HookRecord | null>
+  /** Org-fenced batch read: ids outside `orgId` are simply absent from the
+   *  result, exactly like unknown ids. */
+  getMany(orgId: OrgId, hookIds: HookId[]): Promise<HookRecord[]>
+  /** Tenancy-UNSCOPED batch read for the GitHub machinery: the comment-authorization
+   *  fences and the rerequest resolver address hooks by ids carried on durable
+   *  run/projection rows, which already fix the organization. Never call this
+   *  from the HTTP surface; lint enforces it (§6). */
+  getManyUnscoped(hookIds: HookId[]): Promise<HookRecord[]>
+  /** Every enabled hook, all orgs — the relay-register full-replay source.
+   *  System-tier: the relay pool is deployment-level infrastructure. */
   listEnabled(): Promise<HookRecord[]>
   /** A hook is subordinate to one agent and is only ever listed under it (the
    *  console detail page); access is gated by the AGENT's visibility, so no
-   *  viewer-filter here. Also the re-compile source on a placement change. */
+   *  viewer-filter here. Also the re-compile source on a placement change.
+   *  System-tier (§3.4): agent-fenced, and HTTP callers reach it only with an
+   *  agent id resolved through the org-fenced `AgentRepo.get`. */
   listForAgent(agentId: AgentId): Promise<HookRecord[]>
   /** Distinct kinds of ENABLED hooks per agent, org-wide in one query — feeds
    *  the agents-list read model (each agent's own row; no org hook list). */
@@ -2293,6 +2317,8 @@ export interface HookRepo {
     repoFullName: string,
     observedAt: Date
   ): Promise<GithubRepoFullNameRefreshResult>
+  /** System-tier: the run row behind a relay/daemon report or a durable
+   *  projection, always reached from system state that already fixes the org. */
   getRun(hookId: HookId, deliveryKey: string): Promise<HookRunRecord | null>
   /** Direct lookup for projection-owned metadata such as the terminal session deep link. */
   getRunById(runId: string): Promise<HookRunRecord | null>
@@ -2312,8 +2338,10 @@ export interface HookRepo {
    *  no prior delivery row (rc/run-report lost) still creates one, with
    *  `startedAt` estimated as `at − durationMs`. Returns acceptance. */
   recordReport(hookId: HookId, reportingDaemonId: DaemonId, input: HookReportInput, at: Date): Promise<boolean>
-  /** Run history for the console detail page, newest first. */
-  listRuns(hookId: HookId, limit?: number): Promise<HookRunRecord[]>
+  /** Run history for the console detail page, newest first. Run rows carry their
+   *  own `orgId`, so the fence rides this query directly rather than only through
+   *  the parent hook (§3.6). */
+  listRuns(orgId: OrgId, hookId: HookId, limit?: number): Promise<HookRunRecord[]>
   /** Which of `deliveryKeys` already have a run row (any hook) — the redelivery
    *  reconciler's "did this GUID land at all" probe. */
   existingDeliveryKeys(deliveryKeys: string[]): Promise<Set<string>>
@@ -2436,6 +2464,14 @@ export interface HookRepo {
 
 /** Per-hook HMAC signing key — read ONLY here, NEVER joined into a DTO
  *  (BotSecretStore discipline). */
+/**
+ * The per-hook HMAC secret. Rows are keyed by `hookId` alone and carry no org of
+ * their own, so this store fences through its parent (§3.6): `put` runs on the
+ * create path with a server-minted id, and `get`/`delete` belong to the relay
+ * hook-compile and lifecycle machinery. A route reaching a secret for an
+ * existing hook must resolve that hook through the org-fenced
+ * {@link HookRepo.get} first.
+ */
 export interface HookSecretStore {
   put(hookId: HookId, hmacSecret: string): Promise<void>
   get(hookId: HookId): Promise<string | null>

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -59,7 +59,7 @@ import {
   lockHookReviewOrgProducerScope
 } from '../review-projection-lock.js'
 import { authoritativeHookProjectionState } from '../../github/projection-state.js'
-import { AgentWorkspaceIntegrationConflict } from '../errors.js'
+import { AgentWorkspaceIntegrationConflict, HookMissing } from '../errors.js'
 
 type HookWithUsers = HookDef & {
   createdBy: User | null
@@ -480,6 +480,11 @@ export class PgHookRepo implements HookRepo {
         ])
         await lockHookReviewLifecycleScope(tx, input.hookId)
         const existing = await tx.hookDef.findUnique({ where: { id: input.hookId } })
+        // Tenancy fence (org-scoped-data-layer.md §3), under the same lock as
+        // the write it guards: an id that already names a row in another
+        // organization must not fall through to the update branch, which
+        // rewrites `orgId` and `agentId` along with the definition.
+        if (existing && existing.orgId !== input.orgId) throw new HookMissing(input.hookId)
         if (existing?.agentId && !lockedAgentIds.has(existing.agentId)) {
           return { kind: 'retry', owner: AgentId(existing.agentId) } as const
         }
@@ -587,7 +592,7 @@ export class PgHookRepo implements HookRepo {
     }
   }
 
-  async remove(hookId: HookId, expectedAgentId?: AgentId): Promise<void> {
+  async remove(orgId: OrgId, hookId: HookId, expectedAgentId?: AgentId): Promise<void> {
     let ownerHint =
       expectedAgentId ??
       (await this.db.hookDef.findUnique({ where: { id: hookId }, select: { agentId: true } }))?.agentId
@@ -596,14 +601,18 @@ export class PgHookRepo implements HookRepo {
       const result = await this.transaction(async (tx) => {
         const lockedAgentIds = await this.lockAgentLifecycleScopes(tx, [ownerHint ? AgentId(ownerHint) : null])
         await lockHookReviewLifecycleScope(tx, hookId)
-        const hook = await tx.hookDef.findUnique({ where: { id: hookId }, select: { agentId: true } })
+        const hook = await tx.hookDef.findUnique({ where: { id: hookId }, select: { agentId: true, orgId: true } })
+        // Org fence BEFORE the projection tombstones: reaching those with a
+        // foreign id would tear down another organization's durable Check
+        // projections and only then fail on the delete (§3).
+        if (hook && hook.orgId !== orgId) throw new HookMissing(hookId)
         if (hook?.agentId && !lockedAgentIds.has(hook.agentId)) {
           return { kind: 'retry', owner: AgentId(hook.agentId) } as const
         }
         const projections = await tx.hookReviewProjection.findMany({ where: { hookId } })
         await this.tombstoneProjectionRows(tx, projections, new Date(), 'failure')
         await tx.hookDef.delete({
-          where: { id: hookId, ...(expectedOwnerForMutation ? { agentId: expectedOwnerForMutation } : {}) }
+          where: { id: hookId, orgId, ...(expectedOwnerForMutation ? { agentId: expectedOwnerForMutation } : {}) }
         })
         return { kind: 'done' } as const
       })
@@ -612,12 +621,26 @@ export class PgHookRepo implements HookRepo {
     }
   }
 
-  async get(hookId: HookId): Promise<HookRecord | null> {
+  async get(orgId: OrgId, hookId: HookId): Promise<HookRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const h = await this.db.hookDef.findUnique({ where: { id: hookId, orgId }, include: withUsers })
+    return h ? toRecord(h) : null
+  }
+
+  async getUnscoped(hookId: HookId): Promise<HookRecord | null> {
     const h = await this.db.hookDef.findUnique({ where: { id: hookId }, include: withUsers })
     return h ? toRecord(h) : null
   }
 
-  async getMany(hookIds: HookId[]): Promise<HookRecord[]> {
+  async getMany(orgId: OrgId, hookIds: HookId[]): Promise<HookRecord[]> {
+    if (hookIds.length === 0) return []
+    // Ids outside the org drop out of the result exactly like unknown ones.
+    const rows = await this.db.hookDef.findMany({ where: { id: { in: hookIds }, orgId }, include: withUsers })
+    return rows.map(toRecord)
+  }
+
+  async getManyUnscoped(hookIds: HookId[]): Promise<HookRecord[]> {
     if (hookIds.length === 0) return []
     const rows = await this.db.hookDef.findMany({ where: { id: { in: hookIds } }, include: withUsers })
     return rows.map(toRecord)
@@ -1824,9 +1847,11 @@ export class PgHookRepo implements HookRepo {
     })
   }
 
-  async listRuns(hookId: HookId, limit = 50): Promise<HookRunRecord[]> {
+  async listRuns(orgId: OrgId, hookId: HookId, limit = 50): Promise<HookRunRecord[]> {
+    // Run rows carry their own `orgId`, so the fence rides this query rather
+    // than resting solely on the parent hook (org-scoped-data-layer.md §3.6).
     const rows = await this.db.hookRun.findMany({
-      where: { hookId },
+      where: { hookId, orgId },
       orderBy: { startedAt: 'desc' },
       take: limit
     })

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -17,7 +17,7 @@ function scopedDeps(extra: Record<string, unknown>): DaemonWsDeps {
   return {
     agent: { getUnscoped: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
     agentMutations: { tryBeginMutation: vi.fn(() => vi.fn()) },
-    hook: { get: vi.fn().mockResolvedValue(null) },
+    hook: { getUnscoped: vi.fn().mockResolvedValue(null) },
     ...extra
   } as unknown as DaemonWsDeps
 }
@@ -555,7 +555,7 @@ describe('handleEventSession', () => {
     const deps = scopedDeps({
       session: { recordMilestone },
       hook: {
-        get: vi.fn().mockResolvedValue({ kind: 'github', agentId: AGENT_ID })
+        getUnscoped: vi.fn().mockResolvedValue({ kind: 'github', agentId: AGENT_ID })
       },
       events: { publish: vi.fn() }
     })

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -67,7 +67,9 @@ async function externalCandidate(p: EventSession, agentId: AgentId, deps: Daemon
       : p.platform === 'hook'
         ? p.channel
         : undefined
-    const hook = triggerId ? await deps.hook.get(HookId(triggerId)) : null
+    // Daemon trust domain: the hook a reporting daemon named as a session's
+    // trigger; the `hook.agentId === agentId` check below binds it (§4).
+    const hook = triggerId ? await deps.hook.getUnscoped(HookId(triggerId)) : null
     const legacyGithub = hook?.kind === 'github' && hook.agentId === agentId
     if (legacyGithub) return { provider: 'github', resolution: 'pending' as const }
 

--- a/packages/control-plane/src/ws/handlers/gitcred.test.ts
+++ b/packages/control-plane/src/ws/handlers/gitcred.test.ts
@@ -81,7 +81,7 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
     const deps = {
       agent: { getUnscoped: async () => PLACED_AGENT },
       hook: {
-        get: async () => ({
+        getUnscoped: async () => ({
           agentId: AGENT_ID,
           kind: 'github',
           enabled: true,
@@ -123,7 +123,7 @@ describe('handleGitCredRequest — repoFullName passthrough (issue #457)', () =>
     const mintForHookReply = vi.fn()
     const deps = {
       agent: { getUnscoped: async () => PLACED_AGENT },
-      hook: { get: async () => null },
+      hook: { getUnscoped: async () => null },
       github: { mintForHookReply }
     } as unknown as DaemonWsDeps
     const conn = fakeConn()

--- a/packages/control-plane/src/ws/handlers/gitcred.ts
+++ b/packages/control-plane/src/ws/handlers/gitcred.ts
@@ -61,7 +61,8 @@ export const handleGitCredRequest: Handler = async (frame, conn, deps) => {
       // environment. Its authority is the enabled hook itself, not the
       // workspace contents gitAccess (read workspaces must still be able to
       // deliver the reply promised by an always-on GitHub hook).
-      const hook = await deps.hook.get(HookId(hookId))
+      // Daemon trust domain: the hook named by the requesting daemon's own run (§4).
+      const hook = await deps.hook.getUnscoped(HookId(hookId))
       if (!hook || hook.agentId !== AgentId(agentId) || hook.kind !== 'github' || !hook.enabled) {
         conn.sendError(frame.id, 'SCOPE_DENIED', 'hook is not an enabled github hook of this agent', false)
         return

--- a/packages/control-plane/test/integration/hook-report.test.ts
+++ b/packages/control-plane/test/integration/hook-report.test.ts
@@ -118,7 +118,7 @@ async function recordGithubDeliveryFailure(
   reason: typeof HOOK_DELIVERY_REASON_DAEMON_OFFLINE | typeof HOOK_DELIVERY_REASON_DISPATCH_TIMEOUT,
   daemonId = DAEMON
 ) {
-  const hook = (await repo().get(HookId(hookId)))!
+  const hook = (await repo().getUnscoped(HookId(hookId)))!
   await repo().recordDelivery(HookId(hookId), {
     deliveryKey,
     firedAt,
@@ -140,7 +140,7 @@ async function recordGithubDeliveryFailure(
 }
 
 async function recordGithubPullDeliveryFailure(hookId: string, agentId: string, deliveryKey: string, firedAt: Date) {
-  const hook = (await repo().get(HookId(hookId)))!
+  const hook = (await repo().getUnscoped(HookId(hookId)))!
   await repo().recordDelivery(HookId(hookId), {
     deliveryKey,
     firedAt,
@@ -175,10 +175,10 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     const firedAt = new Date('2026-07-03T09:00:00.000Z')
 
     await repo().recordDelivery(HookId(hookId), { deliveryKey: 'd-1', firedAt, status: 'accepted' })
-    let runs = await repo().listRuns(HookId(hookId))
+    let runs = await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId))
     expect(runs).toHaveLength(1)
     expect(runs[0]).toMatchObject({ deliveryKey: 'd-1', status: 'running', durationMs: null, sessionId: null })
-    expect((await repo().get(HookId(hookId)))!.lastFiredAt).toEqual(firedAt)
+    expect((await repo().getUnscoped(HookId(hookId)))!.lastFiredAt).toEqual(firedAt)
 
     const completion = await report(DAEMON, hookId, agentId, 'd-1', {
       status: 'success',
@@ -187,7 +187,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     })
     expect(completion.conn.replyTo).toHaveBeenCalledWith(completion.frame, 'ack', { ok: true })
     expect(completion.conn.sendError).not.toHaveBeenCalled()
-    runs = await repo().listRuns(HookId(hookId))
+    runs = await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId))
     expect(runs).toHaveLength(1) // closed, not duplicated
     expect(runs[0]).toMatchObject({ status: 'success', durationMs: 5200, sessionId: 'ses_9' })
   })
@@ -200,7 +200,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
       status: 'failed',
       reason: 'daemon_offline'
     })
-    const runs = await repo().listRuns(HookId(hookId))
+    const runs = await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId))
     expect(runs[0]).toMatchObject({ status: 'failed', reason: 'daemon_offline' })
   })
 
@@ -274,7 +274,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     const siblingHookId = await seedGithubHook(agentId)
     const firedAt = new Date('2026-07-03T10:30:00.000Z')
     await recordGithubDeliveryFailure(hookId, agentId, 'mixed-guid', firedAt, HOOK_DELIVERY_REASON_DAEMON_OFFLINE)
-    const sibling = (await repo().get(HookId(siblingHookId)))!
+    const sibling = (await repo().getUnscoped(HookId(siblingHookId)))!
     await repo().recordDelivery(HookId(siblingHookId), {
       deliveryKey: 'mixed-guid',
       firedAt,
@@ -373,7 +373,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     await seedDaemon(prisma, OTHER_DAEMON)
     await prisma.agent.update({ where: { id: agentId }, data: { daemonId: OTHER_DAEMON } })
     await prisma.hookDef.update({ where: { id: hookId }, data: { dispatchRevision: { increment: 1 } } })
-    const current = (await repo().get(HookId(hookId)))!
+    const current = (await repo().getUnscoped(HookId(hookId)))!
     const timeoutAt = new Date(firedAt.getTime() + 1_000)
     expect(
       await repo().recordDelivery(HookId(hookId), {
@@ -431,7 +431,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     await seedDaemon(prisma, OTHER_DAEMON)
     await prisma.agent.update({ where: { id: agentId }, data: { daemonId: OTHER_DAEMON } })
     await prisma.hookDef.update({ where: { id: hookId }, data: { dispatchRevision: { increment: 1 } } })
-    const current = (await repo().get(HookId(hookId)))!
+    const current = (await repo().getUnscoped(HookId(hookId)))!
     const completion = await report(OTHER_DAEMON, hookId, agentId, 'accepted-report-lost', {
       event: 'issues:opened',
       status: 'success',
@@ -482,7 +482,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     await seedDaemon(prisma, OTHER_DAEMON)
     await prisma.agent.update({ where: { id: agentId }, data: { daemonId: OTHER_DAEMON } })
     await prisma.hookDef.update({ where: { id: hookId }, data: { dispatchRevision: { increment: 1 } } })
-    const current = (await repo().get(HookId(hookId)))!
+    const current = (await repo().getUnscoped(HookId(hookId)))!
     const startedAt = new Date(firedAt.getTime() + 1_000)
     expect(
       await repo().recordStart(HookId(hookId), DaemonId(OTHER_DAEMON), {
@@ -680,7 +680,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     await seedDaemon(prisma, OTHER_DAEMON)
     await prisma.agent.update({ where: { id: agentId }, data: { daemonId: OTHER_DAEMON } })
     await prisma.hookDef.update({ where: { id: hookId }, data: { dispatchRevision: { increment: 1 } } })
-    const claimed = (await repo().get(HookId(hookId)))!
+    const claimed = (await repo().getUnscoped(HookId(hookId)))!
     expect(
       await repo().claimRetryableDeliveryRedelivery('claim-placement-pin', [HookId(hookId)], firedAt, [30_000, 120_000])
     ).toBe(true)
@@ -748,7 +748,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
 
   it('does not create a durable GitHub retry gate for Check rererequests', async () => {
     const { agentId, hookId } = await placedGithubHook()
-    const hook = (await repo().get(HookId(hookId)))!
+    const hook = (await repo().getUnscoped(HookId(hookId)))!
     await repo().recordDelivery(HookId(hookId), {
       deliveryKey: 'check-rerequest',
       firedAt: new Date('2026-07-03T10:58:00.000Z'),
@@ -775,7 +775,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     await seedDaemon(prisma, OTHER_DAEMON)
     await prisma.agent.update({ where: { id: agentId }, data: { daemonId: OTHER_DAEMON } })
     await prisma.hookDef.update({ where: { id: hookId }, data: { dispatchRevision: { increment: 1 } } })
-    const current = (await repo().get(HookId(hookId)))!
+    const current = (await repo().getUnscoped(HookId(hookId)))!
     const acceptedAt = new Date('2026-07-03T11:00:01.000Z')
     expect(
       await repo().recordDelivery(HookId(hookId), {
@@ -839,7 +839,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
       where: { id: hookId },
       data: { dispatchRevision: { increment: 1 } }
     })
-    const current = (await repo().get(HookId(hookId)))!
+    const current = (await repo().getUnscoped(HookId(hookId)))!
     expect(
       await repo().recordDelivery(HookId(hookId), {
         deliveryKey: 'same-daemon-reopen',
@@ -872,7 +872,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
 
   it('never claims or reopens nonretryable and effect-bearing failed rows', async () => {
     const { agentId, hookId } = await placedGithubHook()
-    const hook = (await repo().get(HookId(hookId)))!
+    const hook = (await repo().getUnscoped(HookId(hookId)))!
     const accepted = {
       firedAt: new Date('2026-07-03T12:00:01.000Z'),
       status: 'accepted' as const,
@@ -955,7 +955,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     await report(DAEMON, hookId, agentId, 'd-1', { status: 'success', sessionId: 'ses_1' })
     // The redelivery re-posts `accepted` — must NOT reopen the closed run.
     await repo().recordDelivery(HookId(hookId), { deliveryKey: 'd-1', firedAt, status: 'accepted' })
-    const runs = await repo().listRuns(HookId(hookId))
+    const runs = await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId))
     expect(runs).toHaveLength(1)
     expect(runs[0]!.status).toBe('success')
   })
@@ -976,10 +976,13 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
       false
     )
     expect(foreign.conn.replyTo).not.toHaveBeenCalled()
-    expect((await repo().listRuns(HookId(hookId)))[0]!.status).toBe('running') // untouched
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]!.status).toBe('running') // untouched
 
     await report(DAEMON, hookId, agentId, 'd-1', { status: 'success', sessionId: 'ses_ok' })
-    expect((await repo().listRuns(HookId(hookId)))[0]).toMatchObject({ status: 'success', sessionId: 'ses_ok' })
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]).toMatchObject({
+      status: 'success',
+      sessionId: 'ses_ok'
+    })
   })
 
   it('a metadata-light run still rejects a different agent on the same daemon', async () => {
@@ -999,11 +1002,11 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
       'hook completion does not match the accepted dispatch',
       false
     )
-    expect((await repo().listRuns(HookId(hookId)))[0]!.status).toBe('running')
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]!.status).toBe('running')
 
     const accepted = await report(DAEMON, hookId, agentId, 'd-legacy', { status: 'success' })
     expect(accepted.conn.replyTo).toHaveBeenCalledWith(accepted.frame, 'ack', { ok: true })
-    expect((await repo().listRuns(HookId(hookId)))[0]!.status).toBe('success')
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]!.status).toBe('success')
   })
 
   it('a completion with no prior delivery row (CP down at fire) still creates the run', async () => {
@@ -1013,7 +1016,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
       durationMs: 800,
       reason: 'turn failed'
     })
-    const runs = await repo().listRuns(HookId(hookId))
+    const runs = await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId))
     expect(runs).toHaveLength(1)
     expect(runs[0]).toMatchObject({ deliveryKey: 'd-late', status: 'failed', reason: 'turn failed' })
   })
@@ -1040,12 +1043,15 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
 
     const reaped = await repo().reapStaleRuns(new Date('2026-07-03T09:05:00.000Z'))
     expect(reaped).toBe(1)
-    const reapedRun = (await repo().listRuns(HookId(hookId)))[0]!
+    const reapedRun = (await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]!
     expect(reapedRun.status).toBe('failed')
     expect(reapedRun.reason).toMatch(/no completion report/)
 
     // The daemon's report finally lands — last-writer-wins overwrites the reap.
     await report(DAEMON, hookId, agentId, 'd-slow', { status: 'success', sessionId: 'ses_late' })
-    expect((await repo().listRuns(HookId(hookId)))[0]).toMatchObject({ status: 'success', sessionId: 'ses_late' })
+    expect((await repo().listRuns(OrgId(DEFAULT_ORG_ID), HookId(hookId)))[0]).toMatchObject({
+      status: 'success',
+      sessionId: 'ses_late'
+    })
   })
 })

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -20,8 +20,9 @@ import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
 import { PgBotRepo, PgIntegrationRepo } from '../../src/persistence/repositories/integration.repo.js'
 import { PgCronRepo } from '../../src/persistence/repositories/cron.repo.js'
-import { AgentMissing, BotMissing, CronMissing } from '../../src/persistence/errors.js'
-import { AgentId, BotId, CronId, DaemonId, IntegrationId, OrgId } from '../../src/domain/ids.js'
+import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
+import { AgentMissing, BotMissing, CronMissing, HookMissing } from '../../src/persistence/errors.js'
+import { AgentId, BotId, CronId, DaemonId, HookId, IntegrationId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -40,6 +41,8 @@ let ownIntegrationId: string
 let foreignChannelId: string
 let foreignCronId: string
 let ownCronId: string
+let foreignHookId: string
+let foreignHookRunId: string
 
 afterEach(async () => {
   await running?.close()
@@ -146,6 +149,33 @@ beforeEach(async () => {
       trigger: 'foreign trigger'
     }
   })
+
+  // A foreign hook plus one historical run, so the fence has both the definition
+  // and its child run rows to keep out of reach.
+  foreignHookId = randomUUID()
+  await prisma.hookDef.create({
+    data: {
+      id: foreignHookId,
+      orgId: foreignOrgId,
+      agentId: foreignAgentId,
+      kind: 'webhook',
+      name: 'foreign-hook',
+      sessionMode: 'perDelivery',
+      urlToken: randomUUID().replace(/-/g, ''),
+      enabled: true
+    }
+  })
+  foreignHookRunId = randomUUID()
+  await prisma.hookRun.create({
+    data: {
+      id: foreignHookRunId,
+      hookId: foreignHookId,
+      orgId: foreignOrgId,
+      deliveryKey: `delivery-${randomUUID()}`,
+      startedAt: new Date('2026-08-01T00:00:00.000Z'),
+      status: 'success'
+    }
+  })
 })
 
 function build(): HttpApp {
@@ -191,6 +221,17 @@ async function foreignCronUnmodified(): Promise<void> {
   expect(row!.agentId).toBe(foreignAgentId)
   expect(row!.name).toBe('foreign-cron')
   expect(row!.trigger).toBe('foreign trigger')
+}
+
+async function foreignHookUnmodified(): Promise<void> {
+  const row = await prisma.hookDef.findUnique({ where: { id: foreignHookId } })
+  expect(row).not.toBeNull()
+  expect(row!.orgId).toBe(foreignOrgId)
+  expect(row!.agentId).toBe(foreignAgentId)
+  expect(row!.name).toBe('foreign-hook')
+  expect(row!.enabled).toBe(true)
+  // The run row hangs off the hook; a removal would have tombstoned it too.
+  expect(await prisma.hookRun.findUnique({ where: { id: foreignHookRunId } })).not.toBeNull()
 }
 
 async function foreignBotUnmodified(): Promise<void> {
@@ -624,5 +665,75 @@ describe('tenant isolation — IntegrationRepo and CronRepo fences under the rou
       expect(row!.orgId).toBe(winner === 0 ? DEFAULT_ORG_ID : foreignOrgId)
       await prisma.cronDef.delete({ where: { id: contestedId } })
     }
+  })
+})
+
+describe('tenant isolation — Hook over the REST surface', () => {
+  it('point-GET of a foreign hook id reads as absent (404)', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/hooks/${foreignHookId}` })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('PUT of a foreign hook id is 404 and provably writes nothing', async () => {
+    const app = build()
+    const res = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/hooks/${foreignHookId}`,
+      payload: { kind: 'webhook', agentId: ownAgentId, name: 'hijacked', enabled: false }
+    })
+    expect(res.statusCode).toBe(404)
+    await foreignHookUnmodified()
+  })
+
+  it('DELETE of a foreign hook id is 404, and its runs and projections survive', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'DELETE', url: `${ORG}/hooks/${foreignHookId}` })
+    expect(res.statusCode).toBe(404)
+    await foreignHookUnmodified()
+  })
+
+  it('the run history of a foreign hook id is 404', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/hooks/${foreignHookId}/runs` })
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+describe('tenant isolation — HookRepo fences under the routes', () => {
+  it('hook reads and mutations treat a cross-org id exactly like a missing row', async () => {
+    const repo = new PgHookRepo(prisma)
+
+    expect(await repo.get(CALLER_ORG, HookId(foreignHookId))).toBeNull()
+    expect(await repo.get(CALLER_ORG, HookId(randomUUID()))).toBeNull()
+    // The batch read simply drops foreign ids, exactly like unknown ones.
+    expect(await repo.getMany(CALLER_ORG, [HookId(foreignHookId)])).toEqual([])
+
+    // `upsert` is create-or-edit on an id the caller supplies, so its update
+    // branch would rewrite the foreign row's orgId and agentId — refused inside
+    // the transaction, before the definition or its projections are touched.
+    await expect(
+      repo.upsert({
+        hookId: HookId(foreignHookId),
+        orgId: CALLER_ORG,
+        agentId: AgentId(ownAgentId),
+        kind: 'webhook',
+        name: 'hijacked',
+        sessionMode: 'perDelivery'
+      })
+    ).rejects.toBeInstanceOf(HookMissing)
+
+    // `remove` refuses BEFORE it tombstones the hook's durable review projections.
+    await expect(repo.remove(CALLER_ORG, HookId(foreignHookId))).rejects.toBeInstanceOf(HookMissing)
+
+    // Run rows carry their own org, so the history reads empty rather than
+    // another organization's delivery record.
+    expect(await repo.listRuns(CALLER_ORG, HookId(foreignHookId))).toEqual([])
+
+    await foreignHookUnmodified()
+
+    // The unscoped reads are the GitHub-machinery / daemon escape hatches.
+    expect(await repo.getUnscoped(HookId(foreignHookId))).not.toBeNull()
+    expect(await repo.getManyUnscoped([HookId(foreignHookId)])).toHaveLength(1)
   })
 })

--- a/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
+++ b/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
@@ -1544,12 +1544,12 @@ describe('R1/R2a persistence foundation', () => {
       reportingMode: 'check',
       gateMode: 'informational'
     })
-    expect((await hooks.get(hookId))?.dispatchRevision).toBe(1n)
+    expect((await hooks.getUnscoped(hookId))?.dispatchRevision).toBe(1n)
 
     expect(await agents.movePlacement(agentId, D1, D2)).not.toBeNull()
-    expect((await hooks.get(hookId))?.dispatchRevision).toBe(2n)
+    expect((await hooks.getUnscoped(hookId))?.dispatchRevision).toBe(2n)
     await agents.setPlacement(agentId, null)
-    expect((await hooks.get(hookId))?.dispatchRevision).toBe(3n)
+    expect((await hooks.getUnscoped(hookId))?.dispatchRevision).toBe(3n)
   })
 
   it('converges renamed GitHub display fields without changing session affinity or accepting stale names', async () => {
@@ -2185,7 +2185,7 @@ describe('R1/R2a persistence foundation', () => {
     expect(await repo.listRunsNeedingReviewProjection()).toEqual([])
 
     // Hook deletion must not erase the historical run or durable external-effect row.
-    await repo.remove(hookId)
+    await repo.remove(OrgId(DEFAULT_ORG_ID), hookId)
     expect(await repo.getRun(hookId, accepted.deliveryKey)).not.toBeNull()
     expect(await repo.getReviewProjection(projection.id)).not.toBeNull()
   })


### PR DESCRIPTION
Fourth batch of the org-scoped data-layer rollout
(`docs/designs/org-scoped-data-layer.md` §7 M2), after #699 (Agent), #704
(Daemon/Bot) and #706 (Integration/Channel/Cron): `HookRepo`, with `HookSecret`
and `HookRun` as its child rows.

## Migrated methods

| Method | New shape | Why |
| --- | --- | --- |
| `get(id)` | `get(orgId, id)` + `getUnscoped(id)` | org filter rides the unique lookup |
| `getMany(ids)` | `getMany(orgId, ids)` + `getManyUnscoped(ids)` | foreign ids drop out of the result exactly like unknown ones |
| `upsert(input)` | fence inside the existing transaction | see below |
| `remove(id, expectedAgentId?)` | `remove(orgId, id, …)` | fence before the projection tombstones; see below |
| `listRuns(id, limit?)` | `listRuns(orgId, id, limit?)` | run rows carry their own `orgId`, so the fence rides the query rather than resting on the parent |
| `listEnabled` | unchanged | system-tier: the relay-register full replay is deployment-level infrastructure |
| `listForAgent` | unchanged | system-tier (§3.4): agent-fenced, and HTTP callers reach it only with an agent id already resolved through the org-fenced `AgentRepo.get` |
| `kindsByAgent`, `listForOrgKind`, `listIdsForOrgKind` | unchanged | already org-carrying |
| `getRun`, `recordDelivery*`, `recordStart`, `recordReport`, `reserveReviewAttempt`, `recordReviewResult`, every projection/outbox/lease/claim/reaper method | unchanged | system-tier: relay and daemon reports (daemon-fenced), CAS-fenced durable projections, and background sweeps — all reached from system state that already fixes the org |

`HookSecretStore` and the run/projection tables carry no `orgId` of their own
(or, for `HookRun`, are addressed through the hook), so they fence through their
parent per §3.6. The ports now say so explicitly, and the contract suite asserts
it rather than leaving it as prose.

## Two fences that had to sit before side effects

Both are transaction-time row reads rather than a `where` clause, so both raise
the new `HookMissing` (registered in the `http/server.ts` 404 mapping beside
`AGENT_MISSING`, `BOT_MISSING` and `CRON_MISSING`):

- **`upsert`** — its update branch rewrites `orgId` and `agentId` along with the
  definition. `hookId` is minted server-side, so today only the pre-checked
  update route can reach it, but the fence is structural anyway. It rides the
  read the transaction already does under the hook lifecycle lock.
- **`remove`** — it enumerates and tombstones the hook's durable Check
  projections *before* deleting the definition. Fencing only on the delete would
  have torn down another organization's projections first and failed afterwards,
  so the check goes on the row read that opens the critical section.

## Caller classification

- **Routes** (`hooks.ts`, `sessions.ts`) thread `orgOf(req)` and drop their
  `hook.orgId !== …` comparisons. `sessions.ts` also drops a post-filter loop
  now that the batch read is fenced; its `orgId` parameter was `string` and is
  now `OrgId`.
- **`getUnscoped` / `getManyUnscoped`** — the GitHub machinery
  (`review-broker.service.ts`, `comment-authz.service.ts`,
  `rerequest.service.ts`), which addresses hooks by ids carried on durable run
  and projection rows, and the WS handlers (`event-session`, `gitcred`) resolving
  a hook their own reporting daemon named. Every one keeps its existing ownership
  checks — repo/fence matching, `hook.agentId === agentId`, the dispatch fence.
  The `Pick<HookRepo, …>` deps interfaces in those services were renamed in step,
  so a stale caller could not compile.

## Acceptance gate

`test/integration/tenant-isolation.route.test.ts` grows a Hook block: point-GET,
PUT, DELETE and the run history against a foreign id are all 404 with the
definition, its `enabled` flag and its run row provably intact; the repo-level
test asserts `upsert` and `remove` both raise `HookMissing`, that `getMany`
drops a foreign id while `getManyUnscoped` still returns it, and that `listRuns`
reads empty rather than returning another organization's delivery record.

Green: full-repo `typecheck` and `lint`, CP `test:unit` (1256) and `test:int` (1022).
