### PR TITLE
fix(setup): use GitHub manifest email permission

### DIFF
--- a/packages/setup/src/github-app.ts
+++ b/packages/setup/src/github-app.ts
@@ -42,7 +42,7 @@ export const GITHUB_APP_PERMISSIONS = {
   actions: 'write',
   checks: 'write',
   workflows: 'write',
-  email_addresses: 'read'
+  emails: 'read'
 } as const
 
 export const GITHUB_APP_EVENTS = [
@@ -213,12 +213,6 @@ function sameRecord(left: unknown, right: Record<string, string>): boolean {
   )
 }
 
-function githubApiPermissions(manifestPermissions: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(manifestPermissions).map(([key, value]) => [key === 'email_addresses' ? 'emails' : key, value])
-  )
-}
-
 function sameStringSet(left: unknown, right: readonly string[]): boolean {
   if (!Array.isArray(left) || !left.every((value) => typeof value === 'string')) return false
   return JSON.stringify([...left].sort()) === JSON.stringify([...right].sort())
@@ -255,7 +249,7 @@ export async function auditGithubApp(
   if (app.external_url !== expectedManifest.url) {
     addDiff('external_url', 'Homepage URL', app.external_url ?? null, expectedManifest.url ?? null)
   }
-  const expectedPermissions = githubApiPermissions(GITHUB_APP_PERMISSIONS)
+  const expectedPermissions = GITHUB_APP_PERMISSIONS
   if (!sameRecord(app.permissions, expectedPermissions)) {
     addDiff('permissions', 'Repository permissions', asRecord(app.permissions), expectedPermissions)
   }


### PR DESCRIPTION
## Summary

- use the GitHub parameterized permission name emails in App manifests
- keep the post-creation permission audit aligned with the GitHub App response
- remove the obsolete permission-key normalization

## Why

Tenant Admin sent email_addresses, which GitHub Manifest Flow rejects as an unknown parameterized permission. The earlier audit-only conversion kept already-created Apps from appearing mismatched, but did not correct the manifest payload used to create new Apps.

## Validation

- pnpm --filter @agentconnect.md/setup... build
- pnpm --filter @agentconnect.md/setup typecheck
- pnpm exec eslint packages/setup/src/github-app.ts
- rebuilt and restarted only the local Tenant Admin service without clearing data
- confirmed the live GitHub start response emits emails with read access
- submitted the full fixed manifest to the GitHub creation preview and reached the Create GitHub App page without creating an App
- pre-push eslint .
- git diff --check

Created by Codex . GPT-5