### PR TITLE
feat(cp): org-fence the MCP, skill-source and knowledge data layers

### DIFF
--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -849,8 +849,8 @@ export function agentRoutes(deps: HttpDeps) {
       if (!ids || ids.length === 0) return null
       const repo = deps.repos.organizationKnowledge
       if (!repo) return 'managed skills are unavailable on this control plane'
-      const rows = await Promise.all([...new Set(ids)].map((id) => repo.getManagedSkill(id)))
-      const invalid = rows.some((row) => !row || row.orgId !== orgId || row.archivedAt !== null)
+      const rows = await Promise.all([...new Set(ids)].map((id) => repo.getManagedSkill(orgId, id)))
+      const invalid = rows.some((row) => !row || row.archivedAt !== null)
       return invalid ? 'managed skill not found, archived, or outside this organization' : null
     }
 

--- a/packages/control-plane/src/http/routes/connectors.ts
+++ b/packages/control-plane/src/http/routes/connectors.ts
@@ -205,7 +205,7 @@ export function connectorRoutes(deps: HttpDeps) {
             const agents = await deps.repos.agent.list(orgId)
             if (agents.some((a) => a.mcpServers.includes(provider.name))) return
             await pushUnassign(provider, orgId)
-            await deps.repos.mcpProvider.delete(provider.id)
+            await deps.repos.mcpProvider.delete(orgId, provider.id)
           })
           // A 4xx upstream is the caller's fault (bad creds) → 400; anything else → 502.
           // Keep the body's statusCode consistent with the HTTP status actually sent.
@@ -237,9 +237,10 @@ export function connectorRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (!deps.connectors) return reply.code(404).send(notFound)
         if (denyViewerWrite(req, reply)) return
-        const provider = await deps.repos.mcpProvider.get(req.params.id)
-        // A cross-org id OR a restricted provider the caller can't see both read as 404.
-        if (!provider || provider.orgId !== orgOf(req) || !canView(provider, ctxOf(req))) {
+        const provider = await deps.repos.mcpProvider.get(orgOf(req), req.params.id)
+        // A cross-org id (fenced in the repo) OR a restricted provider the caller
+        // can't see both read as 404.
+        if (!provider || !canView(provider, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'connection not found' })
         }
         if (provider.kind !== 'open_connector') {

--- a/packages/control-plane/src/http/routes/mcp-providers.ts
+++ b/packages/control-plane/src/http/routes/mcp-providers.ts
@@ -197,9 +197,10 @@ export function mcpProviderRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const p = await deps.repos.mcpProvider.get(req.params.id)
-        // A cross-org id OR a restricted provider the caller can't see both read as 404.
-        if (!p || p.orgId !== orgOf(req) || !canView(p, ctxOf(req))) {
+        const p = await deps.repos.mcpProvider.get(orgOf(req), req.params.id)
+        // A cross-org id (fenced in the repo) OR a restricted provider the caller
+        // can't see both read as 404.
+        if (!p || !canView(p, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'mcp provider not found' })
         }
         return toDto(p, ctxOf(req), (await deps.repos.mcpProviderSecret.get(p.id)) ?? [])
@@ -288,8 +289,8 @@ export function mcpProviderRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const existing = await deps.repos.mcpProvider.get(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req) || !canView(existing, ctxOf(req))) {
+        const existing = await deps.repos.mcpProvider.get(orgOf(req), req.params.id)
+        if (!existing || !canView(existing, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'mcp provider not found' })
         }
         // An open_connector row's url (the shared open-connector /mcp endpoint) and headers
@@ -311,7 +312,7 @@ export function mcpProviderRoutes(deps: HttpDeps) {
         // no atomic rename, so only the url may change the row here.
         const provider =
           req.body.url !== undefined
-            ? await deps.repos.mcpProvider.update(existing.id, { url: req.body.url })
+            ? await deps.repos.mcpProvider.update(orgOf(req), existing.id, { url: req.body.url })
             : existing
         if (req.body.headers !== undefined) await deps.repos.mcpProviderSecret.put(provider.id, req.body.headers)
         const headers = req.body.headers ?? (await deps.repos.mcpProviderSecret.get(provider.id)) ?? []
@@ -341,8 +342,8 @@ export function mcpProviderRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const provider = await deps.repos.mcpProvider.get(req.params.id)
-        if (!provider || provider.orgId !== orgOf(req) || !canView(provider, ctxOf(req))) {
+        const provider = await deps.repos.mcpProvider.get(orgOf(req), req.params.id)
+        if (!provider || !canView(provider, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'mcp provider not found' })
         }
         const headers = (await deps.repos.mcpProviderSecret.get(provider.id)) ?? []
@@ -380,8 +381,8 @@ export function mcpProviderRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const existing = await deps.repos.mcpProvider.get(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req) || !canView(existing, ctxOf(req))) {
+        const existing = await deps.repos.mcpProvider.get(orgOf(req), req.params.id)
+        if (!existing || !canView(existing, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'mcp provider not found' })
         }
         if (!canManageSharing(existing, ctxOf(req))) {
@@ -390,6 +391,7 @@ export function mcpProviderRoutes(deps: HttpDeps) {
         const sharedWith = await resolveShareSet(deps.repos.user, orgOf(req), req.body.sharedWith)
         const provider = await serializeByProvider(orgOf(req), existing.name, () =>
           deps.repos.mcpProvider.setSharing(
+            orgOf(req),
             existing.id,
             {
               visibility: req.body.visibility,
@@ -417,8 +419,8 @@ export function mcpProviderRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const existing = await deps.repos.mcpProvider.get(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req) || !canView(existing, ctxOf(req))) {
+        const existing = await deps.repos.mcpProvider.get(orgOf(req), req.params.id)
+        if (!existing || !canView(existing, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'mcp provider not found' })
         }
         // Serialized with rotation/patch: unbind + delete must not interleave with a rotation
@@ -436,7 +438,7 @@ export function mcpProviderRoutes(deps: HttpDeps) {
           const agents = await deps.repos.agent.list(orgOf(req))
           if (agents.some((a) => a.mcpServers.includes(existing.name))) return 'referenced' as const
           await pushUnassign(existing, orgOf(req)) // unbind relays + affected daemons (before the row is gone)
-          await deps.repos.mcpProvider.delete(existing.id) // FK cascade drops secret + grants
+          await deps.repos.mcpProvider.delete(orgOf(req), existing.id) // FK cascade drops secret + grants
           return 'deleted' as const
         })
         if (outcome === 'referenced') {

--- a/packages/control-plane/src/http/routes/organization-knowledge.ts
+++ b/packages/control-plane/src/http/routes/organization-knowledge.ts
@@ -283,8 +283,8 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (!repo) return unavailable(reply)
-        const row = await repo.getKnowledge(req.params.id)
-        if (!row || row.orgId !== orgOf(req)) return missing(reply)
+        const row = await repo.getKnowledge(orgOf(req), req.params.id)
+        if (!row) return missing(reply)
         return knowledgeDto(row, ctxOf(req).role === 'owner')
       }
     )
@@ -305,10 +305,10 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (denyNonOwner(req, reply)) return
         if (!repo) return unavailable(reply)
-        const existing = await repo.getKnowledge(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req)) return missing(reply)
+        const existing = await repo.getKnowledge(orgOf(req), req.params.id)
+        if (!existing) return missing(reply)
         const { expectedRevision, ...body } = req.body
-        const row = await repo.updateKnowledge(req.params.id, expectedRevision, body, {
+        const row = await repo.updateKnowledge(orgOf(req), req.params.id, expectedRevision, body, {
           source: 'manual',
           createdByUserId: ctxOf(req).userId
         })
@@ -337,8 +337,8 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (!repo) return unavailable(reply)
-        const existing = await repo.getKnowledge(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req)) return missing(reply)
+        const existing = await repo.getKnowledge(orgOf(req), req.params.id)
+        if (!existing) return missing(reply)
         return (await repo.listKnowledgeRevisions(existing.id)).map(knowledgeRevisionDto)
       }
     )
@@ -359,9 +359,9 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (denyNonOwner(req, reply)) return
         if (!repo) return unavailable(reply)
-        const existing = await repo.getKnowledge(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req)) return missing(reply)
-        const row = await repo.setKnowledgeArchived(req.params.id, req.body.archived, ctxOf(req).userId)
+        const existing = await repo.getKnowledge(orgOf(req), req.params.id)
+        if (!existing) return missing(reply)
+        const row = await repo.setKnowledgeArchived(orgOf(req), req.params.id, req.body.archived, ctxOf(req).userId)
         return knowledgeDto(row, true)
       }
     )
@@ -400,8 +400,8 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (!repo) return unavailable(reply)
-        const row = await repo.getManagedSkill(req.params.id)
-        if (!row || row.orgId !== orgOf(req)) return missing(reply, 'managed skill not found')
+        const row = await repo.getManagedSkill(orgOf(req), req.params.id)
+        if (!row) return missing(reply, 'managed skill not found')
         return skillDto(row, ctxOf(req).role === 'owner')
       }
     )
@@ -420,8 +420,8 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (!repo) return unavailable(reply)
-        const existing = await repo.getManagedSkill(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req)) return missing(reply, 'managed skill not found')
+        const existing = await repo.getManagedSkill(orgOf(req), req.params.id)
+        if (!existing) return missing(reply, 'managed skill not found')
         return (await repo.listManagedSkillRevisions(existing.id)).map(skillRevisionDto)
       }
     )
@@ -442,9 +442,9 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (denyNonOwner(req, reply)) return
         if (!repo) return unavailable(reply)
-        const existing = await repo.getManagedSkill(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req)) return missing(reply, 'managed skill not found')
-        const row = await repo.setManagedSkillArchived(req.params.id, req.body.archived, ctxOf(req).userId)
+        const existing = await repo.getManagedSkill(orgOf(req), req.params.id)
+        if (!existing) return missing(reply, 'managed skill not found')
+        const row = await repo.setManagedSkillArchived(orgOf(req), req.params.id, req.body.archived, ctxOf(req).userId)
 
         // Reconcile every enabling placed agent. Offline/error fan-out is best
         // effort; register/ok remains the durable reconnect backstop.
@@ -525,8 +525,8 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (denyNonOwner(req, reply)) return
         if (!repo) return unavailable(reply)
-        const suggestion = await repo.getSuggestion(req.params.id)
-        if (!suggestion || suggestion.orgId !== orgOf(req)) return missing(reply, 'suggestion not found')
+        const suggestion = await repo.getSuggestion(orgOf(req), req.params.id)
+        if (!suggestion) return missing(reply, 'suggestion not found')
         if (suggestion.state !== 'pending') {
           return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: 'suggestion is already reviewed' })
         }
@@ -596,8 +596,8 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (denyNonOwner(req, reply)) return
         if (!repo) return unavailable(reply)
-        const suggestion = await repo.getSuggestion(req.params.id)
-        if (!suggestion || suggestion.orgId !== orgOf(req)) return missing(reply, 'suggestion not found')
+        const suggestion = await repo.getSuggestion(orgOf(req), req.params.id)
+        if (!suggestion) return missing(reply, 'suggestion not found')
         if (suggestion.state !== 'pending') {
           return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: 'suggestion is already reviewed' })
         }
@@ -609,7 +609,7 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
           ) {
             return unavailable(reply)
           }
-          const rejected = await repo.rejectSuggestion(suggestion.id, ctxOf(req).userId, req.body.reason)
+          const rejected = await repo.rejectSuggestion(orgOf(req), suggestion.id, ctxOf(req).userId, req.body.reason)
           if (rejected.state !== 'rejected') {
             return reply.code(409).send({
               error: 'Conflict',
@@ -673,6 +673,7 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
         try {
           if (suggestion.kind === 'knowledge' && content.body.kind === 'knowledge') {
             result = await repo.acceptKnowledgeSuggestion(
+              orgOf(req),
               suggestion.id,
               {
                 title: suggestion.title,
@@ -686,6 +687,7 @@ export function organizationKnowledgeRoutes(deps: HttpDeps) {
           } else if (suggestion.kind === 'skill' && content.body.kind === 'skill') {
             const bundle = packageSkillBundle(content.body.files, suggestion.title)
             result = await repo.acceptSkillSuggestion(
+              orgOf(req),
               suggestion.id,
               { ...bundle, name: suggestion.title, candidateDigest: content.digest },
               req.body.snapshotToken,

--- a/packages/control-plane/src/http/routes/skill-sources.ts
+++ b/packages/control-plane/src/http/routes/skill-sources.ts
@@ -225,8 +225,8 @@ export function skillSourceRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const s = await deps.repos.skillSource.get(req.params.id)
-        if (!s || s.orgId !== orgOf(req) || !canView(s, ctxOf(req))) return notFound(reply)
+        const s = await deps.repos.skillSource.get(orgOf(req), req.params.id)
+        if (!s || !canView(s, ctxOf(req))) return notFound(reply)
         return toDto(s, ctxOf(req))
       }
     )
@@ -245,8 +245,8 @@ export function skillSourceRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const s = await deps.repos.skillSource.get(req.params.id)
-        if (!s || s.orgId !== orgOf(req) || !canView(s, ctxOf(req))) return notFound(reply)
+        const s = await deps.repos.skillSource.get(orgOf(req), req.params.id)
+        if (!s || !canView(s, ctxOf(req))) return notFound(reply)
         const gh = deps.github
         const parsed = parseGithubRepo(s.source)
         if (!gh || !parsed) return { resolvable: false, skills: [] }
@@ -376,8 +376,8 @@ export function skillSourceRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const existing = await deps.repos.skillSource.get(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req) || !canView(existing, ctxOf(req))) return notFound(reply)
+        const existing = await deps.repos.skillSource.get(orgOf(req), req.params.id)
+        if (!existing || !canView(existing, ctxOf(req))) return notFound(reply)
         // Same public-only guard as create, on the EFFECTIVE source — a PATCH that
         // points an existing source at a (now-confirmed) private repo is rejected too.
         if (await isPrivateRepo(orgOf(req), req.body.source ?? existing.source)) {
@@ -400,7 +400,7 @@ export function skillSourceRoutes(deps: HttpDeps) {
         // A subdir source needs a ref; reject if we couldn't resolve one rather than
         // let the daemon assume `main`.
         if (effSubDir && !resolvedRef) return reply.code(400).send(subdirNeedsRef)
-        const source = await deps.repos.skillSource.update(existing.id, {
+        const source = await deps.repos.skillSource.update(orgOf(req), existing.id, {
           ...(req.body.source !== undefined ? { source: req.body.source } : {}),
           ...(repoId !== undefined ? { githubRepoId: repoId } : {}),
           ...(resolvedRef !== undefined
@@ -432,8 +432,8 @@ export function skillSourceRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const existing = await deps.repos.skillSource.get(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req) || !canView(existing, ctxOf(req))) return notFound(reply)
+        const existing = await deps.repos.skillSource.get(orgOf(req), req.params.id)
+        if (!existing || !canView(existing, ctxOf(req))) return notFound(reply)
         if (!canManageSharing(existing, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot change sharing' })
         }
@@ -443,6 +443,7 @@ export function skillSourceRoutes(deps: HttpDeps) {
         // scope (routes/agents.ts), so this flip cannot land between their check
         // and their commit.
         const source = await deps.repos.skillSource.setSharing(
+          orgOf(req),
           existing.id,
           {
             visibility: req.body.visibility,
@@ -469,8 +470,8 @@ export function skillSourceRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
-        const existing = await deps.repos.skillSource.get(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req) || !canView(existing, ctxOf(req))) return notFound(reply)
+        const existing = await deps.repos.skillSource.get(orgOf(req), req.params.id)
+        if (!existing || !canView(existing, ctxOf(req))) return notFound(reply)
         // Agents bind a source by NAME (their enable-refs), so deleting while
         // referenced would leave dangling selectors that silently re-bind to any
         // future source recreated under the same name. The repo runs the
@@ -482,7 +483,7 @@ export function skillSourceRoutes(deps: HttpDeps) {
         // serializes after the drop (its in-scope visibility check then refuses
         // the now-unknown name, and the create guard keeps the name uncapturable
         // while referenced).
-        const outcome = await deps.repos.skillSource.delete(existing.id)
+        const outcome = await deps.repos.skillSource.delete(orgOf(req), existing.id)
         if (outcome === 'referenced') {
           return reply.code(409).send({
             error: 'Conflict',

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
@@ -120,7 +120,11 @@ export class AgentSpecAssembler {
    * daemon's entire reconcile roster. */
   async managedSkillsOf(a: Pick<AgentRecord, 'orgId' | 'managedSkills'>): Promise<ManagedSkillEntry[]> {
     if (!this.organizationKnowledge || a.managedSkills.length === 0) return []
-    const rows = await Promise.all(a.managedSkills.map((id) => this.organizationKnowledge!.getManagedSkill(id)))
+    // The read is org-fenced on the agent's own org, so a foreign id resolves
+    // to null and is dropped by the same defensive filter below.
+    const rows = await Promise.all(
+      a.managedSkills.map((id) => this.organizationKnowledge!.getManagedSkill(a.orgId, id))
+    )
     return rows.flatMap((row) =>
       row !== null && row.orgId === a.orgId && row.archivedAt === null
         ? [

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3963,19 +3963,28 @@ export interface UpdateMcpProviderInput {
 
 export interface McpProviderRepo {
   create(input: CreateMcpProviderInput): Promise<McpProviderRecord>
-  get(id: string): Promise<McpProviderRecord | null>
+  /** Org-fenced point read (docs/designs/org-scoped-data-layer.md §3): a
+   *  cross-org id reads as absent, exactly like a missing row. This port has no
+   *  `getUnscoped` — the daemon and relay reach providers through
+   *  {@link McpProviderRepo.activeForDaemon} and {@link McpProviderRepo.listAll},
+   *  so no internal trust domain needs an id-addressed escape hatch. */
+  get(orgId: OrgId, id: string): Promise<McpProviderRecord | null>
   /** The org's providers, filtered to what a supplied human principal may see
    *  (org-visible OR owned-by-them OR shared-with-them). Undefined is reserved
    *  for unfiltered internal reads. */
   listForOrg(orgId: OrgId, viewer?: ViewCtx): Promise<McpProviderRecord[]>
-  /** Set visibility + share set (console access only; never crosses the wire). */
+  /** Set visibility + share set (console access only; never crosses the wire).
+   *  Org-fenced: a cross-org id throws the same P2025 as a missing row. */
   setSharing(
+    orgId: OrgId,
     id: string,
     sharing: { visibility: ResourceVisibility; sharedWith: string[] },
     byUserId?: string
   ): Promise<McpProviderRecord>
-  update(id: string, patch: UpdateMcpProviderInput): Promise<McpProviderRecord>
-  delete(id: string): Promise<void>
+  /** Org-fenced: a cross-org id throws the same P2025 as a missing row. */
+  update(orgId: OrgId, id: string, patch: UpdateMcpProviderInput): Promise<McpProviderRecord>
+  /** Org-fenced: a cross-org id throws the same P2025 as a missing row. */
+  delete(orgId: OrgId, id: string): Promise<void>
   /**
    * Providers that should be pushed to `daemonId`: an org provider whose `name` is
    * enabled (in `runtimeOverrides.mcpServers`) by some agent placed on the daemon.
@@ -3985,7 +3994,7 @@ export interface McpProviderRepo {
   activeForDaemon(daemonId: DaemonId): Promise<McpProviderRecord[]>
   /** EVERY provider across all orgs — the pool-wide set replayed to a relay that just
    *  (re)registered (its in-memory binding table starts empty; bindings are pool-wide,
-   *  like bots/hooks). */
+   *  like bots/hooks). System-tier: deployment-level infrastructure by design. */
   listAll(): Promise<McpProviderRecord[]>
 }
 
@@ -3997,7 +4006,12 @@ export interface McpHeader {
 
 /** The ONLY read/write path for `mcp_provider_secret` (upstream auth headers).
  *  Store-only: NEVER in a DTO, NEVER pushed to a daemon (relay-only, via rc/mcp-assign).
- *  Same seam/discipline as {@link BotSecretStore}. */
+ *  Same seam/discipline as {@link BotSecretStore}.
+ *
+ *  Rows are keyed by `providerId` alone and carry no org, so this store fences
+ *  through its parent (org-scoped-data-layer.md §3.6): a route reaching a
+ *  secret must have resolved its provider through the org-fenced
+ *  {@link McpProviderRepo.get} (or just created it) first. */
 export interface McpProviderSecretStore {
   put(providerId: string, headers: McpHeader[]): Promise<void>
   get(providerId: string): Promise<McpHeader[] | null>
@@ -4015,6 +4029,9 @@ export interface McpGrantRecord {
   createdAt: Date
 }
 
+/** Grants hang off one provider and carry no org of their own — they fence
+ *  through {@link McpProviderRepo} exactly like {@link McpProviderSecretStore}
+ *  (org-scoped-data-layer.md §3.6). */
 export interface McpGrantRepo {
   /** Mint a fresh active grant (generates a new plaintext key) for a provider.
    *  v1 keeps exactly one active grant per provider — the caller revokes any prior
@@ -4077,7 +4094,11 @@ export interface SkillSourceRepo {
    *  scope, the agent-reference scan, and the insert share one transaction;
    *  null ⇒ an agent still enables skills under this name (caller answers 409). */
   create(input: CreateSkillSourceInput): Promise<SkillSourceRecord | null>
-  get(id: string): Promise<SkillSourceRecord | null>
+  /** Org-fenced point read (docs/designs/org-scoped-data-layer.md §3): a
+   *  cross-org id reads as absent, exactly like a missing row. This port has no
+   *  `getUnscoped` — internal readers resolve a source by its org-unique NAME
+   *  through {@link SkillSourceRepo.getByName}, which is already org-carrying. */
+  get(orgId: OrgId, id: string): Promise<SkillSourceRecord | null>
   /** The org's sources, filtered by the OSS resource-visibility policy for a
    *  supplied human principal; undefined is reserved for internal reads. */
   listForOrg(orgId: OrgId, viewer?: ViewCtx): Promise<SkillSourceRecord[]>
@@ -4085,16 +4106,21 @@ export interface SkillSourceRepo {
   getByName(orgId: OrgId, name: string): Promise<SkillSourceRecord | null>
   /** Holds the (orgId, name) advisory scope for the write: agent enable-list
    *  writes authorize visibility under the same scope, so a flip cannot land
-   *  between their check and their commit. */
+   *  between their check and their commit. Org-fenced: a cross-org id throws
+   *  the same P2025 as a missing row, before that scope is taken. */
   setSharing(
+    orgId: OrgId,
     id: string,
     sharing: { visibility: ResourceVisibility; sharedWith: string[] },
     byUserId?: string
   ): Promise<SkillSourceRecord>
-  update(id: string, patch: UpdateSkillSourceInput): Promise<SkillSourceRecord>
+  /** Org-fenced: a cross-org id throws the same P2025 as a missing row. */
+  update(orgId: OrgId, id: string, patch: UpdateSkillSourceInput): Promise<SkillSourceRecord>
   /** Delete under the referenced-guard, in one transaction with the reference
-   *  scan ('referenced' ⇒ caller answers 409; missing row ⇒ 'deleted'). */
-  delete(id: string): Promise<'deleted' | 'referenced'>
+   *  scan ('referenced' ⇒ caller answers 409; missing row ⇒ 'deleted').
+   *  Org-fenced: a cross-org id is 'deleted' — the same answer as an unknown id,
+   *  and (unlike 'referenced') one that discloses nothing about the foreign row. */
+  delete(orgId: OrgId, id: string): Promise<'deleted' | 'referenced'>
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -4228,9 +4254,20 @@ export type AcceptOrganizationSuggestionResult =
   | { outcome: 'target_missing'; suggestion: OrganizationSuggestionRecord }
   | { outcome: 'name_conflict'; suggestion: OrganizationSuggestionRecord }
 
+/**
+ * Knowledge entries, managed skills and dream suggestions are all org-owned rows
+ * addressed by id, so every point read and mutation here is org-fenced
+ * (docs/designs/org-scoped-data-layer.md §3). Their REVISION tables carry no
+ * `orgId` of their own and fence through the parent (§3.6) — each revision read
+ * sits behind the fenced `getKnowledge` / `getManagedSkill` that admitted it.
+ * Nothing in this port needs a `getUnscoped`: the daemon-facing reads
+ * (`managed-skill/read`, knowledge search) resolve the org from the requesting
+ * agent, which the WS handler has already proved is placed on the connection.
+ */
 export interface OrganizationKnowledgeRepo {
   listKnowledge(orgId: OrgId, includeArchived?: boolean): Promise<OrganizationKnowledgeRecord[]>
-  getKnowledge(id: string): Promise<OrganizationKnowledgeRecord | null>
+  getKnowledge(orgId: OrgId, id: string): Promise<OrganizationKnowledgeRecord | null>
+  /** Fences through {@link OrganizationKnowledgeRepo.getKnowledge} (§3.6). */
   listKnowledgeRevisions(id: string): Promise<OrganizationKnowledgeRevisionRecord[]>
   searchKnowledge(
     orgId: OrgId,
@@ -4241,19 +4278,33 @@ export interface OrganizationKnowledgeRepo {
     input: { title: string; content: string; summary?: string; tags?: string[] },
     provenance: OrganizationArtifactProvenance
   ): Promise<OrganizationKnowledgeRecord>
+  /** Org-fenced: a cross-org id misses the revision CAS exactly like a stale
+   *  `expectedRevision` (null), so it discloses nothing the CAS did not already. */
   updateKnowledge(
+    orgId: OrgId,
     id: string,
     expectedRevision: number,
     input: { title: string; content: string; summary?: string; tags?: string[] },
     provenance: OrganizationArtifactProvenance
   ): Promise<OrganizationKnowledgeRecord | null>
-  setKnowledgeArchived(id: string, archived: boolean, byUserId?: string): Promise<OrganizationKnowledgeRecord>
+  /** Org-fenced: a cross-org id throws the same P2025 as a missing row. */
+  setKnowledgeArchived(
+    orgId: OrgId,
+    id: string,
+    archived: boolean,
+    byUserId?: string
+  ): Promise<OrganizationKnowledgeRecord>
 
   listManagedSkills(orgId: OrgId, includeArchived?: boolean): Promise<ManagedSkillRecord[]>
-  getManagedSkill(id: string): Promise<ManagedSkillRecord | null>
+  /** Org-fenced: a cross-org id reads as absent. Every caller previously
+   *  post-filtered on `row.orgId !== …`; the fence replaces that check. */
+  getManagedSkill(orgId: OrgId, id: string): Promise<ManagedSkillRecord | null>
+  /** Fences through {@link OrganizationKnowledgeRepo.getManagedSkill} (§3.6). */
   getManagedSkillRevision(id: string, revision: number): Promise<ManagedSkillRevisionRecord | null>
+  /** Fences through {@link OrganizationKnowledgeRepo.getManagedSkill} (§3.6). */
   listManagedSkillRevisions(id: string): Promise<ManagedSkillRevisionRecord[]>
-  setManagedSkillArchived(id: string, archived: boolean, byUserId?: string): Promise<ManagedSkillRecord>
+  /** Org-fenced: a cross-org id throws the same P2025 as a missing row. */
+  setManagedSkillArchived(orgId: OrgId, id: string, archived: boolean, byUserId?: string): Promise<ManagedSkillRecord>
 
   syncSuggestions(
     orgId: OrgId,
@@ -4264,19 +4315,29 @@ export interface OrganizationKnowledgeRepo {
     orgId: OrgId,
     filters?: { kind?: OrganizationSuggestionKind; state?: OrganizationSuggestionState; query?: string }
   ): Promise<OrganizationSuggestionRecord[]>
-  getSuggestion(id: string): Promise<OrganizationSuggestionRecord | null>
+  /** Org-fenced: a cross-org id reads as absent. */
+  getSuggestion(orgId: OrgId, id: string): Promise<OrganizationSuggestionRecord | null>
+  /** Org-fenced: a cross-org id throws the same missing-row error as an
+   *  unknown one, and the pending-state CAS is unchanged. */
   rejectSuggestion(
+    orgId: OrgId,
     id: string,
     reviewedByUserId: string | undefined,
     reason?: string
   ): Promise<OrganizationSuggestionRecord>
+  /** Org-fenced on the row-locked read that opens the transaction, before the
+   *  snapshot-token comparison — so a cross-org id can never answer "stale
+   *  snapshot" and confirm the foreign suggestion exists. */
   acceptKnowledgeSuggestion(
+    orgId: OrgId,
     id: string,
     body: { title: string; content: string; summary: string | null; tags: string[] },
     expectedSnapshotToken: string,
     reviewedByUserId?: string
   ): Promise<AcceptOrganizationSuggestionResult>
+  /** Org-fenced like {@link OrganizationKnowledgeRepo.acceptKnowledgeSuggestion}. */
   acceptSkillSuggestion(
+    orgId: OrgId,
     id: string,
     body: {
       archive: Uint8Array

--- a/packages/control-plane/src/persistence/repositories/mcp.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/mcp.repo.ts
@@ -76,8 +76,10 @@ export class PgMcpProviderRepo implements McpProviderRepo {
     })
   }
 
-  async get(id: string): Promise<McpProviderRecord | null> {
-    const p = await this.db.mcpProvider.findUnique({ where: { id } })
+  async get(orgId: OrgId, id: string): Promise<McpProviderRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const p = await this.db.mcpProvider.findUnique({ where: { id, orgId } })
     return p ? toProviderRecord(p) : null
   }
 
@@ -92,13 +94,16 @@ export class PgMcpProviderRepo implements McpProviderRepo {
   }
 
   async setSharing(
+    orgId: OrgId,
     id: string,
     sharing: { visibility: ResourceVisibility; sharedWith: string[] },
     byUserId?: string
   ): Promise<McpProviderRecord> {
     return withAmbientTx(this.db, async (tx) => {
+      // Org fence on the opening read: a cross-org id throws the same P2025 as
+      // a missing row, before the membership lock or any write.
       const existing = await tx.mcpProvider.findUniqueOrThrow({
-        where: { id },
+        where: { id, orgId },
         select: { orgId: true }
       })
       const memberships = await lockResourceWriteMemberships(tx, {
@@ -108,7 +113,7 @@ export class PgMcpProviderRepo implements McpProviderRepo {
         sharedWith: sharing.sharedWith
       })
       const p = await tx.mcpProvider.update({
-        where: { id },
+        where: { id, orgId },
         data: { visibility: sharing.visibility, sharedWith: memberships.sharedWith ?? [] }
       })
       return toProviderRecord(p)
@@ -120,9 +125,10 @@ export class PgMcpProviderRepo implements McpProviderRepo {
     return rows.map(toProviderRecord)
   }
 
-  async update(id: string, patch: UpdateMcpProviderInput): Promise<McpProviderRecord> {
+  async update(orgId: OrgId, id: string, patch: UpdateMcpProviderInput): Promise<McpProviderRecord> {
+    // Org-fenced update: a cross-org id throws the same P2025 as a missing row.
     const p = await this.db.mcpProvider.update({
-      where: { id },
+      where: { id, orgId },
       data: {
         ...(patch.name !== undefined ? { name: patch.name } : {}),
         ...(patch.url !== undefined ? { url: patch.url } : {}),
@@ -132,8 +138,9 @@ export class PgMcpProviderRepo implements McpProviderRepo {
     return toProviderRecord(p)
   }
 
-  async delete(id: string): Promise<void> {
-    await this.db.mcpProvider.delete({ where: { id } }) // FK cascade drops secret + grants
+  async delete(orgId: OrgId, id: string): Promise<void> {
+    // Org-fenced delete: a cross-org id throws the same P2025 as a missing row.
+    await this.db.mcpProvider.delete({ where: { id, orgId } }) // FK cascade drops secret + grants
   }
 
   // Org providers whose `name` is enabled by some agent placed on this daemon. The

--- a/packages/control-plane/src/persistence/repositories/organization-knowledge.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/organization-knowledge.repo.ts
@@ -188,8 +188,13 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
     return rows.map(toKnowledge)
   }
 
-  async getKnowledge(id: string): Promise<OrganizationKnowledgeRecord | null> {
-    const row = await this.db.organizationKnowledge.findUnique({ where: { id }, include: currentKnowledgeInclude })
+  async getKnowledge(orgId: OrgId, id: string): Promise<OrganizationKnowledgeRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const row = await this.db.organizationKnowledge.findUnique({
+      where: { id, orgId },
+      include: currentKnowledgeInclude
+    })
     return row ? toKnowledge(row) : null
   }
 
@@ -305,6 +310,7 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
   }
 
   async updateKnowledge(
+    orgId: OrgId,
     id: string,
     expectedRevision: number,
     input: { title: string; content: string; summary?: string; tags?: string[] },
@@ -312,8 +318,10 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
   ): Promise<OrganizationKnowledgeRecord | null> {
     return withAmbientTx(this.db, async (tx) => {
       const nextRevision = expectedRevision + 1
+      // The org fence rides the revision CAS: a cross-org id misses it exactly
+      // like a stale `expectedRevision` (null), before any revision row is written.
       const updated = await tx.organizationKnowledge.updateMany({
-        where: { id, currentRevision: expectedRevision },
+        where: { id, orgId, currentRevision: expectedRevision },
         data: { title: input.title, currentRevision: nextRevision }
       })
       if (updated.count === 0) return null
@@ -328,14 +336,23 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
           ...provenanceData(provenance)
         }
       })
-      const row = await tx.organizationKnowledge.findUniqueOrThrow({ where: { id }, include: currentKnowledgeInclude })
+      const row = await tx.organizationKnowledge.findUniqueOrThrow({
+        where: { id, orgId },
+        include: currentKnowledgeInclude
+      })
       return toKnowledge(row)
     })
   }
 
-  async setKnowledgeArchived(id: string, archived: boolean, byUserId?: string): Promise<OrganizationKnowledgeRecord> {
+  async setKnowledgeArchived(
+    orgId: OrgId,
+    id: string,
+    archived: boolean,
+    byUserId?: string
+  ): Promise<OrganizationKnowledgeRecord> {
+    // Org-fenced update: a cross-org id throws the same P2025 as a missing row.
     const row = await this.db.organizationKnowledge.update({
-      where: { id },
+      where: { id, orgId },
       data: archived
         ? { archivedAt: new Date(), archivedByUserId: byUserId ?? null }
         : { archivedAt: null, archivedByUserId: null },
@@ -354,8 +371,9 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
     ).map(toSkill)
   }
 
-  async getManagedSkill(id: string): Promise<ManagedSkillRecord | null> {
-    const row = await this.db.managedSkill.findUnique({ where: { id }, include: currentSkillInclude })
+  async getManagedSkill(orgId: OrgId, id: string): Promise<ManagedSkillRecord | null> {
+    // Org-fenced point read; every caller's `row.orgId !== …` post-filter moves here.
+    const row = await this.db.managedSkill.findUnique({ where: { id, orgId }, include: currentSkillInclude })
     return row ? toSkill(row) : null
   }
 
@@ -375,10 +393,16 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
     ).map(toSkillRevision)
   }
 
-  async setManagedSkillArchived(id: string, archived: boolean, byUserId?: string): Promise<ManagedSkillRecord> {
+  async setManagedSkillArchived(
+    orgId: OrgId,
+    id: string,
+    archived: boolean,
+    byUserId?: string
+  ): Promise<ManagedSkillRecord> {
     return withAmbientTx(this.db, async (tx) => {
+      // Org-fenced update: a cross-org id throws the same P2025 as a missing row.
       const row = await tx.managedSkill.update({
-        where: { id },
+        where: { id, orgId },
         data: archived
           ? { archivedAt: new Date(), archivedByUserId: byUserId ?? null }
           : { archivedAt: null, archivedByUserId: null },
@@ -490,18 +514,22 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
     ).map(toSuggestion)
   }
 
-  async getSuggestion(id: string): Promise<OrganizationSuggestionRecord | null> {
-    const row = await this.db.organizationSuggestion.findUnique({ where: { id } })
+  async getSuggestion(orgId: OrgId, id: string): Promise<OrganizationSuggestionRecord | null> {
+    // Org-fenced point read: a cross-org id is indistinguishable from a missing row.
+    const row = await this.db.organizationSuggestion.findUnique({ where: { id, orgId } })
     return row ? toSuggestion(row) : null
   }
 
   async rejectSuggestion(
+    orgId: OrgId,
     id: string,
     reviewedByUserId: string | undefined,
     reason?: string
   ): Promise<OrganizationSuggestionRecord> {
+    // Org fence on the write AND on the read-back below: a cross-org id writes
+    // nothing and then throws the same P2025 as a missing row.
     await this.db.organizationSuggestion.updateMany({
-      where: { id, state: 'pending' },
+      where: { id, orgId, state: 'pending' },
       data: {
         state: 'rejected',
         reviewedByUserId: reviewedByUserId ?? null,
@@ -509,10 +537,11 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
         reviewReason: reason ?? null
       }
     })
-    return toSuggestion(await this.db.organizationSuggestion.findUniqueOrThrow({ where: { id } }))
+    return toSuggestion(await this.db.organizationSuggestion.findUniqueOrThrow({ where: { id, orgId } }))
   }
 
   async acceptKnowledgeSuggestion(
+    orgId: OrgId,
     id: string,
     body: { title: string; content: string; summary: string | null; tags: string[] },
     expectedSnapshotToken: string,
@@ -520,7 +549,10 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
   ): Promise<AcceptOrganizationSuggestionResult> {
     return withAmbientTx(this.db, async (tx) => {
       await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "organization_suggestion" WHERE "id" = ${id}::uuid FOR UPDATE`)
-      const suggestion = await tx.organizationSuggestion.findUniqueOrThrow({ where: { id } })
+      // Org fence on the row-locked read, BEFORE the state and snapshot-token
+      // comparisons: reaching those with a foreign id would answer
+      // 'not_pending' / 'metadata_changed' and confirm it exists (§3).
+      const suggestion = await tx.organizationSuggestion.findUniqueOrThrow({ where: { id, orgId } })
       if (suggestion.state !== 'pending') return { outcome: 'not_pending', suggestion: toSuggestion(suggestion) }
       if (suggestion.kind !== 'knowledge') throw new Error('suggestion kind mismatch')
       if (organizationSuggestionSnapshotToken(toSuggestion(suggestion)) !== expectedSnapshotToken) {
@@ -610,6 +642,7 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
   }
 
   async acceptSkillSuggestion(
+    orgId: OrgId,
     id: string,
     body: {
       archive: Uint8Array
@@ -628,7 +661,9 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
     try {
       return await withAmbientTx(this.db, async (tx) => {
         await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "organization_suggestion" WHERE "id" = ${id}::uuid FOR UPDATE`)
-        const suggestion = await tx.organizationSuggestion.findUniqueOrThrow({ where: { id } })
+        // Org fence on the row-locked read, before the state / snapshot-token
+        // comparisons and before any archive bytes are persisted (§3).
+        const suggestion = await tx.organizationSuggestion.findUniqueOrThrow({ where: { id, orgId } })
         if (suggestion.state !== 'pending') return { outcome: 'not_pending', suggestion: toSuggestion(suggestion) }
         if (suggestion.kind !== 'skill') throw new Error('suggestion kind mismatch')
         if (organizationSuggestionSnapshotToken(toSuggestion(suggestion)) !== expectedSnapshotToken) {
@@ -724,7 +759,7 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
       })
     } catch (err) {
       if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
-        const suggestion = await this.getSuggestion(id)
+        const suggestion = await this.getSuggestion(orgId, id)
         if (!suggestion) throw err
         return { outcome: 'name_conflict', suggestion }
       }

--- a/packages/control-plane/src/persistence/repositories/skill-source.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/skill-source.repo.ts
@@ -99,8 +99,10 @@ export class PgSkillSourceRepo implements SkillSourceRepo {
     })
   }
 
-  async get(id: string): Promise<SkillSourceRecord | null> {
-    const s = await this.db.skillSource.findUnique({ where: { id } })
+  async get(orgId: OrgId, id: string): Promise<SkillSourceRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const s = await this.db.skillSource.findUnique({ where: { id, orgId } })
     return s ? toRecord(s) : null
   }
 
@@ -120,13 +122,16 @@ export class PgSkillSourceRepo implements SkillSourceRepo {
   }
 
   async setSharing(
+    orgId: OrgId,
     id: string,
     sharing: { visibility: ResourceVisibility; sharedWith: string[] },
     byUserId?: string
   ): Promise<SkillSourceRecord> {
     return withAmbientTx(this.db, async (tx) => {
+      // Org fence on the opening read: a cross-org id throws the same P2025 as
+      // a missing row, before the name scope or the membership lock is taken.
       const existing = await tx.skillSource.findUniqueOrThrow({
-        where: { id },
+        where: { id, orgId },
         select: { orgId: true, name: true }
       })
       // Agent enable-list writes authorize against source visibility inside the
@@ -148,13 +153,15 @@ export class PgSkillSourceRepo implements SkillSourceRepo {
     })
   }
 
-  async update(id: string, patch: UpdateSkillSourceInput): Promise<SkillSourceRecord> {
+  async update(orgId: OrgId, id: string, patch: UpdateSkillSourceInput): Promise<SkillSourceRecord> {
     return withAmbientTx(this.db, async (tx) => {
       // The name BEFORE the edit — agents bind by name, so a rename moves which
       // agents resolve through this row and both sets change what they receive.
-      const before = await tx.skillSource.findUnique({ where: { id }, select: { name: true } })
+      // Org-fenced on both statements: a cross-org id reads no `before` name and
+      // throws the same P2025 as a missing row on the update.
+      const before = await tx.skillSource.findUnique({ where: { id, orgId }, select: { name: true } })
       const s = await tx.skillSource.update({
-        where: { id },
+        where: { id, orgId },
         data: {
           ...(patch.name !== undefined ? { name: patch.name } : {}),
           ...(patch.source !== undefined ? { source: patch.source } : {}),
@@ -186,16 +193,23 @@ export class PgSkillSourceRepo implements SkillSourceRepo {
    * enable-list writes). 'referenced' ⇒ the caller answers 409; a row already
    * gone resolves to 'deleted' (the outcome is idempotent).
    */
-  async delete(id: string): Promise<'deleted' | 'referenced'> {
+  async delete(orgId: OrgId, id: string): Promise<'deleted' | 'referenced'> {
     return withAmbientTx(this.db, async (tx) => {
-      const existing = await tx.skillSource.findUnique({ where: { id }, select: { orgId: true, name: true } })
+      // Org fence on the opening read, BEFORE the reference scan: a cross-org id
+      // takes the same early exit as an unknown one, so it can never come back
+      // as 'referenced' — an answer that would disclose the foreign org's agent
+      // enable-lists (org-scoped-data-layer.md §3).
+      const existing = await tx.skillSource.findUnique({
+        where: { id, orgId },
+        select: { orgId: true, name: true }
+      })
       if (!existing) return 'deleted'
       await lockSkillSourceNameScope(tx, existing.orgId, existing.name)
       // Re-read after taking the scope: a concurrent delete may have won it.
-      const row = await tx.skillSource.findUnique({ where: { id }, select: { id: true } })
+      const row = await tx.skillSource.findUnique({ where: { id, orgId }, select: { id: true } })
       if (!row) return 'deleted'
       if (await skillSourceNameReferenced(tx, existing.orgId, existing.name)) return 'referenced'
-      await tx.skillSource.delete({ where: { id } })
+      await tx.skillSource.delete({ where: { id, orgId } })
       return 'deleted'
     })
   }

--- a/packages/control-plane/src/ws/handlers/organization-knowledge.ts
+++ b/packages/control-plane/src/ws/handlers/organization-knowledge.ts
@@ -194,9 +194,12 @@ export const handleManagedSkillRead: Handler = async (frame, conn, deps) => {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'managed skill is not enabled for this agent', false)
     return
   }
-  const skill = await repo.getManagedSkill(frame.payload.managedSkillId)
+  // The managed-skill id comes from the daemon's frame, so it is fenced on the
+  // REQUESTER's org — the one thing this handler has already proved (the agent is
+  // placed on this connection). The revision fences through that parent (§3.6).
+  const skill = await repo.getManagedSkill(requester.orgId, frame.payload.managedSkillId)
   const revision = await repo.getManagedSkillRevision(frame.payload.managedSkillId, frame.payload.revision)
-  if (!skill || skill.orgId !== requester.orgId || skill.archivedAt !== null || !revision) {
+  if (!skill || skill.archivedAt !== null || !revision) {
     conn.sendError(frame.id, 'BAD_PAYLOAD', 'managed skill revision not found', false)
     return
   }

--- a/packages/control-plane/test/integration/organization-knowledge.route.test.ts
+++ b/packages/control-plane/test/integration/organization-knowledge.route.test.ts
@@ -287,7 +287,7 @@ describe('Dream organization suggestion review', () => {
       }
     ])
 
-    const artifact = await repo.getKnowledge(acceptedDto.acceptedArtifactId)
+    const artifact = await repo.getKnowledge(DEF_ORG, acceptedDto.acceptedArtifactId)
     expect(artifact).toMatchObject({
       title: 'Signing-key rotation',
       content,
@@ -431,7 +431,7 @@ describe('Dream organization suggestion review', () => {
       payload: { decision: 'accept', snapshotToken }
     })
     expect(response.statusCode).toBe(409)
-    expect(await repo.getSuggestion(pending!.id)).toMatchObject({ state: 'pending', acceptedArtifactId: null })
+    expect(await repo.getSuggestion(DEF_ORG, pending!.id)).toMatchObject({ state: 'pending', acceptedArtifactId: null })
     expect((await repo.listKnowledge(DEF_ORG)).some((row) => row.title === 'Mutated candidate')).toBe(false)
     expect(control.reviews).toEqual([])
   })
@@ -491,7 +491,7 @@ describe('Dream organization suggestion review', () => {
     })
     expect(response.statusCode).toBe(409)
     expect(response.json()).toMatchObject({ message: expect.stringContaining('metadata changed') })
-    expect(await repo.getSuggestion(pending!.id)).toMatchObject({ state: 'pending', title: 'Refreshed title' })
+    expect(await repo.getSuggestion(DEF_ORG, pending!.id)).toMatchObject({ state: 'pending', title: 'Refreshed title' })
     expect(await repo.listKnowledge(DEF_ORG)).toEqual([])
     expect(control.reviews).toEqual([])
   })
@@ -544,6 +544,7 @@ describe('Dream organization suggestion review', () => {
     ])
     const snapshotToken = organizationSuggestionSnapshotToken(pending!)
     await repo.updateKnowledge(
+      DEF_ORG,
       target.id,
       1,
       { title: 'Escalation', content: 'manual revision two' },
@@ -557,8 +558,11 @@ describe('Dream organization suggestion review', () => {
     })
     expect(response.statusCode).toBe(409)
     expect(response.json()).toMatchObject({ message: 'the target has a newer revision; regenerate the suggestion' })
-    expect(await repo.getSuggestion(pending!.id)).toMatchObject({ state: 'pending', acceptedArtifactId: null })
-    expect(await repo.getKnowledge(target.id)).toMatchObject({ currentRevision: 2, content: 'manual revision two' })
+    expect(await repo.getSuggestion(DEF_ORG, pending!.id)).toMatchObject({ state: 'pending', acceptedArtifactId: null })
+    expect(await repo.getKnowledge(DEF_ORG, target.id)).toMatchObject({
+      currentRevision: 2,
+      content: 'manual revision two'
+    })
     expect(await repo.listKnowledgeRevisions(target.id)).toHaveLength(2)
     expect(control.reviews).toEqual([])
   })
@@ -654,7 +658,7 @@ describe('Dream organization suggestion review', () => {
       payload: { decision: 'reject', reason: 'Conflicts with the approved runbook' }
     })
     expect(rejected.statusCode).toBe(503)
-    expect(await owner.deps.repos.organizationKnowledge!.getSuggestion(pending!.id)).toMatchObject({
+    expect(await owner.deps.repos.organizationKnowledge!.getSuggestion(DEF_ORG, pending!.id)).toMatchObject({
       state: 'pending',
       reviewedAt: null,
       reviewedByUserId: null,
@@ -736,7 +740,7 @@ describe('Dream organization suggestion review', () => {
         })
       ).statusCode
     ).toBe(503)
-    expect(await owner.deps.repos.organizationKnowledge!.getSuggestion(pending!.id)).toMatchObject({
+    expect(await owner.deps.repos.organizationKnowledge!.getSuggestion(DEF_ORG, pending!.id)).toMatchObject({
       state: 'pending',
       reviewedAt: null,
       reviewedByUserId: null,

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -12,7 +12,7 @@
  * migrating a repository (§7 M2) adds its resource block here in the same PR.
  */
 import { describe, it, expect, afterEach, beforeEach } from 'vitest'
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
@@ -21,11 +21,16 @@ import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
 import { PgBotRepo, PgIntegrationRepo } from '../../src/persistence/repositories/integration.repo.js'
 import { PgCronRepo } from '../../src/persistence/repositories/cron.repo.js'
 import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
+import { PgMcpProviderRepo } from '../../src/persistence/repositories/mcp.repo.js'
+import { PgSkillSourceRepo } from '../../src/persistence/repositories/skill-source.repo.js'
+import { PgOrganizationKnowledgeRepo } from '../../src/persistence/repositories/organization-knowledge.repo.js'
 import { AgentMissing, BotMissing, CronMissing, HookMissing } from '../../src/persistence/errors.js'
 import { AgentId, BotId, CronId, DaemonId, HookId, IntegrationId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+/** The revision tables constrain `digest` to `sha256:<64 hex>`. */
+const sha256 = (v: string): string => `sha256:${createHash('sha256').update(v).digest('hex')}`
 const CALLER_ORG = OrgId(DEFAULT_ORG_ID)
 
 let running: HttpApp | undefined
@@ -43,6 +48,13 @@ let foreignCronId: string
 let ownCronId: string
 let foreignHookId: string
 let foreignHookRunId: string
+let foreignProviderId: string
+let ownProviderId: string
+let foreignSkillSourceId: string
+let ownSkillSourceId: string
+let foreignKnowledgeId: string
+let ownKnowledgeId: string
+let foreignManagedSkillId: string
 
 afterEach(async () => {
   await running?.close()
@@ -176,6 +188,80 @@ beforeEach(async () => {
       status: 'success'
     }
   })
+
+  // Shareable org registries: an MCP provider and a skill source per org.
+  ownProviderId = randomUUID()
+  await prisma.mcpProvider.create({
+    data: { id: ownProviderId, orgId: DEFAULT_ORG_ID, name: 'own-mcp', url: 'https://mcp.example.test/own' }
+  })
+  foreignProviderId = randomUUID()
+  await prisma.mcpProvider.create({
+    data: {
+      id: foreignProviderId,
+      orgId: foreignOrgId,
+      name: 'foreign-mcp',
+      url: 'https://mcp.example.test/foreign'
+    }
+  })
+  ownSkillSourceId = randomUUID()
+  await prisma.skillSource.create({
+    data: { id: ownSkillSourceId, orgId: DEFAULT_ORG_ID, name: 'own-skills', source: 'example-org/own-skills' }
+  })
+  foreignSkillSourceId = randomUUID()
+  await prisma.skillSource.create({
+    data: {
+      id: foreignSkillSourceId,
+      orgId: foreignOrgId,
+      name: 'foreign-skills',
+      source: 'example-org/foreign-skills'
+    }
+  })
+
+  // Organization knowledge + one managed skill, each with a current revision.
+  ownKnowledgeId = randomUUID()
+  await prisma.organizationKnowledge.create({
+    data: {
+      id: ownKnowledgeId,
+      orgId: DEFAULT_ORG_ID,
+      title: 'own-runbook',
+      currentRevision: 1,
+      revisions: { create: { revision: 1, content: 'own content', digest: sha256('own content'), source: 'manual' } }
+    }
+  })
+  foreignKnowledgeId = randomUUID()
+  await prisma.organizationKnowledge.create({
+    data: {
+      id: foreignKnowledgeId,
+      orgId: foreignOrgId,
+      title: 'foreign-runbook',
+      currentRevision: 1,
+      revisions: {
+        create: { revision: 1, content: 'foreign content', digest: sha256('foreign content'), source: 'manual' }
+      }
+    }
+  })
+  foreignManagedSkillId = randomUUID()
+  await prisma.managedSkill.create({
+    data: {
+      id: foreignManagedSkillId,
+      orgId: foreignOrgId,
+      name: 'foreign-skill',
+      description: 'foreign managed skill',
+      currentRevision: 1,
+      revisions: {
+        create: {
+          revision: 1,
+          archive: Buffer.from('foreign-archive'),
+          digest: sha256('foreign-archive'),
+          compressedBytes: 15,
+          expandedBytes: 15,
+          fileCount: 1,
+          manifest: {},
+          source: 'manual'
+        }
+      }
+    }
+  })
 })
 
 function build(): HttpApp {
@@ -232,6 +318,32 @@ async function foreignHookUnmodified(): Promise<void> {
   expect(row!.enabled).toBe(true)
   // The run row hangs off the hook; a removal would have tombstoned it too.
   expect(await prisma.hookRun.findUnique({ where: { id: foreignHookRunId } })).not.toBeNull()
+}
+
+async function foreignRegistriesUnmodified(): Promise<void> {
+  const provider = await prisma.mcpProvider.findUnique({ where: { id: foreignProviderId } })
+  expect(provider).not.toBeNull()
+  expect(provider!.orgId).toBe(foreignOrgId)
+  expect(provider!.url).toBe('https://mcp.example.test/foreign')
+  expect(provider!.visibility).toBe('org')
+  const source = await prisma.skillSource.findUnique({ where: { id: foreignSkillSourceId } })
+  expect(source).not.toBeNull()
+  expect(source!.orgId).toBe(foreignOrgId)
+  expect(source!.source).toBe('example-org/foreign-skills')
+  expect(source!.visibility).toBe('org')
+}
+
+async function foreignKnowledgeUnmodified(): Promise<void> {
+  const row = await prisma.organizationKnowledge.findUnique({ where: { id: foreignKnowledgeId } })
+  expect(row).not.toBeNull()
+  expect(row!.orgId).toBe(foreignOrgId)
+  expect(row!.title).toBe('foreign-runbook')
+  expect(row!.currentRevision).toBe(1)
+  expect(row!.archivedAt).toBeNull()
+  // Revisions carry no org of their own — a leaked update would have added one.
+  expect(await prisma.organizationKnowledgeRevision.count({ where: { knowledgeId: foreignKnowledgeId } })).toBe(1)
+  const skill = await prisma.managedSkill.findUnique({ where: { id: foreignManagedSkillId } })
+  expect(skill!.archivedAt).toBeNull()
 }
 
 async function foreignBotUnmodified(): Promise<void> {
@@ -735,5 +847,189 @@ describe('tenant isolation — HookRepo fences under the routes', () => {
     // The unscoped reads are the GitHub-machinery / daemon escape hatches.
     expect(await repo.getUnscoped(HookId(foreignHookId))).not.toBeNull()
     expect(await repo.getManyUnscoped([HookId(foreignHookId)])).toHaveLength(1)
+  })
+})
+
+describe('tenant isolation — MCP providers and skill sources over the REST surface', () => {
+  it('point-GET of a foreign provider or skill source reads as absent (404)', async () => {
+    const app = build()
+    expect((await app.app.inject({ method: 'GET', url: `${ORG}/mcp-providers/${foreignProviderId}` })).statusCode).toBe(
+      404
+    )
+    expect(
+      (await app.app.inject({ method: 'GET', url: `${ORG}/skill-sources/${foreignSkillSourceId}` })).statusCode
+    ).toBe(404)
+    // The per-source skill scan is a second read path onto the same row.
+    expect(
+      (await app.app.inject({ method: 'GET', url: `${ORG}/skill-sources/${foreignSkillSourceId}/skills` })).statusCode
+    ).toBe(404)
+  })
+
+  it('foreign provider and skill-source writes are 404 and change nothing', async () => {
+    const app = build()
+    const patchProvider = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/mcp-providers/${foreignProviderId}`,
+      payload: { url: 'https://mcp.example.test/hijacked' }
+    })
+    expect(patchProvider.statusCode).toBe(404)
+    const rotate = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/mcp-providers/${foreignProviderId}/grant/rotate`
+    })
+    expect(rotate.statusCode).toBe(404)
+    const shareProvider = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/mcp-providers/${foreignProviderId}/sharing`,
+      payload: { visibility: 'restricted', sharedWith: [] }
+    })
+    expect(shareProvider.statusCode).toBe(404)
+    const deleteProvider = await app.app.inject({
+      method: 'DELETE',
+      url: `${ORG}/mcp-providers/${foreignProviderId}`
+    })
+    expect(deleteProvider.statusCode).toBe(404)
+
+    const patchSource = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/skill-sources/${foreignSkillSourceId}`,
+      payload: { source: 'example-org/hijacked' }
+    })
+    expect(patchSource.statusCode).toBe(404)
+    const shareSource = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/skill-sources/${foreignSkillSourceId}/sharing`,
+      payload: { visibility: 'restricted', sharedWith: [] }
+    })
+    expect(shareSource.statusCode).toBe(404)
+    const deleteSource = await app.app.inject({
+      method: 'DELETE',
+      url: `${ORG}/skill-sources/${foreignSkillSourceId}`
+    })
+    expect(deleteSource.statusCode).toBe(404)
+
+    await foreignRegistriesUnmodified()
+  })
+
+  it('neither registry list contains a foreign row', async () => {
+    const app = build()
+    const providers = await app.app.inject({ method: 'GET', url: `${ORG}/mcp-providers` })
+    expect(providers.statusCode).toBe(200)
+    const providerIds = (providers.json() as Array<{ id: string }>).map((p) => p.id)
+    expect(providerIds).toContain(ownProviderId)
+    expect(providerIds).not.toContain(foreignProviderId)
+
+    const sources = await app.app.inject({ method: 'GET', url: `${ORG}/skill-sources` })
+    expect(sources.statusCode).toBe(200)
+    const sourceIds = (sources.json() as Array<{ id: string }>).map((s) => s.id)
+    expect(sourceIds).toContain(ownSkillSourceId)
+    expect(sourceIds).not.toContain(foreignSkillSourceId)
+  })
+})
+
+describe('tenant isolation — organization knowledge and managed skills over the REST surface', () => {
+  it('a foreign knowledge entry is unreachable through its read, revision, and write routes', async () => {
+    const app = build()
+    expect((await app.app.inject({ method: 'GET', url: `${ORG}/knowledge/${foreignKnowledgeId}` })).statusCode).toBe(
+      404
+    )
+    expect(
+      (await app.app.inject({ method: 'GET', url: `${ORG}/knowledge/${foreignKnowledgeId}/revisions` })).statusCode
+    ).toBe(404)
+    const patch = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/knowledge/${foreignKnowledgeId}`,
+      payload: { expectedRevision: 1, title: 'hijacked', content: 'hijacked content' }
+    })
+    expect(patch.statusCode).toBe(404)
+    const archive = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/knowledge/${foreignKnowledgeId}/archive`,
+      payload: { archived: true }
+    })
+    expect(archive.statusCode).toBe(404)
+    await foreignKnowledgeUnmodified()
+  })
+
+  it('a foreign managed skill is unreachable through its read, revision, and archive routes', async () => {
+    const app = build()
+    expect(
+      (await app.app.inject({ method: 'GET', url: `${ORG}/managed-skills/${foreignManagedSkillId}` })).statusCode
+    ).toBe(404)
+    expect(
+      (await app.app.inject({ method: 'GET', url: `${ORG}/managed-skills/${foreignManagedSkillId}/revisions` }))
+        .statusCode
+    ).toBe(404)
+    const archive = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/managed-skills/${foreignManagedSkillId}/archive`,
+      payload: { archived: true }
+    })
+    expect(archive.statusCode).toBe(404)
+    await foreignKnowledgeUnmodified()
+  })
+
+  it('neither knowledge list contains a foreign row', async () => {
+    const app = build()
+    const knowledge = await app.app.inject({ method: 'GET', url: `${ORG}/knowledge` })
+    expect(knowledge.statusCode).toBe(200)
+    const ids = (knowledge.json() as Array<{ id: string }>).map((k) => k.id)
+    expect(ids).toContain(ownKnowledgeId)
+    expect(ids).not.toContain(foreignKnowledgeId)
+
+    const skills = await app.app.inject({ method: 'GET', url: `${ORG}/managed-skills` })
+    expect(skills.statusCode).toBe(200)
+    expect((skills.json() as Array<{ id: string }>).map((s) => s.id)).not.toContain(foreignManagedSkillId)
+  })
+})
+
+describe('tenant isolation — MCP, skill-source and knowledge fences under the routes', () => {
+  it('provider and skill-source reads and mutations treat a cross-org id like a missing row', async () => {
+    const providers = new PgMcpProviderRepo(prisma)
+    expect(await providers.get(CALLER_ORG, foreignProviderId)).toBeNull()
+    expect(await providers.get(CALLER_ORG, ownProviderId)).not.toBeNull()
+    await expect(providers.update(CALLER_ORG, foreignProviderId, { url: 'https://x.example.test' })).rejects.toThrow()
+    await expect(
+      providers.setSharing(CALLER_ORG, foreignProviderId, { visibility: 'restricted', sharedWith: [] })
+    ).rejects.toThrow()
+    await expect(providers.delete(CALLER_ORG, foreignProviderId)).rejects.toThrow()
+
+    const sources = new PgSkillSourceRepo(prisma)
+    expect(await sources.get(CALLER_ORG, foreignSkillSourceId)).toBeNull()
+    expect(await sources.get(CALLER_ORG, ownSkillSourceId)).not.toBeNull()
+    await expect(sources.update(CALLER_ORG, foreignSkillSourceId, { source: 'example-org/hijacked' })).rejects.toThrow()
+    await expect(
+      sources.setSharing(CALLER_ORG, foreignSkillSourceId, { visibility: 'restricted', sharedWith: [] })
+    ).rejects.toThrow()
+    // Delete answers 'deleted' — the same word an unknown id gets. Answering
+    // 'referenced' would confirm the foreign row AND leak its agent enable-lists.
+    expect(await sources.delete(CALLER_ORG, foreignSkillSourceId)).toBe('deleted')
+
+    await foreignRegistriesUnmodified()
+  })
+
+  it('knowledge, managed-skill and suggestion reads and mutations treat a cross-org id like a missing row', async () => {
+    const repo = new PgOrganizationKnowledgeRepo(prisma)
+
+    expect(await repo.getKnowledge(CALLER_ORG, foreignKnowledgeId)).toBeNull()
+    expect(await repo.getKnowledge(CALLER_ORG, ownKnowledgeId)).not.toBeNull()
+    expect(await repo.getManagedSkill(CALLER_ORG, foreignManagedSkillId)).toBeNull()
+    expect(await repo.getSuggestion(CALLER_ORG, randomUUID())).toBeNull()
+
+    // The revision CAS and the fence share one `where`, so a cross-org id misses
+    // exactly like a stale expectedRevision — null, and no revision row written.
+    expect(
+      await repo.updateKnowledge(
+        CALLER_ORG,
+        foreignKnowledgeId,
+        1,
+        { title: 'hijacked', content: 'hijacked content' },
+        { source: 'manual' }
+      )
+    ).toBeNull()
+    await expect(repo.setKnowledgeArchived(CALLER_ORG, foreignKnowledgeId, true)).rejects.toThrow()
+    await expect(repo.setManagedSkillArchived(CALLER_ORG, foreignManagedSkillId, true)).rejects.toThrow()
+
+    await foreignKnowledgeUnmodified()
   })
 })


### PR DESCRIPTION
Fifth batch of the org-scoped data-layer rollout
(`docs/designs/org-scoped-data-layer.md` §7 M2), after #699, #704, #706 and
#709: the shareable org registries (`McpProviderRepo`, `SkillSourceRepo`) and
the organization-knowledge surface (knowledge entries, managed skills, dream
suggestions).

## Migrated methods

### `McpProviderRepo`

`get` → `get(orgId, id)`; `update`, `setSharing` and `delete` all take the org
first and fence on their own `where`. `create` and `listForOrg` were already
org-carrying. `activeForDaemon` and `listAll` stay system-tier — the daemon push
set and the pool-wide relay replay, neither of them id-addressed.

The port grows **no** `getUnscoped`: nothing internal resolves a provider by id.
`McpProviderSecretStore` and `McpGrantRepo` are keyed by `providerId` with no org
of their own and fence through the parent (§3.6); their ports now say so.

### `SkillSourceRepo`

`get` → `get(orgId, id)`; `update`, `setSharing` and `delete` take the org. Also
no `getUnscoped` — internal readers resolve a source by its org-unique NAME
through `getByName(orgId, name)`, which was already fenced.

`delete` is the interesting one. It answers `'deleted' | 'referenced'`, and
`'referenced'` means "some agent still enables this name". Fencing only the row
drop would have let a cross-org id run the reference scan and come back
`'referenced'` — confirming the foreign row *and* leaking whether another
organization's agents enable it. The fence therefore sits on the read that opens
the transaction, so a foreign id takes the same early `'deleted'` exit as an
unknown one.

### `OrganizationKnowledgeRepo`

| Method | New shape |
| --- | --- |
| `getKnowledge`, `getManagedSkill`, `getSuggestion` | `(orgId, id)` |
| `updateKnowledge` | `(orgId, id, expectedRevision, …)` — the fence rides the revision CAS |
| `setKnowledgeArchived`, `setManagedSkillArchived` | `(orgId, id, …)` |
| `rejectSuggestion`, `acceptKnowledgeSuggestion`, `acceptSkillSuggestion` | `(orgId, id, …)` |
| `listKnowledgeRevisions`, `listManagedSkillRevisions`, `getManagedSkillRevision` | unchanged — revision tables carry no `orgId` and fence through the parent (§3.6) |
| `listKnowledge`, `listManagedSkills`, `listSuggestions`, `searchKnowledge`, `createKnowledge`, `syncSuggestions` | unchanged — already org-carrying |

Two of these had to fence **before** a side effect rather than on the write:

- `acceptKnowledgeSuggestion` / `acceptSkillSuggestion` open with a row-locked
  read and then compare state and the snapshot token. Reaching those with a
  foreign id would answer `'not_pending'` or `'metadata_changed'` — both of which
  confirm the suggestion exists — and the skill arm would do it after persisting
  archive bytes. The fence goes on that locked read.
- `updateKnowledge` writes a new revision row after its CAS, so the org rides the
  `updateMany` predicate itself: a cross-org id misses exactly like a stale
  `expectedRevision` (null) and no revision is written.

## Caller consequence worth noting

`getManagedSkill` had three callers, and all three were doing
`row.orgId !== orgId` by hand afterwards — the agent-spec assembler, the agent
PATCH validation, and the `managed-skill/read` WS handler. All three now pass the
org they already held and drop the post-filter. In the WS handler the org is the
**requester agent's**, which the handler has independently proved is placed on
the reporting connection — so this is a real fence, not a tautology.

## Acceptance gate

`test/integration/tenant-isolation.route.test.ts` grows three blocks: the two
registries, the knowledge surface, and their repo-level fences. Beyond the usual
point-read/mutation/list assertions:

- every foreign write path is exercised (provider PATCH, grant rotate, sharing,
  delete; source PATCH, sharing, delete; knowledge PATCH and archive; managed-skill
  archive) and the rows are asserted unchanged afterwards — including that the
  knowledge entry still has exactly **one** revision, which is what proves the
  CAS-fenced update wrote nothing;
- the skill-source delete is asserted to answer `'deleted'`, not `'referenced'`;
- the knowledge update is asserted to return `null` rather than throw, matching
  the CAS shape the route already handles as a 409.

Green: full-repo `typecheck` and `lint`, CP `test:unit` (1256) and `test:int` (1031).
