### PR TITLE
fix(setup): support Logto Cloud bootstrap

### DIFF
--- a/packages/setup/src/admin/html.ts
+++ b/packages/setup/src/admin/html.ts
@@ -90,6 +90,8 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         <p class="muted">Enter the one-time Logto Management API credential. It is sealed in the deployment database and verified before continuing.</p>
         <label class="field">Logto M2M App ID<input id="logto-app-id" autocomplete="off"></label>
         <label class="field">Logto M2M App Secret<input id="logto-app-secret" type="password" autocomplete="new-password"></label>
+        <label class="field">Management API resource<input id="logto-management-api-resource" type="url" autocomplete="off"></label>
+        <p class="muted">Logto Cloud uses <code>https://&lt;tenant-id&gt;.logto.app/api</code>. Keep <code>https://default.logto.app/api</code> for Logto OSS.</p>
         <button id="bootstrap-logto-submit">Save Logto and continue</button>
       </div>
       <div id="bootstrap-provider-step" hidden>
@@ -971,6 +973,7 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
       renderUriList('bootstrap-google-origins', bootstrapInfo.google.javascriptOrigins);
       renderUriList('bootstrap-google-redirects', bootstrapInfo.google.redirectUris);
       renderUriList('bootstrap-slack-redirects', [bootstrapInfo.slackLoginRedirectUrl]);
+      el('logto-management-api-resource').value = bootstrapInfo.logtoManagementResource;
       el('bootstrap-github-submit').disabled = !bootstrapInfo.githubAvailable;
       if (!bootstrapInfo.githubAvailable) {
         el('bootstrap-github-note').textContent = 'GitHub App creation needs valid saved Web, API, and ingress URLs.';
@@ -1025,7 +1028,8 @@ export const TENANT_ADMIN_HTML = String.raw`<!doctype html>
         method: 'POST', headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           managementAppId: el('logto-app-id').value,
-          managementAppSecret: el('logto-app-secret').value
+          managementAppSecret: el('logto-app-secret').value,
+          managementResource: el('logto-management-api-resource').value
         })
       }));
       el('logto-app-secret').value = '';

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -78,6 +78,7 @@ const PutDeploymentConfigBody = z.strictObject({
 const BootstrapLogtoBody = z.strictObject({
   managementAppId: z.string().trim().min(1).max(200),
   managementAppSecret: z.string().min(1).max(10_000),
+  managementResource: z.string().url().optional(),
   socialProvider: z.enum(['github', 'google', 'slack']).optional()
 })
 
@@ -666,6 +667,7 @@ export function buildTenantAdminServer(
       logtoAdminEndpoint,
       logtoConfigured,
       logtoManagementAppId: current?.values.logto?.managementAppId ?? null,
+      logtoManagementResource: current?.values.logto?.managementResource ?? 'https://default.logto.app/api',
       google: { javascriptOrigins: [logtoEndpoint], redirectUris },
       githubAvailable,
       githubWebhookActive,
@@ -708,6 +710,7 @@ export function buildTenantAdminServer(
         {
           managementAppId: parsed.data.managementAppId,
           managementAppSecret: parsed.data.managementAppSecret,
+          managementResource: parsed.data.managementResource,
           socialProvider: parsed.data.socialProvider
         }
       )

--- a/packages/setup/src/admin/server.ts
+++ b/packages/setup/src/admin/server.ts
@@ -75,10 +75,15 @@ const PutDeploymentConfigBody = z.strictObject({
   secrets: DeploymentSecretPatchSchema.optional()
 })
 
+const ManagementApiResourceSchema = z
+  .string()
+  .trim()
+  .pipe(DeploymentConfigValuesV1Schema.shape.logto.unwrap().shape.managementResource)
+
 const BootstrapLogtoBody = z.strictObject({
   managementAppId: z.string().trim().min(1).max(200),
   managementAppSecret: z.string().min(1).max(10_000),
-  managementResource: z.string().url().optional(),
+  managementResource: ManagementApiResourceSchema.optional(),
   socialProvider: z.enum(['github', 'google', 'slack']).optional()
 })
 

--- a/packages/setup/src/deployment-config-client.ts
+++ b/packages/setup/src/deployment-config-client.ts
@@ -78,6 +78,7 @@ export interface LogtoGithubConnectorCredentials {
 export interface LocalAuthLogtoBootstrap {
   managementAppId?: string
   managementAppSecret?: string
+  managementResource?: string
   socialProvider?: 'github' | 'google' | 'slack'
 }
 
@@ -94,7 +95,8 @@ export function localAuthLogtoPut(
       ...current.values,
       logto: {
         managementAppId,
-        managementResource: existing?.managementResource ?? 'https://default.logto.app/api',
+        managementResource:
+          bootstrap.managementResource ?? existing?.managementResource ?? 'https://default.logto.app/api',
         browser:
           existing?.browser ??
           ({

--- a/packages/setup/test/deployment-config-client.test.ts
+++ b/packages/setup/test/deployment-config-client.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1 } from '@agentconnect.md/control-plane/deployment-config-store'
+import { localAuthLogtoPut } from '../src/deployment-config-client.js'
+
+describe('localAuthLogtoPut', () => {
+  it('stores an explicit Logto Management API resource', () => {
+    const result = localAuthLogtoPut(
+      { values: DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1 },
+      {
+        managementAppId: 'cloud-m2m-app',
+        managementAppSecret: 'secret',
+        managementResource: 'https://tenant-id.logto.app/api'
+      }
+    )
+
+    expect(result.values.logto?.managementResource).toBe('https://tenant-id.logto.app/api')
+  })
+})


### PR DESCRIPTION
## Summary

- let Tenant Admin bootstrap accept and persist the exact Logto Management API resource
- show the resource alongside the M2M credentials, with clear Cloud and OSS values
- cover the Cloud resource path with a focused regression test

## Why

Tenant Admin previously defaulted every first-time setup to the Logto OSS resource `https://default.logto.app/api`. Logto Cloud tenants use their canonical tenant resource instead, so Cloud credentials could not pass the bootstrap verification.

## Impact

Self-hosted AgentConnect deployments can now bootstrap against either Logto Cloud or Logto OSS without editing the deployment record outside Tenant Admin. Existing Logto OSS setup keeps its current default.

## Validation

- `pnpm --filter @agentconnect.md/setup test`
- `pnpm --filter @agentconnect.md/setup typecheck`
- targeted ESLint and Prettier checks
- pre-push repository lint
- `git diff --check`

The standalone setup build still encounters the existing `tsdown` `deps.onlyImport` workspace-bundling error on `origin/main`; this change does not touch those imports or the bundling configuration.

Created by Codex . GPT-5.6
