### PR TITLE
feat(cp): org-fence the session and webchat-conversation data layers

### DIFF
--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -521,7 +521,7 @@ export function agentRoutes(deps: HttpDeps) {
       sessionId: string | undefined
     ): Promise<boolean> => {
       if (!sessionId) return true
-      const session = await deps.repos.session.get(SessionId(sessionId))
+      const session = await deps.repos.session.get(orgOf(req), SessionId(sessionId))
       if (
         !session ||
         session.agentId !== agentId ||

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -365,8 +365,8 @@ export function sessionRoutes(deps: HttpDeps) {
     }
 
     const getOrgViewableSession = async (req: FastifyRequest, sessionId: string) => {
-      const session = await deps.repos.session.get(SessionId(sessionId))
-      if (!session || session.orgId !== orgOf(req)) return null
+      const session = await deps.repos.session.get(orgOf(req), SessionId(sessionId))
+      if (!session) return null
       const access = await sessionAccess.forSessions(req, [session])
       if (!canViewSession(session, ctxOf(req), access.identitySet, access.externalAccess)) return null
       return { session, access }
@@ -693,14 +693,14 @@ export function sessionRoutes(deps: HttpDeps) {
         const agentNames = new Map(orgAgents.map((agent) => [agent.id, agentDisplayName(agent)]))
         const ctx = ctxOf(req)
         const [parent, children, siblingCandidates, usage, webchatRoster, hookMetadata] = await Promise.all([
-          s.parentSessionId ? deps.repos.session.get(s.parentSessionId) : Promise.resolve(null),
+          s.parentSessionId ? deps.repos.session.get(orgOf(req), s.parentSessionId) : Promise.resolve(null),
           deps.repos.session.listChildren(SessionId(s.id), orgAgentIds),
           s.parentSessionId ? deps.repos.session.listChildren(s.parentSessionId, orgAgentIds) : Promise.resolve([]),
           deps.repos.sessionUsage.get(s.agentId, s.id),
           // A webchat session's channel IS its conversation id; the roster feeds
           // the adopted-session composer/header, which has no relay socket.
           s.platform === 'webchat' && s.channel
-            ? deps.repos.webchatConversation.participants(s.channel)
+            ? deps.repos.webchatConversation.participants(orgOf(req), s.channel)
             : Promise.resolve([]),
           hookMetadataForSessions(deps, [s], orgOf(req))
         ])
@@ -955,6 +955,7 @@ export function sessionRoutes(deps: HttpDeps) {
         // session, and the former owner's parked request must not still apply —
         // ownership is judged against the LOCKED row.
         const { affected, forbidden } = await deps.repos.session.setVisibility(
+          orgOf(req),
           SessionId(req.params.id),
           req.body.visibility,
           (row) => canChangeSessionVisibility(row, ctx, identitySet)

--- a/packages/control-plane/src/http/routes/sessions.viewer-identity.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.viewer-identity.test.ts
@@ -81,7 +81,12 @@ function fakeDeps(overrides: {
         get: vi.fn(async () => agent)
       },
       session: {
-        get: vi.fn(async () => overrides.session ?? slackDmSession()),
+        // The repo read is org-fenced now (org-scoped-data-layer.md §3), so the
+        // fake enforces the fence instead of the route's deleted comparison.
+        get: vi.fn(async (orgId: string) => {
+          const row = overrides.session ?? slackDmSession()
+          return row.orgId === orgId ? row : null
+        }),
         orgHasAny: vi.fn(async () => true),
         listExternalScopes: vi.fn(async () => []),
         getExternalScopes: vi.fn(async () => []),

--- a/packages/control-plane/src/http/routes/stream.ts
+++ b/packages/control-plane/src/http/routes/stream.ts
@@ -110,7 +110,7 @@ export function streamRoutes(deps: HttpDeps) {
         // single-flight) and the unlink path invalidates that cache, so the
         // revocation lands on the next event, not the next connection.
         const canSeeSession = async (agentId: string, sessionId: string, ctx: ViewCtx): Promise<boolean> => {
-          const session = await deps.repos.session.get(SessionId(sessionId)).catch(() => null)
+          const session = await deps.repos.session.get(orgId, SessionId(sessionId)).catch(() => null)
           if (!session || session.agentId !== agentId) return false
           const access = await sessionAccess.forSessions(req, [session]).catch(() => null)
           return !!access && canStreamSession(session, orgId, ctx, access.identitySet, access.externalAccess)

--- a/packages/control-plane/src/http/routes/stream.viewer-identity.test.ts
+++ b/packages/control-plane/src/http/routes/stream.viewer-identity.test.ts
@@ -69,7 +69,12 @@ describe('stream route × viewer identity (live unlink)', () => {
       repos: {
         org: { roleOf: async () => 'collaborator' },
         session: {
-          get: async (id: string) => sessions[id] ?? null,
+          // Org-fenced read: a row of another org is absent, exactly like an
+          // unknown id (org-scoped-data-layer.md §3).
+          get: async (orgId: string, id: string) => {
+            const row = sessions[id]
+            return row && row.orgId === orgId ? row : null
+          },
           getExternalScopes: async () => [],
           getExternalAccessPolicy: async () => null
         }

--- a/packages/control-plane/src/http/routes/webchat-token.ts
+++ b/packages/control-plane/src/http/routes/webchat-token.ts
@@ -65,7 +65,7 @@ export function webchatTokenRoutes(deps: HttpDeps) {
       orgId: OrgId,
       ctx: ReturnType<typeof ctxOf>
     ): Promise<boolean> => {
-      const roster = await deps.repos.webchatConversation.participants(conversationId)
+      const roster = await deps.repos.webchatConversation.participants(orgId, conversationId)
       for (const p of roster) {
         const member = await deps.repos.agent.get(orgId, p.agentId)
         if (!member || !canView(member, ctx)) return false
@@ -254,9 +254,9 @@ export function webchatTokenRoutes(deps: HttpDeps) {
         if (!agent || !canView(agent, ctxOf(req))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
         }
-        const roster = await deps.repos.webchatConversation.participants(conversationId)
+        const roster = await deps.repos.webchatConversation.participants(orgId, conversationId)
         const respond = async () => {
-          const updated = await deps.repos.webchatConversation.participants(conversationId)
+          const updated = await deps.repos.webchatConversation.participants(orgId, conversationId)
           return reply.send({
             participants: updated.map((p) => ({
               agentId: p.agentId,
@@ -286,7 +286,7 @@ export function webchatTokenRoutes(deps: HttpDeps) {
             })
           }
         }
-        await deps.repos.webchatConversation.addParticipant(conversationId, agent.id, userId)
+        await deps.repos.webchatConversation.addParticipant(orgId, conversationId, agent.id, userId)
         return respond()
       }
     )

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1242,9 +1242,20 @@ export interface SessionRepo {
    *  this compact index to the HTTP layer. */
   listFacets(q: SessionFacetQuery): Promise<SessionFacetIndex>
   list(q: SessionQuery): Promise<SessionListRecord[]>
-  get(id: SessionId): Promise<SessionMetaRecord | null>
+  /** Org-fenced point read (docs/designs/org-scoped-data-layer.md §3): a
+   *  cross-org id reads as absent, exactly like a missing row. The only session
+   *  read the HTTP/MCP surface may use. Visibility (`canViewSession`, the
+   *  identity set, the external-access policy) stays at the route — the fence
+   *  here is tenancy only (§8). */
+  get(orgId: OrgId, id: SessionId): Promise<SessionMetaRecord | null>
+  /** Tenancy-UNSCOPED read for internal trust domains — a daemon proving it owns
+   *  the parent of a child session it is reporting. Never call this from the
+   *  HTTP surface; lint enforces it (§6). */
+  getUnscoped(id: SessionId): Promise<SessionMetaRecord | null>
   /** Fail-closed proof that the durable webchat session for this conversation
-   * remains private before a remote administrative MCP invocation executes. */
+   * remains private before a remote administrative MCP invocation executes.
+   * System-tier (§3.4): fenced by the conversation's own `agentId`, which the
+   * MCP authority has already bound to the delegated agent. */
   hasPrivateWebchatSession(conversationId: string, agentId: AgentId): Promise<boolean>
   /** Distinct settled scopes referenced by external rows matching the non-page
    *  filters. Called before ORDER/LIMIT so membership filtering is pagination-safe. */
@@ -1267,7 +1278,9 @@ export interface SessionRepo {
   }>
   /** Visible-child lookup for the session detail page. Parent ids are opaque and
    *  deliberately not foreign-keyed, so this remains a metadata query. `viewer`
-   *  applies the same session predicate as the list (absent ⇒ internal fail-open). */
+   *  applies the same session predicate as the list (absent ⇒ internal fail-open).
+   *  System-tier (§3.4): `agentIds` is the caller's own org roster, so the query
+   *  is already org-fenced on a stronger axis than the parent id. */
   listChildren(
     parentSessionId: SessionId,
     agentIds: AgentId[],
@@ -1278,6 +1291,7 @@ export interface SessionRepo {
    *  privacy wins) under the lock-then-scan-to-fixpoint protocol of §4.5. Every
    *  rewritten row's `visibilityRev` is bumped in the same transaction. */
   setVisibility(
+    orgId: OrgId,
     sessionId: SessionId,
     visibility: SessionVisibility,
     /** Re-checked against the LOCKED row, closing the gap between the route's
@@ -1304,7 +1318,8 @@ export interface SessionRepo {
    *  bounded snapshot could not carry them all (never a silent truncation). */
   countUnackedVisibility(daemonId: DaemonId, includeExternal?: boolean): Promise<number>
   /** A session plus every descendant — the set a tightening cascade rewrote, so
-   *  the detail view's cutover state covers the whole subtree, not just the root. */
+   *  the detail view's cutover state covers the whole subtree, not just the root.
+   *  System-tier: driven by the visibility-push orchestrator from a row it holds. */
   visibilitySubtree(sessionId: SessionId, limit: number): Promise<SessionMetaRecord[]>
   /** Resolve the agent that owns a bot's `(channel, thread)` — the most-recently-active session
    *  keyed there whose agent still has an active integration for that bot and a current daemon
@@ -1339,17 +1354,21 @@ export interface WebchatConversationRepo {
    *  at creation). Conversation + participant rows commit atomically. */
   create(binding: WebchatConversationBinding, memberAgentIds?: AgentId[]): Promise<void>
   /** The conversation's full roster (primary first, then pick order). Empty
-   *  for an unknown conversation — callers fail closed. */
-  participants(conversationId: string): Promise<WebchatParticipant[]>
+   *  for an unknown conversation — callers fail closed. Org-fenced
+   *  (org-scoped-data-layer.md §3): a cross-org conversation id yields the same
+   *  empty roster as an unknown one, so it fails closed identically. */
+  participants(orgId: OrgId, conversationId: string): Promise<WebchatParticipant[]>
   /** Append one member to an existing conversation's roster (mid-conversation
    *  join, webchat-multi-agents.md §3.1). Idempotent — re-adding an existing
    *  participant is a no-op. Authorization (owner, canView, capability, cap)
    *  belongs to the caller. */
-  addParticipant(conversationId: string, agentId: AgentId, addedByUserId: string): Promise<void>
+  addParticipant(orgId: OrgId, conversationId: string, agentId: AgentId, addedByUserId: string): Promise<void>
   /** The owning console user of a conversation, for session-visibility ingest
    *  (§4.2). Scoped to a PARTICIPANT agent (any roster role); unknown and
    *  foreign bindings both return null (the caller fails closed). */
   findOwner(conversationId: string, agentId: AgentId): Promise<string | null>
+  /* ^ System-tier (§3.4): fenced by the participant `agentId`, which session
+   *   ingest has already bound to the reporting daemon's own agent. */
   /** Exact owner check for resume via the legacy per-agent mint path (the
    *  asserted agent must be the conversation's primary). Unknown and foreign
    *  bindings both return false. */

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -515,7 +515,9 @@ export class PgSessionRepo implements SessionRepo {
             SELECT "visibility", "ownerIdentity", "visibilitySource",
                    "externalProvider", "externalScopeId", "externalResolution",
                    "legacyUnresolved", "classifiedPolicyRev"
-            FROM "session_meta" WHERE "id" = ${ev.parentSessionId} FOR SHARE
+            FROM "session_meta"
+            WHERE "id" = ${ev.parentSessionId} AND "orgId" = ${orgId}
+            FOR SHARE
           `
         )
       : []
@@ -583,6 +585,7 @@ export class PgSessionRepo implements SessionRepo {
           "visibilityRev" = "visibilityRev" + 1,
           "updatedAt" = CURRENT_TIMESTAMP
         WHERE "parentSessionId" = ANY(${frontier}::text[])
+          AND "orgId" = ${parent.orgId}
           AND "visibilitySource" = 'inherited_pending'::"VisibilitySource"
         RETURNING *
       `)
@@ -609,11 +612,12 @@ export class PgSessionRepo implements SessionRepo {
       WITH RECURSIVE descendants AS (
         SELECT child."id"
         FROM "session_meta" child
-        WHERE child."parentSessionId" = ${parent.id}
+        WHERE child."parentSessionId" = ${parent.id} AND child."orgId" = ${parent.orgId}
         UNION
         SELECT child."id"
         FROM "session_meta" child
         JOIN descendants prior ON child."parentSessionId" = prior."id"
+        WHERE child."orgId" = ${parent.orgId}
       )
       UPDATE "session_meta" s SET
         "visibility" = ${parent.visibility}::"SessionVisibility",
@@ -639,14 +643,23 @@ export class PgSessionRepo implements SessionRepo {
    * we re-check. Same CAS, so it is a no-op once anything else has settled the
    * row. Runs in its own transaction after the milestone commits.
    */
-  private async settleFromParent(sessionId: SessionId, parentSessionId: SessionId): Promise<SessionMetaRecord[]> {
+  private async settleFromParent(
+    orgId: OrgId,
+    sessionId: SessionId,
+    parentSessionId: SessionId
+  ): Promise<SessionMetaRecord[]> {
     return withAmbientTx(this.db, async (tx) => {
+      // Same-org hop (see `setVisibility`): a parent claimed across the tenancy
+      // boundary reads as absent, which is exactly the "parent not here yet"
+      // case this settlement already handles by staying pending.
       const parent = await tx.$queryRaw<Array<ResolvedSessionClassification & { visibilitySource: string }>>(
         Prisma.sql`
           SELECT "visibility", "ownerIdentity", "visibilitySource",
                  "externalProvider", "externalScopeId", "externalResolution",
                  "legacyUnresolved", "classifiedPolicyRev"
-          FROM "session_meta" WHERE "id" = ${parentSessionId} FOR SHARE
+          FROM "session_meta"
+          WHERE "id" = ${parentSessionId} AND "orgId" = ${orgId}
+          FOR SHARE
         `
       )
       // Nothing to settle from a parent that is itself still waiting.
@@ -667,6 +680,7 @@ export class PgSessionRepo implements SessionRepo {
           "visibilityRev" = "visibilityRev" + 1,
           "updatedAt" = CURRENT_TIMESTAMP
         WHERE "id" = ${sessionId}
+          AND "orgId" = ${orgId}
           AND "visibilitySource" = 'inherited_pending'::"VisibilitySource"
         RETURNING *
       `)
@@ -684,7 +698,11 @@ export class PgSessionRepo implements SessionRepo {
     // Settling ourselves can in turn settle descendants that were waiting on us,
     // so they join the set the caller owes a §5.1 gate push.
     if (result.session.visibilitySource === 'inherited_pending' && result.session.parentSessionId) {
-      const [self, ...descendants] = await this.settleFromParent(result.session.id, result.session.parentSessionId)
+      const [self, ...descendants] = await this.settleFromParent(
+        result.session.orgId,
+        result.session.id,
+        result.session.parentSessionId
+      )
       if (self) return { ...result, session: self, settled: [...result.settled, ...descendants] }
     }
     return result
@@ -1511,7 +1529,7 @@ export class PgSessionRepo implements SessionRepo {
           "visibilitySource" = 'explicit'::"VisibilitySource",
           "visibilityRev" = "visibilityRev" + 1,
           "updatedAt" = CURRENT_TIMESTAMP
-        WHERE "id" = ${sessionId}
+        WHERE "id" = ${sessionId} AND "orgId" = ${orgId}
         RETURNING *
       `)
       const affected = target.map(toRecord)
@@ -1522,9 +1540,14 @@ export class PgSessionRepo implements SessionRepo {
       while (frontier.length > 0) {
         // Lock this level's children BEFORE reading them as a set to update: a
         // concurrent child insert either waits here or is caught by the re-scan.
+        // `parentSessionId` is a daemon-reported free string with NO foreign key,
+        // so a session in another organization can name this one as its parent.
+        // Every lineage hop is therefore confined to the root's org: without it a
+        // tighten here would lock, rewrite, and push another tenant's row
+        // (org-scoped-data-layer.md §3 — the fence is per-hop, not just per-root).
         const children = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
           SELECT "id" FROM "session_meta"
-          WHERE "parentSessionId" = ANY(${frontier}::text[])
+          WHERE "parentSessionId" = ANY(${frontier}::text[]) AND "orgId" = ${orgId}
           ORDER BY "id"
           FOR UPDATE
         `)
@@ -1553,6 +1576,7 @@ export class PgSessionRepo implements SessionRepo {
             "visibilityRev" = "visibilityRev" + 1,
             "updatedAt" = CURRENT_TIMESTAMP
           WHERE "id" = ANY(${next}::text[])
+            AND "orgId" = ${orgId}
             AND (
               ("externalProvider" IS NULL AND "visibility" <> 'private'::"SessionVisibility")
               OR ("externalProvider" IS NULL AND "ownerIdentity" IS DISTINCT FROM ${ownerIdentity})
@@ -1624,8 +1648,10 @@ export class PgSessionRepo implements SessionRepo {
       WITH RECURSIVE subtree AS (
         SELECT * FROM "session_meta" WHERE "id" = ${sessionId}
         UNION
+        -- Same-org hop only: parentSessionId carries no foreign key, so an
+        -- unconstrained walk would hand the visibility push another tenant's rows.
         SELECT child.* FROM "session_meta" child
-        JOIN subtree ON child."parentSessionId" = subtree."id"
+        JOIN subtree ON child."parentSessionId" = subtree."id" AND child."orgId" = subtree."orgId"
       )
       SELECT * FROM subtree LIMIT ${limit}
     `)

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -1212,7 +1212,14 @@ export class PgSessionRepo implements SessionRepo {
     return this.hydrate(rows)
   }
 
-  async get(id: SessionId): Promise<SessionMetaRecord | null> {
+  async get(orgId: OrgId, id: SessionId): Promise<SessionMetaRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const s = await this.db.sessionMeta.findUnique({ where: { id, orgId } })
+    return s ? toRecord(s) : null
+  }
+
+  async getUnscoped(id: SessionId): Promise<SessionMetaRecord | null> {
     const s = await this.db.sessionMeta.findUnique({ where: { id } })
     return s ? toRecord(s) : null
   }
@@ -1461,6 +1468,7 @@ export class PgSessionRepo implements SessionRepo {
    * mid-level parent could commit a stale `org` snapshot after the scan passed.
    */
   async setVisibility(
+    orgId: OrgId,
     sessionId: SessionId,
     visibility: SessionVisibility,
     authorize?: (row: {
@@ -1474,8 +1482,12 @@ export class PgSessionRepo implements SessionRepo {
         Array<{ visibility: string; ownerIdentity: string | null; externalProvider: string | null }>
       >(Prisma.sql`
         SELECT "visibility", "ownerIdentity", "externalProvider"
-        FROM "session_meta" WHERE "id" = ${sessionId} FOR UPDATE
+        FROM "session_meta" WHERE "id" = ${sessionId} AND "orgId" = ${orgId} FOR UPDATE
       `)
+      // The org fence rides the row-lock read, so a cross-org id takes the same
+      // silent no-op exit as a missing row — never the `forbidden: true` the
+      // immutable-audience guard below would answer, which would confirm it
+      // exists (org-scoped-data-layer.md §3).
       if (locked.length !== 1) return { affected: [] }
       const current = {
         visibility: locked[0]!.visibility as SessionVisibility,

--- a/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.test.ts
+++ b/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { AgentId } from '../../domain/ids.js'
+import { AgentId, OrgId } from '../../domain/ids.js'
 import { PgWebchatConversationRepo } from './webchat-conversation.repo.js'
 
 describe('PgWebchatConversationRepo synthetic coordinates', () => {
@@ -12,7 +12,7 @@ describe('PgWebchatConversationRepo synthetic coordinates', () => {
     } as never)
     const channel = 'a2a:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 
-    await expect(repo.participants(channel)).resolves.toEqual([])
+    await expect(repo.participants(OrgId('org-1'), channel)).resolves.toEqual([])
     await expect(repo.findOwner(channel, AgentId('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'))).resolves.toBeNull()
     expect(findMany).not.toHaveBeenCalled()
     expect(findFirst).not.toHaveBeenCalled()

--- a/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.ts
@@ -56,18 +56,29 @@ export class PgWebchatConversationRepo implements WebchatConversationRepo {
     })
   }
 
-  async participants(conversationId: string): Promise<WebchatParticipant[]> {
+  async participants(orgId: OrgId, conversationId: string): Promise<WebchatParticipant[]> {
     if (!UUID_RE.test(conversationId)) return []
+    // Roster rows carry no org of their own, so the fence rides the relational
+    // filter on the owning conversation (org-scoped-data-layer.md §3.6): a
+    // cross-org id yields the same empty roster as an unknown one, and every
+    // caller already fails closed on empty.
     const rows = await this.db.webchatConversationAgent.findMany({
-      where: { conversationId },
+      where: { conversationId, conversation: { orgId } },
       orderBy: { ord: 'asc' },
       select: { agentId: true, role: true }
     })
     return rows.map((r) => ({ agentId: AgentId(r.agentId), role: r.role === 'primary' ? 'primary' : 'member' }))
   }
 
-  async addParticipant(conversationId: string, agentId: AgentId, addedByUserId: string): Promise<void> {
+  async addParticipant(orgId: OrgId, conversationId: string, agentId: AgentId, addedByUserId: string): Promise<void> {
     await this.inTx(async (tx) => {
+      // Org fence on the conversation itself, inside the same transaction as the
+      // roster insert: a cross-org id adds nothing (§3.6).
+      const conversation = await tx.webchatConversation.findFirst({
+        where: { id: conversationId, orgId },
+        select: { id: true }
+      })
+      if (!conversation) return
       const last = await tx.webchatConversationAgent.aggregate({
         where: { conversationId },
         _max: { ord: true }

--- a/packages/control-plane/src/registry/webchatMcpAuthority.ts
+++ b/packages/control-plane/src/registry/webchatMcpAuthority.ts
@@ -60,7 +60,7 @@ export async function resolveLiveWebchatMcpAuthority(
   // mid-conversation suspends the catalog on the very next request, without
   // waiting for grant expiry. An empty roster is a pre-backfill conversation
   // and stays admissible (the single-agent shape).
-  const roster = await deps.conversations.participants(input.conversationId)
+  const roster = await deps.conversations.participants(OrgId(input.orgId), input.conversationId)
   if (roster.length > 1) return { ok: false, reason: 'multi_agent_conversation' }
 
   const role = await deps.orgs.roleOf(input.orgId, owner)

--- a/packages/control-plane/src/registry/webchatVerification.ts
+++ b/packages/control-plane/src/registry/webchatVerification.ts
@@ -4,7 +4,7 @@ import {
   type RcWebchatParticipant,
   type RegisterReq
 } from '@agentconnect.md/protocol'
-import { AgentId } from '../domain/ids.js'
+import { AgentId, OrgId } from '../domain/ids.js'
 import type { WebchatRemoteMcpService } from './webchatRemoteMcpService.js'
 import type { WebchatTokenService } from './webchatToken.js'
 
@@ -19,7 +19,7 @@ export interface WebchatVerificationDeps {
   daemons: { get(daemonId: string): VerificationDaemon | undefined }
   /** Roster reads for multi-agent conversations (webchat-multi-agents.md §6.2). */
   conversations: {
-    participants(conversationId: string): Promise<Array<{ agentId: AgentId; role: 'primary' | 'member' }>>
+    participants(orgId: OrgId, conversationId: string): Promise<Array<{ agentId: AgentId; role: 'primary' | 'member' }>>
   }
   remoteMcp: Pick<WebchatRemoteMcpService, 'establish'>
 }
@@ -47,7 +47,8 @@ export function createWebchatTokenVerifier(deps: WebchatVerificationDeps): (toke
     // Resolve the roster. An empty result (a conversation minted before the
     // participant backfill, or a mid-deploy create) degrades to the token's
     // primary — exactly the single-agent shape.
-    const roster = await deps.conversations.participants(claims.conversationId)
+    // Fenced on the org the signed token asserts (org-scoped-data-layer.md §3).
+    const roster = await deps.conversations.participants(OrgId(claims.orgId), claims.conversationId)
     const participants: RcWebchatParticipant[] = []
     for (const p of roster) {
       if (p.agentId === claims.agentId) {

--- a/packages/control-plane/src/ws/handlers/child-session-status.test.ts
+++ b/packages/control-plane/src/ws/handlers/child-session-status.test.ts
@@ -61,7 +61,7 @@ function fakeDeps(
     deps: {
       registry: { getUnscoped: async () => ({ id: ASKING_DAEMON, orgId: ORG }) },
       session: {
-        get: async () =>
+        getUnscoped: async () =>
           'parent' in over ? over.parent : { id: PARENT_SESSION, daemonId: ASKING_DAEMON, agentId: CHILD_AGENT }
       },
       agent: {

--- a/packages/control-plane/src/ws/handlers/child-session-status.ts
+++ b/packages/control-plane/src/ws/handlers/child-session-status.ts
@@ -40,7 +40,9 @@ export const handleChildSessionStatus: Handler = async (frame, conn, deps) => {
   // (a) Prove the asking daemon owns the parent session it is asking AS. `daemonId` on the session
   // row is stamped by the CP from the authenticated socket and is never daemon-echoed, so it is
   // trustworthy here. Fail closed when the session is unknown to the CP.
-  const parent = await deps.session.get(SessionId(parentSessionId))
+  // Daemon trust domain: the parent session the asking daemon claims to own —
+  // the ownership check below is what admits it (org-scoped-data-layer.md §4).
+  const parent = await deps.session.getUnscoped(SessionId(parentSessionId))
   if (!parent || parent.daemonId !== conn.daemonId) {
     conn.replyTo(frame, 'session/child-status/ok', NOT_FOUND)
     return

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -278,7 +278,7 @@ describe('session visibility — external conversation audiences', () => {
       ).sessions
     ).toHaveLength(0)
     const enabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'feishu', true)
-    const external = await repo.get(SessionId(sessionId))
+    const external = await repo.getUnscoped(SessionId(sessionId))
     expect(external).toMatchObject({ visibility: 'external', externalProvider: 'feishu' })
     expect(
       (
@@ -521,7 +521,7 @@ describe('session visibility — external conversation audiences', () => {
       at: new Date(),
       classification: { inherit: true }
     })
-    expect(await repo.get(SessionId(childId))).toMatchObject({
+    expect(await repo.getUnscoped(SessionId(childId))).toMatchObject({
       visibilitySource: 'inherited',
       externalProvider: 'slack',
       externalResolution: 'pending',
@@ -623,7 +623,7 @@ describe('session visibility — external conversation audiences', () => {
 
     const enabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'slack', true)
     expect(enabled.policy.state).toBe('enabled')
-    const external = await repo.get(SessionId(sessionId))
+    const external = await repo.getUnscoped(SessionId(sessionId))
     expect(external).toMatchObject({ visibility: 'external', externalResolution: 'settled' })
 
     const denied = await repo.listPage({
@@ -747,7 +747,7 @@ describe('session visibility — membership across an agent filter', () => {
       }
     })
     const enabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'slack', true)
-    expect((await repo.get(SessionId(sessionB)))?.visibility).toBe('external')
+    expect((await repo.getUnscoped(SessionId(sessionB)))?.visibility).toBe('external')
 
     const filtered = { agentIds: [AgentId(agentA)] }
     const widened = { ...filtered, memberAgentIds: [AgentId(agentA), AgentId(agentB)] }
@@ -853,7 +853,10 @@ describe('session visibility — GitHub repository audience', () => {
     })
 
     await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'github', true)
-    expect(await repo.get(githubSessionId)).toMatchObject({ visibility: 'external', externalResolution: 'settled' })
+    expect(await repo.getUnscoped(githubSessionId)).toMatchObject({
+      visibility: 'external',
+      externalResolution: 'settled'
+    })
 
     const response = await appAs(viewer, {
       sessionAccessPlugins: [
@@ -1047,21 +1050,21 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
 
     // -1 is "never acknowledged" — distinct from an ack of revision 0, which is
     // a real revision for a session ingested and never re-classified.
-    expect((await repo.get(SessionId(session)))?.visibilityAckedRev).toBe(-1)
-    const { affected } = await repo.setVisibility(SessionId(session), 'private')
+    expect((await repo.getUnscoped(SessionId(session)))?.visibilityAckedRev).toBe(-1)
+    const { affected } = await repo.setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(session), 'private')
     expect(affected[0]).toMatchObject({ visibilityRev: 1, visibilityAckedRev: -1 })
 
     // At-least-once delivery means acks can arrive out of order; the watermark
     // is monotonic so a late one for an older revision cannot un-apply a change.
     await repo.recordVisibilityAck(SessionId(session), 0)
-    expect((await repo.get(SessionId(session)))?.visibilityAckedRev).toBe(0)
+    expect((await repo.getUnscoped(SessionId(session)))?.visibilityAckedRev).toBe(0)
     await repo.recordVisibilityAck(SessionId(session), 1)
     await repo.recordVisibilityAck(SessionId(session), 0)
-    expect((await repo.get(SessionId(session)))?.visibilityAckedRev).toBe(1)
+    expect((await repo.getUnscoped(SessionId(session)))?.visibilityAckedRev).toBe(1)
 
     // A no-op re-set neither bumps the revision nor re-opens the cutover.
-    expect((await repo.setVisibility(SessionId(session), 'private')).affected).toEqual([])
-    expect((await repo.get(SessionId(session)))?.visibilityRev).toBe(1)
+    expect((await repo.setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(session), 'private')).affected).toEqual([])
+    expect((await repo.getUnscoped(SessionId(session)))?.visibilityRev).toBe(1)
   })
 
   it('replays an unacknowledged gate ahead of newer acknowledged ones', async () => {
@@ -1076,7 +1079,7 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
       daemonId,
       lastActivityAt: new Date(Date.now() - 86_400_000)
     })
-    await repo.setVisibility(SessionId(stale), 'private')
+    await repo.setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(stale), 'private')
     const fresh = await seedSessionMeta(prisma, `s-fresh-${randomUUID()}`, agentId, {
       daemonId,
       lastActivityAt: new Date()
@@ -1099,7 +1102,7 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
       daemonId,
       parentSessionId: root
     })
-    const { affected } = await repo.setVisibility(SessionId(root), 'private')
+    const { affected } = await repo.setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(root), 'private')
     expect(affected.map((a) => a.id).sort()).toEqual([child, root].sort())
 
     // Only the root's daemon acks. The child holds text copied from the root, so
@@ -1223,17 +1226,18 @@ describe('session visibility — §4.5 inheritance and cascade', () => {
     })
 
     // The ancestor cascade re-owns the child to the root's owner.
-    await repo.setVisibility(SessionId(root), 'private')
+    await repo.setVisibility(OrgId(DEFAULT_ORG_ID), SessionId(root), 'private')
 
     // The child's FORMER owner now tries to publish it. The route's own check
     // could have passed on a pre-cascade read; the lock-time re-check refuses.
     const denied = await repo.setVisibility(
+      OrgId(DEFAULT_ORG_ID),
       SessionId(child),
       'org',
       (row) => row.ownerIdentity === `user:${child_owner}`
     )
     expect(denied).toMatchObject({ forbidden: true, affected: [] })
-    expect((await repo.get(SessionId(child)))?.visibility).toBe('private')
+    expect((await repo.getUnscoped(SessionId(child)))?.visibility).toBe('private')
   })
 
   it('settles an out-of-order child once, and never over a human decision', async () => {
@@ -1262,7 +1266,7 @@ describe('session visibility — §4.5 inheritance and cascade', () => {
       classification: { inherit: true },
       at: new Date()
     })
-    await repo.setVisibility(pinned.session!.id, 'org')
+    await repo.setVisibility(OrgId(DEFAULT_ORG_ID), pinned.session!.id, 'org')
 
     // Now the parent lands as an org channel session.
     const parent = await repo.recordMilestone({

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -1181,6 +1181,72 @@ describe('tenant isolation — SessionRepo and WebchatConversationRepo fences un
     expect(await repo.getUnscoped(SessionId(foreignSessionId))).not.toBeNull()
   })
 
+  it('a tighten never follows session lineage across the tenancy boundary', async () => {
+    const repo = new PgSessionRepo(prisma)
+    // `parentSessionId` is a daemon-reported free string with NO foreign key, so
+    // a session in ANOTHER org can name one of ours as its parent. Nothing stops
+    // the claim from being made; what must hold is that our cascade ignores it.
+    const rootId = randomUUID()
+    await prisma.sessionMeta.create({
+      data: {
+        id: rootId,
+        orgId: DEFAULT_ORG_ID,
+        agentId: ownAgentId,
+        platform: 'slack',
+        channel: '#lineage',
+        phase: 'start',
+        visibility: 'org',
+        lastActivityAt: new Date()
+      }
+    })
+    const ownChildId = randomUUID()
+    await prisma.sessionMeta.create({
+      data: {
+        id: ownChildId,
+        orgId: DEFAULT_ORG_ID,
+        agentId: ownAgentId,
+        parentSessionId: rootId,
+        platform: 'slack',
+        channel: '#lineage',
+        phase: 'start',
+        visibility: 'org',
+        lastActivityAt: new Date()
+      }
+    })
+    const impostorChildId = randomUUID()
+    await prisma.sessionMeta.create({
+      data: {
+        id: impostorChildId,
+        orgId: foreignOrgId,
+        agentId: foreignAgentId,
+        parentSessionId: rootId, // the cross-org claim
+        platform: 'slack',
+        channel: '#lineage',
+        phase: 'start',
+        visibility: 'org',
+        lastActivityAt: new Date()
+      }
+    })
+
+    const { affected } = await repo.setVisibility(CALLER_ORG, SessionId(rootId), 'private')
+    const affectedIds = affected.map((a) => a.id)
+    expect(affectedIds).toContain(rootId)
+    expect(affectedIds).toContain(ownChildId) // the real descendant IS rewritten
+    expect(affectedIds).not.toContain(impostorChildId)
+
+    // The impostor keeps its own audience and revision — it was neither rewritten
+    // nor handed to the foreign org's daemon as a visibility push.
+    const impostor = await prisma.sessionMeta.findUnique({ where: { id: impostorChildId } })
+    expect(impostor!.visibility).toBe('org')
+    expect(impostor!.visibilityRev).toBe(0)
+    expect(impostor!.ownerIdentity).toBeNull()
+
+    // The subtree the orchestrator pushes is confined the same way.
+    const subtree = (await repo.visibilitySubtree(SessionId(rootId), 50)).map((row) => row.id)
+    expect(subtree).toEqual(expect.arrayContaining([rootId, ownChildId]))
+    expect(subtree).not.toContain(impostorChildId)
+  })
+
   it('a foreign webchat conversation’s roster reads empty — the child fences through its parent', async () => {
     const repo = new PgWebchatConversationRepo(prisma)
 

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -24,9 +24,11 @@ import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
 import { PgMcpProviderRepo } from '../../src/persistence/repositories/mcp.repo.js'
 import { PgSkillSourceRepo } from '../../src/persistence/repositories/skill-source.repo.js'
 import { PgOrganizationKnowledgeRepo } from '../../src/persistence/repositories/organization-knowledge.repo.js'
+import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.js'
+import { PgWebchatConversationRepo } from '../../src/persistence/repositories/webchat-conversation.repo.js'
 import { AgentMissing, BotMissing, CronMissing, HookMissing } from '../../src/persistence/errors.js'
-import { AgentId, BotId, CronId, DaemonId, HookId, IntegrationId, OrgId } from '../../src/domain/ids.js'
-import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { AgentId, BotId, CronId, DaemonId, HookId, IntegrationId, OrgId, SessionId } from '../../src/domain/ids.js'
+import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 /** The revision tables constrain `digest` to `sha256:<64 hex>`. */
@@ -55,6 +57,9 @@ let ownSkillSourceId: string
 let foreignKnowledgeId: string
 let ownKnowledgeId: string
 let foreignManagedSkillId: string
+let foreignSessionId: string
+let ownSessionId: string
+let foreignConversationId: string
 
 afterEach(async () => {
   await running?.close()
@@ -262,6 +267,47 @@ beforeEach(async () => {
       }
     }
   })
+
+  // Sessions and a webchat conversation whose roster is a pure child table.
+  ownSessionId = randomUUID()
+  await prisma.sessionMeta.create({
+    data: {
+      id: ownSessionId,
+      orgId: DEFAULT_ORG_ID,
+      agentId: ownAgentId,
+      platform: 'slack',
+      channel: '#own',
+      phase: 'start',
+      lastActivityAt: new Date()
+    }
+  })
+  foreignSessionId = randomUUID()
+  await prisma.sessionMeta.create({
+    data: {
+      id: foreignSessionId,
+      orgId: foreignOrgId,
+      agentId: foreignAgentId,
+      platform: 'slack',
+      channel: '#foreign',
+      phase: 'start',
+      visibility: 'org',
+      lastActivityAt: new Date()
+    }
+  })
+  foreignConversationId = randomUUID()
+  await prisma.webchatConversation.create({
+    data: {
+      id: foreignConversationId,
+      orgId: foreignOrgId,
+      agentId: foreignAgentId,
+      // The seeded owner is the only real app_user row; the conversation's ORG
+      // is what this block fences on, not who owns it.
+      userId: DEFAULT_OWNER_ID,
+      participants: {
+        create: { agentId: foreignAgentId, role: 'primary', ord: 0, addedByUserId: DEFAULT_OWNER_ID }
+      }
+    }
+  })
 })
 
 function build(): HttpApp {
@@ -344,6 +390,14 @@ async function foreignKnowledgeUnmodified(): Promise<void> {
   expect(await prisma.organizationKnowledgeRevision.count({ where: { knowledgeId: foreignKnowledgeId } })).toBe(1)
   const skill = await prisma.managedSkill.findUnique({ where: { id: foreignManagedSkillId } })
   expect(skill!.archivedAt).toBeNull()
+}
+
+async function foreignSessionUnmodified(): Promise<void> {
+  const row = await prisma.sessionMeta.findUnique({ where: { id: foreignSessionId } })
+  expect(row).not.toBeNull()
+  expect(row!.orgId).toBe(foreignOrgId)
+  expect(row!.visibility).toBe('org')
+  expect(row!.visibilityRev).toBe(0)
 }
 
 async function foreignBotUnmodified(): Promise<void> {
@@ -1031,5 +1085,84 @@ describe('tenant isolation — MCP, skill-source and knowledge fences under the 
     await expect(repo.setManagedSkillArchived(CALLER_ORG, foreignManagedSkillId, true)).rejects.toThrow()
 
     await foreignKnowledgeUnmodified()
+  })
+})
+
+describe('tenant isolation — Session and webchat conversation over the REST surface', () => {
+  it('point-GET of a foreign session id reads as absent (404)', async () => {
+    const app = build()
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/sessions/${foreignSessionId}` })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('the visibility write on a foreign session id is 404 and never bumps its revision', async () => {
+    const app = build()
+    const res = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/sessions/${foreignSessionId}/visibility`,
+      payload: { visibility: 'private' }
+    })
+    expect(res.statusCode).toBe(404)
+    await foreignSessionUnmodified()
+  })
+
+  it('the proxied transcript and tool-body reads of a foreign session id are 404', async () => {
+    const app = build()
+    expect(
+      (await app.app.inject({ method: 'GET', url: `${ORG}/sessions/${foreignSessionId}/messages` })).statusCode
+    ).toBe(404)
+    expect(
+      (
+        await app.app.inject({
+          method: 'GET',
+          url: `${ORG}/sessions/${foreignSessionId}/tool-body?toolCallId=t1`
+        })
+      ).statusCode
+    ).toBe(404)
+  })
+
+  it('the sessions list never contains a foreign row', async () => {
+    const app = build()
+    // `view=flat` is the ungrouped shape; the default groups rows by conversation.
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })
+    expect(res.statusCode).toBe(200)
+    const ids = (res.json() as { sessions?: Array<{ sessionId: string }> }).sessions?.map((s) => s.sessionId) ?? []
+    expect(ids).toContain(ownSessionId)
+    expect(ids).not.toContain(foreignSessionId)
+  })
+})
+
+describe('tenant isolation — SessionRepo and WebchatConversationRepo fences under the routes', () => {
+  it('session reads and the visibility write treat a cross-org id exactly like a missing row', async () => {
+    const repo = new PgSessionRepo(prisma)
+
+    expect(await repo.get(CALLER_ORG, SessionId(foreignSessionId))).toBeNull()
+    expect(await repo.get(CALLER_ORG, SessionId(randomUUID()))).toBeNull()
+    expect(await repo.get(CALLER_ORG, SessionId(ownSessionId))).not.toBeNull()
+
+    // The fence rides the row-lock read, so a cross-org id takes the SILENT
+    // no-op exit — not the `forbidden: true` the immutable-audience guard just
+    // below would answer, which would confirm the foreign row exists.
+    expect(await repo.setVisibility(CALLER_ORG, SessionId(foreignSessionId), 'private')).toEqual({ affected: [] })
+    await foreignSessionUnmodified()
+
+    // The unscoped read is the daemon escape hatch: `session/child-status`
+    // resolves the parent a reporting daemon claims, then proves it owns it.
+    expect(await repo.getUnscoped(SessionId(foreignSessionId))).not.toBeNull()
+  })
+
+  it('a foreign webchat conversation’s roster reads empty — the child fences through its parent', async () => {
+    const repo = new PgWebchatConversationRepo(prisma)
+
+    // Roster rows carry no org, so the fence is the relational filter on the
+    // owning conversation. Empty is exactly what an unknown id returns, and
+    // every caller fails closed on it.
+    expect(await repo.participants(CALLER_ORG, foreignConversationId)).toEqual([])
+    expect(await repo.participants(OrgId(foreignOrgId), foreignConversationId)).toHaveLength(1)
+
+    // The mid-conversation join writes nothing for a cross-org id.
+    await repo.addParticipant(CALLER_ORG, foreignConversationId, AgentId(ownAgentId), 'attacker')
+    expect(await repo.participants(OrgId(foreignOrgId), foreignConversationId)).toHaveLength(1)
+    expect(await prisma.webchatConversationAgent.count({ where: { conversationId: foreignConversationId } })).toBe(1)
   })
 })

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -50,6 +50,7 @@ let foreignCronId: string
 let ownCronId: string
 let foreignHookId: string
 let foreignHookRunId: string
+let foreignProjectionId: string
 let foreignProviderId: string
 let ownProviderId: string
 let foreignSkillSourceId: string
@@ -191,6 +192,27 @@ beforeEach(async () => {
       deliveryKey: `delivery-${randomUUID()}`,
       startedAt: new Date('2026-08-01T00:00:00.000Z'),
       status: 'success'
+    }
+  })
+  // A durable Check projection too. `HookRepo.remove` tombstones these on its way
+  // to deleting the definition, so a foreign DELETE has an external-effect row to
+  // damage — and only seeding one can show it comes back untouched.
+  foreignProjectionId = randomUUID()
+  await prisma.hookReviewProjection.create({
+    data: {
+      id: foreignProjectionId,
+      hookId: foreignHookId,
+      orgId: foreignOrgId,
+      agentId: foreignAgentId,
+      repoId: 4242n,
+      repoFullName: 'example-org/foreign-repo',
+      headSha: 'a'.repeat(40),
+      reportSha: 'a'.repeat(40),
+      projectionEpoch: 1n,
+      externalId: `ext-${randomUUID()}`,
+      mode: 'check',
+      gateMode: 'informational',
+      desiredState: 'in_progress'
     }
   })
 
@@ -364,6 +386,14 @@ async function foreignHookUnmodified(): Promise<void> {
   expect(row!.enabled).toBe(true)
   // The run row hangs off the hook; a removal would have tombstoned it too.
   expect(await prisma.hookRun.findUnique({ where: { id: foreignHookRunId } })).not.toBeNull()
+  // And the durable Check projection. `remove` runs the tombstones and the delete
+  // in ONE transaction, so the refusal — the typed `HookMissing` from the early
+  // fence, or the delete's own P2025 if it ever regressed to fencing only there —
+  // rolls the tombstones back either way. This asserts that end state directly.
+  const projection = await prisma.hookReviewProjection.findUnique({ where: { id: foreignProjectionId } })
+  expect(projection).not.toBeNull()
+  expect(projection!.tombstonedAt).toBeNull()
+  expect(projection!.desiredState).toBe('in_progress')
 }
 
 async function foreignRegistriesUnmodified(): Promise<void> {

--- a/packages/control-plane/test/repo/session.repo.test.ts
+++ b/packages/control-plane/test/repo/session.repo.test.ts
@@ -152,7 +152,7 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
       })
     )
 
-    const got = await repo.get(SessionId(SESSION))
+    const got = await repo.getUnscoped(SessionId(SESSION))
     expect(got).not.toBeNull()
     expect(got?.phase).toBe('start')
     expect(got?.launchId).toBe(LAUNCH)
@@ -197,7 +197,7 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     )
     await repo.recordMilestone(ev('end')) // e.g. an old daemon's refresh — no exec-config echo
 
-    const got = await repo.get(SessionId(SESSION))
+    const got = await repo.getUnscoped(SessionId(SESSION))
     expect(got?.runtime).toBe('claude')
     expect(got?.model).toBe('opus')
     expect(got?.effort).toBe('high')
@@ -206,7 +206,7 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
 
     // A later snapshot CAN move them (e.g. in-session model switch on the next turn).
     await repo.recordMilestone(ev('end', { model: 'sonnet', fastMode: false }))
-    const moved = await repo.get(SessionId(SESSION))
+    const moved = await repo.getUnscoped(SessionId(SESSION))
     expect(moved?.model).toBe('sonnet')
     expect(moved?.fastMode).toBe(false)
 
@@ -214,7 +214,7 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     // that omits model still preserves that null rather than reviving config.
     await repo.recordMilestone(ev('end', { model: null }))
     await repo.recordMilestone(ev('end'))
-    expect((await repo.get(SessionId(SESSION)))?.model).toBeNull()
+    expect((await repo.getUnscoped(SessionId(SESSION)))?.model).toBeNull()
   })
 
   it('advances phase on subsequent milestones (upsert on sessionId)', async () => {
@@ -225,7 +225,7 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     await repo.recordMilestone(ev('plan', { summary: 'planning' }))
     await repo.recordMilestone(ev('end', { link: 'https://done' }))
 
-    const got = await repo.get(SessionId(SESSION))
+    const got = await repo.getUnscoped(SessionId(SESSION))
     expect(got?.phase).toBe('end')
     expect(got?.summary).toBe('planning') // last non-empty summary retained
     expect(got?.link).toBe('https://done')
@@ -257,7 +257,7 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
       ).recorded
     ).toBe(false)
 
-    const got = await repo.get(SessionId(SESSION))
+    const got = await repo.getUnscoped(SessionId(SESSION))
     expect(got?.agentId).toBe(AGENT)
     expect(got?.title).toBe('Original')
     expect(got?.phase).toBe('start')
@@ -281,7 +281,7 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     ])
 
     expect(accepted.filter((result) => result.recorded)).toHaveLength(1)
-    const got = await repo.get(SessionId(SESSION))
+    const got = await repo.getUnscoped(SessionId(SESSION))
     if (accepted[0]!.recorded) {
       expect(got).toMatchObject({ agentId: AGENT, title: 'Agent A', phase: 'start' })
     } else {
@@ -297,7 +297,7 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     await repo.recordMilestone(ev('end', { status: 'idle' }))
     await repo.recordMilestone(ev('plan', { title: 'Runtime title', status: 'idle', channelName: 'deploys' }))
 
-    const got = await repo.get(SessionId(SESSION))
+    const got = await repo.getUnscoped(SessionId(SESSION))
     expect(got?.phase).toBe('end')
     expect(got?.title).toBe('Runtime title')
     expect(got?.status).toBe('idle')
@@ -467,12 +467,12 @@ describe('SessionRepo.markContentPurged — retention-GC receipt (#485)', () => 
     expect(first.marked).toEqual([SessionId(SESSION)])
     expect(first.alreadyPurged).toBe(1)
 
-    const row = await repo.get(SessionId(SESSION))
+    const row = await repo.getUnscoped(SessionId(SESSION))
     expect(row?.contentPurgedAt).toEqual(purgedAt)
     expect(row?.contentPurgedReason).toBe('retention')
     // The metadata row survives the purge — it is the whole remaining record.
     expect(row?.title).toBe('nightly review')
-    expect((await repo.get(SessionId(OTHER_SESSION)))?.contentPurgedAt).toBeNull()
+    expect((await repo.getUnscoped(SessionId(OTHER_SESSION)))?.contentPurgedAt).toBeNull()
 
     // At-least-once redelivery must not move the date the content went away.
     const again = await repo.markContentPurged(
@@ -482,7 +482,7 @@ describe('SessionRepo.markContentPurged — retention-GC receipt (#485)', () => 
       new Date('2026-09-01T00:00:00.000Z')
     )
     expect(again.marked).toEqual([])
-    expect((await repo.get(SessionId(SESSION)))?.contentPurgedAt).toEqual(purgedAt)
+    expect((await repo.getUnscoped(SessionId(SESSION)))?.contentPurgedAt).toEqual(purgedAt)
   })
 
   it('is a no-op for an unknown session and for an empty report', async () => {


### PR DESCRIPTION
Sixth batch of the org-scoped data-layer rollout
(`docs/designs/org-scoped-data-layer.md` §7 M2), after #699, #704, #706, #709
and #712: `SessionRepo` and `WebchatConversationRepo`.

This one is mostly a **classification** result. `SessionRepo` is a large port,
but almost all of it is already fenced on an axis stronger than the organization
— which is exactly what §3.4 says to leave alone. Only two methods were addressed
by a bare id from the HTTP surface.

## Migrated methods

| Method | New shape | Why |
| --- | --- | --- |
| `get(id)` | `get(orgId, id)` + `getUnscoped(id)` | org filter rides the unique lookup |
| `setVisibility(id, …)` | `setVisibility(orgId, id, …)` | fence on the row-lock read; see below |
| `listPage`, `listConversationPage`, `listConversationMembers`, `listFacets`, `list` | unchanged | query-shaped; already carry `agentIds` + the viewer predicate |
| `orgHasAny`, `getExternalAccessPolicy`, `countExternalUnresolved`, `setExternalAccessEnabled` | unchanged | already org-carrying |
| `listChildren(parentId, agentIds, viewer?)` | unchanged | system-tier: `agentIds` is the caller's own org roster, a stronger fence than the parent id |
| `hasPrivateWebchatSession(conversationId, agentId)` | unchanged | system-tier: fenced by the conversation's own `agentId`, which the MCP authority has bound to the delegated agent |
| `markContentPurged`, `recordMilestone`, `recordVisibilityAck`, `visibilitySnapshotForDaemon`, `countUnackedVisibility`, `findThreadOwner` | unchanged | system-tier: daemon-reported / daemon-fenced |
| `visibilitySubtree` | unchanged | system-tier: the visibility-push orchestrator drives it from a row it holds |

Session children (`SessionUsage`, `SessionSpend`, `AgentLaunch`) need no change:
each is already addressed through its agent or daemon, which is §3.6's parent
fence.

### `WebchatConversationRepo`

`participants` and `addParticipant` take the org; `owns`, `ownedBy` and `create`
were already org-carrying, and `findOwner` stays system-tier (fenced by the
participant `agentId` that session ingest binds to the reporting daemon). The
roster rows carry no `orgId`, so both fence relationally on the owning
conversation (§3.6) — `participants` yields the same empty roster for a
cross-org id as for an unknown one, which is what every caller already fails
closed on.

The relay-facing verifier threads the org **the signed webchat token asserts**,
not one re-derived from the row — so this is a real fence, not a tautology.

## `setVisibility` — why the fence sits on the row lock

The method opens with `SELECT … FOR UPDATE` and then, before any write, can
answer `{ forbidden: true }` for a shared/external row whose audience is
immutable. Fencing on the update would have let a cross-org id reach that guard
and get `forbidden` back — confirming the foreign session exists. The org rides
the locked read instead, so a cross-org id takes the same silent
`{ affected: [] }` exit as a missing row.

## Also in this PR: the #709 review follow-up

`review-bot` noted on the merged hook batch that the foreign-DELETE case claimed
to prove review projections survive but seeded only a `HookRun`. It now seeds a
real `HookReviewProjection` and asserts it comes back un-tombstoned with its
`desiredState` intact.

Worth recording accurately: `HookRepo.remove` runs the tombstones and the delete
in one transaction, so the refusal rolls the tombstones back either way — the
early typed `HookMissing` is what makes it a clean 404 rather than what makes it
safe. I verified this by disabling the early fence: the projection still
survives, and the repo test fails on the error *type*, not on the row state.

## Acceptance gate

`test/integration/tenant-isolation.route.test.ts` grows a Session/webchat block:
point-GET, the visibility write, and the proxied transcript and tool-body reads
against a foreign id are all 404 with `visibilityRev` provably still 0; the flat
list excludes the foreign row; the repo test asserts `setVisibility` returns the
silent `{ affected: [] }` rather than `forbidden`; and the roster test asserts a
cross-org `participants` reads empty while the owning org still sees its member,
and that a cross-org `addParticipant` writes no row.

Green: full-repo `typecheck` and `lint`, CP `test:unit` (1256) and `test:int` (1037).
