### PR TITLE
fix(web): redirect localhost to canonical origin

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -227,6 +227,7 @@ services:
       # Topology-only bootstrap for the DB-backed browser auth snapshot. Public
       # service routes remain owned by this Web container's startup environment.
       - CP_INTERNAL_URL=http://control-plane:8080/api/v1
+      - PUBLIC_WEB_URL=${AGENTCONNECT_PUBLIC_WEB_URL:-http://app.agentconnect.localhost:${AGENTCONNECT_WEB_PORT:-3000}}
       - CP_URL=${AGENTCONNECT_PUBLIC_CP_URL:-http://api.agentconnect.localhost:${AGENTCONNECT_CP_PORT:-8080}}/api/v1
       - RELAY_URL=${AGENTCONNECT_PUBLIC_RELAY_URL:-http://relay.agentconnect.localhost:${AGENTCONNECT_RELAY_PORT:-8090}}
       - LOGTO_ENDPOINT

--- a/packages/web/src/proxy.test.ts
+++ b/packages/web/src/proxy.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { NextRequest } from 'next/server'
+import { proxy } from './proxy'
+
+const originalPublicWebUrl = process.env.PUBLIC_WEB_URL
+
+afterEach(() => {
+  if (originalPublicWebUrl === undefined) delete process.env.PUBLIC_WEB_URL
+  else process.env.PUBLIC_WEB_URL = originalPublicWebUrl
+})
+
+describe('canonical Web origin', () => {
+  it('redirects localhost while preserving the path and query', () => {
+    process.env.PUBLIC_WEB_URL = 'http://app.agentconnect.localhost:3000'
+
+    const response = proxy(
+      new NextRequest('http://localhost:3000/login?next=%2Fsettings', { headers: { host: 'localhost:3000' } })
+    )
+
+    expect(response.status).toBe(308)
+    expect(response.headers.get('location')).toBe('http://app.agentconnect.localhost:3000/login?next=%2Fsettings')
+  })
+
+  it('does not redirect the container health-check origin', () => {
+    process.env.PUBLIC_WEB_URL = 'http://app.agentconnect.localhost:3000'
+
+    const response = proxy(new NextRequest('http://127.0.0.1:8080/', { headers: { host: '127.0.0.1:8080' } }))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+    expect(new URL(response.headers.get('x-middleware-rewrite')!).pathname).toBe('/-/home')
+  })
+})

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -12,7 +12,21 @@ import { NextResponse, type NextRequest } from 'next/server'
 // leak one account's last org into another account and drift across devices.
 const CONSOLE_ROOTS = ['home', 'agents', 'sessions', 'daemons', 'crons', 'tools', 'usage', 'settings', 'profile']
 
+function canonicalRedirect(req: NextRequest): NextResponse | undefined {
+  const publicWebUrl = process.env.PUBLIC_WEB_URL
+  const hostname = req.headers.get('host')?.split(':', 1)[0]?.toLowerCase()
+  if (!publicWebUrl || hostname !== 'localhost') return
+
+  const canonical = new URL(publicWebUrl)
+  if (canonical.origin === req.nextUrl.origin) return
+
+  return NextResponse.redirect(new URL(`${req.nextUrl.pathname}${req.nextUrl.search}`, canonical.origin), 308)
+}
+
 export function proxy(req: NextRequest) {
+  const redirect = canonicalRedirect(req)
+  if (redirect) return redirect
+
   const { pathname } = req.nextUrl
   const first = pathname.split('/')[1]!
   const isEntry = pathname === '/' || CONSOLE_ROOTS.includes(first)
@@ -25,7 +39,7 @@ export function proxy(req: NextRequest) {
 }
 
 export const config = {
-  // Skip static assets and Next internals; /login and /auth pass through
-  // untouched (they're outside the console).
-  matcher: ['/((?!_next|favicon\\.ico|icon\\.svg|apple-icon\\.png|login|auth).*)']
+  // Skip static assets and Next internals. /login and /auth pass through the
+  // canonical-origin check, then bypass the console rewrite above.
+  matcher: ['/((?!_next|favicon\\.ico|icon\\.svg|apple-icon\\.png).*)']
 }


### PR DESCRIPTION
## Summary

- pass the canonical public Web origin into the Compose Web runtime
- return a permanent redirect for localhost requests while preserving path and query
- keep loopback health checks and non-localhost origins unchanged

## Why

Local Compose users can open localhost:3000 even though browser authentication callbacks are registered against the canonical app hostname. The application loaded, but OIDC later rejected the callback because its origin did not match the registered redirect URI.

## Validation

- pnpm --filter @agentconnect.md/web exec vitest run src/proxy.test.ts
- pnpm --filter @agentconnect.md/web typecheck
- pnpm exec eslint packages/web/src/proxy.ts packages/web/src/proxy.test.ts
- pnpm exec prettier --check compose.yaml packages/web/src/proxy.ts packages/web/src/proxy.test.ts
- pnpm --filter @agentconnect.md/web... build
- docker compose -f compose.yaml -f compose.logto.yaml config --quiet
- rebuilt and restarted the local Web service; verified the exact 308 Location, a 200 response on the canonical URL, and a healthy container
- pre-push eslint .
- git diff --check

Created by Codex . GPT-5
