### PR TITLE
fix(web): move variables below session access

### DIFF
--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -787,10 +787,6 @@ export default function SettingsView() {
         }}
       />
 
-      {/* Sits with the other organization-wide agent policies. Owner-only, so the
-          card renders nothing at all for collaborators and viewers (§8.1). */}
-      <OrganizationEnvironmentCard orgId={activeOrg?.id} isOwner={isOwner} agents={agents} />
-
       <div className="card mt-[18px]">
         <div className="cardhead">
           <span className="cardtitle">Session access</span>
@@ -799,6 +795,10 @@ export default function SettingsView() {
         <SessionAccessRow provider="github" orgId={activeOrg?.id} isOwner={isOwner} bordered />
         <SessionAccessRow provider="feishu" orgId={activeOrg?.id} isOwner={isOwner} bordered />
       </div>
+
+      {/* Sits with the other organization-wide agent policies. Owner-only, so the
+          card renders nothing at all for collaborators and viewers (§8.1). */}
+      <OrganizationEnvironmentCard orgId={activeOrg?.id} isOwner={isOwner} agents={agents} />
 
       <div className="card mt-[18px]">
         <div className="cardhead justify-between">


### PR DESCRIPTION
## Summary

- move the organization Variables & secrets card directly below Session access
- preserve the card contents, permissions, and behavior

## Validation

- `node_modules/.bin/prettier --check packages/web/src/components/console/views/SettingsView.tsx`
- `node_modules/.bin/eslint packages/web/src/components/console/views/SettingsView.tsx`
- pre-push full-repository `eslint .`

Created by Codex . GPT-5
