### PR TITLE
feat(cp): org-fence the memory, github-installation and daemon-key data layers

### DIFF
--- a/docs/designs/org-scoped-data-layer.md
+++ b/docs/designs/org-scoped-data-layer.md
@@ -1,6 +1,7 @@
 # Org-Scoped Data Layer
 
-> **Status:** M1 implemented (convention + Agent exemplar); M2 rollout tracked in §7
+> **Status:** M1 + M2 implemented (the convention, and every org-owned repository
+> migrated); M3 (Postgres RLS) is a separate design
 >
 > **Scope:** Control-plane persistence ports and their HTTP/MCP consumers.
 > Related: [`authorization-policy.md`](authorization-policy.md) (the policy layer
@@ -165,14 +166,38 @@ Two structural guards, so the convention cannot silently erode:
 - **M1 (this change):** the convention; `AgentRepo` + `AgentConfigWriter`
   migrated end-to-end; ESLint fence; contract-suite foundation with the Agent
   block.
-- **M2 (mechanical batches, same recipe per repo):** `DaemonRepo`, `BotRepo`,
-  `IntegrationRepo`, `CronRepo`, `HookRepo`, `McpProviderRepo`,
-  `SkillSourceRepo`, `SessionRepo` (+ session children via parent),
-  `WebchatConversationRepo`, `MemoryConnectionRepo`, `OrganizationKnowledge` /
-  `ManagedSkill` repos, `GithubInstallationRepo`, API-key/user-facing stores.
-  Each batch: tighten signatures → follow the type errors → classify each
-  internal caller (`Unscoped` or org-threaded) → delete the now-redundant
-  route comparisons → extend the contract suite.
+- **M2 (mechanical batches, same recipe per repo) — complete.** Each batch
+  tightened signatures → followed the type errors → classified every internal
+  caller (`Unscoped` or org-threaded) → deleted the now-redundant route
+  comparisons → extended the contract suite:
+
+  | Batch | Repositories                                                                                               |
+  | ----- | ---------------------------------------------------------------------------------------------------------- |
+  | 1     | `DaemonRepo`, `BotRepo` (+ the `DaemonRegistry` read model and `ApiKeyAdmin.mintForDaemon` above them)     |
+  | 2     | `IntegrationRepo`, `IntegrationChannelRepo` (child), `CronRepo`                                            |
+  | 3     | `HookRepo` (+ `HookSecretStore` / `HookRun` children)                                                      |
+  | 4     | `McpProviderRepo`, `SkillSourceRepo`, `OrganizationKnowledgeRepo` (knowledge, managed skills, suggestions) |
+  | 5     | `SessionRepo` (+ session children via parent), `WebchatConversationRepo`                                   |
+  | 6     | `ExternalMemoryConnectionRepo`, `GithubInstallationRepo`, `ApiKeyRepo.listForDaemon`                       |
+
+  Three patterns recurred often enough to be worth stating as rules for new code:
+
+  1. **A fence must sit ahead of any answer that would confirm the row.** Where
+     a method can respond `'referenced'`, `BotStillShared`, `'not_pending'`,
+     `'metadata_changed'` or `forbidden` before it writes, the org check goes on
+     the read that opens the critical section — not on the write's `where`.
+     Otherwise a cross-org id gets a distinguishable refusal, which is the exact
+     thing §3 forbids.
+  2. **A client-minted id makes an upsert a takeover risk, not a leak risk.**
+     `CronRepo.upsert` and `HookRepo.upsert` rewrite `orgId` on their update
+     branch. Both fence inside the transaction; the cron one additionally takes a
+     transaction-scoped advisory lock keyed on the id ALONE, because the case that
+     matters is a row that does not exist yet and no row-level lock can cover it.
+  3. **Prefer the row's own `orgId` column when a child table has one.**
+     `HookRun` and `CronRun` do, so their history reads fence directly rather than
+     resting on the parent. Rosters, revisions and secrets do not, and fence
+     relationally through the parent (§3.6).
+
 - **M3 (separate design):** Postgres row-level security as the DB-level
   backstop beneath this fence.
 

--- a/packages/control-plane/src/http/github-session-access.ts
+++ b/packages/control-plane/src/http/github-session-access.ts
@@ -1,4 +1,5 @@
 import type { Clock } from '../domain/clock.js'
+import { OrgId } from '../domain/ids.js'
 import type { ExternalScopeRecord, GithubInstallationRepo } from '../persistence/ports.js'
 import type { GithubService } from '../github/service.js'
 import { UserAuthzDeniedError, type GithubUserAuthzService } from '../github/user-authz.js'
@@ -84,9 +85,11 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
       return 'deny'
     }
     if (!this.deps.github) return 'unknown'
-    const installation = await this.deps.installations.get(scope.credentialId).catch(() => null)
+    // Fenced on the org recorded in the session's own external scope row — the
+    // check this replaces (org-scoped-data-layer.md §3).
+    const installation = await this.deps.installations.get(OrgId(scope.orgId), scope.credentialId).catch(() => null)
     if (!installation) return 'unknown'
-    if (installation.orgId !== scope.orgId || installation.revokedAt || installation.suspendedAt) return 'deny'
+    if (installation.revokedAt || installation.suspendedAt) return 'deny'
 
     const key = [scope.id, scope.aclRevision.toString(), installation.installationId.toString(), userId].join(':')
     const cached = this.cache.get(key)

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -827,8 +827,8 @@ export function agentRoutes(deps: HttpDeps) {
       orgId: OrgId
     ): Promise<string | null> => {
       if (memory?.provider !== 'external') return null
-      const connection = await deps.repos.externalMemoryConnection.get(memory.connectionId)
-      if (!connection || connection.orgId !== orgId) return 'external memory connection not found in this organization'
+      const connection = await deps.repos.externalMemoryConnection.get(orgId, memory.connectionId)
+      if (!connection) return 'external memory connection not found in this organization'
       // Probing is daemon-owned and a connection reaches a daemon through its
       // first binding, so rejecting every non-ready connection here creates a
       // bootstrap deadlock. Persist probing/degraded bindings; daemon admission
@@ -859,8 +859,8 @@ export function agentRoutes(deps: HttpDeps) {
     const pushExternalMemoryToDaemon = async (agent: AgentRecord, daemonId: string): Promise<boolean> => {
       if (agent.memory?.provider !== 'external') return true
       try {
-        const connection = await deps.repos.externalMemoryConnection.get(agent.memory.connectionId)
-        if (!connection || connection.orgId !== agent.orgId) return false
+        const connection = await deps.repos.externalMemoryConnection.get(agent.orgId, agent.memory.connectionId)
+        if (!connection) return false
         const installation = await deps.repos.memoryPluginInstallation.get(connection.installationId)
         if (!installation) return false
         if (installation.transport === 'stdio') {
@@ -1040,8 +1040,8 @@ export function agentRoutes(deps: HttpDeps) {
         }
         if (ws?.mode === 'github' && ws.installationId !== undefined) {
           if (!deps.github) return conflict('github-app workspaces are not enabled on this control plane')
-          const ins = await deps.repos.githubInstallation.get(ws.installationId)
-          if (!ins || ins.orgId !== req.orgCtx!.orgId || ins.revokedAt) {
+          const ins = await deps.repos.githubInstallation.get(orgOf(req), ws.installationId)
+          if (!ins || ins.revokedAt) {
             return conflict('github installation not found in this org')
           }
           const repoParts = gitRepoLabel(ws.gitRepo).split('/')

--- a/packages/control-plane/src/http/routes/github.ts
+++ b/packages/control-plane/src/http/routes/github.ts
@@ -226,8 +226,8 @@ export function githubRoutes(deps: HttpDeps) {
         // human-admin UI gate. Keep that external destructive power owner-only.
         if (denyNonOwner(req, reply)) return
         const orgId = orgOf(req)
-        const ins = await deps.repos.githubInstallation.get(req.params.id)
-        if (!ins || ins.orgId !== orgId) {
+        const ins = await deps.repos.githubInstallation.get(orgId, req.params.id)
+        if (!ins) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'installation not found' })
         }
         // DELETE is idempotent at our boundary too: a repeated request after the
@@ -267,8 +267,8 @@ export function githubRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const ins = await deps.repos.githubInstallation.get(req.params.id)
-        if (!ins || ins.orgId !== req.orgCtx!.orgId || ins.revokedAt) {
+        const ins = await deps.repos.githubInstallation.get(orgOf(req), req.params.id)
+        if (!ins || ins.revokedAt) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'installation not found' })
         }
         try {
@@ -315,8 +315,8 @@ export function githubRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const ins = await deps.repos.githubInstallation.get(req.params.id)
-        if (!ins || ins.orgId !== req.orgCtx!.orgId || ins.revokedAt) {
+        const ins = await deps.repos.githubInstallation.get(orgOf(req), req.params.id)
+        if (!ins || ins.revokedAt) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'installation not found' })
         }
         try {
@@ -369,8 +369,8 @@ export function githubRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const ins = await deps.repos.githubInstallation.get(req.params.id)
-        if (!ins || ins.orgId !== req.orgCtx!.orgId || ins.revokedAt) {
+        const ins = await deps.repos.githubInstallation.get(orgOf(req), req.params.id)
+        if (!ins || ins.revokedAt) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'installation not found' })
         }
         try {
@@ -414,8 +414,8 @@ export function githubRoutes(deps: HttpDeps) {
           }
         },
         async (req, reply) => {
-          const ins = await deps.repos.githubInstallation.get(req.params.id)
-          if (!ins || ins.orgId !== req.orgCtx!.orgId || ins.revokedAt) {
+          const ins = await deps.repos.githubInstallation.get(orgOf(req), req.params.id)
+          if (!ins || ins.revokedAt) {
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'installation not found' })
           }
           try {

--- a/packages/control-plane/src/http/routes/keys.ts
+++ b/packages/control-plane/src/http/routes/keys.ts
@@ -65,7 +65,7 @@ export function keyRoutes(deps: HttpDeps) {
         if (!(await getOrgDaemon(req, req.params.id))) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
         }
-        const rows = await deps.apiKeys.listForDaemon(DaemonId(req.params.id))
+        const rows = await deps.apiKeys.listForDaemon(orgOf(req), DaemonId(req.params.id))
         return rows.map(toDto)
       }
     )
@@ -129,7 +129,7 @@ export function keyRoutes(deps: HttpDeps) {
         }
         // Bind the keyId to the org-checked daemon — a raw key id from ANOTHER
         // daemon/org must read as absent, not get revoked (cross-tenant kill).
-        const owned = await deps.apiKeys.listForDaemon(DaemonId(req.params.id))
+        const owned = await deps.apiKeys.listForDaemon(orgOf(req), DaemonId(req.params.id))
         if (!owned.some((k) => k.id === req.params.keyId)) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'key not found' })
         }

--- a/packages/control-plane/src/http/routes/memory-connections.ts
+++ b/packages/control-plane/src/http/routes/memory-connections.ts
@@ -262,8 +262,8 @@ export function memoryConnectionRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const row = await deps.repos.externalMemoryConnection.get(req.params.id)
-        if (!row || row.orgId !== orgOf(req)) {
+        const row = await deps.repos.externalMemoryConnection.get(orgOf(req), req.params.id)
+        if (!row) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'connection not found' })
         }
         return connectionDto(row, deps)
@@ -340,8 +340,8 @@ export function memoryConnectionRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyNonOwner(req, reply)) return
-        const existing = await deps.repos.externalMemoryConnection.get(req.params.id)
-        if (!existing || existing.orgId !== orgOf(req)) {
+        const existing = await deps.repos.externalMemoryConnection.get(orgOf(req), req.params.id)
+        if (!existing) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'connection not found' })
         }
         const installation = await deps.repos.memoryPluginInstallation.get(existing.installationId)
@@ -407,8 +407,8 @@ export function memoryConnectionRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyNonOwner(req, reply)) return
-        const connection = await deps.repos.externalMemoryConnection.get(req.params.id)
-        if (!connection || connection.orgId !== orgOf(req)) {
+        const connection = await deps.repos.externalMemoryConnection.get(orgOf(req), req.params.id)
+        if (!connection) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'connection not found' })
         }
         const installation = await deps.repos.memoryPluginInstallation.get(connection.installationId)
@@ -491,8 +491,8 @@ export function memoryConnectionRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         if (denyNonOwner(req, reply)) return
-        const connection = await deps.repos.externalMemoryConnection.get(req.params.id)
-        if (!connection || connection.orgId !== orgOf(req)) {
+        const connection = await deps.repos.externalMemoryConnection.get(orgOf(req), req.params.id)
+        if (!connection) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'connection not found' })
         }
         const installation = await deps.repos.memoryPluginInstallation.get(connection.installationId)

--- a/packages/control-plane/src/http/routes/skill-sources.ts
+++ b/packages/control-plane/src/http/routes/skill-sources.ts
@@ -290,8 +290,8 @@ export function skillSourceRoutes(deps: HttpDeps) {
         if (denyViewerWrite(req, reply)) return
         const gh = deps.github
         if (!gh) return notFound(reply) // github-app feature off — no scan possible
-        const ins = await deps.repos.githubInstallation.get(req.body.installationId)
-        if (!ins || ins.orgId !== orgOf(req) || ins.revokedAt) return notFound(reply)
+        const ins = await deps.repos.githubInstallation.get(orgOf(req), req.body.installationId)
+        if (!ins || ins.revokedAt) return notFound(reply)
         const [branches, scan] = await Promise.all([
           gh.listBranches(ins, req.body.owner, req.body.repo).catch(() => [] as string[]),
           gh.scanSkillSource(ins, req.body.owner, req.body.repo, req.body.ref)

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -370,15 +370,27 @@ export interface ApiKeyRepo {
   findByHash(hash: string): Promise<ApiKeyRecord | null>
   /** Throttled liveness write on successful auth. */
   touchLastUsed(id: string, at: Date): Promise<void>
-  /** Kill switch: set `revokedAt` (+ reason). Checked on every auth. */
+  /** Kill switch: set `revokedAt` (+ reason). Checked on every auth.
+   *  System-tier (docs/designs/org-scoped-data-layer.md §3.4): this one method
+   *  revokes daemon, user, oauth AND relay keys, and relay keys are org-less
+   *  deployment infrastructure by design (§7 non-goals). Each caller proves
+   *  ownership on a STRONGER axis first — the org-fenced daemon roster
+   *  ({@link ApiKeyRepo.listForDaemon}) or the caller's own key list
+   *  ({@link ApiKeyRepo.listForUser}) — so an org parameter here would be both
+   *  wrong for relay keys and weaker than the fence already in place. */
   revoke(id: string, reason: string, at: Date): Promise<ApiKeyRecord>
   /** Revoke every live oauth access token minted under a grant — the "disconnect"
    *  cascade so a Profile revoke kills outstanding tokens now, not in ≤1h. Returns count. */
   revokeByOAuthGrant(grantId: string, reason: string, at: Date): Promise<number>
-  /** All keys (including revoked) for a daemon — the console key list. */
-  listForDaemon(daemonId: DaemonId): Promise<ApiKeyRecord[]>
+  /** All keys (including revoked) for a daemon — the console key list, and the
+   *  ownership proof the revoke route binds a raw key id against. Org-fenced
+   *  (§3): a daemon outside `orgId` yields no keys at all, so that proof cannot
+   *  admit a cross-tenant kill even if a route forgot to resolve the daemon. */
+  listForDaemon(orgId: OrgId, daemonId: DaemonId): Promise<ApiKeyRecord[]>
   /** A user's personal keys (all their orgs, active-only by default), joined with each
-   *  key's org label — the profile "API keys" list, newest first. */
+   *  key's org label — the profile "API keys" list, newest first.
+   *  System-tier: fenced by the caller's own identity, which spans organizations
+   *  by design (a personal key list is per-user, not per-org). */
   listForUser(userId: string, opts?: { includeRevoked?: boolean }): Promise<UserApiKeyRecord[]>
 }
 
@@ -2769,7 +2781,10 @@ export interface GithubInstallationRepo {
   /** Claim/update by GitHub installation id. The setup callback is the only
    * path allowed to create a claim; refresh paths pass the durable claim's org. */
   upsertFromGithub(orgId: OrgId, facts: GithubInstallationFacts): Promise<GithubInstallationRecord>
-  get(id: string): Promise<GithubInstallationRecord | null>
+  /** Org-fenced point read (org-scoped-data-layer.md §3): a cross-org id reads
+   *  as absent, exactly like a missing row. The claim row IS the tenancy record
+   *  for an installation, so this is the read the HTTP surface must use. */
+  get(orgId: OrgId, id: string): Promise<GithubInstallationRecord | null>
   /** Live (non-revoked) installations claimed by the org — the picker's first level. */
   listForOrg(orgId: OrgId): Promise<GithubInstallationRecord[]>
   /** Every durable claim for an org, including revoked rows. Sync refreshes
@@ -2778,9 +2793,12 @@ export interface GithubInstallationRepo {
   /** Mint-time resolution: the live installation covering `accountLogin` in this org. */
   liveByOrgAndAccount(orgId: OrgId, accountLogin: string): Promise<GithubInstallationRecord | null>
   /** Doorbell lookup by GITHUB-side id (revoked rows included — the claim row is
-   *  what maps the poke to an org; unknown ⇒ no org claim yet, ignore). */
+   *  what maps the poke to an org; unknown ⇒ no org claim yet, ignore).
+   *  System-tier and deliberately CROSS-ORG: resolving the owning organization
+   *  is the whole point of this read, so it cannot take one. */
   getByInstallationId(installationId: bigint): Promise<GithubInstallationRecord | null>
-  /** Doorbell revoke: GitHub answered 404/410 for this installation (never delete). */
+  /** Doorbell revoke: GitHub answered 404/410 for this installation (never delete).
+   *  System-tier: GitHub-driven, keyed by the same cross-org external id. */
   markRevokedByInstallationId(installationId: bigint): Promise<void>
 }
 
@@ -4448,14 +4466,22 @@ export interface ExternalMemoryConnectionRepo {
     config: Record<string, unknown>
     createdByUserId?: string
   }): Promise<ExternalMemoryConnectionRecord>
-  get(id: string): Promise<ExternalMemoryConnectionRecord | null>
+  /** Org-fenced point read (org-scoped-data-layer.md §3): a cross-org id reads
+   *  as absent, exactly like a missing row. No `getUnscoped` — the daemon and
+   *  relay reach connections through `activeForDaemon` / `listAll`, never by id. */
+  get(orgId: OrgId, id: string): Promise<ExternalMemoryConnectionRecord | null>
   listForOrg(orgId: OrgId): Promise<ExternalMemoryConnectionRecord[]>
+  /** System-tier: the pool-wide set replayed to a relay that just (re)registered. */
   listAll(): Promise<ExternalMemoryConnectionRecord[]>
-  update(id: string, patch: { config?: Record<string, unknown> }): Promise<ExternalMemoryConnectionRecord>
-  delete(id: string): Promise<void>
-  /** Connections referenced by an external-memory agent placed on this daemon. */
+  /** Org-fenced: a cross-org id throws the same P2025 as a missing row. */
+  update(orgId: OrgId, id: string, patch: { config?: Record<string, unknown> }): Promise<ExternalMemoryConnectionRecord>
+  /** Org-fenced: a cross-org id throws the same P2025 as a missing row. */
+  delete(orgId: OrgId, id: string): Promise<void>
+  /** Connections referenced by an external-memory agent placed on this daemon.
+   *  System-tier: daemon-fenced. */
   activeForDaemon(daemonId: DaemonId): Promise<ExternalMemoryConnectionRecord[]>
-  /** Revision-fenced probe fact update; stale daemon facts are ignored. */
+  /** Revision-fenced probe fact update; stale daemon facts are ignored.
+   *  System-tier: daemon-reported, fenced by the revision CAS. */
   updateProbeFact(
     id: string,
     revision: number,
@@ -4471,7 +4497,11 @@ export interface ExternalMemoryConnectionRepo {
   ): Promise<boolean>
 }
 
-/** Secret values keyed by manifest logical field name. Values never enter DTOs. */
+/** Secret values keyed by manifest logical field name. Values never enter DTOs.
+ *  Rows are keyed by `connectionId` alone and carry no org, so this store fences
+ *  through its parent (org-scoped-data-layer.md §3.6) — a route reaching a
+ *  connection's secrets must resolve it through the org-fenced
+ *  {@link ExternalMemoryConnectionRepo.get} first. */
 export interface ExternalMemoryConnectionSecretStore {
   put(connectionId: string, values: Record<string, string>): Promise<void>
   get(connectionId: string): Promise<Record<string, string> | null>
@@ -4487,6 +4517,8 @@ export interface ExternalMemoryGrantRecord {
   createdAt: Date
 }
 
+/** Grants hang off one connection and fence through it, exactly like
+ *  {@link ExternalMemoryConnectionSecretStore} (§3.6). */
 export interface ExternalMemoryGrantRepo {
   mintFor(connectionId: string): Promise<ExternalMemoryGrantRecord>
   activeForConnection(connectionId: string): Promise<ExternalMemoryGrantRecord[]>

--- a/packages/control-plane/src/persistence/repositories/api-key.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/api-key.repo.ts
@@ -75,9 +75,12 @@ export class PgApiKeyRepo implements ApiKeyRepo {
     return res.count
   }
 
-  async listForDaemon(daemonId: DaemonId): Promise<ApiKeyRecord[]> {
+  async listForDaemon(orgId: OrgId, daemonId: DaemonId): Promise<ApiKeyRecord[]> {
+    // Org fence on the key rows themselves (org-scoped-data-layer.md §3): a
+    // daemon outside `orgId` yields nothing, so the revoke route's ownership
+    // proof cannot admit a cross-tenant kill.
     const rows = await this.db.apiKey.findMany({
-      where: { daemonId },
+      where: { daemonId, orgId },
       orderBy: { createdAt: 'desc' }
     })
     return rows.map(toRecord)

--- a/packages/control-plane/src/persistence/repositories/github.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/github.repo.ts
@@ -66,8 +66,10 @@ export class PgGithubInstallationRepo implements GithubInstallationRepo {
     })
   }
 
-  async get(id: string): Promise<GithubInstallationRecord | null> {
-    const row = await this.prisma.githubInstallation.findUnique({ where: { id } })
+  async get(orgId: OrgId, id: string): Promise<GithubInstallationRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const row = await this.prisma.githubInstallation.findUnique({ where: { id, orgId } })
     return row ? toRecord(row) : null
   }
 

--- a/packages/control-plane/src/persistence/repositories/memory-connection.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/memory-connection.repo.ts
@@ -121,8 +121,10 @@ export class PgExternalMemoryConnectionRepo implements ExternalMemoryConnectionR
     )
   }
 
-  async get(id: string): Promise<ExternalMemoryConnectionRecord | null> {
-    const row = await this.db.externalMemoryConnection.findUnique({ where: { id } })
+  async get(orgId: OrgId, id: string): Promise<ExternalMemoryConnectionRecord | null> {
+    // The org filter rides the unique lookup (extended where): a cross-org id
+    // is indistinguishable from a missing row (org-scoped-data-layer.md §3).
+    const row = await this.db.externalMemoryConnection.findUnique({ where: { id, orgId } })
     return row ? toConnection(row) : null
   }
 
@@ -137,12 +139,14 @@ export class PgExternalMemoryConnectionRepo implements ExternalMemoryConnectionR
   }
 
   async update(
+    orgId: OrgId,
     id: string,
-    patch: Parameters<ExternalMemoryConnectionRepo['update']>[1]
+    patch: Parameters<ExternalMemoryConnectionRepo['update']>[2]
   ): Promise<ExternalMemoryConnectionRecord> {
+    // Org-fenced update: a cross-org id throws the same P2025 as a missing row.
     return toConnection(
       await this.db.externalMemoryConnection.update({
-        where: { id },
+        where: { id, orgId },
         data: {
           ...(patch.config !== undefined ? { config: patch.config as Prisma.InputJsonValue } : {}),
           revision: { increment: 1 },
@@ -159,8 +163,9 @@ export class PgExternalMemoryConnectionRepo implements ExternalMemoryConnectionR
     )
   }
 
-  async delete(id: string): Promise<void> {
-    await this.db.externalMemoryConnection.delete({ where: { id } })
+  async delete(orgId: OrgId, id: string): Promise<void> {
+    // Org-fenced delete: a cross-org id throws the same P2025 as a missing row.
+    await this.db.externalMemoryConnection.delete({ where: { id, orgId } })
   }
 
   async activeForDaemon(daemonId: DaemonId): Promise<ExternalMemoryConnectionRecord[]> {

--- a/packages/control-plane/src/persistence/repositories/memory-connection.writer.ts
+++ b/packages/control-plane/src/persistence/repositories/memory-connection.writer.ts
@@ -153,7 +153,7 @@ export class PgMemoryConnectionWriter implements MemoryConnectionWriter {
           update: { values: sealedSecrets as Prisma.InputJsonValue }
         })
       }
-      const connection = await new PgExternalMemoryConnectionRepo(tx).update(id, {
+      const connection = await new PgExternalMemoryConnectionRepo(tx).update(orgId, id, {
         ...(patch.config !== undefined ? { config: patch.config } : {})
       })
       // The projection snapshot for the revision THIS transaction commits: a
@@ -207,7 +207,7 @@ export class PgMemoryConnectionWriter implements MemoryConnectionWriter {
       if (activeNow.length !== observed.length || activeNow.some((row, index) => row.id !== observed[index]!.id)) {
         return { outcome: 'busy' as const }
       }
-      const connection = await new PgExternalMemoryConnectionRepo(tx).update(id, {})
+      const connection = await new PgExternalMemoryConnectionRepo(tx).update(orgId, id, {})
       let fresh: ExternalMemoryGrantRecord
       if (reuse) {
         fresh = reuse
@@ -260,7 +260,7 @@ export class PgMemoryConnectionWriter implements MemoryConnectionWriter {
         where: { id: { in: [...retiringGrantIds] }, connectionId: id },
         data: { status: 'revoked' }
       })
-      const connection = await new PgExternalMemoryConnectionRepo(tx).update(id, {})
+      const connection = await new PgExternalMemoryConnectionRepo(tx).update(orgId, id, {})
       return { outcome: 'retired' as const, connection, sealedSnapshot: await sealedSecretsInTx(tx, id) }
     })
     if (result.outcome !== 'retired') return result

--- a/packages/control-plane/src/persistence/repositories/organization-knowledge.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/organization-knowledge.repo.ts
@@ -548,7 +548,11 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
     reviewedByUserId?: string
   ): Promise<AcceptOrganizationSuggestionResult> {
     return withAmbientTx(this.db, async (tx) => {
-      await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "organization_suggestion" WHERE "id" = ${id}::uuid FOR UPDATE`)
+      // The lock and the fenced read below select the SAME row set: a
+      // cross-org id locks nothing rather than parking on another org's row.
+      await tx.$queryRaw(
+        Prisma.sql`SELECT "id" FROM "organization_suggestion" WHERE "id" = ${id}::uuid AND "orgId" = ${orgId} FOR UPDATE`
+      )
       // Org fence on the row-locked read, BEFORE the state and snapshot-token
       // comparisons: reaching those with a foreign id would answer
       // 'not_pending' / 'metadata_changed' and confirm it exists (§3).
@@ -660,7 +664,11 @@ export class PgOrganizationKnowledgeRepo implements OrganizationKnowledgeRepo {
   ): Promise<AcceptOrganizationSuggestionResult> {
     try {
       return await withAmbientTx(this.db, async (tx) => {
-        await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "organization_suggestion" WHERE "id" = ${id}::uuid FOR UPDATE`)
+        // The lock and the fenced read below select the SAME row set: a
+        // cross-org id locks nothing rather than parking on another org's row.
+        await tx.$queryRaw(
+          Prisma.sql`SELECT "id" FROM "organization_suggestion" WHERE "id" = ${id}::uuid AND "orgId" = ${orgId} FOR UPDATE`
+        )
         // Org fence on the row-locked read, before the state / snapshot-token
         // comparisons and before any archive bytes are persisted (§3).
         const suggestion = await tx.organizationSuggestion.findUniqueOrThrow({ where: { id, orgId } })

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -101,8 +101,11 @@ export interface ApiKeyAdmin {
    *  — the per-relay `rc/auth` `method:'apikey'` credential (shared-bot-relay.md §8).
    *  Plaintext is returned exactly once; minting a relay key is granting relay trust. */
   mintForRelay(opts?: { name?: string; createdByUserId?: string }): Promise<MintedKeyView>
-  /** List a daemon's keys (incl. revoked) for the console. */
-  listForDaemon(daemonId: DaemonId): Promise<ApiKeyView[]>
+  /** List a daemon's keys (incl. revoked) for the console. Org-fenced
+   *  (docs/designs/org-scoped-data-layer.md §3): a daemon outside `orgId` yields
+   *  no keys, which is also what makes the revoke route's ownership check on
+   *  this list structural rather than conventional. */
+  listForDaemon(orgId: OrgId, daemonId: DaemonId): Promise<ApiKeyView[]>
   /** Revoke a key by id (kill switch). */
   revoke(apiKeyId: string, reason: string): Promise<ApiKeyView>
   /** Mint a personal key for `userId`, scoped to `orgId` (default 90-day expiry;

--- a/packages/control-plane/src/registry/apiKeyService.ts
+++ b/packages/control-plane/src/registry/apiKeyService.ts
@@ -115,8 +115,8 @@ export class ApiKeyService implements ApiKeyAdmin {
     return { apiKeyId: rec.id, token: minted.token, displayTail: minted.displayTail }
   }
 
-  async listForDaemon(daemonId: DaemonId): Promise<ApiKeyView[]> {
-    const rows = await this.apiKeys.listForDaemon(daemonId)
+  async listForDaemon(orgId: OrgId, daemonId: DaemonId): Promise<ApiKeyView[]> {
+    const rows = await this.apiKeys.listForDaemon(orgId, daemonId)
     return rows.map(toView)
   }
 

--- a/packages/control-plane/test/integration/memory-connections.route.test.ts
+++ b/packages/control-plane/test/integration/memory-connections.route.test.ts
@@ -15,7 +15,7 @@ import type {
 } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
-import { seedDaemon } from '../fixtures/seed.js'
+import { DEF_ORG, seedDaemon } from '../fixtures/seed.js'
 import type { Prisma } from '../../src/generated/prisma/client.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import {
@@ -320,7 +320,7 @@ describe('external-memory connections — secret/grant discipline', () => {
     const rotation = await app.app.inject({ method: 'POST', url: `${CONNECTIONS}/${connectionId}/grant/rotate` })
     expect(rotation.statusCode).toBe(400)
     expect((rotation.json() as { message: string }).message).toContain('no relay grant')
-    expect(await app.deps.repos.externalMemoryConnection.get(connectionId)).toMatchObject({ revision: 1 })
+    expect(await app.deps.repos.externalMemoryConnection.get(DEF_ORG, connectionId)).toMatchObject({ revision: 1 })
     expect(relay.unassigns).toEqual([])
 
     const unbound = await app.app.inject({
@@ -532,7 +532,7 @@ describe('external-memory connections — secret/grant discipline', () => {
       payload: { config: { projectId: 'serialized' } }
     })
     expect(first.statusCode).toBe(200)
-    expect(await repo.get(connection.id)).toMatchObject({ revision: 2, config: { projectId: 'serialized' } })
+    expect(await repo.get(DEF_ORG, connection.id)).toMatchObject({ revision: 2, config: { projectId: 'serialized' } })
     expect(await app.deps.repos.externalMemoryGrant.activeForConnection(connection.id)).toHaveLength(1)
   })
 
@@ -694,7 +694,7 @@ describe('external-memory connections — secret/grant discipline', () => {
     const tombstone = relay.unassigns.at(-1)!
     expect(tombstone).toEqual({ connectionId: connection.id, revision: 4 })
     expect(tombstone.revision).toBeGreaterThan(lastAssign.revision)
-    expect(await realGet(connection.id)).toBeNull()
+    expect(await realGet(DEF_ORG, connection.id)).toBeNull()
   })
 })
 
@@ -746,7 +746,7 @@ describe('external-memory agent binding — placement and revocation', () => {
     expect((removing.json() as { message: string }).message).toContain('being updated')
     await hold.release()
 
-    expect(await app.deps.repos.externalMemoryConnection.get(connection.id)).not.toBeNull()
+    expect(await app.deps.repos.externalMemoryConnection.get(DEF_ORG, connection.id)).not.toBeNull()
     const settled = await app.app.inject({
       method: 'PATCH',
       url: `${ORG}/agents/${holderId}`,
@@ -853,7 +853,7 @@ describe('external-memory agent binding — placement and revocation', () => {
     const removed = await app.app.inject({ method: 'DELETE', url: `${CONNECTIONS}/${connection.id}` })
     expect(removed.statusCode).toBe(204)
     expect(relay.unassigns.at(-1)).toEqual({ connectionId: connection.id, revision: 2 })
-    expect(await app.deps.repos.externalMemoryConnection.get(connection.id)).toBeNull()
+    expect(await app.deps.repos.externalMemoryConnection.get(DEF_ORG, connection.id)).toBeNull()
   })
 
   it('keeps the ordered AgentSpec hot-sync when a probe ACK is lost', async () => {

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -26,6 +26,9 @@ import { PgSkillSourceRepo } from '../../src/persistence/repositories/skill-sour
 import { PgOrganizationKnowledgeRepo } from '../../src/persistence/repositories/organization-knowledge.repo.js'
 import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.js'
 import { PgWebchatConversationRepo } from '../../src/persistence/repositories/webchat-conversation.repo.js'
+import { PgGithubInstallationRepo } from '../../src/persistence/repositories/github.repo.js'
+import { PgExternalMemoryConnectionRepo } from '../../src/persistence/repositories/memory-connection.repo.js'
+import { PgApiKeyRepo } from '../../src/persistence/repositories/api-key.repo.js'
 import { AgentMissing, BotMissing, CronMissing, HookMissing } from '../../src/persistence/errors.js'
 import { AgentId, BotId, CronId, DaemonId, HookId, IntegrationId, OrgId, SessionId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
@@ -61,6 +64,9 @@ let foreignManagedSkillId: string
 let foreignSessionId: string
 let ownSessionId: string
 let foreignConversationId: string
+let foreignInstallationId: string
+let foreignMemoryConnectionId: string
+let foreignDaemonKeyId: string
 
 afterEach(async () => {
   await running?.close()
@@ -330,6 +336,51 @@ beforeEach(async () => {
       }
     }
   })
+
+  // A GitHub installation claim, an external-memory connection, and one daemon
+  // API key — the last three id-addressed org resources.
+  foreignInstallationId = randomUUID()
+  await prisma.githubInstallation.create({
+    data: {
+      id: foreignInstallationId,
+      orgId: foreignOrgId,
+      installationId: 987654321n,
+      accountLogin: 'example-foreign-org',
+      accountType: 'Organization',
+      repositorySelection: 'all',
+      permissions: { pull_requests: 'write' }
+    }
+  })
+  const foreignPluginInstallationId = randomUUID()
+  await prisma.memoryPluginInstallation.create({
+    data: {
+      id: foreignPluginInstallationId,
+      orgId: foreignOrgId,
+      pluginId: 'mem0',
+      transport: 'streamable_http',
+      endpoint: 'https://memory.example.test/foreign'
+    }
+  })
+  foreignMemoryConnectionId = randomUUID()
+  await prisma.externalMemoryConnection.create({
+    data: {
+      id: foreignMemoryConnectionId,
+      orgId: foreignOrgId,
+      installationId: foreignPluginInstallationId,
+      config: { projectId: 'foreign-project' }
+    }
+  })
+  foreignDaemonKeyId = randomUUID()
+  await prisma.apiKey.create({
+    data: {
+      id: foreignDaemonKeyId,
+      principalType: 'daemon',
+      orgId: foreignOrgId,
+      daemonId: foreignDaemonId,
+      hash: `hash-${randomUUID()}`,
+      displayTail: 'abcd'
+    }
+  })
 })
 
 function build(): HttpApp {
@@ -428,6 +479,21 @@ async function foreignSessionUnmodified(): Promise<void> {
   expect(row!.orgId).toBe(foreignOrgId)
   expect(row!.visibility).toBe('org')
   expect(row!.visibilityRev).toBe(0)
+}
+
+async function foreignInfraUnmodified(): Promise<void> {
+  const installation = await prisma.githubInstallation.findUnique({ where: { id: foreignInstallationId } })
+  expect(installation).not.toBeNull()
+  expect(installation!.orgId).toBe(foreignOrgId)
+  expect(installation!.revokedAt).toBeNull()
+  const connection = await prisma.externalMemoryConnection.findUnique({ where: { id: foreignMemoryConnectionId } })
+  expect(connection).not.toBeNull()
+  expect(connection!.orgId).toBe(foreignOrgId)
+  expect(connection!.revision).toBe(1)
+  expect(connection!.config).toEqual({ projectId: 'foreign-project' })
+  const key = await prisma.apiKey.findUnique({ where: { id: foreignDaemonKeyId } })
+  expect(key).not.toBeNull()
+  expect(key!.revokedAt).toBeNull()
 }
 
 async function foreignBotUnmodified(): Promise<void> {
@@ -584,7 +650,9 @@ describe('tenant isolation — Daemon over the REST surface', () => {
     expect(list.statusCode).toBe(404)
     const mint = await app.app.inject({ method: 'POST', url: `${ORG}/daemons/${foreignDaemonId}/keys` })
     expect(mint.statusCode).toBe(404)
-    expect(await prisma.apiKey.count({ where: { daemonId: foreignDaemonId } })).toBe(0)
+    // The foreign daemon starts with exactly one seeded key; a leaked mint would
+    // have added a second.
+    expect(await prisma.apiKey.count({ where: { daemonId: foreignDaemonId } })).toBe(1)
   })
 
   it('the daemons list never contains a foreign row', async () => {
@@ -1260,5 +1328,78 @@ describe('tenant isolation — SessionRepo and WebchatConversationRepo fences un
     await repo.addParticipant(CALLER_ORG, foreignConversationId, AgentId(ownAgentId), 'attacker')
     expect(await repo.participants(OrgId(foreignOrgId), foreignConversationId)).toHaveLength(1)
     expect(await prisma.webchatConversationAgent.count({ where: { conversationId: foreignConversationId } })).toBe(1)
+  })
+})
+
+describe('tenant isolation — GitHub installations, memory connections and daemon keys', () => {
+  // NOTE: the `/github/*` route tree self-disables when the GitHub App feature is
+  // off, which it is in this harness — a 404 there would prove nothing about the
+  // fence. The installation's tenancy is asserted at the repository instead (see
+  // the fences block below); its route callers are held to `orgOf(req)` by the
+  // tightened signature itself.
+
+  it('a foreign external-memory connection is unreachable through its read and write routes', async () => {
+    const app = build()
+    const base = `${ORG}/external-memory-connections/${foreignMemoryConnectionId}`
+    expect((await app.app.inject({ method: 'GET', url: base })).statusCode).toBe(404)
+    const patch = await app.app.inject({ method: 'PATCH', url: base, payload: { config: { projectId: 'hijacked' } } })
+    expect(patch.statusCode).toBe(404)
+    const rotate = await app.app.inject({ method: 'POST', url: `${base}/grant/rotate` })
+    expect(rotate.statusCode).toBe(404)
+    expect((await app.app.inject({ method: 'DELETE', url: base })).statusCode).toBe(404)
+    await foreignInfraUnmodified()
+  })
+
+  it('a foreign daemon’s key cannot be listed or revoked through the caller’s org', async () => {
+    const app = build()
+    const list = await app.app.inject({ method: 'GET', url: `${ORG}/daemons/${foreignDaemonId}/keys` })
+    expect(list.statusCode).toBe(404)
+    // The revoke route binds a raw key id to the org-fenced daemon key list, so
+    // even a correct foreign key id reads as absent rather than being killed.
+    const revoke = await app.app.inject({
+      method: 'DELETE',
+      url: `${ORG}/daemons/${foreignDaemonId}/keys/${foreignDaemonKeyId}`
+    })
+    expect(revoke.statusCode).toBe(404)
+    // …and so does pairing it with a daemon the caller CAN see.
+    const crossed = await app.app.inject({
+      method: 'DELETE',
+      url: `${ORG}/daemons/${ownDaemonId}/keys/${foreignDaemonKeyId}`
+    })
+    expect(crossed.statusCode).toBe(404)
+    await foreignInfraUnmodified()
+  })
+
+  it('the connections list never contains a foreign row', async () => {
+    const app = build()
+    const connections = await app.app.inject({ method: 'GET', url: `${ORG}/external-memory-connections` })
+    expect(connections.statusCode).toBe(200)
+    expect(JSON.stringify(connections.json())).not.toContain(foreignMemoryConnectionId)
+  })
+})
+
+describe('tenant isolation — installation, memory-connection and key fences under the routes', () => {
+  it('these reads and mutations treat a cross-org id exactly like a missing row', async () => {
+    const installations = new PgGithubInstallationRepo(prisma)
+    expect(await installations.get(CALLER_ORG, foreignInstallationId)).toBeNull()
+    // The doorbell lookup stays deliberately CROSS-ORG: resolving which
+    // organization owns an installation is the whole point of that read.
+    expect(await installations.getByInstallationId(987654321n)).not.toBeNull()
+
+    const connections = new PgExternalMemoryConnectionRepo(prisma)
+    expect(await connections.get(CALLER_ORG, foreignMemoryConnectionId)).toBeNull()
+    expect(await connections.get(OrgId(foreignOrgId), foreignMemoryConnectionId)).not.toBeNull()
+    await expect(
+      connections.update(CALLER_ORG, foreignMemoryConnectionId, { config: { projectId: 'hijacked' } })
+    ).rejects.toThrow()
+    await expect(connections.delete(CALLER_ORG, foreignMemoryConnectionId)).rejects.toThrow()
+
+    // The daemon key list is what the revoke route binds a raw key id against,
+    // so its fence is what keeps a cross-tenant kill unreachable.
+    const keys = new PgApiKeyRepo(prisma)
+    expect(await keys.listForDaemon(CALLER_ORG, DaemonId(foreignDaemonId))).toEqual([])
+    expect(await keys.listForDaemon(OrgId(foreignOrgId), DaemonId(foreignDaemonId))).toHaveLength(1)
+
+    await foreignInfraUnmodified()
   })
 })

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -1095,11 +1095,20 @@ describe('tenant isolation — organization knowledge and managed skills over th
     })
     expect(patch.statusCode).toBe(404)
     const archive = await app.app.inject({
-      method: 'PUT',
+      method: 'POST',
       url: `${ORG}/knowledge/${foreignKnowledgeId}/archive`,
       payload: { archived: true }
     })
     expect(archive.statusCode).toBe(404)
+    // Positive control: the SAME verb and shape on the caller's own entry must
+    // reach the handler. Without it a 404 from a mistyped route would read as a
+    // passing fence assertion.
+    const ownArchive = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/knowledge/${ownKnowledgeId}/archive`,
+      payload: { archived: true }
+    })
+    expect(ownArchive.statusCode).toBe(200)
     await foreignKnowledgeUnmodified()
   })
 
@@ -1113,7 +1122,7 @@ describe('tenant isolation — organization knowledge and managed skills over th
         .statusCode
     ).toBe(404)
     const archive = await app.app.inject({
-      method: 'PUT',
+      method: 'POST',
       url: `${ORG}/managed-skills/${foreignManagedSkillId}/archive`,
       payload: { archived: true }
     })

--- a/packages/control-plane/test/protocol/memory-connections.handler.test.ts
+++ b/packages/control-plane/test/protocol/memory-connections.handler.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { isFrame } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { buildWsHarness } from '../fakes/build-ws.js'
-import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { DEF_ORG, seedAgent, seedDaemon } from '../fixtures/seed.js'
 import {
   PgExternalMemoryConnectionRepo,
   PgExternalMemoryConnectionSecretStore,
@@ -206,16 +206,16 @@ describe('facts/memory-connections — daemon-scoped and revision-fenced', () =>
     })
 
     await vi.waitFor(async () => {
-      expect(await connections.get(connection1.id)).toMatchObject({
+      expect(await connections.get(DEF_ORG, connection1.id)).toMatchObject({
         status: 'ready',
         probedRevision: 1,
         declaredEgressHosts: ['api.example-memory.com']
       })
     })
     // Connection 2 belongs to DAEMON_2: a fact from DAEMON_1 cannot mutate it.
-    expect(await connections.get(connection2.id)).toMatchObject({ status: 'probing', probedRevision: null })
+    expect(await connections.get(DEF_ORG, connection2.id)).toMatchObject({ status: 'probing', probedRevision: null })
 
-    await connections.update(connection1.id, { config: { projectId: 'changed' } })
+    await connections.update(DEF_ORG, connection1.id, { config: { projectId: 'changed' } })
     stub.inject('facts/memory-connections', {
       connections: [
         {
@@ -228,7 +228,7 @@ describe('facts/memory-connections — daemon-scoped and revision-fenced', () =>
       ]
     })
     await new Promise((resolve) => setTimeout(resolve, 20))
-    expect(await connections.get(connection1.id)).toMatchObject({
+    expect(await connections.get(DEF_ORG, connection1.id)).toMatchObject({
       revision: 2,
       status: 'probing',
       probedRevision: null

--- a/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
+++ b/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
@@ -1736,7 +1736,7 @@ describe('R1/R2a persistence foundation', () => {
         permissions: {}
       })
     ).rejects.toBeInstanceOf(GithubInstallationClaimConflict)
-    const durable = await repo.get(first.id)
+    const durable = await repo.get(OrgId(DEFAULT_ORG_ID), first.id)
     expect(durable).toMatchObject({ orgId: DEFAULT_ORG_ID, accountLogin: 'acme' })
     expect(durable?.permissions).toEqual({ pull_requests: 'write', checks: 'write' })
 

--- a/packages/control-plane/test/repo/memory-connection.repo.test.ts
+++ b/packages/control-plane/test/repo/memory-connection.repo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { prisma } from '../setup.db.js'
-import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { DEF_ORG, seedAgent, seedDaemon } from '../fixtures/seed.js'
 import {
   PgExternalMemoryConnectionRepo,
   PgExternalMemoryConnectionSecretStore,
@@ -59,20 +59,20 @@ describe('external-memory persistence (real Postgres)', () => {
         declaredEgressHosts: ['api.example-memory.com']
       })
     ).toBe(true)
-    expect(await connections.get(connection.id)).toMatchObject({
+    expect(await connections.get(DEF_ORG, connection.id)).toMatchObject({
       status: 'ready',
       probedRevision: 1,
       declaredEgressHosts: ['api.example-memory.com']
     })
 
-    const updated = await connections.update(connection.id, { config: { projectId: 'p2' } })
+    const updated = await connections.update(DEF_ORG, connection.id, { config: { projectId: 'p2' } })
     expect(updated).toMatchObject({ revision: 2, status: 'probing', probedRevision: null })
     expect(await connections.updateProbeFact(connection.id, 1, { status: 'invalid' })).toBe(false)
-    expect((await connections.get(connection.id))?.status).toBe('probing')
+    expect((await connections.get(DEF_ORG, connection.id))?.status).toBe('probing')
     expect(await connections.updateProbeFact(connection.id, 2, { status: 'degraded', reasonCode: 'timeout' })).toBe(
       true
     )
-    expect(await connections.get(connection.id)).toMatchObject({
+    expect(await connections.get(DEF_ORG, connection.id)).toMatchObject({
       revision: 2,
       probedRevision: 2,
       status: 'degraded',
@@ -100,7 +100,7 @@ describe('external-memory persistence (real Postgres)', () => {
 
     await grants.revoke(minted.id)
     expect(await grants.activeForConnection(connection.id)).toEqual([])
-    await connections.delete(connection.id)
+    await connections.delete(DEF_ORG, connection.id)
     expect(await prisma.externalMemoryConnectionSecret.count()).toBe(0)
     expect(await prisma.externalMemoryGrant.count()).toBe(0)
   })


### PR DESCRIPTION
Final batch of the org-scoped data-layer rollout
(`docs/designs/org-scoped-data-layer.md` §7 M2), after #699, #704, #706, #709,
#712 and #714: `ExternalMemoryConnectionRepo`, `GithubInstallationRepo`, and the
daemon-key surface. **This completes M2** — the design doc's status and rollout
section are updated to say so.

## Migrated methods

### `ExternalMemoryConnectionRepo`

`get` → `get(orgId, id)`; `update` and `delete` take the org and fence on their
own `where`. `create` and `listForOrg` were already org-carrying; `listAll`
(relay replay), `activeForDaemon` and `updateProbeFact` (revision-CAS-fenced
daemon facts) stay system-tier. No `getUnscoped` — nothing internal resolves a
connection by id. The secret store and grant repo are keyed by `connectionId`
with no org of their own and fence through the parent (§3.6).

`PgExternalMemoryConnectionWriter` threads the `orgId` it already had into the
three `update` calls inside its transactions.

### `GithubInstallationRepo`

`get` → `get(orgId, id)`. The claim row *is* the tenancy record for an
installation, so this is the read the console must use, and it lets five route
call sites plus the GitHub session-access resolver drop their
`ins.orgId !== …` post-check.

`getByInstallationId` and `markRevokedByInstallationId` stay deliberately
**cross-org**: resolving which organization owns an installation is the entire
purpose of the doorbell lookup, so it cannot take one. That is now stated in the
port rather than being implicit.

### The daemon-key surface

`ApiKeyRepo.listForDaemon` → `listForDaemon(orgId, daemonId)` (and the same on
`ApiKeyAdmin`). This is the method the revoke route binds a raw key id against,
so fencing it is what turns that ownership check from a convention into a
structure — a foreign daemon yields no keys at all.

`ApiKeyRepo.revoke` stays **system-tier**, and the port now says why: one method
revokes daemon, user, oauth *and* relay keys, and relay keys are org-less
deployment infrastructure that §7 explicitly does not migrate. Every caller
already proves ownership on a stronger axis first — the org-fenced daemon key
list, or the caller's own `listForUser`. An `orgId` here would be wrong for relay
keys and weaker than the fence already in place. `listForUser` is likewise
user-fenced, which spans organizations by design.

## Also in this PR: the #712 review follow-ups

- The two archive-route cases used `PUT` against `POST` handlers, so they were
  only asserting Fastify's unknown-route 404. Both now use `POST`, and a
  **positive control** asserts the same verb on the caller's own entry returns
  200 — so a mistyped route can never again read as a passing fence assertion.
- The suggestion acceptors' raw `SELECT … FOR UPDATE` was unscoped while the
  Prisma read it guards was scoped. Both now select the same row set, so a
  cross-org id locks nothing rather than parking on another organization's row.

## Design doc

§7 now records M2 as complete with a per-batch table, plus the three patterns
that recurred often enough to be worth stating as rules for new code: fence
ahead of any answer that would confirm the row; a client-minted id makes an
upsert a takeover risk rather than a leak risk; and prefer a child table's own
`orgId` column when it has one.

## Acceptance gate

`test/integration/tenant-isolation.route.test.ts` grows the last two blocks.
Worth noting what is *not* asserted and why: the `/github/*` route tree
self-disables when the App feature is off, which it is in this harness, so a 404
there would prove nothing — the installation's tenancy is asserted at the
repository instead, and its route callers are held to `orgOf(req)` by the
tightened signature itself. That is called out in the test.

The daemon-key case asserts the revoke route refuses a correct foreign key id
both against its own daemon and paired with a daemon the caller *can* see, and
that the foreign key row keeps `revokedAt: null`.

Green: full-repo `typecheck` and `lint`, CP `test:unit` (1256) and `test:int` (1042).
