### PR TITLE
docs(readme): remove rc daemon version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@
 <p align="center">
   <a href="https://github.com/agentconnect-md/agentconnect/actions/workflows/test.yaml"><img src="https://github.com/agentconnect-md/agentconnect/actions/workflows/test.yaml/badge.svg" alt="Test status" /></a>
   <a href="https://www.npmjs.com/package/@agentconnect.md/daemon/v/latest"><img src="https://img.shields.io/npm/v/%40agentconnect.md%2Fdaemon/latest?label=daemon%20latest" alt="Latest daemon version" /></a>
-  <a href="https://www.npmjs.com/package/@agentconnect.md/daemon/v/rc"><img src="https://img.shields.io/npm/v/%40agentconnect.md%2Fdaemon/rc?label=daemon%20rc" alt="RC daemon version" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Apache 2.0 license" /></a>
 </p>
 


### PR DESCRIPTION
## What

Removes the `daemon rc` npm version badge from the README badge row.

## Why

With the stable `daemon latest` badge next to it, the rc dist-tag badge added noise for readers — the rc channel is a release-engineering detail, not something the README audience needs front and center.

## Notes for review

- One-line deletion in `README.md`; the row now shows Test status, `daemon latest`, and license.
- This was the only reference to the rc badge in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)