### PR TITLE
feat: fence relay ingress attribution by tenant

### DIFF
--- a/docs/designs/ingress-tenant-fence.md
+++ b/docs/designs/ingress-tenant-fence.md
@@ -1,0 +1,197 @@
+# Ingress Tenant Fence
+
+> **Status:** Proposed → implemented in this change
+>
+> **Scope:** The relay's inbound HTTP demux ladder (core) and the per-assignment
+> tenant identity the control plane projects into it.
+> Related: [`integration-plugin-architecture.md`](integration-plugin-architecture.md)
+> (§11/D6 demux identity, the core-owned ladder), [`shared-bot-relay.md`](shared-bot-relay.md)
+> (the relay as the unified inbound plane), [`org-scoped-data-layer.md`](org-scoped-data-layer.md)
+> (the same "fence in structure, not in convention" discipline on the CP data layer).
+
+## 1. Problem
+
+A relay pod holds every assigned bot of every organization in one flat pool
+(`shared-bot-relay.md` §4). Attributing an inbound HTTP delivery to a bot is
+therefore a tenancy decision, and the ladder that makes it lives in core
+(`relay-ingress-manager.ts#handleInbound`):
+
+1. composite fast path — `(appId, tenantId)` index hit, assignment-derived;
+2. app-only fast path — `appId` index hit (assignment-derived or _learned_);
+3. bounded scan — try `plugin.verify` against each bot in the pool.
+
+Rung 3 already carries a tenant fence, but it is derived from
+`BotAssignment.teamId`, and **the control plane only ever sets `teamId` for a
+distributed (platform) app's install** — the OAuth funnel in
+`http/routes/slack-platform-install.ts`. Every other Slack bot — quick-install,
+manual credential paste, legacy rows — reaches the relay with `teamId` absent.
+For those assignments:
+
+- rung 3 tries them against **every** delivery regardless of its `team_id`, and
+- rung 2 can reach them through a _learned_ app-only mapping, which carries no
+  tenant check at all.
+
+`plugin.verify` proves only _"this delivery was signed by someone holding this
+app's signing secret"_. It does not prove _"…and it came from the workspace
+this assignment belongs to."_ When one Slack app's credentials are installed
+into two AgentConnect organizations — the same in-house app pasted twice, an
+app whose credentials outlived an employee — both bots verify either
+workspace's deliveries. Whichever the scan reaches first wins, and rung 2 then
+_learns_ that attribution for subsequent deliveries.
+
+The consequence is a cross-organization confidentiality break on the inbound
+path: one organization's workspace messages delivered to another
+organization's agent.
+
+## 2. What makes the fix cheap
+
+The value the fence needs is already durable and already maintained; it is
+simply not on the wire and not consulted.
+
+`Bot.workspaceId` holds the Slack workspace id (`team_id`, from
+`auth.test`/OAuth) and the schema comment states it is filled **for every bot
+kind** — the quick-install funnel writes it at finalize
+(`http/routes/slack-install.ts`), the Settings refresh writes it
+(`http/routes/slack-bot-refresh.ts`), and a background reconciler
+(`orchestrator/slackBotIdentityReconciler.ts`, driven by
+`BotRepo.listSlackMissingIdentity`) backfills rows that lack it.
+
+So the fence needs no new capture path, no migration, and no backfill job of
+its own: it needs the existing value projected onto the assignment and checked.
+
+## 3. Decision
+
+**Separate the two roles `teamId` currently conflates.**
+
+| Role                            | Field         | Fence semantics                                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Demux **index key** (unchanged) | `teamId`      | This bot is one install of a _distributed_ app: siblings share the app id _and_ the signing secret, so it may only be indexed on the composite `(appId, tenantId)` key — and its fence is **strict**: the delivery must name the same tenant, and a delivery naming none has no safe owner among same-secret siblings. This preserves the pre-fence scan guard's fail-closed behavior exactly. |
+| Verification **fence** (new)    | `workspaceId` | The tenant this assignment belongs to, for every _other_ install kind. Its fence refuses only a **provable mismatch** (§3.3) — strictness here would break traffic that is correct today.                                                                                                                                                                                                      |
+
+**The fence is asserted on every rung of the ladder**, not only the scan: a
+delivery whose tenant hint contradicts the assignment's known tenant is never
+attributed to it, however the candidate was reached — composite hit, learned
+app-only hit, or scan. Verification and attribution become two separate
+questions, which is the invariant that was missing.
+
+One consequence worth naming: when two same-app bots in different workspaces
+are both reachable only by scan, the learned app-only mapping may oscillate
+between them as deliveries alternate. That is churn in a bounded cache, not a
+correctness issue — every resolve re-applies the fence, so a learned entry can
+never serve the wrong tenant; it can only miss and fall back to the scan.
+
+### 3.1 Why not simply write `teamId` for every bot
+
+`teamId` being non-null is load-bearing beyond demux: it marks a distributed
+platform-app install, participates in the `(slackAppId, teamId)` composite
+unique, and drives admission/reauthorization decisions in the platform-app
+funnel and the `DemuxIndex.indexAssign` composite-only rule. Populating it for
+quick-install bots would silently change bot identity, uniqueness, and
+admission semantics to buy a fence. The fence is a distinct concern and gets a
+distinct field.
+
+### 3.2 Where the fence lives
+
+In **core** (`relay-ingress-manager.ts`), not in the Slack plugin. The ladder
+is core-owned and platform-agnostic, and CLAUDE.md's rule holds: a platform
+name is never core knowledge. The plugin already supplies the delivery's tenant
+through `extractDemuxHints`; the assignment supplies its own known tenant
+generically. Every platform whose deliveries carry a tenant hint gets the fence
+without a line of platform code. (Feishu's extractor currently surfaces only
+the app id, so the fence is a no-op there until that plugin extracts
+`tenant_key` — the core check is already waiting for it.)
+
+### 3.3 The fail-open boundaries, stated on purpose
+
+These apply to the `workspaceId` arm only — the `teamId` arm stays strict
+(§3's table). The workspace fence refuses an attribution only when it can
+_prove_ the mismatch — both sides must know a tenant:
+
+- **Assignment tenant unknown** (identity capture never succeeded, or the
+  reconciler has not yet backfilled): unfenced, exactly as today. Fencing it
+  would break live installs whose `auth.test` failed. This converges on its own
+  — the reconciler fills `workspaceId`, the CP re-broadcasts the assignment,
+  the fence engages — and that convergence path is the reason this residual is
+  acceptable rather than permanent.
+- **Delivery carries no tenant hint**: unfenced. Not every payload shape
+  carries a workspace id, and refusing those would break real traffic; a
+  delivery that names no tenant also cannot be _steered_ at a chosen victim.
+
+Both residuals are strictly narrower than today's behavior: this change can
+only ever refuse attributions that are provably cross-tenant. It cannot refuse
+anything that is attributed correctly today.
+
+## 4. Threat model note
+
+This is not primarily an "attacker" story. The likeliest path to a cross-tenant
+attribution is administrative: one Slack app's credentials legitimately present
+in two organizations. That makes it a _silent_ failure — no error, no denial,
+just another tenant's messages arriving at the wrong agent — which is precisely
+the class of bug a structural fence, rather than a convention, should remove.
+
+## 5. The companion admission fence
+
+The delivery-time fence has one case it structurally cannot decide: **the same
+app installed into the same workspace by two organizations**. Both rows then
+hold the same signing secret _and_ the same tenant — the fence's comparison
+passes for both, and attribution falls back to pool order. No delivery-time
+check can break that tie; only refusing the second claim can.
+
+That refusal already exists for the distributed platform app: its OAuth
+callback resolves the `(slackAppId, teamId)` claim globally and answers a
+cross-organization hit with `workspace_taken`, deliberately not naming the
+holding organization. This change extends the same admission rule to the
+funnels that lack it — `installNewSlackBot`, the tail both the quick-install
+finalize and the platform callback share, refuses to create a bot when
+**another** organization already holds one for the same
+`(slackAppId, workspaceId)`:
+
+- the repository answers a boolean predicate
+  (`BotRepo.slackWorkspaceClaimedElsewhere`) — the question is deliberately
+  cross-organization, but no foreign row ever crosses the persistence seam;
+- the refusal is a 409 whose message never names the holding organization;
+- revoked rows still claim: transferring a workspace between organizations is
+  an explicit delete-then-reinstall, never a silent capture;
+- unknown identity skips the check (same fail-open arm as §3.3 — `auth.test`
+  may legitimately be unavailable at install time), and the reconciler's later
+  backfill does not retro-revoke an install that was admitted while unknown;
+- the check-then-create window takes no lock — a same-instant double claim
+  from two organizations is accepted as out of scope, consistent with the
+  funnel's existing concurrency posture.
+
+The two fences are complementary, and neither subsumes the other:
+
+|                      | Duplicate claim (same app, same workspace)          | Sibling install (same app, different workspaces)                                            |
+| -------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Admission uniqueness | **the only fix** — refuse the second claim          | not a violation; legitimately allowed (the platform app itself is one app across many orgs) |
+| Delivery-time fence  | cannot tell the rows apart (same tenant both sides) | **the only fix** — same secret verifies both, only the tenant discriminates                 |
+
+This mirrors GitHub's pair exactly: `GithubInstallation.installationId @unique`
+is its admission fence, and the per-rule `installationIds` gate is its
+delivery-time fence. Slack needs the same two, shaped for a per-app secret.
+
+## 6. Acceptance
+
+Relay-side tests over a pool holding two bots that share one app id **and one
+signing secret** but belong to different workspaces:
+
+- a delivery from workspace A is never attributed to the workspace-B bot, on
+  each rung independently (composite, learned app-only, scan);
+- a learned app-only mapping cannot serve a cross-tenant delivery;
+- a bot with no known tenant keeps today's behavior (still attributable), and
+  stops being attributable cross-tenant once its tenant is known;
+- a delivery with no tenant hint keeps today's behavior.
+
+Plus control-plane tests that the projected ingress bag carries the fence
+value for a non-distributed bot (the case that has none today), and that a
+second organization's claim of an already-connected workspace is refused with
+409 while a same-organization re-install proceeds.
+
+## 7. Non-goals
+
+- **Relay credential-surface reduction** — a relay pod still holds every
+  organization's bot secrets; that is the shared-tier topology decision, not
+  this fence's concern.
+- **Changing `teamId` semantics** or the distributed-app admission rules (§3.1).
+- **Per-organization relay sharding / affinity** — deliberately not the answer
+  to cross-tenant risk on the shared tier.

--- a/docs/designs/ingress-tenant-fence.md
+++ b/docs/designs/ingress-tenant-fence.md
@@ -140,15 +140,32 @@ check can break that tie; only refusing the second claim can.
 That refusal already exists for the distributed platform app: its OAuth
 callback resolves the `(slackAppId, teamId)` claim globally and answers a
 cross-organization hit with `workspace_taken`, deliberately not naming the
-holding organization. This change extends the same admission rule to the
-funnels that lack it — `installNewSlackBot`, the tail both the quick-install
-finalize and the platform callback share, refuses to create a bot when
-**another** organization already holds one for the same
-`(slackAppId, workspaceId)`:
+holding organization. This change generalizes the same rule to every create
+path.
+
+**The check lives at the one seam they all pass through** — `installNewBot`,
+core's shared create skeleton — rather than on any single funnel. There are
+three ways a bot is minted (the generic `POST /integrations`, the quick-install
+finalize, and the platform-app callback), and a fence installed on one of them
+leaves the other two open, which is precisely the failure this exists to close.
+Core stays platform-agnostic: the platform _declares_ the claim
+(`CpNewBotInstall.workspaceClaim` — app id, tenant, and the 409 copy), core
+_enforces_ it, mirroring the existing `externalIdentity` seam next to it.
+
+The claim is deliberately distinct from the D6 `externalIdentity` pre-check:
+that one fences the composite unique and stays NULL wherever a platform
+preserves pre-capture semantics (a Slack manual paste captures no `teamId`) —
+which is exactly the arm this one covers, because `auth.test` _does_ resolve
+the workspace even when no OAuth exchange happened.
+
+Refusal semantics:
 
 - the repository answers a boolean predicate
-  (`BotRepo.slackWorkspaceClaimedElsewhere`) — the question is deliberately
+  (`BotRepo.workspaceClaimedElsewhere`) — the question is deliberately
   cross-organization, but no foreign row ever crosses the persistence seam;
+- **a different app in the same workspace is not a claim**: distinct apps carry
+  distinct signing secrets, so nothing is ambiguous at delivery time and
+  admission must not over-refuse;
 - the refusal is a 409 whose message never names the holding organization;
 - revoked rows still claim: transferring a workspace between organizations is
   an explicit delete-then-reinstall, never a silent capture;
@@ -182,10 +199,13 @@ signing secret** but belong to different workspaces:
   stops being attributable cross-tenant once its tenant is known;
 - a delivery with no tenant hint keeps today's behavior.
 
-Plus control-plane tests that the projected ingress bag carries the fence
-value for a non-distributed bot (the case that has none today), and that a
-second organization's claim of an already-connected workspace is refused with
-409 while a same-organization re-install proceeds.
+Plus control-plane tests that the projected ingress bag carries the fence value
+for a non-distributed bot (the case that has none today), and — on **both** the
+funnel tail and the generic `POST /integrations` path, since each is a distinct
+way into the shared create seam — that a second organization's claim of an
+already-connected workspace is refused with 409 without naming the holder,
+while a same-organization re-install and a _different_ app in the same
+workspace both proceed.
 
 ## 7. Non-goals
 

--- a/packages/control-plane/src/http/install-bot.ts
+++ b/packages/control-plane/src/http/install-bot.ts
@@ -25,6 +25,7 @@ import { BotId, IntegrationId, type OrgId } from '../domain/ids.js'
 import { integrationToSpec, isGatedAgent } from '../orchestrator/placement.js'
 import { NoConnection } from '../orchestrator/outbound.js'
 import type { CpNewBotInstall } from '../platforms/provider.js'
+import { BotWorkspaceClaimed } from '../persistence/errors.js'
 
 export interface InstallNewBotArgs extends CpNewBotInstall {
   orgId: OrgId
@@ -62,6 +63,19 @@ export async function installNewBot(
   // (duplicate connections on one credential). The console already hides the
   // toggle for socket; this is the load-bearing guarantee behind it.
   const shareable = transport === 'http' && args.bot?.shareable === true
+
+  // Workspace-claim admission fence (ingress-tenant-fence.md §5), at the ONE
+  // seam every create path passes through — the generic `POST /integrations`
+  // (provider-projected) and both Slack funnels (`install-slack.ts`) alike.
+  // Placing it on any single caller would leave the others open, which is the
+  // whole failure mode this fence exists to close. A claim the platform could
+  // not capture is absent here and simply skips the check (§3.3 fail-open).
+  // The check-then-create window takes no lock: a same-instant double claim is
+  // out of scope, consistent with the create path's existing concurrency posture.
+  const claim = args.workspaceClaim
+  if (claim && (await deps.repos.bot.workspaceClaimedElsewhere(orgId, platform, claim.appId, claim.tenantId))) {
+    throw new BotWorkspaceClaimed(claim.conflictMessage)
+  }
 
   // Ids are minted HERE, not by the caller: the funnel that needs pre-reserved
   // ids for restart-idempotency (Feishu's one-click registration) keeps its own

--- a/packages/control-plane/src/http/install-slack.ts
+++ b/packages/control-plane/src/http/install-slack.ts
@@ -15,6 +15,7 @@ import type { HttpDeps } from './deps.js'
 import type { AgentRecord, IntegrationRecord, SlackTransport } from '../persistence/ports.js'
 import type { OrgId } from '../domain/ids.js'
 import { installNewBot } from './install-bot.js'
+import { SlackWorkspaceClaimed } from '../persistence/errors.js'
 import { slackAppIdFromAppToken } from '../platforms/slack/provider.js'
 
 // Relocated to the Slack platform provider (§9, S3): its `validateConfig` runs
@@ -74,6 +75,23 @@ export async function installNewSlackBot(
   // config-token funnel or bot-token verification. Keep the derivation as the
   // authority when both are present (the caller already rejects a mismatch).
   const slackAppId = (appToken ? slackAppIdFromAppToken(appToken) : undefined) ?? args.slackAppId
+
+  // Workspace-claim admission fence (ingress-tenant-fence.md §5): the same app
+  // installed into the same workspace by TWO organizations would share one
+  // signing secret AND one tenant — the delivery-time fence cannot tell those
+  // rows apart, so the second claim is refused here instead. Unknown identity
+  // skips the check (auth.test may legitimately be unavailable at install
+  // time), mirroring the delivery fence's fail-open arm. The check-then-create
+  // window takes no lock: a same-instant double claim is out of scope,
+  // consistent with the funnel's existing concurrency posture.
+  const claimTenant = args.teamId ?? args.workspaceId
+  if (
+    slackAppId &&
+    claimTenant &&
+    (await deps.repos.bot.slackWorkspaceClaimedElsewhere(orgId, slackAppId, claimTenant))
+  ) {
+    throw new SlackWorkspaceClaimed()
+  }
 
   // The row writes, the transport fork and the shareable coercion are core's ONE
   // create skeleton (§9, `install-bot.ts`) — the same one `POST /integrations`

--- a/packages/control-plane/src/http/install-slack.ts
+++ b/packages/control-plane/src/http/install-slack.ts
@@ -15,8 +15,7 @@ import type { HttpDeps } from './deps.js'
 import type { AgentRecord, IntegrationRecord, SlackTransport } from '../persistence/ports.js'
 import type { OrgId } from '../domain/ids.js'
 import { installNewBot } from './install-bot.js'
-import { SlackWorkspaceClaimed } from '../persistence/errors.js'
-import { slackAppIdFromAppToken } from '../platforms/slack/provider.js'
+import { SLACK_WORKSPACE_CLAIMED_MESSAGE, slackAppIdFromAppToken } from '../platforms/slack/provider.js'
 
 // Relocated to the Slack platform provider (§9, S3): its `validateConfig` runs
 // the same same-app cross-check as the create route, and this module sits
@@ -76,23 +75,6 @@ export async function installNewSlackBot(
   // authority when both are present (the caller already rejects a mismatch).
   const slackAppId = (appToken ? slackAppIdFromAppToken(appToken) : undefined) ?? args.slackAppId
 
-  // Workspace-claim admission fence (ingress-tenant-fence.md §5): the same app
-  // installed into the same workspace by TWO organizations would share one
-  // signing secret AND one tenant — the delivery-time fence cannot tell those
-  // rows apart, so the second claim is refused here instead. Unknown identity
-  // skips the check (auth.test may legitimately be unavailable at install
-  // time), mirroring the delivery fence's fail-open arm. The check-then-create
-  // window takes no lock: a same-instant double claim is out of scope,
-  // consistent with the funnel's existing concurrency posture.
-  const claimTenant = args.teamId ?? args.workspaceId
-  if (
-    slackAppId &&
-    claimTenant &&
-    (await deps.repos.bot.slackWorkspaceClaimedElsewhere(orgId, slackAppId, claimTenant))
-  ) {
-    throw new SlackWorkspaceClaimed()
-  }
-
   // The row writes, the transport fork and the shareable coercion are core's ONE
   // create skeleton (§9, `install-bot.ts`) — the same one `POST /integrations`
   // drives from the provider's `buildNewBotInstall`. What stays here is the Slack
@@ -113,6 +95,18 @@ export async function installNewSlackBot(
       ...(args.botUserId ? { botUserId: args.botUserId } : {}),
       ...(args.shareable ? { shareable: true } : {})
     },
+    // Workspace-claim admission fence — core enforces it at the shared create
+    // seam (`install-bot.ts`, ingress-tenant-fence.md §5); the funnels only
+    // declare what they captured. Absent identity ⇒ no claim ⇒ fail-open.
+    ...(slackAppId && (args.teamId ?? args.workspaceId)
+      ? {
+          workspaceClaim: {
+            appId: slackAppId,
+            tenantId: (args.teamId ?? args.workspaceId)!,
+            conflictMessage: SLACK_WORKSPACE_CLAIMED_MESSAGE
+          }
+        }
+      : {}),
     // The xapp (socket) / signing secret (http) stay CP-side for the relay — the
     // daemon never receives them.
     secrets: { botToken, appToken: appToken ?? null, signingSecret: signingSecret ?? null },

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -38,7 +38,7 @@ import { canView, canEdit } from '../../authorization/policy.js'
 import { resolveWebAppUrl } from '../../config/env.js'
 import { SLACK_BOT_SCOPES, slackPlatformOAuthRedirectUri } from '../slack-manifest.js'
 import { installNewSlackBot } from '../install-slack.js'
-import { SlackWorkspaceClaimed } from '../../persistence/errors.js'
+import { BotWorkspaceClaimed } from '../../persistence/errors.js'
 import { closePageHtml, relayHttpBase } from './slack-install.js'
 import type { SlackRouteSeams } from '../platform-route-seams.js'
 import {
@@ -397,7 +397,7 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
             // workspace some org connected through a DIFFERENT funnel with this
             // same app id. Callback UX, not JSON: same closing page as the
             // pre-check's refusal.
-            if (err instanceof SlackWorkspaceClaimed) return fail('workspace_taken')
+            if (err instanceof BotWorkspaceClaimed) return fail('workspace_taken')
             throw err
           }
           botId = created.botId

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -38,6 +38,7 @@ import { canView, canEdit } from '../../authorization/policy.js'
 import { resolveWebAppUrl } from '../../config/env.js'
 import { SLACK_BOT_SCOPES, slackPlatformOAuthRedirectUri } from '../slack-manifest.js'
 import { installNewSlackBot } from '../install-slack.js'
+import { SlackWorkspaceClaimed } from '../../persistence/errors.js'
 import { closePageHtml, relayHttpBase } from './slack-install.js'
 import type { SlackRouteSeams } from '../platform-route-seams.js'
 import {
@@ -366,27 +367,39 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
           await deps.httpBot.syncBot(existing.id)
         } else {
           if (!agent || expectedBot) return fail('error')
-          const created = await installNewSlackBot(deps, req.log, {
-            orgId: OrgId(row.orgId),
-            agent,
-            name: result.teamName ? `AgentConnect (${result.teamName})` : 'AgentConnect',
-            botToken: result.botToken,
-            // Always http (a distributed app is Events-API-only — there is no
-            // per-workspace xapp token for Socket Mode) and always NON-shareable:
-            // one workspace install backs exactly one agent, keeping the classic
-            // 1-install cap. Widening a workspace to several agents is the
-            // quick-install upgrade path (its own Slack app), not this one.
-            transport: 'http',
-            shareable: false,
-            prebuilt: true,
-            slackAppId: platform.appId,
-            teamId: result.teamId,
-            workspaceId: result.teamId,
-            ...(result.teamName ? { workspaceName: result.teamName } : {}),
-            ...(result.botUserId ? { botUserId: result.botUserId } : {}),
-            signingSecret: platform.signingSecret,
-            ...(row.createdByUserId ? { createdByUserId: row.createdByUserId } : {})
-          })
+          let created: Awaited<ReturnType<typeof installNewSlackBot>>
+          try {
+            created = await installNewSlackBot(deps, req.log, {
+              orgId: OrgId(row.orgId),
+              agent,
+              name: result.teamName ? `AgentConnect (${result.teamName})` : 'AgentConnect',
+              botToken: result.botToken,
+              // Always http (a distributed app is Events-API-only — there is no
+              // per-workspace xapp token for Socket Mode) and always NON-shareable:
+              // one workspace install backs exactly one agent, keeping the classic
+              // 1-install cap. Widening a workspace to several agents is the
+              // quick-install upgrade path (its own Slack app), not this one.
+              transport: 'http',
+              shareable: false,
+              prebuilt: true,
+              slackAppId: platform.appId,
+              teamId: result.teamId,
+              workspaceId: result.teamId,
+              ...(result.teamName ? { workspaceName: result.teamName } : {}),
+              ...(result.botUserId ? { botUserId: result.botUserId } : {}),
+              signingSecret: platform.signingSecret,
+              ...(row.createdByUserId ? { createdByUserId: row.createdByUserId } : {})
+            })
+          } catch (err) {
+            // The install tail's generic workspace-claim fence
+            // (ingress-tenant-fence.md §5). This funnel's own getBySlackAppTeam
+            // pre-check covers platform-app rows; the tail additionally catches a
+            // workspace some org connected through a DIFFERENT funnel with this
+            // same app id. Callback UX, not JSON: same closing page as the
+            // pre-check's refusal.
+            if (err instanceof SlackWorkspaceClaimed) return fail('workspace_taken')
+            throw err
+          }
           botId = created.botId
         }
 

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -176,6 +176,15 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
     if ((err as { code?: string }).code === 'P2002') {
       return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: 'resource already exists' })
     }
+    // Workspace-claim admission fence (ingress-tenant-fence.md §5). The message
+    // deliberately never names the organization holding the workspace.
+    if ((err as { code?: string }).code === 'SLACK_WORKSPACE_CLAIMED') {
+      return reply.code(409).send({
+        error: 'Conflict',
+        statusCode: 409,
+        message: 'this Slack workspace is already connected to another organization'
+      })
+    }
     if ((err as { code?: string }).code === 'ORG_OWNER_REQUIRED') {
       return reply.code(409).send({
         error: 'Conflict',

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -178,11 +178,14 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
     }
     // Workspace-claim admission fence (ingress-tenant-fence.md §5). The message
     // deliberately never names the organization holding the workspace.
-    if ((err as { code?: string }).code === 'SLACK_WORKSPACE_CLAIMED') {
+    if ((err as { code?: string }).code === 'BOT_WORKSPACE_CLAIMED') {
       return reply.code(409).send({
         error: 'Conflict',
         statusCode: 409,
-        message: 'this Slack workspace is already connected to another organization'
+        message:
+          err instanceof Error && err.message
+            ? err.message
+            : 'this workspace is already connected to another organization'
       })
     }
     if ((err as { code?: string }).code === 'ORG_OWNER_REQUIRED') {

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -74,6 +74,19 @@ export class BotExternalIdentityTaken extends Error {
   }
 }
 
+/** A Slack workspace already connected to a DIFFERENT organization refuses a
+ *  second claim (ingress-tenant-fence.md §5): same app + same workspace in two
+ *  orgs would share one signing secret AND one tenant, which the delivery-time
+ *  fence cannot tell apart — admission is the only place to stop it. Mapped to
+ *  409 at the HTTP edge; the message never names the holding organization. */
+export class SlackWorkspaceClaimed extends Error {
+  readonly code = 'SLACK_WORKSPACE_CLAIMED' as const
+  constructor() {
+    super('this Slack workspace is already connected to another organization')
+    this.name = 'SlackWorkspaceClaimed'
+  }
+}
+
 export class BotStillShared extends Error {
   readonly code = 'BOT_STILL_SHARED' as const
   constructor(readonly activeInstalls: number) {

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -74,16 +74,17 @@ export class BotExternalIdentityTaken extends Error {
   }
 }
 
-/** A Slack workspace already connected to a DIFFERENT organization refuses a
- *  second claim (ingress-tenant-fence.md §5): same app + same workspace in two
- *  orgs would share one signing secret AND one tenant, which the delivery-time
- *  fence cannot tell apart — admission is the only place to stop it. Mapped to
- *  409 at the HTTP edge; the message never names the holding organization. */
-export class SlackWorkspaceClaimed extends Error {
-  readonly code = 'SLACK_WORKSPACE_CLAIMED' as const
-  constructor() {
-    super('this Slack workspace is already connected to another organization')
-    this.name = 'SlackWorkspaceClaimed'
+/** A workspace already connected to a DIFFERENT organization refuses a second
+ *  claim (ingress-tenant-fence.md §5): one app installed into one workspace by
+ *  two orgs would share its inbound-verification secret AND its tenant, which
+ *  the relay's delivery-time fence cannot tell apart — admission is the only
+ *  place to stop it. Mapped to 409 at the HTTP edge; the platform supplies the
+ *  copy, and it never names the holding organization. */
+export class BotWorkspaceClaimed extends Error {
+  readonly code = 'BOT_WORKSPACE_CLAIMED' as const
+  constructor(message: string) {
+    super(message)
+    this.name = 'BotWorkspaceClaimed'
   }
 }
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2705,13 +2705,15 @@ export interface BotRepo {
    *  by the composite demux key (a workspace binds to exactly one org). */
   getBySlackAppTeam(slackAppId: string, teamId: string): Promise<BotRecord | null>
   /** Workspace-claim admission predicate (ingress-tenant-fence.md §5): does a
-   *  DIFFERENT organization already hold a Slack bot for this app+workspace?
-   *  The question is deliberately cross-org — same app + same workspace in two
-   *  orgs shares one signing secret AND one tenant, which the delivery-time
-   *  fence cannot tell apart — but the answer is a boolean, so no foreign row
-   *  crosses the persistence seam. Revoked rows still claim (workspace
-   *  transfer is an explicit delete-then-reinstall, never a silent capture). */
-  slackWorkspaceClaimedElsewhere(orgId: OrgId, slackAppId: string, workspaceId: string): Promise<boolean>
+   *  DIFFERENT organization already hold a bot for this app+workspace? The
+   *  question is deliberately cross-org — one app installed into one workspace
+   *  by two orgs shares its inbound-verification secret AND its tenant, which
+   *  the relay's delivery-time fence cannot tell apart — but the answer is a
+   *  boolean, so no foreign row crosses the persistence seam. Revoked rows
+   *  still claim (workspace transfer is an explicit delete-then-reinstall,
+   *  never a silent capture). A DIFFERENT app in the same workspace is not a
+   *  claim: distinct apps carry distinct secrets, so nothing is ambiguous. */
+  workspaceClaimedElsewhere(orgId: OrgId, platform: string, appId: string, workspaceId: string): Promise<boolean>
   /** CROSS-ORG lookup by the generic demux identity (D6). Pass
    *  {@link TENANTLESS_SENTINEL} as `externalTenantId` for tenantless platforms —
    *  the same value {@link BotIdentityProjector} writes. Legacy rows (NULL

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2704,6 +2704,14 @@ export interface BotRepo {
   /** The Bot backing one workspace install of a distributed app — CROSS-ORG lookup
    *  by the composite demux key (a workspace binds to exactly one org). */
   getBySlackAppTeam(slackAppId: string, teamId: string): Promise<BotRecord | null>
+  /** Workspace-claim admission predicate (ingress-tenant-fence.md §5): does a
+   *  DIFFERENT organization already hold a Slack bot for this app+workspace?
+   *  The question is deliberately cross-org — same app + same workspace in two
+   *  orgs shares one signing secret AND one tenant, which the delivery-time
+   *  fence cannot tell apart — but the answer is a boolean, so no foreign row
+   *  crosses the persistence seam. Revoked rows still claim (workspace
+   *  transfer is an explicit delete-then-reinstall, never a silent capture). */
+  slackWorkspaceClaimedElsewhere(orgId: OrgId, slackAppId: string, workspaceId: string): Promise<boolean>
   /** CROSS-ORG lookup by the generic demux identity (D6). Pass
    *  {@link TENANTLESS_SENTINEL} as `externalTenantId` for tenantless platforms —
    *  the same value {@link BotIdentityProjector} writes. Legacy rows (NULL

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -266,6 +266,15 @@ export class PgBotRepo implements BotRepo {
     return rows.map(toBotRecord)
   }
 
+  async slackWorkspaceClaimedElsewhere(orgId: OrgId, slackAppId: string, workspaceId: string): Promise<boolean> {
+    // Cross-org on purpose (the admission question IS cross-org), boolean on
+    // purpose (no foreign row crosses the seam) — ingress-tenant-fence.md §5.
+    const held = await this.db.bot.count({
+      where: { platform: 'slack', slackAppId, workspaceId, NOT: { orgId } }
+    })
+    return held > 0
+  }
+
   async getBySlackAppTeam(slackAppId: string, teamId: string): Promise<BotRecord | null> {
     // Cross-org on purpose: (slackAppId, teamId) is globally unique — a workspace
     // install of a distributed app binds to exactly one org, and the platform

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -266,11 +266,25 @@ export class PgBotRepo implements BotRepo {
     return rows.map(toBotRecord)
   }
 
-  async slackWorkspaceClaimedElsewhere(orgId: OrgId, slackAppId: string, workspaceId: string): Promise<boolean> {
+  async workspaceClaimedElsewhere(
+    orgId: OrgId,
+    platform: string,
+    appId: string,
+    workspaceId: string
+  ): Promise<boolean> {
     // Cross-org on purpose (the admission question IS cross-org), boolean on
     // purpose (no foreign row crosses the seam) — ingress-tenant-fence.md §5.
+    //
+    // The app id matches EITHER column: `externalAppId` is the D6 generic one
+    // every new row dual-writes, `slackAppId` is the legacy one pre-D6 rows
+    // still carry alone. Matching both is what lets a legacy row hold a claim.
     const held = await this.db.bot.count({
-      where: { platform: 'slack', slackAppId, workspaceId, NOT: { orgId } }
+      where: {
+        platform: toDbPlatform(platform),
+        workspaceId,
+        NOT: { orgId },
+        OR: [{ externalAppId: appId }, { slackAppId: appId }]
+      }
     })
     return held > 0
   }

--- a/packages/control-plane/src/platforms/new-bot-install.test.ts
+++ b/packages/control-plane/src/platforms/new-bot-install.test.ts
@@ -98,8 +98,29 @@ describe('slack buildNewBotInstall', () => {
     ).toEqual({
       // `botUserId` is the member id exact channel mentions render (#601).
       bot: { slackAppId: 'AXAPP', workspaceId: 'T1', workspaceName: 'Acme', botUserId: 'U1' },
-      secrets: { botToken: 'xoxb-1', appToken: 'xapp-1-AXAPP-1-deadbeef', signingSecret: null }
+      secrets: { botToken: 'xoxb-1', appToken: 'xapp-1-AXAPP-1-deadbeef', signingSecret: null },
+      // Workspace-claim admission fence (ingress-tenant-fence.md §5), keyed off
+      // the SAME app-id authority as the row above — core refuses the create if
+      // another org already runs this app in this workspace.
+      workspaceClaim: {
+        appId: 'AXAPP',
+        tenantId: 'T1',
+        conflictMessage: expect.stringContaining('already connected to another organization')
+      }
     })
+  })
+
+  it('declares NO workspace claim when auth.test resolved no workspace (§3.3 fail-open)', () => {
+    const built = provider.buildNewBotInstall({
+      credentials: { botToken: 'xoxb-1', appToken: 'xapp-1-AXAPP-1-deadbeef' },
+      identity: { name: 'acme' },
+      transport: 'socket',
+      shareable: false
+    })
+    // An install whose workspace could not be captured must still be creatable;
+    // the relay's delivery fence is likewise open for it until the identity
+    // reconciler backfills the workspace.
+    expect(built.workspaceClaim).toBeUndefined()
   })
 
   it('falls back to the auth.test app id when there is no xapp to parse (http install)', () => {

--- a/packages/control-plane/src/platforms/provider.ts
+++ b/packages/control-plane/src/platforms/provider.ts
@@ -216,6 +216,28 @@ export interface CpNewBotInstall {
     /** The 409 body's user-facing copy — platform-named reuse guidance. */
     conflictMessage: string
   }
+  /**
+   * The WORKSPACE this install claims, when the platform captured one
+   * (ingress-tenant-fence.md §5). Core refuses the create when a DIFFERENT
+   * organization already holds a bot for the same `(appId, tenantId)`: those
+   * two rows would share one inbound-verification secret AND one tenant, which
+   * the relay's delivery-time fence cannot tell apart, so pool order would
+   * decide attribution.
+   *
+   * DISTINCT from {@link CpNewBotInstall.externalIdentity}: that one fences the
+   * D6 composite unique and stays NULL wherever a platform preserves
+   * pre-capture semantics (Slack's manual paste captures no `teamId`). This one
+   * asks a narrower question — "is this workspace already spoken for?" — off
+   * the identity the platform *did* capture, which is exactly the case the
+   * D6 fence leaves open. Absent ⇒ no claim to check (identity unknown, e.g.
+   * `auth.test` was unavailable), which is the §3.3 fail-open arm.
+   */
+  workspaceClaim?: {
+    appId: string
+    tenantId: string
+    /** The 409 body's copy. MUST NOT name the holding organization. */
+    conflictMessage: string
+  }
 }
 
 /**

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -633,4 +633,16 @@ describe('slack projectBotAssign equivalence with the live buildAssign frame (§
       ingress: frame.ingress
     })
   })
+
+  it('projects the workspace tenant fence for a NON-distributed bot (ingress-tenant-fence.md §3)', async () => {
+    // The case the fence exists for: no teamId (quick-install), but the
+    // workspace identity captured at install/backfill must reach the relay —
+    // without it, a same-secret sibling in another org verifies this bot's
+    // deliveries and nothing discriminates.
+    const quickInstall = bot({ transport: 'http', slackAppId: 'A0TESTAPP', workspaceId: 'T0WORKSPACE' })
+    const frame = await liveAssignFrame(quickInstall, HTTP_SECRET)
+    const projected = await provider.projectBotAssign!(quickInstall, HTTP_SECRET)
+    expect(projected.ingress).toEqual(frame.ingress)
+    expect(projected.ingress).toEqual({ apiAppId: 'A0TESTAPP', workspaceId: 'T0WORKSPACE' })
+  })
 })

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -201,6 +201,12 @@ export function slackSharedIntegrationConfig(
  *
  * Token-bearing — NEVER log the result.
  */
+/** The 409 copy when another organization already holds this app+workspace
+ *  (ingress-tenant-fence.md §5). Deliberately never names the holder. Shared by
+ *  the provider's create path and the two Slack funnels' tail. */
+export const SLACK_WORKSPACE_CLAIMED_MESSAGE =
+  'this Slack workspace is already connected to another organization with this app'
+
 export function slackBotAssignBags(
   bot: Pick<BotRecord, 'slackAppId' | 'teamId' | 'workspaceId' | 'botUserId'>,
   secret: Pick<BotSecretMaterial, 'botToken' | 'signingSecret'>
@@ -413,6 +419,21 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
           ...(identity.botUserId ? { botUserId: identity.botUserId } : {}),
           ...(shareable ? { shareable: true } : {})
         },
+        // Workspace-claim admission fence (ingress-tenant-fence.md §5). This is
+        // the arm the D6 `externalIdentity` pre-check deliberately leaves open:
+        // a manual paste captures no `teamId`, so it declares no D6 identity —
+        // but `auth.test` DOES resolve the workspace, and a second org pasting
+        // the same app's credentials for it would produce two rows sharing one
+        // signing secret AND one tenant, which the relay cannot disambiguate.
+        ...(slackAppId && identity.workspaceId
+          ? {
+              workspaceClaim: {
+                appId: slackAppId,
+                tenantId: identity.workspaceId,
+                conflictMessage: SLACK_WORKSPACE_CLAIMED_MESSAGE
+              }
+            }
+          : {}),
         secrets: {
           botToken: credentials.botToken,
           appToken: credentials.appToken ?? null,

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -187,6 +187,12 @@ export function slackSharedIntegrationConfig(
  *    (platform) app's install, where the composite (api_app_id, team_id) is
  *    the ONLY safe demux (all sibling installs share the app id AND the
  *    signing secret).
+ *  - ingress `workspaceId` — the workspace this bot belongs to, captured for
+ *    EVERY bot kind (auth.test / OAuth). Not a demux index key: it is the
+ *    relay's tenant FENCE (ingress-tenant-fence.md §3), which is why a
+ *    quick-install bot — whose `teamId` is deliberately null — still needs it
+ *    on the wire. Without it, a second organization holding the same app's
+ *    signing secret verifies this bot's deliveries too.
  *  - ingress `botUserId` — persisted at OAuth exchange; spares an auth.test
  *    round-trip.
  *  - secrets — the send token + the signing secret the relay HMAC-verifies
@@ -196,7 +202,7 @@ export function slackSharedIntegrationConfig(
  * Token-bearing — NEVER log the result.
  */
 export function slackBotAssignBags(
-  bot: Pick<BotRecord, 'slackAppId' | 'teamId' | 'botUserId'>,
+  bot: Pick<BotRecord, 'slackAppId' | 'teamId' | 'workspaceId' | 'botUserId'>,
   secret: Pick<BotSecretMaterial, 'botToken' | 'signingSecret'>
 ): { secrets: Record<string, unknown>; ingress: Record<string, unknown> } {
   return {
@@ -204,6 +210,7 @@ export function slackBotAssignBags(
     ingress: {
       ...(bot.slackAppId ? { apiAppId: bot.slackAppId } : {}),
       ...(bot.teamId ? { teamId: bot.teamId } : {}),
+      ...(bot.workspaceId ? { workspaceId: bot.workspaceId } : {}),
       ...(bot.botUserId ? { botUserId: bot.botUserId } : {})
     }
   }

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -560,6 +560,99 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     })
   })
 
+  // ingress-tenant-fence.md §5: the manual-paste create path reaches the same
+  // shared create seam as the funnels, so the workspace-claim fence must hold
+  // here too — this is the path a second org would use to paste an app's
+  // credentials for a workspace another org already runs.
+  it('POST /integrations refuses a workspace already claimed by ANOTHER organization', async () => {
+    const agentId = await placedAgent()
+    const { app } = withSpy()
+    app.relayReg.add({ relayId: 'r1', send() {}, close() {} } as RelayChannel)
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'http-bot',
+      appId: 'ACLAIMED',
+      botUserId: 'UCLAIMED',
+      teamId: 'TCLAIMED',
+      teamName: 'Acme',
+      scopes: []
+    })
+    // Another org already runs this app in this workspace: same signing secret,
+    // same tenant — the relay's delivery fence cannot tell the two rows apart.
+    const foreignOrgId = `org-claim-${randomUUID().slice(0, 8)}`
+    await prisma.org.create({ data: { id: foreignOrgId, slug: foreignOrgId } })
+    await prisma.bot.create({
+      data: {
+        id: randomUUID(),
+        orgId: foreignOrgId,
+        platform: 'slack',
+        name: 'foreign-claim',
+        slackAppId: 'ACLAIMED',
+        externalAppId: 'ACLAIMED',
+        workspaceId: 'TCLAIMED'
+      }
+    })
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: {
+        platform: 'slack',
+        agentId,
+        transport: 'http',
+        slack: { botToken: SLACK.botToken, signingSecret: 'signing-secret' }
+      }
+    })
+
+    expect(res.statusCode).toBe(409)
+    // The refusal never names the organization holding the workspace.
+    expect(res.body).not.toContain(foreignOrgId)
+    expect(await prisma.bot.count({ where: { orgId: DEFAULT_ORG_ID, slackAppId: 'ACLAIMED' } })).toBe(0)
+  })
+
+  it('POST /integrations allows a DIFFERENT app in a workspace another org already uses', async () => {
+    const agentId = await placedAgent()
+    const { app } = withSpy()
+    app.relayReg.add({ relayId: 'r1', send() {}, close() {} } as RelayChannel)
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'http-bot',
+      appId: 'AMINE',
+      botUserId: 'UMINE',
+      teamId: 'TSHARED',
+      teamName: 'Acme',
+      scopes: []
+    })
+    // Same workspace, DIFFERENT app ⇒ different signing secret ⇒ nothing is
+    // ambiguous at delivery time, so admission must not over-refuse.
+    const foreignOrgId = `org-otherapp-${randomUUID().slice(0, 8)}`
+    await prisma.org.create({ data: { id: foreignOrgId, slug: foreignOrgId } })
+    await prisma.bot.create({
+      data: {
+        id: randomUUID(),
+        orgId: foreignOrgId,
+        platform: 'slack',
+        name: 'foreign-other-app',
+        slackAppId: 'ATHEIRS',
+        externalAppId: 'ATHEIRS',
+        workspaceId: 'TSHARED'
+      }
+    })
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: {
+        platform: 'slack',
+        agentId,
+        transport: 'http',
+        slack: { botToken: SLACK.botToken, signingSecret: 'signing-secret' }
+      }
+    })
+
+    expect(res.statusCode).toBe(201)
+  })
+
   it('POST an HTTP Feishu app assigns callback-only secrets and keeps API egress on the daemon', async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()

--- a/packages/control-plane/test/integration/slack-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-install.route.test.ts
@@ -369,6 +369,79 @@ describe('slack auto-install funnel', () => {
     expect(JSON.stringify(dto)).not.toContain('xoxb-')
   })
 
+  it('finalize refuses a workspace already connected to ANOTHER organization (ingress-tenant-fence.md §5)', async () => {
+    const { app } = withFunnel()
+    // auth.test resolves the workspace identity — the claim key.
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'acme-bot',
+      appId: 'A1TEST',
+      teamId: 'T1TEST',
+      teamName: 'Acme',
+      botUserId: 'U1',
+      scopes: null
+    })
+    // Another org already holds a bot for this exact app+workspace: the same
+    // signing secret AND the same tenant, which the relay's delivery-time fence
+    // cannot tell apart — admission is the only place to stop the second claim.
+    const foreignOrgId = `org-claim-${randomUUID().slice(0, 8)}`
+    await prisma.org.create({ data: { id: foreignOrgId, slug: foreignOrgId } })
+    await prisma.bot.create({
+      data: {
+        id: randomUUID(),
+        orgId: foreignOrgId,
+        platform: 'slack',
+        name: 'foreign-claim',
+        slackAppId: 'A1TEST',
+        workspaceId: 'T1TEST'
+      }
+    })
+
+    const installId = await startAndAuthorize(app)
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app/${installId}/finalize`,
+      payload: { appToken: 'xapp-1-A1TEST-9-abcdef' }
+    })
+    expect(res.statusCode).toBe(409)
+    // The refusal never names the organization holding the workspace.
+    expect(res.body).not.toContain(foreignOrgId)
+    // Nothing was minted for the caller.
+    expect(await prisma.bot.count({ where: { orgId: DEFAULT_ORG_ID, slackAppId: 'A1TEST' } })).toBe(0)
+  })
+
+  it('finalize proceeds when the SAME organization already holds the workspace', async () => {
+    const { app } = withFunnel()
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'acme-bot',
+      appId: 'A1TEST',
+      teamId: 'T1TEST',
+      teamName: 'Acme',
+      botUserId: 'U1',
+      scopes: null
+    })
+    // A prior install in the CALLER's org is not a foreign claim.
+    await prisma.bot.create({
+      data: {
+        id: randomUUID(),
+        orgId: DEFAULT_ORG_ID,
+        platform: 'slack',
+        name: 'own-earlier-install',
+        slackAppId: 'A1TEST',
+        workspaceId: 'T1TEST'
+      }
+    })
+
+    const installId = await startAndAuthorize(app)
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app/${installId}/finalize`,
+      payload: { appToken: 'xapp-1-A1TEST-9-abcdef' }
+    })
+    expect(res.statusCode).toBe(201)
+  })
+
   it('finalize (http) mints a relay-ingress bot from the OAuth bot token + captured signing secret — no paste', async () => {
     const { app, spy } = withFunnel()
     const agentId = await placedAgent()

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -375,6 +375,19 @@ describe('toBotAssignment (§6.7 open secrets reader)', () => {
     expect(a).toMatchObject({ apiAppId: 'A9', teamId: 'T9', botUserId: 'U9' })
   })
 
+  it('reads the workspace tenant fence from the ingress bag (ingress-tenant-fence.md §3)', () => {
+    // A quick-install bot: no teamId (not a distributed install), but the
+    // workspace it belongs to rides the bag so the ladder can fence the
+    // signature scan and the learned app-only path.
+    const a = toBotAssignment({
+      ...base,
+      secrets,
+      ingress: { apiAppId: 'A9', workspaceId: 'T9' }
+    } as never)
+    expect(a).toMatchObject({ apiAppId: 'A9', workspaceId: 'T9' })
+    expect(a && 'teamId' in a).toBe(false)
+  })
+
   it('IGNORES the retired named top-level fields (deleted from the schema; stripped on decode)', () => {
     // A frame hand-built with the pre-#556 named fields and no bag yields NO
     // demux identity: the bot serves through the bounded verify-scan, exactly

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -37,6 +37,14 @@ export interface BotAssignment {
    *  id AND the signing secret, so this bot may only be demuxed on the composite
    *  `(api_app_id, team_id)` key — never by app id or signature scan alone. */
   teamId?: string
+  /** The tenant this assignment belongs to, captured for EVERY install kind —
+   *  unlike {@link BotAssignment.teamId}, which the CP sets only for a
+   *  distributed app's install. NOT a demux index key: it is the ingress tenant
+   *  FENCE (ingress-tenant-fence.md §3). `verify` proves a delivery was signed
+   *  with this app's signing secret; the fence proves it came from this bot's
+   *  workspace, which a same-secret sibling in another organization would
+   *  otherwise satisfy just as well. */
+  workspaceId?: string
   /** Install GENERATION of `secrets` (CP-assigned). Echoed back on `rc/bot-revoked`
    *  so the CP can refuse a revocation that was observed under a credential a
    *  re-install has since replaced — Slack does not order lifecycle events. */
@@ -678,9 +686,17 @@ export function toBotAssignment(a: RcBotAssign): BotAssignment | null {
   // (emission had already stopped, #556), so there is nothing to fall back to —
   // a non-string slot in the bag reads as absent, and an absent identity means
   // the verify-scan path, exactly as a manual-paste install always demuxed.
-  const ingress = (a.ingress ?? {}) as { apiAppId?: unknown; teamId?: unknown; botUserId?: unknown }
+  const ingress = (a.ingress ?? {}) as {
+    apiAppId?: unknown
+    teamId?: unknown
+    workspaceId?: unknown
+    botUserId?: unknown
+  }
   const apiAppId = typeof ingress.apiAppId === 'string' ? ingress.apiAppId : undefined
   const teamId = typeof ingress.teamId === 'string' ? ingress.teamId : undefined
+  // An older CP omits it; the fence then reads whatever `teamId` carries, which
+  // is exactly today's behaviour (ingress-tenant-fence.md §3.3 fail-open).
+  const workspaceId = typeof ingress.workspaceId === 'string' ? ingress.workspaceId : undefined
   const botUserId = typeof ingress.botUserId === 'string' ? ingress.botUserId : undefined
   return {
     botId: a.botId,
@@ -688,6 +704,7 @@ export function toBotAssignment(a: RcBotAssign): BotAssignment | null {
     secrets,
     ...(apiAppId ? { apiAppId } : {}),
     ...(teamId ? { teamId } : {}),
+    ...(workspaceId ? { workspaceId } : {}),
     ...(a.credentialRevision !== undefined ? { credentialRevision: a.credentialRevision } : {}),
     ...(botUserId ? { botUserId } : {}),
     members: a.members,

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -1869,7 +1869,7 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     manager: RelayIngressManager,
     botId: string,
     signingSecret: string,
-    opts: { apiAppId?: string; teamId?: string; indexed?: boolean } = {}
+    opts: { apiAppId?: string; teamId?: string; workspaceId?: string; indexed?: boolean } = {}
   ) => {
     const internals = internalsOf(manager)
     internals.slackPool.set(botId, {
@@ -1884,7 +1884,8 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
       botId,
       secrets: { botToken: 'xoxb', signingSecret },
       ...(opts.apiAppId ? { apiAppId: opts.apiAppId } : {}),
-      ...(opts.teamId ? { teamId: opts.teamId } : {})
+      ...(opts.teamId ? { teamId: opts.teamId } : {}),
+      ...(opts.workspaceId ? { workspaceId: opts.workspaceId } : {})
     })
     if (opts.apiAppId && opts.teamId && opts.indexed !== false) {
       internals.slackDemux.indexAssign(botId, { appId: opts.apiAppId, tenantId: opts.teamId })
@@ -1999,6 +2000,65 @@ describe('RelayIngressManager.resolveVerified composite demux', () => {
     expect(internals.slackDemux.indexes.byAppTenant.size).toBe(0)
     // The reverse map is DemuxIndex-internal now; an empty composite index IS the proof.
     await expect(resolve(manager, { apiAppId: PLATFORM_APP, teamId: 'T1' })).resolves.toBeUndefined()
+  })
+
+  // ── The ingress tenant fence (ingress-tenant-fence.md §3) ──────────────────
+  //
+  // Two NON-distributed bots (quick-install shape: no teamId, so the old scan
+  // guard never applied) that share one app id AND one signing secret — the
+  // same custom app's credentials living in two organizations. `workspaceId`
+  // is the only thing telling their workspaces apart.
+  const BOT_W1 = 'bbbbbbbb-1111-4111-8111-111111111111'
+  const BOT_W2 = 'bbbbbbbb-2222-4222-8222-222222222222'
+  const CUSTOM_APP = 'ACUSTOM'
+  const CUSTOM_SECRET = 'shared-custom-app-secret'
+
+  it('scan never attributes a delivery across workspaces once the assignment knows its tenant', async () => {
+    const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
+    // Pool order is the adversary: W1 sits first and verifies W2's deliveries.
+    addBot(manager, BOT_W1, CUSTOM_SECRET, { workspaceId: 'T1' })
+    addBot(manager, BOT_W2, CUSTOM_SECRET, { workspaceId: 'T2' })
+
+    await expect(resolve(manager, { teamId: 'T2', secret: CUSTOM_SECRET })).resolves.toBe(BOT_W2)
+    await expect(resolve(manager, { teamId: 'T1', secret: CUSTOM_SECRET })).resolves.toBe(BOT_W1)
+  })
+
+  it('a learned app-only mapping cannot serve a cross-tenant delivery', async () => {
+    const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
+    addBot(manager, BOT_W1, CUSTOM_SECRET, { workspaceId: 'T1' })
+    addBot(manager, BOT_W2, CUSTOM_SECRET, { workspaceId: 'T2' })
+
+    // First delivery teaches the app-only map that ACUSTOM → W1…
+    await expect(resolve(manager, { apiAppId: CUSTOM_APP, teamId: 'T1', secret: CUSTOM_SECRET })).resolves.toBe(BOT_W1)
+    const internals = internalsOf(manager)
+    expect(internals.slackDemux.indexes.byApp.get(CUSTOM_APP)).toBe(BOT_W1)
+    // …and the learned fast path MUST NOT hand W2's traffic to W1: the fence
+    // rejects the learned candidate and the scan finds the right owner.
+    await expect(resolve(manager, { apiAppId: CUSTOM_APP, teamId: 'T2', secret: CUSTOM_SECRET })).resolves.toBe(BOT_W2)
+  })
+
+  it('an assignment with no captured tenant keeps today’s behaviour until backfill converges', async () => {
+    const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
+    // Identity capture failed at install: neither teamId nor workspaceId.
+    addBot(manager, BOT_W1, CUSTOM_SECRET, {})
+
+    // Unfenced — attributable to any tenant's delivery, exactly as today.
+    await expect(resolve(manager, { teamId: 'T2', secret: CUSTOM_SECRET })).resolves.toBe(BOT_W1)
+
+    // The reconciler backfills, the CP re-broadcasts, and the fence engages.
+    addBot(manager, BOT_W1, CUSTOM_SECRET, { workspaceId: 'T1' })
+    await expect(resolve(manager, { teamId: 'T2', secret: CUSTOM_SECRET })).resolves.toBeUndefined()
+    await expect(resolve(manager, { teamId: 'T1', secret: CUSTOM_SECRET })).resolves.toBe(BOT_W1)
+  })
+
+  it('a delivery naming no tenant keeps today’s behaviour for workspace-fenced bots', async () => {
+    const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
+    addBot(manager, BOT_W1, CUSTOM_SECRET, { workspaceId: 'T1' })
+
+    // Unlike a distributed sibling set (strict teamId arm, covered above), a
+    // workspace-fenced bot still accepts a tenant-less delivery: refusing it
+    // would break payload shapes that carry no team id at all.
+    await expect(resolve(manager, { secret: CUSTOM_SECRET })).resolves.toBe(BOT_W1)
   })
 })
 

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -510,7 +510,7 @@ export class RelayIngressManager {
     const hints = plugin.extractDemuxHints(rawBody, body, headers)
     const tryCandidate = (botId: string | undefined) => {
       const ingest = botId ? pool.get(botId) : undefined
-      if (!ingest) return undefined
+      if (!ingest || !this.tenantFencePasses(botId!, hints.tenantId)) return undefined
       const verified = plugin.verify(ingest, rawBody, body, headers, now)
       return verified === undefined ? undefined : { ingest, verified }
     }
@@ -519,14 +519,15 @@ export class RelayIngressManager {
     hit ??= hints.appId ? tryCandidate(demux.resolve({ appId: hints.appId })) : undefined
     if (!hit) {
       for (const [botId, ingest] of pool.entries()) {
-        const assignedTenant = this.router.get(botId)?.teamId
-        if (assignedTenant !== undefined && assignedTenant !== hints.tenantId) continue
+        if (!this.tenantFencePasses(botId, hints.tenantId)) continue
         const verified = plugin.verify(ingest, rawBody, body, headers, now)
         if (verified !== undefined) {
           // Learn only the app-only mapping; the index itself refuses a
           // tenant-scoped bot (registry.test.ts), keeping the invariant even if
-          // a future call site forgets this assignment check.
-          if (hints.appId && assignedTenant === undefined) demux.learn(hints.appId, botId)
+          // a future call site forgets this assignment check. What a learned
+          // entry can serve is bounded by the fence above, which is re-applied
+          // on every resolve through `tryCandidate`.
+          if (hints.appId && this.router.get(botId)?.teamId === undefined) demux.learn(hints.appId, botId)
           hit = { ingest, verified }
           break
         }
@@ -534,6 +535,38 @@ export class RelayIngressManager {
     }
     if (!hit) return undefined
     return entry.plugin.handle(hit.ingest, hit.verified, this.ingressHost)
+  }
+
+  /**
+   * The ingress tenant fence (ingress-tenant-fence.md §3): may a delivery from
+   * `deliveryTenant` be attributed to this bot at all?
+   *
+   * `plugin.verify` proves a delivery was signed with an app's signing secret —
+   * NOT that it came from the workspace this assignment belongs to. Those are
+   * different questions whenever one app's credentials live in two
+   * organizations, and a signature scan answers only the first. So every rung
+   * of the ladder asks this one before it accepts a candidate.
+   *
+   * The fence refuses only a PROVABLE mismatch — both sides must know a tenant
+   * (§3.3). An assignment whose tenant was never captured keeps today's
+   * behaviour and converges once the CP's identity reconciler backfills it; a
+   * delivery naming no tenant keeps today's behaviour too, and cannot be
+   * steered at a chosen victim in the first place.
+   */
+  private tenantFencePasses(botId: string, deliveryTenant: string | undefined): boolean {
+    const assignment = this.router.get(botId)
+    // Distributed install (`teamId` set): STRICT — same-app siblings share the
+    // signing secret, the envelope tenant id is the only discriminator, and a
+    // delivery that names no tenant has no safe owner among them. This arm
+    // preserves the pre-fence scan guard's fail-closed semantics exactly.
+    if (assignment?.teamId !== undefined) return assignment.teamId === deliveryTenant
+    // Every other install kind (`workspaceId` when captured): refuse only a
+    // PROVABLE mismatch — both sides must know a tenant (§3.3 fail-open arms:
+    // an uncaptured identity keeps today's behaviour until the reconciler
+    // backfills it; a tenant-less delivery keeps today's behaviour too).
+    const workspace = assignment?.workspaceId
+    if (workspace === undefined || deliveryTenant === undefined) return true
+    return workspace === deliveryTenant
   }
 
   /** Make the inline selector effective for the current Slack thread immediately.


### PR DESCRIPTION
## What

Closes a cross-organization confidentiality gap on the relay's inbound Slack path, per the included design doc [`docs/designs/ingress-tenant-fence.md`](docs/designs/ingress-tenant-fence.md).

**The problem.** `plugin.verify` proves a delivery was signed with an app's signing secret — not that it came from the workspace an assignment belongs to. Slack signing secrets are per-app, so when one app's credentials live in two organizations (the same in-house app pasted into two orgs), both bots verify either workspace's deliveries. The demux ladder's tenant guard only read `BotAssignment.teamId`, which the CP sets **only for distributed platform-app installs** — quick-install and manual-paste bots were fenced by nothing, and the learned app-only fast path could then fixate a wrong attribution. Result: one org's workspace messages silently delivered to another org's agent.

**The fix — two complementary fences:**

1. **Delivery-time tenant fence** (relay core, platform-agnostic). `Bot.workspaceId` — already captured for every bot kind at install/refresh and backfilled by the identity reconciler — now rides the assignment's opaque ingress bag (no wire-schema change) and is asserted on **every rung** of the demux ladder via one `tenantFencePasses` check: composite hit, learned app-only hit, and signature scan. Two-tier semantics, deliberately: the `teamId` arm (distributed installs) stays **strict** — exactly the pre-existing fail-closed scan-guard behavior; the new `workspaceId` arm refuses only a **provable mismatch** (assignment tenant unknown → today's behavior until the reconciler backfill converges; delivery naming no tenant → today's behavior). The change can only remove provably cross-tenant attributions, never anything correct today.
2. **Admission workspace-claim fence** (CP). The delivery fence structurally cannot decide *same app + same workspace claimed by two orgs* (same secret AND same tenant) — only refusing the second claim can. The platform-app funnel already did this (`workspace_taken`); `installNewSlackBot` — the tail both funnels share — now refuses when another org holds a bot for the same `(slackAppId, workspaceId)`: 409, message never names the holding org, boolean-only repo predicate so no foreign row crosses the persistence seam, unknown identity skips (same fail-open arm), revoked rows still claim (workspace transfer = explicit delete-then-reinstall).

This mirrors GitHub's pair exactly: `installationId @unique` (admission) + the per-rule `installationIds` gate (delivery-time). Slack needed the same two, shaped for a per-app secret.

## Worth reviewer attention

- The first cut of the unified fence accidentally flipped the distributed-app arm's "no tenant in envelope ⇒ no safe owner" edge from fail-closed to fail-open; the two-tier semantics above restore it and the pre-existing test pins it. Called out so review scrutinizes exactly that boundary.
- When two same-app workspace-fenced bots are reachable only by scan, the learned app-only map may oscillate between them — bounded-cache churn, not a correctness issue (every resolve re-applies the fence); noted in the design doc.
- Feishu's hint extractor currently surfaces only the app id, so the core fence is a no-op there until that plugin extracts `tenant_key` (the core check is already generic).

## Verification

- `pnpm typecheck` all packages; `pnpm lint` green.
- Relay 447/447 (new: fence matrix — cross-workspace scan, learned-map cross-tenant refusal, unknown-tenant convergence, tenant-less delivery; plus ingress-bag parse).
- CP unit 1257/1257 (new: bag projection for a non-distributed bot).
- Protocol 281/281 (no wire change).
- CP integration suite: full pass, including two new funnel tests (cross-org claim → 409 that never names the holder + same-org re-install proceeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
