### PR TITLE
feat(web): give integrations their own page and move Daemons to the rail's foot

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1968,6 +1968,7 @@ const RESERVED_SLUGS = new Set([
   'daemons',
   'crons',
   'knowledge',
+  'integrations',
   'usage',
   'settings',
   'profile',

--- a/packages/web/src/app/(app)/[slug]/integrations/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/integrations/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next'
+import IntegrationsView from '@/components/console/views/IntegrationsView'
+
+export const metadata: Metadata = { title: 'Integrations · AgentConnect' }
+
+export default function Page() {
+  return <IntegrationsView />
+}

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -529,6 +529,14 @@
   .navitem svg {
     flex: none;
   }
+  /* Rule between nav groups. Inset to the pills' own gutter so it reads as a
+     divider inside the list, not as a full-bleed section break like the brand
+     row's. */
+  .navsep {
+    height: 1px;
+    margin: 7px 20px;
+    background: var(--border-inverse);
+  }
   /* ----- Collapsed rail (64px, icons only) ----- */
   .rail.collapsed {
     width: 64px;
@@ -552,6 +560,11 @@
   }
   .rail.collapsed .navitem span {
     display: none;
+  }
+  /* Collapsed there is no label column to align to — the rule shortens to sit
+     under the glyph column instead of running the rail's full width. */
+  .rail.collapsed .navsep {
+    margin: 7px 16px;
   }
   /* Collapsed, the brand-row search button gives way to a nav-row one directly above
      Home, so search stays reachable at the same 32px centre line as every other glyph.

--- a/packages/web/src/components/console/ModalProvider.tsx
+++ b/packages/web/src/components/console/ModalProvider.tsx
@@ -12,6 +12,7 @@ import type { CronDto, HookDto } from '@/lib/api'
 import AddAgentModal from './modals/AddAgentModal'
 import AddDaemonModal from './modals/AddDaemonModal'
 import AddIntegrationModal, {
+  AddIntegrationForOrgModal,
   type FeishuRegion,
   type Platform as IntegrationPlatform
 } from './modals/AddIntegrationModal'
@@ -132,14 +133,24 @@ export function ModalProvider({ children }: { children: ReactNode }) {
                 registerDismiss={registerDismiss}
               />
             )}
-            {open.kind === 'integration' && open.target && (
-              <AddIntegrationModal
-                agent={open.target as Agent}
-                initialPlatform={open.opts?.platform}
-                initialFeishuRegion={open.opts?.feishuRegion}
-                onClose={close}
-              />
-            )}
+            {/* With a target the agent is fixed (opened from an agent); without one
+                — the Integrations page's Add button — the same dialog picks the
+                agent inside. */}
+            {open.kind === 'integration' &&
+              (open.target ? (
+                <AddIntegrationModal
+                  agent={open.target as Agent}
+                  initialPlatform={open.opts?.platform}
+                  initialFeishuRegion={open.opts?.feishuRegion}
+                  onClose={close}
+                />
+              ) : (
+                <AddIntegrationForOrgModal
+                  initialPlatform={open.opts?.platform}
+                  initialFeishuRegion={open.opts?.feishuRegion}
+                  onClose={close}
+                />
+              ))}
             {open.kind === 'deleteIntegration' && open.target && (
               <DeleteIntegrationModal integration={open.target as IntegrationRow} onClose={close} />
             )}

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -10,7 +10,7 @@
 // only — no top bar, no breadcrumb, no back-link. Mobile keeps its own app bar
 // (`.mtop`), which is where the section/entity title still shows.
 
-import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
+import { createContext, Fragment, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
 import { SiModelcontextprotocol } from 'react-icons/si'
 import { SWRConfig, type SWRConfiguration } from 'swr'
 import Link from 'next/link'
@@ -44,15 +44,22 @@ interface NavItem {
   icon: string
 }
 
-const NAV_ITEMS: NavItem[] = [
-  { href: '/home', label: 'Home', icon: 'house' },
-  { href: '/agents', label: 'Agents', icon: 'bot' },
-  { href: '/sessions', label: 'Sessions', icon: 'messages-square' },
-  { href: '/crons', label: 'Schedules', icon: 'calendar-clock' },
-  { href: '/daemons', label: 'Daemons', icon: 'server' },
-  { href: '/tools', label: 'Tools & Skills', icon: 'blocks' },
-  { href: '/knowledge', label: 'Knowledge', icon: 'book-open' },
-  { href: '/usage', label: 'Analytics', icon: 'circle-gauge' }
+// The rail's destinations, in groups separated by a rule: what the organization
+// runs (agents and the surfaces they answer on) first, then the fleet the work
+// runs on. Daemons sits alone at the bottom because it is infrastructure — you
+// visit it when something is wrong, not to get work done.
+const NAV_GROUPS: NavItem[][] = [
+  [
+    { href: '/home', label: 'Home', icon: 'house' },
+    { href: '/agents', label: 'Agents', icon: 'bot' },
+    { href: '/sessions', label: 'Sessions', icon: 'messages-square' },
+    { href: '/crons', label: 'Schedules', icon: 'calendar-clock' },
+    { href: '/tools', label: 'Tools & Skills', icon: 'blocks' },
+    { href: '/knowledge', label: 'Knowledge', icon: 'book-open' },
+    { href: '/integrations', label: 'Integrations', icon: 'plug' },
+    { href: '/usage', label: 'Analytics', icon: 'circle-gauge' }
+  ],
+  [{ href: '/daemons', label: 'Daemons', icon: 'server' }]
 ]
 
 // Bottom tab bar (mobile only) — exactly the design's 5-slot bar: the 4 primary
@@ -70,10 +77,11 @@ const MOBILE_NAV: NavItem[] = [
 // bar as a top-right avatar (mirroring the desktop top bar). The org switcher is
 // prepended separately, in the sheet itself.
 const MORE_ROWS: NavItem[] = [
-  { href: '/daemons', label: 'Daemons', icon: 'server' },
   { href: '/usage', label: 'Analytics', icon: 'circle-gauge' },
   { href: '/tools', label: 'Tools & Skills', icon: 'blocks' },
   { href: '/knowledge', label: 'Knowledge', icon: 'book-open' },
+  { href: '/integrations', label: 'Integrations', icon: 'plug' },
+  { href: '/daemons', label: 'Daemons', icon: 'server' },
   { href: '/settings', label: 'Settings', icon: 'settings' }
 ]
 
@@ -133,6 +141,7 @@ const SECTIONS: { prefix: string; label: string }[] = [
   { prefix: '/daemons', label: 'Daemons' },
   { prefix: '/tools', label: 'Tools & Skills' },
   { prefix: '/knowledge', label: 'Knowledge' },
+  { prefix: '/integrations', label: 'Integrations' },
   { prefix: '/usage', label: 'Analytics' },
   { prefix: '/settings', label: 'Settings' },
   { prefix: '/profile', label: 'Profile' }
@@ -712,21 +721,26 @@ function ShellChromeInner({ children }: { children: ReactNode }) {
                 <Icon name="search" size={18} />
                 <span>Search</span>
               </button>
-              {NAV_ITEMS.map((item) => {
-                const on = isActive(barePath, item.href)
-                return (
-                  <Link
-                    key={item.href}
-                    href={orgPath(item.href)}
-                    title={railCollapsed ? item.label : undefined}
-                    className={on ? 'navitem on' : 'navitem'}
-                  >
-                    {/* No inline color — `.navitem.on svg` tints the active glyph brand. */}
-                    <Icon name={item.icon} size={18} />
-                    <span>{item.label}</span>
-                  </Link>
-                )
-              })}
+              {NAV_GROUPS.map((group, groupIndex) => (
+                <Fragment key={group[0]?.href ?? groupIndex}>
+                  {groupIndex > 0 && <div className="navsep" />}
+                  {group.map((item) => {
+                    const on = isActive(barePath, item.href)
+                    return (
+                      <Link
+                        key={item.href}
+                        href={orgPath(item.href)}
+                        title={railCollapsed ? item.label : undefined}
+                        className={on ? 'navitem on' : 'navitem'}
+                      >
+                        {/* No inline color — `.navitem.on svg` tints the active glyph brand. */}
+                        <Icon name={item.icon} size={18} />
+                        <span>{item.label}</span>
+                      </Link>
+                    )
+                  })}
+                </Fragment>
+              ))}
               {/* Rail footer. In auth mode this is the account block: avatar + name +
             active org, whose menu carries everything the deleted top bar used to —
             org switching, Profile, Settings, the theme toggle, sign-out. No-auth has

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -1,9 +1,17 @@
 // No 'use client' here: rendered only by ModalProvider (the client boundary).
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent
+} from 'react'
 import useSWR from 'swr'
 import LarkFeishuSwitcher, { type LarkFeishuTarget } from '@/components/LarkFeishuSwitcher'
-import { GithubMark, PlatformMark } from '@/components/marks'
+import { AgentIconView, GithubMark, PlatformMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { GithubReviewSettings } from '@/components/console/GithubReviewSettings'
 import { GithubPrivateReposNotice, REPOSITORY_ACCESS_BADGE } from '@/components/console/WorkspaceFormFields'
@@ -173,16 +181,24 @@ function hookTestCurl(url: string, sig: string | null, body: string, requiresSig
 }
 
 // The integration is owned by one agent; that agent's daemon opens the connection.
-// The dialog is only reachable from a specific agent (its row / detail page), so the
-// agent is fixed — no picker. `initialPlatform` lets a caller land on a specific
-// pane (the GitHub group card's "Add repository" — adding a repo, not a bot).
+// Reached from an agent (its row / detail page) the agent is FIXED and no picker
+// renders — `agentChoices` is undefined there, and that arm must stay that way.
+// Reached from the Integrations page there is no implied agent, so the caller
+// (`AddIntegrationForOrgModal`) passes the roster and owns the selection.
+// `initialPlatform` lets a caller land on a specific pane (the GitHub group
+// card's "Add repository" — adding a repo, not a bot).
 export default function AddIntegrationModal({
   agent,
+  agentChoices,
+  onPickAgent,
   initialPlatform,
   initialFeishuRegion,
   onClose
 }: {
   agent: Agent
+  /** Present ONLY when the dialog was opened without an agent in hand. */
+  agentChoices?: Agent[]
+  onPickAgent?: (agentId: string) => void
   initialPlatform?: Platform
   initialFeishuRegion?: FeishuRegion
   onClose: () => void
@@ -844,7 +860,15 @@ export default function AddIntegrationModal({
         <div className="min-w-0 flex-1">
           <div className="font-sans text-[16px] font-semibold leading-normal">Add integration</div>
           <div className="mt-[1px] truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-            for <span className="mono">{agentLabel(agent)}</span> — this agent answers on the workspace
+            {agentChoices ? (
+              // The Agent field below names the target — repeating it here would
+              // read as fixed, which is the one thing this arm is not.
+              'Connect a chat platform, webhook or repository to one of your agents'
+            ) : (
+              <>
+                for <span className="mono">{agentLabel(agent)}</span> — this agent answers on the workspace
+              </>
+            )}
           </div>
         </div>
         <button className="iconbtn" onClick={onClose}>
@@ -852,6 +876,15 @@ export default function AddIntegrationModal({
         </button>
       </div>
       <div className="modalbody">
+        {agentChoices && onPickAgent && (
+          <div className="mb-[18px]">
+            <div className="fldlbl mb-2">Agent</div>
+            <AgentPicker agents={agentChoices} value={agent.id} onPick={onPickAgent} />
+            <div className="mt-[7px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+              <span className="mono">{agentLabel(agent)}</span> handles messages from this integration.
+            </div>
+          </div>
+        )}
         <div className="fldlbl mb-2">Platform</div>
         <div className="mb-[18px] grid grid-cols-2 gap-[10px] desktop:grid-cols-6">
           {PLATFORMS.map((candidate) => {
@@ -1675,5 +1708,204 @@ export default function AddIntegrationModal({
         />
       )}
     </>
+  )
+}
+
+/** The Agent field of the org-scoped arm. Same anatomy as `RuntimeSelect`: an
+ *  `.inp` trigger showing the current choice, an `.fmenu` listbox of the roster.
+ *  Only rendered when the dialog was opened without an agent. */
+function AgentPicker({ agents, value, onPick }: { agents: Agent[]; value: string; onPick: (id: string) => void }) {
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  const listboxId = useId()
+  const selectedIndex = Math.max(
+    0,
+    agents.findIndex((a) => a.id === value)
+  )
+  const selected = agents[selectedIndex]
+
+  useEffect(() => {
+    if (!open) return
+    const frame = requestAnimationFrame(() => listRef.current?.focus())
+    return () => cancelAnimationFrame(frame)
+  }, [open])
+
+  const closeAndFocus = () => {
+    setOpen(false)
+    requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+  const pick = (id: string) => {
+    if (id !== value) onPick(id)
+    closeAndFocus()
+  }
+  const onListKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      setActiveIndex((i) => (i + (event.key === 'ArrowDown' ? 1 : -1) + agents.length) % agents.length)
+      return
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      const active = agents[activeIndex]
+      if (active) pick(active.id)
+      return
+    }
+    if (event.key === 'Escape') {
+      // The dialog closes on Escape too — this one belongs to the open menu.
+      event.preventDefault()
+      event.stopPropagation()
+      closeAndFocus()
+      return
+    }
+    if (event.key === 'Tab') setOpen(false)
+  }
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`inp relative w-full cursor-pointer text-left outline-none transition-[background-color,border-color,box-shadow] ${
+          open
+            ? 'border-(--border-focus) ring-[3px] ring-(--brand-ring)'
+            : 'hover:border-(--border-strong) hover:bg-(--surface-hover) focus-visible:border-(--border-focus) focus-visible:ring-[3px] focus-visible:ring-(--brand-ring)'
+        }`}
+        aria-label="Agent"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        onClick={() => {
+          setActiveIndex(selectedIndex)
+          setOpen((v) => !v)
+        }}
+        onKeyDown={(event) => {
+          if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+          event.preventDefault()
+          setActiveIndex(selectedIndex)
+          setOpen(true)
+        }}
+      >
+        <span className="inline-flex min-w-0 items-center gap-[9px]">
+          <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
+            <AgentIconView icon={selected?.icon} runtime={selected?.runtime ?? ''} size={22} />
+          </span>
+          <span className="mono truncate text-[12.5px]">{selected ? agentLabel(selected) : '—'}</span>
+        </span>
+        <Icon
+          name="chevron-down"
+          size={15}
+          color="var(--text-tertiary)"
+          className={`flex-none transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+      {open && (
+        <>
+          <div className="fscrim" onClick={() => setOpen(false)} />
+          <div
+            ref={listRef}
+            id={listboxId}
+            role="listbox"
+            tabIndex={-1}
+            aria-label="Agent"
+            aria-activedescendant={`${listboxId}-option-${activeIndex}`}
+            className="fmenu left-0 z-40 max-h-[260px] w-full overflow-y-auto rounded-lg p-2 shadow-(--shadow-xl) outline-none"
+            onKeyDown={onListKeyDown}
+          >
+            {agents.map((a, index) => {
+              const isSelected = a.id === value
+              return (
+                <button
+                  key={a.id}
+                  id={`${listboxId}-option-${index}`}
+                  type="button"
+                  role="option"
+                  tabIndex={-1}
+                  aria-selected={isSelected}
+                  className={`fopt min-h-10 gap-[9px] rounded-md px-2 py-[6px] ${
+                    isSelected
+                      ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
+                      : index === activeIndex
+                        ? 'bg-(--surface-hover)'
+                        : ''
+                  }`}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => pick(a.id)}
+                >
+                  <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
+                    <AgentIconView icon={a.icon} runtime={a.runtime} size={22} />
+                  </span>
+                  <span className="mono min-w-0 flex-1 truncate text-left text-[12.5px]">{agentLabel(a)}</span>
+                  {isSelected && <Icon name="check" size={16} color="var(--brand)" className="flex-none" />}
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+/** Add-integration opened from the Integrations page, where no agent is implied.
+ *  The dialog itself is unchanged — it just gains the Agent field — and it is
+ *  REMOUNTED per agent (`key`) so nothing agent-scoped (watched repos, authorized
+ *  repos, the picked bot, a half-finished platform flow) survives a switch. */
+export function AddIntegrationForOrgModal({
+  initialPlatform,
+  initialFeishuRegion,
+  onClose
+}: {
+  initialPlatform?: Platform
+  initialFeishuRegion?: FeishuRegion
+  onClose: () => void
+}) {
+  const { agents } = useConsoleData()
+  // Creating an integration writes the agent's spec, so only offer the ones this
+  // viewer may edit — the CP would 403 the rest.
+  const choices = useMemo(() => agents.filter((a) => a.canEdit), [agents])
+  const [agentId, setAgentId] = useState<string | null>(null)
+  const agent = choices.find((a) => a.id === agentId) ?? choices[0]
+
+  if (!agent) {
+    return (
+      <>
+        <div className="modalhead">
+          <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-subtle) bg-(--surface-sunken)">
+            <Icon name="plug" size={17} color="var(--brand)" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="font-sans text-[16px] font-semibold leading-normal">Add integration</div>
+          </div>
+          <button className="iconbtn" onClick={onClose}>
+            <Icon name="x" size={16} />
+          </button>
+        </div>
+        <div className="modalbody">
+          <div className="rounded-[9px] border border-(--border-subtle) bg-(--surface-app) px-4 py-5 text-center font-sans text-[12.5px] font-normal leading-[1.6] text-(--text-tertiary)">
+            An integration is answered by an agent, and there is no agent you can edit yet. Create one first — the
+            Add-integration step is offered again from the agent&rsquo;s own page.
+          </div>
+        </div>
+        <div className="modalfoot">
+          <Button variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <AddIntegrationModal
+      key={agent.id}
+      agent={agent}
+      agentChoices={choices}
+      onPickAgent={setAgentId}
+      initialPlatform={initialPlatform}
+      initialFeishuRegion={initialFeishuRegion}
+      onClose={onClose}
+    />
   )
 }

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -499,7 +499,7 @@ export default function AgentDetailView() {
   const tabCls = (t: DetailTab) => (tab === t ? 'tab on' : 'tab')
   const tabHref = (t: DetailTab) => orgPath(t === 'integrations' ? `/agents/${da.id}` : `/agents/${da.id}?tab=${t}`)
   const botSettingsHref = (botId?: string) =>
-    orgPath(botId ? `/settings?bot=${encodeURIComponent(botId)}` : '/settings')
+    orgPath(botId ? `/integrations?bot=${encodeURIComponent(botId)}` : '/integrations')
 
   // ── Single responsive tree. Base classes are the mobile (≤768px) push-detail
   // body (the Shell provides the top push bar there); `desktop:` variants restore

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -1,0 +1,805 @@
+'use client'
+
+// Integrations page: the org's installed messaging bots and code hosts, and the
+// agents bound to them. Both halves are org-level infrastructure — every member
+// can see them, writes are gated on the role (viewers get no controls, and
+// uninstalling the GitHub App from an account is owner-only).
+//
+// The Add-integration dialog is the SAME one the agent page opens; reached from
+// here it carries no agent, so the modal grows an Agent field (ModalProvider's
+// `integration` kind with no target).
+
+import { Fragment, useEffect, useMemo, useState, type ReactNode } from 'react'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { Button, Icon, Toggle } from '@/components/ui'
+import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
+import type { AgentIcon } from '@/lib/agent-icon'
+import { useModal } from '@/components/console/ModalProvider'
+import { useConsoleData } from '@/lib/data-context'
+import { useProfile } from '@/lib/profile'
+import { useOrgs } from '@/lib/org-context'
+import {
+  creatorLabel,
+  fetchGithubInstallUrl,
+  fetchGithubInstallations,
+  syncGithubInstallations,
+  type BotDto,
+  type GithubInstallationDto,
+  type MeDto
+} from '@/lib/api'
+import { agentLabel, isDirectConversation, type IntegrationRow } from '@/lib/data'
+import { botCardCopy, botSharingEditable, platformRegistry } from '@/components/console/platforms/registry'
+import { BOT_PLATFORM_TABS, botMatchesPlatformTab } from '@/components/console/platforms/host-projections'
+import DeleteBotModal from '@/components/console/modals/DeleteBotModal'
+import UninstallGithubInstallationModal from '@/components/console/modals/UninstallGithubInstallationModal'
+
+// The free-bot sub-line shows where the bot came from without repeating
+// historical usage metadata in the list row.
+function botSubline(b: BotDto): string {
+  return b.freedFromAgent ? `freed from ${b.freedFromAgent}` : b.prebuilt ? 'builtin' : ''
+}
+
+/** The Bots card's fallback `CardProvider`: a platform with no lifecycle
+ *  machinery still needs SOMETHING to key by platform id around the row list. */
+function PassThrough({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}
+
+// Design grid (`isSettings` Bots card): Bot | Sharable | Agents | Created by |
+// actions. The 100px action track fits refresh + platform link + delete and stays
+// identical across rows; below 480px "Created by" is dropped to preserve space.
+const BOT_GRID = 'grid-cols-[3fr_1.1fr_1fr_100px] min-[480px]:grid-cols-[2fr_0.9fr_1.5fr_1fr_100px]'
+type BotRosterRow = { kind: 'workspace'; key: string; label: string } | { kind: 'bot'; key: string; bot: BotDto }
+
+// Preserve the server's bot order within each workspace. The heading is rendered
+// only when this produces several groups, so single-workspace organizations keep
+// the compact flat list.
+function botRosterRows(bots: BotDto[]): BotRosterRow[] {
+  const groups = new Map<string, { label: string; bots: BotDto[] }>()
+  for (const bot of bots) {
+    const workspaceId = bot.workspaceId?.trim() || null
+    const workspaceName = bot.workspaceName?.trim() || null
+    const key = workspaceId ? `id:${workspaceId}` : workspaceName ? `name:${workspaceName.toLowerCase()}` : 'unknown'
+    const current = groups.get(key)
+    if (current) {
+      if (workspaceName && current.label === workspaceId) current.label = workspaceName
+      current.bots.push(bot)
+      continue
+    }
+    groups.set(key, {
+      label: workspaceName ?? workspaceId ?? 'Workspace unavailable',
+      bots: [bot]
+    })
+  }
+  if (groups.size <= 1) return bots.map((bot) => ({ kind: 'bot', key: bot.id, bot }))
+  return [...groups].flatMap(([workspaceKey, group]) => [
+    { kind: 'workspace', key: `workspace:${workspaceKey}`, label: group.label },
+    ...group.bots.map((bot) => ({ kind: 'bot' as const, key: bot.id, bot }))
+  ])
+}
+
+// One merged channel row for a bot's expandable roster.
+interface BotChannelView {
+  channelId: string
+  name: string
+  kind: 'channel' | 'im' | 'mpim'
+  /** Effective per-channel owner; null only before legacy state converges. */
+  agentId: string | null
+  /** Any integration whose snapshot row backs this channel; ownership PATCHes
+   *  are bot-scoped. */
+  integrationId: string | null
+}
+
+// The bot's channel roster, merged across its installs (a shared bot fans out to
+// one integration per agent, each reporting its own membership snapshot).
+function botChannels(bot: BotDto, integrations: IntegrationRow[]): BotChannelView[] {
+  const merged = new Map<string, BotChannelView>()
+  for (const i of integrations) {
+    if (i.botId !== bot.id) continue
+    for (const c of i.channels) {
+      const explicit = c.agentId ?? null
+      const prev = merged.get(c.channelId)
+      if (!prev) {
+        merged.set(c.channelId, {
+          channelId: c.channelId,
+          name: c.name,
+          kind: c.kind ?? 'channel',
+          agentId: explicit,
+          integrationId: i.id ?? null
+        })
+      } else if (!prev.agentId && explicit) {
+        prev.agentId = explicit
+        prev.integrationId = i.id ?? null
+      }
+    }
+  }
+  // Channels first, then the direct conversations (DMs and group DMs) under one
+  // heading — the roster's second half is "places the bot was not invited to".
+  return [...merged.values()].sort((a, b) => {
+    const rank = (k: BotChannelView['kind']) => (isDirectConversation(k) ? 1 : 0)
+    if (rank(a.kind) !== rank(b.kind)) return rank(a.kind) - rank(b.kind)
+    return a.name.localeCompare(b.name)
+  })
+}
+
+/** Per-channel default dispatch for a SHARED bot (design: the Bots card's
+ *  expanded channel rows) — the agent a channel's unmatched messages go to.
+ *  Shows the current one and opens a menu of every agent installed on the bot;
+ *  picking one PATCHes the channel's explicit owner. This is the full-roster
+ *  picker: the agent page's own popover (IntegrationChannelList) only claims the
+ *  channel for the agent being viewed. */
+function DefaultDispatchPicker({
+  options,
+  activeId,
+  disabled,
+  onPick
+}: {
+  options: { id: string; name: string; model: string; runtime: string; icon?: AgentIcon | null }[]
+  activeId: string | null
+  disabled: boolean
+  onPick: (agentId: string) => Promise<void>
+}) {
+  const [open, setOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const active = options.find((o) => o.id === activeId) ?? options[0]
+  const pick = (id: string) => {
+    setOpen(false)
+    if (disabled || saving || id === active?.id) return
+    setSaving(true)
+    onPick(id).finally(() => setSaving(false))
+  }
+  return (
+    <span className="relative justify-self-end" onClick={(e) => e.stopPropagation()}>
+      <button
+        onClick={() => !disabled && setOpen((v) => !v)}
+        title="Default dispatch — the agent this channel's unmatched messages go to"
+        className={`flex items-center gap-2 rounded-[7px] border-0 bg-transparent px-[5px] py-1 hover:bg-(--surface-hover) ${
+          disabled ? 'cursor-default' : 'cursor-pointer'
+        } ${saving ? 'opacity-60' : ''}`}
+      >
+        <span className="av h-5 w-5 rounded-[5px]">
+          <AgentIconView icon={active?.icon} runtime={active?.runtime ?? active?.model ?? ''} size={20} />
+        </span>
+        <span className="mono text-[12.5px] text-(--text-primary)">{active?.name ?? '—'}</span>
+        <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
+      </button>
+      {open && (
+        <>
+          <span className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
+          {/* right-anchored: the picker sits in the roster's right-most column, so a
+              left-anchored menu (wider than its button) would clip past the card edge */}
+          <div className="absolute right-0 top-[calc(100%+5px)] z-40 min-w-[230px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)">
+            <div className="px-[9px] pb-[5px] pt-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+              Default dispatch
+            </div>
+            {options.map((o) => (
+              <button
+                key={o.id}
+                onClick={() => pick(o.id)}
+                className="flex w-full cursor-pointer items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[6px] text-left hover:bg-(--surface-hover)"
+              >
+                <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
+                  <AgentIconView icon={o.icon} runtime={o.runtime} size={22} />
+                </span>
+                <span className="mono min-w-0 flex-1 truncate text-[12.5px] text-(--text-primary)">{o.name}</span>
+                <Icon
+                  name="check"
+                  size={13}
+                  color={o.id === active?.id ? 'var(--brand)' : 'transparent'}
+                  className="flex-none"
+                />
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </span>
+  )
+}
+
+/** The page's two section headings. Cards own no top margin here — the section
+ *  spacing is the wrapper's, so a heading and its card read as one block. */
+function Section({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <section className="mb-[22px]">
+      <div className="mb-2 font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+        {label}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export default function IntegrationsView() {
+  // `?bot=<id>` opens that bot's channel roster — the agent page's bot chip and
+  // the Settings-era deep links land here.
+  const targetBotId = useSearchParams().get('bot')
+  const { me } = useProfile()
+  const { myRole } = useOrgs()
+  const { openModal } = useModal()
+  const isOwner = myRole === 'owner'
+  const canWrite = myRole !== 'viewer' // the CP denies viewer writes; hide the controls too
+  const [deletingBot, setDeletingBot] = useState<BotDto | null>(null)
+
+  return (
+    <div className="wrap max-desktop:p-4">
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <p className="psub mt-0 min-w-[240px] flex-1">
+          Messaging bots and code hosts installed for this organization, and the agents bound to them.
+        </p>
+        {canWrite && (
+          <Button variant="primary" size="sm" onClick={() => openModal('integration')}>
+            <Icon name="plus" size={14} />
+            Add integration
+          </Button>
+        )}
+      </div>
+
+      <Section label="Messaging apps">
+        <BotsCard canWrite={canWrite} me={me} targetBotId={targetBotId} onDelete={setDeletingBot} />
+      </Section>
+
+      <Section label="Code hosts">
+        <GithubCard canWrite={canWrite} isOwner={isOwner} />
+      </Section>
+
+      {deletingBot && (
+        <div className="scrim" onClick={() => setDeletingBot(null)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <DeleteBotModal bot={deletingBot} onClose={() => setDeletingBot(null)} />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Tabbed IM bots card ───────────────────────────────────────────────────────
+// The platform tabs select one complete roster at a time — in-use and free bots
+// are shown together, and "Show in use" narrows to the ones an agent actually
+// answers on. Each row carries the Sharable toggle (PATCH /bots/:id; the CP's
+// 409 reason renders inline) + installed-agent stack and expands to the bot's
+// channel roster.
+function BotsCard({
+  canWrite,
+  me,
+  targetBotId,
+  onDelete
+}: {
+  canWrite: boolean
+  me: MeDto | null
+  targetBotId: string | null
+  onDelete: (b: BotDto) => void
+}) {
+  const { orgPath } = useOrgs()
+  const { bots, integrations, getAgent, setBotShareable, setChannelAgent, loading: dataLoading } = useConsoleData()
+  const [platformTabKey, setPlatformTabKey] = useState<string>(BOT_PLATFORM_TABS[0]?.key ?? '')
+  // Bot row expanded to its channel roster (one at a time), the bot whose
+  // shareable PATCH is in flight, and the last toggle denial to surface (the CP
+  // 409s with a reason: no relay connected / still shared by several agents).
+  const [openBotId, setOpenBotId] = useState<string | null>(null)
+  const [botBusyId, setBotBusyId] = useState<string | null>(null)
+  const [botErr, setBotErr] = useState<{ id: string; msg: string } | null>(null)
+  // Hides the bots no agent is installed on. Free bots are the reusable pool the
+  // Add-integration picker offers, so they belong in the roster by default — this
+  // is for reading the org's live surface area, not for pruning.
+  const [inUseOnly, setInUseOnly] = useState(false)
+
+  const targetBot = bots.find((bot) => bot.id === targetBotId)
+  const targetBotPlatformTabKey = targetBot
+    ? BOT_PLATFORM_TABS.find((tab) => botMatchesPlatformTab(targetBot, tab))?.key
+    : undefined
+  // The registry always registers modules, so the strip is never empty; falling
+  // back to the first tab is what keeps this lookup total, where the hand-written
+  // table simply assumed the key resolved.
+  const platformTab = (BOT_PLATFORM_TABS.find((tab) => tab.key === platformTabKey) ?? BOT_PLATFORM_TABS[0])!
+  const { label } = platformTab
+  const platformBots = bots.filter((bot) => botMatchesPlatformTab(bot, platformTab))
+  const shownBots = inUseOnly ? platformBots.filter((bot) => bot.agentIds.length > 0) : platformBots
+  const rosterRows = botRosterRows(shownBots)
+  // Per-tab totals stay UNFILTERED: they answer "where does this org have bots",
+  // which the filter must not silently rewrite while you read across the strip.
+  const tabCounts = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const tab of BOT_PLATFORM_TABS)
+      counts.set(tab.key, bots.filter((bot) => botMatchesPlatformTab(bot, tab)).length)
+    return counts
+  }, [bots])
+
+  useEffect(() => {
+    if (!targetBotId || !targetBotPlatformTabKey) return
+    setPlatformTabKey(targetBotPlatformTabKey)
+    setOpenBotId(targetBotId)
+  }, [targetBotId, targetBotPlatformTabKey])
+
+  useEffect(() => {
+    if (!targetBotId || openBotId !== targetBotId) return
+    document.getElementById(`integration-bot-${targetBotId}`)?.scrollIntoView({ block: 'start' })
+  }, [openBotId, targetBotId])
+
+  const flipShareable = async (b: BotDto, next: boolean) => {
+    if (botBusyId) return
+    setBotBusyId(b.id)
+    setBotErr(null)
+    try {
+      await setBotShareable(b.id, next)
+    } catch (e) {
+      setBotErr({ id: b.id, msg: e instanceof Error ? e.message : String(e) })
+    } finally {
+      setBotBusyId(null)
+    }
+  }
+
+  // The active platform's Settings fragments (§10 `settingsFragments`): row
+  // badges, provider deep links, and the lifecycle machinery that owns its own
+  // card-scope state. `CardProvider` is mounted below, KEYED BY PLATFORM, which
+  // is what keeps a module's hooks from changing identity when the tab changes.
+  const fragments = platformRegistry.get(platformTab.platform)?.settingsFragments
+  const RowBadges = fragments?.botCard?.RowBadges
+  const RowLinks = fragments?.botCard?.RowLinks
+  const RowActions = fragments?.lifecycleActions?.RowActions
+  const CardNotice = fragments?.lifecycleActions?.CardNotice
+  const CardProvider = fragments?.lifecycleActions?.CardProvider ?? PassThrough
+  // The words the CARD writes into its own chrome (the revoked badge, the
+  // Sharable cell, and `noun` — the "app"/"bot" heading, delete tooltip and
+  // empty-state sentence). All of them used to be Slack's model rendered over
+  // every platform's rows; the module supplies the wording, the host still
+  // decides when and which arm to show.
+  const rowCopy = botCardCopy(platformTab.platform)
+  const noun = rowCopy.identityNoun
+
+  return (
+    <div className="card">
+      <div className="cardhead gap-0 py-0">
+        <div
+          className="flex min-w-0 flex-1 gap-0 overflow-x-auto [scrollbar-width:none] desktop:overflow-x-visible [&::-webkit-scrollbar]:hidden"
+          role="tablist"
+          aria-label="Bot platform"
+        >
+          {BOT_PLATFORM_TABS.map((item) => {
+            const selected = item.key === platformTabKey
+            return (
+              <button
+                key={item.key}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                className={`${selected ? 'tab on' : 'tab'} mr-[5px] flex items-center gap-[5px] whitespace-nowrap last:mr-0 desktop:mr-[22px] desktop:gap-[6px]`}
+                onClick={() => {
+                  setPlatformTabKey(item.key)
+                  setOpenBotId(null)
+                }}
+              >
+                <span className="flex h-[14px] w-[14px] flex-none items-center justify-center">
+                  <PlatformMark platform={item.platform} fillPct={100} />
+                </span>
+                {item.label}
+                <span className="font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary)">
+                  {tabCounts.get(item.key) ?? 0}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+        {/* Pinned right of the scrolling tab strip. At 375px the full label eats a
+            third of the row, so the mobile arm keeps only the words that carry it. */}
+        <label className="flex flex-none cursor-pointer items-center gap-2 pl-3 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+          <span className="max-desktop:hidden">Show in use</span>
+          <span className="desktop:hidden">In use</span>
+          <Toggle checked={inUseOnly} onChange={setInUseOnly} />
+        </label>
+      </div>
+      {/* gap must match the data rows' or the narrow tracks drift out of line. */}
+      <div className={`row h ${BOT_GRID} gap-[11px]`}>
+        {/* `.row.h` uppercases, so the module's lower-case noun renders as the
+            heading did when the host picked between two literals. */}
+        <span>{noun}</span>
+        <span>Sharable</span>
+        <span>Agents</span>
+        <span className="whitespace-nowrap max-[479px]:hidden">Created by</span>
+        <span />
+      </div>
+      {/* Keyed by platform id: switching tabs REMOUNTS the module's card state,
+          which is the only way the fragments' hooks keep a stable identity when
+          the active module changes. Non-lifecycle platforms get `PassThrough`, so
+          the key is inert for them. */}
+      <CardProvider key={platformTab.platform}>
+        {rosterRows.map((row) => {
+          if (row.kind === 'workspace') {
+            return (
+              <div
+                key={row.key}
+                className="flex items-center gap-2 border-b border-(--border-subtle) bg-(--surface-sunken) px-4 py-2"
+              >
+                <span className="font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+                  Workspace
+                </span>
+                <span className="mono min-w-0 truncate text-[12px] text-(--text-secondary)">{row.label}</span>
+              </div>
+            )
+          }
+          const b = row.bot
+          const free = b.agentIds.length === 0
+          const open = openBotId === b.id
+          const channels = open ? botChannels(b, integrations) : []
+          const hasChannelRows = channels.some((c) => c.kind === 'channel')
+          const showDefaultDispatch = b.shareable && hasChannelRows
+          const chanGrid = showDefaultDispatch ? 'grid-cols-[1fr_auto]' : 'grid-cols-[1fr]'
+          // The picker's choices: every agent installed on the bot.
+          const agentOptions = b.agentIds.map((id) => {
+            const ag = getAgent(id)
+            return {
+              id,
+              name: ag ? agentLabel(ag) : id,
+              model: ag?.model || ag?.runtime || '',
+              runtime: ag?.runtime || ag?.model || '',
+              icon: ag?.icon
+            }
+          })
+          return (
+            <Fragment key={b.id}>
+              <div
+                id={`integration-bot-${b.id}`}
+                className={`row click ${BOT_GRID} items-center gap-[11px]`}
+                onClick={() => setOpenBotId(open ? null : b.id)}
+              >
+                <div className="flex min-w-0 items-center gap-[10px]">
+                  <Icon
+                    name="chevron-right"
+                    size={14}
+                    className={`flex-none text-(--text-tertiary) transition-transform ${open ? 'rotate-90' : ''}`}
+                  />
+                  <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
+                    <span className="flex h-[14px] w-[14px] items-center justify-center">
+                      <PlatformMark platform={b.platform} fillPct={100} />
+                    </span>
+                  </span>
+                  <span className="mono min-w-0 flex-1 truncate text-[12.5px]">{b.name}</span>
+                  {b.prebuilt && <span className="badge bg-(--surface-active) text-(--text-tertiary)">builtin</span>}
+                  {/* Workspace uninstalled the app / revoked its tokens (rc/bot-revoked):
+                    the credential is dead until a re-install refreshes it. The
+                    sentence is the module's (§10 `settingsFragments.copy`) — only
+                    Slack can name the lifecycle event that put the bot here. */}
+                  {b.revokedAt && (
+                    <span className="badge bg-(--status-error-soft) text-(--danger)" title={rowCopy.revokedHint}>
+                      revoked
+                    </span>
+                  )}
+                  {RowBadges && <RowBadges bot={b} />}
+                </div>
+                {/* The host picks the arm by transport; the module owns both
+                    sentences. A platform that declares none gets one sentence for
+                    both arms — its transport is not why sharing is unavailable.
+                    Enablement asks the same question the CP does
+                    (`botSharingEditable`): transport ALONE left Feishu's HTTP bots
+                    with a live toggle for a capability the server refuses. */}
+                <span
+                  className="flex items-center justify-self-start"
+                  title={
+                    (b.transport ?? 'socket') === 'socket' ? rowCopy.shareHint.unavailable : rowCopy.shareHint.available
+                  }
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <Toggle
+                    checked={b.shareable}
+                    disabled={!canWrite || botBusyId === b.id || !botSharingEditable(b)}
+                    onChange={(next) => void flipShareable(b, next)}
+                  />
+                </span>
+                <div className="flex min-w-0 items-center">
+                  {b.agentIds.length > 0 ? (
+                    b.agentIds.map((id, idx) => {
+                      const ag = getAgent(id)
+                      return (
+                        <Link
+                          key={id}
+                          href={orgPath(`/agents/${encodeURIComponent(id)}?tab=config`)}
+                          aria-label={`Open ${ag ? agentLabel(ag) : id} configuration`}
+                          title={ag ? agentLabel(ag) : id}
+                          className={`av h-[22px] w-[22px] rounded-[6px] no-underline focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) ${
+                            idx > 0 ? '-ml-[6px] shadow-[-1px_0_0_0_var(--surface-card)]' : ''
+                          }`}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <AgentIconView icon={ag?.icon} runtime={ag?.runtime || ag?.model || ''} size={22} />
+                        </Link>
+                      )
+                    })
+                  ) : (
+                    <span className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                      {botSubline(b)}
+                    </span>
+                  )}
+                </div>
+                <span className="min-w-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary) max-[479px]:hidden">
+                  {b.createdBy ? creatorLabel(b.createdBy, me) : b.prebuilt ? 'AgentConnect' : '—'}
+                </span>
+                {/* The 100px action track: the module's own controls (refresh, provider
+                  deep link) first, then the host's delete. */}
+                <span className="flex items-center justify-end gap-2" onClick={(e) => e.stopPropagation()}>
+                  {RowActions && <RowActions bot={b} canWrite={canWrite} />}
+                  {RowLinks && <RowLinks bot={b} />}
+                  {free && canWrite ? (
+                    <button className="iconbtn h-7 w-7 flex-none" title={`Delete ${noun}`} onClick={() => onDelete(b)}>
+                      <Icon name="trash-2" size={14} />
+                    </button>
+                  ) : !free ? (
+                    <span
+                      title="Uninstall its integration first"
+                      className="flex h-7 w-7 flex-none cursor-not-allowed items-center justify-center opacity-45"
+                    >
+                      <Icon name="trash-2" size={14} />
+                    </span>
+                  ) : (
+                    <span className="h-7 w-7 flex-none" />
+                  )}
+                </span>
+              </div>
+              {botErr?.id === b.id && (
+                <div className="border-b border-(--border-subtle) px-4 py-2 font-sans text-[12px] font-normal leading-normal text-(--status-error)">
+                  {botErr.msg}
+                </div>
+              )}
+              {CardNotice && <CardNotice bot={b} />}
+              {open && (
+                <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 pb-[14px] pl-10 pt-3">
+                  {channels.length > 0 ? (
+                    <>
+                      <div
+                        className={`grid ${chanGrid} gap-[11px] px-3 pb-[7px] font-mono text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)`}
+                      >
+                        <span>Conversation</span>
+                        {showDefaultDispatch && <span className="justify-self-end">Default dispatch</span>}
+                      </div>
+                      <div className="overflow-visible rounded-lg border border-(--border-subtle) bg-(--surface-card)">
+                        {channels.map((c, index) => (
+                          <Fragment key={c.channelId}>
+                            {isDirectConversation(c.kind) && !isDirectConversation(channels[index - 1]?.kind) && (
+                              <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-3 py-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+                                Direct messages
+                              </div>
+                            )}
+                            <div
+                              className={`grid ${chanGrid} items-center gap-[11px] border-b border-(--border-subtle) px-3 py-2 last:border-b-0`}
+                            >
+                              <span className="mono flex min-w-0 items-center gap-[7px] text-[12px]">
+                                <Icon
+                                  name={c.kind === 'mpim' ? 'users' : c.kind === 'im' ? 'at-sign' : 'hash'}
+                                  size={12}
+                                  color="var(--text-tertiary)"
+                                  className="flex-none"
+                                />
+                                <span className="sr-only">
+                                  {c.kind === 'mpim' ? 'Group DM' : c.kind === 'im' ? 'Direct message' : 'Channel'}
+                                  :{' '}
+                                </span>
+                                <span className="truncate">
+                                  {isDirectConversation(c.kind) ? c.name.replace(/^@+/, '') : c.name}
+                                </span>
+                              </span>
+                              {showDefaultDispatch && c.kind === 'channel' && (
+                                <DefaultDispatchPicker
+                                  options={agentOptions}
+                                  activeId={c.agentId ?? b.agentIds[0] ?? null}
+                                  disabled={!canWrite || !c.integrationId}
+                                  onPick={(agentId) => setChannelAgent(c.integrationId!, c.channelId, agentId)}
+                                />
+                              )}
+                            </div>
+                          </Fragment>
+                        ))}
+                      </div>
+                    </>
+                  ) : (
+                    <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+                      Not in any channel yet — invite the bot to a channel and it shows up here.
+                    </div>
+                  )}
+                </div>
+              )}
+            </Fragment>
+          )
+        })}
+      </CardProvider>
+      {shownBots.length === 0 &&
+        (dataLoading ? (
+          <LoadingState size={22} padding={20} />
+        ) : platformBots.length > 0 ? (
+          // Filtered empty — say so, or the roster reads as "this org has no
+          // Slack bots" when it has several sitting free.
+          <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+            No {label} {noun} is installed on an agent — turn off &ldquo;Show in use&rdquo; to see the{' '}
+            {platformBots.length} free {platformBots.length === 1 ? noun : `${noun}s`}.
+          </div>
+        ) : (
+          <div className="px-4 py-7 text-center">
+            <div className="font-sans text-[13px] font-semibold leading-normal">No {noun}s yet</div>
+            <div className="mt-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+              A {label} {noun} is registered when you add a {label} integration to an agent.
+            </div>
+          </div>
+        ))}
+    </div>
+  )
+}
+
+// ── GitHub App card ─────────────────────────────────────────────────────────
+// The deployment GitHub App powering github-app workspaces (repo picker +
+// credential-free daemon git). Deployment-config opt-in: when the CP has no
+// GITHUB_APP_* env the routes 404 and this card shows the disabled note.
+// Installations are org-level infrastructure (like bots) — every member can
+// see them; installing and syncing are writes (viewers don't get those buttons),
+// while uninstalling the App from an account is owner-only.
+function GithubCard({ canWrite, isOwner }: { canWrite: boolean; isOwner: boolean }) {
+  // Gate the org-scoped fetch on the active org (same hard-refresh race as SlackCard):
+  // before OrgProvider resolves, `orgBase()` throws → the catch would show "not enabled"
+  // even when it IS. Re-fetch once the org resolves / on switch.
+  const { activeOrg } = useOrgs()
+  const [enabled, setEnabled] = useState<boolean | null>(null)
+  const [installs, setInstalls] = useState<GithubInstallationDto[]>([])
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [uninstalling, setUninstalling] = useState<GithubInstallationDto | null>(null)
+
+  useEffect(() => {
+    if (!activeOrg) return
+    let alive = true
+    setEnabled(null)
+    fetchGithubInstallations()
+      .then(({ enabled, installations }) => {
+        if (!alive) return
+        setEnabled(enabled)
+        setInstalls(installations)
+      })
+      .catch(() => alive && setEnabled(false))
+    return () => {
+      alive = false
+    }
+  }, [activeOrg])
+
+  // The install link mints a ONE-SHOT signed state — fetch fresh per click.
+  const install = async () => {
+    setErr(null)
+    try {
+      const url = await fetchGithubInstallUrl()
+      if (url) window.open(url, '_blank', 'noopener')
+      else setErr('Could not mint an install link.')
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  // Refresh the org's claimed installations after GitHub changes or an install
+  // finished in the other tab just now.
+  const sync = async () => {
+    if (busy) return
+    setBusy(true)
+    setErr(null)
+    try {
+      setInstalls(await syncGithubInstallations())
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="card">
+      <div className="cardhead justify-between">
+        <span className="cardtitle flex items-center gap-2">
+          <span className="flex h-[15px] w-[15px] items-center justify-center">
+            <GithubMark color="var(--text-primary)" />
+          </span>
+          GitHub
+        </span>
+        {enabled === true && canWrite && (
+          <span className="flex items-center gap-2">
+            <Button variant="ghost" onClick={sync}>
+              <Icon name="refresh-cw" size={13} />
+              {busy ? 'Syncing…' : 'Sync'}
+            </Button>
+            <Button onClick={install}>
+              <Icon name="external-link" size={13} />
+              Install on GitHub
+            </Button>
+          </span>
+        )}
+      </div>
+      {enabled === null && <LoadingState size={22} padding={20} />}
+      {enabled === false && (
+        <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+          Not enabled on this deployment — the control plane has no GitHub App configured.
+        </div>
+      )}
+      {enabled === true && installs.length === 0 && (
+        <div className="px-4 py-7 text-center">
+          <div className="font-sans text-[13px] font-semibold leading-normal">No installations yet</div>
+          <div className="mt-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+            Install the GitHub App on your org to pick private repositories when creating agents — the daemon then
+            clones and pushes with short-lived tokens, no git credentials on the machine.
+          </div>
+        </div>
+      )}
+      {/* Desktop only: the row collapses to one stacked column below the
+          breakpoint, where a two-track header would label nothing. */}
+      {enabled === true && installs.length > 0 && (
+        <div className="row h hidden grid-cols-[minmax(0,1fr)_auto] gap-[11px] desktop:grid">
+          <span>Installation</span>
+          <span>Repository access</span>
+        </div>
+      )}
+      {enabled === true &&
+        installs.map((i) => (
+          <Fragment key={i.id}>
+            <div className="row grid-cols-1 gap-2 desktop:grid-cols-[minmax(0,1fr)_auto] desktop:gap-[11px]">
+              <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
+                <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
+                  <span className="flex h-[14px] w-[14px] items-center justify-center">
+                    <GithubMark color="var(--text-primary)" />
+                  </span>
+                </span>
+                <span className="mono min-w-0 truncate text-[12.5px]">{i.accountLogin}</span>
+                <span className="badge bg-(--surface-active) text-(--text-tertiary)">
+                  {i.accountType === 'Organization' ? 'org' : 'user'}
+                </span>
+                {i.suspended && <span className="badge bg-(--status-error-soft) text-(--status-error)">suspended</span>}
+                {i.permissionsStatus === 'outdated' && (
+                  <span className="badge bg-(--status-paused-soft) text-(--amber-500)">needs update</span>
+                )}
+              </div>
+              <span className="flex items-center justify-between gap-3 desktop:justify-end">
+                <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                  {i.repositorySelection === 'all' ? 'all repositories' : 'selected repositories'}
+                </span>
+                {isOwner && (
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    className="text-(--status-error) hover:text-(--status-error)"
+                    onClick={() => setUninstalling(i)}
+                  >
+                    <Icon name="unplug" size={13} />
+                    Uninstall
+                  </Button>
+                )}
+              </span>
+            </div>
+            {i.permissionsStatus === 'outdated' && (
+              <div
+                role="status"
+                className="flex flex-col items-start gap-2 border-b border-(--border-subtle) bg-(--status-paused-soft) px-4 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--amber-500) desktop:flex-row desktop:items-center desktop:justify-between desktop:gap-3"
+              >
+                <span className="flex min-w-0 items-start gap-2">
+                  <Icon name="triangle-alert" size={14} color="var(--amber-500)" className="mt-[2px] flex-none" />
+                  <span>This installation&rsquo;s GitHub permissions need updating before all features will work.</span>
+                </span>
+                <a href={i.settingsUrl} target="_blank" rel="noopener noreferrer" className="lnk flex-none text-[12px]">
+                  Update permissions
+                  <Icon name="external-link" size={12} />
+                </a>
+              </div>
+            )}
+          </Fragment>
+        ))}
+      {err && (
+        <div className="px-4 py-2 font-sans text-[12px] font-normal leading-normal text-(--status-error)">{err}</div>
+      )}
+      {uninstalling && (
+        <div className="scrim" onClick={() => setUninstalling(null)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <UninstallGithubInstallationModal
+              installation={uninstalling}
+              onClose={() => setUninstalling(null)}
+              onUninstalled={(id) => {
+                setInstalls((current) => current.filter((installation) => installation.id !== id))
+                setUninstalling(null)
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -4,69 +4,45 @@
 // the active org: the Organization card (rename via PATCH /orgs/:id, owners
 // only), self-service organization leave, Members & roles (GET /members;
 // owners can invite-by-email, re-role and remove members — the CP enforces the
-// last-owner guard), the Bots card (the org's durable bot identities; free ones
-// can be deleted here — the Add-integration picker only offers them for reuse),
-// and the Roles explainer.
+// last-owner guard), the org-wide agent policies, and the Roles explainer.
+//
+// The org's bots and code hosts are NOT here — they live on their own
+// Integrations page (IntegrationsView), which unlike Settings is reachable in
+// no-auth mode.
 
-import { Fragment, useCallback, useEffect, useState, type ReactNode } from 'react'
-import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import { Avatar, Button, Icon, Toggle } from '@/components/ui'
-import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
-import type { AgentIcon } from '@/lib/agent-icon'
+import { AgentIconView, LoadingState, PlatformMark } from '@/components/marks'
 import { withIconUrl } from '@/lib/agent-icon'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
 import { useModal } from '@/components/console/ModalProvider'
 import { useConsoleData } from '@/lib/data-context'
-import { useProfile } from '@/lib/profile'
 import { useOrgs } from '@/lib/org-context'
 import { initialsFrom } from '@/lib/auth'
 import {
   createOrgInviteLink,
-  creatorLabel,
-  fetchGithubInstallUrl,
-  fetchGithubInstallations,
   fetchMembers,
   fetchOrgInviteLink,
   fetchSessionExternalAccess,
   memberDisplayName,
   revokeOrgInviteLink,
   ROLE_LABELS,
-  syncGithubInstallations,
   putSessionExternalAccess,
   updateOrg,
   uploadOrgIcon,
-  type BotDto,
-  type GithubInstallationDto,
-  type MeDto,
   type MemberDto,
   type MemberRole,
   type OrgInviteLinkDto,
   type SessionAccessProvider
 } from '@/lib/api'
-import { agentLabel, isDirectConversation, type AgentCallPolicy, type IntegrationRow } from '@/lib/data'
-import { botCardCopy, botSharingEditable, platformRegistry } from '@/components/console/platforms/registry'
-import { BOT_PLATFORM_TABS, botMatchesPlatformTab } from '@/components/console/platforms/host-projections'
+import { type AgentCallPolicy } from '@/lib/data'
 import { consoleKeys } from '@/lib/swr-keys'
 import { inviteLinkStatus, inviteLinkUrl } from '@/lib/org-invite-link'
 import EditMemberModal, { type MemberTarget } from '@/components/console/modals/EditMemberModal'
 import InviteMembersModal from '@/components/console/modals/InviteMembersModal'
-import DeleteBotModal from '@/components/console/modals/DeleteBotModal'
-import UninstallGithubInstallationModal from '@/components/console/modals/UninstallGithubInstallationModal'
 import { OrganizationEnvironmentCard } from '@/components/console/OrganizationEnvironmentCard'
-
-// The free-bot sub-line shows where the bot came from without repeating
-// historical usage metadata in the list row.
-function botSubline(b: BotDto): string {
-  return b.freedFromAgent ? `freed from ${b.freedFromAgent}` : b.prebuilt ? 'builtin' : ''
-}
-
-/** The Bots card's fallback `CardProvider`: a platform with no lifecycle
- *  machinery still needs SOMETHING to key by platform id around the row list. */
-function PassThrough({ children }: { children: ReactNode }) {
-  return <>{children}</>
-}
 
 // One short sub-line per state — the full access policy (who keeps seeing what,
 // and what turning the toggle off does NOT undo) lives in `details`, shown by the
@@ -357,157 +333,6 @@ function rowFromDto(m: MemberDto): MemberRowView {
 }
 
 const MEMBER_GRID = 'grid-cols-[2fr_1.4fr_auto]'
-// Design grid (`isSettings` Bots card): Bot | Sharable | Agents | Created by |
-// actions. The 100px action track fits refresh + platform link + delete and stays
-// identical across rows; below 480px "Created by" is dropped to preserve space.
-const BOT_GRID = 'grid-cols-[3fr_1.1fr_1fr_100px] min-[480px]:grid-cols-[2fr_0.9fr_1.5fr_1fr_100px]'
-type BotRosterRow = { kind: 'workspace'; key: string; label: string } | { kind: 'bot'; key: string; bot: BotDto }
-
-// Preserve the server's bot order within each workspace. The heading is rendered
-// only when this produces several groups, so single-workspace organizations keep
-// the compact flat list.
-function botRosterRows(bots: BotDto[]): BotRosterRow[] {
-  const groups = new Map<string, { label: string; bots: BotDto[] }>()
-  for (const bot of bots) {
-    const workspaceId = bot.workspaceId?.trim() || null
-    const workspaceName = bot.workspaceName?.trim() || null
-    const key = workspaceId ? `id:${workspaceId}` : workspaceName ? `name:${workspaceName.toLowerCase()}` : 'unknown'
-    const current = groups.get(key)
-    if (current) {
-      if (workspaceName && current.label === workspaceId) current.label = workspaceName
-      current.bots.push(bot)
-      continue
-    }
-    groups.set(key, {
-      label: workspaceName ?? workspaceId ?? 'Workspace unavailable',
-      bots: [bot]
-    })
-  }
-  if (groups.size <= 1) return bots.map((bot) => ({ kind: 'bot', key: bot.id, bot }))
-  return [...groups].flatMap(([workspaceKey, group]) => [
-    { kind: 'workspace', key: `workspace:${workspaceKey}`, label: group.label },
-    ...group.bots.map((bot) => ({ kind: 'bot' as const, key: bot.id, bot }))
-  ])
-}
-
-// One merged channel row for a bot's expandable roster.
-interface BotChannelView {
-  channelId: string
-  name: string
-  kind: 'channel' | 'im' | 'mpim'
-  /** Effective per-channel owner; null only before legacy state converges. */
-  agentId: string | null
-  /** Any integration whose snapshot row backs this channel; ownership PATCHes
-   *  are bot-scoped. */
-  integrationId: string | null
-}
-
-// The bot's channel roster, merged across its installs (a shared bot fans out to
-// one integration per agent, each reporting its own membership snapshot).
-function botChannels(bot: BotDto, integrations: IntegrationRow[]): BotChannelView[] {
-  const merged = new Map<string, BotChannelView>()
-  for (const i of integrations) {
-    if (i.botId !== bot.id) continue
-    for (const c of i.channels) {
-      const explicit = c.agentId ?? null
-      const prev = merged.get(c.channelId)
-      if (!prev) {
-        merged.set(c.channelId, {
-          channelId: c.channelId,
-          name: c.name,
-          kind: c.kind ?? 'channel',
-          agentId: explicit,
-          integrationId: i.id ?? null
-        })
-      } else if (!prev.agentId && explicit) {
-        prev.agentId = explicit
-        prev.integrationId = i.id ?? null
-      }
-    }
-  }
-  // Channels first, then the direct conversations (DMs and group DMs) under one
-  // heading — the roster's second half is "places the bot was not invited to".
-  return [...merged.values()].sort((a, b) => {
-    const rank = (k: BotChannelView['kind']) => (isDirectConversation(k) ? 1 : 0)
-    if (rank(a.kind) !== rank(b.kind)) return rank(a.kind) - rank(b.kind)
-    return a.name.localeCompare(b.name)
-  })
-}
-
-/** Per-channel default dispatch for a SHARED bot (design: the Bots card's
- *  expanded channel rows) — the agent a channel's unmatched messages go to.
- *  Shows the current one and opens a menu of every agent installed on the bot;
- *  picking one PATCHes the channel's explicit owner. This is the full-roster
- *  picker: the agent page's own popover (IntegrationChannelList) only claims the
- *  channel for the agent being viewed. */
-function DefaultDispatchPicker({
-  options,
-  activeId,
-  disabled,
-  onPick
-}: {
-  options: { id: string; name: string; model: string; runtime: string; icon?: AgentIcon | null }[]
-  activeId: string | null
-  disabled: boolean
-  onPick: (agentId: string) => Promise<void>
-}) {
-  const [open, setOpen] = useState(false)
-  const [saving, setSaving] = useState(false)
-  const active = options.find((o) => o.id === activeId) ?? options[0]
-  const pick = (id: string) => {
-    setOpen(false)
-    if (disabled || saving || id === active?.id) return
-    setSaving(true)
-    onPick(id).finally(() => setSaving(false))
-  }
-  return (
-    <span className="relative justify-self-end" onClick={(e) => e.stopPropagation()}>
-      <button
-        onClick={() => !disabled && setOpen((v) => !v)}
-        title="Default dispatch — the agent this channel's unmatched messages go to"
-        className={`flex items-center gap-2 rounded-[7px] border-0 bg-transparent px-[5px] py-1 hover:bg-(--surface-hover) ${
-          disabled ? 'cursor-default' : 'cursor-pointer'
-        } ${saving ? 'opacity-60' : ''}`}
-      >
-        <span className="av h-5 w-5 rounded-[5px]">
-          <AgentIconView icon={active?.icon} runtime={active?.runtime ?? active?.model ?? ''} size={20} />
-        </span>
-        <span className="mono text-[12.5px] text-(--text-primary)">{active?.name ?? '—'}</span>
-        <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
-      </button>
-      {open && (
-        <>
-          <span className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
-          {/* right-anchored: the picker sits in the roster's right-most column, so a
-              left-anchored menu (wider than its button) would clip past the card edge */}
-          <div className="absolute right-0 top-[calc(100%+5px)] z-40 min-w-[230px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)">
-            <div className="px-[9px] pb-[5px] pt-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
-              Default dispatch
-            </div>
-            {options.map((o) => (
-              <button
-                key={o.id}
-                onClick={() => pick(o.id)}
-                className="flex w-full cursor-pointer items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[6px] text-left hover:bg-(--surface-hover)"
-              >
-                <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
-                  <AgentIconView icon={o.icon} runtime={o.runtime} size={22} />
-                </span>
-                <span className="mono min-w-0 flex-1 truncate text-[12.5px] text-(--text-primary)">{o.name}</span>
-                <Icon
-                  name="check"
-                  size={13}
-                  color={o.id === active?.id ? 'var(--brand)' : 'transparent'}
-                  className="flex-none"
-                />
-              </button>
-            ))}
-          </div>
-        </>
-      )}
-    </span>
-  )
-}
 
 function InviteLinksCard({ orgId }: { orgId: string }) {
   const key = consoleKeys.inviteLink(orgId)
@@ -666,15 +491,11 @@ function InviteLinksCard({ orgId }: { orgId: string }) {
 }
 
 export default function SettingsView() {
-  const targetBotId = useSearchParams().get('bot')
-  const { me } = useProfile()
   const { activeOrg, myRole, refreshOrgs, updateOrg: updateOrgSettings, leaveOrg, error: orgError } = useOrgs()
   const { openModal } = useModal()
-  // Shared with the Bots card below (same SWR context, no extra pull). The
-  // organization-environment picker filters this to agents the viewer can manage.
+  // The organization-environment picker filters this to agents the viewer can manage.
   const { agents } = useConsoleData()
   const isOwner = myRole === 'owner'
-  const canWrite = myRole !== 'viewer' // the CP denies viewer writes; hide the controls too
 
   const membersKey = consoleKeys.members(activeOrg?.id)
   const {
@@ -686,7 +507,6 @@ export default function SettingsView() {
   const members = loadFailed ? [] : (membersData ?? null)
   const [editing, setEditing] = useState<MemberTarget | null>(null)
   const [inviting, setInviting] = useState(false)
-  const [deletingBot, setDeletingBot] = useState<BotDto | null>(null)
 
   // `?invite=1` auto-opens the invite-members dialog (the getting-started "Invite
   // teammates" CTA lands here with it). One-shot: the param is stripped immediately
@@ -854,15 +674,6 @@ export default function SettingsView() {
 
       {isOwner && activeOrg && <InviteLinksCard orgId={activeOrg.id} />}
 
-      {/* One tabbed card for every IM platform's durable bot identities. Rows carry
-          the Sharable toggle + installed-agent stack and expand to the bot's
-          channel roster (a SHARED bot's channels each get an active-agent picker).
-          Slack rows deep-link to the app's settings; Discord rows offer a ready-made
-          "Add to Discord" invite built from the persisted application id. */}
-      <BotsCard canWrite={canWrite} me={me} targetBotId={targetBotId} onDelete={setDeletingBot} />
-
-      <GithubCard canWrite={canWrite} isOwner={isOwner} />
-
       {inviting && (
         <div className="scrim" onClick={() => setInviting(false)}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
@@ -879,529 +690,6 @@ export default function SettingsView() {
               onLeave={editing.isCurrentUser ? () => leaveOrg(editing.userId) : undefined}
               onClose={() => setEditing(null)}
               onChanged={onMembersChanged}
-            />
-          </div>
-        </div>
-      )}
-      {deletingBot && (
-        <div className="scrim" onClick={() => setDeletingBot(null)}>
-          <div className="modal" onClick={(e) => e.stopPropagation()}>
-            <DeleteBotModal bot={deletingBot} onClose={() => setDeletingBot(null)} />
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ── Tabbed IM bots card ───────────────────────────────────────────────────────
-// The platform tabs select one complete roster at a time — in-use and free bots
-// are always shown together. Each row carries the Sharable toggle (PATCH
-// /bots/:id; the CP's 409 reason renders inline) + installed-agent stack and
-// expands to the bot's channel roster.
-function BotsCard({
-  canWrite,
-  me,
-  targetBotId,
-  onDelete
-}: {
-  canWrite: boolean
-  me: MeDto | null
-  targetBotId: string | null
-  onDelete: (b: BotDto) => void
-}) {
-  const { orgPath } = useOrgs()
-  const {
-    bots,
-    integrations,
-    getAgent,
-    setBotShareable,
-    setChannelAgent,
-    refresh,
-    loading: dataLoading
-  } = useConsoleData()
-  const [platformTabKey, setPlatformTabKey] = useState<string>(BOT_PLATFORM_TABS[0]?.key ?? '')
-  // Bot row expanded to its channel roster (one at a time), the bot whose
-  // shareable PATCH is in flight, and the last toggle denial to surface (the CP
-  // 409s with a reason: no relay connected / still shared by several agents).
-  const [openBotId, setOpenBotId] = useState<string | null>(null)
-  const [botBusyId, setBotBusyId] = useState<string | null>(null)
-  const [botErr, setBotErr] = useState<{ id: string; msg: string } | null>(null)
-
-  const targetBot = bots.find((bot) => bot.id === targetBotId)
-  const targetBotPlatformTabKey = targetBot
-    ? BOT_PLATFORM_TABS.find((tab) => botMatchesPlatformTab(targetBot, tab))?.key
-    : undefined
-  // The registry always registers modules, so the strip is never empty; falling
-  // back to the first tab is what keeps this lookup total, where the hand-written
-  // table simply assumed the key resolved.
-  const platformTab = (BOT_PLATFORM_TABS.find((tab) => tab.key === platformTabKey) ?? BOT_PLATFORM_TABS[0])!
-  const { label } = platformTab
-  const platformBots = bots.filter((bot) => botMatchesPlatformTab(bot, platformTab))
-  const rosterRows = botRosterRows(platformBots)
-
-  useEffect(() => {
-    if (!targetBotId || !targetBotPlatformTabKey) return
-    setPlatformTabKey(targetBotPlatformTabKey)
-    setOpenBotId(targetBotId)
-  }, [targetBotId, targetBotPlatformTabKey])
-
-  useEffect(() => {
-    if (!targetBotId || openBotId !== targetBotId) return
-    document.getElementById(`settings-bot-${targetBotId}`)?.scrollIntoView({ block: 'start' })
-  }, [openBotId, targetBotId])
-
-  const flipShareable = async (b: BotDto, next: boolean) => {
-    if (botBusyId) return
-    setBotBusyId(b.id)
-    setBotErr(null)
-    try {
-      await setBotShareable(b.id, next)
-    } catch (e) {
-      setBotErr({ id: b.id, msg: e instanceof Error ? e.message : String(e) })
-    } finally {
-      setBotBusyId(null)
-    }
-  }
-
-  // The active platform's Settings fragments (§10 `settingsFragments`): row
-  // badges, provider deep links, and the lifecycle machinery that owns its own
-  // card-scope state. `CardProvider` is mounted below, KEYED BY PLATFORM, which
-  // is what keeps a module's hooks from changing identity when the tab changes.
-  const fragments = platformRegistry.get(platformTab.platform)?.settingsFragments
-  const RowBadges = fragments?.botCard?.RowBadges
-  const RowLinks = fragments?.botCard?.RowLinks
-  const RowActions = fragments?.lifecycleActions?.RowActions
-  const CardNotice = fragments?.lifecycleActions?.CardNotice
-  const CardProvider = fragments?.lifecycleActions?.CardProvider ?? PassThrough
-  // The words the CARD writes into its own chrome (the revoked badge, the
-  // Sharable cell, and `noun` — the "app"/"bot" heading, delete tooltip and
-  // empty-state sentence). All of them used to be Slack's model rendered over
-  // every platform's rows; the module supplies the wording, the host still
-  // decides when and which arm to show.
-  const rowCopy = botCardCopy(platformTab.platform)
-  const noun = rowCopy.identityNoun
-
-  return (
-    <div className="card mt-[18px]">
-      <div
-        className="cardhead gap-0 overflow-x-auto py-0 [scrollbar-width:none] desktop:overflow-x-visible [&::-webkit-scrollbar]:hidden"
-        role="tablist"
-        aria-label="Bot platform"
-      >
-        {BOT_PLATFORM_TABS.map((item) => {
-          const selected = item.key === platformTabKey
-          return (
-            <button
-              key={item.key}
-              type="button"
-              role="tab"
-              aria-selected={selected}
-              className={`${selected ? 'tab on' : 'tab'} mr-[5px] flex items-center gap-[5px] whitespace-nowrap last:mr-0 desktop:mr-[22px] desktop:gap-[6px]`}
-              onClick={() => {
-                setPlatformTabKey(item.key)
-                setOpenBotId(null)
-              }}
-            >
-              <span className="flex h-[14px] w-[14px] flex-none items-center justify-center">
-                <PlatformMark platform={item.platform} fillPct={100} />
-              </span>
-              {item.label}
-            </button>
-          )
-        })}
-      </div>
-      {/* gap must match the data rows' or the narrow tracks drift out of line. */}
-      <div className={`row h ${BOT_GRID} gap-[11px]`}>
-        {/* `.row.h` uppercases, so the module's lower-case noun renders as the
-            heading did when the host picked between two literals. */}
-        <span>{noun}</span>
-        <span>Sharable</span>
-        <span>Agents</span>
-        <span className="whitespace-nowrap max-[479px]:hidden">Created by</span>
-        <span />
-      </div>
-      {/* Keyed by platform id: switching tabs REMOUNTS the module's card state,
-          which is the only way the fragments' hooks keep a stable identity when
-          the active module changes. Non-lifecycle platforms get `PassThrough`, so
-          the key is inert for them. */}
-      <CardProvider key={platformTab.platform}>
-        {rosterRows.map((row) => {
-          if (row.kind === 'workspace') {
-            return (
-              <div
-                key={row.key}
-                className="flex items-center gap-2 border-b border-(--border-subtle) bg-(--surface-sunken) px-4 py-2"
-              >
-                <span className="font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
-                  Workspace
-                </span>
-                <span className="mono min-w-0 truncate text-[12px] text-(--text-secondary)">{row.label}</span>
-              </div>
-            )
-          }
-          const b = row.bot
-          const free = b.agentIds.length === 0
-          const open = openBotId === b.id
-          const channels = open ? botChannels(b, integrations) : []
-          const hasChannelRows = channels.some((c) => c.kind === 'channel')
-          const showDefaultDispatch = b.shareable && hasChannelRows
-          const chanGrid = showDefaultDispatch ? 'grid-cols-[1fr_auto]' : 'grid-cols-[1fr]'
-          // The picker's choices: every agent installed on the bot.
-          const agentOptions = b.agentIds.map((id) => {
-            const ag = getAgent(id)
-            return {
-              id,
-              name: ag ? agentLabel(ag) : id,
-              model: ag?.model || ag?.runtime || '',
-              runtime: ag?.runtime || ag?.model || '',
-              icon: ag?.icon
-            }
-          })
-          return (
-            <Fragment key={b.id}>
-              <div
-                id={`settings-bot-${b.id}`}
-                className={`row click ${BOT_GRID} items-center gap-[11px]`}
-                onClick={() => setOpenBotId(open ? null : b.id)}
-              >
-                <div className="flex min-w-0 items-center gap-[10px]">
-                  <Icon
-                    name="chevron-right"
-                    size={14}
-                    className={`flex-none text-(--text-tertiary) transition-transform ${open ? 'rotate-90' : ''}`}
-                  />
-                  <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
-                    <span className="flex h-[14px] w-[14px] items-center justify-center">
-                      <PlatformMark platform={b.platform} fillPct={100} />
-                    </span>
-                  </span>
-                  <span className="mono min-w-0 flex-1 truncate text-[12.5px]">{b.name}</span>
-                  {b.prebuilt && <span className="badge bg-(--surface-active) text-(--text-tertiary)">builtin</span>}
-                  {/* Workspace uninstalled the app / revoked its tokens (rc/bot-revoked):
-                    the credential is dead until a re-install refreshes it. The
-                    sentence is the module's (§10 `settingsFragments.copy`) — only
-                    Slack can name the lifecycle event that put the bot here. */}
-                  {b.revokedAt && (
-                    <span className="badge bg-(--status-error-soft) text-(--danger)" title={rowCopy.revokedHint}>
-                      revoked
-                    </span>
-                  )}
-                  {RowBadges && <RowBadges bot={b} />}
-                </div>
-                {/* The host picks the arm by transport; the module owns both
-                    sentences. A platform that declares none gets one sentence for
-                    both arms — its transport is not why sharing is unavailable.
-                    Enablement asks the same question the CP does
-                    (`botSharingEditable`): transport ALONE left Feishu's HTTP bots
-                    with a live toggle for a capability the server refuses. */}
-                <span
-                  className="flex items-center justify-self-start"
-                  title={
-                    (b.transport ?? 'socket') === 'socket' ? rowCopy.shareHint.unavailable : rowCopy.shareHint.available
-                  }
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Toggle
-                    checked={b.shareable}
-                    disabled={!canWrite || botBusyId === b.id || !botSharingEditable(b)}
-                    onChange={(next) => void flipShareable(b, next)}
-                  />
-                </span>
-                <div className="flex min-w-0 items-center">
-                  {b.agentIds.length > 0 ? (
-                    b.agentIds.map((id, idx) => {
-                      const ag = getAgent(id)
-                      return (
-                        <Link
-                          key={id}
-                          href={orgPath(`/agents/${encodeURIComponent(id)}?tab=config`)}
-                          aria-label={`Open ${ag ? agentLabel(ag) : id} configuration`}
-                          title={ag ? agentLabel(ag) : id}
-                          className={`av h-[22px] w-[22px] rounded-[6px] no-underline focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) ${
-                            idx > 0 ? '-ml-[6px] shadow-[-1px_0_0_0_var(--surface-card)]' : ''
-                          }`}
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <AgentIconView icon={ag?.icon} runtime={ag?.runtime || ag?.model || ''} size={22} />
-                        </Link>
-                      )
-                    })
-                  ) : (
-                    <span className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                      {botSubline(b)}
-                    </span>
-                  )}
-                </div>
-                <span className="min-w-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary) max-[479px]:hidden">
-                  {b.createdBy ? creatorLabel(b.createdBy, me) : b.prebuilt ? 'AgentConnect' : '—'}
-                </span>
-                {/* The 100px action track: the module's own controls (refresh, provider
-                  deep link) first, then the host's delete. */}
-                <span className="flex items-center justify-end gap-2" onClick={(e) => e.stopPropagation()}>
-                  {RowActions && <RowActions bot={b} canWrite={canWrite} />}
-                  {RowLinks && <RowLinks bot={b} />}
-                  {free && canWrite ? (
-                    <button className="iconbtn h-7 w-7 flex-none" title={`Delete ${noun}`} onClick={() => onDelete(b)}>
-                      <Icon name="trash-2" size={14} />
-                    </button>
-                  ) : !free ? (
-                    <span
-                      title="Uninstall its integration first"
-                      className="flex h-7 w-7 flex-none cursor-not-allowed items-center justify-center opacity-45"
-                    >
-                      <Icon name="trash-2" size={14} />
-                    </span>
-                  ) : (
-                    <span className="h-7 w-7 flex-none" />
-                  )}
-                </span>
-              </div>
-              {botErr?.id === b.id && (
-                <div className="border-b border-(--border-subtle) px-4 py-2 font-sans text-[12px] font-normal leading-normal text-(--status-error)">
-                  {botErr.msg}
-                </div>
-              )}
-              {CardNotice && <CardNotice bot={b} />}
-              {open && (
-                <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 pb-[14px] pl-10 pt-3">
-                  {channels.length > 0 ? (
-                    <>
-                      <div
-                        className={`grid ${chanGrid} gap-[11px] px-3 pb-[7px] font-mono text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)`}
-                      >
-                        <span>Conversation</span>
-                        {showDefaultDispatch && <span className="justify-self-end">Default dispatch</span>}
-                      </div>
-                      <div className="overflow-visible rounded-lg border border-(--border-subtle) bg-(--surface-card)">
-                        {channels.map((c, index) => (
-                          <Fragment key={c.channelId}>
-                            {isDirectConversation(c.kind) && !isDirectConversation(channels[index - 1]?.kind) && (
-                              <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-3 py-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
-                                Direct messages
-                              </div>
-                            )}
-                            <div
-                              className={`grid ${chanGrid} items-center gap-[11px] border-b border-(--border-subtle) px-3 py-2 last:border-b-0`}
-                            >
-                              <span className="mono flex min-w-0 items-center gap-[7px] text-[12px]">
-                                <Icon
-                                  name={c.kind === 'mpim' ? 'users' : c.kind === 'im' ? 'at-sign' : 'hash'}
-                                  size={12}
-                                  color="var(--text-tertiary)"
-                                  className="flex-none"
-                                />
-                                <span className="sr-only">
-                                  {c.kind === 'mpim' ? 'Group DM' : c.kind === 'im' ? 'Direct message' : 'Channel'}
-                                  :{' '}
-                                </span>
-                                <span className="truncate">
-                                  {isDirectConversation(c.kind) ? c.name.replace(/^@+/, '') : c.name}
-                                </span>
-                              </span>
-                              {showDefaultDispatch && c.kind === 'channel' && (
-                                <DefaultDispatchPicker
-                                  options={agentOptions}
-                                  activeId={c.agentId ?? b.agentIds[0] ?? null}
-                                  disabled={!canWrite || !c.integrationId}
-                                  onPick={(agentId) => setChannelAgent(c.integrationId!, c.channelId, agentId)}
-                                />
-                              )}
-                            </div>
-                          </Fragment>
-                        ))}
-                      </div>
-                    </>
-                  ) : (
-                    <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-                      Not in any channel yet — invite the bot to a channel and it shows up here.
-                    </div>
-                  )}
-                </div>
-              )}
-            </Fragment>
-          )
-        })}
-      </CardProvider>
-      {platformBots.length === 0 &&
-        (dataLoading ? (
-          <LoadingState size={22} padding={20} />
-        ) : (
-          <div className="px-4 py-7 text-center">
-            <div className="font-sans text-[13px] font-semibold leading-normal">No {noun}s yet</div>
-            <div className="mt-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-              A {label} {noun} is registered when you add a {label} integration to an agent.
-            </div>
-          </div>
-        ))}
-    </div>
-  )
-}
-
-// ── GitHub App card ─────────────────────────────────────────────────────────
-// The deployment GitHub App powering github-app workspaces (repo picker +
-// credential-free daemon git). Deployment-config opt-in: when the CP has no
-// GITHUB_APP_* env the routes 404 and this card shows the disabled note.
-// Installations are org-level infrastructure (like bots) — every member can
-// see them; installing and syncing are writes (viewers don't get those buttons),
-// while uninstalling the App from an account is owner-only.
-function GithubCard({ canWrite, isOwner }: { canWrite: boolean; isOwner: boolean }) {
-  // Gate the org-scoped fetch on the active org (same hard-refresh race as SlackCard):
-  // before OrgProvider resolves, `orgBase()` throws → the catch would show "not enabled"
-  // even when it IS. Re-fetch once the org resolves / on switch.
-  const { activeOrg } = useOrgs()
-  const [enabled, setEnabled] = useState<boolean | null>(null)
-  const [installs, setInstalls] = useState<GithubInstallationDto[]>([])
-  const [busy, setBusy] = useState(false)
-  const [err, setErr] = useState<string | null>(null)
-  const [uninstalling, setUninstalling] = useState<GithubInstallationDto | null>(null)
-
-  useEffect(() => {
-    if (!activeOrg) return
-    let alive = true
-    setEnabled(null)
-    fetchGithubInstallations()
-      .then(({ enabled, installations }) => {
-        if (!alive) return
-        setEnabled(enabled)
-        setInstalls(installations)
-      })
-      .catch(() => alive && setEnabled(false))
-    return () => {
-      alive = false
-    }
-  }, [activeOrg])
-
-  // The install link mints a ONE-SHOT signed state — fetch fresh per click.
-  const install = async () => {
-    setErr(null)
-    try {
-      const url = await fetchGithubInstallUrl()
-      if (url) window.open(url, '_blank', 'noopener')
-      else setErr('Could not mint an install link.')
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e))
-    }
-  }
-
-  // Refresh the org's claimed installations after GitHub changes or an install
-  // finished in the other tab just now.
-  const sync = async () => {
-    if (busy) return
-    setBusy(true)
-    setErr(null)
-    try {
-      setInstalls(await syncGithubInstallations())
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e))
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  return (
-    <div className="card mt-[18px]">
-      <div className="cardhead justify-between">
-        <span className="cardtitle flex items-center gap-2">
-          <span className="flex h-[15px] w-[15px] items-center justify-center">
-            <GithubMark color="var(--text-primary)" />
-          </span>
-          GitHub
-        </span>
-        {enabled === true && canWrite && (
-          <span className="flex items-center gap-2">
-            <Button variant="ghost" onClick={sync}>
-              <Icon name="refresh-cw" size={13} />
-              {busy ? 'Syncing…' : 'Sync'}
-            </Button>
-            <Button onClick={install}>
-              <Icon name="external-link" size={13} />
-              Install on GitHub
-            </Button>
-          </span>
-        )}
-      </div>
-      {enabled === null && <LoadingState size={22} padding={20} />}
-      {enabled === false && (
-        <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-          Not enabled on this deployment — the control plane has no GitHub App configured.
-        </div>
-      )}
-      {enabled === true && installs.length === 0 && (
-        <div className="px-4 py-7 text-center">
-          <div className="font-sans text-[13px] font-semibold leading-normal">No installations yet</div>
-          <div className="mt-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-            Install the GitHub App on your org to pick private repositories when creating agents — the daemon then
-            clones and pushes with short-lived tokens, no git credentials on the machine.
-          </div>
-        </div>
-      )}
-      {enabled === true &&
-        installs.map((i) => (
-          <Fragment key={i.id}>
-            <div className="row grid-cols-1 gap-2 desktop:grid-cols-[minmax(0,1fr)_auto] desktop:gap-[11px]">
-              <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
-                <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
-                  <span className="flex h-[14px] w-[14px] items-center justify-center">
-                    <GithubMark color="var(--text-primary)" />
-                  </span>
-                </span>
-                <span className="mono min-w-0 truncate text-[12.5px]">{i.accountLogin}</span>
-                <span className="badge bg-(--surface-active) text-(--text-tertiary)">
-                  {i.accountType === 'Organization' ? 'org' : 'user'}
-                </span>
-                {i.suspended && <span className="badge bg-(--status-error-soft) text-(--status-error)">suspended</span>}
-                {i.permissionsStatus === 'outdated' && (
-                  <span className="badge bg-(--status-paused-soft) text-(--amber-500)">needs update</span>
-                )}
-              </div>
-              <span className="flex items-center justify-between gap-3 desktop:justify-end">
-                <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                  {i.repositorySelection === 'all' ? 'all repositories' : 'selected repositories'}
-                </span>
-                {isOwner && (
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    className="text-(--status-error) hover:text-(--status-error)"
-                    onClick={() => setUninstalling(i)}
-                  >
-                    <Icon name="unplug" size={13} />
-                    Uninstall
-                  </Button>
-                )}
-              </span>
-            </div>
-            {i.permissionsStatus === 'outdated' && (
-              <div
-                role="status"
-                className="flex flex-col items-start gap-2 border-b border-(--border-subtle) bg-(--status-paused-soft) px-4 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--amber-500) desktop:flex-row desktop:items-center desktop:justify-between desktop:gap-3"
-              >
-                <span className="flex min-w-0 items-start gap-2">
-                  <Icon name="triangle-alert" size={14} color="var(--amber-500)" className="mt-[2px] flex-none" />
-                  <span>This installation&rsquo;s GitHub permissions need updating before all features will work.</span>
-                </span>
-                <a href={i.settingsUrl} target="_blank" rel="noopener noreferrer" className="lnk flex-none text-[12px]">
-                  Update permissions
-                  <Icon name="external-link" size={12} />
-                </a>
-              </div>
-            )}
-          </Fragment>
-        ))}
-      {err && (
-        <div className="px-4 py-2 font-sans text-[12px] font-normal leading-normal text-(--status-error)">{err}</div>
-      )}
-      {uninstalling && (
-        <div className="scrim" onClick={() => setUninstalling(null)}>
-          <div className="modal" onClick={(e) => e.stopPropagation()}>
-            <UninstallGithubInstallationModal
-              installation={uninstalling}
-              onClose={() => setUninstalling(null)}
-              onUninstalled={(id) => {
-                setInstalls((current) => current.filter((installation) => installation.id !== id))
-                setUninstalling(null)
-              }}
             />
           </div>
         </div>


### PR DESCRIPTION
## What

Two console changes:

**1. Rail regroup.** The nav is now two groups separated by a rule instead of one flat list. `Daemons` moves to the foot on its own; `Integrations` returns to the first group, above Analytics. The mobile More sheet mirrors the same order.

**2. Integrations page.** New top-level `/{slug}/integrations` with two sections — **Messaging apps** (the tabbed durable-bot card) and **Code hosts** (the GitHub installations card).

## Why

Both cards lived at the bottom of Settings, which no-auth deployments cannot reach at all — the shell bounces `/settings` and `/profile` when auth is off, so a self-hosted console had no way to see its own bots or GitHub installations. The new page is reachable in both modes.

Daemons sits alone at the foot because it is infrastructure you visit when something is wrong, not a surface you work in.

## Notes for review

- **The two cards are moved, not copied.** The same org-level infrastructure rendered on two pages would be two sources of truth. `SettingsView` keeps organization, members, and the org-wide policies; it shed ~730 lines. The bulk of `IntegrationsView` is that code verbatim — `git diff` shows it as add/delete, but the only edits to the moved bodies are listed below.
- Bots card gains **per-platform counts** and a **"Show in use"** filter. Counts stay *unfiltered* on purpose, so reading across the tab strip still answers "where does this org have bots" while the filter is on; the filtered-empty state says so rather than reusing the "no bots yet" copy. GitHub card gains an Installation / Repository access header row (desktop only — the row stacks below the breakpoint).
- The agent page's bot chip now deep-links to `/integrations?bot=…`, and `integrations` joins the CP's `RESERVED_SLUGS` (a new top-level page must never be shadowed by an org slug).
- Dropped a `refresh` binding in the moved bots card that was already dead before the move.

### Add integration — one dialog, two arms

Reached from an agent the dialog is **unchanged**: the agent is fixed, `agentChoices` is undefined, and no picker renders. Reached from this page there is no implied agent, so `ModalProvider` renders the new `AddIntegrationForOrgModal`, which owns the selection and passes the roster in — that prop is the only thing that makes the Agent field appear.

The dialog is remounted per agent (`key`), so nothing agent-scoped — watched repos, repository authorizations, the picked bot, a half-finished platform flow — survives a switch. The picker lists only agents the viewer can edit, since creating an integration writes the agent's spec.

## Verification

`tsc`, `eslint`, `prettier`, 887 web tests, and the CP typecheck all pass. Checked in the browser (mock mode): light and dark, desktop and 375px, the collapsed rail's separator, the agent-picker dropdown and agent switching, and that the agent-page dialog still opens straight to "Platform" with its original subline.

Unrelated local snag worth flagging: a stale `packages/protocol/dist` (missing `slack-app-manifest.js`) 500s the web dev server — it reproduces on unmodified `main`, and `pnpm --filter @agentconnect.md/protocol build` clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)