### PR TITLE
fix(protocol): keep the slack-app-manifest subpath bundler-resolvable

### DIFF
--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -420,10 +420,9 @@ export const SHARED_CONFIG_ACTION_ID = 'ac_shared_channel_config'
  *  use that id for the legacy 👤 button + modal flow. */
 export const SHARED_AGENT_SELECT_ACTION_ID = 'ac_shared_agent_select'
 
-/** App-level Slack message shortcut for opening the controls of the session that
- * owns the selected message's conversation. Direct apps receive it over Socket
- * Mode; shared apps receive the same callback through the relay HTTP edge. */
-export const SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID = 'ac_manage_session'
+// `SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID` is declared in the app manifest, so
+// it lives in `../slack-app-manifest.ts` and is re-exported from the package root
+// alongside the ids below. See that file for why it cannot import back into here.
 
 /** Slack action ids shared by the daemon-owned status modal and the relay-owned
  *  HTTP interaction edge. Dedicated bots handle them in the daemon directly; shared bots

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -84,6 +84,10 @@ export type { DecodeResult, BuildOpts, InboundControlExt } from './codec.js'
 
 // ── relay wires (separate frame unions; shared-bot-relay.md §7/§8) ──
 export * from './frames/relay-cp.js'
+// Manifest-declared Slack shortcut id — defined in the bundler-facing
+// `./slack-app-manifest.ts` leaf, re-exported here so the package root keeps
+// serving it next to the runtime Slack action ids above.
+export { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from './slack-app-manifest.js'
 export * from './frames/relay-daemon.js'
 export { decodeEnvelopeWith, buildEnvelopeRaw } from './wire.js'
 export type { DecodeResultOf } from './wire.js'

--- a/packages/protocol/src/slack-app-manifest.leaf.test.ts
+++ b/packages/protocol/src/slack-app-manifest.leaf.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `./slack-app-manifest` is the only protocol subpath a *bundler* compiles from
+ * source: the web console value-imports it, and in dev the `development` export
+ * condition resolves it to `src/slack-app-manifest.ts` instead of `dist/`.
+ *
+ * Turbopack does not implement TypeScript's `.js` → `.ts` extension substitution,
+ * and Next lists its webpack escape hatch (`experimental.extensionAlias`) as
+ * Turbopack-unsupported. So a single NodeNext-style `./foo.js` specifier reachable
+ * from that entry point breaks `next dev` for every console route — while
+ * `pnpm typecheck`, `pnpm test`, and `next build` (which reads `dist/`) all stay
+ * green, because none of them run Turbopack against this source.
+ *
+ * Keeping the entry point free of relative imports is what makes it bundler-safe.
+ * If you need to share something with it, define it there and import *from* it.
+ */
+describe('slack-app-manifest is bundler-safe', () => {
+  const read = (path: string) => readFileSync(new URL(path, import.meta.url), 'utf8')
+
+  it('is still the file the development export condition points at', () => {
+    const pkg = JSON.parse(read('../package.json'))
+    expect(pkg.exports['./slack-app-manifest'].development).toBe('./src/slack-app-manifest.ts')
+  })
+
+  it('has no relative imports for a bundler to resolve', () => {
+    // `from './x'` / `from '../x'`, plus dynamic `import('./x')`.
+    const source = read('./slack-app-manifest.ts')
+    const relative = [...source.matchAll(/(?:\bfrom|\bimport)\s*\(?\s*['"](\.[^'"]*)['"]/g)].map((m) => m[1])
+    expect(relative).toEqual([])
+  })
+})

--- a/packages/protocol/src/slack-app-manifest.ts
+++ b/packages/protocol/src/slack-app-manifest.ts
@@ -1,6 +1,26 @@
-import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from './frames/relay-cp.js'
+// ⚠️ THIS MODULE MUST NOT IMPORT ANYTHING RELATIVE. ⚠️
+//
+// It is the one protocol source file a *bundler* compiles directly: the web
+// console imports `@agentconnect.md/protocol/slack-app-manifest`, and in dev the
+// `development` export condition points that subpath at this `.ts` file rather
+// than at `dist/`. Turbopack does not implement TypeScript's `.js` → `.ts`
+// extension substitution, and its only escape hatch (`experimental.extensionAlias`)
+// is on Next's Turbopack-unsupported list — so a NodeNext-style `./foo.js`
+// specifier here fails to resolve and 500s every console route, while
+// `pnpm typecheck` / `pnpm test` / `next build` (which reads `dist/`) all stay
+// green. `slack-app-manifest.leaf.test.ts` enforces this.
+//
+// Anything this module needs is defined here and imported *from* here by the rest
+// of protocol — not the other way around.
 
-export { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID }
+/** App-level Slack message shortcut for opening the controls of the session that
+ * owns the selected message's conversation. Direct apps receive it over Socket
+ * Mode; shared apps receive the same callback through the relay HTTP edge.
+ *
+ * Declared to Slack by {@link buildSlackAppManifest} below, which is why it lives
+ * here rather than beside the runtime Block Kit action ids in `frames/relay-cp.ts`:
+ * those name controls on messages we post, this one names a manifest feature. */
+export const SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID = 'ac_manage_session'
 
 /** Public platform profile copy. Never derive this from an Agent description. */
 export const PLATFORM_APP_DESCRIPTION = 'AI agent powered by AgentConnect.'


### PR DESCRIPTION
## Problem

`pnpm --filter @agentconnect.md/web dev` fails to compile the console. Every route under `packages/web/src/app/(app)/` returns 500:

```
./packages/protocol/src/slack-app-manifest.ts:1:1
Module not found: Can't resolve './frames/relay-cp.js'
```

The web console value-imports `@agentconnect.md/protocol/slack-app-manifest` (its **only** value import of protocol — everything else is comments or erased types). In dev the `development` export condition resolves that subpath to `src/slack-app-manifest.ts` rather than `dist/`, so Turbopack compiles protocol source directly and hits the NodeNext `.js` specifier on line 1.

## Why not a Turbopack setting

Turbopack in Next 16.2.11 does not implement TypeScript's `.js` → `.ts` extension substitution at all. Verified by probe: a `./x.js` import of a `./x.ts` file fails the same way **inside `packages/web/src`**, so this is not a pnpm-symlink effect and not a `"type": "module"` effect. Next also lists the webpack escape hatch `experimental.extensionAlias` in its Turbopack-unsupported config list (`next/dist/lib/turbopack-warning.js`).

So no `next.config.mjs` setting fixes this. Dropping the `development` condition would work but forces a protocol rebuild before every web dev run — exactly what that condition exists to avoid.

## Fix

Make the one bundler-facing entry point a leaf. `SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID` moves out of `frames/relay-cp.ts` into `slack-app-manifest.ts`, which now has **no relative imports at all**.

The constant belongs there on the merits: it is the `callback_id` the manifest declares to Slack, unlike the Block Kit action ids beside it, which name controls on messages we post. The package root re-exports it explicitly, so the public surface is unchanged for daemon, relay, and CP.

Side benefit: the console no longer drags the whole zod frame graph (`relay-cp` → `envelope` → `error` → `integration` → …) into its client bundle for a manifest builder.

## Guard

`slack-app-manifest.leaf.test.ts` asserts the entry point has no relative imports, and that the `development` condition still points at it.

This matters because **nothing else catches this class of breakage** — `pnpm typecheck`, `pnpm test`, and `next build` (which reads `dist/`) all pass today while dev is broken. Verified the guard fails on the exact regression:

```
AssertionError: expected [ './frames/relay-cp.js' ] to deeply equal []
```

## Verification

Ran the dev server and loaded console routes, not just typecheck:

- `/`, `/agents`, `/settings` → **200** (previously 500); Integrations page renders the Slack settings fragment, and the Add-integration modal — the exact broken chain — opens with the Slack module loaded.
- Clean `next build` from a wiped `.next` (prod path reads `dist/`, unaffected either way).
- Repo-wide `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean.
- Suites: protocol 283, web 885, relay 447, control-plane unit 1258 — all pass.
- Daemon: 2 failures (`acp-matrix` live-runtime test, and a 5s-timeout flake in `daemon-agent-mention-routing`) — both reproduce identically on a pristine tree, so they are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)