### PR TITLE
chore(web): stop tracking the generated next-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,11 @@ deployment-config.json
 # Next.js build output
 .next
 out
+# Generated from `distDir`, so `next dev` (.next/dev) and `next build` (.next)
+# each rewrite it over the other's version — tracking it dirties the tree on
+# every switch. Both commands regenerate it, and CI's web typecheck runs through
+# `next build`, so nothing depends on a committed copy. Matches create-next-app.
+next-env.d.ts
 
 # Nuxt.js build / generate output
 .nuxt

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Problem

`packages/web/next-env.d.ts` is generated by Next from `distDir`, so the two commands write *different* content:

| command | line it writes |
| --- | --- |
| `next dev` | `import "./.next/dev/types/routes.d.ts";` |
| `next build` | `import "./.next/types/routes.d.ts";` |

Because it is tracked, every switch between dev and build dirties the working tree with a change nobody authored. You either commit build output or revert it by hand before each commit. (`next/dist/lib/typescript/writeAppTypeDeclarations.js` derives the path straight from `distDir` — this is deterministic, not a fluke.)

## Nothing depends on the committed copy

- **Both commands regenerate it.** Deleted the file and ran `next build`: it came back **byte-identical** to what was tracked.
- **CI never runs `tsc` against web.** `typecheck:ci` filters to control-plane / daemon / setup, and the Check job's own comment says "The tsc and Next builds already typecheck their packages". Web is covered by `next build` in the Build job, which regenerates the file first.
- **`tsc --noEmit` passes** on a tree with neither `next-env.d.ts` nor `.next` present.

## Convention

The file says `// NOTE: This file should not be edited`, and every `create-next-app` template ignores it in the same block we already have:

```
# typescript
*.tsbuildinfo
next-env.d.ts
```

So this brings us in line with upstream rather than inventing a local rule. I put it under our existing `# Next.js build output` section next to `.next`, with a comment recording why.

## Caveat

On a genuinely fresh clone, before anyone runs dev or build, web's `tsc` runs without the `routes.d.ts` import, so route typing is weaker for that one run. Small here: `strictRouteTypes` is off (the generated file carries no `cache-life` / `validator` / `link` imports), there are no static image imports in `packages/web/src` needing `next/image-types/global`, and the first `pnpm dev` or `pnpm build` restores it.

## Verification

- Ran `next dev` → file flips to `.next/dev/...` and **`git status` stays clean**. That is the papercut this removes.
- Clean `next build` from a wiped `.next` → file returns to `.next/...`, build succeeds, tree still clean.
- `pnpm --filter @agentconnect.md/web typecheck`, `pnpm lint`, `pnpm format:check` all pass.
- Console routes `/`, `/agents`, `/settings` all 200 against the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)