### PR TITLE
fix(web): drop magenta from agent transcript bubble tones

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -124,7 +124,8 @@ type ComposerMenuKey = 'permission' | 'model' | 'effort' | 'addAgent'
 // used as a background, which is what lets one hex read correctly in both themes and
 // makes a new hue cost one array entry instead of a second colour table. The `var()`
 // fallback matters — an invalid var() inside color-mix drops the whole declaration,
-// so a turn with no accent gets a brand-tinted bubble, never an invisible one.
+// so a turn with no accent gets an indigo-tinted bubble, never an invisible one
+// (not --brand: magenta's tint reads as a warning/error banner, see agent-tone.ts).
 // AGENT_NAME pulls that accent 62% toward the text colour: gold or green at full
 // strength fails contrast on the light surface.
 // SELF_BUBBLE is the reader's own, deliberately neutral, tail corner mirrored.
@@ -133,9 +134,9 @@ type ComposerMenuKey = 'permission' | 'model' | 'effort' | 'addAgent'
 // stops a long agent bubble short of where the reader's own avatar sits, so the two
 // columns of bubbles share one right edge instead of the bot side running under it.
 const AGENT_BUBBLE =
-  'w-fit max-w-[calc(100%-35px)] rounded-[12px_12px_12px_4px] border px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary) border-[color:color-mix(in_oklab,var(--agent-accent,var(--brand))_var(--bubble-edge),var(--surface-card))] bg-[color:color-mix(in_oklab,var(--agent-accent,var(--brand))_var(--bubble-tint),var(--surface-card))]'
+  'w-fit max-w-[calc(100%-35px)] rounded-[12px_12px_12px_4px] border px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary) border-[color:color-mix(in_oklab,var(--agent-accent,var(--indigo-500))_var(--bubble-edge),var(--surface-card))] bg-[color:color-mix(in_oklab,var(--agent-accent,var(--indigo-500))_var(--bubble-tint),var(--surface-card))]'
 const AGENT_NAME =
-  'font-sans text-[13px] font-semibold leading-normal text-[color:color-mix(in_oklab,var(--agent-accent,var(--brand))_62%,var(--text-primary))]'
+  'font-sans text-[13px] font-semibold leading-normal text-[color:color-mix(in_oklab,var(--agent-accent,var(--indigo-500))_62%,var(--text-primary))]'
 const SELF_BUBBLE =
   'max-w-full rounded-[12px_12px_4px_12px] border border-(--bubble-self-edge) bg-(--bubble-self) px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary)'
 

--- a/packages/web/src/lib/agent-tone.ts
+++ b/packages/web/src/lib/agent-tone.ts
@@ -10,10 +10,10 @@
 // a second table.
 
 /** Design-system hues, spaced far enough apart to be told apart at a 7% tint.
- * Deliberately no warm hues: gold and coral tinted a bubble into something that
- * read as a warning/error banner rather than as an agent's colour. */
+ * Deliberately no warm hues: gold, coral, and magenta tinted a bubble into
+ * something that read as a warning/error banner rather than as an agent's
+ * colour (magenta's 7% tint is a pale pink indistinguishable from --red-50). */
 const AGENT_TONES = [
-  'var(--magenta-500)',
   'var(--purple-500)',
   'var(--indigo-500)',
   'var(--blue-500)',


### PR DESCRIPTION
## What

- Remove `--magenta-500` from the agent transcript tone palette (`lib/agent-tone.ts`), leaving five cool hues: purple / indigo / blue / teal / green.
- Switch the `color-mix` no-accent fallback in `SessionDetailView`'s `AGENT_BUBBLE` / `AGENT_NAME` from `var(--brand)` (also magenta) to `var(--indigo-500)`.

## Why

Agents whose id hashed to magenta got a bubble that reads as a warning/error banner: magenta-500 mixed at the 7% `--bubble-tint` produces a pale pink almost identical to `--red-50` (verified against the live CSS variables: oklab a-axis +0.014 vs red-50's +0.012), and the 62%-mixed name label lands on a dark maroon. The palette comment already excluded gold and coral for exactly this reason — magenta belongs on that list too.

## Notes for review

- Existing agents keyed into magenta will deterministically re-hash to one of the five remaining tones (the color was never persisted, so nothing migrates).
- `agent-tone.test.ts` passes unchanged — its spread assertion is driven by `AGENT_TONE_COUNT`.
- The fallback change is belt-and-braces: `--agent-accent` is always set per turn in this view, but any accent-less path now tints indigo instead of brand pink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)