### PR TITLE
fix(web): adapt getting-started checklist to local-mode deployments

### DIFF
--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -17,7 +17,15 @@ import { usePathname } from 'next/navigation'
 import { useConsoleData } from '@/lib/data-context'
 import { isAuthConfigured } from '@/lib/auth'
 import { computeGettingStarted, type GsAction } from '@/lib/getting-started'
-import { AddToSlackRow, GsRows, MeetYourAgents, useGithubProfileLinked, useGsActions } from './GettingStartedChecklist'
+import {
+  AddToSlackRow,
+  GsRows,
+  MeetYourAgents,
+  useGithubAppEnabled,
+  useGithubProfileLinked,
+  useGsActions,
+  useSlackPlatformAppAvailable
+} from './GettingStartedChecklist'
 import { Button, Icon } from '@/components/ui'
 
 // A r=10.5 progress ring (viewBox 0 0 26 26), rotated so it fills clockwise from 12
@@ -82,6 +90,10 @@ export default function GettingStarted() {
   }, [])
 
   const githubLinked = useGithubProfileLinked()
+  const githubEnabled = useGithubAppEnabled()
+  // Local mode (no platform-published Slack app): the slack row falls back to the
+  // default GsRow, whose CTA opens the Slack integration wizard.
+  const slackOneClick = useSlackPlatformAppAvailable()
   const gs = useMemo(
     () =>
       computeGettingStarted({
@@ -92,9 +104,10 @@ export default function GettingStarted() {
         members,
         authOn,
         orgHasSessions,
-        githubLinked
+        githubLinked,
+        githubEnabled
       }),
-    [agents, daemons, integrations, allSessions, members, authOn, orgHasSessions, githubLinked]
+    [agents, daemons, integrations, allSessions, members, authOn, orgHasSessions, githubLinked, githubEnabled]
   )
 
   // Show on every console page while the checklist is incomplete — including a
@@ -219,7 +232,7 @@ export default function GettingStarted() {
                       toggle={ctx.toggle}
                       onConnect={() => runFromDrawer(it.action)}
                     />
-                  ) : it.key === 'slack' ? (
+                  ) : it.key === 'slack' && slackOneClick ? (
                     <AddToSlackRow
                       done={it.done}
                       open={ctx.open}

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -19,9 +19,11 @@ import { useModal } from './ModalProvider'
 import type { GsAction, GsItem } from '@/lib/getting-started'
 import { agentIsPlaced, agentLabel, modelLabel, runtimeLabel } from '@/lib/data'
 import { isAuthConfigured } from '@/lib/auth'
-import { fetchMySocialAccount } from '@/lib/api'
+import { fetchGithubInstallations, fetchMySocialAccount } from '@/lib/api'
+import { consoleKeys } from '@/lib/swr-keys'
 import { socialLoginProviders } from '@/lib/social-login-providers'
 import { useSlackPlatformInstall } from '@/components/console/platforms/slack/use-platform-install'
+import { useDeploymentConfig } from '@/components/console/platforms/deployment-config'
 import { Button, Icon } from '@/components/ui'
 import { PlatformMark } from '@/components/marks'
 
@@ -89,6 +91,30 @@ export function useGithubProfileLinked(): boolean | undefined {
   })
   if (!data) return undefined
   return data.identities.some((i) => i.target === 'github')
+}
+
+// Backs hiding the "Connect GitHub" step: whether this deployment's GitHub App
+// provider is configured at all (the installations list doubles as the enabled
+// probe — 404 ⇒ off). Undefined while loading or on error, and
+// computeGettingStarted keeps the step for that value.
+export function useGithubAppEnabled(): boolean | undefined {
+  const { activeOrg } = useOrgs()
+  const { data } = useSWR(
+    consoleKeys.githubApp(activeOrg?.id),
+    () => fetchGithubInstallations().then((r) => r.enabled),
+    { revalidateOnFocus: false, revalidateOnReconnect: false, shouldRetryOnError: false }
+  )
+  return data
+}
+
+// Whether the platform-published one-click "Add to Slack" app is installable on
+// this deployment. Local/self-hosted mode has no published app — the checklist
+// then renders the plain "Connect Slack" row, whose CTA opens the Slack
+// integration wizard instead. An unanswered probe keeps the one-click UI (the
+// hosted default); only a definitive false / failed probe switches to manual.
+export function useSlackPlatformAppAvailable(): boolean {
+  const probe = useDeploymentConfig(true)
+  return probe.config ? probe.config.platformInstallAvailable === true : !probe.failed
 }
 
 // The checklist item rows. `runAction` is supplied by the caller so each surface can

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -60,6 +60,8 @@ vi.mock('@/lib/daemon-commands', () => ({ daemonCommands: (command: string) => (
 vi.mock('@/components/console/GettingStartedChecklist', () => ({
   useGsActions: () => ({ runAction: vi.fn(), firstAgent: mocks.agents[0] }),
   useGithubProfileLinked: () => undefined,
+  useGithubAppEnabled: () => undefined,
+  useSlackPlatformAppAvailable: () => true,
   GsRows: () => <div>rows</div>
 }))
 vi.mock('@/components/marks', () => ({

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -14,8 +14,10 @@ import {
   AddToSlackRow,
   GsRows,
   MeetYourAgents,
+  useGithubAppEnabled,
   useGithubProfileLinked,
-  useGsActions
+  useGsActions,
+  useSlackPlatformAppAvailable
 } from '@/components/console/GettingStartedChecklist'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
 import {
@@ -67,6 +69,10 @@ export default function OnboardingView() {
   const { orgPath } = useOrgs()
   const { runAction } = useGsActions()
   const githubLinked = useGithubProfileLinked()
+  const githubEnabled = useGithubAppEnabled()
+  // Local mode (no platform-published Slack app): the slack row falls back to the
+  // default GsRow, whose CTA opens the Slack integration wizard.
+  const slackOneClick = useSlackPlatformAppAvailable()
   const orgKey = typeof params.slug === 'string' ? params.slug : '-'
   const authOn = isAuthConfigured()
 
@@ -241,8 +247,10 @@ export default function OnboardingView() {
             members,
             authOn,
             orgHasSessions,
-            githubLinked
+            githubLinked,
+            githubEnabled
           })}
+          slackOneClick={slackOneClick}
           runAction={runAction}
           onFinish={goConsole}
         />
@@ -502,10 +510,12 @@ function ConfigureAgent({
 // --- Phase 2: daemon online → the same checklist the console shows -------------------
 function RevealChecklist({
   gs,
+  slackOneClick,
   runAction,
   onFinish
 }: {
   gs: ReturnType<typeof computeGettingStarted>
+  slackOneClick: boolean
   runAction: (action: import('@/lib/getting-started').GsAction) => void
   onFinish: () => void
 }) {
@@ -555,7 +565,7 @@ function RevealChecklist({
                   toggle={ctx.toggle}
                   onConnect={() => runAction(it.action)}
                 />
-              ) : it.key === 'slack' ? (
+              ) : it.key === 'slack' && slackOneClick ? (
                 <AddToSlackRow
                   done={it.done}
                   open={ctx.open}

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -134,6 +134,16 @@ describe('computeGettingStarted', () => {
     expect(keys.indexOf('github-profile')).toBe(keys.indexOf('github') + 1)
   })
 
+  it('hides both GitHub steps when the deployment has no GitHub App provider', () => {
+    const keys = (githubEnabled?: boolean, githubLinked?: boolean) =>
+      computeGettingStarted({ ...empty, githubEnabled, githubLinked }).items.map((i) => i.key)
+    expect(keys(false)).not.toContain('github')
+    expect(keys(false, false)).not.toContain('github-profile')
+    // undefined (probe in flight / failed) keeps the step — the hosted default
+    expect(keys(undefined)).toContain('github')
+    expect(keys(true)).toContain('github')
+  })
+
   it('reaches allDone with a full ring when every signal is satisfied', () => {
     const gs = computeGettingStarted({
       agents: [agent({ workspace: { mode: 'github', repo: 'acme/x' } as Agent['workspace'], hookKinds: ['github'] })],

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -70,8 +70,13 @@ export function computeGettingStarted(input: {
    *  ⇒ unknowable or not applicable (auth off, no GitHub connector, account still
    *  loading): the step is omitted rather than shown un-tickable. */
   githubLinked?: boolean
+  /** Whether this deployment's GitHub App provider is configured (GITHUB_APP_* env —
+   *  the installations probe 404s otherwise). False ⇒ the GitHub steps are hidden:
+   *  there is nothing to install. Undefined (probe in flight / failed) keeps them. */
+  githubEnabled?: boolean
 }): GettingStarted {
-  const { agents, daemons, integrations, sessions, members, authOn, orgHasSessions, githubLinked } = input
+  const { agents, daemons, integrations, sessions, members, authOn, orgHasSessions, githubLinked, githubEnabled } =
+    input
   // Pick a chat-capable / bindable agent for the agent-scoped CTAs. Prefer the built-in
   // `agentconnect` preset — the canonical agent every org gets — else the first agent.
   const builtin = agents.find((a) => a.builtin)
@@ -109,31 +114,38 @@ export function computeGettingStarted(input: {
       ctaLabel: 'Connect Slack',
       action: { kind: 'slack', agentId: firstAgent }
     },
-    {
-      key: 'github',
-      label: 'Connect GitHub and assign a repository',
-      expl: 'Install the GitHub App, then point an agent at a repo, branch and working directory so it has code to work in.',
-      done: agents.some((a) => a.workspace?.mode === 'github'),
-      ctaLabel: 'Connect GitHub',
-      action: { kind: 'github', agentId: firstAgent }
-    },
-    // The App install above is org-level; SEEING private repositories is per-user
-    // (repo probes act as the caller — GITHUB_IDENTITY_REQUIRED otherwise). Only a
-    // member signed in WITHOUT GitHub (Google/Slack — no GitHub identity on the
-    // profile) gets this step; GitHub sign-ins are born linked, and for them the
-    // row would be permanent done-noise. Also omitted when unknowable
-    // (see `githubLinked`).
-    ...(githubLinked !== false
+    // Both GitHub steps vanish when the deployment has no GitHub App provider at
+    // all (`githubEnabled === false`) — installing and profile-linking are dead
+    // ends without it.
+    ...(githubEnabled === false
       ? []
       : [
           {
-            key: 'github-profile',
-            label: 'Link your GitHub profile',
-            expl: 'You signed in without GitHub. Link it to your profile so repository pickers and access checks act as you — private repositories included.',
-            done: false,
-            ctaLabel: 'Link GitHub profile',
-            action: { kind: 'github-profile' } as const
-          }
+            key: 'github',
+            label: 'Connect GitHub and assign a repository',
+            expl: 'Install the GitHub App, then point an agent at a repo, branch and working directory so it has code to work in.',
+            done: agents.some((a) => a.workspace?.mode === 'github'),
+            ctaLabel: 'Connect GitHub',
+            action: { kind: 'github', agentId: firstAgent } as const
+          },
+          // The App install above is org-level; SEEING private repositories is per-user
+          // (repo probes act as the caller — GITHUB_IDENTITY_REQUIRED otherwise). Only a
+          // member signed in WITHOUT GitHub (Google/Slack — no GitHub identity on the
+          // profile) gets this step; GitHub sign-ins are born linked, and for them the
+          // row would be permanent done-noise. Also omitted when unknowable
+          // (see `githubLinked`).
+          ...(githubLinked !== false
+            ? []
+            : [
+                {
+                  key: 'github-profile',
+                  label: 'Link your GitHub profile',
+                  expl: 'You signed in without GitHub. Link it to your profile so repository pickers and access checks act as you — private repositories included.',
+                  done: false,
+                  ctaLabel: 'Link GitHub profile',
+                  action: { kind: 'github-profile' } as const
+                }
+              ])
         ]),
     {
       key: 'conversation',

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -24,6 +24,8 @@ export const consoleKeys = {
    *  Slack-NAMED but answered per organization AND per caller, so it is
    *  org-scoped like every other row here. */
   deploymentConfig: (orgId: string | null | undefined) => consoleKey(orgId, 'deployment-config'),
+  /** The deployment GitHub App enabled-probe (`GET /github/installations`, 404 ⇒ off). */
+  githubApp: (orgId: string | null | undefined) => consoleKey(orgId, 'github-app'),
   connectorsConfig: (orgId: string | null | undefined) => consoleKey(orgId, 'connectors-config'),
   memoryPluginInstallations: (orgId: string | null | undefined) => consoleKey(orgId, 'memory-plugin-installations'),
   externalMemoryConnections: (orgId: string | null | undefined) => consoleKey(orgId, 'external-memory-connections'),


### PR DESCRIPTION
## What changed

Two local-mode fixes for the getting-started checklist (console pill/drawer) and the onboarding reveal, which render the same checklist:

- **"Add to Slack" → Slack integration wizard in local mode.** The one-click `AddToSlackRow` (platform-published built-in bot) is now rendered only when the deployment actually has that app (`platformInstallAvailable` from `GET /slack/config`, shared SWR probe with the install wizard). On local/self-hosted deployments the slack step falls back to the default row, whose "Connect Slack" CTA opens the Slack integration modal — instead of a one-click button that can only fail there.
- **Hide "Connect GitHub" when the GitHub provider isn't configured.** `computeGettingStarted` takes a new `githubEnabled` input, backed by a new `useGithubAppEnabled()` probe (`GET /github/installations` — 404s when the CP has no `GITHUB_APP_*` env, mapped to `enabled: false`). When `false`, both the "Connect GitHub and assign a repository" step and the dependent "Link your GitHub profile" step are omitted; the progress count shrinks accordingly.

## Why

Running the stack in local mode left the checklist with two dead-end steps: a one-click "Add to Slack" that requires a platform-published Slack app the deployment doesn't have, and a "Connect GitHub" step with no GitHub App provider behind it.

## Notes for review

- Both probes default to today's UI while unanswered (`undefined` / in-flight), so hosted deployments never flash: only a definitive `false` (or a failed slack probe) switches behavior.
- No backend changes — both signals are existing endpoints (`platformInstallAvailable` is the same flag `AddIntegrationModal` already keys the one-click flow on; the installations list is the documented enabled-probe).
- Tests: new `computeGettingStarted` case for `githubEnabled: false`; the OnboardingView test mock gained the two new hooks. `pnpm --filter @agentconnect.md/web test` (886 passed), typecheck and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)