### PR TITLE
feat(cp): destroy an organization's transit key when it is deleted

### DIFF
--- a/docs/designs/per-org-secret-encryption.md
+++ b/docs/designs/per-org-secret-encryption.md
@@ -1,6 +1,12 @@
 # Per-Org Secret Encryption and Crypto-Shredding
 
-> Status: Proposed. Extends
+> Status: Implemented. `SecretCipher` carries a scope, org keys derive from the
+> deployment key, organization deletion records a shred intent, and
+> `secrets/shred-cli.ts` drains it. What remains is operational: granting the
+> Vault policies of §6 and running the §7 rewrap sweep per environment, without
+> which the shred guarantee is not yet true.
+>
+> Extends
 > [`secret-store-seams.md`](./secret-store-seams.md), which established the
 > single `SecretCipher` seam and the Vault Transit implementation. This document
 > adds a **scope** to that seam so each organization's secrets are encrypted
@@ -336,7 +342,9 @@ The order is therefore:
 1. Deploy. New writes seal under org keys; legacy values keep reading.
 2. Run the rewrap sweep (`secrets/rewrap.ts`) per environment. It resolves each
    row's scope and re-seals under the correct key.
-3. Only then is per-organization shredding a claim that holds.
+3. Only then is per-organization shredding a claim that holds. Until step 2
+   completes, deleting an organization destroys a key that some of its values
+   were never sealed under — the deletion is real, the guarantee is partial.
 
 **Known rolling-update window — accepted, and only safe pre-release.** The
 envelope tag is new, so a binary from before this change does not recognize it:

--- a/docs/designs/per-org-secret-encryption.md
+++ b/docs/designs/per-org-secret-encryption.md
@@ -280,8 +280,16 @@ connected daemon.
 **The CP records the intent; it never deletes a key.** Deleting a Vault key is a
 remote effect that cannot join the deletion transaction, so that transaction
 writes a tombstone instead: one `pending_key_shred` row keyed by the deleted
-organization's id, with the time it was recorded. The row has no foreign key —
-its whole purpose is to outlive the organization.
+organization's id. The row has no foreign key — its whole purpose is to outlive
+the organization.
+
+It stores the **resolved target**, not just the id: the transit mount and the
+full key name as configured at the moment of deletion. Deriving the name at
+drain time instead would read whatever configuration is current then, so
+rotating the mount or the org key prefix in between would aim the destroy at a
+name that does not exist — which the shredder reads as "already destroyed",
+clears the row, and leaves the real key alive forever. Pinning makes each
+tombstone self-describing and immune to later configuration changes.
 A separate operator-run entry point (`secrets/shred-cli.ts`, mirroring the
 existing rewrap CLI) drains the table: for each row it destroys
 `<orgKeyPrefix><orgId>` and clears the row. Both halves are idempotent, and a
@@ -302,6 +310,13 @@ check in application code, guarding an irreversible operation on another
 deployment's data. Deriving key names from ids this deployment recorded itself
 removes the failure mode by construction: the shredder cannot produce a key name
 it did not build from its own tombstone.
+
+**A separate identity means a separate configuration, too.** The job reads its
+own minimal config (`secrets/shred-config.ts`): database, Vault address, and its
+own credential. Reusing the control plane's config loader would demand the CP's
+`API_KEY_PEPPER` and its Vault credential before the job could start, so a
+least-privilege workload would have to be handed the very credential this
+separation exists to keep away from it.
 
 **A separate Vault role is not enough; it needs a separate identity.** Roles in
 a workload-identity auth method bind to the workload's service account, so a

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -65,6 +65,7 @@
     "prepack": "pnpm run prisma:generate && pnpm run build",
     "prisma:generate": "prisma generate",
     "secrets:rewrap": "tsx --env-file-if-exists=../../.env src/secrets/rewrap-cli.ts",
+    "secrets:shred": "tsx --env-file-if-exists=../../.env src/secrets/shred-cli.ts",
     "start": "node dist/index.js",
     "test": "pnpm run test:unit && pnpm run test:int",
     "test:int": "vitest run --project integration",

--- a/packages/control-plane/prisma/migrations/20260806140000_pending_key_shred/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260806140000_pending_key_shred/migration.sql
@@ -2,8 +2,13 @@
 -- Written in the same transaction that deletes the org, drained by the
 -- operator-run shred CLI. No foreign key by design — the row must outlive the
 -- organization it names (docs/designs/per-org-secret-encryption.md §6).
+-- The resolved target is pinned at delete time: deriving it at drain time would
+-- use whatever configuration is current then, so a mount/prefix change in
+-- between would aim the destroy at a non-existent name, read as "already gone".
 CREATE TABLE "pending_key_shred" (
     "orgId" TEXT NOT NULL,
+    "mount" TEXT NOT NULL,
+    "keyName" TEXT NOT NULL,
     "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "pending_key_shred_pkey" PRIMARY KEY ("orgId")

--- a/packages/control-plane/prisma/migrations/20260806140000_pending_key_shred/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260806140000_pending_key_shred/migration.sql
@@ -1,0 +1,10 @@
+-- One row per deleted organization: its transit key is still to be destroyed.
+-- Written in the same transaction that deletes the org, drained by the
+-- operator-run shred CLI. No foreign key by design — the row must outlive the
+-- organization it names (docs/designs/per-org-secret-encryption.md §6).
+CREATE TABLE "pending_key_shred" (
+    "orgId" TEXT NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "pending_key_shred_pkey" PRIMARY KEY ("orgId")
+);

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -180,6 +180,22 @@ model DeletedIdentityCutoff {
   @@map("deleted_identity_cutoff")
 }
 
+// One row per deleted organization, recording that its transit key should be
+// destroyed (docs/designs/per-org-secret-encryption.md §6). Written inside the
+// same transaction that deletes the org, so the intent survives whatever
+// happens next; drained by the operator-run `secrets:shred` CLI, which is the
+// ONLY thing that ever deletes a key — the CP process cannot.
+//
+// Deliberately NO foreign key: the row's entire purpose is to outlive the
+// organization it names. The org id is enough to derive the key name, which is
+// why the shredder never has to enumerate keys.
+model PendingKeyShred {
+  orgId     String   @id // the deleted org; the key name derives from it
+  createdAt DateTime @default(now()) @db.Timestamptz(6)
+
+  @@map("pending_key_shred")
+}
+
 // Console roles (§3.2): owner = edit everything + manage members/org info (an
 // org can have several owners); collaborator = create/edit/run agents, manage
 // sessions; viewer = read-only.

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -187,10 +187,19 @@ model DeletedIdentityCutoff {
 // ONLY thing that ever deletes a key — the CP process cannot.
 //
 // Deliberately NO foreign key: the row's entire purpose is to outlive the
-// organization it names. The org id is enough to derive the key name, which is
-// why the shredder never has to enumerate keys.
+// organization it names.
+//
+// The RESOLVED target is stored, not just the org id. Deriving the name at
+// drain time would read it from whatever configuration is current then, so
+// rotating VAULT_TRANSIT_MOUNT or the org key prefix between the delete and the
+// drain would aim the destroy at a name that does not exist — which the
+// shredder reads as "already gone", clears the row, and leaves the real key
+// alive forever. Pinning the target at delete time makes the tombstone
+// self-describing and immune to later configuration changes.
 model PendingKeyShred {
-  orgId     String   @id // the deleted org; the key name derives from it
+  orgId     String   @id // the deleted org (identity + idempotency key)
+  mount     String // transit mount as configured when the org was deleted
+  keyName   String // fully resolved key name, e.g. <orgKeyPrefix><orgId>
   createdAt DateTime @default(now()) @db.Timestamptz(6)
 
   @@map("pending_key_shred")

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -132,6 +132,7 @@ import type { SecretsProvider } from './secrets/providers/provider.js'
 import { makeSecretsProvider } from './secrets/providers/memory.js'
 import { SecretsBrokerService } from './secrets/secretsBroker.js'
 import { makeSecretCipher, type SecretCipher } from './secrets/cipher.js'
+import { effectiveOrgKeyPrefix } from './secrets/scope.js'
 import type { DeploymentConfigRuntime } from './persistence/deployment-config.js'
 
 import { ConnectionRegistry } from './ws/registry.js'
@@ -351,7 +352,10 @@ export function buildContainer(
     // an org" can't bypass the admission gate. Every org-creating repo carries the
     // preset-agent seam flag (preset-agents.md §3.2).
     user: new PgUserRepo(prisma, !config.WAITLIST_MODE, config.PRESET_AGENTS_ENABLED),
-    org: new PgOrgRepo(prisma, config.PRESET_AGENTS_ENABLED),
+    org: new PgOrgRepo(prisma, config.PRESET_AGENTS_ENABLED, (orgId) => ({
+      mount: config.VAULT_TRANSIT_MOUNT,
+      keyName: `${effectiveOrgKeyPrefix(config.VAULT_TRANSIT_KEY, config.VAULT_TRANSIT_ORG_KEY_PREFIX)}${orgId}`
+    })),
     orgInviteLink: new PgOrgInviteLinkRepo(prisma),
     waitlist: new PgWaitlistRepo(prisma, config.PRESET_AGENTS_ENABLED),
     githubInstallation: new PgGithubInstallationRepo(prisma),

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -2852,7 +2852,8 @@ export class PgHookRepo implements HookRepo {
    */
   async deleteOrgWithReviewProjectionCleanup(
     orgId: OrgId,
-    at: Date
+    at: Date,
+    shredTarget: { mount: string; keyName: string }
   ): Promise<{
     status: 'deleted' | 'review_cleanup_pending' | 'daemons_present'
     removedHookIds: string[]
@@ -3011,7 +3012,10 @@ export class PgHookRepo implements HookRepo {
         // die". Nothing here destroys a key — the operator-run shred CLI does,
         // under its own identity. `createMany` + skipDuplicates keeps a re-run
         // harmless if a prior attempt already recorded the intent.
-        await tx.pendingKeyShred.createMany({ data: [{ orgId }], skipDuplicates: true })
+        await tx.pendingKeyShred.createMany({
+          data: [{ orgId, mount: shredTarget.mount, keyName: shredTarget.keyName }],
+          skipDuplicates: true
+        })
         await tx.org.delete({ where: { id: orgId } })
         return { status: 'deleted' as const, removedHookIds: hookRows.map((row) => row.id) }
       },

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -3003,6 +3003,15 @@ export class PgHookRepo implements HookRepo {
         // in the same fenced transaction as the final Org cascade.
         await tx.hookReviewProjection.deleteMany({ where: { orgId } })
         await tx.hookRun.deleteMany({ where: { orgId } })
+        // Record the crypto-shred intent in the SAME transaction as the delete
+        // (docs/designs/per-org-secret-encryption.md §6). Deleting the Vault key
+        // is a remote effect that cannot join this transaction, and after the
+        // org row is gone nothing else remembers the id, so the tombstone is the
+        // only durable link between "this org was deleted" and "its key must
+        // die". Nothing here destroys a key — the operator-run shred CLI does,
+        // under its own identity. `createMany` + skipDuplicates keeps a re-run
+        // harmless if a prior attempt already recorded the intent.
+        await tx.pendingKeyShred.createMany({ data: [{ orgId }], skipDuplicates: true })
         await tx.org.delete({ where: { id: orgId } })
         return { status: 'deleted' as const, removedHookIds: hookRows.map((row) => row.id) }
       },

--- a/packages/control-plane/src/persistence/repositories/org.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org.repo.ts
@@ -18,7 +18,15 @@ export class PgOrgRepo implements OrgRepo {
     private readonly db: PrismaLike,
     /** Provision preset agents with each created org (preset-agents.md §3.2);
      *  deploy-time opt-out via PRESET_AGENTS_ENABLED. */
-    private readonly presetAgents = true
+    private readonly presetAgents = true,
+    /** The transit target this deployment would seal THIS org's secrets under,
+     *  pinned onto the shred tombstone at delete time so a later mount/prefix
+     *  change cannot silently redirect the destroy
+     *  (docs/designs/per-org-secret-encryption.md §6). */
+    private readonly shredTarget: (orgId: string) => { mount: string; keyName: string } = (orgId) => ({
+      mount: 'transit',
+      keyName: orgId
+    })
   ) {}
 
   private transaction<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>): Promise<T> {
@@ -142,6 +150,10 @@ export class PgOrgRepo implements OrgRepo {
     // R2a HookRun/projection rows intentionally have no owner FK so ordinary
     // HookDef/Agent deletion can finish GitHub cleanup. Organization deletion
     // therefore needs an explicit durable barrier instead of a raw cascade.
-    return new PgHookRepo(this.db).deleteOrgWithReviewProjectionCleanup(OrgId(orgId), new Date())
+    return new PgHookRepo(this.db).deleteOrgWithReviewProjectionCleanup(
+      OrgId(orgId),
+      new Date(),
+      this.shredTarget(orgId)
+    )
   }
 }

--- a/packages/control-plane/src/secrets/shred-cli.ts
+++ b/packages/control-plane/src/secrets/shred-cli.ts
@@ -21,61 +21,33 @@
  *   node dist/secrets/shred-cli.js         # in the deployed runtime environment
  *   pnpm secrets:shred                     # locally, via tsx on this same file
  *
- * `SECRET_SHRED_VAULT_TOKEN` / `SECRET_SHRED_VAULT_JWT_ROLE` select this job's
- * own credential; it refuses to fall back to the CP's. Unconfigured deployments
- * simply accumulate unreferenced keys, which is the right default for
- * self-hosted and development installs.
+ * It reads a MINIMAL configuration of its own (`shred-config.ts`) — database,
+ * Vault address, and `SECRET_SHRED_VAULT_TOKEN` / `SECRET_SHRED_VAULT_JWT_ROLE`.
+ * Deliberately not the control plane's `loadConfig()`: that would demand the
+ * CP's `API_KEY_PEPPER` and its Vault credential before this job could start,
+ * handing back the very separation the job exists to create. The transit target
+ * is not configured here at all — each tombstone carries the mount and key name
+ * pinned when its organization was deleted.
+ *
+ * Unconfigured deployments simply accumulate unreferenced keys, which is the
+ * right default for self-hosted and development installs.
  */
-import { loadConfig } from '../config/env.js'
 import { createPrisma, disconnectPrisma } from '../persistence/prisma.js'
-import { effectiveOrgKeyPrefix } from './scope.js'
+import { loadShredConfig, shredVaultAuth } from './shred-config.js'
 import { shredPendingKeys, VaultTransitKeyDestroyer } from './shred.js'
-import { VaultHttp, type VaultAuth } from './vault-http.js'
-
-function shredAuth(env: NodeJS.ProcessEnv, config: { VAULT_JWT_PATH: string; VAULT_AUTH_MOUNT: string }): VaultAuth {
-  const token = env.SECRET_SHRED_VAULT_TOKEN
-  const role = env.SECRET_SHRED_VAULT_JWT_ROLE
-  if (token && role) throw new Error('set exactly one of SECRET_SHRED_VAULT_TOKEN or SECRET_SHRED_VAULT_JWT_ROLE')
-  if (token) return { method: 'token', token }
-  if (role) {
-    return {
-      method: 'jwt',
-      role,
-      jwtPath: env.SECRET_SHRED_VAULT_JWT_PATH ?? config.VAULT_JWT_PATH,
-      authMount: env.SECRET_SHRED_VAULT_AUTH_MOUNT ?? config.VAULT_AUTH_MOUNT
-    }
-  }
-  // Deliberately NOT falling back to the CP's credential: that would put key
-  // deletion back inside the identity this job exists to stay outside of.
-  throw new Error(
-    'no shred credential — set SECRET_SHRED_VAULT_TOKEN or SECRET_SHRED_VAULT_JWT_ROLE for this job’s OWN Vault identity'
-  )
-}
+import { VaultHttp } from './vault-http.js'
 
 async function main(): Promise<void> {
-  const config = loadConfig()
-  if (config.SECRET_CIPHER === 'none') {
-    console.error('secrets:shred: SECRET_CIPHER=none — values are stored in plaintext, so there is no key to destroy.')
-    process.exitCode = 2
-    return
-  }
-  if (!config.VAULT_ADDR) {
-    console.error('secrets:shred: VAULT_ADDR is required.')
-    process.exitCode = 2
-    return
-  }
+  const config = loadShredConfig()
   const http = new VaultHttp({
     addr: config.VAULT_ADDR,
     namespace: config.VAULT_NAMESPACE,
-    auth: shredAuth(process.env, config)
+    auth: shredVaultAuth(config)
   })
   const prisma = createPrisma(config.DATABASE_URL)
   try {
-    const stats = await shredPendingKeys(
-      prisma,
-      new VaultTransitKeyDestroyer(http, config.VAULT_TRANSIT_MOUNT),
-      effectiveOrgKeyPrefix(config.VAULT_TRANSIT_KEY, config.VAULT_TRANSIT_ORG_KEY_PREFIX),
-      (m) => console.log(`secrets:shred: ${m}`)
+    const stats = await shredPendingKeys(prisma, new VaultTransitKeyDestroyer(http), (m) =>
+      console.log(`secrets:shred: ${m}`)
     )
     console.log(`secrets:shred: done — ${stats.shredded} key(s) destroyed, ${stats.failed} left for a re-run`)
     if (stats.failed > 0) process.exitCode = 1

--- a/packages/control-plane/src/secrets/shred-cli.ts
+++ b/packages/control-plane/src/secrets/shred-cli.ts
@@ -1,0 +1,90 @@
+/**
+ * Shred CLI — destroy the transit key of every deleted organization
+ * (docs/designs/per-org-secret-encryption.md §6). This is the ONLY thing in the
+ * codebase that deletes a Vault key; the control plane records the intent and
+ * nothing more.
+ *
+ * Run it as its own workload with its OWN identity, not the CP's. A Vault role
+ * binds to a service account, so granting key deletion to a second role bound to
+ * the CP's account would leave the capability reachable from the CP — the
+ * separation is the workload, not the role name. Give this job a service
+ * account of its own whose policy carries, scoped to the org key prefix only,
+ * `delete` on `<mount>/keys/<orgKeyPrefix>` + glob and `update` on that same
+ * glob's `config` sub-path.
+ *
+ * No `list` capability is required, and none should be granted: this never
+ * enumerates keys, it derives every name from a tombstone this deployment wrote.
+ *
+ * Like `rewrap-cli.ts` this lives in `src/` so it compiles into `dist/` and
+ * ships in the runtime image:
+ *
+ *   node dist/secrets/shred-cli.js         # in the deployed runtime environment
+ *   pnpm secrets:shred                     # locally, via tsx on this same file
+ *
+ * `SECRET_SHRED_VAULT_TOKEN` / `SECRET_SHRED_VAULT_JWT_ROLE` select this job's
+ * own credential; it refuses to fall back to the CP's. Unconfigured deployments
+ * simply accumulate unreferenced keys, which is the right default for
+ * self-hosted and development installs.
+ */
+import { loadConfig } from '../config/env.js'
+import { createPrisma, disconnectPrisma } from '../persistence/prisma.js'
+import { effectiveOrgKeyPrefix } from './scope.js'
+import { shredPendingKeys, VaultTransitKeyDestroyer } from './shred.js'
+import { VaultHttp, type VaultAuth } from './vault-http.js'
+
+function shredAuth(env: NodeJS.ProcessEnv, config: { VAULT_JWT_PATH: string; VAULT_AUTH_MOUNT: string }): VaultAuth {
+  const token = env.SECRET_SHRED_VAULT_TOKEN
+  const role = env.SECRET_SHRED_VAULT_JWT_ROLE
+  if (token && role) throw new Error('set exactly one of SECRET_SHRED_VAULT_TOKEN or SECRET_SHRED_VAULT_JWT_ROLE')
+  if (token) return { method: 'token', token }
+  if (role) {
+    return {
+      method: 'jwt',
+      role,
+      jwtPath: env.SECRET_SHRED_VAULT_JWT_PATH ?? config.VAULT_JWT_PATH,
+      authMount: env.SECRET_SHRED_VAULT_AUTH_MOUNT ?? config.VAULT_AUTH_MOUNT
+    }
+  }
+  // Deliberately NOT falling back to the CP's credential: that would put key
+  // deletion back inside the identity this job exists to stay outside of.
+  throw new Error(
+    'no shred credential — set SECRET_SHRED_VAULT_TOKEN or SECRET_SHRED_VAULT_JWT_ROLE for this job’s OWN Vault identity'
+  )
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig()
+  if (config.SECRET_CIPHER === 'none') {
+    console.error('secrets:shred: SECRET_CIPHER=none — values are stored in plaintext, so there is no key to destroy.')
+    process.exitCode = 2
+    return
+  }
+  if (!config.VAULT_ADDR) {
+    console.error('secrets:shred: VAULT_ADDR is required.')
+    process.exitCode = 2
+    return
+  }
+  const http = new VaultHttp({
+    addr: config.VAULT_ADDR,
+    namespace: config.VAULT_NAMESPACE,
+    auth: shredAuth(process.env, config)
+  })
+  const prisma = createPrisma(config.DATABASE_URL)
+  try {
+    const stats = await shredPendingKeys(
+      prisma,
+      new VaultTransitKeyDestroyer(http, config.VAULT_TRANSIT_MOUNT),
+      effectiveOrgKeyPrefix(config.VAULT_TRANSIT_KEY, config.VAULT_TRANSIT_ORG_KEY_PREFIX),
+      (m) => console.log(`secrets:shred: ${m}`)
+    )
+    console.log(`secrets:shred: done — ${stats.shredded} key(s) destroyed, ${stats.failed} left for a re-run`)
+    if (stats.failed > 0) process.exitCode = 1
+  } finally {
+    await disconnectPrisma()
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('secrets:shred: failed —', err instanceof Error ? err.message : err)
+  process.exitCode = 1
+})

--- a/packages/control-plane/src/secrets/shred-config.ts
+++ b/packages/control-plane/src/secrets/shred-config.ts
@@ -1,0 +1,67 @@
+/**
+ * `loadShredConfig` — the MINIMAL configuration the shred workload needs
+ * (docs/designs/per-org-secret-encryption.md §6).
+ *
+ * Deliberately not `loadConfig()`. The control plane's parser demands the CP's
+ * own settings — `API_KEY_PEPPER`, and under `SECRET_CIPHER=vault-transit` a CP
+ * `VAULT_TOKEN` or `VAULT_JWT_ROLE` — so reusing it would force a least-
+ * privilege shred workload to be handed the control plane's credential (or fake
+ * one) just to start. That would hand back exactly the separation this job
+ * exists to create: a Vault role binds to a service account, so the destructive
+ * capability is only genuinely apart when the workload, its identity and its
+ * configuration are all its own.
+ *
+ * What it therefore reads: where the database is, where Vault is, and this
+ * job's OWN credential. Nothing else. The transit target is NOT read from here —
+ * each tombstone carries the mount and key name pinned when its organization was
+ * deleted, so a mount or prefix rotation cannot redirect a destroy.
+ */
+import { z } from 'zod'
+import type { VaultAuth } from './vault-http.js'
+
+const ShredConfigSchema = z
+  .object({
+    DATABASE_URL: z.string().min(1),
+    VAULT_ADDR: z.string().url(),
+    VAULT_NAMESPACE: z.string().optional(),
+    // This job's own identity — never the control plane's.
+    SECRET_SHRED_VAULT_TOKEN: z.string().optional(),
+    SECRET_SHRED_VAULT_JWT_ROLE: z.string().optional(),
+    SECRET_SHRED_VAULT_JWT_PATH: z.string().default('/var/run/secrets/kubernetes.io/serviceaccount/token'),
+    SECRET_SHRED_VAULT_AUTH_MOUNT: z.string().default('kubernetes')
+  })
+  .superRefine((config, ctx) => {
+    const modes = [config.SECRET_SHRED_VAULT_TOKEN, config.SECRET_SHRED_VAULT_JWT_ROLE].filter(
+      (v) => v !== undefined
+    ).length
+    if (modes !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['SECRET_SHRED_VAULT_TOKEN'],
+        message:
+          'the shred job needs exactly one of SECRET_SHRED_VAULT_TOKEN or SECRET_SHRED_VAULT_JWT_ROLE — its OWN Vault identity, never the control plane’s'
+      })
+    }
+  })
+
+export type ShredConfig = z.infer<typeof ShredConfigSchema>
+
+export function loadShredConfig(env: NodeJS.ProcessEnv = process.env): ShredConfig {
+  const parsed = ShredConfigSchema.safeParse(env)
+  if (!parsed.success) {
+    const detail = parsed.error.issues.map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`).join('; ')
+    throw new Error(`invalid shred configuration — ${detail}`)
+  }
+  return parsed.data
+}
+
+/** This job's Vault credential. Never falls back to the control plane's. */
+export function shredVaultAuth(config: ShredConfig): VaultAuth {
+  if (config.SECRET_SHRED_VAULT_TOKEN) return { method: 'token', token: config.SECRET_SHRED_VAULT_TOKEN }
+  return {
+    method: 'jwt',
+    role: config.SECRET_SHRED_VAULT_JWT_ROLE!,
+    jwtPath: config.SECRET_SHRED_VAULT_JWT_PATH,
+    authMount: config.SECRET_SHRED_VAULT_AUTH_MOUNT
+  }
+}

--- a/packages/control-plane/src/secrets/shred.test.ts
+++ b/packages/control-plane/src/secrets/shred.test.ts
@@ -10,19 +10,18 @@
 import { describe, it, expect } from 'vitest'
 import type { PrismaClient } from '../generated/prisma/client.js'
 import { shredPendingKeys, VaultTransitKeyDestroyer, type KeyDestroyer } from './shred.js'
+import { loadShredConfig, shredVaultAuth } from './shred-config.js'
 import { VaultHttp } from './vault-http.js'
 
 describe('shredPendingKeys', () => {
-  const PREFIX = 'ac-cp-org-'
-
-  it('destroys <prefix><orgId> for each tombstone and clears only the rows that succeeded', async () => {
+  it('destroys each tombstone’s PINNED target and clears only the rows that succeeded', async () => {
     const destroyed: string[] = []
     const deleted: string[] = []
     const prisma = {
       pendingKeyShred: {
         findMany: async () => [
-          { orgId: 'org-aaa', createdAt: new Date(1) },
-          { orgId: 'org-bbb', createdAt: new Date(2) }
+          { orgId: 'org-aaa', mount: 'transit', keyName: 'ac-cp-org-org-aaa', createdAt: new Date(1) },
+          { orgId: 'org-bbb', mount: 'transit', keyName: 'ac-cp-org-org-bbb', createdAt: new Date(2) }
         ],
         delete: async ({ where }: { where: { orgId: string } }) => {
           deleted.push(where.orgId)
@@ -31,20 +30,41 @@ describe('shredPendingKeys', () => {
       }
     } as unknown as PrismaClient
     const destroyer: KeyDestroyer = {
-      destroy: async (k) => {
-        destroyed.push(k)
+      destroy: async (mount, k) => {
+        destroyed.push(`${mount}/${k}`)
         // The second org's key refuses — its tombstone must survive.
         if (k.endsWith('org-bbb')) throw new Error('vault said no')
       }
     }
 
-    const stats = await shredPendingKeys(prisma, destroyer, PREFIX)
+    const stats = await shredPendingKeys(prisma, destroyer)
 
-    // Names are DERIVED, never discovered: no list call exists to make.
-    expect(destroyed).toEqual(['ac-cp-org-org-aaa', 'ac-cp-org-org-bbb'])
+    // Names come from the ROW, never from current config and never from a list.
+    expect(destroyed).toEqual(['transit/ac-cp-org-org-aaa', 'transit/ac-cp-org-org-bbb'])
     expect(stats).toEqual({ shredded: 1, failed: 1 })
     // Only the successful one lost its tombstone; the failure is retried later.
     expect(deleted).toEqual(['org-aaa'])
+  })
+
+  it('uses the pinned mount even after configuration moved on', async () => {
+    // A tombstone written before a mount rotation must still aim where its key
+    // actually lives; re-deriving would hit a 404 that reads as "already gone"
+    // and would clear the row while the real key survived.
+    const destroyed: string[] = []
+    const prisma = {
+      pendingKeyShred: {
+        findMany: async () => [
+          { orgId: 'org-old', mount: 'transit-legacy', keyName: 'old-prefix-org-old', createdAt: new Date(1) }
+        ],
+        delete: async ({ where }: { where: { orgId: string } }) => where
+      }
+    } as unknown as PrismaClient
+    await shredPendingKeys(prisma, {
+      destroy: async (mount, k) => {
+        destroyed.push(`${mount}/${k}`)
+      }
+    })
+    expect(destroyed).toEqual(['transit-legacy/old-prefix-org-old'])
   })
 
   it('is a no-op with no tombstones', async () => {
@@ -54,7 +74,7 @@ describe('shredPendingKeys', () => {
     const destroy = async (): Promise<void> => {
       throw new Error('must not be called')
     }
-    expect(await shredPendingKeys(prisma, { destroy }, PREFIX)).toEqual({ shredded: 0, failed: 0 })
+    expect(await shredPendingKeys(prisma, { destroy })).toEqual({ shredded: 0, failed: 0 })
   })
 })
 
@@ -83,7 +103,7 @@ describe('VaultTransitKeyDestroyer', () => {
 
   it('allows deletion first, then deletes — a transit key is undeletable until its config says so', async () => {
     const vault = fakeVault(() => ({ status: 204 }))
-    await new VaultTransitKeyDestroyer(http(vault.fetchImpl), 'transit').destroy('ac-cp-org-org-aaa')
+    await new VaultTransitKeyDestroyer(http(vault.fetchImpl)).destroy('transit', 'ac-cp-org-org-aaa')
 
     expect(vault.calls.map((c) => `${c.method} ${c.path}`)).toEqual([
       'POST transit/keys/ac-cp-org-org-aaa/config',
@@ -97,7 +117,7 @@ describe('VaultTransitKeyDestroyer', () => {
   it('treats an already-absent key as done — the previous run died between destroy and clear', async () => {
     const vault = fakeVault(() => ({ status: 404, body: { errors: [] } }))
     await expect(
-      new VaultTransitKeyDestroyer(http(vault.fetchImpl), 'transit').destroy('ac-cp-org-gone')
+      new VaultTransitKeyDestroyer(http(vault.fetchImpl)).destroy('transit', 'ac-cp-org-gone')
     ).resolves.toBeUndefined()
     expect(vault.calls).toHaveLength(1) // stopped after the 404 config call
   })
@@ -106,10 +126,46 @@ describe('VaultTransitKeyDestroyer', () => {
     const vault = fakeVault((method) =>
       method === 'DELETE' ? { status: 403, body: { errors: ['permission denied'] } } : { status: 204 }
     )
-    const err = await new VaultTransitKeyDestroyer(http(vault.fetchImpl), 'transit')
-      .destroy('ac-cp-org-org-aaa')
+    const err = await new VaultTransitKeyDestroyer(http(vault.fetchImpl))
+      .destroy('transit', 'ac-cp-org-org-aaa')
       .catch((e: unknown) => e as Error)
     expect((err as Error).message).toContain('403')
     expect((err as Error).message).toContain('permission denied')
+  })
+})
+
+describe('loadShredConfig — the shred workload stands on its OWN configuration', () => {
+  const MINIMAL = {
+    DATABASE_URL: 'postgresql://x:y@localhost:5432/db',
+    VAULT_ADDR: 'https://vault.example.com',
+    SECRET_SHRED_VAULT_TOKEN: 'shred-token'
+  }
+
+  it('parses with NO control-plane variables present — no API_KEY_PEPPER, no CP Vault credential', () => {
+    // The blocker this replaced: loadConfig() demanded both before the job could
+    // start, so a least-privilege workload had to be handed the CP's own
+    // credential (or fake it) — giving back the separation the job exists for.
+    const config = loadShredConfig(MINIMAL as NodeJS.ProcessEnv)
+    expect(config.DATABASE_URL).toBe(MINIMAL.DATABASE_URL)
+    expect(shredVaultAuth(config)).toEqual({ method: 'token', token: 'shred-token' })
+  })
+
+  it('refuses with neither credential, and with both', () => {
+    expect(() =>
+      loadShredConfig({ DATABASE_URL: MINIMAL.DATABASE_URL, VAULT_ADDR: MINIMAL.VAULT_ADDR } as NodeJS.ProcessEnv)
+    ).toThrow(/exactly one/)
+    expect(() => loadShredConfig({ ...MINIMAL, SECRET_SHRED_VAULT_JWT_ROLE: 'r' } as NodeJS.ProcessEnv)).toThrow(
+      /exactly one/
+    )
+  })
+
+  it('never reads the control plane’s VAULT_TOKEN as a fallback', () => {
+    expect(() =>
+      loadShredConfig({
+        DATABASE_URL: MINIMAL.DATABASE_URL,
+        VAULT_ADDR: MINIMAL.VAULT_ADDR,
+        VAULT_TOKEN: 'the-control-planes-token'
+      } as NodeJS.ProcessEnv)
+    ).toThrow(/exactly one/)
   })
 })

--- a/packages/control-plane/src/secrets/shred.test.ts
+++ b/packages/control-plane/src/secrets/shred.test.ts
@@ -1,0 +1,115 @@
+/**
+ * `shredPendingKeys` + `VaultTransitKeyDestroyer` — the drain half of
+ * crypto-shredding (docs/designs/per-org-secret-encryption.md §6).
+ *
+ * The two properties worth protecting are structural, not behavioural: every
+ * destroyed name is DERIVED from a tombstone this deployment wrote, and no key
+ * is ever enumerated. Both are asserted here, because losing either turns an
+ * irreversible operation loose on names this deployment does not own.
+ */
+import { describe, it, expect } from 'vitest'
+import type { PrismaClient } from '../generated/prisma/client.js'
+import { shredPendingKeys, VaultTransitKeyDestroyer, type KeyDestroyer } from './shred.js'
+import { VaultHttp } from './vault-http.js'
+
+describe('shredPendingKeys', () => {
+  const PREFIX = 'ac-cp-org-'
+
+  it('destroys <prefix><orgId> for each tombstone and clears only the rows that succeeded', async () => {
+    const destroyed: string[] = []
+    const deleted: string[] = []
+    const prisma = {
+      pendingKeyShred: {
+        findMany: async () => [
+          { orgId: 'org-aaa', createdAt: new Date(1) },
+          { orgId: 'org-bbb', createdAt: new Date(2) }
+        ],
+        delete: async ({ where }: { where: { orgId: string } }) => {
+          deleted.push(where.orgId)
+          return where
+        }
+      }
+    } as unknown as PrismaClient
+    const destroyer: KeyDestroyer = {
+      destroy: async (k) => {
+        destroyed.push(k)
+        // The second org's key refuses — its tombstone must survive.
+        if (k.endsWith('org-bbb')) throw new Error('vault said no')
+      }
+    }
+
+    const stats = await shredPendingKeys(prisma, destroyer, PREFIX)
+
+    // Names are DERIVED, never discovered: no list call exists to make.
+    expect(destroyed).toEqual(['ac-cp-org-org-aaa', 'ac-cp-org-org-bbb'])
+    expect(stats).toEqual({ shredded: 1, failed: 1 })
+    // Only the successful one lost its tombstone; the failure is retried later.
+    expect(deleted).toEqual(['org-aaa'])
+  })
+
+  it('is a no-op with no tombstones', async () => {
+    const prisma = {
+      pendingKeyShred: { findMany: async () => [], delete: async () => ({}) }
+    } as unknown as PrismaClient
+    const destroy = async (): Promise<void> => {
+      throw new Error('must not be called')
+    }
+    expect(await shredPendingKeys(prisma, { destroy }, PREFIX)).toEqual({ shredded: 0, failed: 0 })
+  })
+})
+
+describe('VaultTransitKeyDestroyer', () => {
+  function fakeVault(handler: (method: string, path: string) => { status: number; body?: unknown }) {
+    const calls: Array<{ method: string; path: string; body: unknown }> = []
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = String(input)
+      const path = url.slice(url.indexOf('/v1/') + 4)
+      const body = init?.body ? (JSON.parse(String(init.body)) as unknown) : undefined
+      calls.push({ method: init?.method ?? 'GET', path, body })
+      const r = handler(init?.method ?? 'GET', path)
+      // 204 must carry a null body (Vault's real answer for these two calls).
+      return r.status === 204
+        ? new Response(null, { status: 204 })
+        : new Response(JSON.stringify(r.body ?? {}), {
+            status: r.status,
+            headers: { 'content-type': 'application/json' }
+          })
+    }
+    return { calls, fetchImpl }
+  }
+
+  const http = (fetchImpl: typeof fetch): VaultHttp =>
+    new VaultHttp({ addr: 'https://vault.example.com', auth: { method: 'token', token: 't' }, fetchImpl })
+
+  it('allows deletion first, then deletes — a transit key is undeletable until its config says so', async () => {
+    const vault = fakeVault(() => ({ status: 204 }))
+    await new VaultTransitKeyDestroyer(http(vault.fetchImpl), 'transit').destroy('ac-cp-org-org-aaa')
+
+    expect(vault.calls.map((c) => `${c.method} ${c.path}`)).toEqual([
+      'POST transit/keys/ac-cp-org-org-aaa/config',
+      'DELETE transit/keys/ac-cp-org-org-aaa'
+    ])
+    expect(vault.calls[0]!.body).toEqual({ deletion_allowed: true })
+    // No enumeration, ever: a list would span the whole shared mount.
+    expect(vault.calls.some((c) => c.path.endsWith('keys') || c.method === 'LIST')).toBe(false)
+  })
+
+  it('treats an already-absent key as done — the previous run died between destroy and clear', async () => {
+    const vault = fakeVault(() => ({ status: 404, body: { errors: [] } }))
+    await expect(
+      new VaultTransitKeyDestroyer(http(vault.fetchImpl), 'transit').destroy('ac-cp-org-gone')
+    ).resolves.toBeUndefined()
+    expect(vault.calls).toHaveLength(1) // stopped after the 404 config call
+  })
+
+  it('surfaces a refusal as an error (status + Vault errors[], no payload) so the tombstone survives', async () => {
+    const vault = fakeVault((method) =>
+      method === 'DELETE' ? { status: 403, body: { errors: ['permission denied'] } } : { status: 204 }
+    )
+    const err = await new VaultTransitKeyDestroyer(http(vault.fetchImpl), 'transit')
+      .destroy('ac-cp-org-org-aaa')
+      .catch((e: unknown) => e as Error)
+    expect((err as Error).message).toContain('403')
+    expect((err as Error).message).toContain('permission denied')
+  })
+})

--- a/packages/control-plane/src/secrets/shred.ts
+++ b/packages/control-plane/src/secrets/shred.ts
@@ -27,8 +27,8 @@ import type { PrismaClient } from '../generated/prisma/client.js'
 import { describeVaultError, VaultHttp } from './vault-http.js'
 
 export interface KeyDestroyer {
-  /** Destroy one transit key. Absent ⇒ resolve (already shredded). */
-  destroy(keyName: string): Promise<void>
+  /** Destroy one transit key at its pinned mount. Absent ⇒ resolve (already shredded). */
+  destroy(mount: string, keyName: string): Promise<void>
 }
 
 export interface ShredStats {
@@ -41,7 +41,6 @@ export interface ShredStats {
 export async function shredPendingKeys(
   prisma: PrismaClient,
   destroyer: KeyDestroyer,
-  orgKeyPrefix: string,
   log: (message: string) => void = () => {}
 ): Promise<ShredStats> {
   const pending = await prisma.pendingKeyShred.findMany({ orderBy: { createdAt: 'asc' } })
@@ -49,9 +48,13 @@ export async function shredPendingKeys(
   let failed = 0
 
   for (const row of pending) {
-    const keyName = `${orgKeyPrefix}${row.orgId}`
+    // The target was pinned when the org was deleted. Re-deriving it here would
+    // read whatever configuration is current NOW, so a mount or prefix change
+    // in between would aim at a name that does not exist, be read as "already
+    // gone", clear the row, and leave the real key alive forever.
+    const { mount, keyName } = row
     try {
-      await destroyer.destroy(keyName)
+      await destroyer.destroy(mount, keyName)
     } catch (err) {
       failed += 1
       // The tombstone stays: an operator re-run picks it up. Never echo a body.
@@ -73,20 +76,17 @@ export async function shredPendingKeys(
  * previous run destroyed it and died before clearing the row.
  */
 export class VaultTransitKeyDestroyer implements KeyDestroyer {
-  constructor(
-    private readonly http: VaultHttp,
-    private readonly mount: string
-  ) {}
+  constructor(private readonly http: VaultHttp) {}
 
-  async destroy(keyName: string): Promise<void> {
-    const configured = await this.http.request('POST', `${this.mount}/keys/${keyName}/config`, {
+  async destroy(mount: string, keyName: string): Promise<void> {
+    const configured = await this.http.request('POST', `${mount}/keys/${keyName}/config`, {
       deletion_allowed: true
     })
     if (configured.status === 404) return // already gone
     if (!configured.ok) {
       throw new Error(`vault transit allow-deletion failed: ${await describeVaultError(configured)}`)
     }
-    const deleted = await this.http.request('DELETE', `${this.mount}/keys/${keyName}`)
+    const deleted = await this.http.request('DELETE', `${mount}/keys/${keyName}`)
     if (!deleted.ok && deleted.status !== 404) {
       throw new Error(`vault transit key delete failed: ${await describeVaultError(deleted)}`)
     }

--- a/packages/control-plane/src/secrets/shred.ts
+++ b/packages/control-plane/src/secrets/shred.ts
@@ -1,0 +1,94 @@
+/**
+ * `shredPendingKeys` — destroy the transit key of every deleted organization
+ * (docs/designs/per-org-secret-encryption.md §6), turning that org's ciphertext
+ * into permanent noise **including the copies inside older database backups**.
+ *
+ * Reads `pending_key_shred`, which the org-deletion transaction wrote alongside
+ * the delete. Two properties follow from that, and both are the point:
+ *
+ * - **It never enumerates keys.** Every name is derived from an org id this
+ *   deployment recorded itself. A `LIST transit/keys` diff would need list
+ *   capability over the whole mount, and Vault cannot restrict a list to a
+ *   prefix — so on a mount shared by several deployments, every other
+ *   deployment's org keys would look like orphans to this one. There is no key
+ *   name this shredder can produce that it did not build from its own tombstone.
+ * - **It does not run inside the CP.** A Vault role binds to a workload's
+ *   service account, so a second role bound to the CP's account would be
+ *   reachable by the CP itself. The destructive capability is separated only by
+ *   running as its own workload under its own identity — hence a CLI.
+ *
+ * Idempotent: destroying an already-absent key counts as done and clears the
+ * row, and a failure on one org leaves its tombstone for the next run while the
+ * rest proceed. Nothing here logs a key's contents; a key NAME is not secret,
+ * but an org id is tenant-identifying, so names are logged only at the caller's
+ * discretion via `log`.
+ */
+import type { PrismaClient } from '../generated/prisma/client.js'
+import { describeVaultError, VaultHttp } from './vault-http.js'
+
+export interface KeyDestroyer {
+  /** Destroy one transit key. Absent ⇒ resolve (already shredded). */
+  destroy(keyName: string): Promise<void>
+}
+
+export interface ShredStats {
+  /** Tombstones whose key is now gone and whose row was cleared. */
+  shredded: number
+  /** Tombstones left in place because their destroy failed — retried next run. */
+  failed: number
+}
+
+export async function shredPendingKeys(
+  prisma: PrismaClient,
+  destroyer: KeyDestroyer,
+  orgKeyPrefix: string,
+  log: (message: string) => void = () => {}
+): Promise<ShredStats> {
+  const pending = await prisma.pendingKeyShred.findMany({ orderBy: { createdAt: 'asc' } })
+  let shredded = 0
+  let failed = 0
+
+  for (const row of pending) {
+    const keyName = `${orgKeyPrefix}${row.orgId}`
+    try {
+      await destroyer.destroy(keyName)
+    } catch (err) {
+      failed += 1
+      // The tombstone stays: an operator re-run picks it up. Never echo a body.
+      log(`failed to destroy ${keyName} — ${err instanceof Error ? err.message : String(err)}`)
+      continue
+    }
+    // Clear only AFTER the key is gone. The reverse order would drop the only
+    // record that the key must die.
+    await prisma.pendingKeyShred.delete({ where: { orgId: row.orgId } })
+    shredded += 1
+    log(`destroyed ${keyName}`)
+  }
+  return { shredded, failed }
+}
+
+/**
+ * Vault Transit's two-step destroy: a key is undeletable until its config says
+ * otherwise, so allow deletion and then delete. A missing key is success — the
+ * previous run destroyed it and died before clearing the row.
+ */
+export class VaultTransitKeyDestroyer implements KeyDestroyer {
+  constructor(
+    private readonly http: VaultHttp,
+    private readonly mount: string
+  ) {}
+
+  async destroy(keyName: string): Promise<void> {
+    const configured = await this.http.request('POST', `${this.mount}/keys/${keyName}/config`, {
+      deletion_allowed: true
+    })
+    if (configured.status === 404) return // already gone
+    if (!configured.ok) {
+      throw new Error(`vault transit allow-deletion failed: ${await describeVaultError(configured)}`)
+    }
+    const deleted = await this.http.request('DELETE', `${this.mount}/keys/${keyName}`)
+    if (!deleted.ok && deleted.status !== 404) {
+      throw new Error(`vault transit key delete failed: ${await describeVaultError(deleted)}`)
+    }
+  }
+}

--- a/packages/control-plane/src/secrets/vault-http.ts
+++ b/packages/control-plane/src/secrets/vault-http.ts
@@ -1,0 +1,123 @@
+/**
+ * `VaultHttp` — the authenticated request plumbing every Vault caller in the CP
+ * shares: token or workload-JWT login, single-flight re-login before the lease
+ * runs out, one retry after a 403 (revoked/expired server-side), the Enterprise
+ * namespace header, and the never-echo-payloads error discipline.
+ *
+ * Extracted so the {@link VaultTransitSecretCipher} and the shred CLI's key
+ * destroyer (docs/designs/per-org-secret-encryption.md §6) share one
+ * implementation rather than two copies that drift. They deliberately do NOT
+ * share a credential: the destroyer runs as its own workload under its own
+ * identity, because a Vault role binds to a service account and a second role
+ * bound to the CP's account would be reachable from the CP itself.
+ *
+ * Never logs a request or response body; errors carry the HTTP status and
+ * Vault's `errors[]` strings only.
+ */
+import { readFile } from 'node:fs/promises'
+
+export type FetchLike = typeof fetch
+
+export type VaultAuth =
+  { method: 'token'; token: string } | { method: 'jwt'; role: string; jwtPath: string; authMount: string }
+
+export interface VaultHttpOpts {
+  /** Vault origin, e.g. `https://vault.example.com:8200`. */
+  addr: string
+  /** Vault Enterprise namespace (sent as `X-Vault-Namespace`). */
+  namespace?: string | undefined
+  auth: VaultAuth
+  /** Test seams. */
+  fetchImpl?: FetchLike | undefined
+  now?: (() => number) | undefined
+}
+
+/** Renew the JWT login after 80% of the lease (floor 10s so a tiny lease can't thrash). */
+const RENEW_FRACTION = 0.8
+
+export class VaultHttp {
+  private readonly base: string
+  private readonly namespace: string | undefined
+  private readonly auth: VaultAuth
+  private readonly fetchImpl: FetchLike
+  private readonly now: () => number
+
+  private clientToken: { value: string; renewAtMs: number } | undefined
+  private loginInFlight: Promise<string> | undefined
+
+  constructor(opts: VaultHttpOpts) {
+    this.base = `${opts.addr.replace(/\/+$/, '')}/v1`
+    this.namespace = opts.namespace
+    this.auth = opts.auth
+    this.fetchImpl = opts.fetchImpl ?? fetch
+    this.now = opts.now ?? Date.now
+  }
+
+  /**
+   * One authenticated call, with the 403 re-login retry. `body` is omitted for
+   * verbs that carry none (DELETE). Returns the raw `Response`; callers decide
+   * what a non-2xx means for them.
+   */
+  async request(method: 'POST' | 'DELETE', path: string, body?: unknown): Promise<Response> {
+    let res = await this.send(method, path, body, await this.token())
+    if (res.status === 403 && this.auth.method === 'jwt') {
+      // Client token revoked/expired server-side — drop it, re-login, retry ONCE.
+      this.clientToken = undefined
+      res = await this.send(method, path, body, await this.token())
+    }
+    return res
+  }
+
+  private send(method: 'POST' | 'DELETE', path: string, body: unknown, token: string): Promise<Response> {
+    return this.fetchImpl(`${this.base}/${path}`, {
+      method,
+      headers: {
+        'X-Vault-Token': token,
+        'content-type': 'application/json',
+        ...(this.namespace ? { 'X-Vault-Namespace': this.namespace } : {})
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) })
+    })
+  }
+
+  private token(): Promise<string> | string {
+    if (this.auth.method === 'token') return this.auth.token
+    if (this.clientToken && this.now() < this.clientToken.renewAtMs) return this.clientToken.value
+    // Single-flight: concurrent callers during (re-)login share one exchange.
+    this.loginInFlight ??= this.jwtLogin(this.auth).finally(() => {
+      this.loginInFlight = undefined
+    })
+    return this.loginInFlight
+  }
+
+  private async jwtLogin(auth: Extract<VaultAuth, { method: 'jwt' }>): Promise<string> {
+    const jwt = (await readFile(auth.jwtPath, 'utf8')).trim()
+    const res = await this.fetchImpl(`${this.base}/auth/${auth.authMount}/login`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(this.namespace ? { 'X-Vault-Namespace': this.namespace } : {})
+      },
+      body: JSON.stringify({ role: auth.role, jwt })
+    })
+    if (!res.ok) throw new Error(`vault jwt login failed: ${await describeVaultError(res)}`)
+    const json = (await res.json()) as { auth?: { client_token?: string; lease_duration?: number } }
+    const token = json.auth?.client_token
+    if (!token) throw new Error('vault jwt login: no client_token in response')
+    const leaseMs = (json.auth?.lease_duration ?? 3600) * 1000
+    this.clientToken = { value: token, renewAtMs: this.now() + Math.max(leaseMs * RENEW_FRACTION, 10_000) }
+    return token
+  }
+}
+
+/** Status + Vault's `errors[]` only — NEVER the request/response payloads. */
+export async function describeVaultError(res: Response): Promise<string> {
+  let errors = ''
+  try {
+    const json = (await res.json()) as { errors?: string[] }
+    if (Array.isArray(json.errors) && json.errors.length > 0) errors = ` (${json.errors.join('; ')})`
+  } catch {
+    // non-JSON error body — status alone is enough (and never echo the body)
+  }
+  return `HTTP ${res.status}${errors}`
+}

--- a/packages/control-plane/src/secrets/vault-transit.ts
+++ b/packages/control-plane/src/secrets/vault-transit.ts
@@ -35,14 +35,12 @@
  * one. `seal` is never cached — Transit returns fresh ciphertext per call by
  * design.
  */
-import { readFile } from 'node:fs/promises'
 import type { SecretCipher } from './cipher.js'
 import { SECRET_ENVELOPE_PREFIX, type SecretScope } from './scope.js'
+import { describeVaultError, VaultHttp, type FetchLike, type VaultAuth } from './vault-http.js'
 
-type FetchLike = typeof fetch
-
-export type VaultTransitAuth =
-  { method: 'token'; token: string } | { method: 'jwt'; role: string; jwtPath: string; authMount: string }
+/** The auth shape now lives in `vault-http.ts`; re-exported for existing callers. */
+export type VaultTransitAuth = VaultAuth
 
 export interface VaultTransitOpts {
   /** Vault origin, e.g. `https://vault.example.com:8200`. */
@@ -55,7 +53,7 @@ export interface VaultTransitOpts {
   mount?: string
   /** Vault Enterprise namespace (sent as `X-Vault-Namespace`). */
   namespace?: string
-  auth: VaultTransitAuth
+  auth: VaultAuth
   /** Test seams. */
   fetchImpl?: FetchLike
   now?: () => number
@@ -66,33 +64,26 @@ export interface VaultTransitOpts {
 /** Transit ciphertext is self-describing: `vault:v<key-version>:<base64>`. */
 const CIPHERTEXT_RE = /^vault:v\d+:/
 
-/** Renew the JWT login after 80% of the lease (floor 10s so a tiny lease can't thrash). */
-const RENEW_FRACTION = 0.8
-
 export class VaultTransitSecretCipher implements SecretCipher {
-  private readonly base: string
+  private readonly http: VaultHttp
   private readonly key: string
   private readonly orgKeyPrefix: string
   private readonly mount: string
-  private readonly namespace: string | undefined
-  private readonly auth: VaultTransitAuth
-  private readonly fetchImpl: FetchLike
-  private readonly now: () => number
   private readonly openCacheMax: number
 
   private readonly openCache = new Map<string, string>()
-  private clientToken: { value: string; renewAtMs: number } | undefined
-  private loginInFlight: Promise<string> | undefined
 
   constructor(opts: VaultTransitOpts) {
-    this.base = `${opts.addr.replace(/\/+$/, '')}/v1`
+    this.http = new VaultHttp({
+      addr: opts.addr,
+      namespace: opts.namespace,
+      auth: opts.auth,
+      fetchImpl: opts.fetchImpl,
+      now: opts.now
+    })
     this.key = opts.key
     this.orgKeyPrefix = opts.orgKeyPrefix
     this.mount = opts.mount ?? 'transit'
-    this.namespace = opts.namespace
-    this.auth = opts.auth
-    this.fetchImpl = opts.fetchImpl ?? fetch
-    this.now = opts.now ?? Date.now
     this.openCacheMax = opts.openCacheMax ?? 5000
   }
 
@@ -150,68 +141,9 @@ export class VaultTransitSecretCipher implements SecretCipher {
     key: string,
     body: Record<string, string>
   ): Promise<{ ciphertext?: string; plaintext?: string }> {
-    const path = `${this.mount}/${op}/${key}`
-    let res = await this.post(path, body, await this.token())
-    if (res.status === 403 && this.auth.method === 'jwt') {
-      // Client token revoked/expired server-side — drop it, re-login, retry ONCE.
-      this.clientToken = undefined
-      res = await this.post(path, body, await this.token())
-    }
-    if (!res.ok) throw new Error(`vault transit ${op} failed: ${await describeError(res)}`)
+    const res = await this.http.request('POST', `${this.mount}/${op}/${key}`, body)
+    if (!res.ok) throw new Error(`vault transit ${op} failed: ${await describeVaultError(res)}`)
     const json = (await res.json()) as { data?: { ciphertext?: string; plaintext?: string } }
     return json.data ?? {}
   }
-
-  private post(path: string, body: unknown, token: string): Promise<Response> {
-    return this.fetchImpl(`${this.base}/${path}`, {
-      method: 'POST',
-      headers: {
-        'X-Vault-Token': token,
-        'content-type': 'application/json',
-        ...(this.namespace ? { 'X-Vault-Namespace': this.namespace } : {})
-      },
-      body: JSON.stringify(body)
-    })
-  }
-
-  private token(): Promise<string> | string {
-    if (this.auth.method === 'token') return this.auth.token
-    if (this.clientToken && this.now() < this.clientToken.renewAtMs) return this.clientToken.value
-    // Single-flight: concurrent seals/opens during (re-)login share one exchange.
-    this.loginInFlight ??= this.jwtLogin(this.auth).finally(() => {
-      this.loginInFlight = undefined
-    })
-    return this.loginInFlight
-  }
-
-  private async jwtLogin(auth: Extract<VaultTransitAuth, { method: 'jwt' }>): Promise<string> {
-    const jwt = (await readFile(auth.jwtPath, 'utf8')).trim()
-    const res = await this.fetchImpl(`${this.base}/auth/${auth.authMount}/login`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        ...(this.namespace ? { 'X-Vault-Namespace': this.namespace } : {})
-      },
-      body: JSON.stringify({ role: auth.role, jwt })
-    })
-    if (!res.ok) throw new Error(`vault jwt login failed: ${await describeError(res)}`)
-    const json = (await res.json()) as { auth?: { client_token?: string; lease_duration?: number } }
-    const token = json.auth?.client_token
-    if (!token) throw new Error('vault jwt login: no client_token in response')
-    const leaseMs = (json.auth?.lease_duration ?? 3600) * 1000
-    this.clientToken = { value: token, renewAtMs: this.now() + Math.max(leaseMs * RENEW_FRACTION, 10_000) }
-    return token
-  }
-}
-
-/** Status + Vault's `errors[]` only — NEVER the request/response payloads. */
-async function describeError(res: Response): Promise<string> {
-  let errors = ''
-  try {
-    const json = (await res.json()) as { errors?: string[] }
-    if (Array.isArray(json.errors) && json.errors.length > 0) errors = ` (${json.errors.join('; ')})`
-  } catch {
-    // non-JSON error body — status alone is enough (and never echo the body)
-  }
-  return `HTTP ${res.status}${errors}`
 }

--- a/packages/control-plane/test/integration/orgs.route.test.ts
+++ b/packages/control-plane/test/integration/orgs.route.test.ts
@@ -254,6 +254,26 @@ describe('DELETE /orgs/:orgId', () => {
 
       const list = (await (await app.inject({ method: 'GET', url: '/api/v1/orgs' })).json()) as OrgBody[]
       expect(list.map((o) => o.id)).not.toContain(created.id)
+
+      // The crypto-shred intent outlives the org it names: after the cascade
+      // nothing else remembers the id, and the key must still be destroyed
+      // (docs/designs/per-org-secret-encryption.md §6). Deliberately no FK, so
+      // the cascade above cannot take it.
+      expect(await prisma.pendingKeyShred.findUnique({ where: { orgId: created.id } })).not.toBeNull()
+    } finally {
+      await close()
+    }
+  })
+
+  it('records NO shred intent when the deletion is refused', async () => {
+    await prisma.daemon.create({
+      data: { id: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee', orgId: DEFAULT_ORG_ID, sessionEpoch: 1n, status: 'ready' }
+    })
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      expect((await app.inject({ method: 'DELETE', url: ORG })).statusCode).toBe(409)
+      // A tombstone here would schedule the destruction of a LIVE org's key.
+      expect(await prisma.pendingKeyShred.findUnique({ where: { orgId: DEFAULT_ORG_ID } })).toBeNull()
     } finally {
       await close()
     }


### PR DESCRIPTION
## What

Completes crypto-shredding. Deleting an organization now records the intent, and an operator-run CLI destroys that org's transit key — turning its ciphertext into permanent noise **including the copies inside database backups taken before the deletion**.

Follows [#722](https://github.com/agentconnect-md/agentconnect/pull/722), which made the key per-org. Design: [`docs/designs/per-org-secret-encryption.md`](docs/designs/per-org-secret-encryption.md) §6, now marked Implemented.

## The CP never deletes a key

It writes one `pending_key_shred` row inside the same transaction as the delete. Two details are load-bearing:

- **No foreign key.** The row's entire purpose is to outlive the organization it names. A cascade would take the only record that the key must die.
- **Only on the `deleted` path.** A refused deletion (`daemons_present`, `review_cleanup_pending`) writes nothing — a tombstone there would schedule the destruction of a *live* org's key. Tested both ways.

Deletion itself lives in `secrets/shred-cli.ts`, shipping in `dist/` like the rewrap CLI, run as **its own workload**. A separate Vault *role* would not have been enough: roles bind to a service account, so a second role bound to the CP's account stays reachable from the CP. The separation has to be the workload, and the CLI refuses to fall back to the CP's credential.

## It never enumerates keys

Every destroyed name is derived from an org id this deployment recorded itself, so no `list` capability is needed — and none should be granted. Vault cannot restrict a list to a prefix, so on a transit mount shared by several deployments, every *other* deployment's org keys would look like orphans to this one. Deriving names removes that failure mode by construction rather than by a string-prefix check guarding an irreversible operation. Asserted in the tests.

Idempotent throughout: an already-absent key counts as done (the previous run died between destroy and clear), and a failure on one org leaves its tombstone while the rest proceed.

## Also

Vault's auth plumbing (token/JWT login, single-flight renewal, 403 retry) moves to `secrets/vault-http.ts` so the cipher and the destroyer share one implementation instead of two that drift. They share no credential.

## Verification

- typecheck, lint, format — clean
- unit: 1272 passed, including the derive-don't-enumerate assertions and the two-step Vault destroy
- integration: 1047 passed against real Postgres, covering "exactly one tombstone on a successful delete" and "none when refused"

One caveat worth stating: a first integration run showed a single failure I could not reproduce on two subsequent full runs (1047/1047 both times) and could not capture. Treating it as flaky; CI is the arbiter.

## Operational follow-up, not code

The guarantee is not live until the §6 Vault policy is granted to a shred workload and the §7 rewrap sweep has converged each environment onto org keys. Until then deleting an org destroys a key some of its values were never sealed under — the deletion is real, the guarantee partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
