### PR TITLE
refactor(daemon): retire the orchestration tools from the agent tool surface

### DIFF
--- a/docs/designs/agent-collaboration-implementation.md
+++ b/docs/designs/agent-collaboration-implementation.md
@@ -19,6 +19,22 @@
 > channel. Runtime code and protocol schemas are authoritative for exact
 > payload shapes.
 
+> **Orchestration tool surface retired.** `startOrchestration`,
+> `getOrchestration`, and `cancelOrchestration` are no longer injected into any
+> agent's tool set: the send half duplicated `sendMessage` (a fan-out to N workers
+> is N `sendMessage({ toAgent: { agentId, needsReply: true } })` calls) and the
+> status half duplicated `viewSessionStatus`. Section 3 below still describes the
+> daemon machinery accurately — durable records, correlation checks, idempotent
+> report recording, and the one-shot deadline wake are all unchanged and still
+> re-armed from the store on startup — but an agent can no longer start or query an
+> orchestration. The descriptors remain in `RETIRED_ORCHESTRATION_TOOLS`
+> (`packages/daemon/src/mcp/tools.ts`) and `executeTool` still dispatches them, so
+> a session warm with the old descriptors and any still-open record keep resolving.
+> The **deadline wake** is the one capability with no `sendMessage` equivalent
+> today (`needsReply` has no timeout); it is retained precisely so `needsReply` can
+> gain an optional deadline on top of it, and until then no agent-reachable tool
+> offers a timeout-based wake.
+
 > This document is the concrete implementation design for
 > [`agents-collaboration-design.md`](agents-collaboration-design.md). That
 > document explains what and why; this document explains how it lands in the
@@ -51,7 +67,7 @@ daemon remains on the message hot path and CP remains off it.
 | **Peer discovery**          | `listAgents` (alias `listChannelAgents`) uses the `channel/agents` control request. Scope is the requester's **organization**, filtered by the directional call policy; `channel` is an optional narrowing filter. |
 | **Agent-to-agent delivery** | The `sendMessage` peer target invokes the internal `messageAgent` primitive locally or uses `rd/agentmsg` → `rd/agentmsg/fwd` → `rd/agentmsg/ack` across daemons. Message bodies never traverse CP.                |
 | **Call authorization**      | The caller's outbound policy and target's inbound policy must both allow the edge; directory, source daemon, relay, and target daemon verify independently.                                                        |
-| **Orchestration**           | `startOrchestration`, `getOrchestration`, and `cancelOrchestration` use durable daemon-local state, trusted correlation metadata, and deadline wakes.                                                              |
+| **Orchestration**           | Durable daemon-local state, trusted correlation metadata, and deadline wakes are live, but the `startOrchestration` / `getOrchestration` / `cancelOrchestration` tools are retired from the agent tool surface.    |
 | **Concurrency**             | Different sessions run concurrently; a per-`sessionKey` admission gate serializes one conversation and enforces queue/capacity limits.                                                                             |
 
 ### 1.3 Implemented Surface
@@ -61,9 +77,11 @@ daemon remains on the message hot path and CP remains off it.
 - `sendMessage` for peer wakes, parent-session replies, and visible platform
   posts; its peer branch uses the same-daemon or cross-daemon
   `messageAgent` delivery primitive.
+- `viewSessionStatus` for checking a child session the caller started.
 - A durable inbox and per-session admission gate.
 - Fan-out orchestration with correlated worker replies, deadlines, and
-  cancellation.
+  cancellation — **daemon-side only**; the three orchestration tools are no
+  longer part of the agent-facing surface.
 
 ### 1.4 Boundaries / Non-Goals
 
@@ -623,6 +641,11 @@ Human in thread T: @main please upgrade these three RPC nodes.
 
 ### 3.5a Orchestration API That the Main Agent Can Actually Call
 
+> **Retired surface.** The three tools below are no longer injected into any
+> agent's tool set (see the banner at the top of this document). The daemon-side
+> contract they describe — atomic record-first start, owner-scoped read, and
+> deadline-clearing cancel — is unchanged and still reachable internally.
+
 The daemon owns orchestration storage and exposes tools rather than asking a
 skill or prompt to mutate local state:
 
@@ -637,17 +660,18 @@ skill or prompt to mutate local state:
   ```
 - **Read/control tools:** `getOrchestration(orchestrationId)` lets main inspect all subtask/result state after wake. `cancelOrchestration(orchestrationId)` removes the deadline and writes the durable cancelled state. Section 3.3a `call_metadata` automatically preserves correlation in a worker response; main does not manually supply it.
 - **Completion trigger:** On every worker report or durable deadline wake, main calls `getOrchestration` and determines complete/timeout. Daemon applies the four section 3.3 correlation checks and idempotency when storing report results.
-- `startOrchestration`, `getOrchestration`, and `cancelOrchestration` live on
-  the daemon MCP tool surface; durable state lives in `local-store.ts`.
+- `startOrchestration`, `getOrchestration`, and `cancelOrchestration` are
+  declared in the daemon's MCP tool module but detached from every injected tool
+  set; durable state lives in `local-store.ts`.
 
 ### 3.6 Implemented Surface
 
-| Layer    | Behavior                                                                                                                                                                                             |
-| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Daemon   | Carries `correlationId` and trusted caller metadata through the turn, persists a daemon-local orchestration record before delivery, and applies idempotent state transitions and correlation checks. |
-| Deadline | Stores a cancellable one-shot deadline in the orchestration record and wakes `mainSessionKey` directly.                                                                                              |
-| Tools    | Exposes `startOrchestration`, `getOrchestration`, and `cancelOrchestration`; worker replies inherit trusted correlation metadata.                                                                    |
-| Tests    | Cover record-before-send, replay, partial delivery failure, forged or duplicate reports, serialized main wakes, N-of-N completion, deadline partial summaries, and worker errors.                    |
+| Layer    | Behavior                                                                                                                                                                                                          |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Daemon   | Carries `correlationId` and trusted caller metadata through the turn, persists a daemon-local orchestration record before delivery, and applies idempotent state transitions and correlation checks.              |
+| Deadline | Stores a cancellable one-shot deadline in the orchestration record and wakes `mainSessionKey` directly.                                                                                                           |
+| Tools    | `startOrchestration`, `getOrchestration`, and `cancelOrchestration` are retired from injection (still dispatchable for warm sessions and in-flight records); worker replies inherit trusted correlation metadata. |
+| Tests    | Cover record-before-send, replay, partial delivery failure, forged or duplicate reports, serialized main wakes, N-of-N completion, deadline partial summaries, and worker errors.                                 |
 
 ---
 

--- a/docs/designs/agents-collaboration-design.md
+++ b/docs/designs/agents-collaboration-design.md
@@ -114,9 +114,11 @@ There are two interaction paradigms. **Decision: combine them; support both.**
 **Key insight:** the planner model is a **subset** of the multi-agent model. It
 does not need to be a special agent type: define an ordinary agent named
 `planner`, tell it which peers exist, and require it to plan before calling
-them. First-class `startOrchestration`, `getOrchestration`, and
-`cancelOrchestration` tools provide the durable fan-out and collection
-mechanics; see §3 of
+them. Fan-out and collection are ordinary `sendMessage` calls with
+`toAgent.needsReply` plus `viewSessionStatus`; the first-class
+`startOrchestration` / `getOrchestration` / `cancelOrchestration` tools that once
+provided them are retired from the agent tool surface (their durable machinery is
+retained daemon-side) — see §3 of
 [`agent-collaboration-implementation.md`](agent-collaboration-implementation.md).
 
 **Unresolved:** we still lack a genuinely complex, highly dynamic real-world case that demonstrates the incremental value of a planner over pure peer-to-peer calls. Most internal cases so far have relatively fixed workflows.

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -971,12 +971,23 @@ send-only SDK client under `src/feishu/`; see
 
 ACP can only reply to the current thread. Daemon's **MCP Tool Server** adds proactive platform send / agent calls. Declare it in `session/new.mcpServers`; platform tokens remain in the connection and invisible to the agent.
 
-Implemented tools in `src/mcp/tools.ts`: `sendPlatformMessage`; collaboration
-`listAgents` (deprecated alias `listChannelAgents`) / `messageAgent`; channel/user information
+Implemented tools in `src/mcp/tools.ts`: the unified `sendMessage` (which absorbed the
+former `sendPlatformMessage` and `messageAgent`); collaboration `listAgents` (deprecated
+alias `listChannelAgents`) and `viewSessionStatus`; channel/user information
 `getCurrentChannel`, `listChannels`, `listKnownUsers`, `listChannelMembers`,
 `getUserProfile`; attachment readers `readSlackFile`, `readTelegramFile`;
-memory `readMemory`, `writeMemory`, `searchMemory`; orchestration
-`startOrchestration`, `getOrchestration`, `cancelOrchestration`; and others.
+memory `readMemory`, `writeMemory`, `searchMemory`; and others.
+
+The orchestration triple `startOrchestration` / `getOrchestration` /
+`cancelOrchestration` is **retired from the injected tool surface**: its send half
+duplicated `sendMessage` (fan-out to N workers is N `sendMessage` calls with
+`toAgent.needsReply`) and its status half duplicated `viewSessionStatus`. The descriptors
+live on in `RETIRED_ORCHESTRATION_TOOLS` and `executeTool` still dispatches them, so
+sessions already warm with the old descriptors and still-open orchestration records keep
+resolving — but no agent is offered them. The daemon-side machinery below (durable
+records, correlation recording, the re-armed deadline wake) is unchanged; the deadline is
+the one capability `sendMessage(needsReply)` cannot yet express and is kept so
+`needsReply` can gain an optional deadline on top of it.
 
 `listAgents` is **org**-scoped, not channel-scoped: it issues `channel/agents` with
 no channel and gets back every peer in the organization that the directional call

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -1252,6 +1252,12 @@ export async function executeTool(
   // session context, NEVER from tool input; only the subtasks / deadline / replyTarget
   // come from args. The daemon owns record-first persistence, per-subtask atomic
   // delivered|failed via the messageAgent path, and the one-shot deadline.
+  //
+  // RETIRED SURFACE: these three names are no longer injected into any agent's tool set
+  // (`RETIRED_ORCHESTRATION_TOOLS` in tools.ts) because the send half duplicated
+  // `sendMessage`. The dispatch stays so a session already warm with the old descriptors,
+  // and any still-open orchestration record, keep resolving. Do not re-advertise these
+  // without resolving the overlap with `sendMessage` + `viewSessionStatus` first.
   if (name === 'startOrchestration') {
     const rawSubtasks = args.subtasks
     if (!Array.isArray(rawSubtasks) || rawSubtasks.length === 0) {

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -632,7 +632,8 @@ export const EXTERNAL_MEMORY_TOOL_NAMES = new Set(
  * with; channel membership is only an optional filter on that answer. Waking a peer is
  * no longer a separate tool: it is `sendMessage` with `toAgent` (session-concept §4).
  * The requesting agent's identity is injected by the daemon from the session context —
- * it is NOT a tool input.
+ * it is NOT a tool input. Fan-out is likewise not a separate tool: the orchestration
+ * triple is retired, see {@link RETIRED_ORCHESTRATION_TOOLS}.
  */
 const LIST_AGENTS_INPUT_SCHEMA = () =>
   obj({
@@ -691,7 +692,30 @@ export const COLLABORATION_TOOLS: ToolDescriptor[] = [
       },
       ['sessionId']
     )
-  },
+  }
+]
+
+/**
+ * RETIRED from the advertised tool surface — kept here, and still dispatchable by
+ * `executeTool`, but injected into NO agent's tool set.
+ *
+ * Why: the send half duplicated `sendMessage`. A fan-out to N workers is N
+ * `sendMessage({ toAgent: { agentId, needsReply: true } })` calls, and status lookup is
+ * `viewSessionStatus`. Offering both made "give work to another agent" ambiguous, so the
+ * orchestration triple is no longer offered.
+ *
+ * What is NOT retired: the daemon-side machinery behind these names — the durable
+ * orchestration/subtask records, correlation recording on worker reports, and the one-shot
+ * session-anchored DEADLINE WAKE (re-armed from the store on daemon startup). That deadline
+ * is the one capability `sendMessage(needsReply)` cannot express today (it has no timeout),
+ * and it is kept intact so `needsReply` can gain an optional deadline on top of it.
+ *
+ * These descriptors stay dispatchable and stay in {@link ALL_TOOL_NAMES} on purpose: an ACP
+ * session that went warm with the old descriptors, and any orchestration record that is
+ * still in flight, must keep resolving. Re-enabling is a one-line move back into
+ * {@link COLLABORATION_TOOLS}.
+ */
+export const RETIRED_ORCHESTRATION_TOOLS: ToolDescriptor[] = [
   {
     name: 'startOrchestration',
     description:
@@ -816,6 +840,10 @@ export const ALL_TOOL_NAMES = [
       ...KNOWLEDGE_TOOLS,
       ...Object.values(EXTERNAL_MEMORY_TOOLS),
       ...COLLABORATION_TOOLS,
+      // Retired from injection but still dispatched by `executeTool`, so the name stays
+      // reserved (no evaluation tool may shadow it) and auto-allowed (a session warm with
+      // the old descriptor, or an in-flight orchestration, must not start hitting approval).
+      ...RETIRED_ORCHESTRATION_TOOLS,
       ...GITHUB_REVIEW_TOOLS
     ].map((t) => t.name)
   )

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { toolsForIntegrations, ALL_TOOL_NAMES, GITHUB_REVIEW_TOOLS, externalMemoryTools } from '../src/mcp/tools.js'
+import {
+  toolsForIntegrations,
+  ALL_TOOL_NAMES,
+  COLLABORATION_TOOLS,
+  GITHUB_REVIEW_TOOLS,
+  RETIRED_ORCHESTRATION_TOOLS,
+  externalMemoryTools
+} from '../src/mcp/tools.js'
 import type { Integration } from '../src/agents/agent-schema.js'
 
 const slackInt: Integration = {
@@ -298,14 +305,27 @@ describe('toolsForIntegrations', () => {
       // still offered under the old name, for sessions already warm with it
       'listChannelAgents',
       'viewSessionStatus',
-      'startOrchestration',
-      'getOrchestration',
-      'cancelOrchestration',
       'sendMessage'
     ])
   })
 
-  it('removes peer/orchestration targets for a collaboration-off treatment while preserving platform sends', () => {
+  it('never advertises the retired orchestration tools to any agent', () => {
+    const retired = ['startOrchestration', 'getOrchestration', 'cancelOrchestration']
+    const surfaces = [
+      toolsForIntegrations([]),
+      toolsForIntegrations([slackInt, telegramInt, discordInt], { sessionTitle: true, organizationKnowledge: true }),
+      toolsForIntegrations([slackInt], { collaboration: false })
+    ]
+    for (const tools of surfaces) {
+      for (const name of retired) expect(tools.map((t) => t.name)).not.toContain(name)
+    }
+    // The descriptors themselves are deliberately KEPT (the deadline machinery behind them
+    // is still live and re-armable), just detached from every injected surface.
+    expect(RETIRED_ORCHESTRATION_TOOLS.map((t) => t.name)).toEqual(retired)
+    expect(COLLABORATION_TOOLS.map((t) => t.name)).not.toEqual(expect.arrayContaining(retired))
+  })
+
+  it('removes peer targets for a collaboration-off treatment while preserving platform sends', () => {
     expect(toolsForIntegrations([], { collaboration: false }).map((tool) => tool.name)).toEqual([
       'readMemory',
       'writeMemory'
@@ -313,9 +333,9 @@ describe('toolsForIntegrations', () => {
 
     const tools = toolsForIntegrations([slackInt], { collaboration: false })
     const names = tools.map((tool) => tool.name)
-    expect(names).not.toEqual(
-      expect.arrayContaining(['listAgents', 'listChannelAgents', 'startOrchestration', 'getOrchestration'])
-    )
+    for (const gone of ['listAgents', 'listChannelAgents', 'viewSessionStatus']) {
+      expect(names).not.toContain(gone)
+    }
     expect(names).toContain('sendMessage')
     const send = tools.find((tool) => tool.name === 'sendMessage')!
     const schema = send.inputSchema as unknown as ObjectSchema
@@ -350,7 +370,7 @@ describe('toolsForIntegrations', () => {
     )
   })
 
-  it('ALL_TOOL_NAMES lists every injectable tool exactly once', () => {
+  it('ALL_TOOL_NAMES reserves every dispatchable product tool exactly once', () => {
     expect(new Set(ALL_TOOL_NAMES).size).toBe(ALL_TOOL_NAMES.length)
     expect(ALL_TOOL_NAMES).toEqual(
       expect.arrayContaining([
@@ -369,6 +389,9 @@ describe('toolsForIntegrations', () => {
     // The merged-away tool names are gone.
     expect(ALL_TOOL_NAMES).not.toContain('sendPlatformMessage')
     expect(ALL_TOOL_NAMES).not.toContain('messageAgent')
+    // The orchestration triple is retired from INJECTION but `executeTool` still dispatches
+    // it for warm sessions / in-flight records, so the names stay reserved + auto-allowed.
+    for (const retired of RETIRED_ORCHESTRATION_TOOLS) expect(ALL_TOOL_NAMES).toContain(retired.name)
   })
 
   it('projects only reviewed external-memory capabilities onto stable core tool names', () => {


### PR DESCRIPTION
## Why

`startOrchestration` conflicts with `sendMessage`. Its send half is duplicated work: a fan-out to N workers is N `sendMessage({ toAgent: { agentId, needsReply: true } })` calls, and its status half is `viewSessionStatus`. Two tool surfaces both meaning "give work to another agent" is an ambiguity agents have to resolve at runtime, so the orchestration triple is no longer offered.

## What changed

- `startOrchestration`, `getOrchestration`, and `cancelOrchestration` move out of `COLLABORATION_TOOLS` into a new `RETIRED_ORCHESTRATION_TOOLS` in `packages/daemon/src/mcp/tools.ts`. That array is injected into **no** agent's tool set, on any integration combination, with or without the collaboration treatment.
- Docs that advertised orchestration as an agent capability are updated: `docs/designs/agent-collaboration-implementation.md` (banner + §1.2/§1.3/§3.5a/§3.6), `docs/designs/agents-collaboration-design.md`, `docs/designs/daemon-detailed-design.md` §9.4 (whose tool list was also still naming the long-merged `sendPlatformMessage` / `messageAgent`).
- Tests pin the removal: a new case asserts the three names appear on no injected surface, and the existing exact-surface and `ALL_TOOL_NAMES` cases are updated rather than left passing for the wrong reason.

## What was deliberately kept

The machinery behind the tools is untouched and still exercised by `packages/daemon/test/orchestration.test.ts` (17 tests, all passing, including the startup re-arm):

- durable orchestration/subtask records in `local-store.ts`
- the four correlation checks and idempotent worker-report recording
- the **one-shot, session-anchored deadline wake** and its re-arm from the store on daemon startup

The deadline is the one capability with no `sendMessage` equivalent: `needsReply` has no timeout, so an agent whose workers all die is never woken at all. It is retained specifically so `needsReply` can gain an optional deadline reusing this machinery.

## In-flight behavior

`executeTool` still dispatches the three names, and they stay in `ALL_TOOL_NAMES`. That is intentional and has two effects:

1. An ACP session already warm with the old descriptors, and any orchestration record still open, keep resolving — including staying inside the permission auto-allow set rather than suddenly hitting approval.
2. The names stay reserved, so no evaluation tool can shadow a name the daemon still handles.

Scheduled deliveries and deadlines therefore continue to fire and be recorded exactly as before. What goes away is an agent's ability to *start* or *query* an orchestration from a freshly built tool set.

One honest consequence: if a daemon restarts while an orchestration is open, it re-arms and fires the deadline wake as usual, but the main agent's re-spawned session no longer carries a `getOrchestration` descriptor, so it cannot read the partial results the wake is asking it to summarize. Records already in that state are the only ones affected, and the data is intact in the store.

## Reversibility

Re-enabling is a one-line move of `RETIRED_ORCHESTRATION_TOOLS` back into `COLLABORATION_TOOLS`.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm format:check` — clean
- `pnpm eval:collab:contracts` — 15 files / 115 tests passing
- daemon tool-surface + orchestration tests (`mcp-tools`, `mcp-ops`, `orchestration`, `daemon-permission-autoallow`, `mcp-control-server`, `mcp-bridge-e2e`) — 183 passing

The full `pnpm --filter @agentconnect.md/daemon test` run has failures in `daemon-agent-mention-routing`, `daemon-platform-authorship`, `cp/cp-agent-reconcile`, and `acp-matrix`. These reproduce on a pristine checkout of the base commit and pass in isolation (timing/load-sensitive, and `acp-matrix` needs real installed runtimes) — they are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)