### PR TITLE
fix(web): stop reporting an unverifiable conversation as invisible

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -794,7 +794,9 @@ export function buildContainer(
     botSecrets: repos.botSecret,
     clock,
     ...(logtoIdentity ? { identity: logtoIdentity } : {}),
-    ...(opts.slackFetch ? { fetchImpl: opts.slackFetch } : {})
+    ...(opts.slackFetch ? { fetchImpl: opts.slackFetch } : {}),
+    // Lazy over `http.log` (assigned below; only ever called at resolve time).
+    log: { warn: (o, m) => http.log.warn(o, m) }
   })
   const githubSessionAccess = new GithubSessionAccessService({
     installations: repos.githubInstallation,

--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -40,12 +40,16 @@ function bot(): BotRecord {
   } as BotRecord
 }
 
-function service(fetchImpl: (url: string, init?: RequestInit) => Promise<Response>) {
+function service(
+  fetchImpl: (url: string, init?: RequestInit) => Promise<Response>,
+  log?: { warn: (obj: object, msg: string) => void }
+) {
   return new SlackSessionAccessService({
     bots: { getUnscoped: async () => bot() } as never,
     botSecrets: { get: async () => ({ botToken: 'xoxb-test' }) } as never,
     clock: { now: () => 1_000 } as never,
-    fetchImpl
+    fetchImpl,
+    ...(log ? { log } : {})
   })
 }
 
@@ -202,6 +206,41 @@ describe('SlackSessionAccessService', () => {
       allowedScopes: [],
       degraded: true
     })
+  })
+
+  // Degradation is the ONLY trace a hidden session leaves: every failure above
+  // collapses to `unknown`, the session is omitted, and the caller is told
+  // "not visible". Without this line an operator cannot tell a Slack blip from
+  // a real denial after the fact — which is exactly how an intermittent
+  // vanishing conversation stayed undiagnosable.
+  it('logs the degradation, with counts rather than channel keys', async () => {
+    const warn = vi.fn()
+    const resolver = service(async () => json({ ok: false, error: 'ratelimited' }), { warn })
+
+    await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]?.[0]).toEqual({ provider: 'slack', unknownScopes: 1, totalScopes: 1 })
+    // A scope key names a channel; the operator needs the rate, not the target.
+    expect(JSON.stringify(warn.mock.calls[0]?.[0])).not.toContain('C_')
+  })
+
+  it('stays silent when every check answered', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('conversations.info')) {
+        return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+      }
+      if (url.includes('users.info')) {
+        return json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+      }
+      throw new Error(`unexpected Slack request: ${url}`)
+    })
+
+    const result = await service(fetchImpl, { warn }).resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+    expect(result.degraded).toBe(false)
+    expect(warn).not.toHaveBeenCalled()
   })
 
   // A deleted private channel — and a bot removed from one, which is the same

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -81,6 +81,12 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
       clock: Clock
       fetchImpl?: FetchLike
       identity?: Pick<LogtoIdentityService, 'slackIdentityFor'>
+      /** Optional so tests can omit it. Without one a degraded check leaves NO
+       *  trace anywhere: every failure below collapses to `unknown`, which is
+       *  reported to the caller as a hidden session and to the operator as
+       *  nothing at all — which is what made an intermittent Slack blip
+       *  indistinguishable, after the fact, from a real authorization denial. */
+      log?: { warn: (obj: object, msg: string) => void }
     }
   ) {}
 
@@ -110,6 +116,20 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
           if (decision === 'unknown') degraded = true
           return { scope, decision }
         }))
+      )
+    }
+    // One line per degraded RESOLVE, not per scope: enough to correlate a user
+    // reporting a vanished conversation with a Slack-side blip, without a log
+    // entry per channel on a busy list. Counts only — a scope key names a
+    // channel, and the operator needs the rate, not the targets.
+    if (degraded) {
+      this.deps.log?.warn(
+        {
+          provider: 'slack',
+          unknownScopes: decisions.filter(({ decision }) => decision === 'unknown').length,
+          totalScopes: decisions.length
+        },
+        'slack access check degraded — affected sessions are hidden until access can be verified'
       )
     }
     return {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -62,7 +62,8 @@ import { usePgDraft, usePgDraftHasText, usePlayground } from '@/components/conso
 import { AgentIconView, LoadingState, ModelMark, PlatformMark, SocialLoginMark, Spinner } from '@/components/marks'
 import { MessageText } from '@/components/console/MessageText'
 import { NotFound } from '@/components/console/NotFound'
-import { Avatar, Icon } from '@/components/ui'
+import SessionAccessNotice from '@/components/console/SessionAccessNotice'
+import { Avatar, Button, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 import { formatTranscriptRowTime, transcriptRowTimeMs } from '@/lib/transcript-time'
 import { sessionResumeMembers, sessionResumeState } from '@/lib/session-resume'
@@ -1107,13 +1108,21 @@ export default function SessionDetailView() {
   // fan-out and the participants roster.
   const conversationKey = conversationKeyParam ? decodeURIComponent(conversationKeyParam) : null
   const {
-    data: conversationRoster,
+    data: conversationResolution,
     error: conversationError,
-    isLoading: conversationLoading
+    isLoading: conversationLoading,
+    mutate: retryConversation
   } = useSWR(
     conversationKey && activeOrg?.id ? (['conversation-by-key', activeOrg.id, conversationKey] as const) : null,
     ([, orgId, key]) => fetchConversationByKey(key, orgId)
   )
+  // Unwrap to the roster the rest of this view reads, keeping the two states it
+  // distinguishes: `undefined` is still "in flight", `null` still "the resolver
+  // answered with nothing". Degradation rides alongside rather than collapsing
+  // into either — an empty answer the CP could not verify is not an absence.
+  const conversationRoster = conversationResolution === undefined ? undefined : conversationResolution.conversation
+  const conversationAccessDegraded = conversationResolution?.accessSyncDegraded === true
+  const conversationAccessIssues = conversationResolution?.accessIssues ?? []
   const conversationMembers = conversationKey ? (conversationRoster?.sessions ?? null) : null
   const id = conversationKey ? (conversationMembers?.[0]?.sessionId ?? '') : (routeId ?? '')
   const conversationSourceKey =
@@ -1449,11 +1458,16 @@ export default function SessionDetailView() {
       thread: currentSessionDetail.thread
     })
   }, [conversationKey, currentSessionDetail])
-  const { data: selfConversation, isLoading: selfConversationLoading } = useSWR(
+  const { data: selfConversationResolution, isLoading: selfConversationLoading } = useSWR(
     selfKey && activeOrg?.id ? (['conversation-by-key', activeOrg.id, selfKey] as const) : null,
     ([, orgId, key]) => fetchConversationByKey(key, orgId),
     { revalidateOnFocus: false }
   )
+  // Same unwrap as the conversation-mode roster above: `undefined` stays
+  // in-flight, so the §5.3 redirect still waits rather than reading a probe that
+  // has not answered as a single-participant thread.
+  const selfConversation =
+    selfConversationResolution === undefined ? undefined : selfConversationResolution.conversation
   const selfConversationPathname = selfConversationPath({
     flatView,
     conversationKey: selfKey,
@@ -2192,8 +2206,36 @@ export default function SessionDetailView() {
       </SessionDetailFrame>
     )
   }
-  if (conversationKey && (conversationError || !conversationRoster || conversationRoster.sessions.length === 0)) {
-    // conversationError, a grace-expired null, or a resolved-but-empty roster.
+  // A failed read and an unverifiable one are NOT absence, and saying "not found
+  // — or not visible to you" for either states an authorization verdict the
+  // console never actually got. The request erroring is self-evidently not an
+  // answer; a DEGRADED answer is subtler — the CP fails external access checks
+  // closed, so a Slack API blip omits the very members it could not check and
+  // the roster arrives empty with `accessSyncDegraded` set. Both are transient
+  // and retryable, so say so and offer the retry.
+  if (conversationKey && (conversationError || (conversationAccessDegraded && !conversationRoster))) {
+    return (
+      <SessionDetailFrame withRail={false}>
+        <div className="card p-6">
+          <SessionAccessNotice degraded issues={conversationAccessIssues} impact="sessions" />
+          <div className="font-sans text-[13.5px] leading-[1.55] text-(--text-secondary)">
+            {conversationError
+              ? 'This conversation could not be loaded. The console could not reach the control plane.'
+              : 'This conversation cannot be shown until its access checks can be verified.'}
+          </div>
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <Button onClick={() => void retryConversation()}>Try again</Button>
+            <Link className="lnk font-sans text-[12.5px] font-medium leading-normal" href={orgPath('/sessions')}>
+              Back to sessions
+            </Link>
+          </div>
+        </div>
+      </SessionDetailFrame>
+    )
+  }
+  if (conversationKey && (!conversationRoster || conversationRoster.sessions.length === 0)) {
+    // A grace-expired null or a resolved-but-empty roster, with the access
+    // checks themselves healthy — so absence here is a real answer.
     return (
       <SessionDetailFrame withRail={false}>
         <NotFound

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -9,6 +9,7 @@ import {
   deleteOrgIcon,
   fetchAllGithubRepos,
   fetchConversations,
+  fetchConversationByKey,
   fetchSessionFacets,
   fetchGithubRepoRoster,
   fetchMySessionIdentity,
@@ -819,5 +820,48 @@ describe('retention-purge projection (#485)', () => {
 
     const page = await fetchConversations(undefined, 50, 'org-1')
     expect(page.sessions[0]!.contentPurgedAt).toBeUndefined()
+  })
+})
+
+// The resolver's empty answer is the console's "not visible to you" verdict, so
+// the flag that says the CP could not actually CHECK has to survive the call.
+// The CP fails external access checks closed — an unverifiable member is simply
+// omitted — which is what made a Slack blip read as a permanent denial.
+describe('fetchConversationByKey degradation', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const respond = (body: unknown) =>
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () => new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+    )
+
+  it('keeps a degraded empty answer distinguishable from a real absence', async () => {
+    respond({ conversations: [], total: 0, nextCursor: null, accessSyncDegraded: true, accessIssues: [] })
+
+    await expect(fetchConversationByKey('k', 'org-1')).resolves.toEqual({
+      conversation: null,
+      accessSyncDegraded: true,
+      accessIssues: []
+    })
+  })
+
+  it('reports a healthy empty answer as a real absence', async () => {
+    respond({ conversations: [], total: 0, nextCursor: null })
+
+    await expect(fetchConversationByKey('k', 'org-1')).resolves.toEqual({
+      conversation: null,
+      accessSyncDegraded: false,
+      accessIssues: []
+    })
+  })
+
+  it('carries the issues through so the notice can name the cause', async () => {
+    const issues = [{ provider: 'feishu', reason: 'quota', region: 'lark' }]
+    respond({ conversations: [], total: 0, nextCursor: null, accessSyncDegraded: true, accessIssues: issues })
+
+    await expect(fetchConversationByKey('k', 'org-1')).resolves.toMatchObject({ accessIssues: issues })
   })
 })

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2014,13 +2014,32 @@ export async function fetchSessions(
   }
 }
 
+/** What the key-addressed resolver answered for one conversation. */
+export interface ConversationResolution {
+  /** The conversation's currently visible member sessions, or null when the
+   *  caller can see none of them. */
+  conversation: ConversationDto | null
+  /** Whether an external access check could not be completed for this answer.
+   *  The CP fails those CLOSED — a member whose visibility it could not
+   *  determine is omitted — so a degraded empty answer means "we could not
+   *  check", NOT "you cannot see it". Dropping this flag is what made a Slack
+   *  API blip read as a permanent authorization verdict. */
+  accessSyncDegraded: boolean
+  accessIssues: SessionAccessIssue[]
+}
+
 /** Resolve one conversation's current visible member sessions by its §5.1 key
- *  (the bounded key-addressed resolver). Null when the caller can see none of
- *  the members (indistinguishable from a conversation that never existed). */
-export async function fetchConversationByKey(key: string, orgId?: string): Promise<ConversationDto | null> {
+ *  (the bounded key-addressed resolver). An empty answer is only a real
+ *  "nothing here you can see" when `accessSyncDegraded` is false — see above;
+ *  a caller that reports absence must consult it. */
+export async function fetchConversationByKey(key: string, orgId?: string): Promise<ConversationResolution> {
   const q = new URLSearchParams({ conversationKey: key })
   const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`)
-  return page.conversations?.[0] ?? null
+  return {
+    conversation: page.conversations?.[0] ?? null,
+    accessSyncDegraded: page.accessSyncDegraded === true,
+    accessIssues: page.accessIssues ?? []
+  }
 }
 
 /** The grouped sessions list (merged-conversation-view.md §5.2): one row per


### PR DESCRIPTION
## The bug

Opening a conversation sometimes rendered:

> **Conversation not found** — No conversation `…` in this organization — or none of its participants are visible to you.

…for a thread the caller can see perfectly well. Reloading fixed it. That copy states an authorization verdict the console never actually got.

## Root cause

Three different outcomes were landing in one branch:

```js
if (conversationKey && (conversationError || !conversationRoster || conversationRoster.sessions.length === 0))
```

| Outcome | What it means | Was shown as |
| --- | --- | --- |
| request **failed** | network / auth blip | "not visible to you" |
| answer **empty + degraded** | the CP *could not check* | "not visible to you" |
| answer **empty + healthy** | genuinely not visible | "not visible to you" ✅ |

Only the third is about permission.

**The degraded case is the subtle one.** The CP fails external access checks *closed* — `slack-session-access.ts` maps any non-definitive failure to `unknown`, and an `unknown` scope is omitted from `allowedScopes`. So a Slack API blip (or a batch overrunning the **shared 5s** `AbortSignal.timeout`, which covers a whole batch rather than one call) returns **`200` with an empty roster and `accessSyncDegraded: true`**. `fetchConversationByKey` kept only `conversations[0]` and dropped that flag, so the console could not tell "we couldn't check" from "you can't see it".

Note this path produces **no error and no non-2xx** — consistent with control-plane logs for the affected window showing `200`×198, `204`×177, and zero 5xx/401 on that endpoint.

## Evidence

Blocking exactly one `conversationKey` request in a live console — nothing else — reproduced the message immediately; restoring `fetch` and revalidating brought the conversation straight back. That confirms the error→404 path directly. The degraded→404 path is confirmed by construction from the CP code above.

## The fix

1. **Keep the flag.** `fetchConversationByKey` returns `ConversationResolution { conversation, accessSyncDegraded, accessIssues }`.
2. **Split the branch.** A failed or unverifiable read renders the existing `SessionAccessNotice` (*"access checks are unavailable … hidden until access can be verified"*, including its Feishu quota/authorization variants) plus a **Try again**. Only a *healthy* empty answer keeps the not-found copy.
3. **Log the degradation.** Every failure in the Slack check collapses to `unknown` through a bare `catch {}` with **no logging anywhere**, so a hidden session left no trace to correlate against — which is why this needed a client-side experiment to find. Now one line per degraded resolve.

## Reviewer notes

- **The roster unwrap is deliberately semantics-preserving**: `undefined` still means in-flight and `null` still means answered-empty, so all ~12 downstream readers are untouched.
- **The log is counts-only** (`unknownScopes`, `totalScopes`). A scope key names a channel; the diagnostic value is the rate, not the target. A test asserts no channel key leaks into the log line.
- **The new `log` dep follows existing precedent** — `container.ts` already builds services before `http` exists using lazy `log: { warn: (o, m) => http.log.warn(o, m) }` wrappers (see the memory-push and daemon services). It is optional, so tests need not supply one. If you'd rather not grow the access-plugin seam, item 3 is cleanly separable from 1–2.
- Degradation only overrides when the roster is **empty**; a degraded-but-populated answer still renders normally, matching how the sessions list already behaves.

## Verification

- Web: **906 tests** pass (114 files). Control plane: **1278 unit tests** pass (135 files).
- Typecheck, eslint, prettier clean in both packages.
- New coverage: degraded-vs-healthy empty answers survive the resolver; the degraded resolve logs with counts and no channel key; a healthy resolve stays silent.
- **Not verified end-to-end in a browser**: production CORS restricts the API to the deployed console origin, so a local dev server cannot reach it, and `MOCK_MODE` takes a different path. The error→404 half was verified against the live console by request interception, as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
