### PR TITLE
fix(web): drop the stale SessionAccessNotice reference

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -62,7 +62,6 @@ import { usePgDraft, usePgDraftHasText, usePlayground } from '@/components/conso
 import { AgentIconView, LoadingState, ModelMark, PlatformMark, SocialLoginMark, Spinner } from '@/components/marks'
 import { MessageText } from '@/components/console/MessageText'
 import { NotFound } from '@/components/console/NotFound'
-import SessionAccessNotice from '@/components/console/SessionAccessNotice'
 import { Avatar, Button, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 import { formatTranscriptRowTime, transcriptRowTimeMs } from '@/lib/transcript-time'
@@ -1122,7 +1121,6 @@ export default function SessionDetailView() {
   // into either — an empty answer the CP could not verify is not an absence.
   const conversationRoster = conversationResolution === undefined ? undefined : conversationResolution.conversation
   const conversationAccessDegraded = conversationResolution?.accessSyncDegraded === true
-  const conversationAccessIssues = conversationResolution?.accessIssues ?? []
   const conversationMembers = conversationKey ? (conversationRoster?.sessions ?? null) : null
   const id = conversationKey ? (conversationMembers?.[0]?.sessionId ?? '') : (routeId ?? '')
   const conversationSourceKey =
@@ -2217,7 +2215,6 @@ export default function SessionDetailView() {
     return (
       <SessionDetailFrame withRail={false}>
         <div className="card p-6">
-          <SessionAccessNotice degraded issues={conversationAccessIssues} impact="sessions" />
           <div className="font-sans text-[13.5px] leading-[1.55] text-(--text-secondary)">
             {conversationError
               ? 'This conversation could not be loaded. The console could not reach the control plane.'


### PR DESCRIPTION
`main` does not build — [Test / Build on ea940eb](https://github.com/agentconnect-md/agentconnect/actions/runs/31124394128/job/92691893882):

```
./packages/web/src/components/console/views/SessionDetailView.tsx:65:1
Module not found: Can't resolve '@/components/console/SessionAccessNotice'
```

### How it got there

A semantic conflict between two PRs that were each green alone:

- #738 taught the conversation card to explain an unverifiable read by rendering `SessionAccessNotice`.
- #735, branched before that and merged after it, deleted the component as part of moving the Sessions and Usage banners into the notification center. It removed the call sites it knew about — `SessionsView`, `UsageView` — and could not have known about the one #738 had just added.

Nothing in the two diffs overlaps textually, so the merge was clean.

### The fix

Three deletions: the import, the render, and the `conversationAccessIssues` list that fed it. The card's own sentence and its retry stay; the access-degradation copy lives in the notification center now, which is where #735 moved it.

### Verification

`pnpm --filter @agentconnect.md/web build` (the job that failed), `typecheck`, `eslint`, `prettier --check`, and the web suite — 939 tests, 119 files — all pass locally.

### Note, not fixed here

`typecheck:ci` covers control-plane, daemon and setup only, so the Build job is the *only* type gate web has. That is why Check went green on the same commit that failed to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)