### PR TITLE
chore: write NUL key separators as escapes instead of raw bytes

### DIFF
--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -1666,8 +1666,8 @@ describe('LocalStore activation rendezvous (send-message-routing-rework.md §3.2
     // time; admitting both would strand a delivery that never persisted. The inbox row is
     // the only evidence that distinguishes them.
     const s = store()
-    const durable = ['slack', 'scope-1', 'ts-durable', 'agent-target'].join(' ')
-    const lost = ['slack', 'scope-1', 'ts-lost', 'agent-target'].join(' ')
+    const durable = ['slack', 'scope-1', 'ts-durable', 'agent-target'].join('\u0000')
+    const lost = ['slack', 'scope-1', 'ts-lost', 'agent-target'].join('\u0000')
     expect(s.attachActivationEnvelope(durable, ENVELOPE, 1000, 'delivery-durable').dispatch).toBe(true)
     expect(s.attachActivationEnvelope(lost, ENVELOPE, 1000, 'delivery-lost').dispatch).toBe(true)
     // Only the first one's turn actually reached the durable queue before the crash.

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1733,9 +1733,11 @@ export default function SessionDetailView() {
     if (railAgentIds.length === 1) return getSessions(railAgentIds[0]!)
     // The demo fixtures carry no conversation grouping, so stand in for it with
     // the channel — enough for the multi-agent filter to behave like the real one.
-    const channelsOf = (agentId: string) => new Set(getSessions(agentId).map((s) => `${s.platform} ${s.channel}`))
+    const channelsOf = (agentId: string) => new Set(getSessions(agentId).map((s) => `${s.platform}\0${s.channel}`))
     const shared = railAgentIds.map(channelsOf).reduce((a, b) => new Set([...a].filter((c) => b.has(c))))
-    return allSessions.filter((s) => railAgentIds.includes(s.agentId ?? '') && shared.has(`${s.platform} ${s.channel}`))
+    return allSessions.filter(
+      (s) => railAgentIds.includes(s.agentId ?? '') && shared.has(`${s.platform}\0${s.channel}`)
+    )
   }, [allSessions, getSessions, railAgentIds, railQuery, railSessionRows])
   // The open row as the rail sees it: its conversation and, where the resolver
   // has answered, that conversation's full membership. Both are identity the rail


### PR DESCRIPTION
Two composite-key separators were written as literal `0x00` bytes in the source
rather than as an escape sequence. They are deliberate separators and the strings
they build are correct — the problem is purely that a raw control byte in the file
makes every content tool classify it as binary.

Concretely, before this change:

- `grep -r` skipped `SessionDetailView.tsx` entirely, with no output and no warning.
- `rg` stopped after the first match: "stopped searching binary file".
- `git diff` / `git show` needed `--text` to render either file.

That silence has already cost us once. When `SessionAccessNotice.tsx` was removed
in #735, the grep for its remaining references could not see the import that this
same file had just gained, so the stale reference shipped and the build broke on
main.

## The change

An escaped NUL produces exactly the same one-character string as the raw byte, so
this is a zero-behavior change.

| File | Separator now written as | Why that form |
| --- | --- | --- |
| `packages/web/.../SessionDetailView.tsx` | backslash-zero | two template literals in the MOCK_MODE rail-filter memo |
| `packages/daemon/test/local-store.test.ts` | backslash-u-0000 | matches the sibling `KEY` constant built the same way ~135 lines above, and the production key builder in `daemon/src/daemon.ts` |

Prettier rewraps one `return` in the web file: the escape is one source character
wider than the raw byte, which pushed that line from 120 to 121 columns.

A repo-wide sweep of every tracked file found no other raw NUL bytes in source —
only genuine binary assets (three PNGs, a GIF, a JPG).

## Verification

- `rg "SessionAccessNotice|channelsOf" packages/web/.../SessionDetailView.tsx` now
  returns all four matches as text, including the `SessionAccessNotice` import that
  was previously invisible.
- Both files contain zero `0x00` bytes.
- `pnpm --filter @agentconnect.md/web test` — 119 files, 939 tests passed.
- `pnpm --filter @agentconnect.md/daemon exec vitest run test/local-store.test.ts` —
  71 tests passed.
- `prettier --check` and `eslint` clean on both files.
- String identity confirmed directly: the escaped and raw-byte forms compare equal.

## Note: `web typecheck` is already failing on main

`pnpm --filter @agentconnect.md/web typecheck` fails on this branch with one error:

```
src/components/console/views/SessionDetailView.tsx(65,33): error TS2307:
Cannot find module '@/components/console/SessionAccessNotice'
```

This is **pre-existing and not caused by this PR** — I stashed the change and
reproduced the identical single error on pristine `origin/main` (`ea940eb9`).
`SessionAccessNotice.tsx` does not exist in the tree, and the error count is 1
both with and without this change.

In other words the breakage described above is still open on main. I have
deliberately left it alone to keep this PR to the one mechanical concern; it wants
its own fix, either restoring the component or dropping the import and its use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
