### PR TITLE
refactor(cp): retire the pre-scoping decrypt arm and harden the pass-through

### DIFF
--- a/docs/designs/per-org-secret-encryption.md
+++ b/docs/designs/per-org-secret-encryption.md
@@ -142,13 +142,19 @@ acv1:vault:v<key-version>:<base64>
  version      (opaque; nonce + AES-256-GCM ciphertext + tag)
 ```
 
-`open` has exactly three arms, in order:
+`open` has two arms, plus two refusals:
 
-| Stored value starts with | Behaviour                                                                         |
-| ------------------------ | --------------------------------------------------------------------------------- |
-| `acv1:`                  | strip, decrypt the remainder under `scope`'s key                                  |
-| `vault:v`                | legacy single-key value — decrypt under the deployment key, ignoring `scope` (§7) |
-| anything else            | never sealed — return unchanged (existing contract)                               |
+| Stored value starts with | Behaviour                                           |
+| ------------------------ | --------------------------------------------------- |
+| `acv1:`                  | strip, decrypt the remainder under `scope`'s key    |
+| anything unsealed        | never sealed — return unchanged (existing contract) |
+| `vault:v` (pre-scoping)  | **throws** — see §7                                 |
+| `acvN:` for an unknown N | **throws** — a newer envelope than this build knows |
+
+The two refusals matter more than they look. The pass-through arm exists for
+plaintext rows, and it fails OPEN by design; anything that is genuinely sealed
+but unreadable here must not fall into it, because the returned string is shipped
+onward as a live credential. A loud error is the only safe answer.
 
 Key names:
 
@@ -344,57 +350,39 @@ operator policy that must be stated alongside the guarantee. It does not reach
 plaintext already delivered to a daemon, which lives on customer-owned
 infrastructure. And it is only as complete as the migration in §7.
 
-## 7. Migration
+## 7. Migration — complete
 
-Existing deployments already hold ciphertext sealed under the single key. The
-legacy arm of `open` (§4) keeps every such value readable with no backfill and
-no downtime, so the rollout is a deploy, not a migration window.
+Deployments that already held ciphertext under the single key were converged by
+the rewrap sweep (`secrets/rewrap.ts`), which resolves each row's owning
+organization and re-seals under that key. All three environments were swept and
+verified to hold zero pre-scoping values, so **the legacy arm has been retired**:
+a bare `vault:vN:` value now throws rather than decrypting under the deployment
+key.
 
-The guarantee, however, **is not real until convergence**: a value still sealed
-under the deployment key is readable after its organization's key is destroyed.
-The order is therefore:
+Retiring it was not only tidiness. That arm ignored the asserted `scope` and read
+under the deployment key, which is precisely the fence §2.1 exists to build; it
+was a hole justified only by being temporary. It is gone now that nothing needs
+it.
 
-1. Deploy. New writes seal under org keys; legacy values keep reading.
-2. Run the rewrap sweep (`secrets/rewrap.ts`) per environment. It resolves each
-   row's scope and re-seals under the correct key.
-3. Only then is per-organization shredding a claim that holds. Until step 2
-   completes, deleting an organization destroys a key that some of its values
-   were never sealed under — the deletion is real, the guarantee is partial.
+Consequences worth stating plainly:
 
-**Known rolling-update window — accepted, and only safe pre-release.** The
-envelope tag is new, so a binary from before this change does not recognize it:
-its `open` sees no `vault:vN:` prefix, takes the pass-through arm, and returns
-the envelope string itself as if it were plaintext. While old and new replicas
-overlap, an old replica reading a value a new one just wrote hands out
-`acv1:vault:…` verbatim — silently wrong rather than an error. The window closes
-when the rollout finishes, and reconciliation re-delivers correct values after
-it, but anything read during it is garbage.
-
-A released deployment must therefore split this into two releases: one that only
-**recognizes** the envelope, fully rolled out, and a later one that starts
-**writing** it. That was deliberately skipped here because no deployment has
-shipped to users yet. **Do not treat the single-release form as the pattern** —
-any future change to the envelope grammar owes the two-release sequence, and the
-pass-through arm is the reason: it fails open by design, which is right for
-never-sealed plaintext and wrong for a format the reader simply does not know
-yet.
-
-The deployment key is never deleted — legacy `deployment_secret` values stay
-under it permanently, and the legacy arm remains until every environment has
-converged.
-
-**Gap found while auditing.** `feishu_app_registration` seals `deviceCode` and
-`appSecret` through the cipher but is absent from the rewrap sweep. Today that
-means plaintext residue in that table never converges and key rotation skips it;
-after this change it would mean those values can never be shredded. The table
-joins the sweep as part of this work.
+- **Restoring a database backup taken before the sweep** yields values this build
+  cannot read. They fail loudly rather than silently; recovering them means
+  running the rewrap sweep on a pre-scoping build first.
+- **Rolling updates across an envelope change** are the remaining hazard, and it
+  is now half-closed: an older replica meeting a newer envelope throws instead of
+  passing the ciphertext through as plaintext. The other half is unchanged — a
+  build that predates the envelope entirely has no such check, which is why a
+  future envelope version still owes two releases (one that recognizes the
+  format, a later one that writes it).
 
 ## 8. Testing
 
 - **Envelope unit tests** (`secrets/vault-transit.test.ts`): key selection per
-  scope, the legacy arm decrypting under the deployment key whatever the scope
-  says, the plaintext pass-through arm, and — the one that matters — a
-  cross-scope open FAILING rather than returning another org's plaintext. The
+  scope, the plaintext pass-through arm, the two refusals of §4 (a pre-scoping
+  value and a newer envelope version, each asserted to reach Vault zero times),
+  and — the one that matters — a cross-scope open FAILING rather than returning
+  another org's plaintext. The
   fake Transit binds each ciphertext to the key that produced it, so that
   refusal is the real mechanism, not a stub.
 - **Cache key**: a second scope must not be served a cached plaintext; the test
@@ -425,6 +413,5 @@ joins the sweep as part of this work.
 2. **Per-organization rotation cadence.** Rotation is per key, so a policy that
    was deployment-wide becomes per tenant. Rewrap already supports it; the
    schedule is an operations decision.
-3. **Retiring the legacy arm.** Once every environment has converged it can be
-   deleted, turning an unrecognized-but-`vault:`-prefixed value into an error
-   rather than a deployment-key decrypt.
+3. ~~**Retiring the legacy arm.**~~ **Resolved** — every environment converged,
+   so the arm was removed and a pre-scoping value now throws (§7).

--- a/docs/designs/secret-store-seams.md
+++ b/docs/designs/secret-store-seams.md
@@ -31,7 +31,7 @@ secret.
 
 1. **Keep agent secrets in the row-per-key `agent_secret` table behind `AgentSecretStore`**, matching the BotSecret discipline: values never appear on `AgentRecord` (structurally preventing accidental serialization); lists/DTOs obtain only key names through `keys()` (without loading values); and wire projections (`agent/upsert`, the `register/ok` roster, and `agent/activate`) obtain values through `get()`.
    - Row-per-key rather than a single JSONB row: PATCH's per-key merge semantics (string replaces / null deletes / omission leaves unchanged) map naturally to row-level upserts and deletes without read-modify-write races. `keys()` selects only the key column, so **key names remain available without decryption when an encrypting cipher is enabled**. Encryption operates per value, matching the shape of other stores.
-2. **Introduce the `SecretCipher` port (`secrets/cipher.ts`) as the sole at-rest transformation point.** Every secret-store implementation receives the same injected instance. The list grows with new stores, including the two external-memory stores, so construction in `container.ts` is authoritative. Write paths call `seal(plaintext)` and read paths call `open(stored)`. `PlaintextSecretCipher` is the identity implementation used when encryption is disabled.
+2. **Introduce the `SecretCipher` port (`secrets/cipher.ts`) as the sole at-rest transformation point.** Every secret-store implementation receives the same injected instance. The list grows with new stores, including the two external-memory stores, so construction in `container.ts` is authoritative. Write paths call `seal(plaintext, scope)` and read paths call `open(stored, scope)` — the scope names whose key is used, and is supplied by the caller (see [`per-org-secret-encryption.md`](./per-org-secret-encryption.md)). `PlaintextSecretCipher` is the identity implementation used when encryption is disabled.
    - The composition root (`container.ts` / `buildApp.secretCipher`) constructs one instance and passes it to every store. **Changing encryption means replacing that one instance, switching every secret together.**
 3. **Make the cipher constructor argument mandatory**, with no default. Every new store construction site must answer "what is the at-rest transform here?", preventing production wiring omissions from silently falling back to plaintext.
 4. **Do not change the C5 lease broker** (`SecretsProvider` / `secret_lease` / protocol §6). It is the end-state track in which the CP never handles plaintext and the daemon resolves references directly against Vault. That track complements the present design, where the CP must hold plaintext and deliver it over a TLS WebSocket. Future adoption is additive.
@@ -41,15 +41,22 @@ secret.
 
 ```ts
 interface SecretCipher {
-  seal(plaintext: string): Promise<string> // plaintext → persisted string
-  open(stored: string): Promise<string> // persisted string → plaintext
+  seal(plaintext: string, scope: SecretScope): Promise<string> // plaintext → persisted string
+  open(stored: string, scope: SecretScope): Promise<string> // persisted string → plaintext
 }
 ```
 
+The `scope` parameter was added by
+[`per-org-secret-encryption.md`](./per-org-secret-encryption.md), which is the
+authoritative description of the current contract. It is deliberately **not**
+encoded in the stored value: the stored string comes out of Postgres, so letting
+it select its own decryption key would mean a row of one organization, read by
+code serving another, decrypts silently.
+
 Requirements for a real implementation such as Vault Transit are documented on the port:
 
-- the output of `seal` is self-describing (Transit values such as `vault:v1:…` satisfy this naturally);
-- `open` **must pass through values that it did not seal** (unrecognized prefix ⇒ return unchanged), so compatible stored values remain readable and can be re-sealed by the convergence tool;
+- the output of `seal` carries an envelope VERSION tag (never a tenant identity);
+- `open` **must pass through values that it did not seal** (no envelope tag ⇒ return unchanged), so plaintext rows remain readable — but it must **refuse** a value that is sealed and unreadable by that build (a pre-scoping ciphertext, or a newer envelope version) rather than hand ciphertext back as plaintext;
 - neither method may log its arguments.
 
 This shape also supports the variant in which values move to Vault KV and the column stores a reference (`seal` writes KV and returns a reference; `open` resolves the reference), although Transit remains the recommendation because data stays in Postgres and backup consistency is preserved.

--- a/packages/control-plane/src/secrets/cipher.ts
+++ b/packages/control-plane/src/secrets/cipher.ts
@@ -17,12 +17,12 @@
  * Contract for an encrypting implementation (e.g. Vault Transit):
  * - `seal` returns a self-describing value carrying the envelope version
  *   (`acv1:` + Transit's own `vault:v1:…`).
- * - `open` MUST pass through values it did not seal (no recognizable prefix ⇒
- *   return as-is): existing plaintext rows keep working, and re-sealing on the
- *   next write migrates them lazily — the flip is online, no backfill required.
- *   Values sealed before scoping existed (a bare `vault:vN:`) open under the
- *   deployment key whatever `scope` says; only the envelope-tagged arm is
- *   scoped.
+ * - `open` MUST pass through values it did not seal (no envelope tag ⇒ return
+ *   as-is): existing plaintext rows keep working, and re-sealing on the next
+ *   write migrates them lazily — the flip is online, no backfill required. It
+ *   must NOT pass through a value that is sealed but unreadable (a pre-scoping
+ *   `vault:vN:`, or a newer envelope version) — that has to throw, since
+ *   returning ciphertext as plaintext would be shipped onward as a credential.
  * - A value sealed under one scope MUST NOT open under another. Failing closed
  *   there is the point of passing the scope in.
  * - Neither side ever logs its argument.

--- a/packages/control-plane/src/secrets/vault-transit.test.ts
+++ b/packages/control-plane/src/secrets/vault-transit.test.ts
@@ -189,13 +189,24 @@ describe('VaultTransitSecretCipher', () => {
     await expect(cipher.open(sealed, DEPLOYMENT_SCOPE)).rejects.toThrow(/unable to decrypt/)
   })
 
-  it('legacy arm: a pre-envelope vault: value opens under the DEPLOYMENT key whatever the scope says', async () => {
+  it('REFUSES a pre-scoping value instead of decrypting it under the deployment key', async () => {
     const vault = fakeVault()
     const cipher = new VaultTransitSecretCipher({ ...TOKEN_OPTS, fetchImpl: vault.fetchImpl })
-    // Shaped like a value sealed before scoping existed: no envelope tag.
-    const legacy = 'vault:v1:ac-cp.bGVnYWN5' // "legacy" base64 under the deployment key
-    expect(await cipher.open(legacy, ORG_A)).toBe('legacy')
-    expect(vault.calls.at(-1)!.url).toBe('https://vault.example.com/v1/transit/decrypt/ac-cp')
+    // Shaped like a value sealed before scoping existed: no envelope tag. The
+    // old fallback read these under the deployment key, IGNORING the asserted
+    // scope — a hole in the cross-tenant fence that only migration justified.
+    const legacy = 'vault:v1:ac-cp.bGVnYWN5'
+    await expect(cipher.open(legacy, ORG_A)).rejects.toThrow(/unscoped legacy ciphertext/)
+    expect(vault.calls).toHaveLength(0) // refused locally; Vault never asked
+  })
+
+  it('REFUSES a newer envelope version rather than passing it through as plaintext', async () => {
+    const vault = fakeVault()
+    const cipher = new VaultTransitSecretCipher({ ...TOKEN_OPTS, fetchImpl: vault.fetchImpl })
+    // What an older replica sees mid-rolling-update once a newer one writes.
+    // Passing it through would hand a ciphertext onward as a live credential.
+    await expect(cipher.open('acv2:vault:v1:whatever', ORG_A)).rejects.toThrow(/newer envelope version/)
+    expect(vault.calls).toHaveLength(0)
   })
 
   it('a WARM cache does not weaken the cross-scope fence (ciphertext-only keying would leak here)', async () => {

--- a/packages/control-plane/src/secrets/vault-transit.ts
+++ b/packages/control-plane/src/secrets/vault-transit.ts
@@ -11,10 +11,12 @@
  * (docs/designs/per-org-secret-encryption.md).
  *
  * Contract (pinned on the port):
- * - `open` PASSES THROUGH values it did not seal (neither the envelope tag nor
- *   a bare `vault:vN:` prefix ⇒ return as-is): existing plaintext rows keep
- *   reading after the flip, and the next write re-seals them — the rollout is
- *   online, no backfill required.
+ * - `open` PASSES THROUGH values it did not seal (no envelope tag ⇒ return
+ *   as-is): plaintext rows under `SECRET_CIPHER=none` keep reading, and the next
+ *   write seals them — the flip is online, no backfill required. It does NOT
+ *   pass through something that is sealed but unreadable here (a pre-scoping
+ *   `vault:vN:` value, or a newer envelope version); those throw, because
+ *   handing ciphertext back as plaintext is silent corruption.
  * - A value sealed under one scope does NOT open under another: Transit rejects
  *   a ciphertext presented to a different key, which is the cross-tenant fence.
  * - No argument or response body is ever logged; errors carry only the HTTP
@@ -39,9 +41,6 @@ import type { SecretCipher } from './cipher.js'
 import { SECRET_ENVELOPE_PREFIX, type SecretScope } from './scope.js'
 import { describeVaultError, VaultHttp, type FetchLike, type VaultAuth } from './vault-http.js'
 
-/** The auth shape now lives in `vault-http.ts`; re-exported for existing callers. */
-export type VaultTransitAuth = VaultAuth
-
 export interface VaultTransitOpts {
   /** Vault origin, e.g. `https://vault.example.com:8200`. */
   addr: string
@@ -61,8 +60,10 @@ export interface VaultTransitOpts {
   openCacheMax?: number
 }
 
-/** Transit ciphertext is self-describing: `vault:v<key-version>:<base64>`. */
-const CIPHERTEXT_RE = /^vault:v\d+:/
+/** A bare Transit ciphertext — what this cipher produced BEFORE scoping existed. */
+const LEGACY_CIPHERTEXT_RE = /^vault:v\d+:/
+/** Any version of our own envelope, including ones this build predates. */
+const ENVELOPE_RE = /^acv\d+:/
 
 export class VaultTransitSecretCipher implements SecretCipher {
   private readonly http: VaultHttp
@@ -105,16 +106,17 @@ export class VaultTransitSecretCipher implements SecretCipher {
   }
 
   async open(stored: string, scope: SecretScope): Promise<string> {
-    // Three arms, in order (docs/designs/per-org-secret-encryption.md §4):
-    //   envelope-tagged ⇒ scoped value, opens under THIS scope's key — a value
-    //     of another scope fails here, which is the reason scope is a parameter;
-    //   bare `vault:vN:` ⇒ sealed before scoping existed, opens under the
-    //     deployment key regardless of scope (the migration arm, §7);
+    // Two arms (docs/designs/per-org-secret-encryption.md §4):
+    //   envelope-tagged ⇒ opens under THIS scope's key — a value of another
+    //     scope fails here, which is the whole reason scope is a parameter;
     //   anything else ⇒ never sealed, return unchanged (pass-through contract).
-    const scoped = stored.startsWith(SECRET_ENVELOPE_PREFIX)
-    if (!scoped && !CIPHERTEXT_RE.test(stored)) return stored
-    const key = scoped ? this.keyFor(scope) : this.key
-    const ciphertext = scoped ? stored.slice(SECRET_ENVELOPE_PREFIX.length) : stored
+    // Everything the pass-through must NOT swallow is rejected first.
+    if (!stored.startsWith(SECRET_ENVELOPE_PREFIX)) {
+      assertNotUnreadableCiphertext(stored)
+      return stored
+    }
+    const key = this.keyFor(scope)
+    const ciphertext = stored.slice(SECRET_ENVELOPE_PREFIX.length)
     // Cache by KEY + ciphertext: the stored string no longer implies a key, and
     // two scopes must never share an entry.
     const cacheKey = `${key}\u0000${ciphertext}`
@@ -145,5 +147,29 @@ export class VaultTransitSecretCipher implements SecretCipher {
     if (!res.ok) throw new Error(`vault transit ${op} failed: ${await describeVaultError(res)}`)
     const json = (await res.json()) as { data?: { ciphertext?: string; plaintext?: string } }
     return json.data ?? {}
+  }
+}
+
+/**
+ * The pass-through arm exists for values that were never sealed (plaintext rows
+ * under `SECRET_CIPHER=none`). It must never swallow a value that IS sealed but
+ * unreadable by this build — returning ciphertext as if it were plaintext is
+ * silent corruption: the caller ships it to a daemon or a platform API as a
+ * credential. Both cases below are loud instead.
+ */
+function assertNotUnreadableCiphertext(stored: string): void {
+  if (LEGACY_CIPHERTEXT_RE.test(stored)) {
+    // Sealed before scoping (docs/designs/per-org-secret-encryption.md §7). The
+    // deployment-key fallback that used to read these is gone — it ignored the
+    // asserted scope, which was a hole in the cross-tenant fence it only earned
+    // by being temporary. Recovering such a value needs a pre-scoping build to
+    // run the rewrap sweep first.
+    throw new Error('secret cipher: unscoped legacy ciphertext — run the rewrap sweep on a pre-scoping build first')
+  }
+  if (ENVELOPE_RE.test(stored)) {
+    // A NEWER envelope version than this build knows. Happens on a rolling
+    // update where a new replica writes and an old one reads; failing here is
+    // what keeps that window loud rather than silently wrong.
+    throw new Error('secret cipher: stored value uses a newer envelope version than this build supports')
   }
 }


### PR DESCRIPTION
## What

Retires the migration-era decrypt arm now that every deployment has been swept, and closes the hole that removing it would otherwise have opened.

## Why it isn't just cleanup

The arm read a bare `vault:vN:` value under the **deployment key while ignoring the asserted `scope`** — the exact fence the scope parameter exists to build. Any value in that shape bypassed the cross-tenant check entirely. It was a hole justified only by being temporary.

It is no longer needed. Verified empirically across all three environments before touching anything:

| env | bare pre-scoping | `acv1:` scoped | plaintext |
| --- | --- | --- | --- |
| test | **0** | 84 | 0 |
| staging | **0** | 12 | 0 |
| prod | **0** | 92 | 0 |

## Removing it alone would have been worse than leaving it

A bare value would then fall into the plaintext pass-through and be returned **verbatim** — a ciphertext handed onward as a live credential, silently, exactly the failure mode documented for the rolling-update window.

So the pass-through now refuses anything sealed-but-unreadable, locally, without asking Vault:

| stored value | before | now |
| --- | --- | --- |
| no envelope tag (plaintext) | pass through | pass through — **unchanged** |
| `vault:vN:` (pre-scoping) | decrypt under deployment key, ignoring scope | **throws** |
| `acvN:` newer than this build | passed through as "plaintext" | **throws** |

That last row half-closes the hazard the envelope tag introduced: an older replica meeting a newer envelope now fails loudly. The other half is unchanged — a build predating the envelope has no such check — so a future envelope change still owes two releases (recognize, then write). Stated in §7.

## The `none` upgrade path is untouched

Values written under `SECRET_CIPHER=none` carry no envelope tag, so they still pass through; `PlaintextSecretCipher` remains pure identity. The online, zero-backfill flip still holds. Covered by the existing pass-through test.

One edge worth naming: a plaintext value whose literal text begins with `vault:vN:` now throws instead of passing through. Vanishingly unlikely, and it would previously have been sent to Vault and failed anyway — this just fails earlier and more clearly.

## Also

- Drops a dead `VaultTransitAuth` alias no caller ever used (I added it during the `VaultHttp` extraction "for existing callers"; there were none).
- Updates `secret-store-seams.md`, whose contract block still showed the unscoped `seal(plaintext)` / `open(stored)` signatures and the self-describing-value requirement this design explicitly replaced.

## Verification

typecheck, lint, format clean; 1279 unit tests; 1047 integration tests against real Postgres. The two new refusal tests assert Vault is contacted **zero** times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
