### PR TITLE
refactor(cp): consolidate the in-process caches onto lru-cache

### DIFF
--- a/packages/control-plane/src/cache.ts
+++ b/packages/control-plane/src/cache.ts
@@ -1,0 +1,35 @@
+/**
+ * `cache.ts` — the one way this process builds an in-memory cache.
+ *
+ * Every cache here is bounded, expires on the injected clock, and (where it
+ * fronts a provider call) coalesces concurrent readers through `LRUCache#fetch`.
+ * Before this existed the same twenty lines were hand-written per call site with
+ * quietly different semantics — some unbounded, most evicting oldest-INSERTED
+ * rather than least-recently-used, each deciding for itself whether a failure
+ * or a negative answer was worth caching.
+ *
+ * NOT for caches whose invalidation is more than a TTL. `LogtoIdentityService`
+ * and `InstallationTokenService` fence in-flight reads on a per-subject epoch so
+ * a read that began before an unlink cannot write the removed identity back
+ * after it; `fetch` has no such notion, and expressing those here would drop a
+ * deliberate authorization property. They stay hand-written on purpose.
+ */
+import type { Clock } from './domain/clock.js'
+
+/**
+ * Shared `LRUCache` wiring.
+ *
+ * `perf` is THE time seam — without it the cache would read the wall clock
+ * while everything around it reads the injected one. `ttlResolution: 0` turns
+ * off lru-cache's 1 ms `now()` debounce, which is driven by a real timer a
+ * `FakeClock` cannot advance; expiry is evaluated lazily on read, so no
+ * background timer exists either way.
+ *
+ * The clock MUST report real epoch milliseconds, as `Clock` documents. lru-cache
+ * stores an entry's start time and treats a falsy one as "no TTL recorded", so an
+ * entry written at time 0 would never expire. Production passes `Date.now()`;
+ * a test clock has to be seeded with an epoch rather than left at 0.
+ */
+export function cacheOptions(clock: Clock, max: number) {
+  return { max, ttlResolution: 0, perf: clock } as const
+}

--- a/packages/control-plane/src/github/github.test.ts
+++ b/packages/control-plane/src/github/github.test.ts
@@ -402,6 +402,10 @@ describe('GithubService repository picker reads', () => {
     svc.invalidateRepositoryRoster(installation.installationId)
     await svc.listRepos(installation, 1, 100)
     expect(fetchImpl).toHaveBeenCalledTimes(2)
+
+    // Concurrent pickers share one request rather than racing the same page.
+    await Promise.all([svc.listRepos(installation, 2, 100), svc.listRepos(installation, 2, 100)])
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
   })
 
   it('resolves a durable repository id to its current name through the installation grant', async () => {

--- a/packages/control-plane/src/github/service.ts
+++ b/packages/control-plane/src/github/service.ts
@@ -9,6 +9,8 @@
  * (agent → repo owner → LIVE installation → scoped token).
  */
 import { gitRepoLabel, type GitCommitIdentity, type GitCredCapability } from '@agentconnect.md/protocol'
+import { LRUCache } from 'lru-cache'
+import { cacheOptions } from '../cache.js'
 import type { Clock } from '../domain/clock.js'
 import type { OrgId } from '../domain/ids.js'
 import type {
@@ -99,6 +101,8 @@ const OUTDATED_INSTALLATIONS_CACHE_MS = 30_000
 const REPO_PAGE_CACHE_MS = 5 * 60_000
 const MAX_REPO_PAGE_CACHE_ENTRIES = 1_000
 
+type RepoPageLookup = { ins: GithubInstallationRecord; page: number; perPage: number }
+
 /** Capability-level clamp per RepoAccess tier (agent-multi-repo-authorization.md
  *  decision 3). Only capabilities the daemon asked for are actually minted. */
 const REPO_ACCESS_LEVELS: Record<RepoAccess, CapabilityLevels> = {
@@ -154,13 +158,27 @@ export class GithubService {
   private readonly mintBucket: TokenBucket
   private outdatedInstallationsCache:
     { expiresAt: number; settingsUrlsByInstallationId: ReadonlyMap<string, string> } | undefined
-  private readonly repoPageCache = new Map<string, { value: GhRepoPage; expiresAt: number }>()
-  private readonly repoPageInFlight = new Map<string, Promise<GhRepoPage>>()
+  /** One picker page. `fetch` hands concurrent callers of one key the same
+   *  promise; the generation fence lives in `listRepos`, since it is about which
+   *  roster a page belongs to rather than how long the page stays fresh. */
+  private readonly repoPages: LRUCache<string, GhRepoPage, RepoPageLookup>
   private readonly repoRosterGeneration = new Map<string, number>()
 
   constructor(private readonly deps: GithubServiceDeps) {
     this.slug = deps.cfg.slug
     this.tokens = new InstallationTokenService(deps.cfg, deps.clock, deps.fetchImpl, deps.baseUrl)
+    this.repoPages = new LRUCache({
+      ...cacheOptions(deps.clock, MAX_REPO_PAGE_CACHE_ENTRIES),
+      ttl: REPO_PAGE_CACHE_MS,
+      fetchMethod: async (_key, _stale, { context }) => {
+        const token = await this.tokens.metadataToken(context.ins.installationId)
+        const res = await githubRequest<{ total_count: number; repositories: GhRepo[] }>(
+          `/installation/repositories?per_page=${context.perPage}&page=${context.page}`,
+          { auth: token, fetchImpl: deps.fetchImpl, baseUrl: deps.baseUrl, bigIdsAsStrings: true }
+        )
+        return { repos: res.repositories, totalCount: res.total_count }
+      }
+    })
     this.stateKey = deriveInstallStateKey(deps.pepper)
     // 10 burst / 0.2 per sec (~12/min sustained) per key — far above any honest
     // daemon (mints are cached 45+ min per repo), far below GitHub's budget.
@@ -183,8 +201,8 @@ export class GithubService {
   invalidateRepositoryRoster(installationId: bigint): void {
     const prefix = `${installationId}:`
     this.repoRosterGeneration.set(prefix, (this.repoRosterGeneration.get(prefix) ?? 0) + 1)
-    for (const key of this.repoPageCache.keys()) {
-      if (key.startsWith(prefix)) this.repoPageCache.delete(key)
+    for (const key of [...this.repoPages.keys()]) {
+      if (key.startsWith(prefix)) this.repoPages.delete(key)
     }
   }
 
@@ -288,35 +306,14 @@ export class GithubService {
     const prefix = `${ins.installationId}:`
     const generation = this.repoRosterGeneration.get(prefix) ?? 0
     const key = `${prefix}${generation}:${page}:${perPage}`
-    const cached = this.repoPageCache.get(key)
-    if (cached && cached.expiresAt > this.deps.clock.now()) return cached.value
-    if (cached) this.repoPageCache.delete(key)
-
-    let pending = this.repoPageInFlight.get(key)
-    if (!pending) {
-      pending = this.tokens
-        .metadataToken(ins.installationId)
-        .then((token) =>
-          githubRequest<{ total_count: number; repositories: GhRepo[] }>(
-            `/installation/repositories?per_page=${perPage}&page=${page}`,
-            { auth: token, fetchImpl: this.deps.fetchImpl, baseUrl: this.deps.baseUrl, bigIdsAsStrings: true }
-          )
-        )
-        .then((res) => {
-          const value = { repos: res.repositories, totalCount: res.total_count }
-          if ((this.repoRosterGeneration.get(prefix) ?? 0) === generation) {
-            if (this.repoPageCache.size >= MAX_REPO_PAGE_CACHE_ENTRIES) {
-              const oldest = this.repoPageCache.keys().next().value
-              if (oldest) this.repoPageCache.delete(oldest)
-            }
-            this.repoPageCache.set(key, { value, expiresAt: this.deps.clock.now() + REPO_PAGE_CACHE_MS })
-          }
-          return value
-        })
-        .finally(() => this.repoPageInFlight.delete(key))
-      this.repoPageInFlight.set(key, pending)
-    }
-    return pending
+    const value = await this.repoPages.fetch(key, { context: { ins, page, perPage } })
+    // A roster invalidation that lands while this page was in flight bumped the
+    // generation, so the answer describes a roster nobody will ask for again.
+    // The key already makes it unreachable; dropping it keeps it from occupying
+    // the cache until eviction.
+    if ((this.repoRosterGeneration.get(prefix) ?? 0) !== generation) this.repoPages.delete(key)
+    if (!value) throw new Error('github repository page lookup produced no result')
+    return value
   }
 
   /** Resolve a rename-proof repository id to its current canonical name. The

--- a/packages/control-plane/src/github/user-authz.test.ts
+++ b/packages/control-plane/src/github/user-authz.test.ts
@@ -45,6 +45,7 @@ describe('resolveLogtoMgmtConfig', () => {
   })
 })
 
+const EPOCH = 1_777_000_000_000
 const MGMT = { endpoint: 'https://t.logto.app', appId: 'app', appSecret: 'sec', resource: 'https://t.logto.app/api' }
 const MUTATIONS: SocialIdentityMutationGate = {
   runExclusive: async (_oidcSubject, mutation) => mutation()
@@ -209,7 +210,10 @@ function authz(opts: {
   /** Per-repo override keyed by "owner/repo" (falls back to `permission`). */
   permissions?: Record<string, RepoPermission>
 }) {
-  const clock = new FakeClock(0)
+  // Seeded with a real epoch, not 0: the permission/meta caches record an
+  // entry's start time and read a falsy one as "no TTL", which would make every
+  // entry immortal and quietly pass the expiry assertions below (see `cache.ts`).
+  const clock = new FakeClock(EPOCH)
   const calls = { permission: 0 }
   const svc = new GithubUserAuthzService({
     identity: { githubLoginFor: async () => opts.login ?? null },
@@ -294,6 +298,18 @@ describe('GithubUserAuthzService', () => {
     clock.advance(5 * 60_000 + 1)
     await svc.assertAccess('u1', INS, 'o', 'r', 'write')
     expect(calls.permission).toBe(2)
+  })
+
+  it('coalesces concurrent callers into one permission probe', async () => {
+    const { svc, calls } = authz({ login: 'me', permission: 'read' })
+
+    await Promise.all([
+      svc.permissionForUser('u1', INS, 'o', 'r'),
+      svc.permissionForUser('u1', INS, 'o', 'r'),
+      svc.permissionForUser('u1', INS, 'o', 'r')
+    ])
+
+    expect(calls.permission).toBe(1)
   })
 
   it('can bypass the picker cache for a shorter-lived authorization lease', async () => {

--- a/packages/control-plane/src/github/user-authz.ts
+++ b/packages/control-plane/src/github/user-authz.ts
@@ -25,6 +25,8 @@
  *  - authorization is asserted at pick/create time; the daemon keeps running
  *    on installation tokens (creator drift is the tracked re-attest follow-up).
  */
+import { LRUCache } from 'lru-cache'
+import { cacheOptions } from '../cache.js'
 import type { Clock } from '../domain/clock.js'
 import type { GithubInstallationRecord } from '../persistence/ports.js'
 
@@ -75,17 +77,44 @@ interface UserAuthzDeps {
 const ACCESS_TTL_MS = 5 * 60_000
 /** Parallel verified REST permission probes per list-filter call. */
 const FILTER_CONCURRENCY = 8
+/**
+ * Both caches below are keyed per (installation, repo, login), so their natural
+ * size is repositories × console users — bounded in principle, unbounded in the
+ * only sense that matters to a long-lived process. They previously had no cap at
+ * all and grew for the lifetime of the pod.
+ */
+const MAX_CACHE_ENTRIES = 10_000
+
+/** `metaOf`'s answer. Wrapped because `null` (out of the installation's grant)
+ *  is a real answer worth caching, and a cache cannot store a nullish value. */
+type RepoMeta = { meta: { private: boolean } | null }
+
+type PermissionLookup = { ins: GithubInstallationRecord; owner: string; repo: string; login: string }
+type MetaLookup = { ins: GithubInstallationRecord; owner: string; repo: string }
 
 export class GithubUserAuthzService {
   /** (installation, repo, login) → effective permission; the one cacheable unit
-   *  shared by the preflight, the create gate AND the list filter. */
-  private readonly perms = new Map<string, { value: RepoPermission; fetchedAt: number; expiresAt: number }>()
-  private readonly permsInFlight = new Map<string, Promise<RepoPermission>>()
+   *  shared by the preflight, the create gate AND the list filter. `fetch` hands
+   *  concurrent callers of one key the same promise. */
+  private readonly perms: LRUCache<string, RepoPermission, PermissionLookup>
   /** (installation, repo) → meta (or null = out of grant), same TTL. */
-  private readonly metas = new Map<string, { value: { private: boolean } | null; expiresAt: number }>()
-  private readonly metasInFlight = new Map<string, Promise<{ private: boolean } | null>>()
+  private readonly metas: LRUCache<string, RepoMeta, MetaLookup>
 
-  constructor(private readonly deps: UserAuthzDeps) {}
+  constructor(private readonly deps: UserAuthzDeps) {
+    this.perms = new LRUCache({
+      ...cacheOptions(deps.clock, MAX_CACHE_ENTRIES),
+      ttl: ACCESS_TTL_MS,
+      fetchMethod: (_key, _stale, { context }) =>
+        this.deps.github.userRepoPermission(context.ins, context.owner, context.repo, context.login)
+    })
+    this.metas = new LRUCache({
+      ...cacheOptions(deps.clock, MAX_CACHE_ENTRIES),
+      ttl: ACCESS_TTL_MS,
+      fetchMethod: async (_key, _stale, { context }) => ({
+        meta: await this.deps.github.getRepoMeta(context.ins, context.owner, context.repo)
+      })
+    })
+  }
 
   /** The caller's GitHub login, or a GITHUB_IDENTITY_REQUIRED denial — the
    *  shared first leg of every check. */
@@ -112,7 +141,7 @@ export class GithubUserAuthzService {
   }
 
   /** Cached + deduped effective permission of `login` on one repo. */
-  private permissionOf(
+  private async permissionOf(
     login: string,
     ins: GithubInstallationRecord,
     owner: string,
@@ -120,24 +149,18 @@ export class GithubUserAuthzService {
     maxCacheAgeMs?: number
   ): Promise<RepoPermission> {
     const key = this.permissionKey(login, ins, owner, repo)
-    const cached = this.perms.get(key)
-    const now = this.deps.clock.now()
-    if (cached && cached.expiresAt > now && (maxCacheAgeMs === undefined || now - cached.fetchedAt < maxCacheAgeMs)) {
-      return Promise.resolve(cached.value)
-    }
-    let pending = this.permsInFlight.get(key)
-    if (!pending) {
-      pending = this.deps.github
-        .userRepoPermission(ins, owner, repo, login)
-        .then((value) => {
-          const fetchedAt = this.deps.clock.now()
-          this.perms.set(key, { value, fetchedAt, expiresAt: fetchedAt + ACCESS_TTL_MS })
-          return value
-        })
-        .finally(() => this.permsInFlight.delete(key))
-      this.permsInFlight.set(key, pending)
-    }
-    return pending
+    // `maxCacheAgeMs` caps reuse BELOW the cache's own lease: a caller sitting on
+    // a live authorization gate can demand evidence younger than the picker's
+    // five minutes (0 = always re-ask). A missing entry reports a full-TTL age,
+    // which forces the fetch it was going to do anyway.
+    const age = ACCESS_TTL_MS - this.perms.getRemainingTTL(key)
+    const permission = await this.perms.fetch(key, {
+      ...(maxCacheAgeMs !== undefined && age >= maxCacheAgeMs ? { forceRefresh: true } : {}),
+      context: { ins, owner, repo, login }
+    })
+    // Only reachable if the entry is dropped mid-flight. This service fails
+    // CLOSED, and `none` is how it spells that.
+    return permission ?? 'none'
   }
 
   /** Resolve only the user's effective permission. Callers that already
@@ -155,22 +178,17 @@ export class GithubUserAuthzService {
   }
 
   /** Cached + deduped repo meta (privacy flag; null = out of grant). */
-  private metaOf(ins: GithubInstallationRecord, owner: string, repo: string): Promise<{ private: boolean } | null> {
-    const key = `${ins.installationId}:${owner}/${repo}`
-    const cached = this.metas.get(key)
-    if (cached && cached.expiresAt > this.deps.clock.now()) return Promise.resolve(cached.value)
-    let pending = this.metasInFlight.get(key)
-    if (!pending) {
-      pending = this.deps.github
-        .getRepoMeta(ins, owner, repo)
-        .then((value) => {
-          this.metas.set(key, { value, expiresAt: this.deps.clock.now() + ACCESS_TTL_MS })
-          return value
-        })
-        .finally(() => this.metasInFlight.delete(key))
-      this.metasInFlight.set(key, pending)
-    }
-    return pending
+  private async metaOf(
+    ins: GithubInstallationRecord,
+    owner: string,
+    repo: string
+  ): Promise<{ private: boolean } | null> {
+    const observed = await this.metas.fetch(`${ins.installationId}:${owner}/${repo}`, {
+      context: { ins, owner, repo }
+    })
+    // Only reachable if the entry is dropped mid-flight. Out-of-grant is the
+    // fail-closed reading: callers treat it as private with no access.
+    return observed?.meta ?? null
   }
 
   /**

--- a/packages/control-plane/src/http/feishu-session-access.test.ts
+++ b/packages/control-plane/src/http/feishu-session-access.test.ts
@@ -36,7 +36,7 @@ function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
 }
 
-function service(fetchImpl: (url: string, init?: RequestInit) => Promise<Response>) {
+function service(fetchImpl: (url: string, init?: RequestInit) => Promise<Response>, now: () => number = () => 1_000) {
   return new FeishuSessionAccessService({
     bots: { getUnscoped: async () => bot() } as never,
     botSecrets: {
@@ -46,7 +46,7 @@ function service(fetchImpl: (url: string, init?: RequestInit) => Promise<Respons
         signingSecret: null
       })
     } as never,
-    clock: { now: () => 1_000 } as never,
+    clock: { now } as never,
     fetchImpl
   })
 }
@@ -183,6 +183,35 @@ describe('FeishuSessionAccessService', () => {
       accessIssues: [{ provider: 'feishu', region: 'lark', reason: 'quota' }]
     })
     expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  // Running out of quota is a fact about the APP, not about who is in the chat,
+  // so it must never occupy the chat's membership entry — `quotaBlockedUntil` is
+  // what suppresses the retry storm.
+  it('does not leave a quota verdict standing in for a chat’s membership', async () => {
+    let now = 1_777_000_000_000
+    let memberCalls = 0
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith('/tenant_access_token/internal')) {
+        return json({ code: 0, tenant_access_token: 'tenant-token' })
+      }
+      memberCalls += 1
+      return memberCalls === 1
+        ? json({ code: 99991403, msg: "This month's API call quota has been exceeded" }, 429)
+        : json({ code: 0, data: { items: [{ member_id: 'on_member' }] } })
+    })
+    const resolver = service(fetchImpl, () => now)
+
+    await expect(resolver.resolve([scope()], viewer())).resolves.toMatchObject({ degraded: true })
+
+    // Past the organization-wide backoff, the chat has to be asked again.
+    now += 60 * 60_000 + 1
+    await expect(resolver.resolve([scope()], viewer())).resolves.toEqual({
+      allowedScopes: [{ id: scope().id, aclRevision: scope().aclRevision }],
+      degraded: false,
+      accessIssues: []
+    })
+    expect(memberCalls).toBe(2)
   })
 
   it('rejects a scope whose realm does not match its custom Bot app', async () => {

--- a/packages/control-plane/src/http/feishu-session-access.ts
+++ b/packages/control-plane/src/http/feishu-session-access.ts
@@ -1,4 +1,6 @@
 import type { FeishuRegion } from '@agentconnect.md/protocol'
+import { LRUCache } from 'lru-cache'
+import { cacheOptions } from '../cache.js'
 import type { Clock } from '../domain/clock.js'
 import { BotId } from '../domain/ids.js'
 import type { FetchLike } from '../github/api.js'
@@ -31,6 +33,14 @@ type MembershipResult =
   | { status: 'members'; unionIds: ReadonlySet<string> }
   | { status: 'deny' }
   | { status: 'unknown'; issue: SessionAccessIssue }
+type MembershipLookup = {
+  region: FeishuRegion
+  chatId: string
+  bot: BotRecord
+  tokenFor: (bot: BotRecord, signal: AbortSignal) => Promise<string>
+  signal: AbortSignal
+  quotaKey: string
+}
 
 const DEFINITIVE_DENIALS = new Set([232006, 232009, 232010, 232011])
 
@@ -53,8 +63,13 @@ async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value:
  * No request-bound user token is fetched or retained. */
 export class FeishuSessionAccessService implements SessionAccessPlugin {
   readonly provider = 'feishu'
-  private readonly membershipCache = new Map<string, { result: MembershipResult; expiresAt: number }>()
-  private readonly pendingMembership = new Map<string, Promise<MembershipResult>>()
+  /** (bot, credential revision, chat) → membership. Shared across viewers: who
+   *  is in a chat is a property of the CHAT, and the union_id comparison that
+   *  turns it into a verdict is done per caller in `resolveScope`. `fetch` hands
+   *  concurrent callers of one key the same promise, replacing the pending map
+   *  this used to keep alongside. Entries carry their own TTL — see the
+   *  fetchMethod, which sets it from the answer it got. */
+  private readonly membership: LRUCache<string, MembershipResult, MembershipLookup>
   private readonly quotaBlockedUntil = new Map<string, number>()
 
   constructor(
@@ -65,7 +80,27 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
       fetchImpl?: FetchLike
       identity?: Pick<LogtoIdentityService, 'feishuIdentitiesFor'>
     }
-  ) {}
+  ) {
+    this.membership = new LRUCache({
+      ...cacheOptions(deps.clock, MAX_CACHE_ENTRIES),
+      // A per-entry TTL is always set below; this only stops lru-cache from
+      // treating an entry that somehow arrives without one as immortal.
+      ttl: UNKNOWN_TTL_MS,
+      fetchMethod: async (_key, _stale, { context, options }) => {
+        const result = await this.listMembers(
+          context.region,
+          context.chatId,
+          context.bot,
+          context.tokenFor,
+          context.signal,
+          context.quotaKey
+        )
+        options.ttl =
+          result.status === 'members' ? MEMBER_LIST_TTL_MS : result.status === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
+        return result
+      }
+    })
+  }
 
   get available(): boolean {
     return this.deps.identity !== undefined
@@ -188,7 +223,7 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
     return { decision: 'unknown', issue: membership.issue }
   }
 
-  private membershipFor(
+  private async membershipFor(
     key: string,
     quotaKey: string,
     region: FeishuRegion,
@@ -197,26 +232,27 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
     tokenFor: (bot: BotRecord, signal: AbortSignal) => Promise<string>,
     signal: AbortSignal
   ): Promise<MembershipResult> {
-    const now = this.deps.clock.now()
-    const cached = this.membershipCache.get(key)
-    if (cached && cached.expiresAt > now) return Promise.resolve(cached.result)
-    if ((this.quotaBlockedUntil.get(quotaKey) ?? 0) > now) {
-      return Promise.resolve({
-        status: 'unknown',
-        issue: { provider: 'feishu', region, reason: 'quota' }
-      })
+    const cached = this.membership.get(key)
+    if (cached) return cached
+    // The quota gate sits BETWEEN the cache and the provider: once this app has
+    // exhausted its quota there is nothing to ask, but an answer already cached
+    // above stays perfectly usable.
+    if ((this.quotaBlockedUntil.get(quotaKey) ?? 0) > this.deps.clock.now()) {
+      return { status: 'unknown', issue: { provider: 'feishu', region, reason: 'quota' } }
     }
-    const existing = this.pendingMembership.get(key)
-    if (existing) return existing
-
-    const pending = this.listMembers(region, chatId, bot, tokenFor, signal, quotaKey)
-      .then((result) => {
-        if (!(result.status === 'unknown' && result.issue.reason === 'quota')) this.putMembershipCache(key, result)
-        return result
-      })
-      .finally(() => this.pendingMembership.delete(key))
-    this.pendingMembership.set(key, pending)
-    return pending
+    const result = await this.membership.fetch(key, {
+      context: { region, chatId, bot, tokenFor, signal, quotaKey }
+    })
+    // Only reachable if the entry is dropped mid-flight; report it the way an
+    // unanswerable check is reported everywhere else here.
+    if (!result) return { status: 'unknown', issue: { provider: 'feishu', region, reason: 'unavailable' } }
+    // Running out of quota says nothing about the chat, so it must not occupy
+    // the entry: `quotaBlockedUntil` is what suppresses the retry storm, and it
+    // is already set by the time we get here.
+    if (result.status === 'unknown' && result.issue.reason === 'quota') {
+      this.membership.delete(key)
+    }
+    return result
   }
 
   private async listMembers(
@@ -315,15 +351,5 @@ export class FeishuSessionAccessService implements SessionAccessPlugin {
       throw new Error(`Feishu request failed: ${response.status}`)
     }
     return body
-  }
-
-  private putMembershipCache(key: string, result: MembershipResult): void {
-    if (this.membershipCache.size >= MAX_CACHE_ENTRIES) {
-      const oldest = this.membershipCache.keys().next().value as string | undefined
-      if (oldest) this.membershipCache.delete(oldest)
-    }
-    const ttl =
-      result.status === 'members' ? MEMBER_LIST_TTL_MS : result.status === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
-    this.membershipCache.set(key, { result, expiresAt: this.deps.clock.now() + ttl })
   }
 }

--- a/packages/control-plane/src/http/github-session-access.ts
+++ b/packages/control-plane/src/http/github-session-access.ts
@@ -1,4 +1,5 @@
 import { LRUCache } from 'lru-cache'
+import { cacheOptions } from '../cache.js'
 import type { Clock } from '../domain/clock.js'
 import { OrgId } from '../domain/ids.js'
 import type { ExternalScopeRecord, GithubInstallationRecord, GithubInstallationRepo } from '../persistence/ports.js'
@@ -23,24 +24,6 @@ const SCOPE_CONCURRENCY = 6
  * after the shape was OBSERVED, not after it was reused (see `putCache`).
  */
 const REPO_SHAPE_TTL_MS = 120_000
-
-/**
- * Shared `LRUCache` wiring.
- *
- * `perf` is THE time seam — without it the cache would read the wall clock
- * while everything around it reads the injected one. `ttlResolution: 0` turns
- * off lru-cache's 1 ms `now()` debounce, which is driven by a real timer a
- * `FakeClock` cannot advance; expiry is evaluated lazily on read, so no
- * background timer exists either way.
- *
- * The clock MUST report real epoch milliseconds, as `Clock` documents. lru-cache
- * stores an entry's start time and treats a falsy one as "no TTL recorded", so an
- * entry written at time 0 would never expire. Production passes `Date.now()`;
- * a test clock has to be seeded with an epoch rather than left at 0.
- */
-function cacheOptions(clock: Clock) {
-  return { max: MAX_CACHE_ENTRIES, ttlResolution: 0, perf: clock } as const
-}
 
 type Decision = 'allow' | 'deny' | 'unknown'
 /** Narrowed `repoRefById` result; null = outside the installation's grant. */
@@ -83,9 +66,9 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
       clock: Clock
     }
   ) {
-    this.cache = new LRUCache(cacheOptions(deps.clock))
+    this.cache = new LRUCache(cacheOptions(deps.clock, MAX_CACHE_ENTRIES))
     this.shapes = new LRUCache({
-      ...cacheOptions(deps.clock),
+      ...cacheOptions(deps.clock, MAX_CACHE_ENTRIES),
       ttl: REPO_SHAPE_TTL_MS,
       fetchMethod: async (_key, _stale, { context }) => ({
         shape: await context.github

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -1,4 +1,5 @@
 import { LRUCache } from 'lru-cache'
+import { cacheOptions } from '../cache.js'
 import type { FetchLike } from '../github/api.js'
 import type { Clock } from '../domain/clock.js'
 import type { BotRepo, BotSecretStore, ExternalScopeRecord } from '../persistence/ports.js'
@@ -26,24 +27,6 @@ const TIMEOUT_MS = 5_000
  * OBSERVED, not after it was reused (see `putCache`).
  */
 const AUDIENCE_TTL_MS = 120_000
-
-/**
- * Shared `LRUCache` wiring.
- *
- * `perf` is THE time seam — without it the cache would read the wall clock
- * while everything around it reads the injected one. `ttlResolution: 0` turns
- * off lru-cache's 1 ms `now()` debounce, which is driven by a real timer a
- * `FakeClock` cannot advance; expiry is evaluated lazily on read, so no
- * background timer exists either way.
- *
- * The clock MUST report real epoch milliseconds, as `Clock` documents. lru-cache
- * stores an entry's start time and treats a falsy one as "no TTL recorded", so an
- * entry written at time 0 would never expire. Production passes `Date.now()`;
- * a test clock has to be seeded with an epoch rather than left at 0.
- */
-function cacheOptions(clock: Clock) {
-  return { max: MAX_CACHE_ENTRIES, ttlResolution: 0, perf: clock } as const
-}
 
 type Decision = 'allow' | 'deny' | 'unknown'
 type ConversationAudience = 'public' | 'members' | 'gone' | 'unknown'
@@ -127,10 +110,10 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
       log?: { warn: (obj: object, msg: string) => void }
     }
   ) {
-    this.cache = new LRUCache(cacheOptions(deps.clock))
-    this.workspaceAccessCache = new LRUCache(cacheOptions(deps.clock))
+    this.cache = new LRUCache(cacheOptions(deps.clock, MAX_CACHE_ENTRIES))
+    this.workspaceAccessCache = new LRUCache(cacheOptions(deps.clock, MAX_CACHE_ENTRIES))
     this.audiences = new LRUCache({
-      ...cacheOptions(deps.clock),
+      ...cacheOptions(deps.clock, MAX_CACHE_ENTRIES),
       ttl: AUDIENCE_TTL_MS,
       fetchMethod: async (_key, _stale, { context }) => ({
         audience: await this.conversationAudience(context.channel, context.token, context.signal),


### PR DESCRIPTION
Follow-up to #739, which introduced `lru-cache` for the session-access work. This puts the rest of the TTL-shaped caches behind the same idiom and gives the shared wiring one home (`src/cache.ts`).

## Why

An audit of every in-process cache in the repo found thirteen hand-written ones carrying **four different eviction strategies**:

| strategy | where |
|---|---|
| no bound at all | `GithubUserAuthzService.perms` / `.metas` |
| oldest-**inserted** first, labelled as if it were LRU | `GithubService.repoPageCache`, `vault-transit`, `relay/webchat-router` |
| that, plus a TTL | the three session-access plugins |
| epoch-fenced | `LogtoIdentityService`, `InstallationTokenService` |

Each also decided for itself whether a failure or a negative answer was worth keeping. The same twenty lines were being re-derived per call site, and I wrote three of those copies myself in #739 before switching.

## Converted

- **`feishu-session-access.ts`** — the last of the three provider plugins still hand-rolled. `pendingMembership` becomes `fetch`; per-answer TTLs move into the `fetchMethod`. The quota verdict keeps its deliberate exemption: running out of quota is a fact about the *app*, not about who is in the chat, so it must never occupy the chat's entry (`quotaBlockedUntil` is what suppresses the retry storm).
- **`GithubUserAuthzService`** — `perms` and `metas` had **no capacity bound**; keyed per (installation, repo, login) they grew for the lifetime of the process. This is the one real defect the audit turned up. `maxCacheAgeMs` keeps its exact meaning — a caller on a live authorization gate can still demand evidence younger than the picker's five-minute lease, which is what #739's GitHub session-access path relies on.
- **`GithubService.repoPageCache`** — the generation fence stays in `listRepos`, where it belongs: it is about *which roster* a page describes, not about how long a page stays fresh.
- **`cacheOptions`** was already duplicated across the two files #739 touched; it now lives in `src/cache.ts` with the explanation of `perf` / `ttlResolution: 0` and the epoch requirement.

## Left hand-written on purpose

`src/cache.ts` records this so the next person doesn't "finish the job": **`LogtoIdentityService` and `InstallationTokenService` fence in-flight reads on a per-subject epoch**, so a read that began before an unlink cannot write the removed identity back after it. `fetch` has no such notion, and expressing them here would drop a deliberate authorization property.

Also deliberately excluded: single-flight maps that guard work rather than cache values (`managed-skill-cache`, `workspace/*`), single-value memos (`daemonRelease`), write throttles (`apiKeyService`), and the various `ttlMs` that are Postgres row lifetimes with reapers — those are not caches at all.

Not in this PR, for scope: `vault-transit`'s `openCache` (holds decrypted plaintext — deserves its own review) and the daemon/relay ones (would add a production dependency to two more packages).

## A trap worth knowing

The GitHub authz test clock had to be seeded with a real epoch. lru-cache stores an entry's start time and reads a falsy one as "no TTL recorded", so **entries written at time 0 never expire** — the two expiry assertions in `user-authz.test.ts` would have kept passing while testing nothing. `cache.ts` documents the requirement.

## Testing

- `test:unit` — 1291 passed (2 new: Feishu quota verdict not retained; concurrent permission probes coalesced. Plus concurrent picker pages added to the existing `listRepos` test)
- `test:int` — 73 files, 1046 passed
- `typecheck`, `eslint`, `prettier` clean

The pre-existing tests for the converted paths are the real evidence here: Feishu's "coalesces concurrent viewers into one shared Bot chat member snapshot", the roster-invalidation test, and the `maxCacheAgeMs` lease test all pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
