### PR TITLE
fix(web): align notification rail action

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -610,6 +610,11 @@
     padding: 10px;
     border-top: 1px solid var(--border-inverse);
   }
+  /* The header pair uses a 1px gap after its negative-margin correction. Pull
+     the bell 3px toward Help so the footer pair shares those exact centres. */
+  .railnotification {
+    margin-right: -3px;
+  }
   .pfbtn {
     display: flex;
     align-items: center;
@@ -649,6 +654,9 @@
      do it for them. */
   .rail.collapsed .railfoot .railiconbtn {
     margin-inline: auto;
+  }
+  .rail.collapsed .railnotification {
+    margin-right: 0;
   }
   /* The help popover needs room the 64px rail hasn't got, and its contents are all
      reachable from the docs anyway — collapsed, it steps aside for the account block. */

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -610,11 +610,6 @@
     padding: 10px;
     border-top: 1px solid var(--border-inverse);
   }
-  /* The header pair uses a 1px gap after its negative-margin correction. Pull
-     the bell 3px toward Help so the footer pair shares those exact centres. */
-  .railnotification {
-    margin-right: -3px;
-  }
   .pfbtn {
     display: flex;
     align-items: center;
@@ -654,9 +649,6 @@
      do it for them. */
   .rail.collapsed .railfoot .railiconbtn {
     margin-inline: auto;
-  }
-  .rail.collapsed .railnotification {
-    margin-right: 0;
   }
   /* The help popover needs room the 64px rail hasn't got, and its contents are all
      reachable from the docs anyway — collapsed, it steps aside for the account block. */

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -774,7 +774,7 @@ function ShellChromeInner({ children }: { children: ReactNode }) {
                     <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={16} />
                   </button>
                 )}
-                <div className="flex-none">
+                <div className="railnotification flex-none">
                   <NotificationBell variant="rail" />
                 </div>
                 {/* Same 22px box as the brand row's search button, and the same 2px

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -774,7 +774,11 @@ function ShellChromeInner({ children }: { children: ReactNode }) {
                     <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={16} />
                   </button>
                 )}
-                <div className="railnotification flex-none">
+                <div
+                  className={
+                    railCollapsed ? 'flex flex-none justify-center' : 'mr-[-3px] flex flex-none justify-center'
+                  }
+                >
                   <NotificationBell variant="rail" />
                 </div>
                 {/* Same 22px box as the brand row's search button, and the same 2px


### PR DESCRIPTION
## Summary

- align the notification and help controls to the same 22px centers and 1px gap used by the collapse/search pair
- preserve centered notification placement when the rail is collapsed

## Verification

- `pnpm build`
- `pnpm --filter @agentconnect.md/web build`
- `pnpm --filter @agentconnect.md/web test` (119 files, 939 tests)
- `pnpm typecheck`
- `pnpm lint`

Full local `pnpm test` reached one existing macOS timing failure in `packages/cli/test/service-spawn.test.ts`; this PR does not touch CLI code. Linux CI must pass before merge.