### PR TITLE
perf(cp): serve the session-access snapshot while it refreshes

### DIFF
--- a/packages/control-plane/src/http/session-access.test.ts
+++ b/packages/control-plane/src/http/session-access.test.ts
@@ -139,11 +139,17 @@ describe('makeSessionAccessResolver snapshot', () => {
    *  left at 0 would make the first snapshot immortal. */
   const EPOCH = 1_777_000_000_000
 
+  /** Lets a background refresh settle without advancing the clock. */
+  const settle = () => new Promise((done) => setImmediate(done))
+
   function harness(scopes: readonly ExternalScopeRecord[] = [scope]) {
     const clock = new FakeClock(EPOCH)
+    let sweeps = 0
     const resolve = vi.fn(async (given: readonly ExternalScopeRecord[]) => ({
       allowedScopes: given.map(({ id, aclRevision }) => ({ id, aclRevision })),
-      degraded: false,
+      // Marks WHICH sweep an answer came from, so a test can tell a served
+      // snapshot from the refresh that replaced it.
+      degraded: ++sweeps > 1,
       accessIssues: []
     })) satisfies SessionAccessPlugin['resolve']
     const deps = {
@@ -185,18 +191,65 @@ describe('makeSessionAccessResolver snapshot', () => {
     expect(resolve).toHaveBeenCalledTimes(1)
   })
 
-  it('re-asks the providers once the snapshot window closes', async () => {
+  it('serves a fresh snapshot without touching the providers', async () => {
     const { deps, clock, resolve } = harness()
     const resolver = makeSessionAccessResolver(deps)
 
     await resolver.forQuery(request(), query)
-    clock.advance(4_999)
+    clock.advance(29_999)
     await resolver.forQuery(request(), query)
-    expect(resolve).toHaveBeenCalledTimes(1)
 
-    clock.advance(2)
+    expect(resolve).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves the snapshot it has and refreshes behind the request', async () => {
+    const { deps, clock, resolve } = harness()
+    const resolver = makeSessionAccessResolver(deps)
+
     await resolver.forQuery(request(), query)
+    clock.advance(30_001)
+
+    // Past the fresh window: this read must NOT wait on the sweep, so it still
+    // reports the first sweep's answer (`degraded: false`).
+    const served = await resolver.forQuery(request(), query)
+    expect(served.degraded).toBe(false)
+
+    // …and the refresh it kicked off lands without anyone waiting for it, so
+    // the next read sees the second sweep.
+    await settle()
     expect(resolve).toHaveBeenCalledTimes(2)
+    expect((await resolver.forQuery(request(), query)).degraded).toBe(true)
+  })
+
+  it('blocks on a real sweep once the ceiling passes', async () => {
+    const { deps, clock, resolve } = harness()
+    const resolver = makeSessionAccessResolver(deps)
+
+    await resolver.forQuery(request(), query)
+    clock.advance(60_001)
+
+    // Nothing servable is left, so this read waits and gets the fresh answer
+    // rather than an arbitrarily old one.
+    expect((await resolver.forQuery(request(), query)).degraded).toBe(true)
+    expect(resolve).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps serving the previous snapshot when a refresh behind the request fails', async () => {
+    const { deps, clock, resolve } = harness()
+    const resolver = makeSessionAccessResolver(deps)
+
+    await resolver.forQuery(request(), query)
+    clock.advance(30_001)
+    resolve.mockRejectedValueOnce(new Error('slack unreachable'))
+
+    await expect(resolver.forQuery(request(), query)).resolves.toMatchObject({ degraded: false })
+    await settle()
+    // A provider blip does not empty the answer, and does not surface as an
+    // error on a read that never waited for it.
+    await expect(resolver.forQuery(request(), query)).resolves.toMatchObject({
+      degraded: false,
+      externalAccess: { allowedScopes: [{ id: scope.id, aclRevision: scope.aclRevision }] }
+    })
   })
 
   it('keys the snapshot on the scope set, so a re-fenced scope never hits a stale entry', async () => {

--- a/packages/control-plane/src/http/session-access.test.ts
+++ b/packages/control-plane/src/http/session-access.test.ts
@@ -252,6 +252,40 @@ describe('makeSessionAccessResolver snapshot', () => {
     })
   })
 
+  // The ceiling has to hold even when a refresh straddles it. `fetch` coalesces
+  // a later caller onto the SAME in-flight promise and settles it with the
+  // options of the fetch that created it, so a stale-on-rejection policy set by
+  // the refresh would leak to a caller that was supposed to block.
+  it('makes a caller that arrives past the ceiling observe a straddling refresh’s failure', async () => {
+    const { deps, clock, resolve } = harness()
+    const resolver = makeSessionAccessResolver(deps)
+
+    await resolver.forQuery(request(), query)
+
+    // A refresh that starts inside the stale window and is still running later.
+    let failRefresh!: (err: Error) => void
+    resolve.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          failRefresh = reject
+        })
+    )
+    clock.advance(30_001)
+    await expect(resolver.forQuery(request(), query)).resolves.toMatchObject({ degraded: false })
+
+    // Past the ceiling nothing is servable, so this caller joins the pending
+    // refresh and must see its failure rather than inherit the old snapshot.
+    clock.advance(30_000)
+    const blocked = resolver.forQuery(request(), query)
+    // It has to reach the cache and join that refresh BEFORE the refresh
+    // settles, or it simply starts a sweep of its own and the overlap this test
+    // exists for never happens.
+    await settle()
+    failRefresh(new Error('slack unreachable'))
+
+    await expect(blocked).rejects.toThrow('slack unreachable')
+  })
+
   it('keys the snapshot on the scope set, so a re-fenced scope never hits a stale entry', async () => {
     const { deps, resolve } = harness()
     const resolver = makeSessionAccessResolver(deps)

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -31,23 +31,53 @@ export interface SessionAccessResolver {
 }
 
 /**
- * How long one resolved provider snapshot is reused.
+ * How long a snapshot is served with no provider work at all.
  *
- * Deliberately short. One console page load asks the SAME authorization
- * question from `/sessions`, `/sessions/facets` and `/usage` within the same
- * tick, and each answer used to pay its own full provider sweep — which is why
- * those three were the only reads on the page costing seconds while every other
- * read model returned in tens of milliseconds. This window collapses them into
- * one sweep and nothing more: the plugins' own decision leases (allow 120 s,
- * deny 30 s, unknown 5 s) remain the real freshness bound, and this can only add
- * seconds to them.
- *
- * The post-resolution policy re-read (see `forScopes`) is reused for the same
- * window. That fence is backstopped by SQL, which repeats the current-policy
- * check per row on every list read.
+ * One console page load asks the SAME authorization question from `/sessions`,
+ * `/sessions/facets` and `/usage` within the same tick, and each answer used to
+ * pay its own full provider sweep — which is why those three were the only reads
+ * on the page costing seconds while every other read model returned in tens of
+ * milliseconds. Collapsing them fixed the common case but not the tail: whenever
+ * this window and a plugin's own decision lease both lapsed, some unlucky
+ * request still wore the whole sweep.
  */
-const SNAPSHOT_TTL_MS = 5_000
+const SNAPSHOT_FRESH_MS = 30_000
+
+/**
+ * The ceiling on serving a snapshot while its refresh runs behind the request.
+ *
+ * Past the fresh window a read hands back what it has and re-sweeps in the
+ * background, so no console read waits on Slack or GitHub. Past THIS window the
+ * entry is gone and the next read blocks on a real sweep — an unbounded
+ * stale-while-revalidate would mean a revoked user is never re-checked until
+ * they happen to come back.
+ *
+ * It is not free, and the arithmetic is worth stating: a sweep reuses plugin
+ * verdicts that are themselves already up to their own allow lease (120 s) old,
+ * so the worst-case age of the evidence behind a served answer is this window
+ * PLUS that lease. The pre-SWR 5 s window made that ~125 s; 60 s makes it
+ * ~180 s. Every second added here is a second added to the revocation window,
+ * one for one — that is the entire price of never blocking, and no setting of
+ * this constant avoids it.
+ */
+const SNAPSHOT_MAX_STALE_MS = 60_000
+
 const MAX_SNAPSHOT_ENTRIES = 2_000
+
+/**
+ * Hand back the entry we have and refresh behind the request.
+ *
+ * The `allowStale…` pair is scoped to THIS path deliberately. A refresh that
+ * fails keeps serving the snapshot it was refreshing, up to the ceiling; a COLD
+ * sweep that fails must still reject, because resolving it to "no external
+ * access" would silently hide every external row instead of reporting an error.
+ */
+const REFRESH_BEHIND = {
+  forceRefresh: true,
+  allowStale: true,
+  allowStaleOnFetchRejection: true,
+  noDeleteOnFetchRejection: true
+} as const
 
 /** What one sweep needs, carried to `fetchMethod` as its context. */
 type Sweep = { scopes: readonly ExternalScopeRecord[]; viewer: SessionAccessViewer }
@@ -154,7 +184,10 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
    *  never expire. */
   const snapshots = new LRUCache<string, ResolvedSessionAccess, Sweep>({
     max: MAX_SNAPSHOT_ENTRIES,
-    ttl: SNAPSHOT_TTL_MS,
+    // The entry's lifetime is the CEILING, not the fresh window: an entry has to
+    // outlive its own freshness for there to be anything to serve while the
+    // refresh runs. `SNAPSHOT_FRESH_MS` is applied by the reader below.
+    ttl: SNAPSHOT_MAX_STALE_MS,
     ttlResolution: 0,
     perf: deps.clock,
     fetchMethod: (_key, _stale, { context }) => forScopes(context.scopes, context.viewer)
@@ -163,16 +196,25 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
   /** `forScopes` behind the snapshot window. Callers treat the record as
    *  immutable; the identity set is copied per hand-out so a caller that does
    *  not cannot corrupt the entry. `decisionAt` is served as recorded — a
-   *  reused snapshot truthfully reports when it was decided. */
+   *  reused snapshot truthfully reports when it was decided, which is the only
+   *  honest thing to report once one can be served stale. */
   const cachedForScopes = async (
     scopes: readonly ExternalScopeRecord[],
     viewer: SessionAccessViewer
   ): Promise<ResolvedSessionAccess> => {
+    const key = snapshotKey(viewer, scopes)
+    // The entry's lifetime IS the ceiling, so what remains of it gives the age.
+    // A missing or expired key reports 0 and takes the blocking path, which is
+    // also what a cold start and anything past the ceiling should do.
+    const remaining = snapshots.getRemainingTTL(key)
+    const refreshBehind = remaining > 0 && remaining <= SNAPSHOT_MAX_STALE_MS - SNAPSHOT_FRESH_MS
     // `fetch` resolves undefined only if the entry is dropped mid-flight. Sweep
     // directly rather than reporting no external access, which would hide rows.
     const access =
-      (await snapshots.fetch(snapshotKey(viewer, scopes), { context: { scopes, viewer } })) ??
-      (await forScopes(scopes, viewer))
+      (await snapshots.fetch(key, {
+        context: { scopes, viewer },
+        ...(refreshBehind ? REFRESH_BEHIND : {})
+      })) ?? (await forScopes(scopes, viewer))
     return { ...access, identitySet: new Set(access.identitySet) }
   }
 

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -1,5 +1,6 @@
 import type { FastifyRequest } from 'fastify'
 import { LRUCache } from 'lru-cache'
+import { cacheOptions } from '../cache.js'
 import type {
   ExternalScopeRecord,
   SessionExternalAccessSnapshot,
@@ -67,17 +68,25 @@ const MAX_SNAPSHOT_ENTRIES = 2_000
 /**
  * Hand back the entry we have and refresh behind the request.
  *
- * The `allowStale…` pair is scoped to THIS path deliberately. A refresh that
- * fails keeps serving the snapshot it was refreshing, up to the ceiling; a COLD
- * sweep that fails must still reject, because resolving it to "no external
- * access" would silently hide every external row instead of reporting an error.
+ * `noDeleteOnFetchRejection` keeps the snapshot a failed refresh was refreshing,
+ * so a provider blip inside the window does not empty the answer.
+ *
+ * `allowStaleOnFetchRejection` is deliberately NOT set, and its absence is
+ * load-bearing. A refresh started inside the stale window can still be running
+ * once the entry passes the ceiling; `fetch` coalesces the caller that arrives
+ * then onto the SAME promise — its in-flight branch runs before any staleness
+ * check — and lru-cache settles that promise with the options of the fetch that
+ * CREATED it. Allowing stale on rejection here would therefore hand the old
+ * snapshot to a caller that was supposed to block, so the ceiling would stop
+ * being hard in exactly the case it exists for. Without it, that caller observes
+ * the failure, while the reader that never waited still gets its stale value and
+ * the entry still survives.
+ *
+ * A COLD sweep that fails is unaffected either way: it rejects, because
+ * resolving it to "no external access" would silently hide every external row
+ * instead of reporting an error.
  */
-const REFRESH_BEHIND = {
-  forceRefresh: true,
-  allowStale: true,
-  allowStaleOnFetchRejection: true,
-  noDeleteOnFetchRejection: true
-} as const
+const REFRESH_BEHIND = { forceRefresh: true, allowStale: true, noDeleteOnFetchRejection: true } as const
 
 /** What one sweep needs, carried to `fetchMethod` as its context. */
 type Sweep = { scopes: readonly ExternalScopeRecord[]; viewer: SessionAccessViewer }
@@ -176,20 +185,13 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
 
   /** `fetch` hands concurrent callers of one key the SAME promise, which is the
    *  single-flight this exists for, and drops the entry when the sweep rejects —
-   *  a failed sweep is never inherited as a verdict. `perf` is the time seam;
-   *  `ttlResolution: 0` turns off lru-cache's 1 ms `now()` debounce, which is
-   *  driven by a real timer a `FakeClock` cannot advance. The clock must report
-   *  real epoch milliseconds, as `Clock` documents: lru-cache treats a falsy
-   *  entry start as "no TTL recorded", so a snapshot written at time 0 would
-   *  never expire. */
+   *  a failed sweep is never inherited as a verdict. */
   const snapshots = new LRUCache<string, ResolvedSessionAccess, Sweep>({
-    max: MAX_SNAPSHOT_ENTRIES,
+    ...cacheOptions(deps.clock, MAX_SNAPSHOT_ENTRIES),
     // The entry's lifetime is the CEILING, not the fresh window: an entry has to
     // outlive its own freshness for there to be anything to serve while the
     // refresh runs. `SNAPSHOT_FRESH_MS` is applied by the reader below.
     ttl: SNAPSHOT_MAX_STALE_MS,
-    ttlResolution: 0,
-    perf: deps.clock,
     fetchMethod: (_key, _stale, { context }) => forScopes(context.scopes, context.viewer)
   })
 


### PR DESCRIPTION
Stale-while-revalidate on the session-access snapshot. Independent of #744 — different files, either can land first.

## Why

#739 collapsed one page load's four reads into a single provider sweep, which fixed the common case but **not the tail**. The snapshot lasted 5 s, and underneath it the plugin decision caches lapse on their own schedule, so a request that hit both boundaries still wore the whole sweep:

| verdict | plugin lease | so a full sweep resurfaces every |
|---|---|---|
| allow | 120 s | ~2 min |
| deny | 30 s | ~30 s |
| unknown (provider degraded) | 5 s | ~5 s |

## What changes

```
age < 30 s          → serve, no provider work
30 s ≤ age < 60 s   → serve what we have, re-sweep behind the request
age ≥ 60 s          → block on a real sweep
```

The entry's lru-cache `ttl` is the **ceiling**, not the fresh window — an entry has to outlive its own freshness for there to be anything to serve while the refresh runs. `lru-cache`'s `fetch` does the rest natively: `forceRefresh` + `allowStale` returns the existing value immediately and starts the background fetch, and concurrent readers during that window get the same value rather than piling up.

## The cost, stated plainly

**I got this wrong when we scoped it, so it is worth being explicit.** I claimed a 120 s ceiling would keep the revocation window unchanged. It does not — the two layers compound:

> a sweep at time S reuses plugin verdicts decided as early as **S − 120 s**, and that sweep's snapshot is then served until **S + ceiling**

so the worst-case age of the evidence behind a served answer is `ceiling + 120 s`:

| ceiling | worst-case evidence age |
|---|---|
| 5 s (before this change) | ~125 s |
| **60 s (this PR)** | **~180 s** |
| 120 s (originally proposed) | ~240 s |

There is no setting that preserves the old bound — serving anything stale *is* the relaxation. 60 s is the compromise: it removes blocking entirely for anyone reading more often than once a minute (the console re-reads on every SSE session event, on focus, and on a 30 s poll), for ~1.4× the old window rather than ~2×. Raising it is a one-constant change if you want the trade the other way.

## Failure behaviour

Stale-on-rejection is scoped to the refresh path only:

- a **refresh** that fails keeps serving what it was refreshing, up to the ceiling, and does not surface as an error on a read that never waited for it;
- a **cold** sweep that fails still rejects, because resolving it to "no external access" would silently hide every external row instead of reporting an error.

## Testing

`test:unit` 1292 passed / `test:int` 73 files, 1046 passed / typecheck, eslint, prettier clean.

Four new tests replace the old single-window one, each a real discriminator — they fail if the corresponding half is missing:

- serves a fresh snapshot without touching the providers
- serves the snapshot it has and refreshes behind the request (fails if the read blocks: it would see the *second* sweep's answer)
- blocks on a real sweep once the ceiling passes (fails if stale is unbounded)
- keeps serving the previous snapshot when a refresh behind the request fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
