### PR TITLE
fix: improve child reply status guidance

### DIFF
--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -420,7 +420,10 @@ implements the same-thread form, and unified `sendMessage` reuses it.
    is B's logical `sessionKey`, and deletes it at turn end at `daemon.ts:6605`.
    It also writes `originSessionId` as `Parent session` in B's `# Agent`
    system-prompt block at `session-manager.ts:312`. B can then call
-   `sendMessage({sessionId: <Parent session>})`.
+   `sendMessage({sessionId: <Parent session>})`. Only when the wake carries
+   `needsReply` does the daemon also inject a report-back directive into the
+   child session: reply exactly once at completion, then end the turn without
+   repeating the result in ordinary child-session output.
 3. **Authorize and inject on reply.** When B calls a SessionTarget, the daemon:
    - Gets `inbound` from `activeTurnCallMeta.get(callerKey)` at
      `daemon.ts:3491`.
@@ -476,6 +479,15 @@ work therefore needs a handle on the child and a way to ask how it is going.
   addressable: an ACP session id is not accepted, because ACP ids are minted per
   runtime and are not unique across agents. `done` means the child's turn ended,
   not that it reported anything back.
+
+  The answer also carries reply guidance separately from execution status:
+  `reply: { requested, state }`, `nextAction`, and a short `message`. Reply state
+  distinguishes `awaiting` from `queued-for-parent` (the agent replied and the
+  serialized parent session will receive it in its next turn), as well as
+  `not-sent`, `failed`, and `unknown`. In particular, a queued reply instructs
+  the parent to end its current turn and not retry. This state-specific guidance
+  lives in the tool result rather than the always-loaded tool description, so it
+  consumes context only when the parent checks that child.
 
   A turn that is queued, running, or admitted-but-not-yet-started all report
   `in-progress`. That matters for a RE-delegation: until the child picks the new

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7221,7 +7221,14 @@ export class Daemon {
   // read for those is routed through the CP (§5.4) instead of the local store.
   private readonly childSessionLinks = new Map<
     string,
-    { parentSessionId: string; agentId: string; rowUpdatedAtAtAdmission: number | null; remote?: boolean }
+    {
+      parentSessionId: string
+      agentId: string
+      rowUpdatedAtAtAdmission: number | null
+      replyRequested: boolean
+      replyState: 'awaiting' | 'queued-for-parent' | 'failed'
+      remote?: boolean
+    }
   >()
 
   // §3.4/§6.8 orchestration deadline timers, keyed by orchestrationId. Held HERE
@@ -7909,7 +7916,9 @@ export class Daemon {
       this.childSessionLinks.set(childSessionId, {
         parentSessionId: msg.originSessionId,
         agentId: msg.toAgentId,
-        rowUpdatedAtAtAdmission: this.store.getSession(childSessionId)?.updatedAt ?? null
+        rowUpdatedAtAtAdmission: this.store.getSession(childSessionId)?.updatedAt ?? null,
+        replyRequested: msg.needsReply === true,
+        replyState: 'awaiting'
       })
     }
     // No `headless` stamp for a `session-reply` reaching this path either (§7): the report it
@@ -8318,6 +8327,8 @@ export class Daemon {
           parentSessionId: originSessionId,
           agentId: req.toAgentId,
           rowUpdatedAtAtAdmission: null,
+          replyRequested: req.needsReply === true,
+          replyState: 'awaiting',
           remote: true
         })
       }
@@ -8397,7 +8408,9 @@ export class Daemon {
         agentId: req.toAgentId,
         // Snapshot the child row as it stands BEFORE the wake runs (null when it has never run),
         // so a re-wake of a finished child can't be reported with its previous turn's outcome.
-        rowUpdatedAtAtAdmission: this.store.getSession(targetSession)?.updatedAt ?? null
+        rowUpdatedAtAtAdmission: this.store.getSession(targetSession)?.updatedAt ?? null,
+        replyRequested: req.needsReply === true,
+        replyState: 'awaiting'
       })
     }
     // send-message-routing-rework.md §3.2/§8.6 — the "internal wake first" arrival order
@@ -8453,6 +8466,26 @@ export class Daemon {
    * `originSessionId`. A root/human turn (no active call metadata) or any other sessionId is
    * refused — an agent can never inject into an arbitrary session.
    */
+  private markChildParentReply(
+    childSessionKey: string,
+    parentSessionId: string,
+    state: 'queued-for-parent' | 'failed'
+  ): void {
+    const existing = this.childSessionLinks.get(childSessionKey)
+    if (existing && existing.parentSessionId !== parentSessionId) return
+    const child = this.store.getSession(childSessionKey)
+    this.childSessionLinks.set(childSessionKey, {
+      parentSessionId,
+      agentId: existing?.agentId ?? child?.agentId ?? '',
+      // This is a reply observation, not a fresh wake. `null` keeps the re-wake fence inactive
+      // once the durable child row exists.
+      rowUpdatedAtAtAdmission: existing?.rowUpdatedAtAtAdmission ?? null,
+      replyRequested: existing?.replyRequested ?? child?.needsParentReply === 1,
+      replyState: state,
+      ...(existing?.remote ? { remote: true } : {})
+    })
+  }
+
   private async replyToSession(req: ReplyToSessionReq): Promise<ReplyToSessionResult> {
     const platform = req.platform
     const callerKey = sessionKey(
@@ -8572,6 +8605,7 @@ export class Daemon {
       void this.dispatch(originOwner, normalized, integrationId, undefined, callMeta).catch((err) =>
         this.log.error(`replyToSession dispatch failed for session "${req.sessionId}": ${formatErr(err)}`)
       )
+      this.markChildParentReply(callerKey, req.sessionId, 'queued-for-parent')
       this.log.info(`replyToSession: ${req.callerAgentId} → ${originOwner} (${local.key}) delivery=${deliveryId}`)
       return { delivered: true, targetSession: local.key }
     }
@@ -8617,6 +8651,7 @@ export class Daemon {
         deliveryKind: 'session-reply'
       }
     )
+    this.markChildParentReply(callerKey, req.sessionId, res.delivered ? 'queued-for-parent' : 'failed')
     return {
       delivered: res.delivered,
       targetSession: res.targetSession,
@@ -8666,14 +8701,84 @@ export class Daemon {
       const link = this.childSessionLinks.get(req.sessionId)
       if (!link || link.parentSessionId !== callerSessionId) return null
       if (link.remote) return await this.remoteChildStatus(req.sessionId, callerSessionId, link.agentId)
-      return { sessionId: req.sessionId, agentId: link.agentId, status: 'in-progress', state: 'starting' }
+      return {
+        sessionId: req.sessionId,
+        agentId: link.agentId,
+        status: 'in-progress',
+        state: 'starting',
+        ...this.childStatusGuidance('in-progress', link.replyRequested, link.replyState)
+      }
     }
     if (!this.isAuthorizedChildParent(child, callerSessionId)) return null
     // A session cannot be its own child; guard the degenerate case where a caller passes its own
     // id and a stale link would otherwise vouch for it.
     if (child.key === callerKey) return null
-    const collapsed = this.collapseChildStatus(child)
+    const collapsed = this.collapseChildStatus(child, callerSessionId)
     return { sessionId: req.sessionId, ...collapsed }
+  }
+
+  private childStatusGuidance(
+    status: SessionStatusResult['status'],
+    replyRequested: boolean,
+    trackedReplyState?: 'awaiting' | 'queued-for-parent' | 'failed'
+  ): Pick<SessionStatusResult, 'reply' | 'nextAction' | 'message'> {
+    if (trackedReplyState === 'queued-for-parent') {
+      return {
+        reply: { requested: replyRequested, state: 'queued-for-parent' },
+        nextAction: 'finish-turn-and-wait',
+        message:
+          'The agent replied. Its reply is queued for this session and will arrive in your next turn. End this turn; do not retry or ask the agent to repeat it.'
+      }
+    }
+    if (trackedReplyState === 'failed') {
+      return {
+        reply: { requested: replyRequested, state: 'failed' },
+        nextAction: 'report-failure',
+        message: 'The agent tried to reply, but delivery failed. Do not retry automatically; report the failure.'
+      }
+    }
+    if (!replyRequested) {
+      return {
+        reply: { requested: false, state: 'not-requested' },
+        nextAction: status === 'in-progress' ? 'wait' : status === 'failed' ? 'report-failure' : 'none',
+        message:
+          status === 'in-progress'
+            ? 'Message delivered; the agent is still working. No reply was requested.'
+            : status === 'failed'
+              ? 'The child turn failed. No reply was requested.'
+              : 'The child turn finished cleanly. No reply was requested.'
+      }
+    }
+    if (status === 'in-progress') {
+      return {
+        reply: { requested: true, state: 'awaiting' },
+        nextAction: 'finish-turn-and-wait',
+        message:
+          'Message delivered; the agent is still working. End this turn and wait for its reply; do not retry or poll tightly.'
+      }
+    }
+    if (status === 'failed') {
+      return {
+        reply: { requested: true, state: 'not-sent' },
+        nextAction: 'report-failure',
+        message:
+          'The child turn failed before sending the requested reply. Do not retry automatically; report the failure.'
+      }
+    }
+    if (trackedReplyState === 'awaiting') {
+      return {
+        reply: { requested: true, state: 'not-sent' },
+        nextAction: 'report-missing-reply',
+        message:
+          'The child turn finished without sending the requested parent-session reply. Do not retry automatically; report this outcome or wait for user direction.'
+      }
+    }
+    return {
+      reply: { requested: true, state: 'unknown' },
+      nextAction: 'finish-turn-and-wait',
+      message:
+        'The child turn finished, but reply-delivery state is unavailable. End this turn and wait; do not retry or ask the agent to repeat it.'
+    }
   }
 
   /**
@@ -8686,13 +8791,20 @@ export class Daemon {
    * `rowUpdatedAtAtAdmission` note on childSessionLinks). Reporting the previous turn's outcome in
    * any of those windows would tell the parent its NEW delegation had already finished.
    */
-  private collapseChildStatus(child: SessionRecord): {
+  private collapseChildStatus(
+    child: SessionRecord,
+    parentSessionId: string
+  ): {
     agentId: string
     status: SessionStatusResult['status']
     state: SessionStatusResult['state']
     updatedAt: number
+    reply: SessionStatusResult['reply']
+    nextAction: SessionStatusResult['nextAction']
+    message: string
   } {
-    const link = this.childSessionLinks.get(child.key)
+    const candidateLink = this.childSessionLinks.get(child.key)
+    const link = candidateLink?.parentSessionId === parentSessionId ? candidateLink : undefined
     const queuedOrRunning = this.activeGateEntries.has(child.key) || (this.serialQueue.get(child.key)?.length ?? 0) > 0
     const admittedNotStarted = link !== undefined && child.updatedAt === link.rowUpdatedAtAtAdmission
     const inFlight = child.state === 'prompting' || child.state === 'cancelling' || child.state === 'resuming'
@@ -8706,7 +8818,14 @@ export class Daemon {
             : // Idle/closed with no recorded outcome: the row exists but its first turn has not
               // finished (or predates outcome tracking) — treat as still working, never as done.
               'in-progress'
-    return { agentId: child.agentId, status, state: child.state, updatedAt: child.updatedAt }
+    const replyRequested = link?.replyRequested ?? child.needsParentReply === 1
+    return {
+      agentId: child.agentId,
+      status,
+      state: child.state,
+      updatedAt: child.updatedAt,
+      ...this.childStatusGuidance(status, replyRequested, link?.replyState)
+    }
   }
 
   /**
@@ -8737,12 +8856,17 @@ export class Daemon {
       throw new Error(`the daemon running ${childSessionId} is not currently reachable — try again shortly`)
     }
     if (!res.found) return null
+    const link = this.childSessionLinks.get(childSessionId)
+    const fallback = this.childStatusGuidance(res.status ?? 'in-progress', link?.replyRequested ?? false, undefined)
     return {
       sessionId: childSessionId,
       agentId: res.agentId ?? childAgentId,
       status: res.status ?? 'in-progress',
       state: res.state ?? 'starting',
-      ...(res.updatedAt !== undefined ? { updatedAt: res.updatedAt } : {})
+      ...(res.updatedAt !== undefined ? { updatedAt: res.updatedAt } : {}),
+      reply: res.reply ?? fallback.reply,
+      nextAction: res.nextAction ?? fallback.nextAction,
+      message: res.message ?? fallback.message
     }
   }
 
@@ -8763,10 +8887,16 @@ export class Daemon {
       // at ACK time is the only record — and the only authority — until then.
       const link = this.childSessionLinks.get(probe.childSessionId)
       if (!link || link.parentSessionId !== probe.parentSessionId) return { found: false }
-      return { found: true, agentId: link.agentId, status: 'in-progress', state: 'starting' }
+      return {
+        found: true,
+        agentId: link.agentId,
+        status: 'in-progress',
+        state: 'starting',
+        ...this.childStatusGuidance('in-progress', link.replyRequested, link.replyState)
+      }
     }
     if (!this.isAuthorizedChildParent(child, probe.parentSessionId)) return { found: false }
-    return { found: true, ...this.collapseChildStatus(child) }
+    return { found: true, ...this.collapseChildStatus(child, probe.parentSessionId) }
   }
 
   /**

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8604,9 +8604,26 @@ export class Daemon {
             : [],
         isDm: false
       }
-      void this.dispatch(originOwner, normalized, integrationId, undefined, callMeta).catch((err) =>
+      let admission: { accepted: boolean; reason?: string } | undefined
+      const turn = this.dispatch(originOwner, normalized, integrationId, undefined, callMeta, {
+        onAdmission: (result) => {
+          admission = result
+        }
+      })
+      void turn.catch((err) =>
         this.log.error(`replyToSession dispatch failed for session "${req.sessionId}": ${formatErr(err)}`)
       )
+      // dispatch() settles admission synchronously for this live delivery. Do not promise that
+      // the reply is queued when pause/drain, loop protection, or backpressure rejected it.
+      if (!admission) throw new Error('replyToSession admission barrier did not settle synchronously')
+      if (!admission.accepted) {
+        this.markChildParentReply(callerKey, req.sessionId, 'failed')
+        return {
+          delivered: false,
+          targetSession: local.key,
+          reason: admission.reason === 'queue_full' ? 'queue_full' : 'busy'
+        }
+      }
       this.markChildParentReply(callerKey, req.sessionId, 'queued-for-parent')
       this.log.info(`replyToSession: ${req.callerAgentId} → ${originOwner} (${local.key}) delivery=${deliveryId}`)
       return { delivered: true, targetSession: local.key }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8474,6 +8474,8 @@ export class Daemon {
     const existing = this.childSessionLinks.get(childSessionKey)
     if (existing && existing.parentSessionId !== parentSessionId) return
     const child = this.store.getSession(childSessionKey)
+    // Track an unsolicited reply too: `requested` stays false, while the parent can still see
+    // that a real reply was queued instead of mistaking it for an outstanding request.
     this.childSessionLinks.set(childSessionKey, {
       parentSessionId,
       agentId: existing?.agentId ?? child?.agentId ?? '',

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -248,6 +248,15 @@ export interface SessionStatusResult {
   /** The underlying lifecycle state, for a caller that wants the detail: one of the §7.3
    *  states, or 'starting' when the wake was admitted but the session has not opened yet. */
   state: 'starting' | 'idle' | 'prompting' | 'cancelling' | 'resuming' | 'closed'
+  /** Delivery state of the optional child -> parent report requested by `needsReply`. */
+  reply: {
+    requested: boolean
+    state: 'not-requested' | 'awaiting' | 'queued-for-parent' | 'not-sent' | 'failed' | 'unknown'
+  }
+  /** Machine-readable instruction chosen from the live execution + reply state. */
+  nextAction: 'none' | 'wait' | 'finish-turn-and-wait' | 'report-failure' | 'report-missing-reply'
+  /** Short, state-specific model guidance. Kept in the result instead of the always-loaded schema. */
+  message: string
   /** Epoch ms of the last state change; absent while the session is still 'starting'. */
   updatedAt?: number
 }
@@ -1235,6 +1244,14 @@ export async function executeTool(
       ...(wake !== undefined ? { wake } : {}),
       ...(post !== undefined ? { post } : {}),
       ...(childSessionId !== undefined ? { childSessionId } : {}),
+      ...(childSessionId !== undefined && needsReply
+        ? {
+            reply: { requested: true, state: 'awaiting' as const },
+            nextAction: 'finish-turn-and-wait' as const,
+            message:
+              'Message delivered. The agent will reply by waking this session in a later turn. End this turn and wait; do not retry or ask it to repeat the work.'
+          }
+        : {}),
       ...(notice !== undefined ? { notice } : {})
     }
   }

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -147,7 +147,8 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
             'all qualify. A woken peer answers inside ITS OWN conversation, so without `needsReply` its answer ' +
             'never reaches you or the humans waiting in yours, and you are not even told that it failed. With it, ' +
             'the peer’s session carries a standing instruction to reply into YOUR session when it finishes or ' +
-            'fails, and you can poll it meanwhile with `viewSessionStatus` on the returned `childSessionId`. To ' +
+            'fails. The result tells you to end the current turn and wait; use `viewSessionStatus` on the returned ' +
+            '`childSessionId` only for optional diagnostics. To ' +
             'open a new channel-root conversation with YOURSELF, pass your own ID from the # Agent block together ' +
             'with `channel`; a self target without `channel` is rejected.',
           oneOf: [
@@ -299,8 +300,8 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
         'target yourself: use your own # Agent ID to open and activate one new conversation there.\n' +
         '  Use `{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}` WHENEVER you expect an answer ' +
         'back — your message asks a question or requests a result, or someone asked you to relay the peer’s answer. ' +
-        'The peer replies in its own conversation, so without `needsReply` its answer never reaches you. Pass the ' +
-        'returned `childSessionId` to `viewSessionStatus` to check on it.\n' +
+        'The peer replies in its own conversation, so without `needsReply` its answer never reaches you. Follow the ' +
+        'returned `nextAction`; use `viewSessionStatus` only for optional diagnostics.\n' +
         '- toUser — reach HUMAN users (Slack only for now), never an AgentConnect agent or your own bot identity:\n' +
         '  • dm: `{"toUser":"<Slack user id>","message":"..."}` — direct message; do not set `channel`.\n' +
         '  • channel root: `{"toUser":["<user id 1>","<user id 2>"],"channel":"<channel id>","message":"..."}` — ' +
@@ -673,14 +674,8 @@ export const COLLABORATION_TOOLS: ToolDescriptor[] = [
   {
     name: 'viewSessionStatus',
     description:
-      'Check whether a session YOU started is still working. Pass the `childSessionId` a `sendMessage` peer wake ' +
-      'returned. Returns `{ sessionId, agentId, status, … }` where `status` is "in-progress" (queued or a turn is ' +
-      'running), "done" (its last turn finished cleanly), or "failed" (its last turn ended in an error). This is ' +
-      'scoped to YOUR children: sessions you did not start — including your own and unrelated agents’ — cannot be ' +
-      'read, and asking for one is an error. `done` means the child ended its turn, not that it reported anything ' +
-      'back; wake it with `needsReply` if you want its result delivered to you. Works for a peer on another machine ' +
-      'too, where a transient "not reachable" error means retry, not that the session is gone. Poll sparingly, and ' +
-      'prefer waiting for the child’s reply over a tight polling loop.',
+      'Read execution and reply-delivery state for a child session YOU started. Pass the `childSessionId` returned ' +
+      'by `sendMessage`, then follow the returned `nextAction`. This is diagnostic only; it never returns the reply body.',
     inputSchema: obj(
       {
         sessionId: {

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -864,7 +864,10 @@ export class SessionManager {
         `cannot finish — reply to it with ` +
         `\`sendMessage\` \`{"sessionId":"${effectiveOriginSessionId}","message":"..."}\`, saying whether you ` +
         `succeeded or failed and what the result was (on failure, what went wrong). Send it exactly once, at the ` +
-        `end; do not report progress along the way, and do not skip it because the task was small or unsuccessful.`
+        `end; do not report progress along the way, and do not skip it because the task was small or unsuccessful. ` +
+        `Your ordinary assistant response in this child session is not delivered to the parent. Do not write the ` +
+        `result before or after the tool call; after the tool reports successful delivery, end your turn immediately ` +
+        `without repeating the message.`
       : ''
 
     // Standing response-choice rule for EVERY agent session and delivery scenario. Direct

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -113,8 +113,9 @@ async function bootWithDispatchSpy(root: string) {
   })
   const calls: { agentId: string; msg: any; integrationId?: string; callMeta?: any }[] = []
   ;(daemon as any).dispatch = vi.fn(
-    async (agentId: string, msg: any, integrationId?: string, _wc?: any, callMeta?: any) => {
+    async (agentId: string, msg: any, integrationId?: string, _wc?: any, callMeta?: any, opts?: any) => {
       calls.push({ agentId, msg, integrationId, callMeta })
+      opts?.onAdmission?.({ accepted: true })
       return 'acp-1'
     }
   )
@@ -1607,6 +1608,65 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       nextAction: 'finish-turn-and-wait'
     })
     expect(status.message).toMatch(/next turn.*do not retry/i)
+    await daemon.stop()
+  })
+
+  it('reports a failed reply instead of queued-for-parent when local dispatch rejects admission', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon } = await bootWithDispatchSpy(root)
+    ;(daemon as any).store.upsertSession({
+      key: sessionKey('slack', 'C1', '100.1', 'bot-a'),
+      agentId: 'bot-a',
+      platform: 'slack',
+      channel: 'C1',
+      thread: '100.1',
+      acpSessionId: 'acp-parent-1',
+      state: 'prompting',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    const callerKey = sessionKey('slack', 'C2', '200.1', 'bot-b')
+    ;(daemon as any).store.upsertSession({
+      key: callerKey,
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C2',
+      thread: '200.1',
+      acpSessionId: 'acp-child-1',
+      state: 'prompting',
+      lastDeliveredTs: null,
+      updatedAt: Date.now(),
+      originSessionId: 'acp-parent-1',
+      needsParentReply: 1
+    })
+    armTurn(daemon, callerKey, {
+      callFrom: 'bot-a',
+      hopCount: 1,
+      deliveryId: 'd1',
+      originSessionId: 'acp-parent-1',
+      originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
+    })
+    ;(daemon as any).dispatch = vi.fn(
+      (_agentId: string, _msg: any, _integrationId?: string, _wc?: any, _callMeta?: any, opts?: any) => {
+        opts?.onAdmission?.({ accepted: false, reason: 'queue_full' })
+        return Promise.reject(new Error('queue full'))
+      }
+    )
+
+    const res = await (daemon as any).replyToSession(replyReq())
+    expect(res).toEqual({ delivered: false, targetSession: 'slack:C1:100.1:bot-a', reason: 'queue_full' })
+    const status = await (daemon as any).viewSessionStatus({
+      callerAgentId: 'bot-a',
+      platform: 'slack',
+      callerChannel: 'C1',
+      callerThread: '100.1',
+      sessionId: callerKey
+    })
+    expect(status).toMatchObject({
+      reply: { requested: true, state: 'failed' },
+      nextAction: 'report-failure'
+    })
+    expect(status.message).toMatch(/delivery failed.*do not retry/i)
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -1554,6 +1554,19 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       updatedAt: Date.now()
     })
     const callerKey = sessionKey('slack', 'C2', '200.1', 'bot-b')
+    ;(daemon as any).store.upsertSession({
+      key: callerKey,
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C2',
+      thread: '200.1',
+      acpSessionId: 'acp-child-1',
+      state: 'prompting',
+      lastDeliveredTs: null,
+      updatedAt: Date.now(),
+      originSessionId: 'acp-parent-1',
+      needsParentReply: 1
+    })
     armTurn(daemon, callerKey, {
       callFrom: 'bot-a',
       hopCount: 1,
@@ -1582,6 +1595,18 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
     // keeps its reply connection, so a delegated result can reach the humans waiting in the
     // parent's own thread. Muting it made every report-back silent there.
     expect(msg.headless).toBeUndefined()
+    const status = await (daemon as any).viewSessionStatus({
+      callerAgentId: 'bot-a',
+      platform: 'slack',
+      callerChannel: 'C1',
+      callerThread: '100.1',
+      sessionId: callerKey
+    })
+    expect(status).toMatchObject({
+      reply: { requested: true, state: 'queued-for-parent' },
+      nextAction: 'finish-turn-and-wait'
+    })
+    expect(status.message).toMatch(/next turn.*do not retry/i)
     await daemon.stop()
   })
 
@@ -2298,7 +2323,7 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
     const { daemon, call } = await bootWithDispatchSpy(root)
     seedSession(daemon, PARENT_KEY, { acpSessionId: 'acp-parent-1', state: 'prompting' })
 
-    const res = await call(baseReq())
+    const res = await call(baseReq({ needsReply: true }))
     expect(res.delivered).toBe(true)
     // Polled the instant the wake returns: dispatch is fire-and-forget, so the child's session row
     // does not exist yet — the admission-time link must still authorize the parent.
@@ -2306,7 +2331,11 @@ describe('viewSessionStatus: child-only authorization + status collapse', () => 
       sessionId: res.targetSession,
       agentId: 'bot-b',
       status: 'in-progress',
-      state: 'starting'
+      state: 'starting',
+      reply: { requested: true, state: 'awaiting' },
+      nextAction: 'finish-turn-and-wait',
+      message:
+        'Message delivered; the agent is still working. End this turn and wait for its reply; do not retry or poll tightly.'
     })
     await daemon.stop()
   })
@@ -2505,7 +2534,10 @@ describe('viewSessionStatus: cross-daemon children', () => {
       agentId: 'bot-b',
       status: 'done',
       state: 'idle',
-      updatedAt: 9
+      updatedAt: 9,
+      reply: { requested: false, state: 'not-requested' },
+      nextAction: 'none',
+      message: 'The child turn finished cleanly. No reply was requested.'
     })
     // The CP needs the child AGENT to resolve placement — it must not parse the composite key.
     expect(asks[0]).toEqual({
@@ -2715,7 +2747,15 @@ describe('handleRelayAgentMsg: admission handle + pre-row probe window', () => {
         parentSessionId: 'acp-remote-parent',
         childSessionId: ack.childSessionId
       })
-    ).toEqual({ found: true, agentId: 'bot-b', status: 'in-progress', state: 'starting' })
+    ).toEqual({
+      found: true,
+      agentId: 'bot-b',
+      status: 'in-progress',
+      state: 'starting',
+      reply: { requested: false, state: 'not-requested' },
+      nextAction: 'wait',
+      message: 'Message delivered; the agent is still working. No reply was requested.'
+    })
     // …and only to the parent that actually woke it.
     expect(
       (daemon as any).childSessionStatusProbe({

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -1287,6 +1287,19 @@ describe('executeTool: sendMessage (wake / reply)', () => {
     expect(res.childSessionId).toBe(res.wake!.targetSession)
   })
 
+  it('tells a needsReply caller to finish the current turn and wait instead of retrying', async () => {
+    const { deps: d } = wakeDeps()
+    const res = (await executeTool(
+      ctx,
+      'sendMessage',
+      { toAgent: { agentId: 'peer-1', needsReply: true }, message: 'go' },
+      d
+    )) as Record<string, any>
+    expect(res.reply).toEqual({ requested: true, state: 'awaiting' })
+    expect(res.nextAction).toBe('finish-turn-and-wait')
+    expect(res.message).toMatch(/End this turn.*do not retry/i)
+  })
+
   it('omits childSessionId when the wake was refused — nothing was opened', async () => {
     const { deps: d } = wakeDeps({
       messageAgent: async () => ({ delivered: false, targetSession: 'slack:C:root:peer-1', reason: 'not_allowed' })
@@ -1367,7 +1380,10 @@ describe('executeTool: viewSessionStatus', () => {
     agentId: 'peer-1',
     status: 'in-progress' as const,
     state: 'prompting' as const,
-    updatedAt: 5
+    updatedAt: 5,
+    reply: { requested: true, state: 'awaiting' as const },
+    nextAction: 'finish-turn-and-wait' as const,
+    message: 'Message delivered; end this turn and wait.'
   }
 
   it('passes the trusted caller coords and returns the daemon status verbatim', async () => {

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -735,6 +735,8 @@ describe('SessionManager', () => {
       const metaArg = host.newSession.mock.calls[0][3] as string
       expect(metaArg).toContain('# Reporting back to your parent session')
       expect(metaArg).toContain('{"sessionId":"origin-sess-9","message":"..."}')
+      expect(metaArg).toContain('after the tool reports successful delivery, end your turn immediately')
+      expect(metaArg).toContain('without repeating the message')
       // Persisted, so later turns and resumes keep it.
       expect(store.getSession(sessionKey('slack', 'C1', '100.1', 'bot-a'))?.needsParentReply).toBe(1)
       store.close()
@@ -745,7 +747,9 @@ describe('SessionManager', () => {
       const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
       const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
       await sm.handle('bot-a', msg({ ts: '100.1', text: 'hi' }), undefined, undefined, undefined, undefined, true)
-      expect(host.newSession.mock.calls[0][3] as string).not.toContain('# Reporting back')
+      const metaArg = host.newSession.mock.calls[0][3] as string
+      expect(metaArg).not.toContain('# Reporting back')
+      expect(metaArg).not.toContain('end your turn immediately')
       expect(store.getSession(sessionKey('slack', 'C1', '100.1', 'bot-a'))?.needsParentReply ?? null).toBeNull()
       store.close()
     })

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -1157,18 +1157,30 @@ describe('channel agent directory frames (agent collaboration)', () => {
         agentId: AGENT_ID,
         status: 'in-progress',
         state: 'prompting',
-        updatedAt: 17
+        updatedAt: 17,
+        reply: { requested: true, state: 'queued-for-parent' },
+        nextAction: 'finish-turn-and-wait',
+        message: 'The agent replied. End this turn and wait.'
       })
     )
     expect(ok.ok).toBe(true)
     if (!ok.ok || !isFrame('session/child-status/ok')(ok.frame)) throw new Error('expected session/child-status/ok')
     expect(ok.frame.payload.status).toBe('in-progress')
+    expect(ok.frame.payload.reply?.state).toBe('queued-for-parent')
 
     // A negative verdict carries nothing but `found` (plus a transport reason when applicable).
     expect(decodeEnvelope(envelope('session/child-status/ok', { found: false })).ok).toBe(true)
     expect(decodeEnvelope(envelope('session/child-status/ok', { found: false, reason: 'offline' })).ok).toBe(true)
     // The status vocabulary is closed — a typo must not reach an agent as a valid state.
     expect(decodeEnvelope(envelope('session/child-status/ok', { found: true, status: 'finished' })).ok).toBe(false)
+    expect(
+      decodeEnvelope(
+        envelope('session/child-status/ok', {
+          found: true,
+          reply: { requested: true, state: 'invented' }
+        })
+      ).ok
+    ).toBe(false)
   })
 
   it('channel/agents REQ + channel/agents/ok REP round-trip the roster', () => {

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -204,6 +204,15 @@ export const ChildSessionStatus = z.object({
   state: z.enum(['starting', 'idle', 'prompting', 'cancelling', 'resuming', 'closed']).optional(),
   /** Epoch ms of the child's last state change. */
   updatedAt: z.number().int().optional(),
+  /** Optional during rolling upgrades; current daemons always return it for found children. */
+  reply: z
+    .object({
+      requested: z.boolean(),
+      state: z.enum(['not-requested', 'awaiting', 'queued-for-parent', 'not-sent', 'failed', 'unknown'])
+    })
+    .optional(),
+  nextAction: z.enum(['none', 'wait', 'finish-turn-and-wait', 'report-failure', 'report-missing-reply']).optional(),
+  message: z.string().optional(),
   /** Transport-level failure only: the owning daemon is not currently reachable. */
   reason: z.enum(['offline']).optional()
 })


### PR DESCRIPTION
## Summary

- return reply-delivery state, a machine-readable next action, and state-specific guidance from `viewSessionStatus`
- tell a waiting parent to end its current turn instead of polling or retrying
- inject the one-shot report-back instruction into child sessions only when `needsReply` is requested
- keep cross-daemon status frames rolling-upgrade compatible and document the behavior

## Root cause

A child reply is serialized behind the parent session's active turn. The parent could observe that the child turn was done without knowing that the reply was already queued for its next turn, so it could retry the request. Child agents also lacked sufficiently explicit guidance to end immediately after a successful parent-session reply, which could produce duplicated ordinary output.

## Impact

Parents can distinguish execution progress from reply delivery and wait for the queued reply without retrying. Child prompts only pay the extra report-back context cost when a reply was requested.

## Validation

- daemon targeted tests: 322 passed
- protocol tests: 281 passed
- daemon, protocol, and control-plane typechecks
- ESLint on all changed TypeScript files
- `git diff --check`
