### PR TITLE
feat(cp): name outbound client spans and trace Prisma queries

### DIFF
--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -91,6 +91,7 @@
     "@opentelemetry/semantic-conventions": "^1.43.0",
     "@prisma/adapter-pg": "^7.9.0",
     "@prisma/client": "^7.9.0",
+    "@prisma/instrumentation": "^7.9.0",
     "@resvg/resvg-js": "^2.6.2",
     "@slack/web-api": "^8.0.0",
     "aws4fetch": "^1.0.20",
@@ -109,6 +110,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@opentelemetry/sdk-trace": "^2.10.0",
     "@testcontainers/postgresql": "^12.0.4",
     "@types/node": "^24.13.3",
     "@types/ws": "^8.18.1",

--- a/packages/control-plane/src/observability.test.ts
+++ b/packages/control-plane/src/observability.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shouldIgnoreUndiciRequest } from './observability.js'
+import { shouldIgnoreUndiciRequest, undiciClientSpanName } from './observability.js'
 
 describe('shouldIgnoreUndiciRequest', () => {
   it.each(['/bottelegram-secret/getMe', '/bottelegram-secret/setMyProfilePhoto'])(
@@ -14,5 +14,62 @@ describe('shouldIgnoreUndiciRequest', () => {
       false
     )
     expect(shouldIgnoreUndiciRequest({ origin: 'https://api.telegram.org', path: '/file/example' })).toBe(false)
+  })
+})
+
+describe('undiciClientSpanName', () => {
+  const name = (path: string, origin = 'https://api.example.test', method = 'GET') =>
+    undiciClientSpanName({ origin, path, method })
+
+  it('names the destination so a waterfall is readable', () => {
+    expect(name('/repositories/12345')).toBe('GET api.example.test/repositories/{id}')
+    expect(name('/repos/example-org/example-repo/pulls/7', 'https://api.example.test', 'POST')).toBe(
+      'POST api.example.test/repos/example-org/example-repo/pulls/{id}'
+    )
+    expect(name('/api/chat.postMessage', 'https://slack.example.test', 'POST')).toBe(
+      'POST slack.example.test/api/chat.postMessage'
+    )
+  })
+
+  it('redacts a token carried in the path', () => {
+    // The same shape `shouldIgnoreUndiciRequest` drops outright; the naming
+    // function must not leak it either if that hook is ever bypassed.
+    expect(
+      name('/bot7123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw/sendMessage', 'https://api.telegram.org', 'POST')
+    ).toBe('POST api.telegram.org/{id}/sendMessage')
+    // A token without punctuation to break on is still opaque: long, mixed case,
+    // letters and digits together.
+    expect(name('/v1/keys/sk0aBcDeFgHiJkLmNoPqRsTuV')).toBe('GET api.example.test/v1/keys/{id}')
+  })
+
+  it('never carries the query string into the name', () => {
+    expect(name('/oauth/token?client_secret=super-secret&code=abc')).toBe('GET api.example.test/oauth/token')
+    expect(name('/users#fragment')).toBe('GET api.example.test/users')
+  })
+
+  it('collapses high-entropy segments of every shape', () => {
+    // numeric id, uuid, sha digest, unhyphenated hex, digits inside a word
+    expect(name('/v1/items/908172')).toBe('GET api.example.test/v1/items/{id}')
+    expect(name('/v1/items/f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe('GET api.example.test/v1/items/{id}')
+    expect(name('/blobs/da39a3ee5e6b4b0d3255bfef95601890afd80709')).toBe('GET api.example.test/blobs/{id}')
+    expect(name('/blobs/deadbeefdeadbeefdeadbeefdeadbeef')).toBe('GET api.example.test/blobs/{id}')
+    expect(name('/im/v1/messages/om4d9a2f7b13c05e8460711')).toBe('GET api.example.test/im/v1/messages/{id}')
+  })
+
+  it('keeps short, hand-written route words intact', () => {
+    expect(name('/open-apis/im/v1/messages')).toBe('GET api.example.test/open-apis/im/v1/messages')
+    expect(name('/oidc/.well-known/openid-configuration')).toBe(
+      'GET api.example.test/oidc/.well-known/openid-configuration'
+    )
+    expect(name('/')).toBe('GET api.example.test/')
+  })
+
+  it('keeps a non-default port and an unusual method bounded', () => {
+    expect(name('/readyz', 'http://daemon.example.test:8443')).toBe('GET daemon.example.test:8443/readyz')
+    expect(name('/things', 'https://api.example.test', 'not-a-method')).toBe('HTTP api.example.test/things')
+  })
+
+  it('leaves the default name in place when the URL cannot be parsed', () => {
+    expect(undiciClientSpanName({ origin: 'not a url', path: '/things', method: 'GET' })).toBeUndefined()
   })
 })

--- a/packages/control-plane/src/observability.ts
+++ b/packages/control-plane/src/observability.ts
@@ -10,6 +10,7 @@ import {
   ATTR_SERVICE_NAMESPACE,
   ATTR_SERVICE_VERSION
 } from '@opentelemetry/semantic-conventions'
+import { PrismaInstrumentation } from '@prisma/instrumentation'
 
 export interface OpenTelemetryHandle {
   enabled: boolean
@@ -31,6 +32,78 @@ export function shouldIgnoreUndiciRequest(request: Pick<UndiciRequest, 'origin' 
   } catch {
     return false
   }
+}
+
+/** Anything that does not read like a hand-written route word collapses to this. */
+const PATH_SEGMENT_PLACEHOLDER = '{id}'
+
+/** A route word starts with a letter — or a dot, for `.well-known` — and uses
+ * only plain URL punctuation. */
+const ROUTE_WORD = /^[A-Za-z.][A-Za-z0-9._-]*$/
+/** Hex digests: SHA/MD5 sums and unhyphenated UUIDs, which carry no digit run. */
+const HEX_DIGEST = /^[0-9a-fA-F]{16,}$/
+/** Bot ids, snowflakes, and other numeric keys embedded in a longer segment. */
+const LONG_DIGIT_RUN = /\d{4,}/
+const MAX_ROUTE_WORD_LENGTH = 32
+/** Above this length, letters mixed with digits mean an opaque key, not a word. */
+const OPAQUE_SEGMENT_LENGTH = 16
+
+function normalizeSpanNameSegment(segment: string): string {
+  if (!ROUTE_WORD.test(segment)) return PATH_SEGMENT_PLACEHOLDER
+  if (segment.length > MAX_ROUTE_WORD_LENGTH) return PATH_SEGMENT_PLACEHOLDER
+  if (HEX_DIGEST.test(segment)) return PATH_SEGMENT_PLACEHOLDER
+  if (LONG_DIGIT_RUN.test(segment)) return PATH_SEGMENT_PLACEHOLDER
+  if (segment.length >= OPAQUE_SEGMENT_LENGTH && /\d/.test(segment)) return PATH_SEGMENT_PLACEHOLDER
+  return segment
+}
+
+/** Undici names every client span after the bare HTTP method, so a request that
+ * fans out to GitHub, Slack, Feishu, and Logto renders as four identical `GET`
+ * bars. Add the destination — `GET api.example.test/repositories/{id}` — so a
+ * waterfall is readable without expanding each span's attributes.
+ *
+ * Span names are exported and retained, so the name is rebuilt from vetted
+ * pieces rather than interpolated raw:
+ *
+ * - the query string is never included (providers pass tokens there);
+ * - every path segment that is not a plain route word — numeric ids, UUIDs, hex
+ *   digests, bearer-ish blobs — collapses to `{id}`, which keeps credentials out
+ *   of the name (`shouldIgnoreUndiciRequest` already drops the known Telegram
+ *   case; this is the second line of defence) and bounds name cardinality.
+ */
+export function undiciClientSpanName(request: Pick<UndiciRequest, 'origin' | 'path' | 'method'>): string | undefined {
+  let url: URL
+  try {
+    url = new URL(request.path, request.origin)
+  } catch {
+    return undefined
+  }
+  const route = url.pathname
+    .split('/')
+    .map((segment) => (segment === '' ? segment : normalizeSpanNameSegment(segment)))
+    .join('/')
+  // `HTTP` matches what the instrumentation itself falls back to for a method
+  // outside the semantic-convention set.
+  const method = request.method?.toUpperCase() ?? ''
+  return `${/^[A-Z]{3,10}$/.test(method) ? method : 'HTTP'} ${url.host}${route}`
+}
+
+/** Prisma emits `operation`, `serialize`, and `db_query` per call, plus `compile`
+ * the first time it sees a query shape. `serialize` only measures turning JS
+ * arguments into the query AST — always sub-millisecond, never the reason a
+ * request is slow — so it is dropped and steady state settles at two spans per
+ * query. The rest stay: `db_query` carries the SQL this instrumentation exists to
+ * expose, `compile` isolates query-compiler time (a v7 queryCompiler cost that is
+ * otherwise invisible, and cached, so it does not scale with traffic), and
+ * `operation` names the call site that issued them. */
+const PRISMA_IGNORED_SPAN_TYPES = ['prisma:client:serialize']
+
+/** Prisma tracing is a `globalThis` contract, not a module patch: enabling this
+ * installs a tracing helper that the `@prisma/client` runtime looks up by major
+ * version. Exported so the integration test asserts the shipped configuration
+ * rather than a copy of it. */
+export function buildPrismaInstrumentation(): PrismaInstrumentation {
+  return new PrismaInstrumentation({ ignoreSpanTypes: PRISMA_IGNORED_SPAN_TYPES })
 }
 
 const fastifyInstrumentation = new FastifyOtelInstrumentation({
@@ -58,7 +131,14 @@ export function startControlPlaneOpenTelemetry(env: NodeJS.ProcessEnv = process.
     logRecordProcessors: [],
     instrumentations: [
       new HttpInstrumentation(),
-      new UndiciInstrumentation({ ignoreRequestHook: shouldIgnoreUndiciRequest }),
+      new UndiciInstrumentation({
+        ignoreRequestHook: shouldIgnoreUndiciRequest,
+        requestHook: (span, request) => {
+          const name = undiciClientSpanName(request)
+          if (name) span.updateName(name)
+        }
+      }),
+      buildPrismaInstrumentation(),
       fastifyInstrumentation
     ]
   })

--- a/packages/control-plane/test/integration/prisma-tracing.test.ts
+++ b/packages/control-plane/test/integration/prisma-tracing.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Prisma tracing is a `globalThis` handshake, not a module patch:
+ * `@prisma/instrumentation` parks a tracing helper under
+ * `V<major>_PRISMA_INSTRUMENTATION` and the `@prisma/client` runtime picks it up
+ * only when the majors line up. Nothing in the type system checks that, and this
+ * deployment runs the v7 queryCompiler with a driver adapter rather than the old
+ * Rust engine — so a Prisma upgrade can silently turn the database half of every
+ * trace back into the empty space it used to be, with no build or test failure.
+ *
+ * This file is the tripwire: it runs real queries through the pool's client and
+ * asserts the spans actually come out, with the SQL attached and the parameters
+ * left off.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { InMemorySpanExporter, SimpleSpanProcessor, TracerProvider } from '@opentelemetry/sdk-trace'
+import type { ReadableSpan } from '@opentelemetry/sdk-trace'
+import { prisma } from '../setup.db.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { seedAgent, seedDaemon, seedSessionMeta } from '../fixtures/seed.js'
+import { buildPrismaInstrumentation } from '../../src/observability.js'
+
+const AGENT = 'a3333333-3333-4333-8333-333333333333'
+const DAEMON = 'd3333333-3333-4333-8333-333333333333'
+const SESSION = 'sess-prisma-tracing'
+
+const exporter = new InMemorySpanExporter()
+const provider = new TracerProvider({ spanProcessors: [new SimpleSpanProcessor({ exporter })] })
+const instrumentation = buildPrismaInstrumentation()
+
+beforeAll(() => {
+  instrumentation.setTracerProvider(provider)
+  instrumentation.enable()
+})
+
+afterAll(async () => {
+  // The helper lives on globalThis, so leaving it installed would keep tracing
+  // every other test file that shares this worker.
+  instrumentation.disable()
+  await provider.shutdown()
+})
+
+beforeEach(() => {
+  exporter.reset()
+})
+
+const names = (): string[] => exporter.getFinishedSpans().map((span) => span.name)
+const attr = (span: ReadableSpan, key: string): unknown => span.attributes[key]
+
+describe('prisma opentelemetry instrumentation', () => {
+  it('turns a read into spans that name the operation and carry its SQL', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    await seedSessionMeta(prisma, SESSION, AGENT)
+    exporter.reset()
+
+    await prisma.sessionMeta.findMany({ where: { orgId: DEFAULT_ORG_ID }, take: 5 })
+
+    expect(names()).toContain('prisma:client:operation')
+    expect(names()).toContain('prisma:client:db_query')
+
+    const operation = exporter.getFinishedSpans().find((span) => span.name === 'prisma:client:operation')
+    expect(attr(operation!, 'name')).toBe('SessionMeta.findMany')
+
+    const query = exporter.getFinishedSpans().find((span) => span.name === 'prisma:client:db_query')
+    expect(attr(query!, 'db.system.name')).toBe('postgresql')
+    expect(String(attr(query!, 'db.query.text'))).toMatch(/select/i)
+  })
+
+  it('records the SQL template without the parameter values', async () => {
+    // The whole point of naming SQL in a span is that it is the *shape* of the
+    // query. Prisma passes bound values to the query event, not the span; if
+    // that ever changes, every literal a caller filters on starts landing in the
+    // trace store.
+    const secret = 'do-not-export-this-literal'
+    await prisma.sessionMeta.findMany({ where: { orgId: DEFAULT_ORG_ID, channel: secret } })
+
+    const exported = JSON.stringify(exporter.getFinishedSpans().map((span) => span.attributes))
+    expect(exported).not.toContain(secret)
+    expect(exported).toMatch(/select/i)
+  })
+
+  it('drops the serialize span the deployment configuration ignores', async () => {
+    await prisma.sessionMeta.findMany({ where: { orgId: DEFAULT_ORG_ID } })
+
+    // Anchored on a populated span set: asserting the absence alone would pass
+    // just as well when the instrumentation emits nothing at all.
+    expect(names()).toContain('prisma:client:db_query')
+    expect(names()).not.toContain('prisma:client:serialize')
+  })
+
+  it('amortizes the compile span and settles at two spans per query', async () => {
+    // A query shape used nowhere else in this file, so this call compiles it.
+    const shape = { where: { phase: 'start' }, orderBy: { id: 'asc' } } as const
+    await prisma.sessionMeta.findMany(shape)
+    expect(names()).toContain('prisma:client:compile')
+
+    exporter.reset()
+    await prisma.sessionMeta.findMany(shape)
+
+    // Prisma caches the compiled plan per shape, so `compile` does not scale
+    // with traffic. Steady state is one `operation` plus one `db_query` per
+    // call — the volume claim this change is merged on, pinned here so a future
+    // Prisma release that adds a per-query span has to be an explicit decision
+    // rather than a silent multiplier on the collector.
+    expect(names().sort()).toEqual(['prisma:client:db_query', 'prisma:client:operation'])
+  })
+
+  it('spans a transaction so multi-statement work is attributable', async () => {
+    await prisma.$transaction(async (tx) => {
+      await tx.sessionMeta.findMany({ where: { orgId: DEFAULT_ORG_ID } })
+    })
+
+    expect(names()).toContain('prisma:client:transaction')
+    expect(names()).toContain('prisma:client:start_transaction')
+    expect(names()).toContain('prisma:client:commit_transaction')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@prisma/client':
         specifier: ^7.9.0
         version: 7.9.0
+      '@prisma/instrumentation':
+        specifier: ^7.9.0
+        version: 7.9.1(@opentelemetry/api@1.9.1)
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
@@ -230,6 +233,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@opentelemetry/sdk-trace':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
       '@testcontainers/postgresql':
         specifier: ^12.0.4
         version: 12.0.4
@@ -2196,6 +2202,10 @@ packages:
   '@opencode-ai/sdk@1.18.5':
     resolution: {integrity: sha512-7KgMvP5/1oxbhHj6kYBtPSTEdFKYpUeEYOzBTKdzSaRpapUpFFdn6Hkus3rr0rljO0kukWZIgRd3DrVBwTULGA==}
 
+  '@opentelemetry/api-logs@0.207.0':
+    resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.219.0':
     resolution: {integrity: sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==}
     engines: {node: '>=8.0.0'}
@@ -2336,6 +2346,12 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation@0.207.0':
+    resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/instrumentation@0.219.0':
     resolution: {integrity: sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==}
@@ -2547,6 +2563,11 @@ packages:
 
   '@prisma/get-platform@7.9.0':
     resolution: {integrity: sha512-4awv6ATdgrHdLms0XKikCyfArn8BrUHZfqg0mtCKrI4+WJe24nmpsdwsypM9ozd03wa846AngY+zSbnngkMrXQ==}
+
+  '@prisma/instrumentation@7.9.1':
+    resolution: {integrity: sha512-ld/HSXi0FzpgmS06Bxey1SsqmGr0+lZQi1PbcatxQD7BCxpbtcWqDRuEavchT8RE5QUjy+UeINOMyk+WY6/a2g==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.8
 
   '@prisma/query-plan-executor@7.2.0':
     resolution: {integrity: sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==}
@@ -3881,6 +3902,11 @@ packages:
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -5746,6 +5772,9 @@ packages:
   import-from-esm@2.0.0:
     resolution: {integrity: sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==}
     engines: {node: '>=18.20'}
+
+  import-in-the-middle@2.0.6:
+    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
 
   import-in-the-middle@3.3.2:
     resolution: {integrity: sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==}
@@ -10564,6 +10593,10 @@ snapshots:
       cross-spawn: 7.0.6
     optional: true
 
+  '@opentelemetry/api-logs@0.207.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api-logs@0.219.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -10728,6 +10761,15 @@ snapshots:
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.207.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11024,6 +11066,13 @@ snapshots:
   '@prisma/get-platform@7.9.0':
     dependencies:
       '@prisma/debug': 7.9.0
+
+  '@prisma/instrumentation@7.9.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@prisma/query-plan-executor@7.2.0': {}
 
@@ -12311,6 +12360,10 @@ snapshots:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
+
+  acorn-import-attributes@1.9.5(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -14272,6 +14325,13 @@ snapshots:
       import-meta-resolve: 4.2.0
     transitivePeerDependencies:
       - supports-color
+
+  import-in-the-middle@2.0.6:
+    dependencies:
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
 
   import-in-the-middle@3.3.2:
     dependencies:


### PR DESCRIPTION
The console's session read path (`GET /sessions`, `/sessions/facets`, `/usage`) is
slow, and the traces we already ship to the collector can't say why. Two gaps, one
in each half of a request's waterfall.

## Fix 1 — outbound client spans are named after their destination

`@opentelemetry/instrumentation-undici` names every client span after the bare HTTP
method, so a request that fans out to four providers renders as four identical `GET`
bars and you have to expand each one's attributes to tell them apart. A `requestHook`
now renames them to `GET api.example.test/repositories/{id}`.

Span names are exported and retained, so the name is rebuilt from vetted pieces
rather than interpolated from the raw URL:

- the query string is never included — providers pass tokens there;
- every path segment that is not a plain route word collapses to `{id}`: numeric
  ids, UUIDs, hex digests, long digit runs, and long mixed alphanumeric blobs.

That second rule does two jobs. It keeps credentials out of a name that outlives the
request — `shouldIgnoreUndiciRequest` already drops the known Telegram
token-in-the-path case, and this is the second line of defence if that hook is ever
bypassed — and it bounds span-name cardinality, which a raw id per request would
otherwise blow up. The existing ignore hook is unchanged.

## Fix 2 — database queries become spans

SQL time previously showed up as empty space under the `handler` bar. Profiling
found the session-list visibility predicate is the dominant cost (a page query
measured ~6 ms without the predicate versus seconds with it), and the traces gave no
hint of it — it had to be found by hand-running SQL against the database. `db_query`
spans make the follow-up predicate work measurable instead of guesswork.

**Prisma 7 compatibility.** `@prisma/instrumentation@7.9.x` pairs with
`@prisma/client@7.9.0`. It is not a module patch: it parks a tracing helper on
`globalThis` under a key derived from its own major version, and the client runtime
picks it up when the majors match. That matters here because this deployment runs
the v7 queryCompiler with a driver adapter rather than the old Rust query engine, so
"the package installs cleanly" proves nothing about whether spans actually appear.
No schema change or preview feature is needed — tracing is not gated in v7.

Since nothing type-checks that handshake, a Prisma upgrade could silently return the
database half of every trace to empty space with no build or test failure. The new
integration test is the tripwire: it runs real queries through the pool's client and
asserts the spans come out, with the SQL attached and the parameters left off.

## Span volume

Considered before merging, and worth stating explicitly since it is a real increase.

Measured per Prisma call: `operation` + `db_query`, plus `compile` the first time a
query shape is seen and `serialize` on every call. Two decisions follow.

- **`serialize` is dropped** via `ignoreSpanTypes`. It measures turning JS arguments
  into the query AST — sub-millisecond, never the reason a request is slow.
- **`compile` is kept.** It is cached per query shape, so it does not scale with
  traffic, and it isolates query-compiler time, which is a v7 cost that is otherwise
  invisible.

Steady state is therefore **two spans per query** (plus one extra `db_query` per
additional SQL statement, and transaction spans where a transaction is used). A test
pins that count so a future Prisma release that adds a per-query span has to be an
explicit decision rather than a silent multiplier on the collector.

**No code-level sampler was added, deliberately.** The SDK already builds its sampler
from `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` and defaults to
`parentbased_always_on`. Prisma spans are children of the Fastify server span, so
they inherit the trace's sampling decision: setting
`OTEL_TRACES_SAMPLER=parentbased_traceidratio` scales database span volume
proportionally with everything else, at deploy time, without a code change. Hard-coding
a sampler here would only take that lever away. If the collector does come under
pressure, the cheaper first knob is `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` — `db_query`
carries the full SQL text in `db.query.text`, and the session-list predicate is a
large statement.

On the privacy side, `db.query.text` is the parameterized statement only. Prisma
passes bound values to the query *event*, not to the span, so caller-supplied
literals do not reach the trace store. A test asserts that too, since it is the kind
of thing an upstream change could quietly reverse.

## Verification

- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane test:unit`
- `pnpm --filter @agentconnect.md/control-plane test:int`
- `pnpm exec eslint packages/control-plane/src packages/control-plane/test`
- `pnpm exec prettier --check`

The payoff is visible on the session read-path dashboard: a request that shows zero
external calls but takes seconds now shows its database spans directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
