### PR TITLE
perf(cp): collapse the session visibility predicate to a fixed three arms

### DIFF
--- a/packages/control-plane/src/persistence/repositories/session-access-sql.test.ts
+++ b/packages/control-plane/src/persistence/repositories/session-access-sql.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionFilterQuery } from '../ports.js'
+import { sessionViewerSql } from './session-access-sql.js'
+
+type Viewer = NonNullable<SessionFilterQuery['viewer']>
+
+function viewer(scopeCount: number, providers: string[] = ['github']): Viewer {
+  return {
+    role: 'collaborator',
+    identitySet: ['user:u1'],
+    externalAccess: {
+      policies: providers.map((provider) => ({ provider, readFenceRev: null })),
+      allowedScopes: Array.from({ length: scopeCount }, (_, i) => ({
+        id: `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`,
+        aclRevision: BigInt(i + 1)
+      })),
+      decisionAt: new Date(0)
+    }
+  }
+}
+
+/** Correlated subqueries are what this predicate pays per row — and the
+ *  conversation page pays them again per probed row. */
+function existsCount(sql: string): number {
+  return sql.match(/EXISTS\s*\(/g)?.length ?? 0
+}
+
+describe('sessionViewerSql', () => {
+  it('is absent for an internal unfiltered read', () => {
+    expect(sessionViewerSql(undefined)).toBeNull()
+  })
+
+  it('asks nothing of the provider tables without an external-access snapshot', () => {
+    const arm = sessionViewerSql({ role: 'collaborator', identitySet: ['user:u1'] })
+    expect(arm).not.toBeNull()
+    expect(arm!.sql).not.toContain('session_external_access_policy')
+    expect(arm!.sql).not.toContain('external_scope')
+    expect(existsCount(arm!.sql)).toBe(0)
+  })
+
+  /**
+   * The regression this file exists for. Written as one OR arm per granted
+   * scope, an ordinary org reached nineteen arms carrying ~28 correlated
+   * subqueries, and the session page query measured in seconds rather than
+   * milliseconds. The predicate's cost must not scale with how much the
+   * viewer is allowed to see.
+   */
+  it('does not grow a subquery per granted scope', () => {
+    const one = sessionViewerSql(viewer(1))!.sql
+    const many = sessionViewerSql(viewer(50))!.sql
+
+    expect(existsCount(many)).toBe(existsCount(one))
+    // policy-with-fence, policy-presence, and the scope lookup — nothing per scope
+    expect(existsCount(many)).toBe(3)
+  })
+
+  it('does not grow a subquery per provider policy', () => {
+    const one = sessionViewerSql(viewer(2, ['github']))!.sql
+    const three = sessionViewerSql(viewer(2, ['github', 'slack', 'feishu']))!.sql
+
+    expect(existsCount(three)).toBe(existsCount(one))
+  })
+
+  it('still binds each granted scope to the revision it was granted at', () => {
+    const arm = sessionViewerSql(viewer(2))!
+    // the pair check is what keeps a scope from riding another scope's revision
+    expect(arm.sql).toContain('"aclRevision"')
+    expect(arm.sql).toContain('revokedAt')
+    expect(arm.values).toContain(1n)
+    expect(arm.values).toContain(2n)
+  })
+
+  it('keeps reading the live policy and scope tables, not the caller snapshot', () => {
+    const arm = sessionViewerSql(viewer(3))!
+    expect(arm.sql).toContain('session_external_access_policy')
+    expect(arm.sql).toContain('external_scope')
+  })
+
+  it('carries identities and scope ids as parameters', () => {
+    const arm = sessionViewerSql(viewer(2))!
+    expect(arm.values).toContainEqual(['user:u1'])
+    expect(arm.values).toContainEqual(['00000000-0000-4000-8000-000000000000', '00000000-0000-4000-8000-000000000001'])
+  })
+})

--- a/packages/control-plane/src/persistence/repositories/session-access-sql.ts
+++ b/packages/control-plane/src/persistence/repositories/session-access-sql.ts
@@ -1,9 +1,31 @@
 import { Prisma } from '../../generated/prisma/client.js'
 import type { SessionFilterQuery } from '../ports.js'
 
-/** SQL mirror of authorization/policy.ts#canViewSession. The caller's query
+/**
+ * SQL mirror of authorization/policy.ts#canViewSession. The caller's query
  * must expose SessionMeta under `alias` (default `s`). Undefined is reserved
- * for internal unfiltered reads; every human role uses the same predicate. */
+ * for internal unfiltered reads; every human role uses the same predicate.
+ *
+ * Shape matters here, not just meaning. This predicate is evaluated per
+ * candidate row, and the conversation page re-applies it to the inner probe
+ * row of its emit-at-max subquery — so anything written per-scope is paid
+ * twice over, once per row and again per probed row. Written as one arm per
+ * policy and one arm per allowed scope it reached nineteen OR arms carrying
+ * ~28 correlated subqueries for an ordinary org, and the same page query
+ * measured in seconds instead of single-digit milliseconds.
+ *
+ * So the arms are collapsed to a fixed three. The per-provider and per-scope
+ * arms were identical apart from the value they matched, and their `EXISTS`
+ * clauses referenced only the row (`orgId`, `externalProvider`,
+ * `classifiedPolicyRev`) — never the arm — so a set membership plus one
+ * shared `EXISTS` says exactly what the union of the arms said.
+ *
+ * The `EXISTS` checks deliberately read the live policy and scope tables
+ * rather than trusting the caller's snapshot: that is the fence which stops a
+ * concurrent enable (or an ACL bump) from being authorized against a stale
+ * decision. Collapsing the arms keeps that read — it just performs it once
+ * instead of once per scope.
+ */
 export function sessionViewerSql(
   viewer: SessionFilterQuery['viewer'],
   alias: Prisma.Sql = Prisma.raw('s')
@@ -23,10 +45,16 @@ export function sessionViewerSql(
   )`
   const snapshot = viewer.externalAccess
   if (!snapshot) return direct
+
   const externalArms: Prisma.Sql[] = []
-  for (const policy of snapshot.policies) {
+
+  // Provider-wide arm. Every per-policy arm asked the same question of the
+  // same row and differed only in which provider it matched, so the union is
+  // "the row's provider is one we hold a policy for", plus the read fence.
+  if (snapshot.policies.length > 0) {
+    const providers = snapshot.policies.map((policy) => policy.provider)
     externalArms.push(Prisma.sql`(
-      ${s}."externalProvider" = ${policy.provider}
+      ${s}."externalProvider" = ANY(${providers}::text[])
       AND ${s}."visibility" = 'org'::"SessionVisibility"
       AND EXISTS (
         SELECT 1 FROM "session_external_access_policy" policy
@@ -42,11 +70,22 @@ export function sessionViewerSql(
       )
     )`)
   }
-  for (const allowed of snapshot.allowedScopes) {
+
+  // Scope arm. `externalScopeId = ANY(...)` is the cheap sargable half; the
+  // revision fence rides inside the scope lookup as a (scope, revision) pair,
+  // which is what kept each arm honest when they were written out one by one.
+  // `external_scope.id` is the primary key, so at most one row can match the
+  // session's scope id and the pair check binds that row's revision to the
+  // one this viewer was actually granted.
+  if (snapshot.allowedScopes.length > 0) {
+    const scopeIds = snapshot.allowedScopes.map((allowed) => allowed.id)
+    const grantedPairs = snapshot.allowedScopes.map(
+      (allowed) => Prisma.sql`(${allowed.id}::uuid, ${allowed.aclRevision}::bigint)`
+    )
     externalArms.push(Prisma.sql`(
       ${s}."visibility" = 'external'::"SessionVisibility"
       AND ${s}."externalResolution" = 'settled'::"ExternalResolution"
-      AND ${s}."externalScopeId" = ${allowed.id}::uuid
+      AND ${s}."externalScopeId" = ANY(${scopeIds}::uuid[])
       AND EXISTS (
         SELECT 1 FROM "session_external_access_policy" policy
         WHERE policy."orgId" = ${s}."orgId"
@@ -57,10 +96,11 @@ export function sessionViewerSql(
         WHERE scope."id" = ${s}."externalScopeId"
           AND scope."orgId" = ${s}."orgId"
           AND scope."provider" = ${s}."externalProvider"
-          AND scope."aclRevision" = ${allowed.aclRevision}
           AND scope."revokedAt" IS NULL
+          AND (scope."id", scope."aclRevision") IN (${Prisma.join(grantedPairs)})
       )
     )`)
   }
+
   return externalArms.length > 0 ? Prisma.sql`(${direct} OR ${Prisma.join(externalArms, ' OR ')})` : direct
 }


### PR DESCRIPTION
## What

The session-visibility SQL predicate was built as **one OR arm per provider policy and one per granted scope**, each carrying its own `EXISTS`. For an ordinary org that is nineteen arms and ~28 correlated subqueries, evaluated per candidate row — and `listConversationPage` re-applies the whole predicate to the inner probe row of its emit-at-max subquery, so every arm is paid again per probed row.

This collapses it to a fixed three arms.

## Why it is equivalent

The per-provider and per-scope arms were identical apart from the value they matched, and their `EXISTS` clauses referenced only the row (`orgId`, `externalProvider`, `classifiedPolicyRev`) — never the arm. So a set membership plus one shared `EXISTS` says exactly what the union of the arms said.

The revision fence rides inside the scope lookup as a `(scope, revision)` pair instead of one arm per pair. `external_scope.id` is the primary key, so at most one row can match the session's scope id, and the pair check binds that row's revision to the one this viewer was actually granted.

**Both `EXISTS` checks still read the live policy and scope tables** rather than trusting the caller's snapshot — that fence is what stops a concurrent enable, or an ACL bump, from being authorized against a stale decision. It is now performed once instead of once per scope.

## Measurements

Against a database with ~2,600 sessions and 14 granted scopes, old and new predicates were run side by side over the whole table and select an **identical row set** — same count (2,258) and same `md5` fingerprint of the ordered ids.

| query | before | after |
|---|---|---|
| session page (emit-at-max) | 13,316 ms | **132 ms** |
| grouped `COUNT` (`includeTotal`) | 846 ms | **8 ms** |
| session facet (channels) | 393 ms | **6 ms** |

The emit-at-max subquery itself needed **no change**: it was expensive only because the predicate it re-applies was. A window-function rewrite was considered and is not needed, which avoids touching pagination semantics.

## Tests

New `session-access-sql.test.ts` guards the invariant that motivated this — the predicate's cost must not scale with how much the viewer is allowed to see. Verified the guards actually bite: run against the previous implementation they fail with `expected 101 to be 3`.

- `test:unit` — 1309 passed
- `test:int` — session-visibility / session-conversations / usage: 53 passed. Full run: 1045 passed, 1 unrelated timeout in `agent-repos.route.test.ts` under machine load (that file passes 27/27 in isolation).
- typecheck, eslint, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
