### PR TITLE
refactor(control-plane): retire the duplicated bot demux fence and a dead migration cursor

### DIFF
--- a/docs/designs/ingress-tenant-fence.md
+++ b/docs/designs/ingress-tenant-fence.md
@@ -83,8 +83,8 @@ never serve the wrong tenant; it can only miss and fall back to the scan.
 ### 3.1 Why not simply write `teamId` for every bot
 
 `teamId` being non-null is load-bearing beyond demux: it marks a distributed
-platform-app install, participates in the `(slackAppId, teamId)` composite
-unique, and drives admission/reauthorization decisions in the platform-app
+platform-app install, is projected into the `externalTenantId` half of the
+composite unique, and drives admission/reauthorization decisions in the platform-app
 funnel and the `DemuxIndex.indexAssign` composite-only rule. Populating it for
 quick-install bots would silently change bot identity, uniqueness, and
 admission semantics to buy a fence. The fence is a distinct concern and gets a
@@ -138,7 +138,7 @@ passes for both, and attribution falls back to pool order. No delivery-time
 check can break that tie; only refusing the second claim can.
 
 That refusal already exists for the distributed platform app: its OAuth
-callback resolves the `(slackAppId, teamId)` claim globally and answers a
+callback resolves the `(externalAppId, externalTenantId)` claim globally and answers a
 cross-organization hit with `workspace_taken`, deliberately not naming the
 holding organization. This change generalizes the same rule to every create
 path.

--- a/docs/designs/integration-plugin-architecture.md
+++ b/docs/designs/integration-plugin-architecture.md
@@ -154,8 +154,9 @@ teamId` is a load-bearing composite-unique demux key (admission and
   unique index). It generalizes to `externalAppId` / `externalTenantId`
   columns (unique together with platform, preserving today's NULL-distinct
   semantics) — **not** to JSON, which cannot carry a declarative unique
-  constraint. Display-only ids (`discordAppId`, `feishuAppId`,
-  `feishuRegion`) move to a per-platform JSON bag.
+  constraint. Public per-platform metadata (`discordAppId`, `feishuAppId`,
+  `feishuRegion`) lives in a per-platform JSON bag instead, so the fifth
+  platform costs a registry line rather than a migration.
 - **D7 — First-party now, third-party deferred** with four named
   keep-the-door-open items (§13).
 

--- a/docs/designs/preset-agents.md
+++ b/docs/designs/preset-agents.md
@@ -270,8 +270,9 @@ installed via standard OAuth v2. Verified gaps against current code:
 - **Callback branch.** Exchange with the platform credentials and **persist `team.id`
   and `bot_user_id`** — today `SlackOAuthResult` deliberately drops `team.id`
   (`http/slack-config-api.ts`).
-- **Schema.** `Bot.teamId` (nullable for legacy rows) + unique `(slackAppId, teamId)`;
-  multiple `Bot` rows may now share one `slackAppId` across orgs.
+- **Schema.** `Bot.teamId` (nullable when no workspace was captured), projected
+  into the `(platform, externalAppId, externalTenantId)` unique; multiple `Bot`
+  rows may now share one `slackAppId` across orgs.
 - **Relay demux.** Today demux is a learned `api_app_id → botId` map with a
   signing-secret brute scan as fallback (`relay/src/relay-ingress-manager.ts`). Every
   install of a distributed app shares both the app id **and** the signing secret, so a

--- a/packages/control-plane/prisma/migrations/20260807000000_fold_bot_platform_metadata/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260807000000_fold_bot_platform_metadata/migration.sql
@@ -1,0 +1,56 @@
+-- Retire the duplicated bot demux fence, fold per-platform bot metadata into the
+-- generic bag, and drop a dead cursor.
+--
+-- Order matters: every backfill runs BEFORE the constraint or column it makes
+-- redundant is removed, so no row loses a fence or a value part-way through.
+
+-- ---------------------------------------------------------------------------
+-- 1. Give every fenced row a generic identity BEFORE the per-platform fence goes.
+--
+-- Rows written before the D6 dual-write landed carry (slackAppId, teamId) alone.
+-- Dropping `bot_slackAppId_teamId_key` while they have a NULL generic identity
+-- would leave them unfenced — and unfenced here means a second organization can
+-- claim a workspace this one already holds.
+--
+-- Safe against the composite unique this populates: the index being dropped
+-- below already guaranteed (slackAppId, teamId) is unique, and NULL teamIds stay
+-- NULL, which Postgres keeps distinct in both indexes alike.
+UPDATE "public"."bot"
+SET "externalAppId" = "slackAppId",
+    "externalTenantId" = "teamId"
+WHERE "platform" = 'slack'
+  AND "slackAppId" IS NOT NULL
+  AND "externalAppId" IS NULL;
+
+-- 2. The per-platform fence is now redundant with
+--    bot_platform_externalAppId_externalTenantId_key, which carries the same
+--    values for Slack (its projector mirrors the pair verbatim).
+DROP INDEX IF EXISTS "public"."bot_slackAppId_teamId_key";
+
+-- ---------------------------------------------------------------------------
+-- 3. Fold the per-platform metadata columns into the generic bag.
+--
+-- `jsonb_strip_nulls` keeps an absent value absent rather than storing an
+-- explicit null, so a read of the bag cannot tell "unset" from "set to null" —
+-- the same distinction the nullable columns carried. Concatenating onto the
+-- existing bag preserves anything a provider already wrote there.
+UPDATE "public"."bot"
+SET "platformConfig" = COALESCE("platformConfig", '{}'::jsonb) || jsonb_strip_nulls(
+      jsonb_build_object(
+        'discordAppId', "discordAppId",
+        'feishuAppId', "feishuAppId",
+        'feishuRegion', "feishuRegion"
+      )
+    )
+WHERE "discordAppId" IS NOT NULL
+   OR "feishuAppId" IS NOT NULL
+   OR "feishuRegion" IS NOT NULL;
+
+ALTER TABLE "public"."bot" DROP COLUMN "discordAppId";
+ALTER TABLE "public"."bot" DROP COLUMN "feishuAppId";
+ALTER TABLE "public"."bot" DROP COLUMN "feishuRegion";
+
+-- ---------------------------------------------------------------------------
+-- 4. The resume cursor for the one-time external-access classification pass.
+--    Nothing has written it since that pass; every row carries NULL.
+ALTER TABLE "public"."session_external_access_policy" DROP COLUMN "migrationCursor";

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1789,11 +1789,12 @@ model Bot {
   // (slackAppId, teamId) identifies a workspace's Bot. NULL for legacy /
   // single-workspace bots. Public metadata, NOT secret material.
   teamId                String?
-  // NOTE: `slackAppId`/`teamId` are no longer an identity fence — the generic
-  // pair below is. They remain because each still has a job: `slackAppId` is the
-  // console's deep-link to api.slack.com/apps/{id}, and `teamId` is what rides
-  // `rc/bot-assign` to the relay, whose delivery-time demux reads it to pick the
-  // strict (distributed install) or learnable (single-workspace) arm.
+  // Slack's own copies of the identity pair below, kept because each is read for
+  // its own reason: `slackAppId` is the console's deep-link to
+  // api.slack.com/apps/{id}, and `teamId` rides `rc/bot-assign` to the relay,
+  // whose delivery-time demux reads it to pick the strict (distributed install)
+  // or learnable (single-workspace) arm. Neither is an identity fence — that is
+  // the composite unique below.
   // External workspace identity used only to label/group bot rows in the Console.
   // Slack fills this from auth.test/OAuth for every bot kind. It is deliberately
   // separate from teamId, whose non-null value marks a distributed platform-app
@@ -1818,11 +1819,10 @@ model Bot {
   credentialRevision    Int            @default(1)
   credentialInstalledAt DateTime?      @db.Timestamptz(6)
   // ── generic bot demux identity (integration-plugin-architecture.md D6/§11) ──
-  // The platform's app-scoped id plus its tenant scope, and the sole identity
-  // fence: `BotRepo.getByExternalIdentity` is the only lookup, and the composite
-  // unique below is the only constraint. For Slack these mirror
-  // (slackAppId, teamId) verbatim, which is what made retiring the per-platform
-  // fence a no-op rather than a semantic change. NULL means no app identity was
+  // The platform's app-scoped id plus its tenant scope — the row's identity.
+  // `BotRepo.getByExternalIdentity` is the only lookup and the composite unique
+  // below is the only constraint, so every platform is fenced by one rule. Slack
+  // fills these from `(slackAppId, teamId)`. NULL means no app identity was
   // captured (a pasted-token Slack install), and Postgres keeps those distinct; a
   // tenantless platform writes the '-' sentinel instead.
   externalAppId         String?

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1072,7 +1072,6 @@ model SessionExternalAccessPolicy {
   state           ExternalAccessPolicyState @default(disabled)
   currentRev      BigInt                    @default(0) @db.BigInt
   readFenceRev    BigInt?                   @db.BigInt
-  migrationCursor String?
   createdAt       DateTime                  @default(now()) @db.Timestamptz(6)
   updatedAt       DateTime                  @updatedAt @db.Timestamptz(6)
 
@@ -1790,6 +1789,11 @@ model Bot {
   // (slackAppId, teamId) identifies a workspace's Bot. NULL for legacy /
   // single-workspace bots. Public metadata, NOT secret material.
   teamId                String?
+  // NOTE: `slackAppId`/`teamId` are no longer an identity fence — the generic
+  // pair below is. They remain because each still has a job: `slackAppId` is the
+  // console's deep-link to api.slack.com/apps/{id}, and `teamId` is what rides
+  // `rc/bot-assign` to the relay, whose delivery-time demux reads it to pick the
+  // strict (distributed install) or learnable (single-workspace) arm.
   // External workspace identity used only to label/group bot rows in the Console.
   // Slack fills this from auth.test/OAuth for every bot kind. It is deliberately
   // separate from teamId, whose non-null value marks a distributed platform-app
@@ -1814,21 +1818,28 @@ model Bot {
   credentialRevision    Int            @default(1)
   credentialInstalledAt DateTime?      @db.Timestamptz(6)
   // ── generic bot demux identity (integration-plugin-architecture.md D6/§11) ──
-  // Generalizes (slackAppId, teamId): the platform's app-scoped id plus its tenant
-  // scope. NULL is reserved for LEGACY rows (pre-capture Slack installs keep
-  // today's NULLs-distinct semantics; backfilled tenantless rows keep NULL too); a
-  // NEW row on a tenantless platform writes the '-' sentinel so the composite
-  // unique below enforces (platform, externalAppId) uniqueness declaratively.
-  // Dual-write window: reads still ride the legacy per-platform columns; these are
-  // written alongside them until the legacy columns fold away.
+  // The platform's app-scoped id plus its tenant scope, and the sole identity
+  // fence: `BotRepo.getByExternalIdentity` is the only lookup, and the composite
+  // unique below is the only constraint. For Slack these mirror
+  // (slackAppId, teamId) verbatim, which is what made retiring the per-platform
+  // fence a no-op rather than a semantic change. NULL means no app identity was
+  // captured (a pasted-token Slack install), and Postgres keeps those distinct; a
+  // tenantless platform writes the '-' sentinel instead.
   externalAppId         String?
   externalTenantId      String?
-  // Display-only per-platform bag (discordAppId / feishuAppId / feishuRegion fold
-  // here when reads switch). Never demux identity, never secret material.
+  // Per-platform public row metadata, written by `projectBotIdentity` and read
+  // back into the record's named fields at the repository seam. Never demux
+  // identity (that is the pair above), never secret material.
+  //   discordAppId — Discord application (client) id, decoded from the bot token's
+  //     first segment; backs the console's ready-made "Add to Discord" invite URL.
+  //   feishuAppId  — Feishu/Lark app id (cli_…), so Settings can deep-link to the
+  //     app without reading bot_secret.
+  //   feishuRegion — 'feishu' (open.feishu.cn) | 'lark' (open.larksuite.com);
+  //     absent ⇒ 'feishu'. DURABLE home, so a freed Lark bot reinstalls against
+  //     the gateway it came from.
+  // A platform adds a key here instead of a column, which is the whole point:
+  // the fifth platform costs a registry line, not a migration.
   platformConfig        Json?
-  discordAppId          String? // Discord application (client) id, decoded from the bot token's first segment — lets the console offer a ready-made "Add to Discord" invite URL. Public metadata (it IS the bot's user id), NOT secret material.
-  feishuAppId           String? // Feishu/Lark app id (cli_…), copied from the create request so Settings can deep-link to this app without reading bot_secret. Public metadata, NOT secret material.
-  feishuRegion          String? // Feishu/Lark open-platform gateway for this app: 'feishu' (open.feishu.cn) | 'lark' (open.larksuite.com). NULL ⇒ 'feishu'. DURABLE home (survives uninstall) so a freed Lark bot reinstalls against the right gateway. Public config, NOT secret.
   // Shared-bot opt-in (shared-bot-relay.md §4.1). false ⇒ classic 1-bot:1-agent
   // (daemon owns the whole socket, zero behaviour change). true ⇒ the bot's
   // INBOUND migrates to a relay and it may serve MULTIPLE agents (one Integration
@@ -1853,15 +1864,13 @@ model Bot {
   // unique FK (dropped so shared bots can fan out).
   integrations Integration[]
 
-  // One Bot per workspace install of a distributed app — the relay demux key.
-  // NULL teamIds (legacy bots) are distinct under Postgres semantics, so existing
-  // rows are unaffected. Cross-org global: a workspace binds to exactly one org.
-  @@unique([slackAppId, teamId])
-  // The generic successor of the fence above (D6): one Bot per external app
-  // identity per platform. Legacy rows carry NULLs (distinct, unaffected); new
-  // tenantless rows carry the '-' sentinel, which makes this enforce
-  // (platform, externalAppId) uniqueness. Coexists with the Slack fence during
-  // the dual-write window.
+  // One Bot per external app identity per platform — the relay demux fence, and
+  // cross-org global because a workspace binds to exactly one org. A row that
+  // captured no app identity carries NULLs, which Postgres treats as distinct:
+  // that is the pre-capture Slack case (tokens pasted without an OAuth exchange),
+  // deliberately unfenced because there is nothing to fence ON. Tenantless
+  // platforms write the '-' sentinel instead, which makes this enforce
+  // (platform, externalAppId) uniqueness declaratively.
   @@unique([platform, externalAppId, externalTenantId])
   @@index([orgId])
   @@map("bot")

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -308,8 +308,8 @@ export function buildContainer(
     lease: new PgSecretLeaseRepo(prisma),
     integration: new PgIntegrationRepo(prisma),
     integrationChannel: new PgIntegrationChannelRepo(prisma),
-    // §11 D6 dual-write: which columns carry this bot's demux identity is the
-    // provider's declaration, read at write time through the façade above.
+    // §11 D6: which values carry this bot's demux identity is the provider's
+    // declaration, read at write time through the façade above.
     bot: new PgBotRepo(prisma, botIdentityProjector(platforms)),
     botSecret: new PgBotSecretStore(prisma, secretCipher),
     // Owns its transaction: install/revoke each write two tables behind the

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -286,7 +286,7 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
         }
         if (!expectedBot && !agent) return fail('error')
 
-        const existing = await deps.repos.bot.getBySlackAppTeam(platform.appId, result.teamId)
+        const existing = await deps.repos.bot.getByExternalIdentity('slack', platform.appId, result.teamId)
         if (expectedBot && existing?.id !== expectedBot.id) {
           req.log.warn(
             { installId: row.id, botId: expectedBot.id },
@@ -393,8 +393,8 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
             })
           } catch (err) {
             // The install tail's generic workspace-claim fence
-            // (ingress-tenant-fence.md §5). This funnel's own getBySlackAppTeam
-            // pre-check covers platform-app rows; the tail additionally catches a
+            // (ingress-tenant-fence.md §5). This funnel's own identity pre-check
+            // covers platform-app rows; the tail additionally catches a
             // workspace some org connected through a DIFFERENT funnel with this
             // same app id. Callback UX, not JSON: same closing page as the
             // pre-check's refusal.

--- a/packages/control-plane/src/http/session-access.test.ts
+++ b/packages/control-plane/src/http/session-access.test.ts
@@ -49,8 +49,7 @@ describe('makeSessionAccessResolver', () => {
       provider: 'feishu',
       state: 'disabled',
       currentRev: 0n,
-      readFenceRev: null,
-      migrationCursor: null
+      readFenceRev: null
     } as const
     const deps = {
       repos: {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1037,7 +1037,6 @@ export interface SessionExternalAccessPolicyRecord {
   state: ExternalAccessPolicyState
   currentRev: bigint
   readFenceRev: bigint | null
-  migrationCursor: string | null
 }
 
 /** One request-local external authorization snapshot. Scope allows are tied to
@@ -2707,9 +2706,6 @@ export interface BotRepo {
    *  shared-bot orchestrator's convergence worklist (relay register / failover).
    *  System-tier: fleet-wide by design. */
   listHttpActive(): Promise<BotRecord[]>
-  /** The Bot backing one workspace install of a distributed app — CROSS-ORG lookup
-   *  by the composite demux key (a workspace binds to exactly one org). */
-  getBySlackAppTeam(slackAppId: string, teamId: string): Promise<BotRecord | null>
   /** Workspace-claim admission predicate (ingress-tenant-fence.md §5): does a
    *  DIFFERENT organization already hold a bot for this app+workspace? The
    *  question is deliberately cross-org — one app installed into one workspace

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -51,8 +51,16 @@ const botInclude = {
   integrations: { select: { agentId: true, status: true }, orderBy: { createdAt: 'asc' } }
 } as const
 
+/** The bag is `Json`, so a hand-edited row can hold anything. Read it the way any
+ *  untrusted map is read: a non-string is absent, never coerced. */
+function asText(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
 function toBotRecord(b: BotJoined): BotRecord {
   const active = b.integrations.filter((i) => i.status === 'active')
+  const platformConfig = (b.platformConfig as Record<string, unknown> | null) ?? null
+  const cfg = platformConfig ?? {}
   return {
     id: BotId(b.id),
     orgId: OrgId(b.orgId),
@@ -63,16 +71,20 @@ function toBotRecord(b: BotJoined): BotRecord {
     teamId: b.teamId,
     externalAppId: b.externalAppId,
     externalTenantId: b.externalTenantId,
-    platformConfig: (b.platformConfig as Record<string, unknown> | null) ?? null,
+    platformConfig: platformConfig,
     workspaceId: b.workspaceId,
     workspaceName: b.workspaceName,
     botUserId: b.botUserId,
     revokedAt: b.revokedAt,
     credentialRevision: b.credentialRevision,
     credentialInstalledAt: b.credentialInstalledAt,
-    discordAppId: b.discordAppId,
-    feishuAppId: b.feishuAppId,
-    feishuRegion: (b.feishuRegion as FeishuRegion | null) ?? null,
+    // Projected out of the generic bag, which is where every write puts them
+    // (`CpPlatformProvider.projectBotIdentity`). The named fields stay on the
+    // RECORD because that is a domain type with named platform metadata, not a
+    // column list — the bag is a storage decision, so it stops at this seam.
+    discordAppId: asText(cfg.discordAppId),
+    feishuAppId: asText(cfg.feishuAppId),
+    feishuRegion: (asText(cfg.feishuRegion) as FeishuRegion | null) ?? null,
     shareable: b.shareable,
     transport: b.transport as BotRecord['transport'],
     createdBy: b.createdBy
@@ -109,11 +121,11 @@ export class PgBotRepo implements BotRepo {
   ) {}
 
   async create(input: CreateBotInput): Promise<BotRecord> {
-    // The D6 generic dual-write (§11). Reads stay on the legacy columns during
-    // the dual-write window; this keeps the generic pair (and the metadata bag)
-    // in lockstep for every NEW row, whichever platform and whichever install
-    // path wrote it. Resolved BEFORE the write so an unwired projector surfaces
-    // as itself rather than as something the P2002 mapping below has to survive.
+    // The D6 generic identity (§11) — the row's only demux identity, and what
+    // the composite unique fences on. Written for every NEW row, whichever
+    // platform and whichever install path produced it. Resolved BEFORE the write
+    // so an unwired projector surfaces as itself rather than as something the
+    // P2002 mapping below has to survive.
     const identity = this.projectIdentity(input)
     try {
       const b = await this.db.bot.create({
@@ -129,9 +141,6 @@ export class PgBotRepo implements BotRepo {
           ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
           ...(input.workspaceName ? { workspaceName: input.workspaceName } : {}),
           ...(input.botUserId ? { botUserId: input.botUserId } : {}),
-          ...(input.discordAppId ? { discordAppId: input.discordAppId } : {}),
-          ...(input.feishuAppId ? { feishuAppId: input.feishuAppId } : {}),
-          ...(input.feishuRegion ? { feishuRegion: input.feishuRegion } : {}),
           ...(input.shareable !== undefined ? { shareable: input.shareable } : {}),
           ...(input.transport !== undefined ? { transport: input.transport } : {}),
           // Generation 1 (the column default) lands NOW — so a lifecycle event that
@@ -144,10 +153,8 @@ export class PgBotRepo implements BotRepo {
       })
       return toBotRecord(b)
     } catch (err) {
-      // The D6 composite unique fired: a bot with this external app identity
-      // already exists on this platform. Typed so routes can 409 instead of 500.
-      // The legacy (slackAppId, teamId) unique keeps its existing callers'
-      // handling; only the new index maps here.
+      // The composite unique fired: a bot with this external app identity already
+      // exists on this platform. Typed so routes can 409 instead of 500.
       if (
         (err as { code?: string }).code === 'P2002' &&
         String((err as { meta?: { target?: unknown } }).meta?.target ?? '').includes('externalAppId')
@@ -211,9 +218,10 @@ export class PgBotRepo implements BotRepo {
   }
 
   async setSlackAppIdIfMissing(id: BotId, slackAppId: string): Promise<boolean> {
-    // Dual-write (D6): the generic column tracks the legacy one. The tenant half
-    // stays NULL here — the reconciler backfills legacy socket bots, whose
-    // pre-capture NULLs-distinct semantics must be preserved.
+    // Both in one statement, so the demux identity and the console's deep-link id
+    // can never disagree. The tenant half stays NULL: this backfills a socket bot
+    // that never captured a workspace, and NULL is what keeps such rows distinct
+    // under the composite unique.
     const result = await this.db.bot.updateMany({
       where: { id, slackAppId: null },
       data: { slackAppId, externalAppId: slackAppId }
@@ -276,9 +284,13 @@ export class PgBotRepo implements BotRepo {
     // Cross-org on purpose (the admission question IS cross-org), boolean on
     // purpose (no foreign row crosses the seam) — ingress-tenant-fence.md §5.
     //
-    // The app id matches EITHER column: `externalAppId` is the D6 generic one
-    // every new row dual-writes, `slackAppId` is the legacy one pre-D6 rows
-    // still carry alone. Matching both is what lets a legacy row hold a claim.
+    // The app id matches EITHER column. Every write that sets a Slack app id sets
+    // the generic one in the same statement (`create` via the projector,
+    // `setSlackAppIdIfMissing` explicitly), so `slackAppId` alone should be
+    // unreachable — but nothing in the SCHEMA enforces that, and the cost of
+    // being wrong here is one organization capturing another's workspace. A
+    // second predicate is a cheap price for not resting a cross-org fence on an
+    // invariant the database does not hold.
     const held = await this.db.bot.count({
       where: {
         platform: toDbPlatform(platform),
@@ -290,24 +302,14 @@ export class PgBotRepo implements BotRepo {
     return held > 0
   }
 
-  async getBySlackAppTeam(slackAppId: string, teamId: string): Promise<BotRecord | null> {
-    // Cross-org on purpose: (slackAppId, teamId) is globally unique — a workspace
-    // install of a distributed app binds to exactly one org, and the platform
-    // callback must find it wherever it lives to refuse a second org's claim.
-    const b = await this.db.bot.findUnique({
-      where: { slackAppId_teamId: { slackAppId, teamId } },
-      include: botInclude
-    })
-    return b ? toBotRecord(b) : null
-  }
-
   async getByExternalIdentity(
     platform: string,
     externalAppId: string,
     externalTenantId: string
   ): Promise<BotRecord | null> {
-    // Cross-org on purpose, mirroring getBySlackAppTeam: an external app identity
-    // binds to exactly one org, and a second org's claim must find it to refuse.
+    // Cross-org on purpose: an external app identity binds to exactly one org — a
+    // workspace install of a distributed app is global — and a second org's claim
+    // must find it wherever it lives in order to refuse.
     const b = await this.db.bot.findUnique({
       where: { platform_externalAppId_externalTenantId: { platform, externalAppId, externalTenantId } },
       include: botInclude

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -115,8 +115,7 @@ function toExternalPolicyRecord(policy: SessionExternalAccessPolicy): SessionExt
     provider: policy.provider,
     state: policy.state as ExternalAccessPolicyState,
     currentRev: policy.currentRev,
-    readFenceRev: policy.readFenceRev,
-    migrationCursor: policy.migrationCursor
+    readFenceRev: policy.readFenceRev
   }
 }
 

--- a/packages/control-plane/src/platforms/bot-identity.test.ts
+++ b/packages/control-plane/src/platforms/bot-identity.test.ts
@@ -44,9 +44,9 @@ const row = (platform: string, columns: Partial<CreateBotInput> = {}): CreateBot
 })
 
 describe('slack — tenant-scoped', () => {
-  it('mirrors (slackAppId, teamId) into the generic pair', () => {
+  it('projects (slackAppId, teamId) as the generic pair', () => {
     // A platform-app OAuth install: both halves captured, so the pair is the
-    // same key the legacy unique fences on. Lockstep, not a second opinion.
+    // full demux identity and the composite unique fences on it.
     expect(project(row('slack', { slackAppId: 'A123', teamId: 'T999' }))).toEqual({
       externalAppId: 'A123',
       externalTenantId: 'T999'
@@ -55,8 +55,8 @@ describe('slack — tenant-scoped', () => {
 
   it('keeps each half independent — a manual install captures no workspace', () => {
     // Pasting tokens into the create form runs no OAuth exchange, so there is no
-    // teamId to write. That is the pre-capture NULL the legacy fence has always
-    // tolerated, and the reason Slack declares no 409 pre-check.
+    // teamId to write. Postgres keeps those NULL rows distinct, which is why
+    // Slack declares no 409 pre-check — there is nothing to pre-check.
     expect(project(row('slack', { slackAppId: 'A123' }))).toEqual({ externalAppId: 'A123' })
     expect(project(row('slack', { teamId: 'T999' }))).toEqual({ externalTenantId: 'T999' })
     expect(project(row('slack'))).toEqual({})

--- a/packages/control-plane/src/platforms/bot-identity.ts
+++ b/packages/control-plane/src/platforms/bot-identity.ts
@@ -2,7 +2,7 @@
  * The D6 identity projection, read through the platform registry
  * (integration-plugin-architecture.md §9/§11; audit F13).
  *
- * `PgBotRepo.create` performs the generic identity dual-write for EVERY caller —
+ * `PgBotRepo.create` writes the generic identity for EVERY caller —
  * the shared create tail (`http/install-bot.ts`), the Feishu one-click funnel
  * (`http/install-feishu.ts`), and anything added later. It used to decide WHAT
  * to write with a four-arm `switch (input.platform)`: per-platform knowledge in

--- a/packages/control-plane/src/platforms/new-bot-install.test.ts
+++ b/packages/control-plane/src/platforms/new-bot-install.test.ts
@@ -212,7 +212,7 @@ describe('feishu buildNewBotInstall', () => {
     })
     // The pre-check query and the `BotExternalIdentityTaken` backstop both run
     // off this declaration, so the id and the sentinel must be exactly what the
-    // repo's dual-write puts on the row.
+    // repo's identity write puts on the row.
     expect(install.externalIdentity?.externalAppId).toBe('cli_y')
     expect(install.externalIdentity?.externalTenantId).toBe('-')
   })

--- a/packages/control-plane/src/platforms/provider.ts
+++ b/packages/control-plane/src/platforms/provider.ts
@@ -467,20 +467,21 @@ export interface CpPlatformProvider<TCredentials = unknown> {
    * sentinel, and what public metadata rides the generic `platformConfig` bag.
    *
    * An AT-WRITE read, and the reason it is a member rather than a repository
-   * `switch`: `PgBotRepo.create` performs the D6 dual-write for EVERY caller —
+   * `switch`: `PgBotRepo.create` writes the D6 identity for EVERY caller —
    * the shared create tail, the Feishu one-click funnel, and anything added
    * later — so the decision has to be reachable from persistence, but it is not
    * persistence's to make. Core keeps the write (and so keeps §11's guarantee
-   * that a new row never leaves the pair NULL, which is reserved for legacy
-   * rows); the platform keeps the mapping.
+   * that a new row never leaves the pair NULL unless the platform genuinely
+   * captured no app identity); the platform keeps the mapping.
    *
    * DISTINCT from {@link CpNewBotInstall.externalIdentity}, which is the create
    * ROUTE's 409 pre-check and applies only to a platform that wants a clean
    * conflict message on the credential-paste path. This member describes what is
    * PERSISTED, on every path, and a platform may project an identity here
    * without claiming a route-level fence (Slack does exactly that: its rows
-   * carry the pair whenever an app id and workspace were captured, while the
-   * legacy `(slackAppId, teamId)` unique remains its fence).
+   * carry the pair whenever an app id and workspace were captured, and the
+   * composite unique fences them, but a pasted-token install with neither is
+   * admitted unfenced because there is nothing to fence on).
    *
    * Pure: no I/O. Absent ⇒ this platform persists no external identity
    * (Telegram — a bot token and nothing else). PUBLIC metadata only.

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -444,8 +444,8 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
 
     /**
      * D6 identity (§11): Slack is TENANT-SCOPED, so the pair is
-     * `(slackAppId, teamId)` — the same two values the per-platform unique used
-     * to fence on, which is what made retiring that fence a no-op.
+     * `(slackAppId, teamId)` — an install of a distributed app is identified by
+     * the app AND the workspace, never the app alone.
      *
      * Each half is conditional and neither implies the other: a manual
      * single-workspace install pastes tokens without an OAuth exchange, so it

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -443,16 +443,15 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
     },
 
     /**
-     * D6 identity (§11): Slack is TENANT-SCOPED, so the generic pair mirrors
-     * `(slackAppId, teamId)` verbatim — the same two values the legacy unique
-     * fences on, which is what makes the dual-write a lockstep copy rather than
-     * a second opinion.
+     * D6 identity (§11): Slack is TENANT-SCOPED, so the pair is
+     * `(slackAppId, teamId)` — the same two values the per-platform unique used
+     * to fence on, which is what made retiring that fence a no-op.
      *
      * Each half is conditional and neither implies the other: a manual
      * single-workspace install pastes tokens without an OAuth exchange, so it
-     * captures no `teamId` (and sometimes no app id either) and keeps NULLs —
-     * the pre-capture semantics the legacy fence has always had, and the reason
-     * Slack declares no `externalIdentity` 409 pre-check.
+     * captures no `teamId` (and sometimes no app id either) and keeps NULLs.
+     * Postgres holds those rows distinct, which is why Slack declares no
+     * `externalIdentity` 409 pre-check — there is nothing to pre-check.
      */
     projectBotIdentity: (input) => ({
       ...(input.slackAppId ? { externalAppId: input.slackAppId } : {}),

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -205,8 +205,11 @@ describe('Feishu/Lark one-click app registration', () => {
     // the durable cursor switches domains, then a later browser poll resumes it.
     expect(requests.map((request) => request.get('action'))).toEqual(['begin', 'poll', 'poll'])
     expect(requests[0]?.get('request_user_info')).toBe('open_id')
-    const bot = await prisma.bot.findFirst({ where: { feishuAppId: 'cli_oneclick' } })
-    expect(bot).toMatchObject({ name: 'AgentConnect Lark', feishuRegion: 'lark' })
+    // Feishu projects its app id onto the generic identity, so the row is found
+    // by the indexed column rather than a JSON path; the gateway rides the bag.
+    const bot = await prisma.bot.findFirst({ where: { externalAppId: 'cli_oneclick' } })
+    expect(bot).toMatchObject({ name: 'AgentConnect Lark' })
+    expect(bot?.platformConfig).toMatchObject({ feishuAppId: 'cli_oneclick', feishuRegion: 'lark' })
     expect(await prisma.botSecret.findUnique({ where: { botId: bot!.id } })).toMatchObject({
       botToken: 'one-click-secret',
       appToken: 'cli_oneclick'
@@ -580,7 +583,7 @@ describe('Feishu/Lark one-click app registration', () => {
       { timeout: 5_000 }
     )
 
-    const bot = await prisma.bot.findFirstOrThrow({ where: { feishuAppId: 'cli_http_oneclick' } })
+    const bot = await prisma.bot.findFirstOrThrow({ where: { externalAppId: 'cli_http_oneclick' } })
     const secret = await prisma.botSecret.findUniqueOrThrow({ where: { botId: bot.id } })
     expect(bot).toMatchObject({ transport: 'http', botUserId: 'ou_http_bot' })
     expect(secret.verificationToken).toHaveLength(32)

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -345,8 +345,9 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect(secret).toMatchObject({ botToken: DISCORD_TOKEN, appToken: null })
     // The application (client) id is decoded from the token and persisted (public metadata).
     const bot = await prisma.bot.findUnique({ where: { id: dto.botId as string } })
-    expect(bot).toMatchObject({ platform: 'discord', discordAppId: '123456789012345678', slackAppId: null })
-    // D6: Discord has no demux identity — only the display bag is written.
+    expect(bot).toMatchObject({ platform: 'discord', slackAppId: null })
+    // D6: Discord has no demux identity — the decoded application id is public
+    // metadata, so it rides the per-platform bag and fences nothing.
     expect(bot).toMatchObject({
       externalAppId: null,
       externalTenantId: null,
@@ -475,9 +476,10 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     const secret = await prisma.botSecret.findUnique({ where: { botId: dto.botId as string } })
     expect(secret).toMatchObject({ botToken: FEISHU.appSecret, appToken: FEISHU.appId })
     const bot = await prisma.bot.findUnique({ where: { id: dto.botId as string } })
-    expect(bot).toMatchObject({ platform: 'feishu', feishuAppId: FEISHU.appId, feishuRegion: 'lark' })
-    // D6 dual-write: the generic demux identity carries the app id with the
-    // tenantless '-' sentinel, and the display bag holds the fold-ahead fields.
+    expect(bot).toMatchObject({ platform: 'feishu' })
+    // The generic demux identity carries the app id with the tenantless '-'
+    // sentinel; the app id and gateway also ride the per-platform bag, which is
+    // what the console reads and what survives an uninstall.
     expect(bot).toMatchObject({
       externalAppId: FEISHU.appId,
       externalTenantId: '-',

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -1075,8 +1075,11 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       })
     ).json() as { id: string; botId: string }
     await app.app.inject({ method: 'DELETE', url: `${ORG}/integrations/${first.id}` })
-    // Region lives durably on the freed bot.
-    expect((await prisma.bot.findUnique({ where: { id: first.botId } }))?.feishuRegion).toBe('lark')
+    // Region lives durably on the freed bot — in the per-platform bag, which is
+    // what survives the uninstall so a reinstall dials the same gateway.
+    expect((await prisma.bot.findUnique({ where: { id: first.botId } }))?.platformConfig).toMatchObject({
+      feishuRegion: 'lark'
+    })
 
     const otherAgent = randomUUID()
     await seedAgent(prisma, otherAgent, { daemonId: DAEMON })

--- a/packages/control-plane/test/integration/slack-platform-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-platform-install.route.test.ts
@@ -187,7 +187,13 @@ describe('GET /integrations/slack/platform/callback', () => {
     })
 
     const bot = await prisma.bot.findUnique({
-      where: { slackAppId_teamId: { slackAppId: PLATFORM.appId, teamId: 'T0WORKSPACE' } },
+      where: {
+        platform_externalAppId_externalTenantId: {
+          platform: 'slack',
+          externalAppId: PLATFORM.appId,
+          externalTenantId: 'T0WORKSPACE'
+        }
+      },
       include: { secret: true, integrations: true }
     })
     expect(bot).toMatchObject({
@@ -269,7 +275,14 @@ describe('GET /integrations/slack/platform/callback', () => {
         shareable: false,
         prebuilt: true,
         slackAppId: PLATFORM.appId,
-        teamId: 'T0WORKSPACE'
+        teamId: 'T0WORKSPACE',
+        // What a real platform-app install writes: the callback sets workspaceId
+        // from team.id, and PgBotRepo.create projects the demux identity. A row
+        // carrying only the per-platform pair is a shape production cannot
+        // produce, and fencing against it would prove nothing.
+        workspaceId: 'T0WORKSPACE',
+        externalAppId: PLATFORM.appId,
+        externalTenantId: 'T0WORKSPACE'
       }
     })
     const agentId = randomUUID()
@@ -299,7 +312,13 @@ describe('GET /integrations/slack/platform/callback', () => {
       url: `/api/v1/integrations/slack/platform/callback?code=c1&state=${first.id}`
     })
     const bot = await prisma.bot.findUniqueOrThrow({
-      where: { slackAppId_teamId: { slackAppId: PLATFORM.appId, teamId: 'T0WORKSPACE' } }
+      where: {
+        platform_externalAppId_externalTenantId: {
+          platform: 'slack',
+          externalAppId: PLATFORM.appId,
+          externalTenantId: 'T0WORKSPACE'
+        }
+      }
     })
     await app.deps.httpBot.revokeBot(bot.id, 'app_uninstalled')
     const revoked = await prisma.bot.findUniqueOrThrow({ where: { id: bot.id } })
@@ -471,7 +490,13 @@ describe('GET /integrations/slack/platform/callback', () => {
       url: `/api/v1/integrations/slack/platform/callback?code=c1&state=${first.id}`
     })
     const bot = await prisma.bot.findUniqueOrThrow({
-      where: { slackAppId_teamId: { slackAppId: PLATFORM.appId, teamId: 'T0WORKSPACE' } }
+      where: {
+        platform_externalAppId_externalTenantId: {
+          platform: 'slack',
+          externalAppId: PLATFORM.appId,
+          externalTenantId: 'T0WORKSPACE'
+        }
+      }
     })
     expect(bot.credentialRevision).toBe(1)
     // The workspace uninstalls — the event is generated NOW but not delivered yet.
@@ -777,7 +802,14 @@ describe('GET /integrations/slack/platform-install/:id (completion signal)', () 
         transport: 'http',
         shareable: false,
         slackAppId: PLATFORM.appId,
-        teamId: 'T0WORKSPACE'
+        teamId: 'T0WORKSPACE',
+        // What a real platform-app install writes: the callback sets workspaceId
+        // from team.id, and PgBotRepo.create projects the demux identity. A row
+        // carrying only the per-platform pair is a shape production cannot
+        // produce, and fencing against it would prove nothing.
+        workspaceId: 'T0WORKSPACE',
+        externalAppId: PLATFORM.appId,
+        externalTenantId: 'T0WORKSPACE'
       }
     })
     const agentId = randomUUID()


### PR DESCRIPTION
Follow-up to #749. That PR removed pre-release scaffolding from the daemon and
the wire; this one closes what the migration squash (#736) left in the Control
Plane schema — it preserved the final shape, but carried unfinished migration
state along with it.

Three items, shipped together because they share one migration.

## 1. `Bot` fenced its demux identity twice

`@@unique([slackAppId, teamId])` sat beside the D6 successor
`@@unique([platform, externalAppId, externalTenantId])`, with a lookup for each
and reads on the per-platform pair — "written alongside them **until the legacy
columns fold away**."

Retiring the older fence is a no-op rather than a semantic change: Slack is
tenant-scoped, so its `projectBotIdentity` mirrors `(slackAppId, teamId)`
**verbatim** and writes NULLs rather than the tenantless `-` sentinel, so the
generic unique already enforces exactly what the retired one did.
`getBySlackAppTeam` had a single production caller, now on
`getByExternalIdentity`.

**`slackAppId` and `teamId` remain as columns.** Neither is dead weight:
`slackAppId` is the console's deep-link to `api.slack.com/apps/{id}`, and
`teamId` rides `rc/bot-assign` to the relay, whose delivery-time demux reads it
to pick the strict (distributed install) or learnable (single-workspace) arm.
Their comments now say that instead of calling them legacy — the label is
exactly what would invite a later deletion that breaks admission.

## 2. `discordAppId` / `feishuAppId` / `feishuRegion` were dual-written

`platformConfig` already existed as the declared fold target and both providers
already projected into it, while the named columns were still written and read
alongside.

The fold turned out to be small: everything downstream reads `BotRecord`, not
Prisma, so it is three lines in `toBotRecord` and three removed from `create()`.
The named fields **stay on the record** — that is a domain type carrying named
platform metadata, not a column list; the bag is a storage decision and stops at
the repository seam. A platform now adds a key instead of a column, which is the
point of D6.

## 3. `SessionExternalAccessPolicy.migrationCursor` was dead

The resume cursor for the one-time external-access classification pass. Nothing
had written it since; the column, its port field and the repo mapping only
carried NULL to a DTO.

## The migration — forward-only, and it backfills before it removes

`00000000000000_init` is **not** touched. That baseline has shipped, so editing
it would fail every deployed database on its recorded `_prisma_migrations`
checksum, and the change would silently never apply besides. `README.md` and
`resource-visibility.md` §10 both already say the baseline is append-only.

That constraint also surfaces a bug an empty baseline hides. A real database can
hold rows written before the D6 dual-write, carrying `slackAppId` with a NULL
generic identity. Dropping `bot_slackAppId_teamId_key` while those rows have no
generic identity leaves them **unfenced** — and unfenced here means a second
organization can claim a workspace this one already holds. So the migration is
ordered:

1. backfill `externalAppId`/`externalTenantId` from `(slackAppId, teamId)` for
   Slack rows that lack it — *then* drop the older unique index;
2. backfill `platformConfig` from the three columns with `jsonb_strip_nulls`, so
   an absent value stays absent rather than becoming an explicit null — *then*
   drop the columns;
3. drop `migrationCursor`.

## Reviewer notes — what I got wrong on the way

**I first simplified `workspaceClaimedElsewhere`** from matching
`OR: [externalAppId, slackAppId]` down to `externalAppId` alone, reasoning that
every writer sets both. That is true of production and was still the wrong call:
nothing in the **schema** enforces it, and the failure mode is a cross-org
workspace capture. The second predicate is restored, with the reasoning in the
comment.

**Two fixtures built a bot from `(slackAppId, teamId)` alone** — no
`workspaceId`, no generic pair. A real platform-app install writes `workspaceId`
from `team.id` and projects the identity through `PgBotRepo.create`, so that row
shape cannot occur. The fixtures now match production, so the cross-org refusal
is exercised against a row that can actually exist rather than the code being
weakened to accept one that cannot.

## Verification

The migration chain is applied by `prisma migrate deploy` against a real
Postgres in the integration harness, so these numbers exercise the migration
itself, not just the schema file:

- `pnpm typecheck` (10 packages), `pnpm lint`, `pnpm format:check` — clean
- control-plane `test:unit` — 1309 passed
- control-plane `test:int` — full suite green
- relay 447, web 963

🤖 Generated with [Claude Code](https://claude.com/claude-code)
