### PR TITLE
fix(cp): stop serving a platform audience nobody is syncing any more

### DIFF
--- a/packages/control-plane/src/http/session-access.test.ts
+++ b/packages/control-plane/src/http/session-access.test.ts
@@ -152,6 +152,11 @@ describe('makeSessionAccessResolver snapshot', () => {
   function harness(scopes: readonly ExternalScopeRecord[] = [scope]) {
     const clock = new FakeClock(EPOCH)
     let sweeps = 0
+    let policy = enabledPolicy('feishu')
+    /** Mirrors the write path: every toggle bumps the revision. */
+    const setSync = (state: 'enabled' | 'disabled') => {
+      policy = { ...policy, state, currentRev: policy.currentRev + 1n }
+    }
     const resolve = vi.fn(async (given: readonly ExternalScopeRecord[]) => ({
       allowedScopes: given.map(({ id, aclRevision }) => ({ id, aclRevision })),
       // Marks WHICH sweep an answer came from, so a test can tell a served
@@ -164,21 +169,18 @@ describe('makeSessionAccessResolver snapshot', () => {
         session: {
           listExternalScopes: vi.fn(async () => scopes),
           getExternalScopes: vi.fn(async (ids: readonly string[]) => scopes.filter((row) => ids.includes(row.id))),
-          getExternalAccessPolicy: vi.fn(async () => enabledPolicy('feishu'))
+          getExternalAccessPolicy: vi.fn(async () => policy)
         }
       },
       clock,
       sessionAccessPlugins: [{ provider: 'feishu', available: true, resolve }]
     } as unknown as HttpDeps
-    return { deps, clock, resolve }
+    return { deps, clock, resolve, setSync }
   }
 
   it('never asks a provider whose sync is switched off', async () => {
-    const { deps, resolve } = harness()
-    deps.repos.session.getExternalAccessPolicy = vi.fn(async () => ({
-      ...enabledPolicy('feishu'),
-      state: 'disabled'
-    })) as never
+    const { deps, resolve, setSync } = harness()
+    setSync('disabled')
     const resolver = makeSessionAccessResolver(deps)
 
     const access = await resolver.forQuery(request(), query)
@@ -194,6 +196,45 @@ describe('makeSessionAccessResolver snapshot', () => {
     // while sync was off carry the provider, and the provider arm — which does
     // not care about state — is the only thing that makes them visible.
     expect(access.externalAccess.policies.map((policy) => policy.provider)).toEqual(['feishu'])
+  })
+
+  it('re-decides the moment the switch moves, in both directions', async () => {
+    const { deps, setSync } = harness()
+    const resolver = makeSessionAccessResolver(deps)
+    const grants = async () => (await resolver.forQuery(request(), query)).externalAccess.allowedScopes.length
+
+    expect(await grants()).toBe(1)
+
+    // No clock movement: the entry is still well inside its fresh window, so
+    // anything reusing it would keep authorizing on the old setting. The list
+    // path reads the live policy in SQL, so a snapshot that lagged here would
+    // have detail allowing a session the list had already hidden.
+    setSync('disabled')
+    expect(await grants()).toBe(0)
+
+    // And the inverse — a cached empty answer must not delay restoration.
+    setSync('enabled')
+    expect(await grants()).toBe(1)
+  })
+
+  it('drops grants when the switch goes off midway through the sweep', async () => {
+    const { deps, resolve } = harness()
+    let reads = 0
+    // The sweep reads the policy twice: once to key and seed the decision, once
+    // as the durable fence after the provider round trips. Land the disable in
+    // between.
+    deps.repos.session.getExternalAccessPolicy = vi.fn(async () =>
+      ++reads <= 1 ? enabledPolicy('feishu') : { ...enabledPolicy('feishu'), state: 'disabled' }
+    ) as never
+    const resolver = makeSessionAccessResolver(deps)
+
+    const access = await resolver.forQuery(request(), query)
+
+    expect(resolve).toHaveBeenCalledTimes(1)
+    expect(access.externalAccess.allowedScopes).toEqual([])
+    // Obeying the switch is not a provider failing to answer, so this must not
+    // raise the "scopes stopped resolving" banner.
+    expect(access.degraded).toBe(false)
   })
 
   it('collapses the concurrent reads of one page load into a single provider sweep', async () => {

--- a/packages/control-plane/src/http/session-access.test.ts
+++ b/packages/control-plane/src/http/session-access.test.ts
@@ -29,6 +29,11 @@ function request(): FastifyRequest {
   } as unknown as FastifyRequest
 }
 
+/** The durable row a provider always has once ingest has seen a candidate. */
+function enabledPolicy(provider: string) {
+  return { orgId: 'org-1', provider, state: 'enabled', currentRev: 1n, readFenceRev: null, migrationCursor: null }
+}
+
 describe('makeSessionAccessResolver', () => {
   it('matches a custom-Bot p2p owner by union_id without an external access check', async () => {
     const getExternalScopes = vi.fn(async () => [scope])
@@ -94,7 +99,10 @@ describe('makeSessionAccessResolver', () => {
       repos: {
         session: {
           getExternalScopes,
-          getExternalAccessPolicy: vi.fn(async () => null)
+          // Ingest upserts the policy row before it ever records a candidate,
+          // so a provider with scopes to resolve always has one. Resolving is
+          // gated on it being on.
+          getExternalAccessPolicy: vi.fn(async () => enabledPolicy('feishu'))
         }
       },
       clock: { now: () => 1_000 },
@@ -156,7 +164,7 @@ describe('makeSessionAccessResolver snapshot', () => {
         session: {
           listExternalScopes: vi.fn(async () => scopes),
           getExternalScopes: vi.fn(async (ids: readonly string[]) => scopes.filter((row) => ids.includes(row.id))),
-          getExternalAccessPolicy: vi.fn(async () => null)
+          getExternalAccessPolicy: vi.fn(async () => enabledPolicy('feishu'))
         }
       },
       clock,
@@ -164,6 +172,29 @@ describe('makeSessionAccessResolver snapshot', () => {
     } as unknown as HttpDeps
     return { deps, clock, resolve }
   }
+
+  it('never asks a provider whose sync is switched off', async () => {
+    const { deps, resolve } = harness()
+    deps.repos.session.getExternalAccessPolicy = vi.fn(async () => ({
+      ...enabledPolicy('feishu'),
+      state: 'disabled'
+    })) as never
+    const resolver = makeSessionAccessResolver(deps)
+
+    const access = await resolver.forQuery(request(), query)
+
+    // Off means the SQL scope arm stops admitting this provider's `external`
+    // rows, so resolving them would be latency spent on an answer nothing
+    // reads — a disabled Feishu policy was still costing a tenant-token round
+    // trip plus a member-list page on every session list.
+    expect(resolve).not.toHaveBeenCalled()
+    expect(access.externalAccess.allowedScopes).toEqual([])
+    expect(access.degraded).toBe(false)
+    // The policy itself stays in the snapshot: `org`-classified rows created
+    // while sync was off carry the provider, and the provider arm — which does
+    // not care about state — is the only thing that makes them visible.
+    expect(access.externalAccess.policies.map((policy) => policy.provider)).toEqual(['feishu'])
+  })
 
   it('collapses the concurrent reads of one page load into a single provider sweep', async () => {
     const { deps, resolve } = harness()

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -3,6 +3,7 @@ import { LRUCache } from 'lru-cache'
 import { cacheOptions } from '../cache.js'
 import type {
   ExternalScopeRecord,
+  SessionExternalAccessPolicyRecord,
   SessionExternalAccessSnapshot,
   SessionFilterQuery,
   SessionMetaRecord
@@ -88,13 +89,26 @@ const MAX_SNAPSHOT_ENTRIES = 2_000
  */
 const REFRESH_BEHIND = { forceRefresh: true, allowStale: true, noDeleteOnFetchRejection: true } as const
 
+/** The provider policies a decision was made under, in `providers` order. */
+type PolicySnapshot = readonly (SessionExternalAccessPolicyRecord | null)[]
+
 /** What one sweep needs, carried to `fetchMethod` as its context. */
-type Sweep = { scopes: readonly ExternalScopeRecord[]; viewer: SessionAccessViewer }
+type Sweep = {
+  scopes: readonly ExternalScopeRecord[]
+  viewer: SessionAccessViewer
+  policies: PolicySnapshot
+}
 
 /** Exactly the inputs `forScopes` reads — org, the viewer it decides for, the
- *  identities it decides with, and the scope set it decides about. An ACL bump
- *  changes `aclRevision`, so a re-fenced scope can never hit a stale entry. */
-function snapshotKey(viewer: SessionAccessViewer, scopes: readonly ExternalScopeRecord[]): string {
+ *  identities it decides with, the scope set it decides about, and whether each
+ *  provider is syncing. An ACL bump changes `aclRevision`, so a re-fenced scope
+ *  can never hit a stale entry. */
+function snapshotKey(
+  viewer: SessionAccessViewer,
+  scopes: readonly ExternalScopeRecord[],
+  policies: PolicySnapshot,
+  providers: readonly string[]
+): string {
   return [
     viewer.orgId,
     viewer.userId,
@@ -102,8 +116,26 @@ function snapshotKey(viewer: SessionAccessViewer, scopes: readonly ExternalScope
     scopes
       .map((scope) => `${scope.id}:${scope.aclRevision}`)
       .sort()
+      .join(','),
+    // Whether a provider is syncing is an input to the answer, so it has to be
+    // an input to the key. Without it, flipping the switch left every entry
+    // decided under the old setting servable for the rest of its lifetime —
+    // and because the list path reads the live policy in SQL while detail
+    // reads this snapshot, the two would disagree for that whole window. Every
+    // toggle bumps `currentRev`, so both directions re-decide immediately.
+    policies
+      .map((policy, index) => `${providers[index]}:${policy?.state ?? 'none'}:${policy?.currentRev ?? ''}`)
       .join(',')
   ].join('\u0000')
+}
+
+/** Providers whose sync is on. A missing row means no policy at all, and either
+ *  way there is nothing worth resolving: the SQL scope arm requires a live,
+ *  non-disabled row before it admits anything. */
+function syncingProviders(policies: PolicySnapshot, providers: readonly string[]): Set<string> {
+  return new Set(
+    policies.flatMap((policy, index) => (policy && policy.state !== 'disabled' ? [providers[index] as string] : []))
+  )
 }
 
 /** Request-bound resolver shared by list/detail/SSE. It never persists a user
@@ -133,24 +165,21 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
     return viewer
   }
 
+  const readPolicies = (orgId: SessionAccessViewer['orgId']): Promise<PolicySnapshot> =>
+    Promise.all(providers.map((provider) => deps.repos.session.getExternalAccessPolicy(orgId, provider)))
+
   const forScopes = async (
     scopes: readonly ExternalScopeRecord[],
-    viewer: SessionAccessViewer
+    viewer: SessionAccessViewer,
+    initialPolicies: PolicySnapshot
   ): Promise<ResolvedSessionAccess> => {
     const { orgId, identitySet } = viewer
-    const initialPolicies = await Promise.all(
-      providers.map((provider) => deps.repos.session.getExternalAccessPolicy(orgId, provider))
-    )
     // A provider whose sync is off has no say in what anyone can see: the SQL
     // scope arm stops admitting its `external` rows, and its `org`-classified
     // rows never needed a scope. Asking it anyway was pure latency on a
     // user-facing read — a disabled Feishu policy still cost a tenant-token
     // round trip plus a member-list page on every session list.
-    const syncing = new Set(
-      initialPolicies.flatMap((policy, index) =>
-        policy && policy.state !== 'disabled' ? [providers[index] as string] : []
-      )
-    )
+    const syncing = syncingProviders(initialPolicies, providers)
     const results = await Promise.all(
       plugins.map((plugin) =>
         syncing.has(plugin.provider)
@@ -169,12 +198,23 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
       Promise.all(providers.map((provider) => deps.repos.session.getExternalAccessPolicy(orgId, provider))),
       deps.repos.session.getExternalScopes(resolvedScopes.map((scope) => scope.id))
     ])
-    const currentScopeRevisions = new Map(
+    const currentScopes = new Map(
       currentAllowedScopes
         .filter((scope) => scope.orgId === orgId && pluginFor.has(scope.provider) && scope.revokedAt === null)
-        .map((scope) => [scope.id, scope.aclRevision])
+        .map((scope) => [scope.id, scope])
     )
-    const allowedScopes = resolvedScopes.filter((scope) => currentScopeRevisions.get(scope.id) === scope.aclRevision)
+    const revisionHeld = resolvedScopes.filter(
+      (scope) => currentScopes.get(scope.id)?.aclRevision === scope.aclRevision
+    )
+    // The fence re-read covers the scope; it has to cover the switch too. A
+    // disable landing between the two policy reads would otherwise keep grants
+    // the SQL scope arm has already stopped honouring, so a detail read would
+    // allow a session the list had just hidden.
+    const stillSyncing = syncingProviders(currentPolicies, providers)
+    const allowedScopes = revisionHeld.filter((scope) => {
+      const provider = currentScopes.get(scope.id)?.provider
+      return provider !== undefined && stillSyncing.has(provider)
+    })
     return {
       identitySet,
       externalScopes: scopes,
@@ -190,7 +230,10 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
       // migration degradation (for example an unrelated historical pending
       // row) stays on the owner-only settings surface and must not make every
       // member-facing list/detail claim that a provider itself is unavailable.
-      degraded: results.some((result) => result.degraded) || allowedScopes.length !== resolvedScopes.length,
+      // Measured against the REVISION check only. A grant dropped because the
+      // switch went off mid-sweep is the setting being obeyed, not a provider
+      // failing to answer, and must not raise "scopes stopped resolving".
+      degraded: results.some((result) => result.degraded) || revisionHeld.length !== resolvedScopes.length,
       accessIssues: results.flatMap((result) => result.accessIssues ?? [])
     }
   }
@@ -204,7 +247,7 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
     // outlive its own freshness for there to be anything to serve while the
     // refresh runs. `SNAPSHOT_FRESH_MS` is applied by the reader below.
     ttl: SNAPSHOT_MAX_STALE_MS,
-    fetchMethod: (_key, _stale, { context }) => forScopes(context.scopes, context.viewer)
+    fetchMethod: (_key, _stale, { context }) => forScopes(context.scopes, context.viewer, context.policies)
   })
 
   /** `forScopes` behind the snapshot window. Callers treat the record as
@@ -214,9 +257,10 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
    *  honest thing to report once one can be served stale. */
   const cachedForScopes = async (
     scopes: readonly ExternalScopeRecord[],
-    viewer: SessionAccessViewer
+    viewer: SessionAccessViewer,
+    policies: PolicySnapshot
   ): Promise<ResolvedSessionAccess> => {
-    const key = snapshotKey(viewer, scopes)
+    const key = snapshotKey(viewer, scopes, policies, providers)
     // The entry's lifetime IS the ceiling, so what remains of it gives the age.
     // A missing or expired key reports 0 and takes the blocking path, which is
     // also what a cold start and anything past the ceiling should do.
@@ -226,20 +270,23 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
     // directly rather than reporting no external access, which would hide rows.
     const access =
       (await snapshots.fetch(key, {
-        context: { scopes, viewer },
+        context: { scopes, viewer, policies },
         ...(refreshBehind ? REFRESH_BEHIND : {})
-      })) ?? (await forScopes(scopes, viewer))
+      })) ?? (await forScopes(scopes, viewer, policies))
     return { ...access, identitySet: new Set(access.identitySet) }
   }
 
   return {
     async forQuery(req: FastifyRequest, query: SessionFilterQuery): Promise<ResolvedSessionAccess> {
       const viewer = await viewerFor(req)
-      const scopes = await deps.repos.session.listExternalScopes({
-        ...query,
-        viewer: { role: ctxOf(req).role, identitySet: [...viewer.identitySet] }
-      })
-      return cachedForScopes(scopes, viewer)
+      const [scopes, policies] = await Promise.all([
+        deps.repos.session.listExternalScopes({
+          ...query,
+          viewer: { role: ctxOf(req).role, identitySet: [...viewer.identitySet] }
+        }),
+        readPolicies(viewer.orgId)
+      ])
+      return cachedForScopes(scopes, viewer, policies)
     },
     async forSessions(
       req: FastifyRequest,
@@ -249,7 +296,10 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
       const ids = [
         ...new Set(sessions.map((session) => session.externalScopeId).filter((id): id is string => id !== null))
       ]
-      const scopes = await deps.repos.session.getExternalScopes(ids)
+      const [scopes, policies] = await Promise.all([
+        deps.repos.session.getExternalScopes(ids),
+        readPolicies(viewer.orgId)
+      ])
       const accessIds = new Set(
         sessions
           .filter((session) => session.visibility === 'external')
@@ -258,7 +308,8 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
       )
       const access = await cachedForScopes(
         scopes.filter((scope) => accessIds.has(scope.id)),
-        viewer
+        viewer,
+        policies
       )
       // Private rows use scope metadata for provider branding only. Their
       // authorization remains exact owner identity and never reaches a plugin.

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -9,7 +9,7 @@ import type {
 } from '../persistence/ports.js'
 import { identitySetOf } from '../authorization/policy.js'
 import type { HttpDeps } from './deps.js'
-import type { SessionAccessIssue, SessionAccessViewer } from './session-access-plugin.js'
+import type { SessionAccessIssue, SessionAccessResult, SessionAccessViewer } from './session-access-plugin.js'
 import { ctxOf, orgOf } from './rbac.js'
 
 export interface ResolvedSessionAccess {
@@ -141,12 +141,24 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
     const initialPolicies = await Promise.all(
       providers.map((provider) => deps.repos.session.getExternalAccessPolicy(orgId, provider))
     )
+    // A provider whose sync is off has no say in what anyone can see: the SQL
+    // scope arm stops admitting its `external` rows, and its `org`-classified
+    // rows never needed a scope. Asking it anyway was pure latency on a
+    // user-facing read — a disabled Feishu policy still cost a tenant-token
+    // round trip plus a member-list page on every session list.
+    const syncing = new Set(
+      initialPolicies.flatMap((policy, index) =>
+        policy && policy.state !== 'disabled' ? [providers[index] as string] : []
+      )
+    )
     const results = await Promise.all(
       plugins.map((plugin) =>
-        plugin.resolve(
-          scopes.filter((scope) => scope.provider === plugin.provider && scope.orgId === orgId),
-          viewer
-        )
+        syncing.has(plugin.provider)
+          ? plugin.resolve(
+              scopes.filter((scope) => scope.provider === plugin.provider && scope.orgId === orgId),
+              viewer
+            )
+          : Promise.resolve<SessionAccessResult>({ allowedScopes: [], degraded: false, accessIssues: [] })
       )
     )
     const resolvedScopes = results.flatMap((result) => result.allowedScopes)

--- a/packages/control-plane/src/persistence/repositories/session-access-sql.ts
+++ b/packages/control-plane/src/persistence/repositories/session-access-sql.ts
@@ -51,6 +51,13 @@ export function sessionViewerSql(
   // Provider-wide arm. Every per-policy arm asked the same question of the
   // same row and differed only in which provider it matched, so the union is
   // "the row's provider is one we hold a policy for", plus the read fence.
+  //
+  // This arm deliberately does NOT care whether the policy is currently
+  // enabled. A candidate classified while sync is off keeps its `org`
+  // baseline but still records `externalProvider`, so the direct arm above
+  // (which requires a NULL provider) cannot match it and this one is the only
+  // thing that makes it visible. Gating it on state would hide exactly the
+  // sessions that "sync off ⇒ everyone can see" is supposed to expose.
   if (snapshot.policies.length > 0) {
     const providers = snapshot.policies.map((policy) => policy.provider)
     externalArms.push(Prisma.sql`(
@@ -77,6 +84,14 @@ export function sessionViewerSql(
   // `external_scope.id` is the primary key, so at most one row can match the
   // session's scope id and the pair check binds that row's revision to the
   // one this viewer was actually granted.
+  //
+  // Unlike the provider arm this one IS gated on the policy still being on.
+  // Turning sync off stops new sessions binding to platform access but leaves
+  // the ones already bound as `external`; without this check they would go on
+  // being served from a platform audience nobody is maintaining any more, and
+  // every read would go on paying that provider's round trips to decide it.
+  // Off means the synced history stops showing — the rows are untouched, and
+  // re-enabling brings them back.
   if (snapshot.allowedScopes.length > 0) {
     const scopeIds = snapshot.allowedScopes.map((allowed) => allowed.id)
     const grantedPairs = snapshot.allowedScopes.map(
@@ -90,6 +105,7 @@ export function sessionViewerSql(
         SELECT 1 FROM "session_external_access_policy" policy
         WHERE policy."orgId" = ${s}."orgId"
           AND policy."provider" = ${s}."externalProvider"
+          AND policy."state" <> 'disabled'::"ExternalAccessPolicyState"
       )
       AND EXISTS (
         SELECT 1 FROM "external_scope" scope

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -696,6 +696,87 @@ describe('session visibility — external conversation audiences', () => {
     })
     expect((await repo.getExternalAccessPolicy(OrgId(DEFAULT_ORG_ID), 'slack'))?.state).toBe('enabled')
   })
+
+  it('stops showing the sessions synced while sync was on once it is turned back off', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const sessionId = `s-slack-offswitch-${randomUUID()}`
+    const repo = new PgSessionRepo(prisma)
+    const record = (channel: string, id: string) =>
+      repo.recordMilestone({
+        sessionId: SessionId(id),
+        agentId: AgentId(agentId),
+        phase: 'start',
+        platform: 'slack',
+        channel,
+        at: new Date(),
+        classification: { visibility: 'org', ownerIdentity: null, source: 'default' },
+        externalCandidate: {
+          provider: 'slack',
+          resolution: 'settled',
+          scope: {
+            realmKey: 'T_INSTALL',
+            resourceKind: 'conversation',
+            resourceKey: channel,
+            credentialKind: 'bot',
+            credentialId: randomUUID()
+          }
+        }
+      })
+    const viewerWith = (readFenceRev: bigint | null, allowedScopes: { id: string; aclRevision: bigint }[]) => ({
+      role: 'owner' as const,
+      identitySet: [],
+      externalAccess: { policies: [{ provider: 'slack', readFenceRev }], allowedScopes, decisionAt: new Date() }
+    })
+    const visible = async (viewer: ReturnType<typeof viewerWith>) =>
+      (await repo.listPage({ agentIds: [AgentId(agentId)], limit: 10, includeTotal: false, viewer })).sessions.map(
+        (session) => session.id
+      )
+
+    // Sync off from the start: the candidate keeps its `org` baseline and the
+    // provider arm — not the direct arm, which requires a NULL provider — is
+    // what makes it visible to the whole org.
+    await record('C_BEFORE', sessionId)
+    expect(await repo.getUnscoped(SessionId(sessionId))).toMatchObject({
+      visibility: 'org',
+      externalProvider: 'slack'
+    })
+    expect(await visible(viewerWith(null, []))).toEqual([sessionId])
+
+    // On: the row binds to the platform audience and needs the granted scope.
+    const enabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'slack', true)
+    const bound = await repo.getUnscoped(SessionId(sessionId))
+    expect(bound).toMatchObject({ visibility: 'external' })
+    const [scope] = await repo.getExternalScopes([bound!.externalScopeId!])
+    const granted = [{ id: scope!.id, aclRevision: scope!.aclRevision }]
+    expect(await visible(viewerWith(enabled.policy.readFenceRev, granted))).toEqual([sessionId])
+
+    // Off again: the row is untouched, but nobody is maintaining that audience
+    // any more, so it stops showing even for the viewer who still holds the
+    // grant. This is the half the settings copy has to state out loud.
+    const disabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'slack', false)
+    expect(disabled.policy.state).toBe('disabled')
+    expect(await repo.getUnscoped(SessionId(sessionId))).toMatchObject({ visibility: 'external' })
+    expect(await visible(viewerWith(disabled.policy.readFenceRev, granted))).toEqual([])
+
+    // …and a session created while off is org-visible again, so turning sync
+    // off never leaves the org with nothing to look at.
+    const afterId = `s-slack-after-${randomUUID()}`
+    await record('C_AFTER', afterId)
+    expect(await visible(viewerWith(disabled.policy.readFenceRev, granted))).toEqual([afterId])
+
+    // Re-enabling restores the synced history — "hidden", never deleted.
+    const reEnabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'slack', true)
+    const restored = await repo.getExternalScopes([bound!.externalScopeId!])
+    expect(
+      await visible(
+        viewerWith(
+          reEnabled.policy.readFenceRev,
+          restored.map((row) => ({ id: row.id, aclRevision: row.aclRevision }))
+        )
+      )
+    ).toContain(sessionId)
+  })
 })
 
 describe('session visibility — membership across an agent filter', () => {

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -53,11 +53,22 @@ import { OrganizationEnvironmentCard } from '@/components/console/OrganizationEn
 // A provider this deployment cannot offer at all is not an exception to explain,
 // it is a row to leave out — see `hasNothingToOffer`.
 //
+// Two halves, and both are easy to state wrongly.
+//
 // "New sessions" is load-bearing in the Off half: turning the policy off stops
-// NEW sessions binding to platform access, it does not unbind the ones already
-// synced (each `details` string below says so too).
+// NEW sessions binding to platform access. The ones already bound keep their
+// `external` classification and simply stop being shown — they are not
+// deleted, and turning the policy back on brings them back (each `details`
+// string below says so too). That direction surprises people, because turning
+// a restriction OFF shows them LESS, so it has to be spelled out rather than
+// implied.
+//
+// And the Off half is the whole organization, not the agent's audience: the
+// session list reads every org agent regardless of Agent Team visibility
+// (`routes/sessions.ts` — "Agent Team visibility does not narrow Session
+// reads"), so promising "anyone who can view the agent" understated it.
 const SESSION_ACCESS_HINT =
-  "On — session visibility follows the platform's own access. Off — new sessions are visible to anyone who can view the agent."
+  "On — session visibility follows the platform's own access. Off — new sessions are visible to everyone in the organization, and sessions synced while it was on stop showing."
 
 const SESSION_ACCESS_COPY: Record<
   SessionAccessProvider,
@@ -77,7 +88,7 @@ const SESSION_ACCESS_COPY: Record<
       'Public channels follow Slack workspace access; private channels, group DMs, guests and Slack Connect users need current membership.',
       'DMs stay private, and agent memory learned earlier is not erased.',
       'Sessions that predate this setting stay hidden until new trusted activity rebinds them to a Slack conversation.',
-      'Turning this off leaves already-synced sessions following Slack.'
+      'Turning this off hides the sessions synced while it was on — they are not deleted, and turning it back on restores them.'
     ].join('\n'),
     unavailable:
       'Unavailable until console sign-in is configured for this deployment — without it a viewer has no linked Slack identity to check.',
@@ -88,10 +99,10 @@ const SESSION_ACCESS_COPY: Record<
     name: 'GitHub',
     label: 'Follow GitHub access',
     details: [
-      'Public-repository sessions stay visible to members who can view the agent; private-repository sessions need a linked GitHub profile with current access.',
+      'Public-repository sessions stay visible to everyone in the organization; private-repository sessions need a linked GitHub profile with current access.',
       'Agent memory learned earlier is not erased.',
       'Sessions that predate this setting stay hidden until new trusted activity rebinds them to a repository.',
-      'Turning this off leaves already-synced sessions following GitHub.'
+      'Turning this off hides the sessions synced while it was on — they are not deleted, and turning it back on restores them.'
     ].join('\n'),
     unavailable:
       'Unavailable until console sign-in and GitHub access checks are configured for this deployment — without them a viewer has no linked GitHub profile to check.',
@@ -105,7 +116,7 @@ const SESSION_ACCESS_COPY: Record<
       'Group sessions created through the matching AgentConnect app follow current chat membership.',
       'DMs stay private, and agent memory learned earlier is not erased.',
       'User-built apps with a different App ID keep the ordinary organization visibility model.',
-      'Turning this off leaves already-synced sessions following Feishu / Lark.'
+      'Turning this off hides the sessions synced while it was on — they are not deleted, and turning it back on restores them.'
     ].join('\n'),
     unavailable:
       'Unavailable until console sign-in is configured for this deployment — without it a viewer has no linked Feishu / Lark profile to check.',

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -63,12 +63,14 @@ import { OrganizationEnvironmentCard } from '@/components/console/OrganizationEn
 // a restriction OFF shows them LESS, so it has to be spelled out rather than
 // implied.
 //
-// And the Off half is the whole organization, not the agent's audience: the
-// session list reads every org agent regardless of Agent Team visibility
+// And the Off half is Everyone, not the agent's audience: the session list
+// reads every org agent regardless of Agent Team visibility
 // (`routes/sessions.ts` — "Agent Team visibility does not narrow Session
 // reads"), so promising "anyone who can view the agent" understated it.
+// `Everyone` is the audience word for the internal `org` value — see
+// docs/product-conventions.md.
 const SESSION_ACCESS_HINT =
-  "On — session visibility follows the platform's own access. Off — new sessions are visible to everyone in the organization, and sessions synced while it was on stop showing."
+  "On — session visibility follows the platform's own access. Off — new sessions are visible to Everyone, and sessions synced while it was on stop showing."
 
 const SESSION_ACCESS_COPY: Record<
   SessionAccessProvider,
@@ -99,7 +101,7 @@ const SESSION_ACCESS_COPY: Record<
     name: 'GitHub',
     label: 'Follow GitHub access',
     details: [
-      'Public-repository sessions stay visible to everyone in the organization; private-repository sessions need a linked GitHub profile with current access.',
+      'Public-repository sessions stay visible to Everyone; private-repository sessions need a linked GitHub profile with current access.',
       'Agent memory learned earlier is not erased.',
       'Sessions that predate this setting stay hidden until new trusted activity rebinds them to a repository.',
       'Turning this off hides the sessions synced while it was on — they are not deleted, and turning it back on restores them.'


### PR DESCRIPTION
## The rule this implements

Per platform, two strategies — **everyone** or **follow the platform**:

1. Sync never on → everyone in the org can see.
2. Turn it on → new sessions follow platform access; history that cannot rebind stays hidden (unchanged).
3. **Turn it off again → new sessions are org-visible; the history synced while it was on stops showing.** ← this PR

## Why (3) was worth changing

Turning sync off already stopped *new* sessions binding to platform access, but the ones already bound kept `visibility='external'` and went on being served from that platform's audience. Nothing maintains that audience once the switch is off.

It also cost real latency on every read. Measured on a test deployment with Feishu's policy `disabled`:

| upstream call, made for a switched-off provider | slowest observed |
|---|---|
| `POST /open-apis/auth/v3/tenant_access_token/internal` | **1742 ms** |
| `GET /open-apis/im/v1/chats/{id}/members` | 1074 ms |

Those ran on `/sessions`, `/sessions/facets` and `/usage` — for a handful of sessions nobody is syncing.

## The check goes on the scope arm only

This is the part worth reviewing closely. A candidate classified **while sync is off** keeps its `org` baseline but still records `externalProvider`:

```ts
visibility: policy.state === 'disabled' ? base.visibility : 'external',
externalProvider: candidate.provider,   // always set
```

The direct arm requires `externalProvider IS NULL`, so it cannot match that row — the **provider arm** is the only thing that makes it visible. Gating that arm on state too would hide exactly the sessions rules 1 and 3 are supposed to expose. So only the scope arm (`visibility='external'`) gets `policy."state" <> 'disabled'`.

With the scope arm closed, resolving a switched-off provider produces grants no read can honour, so `forScopes` skips it entirely — that is where the round trips go away.

**List and detail stay in agreement.** The in-memory mirror (`policy.ts#externalSessionIsVisible`) already required a policy entry and reads `allowedScopes`; emptying that set for a disabled provider makes the detail path hide the row too, rather than one path hiding and the other 404ing.

## Copy fixes

Two strings were describing behaviour that no longer exists:

- *"Off — new sessions are visible to anyone who can view the agent"* → the session list reads **every** org agent regardless of Agent Team visibility (`routes/sessions.ts`: "Agent Team visibility does not narrow Session reads"), so it is the whole organization. Same error in GitHub's public-repository line.
- *"Turning this off leaves already-synced sessions following Slack"* → now states that they stop showing, are not deleted, and come back on re-enable. Turning a restriction **off** and seeing **less** is surprising enough that it needs saying rather than implying.

## Testing

- New integration test walks the whole cycle: off → visible to the org, on → needs the grant, **off again → hidden even for the viewer still holding the grant**, a session created while off → org-visible, re-enable → restored.
- New unit test asserts a switched-off provider's `resolve()` is never called, `allowedScopes` is empty, and the policy still rides in the snapshot so the provider arm keeps working.
- Two existing stubs returned `getExternalAccessPolicy: null`, a shape ingest never produces (it upserts the row before recording a candidate). Made them realistic.
- `test:unit` 1310 passed · `test:int` 74 files / 1052 passed · web typecheck + 963 tests · eslint + prettier clean.

## Not in this PR

The alternative for (3) — releasing the history to org-wide on disable — needs a bulk reclassification of `session_meta` on toggle and is a one-way disclosure. Hiding is reversible and needs no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
