### PR TITLE
fix(web): lead the session-access card with GitHub

### DIFF
--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -269,8 +269,8 @@ export function SessionAccessCard({ orgId, isOwner }: { orgId?: string; isOwner:
   // Three fixed hooks, one per provider — the card decides what to render, so it
   // has to hold the reads.
   const providers = [
-    useSessionAccess('slack', orgId, isOwner),
     useSessionAccess('github', orgId, isOwner),
+    useSessionAccess('slack', orgId, isOwner),
     useSessionAccess('feishu', orgId, isOwner)
   ]
   const pending = providers.some((state) => state.access === undefined && !state.loadError)


### PR DESCRIPTION
## What

Reorders the Session access card in Settings so the GitHub row comes first, ahead of Slack and Feishu / Lark. Nothing else changes.

## Why

The card listed Slack first only because that provider shipped first, and that ordering understates which switch an owner actually needs to reach.

GitHub is the one row whose switch narrows a *single* audience. Public-repository sessions stay visible to Everyone whether it is on or off, so turning it on tightens private-repository sessions and nothing else. The Slack and Feishu / Lark switches move a whole platform's sessions at once — which is why an owner arriving at this card is most often here for GitHub, and why it should not be the row they scan past.

## Notes

Ordering only. The provider array drives the render order, so `bordered={index > 0}` follows it and the leading row keeps its borderless top edge. No copy, policy, default, or API change — the CP still defaults every provider to disabled.

## Test plan

- `pnpm --filter @agentconnect.md/web test` — 121 files, 963 tests passing. No test asserts row order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)