### PR TITLE
feat(dream): default auto-adopt memories + mine skills

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -146,11 +146,12 @@ export const MemoryDreamingPolicy = z
     timezone: z.string().min(1).max(64).optional(),
     /** Operator steering text applied through the whole pipeline (≤ 4096 chars). */
     instructions: z.string().max(4096).optional(),
-    /** Also mine reusable procedures into candidate skills (§7). Default false. */
+    /** Also mine reusable procedures into candidate skills (§7). Default true;
+     *  false is the opt-out. Mined skills are always proposals — never auto-installed. */
     mineSkills: z.boolean().optional(),
     /** Adopt the memory store automatically on completion without content
-     *  review. Default false; true is an explicit opt-in. Live-memory fence
-     *  conflicts remain reviewable. Never applies to skills (§7). */
+     *  review. Default true; false is the opt-out. Live-memory fence conflicts
+     *  remain reviewable. Never applies to skills (§7). */
     autoAdopt: z.boolean().optional()
   })
   .strict()
@@ -166,10 +167,12 @@ export const BuiltInMemoryBinding = z
 ```
 
 With managed memory, an absent `dreaming` policy resolves to `{ enabled: true,
-schedule: '0 4 * * *', autoAdopt: false }`. The cron uses daemon-local time when
-no timezone is set. An explicit policy preserves an absent schedule as
-manual-only, while absent `autoAdopt` also normalizes to `false`; `autoAdopt:
-true` is the durable opt-in to automatic acceptance.
+schedule: '0 4 * * *', autoAdopt: true, mineSkills: true }`. The cron uses
+daemon-local time when no timezone is set. An explicit policy preserves an absent
+schedule as manual-only, while absent `autoAdopt` and `mineSkills` normalize to
+the product default (`true`); an explicit `false` is the durable opt-out.
+Auto-adopt is text-only and reversible; mined skills are still proposals that need
+explicit approval before install, so `mineSkills` only surfaces candidates.
 
 `memory-settings.ts` (console) grows a **Background memory** section rendered
 only when the Managed provider is selected, presenting the two mechanisms as

--- a/packages/protocol/src/frames/memory-connection.ts
+++ b/packages/protocol/src/frames/memory-connection.ts
@@ -63,11 +63,13 @@ export const MemoryDreamingPolicy = z
     timezone: z.string().min(1).max(64).optional(),
     /** Operator steering text applied through the whole dream pipeline. */
     instructions: z.string().max(4096).optional(),
-    /** Also mine reusable procedures into candidate skills (never auto-installed). */
+    /** Also mine reusable procedures into candidate skills (never auto-installed —
+     *  a mined skill is always a proposal that needs explicit approval). Absent
+     *  defaults to true; false is the opt-out. */
     mineSkills: z.boolean().optional(),
     /** Adopt the staged store automatically on completion without content
      *  review. Live-memory fence conflicts remain reviewable. Absent defaults
-     *  to false for effective managed-memory policies; true is an explicit opt-in. */
+     *  to true for effective managed-memory policies; false is the opt-out. */
     autoAdopt: z.boolean().optional()
   })
   .strict()
@@ -82,7 +84,12 @@ export type MemoryDreamingPolicy = z.infer<typeof MemoryDreamingPolicy>
 export const DEFAULT_MEMORY_DREAMING_POLICY = {
   enabled: true,
   schedule: '0 4 * * *',
-  autoAdopt: false
+  // By default a completed dream is adopted without review and reusable procedures
+  // are mined into candidate skills. Adoption is text-only and reversible; mined
+  // skills are still proposals that need explicit approval before install (they are
+  // executable), so mining-on only surfaces candidates.
+  autoAdopt: true,
+  mineSkills: true
 } as const satisfies MemoryDreamingPolicy
 
 const BuiltInMemoryBinding = z
@@ -121,9 +128,9 @@ export type AgentMemoryBinding = z.infer<typeof AgentMemoryBinding>
 /** Resolve the managed-memory dreaming policy used by the daemon.
  *
  * No memory binding means the managed provider, and no explicit dreaming policy
- * means the daily, review-first product default. Once a policy exists its absent
- * schedule remains meaningful (manual-only), while absent `autoAdopt` normalizes
- * false; an explicit true is the opt-in.
+ * means the daily product default. Once a policy exists its absent schedule
+ * remains meaningful (manual-only), while absent `autoAdopt` and `mineSkills`
+ * normalize to the product default (true); an explicit false is the opt-out.
  */
 export function effectiveMemoryDreamingPolicy(
   binding: AgentMemoryBinding | undefined
@@ -131,7 +138,7 @@ export function effectiveMemoryDreamingPolicy(
   if (binding && binding.provider !== 'managed') return undefined
   const policy = binding?.dreaming
   if (!policy) return { ...DEFAULT_MEMORY_DREAMING_POLICY }
-  return policy.autoAdopt === undefined ? { ...policy, autoAdopt: false } : policy
+  return { ...policy, autoAdopt: policy.autoAdopt ?? true, mineSkills: policy.mineSkills ?? true }
 }
 
 /** Reviewed mapping from a logical secret field to the header the relay injects. */

--- a/packages/protocol/src/frames/memory-dream.test.ts
+++ b/packages/protocol/src/frames/memory-dream.test.ts
@@ -52,22 +52,24 @@ describe('memory dreaming policy (agent binding)', () => {
     expect(() => MemoryDreamingPolicy.parse({ enabled: true, unknown: 1 })).toThrow()
   })
 
-  it('defaults managed memory to a daily review-first dream while preserving explicit opt-in', () => {
+  it('defaults managed memory to a daily auto-adopting, skill-mining dream while preserving explicit opt-out', () => {
     expect(effectiveMemoryDreamingPolicy(undefined)).toEqual(DEFAULT_MEMORY_DREAMING_POLICY)
     expect(effectiveMemoryDreamingPolicy({ provider: 'managed' })).toEqual(DEFAULT_MEMORY_DREAMING_POLICY)
 
-    // An explicit policy with no schedule is manual-only, and an absent
-    // autoAdopt remains review-first.
+    // An explicit policy with no schedule is manual-only; absent autoAdopt and
+    // mineSkills normalize to the product default (true).
     expect(effectiveMemoryDreamingPolicy({ provider: 'managed', dreaming: { enabled: true } })).toEqual({
       enabled: true,
-      autoAdopt: false
+      autoAdopt: true,
+      mineSkills: true
     })
+    // An explicit false is a durable opt-out.
     expect(
       effectiveMemoryDreamingPolicy({
         provider: 'managed',
-        dreaming: { enabled: true, autoAdopt: true }
+        dreaming: { enabled: true, autoAdopt: false, mineSkills: false }
       })
-    ).toEqual({ enabled: true, autoAdopt: true })
+    ).toEqual({ enabled: true, autoAdopt: false, mineSkills: false })
     expect(effectiveMemoryDreamingPolicy({ provider: 'none' })).toBeUndefined()
   })
 })

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -233,7 +233,7 @@ describe('MemoryPanel file editor', () => {
 })
 
 describe('MemoryPanel settings draft', () => {
-  it('defaults managed memory to daily dreaming and lets users opt in to automatic acceptance', async () => {
+  it('defaults managed memory to daily auto-adopting dreaming and lets users opt out', async () => {
     container = document.createElement('div')
     document.body.append(container)
     root = createRoot(container)
@@ -257,12 +257,14 @@ describe('MemoryPanel settings draft', () => {
 
     expect(checkboxFor('Enable dreaming')?.checked).toBe(true)
     expect(checkboxFor('Run on a schedule')?.checked).toBe(true)
-    expect(checkboxFor('Automatically adopt completed memory results')?.checked).toBe(false)
+    // Auto-adopt is on by default, so the accuracy caveat is shown up front.
+    expect(checkboxFor('Automatically adopt completed memory results')?.checked).toBe(true)
     expect(container.textContent).toContain('Daily')
-    expect(container.textContent).not.toContain('Dream memory results can be inaccurate')
-
-    await act(async () => checkboxFor('Automatically adopt completed memory results')?.click())
     expect(container.textContent).toContain('Dream memory results can be inaccurate')
+
+    // Opt out of automatic acceptance.
+    await act(async () => checkboxFor('Automatically adopt completed memory results')?.click())
+    expect(container.textContent).not.toContain('Dream memory results can be inaccurate')
     const save = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
       (button) => button.textContent === 'Save memory settings'
     )
@@ -272,16 +274,16 @@ describe('MemoryPanel settings draft', () => {
       memory: {
         provider: 'managed',
         autoDistill: false,
-        dreaming: { enabled: true, schedule: '0 4 * * *', autoAdopt: true }
+        dreaming: { enabled: true, schedule: '0 4 * * *', mineSkills: true, autoAdopt: false }
       }
     })
   })
 
-  // Skill mining is off unless the policy says otherwise, and the daemon keys
-  // three separate things off that one flag (the extract-procedures phase, the
-  // tool rows in the prompt, and the grounding set). Without a control here it
-  // could never be turned on, so a dream would silently mine nothing forever.
-  it('turns skill mining on and sends it with the memory binding', async () => {
+  // Skill mining is on by default, and the daemon keys three separate things off
+  // that one flag (the extract-procedures phase, the tool rows in the prompt, and
+  // the grounding set). The control lets a user opt out; turning it off must be
+  // sent explicitly so the daemon does not fall back to the mine-by-default policy.
+  it('turns skill mining off and sends it with the memory binding', async () => {
     container = document.createElement('div')
     document.body.append(container)
     root = createRoot(container)
@@ -303,11 +305,12 @@ describe('MemoryPanel settings draft', () => {
         box.parentElement?.textContent?.includes(text)
       )
 
-    expect(checkboxFor('Also mine reusable skills')?.checked).toBe(false)
-    expect(container.textContent).not.toContain('at least two sessions')
-
-    await act(async () => checkboxFor('Also mine reusable skills')?.click())
+    expect(checkboxFor('Also mine reusable skills')?.checked).toBe(true)
     expect(container.textContent).toContain('at least two sessions')
+
+    // Opt out of skill mining.
+    await act(async () => checkboxFor('Also mine reusable skills')?.click())
+    expect(container.textContent).not.toContain('at least two sessions')
 
     const save = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
       (button) => button.textContent === 'Save memory settings'
@@ -318,7 +321,7 @@ describe('MemoryPanel settings draft', () => {
       memory: {
         provider: 'managed',
         autoDistill: false,
-        dreaming: { enabled: true, schedule: '0 4 * * *', autoAdopt: false, mineSkills: true }
+        dreaming: { enabled: true, schedule: '0 4 * * *', mineSkills: false, autoAdopt: true }
       }
     })
   })
@@ -344,7 +347,8 @@ describe('MemoryPanel settings draft', () => {
     expect(container.querySelector('[data-memory-provider="managed"]')).toBeNull()
     expect(container.textContent).toContain('Managed')
     expect(container.textContent).toContain('Dreaming daily')
-    expect(container.textContent).toContain('Auto-accept off')
+    expect(container.textContent).toContain('Auto-accept on')
+    expect(container.textContent).toContain('Skill mining on')
     expect(container.textContent).toContain('Agent scope')
     expect(container.querySelector('[data-testid="file-memory-view"]')).not.toBeNull()
 

--- a/packages/web/src/components/console/memory-settings.test.ts
+++ b/packages/web/src/components/console/memory-settings.test.ts
@@ -91,13 +91,14 @@ describe('memory settings UX model', () => {
     ).toMatchObject({ provider: 'external', connectionId: CONNECTION_A })
   })
 
-  it('models daily dreaming with review-first adoption and a durable opt-in', () => {
+  it('models daily dreaming that auto-adopts and mines skills by default, with durable opt-outs', () => {
     const defaults = memorySettingsDraft({ provider: 'managed', autoDistill: false })
     expect(defaults.dreaming).toEqual({
       enabled: true,
       instructions: '',
       schedule: '0 4 * * *',
-      autoAdopt: false
+      autoAdopt: true,
+      mineSkills: true
     })
     expect(memoryConfigForDraft(defaults)).toEqual({ provider: 'managed', autoDistill: false })
     expect(dreamingConfigForDraft(defaults.dreaming)).toBeUndefined()
@@ -110,21 +111,21 @@ describe('memory settings UX model', () => {
     expect(memoryConfigForDraft(manualReview)).toEqual({
       provider: 'managed',
       autoDistill: false,
-      dreaming: { enabled: true, autoAdopt: false }
+      dreaming: { enabled: true, mineSkills: true, autoAdopt: false }
     })
 
     const disabled = { ...defaults, dreaming: { ...defaults.dreaming, enabled: false } }
     expect(memoryConfigForDraft(disabled)).toEqual({
       provider: 'managed',
       autoDistill: false,
-      dreaming: { enabled: false, schedule: '0 4 * * *', autoAdopt: false }
+      dreaming: { enabled: false, schedule: '0 4 * * *', mineSkills: true, autoAdopt: true }
     })
 
-    const automatic = { ...defaults, dreaming: { ...defaults.dreaming, autoAdopt: true } }
-    expect(memoryConfigForDraft(automatic)).toEqual({
+    const noSkills = { ...defaults, dreaming: { ...defaults.dreaming, mineSkills: false } }
+    expect(memoryConfigForDraft(noSkills)).toEqual({
       provider: 'managed',
       autoDistill: false,
-      dreaming: { enabled: true, schedule: '0 4 * * *', autoAdopt: true }
+      dreaming: { enabled: true, schedule: '0 4 * * *', mineSkills: false, autoAdopt: true }
     })
   })
 

--- a/packages/web/src/components/console/memory-settings.ts
+++ b/packages/web/src/components/console/memory-settings.ts
@@ -23,13 +23,15 @@ export interface DreamingDraft {
   mineSkills?: boolean
 }
 
-/** Managed memory dreams daily at 04:00 in the daemon host's timezone and
- * leaves every result for review unless the user explicitly opts in to adoption. */
+/** Managed memory dreams daily at 04:00 in the daemon host's timezone. By default
+ * completed dreams are adopted without review and reusable procedures are mined
+ * into candidate skills (mined skills still need explicit approval to install). */
 export const DEFAULT_DREAMING_DRAFT: DreamingDraft = {
   enabled: true,
   instructions: '',
   schedule: '0 4 * * *',
-  autoAdopt: false
+  autoAdopt: true,
+  mineSkills: true
 }
 
 export type MemoryProviderChoice = 'managed' | 'native' | 'external' | 'none'
@@ -95,11 +97,11 @@ export function memorySettingsDraft(input: {
       ? {
           enabled: input.dreaming.enabled,
           instructions: input.dreaming.instructions ?? '',
-          autoAdopt: input.dreaming.autoAdopt ?? false,
+          autoAdopt: input.dreaming.autoAdopt ?? true,
           ...(input.dreaming.sessionWindow !== undefined ? { sessionWindow: input.dreaming.sessionWindow } : {}),
           ...(input.dreaming.schedule ? { schedule: input.dreaming.schedule } : {}),
           ...(input.dreaming.timezone ? { timezone: input.dreaming.timezone } : {}),
-          ...(input.dreaming.mineSkills !== undefined ? { mineSkills: input.dreaming.mineSkills } : {})
+          mineSkills: input.dreaming.mineSkills ?? true
         }
       : { ...DEFAULT_DREAMING_DRAFT },
     external: {
@@ -196,7 +198,7 @@ export function dreamingConfigForDraft(draft: DreamingDraft): MemoryDreamingConf
     schedule !== DEFAULT_DREAMING_DRAFT.schedule ||
     !!draft.timezone ||
     draft.sessionWindow !== undefined ||
-    draft.mineSkills !== undefined ||
+    (draft.mineSkills ?? DEFAULT_DREAMING_DRAFT.mineSkills) !== DEFAULT_DREAMING_DRAFT.mineSkills ||
     draft.autoAdopt !== DEFAULT_DREAMING_DRAFT.autoAdopt
   if (!hasAny) return undefined
   return {
@@ -205,7 +207,7 @@ export function dreamingConfigForDraft(draft: DreamingDraft): MemoryDreamingConf
     ...(schedule ? { schedule } : {}),
     ...(draft.timezone ? { timezone: draft.timezone } : {}),
     ...(instructions ? { instructions } : {}),
-    ...(draft.mineSkills !== undefined ? { mineSkills: draft.mineSkills } : {}),
+    mineSkills: draft.mineSkills ?? DEFAULT_DREAMING_DRAFT.mineSkills,
     autoAdopt: draft.autoAdopt
   }
 }


### PR DESCRIPTION
Per @pchsu: by default, auto-accept dream-generated memories and turn on skill mining.

## Change

Managed-memory dreaming now defaults to **auto-adopting** completed memory results and **mining** reusable skills (both were previously off — review-first / mining-off).

- **protocol** `DEFAULT_MEMORY_DREAMING_POLICY`: `autoAdopt: true` + `mineSkills: true`. `effectiveMemoryDreamingPolicy` normalizes an absent `autoAdopt`/`mineSkills` on an explicit policy to the product default (`true`); an explicit `false` is the durable opt-out. (The daemon already resolves the effective policy through this function, so runtime behavior follows.)
- **web console**: `DEFAULT_DREAMING_DRAFT` + the draft parse/serialize reflect the new defaults — the form shows both on, a matches-default form saves no explicit policy, and toggling either off persists an explicit `false`.

## Skills still need approval (answering "it always need approval right?")

Yes. A mined skill is **always a proposal** that needs explicit approval before install — it is executable code the agent will run, so `maybeAutoAdopt` only ever adopts memory text, never skills. This PR only turns **mining on by default** (so candidates get surfaced); it does not auto-install skills. Auto-adopt of memory is text-only and reversible. If you also want to auto-accept mined skills, that's a separate, riskier opt-in I'd recommend keeping off — happy to add it behind a flag if you want.

## Tests

- protocol: effective-policy default (auto-adopt + mine-skills on; explicit `false` preserved).
- web: `memory-settings` round-trip, `MemoryPanel` default-on / opt-out flows, collapsed summary ("Auto-accept on", "Skill mining on").

🤖 Generated with [Claude Code](https://claude.com/claude-code)