### PR TITLE
fix(cp): name the Slack error behind a degraded session-access check

### DIFF
--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -220,9 +220,126 @@ describe('SlackSessionAccessService', () => {
     await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
 
     expect(warn).toHaveBeenCalledTimes(1)
-    expect(warn.mock.calls[0]?.[0]).toEqual({ provider: 'slack', unknownScopes: 1, totalScopes: 1 })
+    expect(warn.mock.calls[0]?.[0]).toEqual({
+      provider: 'slack',
+      unknownScopes: 1,
+      totalScopes: 1,
+      reasons: { ratelimited: 1 }
+    })
     // A scope key names a channel; the operator needs the rate, not the target.
     expect(JSON.stringify(warn.mock.calls[0]?.[0])).not.toContain('C_')
+  })
+
+  // Slack refuses over HTTP 200 with `ok: false`, so its code is the ONLY thing
+  // that separates a missing OAuth scope from rate limiting from an outage —
+  // and a rate with no cause cannot be acted on. Without this, diagnosing a
+  // steady stream of degraded resolves means reaching for production traces.
+  it('names the Slack error a degraded check failed on', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.includes('conversations.info')
+        ? json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+        : json({ ok: false, error: 'missing_scope' })
+    )
+
+    const result = await service(fetchImpl, { warn }).resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+    // Unchanged: it still fails closed. Only the diagnosis is new.
+    expect(result).toEqual({ allowedScopes: [], degraded: true })
+    expect(warn.mock.calls[0]?.[0]).toEqual({
+      provider: 'slack',
+      unknownScopes: 1,
+      totalScopes: 1,
+      reasons: { missing_scope: 1 }
+    })
+  })
+
+  it('aggregates a mixed batch by code, one reason per hidden scope', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('C_CHANNEL_3')) {
+        return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+      }
+      if (url.includes('users.info')) return json({ ok: true, user: { team_id: 'T_INSTALL' } })
+      return json({ ok: false, error: url.includes('C_CHANNEL_1') ? 'missing_scope' : 'ratelimited' })
+    })
+    const scopes = [scopeAt(1), scopeAt(2), scopeAt(3)]
+
+    await service(fetchImpl, { warn }).resolve(scopes, viewer('slack:T_INSTALL:U_MEMBER'))
+
+    const payload = warn.mock.calls[0]?.[0] as { unknownScopes: number; reasons: Record<string, number> }
+    expect(payload).toEqual({
+      provider: 'slack',
+      unknownScopes: 2,
+      totalScopes: 3,
+      reasons: { missing_scope: 1, ratelimited: 1 }
+    })
+    // The counts partition the hidden scopes, so one code's share of an hour of
+    // these lines is readable as a share of the sessions actually hidden.
+    const counted = Object.values(payload.reasons).reduce((sum, count) => sum + count, 0)
+    expect(counted).toBe(payload.unknownScopes)
+  })
+
+  it('reports a failure on this side of the call rather than a Slack code', async () => {
+    const warn = vi.fn()
+    // A body is present, but the status means it was never read.
+    const resolver = service(async () => json({ ok: false, error: 'ratelimited' }, 500), { warn })
+
+    await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+    expect(warn.mock.calls[0]?.[0]).toMatchObject({ reasons: { http_500: 1 } })
+  })
+
+  // The reason is a CAUSE, never a TARGET. Slack's error vocabulary is
+  // lowercase words and every Slack id is uppercase-prefixed, so anything
+  // id-shaped arriving in `error` is reported as its shape and dropped —
+  // a warn that names channels is the one thing this log must never become.
+  it('drops an error payload outside Slack error vocabulary', async () => {
+    const warn = vi.fn()
+    const resolver = service(async () => json({ ok: false, error: 'C_PRIVATE_CHANNEL' }), { warn })
+
+    await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+    expect(warn.mock.calls[0]?.[0]).toMatchObject({ reasons: { unrecognized_error: 1 } })
+    expect(JSON.stringify(warn.mock.calls[0]?.[0])).not.toContain('C_PRIVATE_CHANNEL')
+  })
+
+  it('carries no identifier of what was hidden, and no credential', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.includes('conversations.info')
+        ? json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+        : json({ ok: false, error: 'missing_scope' })
+    )
+
+    await service(fetchImpl, { warn }).resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+    const logged = JSON.stringify(warn.mock.calls[0]?.[0])
+    // Channel, workspace, viewer, scope row — and the bot token, which
+    // `shouldIgnoreUndiciRequest` keeps out of telemetry for the same reason.
+    for (const identifier of ['C_CHANNEL', 'T_INSTALL', 'U_MEMBER', scope().id, 'xoxb']) {
+      expect(logged).not.toContain(identifier)
+    }
+  })
+
+  // A resolve riding a cached `unknown` is the one that would otherwise report
+  // a rate with no cause — the cache holds the reason, not just the verdict.
+  it('still reports the cause when the verdict came from cache', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.includes('conversations.info')
+        ? json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+        : json({ ok: false, error: 'missing_scope' })
+    )
+    const resolver = service(fetchImpl, { warn })
+
+    await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+    const afterFirst = fetchImpl.mock.calls.length
+    await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+    expect(fetchImpl.mock.calls.length).toBe(afterFirst)
+    expect(warn).toHaveBeenCalledTimes(2)
+    expect(warn.mock.calls[1]?.[0]).toEqual(warn.mock.calls[0]?.[0])
   })
 
   it('stays silent when every check answered', async () => {

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -33,9 +33,60 @@ type ConversationAudience = 'public' | 'members' | 'gone' | 'unknown'
 type WorkspaceAccess = 'allow' | 'membership' | 'deny' | 'unknown'
 type SlackPrincipal = { key: string; teamId: string; userId: string }
 
-type ObservedAudience = { audience: ConversationAudience; fetchedAt: number }
+/**
+ * Why a check could not answer, as one low-cardinality label.
+ *
+ * Slack refuses over HTTP 200 with `ok: false`, so `body.error` is the only
+ * thing separating `missing_scope` from `ratelimited` from an outage — and
+ * every reader below used to drop it, leaving the warn in `resolve` reporting a
+ * rate with no cause. The reason rides along with the verdict instead, so that
+ * one line can name it.
+ *
+ * A reason is a CAUSE, never a TARGET: Slack's own code, or a `LocalReason`.
+ * Nothing derived from a channel, conversation, user, team, or scope may become
+ * one — `slackErrorReason` holds the provider half of that line.
+ */
+type DegradedReason = string
+
+/**
+ * The failures this file names itself, as against the ones Slack names. They
+ * cannot be read as a Slack code: Slack has no `bot_*`, no `*_unclassified`,
+ * no `request_*`, and no `http_*`.
+ *
+ * One union keeps the vocabulary an operator greps for in one block, and
+ * `unresolved` takes it, so the labels raised here are checked rather than
+ * free strings.
+ */
+type LocalReason =
+  | 'bot_unresolved'
+  | 'bot_token_missing'
+  /** The shared audience entry was dropped while this caller was reading it. */
+  | 'audience_evicted'
+  /** Slack answered, in a shape no verdict can be read out of. */
+  | 'audience_unclassified'
+  | 'user_unclassified'
+  | 'members_unclassified'
+  | 'member_pages_exhausted'
+  /** `ok: false` carrying something outside Slack's own error vocabulary. */
+  | 'unrecognized_error'
+  | 'request_timeout'
+  | 'request_aborted'
+  | 'transport_failure'
+  | `http_${number}`
+
+/** A verdict, plus — when it is `unknown` — why the check could not answer. */
+type Verdict = { decision: Decision; reason?: DegradedReason }
+/** Slack answered `ok: false`: a definitive denial, or a check that could not
+ *  run and the code Slack gave for it. */
+type FailureVerdict = { decision: 'deny' } | { decision: 'unknown'; reason: DegradedReason }
+/** What one `conversations.info` said. */
+type ReadAudience =
+  | { audience: Exclude<ConversationAudience, 'unknown'>; reason?: undefined }
+  | { audience: 'unknown'; reason: DegradedReason }
+type ObservedAudience = ReadAudience & { fetchedAt: number }
 /** A verdict plus the age of the oldest evidence it rests on. */
-type CheckedAccess = { decision: Decision; evidenceAt: number }
+type CheckedAccess = Verdict & { evidenceAt: number }
+type CheckedWorkspaceAccess = { access: WorkspaceAccess; reason?: DegradedReason }
 type AudienceLookup = { channel: string; token: string; signal: AbortSignal }
 
 // `ok: false` covers two very different answers, and conflating them is what
@@ -56,6 +107,56 @@ const DEFINITIVE_DENIALS = new Set([
 
 function failureDecision(error: unknown): Decision {
   return typeof error === 'string' && DEFINITIVE_DENIALS.has(error) ? 'deny' : 'unknown'
+}
+
+/**
+ * Slack's error vocabulary is lowercase snake_case words. Every Slack object id
+ * — channel, conversation, user, team, enterprise, app — is uppercase-prefixed,
+ * and an address carries `@`, so this shape check is not decoration: it is what
+ * stops an unexpected `error` payload from turning the warn in `resolve` into
+ * somewhere a channel could be named. Anything that is not one of Slack's own
+ * words is reported as its shape and its content dropped.
+ */
+const SLACK_ERROR_CODE = /^[a-z][a-z0-9_]{0,47}$/
+
+function slackErrorReason(error: unknown): DegradedReason {
+  return typeof error === 'string' && SLACK_ERROR_CODE.test(error) ? error : 'unrecognized_error'
+}
+
+/** `failureDecision`, carrying the code Slack gave when the answer was that the
+ *  check could not run. Which codes are a definitive denial is unchanged. */
+function failureVerdict(error: unknown): FailureVerdict {
+  return failureDecision(error) === 'deny'
+    ? { decision: 'deny' }
+    : { decision: 'unknown', reason: slackErrorReason(error) }
+}
+
+/** An `unknown` this file raises on its own behalf. Going through one
+ *  constructor is what makes the label a checked `LocalReason`; the other
+ *  `unknown`s relay a code Slack gave. */
+function unresolved(reason: LocalReason): { decision: 'unknown'; reason: DegradedReason } {
+  return { decision: 'unknown', reason }
+}
+
+/** Carries a reason across the throw, so the catch in `checkAccess` can report
+ *  which failure it caught rather than one undifferentiated bucket. */
+class SlackCallFailed extends Error {
+  constructor(readonly reason: LocalReason) {
+    super(`Slack request failed: ${reason}`)
+    this.name = 'SlackCallFailed'
+  }
+}
+
+function thrownReason(error: unknown): LocalReason {
+  if (error instanceof SlackCallFailed) return error.reason
+  if (!(error instanceof Error)) return 'transport_failure'
+  // `AbortSignal.timeout` surfaces as a TimeoutError — directly, or as the
+  // `cause` of the AbortError `fetch` rejects with. Worth separating from a
+  // plain abort: one says the batch ran out of its budget, the other that
+  // something cancelled the request.
+  const cause = error.cause instanceof Error ? error.cause.name : ''
+  if (error.name === 'TimeoutError' || cause === 'TimeoutError') return 'request_timeout'
+  return error.name === 'AbortError' ? 'request_aborted' : 'transport_failure'
 }
 
 function slackPrincipals(identitySet: ReadonlySet<string>): SlackPrincipal[] {
@@ -86,9 +187,11 @@ async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value:
  * verdicts; linked identity remains request-local and provider-owned. */
 export class SlackSessionAccessService implements SessionAccessPlugin {
   readonly provider = 'slack'
-  /** Per-principal verdicts. Every entry carries its own TTL — see `putCache`. */
-  private readonly cache: LRUCache<string, Decision>
-  private readonly workspaceAccessCache: LRUCache<string, WorkspaceAccess>
+  /** Per-principal verdicts. Every entry carries its own TTL — see `putCache`.
+   *  A cached `unknown` keeps the reason it was reached by, so a resolve that
+   *  rides one is not the one degraded resolve that cannot say why. */
+  private readonly cache: LRUCache<string, Verdict>
+  private readonly workspaceAccessCache: LRUCache<string, CheckedWorkspaceAccess>
   /** (bot, credential revision, channel) → audience. Shared across viewers,
    *  unlike `cache` and `workspaceAccessCache`, which are per principal.
    *  `fetch` hands concurrent callers of one key the same promise, and drops
@@ -116,7 +219,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
       ...cacheOptions(deps.clock, MAX_CACHE_ENTRIES),
       ttl: AUDIENCE_TTL_MS,
       fetchMethod: async (_key, _stale, { context }) => ({
-        audience: await this.conversationAudience(context.channel, context.token, context.signal),
+        ...(await this.conversationAudience(context.channel, context.token, context.signal)),
         fetchedAt: deps.clock.now()
       })
     })
@@ -137,36 +240,46 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     const principals = slackPrincipals(viewer.identitySet)
     if (principals.length === 0 || scopes.length === 0) return { allowedScopes: [], degraded: false }
     let degraded = false
-    const decisions: Array<{ scope: ExternalScopeRecord; decision: Decision }> = []
+    const decisions: Array<{ scope: ExternalScopeRecord; verdict: Verdict }> = []
     // 200 is a provider-work batch, never a visibility ceiling. Walk every
     // batch so UUID ordering cannot silently hide an otherwise-allowed scope.
     for (let start = 0; start < scopes.length; start += SCOPES_PER_BATCH) {
       const signal = AbortSignal.timeout(TIMEOUT_MS)
       decisions.push(
         ...(await mapLimited(scopes.slice(start, start + SCOPES_PER_BATCH), SCOPE_CONCURRENCY, async (scope) => {
-          const decision = await this.resolveScope(scope, principals, signal)
-          if (decision === 'unknown') degraded = true
-          return { scope, decision }
+          const verdict = await this.resolveScope(scope, principals, signal)
+          if (verdict.decision === 'unknown') degraded = true
+          return { scope, verdict }
         }))
       )
     }
     // One line per degraded RESOLVE, not per scope: enough to correlate a user
     // reporting a vanished conversation with a Slack-side blip, without a log
-    // entry per channel on a busy list. Counts only — a scope key names a
-    // channel, and the operator needs the rate, not the targets.
+    // entry per channel on a busy list. Counts and causes only — a scope key
+    // names a channel, and the operator needs the rate and the reason, not the
+    // targets. So `reasons` aggregates by CODE — Slack's own word for the
+    // refusal, or a `LocalReason` — and never by conversation: one bucket may
+    // cover many channels, but no bucket can name one. Its counts sum to
+    // `unknownScopes`, since a scope reports the first cause that hid it.
     if (degraded) {
+      const reasons = new Map<DegradedReason, number>()
+      let unknownScopes = 0
+      for (const { verdict } of decisions) {
+        if (verdict.decision !== 'unknown') continue
+        unknownScopes += 1
+        // `unreported` cannot be reached today — every `unknown` below names a
+        // cause — and is what a future path that forgot to would look like.
+        const reason = verdict.reason ?? 'unreported'
+        reasons.set(reason, (reasons.get(reason) ?? 0) + 1)
+      }
       this.deps.log?.warn(
-        {
-          provider: 'slack',
-          unknownScopes: decisions.filter(({ decision }) => decision === 'unknown').length,
-          totalScopes: decisions.length
-        },
+        { provider: 'slack', unknownScopes, totalScopes: decisions.length, reasons: Object.fromEntries(reasons) },
         'slack access check degraded — affected sessions are hidden until access can be verified'
       )
     }
     return {
       allowedScopes: decisions
-        .filter(({ decision }) => decision === 'allow')
+        .filter(({ verdict }) => verdict.decision === 'allow')
         .map(({ scope }) => ({ id: scope.id, aclRevision: scope.aclRevision })),
       degraded
     }
@@ -176,7 +289,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     scope: ExternalScopeRecord,
     principals: readonly SlackPrincipal[],
     signal: AbortSignal
-  ): Promise<Decision> {
+  ): Promise<Verdict> {
     if (
       scope.provider !== 'slack' ||
       scope.resourceKind !== 'conversation' ||
@@ -184,7 +297,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
       scope.credentialKind !== 'bot' ||
       !scope.credentialId
     ) {
-      return 'deny'
+      return { decision: 'deny' }
     }
     // The credential behind a session's recorded external scope — system state,
     // resolved without an org (org-scoped-data-layer.md §4). The scope row is
@@ -198,21 +311,29 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
       bot.revokedAt !== null ||
       realm !== scope.realmKey
     ) {
-      return 'unknown'
+      return unresolved('bot_unresolved')
     }
-    let sawUnknown = false
+    let unknownReason: DegradedReason | undefined
     for (const principal of principals) {
       const key = [scope.id, scope.aclRevision.toString(), bot.credentialRevision, principal.key].join(':')
-      let decision = this.cache.get(key)
-      if (!decision) {
-        const checked = await this.checkAccess(scope, principal, bot.id, bot.credentialRevision, signal)
-        decision = checked.decision
-        this.putCache(key, decision, checked.evidenceAt)
+      let verdict = this.cache.get(key)
+      if (!verdict) {
+        const { evidenceAt, ...checked } = await this.checkAccess(
+          scope,
+          principal,
+          bot.id,
+          bot.credentialRevision,
+          signal
+        )
+        verdict = checked
+        this.putCache(key, verdict, evidenceAt)
       }
-      if (decision === 'allow') return 'allow'
-      if (decision === 'unknown') sawUnknown = true
+      if (verdict.decision === 'allow') return verdict
+      // The FIRST cause is kept, not the last, so one degraded scope reports
+      // one reason and the counts in `resolve` still sum to `unknownScopes`.
+      if (verdict.decision === 'unknown') unknownReason ??= verdict.reason ?? 'unreported'
     }
-    return sawUnknown ? 'unknown' : 'deny'
+    return unknownReason ? { decision: 'unknown', reason: unknownReason } : { decision: 'deny' }
   }
 
   private async checkAccess(
@@ -224,7 +345,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
   ): Promise<CheckedAccess> {
     const now = this.deps.clock.now()
     const secret = await this.deps.botSecrets.get(scope.orgId, BotId(botId)).catch(() => null)
-    if (!secret?.botToken) return { decision: 'unknown', evidenceAt: now }
+    if (!secret?.botToken) return { ...unresolved('bot_token_missing'), evidenceAt: now }
     try {
       const observed = await this.audienceOf(
         [botId, credentialRevision, scope.resourceKey].join(':'),
@@ -233,34 +354,42 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
         signal
       )
       // Only reachable if the entry is dropped mid-flight; fail closed.
-      if (!observed) return { decision: 'unknown', evidenceAt: now }
+      if (!observed) return { ...unresolved('audience_evicted'), evidenceAt: now }
       const evidenceAt = observed.fetchedAt
       // The conversation is gone (or the bot is no longer in it): a settled fact
       // about the audience, not an unavailable check.
       if (observed.audience === 'gone') return { decision: 'deny', evidenceAt }
-      if (observed.audience === 'unknown') return { decision: 'unknown', evidenceAt }
+      if (observed.audience === 'unknown') return { decision: 'unknown', reason: observed.reason, evidenceAt }
       if (observed.audience === 'public') {
-        const access = await this.workspaceAccess(
+        const { access, ...cause } = await this.workspaceAccess(
           scope.realmKey,
           principal,
           credentialRevision,
           secret.botToken,
           signal
         )
-        if (access !== 'membership') return { decision: access, evidenceAt }
+        if (access !== 'membership') return { decision: access, ...cause, evidenceAt }
         const member = await this.checkMembership(scope.resourceKey, principal.userId, secret.botToken, signal)
-        return { decision: member, evidenceAt }
+        return { ...member, evidenceAt }
       }
 
       const member = await this.checkMembership(scope.resourceKey, principal.userId, secret.botToken, signal)
-      if (member !== 'allow' || principal.teamId === scope.realmKey) return { decision: member, evidenceAt }
+      if (member.decision !== 'allow' || principal.teamId === scope.realmKey) return { ...member, evidenceAt }
 
       // Slack Connect can return a member from another workspace. Verify the
       // identity's home team instead of treating the installing team as proof.
-      const access = await this.workspaceAccess(scope.realmKey, principal, credentialRevision, secret.botToken, signal)
-      return { decision: access === 'unknown' || access === 'deny' ? access : 'allow', evidenceAt }
-    } catch {
-      return { decision: 'unknown', evidenceAt: now }
+      const { access, ...cause } = await this.workspaceAccess(
+        scope.realmKey,
+        principal,
+        credentialRevision,
+        secret.botToken,
+        signal
+      )
+      return access === 'unknown' || access === 'deny'
+        ? { decision: access, ...cause, evidenceAt }
+        : { decision: 'allow', evidenceAt }
+    } catch (error) {
+      return { ...unresolved(thrownReason(error)), evidenceAt: now }
     }
   }
 
@@ -279,25 +408,24 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     return observed
   }
 
-  private async conversationAudience(
-    channel: string,
-    token: string,
-    signal: AbortSignal
-  ): Promise<ConversationAudience> {
+  private async conversationAudience(channel: string, token: string, signal: AbortSignal): Promise<ReadAudience> {
     const body = await this.slackCall<{
       ok?: boolean
       error?: unknown
       channel?: { is_private?: unknown; is_im?: unknown; is_mpim?: unknown }
     }>(`conversations.info?channel=${encodeURIComponent(channel)}`, token, signal)
-    if (!body.ok) return failureDecision(body.error) === 'deny' ? 'gone' : 'unknown'
-    if (!body.channel) return 'unknown'
+    if (!body.ok) {
+      const failure = failureVerdict(body.error)
+      return failure.decision === 'deny' ? { audience: 'gone' } : { audience: 'unknown', reason: failure.reason }
+    }
+    if (!body.channel) return { audience: 'unknown', reason: 'audience_unclassified' }
     if (body.channel.is_private === false && body.channel.is_im !== true && body.channel.is_mpim !== true) {
-      return 'public'
+      return { audience: 'public' }
     }
     if (body.channel.is_private === true || body.channel.is_im === true || body.channel.is_mpim === true) {
-      return 'members'
+      return { audience: 'members' }
     }
-    return 'unknown'
+    return { audience: 'unknown', reason: 'audience_unclassified' }
   }
 
   private async workspaceAccess(
@@ -306,7 +434,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     credentialRevision: number,
     token: string,
     signal: AbortSignal
-  ): Promise<WorkspaceAccess> {
+  ): Promise<CheckedWorkspaceAccess> {
     const key = [realmKey, credentialRevision, principal.key].join(':')
     const cached = this.workspaceAccessCache.get(key)
     if (cached) return cached
@@ -330,9 +458,14 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
       }
     }>(`users.info?user=${encodeURIComponent(principal.userId)}`, token, signal)
 
-    // A user Slack does not know in this workspace is a verdict, not an outage.
-    let access: WorkspaceAccess = body.ok ? 'unknown' : failureDecision(body.error) === 'deny' ? 'deny' : 'unknown'
-    if (body.ok && body.user) {
+    // The initial value covers `ok` with no `user`: Slack answered, in a shape
+    // no verdict can be read out of.
+    let checked: CheckedWorkspaceAccess = { access: 'unknown', reason: 'user_unclassified' }
+    if (!body.ok) {
+      const failure = failureVerdict(body.error)
+      // A user Slack does not know in this workspace is a verdict, not an outage.
+      checked = failure.decision === 'deny' ? { access: 'deny' } : { access: 'unknown', reason: failure.reason }
+    } else if (body.user) {
       const teams = new Set<string>()
       if (typeof body.user.team_id === 'string') teams.add(body.user.team_id)
       if (typeof body.user.profile?.team === 'string') teams.add(body.user.profile.team)
@@ -347,7 +480,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
         body.user.is_profile_only_user === true ||
         body.user.is_invited_user === true
       ) {
-        access = 'deny'
+        checked = { access: 'deny' }
       } else if (
         !teams.has(realmKey) ||
         body.user.is_restricted === true ||
@@ -355,21 +488,16 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
         body.user.is_stranger === true ||
         body.user.is_external === true
       ) {
-        access = 'membership'
+        checked = { access: 'membership' }
       } else {
-        access = 'allow'
+        checked = { access: 'allow' }
       }
     }
-    this.putWorkspaceAccess(key, access)
-    return access
+    this.putWorkspaceAccess(key, checked)
+    return checked
   }
 
-  private async checkMembership(
-    channel: string,
-    userId: string,
-    token: string,
-    signal: AbortSignal
-  ): Promise<Decision> {
+  private async checkMembership(channel: string, userId: string, token: string, signal: AbortSignal): Promise<Verdict> {
     let cursor = ''
     for (let page = 0; page < MAX_MEMBER_PAGES; page++) {
       const query = new URLSearchParams({ channel, limit: String(PAGE_SIZE) })
@@ -380,14 +508,14 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
         members?: unknown
         response_metadata?: { next_cursor?: unknown }
       }>(`conversations.members?${query}`, token, signal)
-      if (!body.ok) return failureDecision(body.error)
-      if (!Array.isArray(body.members)) return 'unknown'
-      if (body.members.includes(userId)) return 'allow'
+      if (!body.ok) return failureVerdict(body.error)
+      if (!Array.isArray(body.members)) return unresolved('members_unclassified')
+      if (body.members.includes(userId)) return { decision: 'allow' }
       cursor = typeof body.response_metadata?.next_cursor === 'string' ? body.response_metadata.next_cursor : ''
-      if (!cursor) return 'deny'
-      if (page === MAX_MEMBER_PAGES - 1) return 'unknown'
+      if (!cursor) return { decision: 'deny' }
+      if (page === MAX_MEMBER_PAGES - 1) return unresolved('member_pages_exhausted')
     }
-    return 'unknown'
+    return unresolved('member_pages_exhausted')
   }
 
   private async slackCall<T>(path: string, token: string, signal: AbortSignal): Promise<T> {
@@ -396,11 +524,12 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
       headers: { authorization: `Bearer ${token}` },
       signal
     })
-    if (!response.ok) throw new Error(`Slack request failed: ${response.status}`)
+    if (!response.ok) throw new SlackCallFailed(`http_${response.status}`)
     return (await response.json()) as T
   }
 
-  private putCache(key: string, decision: Decision, evidenceAt: number): void {
+  private putCache(key: string, verdict: Verdict, evidenceAt: number): void {
+    const { decision } = verdict
     const ttl = decision === 'allow' ? ALLOW_TTL_MS : decision === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
     // An `allow` is leased from the EVIDENCE it rests on — `start` is the
     // observation, not the reuse — so serving a cached audience can never
@@ -408,11 +537,12 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     // `deny` and `unknown` run from now: reused evidence can only narrow
     // access, never widen it, so there is nothing to bound.
     const start = decision === 'allow' ? Math.min(evidenceAt, this.deps.clock.now()) : undefined
-    this.cache.set(key, decision, { ttl, ...(start !== undefined ? { start } : {}) })
+    this.cache.set(key, verdict, { ttl, ...(start !== undefined ? { start } : {}) })
   }
 
-  private putWorkspaceAccess(key: string, access: WorkspaceAccess): void {
+  private putWorkspaceAccess(key: string, checked: CheckedWorkspaceAccess): void {
+    const { access } = checked
     const ttl = access === 'allow' ? ALLOW_TTL_MS : access === 'unknown' ? UNKNOWN_TTL_MS : DENY_TTL_MS
-    this.workspaceAccessCache.set(key, access, { ttl })
+    this.workspaceAccessCache.set(key, checked, { ttl })
   }
 }


### PR DESCRIPTION
## Why

A degraded Slack access check hides sessions and surfaces "Session access checks unavailable" in the console. In production that path fires steadily — about once a minute — and **the cause cannot currently be determined**:

- the no-network branches in `resolveScope` are not it (the scope, bot, and secret rows all check out for the scope that fails consistently);
- membership pagination and the 5 s batch abort are not it (1–2 pages per trace, p50 160 ms);
- there is no HTTP failure to find — every call to Slack returns 200.

So Slack is answering `ok: false` over HTTP 200, and `failureDecision()` maps anything outside its five definitive-denial codes to `unknown`, which fails closed. `body.error` was then discarded by `conversationAudience`, `workspaceAccess`, and `checkMembership` alike, and the one log line carried counts only. The `bot` table stores no granted OAuth scopes, so the answer is not recoverable from persisted state either.

## What this does

The reason now travels with the verdict, and the existing `log.warn` aggregates it by code:

```
{ provider: 'slack', unknownScopes: 13, totalScopes: 41, reasons: { missing_scope: 12, ratelimited: 1 } }
```

A reason is Slack's own code when Slack gave one, or one of a fixed set of local labels when the failure was on this side — no credential, a body no verdict can be read out of, a timeout, an abort, a non-200. Both caches carry it too, so a resolve riding a cached `unknown` is not the one degraded resolve that cannot say why. The counts partition the hidden scopes: one scope reports the first cause that hid it, so they sum to `unknownScopes`.

**Diagnosis only.** Fail-closed behaviour, the TTLs, `failureDecision`'s classification, and the app's OAuth scopes are untouched — once the code is known the real fix is a choice, and changing behaviour now would be guessing.

## Privacy

The warn deliberately reported counts only, because a scope key names a channel. That discipline is what shaped this:

- aggregation is by **cause**, never by target — one bucket may cover many channels, but no bucket can name one;
- no conversation, scope, user, or team identifier, and no bot token, reaches the line (`shouldIgnoreUndiciRequest` in `observability.ts` keeps provider credentials out of telemetry for the same reason);
- a code is admitted only if it matches Slack's lowercase snake_case error vocabulary. Every Slack object id is uppercase-prefixed and an address carries `@`, so an unexpected `error` payload is reported as its shape (`unrecognized_error`) rather than echoed. A test pins that.

No span attribute: the CP has no existing active-span attribute pattern (only a metrics counter in `observability/webchat-mcp.ts`), and the warn is where an operator already looks for this.

## GitHub and Feishu

Both have a version of the same gap; neither is bundled here.

- **GitHub** is worse off — `GithubSessionAccessService` takes no logger at all, so a degraded GitHub resolve is silent everywhere. Closing it means adding the dependency and its container wiring plus a reason vocabulary of its own: a different change, and not the one firing.
- **Feishu** is partly covered — it already classifies into `authorization | quota | unavailable` and surfaces that through `accessIssues`. The provider's numeric `code` is still collapsed inside `unavailable`, so the same detail is missing one level down.

Symmetry is worth having, but as follow-ups: this PR is scoped to the provider under investigation.

## Verification

- `pnpm --filter @agentconnect.md/control-plane typecheck` ✅
- `pnpm --filter @agentconnect.md/control-plane test:unit` ✅ 1318 passed
- `pnpm --filter @agentconnect.md/control-plane test:int` ✅ 1052 passed
- `eslint` + `prettier --check` on both touched files ✅

Six new unit tests on the existing fake-`fetchImpl` harness: the Slack code reaches the log; a mixed batch aggregates by code with counts summing to `unknownScopes`; a non-200 reports `http_500`; an id-shaped `error` is dropped; the payload carries no channel/workspace/viewer/scope identifier and no token; a cached verdict still reports its cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)