### PR TITLE
feat(web): review session access policy step in getting-started

### DIFF
--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -24,6 +24,7 @@ import {
   useGithubAppEnabled,
   useGithubProfileLinked,
   useGsActions,
+  useSessionAccessCardAvailable,
   useSlackPlatformAppAvailable
 } from './GettingStartedChecklist'
 import { Button, Icon } from '@/components/ui'
@@ -91,6 +92,7 @@ export default function GettingStarted() {
 
   const githubLinked = useGithubProfileLinked()
   const githubEnabled = useGithubAppEnabled()
+  const sessionAccessAvailable = useSessionAccessCardAvailable()
   // Local mode (no platform-published Slack app): the slack row falls back to the
   // default GsRow, whose CTA opens the Slack integration wizard.
   const slackOneClick = useSlackPlatformAppAvailable()
@@ -105,9 +107,21 @@ export default function GettingStarted() {
         authOn,
         orgHasSessions,
         githubLinked,
-        githubEnabled
+        githubEnabled,
+        sessionAccessAvailable
       }),
-    [agents, daemons, integrations, allSessions, members, authOn, orgHasSessions, githubLinked, githubEnabled]
+    [
+      agents,
+      daemons,
+      integrations,
+      allSessions,
+      members,
+      authOn,
+      orgHasSessions,
+      githubLinked,
+      githubEnabled,
+      sessionAccessAvailable
+    ]
   )
 
   // Show on every console page while the checklist is incomplete — including a
@@ -140,13 +154,15 @@ export default function GettingStarted() {
   // Modals (add daemon, set up agent, connect Slack) stack above the drawer (their scrim
   // is z-900, the drawer z-80), so the checklist stays open behind them — the user returns
   // to it when the modal closes. Only close the drawer for actions that navigate the page
-  // away (GitHub workspace, Home chat, invite teammates → router.push).
+  // away (GitHub workspace, Home chat, invite teammates, session access → router.push) —
+  // the drawer is fixed in the app shell and would otherwise cover the destination.
   const runFromDrawer = (action: GsAction) => {
     const navigates =
       action.kind === 'github' ||
       action.kind === 'github-profile' ||
       action.kind === 'chat' ||
-      action.kind === 'members'
+      action.kind === 'members' ||
+      action.kind === 'session-access'
     if (navigates) setDrawerOpen(false)
     runAction(action)
   }

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -19,7 +19,12 @@ import { useModal } from './ModalProvider'
 import type { GsAction, GsItem } from '@/lib/getting-started'
 import { agentIsPlaced, agentLabel, modelLabel, runtimeLabel } from '@/lib/data'
 import { isAuthConfigured } from '@/lib/auth'
-import { fetchGithubInstallations, fetchMySocialAccount } from '@/lib/api'
+import {
+  fetchGithubInstallations,
+  fetchMySocialAccount,
+  fetchSessionExternalAccess,
+  type SessionAccessProvider
+} from '@/lib/api'
 import { consoleKeys } from '@/lib/swr-keys'
 import { socialLoginProviders } from '@/lib/social-login-providers'
 import { useSlackPlatformInstall } from '@/components/console/platforms/slack/use-platform-install'
@@ -111,6 +116,26 @@ export function useGithubAppEnabled(): boolean | undefined {
   return data
 }
 
+// Backs hiding the "Review session access policy" step: mirrors GlobalSearch's
+// `sessionAccessRenders` guard (GlobalSearch.tsx) so the checklist's CTA never
+// points at a card that renders null — SessionAccessCard hides itself once every
+// provider is BOTH unavailable and disabled (`hasNothingToOffer`, SettingsView.tsx).
+// Undefined while any read is still pending/unanswered — keep the step rather than
+// guess; only a definitive "nothing to offer" from all three hides it.
+export function useSessionAccessCardAvailable(): boolean | undefined {
+  const { activeOrg } = useOrgs()
+  const key = (provider: SessionAccessProvider) => consoleKeys.sessionAccess(activeOrg?.id, provider)
+  const fetcher = ([, orgId, , provider]: NonNullable<ReturnType<typeof key>>) =>
+    fetchSessionExternalAccess(provider, orgId)
+  const opts = { revalidateOnFocus: false, revalidateOnReconnect: false, shouldRetryOnError: false }
+  const slack = useSWR(key('slack'), fetcher, opts)
+  const github = useSWR(key('github'), fetcher, opts)
+  const feishu = useSWR(key('feishu'), fetcher, opts)
+  const results = [slack, github, feishu]
+  if (results.some(({ data, error }) => data === undefined && !error)) return undefined
+  return results.some(({ data }) => data === undefined || data.available || data.enabled)
+}
+
 // Whether the platform-published one-click "Add to Slack" app is installable on
 // this deployment. Local/self-hosted mode has no published app — the checklist
 // then renders the plain "Connect Slack" row, whose CTA opens the Slack
@@ -151,10 +176,10 @@ export function GsRows({
       >
         <span
           className={`mt-[1px] flex h-[18px] w-[18px] flex-none items-center justify-center rounded-full ${
-            it.done && !it.optional ? 'bg-(--brand) text-white' : 'border-[1.5px] border-(--border-strong)'
+            it.done ? 'bg-(--brand) text-white' : 'border-[1.5px] border-(--border-strong)'
           }`}
         >
-          {it.done && !it.optional && <Icon name="check" size={12} />}
+          {it.done && <Icon name="check" size={12} />}
         </span>
         <div className="min-w-0 flex-1">
           <span className="inline-flex items-center gap-2">

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -70,6 +70,10 @@ export function useGsActions() {
           // Land on Settings with the invite-members dialog auto-opened (`invite` is
           // consumed one-shot by SettingsView).
           return router.push(orgPath('/settings?invite=1'))
+        case 'session-access':
+          // The Session access card owns id="session-access" — the hash lands and
+          // scrolls there natively (same href the console nav / GlobalSearch use).
+          return router.push(orgPath('/settings#session-access'))
       }
     },
     [openModal, router, orgPath, firstAgent, builtinAgent, agents]
@@ -147,25 +151,30 @@ export function GsRows({
       >
         <span
           className={`mt-[1px] flex h-[18px] w-[18px] flex-none items-center justify-center rounded-full ${
-            it.done ? 'bg-(--brand) text-white' : 'border-[1.5px] border-(--border-strong)'
+            it.done && !it.optional ? 'bg-(--brand) text-white' : 'border-[1.5px] border-(--border-strong)'
           }`}
         >
-          {it.done && <Icon name="check" size={12} />}
+          {it.done && !it.optional && <Icon name="check" size={12} />}
         </span>
         <div className="min-w-0 flex-1">
-          <span
-            className={`font-sans text-[13.5px] leading-normal ${
-              it.done ? 'font-normal text-(--text-tertiary) line-through' : 'font-medium text-(--text-primary)'
-            }`}
-          >
-            {it.label}
+          <span className="inline-flex items-center gap-2">
+            <span
+              className={`font-sans text-[13.5px] leading-normal ${
+                it.done && !it.optional
+                  ? 'font-normal text-(--text-tertiary) line-through'
+                  : 'font-medium text-(--text-primary)'
+              }`}
+            >
+              {it.label}
+            </span>
+            {it.tag && <span className="font-mono text-[11.5px] leading-none text-(--text-disabled)">{it.tag}</span>}
           </span>
           {open && (
             <>
               <div className="mt-[5px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
                 {it.expl}
               </div>
-              {!it.done && (
+              {(!it.done || it.optional) && (
                 <div className="mt-[11px]" onClick={(e) => e.stopPropagation()}>
                   <Button size="sm" onClick={() => runAction(it.action)}>
                     {it.ctaLabel}

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -17,6 +17,7 @@ import {
   useGithubAppEnabled,
   useGithubProfileLinked,
   useGsActions,
+  useSessionAccessCardAvailable,
   useSlackPlatformAppAvailable
 } from '@/components/console/GettingStartedChecklist'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
@@ -70,6 +71,7 @@ export default function OnboardingView() {
   const { runAction } = useGsActions()
   const githubLinked = useGithubProfileLinked()
   const githubEnabled = useGithubAppEnabled()
+  const sessionAccessAvailable = useSessionAccessCardAvailable()
   // Local mode (no platform-published Slack app): the slack row falls back to the
   // default GsRow, whose CTA opens the Slack integration wizard.
   const slackOneClick = useSlackPlatformAppAvailable()
@@ -248,7 +250,8 @@ export default function OnboardingView() {
             authOn,
             orgHasSessions,
             githubLinked,
-            githubEnabled
+            githubEnabled,
+            sessionAccessAvailable
           })}
           slackOneClick={slackOneClick}
           runAction={runAction}

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -19,13 +19,16 @@ const empty = { agents: [], daemons: [], integrations: [], sessions: [], members
 describe('computeGettingStarted', () => {
   it('starts all-incomplete for a fresh org and reports progress', () => {
     const gs = computeGettingStarted(empty)
-    expect(gs.done).toBe(0)
-    expect(gs.total).toBe(6) // 5 core + invite (auth mode)
-    expect(gs.fraction).toBe(0)
+    // session-access always counts as done (it's a review step, not a setup task —
+    // see its `optional` comment in getting-started.ts), so it contributes to both
+    // done and total and never moves the fraction.
+    expect(gs.done).toBe(1)
+    expect(gs.total).toBe(7) // 5 core + session-access + invite (auth mode)
+    expect(gs.fraction).toBe(1 / 7)
     expect(gs.allDone).toBe(false)
   })
 
-  it('orders the steps per the design: daemon, agent, slack, github, conversation, invite', () => {
+  it('orders the steps per the design: daemon, agent, slack, github, conversation, session-access, invite', () => {
     // The "Runtime signed in" step is deferred until the explicit probe-status
     // signal ships (neither authRequired nor advertised models encode readiness).
     expect(computeGettingStarted(empty).items.map((i) => i.key)).toEqual([
@@ -34,13 +37,22 @@ describe('computeGettingStarted', () => {
       'slack',
       'github',
       'conversation',
+      'session-access',
       'invite'
     ])
   })
 
-  it('drops the invite item in no-auth mode', () => {
+  it('drops the invite AND session-access items in no-auth mode (no /settings there)', () => {
     expect(computeGettingStarted({ ...empty, authOn: false }).total).toBe(5)
     expect(computeGettingStarted({ ...empty, authOn: false }).items.some((i) => i.key === 'invite')).toBe(false)
+    expect(computeGettingStarted({ ...empty, authOn: false }).items.some((i) => i.key === 'session-access')).toBe(false)
+  })
+
+  it('always marks session-access done (optional, look-not-fix) but keeps its CTA action', () => {
+    const step = computeGettingStarted(empty).items.find((i) => i.key === 'session-access')!
+    expect(step.done).toBe(true)
+    expect(step.optional).toBe(true)
+    expect(step.action).toEqual({ kind: 'session-access' })
   })
 
   it('marks daemon done for any registered daemon, connected or not', () => {

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -55,6 +55,15 @@ describe('computeGettingStarted', () => {
     expect(step.action).toEqual({ kind: 'session-access' })
   })
 
+  it('hides session-access when its card would render nothing — the CTA must not point at a missing anchor', () => {
+    const has = (sessionAccessAvailable?: boolean) =>
+      computeGettingStarted({ ...empty, sessionAccessAvailable }).items.some((i) => i.key === 'session-access')
+    expect(has(false)).toBe(false)
+    // undefined (probe in flight / failed) keeps the step — same convention as githubEnabled
+    expect(has(undefined)).toBe(true)
+    expect(has(true)).toBe(true)
+  })
+
   it('marks daemon done for any registered daemon, connected or not', () => {
     const done = (rows: DaemonRow[]) =>
       computeGettingStarted({ ...empty, daemons: rows }).items.find((i) => i.key === 'daemon')!.done

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -82,9 +82,24 @@ export function computeGettingStarted(input: {
    *  the installations probe 404s otherwise). False ⇒ the GitHub steps are hidden:
    *  there is nothing to install. Undefined (probe in flight / failed) keeps them. */
   githubEnabled?: boolean
+  /** Whether SettingsView's SessionAccessCard would render anything (mirrors its own
+   *  `hasNothingToOffer`, one per provider). False ⇒ the session-access step is hidden —
+   *  its CTA would land on a page with no card to scroll to. Undefined (probe in
+   *  flight) keeps the step. */
+  sessionAccessAvailable?: boolean
 }): GettingStarted {
-  const { agents, daemons, integrations, sessions, members, authOn, orgHasSessions, githubLinked, githubEnabled } =
-    input
+  const {
+    agents,
+    daemons,
+    integrations,
+    sessions,
+    members,
+    authOn,
+    orgHasSessions,
+    githubLinked,
+    githubEnabled,
+    sessionAccessAvailable
+  } = input
   // Pick a chat-capable / bindable agent for the agent-scoped CTAs. Prefer the built-in
   // `agentconnect` preset — the canonical agent every org gets — else the first agent.
   const builtin = agents.find((a) => a.builtin)
@@ -172,9 +187,11 @@ export function computeGettingStarted(input: {
     }
   ]
 
-  // Session access lives on /settings, which no-auth deployments don't have
-  // (they bounce to /home) — gate it with the other auth-only step below.
-  if (authOn) {
+  // Session access lives on /settings, which no-auth deployments don't have (they
+  // bounce to /home) — gate it with the other auth-only step below. It also vanishes
+  // when SessionAccessCard itself would render nothing (`sessionAccessAvailable === false`)
+  // — same reasoning as the GitHub steps: a CTA must not point at a missing anchor.
+  if (authOn && sessionAccessAvailable !== false) {
     items.push({
       key: 'session-access',
       label: 'Review session access policy',
@@ -185,6 +202,8 @@ export function computeGettingStarted(input: {
       ctaLabel: 'Review session access',
       action: { kind: 'session-access' }
     })
+  }
+  if (authOn) {
     items.push({
       key: 'invite',
       label: 'Invite teammates',

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -27,6 +27,7 @@ export type GsAction =
   | { kind: 'github-profile' }
   | { kind: 'chat' }
   | { kind: 'members' }
+  | { kind: 'session-access' }
 
 export interface GsItem {
   key: string
@@ -36,6 +37,13 @@ export interface GsItem {
   done: boolean
   ctaLabel: string
   action: GsAction
+  /** Short chip after the label (e.g. "optional") — see `optional` below. */
+  tag?: string
+  /** Unlike every other item, has no live signal for "done" (it's a look-don't-touch
+   *  review, not a setup task) — `done` is hardcoded true so it never drags the ring
+   *  or blocks "Finish onboarding". `optional` keeps its CTA visible despite `done`,
+   *  since GsRows normally hides the button once an item is done. */
+  optional?: boolean
 }
 
 export interface GettingStarted {
@@ -164,8 +172,19 @@ export function computeGettingStarted(input: {
     }
   ]
 
-  // Members only exist in auth mode; a no-auth deployment has no one to invite.
+  // Session access lives on /settings, which no-auth deployments don't have
+  // (they bounce to /home) — gate it with the other auth-only step below.
   if (authOn) {
+    items.push({
+      key: 'session-access',
+      label: 'Review session access policy',
+      expl: "Decide who can see session content synced from Slack, GitHub, and Feishu — on by default, following each platform's own access.",
+      done: true,
+      optional: true,
+      tag: 'optional',
+      ctaLabel: 'Review session access',
+      action: { kind: 'session-access' }
+    })
     items.push({
       key: 'invite',
       label: 'Invite teammates',


### PR DESCRIPTION
## Summary
- Adds a **Review session access policy** step to the getting-started checklist (console pill/drawer + the `/onboarding` reveal — both render off the same `computeGettingStarted`). Its CTA navigates to `/settings#session-access`, landing on the existing Session access card.
- Only shown in auth mode (`authOn`), since `/settings` doesn't exist on no-auth deployments — same gating as the existing "Invite teammates" step.
- It's a "look, don't fix" review with no live done/undone signal, unlike every other item in this list. Per product decision, it's marked `optional` and **always counts as complete** in the progress ring / `allDone`, so it never blocks the pill from disappearing or "Finish onboarding" — but its row still shows the description + CTA button (checklist rows normally hide the button once `done`), with an "optional" tag next to the label so it reads differently from a real completed step.

## Why
The Session access card (who can see synced session content from Slack/GitHub/Feishu) had no discovery path from the getting-started flow — a new org could easily never notice it exists.

## Test plan
- [x] `pnpm --filter @agentconnect.md/web exec vitest run src/lib/getting-started.test.ts` — updated ordering/count assertions + new test for the always-done/optional behavior, all passing
- [x] `pnpm --filter @agentconnect.md/web typecheck`
- [x] `eslint` on the touched files (also ran automatically via pre-push hook)
- [ ] Manual visual check of the checklist drawer was not done this session (no accessible mock/no-auth dev server at the time) — worth a quick look before merge