### PR TITLE
feat(daemon): remove the evaluation-only collaboration capability toggle

### DIFF
--- a/docs/designs/agent-capability-benchmark-harness.md
+++ b/docs/designs/agent-capability-benchmark-harness.md
@@ -149,9 +149,10 @@ The control and treatment use the same full-daemon path. An internal test compos
 ```ts
 type EvaluationCapabilityProfile = {
   memory: 'off' | 'configured'
-  collaboration: 'off' | 'configured'
 }
 ```
+
+Collaboration is deliberately not part of the profile. Evaluation must run the exact production tool surface and messaging mechanism, so there is no collaboration-off composition: every full-daemon cell exposes the full `sendMessage` target union and the collaboration tools, and delivery follows production policy.
 
 This is constructor/test composition, not a new externally routable platform or production configuration. It must not put message bodies on the control-plane path.
 
@@ -159,7 +160,7 @@ This is constructor/test composition, not a new externally routable platform or 
 
 `runChat`/`AcpHost.newSession(cwd)` bypasses the daemon `SessionManager`, managed-memory injection, daemon MCP bridge, collaboration, routing, and policy. It is useful only for `Δcore`: comparing a raw subject harness with the same harness routed through AgentConnect with add-ons off.
 
-It must never be used as the control for managed memory or collaboration. Those controls are the full daemon with that feature disabled.
+It must never be used as the control for managed memory. That control is the full daemon with memory off. Collaboration has no off control at all — its behavior is checked functionally on the production surface.
 
 ### 4.2 Provider lifecycle
 
@@ -256,7 +257,7 @@ These remain normal tests and gate relevant pull requests:
 - built-in system tools are auto-allowed while dangerous runtime tools follow interactive policy;
 - permission decision events distinguish auto-allow from prompt/cancel;
 - hook bodies remain explicitly untrusted;
-- add-ons-off composition omits the corresponding prompt/tool/memory behavior.
+- memory-off composition omits the corresponding memory prompt/tool behavior; the collaboration surface is identical in every composition.
 
 ### 5.2 Initial paired behavior suite
 
@@ -266,10 +267,10 @@ Keep v1 small and outcome-focused:
 - `memory-cross-session-recall`: full daemon memory off versus on; outcome is a correct answer grounded only in prior-session state, plus recall-state evidence.
 - `memory-proactive-capture`: memory off versus on; after a learn-worthy turn, verify durable state and retrieval in a fresh session.
 - `memory-isolation`: memory on; verify a fact from another agent/principal is neither injected nor disclosed.
-- `collab-delivery-reply`: collaboration off versus on; a task requiring a specialist peer succeeds only through admitted delivery/reply correlation.
+- `collab-delivery-reply`: production-surface functional check; a task requiring a specialist peer succeeds only through admitted delivery/reply correlation (no off cell — the product ships no collaboration-off composition).
 - `collab-context-isolation`: reproduce the greeting/cascade failure; treatment must complete without peer rebroadcast or thread-context bleed.
 - `collab-orchestration-partial-failure`: verify collected successes, timed-out worker state, and final main-agent recovery.
-- `prompt-quiet-mechanics`: AgentConnect collaboration prompt off versus on; the treatment uses the tool without narrating internal delivery mechanics.
+- `prompt-quiet-mechanics`: prompt-variant comparison on the production surface; the treatment uses the tool without narrating internal delivery mechanics.
 - `memory-collab-handoff`: a peer uses relevant managed memory during a delegated task without leaking unrelated memory.
 
 The subject's absolute result remains visible for diagnosis. The product signal is the paired delta plus invariant/safety gates.
@@ -365,8 +366,8 @@ CI publishes redacted JSON/JUnit summaries and retains raw artifacts only in res
 
 - Promptfoo custom TypeScript provider;
 - isolated full-daemon fixture lifecycle and capability-profile composition seam;
-- full-daemon memory-off/on and collaboration-off/on controls;
-- initial paired memory, collaboration, prompt, and interaction cases;
+- full-daemon memory-off/on controls (collaboration always at the production surface);
+- initial paired memory, prompt, and interaction cases plus a functional collaboration case;
 - JSON/JUnit output and an on-demand workflow.
 
 ### P2 — runtime matrix and nightly reliability

--- a/docs/designs/collaboration-arena.md
+++ b/docs/designs/collaboration-arena.md
@@ -29,8 +29,9 @@ Existing suite
 AgentConnect Add-on Evals
   └── Small paired cases:
       memory off/on
-      collaboration off/on
       one delegation and reply
+      (always the production
+       collaboration surface)
 
 New suite
 AgentConnect Collaboration Arena

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,6 +1,6 @@
 # AgentConnect add-on evaluations
 
-This suite measures AgentConnect's incremental memory and collaboration behavior while holding the underlying ACP harness fixed. It is not a model or harness leaderboard.
+This suite measures AgentConnect's incremental memory behavior — and functionally checks its collaboration delivery — while holding the underlying ACP harness fixed. It is not a model or harness leaderboard. Every full-daemon cell runs the exact production tool surface and messaging mechanism: collaboration has no evaluation-only off switch, so it is not a treatment axis.
 
 ## What runs
 
@@ -9,24 +9,22 @@ There are two layers:
 - `pnpm eval:contracts` runs deterministic, credential-free Vitest contracts for the event schema, observer non-interference, permission decisions, daemon composition, redaction, ATIF, and disposable runners.
 - `pnpm eval:addons` runs the configured real ACP subject through Promptfoo. It requires an explicit disposable subject template and model/runtime credentials.
 
-Promptfoo evaluates five treatment cells:
+Promptfoo evaluates three treatment cells. Both full-daemon cells carry the production collaboration surface:
 
-| Label                | Execution path | Memory     | Collaboration |
-| -------------------- | -------------- | ---------- | ------------- |
-| `raw-acp`            | Raw `AcpHost`  | off        | off           |
-| `daemon-core`        | Full daemon    | off        | off           |
-| `memory-only`        | Full daemon    | configured | off           |
-| `collaboration-only` | Full daemon    | off        | configured    |
-| `both`               | Full daemon    | configured | configured    |
+| Label         | Execution path | Memory     |
+| ------------- | -------------- | ---------- |
+| `raw-acp`     | Raw `AcpHost`  | off        |
+| `daemon-core` | Full daemon    | off        |
+| `memory-only` | Full daemon    | configured |
 
 The generated paired summary reports, per case and without combining different harnesses:
 
 ```text
-core          = daemon-core - raw-acp
-memory        = memory-only - daemon-core
-collaboration = collaboration-only - daemon-core
-interaction   = both - memory-only - collaboration-only + daemon-core
+core   = daemon-core - raw-acp
+memory = memory-only - daemon-core
 ```
+
+The collaboration case is a functional check of specialist delivery and reply on the production surface (it runs in `daemon-core`); it has no paired off-cell because the product ships no collaboration-off composition.
 
 Controls may legitimately score zero, so the outcome assertion records `0` or `1` without turning an expected-low control into a process failure. Provider, infrastructure, and artifact errors still fail the Promptfoo run and retain their terminal status.
 

--- a/evals/cases/addons.yaml
+++ b/evals/cases/addons.yaml
@@ -58,12 +58,13 @@
       value: file://assertions/outcome.ts
       metric: outcome
 
+# Collaboration is part of the production surface in every daemon cell (no off
+# switch), so this case is a functional check of delivery/reply, not a paired ablation.
 - description: Collaboration · specialist delivery and reply
   metadata:
     feature: collaboration
   providers:
     - daemon-core
-    - collaboration-only
   vars:
     expected: SPECIALIST-OK-7319
     match: exact
@@ -96,8 +97,6 @@
   providers:
     - daemon-core
     - memory-only
-    - collaboration-only
-    - both
   vars:
     expected: INTERACTION-OK-7319
     match: exact

--- a/evals/extensions/paired-summary.ts
+++ b/evals/extensions/paired-summary.ts
@@ -96,17 +96,11 @@ export async function afterAll(context: AfterAllExtensionHookContext): Promise<v
         })
       )
       const score = (name: string) => (treatments[name] as TreatmentSummary | undefined)?.meanScore
+      // Collaboration is not a treatment axis: every daemon cell runs the
+      // production collaboration surface, so only the core and memory deltas exist.
       const deltas = {
         core: delta(score('daemon-core'), score('raw-acp')),
-        memory: delta(score('memory-only'), score('daemon-core')),
-        collaboration: delta(score('collaboration-only'), score('daemon-core')),
-        interaction:
-          score('both') === undefined ||
-          score('memory-only') === undefined ||
-          score('collaboration-only') === undefined ||
-          score('daemon-core') === undefined
-            ? undefined
-            : roundMetric(score('both')! - score('memory-only')! - score('collaboration-only')! + score('daemon-core')!)
+        memory: delta(score('memory-only'), score('daemon-core'))
       }
       return [
         caseId,

--- a/evals/games/engine.ts
+++ b/evals/games/engine.ts
@@ -489,7 +489,7 @@ export async function runWerewolf(options: WerewolfGameRunOptions): Promise<Coll
       mode: 'deterministic',
       subjectKind: subjectSpec.kind,
       ...(subjectSpec.kind === 'scripted' ? { hostFactory: scriptedWerewolfHostFactory() as never } : {}),
-      capabilityProfile: { memory: 'off', collaboration: 'configured' },
+      capabilityProfile: { memory: 'off' },
       limits: {
         maxSteps: options.maxSteps ?? 60,
         timeoutMs: options.timeoutMs ?? (subjectSpec.kind === 'scripted' ? 240_000 : 30 * 60_000)
@@ -610,7 +610,7 @@ export async function runCrossRoomCounting(options: CrossRoomGameRunOptions): Pr
       mode: 'deterministic',
       subjectKind: subjectSpec.kind,
       ...(subjectSpec.kind === 'scripted' ? { hostFactory: scriptedCrossRoomHostFactory() as never } : {}),
-      capabilityProfile: { memory: 'off', collaboration: 'configured' },
+      capabilityProfile: { memory: 'off' },
       limits: {
         maxSteps: options.maxSteps ?? (options.target ?? 12) * 3 + 10,
         timeoutMs: options.timeoutMs ?? (subjectSpec.kind === 'scripted' ? 180_000 : 20 * 60_000)
@@ -657,7 +657,7 @@ export async function runQuotaCounting(options: QuotaCountingRunOptions): Promis
       mode: 'deterministic',
       subjectKind: subjectSpec.kind,
       ...(subjectSpec.kind === 'scripted' ? { hostFactory: scriptedQuotaHostFactory() as never } : {}),
-      capabilityProfile: { memory: 'off', collaboration: 'configured' },
+      capabilityProfile: { memory: 'off' },
       limits: {
         maxSteps: options.maxSteps ?? target * 3 + 10,
         timeoutMs: options.timeoutMs ?? (subjectSpec.kind === 'scripted' ? 180_000 : 20 * 60_000)
@@ -704,7 +704,7 @@ export async function runSameRoomCounting(options: CountingGameRunOptions): Prom
               : scriptedCountingHostFactory()) as never
           }
         : {}),
-      capabilityProfile: { memory: 'off', collaboration: 'configured' },
+      capabilityProfile: { memory: 'off' },
       limits: {
         maxSteps: options.maxSteps ?? (options.target ?? 12) * 3 + 4,
         timeoutMs: options.timeoutMs ?? (subjectSpec.kind === 'scripted' ? 120_000 : 15 * 60_000)

--- a/evals/promptfooconfig.yaml
+++ b/evals/promptfooconfig.yaml
@@ -10,6 +10,8 @@ providers:
       mode: raw-acp
       name: raw-acp
 
+  # Every daemon cell runs the production tool surface and messaging mechanism —
+  # collaboration has no off switch. Memory is the only capability treatment axis.
   - id: file://providers/agentconnect.ts
     label: daemon-core
     config:
@@ -17,7 +19,6 @@ providers:
       treatment:
         name: daemon-core
         memory: off
-        collaboration: off
 
   - id: file://providers/agentconnect.ts
     label: memory-only
@@ -26,25 +27,6 @@ providers:
       treatment:
         name: memory-only
         memory: configured
-        collaboration: off
-
-  - id: file://providers/agentconnect.ts
-    label: collaboration-only
-    config:
-      mode: daemon
-      treatment:
-        name: collaboration-only
-        memory: off
-        collaboration: configured
-
-  - id: file://providers/agentconnect.ts
-    label: both
-    config:
-      mode: daemon
-      treatment:
-        name: both
-        memory: configured
-        collaboration: configured
 
 tests: file://cases/addons.yaml
 

--- a/evals/providers/agentconnect.ts
+++ b/evals/providers/agentconnect.ts
@@ -130,15 +130,13 @@ function configuredTreatment(config: AgentConnectProviderConfig, mode: ProviderM
   if (mode === 'raw-acp') {
     return {
       name: config.name?.trim() || 'raw-acp',
-      memory: 'off',
-      collaboration: 'off'
+      memory: 'off'
     }
   }
   return (
     config.treatment ?? {
       name: config.name?.trim() || 'daemon-core',
-      memory: 'off',
-      collaboration: 'off'
+      memory: 'off'
     }
   )
 }

--- a/evals/test/game-runner.test.ts
+++ b/evals/test/game-runner.test.ts
@@ -224,7 +224,7 @@ describe('collaboration game runner — same-room counting with scripted hosts',
             stop: async () => {}
           }
         }) as never,
-        capabilityProfile: { memory: 'off', collaboration: 'configured' },
+        capabilityProfile: { memory: 'off' },
         limits: { maxSteps: 12, timeoutMs: 120_000 },
         agents: topology.agents.map((agent) => ({ agentId: agent.agentId, name: agent.alias }))
       })
@@ -288,7 +288,7 @@ describe('collaboration game runner — same-room counting with scripted hosts',
           cancel: async () => {},
           stop: async () => {}
         })) as never,
-        capabilityProfile: { memory: 'off', collaboration: 'configured' },
+        capabilityProfile: { memory: 'off' },
         limits: { maxSteps: 6, timeoutMs: 60_000 },
         agents: topology.agents.map((agent) => ({ agentId: agent.agentId, name: agent.alias }))
       })

--- a/evals/test/paired-summary.test.ts
+++ b/evals/test/paired-summary.test.ts
@@ -45,14 +45,7 @@ describe('Promptfoo paired evaluation reporting', () => {
     try {
       await afterAll({
         evalId: 'eval-7319',
-        results: [
-          evalResult('raw-acp', 0.3),
-          evalResult('daemon-core', 0.2),
-          evalResult('memory-only', 0.6),
-          evalResult('collaboration-only', 0.5),
-          evalResult('both', 1),
-          failed
-        ],
+        results: [evalResult('raw-acp', 0.3), evalResult('daemon-core', 0.2), evalResult('memory-only', 0.6), failed],
         prompts: [],
         suite: {} as AfterAllExtensionHookContext['suite'],
         config: {}
@@ -69,13 +62,11 @@ describe('Promptfoo paired evaluation reporting', () => {
       cases: {
         'memory-collab-handoff': {
           treatments: {
-            both: { meanScore: 1, validTrials: 1, statuses: { passed: 1 } }
+            'memory-only': { meanScore: 0.6, validTrials: 1, statuses: { passed: 1 } }
           },
           deltas: {
             core: -0.1,
-            memory: 0.4,
-            collaboration: 0.3,
-            interaction: 0.1
+            memory: 0.4
           }
         }
       }

--- a/evals/test/provider.test.ts
+++ b/evals/test/provider.test.ts
@@ -4,8 +4,7 @@ import type { EvaluationCaseResult, EvaluationTreatment } from '../../packages/d
 
 const treatment: EvaluationTreatment = {
   name: 'memory-only',
-  memory: 'configured',
-  collaboration: 'off'
+  memory: 'configured'
 }
 
 function result(overrides: Partial<EvaluationCaseResult> = {}): EvaluationCaseResult {
@@ -113,7 +112,7 @@ describe('Promptfoo AgentConnect provider', () => {
 
     expect(failed).toMatchObject({
       error: 'agent_failed: runtime failed safely',
-      metadata: { status: 'agent_failed', treatment: { name: 'raw-acp', memory: 'off', collaboration: 'off' } }
+      metadata: { status: 'agent_failed', treatment: { name: 'raw-acp', memory: 'off' } }
     })
     expect(invalid).toMatchObject({ metadata: { status: 'invalid_case' } })
     expect(invalid.error).toBeTruthy()

--- a/evals/test/routing-fixture.ts
+++ b/evals/test/routing-fixture.ts
@@ -111,7 +111,7 @@ export class RoutingFixture {
       root: subject.root,
       environment,
       runId: `routing-${seed}`,
-      capabilityProfile: { memory: 'off', collaboration: 'configured' },
+      capabilityProfile: { memory: 'off' },
       hostFactory: ((agent: { id: string }, onUpdate: (sessionId: string, update: unknown) => void) => {
         let sessions = 0
         const bindings = new Map<string, DaemonMcpBinding>()

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1616,7 +1616,8 @@ export interface DaemonEvaluationOptions {
   observer?: EvaluationObserver
   /** Stable run identity shared by event, ATIF, and manifest artifacts. */
   runId?: string
-  /** Add-on treatment. Production defaults to both configured. */
+  /** Add-on treatment (memory only). Production defaults to configured. Collaboration
+   *  has no toggle: evaluation always runs the production tool surface and delivery. */
   capabilityProfile?: EvaluationCapabilityProfile
   /** Collaboration Arena environment (collaboration-arena.md §5): the effective
    *  integration registry projected into `agent.integrations` + the connection
@@ -2175,7 +2176,7 @@ export class Daemon {
       throw new Error('evaluation capability profile requires an evaluation observer')
     }
     this.evaluationProfile = EvaluationCapabilityProfileSchema.parse(
-      opts.evaluation?.capabilityProfile ?? { memory: 'configured', collaboration: 'configured' }
+      opts.evaluation?.capabilityProfile ?? { memory: 'configured' }
     )
     this.evaluation = new EvaluationEventEmitter({
       observer: opts.evaluation?.observer,
@@ -3047,7 +3048,6 @@ export class Daemon {
           )
         }),
       memoryEnabled: this.evaluationProfile.memory === 'configured',
-      collaborationEnabled: this.evaluationProfile.collaboration === 'configured',
       quoteForContextEvent: (event, replayed) => this.observedQuoteBlock(event, replayed),
       // The session integration's own bot identity (auth.test-resolved on both
       // socket and send-only connections) for the `# Agent` Slack-identity line.
@@ -3068,7 +3068,6 @@ export class Daemon {
       mcpServersFor: ({ agent, platform, channel, thread, integrationId, transportScope, isDm }) => {
         const servers: McpServer[] = []
         let tools = toolsForIntegrations(agent.integrations, {
-          collaboration: this.evaluationProfile.collaboration === 'configured',
           organizationKnowledge: this.cpClient?.supportsServerFeature?.(ORGANIZATION_KNOWLEDGE_FEATURE) === true
         })
         // Static descriptor, dynamic authority: a per-thread ACP session can
@@ -8128,7 +8127,6 @@ export class Daemon {
 
   private wakeRejectionReason(req: MessageAgentReq): string | null {
     const platform = req.platform
-    if (this.evaluationProfile.collaboration === 'off') return 'capability_disabled'
     if (isPlatformMemberId(platform, req.toAgentId)) {
       return 'invalid_target'
     }
@@ -8182,14 +8180,6 @@ export class Daemon {
         }
       })
       return result
-    }
-    if (this.evaluationProfile.collaboration === 'off') {
-      const thread = req.thread ?? `agentcall:${req.channel}:collaboration-disabled`
-      return observe('collaboration.delivery.rejected', {
-        delivered: false,
-        targetSession: sessionKey(platform, req.channel, thread, req.toAgentId),
-        reason: 'capability_disabled'
-      })
     }
     // `toAgentId` is an AgentConnect id from listAgents / the trusted agent-call
     // envelope, never a platform member id. In particular, accepting Slack's U…/W… ids

--- a/packages/daemon/src/evaluation/artifacts.ts
+++ b/packages/daemon/src/evaluation/artifacts.ts
@@ -24,8 +24,7 @@ export const EvaluationRunManifestSchema = z.object({
   caseId: z.string().min(1),
   treatment: z.object({
     name: z.string().min(1),
-    memory: z.enum(['off', 'configured']),
-    collaboration: z.enum(['off', 'configured'])
+    memory: z.enum(['off', 'configured'])
   }),
   subject: z.object({
     runtime: z.string().min(1),

--- a/packages/daemon/src/evaluation/daemon-harness.ts
+++ b/packages/daemon/src/evaluation/daemon-harness.ts
@@ -42,7 +42,7 @@ export class DaemonEvaluationHarness {
       observer: compositeEvaluationObserver(this.collector),
       runId: options.runId,
       environment: options.environment,
-      capabilityProfile: options.capabilityProfile ?? { memory: 'off', collaboration: 'configured' },
+      capabilityProfile: options.capabilityProfile ?? { memory: 'off' },
       ...(options.onObserverError ? { onObserverError: options.onObserverError } : {})
     }
     this.daemon = new Daemon({

--- a/packages/daemon/src/evaluation/events.ts
+++ b/packages/daemon/src/evaluation/events.ts
@@ -38,9 +38,10 @@ export const EvaluationEventTypeSchema = z.enum([
 
 export type EvaluationEventType = z.infer<typeof EvaluationEventTypeSchema>
 
+// Collaboration is deliberately NOT part of the profile: evaluation always runs
+// the exact production tool surface and messaging mechanism (no capability fork).
 export const EvaluationCapabilityProfileSchema = z.object({
-  memory: z.enum(['off', 'configured']),
-  collaboration: z.enum(['off', 'configured'])
+  memory: z.enum(['off', 'configured'])
 })
 
 export type EvaluationCapabilityProfile = z.infer<typeof EvaluationCapabilityProfileSchema>

--- a/packages/daemon/src/evaluation/game-runner.ts
+++ b/packages/daemon/src/evaluation/game-runner.ts
@@ -386,8 +386,7 @@ export class CollaborationGameRunner {
       caseId: options.game,
       treatment: {
         name: options.subjectKind === 'scripted' ? 'scripted-hosts' : 'real-agents',
-        memory: options.capabilityProfile?.memory ?? 'off',
-        collaboration: options.capabilityProfile?.collaboration ?? 'configured'
+        memory: options.capabilityProfile?.memory ?? 'off'
       },
       subject: { runtime: options.subjectKind },
       agentConnect: { commit: process.env.GITHUB_SHA ?? 'unknown', dirty: true },

--- a/packages/daemon/src/evaluation/runner.ts
+++ b/packages/daemon/src/evaluation/runner.ts
@@ -725,8 +725,7 @@ export class RawAcpEvaluationRunner {
     const startedAt = new Date(startedAtMs).toISOString()
     const treatment: EvaluationTreatment = {
       name: this.options.name?.trim() || 'raw-acp',
-      memory: 'off',
-      collaboration: 'off'
+      memory: 'off'
     }
     const artifactDir = join(
       resolve(this.options.artifactRoot),

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -93,7 +93,7 @@ export const SESSION_TOOLS: ToolDescriptor[] = [
  * ordinary reply cannot do: a postless agent call, a direct message, a channel-root post,
  * or a parent-session reply. A visible send is always at the channel ROOT.
  */
-function buildSendMessageTool(platforms: string[], collaboration = true): ToolDescriptor {
+function buildSendMessageTool(platforms: string[]): ToolDescriptor {
   const platform = {
     type: 'string',
     ...(platforms.length > 0 ? { enum: platforms } : {}),
@@ -283,48 +283,37 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
 
   return {
     name: 'sendMessage',
-    description: collaboration
-      ? 'Send one message using exactly one target mode: an AgentConnect agent (`toAgent`), human users (`toUser`), a channel ' +
-        'with no recipient, or the parent-session reply.\n' +
-        'TO SPEAK IN THE CONVERSATION YOU ARE ALREADY IN — including to address a peer agent or a human there — do ' +
-        'NOT use this tool. Write your ordinary turn reply and @-mention them in it (use `listAgents` to get an ' +
-        'agent’s exact `mention` token). That reply already goes to the right thread as you. This tool is only for ' +
-        'what it cannot do: reaching a DIFFERENT conversation, a direct message, a postless agent call, or a reply ' +
-        'into the parent session.\n' +
-        '- toAgent — wake exactly one AgentConnect agent (id from listAgents or your own # Agent ID; never a ' +
-        'platform member id):\n' +
-        '  • direct: `{"toAgent":"<agent id>","message":"..."}` — postless PEER wake: nothing is posted anywhere; ' +
-        'this form cannot target yourself.\n' +
-        '  • channel root: `{"toAgent":"<agent id>","channel":"<channel id>","message":"..."}` — also posts one ' +
-        'visible message at that channel’s ROOT, @-mentions the target, and anchors it to that post. This form MAY ' +
-        'target yourself: use your own # Agent ID to open and activate one new conversation there.\n' +
-        '  Use `{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}` WHENEVER you expect an answer ' +
-        'back — your message asks a question or requests a result, or someone asked you to relay the peer’s answer. ' +
-        'The peer replies in its own conversation, so without `needsReply` its answer never reaches you. Follow the ' +
-        'returned `nextAction`; use `viewSessionStatus` only for optional diagnostics.\n' +
-        '- toUser — reach HUMAN users (Slack only for now), never an AgentConnect agent or your own bot identity:\n' +
-        '  • dm: `{"toUser":"<Slack user id>","message":"..."}` — direct message; do not set `channel`.\n' +
-        '  • channel root: `{"toUser":["<user id 1>","<user id 2>"],"channel":"<channel id>","message":"..."}` — ' +
-        'posts once at the channel root and @-mentions every listed user; a single id string also works.\n' +
-        '- Channel (bare post, no recipient): `{"channel":"<channel id>","message":"..."}` — posts at the channel ' +
-        'root without waking anyone or @-mentioning anyone; add `platform` or `integrationId` only when needed.\n' +
-        '- Parent session reply: `{"sessionId":"<Parent session>","message":"..."}` — relay an answer back to whoever ' +
-        'asked this way, never by posting it at their channel root.\n' +
-        'Every visible send lands at the channel ROOT and opens a NEW conversation of your own there. Write ' +
-        '`message` as CommonMark/GFM. The daemon supplies your identity; you cannot impersonate anyone. A self ' +
-        'wake is valid only in the explicit `toAgent` channel-root form above.'
-      : 'Post one visible message at exactly one channel’s root, or to a set of human recipients. To speak in the ' +
-        'conversation you are already in — including to address a human there — do NOT use this tool: write your ' +
-        'ordinary turn reply and @-mention them in it. Use this only for a DIFFERENT conversation or a direct ' +
-        'message. `{"channel":"<channel id>","message":"..."}` for a bare channel-root post, ' +
-        '`{"toUser":"<Slack user id>","message":"..."}` for a DM, or `{"toUser":["<user id 1>","<user id 2>"],"channel":"<channel ' +
-        'id>","message":"..."}` for a channel-root post that @-mentions every listed user; a single id also works. ' +
-        'A channel-root post opens a NEW conversation of your own on that post. Peer-agent ' +
-        'and parent-session delivery are disabled for this run. Write `message` as CommonMark/GFM. The daemon ' +
-        'supplies your identity; you cannot impersonate anyone.',
-    inputSchema: unionOf(
-      collaboration ? [agentTarget, userTarget, channelTarget, sessionTarget] : [userTarget, channelTarget]
-    )
+    description:
+      'Send one message using exactly one target mode: an AgentConnect agent (`toAgent`), human users (`toUser`), a channel ' +
+      'with no recipient, or the parent-session reply.\n' +
+      'TO SPEAK IN THE CONVERSATION YOU ARE ALREADY IN — including to address a peer agent or a human there — do ' +
+      'NOT use this tool. Write your ordinary turn reply and @-mention them in it (use `listAgents` to get an ' +
+      'agent’s exact `mention` token). That reply already goes to the right thread as you. This tool is only for ' +
+      'what it cannot do: reaching a DIFFERENT conversation, a direct message, a postless agent call, or a reply ' +
+      'into the parent session.\n' +
+      '- toAgent — wake exactly one AgentConnect agent (id from listAgents or your own # Agent ID; never a ' +
+      'platform member id):\n' +
+      '  • direct: `{"toAgent":"<agent id>","message":"..."}` — postless PEER wake: nothing is posted anywhere; ' +
+      'this form cannot target yourself.\n' +
+      '  • channel root: `{"toAgent":"<agent id>","channel":"<channel id>","message":"..."}` — also posts one ' +
+      'visible message at that channel’s ROOT, @-mentions the target, and anchors it to that post. This form MAY ' +
+      'target yourself: use your own # Agent ID to open and activate one new conversation there.\n' +
+      '  Use `{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}` WHENEVER you expect an answer ' +
+      'back — your message asks a question or requests a result, or someone asked you to relay the peer’s answer. ' +
+      'The peer replies in its own conversation, so without `needsReply` its answer never reaches you. Follow the ' +
+      'returned `nextAction`; use `viewSessionStatus` only for optional diagnostics.\n' +
+      '- toUser — reach HUMAN users (Slack only for now), never an AgentConnect agent or your own bot identity:\n' +
+      '  • dm: `{"toUser":"<Slack user id>","message":"..."}` — direct message; do not set `channel`.\n' +
+      '  • channel root: `{"toUser":["<user id 1>","<user id 2>"],"channel":"<channel id>","message":"..."}` — ' +
+      'posts once at the channel root and @-mentions every listed user; a single id string also works.\n' +
+      '- Channel (bare post, no recipient): `{"channel":"<channel id>","message":"..."}` — posts at the channel ' +
+      'root without waking anyone or @-mentioning anyone; add `platform` or `integrationId` only when needed.\n' +
+      '- Parent session reply: `{"sessionId":"<Parent session>","message":"..."}` — relay an answer back to whoever ' +
+      'asked this way, never by posting it at their channel root.\n' +
+      'Every visible send lands at the channel ROOT and opens a NEW conversation of your own there. Write ' +
+      '`message` as CommonMark/GFM. The daemon supplies your identity; you cannot impersonate anyone. A self ' +
+      'wake is valid only in the explicit `toAgent` channel-root form above.',
+    inputSchema: unionOf([agentTarget, userTarget, channelTarget, sessionTarget])
   }
 }
 
@@ -854,7 +843,7 @@ export const ALL_TOOL_NAMES = [
  */
 export function toolsForIntegrations(
   integrations: Integration[],
-  options: { sessionTitle?: boolean; collaboration?: boolean; organizationKnowledge?: boolean } = {}
+  options: { sessionTitle?: boolean; organizationKnowledge?: boolean } = {}
 ): ToolDescriptor[] {
   const tools: ToolDescriptor[] = []
   const seen = new Set<string>()
@@ -868,17 +857,13 @@ export function toolsForIntegrations(
   if (options.sessionTitle) add(SESSION_TOOLS)
   add(MEMORY_TOOLS)
   if (options.organizationKnowledge) add(KNOWLEDGE_TOOLS)
-  const collaboration = options.collaboration !== false
-  if (collaboration) add(COLLABORATION_TOOLS)
+  add(COLLABORATION_TOOLS)
   // The unified `sendMessage` tool is ALWAYS present (session-concept §3): even a
   // memory-only agent with no platform integration can wake a peer (`toAgent`) or reply to
   // its origin (`sessionId`). The `platform` enum is narrowed to the agent's own platforms
   // so it can post to any of them (empty ⇒ no channel posting, only wake/reply).
   const platforms = [...new Set(integrations.map((i) => i.platform))]
-  // In a collaboration-off evaluation treatment, preserve the ordinary visible
-  // channel-send branch but remove peer/session targets. A platform-free agent then
-  // has no meaningful send target and receives no sendMessage descriptor at all.
-  if (collaboration || platforms.length > 0) add([buildSendMessageTool(platforms, collaboration)])
+  add([buildSendMessageTool(platforms)])
   // Platform read helpers only make sense once the agent has at least one integration.
   if (platforms.length > 0) {
     add(buildReadTools(platforms))

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -266,8 +266,6 @@ export class SessionManager {
       onMemoryRecallEvent?: (agentId: string, event: MemoryRecallLifecycleEvent) => void
       /** Evaluation treatment control. Defaults on for all production callers. */
       memoryEnabled?: boolean
-      /** Evaluation treatment control. Defaults on for all production callers. */
-      collaborationEnabled?: boolean
       /** Daemon-observed reply-source sidecar for context rows. Standalone/test
        * callers omit it and preserve the historical transcript-only behavior. */
       quoteForContextEvent?: (event: TranscriptEntry, replayed: readonly TranscriptEntry[]) => string | undefined
@@ -812,39 +810,37 @@ export class SessionManager {
     // visible in-thread form: speaking in the current conversation is an ordinary reply.
     // `toAgent` without a `channel` is the postless, channel-invisible wake.
     const collabAppend =
-      this.deps.collaborationEnabled === false
-        ? ''
-        : `# Collaborating with other agents\n` +
-          `- To reach a specific agent privately, call \`sendMessage\` with ` +
-          `\`{"toAgent":"<agent id>","message":"..."}\` — it wakes ONLY that agent, delivered directly to it ` +
-          `(nothing is posted to the channel). That bare form is FIRE-AND-FORGET: the peer answers inside its own ` +
-          `conversation and nothing comes back to you, not even a failure. Whenever you expect an answer — your ` +
-          `message asks a question or requests a result, or you were asked to relay that agent's answer to someone ` +
-          `— send \`{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}\` instead, which obliges ` +
-          `it to report into YOUR session when it finishes or fails. Add a \`channel\` ` +
-          `(\`{"toAgent":"<agent id>","channel":"<channel id>","message":"..."}\`, channel-root form) ` +
-          `to ALSO post a visible message at that channel's root and anchor the agent's conversation to that post. ` +
-          `That channel-root form may target YOURSELF to open and activate one new conversation there: use your own ` +
-          `ID from the # Agent block (also included by \`listAgents\`), never your platform bot identity. A direct ` +
-          `\`toAgent\` call without \`channel\` may not target yourself. ` +
-          `To speak in the conversation you are already in — including to address a peer or human there — do NOT ` +
-          `call \`sendMessage\`: write your ordinary turn reply and @-mention them in it (use \`listAgents\` to get ` +
-          `a peer's exact \`mention\` token). To reach HUMAN users elsewhere, use the \`toUser\` mode — never put ` +
-          `an AgentConnect agent or your own bot identity in \`toUser\`: ` +
-          `\`{"toUser":"<Slack user id>","message":"..."}\` DMs that person, and adding \`channel\` posts an ` +
-          `@-mention at the channel root. In that channel form, pass ` +
-          `an array such as \`"toUser":["<user id 1>","<user id 2>"]\` to @-mention multiple people in the one ` +
-          `message; arrays are never DMs. If you were woken by another ` +
-          `session, reply with \`{"sessionId":"<Parent session>","message":"..."}\`. To leave a visible note others ` +
-          `catch up on later without waking anyone, use \`{"channel":"<channel id>","message":"..."}\`. Every ` +
-          `visible \`sendMessage\` lands at a channel root and opens a new conversation there.\n` +
-          `- Act only on what is asked of YOU. Do not relay a message onward or start your own broadcast to other ` +
-          `agents unless a human explicitly tells you to.\n` +
-          `- Be quiet about mechanics: don't narrate each step or post a message per action, and don't restate tool ` +
-          `results like "delivered: true". Take the action, add at most one short status line if needed, then end your turn.\n` +
-          `- When another agent introduces itself to you, record it in your memory (a peer roster — id, name, what it ` +
-          `does, how to reach it) so you know who to delegate to later. Then just acknowledge briefly; do NOT re-introduce ` +
-          `yourself back or broadcast to everyone.`
+      `# Collaborating with other agents\n` +
+      `- To reach a specific agent privately, call \`sendMessage\` with ` +
+      `\`{"toAgent":"<agent id>","message":"..."}\` — it wakes ONLY that agent, delivered directly to it ` +
+      `(nothing is posted to the channel). That bare form is FIRE-AND-FORGET: the peer answers inside its own ` +
+      `conversation and nothing comes back to you, not even a failure. Whenever you expect an answer — your ` +
+      `message asks a question or requests a result, or you were asked to relay that agent's answer to someone ` +
+      `— send \`{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}\` instead, which obliges ` +
+      `it to report into YOUR session when it finishes or fails. Add a \`channel\` ` +
+      `(\`{"toAgent":"<agent id>","channel":"<channel id>","message":"..."}\`, channel-root form) ` +
+      `to ALSO post a visible message at that channel's root and anchor the agent's conversation to that post. ` +
+      `That channel-root form may target YOURSELF to open and activate one new conversation there: use your own ` +
+      `ID from the # Agent block (also included by \`listAgents\`), never your platform bot identity. A direct ` +
+      `\`toAgent\` call without \`channel\` may not target yourself. ` +
+      `To speak in the conversation you are already in — including to address a peer or human there — do NOT ` +
+      `call \`sendMessage\`: write your ordinary turn reply and @-mention them in it (use \`listAgents\` to get ` +
+      `a peer's exact \`mention\` token). To reach HUMAN users elsewhere, use the \`toUser\` mode — never put ` +
+      `an AgentConnect agent or your own bot identity in \`toUser\`: ` +
+      `\`{"toUser":"<Slack user id>","message":"..."}\` DMs that person, and adding \`channel\` posts an ` +
+      `@-mention at the channel root. In that channel form, pass ` +
+      `an array such as \`"toUser":["<user id 1>","<user id 2>"]\` to @-mention multiple people in the one ` +
+      `message; arrays are never DMs. If you were woken by another ` +
+      `session, reply with \`{"sessionId":"<Parent session>","message":"..."}\`. To leave a visible note others ` +
+      `catch up on later without waking anyone, use \`{"channel":"<channel id>","message":"..."}\`. Every ` +
+      `visible \`sendMessage\` lands at a channel root and opens a new conversation there.\n` +
+      `- Act only on what is asked of YOU. Do not relay a message onward or start your own broadcast to other ` +
+      `agents unless a human explicitly tells you to.\n` +
+      `- Be quiet about mechanics: don't narrate each step or post a message per action, and don't restate tool ` +
+      `results like "delivered: true". Take the action, add at most one short status line if needed, then end your turn.\n` +
+      `- When another agent introduces itself to you, record it in your memory (a peer roster — id, name, what it ` +
+      `does, how to reach it) so you know who to delegate to later. Then just acknowledge briefly; do NOT re-introduce ` +
+      `yourself back or broadcast to everyone.`
 
     // The parent asked to be told how this session ends (`toAgent.needsReply`). Standing, not a
     // user turn — the obligation outlives the waking turn, so it belongs beside the collaboration

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -93,7 +93,7 @@ describe('Daemon evaluation surface', () => {
       evaluation: {
         observer: collector,
         runId: 'eval-run-1',
-        capabilityProfile: { memory: 'configured', collaboration: 'off' }
+        capabilityProfile: { memory: 'configured' }
       }
     })
     await daemon.start()
@@ -472,7 +472,7 @@ describe('Daemon evaluation surface', () => {
         new Daemon({
           root: scaffold(),
           hostFactory: factory,
-          evaluation: { capabilityProfile: { memory: 'off', collaboration: 'off' } }
+          evaluation: { capabilityProfile: { memory: 'off' } }
         })
     ).toThrow('evaluation capability profile requires an evaluation observer')
   })
@@ -577,7 +577,7 @@ describe('Daemon evaluation surface', () => {
       evaluation: {
         observer: collector,
         runId: 'eval-run-memory-off',
-        capabilityProfile: { memory: 'off', collaboration: 'off' }
+        capabilityProfile: { memory: 'off' }
       }
     })
     await daemon.start()
@@ -594,38 +594,6 @@ describe('Daemon evaluation surface', () => {
     expect(collector.events().map((event) => event.type)).toEqual(
       expect.arrayContaining(['turn.accepted', 'turn.started', 'turn.completed'])
     )
-    await daemon.stop()
-    collector.assertValid()
-  }, 15_000)
-
-  it('rejects peer delivery at the execution boundary when collaboration is off', async () => {
-    const collector = new EvaluationEventCollector()
-    const { factory } = scriptedHost()
-    const daemon = new Daemon({
-      root: scaffold(),
-      hostFactory: factory,
-      evaluation: {
-        observer: collector,
-        runId: 'eval-run-collaboration-off',
-        capabilityProfile: { memory: 'off', collaboration: 'off' }
-      }
-    })
-    await daemon.start()
-
-    const result = await (daemon as any).messageAgent({
-      callerAgentId: AGENT_ID,
-      platform: 'webchat',
-      callerChannel: 'caller-channel',
-      toAgentId: 'peer-agent',
-      text: 'must not be delivered',
-      channel: 'target-channel'
-    })
-
-    expect(result).toMatchObject({ delivered: false, reason: 'capability_disabled' })
-    expect(collector.events().find((event) => event.type === 'collaboration.delivery.rejected')).toMatchObject({
-      agentId: AGENT_ID,
-      data: { toAgentId: 'peer-agent', reason: 'capability_disabled' }
-    })
     await daemon.stop()
     collector.assertValid()
   }, 15_000)

--- a/packages/daemon/test/evaluation-events.test.ts
+++ b/packages/daemon/test/evaluation-events.test.ts
@@ -233,7 +233,7 @@ describe('evaluation event evidence', () => {
       schemaVersion: EVALUATION_RUN_SCHEMA_VERSION,
       runId: 'run-3',
       caseId: 'memory-cross-session-recall',
-      treatment: { name: 'memory-on', memory: 'configured', collaboration: 'off' },
+      treatment: { name: 'memory-on', memory: 'configured' },
       subject: { runtime: 'codex', model: 'gpt-5.5' },
       agentConnect: { commit: 'abc123', dirty: false },
       startedAt: '2026-07-21T00:00:00.000Z',

--- a/packages/daemon/test/evaluation-runner.test.ts
+++ b/packages/daemon/test/evaluation-runner.test.ts
@@ -96,7 +96,7 @@ describe('EvaluationRunner', () => {
     const runner = new EvaluationRunner({
       subjectRoot: subjectTemplate(),
       artifactRoot,
-      treatment: { name: 'memory-off', memory: 'off', collaboration: 'off' },
+      treatment: { name: 'memory-off', memory: 'off' },
       agentConnect: { commit: 'abc123', dirty: false },
       daemonFactory: ({ root, evaluation }) => {
         preparedRoot = root
@@ -139,7 +139,7 @@ describe('EvaluationRunner', () => {
     const manifest = EvaluationRunManifestSchema.parse(JSON.parse(readFileSync(result.manifestPath, 'utf8')))
     expect(manifest).toMatchObject({
       caseId: 'cross-session-memory',
-      treatment: { name: 'memory-off', memory: 'off', collaboration: 'off' },
+      treatment: { name: 'memory-off', memory: 'off' },
       status: 'passed',
       agentConnect: { commit: 'abc123', dirty: false },
       subject: {
@@ -243,7 +243,7 @@ describe('EvaluationRunner', () => {
     expect(result.output).toContain('echo:hello')
     const manifest = EvaluationRunManifestSchema.parse(JSON.parse(readFileSync(result.manifestPath, 'utf8')))
     expect(manifest).toMatchObject({
-      treatment: { name: 'raw-acp', memory: 'off', collaboration: 'off' },
+      treatment: { name: 'raw-acp', memory: 'off' },
       subject: { settings: { execution: 'raw-acp', approvalsReviewer: 'auto_review' } }
     })
     const events = readFileSync(result.eventsPath, 'utf8')
@@ -272,7 +272,7 @@ describe('EvaluationRunner', () => {
     const runner = new EvaluationRunner({
       subjectRoot: subjectTemplate(),
       artifactRoot: mkdtempSync(join(tmpdir(), 'ac-evaluation-artifacts-')),
-      treatment: { name: 'daemon-core', memory: 'off', collaboration: 'off' },
+      treatment: { name: 'daemon-core', memory: 'off' },
       secrets: [secret],
       daemonFactory: ({ root }) => {
         preparedRoot = root
@@ -306,7 +306,7 @@ describe('EvaluationRunner', () => {
     const runner = new EvaluationRunner({
       subjectRoot: subjectTemplate(),
       artifactRoot: mkdtempSync(join(tmpdir(), 'ac-evaluation-artifacts-')),
-      treatment: { name: 'daemon-core', memory: 'off', collaboration: 'off' },
+      treatment: { name: 'daemon-core', memory: 'off' },
       daemonFactory
     })
 
@@ -327,7 +327,7 @@ describe('EvaluationRunner', () => {
     const runner = new EvaluationRunner({
       subjectRoot: subjectTemplate(),
       artifactRoot,
-      treatment: { name: '..', memory: 'off', collaboration: 'off' },
+      treatment: { name: '..', memory: 'off' },
       daemonFactory: vi.fn()
     })
 
@@ -348,7 +348,7 @@ describe('EvaluationRunner', () => {
     const runner = new EvaluationRunner({
       subjectRoot: subjectTemplate(),
       artifactRoot: mkdtempSync(join(tmpdir(), 'ac-evaluation-artifacts-')),
-      treatment: { name: 'daemon-core', memory: 'off', collaboration: 'off' },
+      treatment: { name: 'daemon-core', memory: 'off' },
       daemonFactory: () =>
         ({
           start: async () => {},
@@ -379,7 +379,7 @@ describe('EvaluationRunner', () => {
     const runner = new EvaluationRunner({
       subjectRoot: subjectTemplate(),
       artifactRoot: mkdtempSync(join(tmpdir(), 'ac-evaluation-artifacts-')),
-      treatment: { name: 'daemon-core', memory: 'off', collaboration: 'off' },
+      treatment: { name: 'daemon-core', memory: 'off' },
       daemonFactory: () =>
         ({
           start: () => new Promise<never>(() => {}),
@@ -412,7 +412,7 @@ describe('EvaluationRunner', () => {
     const runner = new EvaluationRunner({
       subjectRoot,
       artifactRoot: mkdtempSync(join(tmpdir(), 'ac-evaluation-artifacts-')),
-      treatment: { name: 'memory-only', memory: 'configured', collaboration: 'off' },
+      treatment: { name: 'memory-only', memory: 'configured' },
       daemonFactory
     })
 
@@ -438,7 +438,7 @@ describe('EvaluationRunner', () => {
     const runner = new EvaluationRunner({
       subjectRoot,
       artifactRoot: mkdtempSync(join(tmpdir(), 'ac-evaluation-artifacts-')),
-      treatment: { name: 'memory-only', memory: 'configured', collaboration: 'off' },
+      treatment: { name: 'memory-only', memory: 'configured' },
       daemonFactory
     })
 
@@ -462,7 +462,7 @@ describe('EvaluationRunner', () => {
       const runner = new EvaluationRunner({
         subjectRoot: subjectTemplate(),
         artifactRoot: mkdtempSync(join(tmpdir(), 'ac-evaluation-artifacts-')),
-        treatment: { name: 'memory-only', memory: 'configured', collaboration: 'off' },
+        treatment: { name: 'memory-only', memory: 'configured' },
         daemonFactory: ({ evaluation }) => {
           const emitter = new EvaluationEventEmitter({ observer: evaluation.observer, runId: evaluation.runId })
           return {
@@ -507,7 +507,7 @@ describe('EvaluationRunner', () => {
     const runner = new EvaluationRunner({
       subjectRoot: subjectTemplate(),
       artifactRoot: mkdtempSync(join(tmpdir(), 'ac-evaluation-artifacts-')),
-      treatment: { name: 'daemon-core', memory: 'off', collaboration: 'off' },
+      treatment: { name: 'daemon-core', memory: 'off' },
       daemonFactory: ({ evaluation }) =>
         ({
           start: async () => {
@@ -540,7 +540,7 @@ describe('EvaluationRunner', () => {
     const runner = new EvaluationRunner({
       subjectRoot: subjectTemplate(),
       artifactRoot: mkdtempSync(join(tmpdir(), 'ac-evaluation-artifacts-')),
-      treatment: { name: 'collaboration-only', memory: 'off', collaboration: 'configured' },
+      treatment: { name: 'collaboration-only', memory: 'off' },
       daemonFactory: ({ evaluation }) => {
         const emitter = new EvaluationEventEmitter({ observer: evaluation.observer, runId: evaluation.runId })
         return {

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -242,15 +242,6 @@ describe('toolsForIntegrations', () => {
     // which is a legitimate reason to send into a conversation the agent is not in.
     expect(description).toContain('@-mentions every listed user')
     expect(sendTargetBranch([slackInt], 'toUser').description).toContain('@-mentions every listed user')
-
-    // Collaboration off leaves only the visible platform targets, so the channel-root cost must
-    // still be stated there (spawnChannelRootSession runs either way).
-    const soloDescription = toolsForIntegrations([slackInt], { collaboration: false }).find(
-      (t) => t.name === 'sendMessage'
-    )!.description
-    expect(soloDescription).toContain('opens a NEW conversation')
-    expect(soloDescription).toContain('ordinary turn reply')
-    expect(soloDescription).toContain('{"toUser":"<Slack user id>","message":"..."}')
   })
 
   it('`toAgent` accepts the bare agent id OR an {agentId, needsReply} object', () => {
@@ -314,7 +305,7 @@ describe('toolsForIntegrations', () => {
     const surfaces = [
       toolsForIntegrations([]),
       toolsForIntegrations([slackInt, telegramInt, discordInt], { sessionTitle: true, organizationKnowledge: true }),
-      toolsForIntegrations([slackInt], { collaboration: false })
+      toolsForIntegrations([slackInt])
     ]
     for (const tools of surfaces) {
       for (const name of retired) expect(tools.map((t) => t.name)).not.toContain(name)
@@ -325,24 +316,31 @@ describe('toolsForIntegrations', () => {
     expect(COLLABORATION_TOOLS.map((t) => t.name)).not.toEqual(expect.arrayContaining(retired))
   })
 
-  it('removes peer targets for a collaboration-off treatment while preserving platform sends', () => {
-    expect(toolsForIntegrations([], { collaboration: false }).map((tool) => tool.name)).toEqual([
-      'readMemory',
-      'writeMemory'
-    ])
-
-    const tools = toolsForIntegrations([slackInt], { collaboration: false })
-    const names = tools.map((tool) => tool.name)
-    for (const gone of ['listAgents', 'listChannelAgents', 'viewSessionStatus']) {
-      expect(names).not.toContain(gone)
+  it('offers one surface only: every composition carries the full production target union', () => {
+    // The user-facing invariant behind removing the evaluation "collaboration off"
+    // toggle: there is exactly ONE tool surface, and it is the production one.
+    // Whatever options a caller composes with, the collaboration tools are present
+    // and sendMessage carries the full four-branch target union in stable order.
+    const surfaces = [
+      toolsForIntegrations([]),
+      toolsForIntegrations([slackInt]),
+      toolsForIntegrations([slackInt, telegramInt, discordInt], { sessionTitle: true, organizationKnowledge: true })
+    ]
+    for (const tools of surfaces) {
+      const names = tools.map((tool) => tool.name)
+      for (const required of ['listAgents', 'listChannelAgents', 'viewSessionStatus', 'sendMessage']) {
+        expect(names).toContain(required)
+      }
+      const send = tools.find((tool) => tool.name === 'sendMessage')!
+      const schema = send.inputSchema as unknown as ObjectSchema
+      expect(schema.oneOf?.map((branch) => branch.required)).toEqual([
+        ['toAgent', 'message'],
+        ['toUser', 'message'],
+        ['channel', 'message'],
+        ['sessionId', 'message']
+      ])
+      expect(send.description).not.toContain('disabled for this run')
     }
-    expect(names).toContain('sendMessage')
-    const send = tools.find((tool) => tool.name === 'sendMessage')!
-    const schema = send.inputSchema as unknown as ObjectSchema
-    expect(schema.oneOf).toHaveLength(2)
-    expect(schema.oneOf?.[0]?.required).toEqual(['toUser', 'message'])
-    expect(schema.oneOf?.[1]?.required).toEqual(['channel', 'message'])
-    expect(send.description).toContain('Peer-agent and parent-session delivery are disabled')
   })
 
   it('injects the session-title fallback only when the runtime is explicitly whitelisted', () => {

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -1905,24 +1905,6 @@ describe('SessionManager — first-class agent thread events', () => {
 })
 
 describe('SessionManager — collaboration preamble', () => {
-  it('omits collaboration standing context when the treatment is off', async () => {
-    const store = newStore()
-    const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
-    const sm = new SessionManager({
-      store,
-      hostFor: async () => host,
-      agentById: () => agent,
-      memory,
-      collaborationEnabled: false
-    })
-    const { blocks } = await sm.handle('bot-a', msg({ ts: '100.1', text: 'hi' }))
-    const metaArg = host.newSession.mock.calls[0][3] as string
-    expect(metaArg).not.toContain('# Collaborating with other agents')
-    expect(metaArg).toContain('# Choosing whether to respond')
-    expect(blocks.at(-1)).toEqual({ type: 'text', text: '[U1] hi' })
-    store.close()
-  })
-
   it('injects the collaboration guidance into a fresh non-Claude session (inline block 0)', async () => {
     const store = newStore()
     const host = { newSession: vi.fn(async () => 'acp-1') } as any


### PR DESCRIPTION
## Why

Evaluation must run the exact same tool surface and messaging mechanism as production. A capability toggle that forks the two means the thing being measured is not the thing being shipped: a "collaboration off" cell exercises a `sendMessage` descriptor, standing context, and delivery path that no production composition can ever produce, so its results say nothing about the product. The only consumer of the off state was the add-on evaluation suite.

## What

**Daemon (production surface — provably unchanged):**
- `packages/daemon/src/mcp/tools.ts` — `toolsForIntegrations()` no longer takes `collaboration`; `COLLABORATION_TOOLS` (`listAgents`/`listChannelAgents`/`viewSessionStatus`) are always injected, and `buildSendMessageTool()` always builds the full production target union (`toAgent`/`toUser`/`channel`/`sessionId`) with the production description. The collaboration-off description branch and the shrunken two-branch union are deleted.
- `packages/daemon/src/session/session-manager.ts` — the `collaborationEnabled` seam is gone; the collaboration standing context is always appended (the always-on production path, byte-for-byte).
- `packages/daemon/src/daemon.ts` — the evaluation profile default is `{ memory: 'configured' }`; the two `capability_disabled` gates in `wakeRejectionReason`/`messageAgent` are removed.

**Fidelity proof:** the default tool surface was dumped as JSON on `main` and on this branch for six integration/option combinations (none, slack, telegram, multi-platform, and both with all options); the outputs are byte-identical. A new test (`mcp-tools.test.ts` "offers one surface only") pins that every composition carries the collaboration tools and the full four-branch `sendMessage` union.

**Evaluation schemas:** `EvaluationCapabilityProfileSchema` and the run-manifest `treatment` schema are memory-only. The field is dropped cleanly (not kept as a vestigial always-`configured` value) because nothing outside the eval suite parses `treatment.collaboration` — the web console and control plane never read run manifests, and the paired-summary extension reads only `treatment.name`. Old manifests still parse (zod strips the unknown key).

**Add-on eval suite behavior change:** the promptfoo matrix collapses from five cells to three — `raw-acp`, `daemon-core` (memory off), `memory-only` (memory configured) — because `collaboration-only` and `both` are now literally identical to `daemon-core` and `memory-only`. The collaboration case runs in `daemon-core` as a functional check of specialist delivery/reply on the production surface (its former `daemon-core` control, which expected `COLLABORATION-UNAVAILABLE`, no longer exists as a distinct composition). The paired summary keeps the `core` and `memory` deltas and drops `collaboration`/`interaction`, which can no longer be formed from distinct cells.

**Docs:** `agent-capability-benchmark-harness.md`, `collaboration-arena.md`, and `evals/README.md` updated to state there is no collaboration-off composition.

**Out of scope:** the `memory: 'off' | 'configured'` profile axis is deliberately untouched — it is a separate decision.

## Verification

- `pnpm typecheck`, `pnpm lint`, `tsc -p evals/tsconfig.json`, `node evals/run-validate.mjs` — clean.
- `pnpm --filter @agentconnect.md/daemon test` — all touched-area suites pass; the only failures are the five known pre-existing flaky files (acp-matrix, cp-agent-reconcile, daemon-agent-mention-routing, daemon-platform-authorship, reconcile-watch), reproduced identically on a clean `main` checkout in the same environment.
- `pnpm eval:contracts` — 46/46 passed.
- `pnpm eval:collab:contracts` — 115/115 passed, matching the current `main` baseline exactly (verified by running both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)