### PR TITLE
fix(setup): delete the Logto Cloud demo connectors blocking managed social targets

### DIFF
--- a/packages/setup/src/server/logto-management.ts
+++ b/packages/setup/src/server/logto-management.ts
@@ -5,6 +5,17 @@ import { ADMIN_ROLE } from './auth.js'
 const MANAGED_APP_TAG = 'agentconnectSetup'
 const MANAGED_APP_TAG_VALUE = { version: 1, resource: 'browser' } as const
 
+/**
+ * Logto Cloud seeds new tenants with demo connectors that sit on real social targets such as
+ * `github` and `google`. Logto treats them as read-only fixtures: `GET` and `PATCH
+ * /api/connectors/:id` both answer 404, the listing hides their config, and creating the real
+ * connector fails with 422 `connector.multiple_target_with_same_platform` while one still holds
+ * the target. So a demo connector is never a connector we can adopt — it is an obstacle to remove
+ * before the managed one is created. `isDemo` is Logto's own flag; the id list is the fallback for
+ * deployments whose Logto predates it.
+ */
+const DEMO_CONNECTOR_IDS: readonly string[] = ['logto-social-demo', 'logto-sms']
+
 export interface LogtoManagementConfig {
   endpoint: string
   appId: string
@@ -43,6 +54,7 @@ interface LogtoConnector {
   connectorId: string
   target: string
   name: string | null
+  isDemo: boolean
   config: Record<string, unknown>
 }
 
@@ -186,6 +198,7 @@ function parseConnector(value: unknown): LogtoConnector | null {
     connectorId: row.connectorId,
     target,
     name: typeof name === 'string' ? name : null,
+    isDemo: row.isDemo === true || DEMO_CONNECTOR_IDS.includes(row.connectorId),
     config: asRecord(row.config)
   }
 }
@@ -233,7 +246,7 @@ function connectorMatches(connector: LogtoConnector, desired: ReturnType<typeof 
 }
 
 function selectConnector(connectors: readonly LogtoConnector[], target: string): LogtoConnector | undefined {
-  const matches = connectors.filter((connector) => connector.target === target)
+  const matches = connectors.filter((connector) => !connector.isDemo && connector.target === target)
   if (matches.length <= 1) return matches[0]
   throw new LogtoManagementError(
     'SOCIAL_CONNECTOR_AMBIGUOUS',
@@ -243,9 +256,16 @@ function selectConnector(connectors: readonly LogtoConnector[], target: string):
 
 function selectConnectorByName(connectors: readonly LogtoConnector[], name: string): LogtoConnector | undefined {
   const normalized = name.trim().toLocaleLowerCase('en-US')
-  const matches = connectors.filter((connector) => connector.name?.trim().toLocaleLowerCase('en-US') === normalized)
+  const matches = connectors.filter(
+    (connector) => !connector.isDemo && connector.name?.trim().toLocaleLowerCase('en-US') === normalized
+  )
   if (matches.length <= 1) return matches[0]
   throw new LogtoManagementError('SOCIAL_CONNECTOR_AMBIGUOUS', `Logto has more than one social connector named ${name}`)
+}
+
+/** Demo connectors holding a social target we need. They block creation and cannot be patched. */
+function selectDemoConnectors(connectors: readonly LogtoConnector[], target: string): LogtoConnector[] {
+  return connectors.filter((connector) => connector.isDemo && connector.target === target)
 }
 
 export class LogtoAdminClaimClient {
@@ -368,6 +388,13 @@ export class LogtoAdminClaimClient {
         diff: applicationDiff
       },
       connectors: desired.socialProviders.map((target) => {
+        // A Logto Cloud demo connector on this target is not the connector we want; report it so
+        // the operator sees why the target reads as missing and what reconciliation will remove.
+        const demos = selectDemoConnectors(connectors, target).map((demo): LogtoConfigurationDiff => ({
+          field: `${target} demo connector`,
+          current: demo.name ?? demo.connectorId,
+          expected: 'Removed'
+        }))
         if (!isManagedConnectorTarget(target)) {
           const connector = selectConnector(connectors, target)
           return {
@@ -375,12 +402,14 @@ export class LogtoAdminClaimClient {
             id: connector?.id ?? null,
             exists: connector !== undefined,
             matches: connector !== undefined,
-            diff: connector ? [] : [{ field: `${target} connector`, current: 'Missing', expected: 'Configured' }]
+            diff: connector
+              ? demos
+              : [...demos, { field: `${target} connector`, current: 'Missing', expected: 'Configured' }]
           }
         }
         const expected = desiredConnector(target, desired)
         const connector = selectConnector(connectors, target)
-        const diff: LogtoConfigurationDiff[] = []
+        const diff: LogtoConfigurationDiff[] = [...demos]
         if (!connector) {
           diff.push({ field: `${target} connector`, current: 'Missing', expected: expected.id })
         } else {
@@ -389,7 +418,7 @@ export class LogtoAdminClaimClient {
           if (target === 'slack') {
             addDiff(diff, 'Slack OIDC scope', connector.config.scope ?? null, expected.config.scope ?? null)
           }
-          if (!connectorMatches(connector, expected) && diff.length === 0) {
+          if (!connectorMatches(connector, expected) && diff.length === demos.length) {
             diff.push({ field: `${target} OAuth client settings`, current: '*** (different)', expected: '***' })
           }
         }
@@ -578,15 +607,20 @@ export class LogtoAdminClaimClient {
       if (!isManagedConnectorTarget(target)) {
         const connector = selectConnector(existing, target)
         if (!connector) {
+          // Never delete a demo connector we cannot replace — name it so the operator can.
           throw new LogtoManagementError(
             'SOCIAL_CONNECTOR_UNSUPPORTED',
-            `automatic creation is not supported for the missing Logto social connector ${target}`
+            selectDemoConnectors(existing, target).length > 0
+              ? `a Logto demo connector occupies the ${target} social target; delete it in Logto, then create the real ${target} connector`
+              : `automatic creation is not supported for the missing Logto social connector ${target}`
           )
         }
         result.push({ target, id: connector.id, created: false, changed: false })
         continue
       }
+      // Resolve the replacement first: a missing credential must fail before anything is deleted.
       const expected = desiredConnector(target, desired)
+      await this.deleteDemoConnectors(existing, target)
       const connector = selectConnector(existing, target)
       if (connector && connectorMatches(connector, expected) && !refreshSecrets) {
         result.push({ target, id: connector.id, created: false, changed: false })
@@ -628,6 +662,17 @@ export class LogtoAdminClaimClient {
       result.push({ target, id: created.id, created: true, changed: true })
     }
     return result
+  }
+
+  /**
+   * Drop the Logto Cloud demo connectors parked on a managed target. Logto rejects creating the
+   * real connector while one holds the same target and platform, and rejects patching the demo one.
+   */
+  private async deleteDemoConnectors(existing: LogtoConnector[], target: string): Promise<void> {
+    for (const demo of selectDemoConnectors(existing, target)) {
+      await this.request(`/api/connectors/${encodeURIComponent(demo.id)}`, { method: 'DELETE' })
+      existing.splice(existing.indexOf(demo), 1)
+    }
   }
 
   private async listConnectors(): Promise<LogtoConnector[]> {

--- a/packages/setup/test/logto-management.test.ts
+++ b/packages/setup/test/logto-management.test.ts
@@ -250,4 +250,140 @@ describe('Logto setup reconciliation', () => {
       signInMode: 'SignInAndRegister'
     })
   })
+
+  it('deletes the Logto Cloud demo connectors parked on the managed social targets', async () => {
+    // A Logto Cloud tenant ships demo connectors sitting on real targets. Logto answers 404 to a
+    // PATCH and 422 to a create while one holds the target, so setup has to delete it first.
+    const connectors: Record<string, unknown>[] = [
+      { id: 'demo-github', connectorId: 'logto-social-demo', target: 'github', isDemo: true, config: {} },
+      { id: 'demo-google', connectorId: 'logto-social-demo', target: 'google', isDemo: true, config: {} }
+    ]
+    const deleted: string[] = []
+    let application: Record<string, unknown> | undefined
+    let role: Record<string, unknown> | undefined
+    let signInExperience: Record<string, unknown> = {
+      signIn: { methods: [] },
+      signUp: { identifiers: [], password: false, verify: false, secondaryIdentifiers: [] },
+      socialSignInConnectorTargets: ['github', 'google'],
+      signInMode: 'SignInAndRegister'
+    }
+    const fetcher: typeof fetch = async (input, init) => {
+      const url = new URL(String(input))
+      if (url.pathname === '/oidc/token') return response({ access_token: 'management-token', expires_in: 3600 })
+      if (url.pathname === '/api/applications' && init?.method === 'POST') {
+        application = { id: 'browser-app', ...JSON.parse(String(init.body)) }
+        return response(application)
+      }
+      if (url.pathname === '/api/applications') return response(application ? [application] : [])
+      const connectorId = url.pathname.startsWith('/api/connectors/')
+        ? decodeURIComponent(url.pathname.slice('/api/connectors/'.length))
+        : undefined
+      if (connectorId && init?.method === 'DELETE') {
+        const index = connectors.findIndex((connector) => connector.id === connectorId)
+        // Logto hides demo connectors from every by-id read, so only a delete may reach one.
+        if (index < 0) return response({ code: 'connector.not_found' }, 404)
+        connectors.splice(index, 1)
+        deleted.push(connectorId)
+        return new Response(null, { status: 204 })
+      }
+      if (connectorId) return response({ code: 'connector.not_found' }, 404)
+      if (url.pathname === '/api/connectors' && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body)) as Record<string, unknown>
+        const target = body.connectorId === 'google-universal' ? 'google' : 'github'
+        // Logto rejects a create while another social connector holds the same target.
+        if (connectors.some((connector) => connector.target === target)) {
+          return response({ code: 'connector.multiple_target_with_same_platform' }, 422)
+        }
+        const connector = { ...body, target }
+        connectors.push(connector)
+        return response(connector)
+      }
+      if (url.pathname === '/api/connectors') return response(connectors)
+      if (url.pathname === '/api/sign-in-exp' && init?.method === 'PATCH') {
+        signInExperience = { ...signInExperience, ...JSON.parse(String(init.body)) }
+        return response(signInExperience)
+      }
+      if (url.pathname === '/api/sign-in-exp') return response(signInExperience)
+      if (url.pathname === '/api/roles' && url.search) return response(role ? [role] : [])
+      if (url.pathname === '/api/roles') {
+        role = { id: 'admin-role', ...JSON.parse(String(init?.body)) }
+        return response(role)
+      }
+      return response({}, 404)
+    }
+    const client = new LogtoAdminClaimClient(config, fetcher)
+    const desired = {
+      applicationName: 'AgentConnect',
+      redirectUris: ['http://localhost:3000/auth/callback'],
+      postLogoutRedirectUris: ['http://localhost:3000/login'],
+      socialProviders: ['github', 'google'],
+      github: { clientId: 'github-client', clientSecret: 'github-secret' },
+      google: { clientId: 'google-client', clientSecret: 'google-secret' }
+    }
+
+    // The demo connectors are obstacles, not connectors to adopt: the inspection reports both the
+    // pending removal and the missing managed connector.
+    await expect(client.inspectSetup(desired)).resolves.toMatchObject({
+      connectors: [
+        {
+          target: 'github',
+          id: null,
+          exists: false,
+          matches: false,
+          diff: [
+            { field: 'github demo connector', current: 'logto-social-demo', expected: 'Removed' },
+            { field: 'github connector', current: 'Missing', expected: 'agentconnect-github' }
+          ]
+        },
+        { target: 'google', id: null, exists: false, matches: false }
+      ]
+    })
+
+    await expect(client.reconcileSetup(desired)).resolves.toMatchObject({
+      changed: true,
+      connectors: [
+        { target: 'github', id: 'agentconnect-github', created: true, changed: true },
+        { target: 'google', id: 'agentconnect-google', created: true, changed: true }
+      ]
+    })
+    expect(deleted).toEqual(['demo-github', 'demo-google'])
+    expect(connectors.map((connector) => connector.id)).toEqual(['agentconnect-github', 'agentconnect-google'])
+
+    // Second pass: nothing left to delete, and the managed connectors are adopted as-is.
+    await expect(client.reconcileSetup(desired)).resolves.toMatchObject({
+      changed: false,
+      connectors: [
+        { target: 'github', id: 'agentconnect-github', created: false, changed: false },
+        { target: 'google', id: 'agentconnect-google', created: false, changed: false }
+      ]
+    })
+    expect(deleted).toEqual(['demo-github', 'demo-google'])
+  })
+
+  it('reports a demo connector blocking a social target it cannot recreate', async () => {
+    const connectors = [
+      { id: 'demo-feishu', connectorId: 'logto-social-demo', target: 'feishu', isDemo: true, config: {} }
+    ]
+    const fetcher: typeof fetch = async (input, init) => {
+      const url = new URL(String(input))
+      if (url.pathname === '/oidc/token') return response({ access_token: 'management-token', expires_in: 3600 })
+      if (url.pathname === '/api/applications' && init?.method === 'POST') {
+        return response({ id: 'browser-app', ...JSON.parse(String(init.body)) })
+      }
+      if (url.pathname === '/api/applications') return response([])
+      if (url.pathname === '/api/connectors') return response(connectors)
+      return response({}, 404)
+    }
+
+    await expect(
+      new LogtoAdminClaimClient(config, fetcher).reconcileSetup({
+        applicationName: 'AgentConnect',
+        redirectUris: ['http://localhost:3000/auth/callback'],
+        postLogoutRedirectUris: ['http://localhost:3000/login'],
+        socialProviders: ['feishu']
+      })
+    ).rejects.toMatchObject({ code: 'SOCIAL_CONNECTOR_UNSUPPORTED' })
+    // Setup cannot create a Feishu connector, so it must not delete the one occupying the target.
+    expect(connectors).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
## The bug

Setup Server could never finish Logto sign-in setup against a **Logto Cloud** tenant. Cloud seeds new tenants with *demo connectors* parked on the real social targets (`github`, `google`, …), and Logto treats those rows as read-only fixtures:

| Operation on a demo connector | Logto's answer |
| --- | --- |
| `GET` / `PATCH /api/connectors/:id` | 404 `connector.not_found` |
| `POST /api/connectors` for the same target | 422 `connector.multiple_target_with_same_platform` |
| `GET /api/connectors` (list) | returned, but with `config: {}` and `isDemo: true` |
| `DELETE /api/connectors/:id` | allowed |

`ensureConnectors` selected connectors purely by target, so it adopted the demo row as "the GitHub connector", found a mismatch (the blanked config means `connectorMatches` can never be true), and issued a `PATCH` → 404 → `LOGTO_UNAVAILABLE`. `resolveConnectorIds` had the same flaw from the other side: it handed the demo connector's id out as the Google callback id, which then propagated into the GitHub and Slack app manifests.

## The fix

A demo connector is never a connector we can adopt — it is an obstacle to remove.

- Parse Logto's own `isDemo` flag, falling back to the reserved connector ids (`logto-social-demo`, `logto-sms`) for deployments whose Logto predates it.
- `selectConnector` / `selectConnectorByName` skip demo connectors, so one is never adopted and no longer trips `SOCIAL_CONNECTOR_AMBIGUOUS`.
- `ensureConnectors` deletes the demo connector occupying a managed target (`github` / `google` / `slack`) before creating the real one. The replacement is resolved **first**, so a missing client secret still fails before anything is deleted.
- For a target Setup cannot create — the manually configured Feishu / Lark OAuth 2.0 connectors — the demo connector is **left alone** and named in the error instead. Deleting something we cannot replace would leave the tenant with nothing.
- `inspectSetup` reports the pending removal as a `<target> demo connector → Removed` diff row, so the console shows the deletion before it happens rather than a bare "Missing".

## Notes for reviewers

- The behaviours in the table above were read off Logto's connector routes, not inferred from the failure. The demo-connectors-on-real-targets detail is confirmed by Logto's own `PATCH /api/sign-in-exp?removeUnusedDemoSocialConnector`, which matches demo connectors' `metadata.target` against real provider targets.
- Deletion is scoped to targets we are about to recreate, and only ever reached after the desired connector (with credentials) has been resolved.
- `DELETE` failures are not swallowed; they surface as `LOGTO_UNAVAILABLE` like every other management call in this client.

## Tests

Two new cases in `packages/setup/test/logto-management.test.ts`:

- a Cloud-shaped tenant (demo rows on `github`/`google`, create returning 422 while one holds the target) reconciles clean, deletes exactly the two demo rows, and is idempotent on a second pass;
- an unmanaged target (`feishu`) fails with `SOCIAL_CONNECTOR_UNSUPPORTED` and the demo connector survives.

`pnpm --filter @agentconnect.md/setup test` — 17 passed. Typecheck, eslint and prettier are clean.

> Unrelated: the suite needs `pnpm --filter @agentconnect.md/control-plane prisma:generate` first in a fresh worktree, otherwise `deployment-config-client.test.ts` fails to import the generated client. `CLAUDE.md` describes that client as committed, but it is not tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)