### PR TITLE
feat(web): add @mention picker to webchat composers

### DIFF
--- a/packages/web/src/components/console/MentionMenu.tsx
+++ b/packages/web/src/components/console/MentionMenu.tsx
@@ -2,6 +2,7 @@
 
 import { AgentIconView } from '@/components/marks'
 import type { AgentIcon } from '@/lib/agent-icon'
+import { MENTION_MENU_MAX_HEIGHT, type MentionCoords } from '@/components/console/useMentionAutocomplete'
 
 export interface MentionOption {
   id: string
@@ -27,18 +28,22 @@ export function MentionMenu({
   options: readonly MentionOption[]
   activeIndex: number
   /** Where the triggering `@` sits inside the textarea (useMentionAutocomplete's
-   *  `coords`) — the list anchors right under that line, not the textarea's edge. */
-  coords: { top: number; left: number; height: number } | null
+   *  `coords`) — the list anchors right under (or, near the bottom of the
+   *  viewport, above) that line, not the textarea's edge. */
+  coords: MentionCoords | null
   onHover: (index: number) => void
   onPick: (option: MentionOption) => void
 }) {
   if (options.length === 0 || !coords) return null
+  const position = coords.openUpward
+    ? { bottom: coords.elHeight - coords.top + 4 }
+    : { top: coords.top + coords.height + 4 }
   return (
     <div
       role="listbox"
       aria-label="Mention an agent"
-      style={{ top: coords.top + coords.height + 4, left: Math.max(0, coords.left - 4) }}
-      className="absolute z-50 max-h-[220px] w-[220px] max-w-[calc(100%-15px)] overflow-y-auto rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
+      style={{ ...position, left: Math.max(0, coords.left - 4), maxHeight: MENTION_MENU_MAX_HEIGHT }}
+      className="absolute z-50 w-[220px] max-w-[calc(100%-15px)] overflow-y-auto rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
     >
       {options.map((option, index) => (
         <button

--- a/packages/web/src/components/console/MentionMenu.tsx
+++ b/packages/web/src/components/console/MentionMenu.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { AgentIconView } from '@/components/marks'
+import type { AgentIcon } from '@/lib/agent-icon'
+
+export interface MentionOption {
+  id: string
+  name: string
+  icon: AgentIcon | null | undefined
+  runtime: string
+  /** Already a conversation participant — picking it only inserts the name.
+   *  Not yet in the roster — picking it also joins the conversation. */
+  inRoster: boolean
+}
+
+/** The @mention picker's floating list (webchat-multi-agents.md §9.1/§9.2).
+ *  Markup mirrors ComposerMenu's dropdown, but it owns no focus/trigger of its
+ *  own — the textarea keeps focus throughout typing, and its onKeyDown drives
+ *  `activeIndex` via useMentionAutocomplete.handleKeyDown. */
+export function MentionMenu({
+  options,
+  activeIndex,
+  coords,
+  onHover,
+  onPick
+}: {
+  options: readonly MentionOption[]
+  activeIndex: number
+  /** Where the triggering `@` sits inside the textarea (useMentionAutocomplete's
+   *  `coords`) — the list anchors right under that line, not the textarea's edge. */
+  coords: { top: number; left: number; height: number } | null
+  onHover: (index: number) => void
+  onPick: (option: MentionOption) => void
+}) {
+  if (options.length === 0 || !coords) return null
+  return (
+    <div
+      role="listbox"
+      aria-label="Mention an agent"
+      style={{ top: coords.top + coords.height + 4, left: Math.max(0, coords.left - 4) }}
+      className="absolute z-50 max-h-[220px] w-[220px] max-w-[calc(100%-15px)] overflow-y-auto rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
+    >
+      {options.map((option, index) => (
+        <button
+          key={option.id}
+          type="button"
+          role="option"
+          aria-selected={index === activeIndex}
+          className={`fopt min-h-8 w-full gap-2 rounded-md px-2 py-[5px] text-[12px] ${
+            index === activeIndex ? 'bg-(--surface-hover)' : ''
+          }`}
+          onMouseEnter={() => onHover(index)}
+          onMouseDown={(event) => {
+            // preventDefault keeps focus (and the caret) in the textarea —
+            // a plain click would blur it before onPick can read selectionStart.
+            event.preventDefault()
+            onPick(option)
+          }}
+        >
+          <span className="av h-[18px] w-[18px] flex-none rounded-xs">
+            <AgentIconView icon={option.icon} runtime={option.runtime} size={18} />
+          </span>
+          <span className="min-w-0 flex-1 truncate text-left">{option.name}</span>
+          {!option.inRoster && <span className="flex-none font-sans text-[10.5px] text-(--text-tertiary)">Add</span>}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/MentionMenu.tsx
+++ b/packages/web/src/components/console/MentionMenu.tsx
@@ -64,12 +64,15 @@ export function MentionMenu({
           key={option.id}
           type="button"
           role="option"
-          aria-selected={index === activeIndex}
+          // A dimmed option is never the "selected" one, ARIA-wise, even
+          // while it sits at activeIndex (the all-dimmed edge case, where
+          // there's nothing reachable to land on).
+          aria-selected={index === activeIndex && !option.dimmed}
           aria-disabled={option.dimmed}
           disabled={option.dimmed}
           title={option.description}
           className={`fopt min-h-8 w-full gap-2 rounded-md px-2 py-[5px] text-[12px] ${
-            index === activeIndex ? 'bg-(--surface-hover)' : ''
+            index === activeIndex && !option.dimmed ? 'bg-(--surface-hover)' : ''
           } ${option.dimmed ? 'cursor-not-allowed opacity-55' : ''}`}
           onMouseEnter={() => {
             if (!option.dimmed) onHover(index)

--- a/packages/web/src/components/console/MentionMenu.tsx
+++ b/packages/web/src/components/console/MentionMenu.tsx
@@ -14,12 +14,12 @@ export interface MentionOption {
   /** Already a conversation participant — picking it only inserts the name.
    *  Not yet in the roster — picking it also joins the conversation. */
   inRoster: boolean
-  /** Offline / no signed-in runtime — shown dimmed with `description` as the
-   *  reason, but still pickable: matches ComposerMenu's existing add-agent
-   *  options ("Render the option dimmed (still selectable)"), so picking one
-   *  here has the exact same consequence picking it there already does —
-   *  Send disables once the roster has an unready member, with the reason in
-   *  the Send button's own tooltip (see HomeView's `notReadyMember`). */
+  /** Offline / no signed-in runtime — shown, with `description` as the
+   *  reason, but not reachable by mouse or keyboard: useMentionAutocomplete's
+   *  arrow-nav skips it and `pick()` refuses it, so — unlike ComposerMenu's
+   *  add-agent options, which ARE still selectable — this can't silently
+   *  disable Send with no visible cause (the mention picker has no per-member
+   *  blocked banner the way HomeView's primary-agent composer does). */
   dimmed?: boolean
   description?: string
 }
@@ -65,17 +65,21 @@ export function MentionMenu({
           type="button"
           role="option"
           aria-selected={index === activeIndex}
+          aria-disabled={option.dimmed}
+          disabled={option.dimmed}
           title={option.description}
           className={`fopt min-h-8 w-full gap-2 rounded-md px-2 py-[5px] text-[12px] ${
             index === activeIndex ? 'bg-(--surface-hover)' : ''
-          } ${option.dimmed ? 'opacity-55' : ''}`}
-          onMouseEnter={() => onHover(index)}
+          } ${option.dimmed ? 'cursor-not-allowed opacity-55' : ''}`}
+          onMouseEnter={() => {
+            if (!option.dimmed) onHover(index)
+          }}
           onMouseDown={(event) => {
             // preventDefault keeps focus in the textarea — a plain click
             // would blur it, and `pick()` needs `ref.current` still pointed
             // at the live element to restore the caret afterward.
             event.preventDefault()
-            onPick(option)
+            if (!option.dimmed) onPick(option)
           }}
         >
           <span className="av h-[18px] w-[18px] flex-none rounded-xs">

--- a/packages/web/src/components/console/MentionMenu.tsx
+++ b/packages/web/src/components/console/MentionMenu.tsx
@@ -4,6 +4,8 @@ import { AgentIconView } from '@/components/marks'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { MENTION_MENU_MAX_HEIGHT, type MentionCoords } from '@/components/console/useMentionAutocomplete'
 
+const MENU_WIDTH = 220
+
 export interface MentionOption {
   id: string
   name: string
@@ -12,6 +14,11 @@ export interface MentionOption {
   /** Already a conversation participant — picking it only inserts the name.
    *  Not yet in the roster — picking it also joins the conversation. */
   inRoster: boolean
+  /** Not selectable right now (offline / no signed-in runtime) — still shown,
+   *  dimmed, with `description` as the reason, matching ComposerMenu's
+   *  existing add-agent options. */
+  dimmed?: boolean
+  description?: string
 }
 
 /** The @mention picker's floating list (webchat-multi-agents.md §9.1/§9.2).
@@ -38,11 +45,15 @@ export function MentionMenu({
   const position = coords.openUpward
     ? { bottom: coords.elHeight - coords.top + 4 }
     : { top: coords.top + coords.height + 4 }
+  // Clamp the LEFT edge too: near the right side of a narrow composer,
+  // `max-w-[calc(100%-15px)]` bounds the menu's own width but not how far
+  // `left` can push it past the textarea's right edge.
+  const left = Math.min(Math.max(0, coords.left - 4), Math.max(0, coords.elWidth - MENU_WIDTH))
   return (
     <div
       role="listbox"
       aria-label="Mention an agent"
-      style={{ ...position, left: Math.max(0, coords.left - 4), maxHeight: MENTION_MENU_MAX_HEIGHT }}
+      style={{ ...position, left, maxHeight: MENTION_MENU_MAX_HEIGHT }}
       className="absolute z-50 w-[220px] max-w-[calc(100%-15px)] overflow-y-auto rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
     >
       {options.map((option, index) => (
@@ -51,13 +62,15 @@ export function MentionMenu({
           type="button"
           role="option"
           aria-selected={index === activeIndex}
+          title={option.description}
           className={`fopt min-h-8 w-full gap-2 rounded-md px-2 py-[5px] text-[12px] ${
             index === activeIndex ? 'bg-(--surface-hover)' : ''
-          }`}
+          } ${option.dimmed ? 'opacity-55' : ''}`}
           onMouseEnter={() => onHover(index)}
           onMouseDown={(event) => {
-            // preventDefault keeps focus (and the caret) in the textarea —
-            // a plain click would blur it before onPick can read selectionStart.
+            // preventDefault keeps focus in the textarea — a plain click
+            // would blur it, and `pick()` needs `ref.current` still pointed
+            // at the live element to restore the caret afterward.
             event.preventDefault()
             onPick(option)
           }}

--- a/packages/web/src/components/console/MentionMenu.tsx
+++ b/packages/web/src/components/console/MentionMenu.tsx
@@ -14,9 +14,12 @@ export interface MentionOption {
   /** Already a conversation participant — picking it only inserts the name.
    *  Not yet in the roster — picking it also joins the conversation. */
   inRoster: boolean
-  /** Not selectable right now (offline / no signed-in runtime) — still shown,
-   *  dimmed, with `description` as the reason, matching ComposerMenu's
-   *  existing add-agent options. */
+  /** Offline / no signed-in runtime — shown dimmed with `description` as the
+   *  reason, but still pickable: matches ComposerMenu's existing add-agent
+   *  options ("Render the option dimmed (still selectable)"), so picking one
+   *  here has the exact same consequence picking it there already does —
+   *  Send disables once the roster has an unready member, with the reason in
+   *  the Send button's own tooltip (see HomeView's `notReadyMember`). */
   dimmed?: boolean
   description?: string
 }

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -80,8 +80,12 @@ interface PlaygroundData {
   /** Add a participant to a LIVE conversation (mid-conversation join,
    *  webchat-multi-agents.md §3.1). Registers the agent with the CP, then
    *  rebuilds the socket so the relay re-verifies and caches the grown roster.
-   *  Failures surface as a ⚠️ transcript step. Refused while a turn streams. */
-  pgAddAgent: (id: string, agent: Agent) => Promise<void>
+   *  Failures surface as a ⚠️ transcript step AND resolve to `false` — the
+   *  promise settling is not itself success (refused-while-busy and rejected
+   *  joins settle normally too), so a caller that gates routing on this join
+   *  (e.g. the mention picker) can tell an actual join from a no-op/refusal.
+   *  Refused while a turn streams. */
+  pgAddAgent: (id: string, agent: Agent) => Promise<boolean>
   /** Returns whether the send was ACCEPTED — false only when there is nothing to
    *  send. A send while a turn is still streaming is accepted too: it QUEUES
    *  (Claude Code-style) and dispatches in order as turns finish. Callers that
@@ -1021,15 +1025,16 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   )
 
   const pgAddAgent = useCallback(
-    async (id: string, added: Agent): Promise<void> => {
+    async (id: string, added: Agent): Promise<boolean> => {
       const orgId = activeOrg?.id
       const session = pgSessions[id]
       const primaryId = session?.agentId
-      if (!orgId || !primaryId) return
-      if (primaryId === added.id || session.participants?.some((p) => p.agentId === added.id)) return
+      if (!orgId || !primaryId) return false
+      // Already there — nothing to join, but not a failure either.
+      if (primaryId === added.id || session.participants?.some((p) => p.agentId === added.id)) return true
       if (busyRef.current[id]) {
         pushStep(id, { kind: 'done', text: '⚠️ Wait for the current reply to finish before adding an agent.' })
-        return
+        return false
       }
       const conversationId = conversationIds.current.get(id)
       if (conversationId) {
@@ -1040,7 +1045,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             kind: 'done',
             text: `⚠️ ${err instanceof ApiError ? err.message : `Could not add ${agentLabel(added)}.`}`
           })
-          return
+          return false
         }
       }
       const ids = rosterAgentIds.current.get(id) ?? [primaryId]
@@ -1075,6 +1080,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         }
         connect(id, primaryId, conversationId).ready.catch(() => {})
       }
+      return true
     },
     [activeOrg, pgSessions, connect, pushStep]
   )

--- a/packages/web/src/components/console/caret-coordinates.ts
+++ b/packages/web/src/components/console/caret-coordinates.ts
@@ -54,12 +54,22 @@ export function caretCoordinates(
   // instead of the span.
   span.textContent = el.value.slice(position) || '.'
   div.appendChild(span)
+  // `line-height` usually resolves to a pixel value even for the CSS keyword
+  // `normal` (e.g. Tailwind's `leading-normal`, used by both composers), but
+  // that resolution isn't guaranteed everywhere — and falling through to
+  // `span.offsetHeight` here would silently reintroduce the multi-line-suffix
+  // bug this height calculation exists to avoid. `font-size * 1.2` is the
+  // standard approximation of a `normal` line box, so it's a safe second
+  // fallback; only an unparseable font-size (essentially never) reaches the
+  // span itself.
   const lineHeight = parseFloat(computed.lineHeight)
-  const coords = {
-    top: span.offsetTop - el.scrollTop,
-    left: span.offsetLeft,
-    height: Number.isFinite(lineHeight) ? lineHeight : span.offsetHeight
-  }
+  const fontSize = parseFloat(computed.fontSize)
+  const height = Number.isFinite(lineHeight)
+    ? lineHeight
+    : Number.isFinite(fontSize)
+      ? fontSize * 1.2
+      : span.offsetHeight
+  const coords = { top: span.offsetTop - el.scrollTop, left: span.offsetLeft, height }
   document.body.removeChild(div)
   return coords
 }

--- a/packages/web/src/components/console/caret-coordinates.ts
+++ b/packages/web/src/components/console/caret-coordinates.ts
@@ -47,9 +47,19 @@ export function caretCoordinates(
   const span = document.createElement('span')
   // An empty span at the very end of the text collapses to zero width — give
   // it a character so offsetTop/offsetLeft still land on the caret's line.
+  // Keeping the actual suffix (rather than just that placeholder) matters for
+  // wrapping fidelity when it's short, but a long suffix can wrap across
+  // several lines — span.offsetHeight would then be that whole block's
+  // height, not one line, so height comes from the mirrored line-height
+  // instead of the span.
   span.textContent = el.value.slice(position) || '.'
   div.appendChild(span)
-  const coords = { top: span.offsetTop - el.scrollTop, left: span.offsetLeft, height: span.offsetHeight }
+  const lineHeight = parseFloat(computed.lineHeight)
+  const coords = {
+    top: span.offsetTop - el.scrollTop,
+    left: span.offsetLeft,
+    height: Number.isFinite(lineHeight) ? lineHeight : span.offsetHeight
+  }
   document.body.removeChild(div)
   return coords
 }

--- a/packages/web/src/components/console/caret-coordinates.ts
+++ b/packages/web/src/components/console/caret-coordinates.ts
@@ -1,0 +1,55 @@
+// The CSS that affects text layout inside a textarea — mirrored onto a hidden
+// clone so measuring where it wraps gives the real caret position. A textarea
+// has no native API for this (the mention picker needs it to anchor under the
+// line being typed, not the textarea's edge — see useMentionAutocomplete).
+const MIRRORED_PROPERTIES = [
+  'boxSizing',
+  'width',
+  'borderTopWidth',
+  'borderRightWidth',
+  'borderBottomWidth',
+  'borderLeftWidth',
+  'borderStyle',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'fontStyle',
+  'fontVariant',
+  'fontWeight',
+  'fontSize',
+  'lineHeight',
+  'fontFamily',
+  'textAlign',
+  'textTransform',
+  'textIndent',
+  'letterSpacing',
+  'wordSpacing',
+  'tabSize'
+] satisfies Array<keyof CSSStyleDeclaration>
+
+/** Pixel offset of `position` inside `el`, relative to el's own top-left
+ *  (post-scroll) — the standard mirror-div trick. */
+export function caretCoordinates(
+  el: HTMLTextAreaElement,
+  position: number
+): { top: number; left: number; height: number } {
+  const div = document.createElement('div')
+  const computed = window.getComputedStyle(el)
+  const style = div.style
+  style.position = 'absolute'
+  style.visibility = 'hidden'
+  style.whiteSpace = 'pre-wrap'
+  style.wordWrap = 'break-word'
+  for (const prop of MIRRORED_PROPERTIES) style[prop] = computed[prop]
+  document.body.appendChild(div)
+  div.textContent = el.value.slice(0, position)
+  const span = document.createElement('span')
+  // An empty span at the very end of the text collapses to zero width — give
+  // it a character so offsetTop/offsetLeft still land on the caret's line.
+  span.textContent = el.value.slice(position) || '.'
+  div.appendChild(span)
+  const coords = { top: span.offsetTop - el.scrollTop, left: span.offsetLeft, height: span.offsetHeight }
+  document.body.removeChild(div)
+  return coords
+}

--- a/packages/web/src/components/console/useMentionAutocomplete.test.tsx
+++ b/packages/web/src/components/console/useMentionAutocomplete.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import { act, useRef, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useMentionAutocomplete } from './useMentionAutocomplete'
+
+interface Candidate {
+  id: string
+  name: string
+}
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  if (root) act(() => root!.unmount())
+  container?.remove()
+  root = null
+  container = null
+})
+
+function mountHarness(onPick: (c: Candidate) => Promise<boolean> | void) {
+  let api!: ReturnType<typeof useMentionAutocomplete<Candidate>>
+  let setDraft!: (v: string) => void
+  let getValue!: () => string
+
+  function Harness() {
+    const [value, setValue] = useState('')
+    const ref = useRef<HTMLTextAreaElement>(null)
+    api = useMentionAutocomplete<Candidate>({ ref, value, setValue, candidates: [], onPick })
+    setDraft = setValue
+    getValue = () => value
+    return <textarea ref={ref} value={value} readOnly />
+  }
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root!.render(<Harness />))
+  return { api: () => api, setDraft: (v: string) => setDraft(v), getValue: () => getValue() }
+}
+
+// A pending join's rollback range is tracked by absolute offset — the
+// regression this covers: an EARLIER pending pick's rollback removes text
+// and shifts everything after it, and a LATER pick's own tracked range has
+// to move with it or its eventual rollback compares against the wrong slice
+// and silently leaves a dangling, unresolved "@Name" behind.
+describe('useMentionAutocomplete — overlapping failed joins', () => {
+  it('shifts a later pending range when an earlier one rolls back first, so both roll back correctly', async () => {
+    let resolveA!: (v: boolean) => void
+    let resolveB!: (v: boolean) => void
+    const pending: Record<string, Promise<boolean>> = {}
+    const { api, setDraft, getValue } = mountHarness(
+      (c) =>
+        new Promise<boolean>((resolve) => {
+          if (c.id === 'a') resolveA = resolve
+          else resolveB = resolve
+        })
+    )
+    void pending
+
+    act(() => {
+      setDraft('@a')
+      api().sync('@a', 2)
+    })
+    act(() => {
+      api().pick({ id: 'a', name: 'alice' })
+    })
+    expect(getValue()).toBe('@alice ')
+
+    act(() => {
+      setDraft('@alice @b')
+      api().sync('@alice @b', 9)
+    })
+    act(() => {
+      api().pick({ id: 'b', name: 'bob' })
+    })
+    expect(getValue()).toBe('@alice @bob ')
+
+    // alice's join fails first — rolls back, and bob's tracked range must
+    // shift left with it or the next rollback targets stale offsets.
+    await act(async () => {
+      resolveA(false)
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(getValue()).toBe('@bob ')
+
+    // bob's join ALSO fails — without the shift, this compares against the
+    // pre-shift slice, finds no match, and leaves "@bob " behind for good.
+    await act(async () => {
+      resolveB(false)
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(getValue()).toBe('')
+  })
+})

--- a/packages/web/src/components/console/useMentionAutocomplete.test.tsx
+++ b/packages/web/src/components/console/useMentionAutocomplete.test.tsx
@@ -152,7 +152,7 @@ function fakeKeyEvent(key: string): ReactKeyboardEvent<HTMLTextAreaElement> & { 
 // which trapped keyboard focus inside the composer (Tab couldn't leave it)
 // while `pick()` silently no-opped.
 describe('useMentionAutocomplete — every match dimmed', () => {
-  it('lets Tab and Enter fall through instead of consuming them with nothing reachable', () => {
+  it("lets Tab fall through AND closes the picker — it can't survive focus leaving anyway", () => {
     const { api, setDraft } = mountHarness(() => undefined, [{ id: 'x', name: 'offline-bot', dimmed: true }])
     act(() => {
       setDraft('@off')
@@ -161,19 +161,32 @@ describe('useMentionAutocomplete — every match dimmed', () => {
     expect(api().matches).toHaveLength(1)
 
     const tab = fakeKeyEvent('Tab')
-    let consumedTab!: boolean
+    let consumed!: boolean
     act(() => {
-      consumedTab = api().handleKeyDown(tab)
+      consumed = api().handleKeyDown(tab)
     })
-    expect(consumedTab).toBe(false)
+    expect(consumed).toBe(false)
     expect(tab.defaultPrevented).toBe(false)
+    // Left open, it would sit there orphaned next to a textarea that no
+    // longer has focus — Tab already moved on, so the menu should too.
+    expect(api().open).toBe(false)
+  })
+
+  it("lets Enter fall through WITHOUT closing — focus never left, so there's nothing to dismiss", () => {
+    const { api, setDraft } = mountHarness(() => undefined, [{ id: 'x', name: 'offline-bot', dimmed: true }])
+    act(() => {
+      setDraft('@off')
+      api().sync('@off', 4)
+    })
+    expect(api().matches).toHaveLength(1)
 
     const enter = fakeKeyEvent('Enter')
-    let consumedEnter!: boolean
+    let consumed!: boolean
     act(() => {
-      consumedEnter = api().handleKeyDown(enter)
+      consumed = api().handleKeyDown(enter)
     })
-    expect(consumedEnter).toBe(false)
+    expect(consumed).toBe(false)
     expect(enter.defaultPrevented).toBe(false)
+    expect(api().open).toBe(true)
   })
 })

--- a/packages/web/src/components/console/useMentionAutocomplete.test.tsx
+++ b/packages/web/src/components/console/useMentionAutocomplete.test.tsx
@@ -94,6 +94,45 @@ describe('useMentionAutocomplete — overlapping failed joins', () => {
     })
     expect(getValue()).toBe('')
   })
+
+  it('rolls back both even when their joins settle in the same microtask batch', async () => {
+    let resolveA!: (v: boolean) => void
+    let resolveB!: (v: boolean) => void
+    const { api, setDraft, getValue } = mountHarness(
+      (c) =>
+        new Promise<boolean>((resolve) => {
+          if (c.id === 'a') resolveA = resolve
+          else resolveB = resolve
+        })
+    )
+
+    act(() => {
+      setDraft('@a')
+      api().sync('@a', 2)
+    })
+    act(() => {
+      api().pick({ id: 'a', name: 'alice' })
+    })
+    act(() => {
+      setDraft('@alice @b')
+      api().sync('@alice @b', 9)
+    })
+    act(() => {
+      api().pick({ id: 'b', name: 'bob' })
+    })
+    expect(getValue()).toBe('@alice @bob ')
+
+    // Both settle back-to-back with NO render (and no `valueRef` refresh
+    // from one) in between — a rollback that only learns `value` moved on
+    // via the next render, instead of writing its own ref synchronously,
+    // would have bob's rollback compare against the pre-removal string.
+    await act(async () => {
+      resolveA(false)
+      resolveB(false)
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(getValue()).toBe('')
+  })
 })
 
 function fakeKeyEvent(key: string): ReactKeyboardEvent<HTMLTextAreaElement> & { defaultPrevented: boolean } {

--- a/packages/web/src/components/console/useMentionAutocomplete.test.tsx
+++ b/packages/web/src/components/console/useMentionAutocomplete.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { act, useRef, useState } from 'react'
+import { act, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it } from 'vitest'
 import { useMentionAutocomplete } from './useMentionAutocomplete'
@@ -7,6 +7,7 @@ import { useMentionAutocomplete } from './useMentionAutocomplete'
 interface Candidate {
   id: string
   name: string
+  dimmed?: boolean
 }
 
 let root: Root | null = null
@@ -19,7 +20,7 @@ afterEach(() => {
   container = null
 })
 
-function mountHarness(onPick: (c: Candidate) => Promise<boolean> | void) {
+function mountHarness(onPick: (c: Candidate) => Promise<boolean> | void, candidates: Candidate[] = []) {
   let api!: ReturnType<typeof useMentionAutocomplete<Candidate>>
   let setDraft!: (v: string) => void
   let getValue!: () => string
@@ -27,7 +28,7 @@ function mountHarness(onPick: (c: Candidate) => Promise<boolean> | void) {
   function Harness() {
     const [value, setValue] = useState('')
     const ref = useRef<HTMLTextAreaElement>(null)
-    api = useMentionAutocomplete<Candidate>({ ref, value, setValue, candidates: [], onPick })
+    api = useMentionAutocomplete<Candidate>({ ref, value, setValue, candidates, onPick })
     setDraft = setValue
     getValue = () => value
     return <textarea ref={ref} value={value} readOnly />
@@ -92,5 +93,48 @@ describe('useMentionAutocomplete — overlapping failed joins', () => {
       await new Promise((r) => setTimeout(r, 0))
     })
     expect(getValue()).toBe('')
+  })
+})
+
+function fakeKeyEvent(key: string): ReactKeyboardEvent<HTMLTextAreaElement> & { defaultPrevented: boolean } {
+  const event = {
+    key,
+    nativeEvent: { isComposing: false },
+    defaultPrevented: false,
+    preventDefault() {
+      event.defaultPrevented = true
+    }
+  }
+  return event as unknown as ReactKeyboardEvent<HTMLTextAreaElement> & { defaultPrevented: boolean }
+}
+
+// The regression: with every match dimmed, there is nothing `pick()` can
+// land on — but handleKeyDown was still swallowing Tab/Enter to try anyway,
+// which trapped keyboard focus inside the composer (Tab couldn't leave it)
+// while `pick()` silently no-opped.
+describe('useMentionAutocomplete — every match dimmed', () => {
+  it('lets Tab and Enter fall through instead of consuming them with nothing reachable', () => {
+    const { api, setDraft } = mountHarness(() => undefined, [{ id: 'x', name: 'offline-bot', dimmed: true }])
+    act(() => {
+      setDraft('@off')
+      api().sync('@off', 4)
+    })
+    expect(api().matches).toHaveLength(1)
+
+    const tab = fakeKeyEvent('Tab')
+    let consumedTab!: boolean
+    act(() => {
+      consumedTab = api().handleKeyDown(tab)
+    })
+    expect(consumedTab).toBe(false)
+    expect(tab.defaultPrevented).toBe(false)
+
+    const enter = fakeKeyEvent('Enter')
+    let consumedEnter!: boolean
+    act(() => {
+      consumedEnter = api().handleKeyDown(enter)
+    })
+    expect(consumedEnter).toBe(false)
+    expect(enter.defaultPrevented).toBe(false)
   })
 })

--- a/packages/web/src/components/console/useMentionAutocomplete.ts
+++ b/packages/web/src/components/console/useMentionAutocomplete.ts
@@ -7,6 +7,9 @@ import { caretCoordinates } from '@/components/console/caret-coordinates'
 export interface MentionCandidate {
   id: string
   name: string
+  /** Shown (so the user can see it exists and why it's out) but not
+   *  reachable by mouse, keyboard nav, or Enter/Tab — see `pick`/`handleKeyDown`. */
+  dimmed?: boolean
 }
 
 /** Mirrors MentionMenu's `max-h` — the worst-case list height used to decide
@@ -28,6 +31,19 @@ export interface MentionCoords {
    *  SessionDetail composer pinned near the bottom of the screen) — the menu
    *  opens upward from the caret's line instead. */
   openUpward: boolean
+}
+
+/** The next index in `list`, `dir` steps from `from`, skipping `dimmed`
+ *  entries — wraps around, and returns `from` unchanged if every entry (or
+ *  the list itself) has nothing reachable to land on. */
+function nextSelectableIndex<T extends MentionCandidate>(list: readonly T[], from: number, dir: 1 | -1): number {
+  if (list.length === 0) return from
+  let i = from
+  for (let steps = 0; steps < list.length; steps++) {
+    i = (i + dir + list.length) % list.length
+    if (!list[i]?.dimmed) return i
+  }
+  return from
 }
 
 /** Composer @mention autocomplete (webchat-multi-agents.md §9.1/§9.2). Typing
@@ -117,8 +133,22 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
     if (anchor && value[anchor.start] !== '@') close()
   }, [value, anchor])
 
+  // A fresh `matches` list (a new query, or the roster/readiness underneath
+  // it changing) can default `activeIndex` onto a dimmed entry — snap it to
+  // the first reachable one instead, so the default highlight is always
+  // something Enter/Tab can actually land on.
+  useEffect(() => {
+    if (matches.length === 0 || !matches[activeIndex]?.dimmed) return
+    const firstReachable = matches.findIndex((m) => !m.dimmed)
+    if (firstReachable !== -1) setActiveIndex(firstReachable)
+  }, [matches, activeIndex])
+
   const pick = (candidate: T) => {
-    if (!anchor) return
+    // Dimmed candidates are visible (so the reason in `description` explains
+    // why) but not choosable — matching HomeView's non-mention "+" add-agent
+    // menu would let one through and silently disable Send with no visible
+    // cause here, since the mention picker has no per-member blocked banner.
+    if (!anchor || candidate.dimmed) return
     const el = ref.current
     // The token's FULL extent, not just the prefix up to the caret — the
     // caret can sit mid-token (see `sync`'s note), and replacing only up to
@@ -165,12 +195,12 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
     if (event.nativeEvent.isComposing) return false
     if (event.key === 'ArrowDown') {
       event.preventDefault()
-      setActiveIndex((i) => (i + 1) % matches.length)
+      setActiveIndex((i) => nextSelectableIndex(matches, i, 1))
       return true
     }
     if (event.key === 'ArrowUp') {
       event.preventDefault()
-      setActiveIndex((i) => (i - 1 + matches.length) % matches.length)
+      setActiveIndex((i) => nextSelectableIndex(matches, i, -1))
       return true
     }
     if (event.key === 'Enter' || event.key === 'Tab') {

--- a/packages/web/src/components/console/useMentionAutocomplete.ts
+++ b/packages/web/src/components/console/useMentionAutocomplete.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState, type KeyboardEvent, type RefObject } from 'react'
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type RefObject } from 'react'
 import { mentionQueryAt, mentionSpanEnd } from '@/lib/conversation-addressing'
 import { caretCoordinates } from '@/components/console/caret-coordinates'
 
@@ -43,15 +43,30 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
   setValue: (v: string) => void
   candidates: readonly T[]
   /** May join the conversation over the network (SessionDetail's mid-conversation
-   *  add) — while that's in flight, `joining` is true so composers can hold off
-   *  sending until the roster actually reflects the pick (or the join failed and
-   *  surfaced its own error) instead of racing an Enter against it. */
-  onPick?: (candidate: T) => void | Promise<void>
+   *  add) — while any such join is in flight, `joining` is true so composers can
+   *  hold off sending until the roster actually reflects the pick(s) instead of
+   *  racing an Enter against them. The promise settling is NOT itself success —
+   *  return `false` for a refusal/failure (a `void`/sync return, e.g. Home's, is
+   *  never a failure — there was nothing to join) — a `false` rolls back the
+   *  optimistically-inserted "@Name " if it's still there untouched, since that
+   *  agent never actually joined and the mention would otherwise look routable
+   *  while resolving to nobody. */
+  onPick?: (candidate: T) => void | Promise<boolean>
 }) {
   const { ref, value, setValue, candidates, onPick } = params
   const [anchor, setAnchor] = useState<{ start: number; query: string } | null>(null)
   const [activeIndex, setActiveIndex] = useState(0)
-  const [joining, setJoining] = useState(false)
+  // A COUNT, not a bool: two quick non-roster picks overlap their joins, and
+  // whichever settles first must not clear the gate out from under the other
+  // still-pending one.
+  const [pendingJoins, setPendingJoins] = useState(0)
+  const joining = pendingJoins > 0
+  // Mirrors `value` for pick()'s rollback, which can run long after the pick
+  // that started it (an async join settling) — by then `value` has moved on
+  // via further edits, and closing over the pick-time value would roll back
+  // against a draft that no longer exists.
+  const valueRef = useRef(value)
+  valueRef.current = value
   // Where the triggering `@` sits on screen, so the list drops right under the
   // line being typed — not the textarea's edge, which reads as broken on a
   // tall, mostly-empty composer (a multi-row textarea's bottom can be far from
@@ -121,8 +136,22 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
     })
     const result = onPick?.(candidate)
     if (result instanceof Promise) {
-      setJoining(true)
-      result.finally(() => setJoining(false))
+      const insertStart = before.length
+      const insertEnd = insertStart + insertedText.length
+      setPendingJoins((n) => n + 1)
+      result
+        .then((success) => {
+          if (success !== false) return
+          // Best-effort, bounded rollback: only remove the token if it's
+          // EXACTLY what this pick inserted and nothing since has touched
+          // that range — never eat into unrelated edits the user made while
+          // the join was in flight.
+          const cur = valueRef.current
+          if (cur.slice(insertStart, insertEnd) === insertedText) {
+            setValue(cur.slice(0, insertStart) + cur.slice(insertEnd))
+          }
+        })
+        .finally(() => setPendingJoins((n) => n - 1))
     }
   }
 

--- a/packages/web/src/components/console/useMentionAutocomplete.ts
+++ b/packages/web/src/components/console/useMentionAutocomplete.ts
@@ -224,8 +224,14 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
       return true
     }
     if (event.key === 'Enter' || event.key === 'Tab') {
+      // Nothing reachable to land on (every match dimmed) — don't consume
+      // the key at all, so Tab still moves focus out of the composer and
+      // Enter still falls through to the composer's own send handling,
+      // instead of both being silently swallowed while `pick()` no-ops.
+      const candidate = matches[activeIndex]
+      if (!candidate || candidate.dimmed) return false
       event.preventDefault()
-      pick(matches[activeIndex]!)
+      pick(candidate)
       return true
     }
     if (event.key === 'Escape') {

--- a/packages/web/src/components/console/useMentionAutocomplete.ts
+++ b/packages/web/src/components/console/useMentionAutocomplete.ts
@@ -1,7 +1,7 @@
 'use client'
 
-import { useMemo, useState, type KeyboardEvent, type RefObject } from 'react'
-import { mentionQueryAt } from '@/lib/conversation-addressing'
+import { useEffect, useMemo, useState, type KeyboardEvent, type RefObject } from 'react'
+import { mentionQueryAt, mentionSpanEnd } from '@/lib/conversation-addressing'
 import { caretCoordinates } from '@/components/console/caret-coordinates'
 
 export interface MentionCandidate {
@@ -21,6 +21,9 @@ export interface MentionCoords {
   /** The textarea's own box height — lets the menu anchor by `bottom` when
    *  flipped upward without knowing its own rendered height in advance. */
   elHeight: number
+  /** The textarea's own box width — lets the menu clamp its right edge to the
+   *  composer instead of overflowing a narrow one. */
+  elWidth: number
   /** True when there isn't room below the caret in the viewport (a
    *  SessionDetail composer pinned near the bottom of the screen) — the menu
    *  opens upward from the caret's line instead. */
@@ -39,11 +42,16 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
   value: string
   setValue: (v: string) => void
   candidates: readonly T[]
-  onPick?: (candidate: T) => void
+  /** May join the conversation over the network (SessionDetail's mid-conversation
+   *  add) — while that's in flight, `joining` is true so composers can hold off
+   *  sending until the roster actually reflects the pick (or the join failed and
+   *  surfaced its own error) instead of racing an Enter against it. */
+  onPick?: (candidate: T) => void | Promise<void>
 }) {
   const { ref, value, setValue, candidates, onPick } = params
   const [anchor, setAnchor] = useState<{ start: number; query: string } | null>(null)
   const [activeIndex, setActiveIndex] = useState(0)
+  const [joining, setJoining] = useState(false)
   // Where the triggering `@` sits on screen, so the list drops right under the
   // line being typed — not the textarea's edge, which reads as broken on a
   // tall, mostly-empty composer (a multi-row textarea's bottom can be far from
@@ -58,7 +66,11 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
 
   const open = matches.length > 0
 
-  /** Call from the textarea's onChange with the just-committed value + caret. */
+  /** Call from the textarea's onChange AND onSelect with the current value +
+   *  caret — re-deriving the anchor on every caret move (not just typing) is
+   *  what keeps `pick()`'s replace range live: arrow keys, Home/End, or a
+   *  click can move the caret without an onChange, and picking against a
+   *  stale anchor either duplicates or drops the token's tail. */
   const sync = (nextValue: string, caret: number) => {
     const next = mentionQueryAt(nextValue, caret)
     setAnchor(next)
@@ -73,7 +85,7 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
     // composer pinned near the bottom of the screen often has no room there.
     const belowY = el.getBoundingClientRect().top + c.top + c.height
     const openUpward = window.innerHeight - belowY < MENTION_MENU_MAX_HEIGHT + 8
-    setCoords({ ...c, elHeight: el.offsetHeight, openUpward })
+    setCoords({ ...c, elHeight: el.offsetHeight, elWidth: el.offsetWidth, openUpward })
   }
 
   const close = () => {
@@ -81,27 +93,47 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
     setCoords(null)
   }
 
+  // A draft can change out from under the anchor without going through
+  // `sync` — a queued send clearing it, a session switch, an external reset —
+  // and picking against a now-mismatched anchor would splice the replacement
+  // into the wrong place. Cheap invariant: the anchor's `@` must still be
+  // there; if `value` moved on without it, drop the stale anchor.
+  useEffect(() => {
+    if (anchor && value[anchor.start] !== '@') close()
+  }, [value, anchor])
+
   const pick = (candidate: T) => {
     if (!anchor) return
     const el = ref.current
-    const caret = el?.selectionStart ?? value.length
+    // The token's FULL extent, not just the prefix up to the caret — the
+    // caret can sit mid-token (see `sync`'s note), and replacing only up to
+    // it would leave the token's tail dangling as stray text.
+    const end = mentionSpanEnd(value, anchor.start)
     const before = value.slice(0, anchor.start)
-    const after = value.slice(caret)
+    const after = value.slice(end)
     const insertedText = `@${candidate.name} `
     setValue(before + insertedText + after)
-    onPick?.(candidate)
     close()
     const pos = before.length + insertedText.length
     requestAnimationFrame(() => {
       el?.focus()
       el?.setSelectionRange(pos, pos)
     })
+    const result = onPick?.(candidate)
+    if (result instanceof Promise) {
+      setJoining(true)
+      result.finally(() => setJoining(false))
+    }
   }
 
   /** Call from the textarea's onKeyDown BEFORE any Enter-sends handling — a
    *  `true` return means the key was consumed by the picker. */
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {
     if (!open) return false
+    // An IME candidate window uses Enter/arrows too (to confirm/navigate a
+    // composition) — let those through untouched instead of the picker
+    // hijacking them while composing.
+    if (event.nativeEvent.isComposing) return false
     if (event.key === 'ArrowDown') {
       event.preventDefault()
       setActiveIndex((i) => (i + 1) % matches.length)
@@ -125,5 +157,5 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
     return false
   }
 
-  return { open, matches, activeIndex, setActiveIndex, coords, sync, handleKeyDown, pick, close }
+  return { open, matches, activeIndex, setActiveIndex, coords, joining, sync, handleKeyDown, pick, close }
 }

--- a/packages/web/src/components/console/useMentionAutocomplete.ts
+++ b/packages/web/src/components/console/useMentionAutocomplete.ts
@@ -83,6 +83,14 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
   // against a draft that no longer exists.
   const valueRef = useRef(value)
   valueRef.current = value
+  // Every pick with a join still pending, keyed by its CURRENT (self-adjusting)
+  // insertion range — a plain per-pick closure over its pick-time offsets would
+  // go stale the moment an EARLIER pending pick rolls back: removing that
+  // token shifts every later offset left, and a later pick's own rollback
+  // would then compare against the wrong slice and silently no-op, leaving a
+  // dangling unresolved mention behind. Sharing one mutable array lets a
+  // rollback walk the others and adjust them before removing itself.
+  const pendingRangesRef = useRef<Array<{ start: number; end: number; text: string }>>([])
   // Where the triggering `@` sits on screen, so the list drops right under the
   // line being typed — not the textarea's edge, which reads as broken on a
   // tall, mostly-empty composer (a multi-row textarea's bottom can be far from
@@ -166,8 +174,8 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
     })
     const result = onPick?.(candidate)
     if (result instanceof Promise) {
-      const insertStart = before.length
-      const insertEnd = insertStart + insertedText.length
+      const range = { start: before.length, end: before.length + insertedText.length, text: insertedText }
+      pendingRangesRef.current.push(range)
       setPendingJoins((n) => n + 1)
       result
         .then((success) => {
@@ -177,11 +185,23 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
           // that range — never eat into unrelated edits the user made while
           // the join was in flight.
           const cur = valueRef.current
-          if (cur.slice(insertStart, insertEnd) === insertedText) {
-            setValue(cur.slice(0, insertStart) + cur.slice(insertEnd))
+          if (cur.slice(range.start, range.end) !== range.text) return
+          setValue(cur.slice(0, range.start) + cur.slice(range.end))
+          // This removal shifts every OTHER still-pending range that sits
+          // after it — keep them pointed at their own token so THEIR
+          // eventual rollback (if any) lands on the right slice too.
+          const removedLength = range.end - range.start
+          for (const other of pendingRangesRef.current) {
+            if (other !== range && other.start >= range.end) {
+              other.start -= removedLength
+              other.end -= removedLength
+            }
           }
         })
-        .finally(() => setPendingJoins((n) => n - 1))
+        .finally(() => {
+          pendingRangesRef.current = pendingRangesRef.current.filter((r) => r !== range)
+          setPendingJoins((n) => n - 1)
+        })
     }
   }
 

--- a/packages/web/src/components/console/useMentionAutocomplete.ts
+++ b/packages/web/src/components/console/useMentionAutocomplete.ts
@@ -234,12 +234,18 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
       return true
     }
     if (event.key === 'Enter' || event.key === 'Tab') {
-      // Nothing reachable to land on (every match dimmed) — don't consume
-      // the key at all, so Tab still moves focus out of the composer and
-      // Enter still falls through to the composer's own send handling,
-      // instead of both being silently swallowed while `pick()` no-ops.
       const candidate = matches[activeIndex]
-      if (!candidate || candidate.dimmed) return false
+      // Nothing reachable to land on (every match dimmed) — don't consume
+      // the key itself, so Tab still moves focus out of the composer and
+      // Enter still falls through to the composer's own send handling.
+      if (!candidate || candidate.dimmed) {
+        // Tab is ALSO leaving the textarea, and the picker doesn't survive
+        // that anyway — close it now rather than leaving it visibly open,
+        // orphaned, next to a control that isn't focused anymore. Enter
+        // doesn't move focus, so it has nothing to close for.
+        if (event.key === 'Tab') close()
+        return false
+      }
       event.preventDefault()
       pick(candidate)
       return true

--- a/packages/web/src/components/console/useMentionAutocomplete.ts
+++ b/packages/web/src/components/console/useMentionAutocomplete.ts
@@ -83,6 +83,16 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
   // against a draft that no longer exists.
   const valueRef = useRef(value)
   valueRef.current = value
+  // Updates `valueRef` synchronously, not just on the next render — two
+  // pending joins failing in the SAME microtask batch (both promises settle
+  // before React commits either `setValue`) would otherwise both read the
+  // pre-batch `valueRef.current`: the second rollback's equality check would
+  // compare against a slice that's already stale by the time it runs, even
+  // though it's only a moment (not a render) behind the first.
+  const commitValue = (next: string) => {
+    valueRef.current = next
+    setValue(next)
+  }
   // Every pick with a join still pending, keyed by its CURRENT (self-adjusting)
   // insertion range — a plain per-pick closure over its pick-time offsets would
   // go stale the moment an EARLIER pending pick rolls back: removing that
@@ -165,7 +175,7 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
     const before = value.slice(0, anchor.start)
     const after = value.slice(end)
     const insertedText = `@${candidate.name} `
-    setValue(before + insertedText + after)
+    commitValue(before + insertedText + after)
     close()
     const pos = before.length + insertedText.length
     requestAnimationFrame(() => {
@@ -186,7 +196,7 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
           // the join was in flight.
           const cur = valueRef.current
           if (cur.slice(range.start, range.end) !== range.text) return
-          setValue(cur.slice(0, range.start) + cur.slice(range.end))
+          commitValue(cur.slice(0, range.start) + cur.slice(range.end))
           // This removal shifts every OTHER still-pending range that sits
           // after it — keep them pointed at their own token so THEIR
           // eventual rollback (if any) lands on the right slice too.

--- a/packages/web/src/components/console/useMentionAutocomplete.ts
+++ b/packages/web/src/components/console/useMentionAutocomplete.ts
@@ -1,0 +1,102 @@
+'use client'
+
+import { useMemo, useState, type KeyboardEvent, type RefObject } from 'react'
+import { mentionQueryAt } from '@/lib/conversation-addressing'
+import { caretCoordinates } from '@/components/console/caret-coordinates'
+
+export interface MentionCandidate {
+  id: string
+  name: string
+}
+
+/** Composer @mention autocomplete (webchat-multi-agents.md §9.1/§9.2). Typing
+ *  `@` opens a picker over `candidates`; picking one inserts `@Name ` at the
+ *  query's start. That inline text is the whole contract with the send path —
+ *  conversation-addressing.ts's typedMentionIds already resolves an `@Name`
+ *  run against the roster into a structural mention, so the picker only has
+ *  to land the exact display-name text, not maintain its own chip model.
+ */
+export function useMentionAutocomplete<T extends MentionCandidate>(params: {
+  ref: RefObject<HTMLTextAreaElement | null>
+  value: string
+  setValue: (v: string) => void
+  candidates: readonly T[]
+  onPick?: (candidate: T) => void
+}) {
+  const { ref, value, setValue, candidates, onPick } = params
+  const [anchor, setAnchor] = useState<{ start: number; query: string } | null>(null)
+  const [activeIndex, setActiveIndex] = useState(0)
+  // Where the triggering `@` sits on screen, so the list drops right under the
+  // line being typed — not the textarea's edge, which reads as broken on a
+  // tall, mostly-empty composer (a multi-row textarea's bottom can be far from
+  // a first-line "@").
+  const [coords, setCoords] = useState<{ top: number; left: number; height: number } | null>(null)
+
+  const matches = useMemo(() => {
+    if (!anchor) return []
+    const q = anchor.query.toLowerCase()
+    return candidates.filter((c) => c.name.toLowerCase().includes(q)).slice(0, 8)
+  }, [anchor, candidates])
+
+  const open = matches.length > 0
+
+  /** Call from the textarea's onChange with the just-committed value + caret. */
+  const sync = (nextValue: string, caret: number) => {
+    const next = mentionQueryAt(nextValue, caret)
+    setAnchor(next)
+    setActiveIndex(0)
+    const el = ref.current
+    setCoords(next && el ? caretCoordinates(el, next.start) : null)
+  }
+
+  const close = () => {
+    setAnchor(null)
+    setCoords(null)
+  }
+
+  const pick = (candidate: T) => {
+    if (!anchor) return
+    const el = ref.current
+    const caret = el?.selectionStart ?? value.length
+    const before = value.slice(0, anchor.start)
+    const after = value.slice(caret)
+    const insertedText = `@${candidate.name} `
+    setValue(before + insertedText + after)
+    onPick?.(candidate)
+    close()
+    const pos = before.length + insertedText.length
+    requestAnimationFrame(() => {
+      el?.focus()
+      el?.setSelectionRange(pos, pos)
+    })
+  }
+
+  /** Call from the textarea's onKeyDown BEFORE any Enter-sends handling — a
+   *  `true` return means the key was consumed by the picker. */
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+    if (!open) return false
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setActiveIndex((i) => (i + 1) % matches.length)
+      return true
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setActiveIndex((i) => (i - 1 + matches.length) % matches.length)
+      return true
+    }
+    if (event.key === 'Enter' || event.key === 'Tab') {
+      event.preventDefault()
+      pick(matches[activeIndex]!)
+      return true
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      close()
+      return true
+    }
+    return false
+  }
+
+  return { open, matches, activeIndex, setActiveIndex, coords, sync, handleKeyDown, pick, close }
+}

--- a/packages/web/src/components/console/useMentionAutocomplete.ts
+++ b/packages/web/src/components/console/useMentionAutocomplete.ts
@@ -9,6 +9,24 @@ export interface MentionCandidate {
   name: string
 }
 
+/** Mirrors MentionMenu's `max-h` — the worst-case list height used to decide
+ *  whether "below the caret" still fits the viewport. */
+export const MENTION_MENU_MAX_HEIGHT = 220
+
+export interface MentionCoords {
+  /** Caret's line, relative to the textarea's own box (post-scroll). */
+  top: number
+  left: number
+  height: number
+  /** The textarea's own box height — lets the menu anchor by `bottom` when
+   *  flipped upward without knowing its own rendered height in advance. */
+  elHeight: number
+  /** True when there isn't room below the caret in the viewport (a
+   *  SessionDetail composer pinned near the bottom of the screen) — the menu
+   *  opens upward from the caret's line instead. */
+  openUpward: boolean
+}
+
 /** Composer @mention autocomplete (webchat-multi-agents.md §9.1/§9.2). Typing
  *  `@` opens a picker over `candidates`; picking one inserts `@Name ` at the
  *  query's start. That inline text is the whole contract with the send path —
@@ -30,7 +48,7 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
   // line being typed — not the textarea's edge, which reads as broken on a
   // tall, mostly-empty composer (a multi-row textarea's bottom can be far from
   // a first-line "@").
-  const [coords, setCoords] = useState<{ top: number; left: number; height: number } | null>(null)
+  const [coords, setCoords] = useState<MentionCoords | null>(null)
 
   const matches = useMemo(() => {
     if (!anchor) return []
@@ -46,7 +64,16 @@ export function useMentionAutocomplete<T extends MentionCandidate>(params: {
     setAnchor(next)
     setActiveIndex(0)
     const el = ref.current
-    setCoords(next && el ? caretCoordinates(el, next.start) : null)
+    if (!next || !el) {
+      setCoords(null)
+      return
+    }
+    const c = caretCoordinates(el, next.start)
+    // Viewport-relative Y just below the caret's line — a SessionDetail
+    // composer pinned near the bottom of the screen often has no room there.
+    const belowY = el.getBoundingClientRect().top + c.top + c.height
+    const openUpward = window.innerHeight - belowY < MENTION_MENU_MAX_HEIGHT + 8
+    setCoords({ ...c, elHeight: el.offsetHeight, openUpward })
   }
 
   const close = () => {

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -285,9 +285,12 @@ export default function HomeView() {
       : authRequiredFor(agent)
         ? 'auth'
         : null
-  // A multi-agent create needs every roster pick startable (the picker only
-  // offers ready agents, but readiness can change while composing).
+  // A multi-agent create needs every roster pick startable — the "+" menu only
+  // OFFERS ready agents, but the @mention picker (unlike it) also lists unready
+  // ones dimmed (so a typed name still resolves to a real candidate), and
+  // readiness can change mid-compose regardless of how a member was added.
   const canSend = !!agent && blocked === null && members.every(agentReady)
+  const notReadyMember = members.find((m) => !agentReady(m))
   const daemonHref = owningDaemon ? orgPath(`/daemons/${owningDaemon.daemonId}`) : null
 
   const onImageFile = async (file: File | undefined): Promise<void> => {
@@ -708,7 +711,11 @@ export default function HomeView() {
                 ? `${agentLabel(agent!)} is offline — can't start a session`
                 : blocked === 'auth'
                   ? `No AI runtime is signed in on ${owningDaemon?.name ?? 'the daemon'} — can't start a session`
-                  : 'Send'
+                  : notReadyMember
+                    ? !isOnline(notReadyMember)
+                      ? `${agentLabel(notReadyMember)} is offline — can't start a session`
+                      : `${agentLabel(notReadyMember)} has no AI runtime signed in — can't start a session`
+                    : 'Send'
             }
           >
             <Icon name="arrow-up" size={15} color="#fff" />

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -16,6 +16,8 @@ import { useIsMobile } from '@/lib/use-is-mobile'
 import { useConsoleData } from '@/lib/data-context'
 import { usePlayground } from '@/components/console/PlaygroundProvider'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
+import { MentionMenu } from '@/components/console/MentionMenu'
+import { useMentionAutocomplete } from '@/components/console/useMentionAutocomplete'
 import { Card, CardLink, EmptyRow, RecentSessionsCard } from '@/components/console/RecentSessionsCard'
 import {
   dashboardRowBudget,
@@ -161,6 +163,32 @@ export default function HomeView() {
   }
 
   const [input, setInput] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  // @mention picker (webchat-multi-agents.md §9.1): typing "@Name" and picking
+  // it also stages that agent as a participant — the same effect as "+ add
+  // agents" — and typedMentionIds() resolves the inserted text back into a
+  // structural mention on send, so no extra state travels with the message.
+  const mentionCandidates = useMemo(
+    () =>
+      agents.map((a) => ({
+        id: a.id,
+        name: agentLabel(a),
+        icon: a.icon,
+        runtime: a.runtime,
+        inRoster: a.id === agent?.id || memberIds.includes(a.id)
+      })),
+    [agents, agent?.id, memberIds]
+  )
+  const mention = useMentionAutocomplete({
+    ref: textareaRef,
+    value: input,
+    setValue: setInput,
+    candidates: mentionCandidates,
+    onPick: (candidate) => {
+      if (candidate.inRoster) return
+      setMemberIds((cur) => (cur.includes(candidate.id) ? cur : [...cur, candidate.id]))
+    }
+  })
   // One prepared image staged for the first turn (mirrors the session composer:
   // prepareWebchatImage bounds it to the wire's 160 KiB WebP budget).
   const [image, setImage] = useState<SessionImage | undefined>(undefined)
@@ -285,6 +313,7 @@ export default function HomeView() {
     // a setPgImage(id) state write could not land before this same-tick send.
     pgSend(id, agent.id, text, undefined, undefined, image)
     setInput('')
+    mention.close()
     setImage(undefined)
     setImageError(null)
     router.push(orgPath(`/sessions/${id}`))
@@ -435,27 +464,41 @@ export default function HomeView() {
             </button>
           </div>
         )}
-        <textarea
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onPaste={(event) => {
-            const file = clipboardImageFile(event.clipboardData)
-            if (!file) return
-            event.preventDefault()
-            void onImageFile(file)
-          }}
-          onKeyDown={(e) => {
-            // Enter sends, except during IME composition (candidate-confirming Enter)
-            // or with Shift (newline).
-            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-              e.preventDefault()
-              send()
-            }
-          }}
-          rows={5}
-          placeholder="Ask agentconnect to connect a workspace, deploy an agent, or check on a run"
-          className="block max-h-[280px] min-h-[140px] w-full resize-none border-0 bg-transparent px-[15px] pt-[14px] pb-1 font-sans text-[14px] leading-normal text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
-        />
+        <div className="relative">
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value)
+              mention.sync(e.target.value, e.target.selectionStart ?? e.target.value.length)
+            }}
+            onPaste={(event) => {
+              const file = clipboardImageFile(event.clipboardData)
+              if (!file) return
+              event.preventDefault()
+              void onImageFile(file)
+            }}
+            onKeyDown={(e) => {
+              if (mention.handleKeyDown(e)) return
+              // Enter sends, except during IME composition (candidate-confirming Enter)
+              // or with Shift (newline).
+              if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+                e.preventDefault()
+                send()
+              }
+            }}
+            rows={5}
+            placeholder="Ask agentconnect to connect a workspace, deploy an agent, or check on a run"
+            className="block max-h-[280px] min-h-[140px] w-full resize-none border-0 bg-transparent px-[15px] pt-[14px] pb-1 font-sans text-[14px] leading-normal text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
+          />
+          <MentionMenu
+            options={mention.matches}
+            activeIndex={mention.activeIndex}
+            coords={mention.coords}
+            onHover={mention.setActiveIndex}
+            onPick={mention.pick}
+          />
+        </div>
         {/* items-start + a wrapping selector group so the controls reflow onto a second
             row at phone widths instead of overflowing (mobile .content clips overflow-x);
             the send button stays pinned top-right. */}

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -16,7 +16,7 @@ import { useIsMobile } from '@/lib/use-is-mobile'
 import { useConsoleData } from '@/lib/data-context'
 import { usePlayground } from '@/components/console/PlaygroundProvider'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
-import { MentionMenu } from '@/components/console/MentionMenu'
+import { MentionMenu, type MentionOption } from '@/components/console/MentionMenu'
 import { useMentionAutocomplete } from '@/components/console/useMentionAutocomplete'
 import { Card, CardLink, EmptyRow, RecentSessionsCard } from '@/components/console/RecentSessionsCard'
 import {
@@ -168,17 +168,28 @@ export default function HomeView() {
   // it also stages that agent as a participant — the same effect as "+ add
   // agents" — and typedMentionIds() resolves the inserted text back into a
   // structural mention on send, so no extra state travels with the message.
-  const mentionCandidates = useMemo(
-    () =>
-      agents.map((a) => ({
-        id: a.id,
-        name: agentLabel(a),
-        icon: a.icon,
-        runtime: a.runtime,
-        inRoster: a.id === agent?.id || memberIds.includes(a.id)
-      })),
-    [agents, agent?.id, memberIds]
-  )
+  // Not memoized: cheap over a handful of agents, and it depends on
+  // `agentReady`/`isOnline` closures that aren't worth tracking as deps —
+  // matches `addOptions` below, which computes the same way.
+  const mentionCandidates: MentionOption[] = agents.map((a) => {
+    const inRoster = a.id === agent?.id || memberIds.includes(a.id)
+    const ready = agentReady(a)
+    return {
+      id: a.id,
+      name: agentLabel(a),
+      icon: a.icon,
+      runtime: a.runtime,
+      inRoster,
+      dimmed: !inRoster && !ready,
+      description: inRoster
+        ? undefined
+        : ready
+          ? 'Add to this conversation'
+          : !isOnline(a)
+            ? `${agentLabel(a)} is offline — its daemon isn't serving`
+            : `${agentLabel(a)} has no AI runtime signed in`
+    }
+  })
   const mention = useMentionAutocomplete({
     ref: textareaRef,
     value: input,
@@ -296,7 +307,7 @@ export default function HomeView() {
 
   const send = () => {
     const text = input.trim()
-    if ((!text && !image) || imagePreparing) return
+    if ((!text && !image) || imagePreparing || mention.joining) return
     if (!agent || !canSend) return // offline / unsigned-in agents can't take a session
     const id = openPlayground(agent, members, !multi && githubWorkspace ? { worktree } : undefined)
     // Stage the EFFECTIVE (displayed) runtime before the turn — not just explicit
@@ -471,6 +482,14 @@ export default function HomeView() {
             onChange={(e) => {
               setInput(e.target.value)
               mention.sync(e.target.value, e.target.selectionStart ?? e.target.value.length)
+            }}
+            onSelect={(e) => {
+              // Re-derives the anchor on every caret move, not just typing —
+              // arrow keys/Home/End/a click can shift the caret without an
+              // onChange, and a stale anchor would make the next pick replace
+              // the wrong range (or stay open after the caret left the token).
+              const el = e.currentTarget
+              mention.sync(el.value, el.selectionStart ?? el.value.length)
             }}
             onPaste={(event) => {
               const file = clipboardImageFile(event.clipboardData)
@@ -682,7 +701,7 @@ export default function HomeView() {
           <button
             type="button"
             className="sendbtn h-7 w-7 flex-none rounded-[7px]"
-            disabled={(!input.trim() && !image) || !canSend || imagePreparing}
+            disabled={(!input.trim() && !image) || !canSend || imagePreparing || mention.joining}
             onClick={send}
             title={
               blocked === 'offline'

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -209,14 +209,18 @@ function ComposerTextarea({
   onSend,
   onImageFile,
   mentionCandidates,
-  onPickMention
+  onPickMention,
+  onMentionJoiningChange
 }: {
   sessionId: string
   placeholder: string
   onSend: () => void
   onImageFile: (file: File) => void
   mentionCandidates: MentionOption[]
-  onPickMention: (option: MentionOption) => void
+  onPickMention: (option: MentionOption) => void | Promise<void>
+  /** Mirrors `mention.joining` up to the parent so the (separately isolated)
+   *  Send button can disable itself too — see the effect below. */
+  onMentionJoiningChange: (joining: boolean) => void
 }) {
   const draft = usePgDraft(sessionId)
   const { setPgInput } = usePlayground()
@@ -231,6 +235,7 @@ function ComposerTextarea({
     candidates: mentionCandidates,
     onPick: onPickMention
   })
+  useEffect(() => onMentionJoiningChange(mention.joining), [mention.joining, onMentionJoiningChange])
   return (
     <div className="relative">
       <textarea
@@ -242,6 +247,12 @@ function ComposerTextarea({
           setPgInput(sessionId, e.target.value)
           mention.sync(e.target.value, e.target.selectionStart ?? e.target.value.length)
         }}
+        onSelect={(e) => {
+          // Re-derives the anchor on every caret move, not just typing — see
+          // the Home composer's identical handler for why.
+          const el = e.currentTarget
+          mention.sync(el.value, el.selectionStart ?? el.value.length)
+        }}
         onPaste={(event) => {
           const image = clipboardImageFile(event.clipboardData)
           if (!image) return
@@ -251,8 +262,9 @@ function ComposerTextarea({
         onKeyDown={(e) => {
           if (mention.handleKeyDown(e)) return
           // Enter sends — but NOT while an IME is composing (that Enter
-          // just confirms the candidate), and Shift+Enter is a newline.
-          if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+          // just confirms the candidate), while a mention join is still in
+          // flight (see onMentionJoiningChange), and Shift+Enter is a newline.
+          if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && !mention.joining) {
             e.preventDefault()
             onSend()
           }
@@ -278,6 +290,7 @@ function ComposerSendButton({
   busy,
   imagePreparing,
   hasImage,
+  mentionJoining,
   onSend,
   onStop
 }: {
@@ -285,6 +298,9 @@ function ComposerSendButton({
   busy: boolean
   imagePreparing: boolean
   hasImage: boolean
+  /** A picked @mention's mid-conversation join is still in flight — see
+   *  ComposerTextarea's onMentionJoiningChange for why Send holds off too. */
+  mentionJoining: boolean
   onSend: () => void
   onStop: () => void
 }) {
@@ -294,7 +310,7 @@ function ComposerSendButton({
       className="sendbtn ml-1 h-[26px] w-[26px] flex-none rounded-[7px]"
       aria-label={busy ? 'Stop response' : 'Send message'}
       onClick={() => (busy ? onStop() : onSend())}
-      disabled={!busy && (imagePreparing || (!hasText && !hasImage))}
+      disabled={!busy && (imagePreparing || mentionJoining || (!hasText && !hasImage))}
     >
       <Icon name={busy ? 'square' : 'arrow-up'} size={busy ? 10 : 14} />
     </button>
@@ -1399,6 +1415,11 @@ export default function SessionDetailView() {
   const [imageError, setImageError] = useState<string | null>(null)
   const [attachMenuOpen, setAttachMenuOpen] = useState(false)
   const [composerMenuOpen, setComposerMenuOpen] = useState<ComposerMenuKey | null>(null)
+  // Mirrors ComposerTextarea's mention.joining (isolated from this component
+  // to keep typing cheap) — true while a picked @mention's mid-conversation
+  // join is still in flight, so the separately-isolated Send button can
+  // disable itself for the same reason ComposerTextarea holds off Enter-send.
+  const [mentionJoining, setMentionJoining] = useState(false)
   const [runtimeSelections, setRuntimeSelections] = useState<
     Record<string, { model?: string; effort?: string; permissionPreset?: string; fast?: boolean }>
   >({})
@@ -2487,7 +2508,7 @@ export default function SessionDetailView() {
   // Resume the webchat conversation by its id (session.channelId == the conversationId);
   // a synthetic playground turn omits it (the CP mints a fresh id).
   const onPgSend = (text?: string) => {
-    if (imagePreparing) return
+    if (imagePreparing || mentionJoining) return
     setImageError(null)
     // Pass the fetched roster: an adopted webchat session has no provider-side
     // state, and without it a multi-agent send can't pre-create stream lanes or
@@ -2572,10 +2593,16 @@ export default function SessionDetailView() {
           return a ? [{ id: a.id, name: p.name, icon: a.icon, runtime: a.runtime, inRoster: true }] : []
         })
       : []
-  const onPickMention = (option: MentionOption) => {
+  // Returns the join's promise (not fire-and-forget): pgAddAgent awaits the
+  // HTTP request before the roster reflects the new participant, and the
+  // composer holds Enter-send off until it settles — sending against the OLD
+  // roster would find no typed mention for the just-picked name and silently
+  // fall back to messaging every existing participant instead (or, on a
+  // failed join, leave the inserted "@Name" text pointing at nobody).
+  const onPickMention = (option: MentionOption): Promise<void> | void => {
     if (option.inRoster) return
     const picked = agents.find((a) => a.id === option.id)
-    if (picked) void pgAddAgent(session.id, picked)
+    return picked ? pgAddAgent(session.id, picked) : undefined
   }
   const onCopyLink = () => {
     try {
@@ -4002,6 +4029,7 @@ export default function SessionDetailView() {
                     onImageFile={(file) => void onImageFile(file)}
                     mentionCandidates={mentionCandidates}
                     onPickMention={onPickMention}
+                    onMentionJoiningChange={setMentionJoining}
                   />
                   <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
                     <div className="relative flex-none">
@@ -4267,6 +4295,7 @@ export default function SessionDetailView() {
                       busy={pgBusy}
                       imagePreparing={imagePreparing}
                       hasImage={!!pgImage}
+                      mentionJoining={mentionJoining}
                       onSend={() => onPgSend()}
                       onStop={() => pgCancel(session.id, session.agentId ?? '', webchatConversationId)}
                     />

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -217,7 +217,7 @@ function ComposerTextarea({
   onSend: () => void
   onImageFile: (file: File) => void
   mentionCandidates: MentionOption[]
-  onPickMention: (option: MentionOption) => void | Promise<void>
+  onPickMention: (option: MentionOption) => void | Promise<boolean>
   /** Mirrors `mention.joining` up to the parent so the (separately isolated)
    *  Send button can disable itself too — see the effect below. */
   onMentionJoiningChange: (joining: boolean) => void
@@ -2599,7 +2599,7 @@ export default function SessionDetailView() {
   // roster would find no typed mention for the just-picked name and silently
   // fall back to messaging every existing participant instead (or, on a
   // failed join, leave the inserted "@Name" text pointing at nobody).
-  const onPickMention = (option: MentionOption): Promise<void> | void => {
+  const onPickMention = (option: MentionOption): Promise<boolean> | void => {
     if (option.inRoster) return
     const picked = agents.find((a) => a.id === option.id)
     return picked ? pgAddAgent(session.id, picked) : undefined

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -83,6 +83,8 @@ import { isAuthConfigured } from '@/lib/auth'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
+import { MentionMenu, type MentionOption } from '@/components/console/MentionMenu'
+import { useMentionAutocomplete } from '@/components/console/useMentionAutocomplete'
 import {
   WORK_LANES,
   sessionTurnInFlight,
@@ -205,36 +207,65 @@ function ComposerTextarea({
   sessionId,
   placeholder,
   onSend,
-  onImageFile
+  onImageFile,
+  mentionCandidates,
+  onPickMention
 }: {
   sessionId: string
   placeholder: string
   onSend: () => void
   onImageFile: (file: File) => void
+  mentionCandidates: MentionOption[]
+  onPickMention: (option: MentionOption) => void
 }) {
   const draft = usePgDraft(sessionId)
   const { setPgInput } = usePlayground()
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  // @mention picker (webchat-multi-agents.md §9.1/§9.2) — same contract as the
+  // Home composer's: picking a candidate inserts "@Name " and typedMentionIds()
+  // resolves that text back into a structural mention on send.
+  const mention = useMentionAutocomplete({
+    ref: textareaRef,
+    value: draft,
+    setValue: (v) => setPgInput(sessionId, v),
+    candidates: mentionCandidates,
+    onPick: onPickMention
+  })
   return (
-    <textarea
-      className="block max-h-[160px] min-h-[56px] w-full resize-none border-0 bg-transparent px-[15px] pt-[13px] pb-[2px] font-sans text-[14px] leading-[1.55] text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
-      placeholder={placeholder}
-      value={draft}
-      onChange={(e) => setPgInput(sessionId, e.target.value)}
-      onPaste={(event) => {
-        const image = clipboardImageFile(event.clipboardData)
-        if (!image) return
-        event.preventDefault()
-        onImageFile(image)
-      }}
-      onKeyDown={(e) => {
-        // Enter sends — but NOT while an IME is composing (that Enter
-        // just confirms the candidate), and Shift+Enter is a newline.
-        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-          e.preventDefault()
-          onSend()
-        }
-      }}
-    />
+    <div className="relative">
+      <textarea
+        ref={textareaRef}
+        className="block max-h-[160px] min-h-[56px] w-full resize-none border-0 bg-transparent px-[15px] pt-[13px] pb-[2px] font-sans text-[14px] leading-[1.55] text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
+        placeholder={placeholder}
+        value={draft}
+        onChange={(e) => {
+          setPgInput(sessionId, e.target.value)
+          mention.sync(e.target.value, e.target.selectionStart ?? e.target.value.length)
+        }}
+        onPaste={(event) => {
+          const image = clipboardImageFile(event.clipboardData)
+          if (!image) return
+          event.preventDefault()
+          onImageFile(image)
+        }}
+        onKeyDown={(e) => {
+          if (mention.handleKeyDown(e)) return
+          // Enter sends — but NOT while an IME is composing (that Enter
+          // just confirms the candidate), and Shift+Enter is a newline.
+          if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+            e.preventDefault()
+            onSend()
+          }
+        }}
+      />
+      <MentionMenu
+        options={mention.matches}
+        activeIndex={mention.activeIndex}
+        coords={mention.coords}
+        onHover={mention.setActiveIndex}
+        onPick={mention.pick}
+      />
+    </div>
   )
 }
 
@@ -2524,6 +2555,28 @@ export default function SessionDetailView() {
           )
         }))
     : []
+  // Same candidate pool as addAgentOptions (isPg can invite; an adopted session
+  // can only narrow among the roster it already has), reshaped for the
+  // @mention picker — see ComposerTextarea's `mention` above.
+  const mentionCandidates: MentionOption[] = isPg
+    ? agents.map((a) => ({
+        id: a.id,
+        name: liveRoster.find((p) => p.agentId === a.id)?.name ?? agentLabel(a),
+        icon: a.icon,
+        runtime: a.runtime,
+        inRoster: liveRoster.some((p) => p.agentId === a.id)
+      }))
+    : multiLive
+      ? liveRoster.flatMap((p) => {
+          const a = agents.find((x) => x.id === p.agentId)
+          return a ? [{ id: a.id, name: p.name, icon: a.icon, runtime: a.runtime, inRoster: true }] : []
+        })
+      : []
+  const onPickMention = (option: MentionOption) => {
+    if (option.inRoster) return
+    const picked = agents.find((a) => a.id === option.id)
+    if (picked) void pgAddAgent(session.id, picked)
+  }
   const onCopyLink = () => {
     try {
       const canonicalId = session.realSessionId ?? session.id
@@ -3947,6 +4000,8 @@ export default function SessionDetailView() {
                     }
                     onSend={() => onPgSend()}
                     onImageFile={(file) => void onImageFile(file)}
+                    mentionCandidates={mentionCandidates}
+                    onPickMention={onPickMention}
                   />
                   <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
                     <div className="relative flex-none">

--- a/packages/web/src/lib/conversation-addressing.test.ts
+++ b/packages/web/src/lib/conversation-addressing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   mentionQueryAt,
+  mentionSpanEnd,
   resolveRoster,
   selfConversationPath,
   typedMentionIds,
@@ -134,6 +135,22 @@ describe('mentionQueryAt', () => {
 
   it('reads the caret position, not the end of the text', () => {
     expect(mentionQueryAt('@agentconnect', 5)).toEqual({ start: 0, query: 'agen' })
+  })
+})
+
+describe('mentionSpanEnd', () => {
+  it('runs to the end of the token, past where the caret currently sits', () => {
+    // "hello @al" with the caret backed up between 'a' and 'l' (position 8) —
+    // the token itself still spans 6..9, so a pick must replace all of it.
+    expect(mentionSpanEnd('hello @al', 6)).toBe(9)
+  })
+
+  it('stops at the next space', () => {
+    expect(mentionSpanEnd('@bob says hi', 0)).toBe(4)
+  })
+
+  it('runs to the end of the text when the token is unterminated', () => {
+    expect(mentionSpanEnd('@bob', 0)).toBe(4)
   })
 })
 

--- a/packages/web/src/lib/conversation-addressing.test.ts
+++ b/packages/web/src/lib/conversation-addressing.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { resolveRoster, selfConversationPath, typedMentionIds, wireMentions } from './conversation-addressing'
+import {
+  mentionQueryAt,
+  resolveRoster,
+  selfConversationPath,
+  typedMentionIds,
+  wireMentions
+} from './conversation-addressing'
 
 const roster = [{ agentId: 'a-primary', primary: true }, { agentId: 'b-peer' }]
 
@@ -105,6 +111,29 @@ describe('typedMentionIds', () => {
 
   it('never narrows a single-agent conversation', () => {
     expect(typedMentionIds([{ agentId: 'solo', name: 'solo' }], '@solo hi')).toEqual([])
+  })
+})
+
+describe('mentionQueryAt', () => {
+  it('finds the run typed after the triggering @', () => {
+    expect(mentionQueryAt('hello @cla', 10)).toEqual({ start: 6, query: 'cla' })
+    expect(mentionQueryAt('hi @', 4)).toEqual({ start: 3, query: '' })
+  })
+
+  it('ends the query at the first space — a finished word is a stale @', () => {
+    expect(mentionQueryAt('hi @agent typing more', 10)).toBeNull()
+  })
+
+  it('ignores an @ welded to the word before it', () => {
+    expect(mentionQueryAt('mail me at foo@test.dev', 15)).toBeNull()
+  })
+
+  it('sees no query without an @', () => {
+    expect(mentionQueryAt('no at signs here', 5)).toBeNull()
+  })
+
+  it('reads the caret position, not the end of the text', () => {
+    expect(mentionQueryAt('@agentconnect', 5)).toEqual({ start: 0, query: 'agen' })
   })
 })
 

--- a/packages/web/src/lib/conversation-addressing.ts
+++ b/packages/web/src/lib/conversation-addressing.ts
@@ -109,6 +109,20 @@ export function mentionQueryAt(text: string, caret: number): { start: number; qu
   return { start: at, query }
 }
 
+/** The full extent of the @mention token starting at `start` (the `@`'s
+ *  index) — the run of non-space characters after it, regardless of where the
+ *  caret currently sits inside that run. Picking an option replaces this
+ *  whole span, not just the prefix up to the caret: the caret can land
+ *  mid-token (arrow keys, a click) after `mentionQueryAt` first found it, and
+ *  replacing only up to a mid-token caret would leave the token's tail behind
+ *  as stray text instead of being consumed by the inserted name.
+ */
+export function mentionSpanEnd(text: string, start: number): number {
+  let end = start + 1
+  while (end < text.length && !/\s/.test(text[end]!)) end++
+  return end
+}
+
 /** Where a `/sessions/:id` deep link goes when its session turns out to belong
  *  to a multi-participant conversation (merged-conversation-view.md §5.3).
  *

--- a/packages/web/src/lib/conversation-addressing.ts
+++ b/packages/web/src/lib/conversation-addressing.ts
@@ -92,6 +92,23 @@ export function typedMentionIds(
   return roster.filter((p) => mentioned.has(p.agentId)).map((p) => p.agentId)
 }
 
+/** The @mention being typed at `caret`, if any (composer autocomplete —
+ *  webchat-multi-agents.md §9.1/§9.2). Mirrors typedMentionIds' left-edge rule:
+ *  an `@` glued to a preceding word addresses no one, so it never opens the
+ *  picker either. A space since the `@` ends the query — the picker narrows on
+ *  the first word only; a multi-word display name still lands in full because
+ *  picking inserts the whole name, not just what was typed.
+ */
+export function mentionQueryAt(text: string, caret: number): { start: number; query: string } | null {
+  const upto = text.slice(0, caret)
+  const at = upto.lastIndexOf('@')
+  if (at === -1) return null
+  const query = upto.slice(at + 1)
+  if (/\s/.test(query)) return null
+  if (at > 0 && NAME_CHAR_RE.test(upto[at - 1]!)) return null
+  return { start: at, query }
+}
+
 /** Where a `/sessions/:id` deep link goes when its session turns out to belong
  *  to a multi-participant conversation (merged-conversation-view.md §5.3).
  *


### PR DESCRIPTION
## Summary
- Home and SessionDetail's composers now open an @mention autocomplete over org agents when you type `@Name`; picking one joins the conversation roster (or narrows an existing multi-agent one) and inserts the exact display-name text.
- No protocol/daemon changes were needed — the wire already resolves an `@Name` run against the roster into a structural mention (`conversation-addressing.ts`'s `typedMentionIds`), so the picker only had to land that text precisely.
- The dropdown anchors under the caret's actual line (mirror-div pixel measurement) instead of the textarea's edge, so it doesn't float away from the typed `@` on a tall, mostly-empty composer.

Closes #730

## Test plan
- [x] `pnpm --filter @agentconnect.md/web typecheck`
- [x] `pnpm --filter @agentconnect.md/web lint`
- [x] `pnpm --filter @agentconnect.md/web test -- conversation-addressing` (new `mentionQueryAt` cases)
- [x] Manually verified in the browser (mock data): typing `@` opens the picker, ↑/↓/Enter/Tab/Esc work, picking a non-roster agent adds it as a participant, and the dropdown anchors under the caret line instead of the textarea's edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)