### PR TITLE
test(relay): poll for router unregister instead of a fixed sleep

### DIFF
--- a/packages/relay/src/relay-browser-server.test.ts
+++ b/packages/relay/src/relay-browser-server.test.ts
@@ -107,7 +107,6 @@ async function nextFrame(ws: BufferedWs, type: string): Promise<Frame> {
     await new Promise((r) => setTimeout(r, 5))
   }
 }
-const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 30))
 
 describe('createRelayBrowserServer (browser webchat edge)', () => {
   it('refuses a dial with no token (401) — never completes the handshake', async () => {
@@ -282,7 +281,8 @@ describe('createRelayBrowserServer (browser webchat edge)', () => {
     await nextFrame(ws, 'ready')
     expect(router.size()).toBe(1)
     ws.close()
-    await tick()
-    expect(router.size()).toBe(0)
+    // The server-side unregister runs async after the close handshake — poll (same 2s
+    // budget as `nextFrame`); a fixed sleep lost the race on a loaded CI runner.
+    await vi.waitFor(() => expect(router.size()).toBe(0), { timeout: 2000, interval: 5 })
   })
 })


### PR DESCRIPTION
## What changed

`unregisters from the router on browser close` in `packages/relay/src/relay-browser-server.test.ts`
waited on a fixed 30ms sleep before asserting the router had emptied:

```ts
ws.close()
await tick()
expect(router.size()).toBe(0)
```

It now waits for the condition itself:

```ts
ws.close()
await vi.waitFor(() => expect(router.size()).toBe(0), { timeout: 2000, interval: 5 })
```

The unused `tick` helper is removed — this assertion was its only caller.

## Why

The server-side close handler that calls `router.unregister` runs asynchronously after
the close handshake completes. A fixed 30ms window is a bet on that handler winning a
race, and on a loaded CI runner it did not always fire in time, so the test failed
intermittently with `AssertionError: expected 1 to be +0`. It passed reliably on an
unloaded machine, which is why it only surfaced in CI.

Polling makes the wait scale with how long the handler actually takes: it returns as
soon as the router is empty, and only spends the full budget when something is genuinely
slow. The 2s timeout matches the budget the file's own `nextFrame` helper already uses.

## Notes for reviewers

- **Scope is deliberately just this flake.** No unrelated cleanup is bundled in.
- **`tick` had exactly one caller.** It was defined at the top of the file but only used
  by this one assertion, so removing it is required rather than optional — leaving it
  would trip the unused-variable lint.
- **The other `setTimeout` in the file is intentionally untouched.** The 5ms sleep inside
  `nextFrame` is that helper's poll interval, not a fixed wait on an observable
  condition, so it does not have the same latent problem. This is the first `vi.waitFor`
  in the file.

## Verification

- `npx vitest run src/relay-browser-server.test.ts --root packages/relay` — 15 consecutive
  runs, 13/13 tests green each time.
- `npx eslint packages/relay/src/relay-browser-server.test.ts` — clean.
- `pnpm --filter @agentconnect.md/relay typecheck` — exit 0.

One caveat worth stating plainly: I did not manage to reproduce the original failure
locally under synthetic CPU load before landing this, so the justification is the
mechanism (a fixed sleep racing an async handler, replaced by a wait on the condition)
rather than an observed red-to-green transition. The pre-existing test passed locally
either way, which is consistent with the report that this only shows up on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)