### PR TITLE
fix(web): point console error text at the defined --status-error token

### DIFF
--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -401,7 +401,7 @@ export function AddToSlackRow({
           </div>
         )}
         {slack.err && (
-          <div className="mt-2 font-sans text-[11.5px] font-normal leading-[1.4] text-(--danger)">
+          <div className="mt-2 font-sans text-[11.5px] font-normal leading-[1.4] text-(--status-error)">
             {slack.err}{' '}
             <button
               type="button"

--- a/packages/web/src/components/console/platforms/slack/Body.tsx
+++ b/packages/web/src/components/console/platforms/slack/Body.tsx
@@ -488,7 +488,7 @@ export function SlackWizardBody({ agent, host }: { agent: Agent; host: WizardHos
               </button>
             )}
             {platformErr && (
-              <div className="mt-2 font-sans text-[11.5px] font-normal leading-[1.4] text-(--danger)">
+              <div className="mt-2 font-sans text-[11.5px] font-normal leading-[1.4] text-(--status-error)">
                 {platformErr}
               </div>
             )}

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -462,7 +462,7 @@ function BotsCard({
                     sentence is the module's (§10 `settingsFragments.copy`) — only
                     Slack can name the lifecycle event that put the bot here. */}
                   {b.revokedAt && (
-                    <span className="badge bg-(--status-error-soft) text-(--danger)" title={rowCopy.revokedHint}>
+                    <span className="badge bg-(--status-error-soft) text-(--status-error)" title={rowCopy.revokedHint}>
                       revoked
                     </span>
                   )}

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -532,7 +532,7 @@ export default function UsageView() {
         )}
 
         {!data && err && (
-          <div className="px-4 py-7 text-[13px] text-(--text-tertiary) desktop:px-[18px] desktop:text-(--danger-text,var(--text-tertiary))">
+          <div className="px-4 py-7 text-[13px] text-(--status-error) desktop:px-[18px]">
             Couldn’t load usage: {err}
           </div>
         )}


### PR DESCRIPTION
## What

Four console sites styled error text with `--danger`, and one of those with `--danger-text`. Neither token is defined anywhere in the repo:

| | file |
|---|---|
| `text-(--danger)` | `platforms/slack/Body.tsx`, `GettingStartedChecklist.tsx`, `views/IntegrationsView.tsx` |
| `desktop:text-(--danger-text,var(--text-tertiary))` | `views/UsageView.tsx` |

They arrived undefined with the initial import (`bce5c90a7`) and no commit ever added them, so the affected text fell back to the inherited color instead of the error red. The "revoked" bot badge was the most visible case — it read as plain body text on a red-soft background.

All four now use `--status-error`.

## Why this token, not an alias

`STYLE.md` never mentions `--danger`; it states that tokens live in `globals.css` as the single source of truth. The status pairings defined there are `--status-{online,paused,error,info}` plus their `-soft` variants, and `text-(--status-error)` is already the console-wide idiom for error text — around 40 call sites, including the identical `bg-(--status-error-soft) text-(--status-error)` badge pairing in `MemoryConnectionsCard.tsx`. Defining `--danger` as an alias would have introduced a second semantic name for one concept.

## One judgment call worth reviewing

`UsageView.tsx` was not a straight swap:

```diff
-text-(--text-tertiary) desktop:px-[18px] desktop:text-(--danger-text,var(--text-tertiary))
+text-(--status-error) desktop:px-[18px]
```

It carried a `var()` fallback to `--text-tertiary` and scoped the undefined color to `desktop:` only. A literal token swap would have made that error message red on desktop and grey on mobile — a form-factor-dependent error color no token or style rule supports, while every other error string in the console is unconditional. **This changes that one line's mobile rendering from grey to red.** The empty-state sibling directly below it keeps `--text-tertiary`; it is not an error.

## Verification

- `pnpm --filter @agentconnect.md/web typecheck` — clean
- `pnpm exec eslint` on all four files — clean
- `pnpm exec prettier --check` on all four files — clean
- No `--danger` remains in the repo

Measured live in the running console, probing both the old and new class:

| | light | dark |
|---|---|---|
| `--danger` token | undefined | undefined |
| old `text-(--danger)` | `rgb(26,33,43)` — inherited body color | `rgb(237,239,243)` — inherited |
| new `text-(--status-error)` | `rgb(220,75,75)` = `#dc4b4b` | `rgb(239,107,107)` = `#ef6b6b` |

The `UsageView` site is reachable for real: with no control plane running the usage fetch fails and the error branch renders. Confirmed showing the error color in both themes. The other three need error states the mock data does not produce (a failed Slack OAuth install, a revoked bot), so those rest on the computed-style measurement of the same class rather than a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)