### PR TITLE
fix(slack): fail an install whose workspace grant is short on bot scopes

### DIFF
--- a/packages/control-plane/prisma/migrations/20260807000000_slack_platform_install_missing_scopes/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260807000000_slack_platform_install_missing_scopes/migration.sql
@@ -1,0 +1,5 @@
+-- Record WHICH required bot scopes a platform Slack app install failed to obtain.
+-- The console polls this row for the install's outcome, and "reinstall the app"
+-- is only actionable when the failure names the permissions that are absent.
+ALTER TABLE "slack_platform_install"
+  ADD COLUMN "missingScopes" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2087,6 +2087,11 @@ model SlackPlatformInstall {
   // callback's close page shows, so the console can report WHY it failed.
   status          SlackPlatformInstallStatus @default(pending)
   failureReason   String?
+  // The required bot scopes the workspace authorization did not grant, when
+  // `failureReason` is 'missing_scopes'. Empty otherwise. Reported verbatim to
+  // the console: "reinstall the app" is only actionable when it names what is
+  // absent, and the console cannot derive the list from the code alone.
+  missingScopes   String[]                   @default([])
   // For a Settings reauthorization this is populated while pending and fences
   // the OAuth callback to that exact Bot/workspace. Generic installs fill it on
   // completion for the console deep-link.

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1538,9 +1538,13 @@ export const SlackPlatformInstallStatusDto = z.object({
   id: z.string(),
   status: z.enum(['pending', 'completed', 'failed']),
   /** Short code identifying the failure ('denied' | 'expired' |
-   *  'workspace_taken' | 'workspace_mismatch' | 'agent_taken' | 'error') —
-   *  the console renders a message from it. Null unless `failed`. */
+   *  'workspace_taken' | 'workspace_mismatch' | 'agent_taken' |
+   *  'missing_scopes' | 'error') — the console renders a message from it. Null
+   *  unless `failed`. */
   failureReason: z.string().nullable(),
+  /** The required bot scopes Slack did not grant, when `failureReason` is
+   *  'missing_scopes'. Empty on every other outcome. */
+  missingScopes: z.array(z.string()),
   /** The expected workspace bot during a Settings reauthorization, or the
    *  installed bot after a generic install; null otherwise. */
   botId: z.string().nullable()
@@ -3016,6 +3020,16 @@ export const ErrorDto = z.object({
   /** Machine-readable denial reason where the console branches on it (e.g.
    *  github user-authz: GITHUB_IDENTITY_REQUIRED vs USER_NO_ACCESS). */
   code: z.string().optional()
+})
+
+/** The Slack install funnels' error shape. A refusal carrying
+ *  `code: 'SLACK_MISSING_SCOPES'` also names the required bot scopes the
+ *  workspace authorization did not grant — the console renders THAT list, since
+ *  "reinstall the app" is only actionable when it says what is absent. Every
+ *  other refusal from those routes omits the field and reads as a plain
+ *  {@link ErrorDto}. */
+export const SlackInstallErrorDto = ErrorDto.extend({
+  missingScopes: z.array(z.string()).optional()
 })
 
 // Inferred response types — route handlers return these so the zod type provider

--- a/packages/control-plane/src/http/routes/slack-bot-refresh.ts
+++ b/packages/control-plane/src/http/routes/slack-bot-refresh.ts
@@ -27,7 +27,7 @@ import { BotId } from '../../domain/ids.js'
 import { denyViewerWrite, orgOf } from '../rbac.js'
 import { SlackBotRefreshDto, ErrorDto, IdParam, type SlackBotRefreshDtoT } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
-import { mergeManagedSlackManifest, slackOAuthRedirectUri, SLACK_BOT_SCOPES } from '../slack-manifest.js'
+import { checkSlackBotScopes, mergeManagedSlackManifest, slackOAuthRedirectUri } from '../slack-manifest.js'
 import { relayHttpBase } from './slack-install.js'
 
 /** Slack errors from the manifest export/update that mean "this app is not
@@ -162,10 +162,16 @@ export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
           authorization = 'invalid'
         } else if (checked?.status === 'ok' && checked.appId && checked.appId !== bot.slackAppId) {
           authorization = 'app_mismatch'
-        } else if (checked?.status === 'ok' && checked.scopes) {
-          const granted = new Set(checked.scopes)
-          missingScopes = SLACK_BOT_SCOPES.filter((scope) => !granted.has(scope))
-          authorization = missingScopes.length > 0 ? 'reinstall_required' : 'current'
+        } else if (checked?.status === 'ok') {
+          // The same shared diff both install funnels fence on. A grant Slack
+          // declined to report stays `unknown` — silence is not a shortfall.
+          const grant = checkSlackBotScopes(checked.scopes)
+          if (grant.status === 'short') {
+            missingScopes = grant.missing
+            authorization = 'reinstall_required'
+          } else if (grant.status === 'complete') {
+            authorization = 'current'
+          }
         }
 
         return {

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -27,7 +27,7 @@ import { AgentId, OrgId } from '../../domain/ids.js'
 import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { resolveWebAppUrl } from '../../config/env.js'
-import { buildInstallManifest, slackOAuthRedirectUri } from '../slack-manifest.js'
+import { buildInstallManifest, checkSlackBotScopes, slackOAuthRedirectUri } from '../slack-manifest.js'
 import { agentIconBackgroundColor } from '../../agents/agent-icon.js'
 import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
 import { CONFIG_ACCESS_TTL_MS, configUsable } from '../slack-user-config.js'
@@ -42,6 +42,7 @@ import {
   SlackConfigDto,
   IntegrationDto,
   ErrorDto,
+  SlackInstallErrorDto,
   IdParam
 } from '../dto/index.js'
 
@@ -281,11 +282,17 @@ export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
           tags: [Tag.Integrations],
           summary: 'Finalize Slack auto-install',
           description:
-            'Combine the OAuth-obtained bot token (held server-side) with the operator-pasted app-level token to create the bot + integration and push it live, then delete the pending session.',
+            'Combine the OAuth-obtained bot token (held server-side) with the operator-pasted app-level token to create the bot + integration and push it live, then delete the pending session. Refuses with `SLACK_MISSING_SCOPES` (and the `missingScopes` list) when the workspace authorization granted fewer bot scopes than the app requires, so a short install never becomes a bot.',
           operationId: 'finalizeSlackAppInstall',
           params: IdParam,
           body: SlackAppFinalizeBody,
-          response: { 201: IntegrationDto, 400: ErrorDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
+          response: {
+            201: IntegrationDto,
+            400: ErrorDto,
+            403: ErrorDto,
+            404: ErrorDto,
+            409: SlackInstallErrorDto
+          }
         }
       },
       async (req, reply) => {
@@ -369,8 +376,33 @@ export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
         }
 
         // auth.test supplies display-only workspace metadata for the Settings
-        // grouping. It also remains the fallback source for an omitted app name.
+        // grouping. It also remains the fallback source for an omitted app name,
+        // and — via `x-oauth-scopes` — the granted bot scopes checked below.
         const botCheck = slack.verifyBot ? await slack.verifyBot(row.botToken) : null
+
+        // Slack's authorization does not reliably apply every bot permission the
+        // manifest declares, and a short grant installs SILENTLY: the shortfall
+        // only surfaces much later, when a scoped call starts answering
+        // `missing_scope` and the session-access check fails closed. Refuse it
+        // here — while the operator is still in the flow and one reinstall away
+        // — and name the scopes so the console can say which. Before
+        // `installNewSlackBot` on purpose: a short grant must not leave a bot or
+        // integration behind. An inconclusive check never blocks (see
+        // `checkSlackBotScopes`); repairing an ALREADY-installed bot stays the
+        // Settings refresh's job.
+        if (botCheck?.status === 'ok') {
+          const grant = checkSlackBotScopes(botCheck.scopes)
+          if (grant.status === 'short') {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              code: 'SLACK_MISSING_SCOPES',
+              message: `Slack didn’t grant every permission this app needs. Reinstall it in your Slack workspace, then finish here. Missing: ${grant.missing.join(', ')}`,
+              missingScopes: grant.missing
+            })
+          }
+        }
+
         const name = row.name || (botCheck?.status === 'ok' ? botCheck.name : null) || agent.name
         const release = deps.agentMutations.tryBeginMutation(agent.id)
         if (!release) {
@@ -588,7 +620,14 @@ export function slackConfigRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
 }
 
 export type SlackCallbackNote =
-  'connected' | 'denied' | 'expired' | 'error' | 'workspace_taken' | 'workspace_mismatch' | 'agent_taken'
+  | 'connected'
+  | 'denied'
+  | 'expired'
+  | 'error'
+  | 'workspace_taken'
+  | 'workspace_mismatch'
+  | 'agent_taken'
+  | 'missing_scopes'
 
 /**
  * The callback tab is a THROWAWAY — the real flow continues in the ORIGINAL
@@ -618,7 +657,11 @@ export function closePageHtml(note: SlackCallbackNote, consoleUrl?: string): str
               ? 'Slack authorized a different workspace. Close this tab and try again, choosing the workspace shown in AgentConnect.'
               : note === 'agent_taken'
                 ? 'This Slack workspace is already connected to another agent in your organization. Remove that integration first, then try again.'
-                : 'Something went wrong finishing the install. Close this tab and try again in AgentConnect.'
+                : note === 'missing_scopes'
+                  ? // The scopes themselves are listed in AgentConnect (this tab is
+                    // a throwaway and the console is where the retry happens).
+                    'Slack didn’t grant every permission AgentConnect needs. Close this tab — AgentConnect lists which ones are missing.'
+                  : 'Something went wrong finishing the install. Close this tab and try again in AgentConnect.'
   // Auto-close only on success (a failure needs reading). window.close() is allowed
   // for script-opened tabs (this one was window.open'd); the text is the fallback.
   const autoClose = ok ? '<script>setTimeout(function(){try{window.close()}catch(e){}},1500)</script>' : ''

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -36,7 +36,7 @@ import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
 import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { resolveWebAppUrl } from '../../config/env.js'
-import { SLACK_BOT_SCOPES, slackPlatformOAuthRedirectUri } from '../slack-manifest.js'
+import { checkSlackBotScopes, SLACK_BOT_SCOPES, slackPlatformOAuthRedirectUri } from '../slack-manifest.js'
 import { installNewSlackBot } from '../install-slack.js'
 import { BotWorkspaceClaimed } from '../../persistence/errors.js'
 import { closePageHtml, relayHttpBase } from './slack-install.js'
@@ -151,7 +151,7 @@ export function slackPlatformInstallRoutes(deps: HttpDeps, slack: SlackRouteSeam
           tags: [Tag.Integrations],
           summary: 'Poll platform Slack app install',
           description:
-            'Completion signal for the "Add to Slack" round trip: `pending` while the authorize tab is open, then `completed` (the Bot + install are live) or `failed` with a short reason code. Returns no tokens.',
+            'Completion signal for the "Add to Slack" round trip: `pending` while the authorize tab is open, then `completed` (the Bot + install are live) or `failed` with a short reason code. A `missing_scopes` failure also lists the required bot scopes the workspace authorization withheld. Returns no tokens.',
           operationId: 'getSlackPlatformInstall',
           params: z.object({ id: z.string() }),
           response: { 200: SlackPlatformInstallStatusDto, 404: ErrorDto }
@@ -164,7 +164,13 @@ export function slackPlatformInstallRoutes(deps: HttpDeps, slack: SlackRouteSeam
         if (!row || row.orgId !== req.orgCtx!.orgId) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'install not found' })
         }
-        return { id: row.id, status: row.status, failureReason: row.failureReason, botId: row.botId }
+        return {
+          id: row.id,
+          status: row.status,
+          failureReason: row.failureReason,
+          missingScopes: row.missingScopes,
+          botId: row.botId
+        }
       }
     )
   }
@@ -219,9 +225,20 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
         // integration — a re-authorization need not create one). Safe to call
         // with no pending row (a bare denial, an already-settled replay) — it
         // just renders the page.
-        const fail = async (note: Parameters<typeof closePageHtml>[0]): Promise<FastifyReply> => {
+        // `missingScopes` rides along on the short-grant refusal below: the poll
+        // is the console's only channel here (this tab is a throwaway), so the
+        // reason code alone would leave it unable to say WHICH permissions
+        // Slack withheld.
+        const fail = async (
+          note: Parameters<typeof closePageHtml>[0],
+          missingScopes?: readonly string[]
+        ): Promise<FastifyReply> => {
           if (row?.status === 'pending') {
-            await deps.repos.slackPlatformInstall.settle(row.id, { status: 'failed', failureReason: note })
+            await deps.repos.slackPlatformInstall.settle(row.id, {
+              status: 'failed',
+              failureReason: note,
+              ...(missingScopes ? { missingScopes } : {})
+            })
           }
           return back(note)
         }
@@ -299,6 +316,26 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
           // Don't leak WHICH org holds it.
           req.log.warn({ installId: row.id, botId: existing.id }, 'slack platform install: workspace already bound')
           return fail('workspace_taken')
+        }
+
+        // The quick-install funnel's short-grant fence, applied to the workspace
+        // token this authorization just produced. Slack does not reliably apply
+        // every scope the authorize URL asked for, and a short grant is silent —
+        // it surfaces much later as a scoped call answering `missing_scope` and
+        // the session-access check failing closed. LAST of the fences and before
+        // the first write, so a more specific refusal (wrong workspace, another
+        // org's) still wins and a short grant costs no bot row, no credential
+        // rotation, and no membership change. An inconclusive check never blocks
+        // (see `checkSlackBotScopes`); an already-installed workspace is the
+        // Settings refresh's job, not this callback's.
+        const checked = await slack.verifyBot?.(result.botToken)
+        const grant = checked?.status === 'ok' ? checkSlackBotScopes(checked.scopes) : { status: 'unknown' as const }
+        if (grant.status === 'short') {
+          req.log.warn(
+            { installId: row.id, missingScopes: grant.missing },
+            'slack platform install: workspace granted fewer bot scopes than required'
+          )
+          return fail('missing_scopes', grant.missing)
         }
 
         let botId: string

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   buildInstallManifest,
+  checkSlackBotScopes,
   mergeManagedSlackManifest,
   slackOAuthRedirectUri,
   SLACK_BOT_SCOPES,
@@ -117,6 +118,38 @@ describe('buildInstallManifest', () => {
       'group_left',
       'tokens_revoked'
     ])
+  })
+})
+
+// The one place the "did this install actually get every scope" comparison
+// lives — both install funnels fence on it and the Settings refresh reports it.
+// Grants are built FROM `SLACK_BOT_SCOPES` rather than spelled out, so adding a
+// required scope never has to be mirrored here.
+describe('checkSlackBotScopes', () => {
+  it('accepts a grant that carries every required scope', () => {
+    expect(checkSlackBotScopes([...SLACK_BOT_SCOPES])).toEqual({ status: 'complete' })
+  })
+
+  it('ignores extra scopes the workspace happens to have granted', () => {
+    expect(checkSlackBotScopes([...SLACK_BOT_SCOPES, 'bookmarks:read'])).toEqual({ status: 'complete' })
+  })
+
+  it('names exactly the required scopes a short grant is missing', () => {
+    const withheld = [SLACK_BOT_SCOPES[0], SLACK_BOT_SCOPES[SLACK_BOT_SCOPES.length - 1]!]
+    const granted = SLACK_BOT_SCOPES.filter((scope) => !withheld.includes(scope))
+    expect(checkSlackBotScopes(granted)).toEqual({ status: 'short', missing: withheld })
+  })
+
+  it('reports an empty grant as short rather than complete', () => {
+    expect(checkSlackBotScopes([])).toEqual({ status: 'short', missing: [...SLACK_BOT_SCOPES] })
+  })
+
+  // Slack does not always send `x-oauth-scopes`. "We could not tell" must never
+  // be read as "the grant is short" — that would fail installs for a reason
+  // that has nothing to do with permissions.
+  it('treats an unreported grant as unknown, not short', () => {
+    expect(checkSlackBotScopes(null)).toEqual({ status: 'unknown' })
+    expect(checkSlackBotScopes(undefined)).toEqual({ status: 'unknown' })
   })
 })
 

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -30,6 +30,35 @@ export {
   slackInteractionsRequestUrl
 }
 
+/**
+ * Whether an installation actually granted every bot scope AgentConnect requires.
+ *
+ * `unknown` is NOT a short grant. Slack reports the granted scopes only in the
+ * `x-oauth-scopes` response header of `auth.test`, and it does not always send
+ * one — an absent header means "we could not tell". Callers MUST NOT refuse an
+ * install on it: that would break installs for a reason that has nothing to do
+ * with permissions. Only a positively-known short grant is actionable.
+ */
+export type SlackBotScopeGrant = { status: 'unknown' } | { status: 'complete' } | { status: 'short'; missing: string[] }
+
+/**
+ * The required bot scopes an installation is missing — the ONE place that diff
+ * lives. Both install funnels fence on it (a short grant never becomes a bot),
+ * and the Settings refresh reports it as `reinstall_required`; keeping the
+ * comparison here is what stops those three from drifting, in particular on the
+ * `null`-means-unknown rule above.
+ *
+ * Slack's initial authorization does not reliably apply every bot permission an
+ * app's manifest declares — the app installs cleanly and the shortfall surfaces
+ * much later, as a scoped call failing with `missing_scope`.
+ */
+export function checkSlackBotScopes(granted: readonly string[] | null | undefined): SlackBotScopeGrant {
+  if (!granted) return { status: 'unknown' }
+  const held = new Set(granted)
+  const missing = SLACK_BOT_SCOPES.filter((scope) => !held.has(scope))
+  return missing.length > 0 ? { status: 'short', missing } : { status: 'complete' }
+}
+
 type ManifestRecord = Record<string, unknown>
 
 function asRecord(value: unknown): ManifestRecord {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3075,6 +3075,9 @@ export interface SlackPlatformInstallRecord {
   status: SlackPlatformInstallStatus
   /** Short code (same note the callback's close page shows) when `failed`. */
   failureReason: string | null
+  /** Required bot scopes the workspace authorization did not grant, when
+   *  `failureReason` is 'missing_scopes'. Empty on every other outcome. */
+  missingScopes: string[]
   /** Expected Bot fence for Settings reauthorization, or the resulting Bot once
    *  a generic install completes. */
   botId: string | null
@@ -3102,7 +3105,11 @@ export interface SlackPlatformInstallStore {
    */
   settle(
     id: string,
-    outcome: { status: 'completed'; botId?: string } | { status: 'failed'; failureReason: string }
+    outcome:
+      | { status: 'completed'; botId?: string }
+      // `missingScopes` accompanies the 'missing_scopes' reason so the console's
+      // poll can name the permissions rather than just the failure.
+      | { status: 'failed'; failureReason: string; missingScopes?: readonly string[] }
   ): Promise<void>
   delete(id: string): Promise<void>
   /** TTL sweep: delete rows created before `staleBefore` (settled or not — a

--- a/packages/control-plane/src/persistence/repositories/slack-platform-install.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/slack-platform-install.repo.ts
@@ -18,6 +18,7 @@ function toRecord(r: SlackPlatformInstall): SlackPlatformInstallRecord {
     agentId: r.agentId ? AgentId(r.agentId) : null,
     status: r.status,
     failureReason: r.failureReason,
+    missingScopes: r.missingScopes,
     botId: r.botId,
     createdByUserId: r.createdByUserId,
     createdAt: r.createdAt,
@@ -54,7 +55,9 @@ export class PgSlackPlatformInstallStore implements SlackPlatformInstallStore {
 
   async settle(
     id: string,
-    outcome: { status: 'completed'; botId?: string } | { status: 'failed'; failureReason: string }
+    outcome:
+      | { status: 'completed'; botId?: string }
+      | { status: 'failed'; failureReason: string; missingScopes?: readonly string[] }
   ): Promise<void> {
     // `status: 'pending'` in the WHERE: a double callback (Slack retry / a
     // double-clicked tab) keeps the FIRST outcome rather than overwriting a
@@ -67,7 +70,10 @@ export class PgSlackPlatformInstallStore implements SlackPlatformInstallStore {
         settledAt: new Date(),
         ...(outcome.status === 'completed'
           ? { ...(outcome.botId ? { botId: outcome.botId } : {}) }
-          : { failureReason: outcome.failureReason })
+          : {
+              failureReason: outcome.failureReason,
+              ...(outcome.missingScopes ? { missingScopes: [...outcome.missingScopes] } : {})
+            })
       }
     })
   }

--- a/packages/control-plane/test/integration/slack-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-install.route.test.ts
@@ -27,6 +27,7 @@ import type {
   SlackRotateResult
 } from '../../src/http/slack-config-api.js'
 import { PLATFORM_APP_DESCRIPTION } from '../../src/http/platform-app-description.js'
+import { SLACK_BOT_SCOPES } from '../../src/http/slack-manifest.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -367,6 +368,89 @@ describe('slack auto-install funnel', () => {
     expect(spy.upserts).toHaveLength(1)
     expect(spy.upserts[0]!.u).toMatchObject({ config: { botToken: 'xoxb-from-oauth' } })
     expect(JSON.stringify(dto)).not.toContain('xoxb-')
+  })
+
+  // Slack's initial authorization does not reliably apply every bot permission
+  // the manifest declares, and a short grant is SILENT — it only surfaces much
+  // later, as a scoped call answering `missing_scope` and the session-access
+  // check failing closed. Finalize is the last point where the operator is still
+  // in the flow and one reinstall away, so it refuses there.
+  it('finalize refuses a workspace authorization that granted fewer bot scopes, minting nothing', async () => {
+    const { app, spy } = withFunnel()
+    const withheld = ['channels:history', 'users:read']
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'acme-bot',
+      appId: 'A1TEST',
+      teamId: 'T_INSTALL',
+      teamName: 'Acme',
+      botUserId: 'U1',
+      scopes: SLACK_BOT_SCOPES.filter((scope) => !withheld.includes(scope))
+    })
+    const installId = await startAndAuthorize(app)
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app/${installId}/finalize`,
+      payload: { appToken: 'xapp-1-A1TEST-9-abcdef' }
+    })
+
+    expect(res.statusCode).toBe(409)
+    const body = res.json() as { code: string; message: string; missingScopes: string[] }
+    // The list is the point: "reinstall the app" is only actionable when the
+    // refusal says WHICH permissions are absent, so the console can render them.
+    expect(body.code).toBe('SLACK_MISSING_SCOPES')
+    expect(body.missingScopes).toEqual(withheld)
+    expect(body.message).toContain('channels:history')
+    // No bot, no integration, no daemon push — and the pending row survives, so
+    // reinstalling in Slack and retrying Connect is the whole recovery loop.
+    expect(await prisma.bot.count({ where: { orgId: DEFAULT_ORG_ID, slackAppId: 'A1TEST' } })).toBe(0)
+    expect(await prisma.integration.count({ where: { orgId: DEFAULT_ORG_ID } })).toBe(0)
+    expect(spy.upserts).toHaveLength(0)
+    expect(await prisma.slackInstall.findUnique({ where: { id: installId } })).not.toBeNull()
+  })
+
+  it('finalize installs normally when the workspace granted every required scope', async () => {
+    const { app } = withFunnel()
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'acme-bot',
+      appId: 'A1TEST',
+      teamId: 'T_INSTALL',
+      teamName: 'Acme',
+      botUserId: 'U1',
+      // Extra scopes a workspace happens to hold are not a reason to refuse.
+      scopes: [...SLACK_BOT_SCOPES, 'bookmarks:read']
+    })
+    const installId = await startAndAuthorize(app)
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app/${installId}/finalize`,
+      payload: { appToken: 'xapp-1-A1TEST-9-abcdef' }
+    })
+    expect(res.statusCode).toBe(201)
+  })
+
+  // Slack does not always send the `x-oauth-scopes` header. An unreported grant
+  // is "we could not tell", NOT "the grant is short" — reading it the other way
+  // would start failing installs for a reason unrelated to permissions.
+  it('finalize does not refuse when Slack did not report the granted scopes', async () => {
+    const { app } = withFunnel()
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'acme-bot',
+      appId: 'A1TEST',
+      teamId: 'T_INSTALL',
+      teamName: 'Acme',
+      botUserId: 'U1',
+      scopes: null
+    })
+    const installId = await startAndAuthorize(app)
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app/${installId}/finalize`,
+      payload: { appToken: 'xapp-1-A1TEST-9-abcdef' }
+    })
+    expect(res.statusCode).toBe(201)
   })
 
   it('finalize refuses a workspace already connected to ANOTHER organization (ingress-tenant-fence.md §5)', async () => {

--- a/packages/control-plane/test/integration/slack-platform-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-platform-install.route.test.ts
@@ -262,6 +262,111 @@ describe('GET /integrations/slack/platform/callback', () => {
     expect(cb.body).toContain('Connected to Slack')
   })
 
+  // The quick-install funnel's short-grant fence, on the distributed app. Slack
+  // does not reliably apply every scope the authorize URL asked for, and the
+  // shortfall is invisible until a scoped call starts answering `missing_scope`.
+  it('refuses a workspace that granted fewer bot scopes, writing no bot (missing_scopes)', async () => {
+    const { app } = withPlatform()
+    const withheld = ['channels:history', 'users:read']
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'agentconnect',
+      appId: PLATFORM.appId,
+      teamId: 'T0WORKSPACE',
+      teamName: 'Acme',
+      botUserId: 'U0BOT',
+      scopes: SLACK_BOT_SCOPES.filter((scope) => !withheld.includes(scope))
+    })
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    const started = await startInstall(app, agentId)
+
+    const cb = await app.app.inject({
+      method: 'GET',
+      url: `/api/v1/integrations/slack/platform/callback?code=c&state=${started.id}`
+    })
+    expect(cb.statusCode).toBe(200)
+    expect(cb.body).toContain('didn’t grant every permission')
+    // Nothing was written: this is the last fence before the first mutation.
+    expect(await prisma.bot.count({ where: { slackAppId: PLATFORM.appId } })).toBe(0)
+    expect(await prisma.integration.count({ where: { agentId } })).toBe(0)
+    // The console's only channel here is the poll (the OAuth tab is a
+    // throwaway), so the row carries the scopes, not just the reason code.
+    const polled = (await status(app, started.id)).json() as {
+      status: string
+      failureReason: string
+      missingScopes: string[]
+    }
+    expect(polled).toMatchObject({ status: 'failed', failureReason: 'missing_scopes', missingScopes: withheld })
+  })
+
+  it('does not refuse when Slack did not report the granted scopes', async () => {
+    const { app } = withPlatform()
+    // The default stub is absent ⇒ the seam answers `unreachable`; make the
+    // inconclusive case explicit — Slack answered, but sent no scope header.
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'agentconnect',
+      appId: PLATFORM.appId,
+      teamId: 'T0WORKSPACE',
+      teamName: 'Acme',
+      botUserId: 'U0BOT',
+      scopes: null
+    })
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    const started = await startInstall(app, agentId)
+
+    const cb = await app.app.inject({
+      method: 'GET',
+      url: `/api/v1/integrations/slack/platform/callback?code=c&state=${started.id}`
+    })
+    expect(cb.body).toContain('Connected to Slack')
+    expect(await prisma.bot.count({ where: { slackAppId: PLATFORM.appId } })).toBe(1)
+  })
+
+  // A short grant must not out-rank the more specific refusals: it is checked
+  // last, so "you authorized someone else's workspace" still wins.
+  it('reports a cross-org workspace claim rather than the scope shortfall', async () => {
+    const { app } = withPlatform()
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'agentconnect',
+      appId: PLATFORM.appId,
+      teamId: 'T0WORKSPACE',
+      teamName: 'Acme',
+      botUserId: 'U0BOT',
+      scopes: []
+    })
+    const otherOrg = await prisma.org.create({ data: { slug: `other-${randomUUID().slice(0, 8)}` } })
+    await prisma.bot.create({
+      data: {
+        id: randomUUID(),
+        orgId: otherOrg.id,
+        platform: 'slack',
+        name: 'AgentConnect (Theirs)',
+        transport: 'http',
+        shareable: false,
+        prebuilt: true,
+        slackAppId: PLATFORM.appId,
+        teamId: 'T0WORKSPACE',
+        workspaceId: 'T0WORKSPACE',
+        externalAppId: PLATFORM.appId,
+        externalTenantId: 'T0WORKSPACE'
+      }
+    })
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    const started = await startInstall(app, agentId)
+
+    const cb = await app.app.inject({
+      method: 'GET',
+      url: `/api/v1/integrations/slack/platform/callback?code=c&state=${started.id}`
+    })
+    expect(cb.body).toContain('already connected to a different AgentConnect organization')
+    expect((await status(app, started.id)).json()).toMatchObject({ failureReason: 'workspace_taken' })
+  })
+
   it('refuses a workspace already bound to a DIFFERENT org (workspace_taken)', async () => {
     const { app } = withPlatform()
     const otherOrg = await prisma.org.create({ data: { slug: `other-${randomUUID().slice(0, 8)}` } })

--- a/packages/web/src/components/console/platforms/slack/Body.tsx
+++ b/packages/web/src/components/console/platforms/slack/Body.tsx
@@ -10,6 +10,7 @@ import { useConsoleData } from '@/lib/data-context'
 import {
   slackAppIdFromAppToken,
   slackAppOAuthUrl,
+  slackAppReinstallUrl,
   slackAppSettingsUrl,
   slackCreateAppUrl,
   slackManifestJson
@@ -19,23 +20,13 @@ import { useDeploymentConfig } from '../deployment-config'
 import { usePublishedFooter, usePublishedIdentityChrome } from '../publish'
 import { DeliveryLine } from '../wizard-chrome'
 import { slackApi } from './api'
+import { SLACK_INSTALL_EXPIRED, slackMissingScopesFromError, slackPlatformInstallFailure } from './install-failure'
 import { SlackConfigTokenPreview, SlackManifestPreview } from './previews'
 
 /** This platform's delivery vocabulary — {@link WebTransportAffordance.labels}. */
 export const SLACK_TRANSPORT_LABEL: Record<WebWizardTransport, string> = {
   socket: 'Socket Mode',
   http: 'HTTP (Events API)'
-}
-
-// Why a platform "Add to Slack" round trip ended without connecting. Keyed by the
-// CP's short reason code (the same note its close page shows).
-const PLATFORM_INSTALL_FAILURES: Record<string, string> = {
-  denied: 'The install was cancelled in Slack.',
-  expired: 'This install link expired — start again.',
-  workspace_taken: 'That Slack workspace is already connected to another organization.',
-  workspace_mismatch: 'Slack authorized a different workspace. Start again and choose the expected workspace.',
-  agent_taken: 'That Slack workspace is already connected to another agent here. Remove that integration first.',
-  error: 'Slack could not complete the install. Please try again.'
 }
 
 /**
@@ -74,6 +65,11 @@ export function SlackWizardBody({ agent, host }: { agent: Agent; host: WizardHos
   const [cfgRefresh, setCfgRefresh] = useState('')
   // config → authorizing (OAuth in the other tab) → appToken (bot ready, paste xapp).
   const [autoPhase, setAutoPhase] = useState<'config' | 'authorizing' | 'appToken'>('config')
+  // The bot scopes Slack withheld, when the CP refused the finalize because the
+  // workspace authorization came up short. Its own state rather than the footer's
+  // error line: this failure is only useful if it NAMES the permissions and the
+  // remedy (reinstall in Slack, then Connect again), which a one-line error can't.
+  const [missingScopes, setMissingScopes] = useState<string[] | null>(null)
   const [install, setInstall] = useState<{
     installId: string
     appId: string
@@ -326,6 +322,7 @@ export function SlackWizardBody({ agent, host }: { agent: Agent; host: WizardHos
     if (busyRef.current) return
     setInstall(null)
     setAutoPhase('config')
+    setMissingScopes(null)
     host.setError(null)
   }
 
@@ -339,6 +336,7 @@ export function SlackWizardBody({ agent, host }: { agent: Agent; host: WizardHos
     if (transport === 'socket' && !appOk) return
     busyRef.current = true
     setSaving(true)
+    setMissingScopes(null)
     host.setError(null)
     try {
       await finalizeSlackInstall(install.installId, {
@@ -348,7 +346,13 @@ export function SlackWizardBody({ agent, host }: { agent: Agent; host: WizardHos
       })
       host.close()
     } catch (e) {
-      host.setError(e instanceof Error ? e.message : String(e))
+      // A SHORT PERMISSION GRANT is not a generic error: Slack authorized the app
+      // with fewer bot scopes than it declares, nothing is wrong with what the
+      // operator typed, and the fix is a reinstall in Slack. Route it to the
+      // panel below, which names the scopes — the footer's one-line error can't.
+      const missing = slackMissingScopesFromError(e)
+      if (missing) setMissingScopes(missing)
+      else host.setError(e instanceof Error ? e.message : String(e))
       setSaving(false)
       busyRef.current = false
     }
@@ -389,11 +393,11 @@ export function SlackWizardBody({ agent, host }: { agent: Agent; host: WizardHos
         const s = await slackApi.getPlatformInstall(platformInstallId)
         if (!alive || s.status === 'pending') return
         if (s.status === 'completed') return close() // lists refetch on close
-        stop(PLATFORM_INSTALL_FAILURES[s.failureReason ?? ''] ?? 'The Slack install did not complete.')
+        stop(slackPlatformInstallFailure(s.failureReason, s.missingScopes))
       } catch (e) {
         // 404 = the row was TTL-reaped (an abandoned tab), which is terminal —
         // anything else is transient, so keep polling.
-        if (alive && e instanceof ApiError && e.status === 404) stop(PLATFORM_INSTALL_FAILURES.expired!)
+        if (alive && e instanceof ApiError && e.status === 404) stop(SLACK_INSTALL_EXPIRED)
       }
     }
     const h = setInterval(() => void tick(), 2500)
@@ -676,6 +680,57 @@ export function SlackWizardBody({ agent, host }: { agent: Agent; host: WizardHos
                             <div className="mt-[8px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
                               Unlocks once you approve the install in Slack.
                             </div>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* The install was approved, but Slack authorized the app with
+                  fewer bot permissions than it declares — the failure this whole
+                  check exists to catch, because left alone it stays invisible
+                  until session access starts failing closed weeks later. Naming
+                  the scopes is the point: "reinstall the app" is only actionable
+                  when it says what is absent. Connect stays live, so reinstalling
+                  in Slack and clicking it again is the whole loop. */}
+                  {missingScopes && (
+                    <div className="mt-[14px] rounded-lg bg-(--status-error-soft) px-[11px] py-[10px]">
+                      <div className="flex items-start gap-2">
+                        <Icon
+                          name="triangle-alert"
+                          size={14}
+                          color="var(--status-error)"
+                          className="mt-[1px] flex-none"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="font-sans text-[12px] font-semibold leading-normal text-(--text-primary)">
+                            Slack didn’t grant every permission this app needs
+                          </div>
+                          <div className="mt-[3px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-secondary)">
+                            Reinstall the app in your Slack workspace to grant them, then click Connect again.
+                          </div>
+                          {missingScopes.length > 0 && (
+                            <div className="mt-[7px] flex flex-wrap gap-[5px]">
+                              {missingScopes.map((scope) => (
+                                <span
+                                  key={scope}
+                                  className="mono rounded-[5px] bg-(--surface-card) px-[6px] py-[2px] text-[11px] text-(--text-secondary)"
+                                >
+                                  {scope}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                          {install && (
+                            <a
+                              href={slackAppReinstallUrl(install.appId)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="lnk mt-[9px] inline-flex items-center gap-[5px]"
+                            >
+                              Reinstall in Slack
+                              <Icon name="external-link" size={12} />
+                            </a>
                           )}
                         </div>
                       </div>

--- a/packages/web/src/components/console/platforms/slack/install-failure.test.ts
+++ b/packages/web/src/components/console/platforms/slack/install-failure.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { ApiError } from '@/lib/api'
+import {
+  SLACK_MISSING_SCOPES_CODE,
+  slackMissingScopesFromError,
+  slackMissingScopesMessage,
+  slackPlatformInstallFailure
+} from './install-failure'
+
+const missingScopesError = (missingScopes?: unknown) =>
+  new ApiError('Slack didn’t grant every permission this app needs.', 409, SLACK_MISSING_SCOPES_CODE, {
+    ...(missingScopes === undefined ? {} : { missingScopes })
+  })
+
+describe('slackMissingScopesFromError', () => {
+  it('returns the withheld scopes from the CP’s short-grant refusal', () => {
+    expect(slackMissingScopesFromError(missingScopesError(['channels:history', 'users:read']))).toEqual([
+      'channels:history',
+      'users:read'
+    ])
+  })
+
+  // The code is what identifies the failure — a refusal that somehow arrives
+  // without a list is still the scope failure, and the console must render the
+  // remedy rather than fall through to a generic error.
+  it('still identifies the failure when the list is absent or malformed', () => {
+    expect(slackMissingScopesFromError(missingScopesError())).toEqual([])
+    expect(slackMissingScopesFromError(missingScopesError('chat:write'))).toEqual([])
+    expect(slackMissingScopesFromError(missingScopesError([1, 'chat:write']))).toEqual(['chat:write'])
+  })
+
+  it('leaves every other failure to the generic error path', () => {
+    expect(slackMissingScopesFromError(new ApiError('agent not found', 404))).toBeNull()
+    expect(
+      slackMissingScopesFromError(new ApiError('conflict', 409, 'SOMETHING_ELSE', { missingScopes: ['x'] }))
+    ).toBeNull()
+    expect(slackMissingScopesFromError(new Error('network down'))).toBeNull()
+  })
+})
+
+describe('slackPlatformInstallFailure', () => {
+  it('names the withheld scopes and the remedy on a short grant', () => {
+    const message = slackPlatformInstallFailure('missing_scopes', ['channels:history', 'users:read'])
+    expect(message).toContain('Reinstall the app in your Slack workspace')
+    expect(message).toContain('Missing: channels:history, users:read')
+  })
+
+  it('states the remedy even when the scope list did not come through', () => {
+    expect(slackPlatformInstallFailure('missing_scopes')).toBe(slackMissingScopesMessage([]))
+    expect(slackPlatformInstallFailure('missing_scopes')).not.toContain('Missing:')
+  })
+
+  it('keeps the existing copy for the other terminal outcomes', () => {
+    expect(slackPlatformInstallFailure('denied')).toBe('The install was cancelled in Slack.')
+    expect(slackPlatformInstallFailure('workspace_taken')).toBe(
+      'That Slack workspace is already connected to another organization.'
+    )
+  })
+
+  it('falls back for an unknown or absent reason', () => {
+    expect(slackPlatformInstallFailure(null)).toBe('The Slack install did not complete.')
+    expect(slackPlatformInstallFailure('something_new')).toBe('The Slack install did not complete.')
+  })
+
+  // A non-scope failure must not pick up a stale list.
+  it('ignores scopes passed alongside another reason', () => {
+    expect(slackPlatformInstallFailure('denied', ['chat:write'])).toBe('The install was cancelled in Slack.')
+  })
+})

--- a/packages/web/src/components/console/platforms/slack/install-failure.ts
+++ b/packages/web/src/components/console/platforms/slack/install-failure.ts
@@ -1,0 +1,72 @@
+// Why a Slack install ended without connecting — the ONE copy of that vocabulary.
+//
+// Two surfaces report it and used to keep near-identical maps of the same reason
+// codes: the create modal's wizard body (`./Body.tsx`) and the getting-started
+// card's platform-install poll (`./use-platform-install.ts`). They drifted the
+// moment a new outcome was added, which is exactly what happened when the CP
+// learned to refuse a SHORT PERMISSION GRANT.
+//
+// Short grant, in one line: Slack's initial authorization does not reliably apply
+// every bot permission an app declares. The app installs cleanly and nothing
+// looks wrong until, much later, a scoped call answers `missing_scope` and
+// conversations quietly stop being visible. Both CP install funnels now refuse
+// that install up front and say WHICH scopes are absent — which is the whole
+// point of failing rather than warning, so these messages must carry the list.
+
+import { ApiError } from '@/lib/api'
+
+/** The CP's machine-readable refusal code on the config-token funnel's finalize
+ *  (`POST /integrations/slack/app/:id/finalize`) when the workspace
+ *  authorization granted fewer bot scopes than the app requires. */
+export const SLACK_MISSING_SCOPES_CODE = 'SLACK_MISSING_SCOPES'
+
+/** The same outcome on the platform-app callback, where it reaches the console as
+ *  the polled install row's `failureReason` rather than as a request error. */
+export const SLACK_MISSING_SCOPES_REASON = 'missing_scopes'
+
+/**
+ * The withheld scopes behind a finalize failure, or null when the failure was
+ * something else. Returns a (possibly empty) list only for the CP's short-grant
+ * refusal, so callers can branch on "is this the scope failure" without
+ * inspecting messages.
+ */
+export function slackMissingScopesFromError(err: unknown): string[] | null {
+  if (!(err instanceof ApiError) || err.code !== SLACK_MISSING_SCOPES_CODE) return null
+  const missing = err.details?.missingScopes
+  return Array.isArray(missing) ? missing.filter((scope): scope is string => typeof scope === 'string') : []
+}
+
+/** The remedy, in one sentence, for surfaces that can only show a string. The
+ *  wizard renders the same facts structurally instead (see `./Body.tsx`). */
+export function slackMissingScopesMessage(missingScopes: readonly string[]): string {
+  const remedy =
+    'Slack didn’t grant every permission AgentConnect needs. Reinstall the app in your Slack workspace to grant them, then try again.'
+  return missingScopes.length > 0 ? `${remedy} Missing: ${missingScopes.join(', ')}` : remedy
+}
+
+/** Keyed by the CP's short reason code — the same note its OAuth close page shows. */
+const PLATFORM_INSTALL_FAILURES: Record<string, string> = {
+  denied: 'The install was cancelled in Slack.',
+  expired: 'This install link expired — start again.',
+  workspace_taken: 'That Slack workspace is already connected to another organization.',
+  workspace_mismatch: 'Slack authorized a different workspace. Start again and choose the expected workspace.',
+  agent_taken: 'That Slack workspace is already connected to another agent here. Remove that integration first.',
+  error: 'Slack could not complete the install. Please try again.'
+}
+
+/**
+ * Render a platform-app install row's terminal failure. `missingScopes` is the
+ * list the CP persisted alongside a `missing_scopes` reason; every other outcome
+ * ignores it.
+ */
+export function slackPlatformInstallFailure(
+  failureReason: string | null | undefined,
+  missingScopes: readonly string[] = []
+): string {
+  if (failureReason === SLACK_MISSING_SCOPES_REASON) return slackMissingScopesMessage(missingScopes)
+  return PLATFORM_INSTALL_FAILURES[failureReason ?? ''] ?? 'The Slack install did not complete.'
+}
+
+/** The 'expired' copy, for the callers that reach it without a row (a TTL-reaped
+ *  install polls as a 404, not as a settled failure). */
+export const SLACK_INSTALL_EXPIRED = PLATFORM_INSTALL_FAILURES.expired!

--- a/packages/web/src/components/console/platforms/slack/manifest.ts
+++ b/packages/web/src/components/console/platforms/slack/manifest.ts
@@ -118,3 +118,11 @@ export function slackAppOAuthUrl(appId: string): string {
 export function slackAppSettingsUrl(appId?: string | null): string {
   return appId ? `https://api.slack.com/apps/${encodeURIComponent(appId)}` : 'https://api.slack.com/apps'
 }
+
+/** Deep link to Slack's own "install to a workspace" flow for an app — the remedy
+ *  when an authorization granted fewer bot scopes than the app declares, since
+ *  reinstalling is what makes Slack apply the full set. Mirrors the `reinstallUrl`
+ *  the CP's Slack refresh DTO hands the settings fragment. */
+export function slackAppReinstallUrl(appId: string): string {
+  return `https://api.slack.com/apps/${encodeURIComponent(appId)}/install-on-team?`
+}

--- a/packages/web/src/components/console/platforms/slack/settings.tsx
+++ b/packages/web/src/components/console/platforms/slack/settings.tsx
@@ -15,6 +15,7 @@ import { ApiError, type BotDto, type SlackBotRefreshDto } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
 import type { WebBotSettingsFragments } from '../contract'
 import { slackApi } from './api'
+import { SLACK_MISSING_SCOPES_REASON, slackMissingScopesMessage } from './install-failure'
 import { slackAppSettingsUrl } from './manifest'
 import { SlackMark } from './mark'
 import { slackRefreshNoticeState } from './refresh-notice'
@@ -124,7 +125,12 @@ function SlackBotCardProvider({ children }: { children: ReactNode }) {
               ? 'The reinstall was cancelled in Slack.'
               : status.failureReason === 'workspace_mismatch'
                 ? 'Slack authorized a different workspace. Try again and choose this bot’s workspace.'
-                : 'Slack could not complete the reinstall. Please try again.'
+                : // A reinstall is the remedy for a short permission grant, so a
+                  // reinstall that is ITSELF short has to name what is still
+                  // absent — the generic line below would hide exactly that.
+                  status.failureReason === SLACK_MISSING_SCOPES_REASON
+                  ? slackMissingScopesMessage(status.missingScopes)
+                  : 'Slack could not complete the reinstall. Please try again.'
           )
           return
         }

--- a/packages/web/src/components/console/platforms/slack/use-platform-install.ts
+++ b/packages/web/src/components/console/platforms/slack/use-platform-install.ts
@@ -17,17 +17,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { ApiError } from '@/lib/api'
 import type { WebInstallPoll } from '../contract'
 import { slackApi } from './api'
-
-// Why a platform install round trip ended without connecting, keyed by the install
-// row's `failureReason`. Mirrors AddIntegrationModal's PLATFORM_INSTALL_FAILURES.
-const FAILURES: Record<string, string> = {
-  denied: 'The install was cancelled in Slack.',
-  expired: 'This install link expired — start again.',
-  workspace_taken: 'That Slack workspace is already connected to another organization.',
-  workspace_mismatch: 'Slack authorized a different workspace. Start again and choose the expected workspace.',
-  agent_taken: 'That Slack workspace is already connected to another agent here. Remove that integration first.',
-  error: 'Slack could not complete the install. Please try again.'
-}
+import { SLACK_INSTALL_EXPIRED, slackPlatformInstallFailure } from './install-failure'
 
 /** `onCompleted` fires once the install reaches `completed` (refresh lists / close the surface). */
 export function useSlackPlatformInstall(agentId: string, onCompleted: () => void): WebInstallPoll {
@@ -89,9 +79,9 @@ export function useSlackPlatformInstall(agentId: string, onCompleted: () => void
           onCompleted()
           return
         }
-        stop(FAILURES[s.failureReason ?? ''] ?? 'The Slack install did not complete.')
+        stop(slackPlatformInstallFailure(s.failureReason, s.missingScopes))
       } catch (e) {
-        if (alive && e instanceof ApiError && e.status === 404) stop(FAILURES.expired!)
+        if (alive && e instanceof ApiError && e.status === 404) stop(SLACK_INSTALL_EXPIRED)
       }
     }
     const poll = setInterval(() => void check(), 2500)

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -31,7 +31,11 @@ export class ApiError extends Error {
   constructor(
     message: string,
     readonly status: number,
-    readonly code?: string
+    readonly code?: string,
+    /** The CP's parsed error body, for the few denials that carry structured
+     *  detail a message can't render well (Slack's `missingScopes` list). Read
+     *  it behind a `code` check and narrow it — nothing here is guaranteed. */
+    readonly details?: Record<string, unknown>
   ) {
     super(message)
     this.name = 'ApiError'
@@ -780,6 +784,9 @@ export interface SlackPlatformInstallStatusDto {
   id: string
   status: 'pending' | 'completed' | 'failed'
   failureReason: string | null
+  /** The required bot scopes Slack withheld, when `failureReason` is
+   *  'missing_scopes'. Empty on every other outcome. */
+  missingScopes: string[]
   botId: string | null
 }
 /** `PUT /slack/config` body — the caller's own Slack App Configuration token. The
@@ -1396,7 +1403,7 @@ async function apiPost<T>(path: string, body: unknown): Promise<T> {
 }
 
 async function apiErrorFromResponse(method: string, path: string, res: Response): Promise<ApiError> {
-  const body = (await res.json().catch(() => ({}))) as { code?: unknown; message?: unknown }
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>
   const message =
     typeof body.message === 'string' && body.message.length > 0
       ? body.message
@@ -1406,7 +1413,7 @@ async function apiErrorFromResponse(method: string, path: string, res: Response)
   // the console can work, and no retry helps, so sign out instead of surfacing the
   // failure on every panel. The error is still thrown for the in-flight caller.
   if (res.status === 401 && code === 'ACCOUNT_GONE') void signOutDeletedAccount()
-  return new ApiError(message, res.status, code)
+  return new ApiError(message, res.status, code, body)
 }
 
 async function apiPatch<T>(path: string, body: unknown): Promise<T> {


### PR DESCRIPTION
## The failure

Slack's initial authorization does not reliably apply every bot permission an app's manifest declares — a reinstall is needed to pick up the rest. Almost nobody notices, because nothing in the install flow checks: the wizard reports success while the bot token is short of `SLACK_BOT_SCOPES`.

**A short grant is not a degraded install, it is a broken one.** Without `app_mentions:read` the bot cannot see @-mentions; without `im:history`/`im:write` it cannot hold a DM; without `commands` there are no slash commands; without `assistant:write` no assistant features. And the way it surfaces looks unrelated to any of that: the session-access check calls Slack, gets `missing_scope`, fails closed, and conversations silently disappear from the console behind an "access checks unavailable" notice that names no cause.

Reporting success for an install in that state is actively wrong. This catches it at install time, while the operator is still in the flow and one reinstall away.

## What changed

**Verify the granted scopes at the end of both install paths and refuse a positively-short grant, naming the scopes that are absent.**

- **Config-token / custom app** (`slack-install.ts`) — finalize already called `auth.test` and threw away the `scopes` it returns. It now checks them **before** `installNewSlackBot`, so a short grant leaves no bot and no integration behind, and answers `409` with `code: SLACK_MISSING_SCOPES` and a `missingScopes` list. The pending row survives, so reinstalling in Slack and clicking Connect again is the whole recovery loop.
- **Platform-published app** (`slack-platform-install.ts`) — the OAuth callback verifies the workspace token it just obtained, as the **last** fence before the first write (so a more specific refusal — wrong workspace, another org's — still wins) and settles the pending row with `missing_scopes` plus the list. The poll is the console's only channel there, so a bare reason code could not say which permissions were withheld; that list is a new `missingScopes` column on `slack_platform_install`.

Worth noting for the severe cases: `scopes` is read from `auth.test`'s `x-oauth-scopes` response header, and `auth.test` itself requires no scopes — so the check keeps working no matter how little was granted. The `appId` resolution in the same function goes through `bots.info` (which needs `users:read`) and can come back empty on a short grant, but neither fence depends on it.

### One implementation, not a third copy

The scope diff moves next to `SLACK_BOT_SCOPES` as `checkSlackBotScopes` and is now the single implementation behind both funnels and the Settings refresh, which held the only prior copy.

It is deliberately **tri-state**. Slack reports granted scopes only in that header and does not always send one, so an unreported grant is `unknown`, never `short` — reading silence as a shortfall would start failing installs for a reason that has nothing to do with permissions. Keeping that rule inside the helper is what stops the three callers from diverging on it.

### Console

The wizard's final step renders this as an actionable panel — the missing scopes and a deep link to reinstall — rather than a generic error line, and Connect stays live so reinstalling and retrying works without starting over. The Settings reauthorization path polls the same row and now reports the shortfall too: a reinstall is the *remedy* for a short grant, so a reinstall that is itself short has to say what is still absent.

The two duplicated copies of the platform-install failure map collapse into one module alongside the new outcome.

## Out of scope

Repairing already-installed bots (that path exists: `slack-bot-refresh.ts` plus "Update permissions" in Settings), the session-access plugin's fail-closed behaviour and TTLs, and the separate one-line `im:read` addition to `SLACK_BOT_SCOPES` — the tests here derive their grants from `SLACK_BOT_SCOPES` itself, so they neither depend on nor block it.

## Verification

- `control-plane` `typecheck`, `test:unit` (1323 pass), `test:int` (1058 pass, migration applies)
- `web` `typecheck`, platform tests (86 pass). Pre-existing unrelated `OnboardingView.test.tsx` failures reproduce on a clean `main`.
- `eslint` + `prettier --check` clean on every touched file

New tests: a short grant fails each install and names the scopes; a complete grant (including one with extra scopes) installs as before; an unreported scope list does **not** fail either install; a cross-org claim still out-ranks the scope check; and the helper's rules are pinned independently of the scope list's contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
