### PR TITLE
feat(cp,web): name a short Slack app grant as an actionable access issue

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2440,7 +2440,7 @@ export const ConversationDto = z.object({
 export const SessionAccessIssueDto = z.object({
   provider: z.string().min(1),
   region: z.string().min(1).optional(),
-  reason: z.enum(['authorization', 'quota', 'unavailable'])
+  reason: z.enum(['authorization', 'app_authorization', 'quota', 'unavailable'])
 })
 
 export const SessionListPageDto = z.object({

--- a/packages/control-plane/src/http/session-access-plugin.ts
+++ b/packages/control-plane/src/http/session-access-plugin.ts
@@ -2,10 +2,31 @@ import type { FastifyRequest } from 'fastify'
 import type { OrgId } from '../domain/ids.js'
 import type { ExternalScopeRecord } from '../persistence/ports.js'
 
+/**
+ * Why a provider could not answer, as one low-cardinality CAUSE — never a
+ * target. Nothing derived from a channel, conversation, user, team, or scope
+ * belongs here; the console renders this to a member of the owning org, and
+ * `provider`/`region`/`reason` is the whole vocabulary it gets.
+ *
+ * The two authorization reasons are told apart by WHOSE authorization fell
+ * short, because their remedies have nothing in common:
+ *
+ * - `authorization` — the VIEWER's linked identity. They fix it themselves, on
+ *   their own Profile, and no one else's view is affected.
+ * - `app_authorization` — the INSTALLED APP's grant or credential. An
+ *   administrator fixes it once, on Integrations, and it was the missing
+ *   variant: a Slack app short of a required scope reached the console as a
+ *   bare `degraded`, so the only copy that fit was "checks unavailable" —
+ *   which reads as an outage and suggests nothing to do, while the state
+ *   persists until someone reauthorizes the app.
+ *
+ * `unavailable` stays what it says: rate limiting, an outage, a timeout —
+ * something that clears on its own. Do not widen it to carry either.
+ */
 export interface SessionAccessIssue {
   provider: string
   region?: string
-  reason: 'authorization' | 'quota' | 'unavailable'
+  reason: 'authorization' | 'app_authorization' | 'quota' | 'unavailable'
 }
 
 export interface SessionAccessViewer {

--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -99,7 +99,8 @@ describe('SlackSessionAccessService', () => {
 
     await expect(service(fetchImpl).resolve([scope()], viewer('slack:T_INSTALL:U_NOT_JOINED'))).resolves.toEqual({
       allowedScopes: [{ id: scope().id, aclRevision: 2n }],
-      degraded: false
+      degraded: false,
+      accessIssues: []
     })
     expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('conversations.members'))).toBe(false)
   })
@@ -118,11 +119,13 @@ describe('SlackSessionAccessService', () => {
 
     await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_GUEST'))).resolves.toEqual({
       allowedScopes: [{ id: scope().id, aclRevision: 2n }],
-      degraded: false
+      degraded: false,
+      accessIssues: []
     })
     await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_OTHER_GUEST'))).resolves.toEqual({
       allowedScopes: [],
-      degraded: false
+      degraded: false,
+      accessIssues: []
     })
   })
 
@@ -141,7 +144,8 @@ describe('SlackSessionAccessService', () => {
 
       await expect(service(fetchImpl).resolve([scope()], viewer('slack:T_INSTALL:U_LIMITED'))).resolves.toEqual({
         allowedScopes: [],
-        degraded: false
+        degraded: false,
+        accessIssues: []
       })
       expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('conversations.members'))).toBe(false)
     }
@@ -157,11 +161,13 @@ describe('SlackSessionAccessService', () => {
 
     await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))).resolves.toEqual({
       allowedScopes: [{ id: scope().id, aclRevision: 2n }],
-      degraded: false
+      degraded: false,
+      accessIssues: []
     })
     await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_OTHER'))).resolves.toEqual({
       allowedScopes: [],
-      degraded: false
+      degraded: false,
+      accessIssues: []
     })
     expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('users.info'))).toBe(false)
   })
@@ -179,7 +185,8 @@ describe('SlackSessionAccessService', () => {
 
     await expect(service(fetchImpl).resolve([scope()], viewer('slack:T_HOME:U_CONNECT'))).resolves.toEqual({
       allowedScopes: [{ id: scope().id, aclRevision: 2n }],
-      degraded: false
+      degraded: false,
+      accessIssues: []
     })
   })
 
@@ -196,7 +203,8 @@ describe('SlackSessionAccessService', () => {
 
     await expect(service(fetchImpl).resolve([scope()], viewer('slack:T_HOME:U_CONNECT'))).resolves.toEqual({
       allowedScopes: [],
-      degraded: false
+      degraded: false,
+      accessIssues: []
     })
   })
 
@@ -204,7 +212,10 @@ describe('SlackSessionAccessService', () => {
     const resolver = service(async () => json({ ok: false, error: 'ratelimited' }))
     await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))).resolves.toEqual({
       allowedScopes: [],
-      degraded: true
+      degraded: true,
+      // Rate limiting clears on its own: the console keeps the generic
+      // "unavailable" copy rather than sending anyone to reauthorize an app.
+      accessIssues: [{ provider: 'slack', reason: 'unavailable' }]
     })
   })
 
@@ -245,13 +256,101 @@ describe('SlackSessionAccessService', () => {
     const result = await service(fetchImpl, { warn }).resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
 
     // Unchanged: it still fails closed. Only the diagnosis is new.
-    expect(result).toEqual({ allowedScopes: [], degraded: true })
+    expect(result).toEqual({
+      allowedScopes: [],
+      degraded: true,
+      accessIssues: [{ provider: 'slack', reason: 'app_authorization' }]
+    })
     expect(warn.mock.calls[0]?.[0]).toEqual({
       provider: 'slack',
       unknownScopes: 1,
       totalScopes: 1,
       reasons: { missing_scope: 1 }
     })
+  })
+
+  // The gap this whole seam existed to close: the plugin knew the cause, the
+  // DTO had a field for it, and nothing connected the two — so an app short of
+  // a required scope reached the console as a bare `degraded` and got the
+  // "checks unavailable" copy, which reads as an outage and never clears.
+  it.each([
+    'missing_scope',
+    'invalid_auth',
+    'account_inactive',
+    'token_revoked',
+    'token_expired',
+    'no_permission'
+  ] as const)('reports a short app grant as one the org can act on (%s)', async (error) => {
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.includes('conversations.info')
+        ? json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+        : json({ ok: false, error })
+    )
+
+    const result = await service(fetchImpl).resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+    expect(result.accessIssues).toEqual([{ provider: 'slack', reason: 'app_authorization' }])
+  })
+
+  // The other half of the same decision. Relabelling these would put a
+  // "reauthorize your app" prompt in front of someone with nothing to fix.
+  it.each(['ratelimited', 'service_unavailable', 'fatal_error', 'ekm_access_denied'] as const)(
+    'leaves a transient failure on the generic copy (%s)',
+    async (error) => {
+      const resolver = service(async () => json({ ok: false, error }))
+
+      const result = await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+      expect(result.accessIssues).toEqual([{ provider: 'slack', reason: 'unavailable' }])
+    }
+  )
+
+  // A failure on THIS side of the call says nothing about the app's grant.
+  it('reports a transport failure as unavailable rather than an app problem', async () => {
+    const resolver = service(async () => json({ ok: false, error: 'missing_scope' }, 500))
+
+    const result = await resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+    expect(result.accessIssues).toEqual([{ provider: 'slack', reason: 'unavailable' }])
+  })
+
+  // `accessIssues` crosses to the browser, where the log discipline's rationale
+  // — "the operator needs the rate, not the target" — is replaced by a stricter
+  // one: a reason is a CAUSE, and a member has no business learning which
+  // conversation, workspace or credential was behind one.
+  it('carries no channel, workspace, viewer or credential into the issues', async () => {
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.includes('conversations.info')
+        ? json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+        : json({ ok: false, error: 'missing_scope' })
+    )
+
+    const result = await service(fetchImpl).resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+
+    const serialized = JSON.stringify(result.accessIssues)
+    for (const identifier of ['C_CHANNEL', 'T_INSTALL', 'U_MEMBER', scope().id, BOT_ID, 'xoxb']) {
+      expect(serialized).not.toContain(identifier)
+    }
+  })
+
+  // One issue per REMEDY, not per hidden scope: the console renders one banner
+  // for each thing the reader could go and do, and 200 channels behind the same
+  // short grant are one thing to do.
+  it('collapses many hidden scopes into one issue per remedy', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('conversations.info')) {
+        return json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+      }
+      return json({ ok: false, error: url.includes('C_CHANNEL_1') ? 'ratelimited' : 'missing_scope' })
+    })
+    const scopes = [scopeAt(1), scopeAt(2), scopeAt(3)]
+
+    const result = await service(fetchImpl).resolve(scopes, viewer('slack:T_INSTALL:U_MEMBER'))
+
+    expect(result.accessIssues).toEqual([
+      { provider: 'slack', reason: 'unavailable' },
+      { provider: 'slack', reason: 'app_authorization' }
+    ])
   })
 
   it('aggregates a mixed batch by code, one reason per hidden scope', async () => {
@@ -370,7 +469,8 @@ describe('SlackSessionAccessService', () => {
       const resolver = service(async () => json({ ok: false, error }))
       await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))).resolves.toEqual({
         allowedScopes: [],
-        degraded: false
+        degraded: false,
+        accessIssues: []
       })
     }
   )
@@ -384,7 +484,8 @@ describe('SlackSessionAccessService', () => {
     })
     await expect(service(fetchImpl).resolve([scope()], viewer('slack:T_INSTALL:U_GONE'))).resolves.toEqual({
       allowedScopes: [],
-      degraded: false
+      degraded: false,
+      accessIssues: []
     })
   })
 
@@ -408,7 +509,8 @@ describe('SlackSessionAccessService', () => {
     })
     await expect(service(fetchImpl).resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))).resolves.toEqual({
       allowedScopes: [],
-      degraded: true
+      degraded: true,
+      accessIssues: [{ provider: 'slack', reason: 'app_authorization' }]
     })
   })
 

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -5,7 +5,12 @@ import type { Clock } from '../domain/clock.js'
 import type { BotRepo, BotSecretStore, ExternalScopeRecord } from '../persistence/ports.js'
 import { BotId } from '../domain/ids.js'
 import type { LogtoIdentityService } from '../github/logto-identity.js'
-import type { SessionAccessPlugin, SessionAccessResult, SessionAccessViewer } from './session-access-plugin.js'
+import type {
+  SessionAccessIssue,
+  SessionAccessPlugin,
+  SessionAccessResult,
+  SessionAccessViewer
+} from './session-access-plugin.js'
 
 const ALLOW_TTL_MS = 120_000
 const DENY_TTL_MS = 30_000
@@ -159,6 +164,46 @@ function thrownReason(error: unknown): LocalReason {
   return error.name === 'AbortError' ? 'request_aborted' : 'transport_failure'
 }
 
+/**
+ * The refusals that mean the INSTALLED APP's authorization is what failed — as
+ * opposed to Slack being unreachable, slow, or rate limiting.
+ *
+ * The distinction is the whole point of `app_authorization`: everything in here
+ * is fixed once, by an administrator, through the app's own row on Integrations
+ * (`POST /bots/:id/slack/refresh` syncs the manifest and names the missing
+ * scopes), and nothing in here clears on its own. `missing_scope` is the
+ * observed case — an app installed before a scope was added to
+ * `SLACK_BOT_SCOPES` keeps a grant that can never pass the check — and the rest
+ * are the other ways Slack says "this credential is the problem", which land on
+ * the same page and the same button.
+ *
+ * Deliberately NOT here: `ratelimited` and every transport/HTTP failure, which
+ * really are transient; and `ekm_access_denied`, which is an enterprise key
+ * policy that reauthorizing the app cannot lift. Those stay `unavailable`.
+ */
+const APP_AUTHORIZATION_ERRORS = new Set([
+  'missing_scope',
+  'invalid_auth',
+  'account_inactive',
+  'token_revoked',
+  'token_expired',
+  'no_permission'
+])
+
+/**
+ * One degraded scope's cause, projected onto the console's vocabulary.
+ *
+ * The projection is deliberately lossy. `DegradedReason` is an operator-facing
+ * label — Slack's own word, or a `LocalReason` — and it stays in the log; what
+ * crosses into `accessIssues` is only which REMEDY the reason implies, so a
+ * member sees "reauthorize the app" or "try again later" and never a code they
+ * would have to look up. It carries no bot, workspace, or channel: see
+ * `SessionAccessIssue`.
+ */
+function accessIssueFor(reason: DegradedReason): SessionAccessIssue {
+  return { provider: 'slack', reason: APP_AUTHORIZATION_ERRORS.has(reason) ? 'app_authorization' : 'unavailable' }
+}
+
 function slackPrincipals(identitySet: ReadonlySet<string>): SlackPrincipal[] {
   const principals: SlackPrincipal[] = []
   for (const key of identitySet) {
@@ -238,7 +283,9 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
 
   async resolve(scopes: readonly ExternalScopeRecord[], viewer: SessionAccessViewer): Promise<SessionAccessResult> {
     const principals = slackPrincipals(viewer.identitySet)
-    if (principals.length === 0 || scopes.length === 0) return { allowedScopes: [], degraded: false }
+    if (principals.length === 0 || scopes.length === 0) {
+      return { allowedScopes: [], degraded: false, accessIssues: [] }
+    }
     let degraded = false
     const decisions: Array<{ scope: ExternalScopeRecord; verdict: Verdict }> = []
     // 200 is a provider-work batch, never a visibility ceiling. Walk every
@@ -261,6 +308,14 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     // refusal, or a `LocalReason` — and never by conversation: one bucket may
     // cover many channels, but no bucket can name one. Its counts sum to
     // `unknownScopes`, since a scope reports the first cause that hid it.
+    //
+    // The SAME walk feeds `accessIssues`, which is the requester-facing half of
+    // the diagnosis and the reason a degraded Slack check used to reach the
+    // console as a bare boolean. Two audiences, two vocabularies, one pass: the
+    // operator gets the codes and their counts, the member gets the remedy those
+    // codes imply and nothing else — at most one issue per remedy, because a
+    // reason is a cause and there is no per-scope axis to spread them over.
+    const accessIssues = new Map<SessionAccessIssue['reason'], SessionAccessIssue>()
     if (degraded) {
       const reasons = new Map<DegradedReason, number>()
       let unknownScopes = 0
@@ -271,6 +326,8 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
         // cause — and is what a future path that forgot to would look like.
         const reason = verdict.reason ?? 'unreported'
         reasons.set(reason, (reasons.get(reason) ?? 0) + 1)
+        const issue = accessIssueFor(reason)
+        accessIssues.set(issue.reason, issue)
       }
       this.deps.log?.warn(
         { provider: 'slack', unknownScopes, totalScopes: decisions.length, reasons: Object.fromEntries(reasons) },
@@ -281,7 +338,8 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
       allowedScopes: decisions
         .filter(({ verdict }) => verdict.decision === 'allow')
         .map(({ scope }) => ({ id: scope.id, aclRevision: scope.aclRevision })),
-      degraded
+      degraded,
+      accessIssues: [...accessIssues.values()]
     }
   }
 

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -213,8 +213,13 @@ function Section({ label, children }: { label: string; children: ReactNode }) {
 
 export default function IntegrationsView() {
   // `?bot=<id>` opens that bot's channel roster — the agent page's bot chip and
-  // the Settings-era deep links land here.
-  const targetBotId = useSearchParams().get('bot')
+  // the Settings-era deep links land here. `?platform=<id>` only selects the
+  // tab, for senders that know which provider needs attention but not which of
+  // its installs: the session-access "reauthorize your Slack app" notification
+  // is deliberately one of those (see `session-access-notifications.ts`).
+  const params = useSearchParams()
+  const targetBotId = params.get('bot')
+  const targetPlatform = params.get('platform')
   const { me } = useProfile()
   const { myRole } = useOrgs()
   const { openModal } = useModal()
@@ -237,7 +242,13 @@ export default function IntegrationsView() {
       </div>
 
       <Section label="Messaging apps">
-        <BotsCard canWrite={canWrite} me={me} targetBotId={targetBotId} onDelete={setDeletingBot} />
+        <BotsCard
+          canWrite={canWrite}
+          me={me}
+          targetBotId={targetBotId}
+          targetPlatform={targetPlatform}
+          onDelete={setDeletingBot}
+        />
       </Section>
 
       <Section label="Code hosts">
@@ -265,11 +276,13 @@ function BotsCard({
   canWrite,
   me,
   targetBotId,
+  targetPlatform,
   onDelete
 }: {
   canWrite: boolean
   me: MeDto | null
   targetBotId: string | null
+  targetPlatform: string | null
   onDelete: (b: BotDto) => void
 }) {
   const { orgPath } = useOrgs()
@@ -306,6 +319,14 @@ function BotsCard({
       counts.set(tab.key, bots.filter((bot) => botMatchesPlatformTab(bot, tab)).length)
     return counts
   }, [bots])
+
+  // Runs before the bot effect below, so `?bot=` still wins when both are given:
+  // an unknown platform is simply ignored rather than emptying the strip.
+  const targetPlatformTabKey = BOT_PLATFORM_TABS.find((tab) => tab.platform === targetPlatform)?.key
+  useEffect(() => {
+    if (!targetPlatformTabKey) return
+    setPlatformTabKey(targetPlatformTabKey)
+  }, [targetPlatformTabKey])
 
   useEffect(() => {
     if (!targetBotId || !targetBotPlatformTabKey) return

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -425,10 +425,15 @@ export interface ConversationDto {
   memberSessionIds?: string[]
 }
 
+/** Why a provider failed closed — a CAUSE, never a target (no channel, user or
+ *  workspace id ever appears here). `authorization` is the VIEWER's own linked
+ *  identity; `app_authorization` is the installed app's grant, which only an
+ *  administrator can restore. A CP that predates a variant simply never sends
+ *  it, and an unrecognized one falls back to the generic notification. */
 export interface SessionAccessIssue {
   provider: string
   region?: string
-  reason: 'authorization' | 'quota' | 'unavailable'
+  reason: 'authorization' | 'app_authorization' | 'quota' | 'unavailable'
 }
 
 export interface SessionListPageDto {

--- a/packages/web/src/lib/session-access-notifications.test.ts
+++ b/packages/web/src/lib/session-access-notifications.test.ts
@@ -48,6 +48,76 @@ describe('sessionAccessNotifications', () => {
     ])
   })
 
+  // The whole point of the `app_authorization` variant: this state is a
+  // two-minute administrator fix, and the generic copy below ("checks
+  // unavailable") reads as a Slack outage and suggests nothing to do — so
+  // people wait for something that never clears.
+  it('turns a short Slack app grant into a reauthorize prompt', () => {
+    expect(
+      sessionAccessNotifications('sessions', true, [{ provider: 'slack', reason: 'app_authorization' }], orgPath)
+    ).toEqual([
+      {
+        category: 'session_access',
+        severity: 'warning',
+        sourceKey: 'sessions:slack:app_authorization',
+        title: 'Reauthorize your Slack app',
+        message:
+          'Refresh the app in Integrations to grant the permissions AgentConnect needs and restore access to affected sessions.',
+        action: {
+          label: 'Open Integrations',
+          // Where the existing per-app refresh action lives, and the only place
+          // that can say WHICH scopes an installation is missing.
+          href: '/acme/integrations?platform=slack',
+          external: false
+        }
+      }
+    ])
+  })
+
+  it('phrases the Slack reauthorize prompt for the usage surface', () => {
+    expect(
+      sessionAccessNotifications('usage', true, [{ provider: 'slack', reason: 'app_authorization' }], orgPath)
+    ).toEqual([
+      expect.objectContaining({
+        sourceKey: 'usage:slack:app_authorization',
+        message:
+          'Refresh the app in Integrations to grant the permissions AgentConnect needs and restore usage from affected sessions.'
+      })
+    ])
+  })
+
+  // Rate limiting, an outage or a timeout really do clear on their own. Sending
+  // that reader to reauthorize an app would waste their time on a healthy one.
+  it('keeps the generic copy for a transient Slack failure', () => {
+    expect(
+      sessionAccessNotifications('sessions', true, [{ provider: 'slack', reason: 'unavailable' }], orgPath)
+    ).toEqual([
+      {
+        category: 'session_access',
+        severity: 'warning',
+        sourceKey: 'sessions:generic:unavailable',
+        title: 'Session access checks unavailable',
+        message: 'Affected sessions are hidden until access can be verified.'
+      }
+    ])
+  })
+
+  // Both halves of a mixed sweep are worth showing: one is actionable now, the
+  // other explains the sessions that stay hidden after the app is fixed.
+  it('shows the reauthorize prompt alongside the generic copy for a mixed sweep', () => {
+    expect(
+      sessionAccessNotifications(
+        'sessions',
+        true,
+        [
+          { provider: 'slack', reason: 'app_authorization' },
+          { provider: 'slack', reason: 'unavailable' }
+        ],
+        orgPath
+      ).map((notification) => notification.sourceKey)
+    ).toEqual(['sessions:generic:unavailable', 'sessions:slack:app_authorization'])
+  })
+
   it('collapses unsupported and unusable diagnostics into one generic source per surface', () => {
     expect(
       sessionAccessNotifications(

--- a/packages/web/src/lib/session-access-notifications.ts
+++ b/packages/web/src/lib/session-access-notifications.ts
@@ -41,6 +41,39 @@ function genericNotification(surface: SessionAccessSurface): SessionAccessNotifi
   }
 }
 
+/**
+ * The installed app's grant fell short — an administrator's two-minute fix, not
+ * an outage.
+ *
+ * It routes to the app's own row on Integrations rather than restating what is
+ * wrong, because the row's refresh action is the AUTHORITATIVE per-app
+ * diagnosis: it asks Slack which scopes the installation actually granted and
+ * names the missing ones. This notification only knows that some app behind the
+ * sessions on this page came up short, so telling the reader more than "one of
+ * your Slack apps needs reauthorizing, here is where you fix it" would be
+ * guessing — see the plugin's `accessIssueFor`.
+ */
+function appAuthorizationNotification(
+  surface: SessionAccessSurface,
+  orgPath: (path: string) => string
+): SessionAccessNotificationInput {
+  return {
+    category: 'session_access',
+    severity: 'warning',
+    sourceKey: `${surface}:slack:app_authorization`,
+    title: 'Reauthorize your Slack app',
+    message:
+      surface === 'sessions'
+        ? 'Refresh the app in Integrations to grant the permissions AgentConnect needs and restore access to affected sessions.'
+        : 'Refresh the app in Integrations to grant the permissions AgentConnect needs and restore usage from affected sessions.',
+    action: {
+      label: 'Open Integrations',
+      href: orgPath('/integrations?platform=slack'),
+      external: false
+    }
+  }
+}
+
 function classifiedNotification(
   surface: SessionAccessSurface,
   region: FeishuRegion,
@@ -102,7 +135,13 @@ export function sessionAccessNotifications(
     ) {
       const notification = classifiedNotification(surface, issue.region, issue.reason, orgPath)
       notifications.set(notification.sourceKey, notification)
+    } else if (issue.provider === 'slack' && issue.reason === 'app_authorization') {
+      const notification = appAuthorizationNotification(surface, orgPath)
+      notifications.set(notification.sourceKey, notification)
     } else {
+      // Including a Slack `unavailable`: rate limiting and outages really do
+      // clear on their own, and relabelling them would put a "reauthorize your
+      // app" prompt in front of someone with nothing to reauthorize.
       needsGeneric = true
     }
   }


### PR DESCRIPTION
## The problem

When the session-access check asks Slack about a conversation and the installed app's token lacks a required scope, Slack answers `missing_scope`. The check fails closed, the sessions are hidden, and the console shows:

> **Session access checks unavailable** — Affected sessions are hidden until access can be verified.

That reads like a Slack outage and suggests nothing to do. It is in fact a configuration problem the organization can fix itself in about two minutes, and the remedy already ships: the Slack app's refresh action on Integrations syncs the manifest and reports exactly which scopes the installation is missing. Nothing connected the two, so people wait for an outage that will never clear.

This is not hypothetical. In a multi-hour production window every degraded Slack access check reported `missing_scope`, across several installs that have never been reauthorized — and the console's copy gave no clue at all during an investigation of exactly that problem.

## What was missing

Everything needed already existed except one connection. `SessionAccessIssue` is already the channel from a plugin to the console, already carried through `SessionAccessResult.accessIssues`, already in the DTOs and already typed in the web client. `slack-session-access.ts` already classifies every failure into a `DegradedReason` and aggregates it — that is how `missing_scope` was identified in the first place.

**The Slack plugin simply never populated `accessIssues`.** Only the Feishu plugin did. So a Slack degradation reached the console as a bare `accessSyncDegraded: true` with no cause attached, which is why the copy had to be generic.

That same classification now feeds the requester-facing half, in the same pass over the same verdicts: the operator keeps the codes and their counts, the member gets the remedy those codes imply and nothing else.

## Decision 1 — a new `reason` variant rather than reusing `authorization`

The enum was `'authorization' | 'quota' | 'unavailable'`. `authorization` today means the **viewer's** linked identity fell short: they fix it themselves, on their own Profile, and no one else's view is affected. An installed app that is short of a scope is a different actor, a different page and a different fix — an administrator, once, for everyone. Overloading one label would have forced the console to render one of the two remedies to the wrong person.

So `app_authorization` was added. It costs the DTO enum plus its two mirrors, and both directions degrade safely: a console that predates the variant falls through to the generic notification, and a control plane that predates it simply never sends one.

## Decision 2 — the issue stays coarse and does not name which install

An organization can run several Slack apps, so "reauthorize Slack" is admittedly only somewhat more specific than today's copy, and the payload goes to an authorized member of the org that owns the app rather than to an operator — a different audience from the one the plugin's logging discipline is written for.

Naming one was still rejected, on **correctness** rather than privacy: `accessIssues` only ever sees the apps behind the sessions on the page being read. A named app would be an *incomplete* answer — someone could fix the one named and stay degraded, with no hint that another app was also short. The production case is exactly that shape: several installs are short at once, so singling one out would misdescribe the problem rather than sharpen it. The refresh action on the app's own row is the authoritative per-app diagnosis, because it asks Slack which scopes the installation actually granted, so the notification's job is to route there rather than duplicate it partially.

`SessionAccessIssue` accordingly stays a cause and never a target: no channel, conversation, user, team or credential enters it, and a test pins that.

## Scope discipline

Transient failures are untouched. Rate limiting, outages, timeouts and every transport/HTTP failure stay `unavailable` and keep the generic copy — the point is to separate "we cannot reach Slack" from "your app's permissions are short", not to relabel everything. `ekm_access_denied` stays transient for the same reason: reauthorizing the app cannot lift an enterprise key policy.

`missing_scope` is the observed case. The set also covers the credential-death codes (`invalid_auth`, `account_inactive`, `token_revoked`, `token_expired`, `no_permission`), which are not transient either and whose remedy is the same page and the same button — they would otherwise produce the identical dead end.

Unchanged: fail-closed behaviour, the access-check TTLs, `failureDecision`'s classification, and install-time verification.

`?platform=<id>` is added to Integrations so the notification lands on the right tab rather than relying on Slack happening to be the first one. `?bot=<id>` — which selects the tab *and* expands the row — still wins when both are present, and an unknown platform is ignored.

## Verification

- `control-plane` typecheck, `test:unit` (1331 passed), `test:int` (1052 passed, Docker)
- `web` typecheck and tests — `OnboardingView.test.tsx` fails identically on `main` (a `GettingStartedChecklist` mock missing `useSessionAccessCardAvailable`, added in #760); confirmed pre-existing by stashing
- `eslint` and `prettier --check` clean on every touched file
- Console checked in the browser against mock data: the notification renders with its action, `Open Integrations` routes to `/<org>/integrations?platform=slack` and selects the Slack tab, a non-default platform selects its own tab, an unknown one falls back, and the tab strip stays interactive afterwards

New tests: a `missing_scope` degradation produces an `app_authorization` issue the console renders as a reauthorize prompt; a transient failure still renders the unavailable copy; no channel, workspace, viewer or credential appears in `accessIssues`; many hidden scopes collapse to one issue per remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)