### PR TITLE
refactor(web): collapse the session rail's Related tree to three levels

### DIFF
--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -423,16 +423,32 @@ lineage-siblings) would be listed twice.
 
 Attribution still has to be **surfaced**, and the merged transcript cannot do
 it: it interleaves its members by time, so "who woke whom" is unreadable from
-the ordering. The rail carries it, anchored on the OPEN row and labelled as
-delegation — **"Delegated by"** for the participant that woke it, **"Delegated
-to"** for the ones it woke — never as "Parent conversation", which would name a
-member of this room as another conversation and link back to the page you are
-already on. Anchoring on the open row is what keeps it directional: the
-representative is the newest visible member and rotates whenever either agent
-speaks, and one A → B edge is A's child and B's parent at once, so a
-side-agnostic filter would mislabel one of the two. Rows are deduplicated
-against the ordinary list exactly as family rows are, which preserves the
-displayed-once invariant above.
+the ordering. The rail carries it, anchored on the OPEN row — never as a
+navigation row, which would name a member of this room as another conversation
+and link back to the page you are already on. Anchoring on the open row is what
+keeps it directional: the representative is the newest visible member and
+rotates whenever either agent speaks, and one A → B edge is A's child and B's
+parent at once, so a side-agnostic filter would mislabel one of the two. Rows
+are deduplicated against the ordinary list exactly as family rows are, which
+preserves the displayed-once invariant above.
+
+The rail's Related tree is **exactly three levels — whatever woke the open row,
+the open row, whatever it woke — and direction is drawn as position on them**,
+with no group headings. An in-room `wokenBy` and a cross-room parent are one
+edge seen from two locations, so they share level 0 rather than nesting; `woke`
+and cross-room delegations share level 2 for the same reason. Nesting them
+would assert a chain the lift does not have: §9.2 unions parents across every
+member **without recording which member each one woke**. The headings this
+replaced ("Parent conversation" / "Delegated by" / "Delegated to" /
+"Delegations") each spent a line restating the indent directly beneath them,
+and usually the title too, since a conversation is named after its first
+message — typically the human @mentioning the very agent that then delegates.
+Kind is already in the row: an agent mark and a name that do not click, against
+a platform mark and a title that do. The words move into each row's hover
+tooltip — **the same two words for the navigation row and the attribution row**,
+since they are one edge — and stay as `sr-only` text besides, because
+indentation is a visual relation that a screen reader hears nothing of and a
+tooltip never reaches.
 
 Each row is built around the AGENT, not the session: agent mark and agent name
 (org roster, then the relation's own projection, then the raw id). A session
@@ -465,10 +481,11 @@ page (parent/sibling/child links) — a page this design stops surfacing for
 multi-participant conversations. The merged page therefore inherits it at
 conversation level: the union of member sessions' lineage links whose target
 lies in a DIFFERENT conversation (§9.1 filters the intra-room ones), each
-mapped to the conversation its target session belongs to, rendered as
-**"Parent conversation"** and **"Delegations"** (child conversations, grouped
-by the waking member). No new CP surface — the member detail DTOs already carry the
-links, and mapping a session to its conversation key is a metadata lookup.
+mapped to the conversation its target session belongs to, rendered on §9.1's
+three levels — parents above the open row, child conversations below it,
+grouped by the waking member. No new CP surface — the member detail DTOs
+already carry the links, and mapping a session to its conversation key is a
+metadata lookup.
 (C2 ships the links; grouping delegations by waking turn is C3.)
 
 One invariant stays absolute: **lineage never changes membership**. A child
@@ -578,6 +595,6 @@ how divergence starts.
    (same parent session). An edge whose endpoints share the conversation key
    renders as attribution and is excluded from lifted navigation — the
    room-mates-AND-siblings overlap is displayed once, not twice (§9.1).
-   Attribution is surfaced in the rail as "Delegated by" / "Delegated to",
-   anchored on the open row and kept out of the family shape, whose parent
+   Attribution is surfaced in the rail as tree position around the open row —
+   waker above it, woken below — and kept out of the family shape, whose parent
    slot means "another conversation" and navigates away (§9.1).

--- a/packages/web/src/components/console/SessionRail.test.tsx
+++ b/packages/web/src/components/console/SessionRail.test.tsx
@@ -225,6 +225,19 @@ describe('SessionRail room attribution', () => {
     expect(markup).toContain('db-operator')
   })
 
+  it('gives the navigation rows the same words', () => {
+    // A cross-room parent is the same edge as `wokenBy`, and a cross-room
+    // delegation the same edge as `woke` — only the other end's location
+    // differs. A screen reader gets no indent and no tooltip, so both kinds of
+    // row have to carry the words, or half the tree loses its direction.
+    const markup = railMarkup({
+      family: { ...NO_FAMILY, parentSession: relation('rel-p'), childSessions: [relation('rel-k')] }
+    })
+
+    expect(markup).toContain('<span class="sr-only">Delegated by</span>')
+    expect(markup).toContain('<span class="sr-only">Delegated to</span>')
+  })
+
   it('falls back to the agent id when nothing can name the agent', () => {
     // Older Control Planes omit the projection, and a restricted agent can own a
     // member session while staying out of this viewer's roster. An id beats a

--- a/packages/web/src/components/console/SessionRail.test.tsx
+++ b/packages/web/src/components/console/SessionRail.test.tsx
@@ -212,8 +212,13 @@ describe('SessionRail room attribution', () => {
       }
     })
 
-    expect(markup).toContain('Delegated by')
-    expect(markup).toContain('Delegated to')
+    // Direction is drawn as indent, so the words live in the tooltip and in
+    // sr-only text — never in a heading line, which restated the indent below
+    // it and usually the title with it.
+    expect(markup).toContain('title="Delegated by Alert Analyzer')
+    expect(markup).toContain('title="Delegated to node-operator')
+    expect(markup).toContain('<span class="sr-only">Delegated by</span>')
+    expect(markup).toContain('<span class="sr-only">Delegated to</span>')
     // The identities, which the shared title cannot carry.
     expect(markup).toContain('Alert Analyzer')
     expect(markup).toContain('node-operator')

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -81,6 +81,9 @@ interface RailRow {
   platform: string
   title: string
   tooltip: string
+  /** The edge this row sits on, for readers the indent does not reach. Absent on
+   *  a plain list row, which sits on no edge at all. */
+  relationLabel?: string
   /** Where the row goes. A multi-participant row is a CONVERSATION, and the merged
    *  page is its default surfaced view (merged-conversation-view.md §5.3). */
   href: string
@@ -386,11 +389,11 @@ export function SessionRail({
       session: s
     }
   }
-  // `relationLabel` names the edge in the tooltip — the same two words an
-  // attribution row uses, because it is the same edge: a lineage parent and an
-  // in-room `wokenBy` differ only in where the other end lives, and the row
-  // already shows that by being a link or not. Omitted for siblings, whose slot
-  // means two different things by page (see conversation-lineage.ts).
+  // `relationLabel` names the edge in the tooltip and in sr-only text — the same
+  // two words an attribution row uses, because it is the same edge: a lineage
+  // parent and an in-room `wokenBy` differ only in where the other end lives,
+  // and the row already shows that by being a link or not. Omitted for siblings,
+  // whose slot means two different things by page (see conversation-lineage.ts).
   const relationRow = (relation: SessionRelationDto, relationLabel?: string): RailRow => {
     const title = relation.title?.trim() || `Session ${relation.id.slice(0, 8)}`
     return {
@@ -398,6 +401,7 @@ export function SessionRail({
       platform: relation.platform,
       title,
       tooltip: relationLabel ? `${relationLabel}\n${title}` : title,
+      ...(relationLabel ? { relationLabel } : {}),
       href: orgPath(`/sessions/${encodeURIComponent(relation.id)}${flatSearch}`),
       pinId: relation.id
     }
@@ -498,6 +502,7 @@ export function SessionRail({
           <span className="imark h-[18px] w-[18px] flex-none rounded-xs">
             <PlatformMark platform={item.platform} fillPct={100} />
           </span>
+          {item.relationLabel && <span className="sr-only">{item.relationLabel}</span>}
           <span
             className={`min-w-0 flex-1 truncate font-sans text-[12.5px] leading-normal ${
               on ? 'font-semibold' : 'font-medium'

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -144,7 +144,6 @@ export function SessionRail({
   filterTouched,
   onAgentIdsChange,
   family,
-  conversation = false,
   flatView = false,
   childOriginById,
   roomLineage,
@@ -165,9 +164,6 @@ export function SessionRail({
   onAgentIdsChange: (agentIds: string[]) => void
   /** Direct lineage from the detail endpoint. Undefined while it is unavailable. */
   family?: Pick<SessionDetailDto, 'parentSession' | 'siblingSessions' | 'childSessions'>
-  /** Conversation-level lineage (merged-conversation-view.md §9.2): relabels the
-   *  related tree and groups delegations by their waking member. */
-  conversation?: boolean
   /** Keep raw session rows and links instead of collapsing into conversations. */
   flatView?: boolean
   /** Delegation target id → waking member agentId (conversation mode). */
@@ -227,7 +223,8 @@ export function SessionRail({
   const children = family?.childSessions ?? EMPTY_RELATIONS
   // Attribution inside the open conversation, kept apart from `family` on
   // purpose: these are fellow PARTICIPANTS, not other conversations, so they
-  // never take the "Parent conversation" label or its navigate-away meaning.
+  // share the tree level of the matching `family` slot but never its
+  // navigate-away meaning.
   const wokenBy = roomLineage?.wokenBy ?? null
   const woke = roomLineage?.woke ?? EMPTY_RELATIONS
   const hasFamily = Boolean(parent || siblings.length > 0 || children.length > 0 || wokenBy || woke.length > 0)
@@ -389,13 +386,18 @@ export function SessionRail({
       session: s
     }
   }
-  const relationRow = (relation: SessionRelationDto): RailRow => {
+  // `relationLabel` names the edge in the tooltip — the same two words an
+  // attribution row uses, because it is the same edge: a lineage parent and an
+  // in-room `wokenBy` differ only in where the other end lives, and the row
+  // already shows that by being a link or not. Omitted for siblings, whose slot
+  // means two different things by page (see conversation-lineage.ts).
+  const relationRow = (relation: SessionRelationDto, relationLabel?: string): RailRow => {
     const title = relation.title?.trim() || `Session ${relation.id.slice(0, 8)}`
     return {
       id: relation.id,
       platform: relation.platform,
       title,
-      tooltip: title,
+      tooltip: relationLabel ? `${relationLabel}\n${title}` : title,
       href: orgPath(`/sessions/${encodeURIComponent(relation.id)}${flatSearch}`),
       pinId: relation.id
     }
@@ -412,8 +414,16 @@ export function SessionRail({
   // session. The generic row renders a session title and a platform mark, and
   // neither identifies anyone here: participants of one thread routinely share
   // a title (it is derived from the same first message) and necessarily share
-  // the platform, so "Delegated by" over a title equal to the current row's
-  // says nothing, and several `woke` rows would be indistinguishable.
+  // the platform, so a row built from those two fields would name nobody, and
+  // several `woke` rows would be indistinguishable.
+  //
+  // The DIRECTION rides on the row's place in the tree — waker above the open
+  // row, woken below it — and not on a heading, which spent a line restating
+  // that indent and usually the title too: a conversation is named after its
+  // first message, typically the human @mentioning the very agent that then
+  // delegates. `relationLabel` moves into the hover tooltip, and stays as
+  // `sr-only` text besides, since indentation is a visual relation that a
+  // screen reader hears nothing of and a tooltip never reaches.
   //
   // It is also NOT navigation, which is §9.1's own title. The target is a
   // participant of the conversation already on screen, so `/sessions/:id` would
@@ -425,14 +435,14 @@ export function SessionRail({
   // relation's own projection (older CPs omit it), then the raw id — a
   // restricted agent can own a member session while staying out of this
   // viewer's roster, and showing an id beats showing nothing.
-  const attributionRow = (relation: SessionRelationDto, depth: 0 | 1 | 2 = 0) => {
+  const attributionRow = (relation: SessionRelationDto, depth: 0 | 1 | 2, relationLabel: string) => {
     const agent = agents.find((candidate) => candidate.id === relation.agentId)
     const name = agent ? agentLabel(agent) : relation.agentName?.trim() || relation.agentId
     const title = relation.title?.trim() || `Session ${relation.id.slice(0, 8)}`
     return (
       <div
         key={`attribution-${relation.id}`}
-        title={`${name}\n${title}`}
+        title={`${relationLabel} ${name}\n${title}`}
         className={`flex w-full min-w-0 items-center gap-2 rounded-sm py-[6px] pr-[9px] text-(--text-secondary) ${
           depth === 2 ? 'pl-[26px]' : 'pl-[9px]'
         }`}
@@ -446,6 +456,7 @@ export function SessionRail({
         <span className="av h-[18px] w-[18px] flex-none rounded-xs">
           <AgentIconView icon={agent?.icon} runtime={agent?.runtime ?? ''} size={18} />
         </span>
+        <span className="sr-only">{relationLabel}</span>
         <span className="min-w-0 flex-1 truncate font-sans text-[12.5px] font-medium leading-normal">{name}</span>
       </div>
     )
@@ -512,6 +523,18 @@ export function SessionRail({
     )
   }
 
+  // The Related tree is exactly three levels — whatever woke the open row, the
+  // open row, whatever it woke — and the indent is now the only thing saying
+  // which is which. A cross-room parent and an in-room `wokenBy` are the SAME
+  // edge seen from two locations, so they share level 0 rather than nesting:
+  // the lift unions parents across every member without recording WHICH member
+  // each one woke, so hanging `wokenBy` under `parent` would draw a chain the
+  // data does not contain. `woke` and cross-room `children` share level 2 for
+  // the same reason. Siblings sit at the open row's own level, below a divider.
+  const aboveCurrent = Boolean(parent || wokenBy)
+  const currentDepth = aboveCurrent ? 1 : 0
+  const delegatedDepth = aboveCurrent ? 2 : 1
+
   const allSessionsQuery = new URLSearchParams()
   if (flatView) allSessionsQuery.set('view', 'flat')
   if (agentIds.length === 1) allSessionsQuery.set('agent', agentIds[0]!)
@@ -541,34 +564,16 @@ export function SessionRail({
             <div className="flex-none px-[9px] pb-[3px] font-mono text-[10px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
               Related
             </div>
-            {conversation && parent && (
-              <div className="flex-none px-[9px] pt-[2px] pb-[2px] font-mono text-[9.5px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
-                Parent conversation
-              </div>
-            )}
-            {parent && row(relationRow(parent), isPinned(parent.id))}
+            {parent && row(relationRow(parent, 'Delegated by'), isPinned(parent.id))}
             {/* Attribution, not navigation: the participant that woke the open
-                row. Deliberately NOT labelled "Parent conversation" — it is a
-                member of this same conversation, so calling it another
-                conversation would be wrong and its link comes back here. */}
-            {wokenBy && (
-              <div className="flex-none px-[9px] pt-[2px] pb-[2px] font-mono text-[9.5px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
-                Delegated by
-              </div>
-            )}
-            {wokenBy && attributionRow(wokenBy, parent ? 1 : 0)}
-            {row(sessionRow(current), rowPin(current).pinned, parent || wokenBy ? 1 : 0, true)}
-            {woke.length > 0 && (
-              <div className="flex-none px-[9px] pt-[4px] pb-[2px] font-mono text-[9.5px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
-                Delegated to
-              </div>
-            )}
-            {woke.map((target) => attributionRow(target, parent || wokenBy ? 2 : 1))}
-            {conversation && children.length > 0 && (
-              <div className="flex-none px-[9px] pt-[4px] pb-[2px] font-mono text-[9.5px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
-                Delegations
-              </div>
-            )}
+                row, then the ones it woke. Same lineage edge as `parent` — the
+                only difference is that these two live in THIS conversation, so
+                their link would come straight back to the page you are on.
+                That difference is already in the row: an agent mark and a name
+                that do not click, against a platform mark and a title that do. */}
+            {wokenBy && attributionRow(wokenBy, 0, 'Delegated by')}
+            {row(sessionRow(current), rowPin(current).pinned, currentDepth, true)}
+            {woke.map((target) => attributionRow(target, delegatedDepth, 'Delegated to'))}
             {children.map((child, index) => {
               const origin = childOriginById?.get(child.id)
               const previousOrigin = index > 0 ? childOriginById?.get(children[index - 1]!.id) : undefined
@@ -580,7 +585,7 @@ export function SessionRail({
                       via {originAgent ? agentLabel(originAgent) : origin}
                     </div>
                   )}
-                  {row(relationRow(child), isPinned(child.id), parent ? 2 : 1)}
+                  {row(relationRow(child, 'Delegated to'), isPinned(child.id), delegatedDepth)}
                 </Fragment>
               )
             })}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -4237,7 +4237,6 @@ export default function SessionDetailView() {
         filterTouched={railFilter.touched}
         onAgentIdsChange={setRailAgentIds}
         family={conversationFamily ?? (currentSessionDetail?.id === session.id ? currentSessionDetail : undefined)}
-        conversation={conversationMode}
         flatView={flatView}
         childOriginById={conversationLineage?.childOriginById}
         roomLineage={conversationLineage?.roomLineage}

--- a/packages/web/src/lib/conversation-lineage.ts
+++ b/packages/web/src/lib/conversation-lineage.ts
@@ -19,11 +19,12 @@
 // instead. The same conversation therefore showed its delegation or hid it
 // depending on how many members happened to resolve that second.
 //
-// The two must NOT share a shape. `family` is directional in the UI — a
-// `parentSession` renders as "Parent conversation" and links away — so putting
-// a co-participant there labels a member of THIS room as another conversation
-// and links back to the page you are on. Attribution is therefore its own
-// structure, anchored on the open row: who woke it, and whom it woke.
+// The two must NOT share a shape. `family` is navigation in the UI — a
+// `parentSession` links AWAY, to another conversation — so putting a
+// co-participant there hands the reader a link back to the page they are on.
+// Attribution is therefore its own structure, anchored on the open row: who
+// woke it, and whom it woke. The rail draws both on the same three levels
+// (waker · open row · woken), since they are one edge seen from two locations.
 
 import type { SessionRelationDto } from '@/lib/api'
 


### PR DESCRIPTION
## What

The session rail's **Related** block spent a heading line on each lineage group — `Parent conversation`, `Delegated by`, `Delegated to`, `Delegations` — directly above the rows it described. All four are gone. The tree is now exactly three levels: **whatever woke the open row · the open row · whatever it woke**.

Before / after, the common case (an in-thread delegation):

```
RELATED                          RELATED
DELEGATED BY                     🔥 Alert Analyzer
🔥 Alert Analyzer          →       └ @Alert Analyzer: Tai…
  └ @Alert Analyzer: Tai…            └ node-operator
DELEGATED TO
  └ node-operator
```

## Why

Each heading restated the indent directly beneath it — and usually the title as well. A conversation is named after its first message, which is typically the human `@`-mentioning the very agent that then delegates, so heading, agent row and open row all carried one name.

The headings also split **one relation into two vocabularies**. A lineage `parent` and an in-room `wokenBy` are the same edge; the only difference is whether the other end lives in this conversation, and the row already shows that by being a link or not.

## Notable

- **A cross-room `parent` and `wokenBy` now share level 0 instead of nesting.** The old indent asserted a chain the data never had: the §9.2 lift unions parents across every member *without* recording which member each one woke, so hanging `wokenBy` under `parent` drew a relation nobody computed. `woke` and cross-room delegations share level 2 for the same reason — which is also why no fourth level is needed.
- **The words moved into each row's hover tooltip**, the same two words for the navigation row and the attribution row, and stay as `sr-only` text besides. A tooltip needs a pointer and indentation is a visual relation, so neither reaches a screen reader on its own.
- **`SessionRail`'s `conversation` prop is deleted.** It only ever chose between heading wordings.
- `docs/designs/merged-conversation-view.md` §9.1/§9.2 updated — the labels were documented there.

## Not in scope

- On a merged page, extra cross-room parents still ride in the `siblingSessions` slot, which means *other children of the same parent* on a single-session page. Same slot, two meanings; unchanged here, tracked separately.
- The mobile family card (`MobileSessionFamilyLinks`, `desktop:hidden`) keeps its own label/value table and still omits the attribution rows, so ≤768px draws the same edges twice.

## Test

`pnpm --filter @agentconnect.md/web exec vitest run src/components/console/SessionRail` — 18 passed. Typecheck, prettier and eslint clean. Not exercised in a browser: the tree needs a live multi-agent conversation with a cross-room delegation to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)