### PR TITLE
fix(web): stop offering a futile retry for a permanently unverifiable conversation

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -7,6 +7,7 @@ import { mergeConversation, type MergeSource } from '@/lib/conversation-merge'
 import { selfConversationPath } from '@/lib/conversation-addressing'
 import { assembleConversationLineage } from '@/lib/conversation-lineage'
 import { encodeConversationKey } from '@/lib/conversation-key'
+import { unverifiedConversationNotice } from '@/lib/session-access-notifications'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import {
@@ -1173,6 +1174,9 @@ export default function SessionDetailView() {
   // into either — an empty answer the CP could not verify is not an absence.
   const conversationRoster = conversationResolution === undefined ? undefined : conversationResolution.conversation
   const conversationAccessDegraded = conversationResolution?.accessSyncDegraded === true
+  // Why it could not be verified, which decides whether the blocked state below
+  // is worth retrying or worth acting on.
+  const conversationAccessIssues = conversationResolution?.accessIssues ?? []
   const conversationMembers = conversationKey ? (conversationRoster?.sessions ?? null) : null
   const id = conversationKey ? (conversationMembers?.[0]?.sessionId ?? '') : (routeId ?? '')
   const conversationSourceKey =
@@ -2249,19 +2253,27 @@ export default function SessionDetailView() {
   // console never actually got. The request erroring is self-evidently not an
   // answer; a DEGRADED answer is subtler — the CP fails external access checks
   // closed, so a Slack API blip omits the very members it could not check and
-  // the roster arrives empty with `accessSyncDegraded` set. Both are transient
-  // and retryable, so say so and offer the retry.
+  // the roster arrives empty with `accessSyncDegraded` set.
+  //
+  // What is NOT true of both is that they are transient. This page used to say
+  // so unconditionally and offer a retry, which for a short app grant is a
+  // button that cannot ever succeed — and because a resolved verdict is cached
+  // for a couple of minutes, the permanent failure even reads as flakiness. The
+  // cause now picks the words and the way out; `accessIssues` rode along on this
+  // response the whole time (see `unverifiedConversationNotice`).
   if (conversationKey && (conversationError || (conversationAccessDegraded && !conversationRoster))) {
+    const notice = unverifiedConversationNotice(Boolean(conversationError), conversationAccessIssues, orgPath)
     return (
       <SessionDetailFrame withRail={false}>
         <div className="card p-6">
-          <div className="font-sans text-[13.5px] leading-[1.55] text-(--text-secondary)">
-            {conversationError
-              ? 'This conversation could not be loaded. The console could not reach the control plane.'
-              : 'This conversation cannot be shown until its access checks can be verified.'}
-          </div>
+          <div className="font-sans text-[13.5px] leading-[1.55] text-(--text-secondary)">{notice.message}</div>
           <div className="mt-4 flex flex-wrap items-center gap-2">
-            <Button onClick={() => void retryConversation()}>Try again</Button>
+            {notice.retry && <Button onClick={() => void retryConversation()}>Try again</Button>}
+            {notice.action && (
+              <Link className="dsbtn dsbtn-primary no-underline" href={notice.action.href}>
+                {notice.action.label}
+              </Link>
+            )}
             <Link className="lnk font-sans text-[12.5px] font-medium leading-normal" href={orgPath('/sessions')}>
               Back to sessions
             </Link>

--- a/packages/web/src/lib/session-access-notifications.test.ts
+++ b/packages/web/src/lib/session-access-notifications.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sessionAccessNotifications } from '@/lib/session-access-notifications'
+import { sessionAccessNotifications, unverifiedConversationNotice } from '@/lib/session-access-notifications'
 
 const orgPath = (path: string) => `/acme${path}`
 
@@ -167,5 +167,72 @@ describe('sessionAccessNotifications', () => {
     expect(
       sessionAccessNotifications('sessions', false, [{ provider: 'feishu', region: 'lark', reason: 'quota' }], orgPath)
     ).toEqual([])
+  })
+})
+
+describe('unverifiedConversationNotice', () => {
+  // The conversation page blocked on this state used to call every cause
+  // transient and offer a retry. For a short app grant that button can never
+  // succeed — and because a resolved verdict is cached for a couple of minutes,
+  // the page keeps working intermittently, so "try again" even looks like it
+  // sometimes works. Naming the cause is what turns a futile loop into a fix.
+  it('sends a short app grant to the fix instead of offering a futile retry', () => {
+    expect(unverifiedConversationNotice(false, [{ provider: 'slack', reason: 'app_authorization' }], orgPath)).toEqual({
+      message:
+        'This conversation is hidden because a Slack app is missing permissions AgentConnect needs. It will not clear on its own — refresh the app in Integrations to restore access.',
+      retry: false,
+      action: { label: 'Open Integrations', href: '/acme/integrations?platform=slack', external: false }
+    })
+  })
+
+  // The reason the retry exists at all, and it stays for the causes that earn it.
+  it('keeps the retry for a transient access failure', () => {
+    expect(unverifiedConversationNotice(false, [{ provider: 'slack', reason: 'unavailable' }], orgPath)).toEqual({
+      message: 'This conversation cannot be shown until its access checks can be verified.',
+      retry: true
+    })
+  })
+
+  it('keeps the retry when the degradation names no cause at all', () => {
+    expect(unverifiedConversationNotice(false, [], orgPath)).toEqual({
+      message: 'This conversation cannot be shown until its access checks can be verified.',
+      retry: true
+    })
+  })
+
+  // A request that never reached the control plane is not an access verdict,
+  // so it keeps the retry however the access issues read.
+  it('reports a failed read as a failed read, not as an app problem', () => {
+    expect(unverifiedConversationNotice(true, [{ provider: 'slack', reason: 'app_authorization' }], orgPath)).toEqual({
+      message: 'This conversation could not be loaded. The console could not reach the control plane.',
+      retry: true
+    })
+  })
+
+  // One actionable cause is enough: a sweep that hit both a short grant and a
+  // blip still has something the reader can go and do.
+  it('prefers the actionable cause when a sweep mixed both', () => {
+    expect(
+      unverifiedConversationNotice(
+        false,
+        [
+          { provider: 'slack', reason: 'unavailable' },
+          { provider: 'slack', reason: 'app_authorization' }
+        ],
+        orgPath
+      ).retry
+    ).toBe(false)
+  })
+
+  // The console's own reasons are not an installed app's: a viewer whose Feishu
+  // identity needs refreshing must not be told to reauthorize a Slack app.
+  it('does not treat another provider or the viewer-side reason as an app problem', () => {
+    for (const issues of [
+      [{ provider: 'feishu', region: 'lark', reason: 'authorization' as const }],
+      [{ provider: 'feishu', region: 'lark', reason: 'quota' as const }],
+      [{ provider: 'github', reason: 'app_authorization' as const }]
+    ]) {
+      expect(unverifiedConversationNotice(false, issues, orgPath).retry).toBe(true)
+    }
   })
 })

--- a/packages/web/src/lib/session-access-notifications.ts
+++ b/packages/web/src/lib/session-access-notifications.ts
@@ -17,6 +17,69 @@ export interface SessionAccessNotificationInput {
   action?: SessionAccessNotificationAction
 }
 
+/** Where an installed app's permissions are actually repaired: the app's own row
+ *  on Integrations, whose refresh action asks Slack which scopes the
+ *  installation granted and names the missing ones. */
+const SLACK_APP_SETTINGS_PATH = '/integrations?platform=slack'
+
+/**
+ * A degradation an administrator can clear, as opposed to one that clears
+ * itself.
+ *
+ * Exported because two surfaces answer this question — the notification below
+ * and the conversation page that refuses to render — and they must not drift on
+ * it. Getting it wrong in either direction is a real cost: calling a permanent
+ * state transient tells someone to wait for something that will never happen,
+ * and calling a transient one permanent sends them to reauthorize a healthy app.
+ */
+export function isAppAuthorizationIssue(issue: SessionAccessIssue): boolean {
+  return issue.provider === 'slack' && issue.reason === 'app_authorization'
+}
+
+/**
+ * What a conversation page that could not be verified should say, and what it
+ * should offer instead of guessing.
+ *
+ * The page fails closed on purpose — refusing to report "not found" for
+ * something the console never got a verdict on is right and stays. What was
+ * wrong is the assumption underneath it, that every such state is transient. A
+ * short app grant never clears, so the retry it offered could not succeed;
+ * worse, a successful resolution is cached (the plugin's allow lease plus the
+ * access snapshot), so the page keeps working for a couple of minutes at a time
+ * and the permanent failure is experienced as flakiness. Hence `retry` is a
+ * property of the CAUSE here, not a constant.
+ */
+export interface UnverifiedConversationNotice {
+  message: string
+  /** Whether trying the same read again could plausibly answer differently. */
+  retry: boolean
+  action?: SessionAccessNotificationAction
+}
+
+export function unverifiedConversationNotice(
+  failed: boolean,
+  issues: readonly SessionAccessIssue[],
+  orgPath: (path: string) => string
+): UnverifiedConversationNotice {
+  // A failed request is not an access verdict at all — the console never
+  // reached the control plane, and that genuinely is worth retrying.
+  if (failed) {
+    return {
+      message: 'This conversation could not be loaded. The console could not reach the control plane.',
+      retry: true
+    }
+  }
+  if (issues.some(isAppAuthorizationIssue)) {
+    return {
+      message:
+        'This conversation is hidden because a Slack app is missing permissions AgentConnect needs. It will not clear on its own — refresh the app in Integrations to restore access.',
+      retry: false,
+      action: { label: 'Open Integrations', href: orgPath(SLACK_APP_SETTINGS_PATH), external: false }
+    }
+  }
+  return { message: 'This conversation cannot be shown until its access checks can be verified.', retry: true }
+}
+
 const FEISHU_ADMIN_URL = {
   feishu: 'https://www.feishu.cn/admin',
   lark: 'https://www.larksuite.com/admin'
@@ -68,7 +131,7 @@ function appAuthorizationNotification(
         : 'Refresh the app in Integrations to grant the permissions AgentConnect needs and restore usage from affected sessions.',
     action: {
       label: 'Open Integrations',
-      href: orgPath('/integrations?platform=slack'),
+      href: orgPath(SLACK_APP_SETTINGS_PATH),
       external: false
     }
   }
@@ -135,7 +198,7 @@ export function sessionAccessNotifications(
     ) {
       const notification = classifiedNotification(surface, issue.region, issue.reason, orgPath)
       notifications.set(notification.sourceKey, notification)
-    } else if (issue.provider === 'slack' && issue.reason === 'app_authorization') {
+    } else if (isAppAuthorizationIssue(issue)) {
       const notification = appAuthorizationNotification(surface, orgPath)
       notifications.set(notification.sourceKey, notification)
     } else {


### PR DESCRIPTION
Follows #769, which taught the control plane to say *why* a Slack access check failed closed and taught the notification centre to act on it. This is the third surface, and arguably the worst one, because it blocks a whole page rather than adding a banner to one.

## The problem

`SessionDetailView` refuses to render a conversation whose roster comes back empty with `accessSyncDegraded` set:

> This conversation cannot be shown until its access checks can be verified.
> **[Try again]** [Back to sessions]

**The refusal is right and stays.** Reporting "not found" for something the console never got a verdict on would state an authorization answer nobody gave.

**The assumption underneath it was wrong.** The comment read "Both are transient and retryable, so say so and offer the retry." That holds for an outage or a timeout. It is exactly false for a short app grant, which is a permanent configuration state — so the reader got a blank page, a button that cannot ever succeed, and no hint that the fix is a two-minute reauthorization two screens away.

It is worse than a dead end, because it does not look like one. A resolved verdict is cached — the plugin's 120 s allow lease plus the access snapshot's 60 s — so any successful resolution keeps the page working for a couple of minutes before it flips back. The failure is permanent but is *experienced* as flakiness, which is precisely the reading "Try again" invites.

## The change

The cause now picks both the words and the way out, using the same distinction #769 introduced:

| Cause | Says | Offers |
| --- | --- | --- |
| `app_authorization` | a Slack app is missing permissions, and it will not clear on its own | **Open Integrations** |
| any other degradation | unchanged | **Try again** |
| the request itself failed | unchanged | **Try again** |

Whether a retry could plausibly answer differently is a property of the cause, not a constant. `accessIssues` was already on this response and already unwrapped into `ConversationResolution` — the view simply never read it.

A failed request keeps its own copy and its retry regardless of what the issues say: the console never reached the control plane, so it holds no access verdict to interpret.

## Where the decision lives

In `unverifiedConversationNotice`, beside the notification that answers the same question, so the two surfaces cannot drift on which reasons an administrator can actually clear. Both now go through one `isAppAuthorizationIssue` predicate and one Integrations path constant.

Getting that wrong in either direction has a real cost, which is why it is one function rather than two conditionals: calling a permanent state transient tells someone to wait for something that will never happen, and calling a transient one permanent sends them to reauthorize a healthy app.

## Verification

- `web` typecheck; `eslint` and `prettier --check` clean on all three files
- 6 new tests on `unverifiedConversationNotice`: a short grant drops the retry and routes to Integrations; a transient reason keeps it; a degradation naming no cause keeps it; a failed read stays a failed read even when the issues say otherwise; a mixed sweep prefers the actionable cause; another provider's issue, and the viewer-side `authorization` reason, are not treated as app problems
- Driven in a browser against a throwaway stand-in control plane, both arms confirmed end to end — the `app_authorization` response renders the cause and the **Open Integrations** action with no retry, and switching the same response to `unavailable` restores the original copy and the **Try again** button

One thing left alone deliberately: this state only appears after the resolver's 15 s grace window, which exists so a just-created conversation never flashes a premature not-found. A permanent degradation gains nothing from that wait, but the window is load-bearing for the race it was written for, so shortening it is a separate decision from this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)