### PR TITLE
test(web): restore the OnboardingView checklist mock after the session-access step

### DIFF
--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -61,6 +61,10 @@ vi.mock('@/components/console/GettingStartedChecklist', () => ({
   useGsActions: () => ({ runAction: vi.fn(), firstAgent: mocks.agents[0] }),
   useGithubProfileLinked: () => undefined,
   useGithubAppEnabled: () => undefined,
+  // Same convention as the two probes above: undefined is the "unknowable, keep the
+  // step" value, so the reveal renders the full checklist (computeGettingStarted only
+  // drops the session-access row on a definitive false).
+  useSessionAccessCardAvailable: () => undefined,
   useSlackPlatformAppAvailable: () => true,
   GsRows: () => <div>rows</div>
 }))


### PR DESCRIPTION
## What

Adds the missing `useSessionAccessCardAvailable` export to the `@/components/console/GettingStartedChecklist` `vi.mock` factory in `OnboardingView.test.tsx`.

## Why

All 12 tests in `packages/web/src/components/console/views/OnboardingView.test.tsx` currently fail on `main` — this is a pre-existing red suite, not a regression from any in-flight branch.

When the "review session access policy" step was added to the getting-started checklist, `OnboardingView` started calling `useSessionAccessCardAvailable()` (`OnboardingView.tsx:74`). The test's mock factory for that module was not extended with the new export, so Vitest raised:

```
Error: [vitest] No "useSessionAccessCardAvailable" export is defined on the
"@/components/console/GettingStartedChecklist" mock.
```

The hook is called unconditionally at the top of the component, so every test in the file threw during render — before reaching a single assertion.

## Why `undefined`

The real hook (`GettingStartedChecklist.tsx:125`) returns `boolean | undefined`, and `computeGettingStarted` gates the row on `sessionAccessAvailable !== false` (`lib/getting-started.ts:194`) — only a *definitive* `false` hides it. So `undefined` and `true` are behaviourally identical for every assertion in this file.

`undefined` is chosen because it is the "unknowable, keep the step" value and matches the convention already used by the two sibling hide-the-step probes in the same factory (`useGithubProfileLinked`, `useGithubAppEnabled`). The reveal therefore renders the full checklist, as it does in a real auth-on org.

The value is not load-bearing, but I checked the one assertion that could plausibly be sensitive to it: `finish stays disabled until every step is done` derives `done = 2` of `total = 6` with the row kept (only `daemon` and the always-done `session-access` tick), so it still exercises the disabled path rather than passing by accident.

## Verification

Run on this branch, which is cut from current `main`:

- Before: `12 failed (12)` in the target file.
- After: `12 passed (12)`.
- Full package suite `pnpm --filter @agentconnect.md/web test`: **122 files / 977 tests, 0 failures**.
- `prettier --check`, `eslint`, and `tsc --noEmit` are clean.

The `ECONNREFUSED ::1:3000` stderr in the suite output is pre-existing noise unrelated to this change — it appears identically with the change stashed and fails nothing.

## Reviewer note

Test-only change; no production code or behaviour is touched.

Worth noting for follow-up: this class of breakage is silent until someone runs the suite, because a `vi.mock` factory has no compile-time link to the mocked module's export list. Any future hook added to `GettingStartedChecklist` and consumed by `OnboardingView` will break this file the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
