### PR TITLE
fix(web): stop merged-conversation parents renting the sibling slot

### DIFF
--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -488,6 +488,21 @@ already carry the links, and mapping a session to its conversation key is a
 metadata lookup.
 (C2 ships the links; grouping delegations by waking turn is C3.)
 
+The lifted shape carries **all** waking conversations in one list, and carries
+no sibling slot at all. A conversation has as many parents as it has members
+woken from elsewhere, and they are peers — the union that produced them does
+not record which member each one woke, so nothing ranks one of them first.
+Level 0 holds every one of them, alongside `wokenBy` for the same reason.
+
+An earlier shape kept a single `parentSession` and spilled the remainder into
+`siblingSessions`, which is where it collided with §9.1's last paragraph: on a
+single-session page that field means the other children of ONE parent, and the
+rail draws it at the open row's own level below a divider. So a conversation
+that WOKE this one was rendered beside the row it woke rather than above it —
+two meanings in one slot, and the wrong one drawn. The conversation-level
+structure therefore names only what it actually has, parents and delegations,
+and the per-session DTO keeps `siblingSessions` to itself.
+
 One invariant stays absolute: **lineage never changes membership**. A child
 spawned elsewhere is linked, never merged in — merging by causation would
 break the location-pure dedupe (§6) and blur the structural guarantees around
@@ -597,4 +612,7 @@ how divergence starts.
    room-mates-AND-siblings overlap is displayed once, not twice (§9.1).
    Attribution is surfaced in the rail as tree position around the open row —
    waker above it, woken below — and kept out of the family shape, whose parent
-   slot means "another conversation" and navigates away (§9.1).
+   slot means "another conversation" and navigates away (§9.1). The lifted
+   family has NO sibling slot: every waking conversation is a parent and
+   shares the level above the open row, so the per-session meaning of
+   `siblingSessions` is never borrowed to hold one (§9.2).

--- a/packages/web/src/components/console/SessionRail.test.tsx
+++ b/packages/web/src/components/console/SessionRail.test.tsx
@@ -58,7 +58,7 @@ const relation = (id: string): SessionRelationDto => ({
   platform: 'slack'
 })
 
-const NO_FAMILY = { parentSession: null, siblingSessions: [], childSessions: [] }
+const NO_FAMILY = { parentSessions: [], siblingSessions: [], childSessions: [] }
 
 function railMarkup({
   sessions = [],
@@ -71,8 +71,8 @@ function railMarkup({
   sessions?: Session[]
   total?: number
   family?: {
-    parentSession: SessionRelationDto | null
-    siblingSessions: SessionRelationDto[]
+    parentSessions: SessionRelationDto[]
+    siblingSessions?: SessionRelationDto[]
     childSessions: SessionRelationDto[]
   }
   filterTouched?: boolean
@@ -94,6 +94,13 @@ function railMarkup({
     />
   )
 }
+
+/** The indent elbow a row draws at depth > 0, and the horizontal rule that sets
+ *  rows beside the open one apart from the path through it. Read out of the
+ *  markup because level is what this rail communicates, and both are invisible
+ *  to any assertion made on text alone. */
+const ELBOW = 'rounded-bl-[4px]'
+const DIVIDER = 'bg-(--border-subtle)'
 
 // The column's width and its breakpoint gate, as they appear in the markup. A
 // change here is a change to the page's geometry, so it should fail loudly rather
@@ -231,7 +238,7 @@ describe('SessionRail room attribution', () => {
     // differs. A screen reader gets no indent and no tooltip, so both kinds of
     // row have to carry the words, or half the tree loses its direction.
     const markup = railMarkup({
-      family: { ...NO_FAMILY, parentSession: relation('rel-p'), childSessions: [relation('rel-k')] }
+      family: { ...NO_FAMILY, parentSessions: [relation('rel-p')], childSessions: [relation('rel-k')] }
     })
 
     expect(markup).toContain('<span class="sr-only">Delegated by</span>')
@@ -271,5 +278,65 @@ describe('SessionRail room attribution', () => {
     // Four rows are drawn — three attribution plus the open one — and only the
     // open row, which is a real session in the list, carries a pin toggle.
     expect(markup.split('aria-pressed=').length - 1).toBe(1)
+  })
+})
+
+// Level 0 over a MERGED page, which is the one that can have several parents:
+// each member woken from another room contributes its own. With the headings
+// gone, the level a row is drawn at is the ONLY thing saying which of the three
+// it is, so a parent put anywhere else is a parent misreported.
+describe('SessionRail conversation parents', () => {
+  it('draws every waking conversation on the level above the open row', () => {
+    // The regression: only one parent slot existed, so the second waking
+    // conversation was carried in `siblingSessions` — a field that means "other
+    // children of my parent" on a single-session page — and the rail drew it
+    // BELOW the open row, at the open row's own level, under the divider.
+    const markup = railMarkup({
+      family: { parentSessions: [relation('parent-a'), relation('parent-b')], childSessions: [] }
+    })
+
+    const first = markup.indexOf('href="/sessions/parent-a"')
+    const second = markup.indexOf('href="/sessions/parent-b"')
+    const open = markup.indexOf('href="/sessions/current"')
+    expect(first).toBeGreaterThan(-1)
+    expect(second).toBeGreaterThan(first)
+    expect(open).toBeGreaterThan(second)
+    // Level 0 draws no elbow, so the only one belongs to the open row beneath
+    // them — and nothing was set aside behind a divider.
+    expect(markup.split(ELBOW).length - 1).toBe(1)
+    expect(markup).not.toContain(DIVIDER)
+  })
+
+  it('gives each waking conversation the same edge words', () => {
+    // Both are the same edge, so neither gets a different vocabulary for being
+    // second — the words a screen reader hears must not depend on order.
+    const markup = railMarkup({
+      family: { parentSessions: [relation('parent-a'), relation('parent-b')], childSessions: [] }
+    })
+
+    expect(markup.split('<span class="sr-only">Delegated by</span>').length - 1).toBe(2)
+  })
+
+  it('keeps lineage siblings beside the open row, which is what they are', () => {
+    // The other meaning, on a single-session page: siblings share the open
+    // session's PARENT, so they belong at its level, past the divider that ends
+    // the path through it. Nothing on a merged page reaches this branch.
+    const markup = railMarkup({
+      family: {
+        parentSessions: [relation('parent-a')],
+        siblingSessions: [relation('sibling-a')],
+        childSessions: []
+      }
+    })
+
+    const open = markup.indexOf('href="/sessions/current"')
+    const divider = markup.indexOf(DIVIDER)
+    const sibling = markup.indexOf('href="/sessions/sibling-a"')
+    expect(divider).toBeGreaterThan(open)
+    expect(sibling).toBeGreaterThan(divider)
+    // Both the open row and the sibling hang off the parent above them.
+    expect(markup.split(ELBOW).length - 1).toBe(2)
+    // A sibling sits on neither edge the two words name, so it carries neither.
+    expect(markup.split('<span class="sr-only">Delegated by</span>').length - 1).toBe(1)
   })
 })

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -58,7 +58,7 @@ import {
   type Agent,
   type Session
 } from '@/lib/data'
-import { fetchSessionDetail, sessionFromDetailDto, type SessionDetailDto, type SessionRelationDto } from '@/lib/api'
+import { fetchSessionDetail, sessionFromDetailDto, type SessionRelationDto } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
@@ -165,8 +165,21 @@ export function SessionRail({
   filterTouched: boolean
   /** Edit the filter. The caller owns it — the rail is not the only thing it scopes. */
   onAgentIdsChange: (agentIds: string[]) => void
-  /** Direct lineage from the detail endpoint. Undefined while it is unavailable. */
-  family?: Pick<SessionDetailDto, 'parentSession' | 'siblingSessions' | 'childSessions'>
+  /** Direct lineage, in the rail's own three levels rather than either source's
+   *  wire shape. Undefined while it is unavailable. */
+  family?: {
+    /** LEVEL 0 — whatever woke the open row. A single session has at most one
+     *  parent; a merged conversation has one per member that was woken from
+     *  elsewhere, and all of them belong on this level. */
+    parentSessions: SessionRelationDto[]
+    /** LEVEL 1, beside the open row under a divider — LINEAGE siblings, i.e.
+     *  the other children of the open session's parent (the CP derives these
+     *  per session). A conversation has no such relation, so its caller leaves
+     *  this out rather than lending the slot to something else. */
+    siblingSessions?: SessionRelationDto[]
+    /** LEVEL 2 — whatever the open row woke. */
+    childSessions: SessionRelationDto[]
+  }
   /** Keep raw session rows and links instead of collapsing into conversations. */
   flatView?: boolean
   /** Delegation target id → waking member agentId (conversation mode). */
@@ -221,7 +234,7 @@ export function SessionRail({
   )
 
   const currentId = canonicalSessionId(current)
-  const parent = family?.parentSession ?? null
+  const parents = family?.parentSessions ?? EMPTY_RELATIONS
   const siblings = family?.siblingSessions ?? EMPTY_RELATIONS
   const children = family?.childSessions ?? EMPTY_RELATIONS
   // Attribution inside the open conversation, kept apart from `family` on
@@ -230,18 +243,20 @@ export function SessionRail({
   // navigate-away meaning.
   const wokenBy = roomLineage?.wokenBy ?? null
   const woke = roomLineage?.woke ?? EMPTY_RELATIONS
-  const hasFamily = Boolean(parent || siblings.length > 0 || children.length > 0 || wokenBy || woke.length > 0)
+  const hasFamily = Boolean(
+    parents.length > 0 || siblings.length > 0 || children.length > 0 || wokenBy || woke.length > 0
+  )
   const relatedIds = useMemo(() => {
     const ids = new Set<string>()
     if (!hasFamily) return ids
     ids.add(currentId)
-    if (parent) ids.add(parent.id)
     if (wokenBy) ids.add(wokenBy.id)
+    for (const relation of parents) ids.add(relation.id)
     for (const relation of siblings) ids.add(relation.id)
     for (const relation of children) ids.add(relation.id)
     for (const relation of woke) ids.add(relation.id)
     return ids
-  }, [children, currentId, hasFamily, parent, siblings, wokenBy, woke])
+  }, [children, currentId, hasFamily, parents, siblings, wokenBy, woke])
 
   // Globally pinned rows that the loaded page or current family does not carry.
   // Fetched by id because the list endpoint cannot filter by id; a rail holds a
@@ -392,8 +407,13 @@ export function SessionRail({
   // `relationLabel` names the edge in the tooltip and in sr-only text — the same
   // two words an attribution row uses, because it is the same edge: a lineage
   // parent and an in-room `wokenBy` differ only in where the other end lives,
-  // and the row already shows that by being a link or not. Omitted for siblings,
-  // whose slot means two different things by page (see conversation-lineage.ts).
+  // and the row already shows that by being a link or not.
+  //
+  // Omitted for siblings. That used to be because the slot meant two different
+  // things by page; it now means one (see conversation-lineage.ts), and the
+  // reason is simply that a sibling sits on NEITHER of the two edges those
+  // words name — it hangs off the same parent, beside the open row rather than
+  // on the path through it, so "Delegated by/to" would misreport it.
   const relationRow = (relation: SessionRelationDto, relationLabel?: string): RailRow => {
     const title = relation.title?.trim() || `Session ${relation.id.slice(0, 8)}`
     return {
@@ -533,10 +553,12 @@ export function SessionRail({
   // which is which. A cross-room parent and an in-room `wokenBy` are the SAME
   // edge seen from two locations, so they share level 0 rather than nesting:
   // the lift unions parents across every member without recording WHICH member
-  // each one woke, so hanging `wokenBy` under `parent` would draw a chain the
-  // data does not contain. `woke` and cross-room `children` share level 2 for
-  // the same reason. Siblings sit at the open row's own level, below a divider.
-  const aboveCurrent = Boolean(parent || wokenBy)
+  // each one woke, so hanging `wokenBy` under a parent would draw a chain the
+  // data does not contain — and it is the same reason there can be SEVERAL
+  // parents on that one level, none of them ranked. `woke` and cross-room
+  // `children` share level 2 likewise. Siblings sit at the open row's own
+  // level, below a divider.
+  const aboveCurrent = Boolean(parents.length > 0 || wokenBy)
   const currentDepth = aboveCurrent ? 1 : 0
   const delegatedDepth = aboveCurrent ? 2 : 1
 
@@ -569,9 +591,12 @@ export function SessionRail({
             <div className="flex-none px-[9px] pb-[3px] font-mono text-[10px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
               Related
             </div>
-            {parent && row(relationRow(parent, 'Delegated by'), isPinned(parent.id))}
+            {/* Level 0, all of it. A merged conversation has one parent per
+                member woken from another room; they are peers, and nothing
+                ranks one of them first, so every one of them sits here. */}
+            {parents.map((parent) => row(relationRow(parent, 'Delegated by'), isPinned(parent.id)))}
             {/* Attribution, not navigation: the participant that woke the open
-                row, then the ones it woke. Same lineage edge as `parent` — the
+                row, then the ones it woke. Same lineage edge as a parent — the
                 only difference is that these two live in THIS conversation, so
                 their link would come straight back to the page you are on.
                 That difference is already in the row: an agent mark and a name
@@ -594,6 +619,10 @@ export function SessionRail({
                 </Fragment>
               )
             })}
+            {/* Lineage siblings, which the three levels have no branch for: they
+                share the open row's parent, so they sit at ITS level, under a
+                divider that says "not on the path through this row". Only a
+                single-session page has them. */}
             {siblings.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
             {siblings.map((sibling) => row(relationRow(sibling), isPinned(sibling.id), 1))}
             {ordinaryRows.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}

--- a/packages/web/src/components/console/SessionRail.verdict.test.tsx
+++ b/packages/web/src/components/console/SessionRail.verdict.test.tsx
@@ -75,12 +75,12 @@ const relation = (id: string): SessionRelationDto => ({
 })
 
 interface Family {
-  parentSession: SessionRelationDto | null
-  siblingSessions: SessionRelationDto[]
+  parentSessions: SessionRelationDto[]
+  siblingSessions?: SessionRelationDto[]
   childSessions: SessionRelationDto[]
 }
 
-const NO_FAMILY: Family = { parentSession: null, siblingSessions: [], childSessions: [] }
+const NO_FAMILY: Family = { parentSessions: [], siblingSessions: [], childSessions: [] }
 
 let root: Root | undefined
 let container: HTMLDivElement | undefined

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { liveBotTurnKey, sameBotSpeaker } from '@/lib/bot-turn-grouping'
 import { mergeConversation, type MergeSource } from '@/lib/conversation-merge'
 import { selfConversationPath } from '@/lib/conversation-addressing'
-import { assembleConversationLineage } from '@/lib/conversation-lineage'
+import { assembleConversationLineage, type ConversationLineage } from '@/lib/conversation-lineage'
 import { encodeConversationKey } from '@/lib/conversation-key'
 import { unverifiedConversationNotice } from '@/lib/session-access-notifications'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
@@ -155,6 +155,11 @@ const COMPOSER_PILL =
   'inline-flex h-7 items-center gap-[7px] rounded-full px-[10px] max-desktop:px-0 font-mono text-[11.5px] font-medium leading-normal text-(--text-primary) hover:bg-(--surface-hover)'
 const COMPOSER_PILL_STATIC =
   'inline-flex h-7 min-w-0 items-center gap-[7px] rounded-full px-[10px] max-desktop:px-0 font-mono text-[11.5px] font-medium leading-normal text-(--text-primary)'
+
+// A conversation whose cross-room lineage has not landed yet. Stable identity so
+// the family it feeds is not a new object on every render while the multi-request
+// lineage fetch is in flight.
+const EMPTY_CONVERSATION_FAMILY: ConversationLineage['family'] = { parentSessions: [], childSessions: [] }
 
 // The "fast" tag shown inside the model pill when fast mode is on.
 function FastBadge() {
@@ -999,7 +1004,7 @@ function SessionRelationLink({
 }
 
 function MobileSessionFamilyLinks({
-  parent,
+  parents,
   siblings,
   children,
   agentById,
@@ -1008,7 +1013,12 @@ function MobileSessionFamilyLinks({
   flatView = false,
   childOriginById
 }: {
-  parent: SessionRelationDto | null
+  /** Whatever woke this page. A session has at most one parent; a merged
+   *  conversation has one per member woken from another room, and they are all
+   *  parents — none of them is a sibling of anything. */
+  parents: SessionRelationDto[]
+  /** LINEAGE siblings: the other children of this session's parent. A
+   *  conversation has no such relation and passes none. */
   siblings: SessionRelationDto[]
   children: SessionRelationDto[]
   agentById: ReadonlyMap<string, Agent>
@@ -1020,24 +1030,34 @@ function MobileSessionFamilyLinks({
   /** Delegation target id → waking member agentId (conversation mode). */
   childOriginById?: ReadonlyMap<string, string>
 }) {
-  if (!parent && siblings.length === 0 && children.length === 0) return null
+  if (parents.length === 0 && siblings.length === 0 && children.length === 0) return null
   return (
     <div className="card mx-4 mt-4 overflow-hidden desktop:hidden">
-      {parent && (
+      {parents.length > 0 && (
         <div
           className={`grid grid-cols-[104px_minmax(0,1fr)] gap-3 px-4 ${
             siblings.length > 0 || children.length > 0 ? 'border-b border-(--border-subtle)' : ''
           }`}
         >
           <span className="py-[10px] font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
-            {conversation ? 'Parent conversation' : 'Parent session'}
+            {conversation
+              ? parents.length === 1
+                ? 'Parent conversation'
+                : `Parent conversations (${parents.length})`
+              : 'Parent session'}
           </span>
-          <SessionRelationLink
-            relation={parent}
-            agent={agentById.get(parent.agentId)}
-            orgPath={orgPath}
-            flatView={flatView}
-          />
+          <div className="min-w-0">
+            {parents.map((parent, index) => (
+              <SessionRelationLink
+                key={parent.id}
+                relation={parent}
+                agent={agentById.get(parent.agentId)}
+                orgPath={orgPath}
+                flatView={flatView}
+                bordered={index > 0}
+              />
+            ))}
+          </div>
         </div>
       )}
       {siblings.length > 0 && (
@@ -1256,9 +1276,7 @@ export default function SessionDetailView() {
   // Conversation mode NEVER falls back to the representative's raw family —
   // an empty aggregate means "no cross-room edges", not "show the intra-room
   // links the filter just removed".
-  const conversationFamily = conversationMode
-    ? (conversationLineage?.family ?? { parentSession: null, siblingSessions: [], childSessions: [] })
-    : undefined
+  const conversationFamily = conversationMode ? (conversationLineage?.family ?? EMPTY_CONVERSATION_FAMILY) : undefined
   const {
     agents,
     allSessions,
@@ -1527,6 +1545,27 @@ export default function SessionDetailView() {
         }
       : sessionBase
   const agentRuntime = session?.runtime || owner?.runtime || ''
+
+  // The lineage links the rail and the mobile card draw, in their three levels
+  // rather than either source's wire shape: what woke the open row, the row
+  // itself, what it woke.
+  //
+  // A conversation contributes no lineage SIBLINGS. That relation is "the other
+  // children of my parent session" — a per-session fact the CP derives, which a
+  // room has no version of — so the slot stays absent here instead of carrying
+  // this page's additional parent conversations under a name that means
+  // something else. Those are parents, and they render as parents.
+  const familyLinks = useMemo(() => {
+    if (conversationFamily) {
+      return { parentSessions: conversationFamily.parentSessions, childSessions: conversationFamily.childSessions }
+    }
+    if (!currentSessionDetail || currentSessionDetail.id !== session?.id) return undefined
+    return {
+      parentSessions: currentSessionDetail.parentSession ? [currentSessionDetail.parentSession] : [],
+      siblingSessions: currentSessionDetail.siblingSessions ?? [],
+      childSessions: currentSessionDetail.childSessions
+    }
+  }, [conversationFamily, currentSessionDetail, session?.id])
 
   // A non-flat single-session transcript can contain messages from visible A2A
   // relatives without becoming a same-coordinate merged conversation. Surface
@@ -3417,28 +3456,17 @@ export default function SessionDetailView() {
           )}
         </div>
 
-        {conversationFamily ? (
+        {familyLinks && (
           <MobileSessionFamilyLinks
-            parent={conversationFamily.parentSession}
-            siblings={conversationFamily.siblingSessions}
-            children={conversationFamily.childSessions}
+            parents={familyLinks.parentSessions}
+            siblings={familyLinks.siblingSessions ?? []}
+            children={familyLinks.childSessions}
             agentById={agentById}
             orgPath={orgPath}
-            conversation
+            conversation={conversationMode}
             flatView={flatView}
             childOriginById={conversationLineage?.childOriginById}
           />
-        ) : (
-          currentSessionDetail?.id === session.id && (
-            <MobileSessionFamilyLinks
-              parent={currentSessionDetail.parentSession}
-              siblings={currentSessionDetail.siblingSessions ?? []}
-              children={currentSessionDetail.childSessions}
-              agentById={agentById}
-              orgPath={orgPath}
-              flatView={flatView}
-            />
-          )
         )}
 
         {!isLive && approvalCard('mx-4 mt-4 max-desktop:rounded-lg desktop:mx-0 desktop:mt-0 desktop:mb-4')}
@@ -4248,7 +4276,7 @@ export default function SessionDetailView() {
         agentIds={railDisplayAgentIds}
         filterTouched={railFilter.touched}
         onAgentIdsChange={setRailAgentIds}
-        family={conversationFamily ?? (currentSessionDetail?.id === session.id ? currentSessionDetail : undefined)}
+        family={familyLinks}
         flatView={flatView}
         childOriginById={conversationLineage?.childOriginById}
         roomLineage={conversationLineage?.roomLineage}

--- a/packages/web/src/lib/conversation-lineage.test.ts
+++ b/packages/web/src/lib/conversation-lineage.test.ts
@@ -71,8 +71,7 @@ describe('assembleConversationLineage', () => {
       [A, B]
     ]) {
       const { family } = room(order)
-      expect(family.parentSession).toBeNull()
-      expect(family.siblingSessions).toEqual([])
+      expect(family.parentSessions).toEqual([])
       expect(family.childSessions).toEqual([])
     }
   })
@@ -96,7 +95,7 @@ describe('assembleConversationLineage', () => {
       ])
     })
 
-    expect(out.family.parentSession).toEqual(relation('far-parent'))
+    expect(out.family.parentSessions).toEqual([relation('far-parent')])
     expect(out.family.childSessions).toEqual([relation('far-child')])
     expect(out.roomLineage).toEqual({ wokenBy: null, woke: [] })
     expect(out.childOriginById.get('far-child')).toBe(`agent-of-${A}`)
@@ -113,7 +112,7 @@ describe('assembleConversationLineage', () => {
       targetLocations: new Map([['session-superseded', at(ROOM)]])
     })
 
-    expect(out.family.parentSession).toBeNull()
+    expect(out.family.parentSessions).toEqual([])
     expect(out.roomLineage.wokenBy).toBeNull()
   })
 
@@ -121,7 +120,38 @@ describe('assembleConversationLineage', () => {
     const out = room([B, A], { [A]: { kind: 'unreadable' } })
 
     expect(out.roomLineage.wokenBy).toBeNull()
-    expect(out.family.parentSession).toBeNull()
+    expect(out.family.parentSessions).toEqual([])
+  })
+
+  it('keeps every cross-room parent as a parent', () => {
+    // The regression this guards: with only one parent SLOT, the second waking
+    // conversation had to go somewhere, and it went into `siblingSessions` —
+    // which on a single-session page means the other children of one parent.
+    // The rail then drew it at the open row's own level, below a divider,
+    // describing a conversation that woke this one as a peer of it.
+    const out = assembleConversationLineage({
+      conversationKey: ROOM,
+      members: [{ sessionId: A }, { sessionId: B }],
+      details: [detail(A, { parent: 'far-parent-1' }), detail(B, { parent: 'far-parent-2' })],
+      targetLocations: new Map([
+        ['far-parent-1', at(OTHER_ROOM)],
+        ['far-parent-2', at('room-3')]
+      ])
+    })
+
+    expect(out.family.parentSessions).toEqual([relation('far-parent-1'), relation('far-parent-2')])
+    expect(out.family.childSessions).toEqual([])
+  })
+
+  it('deduplicates one shared parent across members', () => {
+    const out = assembleConversationLineage({
+      conversationKey: ROOM,
+      members: [{ sessionId: A }, { sessionId: B }],
+      details: [detail(A, { parent: 'far-parent' }), detail(B, { parent: 'far-parent' })],
+      targetLocations: new Map([['far-parent', at(OTHER_ROOM)]])
+    })
+
+    expect(out.family.parentSessions).toEqual([relation('far-parent')])
   })
 
   it('ignores a member whose detail could not be fetched', () => {

--- a/packages/web/src/lib/conversation-lineage.ts
+++ b/packages/web/src/lib/conversation-lineage.ts
@@ -20,7 +20,7 @@
 // depending on how many members happened to resolve that second.
 //
 // The two must NOT share a shape. `family` is navigation in the UI — a
-// `parentSession` links AWAY, to another conversation — so putting a
+// `parentSessions` entry links AWAY, to another conversation — so putting a
 // co-participant there hands the reader a link back to the page they are on.
 // Attribution is therefore its own structure, anchored on the open row: who
 // woke it, and whom it woke. The rail draws both on the same three levels
@@ -46,8 +46,14 @@ export interface LineageMemberDetail {
 export interface ConversationLineage {
   /** Navigation OUT of this conversation (§9.2), unchanged. */
   family: {
-    parentSession: SessionRelationDto | null
-    siblingSessions: SessionRelationDto[]
+    /** Every conversation that woke a member of this one. A merged page has as
+     *  many as it has members with a cross-room parent, and they are all the
+     *  SAME relation — so they stay in ONE list rather than a privileged head
+     *  plus a tail borrowing some other slot's name. There is deliberately no
+     *  sibling slot here: "sibling" is lineage's own word for the other
+     *  children of one parent session (§9.1), which is a per-session fact a
+     *  conversation has no version of. */
+    parentSessions: SessionRelationDto[]
     childSessions: SessionRelationDto[]
   }
   /** Delegation target id → the agent whose member session woke it. */
@@ -121,7 +127,6 @@ export function assembleConversationLineage(input: {
       const bo = childOriginById.get(b.id) ?? ''
       return ao < bo ? -1 : ao > bo ? 1 : a.id < b.id ? -1 : 1
     })
-  const [firstParent, ...moreParents] = crossParents
 
   // Attribution: the open row's own edges, kept only when they point at another
   // participant that is actually on this page.
@@ -139,10 +144,9 @@ export function assembleConversationLineage(input: {
 
   return {
     family: {
-      // The family UI models ONE parent; extra cross-room delegation origins
-      // surface beside the delegations.
-      parentSession: firstParent ?? null,
-      siblingSessions: moreParents,
+      // Member order, which is the roster's order: nothing here ranks one
+      // waking conversation above another, so none of them is singled out.
+      parentSessions: crossParents,
       childSessions: crossChildren
     },
     childOriginById,


### PR DESCRIPTION
## What

`assembleConversationLineage()` in [`packages/web/src/lib/conversation-lineage.ts`](packages/web/src/lib/conversation-lineage.ts) had one `parentSession` slot and, on a merged page, potentially several cross-room parents to put in it. It kept the first and spilled the rest into `family.siblingSessions`.

That field already means something else. On `/sessions/:id` it is the CP's per-session derivation — the other children of the open session's parent (`packages/control-plane/src/http/routes/sessions.ts` ~L738) — and `SessionRail` draws it at the open row's own level, under a divider. So a conversation that **woke** this one was rendered beside the row it woke instead of above it.

Rebased onto #770, which collapsed the Related tree to three levels and made position the only thing reporting an edge's direction. That makes this sharper rather than obsolete: with no heading left to disagree with the indent, a parent drawn on the wrong level is simply a parent misreported. #770 called out this slot as the one thing it was deliberately leaving behind.

## How

Give the conversation-level family a shape that cannot express the lie: `{ parentSessions, childSessions }` — every waking conversation in one list, no sibling slot at all. A room has no version of "the other children of my parent session", so there is nothing left to borrow.

- **`SessionRail`** takes its own three-level shape instead of `Pick<SessionDetailDto, …>`, with `siblingSessions` optional and documented as the lineage relation it actually is. Every parent maps onto level 0 beside `wokenBy`, carrying the same `Delegated by` tooltip and `sr-only` text — the union that produced them records no order, so none of them is ranked. `aboveCurrent` reads the list rather than a single parent, so the open row and the delegations keep their levels.
- **`SessionDetailView`** builds a single `familyLinks` memo that adapts either source, replacing two call sites that had drifted apart.
- **`MobileSessionFamilyLinks`** takes `parents: SessionRelationDto[]` and labels them "Parent conversation(s)" / "Parent session". The "Sibling session(s)" heading over the same data on the merged page is gone.
- Sibling rows still carry no edge label, but the reason is restated so it survives this change: #770 omitted it because the slot meant two things; it now means one, and a sibling simply sits on neither of the two edges those words name.
- **`docs/designs/merged-conversation-view.md`** §9.2 and invariant 9 record why the lifted family has no sibling slot.

No CP change — the per-session DTO and its `siblingSessions` derivation are untouched.

## Tests

Five new, all in the web package:

- assembler: two members with two different cross-room parents keep both as parents; one shared parent deduplicates to a single entry.
- rail markup: parent rows precede the open row, draw no indent elbow, and set nothing aside behind a divider; each parent carries the same edge words, so a screen reader hears nothing order-dependent; lineage siblings still render past the divider at the open row's level, with no edge label.

`tsc`, eslint, and prettier are clean. `pnpm --filter @agentconnect.md/web test` is 977 passed / 12 failed — all 12 failures are in `OnboardingView.test.tsx` and reproduce on `main`: its `GettingStartedChecklist` mock does not export `useSessionAccessCardAvailable`, which the component started calling in #760. Nothing in that file's module graph touches this change; it is being fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)