### PR TITLE
docs(readme): add YouTube channel badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 <p align="center">
   <a href="https://slack.agentconnect.md"><img src="https://custom-icon-badges.demolab.com/badge/Slack-4A154B?logo=slack&logoColor=fff" alt="Join AgentConnect on Slack" /></a>
   <a href="https://x.com/getAgentConnect"><img src="https://img.shields.io/twitter/follow/getAgentConnect?style=social" height="28" alt="Follow @getAgentConnect on X" /></a>
+  <a href="https://www.youtube.com/@agentconnect-md"><img src="https://img.shields.io/badge/YouTube-FF0000?logo=youtube&logoColor=fff" alt="Watch AgentConnect on YouTube" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Adds a YouTube badge to the README's social row so the project's video channel is discoverable next to the existing community links.

The badge is placed after the X follow badge, giving the row the order Slack, X, YouTube. It uses the same shields.io static-badge style as the Slack badge and links to https://www.youtube.com/@agentconnect-md.

Documentation only — no code, tests, or behavior are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)