### PR TITLE
docs: correct stale note claiming the Prisma client is committed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,8 +159,10 @@ DATABASE_URL=... pnpm --filter @agentconnect.md/control-plane exec prisma migrat
 pnpm --filter @agentconnect.md/control-plane db:seed:example
 ```
 
-The generated client lands in `src/generated/prisma` (committed). Session rows live in
-table `session_meta`, not `session`.
+The generated client lands in `src/generated/prisma`, which is gitignored — run
+`prisma:generate` above after a fresh clone or a schema change (`typecheck`, `build`,
+and `prepack` already run it as a pre-step). Session rows live in table `session_meta`,
+not `session`.
 
 ## CP composition (dependency injection)
 


### PR DESCRIPTION
## What

CLAUDE.md's Prisma section claimed the generated client in `src/generated/prisma` is committed. It isn't — the note has been stale since the Prisma 7 migration.

The sentence now describes the client as gitignored and points at the `prisma:generate` command already listed in the code block directly above, noting that `typecheck`, `build`, and `prepack` each run it as a pre-step.

## Why

Verified against the current tree:

- `.gitignore` (lines 154-155) ignores `packages/control-plane/src/generated/`, under the comment "Prisma 7 generated client (regenerated by `prisma generate`)".
- `git ls-files packages/control-plane/src/generated` returns zero tracked files, so nothing is checked in.
- `packages/control-plane/package.json` wires `prisma:generate` into `pretypecheck`, `prebuild`, and `prepack`.

As written, the old note would lead someone to expect the client in a fresh clone and to look for a commit step that no longer exists.

## Notes for reviewers

- Docs-only; no code or behavior changes.
- I scanned the rest of CLAUDE.md for other references implying the client is committed — this is the only one. The one other mention of "commit" (in the local full-stack gotchas section) is about `lint-staged` and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)