### PR TITLE
fix(slack): designate one workspace-check credential per realm

### DIFF
--- a/packages/control-plane/prisma/migrations/20260808000000_bot_granted_scopes/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260808000000_bot_granted_scopes/migration.sql
@@ -1,0 +1,8 @@
+-- Bot scopes Slack reported as granted for the bot's CURRENT credential (the
+-- `x-oauth-scopes` header observed when an install/refresh verified the token).
+-- Empty means "never observed" — Slack omits the header at times — and NEVER
+-- "granted nothing": a real bot grant always carries at least one scope. Read
+-- to pick a credential that provably holds a scope (the session-access
+-- workspace checker needs `users:read`); never an authorization fence itself.
+ALTER TABLE "bot"
+  ADD COLUMN "grantedScopes" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1818,6 +1818,14 @@ model Bot {
   // it would kill (the case where the relay already holds the newer assignment).
   credentialRevision    Int            @default(1)
   credentialInstalledAt DateTime?      @db.Timestamptz(6)
+  // Bot scopes Slack REPORTED as granted for the current credential — the
+  // `x-oauth-scopes` header observed when an install/refresh verified the token.
+  // Empty means "never observed" (Slack omits the header at times), NEVER
+  // "granted nothing": a real bot grant always carries at least one scope.
+  // Advisory capability metadata — reads pick a credential that provably holds a
+  // scope (e.g. the session-access workspace checker needs `users:read`); it is
+  // never an authorization fence by itself.
+  grantedScopes         String[]       @default([])
   // ── generic bot demux identity (integration-plugin-architecture.md D6/§11) ──
   // The platform's app-scoped id plus its tenant scope — the row's identity.
   // `BotRepo.getByExternalIdentity` is the only lookup and the composite unique

--- a/packages/control-plane/src/http/install-slack.ts
+++ b/packages/control-plane/src/http/install-slack.ts
@@ -48,6 +48,10 @@ export interface InstallSlackBotArgs {
   botUserId?: string
   /** Provisioned by AgentConnect (the platform app), not a console user. */
   prebuilt?: boolean
+  /** Bot scopes Slack reported as granted for `botToken` (the `x-oauth-scopes`
+   *  header of the funnel's verification call). Omit when Slack sent no header —
+   *  absence is "unknown", never a short grant. */
+  grantedScopes?: string[]
   /** xapp-… — required for socket transport (Socket Mode); absent for http. */
   appToken?: string
   /** Slack signing secret — required for http transport (Events API verification). */
@@ -93,6 +97,7 @@ export async function installNewSlackBot(
       ...(args.workspaceId ? { workspaceId: args.workspaceId } : {}),
       ...(args.workspaceName ? { workspaceName: args.workspaceName } : {}),
       ...(args.botUserId ? { botUserId: args.botUserId } : {}),
+      ...(args.grantedScopes && args.grantedScopes.length > 0 ? { grantedScopes: args.grantedScopes } : {}),
       ...(args.shareable ? { shareable: true } : {})
     },
     // Workspace-claim admission fence — core enforces it at the shared create

--- a/packages/control-plane/src/http/routes/slack-bot-refresh.ts
+++ b/packages/control-plane/src/http/routes/slack-bot-refresh.ts
@@ -114,6 +114,14 @@ export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
         if (appIdentityMatches && checked.teamId) {
           await deps.repos.bot.setWorkspaceMetadata(bot.orgId, bot.id, checked.teamId, checked.teamName)
         }
+        // The granted set observed for the STORED credential — the same token
+        // capability reads (the session-access workspace checker) would use, so
+        // it is recorded even when the app identity mismatches below. This is
+        // how a workspace reauthorization becomes visible to those reads without
+        // a re-probe. An absent header keeps the last known set.
+        if (checked?.status === 'ok' && checked.scopes?.length) {
+          await deps.repos.bot.setGrantedScopes(bot.orgId, bot.id, checked.scopes)
+        }
         // A built-in app's manifest is deployment-managed rather than owned by
         // the signed-in user's Slack config token. Refresh still verifies its
         // installed scopes so the Console can offer the platform OAuth reinstall.

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -439,6 +439,9 @@ export function slackInstallRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
             ...(botCheck?.status === 'ok' && botCheck.teamId ? { workspaceId: botCheck.teamId } : {}),
             ...(botCheck?.status === 'ok' && botCheck.teamName ? { workspaceName: botCheck.teamName } : {}),
             ...(botCheck?.status === 'ok' && botCheck.botUserId ? { botUserId: botCheck.botUserId } : {}),
+            // The granted set behind the fence above, kept on the bot row so
+            // capability reads don't have to re-probe Slack.
+            ...(botCheck?.status === 'ok' && botCheck.scopes?.length ? { grantedScopes: botCheck.scopes } : {}),
             // socket: the pasted xapp; http: the signing secret captured at create. The
             // shareable choice rides the finalize body (installNewSlackBot coerces it off
             // for socket regardless).

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -365,6 +365,12 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
             { restoreRevokedMemberships: !!expectedBot }
           )
           req.log.info({ botId: existing.id, revision }, 'slack platform re-install: credential generation advanced')
+          // The granted set behind the short-grant fence above describes the
+          // credential that just landed; record it for capability reads. An
+          // absent header keeps the last known set (silence is not knowledge).
+          if (checked?.status === 'ok' && checked.scopes?.length) {
+            await deps.repos.bot.setGrantedScopes(existing.orgId, BotId(existing.id), checked.scopes)
+          }
           if (agent) {
             // Generic install/re-install only: membership admission is ATOMIC
             // with the bot row. A bot-bound Settings reauthorization has no
@@ -425,6 +431,7 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps, slack: SlackRouteSea
               workspaceId: result.teamId,
               ...(result.teamName ? { workspaceName: result.teamName } : {}),
               ...(result.botUserId ? { botUserId: result.botUserId } : {}),
+              ...(checked?.status === 'ok' && checked.scopes?.length ? { grantedScopes: checked.scopes } : {}),
               signingSecret: platform.signingSecret,
               ...(row.createdByUserId ? { createdByUserId: row.createdByUserId } : {})
             })

--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it, vi } from 'vitest'
+import { BotId, OrgId } from '../domain/ids.js'
 import type { BotRecord, ExternalScopeRecord } from '../persistence/ports.js'
 import type { SessionAccessViewer } from './session-access-plugin.js'
 import { SlackSessionAccessService } from './slack-session-access.js'
 
 const BOT_ID = 'b0b0b0b0-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const SECOND_BOT_ID = BotId('a1a1a1a1-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
 
 function scope(): ExternalScopeRecord {
   return {
     id: '11111111-1111-4111-8111-111111111111',
-    orgId: 'org-1',
+    orgId: OrgId('org-1'),
     provider: 'slack',
     realmKey: 'T_INSTALL',
     resourceKind: 'conversation',
@@ -28,7 +30,7 @@ function scopeAt(index: number): ExternalScopeRecord {
   }
 }
 
-function bot(): BotRecord {
+function bot(overrides: Partial<BotRecord> = {}): BotRecord {
   return {
     id: BOT_ID,
     orgId: 'org-1',
@@ -36,21 +38,37 @@ function bot(): BotRecord {
     workspaceId: 'T_INSTALL',
     teamId: 'T_INSTALL',
     revokedAt: null,
-    credentialRevision: 3
+    credentialRevision: 3,
+    prebuilt: false,
+    // Unknown grant: eligible for workspace checks, but unproven.
+    grantedScopes: null,
+    createdAt: new Date(500),
+    ...overrides
   } as BotRecord
 }
 
 function service(
   fetchImpl: (url: string, init?: RequestInit) => Promise<Response>,
-  log?: { warn: (obj: object, msg: string) => void }
+  log?: { warn: (obj: object, msg: string) => void },
+  fleet: { bots?: BotRecord[]; tokens?: Record<string, string> } = {}
 ) {
+  const bots = fleet.bots ?? [bot()]
+  const tokens = fleet.tokens ?? { [BOT_ID]: 'xoxb-test' }
   return new SlackSessionAccessService({
-    bots: { getUnscoped: async () => bot() } as never,
-    botSecrets: { get: async () => ({ botToken: 'xoxb-test' }) } as never,
+    bots: {
+      getUnscoped: async (id: string) => bots.find((candidate) => candidate.id === id) ?? null,
+      listForOrg: async () => bots
+    } as never,
+    botSecrets: { get: async (_orgId: unknown, id: string) => ({ botToken: tokens[id] }) } as never,
     clock: { now: () => 1_000 } as never,
     fetchImpl,
     ...(log ? { log } : {})
   })
+}
+
+/** The bearer token a faked Slack call was made with — which BOT answered. */
+function tokenOf(init?: RequestInit): string {
+  return String((init?.headers as Record<string, string> | undefined)?.authorization ?? '')
 }
 
 function json(body: unknown, status = 200): Response {
@@ -559,5 +577,203 @@ describe('SlackSessionAccessService', () => {
       degraded: false
     })
     expect(attempt).toBe(2)
+  })
+
+  // `users.info` asks a WORKSPACE question, and within a realm every credential
+  // that can ask gets the same answer — so which bot asks is a policy choice.
+  // Before it was one, the workspace cache key carried no bot id: every bot in
+  // a workspace shared one entry per viewer despite holding different grants,
+  // and whichever credential resolved first decided everyone's verdict for a
+  // TTL — a deterministic short grant presented as sessions flickering in and
+  // out.
+  describe('designated workspace checker', () => {
+    const CAPABLE = ['channels:read', 'chat:write', 'users:read']
+    const SHORT = ['channels:read', 'chat:write']
+
+    it('answers a same-team check with the capable platform app, not the short recording bot', async () => {
+      const fleet = {
+        bots: [
+          bot({ grantedScopes: SHORT }),
+          bot({
+            id: SECOND_BOT_ID,
+            prebuilt: true,
+            credentialRevision: 7,
+            grantedScopes: CAPABLE,
+            createdAt: new Date(900)
+          })
+        ],
+        tokens: { [BOT_ID]: 'xoxb-recording', [SECOND_BOT_ID]: 'xoxb-checker' }
+      }
+      const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.includes('conversations.info')) {
+          return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+        }
+        if (url.includes('users.info')) {
+          // The recording bot's own grant CANNOT answer this: only the routing
+          // makes the resolve below succeed.
+          return tokenOf(init) === 'Bearer xoxb-checker'
+            ? json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+            : json({ ok: false, error: 'missing_scope' })
+        }
+        throw new Error(`unexpected Slack request: ${url}`)
+      })
+      const resolver = service(fetchImpl, undefined, fleet)
+
+      await expect(resolver.resolve([scopeAt(1)], viewer('slack:T_INSTALL:U_MEMBER'))).resolves.toEqual({
+        allowedScopes: [{ id: scopeAt(1).id, aclRevision: 2n }],
+        degraded: false,
+        accessIssues: []
+      })
+      // A second conversation re-reads its own audience but rides the checker's
+      // cached workspace verdict: one `users.info` per principal, not per scope.
+      await expect(resolver.resolve([scopeAt(2)], viewer('slack:T_INSTALL:U_MEMBER'))).resolves.toMatchObject({
+        degraded: false,
+        allowedScopes: [{ id: scopeAt(2).id, aclRevision: 2n }]
+      })
+      const users = fetchImpl.mock.calls.filter(([url]) => String(url).includes('users.info'))
+      expect(users).toHaveLength(1)
+      expect(tokenOf(users[0]?.[1])).toBe('Bearer xoxb-checker')
+    })
+
+    it('prefers a capable custom bot over a short-granted prebuilt', async () => {
+      // The platform app recorded the session but its grant lacks `users:read`;
+      // preference never overrides capability, so the custom bot answers.
+      const fleet = {
+        bots: [bot({ id: SECOND_BOT_ID, prebuilt: true, grantedScopes: SHORT }), bot({ grantedScopes: CAPABLE })],
+        tokens: { [BOT_ID]: 'xoxb-custom', [SECOND_BOT_ID]: 'xoxb-prebuilt' }
+      }
+      const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.includes('conversations.info')) {
+          return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+        }
+        if (url.includes('users.info')) {
+          return tokenOf(init) === 'Bearer xoxb-custom'
+            ? json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+            : json({ ok: false, error: 'missing_scope' })
+        }
+        throw new Error(`unexpected Slack request: ${url}`)
+      })
+      const recorded = { ...scope(), credentialId: SECOND_BOT_ID }
+
+      await expect(
+        service(fetchImpl, undefined, fleet).resolve([recorded], viewer('slack:T_INSTALL:U_MEMBER'))
+      ).resolves.toEqual({
+        allowedScopes: [{ id: recorded.id, aclRevision: 2n }],
+        degraded: false,
+        accessIssues: []
+      })
+      const users = fetchImpl.mock.calls.filter(([url]) => String(url).includes('users.info'))
+      expect(users.map(([, init]) => tokenOf(init))).toEqual(['Bearer xoxb-custom'])
+    })
+
+    it('keeps a Slack Connect check on the recording bot, not the checker', async () => {
+      const fleet = {
+        bots: [bot(), bot({ id: SECOND_BOT_ID, prebuilt: true, grantedScopes: CAPABLE, createdAt: new Date(900) })],
+        tokens: { [BOT_ID]: 'xoxb-recording', [SECOND_BOT_ID]: 'xoxb-checker' }
+      }
+      const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.includes('conversations.info')) {
+          return json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+        }
+        if (url.includes('conversations.members')) {
+          return json({ ok: true, members: ['U_CONNECT'], response_metadata: {} })
+        }
+        // Only a bot sharing a conversation can see an external user; the
+        // checker would be told the user does not exist — a definitive deny.
+        return tokenOf(init) === 'Bearer xoxb-recording'
+          ? json({ ok: true, user: { team_id: 'T_HOME' } })
+          : json({ ok: false, error: 'user_not_found' })
+      })
+
+      await expect(
+        service(fetchImpl, undefined, fleet).resolve([scope()], viewer('slack:T_HOME:U_CONNECT'))
+      ).resolves.toEqual({
+        allowedScopes: [{ id: scope().id, aclRevision: 2n }],
+        degraded: false,
+        accessIssues: []
+      })
+      const users = fetchImpl.mock.calls.filter(([url]) => String(url).includes('users.info'))
+      expect(users.map(([, init]) => tokenOf(init))).toEqual(['Bearer xoxb-recording'])
+    })
+
+    it('degrades to the reauthorize prompt when no realm credential holds users:read', async () => {
+      const warn = vi.fn()
+      const fleet = {
+        bots: [bot({ grantedScopes: SHORT }), bot({ id: SECOND_BOT_ID, prebuilt: true, grantedScopes: SHORT })],
+        tokens: { [BOT_ID]: 'xoxb-recording', [SECOND_BOT_ID]: 'xoxb-prebuilt' }
+      }
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.includes('conversations.info')) {
+          return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+        }
+        throw new Error(`unexpected Slack request: ${url}`)
+      })
+
+      await expect(
+        service(fetchImpl, { warn }, fleet).resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))
+      ).resolves.toEqual({
+        allowedScopes: [],
+        degraded: true,
+        accessIssues: [{ provider: 'slack', reason: 'app_authorization' }]
+      })
+      // Every candidate's grant POSITIVELY lacks the scope: no call is spent
+      // re-earning `missing_scope`, and the degrade names the local fact.
+      expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('users.info'))).toBe(false)
+      expect(warn.mock.calls[0]?.[0]).toMatchObject({ reasons: { bot_scope_missing: 1 } })
+    })
+
+    it('no longer lets two bots share a workspace verdict across credentials', async () => {
+      // Same realm, same viewer, same credential REVISION — exactly the shape
+      // the old [realm, revision, principal] key collapsed into one entry,
+      // letting bot A's verdict answer for bot B's differently-granted token.
+      // Cross-team viewers pin each check to its recording bot, so both fire.
+      const fleet = {
+        bots: [bot({ credentialRevision: 1 }), bot({ id: SECOND_BOT_ID, credentialRevision: 1 })],
+        tokens: { [BOT_ID]: 'xoxb-a', [SECOND_BOT_ID]: 'xoxb-b' }
+      }
+      const fetchImpl = vi.fn(async (url: string, _init?: RequestInit) => {
+        if (url.includes('conversations.info')) {
+          return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+        }
+        if (url.includes('conversations.members')) {
+          return json({ ok: true, members: ['U_CONNECT'], response_metadata: {} })
+        }
+        return json({ ok: true, user: { team_id: 'T_HOME' } })
+      })
+      const scopes = [scopeAt(1), { ...scopeAt(2), credentialId: SECOND_BOT_ID }]
+
+      const result = await service(fetchImpl, undefined, fleet).resolve(scopes, viewer('slack:T_HOME:U_CONNECT'))
+
+      expect(result.degraded).toBe(false)
+      expect(result.allowedScopes).toHaveLength(2)
+      const users = fetchImpl.mock.calls.filter(([url]) => String(url).includes('users.info'))
+      expect(new Set(users.map(([, init]) => tokenOf(init)))).toEqual(new Set(['Bearer xoxb-a', 'Bearer xoxb-b']))
+    })
+
+    it('shares the workspace verdict between sessions when the checker is the same', async () => {
+      // Isolation is per ANSWERING credential, not per recording bot: two bots'
+      // sessions in one realm still resolve through one checker and one call.
+      const fleet = {
+        bots: [bot(), bot({ id: SECOND_BOT_ID, prebuilt: true, grantedScopes: CAPABLE, createdAt: new Date(900) })],
+        tokens: { [BOT_ID]: 'xoxb-recording', [SECOND_BOT_ID]: 'xoxb-checker' }
+      }
+      const fetchImpl = vi.fn(async (url: string, _init?: RequestInit) => {
+        if (url.includes('conversations.info')) {
+          return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+        }
+        if (url.includes('users.info')) {
+          return json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+        }
+        throw new Error(`unexpected Slack request: ${url}`)
+      })
+      const resolver = service(fetchImpl, undefined, fleet)
+
+      await resolver.resolve([scopeAt(1)], viewer('slack:T_INSTALL:U_MEMBER'))
+      await resolver.resolve([{ ...scopeAt(2), credentialId: SECOND_BOT_ID }], viewer('slack:T_INSTALL:U_MEMBER'))
+
+      const users = fetchImpl.mock.calls.filter(([url]) => String(url).includes('users.info'))
+      expect(users).toHaveLength(1)
+      expect(tokenOf(users[0]?.[1])).toBe('Bearer xoxb-checker')
+    })
   })
 })

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -2,7 +2,7 @@ import { LRUCache } from 'lru-cache'
 import { cacheOptions } from '../cache.js'
 import type { FetchLike } from '../github/api.js'
 import type { Clock } from '../domain/clock.js'
-import type { BotRepo, BotSecretStore, ExternalScopeRecord } from '../persistence/ports.js'
+import type { BotRecord, BotRepo, BotSecretStore, ExternalScopeRecord } from '../persistence/ports.js'
 import { BotId } from '../domain/ids.js'
 import type { LogtoIdentityService } from '../github/logto-identity.js'
 import type {
@@ -21,6 +21,8 @@ const SCOPE_CONCURRENCY = 6
 const MAX_MEMBER_PAGES = 50
 const PAGE_SIZE = 200
 const TIMEOUT_MS = 5_000
+/** The one Slack scope a workspace-standing check spends (`users.info`). */
+const WORKSPACE_READ_SCOPE = 'users:read'
 /**
  * How long one conversation's audience (public / members-only / gone) is reused.
  *
@@ -65,6 +67,11 @@ type DegradedReason = string
 type LocalReason =
   | 'bot_unresolved'
   | 'bot_token_missing'
+  /** No credential in the realm is known to hold `users:read`: every
+   *  candidate's persisted grant positively lacks it, so a workspace check
+   *  degrades without spending a call whose answer is already known (see
+   *  `designatedChecker`). */
+  | 'bot_scope_missing'
   /** The shared audience entry was dropped while this caller was reading it. */
   | 'audience_evicted'
   /** Slack answered, in a shape no verdict can be read out of. */
@@ -93,6 +100,9 @@ type ObservedAudience = ReadAudience & { fetchedAt: number }
 type CheckedAccess = Verdict & { evidenceAt: number }
 type CheckedWorkspaceAccess = { access: WorkspaceAccess; reason?: DegradedReason }
 type AudienceLookup = { channel: string; token: string; signal: AbortSignal }
+/** The credential a Slack question is asked WITH — and, through its bot id and
+ *  credential revision, the cache identity of the answer it produces. */
+type AnsweringBot = { botId: string; credentialRevision: number; token: string }
 
 // `ok: false` covers two very different answers, and conflating them is what
 // made an ordinary event — a private channel deleted, or the bot removed from
@@ -172,10 +182,13 @@ function thrownReason(error: unknown): LocalReason {
  * is fixed once, by an administrator, through the app's own row on Integrations
  * (`POST /bots/:id/slack/refresh` syncs the manifest and names the missing
  * scopes), and nothing in here clears on its own. `missing_scope` is the
- * observed case — an app installed before a scope was added to
- * `SLACK_BOT_SCOPES` keeps a grant that can never pass the check — and the rest
+ * observed case — Slack's initial authorization does not reliably apply every
+ * scope an app's manifest declares, so an install can hold a short grant that
+ * never passes the check until the workspace reinstalls the app — and the rest
  * are the other ways Slack says "this credential is the problem", which land on
- * the same page and the same button.
+ * the same page and the same button. `bot_scope_missing` is the one LOCAL
+ * member: the same short-grant fact, established from persisted grants instead
+ * of a live refusal (see `designatedChecker`), and cleared by the same remedy.
  *
  * Deliberately NOT here: `ratelimited` and every transport/HTTP failure, which
  * really are transient; and `ekm_access_denied`, which is an enterprise key
@@ -183,6 +196,7 @@ function thrownReason(error: unknown): LocalReason {
  */
 const APP_AUTHORIZATION_ERRORS = new Set([
   'missing_scope',
+  'bot_scope_missing',
   'invalid_auth',
   'account_inactive',
   'token_revoked',
@@ -236,6 +250,11 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
    *  A cached `unknown` keeps the reason it was reached by, so a resolve that
    *  rides one is not the one degraded resolve that cannot say why. */
   private readonly cache: LRUCache<string, Verdict>
+  /** (realm, ANSWERING bot, its credential revision, principal) → standing.
+   *  The bot id is load-bearing: bots in one workspace hold different grants,
+   *  so a verdict is reusable only under the credential that produced it —
+   *  and a bot id is org-owned, which keeps two orgs sharing a workspace out
+   *  of each other's entries. */
   private readonly workspaceAccessCache: LRUCache<string, CheckedWorkspaceAccess>
   /** (bot, credential revision, channel) → audience. Shared across viewers,
    *  unlike `cache` and `workspaceAccessCache`, which are per principal.
@@ -404,6 +423,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     const now = this.deps.clock.now()
     const secret = await this.deps.botSecrets.get(scope.orgId, BotId(botId)).catch(() => null)
     if (!secret?.botToken) return { ...unresolved('bot_token_missing'), evidenceAt: now }
+    const recording: AnsweringBot = { botId, credentialRevision, token: secret.botToken }
     try {
       const observed = await this.audienceOf(
         [botId, credentialRevision, scope.resourceKey].join(':'),
@@ -419,13 +439,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
       if (observed.audience === 'gone') return { decision: 'deny', evidenceAt }
       if (observed.audience === 'unknown') return { decision: 'unknown', reason: observed.reason, evidenceAt }
       if (observed.audience === 'public') {
-        const { access, ...cause } = await this.workspaceAccess(
-          scope.realmKey,
-          principal,
-          credentialRevision,
-          secret.botToken,
-          signal
-        )
+        const { access, ...cause } = await this.workspaceAccess(scope, principal, recording, signal)
         if (access !== 'membership') return { decision: access, ...cause, evidenceAt }
         const member = await this.checkMembership(scope.resourceKey, principal.userId, secret.botToken, signal)
         return { ...member, evidenceAt }
@@ -436,13 +450,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
 
       // Slack Connect can return a member from another workspace. Verify the
       // identity's home team instead of treating the installing team as proof.
-      const { access, ...cause } = await this.workspaceAccess(
-        scope.realmKey,
-        principal,
-        credentialRevision,
-        secret.botToken,
-        signal
-      )
+      const { access, ...cause } = await this.workspaceAccess(scope, principal, recording, signal)
       return access === 'unknown' || access === 'deny'
         ? { decision: access, ...cause, evidenceAt }
         : { decision: 'allow', evidenceAt }
@@ -486,14 +494,55 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     return { audience: 'unknown', reason: 'audience_unclassified' }
   }
 
+  /**
+   * Workspace standing ("is this principal a full member of this realm, and
+   * full vs guest?") is a directory fact: within a realm, every credential
+   * that CAN ask gets the same answer — only the ability to ask differs by
+   * grant. So for a same-team principal the question is routed to the one
+   * designated checker for (org, realm) rather than whichever bot happened to
+   * record the conversation, and the recording bot's own grant no longer
+   * decides whether a same-team viewer's sessions resolve.
+   *
+   * A CROSS-team principal (Slack Connect) is the deliberate exception: an
+   * external user is visible only to a bot that shares a conversation with
+   * them, which the designated checker typically does not — its `users.info`
+   * would answer `user_not_found` / `user_not_visible`, both definitive
+   * denials, silently converting today's allows into denies. Cross-team
+   * visibility is relationship-relative, so it stays on the recording
+   * credential, whose shared conversation is what makes the user readable.
+   *
+   * Either way the verdict caches under the ANSWERING bot. The old key —
+   * [realm, credentialRevision, principal], no bot id — let every bot in a
+   * workspace ride one entry despite holding different grants: whichever
+   * credential resolved first decided every bot's verdict for a TTL, which is
+   * how a deterministic short grant presented as sessions flickering in and
+   * out. Isolating per bot WITHOUT the checker would break the other way
+   * (every short-granted bot deterministically failing its own checks), which
+   * is why routing and keying land together.
+   */
   private async workspaceAccess(
-    realmKey: string,
+    scope: ExternalScopeRecord,
     principal: SlackPrincipal,
-    credentialRevision: number,
-    token: string,
+    recording: AnsweringBot,
     signal: AbortSignal
   ): Promise<CheckedWorkspaceAccess> {
-    const key = [realmKey, credentialRevision, principal.key].join(':')
+    const realmKey = scope.realmKey
+    let answerer = recording
+    if (principal.teamId === realmKey) {
+      const checker = await this.designatedChecker(scope.orgId, realmKey)
+      // Deterministic degrade, not a doomed call: every realm credential's
+      // persisted grant lacks `users:read`, so asking any of them could only
+      // re-earn `missing_scope`. The reason lands on the app_authorization
+      // remedy — reauthorize an app on Integrations — which is also the only
+      // thing that clears it.
+      if (!checker) return { access: 'unknown', reason: 'bot_scope_missing' }
+      if (checker.id !== recording.botId) {
+        const secret = await this.deps.botSecrets.get(scope.orgId, checker.id).catch(() => null)
+        if (!secret?.botToken) return { access: 'unknown', reason: 'bot_token_missing' }
+        answerer = { botId: checker.id, credentialRevision: checker.credentialRevision, token: secret.botToken }
+      }
+    }
+    const key = [realmKey, answerer.botId, answerer.credentialRevision, principal.key].join(':')
     const cached = this.workspaceAccessCache.get(key)
     if (cached) return cached
 
@@ -514,7 +563,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
         is_stranger?: unknown
         is_external?: unknown
       }
-    }>(`users.info?user=${encodeURIComponent(principal.userId)}`, token, signal)
+    }>(`users.info?user=${encodeURIComponent(principal.userId)}`, answerer.token, signal)
 
     // The initial value covers `ok` with no `user`: Slack answered, in a shape
     // no verdict can be read out of.
@@ -553,6 +602,50 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     }
     this.putWorkspaceAccess(key, checked)
     return checked
+  }
+
+  /**
+   * The one credential that answers workspace-scoped questions for an (org,
+   * realm) — chosen, not stumbled into.
+   *
+   * Candidates are the org's own live Slack bots installed into the realm: the
+   * org fence means never another org's credential, even for the same
+   * workspace. Capability comes first — a bot whose persisted grant positively
+   * lacks `users:read` never qualifies, while a bot with NO persisted grant
+   * (row predating the column, or Slack omitted the header) stays eligible but
+   * unproven. Among the eligible: a proven grant outranks an unproven one, the
+   * prebuilt platform app outranks a custom one (its grant comes from our own
+   * authorize URL and installs are gated on it being complete), and creation
+   * order breaks ties so the choice is stable across resolves.
+   *
+   * A realm holding custom bots AND the platform app therefore routes every
+   * workspace check through the platform app — including for sessions recorded
+   * by custom bots. That is the point: one good credential covers the realm
+   * regardless of how short the other grants are, which is what the old
+   * realm-wide cache entry was providing by accident, unreliably.
+   *
+   * `null` means no candidate qualifies. The recording bot is itself always a
+   * candidate (the caller resolved it in this org and realm, non-revoked), so
+   * `null` only happens when every credential's grant positively lacks the
+   * scope — a deterministic short-grant fact, not an outage.
+   */
+  private async designatedChecker(orgId: ExternalScopeRecord['orgId'], realmKey: string): Promise<BotRecord | null> {
+    const proven = (bot: BotRecord) => bot.grantedScopes?.includes(WORKSPACE_READ_SCOPE) === true
+    const candidates = (await this.deps.bots.listForOrg(orgId)).filter(
+      (bot) =>
+        bot.platform === 'slack' &&
+        bot.revokedAt === null &&
+        (bot.workspaceId ?? bot.teamId) === realmKey &&
+        (bot.grantedScopes == null || proven(bot))
+    )
+    candidates.sort(
+      (a, b) =>
+        Number(proven(b)) - Number(proven(a)) ||
+        Number(b.prebuilt) - Number(a.prebuilt) ||
+        a.createdAt.getTime() - b.createdAt.getTime() ||
+        a.id.localeCompare(b.id)
+    )
+    return candidates[0] ?? null
   }
 
   private async checkMembership(channel: string, userId: string, token: string, signal: AbortSignal): Promise<Verdict> {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2552,6 +2552,11 @@ export interface CreateBotInput {
   shareable?: boolean
   /** Inbound transport. Default 'socket'. */
   transport?: SlackTransport
+  /** Bot scopes the platform REPORTED as granted for the credential being
+   *  stored (Slack: the `x-oauth-scopes` header of the install's `auth.test`).
+   *  Omit when the platform did not report one — absence is "unknown", never a
+   *  short grant. */
+  grantedScopes?: string[]
   createdByUserId?: string
 }
 
@@ -2629,6 +2634,12 @@ export interface BotRecord {
   /** When the current credential landed; null for bots created before the fence
    *  (their revocations skip the timestamp check and rely on the revision). */
   credentialInstalledAt: Date | null
+  /** Bot scopes the platform reported as granted for the CURRENT credential
+   *  (Slack: `x-oauth-scopes`, persisted at install / refresh verification).
+   *  `null` means never observed — an UNKNOWN grant, not an empty one — so a
+   *  capability read may treat the bot as eligible-but-unproven, never as
+   *  short. Advisory metadata; never an authorization fence by itself. */
+  grantedScopes: string[] | null
   /** Generic demux identity (D6): the platform's app-scoped id. Dual-written beside
    *  the legacy per-platform columns; NULL on legacy rows. */
   externalAppId: string | null
@@ -2681,6 +2692,12 @@ export interface BotRepo {
    *  preserves the last known label. Org-fenced: a cross-org id writes nothing
    *  (the row is filtered out of the update). */
   setWorkspaceMetadata(orgId: OrgId, id: BotId, workspaceId: string, workspaceName: string | null): Promise<void>
+  /** Record the granted bot scopes an install/refresh verification OBSERVED for
+   *  the bot's current credential. Callers pass only a non-empty observed set —
+   *  "the platform reported nothing" keeps the last known set rather than
+   *  overwriting knowledge with silence. Org-fenced: a cross-org id writes
+   *  nothing. */
+  setGrantedScopes(orgId: OrgId, id: BotId, scopes: readonly string[]): Promise<void>
   /** Slack bots missing public app/workspace/member identity metadata.
    *  System-tier: the identity reconciler's worklist is deliberately fleet-wide. */
   listSlackMissingIdentity(): Promise<BotRecord[]>

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -78,6 +78,10 @@ function toBotRecord(b: BotJoined): BotRecord {
     revokedAt: b.revokedAt,
     credentialRevision: b.credentialRevision,
     credentialInstalledAt: b.credentialInstalledAt,
+    // The column cannot be NULL (Prisma scalar list), so empty encodes "never
+    // observed". The RECORD restores the tri-state the readers contract on:
+    // null = unknown grant, non-empty = the observed set.
+    grantedScopes: b.grantedScopes.length > 0 ? b.grantedScopes : null,
     // Projected out of the generic bag, which is where every write puts them
     // (`CpPlatformProvider.projectBotIdentity`). The named fields stay on the
     // RECORD because that is a domain type with named platform metadata, not a
@@ -143,6 +147,9 @@ export class PgBotRepo implements BotRepo {
           ...(input.botUserId ? { botUserId: input.botUserId } : {}),
           ...(input.shareable !== undefined ? { shareable: input.shareable } : {}),
           ...(input.transport !== undefined ? { transport: input.transport } : {}),
+          // Only a non-empty observed set is worth writing: empty is the
+          // column's "never observed" encoding, which the default already says.
+          ...(input.grantedScopes && input.grantedScopes.length > 0 ? { grantedScopes: input.grantedScopes } : {}),
           // Generation 1 (the column default) lands NOW — so a lifecycle event that
           // predates this credential is fenced out even on a bot's first install.
           // Legacy rows keep a null stamp and fall back to the revision arm alone.
@@ -198,6 +205,12 @@ export class PgBotRepo implements BotRepo {
         ...(workspaceName ? { workspaceName } : {})
       }
     })
+  }
+
+  async setGrantedScopes(orgId: OrgId, id: BotId, scopes: readonly string[]): Promise<void> {
+    // Advisory capability metadata: a cross-org (or vanished) id writes nothing
+    // rather than throwing — no caller has a recovery beyond "keep going".
+    await this.db.bot.updateMany({ where: { id, orgId }, data: { grantedScopes: [...scopes] } })
   }
 
   async listSlackMissingIdentity(): Promise<BotRecord[]> {

--- a/packages/control-plane/src/platforms/provider.ts
+++ b/packages/control-plane/src/platforms/provider.ts
@@ -137,6 +137,10 @@ export interface CpValidatedIdentity {
   workspaceId?: string
   workspaceName?: string
   botUserId?: string
+  /** Bot scopes the platform REPORTED as granted for the validated credential
+   *  (Slack: `auth.test`'s `x-oauth-scopes`). Omitted when the platform did not
+   *  report one — absence is "unknown", never a short grant. */
+  grantedScopes?: string[]
 }
 
 /**
@@ -192,6 +196,7 @@ export interface CpNewBotInstall {
         | 'feishuAppId'
         | 'feishuRegion'
         | 'shareable'
+        | 'grantedScopes'
       >
     >
   >

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -388,7 +388,11 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
               ...(botCheck.appId ? { externalAppId: botCheck.appId } : {}),
               ...(botCheck.teamId ? { workspaceId: botCheck.teamId } : {}),
               ...(botCheck.teamName ? { workspaceName: botCheck.teamName } : {}),
-              ...(botCheck.botUserId ? { botUserId: botCheck.botUserId } : {})
+              ...(botCheck.botUserId ? { botUserId: botCheck.botUserId } : {}),
+              // The granted set `auth.test` reported for the pasted token, kept
+              // on the bot row so capability reads (the session-access workspace
+              // checker) don't have to re-probe Slack. Absent header ⇒ omitted.
+              ...(botCheck.scopes && botCheck.scopes.length > 0 ? { grantedScopes: botCheck.scopes } : {})
             }
           : {}
       return { ok: true, identity }
@@ -417,6 +421,7 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
           ...(identity.workspaceId ? { workspaceId: identity.workspaceId } : {}),
           ...(identity.workspaceName ? { workspaceName: identity.workspaceName } : {}),
           ...(identity.botUserId ? { botUserId: identity.botUserId } : {}),
+          ...(identity.grantedScopes ? { grantedScopes: identity.grantedScopes } : {}),
           ...(shareable ? { shareable: true } : {})
         },
         // Workspace-claim admission fence (ingress-tenant-fence.md §5). This is


### PR DESCRIPTION
## The bug

`SlackSessionAccessService.workspaceAccess()` cached workspace-standing verdicts under `[realmKey, credentialRevision, principal]` — no bot id and no org. `credentialRevision` is a per-bot counter (in practice almost always 1), so every bot in a workspace shared one cache entry per viewer despite holding different granted scopes. Whichever bot's check resolved first wrote its verdict (allow 120s / deny 30s / unknown 5s) and every other bot's checks rode it.

In a workspace where bots' grants differ (some lack `users:read`), that turns a **deterministic** per-credential `missing_scope` failure into apparent randomness: the same page alternates between visible and hidden depending on which credential populated the shared slot last. The missing org component also meant two orgs sharing a workspace could serve each other's verdicts — same fact, but a violation of the org fence.

Adding the bot id to the key alone would fix the flapping by making every short-granted bot fail *deterministically* — the collision had been acting as an accidental, unreliable fallback onto capable credentials. So the fix makes "who answers" principled instead of isolating blindly.

## The design

One `resolveScope` run asks two kinds of question:

1. **Conversation-scoped** (`conversations.info` / `conversations.members`): for private channels only a bot that is IN the conversation can answer, and the recording bot qualifies by construction. **Unchanged** — these stay on the recording bot, keys unchanged.

2. **Workspace-scoped** (`users.info` — full member vs guest of the realm): within a realm the answer is credential-independent; only the *ability* to ask differs by grant. These now route through one **designated checker per (org, realm)**:
   - Candidates: the org's own non-revoked Slack bots in that realm (org fence — never another org's credential, even for the same workspace).
   - Selection: capability first (must hold `users:read` per the persisted grant; a bot with *no* persisted grant is eligible but unproven), then proven-over-unproven, then prefer `prebuilt` (the platform app — its grant comes from our own authorize URL and installs are gated on it being complete), then oldest `createdAt` as a stable tiebreak. Preference never overrides capability: a short-granted prebuilt falls through to a capable custom bot.
   - A realm holding custom bots and the platform app therefore routes ALL workspace checks through the platform app, including for sessions recorded by custom bots — one good credential covers the realm.
   - No qualifying candidate → deterministic degrade: `unknown` with a new local reason `bot_scope_missing`, which lands in the existing `app_authorization` access-issue path (the reauthorize prompt on Integrations). No call is spent re-earning a `missing_scope` whose answer is already persisted.

**Slack Connect carve-out**: an external (cross-workspace) user is visible only to bots that share a conversation with them. The designated checker typically shares nothing, so its `users.info` would answer `user_not_found` / `user_not_visible` — both definitive denials — silently converting today's allows into denies. Rule: `principal.teamId === realmKey` → designated checker; cross-team principal → recording bot.

Cache keys split accordingly, both naming the **answering** bot:

- same-team: `[realmKey, checkerBotId, checkerCredentialRevision, principal]`
- cross-team: `[realmKey, recordingBotId, recordingCredentialRevision, principal]`

Bot ids are org-owned, so the org-fence hole closes as a side effect.

## Knowing which bot holds `users:read`

New `Bot.grantedScopes` column (`TEXT[]`, default empty). Chosen over probe-and-cache at designation time because the data already exists at every verification point and was being discarded; persisting it also serves the Integrations surface later.

- The column cannot be NULL (Prisma scalar list), so **empty encodes "never observed"** — a real bot grant always carries at least one scope. The `BotRecord` seam restores the tri-state: `null` = unknown (eligible but unproven), non-empty = the observed set. Absence is never treated as short.
- Written wherever a flow already verifies the token and has the granted set in hand: config-token finalize, the platform OAuth callback (both the new-bot and re-install arms), manual `POST /integrations` validation (via `CpValidatedIdentity`), and the Settings refresh — so a workspace reauthorization becomes visible to capability reads without a re-probe. An absent `x-oauth-scopes` header keeps the last known set (silence is not knowledge).
- Slack's current reference (docs.slack.dev — the Web API responses page and per-method error tables) does **not** document `needed`/`provided` fields on `missing_scope` errors, so the speculative check-time refresh from a failed call was left out; install/refresh writes are the refresh path.

## Out of scope (unchanged)

Fail-closed behaviour, verdict TTLs, `failureDecision` classification, the conversation-scoped call paths, and all UI. The degrade lands in the already-shipped reauthorize-prompt surface; no new console vocabulary. Also corrected the stale `APP_AUTHORIZATION_ERRORS` comment that attributed short grants to manifest drift — short initial authorizations are Slack's known behaviour, not drift.

## Tests

Extended the fake-`fetchImpl` harness to serve a fleet (distinct bots, per-bot tokens, answering-token assertions):

- a capable prebuilt answers a short recording bot's same-team check, exactly one `users.info` per principal across conversations;
- prebuilt preference falls through when the prebuilt lacks `users:read` (capable custom answers);
- a cross-team principal's check uses the recording bot's token, and the checker's `user_not_found` never reaches it;
- all candidates short → `app_authorization` issue + `bot_scope_missing` in the degraded-reasons log, with no `users.info` spent;
- two bots with equal credential revisions no longer share a workspace verdict (the old key's exact collision shape);
- two bots' sessions still share one verdict when the checker is the same.

## Verification

- `pnpm typecheck` (all packages) and `pnpm --filter @agentconnect.md/control-plane test:unit` (1342 passed, 43 in the touched suite) are green.
- `pnpm --filter @agentconnect.md/control-plane test:int` (Docker): 73/74 files passed; the one failure (`test/repo/agent-placement-delegation.test.ts`, untouched by this change) is a load flake — it passes cleanly when the file runs in isolation and only fails under 4-worker CPU contention.
- `eslint` / `prettier --check` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
