### PR TITLE
docs(readme): cover the guided setup skill and local image builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,23 @@ cd agentconnect
 docker compose up -d --pull always
 ```
 
+To build the images from the checkout instead of pulling the published ones,
+run `docker compose up -d --build`. Every service in `compose.yaml` carries a
+build definition, and the built images take the tags the stack already
+references.
+
 Open `http://localhost:3000`. The default stack listens only on `127.0.0.1`,
 uses local no-auth mode, and is intended for local evaluation.
 
 The Compose stack does not run agent daemons. Add a daemon from the Web console,
 then run its generated command on each machine that should host agents,
 workspaces, and runtime credentials.
+
+Past the local stack — sign-in, public URLs, and provider apps — a guided path
+helps. Open Claude Code in the checkout and ask it to set up AgentConnect:
+[`.claude/skills/agentconnect-setup`](.claude/skills/agentconnect-setup/SKILL.md)
+runs those steps as an interactive tutorial and verifies each checkpoint before
+moving on. The rest of this section covers the same ground by hand.
 
 To evaluate local sign-in without configuring DNS or TLS, use the optional
 official Logto overlay and its browser-based Setup Server:


### PR DESCRIPTION
## Why

Two gaps in the self-hosting path:

- The repository ships an interactive setup tutorial as a Claude Code skill at `.claude/skills/agentconnect-setup` (added in #762), but nothing in the README mentioned it — someone who clones the repo to self-host never learns it is there.
- Every service in `compose.yaml` carries a build definition, but that was only discoverable by reading the file.

## What

- A paragraph pointing at the skill, placed where setup stops being two commands and starts on sign-in, public URLs, provider apps, and the first daemon. The plain Compose start needs no guidance, so the skill is not offered ahead of it.
- One paragraph on `docker compose up -d --build` for building the images from the checkout.

The wording claims Claude Code only. The skill directory also carries an `agents/openai.yaml` descriptor, but whether Codex still discovers the skill from `.claude/skills/` after #762 relocated it is unverified, so the docs do not promise it.

Verified the build claim with `docker compose build --print`: all four app images build from `compose.yaml` and take the tags the stack already references.

The docs site gets the matching change in agentconnect-md/docs#73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)