### PR TITLE
docs(skills): address the reading agent, not Codex, in the setup skill

### DIFF
--- a/.claude/skills/agentconnect-setup/SKILL.md
+++ b/.claude/skills/agentconnect-setup/SKILL.md
@@ -45,7 +45,7 @@ Use `scripts/check-local.sh <mode> [checkout]` for a read-only prerequisite and 
 
 - Never ask the user to paste secrets, private keys, configuration tokens, or OAuth client secrets into chat. Direct them to the password field in Setup or the provider console.
 - Never print, source, commit, or echo `compose.env`. Check only whether required variable names exist. Keep it gitignored.
-- Obtain confirmation before starting/stopping containers when the user asked only for guidance. Starting the requested stack is in scope when the user asked Codex to perform the setup.
+- Obtain confirmation before starting/stopping containers when the user asked only for guidance. Starting the requested stack is in scope when the user asked you to perform the setup.
 - Never run `docker compose down --volumes` unless the user explicitly requests a full reset and confirms permanent database deletion.
 - Keep no-auth mode bound to loopback. Do not help expose it to a LAN or public network; switch to authenticated setup first.
 - Preserve the exact Compose file set and `--env-file` choice across `up`, `pull`, `logs`, `restart`, and `down` commands.


### PR DESCRIPTION
`agentconnect-setup/SKILL.md` told the reading agent that starting the stack is in scope "when the user asked **Codex** to perform the setup" — a leftover from the skill's pre-#762 Codex origin. Both harnesses reach this skill, so naming one of them tells the other reader that the clause is about somebody else. It now addresses the reader directly:

> Starting the requested stack is in scope when the user asked **you** to perform the setup.

That is the whole diff — one line.

## On the `agents/openai.yaml` descriptors

An earlier revision of this PR also deleted `agents/openai.yaml` from both repo-local skills, on the theory that they were orphaned Codex interface descriptors sitting in a directory Codex cannot read. **That was wrong, and the deletion is reverted.**

The repo already tracks `.agents/skills` as a symlink to `../.claude/skills` (alongside `AGENTS.md` → `CLAUDE.md`). Codex reads `.agents/skills/`, follows the link, and gets the identical tree — descriptors included. Verified against codex-cli 0.147.0 by rendering the model-visible prompt from this checkout:

```
- agentconnect-setup: … (file: <repo>/.claude/skills/agentconnect-setup/SKILL.md)
- update-model-pricing: … (file: <repo>/.claude/skills/update-model-pricing/SKILL.md)
```

Both skills are live for Codex today, so the descriptors are load-bearing and stay exactly where they are. There is also no separate `.agents/` location to move them to — that path resolves to the same files.

A drive-by edit dropping the `$` from the `` `$update-model-pricing` `` reference in `openai-public-pricing.ts` was justified by the same mistaken premise and is likewise reverted; `$skill-name` is valid syntax for a skill Codex can actually invoke.

## Verification

- `prettier --check` on the touched file.
- Prose-only change to a skill instruction; no code, no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)