### PR TITLE
fix(slack): fail a manual token install whose workspace grant is short on bot scopes

### DIFF
--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -26,6 +26,7 @@ import {
   SlackCreateCredentials
 } from './provider.js'
 import { integrationToSpec, httpIntegrationToSpec } from '../../orchestrator/placement.js'
+import { SLACK_BOT_SCOPES } from '../../http/slack-manifest.js'
 import { HttpBotOrchestrator } from '../../orchestrator/httpBot.js'
 import { RelayRegistry, type RelayChannel } from '../../ws/relay-registry.js'
 import { buildCreateIntegrationBody } from '../../http/dto/create-integration-body.js'
@@ -342,6 +343,59 @@ describe('slack validateConfig (route parity: integrations.ts slack arm)', () =>
     const result = await provider.validateConfig({ botToken: 'xoxb-test', signingSecret: 'shh' }, 'http')
     expect(verifyAppToken).not.toHaveBeenCalled()
     expect(result.ok).toBe(true)
+  })
+
+  // The manual Bot-token wizard is the third install path the #768 scope fences
+  // cover: a workspace authorization that positively granted fewer bot scopes
+  // than the manifest declares must fail HERE, not weeks later as scoped calls
+  // answering `missing_scope`.
+  it('refuses a short workspace grant on BOTH transports, naming the missing scopes', async () => {
+    const provider = createSlackCpProvider({
+      verifyBot: verifierOk({ scopes: ['chat:write'] }),
+      verifyAppToken: vi.fn(async () => 'ok' as const)
+    })
+    const missing = SLACK_BOT_SCOPES.filter((scope) => scope !== 'chat:write')
+    const refusal = {
+      ok: false,
+      status: 400,
+      code: 'SLACK_MISSING_SCOPES',
+      message: `Slack didn’t grant every permission this app needs. Reinstall it in your Slack workspace, then connect again. Missing: ${missing.join(', ')}`
+    }
+    expect(await provider.validateConfig(CREDS, 'socket')).toEqual(refusal)
+    expect(await provider.validateConfig({ botToken: 'xoxb-test', signingSecret: 'shh' }, 'http')).toEqual(refusal)
+  })
+
+  it('proceeds on a complete grant (extra scopes a workspace holds are not a reason to refuse)', async () => {
+    const provider = createSlackCpProvider({
+      verifyBot: verifierOk({ scopes: [...SLACK_BOT_SCOPES, 'bookmarks:read'] }),
+      verifyAppToken: vi.fn(async () => 'ok' as const)
+    })
+    expect((await provider.validateConfig(CREDS, 'socket')).ok).toBe(true)
+  })
+
+  // Slack does not always send the `x-oauth-scopes` header. An unreported grant
+  // is "we could not tell", NOT "the grant is short" — refusing on it would fail
+  // installs for a reason unrelated to permissions (#768's tri-state rule).
+  it('never refuses when Slack did not report the granted scopes (unknown ≠ short)', async () => {
+    const provider = createSlackCpProvider({
+      verifyBot: verifierOk({ scopes: null }),
+      verifyAppToken: vi.fn(async () => 'ok' as const)
+    })
+    expect((await provider.validateConfig(CREDS, 'socket')).ok).toBe(true)
+  })
+
+  // The scope fence is checked LAST: a more specific credential refusal must
+  // not be masked by a shortfall the wrong app's token happens to show.
+  it('a mismatched token pair out-ranks the scope shortfall', async () => {
+    const provider = createSlackCpProvider({
+      verifyBot: verifierOk({ appId: 'A0OTHERAPP', scopes: ['chat:write'] }),
+      verifyAppToken: vi.fn(async () => 'ok' as const)
+    })
+    expect(await provider.validateConfig(CREDS, 'socket')).toEqual({
+      ok: false,
+      status: 400,
+      message: 'The Slack bot token and app-level token belong to different apps.'
+    })
   })
 })
 

--- a/packages/control-plane/src/platforms/slack/provider.ts
+++ b/packages/control-plane/src/platforms/slack/provider.ts
@@ -50,6 +50,7 @@ import type { IntegrationSlackConfig } from '@agentconnect.md/protocol'
 import type { BotRecord, BotSecretMaterial, SlackUserConfigStore } from '../../persistence/ports.js'
 import type { SlackBotVerifier, SlackAppTokenVerifier } from '../../http/slack-identity.js'
 import type { SlackConfigApi } from '../../http/slack-config-api.js'
+import { checkSlackBotScopes } from '../../http/slack-manifest.js'
 import { configUsable, resolveUserConfigAccessToken, type SlackUserConfigDeps } from '../../http/slack-user-config.js'
 import type {
   CpConfigValidation,
@@ -339,11 +340,16 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
      * `auth.test` + (socket) the app-level token check + the same-app
      * cross-check — the live checks the create route runs before anything is
      * stored (`integrations.ts` slack arm), with the route's statuses and
-     * user-facing copy verbatim (none carries a machine code today).
-     * Reachability is best-effort by contract: an unreachable Slack refuses
-     * NOTHING here (the route proceeds with no derived identity) — only a
-     * definitive rejection blocks. The http-transport relay-availability check
-     * is a 409 and stays core (contract §9: core knows the relay pool).
+     * user-facing copy verbatim — plus, LAST, the same bot-scope fence the two
+     * install funnels apply (#768): a workspace authorization that positively
+     * granted fewer scopes than the manifest declares is refused on BOTH
+     * transports, carrying `code: 'SLACK_MISSING_SCOPES'` (the one refusal
+     * here with a machine code). Reachability is best-effort by contract: an
+     * unreachable Slack refuses NOTHING here (the route proceeds with no
+     * derived identity) — only a definitive rejection blocks, and an
+     * unreported grant (`scopes: null`) is inconclusive, never short (see
+     * `checkSlackBotScopes`). The http-transport relay-availability check is a
+     * 409 and stays core (contract §9: core knows the relay pool).
      */
     async validateConfig(credentials, transport): Promise<CpConfigValidation> {
       const botCheck = verifyBot ? await verifyBot(credentials.botToken) : null
@@ -372,6 +378,28 @@ export function createSlackCpProvider(deps: SlackCpProviderDeps): CpPlatformProv
             ok: false,
             status: 400,
             message: 'The Slack bot token and app-level token belong to different apps.'
+          }
+        }
+      }
+      // The manual Bot-token wizard is the third install path the #768 scope
+      // fences cover: Slack's authorization does not reliably apply every bot
+      // permission the manifest declares, and a short grant installs SILENTLY —
+      // the shortfall surfaces much later, as scoped calls answering
+      // `missing_scope` and the session-access check failing closed. Refuse it
+      // here — while the operator is one Reinstall away — naming the scopes,
+      // for both transports. LAST of the checks, so a more specific credential
+      // refusal (bad token, mismatched apps) still wins; an inconclusive check
+      // never blocks (`checkSlackBotScopes`: an unreported grant is unknown,
+      // not short). The reused-bot arm (`botId`) mints no new grant and stays
+      // the Settings refresh's job.
+      if (botCheck?.status === 'ok') {
+        const grant = checkSlackBotScopes(botCheck.scopes)
+        if (grant.status === 'short') {
+          return {
+            ok: false,
+            status: 400,
+            code: 'SLACK_MISSING_SCOPES',
+            message: `Slack didn’t grant every permission this app needs. Reinstall it in your Slack workspace, then connect again. Missing: ${grant.missing.join(', ')}`
           }
         }
       }

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -154,7 +154,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       botUserId: 'UHTTPBOT',
       teamId: 'T1',
       teamName: 'Acme',
-      scopes: []
+      scopes: [...SLACK_BOT_SCOPES]
     })
 
     const res = await app.app.inject({
@@ -577,7 +577,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       botUserId: 'UCLAIMED',
       teamId: 'TCLAIMED',
       teamName: 'Acme',
-      scopes: []
+      scopes: [...SLACK_BOT_SCOPES]
     })
     // Another org already runs this app in this workspace: same signing secret,
     // same tenant — the relay's delivery fence cannot tell the two rows apart.
@@ -623,7 +623,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       botUserId: 'UMINE',
       teamId: 'TSHARED',
       teamName: 'Acme',
-      scopes: []
+      scopes: [...SLACK_BOT_SCOPES]
     })
     // Same workspace, DIFFERENT app ⇒ different signing secret ⇒ nothing is
     // ambiguous at delivery time, so admission must not over-refuse.
@@ -871,7 +871,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       appId: null,
       teamId: null,
       teamName: null,
-      scopes: []
+      scopes: [...SLACK_BOT_SCOPES]
     })
     app.platformStubs.verifySlackAppToken = async () => 'invalid'
 
@@ -894,7 +894,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       appId: 'AOTHER',
       teamId: null,
       teamName: null,
-      scopes: []
+      scopes: [...SLACK_BOT_SCOPES]
     })
     app.platformStubs.verifySlackAppToken = async () => 'ok'
 
@@ -913,6 +913,44 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect(await prisma.bot.count()).toBe(0)
   })
 
+  // The manual Bot-token wizard is the third install path the #768 scope fences
+  // cover (after the config-token finalize and the platform OAuth callback): a
+  // workspace authorization that positively granted fewer bot scopes than the
+  // manifest declares used to install silently and only fail weeks later, as
+  // scoped calls answering `missing_scope`.
+  it('POST rejects a bot token whose workspace grant is short on scopes (400) and stores nothing', async () => {
+    const agentId = await placedAgent()
+    const { app, spy } = withSpy()
+    const withheld = ['channels:history', 'users:read']
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'acme-bot',
+      appId: 'A1TEST',
+      teamId: 'T_INSTALL',
+      teamName: 'Acme',
+      botUserId: 'U1',
+      scopes: SLACK_BOT_SCOPES.filter((scope) => !withheld.includes(scope))
+    })
+    app.platformStubs.verifySlackAppToken = async () => 'ok'
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { platform: 'slack', agentId, slack: SLACK }
+    })
+    expect(res.statusCode).toBe(400)
+    const body = res.json() as { code?: string; message: string }
+    // The list is the point: "reinstall the app" is only actionable when the
+    // refusal says WHICH permissions are absent.
+    expect(body.code).toBe('SLACK_MISSING_SCOPES')
+    expect(body.message).toContain('channels:history')
+    expect(body.message).toContain('users:read')
+    expect(await prisma.integration.count()).toBe(0)
+    expect(await prisma.bot.count()).toBe(0)
+    expect(await prisma.botSecret.count()).toBe(0)
+    expect(spy.upserts).toHaveLength(0)
+  })
+
   it('POST derives the bot name from auth.test when none is given', async () => {
     const agentId = await placedAgent()
     const { app } = withSpy()
@@ -922,7 +960,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       appId: null,
       teamId: null,
       teamName: null,
-      scopes: []
+      scopes: [...SLACK_BOT_SCOPES]
     })
 
     const res = await app.app.inject({

--- a/packages/control-plane/test/integration/slack-tooling-credentials.route.test.ts
+++ b/packages/control-plane/test/integration/slack-tooling-credentials.route.test.ts
@@ -37,6 +37,7 @@ import { MemorySecretsProvider } from '../../src/secrets/providers/memory.js'
 import { systemClock } from '../../src/domain/clock.js'
 import { PgSlackUserConfigStore } from '../../src/persistence/index.js'
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
+import { SLACK_BOT_SCOPES } from '../../src/http/slack-manifest.js'
 import type {
   SlackConfigApi,
   SlackAppCreateResult,
@@ -133,7 +134,9 @@ async function storeConfig(
 }
 
 /** A Slack bot whose app id matches what `verifySlackBot` will claim, so the
- *  refresh route reaches its credential resolution. */
+ *  refresh route reaches its credential resolution. The fake reports a FULL
+ *  scope grant: the create path now refuses a positively-short one (#768's
+ *  third fence), and this helper's job is a bot that exists. */
 async function installedSlackBot(app: HttpApp, appId: string): Promise<string> {
   const agentId = await placedAgent()
   app.platformStubs.verifySlackBot = async () => ({
@@ -142,9 +145,9 @@ async function installedSlackBot(app: HttpApp, appId: string): Promise<string> {
     appId,
     teamId: 'T1',
     teamName: 'Acme',
-    scopes: []
+    scopes: [...SLACK_BOT_SCOPES]
   })
-  const created = (await app.app.inject({
+  const created = await app.app.inject({
     method: 'POST',
     url: `${ORG}/integrations`,
     payload: {
@@ -153,8 +156,9 @@ async function installedSlackBot(app: HttpApp, appId: string): Promise<string> {
       agentId,
       slack: { botToken: 'xoxb-tooling', appToken: `xapp-1-${appId}-123-abcdef` }
     }
-  })) as { json(): { botId: string } }
-  return created.json().botId
+  })
+  expect(created.statusCode).toBe(201)
+  return (created.json() as { botId: string }).botId
 }
 
 describe('providerToolingCredentials — the funnel start (POST /integrations/slack/app)', () => {
@@ -390,7 +394,17 @@ describe('the §9 DI collapse keeps its read-through seam', () => {
     const { app } = withFunnel()
     const botId = await installedSlackBot(app, 'A0TOOL0005')
 
-    // `installedSlackBot` left a verifier claiming this exact app id + no scopes.
+    // Swap the install-time FULL-grant verifier for a short-grant one claiming
+    // the same app id: the refresh must observe THIS stub, not one captured at
+    // composition or install time.
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'tooling-bot',
+      appId: 'A0TOOL0005',
+      teamId: 'T1',
+      teamName: 'Acme',
+      scopes: []
+    })
     expect((await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })).json()).toMatchObject({
       authorization: 'reinstall_required'
     })


### PR DESCRIPTION
Completes #768, which fenced two of the three Slack install paths — the config-token finalize and the platform OAuth callback — against workspace authorizations that grant fewer bot scopes than the manifest declares. The third path was still open, and confirmed live: the manual **Bot token** wizard (copy the manifest into Slack, paste the `xoxb-` + `xapp-` tokens, Connect & authorize) discarded the scopes `auth.test` reported, so a short grant installed successfully and the shortfall only surfaced later, through the Integrations page's refresh action or scoped calls answering `missing_scope`.

## What changed

- **`platforms/slack/provider.ts` — `validateConfig`**: run the shared `checkSlackBotScopes` diff on the `auth.test` result (whose `scopes` were already fetched and discarded) and refuse a positively-short grant with the provider-contract failure shape: 400, `code: 'SLACK_MISSING_SCOPES'`, and a message that names the missing scopes and points at the wizard's existing remedy — reinstall the app in Slack (which activates the full grant), then connect again. `validateConfig` is the seam both transports (socket and http) of the pasted-token path go through, so one fence covers both.
- The #768 rules carry over unchanged:
  - **Tri-state**: `scopes: null` (Slack omitted the `x-oauth-scopes` header, or the check was unreachable) is *unknown*, not *short* — it never blocks, so an install is never refused for a reason unrelated to permissions.
  - The fence runs **last** of the credential checks, so a more specific refusal (rejected token, mismatched app pair) still wins.
  - The **reuse-an-existing-bot** arm (`botId`) mints no new grant and stays the Settings refresh's job — untouched.

## Tests

- `provider.test.ts`: short grant → 400 naming the missing scopes, on both transports; complete grant (extra scopes tolerated) proceeds; `scopes: null` proceeds (unknown ≠ short); a mismatched token pair out-ranks the scope shortfall.
- `integrations.route.test.ts`: end-to-end — a short grant answers 400 `SLACK_MISSING_SCOPES` naming the withheld scopes and stores nothing (no bot, no secret, no integration, no daemon push). Pre-existing fakes reporting `scopes: []` now report a full grant: an empty array is a *positively short* grant under the shared diff, and those suites exercise other fences.
- `slack-tooling-credentials.route.test.ts`: the install helper reports a full grant and asserts the install succeeded (a refused install used to surface as a 500 on a `bots/undefined` URL); the verifier-swap test now swaps in its short-grant stub explicitly, which is a stronger read-through claim than relying on the helper's leftover.

## Verification

- `pnpm --filter @agentconnect.md/control-plane typecheck` ✓
- `test:unit` 1340 passed ✓ / `test:int` 1059 passed (full suite, Docker) ✓
- `eslint` + `prettier --check` on touched files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)