### PR TITLE
test(cp): give integration tests headroom over the two 5s timing walls

### DIFF
--- a/packages/control-plane/test/setup.db.ts
+++ b/packages/control-plane/test/setup.db.ts
@@ -23,9 +23,22 @@ if (!connectionString) {
 }
 process.env.DATABASE_URL = connectionString
 
-/** The pool-local client every repo/integration test in this worker uses. */
+/**
+ * The pool-local client every repo/integration test in this worker uses.
+ *
+ * Prisma's interactive-transaction defaults (`timeout` 5s, `maxWait` 2s) are the
+ * second timing wall under this suite, and the one no test can reach: repository
+ * methods open their own `$transaction` internally, so a test that calls
+ * `setPlacement`/`establish` on this root client inherits that 5s budget with no
+ * way to widen it. Under `integrationWorkers` workers sharing one Dockerized
+ * Postgres, a stall long enough to cross it says nothing about the code under
+ * test. Tests that deliberately hold a row or advisory lock open pass their own
+ * explicit `{ timeout: 20_000 }`, which still wins over this default; matching
+ * that number keeps one budget to reason about.
+ */
 export const prisma = new PrismaClient({
-  adapter: new PrismaPg({ connectionString })
+  adapter: new PrismaPg({ connectionString }),
+  transactionOptions: { timeout: 20_000, maxWait: 10_000 }
 })
 
 /**

--- a/packages/control-plane/vitest.config.ts
+++ b/packages/control-plane/vitest.config.ts
@@ -41,7 +41,18 @@ export default defineConfig({
           setupFiles: ['./test/setup.db.ts'],
           maxWorkers: integrationWorkers,
           fileParallelism: true,
-          hookTimeout: 120_000
+          hookTimeout: 120_000,
+          // Vitest's 5s default is a unit-test budget, and it is the FIRST wall a
+          // test here hits: its clock starts before any repo call opens its own
+          // transaction, so a stalled statement always surfaces as an opaque
+          // "Test timed out in 5000ms" rather than the Postgres/Prisma error that
+          // explains it. These tests share one Dockerized Postgres across
+          // `integrationWorkers` workers, so a multi-second stall (a CI runner
+          // whose vCPUs are oversubscribed, a Docker Desktop I/O hiccup) is
+          // ordinary weather, not a hang. 30s stays above the 20s transaction
+          // budget `setup.db.ts` sets, so a genuine lock cycle fails with the real
+          // Prisma error instead of being cut short by this one.
+          testTimeout: 30_000
         }
       }
     ]


### PR DESCRIPTION
## What

Two harness-level timing budgets, no test file changes:

- `packages/control-plane/vitest.config.ts` — the `integration` project gets `testTimeout: 30_000`.
- `packages/control-plane/test/setup.db.ts` — the pool-local `PrismaClient` gets `transactionOptions: { timeout: 20_000, maxWait: 10_000 }`.

## Why

`agent-placement-delegation.test.ts > revokes on a real setPlacement change but not on setPlacement or movePlacement no-ops` failed intermittently when the integration suite ran with the default 4 workers under CPU contention (~5.9s runtime against ~0.6s healthy), while passing reliably when the file ran in isolation.

That test drives no concurrency and reads no clock, so every assertion is deterministic given its fixtures — it can only fail on a timeout. Two 5s budgets sat under it, neither reachable from the test:

1. **Vitest's default `testTimeout`.** The integration project already raises `hookTimeout` to 120s but left this at the unit-test default. It is the *first* wall a test hits, because its clock starts before any repository call opens a transaction — so a stalled statement surfaced as an opaque `Test timed out in 5000ms` instead of the error that explains it.
2. **Prisma's interactive-transaction defaults** (`timeout` 5s, `maxWait` 2s). `setPlacement` / `movePlacement` / `establish` open `$transaction` internally, so a test calling them on the root client has no way to widen it.

This test is the file's canary because it is the only one driving four separate repository transactions plus three reads sequentially on the root client; every other test in the file wraps its work in an explicit `{ timeout: 20_000 }` transaction. Its body measures **62–155 ms** even under 8 workers plus 8 busy loops, so the failure is not gradual slowdown — it takes a multi-second stall (oversubscribed CI vCPUs, a container I/O hiccup), which the 5s wall then converts into a failure.

## Evidence

Stalling the agent row for 9s on a second connection, against the verbatim body of the failing test:

| Configuration | Result |
| --- | --- |
| Before (both defaults) | `Error: Test timed out in 5000ms.`, reported runtime **6890 ms** — reproduces the observed signature |
| `testTimeout` raised only | failure moves to the internal transaction, which closed itself at its own 5s budget (`PrismaClientKnownRequestError` out of `agent.repo.ts` `tx.agent.update()`) |
| After (both raised) | passes, body 8797 ms, all three revocation assertions intact |

## Reviewer notes

- **Nothing the test verifies changed.** The setPlacement / movePlacement revocation semantics are asserted exactly as before; the test file is untouched. The 5s cap asserted nothing about the product.
- **Ordering is deliberate:** 20s transactions under a 30s test budget, so a genuine lock cycle now fails with the real Prisma error rather than being cut short by an opaque test timeout.
- **Explicit options still win.** Tests that deliberately hold a row or advisory lock open (`members.route`, `skill-sources.route`, `personal-org-serialization`, and this file's own concurrency cases) pass their own `{ timeout: 20_000 }`, which overrides the client default. I checked each one releases its blocker explicitly — none rely on the old 5s budget to break a deadlock, and no test asserts on `P2028`/`P2024`.
- The tradeoff is that a true hang now takes 30s to report instead of 5s. That matches the precedent already set by `hookTimeout: 120_000` for the same reason.

## Verification

- `agent-placement-delegation.test.ts` — 8/8 passing, target test 681 ms.
- `typecheck`, `prettier --check`, `eslint` — clean.
- The pre-fix full integration suite passed 75 files / 1073 tests under 8 workers plus 8 busy loops; the equivalent post-fix full run was stopped part-way and is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
