### PR TITLE
perf(control-plane): refresh Logto identity caches ahead of the lease

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -778,7 +778,10 @@ export function buildContainer(
   const logtoMgmtCfg = resolveLogtoMgmtConfig(config)
   const logtoIdentity =
     logtoMgmtCfg && config.OIDC_ISSUER
-      ? new LogtoIdentityService(logtoMgmtCfg, clock, new PgSocialIdentityMutationGate(prisma))
+      ? new LogtoIdentityService(logtoMgmtCfg, clock, new PgSocialIdentityMutationGate(prisma), undefined, {
+          // Lazy over `http.log` (assigned below; only ever called at lookup time).
+          debug: (o, m) => http.log.debug(o, m)
+        })
       : undefined
   const githubUserAuthz =
     github && logtoIdentity

--- a/packages/control-plane/src/github/logto-identity.test.ts
+++ b/packages/control-plane/src/github/logto-identity.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for LogtoIdentityService's access-triggered refresh-ahead (fake
+ * fetch — no Docker, no network). A cache hit past half of the lease it ran
+ * under answers from cache and renews the entry through a background lookup on
+ * the shared in-flight dedupe and epoch fence; the leases themselves stay hard
+ * for first-ever and idle-return reads. The identity projections are covered
+ * by `slack-identity.test.ts`, the GitHub login half and the unlink writes by
+ * `user-authz.test.ts`.
+ */
+import { describe, expect, it } from 'vitest'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+import type { SocialIdentityMutationGate } from '../persistence/ports.js'
+import { LogtoIdentityService } from './logto-identity.js'
+
+const MGMT = { endpoint: 'https://t.logto.app', appId: 'app', appSecret: 'sec', resource: 'https://t.logto.app/api' }
+const MUTATIONS: SocialIdentityMutationGate = {
+  runExclusive: async (_oidcSubject, mutation) => mutation()
+}
+
+type FetchImpl = (url: string, init?: RequestInit) => Promise<Response>
+
+/** A Logto user with a Slack identity in the given workspace. Synthetic ids. */
+function slackUser(teamId = 'T0EXAMPLE1') {
+  const rawData = { 'https://slack.com/team_id': teamId, 'https://slack.com/user_id': 'U0EXAMPLE1' }
+  return { identities: { slack: { userId: 'U0EXAMPLE1', details: { rawData } } } }
+}
+
+/** A Logto user with a GitHub login (plus Google, so an unlink is not blocked
+ *  by the last-sign-in-method guard). */
+function githubUser(login: string) {
+  return { identities: { github: { details: { rawData: { userInfo: { login } } } }, google: { userId: 'g' } } }
+}
+
+/**
+ * Fake Logto: one token endpoint + a mutable user directory. Counts user
+ * reads, and can PARK the `parkRead`-th of them (1-based) until `release()` —
+ * how these tests hold a background refresh in flight. A parked response
+ * carries the directory snapshot from when the request ARRIVED, which is what
+ * a slow provider response delivers.
+ */
+function fakeLogto(users: Record<string, unknown>, opts: { parkRead?: number; onDelete?: () => void } = {}) {
+  const calls = { user: 0 }
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => (release = resolve))
+  let arrived!: () => void
+  const parkedReadArrived = new Promise<void>((resolve) => (arrived = resolve))
+  const fetchImpl: FetchImpl = async (url, init) => {
+    if (url.endsWith('/oidc/token')) return Response.json({ access_token: 'tok', expires_in: 3600 })
+    if (init?.method === 'DELETE') {
+      opts.onDelete?.()
+      return new Response(null, { status: 204 })
+    }
+    calls.user++
+    const snapshot = users[decodeURIComponent(url.split('/').pop()!)]
+    if (calls.user === opts.parkRead) {
+      arrived()
+      await gate
+    }
+    return snapshot ? Response.json(snapshot) : new Response('{}', { status: 404 })
+  }
+  return { fetchImpl, calls, release: () => release(), parkedReadArrived }
+}
+
+const svcOf = (fetchImpl: FetchImpl, clock: FakeClock) => new LogtoIdentityService(MGMT, clock, MUTATIONS, fetchImpl)
+
+/** Drain a (released) background refresh — the fakes settle in micro/macrotasks,
+ *  never on real timers, so a few event-loop turns are enough. */
+async function settled(): Promise<void> {
+  for (let i = 0; i < 4; i++) await new Promise((resolve) => setImmediate(resolve))
+}
+
+describe('LogtoIdentityService refresh-ahead', () => {
+  it('a qualifying hit past the half-lease answers from cache and renews behind the caller', async () => {
+    const clock = new FakeClock(0)
+    const { fetchImpl, calls, release, parkedReadArrived } = fakeLogto({ 'sub-1': slackUser() }, { parkRead: 2 })
+    const svc = svcOf(fetchImpl, clock)
+
+    await svc.slackIdentityFor('sub-1') // the first-ever read blocks — that is the lease speaking
+    expect(calls.user).toBe(1)
+
+    // Age 61 s: satisfies the 120 s provider-identity cap, past its 60 s half.
+    // The renewal is PARKED upstream, so these resolving proves callers never
+    // wait on it — and two triggers coalesce onto ONE in-flight lookup.
+    clock.advance(61_000)
+    await expect(svc.slackIdentityFor('sub-1')).resolves.toMatchObject({ teamId: 'T0EXAMPLE1' })
+    await expect(svc.slackIdentityFor('sub-1')).resolves.toMatchObject({ teamId: 'T0EXAMPLE1' })
+    await parkedReadArrived
+    expect(calls.user).toBe(2)
+
+    release()
+    await settled()
+    expect(calls.user).toBe(2)
+
+    // The refresh renewed fetchedAt: this read sits 120 s past the ORIGINAL
+    // fetch (a blocking miss before this change) but 59 s past the renewal —
+    // a quiet cache hit, no third lookup.
+    clock.advance(59_000)
+    await expect(svc.slackIdentityFor('sub-1')).resolves.toMatchObject({ teamId: 'T0EXAMPLE1' })
+    expect(calls.user).toBe(2)
+  })
+
+  it('a read past the full lease still blocks and fetches — the lease stays hard', async () => {
+    const clock = new FakeClock(0)
+    const users: Record<string, unknown> = { 'sub-1': slackUser('T0BEFORE00') }
+    const { fetchImpl, calls } = fakeLogto(users)
+    const svc = svcOf(fetchImpl, clock)
+
+    await svc.slackIdentityFor('sub-1')
+    clock.advance(120_001) // idle return: the entry can no longer satisfy the 120 s cap
+    users['sub-1'] = slackUser('T0AFTER000')
+
+    // Served-then-refreshed would hand back the stale workspace; blocking does not.
+    await expect(svc.slackIdentityFor('sub-1')).resolves.toMatchObject({ teamId: 'T0AFTER000' })
+    expect(calls.user).toBe(2)
+  })
+
+  it('a display read (no caller cap) refreshes against its own 10 min lease, not the 120 s one', async () => {
+    const clock = new FakeClock(0)
+    const { fetchImpl, calls } = fakeLogto({ 'sub-1': slackUser() })
+    const svc = svcOf(fetchImpl, clock)
+
+    await svc.socialAccountFor('sub-1')
+    clock.advance(61_000) // far past the identity half-lease, nowhere near half of 10 min
+    await svc.socialAccountFor('sub-1')
+    await settled()
+    expect(calls.user).toBe(1)
+
+    clock.advance(240_000) // age 301 s — past half of the 10 min positive TTL
+    await svc.socialAccountFor('sub-1')
+    await settled()
+    expect(calls.user).toBe(2)
+  })
+
+  it('forgetUser racing an in-flight background refresh keeps the refreshed result out of the cache', async () => {
+    const clock = new FakeClock(0)
+    const users: Record<string, unknown> = { 'sub-1': slackUser('T0BEFORE00') }
+    const { fetchImpl, calls, release, parkedReadArrived } = fakeLogto(users, { parkRead: 2 })
+    const svc = svcOf(fetchImpl, clock)
+
+    await svc.slackIdentityFor('sub-1')
+    clock.advance(61_000)
+    await svc.slackIdentityFor('sub-1') // serves the cache, parks the background refresh
+    await parkedReadArrived
+
+    // While the refresh is parked holding a PRE-change snapshot, the identity
+    // changes at the provider and the console announces it (forgetUser).
+    users['sub-1'] = slackUser('T0AFTER000')
+    svc.forgetUser('sub-1')
+    release()
+    await settled()
+
+    // The refresh settled after the invalidation, so the epoch fence dropped
+    // its result; the next read fetches and sees the post-change world.
+    await expect(svc.slackIdentityFor('sub-1')).resolves.toMatchObject({ teamId: 'T0AFTER000' })
+    expect(calls.user).toBe(3)
+  })
+
+  it('an unlink invalidation racing a background login refresh wins — the stale login never returns', async () => {
+    const clock = new FakeClock(0)
+    const users: Record<string, unknown> = { 'sub-1': githubUser('octocat') }
+    const { fetchImpl, calls, release, parkedReadArrived } = fakeLogto(users, {
+      parkRead: 2,
+      onDelete: () => (users['sub-1'] = { identities: { google: { userId: 'g' } } })
+    })
+    const svc = svcOf(fetchImpl, clock)
+
+    await expect(svc.githubLoginFor('sub-1', 120_000)).resolves.toBe('octocat')
+    clock.advance(61_000)
+    // Qualifying hit under the caller's 120 s cap — parks the background refresh.
+    await expect(svc.githubLoginFor('sub-1', 120_000)).resolves.toBe('octocat')
+    await parkedReadArrived
+
+    // The unlink's own read/check/delete passes the gate (only read #2 parks)
+    // and lands its invalidation while the refresh is still in flight.
+    await svc.unlinkSocialIdentity('sub-1', 'github')
+    release()
+    await settled()
+
+    // The parked refresh carried the pre-unlink login; the fence kept it out,
+    // so the next read fetches the post-unlink account.
+    await expect(svc.githubLoginFor('sub-1', 120_000)).resolves.toBeNull()
+    expect(calls.user).toBe(4)
+  })
+
+  it('a negative entry refreshes ahead too, flipping to the just-linked login without a blocking read', async () => {
+    const clock = new FakeClock(0)
+    const users: Record<string, unknown> = {}
+    const { fetchImpl, calls } = fakeLogto(users)
+    const svc = svcOf(fetchImpl, clock)
+
+    await expect(svc.githubLoginFor('sub-1', 120_000)).resolves.toBeNull() // 404 → negative entry
+    expect(calls.user).toBe(1)
+
+    // 31 s: inside the 60 s negative window, past ITS half — the negative TTL,
+    // tighter than the caller's 120 s cap, is the lease that counts here. The
+    // hit itself still answers null: refresh-ahead does not shorten (or
+    // extend) what the negative lease promises.
+    clock.advance(31_000)
+    users['sub-1'] = githubUser('late')
+    await expect(svc.githubLoginFor('sub-1', 120_000)).resolves.toBeNull()
+    await settled()
+    expect(calls.user).toBe(2)
+
+    // The background refresh replaced the miss with the just-linked login.
+    await expect(svc.githubLoginFor('sub-1', 120_000)).resolves.toBe('late')
+    expect(calls.user).toBe(2)
+  })
+})

--- a/packages/control-plane/src/github/logto-identity.ts
+++ b/packages/control-plane/src/github/logto-identity.ts
@@ -14,8 +14,11 @@
  *
  * Caching: the M2M token until 60s before expiry; display/GitHub projections
  * keep a 10 min positive / 60 s negative user cache, while provider authorization
- * caps reuse of a positive assertion at 2 min. Lookups are single-flight and
- * fail CLOSED at their authorization callers.
+ * caps reuse of a positive assertion at 2 min. A hit past half of the lease it
+ * ran under also renews the entry in the background (refresh-ahead), so an
+ * entry read at least once per half-lease never ages into a blocking refetch —
+ * the leases themselves stay hard for first-ever and idle-return reads.
+ * Lookups are single-flight and fail CLOSED at their authorization callers.
  */
 import type { Clock } from '../domain/clock.js'
 import type { SocialIdentityMutationGate } from '../persistence/ports.js'
@@ -75,9 +78,14 @@ const NEGATIVE_TTL_MS = 60_000
 // Provider identity participates in live Session authorization. Even if no
 // in-product unlink invalidation fires (for example an administrator changes
 // the Logto account directly), a positive assertion is never reused beyond
-// this hard lease.
-const PROVIDER_IDENTITY_TTL_MS = 120_000
-const TIMEOUT_MS = 10_000
+// this hard lease. Exported so callers holding provider identity evidence of
+// their own (the GitHub session-access login leg) can join the same lease
+// instead of inventing a second number.
+export const PROVIDER_IDENTITY_TTL_MS = 120_000
+// Bounds the BLOCKING lookups (first-ever read, idle return past a lease) —
+// refresh-ahead keeps actively-read entries off that path, so a hung upstream
+// can pin a request for at most this long, and only a cold one.
+const TIMEOUT_MS = 5_000
 // How long a target's link mode is trusted. Short enough that a Logto upgrade
 // which fixes a connector is picked up the same day, long enough that the probe
 // is not per click.
@@ -93,6 +101,19 @@ interface CachedUser {
   user: LogtoUser | null
   fetchedAt: number
   expiresAt: number
+}
+
+/**
+ * Should a hit that satisfied its caller also renew the entry in the
+ * background? Yes once the entry is past HALF the lease the read ran under —
+ * the tighter of the entry's own window (positive or negative TTL) and the
+ * caller's `maxAgeMs` cap. E.g. a provider-identity read (120 s cap) starts
+ * refreshing at 60 s, so a subject read at least once a minute never ages out.
+ * Strictly greater than: at exactly half the lease the hit is still quiet.
+ */
+function refreshAheadDue(cached: { fetchedAt: number; expiresAt: number }, now: number, maxAgeMs?: number): boolean {
+  const leaseMs = Math.min(cached.expiresAt - cached.fetchedAt, maxAgeMs ?? Number.POSITIVE_INFINITY)
+  return now - cached.fetchedAt > leaseMs / 2
 }
 
 /** One linked sign-in method, narrowed to what the Profile card renders. The
@@ -232,7 +253,8 @@ export class LogtoIdentityService {
     private readonly cfg: LogtoMgmtConfig,
     private readonly clock: Clock,
     private readonly mutations: SocialIdentityMutationGate,
-    private readonly fetchImpl: FetchLike = fetch as FetchLike
+    private readonly fetchImpl: FetchLike = fetch as FetchLike,
+    private readonly log?: { debug(obj: object, msg: string): void }
   ) {}
 
   /**
@@ -244,8 +266,15 @@ export class LogtoIdentityService {
     const cached = this.logins.get(sub)
     const now = this.clock.now()
     if (cached && cached.expiresAt > now && (maxAgeMs === undefined || now - cached.fetchedAt < maxAgeMs)) {
+      if (refreshAheadDue(cached, now, maxAgeMs)) this.refreshInBackground(sub, () => this.pendingLogin(sub))
       return cached.login
     }
+    return this.pendingLogin(sub)
+  }
+
+  /** The deduped in-flight login lookup — one upstream read serves every
+   *  concurrent caller, blocking miss and refresh-ahead alike. */
+  private pendingLogin(sub: string): Promise<string | null> {
     let pending = this.loginInFlight.get(sub)
     if (!pending) {
       const tracked: Promise<string | null> = this.lookupLogin(sub).finally(() => {
@@ -321,8 +350,15 @@ export class LogtoIdentityService {
     const cached = this.users.get(sub)
     const now = this.clock.now()
     if (cached && cached.expiresAt > now && (maxAgeMs === undefined || now - cached.fetchedAt < maxAgeMs)) {
+      if (refreshAheadDue(cached, now, maxAgeMs)) this.refreshInBackground(sub, () => this.pendingUser(sub))
       return cached.user
     }
+    return this.pendingUser(sub)
+  }
+
+  /** The deduped in-flight user lookup — one upstream read serves every
+   *  concurrent caller, blocking miss and refresh-ahead alike. */
+  private pendingUser(sub: string): Promise<LogtoUser | null> {
     let pending = this.userInFlight.get(sub)
     if (!pending) {
       const tracked: Promise<LogtoUser | null> = this.lookupUser(sub).finally(() => {
@@ -334,6 +370,19 @@ export class LogtoIdentityService {
       this.userInFlight.set(sub, pending)
     }
     return pending
+  }
+
+  /**
+   * Fire-and-forget renewal behind a served cache hit. Routed through the same
+   * in-flight dedupe as a blocking miss (concurrent triggers coalesce onto one
+   * fetch) and through the same epoch-checked lookups (a refresh in flight
+   * across an invalidation is returned to nobody and never cached). A failure
+   * is only debug-logged: the entry it would have replaced is still within its
+   * lease, and once that runs out the blocking path surfaces the same error to
+   * a caller that can act on it.
+   */
+  private refreshInBackground(sub: string, lookup: () => Promise<unknown>): void {
+    void lookup().catch((err: unknown) => this.log?.debug({ err, sub }, 'logto refresh-ahead lookup failed'))
   }
 
   /**

--- a/packages/control-plane/src/github/user-authz.test.ts
+++ b/packages/control-plane/src/github/user-authz.test.ts
@@ -214,9 +214,14 @@ function authz(opts: {
   // entry's start time and read a falsy one as "no TTL", which would make every
   // entry immortal and quietly pass the expiry assertions below (see `cache.ts`).
   const clock = new FakeClock(EPOCH)
-  const calls = { permission: 0 }
+  const calls = { permission: 0, loginCaps: [] as Array<number | undefined> }
   const svc = new GithubUserAuthzService({
-    identity: { githubLoginFor: async () => opts.login ?? null },
+    identity: {
+      githubLoginFor: async (_sub, maxAgeMs) => {
+        calls.loginCaps.push(maxAgeMs)
+        return opts.login ?? null
+      }
+    },
     users: { getOidcSubject: async () => (opts.sub === undefined ? 'sub-1' : opts.sub) },
     github: {
       getRepoMeta: async () => (opts.repo === undefined ? { private: true } : opts.repo),
@@ -320,6 +325,23 @@ describe('GithubUserAuthzService', () => {
 
     await svc.permissionForUser('u1', INS, 'o', 'r', { maxCacheAgeMs: 0 })
     expect(calls.permission).toBe(2)
+  })
+
+  it('splits the caps: the login leg rides the identity lease while the permission is re-proved', async () => {
+    const { svc, calls } = authz({ login: 'me', permission: 'read' })
+
+    await svc.permissionForUser('u1', INS, 'o', 'r', { maxCacheAgeMs: 0, loginMaxAgeMs: 120_000 })
+    await svc.permissionForUser('u1', INS, 'o', 'r', { maxCacheAgeMs: 0, loginMaxAgeMs: 120_000 })
+    // The identity leg may accept a ≤120 s cached login — it answers "which
+    // GitHub account", invalidated on link/unlink — while the permission, the
+    // revocable fact, is still re-proved against GitHub on every call.
+    expect(calls.loginCaps).toEqual([120_000, 120_000])
+    expect(calls.permission).toBe(2)
+
+    // One cap without the split option keeps its old both-legs meaning.
+    await svc.permissionForUser('u1', INS, 'o', 'r', { maxCacheAgeMs: 0 })
+    expect(calls.loginCaps).toEqual([120_000, 120_000, 0])
+    expect(calls.permission).toBe(3)
   })
 
   it('filters the repo list: public stays, readable private stays, no-access private drops', async () => {

--- a/packages/control-plane/src/github/user-authz.ts
+++ b/packages/control-plane/src/github/user-authz.ts
@@ -165,15 +165,23 @@ export class GithubUserAuthzService {
 
   /** Resolve only the user's effective permission. Callers that already
    * verified repository metadata can cap or bypass this service's picker cache
-   * instead of extending a shorter authorization lease. */
+   * instead of extending a shorter authorization lease.
+   *
+   * The two legs answer different questions and may carry different caps:
+   * `maxCacheAgeMs` bounds the GitHub permission evidence ("does that account
+   * still have access" — the revocable fact), while `loginMaxAgeMs` bounds the
+   * Logto login resolution ("which GitHub account is linked" — identity
+   * metadata that changes only through link/unlink, which invalidate the cache
+   * anyway). It defaults to `maxCacheAgeMs`, so a single cap keeps its old
+   * both-legs meaning. */
   async permissionForUser(
     userId: string,
     ins: GithubInstallationRecord,
     owner: string,
     repo: string,
-    options: { maxCacheAgeMs?: number } = {}
+    options: { maxCacheAgeMs?: number; loginMaxAgeMs?: number } = {}
   ): Promise<RepoPermission> {
-    const login = await this.loginOf(userId, options.maxCacheAgeMs)
+    const login = await this.loginOf(userId, options.loginMaxAgeMs ?? options.maxCacheAgeMs)
     return this.permissionOf(login, ins, owner, repo, options.maxCacheAgeMs)
   }
 

--- a/packages/control-plane/src/http/github-session-access.test.ts
+++ b/packages/control-plane/src/http/github-session-access.test.ts
@@ -102,8 +102,11 @@ describe('GithubSessionAccessService', () => {
     )
 
     expect((await allowed.service.resolve([scope], viewer)).allowedScopes).toHaveLength(1)
+    // The permission itself is demanded age-zero; the login resolution rides
+    // the same 120 s identity lease as the Slack/Feishu session-access checks.
     expect(allowed.permissionForUser).toHaveBeenCalledWith('user-1', installation, 'acme', 'private-repo', {
-      maxCacheAgeMs: 0
+      maxCacheAgeMs: 0,
+      loginMaxAgeMs: 120_000
     })
     await expect(denied.service.resolve([scope], viewer)).resolves.toEqual({
       allowedScopes: [],

--- a/packages/control-plane/src/http/github-session-access.ts
+++ b/packages/control-plane/src/http/github-session-access.ts
@@ -4,6 +4,7 @@ import type { Clock } from '../domain/clock.js'
 import { OrgId } from '../domain/ids.js'
 import type { ExternalScopeRecord, GithubInstallationRecord, GithubInstallationRepo } from '../persistence/ports.js'
 import type { GithubService } from '../github/service.js'
+import { PROVIDER_IDENTITY_TTL_MS } from '../github/logto-identity.js'
 import { UserAuthzDeniedError, type GithubUserAuthzService } from '../github/user-authz.js'
 import type { SessionAccessPlugin, SessionAccessResult, SessionAccessViewer } from './session-access-plugin.js'
 
@@ -152,7 +153,13 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
         else
           decision =
             (await this.deps.userAuthz.permissionForUser(userId, installation, owner, name, {
-              maxCacheAgeMs: 0
+              // The permission is the revocable fact — demand it age-zero.
+              // WHICH GitHub account the viewer is, is identity metadata that
+              // changes only through link/unlink (both invalidate the cache),
+              // so it rides the same 120 s identity lease the Slack and Feishu
+              // session-access plugins already run on.
+              maxCacheAgeMs: 0,
+              loginMaxAgeMs: PROVIDER_IDENTITY_TTL_MS
             })) !== 'none'
               ? 'allow'
               : 'deny'


### PR DESCRIPTION
## Problem

The CP calls Logto's Management API `GET /api/users/{sub}` roughly 1,900 times a day, at p50 ~377 ms / p95 ~1.1 s, with the worst calls hitting the client timeout. About 99% of that volume is the session read path — `/sessions`, `/sessions/facets`, `/usage` and their snapshot background refreshes — via `viewerFor` resolving the viewer's linked Slack/Feishu identities and the GitHub session-access plugin resolving the viewer's GitHub login. The latency floor is on the upstream side (even a warm-connection gateway 401 costs ~210–250 ms), so the fix is to stop *waiting* on these calls, not to make them faster.

Today the identity caches in `logto-identity.ts` are expire-then-block: entries carry `fetchedAt` + TTL, and the first read after expiry blocks a user-facing request on the round trip.

## Change 1 — access-triggered refresh-ahead within the lease

On a cache read that **satisfies the caller's freshness constraint** but whose entry age exceeds half the lease the read ran under (the tighter of the entry's own TTL window and the caller's `maxAgeMs` cap — e.g. 60 s against the 120 s `PROVIDER_IDENTITY_TTL_MS`), the cached value is returned immediately and the corresponding lookup fires in the background.

Properties preserved:

- **No lease loosens.** `PROVIDER_IDENTITY_TTL_MS`, `LOGIN_TTL_MS`, and `NEGATIVE_TTL_MS` keep their values and meanings. A read the entry can *not* satisfy (first-ever lookup, idle return past the lease) still blocks and fetches — that block is the lease speaking. The win is that entries touched at least once per half-lease never age past the lease, so active viewers never block.
- **The background refresh is just another lookup.** It routes through the existing `userInFlight` / `loginInFlight` dedupe (concurrent triggers coalesce onto one fetch) and the existing epoch fence (`lookupUser` / `lookupLogin` check the epoch before caching, so a refresh in flight across `invalidate()` / `forgetUser()` cannot write a removed identity back). The fence itself is untouched; the in-flight registration blocks were extracted verbatim into `pendingUser` / `pendingLogin` so both the blocking-miss path and the refresh-ahead path share them.
- A failed background refresh is debug-logged and otherwise ignored: the entry it would have replaced is still within its lease, and once that runs out the blocking path surfaces the same error to a caller that can act on it.
- Link/unlink invalidation paths are untouched — already immediate and epoch-fenced.

## Change 2 — split the caps in the GitHub session-access leg

`GithubSessionAccessService` called `permissionForUser(..., { maxCacheAgeMs: 0 })`, and that single cap applied to two different legs inside `GithubUserAuthzService`:

- `loginOf` → `githubLoginFor` — a **Logto** call answering "which GitHub account is linked": identity metadata that changes only at link/unlink, both of which invalidate through the CP. The Slack and Feishu equivalents already run on the 120 s `PROVIDER_IDENTITY_TTL_MS` lease.
- `permissionOf` — a **GitHub** call answering "does that account still have access to this repo": the genuinely revocable authorization fact.

A cap of 0 demands age-zero evidence, which forces the blocking Logto fetch no matter how warm the cache is — defeating refresh-ahead at exactly the hottest call site. `permissionForUser` now takes a separate `loginMaxAgeMs` (defaulting to `maxCacheAgeMs`, so the single-cap shape keeps its old meaning), and the plugin passes `{ maxCacheAgeMs: 0, loginMaxAgeMs: PROVIDER_IDENTITY_TTL_MS }`: GitHub identity evidence joins the same 120 s identity-lease regime Slack and Feishu already use, while the permission check's freshness is untouched — no revocation window widens.

## Change 3 — bound the blocking case

`TIMEOUT_MS` in `logto-identity.ts` drops from 10 s to 5 s. Production maxima showed real hangs reaching the old cap; the remaining blocking fetches (first-ever, idle-return) should not be able to pin a request for 10 s.

## Explicitly out of scope

**No DB persistence of identity evidence.** That is Phase 2, deferred until one of its actual triggers appears: CP multi-replica, post-deploy cold-start herds hitting Logto rate limits, or a requirement to keep serving through a Logto outage. In-memory already captures the full latency win because the freshness mechanism, not the storage layer, is what takes Logto off the request path — persistence would only change who pays on a cold start.

No TTL constant changes (other than `TIMEOUT_MS`), no webhooks, no Logto topology changes.

## Tests

- New `logto-identity.test.ts` (FakeClock + fake fetch, with a parkable upstream read to hold a background refresh in flight):
  - a qualifying hit past the half-lease answers from cache while the refresh is parked, concurrent triggers coalesce onto one lookup, and the settled refresh renews `fetchedAt`;
  - a read past the full lease still blocks and fetches;
  - a display read (no caller cap) refreshes against its own 10 min lease, not the 120 s one;
  - `forgetUser` and an unlink `invalidate()` racing an in-flight background refresh: the fenced result is never cached and the next read sees the post-change identity;
  - negative entries participate in refresh-ahead (a just-linked login appears without a blocking read) without extending `NEGATIVE_TTL_MS` semantics.
- `user-authz.test.ts`: the split — the login leg receives `loginMaxAgeMs` while the permission leg is re-proved per call; a single `maxCacheAgeMs` still caps both legs; the existing picker-cache-bypass test is unchanged.
- `github-session-access.test.ts`: the plugin's call shape is now `{ maxCacheAgeMs: 0, loginMaxAgeMs: 120_000 }`.

## Post-deploy observable

Foreground Logto calls attributed to session endpoints should drop toward zero in tracing; `GET /api/users/{sub}` volume stays roughly flat but shifts to background refreshes.

## Verification

- `pnpm --filter @agentconnect.md/control-plane typecheck` / `test:unit` (1349 passed) / `test:int`
- `pnpm exec eslint` and `pnpm exec prettier --check` on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
