### PR TITLE
fix(release): track the shared observability package in every release input set

### DIFF
--- a/scripts/component-versions.sh
+++ b/scripts/component-versions.sh
@@ -48,10 +48,10 @@ esac
 # .npmrc), the build-context filter (.dockerignore), and the shared tsconfig
 # every package build extends.
 COMMON="docker/Dockerfile docker-bake.hcl .dockerignore .npmrc .pnpmfile.mjs pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.base.json scripts"
-CP_PATHS="packages/control-plane packages/setup packages/protocol $COMMON"
+CP_PATHS="packages/control-plane packages/setup packages/protocol packages/observability $COMMON"
 SETUP_PATHS="$CP_PATHS"
 WEB_PATHS="packages/web $COMMON"
-RELAY_PATHS="packages/relay packages/message packages/protocol packages/connection $COMMON"
+RELAY_PATHS="packages/relay packages/message packages/protocol packages/connection packages/observability $COMMON"
 MEM0_PATHS="packages/memory-plugin-mem0 packages/protocol $COMMON"
 # The backend's application source is the immutable external context declared in
 # docker-bake.hcl. Changes to that pin, its owned Dockerfile, or this resolver

--- a/scripts/publish-setup-if-changed.sh
+++ b/scripts/publish-setup-if-changed.sh
@@ -30,8 +30,8 @@ esac
 # component-versions.sh. The image embeds this package, so whenever those bits
 # rebuild, npm receives the same version that the image reports.
 COMMON="docker/Dockerfile docker-bake.hcl .dockerignore .npmrc .pnpmfile.mjs pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.base.json scripts"
-SETUP_PATHS="packages/control-plane packages/setup packages/protocol $COMMON"
-SETUP_IMPORTERS="packages/setup packages/control-plane packages/protocol"
+SETUP_PATHS="packages/control-plane packages/setup packages/protocol packages/observability $COMMON"
+SETUP_IMPORTERS="packages/setup packages/control-plane packages/protocol packages/observability"
 
 if [ -n "$LAST_TAG" ] && git rev-parse -q --verify "${LAST_TAG}^{commit}" > /dev/null; then
   # shellcheck disable=SC2086
@@ -49,6 +49,7 @@ fi
 if [ "$MODE" = prepare ]; then
   cd "$REPO_ROOT"
   pnpm --filter @agentconnect.md/protocol build
+  pnpm --filter @agentconnect.md/observability build
   pnpm --filter @agentconnect.md/control-plane build
   cd "$REPO_ROOT/packages/setup"
   pnpm exec json -I -f package.json -e "this.version='$VALUE'"


### PR DESCRIPTION
## What broke

The release job fails on `main` after #783:

```
src/observability.ts: TS2307: Cannot find module '@agentconnect.md/observability'
src/index.ts:         TS7006: Parameter 'otelErr' implicitly has an 'any' type
```

The second is a cascade of the first — the unresolved module makes `telemetry` `any`, so the `.catch` callback parameter is implicitly `any`.

`scripts/publish-setup-if-changed.sh` builds `protocol` then `control-plane`. The control plane's `build` is a plain `tsc -p tsconfig.json`, which resolves `@agentconnect.md/observability` to its **dist** rather than to the `development` export — and nothing had built that dist.

## Fix

Handled the way `connection` already is: named explicitly in the build sequence and in the change-detection sets, not derived from the dependency graph.

```diff
   pnpm --filter @agentconnect.md/protocol build
+  pnpm --filter @agentconnect.md/observability build
   pnpm --filter @agentconnect.md/control-plane build
```

```diff
-SETUP_PATHS="packages/control-plane packages/setup packages/protocol $COMMON"
-SETUP_IMPORTERS="packages/setup packages/control-plane packages/protocol"
+SETUP_PATHS="… packages/protocol packages/observability $COMMON"
+SETUP_IMPORTERS="… packages/control-plane packages/protocol packages/observability"
```

## The same omission in the sibling resolver

Caught in review, and the more serious half. `publish-setup-if-changed.sh` carries a comment telling you to keep its path set identical to the Control Plane image input set in `component-versions.sh` — and that file had the shared package missing from two sets:

```diff
-CP_PATHS="packages/control-plane packages/setup packages/protocol $COMMON"
+CP_PATHS="packages/control-plane packages/setup packages/protocol packages/observability $COMMON"
-RELAY_PATHS="packages/relay packages/message packages/protocol packages/connection $COMMON"
+RELAY_PATHS="packages/relay packages/message packages/protocol packages/connection packages/observability $COMMON"
```

`SETUP_PATHS` is an alias of `CP_PATHS`, so it inherits the fix. Both the control plane and the relay depend on the shared package and the Dockerfile builds it into both images, so this decides whether an image is rebuilt at all — and `component-versions.sh` says what that costs:

> under-including silently ships a stale image under a new version, so err on the side of more

Replaying `effective()`'s predicate over a synthetic release whose only change is under `packages/observability/`:

| component | before | after |
|---|---|---|
| controlPlane / setup | `unchanged` → stale image | `REBUILD` |
| relay | `unchanged` → stale image | `REBUILD` |

So the failure mode was worse than the build break this PR started from: the build break is loud, this one ships a new version tag pointing at an image built from the old shared package.

## Why three checks missed the build break

| check | why it passed |
|---|---|
| `typecheck` | uses `tsconfig.typecheck.json` with `customConditions: ["development"]`, so it resolved to `src/` |
| repo-wide `pnpm build` | `pnpm -r` orders by the dependency graph on its own |
| both container images | their build lists **were** updated in #783 |
| **release** | the two remaining lists, left stale |

## Testing

Build sequence — cleared `dist/` for observability, protocol and control-plane, then ran the script's prepare sequence on top of current `main`, followed by the setup build it feeds:

```
protocol: ok
observability: ok
control-plane: ok
setup: Build complete · setup bundle is self-contained
```

Resolver — the table above, produced by replaying the real `git diff --name-only … -- $paths` predicate against a commit touching only the shared package. `bash -n` clean on both scripts.

## Not fixed here

`WEB_PATHS` omits `packages/protocol`, though web depends on it and the web image stage builds it — so a protocol-only release ships a stale web image by the same mechanism. Pre-existing and unrelated to the shared package, so it is left for its own change rather than folded in here.
