### PR TITLE
docs: add a comment-style rule to CLAUDE.md / AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,13 @@ A few detail/list views keep an `if (isMobile) return (…)` fork where the two
 form factors differ in **features or interaction**, not just layout — when you
 touch one branch, keep the other in sync.
 
+## Comment style
+
+Prefer one-line comments. Do not write multiline comment blocks — if a comment
+does not fit on one line, tighten it until it does. When code you are touching
+carries a verbose comment, including a pre-existing one, condense it to a single
+line instead of leaving it as is.
+
 ## Commands
 
 Requires **Node >= 24.12.0** (`.nvmrc` = 24.12.0) and **pnpm 11**.


### PR DESCRIPTION
## Summary

Adds a **Comment style** section to `CLAUDE.md` (and therefore `AGENTS.md`, which symlinks to it) so coding agents follow one comment convention:

- Prefer one-line comments; do not write multiline comment blocks.
- If a comment does not fit on one line, tighten it until it does.
- When touching code that carries a verbose comment — including pre-existing ones — condense it to a single line instead of leaving it as is.

Docs-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)