### PR TITLE
feat(memory): channel memory scope — per-channel folders (backend)

### DIFF
--- a/packages/daemon/src/agents/memory-provider.ts
+++ b/packages/daemon/src/agents/memory-provider.ts
@@ -42,7 +42,7 @@ import { MEMORY_TOOLS, externalMemoryTools } from '../mcp/tools.js'
 import {
   ensureMemory,
   readIndex,
-  readMemoryFile,
+  readMemoryFileIfPresent,
   writeMemoryFile,
   listMemory,
   listMemoryHistory,
@@ -398,10 +398,12 @@ export class ManagedMemoryProvider implements MemoryProvider {
   }
 
   async read(scope: MemoryScope, path: string): Promise<MemoryReadResult> {
-    // Channel layer shadows the base: return the first root that has the file.
+    // Channel layer shadows the base: return the first root that HAS the file.
+    // Existence (not emptiness) decides — an intentionally-empty channel file must
+    // still shadow a non-empty base file rather than fall through.
     for (const root of this.readRoots(scope)) {
-      const content = await readMemoryFile(root, path)
-      if (content !== '') return { path, content }
+      const content = await readMemoryFileIfPresent(root, path)
+      if (content !== null) return { path, content }
     }
     return { path, content: '' }
   }

--- a/packages/daemon/src/agents/memory-provider.ts
+++ b/packages/daemon/src/agents/memory-provider.ts
@@ -46,8 +46,12 @@ import {
   writeMemoryFile,
   listMemory,
   listMemoryHistory,
+  channelMemoryRoot,
+  writeChannelMemoryMeta,
+  MEMORY_INDEX,
   MemoryConflictError,
   MemoryTooLargeError,
+  type MemoryFile,
   type MemoryWriteSource,
   type ManagedMemoryHistoryPage
 } from './memory.js'
@@ -76,10 +80,19 @@ export type MemoryRecord = CanonicalMemoryRecord
 /** The provider kind an agent is configured with (protocol `memory.provider`). */
 export type MemoryProviderKind = 'none' | 'native' | 'managed' | 'external'
 
-/** The context key every memory op carries. `managed` uses `agentId` only today;
- *  `userId`/`sessionId` are reserved for per-scope partitioning in later providers. */
+/** The context key every memory op carries. `managed` routes by `agentId`, and by
+ *  `channelKey` when the agent's memory scope is `channel` (#653): reads overlay the
+ *  agent-level base + the channel folder, writes/capture go to the channel folder.
+ *  `userId`/`sessionId` are reserved for later providers. */
 export interface MemoryScope {
   agentId: string
+  /** A filesystem-safe per-channel folder name (channel + transport scope), set by
+   *  the daemon only for channel-scoped agents. Absent ⇒ agent-level store. */
+  channelKey?: string
+  /** Raw source identity for the channel folder, recorded once so the console can
+   *  render a name instead of the opaque key. Only meaningful with `channelKey`. */
+  channel?: string
+  transportScope?: string
   userId?: string
   sessionId?: string
 }
@@ -288,6 +301,22 @@ export class ManagedMemoryProvider implements MemoryProvider {
     return dir
   }
 
+  /** The write/active memory root: the channel folder when channel-scoped, else the
+   *  agent base. All WRITES (tools + distillation) target this so a channel's
+   *  content never lands in another channel or the shared base (#653). */
+  private activeRoot(scope: MemoryScope): string {
+    const base = this.dirFor(scope.agentId)
+    return scope.channelKey ? channelMemoryRoot(base, scope.channelKey) : base
+  }
+
+  /** The read overlay roots, most-specific first — `[channel, base]` when channel-
+   *  scoped so the channel layer shadows the shared base per file; `[base]`
+   *  otherwise. */
+  private readRoots(scope: MemoryScope): string[] {
+    const base = this.dirFor(scope.agentId)
+    return scope.channelKey ? [channelMemoryRoot(base, scope.channelKey), base] : [base]
+  }
+
   // Managed keeps a single store: turn OFF any verified runtime-owned memory so
   // the agent doesn't end up with two competing stores. Unknown harnesses retain
   // managed support; adding a real native-memory feature requires a registry entry.
@@ -296,11 +325,27 @@ export class ManagedMemoryProvider implements MemoryProvider {
   }
 
   ensure(scope: MemoryScope, agentName: string): void {
-    ensureMemory(this.dirFor(scope.agentId), agentName)
+    ensureMemory(this.activeRoot(scope), agentName)
+    // Record the source identity of a channel folder once, so the console can name
+    // it. Best-effort and off the critical path — a failure never blocks memory.
+    if (scope.channelKey && scope.channel) {
+      void writeChannelMemoryMeta(this.dirFor(scope.agentId), scope.channelKey, {
+        channel: scope.channel,
+        ...(scope.transportScope ? { transportScope: scope.transportScope } : {})
+      }).catch(() => {})
+    }
   }
 
   async standingContextAtSessionStart(scope: MemoryScope): Promise<string> {
-    return readIndex(this.dirFor(scope.agentId))
+    // Overlay: inject the shared base index first, then the channel index, so the
+    // agent sees "shared knowledge + this channel" as one memory (#653).
+    const ordered = [...this.readRoots(scope)].reverse() // [base] or [base, channel]
+    const parts: string[] = []
+    for (const root of ordered) {
+      const index = (await readIndex(root)).trim()
+      if (index) parts.push(index)
+    }
+    return parts.join('\n\n')
   }
 
   async recallForTurn(): Promise<MemoryRecord[]> {
@@ -313,7 +358,9 @@ export class ManagedMemoryProvider implements MemoryProvider {
 
   async recordTurn(scope: MemoryScope, turn: TurnRecord): Promise<void> {
     if (!this.autoDistillFor(scope.agentId) || !this.extract) return
-    const dir = this.dirFor(scope.agentId)
+    // Per-turn distillation is a WRITE: it goes to the active (channel) folder so a
+    // channel's turns never distill into the shared base or another channel (#653).
+    const dir = this.activeRoot(scope)
     const prompt = await buildDistillationPrompt(dir, turn)
     const output = await this.extract(scope.agentId, prompt)
     await appendDistilledMemories(dir, parseDistilledMemories(output))
@@ -333,16 +380,30 @@ export class ManagedMemoryProvider implements MemoryProvider {
       list: (scope) => this.list(scope),
       read: (scope, path) => this.read(scope, path),
       write: (scope, path, content, ifMatch, source) => this.write(scope, path, content, ifMatch, source),
-      history: (scope, req) => listMemoryHistory(this.dirFor(scope.agentId), req.path, req.cursor, req.limit)
+      history: (scope, req) => listMemoryHistory(this.activeRoot(scope), req.path, req.cursor, req.limit)
     }
   }
 
   async list(scope: MemoryScope): Promise<MemoryEntry[]> {
-    return listMemory(this.dirFor(scope.agentId))
+    const roots = this.readRoots(scope)
+    if (roots.length === 1) return listMemory(roots[0]!)
+    // Union base + channel, channel shadowing the base by name, MEMORY.md first.
+    const byName = new Map<string, MemoryFile>()
+    for (const root of [...roots].reverse()) {
+      for (const file of await listMemory(root)) byName.set(file.name, file)
+    }
+    return [...byName.values()].sort((a, b) =>
+      a.name === MEMORY_INDEX ? -1 : b.name === MEMORY_INDEX ? 1 : a.name.localeCompare(b.name)
+    )
   }
 
   async read(scope: MemoryScope, path: string): Promise<MemoryReadResult> {
-    return { path, content: await readMemoryFile(this.dirFor(scope.agentId), path) }
+    // Channel layer shadows the base: return the first root that has the file.
+    for (const root of this.readRoots(scope)) {
+      const content = await readMemoryFile(root, path)
+      if (content !== '') return { path, content }
+    }
+    return { path, content: '' }
   }
 
   async write(
@@ -352,7 +413,7 @@ export class ManagedMemoryProvider implements MemoryProvider {
     ifMatch?: string,
     source?: MemoryWriteSource
   ): Promise<MemoryWriteResult> {
-    const { size, mtime } = await writeMemoryFile(this.dirFor(scope.agentId), path, content, ifMatch, source)
+    const { size, mtime } = await writeMemoryFile(this.activeRoot(scope), path, content, ifMatch, source)
     return { ok: true, path, size, mtime }
   }
 }

--- a/packages/daemon/src/agents/memory.ts
+++ b/packages/daemon/src/agents/memory.ts
@@ -17,7 +17,7 @@
  * Writes additionally publish through a random exclusive temp file. Flat by design
  * (one level): a topic is a file directly under `memory/`, no nested dirs.
  */
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { constants, promises as fsp, lstatSync, mkdirSync, realpathSync, writeFileSync, type Stats } from 'node:fs'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import {
@@ -107,6 +107,87 @@ export class MemoryConflictError extends Error {
 /** The memory directory for an agent, given its root dir (where agent.json lives). */
 export function memoryDir(agentDir: string): string {
   return join(agentDir, MEMORY_DIRNAME)
+}
+
+/** Sibling of `memory/` that holds one self-contained memory subtree per channel
+ *  when the agent's memory scope is `channel` (#653). */
+export const CHANNEL_MEMORY_DIRNAME = 'channels'
+
+/** A deterministic, filesystem-safe folder name for one channel's memory. Keeps a
+ *  readable prefix and appends a short digest so distinct (transportScope, channel)
+ *  pairs never collide after sanitization. */
+export function memoryChannelKey(channel: string, transportScope?: string): string {
+  const raw = transportScope ? `${transportScope}::${channel}` : channel
+  const digest = createHash('sha256').update(raw).digest('hex').slice(0, 12)
+  const prefix = raw
+    .replace(/[^A-Za-z0-9._-]/g, '-')
+    .replace(/^[.-]+/, '')
+    .slice(0, 80)
+  return prefix ? `${prefix}-${digest}` : digest
+}
+
+/** The self-contained memory root for one channel (its own `memory/` + `.history`),
+ *  used exactly like an agent root. `channelKey` MUST be a pre-sanitized single
+ *  path segment (from {@link memoryChannelKey}); anything else is rejected so a
+ *  crafted key cannot escape the agent tree. */
+export function channelMemoryRoot(agentDir: string, channelKey: string): string {
+  if (channelKey === '.' || channelKey === '..' || !/^[A-Za-z0-9._-]{1,120}$/.test(channelKey)) {
+    throw new MemoryPathError('invalid channel memory key')
+  }
+  return join(agentDir, CHANNEL_MEMORY_DIRNAME, channelKey)
+}
+
+/** Source identity of a channel memory folder, so the console can render a name
+ *  instead of the opaque key. Written when the folder is first created. */
+export interface ChannelMemoryMeta {
+  channel: string
+  transportScope?: string
+}
+
+/** Record the source channel identity for a channel memory folder (idempotent
+ *  best-effort; a write failure never blocks memory itself). Lives at the channel
+ *  root, outside `memory/`, so it never appears as a memory topic. */
+export async function writeChannelMemoryMeta(
+  agentDir: string,
+  channelKey: string,
+  meta: ChannelMemoryMeta
+): Promise<void> {
+  const root = channelMemoryRoot(agentDir, channelKey)
+  await fsp.mkdir(root, { recursive: true })
+  const body = JSON.stringify({
+    channel: meta.channel,
+    ...(meta.transportScope ? { transportScope: meta.transportScope } : {})
+  })
+  await fsp.writeFile(join(root, 'channel.json'), body, 'utf8').catch(() => {})
+}
+
+/** Read a channel memory folder's source identity, or null if absent/unreadable. */
+export async function readChannelMemoryMeta(agentDir: string, channelKey: string): Promise<ChannelMemoryMeta | null> {
+  try {
+    const raw = await fsp.readFile(join(channelMemoryRoot(agentDir, channelKey), 'channel.json'), 'utf8')
+    const parsed = JSON.parse(raw) as ChannelMemoryMeta
+    if (parsed && typeof parsed.channel === 'string') return parsed
+  } catch {
+    /* missing or malformed — treat as unknown */
+  }
+  return null
+}
+
+/** List the channelKeys that have a memory subtree under an agent root (the folder
+ *  names under `channels/`). ENOENT ⇒ none. */
+export async function listChannelMemoryKeys(agentDir: string): Promise<string[]> {
+  const root = join(agentDir, CHANNEL_MEMORY_DIRNAME)
+  let dirents
+  try {
+    dirents = await fsp.readdir(root, { withFileTypes: true })
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw err
+  }
+  return dirents
+    .filter((d) => d.isDirectory() && /^[A-Za-z0-9._-]{1,120}$/.test(d.name))
+    .map((d) => d.name)
+    .sort()
 }
 
 /**

--- a/packages/daemon/src/agents/memory.ts
+++ b/packages/daemon/src/agents/memory.ts
@@ -475,6 +475,17 @@ export async function readMemoryFile(agentDir: string, relPath: string): Promise
   return readContainedMemoryFile(agentDir, memoryDir(agentDir), abs)
 }
 
+/** Like {@link readMemoryFile} but distinguishes absent (`null`) from present-but-
+ *  empty (`''`). The channel/base overlay needs this so an intentionally-empty
+ *  channel file still shadows a non-empty base file instead of falling through. */
+export async function readMemoryFileIfPresent(agentDir: string, relPath: string): Promise<string | null> {
+  const abs = resolveInMemoryDir(agentDir, relPath)
+  const target = await containedReadTarget(agentDir, memoryDir(agentDir), abs)
+  if (target === null) return null
+  const current = await readCurrentMemoryFile(target)
+  return current.existed ? current.before : null
+}
+
 /** Truncate a snapshot to the history value cap, on a UTF-8 boundary, flagging it. */
 export function clampMemoryHistoryValue(text: string): { value: string; truncated: boolean } {
   if (Buffer.byteLength(text) <= MAX_HISTORY_VALUE_BYTES) return { value: text, truncated: false }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -302,6 +302,7 @@ import {
   SLACK_SESSION_AUDIENCE_FEATURE,
   WORKSPACE_SESSION_READ_FEATURE,
   effectiveMemoryDreamingPolicy,
+  effectiveManagedMemoryScope,
   RdSlackAction,
   WireFeishuCardActionEvent,
   gitRepoLabel,
@@ -324,8 +325,10 @@ import {
   memoryKindOf,
   MemoryProviderUnavailableError,
   type DispatchingMemoryProvider,
+  type MemoryScope,
   type PreparedExternalMemoryCapture
 } from './agents/memory-provider.js'
+import { memoryChannelKey } from './agents/memory.js'
 import { createWorkspaceGit } from './cp/workspace-git.js'
 import { DAEMON_VERSION } from './version.js'
 import { CpCronRegistry } from './cp/cp-cron.js'
@@ -2998,6 +3001,7 @@ export class Daemon {
       // time so a policy change takes effect for an already-running ACP session.
       memoryAccessAllowed: (ctx, mode) =>
         mode === 'read' || !this.store.isCaptureExcluded(this.acpSessionIdForToolCall(ctx)),
+      memoryScope: (ctx) => this.memoryScope(ctx.agentId, ctx.channel, ctx.transportScope),
       recordOutbound: (ctx, channel, thread, text, ts, integrationId) =>
         this.store.appendTranscript({
           channel: transcriptChannelKey(channel, this.transportScopeForIntegrationIds([integrationId])),
@@ -3018,6 +3022,12 @@ export class Daemon {
     )
 
     this.sessions = new SessionManager({
+      memoryScopeFor: (agentId, msg, integrationId) =>
+        this.memoryScope(
+          agentId,
+          msg.channel,
+          this.transportScopeForIntegrationIds(integrationId ? [integrationId] : [])
+        ),
       store: this.store,
       // Must hand back a *started* host: handle() calls host.newSession() immediately,
       // which needs the ACP connection that start() establishes.
@@ -5122,6 +5132,27 @@ export class Daemon {
     await Promise.all([...selected].map((lifecycle) => lifecycle.stop(0)))
   }
 
+  /** Build the memory scope for an agent + conversation. For a `channel`-scoped
+   *  agent this carries the per-channel folder key (DM/webchat are special channels
+   *  keyed by their conversation); otherwise it is the agent-level store (#653). */
+  private memoryScope(agentId: string, channel: string | undefined, transportScope?: string | null): MemoryScope {
+    const agent = this.agents.get(agentId)
+    if (effectiveManagedMemoryScope(agent?.memory) !== 'channel' || !channel) return { agentId }
+    return {
+      agentId,
+      channelKey: memoryChannelKey(channel, transportScope ?? undefined),
+      channel,
+      ...(transportScope ? { transportScope } : {})
+    }
+  }
+
+  /** Memory scope for a running session, resolving its channel from the store by
+   *  ACP session id (the capture path only carries the session id). */
+  private memoryScopeForSession(agentId: string, acpSessionId: string): MemoryScope {
+    const rec = this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+    return this.memoryScope(agentId, rec?.channel, rec?.transportScope)
+  }
+
   private queueMemoryPostTurn(
     agentId: string,
     sessionId: string,
@@ -5154,7 +5185,7 @@ export class Daemon {
       }
       try {
         await this.memory.recordTurnForBinding(
-          { agentId, sessionId },
+          { ...this.memoryScopeForSession(agentId, sessionId), sessionId },
           { turnId, sessionId, input, output },
           binding,
           captureTarget

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -1,5 +1,5 @@
 import type { ToolDescriptor } from './tools.js'
-import type { MemoryProvider } from '../agents/memory-provider.js'
+import type { MemoryProvider, MemoryScope } from '../agents/memory-provider.js'
 import {
   rootPostNeedsThreadMaterialization,
   rootPostThreadName,
@@ -551,6 +551,10 @@ export interface OpsDeps {
    *  mid-session policy change takes effect immediately. Absent ⇒ allowed (e.g. in
    *  unit fixtures). */
   memoryAccessAllowed?: (ctx: SessionContext, mode: 'read' | 'write') => boolean
+  /** Build the memory scope for a tool call — carries the per-channel folder key
+   *  for a channel-scoped agent so tools read/write that channel's memory (#653).
+   *  Absent ⇒ agent-level store (unit fixtures). */
+  memoryScope?: (ctx: SessionContext) => MemoryScope
   /** Collaboration Arena §6: resolve + execute an evaluation-registry tool.
    *  Returns undefined when `name` is not an evaluation tool. Visibility and
    *  role-aware authorization live behind this seam (the daemon guarantees
@@ -702,7 +706,7 @@ export async function executeTool(
   if (name === 'readMemory' || name === 'writeMemory') {
     const mode = name === 'writeMemory' ? 'write' : 'read'
     if (deps.memoryAccessAllowed?.(ctx, mode) === false) throw new Error(MEMORY_ACCESS_BLOCKED)
-    const scope = { agentId: ctx.agentId }
+    const scope = deps.memoryScope?.(ctx) ?? { agentId: ctx.agentId }
     try {
       if (name === 'readMemory') {
         const path = optionalString(args, 'path') ?? 'MEMORY.md'
@@ -759,7 +763,7 @@ export async function executeTool(
     if (deps.memoryAccessAllowed?.(ctx, mode) === false) throw new Error(MEMORY_ACCESS_BLOCKED)
     const surface = deps.memory.adminSurfaceForAgent?.(ctx.agentId) ?? deps.memory.adminSurface()
     if (!surface || surface.shape !== 'records') throw new Error('record memory is not available for this agent')
-    const scope = { agentId: ctx.agentId }
+    const scope = deps.memoryScope?.(ctx) ?? { agentId: ctx.agentId }
     const requireCapability = (operation: 'recall' | 'create' | 'get' | 'update' | 'delete'): void => {
       if (!surface.capabilities.has(operation)) throw new Error(`record memory does not support ${operation}`)
     }

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -3,7 +3,7 @@ import { LocalStore, sessionKey, transcriptChannelKey, type TranscriptEntry } fr
 import { monotonicTs } from '../store/monotonic-ts.js'
 import { SLACK_RESPONSE_FINAL_EVENT_TAG } from '@agentconnect.md/message'
 import { additionalWorkspaceDirectories, prepareWorkspace } from '../workspace/workspace-manager.js'
-import { memoryKindOf, type MemoryProvider } from '../agents/memory-provider.js'
+import { memoryKindOf, type MemoryProvider, type MemoryScope } from '../agents/memory-provider.js'
 import { MAX_INDEX_INJECT_BYTES } from '../agents/memory.js'
 import { agentChildEnv } from '../agents/agent-env.js'
 import { planConfigFiles } from '../agents/config-file-env.js'
@@ -257,6 +257,10 @@ export class SessionManager {
       /** The agent memory provider — seeds the memory dir and supplies the index
        *  injected at the start of a fresh session. */
       memory: MemoryProvider
+      /** Build the memory scope for this turn's agent + conversation — carries the
+       *  per-channel folder key for channel-scoped agents (#653). Absent ⇒ the
+       *  agent-level store (tests / chat CLI). */
+      memoryScopeFor?: (agentId: string, msg: NormalizedMessage, integrationId?: string) => MemoryScope
       /** Fail-open recall diagnostics. Must never include query/record/plugin body text. */
       onMemoryRecallError?: (agentId: string, error: unknown) => void
       /** Exact final reference bytes after provider-neutral validation/rendering. */
@@ -429,9 +433,13 @@ export class SessionManager {
     const usesSessionTitleTool = this.deps.usesSessionTitleTool?.(agent) ?? false
     const memoryEnabled = this.deps.memoryEnabled !== false
     const currentMemoryProvider = memoryEnabled ? memoryKindOf(agent) : 'none'
+    // The memory scope for this turn — the per-channel folder for a channel-scoped
+    // agent, else the agent-level store (#653). Reused for seeding, injection, and
+    // recall so all three hit the same store.
+    const memScope = this.deps.memoryScopeFor?.(agentId, msg, integrationId) ?? { agentId }
     // Seed the agent's memory file at its ROOT dir (outside the workspace) if absent,
     // so the prompt injection below and the `updateMemory` tool always have a file.
-    if (memoryEnabled) this.deps.memory.ensure({ agentId }, agent.name)
+    if (memoryEnabled) this.deps.memory.ensure(memScope, agent.name)
     const { thread, ts: coordTs } = transcriptCoords(msg)
     // webchat's msgId is stable per-conversation, so transcriptCoords yields the SAME ts
     // for every turn — the transcript's (channel,thread,ts) unique index would then dedup
@@ -687,7 +695,7 @@ export class SessionManager {
     // memory is enabled, regardless of session isolation. Only WRITES (the memory
     // write tools + post-turn distillation) stay gated for private sessions.
     const memoryIndex = memoryEnabled
-      ? (await abortable(() => this.deps.memory.standingContextAtSessionStart({ agentId }), signal)).trim()
+      ? (await abortable(() => this.deps.memory.standingContextAtSessionStart(memScope), signal)).trim()
       : ''
     const memoryAppend = memoryIndex
       ? `# Persistent memory\n` +
@@ -1223,7 +1231,7 @@ export class SessionManager {
     // deliberately reuses one msgId for the whole conversation, so use its
     // per-turn trace id instead.
     const turnId = stableTurnId(agentId, msg)
-    const recallScope = { agentId, sessionId: rec.acpSessionId! }
+    const recallScope = { ...memScope, sessionId: rec.acpSessionId! }
     const recallPolicy = memoryEnabled ? this.deps.memory.recallPolicy(recallScope) : undefined
     if (captureInput && recallPolicy?.mode === 'auto') {
       const recallAbort = new AbortController()

--- a/packages/daemon/test/channel-memory.test.ts
+++ b/packages/daemon/test/channel-memory.test.ts
@@ -81,6 +81,22 @@ describe('channel-scoped memory overlay', () => {
     expect(listed.filter((n) => n === 'topic.md')).toHaveLength(1)
   })
 
+  it('an empty channel file still shadows a non-empty base file (existence, not emptiness)', async () => {
+    const { mem } = provider()
+    const base = { agentId: 'bot-a' }
+    const a = chan('C1')
+    mem.ensure(base, 'bot')
+    await mem.write(base, 'topic.md', '- base version', undefined, 'tool')
+    mem.ensure(a, 'bot')
+    // Intentionally clear the topic in this channel by writing empty content.
+    await mem.write(a, 'topic.md', '', undefined, 'tool')
+
+    // The channel's empty file must win over the base's stale content.
+    expect((await mem.read(a, 'topic.md')).content).toBe('')
+    // The base is untouched.
+    expect((await mem.read(base, 'topic.md')).content).toBe('- base version')
+  })
+
   it('injects the base index then the channel index', async () => {
     const { mem } = provider()
     const base = { agentId: 'bot-a' }

--- a/packages/daemon/test/channel-memory.test.ts
+++ b/packages/daemon/test/channel-memory.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Channel-scoped managed memory (#653): each channel gets a self-contained folder
+ * under `<agentRoot>/channels/<key>/`. Reads overlay the shared base + the channel
+ * layer (channel shadows base); writes go only to the channel layer, so channels
+ * never cross. DM/webchat are special channels keyed by their conversation.
+ */
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createManagedMemoryProvider } from '../src/agents/memory-provider.js'
+import {
+  memoryChannelKey,
+  channelMemoryRoot,
+  listChannelMemoryKeys,
+  readChannelMemoryMeta,
+  MemoryPathError
+} from '../src/agents/memory.js'
+
+function provider() {
+  const dir = mkdtempSync(join(tmpdir(), 'ac-chan-mem-'))
+  return { dir, mem: createManagedMemoryProvider(() => dir) }
+}
+
+const chan = (channel: string, transportScope?: string) => ({
+  agentId: 'bot-a',
+  channelKey: memoryChannelKey(channel, transportScope),
+  channel,
+  ...(transportScope ? { transportScope } : {})
+})
+
+describe('memoryChannelKey / channelMemoryRoot', () => {
+  it('is deterministic, filesystem-safe, and disambiguates transport scope', () => {
+    expect(memoryChannelKey('C1')).toBe(memoryChannelKey('C1'))
+    expect(memoryChannelKey('C1', 's1')).not.toBe(memoryChannelKey('C1', 's2'))
+    expect(memoryChannelKey('weird/../name:with spaces')).toMatch(/^[A-Za-z0-9._-]+$/)
+  })
+
+  it('rejects an unsafe channel key so a crafted key cannot escape the agent tree', () => {
+    expect(() => channelMemoryRoot('/agent', '..')).toThrow(MemoryPathError)
+    expect(() => channelMemoryRoot('/agent', 'a/b')).toThrow(MemoryPathError)
+    expect(channelMemoryRoot('/agent', 'ok-key_1')).toBe('/agent/channels/ok-key_1')
+  })
+})
+
+describe('channel-scoped memory overlay', () => {
+  it('isolates writes per channel and never crosses', async () => {
+    const { mem } = provider()
+    const a = chan('C1')
+    const b = chan('C2')
+    mem.ensure(a, 'bot')
+    mem.ensure(b, 'bot')
+
+    await mem.write(a, 'notes.md', '- channel A note', undefined, 'tool')
+    expect((await mem.read(a, 'notes.md')).content).toBe('- channel A note')
+    // Channel B never sees channel A's content.
+    expect((await mem.read(b, 'notes.md')).content).toBe('')
+    expect((await mem.list(b)).some((f) => f.name === 'notes.md')).toBe(false)
+  })
+
+  it('overlays the shared base under a channel: base is readable, channel shadows it', async () => {
+    const { mem } = provider()
+    const base = { agentId: 'bot-a' }
+    const a = chan('C1')
+    mem.ensure(base, 'bot')
+    await mem.write(base, 'shared.md', '- shared base fact', undefined, 'tool')
+    await mem.write(base, 'topic.md', '- base version', undefined, 'tool')
+
+    mem.ensure(a, 'bot')
+    await mem.write(a, 'topic.md', '- channel version', undefined, 'tool')
+
+    // Base-only file is visible from the channel (fallback); shadowed file returns
+    // the channel version; a channel-only write is invisible to the base.
+    expect((await mem.read(a, 'shared.md')).content).toBe('- shared base fact')
+    expect((await mem.read(a, 'topic.md')).content).toBe('- channel version')
+    expect((await mem.read(base, 'topic.md')).content).toBe('- base version')
+
+    const listed = (await mem.list(a)).map((f) => f.name)
+    expect(listed).toEqual(expect.arrayContaining(['shared.md', 'topic.md']))
+    // Union does not duplicate the shadowed file.
+    expect(listed.filter((n) => n === 'topic.md')).toHaveLength(1)
+  })
+
+  it('injects the base index then the channel index', async () => {
+    const { mem } = provider()
+    const base = { agentId: 'bot-a' }
+    const a = chan('C1')
+    mem.ensure(base, 'bot')
+    await mem.write(base, 'MEMORY.md', '# base index', undefined, 'tool')
+    mem.ensure(a, 'bot')
+    await mem.write(a, 'MEMORY.md', '# channel index', undefined, 'tool')
+
+    const injected = await mem.standingContextAtSessionStart(a)
+    expect(injected.indexOf('# base index')).toBeGreaterThanOrEqual(0)
+    expect(injected.indexOf('# channel index')).toBeGreaterThan(injected.indexOf('# base index'))
+  })
+
+  it('records channel source metadata so the console can name folders', async () => {
+    const { dir, mem } = provider()
+    const a = chan('C1', 'scope-1')
+    mem.ensure(a, 'bot')
+    await mem.write(a, 'x.md', '- x', undefined, 'tool')
+
+    const keys = await listChannelMemoryKeys(dir)
+    expect(keys).toContain(a.channelKey)
+    expect(await readChannelMemoryMeta(dir, a.channelKey)).toEqual({ channel: 'C1', transportScope: 'scope-1' })
+  })
+})

--- a/packages/protocol/src/frames/memory-connection.ts
+++ b/packages/protocol/src/frames/memory-connection.ts
@@ -92,11 +92,19 @@ export const DEFAULT_MEMORY_DREAMING_POLICY = {
   mineSkills: true
 } as const satisfies MemoryDreamingPolicy
 
+/** Managed-memory partitioning. `agent` (default) keeps one store per agent;
+ *  `channel` gives each channel (DM/webchat included, as special channels) its own
+ *  memory folder so different channels never cross. The agent-level store stays as
+ *  a shared read-only base under `channel` (see docs/designs/memory-dreaming.md). */
+export const ManagedMemoryScope = z.enum(['agent', 'channel'])
+export type ManagedMemoryScope = z.infer<typeof ManagedMemoryScope>
+
 const BuiltInMemoryBinding = z
   .object({
     provider: z.enum(['none', 'native', 'managed']),
     autoDistill: z.boolean().optional(),
-    dreaming: MemoryDreamingPolicy.optional()
+    dreaming: MemoryDreamingPolicy.optional(),
+    scope: ManagedMemoryScope.optional()
   })
   .strict()
   .superRefine((binding, ctx) => {
@@ -105,6 +113,13 @@ const BuiltInMemoryBinding = z
         code: 'custom',
         path: ['dreaming'],
         message: 'dreaming is only supported with the managed memory provider'
+      })
+    }
+    if (binding.scope && binding.provider !== 'managed') {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['scope'],
+        message: 'memory scope is only supported with the managed memory provider'
       })
     }
   })
@@ -136,9 +151,21 @@ export function effectiveMemoryDreamingPolicy(
   binding: AgentMemoryBinding | undefined
 ): MemoryDreamingPolicy | undefined {
   if (binding && binding.provider !== 'managed') return undefined
+  // Dreaming (offline consolidation) is not supported under channel scope — a
+  // dream mines and rewrites a single store, which does not map onto per-channel
+  // folders. Channel-scoped agents have no dreaming policy (the console hides the
+  // controls); per-channel dreaming may arrive later.
+  if (effectiveManagedMemoryScope(binding) === 'channel') return undefined
   const policy = binding?.dreaming
   if (!policy) return { ...DEFAULT_MEMORY_DREAMING_POLICY }
   return { ...policy, autoAdopt: policy.autoAdopt ?? true, mineSkills: policy.mineSkills ?? true }
+}
+
+/** The effective managed-memory partitioning scope. Non-managed and unset ⇒
+ *  `agent` (the historical single-store behavior). */
+export function effectiveManagedMemoryScope(binding: AgentMemoryBinding | undefined): ManagedMemoryScope {
+  if (!binding || binding.provider !== 'managed') return 'agent'
+  return binding.scope ?? 'agent'
 }
 
 /** Reviewed mapping from a logical secret field to the header the relay injects. */

--- a/packages/protocol/src/frames/memory-dream.test.ts
+++ b/packages/protocol/src/frames/memory-dream.test.ts
@@ -4,6 +4,7 @@ import {
   AgentMemoryBinding,
   DEFAULT_MEMORY_DREAMING_POLICY,
   effectiveMemoryDreamingPolicy,
+  effectiveManagedMemoryScope,
   MemoryDreamingPolicy
 } from './memory-connection.js'
 import { DreamInfo, DreamStartReq, DreamFileReadReq, DreamAdoptReq } from './memory.js'
@@ -71,6 +72,20 @@ describe('memory dreaming policy (agent binding)', () => {
       })
     ).toEqual({ enabled: true, autoAdopt: false, mineSkills: false })
     expect(effectiveMemoryDreamingPolicy({ provider: 'none' })).toBeUndefined()
+  })
+
+  it('resolves the managed memory scope and disables dreaming under channel scope (#653)', () => {
+    expect(effectiveManagedMemoryScope(undefined)).toBe('agent')
+    expect(effectiveManagedMemoryScope({ provider: 'managed' })).toBe('agent')
+    expect(effectiveManagedMemoryScope({ provider: 'managed', scope: 'channel' })).toBe('channel')
+    // A channel-scoped agent has no dreaming policy (offline consolidation does not
+    // map onto per-channel folders); the console hides the controls.
+    expect(effectiveMemoryDreamingPolicy({ provider: 'managed', scope: 'channel' })).toBeUndefined()
+    expect(
+      effectiveMemoryDreamingPolicy({ provider: 'managed', scope: 'channel', dreaming: { enabled: true } })
+    ).toBeUndefined()
+    // The binding still validates: scope requires the managed provider.
+    expect(AgentMemoryBinding.safeParse({ provider: 'native', scope: 'channel' }).success).toBe(false)
   })
 })
 


### PR DESCRIPTION
Part 1 of the channel memory scope feature (#653), requested by @pchsu. Backend routing only; the console controls (Channel toggle + channel selector + a "list channels with memory" endpoint) follow in a second PR. Design was agreed with @pchsu over DM.

## Model

- **Config:** `BuiltInMemoryBinding.scope: 'agent' | 'channel'` (managed only). `effectiveManagedMemoryScope` resolves it (default `agent`).
- **Two-layer, migration-free:** the agent-level `memory/` is always a shared base; channel scope adds a per-channel folder `<agentRoot>/channels/<key>/` (self-contained — own `memory/` + `.history`). Switching scope is a pure routing change; no data is moved. A channel-from-start agent just has an empty base.
- **Reads overlay** base + channel (channel shadows base per file): index injection = base then channel; `list` = union; `read` = channel-first then base. **Writes** (tools + per-turn distillation) go only to the channel folder, so a channel's content never reaches the base or another channel.
- **No new agent tools** — the two folders are daemon-internal routing, transparent to the agent (the agent sees one merged memory).
- **Dreaming is off under channel scope** (offline consolidation doesn't map onto per-channel folders); `effectiveMemoryDreamingPolicy` returns none, and the console will hide the controls.

## Implementation

- `memory.ts`: `memoryChannelKey` (safe, collision-resistant folder name via readable-prefix + digest), `channelMemoryRoot` (validated so a crafted key can't escape the tree), `listChannelMemoryKeys`, and channel source metadata (`channel.json`) for the console.
- `FileMemoryProvider`: `activeRoot`/`readRoots` + overlay in `list`/`read`/`standingContextAtSessionStart`/`recordTurn`; `ensure` records channel metadata.
- `MemoryScope` gains `channelKey`/`channel`/`transportScope`; the daemon builds it (`memoryScope`/`memoryScopeForSession`) and threads it through session-manager (seed/inject/recall), the capture path, and the memory MCP tools (`ops`).

## Tests

- `channel-memory.test.ts`: per-channel isolation, base/channel overlay + shadowing, index injection order, key safety, metadata.
- protocol: scope resolver + dreaming disabled under channel scope.
- Existing memory tests unchanged — no `channelKey` ⇒ agent scope, fully backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)