### PR TITLE
fix(release): track protocol as a web image input

### DIFF
--- a/scripts/component-versions.sh
+++ b/scripts/component-versions.sh
@@ -50,7 +50,7 @@ esac
 COMMON="docker/Dockerfile docker-bake.hcl .dockerignore .npmrc .pnpmfile.mjs pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.base.json scripts"
 CP_PATHS="packages/control-plane packages/setup packages/protocol packages/observability $COMMON"
 SETUP_PATHS="$CP_PATHS"
-WEB_PATHS="packages/web $COMMON"
+WEB_PATHS="packages/web packages/protocol $COMMON"
 RELAY_PATHS="packages/relay packages/message packages/protocol packages/connection packages/observability $COMMON"
 MEM0_PATHS="packages/memory-plugin-mem0 packages/protocol $COMMON"
 # The backend's application source is the immutable external context declared in


### PR DESCRIPTION
`WEB_PATHS` in `scripts/component-versions.sh` omitted `packages/protocol`, so a
release whose only change was under `packages/protocol/` resolved web to its
previous effective tag — the new version tag then aliased a web image built from
the old protocol.

This is the same bug class as #784 (which added `packages/observability` to
`CP_PATHS`/`RELAY_PATHS`), deliberately left out of that PR to keep it scoped.

## Why protocol is a web build input

- `packages/web/package.json` declares `"@agentconnect.md/protocol": "workspace:*"`.
- The web builder stage in `docker/Dockerfile` runs
  `pnpm --filter "@agentconnect.md/protocol" build` before building web.
- `packages/web/src/components/console/platforms/slack/manifest.ts` imports
  `@agentconnect.md/protocol/slack-app-manifest` — a real runtime import, not
  type-only.

`MEM0_PATHS` already listed the package, which left web the odd one out. The
file's own comment states the rule this broke: under-including "silently ships a
stale image under a new version, so err on the side of more."

## Verification

Using the resolver's own predicate, on a synthetic release touching only
`packages/protocol/src/index.ts`:

```
OLD WEB_PATHS -> []                              => web NOT rebuilt (stale)
NEW WEB_PATHS -> [packages/protocol/src/index.ts] => web rebuilt
```

I also probed every workspace package against every path set, sourcing the
definitions verbatim from the script so the audit cannot drift from what the
release actually uses. Each column matches its true closure (workspace deps plus
the Dockerfile build stages), and web was the only omission:

| touched | CP | WEB | RELAY | MEM0 | SETUP |
|---|---|---|---|---|---|
| protocol | yes | **yes (was stale)** | yes | yes | yes |
| observability | yes | - | yes | - | yes |
| connection / message | - | - | yes | - | - |
| control-plane / setup | yes | - | - | - | yes |
| web | - | yes | - | - | - |

`cli` and `daemon` correctly move nothing — they are npm-published, not imaged.
A second probe over the non-package inputs confirms no column is dead:
`MEM0_BACKEND` does fire on its own Dockerfile, `docker-bake.hcl`, and this
resolver. `docker/prisma-cli.Dockerfile` stays outside the resolver by design —
it carries its own pin tracking the Prisma CLI, not the release train.

## Real-world impact

Replaying the effective-version walk over actual tag history: 2 of 45 stable
releases (v1.5.1, v1.8.0) and 117 of 1086 rc releases resolved web to a stale
image.

Web compiles exactly one protocol module today (the `slack-app-manifest`
subpath), so most of those were latent rather than harmful — a protocol change
elsewhere produced a byte-identical bundle. One was not: **v1.37.0-rc.4 reused
the rc.3 web image across #726**, the commit whose entire purpose was keeping
that subpath bundler-resolvable for web.

## Notes for reviewers

- Re-running the probe by hand requires **bash, not zsh** — zsh does not
  word-split the unquoted `$paths` pathspec list, which makes every probe
  falsely report "unchanged".
- This commit touches `scripts/`, which is in `COMMON`, so the next release
  rebuilds every component once. That is the intended over-including direction.
- Not included, worth a separate PR: there is no test guarding this bug class,
  and it has now recurred twice. A `scripts/*.test.mjs` check asserting each path
  set covers its package's transitive workspace deps would fail in CI instead of
  in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
