### PR TITLE
feat(memory): channel memory scope — console scope toggle

### DIFF
--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -363,7 +363,7 @@ describe('MemoryPanel settings draft', () => {
     expect(container.querySelector('[data-memory-provider="managed"]')).toBeNull()
   })
 
-  it('shows the fixed agent scope and explains that memory is shared across users', async () => {
+  it('offers an editable Agent/Channel scope; choosing Channel hides dreaming and saves the scope', async () => {
     container = document.createElement('div')
     document.body.append(container)
     root = createRoot(container)
@@ -380,16 +380,29 @@ describe('MemoryPanel settings draft', () => {
     })
 
     await openSettings(container)
-    const scope = container.querySelector<HTMLButtonElement>('[data-memory-scope="agent"]')
-    expect(scope?.textContent).toBe('Agent')
-    expect(scope?.disabled).toBe(true)
+    const agentPill = container.querySelector<HTMLButtonElement>('[data-memory-scope="agent"]')
+    const channelPill = container.querySelector<HTMLButtonElement>('[data-memory-scope="channel"]')
+    // Both options are offered and editable; Agent is selected by default.
+    expect(agentPill?.textContent).toBe('Agent')
+    expect(channelPill?.textContent).toBe('Channel')
+    expect(agentPill?.disabled).toBe(false)
+    expect(agentPill?.getAttribute('aria-pressed')).toBe('true')
 
-    const help = container.querySelector<HTMLButtonElement>('[aria-label="About agent memory scope"]')
-    const tooltipId = help?.getAttribute('aria-describedby')
-    expect(tooltipId).toBeTruthy()
-    const tooltip = tooltipId ? container.querySelector<HTMLElement>(`#${tooltipId}`) : null
-    expect(tooltip?.getAttribute('role')).toBe('tooltip')
-    expect(tooltip?.textContent).toContain('Memory is shared across all users who interact with this agent.')
+    // Dreaming controls are visible under agent scope.
+    expect(container.textContent).toContain('Enable dreaming')
+
+    await act(async () => channelPill?.click())
+    // Channel scope hides the dreaming controls and explains the tradeoff.
+    expect(container.textContent).not.toContain('Enable dreaming')
+    expect(container.textContent).toContain('Dreaming is unavailable under channel scope')
+
+    const save = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent === 'Save memory settings'
+    )
+    await act(async () => save?.click())
+    expect(mocks.updateAgent).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222', {
+      memory: { provider: 'managed', autoDistill: false, scope: 'channel' }
+    })
   })
 
   it('hides the persisted memory session while a different backend is selected but unsaved', async () => {

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -19,6 +19,7 @@ import {
   listAgentMemory,
   ApiError,
   type MemoryFileEntry,
+  type ManagedMemoryScope,
   type MemoryDreamingConfig
 } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
@@ -72,31 +73,50 @@ const MarkdownView = dynamic(() => import('@/components/console/MarkdownView'), 
 
 const INDEX = 'MEMORY.md'
 const TOPIC_RE = /^[A-Za-z0-9._-]+\.md$/ // flat file name, .md
-const AGENT_SCOPE_HELP =
-  'Agent scope is the only option currently. Memory is shared across all users who interact with this agent.'
+const SCOPE_HELP =
+  'Agent scope shares one memory across everyone who talks to this agent. Channel scope gives each channel (DMs and webchat included) its own memory folder, so different channels never mix. Dreaming is turned off under channel scope.'
 
-function MemoryScopeField() {
+function MemoryScopeField({
+  scope,
+  canEdit,
+  onChange
+}: {
+  scope: ManagedMemoryScope
+  canEdit: boolean
+  onChange: (next: ManagedMemoryScope) => void
+}) {
   const tooltipId = useId()
+  const options: Array<{ value: ManagedMemoryScope; label: string }> = [
+    { value: 'agent', label: 'Agent' },
+    { value: 'channel', label: 'Channel' }
+  ]
 
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
       <span className="font-sans text-[13px] font-semibold leading-normal">Scope</span>
       <span className="group relative inline-flex items-center gap-1">
         <span className="pillbar">
-          <button
-            type="button"
-            disabled
-            data-memory-scope="agent"
-            aria-describedby={tooltipId}
-            className="pill on cursor-not-allowed px-2 py-1 text-[12px]"
-          >
-            Agent
-          </button>
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              disabled={!canEdit}
+              data-memory-scope={option.value}
+              aria-pressed={scope === option.value}
+              aria-describedby={tooltipId}
+              className={`pill ${scope === option.value ? 'on' : ''} px-2 py-1 text-[12px] ${canEdit ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+              onClick={() => {
+                if (canEdit) onChange(option.value)
+              }}
+            >
+              {option.label}
+            </button>
+          ))}
         </span>
         <button
           type="button"
           className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full text-(--text-tertiary) transition-colors hover:text-(--text-primary) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand)"
-          aria-label="About agent memory scope"
+          aria-label="About memory scope"
           aria-describedby={tooltipId}
           onKeyDown={(event) => {
             if (event.key === 'Escape') {
@@ -113,7 +133,7 @@ function MemoryScopeField() {
           role="tooltip"
           className="pointer-events-none invisible absolute top-full left-0 z-30 mt-2 w-[280px] max-w-[calc(100vw-72px)] -translate-y-1 rounded-md border border-(--border-default) bg-(--surface-card) p-3 font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-secondary) opacity-0 shadow-(--shadow-lg) transition-[opacity,transform,visibility] duration-150 group-hover:visible group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:visible group-focus-within:translate-y-0 group-focus-within:opacity-100"
         >
-          {AGENT_SCOPE_HELP}
+          {SCOPE_HELP}
         </span>
       </span>
     </div>
@@ -123,6 +143,7 @@ function MemoryScopeField() {
 function settingsFromProps(input: {
   memoryProvider: string
   autoDistill: boolean
+  memoryScope?: ManagedMemoryScope
   memoryDreaming?: MemoryDreamingConfig
   memoryConnectionId?: string
   memoryRecall?: ExternalMemoryBindingDraft['recall']
@@ -131,6 +152,7 @@ function settingsFromProps(input: {
   return memorySettingsDraft({
     provider: input.memoryProvider,
     autoDistill: input.autoDistill,
+    scope: input.memoryScope,
     dreaming: input.memoryDreaming,
     connectionId: input.memoryConnectionId,
     recall: input.memoryRecall,
@@ -143,6 +165,7 @@ export function MemoryPanel({
   canEdit,
   memoryProvider,
   autoDistill,
+  memoryScope,
   memoryDreaming,
   memoryConnectionId,
   memoryRecall,
@@ -153,6 +176,7 @@ export function MemoryPanel({
   canEdit: boolean
   memoryProvider: string
   autoDistill: boolean
+  memoryScope?: ManagedMemoryScope
   memoryDreaming?: MemoryDreamingConfig
   memoryConnectionId?: string
   memoryRecall?: ExternalMemoryBindingDraft['recall']
@@ -183,6 +207,7 @@ export function MemoryPanel({
   const initialSettings = settingsFromProps({
     memoryProvider,
     autoDistill,
+    memoryScope,
     memoryDreaming,
     memoryConnectionId,
     memoryRecall,
@@ -301,10 +326,17 @@ export function MemoryPanel({
   }
 
   // One-line summary of the PERSISTED settings for the collapsed bar. Scope is
-  // always named — memory is agent-scoped and shared across users.
+  // always named. Channel scope has no dreaming, so those chips are dropped.
   const settingsSummary = (() => {
     switch (persistedProvider) {
       case 'managed': {
+        if (persistedSettings.scope === 'channel') {
+          return [
+            'Managed directory',
+            `Auto-distill ${persistedSettings.autoDistill ? 'on' : 'off'}`,
+            'Channel scope'
+          ].join(' · ')
+        }
         const dreaming = persistedSettings.dreaming
         const cadence = dreaming.schedule === '0 4 * * *' ? 'daily' : dreaming.schedule ? 'scheduled' : 'manual'
         return [
@@ -665,7 +697,16 @@ export function MemoryPanel({
               </span>
             </div>
 
-            <MemoryScopeField />
+            {provider === 'managed' ? (
+              <MemoryScopeField
+                scope={settings.scope}
+                canEdit={canEdit && !savingProvider}
+                onChange={(next) => {
+                  setSettings((current) => ({ ...current, scope: next }))
+                  setProviderError(null)
+                }}
+              />
+            ) : null}
 
             {provider === 'managed' ? (
               <label className="flex items-center gap-2 font-sans text-[12px] font-normal leading-normal text-(--text-secondary)">
@@ -682,7 +723,14 @@ export function MemoryPanel({
               </label>
             ) : null}
 
-            {provider === 'managed' ? (
+            {provider === 'managed' && settings.scope === 'channel' ? (
+              <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                Each channel (DMs and webchat included) keeps its own memory folder, so different channels never mix.
+                Dreaming is unavailable under channel scope.
+              </span>
+            ) : null}
+
+            {provider === 'managed' && settings.scope !== 'channel' ? (
               <div className="flex flex-col gap-2">
                 <label className="flex items-center gap-2 font-sans text-[12px] font-normal leading-normal text-(--text-secondary)">
                   <input

--- a/packages/web/src/components/console/memory-settings.test.ts
+++ b/packages/web/src/components/console/memory-settings.test.ts
@@ -129,6 +129,24 @@ describe('memory settings UX model', () => {
     })
   })
 
+  it('models channel scope: no dreaming in the config, and a change vs the agent default (#653)', () => {
+    const agent = memorySettingsDraft({ provider: 'managed', autoDistill: false })
+    expect(agent.scope).toBe('agent')
+
+    // Parsing a channel-scoped binding.
+    const channel = memorySettingsDraft({ provider: 'managed', autoDistill: false, scope: 'channel' })
+    expect(channel.scope).toBe('channel')
+    // Serializing channel scope never carries a dreaming policy.
+    expect(memoryConfigForDraft(channel)).toEqual({ provider: 'managed', autoDistill: false, scope: 'channel' })
+
+    // Switching agent → channel is a change (even though dreaming fields are equal).
+    expect(memorySettingsChanged(agent, { ...agent, scope: 'channel' })).toBe(true)
+    // Under channel scope, dreaming-field edits don't count as a change.
+    expect(memorySettingsChanged(channel, { ...channel, dreaming: { ...channel.dreaming, autoAdopt: false } })).toBe(
+      false
+    )
+  })
+
   it('preserves the full dreaming policy across a save, even fields the console does not edit', () => {
     // A complete API-configured policy round-trips: the wholesale `memory` PATCH
     // must not drop sessionWindow / timezone / mineSkills / autoAdopt just because

--- a/packages/web/src/components/console/memory-settings.test.ts
+++ b/packages/web/src/components/console/memory-settings.test.ts
@@ -145,6 +145,14 @@ describe('memory settings UX model', () => {
     expect(memorySettingsChanged(channel, { ...channel, dreaming: { ...channel.dreaming, autoAdopt: false } })).toBe(
       false
     )
+
+    // A stale (hidden) invalid dreaming schedule must not block a channel-scope save.
+    const staleInvalidDream = {
+      ...channel,
+      dreaming: { ...channel.dreaming, enabled: true, schedule: 'not a cron' }
+    }
+    expect(memorySettingsBlocker({ ...staleInvalidDream, scope: 'agent' })).not.toBeNull()
+    expect(memorySettingsBlocker(staleInvalidDream)).toBeNull()
   })
 
   it('preserves the full dreaming policy across a save, even fields the console does not edit', () => {

--- a/packages/web/src/components/console/memory-settings.ts
+++ b/packages/web/src/components/console/memory-settings.ts
@@ -1,4 +1,4 @@
-import type { AgentMemoryConfig, MemoryDreamingConfig } from '@/lib/api'
+import type { AgentMemoryConfig, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
 import { isIanaTimezone, isValidCron } from '@/lib/cron'
 import {
   DEFAULT_EXTERNAL_MEMORY_BINDING,
@@ -50,6 +50,9 @@ export const MEMORY_PROVIDER_OPTIONS: ReadonlyArray<{
 export interface MemorySettingsDraft {
   provider: MemoryProviderChoice
   autoDistill: boolean
+  /** Managed partitioning (#653). `channel` gives each channel its own memory and
+   *  disables dreaming (offline consolidation doesn't map onto per-channel folders). */
+  scope: ManagedMemoryScope
   dreaming: DreamingDraft
   external: ExternalMemoryBindingDraft
 }
@@ -85,6 +88,7 @@ function sameDreaming(a: DreamingDraft, b: DreamingDraft): boolean {
 export function memorySettingsDraft(input: {
   provider: string
   autoDistill: boolean
+  scope?: ManagedMemoryScope
   dreaming?: MemoryDreamingConfig | null
   connectionId?: string
   recall?: ExternalMemoryBindingDraft['recall']
@@ -93,6 +97,7 @@ export function memorySettingsDraft(input: {
   return {
     provider: memoryProviderChoice(input.provider),
     autoDistill: input.autoDistill,
+    scope: input.scope === 'channel' ? 'channel' : 'agent',
     dreaming: input.dreaming
       ? {
           enabled: input.dreaming.enabled,
@@ -128,6 +133,9 @@ function sameExternalSettings(a: ExternalMemoryBindingDraft, b: ExternalMemoryBi
 export function memorySettingsChanged(persisted: MemorySettingsDraft, draft: MemorySettingsDraft): boolean {
   if (persisted.provider !== draft.provider) return true
   if (draft.provider === 'managed') {
+    if (persisted.scope !== draft.scope) return true
+    // Under channel scope dreaming is hidden/disabled, so its draft fields don't count.
+    if (draft.scope === 'channel') return persisted.autoDistill !== draft.autoDistill
     return persisted.autoDistill !== draft.autoDistill || !sameDreaming(persisted.dreaming, draft.dreaming)
   }
   if (draft.provider === 'external') return !sameExternalSettings(persisted.external, draft.external)
@@ -180,6 +188,11 @@ export function memoryConfigForDraft(draft: MemorySettingsDraft): AgentMemoryCon
     }
   }
   if (draft.provider === 'managed') {
+    // Channel scope has no dreaming (offline consolidation doesn't map onto
+    // per-channel folders), so never serialize a dreaming policy with it.
+    if (draft.scope === 'channel') {
+      return { provider: 'managed', autoDistill: draft.autoDistill, scope: 'channel' }
+    }
     const dreaming = dreamingConfigForDraft(draft.dreaming)
     return { provider: 'managed', autoDistill: draft.autoDistill, ...(dreaming ? { dreaming } : {}) }
   }

--- a/packages/web/src/components/console/memory-settings.ts
+++ b/packages/web/src/components/console/memory-settings.ts
@@ -173,7 +173,11 @@ export function memorySettingsBlocker(draft: MemorySettingsDraft): string | null
   if (draft.provider === 'external' && !draft.external.connectionId) {
     return 'Choose an external-memory connection before saving.'
   }
-  if (draft.provider === 'managed') return dreamingScheduleBlocker(draft.dreaming)
+  if (draft.provider === 'managed') {
+    // Channel scope has no dreaming, so a stale (hidden) dreaming draft must not
+    // block the save — mirror memoryConfigForDraft, which drops it entirely.
+    return draft.scope === 'channel' ? null : dreamingScheduleBlocker(draft.dreaming)
+  }
   return null
 }
 

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1698,6 +1698,7 @@ export default function AgentDetailView() {
           canEdit={!da.name.startsWith(MOCK_PREFIX) && da.canEdit}
           memoryProvider={da.memoryProvider}
           autoDistill={da.memoryAutoDistill}
+          memoryScope={da.memoryScope}
           memoryDreaming={da.memoryDreaming}
           memoryConnectionId={da.memoryConnectionId}
           memoryRecall={da.memoryRecall}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -244,8 +244,12 @@ export interface MemoryDreamingConfig {
   autoAdopt?: boolean // adopt automatically without content review; absent defaults off
 }
 
+/** Managed-memory partitioning: `agent` (default) is one store per agent;
+ *  `channel` gives each channel its own memory folder (#653). */
+export type ManagedMemoryScope = 'agent' | 'channel'
+
 export type AgentMemoryConfig =
-  | { provider: 'managed'; autoDistill?: boolean; dreaming?: MemoryDreamingConfig }
+  | { provider: 'managed'; autoDistill?: boolean; dreaming?: MemoryDreamingConfig; scope?: ManagedMemoryScope }
   | { provider: 'native' | 'none'; autoDistill?: boolean }
   | {
       provider: 'external'
@@ -1694,6 +1698,7 @@ export function agentFromDto(d: AgentDto): Agent {
     // Memory backend (unset ⇒ managed default).
     memoryProvider: d.memory?.provider ?? 'managed',
     memoryAutoDistill: d.memory?.provider === 'managed' ? (d.memory.autoDistill ?? false) : false,
+    ...(d.memory?.provider === 'managed' && d.memory.scope === 'channel' ? { memoryScope: 'channel' as const } : {}),
     ...(d.memory?.provider === 'managed' && d.memory.dreaming ? { memoryDreaming: d.memory.dreaming } : {}),
     ...(d.memory?.provider === 'external'
       ? {

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -2,7 +2,7 @@
 // Ported from the AgentConnect design (static demo content for the console UI).
 
 import type { AgentIcon } from '@/lib/agent-icon'
-import type { DaemonSessionRetention, MemoryDreamingConfig } from '@/lib/api'
+import type { DaemonSessionRetention, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
 import { platformLabel } from '@/lib/platform-labels'
 
 export type LifecycleStatusKey = 'upgrading' | 'restarting'
@@ -269,6 +269,8 @@ export interface Agent {
   memoryProvider: string
   /** Opt-in managed-memory extraction after each completed turn. */
   memoryAutoDistill: boolean
+  /** Managed-memory partitioning; 'channel' ⇒ per-channel folders (#653). Absent ⇒ agent. */
+  memoryScope?: ManagedMemoryScope
   /** Managed-memory dreaming policy; present only when configured (managed provider). */
   memoryDreaming?: MemoryDreamingConfig
   /** External-memory binding metadata; present only when memoryProvider='external'. */


### PR DESCRIPTION
Part 2 of the channel memory scope feature (#653). Backend routing landed in #786; this adds the console control to **switch** scope and reflect it. The per-channel memory **viewer** (a channel selector + a "list channels with memory" endpoint) follows in a third PR.

## Change

- The memory settings **Scope** control is now an editable **Agent | Channel** pillbar (was a fixed, disabled "Agent"). Selecting Channel saves `memory.scope: 'channel'`.
- Under channel scope the **dreaming sub-section is hidden** and replaced with a short note (the backend already disables dreaming under channel scope), and the saved config never carries a dreaming policy.
- `MemorySettingsDraft` / `memoryConfigForDraft` / `memorySettingsChanged` carry `scope`; `AgentMemoryConfig` + the data mapping thread `memory.scope` through to the panel. The collapsed summary shows "Channel scope" (dreaming chips dropped) vs the agent-scope chips.

## Tests

- `memory-settings`: scope round-trip (channel ⇒ no dreaming in config; agent→channel is a change; dreaming-field edits don't count under channel scope).
- `MemoryPanel`: the Agent/Channel toggle hides dreaming under channel and saves `scope: 'channel'`.
- Full web suite green.

## Follow-up (PR3)

Channel memory **viewer**: a "list channels with memory" daemon endpoint + `channelKey` on the memory read frames, and a channel selector in the memory viewer so a human can browse each channel's folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)