### PR TITLE
feat(memory): channel memory viewer — selector + per-channel reads

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2712,8 +2712,26 @@ export const MemoryFilesDto = z.object({
   exists: z.boolean(), // false ⇒ the memory dir does not exist yet
   files: z.array(MemoryFileEntryDto)
 })
+/** A channel memory folder's key; selects the channel layer for a channel-scoped
+ *  agent (#653). Absent ⇒ the agent-level store. */
+const MemoryChannelKeyQuery = z
+  .string()
+  .min(1)
+  .max(120)
+  .regex(/^[A-Za-z0-9._-]+$/)
+  .optional()
+/** Query for listing memory files, optionally scoped to one channel folder. */
+export const MemoryFilesQueryDto = z.object({ channelKey: MemoryChannelKeyQuery })
+/** One channel with its own memory folder (console channel selector). */
+export const MemoryChannelDto = z.object({
+  channelKey: z.string(),
+  channel: z.string().nullable(),
+  transportScope: z.string().nullable()
+})
+export const MemoryChannelsDto = z.object({ channels: z.array(MemoryChannelDto) })
 /** Query for reading one memory file: `path` (defaults to the MEMORY.md index) + slice. */
 export const MemoryFileQueryDto = z.object({
+  channelKey: MemoryChannelKeyQuery,
   path: z.string().min(1).optional(), // memory-dir-relative file name; defaults to MEMORY.md
   offset: z.coerce.number().int().nonnegative().optional(), // byte offset
   limit: z.coerce.number().int().positive().max(65536).optional() // byte count per slice
@@ -2731,7 +2749,7 @@ export const AgentMemoryDto = z.object({
   truncated: z.boolean().nullable() // true ⇒ nextOffset < size (more bytes remain)
 })
 /** Write query: which memory file to replace (defaults to the MEMORY.md index). */
-export const PutMemoryFileQueryDto = z.object({ path: z.string().min(1).optional() })
+export const PutMemoryFileQueryDto = z.object({ channelKey: MemoryChannelKeyQuery, path: z.string().min(1).optional() })
 /** `PUT /agents/:id/memory[/file]` — replace the whole named memory file.
  *  `ifMatchMtime` (optional) is optimistic concurrency: the mtime the client last
  *  read; the write 409s if the file changed under it. */
@@ -2745,6 +2763,7 @@ export const AgentMemoryWriteDto = z.object({
 
 /** `GET /agents/:id/memory/history` — newest-first provenance for one managed file. */
 export const MemoryHistoryQueryDto = z.object({
+  channelKey: MemoryChannelKeyQuery,
   path: z.string().min(1).max(255),
   cursor: z.string().uuid().optional(),
   limit: z.coerce.number().int().positive().max(5).optional()

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -102,6 +102,8 @@ import {
   WorkspaceGitPullDto,
   AgentMemoryDto,
   MemoryFilesDto,
+  MemoryFilesQueryDto,
+  MemoryChannelsDto,
   MemoryFileQueryDto,
   PutMemoryFileQueryDto,
   PutAgentMemoryBody,
@@ -2691,6 +2693,7 @@ export function agentRoutes(deps: HttpDeps) {
         try {
           const rep = await deps.control.memoryRead(agent.daemonId, {
             agentId: agent.id,
+            ...(req.query.channelKey ? { channelKey: req.query.channelKey } : {}),
             path: req.query.path ?? 'MEMORY.md',
             offset: req.query.offset ?? 0,
             limit: req.query.limit ?? 65536
@@ -2717,6 +2720,7 @@ export function agentRoutes(deps: HttpDeps) {
             "List the files in the agent's memory dir (MEMORY.md index + topic files) live from the owning daemon. 503 when unplaced or the daemon is offline.",
           operationId: 'listAgentMemoryFiles',
           params: IdParam,
+          querystring: MemoryFilesQueryDto,
           response: { 200: MemoryFilesDto, 400: ErrorDto, 404: ErrorDto, 503: ErrorDto }
         }
       },
@@ -2737,8 +2741,55 @@ export function agentRoutes(deps: HttpDeps) {
             .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
         }
         try {
-          const rep = await deps.control.memoryList(agent.daemonId, { agentId: agent.id })
+          const rep = await deps.control.memoryList(agent.daemonId, {
+            agentId: agent.id,
+            ...(req.query.channelKey ? { channelKey: req.query.channelKey } : {})
+          })
           return toMemoryFilesDto(rep)
+        } catch (err) {
+          const unavailable = daemonEdgeFailure(err)
+          if (unavailable !== null) {
+            return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: unavailable })
+          }
+          throw err
+        }
+      }
+    )
+
+    // List the channels that have their own memory folder (channel-scoped agents).
+    r.get(
+      '/agents/:id/memory/channels',
+      {
+        schema: {
+          tags: [Tag.Agents],
+          summary: 'List agent channel memory folders',
+          description:
+            'List the channels that have their own memory folder for a channel-scoped agent, live from the owning daemon (empty for agent-scoped agents). 503 when unplaced or the daemon is offline.',
+          operationId: 'listAgentMemoryChannels',
+          params: IdParam,
+          response: { 200: MemoryChannelsDto, 400: ErrorDto, 404: ErrorDto, 503: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const agent = await getOrgAgent(req, req.params.id)
+        if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+        if (agent.memory?.provider !== undefined && agent.memory.provider !== 'managed') {
+          return { channels: [] }
+        }
+        if (!agent.daemonId) {
+          return reply
+            .code(503)
+            .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
+        }
+        try {
+          const rep = await deps.control.memoryChannels(agent.daemonId, { agentId: agent.id })
+          return {
+            channels: rep.channels.map((c) => ({
+              channelKey: c.channelKey,
+              channel: c.channel ?? null,
+              transportScope: c.transportScope ?? null
+            }))
+          }
         } catch (err) {
           const unavailable = daemonEdgeFailure(err)
           if (unavailable !== null) {
@@ -2783,6 +2834,7 @@ export function agentRoutes(deps: HttpDeps) {
         try {
           const rep = await deps.control.memoryRead(agent.daemonId, {
             agentId: agent.id,
+            ...(req.query.channelKey ? { channelKey: req.query.channelKey } : {}),
             path: req.query.path ?? 'MEMORY.md',
             offset: req.query.offset ?? 0,
             limit: req.query.limit ?? 65536
@@ -2846,6 +2898,7 @@ export function agentRoutes(deps: HttpDeps) {
         try {
           const ok = await deps.control.memoryWrite(agent.daemonId, {
             agentId: agent.id,
+            ...(req.query.channelKey ? { channelKey: req.query.channelKey } : {}),
             path: req.query.path ?? 'MEMORY.md',
             content: req.body.content,
             ...(req.body.ifMatchMtime ? { ifMatchMtime: req.body.ifMatchMtime } : {})
@@ -2910,6 +2963,7 @@ export function agentRoutes(deps: HttpDeps) {
           return toMemoryHistoryPageDto(
             await deps.control.memoryHistory(agent.daemonId, {
               agentId: agent.id,
+              ...(req.query.channelKey ? { channelKey: req.query.channelKey } : {}),
               path: req.query.path,
               ...(req.query.cursor ? { cursor: req.query.cursor } : {}),
               limit: req.query.limit ?? 5

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -52,6 +52,8 @@ import type {
   WorkspaceGitStatus,
   WorkspaceGitPullReq,
   WorkspaceGitPullResult,
+  MemoryChannelsReq,
+  MemoryChannelsPage,
   MemoryListReq,
   MemoryListPage,
   MemoryReadReq,
@@ -529,6 +531,15 @@ export class ControlSender {
   async memoryList(daemonId: string, req: MemoryListReq): Promise<MemoryListPage> {
     const c = this.must(daemonId)
     return c.conn.request<MemoryListPage>('memory/list', req, { epoch: c.sessionEpoch })
+  }
+
+  /**
+   * List the channels that have a memory folder for a channel-scoped agent, for the
+   * console channel selector (REQ → `memory/channels/page`). Read-only proxy.
+   */
+  async memoryChannels(daemonId: string, req: MemoryChannelsReq): Promise<MemoryChannelsPage> {
+    const c = this.must(daemonId)
+    return c.conn.request<MemoryChannelsPage>('memory/channels', req, { epoch: c.sessionEpoch })
   }
 
   /**

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -46,6 +46,7 @@ import type {
   ChildSessionStatus,
   ChildSessionStatusReq,
   ChildSessionStatusProbe,
+  MemoryChannelsReq,
   MemoryListReq,
   MemoryReadReq,
   MemoryWriteReq,
@@ -1270,6 +1271,13 @@ export class CpClient {
           .pull((frame.payload as WorkspaceGitPullReq).agentId)
           .then((result) => this.reply(frame, 'workspace/gitpull/result', result))
           .catch((err) => this.workspaceError(frame.id, 'workspace/gitpull', err))
+        return
+      }
+      case 'memory/channels': {
+        this.deps.memoryReader
+          .channels(frame.payload as MemoryChannelsReq)
+          .then((page) => this.reply(frame, 'memory/channels/page', page))
+          .catch((err) => this.memoryError(frame.id, 'memory/channels', err))
         return
       }
       case 'memory/list': {

--- a/packages/daemon/src/cp/memory-reader.ts
+++ b/packages/daemon/src/cp/memory-reader.ts
@@ -13,6 +13,8 @@
  */
 import { randomUUID } from 'node:crypto'
 import type {
+  MemoryChannelsReq,
+  MemoryChannelsPage,
   MemoryListReq,
   MemoryListPage,
   MemoryReadReq,
@@ -45,6 +47,8 @@ import {
   listMemoryHistory,
   readMemoryFile,
   writeMemoryFile,
+  listChannelMemoryKeys,
+  readChannelMemoryMeta,
   MemoryPathError,
   MemoryTooLargeError,
   MemoryConflictError
@@ -63,6 +67,7 @@ export class MemoryViolationError extends Error {
 export { MemoryPathError, MemoryTooLargeError, MemoryConflictError }
 
 export interface MemoryReader {
+  channels(req: MemoryChannelsReq): Promise<MemoryChannelsPage>
   list(req: MemoryListReq): Promise<MemoryListPage>
   read(req: MemoryReadReq): Promise<MemoryReadContent>
   write(req: MemoryWriteReq): Promise<MemoryWriteOk>
@@ -134,12 +139,30 @@ export function createMemoryReader(
     return surface
   }
 
-  const scopeFor = (agentId: string): MemoryScope => ({ agentId })
+  const scopeFor = (agentId: string, channelKey?: string): MemoryScope => ({
+    agentId,
+    ...(channelKey ? { channelKey } : {})
+  })
 
   return {
+    async channels(req) {
+      const dir = dirFor(req.agentId)
+      const keys = await listChannelMemoryKeys(dir)
+      const channels = []
+      for (const channelKey of keys) {
+        const meta = await readChannelMemoryMeta(dir, channelKey)
+        channels.push({
+          channelKey,
+          ...(meta?.channel ? { channel: meta.channel } : {}),
+          ...(meta?.transportScope ? { transportScope: meta.transportScope } : {})
+        })
+      }
+      return { agentId: req.agentId, channels }
+    },
+
     async list(req) {
       const surface = requireFileSurface(req.agentId)
-      const files = await surface.list(scopeFor(req.agentId))
+      const files = await surface.list(scopeFor(req.agentId, req.channelKey))
       // Providers return [] for a missing/empty store; the console shows that as
       // `exists:false`, preserving the legacy file-frame contract.
       return { agentId: req.agentId, exists: files.length > 0, entries: files }
@@ -147,7 +170,7 @@ export function createMemoryReader(
 
     async read(req) {
       const surface = requireFileSurface(req.agentId)
-      const scope = scopeFor(req.agentId)
+      const scope = scopeFor(req.agentId, req.channelKey)
       const notFound = { agentId: req.agentId, path: req.path, exists: false }
 
       const files = await surface.list(scope)
@@ -189,7 +212,7 @@ export function createMemoryReader(
     async write(req) {
       const surface = requireFileSurface(req.agentId)
       const { size, mtime } = await surface.write(
-        scopeFor(req.agentId),
+        scopeFor(req.agentId, req.channelKey),
         req.path,
         req.content,
         req.ifMatchMtime,
@@ -203,7 +226,7 @@ export function createMemoryReader(
       if (!surface.history) {
         throw new MemoryViolationError('this memory provider does not expose file history')
       }
-      const page = await surface.history(scopeFor(req.agentId), {
+      const page = await surface.history(scopeFor(req.agentId, req.channelKey), {
         path: req.path,
         ...(req.cursor ? { cursor: req.cursor } : {}),
         limit: req.limit

--- a/packages/daemon/test/channel-memory.test.ts
+++ b/packages/daemon/test/channel-memory.test.ts
@@ -9,6 +9,7 @@ import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createManagedMemoryProvider } from '../src/agents/memory-provider.js'
+import { createMemoryReader } from '../src/cp/memory-reader.js'
 import {
   memoryChannelKey,
   channelMemoryRoot,
@@ -109,6 +110,30 @@ describe('channel-scoped memory overlay', () => {
     const injected = await mem.standingContextAtSessionStart(a)
     expect(injected.indexOf('# base index')).toBeGreaterThanOrEqual(0)
     expect(injected.indexOf('# channel index')).toBeGreaterThan(injected.indexOf('# base index'))
+  })
+
+  it('the CP memory reader lists channel folders and routes reads to the selected channel', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-chan-reader-'))
+    const mem = createManagedMemoryProvider(() => dir)
+    const reader = createMemoryReader(() => dir, { adminSurfaceForAgent: () => mem.adminSurface() })
+    const a = chan('C1')
+    mem.ensure(a, 'bot')
+    await mem.write(a, 'notes.md', '- channel A note', undefined, 'tool')
+
+    // channels() surfaces the folder with its source identity.
+    expect((await reader.channels({ agentId: 'bot-a' })).channels).toContainEqual({
+      channelKey: a.channelKey,
+      channel: 'C1'
+    })
+    // list/read scoped to the channelKey see the channel layer; the base does not.
+    expect(
+      (await reader.list({ agentId: 'bot-a', channelKey: a.channelKey })).entries.some((e) => e.name === 'notes.md')
+    ).toBe(true)
+    expect((await reader.list({ agentId: 'bot-a' })).entries.some((e) => e.name === 'notes.md')).toBe(false)
+    expect(
+      (await reader.read({ agentId: 'bot-a', channelKey: a.channelKey, path: 'notes.md', offset: 0, limit: 65536 }))
+        .content
+    ).toBe('- channel A note')
   })
 
   it('records channel source metadata so the console can name folders', async () => {

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -70,6 +70,8 @@ import {
   WorkspaceGitPullResult
 } from './frames/workspace.js'
 import {
+  MemoryChannelsReq,
+  MemoryChannelsPage,
   MemoryListReq,
   MemoryListPage,
   MemoryReadReq,
@@ -290,6 +292,8 @@ export const FRAME_SCHEMAS = {
   'workspace/gitstatus/result': WorkspaceGitStatus,
   'workspace/gitpull': WorkspaceGitPullReq,
   'workspace/gitpull/result': WorkspaceGitPullResult,
+  'memory/channels': MemoryChannelsReq,
+  'memory/channels/page': MemoryChannelsPage,
   'memory/list': MemoryListReq,
   'memory/list/page': MemoryListPage,
   'memory/read': MemoryReadReq,
@@ -496,6 +500,8 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('workspace/gitstatus/result', FRAME_SCHEMAS['workspace/gitstatus/result']),
   frame('workspace/gitpull', FRAME_SCHEMAS['workspace/gitpull']),
   frame('workspace/gitpull/result', FRAME_SCHEMAS['workspace/gitpull/result']),
+  frame('memory/channels', FRAME_SCHEMAS['memory/channels']),
+  frame('memory/channels/page', FRAME_SCHEMAS['memory/channels/page']),
   frame('memory/list', FRAME_SCHEMAS['memory/list']),
   frame('memory/list/page', FRAME_SCHEMAS['memory/list/page']),
   frame('memory/read', FRAME_SCHEMAS['memory/read']),

--- a/packages/protocol/src/frames/memory.ts
+++ b/packages/protocol/src/frames/memory.ts
@@ -42,11 +42,42 @@ export const MemoryEntry = z.object({
 })
 export type MemoryEntry = z.infer<typeof MemoryEntry>
 
-/** C→D REQ: list the files in the agent's memory dir. */
+/** A channel's memory-folder key (from `memoryChannelKey`) — selects the channel
+ *  layer for a channel-scoped agent's console reads/writes (#653). Absent ⇒ the
+ *  agent-level store. Bounded + charset-limited so it can't escape the tree. */
+export const MemoryChannelKey = z
+  .string()
+  .min(1)
+  .max(120)
+  .regex(/^[A-Za-z0-9._-]+$/)
+
+/** C→D REQ: list the files in the agent's memory dir (or one channel's overlay). */
 export const MemoryListReq = z.object({
-  agentId: z.string().min(1) // local agent id (NOT a wire UUID)
+  agentId: z.string().min(1), // local agent id (NOT a wire UUID)
+  channelKey: MemoryChannelKey.optional()
 })
 export type MemoryListReq = z.infer<typeof MemoryListReq>
+
+/** C→D REQ: list the channels that have a memory folder for this agent. */
+export const MemoryChannelsReq = z.object({
+  agentId: z.string().min(1)
+})
+export type MemoryChannelsReq = z.infer<typeof MemoryChannelsReq>
+
+/** One channel with its own memory folder, for the console channel selector. */
+export const MemoryChannelEntry = z.object({
+  channelKey: MemoryChannelKey,
+  channel: z.string().optional(), // source channel id (from channel.json), if recorded
+  transportScope: z.string().optional()
+})
+export type MemoryChannelEntry = z.infer<typeof MemoryChannelEntry>
+
+/** D→C REP: the agent's channel memory folders (empty when none / not channel-scoped). */
+export const MemoryChannelsPage = z.object({
+  agentId: z.string(),
+  channels: z.array(MemoryChannelEntry).max(1000)
+})
+export type MemoryChannelsPage = z.infer<typeof MemoryChannelsPage>
 
 /** D→C REP (corr = the req id): the memory dir's files (or `exists:false`). */
 export const MemoryListPage = z.object({
@@ -59,6 +90,7 @@ export type MemoryListPage = z.infer<typeof MemoryListPage>
 /** C→D REQ: read one byte slice of a memory file (path relative to the memory dir). */
 export const MemoryReadReq = z.object({
   agentId: z.string().min(1), // local agent id (NOT a wire UUID)
+  channelKey: MemoryChannelKey.optional(),
   path: z.string().default(MEMORY_INDEX), // memory-dir-relative POSIX path; default the index
   offset: z.number().int().nonnegative().default(0), // byte offset
   limit: z.number().int().positive().max(65536).default(65536) // byte count per slice (64 KiB, see docblock)
@@ -82,6 +114,7 @@ export type MemoryReadContent = z.infer<typeof MemoryReadContent>
 /** C→D REQ: replace the whole named memory file with `content` (console edit). */
 export const MemoryWriteReq = z.object({
   agentId: z.string().min(1), // local agent id (NOT a wire UUID)
+  channelKey: MemoryChannelKey.optional(),
   path: z.string().default(MEMORY_INDEX), // memory-dir-relative POSIX path; default the index
   content: z.string(), // full new file content (utf8); '' clears the file
   // Optimistic concurrency: the mtime the writer last read. When present the write
@@ -121,6 +154,7 @@ export type MemoryFileHistoryEvent = z.infer<typeof MemoryFileHistoryEvent>
 export const MemoryHistoryReq = z
   .object({
     agentId: z.string().min(1).max(255),
+    channelKey: MemoryChannelKey.optional(),
     path: z.string().min(1).max(255),
     // Opaque to callers. This is a stable event ID, so appends and retention
     // cannot shift older pages.

--- a/packages/web/src/components/console/ManagedMemoryHistory.tsx
+++ b/packages/web/src/components/console/ManagedMemoryHistory.tsx
@@ -102,7 +102,15 @@ function HistoryEvent({ event }: { event: MemoryFileHistoryEventDto }) {
 }
 
 /** Read-only panel over managed memory's hidden `.history` sidecar; its summary action mounts this lazily. */
-export function ManagedMemoryHistory({ agentId, path }: { agentId: string; path: string }) {
+export function ManagedMemoryHistory({
+  agentId,
+  path,
+  channelKey
+}: {
+  agentId: string
+  path: string
+  channelKey?: string
+}) {
   const request = useRef(0)
   const [events, setEvents] = useState<MemoryFileHistoryEventDto[] | null>(null)
   const [nextCursor, setNextCursor] = useState<string | null>(null)
@@ -115,7 +123,11 @@ export function ManagedMemoryHistory({ agentId, path }: { agentId: string; path:
       setLoading(true)
       setError(null)
       try {
-        const page = await listMemoryFileHistory(agentId, path, { ...(cursor ? { cursor } : {}), limit: PAGE_SIZE })
+        const page = await listMemoryFileHistory(agentId, path, {
+          ...(cursor ? { cursor } : {}),
+          ...(channelKey ? { channelKey } : {}),
+          limit: PAGE_SIZE
+        })
         if (id !== request.current) return
         setEvents((current) => (append ? [...(current ?? []), ...page.events] : page.events))
         setNextCursor(page.nextCursor)
@@ -132,7 +144,7 @@ export function ManagedMemoryHistory({ agentId, path }: { agentId: string; path:
         if (id === request.current) setLoading(false)
       }
     },
-    [agentId, path]
+    [agentId, path, channelKey]
   )
 
   useEffect(() => {

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -18,7 +18,8 @@ vi.mock('@/lib/api', () => ({
   },
   fetchAgentMemoryFull: vi.fn(),
   listAgentMemory: vi.fn(),
-  updateAgentMemory: vi.fn()
+  updateAgentMemory: vi.fn(),
+  fetchAgentMemoryChannels: vi.fn(async () => ({ channels: [] }))
 }))
 
 vi.mock('@/components/console/ExternalMemoryBindingFields', () => ({
@@ -189,7 +190,8 @@ describe('MemoryPanel file editor', () => {
       '22222222-2222-4222-8222-222222222222',
       '# Deploys',
       'deploys.md',
-      undefined
+      undefined,
+      undefined // channelKey — agent scope
     )
   })
 

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -59,7 +59,7 @@ vi.mock('@/components/console/ManagedMemoryHistory', () => ({
   ManagedMemoryHistory: () => <div data-testid="memory-file-history" />
 }))
 
-import { fetchAgentMemoryFull, listAgentMemory, updateAgentMemory } from '@/lib/api'
+import { fetchAgentMemoryFull, listAgentMemory, updateAgentMemory, fetchAgentMemoryChannels } from '@/lib/api'
 import { MemoryPanel } from './MemoryPanel'
 
 const CONNECTION_ID = '11111111-1111-4111-8111-111111111111'
@@ -84,6 +84,7 @@ beforeEach(() => {
   vi.mocked(updateAgentMemory)
     .mockReset()
     .mockResolvedValue({ path: 'MEMORY.md', size: 9, mtime: '2026-07-27T09:01:00.000Z' })
+  vi.mocked(fetchAgentMemoryChannels).mockReset().mockResolvedValue({ channels: [] })
 })
 
 afterEach(async () => {
@@ -405,6 +406,48 @@ describe('MemoryPanel settings draft', () => {
     expect(mocks.updateAgent).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222', {
       memory: { provider: 'managed', autoDistill: false, scope: 'channel' }
     })
+  })
+
+  it('channel scope: the viewer lists channels and reads the selected channel (#653)', async () => {
+    vi.mocked(fetchAgentMemoryChannels).mockResolvedValue({
+      channels: [
+        { channelKey: 'slack-C1-abc', channel: 'C1', transportScope: null },
+        { channelKey: 'slack-C2-def', channel: 'C2', transportScope: null }
+      ]
+    })
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(
+        <MemoryPanel
+          agentId="22222222-2222-4222-8222-222222222222"
+          canEdit
+          memoryProvider="managed"
+          memoryScope="channel"
+          autoDistill={false}
+        />
+      )
+    })
+    // Let the channel-fetch effect resolve and re-render.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    const selector = container.querySelector<HTMLSelectElement>('[aria-label="Channel memory folder"]')
+    expect(selector).not.toBeNull()
+    expect([...selector!.options].map((o) => o.textContent)).toEqual(['Agent (shared)', 'C1', 'C2'])
+
+    vi.mocked(listAgentMemory).mockClear()
+    vi.mocked(fetchAgentMemoryFull).mockClear()
+    await act(async () => {
+      selector!.value = 'slack-C2-def'
+      selector!.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    // Reads for the newly selected channel carry its channelKey.
+    expect(listAgentMemory).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222', 'slack-C2-def')
+    expect(fetchAgentMemoryFull).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222', undefined, 'slack-C2-def')
   })
 
   it('hides the persisted memory session while a different backend is selected but unsaved', async () => {

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -243,6 +243,7 @@ export function MemoryPanel({
     const next = settingsFromProps({
       memoryProvider,
       autoDistill,
+      memoryScope,
       memoryDreaming,
       memoryConnectionId,
       memoryRecall,
@@ -256,6 +257,7 @@ export function MemoryPanel({
     agentId,
     memoryProvider,
     autoDistill,
+    memoryScope,
     memoryDreaming?.enabled,
     memoryDreaming?.sessionWindow,
     memoryDreaming?.schedule,
@@ -452,11 +454,13 @@ export function MemoryPanel({
   }, [loadList, loadFile, persistedProvider])
 
   // Under channel scope, load the list of channels that have their own memory folder
-  // so the viewer can offer a channel selector. Reset when not channel-scoped.
+  // so the viewer can offer a channel selector. Always reset the selection first —
+  // the component instance is reused across agent navigations, so a stale channelKey
+  // from another agent must never leak into this one's reads.
   useEffect(() => {
+    setSelectedChannel(undefined)
     if (persistedProvider !== 'managed' || persistedSettings.scope !== 'channel') {
       setChannels([])
-      setSelectedChannel(undefined)
       return
     }
     let live = true

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -17,9 +17,11 @@ import {
   fetchAgentMemoryFull,
   updateAgentMemory,
   listAgentMemory,
+  fetchAgentMemoryChannels,
   ApiError,
   type MemoryFileEntry,
   type ManagedMemoryScope,
+  type MemoryChannelDto,
   type MemoryDreamingConfig
 } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
@@ -195,6 +197,11 @@ export function MemoryPanel({
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [historyOpen, setHistoryOpen] = useState(false)
+  // Channel memory viewer (#653): the channels with their own folder, and which one
+  // is being viewed. `undefined` = the shared agent-level base. Only meaningful when
+  // the persisted scope is `channel`.
+  const [channels, setChannels] = useState<MemoryChannelDto[]>([])
+  const [selectedChannel, setSelectedChannel] = useState<string | undefined>(undefined)
   const loadRequest = useRef(0)
   const listRequest = useRef(0)
 
@@ -370,7 +377,7 @@ export function MemoryPanel({
     setListLoading(true)
     setListError(null)
     try {
-      const { files } = await listAgentMemory(agentId)
+      const { files } = await listAgentMemory(agentId, selectedChannel)
       if (request !== listRequest.current) return
       setFiles(files)
     } catch (e) {
@@ -385,7 +392,7 @@ export function MemoryPanel({
     } finally {
       if (request === listRequest.current) setListLoading(false)
     }
-  }, [agentId])
+  }, [agentId, selectedChannel])
 
   // Load one file's content WHOLE (paging every slice) so the editor holds the full
   // file — a partial read would let Save clobber the tail. The index is fetched via
@@ -401,7 +408,7 @@ export function MemoryPanel({
       setLoadedMtime(null)
       setFileExists(null)
       try {
-        const mem = await fetchAgentMemoryFull(agentId, name === INDEX ? undefined : name)
+        const mem = await fetchAgentMemoryFull(agentId, name === INDEX ? undefined : name, selectedChannel)
         if (request !== loadRequest.current) return
         setContent(mem.content)
         setLoadedMtime(mem.mtime)
@@ -419,7 +426,7 @@ export function MemoryPanel({
         if (request === loadRequest.current) setLoading(false)
       }
     },
-    [agentId]
+    [agentId, selectedChannel]
   )
 
   useEffect(() => {
@@ -443,6 +450,27 @@ export function MemoryPanel({
       listRequest.current += 1
     }
   }, [loadList, loadFile, persistedProvider])
+
+  // Under channel scope, load the list of channels that have their own memory folder
+  // so the viewer can offer a channel selector. Reset when not channel-scoped.
+  useEffect(() => {
+    if (persistedProvider !== 'managed' || persistedSettings.scope !== 'channel') {
+      setChannels([])
+      setSelectedChannel(undefined)
+      return
+    }
+    let live = true
+    void fetchAgentMemoryChannels(agentId)
+      .then((r) => {
+        if (live) setChannels(r.channels)
+      })
+      .catch(() => {
+        if (live) setChannels([])
+      })
+    return () => {
+      live = false
+    }
+  }, [agentId, persistedProvider, persistedSettings.scope])
 
   const select = (name: string) => {
     if (name === selected) {
@@ -508,7 +536,8 @@ export function MemoryPanel({
         agentId,
         savingEditor.content,
         target === INDEX ? undefined : target,
-        creating ? undefined : savingEditor.mtime
+        creating ? undefined : savingEditor.mtime,
+        selectedChannel
       )
       setSelected(target)
       setContent(savingEditor.content)
@@ -602,7 +631,12 @@ export function MemoryPanel({
       />
 
       {historyOpen && persistedProvider === 'managed' && fileExists === true ? (
-        <ManagedMemoryHistory key={`${agentId}:${selected}`} agentId={agentId} path={selected} />
+        <ManagedMemoryHistory
+          key={`${agentId}:${selected}:${selectedChannel ?? ''}`}
+          agentId={agentId}
+          path={selected}
+          channelKey={selectedChannel}
+        />
       ) : loading ? (
         <div className="flex items-center justify-center py-10">
           <Spinner />
@@ -909,6 +943,27 @@ export function MemoryPanel({
         </div>
       ) : (
         <>
+          {persistedProvider === 'managed' && persistedSettings.scope === 'channel' ? (
+            <div className="flex flex-wrap items-center gap-2 px-4 pt-3 font-sans text-[12px] leading-normal text-(--text-secondary)">
+              <span className="font-semibold">Channel</span>
+              <select
+                value={selectedChannel ?? ''}
+                onChange={(event) => setSelectedChannel(event.target.value || undefined)}
+                aria-label="Channel memory folder"
+                className="rounded-sm border border-(--border-subtle) bg-(--surface-card) px-2 py-1 font-sans text-[12px] text-(--text-primary)"
+              >
+                <option value="">Agent (shared)</option>
+                {channels.map((entry) => (
+                  <option key={entry.channelKey} value={entry.channelKey}>
+                    {entry.channel ?? entry.channelKey}
+                  </option>
+                ))}
+              </select>
+              {channels.length === 0 ? (
+                <span className="text-(--text-tertiary)">No channel has memory yet — showing the shared base.</span>
+              ) : null}
+            </div>
+          ) : null}
           <FileBrowserShell
             title={
               <FileBrowserBreadcrumb

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2432,16 +2432,33 @@ export interface MemoryFilesDto {
 }
 
 // List the files in the agent's memory dir (MEMORY.md index + topic files).
-export async function listAgentMemory(agentId: string): Promise<MemoryFilesDto> {
-  return apiGet<MemoryFilesDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/memory/files`)
+/** A channel that has its own memory folder (channel-scoped agents, #653). */
+export interface MemoryChannelDto {
+  channelKey: string
+  channel: string | null
+  transportScope: string | null
+}
+export interface MemoryChannelsDto {
+  channels: MemoryChannelDto[]
+}
+
+/** List the channels that have their own memory folder (empty for agent scope). */
+export async function fetchAgentMemoryChannels(agentId: string): Promise<MemoryChannelsDto> {
+  return apiGet<MemoryChannelsDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/memory/channels`)
+}
+
+export async function listAgentMemory(agentId: string, channelKey?: string): Promise<MemoryFilesDto> {
+  const q = channelKey ? `?channelKey=${encodeURIComponent(channelKey)}` : ''
+  return apiGet<MemoryFilesDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/memory/files${q}`)
 }
 
 // Read one memory file (`path` defaults to the MEMORY.md index).
 export async function fetchAgentMemory(
   agentId: string,
-  opts: { path?: string; offset?: number; limit?: number } = {}
+  opts: { path?: string; offset?: number; limit?: number; channelKey?: string } = {}
 ): Promise<AgentMemoryDto> {
   const q = new URLSearchParams()
+  if (opts.channelKey) q.set('channelKey', opts.channelKey)
   if (opts.path) q.set('path', opts.path)
   if (opts.offset) q.set('offset', String(opts.offset))
   if (opts.limit) q.set('limit', String(opts.limit))
@@ -2456,7 +2473,8 @@ export async function fetchAgentMemory(
 // (a partial read would let Save clobber the tail). Returns { exists, content }.
 export async function fetchAgentMemoryFull(
   agentId: string,
-  path?: string
+  path?: string,
+  channelKey?: string
 ): Promise<{ exists: boolean; content: string; mtime: string | null }> {
   let offset = 0
   let content = ''
@@ -2464,7 +2482,11 @@ export async function fetchAgentMemoryFull(
   let mtime: string | null = null
   // Bounded loop: nextOffset strictly advances while truncated, so this terminates.
   for (let guard = 0; guard < 4096; guard++) {
-    const slice = await fetchAgentMemory(agentId, path ? { path, offset } : { offset })
+    const slice = await fetchAgentMemory(agentId, {
+      offset,
+      ...(path ? { path } : {}),
+      ...(channelKey ? { channelKey } : {})
+    })
     exists = slice.exists
     mtime = slice.mtime
     if (!slice.exists) break
@@ -2482,11 +2504,15 @@ export async function updateAgentMemory(
   agentId: string,
   content: string,
   path?: string,
-  ifMatchMtime?: string | null
+  ifMatchMtime?: string | null,
+  channelKey?: string
 ): Promise<{ path: string; size: number; mtime: string }> {
-  const q = path ? `?path=${encodeURIComponent(path)}` : ''
+  const q = new URLSearchParams()
+  if (channelKey) q.set('channelKey', channelKey)
+  if (path) q.set('path', path)
+  const qs = q.toString()
   return apiPut<{ path: string; size: number; mtime: string }>(
-    `${orgBase()}/agents/${encodeURIComponent(agentId)}/memory/file${q}`,
+    `${orgBase()}/agents/${encodeURIComponent(agentId)}/memory/file${qs ? `?${qs}` : ''}`,
     ifMatchMtime ? { content, ifMatchMtime } : { content }
   )
 }
@@ -2513,9 +2539,10 @@ export interface MemoryFileHistoryPageDto {
 export async function listMemoryFileHistory(
   agentId: string,
   path: string,
-  opts: { cursor?: string; limit?: number } = {}
+  opts: { cursor?: string; limit?: number; channelKey?: string } = {}
 ): Promise<MemoryFileHistoryPageDto> {
   const query = new URLSearchParams({ path })
+  if (opts.channelKey) query.set('channelKey', opts.channelKey)
   if (opts.cursor) query.set('cursor', opts.cursor)
   if (opts.limit) query.set('limit', String(opts.limit))
   return apiGet<MemoryFileHistoryPageDto>(


### PR DESCRIPTION
Part 3 (final) of the channel memory scope feature (#653). Routing landed in #786, the scope toggle in #788; this adds the console **viewer** so a human can browse each channel's memory.

## Change

- **protocol:** optional `channelKey` on the memory read/write/history frames + new `memory/channels` ⇄ `memory/channels/page` frames (the channel folders for the selector).
- **daemon:** `cp/memory-reader` threads `channelKey` into its scope, so list/read/write/history hit the channel overlay in the provider; adds `channels()` (via `listChannelMemoryKeys` + the `channel.json` metadata). `cp/client` dispatches `memory/channels`.
- **CP:** `ControlSender.memoryChannels` + `GET /agents/:id/memory/channels`; the existing memory routes accept an optional `channelKey` query/param and forward it.
- **web:** `fetchAgentMemoryChannels` + `channelKey` on the memory api calls; the MemoryPanel viewer shows a **channel selector** under channel scope ("Agent (shared)" + one entry per channel, named from `channel.json`) and loads that channel's files, content, and history.

## Tests

- daemon: the memory-reader lists channel folders and routes reads to the selected channel (base vs channel isolation).
- web: MemoryPanel api-mock + save-arg updated for `channelKey`.
- CP `agents.memory` route integration suite green; protocol/CP-unit/web suites green.

This completes the channel memory scope feature: switch scope (#788), per-channel routing (#786), and browse each channel's memory (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)