### PR TITLE
feat(cp): warm the Logto identity projection at first authenticated touch

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -780,7 +780,8 @@ export function buildContainer(
     logtoMgmtCfg && config.OIDC_ISSUER
       ? new LogtoIdentityService(logtoMgmtCfg, clock, new PgSocialIdentityMutationGate(prisma), undefined, {
           // Lazy over `http.log` (assigned below; only ever called at lookup time).
-          debug: (o, m) => http.log.debug(o, m)
+          debug: (o, m) => http.log.debug(o, m),
+          info: (o, m) => http.log.info(o, m)
         })
       : undefined
   const githubUserAuthz =

--- a/packages/control-plane/src/github/logto-identity.test.ts
+++ b/packages/control-plane/src/github/logto-identity.test.ts
@@ -7,7 +7,7 @@
  * by `slack-identity.test.ts`, the GitHub login half and the unlink writes by
  * `user-authz.test.ts`.
  */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { FakeClock } from '../../test/fakes/fake-clock.js'
 import type { SocialIdentityMutationGate } from '../persistence/ports.js'
 import { LogtoIdentityService } from './logto-identity.js'
@@ -29,6 +29,11 @@ function slackUser(teamId = 'T0EXAMPLE1') {
  *  by the last-sign-in-method guard). */
 function githubUser(login: string) {
   return { identities: { github: { details: { rawData: { userInfo: { login } } } }, google: { userId: 'g' } } }
+}
+
+/** A Logto user with both a Slack and a GitHub identity — one directory read feeds both caches. */
+function linkedUser() {
+  return { identities: { ...slackUser().identities, ...githubUser('octocat').identities } }
 }
 
 /**
@@ -61,7 +66,13 @@ function fakeLogto(users: Record<string, unknown>, opts: { parkRead?: number; on
   return { fetchImpl, calls, release: () => release(), parkedReadArrived }
 }
 
-const svcOf = (fetchImpl: FetchImpl, clock: FakeClock) => new LogtoIdentityService(MGMT, clock, MUTATIONS, fetchImpl)
+const logSpy = () => ({
+  debug: vi.fn<(obj: object, msg: string) => void>(),
+  info: vi.fn<(obj: object, msg: string) => void>()
+})
+type SvcLog = ReturnType<typeof logSpy>
+const svcOf = (fetchImpl: FetchImpl, clock: FakeClock, log?: SvcLog) =>
+  new LogtoIdentityService(MGMT, clock, MUTATIONS, fetchImpl, log)
 
 /** Drain a (released) background refresh — the fakes settle in micro/macrotasks,
  *  never on real timers, so a few event-loop turns are enough. */
@@ -204,5 +215,136 @@ describe('LogtoIdentityService refresh-ahead', () => {
     // The background refresh replaced the miss with the just-linked login.
     await expect(svc.githubLoginFor('sub-1', 120_000)).resolves.toBe('late')
     expect(calls.user).toBe(2)
+  })
+})
+
+describe('LogtoIdentityService.ensureIdentityFresh (cold-visit warm trigger)', () => {
+  it('cold caches: one background lookup per cache, then capped reads serve without blocking', async () => {
+    const clock = new FakeClock(0)
+    const log = logSpy()
+    const { fetchImpl, calls } = fakeLogto({ 'sub-1': linkedUser() })
+    const svc = svcOf(fetchImpl, clock, log)
+
+    svc.ensureIdentityFresh('sub-1')
+    await settled()
+    // One lookup per cache — users and logins read the same Logto resource.
+    expect(calls.user).toBe(2)
+    expect(log.debug).toHaveBeenCalledWith(
+      { sub: 'sub-1', users: true, logins: true },
+      'logto identity warm-ahead fired'
+    )
+
+    // The session path finds both caches fresh: no further fetch, no cold-block line.
+    await expect(svc.slackIdentityFor('sub-1')).resolves.toMatchObject({ teamId: 'T0EXAMPLE1' })
+    await expect(svc.feishuIdentitiesFor('sub-1')).resolves.toEqual([])
+    await expect(svc.githubLoginFor('sub-1', 120_000)).resolves.toBe('octocat')
+    expect(calls.user).toBe(2)
+    expect(log.info).not.toHaveBeenCalled()
+  })
+
+  it('fires only when an entry is missing or past half of the 120 s cap', async () => {
+    const clock = new FakeClock(0)
+    const log = logSpy()
+    const { fetchImpl, calls } = fakeLogto({ 'sub-1': linkedUser() })
+    const svc = svcOf(fetchImpl, clock, log)
+
+    svc.ensureIdentityFresh('sub-1')
+    await settled()
+    expect(calls.user).toBe(2)
+
+    log.debug.mockClear()
+    clock.advance(59_000) // age 59 s — under half of the cap, both entries quiet
+    svc.ensureIdentityFresh('sub-1')
+    await settled()
+    expect(calls.user).toBe(2)
+    expect(log.debug).not.toHaveBeenCalled()
+
+    clock.advance(2_000) // age 61 s — fresh by the 10 min TTL, due against the 120 s cap's half
+    svc.ensureIdentityFresh('sub-1')
+    await settled()
+    expect(calls.user).toBe(4)
+    expect(log.debug).toHaveBeenCalledWith(
+      { sub: 'sub-1', users: true, logins: true },
+      'logto identity warm-ahead fired'
+    )
+  })
+
+  it('concurrent triggers and a blocking read coalesce onto one in-flight lookup', async () => {
+    const clock = new FakeClock(0)
+    const log = logSpy()
+    const { fetchImpl, calls, release, parkedReadArrived } = fakeLogto({ 'sub-1': linkedUser() }, { parkRead: 2 })
+    const svc = svcOf(fetchImpl, clock, log)
+
+    // Read 1 — a genuine cold block on the logins cache, counted.
+    await expect(svc.githubLoginFor('sub-1', 120_000)).resolves.toBe('octocat')
+    expect(log.info).toHaveBeenCalledWith({ sub: 'sub-1', cache: 'logins' }, 'logto identity blocking fetch')
+
+    clock.advance(10_000) // logins young → the trigger has only the users cache to warm
+    svc.ensureIdentityFresh('sub-1') // parks upstream as read 2
+    await parkedReadArrived
+    svc.ensureIdentityFresh('sub-1') // users in flight, logins young — nothing new fires
+
+    const read = svc.slackIdentityFor('sub-1') // joins the parked lookup
+    release()
+    await expect(read).resolves.toMatchObject({ teamId: 'T0EXAMPLE1' })
+    await settled()
+    expect(calls.user).toBe(2)
+    // The joiner found the warm's lookup in flight — never counted as a cold block.
+    expect(log.info).toHaveBeenCalledTimes(1)
+  })
+
+  it('forgetUser racing a warm-fired lookup keeps its result out of the cache', async () => {
+    const clock = new FakeClock(0)
+    const users: Record<string, unknown> = { 'sub-1': linkedUser() }
+    const { fetchImpl, calls, release, parkedReadArrived } = fakeLogto(users, { parkRead: 2 })
+    const svc = svcOf(fetchImpl, clock)
+
+    await svc.githubLoginFor('sub-1', 120_000) // read 1 — leaves only the users cache cold
+    clock.advance(10_000)
+    svc.ensureIdentityFresh('sub-1') // fires the users lookup; parks as read 2
+    await parkedReadArrived
+
+    // The identity changes at the provider and the console announces it while the
+    // warm's lookup is still in flight holding the pre-change snapshot.
+    users['sub-1'] = slackUser('T0AFTER000')
+    svc.forgetUser('sub-1')
+    release()
+    await settled()
+
+    // The epoch fence dropped the parked result — the next read sees the new world.
+    await expect(svc.slackIdentityFor('sub-1')).resolves.toMatchObject({ teamId: 'T0AFTER000' })
+    expect(calls.user).toBe(3)
+  })
+
+  it('a failing warm is swallowed: debug-logged, nothing thrown', async () => {
+    const clock = new FakeClock(0)
+    const log = logSpy()
+    const failing: FetchImpl = async () => {
+      throw new Error('logto unreachable')
+    }
+    const svc = svcOf(failing, clock, log)
+
+    expect(() => svc.ensureIdentityFresh('sub-1')).not.toThrow()
+    await settled()
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: 'sub-1' }),
+      'logto refresh-ahead lookup failed'
+    )
+  })
+
+  it('counts a capped read blocking on a cold cache; display reads and warmed reads are quiet', async () => {
+    const clock = new FakeClock(0)
+    const log = logSpy()
+    const { fetchImpl } = fakeLogto({ 'sub-1': linkedUser() })
+    const svc = svcOf(fetchImpl, clock, log)
+
+    await svc.socialAccountFor('sub-1') // display read (no cap): cold, but not the authorization path
+    expect(log.info).not.toHaveBeenCalled()
+
+    await svc.githubLoginFor('sub-1', 120_000) // capped read on a cold logins cache
+    expect(log.info).toHaveBeenCalledWith({ sub: 'sub-1', cache: 'logins' }, 'logto identity blocking fetch')
+
+    await svc.slackIdentityFor('sub-1') // users cache already warm from the display read
+    expect(log.info).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/control-plane/src/github/logto-identity.test.ts
+++ b/packages/control-plane/src/github/logto-identity.test.ts
@@ -348,3 +348,19 @@ describe('LogtoIdentityService.ensureIdentityFresh (cold-visit warm trigger)', (
     expect(log.info).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('LogtoIdentityService subject-cache bounds', () => {
+  it('evicts the least-recently-written subject past the cap instead of growing forever', async () => {
+    const clock = new FakeClock(0)
+    const { fetchImpl, calls } = fakeLogto({}) // every subject 404s — tiny negative entries
+    const svc = svcOf(fetchImpl, clock)
+
+    for (let i = 0; i <= 10_000; i++) await svc.githubLoginFor(`sub-${i}`, 120_000)
+    expect(calls.user).toBe(10_001)
+
+    await svc.githubLoginFor('sub-10000', 120_000) // most recent write — still resident
+    expect(calls.user).toBe(10_001)
+    await svc.githubLoginFor('sub-0', 120_000) // the one evicted entry refetches
+    expect(calls.user).toBe(10_002)
+  })
+})

--- a/packages/control-plane/src/github/logto-identity.ts
+++ b/packages/control-plane/src/github/logto-identity.ts
@@ -90,6 +90,12 @@ const TIMEOUT_MS = 5_000
 // which fixes a connector is picked up the same day, long enough that the probe
 // is not per click.
 const LINK_MODE_TTL_MS = 60 * 60_000
+// The subject-keyed caches are written for EVERY authenticated account (the §3 warm
+// trigger reaches them per subject), so they are size-bounded: a write refreshes the
+// entry's recency, overflow evicts the least-recently-written subject, and an evicted
+// entry simply refetches on its next read. Hot subjects rewrite at least every lease,
+// so write recency tracks read recency closely enough for eviction.
+const MAX_SUBJECT_ENTRIES = 10_000
 
 interface CachedLogin {
   login: string | null
@@ -388,6 +394,16 @@ export class LogtoIdentityService {
     if (maxAgeMs !== undefined && !inFlight) this.log?.info({ sub, cache }, 'logto identity blocking fetch')
   }
 
+  /** Recency-ordered bounded write — a subject cache never grows past its cap. */
+  private setBounded<T>(map: Map<string, T>, key: string, value: T): void {
+    map.delete(key)
+    map.set(key, value)
+    if (map.size > MAX_SUBJECT_ENTRIES) {
+      const oldest = map.keys().next()
+      if (!oldest.done) map.delete(oldest.value)
+    }
+  }
+
   /** The deduped in-flight user lookup — one upstream read serves every
    *  concurrent caller, blocking miss and refresh-ahead alike. */
   private pendingUser(sub: string): Promise<LogtoUser | null> {
@@ -547,7 +563,7 @@ export class LogtoIdentityService {
       // Deleted at the provider — cache the miss briefly.
       if (current()) {
         const fetchedAt = this.clock.now()
-        this.users.set(sub, { user: null, fetchedAt, expiresAt: fetchedAt + NEGATIVE_TTL_MS })
+        this.setBounded(this.users, sub, { user: null, fetchedAt, expiresAt: fetchedAt + NEGATIVE_TTL_MS })
       }
       return null
     }
@@ -557,7 +573,7 @@ export class LogtoIdentityService {
     const user = (await res.json()) as LogtoUser
     if (current()) {
       const fetchedAt = this.clock.now()
-      this.users.set(sub, { user, fetchedAt, expiresAt: fetchedAt + LOGIN_TTL_MS })
+      this.setBounded(this.users, sub, { user, fetchedAt, expiresAt: fetchedAt + LOGIN_TTL_MS })
     }
     return user
   }
@@ -570,7 +586,7 @@ export class LogtoIdentityService {
       // Deleted at the provider — no identity, cache the miss briefly.
       if (current()) {
         const fetchedAt = this.clock.now()
-        this.logins.set(sub, { login: null, fetchedAt, expiresAt: fetchedAt + NEGATIVE_TTL_MS })
+        this.setBounded(this.logins, sub, { login: null, fetchedAt, expiresAt: fetchedAt + NEGATIVE_TTL_MS })
       }
       return null
     }
@@ -582,7 +598,7 @@ export class LogtoIdentityService {
     const login = firstString(raw?.userInfo?.login, raw?.login)
     if (current()) {
       const fetchedAt = this.clock.now()
-      this.logins.set(sub, {
+      this.setBounded(this.logins, sub, {
         login,
         fetchedAt,
         expiresAt: fetchedAt + (login ? LOGIN_TTL_MS : NEGATIVE_TTL_MS)

--- a/packages/control-plane/src/github/logto-identity.ts
+++ b/packages/control-plane/src/github/logto-identity.ts
@@ -254,7 +254,7 @@ export class LogtoIdentityService {
     private readonly clock: Clock,
     private readonly mutations: SocialIdentityMutationGate,
     private readonly fetchImpl: FetchLike = fetch as FetchLike,
-    private readonly log?: { debug(obj: object, msg: string): void }
+    private readonly log?: { debug(obj: object, msg: string): void; info(obj: object, msg: string): void }
   ) {}
 
   /**
@@ -269,6 +269,7 @@ export class LogtoIdentityService {
       if (refreshAheadDue(cached, now, maxAgeMs)) this.refreshInBackground(sub, () => this.pendingLogin(sub))
       return cached.login
     }
+    this.noteColdBlock('logins', sub, maxAgeMs, this.loginInFlight.has(sub))
     return this.pendingLogin(sub)
   }
 
@@ -307,6 +308,28 @@ export class LogtoIdentityService {
   /** Linked Feishu/Lark identities, keyed by the provider's cross-app union_id. */
   async feishuIdentitiesFor(sub: string): Promise<FeishuIdentity[]> {
     return feishuIdentitiesOf(await this.logtoUser(sub, PROVIDER_IDENTITY_TTL_MS))
+  }
+
+  /**
+   * Warm-at-touch trigger (session-access-cold-visit.md §3): start, fire-and-forget,
+   * the background lookups a later authorization read of this subject would block on.
+   * Gated on the same dueness those reads apply (missing / expired against the 120 s
+   * cap / past its half-lease, nothing already in flight) so the debug line counts
+   * actual upstream fires. Rides the shared single-flight lookups and the epoch fence
+   * unchanged; the 120 s lease is untouched — this adds a trigger, not a serving rule.
+   */
+  ensureIdentityFresh(sub: string): void {
+    const now = this.clock.now()
+    const due = (cached: { fetchedAt: number; expiresAt: number } | undefined) =>
+      !cached ||
+      cached.expiresAt <= now ||
+      now - cached.fetchedAt >= PROVIDER_IDENTITY_TTL_MS ||
+      refreshAheadDue(cached, now, PROVIDER_IDENTITY_TTL_MS)
+    const users = due(this.users.get(sub)) && !this.userInFlight.has(sub)
+    const logins = due(this.logins.get(sub)) && !this.loginInFlight.has(sub)
+    if (users) this.refreshInBackground(sub, () => this.pendingUser(sub))
+    if (logins) this.refreshInBackground(sub, () => this.pendingLogin(sub))
+    if (users || logins) this.log?.debug({ sub, users, logins }, 'logto identity warm-ahead fired')
   }
 
   /**
@@ -353,7 +376,16 @@ export class LogtoIdentityService {
       if (refreshAheadDue(cached, now, maxAgeMs)) this.refreshInBackground(sub, () => this.pendingUser(sub))
       return cached.user
     }
+    this.noteColdBlock('users', sub, maxAgeMs, this.userInFlight.has(sub))
     return this.pendingUser(sub)
+  }
+
+  // Cold-block counter (session-access-cold-visit.md §5): an authorization-lease read
+  // (`maxAgeMs` set — display reads pass none) found neither a servable entry nor an
+  // in-flight lookup to join, so the caller stalls on Logto. The rate of this line is
+  // the number the §3 warm trigger exists to drive to ~zero for console traffic.
+  private noteColdBlock(cache: 'users' | 'logins', sub: string, maxAgeMs: number | undefined, inFlight: boolean): void {
+    if (maxAgeMs !== undefined && !inFlight) this.log?.info({ sub, cache }, 'logto identity blocking fetch')
   }
 
   /** The deduped in-flight user lookup — one upstream read serves every

--- a/packages/control-plane/src/http/identity-warm.test.ts
+++ b/packages/control-plane/src/http/identity-warm.test.ts
@@ -97,4 +97,26 @@ describe('createIdentityWarmTrigger', () => {
     expect(getOidcSubject).not.toHaveBeenCalled()
     expect(ensureIdentityFresh).toHaveBeenNthCalledWith(2, 'sub-1')
   })
+
+  it('cardinality overflow evicts one principal from the throttle, never the whole book', () => {
+    const { trigger, ensureIdentityFresh } = harness()
+    for (let i = 0; i <= 10_000; i++) trigger({ userId: `u${i}`, oidcSubject: `s${i}` })
+    expect(ensureIdentityFresh).toHaveBeenCalledTimes(10_001)
+
+    trigger({ userId: 'u9999', oidcSubject: 's9999' }) // resident — still inside its window
+    expect(ensureIdentityFresh).toHaveBeenCalledTimes(10_001)
+
+    trigger({ userId: 'u0', oidcSubject: 's0' }) // only the evicted principal re-checks early
+    expect(ensureIdentityFresh).toHaveBeenCalledTimes(10_002)
+  })
+
+  it('the sub memo survives overflow for recent principals — no per-request DB reads under load', () => {
+    const { trigger, ensureIdentityFresh, getOidcSubject, clock } = harness()
+    for (let i = 0; i <= 10_000; i++) trigger({ userId: `u${i}`, oidcSubject: `s${i}` })
+
+    clock.advance(30_000)
+    trigger({ userId: 'u9999' }) // API-key shape: its binding is still memoized
+    expect(getOidcSubject).not.toHaveBeenCalled()
+    expect(ensureIdentityFresh).toHaveBeenLastCalledWith('s9999')
+  })
 })

--- a/packages/control-plane/src/http/identity-warm.test.ts
+++ b/packages/control-plane/src/http/identity-warm.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the identity warm-at-touch trigger (session-access-cold-visit.md
+ * §3): per-principal throttling, API-key sub resolution + memoization, and the
+ * fire-and-forget contract — failures swallowed, the request never touched.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+import { createIdentityWarmTrigger } from './identity-warm.js'
+
+/** The trigger's async leg settles in microtasks — one macrotask turn is enough. */
+const settled = () => new Promise((resolve) => setImmediate(resolve))
+
+function harness(getOidcSubject = vi.fn(async (_userId: string): Promise<string | null> => 'sub-1')) {
+  const clock = new FakeClock(0)
+  const ensureIdentityFresh = vi.fn<(sub: string) => void>()
+  const log = { debug: vi.fn<(obj: object, msg: string) => void>() }
+  const trigger = createIdentityWarmTrigger({
+    identity: { ensureIdentityFresh },
+    users: { getOidcSubject },
+    clock,
+    log
+  })
+  return { clock, ensureIdentityFresh, getOidcSubject, log, trigger }
+}
+
+describe('createIdentityWarmTrigger', () => {
+  it('an OIDC principal warms with the request sub — no DB read', () => {
+    const { trigger, ensureIdentityFresh, getOidcSubject } = harness()
+    trigger({ userId: 'u1', oidcSubject: 'sub-1' })
+    expect(ensureIdentityFresh).toHaveBeenCalledWith('sub-1')
+    expect(getOidcSubject).not.toHaveBeenCalled()
+  })
+
+  it('checks each principal at most once per throttle window', () => {
+    const { trigger, ensureIdentityFresh, clock } = harness()
+    trigger({ userId: 'u1', oidcSubject: 'sub-1' })
+    clock.advance(29_999)
+    trigger({ userId: 'u1', oidcSubject: 'sub-1' })
+    expect(ensureIdentityFresh).toHaveBeenCalledTimes(1)
+    clock.advance(1) // the window closes at exactly 30 s
+    trigger({ userId: 'u1', oidcSubject: 'sub-1' })
+    expect(ensureIdentityFresh).toHaveBeenCalledTimes(2)
+  })
+
+  it('throttles per principal, not globally', () => {
+    const { trigger, ensureIdentityFresh } = harness()
+    trigger({ userId: 'u1', oidcSubject: 'sub-1' })
+    trigger({ userId: 'u2', oidcSubject: 'sub-2' })
+    expect(ensureIdentityFresh).toHaveBeenCalledTimes(2)
+  })
+
+  it('an API-key principal resolves its sub once, memoizes it, then warms', async () => {
+    const { trigger, ensureIdentityFresh, getOidcSubject, clock } = harness()
+    trigger({ userId: 'u1' })
+    await settled()
+    expect(getOidcSubject).toHaveBeenCalledWith('u1')
+    expect(ensureIdentityFresh).toHaveBeenCalledWith('sub-1')
+
+    clock.advance(30_000)
+    trigger({ userId: 'u1' })
+    expect(getOidcSubject).toHaveBeenCalledTimes(1) // memoized — no second read
+    expect(ensureIdentityFresh).toHaveBeenCalledTimes(2)
+  })
+
+  it('a principal with no OIDC identity warms nothing and is retried next window', async () => {
+    const getOidcSubject = vi.fn(async (): Promise<string | null> => null)
+    const { trigger, ensureIdentityFresh, clock } = harness(getOidcSubject)
+    trigger({ userId: 'u1' })
+    await settled()
+    expect(ensureIdentityFresh).not.toHaveBeenCalled()
+
+    trigger({ userId: 'u1' }) // inside the window: not even a DB read
+    expect(getOidcSubject).toHaveBeenCalledTimes(1)
+
+    clock.advance(30_000)
+    trigger({ userId: 'u1' }) // null was not memoized — the next window asks again
+    await settled()
+    expect(getOidcSubject).toHaveBeenCalledTimes(2)
+  })
+
+  it('a failing sub lookup is swallowed and debug-logged', async () => {
+    const getOidcSubject = vi.fn(async (): Promise<string | null> => {
+      throw new Error('db blip')
+    })
+    const { trigger, ensureIdentityFresh, log } = harness(getOidcSubject)
+    expect(() => trigger({ userId: 'u1' })).not.toThrow()
+    await settled()
+    expect(ensureIdentityFresh).not.toHaveBeenCalled()
+    expect(log.debug).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u1' }), 'identity warm sub lookup failed')
+  })
+
+  it('a sub learned from an OIDC request serves later API-key requests without a DB read', () => {
+    const { trigger, ensureIdentityFresh, getOidcSubject, clock } = harness()
+    trigger({ userId: 'u1', oidcSubject: 'sub-1' })
+    clock.advance(30_000)
+    trigger({ userId: 'u1' }) // same principal over an API key
+    expect(getOidcSubject).not.toHaveBeenCalled()
+    expect(ensureIdentityFresh).toHaveBeenNthCalledWith(2, 'sub-1')
+  })
+})

--- a/packages/control-plane/src/http/identity-warm.ts
+++ b/packages/control-plane/src/http/identity-warm.ts
@@ -28,8 +28,21 @@ export interface IdentityWarmDeps {
 // Per-principal re-check cadence: half the 60 s refresh-ahead band, so a due warm
 // fires at most 30 s late while API-key sub resolution stays ≤ 2 reads/principal/min.
 const WARM_THROTTLE_MS = 30_000
-// Bounds both maps; the wholesale clear costs at most one extra check per principal.
+// Caps both maps below, enforced per entry by {@link boundedSet}.
 const MAX_TRACKED_PRINCIPALS = 10_000
+
+// Recency-ordered bounded write: refresh the key's position, evict only the
+// least-recently-written entry on overflow. A wholesale clear would let a working
+// set just past the cap defeat the throttle and the memo continuously; per-entry
+// eviction costs one early re-check for the evicted principal and nothing else.
+function boundedSet<T>(map: Map<string, T>, key: string, value: T): void {
+  map.delete(key)
+  map.set(key, value)
+  if (map.size > MAX_TRACKED_PRINCIPALS) {
+    const oldest = map.keys().next()
+    if (!oldest.done) map.delete(oldest.value)
+  }
+}
 
 /** Build the trigger the auth plugin fires after each successful authentication.
  *  Fire-and-forget by contract: it never throws and never surfaces a rejection. */
@@ -41,16 +54,12 @@ export function createIdentityWarmTrigger(
   // ever set it), so positives memoize for the process lifetime; a subless account
   // (devAuth-era row) is retried once per throttle window instead.
   const subs = new Map<string, string>()
-  const remember = (userId: string, sub: string) => {
-    if (subs.size >= MAX_TRACKED_PRINCIPALS && !subs.has(userId)) subs.clear()
-    subs.set(userId, sub)
-  }
+  const remember = (userId: string, sub: string) => boundedSet(subs, userId, sub)
   return ({ userId, oidcSubject }) => {
     const now = deps.clock.now()
     const last = lastCheckedAt.get(userId)
     if (last !== undefined && now - last < WARM_THROTTLE_MS) return
-    if (lastCheckedAt.size >= MAX_TRACKED_PRINCIPALS && !lastCheckedAt.has(userId)) lastCheckedAt.clear()
-    lastCheckedAt.set(userId, now)
+    boundedSet(lastCheckedAt, userId, now)
     const sub = oidcSubject ?? subs.get(userId)
     if (sub !== undefined) {
       remember(userId, sub)

--- a/packages/control-plane/src/http/identity-warm.ts
+++ b/packages/control-plane/src/http/identity-warm.ts
@@ -1,0 +1,71 @@
+/**
+ * Identity warm-at-touch (session-access-cold-visit.md §3, Phase 1).
+ *
+ * The Logto identity projection is the serial head of every cold session read:
+ * `viewerFor` needs the caller's linked identities before the SQL predicate can
+ * run, and an infrequent visitor's entry is always expired. But `/sessions` is
+ * never the visit's first authenticated request — so the auth plane fires this
+ * trigger on EVERY successful authentication, and by the time the session read
+ * arrives the entry is fresh or the lookup is already in flight.
+ *
+ * Fires on both auth paths (§9 Q2 decided as "every authenticated request"):
+ * OIDC requests carry the sub for free; API-key requests (agent-assistant MCP
+ * reads pay the same Logto hop through `users.getOidcSubject`) resolve it here,
+ * behind the per-principal throttle and a process-lifetime memo, so steady-state
+ * API-key traffic costs no extra reads. The upstream ceiling is owned by the
+ * service's dueness gate; this module only bounds its own bookkeeping.
+ */
+import type { Clock } from '../domain/clock.js'
+
+/** Structural deps — the composition root passes LogtoIdentityService + PgUserRepo. */
+export interface IdentityWarmDeps {
+  identity: { ensureIdentityFresh(sub: string): void }
+  users: { getOidcSubject(userId: string): Promise<string | null> }
+  clock: Clock
+  log?: { debug(obj: object, msg: string): void }
+}
+
+// Per-principal re-check cadence: half the 60 s refresh-ahead band, so a due warm
+// fires at most 30 s late while API-key sub resolution stays ≤ 2 reads/principal/min.
+const WARM_THROTTLE_MS = 30_000
+// Bounds both maps; the wholesale clear costs at most one extra check per principal.
+const MAX_TRACKED_PRINCIPALS = 10_000
+
+/** Build the trigger the auth plugin fires after each successful authentication.
+ *  Fire-and-forget by contract: it never throws and never surfaces a rejection. */
+export function createIdentityWarmTrigger(
+  deps: IdentityWarmDeps
+): (principal: { userId: string; oidcSubject?: string }) => void {
+  const lastCheckedAt = new Map<string, number>()
+  // userId → OIDC sub. Immutable once bound (JIT provisioning and invite claims only
+  // ever set it), so positives memoize for the process lifetime; a subless account
+  // (devAuth-era row) is retried once per throttle window instead.
+  const subs = new Map<string, string>()
+  const remember = (userId: string, sub: string) => {
+    if (subs.size >= MAX_TRACKED_PRINCIPALS && !subs.has(userId)) subs.clear()
+    subs.set(userId, sub)
+  }
+  return ({ userId, oidcSubject }) => {
+    const now = deps.clock.now()
+    const last = lastCheckedAt.get(userId)
+    if (last !== undefined && now - last < WARM_THROTTLE_MS) return
+    if (lastCheckedAt.size >= MAX_TRACKED_PRINCIPALS && !lastCheckedAt.has(userId)) lastCheckedAt.clear()
+    lastCheckedAt.set(userId, now)
+    const sub = oidcSubject ?? subs.get(userId)
+    if (sub !== undefined) {
+      remember(userId, sub)
+      deps.identity.ensureIdentityFresh(sub)
+      return
+    }
+    // API-key path: one indexed PK read (throttled above); swallowed on failure —
+    // the warm must never delay or fail the request it rides behind.
+    void deps.users
+      .getOidcSubject(userId)
+      .then((resolved) => {
+        if (resolved === null) return
+        remember(userId, resolved)
+        deps.identity.ensureIdentityFresh(resolved)
+      })
+      .catch((err: unknown) => deps.log?.debug({ err, userId }, 'identity warm sub lookup failed'))
+  }
+}

--- a/packages/control-plane/src/http/plugins/auth.test.ts
+++ b/packages/control-plane/src/http/plugins/auth.test.ts
@@ -1,9 +1,12 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
 import Fastify from 'fastify'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { exportJWK, generateKeyPair, SignJWT } from 'jose'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { WebchatMcpGrantTokenCodec } from '../../registry/webchatMcpGrantToken.js'
 import { INTERNAL_INVOCATION_AUTH_HEADER, InternalInvocationAuth } from '../mcp/internal-invocation-auth.js'
 import type { InvocationContext } from '../mcp/remote-grant-authenticator.js'
-import { humanAuthPlugin, type VerifyApiKey } from './auth.js'
+import { humanAuthPlugin, type EnsureIdentityFresh, type HumanAuthOptions, type VerifyApiKey } from './auth.js'
 
 const CONTEXT: InvocationContext = {
   invocationId: '11111111-1111-4111-8111-111111111111',
@@ -129,5 +132,146 @@ describe('humanAuthPlugin internal invocation seam', () => {
 
     expect(response.statusCode).toBe(401)
     expect(verifyApiKey).toHaveBeenCalledWith(assertion)
+  })
+})
+
+/** An app with the given plugin options and one probed route behind humanAuth. */
+async function appWithOptions(options: Partial<HumanAuthOptions>) {
+  const app = Fastify({ logger: false })
+  apps.push(app)
+  await app.register(humanAuthPlugin, { DEFAULT_OWNER_ID: 'dev-owner', ...options })
+  app.get('/api/v1/probe', { preHandler: app.humanAuth }, async (req) => ({ principal: req.principal }))
+  await app.ready()
+  return app
+}
+
+describe('humanAuthPlugin identity warm trigger (api-key path)', () => {
+  const acceptKey: VerifyApiKey = async () => ({ userId: 'user-1', orgId: 'org-1', apiKeyId: 'key-1', scopes: [] })
+
+  it('fires with the resolved principal after api-key auth (the trigger resolves the sub itself)', async () => {
+    const warm = vi.fn<EnsureIdentityFresh>()
+    const app = await appWithOptions({ verifyApiKey: acceptKey, ensureIdentityFresh: warm })
+
+    const response = await app.inject({ method: 'GET', url: '/api/v1/probe', headers: { authorization: 'Bearer k3y' } })
+
+    expect(response.statusCode).toBe(200)
+    expect(warm).toHaveBeenCalledWith({ userId: 'user-1' })
+  })
+
+  it('does not fire when the api key is rejected', async () => {
+    const warm = vi.fn<EnsureIdentityFresh>()
+    const app = await appWithOptions({ verifyApiKey: async () => null, ensureIdentityFresh: warm })
+
+    const response = await app.inject({ method: 'GET', url: '/api/v1/probe', headers: { authorization: 'Bearer bad' } })
+
+    expect(response.statusCode).toBe(401)
+    expect(warm).not.toHaveBeenCalled()
+  })
+
+  it('a throwing trigger never fails the request', async () => {
+    const warm = vi.fn<EnsureIdentityFresh>(() => {
+      throw new Error('warm exploded')
+    })
+    const app = await appWithOptions({ verifyApiKey: acceptKey, ensureIdentityFresh: warm })
+
+    const response = await app.inject({ method: 'GET', url: '/api/v1/probe', headers: { authorization: 'Bearer k3y' } })
+
+    expect(response.statusCode).toBe(200)
+    expect(warm).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('humanAuthPlugin identity warm trigger (oidc path)', () => {
+  // A loopback OIDC issuer: discovery + JWKS, and a signer for bearers — the same
+  // shape the OIDC integration tests use, without any database behind it.
+  let oidcServer: Server
+  let oidcIssuer = ''
+  let mintBearer: (subject: string) => Promise<string>
+
+  beforeAll(async () => {
+    const { privateKey, publicKey } = await generateKeyPair('RS256')
+    const jwk = { ...(await exportJWK(publicKey)), alg: 'RS256', kid: 'warm-test', use: 'sig' }
+    oidcServer = createServer((req, res) => {
+      res.setHeader('content-type', 'application/json')
+      if (req.url === '/.well-known/openid-configuration') {
+        res.end(JSON.stringify({ issuer: oidcIssuer, jwks_uri: `${oidcIssuer}/jwks` }))
+        return
+      }
+      if (req.url === '/jwks') {
+        res.end(JSON.stringify({ keys: [jwk] }))
+        return
+      }
+      res.statusCode = 404
+      res.end('{}')
+    })
+    await new Promise<void>((resolve, reject) => {
+      oidcServer.once('error', reject)
+      oidcServer.listen(0, '127.0.0.1', resolve)
+    })
+    const { port } = oidcServer.address() as AddressInfo
+    oidcIssuer = `http://127.0.0.1:${port}`
+    mintBearer = (subject) =>
+      new SignJWT({})
+        .setProtectedHeader({ alg: 'RS256', kid: 'warm-test' })
+        .setIssuer(oidcIssuer)
+        .setSubject(subject)
+        .setIssuedAt()
+        .setExpirationTime('10m')
+        .sign(privateKey)
+  })
+
+  afterAll(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        oidcServer.close((err) => (err ? reject(err) : resolve()))
+      })
+  )
+
+  it('fires with the local principal and the verified subject', async () => {
+    const warm = vi.fn<EnsureIdentityFresh>()
+    const app = await appWithOptions({
+      OIDC_ISSUER: oidcIssuer,
+      resolveUser: async ({ oidcSubject }) => ({ userId: `local-${oidcSubject}` }),
+      ensureIdentityFresh: warm
+    })
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/probe',
+      headers: { authorization: `Bearer ${await mintBearer('sub-42')}` }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(warm).toHaveBeenCalledWith({ userId: 'local-sub-42', oidcSubject: 'sub-42' })
+  })
+
+  it('a throwing trigger does not 401 a valid token', async () => {
+    const warm = vi.fn<EnsureIdentityFresh>(() => {
+      throw new Error('warm exploded')
+    })
+    const app = await appWithOptions({ OIDC_ISSUER: oidcIssuer, ensureIdentityFresh: warm })
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/probe',
+      headers: { authorization: `Bearer ${await mintBearer('sub-42')}` }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(warm).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire when the bearer is rejected', async () => {
+    const warm = vi.fn<EnsureIdentityFresh>()
+    const app = await appWithOptions({ OIDC_ISSUER: oidcIssuer, ensureIdentityFresh: warm })
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/probe',
+      headers: { authorization: 'Bearer not.a.jwt' }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(warm).not.toHaveBeenCalled()
   })
 })

--- a/packages/control-plane/src/http/plugins/auth.ts
+++ b/packages/control-plane/src/http/plugins/auth.ts
@@ -101,12 +101,22 @@ export interface DeletedIdentityStore {
   record: (oidcSubject: string, cutoffAt: Date, expiresAt: Date) => Promise<void>
 }
 
+/**
+ * Fire-and-forget warm of the caller's provider-identity projection
+ * (session-access-cold-visit.md §3), fired after every successful OIDC or
+ * API-key authentication. `oidcSubject` rides along when the OIDC path already
+ * verified it; the API-key path resolves it behind the trigger. Never awaited —
+ * the request must complete identically whether it fires, throws, or is absent.
+ */
+export type EnsureIdentityFresh = (principal: { userId: string; oidcSubject?: string }) => void
+
 /** Registration options: the config plus the optional JIT resolver + API-key verifier. */
 export type HumanAuthOptions = HumanAuthConfig & {
   resolveUser?: ResolveOidcUser
   verifyApiKey?: VerifyApiKey
   principalExists?: PrincipalExists
   deletedIdentities?: DeletedIdentityStore
+  ensureIdentityFresh?: EnsureIdentityFresh
   /** In-process one-time nonce verifier for nested delegated MCP REST calls. */
   internalInvocationAuth?: Pick<InternalInvocationAuth, 'authorizeInjectedRequest'>
 }
@@ -399,6 +409,13 @@ function oidcAuth(cfg: HumanAuthOptions & { OIDC_ISSUER: string }): preHandlerHo
       // (`/orgs/:orgId/…`, verified by the org-scope guard).
       req.principal = { userId: identity.userId, email: email ?? headerEmail }
       req.oidcSubject = sub
+      // Warm the identity projection behind this response (cold-visit §3). Contained:
+      // a throw here must not fall into the outer catch and 401 a valid token.
+      try {
+        cfg.ensureIdentityFresh?.({ userId: identity.userId, oidcSubject: sub })
+      } catch (warmErr) {
+        req.log.debug({ err: warmErr }, 'humanAuth: identity warm trigger failed')
+      }
     } catch (err) {
       // Surface WHY verification failed — expiry vs. audience/issuer vs. signature.
       // jose tags each with a stable `code` (ERR_JWT_EXPIRED,
@@ -428,7 +445,11 @@ function bearerApiKey(header: string | undefined): string | null {
  * `apiKeyOrgId`); an invalid one is a hard 401 (never falls through to devAuth's
  * admit-all). Any other Authorization (a JWT, or none) delegates to `base`.
  */
-function withApiKeyAuth(verify: VerifyApiKey, base: preHandlerHookHandler): preHandlerHookHandler {
+function withApiKeyAuth(
+  verify: VerifyApiKey,
+  base: preHandlerHookHandler,
+  ensureIdentityFresh?: EnsureIdentityFresh
+): preHandlerHookHandler {
   // Our dev/oidc handlers are async 2-arg preHandlers (Fastify awaits them, never
   // passing `done`); call `base` through that shape rather than the 3-arg hook type.
   const delegate = base as (req: FastifyRequest, reply: FastifyReply) => Promise<unknown>
@@ -451,6 +472,14 @@ function withApiKeyAuth(verify: VerifyApiKey, base: preHandlerHookHandler): preH
     req.apiKeyId = resolved.apiKeyId
     req.apiKeyOrgId = resolved.orgId
     req.apiKeyScopes = resolved.scopes
+    // Cold-visit §3: for API-key readers (agent-assistant MCP) the first authenticated
+    // request can BE `/sessions`, so the warm fires here too; the trigger resolves the
+    // sub itself. Contained — it must never fail an authenticated request.
+    try {
+      ensureIdentityFresh?.({ userId: resolved.userId })
+    } catch (warmErr) {
+      req.log.debug({ err: warmErr }, 'humanAuth: identity warm trigger failed')
+    }
   }
 }
 
@@ -475,7 +504,7 @@ export const humanAuthPlugin = fp(
   function humanAuthPlugin(app: FastifyInstance, cfg: HumanAuthOptions, done: (err?: Error) => void) {
     const realOidc = cfg.OIDC_ISSUER ? oidcAuth({ ...cfg, OIDC_ISSUER: cfg.OIDC_ISSUER }) : undefined
     const base = realOidc ?? devAuth(cfg, app.log)
-    const externalHandler = cfg.verifyApiKey ? withApiKeyAuth(cfg.verifyApiKey, base) : base
+    const externalHandler = cfg.verifyApiKey ? withApiKeyAuth(cfg.verifyApiKey, base, cfg.ensureIdentityFresh) : base
     const handler = cfg.internalInvocationAuth
       ? withInternalInvocationAuth(cfg.internalInvocationAuth, externalHandler)
       : externalHandler

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -18,6 +18,7 @@ import Fastify, {
 import cors from '@fastify/cors'
 import { hasZodFastifySchemaValidationErrors, isResponseSerializationError } from 'fastify-type-provider-zod'
 import type { HttpDeps } from './deps.js'
+import { createIdentityWarmTrigger } from './identity-warm.js'
 import { installZod } from './plugins/zod.js'
 import { installOpenapi } from './plugins/openapi.js'
 import { humanAuthPlugin } from './plugins/auth.js'
@@ -124,6 +125,19 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
     resolveUser: (input) => deps.repos.user.provisionOidcUser(input),
     verifyApiKey: (token) => deps.apiKeys.authenticateUser(token),
     internalInvocationAuth: deps.internalInvocationAuth,
+    // Identity warm-at-touch (session-access-cold-visit.md §3): every authenticated
+    // request pre-warms the caller's Logto projection so a cold `/sessions` finds it
+    // fresh instead of blocking on the serial identity lookup.
+    ...(deps.logtoIdentity
+      ? {
+          ensureIdentityFresh: createIdentityWarmTrigger({
+            identity: deps.logtoIdentity,
+            users: deps.repos.user,
+            clock: deps.clock,
+            log: { debug: (o, m) => app.log.debug(o, m) }
+          })
+        }
+      : {}),
     // Lets the plane notice an account deleted underneath a live session (→ 401
     // ACCOUNT_GONE, which drives the console to sign out) instead of serving
     // requests for an identity that is no longer there.


### PR DESCRIPTION
## Summary

Phase 1 of the session-access cold-visit design (#792; absorbs the Phase-1 slice of #775): warm the Logto identity projection at first authenticated touch, so the cold console visit's serial head — `viewerFor` blocking ~400 ms p50 / ~1.1 s p95 on the Logto user read — is paid behind `/me` and `/orgs` instead of in front of `/sessions`.

### What changed

- **`LogtoIdentityService.ensureIdentityFresh(sub)`** (design §3): fire-and-forget warm of both identity caches — `users` (the Slack/Feishu identity set) and `logins` (the GitHub sweep leg). It applies the same dueness the capped reads apply (entry missing, expired against the 120 s authorization cap, or past its half-lease, with nothing already in flight) and then rides the existing machinery unchanged: the `userInFlight`/`loginInFlight` single-flight dedupe, the epoch fence (a warm racing an unlink is returned to nobody and never cached), and `refreshInBackground`'s failure swallowing. The 120 s lease is untouched — this adds a trigger, not a serving rule.
- **Auth plugin trigger** (`http/plugins/auth.ts`): an optional `ensureIdentityFresh` callback, injected by the composition root (mirrors `ResolveOidcUser`/`VerifyApiKey`), fired after successful OIDC auth (the verified sub rides along) and after successful API-key auth (principal only). Both call sites are contained in their own try/catch, so the warm can never delay or fail a request — including when Logto is down. Failed auth, unauthenticated routes, and the devAuth stub never fire it.
- **`http/identity-warm.ts`**: the composition trigger. Per-principal 30 s throttle (half the refresh-ahead band, so a due warm fires at most 30 s late); API-key principals resolve `userId → getOidcSubject` (one indexed PK read, throttled) with a process-lifetime memo of positive results — the binding is immutable once set (JIT provisioning and invite claims only ever set it) — so steady-state API-key traffic costs no extra DB reads. A sub learned on the OIDC path serves later API-key requests for the same principal; a subless account retries once per window.
- **Instrumentation (design §5)**: `logto identity warm-ahead fired` at debug only when a background lookup actually fires (with per-cache flags), and `logto identity blocking fetch` at info when an authorization-lease read (`maxAgeMs` set — display reads pass none) misses both the cache and an in-flight lookup to join. The info line's rate is this phase's success metric: it should go to ~zero for console traffic.

### §9 Q2 decision: fire on every authenticated request, not org-scoped only

- The head start is the point: `/me` and `/orgs` are the cold visit's first authenticated requests and are **not** org-scoped. Gating on org scope would delay the warm to the same request burst `/sessions` belongs to, forfeiting the overlap this phase exists to create.
- The volume ceiling is enforced in the service, not the trigger, and is identical either way for console traffic (the console polls org-scoped endpoints while a tab is visible): at most one upstream lookup per cache per half-lease per subject — the design §3 ceiling of ≤ 2 lookups per subject per 60 s for positive entries (the tightest case, a cached negative, re-arms at 30 s). Concretely: ≤ 2,880 lookups/subject/day with a permanently visible tab, ≈ 14.4k/day for five such subjects, against the ~1.9k/day measured baseline — order-of-magnitude headroom under Logto Management API limits, scaling with active subjects rather than request rate. If it ever grows past comfort, the design's named fallbacks (gate to org-scoped, coalesce the two lookups) still apply.
- Firing on API-key requests covers the agent-assistant MCP readers, whose first authenticated request can *be* `/sessions` — the warm converts the rest of the tool-call burst to cache hits and lets the first read join the in-flight lookup early.

### Out of scope (per the design)

Lease values, `refreshAheadDue`, the epoch fence, TTL constants, DB persistence of identity, the resource-shape warmer (Phase 3), UI.

## Testing

- `pnpm --filter @agentconnect.md/control-plane typecheck` — clean
- `test:unit` (137 files / 1362 tests) — new coverage: dueness bands (fires on cold caches and at 61 s; quiet at 59 s), single-flight coalescing including a blocking read joining a warm already in flight, `forgetUser` racing a warm-fired lookup (the epoch fence keeps the stale result out), failure swallowing, cold-block counting (capped vs display vs joined reads), trigger throttling/memoization/null-sub retry/DB-failure swallowing, and auth-plugin behavior on both paths — OIDC via a loopback JWKS issuer and API-key — including a throwing trigger never failing a request
- `test:int` (74 files / 1059 tests) — green, suite unchanged
- `eslint` / `prettier --check` on touched files — clean

Refs #792 (design §3, §5, §9 Q2), #775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)