### PR TITLE
fix(daemon): allow contained skill root aliases

### DIFF
--- a/packages/daemon/src/skills/skill-workspace-mutator.ts
+++ b/packages/daemon/src/skills/skill-workspace-mutator.ts
@@ -1,12 +1,48 @@
 import { spawn } from 'node:child_process'
-import { chmodSync, existsSync, mkdtempSync, promises as fsp, realpathSync, rmSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { chmodSync, existsSync, mkdtempSync, promises as fsp, realpathSync, rmSync, type Stats } from 'node:fs'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { under } from '../fs/contained-path.js'
 import { offlineSandboxLaunch } from './offline-sandbox.js'
 import { currentSkillMutationHelperLease } from './skill-workspace-lock-lease.js'
 
 const MAX_MUTATION_OUTPUT = 64 * 1024
 const MUTATION_TIMEOUT_MS = 20_000
+
+// Resolve a contained CLI-owned alias before the confined helper walks the mutation path.
+export async function canonicalSkillMutationRoot(cwd: string, relativeRoot: string): Promise<string> {
+  const workspace = await fsp.realpath(cwd)
+  const lexicalTarget = resolve(workspace, relativeRoot)
+  if (isAbsolute(relativeRoot) || !under(workspace, lexicalTarget)) return relativeRoot
+
+  const parts = relativeRoot.split('/')
+  if (parts.length < 2 || parts.some((part) => !part || part === '.' || part === '..')) return relativeRoot
+  let sawLink = false
+  let current = workspace
+  for (const part of parts.slice(0, -1)) {
+    current = join(current, part)
+    let stat: Stats
+    try {
+      stat = await fsp.lstat(current)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return relativeRoot
+      throw error
+    }
+    if (stat.isSymbolicLink()) sawLink = true
+    else if (!stat.isDirectory()) return relativeRoot
+  }
+  if (!sawLink) return relativeRoot
+
+  const canonicalParent = await fsp.realpath(dirname(lexicalTarget))
+  if (!under(workspace, canonicalParent)) throw new Error('skill mutation alias resolves outside workspace')
+  const canonical = relative(workspace, join(canonicalParent, basename(lexicalTarget)))
+    .split(sep)
+    .join('/')
+  if (!canonical || canonical.startsWith('../') || isAbsolute(canonical)) {
+    throw new Error('skill mutation alias resolves outside workspace')
+  }
+  return canonical
+}
 
 function helperPath(): string {
   const modulePath = realpathSync(fileURLToPath(import.meta.url))
@@ -44,10 +80,16 @@ export async function runSkillWorkspaceMutation<T extends object>(
             sourceDir: realpathSync((candidate as Record<string, unknown>).sourceDir as string)
           }
         : candidate
+    const relativeRoot = (spec as Record<string, unknown>).relativeRoot
+    const normalizedRelativeRoot =
+      typeof relativeRoot === 'string'
+        ? await canonicalSkillMutationRoot(canonicalWorkspace, relativeRoot)
+        : relativeRoot
     const normalizedSpec = {
       ...spec,
       cwd: canonicalWorkspace,
-      ...(normalizedCandidate === undefined ? {} : { candidate: normalizedCandidate })
+      ...(normalizedCandidate === undefined ? {} : { candidate: normalizedCandidate }),
+      ...(normalizedRelativeRoot === undefined ? {} : { relativeRoot: normalizedRelativeRoot })
     }
     const home = join(root, 'home')
     const runnerCwd = join(root, 'workspace')

--- a/packages/daemon/test/skill-install-ledger.test.ts
+++ b/packages/daemon/test/skill-install-ledger.test.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { lstat, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -110,6 +110,20 @@ describe.skipIf(!hasBwrap)('skill install ledger crash recovery', () => {
     expect(recovered.phase).toBe('ready')
     expect(recovered.owned).toEqual([])
     expect(existsSync(join(cwd, '.runtime'))).toBe(false)
+  })
+
+  it('recovers an old journal through a contained workspace-local skill-root alias', async () => {
+    await mkdir(join(cwd, '.claude/skills'), { recursive: true })
+    await mkdir(join(cwd, '.agents'))
+    await symlink('../.claude/skills', join(cwd, '.agents/skills'))
+    const location = await writeApplying([operation('.agents/skills/never-started')])
+    const applying = await readSkillLedger(location)
+
+    const recovered = await recover(location, applying!)
+
+    expect(recovered.phase).toBe('ready')
+    expect(recovered.owned).toEqual([])
+    expect(existsSync(join(cwd, '.claude/skills/never-started'))).toBe(false)
   })
 
   it('discards only content-free reservation shapes before inode authority is journaled', async () => {

--- a/packages/daemon/test/skill-workspace-mutator.test.ts
+++ b/packages/daemon/test/skill-workspace-mutator.test.ts
@@ -1,0 +1,49 @@
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { canonicalSkillMutationRoot } from '../src/skills/skill-workspace-mutator.js'
+
+const roots: string[] = []
+
+async function workspace(): Promise<{ root: string; cwd: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'ac-skill-alias-'))
+  roots.push(root)
+  const cwd = join(root, 'workspace')
+  await mkdir(cwd)
+  return { root, cwd }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('canonicalSkillMutationRoot', () => {
+  it('maps a workspace-local skill-root alias to its real relative path', async () => {
+    const { cwd } = await workspace()
+    await mkdir(join(cwd, '.claude/skills'), { recursive: true })
+    await mkdir(join(cwd, '.agents'))
+    await symlink('../.claude/skills', join(cwd, '.agents/skills'))
+
+    await expect(canonicalSkillMutationRoot(cwd, '.agents/skills/audit')).resolves.toBe('.claude/skills/audit')
+  })
+
+  it('leaves an ordinary or not-yet-created skill root unchanged', async () => {
+    const { cwd } = await workspace()
+    await mkdir(join(cwd, '.claude/skills'), { recursive: true })
+
+    await expect(canonicalSkillMutationRoot(cwd, '.claude/skills/audit')).resolves.toBe('.claude/skills/audit')
+    await expect(canonicalSkillMutationRoot(cwd, '.runtime/skills/audit')).resolves.toBe('.runtime/skills/audit')
+  })
+
+  it('refuses a skill-root alias that resolves outside the workspace', async () => {
+    const { root, cwd } = await workspace()
+    await mkdir(join(root, 'outside/skills'), { recursive: true })
+    await mkdir(join(cwd, '.agents'))
+    await symlink(join(root, 'outside/skills'), join(cwd, '.agents/skills'))
+
+    await expect(canonicalSkillMutationRoot(cwd, '.agents/skills/audit')).rejects.toThrow(
+      /alias resolves outside workspace/
+    )
+  })
+})

--- a/packages/daemon/test/unified-skills.test.ts
+++ b/packages/daemon/test/unified-skills.test.ts
@@ -108,6 +108,24 @@ describe.skipIf(!hasBwrap)('unified isolated skill installation', () => {
     expect(await readFile(join(cwd, '.cli-owned/skills/dream/SKILL.md'), 'utf8')).toContain('# dream')
   }, 120_000)
 
+  it('publishes a Codex skill through a contained workspace-local skill-root alias', async () => {
+    const sourceDir = await writeSkill(sources, 'audit', 'audit')
+    await mkdir(join(cwd, '.claude/skills'), { recursive: true })
+    await mkdir(join(cwd, '.agents'))
+    await symlink('../.claude/skills', join(cwd, '.agents/skills'))
+    const cli = fakeCli(() => '.agents')
+
+    const result = await installSkills({ id: 'a1', runtime: 'codex-acp', skills: [] }, cwd, {
+      stateDir,
+      localSkills: [{ kind: 'dream', key: 'dream:audit', name: 'audit', sourceDir }],
+      runCli: cli.run
+    })
+
+    expect(result.errors).toEqual([])
+    expect(result.installed).toEqual(['.agents/skills/audit'])
+    expect(await readFile(join(cwd, '.claude/skills/audit/SKILL.md'), 'utf8')).toContain('# audit')
+  })
+
   it.each([
     ['direct skills root', ''],
     ['multi-component prefix', 'vendor/harness']


### PR DESCRIPTION
## Summary

- resolve CLI-derived skill destinations through workspace-local symlink aliases before the confined helper
- continue rejecting aliases that resolve outside the workspace
- recover old applying ledgers and cover the tracked Codex-to-Claude skill alias

## Tests

- daemon targeted Vitest suite
- daemon typecheck
- changed-file ESLint
- pre-push full-repository ESLint