### PR TITLE
feat(cp): surface session-access refresh-behind failures

### DIFF
--- a/packages/control-plane/src/http/session-access.test.ts
+++ b/packages/control-plane/src/http/session-access.test.ts
@@ -323,6 +323,65 @@ describe('makeSessionAccessResolver snapshot', () => {
     })
   })
 
+  it('emits one countable warn and stamps the snapshot when a refresh behind the request fails', async () => {
+    const { deps, clock, resolve } = harness()
+    const resolver = makeSessionAccessResolver(deps)
+
+    await resolver.forQuery(request(), query)
+    clock.advance(30_001)
+    resolve.mockRejectedValueOnce(
+      Object.assign(new Error('getaddrinfo failed for the provider host'), { code: 'ENOTFOUND' })
+    )
+
+    const kicker = request()
+    await expect(resolver.forQuery(kicker, query)).resolves.toMatchObject({ degraded: false })
+    await settle()
+
+    // The failure reached no caller, so this warn is its only trace: a CAUSE and the org, never the message.
+    expect(kicker.log.warn).toHaveBeenCalledTimes(1)
+    expect(kicker.log.warn).toHaveBeenCalledWith(
+      { orgId: 'org-1', cause: 'ENOTFOUND' },
+      'session access refresh-behind failed — still serving the previous snapshot'
+    )
+    // The entry it left behind says when it went stale-and-failing, and still serves the recorded answer.
+    const served = await resolver.forQuery(request(), query)
+    expect(served.refreshFailedAt).toEqual(new Date(clock.now()))
+    expect(served.degraded).toBe(false)
+    expect(served.externalAccess.allowedScopes).toEqual([{ id: scope.id, aclRevision: scope.aclRevision }])
+  })
+
+  it('clears the staleness stamp once a refresh lands', async () => {
+    const { deps, clock, resolve } = harness()
+    const resolver = makeSessionAccessResolver(deps)
+
+    await resolver.forQuery(request(), query)
+    clock.advance(30_001)
+    resolve.mockRejectedValueOnce(new Error('slack unreachable'))
+    await resolver.forQuery(request(), query)
+    await settle()
+
+    // Still inside the stale window: this read serves the stamped entry and kicks a refresh that succeeds.
+    expect((await resolver.forQuery(request(), query)).refreshFailedAt).toBeDefined()
+    await settle()
+
+    const after = await resolver.forQuery(request(), query)
+    expect(after.refreshFailedAt).toBeUndefined()
+    // `degraded` marks the third sweep's answer: the stamp is gone because the refresh REPLACED the entry.
+    expect(after.degraded).toBe(true)
+    expect(resolve).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not emit the refresh-behind warn when a cold blocking sweep fails', async () => {
+    const { deps, resolve } = harness()
+    const resolver = makeSessionAccessResolver(deps)
+    resolve.mockRejectedValueOnce(new Error('slack unreachable'))
+
+    // A cold sweep's failure already surfaces to its caller; only the invisible background class is logged.
+    const req = request()
+    await expect(resolver.forQuery(req, query)).rejects.toThrow('slack unreachable')
+    expect(req.log.warn).not.toHaveBeenCalled()
+  })
+
   // The ceiling has to hold even when a refresh straddles it. `fetch` coalesces
   // a later caller onto the SAME in-flight promise and settles it with the
   // options of the fetch that created it, so a stale-on-rejection policy set by

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -22,6 +22,8 @@ export interface ResolvedSessionAccess {
   externalScopes: readonly ExternalScopeRecord[]
   degraded: boolean
   accessIssues: SessionAccessIssue[]
+  /** Set when this snapshot's last refresh-behind failed; cleared by the next one that lands. Observability only (#775). */
+  refreshFailedAt?: Date
 }
 
 export interface SessionAccessResolver {
@@ -97,6 +99,15 @@ type Sweep = {
   scopes: readonly ExternalScopeRecord[]
   viewer: SessionAccessViewer
   policies: PolicySnapshot
+  /** True for a refresh behind a served response; a cold blocking sweep reports its failure to the caller instead. */
+  background: boolean
+}
+
+/** A CAUSE, never a TARGET (the slack-session-access.ts discipline): the error's code or class name, never its message. */
+function refreshFailureCause(err: unknown): string {
+  if (!(err instanceof Error)) return typeof err
+  const code = (err as { code?: unknown }).code
+  return typeof code === 'string' || typeof code === 'number' ? String(code) : err.name
 }
 
 /** Exactly the inputs `forScopes` reads — org, the viewer it decides for, the
@@ -247,7 +258,18 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
     // outlive its own freshness for there to be anything to serve while the
     // refresh runs. `SNAPSHOT_FRESH_MS` is applied by the reader below.
     ttl: SNAPSHOT_MAX_STALE_MS,
-    fetchMethod: (_key, _stale, { context }) => forScopes(context.scopes, context.viewer, context.policies)
+    fetchMethod: (_key, stale, { context }) =>
+      forScopes(context.scopes, context.viewer, context.policies).catch((err: unknown) => {
+        // A refresh-behind rejection reaches no caller: stamp the surviving entry and log the one countable warn.
+        if (context.background) {
+          if (stale) stale.refreshFailedAt = new Date(deps.clock.now())
+          context.viewer.request.log.warn(
+            { orgId: context.viewer.orgId, cause: refreshFailureCause(err) },
+            'session access refresh-behind failed — still serving the previous snapshot'
+          )
+        }
+        throw err
+      })
   })
 
   /** `forScopes` behind the snapshot window. Callers treat the record as
@@ -270,7 +292,7 @@ function buildSessionAccessResolver(deps: HttpDeps): SessionAccessResolver {
     // directly rather than reporting no external access, which would hide rows.
     const access =
       (await snapshots.fetch(key, {
-        context: { scopes, viewer, policies },
+        context: { scopes, viewer, policies, background: refreshBehind },
         ...(refreshBehind ? REFRESH_BEHIND : {})
       })) ?? (await forScopes(scopes, viewer, policies))
     return { ...access, identitySet: new Set(access.identitySet) }


### PR DESCRIPTION
Phase 4 of `docs/designs/session-access-cold-visit.md` (§5 last bullet, §8) — follow-up to #792, item 4 of #775. Observability only; no behavior changes.

## The gap

The session-access snapshot cache serves stale entries while refreshing behind the request; `noDeleteOnFetchRejection` deliberately keeps the previous entry serving when that background refresh fails, so a provider blip never empties the answer. But the failure was visible nowhere: the served snapshot still carried its recorded `degraded: false`, nothing was logged, no counter moved. A refresh pipeline broken for minutes looked identical to a healthy one — which #775 called out as the precondition for ever discussing a longer stale window.

## What this adds

- **A structured warn per rejected refresh-behind sweep**, stable message `session access refresh-behind failed — still serving the previous snapshot`, carrying the org id and a cause classification. The cause follows the `slack-session-access.ts` discipline — a CAUSE, never a TARGET: the error's `code` or class name, never its message, so no scope/channel/workspace identifier can ride into the log.
- **The event doubles as the counter.** It fires only for the background class: a cold blocking sweep's failure already surfaces to its caller as an error (unchanged), so counting this message counts exactly the previously invisible failures. Log-based counting is the established precedent on this surface (the Slack degraded-resolve warn, the doorbell per-pull log — design §5); an OTel counter can follow if that proves insufficient.
- **A staleness stamp on the entry**: `refreshFailedAt` is set on the snapshot the failure leaves serving; a refresh that lands replaces the entry, which clears it.

Deliberately untouched: the `REFRESH_BEHIND` options — in particular `allowStaleOnFetchRejection` stays absent, so a caller past the ceiling coalescing onto an in-flight refresh still observes its failure — plus `SNAPSHOT_FRESH_MS` / `SNAPSHOT_MAX_STALE_MS`, fail-closed behavior, and every DTO/UI surface.

## Natural follow-up (not in this PR)

`refreshFailedAt` is recorded but not surfaced. Folding it into `accessSyncDegraded` (or an `accessIssue`) on responses served from a stale-and-failing snapshot is a behavior change: every list/detail/usage consumer would start showing the degraded banner during provider outages that today serve quietly. It would take reading the stamp in the snapshot hand-out path plus a product decision on those banner semantics.

## Tests

Three additions to the existing FakeClock harness in `session-access.test.ts`:
- a refresh-behind rejection emits exactly one warn (org + cause payload asserted exactly, message excluded) and the entry keeps serving the recorded answer, now stamped;
- a subsequent successful refresh clears the stamp, asserted via the replacing entry's fresh answer;
- a cold blocking-sweep failure propagates to the caller as today and emits nothing.

## Verification

- `pnpm --filter @agentconnect.md/control-plane typecheck` — exit 0
- `test:unit` — 1398 passed (138 files)
- `test:int` — 1059 passed (74 files, Testcontainers Postgres), exit code captured explicitly: 0
- `eslint` and `prettier --check` on the touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)