### PR TITLE
feat(cp): warm session-access resource facts from session activity

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -186,6 +186,8 @@ import { configureFeishuHttpApp } from './http/feishu-app-config.js'
 import { SlackSessionAccessService } from './http/slack-session-access.js'
 import { GithubSessionAccessService } from './http/github-session-access.js'
 import { FeishuSessionAccessService } from './http/feishu-session-access.js'
+import { SessionAccessWarmer } from './http/session-access-warmer.js'
+import type { ExternalScopeRecord } from './persistence/ports.js'
 
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from './config/defaults.js'
 
@@ -1165,6 +1167,26 @@ export function buildContainer(
   const pendingInstallReapers = buildPendingInstallReapers(platforms, clock, http.log)
   const backgroundLoops = platformBackgroundLoops(platforms)
 
+  // §4 session-access warmer (session-access-cold-visit.md, Phase 3): keeps the
+  // resource facts behind ACTIVE external scopes leased so a cold console visit
+  // skips the per-resource provider sweep. Poked from `event/session` ingest;
+  // observes only through the plugins' classifying warm entries (§4.2(3)).
+  // Built here so the graph is whole, armed only by `startBackground()`.
+  const sessionAccessWarmer = new SessionAccessWarmer({
+    sessions: repos.session,
+    targets: new Map([
+      ['slack', (scope: ExternalScopeRecord) => slackSessionAccess.warmAudience(scope)],
+      ['github', (scope: ExternalScopeRecord) => githubSessionAccess.warmShape(scope)]
+    ]),
+    clock,
+    publicTtlMs: sessionAccessTtls.publicTtlMs,
+    log: {
+      debug: (o, m) => http.log.debug(o, m),
+      info: (o, m) => http.log.info(o, m),
+      warn: (o, m) => http.log.warn(o, m)
+    }
+  })
+
   // ── daemon WS edge (mounted on the live http.Server after listen) ──────────
   const wsDeps: DaemonWsServerDeps = {
     auth,
@@ -1183,6 +1205,7 @@ export function buildContainer(
     githubInstallation: repos.githubInstallation,
     integrationChannel: repos.integrationChannel,
     slackSessionAccess,
+    sessionAccessWarmer,
     agentMutations,
     recoverStagedAgent: (agentId, daemonId, moveId) => stagedAgentMoves.recoverStaged(agentId, daemonId, moveId),
     collabRoutes,
@@ -1510,6 +1533,7 @@ export function buildContainer(
       hookRedeliveryReconciler?.start()
       for (const reaper of pendingInstallReapers) reaper.start()
       relaySweeper.start()
+      sessionAccessWarmer.start()
       for (const loop of backgroundLoops) loop.start()
       // One-shot (not a re-arming loop): the worklist empties itself; a partially
       // failed boot resumes on the next one. Never blocks listen.
@@ -1524,12 +1548,14 @@ export function buildContainer(
       installationDoorbell?.stop()
       for (const reaper of pendingInstallReapers) reaper.stop()
       relaySweeper.stop()
+      sessionAccessWarmer.stop()
       for (const loop of backgroundLoops) loop.stop()
       visibilityPush.stop()
       await Promise.allSettled([
         webchatMcpOperationSettled,
         ...relayRegistrationTasks,
         visibilityPush.settle(),
+        sessionAccessWarmer.settle(),
         ...(installationDoorbell ? [installationDoorbell.settle()] : [])
       ])
       await rootPrisma.$disconnect()

--- a/packages/control-plane/src/http/github-session-access.test.ts
+++ b/packages/control-plane/src/http/github-session-access.test.ts
@@ -360,6 +360,37 @@ describe('GithubSessionAccessService', () => {
       expect(h.repoRefById).toHaveBeenCalledTimes(2)
     })
 
+    // §4.2(6): a cadence warm on an already-leased entry must hold the warmer's
+    // permit for the REAL provider work — the touch-revalidation it fires —
+    // not resolve while that request is still in flight.
+    it('holds the warm open until its re-observation lands', async () => {
+      const h = make(false)
+
+      await expect(h.service.warmShape(scope)).resolves.toEqual({ outcome: 'warmed', verdict: 'public' })
+
+      // Half a lease later the entry still serves but is past the recheck
+      // threshold, so this warm fires a re-observation — and must await it.
+      h.clock.advance(30 * 60_000)
+      let release!: () => void
+      h.repoRefById.mockImplementationOnce(() => {
+        return new Promise((resolve) => {
+          release = () =>
+            resolve({ repoId: 123n, fullName: 'acme/private-repo', private: false, defaultBranch: 'main' })
+        })
+      })
+      let settled = false
+      const warm = h.service.warmShape(scope).then((outcome) => {
+        settled = true
+        return outcome
+      })
+      await vi.waitFor(() => expect(h.repoRefById).toHaveBeenCalledTimes(2))
+      expect(settled).toBe(false)
+
+      release()
+      await expect(warm).resolves.toEqual({ outcome: 'warmed', verdict: 'public' })
+      expect(h.service.stats.shapeRevalidations).toBe(1)
+    })
+
     it('skips a revoked installation or a foreign scope with zero provider calls', async () => {
       const repoRefById = vi.fn().mockResolvedValue(PRIVATE_SHAPE)
       const service = new GithubSessionAccessService({

--- a/packages/control-plane/src/http/github-session-access.test.ts
+++ b/packages/control-plane/src/http/github-session-access.test.ts
@@ -314,4 +314,72 @@ describe('GithubSessionAccessService', () => {
     })
     expect(h.repoRefById).toHaveBeenCalledTimes(2)
   })
+
+  // §4.1 warm entry: a background warm observes through the SAME classifying
+  // wrapper as the read path, so a warmed shape leases and a failure pins nothing.
+  describe('warmShape (§4.1 warm entry)', () => {
+    it('leases the shape so a later resolve pays no lookup', async () => {
+      const h = make(false)
+
+      await expect(h.service.warmShape(scope)).resolves.toEqual({ outcome: 'warmed', verdict: 'public' })
+      expect(h.repoRefById).toHaveBeenCalledTimes(1)
+
+      await expect(h.service.resolve([scope], viewer)).resolves.toEqual({
+        allowedScopes: [{ id: scope.id, aclRevision: scope.aclRevision }],
+        degraded: false
+      })
+      expect(h.repoRefById).toHaveBeenCalledTimes(1)
+      expect(h.permissionForUser).not.toHaveBeenCalled()
+    })
+
+    it('warms a private shape without ever running a per-principal check', async () => {
+      const h = make(true, vi.fn().mockResolvedValue('read'))
+
+      await expect(h.service.warmShape(scope)).resolves.toEqual({ outcome: 'warmed', verdict: 'private' })
+      expect(h.permissionForUser).not.toHaveBeenCalled()
+
+      // The viewer's own resolve reuses the shape but still pays its age-0 permission.
+      await expect(h.service.resolve([scope], viewer)).resolves.toEqual({
+        allowedScopes: [{ id: scope.id, aclRevision: scope.aclRevision }],
+        degraded: false
+      })
+      expect(h.repoRefById).toHaveBeenCalledTimes(1)
+      expect(h.permissionForUser).toHaveBeenCalledTimes(1)
+    })
+
+    it('never caches a failed warm lookup', async () => {
+      const h = make(false)
+      h.repoRefById.mockRejectedValueOnce(new Error('provider unavailable'))
+
+      await expect(h.service.warmShape(scope)).resolves.toEqual({ outcome: 'failed', reason: 'lookup_failed' })
+
+      await expect(h.service.resolve([scope], viewer)).resolves.toEqual({
+        allowedScopes: [{ id: scope.id, aclRevision: scope.aclRevision }],
+        degraded: false
+      })
+      expect(h.repoRefById).toHaveBeenCalledTimes(2)
+    })
+
+    it('skips a revoked installation or a foreign scope with zero provider calls', async () => {
+      const repoRefById = vi.fn().mockResolvedValue(PRIVATE_SHAPE)
+      const service = new GithubSessionAccessService({
+        installations: {
+          get: vi.fn().mockResolvedValue({ ...installation, revokedAt: new Date(EPOCH) })
+        } as never,
+        github: { repoRefById },
+        userAuthz: { permissionForUser: vi.fn() },
+        clock: new FakeClock(EPOCH)
+      })
+
+      await expect(service.warmShape(scope)).resolves.toEqual({
+        outcome: 'skipped',
+        reason: 'installation_revoked'
+      })
+      await expect(service.warmShape({ ...scope, provider: 'slack' })).resolves.toEqual({
+        outcome: 'skipped',
+        reason: 'scope_shape'
+      })
+      expect(repoRefById).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/control-plane/src/http/github-session-access.ts
+++ b/packages/control-plane/src/http/github-session-access.ts
@@ -260,11 +260,15 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
     if (installation.revokedAt || installation.suspendedAt)
       return { outcome: 'skipped', reason: 'installation_revoked' }
     try {
-      const observed = await this.shapeOf(`${installation.installationId}:${scope.resourceKey}`, {
-        github,
-        ins: installation,
-        repoId: BigInt(scope.resourceKey)
-      })
+      const key = `${installation.installationId}:${scope.resourceKey}`
+      const observed = await this.shapeOf(key, { github, ins: installation, repoId: BigInt(scope.resourceKey) })
+      // §4.2(6): past the recheck threshold `shapeOf` serves cached and
+      // re-observes DETACHED — right for a foreground read, wrong for a cadence
+      // sweep, which would fan out one detached provider call per scope and
+      // bypass the warmer's concurrency permit and settle(). Hold the warm open
+      // until the re-observation it (or a foreground read) fired lands; the
+      // task never rejects and its write stays behind the object fence.
+      await this.revalidating.get(key)
       if (!observed) return { outcome: 'failed', reason: 'shape_evicted' }
       const shape = observed.shape
       return { outcome: 'warmed', verdict: shape === null ? 'ungranted' : shape.private ? 'private' : 'public' }

--- a/packages/control-plane/src/http/github-session-access.ts
+++ b/packages/control-plane/src/http/github-session-access.ts
@@ -6,7 +6,12 @@ import type { ExternalScopeRecord, GithubInstallationRecord, GithubInstallationR
 import type { GithubService } from '../github/service.js'
 import { PROVIDER_IDENTITY_TTL_MS } from '../github/logto-identity.js'
 import { UserAuthzDeniedError, type GithubUserAuthzService } from '../github/user-authz.js'
-import type { SessionAccessPlugin, SessionAccessResult, SessionAccessViewer } from './session-access-plugin.js'
+import type {
+  SessionAccessPlugin,
+  SessionAccessResult,
+  SessionAccessViewer,
+  SessionAccessWarmOutcome
+} from './session-access-plugin.js'
 
 const DENY_TTL_MS = 30_000
 const UNKNOWN_TTL_MS = 5_000
@@ -23,6 +28,22 @@ type Decision = 'allow' | 'deny' | 'unknown'
 type RepoShape = { fullName: string; private: boolean } | null
 type ObservedRepoShape = { shape: RepoShape; fetchedAt: number }
 type ShapeLookup = { github: Pick<GithubService, 'repoRefById'>; ins: GithubInstallationRecord; repoId: bigint }
+
+/** The scope rows GitHub can answer for at all — the shared gate of the read path
+ *  (anything else is a plain deny) and the §4.1 warm entry (a skip). */
+function installationRepositoryScope(
+  scope: ExternalScopeRecord
+): scope is ExternalScopeRecord & { credentialId: string } {
+  return (
+    scope.provider === 'github' &&
+    scope.realmKey === 'github.com' &&
+    scope.resourceKind === 'repository' &&
+    scope.revokedAt === null &&
+    scope.credentialKind === 'github_installation' &&
+    !!scope.credentialId &&
+    /^[1-9]\d*$/.test(scope.resourceKey)
+  )
+}
 
 async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value: T) => Promise<R>): Promise<R[]> {
   const out = new Array<R>(values.length)
@@ -129,17 +150,7 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
   }
 
   private async resolveScope(scope: ExternalScopeRecord, userId: string): Promise<Decision> {
-    if (
-      scope.provider !== 'github' ||
-      scope.realmKey !== 'github.com' ||
-      scope.resourceKind !== 'repository' ||
-      scope.revokedAt !== null ||
-      scope.credentialKind !== 'github_installation' ||
-      !scope.credentialId ||
-      !/^[1-9]\d*$/.test(scope.resourceKey)
-    ) {
-      return 'deny'
-    }
+    if (!installationRepositoryScope(scope)) return 'deny'
     const github = this.deps.github
     if (!github) return 'unknown'
     // Fenced on the org recorded in the session's own external scope row — the
@@ -229,6 +240,37 @@ export class GithubSessionAccessService implements SessionAccessPlugin {
   /** Await in-flight background re-observations — nothing else ever awaits them. */
   async settle(): Promise<void> {
     await Promise.all([...this.revalidating.values()])
+  }
+
+  /**
+   * §4.1 warm entry (session-access-cold-visit.md): observe one scope's
+   * repository shape so a later cold visit finds it leased. The observation
+   * goes through `shapeOf` — the classifying wrapper — never the raw cache
+   * (§4.2(3)): a rejected lookup stays a per-request failure, and a touch past
+   * the recheck threshold re-observes in the background under the write fence.
+   * The installation is resolved here, at execution, through the read path's
+   * own org fence (§4.2(2)); a failed fence skips and caches nothing.
+   */
+  async warmShape(scope: ExternalScopeRecord): Promise<SessionAccessWarmOutcome> {
+    if (!installationRepositoryScope(scope)) return { outcome: 'skipped', reason: 'scope_shape' }
+    const github = this.deps.github
+    if (!github) return { outcome: 'skipped', reason: 'github_unconfigured' }
+    const installation = await this.deps.installations.get(OrgId(scope.orgId), scope.credentialId).catch(() => null)
+    if (!installation) return { outcome: 'skipped', reason: 'installation_unresolved' }
+    if (installation.revokedAt || installation.suspendedAt)
+      return { outcome: 'skipped', reason: 'installation_revoked' }
+    try {
+      const observed = await this.shapeOf(`${installation.installationId}:${scope.resourceKey}`, {
+        github,
+        ins: installation,
+        repoId: BigInt(scope.resourceKey)
+      })
+      if (!observed) return { outcome: 'failed', reason: 'shape_evicted' }
+      const shape = observed.shape
+      return { outcome: 'warmed', verdict: shape === null ? 'ungranted' : shape.private ? 'private' : 'public' }
+    } catch {
+      return { outcome: 'failed', reason: 'lookup_failed' }
+    }
   }
 
   private putCache(key: string, decision: Decision, identityBacked: boolean): void {

--- a/packages/control-plane/src/http/session-access-plugin.ts
+++ b/packages/control-plane/src/http/session-access-plugin.ts
@@ -42,6 +42,12 @@ export interface SessionAccessResult {
   accessIssues?: SessionAccessIssue[]
 }
 
+/** §4.1 warm outcome (session-access-cold-visit.md): `warmed` carries the verdict now
+ *  leased; `skipped` is a fence refusing before any provider call; `failed` is a check
+ *  that ran and could not answer — and, by the wrapper invariant, was never cached. */
+export type SessionAccessWarmOutcome =
+  { outcome: 'warmed'; verdict: string } | { outcome: 'skipped' | 'failed'; reason: string }
+
 /** Provider-owned half of Session visibility. Core combines the provider
  * audience with the Session's own classification; Agent Team visibility is a
  * separate resource boundary. */

--- a/packages/control-plane/src/http/session-access-warmer.test.ts
+++ b/packages/control-plane/src/http/session-access-warmer.test.ts
@@ -33,7 +33,7 @@ function policyRecord(state: SessionExternalAccessPolicyRecord['state']): Sessio
   return { orgId: ORG, provider: 'slack', state, currentRev: 1n, readFenceRev: 1n }
 }
 
-function harness(opts: { random?: () => number; idleDropMs?: number } = {}) {
+function harness(opts: { random?: () => number; idleDropMs?: number; maxScopes?: number } = {}) {
   const clock = new FakeClock(EPOCH)
   const scopes = new Map<string, ExternalScopeRecord>([[SCOPE_ID, scopeRecord()]])
   const policies = new Map<string, SessionExternalAccessPolicyRecord>([[`${ORG}:slack`, policyRecord('enabled')]])
@@ -51,7 +51,8 @@ function harness(opts: { random?: () => number; idleDropMs?: number } = {}) {
     targets: new Map([['slack', target]]),
     clock,
     random: opts.random ?? (() => 0),
-    ...(opts.idleDropMs !== undefined ? { idleDropMs: opts.idleDropMs } : {})
+    ...(opts.idleDropMs !== undefined ? { idleDropMs: opts.idleDropMs } : {}),
+    ...(opts.maxScopes !== undefined ? { maxScopes: opts.maxScopes } : {})
   })
   return { clock, warmer, target, scopes, policies, getExternalScopes, getExternalAccessPolicy }
 }
@@ -229,6 +230,25 @@ describe('SessionAccessWarmer', () => {
     h.clock.advance(INTERVAL)
     await h.warmer.settle()
     expect(h.target).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels the scheduled warm of a scope evicted from the working set', async () => {
+    const h = harness({ random: () => 0.5, maxScopes: 3 })
+    for (let index = 1; index <= 4; index++) {
+      h.scopes.set(`scope-${index}`, scopeRecord({ id: `scope-${index}` }))
+    }
+    h.warmer.start()
+    // Young-window jitter keeps every first warm pending as a timer.
+    for (let index = 1; index <= 4; index++) h.warmer.poke(ORG, `scope-${index}`)
+
+    // 1 loop timer + 3 scheduled: scope-1's timer left with its evicted entry.
+    expect(h.clock.pendingTimers()).toBe(4)
+
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+    const warmedIds = h.target.mock.calls.map(([warmed]) => warmed.id)
+    expect(warmedIds).toHaveLength(3)
+    expect(warmedIds).not.toContain('scope-1')
   })
 
   it('stop() cancels the loop and every scheduled warm', async () => {

--- a/packages/control-plane/src/http/session-access-warmer.test.ts
+++ b/packages/control-plane/src/http/session-access-warmer.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+import { OrgId } from '../domain/ids.js'
+import type { ExternalScopeRecord, SessionExternalAccessPolicyRecord } from '../persistence/ports.js'
+import type { SessionAccessWarmOutcome } from './session-access-plugin.js'
+import { SessionAccessWarmer } from './session-access-warmer.js'
+
+/** `Clock` reports wall-clock epoch milliseconds, and lru-cache reads a falsy
+ *  entry start as "no TTL recorded" — a clock left at 0 would hide expiry. */
+const EPOCH = 1_777_000_000_000
+const ORG = OrgId('org-1')
+const SCOPE_ID = '11111111-1111-4111-8111-111111111111'
+/** Half the default public TTL — the §4.3 re-warm cadence. */
+const INTERVAL = 1_800_000
+
+function scopeRecord(overrides: Partial<ExternalScopeRecord> = {}): ExternalScopeRecord {
+  return {
+    id: SCOPE_ID,
+    orgId: ORG,
+    provider: 'slack',
+    realmKey: 'T_INSTALL',
+    resourceKind: 'conversation',
+    resourceKey: 'C_CHANNEL',
+    credentialKind: 'bot',
+    credentialId: 'b0b0b0b0-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    aclRevision: 1n,
+    revokedAt: null,
+    ...overrides
+  }
+}
+
+function policyRecord(state: SessionExternalAccessPolicyRecord['state']): SessionExternalAccessPolicyRecord {
+  return { orgId: ORG, provider: 'slack', state, currentRev: 1n, readFenceRev: 1n }
+}
+
+function harness(opts: { random?: () => number; idleDropMs?: number } = {}) {
+  const clock = new FakeClock(EPOCH)
+  const scopes = new Map<string, ExternalScopeRecord>([[SCOPE_ID, scopeRecord()]])
+  const policies = new Map<string, SessionExternalAccessPolicyRecord>([[`${ORG}:slack`, policyRecord('enabled')]])
+  const target = vi.fn(async (_scope: ExternalScopeRecord): Promise<SessionAccessWarmOutcome> => {
+    return { outcome: 'warmed', verdict: 'public' }
+  })
+  const getExternalScopes = vi.fn(async (ids: string[]) =>
+    ids.flatMap((id) => (scopes.has(id) ? [scopes.get(id)!] : []))
+  )
+  const getExternalAccessPolicy = vi.fn(async (orgId: OrgId, provider: string) => {
+    return policies.get(`${orgId}:${provider}`) ?? null
+  })
+  const warmer = new SessionAccessWarmer({
+    sessions: { getExternalScopes, getExternalAccessPolicy },
+    targets: new Map([['slack', target]]),
+    clock,
+    random: opts.random ?? (() => 0),
+    ...(opts.idleDropMs !== undefined ? { idleDropMs: opts.idleDropMs } : {})
+  })
+  return { clock, warmer, target, scopes, policies, getExternalScopes, getExternalAccessPolicy }
+}
+
+describe('SessionAccessWarmer', () => {
+  it('warms a poked scope and re-warms it on the half-lease cadence', async () => {
+    const h = harness()
+    h.warmer.start()
+
+    h.warmer.poke(ORG, SCOPE_ID)
+    h.clock.advance(0)
+    await h.warmer.settle()
+    expect(h.target).toHaveBeenCalledTimes(1)
+    expect(h.target).toHaveBeenCalledWith(expect.objectContaining({ id: SCOPE_ID, provider: 'slack' }))
+
+    // Repeated pokes inside the cadence add no provider work — the loop carries
+    // the scope; the poke only refreshes its working-set retention.
+    h.warmer.poke(ORG, SCOPE_ID)
+    h.clock.advance(0)
+    await h.warmer.settle()
+    expect(h.target).toHaveBeenCalledTimes(1)
+
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+    expect(h.target).toHaveBeenCalledTimes(2)
+
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+    expect(h.target).toHaveBeenCalledTimes(3)
+    expect(h.warmer.stats).toMatchObject({ warms: 3, warmed: 3, skipped: 0, failed: 0 })
+  })
+
+  it('drops a scope with no poke past the retention window, until it is poked again', async () => {
+    const h = harness({ idleDropMs: 2 * INTERVAL })
+    h.warmer.start()
+    h.warmer.poke(ORG, SCOPE_ID)
+    h.clock.advance(0)
+    await h.warmer.settle()
+
+    // Two cadence sweeps still carry it (idle age 1× and exactly 2× the window)…
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+    expect(h.target).toHaveBeenCalledTimes(3)
+
+    // …the next sweep finds it idle beyond the window and drops it for good.
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+    expect(h.target).toHaveBeenCalledTimes(3)
+
+    // Fresh activity re-enters the working set immediately.
+    h.warmer.poke(ORG, SCOPE_ID)
+    h.clock.advance(0)
+    await h.warmer.settle()
+    expect(h.target).toHaveBeenCalledTimes(4)
+  })
+
+  it('skips a warm for a disabled or missing policy with zero provider calls', async () => {
+    const h = harness()
+    h.policies.set(`${ORG}:slack`, policyRecord('disabled'))
+    h.warmer.start()
+
+    h.warmer.poke(ORG, SCOPE_ID)
+    h.clock.advance(0)
+    await h.warmer.settle()
+    expect(h.target).not.toHaveBeenCalled()
+
+    h.policies.delete(`${ORG}:slack`)
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+    expect(h.target).not.toHaveBeenCalled()
+    expect(h.warmer.stats).toMatchObject({ warms: 2, skipped: 2, warmed: 0 })
+  })
+
+  it('skips at execution when the scope no longer resolves under the poked org', async () => {
+    const h = harness()
+    h.warmer.start()
+
+    h.warmer.poke(OrgId('org-2'), SCOPE_ID)
+    h.clock.advance(0)
+    await h.warmer.settle()
+    expect(h.target).not.toHaveBeenCalled()
+    // The policy gate was never consulted either — the scope fence comes first.
+    expect(h.getExternalAccessPolicy).not.toHaveBeenCalled()
+    expect(h.warmer.stats.skipped).toBe(1)
+  })
+
+  it('skips a provider with no warm target', async () => {
+    const h = harness()
+    h.scopes.set(SCOPE_ID, scopeRecord({ provider: 'feishu' }))
+    h.warmer.start()
+
+    h.warmer.poke(ORG, SCOPE_ID)
+    h.clock.advance(0)
+    await h.warmer.settle()
+    expect(h.target).not.toHaveBeenCalled()
+    expect(h.warmer.stats.skipped).toBe(1)
+  })
+
+  it('holds the concurrency cap under a burst of pokes', async () => {
+    const h = harness()
+    let active = 0
+    let maxActive = 0
+    const releases: Array<() => void> = []
+    h.target.mockImplementation(() => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      return new Promise<SessionAccessWarmOutcome>((resolve) => {
+        releases.push(() => {
+          active -= 1
+          resolve({ outcome: 'warmed', verdict: 'public' })
+        })
+      })
+    })
+    for (let index = 1; index <= 8; index++) {
+      h.scopes.set(`scope-${index}`, scopeRecord({ id: `scope-${index}` }))
+    }
+    h.warmer.start()
+    for (let index = 1; index <= 8; index++) h.warmer.poke(ORG, `scope-${index}`)
+    h.clock.advance(0)
+
+    await vi.waitFor(() => expect(h.target.mock.calls.length).toBe(3))
+    expect(maxActive).toBe(3)
+
+    // Draining a slot admits exactly the next queued warm, never a burst.
+    await vi.waitFor(() => {
+      while (releases.length > 0) releases.shift()!()
+      expect(h.target.mock.calls.length).toBe(8)
+    })
+    while (releases.length > 0) releases.shift()!()
+    await h.warmer.settle()
+    expect(maxActive).toBe(3)
+    expect(h.warmer.stats.warmed).toBe(8)
+  })
+
+  it('spreads first warms after a restart across the young-process window', async () => {
+    const h = harness({ random: () => 0.5 })
+    h.warmer.start()
+
+    h.warmer.poke(ORG, SCOPE_ID)
+    h.clock.advance(INTERVAL / 2 - 1)
+    await h.warmer.settle()
+    expect(h.target).not.toHaveBeenCalled()
+
+    h.clock.advance(1)
+    await h.warmer.settle()
+    expect(h.target).toHaveBeenCalledTimes(1)
+  })
+
+  it('jitters within the small band once the process is no longer young', async () => {
+    const h = harness({ random: () => 0.5 })
+    h.warmer.start()
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+
+    h.warmer.poke(ORG, SCOPE_ID)
+    h.clock.advance(15_000)
+    await h.warmer.settle()
+    expect(h.target).toHaveBeenCalledTimes(1)
+  })
+
+  it('records pokes before startBackground but never arms a timer', async () => {
+    const h = harness()
+    h.warmer.poke(ORG, SCOPE_ID)
+    expect(h.clock.pendingTimers()).toBe(0)
+    h.clock.advance(10 * INTERVAL)
+    await h.warmer.settle()
+    expect(h.target).not.toHaveBeenCalled()
+
+    // Arming later picks the recorded scope up on the first sweep.
+    h.warmer.start()
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+    expect(h.target).toHaveBeenCalledTimes(1)
+  })
+
+  it('stop() cancels the loop and every scheduled warm', async () => {
+    const h = harness({ random: () => 0.5 })
+    h.warmer.start()
+    expect(h.clock.pendingTimers()).toBe(1)
+    h.warmer.poke(ORG, SCOPE_ID)
+    expect(h.clock.pendingTimers()).toBe(2)
+
+    h.warmer.stop()
+    expect(h.clock.pendingTimers()).toBe(0)
+    await h.warmer.settle()
+
+    h.clock.advance(10 * INTERVAL)
+    await h.warmer.settle()
+    expect(h.target).not.toHaveBeenCalled()
+  })
+
+  it('settle() drains a warm still in flight when stop() lands', async () => {
+    const h = harness()
+    let release!: () => void
+    h.target.mockImplementation(() => {
+      return new Promise<SessionAccessWarmOutcome>((resolve) => {
+        release = () => resolve({ outcome: 'warmed', verdict: 'public' })
+      })
+    })
+    h.warmer.start()
+    h.warmer.poke(ORG, SCOPE_ID)
+    h.clock.advance(0)
+    await vi.waitFor(() => expect(h.target).toHaveBeenCalledTimes(1))
+
+    h.warmer.stop()
+    const settled = vi.fn()
+    const settling = h.warmer.settle().then(settled)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(settled).not.toHaveBeenCalled()
+
+    release()
+    await settling
+    expect(settled).toHaveBeenCalledTimes(1)
+    expect(h.warmer.stats.warmed).toBe(1)
+  })
+
+  it('counts a target failure without caching responsibilities of its own', async () => {
+    const h = harness()
+    h.target.mockResolvedValue({ outcome: 'failed', reason: 'ratelimited' })
+    h.warmer.start()
+
+    h.warmer.poke(ORG, SCOPE_ID)
+    h.clock.advance(0)
+    await h.warmer.settle()
+    expect(h.warmer.stats).toMatchObject({ warms: 1, failed: 1, warmed: 0 })
+
+    // The scope stays in the working set; the next sweep retries.
+    h.target.mockResolvedValue({ outcome: 'warmed', verdict: 'public' })
+    h.clock.advance(INTERVAL)
+    await h.warmer.settle()
+    expect(h.warmer.stats).toMatchObject({ warms: 2, failed: 1, warmed: 1 })
+  })
+})

--- a/packages/control-plane/src/http/session-access-warmer.ts
+++ b/packages/control-plane/src/http/session-access-warmer.ts
@@ -72,6 +72,8 @@ export interface SessionAccessWarmerDeps {
   publicTtlMs?: number
   /** §4.3 working-set retention; default 24 h. Injectable for tests. */
   idleDropMs?: number
+  /** Working-set bound; default 10 000. Injectable for tests. */
+  maxScopes?: number
   /** Jitter source; injectable so tests are deterministic. */
   random?: () => number
 }
@@ -93,7 +95,14 @@ export class SessionAccessWarmer {
   readonly stats = { pokes: 0, warms: 0, warmed: 0, skipped: 0, failed: 0 }
 
   constructor(private readonly deps: SessionAccessWarmerDeps) {
-    this.entries = new LRUCache(cacheOptions(deps.clock, MAX_WORKING_SET))
+    this.entries = new LRUCache({
+      ...cacheOptions(deps.clock, deps.maxScopes ?? MAX_WORKING_SET),
+      // The working-set bound must bound the timers too: an entry leaving the
+      // set — LRU pressure or the idle drop — takes its scheduled warm with it,
+      // or a distinct-scope burst during the young window would grow
+      // `scheduled` past the advertised bound.
+      dispose: (_entry, scopeId) => this.cancelScheduled(scopeId)
+    })
     this.warmIntervalMs = Math.floor((deps.publicTtlMs ?? DEFAULT_PUBLIC_TTL_MS) / 2)
     this.idleDropMs = deps.idleDropMs ?? DEFAULT_IDLE_DROP_MS
     this.random = deps.random ?? Math.random
@@ -167,6 +176,14 @@ export class SessionAccessWarmer {
     } finally {
       this.armLoop()
     }
+  }
+
+  /** Cancel a scope's pending warm timer, if any (eviction/idle-drop dispose). */
+  private cancelScheduled(scopeId: string): void {
+    const timer = this.scheduled.get(scopeId)
+    if (timer === undefined) return
+    this.deps.clock.clearTimeout(timer)
+    this.scheduled.delete(scopeId)
   }
 
   /** Queue one warm — deduped against a scheduled or in-flight one. */

--- a/packages/control-plane/src/http/session-access-warmer.ts
+++ b/packages/control-plane/src/http/session-access-warmer.ts
@@ -1,0 +1,265 @@
+/**
+ * `SessionAccessWarmer` — §4 of session-access-cold-visit.md (Phase 3).
+ *
+ * The session-access plugins cache viewer-independent resource facts (Slack
+ * conversation audiences, GitHub repository shapes) under the §2 verdict-split
+ * leases, but only console reads populate them — so the infrequent visitor
+ * always misses. This service turns the product's own activity into the warming
+ * signal: the `event/session` ingest handler pokes it fire-and-forget with
+ * `(orgId, externalScopeId)` after commit-then-publish, and everything else is
+ * re-resolved at execution time.
+ *
+ * A poke marks the scope active in a bounded working set (per-entry LRU
+ * eviction, never a wholesale clear) and — when the scope is not already
+ * carried by the loop — schedules one warm. A `CronRunReaper`-style
+ * clock-driven loop re-warms every working-set scope on a cadence of half the
+ * public-verdict lease and drops scopes with no poke for `idleDropMs` (24 h),
+ * so warmth follows activity through a workday instead of ending one lease
+ * after the last message (§4.3). An idle org costs zero.
+ *
+ * Execution discipline (§4.2): the org's external-access policy is read before
+ * any provider work (`disabled`/missing row skips the warm entirely); scope →
+ * credential → secret re-resolve through the read path's own fences inside the
+ * plugins' warm entries; and every observation goes through the classifying
+ * wrappers (`warmAudience`/`warmShape`) — never the raw caches — so a failed
+ * warm is never cached and a §4.2(4) invalidation always wins. Rate
+ * discipline: a global concurrency cap, per-warm jitter, and first warms after
+ * a restart spread across the young-process window; replayed
+ * `event/session-sync` frames never poke (the handler layer enforces that).
+ *
+ * Lifecycle: constructed in the container, armed by `startBackground()` only
+ * (tests never see a timer), stopped in `shutdown()` — `stop()` cancels timers
+ * first, then `settle()` drains in-flight warms until quiescent.
+ */
+import { LRUCache } from 'lru-cache'
+import { cacheOptions } from '../cache.js'
+import type { Clock, TimerHandle } from '../domain/clock.js'
+import type { OrgId } from '../domain/ids.js'
+import type { ExternalScopeRecord, SessionRepo } from '../persistence/ports.js'
+import type { SessionAccessWarmOutcome } from './session-access-plugin.js'
+
+const MAX_WORKING_SET = 10_000
+/** §4.3: a scope with no poke for this long leaves the working set. */
+const DEFAULT_IDLE_DROP_MS = 24 * 60 * 60 * 1000
+/** §4.2(6): warms never start aligned — each start is jittered within this. */
+const WARM_JITTER_MS = 30_000
+/** §4.2(6): warms in flight at once, across all tokens. */
+const WARM_CONCURRENCY = 3
+/** Matches the plugins' default `SESSION_ACCESS_PUBLIC_TTL_SEC` when omitted. */
+const DEFAULT_PUBLIC_TTL_MS = 3_600_000
+
+interface WorkingEntry {
+  orgId: OrgId
+  lastPokeAtMs: number
+  lastWarmAtMs?: number
+}
+
+export interface WarmerLog {
+  debug(obj: unknown, msg?: string): void
+  info(obj: unknown, msg?: string): void
+  warn(obj: unknown, msg?: string): void
+}
+
+export interface SessionAccessWarmerDeps {
+  /** Scope re-read + the §4.2(1) policy gate, both at execution time. */
+  sessions: Pick<SessionRepo, 'getExternalScopes' | 'getExternalAccessPolicy'>
+  /** provider → the plugin's §4.1 warm entry (its classifying-wrapper front
+   *  door, §4.2(3)); a provider with no entry is skipped, never improvised. */
+  targets: ReadonlyMap<string, (scope: ExternalScopeRecord) => Promise<SessionAccessWarmOutcome>>
+  clock: Clock
+  log?: WarmerLog
+  /** `SESSION_ACCESS_PUBLIC_TTL_SEC` in ms; the re-warm cadence is half of it. */
+  publicTtlMs?: number
+  /** §4.3 working-set retention; default 24 h. Injectable for tests. */
+  idleDropMs?: number
+  /** Jitter source; injectable so tests are deterministic. */
+  random?: () => number
+}
+
+export class SessionAccessWarmer {
+  /** externalScopeId → activity record. LRU-bounded; pruned by the loop. */
+  private readonly entries: LRUCache<string, WorkingEntry>
+  private readonly inflight = new Map<string, Promise<void>>()
+  private readonly scheduled = new Map<string, TimerHandle>()
+  private loopTimer: TimerHandle | undefined
+  private armed = false
+  private startedAtMs = 0
+  private active = 0
+  private readonly waiters: Array<() => void> = []
+  private readonly warmIntervalMs: number
+  private readonly idleDropMs: number
+  private readonly random: () => number
+  /** §5 instrumentation: poke volume, warm executions, and their outcomes. */
+  readonly stats = { pokes: 0, warms: 0, warmed: 0, skipped: 0, failed: 0 }
+
+  constructor(private readonly deps: SessionAccessWarmerDeps) {
+    this.entries = new LRUCache(cacheOptions(deps.clock, MAX_WORKING_SET))
+    this.warmIntervalMs = Math.floor((deps.publicTtlMs ?? DEFAULT_PUBLIC_TTL_MS) / 2)
+    this.idleDropMs = deps.idleDropMs ?? DEFAULT_IDLE_DROP_MS
+    this.random = deps.random ?? Math.random
+  }
+
+  /**
+   * §4.4 hot-path discipline: the ingest handler's only new work — a map write
+   * and maybe one armed timer, never a provider call. Records activity always;
+   * schedules a warm only when armed and the loop is not already carrying the
+   * scope (its last warm at least one full cadence old, or never warmed).
+   */
+  poke(orgId: OrgId, externalScopeId: string): void {
+    this.stats.pokes += 1
+    const now = this.deps.clock.now()
+    let entry = this.entries.get(externalScopeId)
+    if (entry && entry.orgId === orgId) {
+      entry.lastPokeAtMs = now
+    } else {
+      entry = { orgId, lastPokeAtMs: now }
+      this.entries.set(externalScopeId, entry)
+    }
+    if (entry.lastWarmAtMs === undefined || now - entry.lastWarmAtMs >= this.warmIntervalMs) {
+      this.scheduleWarm(externalScopeId, entry)
+    }
+  }
+
+  /** Arm the re-warm loop. Idempotent — a second call re-arms from now. */
+  start(): void {
+    this.armed = true
+    if (this.startedAtMs === 0) this.startedAtMs = this.deps.clock.now()
+    this.armLoop()
+  }
+
+  /** Cancel the loop and every scheduled warm — call before `settle()`. */
+  stop(): void {
+    this.armed = false
+    if (this.loopTimer !== undefined) {
+      this.deps.clock.clearTimeout(this.loopTimer)
+      this.loopTimer = undefined
+    }
+    for (const timer of this.scheduled.values()) this.deps.clock.clearTimeout(timer)
+    this.scheduled.clear()
+  }
+
+  /** Await quiescence: a draining warm can release a queued one, so loop until
+   *  nothing is in flight rather than awaiting one snapshot of the map. */
+  async settle(): Promise<void> {
+    while (this.inflight.size > 0) await Promise.all([...this.inflight.values()])
+  }
+
+  private armLoop(): void {
+    if (!this.armed) return
+    if (this.loopTimer !== undefined) this.deps.clock.clearTimeout(this.loopTimer)
+    this.loopTimer = this.deps.clock.setTimeout(() => this.tick(), this.warmIntervalMs)
+  }
+
+  /** One cadence sweep: drop idle scopes, queue one warm for every survivor.
+   *  Errors are logged and swallowed — nothing may kill the loop. */
+  private tick(): void {
+    this.loopTimer = undefined
+    try {
+      const now = this.deps.clock.now()
+      const dropped: string[] = []
+      for (const [scopeId, entry] of this.entries.entries()) {
+        if (now - entry.lastPokeAtMs > this.idleDropMs) dropped.push(scopeId)
+        else this.scheduleWarm(scopeId, entry)
+      }
+      for (const scopeId of dropped) this.entries.delete(scopeId)
+    } catch (err) {
+      this.deps.log?.warn({ err }, 'session-access warmer: sweep failed')
+    } finally {
+      this.armLoop()
+    }
+  }
+
+  /** Queue one warm — deduped against a scheduled or in-flight one. */
+  private scheduleWarm(scopeId: string, entry: WorkingEntry): void {
+    if (!this.armed || this.scheduled.has(scopeId) || this.inflight.has(scopeId)) return
+    const timer = this.deps.clock.setTimeout(() => {
+      this.scheduled.delete(scopeId)
+      void this.runWarm(scopeId)
+    }, this.warmDelayMs(entry))
+    this.scheduled.set(scopeId, timer)
+  }
+
+  /**
+   * §4.2(6): while the process is younger than one cadence, a scope's FIRST
+   * warm draws its delay from what remains of that window, so the reconnect
+   * wave after a deploy trickles out instead of bursting against token budgets
+   * shared with the fail-closed foreground sweep. Everything else jitters
+   * within `WARM_JITTER_MS` so no batch lands on a provider aligned.
+   */
+  private warmDelayMs(entry: WorkingEntry): number {
+    const young = this.warmIntervalMs - (this.deps.clock.now() - this.startedAtMs)
+    const window = entry.lastWarmAtMs === undefined && young > WARM_JITTER_MS ? young : WARM_JITTER_MS
+    return Math.floor(this.random() * window)
+  }
+
+  private async runWarm(scopeId: string): Promise<void> {
+    if (!this.armed || this.inflight.has(scopeId)) return
+    const entry = this.entries.peek(scopeId)
+    if (!entry) return
+    const run = this.executeWarm(scopeId, entry.orgId).finally(() => {
+      // `peek`: completing a warm is not activity and must not refresh LRU retention.
+      const current = this.entries.peek(scopeId)
+      if (current) current.lastWarmAtMs = this.deps.clock.now()
+      this.inflight.delete(scopeId)
+    })
+    this.inflight.set(scopeId, run)
+    await run
+  }
+
+  private async executeWarm(scopeId: string, orgId: OrgId): Promise<void> {
+    await this.acquire()
+    try {
+      if (!this.armed) return
+      this.stats.warms += 1
+      const { provider, ...result } = await this.observe(scopeId, orgId)
+      this.stats[result.outcome] += 1
+      // Doorbell precedent: one structured line per warm, outcome attached — the
+      // §5 signal for warming volume and failure rate. Ids only, never a resource key.
+      const line = { scopeId, orgId, provider, ...result }
+      if (result.outcome === 'warmed') this.deps.log?.info(line, 'session-access warm applied')
+      else if (result.outcome === 'failed') this.deps.log?.warn(line, 'session-access warm failed')
+      else this.deps.log?.debug(line, 'session-access warm skipped')
+    } catch {
+      // `observe` already reported; nothing here may become an unhandled rejection.
+    } finally {
+      this.release()
+    }
+  }
+
+  private async observe(scopeId: string, orgId: OrgId): Promise<SessionAccessWarmOutcome & { provider?: string }> {
+    try {
+      const [scope] = await this.deps.sessions.getExternalScopes([scopeId])
+      // §4.2(2): the poke-time snapshot proves nothing at run time — a missing,
+      // moved, or revoked scope skips; the plugin re-fences the credential.
+      if (!scope || scope.orgId !== orgId || scope.revokedAt !== null) {
+        return { outcome: 'skipped', reason: 'scope_unresolved' }
+      }
+      const target = this.deps.targets.get(scope.provider)
+      if (!target) return { outcome: 'skipped', reason: 'provider_unwarmed', provider: scope.provider }
+      // §4.2(1) policy gate: an org that turned sync off has withdrawn consent
+      // for the CP to question its workspace — zero provider calls.
+      const policy = await this.deps.sessions.getExternalAccessPolicy(orgId, scope.provider)
+      if (!policy || policy.state === 'disabled') {
+        return { outcome: 'skipped', reason: 'policy_disabled', provider: scope.provider }
+      }
+      return { ...(await target(scope)), provider: scope.provider }
+    } catch (err) {
+      this.deps.log?.warn({ err, scopeId, orgId }, 'session-access warm errored — skipped')
+      return { outcome: 'failed', reason: 'warm_error' }
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.active < WARM_CONCURRENCY) {
+      this.active += 1
+      return Promise.resolve()
+    }
+    return new Promise((resolve) => this.waiters.push(resolve))
+  }
+
+  private release(): void {
+    const next = this.waiters.shift()
+    if (next) next()
+    else this.active -= 1
+  }
+}

--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -1134,4 +1134,115 @@ describe('SlackSessionAccessService', () => {
       expect(calls(fetchImpl, 'conversations.info')).toBe(1)
     })
   })
+
+  // §4.1 warm entry: a background warm observes through the SAME classifying
+  // wrapper as the read path, so its invariants — an `unknown` never cached,
+  // the §4.2(4) generation fence — hold for warmed observations too.
+  describe('warmAudience (§4.1 warm entry)', () => {
+    it('leases the audience so a later resolve pays no conversations.info', async () => {
+      const clock = new FakeClock(EPOCH)
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.includes('conversations.info')) {
+          return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+        }
+        if (url.includes('users.info')) {
+          return json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+        }
+        throw new Error(`unexpected Slack request: ${url}`)
+      })
+      const resolver = service(fetchImpl, undefined, { clock })
+
+      await expect(resolver.warmAudience(scope())).resolves.toEqual({ outcome: 'warmed', verdict: 'public' })
+      expect(calls(fetchImpl, 'conversations.info')).toBe(1)
+
+      await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))).resolves.toMatchObject({
+        allowedScopes: [{ id: scope().id, aclRevision: 2n }]
+      })
+      expect(calls(fetchImpl, 'conversations.info')).toBe(1)
+    })
+
+    it('never caches a failed warm observation', async () => {
+      const state = { infoError: 'ratelimited' as string | undefined }
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.includes('conversations.info')) {
+          if (state.infoError) return json({ ok: false, error: state.infoError })
+          return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+        }
+        return json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+      })
+      const resolver = service(fetchImpl)
+
+      await expect(resolver.warmAudience(scope())).resolves.toEqual({ outcome: 'failed', reason: 'ratelimited' })
+
+      // Had the failure been cached as `unknown`, this read would degrade for
+      // its lease; instead it re-reads and resolves cleanly.
+      state.infoError = undefined
+      await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_MEMBER'))).resolves.toMatchObject({
+        allowedScopes: [{ id: scope().id, aclRevision: 2n }],
+        degraded: false
+      })
+      expect(calls(fetchImpl, 'conversations.info')).toBe(2)
+    })
+
+    // The fence test: a §4.2(4) invalidation landing while a WARM's observation
+    // is in flight must win — the warm reports its answer but never leases it.
+    it('a snapshot invalidation wins over an in-flight warm', async () => {
+      const clock = new FakeClock(EPOCH)
+      const state = { isPrivate: false, defer: false }
+      let release: (() => void) | undefined
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.includes('conversations.info')) {
+          if (state.defer) {
+            state.defer = false
+            return new Promise<Response>((resolve) => {
+              release = () => resolve(json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } }))
+            })
+          }
+          return json({ ok: true, channel: { is_private: state.isPrivate, is_im: false, is_mpim: false } })
+        }
+        if (url.includes('users.info')) {
+          return json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+        }
+        return json({ ok: true, members: [], response_metadata: {} })
+      })
+      const resolver = service(fetchImpl, undefined, { clock })
+
+      // The warm's observation hangs at Slack…
+      state.defer = true
+      const warm = resolver.warmAudience(scope())
+      await vi.waitFor(() => expect(release).toBeDefined())
+      // …a daemon snapshot observes the channel private while it is in flight…
+      resolver.dropPublicAudiences(BOT_ID, [scope().resourceKey])
+      // …then the pre-conversion `public` arrives: reported once, never leased.
+      release!()
+      await expect(warm).resolves.toEqual({ outcome: 'warmed', verdict: 'public' })
+
+      state.isPrivate = true
+      await expect(resolver.resolve([scope()], viewer('slack:T_INSTALL:U_TWO'))).resolves.toMatchObject({
+        allowedScopes: [],
+        degraded: false
+      })
+      expect(calls(fetchImpl, 'conversations.info')).toBe(2)
+    })
+
+    it('skips when a run-time fence refuses, with zero provider calls', async () => {
+      const fetchImpl = vi.fn(async () => json({ ok: false, error: 'unreachable' }))
+
+      const revoked = service(fetchImpl, undefined, { bots: [bot({ revokedAt: new Date(EPOCH) })] })
+      await expect(revoked.warmAudience(scope())).resolves.toEqual({ outcome: 'skipped', reason: 'bot_unresolved' })
+
+      const tokenless = service(fetchImpl, undefined, { tokens: {} })
+      await expect(tokenless.warmAudience(scope())).resolves.toEqual({
+        outcome: 'skipped',
+        reason: 'bot_token_missing'
+      })
+
+      const foreign = service(fetchImpl)
+      await expect(foreign.warmAudience({ ...scope(), provider: 'github' })).resolves.toEqual({
+        outcome: 'skipped',
+        reason: 'scope_shape'
+      })
+      expect(fetchImpl).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -1225,6 +1225,47 @@ describe('SlackSessionAccessService', () => {
       expect(calls(fetchImpl, 'conversations.info')).toBe(2)
     })
 
+    // §4.2(6): a cadence warm on an already-leased entry must hold the warmer's
+    // permit for the REAL provider work — the touch-revalidation it fires —
+    // not resolve while that request is still in flight.
+    it('holds the warm open until its re-observation lands', async () => {
+      const clock = new FakeClock(EPOCH)
+      const state = { defer: false }
+      let release: (() => void) | undefined
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.includes('conversations.info')) {
+          if (state.defer) {
+            state.defer = false
+            return new Promise<Response>((resolve) => {
+              release = () => resolve(json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } }))
+            })
+          }
+          return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+        }
+        return json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+      })
+      const resolver = service(fetchImpl, undefined, { clock })
+
+      await expect(resolver.warmAudience(scope())).resolves.toEqual({ outcome: 'warmed', verdict: 'public' })
+
+      // Half a lease later the entry still serves but is past the recheck
+      // threshold, so this warm fires a re-observation — and must await it.
+      clock.advance(30 * 60_000)
+      state.defer = true
+      let settled = false
+      const warm = resolver.warmAudience(scope()).then((outcome) => {
+        settled = true
+        return outcome
+      })
+      await vi.waitFor(() => expect(release).toBeDefined())
+      expect(settled).toBe(false)
+
+      release!()
+      await expect(warm).resolves.toEqual({ outcome: 'warmed', verdict: 'public' })
+      expect(resolver.stats.audienceRevalidations).toBe(1)
+      expect(calls(fetchImpl, 'conversations.info')).toBe(2)
+    })
+
     it('skips when a run-time fence refuses, with zero provider calls', async () => {
       const fetchImpl = vi.fn(async () => json({ ok: false, error: 'unreachable' }))
 

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -484,6 +484,11 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     return this.generations.get(`${botId}:${channel}`) ?? 0
   }
 
+  /** The `audiences` cache key — one constructor, shared by every reader. */
+  private audienceKey(botId: string, credentialRevision: number, channel: string): string {
+    return [botId, credentialRevision, channel].join(':')
+  }
+
   /** Cached + deduped conversation audience — the classifying wrapper every
    *  reader (and re-observer) of the `audiences` cache goes through. */
   private async audienceOf(
@@ -493,7 +498,7 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     token: string,
     signal: AbortSignal
   ): Promise<ObservedAudience | undefined> {
-    const key = [botId, credentialRevision, channel].join(':')
+    const key = this.audienceKey(botId, credentialRevision, channel)
     const generation = this.generationOf(botId, channel)
     const observed = await this.audiences.fetch(key, { context: { channel, token, signal } })
     // `unknown` is the CHECK failing, not an answer about the audience. Keeping
@@ -583,6 +588,13 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
         secret.botToken,
         AbortSignal.timeout(TIMEOUT_MS)
       )
+      // §4.2(6): past the recheck threshold `audienceOf` serves cached and
+      // re-observes DETACHED — right for a foreground read, wrong for a cadence
+      // sweep, which would fan out one detached provider call per scope and
+      // bypass the warmer's concurrency permit and settle(). Hold the warm open
+      // until the re-observation it (or a foreground read) fired lands; the
+      // task never rejects and its write stays behind the §4.2(4) fences.
+      await this.revalidating.get(this.audienceKey(bot.id, bot.credentialRevision, scope.resourceKey))
       if (!observed) return { outcome: 'failed', reason: 'audience_evicted' }
       if (observed.audience === 'unknown') return { outcome: 'failed', reason: observed.reason }
       return { outcome: 'warmed', verdict: observed.audience }

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -9,7 +9,8 @@ import type {
   SessionAccessIssue,
   SessionAccessPlugin,
   SessionAccessResult,
-  SessionAccessViewer
+  SessionAccessViewer,
+  SessionAccessWarmOutcome
 } from './session-access-plugin.js'
 
 const DENY_TTL_MS = 30_000
@@ -217,6 +218,18 @@ function slackPrincipals(identitySet: ReadonlySet<string>): SlackPrincipal[] {
   return principals
 }
 
+/** The scope rows Slack can answer for at all — the shared gate of the read path
+ *  (anything else is a plain deny) and the §4.1 warm entry (a skip). */
+function botConversationScope(scope: ExternalScopeRecord): scope is ExternalScopeRecord & { credentialId: string } {
+  return (
+    scope.provider === 'slack' &&
+    scope.resourceKind === 'conversation' &&
+    scope.revokedAt === null &&
+    scope.credentialKind === 'bot' &&
+    !!scope.credentialId
+  )
+}
+
 async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value: T) => Promise<R>): Promise<R[]> {
   const out = new Array<R>(values.length)
   let next = 0
@@ -389,29 +402,9 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
     principals: readonly SlackPrincipal[],
     signal: AbortSignal
   ): Promise<Verdict> {
-    if (
-      scope.provider !== 'slack' ||
-      scope.resourceKind !== 'conversation' ||
-      scope.revokedAt !== null ||
-      scope.credentialKind !== 'bot' ||
-      !scope.credentialId
-    ) {
-      return { decision: 'deny' }
-    }
-    // The credential behind a session's recorded external scope — system state,
-    // resolved without an org (org-scoped-data-layer.md §4). The scope row is
-    // itself reached through the session, which the caller already fenced.
-    const bot = await this.deps.bots.getUnscoped(BotId(scope.credentialId)).catch(() => null)
-    const realm = bot?.workspaceId ?? bot?.teamId
-    if (
-      !bot ||
-      bot.orgId !== scope.orgId ||
-      bot.platform !== 'slack' ||
-      bot.revokedAt !== null ||
-      realm !== scope.realmKey
-    ) {
-      return unresolved('bot_unresolved')
-    }
+    if (!botConversationScope(scope)) return { decision: 'deny' }
+    const bot = await this.recordingBotFor(scope)
+    if (!bot) return unresolved('bot_unresolved')
     let unknownReason: DegradedReason | undefined
     for (const principal of principals) {
       const key = [scope.id, scope.aclRevision.toString(), bot.credentialRevision, principal.key].join(':')
@@ -426,6 +419,28 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
       if (verdict.decision === 'unknown') unknownReason ??= verdict.reason ?? 'unreported'
     }
     return unknownReason ? { decision: 'unknown', reason: unknownReason } : { decision: 'deny' }
+  }
+
+  /**
+   * Resolve + fence the credential behind a session's recorded external scope —
+   * system state, resolved without an org (org-scoped-data-layer.md §4). The
+   * scope row is itself reached through the session, which the caller already
+   * fenced. The §4.1 warm entry runs the same fences at execution time
+   * (§4.2(2)), so a poke-time snapshot gone stale skips instead of caching.
+   */
+  private async recordingBotFor(scope: ExternalScopeRecord & { credentialId: string }): Promise<BotRecord | null> {
+    const bot = await this.deps.bots.getUnscoped(BotId(scope.credentialId)).catch(() => null)
+    const realm = bot?.workspaceId ?? bot?.teamId
+    if (
+      !bot ||
+      bot.orgId !== scope.orgId ||
+      bot.platform !== 'slack' ||
+      bot.revokedAt !== null ||
+      realm !== scope.realmKey
+    ) {
+      return null
+    }
+    return bot
   }
 
   private async checkAccess(
@@ -539,6 +554,41 @@ export class SlackSessionAccessService implements SessionAccessPlugin {
   /** Await in-flight background re-observations — nothing else ever awaits them. */
   async settle(): Promise<void> {
     await Promise.all([...this.revalidating.values()])
+  }
+
+  /**
+   * §4.1 warm entry (session-access-cold-visit.md): observe one scope's
+   * conversation audience so a later cold visit finds it leased. The
+   * observation goes through `audienceOf` — the classifying wrapper — never the
+   * raw cache (§4.2(3)): an `unknown` is never cached, a §4.2(4) generation
+   * bump beats the in-flight answer, and a touch past the recheck threshold
+   * re-observes in the background. Credential and token are resolved here, at
+   * execution, through the read path's own fences (§4.2(2)); a failed fence
+   * skips and caches nothing.
+   */
+  async warmAudience(scope: ExternalScopeRecord): Promise<SessionAccessWarmOutcome> {
+    if (!botConversationScope(scope)) return { outcome: 'skipped', reason: 'scope_shape' }
+    const bot = await this.recordingBotFor(scope)
+    if (!bot) return { outcome: 'skipped', reason: 'bot_unresolved' }
+    // §4.2(7) secret economy: only `botToken` is needed, but the store opens the
+    // whole sealed material. TODO: a field-scoped BotSecretStore read would save
+    // the extra decrypts per warm; not worth redesigning the store here.
+    const secret = await this.deps.botSecrets.get(scope.orgId, BotId(bot.id)).catch(() => null)
+    if (!secret?.botToken) return { outcome: 'skipped', reason: 'bot_token_missing' }
+    try {
+      const observed = await this.audienceOf(
+        bot.id,
+        bot.credentialRevision,
+        scope.resourceKey,
+        secret.botToken,
+        AbortSignal.timeout(TIMEOUT_MS)
+      )
+      if (!observed) return { outcome: 'failed', reason: 'audience_evicted' }
+      if (observed.audience === 'unknown') return { outcome: 'failed', reason: observed.reason }
+      return { outcome: 'warmed', verdict: observed.audience }
+    } catch (error) {
+      return { outcome: 'failed', reason: thrownReason(error) }
+    }
   }
 
   /** §4.2(4) cross-check: a daemon snapshot observed these channels private, so their cached

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -39,6 +39,7 @@ import type { CollabRoutesService } from '../orchestrator/collabRoutes.service.j
 import type { AgentId, DaemonId } from '../domain/ids.js'
 import type { WebchatRemoteMcpService } from '../registry/webchatRemoteMcpService.js'
 import type { SlackSessionAccessService } from '../http/slack-session-access.js'
+import type { SessionAccessWarmer } from '../http/session-access-warmer.js'
 
 /** Config slice the WS edge reads. */
 export interface WsConfig {
@@ -83,6 +84,10 @@ export interface DaemonWsDeps {
   /** §4.2(4) `isPrivate` cross-check (session-access-cold-visit.md): a snapshot observing a
    *  channel private drops its cached `public` audience verdict — invalidation only. */
   slackSessionAccess?: Pick<SlackSessionAccessService, 'dropPublicAudiences'>
+  /** §4.1 activity poke (session-access-cold-visit.md): a committed live `event/session`
+   *  milestone marks its external scope active so the warmer keeps its resource facts
+   *  leased. Replayed `event/session-sync` frames never poke (§4.2(6)). */
+  sessionAccessWarmer?: Pick<SessionAccessWarmer, 'poke'>
   /** Shares the HTTP agent-move boundary with daemon-originated conversation reports. */
   agentMutations: AgentMutationGate
   /** Resumes durable move tombstones advertised by a reconnecting daemon. */

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -573,6 +573,72 @@ describe('handleEventSession', () => {
     )
   })
 
+  it('pokes the session-access warmer only after the commit-then-publish point', async () => {
+    const order: string[] = []
+    const poke = vi.fn(() => {
+      order.push('poke')
+    })
+    const recordMilestone = vi.fn().mockResolvedValue(
+      recorded({
+        orgId: 'org-1' as SessionMetaRecord['orgId'],
+        visibility: 'external',
+        externalScopeId: 'scope-1'
+      })
+    )
+    const deps = scopedDeps({
+      session: { recordMilestone },
+      events: { publish: vi.fn(() => order.push('publish')) },
+      sessionAccessWarmer: { poke }
+    })
+
+    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(order).toEqual(['publish', 'poke'])
+    expect(poke).toHaveBeenCalledWith('org-1', 'scope-1')
+  })
+
+  it('does not poke the warmer for a non-external milestone', async () => {
+    const poke = vi.fn()
+    const deps = scopedDeps({
+      session: {
+        recordMilestone: vi.fn().mockResolvedValue(recorded({ visibility: 'org', externalScopeId: null }))
+      },
+      events: { publish: vi.fn() },
+      sessionAccessWarmer: { poke }
+    })
+
+    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(poke).not.toHaveBeenCalled()
+  })
+
+  // §4.2(6): a CP restart drains daemon outboxes as `event/session-sync` — one
+  // frame per active session, against cold cooldown state. Replays never poke.
+  it('never pokes the warmer from a replayed event/session-sync snapshot', async () => {
+    const poke = vi.fn()
+    const deps = scopedDeps({
+      session: {
+        recordMilestone: vi.fn().mockResolvedValue(
+          recorded({
+            orgId: 'org-1' as SessionMetaRecord['orgId'],
+            visibility: 'external',
+            externalScopeId: 'scope-1'
+          })
+        )
+      },
+      events: { publish: vi.fn() },
+      sessionAccessWarmer: { poke }
+    })
+
+    await handleEventSessionSync(
+      eventSessionFrame('event/session-sync'),
+      { daemonId: DAEMON_ID, replyTo: vi.fn(), sendError: vi.fn() } as unknown as DaemonConnection,
+      deps
+    )
+
+    expect(poke).not.toHaveBeenCalled()
+  })
+
   it('does not publish when persistence fails', async () => {
     const failure = new Error('write failed')
     const publish = vi.fn()

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -166,7 +166,12 @@ async function recordEventSession(
   p: EventSession,
   agentId: AgentId,
   daemonId: DaemonId,
-  deps: DaemonWsDeps
+  deps: DaemonWsDeps,
+  /** §4.1 poke sink (session-access-cold-visit.md) — live `event/session` only. A CP
+   *  restart drains daemon outboxes as `event/session-sync`, and replaying those as
+   *  pokes would herd the warmer against cold cooldown state (§4.2(6)), so the sync
+   *  handler passes nothing. */
+  warmer?: DaemonWsDeps['sessionAccessWarmer']
 ): Promise<void> {
   const [classification, candidate] = await Promise.all([
     classifyMilestone(p, agentId, deps),
@@ -221,6 +226,11 @@ async function recordEventSession(
   // invalidation signal and immediately re-read `/sessions`; publishing first
   // would race that GET against the upsert and leave the new row invisible.
   deps.events.publish(daemonId, p)
+  // Fire-and-forget §4.1 activity poke, after commit-then-publish: external
+  // sessions only, carrying nothing but the committed scope coordinates.
+  if (session?.visibility === 'external' && session.externalScopeId) {
+    warmer?.poke(session.orgId, session.externalScopeId)
+  }
 }
 
 export const handleEventSession: Handler = async (frame, conn, deps) => {
@@ -228,7 +238,9 @@ export const handleEventSession: Handler = async (frame, conn, deps) => {
   const p = frame.payload
   const agentId = AgentId(p.agentId)
   const daemonId = DaemonId(conn.daemonId)
-  await runForReportingAgent(agentId, daemonId, deps, () => recordEventSession(p, agentId, daemonId, deps))
+  await runForReportingAgent(agentId, daemonId, deps, () =>
+    recordEventSession(p, agentId, daemonId, deps, deps.sessionAccessWarmer)
+  )
 }
 
 /** Durable variant. Lease contention is retryable; a deleted/moved agent is a


### PR DESCRIPTION
Phase 3 of [`docs/designs/session-access-cold-visit.md`](docs/designs/session-access-cold-visit.md) (#792, issue #775): the §4 session-activity warmer. Builds on Phase 1 (#793) and Phase 2 (#794) — the verdict-split leases make warmth durable, and the warmer observes exclusively through #794's classifying wrappers so it inherits their invariants instead of re-implementing them.

## What

**`SessionAccessWarmer`** (`http/session-access-warmer.ts`): the `event/session` ingest handler pokes it fire-and-forget with `(orgId, externalScopeId)` after the commit-then-publish point (same pattern as the existing `visibilityPush.notifySessions` call). A poke marks the scope active in a bounded working set (per-entry LRU eviction, never a wholesale clear) and — when the loop is not already carrying the scope — schedules one warm. A `CronRunReaper`-style clock-driven loop re-warms every working-set scope on a cadence of **half the public TTL** and drops scopes with no poke for 24 h, so warmth follows activity through a workday instead of ending one lease after the last message (§4.3). An idle org costs zero.

**Warm entries on the plugins** (§4.2(3)): `SlackSessionAccessService.warmAudience` and `GithubSessionAccessService.warmShape` are narrow public entry points that re-resolve scope → credential → secret through the read path's own fences at execution time (§4.2(2); the fence heads are now shared helpers, not copies) and then observe through `audienceOf`/`shapeOf`. The warmer never touches the lru-cache handles, so the "`unknown` is never cached" invariant, the §4.2(4) generation fence, and the object write fence all hold for background warms.

**Execution rules** (§4.2):
1. Policy gate — the org's external-access policy is read before any provider call; `disabled` or missing row skips with zero provider work.
2. Run-time re-resolution — a poke-time snapshot proves nothing at run time; a failed fence skips, never caches.
3. Rate discipline — a global concurrency cap (3), per-warm jitter, first warms after a restart spread across the young-process window, and **no pokes from replayed `event/session-sync` frames** (a CP restart drains daemon outboxes and would herd the warmer against cold cooldown state).
4. Secret economy — a Slack warm needs `botToken` only; the store has no field-scoped read, so the cost is noted as a TODO rather than a store redesign.

**Instrumentation** (§5): one structured log line per warm with its outcome (`warmed`/`skipped`/`failed`, doorbell per-pull precedent) plus `stats` counters for poke volume, warm executions, and outcomes. The #794 `stats` counters already cover cache-side hit/revalidation rates.

**Lifecycle**: constructed in `buildContainer`, armed by `startBackground()` only (tests never see a timer), stopped in `shutdown()` — `stop()` cancels timers first, then `settle()` drains in-flight warms until quiescent.

## Tests

All `FakeClock` (nonzero epoch). Warmer: poke → warm → cadence re-warm; 24 h idle drop; policy-disabled and org-mismatch skips with zero provider calls; concurrency cap under a poke burst; restart spread and mature-process jitter; pokes before `startBackground` arm nothing; `stop()`/`settle()` leave no timers and drain in-flight work. Plugins: a warm leases the observation for the read path; a failed warm is never cached; **a §4.2(4) invalidation landing while a warm is in flight wins** (the fence test, mirroring #794's harness); fence-refused warms make zero provider calls. Handler: poke fires only after publish, only for external milestones, and never from `event/session-sync`.

## Out of scope

Per-principal warming (`users.info`, `conversations.members`, repo permission), identity warming (Phase 1), lease/TTL value changes, snapshot constants, UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
