### PR TITLE
fix(daemon): lead the collaboration guidance with a tool-precedence rule (#800)

### DIFF
--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -817,8 +817,17 @@ export class SessionManager {
     // reach humans, post at a channel root, or reply into a parent session. It has no
     // visible in-thread form: speaking in the current conversation is an ordinary reply.
     // `toAgent` without a `channel` is the postless, channel-invisible wake.
+    // The precedence bullet leads for a measured reason (issue #800): on the Claude
+    // Code runtime the session also carries the runtime's own built-in `SendMessage`
+    // (agent-teams messaging) — a literal name match for a report-back instruction —
+    // and a child that picks it loses its parent report silently. Costs ~80 standing
+    // tokens per session.
     const collabAppend =
       `# Collaborating with other agents\n` +
+      `- AgentConnect's tools (the \`agentconnect\` MCP server, e.g. \`mcp__agentconnect__sendMessage\`) are the ` +
+      `ONLY channel that reaches other agents and humans here. Your runtime may offer built-in tools with similar ` +
+      `names (e.g. a bare \`SendMessage\`) — those do NOT reach AgentConnect and anything sent through them is ` +
+      `lost. Never use them for messaging, reporting back, or collaboration.\n` +
       `- To reach a specific agent privately, call \`sendMessage\` with ` +
       `\`{"toAgent":"<agent id>","message":"..."}\` — it wakes ONLY that agent, delivered directly to it ` +
       `(nothing is posted to the channel). That bare form is FIRE-AND-FORGET: the peer answers inside its own ` +

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -1934,6 +1934,30 @@ describe('SessionManager — collaboration preamble', () => {
     store.close()
   })
 
+  it('leads the guidance with the tool-precedence rule naming the built-in SendMessage hazard (issue #800)', async () => {
+    // Measured (tool-surface A/B, 2026-08-09): a Claude Code child session also
+    // carries the runtime's own built-in `SendMessage` — a literal name match
+    // for a report-back instruction — and a child that picks it loses its
+    // parent report silently. The standing context must say, before anything
+    // else about collaboration, that AgentConnect's MCP tools are the only
+    // channel that reaches anyone and that similarly-named built-ins are lost.
+    const store = newStore()
+    const host = { newSession: vi.fn(async () => 'acp-1') } as any
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    const { blocks } = await sm.handle('bot-a', msg({ ts: '100.1', text: 'hi' }))
+    const first = (blocks[0] as any).text as string
+    expect(first).toContain('ONLY channel that reaches other agents and humans')
+    expect(first).toContain('mcp__agentconnect__sendMessage')
+    expect(first).toContain('a bare `SendMessage`')
+    expect(first).toContain('do NOT reach AgentConnect')
+    expect(first).toContain('Never use them for messaging, reporting back, or collaboration')
+    // It LEADS the collaboration section: the collision fires exactly when the
+    // model is choosing a messaging tool, so the warning must come first.
+    const section = first.slice(first.indexOf('# Collaborating with other agents'))
+    expect(section.indexOf('ONLY channel that reaches')).toBeLessThan(section.indexOf('To reach a specific agent'))
+    store.close()
+  })
+
   it('states the needsReply rule in the standing context, not only in the tool descriptor', async () => {
     // The descriptor is one input among many; this context is ALWAYS present and used to
     // present the bare `toAgent` form as the normal way to reach a peer privately, with no


### PR DESCRIPTION
## What

Adds one leading bullet to the standing collaboration guidance (every session carries it): AgentConnect's MCP tools are the **only** channel that reaches other agents and humans; runtime built-ins with similar names (e.g. Claude Code's bare `SendMessage`) do not reach AgentConnect and anything sent through them is lost — never use them for messaging, reporting back, or collaboration. Cost: ~330 chars ≈ ~80 standing tokens per session. Pinned by a contract test that also asserts the bullet LEADS the section (the collision fires exactly when the model is choosing a messaging tool).

## Why

Issue #800, measured in the tool-surface A/B (PR #791, 2026-08-09): on the Claude Code runtime a child session's tool list contains both `mcp__agentconnect__sendMessage` and the runtime's own built-in `SendMessage` (agent-teams messaging). In 3 of 6 parent-report trials the model's first attempt went to the built-in — a literal name match for the report-back instruction — and 2 of 6 trials lost the parent's answer entirely, silently.

## Measured before/after (parent-session scenario, same harness as #791; criteria fixed before looking)

| Metric | Before (6 trials) | After (10 trials, 5 per surface arm) |
| --- | --- | --- |
| Trials with any built-in `SendMessage` attempt | 3/6 | **0/10** (verified in scored attempts AND raw ACP events) |
| Answers lost to the built-in | 2/6 | **0/10** |
| Total success (parent actually woken with the answer) | 4/6 | **10/10** |
| First-attempt correct form | 0/6 | 4/10 |

The collision is eliminated in this sample and no answer was lost. First-attempt behavior improved but is not perfect — the child still sometimes wraps the correct parent reply in extra (legal) postless calls — so #800's deeper fixes (suppress the built-in tool for daemon-owned sessions; reply-hint the exact pre-filled call; inferred reply) remain worthwhile hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)