### PR TITLE
feat(daemon): recover upgrades before registration

### DIFF
--- a/docs/designs/cli-daemon-split.md
+++ b/docs/designs/cli-daemon-split.md
@@ -290,10 +290,12 @@ The upgrade body supplies a version string. The Control Plane sends only that
 version in `daemon/upgrade`; registry choice, package name, and tarball
 resolution remain local to the CLI.
 
-The Control Plane authorizes the caller against the daemon, requires a live
-`READY` connection, and permits one pending lifecycle operation per daemon. It
-persists an operation record before sending the epoch-fenced
-`daemon/restart` or `daemon/upgrade` request.
+The Control Plane authorizes the caller against the daemon and permits one
+pending lifecycle operation per daemon. Restart still requires a live `READY`
+connection. Upgrade uses the same live path when available; a daemon that has
+previously advertised `daemon-bootstrap-upgrade-v1` may instead receive a
+durable queued upgrade while offline or stuck before `READY`. The Control Plane
+persists the operation before either delivery path.
 
 The lifecycle request is not retransmitted. A definite rejection closes the
 operation as failed. A lost reply is ambiguous because the daemon may already
@@ -336,6 +338,35 @@ supervisor then launches the new `current` version.
 Remote completion is determined by the later `READY` registration. Unlike a
 local `upgrade --restart`, the remote flow does not perform process-level
 automatic rollback after the old daemon exits.
+
+### 6.3 Auth-time bootstrap recovery
+
+The installed daemon entry performs a bounded auth-only bootstrap check before
+loading the full daemon business graph. It advertises
+`bootstrapProtocolVersion: 1` only when a CLI/service supervisor and a valid
+`<root>/cli-entry` are present. The check reads only the Control Plane URL and
+daemon key; complete config validation remains the full daemon's responsibility.
+A Control Plane or network failure skips the check and preserves local-first
+startup.
+
+When the authenticated daemon has a pending upgrade, `auth/ok.lifecycle`
+carries its operation id and target version. The bootstrap invokes the existing
+CLI `upgrade --to <version> --root <root>` implementation. Failure leaves the
+current version selected, reports `daemon/bootstrap/result{status:"failed"}`
+while the connection is still registering, and continues ordinary startup.
+Success reports `installed` and exits with `RESERVED_RESTART_CODE`; the existing
+supervisor then resolves the newly selected `current` entry.
+
+If the process was already running and repeatedly failing the full register
+handshake, the ordinary daemon CP client advertises and consumes the same
+auth-time directive. This prevents a locally alive but protocol-incompatible
+daemon from waiting forever for a `READY`-only command.
+
+The directive is idempotent and remains pending until a daemon reaches `READY`
+on the exact target version. A process already running that version proceeds to
+registration instead of reinstalling or restarting again. Historical daemons
+that never advertised `daemon-bootstrap-upgrade-v1` cannot be recovered through
+this path and still require an online control connection or host-side upgrade.
 
 ## 7. Security and trust boundaries
 

--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -76,7 +76,7 @@ sequenceDiagram
 
 `CONNECTING → AUTHENTICATING → REGISTERING → READY → (DRAINING) → CLOSED`, plus the off-socket state `DEGRADED` (local autonomy, §7).
 
-- **READY** is the only state in which the CP issues orchestration control. Before READY, only `auth`/`register` frames are valid; anything else → `error PROTOCOL_STATE`.
+- **READY** is the only state in which the CP issues ordinary orchestration control. Before READY, `auth`/`register` are valid, plus the narrowly scoped `daemon/bootstrap/result` while `REGISTERING`; anything else → `error PROTOCOL_STATE`.
 - **DRAINING** is entered on `daemon/drain` (§6) — daemon stops accepting new `route/assign`, finishes in-flight, then closes.
 
 ### 2.2 Heartbeat & watchdog
@@ -102,6 +102,7 @@ const AuthReq = z.object({
   machineId: z.string().uuid().optional(), // reserved scope-attestation identity (§3.2), not the auth credential
   attestation: z.string().optional(), // reserved signed proof (JWS), see §3.2
   agentVersion: z.string(), // daemon build/version
+  bootstrapProtocolVersion: z.literal(1).optional(), // auth-only upgrade recovery support
   resume: z
     .object({
       // present only on reconnect
@@ -118,6 +119,13 @@ const AuthOk = z.object({
   webAppUrl: z.string().optional(), // optional console-base override for session deep links;
   // daemon fallback order is local config, this value, then http://localhost:3000
   orgSlug: z.string().optional(), // org slug for those links (console routes are org-scoped)
+  lifecycle: z
+    .object({
+      operationId: z.string(),
+      action: z.literal('upgrade'),
+      targetVersion: z.string()
+    })
+    .optional(), // durable upgrade intent, only for bootstrap-capable callers
   resume: z
     .object({
       accepted: z.boolean() // false ⇒ daemon must do a full register reconcile
@@ -125,6 +133,14 @@ const AuthOk = z.object({
     .optional()
 })
 ```
+
+`bootstrapProtocolVersion: 1` is a frozen recovery handshake implemented by the
+thin daemon entry before the full daemon graph loads. When a pending upgrade
+exists, the CP arms it at auth delivery and returns `lifecycle`; the daemon
+installs through its local CLI and reports
+`daemon/bootstrap/result {operationId,status:'installed'|'failed',reason?}`.
+`installed` is progress only. Success still requires a later authenticated
+connection to reach `READY` with `agentVersion == targetVersion`.
 
 **`sessionEpoch` is the global fencing token.** Every C→D control frame that mutates routing or sessions carries the `epoch` it was issued under (see §4 envelope-ext). A daemon **rejects** any control frame whose `epoch < its current sessionEpoch` (a late frame from a pre-reconnect CP view) with `error STALE_EPOCH`.
 

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1198,6 +1198,7 @@ export function buildContainer(
   // ── daemon WS edge (mounted on the live http.Server after listen) ──────────
   const wsDeps: DaemonWsServerDeps = {
     auth,
+    lifecycleOps: repos.daemonLifecycleOp,
     registry,
     orchestrator,
     connReg,

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -12,7 +12,7 @@
  */
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import { z } from 'zod'
-import { SESSION_RETENTION_RE } from '@agentconnect.md/protocol'
+import { DAEMON_BOOTSTRAP_UPGRADE_FEATURE, SESSION_RETENTION_RE } from '@agentconnect.md/protocol'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import type { DaemonView, DaemonLiveness, DaemonRegistry } from '../../ports.js'
@@ -417,12 +417,7 @@ export function daemonRoutes(deps: HttpDeps) {
       }
     )
 
-    // Command a live daemon to drain + exit so its supervisor relaunches it —
-    // `upgrade` first installs `targetVersion` via the daemon's CLI (cli-daemon-split.md
-    // §7). Owner-only fleet op. Opens a pending lifecycle op and sends the C→D REQ; the
-    // 202 returns the op (with its `id`) — it only means the daemon ACCEPTED the command.
-    // Success is closed out-of-band on its READY re-register; the console tracks the op by
-    // `id` in the fleet read model's `lifecycleOp` and renders terminal state from `status`.
+    // Open a fleet lifecycle op; bootstrap-capable upgrades may wait durably for the next auth.
     const commandLifecycle = async (
       req: FastifyRequest,
       reply: FastifyReply,
@@ -435,23 +430,21 @@ export function daemonRoutes(deps: HttpDeps) {
       if (!existing) {
         return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
       }
-      // Restart/upgrade use the ordinary daemon edit policy: the resource must
-      // be visible and the caller must not be a viewer.
+      // Restart/upgrade use the ordinary daemon edit policy: visible and not viewer-owned.
       if (!canEdit(existing, ctxOf(req))) {
         return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot manage this daemon' })
       }
       const liveConn = deps.liveness.get(id)
-      // Must be READY: `reachable` also covers AUTHENTICATING/REGISTERING, where the daemon
-      // protocol only permits `register` and a lifecycle frame would be rejected (PROTOCOL_STATE).
-      if (!liveConn || !liveConn.reachable || liveConn.state !== 'READY') {
+      // Direct delivery requires READY; only advertised bootstrap upgrades can queue offline.
+      const liveReady = Boolean(liveConn?.reachable && liveConn.state === 'READY')
+      const bootstrapUpgrade =
+        op === 'upgrade' && existing.capabilities.features.includes(DAEMON_BOOTSTRAP_UPGRADE_FEATURE)
+      if (!liveReady && !bootstrapUpgrade) {
         return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: 'daemon is not ready' })
       }
-      // Clock-driven expiry FIRST: a prior op whose daemon accepted the command but never
-      // re-registered is still `pending` in the DB and the partial unique index still
-      // reserves the daemon. Fail it now so a stuck op can't block every later command.
+      // Expire stale operations before the partial unique index admits another command.
       await deps.repos.daemonLifecycleOp.expireOverdue(new Date(), DaemonId(id))
-      // One lifecycle op at a time (the daemon also refuses a concurrent one, §7.1). A
-      // pre-check gives a clear 409; the partial unique index backstops a race.
+      // The pre-check gives a clear 409; the partial unique index backstops races.
       if (await deps.repos.daemonLifecycleOp.pendingForDaemon(DaemonId(id))) {
         return reply
           .code(409)
@@ -462,14 +455,23 @@ export function daemonRoutes(deps: HttpDeps) {
         op,
         ...(targetVersion ? { targetVersion } : {}),
         ...(req.principal?.userId ? { initiator: req.principal.userId } : {}),
-        // Pre-send ESTIMATE; overwritten on arm with the sender's ACTUAL connection epoch.
-        commandEpoch: BigInt(liveConn.sessionEpoch),
+        // Live delivery replaces this estimate with the sender's actual connection epoch.
+        commandEpoch: BigInt(liveConn?.sessionEpoch ?? existing.sessionEpoch),
         deadline: new Date(Date.now() + LIFECYCLE_DEADLINE_MS)
       })
 
-      // Arm the op (set acceptedAt + the EXACT sent epoch) — only an armed op settles on a
-      // later READY. Retried in-request; a persistent failure falls back to background
-      // recovery so an accepted command is never stranded unarmed (falsely timed out).
+      // A bootstrap-capable daemon consumes this durable intent on its next auth.
+      if (!liveReady) {
+        return reply.code(202).send({
+          id: opRow.id,
+          op: opRow.op,
+          status: opRow.status,
+          targetVersion: opRow.targetVersion,
+          outcome: opRow.outcome
+        })
+      }
+
+      // Arm with the exact sent epoch; background recovery handles exhausted write retries.
       const arm = async (epoch: bigint): Promise<boolean> => {
         for (let attempt = 0; attempt < 3; attempt++) {
           try {
@@ -565,7 +567,7 @@ export function daemonRoutes(deps: HttpDeps) {
           tags: [Tag.Daemons],
           summary: 'Upgrade a daemon',
           description:
-            'Command a daemon to install a target version via its CLI, then drain and relaunch onto it. The 202 returns the opened lifecycle op (with its id) and only means the daemon accepted the command; success is confirmed when it re-registers on the new version — track the op by id via the fleet read model’s lifecycleOp.',
+            'Open an upgrade op for a daemon. A ready daemon receives it immediately; an offline daemon that previously advertised bootstrap recovery consumes it during its next auth. The 202 means accepted or durably queued, while success requires READY on the target version.',
           operationId: 'upgradeDaemon',
           params: IdParam,
           body: DaemonUpgradeBody,

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -460,8 +460,13 @@ export function daemonRoutes(deps: HttpDeps) {
         deadline: new Date(Date.now() + LIFECYCLE_DEADLINE_MS)
       })
 
-      // A bootstrap-capable daemon consumes this durable intent on its next auth.
-      if (!liveReady) {
+      // Re-resolve after open: READY receives direct control; pre-READY reconnects through auth.
+      const deliveryConn = deps.liveness.get(id)
+      const deliveryReady = Boolean(deliveryConn?.reachable && deliveryConn.state === 'READY')
+      if (!deliveryReady && bootstrapUpgrade) {
+        if (deliveryConn?.reachable) {
+          deps.liveness.reconnectForBootstrap?.(id, deliveryConn.sessionEpoch)
+        }
         return reply.code(202).send({
           id: opRow.id,
           op: opRow.op,

--- a/packages/control-plane/src/orchestrator/outbound.daemon-lifecycle.test.ts
+++ b/packages/control-plane/src/orchestrator/outbound.daemon-lifecycle.test.ts
@@ -82,3 +82,22 @@ describe('ControlSender daemon restart/upgrade — send outcome classification',
     expect(r).toEqual({ kind: 'unsent' })
   })
 })
+
+describe('ConnectionRegistry bootstrap reconnect', () => {
+  it('closes only the matching reachable pre-READY epoch', () => {
+    const close = vi.fn()
+    const conn = { daemonId: DAEMON, request: vi.fn(), send: vi.fn(), close } as unknown as ConnChannel
+    const registry = new ConnectionRegistry()
+    const registering: DaemonConnState = { ...state(conn), state: 'REGISTERING' }
+    registry.add(registering)
+
+    expect(registry.reconnectForBootstrap(DAEMON, 6)).toBe(false)
+    expect(close).not.toHaveBeenCalled()
+    expect(registry.reconnectForBootstrap(DAEMON, 7)).toBe(true)
+    expect(close).toHaveBeenCalledWith(1012, 'bootstrap upgrade queued')
+
+    registering.state = 'READY'
+    expect(registry.reconnectForBootstrap(DAEMON, 7)).toBe(false)
+    expect(close).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -235,6 +235,8 @@ export interface DaemonLiveness {
   /** `sessionEpoch` is the LIVE connection's fencing epoch — the epoch a control frame
    *  sent right now would ride. Lifecycle commands capture it as the settlement baseline. */
   get(daemonId: string): { state: string; reachable: boolean; sessionEpoch: number } | undefined
+  /** Close the same non-READY epoch so an auth-time bootstrap directive cannot be missed. */
+  reconnectForBootstrap?(daemonId: string, sessionEpoch: number): boolean
 }
 
 /**

--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -2,8 +2,8 @@
  * `DaemonConnection` — the per-socket lifecycle actor + FSM (design §4.4,
  * protocol §2.1).
  *
- * Owns the `LifecycleState`, gates which frames are legal in each state (before
- * READY only `auth`/`register`; anything else → `error PROTOCOL_STATE`), routes
+ * Owns the `LifecycleState`, gates which frames are legal in each state (`auth`,
+ * then `register` or one bootstrap result; anything else → `error PROTOCOL_STATE`), routes
  * correlated REPs to the `ReqRep`, and dispatches legal inbound frames to the
  * `FrameRouter`. Every byte crosses the {@link Transport} seam, so the
  * `InMemoryDaemonStub` drives it with no real socket.
@@ -128,7 +128,7 @@ export class DaemonConnection implements ConnChannel {
       case 'AUTHENTICATING':
         return type === 'auth'
       case 'REGISTERING':
-        return type === 'register'
+        return type === 'register' || type === 'daemon/bootstrap/result'
       case 'READY':
       case 'DRAINING':
         return true

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -23,7 +23,8 @@ import type {
   LaunchRepo,
   OrganizationKnowledgeRepo,
   BotRepo,
-  GithubInstallationRepo
+  GithubInstallationRepo,
+  DaemonLifecycleOpRepo
 } from '../persistence/ports.js'
 import type { SessionVisibilityPushService } from '../orchestrator/visibilityPush.js'
 import type { RelayRosterEntry } from '@agentconnect.md/protocol'
@@ -51,6 +52,8 @@ export interface WsConfig {
 
 export interface DaemonWsDeps {
   auth: DaemonAuth
+  /** Durable lifecycle intent exposed during auth-only bootstrap. */
+  lifecycleOps: DaemonLifecycleOpRepo
   registry: DaemonRegistry
   orchestrator: ReconcileService
   connReg: ConnectionRegistry

--- a/packages/control-plane/src/ws/handlers/auth.ts
+++ b/packages/control-plane/src/ws/handlers/auth.ts
@@ -51,5 +51,23 @@ export const handleAuth: Handler = async (frame, conn, deps) => {
     launches: new Map()
   })
 
-  conn.replyTo(frame, 'auth/ok', verdict.okFrame)
+  let okFrame = verdict.okFrame
+  if (req.bootstrapProtocolVersion === 1) {
+    await deps.lifecycleOps.expireOverdue(new Date(deps.clock.now()), verdict.daemonId)
+    const op = await deps.lifecycleOps.pendingForDaemon(verdict.daemonId)
+    if (op?.op === 'upgrade' && op.targetVersion) {
+      // An already-target process may READY now; any other version must re-auth after install.
+      const commandEpoch =
+        req.agentVersion === op.targetVersion
+          ? BigInt(Math.max(0, verdict.okFrame.sessionEpoch - 1))
+          : BigInt(verdict.okFrame.sessionEpoch)
+      await deps.lifecycleOps.markAccepted(op.id, new Date(deps.clock.now()), commandEpoch)
+      okFrame = {
+        ...okFrame,
+        lifecycle: { operationId: op.id, action: 'upgrade', targetVersion: op.targetVersion }
+      }
+    }
+  }
+
+  conn.replyTo(frame, 'auth/ok', okFrame)
 }

--- a/packages/control-plane/src/ws/handlers/daemon-bootstrap-result.ts
+++ b/packages/control-plane/src/ws/handlers/daemon-bootstrap-result.ts
@@ -1,0 +1,22 @@
+import type { DaemonBootstrapResult } from '@agentconnect.md/protocol'
+import type { Handler } from './index.js'
+
+/** Record installer failure; installation success still requires READY. */
+export const handleDaemonBootstrapResult: Handler = async (frame, conn, deps) => {
+  if (frame.type !== 'daemon/bootstrap/result') return
+  const result = frame.payload as DaemonBootstrapResult
+  const op = await deps.lifecycleOps.getById(result.operationId)
+  if (!op || op.daemonId !== conn.daemonId || op.status !== 'pending' || op.op !== 'upgrade') {
+    conn.replyTo(frame, 'ack', { ok: false, reason: 'bootstrap operation is not pending for this daemon' })
+    return
+  }
+  if (result.status === 'failed') {
+    await deps.lifecycleOps.settle(
+      op.id,
+      'failed',
+      result.reason ?? 'daemon bootstrap upgrade failed',
+      new Date(deps.clock.now())
+    )
+  }
+  conn.replyTo(frame, 'ack', { ok: true })
+}

--- a/packages/control-plane/src/ws/handlers/index.ts
+++ b/packages/control-plane/src/ws/handlers/index.ts
@@ -7,7 +7,7 @@
  * legal-frame gate (protocol §2.1) is checked there too — so a handler only ever
  * sees a legal, fully-validated inbound frame.
  *
- * Registers `auth`, `register`, `heartbeat`, `facts/runtime-profile`,
+ * Registers `auth`, `daemon/bootstrap/result`, `register`, `heartbeat`, `facts/runtime-profile`,
  * `facts/daemon-runtimes`, `usage/report`, `integration/channels`, `cron/report`.
  * Unhandled-but-legal EVTs (telemetry that lands in later phases) are a deliberate
  * no-op (forward-compat), never an error.
@@ -17,6 +17,7 @@ import type { DaemonWsDeps } from '../deps.js'
 // Type-only import — erased at runtime, so there is no cycle with connection.ts.
 import type { DaemonConnection } from '../connection.js'
 import { handleAuth } from './auth.js'
+import { handleDaemonBootstrapResult } from './daemon-bootstrap-result.js'
 import { handleRegister } from './register.js'
 import { handleCapabilitiesUpdate } from './capabilities-update.js'
 import { handleHeartbeat } from './heartbeat.js'
@@ -57,6 +58,7 @@ export class FrameRouter {
   constructor(overrides: Partial<Record<FrameType, Handler>> = {}) {
     this.table = {
       auth: handleAuth,
+      'daemon/bootstrap/result': handleDaemonBootstrapResult,
       register: handleRegister,
       'capabilities/update': handleCapabilitiesUpdate,
       heartbeat: handleHeartbeat,
@@ -98,6 +100,7 @@ export class FrameRouter {
 
 export {
   handleAuth,
+  handleDaemonBootstrapResult,
   handleRegister,
   handleCapabilitiesUpdate,
   handleHeartbeat,

--- a/packages/control-plane/src/ws/registry.ts
+++ b/packages/control-plane/src/ws/registry.ts
@@ -70,6 +70,13 @@ export class ConnectionRegistry {
     return this.byDaemon.get(daemonId)
   }
 
+  reconnectForBootstrap(daemonId: string, sessionEpoch: number): boolean {
+    const state = this.byDaemon.get(daemonId)
+    if (!state?.reachable || state.state === 'READY' || state.sessionEpoch !== sessionEpoch) return false
+    state.conn.close(1012, 'bootstrap upgrade queued')
+    return true
+  }
+
   has(daemonId: string): boolean {
     return this.byDaemon.has(daemonId)
   }

--- a/packages/control-plane/test/fakes/build-app.ts
+++ b/packages/control-plane/test/fakes/build-app.ts
@@ -124,6 +124,7 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
     listening = true
     createDaemonWsServer(app, {
       auth,
+      lifecycleOps: repos.daemonLifecycleOp,
       registry,
       orchestrator,
       connReg,

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -178,6 +178,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
 
   const deps: DaemonWsDeps = {
     auth,
+    lifecycleOps: repos.daemonLifecycleOp,
     registry,
     orchestrator,
     connReg,

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -43,13 +43,15 @@ afterEach(async () => {
 /** A liveness index backed by a plain map — what the in-memory ConnectionRegistry is, sans
  *  socket. `sessionEpoch` defaults to 1 (seedDaemon's first auth epoch). */
 function liveness(
-  entries: Record<string, { state: string; reachable: boolean; sessionEpoch?: number }>
+  entries: Record<string, { state: string; reachable: boolean; sessionEpoch?: number }>,
+  reconnectForBootstrap?: DaemonLiveness['reconnectForBootstrap']
 ): DaemonLiveness {
   return {
     get: (id) => {
       const e = entries[id]
       return e ? { state: e.state, reachable: e.reachable, sessionEpoch: e.sessionEpoch ?? 1 } : undefined
-    }
+    },
+    ...(reconnectForBootstrap ? { reconnectForBootstrap } : {})
   }
 }
 
@@ -693,6 +695,26 @@ describe('POST /daemons/:id/upgrade', () => {
     expect(calls).toHaveLength(0)
     const op = await new PgDaemonLifecycleOpRepo(prisma).pendingForDaemon(DaemonId(DAEMON))
     expect(op).toMatchObject({ op: 'upgrade', targetVersion: '0.5.0', acceptedAt: null })
+  })
+
+  it('reconnects a registering daemon after enqueue so auth cannot miss the upgrade', async () => {
+    await seedDaemon(['worktree-iso', DAEMON_BOOTSTRAP_UPGRADE_FEATURE])
+    const reconnect = vi.fn(() => true)
+    const { spy, calls } = controlSpy({ accepted: true })
+    running = buildHttpApp(
+      prisma,
+      undefined,
+      liveness({ [DAEMON]: { state: 'REGISTERING', reachable: true } }, reconnect),
+      spy
+    )
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '0.5.0' }
+    })
+    expect(res.statusCode).toBe(202)
+    expect(calls).toHaveLength(0)
+    expect(reconnect).toHaveBeenCalledWith(DAEMON, 1)
   })
 
   it('409s a second command while one is already in flight', async () => {

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -26,7 +26,7 @@ import { DaemonId, OrgId } from '../../src/domain/ids.js'
 import type { DaemonLiveness } from '../../src/ports.js'
 import type { ControlSender } from '../../src/orchestrator/outbound.js'
 import { retryArm } from '../../src/http/routes/daemons.js'
-import type { DaemonControlAck } from '@agentconnect.md/protocol'
+import { DAEMON_BOOTSTRAP_UPGRADE_FEATURE, type DaemonControlAck } from '@agentconnect.md/protocol'
 
 // Console routes are org-scoped: /orgs/:orgId/… (devAuth = seeded owner of the default org).
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -54,12 +54,12 @@ function liveness(
 }
 
 /** Seed a registered daemon row (status `ready`, host + capabilities + version). */
-async function seedDaemon() {
+async function seedDaemon(features = ['worktree-iso']) {
   const repo = new PgDaemonRepo(prisma)
   await repo.upsertOnAuth({ daemonId: DaemonId(DAEMON), orgId: OrgId(DEFAULT_ORG_ID), agentVersion: '0.4.2' })
   await repo.applyRegister(DaemonId(DAEMON), {
     host: 'macbook-pro',
-    capabilities: { platforms: ['slack'], runtimes: ['claude', 'codex'], acp: true, features: ['worktree-iso'] },
+    capabilities: { platforms: ['slack'], runtimes: ['claude', 'codex'], acp: true, features },
     maxAgents: 3
   })
 }
@@ -678,6 +678,21 @@ describe('POST /daemons/:id/upgrade', () => {
     expect(res.statusCode).toBe(503)
     expect(calls).toHaveLength(0)
     expect(await new PgDaemonLifecycleOpRepo(prisma).pendingForDaemon(DaemonId(DAEMON))).toBeNull()
+  })
+
+  it('queues an upgrade without sending control when the offline daemon supports bootstrap recovery', async () => {
+    await seedDaemon(['worktree-iso', DAEMON_BOOTSTRAP_UPGRADE_FEATURE])
+    const { spy, calls } = controlSpy({ accepted: true })
+    running = buildHttpApp(prisma, undefined, liveness({}), spy)
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '0.5.0' }
+    })
+    expect(res.statusCode).toBe(202)
+    expect(calls).toHaveLength(0)
+    const op = await new PgDaemonLifecycleOpRepo(prisma).pendingForDaemon(DaemonId(DAEMON))
+    expect(op).toMatchObject({ op: 'upgrade', targetVersion: '0.5.0', acceptedAt: null })
   })
 
   it('409s a second command while one is already in flight', async () => {

--- a/packages/control-plane/test/protocol/auth.handler.test.ts
+++ b/packages/control-plane/test/protocol/auth.handler.test.ts
@@ -134,4 +134,34 @@ describe('auth handler — valid key mints next epoch; invalid key closes 4401',
     const row = await repo.getUnscoped(DaemonId(DAEMON))
     expect(row?.sessionEpoch).toBe(1n)
   })
+
+  it('delivers and arms a pending upgrade during bootstrap auth, then records installer failure', async () => {
+    const h = buildWsHarness(prisma)
+    const token = await h.mintToken(DAEMON)
+    const op = await h.deps.lifecycleOps.open({
+      daemonId: DaemonId(DAEMON),
+      op: 'upgrade',
+      targetVersion: '2.0.0',
+      commandEpoch: 0n,
+      deadline: new Date(h.clock.now() + 60_000)
+    })
+    const { stub } = h.connect()
+    stub.inject('auth', { ...authPayload(token), bootstrapProtocolVersion: 1 }, { id: AUTH_ID })
+
+    const ok = await stub.expectFrame('auth/ok')
+    if (!isFrame('auth/ok')(ok)) throw new Error('expected auth/ok')
+    expect(ok.payload.lifecycle).toEqual({ operationId: op.id, action: 'upgrade', targetVersion: '2.0.0' })
+    expect((await h.deps.lifecycleOps.getById(op.id))?.acceptedAt).not.toBeNull()
+    expect((await h.deps.lifecycleOps.getById(op.id))?.commandEpoch).toBe(1n)
+
+    stub.inject('daemon/bootstrap/result', {
+      operationId: op.id,
+      status: 'failed',
+      reason: 'registry unavailable'
+    })
+    const ack = await stub.expectFrame('ack')
+    if (!isFrame('ack')(ack)) throw new Error('expected ack')
+    expect(ack.payload.ok).toBe(true)
+    expect((await h.deps.lifecycleOps.getById(op.id))?.status).toBe('failed')
+  })
 })

--- a/packages/control-plane/test/protocol/drain.test.ts
+++ b/packages/control-plane/test/protocol/drain.test.ts
@@ -126,6 +126,7 @@ function build(): Built {
   const connReg = new ConnectionRegistry()
   const deps: DaemonWsDeps = {
     auth: {} as DaemonWsDeps['auth'],
+    lifecycleOps: {} as DaemonWsDeps['lifecycleOps'],
     registry: {} as DaemonWsDeps['registry'],
     orchestrator: {} as DaemonWsDeps['orchestrator'],
     connReg,

--- a/packages/control-plane/test/protocol/fencing.test.ts
+++ b/packages/control-plane/test/protocol/fencing.test.ts
@@ -34,6 +34,7 @@ function fencingDeps(clock: FakeClock): DaemonWsDeps {
   const connReg = new ConnectionRegistry()
   return {
     auth: {} as DaemonWsDeps['auth'],
+    lifecycleOps: {} as DaemonWsDeps['lifecycleOps'],
     registry: {} as DaemonWsDeps['registry'],
     orchestrator: {} as DaemonWsDeps['orchestrator'],
     connReg,

--- a/packages/daemon/src/bootstrap-upgrade.ts
+++ b/packages/daemon/src/bootstrap-upgrade.ts
@@ -1,0 +1,144 @@
+import { existsSync, readFileSync } from 'node:fs'
+import type { AnyFrame, AuthOk, BootstrapLifecycle } from '@agentconnect.md/protocol'
+import {
+  buildEnvelope,
+  CP_SUBPROTOCOL,
+  CP_WS_PATH,
+  DAEMON_BOOTSTRAP_PROTOCOL_VERSION,
+  decodeEnvelope,
+  RESERVED_RESTART_CODE
+} from '@agentconnect.md/protocol'
+import { ClientTransport, ReqRep, systemClock, type Transport } from '@agentconnect.md/connection'
+import type { FlatOverrides } from './config/load-config.js'
+import { configPath, resolveRoot } from './paths.js'
+import { DAEMON_VERSION } from './version.js'
+import { readCliEntry, runCliUpgrade, type UpgradeLog } from './lifecycle/cli-upgrade.js'
+
+const BOOTSTRAP_TIMEOUT_MS = 5_000
+export const BOOTSTRAP_RESTART_CODE = RESERVED_RESTART_CODE
+
+export interface BootstrapUpgradeOpts {
+  root?: string
+  configPath?: string
+  supervisor?: string
+  overrides?: FlatOverrides
+}
+
+interface BootstrapControlPlane {
+  url: string
+  key: string
+  daemonId?: string
+}
+
+export interface BootstrapUpgradeDeps {
+  connect: (url: string) => Promise<Transport>
+  install: (cliEntry: string, targetVersion: string, root: string, log: UpgradeLog) => Promise<boolean>
+  log: UpgradeLog
+}
+
+/** Read only CP bootstrap fields; full validation remains in the daemon. */
+export function bootstrapControlPlane(opts: BootstrapUpgradeOpts): BootstrapControlPlane | undefined {
+  const overrides = opts.overrides ?? {}
+  if (overrides.noCp) return undefined
+  const root = resolveRoot(opts.root)
+  const file = opts.configPath ?? configPath(root)
+  let raw: Record<string, unknown> = {}
+  try {
+    if (existsSync(file)) raw = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>
+  } catch {
+    return undefined
+  }
+  const hasStoredControlPlane = typeof raw.controlPlane === 'object' && raw.controlPlane !== null
+  const stored = hasStoredControlPlane ? (raw.controlPlane as Record<string, unknown>) : {}
+  const enabled = overrides.apiUrl || overrides.apiKey ? true : hasStoredControlPlane && stored.enabled !== false
+  const url = overrides.apiUrl ?? (typeof stored.url === 'string' ? stored.url : undefined)
+  const key = overrides.apiKey ?? (typeof stored.key === 'string' ? stored.key : undefined)
+  const daemonId = overrides.daemonId ?? (typeof raw.daemonId === 'string' ? raw.daemonId : undefined)
+  if (!enabled || !url || !key) return undefined
+  return { url, key, ...(daemonId ? { daemonId } : {}) }
+}
+
+async function reportResult(
+  transport: Transport,
+  correlator: ReqRep<AnyFrame>,
+  lifecycle: BootstrapLifecycle,
+  status: 'installed' | 'failed',
+  reason?: string
+): Promise<void> {
+  const result = buildEnvelope('daemon/bootstrap/result', {
+    operationId: lifecycle.operationId,
+    status,
+    ...(reason ? { reason: reason.slice(0, 500) } : {})
+  })
+  const reply = await correlator.request(result, (encoded) => transport.send(encoded), {
+    maxTries: 1,
+    ackTimeoutMs: BOOTSTRAP_TIMEOUT_MS
+  })
+  if (reply.type !== 'ack' || !(reply.payload as { ok?: boolean }).ok) {
+    throw new Error('control plane rejected the bootstrap result')
+  }
+}
+
+/** Run the non-blocking auth-only recovery check before loading the full daemon. */
+export async function runBootstrapUpgrade(
+  opts: BootstrapUpgradeOpts,
+  partial: Partial<BootstrapUpgradeDeps> = {}
+): Promise<'continue' | 'restart'> {
+  const cp = bootstrapControlPlane(opts)
+  if (!cp || (opts.supervisor !== 'cli' && opts.supervisor !== 'service')) return 'continue'
+  const root = resolveRoot(opts.root)
+  const cliEntry = readCliEntry(root)
+  if (!cliEntry) return 'continue'
+
+  const deps: BootstrapUpgradeDeps = {
+    connect: (url) =>
+      ClientTransport.dial(url, {
+        subprotocol: CP_SUBPROTOCOL,
+        path: CP_WS_PATH,
+        handshakeTimeoutMs: BOOTSTRAP_TIMEOUT_MS
+      }),
+    install: runCliUpgrade,
+    log: { info: (message) => console.error(message), error: (message) => console.error(message) },
+    ...partial
+  }
+
+  let transport: Transport | undefined
+  const correlator = new ReqRep<AnyFrame>(systemClock, BOOTSTRAP_TIMEOUT_MS, 1)
+  try {
+    transport = await deps.connect(cp.url)
+    transport.onMessage((text) => {
+      const decoded = decodeEnvelope(text)
+      if (decoded.ok && decoded.frame.corr) correlator.settle(decoded.frame)
+    })
+    transport.onClose(() => correlator.rejectAll(new Error('bootstrap connection closed')))
+    const auth = buildEnvelope('auth', {
+      apiKey: cp.key,
+      ...(cp.daemonId ? { daemonId: cp.daemonId } : {}),
+      agentVersion: DAEMON_VERSION,
+      bootstrapProtocolVersion: DAEMON_BOOTSTRAP_PROTOCOL_VERSION
+    })
+    const reply = await correlator.request(auth, (encoded) => transport!.send(encoded), {
+      maxTries: 1,
+      ackTimeoutMs: BOOTSTRAP_TIMEOUT_MS
+    })
+    if (reply.type !== 'auth/ok') throw new Error(`expected auth/ok, got ${reply.type}`)
+    const lifecycle = (reply.payload as AuthOk).lifecycle
+    if (!lifecycle || lifecycle.action !== 'upgrade' || lifecycle.targetVersion === DAEMON_VERSION) return 'continue'
+
+    const installed = await deps.install(cliEntry, lifecycle.targetVersion, root, deps.log)
+    if (!installed) {
+      await reportResult(transport, correlator, lifecycle, 'failed', `failed to install ${lifecycle.targetVersion}`)
+      return 'continue'
+    }
+    await reportResult(transport, correlator, lifecycle, 'installed').catch((err) => {
+      deps.log.error(`cp: could not confirm bootstrap installation: ${(err as Error).message}`)
+    })
+    return 'restart'
+  } catch (err) {
+    deps.log.info(`cp: bootstrap check skipped (${(err as Error).message})`)
+    return 'continue'
+  } finally {
+    correlator.rejectAll(new Error('bootstrap complete'))
+    transport?.close(1000, 'bootstrap complete')
+  }
+}

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -133,6 +133,9 @@ const utf8Bytes = (value: string) => new TextEncoder().encode(value).length
 
 export type CpState = 'CONNECTING' | 'AUTHENTICATING' | 'REGISTERING' | 'READY' | 'DRAINING' | 'CLOSED' | 'DEGRADED'
 
+export type BootstrapUpgradeOutcome =
+  { status: 'current' } | { status: 'failed'; reason: string } | { status: 'installed'; restart: () => void }
+
 interface RegisterControlBarrier {
   transport: Transport
   registerRequestId: string
@@ -199,7 +202,7 @@ export interface CpClientDeps {
    *  session deep link (`<webAppUrl>/<orgSlug>/sessions/<id>`). */
   onOrgSlug?: (orgSlug: string | undefined) => void
   /** Auth-time recovery directive handled before full registration. */
-  onBootstrapUpgrade?: (lifecycle: BootstrapLifecycle) => boolean
+  onBootstrapUpgrade?: (lifecycle: BootstrapLifecycle) => Promise<BootstrapUpgradeOutcome>
   /** Called once the daemon reaches READY on each (re)connect, after the initial
    *  runtime profiles are emitted. The daemon uses this to kick off background
    *  runtime probing and push the refreshed snapshot via `emitDaemonRuntimes`. */
@@ -379,15 +382,28 @@ export class CpClient {
     this.deps.onWebAppUrl?.(ok.webAppUrl)
     // Adopt the org slug the daemon belongs to — the `<orgSlug>` path segment of a deep link.
     this.deps.onOrgSlug?.(ok.orgSlug)
-    if (ok.lifecycle && this.deps.onBootstrapUpgrade?.(ok.lifecycle)) {
-      // Stop reconnecting into the same directive while the daemon-owned installer runs.
-      this.stopped = true
-      expectedTransport.close(1000, 'bootstrap upgrade accepted')
-      throw new Error(`bootstrap upgrade to ${ok.lifecycle.targetVersion} accepted`)
+    this.state = 'REGISTERING'
+    if (ok.lifecycle && this.deps.onBootstrapUpgrade) {
+      let outcome: BootstrapUpgradeOutcome
+      try {
+        outcome = await this.deps.onBootstrapUpgrade(ok.lifecycle)
+      } catch (err) {
+        outcome = { status: 'failed', reason: err instanceof Error ? err.message : String(err) }
+      }
+      if (outcome.status === 'failed') {
+        await this.reportBootstrapResult(expectedTransport, ok.lifecycle, 'failed', outcome.reason)
+      } else if (outcome.status === 'installed') {
+        await this.reportBootstrapResult(expectedTransport, ok.lifecycle, 'installed').catch((err) => {
+          this.deps.log.error(`cp: could not confirm bootstrap installation: ${(err as Error).message}`)
+        })
+        this.stopped = true
+        outcome.restart()
+        expectedTransport.close(1000, 'bootstrap upgrade installed')
+        throw new Error(`bootstrap upgrade to ${ok.lifecycle.targetVersion} installed`)
+      }
     }
 
     // ── register ──
-    this.state = 'REGISTERING'
     const registerCapabilities = this.deps.capabilities()
     this.lastSentCapabilities = JSON.stringify(registerCapabilities)
     const register = buildEnvelope('register', {
@@ -453,6 +469,23 @@ export class CpClient {
     // arrive later as another `facts/daemon-runtimes` snapshot that replaces
     // the one just sent.
     this.deps.onReady?.()
+  }
+
+  private async reportBootstrapResult(
+    transport: Transport,
+    lifecycle: BootstrapLifecycle,
+    status: 'installed' | 'failed',
+    reason?: string
+  ): Promise<void> {
+    const result = buildEnvelope('daemon/bootstrap/result', {
+      operationId: lifecycle.operationId,
+      status,
+      ...(reason ? { reason: reason.slice(0, 500) } : {})
+    })
+    const reply = await this.correlator.request(result, (encoded) => transport.send(encoded))
+    if (reply.type !== 'ack' || !(reply.payload as { ok?: boolean }).ok) {
+      throw new Error('control plane rejected the bootstrap result')
+    }
   }
 
   /**

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -89,7 +89,8 @@ import type {
   ManagedSkillReadReq,
   ManagedSkillChunk,
   OrganizationSuggestionReadReq,
-  OrganizationSuggestionReviewReq
+  OrganizationSuggestionReviewReq,
+  BootstrapLifecycle
 } from '@agentconnect.md/protocol'
 import {
   buildEnvelope,
@@ -99,7 +100,8 @@ import {
   SESSION_LIVE_TAIL_FEATURE,
   SESSION_METADATA_ACK_FEATURE,
   SESSION_PURGE_FEATURE,
-  ORGANIZATION_KNOWLEDGE_FEATURE
+  ORGANIZATION_KNOWLEDGE_FEATURE,
+  DAEMON_BOOTSTRAP_PROTOCOL_VERSION
 } from '@agentconnect.md/protocol'
 import type { SessionReader } from './session-reader.js'
 import { WorkspaceConflictError, WorkspaceViolationError, type WorkspaceReader } from './workspace-reader.js'
@@ -196,6 +198,8 @@ export interface CpClientDeps {
    *  resolve it). The console is org-scoped, so this becomes the `<orgSlug>` segment of a
    *  session deep link (`<webAppUrl>/<orgSlug>/sessions/<id>`). */
   onOrgSlug?: (orgSlug: string | undefined) => void
+  /** Auth-time recovery directive handled before full registration. */
+  onBootstrapUpgrade?: (lifecycle: BootstrapLifecycle) => boolean
   /** Called once the daemon reaches READY on each (re)connect, after the initial
    *  runtime profiles are emitted. The daemon uses this to kick off background
    *  runtime probing and push the refreshed snapshot via `emitDaemonRuntimes`. */
@@ -343,7 +347,8 @@ export class CpClient {
     this.state = 'AUTHENTICATING'
     const authPayload: Record<string, unknown> = {
       apiKey: this.deps.token,
-      agentVersion: this.deps.agentVersion
+      agentVersion: this.deps.agentVersion,
+      ...(this.deps.onBootstrapUpgrade ? { bootstrapProtocolVersion: DAEMON_BOOTSTRAP_PROTOCOL_VERSION } : {})
     }
     // Send daemonId only if configured; otherwise the CP derives it from the
     // token's `sub` and returns it in auth/ok (token-only onboarding).
@@ -360,6 +365,7 @@ export class CpClient {
       heartbeatSec: number
       webAppUrl?: string
       orgSlug?: string
+      lifecycle?: BootstrapLifecycle
     }
     this.sessionEpoch = ok.sessionEpoch
     this.lastAuthedEpoch = ok.sessionEpoch
@@ -373,6 +379,12 @@ export class CpClient {
     this.deps.onWebAppUrl?.(ok.webAppUrl)
     // Adopt the org slug the daemon belongs to — the `<orgSlug>` path segment of a deep link.
     this.deps.onOrgSlug?.(ok.orgSlug)
+    if (ok.lifecycle && this.deps.onBootstrapUpgrade?.(ok.lifecycle)) {
+      // Stop reconnecting into the same directive while the daemon-owned installer runs.
+      this.stopped = true
+      expectedTransport.close(1000, 'bootstrap upgrade accepted')
+      throw new Error(`bootstrap upgrade to ${ok.lifecycle.targetVersion} accepted`)
+    }
 
     // ── register ──
     this.state = 'REGISTERING'

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -280,7 +280,7 @@ import { composeRuntimeLaunch, runtimeSandboxReadRoots } from './runtimes/launch
 import { resolveTrustedExecutable, trustedRuntimeReadRoots } from './runtimes/read-roots.js'
 import { nodeExecArgvModuleEntries } from './runtimes/node-exec-argv.js'
 import { makeLogger, type Logger } from './log.js'
-import { CpClient, CP_SUBPROTOCOL, CP_WS_PATH } from './cp/client.js'
+import { CpClient, CP_SUBPROTOCOL, CP_WS_PATH, type BootstrapUpgradeOutcome } from './cp/client.js'
 import { RelayManager } from './cp/relay-manager.js'
 import { CpCollabRoutes } from './cp/cp-collab-routes.js'
 import { ClientTransport, systemClock, type Clock, type TimerHandle } from '@agentconnect.md/connection'
@@ -18062,59 +18062,53 @@ export class Daemon {
     // negotiates ACK support; scheduling here would hammer legacy EVT delivery.
   }
 
-  /** daemon/restart + daemon/upgrade (§8.3): ack now, then drain + stop + exit so
-   *  the supervisor relaunches (the new binary, for upgrade). Refused when no
-   *  supervisor is present, since exiting would leave the daemon down (§7.1). */
-  private scheduleFleetExit(kind: 'restart' | 'upgrade', targetVersion?: string): DaemonControlAck {
+  private admitFleetExit(
+    kind: 'restart' | 'upgrade',
+    targetVersion?: string
+  ):
+    { accepted: false; reason: string } | { accepted: true; root: string; cliEntry?: string; willDrainUntil?: string } {
+    const refuse = (reason: string) => {
+      this.log.warn(`cp: ${kind} refused — ${reason}`)
+      return { accepted: false as const, reason }
+    }
     const supervisor = this.opts.supervisor
     if (supervisor !== 'cli' && supervisor !== 'service') {
       const reason = `no supervisor (AGENTCONNECT_SUPERVISOR=${supervisor ?? 'unset'}) — a bare \`run\` cannot ${kind}; use the CLI or an installed service`
-      this.log.warn(`cp: ${kind} refused — ${reason}`)
-      return { accepted: false, reason }
+      return refuse(reason)
     }
     if (this.lifecycleInFlight) {
-      const reason = 'another lifecycle operation is already in progress'
-      this.log.warn(`cp: ${kind} refused — ${reason}`)
-      return { accepted: false, reason }
+      return refuse('another lifecycle operation is already in progress')
     }
 
     const root = resolveRoot(this.opts.root)
-
-    // An upgrade must locate the CLI (the out-of-band installer, §7.1) up front, so
-    // an unreachable CLI is refused now rather than silently downgraded to a restart.
     let cliEntry: string | undefined
     if (kind === 'upgrade') {
       cliEntry = readCliEntry(root)
       if (!cliEntry) {
         const reason = `cannot locate the CLI (${cliEntryPointer(root)} missing or invalid) to run the upgrade`
-        this.log.warn(`cp: upgrade refused — ${reason}`)
-        return { accepted: false, reason }
+        return refuse(reason)
       }
-      if (!targetVersion) {
-        return { accepted: false, reason: 'upgrade requires a targetVersion' }
-      }
+      if (!targetVersion) return refuse('upgrade requires a targetVersion')
     }
 
     this.lifecycleInFlight = true
-    // restart drains on a predictable timer; upgrade's install runs FIRST and its
-    // duration is unbounded, so `willDrainUntil` would be misleading — omit it (§7.1).
     const willDrainUntil =
       kind === 'restart' ? new Date(this.clock.now() + this.cfg.limits.shutdownDrainMs).toISOString() : undefined
     this.log.info(`cp: ${kind}${targetVersion ? ` → ${targetVersion}` : ''} accepted`)
+    return { accepted: true, root, ...(cliEntry ? { cliEntry } : {}), ...(willDrainUntil ? { willDrainUntil } : {}) }
+  }
 
+  private async installFleetUpgrade(cliEntry: string, targetVersion: string, root: string): Promise<boolean> {
+    const ok = await runCliUpgrade(cliEntry, targetVersion, root, this.log)
+    if (!ok) {
+      this.log.error(`cp: upgrade to ${targetVersion} aborted — daemon continues on the current version`)
+      this.lifecycleInFlight = false
+    }
+    return ok
+  }
+
+  private finishFleetExit(kind: 'restart' | 'upgrade'): void {
     void (async () => {
-      // §7.1 ②: for upgrade, swap `current` via the CLI BEFORE draining. On failure
-      // the daemon stays up, fully intact — no drain, no exit, `current` untouched.
-      if (kind === 'upgrade') {
-        const ok = await runCliUpgrade(cliEntry!, targetVersion!, root, this.log)
-        if (!ok) {
-          this.log.error(`cp: upgrade to ${targetVersion} aborted — daemon continues on the current version`)
-          this.lifecycleInFlight = false
-          return
-        }
-      }
-      // §7.1 ③: drain then exit with the reserved code so the supervisor relaunches
-      // (the new bundle via <root>/current for upgrade).
       try {
         await this.stop()
       } catch (err) {
@@ -18123,8 +18117,33 @@ export class Daemon {
         this.requestExit(RESERVED_RESTART_CODE)
       }
     })()
+  }
 
-    return { accepted: true, willDrainUntil }
+  /** Admit immediately, then install before the existing drain-and-relaunch path. */
+  private scheduleFleetExit(kind: 'restart' | 'upgrade', targetVersion?: string): DaemonControlAck {
+    const admission = this.admitFleetExit(kind, targetVersion)
+    if (!admission.accepted) return admission
+    void (async () => {
+      if (
+        kind === 'upgrade' &&
+        !(await this.installFleetUpgrade(admission.cliEntry!, targetVersion!, admission.root))
+      ) {
+        return
+      }
+      this.finishFleetExit(kind)
+    })()
+
+    return { accepted: true, ...(admission.willDrainUntil ? { willDrainUntil: admission.willDrainUntil } : {}) }
+  }
+
+  private async runBootstrapFleetUpgrade(targetVersion: string): Promise<BootstrapUpgradeOutcome> {
+    if (targetVersion === DAEMON_VERSION) return { status: 'current' }
+    const admission = this.admitFleetExit('upgrade', targetVersion)
+    if (!admission.accepted) return { status: 'failed', reason: admission.reason }
+    if (!(await this.installFleetUpgrade(admission.cliEntry!, targetVersion, admission.root))) {
+      return { status: 'failed', reason: `failed to install ${targetVersion}` }
+    }
+    return { status: 'installed', restart: () => this.finishFleetExit('upgrade') }
   }
 
   // ── ConfigApply seam (CP changes config, never live routing) ──
@@ -19173,10 +19192,8 @@ export class Daemon {
       },
       ...(this.bootstrapUpgradeCapable()
         ? {
-            onBootstrapUpgrade: (lifecycle: { targetVersion: string }) => {
-              if (lifecycle.targetVersion === DAEMON_VERSION) return false
-              return this.scheduleFleetExit('upgrade', lifecycle.targetVersion).accepted
-            }
+            onBootstrapUpgrade: (lifecycle: { targetVersion: string }) =>
+              this.runBootstrapFleetUpgrade(lifecycle.targetVersion)
           }
         : {}),
       agentVersion: DAEMON_VERSION,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,10 +1,11 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { hostname, tmpdir } from 'node:os'
-import { existsSync, readFileSync, type Stats } from 'node:fs'
+import type { Stats } from 'node:fs'
 import { mkdtemp } from 'node:fs/promises'
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
 import { loadConfig, persistDaemonId, persistRelays, type FlatOverrides } from './config/load-config.js'
+import { readCliEntry, runCliUpgrade } from './lifecycle/cli-upgrade.js'
 import { sessionRetentionMs, type Config, type RuntimeDef } from './config/config-schema.js'
 import { discoverAgentsTolerant, type LoadedAgent } from './agents/load-agents.js'
 import { agentChildEnv } from './agents/agent-env.js'
@@ -295,6 +296,7 @@ import {
   RELAY_DAEMON_WS_PATH,
   RESERVED_RESTART_CODE,
   AGENT_CONFIG_REVISION_FEATURE,
+  DAEMON_BOOTSTRAP_UPGRADE_FEATURE,
   ORGANIZATION_KNOWLEDGE_FEATURE,
   ORGANIZATION_SUGGESTION_REVIEW_FEATURE,
   SESSION_METADATA_ACK_FEATURE,
@@ -5067,6 +5069,7 @@ export class Daemon {
       // organization environment entry on this marker. Static — the fence is
       // unconditional daemon code, with no runtime dependency.
       AGENT_CONFIG_REVISION_FEATURE,
+      ...(this.bootstrapUpgradeCapable() ? [DAEMON_BOOTSTRAP_UPGRADE_FEATURE] : []),
       // Multi-agent webchat conversations (webchat-multi-agents.md): mentions/post
       // on turns, the transcript-only context op, agent-attributed stream frames,
       // and rd/webchat-post reply fan-out. Static — no runtime dependency.
@@ -5077,6 +5080,12 @@ export class Daemon {
       // built-in preset; turn-time dispatch rechecks the replicated marker.
       ...(this.remoteWebchatGrants ? [WEBCHAT_REMOTE_MCP_FEATURE] : [])
     ]
+  }
+
+  private bootstrapUpgradeCapable(): boolean {
+    return (
+      (this.opts.supervisor === 'cli' || this.opts.supervisor === 'service') && readCliEntry(this.root) !== undefined
+    )
   }
 
   private selectedOrdinaryTurnHost(agentId: string, host: AcpHost): SelectedTurnHost {
@@ -18075,7 +18084,7 @@ export class Daemon {
     // an unreachable CLI is refused now rather than silently downgraded to a restart.
     let cliEntry: string | undefined
     if (kind === 'upgrade') {
-      cliEntry = this.readCliEntry(root)
+      cliEntry = readCliEntry(root)
       if (!cliEntry) {
         const reason = `cannot locate the CLI (${cliEntryPointer(root)} missing or invalid) to run the upgrade`
         this.log.warn(`cp: upgrade refused — ${reason}`)
@@ -18097,7 +18106,7 @@ export class Daemon {
       // §7.1 ②: for upgrade, swap `current` via the CLI BEFORE draining. On failure
       // the daemon stays up, fully intact — no drain, no exit, `current` untouched.
       if (kind === 'upgrade') {
-        const ok = await this.runCliUpgrade(cliEntry!, targetVersion!, root)
+        const ok = await runCliUpgrade(cliEntry!, targetVersion!, root, this.log)
         if (!ok) {
           this.log.error(`cp: upgrade to ${targetVersion} aborted — daemon continues on the current version`)
           this.lifecycleInFlight = false
@@ -18116,37 +18125,6 @@ export class Daemon {
     })()
 
     return { accepted: true, willDrainUntil }
-  }
-
-  /** Read the CLI entry path the CLI self-heals into `<root>/cli-entry` (§3). */
-  private readCliEntry(root: string): string | undefined {
-    try {
-      const entry = readFileSync(cliEntryPointer(root), 'utf8').trim()
-      return entry && existsSync(entry) ? entry : undefined
-    } catch {
-      return undefined
-    }
-  }
-
-  /** Run `agentconnect upgrade --to <v> --root <root>` (no --restart; the daemon's
-   *  own exit + supervisor relaunch applies it). Resolves true iff it exits 0. */
-  private async runCliUpgrade(cliEntry: string, targetVersion: string, root: string): Promise<boolean> {
-    const { spawn } = await import('node:child_process')
-    this.log.info(`cp: installing daemon ${targetVersion} via ${cliEntry}`)
-    return await new Promise<boolean>((resolve) => {
-      const child = spawn(process.execPath, [cliEntry, 'upgrade', '--to', targetVersion, '--root', root], {
-        stdio: 'inherit'
-      })
-      child.on('exit', (code) => {
-        if (code === 0) this.log.info(`cp: daemon ${targetVersion} installed and activated`)
-        else this.log.error(`cp: CLI upgrade exited ${code ?? 'via signal'}`)
-        resolve(code === 0)
-      })
-      child.on('error', (err) => {
-        this.log.error(`cp: could not launch CLI upgrade: ${formatErr(err)}`)
-        resolve(false)
-      })
-    })
   }
 
   // ── ConfigApply seam (CP changes config, never live routing) ──
@@ -19193,6 +19171,14 @@ export class Daemon {
         this.cpOrgSlug = slug
         if (slug) this.log.debug(`cp: org slug "${slug}" (session deep links)`)
       },
+      ...(this.bootstrapUpgradeCapable()
+        ? {
+            onBootstrapUpgrade: (lifecycle: { targetVersion: string }) => {
+              if (lifecycle.targetVersion === DAEMON_VERSION) return false
+              return this.scheduleFleetExit('upgrade', lifecycle.targetVersion).accepted
+            }
+          }
+        : {}),
       agentVersion: DAEMON_VERSION,
       host: hostname(),
       heartbeatDefaultMs: cp.heartbeatMs,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2029,6 +2029,8 @@ export class Daemon {
   // Guards against a second CP lifecycle command (restart/upgrade) racing one
   // already in flight (§7.1). Cleared only if an upgrade aborts before exiting.
   private lifecycleInFlight = false
+  private fleetUpgradeInFlight?: { targetVersion: string; installation: Promise<boolean> }
+  private fleetExitStarted = false
   // Whole-daemon drain gate: once set, no new turns are dispatched (SIGTERM, or a
   // scope:daemon drain). Agent-scoped drains gate just their agentId.
   private draining = false
@@ -2152,6 +2154,8 @@ export class Daemon {
       clock?: Clock
       /** How the daemon exits for daemon/restart + daemon/upgrade (spied in tests). */
       requestExit?: (code: number) => void
+      /** Test seam for a blocked or failed CLI upgrade installation. */
+      upgradeInstaller?: typeof runCliUpgrade
       /** Who supervises this process — 'cli' (respawn shell) or 'service' (launchd/
        *  systemd). Set by the launcher via AGENTCONNECT_SUPERVISOR. Absent/unknown
        *  means no supervisor (bare `node dist/index.js run`), so CP-commanded
@@ -18098,16 +18102,28 @@ export class Daemon {
     return { accepted: true, root, ...(cliEntry ? { cliEntry } : {}), ...(willDrainUntil ? { willDrainUntil } : {}) }
   }
 
-  private async installFleetUpgrade(cliEntry: string, targetVersion: string, root: string): Promise<boolean> {
-    const ok = await runCliUpgrade(cliEntry, targetVersion, root, this.log)
-    if (!ok) {
-      this.log.error(`cp: upgrade to ${targetVersion} aborted — daemon continues on the current version`)
-      this.lifecycleInFlight = false
-    }
-    return ok
+  private startFleetUpgrade(cliEntry: string, targetVersion: string, root: string): Promise<boolean> {
+    const installation = Promise.resolve()
+      .then(() => (this.opts.upgradeInstaller ?? runCliUpgrade)(cliEntry, targetVersion, root, this.log))
+      .catch((err) => {
+        this.log.error(`cp: could not install daemon ${targetVersion}: ${formatErr(err)}`)
+        return false
+      })
+      .then((ok) => {
+        if (!ok) {
+          this.log.error(`cp: upgrade to ${targetVersion} aborted — daemon continues on the current version`)
+          this.lifecycleInFlight = false
+          if (this.fleetUpgradeInFlight?.installation === installation) this.fleetUpgradeInFlight = undefined
+        }
+        return ok
+      })
+    this.fleetUpgradeInFlight = { targetVersion, installation }
+    return installation
   }
 
   private finishFleetExit(kind: 'restart' | 'upgrade'): void {
+    if (this.fleetExitStarted) return
+    this.fleetExitStarted = true
     void (async () => {
       try {
         await this.stop()
@@ -18124,10 +18140,7 @@ export class Daemon {
     const admission = this.admitFleetExit(kind, targetVersion)
     if (!admission.accepted) return admission
     void (async () => {
-      if (
-        kind === 'upgrade' &&
-        !(await this.installFleetUpgrade(admission.cliEntry!, targetVersion!, admission.root))
-      ) {
+      if (kind === 'upgrade' && !(await this.startFleetUpgrade(admission.cliEntry!, targetVersion!, admission.root))) {
         return
       }
       this.finishFleetExit(kind)
@@ -18138,9 +18151,16 @@ export class Daemon {
 
   private async runBootstrapFleetUpgrade(targetVersion: string): Promise<BootstrapUpgradeOutcome> {
     if (targetVersion === DAEMON_VERSION) return { status: 'current' }
+    const existing = this.fleetUpgradeInFlight
+    if (existing?.targetVersion === targetVersion) {
+      const installed = await existing.installation
+      return installed
+        ? { status: 'installed', restart: () => this.finishFleetExit('upgrade') }
+        : { status: 'failed', reason: `failed to install ${targetVersion}` }
+    }
     const admission = this.admitFleetExit('upgrade', targetVersion)
     if (!admission.accepted) return { status: 'failed', reason: admission.reason }
-    if (!(await this.installFleetUpgrade(admission.cliEntry!, targetVersion, admission.root))) {
+    if (!(await this.startFleetUpgrade(admission.cliEntry!, targetVersion, admission.root))) {
       return { status: 'failed', reason: `failed to install ${targetVersion}` }
     }
     return { status: 'installed', restart: () => this.finishFleetExit('upgrade') }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -23,10 +23,8 @@ if (process.argv[2] === '__sandbox-runtime' || process.argv[2] === '__sandbox-ru
 }
 
 const telemetry = startDaemonOpenTelemetry({ serviceVersion: DAEMON_VERSION })
-const [{ Command }, { runChat }, { runForeground }, { acquireSingletonLock }, { resolveRoot }] = await Promise.all([
+const [{ Command }, { acquireSingletonLock }, { resolveRoot }] = await Promise.all([
   import('commander'),
-  import('./cli/chat.js'),
-  import('./cli/run-foreground.js'),
   import('./lock.js'),
   import('./paths.js')
 ])
@@ -90,6 +88,24 @@ program
       return exit(1)
     }
     try {
+      const bootstrap = await import('./bootstrap-upgrade.js')
+      const bootstrapOutcome = await bootstrap.runBootstrapUpgrade({
+        root: opts.root,
+        configPath: opts.config,
+        supervisor: process.env.AGENTCONNECT_SUPERVISOR,
+        overrides: {
+          apiUrl: opts.apiUrl,
+          apiKey: opts.apiKey,
+          noCp: opts.cp === false,
+          daemonId: opts.daemonId
+        }
+      })
+      if (bootstrapOutcome === 'restart') {
+        lock.release()
+        return exit(bootstrap.BOOTSTRAP_RESTART_CODE)
+      }
+      // Load the business graph only after auth-only recovery.
+      const { runForeground } = await import('./cli/run-foreground.js')
       await runForeground({
         root: opts.root,
         configPath: opts.config,
@@ -190,6 +206,7 @@ program
   .action(async (message?: string) => {
     const opts = program.opts()
     try {
+      const { runChat } = await import('./cli/chat.js')
       await runChat({
         agentsDir: opts.agentsDir,
         agentName: opts.agent,

--- a/packages/daemon/src/lifecycle/cli-upgrade.ts
+++ b/packages/daemon/src/lifecycle/cli-upgrade.ts
@@ -1,0 +1,42 @@
+import { spawn } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { cliEntryPointer } from '../paths.js'
+
+export interface UpgradeLog {
+  info(message: string): void
+  error(message: string): void
+}
+
+/** Resolve the stable CLI entry that owns the daemon version store. */
+export function readCliEntry(root: string): string | undefined {
+  try {
+    const entry = readFileSync(cliEntryPointer(root), 'utf8').trim()
+    return entry && existsSync(entry) ? entry : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Install and atomically activate one CP-selected daemon version. */
+export async function runCliUpgrade(
+  cliEntry: string,
+  targetVersion: string,
+  root: string,
+  log: UpgradeLog
+): Promise<boolean> {
+  log.info(`cp: installing daemon ${targetVersion} via ${cliEntry}`)
+  return await new Promise<boolean>((resolve) => {
+    const child = spawn(process.execPath, [cliEntry, 'upgrade', '--to', targetVersion, '--root', root], {
+      stdio: 'inherit'
+    })
+    child.on('exit', (code) => {
+      if (code === 0) log.info(`cp: daemon ${targetVersion} installed and activated`)
+      else log.error(`cp: CLI upgrade exited ${code ?? 'via signal'}`)
+      resolve(code === 0)
+    })
+    child.on('error', (err) => {
+      log.error(`cp: could not launch CLI upgrade: ${err.message}`)
+      resolve(false)
+    })
+  })
+}

--- a/packages/daemon/test/bootstrap-upgrade.test.ts
+++ b/packages/daemon/test/bootstrap-upgrade.test.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildEnvelope, encode } from '@agentconnect.md/protocol'
+import { bootstrapControlPlane, runBootstrapUpgrade } from '../src/bootstrap-upgrade.js'
+import { FakeTransport } from './cp/fake-transport.js'
+
+const DAEMON_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const SERVER_TIME = '2026-08-10T00:00:00.000Z'
+const roots: string[] = []
+
+function rootWithCli(): string {
+  const root = mkdtempSync(join(tmpdir(), 'agentconnect-bootstrap-'))
+  roots.push(root)
+  const cli = join(root, 'agentconnect-cli.js')
+  writeFileSync(cli, '')
+  writeFileSync(join(root, 'cli-entry'), `${cli}\n`)
+  return root
+}
+
+async function waitForSent(transport: FakeTransport, type: string): Promise<Record<string, unknown>> {
+  await vi.waitFor(() => {
+    if (!transport.sent.some((text) => JSON.parse(text).type === type)) throw new Error(`${type} not sent`)
+  })
+  return JSON.parse(transport.sent.find((text) => JSON.parse(text).type === type)!) as Record<string, unknown>
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('auth-only daemon bootstrap upgrade', () => {
+  it('reads the persisted daemon identity and applies the enabled default', () => {
+    const root = rootWithCli()
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        version: 1,
+        daemonId: DAEMON_ID,
+        controlPlane: { url: 'ws://cp.test', key: 'key' }
+      })
+    )
+
+    expect(bootstrapControlPlane({ root })).toEqual({ url: 'ws://cp.test', key: 'key', daemonId: DAEMON_ID })
+  })
+
+  it('advertises bootstrap v1 and continues when CP has no pending upgrade', async () => {
+    const transport = new FakeTransport()
+    const install = vi.fn()
+    const run = runBootstrapUpgrade(
+      {
+        root: rootWithCli(),
+        supervisor: 'cli',
+        overrides: { apiUrl: 'ws://cp.test', apiKey: 'key' }
+      },
+      { connect: async () => transport, install, log: { info: vi.fn(), error: vi.fn() } }
+    )
+    const auth = await waitForSent(transport, 'auth')
+    expect(auth.payload).toMatchObject({ bootstrapProtocolVersion: 1 })
+    transport.pushInbound(
+      encode(
+        buildEnvelope(
+          'auth/ok',
+          { daemonId: DAEMON_ID, sessionEpoch: 1, heartbeatSec: 15, serverTime: SERVER_TIME },
+          { corr: auth.id as string }
+        )
+      )
+    )
+    await expect(run).resolves.toBe('continue')
+    expect(install).not.toHaveBeenCalled()
+  })
+
+  it('installs the directed version, reports it, and requests a planned restart', async () => {
+    const transport = new FakeTransport()
+    const install = vi.fn(async () => true)
+    const run = runBootstrapUpgrade(
+      {
+        root: rootWithCli(),
+        supervisor: 'service',
+        overrides: { apiUrl: 'ws://cp.test', apiKey: 'key' }
+      },
+      { connect: async () => transport, install, log: { info: vi.fn(), error: vi.fn() } }
+    )
+    const auth = await waitForSent(transport, 'auth')
+    transport.pushInbound(
+      encode(
+        buildEnvelope(
+          'auth/ok',
+          {
+            daemonId: DAEMON_ID,
+            sessionEpoch: 2,
+            heartbeatSec: 15,
+            serverTime: SERVER_TIME,
+            lifecycle: { operationId: 'op-1', action: 'upgrade', targetVersion: '9.9.9' }
+          },
+          { corr: auth.id as string }
+        )
+      )
+    )
+    const result = await waitForSent(transport, 'daemon/bootstrap/result')
+    expect(result.payload).toEqual({ operationId: 'op-1', status: 'installed' })
+    transport.pushInbound(encode(buildEnvelope('ack', { ok: true }, { corr: result.id as string })))
+
+    await expect(run).resolves.toBe('restart')
+    expect(install).toHaveBeenCalledWith(expect.any(String), '9.9.9', expect.any(String), expect.any(Object))
+  })
+})

--- a/packages/daemon/test/cp/client-handshake.test.ts
+++ b/packages/daemon/test/cp/client-handshake.test.ts
@@ -511,4 +511,40 @@ describe('CpClient handshake', () => {
     await tick()
     expect(adopted).toEqual([ASSIGNED])
   })
+
+  it('consumes an auth-time upgrade before register and stops reconnecting', async () => {
+    const t = new FakeTransport()
+    const directives: unknown[] = []
+    const client = new CpClient(
+      makeDeps(t, {
+        onBootstrapUpgrade: (lifecycle) => {
+          directives.push(lifecycle)
+          return true
+        }
+      })
+    )
+    client.start()
+    await tick()
+    const auth = t.lastSent()
+    expect(auth.payload.bootstrapProtocolVersion).toBe(1)
+    t.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'auth/ok',
+          {
+            daemonId: DAEMON_ID,
+            sessionEpoch: 4,
+            heartbeatSec: 15,
+            serverTime: '2026-06-26T00:00:00.000Z',
+            lifecycle: { operationId: 'op-1', action: 'upgrade', targetVersion: '2.0.0' }
+          },
+          { corr: auth.id }
+        )
+      )
+    )
+    await tick()
+    expect(directives).toEqual([{ operationId: 'op-1', action: 'upgrade', targetVersion: '2.0.0' }])
+    expect(t.closed).toEqual({ code: 1000, reason: 'bootstrap upgrade accepted' })
+    expect(t.sent.map((text) => JSON.parse(text).type)).not.toContain('register')
+  })
 })

--- a/packages/daemon/test/cp/client-handshake.test.ts
+++ b/packages/daemon/test/cp/client-handshake.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { buildEnvelope } from '@agentconnect.md/protocol'
 import { CpClient, type CpClientDeps } from '../../src/cp/client.js'
 import { FakeTransport } from './fake-transport.js'
@@ -512,14 +512,15 @@ describe('CpClient handshake', () => {
     expect(adopted).toEqual([ASSIGNED])
   })
 
-  it('consumes an auth-time upgrade before register and stops reconnecting', async () => {
+  it('reports an auth-time installation before restarting without registering', async () => {
     const t = new FakeTransport()
     const directives: unknown[] = []
+    const restart = vi.fn()
     const client = new CpClient(
       makeDeps(t, {
-        onBootstrapUpgrade: (lifecycle) => {
+        onBootstrapUpgrade: async (lifecycle) => {
           directives.push(lifecycle)
-          return true
+          return { status: 'installed', restart }
         }
       })
     )
@@ -544,7 +545,53 @@ describe('CpClient handshake', () => {
     )
     await tick()
     expect(directives).toEqual([{ operationId: 'op-1', action: 'upgrade', targetVersion: '2.0.0' }])
-    expect(t.closed).toEqual({ code: 1000, reason: 'bootstrap upgrade accepted' })
+    const result = t.lastSent()
+    expect(result).toMatchObject({
+      type: 'daemon/bootstrap/result',
+      payload: { operationId: 'op-1', status: 'installed' }
+    })
+    expect(restart).not.toHaveBeenCalled()
+    t.pushInbound(JSON.stringify(buildEnvelope('ack', { ok: true }, { corr: result.id })))
+    await tick()
+    expect(restart).toHaveBeenCalledOnce()
+    expect(t.closed).toEqual({ code: 1000, reason: 'bootstrap upgrade installed' })
     expect(t.sent.map((text) => JSON.parse(text).type)).not.toContain('register')
+  })
+
+  it('reports installer failure and continues registration on the same connection', async () => {
+    const t = new FakeTransport()
+    const client = new CpClient(
+      makeDeps(t, {
+        onBootstrapUpgrade: async () => ({ status: 'failed', reason: 'registry unavailable' })
+      })
+    )
+    client.start()
+    await tick()
+    const auth = t.lastSent()
+    t.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'auth/ok',
+          {
+            daemonId: DAEMON_ID,
+            sessionEpoch: 4,
+            heartbeatSec: 15,
+            serverTime: '2026-06-26T00:00:00.000Z',
+            lifecycle: { operationId: 'op-1', action: 'upgrade', targetVersion: '2.0.0' }
+          },
+          { corr: auth.id }
+        )
+      )
+    )
+    await tick()
+    const result = t.lastSent()
+    expect(result).toMatchObject({
+      type: 'daemon/bootstrap/result',
+      payload: { operationId: 'op-1', status: 'failed', reason: 'registry unavailable' }
+    })
+    t.pushInbound(JSON.stringify(buildEnvelope('ack', { ok: true }, { corr: result.id })))
+    await tick()
+    expect(t.lastSent().type).toBe('register')
+    expect(t.closed).toBeUndefined()
   })
 })

--- a/packages/daemon/test/daemon-fleet-upgrade.test.ts
+++ b/packages/daemon/test/daemon-fleet-upgrade.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Daemon } from '../src/daemon.js'
+
+const roots: string[] = []
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'agentconnect-fleet-upgrade-'))
+  roots.push(root)
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  const cliEntry = join(root, 'agentconnect-cli.js')
+  writeFileSync(cliEntry, '')
+  writeFileSync(join(root, 'cli-entry'), `${cliEntry}\n`)
+  return root
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('daemon fleet upgrade coordination', () => {
+  it('joins the same READY-delivered install when bootstrap auth reconnects', async () => {
+    let finishInstall!: (installed: boolean) => void
+    const blockedInstall = new Promise<boolean>((resolve) => (finishInstall = resolve))
+    const upgradeInstaller = vi.fn(async () => await blockedInstall)
+    const requestExit = vi.fn()
+    const daemon = new Daemon({ root: scaffold(), supervisor: 'cli', upgradeInstaller, requestExit })
+    ;(daemon as any).stop = vi.fn(async () => {})
+
+    expect((daemon as any).scheduleFleetExit('upgrade', '9.9.9')).toEqual({ accepted: true })
+    await vi.waitFor(() => expect(upgradeInstaller).toHaveBeenCalledTimes(1))
+
+    const reconnectOutcome = (daemon as any).runBootstrapFleetUpgrade('9.9.9')
+    finishInstall(true)
+
+    const outcome = await reconnectOutcome
+    expect(outcome.status).toBe('installed')
+    expect(upgradeInstaller).toHaveBeenCalledTimes(1)
+    outcome.restart()
+    await vi.waitFor(() => expect(requestExit).toHaveBeenCalledTimes(1))
+  })
+})

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -79,6 +79,33 @@ describe('decodeEnvelope — first failing test (design §6 Phase 0)', () => {
     expect(AuthReq.safeParse(r.frame.payload).success).toBe(true)
   })
 
+  it('round-trips the frozen auth-time bootstrap upgrade contract', () => {
+    const auth = decodeEnvelope(envelope('auth', { ...validAuthPayload, bootstrapProtocolVersion: 1 }))
+    expect(auth.ok).toBe(true)
+    if (!auth.ok || !isFrame('auth')(auth.frame)) throw new Error('expected auth')
+    expect(auth.frame.payload.bootstrapProtocolVersion).toBe(1)
+
+    const ok = decodeEnvelope(
+      envelope('auth/ok', {
+        daemonId: DAEMON_ID,
+        sessionEpoch: 2,
+        heartbeatSec: 15,
+        serverTime: TS,
+        lifecycle: { operationId: 'op-1', action: 'upgrade', targetVersion: '2.0.0' }
+      })
+    )
+    expect(ok.ok).toBe(true)
+    if (!ok.ok || !isFrame('auth/ok')(ok.frame)) throw new Error('expected auth/ok')
+    expect(ok.frame.payload.lifecycle?.targetVersion).toBe('2.0.0')
+
+    const result = decodeEnvelope(envelope('daemon/bootstrap/result', { operationId: 'op-1', status: 'installed' }))
+    expect(result.ok).toBe(true)
+    if (!result.ok || !isFrame('daemon/bootstrap/result')(result.frame)) {
+      throw new Error('expected bootstrap result')
+    }
+    expect(result.frame.payload.status).toBe('installed')
+  })
+
   it('rejects an unknown type with UNKNOWN_FRAME (a REP, not a close)', () => {
     const r = decodeEnvelope(envelope('totally/unknown', { whatever: true }))
     expect(r).toEqual({ ok: false, id: ID, msg: 'UNKNOWN_FRAME' })

--- a/packages/protocol/src/consts.ts
+++ b/packages/protocol/src/consts.ts
@@ -113,6 +113,12 @@ export const SLACK_SESSION_AUDIENCE_FEATURE = 'slack-session-audience-v1'
  */
 export const AGENT_CONFIG_REVISION_FEATURE = 'agent-config-revision-v1'
 
+/** Auth-only recovery capability that permits CP to queue an offline daemon upgrade. */
+export const DAEMON_BOOTSTRAP_UPGRADE_FEATURE = 'daemon-bootstrap-upgrade-v1'
+
+/** Frozen version of the auth-only bootstrap handshake. */
+export const DAEMON_BOOTSTRAP_PROTOCOL_VERSION = 1
+
 /**
  * Per-value ceiling for an environment variable or secret, shared by the agent
  * and organization surfaces so one entry can never be sized past what any

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -137,6 +137,7 @@ import {
   FactsRuntimeProfile,
   DaemonRuntimes,
   ConfigPush,
+  DaemonBootstrapResult,
   DaemonRestart,
   DaemonUpgrade,
   DaemonControlAck,
@@ -359,6 +360,7 @@ export const FRAME_SCHEMAS = {
   'managed-skill/chunk': ManagedSkillChunk,
   // ── fleet / config ──
   'config/push': ConfigPush,
+  'daemon/bootstrap/result': DaemonBootstrapResult,
   'daemon/restart': DaemonRestart,
   'daemon/upgrade': DaemonUpgrade,
   // ── generic replies ──
@@ -564,6 +566,7 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('managed-skill/read', FRAME_SCHEMAS['managed-skill/read']),
   frame('managed-skill/chunk', FRAME_SCHEMAS['managed-skill/chunk']),
   frame('config/push', FRAME_SCHEMAS['config/push']),
+  frame('daemon/bootstrap/result', FRAME_SCHEMAS['daemon/bootstrap/result']),
   frame('daemon/restart', FRAME_SCHEMAS['daemon/restart']),
   frame('daemon/upgrade', FRAME_SCHEMAS['daemon/upgrade']),
   frame('daemon/control/ack', FRAME_SCHEMAS['daemon/control/ack']),

--- a/packages/protocol/src/frames/auth.ts
+++ b/packages/protocol/src/frames/auth.ts
@@ -18,6 +18,8 @@ export const AuthReq = z.object({
   machineId: z.string().uuid().optional(), // 🅼 machine identity (scope-attestation, §3.2) — NOT the auth credential
   attestation: z.string().optional(), // 🅼 signed proof (JWS), §3.2
   agentVersion: z.string(), // daemon build/version
+  // Auth-time lifecycle support; optional for rolling compatibility.
+  bootstrapProtocolVersion: z.literal(1).optional(),
   resume: z
     .object({
       lastEpoch: z.number().int() // sessionEpoch the daemon last held
@@ -25,6 +27,13 @@ export const AuthReq = z.object({
     .optional()
 })
 export type AuthReq = z.infer<typeof AuthReq>
+
+export const BootstrapLifecycle = z.object({
+  operationId: z.string(),
+  action: z.literal('upgrade'),
+  targetVersion: z.string()
+})
+export type BootstrapLifecycle = z.infer<typeof BootstrapLifecycle>
 
 export const AuthOk = z.object({
   daemonId: z.string().uuid(),
@@ -39,6 +48,8 @@ export const AuthOk = z.object({
   // (`<webAppUrl>/<orgSlug>/sessions/<id>`), so the daemon needs it to build a link that
   // resolves. Omitted when the CP can't resolve it; then the daemon drops the segment.
   orgSlug: z.string().optional(),
+  // Durable upgrade intent returned only to bootstrap-capable callers.
+  lifecycle: BootstrapLifecycle.optional(),
   resume: z
     .object({
       accepted: z.boolean() // false ⇒ daemon must do a full register reconcile

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -356,6 +356,14 @@ export const ConfigPush = z.object({
 })
 export type ConfigPush = z.infer<typeof ConfigPush>
 
+/** Auth-time upgrade result, legal before full registration. */
+export const DaemonBootstrapResult = z.object({
+  operationId: z.string(),
+  status: z.enum(['installed', 'failed']),
+  reason: z.string().max(500).optional()
+})
+export type DaemonBootstrapResult = z.infer<typeof DaemonBootstrapResult>
+
 /** Fleet: drain+exit, supervisor restarts — C→D REQ, protocol §8.3 / frame #27. */
 export const DaemonRestart = z.object({
   reason: z.string(),

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -10,6 +10,8 @@
 // ── cross-package wire + lifecycle constants ──
 export {
   AGENT_CONFIG_REVISION_FEATURE,
+  DAEMON_BOOTSTRAP_PROTOCOL_VERSION,
+  DAEMON_BOOTSTRAP_UPGRADE_FEATURE,
   CP_SUBPROTOCOL,
   CP_WS_PATH,
   hasReachedAgentCallHopLimit,


### PR DESCRIPTION
## Summary

- add a frozen auth-time bootstrap upgrade handshake to the daemon/CP protocol
- let the Control Plane durably queue upgrades for offline daemons that previously advertised bootstrap recovery
- run a bounded daemon-owned preflight before loading the full business graph, invoke the existing local CLI installer, and restart through the existing supervisor
- handle the same directive in the normal CP client for daemons that authenticate but cannot complete registration
- document the recovery and add protocol, daemon, and Control Plane regression coverage

## Why

A daemon can become unable to reach READY after a daemon/CP protocol change. The Control Plane then considers it disconnected and cannot deliver the normal READY-only upgrade command, leaving no remote recovery path.

The recovery connection remains daemon-owned. The CLI does not connect to the Control Plane and keeps only its existing local installation responsibility.

## Behavior

- only daemons that previously advertised `daemon-bootstrap-upgrade-v1` are eligible for offline queueing
- CP/network failure during bootstrap does not block ordinary local-first startup
- installer failure is reported and the current daemon continues
- installation success is progress only; the lifecycle operation succeeds after READY on the exact target version
- older daemons without the capability retain the existing online/manual-upgrade behavior

## Validation

- `pnpm --filter @agentconnect.md/protocol test` — 285 passed
- daemon focused tests — 13 passed
- Control Plane focused integration tests — 58 passed
- daemon and Control Plane typechecks
- ESLint, Prettier, and `git diff --check`
- daemon bundle build and self-contained bundle assertion
- full Control Plane integration run — 1060/1061 passed initially; the unrelated rewrap test passed on isolated rerun
