### PR TITLE
fix(daemon): render provider thumbnails for oversized transcript images

### DIFF
--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -364,7 +364,8 @@ export class DiscordConnection implements PlatformConnection {
         name: a.name,
         contentType: a.contentType,
         size: a.size,
-        url: a.url
+        url: a.url,
+        proxyUrl: a.proxyURL
       }))
     }
   }

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -1,4 +1,4 @@
-import type { NormalizedPlatformMessage, PlatformAttachment } from '@agentconnect.md/protocol'
+import type { NormalizedPlatformMessage, PlatformAttachment, SessionImageAttachment } from '@agentconnect.md/protocol'
 
 /**
  * A file shared alongside a message. Platform ingresses carry metadata + a
@@ -20,6 +20,10 @@ export interface Attachment extends Omit<PlatformAttachment, 'sourceUrl'> {
   sourceUrl?: string
   /** Already-bounded bytes from webchat, absent for provider-backed attachments. */
   inlineData?: Buffer
+  /** Bytes fetched from `thumbnailUrl` for transcript preview only, set when the
+   *  full download (`inlineData`) doesn't fit the console history budget. Kept
+   *  apart from `inlineData` so the ACP prompt block never receives it. */
+  transcriptThumbnail?: { data: Buffer; mimeType: SessionImageAttachment['mimeType'] }
 }
 
 export interface NormalizedMessage extends Omit<

--- a/packages/daemon/src/session/attachment-block.ts
+++ b/packages/daemon/src/session/attachment-block.ts
@@ -1,7 +1,8 @@
 import type { ContentBlock } from '@agentclientprotocol/sdk'
 import {
   SessionImageAttachment as SessionImageAttachmentSchema,
-  type SessionImageAttachment
+  type SessionImageAttachment,
+  WEBCHAT_IMAGE_MAX_BYTES
 } from '@agentconnect.md/protocol'
 import type { Attachment } from '../messages/normalized.js'
 
@@ -116,6 +117,15 @@ export function sniffImageMimeType(bytes: Buffer): SessionImageAttachment['mimeT
  * skipped identically here; the tighter transcript ceiling is enforced by the
  * `SessionImageAttachment` schema in `transcriptImageAttachments`.
  *
+ * The console history frame's budget (`WEBCHAT_IMAGE_MAX_BYTES`) is far tighter
+ * than `maxBytes` above, so a full-res download routinely clears the prompt cap
+ * but not the transcript one. When that happens — or the full download was
+ * never attempted because the declared size already exceeded `maxBytes` — a
+ * provider-supplied smaller rendition (`thumbnailUrl`: Slack `thumb_*`, a
+ * smaller Telegram `PhotoSize`, a resized Discord `proxy_url`) is fetched
+ * separately and kept in `transcriptThumbnail`, never in `inlineData`, so the
+ * agent's own prompt block always sees the full-resolution bytes.
+ *
  * ponytail: one image per message. A second one keeps the label; showing more
  * needs chunked/off-frame image reads, not a bigger cap.
  */
@@ -128,23 +138,39 @@ export async function hydrateTranscriptImage(
   )
   if (!image || image.inlineData) return
   const cap = deps.maxBytes ?? Infinity
-  if (typeof image.size === 'number' && image.size > cap) return
-  const bytes = await deps.download(image).catch(() => null)
-  if (!bytes || bytes.byteLength > cap) return
-  image.inlineData = bytes
-  const sniffed = sniffImageMimeType(bytes)
-  if (sniffed) image.mimeType = sniffed
+  if (!(typeof image.size === 'number' && image.size > cap)) {
+    const bytes = await deps.download(image).catch(() => null)
+    if (bytes && bytes.byteLength <= cap) {
+      image.inlineData = bytes
+      const sniffed = sniffImageMimeType(bytes)
+      if (sniffed) image.mimeType = sniffed
+    }
+  }
+  if (image.thumbnailUrl && (!image.inlineData || image.inlineData.byteLength > WEBCHAT_IMAGE_MAX_BYTES)) {
+    const thumbBytes = await deps.download({ ...image, sourceUrl: image.thumbnailUrl }).catch(() => null)
+    const sniffed = thumbBytes ? sniffImageMimeType(thumbBytes) : undefined
+    if (thumbBytes && sniffed && thumbBytes.byteLength <= WEBCHAT_IMAGE_MAX_BYTES) {
+      image.transcriptThumbnail = { data: thumbBytes, mimeType: sniffed }
+    }
+  }
 }
 
-/** Keep a validated bounded inline image beside its daemon-local transcript row. */
+/** Keep a validated bounded inline image beside its daemon-local transcript row.
+ *  Prefers a fetched `transcriptThumbnail` over the full-res `inlineData` — the
+ *  former exists only because the latter didn't fit the transcript's budget. */
 export function transcriptImageAttachments(attachments: Attachment[] | undefined): SessionImageAttachment[] {
   return (attachments ?? [])
     .flatMap((attachment) => {
-      if (!attachment.inlineData) return []
+      const image = attachment.transcriptThumbnail
+        ? { mimeType: attachment.transcriptThumbnail.mimeType, data: attachment.transcriptThumbnail.data }
+        : attachment.inlineData
+          ? { mimeType: attachment.mimeType, data: attachment.inlineData }
+          : undefined
+      if (!image) return []
       const parsed = SessionImageAttachmentSchema.safeParse({
         name: attachment.name,
-        mimeType: attachment.mimeType,
-        data: attachment.inlineData.toString('base64')
+        mimeType: image.mimeType,
+        data: image.data.toString('base64')
       })
       return parsed.success ? [parsed.data] : []
     })

--- a/packages/daemon/test/attachment-block.test.ts
+++ b/packages/daemon/test/attachment-block.test.ts
@@ -181,6 +181,28 @@ describe('hydrateTranscriptImage', () => {
     expect(download).toHaveBeenCalledOnce()
   })
 
+  it('fetches a separate thumbnail for the transcript when the full image is too big, without touching the prompt bytes', async () => {
+    const png = Buffer.concat([Buffer.from('89504e470d0a1a0a', 'hex'), Buffer.alloc(WEBCHAT_IMAGE_MAX_BYTES)])
+    const jpegThumb = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff]), Buffer.from('thumb')])
+    const download = vi.fn(async (a: Attachment) => (a.sourceUrl === 'https://files/thumb' ? jpegThumb : png))
+    const attachments = [att({ thumbnailUrl: 'https://files/thumb' })]
+    await hydrateTranscriptImage(attachments, { download })
+    expect(download).toHaveBeenCalledTimes(2)
+    expect(transcriptImageAttachments(attachments)).toEqual([
+      { name: 'a.png', mimeType: 'image/jpeg', data: jpegThumb.toString('base64') }
+    ])
+    // The prompt block still gets the full-resolution bytes, never the thumbnail.
+    const blocks = await buildAttachmentBlocks(attachments, { download, supports: supportsAll })
+    expect(blocks[0]).toMatchObject({ type: 'image', data: png.toString('base64') })
+  })
+
+  it('skips the thumbnail fetch when the full image already fits the transcript budget', async () => {
+    const download = vi.fn(async () => Buffer.from('IMG'))
+    const attachments = [att({ thumbnailUrl: 'https://files/thumb' })]
+    await hydrateTranscriptImage(attachments, { download })
+    expect(download).toHaveBeenCalledOnce()
+  })
+
   it('survives a failed download', async () => {
     const attachments = [att()]
     await hydrateTranscriptImage(attachments, {

--- a/packages/daemon/test/telegram-normalize.test.ts
+++ b/packages/daemon/test/telegram-normalize.test.ts
@@ -150,7 +150,9 @@ describe('normalizeTelegramMessage', () => {
       }),
       ctx
     )
-    expect(n.attachments).toEqual([{ id: 'lg', name: 'uq9.jpg', mimeType: 'image/jpeg', size: 9000, sourceUrl: 'lg' }])
+    expect(n.attachments).toEqual([
+      { id: 'lg', name: 'uq9.jpg', mimeType: 'image/jpeg', size: 9000, sourceUrl: 'lg', thumbnailUrl: 'sm' }
+    ])
   })
 
   it('maps a document attachment, carrying file_id in sourceUrl', () => {

--- a/packages/message/src/discord-message.ts
+++ b/packages/message/src/discord-message.ts
@@ -20,6 +20,9 @@ export interface DiscordAttachmentLike {
   contentType?: string | null
   size?: number
   url: string
+  /** Discord's CDN proxy URL; unlike `url`, it honors a `?width=` query param
+   *  for server-side resizing. */
+  proxyUrl?: string
 }
 
 export interface DiscordMessageLike {
@@ -46,12 +49,17 @@ export interface DiscordMessageLike {
 /** Map public Discord CDN metadata into the shared attachment contract. */
 export function toDiscordAttachment(attachment: DiscordAttachmentLike | null | undefined): PlatformAttachment | null {
   if (!attachment || typeof attachment !== 'object' || !attachment.id || !attachment.url) return null
+  // media.discordapp.net's proxy honors `?width=`, downscaling server-side — the
+  // console transcript needs a preview, not the original resolution.
+  const thumbnailUrl =
+    attachment.contentType?.startsWith('image/') && attachment.proxyUrl ? `${attachment.proxyUrl}?width=320` : undefined
   return {
     id: attachment.id,
     name: attachment.name ?? attachment.id,
     mimeType: attachment.contentType ?? 'application/octet-stream',
     ...(typeof attachment.size === 'number' ? { size: attachment.size } : {}),
-    sourceUrl: attachment.url
+    sourceUrl: attachment.url,
+    ...(thumbnailUrl ? { thumbnailUrl } : {})
   }
 }
 

--- a/packages/message/src/discord-message.ts
+++ b/packages/message/src/discord-message.ts
@@ -46,13 +46,37 @@ export interface DiscordMessageLike {
   attachments: DiscordAttachmentLike[]
 }
 
+/**
+ * media.discordapp.net's proxy honors a `width` query param, downscaling
+ * server-side — the console transcript needs a preview, not the original
+ * resolution. `proxyUrl` commonly arrives already signed (`ex`/`is`/`hm` from
+ * Discord's signed-attachment-CDN-URLs scheme), so `width` must be merged into
+ * the existing query string rather than string-concatenated — a naive
+ * `${url}?width=320` either mints a bogus `?width` key (when the URL already
+ * ends in `&…`) or corrupts the trailing `hm` signature value, and the proxy
+ * rejects both. This package stays dependency-free (no `URL`/DOM types), so
+ * the merge is done by hand rather than via `URLSearchParams`.
+ */
+function withThumbnailWidth(url: string, width: number): string {
+  const [withoutHash, hash = ''] = splitOnce(url, '#')
+  const [base, query = ''] = splitOnce(withoutHash, '?')
+  const params = query.split('&').filter((pair) => pair.length > 0 && !pair.startsWith('width='))
+  params.push(`width=${width}`)
+  return `${base}?${params.join('&')}${hash ? `#${hash}` : ''}`
+}
+
+function splitOnce(value: string, separator: string): [string, string?] {
+  const i = value.indexOf(separator)
+  return i === -1 ? [value] : [value.slice(0, i), value.slice(i + 1)]
+}
+
 /** Map public Discord CDN metadata into the shared attachment contract. */
 export function toDiscordAttachment(attachment: DiscordAttachmentLike | null | undefined): PlatformAttachment | null {
   if (!attachment || typeof attachment !== 'object' || !attachment.id || !attachment.url) return null
-  // media.discordapp.net's proxy honors `?width=`, downscaling server-side — the
-  // console transcript needs a preview, not the original resolution.
   const thumbnailUrl =
-    attachment.contentType?.startsWith('image/') && attachment.proxyUrl ? `${attachment.proxyUrl}?width=320` : undefined
+    attachment.contentType?.startsWith('image/') && attachment.proxyUrl
+      ? withThumbnailWidth(attachment.proxyUrl, 320)
+      : undefined
   return {
     id: attachment.id,
     name: attachment.name ?? attachment.id,

--- a/packages/message/src/slack-message.ts
+++ b/packages/message/src/slack-message.ts
@@ -12,6 +12,11 @@ export interface SlackFile {
   url_private?: string
   url_private_download?: string
   mode?: string
+  /** Slack only sets these on image files; smallest-first is enough for a
+   *  console transcript preview. */
+  thumb_360?: string
+  thumb_720?: string
+  thumb_1024?: string
 }
 
 /**
@@ -127,12 +132,14 @@ export function toSlackAttachment(file: SlackFile | null | undefined): PlatformA
   if (!file || typeof file !== 'object') return null
   const sourceUrl = file.url_private_download ?? file.url_private
   if (!file.id || !sourceUrl) return null
+  const thumbnailUrl = file.thumb_360 ?? file.thumb_720 ?? file.thumb_1024
   return {
     id: file.id,
     name: file.name ?? file.title ?? file.id,
     mimeType: file.mimetype ?? 'application/octet-stream',
     ...(typeof file.size === 'number' ? { size: file.size } : {}),
-    sourceUrl
+    sourceUrl,
+    ...(thumbnailUrl ? { thumbnailUrl } : {})
   }
 }
 

--- a/packages/message/src/telegram-message.ts
+++ b/packages/message/src/telegram-message.ts
@@ -100,12 +100,18 @@ export function toTelegramPhotoAttachment(sizes: TelegramPhotoSize[] | null | un
   if (!Array.isArray(sizes) || sizes.length === 0) return null
   const largest = sizes[sizes.length - 1]!
   if (!largest.file_id) return null
+  // Telegram returns `photo` sorted smallest→largest; the smallest rendition
+  // comfortably fits the console transcript's tight budget where the full-size
+  // photo often won't. Each size is its own file_id, resolved the same way as
+  // the full photo (getFile), so no extra download surface is needed.
+  const smallest = sizes[0]!
   return {
     id: largest.file_id,
     name: `${largest.file_unique_id ?? 'photo'}.jpg`,
     mimeType: 'image/jpeg',
     ...(typeof largest.file_size === 'number' ? { size: largest.file_size } : {}),
-    sourceUrl: largest.file_id
+    sourceUrl: largest.file_id,
+    ...(smallest.file_id && smallest.file_id !== largest.file_id ? { thumbnailUrl: smallest.file_id } : {})
   }
 }
 

--- a/packages/message/test/attachment-thumbnails.test.ts
+++ b/packages/message/test/attachment-thumbnails.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { toSlackAttachment } from '../src/slack-message.js'
+import { toTelegramPhotoAttachment } from '../src/telegram-message.js'
+import { toDiscordAttachment } from '../src/discord-message.js'
+
+describe('toSlackAttachment thumbnailUrl', () => {
+  it('prefers the smallest available thumb_* rendition', () => {
+    const att = toSlackAttachment({
+      id: 'F1',
+      name: 'shot.png',
+      mimetype: 'image/png',
+      url_private: 'https://files.slack.com/f1',
+      thumb_720: 'https://files.slack.com/t720',
+      thumb_1024: 'https://files.slack.com/t1024'
+    })
+    expect(att?.thumbnailUrl).toBe('https://files.slack.com/t720')
+  })
+
+  it('omits thumbnailUrl when Slack reports no thumb_* rendition', () => {
+    const att = toSlackAttachment({
+      id: 'F1',
+      name: 'doc.pdf',
+      mimetype: 'application/pdf',
+      url_private: 'https://files.slack.com/f1'
+    })
+    expect(att?.thumbnailUrl).toBeUndefined()
+  })
+})
+
+describe('toTelegramPhotoAttachment thumbnailUrl', () => {
+  it('uses the smallest PhotoSize file_id as the thumbnail, the largest as the source', () => {
+    const att = toTelegramPhotoAttachment([
+      { file_id: 'small', file_unique_id: 'u1', width: 90, height: 90 },
+      { file_id: 'medium', file_unique_id: 'u1', width: 320, height: 320 },
+      { file_id: 'large', file_unique_id: 'u1', width: 1280, height: 1280 }
+    ])
+    expect(att?.sourceUrl).toBe('large')
+    expect(att?.thumbnailUrl).toBe('small')
+  })
+
+  it('omits thumbnailUrl for a single-size photo', () => {
+    const att = toTelegramPhotoAttachment([{ file_id: 'only', width: 100, height: 100 }])
+    expect(att?.sourceUrl).toBe('only')
+    expect(att?.thumbnailUrl).toBeUndefined()
+  })
+})
+
+describe('toDiscordAttachment thumbnailUrl', () => {
+  it('derives a width-limited proxy URL for an image attachment', () => {
+    const att = toDiscordAttachment({
+      id: 'a1',
+      name: 'shot.png',
+      contentType: 'image/png',
+      url: 'https://cdn.discordapp.com/attachments/1/2/shot.png',
+      proxyUrl: 'https://media.discordapp.net/attachments/1/2/shot.png'
+    })
+    expect(att?.thumbnailUrl).toBe('https://media.discordapp.net/attachments/1/2/shot.png?width=320')
+  })
+
+  it('omits thumbnailUrl for a non-image attachment', () => {
+    const att = toDiscordAttachment({
+      id: 'a1',
+      name: 'doc.pdf',
+      contentType: 'application/pdf',
+      url: 'https://cdn.discordapp.com/attachments/1/2/doc.pdf',
+      proxyUrl: 'https://media.discordapp.net/attachments/1/2/doc.pdf'
+    })
+    expect(att?.thumbnailUrl).toBeUndefined()
+  })
+})

--- a/packages/message/test/attachment-thumbnails.test.ts
+++ b/packages/message/test/attachment-thumbnails.test.ts
@@ -67,4 +67,19 @@ describe('toDiscordAttachment thumbnailUrl', () => {
     })
     expect(att?.thumbnailUrl).toBeUndefined()
   })
+
+  it('preserves a signed proxy URL’s ex/is/hm query params when adding width', () => {
+    const att = toDiscordAttachment({
+      id: 'a1',
+      name: 'shot.png',
+      contentType: 'image/png',
+      url: 'https://cdn.discordapp.com/attachments/1/2/shot.png?ex=66b1&is=66af&hm=deadbeef&',
+      proxyUrl: 'https://media.discordapp.net/attachments/1/2/shot.png?ex=66b1&is=66af&hm=deadbeef&'
+    })
+    const url = new URL(att!.thumbnailUrl!)
+    expect(url.searchParams.get('width')).toBe('320')
+    expect(url.searchParams.get('ex')).toBe('66b1')
+    expect(url.searchParams.get('is')).toBe('66af')
+    expect(url.searchParams.get('hm')).toBe('deadbeef')
+  })
 })

--- a/packages/protocol/src/normalized-message.ts
+++ b/packages/protocol/src/normalized-message.ts
@@ -11,7 +11,12 @@ export const PlatformAttachmentSchema = z.object({
   name: z.string(),
   mimeType: z.string(),
   size: z.number().optional(),
-  sourceUrl: z.string()
+  sourceUrl: z.string(),
+  /** A smaller provider-rendered rendition (Slack thumb_*, a smaller Telegram
+   *  PhotoSize, a resized Discord proxy_url), when the provider offers one.
+   *  Console transcript rendering only — the agent's own prompt always gets
+   *  `sourceUrl`'s full-resolution bytes. */
+  thumbnailUrl: z.string().optional()
 })
 export type PlatformAttachment = z.infer<typeof PlatformAttachmentSchema>
 


### PR DESCRIPTION
## Summary

Implements the "Layer 1" fix proposed in #708: Slack, Telegram, and Discord
already hand out a smaller rendition of an image attachment (`thumb_360`/
`thumb_720`/`thumb_1024`, a smaller Telegram `PhotoSize`, a width-limited
Discord `proxy_url`). Normalization now carries that as an optional
`thumbnailUrl` alongside the full-resolution `sourceUrl`.

`hydrateTranscriptImage` (`packages/daemon/src/session/attachment-block.ts`)
still downloads the full image for the agent's own prompt block exactly as
before. Only when those full-res bytes don't fit the console history budget
(`WEBCHAT_IMAGE_MAX_BYTES` = 160 KiB) — the common case for a real
screenshot — does it fetch the smaller `thumbnailUrl` rendition as a
separate, transcript-only download (`Attachment.transcriptThumbnail`),
kept apart from `inlineData` so the agent never sees a downgraded image.

Feishu is unaffected (no provider thumbnail exists — see #708's own note),
and stays label-only pending Layer 2 (chunked `session/attachment` read).

## Changes

- `packages/protocol`: `PlatformAttachmentSchema` gains optional `thumbnailUrl`.
- `packages/message`: `toSlackAttachment`, `toTelegramPhotoAttachment`,
  `toDiscordAttachment` populate it from each provider's own smaller rendition.
- `packages/daemon`: `Attachment.transcriptThumbnail`, and
  `hydrateTranscriptImage`/`transcriptImageAttachments` prefer it for the
  transcript row when the full image is over budget.
- `discord/connection.ts` maps discord.js's `proxyURL` through.

## Test plan

- [x] `pnpm --filter @agentconnect.md/protocol typecheck`
- [x] `pnpm --filter @agentconnect.md/message typecheck`
- [x] `pnpm --filter @agentconnect.md/daemon typecheck`
- [x] `pnpm --filter @agentconnect.md/daemon build`
- [x] New unit tests: `packages/message/test/attachment-thumbnails.test.ts`
      (thumbnailUrl derivation per platform)
- [x] New unit tests in `packages/daemon/test/attachment-block.test.ts`
      (transcript falls back to the thumbnail only when needed; prompt block
      keeps full-res bytes)
- [x] `pnpm --filter @agentconnect.md/protocol --filter @agentconnect.md/message --filter @agentconnect.md/daemon test` (pre-existing failures in `acp-matrix.test.ts` — missing Gemini API key / unrelated live-runtime assertions — are unaffected by this change)

Fixes #708.