### PR TITLE
fix(daemon): deliver agent-initiated webchat turns to the live view (#753)

### DIFF
--- a/packages/daemon/src/cp/relay-client.ts
+++ b/packages/daemon/src/cp/relay-client.ts
@@ -249,10 +249,13 @@ export class RelayClient {
     }
     this.transport?.send(JSON.stringify(buildRelayDaemonFrame('rd/agentmsg/ack', ack, { corr: reqId })))
   }
-  /** One completed conversation post (fire-and-forget EVT). Sent on the same
-   *  socket the turn arrived on; a dead transport drops it — bounded loss, the
-   *  transcript row already exists on the authoring daemon. */
-  private sendWebchatPost(post: RdWebchatPost): void {
+  /** One completed conversation post (fire-and-forget EVT) — either on the socket the
+   *  triggering turn arrived on, or (agent-initiated turns, #753) broadcast by
+   *  {@link RelayManager.sendWebchatPost} to every relay this daemon holds, since none
+   *  of them is "the" socket for a wake with no browser turn of its own. A dead
+   *  transport drops it — bounded loss, the transcript row already exists on the
+   *  authoring daemon. */
+  sendWebchatPost(post: RdWebchatPost): void {
     this.transport?.send(JSON.stringify(buildRelayDaemonFrame('rd/webchat-post', post)))
   }
 

--- a/packages/daemon/src/cp/relay-manager.ts
+++ b/packages/daemon/src/cp/relay-manager.ts
@@ -9,7 +9,7 @@
  * daemon only does set-convergence — it never assumes the roster is the full relay
  * fleet — so future CP-side sharding is a CP-only change (§17 invariant).
  */
-import type { RelayRosterEntry, RdAgentMsg, RdAgentMsgAck } from '@agentconnect.md/protocol'
+import type { RelayRosterEntry, RdAgentMsg, RdAgentMsgAck, RdWebchatPost } from '@agentconnect.md/protocol'
 import { RelayClient, type RelayClientDeps } from './relay-client.js'
 
 export class RelayManager {
@@ -62,5 +62,18 @@ export class RelayManager {
       if (client.isReady()) return client.sendAgentMsg(payload)
     }
     throw new Error('no READY relay to route agent-call')
+  }
+
+  /**
+   * Fan a completed conversation post out to EVERY relay this daemon holds (#753) —
+   * unlike `sendAgentMsg`, there is no "the" relay for it: the browser socket for the
+   * conversation, and the roster cache used for peer-daemon context fan-out, may live
+   * on any one of them, and only that one will do anything with it. The rest no-op
+   * (`WebchatRouter.deliverPost` drops an unrecognized conversationId). Fire-and-forget.
+   */
+  sendWebchatPost(post: RdWebchatPost): void {
+    for (const client of this.clients.values()) {
+      if (client.isReady()) client.sendWebchatPost(post)
+    }
   }
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -17945,19 +17945,7 @@ export class Daemon {
     this.serialQueue.clear()
   }
 
-  /**
-   * §6.9 #353 startup replay: re-admit durably-persisted admitted-but-not-completed inbox rows
-   * through the SAME serial gate (`dispatch`), FIFO-by-sessionKey (rows come back ordered by
-   * (sessionKey, enqueuedAt), so order within a sessionKey is preserved and the gate keeps them
-   * serial). Runs once on start() after the store is open, agents are loaded into `this.agents`,
-   * and platform connections/crons are up (so a re-admitted turn has its reply transport), as
-   * normal inbound begins. Idempotency: a row whose id is already live in the gate (`liveInboxIds`)
-   * is skipped — dispatch re-appends the same id with INSERT OR IGNORE so no double row is written,
-   * and the re-admitted entry adopts the existing row for later removal. Rows for an agent that no
-   * longer exists on this daemon are SKIPPED + logged (the simplest choice — another owner/daemon
-   * may hold that agent; we neither drop the row nor block on it). Webchat turns were never
-   * persisted, so none appear here.
-   */
+  /** Re-admit durable inbox rows through the serial gate at startup while preserving replay ownership and FIFO. */
   private replayInbox(agentIds?: ReadonlySet<string>): void {
     let rows: InboxRow[]
     try {
@@ -18059,7 +18047,7 @@ export class Daemon {
         row.agentId,
         msg,
         row.integrationId ?? undefined,
-        undefined,
+        msg.source === 'agent' ? this.webchatWakeContext(msg.platform, msg.channel) : undefined,
         callMeta,
         {
           ...(row.isQueueCmd ? { isQueueCmd: true } : {}),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -828,6 +828,9 @@ const WEBCHAT_REPLAY_MAX_EVENTS = 256
 const WEBCHAT_REPLAY_MAX_BYTES = 1024 * 1024
 const WEBCHAT_REPLAY_MAX_STREAMS = 64
 const WEBCHAT_REPLAY_TTL_MS = 5 * 60_000
+/** A genuine webchat conversationId, as opposed to a synthetic `a2a:<agentId>` channel
+ *  (see `webchatWakeContext`). */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 /** Split `text` into pieces whose UTF-8 byte length each stays under WEBCHAT_CHUNK_BYTES
  *  so no single relay `rd/chat` payload exceeds the 256 KiB cap. Splits on byte budget
@@ -1587,6 +1590,11 @@ interface WebchatTurnContext {
    * relay can fan it to the other participants' daemons as context
    * (webchat-multi-agents.md §5.2). Absent on an older relay / synthetic turn. */
   postSink?: (post: RdWebchatPost) => void
+  /** Set only for a post-only wake context built by {@link webchatWakeContext}: an
+   *  agent-initiated turn inside a webchat conversation, with no browser turn of its
+   *  own to stream to (#753). Carried onto the completed `RdWebchatPost` so the
+   *  browser knows this reply never streamed live and needs rendering from the post. */
+  initiator?: 'agent'
   runtime?: WebchatRuntimeConfig
   worktree?: boolean
   /** Authority captured only from the relay's validated rd/msg envelope. It is
@@ -6878,6 +6886,37 @@ export class Daemon {
     return stream
   }
 
+  /**
+   * A post-only `WebchatTurnContext` for a turn that wakes an agent INSIDE a webchat
+   * conversation from another agent — `sendMessage`/lineage-reply, same-daemon or
+   * cross-daemon (#753). Such a wake has no browser turn of its own (no turnId, no
+   * `rd/chat` socket) to stream through, so `sink` is a no-op; only the
+   * completed-reply boundary needs a live transport, and `postSink` fans that out to
+   * every relay this daemon holds via {@link RelayManager.sendWebchatPost} (any relay
+   * without this conversation's browser connection or roster cache just drops it).
+   *
+   * `conversationId` must be the browser's real UUID chatId, not just any webchat-
+   * platform channel: `CpCollabRoutes.coordsDecision` never finds a webchat conversation
+   * "known" (the CP's collab snapshot has no notion of one), so a fresh `toAgent`+
+   * `channel` wake ALWAYS substitutes the synthetic, caller-derived `a2a:<callerId>`
+   * channel (`a2aCoordChannel`) regardless of what channel was asserted — that private
+   * pairwise session has no browser watching it at all. Only a REPLY routed back into an
+   * existing origin session (`origin.channel`/`local.channel`, read from the session row
+   * directly rather than re-derived through `coordsDecision`) can carry the genuine
+   * conversationId. `RdWebchatPost.conversationId` is schema-validated `.uuid()` too —
+   * this guard is what keeps a synthetic channel from ever reaching the wire.
+   */
+  private webchatWakeContext(platform: string, conversationId: string): WebchatTurnContext | undefined {
+    if (platform !== 'webchat' || !UUID_RE.test(conversationId)) return undefined
+    return {
+      conversationId,
+      turnId: randomUUID(),
+      sink: { output: () => undefined, done: () => undefined },
+      initiator: 'agent',
+      postSink: (post) => this.relays?.sendWebchatPost(post)
+    }
+  }
+
   /** Buffer before sending so a transport gap is recoverable even when the live
    * write is lost. The terminal frame carries the final output index for browser
    * gap detection. */
@@ -7896,7 +7935,13 @@ export class Daemon {
         // can answer in its own thread. A parent living on another daemon must not differ
         // from a local one, so neither branch stamps `headless` any more.
       }
-      void this.dispatch(msg.toAgentId, reply, replyIntegrationId, undefined, callMeta).catch((err) =>
+      void this.dispatch(
+        msg.toAgentId,
+        reply,
+        replyIntegrationId,
+        this.webchatWakeContext(origin.platform, origin.channel),
+        callMeta
+      ).catch((err) =>
         this.log.error(`relay lineage-reply dispatch failed for agent "${msg.toAgentId}": ${formatErr(err)}`)
       )
       this.log.info(
@@ -8015,9 +8060,14 @@ export class Daemon {
     // Fire-and-forget dispatch (P4-gate admission). delivered:true on ADMISSION — the
     // target processes the turn in its own time (§6.4). dispatch() drops the turn on a
     // pause/drain gate; a reason-typed NAK on those local gates is a follow-up.
-    void this.dispatch(msg.toAgentId, normalized, integrationId, undefined, callMeta, {
-      ...(pairingKey !== undefined ? { requireDurable: true } : {})
-    }).catch((err) => {
+    void this.dispatch(
+      msg.toAgentId,
+      normalized,
+      integrationId,
+      this.webchatWakeContext(platform, sessionChannel),
+      callMeta,
+      { ...(pairingKey !== undefined ? { requireDurable: true } : {}) }
+    ).catch((err) => {
       if (pairingKey !== undefined) this.store.releaseActivation(pairingKey)
       this.log.error(`relay agentmsg dispatch failed for agent "${msg.toAgentId}": ${formatErr(err)}`)
     })
@@ -8474,9 +8524,14 @@ export class Daemon {
       pairingKey = key
       callMeta.activationKey = key
     }
-    void this.dispatch(req.toAgentId, normalized, integrationId, undefined, callMeta, {
-      ...(pairingKey !== undefined ? { requireDurable: true } : {})
-    }).catch((err) => {
+    void this.dispatch(
+      req.toAgentId,
+      normalized,
+      integrationId,
+      this.webchatWakeContext(platform, coordChannel),
+      callMeta,
+      { ...(pairingKey !== undefined ? { requireDurable: true } : {}) }
+    ).catch((err) => {
       if (pairingKey !== undefined) this.store.releaseActivation(pairingKey)
       this.log.error(`messageAgent dispatch failed for agent "${req.toAgentId}": ${formatErr(err)}`)
     })
@@ -8635,11 +8690,18 @@ export class Daemon {
         isDm: false
       }
       let admission: { accepted: boolean; reason?: string } | undefined
-      const turn = this.dispatch(originOwner, normalized, integrationId, undefined, callMeta, {
-        onAdmission: (result) => {
-          admission = result
+      const turn = this.dispatch(
+        originOwner,
+        normalized,
+        integrationId,
+        this.webchatWakeContext(originPlatform, local.channel),
+        callMeta,
+        {
+          onAdmission: (result) => {
+            admission = result
+          }
         }
-      })
+      )
       void turn.catch((err) =>
         this.log.error(`replyToSession dispatch failed for session "${req.sessionId}": ${formatErr(err)}`)
       )
@@ -13263,7 +13325,8 @@ export class Daemon {
               author: { kind: 'agent', agentId },
               text: p.webchat.replyText,
               at: Number(replyTs)
-            }
+            },
+            ...(p.webchat.initiator ? { initiator: p.webchat.initiator } : {})
           })
         }
         if (!p.webchat.doneSent) {
@@ -13407,7 +13470,8 @@ export class Daemon {
               author: { kind: 'agent', agentId },
               text: p.webchat.replyText,
               at: Number(replyTs)
-            }
+            },
+            ...(p.webchat.initiator ? { initiator: p.webchat.initiator } : {})
           })
         }
       } else {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11498,23 +11498,13 @@ export class Daemon {
     })
   }
 
-  /**
-   * §6.9 #353 durable inbox: persist an ADMITTED entry BEFORE its admission ACK/return, so a
-   * hard kill / agent move can't lose a message the caller was already told delivered:true.
-   * Called ONLY on the two genuine admission branches in dispatch() (claim + enqueue), never
-   * on a rejected/gate-dropped admission — a queue-full or paused/draining drop persists
-   * nothing. WEBCHAT turns are skipped (§6.9 #367): their `sink` is a live in-memory transport
-   * that can't be restored across a restart and a dead browser socket can't be resumed, so a
-   * durable row would be un-replayable. Sets `entry.inboxId` so every terminal path can delete
-   * the row. Its id is the stable deliveryId or bot-scoped platform message id (§6.3), making
-   * same-bot re-appends idempotent without colliding across physical bots.
-   */
+  /** Persist an admitted replayable entry before its admission settles (§6.9 #353). */
   private persistInbox(
     entry: QueueEntry,
     key: string,
     options: { required?: boolean; adoptExisting?: boolean; existingId?: string } = {}
   ): 'inserted' | 'adopted' | 'existing' | 'skipped' | 'failed' {
-    if (entry.webchat) return 'skipped' // non-persistable live sink — see §6.9 #367
+    if (entry.webchat && entry.webchat.initiator !== 'agent') return 'skipped' // Browser-owned live sinks cannot replay.
     const id = options.existingId ?? entry.callMeta?.deliveryId ?? stableMessageId(entry.msg)
     try {
       const inserted = this.store.appendInbox({

--- a/packages/daemon/test/cp/relay-manager.test.ts
+++ b/packages/daemon/test/cp/relay-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { FakeClock, type Transport } from '@agentconnect.md/connection'
-import type { RdMsgWebchat } from '@agentconnect.md/protocol'
+import { buildRelayDaemonFrame, type RdMsgWebchat, type RelayDaemonFrame } from '@agentconnect.md/protocol'
 import { RelayManager } from '../../src/cp/relay-manager.js'
 import type { Logger } from '../../src/log.js'
 
@@ -10,6 +10,26 @@ const silentLog = { debug: () => {}, info: () => {}, warn: () => {}, error: () =
 function hangingConnect(): Promise<Transport> {
   return new Promise<Transport>(() => {})
 }
+
+/** A transport that captures every frame sent on it, for asserting a broadcast reached it. */
+class FakeTransport implements Transport {
+  readonly subprotocol = 'rd'
+  sent: RelayDaemonFrame[] = []
+  private msgCb?: (t: string) => void
+  onMessage(cb: (t: string) => void): void {
+    this.msgCb = cb
+  }
+  onClose(): void {}
+  close(): void {}
+  send(text: string): void {
+    this.sent.push(JSON.parse(text) as RelayDaemonFrame)
+  }
+  inject(frame: RelayDaemonFrame): void {
+    this.msgCb?.(JSON.stringify(frame))
+  }
+}
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
 
 function manager() {
   const connect = vi.fn(hangingConnect)
@@ -71,5 +91,76 @@ describe('RelayManager.converge', () => {
     mgr.converge([entry('r1', 'wss://r1')])
     await mgr.stop()
     expect(mgr.size()).toBe(0)
+  })
+})
+
+/** A manager whose relays actually complete the rd/hello handshake, so `isReady()` is
+ *  true and `sendWebchatPost` can broadcast onto their transports. */
+function readyManager() {
+  const transports = new Map<string, FakeTransport>()
+  const connect = vi.fn(async (url: string) => {
+    const t = new FakeTransport()
+    transports.set(url, t)
+    return t
+  })
+  const mgr = new RelayManager({
+    apiKey: () => 'k',
+    daemonId: () => 'daemon-1',
+    clock: new FakeClock(),
+    connect,
+    log: silentLog,
+    jitter: () => 0,
+    onRelayMsg: (msg: RdMsgWebchat) => ({ msgId: msg.msgId, accepted: true })
+  })
+  return { mgr, transports }
+}
+
+async function toReady(t: FakeTransport, relayId: string): Promise<void> {
+  await flush()
+  const hello = [...t.sent].reverse().find((f) => f.type === 'rd/hello')!
+  t.inject(buildRelayDaemonFrame('rd/hello/ok', { relayId }, { corr: hello.id }))
+  await flush()
+}
+
+const POST = {
+  conversationId: '11111111-1111-4111-8111-111111111111',
+  agentId: '22222222-2222-4222-8222-222222222222',
+  post: {
+    postId: '33333333-3333-4333-8333-333333333333',
+    conversationId: '11111111-1111-4111-8111-111111111111',
+    author: { kind: 'agent' as const, agentId: '22222222-2222-4222-8222-222222222222' },
+    text: 'hi',
+    at: 1
+  },
+  initiator: 'agent' as const
+}
+
+const RELAY_1 = '44444444-4444-4444-8444-444444444444'
+const RELAY_2 = '55555555-5555-4555-8555-555555555555'
+
+describe('RelayManager.sendWebchatPost (#753)', () => {
+  it('broadcasts to every READY relay — only the one holding this conversation acts on it', async () => {
+    const { mgr, transports } = readyManager()
+    mgr.converge([entry(RELAY_1, 'wss://r1'), entry(RELAY_2, 'wss://r2')])
+    await toReady(transports.get('wss://r1')!, RELAY_1)
+    await toReady(transports.get('wss://r2')!, RELAY_2)
+
+    mgr.sendWebchatPost(POST)
+
+    for (const url of ['wss://r1', 'wss://r2']) {
+      const frame = transports.get(url)!.sent.find((f) => f.type === 'rd/webchat-post')
+      expect(frame?.payload).toEqual(POST)
+    }
+  })
+
+  it('skips a relay that has not completed its handshake yet', async () => {
+    const { mgr, transports } = readyManager()
+    mgr.converge([entry(RELAY_1, 'wss://r1'), entry(RELAY_2, 'wss://r2')])
+    await toReady(transports.get('wss://r1')!, RELAY_1) // r2 left mid-handshake
+
+    mgr.sendWebchatPost(POST)
+
+    expect(transports.get('wss://r1')!.sent.some((f) => f.type === 'rd/webchat-post')).toBe(true)
+    expect(transports.get('wss://r2')!.sent.some((f) => f.type === 'rd/webchat-post')).toBe(false)
   })
 })

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -111,10 +111,10 @@ async function bootWithDispatchSpy(root: string) {
     channels: [{ orgId: TEST_ORG, platform: 'slack', channelId: 'C1', agents: localAgents }],
     agents: orgAgents
   })
-  const calls: { agentId: string; msg: any; integrationId?: string; callMeta?: any }[] = []
+  const calls: { agentId: string; msg: any; integrationId?: string; callMeta?: any; webchat?: any }[] = []
   ;(daemon as any).dispatch = vi.fn(
-    async (agentId: string, msg: any, integrationId?: string, _wc?: any, callMeta?: any, opts?: any) => {
-      calls.push({ agentId, msg, integrationId, callMeta })
+    async (agentId: string, msg: any, integrationId?: string, webchat?: any, callMeta?: any, opts?: any) => {
+      calls.push({ agentId, msg, integrationId, callMeta, webchat })
       opts?.onAdmission?.({ accepted: true })
       return 'acp-1'
     }
@@ -539,6 +539,25 @@ describe('messageAgent: same-daemon delivery', () => {
     const second = await call(baseReq({ platform: 'webchat', callerChannel: 'wc-1', channel: 'wc-9' }))
     expect(second.targetSession).toBe(first.targetSession)
     expect(calls).toHaveLength(2)
+    await daemon.stop()
+  })
+
+  // #753 regression: a fresh `toAgent`+`channel` wake from inside a webchat conversation
+  // lands on the synthetic `a2a:<callerId>` session above, not the browser's real
+  // conversation — no browser is watching that private pairwise session, so it must NOT
+  // get a live post-only webchat context (only a REPLY back into the real origin session
+  // should — see the replyToSession suite below).
+  it('a fresh webchat-originated wake gets no live post context — its target is the synthetic a2a session', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, calls, call } = await bootWithDispatchSpy(root)
+    const req = baseReq({
+      platform: 'webchat',
+      callerChannel: '11111111-1111-4111-8111-111111111111',
+      channel: '11111111-1111-4111-8111-111111111111'
+    })
+    expect(await call(req)).toMatchObject({ delivered: true })
+    expect(calls[0]!.msg.channel).toBe('a2a:bot-a') // confirms the synthetic substitution fired
+    expect(calls[0]!.webchat).toBeUndefined()
     await daemon.stop()
   })
 
@@ -1037,6 +1056,51 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     // The reply message carries the origin session's OWN coordinates, raw platform included.
     expect(calls[0]!.msg).toMatchObject({ platform: 'dream', channel: 'memory', thread: 'dream-1', source: 'agent' })
     expect(calls[0]!.callMeta).toMatchObject({ callFrom: 'bot-a', deliveryId: 'd-reply-1' })
+    await daemon.stop()
+  })
+
+  // #753: the cross-daemon analog of the replyToSession webchat test above — a lineage
+  // reply routed back into an existing webchat origin session carries that session's own
+  // real conversationId, so it gets a live post-only context; a FRESH cross-daemon wake
+  // into a webchat-platform coordinate does not (coordsDecision substitutes a2a:<caller>
+  // for it exactly as the same-daemon path does — see "a fresh webchat-originated wake…").
+  it('#753: a cross-daemon lineage reply into a real webchat origin session gets a live post-only context', async () => {
+    const root = scaffold([{ id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    withSnapshot(daemon)
+    const CONV = '66666666-6666-4666-8666-666666666666'
+    const originKey = sessionKey('webchat', CONV, `webchat:${CONV}`, 'bot-b')
+    ;(daemon as any).store.upsertSession({
+      key: originKey,
+      agentId: 'bot-b',
+      platform: 'webchat',
+      channel: CONV,
+      thread: `webchat:${CONV}`,
+      acpSessionId: 'acp-webchat-origin',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    const sendWebchatPost = vi.fn()
+    ;(daemon as any).relays = { stop: vi.fn(async () => {}), sendWebchatPost }
+
+    const ack = await (daemon as any).handleRelayAgentMsg(
+      fwd({
+        coords: { platform: 'webchat', channel: CONV },
+        lineageReplyTo: 'acp-webchat-origin',
+        deliveryId: 'd-reply-2'
+      })
+    )
+    expect(ack).toMatchObject({ delivered: true, childSessionId: originKey })
+    expect(calls).toHaveLength(1)
+    const wc = calls[0]!.webchat
+    expect(wc).toMatchObject({ conversationId: CONV, initiator: 'agent' })
+    wc.postSink({
+      conversationId: CONV,
+      agentId: 'bot-b',
+      post: { postId: 'p2', conversationId: CONV, author: { kind: 'agent', agentId: 'bot-b' }, text: 'hi', at: 1 }
+    })
+    expect(sendWebchatPost).toHaveBeenCalledTimes(1)
     await daemon.stop()
   })
 
@@ -1608,6 +1672,110 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
       nextAction: 'finish-turn-and-wait'
     })
     expect(status.message).toMatch(/next turn.*do not retry/i)
+    await daemon.stop()
+  })
+
+  // #753: a reply routed back into an EXISTING webchat origin session carries that
+  // session's own real conversationId (read off the session row, not re-derived through
+  // coordsDecision) — unlike a fresh wake, this DOES have a live browser to post to.
+  it('#753: a reply into a real webchat origin session gets a live post-only context', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    const CONV = '22222222-2222-4222-8222-222222222222'
+    ;(daemon as any).store.upsertSession({
+      key: sessionKey('webchat', CONV, `webchat:${CONV}`, 'bot-a'),
+      agentId: 'bot-a',
+      platform: 'webchat',
+      channel: CONV,
+      thread: `webchat:${CONV}`,
+      acpSessionId: 'acp-parent-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    const callerKey = sessionKey('slack', 'C2', '200.1', 'bot-b')
+    ;(daemon as any).store.upsertSession({
+      key: callerKey,
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C2',
+      thread: '200.1',
+      acpSessionId: 'acp-child-1',
+      state: 'prompting',
+      lastDeliveredTs: null,
+      updatedAt: Date.now(),
+      originSessionId: 'acp-parent-1',
+      needsParentReply: 1
+    })
+    armTurn(daemon, callerKey, {
+      callFrom: 'bot-a',
+      hopCount: 1,
+      deliveryId: 'd1',
+      originSessionId: 'acp-parent-1',
+      originCoords: { platform: 'webchat', channel: CONV }
+    })
+    const sendWebchatPost = vi.fn()
+    ;(daemon as any).relays = { stop: vi.fn(async () => {}), sendWebchatPost }
+
+    const res = await (daemon as any).replyToSession(replyReq())
+    expect(res.delivered).toBe(true)
+    expect(calls).toHaveLength(1)
+    const wc = calls[0]!.webchat
+    expect(wc).toMatchObject({ conversationId: CONV, initiator: 'agent' })
+    expect(typeof wc.postSink).toBe('function')
+    wc.postSink({
+      conversationId: CONV,
+      agentId: 'bot-a',
+      post: { postId: 'p1', conversationId: CONV, author: { kind: 'agent', agentId: 'bot-a' }, text: 'hi', at: 1 }
+    })
+    expect(sendWebchatPost).toHaveBeenCalledTimes(1)
+    await daemon.stop()
+  })
+
+  // #753: the origin session's channel can itself be a synthetic `a2a:<agentId>` pairwise
+  // session (a reply chain nested inside an earlier postless A2A call) — no browser was
+  // ever watching that channel, so the reply back into it must stay post-less too.
+  it('#753: a reply into a synthetic a2a origin session gets no live post context', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    const SYNTHETIC = 'a2a:bot-a'
+    ;(daemon as any).store.upsertSession({
+      key: sessionKey('webchat', SYNTHETIC, `webchat:${SYNTHETIC}`, 'bot-a'),
+      agentId: 'bot-a',
+      platform: 'webchat',
+      channel: SYNTHETIC,
+      thread: `webchat:${SYNTHETIC}`,
+      acpSessionId: 'acp-parent-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    const callerKey = sessionKey('slack', 'C2', '200.1', 'bot-b')
+    ;(daemon as any).store.upsertSession({
+      key: callerKey,
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C2',
+      thread: '200.1',
+      acpSessionId: 'acp-child-1',
+      state: 'prompting',
+      lastDeliveredTs: null,
+      updatedAt: Date.now(),
+      originSessionId: 'acp-parent-1',
+      needsParentReply: 1
+    })
+    armTurn(daemon, callerKey, {
+      callFrom: 'bot-a',
+      hopCount: 1,
+      deliveryId: 'd1',
+      originSessionId: 'acp-parent-1',
+      originCoords: { platform: 'webchat', channel: SYNTHETIC }
+    })
+
+    const res = await (daemon as any).replyToSession(replyReq())
+    expect(res.delivered).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.webchat).toBeUndefined()
     await daemon.stop()
   })
 

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -1215,4 +1215,76 @@ describe('daemon durable inbox', () => {
     expect(inbox(root)).toHaveLength(0)
     await daemon.stop()
   }, 15_000)
+
+  it('replays an agent-initiated webchat wake with its canonical live post sink', async () => {
+    const root = scaffold()
+    const conversationId = '99999999-9999-4999-8999-999999999999'
+    const deliveryId = 'replayed-agent-post'
+    const wake = {
+      msgId: `agentcall:${conversationId}:${deliveryId}`,
+      traceId: deliveryId,
+      source: 'agent' as const,
+      platform: 'webchat' as const,
+      channel: conversationId,
+      thread: `webchat:${conversationId}`,
+      sender: { id: 'bot-b', isBot: true },
+      text: 'recover this reply into the browser conversation',
+      mentionedBots: [] as string[],
+      isDm: false
+    }
+    const persisted = new LocalStore(statePath(root))
+    persisted.appendInbox({
+      id: deliveryId,
+      sessionKey: sessionKey('webchat', conversationId, `webchat:${conversationId}`, 'bot-a'),
+      agentId: 'bot-a',
+      msg: JSON.stringify(wake),
+      integrationId: null,
+      callMeta: JSON.stringify({ callFrom: 'bot-b', hopCount: 1, deliveryId }),
+      isQueueCmd: null,
+      enqueuedAt: '100'
+    })
+    persisted.close()
+
+    let onUpdate!: (sessionId: string, update: unknown) => void
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-replayed-webchat'),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sessionId: string) => {
+        onUpdate(sessionId, {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'recovered browser reply' }
+        })
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      root,
+      hostFactory: (_agent, update) => {
+        onUpdate = update
+        return host as any
+      }
+    })
+    const sendWebchatPost = vi.fn()
+    ;(daemon as any).relays = { sendWebchatPost, stop: vi.fn(async () => {}) }
+
+    await daemon.start()
+    await vi.waitFor(() => expect(sendWebchatPost).toHaveBeenCalledTimes(1), WAIT)
+    expect(sendWebchatPost).toHaveBeenCalledWith({
+      conversationId,
+      agentId: 'bot-a',
+      post: expect.objectContaining({
+        postId: expect.any(String),
+        conversationId,
+        author: { kind: 'agent', agentId: 'bot-a' },
+        text: 'recovered browser reply',
+        at: expect.any(Number)
+      }),
+      initiator: 'agent'
+    })
+    expect(inbox(root)).toHaveLength(0)
+    await daemon.stop()
+  }, 15_000)
 })

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -1180,4 +1180,39 @@ describe('daemon durable inbox', () => {
     // Still no webchat row after the head drained.
     expect(inbox(root).some((r) => r.id === 'slack:C1:200')).toBe(false)
   }, 15_000)
+
+  it('durably persists an agent-initiated post-only webchat wake', async () => {
+    const g = gatedHost()
+    const root = scaffold()
+    const daemon = await boot(root, g.host)
+    const conversationId = '88888888-8888-4888-8888-888888888888'
+    const deliveryId = 'agent-post-only'
+    const wake = {
+      msgId: `agentcall:${conversationId}:${deliveryId}`,
+      traceId: deliveryId,
+      source: 'agent' as const,
+      platform: 'webchat' as const,
+      channel: conversationId,
+      thread: `webchat:${conversationId}`,
+      sender: { id: 'bot-b', isBot: true },
+      text: 'reply into the browser conversation',
+      mentionedBots: [] as string[],
+      isDm: false
+    }
+    const turn = (daemon as any).dispatch(
+      'bot-a',
+      wake,
+      undefined,
+      (daemon as any).webchatWakeContext('webchat', conversationId),
+      { callFrom: 'bot-b', hopCount: 1, deliveryId }
+    )
+
+    await vi.waitFor(() => expect(g.started).toHaveLength(1), WAIT)
+    expect(inbox(root).map((row) => row.id)).toEqual([deliveryId])
+
+    g.releaseOne()
+    await expect(turn).resolves.toBe('acp-1')
+    expect(inbox(root)).toHaveLength(0)
+    await daemon.stop()
+  }, 15_000)
 })

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -696,7 +696,13 @@ export type RdChat = z.infer<typeof RdChat>
 export const RdWebchatPost = z.object({
   conversationId: z.string().uuid(),
   agentId: z.string().uuid(), // authoring participant (== post.author.agentId)
-  post: WebchatPost
+  post: WebchatPost,
+  // Set only when this turn had NO live rd/chat stream of its own — an agent
+  // waking another agent (or its own lineage reply) inside a webchat
+  // conversation (#753). The browser renders a post carrying this marker as a
+  // fresh transcript step; every other post is the canonical record of a
+  // reply it already rendered live and is dropped to avoid double-rendering.
+  initiator: z.literal('agent').optional()
 })
 export type RdWebchatPost = z.infer<typeof RdWebchatPost>
 

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -231,7 +231,7 @@ export class RelayBrowserConnection implements ChatSink {
    */
   onPost(p: RdWebchatPost): void {
     if (p.conversationId !== this.deps.chatId) return
-    this.send({ type: 'post', post: p.post })
+    this.send({ type: 'post', post: p.post, ...(p.initiator ? { initiator: p.initiator } : {}) })
   }
 
   private onText(text: string): void {

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -128,8 +128,13 @@ interface PlaygroundData {
    *  superseded regeneration keeps its author's lane open, so the indicator
    *  names the agent actually working, not the primary). */
   getBusyLaneAgentIds: (id: string) => string[]
-  /** Retire only optimistic turns confirmed by authoritative transcript rows. */
-  reconcileLiveSteps: (id: string, persisted: SessionMessageDto[], agentId: string) => void
+  /** Retire only live steps confirmed by authoritative transcript rows. */
+  reconcileLiveSteps: (
+    id: string,
+    persisted: SessionMessageDto[],
+    agentId: string,
+    promptRows?: SessionMessageDto[]
+  ) => void
 }
 
 /** One message waiting behind the in-flight turn. Send args are captured at
@@ -1357,18 +1362,21 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const getPgImage = useCallback((id: string) => pgImageBy[id], [pgImageBy])
   const isPgBusy = useCallback((id: string) => !!pgBusyBy[id], [pgBusyBy])
   const getLiveSteps = useCallback((id: string) => wcSteps[id] ?? NO_STEPS, [wcSteps])
-  const reconcileLiveSteps = useCallback((id: string, persisted: SessionMessageDto[], agentId: string): void => {
-    setWcSteps((cur) => {
-      const live = cur[id]
-      if (!live) return cur
-      const reconciled = reconcilePersistedLiveSteps(live, persisted, agentId)
-      if (reconciled === live) return cur
-      const next = { ...cur }
-      if (reconciled.length === 0) delete next[id]
-      else next[id] = reconciled
-      return next
-    })
-  }, [])
+  const reconcileLiveSteps = useCallback(
+    (id: string, persisted: SessionMessageDto[], agentId: string, promptRows?: SessionMessageDto[]): void => {
+      setWcSteps((cur) => {
+        const live = cur[id]
+        if (!live) return cur
+        const reconciled = reconcilePersistedLiveSteps(live, persisted, agentId, promptRows)
+        if (reconciled === live) return cur
+        const next = { ...cur }
+        if (reconciled.length === 0) delete next[id]
+        else next[id] = reconciled
+        return next
+      })
+    },
+    []
+  )
   const pgSessionList = useMemo(() => Object.values(pgSessions), [pgSessions])
 
   const value = useMemo<PlaygroundData>(

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -896,6 +896,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 pushStep(id, {
                   kind: 'done',
                   turnId: m.post.postId,
+                  // The daemon persists this reply before the post frame ever arrives, so
+                  // `postId` is what lets `reconcilePersistedLiveSteps` drop this step once
+                  // the canonical row lands in a later transcript refresh (#753) — text/time
+                  // matching (the prompt-turn heuristic) has nothing to anchor on here.
+                  postId: m.post.postId,
                   agentId,
                   ...(participantName(id, agentId) ? { who: participantName(id, agentId) } : {}),
                   text: m.post.text

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -243,6 +243,15 @@ type WebchatDone = {
   error?: string
 }
 
+/** One completed conversation post (mirrors protocol WebchatPost). Only rendered here
+ *  when its frame carries `initiator: 'agent'` (#753) — a user-authored post's reply
+ *  already streamed live via output/done and would double-render otherwise. */
+type WebchatPost = {
+  postId: string
+  author: { kind: 'user'; user?: string } | { kind: 'agent'; agentId: string }
+  text: string
+}
+
 /** One roster entry from the relay `ready` frame. */
 type WebchatParticipant = { agentId: string; primary?: boolean }
 
@@ -834,6 +843,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 output?: WebchatOutput
                 done?: WebchatDone
                 ack?: { accepted?: boolean; reason?: string; turnId?: string; agentId?: string }
+                post?: WebchatPost
+                initiator?: string
               }
               try {
                 m = JSON.parse(String(e.data))
@@ -877,6 +888,18 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 if (m.output) receiveOutput(id, m.output)
               } else if (m.type === 'done') {
                 if (m.done) receiveDone(id, m.done)
+              } else if (m.type === 'post' && m.initiator === 'agent' && m.post?.author.kind === 'agent') {
+                // Agent-initiated turn (another participant's sendMessage/lineage-reply
+                // wake, #753): it never streamed output/done to this socket, so the
+                // completed post IS its first and only rendering here.
+                const agentId = m.post.author.agentId
+                pushStep(id, {
+                  kind: 'done',
+                  turnId: m.post.postId,
+                  agentId,
+                  ...(participantName(id, agentId) ? { who: participantName(id, agentId) } : {}),
+                  text: m.post.text
+                })
               } else if (m.type === 'ack' && m.ack?.accepted !== false) {
                 let key = cursorKeyFor(id, m.ack?.agentId)
                 // The relay may target participants the client did not lane (a

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2041,10 +2041,7 @@ export default function SessionDetailView() {
         setConversationHasEarlier([...older.values()].some((cursor) => cursor !== null))
         setConversationLoadedKey(conversationKey)
         setConversationOffline(failed)
-        // #753: a peer participant's agent-initiated post lives only in ITS OWN
-        // session's rows, never the representative session's — reconcile against
-        // every source merged together, not just `sid`'s, or a peer's live post
-        // step never sees its own persisted confirmation.
+        // Exact post matching uses every participant row; fuzzy prompt matching stays representative-only.
         const merged = mergeConversationRows(
           sources,
           rowsBySession,
@@ -2059,7 +2056,8 @@ export default function SessionDetailView() {
         liveCursorRef.current = cursors.get(sid) ?? null
         tailReadyRef.current = true
         setTailReady(true)
-        if (merged.length > 0 && !sessionBusyRef.current) reconcileLiveSteps(sid, merged, aid)
+        if (merged.length > 0 && !sessionBusyRef.current)
+          reconcileLiveSteps(sid, merged, aid, rowsBySession.get(sid) ?? [])
       })().catch((e) => {
         if (!active) return
         setMsgErr(e instanceof Error ? e.message : String(e))
@@ -2161,10 +2159,7 @@ export default function SessionDetailView() {
         }
         if (tailSessionRef.current !== sid) return
         setConversationOffline(failed)
-        // #753: reconcile against every source merged together — a peer
-        // participant's agent-initiated post lives only in ITS OWN session's
-        // rows, never the representative session's (see the initial-load fan-out
-        // above for the full rationale).
+        // Exact post matching uses every participant row; fuzzy prompt matching stays representative-only.
         const merged = mergeConversationRows(
           sources,
           state.rows,
@@ -2175,7 +2170,7 @@ export default function SessionDetailView() {
         )
         setMsgs(merged)
         if (tailSessionRef.current === sid && !sessionBusyRef.current && fetchedAny)
-          reconcileLiveSteps(sid, merged, aid)
+          reconcileLiveSteps(sid, merged, aid, state.rows.get(sid) ?? [])
       })()
         .catch(() => {
           // Keep the last good transcript; the next signal retries.

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2041,23 +2041,25 @@ export default function SessionDetailView() {
         setConversationHasEarlier([...older.values()].some((cursor) => cursor !== null))
         setConversationLoadedKey(conversationKey)
         setConversationOffline(failed)
-        setMsgs(
-          mergeConversationRows(
-            sources,
-            rowsBySession,
-            conversationSourceSessionByMessageRef.current,
-            conversationSourceTurnByMessageRef.current,
-            conversationSourcePlatformByMessageRef.current,
-            conversationSourceAgentByMessageRef.current
-          )
+        // #753: a peer participant's agent-initiated post lives only in ITS OWN
+        // session's rows, never the representative session's — reconcile against
+        // every source merged together, not just `sid`'s, or a peer's live post
+        // step never sees its own persisted confirmation.
+        const merged = mergeConversationRows(
+          sources,
+          rowsBySession,
+          conversationSourceSessionByMessageRef.current,
+          conversationSourceTurnByMessageRef.current,
+          conversationSourcePlatformByMessageRef.current,
+          conversationSourceAgentByMessageRef.current
         )
+        setMsgs(merged)
         setMsgLoading(false)
         setMsgPaging(false)
         liveCursorRef.current = cursors.get(sid) ?? null
         tailReadyRef.current = true
         setTailReady(true)
-        const repRows = rowsBySession.get(sid)
-        if (repRows && !sessionBusyRef.current) reconcileLiveSteps(sid, repRows, aid)
+        if (merged.length > 0 && !sessionBusyRef.current) reconcileLiveSteps(sid, merged, aid)
       })().catch((e) => {
         if (!active) return
         setMsgErr(e instanceof Error ? e.message : String(e))
@@ -2127,11 +2129,11 @@ export default function SessionDetailView() {
       const sources = conversationMembersRef.current ?? []
       const run = (async () => {
         const state = conversationSourcesRef.current
-        const repRows: SessionMessageDto[] = []
         // Per-source isolation, mirroring the initial fan-out: one member's
         // daemon going offline mid-conversation must degrade THAT source to
         // the partial-merge notice, never stall the whole tail round.
         let failed = 0
+        let fetchedAny = false
         for (const src of sources) {
           try {
             let cursor = state.cursors.get(src.sessionId) ?? null
@@ -2146,7 +2148,7 @@ export default function SessionDetailView() {
                 src.sessionId,
                 mergeSessionMessages(current, page.messages, platformTranscriptOrdering(src.platform))
               )
-              if (src.sessionId === sid) repRows.push(...page.messages)
+              if (page.messages.length > 0) fetchedAny = true
               if (page.liveCursor !== null) {
                 cursor = page.liveCursor
                 state.cursors.set(src.sessionId, cursor)
@@ -2159,18 +2161,21 @@ export default function SessionDetailView() {
         }
         if (tailSessionRef.current !== sid) return
         setConversationOffline(failed)
-        setMsgs(
-          mergeConversationRows(
-            sources,
-            state.rows,
-            conversationSourceSessionByMessageRef.current,
-            conversationSourceTurnByMessageRef.current,
-            conversationSourcePlatformByMessageRef.current,
-            conversationSourceAgentByMessageRef.current
-          )
+        // #753: reconcile against every source merged together — a peer
+        // participant's agent-initiated post lives only in ITS OWN session's
+        // rows, never the representative session's (see the initial-load fan-out
+        // above for the full rationale).
+        const merged = mergeConversationRows(
+          sources,
+          state.rows,
+          conversationSourceSessionByMessageRef.current,
+          conversationSourceTurnByMessageRef.current,
+          conversationSourcePlatformByMessageRef.current,
+          conversationSourceAgentByMessageRef.current
         )
-        if (tailSessionRef.current === sid && !sessionBusyRef.current && repRows.length > 0)
-          reconcileLiveSteps(sid, repRows, aid)
+        setMsgs(merged)
+        if (tailSessionRef.current === sid && !sessionBusyRef.current && fetchedAny)
+          reconcileLiveSteps(sid, merged, aid)
       })()
         .catch(() => {
           // Keep the last good transcript; the next signal retries.

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -877,6 +877,12 @@ export interface SessionStep {
    *  steps where the owning participant's session differs from the row's
    *  primary `realSessionId`; the on-demand tool-body read targets it. */
   toolSessionId?: string
+  /** Canonical webchat post id (#753) — set on a live step rendered from an
+   *  agent-initiated `rd/webchat-post` frame, which has no preceding optimistic
+   *  `msg` prompt to anchor a turn-shaped reconciliation. `reconcilePersistedLiveSteps`
+   *  drops the step outright once a persisted row carries the same `postId`, from
+   *  ANY conversation participant's session — not just this step's own author. */
+  postId?: string
 }
 
 // Per-session token accounting (protocol `SessionUsage`), metered by the daemon.

--- a/packages/web/src/lib/session-transcript.test.ts
+++ b/packages/web/src/lib/session-transcript.test.ts
@@ -70,4 +70,58 @@ describe('reconcilePersistedLiveSteps', () => {
       live.slice(0, 2)
     )
   })
+
+  function persistedReply(seq: number, sender: string, text: string, ts: number, postId: string): SessionMessageDto {
+    return { seq, ts: String(ts), text, sender, kind: 'text', postId }
+  }
+
+  // #753: an agent-initiated post has no optimistic `msg` prompt to anchor a turn —
+  // it renders as a standalone step, identified only by its canonical postId.
+  it('drops a standalone agent-post step once ITS postId lands in a persisted row (adopted-conversation refresh)', () => {
+    const live = [
+      { kind: 'done', text: 'Sent "hello" to bot-b', agentId: 'bot-a', postId: 'post-1', observedAtMs: 1 }
+    ] satisfies SessionStep[]
+
+    expect(
+      reconcilePersistedLiveSteps(live, [persistedReply(1, 'bot-a', 'Sent "hello" to bot-b', 1, 'post-1')], agentId)
+    ).toEqual([])
+  })
+
+  it('keeps a standalone agent-post step whose postId has not been persisted yet', () => {
+    const live = [
+      { kind: 'done', text: 'Sent "hello" to bot-b', agentId: 'bot-a', postId: 'post-1', observedAtMs: 1 }
+    ] satisfies SessionStep[]
+
+    expect(
+      reconcilePersistedLiveSteps(live, [persistedReply(1, 'bot-a', 'unrelated', 1, 'post-other')], agentId)
+    ).toEqual(live)
+  })
+
+  // The reconciling view's OWN agent is "agent" here, but the confirming row belongs to
+  // a PEER participant's session (a merged multi-agent conversation, #753) — postId
+  // matching must not be gated by sender the way the prompt heuristic is.
+  it('drops a peer participant’s post confirmed by a row from that peer’s OWN session', () => {
+    const live = [
+      { kind: 'done', text: 'hi from bot-b', agentId: 'bot-b', postId: 'post-2', observedAtMs: 1 }
+    ] satisfies SessionStep[]
+
+    expect(
+      reconcilePersistedLiveSteps(live, [persistedReply(1, 'bot-b', 'hi from bot-b', 1, 'post-2')], agentId)
+    ).toEqual([])
+  })
+
+  it('reconciles a standalone post step and a prompt-anchored turn independently in the same refresh', () => {
+    const at = 1_785_000_000_000
+    const live = [
+      { kind: 'done', text: 'stale post', agentId: 'bot-a', postId: 'post-3', observedAtMs: at },
+      prompt('ship it', at + 1_000),
+      { kind: 'done', text: 'deployed', observedAtMs: at + 2_000 }
+    ] satisfies SessionStep[]
+
+    const persisted = [
+      persistedReply(1, 'bot-a', 'stale post', at, 'post-3'),
+      persistedPrompt(2, 'ship it', at + 1_050)
+    ]
+    expect(reconcilePersistedLiveSteps(live, persisted, agentId)).toEqual([])
+  })
 })

--- a/packages/web/src/lib/session-transcript.test.ts
+++ b/packages/web/src/lib/session-transcript.test.ts
@@ -71,6 +71,19 @@ describe('reconcilePersistedLiveSteps', () => {
     )
   })
 
+  it('does not confirm a failed prompt from a matching peer-agent row', () => {
+    const at = 1_785_000_000_000
+    const live = [
+      prompt('yes', at),
+      { kind: 'done', text: '⚠️ Could not reach the agent.', observedAtMs: at + 100 }
+    ] satisfies SessionStep[]
+    const peerRows = [
+      { seq: 1, ts: String(at + 50), text: 'yes', sender: 'bot-b', kind: 'text' }
+    ] satisfies SessionMessageDto[]
+
+    expect(reconcilePersistedLiveSteps(live, peerRows, agentId, [])).toEqual(live)
+  })
+
   function persistedReply(seq: number, sender: string, text: string, ts: number, postId: string): SessionMessageDto {
     return { seq, ts: String(ts), text, sender, kind: 'text', postId }
   }

--- a/packages/web/src/lib/session-transcript.ts
+++ b/packages/web/src/lib/session-transcript.ts
@@ -39,9 +39,14 @@ function promptKey(text: string, image?: SessionImage): string {
 }
 
 /**
- * Drop only adopted-WebChat turns whose optimistic user prompt has a matching,
- * newly persisted transcript row. Failed pre-admission turns have no such row
- * and therefore retain both the attempted prompt and its error feedback.
+ * Drop live steps a persisted refresh has superseded: an adopted-WebChat turn
+ * whose optimistic user prompt has a matching, newly persisted transcript row
+ * (fuzzy text+time match — a prompt carries no canonical id), and a standalone
+ * agent-initiated post step (#753) whose canonical `postId` now appears on ANY
+ * persisted row — an exact match, since that id is unique per post and shared
+ * verbatim across every participant's copy of it. Failed pre-admission turns
+ * have no persisted row at all and therefore retain both the attempted prompt
+ * and its error feedback.
  */
 export function reconcilePersistedLiveSteps(
   live: SessionStep[],
@@ -50,15 +55,20 @@ export function reconcilePersistedLiveSteps(
 ): SessionStep[] {
   if (live.length === 0 || persisted.length === 0) return live
 
+  const persistedPostIds = new Set(persisted.flatMap((m) => (m.postId ? [m.postId] : [])))
+  const withoutConfirmedPosts =
+    persistedPostIds.size === 0 ? live : live.filter((step) => !(step.postId && persistedPostIds.has(step.postId)))
+  if (withoutConfirmedPosts.length === 0) return withoutConfirmedPosts
+
   const turns: Array<{ start: number; end: number; key: string; observedAtMs: number }> = []
-  for (let start = 0; start < live.length;) {
-    if (live[start]!.kind !== 'msg') {
+  for (let start = 0; start < withoutConfirmedPosts.length;) {
+    if (withoutConfirmedPosts[start]!.kind !== 'msg') {
       start += 1
       continue
     }
     let end = start + 1
-    while (end < live.length && live[end]!.kind !== 'msg') end += 1
-    const prompt = live[start]!
+    while (end < withoutConfirmedPosts.length && withoutConfirmedPosts[end]!.kind !== 'msg') end += 1
+    const prompt = withoutConfirmedPosts[start]!
     if (prompt.observedAtMs != null && Number.isFinite(prompt.observedAtMs)) {
       turns.push({
         start,
@@ -69,7 +79,7 @@ export function reconcilePersistedLiveSteps(
     }
     start = end
   }
-  if (turns.length === 0) return live
+  if (turns.length === 0) return withoutConfirmedPosts
 
   const confirmed = new Set<number>()
   for (const message of persisted) {
@@ -89,12 +99,12 @@ export function reconcilePersistedLiveSteps(
     }
     if (bestTurn >= 0) confirmed.add(bestTurn)
   }
-  if (confirmed.size === 0) return live
+  if (confirmed.size === 0) return withoutConfirmedPosts
 
   const removed = new Set<number>()
   for (const index of confirmed) {
     const turn = turns[index]!
     for (let step = turn.start; step < turn.end; step++) removed.add(step)
   }
-  return live.filter((_, index) => !removed.has(index))
+  return withoutConfirmedPosts.filter((_, index) => !removed.has(index))
 }

--- a/packages/web/src/lib/session-transcript.ts
+++ b/packages/web/src/lib/session-transcript.ts
@@ -38,20 +38,12 @@ function promptKey(text: string, image?: SessionImage): string {
   return JSON.stringify([text, image?.name ?? null, image?.mimeType ?? null, image?.data ?? null])
 }
 
-/**
- * Drop live steps a persisted refresh has superseded: an adopted-WebChat turn
- * whose optimistic user prompt has a matching, newly persisted transcript row
- * (fuzzy text+time match — a prompt carries no canonical id), and a standalone
- * agent-initiated post step (#753) whose canonical `postId` now appears on ANY
- * persisted row — an exact match, since that id is unique per post and shared
- * verbatim across every participant's copy of it. Failed pre-admission turns
- * have no persisted row at all and therefore retain both the attempted prompt
- * and its error feedback.
- */
+/** Drop exact post duplicates from all rows and fuzzy prompt duplicates from prompt rows. */
 export function reconcilePersistedLiveSteps(
   live: SessionStep[],
   persisted: SessionMessageDto[],
-  agentId: string
+  agentId: string,
+  promptRows: SessionMessageDto[] = persisted
 ): SessionStep[] {
   if (live.length === 0 || persisted.length === 0) return live
 
@@ -82,7 +74,7 @@ export function reconcilePersistedLiveSteps(
   if (turns.length === 0) return withoutConfirmedPosts
 
   const confirmed = new Set<number>()
-  for (const message of persisted) {
+  for (const message of promptRows) {
     if (message.kind.toLowerCase() !== 'text' || message.sender === agentId) continue
     const persistedAtMs = transcriptRowTimeMs(message)
     if (persistedAtMs == null) continue


### PR DESCRIPTION
## Summary

Fixes #753 — agent-to-agent replies inside a webchat conversation (agent A messaging agent B, or B's lineage reply back into A's origin session) never appeared in the **live** browser view, only in history. The daemon had no live `rd/chat` stream for these turns and never emitted the canonical `rd/webchat-post` either.

- **protocol**: `RdWebchatPost` gains an optional `initiator: 'agent'` marker, backwards compatible.
- **daemon**: new `webchatWakeContext()` builds a post-only `WebchatTurnContext` (no-op sink, real `postSink`) for a wake whose target is a genuine live webchat conversation. This reuses the exact completion machinery (`appendWebchatTextRow`, `flushHeldWebchatText`, `postSink`) that real browser-initiated webchat turns already use, instead of the Slack-shaped renderer fallback that never posts live.
- **`RelayClient`/`RelayManager`**: `sendWebchatPost` is now public and broadcasts to every relay the daemon holds — there's no single "right" relay for a post with no originating socket (unlike `sendAgentMsg`, which just needs any ready relay).
- **relay**: forwards `initiator` through to the browser's `{type:'post'}` frame.
- **web**: `PlaygroundProvider` renders a transcript step only for posts marked `initiator:'agent'`, avoiding double-rendering of turns that already streamed live via output/done.

### A correctness wrinkle worth flagging to reviewers

`webchatWakeContext()` is guarded to only activate when the target conversationId is a real UUID. This matters because `CpCollabRoutes.coordsDecision` **always** substitutes a synthetic `a2a:<callerId>` channel for a fresh `sendMessage(toAgent, channel)` wake originating inside a webchat conversation — the CP's collaboration snapshot has no notion of webchat conversations as "known channels", so the wake never resolves to `verdict: 'asserted'`. That private pairwise `a2a:...` session has no browser watching it, so it must **not** get a live post. Only a *reply* routed back into an *existing* origin session (read directly off the session row, not re-derived through `coordsDecision`) carries the conversation's real UUID. Tests cover both cases (`daemon-message-agent.test.ts`).

## Test plan

- [x] `pnpm --filter @agentconnect.md/protocol typecheck && test` — 285 tests pass
- [x] `pnpm --filter @agentconnect.md/daemon typecheck && test` — 2870 tests pass (excluding the pre-existing, environment-gated `acp-matrix` live-provider suite, which needs a Gemini API key)
- [x] `pnpm --filter @agentconnect.md/relay typecheck && test` — 454 tests pass
- [x] `pnpm --filter @agentconnect.md/web typecheck && test` — 1003 tests pass
- [x] `pnpm lint` clean on all touched files
- [x] Added targeted regression tests: `RelayManager.sendWebchatPost` broadcast behavior, and both the "fresh wake → no live post" and "lineage reply → live post with the real conversationId" cases (same-daemon and cross-daemon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)