### PR TITLE
refactor(daemon): put an ACP spawn driver seam under AcpHost

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -1,6 +1,3 @@
-import { spawn, type ChildProcess } from 'node:child_process'
-import { existsSync, realpathSync } from 'node:fs'
-import { Readable, Writable } from 'node:stream'
 import {
   client as createClientApp,
   methods,
@@ -23,7 +20,6 @@ import {
   type McpTransportCapabilities
 } from '@agentconnect.md/protocol'
 import type { RuntimeDef } from '../config/config-schema.js'
-import { resolveCommandPath } from '../runtimes/probe.js'
 import {
   augmentClaudeEfforts,
   claudeInnerSandboxSettings,
@@ -32,7 +28,7 @@ import {
   type ClaudeProtectedSettings,
   ULTRACODE_EFFORT
 } from './claude-runtime.js'
-import { sandboxWrap, type SandboxMechanism } from './sandbox.js'
+import { LocalDriver, type AcpSandboxLaunch, type SpawnDriver, type SpawnedRuntime } from './spawn-driver.js'
 import type { Logger } from '../log.js'
 import { accountAppIsolation } from './account-apps.js'
 import { permissionPresetSettings, type SessionApprovalsReviewer } from './permission-modes.js'
@@ -153,26 +149,9 @@ export interface SessionConfigPrefs {
   systemPrompt?: string
 }
 
-export interface AcpSandboxLaunch {
-  mechanism: SandboxMechanism
-  writable: string[]
-  /** Common filesystem policy, consumed through SRT settings. */
-  denyReadRoots?: string[]
-  allowReadRoots?: string[]
-  /** Trusted SRT policy for ordinary ACP hosts. */
-  settingsPath?: string
-  /** Trusted working directory used to anchor SRT's Linux mandatory-deny scan. */
-  cwd?: string
-  /** Credential paths available to the trusted ACP runtime itself but denied to
-   * model-authored commands by a runtime-native nested sandbox. */
-  protectedCredentialRoots?: string[]
-  /** A deliberately exposed model-side Unix channel, currently gitcred.sock for
-   * GitHub App workspaces. Linux SRT cannot allow AF_UNIX by pathname. */
-  allowModelToolUnixSockets?: boolean
-  /** SDK flag settings that pin protected parent-only profile selection after
-   * Claude merges workspace-controlled settings. */
-  claudeProtectedSettings?: ClaudeProtectedSettings
-}
+// The launch shape lives with the driver that consumes it; re-exported here because
+// this module is where callers have always imported it from.
+export type { AcpSandboxLaunch, SpawnDriver, SpawnedRuntime } from './spawn-driver.js'
 
 /** The `session/set_config_option` call that applies a desired value, or the reason none is needed. */
 export type ConfigSelectionPlan = { configId: string; value: string } | { skip: string }
@@ -481,7 +460,7 @@ export function fastOptionFrom(configOptions: SessionConfigOption[] | null | und
 }
 
 export class AcpHost {
-  private child?: ChildProcess
+  private spawned?: SpawnedRuntime
   private conn?: ClientConnection
   // acpSessionIds this process created (or loaded). ACP sessions are in-memory in
   // the subprocess, so an id persisted across a daemon restart / host eviction is
@@ -585,6 +564,10 @@ export class AcpHost {
       /** Called once when the owned adapter process reaches terminal exit. The
        *  delegated host manager uses this to tear down its fenced cell. */
       onTerminal?: () => void
+      /** Where the runtime runs. Defaults to a child process of this daemon; a
+       *  cluster driver launches it in a sandbox pod and carries ACP over the
+       *  network, leaving everything below this line unchanged. */
+      driver?: SpawnDriver
       log?: Logger
     }
   ) {}
@@ -597,7 +580,7 @@ export class AcpHost {
   }
 
   async start(): Promise<void> {
-    if (this.child) throw new Error('AcpHost: already started')
+    if (this.spawned) throw new Error('AcpHost: already started')
     const env: NodeJS.ProcessEnv = {
       ...(this.opts.inheritProcessEnv === false ? {} : process.env),
       ...Object.fromEntries(this.runtime.env.map((e) => [e.name, e.value])),
@@ -623,80 +606,41 @@ export class AcpHost {
           `signed-in account apps/connectors may be inherited${detail}`
       )
     }
-    // The claude-agent-sdk resolves the Claude Code binary from its own bundled
-    // native package (an OPTIONAL npm dep, often missing under npx / --omit=optional)
-    // OR from `CLAUDE_CODE_EXECUTABLE`. If nothing set it but a `claude` CLI is on
-    // PATH, point at it so an out-of-the-box Claude Code install just works.
-    if (!env.CLAUDE_CODE_EXECUTABLE && this.isClaudeRuntime()) {
-      const claude = resolveCommandPath('claude', env)
-      if (claude) {
-        env.CLAUDE_CODE_EXECUTABLE = claude
-        this.opts.log?.info(`acp: CLAUDE_CODE_EXECUTABLE not set — using claude on PATH (${claude})`)
-      }
-    }
     // NOTE: the memory-backend env (disable the runtime's own memory for `managed`,
     // or redirect it under the private runtime HOME for `native`) is assembled by the daemon
     // in ensureHost via memoryProviderFor(agent).runtimeEnv() and passed in through
     // `opts.env` — it is NOT set here, so it stays per-agent-configurable. The
     // runtime prober / chat CLI construct AcpHost without that env and therefore get
     // the runtime's default memory behavior.
-    // Resolve the command through resolveCommandPath so spawn gets an absolute path
-    // (or a path-qualified relative one for auto-downloaded archives). This handles
-    // ACP registry binary commands with a `./` prefix ("./opencode", "./goose", …)
-    // that spawn() would otherwise resolve only against CWD and miss the binary on
-    // `$PATH`. Falls back to the raw command when resolution fails (spawn's own error
-    // surface is clearer than a synthetic ours).
-    const resolvedCommand = resolveCommandPath(this.runtime.command, env) ?? this.runtime.command
-    const resolved = this.opts.sandbox && existsSync(resolvedCommand) ? realpathSync(resolvedCommand) : resolvedCommand
     // appendArgs carries any account-app-isolation flags (e.g. Copilot's
     // --disable-builtin-mcps) that must reach the adapter as CLI args.
     const spawnArgs = [...this.runtime.args, ...(isolateAccountApps ? appIsolation.appendArgs : [])]
-    // Linux SRT sandbox (issue #312). Fail-open — ensureHost only sets
-    // opts.sandbox after a live probe, so no mechanism means the adapter runs
-    // unconfined unless daemon policy required sandboxing and refused startup.
-    const launch = this.opts.sandbox
-      ? sandboxWrap(resolved, spawnArgs, this.opts.sandbox)
-      : { cmd: resolved, args: spawnArgs }
-    const child = spawn(launch.cmd, launch.args, {
-      stdio: ['pipe', 'pipe', this.opts.suppressChildStderr ? 'ignore' : 'inherit'],
-      env,
-      // Own process group (POSIX): a foreground daemon's Ctrl-C sends SIGINT to the
-      // whole terminal group, which killed adapters out from under the graceful
-      // drain; and stop()'s escalation must reach the full tree — npx-distributed
-      // runtimes run the real adapter as a grandchild of the npm wrapper, and
-      // SIGKILLing just the wrapper orphans the adapter. The group id (= child pid)
-      // lets stop() signal wrapper + adapter + their children in one kill.
-      detached: process.platform !== 'win32'
+    const driver = this.opts.driver ?? new LocalDriver({ log: this.opts.log })
+    const spawned = await driver.launch({
+      command: this.runtime.command,
+      args: spawnArgs,
+      env: env as Record<string, string>,
+      // The claude-agent-sdk resolves the Claude Code binary from its own bundled
+      // native package (an OPTIONAL npm dep, often missing under npx / --omit=optional)
+      // OR from `CLAUDE_CODE_EXECUTABLE`. If nothing set it but a `claude` CLI is on
+      // PATH, point at it so an out-of-the-box Claude Code install just works. The
+      // lookup belongs to the driver: only it knows the filesystem the runtime sees.
+      ...(this.isClaudeRuntime() ? { hints: [{ envVar: 'CLAUDE_CODE_EXECUTABLE', command: 'claude' }] } : {}),
+      ...(this.opts.suppressChildStderr !== undefined ? { suppressChildStderr: this.opts.suppressChildStderr } : {}),
+      ...(this.opts.sandbox ? { sandbox: this.opts.sandbox } : {})
     })
-    this.child = child
-    child.once('exit', () => {
-      // Sweep group survivors (an adapter orphaned by its npx wrapper's death) NOW:
-      // moments after the leader exits its pgid cannot have been recycled — a pgid
-      // stays reserved while any member lives — so this can never hit a stranger.
-      // A later sweep could (pid reuse), which is why stop() never signals a child
-      // it found already dead. Clearing the handle also lets stop() early-return
-      // instead of waiting on an 'exit' that already fired.
-      if (child.pid && process.platform !== 'win32') {
-        try {
-          process.kill(-child.pid, 'SIGTERM')
-        } catch {
-          /* group already empty */
-        }
-      }
-      if (this.child === child) this.child = undefined
+    this.spawned = spawned
+    spawned.onExit(() => {
+      // Clearing the handle lets stop() early-return instead of waiting on an exit
+      // that already fired.
+      if (this.spawned === spawned) this.spawned = undefined
       try {
         this.opts.onTerminal?.()
       } catch (err) {
         this.opts.log?.debug(`acp: terminal observer failed: ${(err as Error).message}`)
       }
     })
-
-    if (!child.stdin || !child.stdout) {
-      throw new Error('AcpHost: subprocess stdin/stdout are not piped')
-    }
-    const toAgent = Writable.toWeb(child.stdin) as WritableStream<Uint8Array>
-    const fromAgent = Readable.toWeb(child.stdout) as unknown as ReadableStream<Uint8Array>
-    const stream = ndJsonStream(toAgent, fromAgent)
+    const stream = ndJsonStream(spawned.toAgent, spawned.fromAgent)
 
     const self = this
     // fs read/write handlers are intentionally omitted (we advertise fs:false);
@@ -1174,55 +1118,9 @@ export class AcpHost {
    *  Idempotent — the child handle is cleared up front so a concurrent stop (drain
    *  + reconcile racing) is a no-op rather than a double-kill. */
   async stop(deadlineMs = 5000): Promise<void> {
-    const child = this.child
-    if (!child) return
-    this.child = undefined
-    // Group signal when the child has its own group (detached spawn); fall back to
-    // the direct child on win32 or once the group is gone (ESRCH).
-    const kill = (sig: NodeJS.Signals) => {
-      if (child.pid && process.platform !== 'win32') {
-        try {
-          process.kill(-child.pid, sig)
-          return
-        } catch {
-          /* group already gone — try the direct child */
-        }
-      }
-      child.kill(sig)
-    }
-    // A child that already exited on its own has emitted 'exit' already: once('exit')
-    // below would never fire and stop() would hang the daemon forever, kill() being a
-    // no-op on a reaped pid. No group sweep here — the child may have been dead for
-    // minutes (idle sweep cadence) and its pgid recycled to an unrelated process;
-    // the spawn-time 'exit' listener already swept while the pgid was provably ours.
-    if (child.exitCode !== null || child.signalCode !== null) return
-    // Graceful first: ACP is a stdio protocol, EOF on stdin is the idiomatic "we're
-    // done" and propagates through an npx wrapper to the adapter. The web-stream
-    // wrapper may hold the pipe locked mid-write — then the signals below still land.
-    try {
-      child.stdin?.end()
-    } catch {
-      /* stream locked/destroyed — signals still land */
-    }
-    kill('SIGTERM')
-    await new Promise<void>((resolve) => {
-      let settled = false
-      let killFailsafe: NodeJS.Timeout | undefined
-      const done = () => {
-        if (settled) return
-        settled = true
-        clearTimeout(timer)
-        clearTimeout(killFailsafe)
-        resolve()
-      }
-      const timer = setTimeout(() => {
-        this.opts.log?.warn(`acp: child ignored SIGTERM after ${deadlineMs}ms — sending SIGKILL`)
-        kill('SIGKILL')
-        // SIGKILL on a live child always ends in 'exit'; the failsafe only covers a
-        // kill with nothing left to hit, so stop() resolves no matter what.
-        killFailsafe = setTimeout(done, 2000)
-      }, deadlineMs)
-      child.once('exit', done)
-    })
+    const spawned = this.spawned
+    if (!spawned) return
+    this.spawned = undefined
+    await spawned.stop(deadlineMs)
   }
 }

--- a/packages/daemon/src/acp/spawn-driver.ts
+++ b/packages/daemon/src/acp/spawn-driver.ts
@@ -1,0 +1,202 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync, realpathSync } from 'node:fs'
+import { Readable, Writable } from 'node:stream'
+import { resolveCommandPath } from '../runtimes/probe.js'
+import { sandboxWrap, type SandboxMechanism } from './sandbox.js'
+import type { ClaudeProtectedSettings } from './claude-runtime.js'
+import type { Logger } from '../log.js'
+
+export interface AcpSandboxLaunch {
+  mechanism: SandboxMechanism
+  writable: string[]
+  /** Common filesystem policy, consumed through SRT settings. */
+  denyReadRoots?: string[]
+  allowReadRoots?: string[]
+  /** Trusted SRT policy for ordinary ACP hosts. */
+  settingsPath?: string
+  /** Trusted working directory used to anchor SRT's Linux mandatory-deny scan. */
+  cwd?: string
+  /** Credential paths available to the trusted ACP runtime itself but denied to
+   * model-authored commands by a runtime-native nested sandbox. */
+  protectedCredentialRoots?: string[]
+  /** A deliberately exposed model-side Unix channel, currently gitcred.sock for
+   * GitHub App workspaces. Linux SRT cannot allow AF_UNIX by pathname. */
+  allowModelToolUnixSockets?: boolean
+  /** SDK flag settings that pin protected parent-only profile selection after
+   * Claude merges workspace-controlled settings. */
+  claudeProtectedSettings?: ClaudeProtectedSettings
+}
+
+/**
+ * One env pointer the runtime needs filled with an executable path, resolved in
+ * the TARGET's filesystem rather than the daemon's. Only applied when the caller
+ * left the variable unset.
+ */
+export interface ExecutableHint {
+  envVar: string
+  command: string
+}
+
+export interface SpawnRequest {
+  command: string
+  args: string[]
+  /** The complete child environment; the driver adds nothing but resolved hints. */
+  env: Record<string, string>
+  hints?: ExecutableHint[]
+  /** Disposable probes suppress raw stderr so a harness cannot print credential
+   *  material or host paths outside our sanitizer. */
+  suppressChildStderr?: boolean
+  /** OS sandbox for the agent process (issue #312). Absent ⇒ run unconfined. */
+  sandbox?: AcpSandboxLaunch
+}
+
+/** A launched ACP runtime, reduced to what the protocol layer actually needs. */
+export interface SpawnedRuntime {
+  /** ND-JSON byte streams carrying ACP in both directions. */
+  toAgent: WritableStream<Uint8Array>
+  fromAgent: ReadableStream<Uint8Array>
+  /** Fires once when the runtime reaches terminal exit on its own. */
+  onExit(listener: () => void): void
+  /** Graceful stop escalating past the deadline. Safe to call on a dead target. */
+  stop(deadlineMs: number): Promise<void>
+}
+
+/**
+ * Where an ACP runtime runs. `LocalDriver` is a child process on this host; a
+ * cluster driver launches it in a sandbox pod and carries ACP over the network.
+ * The seam is deliberately narrow — the protocol layer wants a byte stream pair
+ * and a lifecycle, and everything filesystem- or process-shaped lives below it.
+ */
+export interface SpawnDriver {
+  launch(request: SpawnRequest): Promise<SpawnedRuntime>
+}
+
+/** The ACP runtime as a child process of this daemon: today's only behavior. */
+export class LocalDriver implements SpawnDriver {
+  constructor(private opts: { log?: Logger } = {}) {}
+
+  async launch(request: SpawnRequest): Promise<SpawnedRuntime> {
+    const env = { ...request.env }
+    for (const hint of request.hints ?? []) {
+      if (env[hint.envVar]) continue
+      const resolved = resolveCommandPath(hint.command, env)
+      if (!resolved) continue
+      env[hint.envVar] = resolved
+      this.opts.log?.info(`acp: ${hint.envVar} not set — using ${hint.command} on PATH (${resolved})`)
+    }
+    // Resolve the command to an absolute path (or a path-qualified relative one for
+    // auto-downloaded archives), so ACP registry binary commands with a `./` prefix
+    // ("./opencode", "./goose", …) are not resolved against CWD only and missed on
+    // `$PATH`. Falls back to the raw command when resolution fails — spawn's own
+    // error surface is clearer than a synthetic one.
+    const resolvedCommand = resolveCommandPath(request.command, env) ?? request.command
+    const resolved = request.sandbox && existsSync(resolvedCommand) ? realpathSync(resolvedCommand) : resolvedCommand
+    // Linux SRT sandbox (issue #312). Fail-open — ensureHost only sets sandbox after a
+    // live probe, so no mechanism means the adapter runs unconfined unless daemon
+    // policy required sandboxing and refused startup.
+    const launch = request.sandbox
+      ? sandboxWrap(resolved, request.args, request.sandbox)
+      : { cmd: resolved, args: request.args }
+    const child = spawn(launch.cmd, launch.args, {
+      stdio: ['pipe', 'pipe', request.suppressChildStderr ? 'ignore' : 'inherit'],
+      env,
+      // Own process group (POSIX): a foreground daemon's Ctrl-C sends SIGINT to the
+      // whole terminal group, which killed adapters out from under the graceful
+      // drain; and stop()'s escalation must reach the full tree — npx-distributed
+      // runtimes run the real adapter as a grandchild of the npm wrapper, and
+      // SIGKILLing just the wrapper orphans the adapter. The group id (= child pid)
+      // lets stop() signal wrapper + adapter + their children in one kill.
+      detached: process.platform !== 'win32'
+    })
+    child.once('exit', () => {
+      // Sweep group survivors (an adapter orphaned by its npx wrapper's death) NOW:
+      // moments after the leader exits its pgid cannot have been recycled — a pgid
+      // stays reserved while any member lives — so this can never hit a stranger.
+      // A later sweep could (pid reuse), which is why stop() never signals a child
+      // it found already dead.
+      if (child.pid && process.platform !== 'win32') {
+        try {
+          process.kill(-child.pid, 'SIGTERM')
+        } catch {
+          /* group already empty */
+        }
+      }
+    })
+
+    if (!child.stdin || !child.stdout) {
+      throw new Error('AcpHost: subprocess stdin/stdout are not piped')
+    }
+    return new LocalSpawnedRuntime(child, this.opts.log)
+  }
+}
+
+class LocalSpawnedRuntime implements SpawnedRuntime {
+  readonly toAgent: WritableStream<Uint8Array>
+  readonly fromAgent: ReadableStream<Uint8Array>
+  private stopped = false
+
+  constructor(
+    private child: ChildProcess,
+    private log?: Logger
+  ) {
+    this.toAgent = Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>
+    this.fromAgent = Readable.toWeb(child.stdout!) as unknown as ReadableStream<Uint8Array>
+  }
+
+  onExit(listener: () => void): void {
+    this.child.once('exit', listener)
+  }
+
+  async stop(deadlineMs: number): Promise<void> {
+    if (this.stopped) return
+    this.stopped = true
+    const child = this.child
+    // Group signal when the child has its own group (detached spawn); fall back to
+    // the direct child on win32 or once the group is gone (ESRCH).
+    const kill = (sig: NodeJS.Signals) => {
+      if (child.pid && process.platform !== 'win32') {
+        try {
+          process.kill(-child.pid, sig)
+          return
+        } catch {
+          /* group already gone — try the direct child */
+        }
+      }
+      child.kill(sig)
+    }
+    // A child that already exited on its own has emitted 'exit' already: once('exit')
+    // below would never fire and stop() would hang the daemon forever, kill() being a
+    // no-op on a reaped pid. No group sweep here — the child may have been dead for
+    // minutes (idle sweep cadence) and its pgid recycled to an unrelated process;
+    // the spawn-time 'exit' listener already swept while the pgid was provably ours.
+    if (child.exitCode !== null || child.signalCode !== null) return
+    // Graceful first: ACP is a stdio protocol, EOF on stdin is the idiomatic "we're
+    // done" and propagates through an npx wrapper to the adapter. The web-stream
+    // wrapper may hold the pipe locked mid-write — then the signals below still land.
+    try {
+      child.stdin?.end()
+    } catch {
+      /* stream locked/destroyed — signals still land */
+    }
+    kill('SIGTERM')
+    await new Promise<void>((resolve) => {
+      let settled = false
+      let killFailsafe: NodeJS.Timeout | undefined
+      const done = () => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        clearTimeout(killFailsafe)
+        resolve()
+      }
+      const timer = setTimeout(() => {
+        this.log?.warn(`acp: child ignored SIGTERM after ${deadlineMs}ms — sending SIGKILL`)
+        kill('SIGKILL')
+        // SIGKILL on a live child always ends in 'exit'; the failsafe only covers a
+        // kill with nothing left to hit, so stop() resolves no matter what.
+        killFailsafe = setTimeout(done, 2000)
+      }, deadlineMs)
+      child.once('exit', done)
+    })
+  }
+}

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -579,7 +579,8 @@ describe('AcpHost.stop', () => {
     // Kill the child out from under the host — the terminal delivering SIGINT to
     // the whole foreground process group does exactly this — and wait until its
     // 'exit' has actually been emitted, so stop() runs against a reaped child.
-    const child = (host as unknown as { child: import('node:child_process').ChildProcess }).child
+    // The process handle now lives in the local spawn driver's launched target.
+    const child = (host as unknown as { spawned: { child: import('node:child_process').ChildProcess } }).spawned.child
     await new Promise<void>((resolve) => {
       child.once('exit', () => resolve())
       child.kill('SIGKILL')

--- a/packages/daemon/test/spawn-driver.test.ts
+++ b/packages/daemon/test/spawn-driver.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { AcpHost } from '../src/acp/acp-host.js'
+import type { SpawnDriver, SpawnRequest, SpawnedRuntime } from '../src/acp/spawn-driver.js'
+
+/**
+ * The seam's whole purpose: `AcpHost` speaks ACP over a byte-stream pair and a
+ * lifecycle, with no knowledge of where the runtime runs. This drives it with an
+ * in-memory ACP agent and no process anywhere — the same shape a cluster driver
+ * will present when the runtime lives in a sandbox pod.
+ */
+
+interface Rpc {
+  id?: number
+  method?: string
+  params?: any
+}
+
+/** A minimal in-memory ACP agent wired to a `SpawnedRuntime` stream pair. */
+function inMemoryRuntime(): { runtime: SpawnedRuntime; stopCalls: number[] } {
+  const toAgentChunks = new TransformStream<Uint8Array, Uint8Array>()
+  const fromAgent = new TransformStream<Uint8Array, Uint8Array>()
+  const writer = fromAgent.writable.getWriter()
+  const encoder = new TextEncoder()
+  const send = (message: unknown) => writer.write(encoder.encode(`${JSON.stringify(message)}\n`))
+  const stopCalls: number[] = []
+  const exitListeners: Array<() => void> = []
+  let sessions = 0
+
+  void (async () => {
+    const decoder = new TextDecoder()
+    let buffered = ''
+    for await (const chunk of toAgentChunks.readable as unknown as AsyncIterable<Uint8Array>) {
+      buffered += decoder.decode(chunk, { stream: true })
+      const lines = buffered.split('\n')
+      buffered = lines.pop() ?? ''
+      for (const line of lines) {
+        if (!line.trim()) continue
+        const rpc = JSON.parse(line) as Rpc
+        if (rpc.id === undefined) continue // notification
+        if (rpc.method === 'initialize') {
+          await send({
+            jsonrpc: '2.0',
+            id: rpc.id,
+            result: {
+              protocolVersion: 1,
+              agentCapabilities: { loadSession: false },
+              agentInfo: { name: 'in-memory', version: '0.0.0' }
+            }
+          })
+        } else if (rpc.method === 'session/new') {
+          await send({ jsonrpc: '2.0', id: rpc.id, result: { sessionId: `mem-${++sessions}` } })
+        } else if (rpc.method === 'session/prompt') {
+          const sessionId = rpc.params?.sessionId
+          await send({
+            jsonrpc: '2.0',
+            method: 'session/update',
+            params: {
+              sessionId,
+              update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'from-memory' } }
+            }
+          })
+          await send({ jsonrpc: '2.0', id: rpc.id, result: { stopReason: 'end_turn' } })
+        } else {
+          await send({ jsonrpc: '2.0', id: rpc.id, error: { code: -32601, message: `no ${rpc.method}` } })
+        }
+      }
+    }
+  })()
+
+  const runtime: SpawnedRuntime = {
+    toAgent: toAgentChunks.writable,
+    fromAgent: fromAgent.readable,
+    onExit: (listener) => exitListeners.push(listener),
+    stop: async (deadlineMs) => {
+      stopCalls.push(deadlineMs)
+      for (const listener of exitListeners.splice(0)) listener()
+    }
+  }
+  return { runtime, stopCalls }
+}
+
+class InMemoryDriver implements SpawnDriver {
+  requests: SpawnRequest[] = []
+  constructor(private target: SpawnedRuntime) {}
+  async launch(request: SpawnRequest): Promise<SpawnedRuntime> {
+    this.requests.push(request)
+    return this.target
+  }
+}
+
+describe('SpawnDriver seam', () => {
+  it('runs a full ACP turn against a driver that owns no process', async () => {
+    const { runtime, stopCalls } = inMemoryRuntime()
+    const driver = new InMemoryDriver(runtime)
+    const updates: string[] = []
+    const host = new AcpHost(
+      { command: 'irrelevant', args: ['--acp'], env: [{ name: 'FROM_RUNTIME_DEF', value: 'yes' }] },
+      {
+        driver,
+        onUpdate: (_sessionId, update) => {
+          if (update.sessionUpdate === 'agent_message_chunk' && (update as any).content?.type === 'text') {
+            updates.push((update as any).content.text)
+          }
+        }
+      }
+    )
+
+    await host.start()
+    const sessionId = await host.newSession('/tmp')
+    const result = await host.prompt(sessionId, [{ type: 'text', text: 'hello' }])
+
+    expect(result.stopReason).toBe('end_turn')
+    expect(updates).toContain('from-memory')
+    // The driver receives the assembled launch, not a pre-resolved local command:
+    // resolving it against a filesystem is the driver's job, since only it knows
+    // which filesystem the runtime will see.
+    expect(driver.requests).toHaveLength(1)
+    expect(driver.requests[0]?.command).toBe('irrelevant')
+    expect(driver.requests[0]?.args).toEqual(['--acp'])
+    expect(driver.requests[0]?.env.FROM_RUNTIME_DEF).toBe('yes')
+
+    await host.stop(1234)
+    expect(stopCalls).toEqual([1234])
+  }, 15_000)
+
+  it('refuses a second start and reports terminal exit through the driver', async () => {
+    const { runtime } = inMemoryRuntime()
+    let terminal = 0
+    const host = new AcpHost(
+      { command: 'irrelevant', args: [], env: [] },
+      { driver: new InMemoryDriver(runtime), onUpdate: () => {}, onTerminal: () => terminal++ }
+    )
+    await host.start()
+    await expect(host.start()).rejects.toThrow(/already started/)
+
+    // The driver, not AcpHost, decides when the target is gone; AcpHost drops its
+    // handle so a later stop() is a no-op rather than a wait on a dead target.
+    await host.stop(10)
+    expect(terminal).toBe(1)
+    await host.stop(10)
+    expect(terminal).toBe(1)
+  }, 15_000)
+
+  it('asks the driver to resolve executable hints only for Claude runtimes', async () => {
+    const claude = new InMemoryDriver(inMemoryRuntime().runtime)
+    const claudeHost = new AcpHost(
+      { command: 'claude-code-acp', args: [], env: [] },
+      { driver: claude, onUpdate: () => {} }
+    )
+    await claudeHost.start()
+    expect(claude.requests[0]?.hints).toEqual([{ envVar: 'CLAUDE_CODE_EXECUTABLE', command: 'claude' }])
+    await claudeHost.stop(10)
+
+    const other = new InMemoryDriver(inMemoryRuntime().runtime)
+    const otherHost = new AcpHost({ command: 'codex-acp', args: [], env: [] }, { driver: other, onUpdate: () => {} })
+    await otherHost.start()
+    expect(other.requests[0]?.hints).toBeUndefined()
+    await otherHost.stop(10)
+  }, 15_000)
+})


### PR DESCRIPTION
Closes #812. Second step of #804, and the gate everything cluster-shaped mounts on.

## Why

`AcpHost` owned two unrelated halves of starting a runtime: the ACP protocol, and
`child_process` + PATH resolution + sandbox wrapping + process groups + signal
escalation. Only the first is about ACP. The second is about *where the runtime
lives* — precisely what changes when the runtime moves into a sandbox pod.

## What moves

Everything process- and filesystem-shaped goes behind `SpawnDriver`
(`src/acp/spawn-driver.ts`), with `LocalDriver` preserving today's behavior verbatim:
detached spawn, the pgid sweep on exit, stdin EOF before `SIGTERM`, the `SIGKILL`
escalation and its failsafe, and the already-exited early return that a past
regression hung on (comments moved with the code they explain).

`AcpHost` keeps what only it can know — env assembly, account-app isolation, argv
composition — and consumes a byte-stream pair plus a lifecycle handle:

```ts
interface SpawnedRuntime {
  toAgent: WritableStream<Uint8Array>
  fromAgent: ReadableStream<Uint8Array>
  onExit(listener: () => void): void
  stop(deadlineMs: number): Promise<void>
}
```

That narrowness is the point: `ndJsonStream` and the ACP `ClientConnection` were
already transport-agnostic, so the protocol layer never needed to know about
processes at all.

## The one judgment call worth reviewing

Two resolutions move *down* rather than staying in `AcpHost`: the command lookup
(`resolveCommandPath`) and the `CLAUDE_CODE_EXECUTABLE` fallback. Both search a
filesystem, and only the driver knows *which* filesystem the runtime will see — a
daemon-side lookup would return daemon-pod paths that mean nothing inside a sandbox
pod. So `AcpHost` states the policy ("this runtime wants `CLAUDE_CODE_EXECUTABLE`
filled from `claude`") as a declarative hint, and the driver performs the lookup
where it actually applies. The alternative — resolving on the daemon and passing
absolute paths down — is the bug this seam exists to prevent.

## Behavior and callers

No behavior change, no caller change. The four other `AcpHost` construction sites
(chat CLI, runtime prober, model enumerator, evaluation runner) only ever passed
options and never touched the process, so they keep working through the default
`LocalDriver`. `AcpSandboxLaunch` moves next to the driver that consumes it and is
re-exported from `acp-host`, where callers have always imported it from.

## Tests

- New `test/spawn-driver.test.ts` drives a full ACP turn — initialize, `session/new`,
  prompt, streamed update, stop — against an in-memory agent with **no process
  anywhere**. That is the shape a cluster driver presents, so this is the seam's
  proof rather than a mock-shaped restatement of it. It also pins the launch request
  the driver receives (unresolved command, assembled env, hints only for Claude
  runtimes) and that a second `stop()` is a no-op.
- `test/acp-host.test.ts` — one test reached into `AcpHost`'s private child handle to
  simulate a terminal Ctrl-C killing the process group; it now reaches through the
  driver's launched target and asserts the same behavior (prompt return, no hang).

Verification: daemon typecheck, eslint, prettier clean. 49 tests in the two ACP files,
plus 252 across the launch / catalog / sandbox / lifecycle / chat / account-app
neighborhood pass.

One failure in that sweep is **pre-existing, not from this change**:
`evaluation-runner.test.ts › "records a raw ACP baseline …"` fails identically on a
clean `origin/main` worktree on this host (verified by running the same file at
`63046260` with no local diff).

## Next

The cluster driver itself lands in #816, on top of the Kubernetes client (#811) and
the shim (#813). This PR deliberately contains no cluster concepts.
