### PR TITLE
feat(daemon): add a thin Kubernetes client for the sandbox API

### DIFF
--- a/packages/daemon/src/k8s/config.ts
+++ b/packages/daemon/src/k8s/config.ts
@@ -1,0 +1,60 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** Where the kubelet projects a pod's ServiceAccount credentials. */
+export const SERVICE_ACCOUNT_DIR = '/var/run/secrets/kubernetes.io/serviceaccount'
+
+export interface InClusterConfig {
+  /** API server base, e.g. `https://10.96.0.1:443`. */
+  server: string
+  /** The pod's namespace, from the projected `namespace` file. */
+  namespace: string
+  /** PEM bundle for the API server, or undefined when the CA file is absent. */
+  ca?: string
+  /**
+   * The current bearer token. Read per call, never captured: the kubelet rotates
+   * the projected token in place, and a token cached at boot expires under a
+   * long-lived daemon.
+   */
+  token(): string
+}
+
+export class InClusterConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InClusterConfigError'
+  }
+}
+
+/**
+ * Discover in-cluster API access from the pod's environment and projected
+ * ServiceAccount volume. Throws with the missing piece named rather than
+ * returning a half-configured client: every caller needs all of it.
+ */
+export function loadInClusterConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  dir: string = SERVICE_ACCOUNT_DIR
+): InClusterConfig {
+  const host = env.KUBERNETES_SERVICE_HOST?.trim()
+  const port = env.KUBERNETES_SERVICE_PORT?.trim() || '443'
+  if (!host) {
+    throw new InClusterConfigError('KUBERNETES_SERVICE_HOST is not set — not running inside a Kubernetes pod')
+  }
+  const tokenPath = join(dir, 'token')
+  const namespacePath = join(dir, 'namespace')
+  const caPath = join(dir, 'ca.crt')
+  if (!existsSync(tokenPath)) {
+    throw new InClusterConfigError(`service account token not found at ${tokenPath}`)
+  }
+  if (!existsSync(namespacePath)) {
+    throw new InClusterConfigError(`service account namespace not found at ${namespacePath}`)
+  }
+  // IPv6 literals must stay bracketed in the URL authority.
+  const authority = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host
+  return {
+    server: `https://${authority}:${port}`,
+    namespace: readFileSync(namespacePath, 'utf8').trim(),
+    ...(existsSync(caPath) ? { ca: readFileSync(caPath, 'utf8') } : {}),
+    token: () => readFileSync(tokenPath, 'utf8').trim()
+  }
+}

--- a/packages/daemon/src/k8s/config.ts
+++ b/packages/daemon/src/k8s/config.ts
@@ -11,11 +11,8 @@ export interface InClusterConfig {
   namespace: string
   /** PEM bundle for the API server, or undefined when the CA file is absent. */
   ca?: string
-  /**
-   * The current bearer token. Read per call, never captured: the kubelet rotates
-   * the projected token in place, and a token cached at boot expires under a
-   * long-lived daemon.
-   */
+  /** The current bearer token, read per call: the kubelet rotates the projected token in
+   *  place, so a value cached at boot expires under a long-lived daemon. */
   token(): string
 }
 
@@ -26,11 +23,8 @@ export class InClusterConfigError extends Error {
   }
 }
 
-/**
- * Discover in-cluster API access from the pod's environment and projected
- * ServiceAccount volume. Throws with the missing piece named rather than
- * returning a half-configured client: every caller needs all of it.
- */
+/** Discover in-cluster API access from the pod env and projected ServiceAccount volume.
+ *  Throws with the missing piece named rather than returning a half-configured client. */
 export function loadInClusterConfig(
   env: NodeJS.ProcessEnv = process.env,
   dir: string = SERVICE_ACCOUNT_DIR

--- a/packages/daemon/src/k8s/http.ts
+++ b/packages/daemon/src/k8s/http.ts
@@ -1,0 +1,150 @@
+import { request as httpRequest, type IncomingMessage } from 'node:http'
+import { request as httpsRequest } from 'node:https'
+import { createInterface } from 'node:readline'
+import type { InClusterConfig } from './config.js'
+
+/** A Kubernetes API rejection, carrying the fields callers actually branch on. */
+export class K8sApiError extends Error {
+  constructor(
+    readonly status: number,
+    /** The `Status.reason` when the API server sent one (e.g. `Conflict`, `Expired`). */
+    readonly reason: string | undefined,
+    message: string
+  ) {
+    super(message)
+    this.name = 'K8sApiError'
+  }
+
+  /** A write lost its optimistic-concurrency race; re-read and retry. */
+  get isConflict(): boolean {
+    return this.status === 409
+  }
+
+  /** The requested `resourceVersion` is too old to resume from — re-list. */
+  get isExpired(): boolean {
+    return this.status === 410 || this.reason === 'Expired'
+  }
+
+  get isNotFound(): boolean {
+    return this.status === 404
+  }
+
+  /** The object already exists; idempotent create-if-absent treats this as success. */
+  get isAlreadyExists(): boolean {
+    return this.status === 409 && this.reason === 'AlreadyExists'
+  }
+}
+
+export interface K8sRequest {
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT'
+  /** Absolute API path, e.g. `/apis/agents.x-k8s.io/v1beta1/namespaces/x/sandboxes`. */
+  path: string
+  query?: Record<string, string | number | boolean | undefined>
+  body?: unknown
+  /** Defaults to `application/json`; JSON Patch writes pass their own. */
+  contentType?: string
+  signal?: AbortSignal
+}
+
+function buildUrl(server: string, req: K8sRequest): URL {
+  const url = new URL(req.path, server)
+  for (const [key, value] of Object.entries(req.query ?? {})) {
+    if (value !== undefined) url.searchParams.set(key, String(value))
+  }
+  return url
+}
+
+function statusFrom(status: number, raw: string): K8sApiError {
+  let reason: string | undefined
+  let message = raw.trim()
+  try {
+    const parsed = JSON.parse(raw) as { reason?: string; message?: string }
+    reason = parsed.reason
+    if (parsed.message) message = parsed.message
+  } catch {
+    /* not a Status body — keep the raw text */
+  }
+  return new K8sApiError(status, reason, `kubernetes ${status}${reason ? ` (${reason})` : ''}: ${message}`)
+}
+
+/**
+ * The transport under the typed Kubernetes operations.
+ *
+ * Deliberately `node:http(s)` rather than `fetch`: the API server is presented
+ * under its own CA, and pinning that CA per request is a plain option here while
+ * `fetch` would need an undici dispatcher — a dependency this daemon does not
+ * carry. It also hands us the raw response stream a watch needs.
+ *
+ * The bearer token is read from {@link InClusterConfig.token} on every request,
+ * never captured: the kubelet rotates the projected token in place.
+ */
+export class K8sHttp {
+  constructor(private cfg: InClusterConfig) {}
+
+  private send(req: K8sRequest): Promise<{ status: number; message: IncomingMessage }> {
+    const url = buildUrl(this.cfg.server, req)
+    const payload = req.body === undefined ? undefined : Buffer.from(JSON.stringify(req.body))
+    const send = url.protocol === 'http:' ? httpRequest : httpsRequest
+    return new Promise((resolve, reject) => {
+      const clientRequest = send(
+        url,
+        {
+          method: req.method,
+          headers: {
+            authorization: `Bearer ${this.cfg.token()}`,
+            accept: 'application/json',
+            ...(payload
+              ? { 'content-type': req.contentType ?? 'application/json', 'content-length': payload.length }
+              : {})
+          },
+          ...(this.cfg.ca ? { ca: this.cfg.ca } : {}),
+          ...(req.signal ? { signal: req.signal } : {})
+        },
+        (message) => resolve({ status: message.statusCode ?? 0, message })
+      )
+      clientRequest.on('error', reject)
+      if (payload) clientRequest.write(payload)
+      clientRequest.end()
+    })
+  }
+
+  private static drain(message: IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let text = ''
+      message.setEncoding('utf8')
+      message.on('data', (chunk: string) => (text += chunk))
+      message.on('end', () => resolve(text))
+      message.on('error', reject)
+    })
+  }
+
+  /** One request/response, parsed as JSON. Non-2xx throws {@link K8sApiError}. */
+  async json<T>(req: K8sRequest): Promise<T> {
+    const { status, message } = await this.send(req)
+    const text = await K8sHttp.drain(message)
+    if (status < 200 || status >= 300) throw statusFrom(status, text)
+    return (text ? JSON.parse(text) : {}) as T
+  }
+
+  /**
+   * A streaming request yielding one decoded JSON object per line — the shape
+   * `?watch=true` responds with. The iterator ends when the API server closes the
+   * stream, which a watch loop treats as "reconnect", not as an error.
+   */
+  async *lines<T>(req: K8sRequest): AsyncGenerator<T> {
+    const { status, message } = await this.send(req)
+    if (status < 200 || status >= 300) {
+      throw statusFrom(status, await K8sHttp.drain(message))
+    }
+    const reader = createInterface({ input: message, crlfDelay: Infinity })
+    try {
+      for await (const line of reader) {
+        if (!line.trim()) continue
+        yield JSON.parse(line) as T
+      }
+    } finally {
+      reader.close()
+      message.destroy()
+    }
+  }
+}

--- a/packages/daemon/src/k8s/http.ts
+++ b/packages/daemon/src/k8s/http.ts
@@ -29,6 +29,12 @@ export class K8sApiError extends Error {
     return this.status === 404
   }
 
+  /** 422 Invalid — how the API server reports a rejected JSON Patch application,
+   *  including a failed `test` operation. Not a concurrency signal on its own. */
+  get isUnprocessable(): boolean {
+    return this.status === 422
+  }
+
   /** The object already exists; idempotent create-if-absent treats this as success. */
   get isAlreadyExists(): boolean {
     return this.status === 409 && this.reason === 'AlreadyExists'

--- a/packages/daemon/src/k8s/http.ts
+++ b/packages/daemon/src/k8s/http.ts
@@ -67,17 +67,11 @@ function statusFrom(status: number, raw: string): K8sApiError {
   return new K8sApiError(status, reason, `kubernetes ${status}${reason ? ` (${reason})` : ''}: ${message}`)
 }
 
-/**
- * The transport under the typed Kubernetes operations.
- *
- * Deliberately `node:http(s)` rather than `fetch`: the API server is presented
- * under its own CA, and pinning that CA per request is a plain option here while
- * `fetch` would need an undici dispatcher — a dependency this daemon does not
- * carry. It also hands us the raw response stream a watch needs.
- *
- * The bearer token is read from {@link InClusterConfig.token} on every request,
- * never captured: the kubelet rotates the projected token in place.
- */
+/** The transport under the typed operations. `node:http(s)` rather than `fetch`: the API
+ *  server presents its own CA, which is a plain per-request option here while `fetch`
+ *  would need an undici dispatcher we do not depend on, and this also hands us the raw
+ *  stream a watch needs. The bearer token is read per request, never captured — the
+ *  kubelet rotates the projected token in place. */
 export class K8sHttp {
   constructor(private cfg: InClusterConfig) {}
 
@@ -126,11 +120,8 @@ export class K8sHttp {
     return (text ? JSON.parse(text) : {}) as T
   }
 
-  /**
-   * A streaming request yielding one decoded JSON object per line — the shape
-   * `?watch=true` responds with. The iterator ends when the API server closes the
-   * stream, which a watch loop treats as "reconnect", not as an error.
-   */
+  /** One decoded JSON object per line — how `?watch=true` responds. The iterator ends
+   *  when the server closes the stream, which a watch loop treats as reconnect. */
   async *lines<T>(req: K8sRequest): AsyncGenerator<T> {
     const { status, message } = await this.send(req)
     if (status < 200 || status >= 300) {

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -9,12 +9,14 @@ export type OperatingMode = 'Running' | 'Suspended'
 
 export interface Sandbox extends K8sObject {
   spec?: { operatingMode?: OperatingMode; podTemplate?: unknown }
-  status?: { conditions?: Array<{ type?: string; status?: string }>; podIPs?: Array<{ ip?: string }> }
+  status?: { conditions?: Array<{ type?: string; status?: string }> }
 }
 
+/** The claim's status names the bound Sandbox; the Sandbox UID comes from that
+ *  object's `metadata.uid`, since the claim carries no uid of its own. */
 export interface SandboxClaim extends K8sObject {
   spec?: { warmPoolRef?: { name?: string }; additionalPodMetadata?: { labels?: Record<string, string> } }
-  status?: { sandbox?: { name?: string; uid?: string } }
+  status?: { sandbox?: { name?: string } }
 }
 
 export interface TokenReviewResult {
@@ -33,18 +35,9 @@ function collectionPath(group: string, namespace: string, plural: string): strin
   return `/apis/${group}/namespaces/${namespace}/${plural}`
 }
 
-/**
- * The daemon's complete Kubernetes surface, one method per granted verb.
- *
- * It is intentionally not a generic CRD client: the RBAC this runs under grants
- * SandboxClaim create/delete/get/list/watch, Sandbox get/watch/patch (restricted
- * to `spec.operatingMode` by an admission policy), and cluster-scoped TokenReview
- * create. A method here that the Role does not authorize would only fail at
- * runtime, so the type surface mirrors the Role exactly.
- *
- * The Pod API is deliberately absent — pods are materialized by the vendor
- * controller and the daemon never addresses them directly.
- */
+/** The daemon's Kubernetes surface, one method per granted verb: the type surface
+ *  mirrors the Role, since a method it does not authorize could only fail at runtime.
+ *  The Pod API is absent by design — pods are the vendor controller's to materialize. */
 export class SandboxApi {
   constructor(
     private http: K8sHttp,
@@ -59,11 +52,8 @@ export class SandboxApi {
     return collectionPath(SANDBOX_GROUP, this.namespace, 'sandboxes')
   }
 
-  /**
-   * Create a claim, treating an existing one as success: claim names are derived
-   * from the agent id, so a retry after a partial reconcile must converge rather
-   * than fail.
-   */
+  /** Create a claim, treating an existing one as success: names are derived from the
+   *  agent id, so a retry after a partial reconcile must converge rather than fail. */
   async ensureClaim(claim: SandboxClaim & { metadata: { name: string } }): Promise<SandboxClaim> {
     try {
       return await this.http.json<SandboxClaim>({
@@ -103,37 +93,26 @@ export class SandboxApi {
     return watchCollection<Sandbox>(this.http, { ...options, path: this.sandboxes() })
   }
 
-  /**
-   * Set a bound Sandbox's operating mode — the sleep/wake path.
-   *
-   * JSON Patch with a `test` guard rather than a bare replace: between reading a
-   * Sandbox and writing it, a message can wake an instance we decided to suspend
-   * (or vice versa). The `test` makes the write fail with a conflict instead of
-   * silently overriding the newer decision, and `expected` names what we believed.
-   * Pass `expected: null` to require the field to be currently unset.
-   */
-  async setOperatingMode(name: string, mode: OperatingMode, expected?: OperatingMode | null): Promise<Sandbox> {
-    const patch: Array<Record<string, unknown>> = []
-    if (expected !== undefined) {
-      patch.push({ op: 'test', path: '/spec/operatingMode', value: expected })
-    }
-    patch.push({ op: 'replace', path: '/spec/operatingMode', value: mode })
+  /** Set a bound Sandbox's operating mode — the sleep/wake path.
+   *  `observed` is mandatory: between reading a Sandbox and writing it, a message can
+   *  wake an instance we decided to suspend (or the reverse), so every write tests the
+   *  value we saw and fails as a conflict rather than clobbering a newer decision.
+   *  v1beta1 defaults the field to `Running`, so an observed value always exists. */
+  setOperatingMode(name: string, mode: OperatingMode, observed: OperatingMode): Promise<Sandbox> {
     return this.http.json<Sandbox>({
       method: 'PATCH',
       path: `${this.sandboxes()}/${name}`,
       contentType: 'application/json-patch+json',
-      body: patch
+      body: [
+        { op: 'test', path: '/spec/operatingMode', value: observed },
+        { op: 'replace', path: '/spec/operatingMode', value: mode }
+      ]
     })
   }
 
-  /**
-   * Verify a token the in-sandbox shim presented, and learn which pod it belongs
-   * to. `audiences` is not optional in practice: a token minted for a different
-   * audience must be rejected, and omitting the field would accept it.
-   *
-   * TokenReview is cluster-scoped, which is why this needs its own ClusterRole
-   * rather than the per-namespace Role that covers everything else here.
-   */
+  /** Verify a token the shim presented and learn which pod it belongs to. `audiences`
+   *  is required: omitting it would accept a token minted for something else.
+   *  TokenReview is cluster-scoped, hence its own ClusterRole rather than the Role. */
   async reviewToken(token: string, audiences: string[]): Promise<TokenReviewResult> {
     const review = await this.http.json<{
       status?: {

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -31,17 +31,24 @@ export interface TokenReviewResult {
 const POD_NAME_EXTRA = 'authentication.kubernetes.io/pod-name'
 const POD_UID_EXTRA = 'authentication.kubernetes.io/pod-uid'
 
-/** The sleep/wake guard rejected the write: the Sandbox moved between our read and our
- *  patch. Retryable by re-reading and re-deciding — never by forcing the write through. */
-export class OperatingModeConflictError extends Error {
+/** A guarded operating-mode write was rejected, so the decision behind it is stale:
+ *  re-read the Sandbox, decide again, and write again — never force the write through.
+ *  It deliberately does NOT claim what the intervening state was. The API server reports
+ *  a failed JSON Patch `test` and any other patch rejection with the same 422, and any
+ *  later read is a fresh snapshot rather than evidence about the failure, so inferring a
+ *  cause would be a guess dressed as a fact. Callers must bound their retries: a
+ *  permanently invalid patch would otherwise re-read and re-attempt forever. */
+export class OperatingModeRejectedError extends Error {
   constructor(
     readonly sandbox: string,
     readonly observed: OperatingMode,
-    readonly actual: OperatingMode,
-    readonly cause: unknown
+    readonly requested: OperatingMode,
+    readonly cause: K8sApiError
   ) {
-    super(`sandbox ${sandbox} is ${actual}, not the observed ${observed} — operating mode write rejected`)
-    this.name = 'OperatingModeConflictError'
+    super(
+      `sandbox ${sandbox}: guarded write to ${requested} was rejected (observed ${observed}) — re-read and decide again`
+    )
+    this.name = 'OperatingModeRejectedError'
   }
 }
 
@@ -112,7 +119,7 @@ export class SandboxApi {
    *  wake an instance we decided to suspend (or the reverse), so every write tests the
    *  value we saw rather than clobbering a newer decision. v1beta1 defaults the field to
    *  `Running`, so an observed value always exists.
-   *  Throws {@link OperatingModeConflictError} when the guard is what rejected the write. */
+   *  A rejected write raises {@link OperatingModeRejectedError} — re-read and re-decide. */
   async setOperatingMode(name: string, mode: OperatingMode, observed: OperatingMode): Promise<Sandbox> {
     try {
       return await this.http.json<Sandbox>({
@@ -125,16 +132,13 @@ export class SandboxApi {
         ]
       })
     } catch (err) {
-      if (!(err instanceof K8sApiError) || !err.isUnprocessable) throw err
-      // The API server reports every rejected JSON Patch as 422 Invalid, and the text
-      // for a failed `test` comes from the patch library, so it varies by version.
-      // Confirm by state instead: re-read and see whether the guard is what failed.
-      const actual = await this.getSandbox(name).then(
-        (sandbox) => sandbox.spec?.operatingMode,
-        () => undefined
-      )
-      if (actual !== undefined && actual !== observed) {
-        throw new OperatingModeConflictError(name, observed, actual, err)
+      // The API server answers every rejected JSON Patch — a failed `test` included —
+      // with 422 Invalid, and the text comes from the patch library, so it varies by
+      // version. Nothing here can prove why the write was rejected: a later read is a
+      // fresh snapshot, not evidence, and the mode can change away and back between the
+      // two. So report the rejection as itself and let the caller re-decide.
+      if (err instanceof K8sApiError && err.isUnprocessable) {
+        throw new OperatingModeRejectedError(name, observed, mode, err)
       }
       throw err
     }

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -1,0 +1,166 @@
+import { K8sApiError, type K8sHttp } from './http.js'
+import { watchCollection, type K8sObject, type ResourceEvent, type WatchOptions } from './watch.js'
+
+/** agent-sandbox API groups, pinned to v1beta1 — the compatibility layer is never touched. */
+export const SANDBOX_GROUP = 'agents.x-k8s.io/v1beta1'
+export const SANDBOX_EXTENSIONS_GROUP = 'extensions.agents.x-k8s.io/v1beta1'
+
+export type OperatingMode = 'Running' | 'Suspended'
+
+export interface Sandbox extends K8sObject {
+  spec?: { operatingMode?: OperatingMode; podTemplate?: unknown }
+  status?: { conditions?: Array<{ type?: string; status?: string }>; podIPs?: Array<{ ip?: string }> }
+}
+
+export interface SandboxClaim extends K8sObject {
+  spec?: { warmPoolRef?: { name?: string }; additionalPodMetadata?: { labels?: Record<string, string> } }
+  status?: { sandbox?: { name?: string; uid?: string } }
+}
+
+export interface TokenReviewResult {
+  authenticated: boolean
+  /** The pod the presented token was issued to, from the bound-object extras. */
+  podName?: string
+  podUid?: string
+  username?: string
+  error?: string
+}
+
+const POD_NAME_EXTRA = 'authentication.kubernetes.io/pod-name'
+const POD_UID_EXTRA = 'authentication.kubernetes.io/pod-uid'
+
+function collectionPath(group: string, namespace: string, plural: string): string {
+  return `/apis/${group}/namespaces/${namespace}/${plural}`
+}
+
+/**
+ * The daemon's complete Kubernetes surface, one method per granted verb.
+ *
+ * It is intentionally not a generic CRD client: the RBAC this runs under grants
+ * SandboxClaim create/delete/get/list/watch, Sandbox get/watch/patch (restricted
+ * to `spec.operatingMode` by an admission policy), and cluster-scoped TokenReview
+ * create. A method here that the Role does not authorize would only fail at
+ * runtime, so the type surface mirrors the Role exactly.
+ *
+ * The Pod API is deliberately absent — pods are materialized by the vendor
+ * controller and the daemon never addresses them directly.
+ */
+export class SandboxApi {
+  constructor(
+    private http: K8sHttp,
+    private namespace: string
+  ) {}
+
+  private claims(): string {
+    return collectionPath(SANDBOX_EXTENSIONS_GROUP, this.namespace, 'sandboxclaims')
+  }
+
+  private sandboxes(): string {
+    return collectionPath(SANDBOX_GROUP, this.namespace, 'sandboxes')
+  }
+
+  /**
+   * Create a claim, treating an existing one as success: claim names are derived
+   * from the agent id, so a retry after a partial reconcile must converge rather
+   * than fail.
+   */
+  async ensureClaim(claim: SandboxClaim & { metadata: { name: string } }): Promise<SandboxClaim> {
+    try {
+      return await this.http.json<SandboxClaim>({
+        method: 'POST',
+        path: this.claims(),
+        body: { apiVersion: SANDBOX_EXTENSIONS_GROUP, kind: 'SandboxClaim', ...claim }
+      })
+    } catch (err) {
+      if (err instanceof K8sApiError && err.isAlreadyExists) return this.getClaim(claim.metadata.name)
+      throw err
+    }
+  }
+
+  getClaim(name: string): Promise<SandboxClaim> {
+    return this.http.json<SandboxClaim>({ method: 'GET', path: `${this.claims()}/${name}` })
+  }
+
+  /** Delete a claim; an already-absent claim is success (agent deletion is idempotent). */
+  async deleteClaim(name: string): Promise<void> {
+    try {
+      await this.http.json({ method: 'DELETE', path: `${this.claims()}/${name}` })
+    } catch (err) {
+      if (err instanceof K8sApiError && err.isNotFound) return
+      throw err
+    }
+  }
+
+  watchClaims(options: Omit<WatchOptions, 'path'> = {}): AsyncGenerator<ResourceEvent<SandboxClaim>> {
+    return watchCollection<SandboxClaim>(this.http, { ...options, path: this.claims() })
+  }
+
+  getSandbox(name: string): Promise<Sandbox> {
+    return this.http.json<Sandbox>({ method: 'GET', path: `${this.sandboxes()}/${name}` })
+  }
+
+  watchSandboxes(options: Omit<WatchOptions, 'path'> = {}): AsyncGenerator<ResourceEvent<Sandbox>> {
+    return watchCollection<Sandbox>(this.http, { ...options, path: this.sandboxes() })
+  }
+
+  /**
+   * Set a bound Sandbox's operating mode — the sleep/wake path.
+   *
+   * JSON Patch with a `test` guard rather than a bare replace: between reading a
+   * Sandbox and writing it, a message can wake an instance we decided to suspend
+   * (or vice versa). The `test` makes the write fail with a conflict instead of
+   * silently overriding the newer decision, and `expected` names what we believed.
+   * Pass `expected: null` to require the field to be currently unset.
+   */
+  async setOperatingMode(name: string, mode: OperatingMode, expected?: OperatingMode | null): Promise<Sandbox> {
+    const patch: Array<Record<string, unknown>> = []
+    if (expected !== undefined) {
+      patch.push({ op: 'test', path: '/spec/operatingMode', value: expected })
+    }
+    patch.push({ op: 'replace', path: '/spec/operatingMode', value: mode })
+    return this.http.json<Sandbox>({
+      method: 'PATCH',
+      path: `${this.sandboxes()}/${name}`,
+      contentType: 'application/json-patch+json',
+      body: patch
+    })
+  }
+
+  /**
+   * Verify a token the in-sandbox shim presented, and learn which pod it belongs
+   * to. `audiences` is not optional in practice: a token minted for a different
+   * audience must be rejected, and omitting the field would accept it.
+   *
+   * TokenReview is cluster-scoped, which is why this needs its own ClusterRole
+   * rather than the per-namespace Role that covers everything else here.
+   */
+  async reviewToken(token: string, audiences: string[]): Promise<TokenReviewResult> {
+    const review = await this.http.json<{
+      status?: {
+        authenticated?: boolean
+        error?: string
+        user?: { username?: string; extra?: Record<string, string[]> }
+      }
+    }>({
+      method: 'POST',
+      path: '/apis/authentication.k8s.io/v1/tokenreviews',
+      body: { apiVersion: 'authentication.k8s.io/v1', kind: 'TokenReview', spec: { token, audiences } }
+    })
+    const status = review.status ?? {}
+    const extra = status.user?.extra ?? {}
+    return {
+      authenticated: status.authenticated === true,
+      ...(extra[POD_NAME_EXTRA]?.[0] ? { podName: extra[POD_NAME_EXTRA][0] } : {}),
+      ...(extra[POD_UID_EXTRA]?.[0] ? { podUid: extra[POD_UID_EXTRA][0] } : {}),
+      ...(status.user?.username ? { username: status.user.username } : {}),
+      ...(status.error ? { error: status.error } : {})
+    }
+  }
+}
+
+/** Whether a Sandbox reports Ready, the signal that its pod is up. */
+export function isSandboxReady(sandbox: Sandbox): boolean {
+  return (sandbox.status?.conditions ?? []).some(
+    (condition) => condition.type === 'Ready' && condition.status === 'True'
+  )
+}

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -31,6 +31,20 @@ export interface TokenReviewResult {
 const POD_NAME_EXTRA = 'authentication.kubernetes.io/pod-name'
 const POD_UID_EXTRA = 'authentication.kubernetes.io/pod-uid'
 
+/** The sleep/wake guard rejected the write: the Sandbox moved between our read and our
+ *  patch. Retryable by re-reading and re-deciding — never by forcing the write through. */
+export class OperatingModeConflictError extends Error {
+  constructor(
+    readonly sandbox: string,
+    readonly observed: OperatingMode,
+    readonly actual: OperatingMode,
+    readonly cause: unknown
+  ) {
+    super(`sandbox ${sandbox} is ${actual}, not the observed ${observed} — operating mode write rejected`)
+    this.name = 'OperatingModeConflictError'
+  }
+}
+
 function collectionPath(group: string, namespace: string, plural: string): string {
   return `/apis/${group}/namespaces/${namespace}/${plural}`
 }
@@ -96,18 +110,34 @@ export class SandboxApi {
   /** Set a bound Sandbox's operating mode — the sleep/wake path.
    *  `observed` is mandatory: between reading a Sandbox and writing it, a message can
    *  wake an instance we decided to suspend (or the reverse), so every write tests the
-   *  value we saw and fails as a conflict rather than clobbering a newer decision.
-   *  v1beta1 defaults the field to `Running`, so an observed value always exists. */
-  setOperatingMode(name: string, mode: OperatingMode, observed: OperatingMode): Promise<Sandbox> {
-    return this.http.json<Sandbox>({
-      method: 'PATCH',
-      path: `${this.sandboxes()}/${name}`,
-      contentType: 'application/json-patch+json',
-      body: [
-        { op: 'test', path: '/spec/operatingMode', value: observed },
-        { op: 'replace', path: '/spec/operatingMode', value: mode }
-      ]
-    })
+   *  value we saw rather than clobbering a newer decision. v1beta1 defaults the field to
+   *  `Running`, so an observed value always exists.
+   *  Throws {@link OperatingModeConflictError} when the guard is what rejected the write. */
+  async setOperatingMode(name: string, mode: OperatingMode, observed: OperatingMode): Promise<Sandbox> {
+    try {
+      return await this.http.json<Sandbox>({
+        method: 'PATCH',
+        path: `${this.sandboxes()}/${name}`,
+        contentType: 'application/json-patch+json',
+        body: [
+          { op: 'test', path: '/spec/operatingMode', value: observed },
+          { op: 'replace', path: '/spec/operatingMode', value: mode }
+        ]
+      })
+    } catch (err) {
+      if (!(err instanceof K8sApiError) || !err.isUnprocessable) throw err
+      // The API server reports every rejected JSON Patch as 422 Invalid, and the text
+      // for a failed `test` comes from the patch library, so it varies by version.
+      // Confirm by state instead: re-read and see whether the guard is what failed.
+      const actual = await this.getSandbox(name).then(
+        (sandbox) => sandbox.spec?.operatingMode,
+        () => undefined
+      )
+      if (actual !== undefined && actual !== observed) {
+        throw new OperatingModeConflictError(name, observed, actual, err)
+      }
+      throw err
+    }
   }
 
   /** Verify a token the shim presented and learn which pod it belongs to. `audiences`

--- a/packages/daemon/src/k8s/watch.ts
+++ b/packages/daemon/src/k8s/watch.ts
@@ -36,40 +36,36 @@ export interface WatchOptions {
   log?: { debug?: (message: string) => void; warn?: (message: string) => void }
 }
 
+/** Clock-driven delay that leaves no listener behind — a long outage retries often
+ *  on one long-lived signal, so the timer path must unregister too. */
 function sleep(clock: Clock, ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve()
   return new Promise((resolve) => {
-    const handle = clock.setTimeout(resolve, ms)
-    signal?.addEventListener(
-      'abort',
-      () => {
-        clock.clearTimeout(handle)
-        resolve()
-      },
-      { once: true }
-    )
+    const cleanup = (): void => signal?.removeEventListener('abort', onAbort)
+    const onAbort = (): void => {
+      cleanup()
+      clock.clearTimeout(handle)
+      resolve()
+    }
+    const handle = clock.setTimeout(() => {
+      cleanup()
+      resolve()
+    }, ms)
+    signal?.addEventListener('abort', onAbort, { once: true })
+    // Closes the race between the pre-check above and listener registration.
+    if (signal?.aborted) onAbort()
   })
 }
 
-/**
- * List-then-watch with resume, the one piece of a hand-rolled Kubernetes client
- * that is genuinely easy to get wrong.
- *
- * The contract this implements:
- *
- * - the initial LIST establishes both the snapshot and the `resourceVersion` the
- *   watch resumes from, so no change between the two is lost;
- * - `allowWatchBookmarks` asks the API server for periodic BOOKMARK events, which
- *   advance our resume point on an idle resource — without them a quiet watch
- *   drifts far enough behind to be Expired on the next reconnect;
- * - a `410 Gone` / `Expired` (the resume point aged out of etcd's history) is not
- *   an error: the only correct response is to re-LIST and re-sync, which is why
- *   `list` is a required verb in this client's RBAC and not an optional extra;
- * - a closed stream is normal (server-side timeout) and reconnects without
- *   backoff; a failed connection backs off through the shared policy.
- *
- * Yields a `synced` snapshot on every (re)sync so the consumer can converge its
- * own view rather than assume incremental continuity.
- */
+/** List-then-watch with resume — the one part of a hand-rolled client that is easy to
+ *  get wrong. The LIST establishes both the snapshot and the `resourceVersion` the watch
+ *  resumes from, so nothing in between is lost. `allowWatchBookmarks` keeps an idle
+ *  watch's resume point fresh; without it a quiet resource drifts far enough behind to
+ *  be Expired on reconnect. A 410 / Expired resume point is answered by re-LISTing, not
+ *  by failing — which is why `list` is a required verb here. A cleanly closed stream is
+ *  the server-side timeout and reconnects at once; a failed connection backs off.
+ *  Every (re)sync yields a `synced` snapshot so consumers converge rather than assume
+ *  incremental continuity across a gap. */
 export async function* watchCollection<T extends K8sObject>(
   http: K8sHttp,
   options: WatchOptions

--- a/packages/daemon/src/k8s/watch.ts
+++ b/packages/daemon/src/k8s/watch.ts
@@ -1,0 +1,154 @@
+import { Backoff, systemClock, type Clock } from '@agentconnect.md/connection'
+import { K8sApiError, type K8sHttp } from './http.js'
+
+export interface K8sObject {
+  metadata?: { name?: string; uid?: string; resourceVersion?: string; annotations?: Record<string, string> }
+}
+
+export interface K8sList<T> {
+  metadata?: { resourceVersion?: string }
+  items?: T[]
+}
+
+export type WatchEventType = 'ADDED' | 'MODIFIED' | 'DELETED' | 'BOOKMARK' | 'ERROR'
+
+export interface WatchEvent<T> {
+  type: WatchEventType
+  object: T
+}
+
+/** What a resumable watch emits: a full snapshot first, then each change. */
+export type ResourceEvent<T> =
+  | { kind: 'synced'; items: T[] }
+  | { kind: 'added'; object: T }
+  | { kind: 'modified'; object: T }
+  | { kind: 'deleted'; object: T }
+
+export interface WatchOptions {
+  /** Collection path, e.g. `/apis/.../namespaces/org-x/sandboxclaims`. */
+  path: string
+  labelSelector?: string
+  /** Server-side watch timeout; the loop reconnects when it elapses. */
+  timeoutSeconds?: number
+  signal?: AbortSignal
+  clock?: Clock
+  backoff?: Backoff
+  log?: { debug?: (message: string) => void; warn?: (message: string) => void }
+}
+
+function sleep(clock: Clock, ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const handle = clock.setTimeout(resolve, ms)
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clock.clearTimeout(handle)
+        resolve()
+      },
+      { once: true }
+    )
+  })
+}
+
+/**
+ * List-then-watch with resume, the one piece of a hand-rolled Kubernetes client
+ * that is genuinely easy to get wrong.
+ *
+ * The contract this implements:
+ *
+ * - the initial LIST establishes both the snapshot and the `resourceVersion` the
+ *   watch resumes from, so no change between the two is lost;
+ * - `allowWatchBookmarks` asks the API server for periodic BOOKMARK events, which
+ *   advance our resume point on an idle resource — without them a quiet watch
+ *   drifts far enough behind to be Expired on the next reconnect;
+ * - a `410 Gone` / `Expired` (the resume point aged out of etcd's history) is not
+ *   an error: the only correct response is to re-LIST and re-sync, which is why
+ *   `list` is a required verb in this client's RBAC and not an optional extra;
+ * - a closed stream is normal (server-side timeout) and reconnects without
+ *   backoff; a failed connection backs off through the shared policy.
+ *
+ * Yields a `synced` snapshot on every (re)sync so the consumer can converge its
+ * own view rather than assume incremental continuity.
+ */
+export async function* watchCollection<T extends K8sObject>(
+  http: K8sHttp,
+  options: WatchOptions
+): AsyncGenerator<ResourceEvent<T>> {
+  const clock = options.clock ?? systemClock
+  const backoff = options.backoff ?? new Backoff()
+  let resourceVersion: string | undefined
+
+  while (!options.signal?.aborted) {
+    if (resourceVersion === undefined) {
+      try {
+        const list = await http.json<K8sList<T>>({
+          method: 'GET',
+          path: options.path,
+          query: { ...(options.labelSelector ? { labelSelector: options.labelSelector } : {}) },
+          ...(options.signal ? { signal: options.signal } : {})
+        })
+        resourceVersion = list.metadata?.resourceVersion
+        backoff.reset()
+        yield { kind: 'synced', items: list.items ?? [] }
+      } catch (err) {
+        if (options.signal?.aborted) return
+        options.log?.warn?.(`k8s: list ${options.path} failed (${(err as Error).message})`)
+        await sleep(clock, backoff.next(), options.signal)
+        continue
+      }
+      if (resourceVersion === undefined) {
+        // A list without a resourceVersion cannot seed a watch; retry the list
+        // rather than starting an unresumable stream from "now".
+        options.log?.warn?.(`k8s: list ${options.path} returned no resourceVersion`)
+        await sleep(clock, backoff.next(), options.signal)
+        continue
+      }
+    }
+
+    try {
+      const events = http.lines<WatchEvent<T>>({
+        method: 'GET',
+        path: options.path,
+        query: {
+          watch: true,
+          allowWatchBookmarks: true,
+          resourceVersion,
+          timeoutSeconds: options.timeoutSeconds ?? 300,
+          ...(options.labelSelector ? { labelSelector: options.labelSelector } : {})
+        },
+        ...(options.signal ? { signal: options.signal } : {})
+      })
+      for await (const event of events) {
+        if (options.signal?.aborted) return
+        const version = event.object?.metadata?.resourceVersion
+        if (version) resourceVersion = version
+        backoff.reset()
+        if (event.type === 'BOOKMARK') continue
+        if (event.type === 'ERROR') {
+          // The stream carries its rejection in-band; `Expired` here means the same
+          // as a 410 status and is handled by dropping the resume point.
+          const status = event.object as unknown as { reason?: string; message?: string; code?: number }
+          const error = new K8sApiError(status.code ?? 0, status.reason, status.message ?? 'watch error')
+          if (!error.isExpired) throw error
+          options.log?.debug?.(`k8s: watch ${options.path} expired in-band — re-listing`)
+          resourceVersion = undefined
+          break
+        }
+        if (event.type === 'ADDED') yield { kind: 'added', object: event.object }
+        else if (event.type === 'MODIFIED') yield { kind: 'modified', object: event.object }
+        else if (event.type === 'DELETED') yield { kind: 'deleted', object: event.object }
+      }
+      // A cleanly ended stream is the server-side timeout: reconnect immediately,
+      // resuming from the last observed version.
+    } catch (err) {
+      if (options.signal?.aborted) return
+      if (err instanceof K8sApiError && err.isExpired) {
+        options.log?.debug?.(`k8s: watch ${options.path} resume point expired — re-listing`)
+        resourceVersion = undefined
+        continue
+      }
+      options.log?.warn?.(`k8s: watch ${options.path} failed (${(err as Error).message})`)
+      await sleep(clock, backoff.next(), options.signal)
+    }
+  }
+}

--- a/packages/daemon/test/k8s-client.test.ts
+++ b/packages/daemon/test/k8s-client.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { Backoff, FakeClock } from '@agentconnect.md/connection'
 import { InClusterConfigError, loadInClusterConfig } from '../src/k8s/config.js'
 import { K8sApiError, K8sHttp } from '../src/k8s/http.js'
-import { OperatingModeConflictError, SandboxApi, isSandboxReady } from '../src/k8s/sandbox-api.js'
+import { OperatingModeRejectedError, SandboxApi, isSandboxReady } from '../src/k8s/sandbox-api.js'
 import { watchCollection, type ResourceEvent } from '../src/k8s/watch.js'
 import type { InClusterConfig } from '../src/k8s/config.js'
 
@@ -428,62 +428,60 @@ describe('SandboxApi', () => {
     ])
   })
 
-  it('reports a lost race as a typed conflict, from the 422 the API server really sends', async () => {
+  it('reports a rejected guarded write from the 422 the API server really sends', async () => {
     // A failed JSON Patch `test` comes back as 422 Invalid — never 409 — and its message
-    // text comes from the patch library, so classification cannot rely on it.
-    const { config, requests } = await fakeApiServer(({ method }) =>
-      method === 'PATCH'
-        ? {
-            status: 422,
-            json: {
-              kind: 'Status',
-              apiVersion: 'v1',
-              status: 'Failure',
-              code: 422,
-              reason: 'Invalid',
-              message: 'testing value /spec/operatingMode failed'
-            }
-          }
-        : { json: { metadata: { name: 'sb-1' }, spec: { operatingMode: 'Running' } } }
-    )
+    // text comes from the patch library, so classification cannot rely on it either.
+    const { config, requests } = await fakeApiServer(() => ({
+      status: 422,
+      json: {
+        kind: 'Status',
+        apiVersion: 'v1',
+        status: 'Failure',
+        code: 422,
+        reason: 'Invalid',
+        message: 'testing value /spec/operatingMode failed'
+      }
+    }))
     const api = new SandboxApi(new K8sHttp(config), 'org-test')
-    const error = await api.setOperatingMode('sb-1', 'Suspended', 'Suspended').catch((err: unknown) => err)
-    expect(error).toBeInstanceOf(OperatingModeConflictError)
-    const typed = error as OperatingModeConflictError
+    const error = await api.setOperatingMode('sb-1', 'Running', 'Suspended').catch((err: unknown) => err)
+    expect(error).toBeInstanceOf(OperatingModeRejectedError)
+    const typed = error as OperatingModeRejectedError
     expect(typed.observed).toBe('Suspended')
-    expect(typed.actual).toBe('Running')
-    // Confirmed by re-reading the object, not by matching the message text.
-    expect(requests.filter((url) => url.pathname.endsWith('/sandboxes/sb-1'))).toHaveLength(2)
+    expect(typed.requested).toBe('Running')
+    expect(typed.cause.isUnprocessable).toBe(true)
+    // No confirming read: a later snapshot is not evidence about why the patch failed.
+    expect(requests).toHaveLength(1)
   })
 
-  it('does not dress an unrelated 422 up as a concurrency conflict', async () => {
-    const { config } = await fakeApiServer(({ method }) =>
-      method === 'PATCH'
-        ? {
-            status: 422,
-            json: { kind: 'Status', code: 422, reason: 'Invalid', message: 'spec.operatingMode: Unsupported value' }
-          }
-        : // The guard held — the mode is still what we observed — so the 422 came from
-          // something else and must surface as itself.
-          { json: { metadata: { name: 'sb-1' }, spec: { operatingMode: 'Running' } } }
-    )
+  it('reports the same rejection when the mode changes away and back before any re-read', async () => {
+    // The sequence that defeats confirm-by-read: we observed Suspended, another actor
+    // set Running (so the guard correctly failed), then set it back to Suspended. A
+    // post-failure read would see Suspended, match `observed`, and wrongly conclude the
+    // guard held. Reporting the rejection without inferring state is immune to it.
+    let patched = false
+    const { config } = await fakeApiServer(({ method }) => {
+      if (method === 'PATCH') {
+        patched = true
+        return { status: 422, json: { kind: 'Status', code: 422, reason: 'Invalid', message: 'test failed' } }
+      }
+      return { json: { metadata: { name: 'sb-1' }, spec: { operatingMode: 'Suspended' } } }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const error = await api.setOperatingMode('sb-1', 'Running', 'Suspended').catch((err: unknown) => err)
+    expect(patched).toBe(true)
+    expect(error).toBeInstanceOf(OperatingModeRejectedError)
+  })
+
+  it('passes through a rejection that is not a patch rejection', async () => {
+    const { config } = await fakeApiServer(() => ({
+      status: 403,
+      json: { kind: 'Status', code: 403, reason: 'Forbidden', message: 'admission policy denied the update' }
+    }))
     const api = new SandboxApi(new K8sHttp(config), 'org-test')
     const error = await api.setOperatingMode('sb-1', 'Suspended', 'Running').catch((err: unknown) => err)
     expect(error).toBeInstanceOf(K8sApiError)
-    expect(error).not.toBeInstanceOf(OperatingModeConflictError)
-    expect((error as K8sApiError).isUnprocessable).toBe(true)
-  })
-
-  it('surfaces the original error when the confirming read is unavailable', async () => {
-    const { config } = await fakeApiServer(({ method }) =>
-      method === 'PATCH'
-        ? { status: 422, json: { kind: 'Status', code: 422, reason: 'Invalid', message: 'rejected' } }
-        : { status: 500, json: { kind: 'Status', code: 500, reason: 'InternalError' } }
-    )
-    const api = new SandboxApi(new K8sHttp(config), 'org-test')
-    const error = await api.setOperatingMode('sb-1', 'Suspended', 'Running').catch((err: unknown) => err)
-    expect(error).toBeInstanceOf(K8sApiError)
-    expect((error as K8sApiError).status).toBe(422)
+    expect(error).not.toBeInstanceOf(OperatingModeRejectedError)
+    expect((error as K8sApiError).status).toBe(403)
   })
 
   it('reviews a shim token with its audience and returns the bound pod identity', async () => {

--- a/packages/daemon/test/k8s-client.test.ts
+++ b/packages/daemon/test/k8s-client.test.ts
@@ -1,0 +1,429 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Backoff, FakeClock } from '@agentconnect.md/connection'
+import { InClusterConfigError, loadInClusterConfig } from '../src/k8s/config.js'
+import { K8sApiError, K8sHttp } from '../src/k8s/http.js'
+import { SandboxApi, isSandboxReady } from '../src/k8s/sandbox-api.js'
+import { watchCollection, type ResourceEvent } from '../src/k8s/watch.js'
+import type { InClusterConfig } from '../src/k8s/config.js'
+
+interface Route {
+  (req: { method: string; url: URL; body: string; headers: Record<string, string | string[] | undefined> }): {
+    status?: number
+    json?: unknown
+    /** Newline-delimited JSON objects, then close — how `?watch=true` responds. */
+    lines?: unknown[]
+    /** Hold the stream open after the lines instead of ending it. */
+    hold?: boolean
+  }
+}
+
+const servers: Server[] = []
+
+async function fakeApiServer(route: Route): Promise<{ config: InClusterConfig; requests: URL[]; tokens: string[] }> {
+  const requests: URL[] = []
+  const tokens: string[] = []
+  const server = createServer((req, res) => {
+    let body = ''
+    req.on('data', (chunk) => (body += chunk))
+    req.on('end', () => {
+      const url = new URL(req.url ?? '/', 'http://localhost')
+      requests.push(url)
+      const auth = req.headers.authorization
+      if (typeof auth === 'string') tokens.push(auth.replace(/^Bearer /, ''))
+      const result = route({ method: req.method ?? 'GET', url, body, headers: req.headers })
+      res.statusCode = result.status ?? 200
+      res.setHeader('content-type', 'application/json')
+      if (result.lines) {
+        for (const line of result.lines) res.write(`${JSON.stringify(line)}\n`)
+        if (!result.hold) res.end()
+        return
+      }
+      res.end(JSON.stringify(result.json ?? {}))
+    })
+  })
+  servers.push(server)
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as { port: number }).port
+  let tokenReads = 0
+  return {
+    config: {
+      server: `http://127.0.0.1:${port}`,
+      namespace: 'org-test',
+      // Every read returns a distinct value, so a client that captures the token
+      // once (instead of re-reading the rotating projected file) is detectable.
+      token: () => `token-${++tokenReads}`
+    },
+    requests,
+    tokens
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))))
+})
+
+/** Minimal poll helper — the abort test only needs "the snapshot arrived". */
+async function waitUntil(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const started = Date.now()
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) throw new Error('condition not met in time')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+async function take<T>(source: AsyncGenerator<T>, count: number): Promise<T[]> {
+  const out: T[] = []
+  for await (const item of source) {
+    out.push(item)
+    if (out.length === count) break
+  }
+  return out
+}
+
+describe('in-cluster config', () => {
+  it('builds the API server URL and reads the token per call, not once', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-sa-'))
+    writeFileSync(join(dir, 'token'), 'first\n')
+    writeFileSync(join(dir, 'namespace'), 'org-abc\n')
+    writeFileSync(join(dir, 'ca.crt'), '-----BEGIN CERTIFICATE-----\n')
+    const config = loadInClusterConfig({ KUBERNETES_SERVICE_HOST: '10.96.0.1', KUBERNETES_SERVICE_PORT: '443' }, dir)
+    expect(config.server).toBe('https://10.96.0.1:443')
+    expect(config.namespace).toBe('org-abc')
+    expect(config.ca).toContain('BEGIN CERTIFICATE')
+    expect(config.token()).toBe('first')
+    // The kubelet rotates the projected token in place; a long-lived daemon must
+    // observe the new value rather than a boot-time snapshot.
+    writeFileSync(join(dir, 'token'), 'rotated\n')
+    expect(config.token()).toBe('rotated')
+  })
+
+  it('brackets an IPv6 API server address', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-sa-'))
+    writeFileSync(join(dir, 'token'), 't')
+    writeFileSync(join(dir, 'namespace'), 'n')
+    const config = loadInClusterConfig({ KUBERNETES_SERVICE_HOST: 'fd00::1', KUBERNETES_SERVICE_PORT: '443' }, dir)
+    expect(config.server).toBe('https://[fd00::1]:443')
+  })
+
+  it('names the missing piece instead of returning a half-configured client', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-sa-'))
+    expect(() => loadInClusterConfig({}, dir)).toThrow(InClusterConfigError)
+    expect(() => loadInClusterConfig({ KUBERNETES_SERVICE_HOST: '10.0.0.1' }, dir)).toThrow(/token not found/)
+    writeFileSync(join(dir, 'token'), 't')
+    expect(() => loadInClusterConfig({ KUBERNETES_SERVICE_HOST: '10.0.0.1' }, dir)).toThrow(/namespace not found/)
+  })
+})
+
+describe('K8sHttp', () => {
+  it('re-reads the bearer token for every request', async () => {
+    const { config, tokens } = await fakeApiServer(() => ({ json: { ok: true } }))
+    const http = new K8sHttp(config)
+    await http.json({ method: 'GET', path: '/healthz' })
+    await http.json({ method: 'GET', path: '/healthz' })
+    expect(tokens).toEqual(['token-1', 'token-2'])
+  })
+
+  it('surfaces a Status body as a typed error callers can branch on', async () => {
+    const { config } = await fakeApiServer(() => ({
+      status: 409,
+      json: { kind: 'Status', reason: 'AlreadyExists', message: 'sandboxclaims "agent-a" already exists' }
+    }))
+    const http = new K8sHttp(config)
+    const error = await http.json({ method: 'POST', path: '/x' }).catch((err: unknown) => err)
+    expect(error).toBeInstanceOf(K8sApiError)
+    const typed = error as K8sApiError
+    expect(typed.status).toBe(409)
+    expect(typed.reason).toBe('AlreadyExists')
+    expect(typed.isAlreadyExists).toBe(true)
+    expect(typed.isConflict).toBe(true)
+    expect(typed.message).toContain('already exists')
+  })
+
+  it('treats a 410 as expired regardless of which side reports it', async () => {
+    expect(new K8sApiError(410, undefined, 'gone').isExpired).toBe(true)
+    expect(new K8sApiError(0, 'Expired', 'too old resource version').isExpired).toBe(true)
+    expect(new K8sApiError(404, 'NotFound', 'nope').isExpired).toBe(false)
+  })
+})
+
+describe('watchCollection', () => {
+  it('seeds the resume point from the list and resumes the watch at that version', async () => {
+    const { config, requests } = await fakeApiServer(({ url }) =>
+      url.searchParams.get('watch')
+        ? {
+            lines: [
+              { type: 'ADDED', object: { metadata: { name: 'a', resourceVersion: '11' } } },
+              { type: 'MODIFIED', object: { metadata: { name: 'a', resourceVersion: '12' } } }
+            ]
+          }
+        : { json: { metadata: { resourceVersion: '10' }, items: [{ metadata: { name: 'seed' } }] } }
+    )
+    const clock = new FakeClock()
+    const events = await take(
+      watchCollection(new K8sHttp(config), {
+        path: '/apis/x/claims',
+        clock,
+        backoff: new Backoff({ jitter: () => 0 })
+      }),
+      3
+    )
+    expect(events[0]).toEqual({ kind: 'synced', items: [{ metadata: { name: 'seed' } }] })
+    expect(events[1]?.kind).toBe('added')
+    expect(events[2]?.kind).toBe('modified')
+    const watchRequest = requests.find((url) => url.searchParams.get('watch'))
+    expect(watchRequest?.searchParams.get('resourceVersion')).toBe('10')
+    // Bookmarks are what keep an idle watch's resume point fresh enough to reuse.
+    expect(watchRequest?.searchParams.get('allowWatchBookmarks')).toBe('true')
+  })
+
+  it('advances the resume point on a BOOKMARK without emitting it', async () => {
+    let watches = 0
+    const { config, requests } = await fakeApiServer(({ url }) => {
+      if (!url.searchParams.get('watch')) return { json: { metadata: { resourceVersion: '10' }, items: [] } }
+      watches += 1
+      return watches === 1
+        ? { lines: [{ type: 'BOOKMARK', object: { metadata: { resourceVersion: '77' } } }] }
+        : { lines: [{ type: 'ADDED', object: { metadata: { name: 'later', resourceVersion: '78' } } }] }
+    })
+    const clock = new FakeClock()
+    const events = await take(
+      watchCollection(new K8sHttp(config), {
+        path: '/apis/x/claims',
+        clock,
+        backoff: new Backoff({ jitter: () => 0 })
+      }),
+      2
+    )
+    // synced, then the post-reconnect ADDED — the bookmark itself is not an event.
+    expect(events.map((event) => event.kind)).toEqual(['synced', 'added'])
+    const watchVersions = requests
+      .filter((url) => url.searchParams.get('watch'))
+      .map((url) => url.searchParams.get('resourceVersion'))
+    expect(watchVersions).toEqual(['10', '77'])
+  })
+
+  it('re-lists when the resume point has expired, rather than failing the watch', async () => {
+    let lists = 0
+    let watches = 0
+    const { config } = await fakeApiServer(({ url }) => {
+      if (!url.searchParams.get('watch')) {
+        lists += 1
+        return { json: { metadata: { resourceVersion: lists === 1 ? '10' : '900' }, items: [] } }
+      }
+      watches += 1
+      if (watches === 1) return { status: 410, json: { kind: 'Status', reason: 'Expired', code: 410 } }
+      return { lines: [{ type: 'ADDED', object: { metadata: { name: 'fresh', resourceVersion: '901' } } }] }
+    })
+    const clock = new FakeClock()
+    const events = await take(
+      watchCollection(new K8sHttp(config), {
+        path: '/apis/x/claims',
+        clock,
+        backoff: new Backoff({ jitter: () => 0 })
+      }),
+      3
+    )
+    // A 410 forces a fresh snapshot; the consumer sees a second `synced` and can
+    // converge instead of assuming its incremental view is still valid.
+    expect(events.map((event) => event.kind)).toEqual(['synced', 'synced', 'added'])
+    expect(lists).toBe(2)
+  })
+
+  it('re-lists on an in-band Expired ERROR event', async () => {
+    let lists = 0
+    let watches = 0
+    const { config } = await fakeApiServer(({ url }) => {
+      if (!url.searchParams.get('watch')) {
+        lists += 1
+        return { json: { metadata: { resourceVersion: `${lists}0` }, items: [] } }
+      }
+      watches += 1
+      return watches === 1
+        ? { lines: [{ type: 'ERROR', object: { kind: 'Status', reason: 'Expired', code: 410 } }] }
+        : { lines: [{ type: 'ADDED', object: { metadata: { name: 'after', resourceVersion: '31' } } }] }
+    })
+    const events = await take(
+      watchCollection(new K8sHttp(config), {
+        path: '/apis/x/claims',
+        clock: new FakeClock(),
+        backoff: new Backoff({ jitter: () => 0 })
+      }),
+      3
+    )
+    expect(events.map((event) => event.kind)).toEqual(['synced', 'synced', 'added'])
+    expect(lists).toBe(2)
+  })
+
+  it('stops when aborted', async () => {
+    const controller = new AbortController()
+    const { config } = await fakeApiServer(({ url }) =>
+      url.searchParams.get('watch')
+        ? { lines: [], hold: true }
+        : { json: { metadata: { resourceVersion: '1' }, items: [] } }
+    )
+    const source = watchCollection(new K8sHttp(config), {
+      path: '/apis/x/claims',
+      signal: controller.signal,
+      clock: new FakeClock()
+    })
+    const collected: ResourceEvent<never>[] = []
+    const drain = (async () => {
+      for await (const event of source) collected.push(event as ResourceEvent<never>)
+    })()
+    await waitUntil(() => collected.length === 1)
+    controller.abort()
+    await drain
+    expect(collected.map((event) => event.kind)).toEqual(['synced'])
+  })
+})
+
+describe('SandboxApi', () => {
+  it('addresses v1beta1 collections in the pod namespace', async () => {
+    const { config, requests } = await fakeApiServer(() => ({ json: { metadata: { name: 'agent-a' } } }))
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await api.getClaim('agent-a')
+    await api.getSandbox('sb-1')
+    expect(requests.map((url) => url.pathname)).toEqual([
+      '/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/org-test/sandboxclaims/agent-a',
+      '/apis/agents.x-k8s.io/v1beta1/namespaces/org-test/sandboxes/sb-1'
+    ])
+  })
+
+  it('treats an existing claim as success so a retried create converges', async () => {
+    let posts = 0
+    const { config, requests } = await fakeApiServer(({ method }) => {
+      if (method === 'POST') {
+        posts += 1
+        return { status: 409, json: { kind: 'Status', reason: 'AlreadyExists', message: 'exists' } }
+      }
+      return { json: { metadata: { name: 'agent-a' }, status: { sandbox: { name: 'sb-7' } } } }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const claim = await api.ensureClaim({ metadata: { name: 'agent-a' }, spec: { warmPoolRef: { name: 'pool' } } })
+    expect(posts).toBe(1)
+    expect(claim.status?.sandbox?.name).toBe('sb-7')
+    expect(requests.at(-1)?.pathname).toContain('/sandboxclaims/agent-a')
+  })
+
+  it('sends a claim body carrying the pool reference and no per-agent env', async () => {
+    let received: any
+    const { config } = await fakeApiServer(({ body }) => {
+      if (body) received = JSON.parse(body)
+      return { json: {} }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await api.ensureClaim({
+      metadata: { name: 'agent-a' },
+      spec: {
+        warmPoolRef: { name: 'ac-runtime-standard-pool' },
+        additionalPodMetadata: { labels: { 'agentconnect.md/agent': 'a' } }
+      }
+    })
+    expect(received.apiVersion).toBe('extensions.agents.x-k8s.io/v1beta1')
+    expect(received.kind).toBe('SandboxClaim')
+    expect(received.spec.warmPoolRef.name).toBe('ac-runtime-standard-pool')
+    // A claim carrying `env` or `volumeClaimTemplates` bypasses warm-pool adoption,
+    // so the shape this client sends must never grow them.
+    expect(received.spec.env).toBeUndefined()
+    expect(received.spec.volumeClaimTemplates).toBeUndefined()
+  })
+
+  it('treats deleting an absent claim as success', async () => {
+    const { config } = await fakeApiServer(() => ({ status: 404, json: { kind: 'Status', reason: 'NotFound' } }))
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await expect(api.deleteClaim('gone')).resolves.toBeUndefined()
+  })
+
+  it('guards an operatingMode patch with a test op on the value it observed', async () => {
+    let patch: any
+    let contentType: string | undefined
+    const { config } = await fakeApiServer(({ body, headers }) => {
+      if (body) patch = JSON.parse(body)
+      contentType = headers['content-type'] as string | undefined
+      return { json: { spec: { operatingMode: 'Running' } } }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await api.setOperatingMode('sb-1', 'Running', 'Suspended')
+    expect(contentType).toBe('application/json-patch+json')
+    expect(patch).toEqual([
+      { op: 'test', path: '/spec/operatingMode', value: 'Suspended' },
+      { op: 'replace', path: '/spec/operatingMode', value: 'Running' }
+    ])
+  })
+
+  it('omits the guard only when the caller states no expectation', async () => {
+    let patch: any
+    const { config } = await fakeApiServer(({ body }) => {
+      if (body) patch = JSON.parse(body)
+      return { json: {} }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await api.setOperatingMode('sb-1', 'Suspended')
+    expect(patch).toEqual([{ op: 'replace', path: '/spec/operatingMode', value: 'Suspended' }])
+  })
+
+  it('reports a lost race as a conflict rather than overwriting the newer decision', async () => {
+    const { config } = await fakeApiServer(() => ({
+      status: 409,
+      json: { kind: 'Status', reason: 'Conflict', message: 'the test operation failed' }
+    }))
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const error = await api.setOperatingMode('sb-1', 'Suspended', 'Running').catch((err: unknown) => err)
+    expect((error as K8sApiError).isConflict).toBe(true)
+  })
+
+  it('reviews a shim token with its audience and returns the bound pod identity', async () => {
+    let sent: any
+    const { config, requests } = await fakeApiServer(({ body }) => {
+      sent = JSON.parse(body)
+      return {
+        json: {
+          status: {
+            authenticated: true,
+            user: {
+              username: 'system:serviceaccount:org-test:ac-runtime',
+              extra: {
+                'authentication.kubernetes.io/pod-name': ['runtime-abc'],
+                'authentication.kubernetes.io/pod-uid': ['uid-123']
+              }
+            }
+          }
+        }
+      }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const result = await api.reviewToken('shim-token', ['ac-daemon-callback'])
+    // Cluster-scoped path: no namespace segment, which is why this needs its own
+    // ClusterRole rather than the per-namespace Role.
+    expect(requests[0]?.pathname).toBe('/apis/authentication.k8s.io/v1/tokenreviews')
+    // Without the audience the API server would accept a token minted for anything.
+    expect(sent.spec.audiences).toEqual(['ac-daemon-callback'])
+    expect(result).toEqual({
+      authenticated: true,
+      podName: 'runtime-abc',
+      podUid: 'uid-123',
+      username: 'system:serviceaccount:org-test:ac-runtime'
+    })
+  })
+
+  it('reports an unauthenticated review with its reason and no pod identity', async () => {
+    const { config } = await fakeApiServer(() => ({
+      json: { status: { authenticated: false, error: 'audiences is not valid for this token' } }
+    }))
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const result = await api.reviewToken('wrong-audience', ['ac-daemon-callback'])
+    expect(result.authenticated).toBe(false)
+    expect(result.podName).toBeUndefined()
+    expect(result.error).toMatch(/audiences/)
+  })
+
+  it('reads Ready off the Sandbox conditions', () => {
+    expect(isSandboxReady({ status: { conditions: [{ type: 'Ready', status: 'True' }] } })).toBe(true)
+    expect(isSandboxReady({ status: { conditions: [{ type: 'Ready', status: 'False' }] } })).toBe(false)
+    expect(isSandboxReady({})).toBe(false)
+  })
+})

--- a/packages/daemon/test/k8s-client.test.ts
+++ b/packages/daemon/test/k8s-client.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { Backoff, FakeClock } from '@agentconnect.md/connection'
 import { InClusterConfigError, loadInClusterConfig } from '../src/k8s/config.js'
 import { K8sApiError, K8sHttp } from '../src/k8s/http.js'
-import { SandboxApi, isSandboxReady } from '../src/k8s/sandbox-api.js'
+import { OperatingModeConflictError, SandboxApi, isSandboxReady } from '../src/k8s/sandbox-api.js'
 import { watchCollection, type ResourceEvent } from '../src/k8s/watch.js'
 import type { InClusterConfig } from '../src/k8s/config.js'
 
@@ -428,14 +428,62 @@ describe('SandboxApi', () => {
     ])
   })
 
-  it('reports a lost race as a conflict rather than overwriting the newer decision', async () => {
-    const { config } = await fakeApiServer(() => ({
-      status: 409,
-      json: { kind: 'Status', reason: 'Conflict', message: 'the test operation failed' }
-    }))
+  it('reports a lost race as a typed conflict, from the 422 the API server really sends', async () => {
+    // A failed JSON Patch `test` comes back as 422 Invalid — never 409 — and its message
+    // text comes from the patch library, so classification cannot rely on it.
+    const { config, requests } = await fakeApiServer(({ method }) =>
+      method === 'PATCH'
+        ? {
+            status: 422,
+            json: {
+              kind: 'Status',
+              apiVersion: 'v1',
+              status: 'Failure',
+              code: 422,
+              reason: 'Invalid',
+              message: 'testing value /spec/operatingMode failed'
+            }
+          }
+        : { json: { metadata: { name: 'sb-1' }, spec: { operatingMode: 'Running' } } }
+    )
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const error = await api.setOperatingMode('sb-1', 'Suspended', 'Suspended').catch((err: unknown) => err)
+    expect(error).toBeInstanceOf(OperatingModeConflictError)
+    const typed = error as OperatingModeConflictError
+    expect(typed.observed).toBe('Suspended')
+    expect(typed.actual).toBe('Running')
+    // Confirmed by re-reading the object, not by matching the message text.
+    expect(requests.filter((url) => url.pathname.endsWith('/sandboxes/sb-1'))).toHaveLength(2)
+  })
+
+  it('does not dress an unrelated 422 up as a concurrency conflict', async () => {
+    const { config } = await fakeApiServer(({ method }) =>
+      method === 'PATCH'
+        ? {
+            status: 422,
+            json: { kind: 'Status', code: 422, reason: 'Invalid', message: 'spec.operatingMode: Unsupported value' }
+          }
+        : // The guard held — the mode is still what we observed — so the 422 came from
+          // something else and must surface as itself.
+          { json: { metadata: { name: 'sb-1' }, spec: { operatingMode: 'Running' } } }
+    )
     const api = new SandboxApi(new K8sHttp(config), 'org-test')
     const error = await api.setOperatingMode('sb-1', 'Suspended', 'Running').catch((err: unknown) => err)
-    expect((error as K8sApiError).isConflict).toBe(true)
+    expect(error).toBeInstanceOf(K8sApiError)
+    expect(error).not.toBeInstanceOf(OperatingModeConflictError)
+    expect((error as K8sApiError).isUnprocessable).toBe(true)
+  })
+
+  it('surfaces the original error when the confirming read is unavailable', async () => {
+    const { config } = await fakeApiServer(({ method }) =>
+      method === 'PATCH'
+        ? { status: 422, json: { kind: 'Status', code: 422, reason: 'Invalid', message: 'rejected' } }
+        : { status: 500, json: { kind: 'Status', code: 500, reason: 'InternalError' } }
+    )
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const error = await api.setOperatingMode('sb-1', 'Suspended', 'Running').catch((err: unknown) => err)
+    expect(error).toBeInstanceOf(K8sApiError)
+    expect((error as K8sApiError).status).toBe(422)
   })
 
   it('reviews a shim token with its audience and returns the bound pod identity', async () => {

--- a/packages/daemon/test/k8s-client.test.ts
+++ b/packages/daemon/test/k8s-client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
+import { getEventListeners } from 'node:events'
 import { createServer, type Server } from 'node:http'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -258,6 +259,62 @@ describe('watchCollection', () => {
     expect(lists).toBe(2)
   })
 
+  it('backs off a failed connection without accumulating abort listeners', async () => {
+    let lists = 0
+    const { config } = await fakeApiServer(() => {
+      lists += 1
+      return lists < 4
+        ? { status: 500, json: { kind: 'Status', reason: 'InternalError', message: 'apiserver down' } }
+        : { json: { metadata: { resourceVersion: '10' }, items: [] } }
+    })
+    const controller = new AbortController()
+    const clock = new FakeClock()
+    const source = watchCollection(new K8sHttp(config), {
+      path: '/apis/x/claims',
+      signal: controller.signal,
+      clock,
+      backoff: new Backoff({ jitter: () => 0 })
+    })
+    const collected: string[] = []
+    const drain = (async () => {
+      for await (const event of source) {
+        collected.push(event.kind)
+        break
+      }
+    })()
+    // Each failed list parks on a clock-driven delay; advancing releases it. A retry
+    // whose timer wins must unregister its listener, or a long outage grows them
+    // without bound on this one long-lived signal.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await waitUntil(() => lists === attempt + 1)
+      clock.advance(60_000)
+      expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
+    }
+    await drain
+    expect(collected).toEqual(['synced'])
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
+    controller.abort()
+  })
+
+  it('returns immediately from a backoff delay on an already-aborted signal', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const { config } = await fakeApiServer(() => ({ status: 500, json: { kind: 'Status' } }))
+    const clock = new FakeClock()
+    const collected: string[] = []
+    // The loop must not park on a full backoff delay when the signal is already
+    // aborted before the listener is registered.
+    for await (const event of watchCollection(new K8sHttp(config), {
+      path: '/apis/x/claims',
+      signal: controller.signal,
+      clock,
+      backoff: new Backoff({ jitter: () => 0 })
+    })) {
+      collected.push(event.kind)
+    }
+    expect(collected).toEqual([])
+  })
+
   it('stops when aborted', async () => {
     const controller = new AbortController()
     const { config } = await fakeApiServer(({ url }) =>
@@ -305,6 +362,8 @@ describe('SandboxApi', () => {
     const api = new SandboxApi(new K8sHttp(config), 'org-test')
     const claim = await api.ensureClaim({ metadata: { name: 'agent-a' }, spec: { warmPoolRef: { name: 'pool' } } })
     expect(posts).toBe(1)
+    // The claim names the bound Sandbox and nothing more; its UID comes from that
+    // object's metadata, which is what the spawn record has to key on.
     expect(claim.status?.sandbox?.name).toBe('sb-7')
     expect(requests.at(-1)?.pathname).toContain('/sandboxclaims/agent-a')
   })
@@ -355,15 +414,18 @@ describe('SandboxApi', () => {
     ])
   })
 
-  it('omits the guard only when the caller states no expectation', async () => {
+  it('carries the guard on the suspend direction too — there is no unguarded path', async () => {
     let patch: any
     const { config } = await fakeApiServer(({ body }) => {
       if (body) patch = JSON.parse(body)
       return { json: {} }
     })
     const api = new SandboxApi(new K8sHttp(config), 'org-test')
-    await api.setOperatingMode('sb-1', 'Suspended')
-    expect(patch).toEqual([{ op: 'replace', path: '/spec/operatingMode', value: 'Suspended' }])
+    await api.setOperatingMode('sb-1', 'Suspended', 'Running')
+    expect(patch).toEqual([
+      { op: 'test', path: '/spec/operatingMode', value: 'Running' },
+      { op: 'replace', path: '/spec/operatingMode', value: 'Suspended' }
+    ])
   })
 
   it('reports a lost race as a conflict rather than overwriting the newer decision', async () => {
@@ -425,5 +487,14 @@ describe('SandboxApi', () => {
     expect(isSandboxReady({ status: { conditions: [{ type: 'Ready', status: 'True' }] } })).toBe(true)
     expect(isSandboxReady({ status: { conditions: [{ type: 'Ready', status: 'False' }] } })).toBe(false)
     expect(isSandboxReady({})).toBe(false)
+  })
+
+  it('exposes the Sandbox UID from object metadata, the only place it exists', async () => {
+    const { config } = await fakeApiServer(() => ({
+      json: { metadata: { name: 'sb-7', uid: 'sandbox-uid-9' }, spec: { operatingMode: 'Running' } }
+    }))
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const sandbox = await api.getSandbox('sb-7')
+    expect(sandbox.metadata?.uid).toBe('sandbox-uid-9')
   })
 })


### PR DESCRIPTION
Closes #811. Part of #804.

agent-sandbox ships Go and Python SDKs; this daemon is TypeScript. Its CRDs are
ordinary REST endpoints, so the missing TS SDK costs nothing — this adds exactly what
the daemon needs, with **no new npm dependency**.

## Three parts

**`src/k8s/config.ts`** — in-cluster discovery. The load-bearing detail is that the
bearer token is read **per request**, not once: the kubelet rotates the projected
token in place, so a boot-time capture expires under a long-lived daemon. It throws
with the missing piece named rather than handing back a half-configured client.

**`src/k8s/http.ts`** — `node:http(s)`, deliberately not `fetch`. The API server
presents its own CA; pinning it is a plain per-request option here, while `fetch`
would need an undici dispatcher this package does not depend on. It also hands us the
raw stream a watch needs. Rejections become `K8sApiError` carrying `status` and
`Status.reason`, so callers branch on `isConflict` / `isExpired` / `isAlreadyExists`
instead of matching message text.

**`src/k8s/watch.ts`** — the part that is genuinely easy to get wrong, so it is worth
the review attention:

- the initial LIST establishes both the snapshot **and** the `resourceVersion` the
  watch resumes from, so no change between the two is lost;
- `allowWatchBookmarks` keeps an idle watch's resume point fresh — without it a quiet
  resource drifts far enough behind to be `Expired` on the next reconnect;
- a `410 Gone` / `Expired` is answered by re-LISTing, not by failing. It arrives two
  ways — as a response status, or **in-band as an `ERROR` event on an open stream** —
  and both are handled. This is precisely why `list` is a required verb in this
  client's RBAC rather than an optional extra;
- a cleanly closed stream is the server-side timeout and reconnects immediately; a
  failed connection backs off through the shared `Backoff`, and the loop takes an
  injected `Clock`, so tests drive it deterministically with no real timers.

Every re-sync yields a fresh `synced` snapshot, so consumers converge their view
rather than assuming incremental continuity across a gap.

**`src/k8s/sandbox-api.ts`** — one method per granted verb and nothing more. The type
surface mirrors the Role, because a method the Role does not authorize could only ever
fail at runtime. Three behaviors encode decisions rather than convenience:

- claim create treats `AlreadyExists` as success and delete treats `NotFound` as
  success — both are keyed on the agent id and must converge on retry;
- `operatingMode` writes are JSON Patch with a `test` guard on the value we observed,
  so a wake racing a suspend decision fails as a **conflict** instead of silently
  overriding the newer decision;
- `reviewToken` always sends `audiences`; omitting it would accept a token minted for
  something else entirely. TokenReview is cluster-scoped, which is why it needs its
  own ClusterRole rather than the per-namespace Role covering everything else.

The Pod API is absent by design — pods are the vendor controller's to materialize.

## Tests

21 tests against a `node:http` fake API server. The ones that matter are the watch
semantics: resume point seeded from the list, bookmark advancing the resume point
without surfacing as an event, `410`-as-status and `Expired`-as-in-band-event both
re-listing, and abort stopping the loop. Plus: the token is re-read per request (the
fake returns a distinct value each read, so a client that caches it fails), the claim
body carries `warmPoolRef` and **never** `env` or `volumeClaimTemplates` (either would
bypass warm-pool adoption), and the patch guard is present or absent exactly as the
caller states an expectation.

Daemon typecheck, eslint, prettier clean.

## Not in this PR

Nothing consumes this yet. The cluster spawn driver (#816) is its first caller, and
the shim handshake (#813) is what needs `reviewToken`.
