### PR TITLE
feat(web): add the dock's Files tab and the left-pane file viewer

### DIFF
--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -203,10 +203,11 @@ Fetching both blobs and reusing the LCS path instead would work but is worse on
 every axis — two round trips per file, quadratic matching on large files, and it
 throws away git's own rename/whitespace handling.
 
-**Deep-linking.** Open question: is the viewer URL-addressable
-(`/sessions/:id?file=…&mode=diff`) or transient component state? Addressable is
-strictly better for a review workflow — "look at this file" is a link people
-send — but it puts a second resource in a route that today is one session.
+**Deep-linking.** Settled in M1: the viewer is URL-addressable, `?file=<path>`
+plus `agent=<id>` on the session route. "Look at this file" is a link people send,
+so it has to survive a reload and name the workspace it was made from; §9's M1
+entry records the mechanics and why `replace` beats `push`. M2 adds `mode` to the
+same param set when the Diff view arrives.
 
 ## 5. Gap analysis — the two AI features
 
@@ -581,14 +582,20 @@ conversation↔viewer mode switch and the deep-link decision. No protocol change
 _Exit:_ browse a session worktree and read any file without leaving the session.
 **Landed.**
 
-The deep-link question §12 left open is settled: the viewer IS URL-addressable,
-`?file=<path>` on the session route, written with `router.replace` so reading N
-files costs no history entries and Back still means leaving the session. The
-conversation pane is **concealed, not unmounted** (`hidden` vs `contents` on one
-JSX slot) — every expanded tool body, the composer's caret and any open @mention
-menu is state a file read must not spend.
+The deep-link question §12 Q1 left open is settled the addressable way: the
+viewer is `?file=<path>` on the session route, written with `router.replace` —
+it is a pane mode inside one route, not a place, so pushing would spend a history
+entry per tree click and Back would stop meaning "leave this session". The link
+carries `agent=<id>` beside the path, because a merged conversation's header focus
+is component state that follows whichever participant is newest: without the
+workspace identity, a link copied while focused on one agent reopens that path
+against another's checkout.
 
-Known M1 follow-ups:
+The conversation pane is **concealed, not unmounted** (`hidden` vs `contents` on
+one JSX slot) — every expanded tool body, the composer's caret and any open
+@mention menu is state a file read must not spend.
+
+Known M1 follow-ups, none of which change what the code does today:
 
 - A `?file=` naming a **directory** — or a path that escapes the workspace —
   reads as "the daemon may be offline". The daemon raises
@@ -600,12 +607,10 @@ Known M1 follow-ups:
 - Two app-wiring mutants still survive: dropping the Files tab when
   `filesAgentId` is null, and the `dockTabKey` existence fallback. The primitives
   under them are covered; only the wiring is not.
-  **Landed.** The deep-link question (§4, §12 Q1) is settled the addressable way:
-  `?file=<path>` on the session route, written with `router.replace` — the viewer is
-  a pane mode inside one route, so pushing would spend a history entry per tree
-  click and Back would stop meaning "leave this session".
-
-Known M1 follow-ups, none of which change what the code does today:
+- Two review fixes are **unpinned by tests**: holding the Files surface while a
+  related session's isolation is still unknown, and keying the viewer on the
+  whole workspace scope rather than the path alone. Both need a multi-agent focus
+  fixture with a pending `extraHeaderDetail`, which this suite does not build yet.
 
 - A pending **webchat MCP write approval** is concealed with the composer and has
   no header twin the way permission requests do (those stay reachable in the
@@ -716,9 +721,8 @@ location, body, and the review state that already comes from `HookRun.verdict`.
 
 ## 12. Open questions
 
-1. **Viewer deep-linking.** URL-addressable (`?file=…&mode=diff`) or transient
-   state? Addressable is better for review workflows but puts a second resource
-   in a one-session route.
+1. ~~**Viewer deep-linking.**~~ Settled in M1 — addressable, `?file=` + `agent=`,
+   written with `replace`. See §4 and §9's M1 entry.
 2. **Thread resolution.** §5.2 leaves resolving GitHub threads to the agent's
    own write-back inside the Auto-fix turn. Is that reliable enough in practice,
    or does the panel eventually need its own resolve control? Worth revisiting

--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -607,10 +607,14 @@ Known M1 follow-ups, none of which change what the code does today:
 - Two app-wiring mutants still survive: dropping the Files tab when
   `filesAgentId` is null, and the `dockTabKey` existence fallback. The primitives
   under them are covered; only the wiring is not.
-- Two review fixes are **unpinned by tests**: holding the Files surface while a
-  related session's isolation is still unknown, and keying the viewer on the
-  whole workspace scope rather than the path alone. Both need a multi-agent focus
-  fixture with a pending `extraHeaderDetail`, which this suite does not build yet.
+- Four review fixes are **unpinned by tests**, all for the same missing fixture —
+  a multi-agent focus menu with a pending or rejected `extraHeaderDetail`, which
+  this suite does not build: holding the Files surface while a related session's
+  isolation is unknown, the unavailable state when that read is rejected outright,
+  keying the viewer on the whole workspace scope rather than the path alone, and
+  the focus menu rewriting the link's `agent` so it is not a no-op while a file is
+  open. The code is right; the guard is missing, and a test that cannot construct
+  the state would be worse than none.
 
 - A pending **webchat MCP write approval** is concealed with the composer and has
   no header twin the way permission requests do (those stay reachable in the

--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -579,6 +579,56 @@ Known M0 follow-ups, none of which change what the code does today:
 viewer in File mode over `workspace/read` + `@/lib/highlight`, including the
 conversation↔viewer mode switch and the deep-link decision. No protocol change.
 _Exit:_ browse a session worktree and read any file without leaving the session.
+**Landed.**
+
+The deep-link question §12 left open is settled: the viewer IS URL-addressable,
+`?file=<path>` on the session route, written with `router.replace` so reading N
+files costs no history entries and Back still means leaving the session. The
+conversation pane is **concealed, not unmounted** (`hidden` vs `contents` on one
+JSX slot) — every expanded tool body, the composer's caret and any open @mention
+menu is state a file read must not spend.
+
+Known M1 follow-ups:
+
+- A `?file=` naming a **directory** — or a path that escapes the workspace —
+  reads as "the daemon may be offline". The daemon raises
+  `WorkspaceViolationError`, the CP maps that to 503, and the viewer cannot tell
+  it from a real outage. Distinguishing it needs a daemon/CP error code, not a
+  web change, so it waits for the next milestone that touches those layers.
+- The filter corpus is rebuilt and sorted on every folder expansion even while
+  the box is empty. Harmless at today's tree sizes; gate the memo on the query.
+- Two app-wiring mutants still survive: dropping the Files tab when
+  `filesAgentId` is null, and the `dockTabKey` existence fallback. The primitives
+  under them are covered; only the wiring is not.
+  **Landed.** The deep-link question (§4, §12 Q1) is settled the addressable way:
+  `?file=<path>` on the session route, written with `router.replace` — the viewer is
+  a pane mode inside one route, so pushing would spend a history entry per tree
+  click and Back would stop meaning "leave this session".
+
+Known M1 follow-ups, none of which change what the code does today:
+
+- A pending **webchat MCP write approval** is concealed with the composer and has
+  no header twin the way permission requests do (those stay reachable in the
+  Requests popover). A reader with a file open sees the agent stall. Either that
+  card needs a home above the viewer, or the viewer needs to surface a pending
+  count.
+- The reader's **place in the transcript is not preserved** across a viewer round
+  trip: the concealed pane stops contributing height to `.content`, so the browser
+  clamps `scrollTop`. Restoring it needs the offset captured _before_ the swap and
+  keyed per session, which is more state than this seam carries.
+- The viewer's own scroller is a class-level arrangement: an `overflow-auto` box
+  under `min-h-0 flex-1`, inside the `min-h-full` body column. happy-dom has no
+  layout engine, so "it never grows the page" is unmeasured and needs a real
+  browser — the same caveat as M0's resize handle.
+- `SessionDetailFrame` keeps its 880px cap, so a cold load straight into `?file=`
+  paints the centred loading state at 880px for one round trip before the viewer
+  takes the full width. Invisible for a centred spinner; it becomes visible the
+  day that frame draws content.
+- The Files panel is mounted on **every** session page, not on first visit to its
+  tab. Its verdict is what keeps the dock out of `vacant`, and a lazily mounted
+  panel makes the tab unreachable — both tabs non-ready withholds the strip that
+  would mount it. Cost: one `workspace/list` and one or two `workspace/gitstatus`
+  reads per session page view.
 
 **M2 — Git read + diff viewer.** `WorkspaceGitFile.additions/deletions`, the
 `workspace/gitdiff` and `workspace/gitlog` frames + routes, the unified-diff

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -367,6 +367,26 @@ it('turns slash-separated new-file directories into breadcrumb segments', async 
   expect(writeWorkspaceFile).toHaveBeenCalledWith('agent-a', 'guides/setup/README.md', { content: '# Setup' })
 })
 
+it('loads and expands the directories a new-file path names', async () => {
+  workspace.entries = [{ name: 'guides', type: 'dir', size: null, mtime: null }]
+  workspace.listings = {
+    guides: [{ name: 'setup', type: 'dir', size: null, mtime: null }],
+    'guides/setup': [{ name: 'intro.md', type: 'file', size: 4, mtime: null }]
+  }
+  await renderWorkspace()
+  await clickButton('Add file')
+
+  const path = container?.querySelector<HTMLInputElement>('input[aria-label="New file path"]')
+  await changeValue(path!, 'guides/setup/')
+  await act(async () => Promise.resolve())
+
+  // Each typed segment is fetched and left open, so the tree behind the draft shows where the file is about to land.
+  const requested = vi.mocked(fetchWorkspaceFiles).mock.calls.map((call) => call[1].path)
+  expect(requested).toContain('guides')
+  expect(requested).toContain('guides/setup')
+  expect(container?.textContent).toContain('intro.md')
+})
+
 it('keeps file identity in the breadcrumb and confirms deletion inline', async () => {
   workspace.entries = [
     {

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -1,17 +1,8 @@
 'use client'
 
-// Live workspace file browser for one agent — modelled on GitHub's file explorer:
-// a single workspace card up top, an expandable directory tree on the left, and
-// a file preview on the right. Listings and file bytes are proxied through the CP
-// straight from the owning daemon (never stored on the CP — body-locality), so a
-// 503 here just means that daemon is offline / the agent is unplaced — an expected
-// state, rendered as a friendly notice.
-//
-// This component owns the live git read model (status / pull) but not the card
-// that displays it: it projects that state into a <WorkspaceHeaderInfo> and hands
-// it to `renderHeader`, so the workspace card can also carry the source and
-// repository-authorization controls, which need agent-level data this component
-// has no business fetching. Demo agents use <WorkspaceFilesMock>.
+// Live workspace file browser for one agent, GitHub-style: a workspace card up top, an expandable tree on the left, a file preview on the right. Demo agents use <WorkspaceFilesMock>.
+// The tree and git-status read model is `workspace-tree.tsx`, shared with the dock's Files panel; this file owns the preview, the editor and the pull, and file bytes are proxied live from the owning daemon (body-locality), so a 503 is an expected state rendered as a notice.
+// It projects the git read model into a <WorkspaceHeaderInfo> for `renderHeader` rather than drawing the card, which also carries source and repository-authorization controls needing agent-level data this component has no business fetching.
 
 import { Fragment, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import dynamic from 'next/dynamic'
@@ -20,13 +11,9 @@ import {
   deleteWorkspaceFile,
   fetchWorkspaceFile,
   fetchWorkspaceFileFull,
-  fetchWorkspaceFiles,
-  fetchWorkspaceGitStatus,
   writeWorkspaceFile,
   workspaceGitPull,
-  type WorkspaceEntryDto,
-  type WorkspaceFileDto,
-  type WorkspaceGitStatusDto
+  type WorkspaceFileDto
 } from '@/lib/api'
 import { Spinner } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
@@ -45,11 +32,17 @@ import {
   FileBrowserRow,
   FileBrowserShell,
   MARKDOWN_FILE_RE,
-  fileBrowserGlyph,
   formatFileMtime,
   formatFileSize,
   type FileBrowserEditorDraft
 } from '@/components/console/FileBrowser'
+import {
+  StatusBadge,
+  useWorkspaceGitStatus,
+  useWorkspaceTree,
+  workspaceDirtyMap,
+  workspaceEntryIcon
+} from '@/components/console/workspace-tree'
 
 // react-markdown + remark-gfm are heavy and only needed when a markdown file is
 // previewed, so keep them out of the main console bundle (lazy client chunk).
@@ -82,13 +75,6 @@ export function workspaceReadModelKey(agent: Pick<Agent, 'id' | 'workspace' | 'w
   return ws.mode === 'github' ? `${at}:github:${ws.repo}@${ws.branch}:${ws.agentDir}` : `${at}:scratch`
 }
 
-function entryIcon(e: WorkspaceEntryDto): string {
-  if (e.type === 'dir') return 'folder'
-  if (e.type === 'symlink') return 'link-2'
-  if (e.type === 'other') return 'file-question-mark'
-  return fileBrowserGlyph(e.name)
-}
-
 // Parse a full git remote address (https or ssh) into a display label ("org/repo")
 // and a browsable https URL. Returns null when it doesn't look like a hosted repo.
 function parseRemote(repo: string | null): { label: string; host: string; url: string } | null {
@@ -96,43 +82,6 @@ function parseRemote(repo: string | null): { label: string; host: string; url: s
   const m = repo.match(/^https?:\/\/([^/]+)\/(.+?)(?:\.git)?\/?$/) ?? repo.match(/^git@([^:]+):(.+?)(?:\.git)?\/?$/)
   if (!m) return null
   return { host: m[1]!, label: m[2]!, url: `https://${m[1]}/${m[2]}` }
-}
-
-// A one-letter git status for the tree badge, coloured GitHub-style: modified/renamed
-// amber, added/untracked green, deleted red.
-function statusMeta(ch: string): { color: string; title: string } {
-  switch (ch) {
-    case 'A':
-    case 'U':
-      return { color: 'var(--green-500)', title: ch === 'U' ? 'Untracked' : 'Added' }
-    case 'D':
-      return { color: 'var(--red-500)', title: 'Deleted' }
-    case 'R':
-      return { color: 'var(--amber-500)', title: 'Renamed' }
-    default:
-      return { color: 'var(--amber-500)', title: 'Modified' }
-  }
-}
-
-// Per-directory listing state, keyed by directory path ('' = workspace root). Loaded
-// lazily: the root on mount, each folder on first expand.
-type DirState = {
-  entries: WorkspaceEntryDto[] | null
-  exists: boolean
-  nextCursor: string | null
-  loading: boolean
-  loadingMore: boolean
-  err: string | null
-  moreErr: string | null
-}
-const LOADING_DIR: DirState = {
-  entries: null,
-  exists: true,
-  nextCursor: null,
-  loading: true,
-  loadingMore: false,
-  err: null,
-  moreErr: null
 }
 
 type Viewer = {
@@ -177,85 +126,23 @@ export function WorkspaceFiles({
   renderHeader: (header: WorkspaceHeaderInfo) => ReactNode
 }) {
   const isMobile = useIsMobile()
-  const [dirs, setDirs] = useState<Record<string, DirState>>({})
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
   const [viewer, setViewer] = useState<Viewer | null>(null)
   const [editor, setEditor] = useState<FileBrowserEditorDraft | null>(null)
   const [deleteDraft, setDeleteDraft] = useState<DeleteDraft | null>(null)
   const [mobileListSignal, setMobileListSignal] = useState(0)
-  // git-repo workspaces: current-checkout status + on-demand pull. Null while
-  // loading, for a non-repo workspace, and when the owning daemon is offline —
-  // the workspace card falls back to the agent's configured source in all three.
-  const [git, setGit] = useState<WorkspaceGitStatusDto | null>(null)
-  const [primaryBranch, setPrimaryBranch] = useState<string | null>(null)
   const [gitPulling, setGitPulling] = useState(false)
   const [gitMsg, setGitMsg] = useState<string | null>(null)
   // Bumped after a pull to re-fetch both the git status and the tree.
   const [refreshTick, setRefreshTick] = useState(0)
+  // The tree and git halves of the read model, shared with the dock's Files panel.
+  const { dirs, expanded, toggleDir, loadMoreDir, openPath } = useWorkspaceTree(agentId, sessionId, refreshTick)
+  // `git` is null while loading, for a non-repo workspace, and when the owning daemon is offline — the workspace card falls back to the agent's configured source in all three.
+  const { git, primaryBranch } = useWorkspaceGitStatus(agentId, sessionId, refreshTick)
   // One-shot: on first entry, auto-preview the project guide (CLAUDE.md / README.md).
   const autoOpenedRef = useRef(false)
   // A path check alone cannot distinguish A → B → A requests. Sequence every file
   // read so an older response can never replace or append to a newer selection.
   const viewerRequestRef = useRef(0)
-
-  // Patch one directory's state, seeding from LOADING_DIR when first seen.
-  const patchDir = (path: string, patch: Partial<DirState>) =>
-    setDirs((prev) => ({ ...prev, [path]: { ...(prev[path] ?? LOADING_DIR), ...patch } }))
-
-  // Fetch a folder's first page (root on mount, or a folder on first expand).
-  const loadDir = (path: string) => {
-    patchDir(path, { loading: true, err: null })
-    fetchWorkspaceFiles(agentId, { path, ...(sessionId ? { sessionId } : {}) }).then(
-      (page) =>
-        setDirs((prev) => ({
-          ...prev,
-          [path]: {
-            entries: page.entries,
-            exists: page.exists,
-            nextCursor: page.nextCursor,
-            loading: false,
-            loadingMore: false,
-            err: null,
-            moreErr: null
-          }
-        })),
-      (e) => patchDir(path, { loading: false, err: msg(e) })
-    )
-  }
-
-  const loadMoreDir = (path: string) => {
-    const d = dirs[path]
-    if (!d?.nextCursor || d.loadingMore) return
-    patchDir(path, { loadingMore: true, moreErr: null })
-    fetchWorkspaceFiles(agentId, { path, cursor: d.nextCursor, ...(sessionId ? { sessionId } : {}) }).then(
-      (page) =>
-        setDirs((prev) => {
-          const cur = prev[path]
-          if (!cur) return prev
-          return {
-            ...prev,
-            [path]: {
-              ...cur,
-              entries: [...(cur.entries ?? []), ...page.entries],
-              nextCursor: page.nextCursor,
-              loadingMore: false
-            }
-          }
-        }),
-      (e) => patchDir(path, { loadingMore: false, moreErr: msg(e) })
-    )
-  }
-
-  const toggleDir = (path: string) => {
-    const willOpen = !expanded.has(path)
-    setExpanded((prev) => {
-      const next = new Set(prev)
-      if (next.has(path)) next.delete(path)
-      else next.add(path)
-      return next
-    })
-    if (willOpen && !dirs[path]) loadDir(path)
-  }
 
   // Select a file into the right-hand preview pane (fetch its first slice).
   const selectFile = (filePath: string, name: string) => {
@@ -292,35 +179,6 @@ export function WorkspaceFiles({
     if (!viewer) return undefined
     return resolveWorkspaceMarkdownLink(viewer.path, href, (target) => selectFile(target.path, target.name))
   }
-
-  // Reset the tree and load the root whenever the agent changes or a pull lands.
-  useEffect(() => {
-    let active = true
-    setDirs({ '': { ...LOADING_DIR } })
-    setExpanded(new Set())
-    fetchWorkspaceFiles(agentId, { path: '', ...(sessionId ? { sessionId } : {}) }).then(
-      (page) => {
-        if (!active) return
-        setDirs({
-          '': {
-            entries: page.entries,
-            exists: page.exists,
-            nextCursor: page.nextCursor,
-            loading: false,
-            loadingMore: false,
-            err: null,
-            moreErr: null
-          }
-        })
-      },
-      (e) => {
-        if (active) setDirs({ '': { ...LOADING_DIR, loading: false, err: msg(e) } })
-      }
-    )
-    return () => {
-      active = false
-    }
-  }, [agentId, refreshTick, sessionId])
 
   // Per-agent view reset (NOT on a refreshTick bump — that would erase the pull
   // message and yank the open file / re-run the one-shot auto-open).
@@ -376,38 +234,6 @@ export function WorkspaceFiles({
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [deleteDraft])
-
-  // git status of the workspace checkout. A non-repo answer and a thrown request
-  // (offline daemon) both leave `git` unset — the workspace card then renders the
-  // agent's configured source with no live status half.
-  useEffect(() => {
-    let active = true
-    fetchWorkspaceGitStatus(agentId, sessionId).then(
-      (s) => {
-        if (!active) return
-        setGit(s.isRepo ? s : null)
-        if (!sessionId) setPrimaryBranch(s.isRepo ? s.branch : null)
-      },
-      () => {
-        if (!active) return
-        setGit(null)
-        if (!sessionId) setPrimaryBranch(null)
-      }
-    )
-    if (sessionId) {
-      fetchWorkspaceGitStatus(agentId).then(
-        (s) => {
-          if (active) setPrimaryBranch(s.isRepo ? s.branch : null)
-        },
-        () => {
-          if (active) setPrimaryBranch(null)
-        }
-      )
-    }
-    return () => {
-      active = false
-    }
-  }, [agentId, refreshTick, sessionId])
 
   // On first entry, preload the project guide so the desktop preview isn't empty.
   // Mobile starts unselected on the shared browser's file list.
@@ -471,25 +297,8 @@ export function WorkspaceFiles({
     selectFile(path, path.split('/').at(-1) ?? path)
   }
 
-  // Map browse-relative path → git status letter for the tree badges. git file paths
-  // are repo-relative; if the browse root sits in a repo subdir (agentDir), also index
-  // the subdir-relative form so badges match whichever root the daemon lists from.
-  const dirtyMap = useMemo(() => {
-    const m = new Map<string, string>()
-    if (!git) return m
-    const ad = (git.agentDir ?? '').replace(/^\.?\/*/, '').replace(/\/+$/, '')
-    for (const f of git.files) {
-      const x = (f.index ?? '').trim()
-      const y = (f.workingDir ?? '').trim()
-      const ch = x === '?' || y === '?' ? 'U' : (x || y || 'M').charAt(0)
-      const put = (p: string) => {
-        if (p && !m.has(p)) m.set(p, ch)
-      }
-      put(f.path)
-      if (ad && (f.path === ad || f.path.startsWith(`${ad}/`))) put(f.path.slice(ad.length + 1))
-    }
-    return m
-  }, [git])
+  // Browse-relative path → git status letter for the tree badges.
+  const dirtyMap = useMemo(() => workspaceDirtyMap(git), [git])
 
   const root = dirs['']
   const selectedDirectory = viewer ? viewer.path.split('/').slice(0, -1).join('/') : ''
@@ -604,11 +413,7 @@ export function WorkspaceFiles({
     const targetDirectory = [editor.directory, ...typedDirectories].filter(Boolean).join('/')
     if (!targetDirectory) return
     const parts = targetDirectory.split('/').filter(Boolean)
-    const paths = parts.map((_, index) => parts.slice(0, index + 1).join('/'))
-    setExpanded((current) => new Set([...current, ...paths]))
-    for (const directory of paths) {
-      if (!dirs[directory]) loadDir(directory)
-    }
+    openPath(parts.map((_, index) => parts.slice(0, index + 1).join('/')))
   }
 
   const breadcrumbPath = editor ? editor.target || editor.directory : (viewer?.path ?? '')
@@ -661,7 +466,7 @@ export function WorkspaceFiles({
             <FileBrowserRow
               key={full}
               depth={depth}
-              icon={entryIcon(e)}
+              icon={workspaceEntryIcon(e)}
               name={e.name}
               title={meta}
               trailing={status ? <StatusBadge ch={status} /> : undefined}
@@ -889,19 +694,6 @@ function EmptyNote({ text }: { text: string }) {
       <Icon name="folder" size={20} color="var(--text-tertiary)" />
       <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">{text}</div>
     </div>
-  )
-}
-
-export function StatusBadge({ ch }: { ch: string }) {
-  const { color, title } = statusMeta(ch)
-  return (
-    <span
-      className="mono inline-flex h-[15px] w-[15px] flex-none items-center justify-center rounded-xs bg-(--surface-sunken) text-[10px] font-bold"
-      title={`${title} (uncommitted)`}
-      style={{ color }}
-    >
-      {ch}
-    </span>
   )
 }
 

--- a/packages/web/src/components/console/WorkspaceFilesMock.tsx
+++ b/packages/web/src/components/console/WorkspaceFilesMock.tsx
@@ -11,7 +11,7 @@ import dynamic from 'next/dynamic'
 import { flattenFiles, type WorkspaceFile } from '@/lib/data'
 import { indexWorkspaceFileTree, resolveWorkspaceMarkdownLink } from '@/components/console/workspace-links'
 import type { MarkdownLinkResolution } from '@/components/console/MarkdownView'
-import { StatusBadge } from '@/components/console/WorkspaceFiles'
+import { StatusBadge } from '@/components/console/workspace-tree'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import {
   FileBrowserLayout,

--- a/packages/web/src/components/console/dock/DockPanel.test.tsx
+++ b/packages/web/src/components/console/dock/DockPanel.test.tsx
@@ -1,0 +1,269 @@
+// @vitest-environment happy-dom
+
+// Two tabs, one body position: what the dock draws for the tab a reader is looking at, what it must NOT draw for the one they are not, and the placeholder branch that only becomes reachable once a second tab is usually ready.
+
+import { act, useEffect, useRef, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const wire = vi.hoisted(() => ({
+  entries: [] as Array<{ name: string; type: string }>,
+  /** Non-null holds every listing until it is released, which is the only window in which the Files tab is not ready. */
+  gate: null as null | Array<() => void>
+}))
+
+vi.mock('@/lib/api', () => ({
+  ApiError: class ApiError extends Error {
+    constructor(public status: number) {
+      super(`HTTP ${status}`)
+    }
+  },
+  fetchWorkspaceFiles: vi.fn(async (_agentId: string, opts: { path: string }) => {
+    if (wire.gate) await new Promise<void>((resolve) => wire.gate?.push(resolve))
+    return {
+      path: opts.path,
+      exists: true,
+      entries: wire.entries.map((entry) => ({ ...entry, size: 10, mtime: null })),
+      nextCursor: null
+    }
+  }),
+  fetchWorkspaceGitStatus: vi.fn(() => Promise.resolve({ isRepo: false })),
+  // The Sessions panel hydrates pins through this; no case here has a pin to hydrate.
+  fetchSessionDetail: vi.fn(() => Promise.reject(new Error('no detail'))),
+  sessionFromDetailDto: (dto: unknown) => dto
+}))
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ orgPath: (path: string) => path, activeOrg: { id: 'org-1' } })
+}))
+
+vi.mock('@/lib/data-context', () => ({ useConsoleData: () => ({ agents: [], crons: [] }) }))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>
+}))
+
+// The dock reads the shell's mobile action slot; mounting the real Shell would pull the whole console behind the mocked api.
+vi.mock('@/components/console/Shell', () => ({
+  useMobileActionSlot: () => ({ action: null, register: () => {} })
+}))
+
+import { DockPanel, SessionDock, type DockTab } from './SessionDock'
+import { FilesPanel, filesTabStatus } from './FilesPanel'
+import { SessionsPanel } from './SessionsPanel'
+import type { Session } from '@/lib/data'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let container: HTMLDivElement | undefined
+let root: ReturnType<typeof createRoot> | undefined
+
+beforeEach(() => {
+  wire.entries = [{ name: 'src', type: 'dir' }]
+  wire.gate = null
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  window.localStorage.clear()
+  // happy-dom's matchMedia ignores innerWidth, and `useIsMobile` reads the band.
+  window.matchMedia = ((query: string) => ({
+    matches: /max-width:\s*768px/.test(query) ? window.innerWidth <= 768 : false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    onchange: null,
+    dispatchEvent: () => false
+  })) as unknown as typeof window.matchMedia
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container?.remove()
+  container = undefined
+  root = undefined
+})
+
+const text = () => container?.textContent ?? ''
+
+describe('DockPanel', () => {
+  // One mount, one node — the property, not its markup: an inactive panel that unmounted would silence the verdict that sets its own tab's status and throw away its tree, filter and scroll position.
+  function Counted({ mounts, nodes }: { mounts: { current: number }; nodes: HTMLElement[] }) {
+    const ref = useRef<HTMLDivElement | null>(null)
+    useEffect(() => {
+      mounts.current += 1
+    }, [mounts])
+    useEffect(() => {
+      if (ref.current) nodes.push(ref.current)
+    })
+    return <div ref={ref} data-counted="" />
+  }
+
+  it('keeps the same mount and the same node across being hidden and shown again', async () => {
+    const mounts = { current: 0 }
+    const nodes: HTMLElement[] = []
+    const render = (active: boolean) =>
+      act(() => {
+        root?.render(
+          <DockPanel active={active}>
+            <Counted mounts={mounts} nodes={nodes} />
+          </DockPanel>
+        )
+      })
+    await render(true)
+    const first = container?.querySelector('[data-counted]')
+    await render(false)
+    await render(true)
+    expect(mounts.current).toBe(1)
+    expect(container?.querySelector('[data-counted]')).toBe(first)
+    expect(new Set(nodes).size).toBe(1)
+  })
+
+  it('spends no box of its own while active, and draws nothing while not', async () => {
+    await act(() => {
+      root?.render(
+        <DockPanel active>
+          <div data-counted="" />
+        </DockPanel>
+      )
+    })
+    expect(container?.querySelector('[data-dock-panel]')?.className).toBe('contents')
+    await act(() => {
+      root?.render(
+        <DockPanel active={false}>
+          <div data-counted="" />
+        </DockPanel>
+      )
+    })
+    expect(container?.querySelector('[data-dock-panel]')?.className).toBe('hidden')
+  })
+})
+
+// The caller's own composition, as SessionDetailView builds it: two tabs, both panels mounted, the dock told which one is active.
+const SESSIONS_TAB: DockTab = { key: 'sessions', label: 'Sessions', icon: 'messages-square' }
+const FILES_TAB: DockTab = { key: 'files', label: 'Files', icon: 'folder-tree' }
+
+const openSession: Session = {
+  id: 'session-1',
+  title: 'Session one',
+  time: '11:02 AM',
+  lastActivityAt: '2026-08-10T11:02:00.000Z',
+  status: 'online',
+  platform: 'slack',
+  channel: '#ops',
+  user: 'sam',
+  duration: '1m',
+  tokens: '2.1K',
+  cost: '$0.01',
+  toolCount: '1',
+  statusLabel: 'completed',
+  steps: [],
+  agentId: 'agent-1'
+}
+
+function Host({ activeKey, sessions }: { activeKey: string; sessions: Session[] }) {
+  const [filesSettled, setFilesSettled] = useState(false)
+  const [sessionsWouldHide, setSessionsWouldHide] = useState<boolean | null>(null)
+  const tabs: DockTab[] = [
+    // The Sessions verdict, settled: `empty` only once the panel has answered that it would hide itself.
+    {
+      ...SESSIONS_TAB,
+      status: sessionsWouldHide === false ? 'ready' : sessionsWouldHide === true ? 'empty' : 'loading'
+    },
+    { ...FILES_TAB, status: filesTabStatus(filesSettled) }
+  ]
+  return (
+    <SessionDock tabs={tabs} activeKey={activeKey} onTabChange={() => {}} label="Panels">
+      <DockPanel active={activeKey === 'sessions'}>
+        <SessionsPanel
+          sessions={sessions}
+          current={openSession}
+          total={sessions.length}
+          agentIds={[]}
+          filterTouched={false}
+          onAgentIdsChange={() => {}}
+          family={{ parentSessions: [], siblingSessions: [], childSessions: [] }}
+          flatView={false}
+          onSelect={() => {}}
+          onWouldHideChange={setSessionsWouldHide}
+        />
+      </DockPanel>
+      <DockPanel active={activeKey === 'files'}>
+        <FilesPanel
+          agentId="agent-1"
+          sessionId="session-1"
+          onOpenFile={() => {}}
+          onRootSettledChange={setFilesSettled}
+        />
+      </DockPanel>
+    </SessionDock>
+  )
+}
+
+async function host(props: { activeKey: string; sessions?: Session[] }) {
+  await act(async () => {
+    root?.render(<Host activeKey={props.activeKey} sessions={props.sessions ?? [openSession]} />)
+    await Promise.resolve()
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+const activePanel = () => container?.querySelector('[data-dock-panel][data-dock-panel-active]')
+// The Files body by the one thing only it draws — its filter input, whose label is not text content.
+const filesBody = () => container?.querySelector('[aria-label="Find file by path"]')
+// A second row is what keeps the Sessions list worth drawing (`sessionsPanelWouldHide`: fewer than two rows and no family hides it).
+const secondSession: Session = { ...openSession, id: 'session-2', title: 'Session two' }
+
+describe('two tabs in the real dock', () => {
+  it('draws the active panel and no placeholder once its own fetch has answered', async () => {
+    await host({ activeKey: 'files', sessions: [openSession, secondSession] })
+    expect(filesBody()).not.toBeNull()
+    expect(container?.querySelector('[data-dock-loading]')).toBeNull()
+    expect(container?.querySelector('[data-dock-empty]')).toBeNull()
+    // Both panels are mounted; only one wrapper is the active one, and the file tree is inside it.
+    expect(container?.querySelectorAll('[data-dock-panel]').length).toBe(2)
+    expect(activePanel()?.contains(filesBody() ?? null)).toBe(true)
+    // The Sessions rows are in the DOM too, under the wrapper that draws nothing.
+    expect(text()).toContain('Session two')
+  })
+
+  it('says which kind of nothing the active tab has, with the chrome up because the OTHER tab is ready', async () => {
+    // One session, no family, an untouched filter: the panel's own verdict is that it would hide itself.
+    await host({ activeKey: 'sessions', sessions: [] })
+    expect(container?.querySelector('[data-dock-empty]')?.textContent).toContain('Nothing to show')
+    // Chrome up: with M0's single tab this same verdict made the dock `vacant` and withheld the strip entirely.
+    expect(container?.querySelector('[role="tablist"]')).not.toBeNull()
+    // Placeholder and body share one tabpanel, so the Files tree has to be outside the ACTIVE wrapper and inside a concealed one — the dock draws `body` whichever tab is selected.
+    expect(activePanel()?.contains(filesBody() ?? null)).toBe(false)
+    expect(filesBody()?.closest('[data-dock-panel]')?.className).toBe('hidden')
+    expect(container?.querySelector('[data-dock-loading]')).toBeNull()
+  })
+
+  it('draws the loading placeholder, not an empty panel, while the active tab is still reading', async () => {
+    // The listing held open, which is the only window in which Files is not ready. Sessions is ready beside it, which is what raises the chrome the placeholder needs — with M0's one tab this state was `vacant` and drew nothing at all.
+    wire.gate = []
+    await host({ activeKey: 'files', sessions: [openSession, secondSession] })
+    expect(container?.querySelector('[data-dock-loading]')?.textContent).toContain('Loading…')
+    expect(container?.querySelector('[role="tablist"]')).not.toBeNull()
+    expect(filesBody()).toBeNull()
+
+    const release = wire.gate
+    wire.gate = null
+    await act(async () => {
+      release.forEach((resolve) => resolve())
+      await Promise.resolve()
+    })
+    expect(container?.querySelector('[data-dock-loading]')).toBeNull()
+    expect(filesBody()).not.toBeNull()
+  })
+
+  it('holds the dock track and its width in every one of those states', async () => {
+    await host({ activeKey: 'sessions', sessions: [] })
+    const track = container?.querySelector('[data-dock-track]')
+    expect(track?.className).toContain('w-[var(--dock-width)]')
+    expect(track?.className).toContain('wide:block')
+  })
+})

--- a/packages/web/src/components/console/dock/FilesPanel.test.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.test.tsx
@@ -454,6 +454,31 @@ describe('FilesPanel session scope', () => {
     ])
   })
 
+  it('discards a directory reply that belongs to the checkout it has left', async () => {
+    // The panel SURVIVES a scope change, so an in-flight subdirectory read is not cancelled by anything. Without a generation fence its entries land in the NEW scope's cache — and because `dirs['src']` is then populated, expanding `src` there skips the fetch that would have corrected it, so the wrong worktree's listing simply stays.
+    const reply = (path: string, entries: Entry[]) => ({ path, exists: true, entries, nextCursor: null })
+    let releaseStale: (() => void) | undefined
+    wire.listings = { '': { entries: [dir('src')] } }
+    await render()
+    // Hold session-1's `src` open, then leave for session-2 before it answers.
+    vi.mocked(fetchWorkspaceFiles).mockImplementationOnce(
+      () => new Promise((resolve) => (releaseStale = () => resolve(reply('src', [textFile('from-session-1.ts')]))))
+    )
+    await click(row('src'), 'src folder row')
+
+    wire.listings = { '': { entries: [dir('src')] }, src: { entries: [textFile('from-session-2.ts')] } }
+    await rerender({ sessionId: 'session-2' })
+    await act(async () => {
+      releaseStale?.()
+      await Promise.resolve()
+    })
+
+    // session-1's file never appears, and `src` is still unexpanded in session-2 — so opening it fetches session-2's listing rather than reading a poisoned cache.
+    expect(text()).not.toContain('from-session-1.ts')
+    await click(row('src'), 'src folder row in session-2')
+    expect(rowNames()).toEqual(['src', 'from-session-2.ts'])
+  })
+
   it('scopes EVERY listing, not just the root one', async () => {
     // The root read is the easy one. A subdirectory expansion and a cursor page are separate call sites, and either dropping the id would silently read the agent's primary checkout while every other assertion here still passed.
     wire.listings = {

--- a/packages/web/src/components/console/dock/FilesPanel.test.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.test.tsx
@@ -1,0 +1,701 @@
+// @vitest-environment happy-dom
+
+// The dock's Files panel: what it reports to its tab, what it draws for every degraded answer the workspace wire can give, and the two things it must never do — search a server that has no search, or vanish when a read fails.
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Entry = { name: string; type: 'dir' | 'file' | 'symlink' | 'other'; size: number | null; mtime: string | null }
+type Listing = { entries: Entry[]; exists?: boolean; nextCursor?: string | null }
+
+// Keyed by listing request: a directory path, or `${path}@${cursor}` for a later page. A failure is an HTTP status or 'network' (a rejection with no status, as a dropped connection arrives).
+const wire = vi.hoisted(() => ({
+  listings: {} as Record<string, Listing>,
+  failures: {} as Record<string, number | 'network'>,
+  git: null as unknown,
+  primary: null as unknown,
+  gitFails: false,
+  primaryFails: false
+}))
+
+vi.mock('@/lib/api', () => {
+  class ApiError extends Error {
+    constructor(
+      public status: number,
+      message = `HTTP ${status}`
+    ) {
+      super(message)
+    }
+  }
+  const reject = (failure: number | 'network') =>
+    Promise.reject(failure === 'network' ? new Error('fetch failed') : new ApiError(failure))
+  return {
+    ApiError,
+    fetchWorkspaceFiles: vi.fn((_agentId: string, opts: { path: string; cursor?: string; sessionId?: string }) => {
+      const key = opts.cursor ? `${opts.path}@${opts.cursor}` : opts.path
+      const failure = wire.failures[key]
+      if (failure !== undefined) return reject(failure)
+      const listing = wire.listings[key] ?? { entries: [] }
+      return Promise.resolve({
+        path: opts.path,
+        exists: listing.exists ?? true,
+        entries: listing.entries,
+        nextCursor: listing.nextCursor ?? null
+      })
+    }),
+    fetchWorkspaceGitStatus: vi.fn((_agentId: string, sessionId?: string) => {
+      if (sessionId) return wire.gitFails ? Promise.reject(new Error('offline')) : Promise.resolve(wire.git)
+      return wire.primaryFails ? Promise.reject(new Error('offline')) : Promise.resolve(wire.primary)
+    })
+  }
+})
+
+import { FilesPanel, filesTabStatus } from './FilesPanel'
+import { SessionDock, type DockTab } from './SessionDock'
+import { fetchWorkspaceFiles, fetchWorkspaceGitStatus } from '@/lib/api'
+import type { WorkspaceGitFileDto, WorkspaceGitStatusDto } from '@/lib/api'
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ orgPath: (path: string) => path, activeOrg: { id: 'org-1' } })
+}))
+
+// The dock reads the shell's mobile action slot; mounting the real Shell would pull the whole console — and every platform module's api — behind the mocked `@/lib/api`.
+vi.mock('@/components/console/Shell', () => ({
+  useMobileActionSlot: () => ({ action: null, register: () => {} })
+}))
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let container: HTMLDivElement | undefined
+let root: ReturnType<typeof createRoot> | undefined
+let opened: string[] = []
+let settledReports: boolean[] = []
+
+function gitStatus(overrides: Partial<WorkspaceGitStatusDto> = {}): WorkspaceGitStatusDto {
+  return {
+    isRepo: true,
+    clean: true,
+    repo: null,
+    agentDir: null,
+    branch: 'main',
+    tracking: null,
+    ahead: 0,
+    behind: 0,
+    files: [],
+    truncated: false,
+    lastCommit: null,
+    lastFetchAt: null,
+    ...overrides
+  }
+}
+
+const changed = (path: string, index: string, workingDir: string): WorkspaceGitFileDto => ({ path, index, workingDir })
+
+const dir = (name: string): Entry => ({ name, type: 'dir', size: null, mtime: null })
+const textFile = (name: string): Entry => ({ name, type: 'file', size: 120, mtime: '2026-08-10T11:00:00.000Z' })
+
+type PanelProps = Parameters<typeof FilesPanel>[0]
+
+function panel(props: Partial<PanelProps> = {}) {
+  return (
+    <FilesPanel
+      agentId="agent-a"
+      sessionId="session-1"
+      workdir="/ws/agent-a"
+      onOpenFile={(path) => opened.push(path)}
+      onRootSettledChange={(settled) => settledReports.push(settled)}
+      {...props}
+    />
+  )
+}
+
+async function render(props: Partial<PanelProps> = {}) {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(panel(props))
+    await Promise.resolve()
+  })
+}
+
+async function rerender(props: Partial<PanelProps> = {}) {
+  await act(async () => {
+    root?.render(panel(props))
+    await Promise.resolve()
+  })
+}
+
+const text = () => container?.textContent ?? ''
+
+// A row is the one element carrying FileBrowserRow's selected-edge border, which nothing else in the panel has — matching on 'the first mono span inside any div' picks up the scroller.
+const ROW = '[class*="border-r-2"]'
+const rows = () => Array.from(container?.querySelectorAll<HTMLElement>(ROW) ?? [])
+const rowName = (element: Element) => element.querySelector('span.mono')?.textContent ?? ''
+
+/** Every row the tree drew, by the name in its mono cell — the reader's own index into the panel. */
+const rowNames = (): string[] => rows().map(rowName).filter(Boolean)
+
+const row = (name: string): HTMLElement | undefined => rows().find((candidate) => rowName(candidate) === name)
+
+async function click(element: Element | undefined, what: string) {
+  expect(element, what).toBeDefined()
+  await act(async () => (element as HTMLElement | undefined)?.click())
+}
+
+async function clickText(label: string) {
+  const button = Array.from(container?.querySelectorAll('button') ?? []).find(
+    (candidate) => candidate.textContent?.trim() === label
+  )
+  await click(button, `${label} button`)
+}
+
+async function type(value: string) {
+  const input = container?.querySelector('input')
+  expect(input, 'filter input').toBeDefined()
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(input, value)
+    input?.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+/** The git tags on the rows, as the letters a reader sees, with the title that names each. */
+function badges(): Array<{ ch: string; title: string }> {
+  return Array.from(container?.querySelectorAll<HTMLElement>('span[title$="(uncommitted)"]') ?? []).map((badge) => ({
+    ch: badge.textContent ?? '',
+    title: badge.getAttribute('title') ?? ''
+  }))
+}
+
+beforeEach(() => {
+  wire.listings = { '': { entries: [dir('src'), textFile('README.md')] } }
+  wire.failures = {}
+  wire.git = gitStatus()
+  wire.primary = gitStatus()
+  wire.gitFails = false
+  wire.primaryFails = false
+  opened = []
+  settledReports = []
+})
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  container?.remove()
+  container = undefined
+  root = undefined
+  vi.mocked(fetchWorkspaceFiles).mockClear()
+  vi.mocked(fetchWorkspaceGitStatus).mockClear()
+})
+
+describe('filesTabStatus', () => {
+  it('is loading only until the first root listing has answered', () => {
+    expect(filesTabStatus(false)).toBe('loading')
+    expect(filesTabStatus(true)).toBe('ready')
+  })
+
+  it('never says empty, whatever the root turned out to be', () => {
+    // A workspace with no files still draws a branch line, a filter and the notice explaining the emptiness; `empty` would replace all of it with the dock's "Nothing to show", and — since `vacant` is every tab non-ready — a settled-empty Sessions tab beside it would take the dock's whole chrome away, leaving no way to open Files at all.
+    expect([filesTabStatus(false), filesTabStatus(true)]).not.toContain('empty')
+  })
+})
+
+describe('FilesPanel tab status', () => {
+  it('reports the first listing as unsettled and draws nothing until it lands', async () => {
+    let land: ((listing: unknown) => void) | undefined
+    vi.mocked(fetchWorkspaceFiles).mockImplementationOnce(
+      () => new Promise((resolve) => (land = resolve as (listing: unknown) => void))
+    )
+    await render()
+
+    // The dock owns the wait (its `loading` placeholder), and a panel that drew its own header underneath would double it.
+    expect(settledReports).toEqual([false])
+    expect(container?.querySelector('input')).toBeNull()
+    expect(text()).toBe('')
+
+    await act(async () => {
+      land?.({ path: '', exists: true, entries: [textFile('README.md')], nextCursor: null })
+      await Promise.resolve()
+    })
+    expect(settledReports).toEqual([false, true])
+    expect(container?.querySelector('input')?.getAttribute('placeholder')).toBe('Find file by path…')
+  })
+
+  it('reports ready for a root that failed, because a notice is content', async () => {
+    wire.failures = { '': 'network' }
+    await render()
+
+    expect(settledReports.at(-1)).toBe(true)
+    expect(text()).toContain('the owning daemon may be offline')
+  })
+
+  it('stays ready and keeps the reader’s filter across a refresh', async () => {
+    wire.listings = { '': { entries: [textFile('README.md'), textFile('notes.txt')] } }
+    await render()
+    await type('read')
+    expect(text()).toContain('Matched 1 of 2 loaded files')
+
+    await rerender({ refreshTick: 1 })
+
+    // The refresh re-reads the tree; the latch means the tab never drops back to `loading`, so the panel — and the query in it — is never torn off screen.
+    expect(settledReports).toEqual([false, true])
+    expect(container?.querySelector('input')?.value).toBe('read')
+    expect(vi.mocked(fetchWorkspaceFiles).mock.calls.filter((call) => call[1].path === '').length).toBe(2)
+  })
+
+  it('re-arms for another session, whose tree is a different set of paths', async () => {
+    await render()
+    expect(settledReports).toEqual([false, true])
+
+    await rerender({ sessionId: 'session-2' })
+
+    // Scope change: unsettled again (the dock shows its spinner), then ready — and the filter does not carry over.
+    expect(settledReports).toEqual([false, true, false, true])
+    expect(container?.querySelector('input')?.value).toBe('')
+  })
+})
+
+describe('FilesPanel inside the dock', () => {
+  const FILES_TAB: DockTab = {
+    key: 'files',
+    label: 'Files',
+    icon: 'folder-tree',
+    actionIcon: 'refresh-cw',
+    actionLabel: 'Refresh files'
+  }
+  const SESSIONS_TAB: DockTab = { key: 'sessions', label: 'Sessions', icon: 'messages-square' }
+
+  it('draws nothing beside the dock placeholder while its own tab is loading', () => {
+    // The dock renders the placeholder IN ADDITION to the body (SessionDock.tsx:510-522), so the panel must be the one that stays quiet. Reachable only with another tab ready: with Files alone the dock is `vacant` and withholds even the placeholder.
+    const markup = renderToStaticMarkup(
+      <SessionDock tabs={[SESSIONS_TAB, { ...FILES_TAB, status: 'loading' }]} activeKey="files" onTabChange={() => {}}>
+        {() => panel()}
+      </SessionDock>
+    )
+
+    expect(markup).toContain('data-dock-loading')
+    expect(markup).not.toContain('Find file by path')
+    // And the panel changes no dock geometry: the reserved track keeps the width the pre-paint script published.
+    expect(markup).toContain('w-[var(--dock-width)]')
+    expect(markup).toContain('wide:block')
+  })
+
+  it('offers the refresh action on the tab, not inside the panel', async () => {
+    // The dock owns the per-tab action; a second refresh control in the body would be two answers to one question.
+    const markup = renderToStaticMarkup(
+      <SessionDock tabs={[FILES_TAB]} activeKey="files" onTabChange={() => {}}>
+        {() => panel()}
+      </SessionDock>
+    )
+
+    expect(markup).toContain('aria-label="Refresh files"')
+    await render()
+    expect(text()).not.toContain('Refresh')
+  })
+})
+
+describe('FilesPanel tree', () => {
+  it('lists the root and expands a folder on demand', async () => {
+    wire.listings = {
+      '': { entries: [dir('src'), textFile('README.md')] },
+      src: { entries: [textFile('index.ts')] }
+    }
+    await render()
+
+    expect(rowNames()).toEqual(['src', 'README.md'])
+    // Nothing is fetched for a folder until it is opened — the tree is lazy per directory.
+    expect(vi.mocked(fetchWorkspaceFiles).mock.calls.map((call) => call[1].path)).toEqual([''])
+
+    await click(row('src'), 'src folder row')
+
+    expect(rowNames()).toEqual(['src', 'index.ts', 'README.md'])
+    expect(vi.mocked(fetchWorkspaceFiles).mock.calls.map((call) => call[1].path)).toEqual(['', 'src'])
+    // Depth is drawn as indent, and a child sits one level in.
+    expect(row('index.ts')?.getAttribute('style')).toContain('padding-left: 22px')
+    expect(row('src')?.getAttribute('style')).toContain('padding-left: 8px')
+  })
+
+  it('drops a stale subtree on a refresh instead of leaving it on screen', async () => {
+    wire.listings = { '': { entries: [dir('src'), textFile('README.md')] }, src: { entries: [textFile('index.ts')] } }
+    await render()
+    await click(row('src'), 'src folder row')
+    expect(rowNames()).toEqual(['src', 'index.ts', 'README.md'])
+
+    await rerender({ refreshTick: 1 })
+
+    // The refresh re-reads the root and starts the cache and the expand set over: a directory that has since been deleted must not keep drawing its old children.
+    expect(rowNames()).toEqual(['src', 'README.md'])
+  })
+
+  it('shows the tree loading while a refresh is in flight, not the rows it is replacing', async () => {
+    await render()
+    let land: ((listing: unknown) => void) | undefined
+    vi.mocked(fetchWorkspaceFiles).mockImplementationOnce(
+      () => new Promise((resolve) => (land = resolve as (listing: unknown) => void))
+    )
+
+    await rerender({ refreshTick: 1 })
+
+    // The panel itself stays (the tab is still `ready`), and the rows a stale listing would keep showing are replaced by the tree's own spinner.
+    expect(rowNames()).toEqual([])
+    expect(container?.querySelector('svg[aria-label="Loading"]')).not.toBeNull()
+    expect(container?.querySelector('input')).not.toBeNull()
+
+    await act(async () => {
+      land?.({ path: '', exists: true, entries: [textFile('fresh.ts')], nextCursor: null })
+      await Promise.resolve()
+    })
+    expect(rowNames()).toEqual(['fresh.ts'])
+  })
+
+  it('re-reads a folder after a refresh instead of re-showing its old listing', async () => {
+    wire.listings = { '': { entries: [dir('src')] }, src: { entries: [textFile('old.ts')] } }
+    await render()
+    await click(row('src'), 'src folder row')
+    expect(rowNames()).toEqual(['src', 'old.ts'])
+
+    wire.listings.src = { entries: [textFile('new.ts')] }
+    await rerender({ refreshTick: 1 })
+    await click(row('src'), 'src folder row')
+
+    // A refresh starts the cache AND the expand set over: keeping the cache would put back a file the agent has since renamed, and keeping the expand set would make this click close a folder the reader sees as shut.
+    expect(rowNames()).toEqual(['src', 'new.ts'])
+    expect(vi.mocked(fetchWorkspaceFiles).mock.calls.filter((call) => call[1].path === 'src').length).toBe(2)
+  })
+
+  it('keeps a collapsed folder’s listing, so re-opening it costs no round trip', async () => {
+    wire.listings = { '': { entries: [dir('src')] }, src: { entries: [textFile('index.ts')] } }
+    await render()
+
+    await click(row('src'), 'src folder row')
+    await click(row('src'), 'src folder row')
+    expect(rowNames()).toEqual(['src'])
+    await click(row('src'), 'src folder row')
+
+    expect(rowNames()).toEqual(['src', 'index.ts'])
+    expect(vi.mocked(fetchWorkspaceFiles).mock.calls.filter((call) => call[1].path === 'src').length).toBe(1)
+  })
+
+  it('opens a file by its full path, not its name', async () => {
+    wire.listings = { '': { entries: [dir('src')] }, src: { entries: [textFile('index.ts')] } }
+    await render()
+    await click(row('src'), 'src folder row')
+
+    await click(row('index.ts'), 'index.ts row')
+
+    expect(opened).toEqual(['src/index.ts'])
+  })
+
+  it('marks the row the viewer is holding', async () => {
+    await render({ openFilePath: 'README.md' })
+
+    expect(row('README.md')?.getAttribute('aria-current')).toBe('page')
+    expect(row('README.md')?.className).toContain('bg-(--brand-soft)')
+  })
+
+  it('does not offer to open a row that is not a file', async () => {
+    wire.listings = { '': { entries: [{ name: 'sock', type: 'other', size: null, mtime: null }] } }
+    await render()
+
+    const sock = row('sock')
+    expect(sock?.tagName).toBe('DIV')
+    await click(sock, 'sock row')
+    expect(opened).toEqual([])
+  })
+
+  it('pages a long directory with the cursor the daemon handed back', async () => {
+    wire.listings = {
+      '': { entries: [textFile('a.ts')], nextCursor: '1' },
+      '@1': { entries: [textFile('b.ts')], nextCursor: null }
+    }
+    await render()
+
+    expect(rowNames()).toEqual(['a.ts'])
+    await clickText('Load more')
+
+    expect(rowNames()).toEqual(['a.ts', 'b.ts'])
+    expect(text()).not.toContain('Load more')
+  })
+
+  it('keeps the loaded page when the next one fails', async () => {
+    wire.listings = { '': { entries: [textFile('a.ts')], nextCursor: '1' } }
+    wire.failures = { '@1': 'network' }
+    await render()
+
+    await clickText('Load more')
+
+    // `moreErr` is separate from `err` precisely so an append failure does not take the rows already on screen.
+    expect(rowNames()).toEqual(['a.ts'])
+    expect(text()).toContain('Retry')
+  })
+
+  it('reports a failed subdirectory at its own depth and keeps the rest of the tree', async () => {
+    wire.listings = { '': { entries: [dir('src'), textFile('README.md')] } }
+    wire.failures = { src: 'network' }
+    await render()
+
+    await click(row('src'), 'src folder row')
+
+    expect(text()).toContain("Couldn't load — the daemon may be offline.")
+    expect(rowNames()).toEqual(['src', 'README.md'])
+  })
+})
+
+describe('FilesPanel session scope', () => {
+  it('reads the session’s worktree, for the tree and for the status', async () => {
+    await render()
+
+    expect(vi.mocked(fetchWorkspaceFiles).mock.calls[0]?.[1]).toMatchObject({ path: '', sessionId: 'session-1' })
+    expect(vi.mocked(fetchWorkspaceGitStatus).mock.calls).toEqual([
+      ['agent-a', 'session-1'],
+      // The second, sessionless read is the branch label: a session worktree is detached, so its own status names no branch.
+      ['agent-a']
+    ])
+  })
+
+  it('scopes EVERY listing, not just the root one', async () => {
+    // The root read is the easy one. A subdirectory expansion and a cursor page are separate call sites, and either dropping the id would silently read the agent's primary checkout while every other assertion here still passed.
+    wire.listings = {
+      '': { entries: [dir('src'), textFile('a.ts')], nextCursor: '1' },
+      '@1': { entries: [textFile('b.ts')], nextCursor: null },
+      src: { entries: [textFile('index.ts')] }
+    }
+    await render()
+    await click(row('src'), 'src folder row')
+    await clickText('Load more')
+
+    const calls = vi.mocked(fetchWorkspaceFiles).mock.calls
+    // Root, the subdirectory, and the cursor page — all three reached, and all three scoped.
+    expect(calls.map((call) => call[1].path)).toEqual(expect.arrayContaining(['', 'src']))
+    expect(calls.some((call) => call[1].cursor === '1')).toBe(true)
+    expect(calls.map((call) => call[1].sessionId)).toEqual(calls.map(() => 'session-1'))
+  })
+
+  it('reads the primary checkout when no session is given', async () => {
+    await render({ sessionId: undefined })
+
+    expect(vi.mocked(fetchWorkspaceFiles).mock.calls[0]?.[1]).not.toHaveProperty('sessionId')
+    expect(vi.mocked(fetchWorkspaceGitStatus).mock.calls).toEqual([['agent-a', undefined]])
+  })
+
+  it('shows the primary branch beside the workdir, and says whose branch it is', async () => {
+    // The worktree's own `branch` is a detached HEAD, so drawing it would name a branch this tree is not on.
+    wire.git = gitStatus({ branch: 'HEAD' })
+    wire.primary = gitStatus({ branch: 'release/2.1' })
+    await render()
+
+    expect(text()).toContain('release/2.1')
+    expect(text()).not.toContain('HEAD')
+    expect(container?.innerHTML).toContain("this session's worktree is detached from it")
+    expect(text()).toContain('/ws/agent-a')
+  })
+
+  it('shows the checkout’s own branch outside session scope', async () => {
+    wire.primary = gitStatus({ branch: 'main' })
+    await render({ sessionId: undefined })
+
+    expect(text()).toContain('main')
+    expect(container?.innerHTML).toContain('Current branch of the workspace checkout')
+  })
+})
+
+describe('FilesPanel git tags', () => {
+  it('tags changed files and leaves their folder alone', async () => {
+    wire.listings = { '': { entries: [dir('src'), textFile('README.md')] }, src: { entries: [textFile('index.ts')] } }
+    wire.git = gitStatus({ clean: false, files: [changed('src/index.ts', ' ', 'M')] })
+    await render()
+    await click(row('src'), 'src folder row')
+
+    expect(badges()).toEqual([{ ch: 'M', title: 'Modified (uncommitted)' }])
+    expect(row('src')?.querySelector('span[title$="(uncommitted)"]')).toBeNull()
+  })
+
+  it('tags a staged-then-edited file with its staged letter', async () => {
+    // 'AM' is one path in two states; the badge is one letter, and it is the index half.
+    wire.listings = { '': { entries: [textFile('added.ts'), textFile('fresh.ts')] } }
+    wire.git = gitStatus({
+      clean: false,
+      files: [changed('added.ts', 'A', 'M'), changed('fresh.ts', '?', '?')]
+    })
+    await render()
+
+    expect(badges()).toEqual([
+      { ch: 'A', title: 'Added (uncommitted)' },
+      { ch: 'U', title: 'Untracked (uncommitted)' }
+    ])
+  })
+
+  it('says how far the tags reach when the status list was capped', async () => {
+    wire.git = gitStatus({ clean: false, truncated: true, files: [changed('README.md', 'M', ' ')] })
+    await render()
+
+    // The daemon caps its file list at 500, so an uncapped reading of `files.length` would quietly under-tag a big working tree.
+    expect(text()).toContain('status tags cover the first 1 changed files')
+  })
+})
+
+describe('FilesPanel path filter', () => {
+  beforeEach(() => {
+    wire.listings = {
+      '': { entries: [dir('src'), dir('docs'), textFile('README.md')] },
+      src: { entries: [textFile('index.ts'), textFile('reader.ts')] },
+      docs: { entries: [textFile('guide.md')] }
+    }
+  })
+
+  it('filters the loaded tree and says that is what it filtered', async () => {
+    await render()
+    await click(row('src'), 'src folder row')
+
+    await type('reader')
+
+    // Full paths, flat, and a label that does not let the reader believe a repository was searched.
+    expect(rowNames()).toEqual(['src/reader.ts'])
+    expect(text()).toContain('Matched 1 of 3 loaded files')
+    expect(text()).toContain('not the whole repository')
+  })
+
+  it('never asks the server, because there is no path-search route', async () => {
+    await render()
+    const before = vi.mocked(fetchWorkspaceFiles).mock.calls.length
+
+    await type('guide')
+
+    expect(vi.mocked(fetchWorkspaceFiles).mock.calls.length).toBe(before)
+    // 'docs' was never opened, so its file is not in the corpus — the honest consequence the label warns about.
+    expect(rowNames()).toEqual([])
+    expect(text()).toContain('No loaded file path contains “guide”')
+    expect(text()).toContain('Open more folders')
+  })
+
+  it('opens a filtered row by its full path', async () => {
+    await render()
+    await click(row('src'), 'src folder row')
+    await type('index')
+
+    await click(row('src/index.ts'), 'filtered row')
+
+    expect(opened).toEqual(['src/index.ts'])
+  })
+
+  it('carries the git tag onto the filtered row', async () => {
+    wire.git = gitStatus({ clean: false, files: [changed('src/index.ts', 'M', ' ')] })
+    await render()
+    await click(row('src'), 'src folder row')
+
+    await type('index')
+
+    expect(badges()).toEqual([{ ch: 'M', title: 'Modified (uncommitted)' }])
+  })
+
+  it('shows the tree again when the filter is cleared', async () => {
+    await render()
+    await type('read')
+    await type('')
+
+    expect(rowNames()).toEqual(['src', 'docs', 'README.md'])
+    expect(text()).not.toContain('loaded files')
+  })
+})
+
+describe('FilesPanel degraded states', () => {
+  it('explains an offline daemon rather than throwing', async () => {
+    wire.failures = { '': 503 }
+    await render()
+
+    expect(text()).toContain('the owning daemon may be offline')
+    // Still a panel: the header the reader navigates with survives the failure.
+    expect(container?.querySelector('input')).not.toBeNull()
+  })
+
+  it('explains a daemon too old for session worktrees, and does not blame the network', async () => {
+    // The CP's 409 is `workspace-session-read-v1` missing, which the offline copy would misdescribe.
+    wire.failures = { '': 409 }
+    await render()
+
+    expect(text()).toContain('cannot browse a session worktree')
+    expect(text()).not.toContain('may be offline')
+  })
+
+  it('explains a worktree the session does not have', async () => {
+    wire.failures = { '': 404 }
+    await render()
+
+    expect(text()).toContain('may have been cleaned up')
+    expect(text()).not.toContain('may be offline')
+  })
+
+  it('explains a cleaned-up worktree that the listing reports as missing', async () => {
+    wire.listings = { '': { entries: [], exists: false } }
+    await render()
+
+    expect(text()).toContain('will be recreated from the repository')
+  })
+
+  it('explains a primary workspace that has no files yet', async () => {
+    wire.listings = { '': { entries: [], exists: false } }
+    await render({ sessionId: undefined })
+
+    expect(text()).toContain('the agent creates them as it works')
+  })
+
+  it('says an empty workspace is empty', async () => {
+    wire.listings = { '': { entries: [] } }
+    await render()
+
+    expect(text()).toContain('This workspace is empty.')
+  })
+
+  it('says a scratch workspace has no git checkout', async () => {
+    wire.git = gitStatus({ isRepo: false, branch: null })
+    wire.primary = gitStatus({ isRepo: false, branch: null })
+    await render()
+
+    expect(text()).toContain('Not a git checkout')
+    expect(badges()).toEqual([])
+    // The tree is unaffected: git status is not what makes a workspace browsable.
+    expect(rowNames()).toEqual(['src', 'README.md'])
+  })
+
+  it('keeps a failed git status apart from a workspace that has no git', async () => {
+    // Both leave the status null, and a reader told "not a git checkout" about a repo would go looking for the wrong problem.
+    wire.gitFails = true
+    await render()
+
+    expect(text()).toContain('Git status unavailable')
+    expect(text()).not.toContain('Not a git checkout')
+    expect(rowNames()).toEqual(['src', 'README.md'])
+  })
+})
+
+describe('FilesPanel footer', () => {
+  it('shows when the checkout last fetched', async () => {
+    wire.git = gitStatus({ lastFetchAt: new Date(Date.now() - 120_000).toISOString() })
+    await render()
+
+    expect(container?.querySelector('[data-files-footer]')?.textContent).toBe('synced 2m ago')
+    // Dropped on purpose: a file count and a total size would each need a daemon-side walk of the whole tree.
+    expect(text()).not.toContain('files ·')
+  })
+
+  it('keeps a non-repo workspace out of the footer whatever its status carried', async () => {
+    // Defensive: the daemon computes `lastFetchAt` only on the isRepo branch, and a workspace with no checkout has no remote it could have synced with.
+    wire.git = gitStatus({ isRepo: false, branch: null, lastFetchAt: new Date().toISOString() })
+    wire.primary = gitStatus({ isRepo: false, branch: null })
+    await render()
+
+    expect(container?.querySelector('[data-files-footer]')).toBeNull()
+    expect(text()).toContain('Not a git checkout')
+  })
+
+  it('drops the clause when there is no fetch time, which is every session worktree', async () => {
+    // A linked worktree's `.git` is a FILE, so `.git/FETCH_HEAD` cannot be stat'd and the daemon always answers null here.
+    wire.git = gitStatus({ lastFetchAt: null })
+    await render()
+
+    expect(text()).not.toContain('synced')
+    // Not an empty bordered strip either: the footer is absent, not blank.
+    expect(container?.querySelector('[data-files-footer]')).toBeNull()
+  })
+})

--- a/packages/web/src/components/console/dock/FilesPanel.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.tsx
@@ -1,0 +1,314 @@
+'use client'
+
+// The dock's Files tab: the open session's worktree as ONE narrow column at 380–760px — lazily expanded rows with git status tags, a path filter over the tree already loaded, and the checkout's last fetch time.
+// The file itself opens in the left-pane viewer (§4), which this panel does not own: a file row reports the path and nothing more.
+
+import { Fragment, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { Spinner } from '@/components/marks'
+import { Icon } from '@/components/ui'
+import { FileBrowserRow, formatFileMtime, formatFileSize } from '@/components/console/FileBrowser'
+import {
+  StatusBadge,
+  useWorkspaceGitStatus,
+  useWorkspaceTree,
+  workspaceDirtyMap,
+  workspaceEntryIcon
+} from '@/components/console/workspace-tree'
+import type { DockTabStatus } from './SessionDock'
+
+/** The Files tab's status: `loading` covers the first root listing only, and everything after it is `ready` — an offline daemon, a non-repo workspace and an empty directory are each something this panel has copy for, and copy is content. */
+// Never `empty`: a workspace with no files still draws its branch line, its filter and the notice saying WHY it is empty, so `empty` would trade that explanation for the dock's centred "Nothing to show" — and it would put `vacant` (every tab non-ready) back in reach beside a settled-empty Sessions tab, where the dock withholds all its chrome and the tab a reader asked for cannot be opened at all.
+export function filesTabStatus(rootSettled: boolean): DockTabStatus {
+  return rootSettled ? 'ready' : 'loading'
+}
+
+// The root listing failed. Only 409 and 404 are distinguishable answers; everything else (503 for both an offline daemon and an unplaced agent, plus network failures) is the offline story.
+function rootNoticeText(status: number | null, scoped: boolean): string {
+  if (status === 409) {
+    return 'This agent runs a daemon version that cannot browse a session worktree. Update the agent, or read the files from its workspace page.'
+  }
+  if (status === 404) {
+    return scoped
+      ? "This session's worktree is not available to browse — it may have been cleaned up, or this session may not have one of its own."
+      : 'This workspace is not available to browse.'
+  }
+  return "Couldn't browse the workspace — the owning daemon may be offline. Files live only on that machine and are read live from it, so they are unavailable while it is disconnected."
+}
+
+export function FilesPanel({
+  agentId,
+  sessionId,
+  workdir,
+  refreshTick = 0,
+  openFilePath,
+  onOpenFile,
+  onRootSettledChange
+}: {
+  agentId: string
+  /** ACP session id selecting that session's isolated worktree; omit for the agent's primary checkout. Pass it only when the session's `workspaceIsolation` is `'session'` — the daemon answers a shared-workspace sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline". */
+  sessionId?: string
+  /** The agent's working directory, shown beside the branch. */
+  workdir?: string
+  /** Bumped by the tab's `refresh-cw` action: re-reads the tree and the git status. */
+  refreshTick?: number
+  /** The path the viewer currently holds, so the tree marks its row. */
+  openFilePath?: string | null
+  /** A file row was pressed. The viewer is the caller's (§4). */
+  onOpenFile: (path: string) => void
+  /** Whether the first root listing has answered — the input to {@link filesTabStatus}. The caller owns the tab descriptor, so the verdict is reported rather than applied. */
+  onRootSettledChange?: (settled: boolean) => void
+}) {
+  const { dirs, root, expanded, toggleDir, loadMoreDir } = useWorkspaceTree(agentId, sessionId, refreshTick)
+  const { git, outcome, primaryBranch } = useWorkspaceGitStatus(agentId, sessionId, refreshTick)
+  const [query, setQuery] = useState('')
+  const scope = `${agentId}:${sessionId ?? 'primary'}`
+  // Latched per scope, so the tab reports `ready` once and a refresh keeps the panel — and the reader's filter text — on screen behind an in-tree spinner.
+  const [settledScope, setSettledScope] = useState<string | null>(null)
+  useEffect(() => {
+    if (root && !root.loading && settledScope !== scope) setSettledScope(scope)
+  }, [root, scope, settledScope])
+  const settled = settledScope === scope
+  // Reported on the EDGE: the callback the caller passes is usually a fresh closure per render, and a re-report of the value the tab already has is a state write for nothing.
+  const reported = useRef<boolean | null>(null)
+  useEffect(() => {
+    if (reported.current === settled) return
+    reported.current = settled
+    onRootSettledChange?.(settled)
+  }, [onRootSettledChange, settled])
+  // A filter is over one tree; another session's is a different set of paths.
+  useEffect(() => setQuery(''), [scope])
+
+  const dirtyMap = useMemo(() => workspaceDirtyMap(git), [git])
+  // Every FILE the tree has actually loaded — the only corpus a client-side filter can honestly search, since `workspace/list` is per-directory and no path-search frame exists.
+  const loadedFiles = useMemo(() => {
+    const out: Array<{ path: string; name: string; icon: string; clickable: boolean; meta: string }> = []
+    for (const [dirPath, dir] of Object.entries(dirs)) {
+      for (const entry of dir.entries ?? []) {
+        if (entry.type === 'dir') continue
+        out.push({
+          path: dirPath ? `${dirPath}/${entry.name}` : entry.name,
+          name: entry.name,
+          icon: workspaceEntryIcon(entry),
+          clickable: entry.type === 'file',
+          meta: [formatFileSize(entry.size), formatFileMtime(entry.mtime)].filter(Boolean).join(' · ')
+        })
+      }
+    }
+    return out.sort((a, b) => a.path.localeCompare(b.path))
+  }, [dirs])
+  const q = query.trim().toLowerCase()
+  const matches = useMemo(
+    () => (q ? loadedFiles.filter((file) => file.path.toLowerCase().includes(q)) : []),
+    [loadedFiles, q]
+  )
+
+  if (!settled) return null
+
+  // One directory level, rendered inline into the flat DOM its indent describes.
+  const renderLevel = (dirPath: string, depth: number): ReactNode => {
+    const dir = dirs[dirPath]
+    if (!dir) return null
+    if (dir.loading && !dir.entries) {
+      return (
+        <div key={`${dirPath}::spin`} className="py-2 pr-3" style={{ paddingLeft: 12 + depth * 14 }}>
+          <Spinner size={15} />
+        </div>
+      )
+    }
+    if (dir.err && !dir.entries) {
+      return (
+        <div
+          key={`${dirPath}::err`}
+          className="py-[7px] pr-3 font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)"
+          style={{ paddingLeft: 12 + depth * 14 }}
+        >
+          Couldn&apos;t load — the daemon may be offline.
+        </div>
+      )
+    }
+    return (
+      <>
+        {dir.entries?.map((entry) => {
+          const full = dirPath ? `${dirPath}/${entry.name}` : entry.name
+          if (entry.type === 'dir') {
+            const open = expanded.has(full)
+            return (
+              <Fragment key={full}>
+                <FileBrowserRow
+                  depth={depth}
+                  chevron={open ? 'chevron-down' : 'chevron-right'}
+                  icon={open ? 'folder-open' : 'folder'}
+                  name={entry.name}
+                  onClick={() => toggleDir(full)}
+                />
+                {open && renderLevel(full, depth + 1)}
+              </Fragment>
+            )
+          }
+          const status = dirtyMap.get(full)
+          return (
+            <FileBrowserRow
+              key={full}
+              depth={depth}
+              icon={workspaceEntryIcon(entry)}
+              name={entry.name}
+              title={[formatFileSize(entry.size), formatFileMtime(entry.mtime)].filter(Boolean).join(' · ')}
+              trailing={status ? <StatusBadge ch={status} /> : undefined}
+              selected={openFilePath === full}
+              onClick={entry.type === 'file' ? () => onOpenFile(full) : undefined}
+            />
+          )
+        })}
+        {dir.nextCursor && (
+          <div className="flex flex-col gap-1 py-[6px] pr-3" style={{ paddingLeft: 12 + depth * 14 }}>
+            <button className="lnk text-[12px]" onClick={() => loadMoreDir(dirPath)}>
+              {dir.loadingMore ? 'Loading…' : dir.moreErr ? 'Retry' : 'Load more'}
+            </button>
+          </div>
+        )}
+      </>
+    )
+  }
+
+  // Which of the tree's states the body draws. Every branch here is data — none of them may take the panel, the dock or the transcript down (§2).
+  const body = (): ReactNode => {
+    if (root?.err && !root.entries)
+      return <PanelNotice warn text={rootNoticeText(root.errStatus, Boolean(sessionId))} />
+    if (root && !root.loading && !root.err && !root.exists) {
+      return (
+        <PanelNotice
+          text={
+            sessionId
+              ? "This session's workspace has been cleaned up — it will be recreated from the repository when the agent next works in this session."
+              : 'The workspace has no files yet — the agent creates them as it works.'
+          }
+        />
+      )
+    }
+    if (root?.entries && root.exists && root.entries.length === 0)
+      return <PanelNotice text="This workspace is empty." />
+    if (q) {
+      return (
+        <>
+          <div className="px-3 pb-[7px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+            {matches.length > 0
+              ? `Matched ${matches.length} of ${loadedFiles.length} loaded files. This filters the folders you have opened, not the whole repository.`
+              : `No loaded file path contains “${query.trim()}”. Open more folders to load more of the tree — this filter never searches the whole repository.`}
+          </div>
+          {matches.map((file) => {
+            const status = dirtyMap.get(file.path)
+            return (
+              <FileBrowserRow
+                key={file.path}
+                icon={file.icon}
+                name={file.path}
+                title={[file.path, file.meta].filter(Boolean).join('\n')}
+                trailing={status ? <StatusBadge ch={status} /> : undefined}
+                selected={openFilePath === file.path}
+                onClick={file.clickable ? () => onOpenFile(file.path) : undefined}
+              />
+            )
+          })}
+        </>
+      )
+    }
+    return renderLevel('', 0)
+  }
+
+  const branch = sessionId ? primaryBranch : (git?.branch ?? null)
+  // A session worktree is detached, so the branch on screen is the primary checkout's — say so rather than implying the worktree is on it.
+  const branchTitle = sessionId
+    ? "Branch of the agent's primary checkout; this session's worktree is detached from it"
+    : 'Current branch of the workspace checkout'
+  const gitNote =
+    outcome === 'none'
+      ? 'Not a git checkout — no branch or file status'
+      : outcome === 'unavailable'
+        ? 'Git status unavailable — the daemon may be offline'
+        : null
+
+  return (
+    <div data-files-panel="" className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-none flex-col gap-[7px] border-b border-(--border-subtle) px-3 py-[10px]">
+        <div className="relative flex items-center">
+          <Icon
+            name="search"
+            size={13}
+            color="var(--text-tertiary)"
+            className="pointer-events-none absolute left-[9px]"
+          />
+          <input
+            className="inp mn h-8 min-h-8 w-full py-1 pr-2 pl-[27px] text-[12px]"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Find file by path…"
+            aria-label="Find file by path"
+            spellCheck={false}
+          />
+        </div>
+        <div className="flex min-w-0 items-center gap-2">
+          {/* The note outranks the branch: the SCOPED status is where the row tags come from, so a reader looking at an untagged tree is owed the reason, not a branch label borrowed from the primary checkout. */}
+          {outcome === 'repo' && branch ? (
+            <span
+              className="mono flex min-w-0 max-w-[55%] flex-none items-center gap-[4px] text-[11px] font-medium text-(--text-secondary)"
+              title={branchTitle}
+            >
+              <Icon name="git-branch" size={11} color="var(--text-tertiary)" className="flex-none" />
+              <span className="truncate">{branch}</span>
+            </span>
+          ) : gitNote ? (
+            <span className="flex-none font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+              {gitNote}
+            </span>
+          ) : null}
+          {workdir ? (
+            // The agent's configured directory either way, so in session scope it names the primary checkout rather than the worktree listed below — same disclaimer the branch beside it carries.
+            <span
+              className="mono min-w-0 flex-1 truncate text-right text-[11px] font-normal text-(--text-tertiary)"
+              title={sessionId ? `${workdir} — the agent's workspace; this session runs in its own worktree` : workdir}
+            >
+              {workdir}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-auto py-[6px]">{body()}</div>
+      {/* `lastFetchAt` is `.git/FETCH_HEAD`'s mtime, which a linked worktree has no directory for — so session scope has no footer at all, by construction rather than by omission. The design's file count and total size are dropped: neither exists without a daemon-side walk. */}
+      {git?.lastFetchAt || git?.truncated ? (
+        <div
+          data-files-footer=""
+          className="flex flex-none items-center gap-2 border-t border-(--border-subtle) px-3 py-[7px]"
+        >
+          {git.lastFetchAt ? (
+            <span
+              className="mono flex-none text-[11px] font-normal text-(--text-tertiary)"
+              title="When this checkout last fetched from its remote"
+            >
+              {`synced ${formatFileMtime(git.lastFetchAt)}`}
+            </span>
+          ) : null}
+          {git.truncated ? (
+            <span className="min-w-0 flex-1 truncate font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+              {`status tags cover the first ${git.files.length} changed files`}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+// A degraded state, drawn calmly: a workspace nobody can read still has something to say about why.
+function PanelNotice({ text, warn = false }: { text: string; warn?: boolean }) {
+  return (
+    <div className="flex items-start gap-2 px-3 py-[10px] font-sans text-[12px] font-normal leading-[1.55] text-(--text-secondary)">
+      <Icon
+        name={warn ? 'triangle-alert' : 'folder'}
+        size={14}
+        color={warn ? 'var(--amber-500)' : 'var(--text-tertiary)'}
+        className="mt-[2px] flex-none"
+      />
+      <span>{text}</span>
+    </div>
+  )
+}

--- a/packages/web/src/components/console/dock/SessionDock.test.tsx
+++ b/packages/web/src/components/console/dock/SessionDock.test.tsx
@@ -18,7 +18,14 @@ vi.mock('@/components/console/Shell', () => ({
   useMobileActionSlot: () => ({ action: null, register: (a: unknown) => mobileActions.push(a as never) })
 }))
 
-import { DOCK_LABEL_WIDTH, SessionDock, SessionDockSlot, type DockTab, type DockTabStatus } from './SessionDock'
+import {
+  DOCK_LABEL_WIDTH,
+  DockPanel,
+  SessionDock,
+  SessionDockSlot,
+  type DockTab,
+  type DockTabStatus
+} from './SessionDock'
 import {
   DOCK_BODY_FLOOR,
   DOCK_INLINE_CHROME,
@@ -953,6 +960,30 @@ describe('SessionDock overlay dialog semantics', () => {
       panel()!.querySelectorAll<HTMLElement>('[role="separator"],[data-dock-tab="files"],button')
     )
     expect(document.activeElement).toBe(stops.at(-1))
+  })
+
+  it('never wraps onto a control in the panel the reader cannot see', () => {
+    // An inactive DockPanel stays mounted at `display:none`, where `.focus()` is a no-op — counting its
+    // controls as stops makes the wrap a dead key and lets a forward Tab off the last VISIBLE stop leave
+    // the modal for one press. happy-dom does not enforce visibility, so assert the stop, not the paint.
+    render(
+      <SessionDock tabs={TABS} activeKey="files" onTabChange={() => {}}>
+        <DockPanel active={true}>
+          <button data-visible-stop="">shown</button>
+        </DockPanel>
+        <DockPanel active={false}>
+          <button data-hidden-stop="">concealed</button>
+        </DockPanel>
+      </SessionDock>
+    )
+    click(trigger())
+    tab(true)
+    const landed = document.activeElement as HTMLElement
+    expect(landed.hasAttribute('data-hidden-stop')).toBe(false)
+    expect(landed.hasAttribute('data-visible-stop')).toBe(true)
+    // And forward off that same last visible stop wraps back inside rather than out past the scrim.
+    tab()
+    expect(panel()?.contains(document.activeElement)).toBe(true)
   })
 
   it('pulls focus back in when it has escaped the dialog altogether', () => {

--- a/packages/web/src/components/console/dock/SessionDock.tsx
+++ b/packages/web/src/components/console/dock/SessionDock.tsx
@@ -117,9 +117,15 @@ function usePublishedWidth(width: number | null): void {
 }
 
 // Every tab stop inside the panel, in order. The `tabindex` ATTRIBUTE, not `tabIndex`: the strip's roving −1 tabs are not stops, and a default 0 is never written.
+// An INACTIVE DockPanel stays mounted but `display:none`, and `.focus()` on such a node is a no-op — leaving its controls in this list makes the wrap a dead key and lets a forward Tab off the last visible stop walk out past the scrim for one press.
 function focusStops(panel: HTMLElement): HTMLElement[] {
   const found = panel.querySelectorAll<HTMLElement>('a[href],button,input,select,textarea,[tabindex]')
-  return Array.from(found).filter((el) => !el.hasAttribute('disabled') && el.getAttribute('tabindex') !== '-1')
+  return Array.from(found).filter(
+    (el) =>
+      !el.hasAttribute('disabled') &&
+      el.getAttribute('tabindex') !== '-1' &&
+      !el.closest('[data-dock-panel]:not([data-dock-panel-active])')
+  )
 }
 
 // Tab off either end of the dialog wraps to the other, and focus that has escaped it entirely is brought back to the near end.
@@ -148,6 +154,16 @@ export function SessionDockSlot() {
   // Storage is read for the property, never for the markup (the slot renders one tree on both sides), and withheld until the viewport is measured as the dock withholds until storage is read: at the seeded 0 the ceiling is `DOCK_WIDTH_MAX`, so an unfitted width would land over the script's fitted one.
   usePublishedWidth(viewportWidth === 0 ? null : fitDockWidth(readDockWidth(activeOrg?.id ?? ''), viewportWidth))
   return <div aria-hidden="true" data-dock-track="" className={TRACK} />
+}
+
+/** One hosted panel among several: drawn when its tab is active, MOUNTED and undrawn when it is not. */
+// `contents` rather than a box of its own, so an active panel is the flex child of the body the dock renders and its geometry is the same whether it is hosted alone or beside four siblings; unmounting instead would silence the verdict that sets its own tab's status and throw away its scroll position, tree and filter — the same reason the dock keeps `body` at one tree position across the vacant boundary.
+export function DockPanel({ active, children }: { active: boolean; children: ReactNode }) {
+  return (
+    <div data-dock-panel="" data-dock-panel-active={active ? '' : undefined} className={active ? 'contents' : 'hidden'}>
+      {children}
+    </div>
+  )
 }
 
 export function SessionDock({

--- a/packages/web/src/components/console/viewer/SessionViewer.test.tsx
+++ b/packages/web/src/components/console/viewer/SessionViewer.test.tsx
@@ -1,0 +1,363 @@
+// @vitest-environment happy-dom
+
+// The left-pane file viewer: what it draws for every answer `workspace/read` can give, and the two things a sliced read must never get wrong — trusting its own byte arithmetic over the daemon's, or splicing two revisions of one file together.
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Slice = {
+  exists?: boolean
+  size?: number | null
+  mtime?: string | null
+  encoding?: 'utf8' | 'none' | null
+  content?: string | null
+  offset?: number | null
+  nextOffset?: number | null
+  truncated?: boolean | null
+}
+
+// Keyed by the byte offset asked for, so a case can give slice 0 and slice 64 different bytes — and a different mtime.
+const wire = vi.hoisted(() => ({
+  slices: {} as Record<number, Slice>,
+  failure: null as number | 'network' | null,
+  calls: [] as Array<{ path: string; offset?: number; sessionId?: string }>,
+  /** Resolve the next read by hand, for the cases about which answer wins a race. */
+  hold: null as null | Array<(value?: unknown) => void>
+}))
+
+vi.mock('@/lib/api', () => {
+  class ApiError extends Error {
+    constructor(
+      public status: number,
+      message = `HTTP ${status}`
+    ) {
+      super(message)
+    }
+  }
+  return {
+    ApiError,
+    fetchWorkspaceFile: vi.fn(async (_agentId: string, opts: { path: string; offset?: number; sessionId?: string }) => {
+      wire.calls.push(opts)
+      if (wire.hold) await new Promise((resolve) => wire.hold?.push(resolve))
+      if (wire.failure !== null) {
+        throw wire.failure === 'network' ? new Error('fetch failed') : new ApiError(wire.failure)
+      }
+      const slice = wire.slices[opts.offset ?? 0] ?? {}
+      return {
+        path: opts.path,
+        exists: slice.exists ?? true,
+        size: slice.size ?? slice.content?.length ?? 0,
+        mtime: slice.mtime ?? '2026-08-10T10:00:00.000Z',
+        encoding: slice.encoding ?? 'utf8',
+        content: slice.content ?? '',
+        offset: slice.offset ?? opts.offset ?? 0,
+        nextOffset: slice.nextOffset ?? null,
+        truncated: slice.truncated ?? false
+      }
+    })
+  }
+})
+
+// The real pipeline either side of the lazy chunk: `highlight`, `escapeHtml`, `linkifyHtml` and `languageLabel` stay real, only the dynamic import is stood in for.
+const hl = vi.hoisted(() => ({ fail: false }))
+vi.mock('@/lib/highlight', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/highlight')>()
+  return {
+    ...actual,
+    loadHljs: () =>
+      hl.fail
+        ? Promise.reject(new Error('chunk failed'))
+        : Promise.resolve({
+            getLanguage: () => ({ name: 'TypeScript' }),
+            highlight: (code: string) => ({ value: `<b class="hljs-keyword">${code}</b>` })
+          })
+  }
+})
+
+import { SessionViewer } from './SessionViewer'
+import { fetchWorkspaceFile } from '@/lib/api'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let container: HTMLDivElement | undefined
+let root: ReturnType<typeof createRoot> | undefined
+let closed = 0
+
+type ViewerProps = Parameters<typeof SessionViewer>[0]
+
+function viewer(props: Partial<ViewerProps> = {}) {
+  return (
+    <SessionViewer
+      agentId="agent-a"
+      sessionId="session-1"
+      path="src/app/page.tsx"
+      onClose={() => closed++}
+      {...props}
+    />
+  )
+}
+
+async function render(props: Partial<ViewerProps> = {}) {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(viewer(props))
+    await Promise.resolve()
+  })
+}
+
+async function rerender(props: Partial<ViewerProps> = {}) {
+  await act(async () => {
+    root?.render(viewer(props))
+    await Promise.resolve()
+  })
+}
+
+async function settle() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+const text = () => container?.textContent ?? ''
+const gutter = () => container?.querySelector('[data-viewer-gutter]')?.textContent ?? ''
+const code = () => container?.querySelector('[data-viewer-code] pre:last-of-type')?.textContent ?? ''
+const click = async (selector: string) => {
+  const target = container?.querySelector<HTMLElement>(selector)
+  if (!target) throw new Error(`no ${selector}`)
+  await act(async () => {
+    target.click()
+    await Promise.resolve()
+  })
+}
+const button = (label: string) =>
+  Array.from(container?.querySelectorAll('button') ?? []).find((b) => b.textContent?.trim() === label)
+const pressButton = async (label: string) => {
+  const target = button(label)
+  if (!target) throw new Error(`no "${label}" button`)
+  await act(async () => {
+    target.click()
+    await Promise.resolve()
+  })
+}
+
+beforeEach(() => {
+  wire.slices = {}
+  wire.failure = null
+  wire.calls = []
+  wire.hold = null
+  hl.fail = false
+  closed = 0
+  vi.mocked(fetchWorkspaceFile).mockClear()
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container?.remove()
+  container = undefined
+  root = undefined
+})
+
+describe('SessionViewer header', () => {
+  it('names the file, its language, its line count and its size', async () => {
+    wire.slices[0] = { content: 'const a = 1\nconst b = 2\n', size: 24 }
+    await render()
+    expect(text()).toContain('src/app/')
+    expect(text()).toContain('page.tsx')
+    // Two lines, not three: the trailing newline ends the second line rather than beginning an empty third.
+    expect(text()).toContain('TypeScript · 2 lines · 24 B')
+  })
+
+  it('closes back to the conversation rather than naming a mode', async () => {
+    wire.slices[0] = { content: 'x' }
+    await render()
+    const close = container?.querySelector<HTMLElement>('[data-viewer-close]')
+    expect(close?.getAttribute('aria-label')).toBe('Back to the conversation')
+    await click('[data-viewer-close]')
+    expect(closed).toBe(1)
+  })
+
+  it('names no language for an extension nothing maps', async () => {
+    wire.slices[0] = { content: 'blob\n', size: 5 }
+    await render({ path: 'notes.wat' })
+    expect(text()).toContain('1 line · 5 B')
+    expect(text()).not.toContain('TypeScript')
+  })
+
+  it('says the line count describes only the slice on screen while more is unread', async () => {
+    wire.slices[0] = { content: 'a\nb\nc\n', size: 200_000, truncated: true, nextOffset: 65_536 }
+    await render()
+    expect(text()).toContain('first 3 lines')
+    expect(text()).not.toContain('TypeScript · 3 lines')
+  })
+})
+
+describe('SessionViewer body', () => {
+  it('numbers every line it renders, and only the lines it renders', async () => {
+    wire.slices[0] = { content: 'one\ntwo\nthree' }
+    await render()
+    expect(gutter()).toBe('1\n2\n3')
+    expect(code()).toBe('one\ntwo\nthree')
+  })
+
+  it('sends the highlighted markup through, and the escaped text when the highlighter never arrives', async () => {
+    wire.slices[0] = { content: 'const x = 1' }
+    await render()
+    expect(container?.querySelector('[data-viewer-code] b.hljs-keyword')?.textContent).toBe('const x = 1')
+
+    hl.fail = true
+    await rerender({ path: 'src/other.tsx' })
+    await settle()
+    expect(container?.querySelector('[data-viewer-code] b.hljs-keyword')).toBeNull()
+    expect(code()).toBe('const x = 1')
+  })
+
+  it('escapes rather than injects content that looks like markup', async () => {
+    hl.fail = true
+    wire.slices[0] = { content: '<script>alert(1)</script>' }
+    await render()
+    expect(container?.querySelector('[data-viewer-code] script')).toBeNull()
+    expect(code()).toBe('<script>alert(1)</script>')
+  })
+
+  it('says an empty file is empty instead of drawing an empty gutter', async () => {
+    wire.slices[0] = { content: '', size: 0 }
+    await render()
+    expect(text()).toContain('This file is empty.')
+    expect(container?.querySelector('[data-viewer-gutter]')).toBeNull()
+  })
+
+  it('draws a path this checkout does not have as a not-found state, not a failure', async () => {
+    wire.slices[0] = { exists: false, content: null, size: null }
+    await render({ path: 'src/gone.ts' })
+    expect(text()).toContain('this checkout has no file at that path')
+    expect(text()).not.toContain('daemon may be offline')
+    expect(container?.querySelector('[data-viewer-gutter]')).toBeNull()
+  })
+
+  it('withholds a binary file by name and size, as the daemon withheld its bytes', async () => {
+    wire.slices[0] = { encoding: 'none', content: null, size: 2048 }
+    await render({ path: 'assets/logo.png' })
+    expect(text()).toContain('Binary file — not displayed (2.0 KB)')
+    expect(container?.querySelector('[data-viewer-gutter]')).toBeNull()
+  })
+})
+
+describe('SessionViewer degraded reads', () => {
+  it('reads a rejected read as an offline daemon', async () => {
+    wire.failure = 'network'
+    await render()
+    expect(text()).toContain('the owning daemon may be offline')
+    expect(text()).not.toContain('cannot read a session worktree')
+    expect(text()).not.toContain('not available to read')
+  })
+
+  it('tells a daemon too old for worktree reads apart from an offline one', async () => {
+    wire.failure = 409
+    await render()
+    expect(text()).toContain('cannot read a session worktree')
+    expect(text()).not.toContain('may be offline')
+  })
+
+  it('says whose worktree is missing when the scope itself is refused', async () => {
+    wire.failure = 404
+    await render()
+    expect(text()).toContain("This session's worktree is not available to read")
+
+    await act(() => root?.unmount())
+    container?.remove()
+    await render({ sessionId: undefined })
+    expect(text()).toContain('This workspace is not available to read.')
+    expect(text()).not.toContain("session's worktree")
+  })
+})
+
+describe('SessionViewer scope', () => {
+  it('scopes the read to the session worktree it was given', async () => {
+    wire.slices[0] = { content: 'x' }
+    await render()
+    expect(wire.calls[0]).toEqual({ path: 'src/app/page.tsx', sessionId: 'session-1' })
+  })
+
+  it('reads the primary checkout when no session scope is given', async () => {
+    wire.slices[0] = { content: 'x' }
+    await render({ sessionId: undefined })
+    expect(wire.calls[0]).toEqual({ path: 'src/app/page.tsx' })
+  })
+
+  it('drops an answer that is no longer the file on screen', async () => {
+    wire.hold = []
+    await render({ path: 'a.ts' })
+    await rerender({ path: 'b.ts' })
+    wire.slices[0] = { content: 'B' }
+    // The second read answers first, then the first read's answer arrives for a path nobody is looking at.
+    const [releaseA, releaseB] = wire.hold
+    wire.hold = null
+    await act(async () => {
+      releaseB?.()
+      await Promise.resolve()
+    })
+    wire.slices[0] = { content: 'A' }
+    await act(async () => {
+      releaseA?.()
+      await Promise.resolve()
+    })
+    expect(code()).toBe('B')
+  })
+})
+
+describe('SessionViewer sliced reads', () => {
+  const truncated = { content: 'a\nb\n', size: 200_000, truncated: true, nextOffset: 65_536, offset: 0 }
+
+  it('asks for the next slice at the offset the daemon named, not at the length of the text it decoded', async () => {
+    wire.slices[0] = truncated
+    wire.slices[65_536] = { content: 'c\n', size: 200_000, truncated: false, nextOffset: 200_000, offset: 65_536 }
+    await render()
+    expect(text()).toContain('Showing first 64.0 KB of 195.3 KB')
+    await pressButton('Load more')
+    expect(wire.calls[1]).toEqual({ path: 'src/app/page.tsx', offset: 65_536, sessionId: 'session-1' })
+    expect(code()).toBe('a\nb\nc')
+    expect(gutter()).toBe('1\n2\n3')
+    expect(text()).not.toContain('Showing first')
+  })
+
+  it('keeps the slices it has when the next one fails, and offers the read again', async () => {
+    wire.slices[0] = truncated
+    await render()
+    wire.failure = 'network'
+    await pressButton('Load more')
+    expect(code()).toBe('a\nb')
+    expect(text()).toContain("Couldn't load more — the daemon may be offline.")
+    expect(button('Retry')).toBeDefined()
+  })
+
+  it('refuses to splice two revisions of one file, and offers to read the current one', async () => {
+    wire.slices[0] = truncated
+    wire.slices[65_536] = {
+      content: 'DIFFERENT\n',
+      mtime: '2026-08-10T12:00:00.000Z',
+      truncated: true,
+      nextOffset: 131_072
+    }
+    await render()
+    await pressButton('Load more')
+    expect(code()).toBe('a\nb')
+    expect(text()).toContain('changed this file while it was loading')
+    expect(button('Load more')).toBeUndefined()
+
+    // Reload starts the read over from byte 0 rather than continuing into the new revision.
+    wire.slices[0] = { content: 'fresh\n', size: 6 }
+    await pressButton('Reload')
+    expect(wire.calls.at(-1)).toEqual({ path: 'src/app/page.tsx', sessionId: 'session-1' })
+    expect(code()).toBe('fresh')
+  })
+
+  it('says the file is partial without offering a read that cannot advance', async () => {
+    wire.slices[0] = { content: 'a\n', size: 200_000, truncated: true, nextOffset: 0, offset: 0 }
+    await render()
+    expect(text()).toContain('Showing part of 195.3 KB')
+    expect(button('Load more')).toBeUndefined()
+  })
+})

--- a/packages/web/src/components/console/viewer/SessionViewer.tsx
+++ b/packages/web/src/components/console/viewer/SessionViewer.tsx
@@ -1,0 +1,273 @@
+'use client'
+
+// The session page's viewer mode (§4): ONE workspace file, full height, in place of the transcript and the composer — line-numbered, syntax-coloured, and scrolling inside itself rather than growing the page.
+// M1 is File mode only. The Diff / File pill toggle needs a `workspace/gitdiff` frame that does not exist yet (M2), so this header leaves it a slot and stubs nothing.
+// Bytes come straight from the owning daemon through the CP (body-locality), so an offline daemon, a path this checkout does not have, a binary file and a file too large for one slice are all expected answers — each is drawn as data.
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Spinner } from '@/components/marks'
+import { Icon } from '@/components/ui'
+import { formatFileSize } from '@/components/console/FileBrowser'
+import { escapeHtml, highlight, languageLabel, linkifyHtml, loadHljs } from '@/lib/highlight'
+import { ApiError, fetchWorkspaceFile, type WorkspaceFileDto } from '@/lib/api'
+
+const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
+const statusOf = (e: unknown) => (e instanceof ApiError ? e.status : null)
+
+// One file read, accumulated slice by slice. `file` is the LATEST slice — it carries the authoritative `nextOffset`/`truncated`/`size`; `content` is every slice so far.
+interface Read {
+  loading: boolean
+  /** Initial-read failure: nothing to show. */
+  err: string | null
+  /** That failure's HTTP status, when it had one — the CP tells an offline daemon apart from a version that cannot read a worktree. */
+  errStatus: number | null
+  file: WorkspaceFileDto | null
+  content: string
+  loadingMore: boolean
+  /** Append failure or a mid-read revision change — keeps the slices already read. */
+  moreNote: string | null
+  /** The file changed under the read, so appending would splice two revisions. */
+  stale: boolean
+}
+
+const PENDING: Read = {
+  loading: true,
+  err: null,
+  errStatus: null,
+  file: null,
+  content: '',
+  loadingMore: false,
+  moreNote: null,
+  stale: false
+}
+
+// The read failed outright. Only 409 (daemon too old for worktree reads) and 404 (a worktree scope this viewer may not read) are distinguishable; everything else — 503 for an offline daemon and for an unplaced agent, plus a daemon that rejected the path — is the offline story.
+function readNoticeText(status: number | null, scoped: boolean): string {
+  if (status === 409) {
+    return 'This agent runs a daemon version that cannot read a session worktree. Update the agent, or open the file from its workspace page.'
+  }
+  if (status === 404) {
+    return scoped
+      ? "This session's worktree is not available to read — it may have been cleaned up, or this session may not have one of its own."
+      : 'This workspace is not available to read.'
+  }
+  return "Couldn't read the file — the owning daemon may be offline. Workspace files live only on that machine and are read live from it, so they are unavailable while it is disconnected."
+}
+
+export function SessionViewer({
+  agentId,
+  sessionId,
+  path,
+  onClose
+}: {
+  agentId: string
+  /** ACP session id selecting that session's isolated worktree; omit for the agent's primary checkout. Pass it only for a session whose `workspaceIsolation` is `'session'` — the daemon answers a shared-workspace sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline". */
+  sessionId?: string
+  /** Workspace-relative path of the file to read. Changing it starts a fresh read; an older slice can never land in the newer one. */
+  path: string
+  onClose: () => void
+}) {
+  const [read, setRead] = useState<Read>(PENDING)
+  // Re-reads the same path from byte 0, for a file that changed while it was being read.
+  const [reloadTick, setReloadTick] = useState(0)
+  // A path check alone cannot tell an A → B → A read apart, so every read is sequenced and an answer that is not the current one is dropped.
+  const requestRef = useRef(0)
+
+  useEffect(() => {
+    const requestId = ++requestRef.current
+    setRead(PENDING)
+    fetchWorkspaceFile(agentId, { path, ...(sessionId ? { sessionId } : {}) }).then(
+      (f) =>
+        setRead((r) =>
+          requestId === requestRef.current ? { ...r, loading: false, file: f, content: f.content ?? '' } : r
+        ),
+      (e) =>
+        setRead((r) =>
+          requestId === requestRef.current ? { ...r, loading: false, err: msg(e), errStatus: statusOf(e) } : r
+        )
+    )
+    return () => {
+      requestRef.current += 1
+    }
+  }, [agentId, sessionId, path, reloadTick])
+
+  const file = read.file
+  // The daemon's own byte offset, never recomputed from the decoded text: a slice can end mid-character, so the decoded length drifts from the byte count.
+  const nextOffset =
+    file?.truncated && file.nextOffset != null && file.nextOffset > (file.offset ?? 0) ? file.nextOffset : null
+
+  const loadMore = () => {
+    if (nextOffset === null || read.loadingMore || read.stale) return
+    const requestId = requestRef.current
+    const at = nextOffset
+    const readMtime = file?.mtime ?? null
+    setRead((r) => ({ ...r, loadingMore: true, moreNote: null }))
+    fetchWorkspaceFile(agentId, { path, offset: at, ...(sessionId ? { sessionId } : {}) }).then(
+      (f) =>
+        setRead((r) => {
+          if (requestId !== requestRef.current) return r
+          // Fenced on mtime like the editor's whole-file read: appending across a revision change would assemble one document out of two.
+          if (readMtime && f.mtime && f.mtime !== readMtime) {
+            return {
+              ...r,
+              loadingMore: false,
+              stale: true,
+              moreNote: 'The agent changed this file while it was loading — reload it to read the current version.'
+            }
+          }
+          return { ...r, loadingMore: false, file: f, content: r.content + (f.content ?? '') }
+        }),
+      () =>
+        setRead((r) =>
+          requestId === requestRef.current
+            ? { ...r, loadingMore: false, moreNote: "Couldn't load more — the daemon may be offline." }
+            : r
+        )
+    )
+  }
+
+  const name = path.split('/').at(-1) ?? path
+  const dir = path.slice(0, Math.max(0, path.length - name.length - 1))
+  const isText = file?.exists === true && file.encoding === 'utf8'
+
+  // Lines as an editor counts them: a trailing newline ENDS the last line rather than beginning an empty one, so the gutter and the header's count describe the same rows.
+  const lines = useMemo(() => {
+    if (!read.content) return []
+    const parts = read.content.split('\n')
+    if (parts.length > 1 && parts[parts.length - 1] === '') parts.pop()
+    return parts
+  }, [read.content])
+  // Rendered and highlighted from the SAME string as the gutter is numbered from.
+  const text = useMemo(() => lines.join('\n'), [lines])
+  const gutter = useMemo(() => lines.map((_, index) => index + 1).join('\n'), [lines])
+
+  const [html, setHtml] = useState<string | null>(null)
+  useEffect(() => {
+    if (!isText || !text) {
+      setHtml(null)
+      return
+    }
+    let active = true
+    loadHljs().then(
+      (hljs) => {
+        if (active) setHtml(highlight(hljs, text, name))
+      },
+      () => {
+        // Highlighter unavailable: escaped plain text through the same pipeline.
+        if (active) setHtml(null)
+      }
+    )
+    return () => {
+      active = false
+    }
+  }, [isText, text, name])
+  const codeHtml = useMemo(() => (isText && text ? linkifyHtml(html ?? escapeHtml(text)) : null), [isText, text, html])
+
+  // What the file IS, for a reader who arrived on a link: the language only when the mapping is confident, and a line count that says so when it describes a slice rather than the whole file.
+  const lineCount = `${lines.length} line${lines.length === 1 ? '' : 's'}`
+  const meta = isText
+    ? [languageLabel(name), file?.truncated ? `first ${lineCount}` : lineCount, formatFileSize(file?.size ?? null)]
+        .filter(Boolean)
+        .join(' · ')
+    : ''
+
+  return (
+    <section className="card flex min-h-0 flex-1 flex-col overflow-hidden max-desktop:m-4">
+      <div className="flex flex-none items-center gap-2 border-b border-(--border-subtle) px-4 py-[10px]">
+        <Icon name="file" size={15} color="var(--text-tertiary)" className="flex-none" />
+        <span className="mono flex min-w-0 flex-1 items-baseline text-[12px] leading-normal" title={path}>
+          {dir ? <span className="min-w-0 truncate font-normal text-(--text-tertiary)">{`${dir}/`}</span> : null}
+          <span className="flex-none font-medium text-(--text-primary)">{name}</span>
+        </span>
+        {/* M2's Diff / File pill toggle slots in here, between the path and its meta — nothing else in this header moves for it. */}
+        {meta ? (
+          <span className="mono flex-none text-[11px] font-normal text-(--text-tertiary) max-desktop:hidden">
+            {meta}
+          </span>
+        ) : null}
+        <button
+          type="button"
+          className="iconbtn flex-none"
+          data-viewer-close=""
+          aria-label="Back to the conversation"
+          title="Back to the conversation"
+          onClick={onClose}
+        >
+          <Icon name="x" size={15} />
+        </button>
+      </div>
+      {/* Same string, second row: at ≤768px the header has no room for it beside a path, and the path is the half a reader cannot do without. */}
+      {meta ? (
+        <div className="mono flex-none border-b border-(--border-subtle) px-4 py-[5px] text-[11px] font-normal text-(--text-tertiary) desktop:hidden">
+          {meta}
+        </div>
+      ) : null}
+
+      {read.loading ? (
+        <div className="flex flex-1 items-center justify-center py-10">
+          <Spinner size={30} />
+        </div>
+      ) : read.err ? (
+        <div className="flex items-start gap-[10px] p-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary)">
+          <Icon name="triangle-alert" size={15} color="var(--amber-500)" className="mt-[2px] flex-none" />
+          <span>{readNoticeText(read.errStatus, Boolean(sessionId))}</span>
+        </div>
+      ) : file && !file.exists ? (
+        <div className="flex items-start gap-[10px] p-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary)">
+          <Icon name="file-question-mark" size={15} color="var(--text-tertiary)" className="mt-[2px] flex-none" />
+          <span>
+            Not found — this checkout has no file at that path. It may have been removed since the link was made, or the
+            link may name another agent&apos;s workspace.
+          </span>
+        </div>
+      ) : file?.encoding === 'none' ? (
+        <div className="flex items-center gap-2 p-4 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+          <Icon name="file-question-mark" size={15} />
+          Binary file — not displayed ({formatFileSize(file.size)})
+        </div>
+      ) : lines.length === 0 ? (
+        <div className="p-4 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+          This file is empty.
+        </div>
+      ) : (
+        // The viewer's OWN scroller: the page's `.content` is what the transcript's stick-to-bottom pins, so a file that grew the page would move the transcript's anchor instead of scrolling here.
+        <div className="min-h-0 flex-1 overflow-auto" data-viewer-code="">
+          <div className="flex min-w-max">
+            {/* One text node, not a row per line: the numbers then share the code's line boxes by construction, and `sticky` keeps them in place while a long line scrolls sideways. */}
+            <pre
+              aria-hidden="true"
+              data-viewer-gutter=""
+              className="mono sticky left-0 z-[1] m-0 flex-none select-none border-r border-(--border-subtle) bg-(--surface-card) px-3 py-[14px] text-right text-[12px] leading-[1.7] whitespace-pre text-(--text-disabled)"
+            >
+              {gutter}
+            </pre>
+            <pre className="hljs mono m-0 flex-none bg-transparent px-4 py-[14px] text-[12px] leading-[1.7] whitespace-pre text-(--text-primary)">
+              {codeHtml != null ? <code dangerouslySetInnerHTML={{ __html: codeHtml }} /> : <code>{text}</code>}
+            </pre>
+          </div>
+        </div>
+      )}
+
+      {file?.truncated && isText ? (
+        <div className="flex flex-none flex-wrap items-center gap-x-[10px] gap-y-1 border-t border-(--border-subtle) px-4 py-[9px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+          {/* The slice's own end offset names how much is on screen; a truncated slice that named no offset it could continue from can still say the whole file is bigger. */}
+          <span>
+            {nextOffset !== null
+              ? `Showing first ${formatFileSize(nextOffset)} of ${formatFileSize(file.size)}`
+              : `Showing part of ${formatFileSize(file.size)}`}
+          </span>
+          {read.stale ? (
+            <button className="lnk text-[12px]" onClick={() => setReloadTick((tick) => tick + 1)}>
+              Reload
+            </button>
+          ) : nextOffset !== null ? (
+            <button className="lnk text-[12px]" onClick={loadMore} disabled={read.loadingMore}>
+              {read.loadingMore ? 'Loading…' : read.moreNote ? 'Retry' : 'Load more'}
+            </button>
+          ) : null}
+          {read.moreNote ? <span>{read.moreNote}</span> : null}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/packages/web/src/components/console/viewer/SessionViewer.tsx
+++ b/packages/web/src/components/console/viewer/SessionViewer.tsx
@@ -141,7 +141,8 @@ export function SessionViewer({
   const text = useMemo(() => lines.join('\n'), [lines])
   const gutter = useMemo(() => lines.map((_, index) => index + 1).join('\n'), [lines])
 
-  const [html, setHtml] = useState<string | null>(null)
+  // Highlighted HTML is stored WITH the source it was produced from. The highlighter is async, so a paginated or reloaded slice would otherwise render the previous revision's colouring — and its gutter — beside the new source for as many paints as the pass takes; escaped plain text is the correct thing to show in that window.
+  const [html, setHtml] = useState<{ text: string; name: string; html: string } | null>(null)
   useEffect(() => {
     if (!isText || !text) {
       setHtml(null)
@@ -150,7 +151,10 @@ export function SessionViewer({
     let active = true
     loadHljs().then(
       (hljs) => {
-        if (active) setHtml(highlight(hljs, text, name))
+        if (!active) return
+        // `highlight` declines an unknown language by returning null — the same "use escaped text" answer as a failed load.
+        const marked = highlight(hljs, text, name)
+        setHtml(marked === null ? null : { text, name, html: marked })
       },
       () => {
         // Highlighter unavailable: escaped plain text through the same pipeline.
@@ -161,7 +165,11 @@ export function SessionViewer({
       active = false
     }
   }, [isText, text, name])
-  const codeHtml = useMemo(() => (isText && text ? linkifyHtml(html ?? escapeHtml(text)) : null), [isText, text, html])
+  const fresh = html && html.text === text && html.name === name ? html.html : null
+  const codeHtml = useMemo(
+    () => (isText && text ? linkifyHtml(fresh ?? escapeHtml(text)) : null),
+    [isText, text, fresh]
+  )
 
   // What the file IS, for a reader who arrived on a link: the language only when the mapping is confident, and a line count that says so when it describes a slice rather than the whole file.
   const lineCount = `${lines.length} line${lines.length === 1 ? '' : 's'}`

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1743,13 +1743,23 @@ export default function SessionDetailView() {
   const storedHeaderFocusValid =
     headerFocusSelection.scope === headerFocusScope &&
     headerFocusOptions.some((option) => option.agentId === headerFocusSelection.agentId)
-  // A deep link's `agent` outranks both the stored selection and the default, but only while it names an agent this conversation actually has — a stale link must fall back rather than focus nothing.
+  // A deep link's `agent` outranks both the stored selection and the default while it names an agent this conversation actually has.
   const linkedFocusAgentId =
     viewerAgentParam && headerFocusOptions.some((option) => option.agentId === viewerAgentParam)
       ? viewerAgentParam
       : null
+  // An `agent` that is PRESENT but does not resolve fails CLOSED. Falling back to the default here would read the linked path from a different checkout and draw plausible-but-wrong content — exactly the ambiguity this parameter exists to remove. Only a link without `agent` at all gets the legacy default. Held until the roster has options, since an empty list means "not known yet", not "not there".
+  const linkedFocusStale = viewerAgentParam !== null && linkedFocusAgentId === null && headerFocusOptions.length > 0
   const headerFocusAgentId =
     linkedFocusAgentId ?? (storedHeaderFocusValid ? headerFocusSelection.agentId : defaultHeaderFocusAgentId)
+  // Both focus menus go through here, because a `?file=` with an `agent` OUTRANKS the local selection: writing only the selection would make the control a no-op — the menu closes and the URL's agent renders again. So the URL moves with the reader, and the open path follows them into the checkout they picked (where the viewer's own not-found state covers a path that agent does not have).
+  const changeHeaderFocus = useCallback(
+    (agentId: string) => {
+      setHeaderFocusSelection({ scope: headerFocusScope, agentId })
+      if (viewerPath !== null) setViewerFile(viewerPath, agentId)
+    },
+    [headerFocusScope, setViewerFile, viewerPath]
+  )
   useEffect(() => {
     if (!defaultHeaderFocusAgentId) return
     setHeaderFocusSelection((current) =>
@@ -1766,7 +1776,11 @@ export default function SessionDetailView() {
     headerFocusSessionId && headerFocusSessionId !== currentSessionDetail?.id && !syntheticPlayground
       ? headerFocusSessionId
       : null
-  const { data: extraHeaderDetail, mutate: mutateExtraHeaderDetail } = useSWR<SessionDetailDto>(
+  const {
+    data: extraHeaderDetail,
+    error: extraHeaderDetailError,
+    mutate: mutateExtraHeaderDetail
+  } = useSWR<SessionDetailDto>(
     consoleKeys.sessionDetail(activeOrg?.id, extraHeaderDetailId),
     ([, orgId, , sessionId]) => fetchSessionDetail(sessionId as string, orgId as string)
   )
@@ -1796,6 +1810,8 @@ export default function SessionDetailView() {
     extraHeaderDetailId === null ||
     extraHeaderDetail !== undefined ||
     focusedSession?.workspaceIsolation !== undefined
+  // A REJECTED isolation read is not a pending one. The checkout still may not be read — the answer is unknown either way — but a spinner that never resolves is a worse lie than saying so, so this state gets its own copy and the tab counts as answered.
+  const filesScopeFailed = !filesScopeReady && extraHeaderDetailError !== undefined
   const focusedAgentRuntime = focusedSession?.runtime || focusedAgent?.runtime || ''
   const focusedRuntimeMeta = acpRuntime(acpRegistry, focusedAgentRuntime)
 
@@ -1854,8 +1870,8 @@ export default function SessionDetailView() {
   )
   // What tells "the list is still coming" from "there is no list": the dock withholds its chrome and holds its track for either, and the two only differ in the placeholder a sibling-tab-ready dock shows.
   const sessionsStatus = sessionsTabStatus(sessionsWouldHide, !seededRailLoading && railFamilySettled)
-  // `loading` also covers "we do not know which checkout yet": a related session's isolation is a round trip behind, and reading before it lands would read the wrong one.
-  const filesStatus = filesScopeReady ? filesTabStatus(filesRootSettled) : 'loading'
+  // `loading` also covers "we do not know which checkout yet": a related session's isolation is a round trip behind, and reading before it lands would read the wrong one. A failed isolation read is `ready` instead — it has copy to draw, and it is never going to resolve on its own.
+  const filesStatus = filesScopeFailed ? 'ready' : filesScopeReady ? filesTabStatus(filesRootSettled) : 'loading'
   // Each tab's own verdict, spliced onto the static descriptors. Files is dropped outright rather than left `loading` forever when there is no agent behind it — a tab that can never answer is not a tab — and the demo tour has no daemon to read a checkout from at all, so it does not get one either.
   const dockTabs = useMemo<DockTab[]>(
     () =>
@@ -2554,8 +2570,8 @@ export default function SessionDetailView() {
   // Scoped to this session's OWN worktree only where it has one. `hasSessionWorktree` is the same gate the Workspace link above uses, and it is load-bearing for the reads: the daemon answers a shared workspace's sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline".
   const filesSessionId = hasSessionWorktree && headerFocusSessionId ? headerFocusSessionId : undefined
   const filesWorkdir = focusedAgent && focusedAgent.workdir !== '—' ? focusedAgent.workdir : undefined
-  // A `?file=` on a session with no agent to read it from has nothing to open, so the conversation stays: the viewer never renders without a checkout behind it — nor before that checkout's scope is known.
-  const viewerOpen = viewerPath !== null && filesAgentId !== null && filesScopeReady
+  // A `?file=` on a session with no agent to read it from has nothing to open, so the conversation stays: the viewer never renders without a checkout behind it, nor before that checkout's scope is known, nor when the link named a workspace this conversation does not have.
+  const viewerOpen = viewerPath !== null && filesAgentId !== null && filesScopeReady && !linkedFocusStale
   const liveSteps = isWebchat ? getLiveSteps(session.id) : []
 
   // The conversation roster, for EVERY live surface — the synthetic playground and
@@ -3366,7 +3382,7 @@ export default function SessionDetailView() {
           <SessionAgentFocusMenu
             options={headerFocusOptions}
             value={headerFocusAgentId}
-            onChange={(agentId) => setHeaderFocusSelection({ scope: headerFocusScope, agentId })}
+            onChange={(agentId) => changeHeaderFocus(agentId)}
           />
           {headerCron ? (
             <Link
@@ -3485,6 +3501,17 @@ export default function SessionDetailView() {
           </div>
         )}
 
+        {/* The link named a workspace this conversation does not have. Saying so beats opening the same path against whichever agent the header would otherwise focus — that reads plausible and is wrong. */}
+        {linkedFocusStale && viewerPath !== null && (
+          <div
+            data-viewer-stale-link=""
+            className="mb-3 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4 max-desktop:mt-3"
+          >
+            This link points at an agent that is not part of this conversation, so its file was not opened. Pick an
+            agent in the header and open the file from the Files tab.
+          </div>
+        )}
+
         {/* MOBILE HEADER ROW — the desktop meta row's shape at 390px: the focused
           agent, workspace, visibility, and everything numeric collapsed behind
           the SAME Details popover. It replaces the old 4-up stat strip and the
@@ -3496,7 +3523,7 @@ export default function SessionDetailView() {
             <SessionAgentFocusMenu
               options={headerFocusOptions}
               value={headerFocusAgentId}
-              onChange={(agentId) => setHeaderFocusSelection({ scope: headerFocusScope, agentId })}
+              onChange={(agentId) => changeHeaderFocus(agentId)}
             />
           </span>
           {workspaceHref ? (
@@ -4424,7 +4451,16 @@ export default function SessionDetailView() {
           />
         </DockPanel>
         <DockPanel active={dockTabKey === 'files'}>
-          {/* Withheld until the scope is known, so no listing is ever issued against a checkout we only assumed. */}
+          {/* Withheld until the scope is known, so no listing is ever issued against a checkout we only assumed. A rejected isolation read says so rather than spinning forever. */}
+          {filesScopeFailed ? (
+            <div
+              data-files-scope-failed=""
+              className="px-3 py-4 font-sans text-[12px] font-normal leading-normal text-(--text-secondary)"
+            >
+              Couldn’t tell which checkout this session reads — its details didn’t load. Reopen the session, or read the
+              files from the agent’s workspace page.
+            </div>
+          ) : null}
           {filesAgentId && filesScopeReady ? (
             <FilesPanel
               agentId={filesAgentId}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1226,14 +1226,19 @@ export default function SessionDetailView() {
   const flatView = isFlatSessionView(searchParams)
   const { id: routeId, key: conversationKeyParam } = useParams<{ id?: string; key?: string }>()
   // Which file the viewer holds, and the ONLY place that answer lives (§4): "look at this file" is a link a reviewer sends, so the pane mode is addressable and survives a reload. Derived from the route rather than mirrored into state — that is also what makes it per-session for free, since a session link carries no `file`.
-  const viewerParam = searchParams.get('file')?.trim()
-  const viewerPath = viewerParam ? viewerParam : null
+  // NOT trimmed: a POSIX filename may legitimately begin or end with whitespace, and `URLSearchParams` round-trips those bytes faithfully — trimming would ask the daemon for a different file, or close the viewer outright on a name made only of spaces. Only an absent or empty param means "no file".
+  const viewerPath = searchParams.get('file') || null
+  // Which workspace that path was read from. A merged conversation's header focus is component state that defaults to the current REPRESENTATIVE, and the representative changes as another participant becomes newest — so without this a link copied while focused on agent B reopens B's path against A's checkout.
+  const viewerAgentParam = searchParams.get('agent')
   // REPLACE, never push. The viewer is a pane mode inside one route, not a place: pushing would spend a history entry per tree click, so a reader who read six files would need seven Back presses to leave the session, and Back would stop meaning "leave this session". The cost, accepted: Back does not step file-by-file within a visit. Writing through URLSearchParams is also what makes a path with slashes and spaces round-trip — `router.replace` on `.toString()`, `searchParams.get` back.
   const setViewerFile = useCallback(
-    (next: string | null) => {
+    (next: string | null, agentId?: string | null) => {
       const query = new URLSearchParams(searchParams)
       if (next) query.set('file', next)
       else query.delete('file')
+      // The workspace travels with the path, so the link resolves to the checkout it was made from rather than to whichever agent the header happens to focus on reopening.
+      if (next && agentId) query.set('agent', agentId)
+      else query.delete('agent')
       const search = query.toString()
       router.replace(search ? `${pathname}?${search}` : pathname, { scroll: false })
     },
@@ -1738,7 +1743,13 @@ export default function SessionDetailView() {
   const storedHeaderFocusValid =
     headerFocusSelection.scope === headerFocusScope &&
     headerFocusOptions.some((option) => option.agentId === headerFocusSelection.agentId)
-  const headerFocusAgentId = storedHeaderFocusValid ? headerFocusSelection.agentId : defaultHeaderFocusAgentId
+  // A deep link's `agent` outranks both the stored selection and the default, but only while it names an agent this conversation actually has — a stale link must fall back rather than focus nothing.
+  const linkedFocusAgentId =
+    viewerAgentParam && headerFocusOptions.some((option) => option.agentId === viewerAgentParam)
+      ? viewerAgentParam
+      : null
+  const headerFocusAgentId =
+    linkedFocusAgentId ?? (storedHeaderFocusValid ? headerFocusSelection.agentId : defaultHeaderFocusAgentId)
   useEffect(() => {
     if (!defaultHeaderFocusAgentId) return
     setHeaderFocusSelection((current) =>
@@ -1779,6 +1790,12 @@ export default function SessionDetailView() {
         daemon: focusedSessionBase.daemon ?? focusedAgent?.daemon
       }
     : null
+  // Whether the focused session's workspace isolation has an ANSWER yet. A related session in the focus menu has an id but no detail until its own round trip lands, and both isolation sources read undefined until then — so a surface mounted now would take "not isolated" for an answer and read the agent's primary checkout instead of the worktree the session actually owns. Withhold rather than guess.
+  const filesScopeReady =
+    !headerFocusSessionId ||
+    extraHeaderDetailId === null ||
+    extraHeaderDetail !== undefined ||
+    focusedSession?.workspaceIsolation !== undefined
   const focusedAgentRuntime = focusedSession?.runtime || focusedAgent?.runtime || ''
   const focusedRuntimeMeta = acpRuntime(acpRegistry, focusedAgentRuntime)
 
@@ -1837,11 +1854,12 @@ export default function SessionDetailView() {
   )
   // What tells "the list is still coming" from "there is no list": the dock withholds its chrome and holds its track for either, and the two only differ in the placeholder a sibling-tab-ready dock shows.
   const sessionsStatus = sessionsTabStatus(sessionsWouldHide, !seededRailLoading && railFamilySettled)
-  const filesStatus = filesTabStatus(filesRootSettled)
-  // Each tab's own verdict, spliced onto the static descriptors. Files is dropped outright rather than left `loading` forever when there is no agent behind it — a tab that can never answer is not a tab.
+  // `loading` also covers "we do not know which checkout yet": a related session's isolation is a round trip behind, and reading before it lands would read the wrong one.
+  const filesStatus = filesScopeReady ? filesTabStatus(filesRootSettled) : 'loading'
+  // Each tab's own verdict, spliced onto the static descriptors. Files is dropped outright rather than left `loading` forever when there is no agent behind it — a tab that can never answer is not a tab — and the demo tour has no daemon to read a checkout from at all, so it does not get one either.
   const dockTabs = useMemo<DockTab[]>(
     () =>
-      DOCK_TABS.filter((tab) => tab.key !== 'files' || filesAgentId !== null).map((tab) =>
+      DOCK_TABS.filter((tab) => tab.key !== 'files' || (filesAgentId !== null && !MOCK_MODE)).map((tab) =>
         tab.key === 'sessions'
           ? { ...tab, status: sessionsStatus }
           : tab.key === 'files'
@@ -2536,8 +2554,8 @@ export default function SessionDetailView() {
   // Scoped to this session's OWN worktree only where it has one. `hasSessionWorktree` is the same gate the Workspace link above uses, and it is load-bearing for the reads: the daemon answers a shared workspace's sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline".
   const filesSessionId = hasSessionWorktree && headerFocusSessionId ? headerFocusSessionId : undefined
   const filesWorkdir = focusedAgent && focusedAgent.workdir !== '—' ? focusedAgent.workdir : undefined
-  // A `?file=` on a session with no agent to read it from has nothing to open, so the conversation stays: the viewer never renders without a checkout behind it.
-  const viewerOpen = viewerPath !== null && filesAgentId !== null
+  // A `?file=` on a session with no agent to read it from has nothing to open, so the conversation stays: the viewer never renders without a checkout behind it — nor before that checkout's scope is known.
+  const viewerOpen = viewerPath !== null && filesAgentId !== null && filesScopeReady
   const liveSteps = isWebchat ? getLiveSteps(session.id) : []
 
   // The conversation roster, for EVERY live surface — the synthetic playground and
@@ -3564,9 +3582,9 @@ export default function SessionDetailView() {
         {!isLive && approvalCard('mx-4 mt-4 max-desktop:rounded-lg desktop:mx-0 desktop:mt-0 desktop:mb-4')}
 
         {viewerOpen && viewerPath && filesAgentId ? (
-          // Keyed on the path: the viewer resets its slice in a passive effect, which runs AFTER paint, so without a fresh mount one committed frame draws the previous file's bytes — and its line count and size — under the new file's name. Same hazard `transcriptMatchesSession` guards for the transcript; nothing inside the viewer is worth carrying across files.
+          // Keyed on the whole WORKSPACE SCOPE, not just the path: the viewer resets its slice in a passive effect, which runs AFTER paint, so without a fresh mount one committed frame draws the previous read's bytes — and its line count and size — under the new heading. The path alone is not that scope: switching header focus from one agent to another while `?file=` holds still is the same stale paint. Same hazard `transcriptMatchesSession` guards for the transcript; nothing inside the viewer is worth carrying across either axis.
           <SessionViewer
-            key={viewerPath}
+            key={`${filesAgentId}:${filesSessionId ?? 'primary'}:${viewerPath}`}
             agentId={filesAgentId}
             {...(filesSessionId ? { sessionId: filesSessionId } : {})}
             path={viewerPath}
@@ -4406,14 +4424,15 @@ export default function SessionDetailView() {
           />
         </DockPanel>
         <DockPanel active={dockTabKey === 'files'}>
-          {filesAgentId ? (
+          {/* Withheld until the scope is known, so no listing is ever issued against a checkout we only assumed. */}
+          {filesAgentId && filesScopeReady ? (
             <FilesPanel
               agentId={filesAgentId}
               {...(filesSessionId ? { sessionId: filesSessionId } : {})}
               {...(filesWorkdir ? { workdir: filesWorkdir } : {})}
               refreshTick={filesRefreshTick}
               openFilePath={viewerPath}
-              onOpenFile={(path) => setViewerFile(path)}
+              onOpenFile={(path) => setViewerFile(path, filesAgentId)}
               onRootSettledChange={setFilesRootSettled}
             />
           ) : null}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -8,7 +8,7 @@ import { selfConversationPath } from '@/lib/conversation-addressing'
 import { assembleConversationLineage, type ConversationLineage } from '@/lib/conversation-lineage'
 import { encodeConversationKey } from '@/lib/conversation-key'
 import { unverifiedConversationNotice } from '@/lib/session-access-notifications'
-import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import {
   agentLabel,
@@ -98,8 +98,10 @@ import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
 import { SessionAgentFocusMenu, type SessionAgentFocusOption } from '@/components/console/SessionAgentFocusMenu'
 import { useCrumbSlot } from '@/components/console/Shell'
-import { SessionDock, SessionDockSlot, type DockTab } from '@/components/console/dock/SessionDock'
+import { DockPanel, SessionDock, SessionDockSlot, type DockTab } from '@/components/console/dock/SessionDock'
 import { SessionsPanel, sessionsTabStatus } from '@/components/console/dock/SessionsPanel'
+import { FilesPanel, filesTabStatus } from '@/components/console/dock/FilesPanel'
+import { SessionViewer } from '@/components/console/viewer/SessionViewer'
 import {
   EMPTY_RAIL_AGENT_FILTER,
   railAgentFilterQuery,
@@ -1172,8 +1174,11 @@ function MobileSessionFamilyLinks({
   )
 }
 
-/** The dock's tabs. Files / Git / PR / Tasks are each one more entry (§9), not a stub; Sessions' §1 `plus` action awaits a new-session flow. */
-const DOCK_TABS: DockTab[] = [{ key: 'sessions', label: 'Sessions', icon: 'messages-square' }]
+/** The dock's tabs. Git / PR / Tasks are each one more entry (§9), not a stub; Sessions' §1 `plus` action awaits a new-session flow. */
+const DOCK_TABS: DockTab[] = [
+  { key: 'sessions', label: 'Sessions', icon: 'messages-square' },
+  { key: 'files', label: 'Files', icon: 'folder-tree', actionIcon: 'refresh-cw', actionLabel: 'Refresh files' }
+]
 
 /** Loading keeps the same dock + body tracks as the transcript; a resolved 404 opts out, so its card gets the whole content wrap. */
 function SessionDetailFrame({ children, withDock = true }: { children: ReactNode; withDock?: boolean }) {
@@ -1216,9 +1221,24 @@ export default function SessionDetailView() {
   const acpRegistry = useAcpRegistry()
   const { activeOrg, orgPath } = useOrgs()
   const router = useRouter()
+  const pathname = usePathname()
   const searchParams = useSearchParams()
   const flatView = isFlatSessionView(searchParams)
   const { id: routeId, key: conversationKeyParam } = useParams<{ id?: string; key?: string }>()
+  // Which file the viewer holds, and the ONLY place that answer lives (§4): "look at this file" is a link a reviewer sends, so the pane mode is addressable and survives a reload. Derived from the route rather than mirrored into state — that is also what makes it per-session for free, since a session link carries no `file`.
+  const viewerParam = searchParams.get('file')?.trim()
+  const viewerPath = viewerParam ? viewerParam : null
+  // REPLACE, never push. The viewer is a pane mode inside one route, not a place: pushing would spend a history entry per tree click, so a reader who read six files would need seven Back presses to leave the session, and Back would stop meaning "leave this session". The cost, accepted: Back does not step file-by-file within a visit. Writing through URLSearchParams is also what makes a path with slashes and spaces round-trip — `router.replace` on `.toString()`, `searchParams.get` back.
+  const setViewerFile = useCallback(
+    (next: string | null) => {
+      const query = new URLSearchParams(searchParams)
+      if (next) query.set('file', next)
+      else query.delete('file')
+      const search = query.toString()
+      router.replace(search ? `${pathname}?${search}` : pathname, { scroll: false })
+    },
+    [pathname, router, searchParams]
+  )
   // Merged conversation mode (merged-conversation-view.md §5.3): /conversations/:key
   // resolves the roster through the bounded key-addressed resolver; the
   // REPRESENTATIVE (newest visible member) then drives every session-scoped
@@ -1727,6 +1747,8 @@ export default function SessionDetailView() {
         : { scope: headerFocusScope, agentId: defaultHeaderFocusAgentId }
     )
   }, [defaultHeaderFocusAgentId, headerFocusOptionIds, headerFocusScope])
+  // Whose checkout the Files tab and the viewer read: the agent the header is focused on. Empty on a session with no agent at all, and then there is no workspace to offer a tab for.
+  const filesAgentId = headerFocusAgentId || null
   const headerFocusOption = headerFocusOptions.find((option) => option.agentId === headerFocusAgentId)
   const headerFocusSessionId = headerFocusOption?.sessionId
   const extraHeaderDetailId =
@@ -1788,8 +1810,12 @@ export default function SessionDetailView() {
     total: seededRailTotal,
     isLoading: seededRailLoading
   } = useSessionList(MOCK_MODE || !railQuery ? null : activeOrg?.id, railQuery ?? {}, { grouped: !flatView })
-  // Which panel is on screen. One tab in M0, so it never changes; state because a second tab makes it change.
+  // Which panel is on screen. Sessions is where a session page opens; every other tab is one the reader asked for.
   const [dockTab, setDockTab] = useState(DOCK_TABS[0]!.key)
+  // The Files tab's `refresh-cw` action: re-reads the tree and the git status without remounting the panel, so the reader's filter and expanded folders survive it.
+  const [filesRefreshTick, setFilesRefreshTick] = useState(0)
+  // Reported by the panel, like the Sessions verdict: only it knows whether its first root listing has answered.
+  const [filesRootSettled, setFilesRootSettled] = useState(false)
   // A seed narrowed to the conversation already on screen hides the list AND the picker that could widen it, so re-ask it unfiltered.
   const railSeedKeyNow = railSeedKey(railFilter)
   // Waited on because an in-flight family reads as EMPTY, not `undefined`: latching there widens a list about to grow a Related tree.
@@ -1811,10 +1837,21 @@ export default function SessionDetailView() {
   )
   // What tells "the list is still coming" from "there is no list": the dock withholds its chrome and holds its track for either, and the two only differ in the placeholder a sibling-tab-ready dock shows.
   const sessionsStatus = sessionsTabStatus(sessionsWouldHide, !seededRailLoading && railFamilySettled)
+  const filesStatus = filesTabStatus(filesRootSettled)
+  // Each tab's own verdict, spliced onto the static descriptors. Files is dropped outright rather than left `loading` forever when there is no agent behind it — a tab that can never answer is not a tab.
   const dockTabs = useMemo<DockTab[]>(
-    () => DOCK_TABS.map((tab) => (tab.key === 'sessions' ? { ...tab, status: sessionsStatus } : tab)),
-    [sessionsStatus]
+    () =>
+      DOCK_TABS.filter((tab) => tab.key !== 'files' || filesAgentId !== null).map((tab) =>
+        tab.key === 'sessions'
+          ? { ...tab, status: sessionsStatus }
+          : tab.key === 'files'
+            ? { ...tab, status: filesStatus }
+            : tab
+      ),
+    [filesAgentId, filesStatus, sessionsStatus]
   )
+  // The active tab has to be one that exists: a Files tab dropped under the reader would otherwise leave the dock with no active tab and an unlabelled panel.
+  const dockTabKey = dockTabs.some((tab) => tab.key === dockTab) ? dockTab : DOCK_TABS[0]!.key
   const railSeedWidened = !MOCK_MODE && railSeedKeyNow !== '' && widenedSeed === railSeedKeyNow
   const { sessions: widenedRailRows, total: widenedRailTotal } = useSessionList(
     railSeedWidened ? activeOrg?.id : null,
@@ -2496,6 +2533,11 @@ export default function SessionDetailView() {
   const workspaceTitle = hasSessionWorktree
     ? `Open ${focusedAgentLabel}’s session worktree`
     : `Open ${focusedAgentLabel}’s workspace`
+  // Scoped to this session's OWN worktree only where it has one. `hasSessionWorktree` is the same gate the Workspace link above uses, and it is load-bearing for the reads: the daemon answers a shared workspace's sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline".
+  const filesSessionId = hasSessionWorktree && headerFocusSessionId ? headerFocusSessionId : undefined
+  const filesWorkdir = focusedAgent && focusedAgent.workdir !== '—' ? focusedAgent.workdir : undefined
+  // A `?file=` on a session with no agent to read it from has nothing to open, so the conversation stays: the viewer never renders without a checkout behind it.
+  const viewerOpen = viewerPath !== null && filesAgentId !== null
   const liveSteps = isWebchat ? getLiveSteps(session.id) : []
 
   // The conversation roster, for EVERY live surface — the synthetic playground and
@@ -3257,7 +3299,14 @@ export default function SessionDetailView() {
           `.content`'s bottom inset (see its negative `bottom`), so any padding
           BELOW it becomes a strip the composer can never reach — it stops short
           of the screen edge at the end of the scroll. */}
-      <div className="mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col">
+      {/* The viewer is full-width in every band (§7) — a file wants the columns a transcript does not. The 880px cap is the only geometry that changes: the dock's reserved TRACK keeps its column either way, which is the one thing §7 forbids trading. */}
+      <div
+        className={
+          viewerOpen
+            ? 'flex min-h-full min-w-0 flex-1 flex-col'
+            : 'mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col'
+        }
+      >
         {/* DESKTOP TITLE ROW — the session name + its status badge. These used to live
           in the top-bar crumb; with the crumb gone the page has to name itself. The
           mobile title/status live in Shell's app bar, so this region is desktop-only. */}
@@ -3514,817 +3563,861 @@ export default function SessionDetailView() {
 
         {!isLive && approvalCard('mx-4 mt-4 max-desktop:rounded-lg desktop:mx-0 desktop:mt-0 desktop:mb-4')}
 
-        {wantTranscript && visibleMsgLoading && (
-          <div className="flex justify-center py-10">
-            <Spinner size={30} />
-          </div>
-        )}
-        {conversationOffline > 0 && (
-          <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
-            <Icon name="triangle-alert" size={15} color="var(--amber-500)" />
-            <span>
-              Some participants&apos; records are on an offline daemon — this view may be missing part of the
-              conversation until it reconnects.
-            </span>
-          </div>
-        )}
-        {wantTranscript && visibleMsgErr && !transcriptPurged && (
-          <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
-            <Icon name="triangle-alert" size={15} color="var(--amber-500)" />
-            <span>
-              Couldn&apos;t load the transcript — the owning daemon may be offline. Session history is pulled live from
-              the daemon, so it&apos;s unavailable while that machine is disconnected.
-            </span>
-          </div>
-        )}
-        {transcriptPurged && (
-          <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
-            <Icon name="trash-2" size={15} color="var(--text-tertiary)" />
-            <span>
-              This transcript was deleted on {fmtDate(purgedAt)} by the session retention policy, together with any
-              workspace created just for it. The details on this page are all that remain.
-            </span>
-          </div>
-        )}
-        {transcriptPartiallyPurged && (
-          <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
-            <Icon name="trash-2" size={15} color="var(--text-tertiary)" />
-            <span>
-              Part of this history is missing:{' '}
-              {memberCount > 1
-                ? `${purgedMemberCount} of ${memberCount} participants had their transcript deleted`
-                : 'this transcript was deleted'}{' '}
-              on {fmtDate(purgedAt)} by the session retention policy. What you see below is the remaining record.
-            </span>
-          </div>
-        )}
-        {transcriptEmpty && !transcriptPurged && (
-          <div className="card m-4 flex flex-col items-center gap-[6px] px-6 py-[34px] text-center desktop:m-0">
-            <Icon name="message-square-dashed" size={20} color="var(--text-tertiary)" />
-            <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-              No messages in this session yet.
-            </div>
-          </div>
-        )}
+        {viewerOpen && viewerPath && filesAgentId ? (
+          // Keyed on the path: the viewer resets its slice in a passive effect, which runs AFTER paint, so without a fresh mount one committed frame draws the previous file's bytes — and its line count and size — under the new file's name. Same hazard `transcriptMatchesSession` guards for the transcript; nothing inside the viewer is worth carrying across files.
+          <SessionViewer
+            key={viewerPath}
+            agentId={filesAgentId}
+            {...(filesSessionId ? { sessionId: filesSessionId } : {})}
+            path={viewerPath}
+            onClose={() => setViewerFile(null)}
+          />
+        ) : null}
 
-        {conversationKey && conversationHasEarlier && (
-          <div className="flex items-center justify-center pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
-            <button
-              className="lnk text-[12px]"
-              onClick={() => void loadEarlierConversation()}
-              disabled={conversationPagingEarlier}
-            >
-              {conversationPagingEarlier ? 'Loading earlier activity…' : 'Load earlier activity'}
-            </button>
-          </div>
-        )}
-        {visibleMsgPaging && (
-          <div className="flex items-center justify-center gap-2 pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
-            <Spinner size={14} />
-            Loading earlier activity…
-          </div>
-        )}
-        {/* TRANSCRIPT — one shared tree. Mobile adds the 16px gutter column around
+        {/* CONVERSATION MODE, concealed rather than unmounted. Everything below belongs to the transcript and the composer, and all of it is state a session round trip must not spend: every expanded tool body and its refetch, the composer's caret and any open @mention menu (with the `mentionJoining` latch it reports upward, which has no owner left to clear it once the composer is gone), and the approval cards' poll. `contents` keeps the flex layout it has today exactly — an active box here would be a second flex item in the column.
+          The cost, accepted: a pending webchat MCP write approval is concealed with the composer and has no header twin the way permission requests do (those stay in the Requests popover). A reader who opened a file sees the agent stall until they come back. */}
+        <div data-conversation-pane="" className={viewerOpen ? 'hidden' : 'contents'}>
+          {wantTranscript && visibleMsgLoading && (
+            <div className="flex justify-center py-10">
+              <Spinner size={30} />
+            </div>
+          )}
+          {conversationOffline > 0 && (
+            <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
+              <Icon name="triangle-alert" size={15} color="var(--amber-500)" />
+              <span>
+                Some participants&apos; records are on an offline daemon — this view may be missing part of the
+                conversation until it reconnects.
+              </span>
+            </div>
+          )}
+          {wantTranscript && visibleMsgErr && !transcriptPurged && (
+            <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
+              <Icon name="triangle-alert" size={15} color="var(--amber-500)" />
+              <span>
+                Couldn&apos;t load the transcript — the owning daemon may be offline. Session history is pulled live
+                from the daemon, so it&apos;s unavailable while that machine is disconnected.
+              </span>
+            </div>
+          )}
+          {transcriptPurged && (
+            <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
+              <Icon name="trash-2" size={15} color="var(--text-tertiary)" />
+              <span>
+                This transcript was deleted on {fmtDate(purgedAt)} by the session retention policy, together with any
+                workspace created just for it. The details on this page are all that remain.
+              </span>
+            </div>
+          )}
+          {transcriptPartiallyPurged && (
+            <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
+              <Icon name="trash-2" size={15} color="var(--text-tertiary)" />
+              <span>
+                Part of this history is missing:{' '}
+                {memberCount > 1
+                  ? `${purgedMemberCount} of ${memberCount} participants had their transcript deleted`
+                  : 'this transcript was deleted'}{' '}
+                on {fmtDate(purgedAt)} by the session retention policy. What you see below is the remaining record.
+              </span>
+            </div>
+          )}
+          {transcriptEmpty && !transcriptPurged && (
+            <div className="card m-4 flex flex-col items-center gap-[6px] px-6 py-[34px] text-center desktop:m-0">
+              <Icon name="message-square-dashed" size={20} color="var(--text-tertiary)" />
+              <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+                No messages in this session yet.
+              </div>
+            </div>
+          )}
+
+          {conversationKey && conversationHasEarlier && (
+            <div className="flex items-center justify-center pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
+              <button
+                className="lnk text-[12px]"
+                onClick={() => void loadEarlierConversation()}
+                disabled={conversationPagingEarlier}
+              >
+                {conversationPagingEarlier ? 'Loading earlier activity…' : 'Load earlier activity'}
+              </button>
+            </div>
+          )}
+          {visibleMsgPaging && (
+            <div className="flex items-center justify-center gap-2 pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
+              <Spinner size={14} />
+              Loading earlier activity…
+            </div>
+          )}
+          {/* TRANSCRIPT — one shared tree. Mobile adds the 16px gutter column around
           turns + live tail. The column grows to fill the page (flex-1 inside the
           min-h-full wrap) so the flex-1 spacer below can pin the composer to the
           bottom even when the transcript is short. */}
-        {/* `max-desktop:pb-0` for the same reason as the wrap above: this column's
+          {/* `max-desktop:pb-0` for the same reason as the wrap above: this column's
           last child is the sticky composer, and a bottom gutter under it is a strip
           the composer stops short of. (Longhand `pb-*` always sorts after shorthand
           `p-*`, so the cancel wins — STYLE.md §8.) */}
-        <div className="flex flex-1 flex-col gap-4 p-4 max-desktop:pb-0 desktop:gap-0 desktop:p-0">
-          {turns.length > 0 && (
-            <div className="flex flex-col gap-4 desktop:gap-[15px]">
-              {turns.map((turn, ti) => (
-                // The turn's clock time is its own centred line above the message —
-                // a shared separator for both sides, instead of a label-row tail
-                // that never lines up with the bubble edge on either side.
-                <div key={`${session.id}:${ti}`} className="flex flex-col gap-[5px]">
-                  {turn.time && (
-                    <div className="mono text-center text-[11px] leading-normal text-(--text-tertiary)">
-                      {turn.time}
-                    </div>
-                  )}
-                  {turn.kind === 'user' ? (
-                    // 2b: user turns are right-aligned brand-soft bubbles. A sender label
-                    // sits above the bubble only when it isn't you (platform user / cron).
-                    <div key={`${session.id}:${ti}`} className="group/turn flex items-start justify-end gap-[9px]">
-                      <div className="relative flex min-w-0 max-w-[86%] flex-col items-end gap-[3px]">
-                        {showsSenderLabel(turn) && (
-                          <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
-                            {turn.isCron && turn.cronId ? (
-                              <Link className="lnk text-inherit" href={orgPath(`/crons/${turn.cronId}`)}>
-                                {turn.sp.name}
-                              </Link>
-                            ) : (
-                              <span>{turn.sp.name}</span>
-                            )}
-                          </span>
-                        )}
-                        <div className={SELF_BUBBLE}>
-                          {turn.image && (
-                            <img
-                              src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
-                              alt={turn.image.name}
-                              className={`max-h-[360px] max-w-full rounded-md object-contain ${turn.text ? 'mb-[10px]' : ''}`}
-                            />
+          <div className="flex flex-1 flex-col gap-4 p-4 max-desktop:pb-0 desktop:gap-0 desktop:p-0">
+            {turns.length > 0 && (
+              <div className="flex flex-col gap-4 desktop:gap-[15px]">
+                {turns.map((turn, ti) => (
+                  // The turn's clock time is its own centred line above the message —
+                  // a shared separator for both sides, instead of a label-row tail
+                  // that never lines up with the bubble edge on either side.
+                  <div key={`${session.id}:${ti}`} className="flex flex-col gap-[5px]">
+                    {turn.time && (
+                      <div className="mono text-center text-[11px] leading-normal text-(--text-tertiary)">
+                        {turn.time}
+                      </div>
+                    )}
+                    {turn.kind === 'user' ? (
+                      // 2b: user turns are right-aligned brand-soft bubbles. A sender label
+                      // sits above the bubble only when it isn't you (platform user / cron).
+                      <div key={`${session.id}:${ti}`} className="group/turn flex items-start justify-end gap-[9px]">
+                        <div className="relative flex min-w-0 max-w-[86%] flex-col items-end gap-[3px]">
+                          {showsSenderLabel(turn) && (
+                            <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
+                              {turn.isCron && turn.cronId ? (
+                                <Link className="lnk text-inherit" href={orgPath(`/crons/${turn.cronId}`)}>
+                                  {turn.sp.name}
+                                </Link>
+                              ) : (
+                                <span>{turn.sp.name}</span>
+                              )}
+                            </span>
                           )}
-                          {turn.text && <MessageText text={turn.text} platform={turn.platform} />}
-                        </div>
-                        {/* Sent bubbles are complete by definition — the copy affordance
+                          <div className={SELF_BUBBLE}>
+                            {turn.image && (
+                              <img
+                                src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
+                                alt={turn.image.name}
+                                className={`max-h-[360px] max-w-full rounded-md object-contain ${turn.text ? 'mb-[10px]' : ''}`}
+                              />
+                            )}
+                            {turn.text && <MessageText text={turn.text} platform={turn.platform} />}
+                          </div>
+                          {/* Sent bubbles are complete by definition — the copy affordance
                         (hover-revealed, right-aligned under the bubble) always mounts.
                         Absolutely positioned into the inter-turn gap so revealing it
                         never changes the row's height. */}
-                        {turn.text && (
-                          <span className="absolute right-0 top-full">
-                            <CopyTurnButton text={turn.text} />
-                          </span>
-                        )}
+                          {turn.text && (
+                            <span className="absolute right-0 top-full">
+                              <CopyTurnButton text={turn.text} />
+                            </span>
+                          )}
+                        </div>
+                        <ParticipantAvatar
+                          agent={turn.agent}
+                          avatarUrl={turn.avatarUrl}
+                          avatarInitials={turn.avatarInitials}
+                          platformMark={usesIntegrationAvatar ? sessionIntegration : undefined}
+                          sp={turn.sp}
+                          isCron={turn.isCron}
+                          // Optically centre the 26px mark on the bubble's FIRST LINE, not
+                          // on the bubble's top edge: 9px of padding plus half of a 21px
+                          // line puts that centre 19.5px down, while a top-aligned mark
+                          // centres at 13px — the 6px it looked too high by. A labelled row
+                          // keeps the mark level with its label instead, like the bot side.
+                          className={showsSenderLabel(turn) ? '' : 'mt-[6px]'}
+                        />
                       </div>
-                      <ParticipantAvatar
-                        agent={turn.agent}
-                        avatarUrl={turn.avatarUrl}
-                        avatarInitials={turn.avatarInitials}
-                        platformMark={usesIntegrationAvatar ? sessionIntegration : undefined}
-                        sp={turn.sp}
-                        isCron={turn.isCron}
-                        // Optically centre the 26px mark on the bubble's FIRST LINE, not
-                        // on the bubble's top edge: 9px of padding plus half of a 21px
-                        // line puts that centre 19.5px down, while a top-aligned mark
-                        // centres at 13px — the 6px it looked too high by. A labelled row
-                        // keeps the mark level with its label instead, like the bot side.
-                        className={showsSenderLabel(turn) ? '' : 'mt-[6px]'}
-                      />
-                    </div>
-                  ) : (
-                    (() => {
-                      // 2b: the spoken answer (MSG/DONE) is plain text; the agent's work
-                      // (reasoning / plan / tool / edit) collapses behind a per-turn toggle.
-                      const textSteps = turn.steps.filter((s) => !WORK_LANES.has(s.lane))
-                      const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
-                      // Reasoning steps / tool commands / edited FILES (distinct paths across
-                      // EDIT rows, since one EDIT row can touch several files).
-                      const { thinkCount, toolCount, editCount } = workCounts(workSteps)
-                      const summary = workSummary(thinkCount, toolCount, editCount)
-                      // Is this turn still streaming? A multi-agent live webchat runs
-                      // several reply lanes at once, so a TAGGED turn asks its own lane
-                      // (an earlier still-active participant must not show the copy
-                      // affordance or lose its live line just because a later turn renders
-                      // below it). Lane-less/single-agent streams keep the trailing-turn
-                      // fallback. statusLabel carries the RAW session state — the
-                      // active-turn predicate lives (and is tested) in session-work.ts.
-                      const turnInFlight = sessionTurnInFlight(pgBusy, session.statusLabel)
-                      const busyLanes = turnInFlight ? getBusyLaneAgentIds(session.id) : []
-                      // The lane only says WHICH AGENT is busy — restrict the match to that
-                      // agent's LAST turn so its finished history stays non-streaming.
-                      const streaming =
-                        turnInFlight &&
-                        (turn.agentId && busyLanes.length > 0
-                          ? busyLanes.includes(turn.agentId) && lastBotTurnIndexByAgent.get(turn.agentId) === ti
-                          : ti === turns.length - 1)
-                      const openWork = workPanelOpen(workOverride.get(ti))
-                      // Is the WORK itself still running? `streaming` alone is turn-level —
-                      // it stays true while the spoken answer streams AFTER the last tool
-                      // finished, which must not keep the live line alive. ACP tool calls
-                      // can also run in PARALLEL, each update replacing its original row
-                      // in place (keyed by toolCallId) — so "the newest row is finished"
-                      // does not mean the work is: any non-terminal tool row keeps the
-                      // work running, and the LATEST such row is what the toggle line
-                      // reports. With no active tool, a trailing unfinished work step
-                      // still counts (THINK rows carry no status and run until
-                      // superseded); a trailing text step means the agent moved on to its
-                      // answer.
-                      const stepDone = (st?: FmtStep) =>
-                        ['completed', 'failed'].includes((st?.msg?.toolStatus ?? '').toLowerCase())
-                      const activeTool = [...workSteps].reverse().find((st) => st.msg?.toolCallId && !stepDone(st))
-                      const lastStep = turn.steps[turn.steps.length - 1]
-                      const tailRunning = !!lastStep && WORK_LANES.has(lastStep.lane) && !stepDone(lastStep)
-                      const liveStep = activeTool ?? (tailRunning ? lastStep : undefined)
-                      const workRunning = streaming && liveStep !== undefined
-                      // While work runs, the toggle line also carries what is running RIGHT
-                      // NOW — the live step's first line (tool rows keep the command in
-                      // `code`) — so a collapsed panel still shows live progress.
-                      const liveLine =
-                        workRunning && liveStep
-                          ? (liveStep.text || liveStep.code)?.split('\n', 1)[0]?.trim()
-                          : undefined
-                      // Step identity for the fade-in key: two consecutive steps can show
-                      // the SAME first line, and a keyed-by-text span would keep its DOM
-                      // node and never replay the animation.
-                      const liveKey =
-                        liveStep && liveLine
-                          ? `${liveStep.msg?.toolCallId ?? turn.steps.indexOf(liveStep)}:${liveLine}`
-                          : undefined
-                      // Keyed by agent id where there is one so the colour survives a
-                      // rename; a mock/playground row without an id falls back to the
-                      // display name, which is stable for as long as the row is.
-                      const turnTone = agentToneColor(turn.agentId || turn.agentName)
-                      // What the bubble-level copy button copies: the spoken answer.
-                      const answerText = textSteps
-                        .map((st) => st.text)
-                        .filter(Boolean)
-                        .join('\n\n')
-                      return (
-                        <div key={`${session.id}:${ti}`} className="group/turn flex items-start gap-[10px]">
-                          <span className="av h-[26px] w-[26px] flex-none rounded-md">
-                            <AgentIconView
-                              icon={((turn.agentId ? agentById.get(turn.agentId) : owner) ?? owner)?.icon}
-                              runtime={
-                                (turn.agentId ? agentById.get(turn.agentId)?.runtime : undefined) ??
-                                (agentRuntime || turn.model)
-                              }
-                              size={26}
-                            />
-                          </span>
-                          <div className="min-w-0 flex-1" style={{ '--agent-accent': turnTone } as CSSProperties}>
-                            <div className="mb-[5px] flex items-center gap-[7px]">
-                              <span className={AGENT_NAME}>{turn.agentName}</span>
-                            </div>
-                            {/* One bubble PER text step, not one around the set: each step is
+                    ) : (
+                      (() => {
+                        // 2b: the spoken answer (MSG/DONE) is plain text; the agent's work
+                        // (reasoning / plan / tool / edit) collapses behind a per-turn toggle.
+                        const textSteps = turn.steps.filter((s) => !WORK_LANES.has(s.lane))
+                        const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
+                        // Reasoning steps / tool commands / edited FILES (distinct paths across
+                        // EDIT rows, since one EDIT row can touch several files).
+                        const { thinkCount, toolCount, editCount } = workCounts(workSteps)
+                        const summary = workSummary(thinkCount, toolCount, editCount)
+                        // Is this turn still streaming? A multi-agent live webchat runs
+                        // several reply lanes at once, so a TAGGED turn asks its own lane
+                        // (an earlier still-active participant must not show the copy
+                        // affordance or lose its live line just because a later turn renders
+                        // below it). Lane-less/single-agent streams keep the trailing-turn
+                        // fallback. statusLabel carries the RAW session state — the
+                        // active-turn predicate lives (and is tested) in session-work.ts.
+                        const turnInFlight = sessionTurnInFlight(pgBusy, session.statusLabel)
+                        const busyLanes = turnInFlight ? getBusyLaneAgentIds(session.id) : []
+                        // The lane only says WHICH AGENT is busy — restrict the match to that
+                        // agent's LAST turn so its finished history stays non-streaming.
+                        const streaming =
+                          turnInFlight &&
+                          (turn.agentId && busyLanes.length > 0
+                            ? busyLanes.includes(turn.agentId) && lastBotTurnIndexByAgent.get(turn.agentId) === ti
+                            : ti === turns.length - 1)
+                        const openWork = workPanelOpen(workOverride.get(ti))
+                        // Is the WORK itself still running? `streaming` alone is turn-level —
+                        // it stays true while the spoken answer streams AFTER the last tool
+                        // finished, which must not keep the live line alive. ACP tool calls
+                        // can also run in PARALLEL, each update replacing its original row
+                        // in place (keyed by toolCallId) — so "the newest row is finished"
+                        // does not mean the work is: any non-terminal tool row keeps the
+                        // work running, and the LATEST such row is what the toggle line
+                        // reports. With no active tool, a trailing unfinished work step
+                        // still counts (THINK rows carry no status and run until
+                        // superseded); a trailing text step means the agent moved on to its
+                        // answer.
+                        const stepDone = (st?: FmtStep) =>
+                          ['completed', 'failed'].includes((st?.msg?.toolStatus ?? '').toLowerCase())
+                        const activeTool = [...workSteps].reverse().find((st) => st.msg?.toolCallId && !stepDone(st))
+                        const lastStep = turn.steps[turn.steps.length - 1]
+                        const tailRunning = !!lastStep && WORK_LANES.has(lastStep.lane) && !stepDone(lastStep)
+                        const liveStep = activeTool ?? (tailRunning ? lastStep : undefined)
+                        const workRunning = streaming && liveStep !== undefined
+                        // While work runs, the toggle line also carries what is running RIGHT
+                        // NOW — the live step's first line (tool rows keep the command in
+                        // `code`) — so a collapsed panel still shows live progress.
+                        const liveLine =
+                          workRunning && liveStep
+                            ? (liveStep.text || liveStep.code)?.split('\n', 1)[0]?.trim()
+                            : undefined
+                        // Step identity for the fade-in key: two consecutive steps can show
+                        // the SAME first line, and a keyed-by-text span would keep its DOM
+                        // node and never replay the animation.
+                        const liveKey =
+                          liveStep && liveLine
+                            ? `${liveStep.msg?.toolCallId ?? turn.steps.indexOf(liveStep)}:${liveLine}`
+                            : undefined
+                        // Keyed by agent id where there is one so the colour survives a
+                        // rename; a mock/playground row without an id falls back to the
+                        // display name, which is stable for as long as the row is.
+                        const turnTone = agentToneColor(turn.agentId || turn.agentName)
+                        // What the bubble-level copy button copies: the spoken answer.
+                        const answerText = textSteps
+                          .map((st) => st.text)
+                          .filter(Boolean)
+                          .join('\n\n')
+                        return (
+                          <div key={`${session.id}:${ti}`} className="group/turn flex items-start gap-[10px]">
+                            <span className="av h-[26px] w-[26px] flex-none rounded-md">
+                              <AgentIconView
+                                icon={((turn.agentId ? agentById.get(turn.agentId) : owner) ?? owner)?.icon}
+                                runtime={
+                                  (turn.agentId ? agentById.get(turn.agentId)?.runtime : undefined) ??
+                                  (agentRuntime || turn.model)
+                                }
+                                size={26}
+                              />
+                            </span>
+                            <div className="min-w-0 flex-1" style={{ '--agent-accent': turnTone } as CSSProperties}>
+                              <div className="mb-[5px] flex items-center gap-[7px]">
+                                <span className={AGENT_NAME}>{turn.agentName}</span>
+                              </div>
+                              {/* One bubble PER text step, not one around the set: each step is
                             its own delivered message (a turn that answers in two chunks
                             arrives as two), so bubbling them together would merge messages
                             the platform kept apart. `w-fit` keeps a short reply from
                             drawing a full-width card. */}
-                            {textSteps.map((st, si) => (
-                              <div key={si} className={`${AGENT_BUBBLE} ${si > 0 ? 'mt-2' : ''}`}>
-                                {st.image && (
-                                  <img
-                                    src={`data:${st.image.mimeType};base64,${st.image.data}`}
-                                    alt={st.image.name}
-                                    className={`max-h-[360px] max-w-full rounded-md object-contain ${st.text ? 'mb-[10px]' : ''}`}
-                                  />
-                                )}
-                                {st.text && (
-                                  <div className="whitespace-pre-wrap">
-                                    <MessageText text={st.text} platform={st.platform} />
-                                  </div>
-                                )}
-                                <StepExtras step={st} sessionId={toolSid} />
-                              </div>
-                            ))}
-                            {workSteps.length > 0 && (
-                              <>
-                                {/* One row: the work toggle, with the bubble's copy button at
-                                the line's end — mounted only once the turn has finished. */}
-                                <div className="mt-2 flex min-w-0 items-center gap-[6px]">
-                                  <button
-                                    type="button"
-                                    onClick={() => toggleWork(ti, openWork)}
-                                    className="inline-flex min-w-0 items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
-                                    title={openWork ? 'Hide the agent’s work' : 'Show the agent’s work'}
-                                  >
-                                    <Icon
-                                      name={openWork ? 'chevron-down' : 'chevron-right'}
-                                      size={13}
-                                      color="var(--text-tertiary)"
+                              {textSteps.map((st, si) => (
+                                <div key={si} className={`${AGENT_BUBBLE} ${si > 0 ? 'mt-2' : ''}`}>
+                                  {st.image && (
+                                    <img
+                                      src={`data:${st.image.mimeType};base64,${st.image.data}`}
+                                      alt={st.image.name}
+                                      className={`max-h-[360px] max-w-full rounded-md object-contain ${st.text ? 'mb-[10px]' : ''}`}
                                     />
-                                    <span className="flex-none">{summary || 'Details'}</span>
-                                    {liveLine && (
-                                      // Keyed by step identity + content: a new step (or a new
-                                      // first line within one) remounts the span, replaying the
-                                      // ac-rise fade-in (honors reduced-motion in globals.css).
-                                      <span key={liveKey} className="ac-rise min-w-0 truncate">
-                                        · {liveLine}
-                                      </span>
-                                    )}
-                                  </button>
-                                  {!streaming && answerText && <CopyTurnButton text={answerText} />}
+                                  )}
+                                  {st.text && (
+                                    <div className="whitespace-pre-wrap">
+                                      <MessageText text={st.text} platform={st.platform} />
+                                    </div>
+                                  )}
+                                  <StepExtras step={st} sessionId={toolSid} />
                                 </div>
-                                {openWork && (
-                                  <div className="mt-2 overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
-                                    {/* All work steps show, streaming or not — a live turn's
+                              ))}
+                              {workSteps.length > 0 && (
+                                <>
+                                  {/* One row: the work toggle, with the bubble's copy button at
+                                the line's end — mounted only once the turn has finished. */}
+                                  <div className="mt-2 flex min-w-0 items-center gap-[6px]">
+                                    <button
+                                      type="button"
+                                      onClick={() => toggleWork(ti, openWork)}
+                                      className="inline-flex min-w-0 items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
+                                      title={openWork ? 'Hide the agent’s work' : 'Show the agent’s work'}
+                                    >
+                                      <Icon
+                                        name={openWork ? 'chevron-down' : 'chevron-right'}
+                                        size={13}
+                                        color="var(--text-tertiary)"
+                                      />
+                                      <span className="flex-none">{summary || 'Details'}</span>
+                                      {liveLine && (
+                                        // Keyed by step identity + content: a new step (or a new
+                                        // first line within one) remounts the span, replaying the
+                                        // ac-rise fade-in (honors reduced-motion in globals.css).
+                                        <span key={liveKey} className="ac-rise min-w-0 truncate">
+                                          · {liveLine}
+                                        </span>
+                                      )}
+                                    </button>
+                                    {!streaming && answerText && <CopyTurnButton text={answerText} />}
+                                  </div>
+                                  {openWork && (
+                                    <div className="mt-2 overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
+                                      {/* All work steps show, streaming or not — a live turn's
                                     panel grows as steps arrive so the whole run is visible. */}
-                                    {workSteps.map((st, si) => (
-                                      <div
-                                        // Keyed by tool identity where there is one, so an
-                                        // expanded ToolBodyDetail survives re-renders as new
-                                        // steps stream in. Steps without a tool id (THINK
-                                        // rows) fall back to the index; within one agent's
-                                        // turn a toolCallId appears once.
-                                        key={st.msg?.toolCallId ?? `i:${si}`}
-                                        className={`flex items-start gap-[11px] px-[14px] py-[10px] ${
-                                          si > 0 ? 'border-t border-(--border-subtle)' : ''
-                                        }`}
-                                      >
-                                        {/* min-h matches the text column's FIRST LINE box
+                                      {workSteps.map((st, si) => (
+                                        <div
+                                          // Keyed by tool identity where there is one, so an
+                                          // expanded ToolBodyDetail survives re-renders as new
+                                          // steps stream in. Steps without a tool id (THINK
+                                          // rows) fall back to the index; within one agent's
+                                          // turn a toolCallId appears once.
+                                          key={st.msg?.toolCallId ?? `i:${si}`}
+                                          className={`flex items-start gap-[11px] px-[14px] py-[10px] ${
+                                            si > 0 ? 'border-t border-(--border-subtle)' : ''
+                                          }`}
+                                        >
+                                          {/* min-h matches the text column's FIRST LINE box
                                         (13px × 1.5), so centring inside it puts the dot
                                         and lane label on that line's centre line. The
                                         old `pt-[1px]` guessed at the same thing against
                                         a 15px-tall mono box and read a few px high. */}
-                                        <div className="flex min-h-[20px] w-[52px] flex-none items-center gap-[6px]">
-                                          <span className="dot h-[7px] w-[7px]" style={{ background: st.dot }} />
-                                          <span
-                                            className="mono text-[10px] font-semibold tracking-[.02em]"
-                                            style={{ color: st.laneColor }}
-                                          >
-                                            {st.lane}
-                                          </span>
-                                        </div>
-                                        <div className="min-w-0 flex-1">
-                                          {st.text && (
-                                            <div
-                                              className="font-sans text-[13px] leading-[1.5]"
-                                              style={{ fontWeight: st.weight, color: st.textColor }}
+                                          <div className="flex min-h-[20px] w-[52px] flex-none items-center gap-[6px]">
+                                            <span className="dot h-[7px] w-[7px]" style={{ background: st.dot }} />
+                                            <span
+                                              className="mono text-[10px] font-semibold tracking-[.02em]"
+                                              style={{ color: st.laneColor }}
                                             >
-                                              <MessageText text={st.text} platform={st.platform} />
-                                            </div>
-                                          )}
-                                          <StepExtras step={st} sessionId={toolSid} />
+                                              {st.lane}
+                                            </span>
+                                          </div>
+                                          <div className="min-w-0 flex-1">
+                                            {st.text && (
+                                              <div
+                                                className="font-sans text-[13px] leading-[1.5]"
+                                                style={{ fontWeight: st.weight, color: st.textColor }}
+                                              >
+                                                <MessageText text={st.text} platform={st.platform} />
+                                              </div>
+                                            )}
+                                            <StepExtras step={st} sessionId={toolSid} />
+                                          </div>
                                         </div>
-                                      </div>
-                                    ))}
-                                  </div>
-                                )}
-                              </>
-                            )}
-                            {/* A turn with no work has no toggle row — the finished
+                                      ))}
+                                    </div>
+                                  )}
+                                </>
+                              )}
+                              {/* A turn with no work has no toggle row — the finished
                             bubble's copy button gets its own line instead. */}
-                            {workSteps.length === 0 && !streaming && answerText && (
-                              <div className="mt-2 flex">
-                                <CopyTurnButton text={answerText} />
-                              </div>
-                            )}
+                              {workSteps.length === 0 && !streaming && answerText && (
+                                <div className="mt-2 flex">
+                                  <CopyTurnButton text={answerText} />
+                                </div>
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      )
-                    })()
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
+                        )
+                      })()
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
 
-          {/* LIVE INDICATOR — mobile-only trailing bot avatar + blue-dot note while a
+            {/* LIVE INDICATOR — mobile-only trailing bot avatar + blue-dot note while a
             platform run is live. (A live playground/webchat surface uses the
             typing-dots affordance below instead.) */}
-          {session.status === 'online' && !isLive && (
-            <div className="flex items-center gap-[10px] desktop:hidden">
-              <span className="av h-[30px] w-[30px] flex-none rounded-md">
-                <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={30} />
-              </span>
-              <span className="inline-flex items-center gap-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
-                <span className="h-[6px] w-[6px] rounded-full bg-(--blue-500)" />
-                {session.statusLabel || 'Live'}
-              </span>
-            </div>
-          )}
+            {session.status === 'online' && !isLive && (
+              <div className="flex items-center gap-[10px] desktop:hidden">
+                <span className="av h-[30px] w-[30px] flex-none rounded-md">
+                  <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={30} />
+                </span>
+                <span className="inline-flex items-center gap-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
+                  <span className="h-[6px] w-[6px] rounded-full bg-(--blue-500)" />
+                  {session.statusLabel || 'Live'}
+                </span>
+              </div>
+            )}
 
-          {/* Playground / resumed webchat: typing indicator, starter prompts, composer. */}
-          {isLive && (
-            <>
-              {pgBusy &&
-                (() => {
-                  // Multi-agent conversations attribute the typing indicator to
-                  // the participants whose reply lanes are STILL OPEN — after a
-                  // supersession it is the REGENERATING agent working, not the
-                  // primary. Single-agent (and lane-less adopted) sessions keep
-                  // the owner row.
-                  const busyAgents =
-                    (session.participants?.length ?? 0) > 1
-                      ? getBusyLaneAgentIds(session.id)
-                          .map((agentId) => agentById.get(agentId))
-                          .filter((agent): agent is Agent => agent !== undefined)
-                      : []
-                  const rows = busyAgents.length > 0 ? busyAgents : [owner]
-                  // 26px mark + 10px gap, same geometry as an agent turn's row, so the
-                  // dots start on the same left edge as that agent's bubbles above.
-                  return rows.map((agent, i) => (
-                    <div key={agent?.id ?? i} className="flex items-center gap-[10px] desktop:mt-[14px]">
-                      <span className="av h-[26px] w-[26px] flex-none rounded-md">
-                        <AgentIconView icon={agent?.icon} runtime={agent?.runtime || agentRuntime} size={26} />
-                      </span>
-                      <div className="inline-flex items-center gap-1 rounded-[11px] bg-(--brand-soft) px-[14px] py-[11px]">
-                        <span className="tdot" />
-                        <span className="tdot [animation-delay:.18s]" />
-                        <span className="tdot [animation-delay:.36s]" />
+            {/* Playground / resumed webchat: typing indicator, starter prompts, composer. */}
+            {isLive && (
+              <>
+                {pgBusy &&
+                  (() => {
+                    // Multi-agent conversations attribute the typing indicator to
+                    // the participants whose reply lanes are STILL OPEN — after a
+                    // supersession it is the REGENERATING agent working, not the
+                    // primary. Single-agent (and lane-less adopted) sessions keep
+                    // the owner row.
+                    const busyAgents =
+                      (session.participants?.length ?? 0) > 1
+                        ? getBusyLaneAgentIds(session.id)
+                            .map((agentId) => agentById.get(agentId))
+                            .filter((agent): agent is Agent => agent !== undefined)
+                        : []
+                    const rows = busyAgents.length > 0 ? busyAgents : [owner]
+                    // 26px mark + 10px gap, same geometry as an agent turn's row, so the
+                    // dots start on the same left edge as that agent's bubbles above.
+                    return rows.map((agent, i) => (
+                      <div key={agent?.id ?? i} className="flex items-center gap-[10px] desktop:mt-[14px]">
+                        <span className="av h-[26px] w-[26px] flex-none rounded-md">
+                          <AgentIconView icon={agent?.icon} runtime={agent?.runtime || agentRuntime} size={26} />
+                        </span>
+                        <div className="inline-flex items-center gap-1 rounded-[11px] bg-(--brand-soft) px-[14px] py-[11px]">
+                          <span className="tdot" />
+                          <span className="tdot [animation-delay:.18s]" />
+                          <span className="tdot [animation-delay:.36s]" />
+                        </div>
                       </div>
+                    ))
+                  })()}
+                {pgEmpty && (
+                  <div className="desktop:mt-[6px]">
+                    <div className="mb-2 font-mono text-[10.5px] font-semibold uppercase tracking-[.08em] text-(--text-tertiary)">
+                      Start with
                     </div>
-                  ))
-                })()}
-              {pgEmpty && (
-                <div className="desktop:mt-[6px]">
-                  <div className="mb-2 font-mono text-[10.5px] font-semibold uppercase tracking-[.08em] text-(--text-tertiary)">
-                    Start with
+                    <div className="flex flex-wrap gap-2">
+                      {prompts.map((p) => (
+                        <button key={p} className="chip whitespace-nowrap" onClick={() => onPgSend(p)}>
+                          {p}
+                        </button>
+                      ))}
+                    </div>
                   </div>
-                  <div className="flex flex-wrap gap-2">
-                    {prompts.map((p) => (
-                      <button key={p} className="chip whitespace-nowrap" onClick={() => onPgSend(p)}>
-                        {p}
-                      </button>
-                    ))}
+                )}
+                {imageError && (
+                  <div className="font-sans text-[11.5px] font-medium leading-normal text-(--red-600)">
+                    {imageError}
                   </div>
-                </div>
-              )}
-              {imageError && (
-                <div className="font-sans text-[11.5px] font-medium leading-normal text-(--red-600)">{imageError}</div>
-              )}
-              {/* Flexible spacer (design): pushes the composer to the bottom of the page
+                )}
+                {/* Flexible spacer (design): pushes the composer to the bottom of the page
                 when the transcript is short; collapses once content overflows. -mt-4
                 cancels the mobile gutter's gap so a collapsed spacer adds no height. */}
-              <div aria-hidden="true" className="-mt-4 flex-1 desktop:mt-0 desktop:min-h-[18px]" />
-              {/* Sticky-to-bottom composer: pinned to the bottom of the scroll area so it's
+                <div aria-hidden="true" className="-mt-4 flex-1 desktop:mt-0 desktop:min-h-[18px]" />
+                {/* Sticky-to-bottom composer: pinned to the bottom of the scroll area so it's
                 always reachable while scrolling the transcript. Its opaque page-colour
                 background covers earlier turns scrolling behind it; the negative `bottom`
                 + matching bottom padding pull it flush past `.content`'s bottom padding
                 (else turns would show through that strip). A top gradient softens the
                 seam where the transcript slides underneath. */}
-              <div className="sticky z-10 bg-(--surface-app) bottom-[calc(-24px-env(safe-area-inset-bottom,0px))] pb-[calc(24px+env(safe-area-inset-bottom,0px))] pt-2 desktop:bottom-[-26px] desktop:pb-[26px] desktop:pt-3">
-                <div
-                  aria-hidden="true"
-                  className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-b from-transparent to-(--surface-app)"
-                />
-                {approvalCard('mb-2 max-desktop:rounded-lg')}
-                {/* Webchat MCP write approvals ride the same sticky footer as permission
-                  requests: always above the input, never scrolled away. */}
-                {activeOrg && session.agentId && webchatConversationId && (
-                  <WebchatMcpApprovalCard
-                    key={webchatConversationId}
-                    orgId={activeOrg.id}
-                    agentId={session.agentId}
-                    conversationId={webchatConversationId}
-                    className="mb-2"
+                <div className="sticky z-10 bg-(--surface-app) bottom-[calc(-24px-env(safe-area-inset-bottom,0px))] pb-[calc(24px+env(safe-area-inset-bottom,0px))] pt-2 desktop:bottom-[-26px] desktop:pb-[26px] desktop:pt-3">
+                  <div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-b from-transparent to-(--surface-app)"
                   />
-                )}
-                {/* Queued messages (Claude Code-style): sends accepted while a turn was
+                  {approvalCard('mb-2 max-desktop:rounded-lg')}
+                  {/* Webchat MCP write approvals ride the same sticky footer as permission
+                  requests: always above the input, never scrolled away. */}
+                  {activeOrg && session.agentId && webchatConversationId && (
+                    <WebchatMcpApprovalCard
+                      key={webchatConversationId}
+                      orgId={activeOrg.id}
+                      agentId={session.agentId}
+                      conversationId={webchatConversationId}
+                      className="mb-2"
+                    />
+                  )}
+                  {/* Queued messages (Claude Code-style): sends accepted while a turn was
                   still streaming wait here, dispatch in order as turns finish, and can
                   be cancelled individually before they go out. */}
-                {pgQueue.length > 0 && (
-                  <div className="mb-2 flex flex-col items-end gap-1">
-                    {pgQueue.map((q) => (
-                      <div
-                        key={q.queueId}
-                        className="group flex max-w-full items-center gap-2 rounded-[9px] border border-dashed border-(--border-default) bg-(--surface-card) py-[5px] pr-[5px] pl-3"
-                      >
-                        <Icon name="clock" size={13} color="var(--text-tertiary)" />
-                        <span
-                          className="min-w-0 truncate font-sans text-[13px] leading-normal text-(--text-tertiary)"
-                          title={q.text}
+                  {pgQueue.length > 0 && (
+                    <div className="mb-2 flex flex-col items-end gap-1">
+                      {pgQueue.map((q) => (
+                        <div
+                          key={q.queueId}
+                          className="group flex max-w-full items-center gap-2 rounded-[9px] border border-dashed border-(--border-default) bg-(--surface-card) py-[5px] pr-[5px] pl-3"
                         >
-                          {q.text || q.image?.name || 'Image'}
-                        </span>
-                        <button
-                          type="button"
-                          className="flex h-6 w-6 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) opacity-0 group-hover:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100 hover:bg-(--surface-hover) hover:text-(--text-secondary)"
-                          aria-label="Cancel queued message"
-                          title="Cancel queued message"
-                          onClick={() => pgCancelQueued(session.id, q.queueId)}
-                        >
-                          <Icon name="x" size={13} />
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {/* Composer card (design "achero"): textarea on top, a toolbar row below
+                          <Icon name="clock" size={13} color="var(--text-tertiary)" />
+                          <span
+                            className="min-w-0 truncate font-sans text-[13px] leading-normal text-(--text-tertiary)"
+                            title={q.text}
+                          >
+                            {q.text || q.image?.name || 'Image'}
+                          </span>
+                          <button
+                            type="button"
+                            className="flex h-6 w-6 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) opacity-0 group-hover:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100 hover:bg-(--surface-hover) hover:text-(--text-secondary)"
+                            aria-label="Cancel queued message"
+                            title="Cancel queued message"
+                            onClick={() => pgCancelQueued(session.id, q.queueId)}
+                          >
+                            <Icon name="x" size={13} />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {/* Composer card (design "achero"): textarea on top, a toolbar row below
                   the divider — attach · model pill (fast toggle in its menu) · effort ·
                   permission · context ring · send. Tokens/cost live in the header's
                   Details popover, not here. */}
-                <div
-                  className="relative min-w-0 rounded-[11px] border border-(--border-default) bg-(--surface-card) shadow-(--shadow-xs) transition-[border-color,box-shadow] focus-within:border-(--brand) focus-within:[box-shadow:0_0_0_3px_var(--brand-ring)]"
-                  inert={resumeDisabled}
-                  aria-disabled={resumeDisabled}
-                  onKeyDown={(event) => {
-                    if (event.key !== 'Escape') return
-                    setAttachMenuOpen(false)
-                    setComposerMenuOpen(null)
-                  }}
-                >
-                  {resumeDisabled && (
-                    <textarea
-                      className="absolute inset-0 z-10 block h-full min-h-[92px] w-full resize-none rounded-[10px] border-0 bg-(--surface-sunken) px-[15px] py-[13px] font-sans text-[14px] font-normal leading-[1.55] text-(--text-tertiary) outline-none placeholder:text-(--text-tertiary) disabled:cursor-not-allowed"
-                      aria-label="Conversation unavailable"
-                      placeholder={resumePlaceholder}
-                      disabled
-                    />
-                  )}
-                  <input
-                    ref={imageInputRef}
-                    type="file"
-                    accept="image/*"
-                    hidden
-                    onChange={(event) => void onImageFile(event.target.files?.[0])}
-                  />
-                  {pgImage && (
-                    <div className="relative mx-[15px] mt-3 w-fit">
-                      <img
-                        src={`data:${pgImage.mimeType};base64,${pgImage.data}`}
-                        alt={pgImage.name}
-                        title={pgImage.name}
-                        className="h-20 w-20 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) object-cover"
+                  <div
+                    className="relative min-w-0 rounded-[11px] border border-(--border-default) bg-(--surface-card) shadow-(--shadow-xs) transition-[border-color,box-shadow] focus-within:border-(--brand) focus-within:[box-shadow:0_0_0_3px_var(--brand-ring)]"
+                    inert={resumeDisabled}
+                    aria-disabled={resumeDisabled}
+                    onKeyDown={(event) => {
+                      if (event.key !== 'Escape') return
+                      setAttachMenuOpen(false)
+                      setComposerMenuOpen(null)
+                    }}
+                  >
+                    {resumeDisabled && (
+                      <textarea
+                        className="absolute inset-0 z-10 block h-full min-h-[92px] w-full resize-none rounded-[10px] border-0 bg-(--surface-sunken) px-[15px] py-[13px] font-sans text-[14px] font-normal leading-[1.55] text-(--text-tertiary) outline-none placeholder:text-(--text-tertiary) disabled:cursor-not-allowed"
+                        aria-label="Conversation unavailable"
+                        placeholder={resumePlaceholder}
+                        disabled
                       />
-                      <button
-                        type="button"
-                        className="iconbtn absolute -right-2 -top-2 h-6 w-6 rounded-full shadow-(--shadow-xs)"
-                        title="Remove image"
-                        aria-label="Remove image"
-                        onClick={() => setPgImage(session.id)}
-                      >
-                        <Icon name="x" size={14} />
-                      </button>
-                    </div>
-                  )}
-                  <ComposerTextarea
-                    sessionId={session.id}
-                    placeholder={
-                      (session.participants?.length ?? 0) > 1 ? 'Message everyone…' : `Message ${session.agentName}…`
-                    }
-                    onSend={() => onPgSend()}
-                    onImageFile={(file) => void onImageFile(file)}
-                    mentionCandidates={mentionCandidates}
-                    onPickMention={onPickMention}
-                    onMentionJoiningChange={setMentionJoining}
-                  />
-                  <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
-                    <div className="relative flex-none">
-                      <button
-                        type="button"
-                        className="flex h-7 w-7 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) hover:bg-(--surface-hover) hover:text-(--text-secondary)"
-                        aria-label="Attach a file"
-                        aria-haspopup="menu"
-                        aria-expanded={attachMenuOpen}
-                        title="Attach a file"
-                        disabled={imagePreparing}
-                        onClick={() => {
-                          setComposerMenuOpen(null)
-                          setAttachMenuOpen((open) => !open)
-                        }}
-                      >
-                        {imagePreparing ? <Spinner size={14} /> : <Icon name="paperclip" size={15} />}
-                      </button>
-                      {attachMenuOpen && (
-                        <>
-                          <div
-                            aria-hidden="true"
-                            className="fixed inset-0 z-40"
-                            onClick={() => setAttachMenuOpen(false)}
-                          ></div>
-                          <div
-                            role="menu"
-                            className="absolute bottom-[calc(100%+8px)] left-0 z-50 w-[166px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
-                          >
-                            <button
-                              type="button"
-                              role="menuitem"
-                              className="fopt"
-                              onClick={() => {
-                                setAttachMenuOpen(false)
-                                imageInputRef.current?.click()
-                              }}
+                    )}
+                    <input
+                      ref={imageInputRef}
+                      type="file"
+                      accept="image/*"
+                      hidden
+                      onChange={(event) => void onImageFile(event.target.files?.[0])}
+                    />
+                    {pgImage && (
+                      <div className="relative mx-[15px] mt-3 w-fit">
+                        <img
+                          src={`data:${pgImage.mimeType};base64,${pgImage.data}`}
+                          alt={pgImage.name}
+                          title={pgImage.name}
+                          className="h-20 w-20 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) object-cover"
+                        />
+                        <button
+                          type="button"
+                          className="iconbtn absolute -right-2 -top-2 h-6 w-6 rounded-full shadow-(--shadow-xs)"
+                          title="Remove image"
+                          aria-label="Remove image"
+                          onClick={() => setPgImage(session.id)}
+                        >
+                          <Icon name="x" size={14} />
+                        </button>
+                      </div>
+                    )}
+                    <ComposerTextarea
+                      sessionId={session.id}
+                      placeholder={
+                        (session.participants?.length ?? 0) > 1 ? 'Message everyone…' : `Message ${session.agentName}…`
+                      }
+                      onSend={() => onPgSend()}
+                      onImageFile={(file) => void onImageFile(file)}
+                      mentionCandidates={mentionCandidates}
+                      onPickMention={onPickMention}
+                      onMentionJoiningChange={setMentionJoining}
+                    />
+                    <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
+                      <div className="relative flex-none">
+                        <button
+                          type="button"
+                          className="flex h-7 w-7 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) hover:bg-(--surface-hover) hover:text-(--text-secondary)"
+                          aria-label="Attach a file"
+                          aria-haspopup="menu"
+                          aria-expanded={attachMenuOpen}
+                          title="Attach a file"
+                          disabled={imagePreparing}
+                          onClick={() => {
+                            setComposerMenuOpen(null)
+                            setAttachMenuOpen((open) => !open)
+                          }}
+                        >
+                          {imagePreparing ? <Spinner size={14} /> : <Icon name="paperclip" size={15} />}
+                        </button>
+                        {attachMenuOpen && (
+                          <>
+                            <div
+                              aria-hidden="true"
+                              className="fixed inset-0 z-40"
+                              onClick={() => setAttachMenuOpen(false)}
+                            ></div>
+                            <div
+                              role="menu"
+                              className="absolute bottom-[calc(100%+8px)] left-0 z-50 w-[166px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
                             >
-                              <Icon name="image" size={16} color="var(--text-secondary)" />
-                              Add photos
-                            </button>
-                          </div>
-                        </>
-                      )}
-                    </div>
-                    {/* nowrap on mobile — pills shrink + truncate (ComposerMenu min-w-0)
+                              <button
+                                type="button"
+                                role="menuitem"
+                                className="fopt"
+                                onClick={() => {
+                                  setAttachMenuOpen(false)
+                                  imageInputRef.current?.click()
+                                }}
+                              >
+                                <Icon name="image" size={16} color="var(--text-secondary)" />
+                                Add photos
+                              </button>
+                            </div>
+                          </>
+                        )}
+                      </div>
+                      {/* nowrap on mobile — pills shrink + truncate (ComposerMenu min-w-0)
                       instead of wrapping into a second toolbar line. Except with a
                       multi-agent roster: those chips are unbounded in count, so no
                       amount of truncation bounds one line — let that case wrap. */}
-                    <div
-                      className={
-                        multiLive
-                          ? 'flex min-w-0 flex-1 flex-wrap items-center gap-2'
-                          : 'flex min-w-0 flex-1 items-center gap-2 desktop:flex-wrap'
-                      }
-                    >
-                      {multiLive &&
-                        liveRoster.map((p) => {
-                          const rosterAgent = agents.find((a) => a.id === p.agentId)
-                          return (
-                            <span key={p.agentId} className={COMPOSER_PILL_STATIC} title="Participant">
-                              {rosterAgent && (
-                                <span className="av h-[14px] w-[14px] flex-none rounded-xs">
-                                  <AgentIconView icon={rosterAgent.icon} runtime={rosterAgent.runtime} size={14} />
-                                </span>
-                              )}
-                              <span className="truncate">{p.name}</span>
-                            </span>
-                          )
-                        })}
-                      {/* h-7 w-7 like every other control on this row (and the Home composer's
+                      <div
+                        className={
+                          multiLive
+                            ? 'flex min-w-0 flex-1 flex-wrap items-center gap-2'
+                            : 'flex min-w-0 flex-1 items-center gap-2 desktop:flex-wrap'
+                        }
+                      >
+                        {multiLive &&
+                          liveRoster.map((p) => {
+                            const rosterAgent = agents.find((a) => a.id === p.agentId)
+                            return (
+                              <span key={p.agentId} className={COMPOSER_PILL_STATIC} title="Participant">
+                                {rosterAgent && (
+                                  <span className="av h-[14px] w-[14px] flex-none rounded-xs">
+                                    <AgentIconView icon={rosterAgent.icon} runtime={rosterAgent.runtime} size={14} />
+                                  </span>
+                                )}
+                                <span className="truncate">{p.name}</span>
+                              </span>
+                            )
+                          })}
+                        {/* h-7 w-7 like every other control on this row (and the Home composer's
                         twin), so the dashed circle shares their 28px box instead of floating
                         inside it. A lucide glyph, not a text "+": a text plus centres on its
                         line box, which left it a hair low. */}
-                      {isPg && addAgentOptions.length > 0 && (
-                        <ComposerMenu
-                          title="Add agents"
-                          value=""
-                          options={addAgentOptions}
-                          iconOnly
-                          open={composerMenuOpen === 'addAgent'}
-                          align="left"
-                          triggerClassName="inline-flex h-7 w-7 flex-none items-center justify-center rounded-full border border-dashed border-(--border-default) font-sans leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)"
-                          tooltips={false}
-                          leading={<Icon name="plus" size={14} />}
-                          onOpenChange={(open) => {
-                            setAttachMenuOpen(false)
-                            setComposerMenuOpen(open ? 'addAgent' : null)
-                          }}
-                          onChange={(v) => {
-                            const picked = agents.find((a) => a.id === v)
-                            if (picked) void pgAddAgent(session.id, picked)
-                          }}
-                        />
-                      )}
-                      {!multiLive &&
-                        (runtimeChangesEnabled && pgModelOptions.length > 0 ? (
+                        {isPg && addAgentOptions.length > 0 && (
                           <ComposerMenu
-                            title="Model"
-                            value={pgModel}
-                            options={pgModelOptions.map((model) => ({ value: model, label: modelLabel(model) }))}
-                            open={composerMenuOpen === 'model'}
+                            title="Add agents"
+                            value=""
+                            options={addAgentOptions}
+                            iconOnly
+                            open={composerMenuOpen === 'addAgent'}
                             align="left"
-                            triggerClassName={COMPOSER_PILL}
+                            triggerClassName="inline-flex h-7 w-7 flex-none items-center justify-center rounded-full border border-dashed border-(--border-default) font-sans leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)"
                             tooltips={false}
-                            leading={
-                              <span className="inline-flex h-[14px] w-[14px] flex-none items-center justify-center">
-                                <ModelMark model={pgModel} fallbackRuntime={agentRuntime} />
-                              </span>
-                            }
-                            trailing={pgFastModeAvailable && pgFastMode ? <FastBadge /> : undefined}
-                            footer={
-                              pgFastModeAvailable ? (
-                                <div className="flex items-center gap-[10px] px-[7px] pt-2 pb-[3px]">
-                                  <button
-                                    type="button"
-                                    role="switch"
-                                    aria-checked={pgFastMode}
-                                    aria-label="Fast mode"
-                                    title="Fast mode trades depth for latency"
-                                    className={`relative h-[15px] w-[26px] flex-none cursor-pointer rounded-full border-0 p-0 transition-colors ${
-                                      pgFastMode ? 'bg-(--brand)' : 'bg-(--border-strong)'
-                                    }`}
-                                    onClick={() => {
-                                      const fast = !pgFastMode
-                                      setRuntimeSelection({ fast })
-                                      pgSetFast(session.id, session.agentId ?? '', fast, webchatConversationId)
-                                    }}
-                                  >
-                                    <span
-                                      className={`absolute top-[1px] h-[13px] w-[13px] rounded-full bg-white transition-[left] ${
-                                        pgFastMode ? 'left-3' : 'left-[1px]'
-                                      }`}
-                                    />
-                                  </button>
-                                  <span className="flex-1 font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
-                                    Fast mode
-                                  </span>
-                                  <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                                    lower latency
-                                  </span>
-                                </div>
-                              ) : undefined
-                            }
+                            leading={<Icon name="plus" size={14} />}
                             onOpenChange={(open) => {
                               setAttachMenuOpen(false)
-                              setComposerMenuOpen(open ? 'model' : null)
+                              setComposerMenuOpen(open ? 'addAgent' : null)
                             }}
-                            onChange={(model) => {
-                              const currentEffort = runtimeSelection?.effort ?? session.effort ?? owner?.reasoning ?? ''
-                              const effort = sessionEffortAfterModelChange(
-                                agentRuntime,
-                                owningDaemon,
-                                model,
-                                currentEffort
-                              )
-                              setRuntimeSelection(effort === currentEffort ? { model } : { model, effort })
-                              pgSetModel(session.id, session.agentId ?? '', model, webchatConversationId)
-                              if (effort !== currentEffort) {
-                                pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
+                            onChange={(v) => {
+                              const picked = agents.find((a) => a.id === v)
+                              if (picked) void pgAddAgent(session.id, picked)
+                            }}
+                          />
+                        )}
+                        {!multiLive &&
+                          (runtimeChangesEnabled && pgModelOptions.length > 0 ? (
+                            <ComposerMenu
+                              title="Model"
+                              value={pgModel}
+                              options={pgModelOptions.map((model) => ({ value: model, label: modelLabel(model) }))}
+                              open={composerMenuOpen === 'model'}
+                              align="left"
+                              triggerClassName={COMPOSER_PILL}
+                              tooltips={false}
+                              leading={
+                                <span className="inline-flex h-[14px] w-[14px] flex-none items-center justify-center">
+                                  <ModelMark model={pgModel} fallbackRuntime={agentRuntime} />
+                                </span>
                               }
-                            }}
-                          />
-                        ) : (
-                          pgModel && (
-                            <span className={COMPOSER_PILL_STATIC} title="Model">
-                              <span className="inline-flex h-[14px] w-[14px] flex-none items-center justify-center">
-                                <ModelMark model={pgModel} fallbackRuntime={agentRuntime} />
+                              trailing={pgFastModeAvailable && pgFastMode ? <FastBadge /> : undefined}
+                              footer={
+                                pgFastModeAvailable ? (
+                                  <div className="flex items-center gap-[10px] px-[7px] pt-2 pb-[3px]">
+                                    <button
+                                      type="button"
+                                      role="switch"
+                                      aria-checked={pgFastMode}
+                                      aria-label="Fast mode"
+                                      title="Fast mode trades depth for latency"
+                                      className={`relative h-[15px] w-[26px] flex-none cursor-pointer rounded-full border-0 p-0 transition-colors ${
+                                        pgFastMode ? 'bg-(--brand)' : 'bg-(--border-strong)'
+                                      }`}
+                                      onClick={() => {
+                                        const fast = !pgFastMode
+                                        setRuntimeSelection({ fast })
+                                        pgSetFast(session.id, session.agentId ?? '', fast, webchatConversationId)
+                                      }}
+                                    >
+                                      <span
+                                        className={`absolute top-[1px] h-[13px] w-[13px] rounded-full bg-white transition-[left] ${
+                                          pgFastMode ? 'left-3' : 'left-[1px]'
+                                        }`}
+                                      />
+                                    </button>
+                                    <span className="flex-1 font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
+                                      Fast mode
+                                    </span>
+                                    <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                                      lower latency
+                                    </span>
+                                  </div>
+                                ) : undefined
+                              }
+                              onOpenChange={(open) => {
+                                setAttachMenuOpen(false)
+                                setComposerMenuOpen(open ? 'model' : null)
+                              }}
+                              onChange={(model) => {
+                                const currentEffort =
+                                  runtimeSelection?.effort ?? session.effort ?? owner?.reasoning ?? ''
+                                const effort = sessionEffortAfterModelChange(
+                                  agentRuntime,
+                                  owningDaemon,
+                                  model,
+                                  currentEffort
+                                )
+                                setRuntimeSelection(effort === currentEffort ? { model } : { model, effort })
+                                pgSetModel(session.id, session.agentId ?? '', model, webchatConversationId)
+                                if (effort !== currentEffort) {
+                                  pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
+                                }
+                              }}
+                            />
+                          ) : (
+                            pgModel && (
+                              <span className={COMPOSER_PILL_STATIC} title="Model">
+                                <span className="inline-flex h-[14px] w-[14px] flex-none items-center justify-center">
+                                  <ModelMark model={pgModel} fallbackRuntime={agentRuntime} />
+                                </span>
+                                <span className="truncate">{modelLabel(pgModel)}</span>
+                                {pgFastModeAvailable && pgFastMode && <FastBadge />}
                               </span>
-                              <span className="truncate">{modelLabel(pgModel)}</span>
-                              {pgFastModeAvailable && pgFastMode && <FastBadge />}
-                            </span>
-                          )
-                        ))}
-                      {!multiLive &&
-                        (runtimeChangesEnabled && pgEffortOptions.length > 0 ? (
-                          <ComposerMenu
-                            title="Effort"
-                            value={pgEffort}
-                            options={pgEffortOptions.map((effort) => ({
-                              value: effort.value,
-                              label: effort.label,
-                              description: effort.description
-                            }))}
-                            open={composerMenuOpen === 'effort'}
-                            align="left"
-                            triggerClassName={COMPOSER_CHIP}
-                            tooltips={false}
-                            onOpenChange={(open) => {
-                              setAttachMenuOpen(false)
-                              setComposerMenuOpen(open ? 'effort' : null)
-                            }}
-                            onChange={(effort) => {
-                              setRuntimeSelection({ effort })
-                              pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
-                            }}
-                          />
-                        ) : (
-                          pgEffort && (
-                            <span className={COMPOSER_CHIP_STATIC} title="Effort">
-                              <span className="truncate">
-                                {pgEffortChoices.find((choice) => choice.value === pgEffort)?.label ??
-                                  effortLabel(agentRuntime, pgEffort)}
+                            )
+                          ))}
+                        {!multiLive &&
+                          (runtimeChangesEnabled && pgEffortOptions.length > 0 ? (
+                            <ComposerMenu
+                              title="Effort"
+                              value={pgEffort}
+                              options={pgEffortOptions.map((effort) => ({
+                                value: effort.value,
+                                label: effort.label,
+                                description: effort.description
+                              }))}
+                              open={composerMenuOpen === 'effort'}
+                              align="left"
+                              triggerClassName={COMPOSER_CHIP}
+                              tooltips={false}
+                              onOpenChange={(open) => {
+                                setAttachMenuOpen(false)
+                                setComposerMenuOpen(open ? 'effort' : null)
+                              }}
+                              onChange={(effort) => {
+                                setRuntimeSelection({ effort })
+                                pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
+                              }}
+                            />
+                          ) : (
+                            pgEffort && (
+                              <span className={COMPOSER_CHIP_STATIC} title="Effort">
+                                <span className="truncate">
+                                  {pgEffortChoices.find((choice) => choice.value === pgEffort)?.label ??
+                                    effortLabel(agentRuntime, pgEffort)}
+                                </span>
                               </span>
-                            </span>
-                          )
-                        ))}
-                      {!multiLive &&
-                        (runtimeChangesEnabled && pgPermissionPresets.length > 0 ? (
-                          <ComposerMenu
-                            title="Permission"
-                            value={pgPermissionPreset}
-                            options={pgPermissionPresets.map((mode) => ({
-                              value: mode.v,
-                              label: mode.l,
-                              description: mode.description
-                            }))}
-                            open={composerMenuOpen === 'permission'}
-                            align="left"
-                            triggerClassName={COMPOSER_CHIP}
-                            onOpenChange={(open) => {
-                              setAttachMenuOpen(false)
-                              setComposerMenuOpen(open ? 'permission' : null)
-                            }}
-                            onChange={(permissionPreset) => {
-                              setRuntimeSelection({ permissionPreset })
-                              pgSetPermissionPreset(
-                                session.id,
-                                session.agentId ?? '',
-                                permissionPreset,
-                                webchatConversationId
-                              )
-                            }}
-                          />
-                        ) : (
-                          pgPermissionPreset && (
-                            <span className={COMPOSER_CHIP_STATIC} title="Permission">
-                              <span className="truncate">
-                                {agentPermissionDisplay(owningDaemon, agentRuntime, pgPermissionPreset)}
+                            )
+                          ))}
+                        {!multiLive &&
+                          (runtimeChangesEnabled && pgPermissionPresets.length > 0 ? (
+                            <ComposerMenu
+                              title="Permission"
+                              value={pgPermissionPreset}
+                              options={pgPermissionPresets.map((mode) => ({
+                                value: mode.v,
+                                label: mode.l,
+                                description: mode.description
+                              }))}
+                              open={composerMenuOpen === 'permission'}
+                              align="left"
+                              triggerClassName={COMPOSER_CHIP}
+                              onOpenChange={(open) => {
+                                setAttachMenuOpen(false)
+                                setComposerMenuOpen(open ? 'permission' : null)
+                              }}
+                              onChange={(permissionPreset) => {
+                                setRuntimeSelection({ permissionPreset })
+                                pgSetPermissionPreset(
+                                  session.id,
+                                  session.agentId ?? '',
+                                  permissionPreset,
+                                  webchatConversationId
+                                )
+                              }}
+                            />
+                          ) : (
+                            pgPermissionPreset && (
+                              <span className={COMPOSER_CHIP_STATIC} title="Permission">
+                                <span className="truncate">
+                                  {agentPermissionDisplay(owningDaemon, agentRuntime, pgPermissionPreset)}
+                                </span>
                               </span>
-                            </span>
-                          )
-                        ))}
-                      {canChooseWorktree && (
-                        <label className={`${COMPOSER_CHIP} min-w-0 cursor-pointer`}>
-                          <input
-                            type="checkbox"
-                            checked={pgWorktree}
-                            onChange={(event) => {
-                              const worktree = event.target.checked
-                              setWorktreeSelections((current) => ({ ...current, [session.id]: worktree }))
-                              pgSetWorktree(session.id, worktree)
-                            }}
-                            className="h-4 w-4 flex-none accent-(--brand)"
-                          />
-                          <span className="truncate">Worktree</span>
-                        </label>
-                      )}
+                            )
+                          ))}
+                        {canChooseWorktree && (
+                          <label className={`${COMPOSER_CHIP} min-w-0 cursor-pointer`}>
+                            <input
+                              type="checkbox"
+                              checked={pgWorktree}
+                              onChange={(event) => {
+                                const worktree = event.target.checked
+                                setWorktreeSelections((current) => ({ ...current, [session.id]: worktree }))
+                                pgSetWorktree(session.id, worktree)
+                              }}
+                              className="h-4 w-4 flex-none accent-(--brand)"
+                            />
+                            <span className="truncate">Worktree</span>
+                          </label>
+                        )}
+                      </div>
+                      <ContextWindowIndicator used={u?.contextUsed} size={u?.contextSize} />
+                      <ComposerSendButton
+                        sessionId={session.id}
+                        busy={pgBusy}
+                        imagePreparing={imagePreparing}
+                        hasImage={!!pgImage}
+                        mentionJoining={mentionJoining}
+                        onSend={() => onPgSend()}
+                        onStop={() => pgCancel(session.id, session.agentId ?? '', webchatConversationId)}
+                      />
                     </div>
-                    <ContextWindowIndicator used={u?.contextUsed} size={u?.contextSize} />
-                    <ComposerSendButton
-                      sessionId={session.id}
-                      busy={pgBusy}
-                      imagePreparing={imagePreparing}
-                      hasImage={!!pgImage}
-                      mentionJoining={mentionJoining}
-                      onSend={() => onPgSend()}
-                      onStop={() => pgCancel(session.id, session.agentId ?? '', webchatConversationId)}
-                    />
                   </div>
                 </div>
-              </div>
-            </>
-          )}
+              </>
+            )}
+          </div>
         </div>
       </div>
-      <SessionDock tabs={dockTabs} activeKey={dockTab} onTabChange={setDockTab} overlayKey={session.id} label="Panels">
-        <SessionsPanel
-          sessions={railSessions}
-          // Named by conversation and members (the §5.1 key, roster complete): that is how the panel collapses this row and how a pin finds it.
-          current={railCurrent ?? session}
-          total={railSessionTotal}
-          agentIds={railDisplayAgentIds}
-          filterTouched={railFilter.touched}
-          onAgentIdsChange={setRailAgentIds}
-          family={familyLinks}
-          flatView={flatView}
-          childOriginById={conversationLineage?.childOriginById}
-          roomLineage={conversationLineage?.roomLineage}
-          onSelect={setRouteSession}
-          onWouldHideChange={handleSessionsWouldHide}
-        />
+      {/* Opening a file also closes the collapsed-band overlay: below `wide:` the dock is a drawer over the very pane the file lands in, and on a phone the viewer IS the screen (§8). The dock's own latch resets on this key. */}
+      <SessionDock
+        tabs={dockTabs}
+        activeKey={dockTabKey}
+        onTabChange={setDockTab}
+        onTabAction={(key) => {
+          if (key === 'files') setFilesRefreshTick((tick) => tick + 1)
+        }}
+        overlayKey={`${session.id}:${viewerPath ?? ''}`}
+        label="Panels"
+      >
+        {/* Both panels stay mounted; only the active one draws. Sessions owns the verdict that sets its own tab status, and Files owns the tree, the filter and the scroll position a tab switch must not spend. */}
+        <DockPanel active={dockTabKey === 'sessions'}>
+          <SessionsPanel
+            sessions={railSessions}
+            // Named by conversation and members (the §5.1 key, roster complete): that is how the panel collapses this row and how a pin finds it.
+            current={railCurrent ?? session}
+            total={railSessionTotal}
+            agentIds={railDisplayAgentIds}
+            filterTouched={railFilter.touched}
+            onAgentIdsChange={setRailAgentIds}
+            family={familyLinks}
+            flatView={flatView}
+            childOriginById={conversationLineage?.childOriginById}
+            roomLineage={conversationLineage?.roomLineage}
+            onSelect={setRouteSession}
+            onWouldHideChange={handleSessionsWouldHide}
+          />
+        </DockPanel>
+        <DockPanel active={dockTabKey === 'files'}>
+          {filesAgentId ? (
+            <FilesPanel
+              agentId={filesAgentId}
+              {...(filesSessionId ? { sessionId: filesSessionId } : {})}
+              {...(filesWorkdir ? { workdir: filesWorkdir } : {})}
+              refreshTick={filesRefreshTick}
+              openFilePath={viewerPath}
+              onOpenFile={(path) => setViewerFile(path)}
+              onRootSettledChange={setFilesRootSettled}
+            />
+          ) : null}
+        </DockPanel>
       </SessionDock>
     </div>
   )

--- a/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
@@ -464,6 +464,17 @@ describe('the viewer route', () => {
     expect(written.get('agent')).toBe('agent-1')
   })
 
+  it('fails CLOSED when the link names a workspace this conversation does not have', async () => {
+    // The dangerous alternative is falling back to the default agent: the same path opens against a different checkout and draws plausible, wrong content — which is the ambiguity `agent=` exists to remove.
+    nav.search = 'file=a.ts&agent=agent-not-here'
+    await render()
+    expect(viewer()).toBeNull()
+    expect(container?.querySelector('[data-viewer-stale-link]')).not.toBeNull()
+    // And nothing was read from anyone's checkout on the strength of that link.
+    expect(wire.fileCalls).toEqual([])
+    expect(pane()?.className).toBe('contents')
+  })
+
   it('drops the workspace along with the file, so a closed viewer leaves no scope behind', async () => {
     nav.search = 'file=a.ts&agent=agent-1'
     await render()

--- a/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
@@ -1,0 +1,452 @@
+// @vitest-environment happy-dom
+
+// The conversation ↔ viewer switch on the real session page: that `?file=` opens the viewer, that closing it puts the conversation back, and above all that the round trip does not REMOUNT the transcript — the state inside that region (expanded tool bodies, the composer's caret, an open @mention menu and the latch it reports upward) belongs to the session, not to the pane.
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent, Session } from '@/lib/data'
+
+const nav = vi.hoisted(() => ({ search: '', replaced: [] as string[], pushed: [] as string[] }))
+const wire = vi.hoisted(() => ({
+  file: '',
+  fileExists: true,
+  fileCalls: [] as Array<{ path: string; sessionId?: string }>,
+  listCalls: [] as Array<{ path: string; sessionId?: string }>,
+  /** Whether the open session has a worktree of its own; a shared workspace must never be asked for one. */
+  isolation: 'session' as 'session' | 'shared'
+}))
+
+const NASTY_DIR = 'my dir+x'
+const NASTY_FILE = 'ノート a+b (1).md'
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'session-1' }),
+  usePathname: () => '/acme/sessions/session-1',
+  useSearchParams: () => new URLSearchParams(nav.search),
+  useRouter: () => ({
+    replace: (href: string) => {
+      nav.replaced.push(href)
+      nav.search = href.includes('?') ? href.slice(href.indexOf('?') + 1) : ''
+    },
+    push: (href: string) => nav.pushed.push(href),
+    prefetch: () => {},
+    back: () => {},
+    forward: () => {},
+    refresh: () => {}
+  })
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>
+}))
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    fetchWorkspaceFiles: vi.fn((_agentId: string, opts: { path: string; sessionId?: string }) => {
+      wire.listCalls.push(opts)
+      // Root carries a directory whose name and child are deliberately hostile to a URL — space, `+`, parens and non-ASCII — so the param round-trip is exercised on bytes that actually encode, not on `notes.md`.
+      return Promise.resolve({
+        path: opts.path,
+        exists: true,
+        entries:
+          opts.path === NASTY_DIR
+            ? [{ name: NASTY_FILE, type: 'file' as const, size: 12, mtime: null }]
+            : [
+                { name: NASTY_DIR, type: 'dir' as const, size: null, mtime: null },
+                { name: 'notes.md', type: 'file' as const, size: 12, mtime: null }
+              ],
+        nextCursor: null
+      })
+    }),
+    fetchWorkspaceGitStatus: vi.fn(() => Promise.resolve({ isRepo: false })),
+    fetchWorkspaceFile: vi.fn((_agentId: string, opts: { path: string; sessionId?: string }) => {
+      wire.fileCalls.push(opts)
+      return Promise.resolve({
+        path: opts.path,
+        exists: wire.fileExists,
+        size: wire.file.length,
+        mtime: '2026-08-10T10:00:00.000Z',
+        encoding: 'utf8' as const,
+        content: wire.file,
+        offset: 0,
+        nextOffset: null,
+        truncated: false
+      })
+    }),
+    fetchSessionMessages: vi.fn(() => Promise.resolve({ messages: [], nextCursor: null })),
+    fetchSessionDetail: vi.fn(() => Promise.reject(new Error('no detail'))),
+    fetchMySessionIdentity: vi.fn(() => Promise.reject(new Error('no identity'))),
+    fetchConversationByKey: vi.fn(() => Promise.reject(new Error('no conversation')))
+  }
+})
+
+const agent: Agent = {
+  id: 'agent-1',
+  name: 'Ops bot',
+  runtime: 'claude',
+  model: 'sonnet',
+  status: 'online',
+  statusLabel: 'online',
+  icon: 'bot',
+  daemon: 'daemon-1',
+  workdir: './services/api',
+  // A github checkout, which with a session-isolated worktree is what makes the reads session-scoped.
+  workspace: { mode: 'github', repo: 'https://github.com/acme/api', branch: 'main' },
+  canEdit: false
+} as unknown as Agent
+
+const session: Session = {
+  id: 'session-1',
+  title: 'Deploy the thing',
+  time: '11:02 AM',
+  lastActivityAt: '2026-08-10T11:02:00.000Z',
+  status: 'idle',
+  platform: 'slack',
+  channel: '#ops',
+  user: 'sam',
+  duration: '1m',
+  tokens: '2.1K',
+  cost: '$0.01',
+  toolCount: '1',
+  statusLabel: 'completed',
+  agentId: 'agent-1',
+  agentName: 'Ops bot',
+  steps: [{ kind: 'msg', who: 'sam', text: 'TRANSCRIPT MARKER' }]
+} as unknown as Session
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    agents: [agent],
+    allSessions: [{ ...session, workspaceIsolation: wire.isolation }],
+    getSessions: () => [session],
+    sessionsLoading: false,
+    crons: [],
+    daemons: [],
+    members: [],
+    sessionActivityVersionById: {},
+    sessionStreamGeneration: 0,
+    revalidateSessionLists: () => {}
+  })
+}))
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1', slug: 'acme' }, orgPath: (path: string) => `/acme${path}` })
+}))
+
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ user: { name: 'Sam' }, me: null }) }))
+
+vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
+
+vi.mock('@/lib/stick-to-bottom', () => ({ useStickToBottom: () => () => {} }))
+
+vi.mock('@/lib/auth', () => ({ isAuthConfigured: () => false }))
+
+vi.mock('@/lib/use-session-list', () => ({
+  useSessionList: () => ({ sessions: [], total: 0, isLoading: false, nextCursor: null, loadingMore: false })
+}))
+
+vi.mock('@/components/console/Shell', () => ({
+  useCrumbSlot: () => ({ register: () => {} }),
+  useMobileActionSlot: () => ({ action: null, register: () => {} })
+}))
+
+vi.mock('@/components/console/PlaygroundProvider', () => ({
+  usePlayground: () => ({
+    getPgSession: () => undefined,
+    getLiveSteps: () => [],
+    getBusyLaneAgentIds: () => [],
+    reconcileLiveSteps: () => {},
+    getPgImage: () => null,
+    getPgWorktree: () => false,
+    isPgBusy: () => false,
+    setPgImage: () => {},
+    pgSend: () => {},
+    getPgQueue: () => [],
+    pgCancelQueued: () => {},
+    pgAddAgent: () => {},
+    pgSetModel: () => {},
+    pgSetEffort: () => {},
+    pgSetPermissionPreset: () => {},
+    pgSetFast: () => {},
+    pgSetWorktree: () => {},
+    pgCancel: () => {},
+    setPgInput: () => {}
+  }),
+  usePgDraft: () => '',
+  usePgDraftHasText: () => false
+}))
+
+import SessionDetailView from './SessionDetailView'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let container: HTMLDivElement | undefined
+let root: ReturnType<typeof createRoot> | undefined
+
+async function render() {
+  await act(async () => {
+    root?.render(<SessionDetailView />)
+    await Promise.resolve()
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+const text = () => container?.textContent ?? ''
+const pane = () => container?.querySelector('[data-conversation-pane]')
+const viewer = () => container?.querySelector('[data-viewer-code]')
+// A real transcript leaf, found by its own text rather than by a hook added for the test: the node the marker text lives in is exactly what a remount would replace.
+const marker = () =>
+  Array.from(container?.querySelectorAll('*') ?? []).find(
+    (element) => element.children.length === 0 && element.textContent === 'TRANSCRIPT MARKER'
+  )
+
+/** Navigate the way the app does — a `router.replace` the mocked router feeds straight back into `useSearchParams`. */
+async function press(selector: string) {
+  const target = container?.querySelector<HTMLElement>(selector)
+  if (!target) throw new Error(`no ${selector}`)
+  await act(async () => {
+    target.click()
+    await Promise.resolve()
+  })
+  await render()
+}
+
+beforeEach(() => {
+  nav.search = ''
+  nav.replaced = []
+  nav.pushed = []
+  wire.file = 'line one\nline two\n'
+  wire.fileExists = true
+  wire.fileCalls = []
+  wire.listCalls = []
+  wire.isolation = 'session'
+  window.localStorage.clear()
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    onchange: null,
+    dispatchEvent: () => false
+  })) as unknown as typeof window.matchMedia
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container?.remove()
+  container = undefined
+  root = undefined
+})
+
+describe('the session page in conversation mode', () => {
+  it('draws the transcript and no viewer', async () => {
+    await render()
+    expect(text()).toContain('TRANSCRIPT MARKER')
+    expect(viewer()).toBeNull()
+    expect(pane()?.className).toBe('contents')
+  })
+})
+
+describe('the session page in viewer mode', () => {
+  it('opens the file named by the route, keeping the session header above it', async () => {
+    nav.search = 'file=src%2Fnotes.md'
+    await render()
+    expect(wire.fileCalls.at(-1)?.path).toBe('src/notes.md')
+    expect(viewer()).not.toBeNull()
+    // The header stays: the page still names the session it belongs to.
+    expect(text()).toContain('Deploy the thing')
+  })
+
+  it('conceals the conversation rather than unmounting it, and gives it back on close', async () => {
+    nav.search = 'file=src%2Fnotes.md'
+    await render()
+    expect(pane()?.className).toBe('hidden')
+    // Concealed, not gone — the transcript nodes are still in the tree.
+    expect(text()).toContain('TRANSCRIPT MARKER')
+
+    await press('[data-viewer-close]')
+    expect(viewer()).toBeNull()
+    expect(pane()?.className).toBe('contents')
+  })
+
+  it('does not remount the transcript across the round trip', async () => {
+    await render()
+    const before = marker()
+    expect(before).not.toBeNull()
+
+    nav.search = 'file=src%2Fnotes.md'
+    await render()
+    expect(marker()).toBe(before)
+
+    await press('[data-viewer-close]')
+    // The SAME DOM node, not an equal one: a remount would have built a new element and thrown away every piece of state hanging off it.
+    expect(marker()).toBe(before)
+  })
+
+  it('takes the full width of the body column, and never the dock track', async () => {
+    await render()
+    const column = container?.querySelector('[data-conversation-pane]')?.parentElement
+    expect(column?.className).toContain('max-w-[880px]')
+
+    nav.search = 'file=src%2Fnotes.md'
+    await render()
+    expect(column?.className).not.toContain('max-w-[880px]')
+    const track = container?.querySelector('[data-dock-track]')
+    expect(track?.className).toContain('w-[var(--dock-width)]')
+    expect(track?.className).toContain('wide:block')
+  })
+
+  it('renders the not-found state for a path this checkout does not have', async () => {
+    wire.fileExists = false
+    nav.search = 'file=src%2Fgone.ts'
+    await render()
+    expect(text()).toContain('this checkout has no file at that path')
+    expect(viewer()).toBeNull()
+    expect(pane()?.className).toBe('hidden')
+  })
+})
+
+describe('the dock, now that a second tab exists', () => {
+  it('draws exactly one panel at a time, whichever tab is active', async () => {
+    // Both panels stay MOUNTED, so "is the Files body in the document" cannot answer this — the question is which wrapper is the active one.
+    await render()
+    const active = () => Array.from(container?.querySelectorAll('[data-dock-panel][data-dock-panel-active]') ?? [])
+    expect(active()).toHaveLength(1)
+    expect(active()[0]?.querySelector('[data-files-panel]')).toBeNull()
+
+    await act(async () => {
+      container?.querySelector<HTMLElement>('[data-dock-tab="files"]')?.click()
+      await Promise.resolve()
+    })
+    await render()
+    expect(active()).toHaveLength(1)
+    expect(active()[0]?.querySelector('[data-files-panel]')).not.toBeNull()
+  })
+
+  it('offers both tabs and keeps the reserved track', async () => {
+    await render()
+    expect(container?.querySelector('[data-dock-tab="sessions"]')).not.toBeNull()
+    expect(container?.querySelector('[data-dock-tab="files"]')).not.toBeNull()
+    // The Files tab's own header action, drawn only while that tab is the active one.
+    expect(container?.querySelector('[data-dock-action="files"]')).toBeNull()
+  })
+
+  it('says which kind of nothing the Sessions tab has, which M0 could not because the dock withheld its chrome', async () => {
+    // One session, no family, an untouched filter: the Sessions verdict is a settled hide. With Files ready beside it the dock is no longer `vacant`, so the placeholder branch is reachable for the first time.
+    await render()
+    expect(container?.querySelector('[role=\"tablist\"]')).not.toBeNull()
+    expect(container?.querySelector('[data-dock-empty]')?.textContent).toContain('Nothing to show')
+    expect(container?.querySelector('[data-dock-loading]')).toBeNull()
+  })
+
+  it('gives the Files tab its refresh action once it is the tab on screen', async () => {
+    await render()
+    await act(async () => {
+      container?.querySelector<HTMLElement>('[data-dock-tab=\"files\"]')?.click()
+      await Promise.resolve()
+    })
+    const action = container?.querySelector('[data-dock-action="files"]')
+    expect(action?.getAttribute('aria-label')).toBe('Refresh files')
+    expect(container?.querySelector('[data-dock-empty]')).toBeNull()
+    const listsBefore = wire.listCalls.length
+    await act(async () => {
+      ;(action as HTMLElement | null)?.click()
+      await Promise.resolve()
+    })
+    expect(wire.listCalls.length).toBeGreaterThan(listsBefore)
+  })
+})
+
+describe('the collapsed-band overlay', () => {
+  it('closes when a file opens, because the drawer covers the pane the file lands in', async () => {
+    await render()
+    const trigger = container?.querySelector<HTMLElement>('[data-dock-trigger]')
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false')
+    await act(async () => {
+      trigger?.click()
+      await Promise.resolve()
+    })
+    expect(container?.querySelector('[data-dock-trigger]')?.getAttribute('aria-expanded')).toBe('true')
+    expect(container?.querySelector('[data-dock-scrim]')).not.toBeNull()
+
+    nav.search = 'file=src%2Fnotes.md'
+    await render()
+    expect(container?.querySelector('[data-dock-trigger]')?.getAttribute('aria-expanded')).toBe('false')
+    expect(container?.querySelector('[data-dock-scrim]')).toBeNull()
+  })
+})
+
+describe('the workspace scope both surfaces read', () => {
+  it('reads this session\u2019s own worktree when it has one', async () => {
+    nav.search = 'file=src%2Fnotes.md'
+    await render()
+    expect(wire.fileCalls.at(-1)).toEqual({ path: 'src/notes.md', sessionId: 'session-1' })
+    expect(wire.listCalls[0]).toEqual({ path: '', sessionId: 'session-1' })
+  })
+
+  it('never asks a shared workspace for a session worktree', async () => {
+    // The daemon answers a shared workspace's sessionId with BAD_PAYLOAD, which the CP maps to a 503 reading \u201cthe daemon may be offline\u201d \u2014 so the scope has to be decided here, not discovered there.
+    wire.isolation = 'shared'
+    nav.search = 'file=src%2Fnotes.md'
+    await render()
+    expect(wire.fileCalls.at(-1)).toEqual({ path: 'src/notes.md' })
+    expect(wire.listCalls[0]).toEqual({ path: '' })
+  })
+})
+
+describe('the viewer route', () => {
+  it('round-trips a nested path whose every segment has to be encoded', async () => {
+    // A slash separator, a space, a `+` (which decodes back to a space if the param was written as a query value), parens and non-ASCII — the encoder has to survive all of them in both directions.
+    const clickRow = async (text: string) => {
+      const row = Array.from(container?.querySelectorAll<HTMLElement>('[data-dock-panel] button') ?? []).find(
+        (button) => button.textContent?.includes(text)
+      )
+      expect(row, `no row for ${text}`).not.toBeNull()
+      await act(async () => {
+        row?.click()
+        await Promise.resolve()
+      })
+      await render()
+    }
+
+    await render()
+    // Opened from the Files tree, which is what writes the param.
+    await clickRow('Files')
+    await clickRow(NASTY_DIR)
+    await clickRow(NASTY_FILE)
+
+    const full = `${NASTY_DIR}/${NASTY_FILE}`
+    const written = nav.replaced.at(-1) ?? ''
+    const query = written.slice(written.indexOf('?') + 1)
+    // Asserted as PROPERTIES rather than against a copy of the encoder, which could not catch the encoder being wrong: it is encoded at all, and it decodes to exactly the bytes the daemon is asked for.
+    expect(query).not.toContain(' ')
+    expect(query).not.toContain(full)
+    expect(new URLSearchParams(query).get('file')).toBe(full)
+    expect(wire.fileCalls.at(-1)?.path).toBe(full)
+  })
+
+  it('replaces rather than pushes, so reading N files costs no history entries', async () => {
+    nav.search = 'file=a.ts'
+    await render()
+    await press('[data-viewer-close]')
+    expect(nav.pushed).toEqual([])
+    expect(nav.replaced.length).toBeGreaterThan(0)
+  })
+
+  it('keeps every other query param it found', async () => {
+    nav.search = 'view=flat&file=a.ts'
+    await render()
+    await press('[data-viewer-close]')
+    expect(nav.replaced.at(-1)).toBe('/acme/sessions/session-1?view=flat')
+  })
+})

--- a/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
@@ -435,6 +435,43 @@ describe('the viewer route', () => {
     expect(wire.fileCalls.at(-1)?.path).toBe(full)
   })
 
+  it('asks for the bytes the param carries, whitespace and all', async () => {
+    // A POSIX filename may begin or end with a space. `URLSearchParams` round-trips those bytes, so trimming here would ask the daemon for a DIFFERENT file — and a name made only of spaces would close the viewer instead of opening it.
+    nav.search = `file=${encodeURIComponent(' padded .ts ')}`
+    await render()
+    expect(wire.fileCalls.at(-1)?.path).toBe(' padded .ts ')
+    expect(viewer()).not.toBeNull()
+  })
+
+  it('records which workspace the path was read from, and reopens against that one', async () => {
+    // Header focus is component state that defaults to the current representative, and on a merged conversation that representative moves as another participant becomes newest — so a link carrying only `file` reopens someone else's checkout under the same path.
+    await render()
+    await act(async () => {
+      container?.querySelector<HTMLElement>('[data-dock-tab="files"]')?.click()
+      await Promise.resolve()
+    })
+    await render()
+    const row = Array.from(container?.querySelectorAll<HTMLElement>('[data-dock-panel] button') ?? []).find((button) =>
+      button.textContent?.includes('notes.md')
+    )
+    await act(async () => {
+      row?.click()
+      await Promise.resolve()
+    })
+    await render()
+    const written = new URLSearchParams((nav.replaced.at(-1) ?? '').split('?')[1] ?? '')
+    expect(written.get('file')).toBe('notes.md')
+    expect(written.get('agent')).toBe('agent-1')
+  })
+
+  it('drops the workspace along with the file, so a closed viewer leaves no scope behind', async () => {
+    nav.search = 'file=a.ts&agent=agent-1'
+    await render()
+    await press('[data-viewer-close]')
+    expect(nav.replaced.at(-1)).not.toContain('agent=')
+    expect(nav.replaced.at(-1)).not.toContain('file=')
+  })
+
   it('replaces rather than pushes, so reading N files costs no history entries', async () => {
     nav.search = 'file=a.ts'
     await render()

--- a/packages/web/src/components/console/workspace-tree.test.tsx
+++ b/packages/web/src/components/console/workspace-tree.test.tsx
@@ -1,0 +1,112 @@
+// The shared workspace read model's pure halves: the git-status join a tree's badges come from, and the row glyph. The hooks are exercised through their consumers (dock/FilesPanel.test.tsx, WorkspaceFiles.test.tsx).
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { StatusBadge, workspaceDirtyMap, workspaceEntryIcon } from './workspace-tree'
+import type { WorkspaceGitFileDto, WorkspaceGitStatusDto } from '@/lib/api'
+
+function status(files: WorkspaceGitFileDto[], agentDir: string | null = null): WorkspaceGitStatusDto {
+  return {
+    isRepo: true,
+    clean: files.length === 0,
+    repo: 'https://github.com/acme/repo.git',
+    agentDir,
+    branch: 'main',
+    tracking: 'origin/main',
+    ahead: 0,
+    behind: 0,
+    files,
+    truncated: false,
+    lastCommit: null,
+    lastFetchAt: null
+  }
+}
+
+const file = (path: string, index: string, workingDir: string): WorkspaceGitFileDto => ({ path, index, workingDir })
+
+describe('workspaceDirtyMap', () => {
+  it('has nothing to join without a status', () => {
+    // A scratch workspace and an offline daemon both arrive as null, and neither may badge a row.
+    expect(workspaceDirtyMap(null).size).toBe(0)
+  })
+
+  it('takes the working-tree letter when nothing is staged', () => {
+    // ' M' — X is a space, so the letter has to come from Y.
+    expect(workspaceDirtyMap(status([file('src/a.ts', ' ', 'M')])).get('src/a.ts')).toBe('M')
+  })
+
+  it('reads untracked off either half of the pair', () => {
+    const m = workspaceDirtyMap(status([file('new.ts', '?', '?'), file('half.ts', ' ', '?')]))
+    expect(m.get('new.ts')).toBe('U')
+    expect(m.get('half.ts')).toBe('U')
+  })
+
+  it('shows the STAGED half of a file that is both staged and dirty', () => {
+    // 'AM' = staged addition, edited since; 'MM' = staged edit, edited since. One letter cannot carry both, and the index char is the one that wins — the unstaged half is invisible here by design.
+    const m = workspaceDirtyMap(
+      status([file('added.ts', 'A', 'M'), file('twice.ts', 'M', 'M'), file('gone.ts', 'D', ' ')])
+    )
+    expect(m.get('added.ts')).toBe('A')
+    expect(m.get('twice.ts')).toBe('M')
+    expect(m.get('gone.ts')).toBe('D')
+  })
+
+  it('falls back to M for a pair with no letters at all', () => {
+    expect(workspaceDirtyMap(status([file('odd.ts', ' ', ' ')])).get('odd.ts')).toBe('M')
+  })
+
+  it('also indexes the agentDir-relative path, because git paths are repo-relative', () => {
+    // The daemon lists from the repo SUBDIR the agent runs in, so 'apps/web/src/a.ts' has to be reachable as 'src/a.ts' too or the badge lands on nothing.
+    const m = workspaceDirtyMap(status([file('apps/web/src/a.ts', 'M', ' ')], 'apps/web'))
+    expect(m.get('apps/web/src/a.ts')).toBe('M')
+    expect(m.get('src/a.ts')).toBe('M')
+  })
+
+  it('normalizes a ./-prefixed or trailing-slash agentDir', () => {
+    expect(workspaceDirtyMap(status([file('apps/web/a.ts', 'M', ' ')], './apps/web/')).get('a.ts')).toBe('M')
+  })
+
+  it('leaves paths outside the agentDir alone', () => {
+    // A sibling directory shares no prefix, so nothing may be re-indexed off it.
+    const m = workspaceDirtyMap(status([file('apps/api/a.ts', 'M', ' ')], 'apps/web'))
+    expect(m.get('apps/api/a.ts')).toBe('M')
+    expect([...m.keys()]).toEqual(['apps/api/a.ts'])
+  })
+
+  it('keeps the first letter written for a path, not the last', () => {
+    const m = workspaceDirtyMap(status([file('dup.ts', 'A', ' '), file('dup.ts', 'D', ' ')]))
+    expect(m.get('dup.ts')).toBe('A')
+  })
+
+  it('rolls nothing up to the directory that contains a changed file', () => {
+    // Only file rows carry a badge; a folder row that implied a dirty descendant would be inventing a wire field.
+    const m = workspaceDirtyMap(status([file('src/a.ts', 'M', ' ')]))
+    expect(m.has('src')).toBe(false)
+  })
+})
+
+describe('workspaceEntryIcon', () => {
+  const entry = (name: string, type: 'dir' | 'file' | 'symlink' | 'other') => ({ name, type, size: null, mtime: null })
+
+  it('separates the four listing types', () => {
+    expect(workspaceEntryIcon(entry('src', 'dir'))).toBe('folder')
+    expect(workspaceEntryIcon(entry('link', 'symlink'))).toBe('link-2')
+    expect(workspaceEntryIcon(entry('sock', 'other'))).toBe('file-question-mark')
+  })
+
+  it('picks the code glyph off the extension for a plain file', () => {
+    expect(workspaceEntryIcon(entry('a.ts', 'file'))).toBe('file-code')
+    expect(workspaceEntryIcon(entry('NOTES', 'file'))).toBe('file-text')
+  })
+})
+
+describe('StatusBadge', () => {
+  it('names and colours each letter it can be handed', () => {
+    // The colour is the only thing separating an addition from a deletion at 15px, and the title is the only thing separating either for a screen reader.
+    expect(renderToStaticMarkup(<StatusBadge ch="U" />)).toContain('title="Untracked (uncommitted)"')
+    expect(renderToStaticMarkup(<StatusBadge ch="A" />)).toContain('title="Added (uncommitted)"')
+    expect(renderToStaticMarkup(<StatusBadge ch="D" />)).toContain('var(--red-500)')
+    expect(renderToStaticMarkup(<StatusBadge ch="R" />)).toContain('title="Renamed (uncommitted)"')
+    expect(renderToStaticMarkup(<StatusBadge ch="M" />)).toContain('title="Modified (uncommitted)"')
+  })
+})

--- a/packages/web/src/components/console/workspace-tree.tsx
+++ b/packages/web/src/components/console/workspace-tree.tsx
@@ -3,7 +3,7 @@
 // The live workspace read model, shared by the agent-detail file browser and the dock's Files panel: the per-directory listing cache with its cursor paging and expand set, the git status a tree's badges join against, and that badge.
 // Listings and status are proxied through the CP straight from the owning daemon (body-locality), so a rejected read means that daemon is offline or the agent is unplaced — an expected state every consumer renders as data.
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   ApiError,
   fetchWorkspaceFiles,
@@ -60,6 +60,8 @@ export interface WorkspaceTree {
 export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTick = 0): WorkspaceTree {
   const [dirs, setDirs] = useState<Record<string, WorkspaceDirState>>({})
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
+  // Which checkout+refresh a reply was asked for. The panel SURVIVES a scope change, so an in-flight directory read from the previous agent or worktree would otherwise splice its entries into the new one's cache — and worse, leave `dirs[path]` populated, so expanding that folder in the new scope skips the fetch that would have corrected it.
+  const generation = useRef(0)
 
   // Patch one directory's state, seeding from LOADING_DIR when first seen.
   const patchDir = useCallback(
@@ -71,9 +73,11 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
   // Fetch a folder's first page (a folder on first expand, or one typed into a path).
   const loadDir = useCallback(
     (path: string) => {
+      const gen = generation.current
       patchDir(path, { loading: true, err: null, errStatus: null })
       fetchWorkspaceFiles(agentId, { path, ...(sessionId ? { sessionId } : {}) }).then(
-        (page) =>
+        (page) => {
+          if (gen !== generation.current) return
           setDirs((prev) => ({
             ...prev,
             [path]: {
@@ -86,8 +90,12 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
               errStatus: null,
               moreErr: null
             }
-          })),
-        (e) => patchDir(path, { loading: false, err: msg(e), errStatus: statusOf(e) })
+          }))
+        },
+        (e) => {
+          if (gen !== generation.current) return
+          patchDir(path, { loading: false, err: msg(e), errStatus: statusOf(e) })
+        }
       )
     },
     [agentId, patchDir, sessionId]
@@ -97,9 +105,11 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
     (path: string) => {
       const d = dirs[path]
       if (!d?.nextCursor || d.loadingMore) return
+      const gen = generation.current
       patchDir(path, { loadingMore: true, moreErr: null })
       fetchWorkspaceFiles(agentId, { path, cursor: d.nextCursor, ...(sessionId ? { sessionId } : {}) }).then(
-        (page) =>
+        (page) => {
+          if (gen !== generation.current) return
           setDirs((prev) => {
             const cur = prev[path]
             if (!cur) return prev
@@ -112,8 +122,12 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
                 loadingMore: false
               }
             }
-          }),
-        (e) => patchDir(path, { loadingMore: false, moreErr: msg(e) })
+          })
+        },
+        (e) => {
+          if (gen !== generation.current) return
+          patchDir(path, { loadingMore: false, moreErr: msg(e) })
+        }
       )
     },
     [agentId, dirs, patchDir, sessionId]
@@ -146,12 +160,15 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
 
   // Reset the tree and load the root whenever the scope changes or a refresh lands.
   useEffect(() => {
-    let active = true
+    // Bumped FIRST, so any directory read still in flight for the previous checkout is already fenced by the time this one's root lands.
+    generation.current += 1
+    const gen = generation.current
+    const active = () => gen === generation.current
     setDirs({ '': { ...LOADING_DIR } })
     setExpanded(new Set())
     fetchWorkspaceFiles(agentId, { path: '', ...(sessionId ? { sessionId } : {}) }).then(
       (page) => {
-        if (!active) return
+        if (!active()) return
         setDirs({
           '': {
             entries: page.entries,
@@ -166,11 +183,12 @@ export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTic
         })
       },
       (e) => {
-        if (active) setDirs({ '': { ...LOADING_DIR, loading: false, err: msg(e), errStatus: statusOf(e) } })
+        if (active()) setDirs({ '': { ...LOADING_DIR, loading: false, err: msg(e), errStatus: statusOf(e) } })
       }
     )
     return () => {
-      active = false
+      // A teardown is its own generation change: the next mount's reads must not be answered by this one's.
+      generation.current += 1
     }
   }, [agentId, refreshTick, sessionId])
 

--- a/packages/web/src/components/console/workspace-tree.tsx
+++ b/packages/web/src/components/console/workspace-tree.tsx
@@ -1,0 +1,285 @@
+'use client'
+
+// The live workspace read model, shared by the agent-detail file browser and the dock's Files panel: the per-directory listing cache with its cursor paging and expand set, the git status a tree's badges join against, and that badge.
+// Listings and status are proxied through the CP straight from the owning daemon (body-locality), so a rejected read means that daemon is offline or the agent is unplaced — an expected state every consumer renders as data.
+
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ApiError,
+  fetchWorkspaceFiles,
+  fetchWorkspaceGitStatus,
+  type WorkspaceEntryDto,
+  type WorkspaceGitStatusDto
+} from '@/lib/api'
+import { fileBrowserGlyph } from '@/components/console/FileBrowser'
+
+const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
+// The CP's status separates an offline daemon (503) from one too old for session worktrees (409) and a session whose worktree the viewer cannot read (404); a consumer that wants those apart needs the number, not the flattened message.
+const statusOf = (e: unknown) => (e instanceof ApiError ? e.status : null)
+
+/** Per-directory listing state, keyed by directory path ('' = workspace root). Loaded lazily: the root on mount, each folder on first expand. */
+export interface WorkspaceDirState {
+  entries: WorkspaceEntryDto[] | null
+  exists: boolean
+  nextCursor: string | null
+  loading: boolean
+  loadingMore: boolean
+  /** Initial-load failure — no entries yet. */
+  err: string | null
+  /** That failure's HTTP status, when it had one. */
+  errStatus: number | null
+  /** Append (Load more) failure — keeps the rows already loaded. */
+  moreErr: string | null
+}
+
+const LOADING_DIR: WorkspaceDirState = {
+  entries: null,
+  exists: true,
+  nextCursor: null,
+  loading: true,
+  loadingMore: false,
+  err: null,
+  errStatus: null,
+  moreErr: null
+}
+
+export interface WorkspaceTree {
+  /** Every directory fetched so far. Nothing is evicted — the cache lives as long as the mount, and is cleared only by a scope change or a refresh. */
+  dirs: Record<string, WorkspaceDirState>
+  /** The root listing; undefined only before the first fetch is dispatched. */
+  root: WorkspaceDirState | undefined
+  expanded: ReadonlySet<string>
+  toggleDir: (path: string) => void
+  loadMoreDir: (path: string) => void
+  /** Open every directory in `paths`, loading each on first open. */
+  openPath: (paths: string[]) => void
+}
+
+/** The tree half of the read model for one daemon-local checkout. `refreshTick` re-runs the root load, deliberately wiping the cache and the expand set with it. */
+// `sessionId` selects that session's isolated worktree; omit it for the primary checkout, and pass it only for a session whose `workspaceIsolation` is `'session'` — the daemon answers a shared-workspace sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline".
+export function useWorkspaceTree(agentId: string, sessionId?: string, refreshTick = 0): WorkspaceTree {
+  const [dirs, setDirs] = useState<Record<string, WorkspaceDirState>>({})
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
+
+  // Patch one directory's state, seeding from LOADING_DIR when first seen.
+  const patchDir = useCallback(
+    (path: string, patch: Partial<WorkspaceDirState>) =>
+      setDirs((prev) => ({ ...prev, [path]: { ...(prev[path] ?? LOADING_DIR), ...patch } })),
+    []
+  )
+
+  // Fetch a folder's first page (a folder on first expand, or one typed into a path).
+  const loadDir = useCallback(
+    (path: string) => {
+      patchDir(path, { loading: true, err: null, errStatus: null })
+      fetchWorkspaceFiles(agentId, { path, ...(sessionId ? { sessionId } : {}) }).then(
+        (page) =>
+          setDirs((prev) => ({
+            ...prev,
+            [path]: {
+              entries: page.entries,
+              exists: page.exists,
+              nextCursor: page.nextCursor,
+              loading: false,
+              loadingMore: false,
+              err: null,
+              errStatus: null,
+              moreErr: null
+            }
+          })),
+        (e) => patchDir(path, { loading: false, err: msg(e), errStatus: statusOf(e) })
+      )
+    },
+    [agentId, patchDir, sessionId]
+  )
+
+  const loadMoreDir = useCallback(
+    (path: string) => {
+      const d = dirs[path]
+      if (!d?.nextCursor || d.loadingMore) return
+      patchDir(path, { loadingMore: true, moreErr: null })
+      fetchWorkspaceFiles(agentId, { path, cursor: d.nextCursor, ...(sessionId ? { sessionId } : {}) }).then(
+        (page) =>
+          setDirs((prev) => {
+            const cur = prev[path]
+            if (!cur) return prev
+            return {
+              ...prev,
+              [path]: {
+                ...cur,
+                entries: [...(cur.entries ?? []), ...page.entries],
+                nextCursor: page.nextCursor,
+                loadingMore: false
+              }
+            }
+          }),
+        (e) => patchDir(path, { loadingMore: false, moreErr: msg(e) })
+      )
+    },
+    [agentId, dirs, patchDir, sessionId]
+  )
+
+  const toggleDir = useCallback(
+    (path: string) => {
+      const willOpen = !expanded.has(path)
+      setExpanded((prev) => {
+        const next = new Set(prev)
+        if (next.has(path)) next.delete(path)
+        else next.add(path)
+        return next
+      })
+      // Collapsing keeps the cached listing, so re-expanding is instant.
+      if (willOpen && !dirs[path]) loadDir(path)
+    },
+    [dirs, expanded, loadDir]
+  )
+
+  const openPath = useCallback(
+    (paths: string[]) => {
+      setExpanded((current) => new Set([...current, ...paths]))
+      for (const path of paths) {
+        if (!dirs[path]) loadDir(path)
+      }
+    },
+    [dirs, loadDir]
+  )
+
+  // Reset the tree and load the root whenever the scope changes or a refresh lands.
+  useEffect(() => {
+    let active = true
+    setDirs({ '': { ...LOADING_DIR } })
+    setExpanded(new Set())
+    fetchWorkspaceFiles(agentId, { path: '', ...(sessionId ? { sessionId } : {}) }).then(
+      (page) => {
+        if (!active) return
+        setDirs({
+          '': {
+            entries: page.entries,
+            exists: page.exists,
+            nextCursor: page.nextCursor,
+            loading: false,
+            loadingMore: false,
+            err: null,
+            errStatus: null,
+            moreErr: null
+          }
+        })
+      },
+      (e) => {
+        if (active) setDirs({ '': { ...LOADING_DIR, loading: false, err: msg(e), errStatus: statusOf(e) } })
+      }
+    )
+    return () => {
+      active = false
+    }
+  }, [agentId, refreshTick, sessionId])
+
+  return { dirs, root: dirs[''], expanded, toggleDir, loadMoreDir, openPath }
+}
+
+/** What the scoped git status resolved to. `none` is a from-scratch workspace and `unavailable` an offline daemon or unplaced agent — a null status alone cannot tell those two apart. */
+export type WorkspaceGitOutcome = 'pending' | 'repo' | 'none' | 'unavailable'
+
+export interface WorkspaceGitRead {
+  /** The live status, or null for a non-repo workspace, an offline daemon, and the window before the first answer. */
+  git: WorkspaceGitStatusDto | null
+  outcome: WorkspaceGitOutcome
+  /** The PRIMARY checkout's branch. Fetched separately in session scope, where the worktree is detached and its own `branch` names no branch. */
+  primaryBranch: string | null
+}
+
+/** The git half of the read model: status for the badges and the footer, plus the branch label a session worktree cannot supply itself. */
+export function useWorkspaceGitStatus(agentId: string, sessionId?: string, refreshTick = 0): WorkspaceGitRead {
+  const [git, setGit] = useState<WorkspaceGitStatusDto | null>(null)
+  const [outcome, setOutcome] = useState<WorkspaceGitOutcome>('pending')
+  const [primaryBranch, setPrimaryBranch] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    setOutcome('pending')
+    fetchWorkspaceGitStatus(agentId, sessionId).then(
+      (s) => {
+        if (!active) return
+        setGit(s.isRepo ? s : null)
+        setOutcome(s.isRepo ? 'repo' : 'none')
+        if (!sessionId) setPrimaryBranch(s.isRepo ? s.branch : null)
+      },
+      () => {
+        if (!active) return
+        setGit(null)
+        setOutcome('unavailable')
+        if (!sessionId) setPrimaryBranch(null)
+      }
+    )
+    if (sessionId) {
+      fetchWorkspaceGitStatus(agentId).then(
+        (s) => {
+          if (active) setPrimaryBranch(s.isRepo ? s.branch : null)
+        },
+        () => {
+          if (active) setPrimaryBranch(null)
+        }
+      )
+    }
+    return () => {
+      active = false
+    }
+  }, [agentId, refreshTick, sessionId])
+
+  return { git, outcome, primaryBranch }
+}
+
+/** Map browse-relative path → one git status letter for the tree badges. git paths are repo-relative, so when the browse root sits in a repo subdir (`agentDir`) the subdir-relative form is indexed too and badges match whichever root the daemon listed from; first write wins. */
+// The XY pair collapses to one letter: untracked ('?' on either side) reads as 'U', otherwise the INDEX char wins — so a staged-then-edited file ('AM') badges its staged half and the unstaged half is invisible. One letter cannot show both, and a panel needing the split has to keep the raw pair. No directory roll-up: only file rows carry a badge.
+export function workspaceDirtyMap(git: WorkspaceGitStatusDto | null): Map<string, string> {
+  const m = new Map<string, string>()
+  if (!git) return m
+  const ad = (git.agentDir ?? '').replace(/^\.?\/*/, '').replace(/\/+$/, '')
+  for (const f of git.files) {
+    const x = (f.index ?? '').trim()
+    const y = (f.workingDir ?? '').trim()
+    const ch = x === '?' || y === '?' ? 'U' : (x || y || 'M').charAt(0)
+    const put = (p: string) => {
+      if (p && !m.has(p)) m.set(p, ch)
+    }
+    put(f.path)
+    if (ad && (f.path === ad || f.path.startsWith(`${ad}/`))) put(f.path.slice(ad.length + 1))
+  }
+  return m
+}
+
+/** The row glyph for one listing entry. */
+export function workspaceEntryIcon(entry: WorkspaceEntryDto): string {
+  if (entry.type === 'dir') return 'folder'
+  if (entry.type === 'symlink') return 'link-2'
+  if (entry.type === 'other') return 'file-question-mark'
+  return fileBrowserGlyph(entry.name)
+}
+
+// A one-letter git status for the tree badge, coloured GitHub-style: modified/renamed amber, added/untracked green, deleted red.
+function statusMeta(ch: string): { color: string; title: string } {
+  switch (ch) {
+    case 'A':
+    case 'U':
+      return { color: 'var(--green-500)', title: ch === 'U' ? 'Untracked' : 'Added' }
+    case 'D':
+      return { color: 'var(--red-500)', title: 'Deleted' }
+    case 'R':
+      return { color: 'var(--amber-500)', title: 'Renamed' }
+    default:
+      return { color: 'var(--amber-500)', title: 'Modified' }
+  }
+}
+
+export function StatusBadge({ ch }: { ch: string }) {
+  const { color, title } = statusMeta(ch)
+  return (
+    <span
+      className="mono inline-flex h-[15px] w-[15px] flex-none items-center justify-center rounded-xs bg-(--surface-sunken) text-[10px] font-bold"
+      title={`${title} (uncommitted)`}
+      style={{ color }}
+    >
+      {ch}
+    </span>
+  )
+}

--- a/packages/web/src/lib/highlight.test.ts
+++ b/packages/web/src/lib/highlight.test.ts
@@ -1,0 +1,37 @@
+// The one thing the viewer header states about a file that is not measured from its bytes: what language it is. A wrong name is worse than none, so an unmapped extension has to answer null.
+
+import { describe, expect, it } from 'vitest'
+import { langForName, languageLabel } from './highlight'
+
+describe('languageLabel', () => {
+  it('names the language a mapped extension highlights as', () => {
+    expect(languageLabel('page.tsx')).toBe('TypeScript')
+    expect(languageLabel('server.mjs')).toBe('JavaScript')
+    expect(languageLabel('main.rs')).toBe('Rust')
+    expect(languageLabel('deploy.sh')).toBe('Shell')
+    expect(languageLabel('README.md')).toBe('Markdown')
+  })
+
+  it('names an extension that only SHARES a highlighter after itself, not after the highlighter', () => {
+    // All four highlight as another language, and calling an HTML file "XML" would be wrong where highlighting it as XML is merely approximate.
+    expect(langForName('index.html')).toBe('xml')
+    expect(languageLabel('index.html')).toBe('HTML')
+    expect(languageLabel('logo.svg')).toBe('SVG')
+    expect(languageLabel('App.vue')).toBe('Vue')
+    expect(langForName('pyproject.toml')).toBe('ini')
+    expect(languageLabel('pyproject.toml')).toBe('TOML')
+    expect(languageLabel('setup.ini')).toBe('INI')
+  })
+
+  it('names the extensionless files the highlighter knows by name', () => {
+    expect(languageLabel('Dockerfile')).toBe('Dockerfile')
+    expect(languageLabel('makefile')).toBe('Makefile')
+  })
+
+  it('answers null rather than guessing at an extension nothing maps', () => {
+    // The highlighter still auto-detects these; auto-detection is just not something to put a name on in a header.
+    expect(languageLabel('notes.wat')).toBeNull()
+    expect(languageLabel('LICENSE')).toBeNull()
+    expect(languageLabel('archive.tar.zst')).toBeNull()
+  })
+})

--- a/packages/web/src/lib/highlight.ts
+++ b/packages/web/src/lib/highlight.ts
@@ -87,6 +87,49 @@ export function langForName(name: string): string | null {
   return NAME_LANG[lower] ?? null
 }
 
+// What to CALL the language, for a viewer header that names what it is showing. Keyed by language id, since that is what the maps above resolve to.
+const LANG_LABEL: Record<string, string> = {
+  typescript: 'TypeScript',
+  javascript: 'JavaScript',
+  json: 'JSON',
+  python: 'Python',
+  go: 'Go',
+  rust: 'Rust',
+  ruby: 'Ruby',
+  java: 'Java',
+  kotlin: 'Kotlin',
+  c: 'C',
+  cpp: 'C++',
+  csharp: 'C#',
+  php: 'PHP',
+  swift: 'Swift',
+  bash: 'Shell',
+  sql: 'SQL',
+  xml: 'XML',
+  css: 'CSS',
+  scss: 'SCSS',
+  less: 'Less',
+  yaml: 'YAML',
+  ini: 'INI',
+  markdown: 'Markdown',
+  dockerfile: 'Dockerfile',
+  makefile: 'Makefile',
+  diff: 'Diff'
+}
+
+// The extensions that share a highlighter with a differently-named language: `.html`/`.svg`/`.vue` all highlight as xml and `.toml` as ini, and calling an HTML file "XML" would be wrong where highlighting it as XML is merely approximate.
+const EXT_LABEL: Record<string, string> = { html: 'HTML', svg: 'SVG', vue: 'Vue', toml: 'TOML' }
+
+/** The language's display name for a file name, or null when no confident mapping exists — the caller then names no language rather than guessing one from auto-detection. */
+export function languageLabel(name: string): string | null {
+  const lower = name.toLowerCase()
+  const ext = lower.includes('.') ? lower.split('.').pop()! : ''
+  const override = ext ? EXT_LABEL[ext] : undefined
+  if (override) return override
+  const lang = langForName(name)
+  return lang ? (LANG_LABEL[lang] ?? null) : null
+}
+
 // Highlight `code`, returning an HTML string of `<span class="hljs-…">` tokens.
 // Uses the mapped language when known and registered, otherwise auto-detects.
 // Returns null if highlighting throws (the caller renders plain text instead).


### PR DESCRIPTION
M1 of [`docs/designs/webchat-side-panels.md`](docs/designs/webchat-side-panels.md), on top of #808. No protocol, daemon or control-plane change — everything here rides `workspace/list`, `workspace/read` and `workspace/gitstatus`, which already exist.

> **Read `SessionDetailView.tsx` with `git diff -w`.** Its diff is 836/743 lines but only **119** are real; the rest is indentation from wrapping the transcript in the conversation-pane div.

## What landed

| File | Role |
| --- | --- |
| `dock/FilesPanel.tsx` | the Files tab — one narrow column, lazy per directory, M/A/D tags, path filter, fetch-time footer |
| `viewer/SessionViewer.tsx` | the left-pane file view: line-numbered, highlighted, paged |
| `workspace-tree.tsx` | extracted from `WorkspaceFiles.tsx` — the tree + git-status read model both surfaces now share |
| `dock/DockPanel` | hosts several panels, drawing one and keeping the rest mounted |

## Decisions worth reviewing

**The conversation pane is concealed, not unmounted.** One JSX slot, `hidden` vs `contents`. Unmounting would spend state a file read has no business spending: every expanded tool body and its refetch, the composer's caret, any open @mention menu (with the `mentionJoining` latch it reports upward, which would have no owner left to clear it). M0 already learned this for the dock's hosted panel, so there is a test asserting mount **identity**, not presence — and a mutation adding `key={viewerOpen ? …}` reddens exactly that test while the presence test stays green.

Accepted cost, stated because it is a real one: a pending webchat MCP write approval is concealed along with the composer and has no header twin the way permission requests do, so a reader who opened a file sees the agent stall until they come back.

**The viewer is URL-addressable** (`?file=<path>`), settling the deep-link question §12 left open. `router.replace`, not `push` — reading ten files should not cost ten Back presses, and Back should still mean leaving the session. This matches the house idiom (`Shell.tsx`, `WorkspaceCard.tsx`, `SettingsView.tsx` all do `new URLSearchParams(searchParams)` + `replace(…, {scroll:false})`).

**The path filter is honest about being a filter.** No server-side path search exists, so it searches only the directories you have opened, and says so — "Matched N of M loaded files. This filters the folders you have opened, not the whole repository." A mutation stripping that qualifier reddens a named test.

**The footer invents nothing.** `synced <time>` from `lastFetchAt`, and when the status list is capped, how far the tags reach. The design's "1,284 files · 62 MB" is dropped: neither number exists without a daemon-side walk. In session scope there is no footer at all, by construction — `lastFetchAt` is `.git/FETCH_HEAD`'s mtime and a linked worktree has no directory for it.

**Files is never `empty`.** A workspace with no files still draws its branch line, its filter and the notice saying *why* it is empty. Reporting `empty` would trade that explanation for the dock's centred "Nothing to show" — and would put `vacant` back in reach beside a settled-empty Sessions tab, where the dock withholds all its chrome and the tab a reader asked for cannot be opened at all.

## Verification

132 files / 1288 tests, typecheck, eslint, prettier clean. The adversarial pass ran ~50 mutations across the diff; all but eight reddened a specifically named test, and the eight are either equivalent mutants or were fixed in this branch.

Six things it caught that the build had claimed were fine, all fixed here:

- **A focus-trap regression.** `focusStops` collected controls from the whole panel, including the inactive `DockPanel` that M1 is the first milestone to create. Since that panel is `display:none`, `.focus()` on its controls is a no-op — Shift+Tab off the panel box became a dead key, and forward Tab walked out past the scrim for one press. happy-dom does not enforce visibility, which is why the M0 tests could not see it.
- **A one-frame wrong-file paint.** The viewer reset its slice in a passive effect, which runs after paint, so one committed frame showed the previous file's bytes — and its line count and size — under the new file's name. Fixed with `key={viewerPath}`; the codebase already guards this exact hazard for the transcript (`transcriptMatchesSession`).
- **Two of four session-scope call sites were unpinned.** Dropping `sessionId` from the subdirectory listing or the cursor page left every test green, so §2's session-scope invariant was half-guarded. Both now redden a test.
- **A mislabelled test.** `it('round-trips a path with slashes and spaces')` exercised `notes.md`. It now uses `my dir+x/ノート a+b (1).md`, and asserts the round-trip as *properties* — encoded at all, decodes to exactly the bytes the daemon is asked for — rather than against a copy of the encoder, which could not catch the encoder being wrong.
- **Both panels could draw at once** with zero tests red. Now pinned.
- **The workdir label** named the primary checkout while the tree below listed the session worktree; it carries the same disclaimer the branch beside it already had.

## Known follow-ups, recorded in §9

- A `?file=` naming a **directory**, or a path escaping the workspace, reads as "the daemon may be offline": the daemon raises `WorkspaceViolationError`, the CP maps it to 503, and the web cannot tell it from a real outage. Fixing it needs a daemon/CP error code, so it waits for the next milestone that touches those layers.
- The filter corpus is rebuilt and sorted on every folder expansion even while the box is empty.
- Two app-wiring mutants survive: dropping the Files tab when `filesAgentId` is null, and the `dockTabKey` existence fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
