### PR TITLE
feat(daemon): add the in-sandbox shim and its bind-on-callback handshake

### DIFF
--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -1,0 +1,127 @@
+# Cluster Spawn and the In-Sandbox Shim
+
+How a daemon runs an agent's ACP runtime in a Kubernetes sandbox pod instead of as a
+local child process, and how the two halves talk. Companion to
+[cli-daemon-split.md](cli-daemon-split.md) §7 (trust boundaries) and
+[daemon-detailed-design.md](daemon-detailed-design.md) §2.6 (`--cloud`).
+
+Staged scope: this describes the mechanism. The hardened security model — an isolating
+runtimeClass, admission policy, egress control, and a managed egress proxy so a provider
+key never enters the sandbox — is a separate, later plan. Until it lands, the pod and the
+per-org namespace are the only isolation boundaries, and a provider key is present inside
+the sandbox, so this shape suits internal dogfooding and self-hosted
+bring-your-own-key.
+
+## 1. Why a seam at all
+
+`AcpHost` used to own two unrelated jobs: the ACP protocol, and the mechanics of a child
+process (PATH resolution, sandbox wrapping, process groups, signal escalation). Only the
+first is about ACP; the second is about _where the runtime lives_, which is exactly what
+changes when it moves into a pod.
+
+`SpawnDriver` (`src/acp/spawn-driver.ts`) is that seam. It is deliberately narrow — a
+byte-stream pair plus a lifecycle:
+
+```ts
+interface SpawnedRuntime {
+  toAgent: WritableStream<Uint8Array>
+  fromAgent: ReadableStream<Uint8Array>
+  onExit(listener: () => void): void
+  stop(deadlineMs: number): Promise<void>
+}
+```
+
+`ndJsonStream` and the ACP client were already transport-agnostic, so the protocol layer
+never needed to know about processes.
+
+Two resolutions live _below_ the seam rather than above it: the command lookup and the
+`CLAUDE_CODE_EXECUTABLE` fallback. Both search a filesystem, and only the driver knows
+which filesystem the runtime will see — a daemon-side lookup would hand a sandbox pod
+absolute paths from the daemon pod. The host states the policy as a declarative hint; the
+driver performs the lookup where it applies.
+
+## 2. The shim, and why it dials out
+
+Once the runtime is in another pod, everything the daemon used to do by sharing a
+filesystem and a set of unix sockets needs an explicit protocol: materializing secrets and
+config files, proxying the git-credential and `gh` helper sockets, the MCP bridge, and the
+whole workspace git orchestration. The **shim** is the thin arm inside the sandbox that
+performs those, and it holds no policy — every decision stays in the daemon.
+
+**The shim dials out; the daemon listens.** The sandbox therefore needs zero inbound: its
+NetworkPolicy keeps an empty ingress list and no per-sandbox Service exists. The reverse
+direction would need a Service per sandbox, an ingress allowance, and a readiness probe —
+all surface for nothing.
+
+## 3. Binding: proving which pod is calling
+
+A shim connection must be bound to the pod it claims to be, before it is given anything.
+
+Two tempting shortcuts are wrong, and both were rejected explicitly:
+
+- **A bootstrap token in the SandboxClaim.** A claim carrying non-empty `env` bypasses
+  warm-pool adoption, and claim env does not propagate to a rebuilt pod — so after a
+  resume or an eviction the pod would hold only an exhausted token and the wake path would
+  deadlock.
+- **Reverse-looking the source IP.** Pod IPs are reusable and the Sandbox status that
+  mirrors them is asynchronous. Inside that stale window, a sibling sandbox in the same
+  namespace could present a just-recycled IP and claim a victim agent's channel. The
+  connection's source address is therefore a logging and correlation hint only, never a
+  trust input.
+
+What is used instead is the pod's own Kubernetes credential:
+
+1. the pod template mounts an **audience-restricted projected ServiceAccount token**
+   (minute-scale TTL, rotated by the kubelet, invalid the moment the pod is gone) and pins
+   a dedicated runtime ServiceAccount that holds **no RoleBindings**. Audience-restricted
+   plus permissionless means the token is useless anywhere except proving "I am this pod"
+   to this endpoint;
+2. the shim reads it and dials the daemon, presenting it as its only claim;
+3. the daemon calls **TokenReview** with the expected audience — omitting the audience
+   would accept a token minted for something else entirely — and takes the bound pod
+   name/UID from the response;
+4. the daemon maps that pod to its own spawn record. No match, no binding: an
+   authenticated pod that this daemon did not launch binds to nothing;
+5. **only then** is a session credential issued, short-lived and bound to this pod and
+   generation.
+
+Because the identity is the pod's own rotating credential, first bind, resume from
+suspension, and eviction/rescheduling are indistinguishable to the protocol: each new pod
+simply presents its own token. There is no one-shot token that can be revived.
+
+Rejections carry one coarse reason and a message that names no pod, token, or agent, so
+the endpoint cannot be probed for valid identities.
+
+## 4. The five invariants, and where they are enforced
+
+1. **Mutual authentication** — the shim proves its pod through TokenReview; the daemon
+   proves itself by being the only party that can issue a working session credential.
+2. **Binding identity** — a connection is bound to (sandbox UID, pod UID, org, agent,
+   generation), and only to a pod matching a live spawn record.
+3. **Per-operation capability** — holding the channel is not holding every operation on
+   it. Each request is authorized against the grants of that launch, so one runtime can
+   never reach another's credentials.
+4. **Replay fence** — every post-binding frame carries its generation; a frame from a
+   previous pod incarnation is refused, and a re-bind drops the superseded credential.
+5. **No long-lived credential in the sandbox** — what the shim holds expires and is
+   re-obtained by re-handshaking. It never holds an org-scoped credential.
+
+These are enforced through **one predicate**, `ShimBindingRegistry.authorize`
+(`src/shim/binding.ts`): credential (compared in constant time), expiry, generation,
+capability. There is no other way to turn a credential into a binding, so a channel added
+later cannot accidentally skip a check — an invariant is only as strong as its weakest
+enforcement point, and spreading these across call sites is how one gets missed.
+
+The shim re-checks the credential, generation, and grant before serving, rather than
+trusting that the daemon already did. That is deliberate redundancy on the boundary that
+matters most.
+
+## 5. What is not in the channel
+
+The workspace git orchestration is _executed_ in the sandbox through the shim, but its
+logic stays in the daemon. Moving that logic into the shim would look like code reuse and
+would actually be a trust-boundary move: the shim is the half-trusted side.
+
+`exec` takes an argv array and never composes a shell string, and path containment is
+re-checked on the shim side — a daemon-side check cannot assume anything about the shim's
+environment.

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "agent:chat": "tsx src/index.ts --agents-dir ./test/fixtures/sample-agent chat",
     "agent:run": "tsx src/index.ts --agents-dir ./test/fixtures/sample-agent run",
-    "build": "pnpm --filter '{.}^...' build && tsdown && node scripts/prepare-bundled-skills.mjs && node scripts/assert-self-contained.mjs",
+    "build": "pnpm --filter '{.}^...' build && tsdown && tsdown --config tsdown.shim.config.ts && node scripts/prepare-bundled-skills.mjs && node scripts/assert-self-contained.mjs",
     "clean": "rm -rf dist",
     "dev": "tsx watch src/index.ts run",
     "prepack": "pnpm run build",

--- a/packages/daemon/scripts/assert-self-contained.mjs
+++ b/packages/daemon/scripts/assert-self-contained.mjs
@@ -68,4 +68,32 @@ for (const arch of ['x64', 'arm64']) {
   }
 }
 
+// The in-sandbox shim is a SEPARATE bundle, and its self-containment is a stronger
+// requirement than the daemon's: it ships in the runtime image, so a relative import here
+// means the image must also carry the daemon's chunk graph — its CP client, platform SDKs
+// and credential paths — into the half-trusted sandbox. One file, or the build fails.
+const shimPath = new URL('../dist/shim/index.js', import.meta.url)
+if (!existsSync(shimPath)) {
+  console.error('✗ shim bundle is missing — `tsdown --config tsdown.shim.config.ts` did not run')
+  process.exit(1)
+}
+const shim = readFileSync(shimPath, 'utf8')
+const shimSpecs = [
+  ...shim.matchAll(/\bfrom\s*["']([^"']+)["']/g),
+  ...shim.matchAll(/\bimport\(\s*["']([^"']+)["']\s*\)/g)
+].map((match) => match[1])
+const shimLeaked = shimSpecs.filter((spec) => !spec.startsWith('node:'))
+if (shimLeaked.length > 0) {
+  console.error(
+    '✗ shim bundle is not self-contained — it imports outside node: builtins:\n' +
+      [...new Set(shimLeaked)]
+        .sort()
+        .map((s) => `    ${s}`)
+        .join('\n') +
+      '\n  It ships alone in the runtime image, so every dependency must be inlined.\n'
+  )
+  process.exit(1)
+}
+
 console.log('✓ daemon bundle is self-contained (including skills CLI 1.5.21 and SRT seccomp helpers)')
+console.log('✓ shim bundle is self-contained (node: builtins only)')

--- a/packages/daemon/src/shim/binding.ts
+++ b/packages/daemon/src/shim/binding.ts
@@ -126,11 +126,19 @@ export class ShimBindingRegistry {
     return { ok: true, binding: match }
   }
 
-  /** Drop a pod's binding — its sandbox went away, or the agent was deleted. */
-  revokePod(podUid: string): void {
-    const credential = this.credentialByPod.get(podUid)
-    if (credential) this.byCredential.delete(credential)
-    this.credentialByPod.delete(podUid)
+  /**
+   * Revoke exactly the credential given, leaving any newer one for the same pod intact.
+   *
+   * Compare-and-delete rather than delete-by-pod: a same-pod renewal re-points the pod
+   * index at the replacement before the superseded socket finishes closing, so revoking
+   * "whatever this pod currently holds" from that late close would delete the credential
+   * the live channel is using — renewal would appear to succeed and then silently die.
+   */
+  revokeIssued(credential: string): void {
+    const binding = this.byCredential.get(credential)
+    if (!binding) return
+    this.byCredential.delete(credential)
+    if (this.credentialByPod.get(binding.podUid) === credential) this.credentialByPod.delete(binding.podUid)
   }
 
   /** Drop every binding for an agent, across pod incarnations. */
@@ -156,8 +164,6 @@ export class ShimBindingRegistry {
   }
 
   private revokeCredential(credential: string): void {
-    const binding = this.byCredential.get(credential)
-    this.byCredential.delete(credential)
-    if (binding) this.credentialByPod.delete(binding.podUid)
+    this.revokeIssued(credential)
   }
 }

--- a/packages/daemon/src/shim/binding.ts
+++ b/packages/daemon/src/shim/binding.ts
@@ -24,6 +24,11 @@ export type AuthorizeFailure =
 
 export type AuthorizeResult = { ok: true; binding: Binding } | { ok: false; failure: AuthorizeFailure }
 
+export type BindResult =
+  | { ok: true; credential: string; binding: Binding; superseded: Binding[] }
+  /** A newer launch already holds this sandbox's channel; the caller must not bind. */
+  | { ok: false; reason: 'superseded_generation'; current: number }
+
 /** Constant-time compare that cannot throw on a length mismatch. */
 function sameSecret(a: string, b: string): boolean {
   const left = Buffer.from(a)
@@ -64,13 +69,17 @@ export class ShimBindingRegistry {
    * credential live and its generation authorized: precisely the replay the fence exists
    * to stop. The superseded bindings are returned so the caller can close their channels.
    */
-  bind(
-    record: SpawnRecord,
-    pod: { name: string; uid: string }
-  ): { credential: string; binding: Binding; superseded: Binding[] } {
+  bind(record: SpawnRecord, pod: { name: string; uid: string }): BindResult {
     const superseded: Binding[] = []
     for (const [credential, existing] of [...this.byCredential]) {
       if (existing.agentId !== record.agentId || existing.sandboxUid !== record.sandboxUid) continue
+      // Monotonic, and mutating nothing when it is not: an older incarnation can bind
+      // AFTER a newer one — a terminating pod reconnecting during overlap, or simply a
+      // slower TokenReview — and replacing the current binding would hand the channel back
+      // to the sandbox that is going away.
+      if (existing.generation >= record.generation) {
+        return { ok: false, reason: 'superseded_generation', current: existing.generation }
+      }
       superseded.push(existing)
       this.byCredential.delete(credential)
       this.credentialByPod.delete(existing.podUid)
@@ -85,7 +94,7 @@ export class ShimBindingRegistry {
     }
     this.byCredential.set(credential, binding)
     this.credentialByPod.set(pod.uid, credential)
-    return { credential, binding, superseded }
+    return { ok: true, credential, binding, superseded }
   }
 
   /**

--- a/packages/daemon/src/shim/binding.ts
+++ b/packages/daemon/src/shim/binding.ts
@@ -27,7 +27,7 @@ export type AuthorizeResult = { ok: true; binding: Binding } | { ok: false; fail
 export type BindResult =
   | { ok: true; credential: string; binding: Binding; superseded: Binding[] }
   /** A newer launch already holds this sandbox's channel; the caller must not bind. */
-  | { ok: false; reason: 'superseded_generation'; current: number }
+  | { ok: false; reason: 'superseded_generation' | 'generation_claimed_by_another_pod'; current: number }
 
 /** Constant-time compare that cannot throw on a length mismatch. */
 function sameSecret(a: string, b: string): boolean {
@@ -73,12 +73,20 @@ export class ShimBindingRegistry {
     const superseded: Binding[] = []
     for (const [credential, existing] of [...this.byCredential]) {
       if (existing.agentId !== record.agentId || existing.sandboxUid !== record.sandboxUid) continue
-      // Monotonic, and mutating nothing when it is not: an older incarnation can bind
-      // AFTER a newer one — a terminating pod reconnecting during overlap, or simply a
-      // slower TokenReview — and replacing the current binding would hand the channel back
-      // to the sandbox that is going away.
-      if (existing.generation >= record.generation) {
+      // Monotonic in the generation, mutating nothing when it is not: an older incarnation
+      // can bind AFTER a newer one — a terminating pod reconnecting during overlap, or
+      // simply a slower TokenReview — and replacing the current binding would hand the
+      // channel back to the sandbox that is going away.
+      if (existing.generation > record.generation) {
         return { ok: false, reason: 'superseded_generation', current: existing.generation }
+      }
+      // Equal generation is the ordinary case, not a duplicate: the generation counts pod
+      // launches, while a credential renewal at half TTL and a reconnect after a dropped
+      // socket both happen inside the SAME pod. Refusing it would strand a healthy pod
+      // permanently unbindable. Equal generation from a DIFFERENT pod is the ambiguous one
+      // — two pods claiming one launch — and stays refused.
+      if (existing.generation === record.generation && existing.podUid !== pod.uid) {
+        return { ok: false, reason: 'generation_claimed_by_another_pod', current: existing.generation }
       }
       superseded.push(existing)
       this.byCredential.delete(credential)

--- a/packages/daemon/src/shim/binding.ts
+++ b/packages/daemon/src/shim/binding.ts
@@ -1,0 +1,132 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import type { ShimCapability } from './protocol.js'
+
+/** What the daemon knows about a sandbox it launched, before any shim dials in. */
+export interface SpawnRecord {
+  agentId: string
+  /** Sandbox object UID — from the Sandbox's own `metadata.uid`; the claim has none. */
+  sandboxUid: string
+  /** Monotonic per-agent counter, incremented on every launch of a new pod. */
+  generation: number
+  /** Capabilities this launch may exercise, decided by the daemon at spawn time. */
+  grants: ShimCapability[]
+}
+
+/** A bound shim connection: the pod that proved its identity plus what it may do. */
+export interface Binding extends SpawnRecord {
+  podName: string
+  podUid: string
+  expiresAtMs: number
+}
+
+export type AuthorizeFailure =
+  'unknown_credential' | 'expired_credential' | 'stale_generation' | 'capability_not_granted'
+
+export type AuthorizeResult = { ok: true; binding: Binding } | { ok: false; failure: AuthorizeFailure }
+
+/** Constant-time compare that cannot throw on a length mismatch. */
+function sameSecret(a: string, b: string): boolean {
+  const left = Buffer.from(a)
+  const right = Buffer.from(b)
+  if (left.length !== right.length) return false
+  return timingSafeEqual(left, right)
+}
+
+/**
+ * The bindings a daemon has issued, and the single place every shim invariant is
+ * enforced.
+ *
+ * Deliberately one predicate rather than checks spread across call sites: the
+ * invariants are only as strong as their weakest enforcement point, so `authorize`
+ * is the sole gate and every channel goes through it. Adding a channel cannot
+ * accidentally skip the generation fence or the capability check, because there is
+ * no other way to resolve a credential into a binding.
+ */
+export class ShimBindingRegistry {
+  private readonly byCredential = new Map<string, Binding>()
+  /** Credential per pod UID, so re-binding the same pod replaces rather than stacks. */
+  private readonly credentialByPod = new Map<string, string>()
+
+  constructor(
+    private readonly now: () => number,
+    private readonly ttlMs: number
+  ) {}
+
+  /**
+   * Issue a credential for a pod that proved its identity and matched a spawn record.
+   * The credential is the only thing the shim ever holds: it is short-lived, bound to
+   * this pod and generation, and re-obtained by re-handshaking, so the shim never
+   * carries a long-lived org credential.
+   */
+  bind(record: SpawnRecord, pod: { name: string; uid: string }): { credential: string; binding: Binding } {
+    const previous = this.credentialByPod.get(pod.uid)
+    if (previous) this.byCredential.delete(previous)
+    const credential = randomBytes(32).toString('base64url')
+    const binding: Binding = {
+      ...record,
+      grants: [...record.grants],
+      podName: pod.name,
+      podUid: pod.uid,
+      expiresAtMs: this.now() + this.ttlMs
+    }
+    this.byCredential.set(credential, binding)
+    this.credentialByPod.set(pod.uid, credential)
+    return { credential, binding }
+  }
+
+  /**
+   * Resolve a frame's credential into a binding, or say why not. Checks, in order:
+   * the credential exists (constant-time), has not expired, the frame's generation is
+   * the bound one, and the capability was granted to this launch.
+   *
+   * The generation check is what makes a replayed frame from a previous pod
+   * incarnation useless: resume and eviction both produce a new generation, and the
+   * old credential is dropped when the same pod re-binds.
+   */
+  authorize(input: { credential: string; generation: number; capability: ShimCapability }): AuthorizeResult {
+    const match = this.find(input.credential)
+    if (!match) return { ok: false, failure: 'unknown_credential' }
+    if (this.now() >= match.expiresAtMs) {
+      this.revokeCredential(input.credential)
+      return { ok: false, failure: 'expired_credential' }
+    }
+    if (input.generation !== match.generation) return { ok: false, failure: 'stale_generation' }
+    if (!match.grants.includes(input.capability)) return { ok: false, failure: 'capability_not_granted' }
+    return { ok: true, binding: match }
+  }
+
+  /** Drop a pod's binding — its sandbox went away, or the agent was deleted. */
+  revokePod(podUid: string): void {
+    const credential = this.credentialByPod.get(podUid)
+    if (credential) this.byCredential.delete(credential)
+    this.credentialByPod.delete(podUid)
+  }
+
+  /** Drop every binding for an agent, across pod incarnations. */
+  revokeAgent(agentId: string): void {
+    for (const [credential, binding] of [...this.byCredential]) {
+      if (binding.agentId !== agentId) continue
+      this.byCredential.delete(credential)
+      this.credentialByPod.delete(binding.podUid)
+    }
+  }
+
+  size(): number {
+    return this.byCredential.size
+  }
+
+  private find(credential: string): Binding | undefined {
+    // Constant-time over the whole set: a plain Map.get would leak whether a guessed
+    // credential shares a prefix with a live one through timing.
+    for (const [known, binding] of this.byCredential) {
+      if (sameSecret(known, credential)) return binding
+    }
+    return undefined
+  }
+
+  private revokeCredential(credential: string): void {
+    const binding = this.byCredential.get(credential)
+    this.byCredential.delete(credential)
+    if (binding) this.credentialByPod.delete(binding.podUid)
+  }
+}

--- a/packages/daemon/src/shim/binding.ts
+++ b/packages/daemon/src/shim/binding.ts
@@ -44,7 +44,7 @@ function sameSecret(a: string, b: string): boolean {
  */
 export class ShimBindingRegistry {
   private readonly byCredential = new Map<string, Binding>()
-  /** Credential per pod UID, so re-binding the same pod replaces rather than stacks. */
+  /** Credential per bound pod UID, for revoking one incarnation by identity. */
   private readonly credentialByPod = new Map<string, string>()
 
   constructor(
@@ -54,13 +54,27 @@ export class ShimBindingRegistry {
 
   /**
    * Issue a credential for a pod that proved its identity and matched a spawn record.
-   * The credential is the only thing the shim ever holds: it is short-lived, bound to
-   * this pod and generation, and re-obtained by re-handshaking, so the shim never
-   * carries a long-lived org credential.
+   * The credential is the only thing the shim ever holds: short-lived, bound to this pod
+   * and generation, re-obtained by re-handshaking, so no long-lived credential is in the
+   * sandbox.
+   *
+   * Binding supersedes every earlier binding for the same launch identity — the agent's
+   * sandbox — NOT merely the same pod UID. A rescheduled or resumed pod arrives with a
+   * NEW UID, so keying supersession on the pod would leave the evicted incarnation's
+   * credential live and its generation authorized: precisely the replay the fence exists
+   * to stop. The superseded bindings are returned so the caller can close their channels.
    */
-  bind(record: SpawnRecord, pod: { name: string; uid: string }): { credential: string; binding: Binding } {
-    const previous = this.credentialByPod.get(pod.uid)
-    if (previous) this.byCredential.delete(previous)
+  bind(
+    record: SpawnRecord,
+    pod: { name: string; uid: string }
+  ): { credential: string; binding: Binding; superseded: Binding[] } {
+    const superseded: Binding[] = []
+    for (const [credential, existing] of [...this.byCredential]) {
+      if (existing.agentId !== record.agentId || existing.sandboxUid !== record.sandboxUid) continue
+      superseded.push(existing)
+      this.byCredential.delete(credential)
+      this.credentialByPod.delete(existing.podUid)
+    }
     const credential = randomBytes(32).toString('base64url')
     const binding: Binding = {
       ...record,
@@ -71,7 +85,7 @@ export class ShimBindingRegistry {
     }
     this.byCredential.set(credential, binding)
     this.credentialByPod.set(pod.uid, credential)
-    return { credential, binding }
+    return { credential, binding, superseded }
   }
 
   /**

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -43,6 +43,8 @@ export class ShimClient {
   private transport?: ShimTransport
   private bound?: ShimBound
   private stopped = false
+  /** Ends the current channel so the supervision loop rebuilds it. */
+  private endChannel?: () => void
   private readonly clock: Clock
   private readonly backoff: Backoff
 
@@ -55,26 +57,79 @@ export class ShimClient {
     return this.bound
   }
 
-  /** Dial and bind, retrying with backoff until stopped. Resolves on first binding. */
-  async start(): Promise<ShimBound> {
-    for (;;) {
-      if (this.stopped) throw new Error('shim: stopped before binding')
-      try {
-        return await this.connectOnce()
-      } catch (err) {
-        if (this.stopped) throw err
-        const delay = this.backoff.next()
-        this.deps.log?.warn(`shim: bind failed, retrying in ${delay}ms (${(err as Error).message})`)
-        await new Promise<void>((resolve) => this.clock.setTimeout(resolve, delay))
-      }
-    }
+  /**
+   * Run the channel for the pod's lifetime, resolving once the FIRST binding succeeds so a
+   * caller can wait for readiness. The supervision loop keeps running after that: a
+   * dropped socket re-dials with backoff, and the credential is renewed by re-handshaking
+   * before it expires.
+   *
+   * Both halves matter. Returning after the first bind and stopping there left a live
+   * executable permanently disconnected after any close, and let the daemon-side credential
+   * expire under a perfectly healthy pod — a channel that works for ten minutes and then
+   * silently never again.
+   */
+  start(): Promise<ShimBound> {
+    return new Promise<ShimBound>((resolve, reject) => {
+      let ready = false
+      void (async () => {
+        for (;;) {
+          if (this.stopped) {
+            if (!ready) reject(new Error('shim: stopped before binding'))
+            return
+          }
+          try {
+            const bound = await this.connectOnce()
+            if (!ready) {
+              ready = true
+              resolve(bound)
+            }
+            // connectOnce resolves at binding; wait here for the channel to end, whether
+            // from a close or from the renewal deadline coming due.
+            await this.runUntilRebindNeeded(bound)
+          } catch (err) {
+            if (this.stopped) {
+              if (!ready) reject(err)
+              return
+            }
+            const delay = this.backoff.next()
+            this.deps.log?.warn(`shim: channel lost, re-dialing in ${delay}ms (${(err as Error).message})`)
+            await new Promise<void>((settle) => this.clock.setTimeout(settle, delay))
+          }
+        }
+      })()
+    })
   }
 
   stop(): void {
     this.stopped = true
     this.bound = undefined
+    this.endChannel?.()
     this.transport?.close(1000, 'shim stopping')
     this.transport = undefined
+  }
+
+  /**
+   * Resolve when the channel needs rebuilding: the socket closed, or the credential is
+   * close enough to expiry to renew. Renewing at half the lifetime leaves a full half as
+   * margin for a slow TokenReview or a re-dial.
+   */
+  private runUntilRebindNeeded(bound: ShimBound): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const renewInMs = Math.max(1_000, Math.floor((bound.expiresInSeconds * 1000) / 2))
+      const timer = this.clock.setTimeout(() => {
+        this.deps.log?.info('shim: renewing the session credential before it expires')
+        finish()
+      }, renewInMs)
+      const finish = (): void => {
+        this.clock.clearTimeout(timer)
+        this.endChannel = undefined
+        this.transport?.close(1000, 'rebinding')
+        this.transport = undefined
+        this.bound = undefined
+        resolve()
+      }
+      this.endChannel = finish
+    })
   }
 
   private async connectOnce(): Promise<ShimBound> {
@@ -94,7 +149,10 @@ export class ShimClient {
       transport.onClose((code, reason) => {
         this.bound = undefined
         if (this.transport === transport) this.transport = undefined
+        // Before binding this fails the dial; after binding it ends the channel so the
+        // supervision loop re-dials instead of leaving the process alive but detached.
         fail(`connection closed (${code}${reason ? ` ${reason}` : ''})`)
+        this.endChannel?.()
       })
       transport.onMessage((text) => {
         const frame = parseShimFrame(text)

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from 'node:fs'
+import { Backoff, systemClock, type Clock } from '@agentconnect.md/connection'
+import {
+  SHIM_IDENTITY_TOKEN_PATH,
+  SHIM_SUBPROTOCOL,
+  SHIM_WS_PATH,
+  parseShimFrame,
+  type ShimBound,
+  type ShimCapability,
+  type ShimFrame
+} from './protocol.js'
+
+export interface ShimTransport {
+  send(text: string): void
+  onMessage(cb: (text: string) => void): void
+  onClose(cb: (code: number, reason: string) => void): void
+  close(code: number, reason: string): void
+}
+
+export interface ShimClientDeps {
+  endpoint: string
+  /** Dial the daemon. Injected so tests need no real WebSocket. */
+  dial: (url: string, opts: { subprotocol: string; path: string }) => Promise<ShimTransport>
+  /** Reads the projected token. Injected for tests; defaults to the mounted path. */
+  readToken?: () => string
+  /** Handles an authorized request from the daemon. The channels land in #814 / #815. */
+  handle?: (capability: ShimCapability, payload: unknown) => Promise<unknown>
+  clock?: Clock
+  backoff?: Backoff
+  log?: { info: (m: string) => void; warn: (m: string) => void }
+}
+
+/**
+ * The in-sandbox arm. It holds no policy: it proves which pod it is, then executes the
+ * operations the daemon authorizes. Everything it carries is short-lived and re-obtained
+ * by re-handshaking, so a compromised sandbox yields no lasting credential.
+ *
+ * It re-reads the projected token on every dial. The kubelet rotates that token and
+ * invalidates it when the pod goes away, which is what makes first bind, resume from
+ * suspension, and eviction indistinguishable here: each new pod simply presents its own.
+ */
+export class ShimClient {
+  private transport?: ShimTransport
+  private bound?: ShimBound
+  private stopped = false
+  private readonly clock: Clock
+  private readonly backoff: Backoff
+
+  constructor(private readonly deps: ShimClientDeps) {
+    this.clock = deps.clock ?? systemClock
+    this.backoff = deps.backoff ?? new Backoff()
+  }
+
+  binding(): ShimBound | undefined {
+    return this.bound
+  }
+
+  /** Dial and bind, retrying with backoff until stopped. Resolves on first binding. */
+  async start(): Promise<ShimBound> {
+    for (;;) {
+      if (this.stopped) throw new Error('shim: stopped before binding')
+      try {
+        return await this.connectOnce()
+      } catch (err) {
+        if (this.stopped) throw err
+        const delay = this.backoff.next()
+        this.deps.log?.warn(`shim: bind failed, retrying in ${delay}ms (${(err as Error).message})`)
+        await new Promise<void>((resolve) => this.clock.setTimeout(resolve, delay))
+      }
+    }
+  }
+
+  stop(): void {
+    this.stopped = true
+    this.bound = undefined
+    this.transport?.close(1000, 'shim stopping')
+    this.transport = undefined
+  }
+
+  private async connectOnce(): Promise<ShimBound> {
+    const token = (this.deps.readToken ?? (() => readFileSync(SHIM_IDENTITY_TOKEN_PATH, 'utf8').trim()))()
+    const transport = await this.deps.dial(this.deps.endpoint, {
+      subprotocol: SHIM_SUBPROTOCOL,
+      path: SHIM_WS_PATH
+    })
+    this.transport = transport
+    return await new Promise<ShimBound>((resolve, reject) => {
+      let settled = false
+      const fail = (message: string): void => {
+        if (settled) return
+        settled = true
+        reject(new Error(message))
+      }
+      transport.onClose((code, reason) => {
+        this.bound = undefined
+        if (this.transport === transport) this.transport = undefined
+        fail(`connection closed (${code}${reason ? ` ${reason}` : ''})`)
+      })
+      transport.onMessage((text) => {
+        const frame = parseShimFrame(text)
+        if (!frame) {
+          transport.close(4400, 'malformed frame')
+          return
+        }
+        if (frame.type === 'shim/bound') {
+          this.bound = frame
+          this.backoff.reset()
+          if (!settled) {
+            settled = true
+            this.deps.log?.info(`shim: bound as ${frame.agentId} generation ${frame.generation}`)
+            resolve(frame)
+          }
+          return
+        }
+        if (frame.type === 'shim/rejected') {
+          fail(`rejected: ${frame.reason}`)
+          transport.close(4403, frame.reason)
+          return
+        }
+        if (frame.type === 'shim/request') void this.serve(transport, frame)
+      })
+      // The token is the whole proof; nothing else about this pod is asserted.
+      transport.send(JSON.stringify({ type: 'shim/hello', token } satisfies Extract<ShimFrame, { type: 'shim/hello' }>))
+    })
+  }
+
+  private async serve(transport: ShimTransport, request: Extract<ShimFrame, { type: 'shim/request' }>): Promise<void> {
+    const bound = this.bound
+    // A request that does not match the credential and generation we were issued is not
+    // ours to serve: the daemon would refuse it too, and answering would be a second,
+    // weaker enforcement point.
+    if (!bound || request.sessionCredential !== bound.sessionCredential || request.generation !== bound.generation) {
+      transport.send(JSON.stringify({ type: 'shim/response', id: request.id, ok: false, error: 'not bound' }))
+      return
+    }
+    if (!bound.grants.includes(request.capability)) {
+      transport.send(JSON.stringify({ type: 'shim/response', id: request.id, ok: false, error: 'not granted' }))
+      return
+    }
+    try {
+      const payload = await (this.deps.handle ?? (async () => undefined))(request.capability, request.payload)
+      transport.send(JSON.stringify({ type: 'shim/response', id: request.id, ok: true, payload }))
+    } catch (err) {
+      transport.send(
+        JSON.stringify({ type: 'shim/response', id: request.id, ok: false, error: (err as Error).message })
+      )
+    }
+  }
+}

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -17,6 +17,14 @@ export interface ShimTransport {
   close(code: number, reason: string): void
 }
 
+/** One dial's channel. `ended` records a close that arrived before the supervision loop
+ *  armed `end`, so the wait cannot miss it and park forever. */
+interface Channel {
+  transport: ShimTransport
+  end?: (reason: 'renew' | 'lost') => void
+  ended?: 'renew' | 'lost'
+}
+
 export interface ShimClientDeps {
   endpoint: string
   /** Dial the daemon. Injected so tests need no real WebSocket. */
@@ -43,8 +51,10 @@ export class ShimClient {
   private transport?: ShimTransport
   private bound?: ShimBound
   private stopped = false
-  /** Ends the current channel so the supervision loop rebuilds it. */
-  private endChannel?: () => void
+  /** The channel in service. Every transport callback compares against this before
+   *  mutating shared state: a delayed close from a transport being replaced must not tear
+   *  down the healthy replacement that already bound. */
+  private channel?: Channel
   private readonly clock: Clock
   private readonly backoff: Backoff
 
@@ -78,14 +88,25 @@ export class ShimClient {
             return
           }
           try {
-            const bound = await this.connectOnce()
+            const { bound, channel } = await this.connectOnce()
             if (!ready) {
               ready = true
               resolve(bound)
             }
             // connectOnce resolves at binding; wait here for the channel to end, whether
             // from a close or from the renewal deadline coming due.
-            await this.runUntilRebindNeeded(bound)
+            const reason = await this.runUntilRebindNeeded(bound, channel)
+            if (reason === 'renew') {
+              // A planned renewal is not a failure: re-dial at once, and keep the backoff
+              // counter clean so a later genuine drop starts from its base delay.
+              this.backoff.reset()
+              continue
+            }
+            // A drop IS a failure signal, so it goes through backoff — the daemon may be
+            // rolling, and hammering it with immediate re-dials is what backoff prevents.
+            const delay = this.backoff.next()
+            this.deps.log?.warn(`shim: channel dropped, re-dialing in ${delay}ms`)
+            await new Promise<void>((settle) => this.clock.setTimeout(settle, delay))
           } catch (err) {
             if (this.stopped) {
               if (!ready) reject(err)
@@ -103,9 +124,10 @@ export class ShimClient {
   stop(): void {
     this.stopped = true
     this.bound = undefined
-    this.endChannel?.()
+    this.channel?.end?.('lost')
     this.transport?.close(1000, 'shim stopping')
     this.transport = undefined
+    this.channel = undefined
   }
 
   /**
@@ -113,33 +135,42 @@ export class ShimClient {
    * close enough to expiry to renew. Renewing at half the lifetime leaves a full half as
    * margin for a slow TokenReview or a re-dial.
    */
-  private runUntilRebindNeeded(bound: ShimBound): Promise<void> {
-    return new Promise<void>((resolve) => {
+  private runUntilRebindNeeded(bound: ShimBound, channel: Channel): Promise<'renew' | 'lost'> {
+    if (channel.ended) {
+      if (this.channel === channel) this.channel = undefined
+      if (this.transport === channel.transport) this.transport = undefined
+      this.bound = undefined
+      return Promise.resolve(channel.ended)
+    }
+    return new Promise<'renew' | 'lost'>((resolve) => {
       const renewInMs = Math.max(1_000, Math.floor((bound.expiresInSeconds * 1000) / 2))
       const timer = this.clock.setTimeout(() => {
         this.deps.log?.info('shim: renewing the session credential before it expires')
-        finish()
+        finish('renew')
       }, renewInMs)
-      const finish = (): void => {
+      const finish = (reason: 'renew' | 'lost'): void => {
         this.clock.clearTimeout(timer)
-        this.endChannel = undefined
-        this.transport?.close(1000, 'rebinding')
-        this.transport = undefined
+        if (this.channel !== channel) return
+        this.channel = undefined
+        channel.transport.close(1000, reason === 'renew' ? 'rebinding' : 'channel lost')
+        if (this.transport === channel.transport) this.transport = undefined
         this.bound = undefined
-        resolve()
+        resolve(reason)
       }
-      this.endChannel = finish
+      channel.end = finish
     })
   }
 
-  private async connectOnce(): Promise<ShimBound> {
+  private async connectOnce(): Promise<{ bound: ShimBound; channel: Channel }> {
     const token = (this.deps.readToken ?? (() => readFileSync(SHIM_IDENTITY_TOKEN_PATH, 'utf8').trim()))()
     const transport = await this.deps.dial(this.deps.endpoint, {
       subprotocol: SHIM_SUBPROTOCOL,
       path: SHIM_WS_PATH
     })
     this.transport = transport
-    return await new Promise<ShimBound>((resolve, reject) => {
+    const channel: Channel = { transport }
+    this.channel = channel
+    return await new Promise<{ bound: ShimBound; channel: typeof channel }>((resolve, reject) => {
       let settled = false
       const fail = (message: string): void => {
         if (settled) return
@@ -147,12 +178,19 @@ export class ShimClient {
         reject(new Error(message))
       }
       transport.onClose((code, reason) => {
+        // Scoped to THIS transport. A close arriving late from a transport we already
+        // replaced (a close-handshake timeout, say) must not clear the binding or end the
+        // channel of the replacement that has since bound.
+        if (this.channel !== channel) return
         this.bound = undefined
         if (this.transport === transport) this.transport = undefined
         // Before binding this fails the dial; after binding it ends the channel so the
         // supervision loop re-dials instead of leaving the process alive but detached.
         fail(`connection closed (${code}${reason ? ` ${reason}` : ''})`)
-        this.endChannel?.()
+        // A close can land between binding and the loop arming `end`. Recording it means
+        // the wait below observes it instead of parking on a channel that is already gone.
+        if (channel.end) channel.end('lost')
+        else channel.ended = 'lost'
       })
       transport.onMessage((text) => {
         const frame = parseShimFrame(text)
@@ -166,7 +204,7 @@ export class ShimClient {
           if (!settled) {
             settled = true
             this.deps.log?.info(`shim: bound as ${frame.agentId} generation ${frame.generation}`)
-            resolve(frame)
+            resolve({ bound: frame, channel })
           }
           return
         }

--- a/packages/daemon/src/shim/index.ts
+++ b/packages/daemon/src/shim/index.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/** The in-sandbox shim executable. Lives at a fixed path in the runtime image
+ *  (`/opt/agentconnect/shim`), root-owned and read-only, with tini as PID 1. */
+import { ClientTransport } from '@agentconnect.md/connection'
+import { ShimClient, type ShimTransport } from './client.js'
+import { SHIM_ENDPOINT_ENV } from './protocol.js'
+
+const log = {
+  info: (message: string) => console.error(`[shim] ${message}`),
+  warn: (message: string) => console.error(`[shim] ${message}`)
+}
+
+async function main(): Promise<number> {
+  const endpoint = process.env[SHIM_ENDPOINT_ENV]?.trim()
+  if (!endpoint) {
+    log.warn(`${SHIM_ENDPOINT_ENV} is not set — nothing to dial`)
+    return 2
+  }
+  const client = new ShimClient({
+    endpoint,
+    dial: (url, opts) =>
+      ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
+    log
+  })
+  // A signal is the pod being torn down; drop the channel rather than racing the
+  // container's exit, since every credential we hold is re-obtained on the next bind.
+  for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+    process.on(signal, () => {
+      client.stop()
+      process.exit(0)
+    })
+  }
+  await client.start()
+  // Bound: stay up serving daemon requests until the pod goes away.
+  await new Promise<void>(() => {})
+  return 0
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err: unknown) => {
+    log.warn(`fatal: ${(err as Error).message}`)
+    process.exit(1)
+  }
+)

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -255,7 +255,13 @@ export class ShimListener {
     })
 
     ws.on('close', () => {
-      if (bound) this.connections.delete(bound)
+      if (bound) {
+        this.connections.delete(bound)
+        // Revoke the credential too, not just the connection entry: a credential whose
+        // channel is gone is useless, and leaving it behind is what let a stale binding
+        // outlive its socket.
+        this.registry.revokePod(bound.binding.podUid)
+      }
     })
   }
 

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -1,0 +1,232 @@
+import { createServer, type Server } from 'node:http'
+import { WebSocketServer, type WebSocket } from 'ws'
+import { ShimBindingRegistry, type Binding, type SpawnRecord } from './binding.js'
+import {
+  SHIM_SUBPROTOCOL,
+  SHIM_TOKEN_AUDIENCE,
+  SHIM_WS_PATH,
+  parseShimFrame,
+  type ShimFrame,
+  type ShimRejected
+} from './protocol.js'
+
+/** Verifies a presented token and reports which pod it was issued to. Satisfied by
+ *  the Kubernetes client's TokenReview; injected so tests need no API server. */
+export interface PodIdentityVerifier {
+  reviewToken(
+    token: string,
+    audiences: string[]
+  ): Promise<{
+    authenticated: boolean
+    podName?: string
+    podUid?: string
+    error?: string
+  }>
+}
+
+export interface ShimListenerDeps {
+  verifier: PodIdentityVerifier
+  /** The spawn record for a pod, or undefined when this daemon did not launch it. */
+  spawnRecordForPod: (pod: { name: string; uid: string }) => SpawnRecord | undefined
+  now: () => number
+  log: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
+  /** Session-credential lifetime; a shim re-handshakes rather than refreshing. */
+  credentialTtlMs?: number
+}
+
+const DEFAULT_CREDENTIAL_TTL_MS = 10 * 60_000
+
+/** A bound shim connection the daemon can send requests on. */
+export interface ShimConnection {
+  binding: Binding
+  send(frame: ShimFrame): void
+  close(reason: string): void
+}
+
+/**
+ * The daemon's shim endpoint: the shim dials out, this listens.
+ *
+ * Direction is deliberate — the sandbox needs zero inbound, so its NetworkPolicy keeps
+ * an empty ingress list and no per-sandbox Service exists. Binding is proved by the
+ * pod's own audience-restricted ServiceAccount token, reviewed through the API server,
+ * because a pod IP is reusable and the Sandbox status that mirrors it is asynchronous:
+ * within that stale window a sibling sandbox could otherwise claim a victim's channel.
+ * The connection's source address is therefore logged as a hint and never trusted.
+ */
+export class ShimListener {
+  private server?: Server
+  private wss?: WebSocketServer
+  private readonly registry: ShimBindingRegistry
+  private readonly connections = new Set<ShimConnection>()
+  private port?: number
+
+  constructor(private readonly deps: ShimListenerDeps) {
+    this.registry = new ShimBindingRegistry(deps.now, deps.credentialTtlMs ?? DEFAULT_CREDENTIAL_TTL_MS)
+  }
+
+  async start(port = 0, host = '0.0.0.0'): Promise<number> {
+    const server = createServer((_req, res) => {
+      // The endpoint speaks only the WS upgrade; a plain GET is not a health surface.
+      res.statusCode = 404
+      res.end()
+    })
+    const wss = new WebSocketServer({ noServer: true })
+    server.on('upgrade', (req, socket, head) => {
+      if (!(req.url ?? '').startsWith(SHIM_WS_PATH)) {
+        socket.destroy()
+        return
+      }
+      // Refuse an upgrade that does not offer our subprotocol: a browser or scanner
+      // reaching this port should not get as far as the handshake.
+      const offered = (req.headers['sec-websocket-protocol'] ?? '')
+        .toString()
+        .split(',')
+        .map((value) => value.trim())
+      if (!offered.includes(SHIM_SUBPROTOCOL)) {
+        socket.destroy()
+        return
+      }
+      wss.handleUpgrade(req, socket, head, (ws) => this.accept(ws, req.socket.remoteAddress ?? 'unknown'))
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(port, host, () => {
+        server.removeListener('error', reject)
+        resolve()
+      })
+    })
+    this.server = server
+    this.wss = wss
+    this.port = (server.address() as { port: number }).port
+    this.deps.log.info(`shim: listening on ${host}:${this.port}${SHIM_WS_PATH}`)
+    return this.port
+  }
+
+  async stop(): Promise<void> {
+    for (const connection of [...this.connections]) connection.close('daemon shutting down')
+    this.connections.clear()
+    this.wss?.close()
+    await new Promise<void>((resolve) => (this.server ? this.server.close(() => resolve()) : resolve()))
+    this.server = undefined
+    this.wss = undefined
+  }
+
+  listeningPort(): number | undefined {
+    return this.port
+  }
+
+  /** Bound connections for an agent — the channels a turn is delivered over. */
+  connectionsFor(agentId: string): ShimConnection[] {
+    return [...this.connections].filter((connection) => connection.binding.agentId === agentId)
+  }
+
+  /** Forget an agent's bindings; its sandbox is gone or its claim was deleted. */
+  revokeAgent(agentId: string): void {
+    for (const connection of this.connectionsFor(agentId)) connection.close('binding revoked')
+    this.registry.revokeAgent(agentId)
+  }
+
+  /** Authorize an inbound post-binding frame. Exposed for the channels landing later. */
+  authorize(input: Parameters<ShimBindingRegistry['authorize']>[0]): ReturnType<ShimBindingRegistry['authorize']> {
+    return this.registry.authorize(input)
+  }
+
+  private accept(ws: WebSocket, remoteAddress: string): void {
+    let bound: ShimConnection | undefined
+    const reject = (rejected: ShimRejected): void => {
+      // One coarse reason, never which check failed: a caller must not be able to probe
+      // for valid pod names by comparing responses.
+      try {
+        ws.send(JSON.stringify(rejected))
+      } catch {
+        /* peer already gone */
+      }
+      ws.close(4403, rejected.reason)
+    }
+
+    ws.on('message', (data: unknown, isBinary?: boolean) => {
+      if (isBinary) return
+      const frame = parseShimFrame(typeof data === 'string' ? data : String(data))
+      if (!frame) {
+        ws.close(4400, 'malformed frame')
+        return
+      }
+      if (frame.type === 'shim/hello') {
+        if (bound) {
+          ws.close(4400, 'already bound')
+          return
+        }
+        void this.bindFrom(frame.token, remoteAddress).then(
+          (result) => {
+            if (!result.ok) return reject(result.rejected)
+            const connection: ShimConnection = {
+              binding: result.binding,
+              send: (outbound) => ws.send(JSON.stringify(outbound)),
+              close: (reason) => ws.close(4000, reason)
+            }
+            bound = connection
+            this.connections.add(connection)
+            connection.send({
+              type: 'shim/bound',
+              sessionCredential: result.credential,
+              expiresInSeconds: Math.max(1, Math.floor((result.binding.expiresAtMs - this.deps.now()) / 1000)),
+              agentId: result.binding.agentId,
+              generation: result.binding.generation,
+              grants: result.binding.grants
+            })
+            this.deps.log.info(
+              `shim: bound agent ${result.binding.agentId} generation ${result.binding.generation} ` +
+                `(pod ${result.binding.podName}, from ${remoteAddress})`
+            )
+          },
+          (err: unknown) => {
+            this.deps.log.warn(`shim: binding failed (${(err as Error).message})`)
+            reject({ type: 'shim/rejected', reason: 'unavailable', message: 'binding unavailable' })
+          }
+        )
+        return
+      }
+      // Only the hello frame is accepted before binding; a request that arrives first
+      // has no credential to authorize and must not be treated as anything else.
+      if (!bound) {
+        ws.close(4403, 'not bound')
+        return
+      }
+      if (frame.type === 'shim/request') {
+        // The daemon is the requester on this channel; a request FROM the sandbox is
+        // out of protocol and closing is the safe response.
+        ws.close(4400, 'unexpected request from sandbox')
+      }
+    })
+
+    ws.on('close', () => {
+      if (bound) this.connections.delete(bound)
+    })
+  }
+
+  private async bindFrom(
+    token: string,
+    remoteAddress: string
+  ): Promise<{ ok: true; credential: string; binding: Binding } | { ok: false; rejected: ShimRejected }> {
+    const review = await this.deps.verifier.reviewToken(token, [SHIM_TOKEN_AUDIENCE])
+    if (!review.authenticated || !review.podName || !review.podUid) {
+      this.deps.log.warn(
+        `shim: rejected an unauthenticated callback from ${remoteAddress}${review.error ? ` (${review.error})` : ''}`
+      )
+      return {
+        ok: false,
+        rejected: { type: 'shim/rejected', reason: 'unauthenticated', message: 'token not accepted' }
+      }
+    }
+    const pod = { name: review.podName, uid: review.podUid }
+    const record = this.deps.spawnRecordForPod(pod)
+    if (!record) {
+      // Authenticated, but not a pod this daemon launched — or one whose spawn record is
+      // gone. Either way there is nothing to bind it to.
+      this.deps.log.warn(`shim: no spawn record for pod ${pod.name} (${remoteAddress})`)
+      return { ok: false, rejected: { type: 'shim/rejected', reason: 'unknown_pod', message: 'pod not recognized' } }
+    }
+    const { credential, binding } = this.registry.bind(record, pod)
+    return { ok: true, credential, binding }
+  }
+}

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -1,4 +1,6 @@
 import { createServer, type Server } from 'node:http'
+import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import { systemClock, type Clock } from '@agentconnect.md/connection'
 import { WebSocketServer, type WebSocket } from 'ws'
 import { ShimBindingRegistry, type Binding, type SpawnRecord } from './binding.js'
 import {
@@ -29,6 +31,8 @@ export interface ShimListenerDeps {
   /** The spawn record for a pod, or undefined when this daemon did not launch it. */
   spawnRecordForPod: (pod: { name: string; uid: string }) => SpawnRecord | undefined
   now: () => number
+  /** Time seam for the credential-expiry backstop; a FakeClock drives it in tests. */
+  clock?: Clock
   log: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
   /** Session-credential lifetime; a shim re-handshakes rather than refreshing. */
   credentialTtlMs?: number
@@ -57,11 +61,13 @@ export class ShimListener {
   private server?: Server
   private wss?: WebSocketServer
   private readonly registry: ShimBindingRegistry
+  private readonly clock: Clock
   private readonly connections = new Set<ShimConnection>()
   private port?: number
 
   constructor(private readonly deps: ShimListenerDeps) {
     this.registry = new ShimBindingRegistry(deps.now, deps.credentialTtlMs ?? DEFAULT_CREDENTIAL_TTL_MS)
+    this.clock = deps.clock ?? systemClock
   }
 
   async start(port = 0, host = '0.0.0.0'): Promise<number> {
@@ -70,7 +76,9 @@ export class ShimListener {
       res.statusCode = 404
       res.end()
     })
-    const wss = new WebSocketServer({ noServer: true })
+    // Same 256 KiB cap the CP gateways use: a half-trusted peer must not be able to make
+    // the daemon buffer an arbitrarily large frame.
+    const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_FRAME_BYTES })
     server.on('upgrade', (req, socket, head) => {
       if (!(req.url ?? '').startsWith(SHIM_WS_PATH)) {
         socket.destroy()
@@ -133,15 +141,23 @@ export class ShimListener {
 
   private accept(ws: WebSocket, remoteAddress: string): void {
     let bound: ShimConnection | undefined
+    let binding = false
     const reject = (rejected: ShimRejected): void => {
-      // One coarse reason, never which check failed: a caller must not be able to probe
-      // for valid pod names by comparing responses.
+      // The wire answer is identical for every pre-binding failure. An earlier version
+      // sent the precise reason, which let a caller distinguish "token not accepted" from
+      // "pod not recognized" and probe for pods this daemon launched — the exact thing the
+      // anti-probing claim rules out. The precise reason stays in the daemon's own logs.
       try {
         ws.send(JSON.stringify(rejected))
       } catch {
         /* peer already gone */
       }
       ws.close(4403, rejected.reason)
+    }
+    const uniformRejection: ShimRejected = {
+      type: 'shim/rejected',
+      reason: 'unauthenticated',
+      message: 'not accepted'
     }
 
     ws.on('message', (data: unknown, isBinary?: boolean) => {
@@ -152,13 +168,27 @@ export class ShimListener {
         return
       }
       if (frame.type === 'shim/hello') {
-        if (bound) {
-          ws.close(4400, 'already bound')
+        // Single-flight: a second hello arriving while TokenReview is in flight would bind
+        // twice and leave a stale connection entry behind.
+        if (bound || binding) {
+          ws.close(4400, 'already binding')
           return
         }
+        binding = true
         void this.bindFrom(frame.token, remoteAddress).then(
           (result) => {
-            if (!result.ok) return reject(result.rejected)
+            binding = false
+            if (!result.ok) return reject(uniformRejection)
+            // Close the superseded incarnation's channel: its credential is already gone
+            // from the registry, and leaving the socket open would keep a dead binding in
+            // connectionsFor().
+            for (const previous of result.superseded) {
+              for (const connection of [...this.connections]) {
+                if (connection.binding.podUid !== previous.podUid) continue
+                this.connections.delete(connection)
+                connection.close('superseded by a newer launch')
+              }
+            }
             const connection: ShimConnection = {
               binding: result.binding,
               send: (outbound) => ws.send(JSON.stringify(outbound)),
@@ -166,20 +196,34 @@ export class ShimListener {
             }
             bound = connection
             this.connections.add(connection)
+            const remainingMs = result.binding.expiresAtMs - this.deps.now()
             connection.send({
               type: 'shim/bound',
               sessionCredential: result.credential,
-              expiresInSeconds: Math.max(1, Math.floor((result.binding.expiresAtMs - this.deps.now()) / 1000)),
+              expiresInSeconds: Math.max(1, Math.floor(remainingMs / 1000)),
               agentId: result.binding.agentId,
               generation: result.binding.generation,
               grants: result.binding.grants
             })
+            // Backstop the shim's own re-handshake: if it never comes, close at expiry so
+            // the peer observes a dead channel instead of holding an expired credential.
+            const expiry = this.clock.setTimeout(
+              () => {
+                if (bound !== connection) return
+                this.connections.delete(connection)
+                this.deps.log.info(`shim: credential expired for agent ${result.binding.agentId} — closing channel`)
+                connection.close('credential expired')
+              },
+              Math.max(0, remainingMs)
+            )
+            ws.once('close', () => this.clock.clearTimeout(expiry))
             this.deps.log.info(
               `shim: bound agent ${result.binding.agentId} generation ${result.binding.generation} ` +
                 `(pod ${result.binding.podName}, from ${remoteAddress})`
             )
           },
           (err: unknown) => {
+            binding = false
             this.deps.log.warn(`shim: binding failed (${(err as Error).message})`)
             reject({ type: 'shim/rejected', reason: 'unavailable', message: 'binding unavailable' })
           }
@@ -207,7 +251,9 @@ export class ShimListener {
   private async bindFrom(
     token: string,
     remoteAddress: string
-  ): Promise<{ ok: true; credential: string; binding: Binding } | { ok: false; rejected: ShimRejected }> {
+  ): Promise<
+    { ok: true; credential: string; binding: Binding; superseded: Binding[] } | { ok: false; rejected: ShimRejected }
+  > {
     const review = await this.deps.verifier.reviewToken(token, [SHIM_TOKEN_AUDIENCE])
     if (!review.authenticated || !review.podName || !review.podUid) {
       this.deps.log.warn(
@@ -226,7 +272,7 @@ export class ShimListener {
       this.deps.log.warn(`shim: no spawn record for pod ${pod.name} (${remoteAddress})`)
       return { ok: false, rejected: { type: 'shim/rejected', reason: 'unknown_pod', message: 'pod not recognized' } }
     }
-    const { credential, binding } = this.registry.bind(record, pod)
-    return { ok: true, credential, binding }
+    const { credential, binding, superseded } = this.registry.bind(record, pod)
+    return { ok: true, credential, binding, superseded }
   }
 }

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -43,6 +43,9 @@ const DEFAULT_CREDENTIAL_TTL_MS = 10 * 60_000
 /** A bound shim connection the daemon can send requests on. */
 export interface ShimConnection {
   binding: Binding
+  /** The credential issued to THIS channel, so teardown can revoke exactly it rather than
+   *  whatever the pod currently holds — a renewal may already have replaced that. */
+  issuedCredential: string
   send(frame: ShimFrame): void
   close(reason: string): void
 }
@@ -202,6 +205,7 @@ export class ShimListener {
             }
             const connection: ShimConnection = {
               binding: result.binding,
+              issuedCredential: result.credential,
               send: (outbound) => ws.send(JSON.stringify(outbound)),
               close: (reason) => ws.close(4000, reason)
             }
@@ -257,10 +261,9 @@ export class ShimListener {
     ws.on('close', () => {
       if (bound) {
         this.connections.delete(bound)
-        // Revoke the credential too, not just the connection entry: a credential whose
-        // channel is gone is useless, and leaving it behind is what let a stale binding
-        // outlive its socket.
-        this.registry.revokePod(bound.binding.podUid)
+        // Revoke this channel's OWN credential: a same-pod renewal may already hold the
+        // pod's index, and revoking by pod here would delete the live replacement.
+        this.registry.revokeIssued(bound.issuedCredential)
       }
     })
   }

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -142,6 +142,11 @@ export class ShimListener {
   private accept(ws: WebSocket, remoteAddress: string): void {
     let bound: ShimConnection | undefined
     let binding = false
+    // TokenReview is a network round trip, so the socket can close while it is pending.
+    // The continuation must not then issue a credential, supersede a live binding, or
+    // publish a connection for a socket that is already gone.
+    let socketOpen = true
+    ws.once('close', () => (socketOpen = false))
     const reject = (rejected: ShimRejected): void => {
       // The wire answer is identical for every pre-binding failure. An earlier version
       // sent the precise reason, which let a caller distinguish "token not accepted" from
@@ -175,9 +180,15 @@ export class ShimListener {
           return
         }
         binding = true
-        void this.bindFrom(frame.token, remoteAddress).then(
+        void this.bindFrom(frame.token, remoteAddress, () => socketOpen).then(
           (result) => {
             binding = false
+            if (!result.ok && 'abandoned' in result) {
+              // The socket closed mid-review; bindFrom stopped before the registry.
+              this.deps.log.info('shim: callback closed before its token review finished')
+              return
+            }
+            if (!socketOpen) return
             if (!result.ok) return reject(uniformRejection)
             // Close the superseded incarnation's channel: its credential is already gone
             // from the registry, and leaving the socket open would keep a dead binding in
@@ -250,9 +261,12 @@ export class ShimListener {
 
   private async bindFrom(
     token: string,
-    remoteAddress: string
+    remoteAddress: string,
+    stillOpen: () => boolean
   ): Promise<
-    { ok: true; credential: string; binding: Binding; superseded: Binding[] } | { ok: false; rejected: ShimRejected }
+    | { ok: true; credential: string; binding: Binding; superseded: Binding[] }
+    | { ok: false; rejected: ShimRejected }
+    | { ok: false; abandoned: true }
   > {
     const review = await this.deps.verifier.reviewToken(token, [SHIM_TOKEN_AUDIENCE])
     if (!review.authenticated || !review.podName || !review.podUid) {
@@ -272,7 +286,19 @@ export class ShimListener {
       this.deps.log.warn(`shim: no spawn record for pod ${pod.name} (${remoteAddress})`)
       return { ok: false, rejected: { type: 'shim/rejected', reason: 'unknown_pod', message: 'pod not recognized' } }
     }
-    const { credential, binding, superseded } = this.registry.bind(record, pod)
-    return { ok: true, credential, binding, superseded }
+    // Last check before the only mutation in this path: the registry must not be touched
+    // on behalf of a socket that closed while the review was in flight.
+    if (!stillOpen()) return { ok: false, abandoned: true }
+    const bound = this.registry.bind(record, pod)
+    if (!bound.ok) {
+      // A newer launch already holds this sandbox. Refusing without mutating is what stops
+      // a terminating pod from reclaiming the channel during overlap.
+      this.deps.log.warn(
+        `shim: refused generation ${record.generation} for agent ${record.agentId} — ` +
+          `generation ${bound.current} already holds the channel`
+      )
+      return { ok: false, rejected: { type: 'shim/rejected', reason: 'stale_generation', message: 'superseded' } }
+    }
+    return { ok: true, credential: bound.credential, binding: bound.binding, superseded: bound.superseded }
   }
 }

--- a/packages/daemon/src/shim/protocol.ts
+++ b/packages/daemon/src/shim/protocol.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod'
+
+/** WS subprotocol and path the shim dials the daemon on. */
+export const SHIM_SUBPROTOCOL = 'agentconnect.shim.v1'
+export const SHIM_WS_PATH = '/shim/v1'
+
+/** Audience the projected ServiceAccount token is restricted to. A token minted for
+ *  anything else must not authenticate here, which is what makes the pod's own
+ *  credential safe to hand over: it is useless anywhere but this endpoint. */
+export const SHIM_TOKEN_AUDIENCE = 'ac-daemon-callback'
+
+/** Where the pod template projects that token, and where the shim reads it from. */
+export const SHIM_IDENTITY_TOKEN_PATH = '/var/run/ac-identity/token'
+
+/** The env var carrying the daemon's shim endpoint into the sandbox. Non-secret, so it
+ *  is safe in a SandboxTemplate whose pods are stamped before any user exists. */
+export const SHIM_ENDPOINT_ENV = 'AC_SHIM_ENDPOINT'
+
+/** Operations the daemon may ask a bound shim to perform. Every one is authorized
+ *  individually against the binding's grants — a channel is not a blanket permission.
+ *  The bodies land in #814 / #815; this is the authorization vocabulary they use. */
+export const ShimCapabilitySchema = z.enum([
+  /** Write daemon-materialized files (secrets, config files) into the sandbox. */
+  'materialize',
+  /** Run a command in the sandbox and return a structured result (workspace git). */
+  'exec',
+  /** Read a bounded file back out (BFF workspace reads). */
+  'read',
+  /** Proxy an in-pod unix socket back to a daemon-side server (gitcred, gh, MCP). */
+  'tunnel'
+])
+export type ShimCapability = z.infer<typeof ShimCapabilitySchema>
+
+/** The shim's opening frame: it proves which pod it is and nothing more. */
+export const ShimHelloSchema = z.object({
+  type: z.literal('shim/hello'),
+  /** Projected ServiceAccount token, audience-restricted to {@link SHIM_TOKEN_AUDIENCE}. */
+  token: z.string().min(1),
+  /** Shim build, for operator diagnosis only — never an authorization input. */
+  shimVersion: z.string().max(64).optional()
+})
+
+/** The daemon's answer once the token is verified and mapped to a spawn record. */
+export const ShimBoundSchema = z.object({
+  type: z.literal('shim/bound'),
+  /** Short-TTL credential for subsequent frames, bound to this pod and generation. */
+  sessionCredential: z.string().min(1),
+  /** Seconds until the credential must be re-obtained by re-handshaking. */
+  expiresInSeconds: z.number().int().positive(),
+  agentId: z.string().min(1),
+  /** Monotonic per-agent spawn counter; frames from an older one are refused. */
+  generation: z.number().int().nonnegative(),
+  grants: z.array(ShimCapabilitySchema)
+})
+
+export const ShimRejectedSchema = z.object({
+  type: z.literal('shim/rejected'),
+  /** Coarse, non-probing reason: never leaks which of several checks failed. */
+  reason: z.enum(['unauthenticated', 'unknown_pod', 'stale_generation', 'unavailable']),
+  message: z.string().max(200)
+})
+
+/** Every post-binding frame carries the credential and the generation it was issued
+ *  for, so a replayed frame from a previous pod incarnation is refused on arrival. */
+export const ShimRequestSchema = z.object({
+  type: z.literal('shim/request'),
+  id: z.string().uuid(),
+  sessionCredential: z.string().min(1),
+  generation: z.number().int().nonnegative(),
+  capability: ShimCapabilitySchema,
+  /** Operation payload, shaped per capability by the channels that land later. */
+  payload: z.unknown()
+})
+
+export const ShimResponseSchema = z.object({
+  type: z.literal('shim/response'),
+  id: z.string().uuid(),
+  ok: z.boolean(),
+  payload: z.unknown().optional(),
+  error: z.string().max(500).optional()
+})
+
+export const ShimFrameSchema = z.discriminatedUnion('type', [
+  ShimHelloSchema,
+  ShimBoundSchema,
+  ShimRejectedSchema,
+  ShimRequestSchema,
+  ShimResponseSchema
+])
+
+export type ShimHello = z.infer<typeof ShimHelloSchema>
+export type ShimBound = z.infer<typeof ShimBoundSchema>
+export type ShimRejected = z.infer<typeof ShimRejectedSchema>
+export type ShimRequest = z.infer<typeof ShimRequestSchema>
+export type ShimResponse = z.infer<typeof ShimResponseSchema>
+export type ShimFrame = z.infer<typeof ShimFrameSchema>
+
+/** Parse an inbound frame, returning undefined rather than throwing: a malformed frame
+ *  from a half-trusted peer is a close-the-connection event, not an exception path. */
+export function parseShimFrame(text: string): ShimFrame | undefined {
+  try {
+    const result = ShimFrameSchema.safeParse(JSON.parse(text))
+    return result.success ? result.data : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -225,6 +225,68 @@ describe('shim handshake', () => {
     expect(reason).toBe('credential expired')
   })
 
+  it('refuses an older generation binding after a newer one, without disturbing it', async () => {
+    // The overlap case: generation 4 has bound, then the terminating generation-3 pod
+    // reconnects (or its slower TokenReview lands late). Replacing here would hand the
+    // channel back to the sandbox that is going away.
+    let generation = 4
+    let podUid = 'pod-uid-new'
+    const { instance, endpoint } = await listener({
+      verifier: { reviewToken: async () => ({ authenticated: true, podName: 'p', podUid }) },
+      spawnRecordForPod: () => record({ generation })
+    })
+    const newer = await rawConnect(endpoint)
+    newer.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => newer.frames.length > 0)
+    const held = newer.frames[0] as ShimBound
+
+    generation = 3
+    podUid = 'pod-uid-old'
+    const older = await rawConnect(endpoint)
+    older.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => older.frames.length > 0)
+    expect(older.frames[0]).toMatchObject({ type: 'shim/rejected' })
+
+    // Generation 4 is untouched: still the only connection, still authorized.
+    expect(instance.connectionsFor('agent-a')).toHaveLength(1)
+    expect(instance.connectionsFor('agent-a')[0]?.binding.generation).toBe(4)
+    expect(
+      instance.authorize({ credential: held.sessionCredential, generation: 4, capability: 'materialize' }).ok
+    ).toBe(true)
+  })
+
+  it('issues nothing when the socket closes while its token review is in flight', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => (release = resolve))
+    const clock = new FakeClock()
+    const { instance, endpoint } = await listener({
+      verifier: {
+        reviewToken: async () => {
+          await gate
+          return { authenticated: true, podName: 'p', podUid: 'u' }
+        }
+      },
+      now: () => clock.now(),
+      clock
+    })
+    // A live binding for the same agent, which the late continuation must not supersede.
+    const live = await rawConnect(endpoint)
+    const abandoned = await rawConnect(endpoint)
+    abandoned.send({ type: 'shim/hello', token: 't' })
+    abandoned.socket.close()
+    await abandoned.closed
+    release()
+    // Give the continuation a turn to run before asserting it did nothing.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(instance.connectionsFor('agent-a')).toHaveLength(0)
+
+    // And the endpoint still works afterwards, so the guard did not wedge it.
+    live.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => live.frames.length > 0)
+    expect(live.frames[0]).toMatchObject({ type: 'shim/bound' })
+    expect(instance.connectionsFor('agent-a')).toHaveLength(1)
+  })
+
   it('re-binds a rescheduled pod under a NEW uid and drops the previous credential (invariants 4, 5)', async () => {
     // Resume, first bind and eviction are indistinguishable to the protocol: each new pod
     // presents its own token. Crucially the replacement pod has a DIFFERENT uid — keying
@@ -261,13 +323,47 @@ describe('shim handshake', () => {
   })
 })
 
+/** bind() can refuse (a newer generation holds the channel); these cases expect success. */
+function mustBind(
+  bindings: ShimBindingRegistry,
+  spawn: SpawnRecord,
+  pod: { name: string; uid: string }
+): { credential: string } {
+  const result = bindings.bind(spawn, pod)
+  if (!result.ok) throw new Error(`unexpected bind refusal: ${result.reason}`)
+  return { credential: result.credential }
+}
+
 describe('shim binding registry', () => {
   const clock = { value: 1_000 }
   const registry = (): ShimBindingRegistry => new ShimBindingRegistry(() => clock.value, 60_000)
 
+  it('rejects a lower generation instead of replacing the current binding', () => {
+    clock.value = 1_000
+    const bindings = registry()
+    const newer = bindings.bind(record({ generation: 4 }), { name: 'p-new', uid: 'u-new' })
+    const older = bindings.bind(record({ generation: 3 }), { name: 'p-old', uid: 'u-old' })
+    expect(older).toEqual({ ok: false, reason: 'superseded_generation', current: 4 })
+    // The newer binding is untouched — not merely "not replaced", but still authorized.
+    expect(
+      newer.ok && bindings.authorize({ credential: newer.credential, generation: 4, capability: 'materialize' }).ok
+    ).toBe(true)
+    expect(bindings.size()).toBe(1)
+  })
+
+  it('rejects rebinding the same generation, so a duplicate hello cannot rotate the credential', () => {
+    clock.value = 1_000
+    const bindings = registry()
+    const first = bindings.bind(record({ generation: 3 }), { name: 'p', uid: 'u' })
+    expect(bindings.bind(record({ generation: 3 }), { name: 'p', uid: 'u' })).toMatchObject({ ok: false })
+    expect(
+      first.ok && bindings.authorize({ credential: first.credential, generation: 3, capability: 'materialize' }).ok
+    ).toBe(true)
+  })
+
   it('refuses a stale generation even with a live credential (invariant 4)', () => {
     const bindings = registry()
-    const { credential } = bindings.bind(record({ generation: 7 }), { name: 'p', uid: 'u' })
+    const { credential } = mustBind(bindings, record({ generation: 7 }), { name: 'p', uid: 'u' })
     expect(bindings.authorize({ credential, generation: 7, capability: 'materialize' }).ok).toBe(true)
     expect(bindings.authorize({ credential, generation: 6, capability: 'materialize' })).toEqual({
       ok: false,
@@ -277,7 +373,7 @@ describe('shim binding registry', () => {
 
   it('refuses a capability the launch was not granted (invariant 3)', () => {
     const bindings = registry()
-    const { credential } = bindings.bind(record({ grants: ['materialize'] }), { name: 'p', uid: 'u' })
+    const { credential } = mustBind(bindings, record({ grants: ['materialize'] }), { name: 'p', uid: 'u' })
     // Holding the channel is not holding every operation on it: one runtime must not be
     // able to reach a capability its own launch never received.
     expect(bindings.authorize({ credential, generation: 3, capability: 'exec' })).toEqual({
@@ -293,7 +389,7 @@ describe('shim binding registry', () => {
   it('expires a credential rather than honouring it indefinitely (invariant 5)', () => {
     clock.value = 1_000
     const bindings = registry()
-    const { credential } = bindings.bind(record(), { name: 'p', uid: 'u' })
+    const { credential } = mustBind(bindings, record(), { name: 'p', uid: 'u' })
     clock.value = 61_001
     expect(bindings.authorize({ credential, generation: 3, capability: 'materialize' })).toEqual({
       ok: false,
@@ -307,8 +403,8 @@ describe('shim binding registry', () => {
   it('does not leak one agent credential to another agent (invariant 3)', () => {
     const bindings = registry()
     clock.value = 1_000
-    const a = bindings.bind(record({ agentId: 'agent-a' }), { name: 'pa', uid: 'ua' })
-    const b = bindings.bind(record({ agentId: 'agent-b', grants: ['exec'] }), { name: 'pb', uid: 'ub' })
+    const a = mustBind(bindings, record({ agentId: 'agent-a' }), { name: 'pa', uid: 'ua' })
+    const b = mustBind(bindings, record({ agentId: 'agent-b', grants: ['exec'] }), { name: 'pb', uid: 'ub' })
     expect(bindings.authorize({ credential: a.credential, generation: 3, capability: 'exec' }).ok).toBe(false)
     const resolved = bindings.authorize({ credential: b.credential, generation: 3, capability: 'exec' })
     expect(resolved.ok && resolved.binding.agentId).toBe('agent-b')
@@ -317,8 +413,8 @@ describe('shim binding registry', () => {
   it('revokes by agent across pod incarnations', () => {
     const bindings = registry()
     clock.value = 1_000
-    const first = bindings.bind(record(), { name: 'p1', uid: 'u1' })
-    const second = bindings.bind(record({ generation: 4 }), { name: 'p2', uid: 'u2' })
+    const first = mustBind(bindings, record(), { name: 'p1', uid: 'u1' })
+    const second = mustBind(bindings, record({ generation: 4 }), { name: 'p2', uid: 'u2' })
     bindings.revokeAgent('agent-a')
     expect(bindings.size()).toBe(0)
     expect(bindings.authorize({ credential: first.credential, generation: 3, capability: 'materialize' }).ok).toBe(
@@ -446,6 +542,117 @@ describe('shim client', () => {
     // healthy pod, which is what made the channel silently die after ten minutes.
     clock.advance(300_000)
     await waitFor(() => dials === 2)
+    client.stop()
+  })
+
+  it('ignores a delayed close from a transport that has already been replaced', async () => {
+    // Renewal closes transport A and binds B. If A's close event lands late — a
+    // close-handshake timeout, say — it must not clear B's binding or end B's channel.
+    const clock = new FakeClock()
+    const closers: Array<(code: number, reason: string) => void> = []
+    const messagers: Array<(text: string) => void> = []
+    const client = new ShimClient({
+      endpoint: 'ws://daemon:9000',
+      dial: async () => ({
+        send: () => {},
+        onMessage: (cb) => messagers.push(cb),
+        onClose: (cb) => closers.push(cb),
+        close: () => {}
+      }),
+      readToken: () => 't',
+      clock,
+      backoff: new Backoff({ jitter: () => 0 }),
+      log: { info: () => {}, warn: () => {} }
+    })
+    const bind = (index: number, generation: number) =>
+      messagers[index]?.(
+        JSON.stringify({
+          type: 'shim/bound',
+          sessionCredential: `cred-${generation}`,
+          expiresInSeconds: 600,
+          agentId: 'agent-a',
+          generation,
+          grants: ['materialize']
+        })
+      )
+    const started = client.start()
+    await waitFor(() => messagers.length === 1)
+    bind(0, 3)
+    await started
+
+    clock.advance(300_000) // renewal deadline: A is closed, B is dialed
+    await waitFor(() => messagers.length === 2)
+    bind(1, 4)
+    await waitFor(() => client.binding()?.generation === 4)
+
+    // A's delayed close arrives now.
+    closers[0]?.(1006, 'late close from the replaced transport')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(client.binding()?.generation).toBe(4)
+    expect(messagers).toHaveLength(2) // no spurious third dial
+    client.stop()
+  })
+
+  it('backs off after a drop but re-dials a planned renewal at once', async () => {
+    const clock = new FakeClock()
+    let dials = 0
+    const closers: Array<(code: number, reason: string) => void> = []
+    const messagers: Array<(text: string) => void> = []
+    const client = new ShimClient({
+      endpoint: 'ws://daemon:9000',
+      dial: async () => {
+        dials += 1
+        return {
+          send: () => {},
+          onMessage: (cb) => messagers.push(cb),
+          onClose: (cb) => closers.push(cb),
+          close: () => {}
+        }
+      },
+      readToken: () => 't',
+      clock,
+      backoff: new Backoff({ jitter: () => 0 }),
+      log: { info: () => {}, warn: () => {} }
+    })
+    const bind = (index: number, generation: number) =>
+      messagers[index]?.(
+        JSON.stringify({
+          type: 'shim/bound',
+          sessionCredential: `c${generation}`,
+          expiresInSeconds: 600,
+          agentId: 'agent-a',
+          generation,
+          grants: ['materialize']
+        })
+      )
+    const started = client.start()
+    // Wait for the transport's callbacks, not the dial counter: the counter increments
+    // before connectOnce registers them, so binding on it fires into an empty slot.
+    await waitFor(() => messagers.length === 1)
+    bind(0, 3)
+    await started
+
+    // A renewal is not a failure: it re-dials without waiting out a backoff delay.
+    clock.advance(300_000)
+    await waitFor(() => messagers.length === 2)
+    expect(dials).toBe(2)
+    bind(1, 4)
+    await waitFor(() => client.binding()?.generation === 4)
+
+    // A drop IS a failure signal, so the next dial waits for the backoff delay. The daemon
+    // may be rolling, and immediate re-dials are what backoff exists to prevent.
+    expect(closers).toHaveLength(2)
+    closers[1]?.(1006, 'dropped')
+    await waitFor(() => client.binding() === undefined)
+    // Let the loop arm its backoff timer, then assert it has NOT re-dialed: a drop must
+    // wait out the delay, because the daemon may be rolling and immediate re-dials are
+    // exactly what backoff prevents.
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(dials).toBe(2)
+    clock.advance(60_000)
+    await waitFor(() => messagers.length === 3)
+    expect(dials).toBe(3)
+    expect(dials).toBe(3)
     client.stop()
   })
 

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Backoff, FakeClock } from '@agentconnect.md/connection'
 import { WebSocket } from 'ws'
 import { ShimBindingRegistry, type SpawnRecord } from '../src/shim/binding.js'
 import { ShimListener, type PodIdentityVerifier } from '../src/shim/listener.js'
@@ -40,12 +41,14 @@ async function listener(deps: {
   verifier: PodIdentityVerifier
   spawnRecordForPod?: (pod: { name: string; uid: string }) => SpawnRecord | undefined
   now?: () => number
+  clock?: FakeClock
   credentialTtlMs?: number
 }): Promise<{ instance: ShimListener; endpoint: string }> {
   const instance = new ShimListener({
     verifier: deps.verifier,
     spawnRecordForPod: deps.spawnRecordForPod ?? (() => record()),
     now: deps.now ?? (() => Date.now()),
+    ...(deps.clock ? { clock: deps.clock } : {}),
     ...(deps.credentialTtlMs !== undefined ? { credentialTtlMs: deps.credentialTtlMs } : {}),
     log: { info: () => {}, warn: () => {} }
   })
@@ -111,7 +114,7 @@ describe('shim handshake', () => {
     const client = await rawConnect(endpoint)
     client.send({ type: 'shim/hello', token: 'wrong-audience' })
     await waitFor(() => client.frames.length > 0)
-    expect(client.frames[0]).toMatchObject({ type: 'shim/rejected', reason: 'unauthenticated' })
+    expect(client.frames[0]).toMatchObject({ type: 'shim/rejected' })
     const { code } = await client.closed
     expect(code).toBe(4403)
   })
@@ -126,7 +129,8 @@ describe('shim handshake', () => {
     const client = await rawConnect(endpoint)
     client.send({ type: 'shim/hello', token: 'genuine-but-unrelated' })
     await waitFor(() => client.frames.length > 0)
-    expect(client.frames[0]).toMatchObject({ type: 'shim/rejected', reason: 'unknown_pod' })
+    // Same wire answer as an unauthenticated token, deliberately (see the probing test).
+    expect(client.frames[0]).toMatchObject({ type: 'shim/rejected' })
   })
 
   it('gives the same coarse rejection shape for both failures, so it cannot be probed', async () => {
@@ -135,16 +139,19 @@ describe('shim handshake', () => {
       verifier: verifier({ authenticated: true, podName: 'p', podUid: 'u' }),
       spawnRecordForPod: () => undefined
     })
+    const seen: string[] = []
     for (const target of [unauthenticated, unknownPod]) {
       const client = await rawConnect(target.endpoint)
       client.send({ type: 'shim/hello', token: 't' })
       await waitFor(() => client.frames.length > 0)
-      const frame = client.frames[0] as { type: string; message: string }
+      const frame = client.frames[0] as { type: string; reason: string; message: string }
       expect(frame.type).toBe('shim/rejected')
-      // The reason distinguishes them for our own logs, but the message never names a
-      // pod, a token, or which check ran.
+      seen.push(`${frame.reason}|${frame.message}`)
       expect(frame.message).not.toMatch(/pod-uid|token-|agent-a/)
     }
+    // Byte-identical on the wire. Sending the precise reason would let a caller tell
+    // "token not accepted" from "pod not recognized" and probe for launched pods.
+    expect(new Set(seen).size).toBe(1)
   })
 
   it('refuses an upgrade that does not offer the shim subprotocol', async () => {
@@ -182,12 +189,51 @@ describe('shim handshake', () => {
     expect(code).toBe(4400)
   })
 
-  it('re-binds a rebuilt pod and drops the previous credential (invariants 4, 5)', async () => {
+  it('closes a second hello arriving while the first is still being reviewed', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => (release = resolve))
+    const { endpoint } = await listener({
+      verifier: {
+        reviewToken: async () => {
+          await gate
+          return { authenticated: true, podName: 'p', podUid: 'u' }
+        }
+      }
+    })
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 't' })
+    // Without single-flight this would bind twice and leave a stale connection entry.
+    client.send({ type: 'shim/hello', token: 't' })
+    const { code } = await client.closed
+    expect(code).toBe(4400)
+    release()
+  })
+
+  it('closes the channel when the credential expires, so the peer cannot hold a dead one', async () => {
+    const clock = new FakeClock()
+    const { endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'p', podUid: 'u' }),
+      now: () => clock.now(),
+      clock,
+      credentialTtlMs: 60_000
+    })
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => client.frames.length > 0)
+    clock.advance(60_001)
+    const { reason } = await client.closed
+    expect(reason).toBe('credential expired')
+  })
+
+  it('re-binds a rescheduled pod under a NEW uid and drops the previous credential (invariants 4, 5)', async () => {
     // Resume, first bind and eviction are indistinguishable to the protocol: each new pod
-    // presents its own token. What must not survive is the old pod's credential.
+    // presents its own token. Crucially the replacement pod has a DIFFERENT uid — keying
+    // supersession on the pod would leave the evicted incarnation's credential live, which
+    // is exactly the replay the fence exists to stop.
     let generation = 3
+    let podUid = 'pod-uid-1'
     const { instance, endpoint } = await listener({
-      verifier: verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' }),
+      verifier: { reviewToken: async () => ({ authenticated: true, podName: `runtime-${podUid}`, podUid }) },
       spawnRecordForPod: () => record({ generation })
     })
     const first = await rawConnect(endpoint)
@@ -196,6 +242,7 @@ describe('shim handshake', () => {
     const before = first.frames[0] as ShimBound
 
     generation = 4
+    podUid = 'pod-uid-2'
     const second = await rawConnect(endpoint)
     second.send({ type: 'shim/hello', token: 't' })
     await waitFor(() => second.frames.length > 0)
@@ -204,10 +251,13 @@ describe('shim handshake', () => {
     expect(after.generation).toBe(4)
     expect(after.sessionCredential).not.toBe(before.sessionCredential)
     // The superseded credential authorizes nothing, so a frame replayed from the previous
-    // incarnation cannot act.
+    // incarnation cannot act — at its OWN generation, which is the case that matters.
     expect(
       instance.authorize({ credential: before.sessionCredential, generation: 3, capability: 'materialize' })
     ).toEqual({ ok: false, failure: 'unknown_credential' })
+    // And the dead channel is gone rather than lingering as a bindable connection.
+    await waitFor(() => instance.connectionsFor('agent-a').length === 1)
+    expect(instance.connectionsFor('agent-a')[0]?.binding.podUid).toBe('pod-uid-2')
   })
 })
 
@@ -312,6 +362,91 @@ describe('shim client', () => {
     const bound = await started
     expect(bound.agentId).toBe('agent-a')
     expect(client.binding()?.sessionCredential).toBe('cred-1')
+  })
+
+  it('re-dials after the channel drops instead of staying alive but detached', async () => {
+    const clock = new FakeClock()
+    const dials: Array<{ send: (t: string) => void; close: (c: number, r: string) => void }> = []
+    let onMessage: ((text: string) => void) | undefined
+    let onClose: ((code: number, reason: string) => void) | undefined
+    const client = new ShimClient({
+      endpoint: 'ws://daemon:9000',
+      dial: async () => {
+        const transport: ShimTransport = {
+          send: () => {},
+          onMessage: (cb) => (onMessage = cb),
+          onClose: (cb) => (onClose = cb),
+          close: () => {}
+        }
+        dials.push(transport)
+        return transport
+      },
+      readToken: () => 't',
+      clock,
+      backoff: new Backoff({ jitter: () => 0 }),
+      log: { info: () => {}, warn: () => {} }
+    })
+    const bind = (generation: number) =>
+      onMessage?.(
+        JSON.stringify({
+          type: 'shim/bound',
+          sessionCredential: `cred-${generation}`,
+          expiresInSeconds: 600,
+          agentId: 'agent-a',
+          generation,
+          grants: ['materialize']
+        })
+      )
+    const started = client.start()
+    await waitFor(() => dials.length === 1)
+    bind(3)
+    await started
+
+    // The pod is healthy; the socket simply dropped. Previously this left the executable
+    // running with no channel and no retry.
+    onClose?.(1006, 'abnormal closure')
+    // The loop parks on a clock-driven backoff; advancing releases it.
+    await waitFor(() => client.binding() === undefined)
+    clock.advance(60_000)
+    await waitFor(() => dials.length === 2)
+    bind(4)
+    await waitFor(() => client.binding()?.generation === 4)
+    client.stop()
+  })
+
+  it('re-handshakes before the credential expires rather than going stale', async () => {
+    const clock = new FakeClock()
+    let dials = 0
+    let onMessage: ((text: string) => void) | undefined
+    const client = new ShimClient({
+      endpoint: 'ws://daemon:9000',
+      dial: async () => {
+        dials += 1
+        return { send: () => {}, onMessage: (cb) => (onMessage = cb), onClose: () => {}, close: () => {} }
+      },
+      readToken: () => 't',
+      clock,
+      backoff: new Backoff({ jitter: () => 0 }),
+      log: { info: () => {}, warn: () => {} }
+    })
+    const started = client.start()
+    await waitFor(() => dials === 1)
+    onMessage?.(
+      JSON.stringify({
+        type: 'shim/bound',
+        sessionCredential: 'cred-1',
+        expiresInSeconds: 600,
+        agentId: 'agent-a',
+        generation: 3,
+        grants: ['materialize']
+      })
+    )
+    await started
+    // Renewal at half the lifetime: a daemon-side credential must never expire under a
+    // healthy pod, which is what made the channel silently die after ten minutes.
+    clock.advance(300_000)
+    await waitFor(() => dials === 2)
+    client.stop()
   })
 
   it('refuses to serve a request whose credential or generation is not its own', async () => {

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -287,6 +287,72 @@ describe('shim handshake', () => {
     expect(instance.connectionsFor('agent-a')).toHaveLength(1)
   })
 
+  it('survives the superseded socket closing after a same-pod renewal has bound', async () => {
+    // The teardown-ownership race: renewal stores credential B under the same pod UID, and
+    // the superseded socket A closes afterwards. Revoking "whatever this pod holds" from
+    // A's late close deleted B, so renewal looked successful and then silently died.
+    const { instance, endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' })
+    })
+    const first = await rawConnect(endpoint)
+    first.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => first.frames.length > 0)
+    const a = first.frames[0] as ShimBound
+
+    // Same pod, same generation: a credential rotation, not a relaunch.
+    const second = await rawConnect(endpoint)
+    second.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => second.frames.length > 0)
+    const b = second.frames[0] as ShimBound
+    expect(b.sessionCredential).not.toBe(a.sessionCredential)
+    await waitFor(
+      () => instance.authorize({ credential: b.sessionCredential, generation: 3, capability: 'materialize' }).ok
+    )
+
+    // Now A finishes closing, after B is live.
+    first.socket.close()
+    await first.closed
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    // B must still authorize, and be the one live channel.
+    expect(instance.authorize({ credential: b.sessionCredential, generation: 3, capability: 'materialize' }).ok).toBe(
+      true
+    )
+    expect(instance.authorize({ credential: a.sessionCredential, generation: 3, capability: 'materialize' }).ok).toBe(
+      false
+    )
+    expect(instance.connectionsFor('agent-a')).toHaveLength(1)
+    expect(instance.connectionsFor('agent-a')[0]?.issuedCredential).toBe(b.sessionCredential)
+  })
+
+  it('expiry of a superseded channel does not revoke the renewed credential', async () => {
+    // Same ordering hazard through the expiry backstop rather than a socket close.
+    const clock = new FakeClock()
+    const { instance, endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' }),
+      now: () => clock.now(),
+      clock,
+      credentialTtlMs: 60_000
+    })
+    const first = await rawConnect(endpoint)
+    first.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => first.frames.length > 0)
+    const a = first.frames[0] as ShimBound
+
+    clock.advance(30_000)
+    const second = await rawConnect(endpoint)
+    second.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => second.frames.length > 0)
+    const b = second.frames[0] as ShimBound
+
+    // A's expiry deadline comes due while B is live and nowhere near its own.
+    clock.advance(30_001)
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(instance.authorize({ credential: b.sessionCredential, generation: 3, capability: 'materialize' }).ok).toBe(
+      true
+    )
+  })
+
   it('re-binds a rescheduled pod under a NEW uid and drops the previous credential (invariants 4, 5)', async () => {
     // Resume, first bind and eviction are indistinguishable to the protocol: each new pod
     // presents its own token. Crucially the replacement pod has a DIFFERENT uid — keying

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { Backoff, FakeClock } from '@agentconnect.md/connection'
-import { ClientTransport } from '@agentconnect.md/connection'
+import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
 import { WebSocket } from 'ws'
 import { ShimBindingRegistry, type SpawnRecord } from '../src/shim/binding.js'
 import { ShimListener, type PodIdentityVerifier } from '../src/shim/listener.js'

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Backoff, FakeClock } from '@agentconnect.md/connection'
+import { ClientTransport } from '@agentconnect.md/connection'
 import { WebSocket } from 'ws'
 import { ShimBindingRegistry, type SpawnRecord } from '../src/shim/binding.js'
 import { ShimListener, type PodIdentityVerifier } from '../src/shim/listener.js'
@@ -351,14 +352,35 @@ describe('shim binding registry', () => {
     expect(bindings.size()).toBe(1)
   })
 
-  it('rejects rebinding the same generation, so a duplicate hello cannot rotate the credential', () => {
+  it('allows the same generation from the same pod: renewal and reconnect do not relaunch', () => {
+    // The generation counts pod launches, but a half-TTL credential renewal and a reconnect
+    // after a dropped socket both happen inside one pod. Refusing equality here stranded a
+    // healthy pod permanently unbindable.
     clock.value = 1_000
     const bindings = registry()
-    const first = bindings.bind(record({ generation: 3 }), { name: 'p', uid: 'u' })
-    expect(bindings.bind(record({ generation: 3 }), { name: 'p', uid: 'u' })).toMatchObject({ ok: false })
-    expect(
-      first.ok && bindings.authorize({ credential: first.credential, generation: 3, capability: 'materialize' }).ok
-    ).toBe(true)
+    const first = mustBind(bindings, record({ generation: 3 }), { name: 'p', uid: 'u' })
+    const renewed = mustBind(bindings, record({ generation: 3 }), { name: 'p', uid: 'u' })
+    expect(renewed.credential).not.toBe(first.credential)
+    expect(bindings.authorize({ credential: renewed.credential, generation: 3, capability: 'materialize' }).ok).toBe(
+      true
+    )
+    // The rotated-away credential stops working, so a renewal is still a replacement.
+    expect(bindings.authorize({ credential: first.credential, generation: 3, capability: 'materialize' }).ok).toBe(
+      false
+    )
+    expect(bindings.size()).toBe(1)
+  })
+
+  it('refuses the same generation from a DIFFERENT pod, which is the ambiguous case', () => {
+    clock.value = 1_000
+    const bindings = registry()
+    const held = mustBind(bindings, record({ generation: 3 }), { name: 'p1', uid: 'u1' })
+    expect(bindings.bind(record({ generation: 3 }), { name: 'p2', uid: 'u2' })).toEqual({
+      ok: false,
+      reason: 'generation_claimed_by_another_pod',
+      current: 3
+    })
+    expect(bindings.authorize({ credential: held.credential, generation: 3, capability: 'materialize' }).ok).toBe(true)
   })
 
   it('refuses a stale generation even with a live credential (invariant 4)', () => {
@@ -564,11 +586,11 @@ describe('shim client', () => {
       backoff: new Backoff({ jitter: () => 0 }),
       log: { info: () => {}, warn: () => {} }
     })
-    const bind = (index: number, generation: number) =>
+    const bind = (index: number, generation: number, credential = `cred-${generation}`) =>
       messagers[index]?.(
         JSON.stringify({
           type: 'shim/bound',
-          sessionCredential: `cred-${generation}`,
+          sessionCredential: credential,
           expiresInSeconds: 600,
           agentId: 'agent-a',
           generation,
@@ -582,13 +604,15 @@ describe('shim client', () => {
 
     clock.advance(300_000) // renewal deadline: A is closed, B is dialed
     await waitFor(() => messagers.length === 2)
-    bind(1, 4)
-    await waitFor(() => client.binding()?.generation === 4)
+    // Same generation: a renewal does not relaunch the pod. The replacement is identified
+    // by its credential, not by a bumped generation.
+    bind(1, 3, 'cred-renewed')
+    await waitFor(() => client.binding()?.sessionCredential === 'cred-renewed')
 
     // A's delayed close arrives now.
     closers[0]?.(1006, 'late close from the replaced transport')
     await new Promise((resolve) => setTimeout(resolve, 20))
-    expect(client.binding()?.generation).toBe(4)
+    expect(client.binding()?.sessionCredential).toBe('cred-renewed')
     expect(messagers).toHaveLength(2) // no spurious third dial
     client.stop()
   })
@@ -614,11 +638,11 @@ describe('shim client', () => {
       backoff: new Backoff({ jitter: () => 0 }),
       log: { info: () => {}, warn: () => {} }
     })
-    const bind = (index: number, generation: number) =>
+    const bind = (index: number, generation: number, credential = `c${index}`) =>
       messagers[index]?.(
         JSON.stringify({
           type: 'shim/bound',
-          sessionCredential: `c${generation}`,
+          sessionCredential: credential,
           expiresInSeconds: 600,
           agentId: 'agent-a',
           generation,
@@ -636,8 +660,8 @@ describe('shim client', () => {
     clock.advance(300_000)
     await waitFor(() => messagers.length === 2)
     expect(dials).toBe(2)
-    bind(1, 4)
-    await waitFor(() => client.binding()?.generation === 4)
+    bind(1, 3)
+    await waitFor(() => client.binding()?.sessionCredential === 'c1')
 
     // A drop IS a failure signal, so the next dial waits for the backoff delay. The daemon
     // may be rolling, and immediate re-dials are what backoff exists to prevent.
@@ -720,4 +744,61 @@ describe('shim client', () => {
     expect(sent.at(-1)).toMatchObject({ ok: true, payload: 'executed' })
     client.stop()
   })
+})
+
+describe('shim renewal, end to end', () => {
+  it('renews and reconnects at an UNCHANGED generation, against the real listener', async () => {
+    // The case the client-only tests masked by synthesizing a new generation: the pod never
+    // relaunches, so SpawnRecord.generation stays put across a credential renewal and a
+    // reconnect. This drives the real ShimClient against the real ShimListener over a real
+    // socket, so nothing about the generation is stubbed.
+    const clock = new FakeClock()
+    const { instance, endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' }),
+      now: () => clock.now(),
+      clock,
+      credentialTtlMs: 600_000
+    })
+    const clientClock = new FakeClock()
+    const client = new ShimClient({
+      endpoint,
+      dial: (url, opts) =>
+        ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
+      readToken: () => 'projected-token',
+      clock: clientClock,
+      backoff: new Backoff({ jitter: () => 0 }),
+      log: { info: () => {}, warn: () => {} }
+    })
+    try {
+      const first = await client.start()
+      expect(first.generation).toBe(3)
+      await waitFor(() => instance.connectionsFor('agent-a').length === 1)
+
+      // Renewal at half the advertised lifetime, with the generation unchanged.
+      clientClock.advance(300_000)
+      await waitFor(
+        () => client.binding() !== undefined && client.binding()?.sessionCredential !== first.sessionCredential
+      )
+      const renewed = client.binding()!
+      expect(renewed.generation).toBe(3)
+      // Exactly one live channel, and the new credential is the one that authorizes.
+      await waitFor(() => instance.connectionsFor('agent-a').length === 1)
+      expect(
+        instance.authorize({ credential: renewed.sessionCredential, generation: 3, capability: 'materialize' }).ok
+      ).toBe(true)
+      expect(
+        instance.authorize({ credential: first.sessionCredential, generation: 3, capability: 'materialize' }).ok
+      ).toBe(false)
+
+      // And a reconnect after the daemon drops the channel, also at generation 3.
+      instance.connectionsFor('agent-a')[0]?.close('simulated drop')
+      await waitFor(() => client.binding() === undefined)
+      clientClock.advance(60_000)
+      await waitFor(() => client.binding() !== undefined)
+      expect(client.binding()?.generation).toBe(3)
+      await waitFor(() => instance.connectionsFor('agent-a').length === 1)
+    } finally {
+      client.stop()
+    }
+  }, 20_000)
 })

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -1,0 +1,381 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { WebSocket } from 'ws'
+import { ShimBindingRegistry, type SpawnRecord } from '../src/shim/binding.js'
+import { ShimListener, type PodIdentityVerifier } from '../src/shim/listener.js'
+import { ShimClient, type ShimTransport } from '../src/shim/client.js'
+import {
+  SHIM_SUBPROTOCOL,
+  SHIM_TOKEN_AUDIENCE,
+  SHIM_WS_PATH,
+  parseShimFrame,
+  type ShimBound,
+  type ShimFrame
+} from '../src/shim/protocol.js'
+
+/** The five security invariants of the shim channel, each with the negative case that
+ *  would pass if its enforcement were removed:
+ *   1. mutual authentication — an unverifiable token binds nothing;
+ *   2. binding identity — only a pod this daemon launched can bind;
+ *   3. per-operation capability — a granted channel is not a blanket permission;
+ *   4. replay fence — a frame from a previous pod generation is refused;
+ *   5. no long-lived credential — what the shim holds is short-lived and re-obtained. */
+
+const listeners: ShimListener[] = []
+const sockets: WebSocket[] = []
+
+afterEach(async () => {
+  for (const socket of sockets.splice(0)) socket.close()
+  await Promise.all(listeners.splice(0).map((listener) => listener.stop()))
+})
+
+function record(overrides: Partial<SpawnRecord> = {}): SpawnRecord {
+  return { agentId: 'agent-a', sandboxUid: 'sandbox-uid-1', generation: 3, grants: ['materialize'], ...overrides }
+}
+
+function verifier(result: Awaited<ReturnType<PodIdentityVerifier['reviewToken']>>): PodIdentityVerifier {
+  return { reviewToken: vi.fn(async () => result) }
+}
+
+async function listener(deps: {
+  verifier: PodIdentityVerifier
+  spawnRecordForPod?: (pod: { name: string; uid: string }) => SpawnRecord | undefined
+  now?: () => number
+  credentialTtlMs?: number
+}): Promise<{ instance: ShimListener; endpoint: string }> {
+  const instance = new ShimListener({
+    verifier: deps.verifier,
+    spawnRecordForPod: deps.spawnRecordForPod ?? (() => record()),
+    now: deps.now ?? (() => Date.now()),
+    ...(deps.credentialTtlMs !== undefined ? { credentialTtlMs: deps.credentialTtlMs } : {}),
+    log: { info: () => {}, warn: () => {} }
+  })
+  listeners.push(instance)
+  const port = await instance.start(0, '127.0.0.1')
+  return { instance, endpoint: `ws://127.0.0.1:${port}` }
+}
+
+/** Raw client: sends exactly what a test dictates, including out-of-protocol frames. */
+async function rawConnect(endpoint: string): Promise<{
+  socket: WebSocket
+  frames: ShimFrame[]
+  closed: Promise<{ code: number; reason: string }>
+  send: (frame: unknown) => void
+}> {
+  const socket = new WebSocket(`${endpoint}${SHIM_WS_PATH}`, [SHIM_SUBPROTOCOL])
+  sockets.push(socket)
+  const frames: ShimFrame[] = []
+  const closed = new Promise<{ code: number; reason: string }>((resolve) =>
+    socket.on('close', (code, reason) => resolve({ code, reason: reason.toString() }))
+  )
+  socket.on('message', (data) => {
+    const frame = parseShimFrame(data.toString())
+    if (frame) frames.push(frame)
+  })
+  await new Promise<void>((resolve, reject) => {
+    socket.once('open', resolve)
+    socket.once('error', reject)
+  })
+  return { socket, frames, closed, send: (frame) => socket.send(JSON.stringify(frame)) }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const started = Date.now()
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) throw new Error('condition not met in time')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+describe('shim handshake', () => {
+  it('binds a pod whose token verifies against a spawn record, and issues only then', async () => {
+    const review = verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' })
+    const { endpoint } = await listener({ verifier: review })
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 'projected-token' })
+    await waitFor(() => client.frames.length > 0)
+    const bound = client.frames[0] as ShimBound
+    expect(bound.type).toBe('shim/bound')
+    expect(bound.agentId).toBe('agent-a')
+    expect(bound.generation).toBe(3)
+    expect(bound.grants).toEqual(['materialize'])
+    expect(bound.sessionCredential).toMatch(/^[\w-]{20,}$/)
+    // The audience is what makes handing over the pod's own token safe: a token minted
+    // for anything else must not authenticate here.
+    expect(review.reviewToken).toHaveBeenCalledWith('projected-token', [SHIM_TOKEN_AUDIENCE])
+  })
+
+  it('rejects an unauthenticated token without binding anything (invariant 1)', async () => {
+    const { endpoint } = await listener({
+      verifier: verifier({ authenticated: false, error: 'audiences is not valid for this token' })
+    })
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 'wrong-audience' })
+    await waitFor(() => client.frames.length > 0)
+    expect(client.frames[0]).toMatchObject({ type: 'shim/rejected', reason: 'unauthenticated' })
+    const { code } = await client.closed
+    expect(code).toBe(4403)
+  })
+
+  it('rejects an authenticated pod this daemon did not launch (invariant 2)', async () => {
+    // A sibling sandbox in the same org: its token is genuine and the namespace lets it
+    // reach this port, but no spawn record matches, so it binds to nothing.
+    const { endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'someone-elses-pod', podUid: 'pod-uid-9' }),
+      spawnRecordForPod: (pod) => (pod.uid === 'pod-uid-1' ? record() : undefined)
+    })
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 'genuine-but-unrelated' })
+    await waitFor(() => client.frames.length > 0)
+    expect(client.frames[0]).toMatchObject({ type: 'shim/rejected', reason: 'unknown_pod' })
+  })
+
+  it('gives the same coarse rejection shape for both failures, so it cannot be probed', async () => {
+    const unauthenticated = await listener({ verifier: verifier({ authenticated: false }) })
+    const unknownPod = await listener({
+      verifier: verifier({ authenticated: true, podName: 'p', podUid: 'u' }),
+      spawnRecordForPod: () => undefined
+    })
+    for (const target of [unauthenticated, unknownPod]) {
+      const client = await rawConnect(target.endpoint)
+      client.send({ type: 'shim/hello', token: 't' })
+      await waitFor(() => client.frames.length > 0)
+      const frame = client.frames[0] as { type: string; message: string }
+      expect(frame.type).toBe('shim/rejected')
+      // The reason distinguishes them for our own logs, but the message never names a
+      // pod, a token, or which check ran.
+      expect(frame.message).not.toMatch(/pod-uid|token-|agent-a/)
+    }
+  })
+
+  it('refuses an upgrade that does not offer the shim subprotocol', async () => {
+    const { endpoint } = await listener({ verifier: verifier({ authenticated: true, podName: 'p', podUid: 'u' }) })
+    const socket = new WebSocket(`${endpoint}${SHIM_WS_PATH}`)
+    sockets.push(socket)
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        socket.once('open', () => resolve())
+        socket.once('error', reject)
+      })
+    ).rejects.toThrow()
+  })
+
+  it('closes on a request arriving before a binding exists', async () => {
+    const { endpoint } = await listener({ verifier: verifier({ authenticated: true, podName: 'p', podUid: 'u' }) })
+    const client = await rawConnect(endpoint)
+    client.send({
+      type: 'shim/request',
+      id: '11111111-1111-4111-8111-111111111111',
+      sessionCredential: 'guessed',
+      generation: 3,
+      capability: 'materialize',
+      payload: {}
+    })
+    const { code } = await client.closed
+    expect(code).toBe(4403)
+  })
+
+  it('closes on a malformed frame rather than tolerating it', async () => {
+    const { endpoint } = await listener({ verifier: verifier({ authenticated: true, podName: 'p', podUid: 'u' }) })
+    const client = await rawConnect(endpoint)
+    client.socket.send('{not json')
+    const { code } = await client.closed
+    expect(code).toBe(4400)
+  })
+
+  it('re-binds a rebuilt pod and drops the previous credential (invariants 4, 5)', async () => {
+    // Resume, first bind and eviction are indistinguishable to the protocol: each new pod
+    // presents its own token. What must not survive is the old pod's credential.
+    let generation = 3
+    const { instance, endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' }),
+      spawnRecordForPod: () => record({ generation })
+    })
+    const first = await rawConnect(endpoint)
+    first.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => first.frames.length > 0)
+    const before = first.frames[0] as ShimBound
+
+    generation = 4
+    const second = await rawConnect(endpoint)
+    second.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => second.frames.length > 0)
+    const after = second.frames[0] as ShimBound
+
+    expect(after.generation).toBe(4)
+    expect(after.sessionCredential).not.toBe(before.sessionCredential)
+    // The superseded credential authorizes nothing, so a frame replayed from the previous
+    // incarnation cannot act.
+    expect(
+      instance.authorize({ credential: before.sessionCredential, generation: 3, capability: 'materialize' })
+    ).toEqual({ ok: false, failure: 'unknown_credential' })
+  })
+})
+
+describe('shim binding registry', () => {
+  const clock = { value: 1_000 }
+  const registry = (): ShimBindingRegistry => new ShimBindingRegistry(() => clock.value, 60_000)
+
+  it('refuses a stale generation even with a live credential (invariant 4)', () => {
+    const bindings = registry()
+    const { credential } = bindings.bind(record({ generation: 7 }), { name: 'p', uid: 'u' })
+    expect(bindings.authorize({ credential, generation: 7, capability: 'materialize' }).ok).toBe(true)
+    expect(bindings.authorize({ credential, generation: 6, capability: 'materialize' })).toEqual({
+      ok: false,
+      failure: 'stale_generation'
+    })
+  })
+
+  it('refuses a capability the launch was not granted (invariant 3)', () => {
+    const bindings = registry()
+    const { credential } = bindings.bind(record({ grants: ['materialize'] }), { name: 'p', uid: 'u' })
+    // Holding the channel is not holding every operation on it: one runtime must not be
+    // able to reach a capability its own launch never received.
+    expect(bindings.authorize({ credential, generation: 3, capability: 'exec' })).toEqual({
+      ok: false,
+      failure: 'capability_not_granted'
+    })
+    expect(bindings.authorize({ credential, generation: 3, capability: 'tunnel' })).toEqual({
+      ok: false,
+      failure: 'capability_not_granted'
+    })
+  })
+
+  it('expires a credential rather than honouring it indefinitely (invariant 5)', () => {
+    clock.value = 1_000
+    const bindings = registry()
+    const { credential } = bindings.bind(record(), { name: 'p', uid: 'u' })
+    clock.value = 61_001
+    expect(bindings.authorize({ credential, generation: 3, capability: 'materialize' })).toEqual({
+      ok: false,
+      failure: 'expired_credential'
+    })
+    // And it is dropped, so a later clock rewind cannot revive it.
+    clock.value = 1_000
+    expect(bindings.authorize({ credential, generation: 3, capability: 'materialize' }).ok).toBe(false)
+  })
+
+  it('does not leak one agent credential to another agent (invariant 3)', () => {
+    const bindings = registry()
+    clock.value = 1_000
+    const a = bindings.bind(record({ agentId: 'agent-a' }), { name: 'pa', uid: 'ua' })
+    const b = bindings.bind(record({ agentId: 'agent-b', grants: ['exec'] }), { name: 'pb', uid: 'ub' })
+    expect(bindings.authorize({ credential: a.credential, generation: 3, capability: 'exec' }).ok).toBe(false)
+    const resolved = bindings.authorize({ credential: b.credential, generation: 3, capability: 'exec' })
+    expect(resolved.ok && resolved.binding.agentId).toBe('agent-b')
+  })
+
+  it('revokes by agent across pod incarnations', () => {
+    const bindings = registry()
+    clock.value = 1_000
+    const first = bindings.bind(record(), { name: 'p1', uid: 'u1' })
+    const second = bindings.bind(record({ generation: 4 }), { name: 'p2', uid: 'u2' })
+    bindings.revokeAgent('agent-a')
+    expect(bindings.size()).toBe(0)
+    expect(bindings.authorize({ credential: first.credential, generation: 3, capability: 'materialize' }).ok).toBe(
+      false
+    )
+    expect(bindings.authorize({ credential: second.credential, generation: 4, capability: 'materialize' }).ok).toBe(
+      false
+    )
+  })
+})
+
+describe('shim client', () => {
+  it('presents the projected token and reports the binding it was issued', async () => {
+    const sent: unknown[] = []
+    let onMessage: ((text: string) => void) | undefined
+    const transport: ShimTransport = {
+      send: (text) => sent.push(JSON.parse(text)),
+      onMessage: (cb) => (onMessage = cb),
+      onClose: () => {},
+      close: () => {}
+    }
+    const client = new ShimClient({
+      endpoint: 'ws://daemon:9000',
+      dial: async () => transport,
+      readToken: () => 'rotating-token',
+      log: { info: () => {}, warn: () => {} }
+    })
+    const started = client.start()
+    await waitFor(() => sent.length > 0)
+    expect(sent[0]).toEqual({ type: 'shim/hello', token: 'rotating-token' })
+    onMessage?.(
+      JSON.stringify({
+        type: 'shim/bound',
+        sessionCredential: 'cred-1',
+        expiresInSeconds: 600,
+        agentId: 'agent-a',
+        generation: 3,
+        grants: ['materialize']
+      })
+    )
+    const bound = await started
+    expect(bound.agentId).toBe('agent-a')
+    expect(client.binding()?.sessionCredential).toBe('cred-1')
+  })
+
+  it('refuses to serve a request whose credential or generation is not its own', async () => {
+    const sent: any[] = []
+    let onMessage: ((text: string) => void) | undefined
+    const transport: ShimTransport = {
+      send: (text) => sent.push(JSON.parse(text)),
+      onMessage: (cb) => (onMessage = cb),
+      onClose: () => {},
+      close: () => {}
+    }
+    const handle = vi.fn(async () => 'executed')
+    const client = new ShimClient({
+      endpoint: 'ws://daemon:9000',
+      dial: async () => transport,
+      readToken: () => 't',
+      handle,
+      log: { info: () => {}, warn: () => {} }
+    })
+    const started = client.start()
+    await waitFor(() => sent.length > 0)
+    onMessage?.(
+      JSON.stringify({
+        type: 'shim/bound',
+        sessionCredential: 'cred-1',
+        expiresInSeconds: 600,
+        agentId: 'agent-a',
+        generation: 3,
+        grants: ['materialize']
+      })
+    )
+    await started
+
+    const request = (overrides: Record<string, unknown>) =>
+      onMessage?.(
+        JSON.stringify({
+          type: 'shim/request',
+          id: '22222222-2222-4222-8222-222222222222',
+          sessionCredential: 'cred-1',
+          generation: 3,
+          capability: 'materialize',
+          payload: {},
+          ...overrides
+        })
+      )
+
+    request({ sessionCredential: 'stolen' })
+    await waitFor(() => sent.length > 1)
+    expect(sent.at(-1)).toMatchObject({ ok: false, error: 'not bound' })
+
+    request({ generation: 2 })
+    await waitFor(() => sent.length > 2)
+    expect(sent.at(-1)).toMatchObject({ ok: false, error: 'not bound' })
+
+    request({ capability: 'exec' })
+    await waitFor(() => sent.length > 3)
+    expect(sent.at(-1)).toMatchObject({ ok: false, error: 'not granted' })
+    // None of the three reached the handler: the shim re-checks rather than trusting that
+    // the daemon already did, so a compromised daemon-side path is not the only gate.
+    expect(handle).not.toHaveBeenCalled()
+
+    request({})
+    await waitFor(() => sent.length > 4)
+    expect(sent.at(-1)).toMatchObject({ ok: true, payload: 'executed' })
+    client.stop()
+  })
+})

--- a/packages/daemon/tsdown.shim.config.ts
+++ b/packages/daemon/tsdown.shim.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'tsdown'
+
+// The in-sandbox shim is built SEPARATELY from the daemon bundle, and that separation is
+// the point rather than a convenience. Adding it as another entry of the main build makes
+// rolldown share chunks between them, so shipping the shim would mean copying the daemon's
+// whole chunk graph — its CP client, platform SDKs and credential paths — into the
+// half-trusted runtime image. A separate build gives the shim its own graph with
+// everything inlined, so the image carries one file and nothing else.
+//
+// It is built in this package so both halves of the channel are versioned, reviewed and
+// tested together; it is published as part of the runtime image, not the daemon.
+export default defineConfig({
+  entry: { index: 'src/shim/index.ts' },
+  outDir: 'dist/shim',
+  format: ['esm'],
+  platform: 'node',
+  fixedExtension: false,
+  // Inline everything: the runtime image installs no node_modules for the shim.
+  deps: { alwaysBundle: [/.*/], neverBundle: ['bufferutil', 'utf-8-validate'] },
+  shims: true,
+  dts: false,
+  sourcemap: true,
+  // No `clean`: this build writes into the same dist/ the daemon bundle owns.
+  clean: false
+})


### PR DESCRIPTION
Closes #813. Part of #804, and the most security-relevant seam in it.

The shim is the arm inside a runtime sandbox that performs what the daemon used to do by
sharing a filesystem and a set of unix sockets. It holds **no policy** — every decision
stays daemon-side. The channels themselves (materialization, exec, socket tunnels) land in
#814 / #815 on top of this.

## Direction

The shim dials out; the daemon listens. The sandbox therefore needs **zero inbound**: an
empty NetworkPolicy ingress list and no per-sandbox Service. The reverse direction would
need a Service per sandbox, an ingress allowance, and a readiness probe — all surface for
nothing.

## Binding, and the two shortcuts that are wrong

Identity is the pod's own **audience-restricted, permissionless** projected ServiceAccount
token, verified through TokenReview and mapped to a spawn record. Audience-restricted plus
zero RoleBindings means the token is useless anywhere except proving "I am this pod" here.

Both tempting alternatives are rejected in comments so they are not reinvented:

- **A bootstrap token in the `SandboxClaim`.** A claim with non-empty `env` bypasses
  warm-pool adoption, and claim env does not propagate to a rebuilt pod — so after a resume
  or eviction the pod holds only an exhausted token and the wake path deadlocks.
- **Reverse-looking the source IP.** Pod IPs are reusable and the Sandbox status mirroring
  them is asynchronous; inside that stale window a sibling sandbox in the same namespace
  could present a just-recycled IP and claim a victim agent's channel. The source address
  is a logging hint only, never a trust input.

Because identity is the pod's own rotating credential, first bind, resume, and eviction are
indistinguishable to the protocol — each new pod presents its own token, so there is no
one-shot token that can be revived.

## One predicate, not five checks

All five invariants are enforced through a single gate, `ShimBindingRegistry.authorize`:
credential (constant-time compare), expiry, generation, capability. There is no other way
to turn a credential into a binding, so a channel added later **cannot** skip the
generation fence or the capability check.

That structure is a direct response to this workstream's review history: my defects have
clustered exactly where a rule had more than one enforcement point and the points
disagreed (#821's startup-vs-capability gap, #825's mode-vs-marker gap). An invariant is
only as strong as its weakest enforcement point.

The shim also re-checks credential, generation, and grant before serving, rather than
trusting the daemon already did — deliberate redundancy on the boundary that matters most.
Rejections carry one coarse reason and name no pod, token, or agent, so the endpoint cannot
be probed for valid identities.

## Packaging turned out to matter as much as the protocol

My first attempt added the shim as another entry of the daemon bundle. It built — and
produced a shim that `import`s shared chunks. Shipping that means copying the daemon's
**entire chunk graph** (CP client, platform SDKs, credential paths) into the half-trusted
runtime image.

So the shim is a separate `tsdown` build with its own graph and everything inlined, and
`assert-self-contained.mjs` now **fails the build** if the shim imports anything but
`node:` builtins. The image carries one 258 KB file. Worth noting the failure mode this
closes: nothing about a code-split shim looks wrong until you read its imports.

## Tests

15 tests, one per invariant plus the negative case that would pass if its enforcement were
removed: unauthenticated token binds nothing; an authenticated pod with no spawn record
(the sibling-sandbox case) binds nothing; both rejections are shape-identical so they
cannot be compared to probe; a stale generation with a live credential is refused; an
ungranted capability is refused; a credential expires and stays dead across a clock rewind;
one agent's credential cannot reach another's capability; a rebuilt pod supersedes the old
credential; requests before binding, malformed frames, and upgrades without the subprotocol
are all closed.

Daemon typecheck, eslint, prettier clean; build green including the new self-containment
assertion.

## Not in this PR

No cluster driver yet (#816) and no channel bodies (#814 / #815) — this is the transport
and the trust boundary they mount on. `docs/designs/cluster-spawn-and-shim.md` records the
seam, the rejected alternatives, and states plainly that this stage has no hardened
isolation and keeps a provider key inside the sandbox.
