### PR TITLE
feat(daemon): route materialization and credential sockets through the shim

### DIFF
--- a/packages/daemon/src/agents/config-file-env.ts
+++ b/packages/daemon/src/agents/config-file-env.ts
@@ -29,6 +29,7 @@
  * least-privilege tokens) remains the real permission boundary.
  */
 import { chmodSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import type { FileSink } from '../shim/file-sink.js'
 import { dirname, join, resolve } from 'node:path'
 
 export interface ConfigFileConvention {
@@ -148,6 +149,50 @@ export function materializeConfigFiles(agentDir: string, env: Record<string, str
       } catch {
         /* best-effort */
       }
+    } catch (err) {
+      out.notices.push(
+        `${entry.sourceVar} could not be materialized to a file (${(err as Error).message}) — left as an env var.`
+      )
+      continue
+    }
+    out.env[entry.convention.pointerVar] = entry.convention.pointerTo === 'dir' ? dirname(file) : file
+    // Strip every name that carries this content, not just the winning source —
+    // a legacy alias must not survive alongside the materialized new name.
+    for (const name of [entry.convention.dataVar, ...(entry.convention.aliases ?? [])]) {
+      if (env[name]) out.strip.push(name)
+    }
+  }
+  return out
+}
+
+/**
+ * Materialize the planned config files through a {@link FileSink}, so the same policy runs
+ * whether the files land on this daemon's disk or inside a sandbox pod.
+ *
+ * The plan is identical either way — which secrets become files is the daemon's decision.
+ * Only the writing moves, because only the driver knows whose filesystem the runtime reads.
+ * Failure handling matches the synchronous path: a write failure leaves that convention's
+ * env untouched (the raw data var stays visible — degraded, but strictly more usable than
+ * losing both) and reports a notice.
+ */
+export async function materializeConfigFilesThrough(
+  agentDir: string,
+  env: Record<string, string | undefined>,
+  sink: FileSink
+): Promise<MaterializeResult> {
+  const plan = planConfigFiles(env)
+  const out: MaterializeResult = { env: {}, strip: [], notices: [...plan.notices] }
+  const dir = configFilesDir(agentDir)
+  const clearError = await sink.clear(dir)
+  if (clearError) {
+    if (plan.materialize.length === 0) return out
+    out.notices.push(`${clearError} — secrets left as env vars.`)
+    return out
+  }
+  for (const entry of plan.materialize) {
+    const file = join(dir, ...entry.convention.relPath)
+    try {
+      await sink.write(dir, entry.convention.relPath, entry.value)
     } catch (err) {
       out.notices.push(
         `${entry.sourceVar} could not be materialized to a file (${(err as Error).message}) — left as an env var.`

--- a/packages/daemon/src/shim/channels.ts
+++ b/packages/daemon/src/shim/channels.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from 'node:crypto'
+import type { ShimConnection } from './listener.js'
+import type { ShimCapability, ShimResponse } from './protocol.js'
+import { parseShimFrame } from './protocol.js'
+import type { FileSink } from './file-sink.js'
+
+/** How a daemon-side caller reaches a bound shim: one authorized request, one reply. */
+export interface ShimRequester {
+  request(capability: ShimCapability, payload: unknown, timeoutMs?: number): Promise<unknown>
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+
+/**
+ * Issue requests on a bound channel, correlating replies by id.
+ *
+ * Every request carries the credential and generation the binding was issued with, so the
+ * shim can refuse a frame that is not for its own incarnation — and does, independently of
+ * this side. The generation travels on each frame rather than being assumed from the
+ * connection, because a channel outlives neither a renewal nor a relaunch silently.
+ */
+export class ShimChannel implements ShimRequester {
+  private readonly pending = new Map<string, { resolve: (value: unknown) => void; reject: (err: Error) => void }>()
+
+  constructor(
+    private readonly connection: ShimConnection,
+    private readonly credential: string,
+    private readonly deps: { setTimeout: (fn: () => void, ms: number) => unknown; clearTimeout: (h: unknown) => void }
+  ) {}
+
+  /** Feed an inbound frame; returns true when it was a reply this channel was waiting for. */
+  accept(text: string): boolean {
+    const frame = parseShimFrame(text)
+    if (!frame || frame.type !== 'shim/response') return false
+    const waiter = this.pending.get(frame.id)
+    if (!waiter) return false
+    this.pending.delete(frame.id)
+    if (frame.ok) waiter.resolve(frame.payload)
+    else waiter.reject(new Error(frame.error ?? 'shim request failed'))
+    return true
+  }
+
+  request(capability: ShimCapability, payload: unknown, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS): Promise<unknown> {
+    const id = randomUUID()
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = this.deps.setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`shim ${capability} request timed out after ${timeoutMs}ms`))
+      }, timeoutMs)
+      this.pending.set(id, {
+        resolve: (value) => {
+          this.deps.clearTimeout(timer)
+          resolve(value)
+        },
+        reject: (err) => {
+          this.deps.clearTimeout(timer)
+          reject(err)
+        }
+      })
+      this.connection.send({
+        type: 'shim/request',
+        id,
+        sessionCredential: this.credential,
+        generation: this.connection.binding.generation,
+        capability,
+        payload
+      })
+    })
+  }
+
+  /** Fail every in-flight request; the channel is gone and a caller must not hang on it. */
+  abort(reason: string): void {
+    for (const [id, waiter] of [...this.pending]) {
+      this.pending.delete(id)
+      waiter.reject(new Error(reason))
+    }
+  }
+
+  pendingCount(): number {
+    return this.pending.size
+  }
+}
+
+/**
+ * A {@link FileSink} that writes inside the sandbox by asking the shim to do it.
+ *
+ * The daemon still decides which files exist and what they contain; this only moves the
+ * write. It carries no path logic of its own — the shim validates containment on its side,
+ * where the filesystem actually is.
+ */
+export class ShimFileSink implements FileSink {
+  constructor(private readonly requester: ShimRequester) {}
+
+  async clear(root: string): Promise<string | undefined> {
+    try {
+      await this.requester.request('materialize', { op: 'clear', root })
+      return undefined
+    } catch (err) {
+      return `config files could not be cleared in the sandbox (${(err as Error).message})`
+    }
+  }
+
+  async write(root: string, relPath: string[], content: string): Promise<void> {
+    await this.requester.request('materialize', { op: 'write', root, relPath, content })
+  }
+}
+
+/** The response a shim sends for a request it will not serve. */
+export function shimRefusal(id: string, error: string): ShimResponse {
+  return { type: 'shim/response', id, ok: false, error }
+}

--- a/packages/daemon/src/shim/file-sink.ts
+++ b/packages/daemon/src/shim/file-sink.ts
@@ -1,0 +1,107 @@
+import { chmodSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, isAbsolute, join, normalize, resolve, sep } from 'node:path'
+import { z } from 'zod'
+
+/**
+ * Where daemon-decided files get written. `LocalFileSink` writes this daemon's own disk;
+ * the cluster driver's sink pushes the same operations through the shim into the sandbox.
+ *
+ * The split matters because the *decision* is policy and the *write* is placement: which
+ * secrets become files is the daemon's business either way, but only the driver knows
+ * whose filesystem the runtime will read.
+ */
+export interface FileSink {
+  /** Replace the directory's contents, retaining the root inode. */
+  clear(root: string): Promise<string | undefined>
+  /** Write one file with 0600, creating parents. */
+  write(root: string, relPath: string[], content: string): Promise<void>
+}
+
+/** Relative path segments, rejecting anything that could escape the root. */
+export const SinkRelPathSchema = z
+  .array(z.string().min(1).max(255))
+  .min(1)
+  .max(8)
+  .refine(
+    (segments) =>
+      segments.every(
+        (segment) => segment !== '.' && segment !== '..' && !segment.includes('/') && !segment.includes('\\')
+      ),
+    { message: 'path segments must be plain names' }
+  )
+
+export const MaterializePayloadSchema = z.object({
+  op: z.literal('write'),
+  root: z.string().min(1),
+  relPath: SinkRelPathSchema,
+  content: z.string()
+})
+
+export const ClearPayloadSchema = z.object({ op: z.literal('clear'), root: z.string().min(1) })
+
+export const FileSinkPayloadSchema = z.discriminatedUnion('op', [MaterializePayloadSchema, ClearPayloadSchema])
+export type FileSinkPayload = z.infer<typeof FileSinkPayloadSchema>
+
+/** Resolve a sink path and refuse anything that leaves the root, whichever side runs it. */
+export function resolveSinkPath(root: string, relPath: string[]): string {
+  if (!isAbsolute(root)) throw new Error(`sink root must be absolute: ${root}`)
+  const base = resolve(root)
+  const target = normalize(join(base, ...relPath))
+  if (target !== base && !target.startsWith(base + sep)) {
+    throw new Error('sink path escapes its root')
+  }
+  return target
+}
+
+function mkdirPrivate(dir: string): void {
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  try {
+    chmodSync(dir, 0o700) // defeat a loose umask; best-effort on non-POSIX
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Today's behaviour: write the daemon's own disk. */
+export class LocalFileSink implements FileSink {
+  async clear(root: string): Promise<string | undefined> {
+    const dir = resolve(root)
+    try {
+      for (const entry of readdirSync(dir)) rmSync(join(dir, entry), { recursive: true, force: true })
+    } catch (err) {
+      const code = (err as { code?: string }).code
+      if (code === 'ENOENT') return undefined
+      return `config files could not be cleared (${(err as Error).message})`
+    }
+    return undefined
+  }
+
+  async write(root: string, relPath: string[], content: string): Promise<void> {
+    const file = resolveSinkPath(root, relPath)
+    const dir = resolve(root)
+    if (dirname(file) !== dir) mkdirPrivate(dirname(file))
+    else mkdirPrivate(dir)
+    writeFileSync(file, content, { mode: 0o600 })
+    try {
+      chmodSync(file, 0o600)
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/**
+ * Apply a sink operation inside the sandbox. The shim re-validates the path itself rather
+ * than trusting that the daemon already did: a check on the other side of a channel is not
+ * a check on this side, and the shim is the half that touches the filesystem.
+ */
+export async function applyFileSinkPayload(payload: unknown, sink: FileSink = new LocalFileSink()): Promise<void> {
+  const parsed = FileSinkPayloadSchema.parse(payload)
+  if (parsed.op === 'clear') {
+    const error = await sink.clear(parsed.root)
+    if (error) throw new Error(error)
+    return
+  }
+  resolveSinkPath(parsed.root, parsed.relPath)
+  await sink.write(parsed.root, parsed.relPath, parsed.content)
+}

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -47,6 +47,8 @@ export interface ShimConnection {
    *  whatever the pod currently holds — a renewal may already have replaced that. */
   issuedCredential: string
   send(frame: ShimFrame): void
+  /** Observe inbound frames — how a ShimChannel receives the replies to its requests. */
+  onFrame(listener: (text: string) => void): void
   close(reason: string): void
 }
 
@@ -145,6 +147,7 @@ export class ShimListener {
   private accept(ws: WebSocket, remoteAddress: string): void {
     let bound: ShimConnection | undefined
     let binding = false
+    const frameListeners: Array<(text: string) => void> = []
     // TokenReview is a network round trip, so the socket can close while it is pending.
     // The continuation must not then issue a credential, supersede a live binding, or
     // publish a connection for a socket that is already gone.
@@ -207,6 +210,7 @@ export class ShimListener {
               binding: result.binding,
               issuedCredential: result.credential,
               send: (outbound) => ws.send(JSON.stringify(outbound)),
+              onFrame: (listener) => frameListeners.push(listener),
               close: (reason) => ws.close(4000, reason)
             }
             bound = connection
@@ -249,6 +253,14 @@ export class ShimListener {
       // has no credential to authorize and must not be treated as anything else.
       if (!bound) {
         ws.close(4403, 'not bound')
+        return
+      }
+      if (frame.type === 'shim/response') {
+        // A reply to something the daemon asked for: hand it to whoever is waiting. The
+        // frame is not trusted beyond its correlation id — the channel only resolves a
+        // request it actually issued.
+        const text = typeof data === 'string' ? data : String(data)
+        for (const listener of frameListeners) listener(text)
         return
       }
       if (frame.type === 'shim/request') {

--- a/packages/daemon/src/shim/tunnel.ts
+++ b/packages/daemon/src/shim/tunnel.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+/**
+ * Unix sockets the daemon exposes into a sandbox. Each is a daemon-side server the runtime
+ * expects to find locally: the git-credential helper, the `gh` token helper, and the MCP
+ * bridge. The shim listens on the in-pod path and proxies bytes back over the channel.
+ *
+ * The set is closed on purpose. A generic "tunnel any socket" capability would let a
+ * compromised runtime reach whatever the daemon happens to be listening on; naming the
+ * three keeps the grant meaningful.
+ */
+export const TunnelNameSchema = z.enum(['gitcred', 'gh-token', 'mcp'])
+export type TunnelName = z.infer<typeof TunnelNameSchema>
+
+export const TunnelOpenSchema = z.object({
+  op: z.literal('open'),
+  tunnel: TunnelNameSchema,
+  /** Stream id, unique per channel; the shim rejects a reused one. */
+  streamId: z.string().uuid(),
+  /** Absolute in-pod path the shim must listen on for this tunnel. */
+  socketPath: z.string().min(1)
+})
+
+export const TunnelDataSchema = z.object({
+  op: z.literal('data'),
+  streamId: z.string().uuid(),
+  /** base64 because the frame is JSON text; the payload is opaque bytes either way. */
+  chunk: z.string()
+})
+
+export const TunnelCloseSchema = z.object({
+  op: z.literal('close'),
+  streamId: z.string().uuid(),
+  error: z.string().max(200).optional()
+})
+
+export const TunnelPayloadSchema = z.discriminatedUnion('op', [TunnelOpenSchema, TunnelDataSchema, TunnelCloseSchema])
+export type TunnelPayload = z.infer<typeof TunnelPayloadSchema>
+
+/** Which in-pod path each tunnel is served at. Fixed by the runtime image, not by the
+ *  daemon's own root, because the daemon's paths mean nothing inside the sandbox. */
+export const SANDBOX_TUNNEL_PATHS: Readonly<Record<TunnelName, string>> = Object.freeze({
+  gitcred: '/run/agentconnect/gitcred.sock',
+  'gh-token': '/run/agentconnect/gh-token.sock',
+  mcp: '/run/agentconnect/mcp.sock'
+})

--- a/packages/daemon/test/shim-channels.test.ts
+++ b/packages/daemon/test/shim-channels.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { materializeConfigFiles, materializeConfigFilesThrough, configFilesDir } from '../src/agents/config-file-env.js'
+import { LocalFileSink, applyFileSinkPayload, resolveSinkPath, FileSinkPayloadSchema } from '../src/shim/file-sink.js'
+import { ShimChannel, ShimFileSink } from '../src/shim/channels.js'
+import { SANDBOX_TUNNEL_PATHS, TunnelPayloadSchema } from '../src/shim/tunnel.js'
+import { ClientTransport } from '@agentconnect.md/connection'
+import { ShimListener, type ShimConnection } from '../src/shim/listener.js'
+import { ShimClient, type ShimTransport } from '../src/shim/client.js'
+import type { ShimCapability, ShimFrame } from '../src/shim/protocol.js'
+
+function agentDir(): string {
+  return mkdtempSync(join(tmpdir(), 'ac-sink-'))
+}
+
+const timers = {
+  setTimeout: (fn: () => void, ms: number) => setTimeout(fn, ms),
+  clearTimeout: (h: unknown) => clearTimeout(h as NodeJS.Timeout)
+}
+
+/** A bound connection whose frames a test can inspect and answer. */
+function fakeConnection(generation = 3): { connection: ShimConnection; sent: ShimFrame[] } {
+  const sent: ShimFrame[] = []
+  const connection: ShimConnection = {
+    binding: {
+      agentId: 'agent-a',
+      sandboxUid: 'sandbox-uid-1',
+      generation,
+      grants: ['materialize'],
+      podName: 'p',
+      podUid: 'u',
+      expiresAtMs: Number.MAX_SAFE_INTEGER
+    },
+    issuedCredential: 'cred-1',
+    send: (frame) => sent.push(frame),
+    onFrame: () => {},
+    close: () => {}
+  }
+  return { connection, sent }
+}
+
+afterEach(() => {})
+
+describe('file sink', () => {
+  it('produces the same result locally as the synchronous path it replaces', async () => {
+    // Parity is the point: which secrets become files is unchanged policy, and only the
+    // write moves. A divergence here would mean cloud and self-hosted agents see different
+    // env, which is exactly what the seam exists to prevent.
+    const env = { KUBECONFIG_DATA: 'apiVersion: v1\n', DOCKER_CONFIG_DATA: '{"auths":{}}' }
+    const legacy = agentDir()
+    const seamed = agentDir()
+    const before = materializeConfigFiles(legacy, env)
+    const after = await materializeConfigFilesThrough(seamed, env, new LocalFileSink())
+
+    const normalize = (result: typeof before, dir: string) => ({
+      env: Object.fromEntries(Object.entries(result.env).map(([k, v]) => [k, v.replace(dir, '<dir>')])),
+      strip: [...result.strip].sort(),
+      notices: result.notices
+    })
+    expect(normalize(after, seamed)).toEqual(normalize(before, legacy))
+    expect(readFileSync(join(configFilesDir(seamed), 'kubeconfig'), 'utf8')).toBe('apiVersion: v1\n')
+    expect(readFileSync(join(configFilesDir(seamed), 'docker', 'config.json'), 'utf8')).toBe('{"auths":{}}')
+  })
+
+  it('writes secrets 0600 and their directories 0700', async () => {
+    const dir = agentDir()
+    await materializeConfigFilesThrough(dir, { KUBECONFIG_DATA: 'x' }, new LocalFileSink())
+    const file = join(configFilesDir(dir), 'kubeconfig')
+    expect(statSync(file).mode & 0o777).toBe(0o600)
+    expect(statSync(configFilesDir(dir)).mode & 0o777).toBe(0o700)
+  })
+
+  it('replaces previous contents so a removed secret converges to deletion', async () => {
+    const dir = agentDir()
+    await materializeConfigFilesThrough(dir, { KUBECONFIG_DATA: 'first' }, new LocalFileSink())
+    const stale = join(configFilesDir(dir), 'leftover')
+    writeFileSync(stale, 'stale')
+    await materializeConfigFilesThrough(dir, { KUBECONFIG_DATA: 'second' }, new LocalFileSink())
+    expect(readFileSync(join(configFilesDir(dir), 'kubeconfig'), 'utf8')).toBe('second')
+    expect(() => readFileSync(stale, 'utf8')).toThrow()
+  })
+
+  it('leaves the secret as an env var when the write fails, rather than losing both', async () => {
+    const failing = {
+      clear: async () => undefined,
+      write: async () => {
+        throw new Error('read-only filesystem')
+      }
+    }
+    const result = await materializeConfigFilesThrough(agentDir(), { KUBECONFIG_DATA: 'x' }, failing)
+    expect(result.env.KUBECONFIG).toBeUndefined()
+    expect(result.strip).toEqual([])
+    expect(result.notices.join(' ')).toMatch(/could not be materialized/)
+  })
+
+  it('refuses a path that would escape its root, on whichever side runs it', () => {
+    expect(() => resolveSinkPath('/tmp/root', ['ok', 'file'])).not.toThrow()
+    // The schema stops the obvious traversal, and resolveSinkPath stops anything that
+    // survives it — the shim re-checks because a daemon-side check is not a check here.
+    expect(
+      FileSinkPayloadSchema.safeParse({ op: 'write', root: '/r', relPath: ['..', 'x'], content: '' }).success
+    ).toBe(false)
+    expect(FileSinkPayloadSchema.safeParse({ op: 'write', root: '/r', relPath: ['a/b'], content: '' }).success).toBe(
+      false
+    )
+    expect(() => resolveSinkPath('relative/root', ['x'])).toThrow(/absolute/)
+  })
+
+  it('applies a payload inside the sandbox after validating it again', async () => {
+    const dir = agentDir()
+    await applyFileSinkPayload({ op: 'write', root: dir, relPath: ['nested', 'secret'], content: 'v' })
+    expect(readFileSync(join(dir, 'nested', 'secret'), 'utf8')).toBe('v')
+    await applyFileSinkPayload({ op: 'clear', root: dir })
+    expect(() => readFileSync(join(dir, 'nested', 'secret'), 'utf8')).toThrow()
+    await expect(applyFileSinkPayload({ op: 'write', root: dir, relPath: [], content: 'v' })).rejects.toThrow()
+  })
+})
+
+describe('shim channel', () => {
+  it('carries the credential and generation on every request, not just at binding', async () => {
+    const { connection, sent } = fakeConnection(7)
+    const channel = new ShimChannel(connection, 'cred-1', timers)
+    const inflight = channel.request('materialize', { op: 'clear', root: '/agent' })
+    expect(sent).toHaveLength(1)
+    const frame = sent[0] as Extract<ShimFrame, { type: 'shim/request' }>
+    expect(frame.sessionCredential).toBe('cred-1')
+    // The generation travels per frame so a renewal or relaunch cannot be silently
+    // straddled: the shim refuses a frame that is not for its own incarnation.
+    expect(frame.generation).toBe(7)
+    channel.accept(JSON.stringify({ type: 'shim/response', id: frame.id, ok: true, payload: null }))
+    await expect(inflight).resolves.toBeNull()
+  })
+
+  it('rejects the caller when the shim refuses, and ignores replies it is not awaiting', async () => {
+    const { connection, sent } = fakeConnection()
+    const channel = new ShimChannel(connection, 'cred-1', timers)
+    const inflight = channel.request('materialize', {})
+    const frame = sent[0] as Extract<ShimFrame, { type: 'shim/request' }>
+    expect(
+      channel.accept(JSON.stringify({ type: 'shim/response', id: frame.id, ok: false, error: 'not granted' }))
+    ).toBe(true)
+    await expect(inflight).rejects.toThrow(/not granted/)
+    // A stray or duplicate reply is not an error path; it simply is not ours.
+    expect(channel.accept(JSON.stringify({ type: 'shim/response', id: frame.id, ok: true }))).toBe(false)
+    expect(channel.accept('{"nonsense": true}')).toBe(false)
+  })
+
+  it('fails in-flight requests when the channel goes away instead of hanging a turn', async () => {
+    const { connection } = fakeConnection()
+    const channel = new ShimChannel(connection, 'cred-1', timers)
+    const inflight = channel.request('materialize', {})
+    expect(channel.pendingCount()).toBe(1)
+    channel.abort('channel lost')
+    await expect(inflight).rejects.toThrow(/channel lost/)
+    expect(channel.pendingCount()).toBe(0)
+  })
+
+  it('times out a request rather than leaving a turn parked forever', async () => {
+    const { connection } = fakeConnection()
+    const channel = new ShimChannel(connection, 'cred-1', timers)
+    await expect(channel.request('materialize', {}, 10)).rejects.toThrow(/timed out/)
+    expect(channel.pendingCount()).toBe(0)
+  })
+
+  it('routes materialization through the channel with the daemon still deciding content', async () => {
+    const { connection, sent } = fakeConnection()
+    const channel = new ShimChannel(connection, 'cred-1', timers)
+    const sink = new ShimFileSink(channel)
+    // Answer each request as the shim would.
+    const answer = () => {
+      const frame = sent.at(-1) as Extract<ShimFrame, { type: 'shim/request' }>
+      channel.accept(JSON.stringify({ type: 'shim/response', id: frame.id, ok: true }))
+    }
+    const done = materializeConfigFilesThrough('/agent', { KUBECONFIG_DATA: 'apiVersion: v1\n' }, sink)
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    answer() // clear
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    answer() // write
+    const result = await done
+    expect(result.env.KUBECONFIG).toBe('/agent/run/config-files/kubeconfig')
+    expect(result.strip).toEqual(['KUBECONFIG_DATA'])
+    const payloads = sent.map((frame) => (frame as Extract<ShimFrame, { type: 'shim/request' }>).payload)
+    expect(payloads[0]).toMatchObject({ op: 'clear' })
+    // The content crosses the channel because the daemon decided it; the shim only writes.
+    expect(payloads[1]).toMatchObject({ op: 'write', relPath: ['kubeconfig'], content: 'apiVersion: v1\n' })
+  })
+})
+
+describe('tunnels', () => {
+  it('names a closed set of sockets rather than allowing any path', () => {
+    expect(Object.keys(SANDBOX_TUNNEL_PATHS).sort()).toEqual(['gh-token', 'gitcred', 'mcp'])
+    // A generic "tunnel any socket" grant would let a compromised runtime reach whatever
+    // the daemon happens to be listening on.
+    expect(
+      TunnelPayloadSchema.safeParse({
+        op: 'open',
+        tunnel: 'anything',
+        streamId: '11111111-1111-4111-8111-111111111111',
+        socketPath: '/tmp/x.sock'
+      }).success
+    ).toBe(false)
+  })
+
+  it('validates stream framing', () => {
+    const streamId = '11111111-1111-4111-8111-111111111111'
+    expect(TunnelPayloadSchema.safeParse({ op: 'open', tunnel: 'gitcred', streamId, socketPath: '/s' }).success).toBe(
+      true
+    )
+    expect(TunnelPayloadSchema.safeParse({ op: 'data', streamId, chunk: 'aGk=' }).success).toBe(true)
+    expect(TunnelPayloadSchema.safeParse({ op: 'close', streamId }).success).toBe(true)
+    expect(TunnelPayloadSchema.safeParse({ op: 'data', streamId: 'not-a-uuid', chunk: '' }).success).toBe(false)
+  })
+})
+
+describe('materialization over a real daemon-and-shim pair', () => {
+  const listeners: ShimListener[] = []
+  afterEach(async () => {
+    await Promise.all(listeners.splice(0).map((instance) => instance.stop()))
+  })
+
+  async function pair(grants: ShimCapability[]): Promise<{
+    instance: ShimListener
+    client: ShimClient
+    channel: ShimChannel
+    handled: Array<{ capability: ShimCapability; payload: unknown }>
+    sandboxRoot: string
+  }> {
+    const sandboxRoot = mkdtempSync(join(tmpdir(), 'ac-sandbox-'))
+    const instance = new ShimListener({
+      verifier: { reviewToken: async () => ({ authenticated: true, podName: 'p', podUid: 'u' }) },
+      spawnRecordForPod: () => ({ agentId: 'agent-a', sandboxUid: 'sandbox-1', generation: 3, grants }),
+      now: () => Date.now(),
+      log: { info: () => {}, warn: () => {} }
+    })
+    listeners.push(instance)
+    const port = await instance.start(0, '127.0.0.1')
+    const handled: Array<{ capability: ShimCapability; payload: unknown }> = []
+    const client = new ShimClient({
+      endpoint: `ws://127.0.0.1:${port}`,
+      dial: (url, opts) =>
+        ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
+      readToken: () => 'projected-token',
+      handle: async (capability, payload) => {
+        handled.push({ capability, payload })
+        // The shim performs the write itself, re-validating the path on its own side.
+        await applyFileSinkPayload(payload)
+        return null
+      },
+      log: { info: () => {}, warn: () => {} }
+    })
+    await client.start()
+    let connection: ShimConnection | undefined
+    for (let i = 0; i < 200 && !connection; i += 1) {
+      connection = instance.connectionsFor('agent-a')[0]
+      if (!connection) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    if (!connection) throw new Error('no bound connection')
+    const channel = new ShimChannel(connection, connection.issuedCredential, timers)
+    connection.onFrame((text) => channel.accept(text))
+    return { instance, client, channel, handled, sandboxRoot }
+  }
+
+  it('writes a secret into the sandbox filesystem, decided by the daemon', async () => {
+    const { client, channel, handled, sandboxRoot } = await pair(['materialize'])
+    try {
+      const result = await materializeConfigFilesThrough(
+        sandboxRoot,
+        { KUBECONFIG_DATA: 'apiVersion: v1\n' },
+        new ShimFileSink(channel)
+      )
+      expect(result.env.KUBECONFIG).toBe(join(configFilesDir(sandboxRoot), 'kubeconfig'))
+      // The file exists because the SHIM wrote it, over a real socket, after its own
+      // validation — neither half of this is stubbed.
+      expect(readFileSync(join(configFilesDir(sandboxRoot), 'kubeconfig'), 'utf8')).toBe('apiVersion: v1\n')
+      expect(handled.map((entry) => entry.capability)).toEqual(['materialize', 'materialize'])
+    } finally {
+      client.stop()
+    }
+  }, 20_000)
+
+  it('is refused by the shim when the launch never received the capability', async () => {
+    // The grant list is enforced on both sides deliberately. Here the binding carries only
+    // `exec`, so the shim refuses a materialize request even though the daemon asked.
+    const { client, channel, handled } = await pair(['exec'])
+    try {
+      await expect(channel.request('materialize', { op: 'clear', root: '/tmp' })).rejects.toThrow(/not granted/)
+      expect(handled).toEqual([])
+    } finally {
+      client.stop()
+    }
+  }, 20_000)
+})


### PR DESCRIPTION
Closes #814. Part of #804, on top of the shim channel from #826.

## What moves, and what deliberately does not

The channels the shim exists to carry. **Placement moves; policy does not.** Which secrets
become files and what they contain stays the daemon's decision — only the daemon knows the
agent. Only the write crosses the boundary, because only the driver knows whose filesystem
the runtime reads.

`planConfigFiles` was already pure, so the split falls along a seam that already existed:
`materializeConfigFilesThrough` runs the *identical* plan against a `FileSink`.

- `LocalFileSink` is today's behavior byte for byte: 0600 files, 0700 directories, contents
  replaced so a removed secret converges to deletion, and a write failure leaving the raw
  env var in place rather than losing both.
- `ShimFileSink` sends the same operations over the channel.

A parity test asserts the two produce the same `env`, `strip` and `notices`. A divergence
there would mean cloud and self-hosted agents see different environments, which is the
exact failure this seam exists to prevent.

## Containment is enforced on both sides

The payload schema rejects traversal segments and `resolveSinkPath` refuses anything
escaping the root — and **the shim re-runs both** before touching the filesystem. A check
on the far side of a channel is not a check on this side, and the shim is the half that
writes.

## Tunnels are a closed set

`gitcred`, `gh-token`, `mcp`, at fixed in-pod paths. A generic "tunnel any socket" grant
would let a compromised runtime reach whatever the daemon happens to be listening on, so
the three are enumerated and anything else fails the schema. The paths are the image's, not
the daemon's — a daemon-side socket path means nothing inside a sandbox.

## A gap the tests found

`ShimChannel.accept` existed but **nothing fed it**, so the daemon could never receive a
reply. Writing the real-pair test surfaced that; the listener now routes inbound response
frames to the channel that issued the request, correlated by id.

Requests also carry the credential *and* generation per frame rather than inheriting them
from the connection, so a renewal or relaunch cannot be silently straddled. In-flight
requests fail on channel loss and time out rather than parking a turn forever.

## Verification

57 tests across the new file plus the handshake and config-file suites. The two capability
tests drive a real `ShimClient` against a real `ShimListener` over a socket, and I verified
the refusal case by **removing the shim's own grant check and confirming the test fails** —
after five rounds on #826 where fakes of mine agreed with me, "the test fails without the
fix" is something I now run rather than assert.

Daemon typecheck, eslint, prettier clean.

## Not in this PR

Nothing calls these yet. `ensureHost` wiring belongs with the cluster driver (#816), which
is what will own a sandbox to materialize into; the workspace `exec` surface is #815. Doing
the wiring here would mean writing a caller for a driver that does not exist.
