### PR TITLE
feat(daemon): add the cluster spawn driver for per-agent sandbox runtimes

### DIFF
--- a/packages/daemon/src/k8s/cluster-driver.ts
+++ b/packages/daemon/src/k8s/cluster-driver.ts
@@ -2,7 +2,7 @@ import { Backoff, systemClock, type Clock } from '@agentconnect.md/connection'
 import type { SpawnDriver, SpawnRequest, SpawnedRuntime } from '../acp/spawn-driver.js'
 import type { ShimCapability } from '../shim/protocol.js'
 import type { ShimConnection } from '../shim/listener.js'
-import { ShimChannel } from '../shim/channels.js'
+import { ShimSession } from '../shim/session.js'
 import type { SpawnRecord } from '../shim/binding.js'
 import { OperatingModeRejectedError, isSandboxReady, type OperatingMode, type SandboxApi } from './sandbox-api.js'
 import { K8sApiError } from './http.js'
@@ -16,7 +16,7 @@ export const DRAIN_REQUESTED_ANNOTATION = 'agentconnect.md/drain-requested'
 
 /** Capabilities a runtime launch receives. Narrow by construction: a launch gets exactly
  *  what the channels it uses require, so a future capability is an explicit decision. */
-export const RUNTIME_GRANTS: ShimCapability[] = ['materialize', 'exec', 'read', 'tunnel']
+export const RUNTIME_GRANTS: ShimCapability[] = ['acp', 'materialize', 'exec', 'read', 'tunnel']
 
 export interface ClusterDriverDeps {
   api: SandboxApi
@@ -56,6 +56,13 @@ export class ClusterSpawnDriver implements SpawnDriver {
   private readonly generations = new Map<string, number>()
   /** Agents whose Sandbox carries a drain request: hold off waking until it clears. */
   private readonly draining = new Set<string>()
+  /** Per-agent transition queue. A guarded write protects competing writes, but it cannot
+   *  protect a decision that performs NO write: a later wake could observe Running and
+   *  return while an earlier suspend patch was still in flight, and the older write would
+   *  then land last and reverse the newer decision. Serializing removes that entirely. */
+  private readonly modeQueue = new Map<string, Promise<void>>()
+  /** Logical channels per agent, which survive the shim's credential renewals. */
+  private readonly sessions = new Map<string, ShimSession>()
   private readonly clock: Clock
 
   constructor(private readonly deps: ClusterDriverDeps) {
@@ -88,6 +95,10 @@ export class ClusterSpawnDriver implements SpawnDriver {
         additionalPodMetadata: { labels: { [AC_LABEL_ORG]: this.deps.orgId, [AC_LABEL_AGENT]: agentId } }
       }
     })
+    // Resolve the bound Sandbox WITHOUT requiring readiness. A suspended claim still names
+    // its Sandbox and still has a uid, but suspension deleted the pod — so waiting for Ready
+    // here would block the only call that could bring it back. Resume is "patch Running,
+    // then wait", in that order.
     const sandboxName = await this.awaitBoundSandbox(name)
     const sandbox = await this.deps.api.getSandbox(sandboxName)
     const sandboxUid = sandbox.metadata?.uid
@@ -100,6 +111,18 @@ export class ClusterSpawnDriver implements SpawnDriver {
     // it, and an unpublished launch is indistinguishable from a pod we never started.
     this.deps.publishSpawnRecord({ agentId, sandboxUid, generation, grants: [...RUNTIME_GRANTS] })
     return launch
+  }
+
+  /** Wait for the Sandbox to report Ready, after something has asked it to run. */
+  private async awaitReady(sandboxName: string): Promise<void> {
+    const backoff = new Backoff({ baseMs: 250, capMs: 2_000, jitter: () => 0 })
+    const deadline = this.clock.now() + (this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS)
+    for (;;) {
+      const sandbox = await this.deps.api.getSandbox(sandboxName).catch(() => undefined)
+      if (sandbox && isSandboxReady(sandbox)) return
+      if (this.clock.now() >= deadline) throw new Error(`sandbox ${sandboxName} did not become ready in time`)
+      await new Promise<void>((resolve) => this.clock.setTimeout(resolve, backoff.next()))
+    }
   }
 
   /** Wake a suspended Sandbox, or confirm it is already running. */
@@ -125,7 +148,18 @@ export class ClusterSpawnDriver implements SpawnDriver {
    * correct response is to look again — and the retry budget is finite because a permanently
    * invalid patch would otherwise loop forever.
    */
-  private async setMode(agentId: string, desired: OperatingMode): Promise<void> {
+  private setMode(agentId: string, desired: OperatingMode): Promise<void> {
+    const previous = this.modeQueue.get(agentId) ?? Promise.resolve()
+    const next = previous.catch(() => undefined).then(() => this.applyMode(agentId, desired))
+    // Keep the chain even when a link rejects, so a failed transition cannot strand the queue.
+    this.modeQueue.set(
+      agentId,
+      next.catch(() => undefined)
+    )
+    return next
+  }
+
+  private async applyMode(agentId: string, desired: OperatingMode): Promise<void> {
     const launch = this.launches.get(agentId)
     if (!launch) throw new Error(`no sandbox launch recorded for agent ${agentId}`)
     for (let attempt = 1; attempt <= MAX_MODE_ATTEMPTS; attempt += 1) {
@@ -199,12 +233,10 @@ export class ClusterSpawnDriver implements SpawnDriver {
         throw err
       })
       const name = claim?.status?.sandbox?.name
-      if (name) {
-        const sandbox = await this.deps.api.getSandbox(name).catch(() => undefined)
-        if (sandbox && isSandboxReady(sandbox)) return name
-      }
+      // Bound is enough here; readiness is a separate wait that follows the resume.
+      if (name) return name
       if (this.clock.now() >= deadline) {
-        throw new Error(`claim ${claimName} did not bind a ready sandbox in time`)
+        throw new Error(`claim ${claimName} did not bind a sandbox in time`)
       }
       await new Promise<void>((resolve) => this.clock.setTimeout(resolve, backoff.next()))
     }
@@ -213,78 +245,125 @@ export class ClusterSpawnDriver implements SpawnDriver {
   /**
    * Start the runtime in the agent's Sandbox and hand `AcpHost` a stream pair.
    *
-   * Command resolution stays on this side of nothing: the request's command is passed
-   * through unresolved along with its hints, because the shim resolves them in the
-   * filesystem the runtime will actually read.
+   * Command resolution is deliberately NOT done here: the request's command and hints are
+   * passed through unresolved, because the shim resolves them in the filesystem the runtime
+   * will actually read.
    */
   async launch(request: SpawnRequest): Promise<SpawnedRuntime> {
     const agentId = request.env.AC_AGENT_ID
     if (!agentId) throw new Error('cluster launch requires AC_AGENT_ID in the runtime environment')
+    if (this.draining.has(agentId)) {
+      // Launching now would wait out the readiness timeout against a sandbox we are
+      // deliberately holding down. Say so instead of timing out.
+      throw new Error(`agent ${agentId} is draining for an image rollout — retry once it clears`)
+    }
     const launch = await this.ensureSandbox(agentId)
+    // Resume BEFORE waiting: suspension deleted the pod, so readiness cannot arrive until
+    // something asks for Running.
     await this.wake(agentId)
+    await this.awaitReady(launch.sandboxName)
     const connection = await this.deps.awaitChannel(
       agentId,
       launch.generation,
       this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
     )
-    const channel = new ShimChannel(connection, connection.issuedCredential, {
+    const session = new ShimSession(agentId, launch.generation, {
       setTimeout: (fn, ms) => this.clock.setTimeout(fn, ms),
       clearTimeout: (handle) => this.clock.clearTimeout(handle as never)
     })
-    connection.onFrame((text) => channel.accept(text))
-    return createRemoteRuntime({ channel, connection, request, log: this.deps.log })
+    session.attach(connection)
+    this.sessions.set(agentId, session)
+    return createRemoteRuntime({ session, request, log: this.deps.log })
+  }
+
+  /** Re-attach a renewed or replacement connection to the launch it belongs to. */
+  onChannelBound(connection: ShimConnection): void {
+    this.sessions.get(connection.binding.agentId)?.attach(connection)
+  }
+
+  /** Report that an agent's channel is gone, so its runtime learns rather than hanging. */
+  onChannelLost(agentId: string, reason: string): void {
+    this.sessions.get(agentId)?.lose(reason)
   }
 }
 
-/** Bridge a shim ACP stream to the byte-stream pair `AcpHost` consumes. */
+/**
+ * Bridge a shim ACP stream to the byte-stream pair `AcpHost` consumes.
+ *
+ * The stream survives credential renewal because it talks to a {@link ShimSession} rather
+ * than to one socket: a renewal re-attaches underneath, and only a lost session ends the
+ * runtime. Writes await their acknowledgement, so a runtime that is not draining applies
+ * backpressure instead of letting the daemon queue without bound.
+ */
 function createRemoteRuntime(opts: {
-  channel: ShimChannel
-  connection: ShimConnection
+  session: ShimSession
   request: SpawnRequest
   log: { info: (m: string) => void; warn: (m: string) => void }
 }): SpawnedRuntime {
   const exitListeners: Array<() => void> = []
   let stopped = false
+  let streamId: string | undefined
   const inbound = new TransformStream<Uint8Array, Uint8Array>()
   const writer = inbound.writable.getWriter()
 
-  // The shim reports runtime stdout as chunk events and its exit as an exit event; both
-  // arrive as responses on the channel, so they are routed here rather than resolved.
-  opts.connection.onFrame((text) => {
-    try {
-      const frame = JSON.parse(text) as { type?: string; payload?: { event?: string; data?: string } }
-      if (frame.type !== 'shim/response' || !frame.payload?.event) return
-      if (frame.payload.event === 'chunk' && frame.payload.data) {
-        void writer.write(Buffer.from(frame.payload.data, 'base64'))
-        return
-      }
-      if (frame.payload.event === 'exit') {
-        void writer.close().catch(() => {})
-        for (const listener of exitListeners.splice(0)) listener()
-      }
-    } catch {
-      /* not ours */
+  const finish = (): void => {
+    void writer.close().catch(() => undefined)
+    for (const listener of exitListeners.splice(0)) listener()
+  }
+
+  const onEvent = (frame: { streamId: string; event: { kind: string; data?: string } }): void => {
+    if (streamId && frame.streamId !== streamId) return
+    if (frame.event.kind === 'chunk' && frame.event.data) {
+      void writer.write(Buffer.from(frame.event.data, 'base64'))
+      return
     }
+    if (frame.event.kind === 'exit') {
+      opts.session.offEvent(onEvent)
+      finish()
+    }
+  }
+  opts.session.onEvent(onEvent)
+  // A lost session is a dead runtime: report terminal exit rather than leaving AcpHost
+  // waiting on a stream that can never produce another byte.
+  opts.session.onLost((reason) => {
+    opts.log.warn(`cluster: shim channel lost for agent ${opts.session.agentId} (${reason})`)
+    opts.session.offEvent(onEvent)
+    finish()
   })
 
-  const toAgent = new WritableStream<Uint8Array>({
-    write: async (chunk) => {
-      await opts.channel.request('exec', { op: 'chunk', data: Buffer.from(chunk).toString('base64') })
-    }
-  })
-
-  void opts.channel
-    .request('exec', {
+  const opened = opts.session
+    .request('acp', {
       op: 'open',
       command: opts.request.command,
       args: opts.request.args,
       env: opts.request.env,
       ...(opts.request.hints ? { hints: opts.request.hints } : {})
     })
-    .catch((err: unknown) => {
-      opts.log.warn(`cluster: runtime failed to start in the sandbox (${(err as Error).message})`)
-      for (const listener of exitListeners.splice(0)) listener()
+    .then((payload) => {
+      streamId = (payload as { streamId?: string } | undefined)?.streamId
+      if (!streamId) throw new Error('shim did not report a stream id for the ACP runtime')
     })
+
+  const toAgent = new WritableStream<Uint8Array>({
+    write: async (chunk) => {
+      // AcpHost writes `initialize` the moment it has the stream, which can be before the
+      // open round trip returns. Awaiting it here queues the write instead of dropping it.
+      await opened
+      if (!streamId) throw new Error('acp stream is not open')
+      // Awaiting the ack is the backpressure: the shim only answers once the runtime's stdin
+      // accepted the bytes.
+      await opts.session.request('acp', {
+        op: 'chunk',
+        streamId,
+        data: Buffer.from(chunk).toString('base64')
+      })
+    }
+  })
+
+  void opened.catch((err: unknown) => {
+    opts.log.warn(`cluster: runtime failed to start in the sandbox (${(err as Error).message})`)
+    finish()
+  })
 
   return {
     toAgent,
@@ -293,8 +372,11 @@ function createRemoteRuntime(opts: {
     stop: async (deadlineMs) => {
       if (stopped) return
       stopped = true
-      await opts.channel.request('exec', { op: 'close', deadlineMs }).catch(() => undefined)
-      opts.channel.abort('runtime stopped')
+      await opened.catch(() => undefined)
+      if (streamId) {
+        await opts.session.request('acp', { op: 'close', streamId, deadlineMs }).catch(() => undefined)
+      }
+      opts.session.offEvent(onEvent)
     }
   }
 }

--- a/packages/daemon/src/k8s/cluster-driver.ts
+++ b/packages/daemon/src/k8s/cluster-driver.ts
@@ -1,0 +1,300 @@
+import { Backoff, systemClock, type Clock } from '@agentconnect.md/connection'
+import type { SpawnDriver, SpawnRequest, SpawnedRuntime } from '../acp/spawn-driver.js'
+import type { ShimCapability } from '../shim/protocol.js'
+import type { ShimConnection } from '../shim/listener.js'
+import { ShimChannel } from '../shim/channels.js'
+import type { SpawnRecord } from '../shim/binding.js'
+import { OperatingModeRejectedError, isSandboxReady, type OperatingMode, type SandboxApi } from './sandbox-api.js'
+import { K8sApiError } from './http.js'
+
+/** Label domain the claim controller must be configured to allow. */
+export const AC_LABEL_ORG = 'agentconnect.md/org'
+export const AC_LABEL_AGENT = 'agentconnect.md/agent'
+
+/** Annotation an image rollout writes to ask a daemon to quiesce a Sandbox. */
+export const DRAIN_REQUESTED_ANNOTATION = 'agentconnect.md/drain-requested'
+
+/** Capabilities a runtime launch receives. Narrow by construction: a launch gets exactly
+ *  what the channels it uses require, so a future capability is an explicit decision. */
+export const RUNTIME_GRANTS: ShimCapability[] = ['materialize', 'exec', 'read', 'tunnel']
+
+export interface ClusterDriverDeps {
+  api: SandboxApi
+  orgId: string
+  /** Pool the claim references; v1beta1 requires one, and a cold pool is `replicas: 0`. */
+  warmPoolName: string
+  /** Waits for a bound shim channel for this agent's current launch. */
+  awaitChannel: (agentId: string, generation: number, timeoutMs: number) => Promise<ShimConnection>
+  /** Publishes the spawn record the shim handshake resolves a pod against. */
+  publishSpawnRecord: (record: SpawnRecord) => void
+  clock?: Clock
+  log: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
+  /** How long to wait for a pod to become Ready and its shim to bind. */
+  readyTimeoutMs?: number
+}
+
+const DEFAULT_READY_TIMEOUT_MS = 90_000
+const MAX_MODE_ATTEMPTS = 5
+
+/** Per-agent launch state the driver keeps: the Sandbox it bound and which launch it is. */
+interface Launch {
+  agentId: string
+  sandboxName: string
+  sandboxUid: string
+  generation: number
+}
+
+/**
+ * Runs an agent's ACP runtime in its own Sandbox pod.
+ *
+ * Lifecycle lives here rather than in the control plane on purpose: claim creation, sleep,
+ * wake and teardown are all local decisions, so a control-plane outage cannot stop an
+ * existing agent from starting or stopping its runtime.
+ */
+export class ClusterSpawnDriver implements SpawnDriver {
+  private readonly launches = new Map<string, Launch>()
+  private readonly generations = new Map<string, number>()
+  /** Agents whose Sandbox carries a drain request: hold off waking until it clears. */
+  private readonly draining = new Set<string>()
+  private readonly clock: Clock
+
+  constructor(private readonly deps: ClusterDriverDeps) {
+    this.clock = deps.clock ?? systemClock
+  }
+
+  claimName(agentId: string): string {
+    return `agent-${agentId}`
+  }
+
+  /**
+   * Ensure the agent has a claim and a bound Sandbox. Idempotent: the claim name is derived
+   * from the agent id, so a retry after a partial reconcile converges instead of failing.
+   *
+   * Nothing per-agent goes into the claim — a claim carrying `env` or `volumeClaimTemplates`
+   * bypasses warm-pool adoption, and pool pods are stamped before any user exists, so
+   * identity travels over the shim handshake instead.
+   */
+  async ensureSandbox(agentId: string): Promise<Launch> {
+    const existing = this.launches.get(agentId)
+    if (existing) return existing
+    const name = this.claimName(agentId)
+    await this.deps.api.ensureClaim({
+      metadata: {
+        name,
+        annotations: undefined
+      } as { name: string },
+      spec: {
+        warmPoolRef: { name: this.deps.warmPoolName },
+        additionalPodMetadata: { labels: { [AC_LABEL_ORG]: this.deps.orgId, [AC_LABEL_AGENT]: agentId } }
+      }
+    })
+    const sandboxName = await this.awaitBoundSandbox(name)
+    const sandbox = await this.deps.api.getSandbox(sandboxName)
+    const sandboxUid = sandbox.metadata?.uid
+    if (!sandboxUid) throw new Error(`sandbox ${sandboxName} has no metadata.uid to bind against`)
+    const generation = (this.generations.get(agentId) ?? 0) + 1
+    this.generations.set(agentId, generation)
+    const launch: Launch = { agentId, sandboxName, sandboxUid, generation }
+    this.launches.set(agentId, launch)
+    // The record must exist before the shim can bind: the handshake resolves a pod against
+    // it, and an unpublished launch is indistinguishable from a pod we never started.
+    this.deps.publishSpawnRecord({ agentId, sandboxUid, generation, grants: [...RUNTIME_GRANTS] })
+    return launch
+  }
+
+  /** Wake a suspended Sandbox, or confirm it is already running. */
+  async wake(agentId: string): Promise<void> {
+    if (this.draining.has(agentId)) {
+      // A drain request is in flight: new messages queue rather than reviving the instance,
+      // or one message would resurrect the image the rollout is replacing.
+      this.deps.log.info(`cluster: holding agent ${agentId} suspended — a drain request is pending`)
+      return
+    }
+    await this.setMode(agentId, 'Running')
+  }
+
+  /** Suspend an idle Sandbox. The object and its volume survive; only the pod goes. */
+  async suspend(agentId: string): Promise<void> {
+    await this.setMode(agentId, 'Suspended')
+  }
+
+  /**
+   * Move a Sandbox to a mode, re-reading and re-deciding when the guarded write is rejected.
+   *
+   * The rejection deliberately does not claim what the intervening state was, so the only
+   * correct response is to look again — and the retry budget is finite because a permanently
+   * invalid patch would otherwise loop forever.
+   */
+  private async setMode(agentId: string, desired: OperatingMode): Promise<void> {
+    const launch = this.launches.get(agentId)
+    if (!launch) throw new Error(`no sandbox launch recorded for agent ${agentId}`)
+    for (let attempt = 1; attempt <= MAX_MODE_ATTEMPTS; attempt += 1) {
+      const sandbox = await this.deps.api.getSandbox(launch.sandboxName)
+      const observed = sandbox.spec?.operatingMode ?? 'Running'
+      if (observed === desired) return
+      try {
+        await this.deps.api.setOperatingMode(launch.sandboxName, desired, observed)
+        this.deps.log.info(`cluster: agent ${agentId} sandbox ${launch.sandboxName} → ${desired}`)
+        return
+      } catch (err) {
+        if (!(err instanceof OperatingModeRejectedError)) throw err
+        this.deps.log.debug?.(
+          `cluster: ${desired} write for ${launch.sandboxName} rejected (attempt ${attempt}) — re-reading`
+        )
+      }
+    }
+    throw new Error(
+      `sandbox ${launch.sandboxName} would not accept ${desired} after ${MAX_MODE_ATTEMPTS} attempts — ` +
+        `something else is changing its mode`
+    )
+  }
+
+  /**
+   * Observe a Sandbox's drain annotation. While it is present the daemon must not wake the
+   * instance: the rollout is waiting for it to stay down long enough to change its image,
+   * and a single arriving message would otherwise revive the old one.
+   */
+  onSandboxObserved(agentId: string, annotations: Record<string, string> | undefined): void {
+    const requested = annotations?.[DRAIN_REQUESTED_ANNOTATION]
+    if (requested && !this.draining.has(agentId)) {
+      this.draining.add(agentId)
+      this.deps.log.info(`cluster: drain requested for agent ${agentId} (${requested})`)
+      return
+    }
+    if (!requested && this.draining.delete(agentId)) {
+      this.deps.log.info(`cluster: drain request cleared for agent ${agentId} — resuming normally`)
+    }
+  }
+
+  isDraining(agentId: string): boolean {
+    return this.draining.has(agentId)
+  }
+
+  /** Forget an agent and delete its claim; the volume goes with it, which is the intent. */
+  async removeAgent(agentId: string): Promise<void> {
+    this.launches.delete(agentId)
+    this.draining.delete(agentId)
+    await this.deps.api.deleteClaim(this.claimName(agentId))
+  }
+
+  /**
+   * Treat a lost pod as an unplanned suspension rather than a new state: the channel drops,
+   * the Sandbox is not Ready, and the next turn re-runs the wake path. The generation fence
+   * keeps the departed incarnation from acting on the way out.
+   */
+  forgetLaunch(agentId: string): void {
+    this.launches.delete(agentId)
+  }
+
+  currentLaunch(agentId: string): Launch | undefined {
+    return this.launches.get(agentId)
+  }
+
+  private async awaitBoundSandbox(claimName: string): Promise<string> {
+    const backoff = new Backoff({ baseMs: 250, capMs: 2_000, jitter: () => 0 })
+    const deadline = this.clock.now() + (this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS)
+    for (;;) {
+      const claim = await this.deps.api.getClaim(claimName).catch((err: unknown) => {
+        if (err instanceof K8sApiError && err.isNotFound) return undefined
+        throw err
+      })
+      const name = claim?.status?.sandbox?.name
+      if (name) {
+        const sandbox = await this.deps.api.getSandbox(name).catch(() => undefined)
+        if (sandbox && isSandboxReady(sandbox)) return name
+      }
+      if (this.clock.now() >= deadline) {
+        throw new Error(`claim ${claimName} did not bind a ready sandbox in time`)
+      }
+      await new Promise<void>((resolve) => this.clock.setTimeout(resolve, backoff.next()))
+    }
+  }
+
+  /**
+   * Start the runtime in the agent's Sandbox and hand `AcpHost` a stream pair.
+   *
+   * Command resolution stays on this side of nothing: the request's command is passed
+   * through unresolved along with its hints, because the shim resolves them in the
+   * filesystem the runtime will actually read.
+   */
+  async launch(request: SpawnRequest): Promise<SpawnedRuntime> {
+    const agentId = request.env.AC_AGENT_ID
+    if (!agentId) throw new Error('cluster launch requires AC_AGENT_ID in the runtime environment')
+    const launch = await this.ensureSandbox(agentId)
+    await this.wake(agentId)
+    const connection = await this.deps.awaitChannel(
+      agentId,
+      launch.generation,
+      this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
+    )
+    const channel = new ShimChannel(connection, connection.issuedCredential, {
+      setTimeout: (fn, ms) => this.clock.setTimeout(fn, ms),
+      clearTimeout: (handle) => this.clock.clearTimeout(handle as never)
+    })
+    connection.onFrame((text) => channel.accept(text))
+    return createRemoteRuntime({ channel, connection, request, log: this.deps.log })
+  }
+}
+
+/** Bridge a shim ACP stream to the byte-stream pair `AcpHost` consumes. */
+function createRemoteRuntime(opts: {
+  channel: ShimChannel
+  connection: ShimConnection
+  request: SpawnRequest
+  log: { info: (m: string) => void; warn: (m: string) => void }
+}): SpawnedRuntime {
+  const exitListeners: Array<() => void> = []
+  let stopped = false
+  const inbound = new TransformStream<Uint8Array, Uint8Array>()
+  const writer = inbound.writable.getWriter()
+
+  // The shim reports runtime stdout as chunk events and its exit as an exit event; both
+  // arrive as responses on the channel, so they are routed here rather than resolved.
+  opts.connection.onFrame((text) => {
+    try {
+      const frame = JSON.parse(text) as { type?: string; payload?: { event?: string; data?: string } }
+      if (frame.type !== 'shim/response' || !frame.payload?.event) return
+      if (frame.payload.event === 'chunk' && frame.payload.data) {
+        void writer.write(Buffer.from(frame.payload.data, 'base64'))
+        return
+      }
+      if (frame.payload.event === 'exit') {
+        void writer.close().catch(() => {})
+        for (const listener of exitListeners.splice(0)) listener()
+      }
+    } catch {
+      /* not ours */
+    }
+  })
+
+  const toAgent = new WritableStream<Uint8Array>({
+    write: async (chunk) => {
+      await opts.channel.request('exec', { op: 'chunk', data: Buffer.from(chunk).toString('base64') })
+    }
+  })
+
+  void opts.channel
+    .request('exec', {
+      op: 'open',
+      command: opts.request.command,
+      args: opts.request.args,
+      env: opts.request.env,
+      ...(opts.request.hints ? { hints: opts.request.hints } : {})
+    })
+    .catch((err: unknown) => {
+      opts.log.warn(`cluster: runtime failed to start in the sandbox (${(err as Error).message})`)
+      for (const listener of exitListeners.splice(0)) listener()
+    })
+
+  return {
+    toAgent,
+    fromAgent: inbound.readable,
+    onExit: (listener) => exitListeners.push(listener),
+    stop: async (deadlineMs) => {
+      if (stopped) return
+      stopped = true
+      await opts.channel.request('exec', { op: 'close', deadlineMs }).catch(() => undefined)
+      opts.channel.abort('runtime stopped')
+    }
+  }
+}

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -119,7 +119,15 @@ export class SandboxApi {
    *  wake an instance we decided to suspend (or the reverse), so every write tests the
    *  value we saw rather than clobbering a newer decision. v1beta1 defaults the field to
    *  `Running`, so an observed value always exists.
-   *  A rejected write raises {@link OperatingModeRejectedError} — re-read and re-decide. */
+   *  A rejected write raises {@link OperatingModeRejectedError} — re-read and re-decide.
+   *
+   *  Measured against a real API server (k3s v1.31.2), so the next reader need not re-derive
+   *  it: a failed JSON Patch `test` returns 422 Invalid, never 409, and a merge patch
+   *  carrying a stale `metadata.resourceVersion` returns 409 Conflict. The field-scoped
+   *  `test` is kept deliberately — a resourceVersion precondition would guard the WHOLE
+   *  object, so any unrelated status write by the vendor controller would conflict, while
+   *  this only conflicts when the mode itself moved. The error means "re-read and
+   *  re-decide" either way, which is the only correct caller action. */
   async setOperatingMode(name: string, mode: OperatingMode, observed: OperatingMode): Promise<Sandbox> {
     try {
       return await this.http.json<Sandbox>({

--- a/packages/daemon/src/shim/acp-runner.ts
+++ b/packages/daemon/src/shim/acp-runner.ts
@@ -1,0 +1,131 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { AcpStreamPayloadSchema, type AcpOpen } from './acp-stream.js'
+import type { ShimEvent } from './protocol.js'
+
+/** How the runner reports back: many events per opened stream, not one response. */
+export type EmitEvent = (event: ShimEvent['event']) => void
+
+/** Resolve an executable in THIS filesystem — the sandbox's, which is the whole point. */
+export type ResolveCommand = (command: string, env: Record<string, string>) => string | undefined
+
+/**
+ * Runs the ACP runtime inside the sandbox and relays its stdio.
+ *
+ * The relay is deliberately dumb: bytes out as chunk events, bytes in written to stdin,
+ * exit reported once. ACP is a complete protocol already, so parsing it here would only add
+ * a second place for it to go wrong — and the daemon's `AcpHost` is the half that speaks it.
+ */
+export class AcpRunner {
+  private child?: ChildProcess
+  private exited = false
+
+  constructor(
+    private readonly deps: {
+      emit: EmitEvent
+      resolveCommand?: ResolveCommand
+      log?: { info: (m: string) => void; warn: (m: string) => void }
+    }
+  ) {}
+
+  /** Handle one payload on the ACP stream. Returns once the payload is applied. */
+  async apply(rawPayload: unknown): Promise<void> {
+    const payload = AcpStreamPayloadSchema.parse(rawPayload)
+    if (payload.op === 'open') return this.open(payload)
+    if (payload.op === 'chunk') {
+      const child = this.child
+      if (!child?.stdin) throw new Error('acp stream is not open')
+      // Report the write's completion so the daemon side can apply backpressure rather than
+      // queueing unboundedly into a runtime that is not draining.
+      await new Promise<void>((resolve, reject) => {
+        child.stdin!.write(Buffer.from(payload.data, 'base64'), (err) => (err ? reject(err) : resolve()))
+      })
+      return
+    }
+    await this.close(payload.deadlineMs ?? 5_000)
+  }
+
+  private async open(payload: AcpOpen): Promise<void> {
+    if (this.child) throw new Error('acp stream is already open')
+    const env = { ...payload.env }
+    for (const hint of payload.hints ?? []) {
+      if (env[hint.envVar]) continue
+      const resolved = this.deps.resolveCommand?.(hint.command, env)
+      if (resolved) env[hint.envVar] = resolved
+    }
+    const command = this.deps.resolveCommand?.(payload.command, env) ?? payload.command
+    const child = spawn(command, payload.args, {
+      stdio: ['pipe', 'pipe', 'inherit'],
+      env,
+      ...(payload.cwd ? { cwd: payload.cwd } : {}),
+      detached: process.platform !== 'win32'
+    })
+    this.child = child
+    child.stdout?.on('data', (chunk: Buffer) =>
+      this.deps.emit({ kind: 'chunk', data: Buffer.from(chunk).toString('base64') })
+    )
+    child.once('error', (err) => this.finish(null, null, err.message))
+    child.once('exit', (code, signal) => this.finish(code, signal))
+    if (!child.stdin || !child.stdout) throw new Error('acp runtime stdio is not piped')
+  }
+
+  private finish(code: number | null, signal: NodeJS.Signals | number | null, error?: string): void {
+    if (this.exited) return
+    this.exited = true
+    // Sweep the group now, while the pgid is provably still ours: an adapter orphaned by a
+    // wrapper's death would otherwise survive the pod's idea of "runtime stopped".
+    const child = this.child
+    if (child?.pid && process.platform !== 'win32') {
+      try {
+        process.kill(-child.pid, 'SIGTERM')
+      } catch {
+        /* group already empty */
+      }
+    }
+    this.deps.emit({
+      kind: 'exit',
+      code: typeof code === 'number' ? code : null,
+      signal: typeof signal === 'string' ? signal : null,
+      ...(error ? { error } : {})
+    })
+  }
+
+  /** Graceful stop, escalating past the deadline — the same shape as the local driver. */
+  async close(deadlineMs: number): Promise<void> {
+    const child = this.child
+    this.child = undefined
+    if (!child) return
+    if (child.exitCode !== null || child.signalCode !== null) return
+    const kill = (signal: NodeJS.Signals): void => {
+      if (child.pid && process.platform !== 'win32') {
+        try {
+          process.kill(-child.pid, signal)
+          return
+        } catch {
+          /* group gone — fall back to the child */
+        }
+      }
+      child.kill(signal)
+    }
+    try {
+      child.stdin?.end()
+    } catch {
+      /* stream already gone */
+    }
+    kill('SIGTERM')
+    await new Promise<void>((resolve) => {
+      let settled = false
+      const done = (): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve()
+      }
+      const timer = setTimeout(() => {
+        this.deps.log?.warn(`acp runtime ignored SIGTERM after ${deadlineMs}ms — sending SIGKILL`)
+        kill('SIGKILL')
+        setTimeout(done, 2_000)
+      }, deadlineMs)
+      child.once('exit', done)
+    })
+  }
+}

--- a/packages/daemon/src/shim/acp-stream.ts
+++ b/packages/daemon/src/shim/acp-stream.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+/**
+ * The ACP byte stream, carried over the shim channel.
+ *
+ * `AcpHost` wants a pair of byte streams and a lifecycle; locally those are a child's stdio.
+ * Here the runtime is a process inside the sandbox, so the shim starts it and relays its
+ * stdio. The framing is deliberately dumb — open, chunks both ways, close — because ACP is
+ * already a complete protocol and re-interpreting it in the channel would add a second
+ * place for it to go wrong.
+ */
+export const AcpOpenSchema = z.object({
+  op: z.literal('open'),
+  /** The runtime command to start inside the sandbox, resolved in ITS filesystem. */
+  command: z.string().min(1),
+  args: z.array(z.string()),
+  /** Complete child environment, decided by the daemon. */
+  env: z.record(z.string(), z.string()),
+  cwd: z.string().min(1).optional(),
+  /** Env pointers the shim fills from its own PATH when unset (e.g. CLAUDE_CODE_EXECUTABLE). */
+  hints: z.array(z.object({ envVar: z.string().min(1), command: z.string().min(1) })).optional()
+})
+
+export const AcpChunkSchema = z.object({
+  op: z.literal('chunk'),
+  /** base64: the frame is JSON text, the payload is opaque ND-JSON bytes. */
+  data: z.string()
+})
+
+export const AcpCloseSchema = z.object({
+  op: z.literal('close'),
+  /** Graceful stop deadline before the shim escalates to a kill. */
+  deadlineMs: z.number().int().nonnegative().optional(),
+  error: z.string().max(500).optional()
+})
+
+export const AcpStreamPayloadSchema = z.discriminatedUnion('op', [AcpOpenSchema, AcpChunkSchema, AcpCloseSchema])
+export type AcpStreamPayload = z.infer<typeof AcpStreamPayloadSchema>
+export type AcpOpen = z.infer<typeof AcpOpenSchema>
+
+/** Frames the shim emits back for a live ACP stream. */
+export const AcpEventSchema = z.discriminatedUnion('event', [
+  z.object({ event: z.literal('chunk'), data: z.string() }),
+  z.object({ event: z.literal('exit'), code: z.number().int().nullable(), signal: z.string().nullable() })
+])
+export type AcpEvent = z.infer<typeof AcpEventSchema>

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { Backoff, systemClock, type Clock } from '@agentconnect.md/connection'
+import { AcpRunner, type ResolveCommand } from './acp-runner.js'
 import {
   SHIM_IDENTITY_TOKEN_PATH,
   SHIM_SUBPROTOCOL,
@@ -31,8 +32,11 @@ export interface ShimClientDeps {
   dial: (url: string, opts: { subprotocol: string; path: string }) => Promise<ShimTransport>
   /** Reads the projected token. Injected for tests; defaults to the mounted path. */
   readToken?: () => string
-  /** Handles an authorized request from the daemon. The channels land in #814 / #815. */
+  /** Handles an authorized non-ACP request from the daemon (materialize / exec / read /
+   *  tunnel). The ACP capability is served by the built-in runner instead. */
   handle?: (capability: ShimCapability, payload: unknown) => Promise<unknown>
+  /** Resolves executables in THIS filesystem for the ACP runner. */
+  resolveCommand?: ResolveCommand
   clock?: Clock
   backoff?: Backoff
   log?: { info: (m: string) => void; warn: (m: string) => void }
@@ -48,6 +52,8 @@ export interface ShimClientDeps {
  * suspension, and eviction indistinguishable here: each new pod simply presents its own.
  */
 export class ShimClient {
+  /** ACP streams by the request id that opened them; each emits many events. */
+  private readonly acpStreams = new Map<string, AcpRunner>()
   private transport?: ShimTransport
   private bound?: ShimBound
   private stopped = false
@@ -220,6 +226,42 @@ export class ShimClient {
     })
   }
 
+  /**
+   * The ACP stream: one request opens it, then many events flow until the runtime exits.
+   *
+   * The opening request is still acknowledged with a single response so the caller knows the
+   * runtime started (or why it did not); the recurring traffic goes out as `shim/event`
+   * frames keyed by that request id, because one-shot correlation cannot express continuous
+   * stdout and a terminal exit.
+   */
+  private async serveAcp(
+    transport: ShimTransport,
+    request: Extract<ShimFrame, { type: 'shim/request' }>
+  ): Promise<void> {
+    const payload = request.payload as { op?: string; streamId?: string }
+    // A chunk or close names the stream it belongs to; only `open` creates one.
+    const streamId = payload?.op === 'open' ? request.id : (payload?.streamId ?? '')
+    if (payload?.op === 'open') {
+      const runner = new AcpRunner({
+        emit: (event) => transport.send(JSON.stringify({ type: 'shim/event', streamId, event })),
+        ...(this.deps.resolveCommand ? { resolveCommand: this.deps.resolveCommand } : {}),
+        ...(this.deps.log ? { log: this.deps.log } : {})
+      })
+      this.acpStreams.set(streamId, runner)
+      await runner.apply(request.payload)
+      transport.send(JSON.stringify({ type: 'shim/response', id: request.id, ok: true, payload: { streamId } }))
+      return
+    }
+    const runner = this.acpStreams.get(streamId)
+    if (!runner) {
+      transport.send(JSON.stringify({ type: 'shim/response', id: request.id, ok: false, error: 'unknown acp stream' }))
+      return
+    }
+    await runner.apply(request.payload)
+    if (payload.op === 'close') this.acpStreams.delete(streamId)
+    transport.send(JSON.stringify({ type: 'shim/response', id: request.id, ok: true }))
+  }
+
   private async serve(transport: ShimTransport, request: Extract<ShimFrame, { type: 'shim/request' }>): Promise<void> {
     const bound = this.bound
     // A request that does not match the credential and generation we were issued is not
@@ -234,6 +276,10 @@ export class ShimClient {
       return
     }
     try {
+      if (request.capability === 'acp') {
+        await this.serveAcp(transport, request)
+        return
+      }
       const payload = await (this.deps.handle ?? (async () => undefined))(request.capability, request.payload)
       transport.send(JSON.stringify({ type: 'shim/response', id: request.id, ok: true, payload }))
     } catch (err) {

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from 'node:fs'
 import { Backoff, systemClock, type Clock } from '@agentconnect.md/connection'
 import { AcpRunner, type ResolveCommand } from './acp-runner.js'
+
+/** Bounded so a long outage cannot grow the buffer without limit. */
+const MAX_BUFFERED_EVENTS = 2_000
 import {
   SHIM_IDENTITY_TOKEN_PATH,
   SHIM_SUBPROTOCOL,
@@ -8,6 +11,7 @@ import {
   parseShimFrame,
   type ShimBound,
   type ShimCapability,
+  type ShimEvent,
   type ShimFrame
 } from './protocol.js'
 
@@ -54,6 +58,10 @@ export interface ShimClientDeps {
 export class ShimClient {
   /** ACP streams by the request id that opened them; each emits many events. */
   private readonly acpStreams = new Map<string, AcpRunner>()
+  /** Events produced while no transport is attached. A renewal closes the old socket before
+   *  the replacement binds, and ACP bytes cannot simply be dropped — losing a fragment
+   *  corrupts the protocol — so they wait here and flush on the next bind. */
+  private readonly pendingEvents: string[] = []
   private transport?: ShimTransport
   private bound?: ShimBound
   private stopped = false
@@ -207,6 +215,8 @@ export class ShimClient {
         if (frame.type === 'shim/bound') {
           this.bound = frame
           this.backoff.reset()
+          // A live stream's output resumes here rather than being lost with the old socket.
+          this.flushPendingEvents(transport)
           if (!settled) {
             settled = true
             this.deps.log?.info(`shim: bound as ${frame.agentId} generation ${frame.generation}`)
@@ -243,7 +253,9 @@ export class ShimClient {
     const streamId = payload?.op === 'open' ? request.id : (payload?.streamId ?? '')
     if (payload?.op === 'open') {
       const runner = new AcpRunner({
-        emit: (event) => transport.send(JSON.stringify({ type: 'shim/event', streamId, event })),
+        // Deliberately NOT the transport that handled `open`: renewal closes that socket, and
+        // a captured reference would send every later byte into it.
+        emit: (event) => this.emitEvent(streamId, event),
         ...(this.deps.resolveCommand ? { resolveCommand: this.deps.resolveCommand } : {}),
         ...(this.deps.log ? { log: this.deps.log } : {})
       })
@@ -260,6 +272,40 @@ export class ShimClient {
     await runner.apply(request.payload)
     if (payload.op === 'close') this.acpStreams.delete(streamId)
     transport.send(JSON.stringify({ type: 'shim/response', id: request.id, ok: true }))
+  }
+
+  /** Send an event on whichever transport is currently bound, or hold it until one is. */
+  private emitEvent(streamId: string, event: ShimEvent['event']): void {
+    const text = JSON.stringify({ type: 'shim/event', streamId, event })
+    if (event.kind === 'exit') this.acpStreams.delete(streamId)
+    const transport = this.transport
+    if (transport && this.bound) {
+      transport.send(text)
+      return
+    }
+    if (this.pendingEvents.length >= MAX_BUFFERED_EVENTS) {
+      // Dropping ACP bytes silently would corrupt the stream, so fail it loudly instead.
+      this.deps.log?.warn(`shim: buffered ${MAX_BUFFERED_EVENTS} events with no channel — failing stream ${streamId}`)
+      this.pendingEvents.length = 0
+      void this.acpStreams.get(streamId)?.close(0)
+      this.acpStreams.delete(streamId)
+      this.pendingEvents.push(
+        JSON.stringify({
+          type: 'shim/event',
+          streamId,
+          event: { kind: 'exit', code: null, signal: null, error: 'channel unavailable too long' }
+        })
+      )
+      return
+    }
+    this.pendingEvents.push(text)
+  }
+
+  /** Flush events produced while the channel was down, oldest first. */
+  private flushPendingEvents(transport: ShimTransport): void {
+    if (this.pendingEvents.length === 0) return
+    this.deps.log?.info(`shim: flushing ${this.pendingEvents.length} event(s) buffered across a rebind`)
+    for (const text of this.pendingEvents.splice(0)) transport.send(text)
   }
 
   private async serve(transport: ShimTransport, request: Extract<ShimFrame, { type: 'shim/request' }>): Promise<void> {

--- a/packages/daemon/src/shim/index.ts
+++ b/packages/daemon/src/shim/index.ts
@@ -3,6 +3,7 @@
  *  (`/opt/agentconnect/shim`), root-owned and read-only, with tini as PID 1. */
 import { ClientTransport } from '@agentconnect.md/connection'
 import { ShimClient, type ShimTransport } from './client.js'
+import { resolveCommandInPath } from './path-resolve.js'
 import { SHIM_ENDPOINT_ENV } from './protocol.js'
 
 const log = {
@@ -20,6 +21,9 @@ async function main(): Promise<number> {
     endpoint,
     dial: (url, opts) =>
       ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
+    // Without this the runner skips executable hints entirely, so CLAUDE_CODE_EXECUTABLE and
+    // path-qualified registry commands would never resolve in the sandbox.
+    resolveCommand: resolveCommandInPath,
     log
   })
   // A signal is the pod being torn down; drop the channel rather than racing the

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -255,10 +255,10 @@ export class ShimListener {
         ws.close(4403, 'not bound')
         return
       }
-      if (frame.type === 'shim/response') {
-        // A reply to something the daemon asked for: hand it to whoever is waiting. The
-        // frame is not trusted beyond its correlation id — the channel only resolves a
-        // request it actually issued.
+      if (frame.type === 'shim/response' || frame.type === 'shim/event') {
+        // A reply, or a recurring event on a stream the daemon opened: hand it to whoever is
+        // waiting. Neither is trusted beyond its correlation id — a channel only resolves a
+        // request it actually issued, and a stream consumer only accepts its own stream id.
         const text = typeof data === 'string' ? data : String(data)
         for (const listener of frameListeners) listener(text)
         return

--- a/packages/daemon/src/shim/path-resolve.ts
+++ b/packages/daemon/src/shim/path-resolve.ts
@@ -1,0 +1,30 @@
+import { accessSync, constants, statSync } from 'node:fs'
+import { delimiter, isAbsolute, join, resolve } from 'node:path'
+
+/**
+ * Resolve a command in THIS filesystem, which inside a sandbox is the only one that counts.
+ *
+ * Deliberately a local implementation rather than an import of the daemon's resolver: that
+ * one pulls the runtime registry and curated catalog behind it, and the shim ships as a
+ * single self-contained file with nothing but node builtins.
+ */
+export function resolveCommandInPath(command: string, env: Record<string, string>): string | undefined {
+  const executable = (candidate: string): string | undefined => {
+    try {
+      if (!statSync(candidate).isFile()) return undefined
+      accessSync(candidate, constants.X_OK)
+      return candidate
+    } catch {
+      return undefined
+    }
+  }
+  // An absolute or explicitly relative command is a path already, not a PATH lookup.
+  if (isAbsolute(command)) return executable(command)
+  if (command.startsWith('./') || command.startsWith('../')) return executable(resolve(command))
+  for (const dir of (env.PATH ?? '').split(delimiter)) {
+    if (!dir) continue
+    const found = executable(join(dir, command))
+    if (found) return found
+  }
+  return undefined
+}

--- a/packages/daemon/src/shim/protocol.ts
+++ b/packages/daemon/src/shim/protocol.ts
@@ -27,7 +27,10 @@ export const ShimCapabilitySchema = z.enum([
   /** Read a bounded file back out (BFF workspace reads). */
   'read',
   /** Proxy an in-pod unix socket back to a daemon-side server (gitcred, gh, MCP). */
-  'tunnel'
+  'tunnel',
+  /** Run the ACP runtime and relay its stdio as a stream (its own channel: ACP is already
+   *  a complete protocol, and reinterpreting it here would add a second place to break). */
+  'acp'
 ])
 export type ShimCapability = z.infer<typeof ShimCapabilitySchema>
 
@@ -80,12 +83,30 @@ export const ShimResponseSchema = z.object({
   error: z.string().max(500).optional()
 })
 
+/** A recurring event on an open stream. Unlike a response, many arrive per request: an ACP
+ *  runtime emits stdout continuously and exits once, and neither fits one-shot correlation. */
+export const ShimEventSchema = z.object({
+  type: z.literal('shim/event'),
+  /** The request id that opened the stream. */
+  streamId: z.string().uuid(),
+  event: z.discriminatedUnion('kind', [
+    z.object({ kind: z.literal('chunk'), data: z.string() }),
+    z.object({
+      kind: z.literal('exit'),
+      code: z.number().int().nullable(),
+      signal: z.string().nullable(),
+      error: z.string().max(500).optional()
+    })
+  ])
+})
+
 export const ShimFrameSchema = z.discriminatedUnion('type', [
   ShimHelloSchema,
   ShimBoundSchema,
   ShimRejectedSchema,
   ShimRequestSchema,
-  ShimResponseSchema
+  ShimResponseSchema,
+  ShimEventSchema
 ])
 
 export type ShimHello = z.infer<typeof ShimHelloSchema>
@@ -93,6 +114,7 @@ export type ShimBound = z.infer<typeof ShimBoundSchema>
 export type ShimRejected = z.infer<typeof ShimRejectedSchema>
 export type ShimRequest = z.infer<typeof ShimRequestSchema>
 export type ShimResponse = z.infer<typeof ShimResponseSchema>
+export type ShimEvent = z.infer<typeof ShimEventSchema>
 export type ShimFrame = z.infer<typeof ShimFrameSchema>
 
 /** Parse an inbound frame, returning undefined rather than throwing: a malformed frame

--- a/packages/daemon/src/shim/session.ts
+++ b/packages/daemon/src/shim/session.ts
@@ -1,0 +1,85 @@
+import { ShimChannel } from './channels.js'
+import type { ShimConnection } from './listener.js'
+import type { ShimCapability, ShimEvent } from './protocol.js'
+import { parseShimFrame } from './protocol.js'
+
+/**
+ * A logical channel to one agent's sandbox that survives the physical connection.
+ *
+ * A runtime lives for hours; a shim connection does not. The shim renews its credential by
+ * dialing a replacement at half the TTL, and the listener closes the superseded socket — so
+ * anything holding one `ShimConnection` for a runtime's lifetime is stranded on the first
+ * ordinary renewal. This tracks the current connection instead, re-attaching when the same
+ * launch rebinds and reporting a genuine loss when a NEW launch takes over.
+ */
+export class ShimSession {
+  private channel?: ShimChannel
+  private connection?: ShimConnection
+  private readonly eventListeners = new Set<(event: ShimEvent) => void>()
+  private readonly lostListeners = new Set<(reason: string) => void>()
+  private closed = false
+
+  constructor(
+    readonly agentId: string,
+    readonly generation: number,
+    private readonly timers: { setTimeout: (fn: () => void, ms: number) => unknown; clearTimeout: (h: unknown) => void }
+  ) {}
+
+  /**
+   * Attach (or re-attach) the physical connection serving this launch.
+   *
+   * A rebind at the same generation is a renewal: in-flight requests are failed, because
+   * their replies would have gone to a socket that no longer exists, but the session itself
+   * continues and a caller can simply ask again. A different generation is a new launch, so
+   * the session is finished rather than reused.
+   */
+  attach(connection: ShimConnection): void {
+    if (this.closed) return
+    if (connection.binding.generation !== this.generation) {
+      this.lose(`superseded by generation ${connection.binding.generation}`)
+      return
+    }
+    this.channel?.abort('shim channel renewed')
+    this.connection = connection
+    const channel = new ShimChannel(connection, connection.issuedCredential, this.timers)
+    this.channel = channel
+    connection.onFrame((text) => {
+      if (channel.accept(text)) return
+      const frame = parseShimFrame(text)
+      if (frame?.type !== 'shim/event') return
+      for (const listener of this.eventListeners) listener(frame)
+    })
+  }
+
+  /** Report that this launch's channel is gone for good. */
+  lose(reason: string): void {
+    if (this.closed) return
+    this.closed = true
+    this.channel?.abort(reason)
+    this.channel = undefined
+    this.connection = undefined
+    for (const listener of this.lostListeners) listener(reason)
+  }
+
+  onEvent(listener: (event: ShimEvent) => void): void {
+    this.eventListeners.add(listener)
+  }
+
+  onLost(listener: (reason: string) => void): void {
+    this.lostListeners.add(listener)
+  }
+
+  /** Drop a subscription — the runtime it belonged to is gone, and a session outlives it. */
+  offEvent(listener: (event: ShimEvent) => void): void {
+    this.eventListeners.delete(listener)
+  }
+
+  isAttached(): boolean {
+    return this.channel !== undefined
+  }
+
+  request(capability: ShimCapability, payload: unknown, timeoutMs?: number): Promise<unknown> {
+    if (!this.channel) throw new Error(`agent ${this.agentId} has no attached shim channel`)
+    return this.channel.request(capability, payload, timeoutMs)
+  }
+}

--- a/packages/daemon/test/cluster-acp-e2e.test.ts
+++ b/packages/daemon/test/cluster-acp-e2e.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { ClientTransport } from '@agentconnect.md/connection'
+import { AcpHost } from '../src/acp/acp-host.js'
+import { ClusterSpawnDriver } from '../src/k8s/cluster-driver.js'
+import { ShimListener, type ShimConnection } from '../src/shim/listener.js'
+import { ShimClient, type ShimTransport } from '../src/shim/client.js'
+import { K8sApiError } from '../src/k8s/http.js'
+import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
+import type { SpawnRecord } from '../src/shim/binding.js'
+
+/**
+ * A complete ACP turn through the cluster path: driver → listener → shim → runtime → back.
+ *
+ * This test exists because the first version of the driver did not work at all. It sent the
+ * ACP stream through the one-request/one-response channel, so stdout and exit had no path
+ * home and `AcpHost.start()` would have hung forever — and every unit test passed, because
+ * they all checked the parts I had a model for (claim shape, generations, drain, retries)
+ * and never ran a turn. A driver that cannot carry a turn is not a driver.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fakeAgent = join(here, 'fixtures', 'fake-acp-agent.mjs')
+
+const listeners: ShimListener[] = []
+const clients: ShimClient[] = []
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) client.stop()
+  await Promise.all(listeners.splice(0).map((instance) => instance.stop()))
+})
+
+/** Minimal SandboxApi: one claim, one always-ready Sandbox, mode held in memory. */
+function fakeApi() {
+  const state = {
+    mode: 'Suspended' as 'Running' | 'Suspended',
+    sandbox: {
+      metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
+      spec: { operatingMode: 'Suspended' as 'Running' | 'Suspended' },
+      status: { conditions: [{ type: 'Ready', status: 'True' }] }
+    } as Sandbox,
+    claim: undefined as SandboxClaim | undefined
+  }
+  return {
+    state,
+    api: {
+      ensureClaim: async (claim: SandboxClaim & { metadata: { name: string } }) => {
+        state.claim = { ...claim, status: { sandbox: { name: 'sb-1' } } }
+        return state.claim
+      },
+      getClaim: async () => {
+        if (!state.claim) throw new K8sApiError(404, 'NotFound', 'no claim')
+        return state.claim
+      },
+      deleteClaim: async () => {
+        state.claim = undefined
+      },
+      getSandbox: async () => state.sandbox,
+      setOperatingMode: async (_name: string, desired: 'Running' | 'Suspended') => {
+        state.mode = desired
+        state.sandbox = { ...state.sandbox, spec: { operatingMode: desired } }
+        return state.sandbox
+      },
+      watchClaims: vi.fn(),
+      watchSandboxes: vi.fn(),
+      reviewToken: vi.fn()
+    }
+  }
+}
+
+/** Wire a real listener, a real shim client, and a driver that connects them. */
+async function clusterUnderTest(): Promise<{
+  driver: ClusterSpawnDriver
+  api: ReturnType<typeof fakeApi>
+  connections: ShimConnection[]
+}> {
+  const api = fakeApi()
+  let record: SpawnRecord | undefined
+  const connections: ShimConnection[] = []
+  const listener = new ShimListener({
+    verifier: { reviewToken: async () => ({ authenticated: true, podName: 'runtime-1', podUid: 'pod-uid-1' }) },
+    spawnRecordForPod: () => record,
+    now: () => Date.now(),
+    log: { info: () => {}, warn: () => {} }
+  })
+  listeners.push(listener)
+  const port = await listener.start(0, '127.0.0.1')
+
+  const driver = new ClusterSpawnDriver({
+    api: api.api as never,
+    orgId: 'org-1',
+    warmPoolName: 'pool',
+    publishSpawnRecord: (published) => {
+      record = published
+      // The shim can only dial once a record exists, so start it here — the same ordering the
+      // real driver depends on.
+      const client = new ShimClient({
+        endpoint: `ws://127.0.0.1:${port}`,
+        dial: (url, opts) =>
+          ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
+        readToken: () => 'projected-token',
+        log: { info: () => {}, warn: () => {} }
+      })
+      clients.push(client)
+      void client.start()
+    },
+    awaitChannel: async (agentId, generation, timeoutMs) => {
+      const deadline = Date.now() + timeoutMs
+      for (;;) {
+        const match = listener
+          .connectionsFor(agentId)
+          .find((connection) => connection.binding.generation === generation)
+        if (match) {
+          connections.push(match)
+          return match
+        }
+        if (Date.now() > deadline) throw new Error('no channel bound in time')
+        await new Promise((resolve) => setTimeout(resolve, 20))
+      }
+    },
+    readyTimeoutMs: 15_000,
+    log: { info: () => {}, warn: () => {}, debug: () => {} }
+  })
+  return { driver, api, connections }
+}
+
+describe('a full ACP turn over the cluster driver', () => {
+  it('starts the runtime in the sandbox, prompts it, and streams the reply back', async () => {
+    const { driver, api } = await clusterUnderTest()
+    const updates: string[] = []
+    const host = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: [] },
+      {
+        driver,
+        onUpdate: (_sessionId, update) => {
+          if (
+            update.sessionUpdate === 'agent_message_chunk' &&
+            (update as { content?: { type?: string; text?: string } }).content?.type === 'text'
+          ) {
+            updates.push((update as unknown as { content: { text: string } }).content.text)
+          }
+        },
+        env: { AC_AGENT_ID: 'agent-a' }
+      }
+    )
+
+    await host.start()
+    // The sandbox was suspended: resuming it is what let the runtime start at all.
+    expect(api.state.mode).toBe('Running')
+
+    const sessionId = await host.newSession('/tmp')
+    const result = await host.prompt(sessionId, [{ type: 'text', text: 'hello' }])
+    expect(result.stopReason).toBe('end_turn')
+    // The reply came from a process the SHIM started, relayed as events over the channel.
+    expect(updates).toContain('echo:hello')
+    await host.stop(2_000)
+  }, 60_000)
+
+  it('reports terminal exit to AcpHost when the channel is lost, instead of hanging', async () => {
+    const { driver } = await clusterUnderTest()
+    let terminal = 0
+    const host = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: [] },
+      { driver, onUpdate: () => {}, onTerminal: () => terminal++, env: { AC_AGENT_ID: 'agent-a' } }
+    )
+    await host.start()
+    // A lost channel is a dead runtime; without this the host waits on a stream that can
+    // never produce another byte.
+    driver.onChannelLost('agent-a', 'sandbox evicted')
+    await vi.waitFor(() => expect(terminal).toBe(1), { timeout: 10_000 })
+  }, 60_000)
+
+  it('survives a credential renewal: the same runtime keeps working across a rebind', async () => {
+    // The defect this covers: pinning a runtime to one physical connection strands it on the
+    // first ordinary renewal, because the shim reconnects at half TTL and the listener closes
+    // the superseded socket.
+    const { driver } = await clusterUnderTest()
+    const host = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: [] },
+      { driver, onUpdate: () => {}, env: { AC_AGENT_ID: 'agent-a' } }
+    )
+    await host.start()
+    const first = await host.newSession('/tmp')
+    expect(await host.prompt(first, [{ type: 'text', text: 'before' }])).toMatchObject({ stopReason: 'end_turn' })
+    await host.stop(2_000)
+  }, 60_000)
+})

--- a/packages/daemon/test/cluster-acp-e2e.test.ts
+++ b/packages/daemon/test/cluster-acp-e2e.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { ClientTransport } from '@agentconnect.md/connection'
+import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
 import { AcpHost } from '../src/acp/acp-host.js'
 import { ClusterSpawnDriver } from '../src/k8s/cluster-driver.js'
 import { ShimListener, type ShimConnection } from '../src/shim/listener.js'
@@ -25,8 +25,10 @@ const fakeAgent = join(here, 'fixtures', 'fake-acp-agent.mjs')
 
 const listeners: ShimListener[] = []
 const clients: ShimClient[] = []
+const intervals: NodeJS.Timeout[] = []
 
 afterEach(async () => {
+  for (const timer of intervals.splice(0)) clearInterval(timer)
   for (const client of clients.splice(0)) client.stop()
   await Promise.all(listeners.splice(0).map((instance) => instance.stop()))
 })
@@ -70,19 +72,25 @@ function fakeApi() {
 }
 
 /** Wire a real listener, a real shim client, and a driver that connects them. */
-async function clusterUnderTest(): Promise<{
+async function clusterUnderTest(options: { credentialTtlMs?: number } = {}): Promise<{
   driver: ClusterSpawnDriver
   api: ReturnType<typeof fakeApi>
   connections: ShimConnection[]
+  shimClock: FakeClock
+  listener: ShimListener
+  bindCount: () => number
 }> {
   const api = fakeApi()
   let record: SpawnRecord | undefined
   const connections: ShimConnection[] = []
+  const shimClock = new FakeClock()
+  let binds = 0
   const listener = new ShimListener({
     verifier: { reviewToken: async () => ({ authenticated: true, podName: 'runtime-1', podUid: 'pod-uid-1' }) },
     spawnRecordForPod: () => record,
     now: () => Date.now(),
-    log: { info: () => {}, warn: () => {} }
+    ...(options.credentialTtlMs !== undefined ? { credentialTtlMs: options.credentialTtlMs } : {}),
+    log: { info: () => (binds += 0), warn: () => {} }
   })
   listeners.push(listener)
   const port = await listener.start(0, '127.0.0.1')
@@ -100,6 +108,8 @@ async function clusterUnderTest(): Promise<{
         dial: (url, opts) =>
           ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
         readToken: () => 'projected-token',
+        clock: shimClock,
+        backoff: new Backoff({ jitter: () => 0 }),
         log: { info: () => {}, warn: () => {} }
       })
       clients.push(client)
@@ -111,10 +121,12 @@ async function clusterUnderTest(): Promise<{
         const match = listener
           .connectionsFor(agentId)
           .find((connection) => connection.binding.generation === generation)
-        if (match) {
+        if (match && !connections.includes(match)) {
           connections.push(match)
+          binds += 1
           return match
         }
+        if (match) return match
         if (Date.now() > deadline) throw new Error('no channel bound in time')
         await new Promise((resolve) => setTimeout(resolve, 20))
       }
@@ -122,7 +134,18 @@ async function clusterUnderTest(): Promise<{
     readyTimeoutMs: 15_000,
     log: { info: () => {}, warn: () => {}, debug: () => {} }
   })
-  return { driver, api, connections }
+  // Whoever owns the listener re-attaches a rebound channel; the daemon does this in
+  // production, and the test stands in for it.
+  const watchBinds = setInterval(() => {
+    for (const connection of listener.connectionsFor('agent-a')) {
+      if (connections.includes(connection)) continue
+      connections.push(connection)
+      binds += 1
+      driver.onChannelBound(connection)
+    }
+  }, 20)
+  intervals.push(watchBinds)
+  return { driver, api, connections, shimClock, listener, bindCount: () => binds }
 }
 
 describe('a full ACP turn over the cluster driver', () => {
@@ -171,18 +194,27 @@ describe('a full ACP turn over the cluster driver', () => {
     await vi.waitFor(() => expect(terminal).toBe(1), { timeout: 10_000 })
   }, 60_000)
 
-  it('survives a credential renewal: the same runtime keeps working across a rebind', async () => {
-    // The defect this covers: pinning a runtime to one physical connection strands it on the
-    // first ordinary renewal, because the shim reconnects at half TTL and the listener closes
-    // the superseded socket.
-    const { driver } = await clusterUnderTest()
+  it('keeps the SAME runtime working across a real credential renewal', async () => {
+    // The defect this covers: the shim's event sink captured the socket that handled `open`,
+    // so after the renewal at half TTL every byte of stdout went into a closed WebSocket.
+    // The previous version of this test performed one prompt and never renewed, so it could
+    // not have caught that — the case it was named for never occurred in it.
+    const { driver, shimClock, bindCount } = await clusterUnderTest({ credentialTtlMs: 600_000 })
     const host = new AcpHost(
       { command: process.execPath, args: [fakeAgent], env: [] },
       { driver, onUpdate: () => {}, env: { AC_AGENT_ID: 'agent-a' } }
     )
     await host.start()
-    const first = await host.newSession('/tmp')
-    expect(await host.prompt(first, [{ type: 'text', text: 'before' }])).toMatchObject({ stopReason: 'end_turn' })
+    const sessionId = await host.newSession('/tmp')
+    expect(await host.prompt(sessionId, [{ type: 'text', text: 'before' }])).toMatchObject({ stopReason: 'end_turn' })
+
+    const bindsBefore = bindCount()
+    // Half the advertised lifetime: the shim closes its socket and dials a replacement.
+    shimClock.advance(300_000)
+    await vi.waitFor(() => expect(bindCount()).toBeGreaterThan(bindsBefore), { timeout: 15_000 })
+
+    // Same runtime, same ACP session, after the channel underneath was replaced.
+    expect(await host.prompt(sessionId, [{ type: 'text', text: 'after' }])).toMatchObject({ stopReason: 'end_turn' })
     await host.stop(2_000)
   }, 60_000)
 })

--- a/packages/daemon/test/cluster-driver.test.ts
+++ b/packages/daemon/test/cluster-driver.test.ts
@@ -97,7 +97,7 @@ describe('cluster spawn driver', () => {
         agentId: 'agent-a',
         sandboxUid: 'sandbox-uid-1',
         generation: 1,
-        grants: ['materialize', 'exec', 'read', 'tunnel']
+        grants: ['acp', 'materialize', 'exec', 'read', 'tunnel']
       }
     ])
   })
@@ -165,6 +165,55 @@ describe('cluster spawn driver', () => {
     expect(instance.isDraining('agent-a')).toBe(false)
     await instance.wake('agent-a')
     expect(state.modeWrites).toEqual([{ desired: 'Running', observed: 'Suspended' }])
+  })
+
+  it('orders concurrent wake and suspend decisions so the newer one wins', async () => {
+    // A guarded write protects competing WRITES, but it cannot protect a decision that
+    // performs no write: a later wake reading Running would return while an earlier suspend
+    // patch was still in flight, and the older write would land last and reverse it.
+    const { api, state } = fakeApi({ mode: 'Running' })
+    let releaseFirst!: () => void
+    const gate = new Promise<void>((resolve) => (releaseFirst = resolve))
+    let calls = 0
+    const original = api.setOperatingMode
+    api.setOperatingMode = vi.fn(async (name: string, desired: never, observed: never) => {
+      calls += 1
+      if (calls === 1) await gate
+      return original(name, desired, observed)
+    }) as never
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+
+    const suspending = instance.suspend('agent-a')
+    const waking = instance.wake('agent-a')
+    releaseFirst()
+    await Promise.all([suspending, waking])
+
+    // The wake was decided second, so it must be the state that survives.
+    expect(state.sandbox.spec?.operatingMode).toBe('Running')
+    expect(state.modeWrites.map((write) => write.desired)).toEqual(['Suspended', 'Running'])
+  })
+
+  it('refuses to launch while a drain request is pending, instead of waiting out a timeout', async () => {
+    const { api } = fakeApi({ mode: 'Suspended' })
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    instance.onSandboxObserved('agent-a', { [DRAIN_REQUESTED_ANNOTATION]: 'rollout-1/img' })
+    // wake() holds the sandbox down deliberately, so launching would block until the readiness
+    // deadline elapsed. Failing fast says what is actually happening.
+    await expect(instance.launch({ command: 'x', args: [], env: { AC_AGENT_ID: 'agent-a' } })).rejects.toThrow(
+      /draining/
+    )
+  })
+
+  it('resolves a suspended claim without waiting for readiness first', async () => {
+    // After a daemon restart the claim still names its Sandbox, but suspension deleted the
+    // pod — so requiring Ready here would block the only call that could bring it back.
+    const { api } = fakeApi({ mode: 'Suspended', ready: false })
+    const { instance, records } = driver(api)
+    const launch = await instance.ensureSandbox('agent-a')
+    expect(launch.sandboxName).toBe('sb-1')
+    expect(records).toHaveLength(1)
   })
 
   it('deletes the claim when an agent goes away', async () => {

--- a/packages/daemon/test/cluster-driver.test.ts
+++ b/packages/daemon/test/cluster-driver.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FakeClock } from '@agentconnect.md/connection'
+import { ClusterSpawnDriver, DRAIN_REQUESTED_ANNOTATION, AC_LABEL_AGENT } from '../src/k8s/cluster-driver.js'
+import { OperatingModeRejectedError } from '../src/k8s/sandbox-api.js'
+import { K8sApiError } from '../src/k8s/http.js'
+import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
+import type { SpawnRecord } from '../src/shim/binding.js'
+import type { ShimConnection } from '../src/shim/listener.js'
+
+/** A SandboxApi stand-in whose object state a test drives directly. */
+function fakeApi(options: { ready?: boolean; mode?: 'Running' | 'Suspended' } = {}) {
+  const state = {
+    claims: new Map<string, SandboxClaim>(),
+    sandbox: {
+      metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
+      spec: { operatingMode: options.mode ?? 'Running' },
+      status: { conditions: [{ type: 'Ready', status: options.ready === false ? 'False' : 'True' }] }
+    } as Sandbox,
+    modeWrites: [] as Array<{ desired: string; observed: string }>,
+    rejectNextModeWrites: 0,
+    created: [] as SandboxClaim[],
+    deleted: [] as string[]
+  }
+  const api = {
+    ensureClaim: vi.fn(async (claim: SandboxClaim & { metadata: { name: string } }) => {
+      state.created.push(claim)
+      state.claims.set(claim.metadata.name, { ...claim, status: { sandbox: { name: 'sb-1' } } })
+      return state.claims.get(claim.metadata.name)!
+    }),
+    getClaim: vi.fn(async (name: string) => {
+      const claim = state.claims.get(name)
+      if (!claim) throw new K8sApiError(404, 'NotFound', 'no claim')
+      return claim
+    }),
+    deleteClaim: vi.fn(async (name: string) => {
+      state.deleted.push(name)
+      state.claims.delete(name)
+    }),
+    getSandbox: vi.fn(async () => state.sandbox),
+    setOperatingMode: vi.fn(
+      async (_name: string, desired: 'Running' | 'Suspended', observed: 'Running' | 'Suspended') => {
+        state.modeWrites.push({ desired, observed })
+        if (state.rejectNextModeWrites > 0) {
+          state.rejectNextModeWrites -= 1
+          throw new OperatingModeRejectedError('sb-1', observed, desired, new K8sApiError(422, 'Invalid', 'rejected'))
+        }
+        state.sandbox = { ...state.sandbox, spec: { ...state.sandbox.spec, operatingMode: desired } }
+        return state.sandbox
+      }
+    ),
+    watchClaims: vi.fn(),
+    watchSandboxes: vi.fn(),
+    reviewToken: vi.fn()
+  }
+  return { api, state }
+}
+
+function driver(api: ReturnType<typeof fakeApi>['api'], overrides: Record<string, unknown> = {}) {
+  const records: SpawnRecord[] = []
+  const clock = new FakeClock()
+  const instance = new ClusterSpawnDriver({
+    api: api as never,
+    orgId: 'org-1',
+    warmPoolName: 'ac-runtime-standard-pool',
+    awaitChannel: async () => ({}) as ShimConnection,
+    publishSpawnRecord: (record) => records.push(record),
+    clock,
+    log: { info: () => {}, warn: () => {}, debug: () => {} },
+    ...overrides
+  })
+  return { instance, records, clock }
+}
+
+describe('cluster spawn driver', () => {
+  it('creates a claim that carries the pool and labels but no per-agent env', async () => {
+    const { api, state } = fakeApi()
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    expect(state.created).toHaveLength(1)
+    const claim = state.created[0]!
+    expect(claim.metadata.name).toBe('agent-agent-a')
+    expect(claim.spec?.warmPoolRef?.name).toBe('ac-runtime-standard-pool')
+    expect(claim.spec?.additionalPodMetadata?.labels?.[AC_LABEL_AGENT]).toBe('agent-a')
+    // A claim carrying env or volumeClaimTemplates bypasses warm-pool adoption, so identity
+    // travels over the handshake instead. This asserts the shape stays clean.
+    expect((claim.spec as Record<string, unknown>).env).toBeUndefined()
+    expect((claim.spec as Record<string, unknown>).volumeClaimTemplates).toBeUndefined()
+  })
+
+  it('publishes a spawn record before a shim could bind, keyed on the Sandbox metadata uid', async () => {
+    const { api } = fakeApi()
+    const { instance, records } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    // The uid comes from the Sandbox object; the claim status carries only a name.
+    expect(records).toEqual([
+      {
+        agentId: 'agent-a',
+        sandboxUid: 'sandbox-uid-1',
+        generation: 1,
+        grants: ['materialize', 'exec', 'read', 'tunnel']
+      }
+    ])
+  })
+
+  it('increments the generation per launch so a departed incarnation cannot act', async () => {
+    const { api } = fakeApi()
+    const { instance, records } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    instance.forgetLaunch('agent-a')
+    await instance.ensureSandbox('agent-a')
+    expect(records.map((record) => record.generation)).toEqual([1, 2])
+  })
+
+  it('is idempotent: an existing launch is reused rather than re-claimed', async () => {
+    const { api, state } = fakeApi()
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    await instance.ensureSandbox('agent-a')
+    expect(state.created).toHaveLength(1)
+  })
+
+  it('skips the mode write when the sandbox is already where it should be', async () => {
+    const { api, state } = fakeApi({ mode: 'Running' })
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    await instance.wake('agent-a')
+    expect(state.modeWrites).toEqual([])
+  })
+
+  it('re-reads and retries when the guarded write is rejected', async () => {
+    const { api, state } = fakeApi({ mode: 'Running' })
+    state.rejectNextModeWrites = 2
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    await instance.suspend('agent-a')
+    // The rejection does not say what the state became, so the only correct response is to
+    // look again — three attempts, the third landing.
+    expect(state.modeWrites).toHaveLength(3)
+    expect(state.sandbox.spec?.operatingMode).toBe('Suspended')
+  })
+
+  it('gives up after a bounded number of rejections instead of looping forever', async () => {
+    const { api, state } = fakeApi({ mode: 'Running' })
+    state.rejectNextModeWrites = 99
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    // A permanently invalid patch must not spin: the error is deliberately unclaimed about
+    // its cause, so a caller that retried forever would never learn otherwise.
+    await expect(instance.suspend('agent-a')).rejects.toThrow(/would not accept/)
+    expect(state.modeWrites).toHaveLength(5)
+  })
+
+  it('does not wake an instance while a drain request is pending', async () => {
+    const { api, state } = fakeApi({ mode: 'Suspended' })
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    instance.onSandboxObserved('agent-a', { [DRAIN_REQUESTED_ANNOTATION]: 'rollout-7/image:v2' })
+    expect(instance.isDraining('agent-a')).toBe(true)
+    await instance.wake('agent-a')
+    // One arriving message must not revive the image the rollout is replacing; the message
+    // queues instead.
+    expect(state.modeWrites).toEqual([])
+
+    instance.onSandboxObserved('agent-a', {})
+    expect(instance.isDraining('agent-a')).toBe(false)
+    await instance.wake('agent-a')
+    expect(state.modeWrites).toEqual([{ desired: 'Running', observed: 'Suspended' }])
+  })
+
+  it('deletes the claim when an agent goes away', async () => {
+    const { api, state } = fakeApi()
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    await instance.removeAgent('agent-a')
+    expect(state.deleted).toEqual(['agent-agent-a'])
+    expect(instance.currentLaunch('agent-a')).toBeUndefined()
+  })
+
+  it('refuses to launch without an agent id in the runtime environment', async () => {
+    const { api } = fakeApi()
+    const { instance } = driver(api)
+    await expect(instance.launch({ command: 'claude-code-acp', args: [], env: {} })).rejects.toThrow(/AC_AGENT_ID/)
+  })
+})

--- a/packages/daemon/test/k8s-real-apiserver.test.ts
+++ b/packages/daemon/test/k8s-real-apiserver.test.ts
@@ -1,0 +1,314 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { K8sApiError, K8sHttp } from '../src/k8s/http.js'
+import { SandboxApi, OperatingModeRejectedError } from '../src/k8s/sandbox-api.js'
+import { watchCollection } from '../src/k8s/watch.js'
+import { Backoff, FakeClock } from '@agentconnect.md/connection'
+import type { InClusterConfig } from '../src/k8s/config.js'
+
+/**
+ * The Kubernetes beliefs this client is built on, checked against a REAL API server rather
+ * than a fake of my own making.
+ *
+ * This exists because every defect in the shim/client review history got through the same
+ * way: a fixture written from the same assumption as the code, agreeing with it. A fake
+ * cannot tell me what status Kubernetes returns for a failed JSON Patch `test` — only
+ * Kubernetes can, and it answers 422, not the 409 the first implementation expected.
+ *
+ * Gated rather than always-on: it needs Docker and a k3s image, which a plain unit run has
+ * no business requiring. Set AC_K8S_E2E=1 to run it.
+ */
+const ENABLED = process.env.AC_K8S_E2E === '1'
+const IMAGE = process.env.AC_K3S_IMAGE ?? 'rancher/k3s:v1.31.2-k3s1'
+const CONTAINER = 'ac-k8s-e2e'
+const GROUP = 'test.agentconnect.md'
+
+function docker(args: string[], timeoutMs = 120_000): string {
+  return execFileSync('docker', args, { encoding: 'utf8', timeout: timeoutMs })
+}
+
+function kubectl(args: string[], stdin?: string): string {
+  return execFileSync('docker', ['exec', '-i', CONTAINER, 'kubectl', ...args], {
+    encoding: 'utf8',
+    timeout: 120_000,
+    ...(stdin ? { input: stdin } : {})
+  })
+}
+
+const CRD = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: probes.${GROUP}
+spec:
+  group: ${GROUP}
+  names: { kind: Probe, plural: probes, singular: probe }
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources: { status: {} }
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                operatingMode: { type: string, enum: [Running, Suspended] }
+            status:
+              type: object
+              properties:
+                note: { type: string }
+`
+
+/** The RBAC the design specifies for a daemon, applied here so the test exercises the real
+ *  authorization path rather than a cluster-admin shortcut: namespaced verbs on the custom
+ *  resource, plus cluster-scoped TokenReview create and nothing else. */
+const RBAC = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: { name: ac-daemon, namespace: default }
+rules:
+  - apiGroups: ["${GROUP}"]
+    resources: [probes]
+    verbs: [create, delete, get, list, watch, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: { name: ac-daemon, namespace: default }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: ac-daemon }
+subjects:
+  - { kind: ServiceAccount, name: default, namespace: default }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: { name: ac-tokenreview }
+rules:
+  - apiGroups: [authentication.k8s.io]
+    resources: [tokenreviews]
+    verbs: [create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: { name: ac-tokenreview }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: ac-tokenreview }
+subjects:
+  - { kind: ServiceAccount, name: default, namespace: default }
+`
+
+describe.skipIf(!ENABLED)('Kubernetes client against a real API server', () => {
+  let config: InClusterConfig
+  let http: K8sHttp
+
+  beforeAll(async () => {
+    try {
+      docker(['rm', '-f', CONTAINER], 30_000)
+    } catch {
+      /* not running */
+    }
+    docker(
+      [
+        'run',
+        '-d',
+        '--privileged',
+        '--name',
+        CONTAINER,
+        '-p',
+        '26443:6443',
+        '-e',
+        'K3S_KUBECONFIG_MODE=644',
+        IMAGE,
+        'server',
+        '--disable-agent',
+        '--disable=traefik,servicelb,metrics-server,local-storage'
+      ],
+      300_000
+    )
+    const deadline = Date.now() + 240_000
+    for (;;) {
+      try {
+        kubectl(['get', '--raw', '/readyz'])
+        break
+      } catch (err) {
+        if (Date.now() > deadline) throw err
+        await new Promise((resolve) => setTimeout(resolve, 2_000))
+      }
+    }
+    kubectl(['apply', '-f', '-'], CRD)
+    // Wait for the CRD's endpoint to be served before using it.
+    for (let i = 0; i < 60; i += 1) {
+      try {
+        kubectl(['get', 'probes'])
+        break
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 1_000))
+      }
+    }
+    // The controller manager creates the namespace's default ServiceAccount shortly after
+    // the API server is ready, so a token request can arrive before it exists.
+    for (let i = 0; i < 120; i += 1) {
+      try {
+        kubectl(['get', 'serviceaccount', 'default'])
+        break
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 1_000))
+      }
+    }
+    kubectl(['apply', '-f', '-'], RBAC)
+    const token = kubectl(['create', 'token', 'default', '--duration=3600s']).trim()
+    // Pin the cluster's own CA, exactly as the in-cluster config does from the projected
+    // volume: the API server is self-signed, and trusting it any other way would not
+    // exercise the same code path.
+    const ca = docker(['exec', CONTAINER, 'cat', '/var/lib/rancher/k3s/server/tls/server-ca.crt'])
+    config = {
+      server: 'https://127.0.0.1:26443',
+      namespace: 'default',
+      ca,
+      token: () => token
+    }
+    http = new K8sHttp(config)
+  }, 600_000)
+
+  afterAll(() => {
+    try {
+      docker(['rm', '-f', CONTAINER], 60_000)
+    } catch {
+      /* already gone */
+    }
+  })
+
+  const probePath = '/apis/test.agentconnect.md/v1/namespaces/default/probes'
+
+  it('reports a failed JSON Patch test as 422 Invalid, not 409', async () => {
+    // The belief the first implementation got wrong. A fake told me 409 because I wrote the
+    // fake; the API server says 422, so `isConflict` would never have fired in the race the
+    // guard exists for.
+    await http.json({
+      method: 'POST',
+      path: probePath,
+      body: {
+        apiVersion: `${GROUP}/v1`,
+        kind: 'Probe',
+        metadata: { name: 'patch-probe' },
+        spec: { operatingMode: 'Running' }
+      }
+    })
+    const error = await http
+      .json({
+        method: 'PATCH',
+        path: `${probePath}/patch-probe`,
+        contentType: 'application/json-patch+json',
+        body: [
+          { op: 'test', path: '/spec/operatingMode', value: 'Suspended' },
+          { op: 'replace', path: '/spec/operatingMode', value: 'Running' }
+        ]
+      })
+      .catch((err: unknown) => err)
+    expect(error).toBeInstanceOf(K8sApiError)
+    const typed = error as K8sApiError
+    expect(typed.status).toBe(422)
+    expect(typed.isUnprocessable).toBe(true)
+    expect(typed.isConflict).toBe(false)
+  }, 120_000)
+
+  it('raises OperatingModeRejectedError from the guard the API server actually rejects', async () => {
+    const api = new SandboxApi(http, 'default')
+    // Reuse the probe CRD by pointing the sandbox path at it is not possible, so exercise the
+    // same code path through the raw client and assert the classification the driver relies
+    // on: a guarded write whose observed value is wrong is a rejection, not a success.
+    const error = await http
+      .json({
+        method: 'PATCH',
+        path: `${probePath}/patch-probe`,
+        contentType: 'application/json-patch+json',
+        body: [
+          { op: 'test', path: '/spec/operatingMode', value: 'Suspended' },
+          { op: 'replace', path: '/spec/operatingMode', value: 'Suspended' }
+        ]
+      })
+      .catch((err: unknown) => err)
+    expect((error as K8sApiError).isUnprocessable).toBe(true)
+    // And the driver's retry budget depends on this being a distinguishable class.
+    expect(new OperatingModeRejectedError('s', 'Running', 'Suspended', error as K8sApiError).name).toBe(
+      'OperatingModeRejectedError'
+    )
+    expect(api).toBeDefined()
+  }, 120_000)
+
+  it('returns 409 Conflict for a stale resourceVersion precondition', async () => {
+    // The alternative mechanism, measured: it IS a structured 409. It stays unused because it
+    // guards the whole object, so unrelated status writes would conflict — but the next
+    // person deciding this should not have to guess either.
+    const created = await http.json<{ metadata: { resourceVersion: string } }>({
+      method: 'POST',
+      path: probePath,
+      body: {
+        apiVersion: `${GROUP}/v1`,
+        kind: 'Probe',
+        metadata: { name: 'rv-probe' },
+        spec: { operatingMode: 'Running' }
+      }
+    })
+    const stale = String(Number(created.metadata.resourceVersion) - 5)
+    const error = await http
+      .json({
+        method: 'PATCH',
+        path: `${probePath}/rv-probe`,
+        contentType: 'application/merge-patch+json',
+        body: { metadata: { resourceVersion: stale }, spec: { operatingMode: 'Suspended' } }
+      })
+      .catch((err: unknown) => err)
+    expect((error as K8sApiError).status).toBe(409)
+    expect((error as K8sApiError).isConflict).toBe(true)
+  }, 120_000)
+
+  it('lists then watches, resuming from the list resourceVersion', async () => {
+    // Watch correctness against a real apiserver: the snapshot seeds the resume point, and a
+    // change made after the list arrives as an event rather than being lost.
+    const events: string[] = []
+    const controller = new AbortController()
+    const source = watchCollection(http, {
+      path: probePath,
+      signal: controller.signal,
+      clock: new FakeClock(),
+      backoff: new Backoff({ jitter: () => 0 })
+    })
+    const drain = (async () => {
+      for await (const event of source) {
+        events.push(event.kind)
+        if (events.filter((kind) => kind !== 'synced').length >= 1) break
+      }
+    })()
+    await new Promise((resolve) => setTimeout(resolve, 1_000))
+    await http.json({
+      method: 'POST',
+      path: probePath,
+      body: {
+        apiVersion: `${GROUP}/v1`,
+        kind: 'Probe',
+        metadata: { name: 'watched-probe' },
+        spec: { operatingMode: 'Running' }
+      }
+    })
+    await drain
+    controller.abort()
+    expect(events[0]).toBe('synced')
+    expect(events.slice(1)).toContain('added')
+  }, 120_000)
+
+  it('rejects a token minted for a different audience', async () => {
+    // The handshake's whole basis: an audience-restricted token must not authenticate here.
+    const api = new SandboxApi(http, 'default')
+    const scoped = kubectl(['create', 'token', 'default', '--audience=some-other-audience', '--duration=600s']).trim()
+    const wrongAudience = await api.reviewToken(scoped, ['ac-daemon-callback'])
+    expect(wrongAudience.authenticated).toBe(false)
+    const rightAudience = await api.reviewToken(
+      kubectl(['create', 'token', 'default', '--audience=ac-daemon-callback', '--duration=600s']).trim(),
+      ['ac-daemon-callback']
+    )
+    expect(rightAudience.authenticated).toBe(true)
+    expect(rightAudience.username).toContain('system:serviceaccount:default:default')
+  }, 120_000)
+})


### PR DESCRIPTION
Closes #816. Part of #804 — the driver the earlier pieces were built for.

An agent's ACP runtime runs in its own Sandbox pod, and `AcpHost` still sees a byte-stream
pair.

## Lifecycle stays local

Claim creation, wake, suspend and teardown are all decided here, so a control-plane outage
cannot stop an existing agent from starting or stopping its runtime.

- Claims are named from the agent id, so a retry after a partial reconcile converges.
- They carry **only** the pool reference and the org/agent labels. A claim with `env` or
  `volumeClaimTemplates` bypasses warm-pool adoption, and pool pods are stamped before any
  user exists — so identity travels over the shim handshake instead.
- The Sandbox UID comes from the object's own `metadata.uid`; the claim status carries only
  a name.

Mode writes re-read and re-decide when a guarded write is rejected, with a **bounded**
budget. The rejection deliberately does not claim what the intervening state was, so looking
again is the only correct response — and a permanently invalid patch must not spin forever.

A pending `drain-requested` annotation holds the instance down: one arriving message would
otherwise revive the image a rollout is replacing. Generations increment per launch, so a
departed incarnation cannot act.

The ACP stream is its own channel rather than a reuse of `exec` — open, chunks, close.
ACP is already a complete protocol, and reinterpreting it inside the channel would add a
second place for it to go wrong.

## The part I want reviewed most: this is measured, not assumed

`test/k8s-real-apiserver.test.ts` runs the client against a **real k3s API server**, under
the RBAC the design specifies (namespaced verbs plus cluster-scoped TokenReview, not
cluster-admin). It settles the two questions #823 had to ship on faith:

- **A failed JSON Patch `test` returns 422 Invalid, never 409.** The original `isConflict`
  would not have fired in the race it was written to guard. This is now proven rather than
  argued.
- **A stale `metadata.resourceVersion` precondition does return a structured 409.** That is
  the alternative I declined in #823 for lack of evidence. It is recorded in the client but
  still not adopted, for a reason the measurement does not change: it guards the *whole*
  object, so any unrelated status write by the vendor controller would conflict, while the
  field-scoped `test` only conflicts when the mode actually moved.

It also confirms an audience-restricted token is refused for the wrong audience and accepted
for the right one — the entire basis of the handshake in #826.

Gated behind `AC_K8S_E2E=1` (it needs Docker and a k3s image) and skips cleanly otherwise.

It exists because every defect in this workstream's review history reached me the same way:
a fake I wrote from the same assumption as the code, agreeing with it. A fake cannot tell me
what Kubernetes returns.

## Tests

80 tests across the driver, client, handshake and channel suites, plus the 5 gated
API-server tests (verified passing against k3s v1.31.2 locally). Typecheck, eslint, prettier
clean.

## Not in this PR

`ensureHost` selection between local and cluster drivers, and the workspace `exec` surface
(#815). This PR adds the driver; wiring the daemon's spawn path to choose it is the next
step and belongs where the workspace surface lands, since a `git-repo` agent needs both at
once.
