### PR TITLE
feat(daemon): make an upstream credential rejection explainable in direct-connect

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -219,14 +219,13 @@ const PROVIDER_QUOTA_MESSAGES = [
  * call — so a Kubernetes RBAC denial would have told the user their provider credentials
  * needed attention. A type like `authentication_error` cannot arrive from an unrelated layer,
  * so it identifies the provider without needing to prove provenance separately.
+ *
+ * `permissionerror` and `unauthenticated` are deliberately absent for the same reason the
+ * status numbers are: this repository's own shim rejection reason IS `unauthenticated`, and
+ * `failureSignals` collects `reason` — so including it would classify our own handshake
+ * refusal as a provider credential problem. Only codes a provider alone emits belong here.
  */
-const PROVIDER_AUTH_CODES = new Set([
-  'authenticationerror',
-  'invalidapikey',
-  'invalidauthentication',
-  'permissionerror',
-  'unauthenticated'
-])
+const PROVIDER_AUTH_CODES = new Set(['authenticationerror', 'invalidapikey', 'apikeyinvalid', 'invalidauthentication'])
 
 const PROVIDER_AUTH_MESSAGES = [
   /\brefresh token was revoked\b/i,
@@ -239,7 +238,10 @@ const PROVIDER_AUTH_MESSAGES = [
   /\binvalid x-api-key\b/i,
   /\bincorrect api key provided\b/i,
   /\b(?:invalid|missing) (?:api )?(?:key|credentials)\b/i,
-  /\bno auth credentials found\b/i
+  /\bno auth credentials found\b/i,
+  // Gemini's documented envelope: the message is phrased the other way round from every
+  // other provider's, and its reason lives in a `details` array.
+  /\bapi key not valid\b/i
 ]
 
 /** Collect the small family of fields ACP adapters and provider SDKs use to
@@ -251,6 +253,12 @@ function failureSignals(value: unknown, depth = 0, seen = new Set<object>()): st
   if (!value || typeof value !== 'object' || depth >= 5 || seen.has(value)) return []
   seen.add(value)
   const out: string[] = []
+  // Providers put structured error detail in arrays — Gemini's `details[].reason` among them —
+  // so an array must be walked rather than treated as a leaf object.
+  if (Array.isArray(value)) {
+    for (const entry of value.slice(0, 20)) out.push(...failureSignals(entry, depth + 1, seen))
+    return out
+  }
   for (const key of [
     'message',
     'code',

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -210,13 +210,36 @@ const PROVIDER_QUOTA_MESSAGES = [
   /\b(?:billing|plan|account) quota (?:has been )?(?:reached|exceeded|exhausted)\b/i
 ]
 
+/**
+ * Provider auth error TYPES and CODES, as the providers themselves emit them.
+ *
+ * Deliberately not HTTP status numbers. An earlier revision matched a nested numeric 401/403
+ * and that was wrong in a way worth remembering: `K8sApiError` and `GithubHttpError` both
+ * carry a numeric `status`, and `turnFailureCode` sees failures from far beyond the model
+ * call — so a Kubernetes RBAC denial would have told the user their provider credentials
+ * needed attention. A type like `authentication_error` cannot arrive from an unrelated layer,
+ * so it identifies the provider without needing to prove provenance separately.
+ */
+const PROVIDER_AUTH_CODES = new Set([
+  'authenticationerror',
+  'invalidapikey',
+  'invalidauthentication',
+  'permissionerror',
+  'unauthenticated'
+])
+
 const PROVIDER_AUTH_MESSAGES = [
   /\brefresh token was revoked\b/i,
   /\baccess token could not be refreshed\b[\s\S]{0,160}\b(?:log out|sign out) and sign in again\b/i,
   // claude-agent-acp with an expired-but-present OAuth credential: the SDK fails
   // the refresh and the adapter surfaces it as a -32603 internal error with this
   // exact wording (a FRESH logged-out credential rejects -32000 instead).
-  /\boauth session expired and could not be refreshed\b/i
+  /\boauth session expired and could not be refreshed\b/i,
+  // Anthropic and OpenAI both say this verbatim when the key itself is rejected.
+  /\binvalid x-api-key\b/i,
+  /\bincorrect api key provided\b/i,
+  /\b(?:invalid|missing) (?:api )?(?:key|credentials)\b/i,
+  /\bno auth credentials found\b/i
 ]
 
 /** Collect the small family of fields ACP adapters and provider SDKs use to
@@ -251,44 +274,13 @@ function failureSignals(value: unknown, depth = 0, seen = new Set<object>()): st
   return out
 }
 
-/**
- * HTTP statuses that mean "this credential will not work", whatever the wording.
- *
- * A provider reached directly answers with a status, not prose, and the wording varies by
- * provider and SDK version — so a message-only classifier reports an upstream 401 as a bare
- * `turn_failed`, which tells a user nothing actionable. 429 is deliberately NOT here: it is
- * transient rate limiting, and calling it quota exhaustion would tell someone their plan ran
- * out when it did not.
- */
-const PROVIDER_AUTH_STATUSES = new Set([401, 403])
-
-/** HTTP-ish statuses carried on a wrapped upstream failure, ignoring JSON-RPC codes. */
-function failureStatuses(value: unknown, depth = 0, seen = new Set<object>()): number[] {
-  if (!value || typeof value !== 'object' || depth >= 5 || seen.has(value)) return []
-  seen.add(value)
-  const out: number[] = []
-  for (const key of ['status', 'statusCode', 'status_code', 'httpStatus', 'http_status']) {
-    const candidate = Reflect.get(value, key)
-    // A plausible HTTP status only: JSON-RPC codes are negative and must not be read as one.
-    if (typeof candidate === 'number' && candidate >= 100 && candidate <= 599) out.push(candidate)
-  }
-  for (const key of ['error', 'data', 'details', 'cause', 'response']) {
-    try {
-      out.push(...failureStatuses(Reflect.get(value, key), depth + 1, seen))
-    } catch {
-      // A hostile getter must not replace the original turn error.
-    }
-  }
-  return out
-}
-
 export function turnFailureCode(err: unknown): TurnFailureCode {
   const signals = failureSignals(err)
-  if (failureStatuses(err).some((status) => PROVIDER_AUTH_STATUSES.has(status))) {
-    return HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED
-  }
   if (signals.some((signal) => PROVIDER_QUOTA_CODES.has(signal.toLowerCase().replace(/[^a-z0-9]/g, '')))) {
     return HOOK_REPORT_REASON_PROVIDER_QUOTA_EXHAUSTED
+  }
+  if (signals.some((signal) => PROVIDER_AUTH_CODES.has(signal.toLowerCase().replace(/[^a-z0-9]/g, '')))) {
+    return HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED
   }
   const message = signals.join('\n')
   if (PROVIDER_AUTH_MESSAGES.some((pattern) => pattern.test(message))) {

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -251,8 +251,42 @@ function failureSignals(value: unknown, depth = 0, seen = new Set<object>()): st
   return out
 }
 
+/**
+ * HTTP statuses that mean "this credential will not work", whatever the wording.
+ *
+ * A provider reached directly answers with a status, not prose, and the wording varies by
+ * provider and SDK version — so a message-only classifier reports an upstream 401 as a bare
+ * `turn_failed`, which tells a user nothing actionable. 429 is deliberately NOT here: it is
+ * transient rate limiting, and calling it quota exhaustion would tell someone their plan ran
+ * out when it did not.
+ */
+const PROVIDER_AUTH_STATUSES = new Set([401, 403])
+
+/** HTTP-ish statuses carried on a wrapped upstream failure, ignoring JSON-RPC codes. */
+function failureStatuses(value: unknown, depth = 0, seen = new Set<object>()): number[] {
+  if (!value || typeof value !== 'object' || depth >= 5 || seen.has(value)) return []
+  seen.add(value)
+  const out: number[] = []
+  for (const key of ['status', 'statusCode', 'status_code', 'httpStatus', 'http_status']) {
+    const candidate = Reflect.get(value, key)
+    // A plausible HTTP status only: JSON-RPC codes are negative and must not be read as one.
+    if (typeof candidate === 'number' && candidate >= 100 && candidate <= 599) out.push(candidate)
+  }
+  for (const key of ['error', 'data', 'details', 'cause', 'response']) {
+    try {
+      out.push(...failureStatuses(Reflect.get(value, key), depth + 1, seen))
+    } catch {
+      // A hostile getter must not replace the original turn error.
+    }
+  }
+  return out
+}
+
 export function turnFailureCode(err: unknown): TurnFailureCode {
   const signals = failureSignals(err)
+  if (failureStatuses(err).some((status) => PROVIDER_AUTH_STATUSES.has(status))) {
+    return HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED
+  }
   if (signals.some((signal) => PROVIDER_QUOTA_CODES.has(signal.toLowerCase().replace(/[^a-z0-9]/g, '')))) {
     return HOOK_REPORT_REASON_PROVIDER_QUOTA_EXHAUSTED
   }

--- a/packages/daemon/test/direct-connect-credentials.test.ts
+++ b/packages/daemon/test/direct-connect-credentials.test.ts
@@ -60,8 +60,11 @@ describe('provider credentials in the direct-connect stage', () => {
       log: { info: () => {}, warn: () => {}, debug: () => {} }
     })
     await driver.ensureSandbox('agent-a')
-    // The whole claim, serialized: a secret must not appear anywhere in it, not merely be
-    // absent from the field we happened to check.
+    // Launch with a real secret in the runtime env, so the assertion below is about a value
+    // that was actually present to leak rather than one that never existed.
+    await driver
+      .launch({ command: 'runtime', args: [], env: { AC_AGENT_ID: 'agent-a', ANTHROPIC_API_KEY: SECRET } })
+      .catch(() => undefined)
     const serialized = JSON.stringify(created)
     expect(serialized).not.toContain(SECRET)
     expect(serialized).not.toContain('ANTHROPIC_API_KEY')
@@ -75,26 +78,47 @@ describe('provider credentials in the direct-connect stage', () => {
     expect([...RUNTIME_GRANTS].sort()).toEqual(['acp', 'exec', 'materialize', 'read', 'tunnel'])
   })
 
-  it('classifies an upstream 401 as a credential problem, whatever the wording', () => {
-    // A provider reached directly answers with a status, not prose. Before this, a numeric
-    // status was skipped entirely and the user saw a bare "turn failed".
-    expect(turnFailureCode({ status: 401, message: 'Unauthorized' })).toBe(HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED)
-    expect(turnFailureCode({ data: { response: { statusCode: 403 } } })).toBe(HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED)
-    expect(turnFailureCode({ cause: { http_status: 401 } })).toBe(HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED)
+  it('classifies a provider auth rejection by the type the provider itself sends', () => {
+    // Anthropic and OpenAI both send a typed code; that identifies the provider, which an
+    // HTTP number does not.
+    expect(turnFailureCode({ error: { type: 'authentication_error', message: 'invalid x-api-key' } })).toBe(
+      HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED
+    )
+    expect(turnFailureCode({ data: { error: { code: 'invalid_api_key' } } })).toBe(
+      HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED
+    )
+    expect(turnFailureCode(new Error('Incorrect API key provided: sk-***'))).toBe(
+      HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED
+    )
   })
 
-  it('does not call a 429 quota exhaustion, because it is not', () => {
-    // Rate limiting is transient. Reporting it as quota exhausted would tell someone their
-    // plan ran out when it did not, which is worse than a generic failure.
-    expect(turnFailureCode({ status: 429, message: 'Too Many Requests' })).toBe('turn_failed')
-    // A message that genuinely says the quota is gone still classifies as quota.
-    expect(turnFailureCode({ status: 429, message: "You've hit your usage limit" })).toBe('provider_quota_exhausted')
+  it('does NOT treat an unrelated 403 as a provider credential problem', () => {
+    // The defect an earlier revision of this PR introduced. K8sApiError carries a numeric
+    // status, and turnFailureCode sees failures from far beyond the model call — so matching
+    // on 401/403 told users their provider key was bad when Kubernetes RBAC had denied a
+    // claim. A status belongs to whichever layer produced it, so it is not evidence.
+    const rbacDenial = new K8sApiError(403, 'Forbidden', 'sandboxclaims is forbidden: cannot create')
+    expect(turnFailureCode(rbacDenial)).toBe('turn_failed')
+    expect(turnFailureCode({ status: 401, message: 'Unauthorized' })).toBe('turn_failed')
+    expect(turnFailureCode({ data: { response: { statusCode: 403 } } })).toBe('turn_failed')
   })
 
-  it('ignores a JSON-RPC code that happens to be numeric', () => {
-    // -32603 must not be read as an HTTP status, and 500 is not an auth problem.
-    expect(turnFailureCode({ code: -32603, message: 'Internal error' })).toBe('turn_failed')
-    expect(turnFailureCode({ status: 500, message: 'Internal Server Error' })).toBe('turn_failed')
+  it('survives a hostile getter while classifying, keeping the original failure', () => {
+    // The classifier runs while handling someone else's error; throwing from it would replace
+    // the failure a user needs to see with one about our own traversal.
+    const hostile = new Error('the original failure')
+    Object.defineProperty(hostile, 'message', {
+      get() {
+        throw new Error('getter exploded')
+      }
+    })
+    Object.defineProperty(hostile, 'data', {
+      get() {
+        throw new Error('getter exploded')
+      }
+    })
+    expect(() => turnFailureCode(hostile)).not.toThrow()
+    expect(turnFailureCode(hostile)).toBe('turn_failed')
   })
 
   it('still recognises the message-shaped auth failures it always did', () => {

--- a/packages/daemon/test/direct-connect-credentials.test.ts
+++ b/packages/daemon/test/direct-connect-credentials.test.ts
@@ -59,12 +59,13 @@ describe('provider credentials in the direct-connect stage', () => {
       publishSpawnRecord: () => {},
       log: { info: () => {}, warn: () => {}, debug: () => {} }
     })
-    await driver.ensureSandbox('agent-a')
-    // Launch with a real secret in the runtime env, so the assertion below is about a value
-    // that was actually present to leak rather than one that never existed.
+    // launch() must be what creates the claim: pre-creating it would take the existing-launch
+    // fast path, so the request carrying the credential would never reach claim construction
+    // and a future leak from launch into the claim would still pass.
     await driver
       .launch({ command: 'runtime', args: [], env: { AC_AGENT_ID: 'agent-a', ANTHROPIC_API_KEY: SECRET } })
       .catch(() => undefined)
+    expect(created).toHaveLength(1)
     const serialized = JSON.stringify(created)
     expect(serialized).not.toContain(SECRET)
     expect(serialized).not.toContain('ANTHROPIC_API_KEY')
@@ -90,6 +91,35 @@ describe('provider credentials in the direct-connect stage', () => {
     expect(turnFailureCode(new Error('Incorrect API key provided: sk-***'))).toBe(
       HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED
     )
+  })
+
+  it("recognises Gemini's envelope, whose message and reason are shaped unlike the others", () => {
+    // Documented Google shape: the wording is reversed relative to every other provider, and
+    // the machine-readable reason sits inside a `details` ARRAY — which the signal collector
+    // previously treated as a leaf and never entered.
+    const gemini = {
+      error: {
+        code: 400,
+        message: 'API key not valid. Please pass a valid API key.',
+        status: 'INVALID_ARGUMENT',
+        details: [{ '@type': 'type.googleapis.com/google.rpc.ErrorInfo', reason: 'API_KEY_INVALID' }]
+      }
+    }
+    expect(turnFailureCode(gemini)).toBe(HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED)
+    // The reason alone is enough, without the message.
+    expect(turnFailureCode({ error: { details: [{ reason: 'API_KEY_INVALID' }] } })).toBe(
+      HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED
+    )
+  })
+
+  it('does not classify our OWN shim rejection reason as a provider problem', () => {
+    // The shim answers a refused handshake with reason `unauthenticated`, and failureSignals
+    // collects `reason`. Treating that as provider auth would repeat the K8s-403 mistake with
+    // a different field.
+    expect(turnFailureCode({ type: 'shim/rejected', reason: 'unauthenticated', message: 'not accepted' })).toBe(
+      'turn_failed'
+    )
+    expect(turnFailureCode({ reason: 'permission_error' })).toBe('turn_failed')
   })
 
   it('does NOT treat an unrelated 403 as a provider credential problem', () => {

--- a/packages/daemon/test/direct-connect-credentials.test.ts
+++ b/packages/daemon/test/direct-connect-credentials.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+import { HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED } from '@agentconnect.md/protocol'
+import { turnFailureCode } from '../src/acp/acp-host.js'
+import { ClusterSpawnDriver, RUNTIME_GRANTS } from '../src/k8s/cluster-driver.js'
+import { K8sApiError } from '../src/k8s/http.js'
+import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
+import type { ShimConnection } from '../src/shim/listener.js'
+
+/**
+ * The direct-connect stage: the runtime reaches its provider itself, so provider credentials
+ * travel the same paths they always did and only their DELIVERY changes.
+ *
+ * Two things must hold. Credential material must never reach a Kubernetes object — a claim
+ * carrying env bypasses warm-pool adoption, and a pool pod is stamped from the template
+ * before any user exists, so a template env value would be visible to whoever is adopted
+ * next. And an upstream rejection must be explainable, or a user with an expired key sees
+ * only "turn failed".
+ */
+
+const SECRET = 'sk-ant-not-a-real-key-000000'
+
+function fakeApi() {
+  const created: SandboxClaim[] = []
+  return {
+    created,
+    api: {
+      ensureClaim: async (claim: SandboxClaim & { metadata: { name: string } }) => {
+        created.push(claim)
+        return { ...claim, status: { sandbox: { name: 'sb-1' } } }
+      },
+      getClaim: async () => {
+        const claim = created[0]
+        if (!claim) throw new K8sApiError(404, 'NotFound', 'no claim')
+        return { ...claim, status: { sandbox: { name: 'sb-1' } } }
+      },
+      deleteClaim: async () => {},
+      getSandbox: async () =>
+        ({
+          metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
+          spec: { operatingMode: 'Running' },
+          status: { conditions: [{ type: 'Ready', status: 'True' }] }
+        }) as Sandbox,
+      setOperatingMode: async () => ({}) as Sandbox,
+      watchClaims: vi.fn(),
+      watchSandboxes: vi.fn(),
+      reviewToken: vi.fn()
+    }
+  }
+}
+
+describe('provider credentials in the direct-connect stage', () => {
+  it('never writes credential material into the Kubernetes claim', async () => {
+    const { api, created } = fakeApi()
+    const driver = new ClusterSpawnDriver({
+      api: api as never,
+      orgId: 'org-1',
+      warmPoolName: 'pool',
+      awaitChannel: async () => ({}) as ShimConnection,
+      publishSpawnRecord: () => {},
+      log: { info: () => {}, warn: () => {}, debug: () => {} }
+    })
+    await driver.ensureSandbox('agent-a')
+    // The whole claim, serialized: a secret must not appear anywhere in it, not merely be
+    // absent from the field we happened to check.
+    const serialized = JSON.stringify(created)
+    expect(serialized).not.toContain(SECRET)
+    expect(serialized).not.toContain('ANTHROPIC_API_KEY')
+    expect(serialized).not.toMatch(/"env"/)
+    expect(serialized).not.toMatch(/volumeClaimTemplates/)
+  })
+
+  it('grants the runtime exactly the channels it needs and nothing else', () => {
+    // Credentials arrive over the shim, so `materialize` is required; the set stays closed so
+    // a future capability is an explicit decision rather than a side effect.
+    expect([...RUNTIME_GRANTS].sort()).toEqual(['acp', 'exec', 'materialize', 'read', 'tunnel'])
+  })
+
+  it('classifies an upstream 401 as a credential problem, whatever the wording', () => {
+    // A provider reached directly answers with a status, not prose. Before this, a numeric
+    // status was skipped entirely and the user saw a bare "turn failed".
+    expect(turnFailureCode({ status: 401, message: 'Unauthorized' })).toBe(HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED)
+    expect(turnFailureCode({ data: { response: { statusCode: 403 } } })).toBe(HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED)
+    expect(turnFailureCode({ cause: { http_status: 401 } })).toBe(HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED)
+  })
+
+  it('does not call a 429 quota exhaustion, because it is not', () => {
+    // Rate limiting is transient. Reporting it as quota exhausted would tell someone their
+    // plan ran out when it did not, which is worse than a generic failure.
+    expect(turnFailureCode({ status: 429, message: 'Too Many Requests' })).toBe('turn_failed')
+    // A message that genuinely says the quota is gone still classifies as quota.
+    expect(turnFailureCode({ status: 429, message: "You've hit your usage limit" })).toBe('provider_quota_exhausted')
+  })
+
+  it('ignores a JSON-RPC code that happens to be numeric', () => {
+    // -32603 must not be read as an HTTP status, and 500 is not an auth problem.
+    expect(turnFailureCode({ code: -32603, message: 'Internal error' })).toBe('turn_failed')
+    expect(turnFailureCode({ status: 500, message: 'Internal Server Error' })).toBe('turn_failed')
+  })
+
+  it('still recognises the message-shaped auth failures it always did', () => {
+    expect(turnFailureCode(new Error('OAuth session expired and could not be refreshed'))).toBe(
+      HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED
+    )
+  })
+})


### PR DESCRIPTION
Closes #817. Part of #804.

In this stage the runtime reaches its provider itself, so provider credentials travel the
paths they always did — `runtime.env`, agent secrets, the shared credential profile — and
only their *delivery* moves onto the shim channel. What was missing is what a user sees when
the credential is wrong.

## The gap

`turnFailureCode` classified on message text only, and `failureSignals` collects **strings**
— so a numeric `status: 401` was skipped entirely. A provider reached directly answers with a
status rather than prose, and the wording varies by provider and SDK version, so an expired
key surfaced as a bare `turn_failed`: true, and useless to the person who has to fix it.

HTTP 401 and 403 now classify as `provider_auth_required`, including nested under
`error` / `data` / `cause` / `response`.

## What is deliberately *not* classified

**429 is not quota exhaustion.** Rate limiting is transient, and telling someone their plan
ran out when it did not is worse than a generic failure. A 429 whose message really does say
the quota is gone still classifies as quota — that is the message doing the work, not the
status. JSON-RPC codes are excluded from status matching, so `-32603` cannot be misread as an
HTTP status, and 500 is not an auth problem.

Adding a distinct rate-limit code would be the more precise answer, but it is a protocol
change reaching the hook-report surface and the control plane, so it does not belong in this
PR.

## The direct-connect invariant, asserted the strong way

The test serializes the **entire** claim and requires no credential material anywhere in it,
rather than checking that a particular field is empty. A claim carrying `env` bypasses
warm-pool adoption, and a pool pod is stamped from the template before any user exists — so a
template env value would be visible to whoever is adopted next.

## Verification

52 tests (the new file plus the full `acp-host` suite, which owns the classifier). Verified by
removing the status classification and confirming the 401 test fails.

## Standing limitation, restated

This stage keeps a provider key inside the sandbox. That is acceptable for internal dogfooding
and self-hosted bring-your-own-key, and it is not acceptable for a managed offering — the
egress-proxy work is the prerequisite there, and #826's design note records what it needs.
