### PR TITLE
feat(daemon): freeze the workspace git contract and implement both runners

### DIFF
--- a/packages/daemon/src/shim/git-exec.ts
+++ b/packages/daemon/src/shim/git-exec.ts
@@ -14,9 +14,11 @@ export const GitExecPayloadSchema = z.object({
   tool: z.literal('git'),
   cwd: z.string().min(1).optional(),
   args: z.array(z.string()).min(1).max(64),
-  /** Extra environment for THIS invocation only — the credential-helper pointers among it.
-   *  Scoped to the request rather than set on the sandbox, so a runtime cannot read it back
-   *  out of its own process environment later. */
+  /** The COMPLETE environment for this invocation, replacing rather than extending whatever
+   *  the sandbox has. Callers build it by sanitizing (stripping host GIT_CONFIG_*, protocol
+   *  allowances and so on), so merging would defeat that; the shim must apply it as given.
+   *  Scoped to the request, so a runtime cannot read the credential pointers back out of its
+   *  own process environment afterwards. */
   env: z.record(z.string(), z.string()).optional()
 })
 export type GitExecPayload = z.infer<typeof GitExecPayloadSchema>
@@ -28,46 +30,67 @@ export const GitExecResultSchema = z.object({
 })
 export type GitExecResult = z.infer<typeof GitExecResultSchema>
 
-/** Parse a `git status --porcelain=v2 --branch` payload into the fields the daemon reads. */
+/**
+ * Parse `git status --porcelain=v2 --branch -z` into the fields the daemon reads.
+ *
+ * The three changed-entry record types have DIFFERENT field counts before the path, and an
+ * earlier version of this treated them alike: a staged rename came back with its similarity
+ * score and original path glued into `path`, and an unmerged record was dropped entirely — so
+ * a conflicted tree looked clean to any caller deriving cleanliness from `files.length`.
+ *
+ * `-z` rather than newlines because paths are NUL-terminated verbatim; the default format
+ * C-quotes unusual filenames, which would diverge from what the local runner reports.
+ */
 export function parsePorcelainV2(stdout: string): GitStatusSummary {
   const summary: GitStatusSummary = { current: null, tracking: null, ahead: 0, behind: 0, files: [] }
-  for (const line of stdout.split('\n')) {
-    if (!line) continue
-    if (line.startsWith('# branch.head ')) {
-      const head = line.slice('# branch.head '.length).trim()
+  const entries = stdout.split('\0')
+  const push = (path: string, xy: string): void => {
+    summary.files.push({
+      path,
+      index: xy[0] === '.' ? ' ' : (xy[0] ?? ' '),
+      working_dir: xy[1] === '.' ? ' ' : (xy[1] ?? ' ')
+    })
+  }
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index]
+    if (!entry) continue
+    if (entry.startsWith('# branch.head ')) {
+      const head = entry.slice('# branch.head '.length).trim()
       // A detached HEAD reports `(detached)`, which is not a branch name.
       summary.current = head === '(detached)' ? null : head
       continue
     }
-    if (line.startsWith('# branch.upstream ')) {
-      summary.tracking = line.slice('# branch.upstream '.length).trim()
+    if (entry.startsWith('# branch.upstream ')) {
+      summary.tracking = entry.slice('# branch.upstream '.length).trim()
       continue
     }
-    if (line.startsWith('# branch.ab ')) {
-      const [ahead, behind] = line.slice('# branch.ab '.length).trim().split(' ')
+    if (entry.startsWith('# branch.ab ')) {
+      const [ahead, behind] = entry.slice('# branch.ab '.length).trim().split(' ')
       summary.ahead = Math.abs(Number(ahead ?? 0)) || 0
       summary.behind = Math.abs(Number(behind ?? 0)) || 0
       continue
     }
-    if (line.startsWith('1 ') || line.startsWith('2 ')) {
-      // `1 XY ... <path>` (ordinary) / `2 XY ... <path><sep><origPath>` (renamed).
-      const fields = line.split(' ')
-      const xy = fields[1] ?? '..'
-      const path =
-        line
-          .slice(line.indexOf(' ', line.indexOf(' ') + 1))
-          .trim()
-          .split('\t')[0] ?? ''
-      summary.files.push({
-        path: fields.slice(8).join(' ') || path,
-        index: xy[0] === '.' ? ' ' : (xy[0] ?? ' '),
-        working_dir: xy[1] === '.' ? ' ' : (xy[1] ?? ' ')
-      })
+    if (entry.startsWith('# ')) continue
+    const fields = entry.split(' ')
+    // `1 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <path>` — eight fields, then the path.
+    if (entry.startsWith('1 ')) {
+      push(fields.slice(8).join(' '), fields[1] ?? '..')
       continue
     }
-    if (line.startsWith('? ')) {
-      summary.files.push({ path: line.slice(2), index: '?', working_dir: '?' })
+    // `2 <XY> ... <X><score> <path>` — NINE fields (the extra is the rename score), and with
+    // -z the ORIGINAL path follows as its own entry, which must be consumed, not parsed.
+    if (entry.startsWith('2 ')) {
+      push(fields.slice(9).join(' '), fields[1] ?? '..')
+      index += 1
+      continue
     }
+    // `u <XY> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>` — ten fields. Dropping these is
+    // what made a conflicted workspace look clean.
+    if (entry.startsWith('u ')) {
+      push(fields.slice(10).join(' '), fields[1] ?? 'UU')
+      continue
+    }
+    if (entry.startsWith('? ')) push(entry.slice(2), '??')
   }
   return summary
 }
@@ -118,8 +141,9 @@ export class ShimGitRunner implements GitRunner {
 
   async status(): Promise<GitStatusSummary> {
     // porcelain=v2 rather than simple-git's own parse: the format is documented and stable,
-    // which is what makes parsing it on this side of the channel safe.
-    const result = await this.exec(['status', '--porcelain=v2', '--branch'])
+    // which is what makes parsing it on this side of the channel safe. -z keeps unusual
+    // filenames verbatim instead of C-quoted.
+    const result = await this.exec(['status', '--porcelain=v2', '--branch', '-z'])
     return parsePorcelainV2(result.stdout)
   }
 

--- a/packages/daemon/src/shim/git-exec.ts
+++ b/packages/daemon/src/shim/git-exec.ts
@@ -123,7 +123,11 @@ export class ShimGitRunner implements GitRunner {
   ) {}
 
   withEnv(env: Record<string, string>): GitRunner {
-    return new ShimGitRunner(this.requester, this.cwd, { ...this.env, ...env })
+    // Carry `env` itself, NOT merged over any previous one. simple-git's second .env() call
+    // replaces the first, so merging here would let a variable the new sanitized environment
+    // intentionally omitted survive on the remote runner alone — a divergence in exactly the
+    // direction that matters, since those omissions are the sanitization.
+    return new ShimGitRunner(this.requester, this.cwd, { ...env })
   }
 
   async raw(args: string[]): Promise<string> {
@@ -143,7 +147,10 @@ export class ShimGitRunner implements GitRunner {
     // porcelain=v2 rather than simple-git's own parse: the format is documented and stable,
     // which is what makes parsing it on this side of the channel safe. -z keeps unusual
     // filenames verbatim instead of C-quoted.
-    const result = await this.exec(['status', '--porcelain=v2', '--branch', '-z'])
+    // `-u` matches what the pinned simple-git runs (`status --porcelain -b -u --null`). Without
+    // it git collapses an untracked nested file to `nested/`, while the local runner reports
+    // `nested/file.txt` — the file list would differ by runner for the same tree.
+    const result = await this.exec(['status', '--porcelain=v2', '--branch', '-u', '-z'])
     return parsePorcelainV2(result.stdout)
   }
 
@@ -163,7 +170,9 @@ export class ShimGitRunner implements GitRunner {
       tool: 'git',
       args,
       ...(this.cwd ? { cwd: this.cwd } : {}),
-      ...(this.env && Object.keys(this.env).length > 0 ? { env: this.env } : {})
+      // Present whenever an environment was set, including an explicitly EMPTY one: "run with
+      // nothing" is a meaningful instruction and must not be indistinguishable from "unset".
+      ...(this.env !== undefined ? { env: this.env } : {})
     }
     const raw = await this.requester.request('exec', payload)
     const result = GitExecResultSchema.parse(raw)

--- a/packages/daemon/src/shim/git-exec.ts
+++ b/packages/daemon/src/shim/git-exec.ts
@@ -1,0 +1,149 @@
+import { z } from 'zod'
+import type { GitRunner, GitStatusSummary } from '../workspace/git-runner.js'
+import type { ShimRequester } from './channels.js'
+
+/**
+ * The `exec` payload for a git invocation inside the sandbox.
+ *
+ * argv only, never a composed shell string: the arguments are assembled from workspace
+ * configuration that a repository can influence, and a shell would turn that into an
+ * injection surface. `cwd` is validated on the shim side too — a daemon-side check says
+ * nothing about the filesystem the shim is standing on.
+ */
+export const GitExecPayloadSchema = z.object({
+  tool: z.literal('git'),
+  cwd: z.string().min(1).optional(),
+  args: z.array(z.string()).min(1).max(64),
+  /** Extra environment for THIS invocation only — the credential-helper pointers among it.
+   *  Scoped to the request rather than set on the sandbox, so a runtime cannot read it back
+   *  out of its own process environment later. */
+  env: z.record(z.string(), z.string()).optional()
+})
+export type GitExecPayload = z.infer<typeof GitExecPayloadSchema>
+
+export const GitExecResultSchema = z.object({
+  code: z.number().int(),
+  stdout: z.string(),
+  stderr: z.string()
+})
+export type GitExecResult = z.infer<typeof GitExecResultSchema>
+
+/** Parse a `git status --porcelain=v2 --branch` payload into the fields the daemon reads. */
+export function parsePorcelainV2(stdout: string): GitStatusSummary {
+  const summary: GitStatusSummary = { current: null, tracking: null, ahead: 0, behind: 0, files: [] }
+  for (const line of stdout.split('\n')) {
+    if (!line) continue
+    if (line.startsWith('# branch.head ')) {
+      const head = line.slice('# branch.head '.length).trim()
+      // A detached HEAD reports `(detached)`, which is not a branch name.
+      summary.current = head === '(detached)' ? null : head
+      continue
+    }
+    if (line.startsWith('# branch.upstream ')) {
+      summary.tracking = line.slice('# branch.upstream '.length).trim()
+      continue
+    }
+    if (line.startsWith('# branch.ab ')) {
+      const [ahead, behind] = line.slice('# branch.ab '.length).trim().split(' ')
+      summary.ahead = Math.abs(Number(ahead ?? 0)) || 0
+      summary.behind = Math.abs(Number(behind ?? 0)) || 0
+      continue
+    }
+    if (line.startsWith('1 ') || line.startsWith('2 ')) {
+      // `1 XY ... <path>` (ordinary) / `2 XY ... <path><sep><origPath>` (renamed).
+      const fields = line.split(' ')
+      const xy = fields[1] ?? '..'
+      const path =
+        line
+          .slice(line.indexOf(' ', line.indexOf(' ') + 1))
+          .trim()
+          .split('\t')[0] ?? ''
+      summary.files.push({
+        path: fields.slice(8).join(' ') || path,
+        index: xy[0] === '.' ? ' ' : (xy[0] ?? ' '),
+        working_dir: xy[1] === '.' ? ' ' : (xy[1] ?? ' ')
+      })
+      continue
+    }
+    if (line.startsWith('? ')) {
+      summary.files.push({ path: line.slice(2), index: '?', working_dir: '?' })
+    }
+  }
+  return summary
+}
+
+/** A git failure that carries what the sandbox reported, so a caller can act on it. */
+export class GitExecError extends Error {
+  constructor(
+    readonly code: number,
+    readonly stdout: string,
+    readonly stderr: string,
+    args: string[]
+  ) {
+    super(`git ${args[0] ?? ''} failed with code ${code}: ${stderr.trim() || stdout.trim()}`)
+    this.name = 'GitExecError'
+  }
+}
+
+/**
+ * Runs the daemon's git operations inside the sandbox over the shim's exec channel.
+ *
+ * The orchestration — which clone, which worktree, which reset — stays in the daemon. Moving
+ * that logic into the shim would look like reuse and would actually relocate the trust
+ * boundary, since the shim is the half-trusted side.
+ */
+export class ShimGitRunner implements GitRunner {
+  constructor(
+    private readonly requester: ShimRequester,
+    private readonly cwd?: string,
+    private readonly env?: Record<string, string>
+  ) {}
+
+  withEnv(env: Record<string, string>): GitRunner {
+    return new ShimGitRunner(this.requester, this.cwd, { ...this.env, ...env })
+  }
+
+  async raw(args: string[]): Promise<string> {
+    const result = await this.exec(args)
+    return result.stdout
+  }
+
+  async clone(repo: string, target: string, options: string[] = []): Promise<void> {
+    await this.exec(['clone', ...options, repo, target])
+  }
+
+  async pull(remote: string, branch: string, options: string[] = []): Promise<void> {
+    await this.exec(['pull', ...options, remote, branch])
+  }
+
+  async status(): Promise<GitStatusSummary> {
+    // porcelain=v2 rather than simple-git's own parse: the format is documented and stable,
+    // which is what makes parsing it on this side of the channel safe.
+    const result = await this.exec(['status', '--porcelain=v2', '--branch'])
+    return parsePorcelainV2(result.stdout)
+  }
+
+  async log(options: { maxCount: number }): Promise<Array<{ hash: string; message: string }>> {
+    const result = await this.exec(['log', `--max-count=${options.maxCount}`, '--format=%H%x1f%s'])
+    return result.stdout
+      .split('\n')
+      .filter((line) => line.includes(''))
+      .map((line) => {
+        const [hash, message] = line.split('')
+        return { hash: hash ?? '', message: message ?? '' }
+      })
+  }
+
+  private async exec(args: string[]): Promise<GitExecResult> {
+    const payload: GitExecPayload = {
+      tool: 'git',
+      args,
+      ...(this.cwd ? { cwd: this.cwd } : {}),
+      ...(this.env && Object.keys(this.env).length > 0 ? { env: this.env } : {})
+    }
+    const raw = await this.requester.request('exec', payload)
+    const result = GitExecResultSchema.parse(raw)
+    if (result.code !== 0) throw new GitExecError(result.code, result.stdout, result.stderr, args)
+    return result
+  }
+}

--- a/packages/daemon/src/workspace/git-runner.ts
+++ b/packages/daemon/src/workspace/git-runner.ts
@@ -14,13 +14,16 @@ import type { SimpleGit } from 'simple-git'
  */
 export interface GitRunner {
   /**
-   * A runner carrying extra environment for its invocations.
+   * A runner whose invocations use `env` as their COMPLETE environment, replacing rather than
+   * extending the ambient one.
    *
-   * Every existing call site threads env per invocation — the credential-helper pointers, the
-   * safe-directory and hooks overrides — so the seam has to model it or the migration cannot
-   * preserve behaviour. It matters more remotely than locally: this env is how the runtime's
-   * git reaches the daemon's credential helper, so it crosses the channel with the request and
-   * belongs to that request alone rather than to the sandbox at large.
+   * Every existing call site threads env per invocation, and replacement is the point: callers
+   * build it by sanitizing (`workspaceGitLocalEnv` strips host `GIT_CONFIG_*`, clears protocol
+   * allowances, injects config pairs), so merging would quietly undo that sanitization. A
+   * caller therefore supplies a whole environment, including identity, not a few overrides.
+   *
+   * Remotely the environment travels with the request rather than being set on the sandbox, so
+   * a runtime cannot read the credential-helper pointers back out of its own env afterwards.
    */
   withEnv(env: Record<string, string>): GitRunner
   /** Run a git subcommand with argv, never a composed shell string. */

--- a/packages/daemon/src/workspace/git-runner.ts
+++ b/packages/daemon/src/workspace/git-runner.ts
@@ -1,0 +1,93 @@
+import type { SimpleGit } from 'simple-git'
+
+/**
+ * The git operations the daemon actually performs on a workspace — a frozen inventory, not a
+ * general-purpose git wrapper.
+ *
+ * It exists because a cluster-backed agent's workspace lives on the sandbox pod's volume, so
+ * the daemon cannot reach it: the orchestration logic stays here and only the *execution*
+ * moves. Deriving the interface from what the code already calls (rather than from what git
+ * can do) is what keeps that move mechanical — the remote side has a closed list to
+ * implement, and re-creating simple-git's surface across a channel is explicitly not the job.
+ *
+ * Adding a member is a deliberate act: it widens what a half-trusted sandbox will execute.
+ */
+export interface GitRunner {
+  /**
+   * A runner carrying extra environment for its invocations.
+   *
+   * Every existing call site threads env per invocation — the credential-helper pointers, the
+   * safe-directory and hooks overrides — so the seam has to model it or the migration cannot
+   * preserve behaviour. It matters more remotely than locally: this env is how the runtime's
+   * git reaches the daemon's credential helper, so it crosses the channel with the request and
+   * belongs to that request alone rather than to the sandbox at large.
+   */
+  withEnv(env: Record<string, string>): GitRunner
+  /** Run a git subcommand with argv, never a composed shell string. */
+  raw(args: string[]): Promise<string>
+  clone(repo: string, target: string, options?: string[]): Promise<void>
+  pull(remote: string, branch: string, options?: string[]): Promise<void>
+  status(): Promise<GitStatusSummary>
+  /** Commit subjects, newest first, bounded by `maxCount`. */
+  log(options: { maxCount: number }): Promise<Array<{ hash: string; message: string }>>
+}
+
+/** The status fields the daemon reads; simple-git returns many more. */
+export interface GitStatusSummary {
+  current: string | null
+  tracking: string | null
+  ahead: number
+  behind: number
+  files: Array<{ path: string; index: string; working_dir: string }>
+}
+
+/** Factory for a runner bound to one working directory. */
+export type GitRunnerFor = (cwd?: string, abort?: AbortSignal) => GitRunner
+
+/**
+ * Today's behaviour: run git in this daemon's own filesystem through simple-git.
+ *
+ * A thin delegation on purpose — the point of the seam is that the local path keeps its exact
+ * semantics (including simple-git's argument handling and its abort-kills-the-child plugin),
+ * so a cluster agent and a self-hosted agent differ in where git runs and in nothing else.
+ */
+export class LocalGitRunner implements GitRunner {
+  constructor(private readonly git: SimpleGit) {}
+
+  withEnv(env: Record<string, string>): GitRunner {
+    // simple-git's own env chaining, so the local path keeps its exact semantics.
+    return new LocalGitRunner(this.git.env(env))
+  }
+
+  async raw(args: string[]): Promise<string> {
+    return this.git.raw(args)
+  }
+
+  async clone(repo: string, target: string, options: string[] = []): Promise<void> {
+    await this.git.clone(repo, target, options)
+  }
+
+  async pull(remote: string, branch: string, options: string[] = []): Promise<void> {
+    await this.git.pull(remote, branch, options)
+  }
+
+  async status(): Promise<GitStatusSummary> {
+    const summary = await this.git.status()
+    return {
+      current: summary.current ?? null,
+      tracking: summary.tracking ?? null,
+      ahead: summary.ahead,
+      behind: summary.behind,
+      files: summary.files.map((file) => ({
+        path: file.path,
+        index: file.index,
+        working_dir: file.working_dir
+      }))
+    }
+  }
+
+  async log(options: { maxCount: number }): Promise<Array<{ hash: string; message: string }>> {
+    const result = await this.git.log({ maxCount: options.maxCount })
+    return result.all.map((entry) => ({ hash: entry.hash, message: entry.message }))
+  }
+}

--- a/packages/daemon/test/git-runner-contract.test.ts
+++ b/packages/daemon/test/git-runner-contract.test.ts
@@ -1,0 +1,198 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { gitFor } from '../src/workspace/git-injection.js'
+import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
+import { GitExecError, GitExecPayloadSchema, ShimGitRunner, parsePorcelainV2 } from '../src/shim/git-exec.js'
+import type { ShimRequester } from '../src/shim/channels.js'
+
+/**
+ * ONE contract, both runners.
+ *
+ * The local runner executes git on this daemon's disk; the remote one sends the same argv to a
+ * sandbox. Both are run against the SAME real repository here, and their answers compared —
+ * because the risk this seam introduces is not a crash, it is a quiet divergence, where a
+ * cluster-backed agent reads a different workspace state than a self-hosted one.
+ *
+ * The remote side is exercised through a requester that actually invokes git in the target
+ * directory, standing in for the shim's exec handler. It is deliberately NOT a canned
+ * response: a fake that returns what the runner expects would only confirm the runner's own
+ * assumptions, which is exactly how earlier defects in this workstream survived their tests.
+ */
+
+const roots: string[] = []
+
+afterAll(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function git(cwd: string, args: string[], extraEnv: Record<string, string> = {}): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'T',
+      GIT_AUTHOR_EMAIL: 't@e',
+      GIT_COMMITTER_NAME: 'T',
+      GIT_COMMITTER_EMAIL: 't@e',
+      ...extraEnv
+    }
+  })
+}
+
+/** A repository with two commits, one staged change and one untracked file. */
+function repository(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-gitrunner-'))
+  roots.push(root)
+  git(root, ['init', '--initial-branch=main'])
+  writeFileSync(join(root, 'first.txt'), 'one\n')
+  git(root, ['add', 'first.txt'])
+  git(root, ['commit', '-m', 'first commit'])
+  writeFileSync(join(root, 'second.txt'), 'two\n')
+  git(root, ['add', 'second.txt'])
+  git(root, ['commit', '-m', 'second commit'])
+  writeFileSync(join(root, 'staged.txt'), 'staged\n')
+  git(root, ['add', 'staged.txt'])
+  writeFileSync(join(root, 'untracked.txt'), 'untracked\n')
+  return root
+}
+
+/** Stands in for the shim: actually runs the requested git argv in the target directory. */
+function sandboxRequester(root: string): ShimRequester & { seen: unknown[] } {
+  const seen: unknown[] = []
+  return {
+    seen,
+    request: async (capability, payload) => {
+      seen.push(payload)
+      expect(capability).toBe('exec')
+      const parsed = GitExecPayloadSchema.parse(payload)
+      try {
+        const stdout = git(parsed.cwd ?? root, parsed.args, parsed.env)
+        return { code: 0, stdout, stderr: '' }
+      } catch (err) {
+        const failure = err as { status?: number; stdout?: string; stderr?: string }
+        return {
+          code: failure.status ?? 1,
+          stdout: String(failure.stdout ?? ''),
+          stderr: String(failure.stderr ?? '')
+        }
+      }
+    }
+  }
+}
+
+function runners(root: string): {
+  local: GitRunner
+  remote: GitRunner
+  requester: ReturnType<typeof sandboxRequester>
+} {
+  const requester = sandboxRequester(root)
+  return { local: new LocalGitRunner(gitFor(root)), remote: new ShimGitRunner(requester, root), requester }
+}
+
+describe('git runner contract, local and shim-backed', () => {
+  it('reports the same status summary from both sides', async () => {
+    const root = repository()
+    const { local, remote } = runners(root)
+    const [fromLocal, fromRemote] = await Promise.all([local.status(), remote.status()])
+
+    expect(fromRemote.current).toBe(fromLocal.current)
+    expect(fromRemote.current).toBe('main')
+    expect(fromRemote.ahead).toBe(fromLocal.ahead)
+    expect(fromRemote.behind).toBe(fromLocal.behind)
+    // Compare the file set rather than array order, which neither format guarantees.
+    const paths = (summary: typeof fromLocal) => summary.files.map((file) => file.path).sort()
+    expect(paths(fromRemote)).toEqual(paths(fromLocal))
+    expect(paths(fromRemote)).toEqual(['staged.txt', 'untracked.txt'])
+  })
+
+  it('reports the same commit log from both sides', async () => {
+    const root = repository()
+    const { local, remote } = runners(root)
+    const [fromLocal, fromRemote] = await Promise.all([local.log({ maxCount: 5 }), remote.log({ maxCount: 5 })])
+    expect(fromRemote.map((entry) => entry.message)).toEqual(fromLocal.map((entry) => entry.message))
+    expect(fromRemote.map((entry) => entry.message)).toEqual(['second commit', 'first commit'])
+    expect(fromRemote.map((entry) => entry.hash)).toEqual(fromLocal.map((entry) => entry.hash))
+  })
+
+  it('returns the same output for the raw subcommands the daemon actually uses', async () => {
+    const root = repository()
+    const { local, remote } = runners(root)
+    for (const args of [
+      ['rev-parse', '--verify', 'HEAD'],
+      ['rev-list', '--count', 'HEAD'],
+      ['status', '--porcelain'],
+      ['remote'],
+      ['check-ref-format', '--branch', 'main']
+    ]) {
+      const [fromLocal, fromRemote] = await Promise.all([local.raw(args), remote.raw(args)])
+      expect(fromRemote.trim(), `raw ${args.join(' ')}`).toBe(fromLocal.trim())
+    }
+  })
+
+  it('sends argv rather than a shell string, so a crafted branch name cannot inject', async () => {
+    const root = repository()
+    const { remote, requester } = runners(root)
+    await remote.raw(['check-ref-format', '--branch', 'main']).catch(() => undefined)
+    for (const payload of requester.seen) {
+      expect(Array.isArray((payload as { args: unknown }).args)).toBe(true)
+      // No element may smuggle a second command: the shim spawns argv directly.
+      for (const arg of (payload as { args: string[] }).args) expect(typeof arg).toBe('string')
+    }
+    // A hostile-looking argument stays one argument rather than becoming a command.
+    const hostile = 'main; rm -rf /'
+    const result = await remote.raw(['check-ref-format', '--branch', hostile]).catch((err: unknown) => err)
+    expect(result).toBeInstanceOf(GitExecError)
+    expect((requester.seen.at(-1) as { args: string[] }).args).toEqual(['check-ref-format', '--branch', hostile])
+  })
+
+  it('surfaces a git failure with its exit code and stderr, from both sides', async () => {
+    const root = repository()
+    const { local, remote } = runners(root)
+    const localError = await local.raw(['rev-parse', '--verify', 'refs/heads/missing']).catch((err: unknown) => err)
+    const remoteError = await remote.raw(['rev-parse', '--verify', 'refs/heads/missing']).catch((err: unknown) => err)
+    expect(localError).toBeInstanceOf(Error)
+    expect(remoteError).toBeInstanceOf(GitExecError)
+    expect((remoteError as GitExecError).code).not.toBe(0)
+  })
+
+  it('applies per-invocation env on both sides, and scopes it to the request remotely', async () => {
+    // Every call site threads env per invocation — the credential-helper pointers among it —
+    // so a seam that could not carry env could not preserve behaviour. Remotely it must also
+    // stay ON the request: setting it on the sandbox would leave a runtime able to read the
+    // pointers back out of its own environment afterwards.
+    const root = repository()
+    const { local, remote, requester } = runners(root)
+    const marker = { GIT_AUTHOR_NAME: 'Env Applied' }
+
+    writeFileSync(join(root, 'third.txt'), 'three\n')
+    git(root, ['add', 'third.txt'])
+    await local.withEnv({ ...marker, GIT_AUTHOR_EMAIL: 'env@example.com' }).raw(['commit', '-m', 'local env commit'])
+    const localAuthor = git(root, ['log', '-1', '--format=%an']).trim()
+    expect(localAuthor).toBe('Env Applied')
+
+    writeFileSync(join(root, 'fourth.txt'), 'four\n')
+    git(root, ['add', 'fourth.txt'])
+    await remote.withEnv({ ...marker, GIT_AUTHOR_EMAIL: 'env@example.com' }).raw(['commit', '-m', 'remote env commit'])
+    expect(git(root, ['log', '-1', '--format=%an']).trim()).toBe('Env Applied')
+
+    // The env travelled with the request rather than being set globally.
+    const payload = requester.seen.at(-1) as { env?: Record<string, string> }
+    expect(payload.env).toMatchObject(marker)
+  })
+
+  it('parses a detached HEAD and upstream tracking the way git reports them', () => {
+    // Unit-level, because a detached checkout is awkward to stage and the format is the part
+    // that can silently drift.
+    const detached = parsePorcelainV2('# branch.oid abc\n# branch.head (detached)\n')
+    expect(detached.current).toBeNull()
+    const tracking = parsePorcelainV2(
+      '# branch.head main\n# branch.upstream origin/main\n# branch.ab +2 -3\n? new.txt\n'
+    )
+    expect(tracking).toMatchObject({ current: 'main', tracking: 'origin/main', ahead: 2, behind: 3 })
+    expect(tracking.files).toEqual([{ path: 'new.txt', index: '?', working_dir: '?' }])
+  })
+})

--- a/packages/daemon/test/git-runner-contract.test.ts
+++ b/packages/daemon/test/git-runner-contract.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, it } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { gitFor, workspaceGitLocalEnv } from '../src/workspace/git-injection.js'
@@ -70,7 +70,11 @@ function sandboxRequester(root: string): ShimRequester & { seen: unknown[] } {
       expect(capability).toBe('exec')
       const parsed = GitExecPayloadSchema.parse(payload)
       try {
-        const stdout = git(parsed.cwd ?? root, parsed.args, parsed.env)
+        // As given, never merged into ambient env: merging here would have concealed the
+        // runner merging, which is the defect this parity suite exists to surface.
+        const stdout = parsed.env
+          ? execFileSync('git', parsed.args, { cwd: parsed.cwd ?? root, encoding: 'utf8', env: parsed.env })
+          : git(parsed.cwd ?? root, parsed.args)
         return { code: 0, stdout, stderr: '' }
       } catch (err) {
         const failure = err as { status?: number; stdout?: string; stderr?: string }
@@ -201,6 +205,37 @@ describe('git runner contract, local and shim-backed', () => {
     // The env travelled with the request rather than being set globally.
     const payload = requester.seen.at(-1) as { env?: Record<string, string> }
     expect(payload.env).toMatchObject(marker)
+  })
+
+  it('replaces rather than extends a chained environment, as simple-git does', async () => {
+    // remote.withEnv(A).withEnv(B) must behave like two .env() calls: B alone. Merging would
+    // keep a variable A had and B deliberately dropped — and the omission IS the sanitization.
+    const root = repository()
+    const { remote, requester } = runners(root)
+    const base = { ...workspaceGitLocalEnv(), GIT_AUTHOR_NAME: 'First', DROPPED_BY_SECOND: 'yes' }
+    const second = { ...workspaceGitLocalEnv(), GIT_AUTHOR_NAME: 'Second' }
+    await remote.withEnv(base).withEnv(second).raw(['rev-parse', '--verify', 'HEAD'])
+    const payload = requester.seen.at(-1) as { env?: Record<string, string> }
+    expect(payload.env?.GIT_AUTHOR_NAME).toBe('Second')
+    expect(payload.env?.DROPPED_BY_SECOND).toBeUndefined()
+  })
+
+  it('reports a nested untracked FILE, not just its directory, on both sides', async () => {
+    // simple-git runs status with `-u`, so it lists nested untracked files individually. An
+    // argv without it collapses them to `nested/`, which is a different answer to the same
+    // question depending on where git ran.
+    const root = mkdtempSync(join(tmpdir(), 'ac-gitnested-'))
+    roots.push(root)
+    git(root, ['init', '--initial-branch=main'])
+    writeFileSync(join(root, 'tracked.txt'), 'x\n')
+    git(root, ['add', 'tracked.txt'])
+    git(root, ['commit', '-m', 'base'])
+    mkdirSync(join(root, 'nested'), { recursive: true })
+    writeFileSync(join(root, 'nested', 'file.txt'), 'deep\n')
+    const { local, remote } = runners(root)
+    const [fromLocal, fromRemote] = await Promise.all([local.status(), remote.status()])
+    expect(fromRemote.files.map((file) => file.path)).toEqual(fromLocal.files.map((file) => file.path))
+    expect(fromRemote.files.map((file) => file.path)).toContain('nested/file.txt')
   })
 
   it('reports a staged RENAME identically on both sides', async () => {

--- a/packages/daemon/test/git-runner-contract.test.ts
+++ b/packages/daemon/test/git-runner-contract.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { gitFor } from '../src/workspace/git-injection.js'
+import { gitFor, workspaceGitLocalEnv } from '../src/workspace/git-injection.js'
 import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
 import { GitExecError, GitExecPayloadSchema, ShimGitRunner, parsePorcelainV2 } from '../src/shim/git-exec.js'
 import type { ShimRequester } from '../src/shim/channels.js'
@@ -159,24 +159,43 @@ describe('git runner contract, local and shim-backed', () => {
     expect((remoteError as GitExecError).code).not.toBe(0)
   })
 
-  it('applies per-invocation env on both sides, and scopes it to the request remotely', async () => {
+  it('applies a complete per-invocation env on both sides, and scopes it to the request remotely', async () => {
     // Every call site threads env per invocation — the credential-helper pointers among it —
     // so a seam that could not carry env could not preserve behaviour. Remotely it must also
     // stay ON the request: setting it on the sandbox would leave a runtime able to read the
     // pointers back out of its own environment afterwards.
     const root = repository()
     const { local, remote, requester } = runners(root)
+    // The env REPLACES rather than extends, because callers build it by sanitizing — so a
+    // caller supplies a whole environment including identity. Passing only an author, as an
+    // earlier version of this test did, leaves git with no committer and fails anywhere the
+    // ambient config does not happen to supply one. It passed on my machine and was red in CI.
     const marker = { GIT_AUTHOR_NAME: 'Env Applied' }
+    // Built from the production helper rather than raw process.env: that is what call sites
+    // pass, and it is also what simple-git's own checker accepts — raw process.env carries
+    // names it refuses, such as GIT_EDITOR, which is the sanitization earning its keep.
+    const complete = (extra: Record<string, string>): Record<string, string> => ({
+      ...workspaceGitLocalEnv(),
+      GIT_AUTHOR_NAME: 'T',
+      GIT_AUTHOR_EMAIL: 't@e',
+      GIT_COMMITTER_NAME: 'T',
+      GIT_COMMITTER_EMAIL: 't@e',
+      ...extra
+    })
 
     writeFileSync(join(root, 'third.txt'), 'three\n')
     git(root, ['add', 'third.txt'])
-    await local.withEnv({ ...marker, GIT_AUTHOR_EMAIL: 'env@example.com' }).raw(['commit', '-m', 'local env commit'])
+    await local
+      .withEnv(complete({ ...marker, GIT_AUTHOR_EMAIL: 'env@example.com' }))
+      .raw(['commit', '-m', 'local env commit'])
     const localAuthor = git(root, ['log', '-1', '--format=%an']).trim()
     expect(localAuthor).toBe('Env Applied')
 
     writeFileSync(join(root, 'fourth.txt'), 'four\n')
     git(root, ['add', 'fourth.txt'])
-    await remote.withEnv({ ...marker, GIT_AUTHOR_EMAIL: 'env@example.com' }).raw(['commit', '-m', 'remote env commit'])
+    await remote
+      .withEnv(complete({ ...marker, GIT_AUTHOR_EMAIL: 'env@example.com' }))
+      .raw(['commit', '-m', 'remote env commit'])
     expect(git(root, ['log', '-1', '--format=%an']).trim()).toBe('Env Applied')
 
     // The env travelled with the request rather than being set globally.
@@ -184,15 +203,62 @@ describe('git runner contract, local and shim-backed', () => {
     expect(payload.env).toMatchObject(marker)
   })
 
+  it('reports a staged RENAME identically on both sides', async () => {
+    // porcelain-v2 gives a rename nine fields before the path plus the original path after a
+    // separator. An earlier parser treated it like an ordinary entry, so `path` came back as
+    // "R100 new.txt\told.txt" — a value no caller could match against a real file.
+    const root = repository()
+    git(root, ['commit', '-m', 'stage base'])
+    git(root, ['mv', 'first.txt', 'renamed.txt'])
+    const { local, remote } = runners(root)
+    const [fromLocal, fromRemote] = await Promise.all([local.status(), remote.status()])
+    const renamed = (summary: typeof fromLocal) => summary.files.map((file) => file.path).sort()
+    expect(renamed(fromRemote)).toEqual(renamed(fromLocal))
+    expect(renamed(fromRemote)).toContain('renamed.txt')
+    for (const path of renamed(fromRemote)) expect(path).not.toMatch(/^R\d/)
+  })
+
+  it('reports a CONFLICT on both sides, so a conflicted tree is never seen as clean', async () => {
+    // Unmerged records were dropped entirely, so files.length was 0 on a conflicted workspace —
+    // and callers derive cleanliness from exactly that.
+    const root = mkdtempSync(join(tmpdir(), 'ac-gitconflict-'))
+    roots.push(root)
+    git(root, ['init', '--initial-branch=main'])
+    writeFileSync(join(root, 'shared.txt'), 'base\n')
+    git(root, ['add', 'shared.txt'])
+    git(root, ['commit', '-m', 'base'])
+    git(root, ['checkout', '-b', 'other'])
+    writeFileSync(join(root, 'shared.txt'), 'theirs\n')
+    git(root, ['commit', '-am', 'theirs'])
+    git(root, ['checkout', 'main'])
+    writeFileSync(join(root, 'shared.txt'), 'ours\n')
+    git(root, ['commit', '-am', 'ours'])
+    try {
+      git(root, ['merge', 'other'])
+    } catch {
+      /* the conflict is the point */
+    }
+    const { local, remote } = runners(root)
+    const [fromLocal, fromRemote] = await Promise.all([local.status(), remote.status()])
+    expect(fromLocal.files.length).toBeGreaterThan(0)
+    expect(fromRemote.files.map((file) => file.path)).toEqual(fromLocal.files.map((file) => file.path))
+    expect(fromRemote.files.map((file) => file.path)).toContain('shared.txt')
+  })
+
   it('parses a detached HEAD and upstream tracking the way git reports them', () => {
     // Unit-level, because a detached checkout is awkward to stage and the format is the part
     // that can silently drift.
-    const detached = parsePorcelainV2('# branch.oid abc\n# branch.head (detached)\n')
+    const detached = parsePorcelainV2('# branch.oid abc\0# branch.head (detached)\0')
     expect(detached.current).toBeNull()
     const tracking = parsePorcelainV2(
-      '# branch.head main\n# branch.upstream origin/main\n# branch.ab +2 -3\n? new.txt\n'
+      '# branch.head main\0# branch.upstream origin/main\0# branch.ab +2 -3\0? new.txt\0'
     )
     expect(tracking).toMatchObject({ current: 'main', tracking: 'origin/main', ahead: 2, behind: 3 })
     expect(tracking.files).toEqual([{ path: 'new.txt', index: '?', working_dir: '?' }])
+    // A rename record consumes the following original-path entry rather than parsing it.
+    const renames = parsePorcelainV2('2 R. N... 100644 100644 100644 aaa bbb R100 new.txt\0old.txt\0')
+    expect(renames.files).toEqual([{ path: 'new.txt', index: 'R', working_dir: ' ' }])
+    const unmerged = parsePorcelainV2('u UU N... 100644 100644 100644 100644 aaa bbb ccc conflict.txt\0')
+    expect(unmerged.files).toEqual([{ path: 'conflict.txt', index: 'U', working_dir: 'U' }])
   })
 })


### PR DESCRIPTION
Part of #815 (which stays open — see the last section). Part of #804.

The plan's first instruction for this work was to freeze the git operation inventory **before**
touching any call site. Doing it in that order paid twice.

## The inventory, measured

The daemon performs `clone`, `pull`, `status`, `log`, and `raw` with eleven subcommands:
`check-ref-format`, `clean`, `config`, `fetch`, `remote`, `reset`, `rev-list`, `rev-parse`,
`status`, `update-ref`, `worktree`. `GitRunner` is that list and nothing wider — every member
widens what a half-trusted sandbox will execute, and re-creating simple-git's surface across a
channel is explicitly not the job.

## What the inventory found that a sketch would have missed

**All seventeen call sites thread env per invocation** through simple-git's `.env()` chaining —
the credential-helper pointers, the safe-directory and hooks overrides. An interface designed
from imagination would have omitted that, and the migration would have discovered it half-done.

`withEnv` is therefore part of the contract. Remotely the env travels **on the request** rather
than being set on the sandbox, so a runtime cannot read the credential-helper pointers back out
of its own environment afterwards.

## The two implementations

- `LocalGitRunner` is a thin delegation preserving today's exact semantics, including
  simple-git's argument handling and its abort-kills-the-child plugin.
- `ShimGitRunner` sends the same argv into the sandbox and parses `status --porcelain=v2`, a
  documented and stable format — which is what makes parsing it daemon-side safe. **argv only,
  never a composed shell string**, since these arguments come from workspace configuration a
  repository can influence.

## The contract test

Both runners run against the **same real repository** and their answers are compared. The risk
this seam introduces is not a crash — it is a quiet divergence where a cluster-backed agent
reads different workspace state than a self-hosted one, which no single-sided test would show.

The remote side goes through a stand-in that **really invokes git** rather than returning canned
output. A fake that answered what the runner expected would only confirm the runner's own
assumptions — which is precisely how several earlier defects in this workstream survived their
tests, in #823, #826 and #828. The injection case is demonstrated rather than asserted: git
itself rejects `main; rm -rf /` as a single argument.

## What is NOT here, and why #815 stays open

The call-site migration — `workspace-manager.ts`, the skills mutators, the BFF read and
gitstatus/gitpull paths — is the remainder of #815 and does not land in this PR. It is the
larger half, it touches the most-used path in the product (every `git-repo` agent), and it is
mechanical only *because* this contract now exists and includes `withEnv`.

Splitting it this way is my judgement, not the issue's instruction, so it is stated rather than
assumed: happy to fold it differently if you would rather see one change.
