### PR TITLE
feat(daemon): carry the pull summary and commit date through the git contract

### DIFF
--- a/packages/daemon/src/shim/git-exec.ts
+++ b/packages/daemon/src/shim/git-exec.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import type { GitRunner, GitStatusSummary } from '../workspace/git-runner.js'
+import type { GitLogEntry, GitPullSummary, GitRunner, GitStatusSummary } from '../workspace/git-runner.js'
 import type { ShimRequester } from './channels.js'
 
 /**
@@ -95,6 +95,13 @@ export function parsePorcelainV2(stdout: string): GitStatusSummary {
   return summary
 }
 
+/** `N files changed, N insertions(+), N deletions(-)` — a fixed shape, unlike --stat prose. */
+export function parseShortstat(stdout: string): { insertions: number; deletions: number } {
+  const insertions = /(\d+) insertions?\(\+\)/.exec(stdout)
+  const deletions = /(\d+) deletions?\(-\)/.exec(stdout)
+  return { insertions: Number(insertions?.[1] ?? 0), deletions: Number(deletions?.[1] ?? 0) }
+}
+
 /** A git failure that carries what the sandbox reported, so a caller can act on it. */
 export class GitExecError extends Error {
   constructor(
@@ -139,8 +146,22 @@ export class ShimGitRunner implements GitRunner {
     await this.exec(['clone', ...options, repo, target])
   }
 
-  async pull(remote: string, branch: string, options: string[] = []): Promise<void> {
+  async pull(remote: string, branch: string, options: string[] = []): Promise<GitPullSummary> {
+    // `--stat=...` would need parsing prose; the shortstat line has a fixed shape, and the
+    // changed-file list comes from a name-only diff against the pre-pull HEAD.
+    const before = await this.exec(['rev-parse', 'HEAD']).then(
+      (result) => result.stdout.trim(),
+      () => ''
+    )
     await this.exec(['pull', ...options, remote, branch])
+    const after = (await this.exec(['rev-parse', 'HEAD'])).stdout.trim()
+    if (!before || before === after) return { files: [], insertions: 0, deletions: 0 }
+    const names = await this.exec(['diff', '--name-only', `${before}..${after}`])
+    const shortstat = await this.exec(['diff', '--shortstat', `${before}..${after}`])
+    return {
+      files: names.stdout.split('\n').filter((line) => line.trim().length > 0),
+      ...parseShortstat(shortstat.stdout)
+    }
   }
 
   async status(): Promise<GitStatusSummary> {
@@ -154,14 +175,17 @@ export class ShimGitRunner implements GitRunner {
     return parsePorcelainV2(result.stdout)
   }
 
-  async log(options: { maxCount: number }): Promise<Array<{ hash: string; message: string }>> {
-    const result = await this.exec(['log', `--max-count=${options.maxCount}`, '--format=%H%x1f%s'])
+  async log(options: { maxCount: number }): Promise<GitLogEntry[]> {
+    // %cI is git's strict-ISO committer date, matching what the local runner asks simple-git
+    // for; a unit separator keeps subjects that contain spaces or tabs intact.
+    const SEP = '\u001f'
+    const result = await this.exec(['log', `--max-count=${options.maxCount}`, `--format=%H%x1f%cI%x1f%s`])
     return result.stdout
       .split('\n')
-      .filter((line) => line.includes(''))
+      .filter((line) => line.includes(SEP))
       .map((line) => {
-        const [hash, message] = line.split('')
-        return { hash: hash ?? '', message: message ?? '' }
+        const [hash, committedAt, subject] = line.split(SEP)
+        return { hash: hash ?? '', committedAt: committedAt ?? '', subject: subject ?? '' }
       })
   }
 

--- a/packages/daemon/src/workspace/git-runner.ts
+++ b/packages/daemon/src/workspace/git-runner.ts
@@ -29,10 +29,27 @@ export interface GitRunner {
   /** Run a git subcommand with argv, never a composed shell string. */
   raw(args: string[]): Promise<string>
   clone(repo: string, target: string, options?: string[]): Promise<void>
-  pull(remote: string, branch: string, options?: string[]): Promise<void>
+  /** Pull, returning what the console reports: which files moved and by how much. */
+  pull(remote: string, branch: string, options?: string[]): Promise<GitPullSummary>
   status(): Promise<GitStatusSummary>
-  /** Commit subjects, newest first, bounded by `maxCount`. */
-  log(options: { maxCount: number }): Promise<Array<{ hash: string; message: string }>>
+  /** Commits newest first, bounded by `maxCount`. */
+  log(options: { maxCount: number }): Promise<GitLogEntry[]>
+}
+
+/** The pull result the BFF surfaces to the console; nothing here is decorative. */
+export interface GitPullSummary {
+  files: string[]
+  insertions: number
+  deletions: number
+}
+
+/** A commit as the workspace views consume it — the committer date included, because the
+ *  console shows when HEAD last moved and an interface without it cannot serve that. */
+export interface GitLogEntry {
+  hash: string
+  subject: string
+  /** Strict-ISO committer date (`%cI`), empty when the runtime reported none. */
+  committedAt: string
 }
 
 /** The status fields the daemon reads; simple-git returns many more. */
@@ -70,8 +87,13 @@ export class LocalGitRunner implements GitRunner {
     await this.git.clone(repo, target, options)
   }
 
-  async pull(remote: string, branch: string, options: string[] = []): Promise<void> {
-    await this.git.pull(remote, branch, options)
+  async pull(remote: string, branch: string, options: string[] = []): Promise<GitPullSummary> {
+    const result = await this.git.pull(remote, branch, options)
+    return {
+      files: [...result.files],
+      insertions: result.summary.insertions,
+      deletions: result.summary.deletions
+    }
   }
 
   async status(): Promise<GitStatusSummary> {
@@ -89,8 +111,15 @@ export class LocalGitRunner implements GitRunner {
     }
   }
 
-  async log(options: { maxCount: number }): Promise<Array<{ hash: string; message: string }>> {
-    const result = await this.git.log({ maxCount: options.maxCount })
-    return result.all.map((entry) => ({ hash: entry.hash, message: entry.message }))
+  async log(options: { maxCount: number }): Promise<GitLogEntry[]> {
+    const result = await this.git.log({
+      maxCount: options.maxCount,
+      format: { hash: '%H', date: '%cI', subject: '%s' }
+    })
+    return result.all.map((entry) => ({
+      hash: entry.hash,
+      subject: entry.subject ?? '',
+      committedAt: entry.date ?? ''
+    }))
   }
 }

--- a/packages/daemon/test/git-runner-contract.test.ts
+++ b/packages/daemon/test/git-runner-contract.test.ts
@@ -5,7 +5,13 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { gitFor, workspaceGitLocalEnv } from '../src/workspace/git-injection.js'
 import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
-import { GitExecError, GitExecPayloadSchema, ShimGitRunner, parsePorcelainV2 } from '../src/shim/git-exec.js'
+import {
+  GitExecError,
+  GitExecPayloadSchema,
+  ShimGitRunner,
+  parsePorcelainV2,
+  parseShortstat
+} from '../src/shim/git-exec.js'
 import type { ShimRequester } from '../src/shim/channels.js'
 
 /**
@@ -117,9 +123,13 @@ describe('git runner contract, local and shim-backed', () => {
     const root = repository()
     const { local, remote } = runners(root)
     const [fromLocal, fromRemote] = await Promise.all([local.log({ maxCount: 5 }), remote.log({ maxCount: 5 })])
-    expect(fromRemote.map((entry) => entry.message)).toEqual(fromLocal.map((entry) => entry.message))
-    expect(fromRemote.map((entry) => entry.message)).toEqual(['second commit', 'first commit'])
+    expect(fromRemote.map((entry) => entry.subject)).toEqual(fromLocal.map((entry) => entry.subject))
+    expect(fromRemote.map((entry) => entry.subject)).toEqual(['second commit', 'first commit'])
     expect(fromRemote.map((entry) => entry.hash)).toEqual(fromLocal.map((entry) => entry.hash))
+    // The committer date is consumed by the console's workspace view, so parity covers it too:
+    // an interface that dropped it could not serve "when did HEAD last move".
+    expect(fromRemote.map((entry) => entry.committedAt)).toEqual(fromLocal.map((entry) => entry.committedAt))
+    for (const entry of fromRemote) expect(entry.committedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 
   it('returns the same output for the raw subcommands the daemon actually uses', async () => {
@@ -280,6 +290,69 @@ describe('git runner contract, local and shim-backed', () => {
     expect(fromRemote.files.map((file) => file.path)).toContain('shared.txt')
   })
 
+  it('reports the same pull summary from both sides', async () => {
+    // The console shows how many files a pull moved and by how much, so the summary is part of
+    // the contract rather than a convenience: an interface returning void could not serve it.
+    // A real upstream is needed, so this clones from one and pushes a change into it.
+    const upstream = mkdtempSync(join(tmpdir(), 'ac-gitupstream-'))
+    roots.push(upstream)
+    git(upstream, ['init', '--bare', '--initial-branch=main'])
+    const seed = mkdtempSync(join(tmpdir(), 'ac-gitseed-'))
+    roots.push(seed)
+    git(seed, ['clone', upstream, '.'])
+    writeFileSync(join(seed, 'shared.txt'), 'one\n')
+    git(seed, ['add', 'shared.txt'])
+    git(seed, ['commit', '-m', 'seed'])
+    git(seed, ['push', 'origin', 'main'])
+
+    const makeClone = (): string => {
+      const dir = mkdtempSync(join(tmpdir(), 'ac-gitclone-'))
+      roots.push(dir)
+      git(dir, ['clone', upstream, '.'])
+      return dir
+    }
+    const forLocal = makeClone()
+    const forRemote = makeClone()
+
+    // One more upstream commit touching two files, so the summary is non-trivial.
+    writeFileSync(join(seed, 'shared.txt'), 'one\ntwo\n')
+    writeFileSync(join(seed, 'added.txt'), 'new\n')
+    git(seed, ['add', '.'])
+    git(seed, ['commit', '-m', 'upstream change'])
+    git(seed, ['push', 'origin', 'main'])
+
+    const fromLocal = await new LocalGitRunner(gitFor(forLocal)).pull('origin', 'main')
+    const fromRemote = await new ShimGitRunner(sandboxRequester(forRemote), forRemote).pull('origin', 'main')
+
+    expect([...fromRemote.files].sort()).toEqual([...fromLocal.files].sort())
+    expect([...fromRemote.files].sort()).toEqual(['added.txt', 'shared.txt'])
+    expect(fromRemote.insertions).toBe(fromLocal.insertions)
+    expect(fromRemote.deletions).toBe(fromLocal.deletions)
+    expect(fromRemote.insertions).toBeGreaterThan(0)
+  })
+
+  it('reports an up-to-date pull as no change on both sides', async () => {
+    const upstream = mkdtempSync(join(tmpdir(), 'ac-gitupstream2-'))
+    roots.push(upstream)
+    git(upstream, ['init', '--bare', '--initial-branch=main'])
+    const seed = mkdtempSync(join(tmpdir(), 'ac-gitseed2-'))
+    roots.push(seed)
+    git(seed, ['clone', upstream, '.'])
+    writeFileSync(join(seed, 'only.txt'), 'x\n')
+    git(seed, ['add', 'only.txt'])
+    git(seed, ['commit', '-m', 'seed'])
+    git(seed, ['push', 'origin', 'main'])
+    const clone = mkdtempSync(join(tmpdir(), 'ac-gitclone2-'))
+    roots.push(clone)
+    git(clone, ['clone', upstream, '.'])
+
+    const fromLocal = await new LocalGitRunner(gitFor(clone)).pull('origin', 'main')
+    const fromRemote = await new ShimGitRunner(sandboxRequester(clone), clone).pull('origin', 'main')
+    expect(fromRemote).toEqual({ files: [], insertions: 0, deletions: 0 })
+    expect(fromLocal.files).toEqual([])
+    expect(fromLocal.insertions).toBe(0)
+  })
+
   it('parses a detached HEAD and upstream tracking the way git reports them', () => {
     // Unit-level, because a detached checkout is awkward to stage and the format is the part
     // that can silently drift.
@@ -293,6 +366,11 @@ describe('git runner contract, local and shim-backed', () => {
     // A rename record consumes the following original-path entry rather than parsing it.
     const renames = parsePorcelainV2('2 R. N... 100644 100644 100644 aaa bbb R100 new.txt\0old.txt\0')
     expect(renames.files).toEqual([{ path: 'new.txt', index: 'R', working_dir: ' ' }])
+    expect(parseShortstat(' 2 files changed, 3 insertions(+), 1 deletion(-)\n')).toEqual({
+      insertions: 3,
+      deletions: 1
+    })
+    expect(parseShortstat(' 1 file changed, 1 insertion(+)\n')).toEqual({ insertions: 1, deletions: 0 })
     const unmerged = parsePorcelainV2('u UU N... 100644 100644 100644 100644 aaa bbb ccc conflict.txt\0')
     expect(unmerged.files).toEqual([{ path: 'conflict.txt', index: 'U', working_dir: 'U' }])
   })


### PR DESCRIPTION
Continues #815 (still open — the call-site migration itself is not here yet). Follows #830.

## What happened

I started the call-site migration and it immediately found a hole in the contract I had just
frozen. The way I missed it is the point: **I inventoried the calls — `git.pull(`, `git.log(` —
without reading what their results feed.**

`cp/workspace-git.ts` consumes `res.files.length` together with
`res.summary.insertions/deletions` to tell the console how much a pull moved, and `%cI` to say
when HEAD last moved. A `pull` returning `void` and a `log` returning only a subject cannot
serve either — so migrating those call sites onto my contract would have meant silently
deleting two features the console shows.

This is the same review finding as #830's non-blocking note, and the reviewer was right to
raise it before the migration rather than after.

## The extension

- `pull` returns `{ files, insertions, deletions }`.
- `log` returns `{ hash, subject, committedAt }`, `committedAt` being git's strict-ISO
  committer date.

Locally both come straight from simple-git, with `log` asking for the same `%H`/`%cI`/`%s`
format the BFF already requested. Remotely the summary is derived from the pre-pull HEAD: a
`--name-only` diff for the file list, and `--shortstat`, whose output has a fixed shape —
rather than parsing `--stat` prose, which would be a parser waiting to drift.

## Parity, against real repositories

The pull test builds a bare upstream, clones it twice, pushes a two-file change, and requires
both runners to report the same files and the same counts. Plus the up-to-date case, where
nothing moved and both must say so — the branch a summary-less implementation would pass by
accident.

Verified against the defect: with the remote summary derivation removed, the parity test fails.

## Still outstanding on #815

The call-site migration itself, and the four warnings from #830 that belong with it:
cancellation through the shim path so a timed-out remote git child cannot retain `index.lock`;
the production shim's non-ACP `exec` handler; and enforcing the declared subcommand inventory
sandbox-side — which matters most, since a closed inventory only means something if the far
side is what enforces it.
