### PR TITLE
feat(daemon): migrate the BFF git surface and the pull helper onto the runner

### DIFF
--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -14,7 +14,6 @@
  */
 import { existsSync, promises as fs } from 'node:fs'
 import { join } from 'node:path'
-import type { SimpleGit } from 'simple-git'
 import {
   normalizeGithubRepoUrl,
   type WorkspaceGitStatus,
@@ -24,11 +23,12 @@ import {
 } from '@agentconnect.md/protocol'
 import {
   assertSafeWorkspaceGitConfig,
-  gitFor,
   pullWorkspaceRef,
   workspaceGitLocalEnv,
   workspaceGitPullTarget
 } from '../workspace/git-injection.js'
+import { gitFor } from '../workspace/git-injection.js'
+import { LocalGitRunner, type GitRunner } from '../workspace/git-runner.js'
 import { authorizeWorkspaceGitUrl } from '../workspace/git-origin-policy.js'
 import { WorkspaceViolationError } from './workspace-reader.js'
 
@@ -37,6 +37,12 @@ import { WorkspaceViolationError } from './workspace-reader.js'
 const PULL_TIMEOUT_MS = 20_000
 
 /** Cap the changed-file list so a huge working tree can't overflow the frame. */
+/** Where this surface gets its git. A cluster-backed workspace substitutes a shim-backed
+ *  runner here; the questions asked, and the answers' shape, do not change. */
+function runnerFor(cwd: string, abort?: AbortSignal): GitRunner {
+  return new LocalGitRunner(gitFor(cwd, abort))
+}
+
 const MAX_STATUS_FILES = 500
 
 export interface WorkspaceGit {
@@ -90,16 +96,22 @@ export function createWorkspaceGit(
       // Status is read-only and the daemon policy already disables hooks and
       // fsmonitor at command scope. Repository hook/include configuration must
       // not make an otherwise usable workspace disappear from the console.
-      const git = gitFor(root).env({ ...workspaceGitLocalEnv(), GIT_OPTIONAL_LOCKS: '0' })
+      // Through the runner, so a cluster-backed workspace answers the same question by running
+      // git in its own sandbox rather than on a disk this daemon cannot see.
+      const git = runnerFor(root).withEnv({ ...workspaceGitLocalEnv(), GIT_OPTIONAL_LOCKS: '0' })
       const s = await git.status()
       const files: WorkspaceGitFile[] = s.files
         .slice(0, MAX_STATUS_FILES)
-        .map((f) => ({ path: f.path, index: f.index, workingDir: f.working_dir }))
+        .map((f: { path: string; index: string; working_dir: string }) => ({
+          path: f.path,
+          index: f.index,
+          workingDir: f.working_dir
+        }))
       const [lastCommit, lastFetchAt] = await Promise.all([headCommit(git), fetchHeadMtime(root)])
       return {
         agentId,
         isRepo: true,
-        clean: s.isClean(),
+        clean: s.clean,
         ...(s.current ? { branch: s.current } : {}),
         ...(s.tracking ? { tracking: s.tracking } : {}),
         ahead: s.ahead,
@@ -121,7 +133,7 @@ export function createWorkspaceGit(
       let timer: ReturnType<typeof setTimeout> | undefined
       const abort = new AbortController()
       try {
-        const git = gitFor(root, abort.signal).env(workspaceGitLocalEnv())
+        const git = runnerFor(root, abort.signal).withEnv(workspaceGitLocalEnv())
         const target = workspaceTargetByAgent(agentId)
         let currentOrigin: string | undefined
         let expectedOrigin: string
@@ -145,7 +157,8 @@ export function createWorkspaceGit(
         const pullTarget = workspaceGitPullTarget(expectedOrigin)
         timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
         const res = await pullWorkspaceRef(
-          git.env({
+          git.withEnv({
+            ...workspaceGitLocalEnv(),
             ...pullTarget.env,
             ...credentialEnvByAgent(agentId),
             GIT_TERMINAL_PROMPT: '0'
@@ -159,8 +172,8 @@ export function createWorkspaceGit(
           isRepo: true,
           ok: true,
           changed,
-          insertions: res.summary.insertions,
-          deletions: res.summary.deletions,
+          insertions: res.insertions,
+          deletions: res.deletions,
           detail:
             changed > 0 ? `Fast-forwarded — updated ${changed} file${changed === 1 ? '' : 's'}.` : 'Already up to date.'
         }
@@ -175,12 +188,16 @@ export function createWorkspaceGit(
 
 /** The HEAD commit (sha / short sha / subject / committer date), or null for an
  *  empty repo with no commits yet. `%cI` is git's strict-ISO committer date. */
-async function headCommit(git: SimpleGit): Promise<WorkspaceGitCommit | null> {
+async function headCommit(git: GitRunner): Promise<WorkspaceGitCommit | null> {
   try {
-    const log = await git.log({ maxCount: 1, format: { hash: '%H', date: '%cI', subject: '%s' } })
-    const c = log.latest
-    if (!c?.hash) return null
-    return { sha: c.hash, shortSha: c.hash.slice(0, 7), subject: c.subject ?? '', committedAt: c.date }
+    const [commit] = await git.log({ maxCount: 1 })
+    if (!commit?.hash) return null
+    return {
+      sha: commit.hash,
+      shortSha: commit.hash.slice(0, 7),
+      subject: commit.subject,
+      committedAt: commit.committedAt
+    }
   } catch {
     return null // freshly-init'd repo with no commits ⇒ `git log` errors
   }

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -23,11 +23,11 @@ import {
 } from '@agentconnect.md/protocol'
 import {
   assertSafeWorkspaceGitConfig,
+  gitFor,
   pullWorkspaceRef,
   workspaceGitLocalEnv,
   workspaceGitPullTarget
 } from '../workspace/git-injection.js'
-import { gitFor } from '../workspace/git-injection.js'
 import { LocalGitRunner, type GitRunner } from '../workspace/git-runner.js'
 import { authorizeWorkspaceGitUrl } from '../workspace/git-origin-policy.js'
 import { WorkspaceViolationError } from './workspace-reader.js'

--- a/packages/daemon/src/shim/git-exec.ts
+++ b/packages/daemon/src/shim/git-exec.ts
@@ -42,7 +42,7 @@ export type GitExecResult = z.infer<typeof GitExecResultSchema>
  * C-quotes unusual filenames, which would diverge from what the local runner reports.
  */
 export function parsePorcelainV2(stdout: string): GitStatusSummary {
-  const summary: GitStatusSummary = { current: null, tracking: null, ahead: 0, behind: 0, files: [] }
+  const summary: GitStatusSummary = { current: null, tracking: null, ahead: 0, behind: 0, files: [], clean: true }
   const entries = stdout.split('\0')
   const push = (path: string, xy: string): void => {
     summary.files.push({
@@ -92,6 +92,7 @@ export function parsePorcelainV2(stdout: string): GitStatusSummary {
     }
     if (entry.startsWith('? ')) push(entry.slice(2), '??')
   }
+  summary.clean = summary.files.length === 0
   return summary
 }
 

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -31,6 +31,7 @@ import { randomUUID } from 'node:crypto'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import type { GitPullSummary, GitRunner } from './git-runner.js'
 import { simpleGit, type SimpleGit } from 'simple-git'
 import { normalizeGitCloneUrl, type GitCommitIdentity } from '@agentconnect.md/protocol'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../cp/gitcred-server.js'
@@ -298,7 +299,7 @@ export function sessionGitPolicyEnv(): Record<string, string> {
  * origin/<branch> current for status. check-ref-format prevents a configured
  * branch from being interpreted as an option or refspec.
  */
-export async function pullWorkspaceRef(git: SimpleGit, remote: string, branch: string) {
+export async function pullWorkspaceRef(git: GitRunner, remote: string, branch: string): Promise<GitPullSummary> {
   await git.raw(['check-ref-format', '--branch', branch])
   const refspec = `+refs/heads/${branch}:refs/remotes/origin/${branch}`
   return git.pull(remote, refspec, ['--ff-only', '--no-recurse-submodules'])

--- a/packages/daemon/src/workspace/git-runner.ts
+++ b/packages/daemon/src/workspace/git-runner.ts
@@ -59,6 +59,10 @@ export interface GitStatusSummary {
   ahead: number
   behind: number
   files: Array<{ path: string; index: string; working_dir: string }>
+  /** Whether the tree has no changes. Taken from simple-git locally rather than re-derived,
+   *  so the local answer stays authoritative; the remote side derives it and the contract test
+   *  is what establishes the two agree, including on a conflicted tree. */
+  clean: boolean
 }
 
 /** Factory for a runner bound to one working directory. */
@@ -107,7 +111,8 @@ export class LocalGitRunner implements GitRunner {
         path: file.path,
         index: file.index,
         working_dir: file.working_dir
-      }))
+      })),
+      clean: summary.isClean()
     }
   }
 

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -35,6 +35,7 @@ import {
   workspaceGitPullTarget,
   writeRepoHelperConfig
 } from './git-injection.js'
+import { LocalGitRunner } from './git-runner.js'
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
 
 const skillsLog = makeLogger('info')
@@ -316,7 +317,10 @@ export async function prepareWorkspace(agent: Agent, opts: PrepareWorkspaceOptio
       const repository = gitRepoOf(agent)
       await assertSafeWorkspaceGitConfig(cwd)
       const pullTarget = workspaceGitPullTarget(repository)
-      const git = gitFor(cwd, abort.signal).env({
+      // Through the runner, because pullWorkspaceRef is orchestration and now speaks the
+      // contract. The remaining gitFor sites in this file migrate with the rest of #815.
+      const git = new LocalGitRunner(gitFor(cwd, abort.signal)).withEnv({
+        ...workspaceGitLocalEnv(),
         ...pullTarget.env,
         ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
         GIT_TERMINAL_PROMPT: '0'

--- a/packages/daemon/test/git-runner-contract.test.ts
+++ b/packages/daemon/test/git-runner-contract.test.ts
@@ -117,6 +117,50 @@ describe('git runner contract, local and shim-backed', () => {
     const paths = (summary: typeof fromLocal) => summary.files.map((file) => file.path).sort()
     expect(paths(fromRemote)).toEqual(paths(fromLocal))
     expect(paths(fromRemote)).toEqual(['staged.txt', 'untracked.txt'])
+    // `clean` comes from simple-git locally and is derived remotely; this is what establishes
+    // that the two agree rather than my assumption about isClean()'s semantics.
+    expect(fromRemote.clean).toBe(fromLocal.clean)
+    expect(fromRemote.clean).toBe(false)
+  })
+
+  it('agrees on cleanliness across clean, dirty and CONFLICTED trees', async () => {
+    // The console gates on `clean`, and unmerged records were once dropped entirely — so a
+    // conflicted tree reporting clean is the failure this pins.
+    const pristine = mkdtempSync(join(tmpdir(), 'ac-gitclean-'))
+    roots.push(pristine)
+    git(pristine, ['init', '--initial-branch=main'])
+    writeFileSync(join(pristine, 'a.txt'), 'a\n')
+    git(pristine, ['add', 'a.txt'])
+    git(pristine, ['commit', '-m', 'only'])
+    const cleanPair = runners(pristine)
+    const [cleanLocal, cleanRemote] = await Promise.all([cleanPair.local.status(), cleanPair.remote.status()])
+    expect(cleanRemote.clean).toBe(cleanLocal.clean)
+    expect(cleanRemote.clean).toBe(true)
+
+    const conflicted = mkdtempSync(join(tmpdir(), 'ac-gitclean-conflict-'))
+    roots.push(conflicted)
+    git(conflicted, ['init', '--initial-branch=main'])
+    writeFileSync(join(conflicted, 'shared.txt'), 'base\n')
+    git(conflicted, ['add', 'shared.txt'])
+    git(conflicted, ['commit', '-m', 'base'])
+    git(conflicted, ['checkout', '-b', 'other'])
+    writeFileSync(join(conflicted, 'shared.txt'), 'theirs\n')
+    git(conflicted, ['commit', '-am', 'theirs'])
+    git(conflicted, ['checkout', 'main'])
+    writeFileSync(join(conflicted, 'shared.txt'), 'ours\n')
+    git(conflicted, ['commit', '-am', 'ours'])
+    try {
+      git(conflicted, ['merge', 'other'])
+    } catch {
+      /* the conflict is the point */
+    }
+    const conflictPair = runners(conflicted)
+    const [conflictLocal, conflictRemote] = await Promise.all([
+      conflictPair.local.status(),
+      conflictPair.remote.status()
+    ])
+    expect(conflictRemote.clean).toBe(conflictLocal.clean)
+    expect(conflictRemote.clean).toBe(false)
   })
 
   it('reports the same commit log from both sides', async () => {

--- a/packages/daemon/test/workspace-git.test.ts
+++ b/packages/daemon/test/workspace-git.test.ts
@@ -121,13 +121,14 @@ describe('createWorkspaceGit.status', () => {
     const fetchedAt = new Date('2026-07-02T09:00:00.000Z')
     utimesSync(join(dir, '.git', 'FETCH_HEAD'), fetchedAt, fetchedAt)
     statusImpl = vi.fn().mockResolvedValue({ current: 'main', ahead: 0, behind: 0, files: [], isClean: () => true })
-    logImpl = vi.fn().mockResolvedValue({
-      latest: {
-        hash: 'a3f9c21deadbeef0000000000000000000000000',
-        date: '2026-07-02T07:00:00+00:00',
-        subject: 'Pin deploy image'
-      }
-    })
+    // simple-git populates BOTH `all` and `latest`; the runner reads `all`, so a mock
+    // supplying only `latest` describes a response simple-git never returns.
+    const commit = {
+      hash: 'a3f9c21deadbeef0000000000000000000000000',
+      date: '2026-07-02T07:00:00+00:00',
+      subject: 'Pin deploy image'
+    }
+    logImpl = vi.fn().mockResolvedValue({ all: [commit], latest: commit })
     const git = createWorkspaceGit(() => dir)
     const s = await git.status('a')
     expect(s.lastCommit).toEqual({


### PR DESCRIPTION
Continues #815 (still open — see the end). Follows #830 and #831.

The first call sites actually move: the console's workspace **status** and **pull**, plus
`pullWorkspaceRef`, which is orchestration and therefore belongs on the contract rather than on
simple-git. A cluster-backed workspace now answers the same questions by running git in its own
sandbox; the questions and the answer shapes are unchanged.

## `clean` joins the summary, and the test decides its semantics

The BFF gates on `s.isClean()`, which my summary did not carry. Locally `clean` now comes from
**simple-git's own `isClean()`** rather than being re-derived, so the local answer stays
authoritative. Remotely it is derived — and the parity test is what establishes the two agree,
across clean, dirty and **conflicted** trees.

The conflicted case is the one that matters: unmerged records were dropped entirely two
revisions ago, which made a conflicted workspace report clean. I deliberately did not assert my
belief about `isClean()`'s semantics and then implement to it; I took the local value from
simple-git and let a real repository tell me whether the remote derivation matched.

## One existing test broke, and the fix runs against instinct

Its mock returned only simple-git's `latest`, while the runner reads `all`. Real simple-git
populates **both**, so the mock described a response simple-git never returns. I fixed the mock
to match simple-git rather than bending the code to match the mock — the opposite choice would
have been easier and would have encoded the fake's fiction into the product.

## Verification

126 tests across the BFF, git-injection, contract and lifecycle suites. Typecheck, eslint,
prettier clean.

## Still outstanding on #815

Stated plainly rather than implied, because this issue has now spanned three PRs:

- the remaining `gitFor` sites inside `workspace-manager.ts` (the largest group);
- cancellation through the shim path, so a timed-out remote git child cannot retain
  `index.lock` into the next session's pull;
- the production shim's non-ACP `exec` handler;
- **sandbox-side enforcement of the declared subcommand inventory** — the one I would most want
  before this runs anywhere real, since a closed inventory only means something if the far side
  is what enforces it.
