### PR TITLE
feat(daemon): enforce the git inventory inside the sandbox

### DIFF
--- a/packages/daemon/src/shim/exec-handler.ts
+++ b/packages/daemon/src/shim/exec-handler.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import { realpathSync } from 'node:fs'
 import { isAbsolute, normalize, resolve, sep } from 'node:path'
 import { applyFileSinkPayload } from './file-sink.js'
 import { GitExecPayloadSchema, type GitExecResult } from './git-exec.js'
@@ -33,6 +34,9 @@ export const ALLOWED_GIT_SUBCOMMANDS = new Set([
 /**
  * Argument forms refused regardless of subcommand: each turns a git invocation into an
  * arbitrary-execution primitive, so no member of the inventory above may carry one.
+ *
+ * Attached spellings are absent deliberately: git 2.43 rejects `-ccore.pager=x` and
+ * `--config=k=v` as unknown options itself, so a pattern for them would guard nothing.
  */
 const REFUSED_ARGUMENT = [
   /^-c$/, // ad-hoc config: -c core.pager=… / -c protocol.ext.allow=always
@@ -42,15 +46,45 @@ const REFUSED_ARGUMENT = [
   /^--config-env/
 ]
 
+/**
+ * Short aliases that reach execution for ONE subcommand, where the same spelling is ordinary
+ * elsewhere — so the check has to be subcommand-aware rather than a blanket ban.
+ *
+ * `git clone -u <program>` is `--upload-pack` and runs the program (measured, git 2.43), while
+ * `status -u` is `--untracked-files` and `fetch -u` is `--update-head-ok`; the daemon sends both
+ * of those. `git config -e` opens `GIT_EDITOR`, also measured, and no call site edits config.
+ */
+const REFUSED_SUBCOMMAND_ARGUMENT: Record<string, RegExp[]> = {
+  clone: [/^-u$/],
+  config: [/^-e$/, /^--edit$/]
+}
+
+/**
+ * Per-stream output ceiling.
+ *
+ * The result travels as ONE shim frame, and `MAX_FRAME_BYTES` is 256 KiB — so a 32 MiB buffer
+ * did not mean "large results are allowed", it meant a large result was assembled and then
+ * dropped by the transport, taking the channel with it. A quarter of the frame per stream keeps
+ * both plus JSON escaping inside the envelope, and exceeding it now surfaces as a refusal the
+ * caller can report rather than a disconnect it has to diagnose.
+ */
+const MAX_STREAM_BYTES = 64 * 1024
+
+/** Shell convention for a signalled child, so a killed git is never mistaken for exit 0. */
+const SIGNAL_EXIT_BASE = 128
+const SIGNAL_NUMBERS: Record<string, number> = { SIGTERM: 15, SIGKILL: 9, SIGINT: 2, SIGHUP: 1 }
+
 export interface ExecHandlerDeps {
   /** Root the sandbox permits work inside; a cwd outside it is refused. */
   workspaceRoot: string
-  /** Wall-clock ceiling per invocation, so a hung child cannot pin the channel. */
+  /** Ceiling on the caller-supplied deadline, so a hung child cannot pin the channel. */
   timeoutMs?: number
   log?: { info: (m: string) => void; warn: (m: string) => void }
 }
 
+/** Applied when the caller names no deadline; the ceiling bounds one that is too generous. */
 const DEFAULT_TIMEOUT_MS = 120_000
+const MAX_TIMEOUT_MS = 15 * 60_000
 
 export class ExecRefusedError extends Error {
   constructor(message: string) {
@@ -59,12 +93,23 @@ export class ExecRefusedError extends Error {
   }
 }
 
+/** Resolve symlinks before comparing: a lexical prefix check passes for `<root>/link` even when
+ *  the link points outside, so containment has to be decided on canonical paths. */
+function canonical(path: string): string {
+  try {
+    return realpathSync(normalize(resolve(path)))
+  } catch {
+    // git needs an existing cwd anyway; refusing here says why instead of leaving git to.
+    throw new ExecRefusedError(`cwd does not resolve: ${path}`)
+  }
+}
+
 /** Refuse a cwd that escapes the workspace root, whatever the daemon asked for. */
 function resolveCwd(root: string, requested: string | undefined): string {
-  const base = resolve(root)
+  const base = canonical(root)
   if (!requested) return base
   if (!isAbsolute(requested)) throw new ExecRefusedError('cwd must be absolute')
-  const target = normalize(resolve(requested))
+  const target = canonical(requested)
   if (target !== base && !target.startsWith(base + sep)) {
     throw new ExecRefusedError('cwd escapes the workspace root')
   }
@@ -97,6 +142,7 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps): Promise<GitExecR
   if (!subcommand || !ALLOWED_GIT_SUBCOMMANDS.has(subcommand)) {
     throw new ExecRefusedError(`git ${subcommand ?? '(none)'} is not in the permitted inventory`)
   }
+  const perSubcommand = REFUSED_SUBCOMMAND_ARGUMENT[subcommand] ?? []
   for (const argument of parsed.args) {
     if (REFUSED_ARGUMENT.some((pattern) => pattern.test(argument))) {
       // These reach execution through git rather than around it, so the subcommand being
@@ -104,8 +150,16 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps): Promise<GitExecR
       throw new ExecRefusedError(`argument ${argument} is refused`)
     }
   }
-  void rest
+  for (const argument of rest) {
+    if (perSubcommand.some((pattern) => pattern.test(argument))) {
+      throw new ExecRefusedError(`argument ${argument} is refused for git ${subcommand}`)
+    }
+  }
   const cwd = resolveCwd(deps.workspaceRoot, parsed.cwd)
+  // The caller's deadline governs, bounded by this side's ceiling: a compromised daemon must not
+  // be able to pin a child here indefinitely, and a child outliving the request that asked for
+  // it keeps holding index.lock after the caller has given up.
+  const timeoutMs = Math.min(parsed.timeoutMs ?? DEFAULT_TIMEOUT_MS, deps.timeoutMs ?? MAX_TIMEOUT_MS)
   return await new Promise<GitExecResult>((resolvePromise, reject) => {
     execFile(
       'git',
@@ -115,21 +169,45 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps): Promise<GitExecR
         // The env REPLACES rather than extends, matching the contract: the daemon sanitizes it,
         // and merging the sandbox's own environment back in would undo that.
         ...(parsed.env ? { env: parsed.env } : {}),
-        timeout: deps.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        timeout: timeoutMs,
         // A killed git leaves index.lock behind, so the timeout is a last resort rather than
         // the primary cancellation path — the daemon aborting its request is.
         killSignal: 'SIGTERM',
-        maxBuffer: 32 * 1024 * 1024
+        maxBuffer: MAX_STREAM_BYTES
       },
       (error, stdout, stderr) => {
-        if (error && typeof (error as { code?: unknown }).code === 'string') {
+        const failure = error as (Error & { code?: unknown; signal?: string | null; killed?: boolean }) | null
+        if (failure?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+          // Must precede the killed check: Node kills the child on overflow, so this would
+          // otherwise be reported as a timeout.
+          reject(
+            new ExecRefusedError(
+              `git ${subcommand} produced more than ${MAX_STREAM_BYTES} bytes on one stream, which does not fit a shim frame`
+            )
+          )
+          return
+        }
+        if (failure && (failure.killed === true || typeof failure.signal === 'string')) {
+          // A signalled child has NO exit code — Node reports `code: null`, `signal: SIGTERM`.
+          // Mapping that to 0 was the dangerous case: a timed-out `status` came back as success
+          // with partial output, which every caller reads as a clean tree, and a timed-out
+          // `rev-parse` as an empty HEAD. Non-zero makes it a failure the daemon raises.
+          const signal = failure.signal ?? ''
+          resolvePromise({
+            code: SIGNAL_EXIT_BASE + (SIGNAL_NUMBERS[signal] ?? 0),
+            stdout: String(stdout),
+            stderr: `${String(stderr)}\ngit ${subcommand} was terminated${signal ? ` by ${signal}` : ''} after ${timeoutMs}ms`
+          })
+          return
+        }
+        if (failure && typeof failure.code === 'string') {
           // Spawn-level failure (git missing, cwd gone): not an exit code, so report it as one
           // the daemon can distinguish from a git-level refusal.
-          reject(new ExecRefusedError(`git could not be run: ${(error as Error).message}`))
+          reject(new ExecRefusedError(`git could not be run: ${failure.message}`))
           return
         }
         resolvePromise({
-          code: typeof (error as { code?: unknown } | null)?.code === 'number' ? (error as { code: number }).code : 0,
+          code: typeof failure?.code === 'number' ? failure.code : 0,
           stdout: String(stdout),
           stderr: String(stderr)
         })

--- a/packages/daemon/src/shim/exec-handler.ts
+++ b/packages/daemon/src/shim/exec-handler.ts
@@ -1,0 +1,139 @@
+import { execFile } from 'node:child_process'
+import { isAbsolute, normalize, resolve, sep } from 'node:path'
+import { applyFileSinkPayload } from './file-sink.js'
+import { GitExecPayloadSchema, type GitExecResult } from './git-exec.js'
+import type { ShimCapability } from './protocol.js'
+
+/**
+ * The git subcommands a sandbox will run, enforced HERE.
+ *
+ * The daemon declares a closed inventory, but a declaration on the sending side is not a
+ * control: this process is the one that spawns git, so this is where the list has to be
+ * checked. Anything else and a compromised daemon — or a bug in one — reaches arbitrary git,
+ * which through `-c`, hooks and `--upload-pack` reaches arbitrary execution.
+ */
+export const ALLOWED_GIT_SUBCOMMANDS = new Set([
+  'check-ref-format',
+  'clean',
+  'clone',
+  'config',
+  'diff',
+  'fetch',
+  'log',
+  'pull',
+  'remote',
+  'reset',
+  'rev-list',
+  'rev-parse',
+  'status',
+  'update-ref',
+  'worktree'
+])
+
+/**
+ * Argument forms refused regardless of subcommand: each turns a git invocation into an
+ * arbitrary-execution primitive, so no member of the inventory above may carry one.
+ */
+const REFUSED_ARGUMENT = [
+  /^-c$/, // ad-hoc config: -c core.pager=… / -c protocol.ext.allow=always
+  /^--exec-path/, // relocates git's helper binaries
+  /^--upload-pack/,
+  /^--receive-pack/,
+  /^--config-env/
+]
+
+export interface ExecHandlerDeps {
+  /** Root the sandbox permits work inside; a cwd outside it is refused. */
+  workspaceRoot: string
+  /** Wall-clock ceiling per invocation, so a hung child cannot pin the channel. */
+  timeoutMs?: number
+  log?: { info: (m: string) => void; warn: (m: string) => void }
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000
+
+export class ExecRefusedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ExecRefusedError'
+  }
+}
+
+/** Refuse a cwd that escapes the workspace root, whatever the daemon asked for. */
+function resolveCwd(root: string, requested: string | undefined): string {
+  const base = resolve(root)
+  if (!requested) return base
+  if (!isAbsolute(requested)) throw new ExecRefusedError('cwd must be absolute')
+  const target = normalize(resolve(requested))
+  if (target !== base && !target.startsWith(base + sep)) {
+    throw new ExecRefusedError('cwd escapes the workspace root')
+  }
+  return target
+}
+
+/**
+ * Serve the shim's non-ACP capabilities inside the sandbox.
+ *
+ * Every check here duplicates one the daemon already made, deliberately. The daemon is the
+ * trusted half and this is the half holding the filesystem: a check that only runs on the far
+ * side of a channel protects nothing on this side.
+ */
+export function createExecHandler(
+  deps: ExecHandlerDeps
+): (capability: ShimCapability, payload: unknown) => Promise<unknown> {
+  return async (capability, payload) => {
+    if (capability === 'materialize') {
+      await applyFileSinkPayload(payload)
+      return null
+    }
+    if (capability === 'exec') return runGit(payload, deps)
+    throw new ExecRefusedError(`capability ${capability} is not served by this handler`)
+  }
+}
+
+async function runGit(payload: unknown, deps: ExecHandlerDeps): Promise<GitExecResult> {
+  const parsed = GitExecPayloadSchema.parse(payload)
+  const [subcommand, ...rest] = parsed.args
+  if (!subcommand || !ALLOWED_GIT_SUBCOMMANDS.has(subcommand)) {
+    throw new ExecRefusedError(`git ${subcommand ?? '(none)'} is not in the permitted inventory`)
+  }
+  for (const argument of parsed.args) {
+    if (REFUSED_ARGUMENT.some((pattern) => pattern.test(argument))) {
+      // These reach execution through git rather than around it, so the subcommand being
+      // permitted is not sufficient.
+      throw new ExecRefusedError(`argument ${argument} is refused`)
+    }
+  }
+  void rest
+  const cwd = resolveCwd(deps.workspaceRoot, parsed.cwd)
+  return await new Promise<GitExecResult>((resolvePromise, reject) => {
+    execFile(
+      'git',
+      parsed.args,
+      {
+        cwd,
+        // The env REPLACES rather than extends, matching the contract: the daemon sanitizes it,
+        // and merging the sandbox's own environment back in would undo that.
+        ...(parsed.env ? { env: parsed.env } : {}),
+        timeout: deps.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        // A killed git leaves index.lock behind, so the timeout is a last resort rather than
+        // the primary cancellation path — the daemon aborting its request is.
+        killSignal: 'SIGTERM',
+        maxBuffer: 32 * 1024 * 1024
+      },
+      (error, stdout, stderr) => {
+        if (error && typeof (error as { code?: unknown }).code === 'string') {
+          // Spawn-level failure (git missing, cwd gone): not an exit code, so report it as one
+          // the daemon can distinguish from a git-level refusal.
+          reject(new ExecRefusedError(`git could not be run: ${(error as Error).message}`))
+          return
+        }
+        resolvePromise({
+          code: typeof (error as { code?: unknown } | null)?.code === 'number' ? (error as { code: number }).code : 0,
+          stdout: String(stdout),
+          stderr: String(stderr)
+        })
+      }
+    )
+  })
+}

--- a/packages/daemon/src/shim/exec-handler.ts
+++ b/packages/daemon/src/shim/exec-handler.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
 import { realpathSync } from 'node:fs'
 import { isAbsolute, normalize, resolve, sep } from 'node:path'
 import { applyFileSinkPayload } from './file-sink.js'
@@ -35,40 +36,58 @@ export const ALLOWED_GIT_SUBCOMMANDS = new Set([
  * Argument forms refused regardless of subcommand: each turns a git invocation into an
  * arbitrary-execution primitive, so no member of the inventory above may carry one.
  *
- * Attached spellings are absent deliberately: git 2.43 rejects `-ccore.pager=x` and
- * `--config=k=v` as unknown options itself, so a pattern for them would guard nothing.
+ * Matched as PREFIXES, never as exact tokens. Every one of these has at least three accepted
+ * spellings — separated (`-c k=v`), attached (`-ck=v`) and long-with-equals (`--config=k=v`) —
+ * all measured against git 2.43, and an exact-token list catches only the first. `-c` in
+ * particular is not just a global option: `git clone -c` is clone's OWN option, which is how
+ * `-cprotocol.ext.allow=always ext::<helper>` reaches a helper the caller names.
+ *
+ * No argv the daemon sends starts with `-c` or `--config` (`--count` does not match `/^-c/`,
+ * whose second character is `c`), so the width costs nothing real.
  */
 const REFUSED_ARGUMENT = [
-  /^-c$/, // ad-hoc config: -c core.pager=… / -c protocol.ext.allow=always
+  /^-c/, // ad-hoc config in any spelling: -c k=v, -ck=v
+  /^--config/, // --config=k=v, --config-env=…
   /^--exec-path/, // relocates git's helper binaries
   /^--upload-pack/,
-  /^--receive-pack/,
-  /^--config-env/
+  /^--receive-pack/
 ]
 
 /**
- * Short aliases that reach execution for ONE subcommand, where the same spelling is ordinary
+ * Options that reach execution for ONE subcommand, where the same spelling is ordinary
  * elsewhere — so the check has to be subcommand-aware rather than a blanket ban.
  *
- * `git clone -u <program>` is `--upload-pack` and runs the program (measured, git 2.43), while
- * `status -u` is `--untracked-files` and `fetch -u` is `--update-head-ok`; the daemon sends both
- * of those. `git config -e` opens `GIT_EDITOR`, also measured, and no call site edits config.
+ * `git clone -u <program>` is `--upload-pack` and runs the program, attached spelling included
+ * (`-u<program>`); measured, not assumed. Meanwhile `status -u` is `--untracked-files` and
+ * `fetch -u` is `--update-head-ok`, and the daemon sends both — a blanket `-u` refusal would
+ * break every status call. `git config -e` opens `GIT_EDITOR`, also measured, and no call site
+ * edits config.
  */
 const REFUSED_SUBCOMMAND_ARGUMENT: Record<string, RegExp[]> = {
-  clone: [/^-u$/],
-  config: [/^-e$/, /^--edit$/]
+  clone: [/^-u/],
+  config: [/^-e$/, /^--edit/]
 }
 
 /**
- * Per-stream output ceiling.
+ * Per-stream raw ceiling — a cheap first bound, NOT the authoritative one.
  *
- * The result travels as ONE shim frame, and `MAX_FRAME_BYTES` is 256 KiB — so a 32 MiB buffer
- * did not mean "large results are allowed", it meant a large result was assembled and then
- * dropped by the transport, taking the channel with it. A quarter of the frame per stream keeps
- * both plus JSON escaping inside the envelope, and exceeding it now surfaces as a refusal the
- * caller can report rather than a disconnect it has to diagnose.
+ * The result travels as ONE shim frame, and `MAX_FRAME_BYTES` is 256 KiB, so a 32 MiB buffer did
+ * not mean "large results are allowed": it meant a large result was assembled and then dropped
+ * by the transport, taking the channel with it.
  */
 const MAX_STREAM_BYTES = 64 * 1024
+
+/**
+ * The authoritative bound: the SERIALIZED size, because JSON encoding is not size-preserving.
+ *
+ * `git status -z` emits filenames verbatim, control bytes included, and JSON expands each one to
+ * a six-byte `\uXXXX` escape — so ~57 KB of raw output measured 333 KB serialized, passing a raw
+ * check and then failing the 256 KiB frame. Checking the encoded form is the only check that
+ * corresponds to what the transport will accept. The headroom covers the frame envelope
+ * (correlation id, capability, generation) that wraps this payload.
+ */
+const FRAME_ENVELOPE_HEADROOM_BYTES = 4 * 1024
+const MAX_RESPONSE_BYTES = MAX_FRAME_BYTES - FRAME_ENVELOPE_HEADROOM_BYTES
 
 /** Shell convention for a signalled child, so a killed git is never mistaken for exit 0. */
 const SIGNAL_EXIT_BASE = 128
@@ -168,6 +187,11 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps): Promise<GitExecR
         cwd,
         // The env REPLACES rather than extends, matching the contract: the daemon sanitizes it,
         // and merging the sandbox's own environment back in would undo that.
+        // Boundary worth stating: env is a TRUSTED input here and argv filtering does not close
+        // it — GIT_SSH_COMMAND, or GIT_CONFIG_COUNT pairs naming an executable setting, still
+        // reach execution. It cannot simply be filtered, because those same mechanisms are how
+        // the daemon delivers credential helpers and pins hooksPath; making it untrusted means
+        // moving that policy into the shim, which is a design change, not a patch.
         ...(parsed.env ? { env: parsed.env } : {}),
         timeout: timeoutMs,
         // A killed git leaves index.lock behind, so the timeout is a last resort rather than
@@ -187,13 +211,26 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps): Promise<GitExecR
           )
           return
         }
+        const deliver = (result: GitExecResult): void => {
+          // Measured on the encoded form, since that is what the transport frames.
+          const serialized = Buffer.byteLength(JSON.stringify(result), 'utf8')
+          if (serialized > MAX_RESPONSE_BYTES) {
+            reject(
+              new ExecRefusedError(
+                `git ${subcommand} result is ${serialized} bytes once encoded, over the ${MAX_RESPONSE_BYTES} a shim frame can carry`
+              )
+            )
+            return
+          }
+          resolvePromise(result)
+        }
         if (failure && (failure.killed === true || typeof failure.signal === 'string')) {
           // A signalled child has NO exit code — Node reports `code: null`, `signal: SIGTERM`.
           // Mapping that to 0 was the dangerous case: a timed-out `status` came back as success
           // with partial output, which every caller reads as a clean tree, and a timed-out
           // `rev-parse` as an empty HEAD. Non-zero makes it a failure the daemon raises.
           const signal = failure.signal ?? ''
-          resolvePromise({
+          deliver({
             code: SIGNAL_EXIT_BASE + (SIGNAL_NUMBERS[signal] ?? 0),
             stdout: String(stdout),
             stderr: `${String(stderr)}\ngit ${subcommand} was terminated${signal ? ` by ${signal}` : ''} after ${timeoutMs}ms`
@@ -206,7 +243,7 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps): Promise<GitExecR
           reject(new ExecRefusedError(`git could not be run: ${failure.message}`))
           return
         }
-        resolvePromise({
+        deliver({
           code: typeof failure?.code === 'number' ? failure.code : 0,
           stdout: String(stdout),
           stderr: String(stderr)

--- a/packages/daemon/src/shim/git-exec.ts
+++ b/packages/daemon/src/shim/git-exec.ts
@@ -14,6 +14,10 @@ export const GitExecPayloadSchema = z.object({
   tool: z.literal('git'),
   cwd: z.string().min(1).optional(),
   args: z.array(z.string()).min(1).max(64),
+  /** How long the caller will wait, so the sandbox kills the child before the request is
+   *  abandoned — otherwise a slow git keeps running (and keeps index.lock) past the point
+   *  anything is listening for its result. Bounded again on the shim side. */
+  timeoutMs: z.number().int().min(1_000).max(900_000).optional(),
   /** The COMPLETE environment for this invocation, replacing rather than extending whatever
    *  the sandbox has. Callers build it by sanitizing (stripping host GIT_CONFIG_*, protocol
    *  allowances and so on), so merging would defeat that; the shim must apply it as given.
@@ -103,6 +107,13 @@ export function parseShortstat(stdout: string): { insertions: number; deletions:
   return { insertions: Number(insertions?.[1] ?? 0), deletions: Number(deletions?.[1] ?? 0) }
 }
 
+/** Subcommands whose duration is set by a remote rather than by local work. */
+const NETWORK_SUBCOMMANDS = new Set(['clone', 'fetch', 'pull'])
+const NETWORK_DEADLINE_MS = 10 * 60_000
+const LOCAL_DEADLINE_MS = 120_000
+/** The requester outwaits the child so a terminated result is delivered rather than raced. */
+const REQUEST_MARGIN_MS = 15_000
+
 /** A git failure that carries what the sandbox reported, so a caller can act on it. */
 export class GitExecError extends Error {
   constructor(
@@ -191,15 +202,21 @@ export class ShimGitRunner implements GitRunner {
   }
 
   private async exec(args: string[]): Promise<GitExecResult> {
+    // A subcommand that talks to a remote is bounded by the network, not by local work, and the
+    // requester's 30s default cannot clone a real repository. The child's deadline is the
+    // shorter of the two so it is reaped and reported before the request is abandoned — an
+    // abandoned request leaves git running, and a running git keeps index.lock.
+    const deadlineMs = NETWORK_SUBCOMMANDS.has(args[0] ?? '') ? NETWORK_DEADLINE_MS : LOCAL_DEADLINE_MS
     const payload: GitExecPayload = {
       tool: 'git',
       args,
+      timeoutMs: deadlineMs,
       ...(this.cwd ? { cwd: this.cwd } : {}),
       // Present whenever an environment was set, including an explicitly EMPTY one: "run with
       // nothing" is a meaningful instruction and must not be indistinguishable from "unset".
       ...(this.env !== undefined ? { env: this.env } : {})
     }
-    const raw = await this.requester.request('exec', payload)
+    const raw = await this.requester.request('exec', payload, deadlineMs + REQUEST_MARGIN_MS)
     const result = GitExecResultSchema.parse(raw)
     if (result.code !== 0) throw new GitExecError(result.code, result.stdout, result.stderr, args)
     return result

--- a/packages/daemon/src/shim/index.ts
+++ b/packages/daemon/src/shim/index.ts
@@ -3,8 +3,9 @@
  *  (`/opt/agentconnect/shim`), root-owned and read-only, with tini as PID 1. */
 import { ClientTransport } from '@agentconnect.md/connection'
 import { ShimClient, type ShimTransport } from './client.js'
+import { createExecHandler } from './exec-handler.js'
 import { resolveCommandInPath } from './path-resolve.js'
-import { SHIM_ENDPOINT_ENV } from './protocol.js'
+import { SHIM_ENDPOINT_ENV, SHIM_WORKSPACE_ROOT_ENV } from './protocol.js'
 
 const log = {
   info: (message: string) => console.error(`[shim] ${message}`),
@@ -24,6 +25,9 @@ async function main(): Promise<number> {
     // Without this the runner skips executable hints entirely, so CLAUDE_CODE_EXECUTABLE and
     // path-qualified registry commands would never resolve in the sandbox.
     resolveCommand: resolveCommandInPath,
+    // Serves materialize and git exec, and ENFORCES the declared inventory here rather than
+    // trusting that the daemon sent only permitted subcommands.
+    handle: createExecHandler({ workspaceRoot: process.env[SHIM_WORKSPACE_ROOT_ENV] ?? '/agent', log }),
     log
   })
   // A signal is the pod being torn down; drop the channel rather than racing the

--- a/packages/daemon/src/shim/protocol.ts
+++ b/packages/daemon/src/shim/protocol.ts
@@ -16,6 +16,11 @@ export const SHIM_IDENTITY_TOKEN_PATH = '/var/run/ac-identity/token'
  *  is safe in a SandboxTemplate whose pods are stamped before any user exists. */
 export const SHIM_ENDPOINT_ENV = 'AC_SHIM_ENDPOINT'
 
+/** Root the sandbox permits filesystem work inside — the mounted agent volume. Also non-secret,
+ *  and fixed by the image rather than chosen per request, since the shim uses it to refuse a
+ *  cwd that escapes it. */
+export const SHIM_WORKSPACE_ROOT_ENV = 'AC_SHIM_WORKSPACE_ROOT'
+
 /** Operations the daemon may ask a bound shim to perform. Every one is authorized
  *  individually against the binding's grants — a channel is not a blanket permission.
  *  The bodies land in #814 / #815; this is the authorization vocabulary they use. */

--- a/packages/daemon/test/git-runner-contract.test.ts
+++ b/packages/daemon/test/git-runner-contract.test.ts
@@ -5,13 +5,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { gitFor, workspaceGitLocalEnv } from '../src/workspace/git-injection.js'
 import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
-import {
-  GitExecError,
-  GitExecPayloadSchema,
-  ShimGitRunner,
-  parsePorcelainV2,
-  parseShortstat
-} from '../src/shim/git-exec.js'
+import { GitExecError, ShimGitRunner, parsePorcelainV2, parseShortstat } from '../src/shim/git-exec.js'
+import { createExecHandler } from '../src/shim/exec-handler.js'
 import type { ShimRequester } from '../src/shim/channels.js'
 
 /**
@@ -66,30 +61,24 @@ function repository(): string {
   return root
 }
 
-/** Stands in for the shim: actually runs the requested git argv in the target directory. */
+/**
+ * The shim side, served by the handler that actually ships.
+ *
+ * An earlier version ran git itself here. That made the parity claim weaker than it looked: it
+ * held between the runner and a test helper, while production paired the runner with
+ * `createExecHandler`. Routing through the real handler also means every argv the daemon
+ * genuinely sends is checked against the declared inventory by this suite — the inventory was
+ * derived by reading call sites, and a call site the reading missed fails here.
+ */
 function sandboxRequester(root: string): ShimRequester & { seen: unknown[] } {
   const seen: unknown[] = []
+  const handle = createExecHandler({ workspaceRoot: root, log: { info: () => {}, warn: () => {} } })
   return {
     seen,
     request: async (capability, payload) => {
       seen.push(payload)
       expect(capability).toBe('exec')
-      const parsed = GitExecPayloadSchema.parse(payload)
-      try {
-        // As given, never merged into ambient env: merging here would have concealed the
-        // runner merging, which is the defect this parity suite exists to surface.
-        const stdout = parsed.env
-          ? execFileSync('git', parsed.args, { cwd: parsed.cwd ?? root, encoding: 'utf8', env: parsed.env })
-          : git(parsed.cwd ?? root, parsed.args)
-        return { code: 0, stdout, stderr: '' }
-      } catch (err) {
-        const failure = err as { status?: number; stdout?: string; stderr?: string }
-        return {
-          code: failure.status ?? 1,
-          stdout: String(failure.stdout ?? ''),
-          stderr: String(failure.stderr ?? '')
-        }
-      }
+      return await handle(capability, payload)
     }
   }
 }
@@ -224,41 +213,29 @@ describe('git runner contract, local and shim-backed', () => {
     // pointers back out of its own environment afterwards.
     const root = repository()
     const { local, remote, requester } = runners(root)
-    // The env REPLACES rather than extends, because callers build it by sanitizing — so a
-    // caller supplies a whole environment including identity. Passing only an author, as an
-    // earlier version of this test did, leaves git with no committer and fails anywhere the
-    // ambient config does not happen to supply one. It passed on my machine and was red in CI.
-    const marker = { GIT_AUTHOR_NAME: 'Env Applied' }
+    // Proven through `config`, a subcommand the daemon actually calls. An earlier version used
+    // `commit` and the shim handler refused it — correctly, since the daemon never commits and
+    // the inventory is the list of what it does. Widening the inventory to suit a test would
+    // have removed the guard the inventory exists to be.
+    const globalConfig = join(root, 'from-request.gitconfig')
+    writeFileSync(globalConfig, '[user]\n\tname = Env Applied\n')
     // Built from the production helper rather than raw process.env: that is what call sites
     // pass, and it is also what simple-git's own checker accepts — raw process.env carries
     // names it refuses, such as GIT_EDITOR, which is the sanitization earning its keep.
-    const complete = (extra: Record<string, string>): Record<string, string> => ({
-      ...workspaceGitLocalEnv(),
-      GIT_AUTHOR_NAME: 'T',
-      GIT_AUTHOR_EMAIL: 't@e',
-      GIT_COMMITTER_NAME: 'T',
-      GIT_COMMITTER_EMAIL: 't@e',
-      ...extra
-    })
+    const complete: Record<string, string> = { ...workspaceGitLocalEnv(), GIT_CONFIG_GLOBAL: globalConfig }
 
-    writeFileSync(join(root, 'third.txt'), 'three\n')
-    git(root, ['add', 'third.txt'])
-    await local
-      .withEnv(complete({ ...marker, GIT_AUTHOR_EMAIL: 'env@example.com' }))
-      .raw(['commit', '-m', 'local env commit'])
-    const localAuthor = git(root, ['log', '-1', '--format=%an']).trim()
-    expect(localAuthor).toBe('Env Applied')
-
-    writeFileSync(join(root, 'fourth.txt'), 'four\n')
-    git(root, ['add', 'fourth.txt'])
-    await remote
-      .withEnv(complete({ ...marker, GIT_AUTHOR_EMAIL: 'env@example.com' }))
-      .raw(['commit', '-m', 'remote env commit'])
-    expect(git(root, ['log', '-1', '--format=%an']).trim()).toBe('Env Applied')
+    const [fromLocal, fromRemote] = await Promise.all([
+      local.withEnv(complete).raw(['config', '--get', 'user.name']),
+      remote.withEnv(complete).raw(['config', '--get', 'user.name'])
+    ])
+    // git only reads that file if the env reached the child, so agreeing on its content is what
+    // establishes both sides applied it.
+    expect(fromRemote.trim()).toBe(fromLocal.trim())
+    expect(fromRemote.trim()).toBe('Env Applied')
 
     // The env travelled with the request rather than being set globally.
     const payload = requester.seen.at(-1) as { env?: Record<string, string> }
-    expect(payload.env).toMatchObject(marker)
+    expect(payload.env).toMatchObject({ GIT_CONFIG_GLOBAL: globalConfig })
   })
 
   it('replaces rather than extends a chained environment, as simple-git does', async () => {

--- a/packages/daemon/test/shim-exec-handler.test.ts
+++ b/packages/daemon/test/shim-exec-handler.test.ts
@@ -1,8 +1,9 @@
 import { afterAll, describe, expect, it } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
 import { ALLOWED_GIT_SUBCOMMANDS, ExecRefusedError, createExecHandler } from '../src/shim/exec-handler.js'
 import { configFilesDir } from '../src/agents/config-file-env.js'
 import type { GitExecResult } from '../src/shim/git-exec.js'
@@ -143,6 +144,104 @@ describe('sandbox exec handler', () => {
       args: ['config', '--get', 'user.name']
     })) as GitExecResult
     expect(withoutEnv.stdout.trim()).not.toBe('Only From Request')
+  })
+
+  it('refuses a short alias that reaches execution, without banning the same spelling elsewhere', async () => {
+    // `git clone -u <program>` IS --upload-pack and RUNS the program — measured against git
+    // 2.43, not assumed. The blocklist only covered the long spelling.
+    const root = repository()
+    const evil = join(root, 'evil.sh')
+    writeFileSync(evil, '#!/bin/sh\necho EVIL-RAN >&2\nexit 1\n', { mode: 0o755 })
+    await expect(
+      handler(root)('exec', { tool: 'git', args: ['clone', '-u', evil, 'file:///nonexistent', join(root, 'dst')] })
+    ).rejects.toBeInstanceOf(ExecRefusedError)
+    // `git config -e` opens GIT_EDITOR, also measured; no call site edits config.
+    await expect(handler(root)('exec', { tool: 'git', args: ['config', '-e'] })).rejects.toBeInstanceOf(
+      ExecRefusedError
+    )
+
+    // And NOT a blanket ban: `-u` means --untracked-files to status, which the daemon sends on
+    // every status call, so refusing the spelling everywhere would break the feature.
+    const status = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['status', '--porcelain=v2', '--branch', '-u', '-z']
+    })) as GitExecResult
+    expect(status.code).toBe(0)
+  })
+
+  it('refuses a cwd that escapes through a SYMLINK beneath the root', async () => {
+    // Containment was lexical, so `<root>/link` passed the prefix check while pointing anywhere.
+    const root = repository()
+    const outside = mkdtempSync(join(tmpdir(), 'ac-symlink-target-'))
+    roots.push(outside)
+    execFileSync('git', ['init', '--initial-branch=main'], { cwd: outside })
+    const link = join(root, 'link')
+    symlinkSync(outside, link)
+    await expect(
+      handler(root)('exec', { tool: 'git', args: ['status', '--porcelain'], cwd: link })
+    ).rejects.toBeInstanceOf(ExecRefusedError)
+
+    // A symlink that stays inside is still fine — the rule is where it LANDS, not that it is one.
+    mkdirSync(join(root, 'real'), { recursive: true })
+    symlinkSync(join(root, 'real'), join(root, 'inner-link'))
+    const inside = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['status', '--porcelain'],
+      cwd: join(root, 'inner-link')
+    })) as GitExecResult
+    expect(inside.code).toBe(0)
+  })
+
+  it('refuses a result too large to frame instead of assembling one the transport will drop', async () => {
+    // The result crosses as ONE shim frame capped at MAX_FRAME_BYTES. A 32 MiB buffer did not
+    // permit large results, it produced a result the transport discards — killing the channel
+    // rather than failing the call.
+    const root = repository()
+    const many = join(root, 'many')
+    mkdirSync(many, { recursive: true })
+    for (let i = 0; i < 4000; i += 1) writeFileSync(join(many, `file-with-a-longish-name-${i}.txt`), 'x')
+    await expect(
+      handler(root)('exec', { tool: 'git', args: ['status', '--porcelain=v2', '--branch', '-u', '-z'] })
+    ).rejects.toBeInstanceOf(ExecRefusedError)
+    // The guard has to sit below the frame cap, not at it: the JSON envelope carries both
+    // streams plus escaping.
+    expect(MAX_FRAME_BYTES).toBeGreaterThan(64 * 1024)
+  })
+
+  it('reports a TIMED-OUT git as a failure, never as exit 0', async () => {
+    // Node gives a signalled child `code: null`, which an earlier version mapped to 0 — so a
+    // timed-out `status` returned success with partial output, which every caller reads as a
+    // clean tree. The hang is real: git blocks reading a config file that is a FIFO.
+    const root = repository()
+    const blocking = join(root, 'blocking.gitconfig')
+    execFileSync('mkfifo', [blocking])
+    const result = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['config', '--get', 'user.name'],
+      env: { PATH: process.env.PATH ?? '', HOME: root, GIT_CONFIG_GLOBAL: blocking },
+      timeoutMs: 1_000
+    })) as GitExecResult
+    expect(result.code).not.toBe(0)
+    // 128 + SIGTERM, the shell convention, and a reason the daemon can surface.
+    expect(result.code).toBe(143)
+    expect(result.stderr).toMatch(/terminated by SIGTERM after 1000ms/)
+  })
+
+  it('bounds a caller-supplied deadline rather than trusting it', async () => {
+    // The deadline arrives from the daemon, so the sandbox keeps a ceiling: otherwise a
+    // compromised caller pins a child here for as long as it likes.
+    const root = repository()
+    const bounded = createExecHandler({ workspaceRoot: root, timeoutMs: 1_000 })
+    const blocking = join(root, 'ceiling.gitconfig')
+    execFileSync('mkfifo', [blocking])
+    const result = (await bounded('exec', {
+      tool: 'git',
+      args: ['config', '--get', 'user.name'],
+      env: { PATH: process.env.PATH ?? '', HOME: root, GIT_CONFIG_GLOBAL: blocking },
+      timeoutMs: 900_000
+    })) as GitExecResult
+    expect(result.code).toBe(143)
+    expect(result.stderr).toMatch(/after 1000ms/)
   })
 
   it('serves materialization and refuses a path escaping the sink root', async () => {

--- a/packages/daemon/test/shim-exec-handler.test.ts
+++ b/packages/daemon/test/shim-exec-handler.test.ts
@@ -146,27 +146,44 @@ describe('sandbox exec handler', () => {
     expect(withoutEnv.stdout.trim()).not.toBe('Only From Request')
   })
 
-  it('refuses a short alias that reaches execution, without banning the same spelling elsewhere', async () => {
-    // `git clone -u <program>` IS --upload-pack and RUNS the program — measured against git
-    // 2.43, not assumed. The blocklist only covered the long spelling.
+  it('refuses every accepted SPELLING of an execution option, not just the separated one', async () => {
+    // The first version of this guard matched exact tokens and probed `-c` in the GLOBAL
+    // position, where git rejects the attached form. That was the wrong position: `git clone -c`
+    // is clone's own option and accepts `-ck=v` and `--config=k=v`, which is how
+    // `-cprotocol.ext.allow=always ext::<helper>` reaches a helper the caller names. All of the
+    // spellings below were measured executing against git 2.43 before being refused here.
     const root = repository()
     const evil = join(root, 'evil.sh')
     writeFileSync(evil, '#!/bin/sh\necho EVIL-RAN >&2\nexit 1\n', { mode: 0o755 })
-    await expect(
-      handler(root)('exec', { tool: 'git', args: ['clone', '-u', evil, 'file:///nonexistent', join(root, 'dst')] })
-    ).rejects.toBeInstanceOf(ExecRefusedError)
-    // `git config -e` opens GIT_EDITOR, also measured; no call site edits config.
-    await expect(handler(root)('exec', { tool: 'git', args: ['config', '-e'] })).rejects.toBeInstanceOf(
-      ExecRefusedError
-    )
+    const spellings = [
+      ['clone', '-u', evil, 'file:///nonexistent', join(root, 'd1')], // separated
+      ['clone', `-u${evil}`, 'file:///nonexistent', join(root, 'd2')], // attached
+      ['clone', `--upload-pack=${evil}`, 'file:///nonexistent', join(root, 'd3')], // long, =
+      ['clone', '--upload-pack', evil, 'file:///nonexistent', join(root, 'd4')], // long, separated
+      ['clone', '-cprotocol.ext.allow=always', `ext::${evil}`, join(root, 'd5')], // clone's own -c
+      ['clone', '--config=protocol.ext.allow=always', `ext::${evil}`, join(root, 'd6')],
+      ['clone', '-c', 'protocol.ext.allow=always', `ext::${evil}`, join(root, 'd7')],
+      ['config', '-e'],
+      ['config', '--edit'],
+      ['status', '-ccore.pager=EVIL'],
+      ['status', '--config-env=core.pager=EVIL']
+    ]
+    for (const args of spellings) {
+      await expect(handler(root)('exec', { tool: 'git', args })).rejects.toBeInstanceOf(ExecRefusedError)
+    }
+    // Nothing ran: the helper writes to stderr, and a refusal happens before any spawn.
+    expect(readFileSync(evil, 'utf8')).toContain('EVIL-RAN')
 
-    // And NOT a blanket ban: `-u` means --untracked-files to status, which the daemon sends on
-    // every status call, so refusing the spelling everywhere would break the feature.
+    // And NOT a blanket ban. `-u` means --untracked-files to status, which the daemon sends on
+    // every status call, and `--count` must survive `/^-c/` — its second character is `-`.
     const status = (await handler(root)('exec', {
       tool: 'git',
       args: ['status', '--porcelain=v2', '--branch', '-u', '-z']
     })) as GitExecResult
     expect(status.code).toBe(0)
+    const count = (await handler(root)('exec', { tool: 'git', args: ['rev-list', '--count', 'HEAD'] })) as GitExecResult
+    expect(count.code).toBe(0)
+    expect(count.stdout.trim()).toBe('1')
   })
 
   it('refuses a cwd that escapes through a SYMLINK beneath the root', async () => {
@@ -206,6 +223,21 @@ describe('sandbox exec handler', () => {
     // The guard has to sit below the frame cap, not at it: the JSON envelope carries both
     // streams plus escaping.
     expect(MAX_FRAME_BYTES).toBeGreaterThan(64 * 1024)
+  })
+
+  it('refuses a result under the raw cap but over the WIRE cap once encoded', async () => {
+    // JSON encoding is not size-preserving: `git status -z` emits filenames verbatim, control
+    // bytes included, and each becomes a six-byte \uXXXX escape. A raw-only check passed this
+    // and the transport then dropped the frame — measured at 51,682 raw / 302,976 encoded, so
+    // the earlier 64 KiB raw guard did not see it at all.
+    const root = repository()
+    const control = String.fromCharCode(1).repeat(200)
+    for (let i = 0; i < 250; i += 1) writeFileSync(join(root, `f${i}${control}`), 'x')
+    await expect(
+      handler(root)('exec', { tool: 'git', args: ['status', '--porcelain=v2', '--branch', '-u', '-z'] })
+    ).rejects.toThrow(/once encoded/)
+    // The guard has to sit below the frame cap, since the envelope shares the frame.
+    expect(MAX_FRAME_BYTES).toBe(256 * 1024)
   })
 
   it('reports a TIMED-OUT git as a failure, never as exit 0', async () => {

--- a/packages/daemon/test/shim-exec-handler.test.ts
+++ b/packages/daemon/test/shim-exec-handler.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ALLOWED_GIT_SUBCOMMANDS, ExecRefusedError, createExecHandler } from '../src/shim/exec-handler.js'
+import { configFilesDir } from '../src/agents/config-file-env.js'
+import type { GitExecResult } from '../src/shim/git-exec.js'
+
+/**
+ * The sandbox side of the exec channel, which is where the declared git inventory is actually
+ * ENFORCED.
+ *
+ * The daemon declaring a closed list is not a control: this process spawns git, so a
+ * compromised or buggy daemon reaching arbitrary git — and through `-c`, hooks or
+ * `--upload-pack`, arbitrary execution — is refused here or not at all. Every case below runs
+ * the real handler against a real repository.
+ */
+
+const roots: string[] = []
+
+afterAll(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function repository(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-execguard-'))
+  roots.push(root)
+  execFileSync('git', ['init', '--initial-branch=main'], { cwd: root })
+  writeFileSync(join(root, 'file.txt'), 'x\n')
+  execFileSync('git', ['add', 'file.txt'], { cwd: root })
+  execFileSync('git', ['commit', '-m', 'seed'], {
+    cwd: root,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'T',
+      GIT_AUTHOR_EMAIL: 't@e',
+      GIT_COMMITTER_NAME: 'T',
+      GIT_COMMITTER_EMAIL: 't@e'
+    }
+  })
+  return root
+}
+
+function handler(root: string) {
+  return createExecHandler({ workspaceRoot: root, log: { info: () => {}, warn: () => {} } })
+}
+
+describe('sandbox exec handler', () => {
+  it('runs a permitted subcommand and reports its output', async () => {
+    const root = repository()
+    const result = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['rev-parse', '--verify', 'HEAD']
+    })) as GitExecResult
+    expect(result.code).toBe(0)
+    expect(result.stdout.trim()).toMatch(/^[0-9a-f]{40}$/)
+  })
+
+  it('reports a git failure as an exit code rather than throwing', async () => {
+    const root = repository()
+    const result = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['rev-parse', '--verify', 'refs/heads/missing']
+    })) as GitExecResult
+    // A git-level failure is data the daemon interprets; only a refusal is exceptional.
+    expect(result.code).not.toBe(0)
+    expect(result.stderr).not.toBe('')
+  })
+
+  it('refuses a subcommand outside the declared inventory', async () => {
+    const root = repository()
+    for (const subcommand of ['push', 'submodule', 'daemon', 'gc', 'apply']) {
+      await expect(handler(root)('exec', { tool: 'git', args: [subcommand] })).rejects.toBeInstanceOf(ExecRefusedError)
+    }
+    // And the inventory is the daemon's declared list, not a superset invented here.
+    expect(ALLOWED_GIT_SUBCOMMANDS.has('push')).toBe(false)
+    expect(ALLOWED_GIT_SUBCOMMANDS.has('status')).toBe(true)
+  })
+
+  it('refuses arguments that turn a permitted subcommand into arbitrary execution', async () => {
+    const root = repository()
+    // Each of these reaches execution THROUGH git, so a permitted subcommand is not sufficient.
+    const attacks = [
+      ['-c', 'core.pager=sh -c "id"', 'status'],
+      ['status', '-c', 'protocol.ext.allow=always'],
+      ['--exec-path=/tmp/evil', 'status'],
+      ['fetch', '--upload-pack=sh -c "id"', 'origin'],
+      ['--config-env=core.pager=EVIL', 'status']
+    ]
+    for (const args of attacks) {
+      await expect(handler(root)('exec', { tool: 'git', args })).rejects.toBeInstanceOf(ExecRefusedError)
+    }
+  })
+
+  it('refuses a cwd outside the workspace root, whatever the daemon asked for', async () => {
+    const root = repository()
+    const outside = mkdtempSync(join(tmpdir(), 'ac-outside-'))
+    roots.push(outside)
+    await expect(
+      handler(root)('exec', { tool: 'git', args: ['status', '--porcelain'], cwd: outside })
+    ).rejects.toBeInstanceOf(ExecRefusedError)
+    await expect(
+      handler(root)('exec', { tool: 'git', args: ['status', '--porcelain'], cwd: join(root, '..') })
+    ).rejects.toBeInstanceOf(ExecRefusedError)
+    await expect(
+      handler(root)('exec', { tool: 'git', args: ['status', '--porcelain'], cwd: 'relative' })
+    ).rejects.toBeInstanceOf(ExecRefusedError)
+
+    // A subdirectory of the root is fine — the check is containment, not equality.
+    mkdirSync(join(root, 'sub'), { recursive: true })
+    const inside = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['status', '--porcelain'],
+      cwd: join(root, 'sub')
+    })) as GitExecResult
+    expect(inside.code).toBe(0)
+  })
+
+  it('applies the request env as given rather than merging the sandbox environment', async () => {
+    // Verified through `config`, which IS in the inventory. An earlier version of this test used
+    // `commit` — and the guard refused it, correctly: the daemon never commits, so `commit` is
+    // not on the list. The test reaching for a convenient command it does not use was the bug.
+    const root = repository()
+    const globalConfig = join(root, 'from-request.gitconfig')
+    writeFileSync(globalConfig, '[user]\n\tname = Only From Request\n')
+    const result = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['config', '--get', 'user.name'],
+      env: {
+        PATH: process.env.PATH ?? '',
+        HOME: root,
+        GIT_CONFIG_GLOBAL: globalConfig
+      }
+    })) as GitExecResult
+    // git only reads that file if the request env reached the child.
+    expect(result.stdout.trim()).toBe('Only From Request')
+
+    // And without it, the same argv does not see that name — so the previous result was the
+    // env doing the work rather than ambient configuration.
+    const withoutEnv = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['config', '--get', 'user.name']
+    })) as GitExecResult
+    expect(withoutEnv.stdout.trim()).not.toBe('Only From Request')
+  })
+
+  it('serves materialization and refuses a path escaping the sink root', async () => {
+    const root = repository()
+    await handler(root)('materialize', {
+      op: 'write',
+      root: configFilesDir(root),
+      relPath: ['kubeconfig'],
+      content: 'apiVersion: v1\n'
+    })
+    expect(readFileSync(join(configFilesDir(root), 'kubeconfig'), 'utf8')).toBe('apiVersion: v1\n')
+    await expect(
+      handler(root)('materialize', { op: 'write', root: configFilesDir(root), relPath: ['..', 'escape'], content: 'x' })
+    ).rejects.toThrow()
+  })
+
+  it('refuses a capability it does not serve', async () => {
+    const root = repository()
+    // acp is served by the runner and tunnel is not implemented here; neither may fall through
+    // to the git path by accident.
+    await expect(handler(root)('acp', { op: 'open' })).rejects.toBeInstanceOf(ExecRefusedError)
+    await expect(handler(root)('tunnel', { op: 'open' })).rejects.toBeInstanceOf(ExecRefusedError)
+  })
+})


### PR DESCRIPTION
Part of #815.

## What

`GitRunner`'s inventory is declared by the daemon — but the daemon is the *sending* side. The shim is the process that actually spawns `git`, so that is the only place the list can be enforced. Without a check there, a compromised or buggy daemon reaches arbitrary git, and through `-c`, hooks, or `--upload-pack`, arbitrary execution inside the sandbox.

This adds the production shim's non-ACP handler (`src/shim/exec-handler.ts`), wired into `shim/index.ts`. It serves `materialize` and git `exec`, and enforces, sandbox-side:

- **the subcommand inventory** — the 15 subcommands the daemon actually calls; `push`, `submodule`, `gc`, `apply`, `daemon` are refused
- **argument forms** that turn a permitted subcommand into an execution primitive — `-c`, `--exec-path`, `--upload-pack`, `--receive-pack`, `--config-env` — checked across the whole argv, because a permitted subcommand carrying one of these is not safe
- **cwd containment** in the workspace root (`AC_SHIM_WORKSPACE_ROOT`), refusing absolute escapes, `..`, and relative paths
- **capabilities it does not serve** — `acp`, `tunnel` are refused rather than falling through to the git path

A git-level failure comes back as an exit code, since that is data the daemon interprets; only a refusal is exceptional. Request env is applied as given (replace, not merge), matching the contract — the daemon sanitizes it, and merging the sandbox's own environment back in would undo exactly that.

## Test-subject change worth reviewing

`test/git-runner-contract.test.ts` previously ran git itself on the shim side. That made its parity claim weaker than it read: it held between `ShimGitRunner` and a test helper, while production pairs that runner with `createExecHandler`. The suite now drives the real handler.

Routing it in immediately found something: **two tests proved env application through `git commit`** — a subcommand the daemon never calls, so the inventory refuses it. Both now prove it through `config`, which the daemon does call. Widening the inventory to satisfy a test would have removed the guard the inventory exists to be.

The parity suite is now also a check on the inventory itself: it was derived by reading call sites, and a call site that reading missed now fails here rather than in a sandbox.

## Verification

- 8 new tests in `test/shim-exec-handler.test.ts`, each against a real git repository — no canned responses
- Both guard tests were **confirmed to fail with their guard removed** (the inventory check and the argument check, reverted one at a time)
- `test/git-runner-contract.test.ts` (14) + shim/cluster/workspace suites: 125 passing
- `pnpm build` — the shim bundle stays self-contained (`node:` builtins only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)