### PR TITLE
feat(daemon): route workspace-manager git through the runner seam

### DIFF
--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -142,14 +142,8 @@ function isTrustedGithubOrigin(input: string): boolean {
   }
 }
 
-/**
- * Resolves where one agent's git runs.
- *
- * Per-agent rather than global because the answer is per-agent: a cluster-backed workspace lives
- * on its own sandbox pod's volume and its runner sends argv over that pod's shim channel, while a
- * self-hosted agent beside it runs git here. Returning undefined means "local", which is also
- * what an unconfigured daemon does — so the local path needs no registration.
- */
+// Resolves where one agent's git runs. Per-agent because a cluster workspace's runner is bound to
+// that agent's own sandbox channel; undefined means local, so self-hosting needs no registration.
 export type WorkspaceGitRunnerResolver = (agentId: string, cwd?: string, abort?: AbortSignal) => GitRunner | undefined
 
 /** Module-level init, mirroring cloneInFlight and git-injection's own registration. */
@@ -159,8 +153,8 @@ export function setWorkspaceGitRunnerResolver(resolver: WorkspaceGitRunnerResolv
   resolveWorkspaceGitRunner = resolver
 }
 
-/** Every git operation in this file goes through here. A site that calls gitFor directly would
- *  keep working locally and silently run on the WRONG filesystem for a cluster agent. */
+// Every git operation here routes through this: a direct gitFor still passes locally and then runs
+// a cluster agent's git on the wrong filesystem.
 function runnerFor(agentId: string, cwd?: string, abort?: AbortSignal): GitRunner {
   return resolveWorkspaceGitRunner?.(agentId, cwd, abort) ?? new LocalGitRunner(gitFor(cwd, abort))
 }

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -35,7 +35,7 @@ import {
   workspaceGitPullTarget,
   writeRepoHelperConfig
 } from './git-injection.js'
-import { LocalGitRunner } from './git-runner.js'
+import { LocalGitRunner, type GitRunner } from './git-runner.js'
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
 
 const skillsLog = makeLogger('info')
@@ -142,12 +142,35 @@ function isTrustedGithubOrigin(input: string): boolean {
   }
 }
 
+/**
+ * Resolves where one agent's git runs.
+ *
+ * Per-agent rather than global because the answer is per-agent: a cluster-backed workspace lives
+ * on its own sandbox pod's volume and its runner sends argv over that pod's shim channel, while a
+ * self-hosted agent beside it runs git here. Returning undefined means "local", which is also
+ * what an unconfigured daemon does — so the local path needs no registration.
+ */
+export type WorkspaceGitRunnerResolver = (agentId: string, cwd?: string, abort?: AbortSignal) => GitRunner | undefined
+
+/** Module-level init, mirroring cloneInFlight and git-injection's own registration. */
+let resolveWorkspaceGitRunner: WorkspaceGitRunnerResolver | undefined
+
+export function setWorkspaceGitRunnerResolver(resolver: WorkspaceGitRunnerResolver | undefined): void {
+  resolveWorkspaceGitRunner = resolver
+}
+
+/** Every git operation in this file goes through here. A site that calls gitFor directly would
+ *  keep working locally and silently run on the WRONG filesystem for a cluster agent. */
+function runnerFor(agentId: string, cwd?: string, abort?: AbortSignal): GitRunner {
+  return resolveWorkspaceGitRunner?.(agentId, cwd, abort) ?? new LocalGitRunner(gitFor(cwd, abort))
+}
+
 async function convergeWorkspaceOrigin(agent: Agent, cwd = agent.workspace.path): Promise<void> {
   const clone = cloneInFlight.get(cwd)
   if (clone) await clone
   if (!existsSync(join(cwd, '.git'))) return
   const expected = gitRepoOf(agent)
-  const git = gitFor(cwd).env(workspaceGitLocalEnv())
+  const git = runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
   let current: string
   try {
     current = (await git.raw(['remote', 'get-url', 'origin'])).trim()
@@ -317,9 +340,7 @@ export async function prepareWorkspace(agent: Agent, opts: PrepareWorkspaceOptio
       const repository = gitRepoOf(agent)
       await assertSafeWorkspaceGitConfig(cwd)
       const pullTarget = workspaceGitPullTarget(repository)
-      // Through the runner, because pullWorkspaceRef is orchestration and now speaks the
-      // contract. The remaining gitFor sites in this file migrate with the rest of #815.
-      const git = new LocalGitRunner(gitFor(cwd, abort.signal)).withEnv({
+      const git = runnerFor(agent.id, cwd, abort.signal).withEnv({
         ...workspaceGitLocalEnv(),
         ...pullTarget.env,
         ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
@@ -400,7 +421,7 @@ export type SessionWorktreeRemoval =
  * on-disk state. */
 export async function removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
   const id = sessionWorktreeId(sessionKey)
-  const primaryGit = () => gitFor(agent.workspace.path).env(workspaceGitLocalEnv())
+  const primaryGit = () => runnerFor(agent.id, agent.workspace.path).withEnv(workspaceGitLocalEnv())
   // Drop the stale Git registration and this worktree's daemon-owned review refs.
   // Ref deletion is best-effort: most worktrees never had review refs.
   const cleanupRegistrations = async () => {
@@ -439,7 +460,7 @@ export async function removeSessionWorktree(agent: Agent, sessionKey: string): P
       await cleanupRegistrations()
       return { outcome: 'removed' }
     }
-    const worktreeGit = gitFor(cwd).env(workspaceGitLocalEnv())
+    const worktreeGit = runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
     if ((await worktreeGit.raw(['status', '--porcelain'])).trim() !== '') {
       return { outcome: 'retained', reason: 'dirty' }
     }
@@ -472,10 +493,10 @@ function exactObjectId(value: string, label: string): string {
   return value.toLowerCase()
 }
 
-async function revParse(cwd: string, ref: string): Promise<string> {
+async function revParse(agentId: string, cwd: string, ref: string): Promise<string> {
   return (
-    await gitFor(cwd)
-      .env(workspaceGitLocalEnv())
+    await runnerFor(agentId, cwd)
+      .withEnv(workspaceGitLocalEnv())
       .raw(['rev-parse', '--verify', `${ref}^{commit}`])
   ).trim()
 }
@@ -501,7 +522,7 @@ async function fetchReviewRevision(
   const abort = new AbortController()
   const timer = setTimeout(() => abort.abort(), REVIEW_FETCH_TIMEOUT_MS)
   try {
-    const git = gitFor(agent.workspace.path, abort.signal).env({
+    const git = runnerFor(agent.id, agent.workspace.path, abort.signal).withEnv({
       ...pullTarget.env,
       ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
       GIT_TERMINAL_PROMPT: '0'
@@ -515,10 +536,10 @@ async function fetchReviewRevision(
       `+${base}:${baseRef}`,
       `+refs/pull/${review.pullNumber}/head:${headRef}`
     ])
-    if ((await revParse(agent.workspace.path, baseRef)).toLowerCase() !== base) {
+    if ((await revParse(agent.id, agent.workspace.path, baseRef)).toLowerCase() !== base) {
       throw new Error('github review base ref did not resolve to the requested SHA')
     }
-    if ((await revParse(agent.workspace.path, headRef)).toLowerCase() !== head) {
+    if ((await revParse(agent.id, agent.workspace.path, headRef)).toLowerCase() !== head) {
       throw new Error('github review head ref did not resolve to the requested SHA')
     }
 
@@ -535,11 +556,11 @@ async function fetchReviewRevision(
         pullTarget.remote,
         `+refs/pull/${review.pullNumber}/merge:${mergeRef}`
       ])
-      const merge = (await revParse(agent.workspace.path, mergeRef)).toLowerCase()
+      const merge = (await revParse(agent.id, agent.workspace.path, mergeRef)).toLowerCase()
       const expectedMerge = review.mergeCommitSha ? exactObjectId(review.mergeCommitSha, 'merge SHA') : undefined
       const parents = (
-        await gitFor(agent.workspace.path)
-          .env(workspaceGitLocalEnv())
+        await runnerFor(agent.id, agent.workspace.path)
+          .withEnv(workspaceGitLocalEnv())
           .raw(['rev-list', '--parents', '-n', '1', mergeRef])
       )
         .trim()
@@ -611,7 +632,7 @@ export async function prepareSessionWorkspace(
   let attached = existsSync(join(cwd, '.git'))
   if (attached) {
     try {
-      await revParse(cwd, 'HEAD')
+      await revParse(agent.id, cwd, 'HEAD')
     } catch {
       attached = false
       rmSync(cwd, { recursive: true, force: true })
@@ -619,21 +640,23 @@ export async function prepareSessionWorkspace(
   }
   if (!attached) {
     rmSync(cwd, { recursive: true, force: true })
-    await gitFor(agent.workspace.path).env(workspaceGitLocalEnv()).raw(['worktree', 'prune'])
+    await runnerFor(agent.id, agent.workspace.path).withEnv(workspaceGitLocalEnv()).raw(['worktree', 'prune'])
     // prepareWorkspace's pull is best-effort (and may be disabled), but this
     // checkout runs in the daemon process. Unsafe executable config must gate
     // the worktree operation itself instead of being swallowed as a pull error.
     await assertSafeWorkspaceGitConfig(agent.workspace.path)
-    await gitFor(agent.workspace.path).env(workspaceGitLocalEnv()).raw(['worktree', 'add', '--detach', cwd, target])
+    await runnerFor(agent.id, agent.workspace.path)
+      .withEnv(workspaceGitLocalEnv())
+      .raw(['worktree', 'add', '--detach', cwd, target])
   } else if (review) {
     // Re-audit at the checkout boundary rather than relying on the earlier
     // network fetch audit; repository config may have changed while fetching.
     await assertSafeWorkspaceGitConfig(agent.workspace.path)
-    const worktreeGit = gitFor(cwd).env(workspaceGitLocalEnv())
+    const worktreeGit = runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
     await worktreeGit.raw(['reset', '--hard', target])
     await worktreeGit.raw(['clean', '-ffdx'])
   }
-  if (review && (await revParse(cwd, 'HEAD')).toLowerCase() !== review.checkout) {
+  if (review && (await revParse(agent.id, cwd, 'HEAD')).toLowerCase() !== review.checkout) {
     throw new Error('github review worktree HEAD does not match the verified revision')
   }
   const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
@@ -884,11 +907,11 @@ async function cloneRepoAt(agent: Agent, cwd: string): Promise<void> {
 
   const p = (async () => {
     // github-app: credentials ride the env-injected helper (no repo config exists
-    // yet). SPREAD over process.env — simple-git's .env() REPLACES the child env.
+    // yet). SPREAD over process.env — withEnv REPLACES the child env, as .env() did.
     if (githubApp) await preWarmGitCred(agent.id, 'clone')
     const git = githubApp
-      ? gitFor().env({ ...workspaceGitEnvBase(gitRepo), ...cloneGitEnv(agent.id, gitRepo) })
-      : gitFor().env({ ...workspaceGitEnvBase(gitRepo), GIT_TERMINAL_PROMPT: '0' })
+      ? runnerFor(agent.id).withEnv({ ...workspaceGitEnvBase(gitRepo), ...cloneGitEnv(agent.id, gitRepo) })
+      : runnerFor(agent.id).withEnv({ ...workspaceGitEnvBase(gitRepo), GIT_TERMINAL_PROMPT: '0' })
     try {
       await git.clone(gitRepo, cwd, ['--branch', branch, '--single-branch'])
     } catch (e) {

--- a/packages/daemon/test/workspace-git-runner-seam.test.ts
+++ b/packages/daemon/test/workspace-git-runner-seam.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import {
+  removeSessionWorktree,
+  sessionWorktreeRoot,
+  setWorkspaceGitRunnerResolver,
+  type WorkspaceGitRunnerResolver
+} from '../src/workspace/workspace-manager.js'
+import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
+import { gitFor } from '../src/workspace/git-injection.js'
+import type { Agent } from '../src/agents/agent-schema.js'
+
+/**
+ * The resolver seam in workspace-manager, which is what lets a cluster-backed workspace run its
+ * git on the sandbox pod's volume instead of this daemon's disk.
+ *
+ * The migration it exists for is only as good as its completeness: a single site left calling
+ * `gitFor` keeps passing every local test and then, for a cluster agent, runs git against the
+ * WRONG filesystem — reporting a clean tree for a workspace it cannot see. So this covers both
+ * halves: the operations do route through the resolver, and no operation gets to bypass it.
+ */
+
+const roots: string[] = []
+
+afterEach(() => {
+  setWorkspaceGitRunnerResolver(undefined)
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'T',
+      GIT_AUTHOR_EMAIL: 't@e',
+      GIT_COMMITTER_NAME: 'T',
+      GIT_COMMITTER_EMAIL: 't@e'
+    }
+  })
+}
+
+/** A real agent whose workspace is a real repository with a real session worktree. */
+function agentWithWorktree(sessionKey: string): { agent: Agent; worktree: string } {
+  const home = mkdtempSync(join(tmpdir(), 'ac-seam-'))
+  roots.push(home)
+  const path = join(home, 'checkout')
+  mkdirSync(path, { recursive: true })
+  git(path, ['init', '--initial-branch=main'])
+  writeFileSync(join(path, 'a.txt'), 'a\n')
+  git(path, ['add', 'a.txt'])
+  git(path, ['commit', '-m', 'base'])
+  // A real workspace is a CLONE, so its commits are reachable from a remote ref. Without one
+  // every commit counts as unique to the worktree and removal is refused — which is the
+  // judgement working, not a fixture detail to assert around.
+  const origin = join(home, 'origin.git')
+  git(home, ['init', '--bare', '--initial-branch=main', origin])
+  git(path, ['remote', 'add', 'origin', origin])
+  git(path, ['push', '-u', 'origin', 'main'])
+
+  const agent = {
+    id: 'bot-seam',
+    dir: home,
+    name: 'bot-seam',
+    status: 'active',
+    runtime: 'claude',
+    workspace: {
+      mode: 'git-repo',
+      path,
+      gitRepo: 'https://github.com/acme/repo.git',
+      gitBranch: 'main',
+      pullOnNewSession: false,
+      skills: []
+    },
+    integrations: [],
+    output: { mode: 'medium' },
+    permissions: { policy: 'ask', autoApprove: [] },
+    crons: []
+  } as unknown as Agent
+
+  // The real worktree the removal path judges, registered by real git.
+  const id = createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)
+  const worktree = join(sessionWorktreeRoot(agent), id)
+  mkdirSync(dirname(worktree), { recursive: true })
+  git(path, ['worktree', 'add', '--detach', worktree, 'HEAD'])
+  return { agent, worktree }
+}
+
+/** Delegates to the local runner but records what the seam was asked to do. */
+function recording(): {
+  resolver: WorkspaceGitRunnerResolver
+  calls: Array<{ agentId: string; cwd?: string }>
+  argv: string[][]
+} {
+  const calls: Array<{ agentId: string; cwd?: string }> = []
+  const argv: string[][] = []
+  const resolver: WorkspaceGitRunnerResolver = (agentId, cwd, abort) => {
+    calls.push({ agentId, ...(cwd === undefined ? {} : { cwd }) })
+    const inner: GitRunner = new LocalGitRunner(gitFor(cwd, abort))
+    const wrap = (runner: GitRunner): GitRunner => ({
+      withEnv: (env) => wrap(runner.withEnv(env)),
+      raw: async (args) => {
+        argv.push(args)
+        return runner.raw(args)
+      },
+      clone: async (repo, target, options) => {
+        argv.push(['clone', ...(options ?? []), repo, target])
+        return runner.clone(repo, target, options)
+      },
+      pull: async (remote, branch, options) => {
+        argv.push(['pull', ...(options ?? []), remote, branch])
+        return runner.pull(remote, branch, options)
+      },
+      status: async () => {
+        argv.push(['status'])
+        return runner.status()
+      },
+      log: async (options) => {
+        argv.push(['log', String(options.maxCount)])
+        return runner.log(options)
+      }
+    })
+    return wrap(inner)
+  }
+  return { resolver, calls, argv }
+}
+
+describe('workspace-manager git runner seam', () => {
+  it('routes worktree removal through the resolver, with the agent it belongs to', async () => {
+    const { agent, worktree } = agentWithWorktree('session-1')
+    const { resolver, calls, argv } = recording()
+    setWorkspaceGitRunnerResolver(resolver)
+
+    const outcome = await removeSessionWorktree(agent, 'session-1')
+
+    // Real removal against a real worktree — the outcome proves the routed argv actually ran.
+    expect(outcome).toEqual({ outcome: 'removed' })
+    expect(existsSync(worktree)).toBe(false)
+    // The resolver has to be told WHICH agent: the runner for a cluster workspace is bound to
+    // that agent's own sandbox channel, so a seam taking only a cwd could not pick one.
+    expect(calls.length).toBeGreaterThan(0)
+    expect(new Set(calls.map((call) => call.agentId))).toEqual(new Set(['bot-seam']))
+    const flat = argv.map((args) => args.join(' '))
+    expect(flat).toContain('status --porcelain')
+    expect(flat.some((line) => line.startsWith('rev-list --count HEAD'))).toBe(true)
+    expect(flat).toContain(`worktree remove ${worktree}`)
+    expect(flat).toContain('worktree prune')
+    expect(flat.some((line) => line.startsWith('update-ref -d refs/agentconnect/reviews/'))).toBe(true)
+  })
+
+  it('retains a DIRTY worktree, judged through the resolver rather than around it', async () => {
+    const { agent, worktree } = agentWithWorktree('session-2')
+    writeFileSync(join(worktree, 'dirty.txt'), 'x\n')
+    const { resolver } = recording()
+    setWorkspaceGitRunnerResolver(resolver)
+
+    // The decision has to come from the runner's answer: a site reading the daemon's own disk
+    // instead would judge a cluster workspace it cannot see.
+    expect(await removeSessionWorktree(agent, 'session-2')).toEqual({ outcome: 'retained', reason: 'dirty' })
+    expect(existsSync(worktree)).toBe(true)
+  })
+
+  it('cannot be bypassed: a refusing resolver stops the operation instead of falling back', async () => {
+    const { agent, worktree } = agentWithWorktree('session-3')
+    // If any site still reached git directly, the removal would succeed despite the seam
+    // refusing everything — which is exactly the silent failure this guards.
+    setWorkspaceGitRunnerResolver(() => {
+      throw new Error('seam refused')
+    })
+    const outcome = await removeSessionWorktree(agent, 'session-3')
+    expect(outcome.outcome).toBe('failed')
+    expect(existsSync(worktree)).toBe(true)
+  })
+
+  it('leaves the local path unregistered, so a self-hosted daemon needs no wiring', async () => {
+    const { agent, worktree } = agentWithWorktree('session-4')
+    // No resolver installed: undefined means local, and the default must still work.
+    expect(await removeSessionWorktree(agent, 'session-4')).toEqual({ outcome: 'removed' })
+    expect(existsSync(worktree)).toBe(false)
+  })
+
+  it('has no git call site left outside the seam', () => {
+    // A source-level check because the alternative is booting all twelve call sites, and the
+    // failure mode is a NEW site added later: it would pass every local test while running a
+    // cluster agent's git on the wrong machine. `runnerFor` is the one permitted caller.
+    const source = readFileSync(new URL('../src/workspace/workspace-manager.ts', import.meta.url), 'utf8')
+    const offenders = source
+      .split('\n')
+      .map((line, index) => ({ line, number: index + 1 }))
+      .filter(({ line }) => /\bgitFor\(/.test(line))
+      .filter(({ line }) => !line.includes('new LocalGitRunner(gitFor(cwd, abort))'))
+    expect(offenders.map((entry) => `${entry.number}: ${entry.line.trim()}`)).toEqual([])
+  })
+})

--- a/packages/daemon/test/workspace-git-runner-seam.test.ts
+++ b/packages/daemon/test/workspace-git-runner-seam.test.ts
@@ -14,15 +14,9 @@ import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
 import { gitFor } from '../src/workspace/git-injection.js'
 import type { Agent } from '../src/agents/agent-schema.js'
 
-/**
- * The resolver seam in workspace-manager, which is what lets a cluster-backed workspace run its
- * git on the sandbox pod's volume instead of this daemon's disk.
- *
- * The migration it exists for is only as good as its completeness: a single site left calling
- * `gitFor` keeps passing every local test and then, for a cluster agent, runs git against the
- * WRONG filesystem — reporting a clean tree for a workspace it cannot see. So this covers both
- * halves: the operations do route through the resolver, and no operation gets to bypass it.
- */
+// The resolver seam that lets a cluster workspace run git on its sandbox pod instead of this disk.
+// Its value is completeness: one site left on gitFor passes every local test, then reports a clean
+// tree for a workspace it cannot see. So both halves are covered — routed, and unbypassable.
 
 const roots: string[] = []
 
@@ -55,9 +49,8 @@ function agentWithWorktree(sessionKey: string): { agent: Agent; worktree: string
   writeFileSync(join(path, 'a.txt'), 'a\n')
   git(path, ['add', 'a.txt'])
   git(path, ['commit', '-m', 'base'])
-  // A real workspace is a CLONE, so its commits are reachable from a remote ref. Without one
-  // every commit counts as unique to the worktree and removal is refused — which is the
-  // judgement working, not a fixture detail to assert around.
+  // A real workspace is a CLONE, so commits are reachable from a remote ref. Without one every
+  // commit is unique to the worktree and removal is correctly refused.
   const origin = join(home, 'origin.git')
   git(home, ['init', '--bare', '--initial-branch=main', origin])
   git(path, ['remote', 'add', 'origin', origin])
@@ -141,8 +134,7 @@ describe('workspace-manager git runner seam', () => {
     // Real removal against a real worktree — the outcome proves the routed argv actually ran.
     expect(outcome).toEqual({ outcome: 'removed' })
     expect(existsSync(worktree)).toBe(false)
-    // The resolver has to be told WHICH agent: the runner for a cluster workspace is bound to
-    // that agent's own sandbox channel, so a seam taking only a cwd could not pick one.
+    // The resolver needs the agent: a cwd-only seam could not pick which sandbox channel to use.
     expect(calls.length).toBeGreaterThan(0)
     expect(new Set(calls.map((call) => call.agentId))).toEqual(new Set(['bot-seam']))
     const flat = argv.map((args) => args.join(' '))
@@ -159,16 +151,14 @@ describe('workspace-manager git runner seam', () => {
     const { resolver } = recording()
     setWorkspaceGitRunnerResolver(resolver)
 
-    // The decision has to come from the runner's answer: a site reading the daemon's own disk
-    // instead would judge a cluster workspace it cannot see.
+    // The decision must come from the runner's answer, not from this daemon's own disk.
     expect(await removeSessionWorktree(agent, 'session-2')).toEqual({ outcome: 'retained', reason: 'dirty' })
     expect(existsSync(worktree)).toBe(true)
   })
 
   it('cannot be bypassed: a refusing resolver stops the operation instead of falling back', async () => {
     const { agent, worktree } = agentWithWorktree('session-3')
-    // If any site still reached git directly, the removal would succeed despite the seam
-    // refusing everything — which is exactly the silent failure this guards.
+    // A site still reaching git directly would succeed despite the seam refusing everything.
     setWorkspaceGitRunnerResolver(() => {
       throw new Error('seam refused')
     })
@@ -185,9 +175,8 @@ describe('workspace-manager git runner seam', () => {
   })
 
   it('has no git call site left outside the seam', () => {
-    // A source-level check because the alternative is booting all twelve call sites, and the
-    // failure mode is a NEW site added later: it would pass every local test while running a
-    // cluster agent's git on the wrong machine. `runnerFor` is the one permitted caller.
+    // Source-level because the failure mode is a NEW site added later, which every local test
+    // would pass. `runnerFor` is the one permitted caller.
     const source = readFileSync(new URL('../src/workspace/workspace-manager.ts', import.meta.url), 'utf8')
     const offenders = source
       .split('\n')


### PR DESCRIPTION
Part of #815 — the last group of call sites.

## What

Twelve `gitFor` sites in `workspace-manager.ts` now go through one resolver instead of reaching simple-git directly: origin convergence, the session-start pull, worktree add/remove/prune, review ref fetching, `rev-parse`, `reset`/`clean`, and the clone.

The resolver is **per-agent, not global**, because the answer is per-agent — a cluster-backed workspace lives on its own sandbox pod's volume and its runner sends argv over *that pod's* shim channel, while a self-hosted agent beside it runs git here:

```ts
export type WorkspaceGitRunnerResolver = (agentId: string, cwd?: string, abort?: AbortSignal) => GitRunner | undefined
```

Returning `undefined` means local, which is also what an unregistered daemon does — so the self-hosted path needs no wiring and keeps its exact semantics, including simple-git's abort-kills-the-child behaviour that the 4.5 s pull budget depends on.

`revParse` gained an `agentId` parameter for the same reason: a helper taking only a cwd cannot pick which agent's git to run.

## Why the tests are shaped this way

The value of this change is entirely in its **completeness**, and that is exactly what the local suite cannot notice. A single site left on `gitFor` keeps passing every test here, and then for a cluster agent runs git against the **wrong filesystem** — reporting a clean tree for a workspace it cannot see. A "does it still work locally" suite is guaranteed to be green either way.

So `test/workspace-git-runner-seam.test.ts` covers both halves, against a real repository and a real `git worktree`:

- removal routes through the resolver, carrying the agent id it belongs to
- a dirty tree is judged from the **runner's** answer, not the daemon's disk
- a refusing resolver **stops** the operation rather than falling back to local git
- the unregistered default still works, so self-hosting needs no registration
- no call site is left outside the seam (source-level, because the failure mode is a *new* site added later)

Both guards were confirmed load-bearing by reintroducing a direct `gitFor` at one site and watching them fail.

One fixture note worth flagging: the test repo needed a real `origin` with a pushed branch. Without one, every commit is unreachable from `--remotes`, so `removeSessionWorktree` correctly refuses as `unique-commits` — that is the judgement working, and the fix was to make the fixture a real clone rather than to assert around it.

## Verification

- 320 tests across the workspace, session-manager, git-injection, git-runner-contract, shim and daemon-hook suites
- `pnpm build` clean; shim bundle still `node:`-only
- typecheck, eslint, prettier clean

## Not in this PR

Cancellation through the shim path — the remaining #815 item. The deadline now travels with each request and the sandbox reaps the child before the caller abandons it (#834), but a daemon-side abort does not yet propagate as a cancel frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)