### PR TITLE
feat(daemon): propagate cancellation into the sandbox and key the clone lock by filesystem

### DIFF
--- a/packages/daemon/src/shim/channels.ts
+++ b/packages/daemon/src/shim/channels.ts
@@ -4,9 +4,25 @@ import type { ShimCapability, ShimResponse } from './protocol.js'
 import { parseShimFrame } from './protocol.js'
 import type { FileSink } from './file-sink.js'
 
+export interface ShimRequestOptions {
+  timeoutMs?: number
+  // Cancels the work IN THE SANDBOX, not just this side's wait. Abandoning the wait alone leaves
+  // the child running, and a running git keeps index.lock — which is what the local runner's
+  // abort-kills-the-child behaviour exists to prevent.
+  abort?: AbortSignal
+}
+
 /** How a daemon-side caller reaches a bound shim: one authorized request, one reply. */
 export interface ShimRequester {
-  request(capability: ShimCapability, payload: unknown, timeoutMs?: number): Promise<unknown>
+  request(capability: ShimCapability, payload: unknown, options?: ShimRequestOptions): Promise<unknown>
+}
+
+/** Raised when a request was cancelled rather than failing on its own merits. */
+export class ShimRequestAbortedError extends Error {
+  constructor(reason: string) {
+    super(reason)
+    this.name = 'ShimRequestAbortedError'
+  }
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
@@ -40,20 +56,39 @@ export class ShimChannel implements ShimRequester {
     return true
   }
 
-  request(capability: ShimCapability, payload: unknown, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS): Promise<unknown> {
+  request(capability: ShimCapability, payload: unknown, options: ShimRequestOptions = {}): Promise<unknown> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     const id = randomUUID()
     return new Promise<unknown>((resolve, reject) => {
       const timer = this.deps.setTimeout(() => {
         this.pending.delete(id)
+        // Tell the sandbox too: a timeout that only gives up locally leaves the child running.
+        this.sendCancel(id, `timed out after ${timeoutMs}ms`)
         reject(new Error(`shim ${capability} request timed out after ${timeoutMs}ms`))
       }, timeoutMs)
+      const onAbort = (): void => {
+        if (!this.pending.delete(id)) return
+        this.deps.clearTimeout(timer)
+        this.sendCancel(id, 'aborted by caller')
+        reject(new ShimRequestAbortedError(`shim ${capability} request aborted`))
+      }
+      if (options.abort?.aborted) {
+        this.deps.clearTimeout(timer)
+        reject(new ShimRequestAbortedError(`shim ${capability} request aborted`))
+        return
+      }
+      options.abort?.addEventListener('abort', onAbort, { once: true })
+      const done = (): void => {
+        this.deps.clearTimeout(timer)
+        options.abort?.removeEventListener('abort', onAbort)
+      }
       this.pending.set(id, {
         resolve: (value) => {
-          this.deps.clearTimeout(timer)
+          done()
           resolve(value)
         },
         reject: (err) => {
-          this.deps.clearTimeout(timer)
+          done()
           reject(err)
         }
       })
@@ -66,6 +101,21 @@ export class ShimChannel implements ShimRequester {
         payload
       })
     })
+  }
+
+  // Best-effort: a dead channel cannot deliver it, and the shim's own deadline is the backstop.
+  private sendCancel(id: string, reason: string): void {
+    try {
+      this.connection.send({
+        type: 'shim/cancel',
+        id,
+        sessionCredential: this.credential,
+        generation: this.connection.binding.generation,
+        reason
+      })
+    } catch {
+      /* channel already gone */
+    }
   }
 
   /** Fail every in-flight request; the channel is gone and a caller must not hang on it. */

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -59,8 +59,12 @@ export class ShimClient {
   /** ACP streams by the request id that opened them; each emits many events. */
   private readonly acpStreams = new Map<string, AcpRunner>()
   // In-flight non-ACP work, so a cancel frame kills the child instead of only unblocking the
-  // daemon's wait. ACP streams have their own lifecycle and are not in here.
-  private readonly inFlight = new Map<string, AbortController>()
+  // daemon's wait. Keyed by request id and TIED TO ITS TRANSPORT: the daemon fails pending
+  // requests whenever a socket goes (including the routine half-TTL renewal), and work whose
+  // reply has nowhere to go must die with it — otherwise a clone, whose budget outlasts a
+  // renewal, keeps running and holding locks while the daemon retries over the new socket.
+  // ACP streams deliberately survive a renewal and are tracked separately.
+  private readonly inFlight = new Map<string, { transport: ShimTransport; controller: AbortController }>()
   /** Events produced while no transport is attached. A renewal closes the old socket before
    *  the replacement binds, and ACP bytes cannot simply be dropped — losing a fragment
    *  corrupts the protocol — so they wait here and flush on the next bind. */
@@ -140,6 +144,7 @@ export class ShimClient {
 
   stop(): void {
     this.stopped = true
+    if (this.transport) this.abortTransportWork(this.transport, 'shim stopping')
     this.bound = undefined
     this.channel?.end?.('lost')
     this.transport?.close(1000, 'shim stopping')
@@ -195,6 +200,9 @@ export class ShimClient {
         reject(new Error(message))
       }
       transport.onClose((code, reason) => {
+        // Unconditionally, and before the channel guard below: this transport's work is dead
+        // whichever channel is current, because its replies had this socket as their only route.
+        this.abortTransportWork(transport, `channel closed (${code})`)
         // Scoped to THIS transport. A close arriving late from a transport we already
         // replaced (a close-handshake timeout, say) must not clear the binding or end the
         // channel of the replacement that has since bound.
@@ -331,7 +339,7 @@ export class ShimClient {
         return
       }
       const controller = new AbortController()
-      this.inFlight.set(request.id, controller)
+      this.inFlight.set(request.id, { transport, controller })
       try {
         const handle = this.deps.handle ?? (async () => undefined)
         const payload = await handle(request.capability, request.payload, controller.signal)
@@ -349,10 +357,19 @@ export class ShimClient {
   // Fenced exactly like a request: a replayed cancel from a previous incarnation must not be able
   // to kill this one's work, so the credential and generation are checked before anything is
   // aborted. An unknown id is normal — the work may have finished as the cancel arrived.
+  // Abort every non-ACP request whose reply would have gone to this transport, and forget them.
+  private abortTransportWork(transport: ShimTransport, reason: string): void {
+    for (const [id, entry] of [...this.inFlight]) {
+      if (entry.transport !== transport) continue
+      this.inFlight.delete(id)
+      entry.controller.abort(new Error(reason))
+    }
+  }
+
   private cancel(frame: Extract<ShimFrame, { type: 'shim/cancel' }>): void {
     const bound = this.bound
     if (!bound || frame.sessionCredential !== bound.sessionCredential || frame.generation !== bound.generation) return
-    this.inFlight.get(frame.id)?.abort(new Error(frame.reason ?? 'cancelled by daemon'))
+    this.inFlight.get(frame.id)?.controller.abort(new Error(frame.reason ?? 'cancelled by daemon'))
     void this.acpStreams.get(frame.id)?.close(5_000)
   }
 }

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -38,7 +38,7 @@ export interface ShimClientDeps {
   readToken?: () => string
   /** Handles an authorized non-ACP request from the daemon (materialize / exec / read /
    *  tunnel). The ACP capability is served by the built-in runner instead. */
-  handle?: (capability: ShimCapability, payload: unknown) => Promise<unknown>
+  handle?: (capability: ShimCapability, payload: unknown, abort?: AbortSignal) => Promise<unknown>
   /** Resolves executables in THIS filesystem for the ACP runner. */
   resolveCommand?: ResolveCommand
   clock?: Clock
@@ -58,6 +58,9 @@ export interface ShimClientDeps {
 export class ShimClient {
   /** ACP streams by the request id that opened them; each emits many events. */
   private readonly acpStreams = new Map<string, AcpRunner>()
+  // In-flight non-ACP work, so a cancel frame kills the child instead of only unblocking the
+  // daemon's wait. ACP streams have their own lifecycle and are not in here.
+  private readonly inFlight = new Map<string, AbortController>()
   /** Events produced while no transport is attached. A renewal closes the old socket before
    *  the replacement binds, and ACP bytes cannot simply be dropped — losing a fragment
    *  corrupts the protocol — so they wait here and flush on the next bind. */
@@ -230,6 +233,7 @@ export class ShimClient {
           return
         }
         if (frame.type === 'shim/request') void this.serve(transport, frame)
+        if (frame.type === 'shim/cancel') this.cancel(frame)
       })
       // The token is the whole proof; nothing else about this pod is asserted.
       transport.send(JSON.stringify({ type: 'shim/hello', token } satisfies Extract<ShimFrame, { type: 'shim/hello' }>))
@@ -326,12 +330,29 @@ export class ShimClient {
         await this.serveAcp(transport, request)
         return
       }
-      const payload = await (this.deps.handle ?? (async () => undefined))(request.capability, request.payload)
-      transport.send(JSON.stringify({ type: 'shim/response', id: request.id, ok: true, payload }))
+      const controller = new AbortController()
+      this.inFlight.set(request.id, controller)
+      try {
+        const handle = this.deps.handle ?? (async () => undefined)
+        const payload = await handle(request.capability, request.payload, controller.signal)
+        transport.send(JSON.stringify({ type: 'shim/response', id: request.id, ok: true, payload }))
+      } finally {
+        this.inFlight.delete(request.id)
+      }
     } catch (err) {
       transport.send(
         JSON.stringify({ type: 'shim/response', id: request.id, ok: false, error: (err as Error).message })
       )
     }
+  }
+
+  // Fenced exactly like a request: a replayed cancel from a previous incarnation must not be able
+  // to kill this one's work, so the credential and generation are checked before anything is
+  // aborted. An unknown id is normal — the work may have finished as the cancel arrived.
+  private cancel(frame: Extract<ShimFrame, { type: 'shim/cancel' }>): void {
+    const bound = this.bound
+    if (!bound || frame.sessionCredential !== bound.sessionCredential || frame.generation !== bound.generation) return
+    this.inFlight.get(frame.id)?.abort(new Error(frame.reason ?? 'cancelled by daemon'))
+    void this.acpStreams.get(frame.id)?.close(5_000)
   }
 }

--- a/packages/daemon/src/shim/exec-handler.ts
+++ b/packages/daemon/src/shim/exec-handler.ts
@@ -144,18 +144,18 @@ function resolveCwd(root: string, requested: string | undefined): string {
  */
 export function createExecHandler(
   deps: ExecHandlerDeps
-): (capability: ShimCapability, payload: unknown) => Promise<unknown> {
-  return async (capability, payload) => {
+): (capability: ShimCapability, payload: unknown, abort?: AbortSignal) => Promise<unknown> {
+  return async (capability, payload, abort) => {
     if (capability === 'materialize') {
       await applyFileSinkPayload(payload)
       return null
     }
-    if (capability === 'exec') return runGit(payload, deps)
+    if (capability === 'exec') return runGit(payload, deps, abort)
     throw new ExecRefusedError(`capability ${capability} is not served by this handler`)
   }
 }
 
-async function runGit(payload: unknown, deps: ExecHandlerDeps): Promise<GitExecResult> {
+async function runGit(payload: unknown, deps: ExecHandlerDeps, abort?: AbortSignal): Promise<GitExecResult> {
   const parsed = GitExecPayloadSchema.parse(payload)
   const [subcommand, ...rest] = parsed.args
   if (!subcommand || !ALLOWED_GIT_SUBCOMMANDS.has(subcommand)) {
@@ -194,6 +194,8 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps): Promise<GitExecR
         // moving that policy into the shim, which is a design change, not a patch.
         ...(parsed.env ? { env: parsed.env } : {}),
         timeout: timeoutMs,
+        // The daemon's abort kills the child here, matching what simple-git's signal does locally.
+        ...(abort ? { signal: abort } : {}),
         // A killed git leaves index.lock behind, so the timeout is a last resort rather than
         // the primary cancellation path — the daemon aborting its request is.
         killSignal: 'SIGTERM',
@@ -201,6 +203,12 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps): Promise<GitExecR
       },
       (error, stdout, stderr) => {
         const failure = error as (Error & { code?: unknown; signal?: string | null; killed?: boolean }) | null
+        if (failure?.code === 'ABORT_ERR') {
+          // A cancelled child reports neither killed nor a signal, so it must be classified before
+          // the checks below or it reads as a spawn failure.
+          reject(new ExecRefusedError(`git ${subcommand} was cancelled`))
+          return
+        }
         if (failure?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
           // Must precede the killed check: Node kills the child on overflow, so this would
           // otherwise be reported as a timeout.

--- a/packages/daemon/src/shim/git-exec.ts
+++ b/packages/daemon/src/shim/git-exec.ts
@@ -138,7 +138,10 @@ export class ShimGitRunner implements GitRunner {
   constructor(
     private readonly requester: ShimRequester,
     private readonly cwd?: string,
-    private readonly env?: Record<string, string>
+    private readonly env?: Record<string, string>,
+    // Cancels the git running IN THE SANDBOX, matching what the local runner's signal does to a
+    // local child. Without it the caller's budget expires while the remote git keeps index.lock.
+    private readonly abort?: AbortSignal
   ) {}
 
   withEnv(env: Record<string, string>): GitRunner {
@@ -146,7 +149,7 @@ export class ShimGitRunner implements GitRunner {
     // replaces the first, so merging here would let a variable the new sanitized environment
     // intentionally omitted survive on the remote runner alone — a divergence in exactly the
     // direction that matters, since those omissions are the sanitization.
-    return new ShimGitRunner(this.requester, this.cwd, { ...env })
+    return new ShimGitRunner(this.requester, this.cwd, { ...env }, this.abort)
   }
 
   async raw(args: string[]): Promise<string> {
@@ -216,7 +219,10 @@ export class ShimGitRunner implements GitRunner {
       // nothing" is a meaningful instruction and must not be indistinguishable from "unset".
       ...(this.env !== undefined ? { env: this.env } : {})
     }
-    const raw = await this.requester.request('exec', payload, deadlineMs + REQUEST_MARGIN_MS)
+    const raw = await this.requester.request('exec', payload, {
+      timeoutMs: deadlineMs + REQUEST_MARGIN_MS,
+      ...(this.abort ? { abort: this.abort } : {})
+    })
     const result = GitExecResultSchema.parse(raw)
     if (result.code !== 0) throw new GitExecError(result.code, result.stdout, result.stderr, args)
     return result

--- a/packages/daemon/src/shim/protocol.ts
+++ b/packages/daemon/src/shim/protocol.ts
@@ -80,6 +80,16 @@ export const ShimRequestSchema = z.object({
   payload: z.unknown()
 })
 
+// Cancels an in-flight request by id. Carries credential and generation like every post-binding
+// frame, so a replayed cancel from a previous incarnation cannot kill a live request.
+export const ShimCancelSchema = z.object({
+  type: z.literal('shim/cancel'),
+  id: z.string().uuid(),
+  sessionCredential: z.string().min(1),
+  generation: z.number().int().nonnegative(),
+  reason: z.string().max(200).optional()
+})
+
 export const ShimResponseSchema = z.object({
   type: z.literal('shim/response'),
   id: z.string().uuid(),
@@ -110,6 +120,7 @@ export const ShimFrameSchema = z.discriminatedUnion('type', [
   ShimBoundSchema,
   ShimRejectedSchema,
   ShimRequestSchema,
+  ShimCancelSchema,
   ShimResponseSchema,
   ShimEventSchema
 ])
@@ -118,6 +129,7 @@ export type ShimHello = z.infer<typeof ShimHelloSchema>
 export type ShimBound = z.infer<typeof ShimBoundSchema>
 export type ShimRejected = z.infer<typeof ShimRejectedSchema>
 export type ShimRequest = z.infer<typeof ShimRequestSchema>
+export type ShimCancel = z.infer<typeof ShimCancelSchema>
 export type ShimResponse = z.infer<typeof ShimResponseSchema>
 export type ShimEvent = z.infer<typeof ShimEventSchema>
 export type ShimFrame = z.infer<typeof ShimFrameSchema>

--- a/packages/daemon/src/shim/session.ts
+++ b/packages/daemon/src/shim/session.ts
@@ -1,4 +1,4 @@
-import { ShimChannel } from './channels.js'
+import { ShimChannel, type ShimRequestOptions } from './channels.js'
 import type { ShimConnection } from './listener.js'
 import type { ShimCapability, ShimEvent } from './protocol.js'
 import { parseShimFrame } from './protocol.js'
@@ -78,8 +78,8 @@ export class ShimSession {
     return this.channel !== undefined
   }
 
-  request(capability: ShimCapability, payload: unknown, timeoutMs?: number): Promise<unknown> {
+  request(capability: ShimCapability, payload: unknown, options?: ShimRequestOptions): Promise<unknown> {
     if (!this.channel) throw new Error(`agent ${this.agentId} has no attached shim channel`)
-    return this.channel.request(capability, payload, timeoutMs)
+    return this.channel.request(capability, payload, options)
   }
 }

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -104,10 +104,16 @@ const REVIEW_FETCH_TIMEOUT_MS = 15_000
 const MATERIALIZATION_FILE = 'workspace-materialization.json'
 const GIT_OBJECT_ID = /^[0-9a-f]{40,64}$/i
 
-// Single-flight clone lock keyed by the absolute cwd. Two concurrent sessions
-// (especially multiple agents sharing one repo checkout) must not race into the
-// same dir — the second awaits the first's in-flight clone instead of re-cloning.
+// Single-flight clone lock. Two concurrent sessions (especially multiple agents sharing one repo
+// checkout) must not race into the same dir — the second awaits the first's in-flight clone.
 const cloneInFlight = new Map<string, Promise<void>>()
+
+// The key is the cwd for a local workspace, where sharing a path means sharing a checkout and
+// coalescing is the intent. For a cluster workspace the same path is a DIFFERENT filesystem per
+// agent, so coalescing there would hand one agent the other's clone; the agent id disambiguates.
+function cloneKey(agentId: string, cwd: string): string {
+  return resolveWorkspaceGitRunner?.(agentId, cwd) ? `${agentId}\u0000${cwd}` : cwd
+}
 
 function usesGithubApp(agent: Agent): boolean {
   return agent.workspace.mode === 'git-repo' && agent.workspace.gitCredential === 'github-app'
@@ -160,7 +166,7 @@ function runnerFor(agentId: string, cwd?: string, abort?: AbortSignal): GitRunne
 }
 
 async function convergeWorkspaceOrigin(agent: Agent, cwd = agent.workspace.path): Promise<void> {
-  const clone = cloneInFlight.get(cwd)
+  const clone = cloneInFlight.get(cloneKey(agent.id, cwd))
   if (clone) await clone
   if (!existsSync(join(cwd, '.git'))) return
   const expected = gitRepoOf(agent)
@@ -890,7 +896,8 @@ async function cloneRepo(agent: Agent): Promise<void> {
 }
 
 async function cloneRepoAt(agent: Agent, cwd: string): Promise<void> {
-  const inflight = cloneInFlight.get(cwd)
+  const key = cloneKey(agent.id, cwd)
+  const inflight = cloneInFlight.get(key)
   if (inflight) return inflight
 
   // Validate again at the execution boundary: a hand-edited/legacy agent.json
@@ -919,8 +926,8 @@ async function cloneRepoAt(agent: Agent, cwd: string): Promise<void> {
     // can still push" half of the design.
     if (githubApp) await writeRepoHelperConfig(cwd, agent.id)
   })().finally(() => {
-    cloneInFlight.delete(cwd)
+    cloneInFlight.delete(key)
   })
-  cloneInFlight.set(cwd, p)
+  cloneInFlight.set(key, p)
   return p
 }

--- a/packages/daemon/test/shim-cancellation.test.ts
+++ b/packages/daemon/test/shim-cancellation.test.ts
@@ -57,8 +57,9 @@ function blockingRepository(): { root: string; env: Record<string, string>; mark
 
 /** Real listener + real shim client, the client serving git through the production handler. */
 async function channelUnderTest(
-  workspaceRoot: string
-): Promise<{ channel: ShimChannel; connection: ShimConnection; sent: ShimFrame[] }> {
+  workspaceRoot: string,
+  options: { credentialTtlMs?: number; shimClock?: FakeClock } = {}
+): Promise<{ channel: ShimChannel; connection: ShimConnection; sent: ShimFrame[]; listener: ShimListener }> {
   const record: SpawnRecord = {
     agentId: 'agent-a',
     generation: 1,
@@ -70,6 +71,7 @@ async function channelUnderTest(
     verifier: { reviewToken: async () => ({ authenticated: true, podName: 'runtime-1', podUid: 'pod-uid-1' }) },
     spawnRecordForPod: () => record,
     now: () => Date.now(),
+    ...(options.credentialTtlMs !== undefined ? { credentialTtlMs: options.credentialTtlMs } : {}),
     log: { info: () => {}, warn: () => {} }
   })
   listeners.push(listener)
@@ -80,7 +82,7 @@ async function channelUnderTest(
     dial: (url, opts) =>
       ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
     readToken: () => 'projected-token',
-    clock: new FakeClock(),
+    clock: options.shimClock ?? new FakeClock(),
     backoff: new Backoff({ jitter: () => 0 }),
     handle: createExecHandler({ workspaceRoot, log: { info: () => {}, warn: () => {} } }),
     log: { info: () => {}, warn: () => {} }
@@ -106,7 +108,12 @@ async function channelUnderTest(
         onFrame: (listen) => connection.onFrame(listen),
         close: (reason) => connection.close(reason)
       }
-      return { channel: new ShimChannel(observed, connection.issuedCredential, timers), connection: observed, sent }
+      return {
+        channel: new ShimChannel(observed, connection.issuedCredential, timers),
+        connection: observed,
+        sent,
+        listener
+      }
     }
     if (Date.now() > deadline) throw new Error('no channel bound in time')
     await new Promise((resolve) => setTimeout(resolve, 20))
@@ -185,6 +192,41 @@ describe('shim request cancellation', () => {
     expect(await until(() => liveGitChildren(marker) > 0)).toBe(true)
     expect(await inflight).toMatch(/timed out/)
     // A timeout that only gives up locally leaves the child holding whatever it holds.
+    expect(await until(() => liveGitChildren(marker) === 0)).toBe(true)
+  })
+})
+
+describe('shim work spanning a credential renewal', () => {
+  it('kills work whose transport is replaced, so a renewal cannot orphan a running child', async () => {
+    // The daemon fails pending requests on every rebind, including the routine half-TTL renewal.
+    // A child whose reply has nowhere to go must die with the socket: a clone's budget outlasts a
+    // renewal, so otherwise it keeps running — and holding locks — while the daemon retries.
+    const { root, env, marker } = blockingRepository()
+    const shimClock = new FakeClock()
+    const { channel } = await channelUnderTest(root, { credentialTtlMs: 4_000, shimClock })
+
+    const inflight = channel
+      .request('exec', { tool: 'git', args: ['config', '--get', `user.${marker}`], env }, { timeoutMs: 120_000 })
+      .then(() => 'resolved')
+      .catch((err: Error) => err.message)
+    expect(await until(() => liveGitChildren(marker) > 0)).toBe(true)
+
+    // Renewal fires at half the TTL on the shim's own clock — the real trigger, not a close.
+    shimClock.advance(2_500)
+    expect(await until(() => liveGitChildren(marker) === 0)).toBe(true)
+    void inflight
+  })
+
+  it('kills work when the client stops', async () => {
+    // Guards the property, not one line: stop() closes the transport, so the close hook reaches
+    // this too. Both would have to regress for the child to survive — which is the point.
+    const { root, env, marker } = blockingRepository()
+    const { channel } = await channelUnderTest(root)
+    void channel
+      .request('exec', { tool: 'git', args: ['config', '--get', `user.${marker}`], env }, { timeoutMs: 120_000 })
+      .catch(() => undefined)
+    expect(await until(() => liveGitChildren(marker) > 0)).toBe(true)
+    for (const client of clients) client.stop()
     expect(await until(() => liveGitChildren(marker) === 0)).toBe(true)
   })
 })

--- a/packages/daemon/test/shim-cancellation.test.ts
+++ b/packages/daemon/test/shim-cancellation.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
+import { ShimListener, type ShimConnection } from '../src/shim/listener.js'
+import { ShimClient, type ShimTransport } from '../src/shim/client.js'
+import { ShimChannel, ShimRequestAbortedError } from '../src/shim/channels.js'
+import { createExecHandler } from '../src/shim/exec-handler.js'
+import { ShimGitRunner } from '../src/shim/git-exec.js'
+import type { ShimFrame } from '../src/shim/protocol.js'
+import type { SpawnRecord } from '../src/shim/binding.js'
+
+// Cancellation across the channel, end to end: real socket, real shim client, real hanging git.
+// The point is not that the daemon's promise rejects — a bare timeout already did that — but that
+// the CHILD DIES. An abandoned git keeps index.lock and wedges the next session's pull, which is
+// exactly what simple-git's signal handling prevents on the local runner.
+
+const listeners: ShimListener[] = []
+const clients: ShimClient[] = []
+const roots: string[] = []
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) client.stop()
+  await Promise.all(listeners.splice(0).map((instance) => instance.stop()))
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+const timers = {
+  setTimeout: (fn: () => void, ms: number) => setTimeout(fn, ms),
+  clearTimeout: (handle: unknown) => clearTimeout(handle as NodeJS.Timeout)
+}
+
+/**
+ * A repository whose `config` read blocks forever: git waits on a FIFO with no writer.
+ *
+ * `marker` goes in the ARGV, not the env, because the env is how the hang is arranged but not
+ * something `pgrep -f` can see — a first version keyed the process search on the FIFO path and
+ * therefore never found the child, so one test passed while observing nothing at all.
+ */
+function blockingRepository(): { root: string; env: Record<string, string>; marker: string } {
+  const root = mkdtempSync(join(tmpdir(), 'ac-cancel-'))
+  roots.push(root)
+  execFileSync('git', ['init', '-q', '--initial-branch=main'], { cwd: root })
+  writeFileSync(join(root, 'a.txt'), 'a\n')
+  execFileSync('git', ['add', 'a.txt'], { cwd: root })
+  const fifo = join(root, 'blocking.gitconfig')
+  execFileSync('mkfifo', [fifo])
+  return {
+    root,
+    env: { PATH: process.env.PATH ?? '', HOME: root, GIT_CONFIG_GLOBAL: fifo },
+    marker: `acmarker${randomUUID().replace(/-/g, '')}`
+  }
+}
+
+/** Real listener + real shim client, the client serving git through the production handler. */
+async function channelUnderTest(
+  workspaceRoot: string
+): Promise<{ channel: ShimChannel; connection: ShimConnection; sent: ShimFrame[] }> {
+  const record: SpawnRecord = {
+    agentId: 'agent-a',
+    generation: 1,
+    podName: 'runtime-1',
+    podUid: 'pod-uid-1',
+    grants: ['exec', 'materialize']
+  } as SpawnRecord
+  const listener = new ShimListener({
+    verifier: { reviewToken: async () => ({ authenticated: true, podName: 'runtime-1', podUid: 'pod-uid-1' }) },
+    spawnRecordForPod: () => record,
+    now: () => Date.now(),
+    log: { info: () => {}, warn: () => {} }
+  })
+  listeners.push(listener)
+  const port = await listener.start(0, '127.0.0.1')
+
+  const client = new ShimClient({
+    endpoint: `ws://127.0.0.1:${port}`,
+    dial: (url, opts) =>
+      ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
+    readToken: () => 'projected-token',
+    clock: new FakeClock(),
+    backoff: new Backoff({ jitter: () => 0 }),
+    handle: createExecHandler({ workspaceRoot, log: { info: () => {}, warn: () => {} } }),
+    log: { info: () => {}, warn: () => {} }
+  })
+  clients.push(client)
+  void client.start()
+
+  const deadline = Date.now() + 5_000
+  for (;;) {
+    const connection = listener.connectionsFor('agent-a')[0]
+    if (connection) {
+      // Observed so a test can read the REAL request id. Sending a cancel for an invented id
+      // proves nothing — the lookup misses whether or not the fencing is there, which is how the
+      // first version of the stale-generation test below passed against unfenced code.
+      const sent: ShimFrame[] = []
+      const observed: ShimConnection = {
+        binding: connection.binding,
+        issuedCredential: connection.issuedCredential,
+        send: (frame) => {
+          sent.push(frame)
+          connection.send(frame)
+        },
+        onFrame: (listen) => connection.onFrame(listen),
+        close: (reason) => connection.close(reason)
+      }
+      return { channel: new ShimChannel(observed, connection.issuedCredential, timers), connection: observed, sent }
+    }
+    if (Date.now() > deadline) throw new Error('no channel bound in time')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+/** Git children still alive, found by the marker this test put in their argv. */
+function liveGitChildren(marker: string): number {
+  try {
+    return Number(execFileSync('pgrep', ['-fc', marker], { encoding: 'utf8' }).trim()) || 0
+  } catch {
+    // pgrep exits non-zero when nothing matches.
+    return 0
+  }
+}
+
+async function until(predicate: () => boolean, timeoutMs = 5_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  return predicate()
+}
+
+describe('shim request cancellation', () => {
+  it('kills the git running INSIDE the sandbox when the daemon aborts', async () => {
+    const { root, env, marker } = blockingRepository()
+    const { channel } = await channelUnderTest(root)
+    const abort = new AbortController()
+    const runner = new ShimGitRunner(channel, root, undefined, abort.signal).withEnv(env)
+
+    const inflight = runner.raw(['config', '--get', `user.${marker}`])
+    // Abort only once the child is really running, otherwise the test proves nothing about
+    // killing it — an earlier version of this workstream shipped exactly that mistake.
+    expect(await until(() => liveGitChildren(marker) > 0)).toBe(true)
+
+    abort.abort()
+    await expect(inflight).rejects.toBeInstanceOf(ShimRequestAbortedError)
+    // The actual claim: the child is gone. Rejecting the promise while git keeps running is the
+    // failure this exists to prevent, and it looks identical from the caller's side.
+    expect(await until(() => liveGitChildren(marker) === 0)).toBe(true)
+  })
+
+  it('refuses a cancel carrying a stale generation, leaving the work running', async () => {
+    const { root, env, marker } = blockingRepository()
+    const { channel, connection, sent } = await channelUnderTest(root)
+    const runner = new ShimGitRunner(channel, root, undefined).withEnv(env)
+    const inflight = runner.raw(['config', '--get', `user.${marker}`]).catch(() => 'failed')
+    expect(await until(() => liveGitChildren(marker) > 0)).toBe(true)
+
+    // The cancel targets the request that is ACTUALLY in flight, and differs from a valid one
+    // only in its generation — so the child surviving can only be the fencing.
+    const request = sent.find((frame) => frame.type === 'shim/request')
+    expect(request?.type).toBe('shim/request')
+    connection.send({
+      type: 'shim/cancel',
+      id: (request as Extract<ShimFrame, { type: 'shim/request' }>).id,
+      sessionCredential: connection.issuedCredential,
+      generation: connection.binding.generation + 5,
+      reason: 'stale'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    expect(liveGitChildren(marker)).toBeGreaterThan(0)
+    void inflight
+  })
+
+  it('cancels in the sandbox when the request times out, not just locally', async () => {
+    const { root, env, marker } = blockingRepository()
+    const { channel } = await channelUnderTest(root)
+    const inflight = channel
+      .request('exec', { tool: 'git', args: ['config', '--get', `user.${marker}`], env }, { timeoutMs: 1_500 })
+      .then(() => 'resolved')
+      .catch((err: Error) => err.message)
+    // Prove the child got as far as running, so the assertion below is about it being killed.
+    expect(await until(() => liveGitChildren(marker) > 0)).toBe(true)
+    expect(await inflight).toMatch(/timed out/)
+    // A timeout that only gives up locally leaves the child holding whatever it holds.
+    expect(await until(() => liveGitChildren(marker) === 0)).toBe(true)
+  })
+})

--- a/packages/daemon/test/shim-channels.test.ts
+++ b/packages/daemon/test/shim-channels.test.ts
@@ -160,7 +160,7 @@ describe('shim channel', () => {
   it('times out a request rather than leaving a turn parked forever', async () => {
     const { connection } = fakeConnection()
     const channel = new ShimChannel(connection, 'cred-1', timers)
-    await expect(channel.request('materialize', {}, 10)).rejects.toThrow(/timed out/)
+    await expect(channel.request('materialize', {}, { timeoutMs: 10 })).rejects.toThrow(/timed out/)
     expect(channel.pendingCount()).toBe(0)
   })
 

--- a/packages/daemon/test/workspace-git-runner-seam.test.ts
+++ b/packages/daemon/test/workspace-git-runner-seam.test.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import {
+  prefetchWorkspace,
   removeSessionWorktree,
   sessionWorktreeRoot,
   setWorkspaceGitRunnerResolver,
@@ -85,6 +86,29 @@ function agentWithWorktree(sessionKey: string): { agent: Agent; worktree: string
 }
 
 /** Delegates to the local runner but records what the seam was asked to do. */
+/** Same shared path, different agent — the case the cwd-only key could not tell apart. */
+function clusterAgent(id: string, path: string): Agent {
+  return {
+    id,
+    dir: dirname(path),
+    name: id,
+    status: 'active',
+    runtime: 'claude',
+    workspace: {
+      mode: 'git-repo',
+      path,
+      gitRepo: 'https://github.com/acme/repo.git',
+      gitBranch: 'main',
+      pullOnNewSession: false,
+      skills: []
+    },
+    integrations: [],
+    output: { mode: 'medium' },
+    permissions: { policy: 'ask', autoApprove: [] },
+    crons: []
+  } as unknown as Agent
+}
+
 function recording(): {
   resolver: WorkspaceGitRunnerResolver
   calls: Array<{ agentId: string; cwd?: string }>
@@ -172,6 +196,43 @@ describe('workspace-manager git runner seam', () => {
     // No resolver installed: undefined means local, and the default must still work.
     expect(await removeSessionWorktree(agent, 'session-4')).toEqual({ outcome: 'removed' })
     expect(existsSync(worktree)).toBe(false)
+  })
+
+  it('does not coalesce two CLUSTER agents onto one clone, even at the same path', async () => {
+    // The single-flight lock was keyed on the textual cwd. For local agents that is the intent:
+    // one path means one checkout. For cluster agents the same path is a different filesystem per
+    // agent, so coalescing hands one agent the other's clone — and it looks like success.
+    const home = mkdtempSync(join(tmpdir(), 'ac-seam-clone-'))
+    roots.push(home)
+    const shared = join(home, 'checkout')
+    const cloned: string[] = []
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    // Clone is intercepted, so nothing reaches the network; the point is who asks and how often.
+    setWorkspaceGitRunnerResolver((agentId) => {
+      const runner = {
+        withEnv: () => runner,
+        raw: async () => '',
+        clone: async () => {
+          cloned.push(agentId)
+          await blocked
+        },
+        pull: async () => ({ files: [], insertions: 0, deletions: 0 }),
+        status: async () => ({ current: null, tracking: null, ahead: 0, behind: 0, files: [], clean: true }),
+        log: async () => []
+      } as GitRunner
+      return runner
+    })
+
+    const first = prefetchWorkspace(clusterAgent('bot-one', shared))
+    const second = prefetchWorkspace(clusterAgent('bot-two', shared))
+    // Both arrive while the other is in flight, which is the race the lock exists for.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    release()
+    await Promise.all([first, second])
+    expect(cloned.sort()).toEqual(['bot-one', 'bot-two'])
   })
 
   it('has no git call site left outside the seam', () => {


### PR DESCRIPTION
Closes the last two items of #815.

## Cancellation into the sandbox

A daemon-side abort only unblocked *this* side's wait — the git in the sandbox kept running. That is precisely the failure the local runner's abort-kills-the-child behaviour exists to prevent: an abandoned git keeps `index.lock` and wedges the next session's pull. So on the cluster path the 4.5 s pull and 15 s review-fetch budgets were budgets in name only.

- new `shim/cancel` frame, **fenced with credential and generation** like every other post-binding frame, so a replayed cancel from a previous incarnation cannot kill live work
- the shim tracks in-flight non-ACP work per request id and aborts it (ACP streams keep their own lifecycle)
- the exec handler passes the signal to the child and classifies `ABORT_ERR` — which carries neither `killed` nor a `signal`, so without that branch it read as a spawn failure
- a request **timeout** now sends the cancel too: giving up locally while the child runs is the same bug wearing a different coat

`ShimRequester.request` now takes an options object instead of a positional timeout. Worth knowing for anyone changing these signatures: this package's `tsconfig` includes only `src`, so the one stale call site in a test surfaced as a *failing test*, not a type error.

## Clone lock keying

Raised on #835. The lock was keyed on the textual cwd. For local agents that is the intent — one path is one checkout, and coalescing is the whole point. For cluster agents the same path is a **different filesystem per agent**, so coalescing hands one agent the other's clone and looks like success. The key now includes the agent id exactly when a resolver claims that agent; local sharing is untouched, and the pre-existing single-flight test still proves it.

## Two tests that were worthless before I fixed them

Both found by reverting the fix and checking the test actually fails:

1. The first cancellation test searched for the git child by the **FIFO path** — which lives in the child's *env*, not its argv, so `pgrep -f` never matched. The test "passed" having observed nothing at all. It now marks the child with a unique token in argv.
2. The fencing test sent a cancel for an **invented request id**, which misses the in-flight lookup whether or not the fencing exists. It now cancels the real id and differs from a valid cancel *only* in the generation, so the child surviving can only be the fencing.

Everything else was verified the same way: reverting the client's cancel handling, the timeout-side cancel, and the clone key each fails exactly its own test.

## Verification

- 256 tests across the shim, cluster, workspace, session-manager and git suites
- cancellation covered end to end against a **real socket, real shim client, real hanging git**, asserting the child is *gone* rather than that the promise rejected
- typecheck, eslint, prettier, build clean; shim bundle still `node:`-only

## What #815 still leaves open

`setWorkspaceGitRunnerResolver` has no production caller yet, and `assertSafeWorkspaceGitConfig` / `writeRepoHelperConfig` still reach local git directly — so split-filesystem workspaces are not operational on this alone. Also recorded there: `env` remains a trusted input on the exec channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)