### PR TITLE
fix(daemon): audit and write workspace git config through the runner

### DIFF
--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -152,7 +152,7 @@ export function createWorkspaceGit(
         ) {
           return { agentId, isRepo: true, ok: false, detail: 'workspace origin is not a safe remote' }
         }
-        await assertSafeWorkspaceGitConfig(root)
+        await assertSafeWorkspaceGitConfig(runnerFor(root))
         const pullBranch = target.branch
         const pullTarget = workspaceGitPullTarget(expectedOrigin)
         timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -272,9 +272,12 @@ export function workspaceGitLocalEnv(): Record<string, string> {
  * separate worktree config scope is also disallowed because `--local` cannot
  * audit `.git/config.worktree`, while later daemon Git operations still read it.
  */
-export async function assertSafeWorkspaceGitConfig(cwd: string): Promise<void> {
-  const names = await gitFor(cwd)
-    .env(workspaceGitLocalEnv())
+export async function assertSafeWorkspaceGitConfig(git: GitRunner): Promise<void> {
+  // Takes a runner, not a cwd: this audits the config that the git we are about to run will
+  // actually read, so it has to run on THAT filesystem. Auditing the daemon's disk for a
+  // cluster-backed workspace would pass a check nothing had performed.
+  const names = await git
+    .withEnv(workspaceGitLocalEnv())
     .raw(['config', '--local', '--includes', '--name-only', '-z', '--list'])
   if (names.split('\0').some((name) => UNSAFE_LOCAL_WORKSPACE_GIT_CONFIG.test(name))) {
     throw new Error('workspace Git configuration contains a disallowed network override or executable setting')
@@ -402,8 +405,8 @@ export function sessionGitEnv(agentId: string, commitIdentity?: GitCommitIdentit
 }
 
 /** Post-clone: pin the repo-local helper so agent-run git in the checkout works. */
-export async function writeRepoHelperConfig(cwd: string, agentId: string): Promise<void> {
-  const git = gitFor(cwd).env(workspaceGitLocalEnv())
+export async function writeRepoHelperConfig(runner: GitRunner, agentId: string): Promise<void> {
+  const git = runner.withEnv(workspaceGitLocalEnv())
   // `--replace-all` on the first write resets any stale helper list from a
   // previous agent generation; addConfig(append=true) accumulates the rest.
   await git.raw(['config', '--replace-all', 'credential.https://github.com.helper', ''])

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -273,9 +273,8 @@ export function workspaceGitLocalEnv(): Record<string, string> {
  * audit `.git/config.worktree`, while later daemon Git operations still read it.
  */
 export async function assertSafeWorkspaceGitConfig(git: GitRunner): Promise<void> {
-  // Takes a runner, not a cwd: this audits the config that the git we are about to run will
-  // actually read, so it has to run on THAT filesystem. Auditing the daemon's disk for a
-  // cluster-backed workspace would pass a check nothing had performed.
+  // A runner, not a cwd: the audit must read the config the guarded git will read, which for a
+  // cluster workspace is the sandbox's — auditing this disk would pass a check nothing performed.
   const names = await git
     .withEnv(workspaceGitLocalEnv())
     .raw(['config', '--local', '--includes', '--name-only', '-z', '--list'])

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -317,7 +317,7 @@ export async function prepareWorkspace(agent: Agent, opts: PrepareWorkspaceOptio
     // The CP follows repository renames by numeric repo id. Repoint the existing
     // checkout instead of treating that canonical URL refresh as a new workspace.
     await convergeWorkspaceOrigin(agent, cwd)
-    await writeRepoHelperConfig(cwd, agent.id).catch(() => undefined)
+    await writeRepoHelperConfig(runnerFor(agent.id, cwd), agent.id).catch(() => undefined)
   } else {
     // Historical anonymous checkouts may still have credential-bearing or
     // disallowed origins even after their CP row has been sanitized.
@@ -338,7 +338,7 @@ export async function prepareWorkspace(agent: Agent, opts: PrepareWorkspaceOptio
     const timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
     try {
       const repository = gitRepoOf(agent)
-      await assertSafeWorkspaceGitConfig(cwd)
+      await assertSafeWorkspaceGitConfig(runnerFor(agent.id, cwd))
       const pullTarget = workspaceGitPullTarget(repository)
       const git = runnerFor(agent.id, cwd, abort.signal).withEnv({
         ...workspaceGitLocalEnv(),
@@ -516,7 +516,7 @@ async function fetchReviewRevision(
   const headRef = `${root}/head`
   const mergeRef = `${root}/merge`
   const repository = gitRepoOf(agent)
-  await assertSafeWorkspaceGitConfig(agent.workspace.path)
+  await assertSafeWorkspaceGitConfig(runnerFor(agent.id, agent.workspace.path))
   if (usesGithubApp(agent)) await preWarmGitCred(agent.id, 'pull')
   const pullTarget = workspaceGitPullTarget(repository)
   const abort = new AbortController()
@@ -644,14 +644,14 @@ export async function prepareSessionWorkspace(
     // prepareWorkspace's pull is best-effort (and may be disabled), but this
     // checkout runs in the daemon process. Unsafe executable config must gate
     // the worktree operation itself instead of being swallowed as a pull error.
-    await assertSafeWorkspaceGitConfig(agent.workspace.path)
+    await assertSafeWorkspaceGitConfig(runnerFor(agent.id, agent.workspace.path))
     await runnerFor(agent.id, agent.workspace.path)
       .withEnv(workspaceGitLocalEnv())
       .raw(['worktree', 'add', '--detach', cwd, target])
   } else if (review) {
     // Re-audit at the checkout boundary rather than relying on the earlier
     // network fetch audit; repository config may have changed while fetching.
-    await assertSafeWorkspaceGitConfig(agent.workspace.path)
+    await assertSafeWorkspaceGitConfig(runnerFor(agent.id, agent.workspace.path))
     const worktreeGit = runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
     await worktreeGit.raw(['reset', '--hard', target])
     await worktreeGit.raw(['clean', '-ffdx'])
@@ -924,7 +924,7 @@ async function cloneRepoAt(agent: Agent, cwd: string): Promise<void> {
     // Pin the repo-local helper so AGENT-run git in this checkout authenticates
     // through the daemon too — the "no credentials on the machine, but the agent
     // can still push" half of the design.
-    if (githubApp) await writeRepoHelperConfig(cwd, agent.id)
+    if (githubApp) await writeRepoHelperConfig(runnerFor(agent.id, cwd), agent.id)
   })().finally(() => {
     cloneInFlight.delete(key)
   })

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -54,8 +54,8 @@ const POLLUTED = {
   GIT_CONFIG_VALUE_0: 'vim'
 } as const
 
-// The safety audit now takes a runner, since it must read the config that the git it guards will
-// actually read — for a cluster workspace that is the sandbox's filesystem, not this one's.
+// The audit takes a runner: it must read the config the git it guards reads, which for a cluster
+// workspace is the sandbox's filesystem rather than this one.
 function localRunner(cwd: string): GitRunner {
   return new LocalGitRunner(gitFor(cwd))
 }
@@ -325,9 +325,9 @@ describe('gitEnvBase', () => {
   })
 
   it(`audits the config of the filesystem the RUNNER reaches, not this daemon's disk`, async () => {
-    // The whole point of the audit taking a runner: for a cluster workspace the config that the
-    // guarded git will read lives on the sandbox pod, and a check performed here would be a check
-    // performed on the wrong machine — passing while the real config is hostile.
+    // Why the audit takes a runner: a cluster workspace's config lives on the sandbox pod, so a
+    // check performed here is performed on the wrong machine — passing while the real config is
+    // hostile.
     const workspace = mkdtempSync(join(tmpdir(), 'git-audit-filesystem-'))
     const localEnv = workspaceGitLocalEnv()
     try {
@@ -335,8 +335,7 @@ describe('gitEnvBase', () => {
       execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
       await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).resolves.toBeUndefined()
 
-      // ...while the runner's filesystem reports a hostile setting. The audit must follow the
-      // runner and refuse.
+      // ...while the runner's filesystem reports a hostile setting: the audit must follow it.
       const hostile: GitRunner = {
         withEnv: () => hostile,
         raw: async () => 'filter.generated.process\0',
@@ -347,8 +346,7 @@ describe('gitEnvBase', () => {
       }
       await expect(assertSafeWorkspaceGitConfig(hostile)).rejects.toThrow(/executable setting/)
 
-      // And the converse, which is what proves the local disk is not being consulted: an unsafe
-      // LOCAL config while the runner reports a clean one must pass.
+      // The converse proves the local disk is not consulted: unsafe LOCAL, clean runner, passes.
       execFileSync('git', ['-C', workspace, 'config', 'filter.generated.process', './evil'], { env: localEnv })
       await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).rejects.toThrow(/executable setting/)
       const clean: GitRunner = { ...hostile, withEnv: () => clean, raw: async () => '' }

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { simpleGit } from 'simple-git'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../src/cp/gitcred-server.js'
+import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
 import {
   assertSafeWorkspaceGitConfig,
   cloneGitEnv,
@@ -52,6 +53,12 @@ const POLLUTED = {
   GIT_CONFIG_KEY_0: 'core.editor',
   GIT_CONFIG_VALUE_0: 'vim'
 } as const
+
+// The safety audit now takes a runner, since it must read the config that the git it guards will
+// actually read — for a cluster workspace that is the sandbox's filesystem, not this one's.
+function localRunner(cwd: string): GitRunner {
+  return new LocalGitRunner(gitFor(cwd))
+}
 
 function configPairs(env: Record<string, string>): Array<[string | undefined, string | undefined]> {
   return Array.from({ length: Number(env.GIT_CONFIG_COUNT ?? 0) }, (_, index) => [
@@ -265,7 +272,7 @@ describe('gitEnvBase', () => {
           env: workspaceGitEnvBase(repository)
         }).trim()
       ).toBe(repository)
-      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/disallowed network override/)
+      await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).rejects.toThrow(/disallowed network override/)
     } finally {
       rmSync(workspace, { recursive: true, force: true })
     }
@@ -311,7 +318,41 @@ describe('gitEnvBase', () => {
       execFileSync('git', ['-C', workspace, 'config', 'fetch.bundleURI', 'https://127.0.0.1/private.bundle'], {
         env: workspaceGitLocalEnv()
       })
-      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/disallowed network override/)
+      await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).rejects.toThrow(/disallowed network override/)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it(`audits the config of the filesystem the RUNNER reaches, not this daemon's disk`, async () => {
+    // The whole point of the audit taking a runner: for a cluster workspace the config that the
+    // guarded git will read lives on the sandbox pod, and a check performed here would be a check
+    // performed on the wrong machine — passing while the real config is hostile.
+    const workspace = mkdtempSync(join(tmpdir(), 'git-audit-filesystem-'))
+    const localEnv = workspaceGitLocalEnv()
+    try {
+      // Locally CLEAN...
+      execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
+      await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).resolves.toBeUndefined()
+
+      // ...while the runner's filesystem reports a hostile setting. The audit must follow the
+      // runner and refuse.
+      const hostile: GitRunner = {
+        withEnv: () => hostile,
+        raw: async () => 'filter.generated.process\0',
+        clone: async () => undefined,
+        pull: async () => ({ files: [], insertions: 0, deletions: 0 }),
+        status: async () => ({ current: null, tracking: null, ahead: 0, behind: 0, files: [], clean: true }),
+        log: async () => []
+      }
+      await expect(assertSafeWorkspaceGitConfig(hostile)).rejects.toThrow(/executable setting/)
+
+      // And the converse, which is what proves the local disk is not being consulted: an unsafe
+      // LOCAL config while the runner reports a clean one must pass.
+      execFileSync('git', ['-C', workspace, 'config', 'filter.generated.process', './evil'], { env: localEnv })
+      await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).rejects.toThrow(/executable setting/)
+      const clean: GitRunner = { ...hostile, withEnv: () => clean, raw: async () => '' }
+      await expect(assertSafeWorkspaceGitConfig(clean)).resolves.toBeUndefined()
     } finally {
       rmSync(workspace, { recursive: true, force: true })
     }
@@ -325,7 +366,7 @@ describe('gitEnvBase', () => {
       execFileSync('git', ['-C', workspace, 'config', 'filter.generated.process', './filter-process'], {
         env: localEnv
       })
-      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/executable setting/)
+      await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).rejects.toThrow(/executable setting/)
     } finally {
       rmSync(workspace, { recursive: true, force: true })
     }
@@ -340,13 +381,13 @@ describe('gitEnvBase', () => {
       execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
       writeFileSync(include, '[core]\n\thooksPath = .github/.githooks\n')
       execFileSync('git', ['-C', workspace, 'config', 'include.path', include], { env: localEnv })
-      await expect(assertSafeWorkspaceGitConfig(workspace)).resolves.toBeUndefined()
+      await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).resolves.toBeUndefined()
 
       writeFileSync(
         include,
         '[core]\n\thooksPath = .github/.githooks\n[url "https://127.0.0.1.invalid/"]\n\tinsteadOf = https://github.com/\n'
       )
-      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/disallowed network override/)
+      await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).rejects.toThrow(/disallowed network override/)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -364,7 +405,7 @@ describe('gitEnvBase', () => {
         env: localEnv
       })
 
-      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/executable setting/)
+      await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).rejects.toThrow(/executable setting/)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -378,7 +419,7 @@ describe('gitEnvBase', () => {
       execFileSync('git', ['-C', workspace, 'config', 'extensions.worktreeConfig', 'true'], { env: localEnv })
       writeFileSync(join(workspace, '.git', 'config.worktree'), '[filter "evil"]\n\tsmudge = ./filter-smudge\n')
 
-      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/executable setting/)
+      await expect(assertSafeWorkspaceGitConfig(localRunner(workspace))).rejects.toThrow(/executable setting/)
     } finally {
       rmSync(workspace, { recursive: true, force: true })
     }


### PR DESCRIPTION
Closes the remaining in-scope gap of #815, flagged on #835.

## What

`assertSafeWorkspaceGitConfig` and `writeRepoHelperConfig` were the last two helpers reaching local git directly — both took a cwd and built their own simple-git. Both now take a `GitRunner`, and all eight call sites pass one from the seam.

For the audit this is not merely inconsistent, it is **the check running on the wrong machine**. It exists to reject a checkout-owned network override or executable setting *before* the daemon runs git on that checkout. So it has to read the config that the guarded git will actually read — and for a cluster workspace that config lives on the sandbox pod. Auditing this daemon's disk would have reported safe while the real config was hostile: a security check that passes by looking somewhere else.

## The test

Pinned in both directions, because only one of them is the interesting one:

- clean local checkout + runner reporting `filter.generated.process` → **must refuse** (it follows the runner)
- **unsafe** local checkout + runner reporting clean → **must pass** (this is what proves the local disk is no longer consulted)

Reverting the helper to read a cwd fails that test along with every other audit test in the file.

## Verification

- 330 tests across the git-injection, workspace, session-manager, shim, cluster and daemon-hook suites
- typecheck, eslint, prettier, build clean; shim bundle still `node:`-only

## #815 after this

The migration is complete: no workspace git path reaches simple-git outside the seam. What remains there is not migration work but two open decisions, recorded on the issue — `setWorkspaceGitRunnerResolver` still has no production caller (that is the cloud wiring, not this seam), and `env` remains a trusted input on the exec channel, which cannot be filtered without moving credential-helper and `hooksPath` policy into the shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)