### PR TITLE
feat(daemon): staged cluster launch metrics and operability counters

### DIFF
--- a/packages/daemon/src/k8s/cluster-driver.ts
+++ b/packages/daemon/src/k8s/cluster-driver.ts
@@ -138,15 +138,16 @@ export class ClusterSpawnDriver implements SpawnDriver {
     }
   }
 
-  /** Wake a suspended Sandbox, or confirm it is already running. */
-  async wake(agentId: string): Promise<void> {
+  /** Wake a suspended Sandbox, or confirm it is already running. Reports the mode it found, which
+   *  is the only place a CACHED launch can learn whether it is resuming or already warm. */
+  async wake(agentId: string): Promise<OperatingMode | undefined> {
     if (this.draining.has(agentId)) {
       // A drain request is in flight: new messages queue rather than reviving the instance,
       // or one message would resurrect the image the rollout is replacing.
       this.deps.log.info(`cluster: holding agent ${agentId} suspended — a drain request is pending`)
-      return
+      return undefined
     }
-    await this.setMode(agentId, 'Running')
+    return await this.setMode(agentId, 'Running')
   }
 
   /** Suspend an idle Sandbox. The object and its volume survive; only the pod goes. */
@@ -161,28 +162,35 @@ export class ClusterSpawnDriver implements SpawnDriver {
    * correct response is to look again — and the retry budget is finite because a permanently
    * invalid patch would otherwise loop forever.
    */
-  private setMode(agentId: string, desired: OperatingMode): Promise<void> {
+  private setMode(agentId: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
     const previous = this.modeQueue.get(agentId) ?? Promise.resolve()
     const next = previous.catch(() => undefined).then(() => this.applyMode(agentId, desired))
     // Keep the chain even when a link rejects, so a failed transition cannot strand the queue.
     this.modeQueue.set(
       agentId,
-      next.catch(() => undefined)
+      next.then(
+        () => undefined,
+        () => undefined
+      )
     )
     return next
   }
 
-  private async applyMode(agentId: string, desired: OperatingMode): Promise<void> {
+  private async applyMode(agentId: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
     const launch = this.launches.get(agentId)
     if (!launch) throw new Error(`no sandbox launch recorded for agent ${agentId}`)
+    // The mode observed on the FIRST read, before this call changed anything. A later attempt
+    // sees the state we produced, which would say nothing about where the launch started.
+    let first: OperatingMode | undefined
     for (let attempt = 1; attempt <= MAX_MODE_ATTEMPTS; attempt += 1) {
       const sandbox = await this.deps.api.getSandbox(launch.sandboxName)
       const observed = sandbox.spec?.operatingMode ?? 'Running'
-      if (observed === desired) return
+      if (observed === desired) return first ?? observed
+      first ??= observed
       try {
         await this.deps.api.setOperatingMode(launch.sandboxName, desired, observed)
         this.deps.log.info(`cluster: agent ${agentId} sandbox ${launch.sandboxName} → ${desired}`)
-        return
+        return first
       } catch (err) {
         if (!(err instanceof OperatingModeRejectedError)) throw err
         this.metrics.writeRetry('rejected_precondition')
@@ -277,7 +285,11 @@ export class ClusterSpawnDriver implements SpawnDriver {
       const launch = await this.ensureSandbox(agentId, timer)
       // Resume BEFORE waiting: suspension deleted the pod, so readiness cannot arrive until
       // something asks for Running.
-      await this.wake(agentId)
+      const modeBeforeWake = await this.wake(agentId)
+      // A launch this daemon already has cached returns from ensureSandbox before any sandbox
+      // read, so this is where the ordinary `launch → suspend → launch` resume learns what it is.
+      // Without it that path — the COMMON one — reported `warm` and never entered resume p95.
+      if (modeBeforeWake) timer.observedPath(modeBeforeWake === 'Suspended' ? 'resume' : 'warm')
       timer.mark('mode_running')
       await this.awaitReady(launch.sandboxName)
       timer.mark('pod_ready')
@@ -294,9 +306,19 @@ export class ClusterSpawnDriver implements SpawnDriver {
       })
       session.attach(connection)
       this.sessions.set(agentId, session)
-      const runtime = createRemoteRuntime({ session, request, log: this.deps.log, metrics: this.metrics })
-      timer.mark('runtime_ready')
-      timer.finish('ok')
+      // The open is asynchronous, so the stage closes when the runtime reports — not when the
+      // call returns. Marking it here measured the cost of constructing a stream pair and called
+      // a runtime that never started a success.
+      const runtime = createRemoteRuntime({
+        session,
+        request,
+        log: this.deps.log,
+        metrics: this.metrics,
+        onRuntimeOpen: (outcome) => {
+          timer.mark('runtime_ready')
+          timer.finish(outcome)
+        }
+      })
       return runtime
     } catch (err) {
       // Timeouts are the interesting failure — they are what a missed target looks like — so
@@ -338,6 +360,8 @@ function createRemoteRuntime(opts: {
   request: SpawnRequest
   log: { info: (m: string) => void; warn: (m: string) => void }
   metrics?: ClusterMetrics
+  /** Reports when the ACP open resolved, which is when the runtime is genuinely ready. */
+  onRuntimeOpen?: (outcome: 'ok' | 'error') => void
 }): SpawnedRuntime {
   const exitListeners: Array<() => void> = []
   let stopped = false
@@ -399,10 +423,14 @@ function createRemoteRuntime(opts: {
     }
   })
 
-  void opened.catch((err: unknown) => {
-    opts.log.warn(`cluster: runtime failed to start in the sandbox (${(err as Error).message})`)
-    finish()
-  })
+  void opened.then(
+    () => opts.onRuntimeOpen?.('ok'),
+    (err: unknown) => {
+      opts.log.warn(`cluster: runtime failed to start in the sandbox (${(err as Error).message})`)
+      opts.onRuntimeOpen?.('error')
+      finish()
+    }
+  )
 
   return {
     toAgent,

--- a/packages/daemon/src/k8s/cluster-driver.ts
+++ b/packages/daemon/src/k8s/cluster-driver.ts
@@ -344,11 +344,11 @@ export class ClusterSpawnDriver implements SpawnDriver {
       })
       return runtime
     } catch (err) {
-      // Timeouts are the interesting failure — they are what a missed target looks like — so
-      // they are distinguished from an outright error rather than pooled into one bucket.
-      timer.finish(
-        /did not become ready|did not bind a sandbox|bound in time/.test((err as Error).message) ? 'timeout' : 'error'
-      )
+      // Timeouts are the interesting failure — they are what a missed target looks like — so they
+      // are distinguished from an outright error. By TYPE: all three launch deadlines (claim bind,
+      // pod readiness, channel bind) throw LaunchTimeoutError, and the message regex this replaced
+      // silently stopped covering the channel wait the moment its wording changed.
+      timer.finish(err instanceof LaunchTimeoutError ? 'timeout' : 'error')
       throw err
     }
   }

--- a/packages/daemon/src/k8s/cluster-driver.ts
+++ b/packages/daemon/src/k8s/cluster-driver.ts
@@ -1,3 +1,4 @@
+import { LaunchTimer, noopClusterMetrics, type ClusterMetrics } from './cluster-metrics.js'
 import { Backoff, systemClock, type Clock } from '@agentconnect.md/connection'
 import type { SpawnDriver, SpawnRequest, SpawnedRuntime } from '../acp/spawn-driver.js'
 import type { ShimCapability } from '../shim/protocol.js'
@@ -31,6 +32,8 @@ export interface ClusterDriverDeps {
   log: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
   /** How long to wait for a pod to become Ready and its shim to bind. */
   readyTimeoutMs?: number
+  /** Staged latency and operability recorder; omit to record nothing. */
+  metrics?: ClusterMetrics
 }
 
 const DEFAULT_READY_TIMEOUT_MS = 90_000
@@ -52,6 +55,7 @@ interface Launch {
  * existing agent from starting or stopping its runtime.
  */
 export class ClusterSpawnDriver implements SpawnDriver {
+  private readonly metrics: ClusterMetrics
   private readonly launches = new Map<string, Launch>()
   private readonly generations = new Map<string, number>()
   /** Agents whose Sandbox carries a drain request: hold off waking until it clears. */
@@ -67,6 +71,7 @@ export class ClusterSpawnDriver implements SpawnDriver {
 
   constructor(private readonly deps: ClusterDriverDeps) {
     this.clock = deps.clock ?? systemClock
+    this.metrics = deps.metrics ?? noopClusterMetrics
   }
 
   claimName(agentId: string): string {
@@ -81,11 +86,11 @@ export class ClusterSpawnDriver implements SpawnDriver {
    * bypasses warm-pool adoption, and pool pods are stamped before any user exists, so
    * identity travels over the shim handshake instead.
    */
-  async ensureSandbox(agentId: string): Promise<Launch> {
+  async ensureSandbox(agentId: string, timer?: LaunchTimer): Promise<Launch> {
     const existing = this.launches.get(agentId)
     if (existing) return existing
     const name = this.claimName(agentId)
-    await this.deps.api.ensureClaim({
+    const ensured = await this.deps.api.ensureClaim({
       metadata: {
         name,
         annotations: undefined
@@ -100,7 +105,15 @@ export class ClusterSpawnDriver implements SpawnDriver {
     // here would block the only call that could bring it back. Resume is "patch Running,
     // then wait", in that order.
     const sandboxName = await this.awaitBoundSandbox(name)
+    timer?.mark('claim_bound')
     const sandbox = await this.deps.api.getSandbox(sandboxName)
+    // Cold is "the claim did not exist", which is the launch that pays PVC provisioning and an
+    // image pull. A claim that existed and a Sandbox already Running is warm; existing and
+    // Suspended is the resume path. Guessing from elapsed time instead would make the metric
+    // depend on the thing it is supposed to measure.
+    timer?.observedPath(
+      ensured.created ? 'cold' : (sandbox.spec?.operatingMode ?? 'Running') === 'Running' ? 'warm' : 'resume'
+    )
     const sandboxUid = sandbox.metadata?.uid
     if (!sandboxUid) throw new Error(`sandbox ${sandboxName} has no metadata.uid to bind against`)
     const generation = (this.generations.get(agentId) ?? 0) + 1
@@ -172,6 +185,7 @@ export class ClusterSpawnDriver implements SpawnDriver {
         return
       } catch (err) {
         if (!(err instanceof OperatingModeRejectedError)) throw err
+        this.metrics.writeRetry('rejected_precondition')
         this.deps.log.debug?.(
           `cluster: ${desired} write for ${launch.sandboxName} rejected (attempt ${attempt}) — re-reading`
         )
@@ -255,34 +269,58 @@ export class ClusterSpawnDriver implements SpawnDriver {
     if (this.draining.has(agentId)) {
       // Launching now would wait out the readiness timeout against a sandbox we are
       // deliberately holding down. Say so instead of timing out.
+      this.metrics.launch('warm', 'draining', 0)
       throw new Error(`agent ${agentId} is draining for an image rollout — retry once it clears`)
     }
-    const launch = await this.ensureSandbox(agentId)
-    // Resume BEFORE waiting: suspension deleted the pod, so readiness cannot arrive until
-    // something asks for Running.
-    await this.wake(agentId)
-    await this.awaitReady(launch.sandboxName)
-    const connection = await this.deps.awaitChannel(
-      agentId,
-      launch.generation,
-      this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
-    )
-    const session = new ShimSession(agentId, launch.generation, {
-      setTimeout: (fn, ms) => this.clock.setTimeout(fn, ms),
-      clearTimeout: (handle) => this.clock.clearTimeout(handle as never)
-    })
-    session.attach(connection)
-    this.sessions.set(agentId, session)
-    return createRemoteRuntime({ session, request, log: this.deps.log })
+    const timer = new LaunchTimer(this.metrics, () => this.clock.now())
+    try {
+      const launch = await this.ensureSandbox(agentId, timer)
+      // Resume BEFORE waiting: suspension deleted the pod, so readiness cannot arrive until
+      // something asks for Running.
+      await this.wake(agentId)
+      timer.mark('mode_running')
+      await this.awaitReady(launch.sandboxName)
+      timer.mark('pod_ready')
+      const connection = await this.deps.awaitChannel(
+        agentId,
+        launch.generation,
+        this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
+      )
+      timer.mark('shim_handshake')
+      this.metrics.channel('bound')
+      const session = new ShimSession(agentId, launch.generation, {
+        setTimeout: (fn, ms) => this.clock.setTimeout(fn, ms),
+        clearTimeout: (handle) => this.clock.clearTimeout(handle as never)
+      })
+      session.attach(connection)
+      this.sessions.set(agentId, session)
+      const runtime = createRemoteRuntime({ session, request, log: this.deps.log, metrics: this.metrics })
+      timer.mark('runtime_ready')
+      timer.finish('ok')
+      return runtime
+    } catch (err) {
+      // Timeouts are the interesting failure — they are what a missed target looks like — so
+      // they are distinguished from an outright error rather than pooled into one bucket.
+      timer.finish(
+        /did not become ready|did not bind a sandbox|bound in time/.test((err as Error).message) ? 'timeout' : 'error'
+      )
+      throw err
+    }
   }
 
   /** Re-attach a renewed or replacement connection to the launch it belongs to. */
   onChannelBound(connection: ShimConnection): void {
-    this.sessions.get(connection.binding.agentId)?.attach(connection)
+    const session = this.sessions.get(connection.binding.agentId)
+    if (!session) return
+    // Counted apart from the first bind: a re-establishment rate is the signal that renewals or
+    // pod churn are happening more than they should, and pooling the two hides exactly that.
+    this.metrics.channel('reestablished')
+    session.attach(connection)
   }
 
   /** Report that an agent's channel is gone, so its runtime learns rather than hanging. */
   onChannelLost(agentId: string, reason: string): void {
+    this.metrics.channel('dropped')
     this.sessions.get(agentId)?.lose(reason)
   }
 }
@@ -299,6 +337,7 @@ function createRemoteRuntime(opts: {
   session: ShimSession
   request: SpawnRequest
   log: { info: (m: string) => void; warn: (m: string) => void }
+  metrics?: ClusterMetrics
 }): SpawnedRuntime {
   const exitListeners: Array<() => void> = []
   let stopped = false
@@ -374,7 +413,14 @@ function createRemoteRuntime(opts: {
       stopped = true
       await opened.catch(() => undefined)
       if (streamId) {
-        await opts.session.request('acp', { op: 'close', streamId, deadlineMs }).catch(() => undefined)
+        // A close that does not land means the rollout cannot confirm this runtime went quiet —
+        // invisible before, because the failure was swallowed to keep teardown best-effort.
+        await opts.session.request('acp', { op: 'close', streamId, deadlineMs }).catch(() => {
+          opts.metrics?.drainTimeout()
+          opts.log.warn(
+            `cluster: runtime for agent ${opts.session.agentId} did not confirm close within ${deadlineMs}ms`
+          )
+        })
       }
       opts.session.offEvent(onEvent)
     }

--- a/packages/daemon/src/k8s/cluster-driver.ts
+++ b/packages/daemon/src/k8s/cluster-driver.ts
@@ -3,6 +3,7 @@ import { Backoff, systemClock, type Clock } from '@agentconnect.md/connection'
 import type { SpawnDriver, SpawnRequest, SpawnedRuntime } from '../acp/spawn-driver.js'
 import type { ShimCapability } from '../shim/protocol.js'
 import type { ShimConnection } from '../shim/listener.js'
+import { ShimRequestTimeoutError } from '../shim/channels.js'
 import { ShimSession } from '../shim/session.js'
 import type { SpawnRecord } from '../shim/binding.js'
 import { OperatingModeRejectedError, isSandboxReady, type OperatingMode, type SandboxApi } from './sandbox-api.js'
@@ -34,6 +35,15 @@ export interface ClusterDriverDeps {
   readyTimeoutMs?: number
   /** Staged latency and operability recorder; omit to record nothing. */
   metrics?: ClusterMetrics
+}
+
+/** A launch stage that ran out of time. Typed, because a missed target and a broken cluster are
+ *  different operational stories and telling them apart by error text is a liability. */
+export class LaunchTimeoutError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LaunchTimeoutError'
+  }
 }
 
 const DEFAULT_READY_TIMEOUT_MS = 90_000
@@ -133,7 +143,9 @@ export class ClusterSpawnDriver implements SpawnDriver {
     for (;;) {
       const sandbox = await this.deps.api.getSandbox(sandboxName).catch(() => undefined)
       if (sandbox && isSandboxReady(sandbox)) return
-      if (this.clock.now() >= deadline) throw new Error(`sandbox ${sandboxName} did not become ready in time`)
+      if (this.clock.now() >= deadline) {
+        throw new LaunchTimeoutError(`sandbox ${sandboxName} did not become ready in time`)
+      }
       await new Promise<void>((resolve) => this.clock.setTimeout(resolve, backoff.next()))
     }
   }
@@ -258,7 +270,7 @@ export class ClusterSpawnDriver implements SpawnDriver {
       // Bound is enough here; readiness is a separate wait that follows the resume.
       if (name) return name
       if (this.clock.now() >= deadline) {
-        throw new Error(`claim ${claimName} did not bind a sandbox in time`)
+        throw new LaunchTimeoutError(`claim ${claimName} did not bind a sandbox in time`)
       }
       await new Promise<void>((resolve) => this.clock.setTimeout(resolve, backoff.next()))
     }
@@ -293,11 +305,19 @@ export class ClusterSpawnDriver implements SpawnDriver {
       timer.mark('mode_running')
       await this.awaitReady(launch.sandboxName)
       timer.mark('pod_ready')
-      const connection = await this.deps.awaitChannel(
-        agentId,
-        launch.generation,
-        this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
-      )
+      const channelTimeoutMs = this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
+      const waitingSince = this.clock.now()
+      const connection = await this.deps
+        .awaitChannel(agentId, launch.generation, channelTimeoutMs)
+        .catch((err: unknown) => {
+          // awaitChannel is supplied by the host, so its error text is not ours to match on.
+          // Elapsed-versus-the-deadline-we-set is a fact we own, and it is what distinguishes a
+          // channel that never arrived from one that failed for another reason.
+          if (this.clock.now() - waitingSince >= channelTimeoutMs) {
+            throw new LaunchTimeoutError(`no shim channel bound for agent ${agentId} in time`)
+          }
+          throw err
+        })
       timer.mark('shim_handshake')
       this.metrics.channel('bound')
       const session = new ShimSession(agentId, launch.generation, {
@@ -315,7 +335,10 @@ export class ClusterSpawnDriver implements SpawnDriver {
         log: this.deps.log,
         metrics: this.metrics,
         onRuntimeOpen: (outcome) => {
-          timer.mark('runtime_ready')
+          // Only a successful open crossed the "runtime is up" boundary. A rejected one recorded
+          // as a completed stage would sit in the runtime-ready latency distribution as a fast
+          // success, and the stage histogram carries no outcome to filter it back out.
+          if (outcome === 'ok') timer.mark('runtime_ready')
           timer.finish(outcome)
         }
       })
@@ -360,8 +383,9 @@ function createRemoteRuntime(opts: {
   request: SpawnRequest
   log: { info: (m: string) => void; warn: (m: string) => void }
   metrics?: ClusterMetrics
-  /** Reports when the ACP open resolved, which is when the runtime is genuinely ready. */
-  onRuntimeOpen?: (outcome: 'ok' | 'error') => void
+  /** Reports how the ACP open resolved. A timeout is separated from a failure because the two
+   *  mean different things: one is a slow cluster, the other a runtime that will not start. */
+  onRuntimeOpen?: (outcome: 'ok' | 'timeout' | 'error') => void
 }): SpawnedRuntime {
   const exitListeners: Array<() => void> = []
   let stopped = false
@@ -427,7 +451,7 @@ function createRemoteRuntime(opts: {
     () => opts.onRuntimeOpen?.('ok'),
     (err: unknown) => {
       opts.log.warn(`cluster: runtime failed to start in the sandbox (${(err as Error).message})`)
-      opts.onRuntimeOpen?.('error')
+      opts.onRuntimeOpen?.(err instanceof ShimRequestTimeoutError ? 'timeout' : 'error')
       finish()
     }
   )

--- a/packages/daemon/src/k8s/cluster-metrics.ts
+++ b/packages/daemon/src/k8s/cluster-metrics.ts
@@ -1,0 +1,157 @@
+import { metrics } from '@opentelemetry/api'
+
+// Cold start and resume are different paths with different costs — the first pays PVC
+// provisioning and an image pull, the second pays a PVC re-attach — so a single distribution
+// over both cannot settle either target. Every stage carries the path it was measured on.
+export type LaunchPath = 'cold' | 'resume' | 'warm'
+
+// The stages a launch passes through, named for the boundary each one ends at.
+export type LaunchStage =
+  | 'claim_bound' // claim submitted → a Sandbox is named
+  | 'mode_running' // resume patch acknowledged
+  | 'pod_ready' // Sandbox reports Ready
+  | 'shim_handshake' // pod → the shim's channel is bound
+  | 'runtime_ready' // channel → the ACP runtime is up
+  | 'session_replay' // session/load replay
+  | 'first_token' // first token of the first turn
+
+export type LaunchOutcome = 'ok' | 'timeout' | 'draining' | 'error'
+
+// Fixed daemon-authored reasons only. A rejection reason is the one thing a failing handshake
+// tells an operator, and a free-form string here would be both unbounded cardinality and a
+// route for a peer-supplied value into a metric label.
+export type HandshakeRejection = 'unauthenticated' | 'unknown_pod' | 'stale_generation' | 'unavailable' | 'malformed'
+
+export type ChannelEvent = 'bound' | 'dropped' | 'reestablished'
+
+export interface ClusterMetrics {
+  /** One stage of a launch, tagged with the path it was measured on. */
+  stage(stage: LaunchStage, path: LaunchPath, durationMs: number): void
+  /** The whole launch, so the target can be read without summing stages. */
+  launch(path: LaunchPath, outcome: LaunchOutcome, durationMs: number): void
+  handshakeRejected(reason: HandshakeRejection): void
+  /**
+   * A TokenReview the API SERVER rejected, which is not the same event as this daemon refusing
+   * a bound frame — one is an identity failure, the other our own fencing doing its job. D7
+   * shipped a bug from exactly that conflation, so they stay separate counters.
+   */
+  tokenReviewRejected(): void
+  /** A write we retried because the object moved under us. */
+  writeRetry(kind: 'conflict' | 'rejected_precondition'): void
+  /** A watch that had to re-LIST because its resume point was too old. */
+  watchRelist(source: 'status' | 'in_band'): void
+  channel(event: ChannelEvent): void
+  /** A drain handshake that never completed, so the rollout could not confirm quiescence. */
+  drainTimeout(): void
+}
+
+const meter = metrics.getMeter('@agentconnect.md/daemon-cluster', '1.0.0')
+
+const stageDuration = meter.createHistogram('agentconnect.cluster.launch.stage_duration', {
+  unit: 'ms',
+  description: 'Duration of one cluster launch stage, by stage and launch path'
+})
+const launchDuration = meter.createHistogram('agentconnect.cluster.launch.duration', {
+  unit: 'ms',
+  description: 'End-to-end cluster launch duration, by launch path and outcome'
+})
+const handshakeRejections = meter.createCounter('agentconnect.cluster.shim.handshake_rejections', {
+  unit: '{rejection}',
+  description: 'Shim handshakes the daemon refused, by daemon-authored reason'
+})
+const tokenReviewRejections = meter.createCounter('agentconnect.cluster.shim.tokenreview_rejections', {
+  unit: '{rejection}',
+  description: 'ServiceAccount tokens the API server did not accept'
+})
+const writeRetries = meter.createCounter('agentconnect.cluster.api.write_retries', {
+  unit: '{retry}',
+  description: 'Kubernetes writes retried after the object moved under us'
+})
+const watchRelists = meter.createCounter('agentconnect.cluster.api.watch_relists', {
+  unit: '{relist}',
+  description: 'Watches re-LISTed because their resume point expired'
+})
+const channelEvents = meter.createCounter('agentconnect.cluster.shim.channel_events', {
+  unit: '{event}',
+  description: 'Shim channel binds, drops and re-establishments'
+})
+const drainTimeouts = meter.createCounter('agentconnect.cluster.drain.timeouts', {
+  unit: '{timeout}',
+  description: 'Drain handshakes that did not complete before their deadline'
+})
+
+// Attributes are a closed set of daemon-authored enums: no agent id, pod name, sandbox name or
+// org id. Those are unbounded in a multi-tenant deployment, and an agent id in a metric label is
+// also a tenant identifier sitting in a place nobody audits.
+export const clusterMetrics: ClusterMetrics = {
+  stage: (stage, path, durationMs) => stageDuration.record(durationMs, { stage, path }),
+  launch: (path, outcome, durationMs) => launchDuration.record(durationMs, { path, outcome }),
+  handshakeRejected: (reason) => handshakeRejections.add(1, { reason }),
+  tokenReviewRejected: () => tokenReviewRejections.add(1),
+  writeRetry: (kind) => writeRetries.add(1, { kind }),
+  watchRelist: (source) => watchRelists.add(1, { source }),
+  channel: (event) => channelEvents.add(1, { event }),
+  drainTimeout: () => drainTimeouts.add(1)
+}
+
+/** A no-op recorder, so a host that does not want metrics needs no conditional at each site. */
+export const noopClusterMetrics: ClusterMetrics = {
+  stage: () => {},
+  launch: () => {},
+  handshakeRejected: () => {},
+  tokenReviewRejected: () => {},
+  writeRetry: () => {},
+  watchRelist: () => {},
+  channel: () => {},
+  drainTimeout: () => {}
+}
+
+/**
+ * Times the stages of one launch.
+ *
+ * Stages are measured as elapsed-since-the-previous-boundary rather than from the start, because
+ * the question an operator asks is which stage is slow, and cumulative timings answer that only
+ * by subtraction. The total is recorded separately so it does not depend on stages being complete.
+ */
+export class LaunchTimer {
+  private last: number
+  private readonly started: number
+  private path?: LaunchPath
+  // Stages measured before the path was known. The path is a property of the whole launch, and
+  // the earliest stage — claim → bound — is the one that carries PVC provisioning, so emitting
+  // it under a provisional tag would file cold-start time under whatever we had assumed.
+  private readonly pending: Array<{ stage: LaunchStage; durationMs: number }> = []
+
+  constructor(
+    private readonly metrics: ClusterMetrics,
+    private readonly now: () => number
+  ) {
+    this.started = now()
+    this.last = this.started
+  }
+
+  /** The path is only knowable once the claim and the sandbox's mode have been observed. */
+  observedPath(path: LaunchPath): void {
+    this.path = path
+    for (const entry of this.pending.splice(0)) this.metrics.stage(entry.stage, path, entry.durationMs)
+  }
+
+  mark(stage: LaunchStage): void {
+    const at = this.now()
+    const durationMs = at - this.last
+    this.last = at
+    if (this.path === undefined) {
+      this.pending.push({ stage, durationMs })
+      return
+    }
+    this.metrics.stage(stage, this.path, durationMs)
+  }
+
+  // A launch that failed before its path was observed is reported as `warm`: nothing was created
+  // and nothing was resumed, so attributing it to either target would be a claim we cannot make.
+  finish(outcome: LaunchOutcome): void {
+    const path = this.path ?? 'warm'
+    for (const entry of this.pending.splice(0)) this.metrics.stage(entry.stage, path, entry.durationMs)
+    this.metrics.launch(path, outcome, this.now() - this.started)
+  }
+}

--- a/packages/daemon/src/k8s/cluster-metrics.ts
+++ b/packages/daemon/src/k8s/cluster-metrics.ts
@@ -121,6 +121,7 @@ export class LaunchTimer {
   // the earliest stage — claim → bound — is the one that carries PVC provisioning, so emitting
   // it under a provisional tag would file cold-start time under whatever we had assumed.
   private readonly pending: Array<{ stage: LaunchStage; durationMs: number }> = []
+  private finished = false
 
   constructor(
     private readonly metrics: ClusterMetrics,
@@ -130,8 +131,10 @@ export class LaunchTimer {
     this.last = this.started
   }
 
-  /** The path is only knowable once the claim and the sandbox's mode have been observed. */
+  // First observation wins. The earliest determination is the most specific — a created claim is
+  // cold whatever mode the sandbox reports a moment later — and a second call would overwrite it.
   observedPath(path: LaunchPath): void {
+    if (this.path !== undefined) return
     this.path = path
     for (const entry of this.pending.splice(0)) this.metrics.stage(entry.stage, path, entry.durationMs)
   }
@@ -149,7 +152,11 @@ export class LaunchTimer {
 
   // A launch that failed before its path was observed is reported as `warm`: nothing was created
   // and nothing was resumed, so attributing it to either target would be a claim we cannot make.
+  // Idempotent, because the runtime-open outcome arrives asynchronously while the failure path
+  // may already have reported — and two samples for one launch is a corrupted distribution.
   finish(outcome: LaunchOutcome): void {
+    if (this.finished) return
+    this.finished = true
     const path = this.path ?? 'warm'
     for (const entry of this.pending.splice(0)) this.metrics.stage(entry.stage, path, entry.durationMs)
     this.metrics.launch(path, outcome, this.now() - this.started)

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -28,6 +28,12 @@ export interface TokenReviewResult {
   error?: string
 }
 
+/** An ensure result: the claim, plus whether this call is the one that created it. */
+export interface EnsuredClaim {
+  claim: SandboxClaim
+  created: boolean
+}
+
 const POD_NAME_EXTRA = 'authentication.kubernetes.io/pod-name'
 const POD_UID_EXTRA = 'authentication.kubernetes.io/pod-uid'
 
@@ -75,15 +81,21 @@ export class SandboxApi {
 
   /** Create a claim, treating an existing one as success: names are derived from the
    *  agent id, so a retry after a partial reconcile must converge rather than fail. */
-  async ensureClaim(claim: SandboxClaim & { metadata: { name: string } }): Promise<SandboxClaim> {
+  // Reports whether it CREATED the claim, because that is the only trustworthy cold-start
+  // signal: a first claim is the launch that pays PVC provisioning and an image pull, and the
+  // AlreadyExists branch is exactly the case that does not.
+  async ensureClaim(claim: SandboxClaim & { metadata: { name: string } }): Promise<EnsuredClaim> {
     try {
-      return await this.http.json<SandboxClaim>({
+      const created = await this.http.json<SandboxClaim>({
         method: 'POST',
         path: this.claims(),
         body: { apiVersion: SANDBOX_EXTENSIONS_GROUP, kind: 'SandboxClaim', ...claim }
       })
+      return { claim: created, created: true }
     } catch (err) {
-      if (err instanceof K8sApiError && err.isAlreadyExists) return this.getClaim(claim.metadata.name)
+      if (err instanceof K8sApiError && err.isAlreadyExists) {
+        return { claim: await this.getClaim(claim.metadata.name), created: false }
+      }
       throw err
     }
   }

--- a/packages/daemon/src/k8s/watch.ts
+++ b/packages/daemon/src/k8s/watch.ts
@@ -1,4 +1,5 @@
 import { Backoff, systemClock, type Clock } from '@agentconnect.md/connection'
+import type { ClusterMetrics } from './cluster-metrics.js'
 import { K8sApiError, type K8sHttp } from './http.js'
 
 export interface K8sObject {
@@ -34,6 +35,8 @@ export interface WatchOptions {
   clock?: Clock
   backoff?: Backoff
   log?: { debug?: (message: string) => void; warn?: (message: string) => void }
+  /** Operability counters; a re-list is invisible in logs alone at any real volume. */
+  metrics?: ClusterMetrics
 }
 
 /** Clock-driven delay that leaves no listener behind — a long outage retries often
@@ -126,6 +129,7 @@ export async function* watchCollection<T extends K8sObject>(
           const status = event.object as unknown as { reason?: string; message?: string; code?: number }
           const error = new K8sApiError(status.code ?? 0, status.reason, status.message ?? 'watch error')
           if (!error.isExpired) throw error
+          options.metrics?.watchRelist('in_band')
           options.log?.debug?.(`k8s: watch ${options.path} expired in-band — re-listing`)
           resourceVersion = undefined
           break
@@ -139,6 +143,7 @@ export async function* watchCollection<T extends K8sObject>(
     } catch (err) {
       if (options.signal?.aborted) return
       if (err instanceof K8sApiError && err.isExpired) {
+        options.metrics?.watchRelist('status')
         options.log?.debug?.(`k8s: watch ${options.path} resume point expired — re-listing`)
         resourceVersion = undefined
         continue

--- a/packages/daemon/src/shim/channels.ts
+++ b/packages/daemon/src/shim/channels.ts
@@ -17,6 +17,15 @@ export interface ShimRequester {
   request(capability: ShimCapability, payload: unknown, options?: ShimRequestOptions): Promise<unknown>
 }
 
+/** Raised when a request outlived its deadline, so a caller can tell a slow peer from a broken
+ *  one without matching on message text. */
+export class ShimRequestTimeoutError extends Error {
+  constructor(reason: string) {
+    super(reason)
+    this.name = 'ShimRequestTimeoutError'
+  }
+}
+
 /** Raised when a request was cancelled rather than failing on its own merits. */
 export class ShimRequestAbortedError extends Error {
   constructor(reason: string) {
@@ -64,7 +73,7 @@ export class ShimChannel implements ShimRequester {
         this.pending.delete(id)
         // Tell the sandbox too: a timeout that only gives up locally leaves the child running.
         this.sendCancel(id, `timed out after ${timeoutMs}ms`)
-        reject(new Error(`shim ${capability} request timed out after ${timeoutMs}ms`))
+        reject(new ShimRequestTimeoutError(`shim ${capability} request timed out after ${timeoutMs}ms`))
       }, timeoutMs)
       const onAbort = (): void => {
         if (!this.pending.delete(id)) return

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -256,6 +256,7 @@ export class ShimListener {
           },
           (err: unknown) => {
             binding = false
+            this.metrics.handshakeRejected('unavailable')
             this.deps.log.warn(`shim: binding failed (${(err as Error).message})`)
             reject({ type: 'shim/rejected', reason: 'unavailable', message: 'binding unavailable' })
           }

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from 'node:http'
 import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import { noopClusterMetrics, type ClusterMetrics } from '../k8s/cluster-metrics.js'
 import { systemClock, type Clock } from '@agentconnect.md/connection'
 import { WebSocketServer, type WebSocket } from 'ws'
 import { ShimBindingRegistry, type Binding, type SpawnRecord } from './binding.js'
@@ -36,9 +37,18 @@ export interface ShimListenerDeps {
   log: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
   /** Session-credential lifetime; a shim re-handshakes rather than refreshing. */
   credentialTtlMs?: number
+  /** Operability counters; omit to record nothing. */
+  metrics?: ClusterMetrics
 }
 
 const DEFAULT_CREDENTIAL_TTL_MS = 10 * 60_000
+
+// A verifier's error is an unbounded string from an external system, and it reaches a log. Keep
+// the diagnostic but never the credential inside it: a token in a log outlives the request by
+// however long the logs are kept, and by then it is somewhere nobody is auditing.
+function withoutToken(message: string, token: string): string {
+  return token.length > 0 ? message.split(token).join('[redacted]') : message
+}
 
 /** A bound shim connection the daemon can send requests on. */
 export interface ShimConnection {
@@ -66,12 +76,14 @@ export class ShimListener {
   private server?: Server
   private wss?: WebSocketServer
   private readonly registry: ShimBindingRegistry
+  private readonly metrics: ClusterMetrics
   private readonly clock: Clock
   private readonly connections = new Set<ShimConnection>()
   private port?: number
 
   constructor(private readonly deps: ShimListenerDeps) {
     this.registry = new ShimBindingRegistry(deps.now, deps.credentialTtlMs ?? DEFAULT_CREDENTIAL_TTL_MS)
+    this.metrics = deps.metrics ?? noopClusterMetrics
     this.clock = deps.clock ?? systemClock
   }
 
@@ -175,6 +187,7 @@ export class ShimListener {
       if (isBinary) return
       const frame = parseShimFrame(typeof data === 'string' ? data : String(data))
       if (!frame) {
+        this.metrics.handshakeRejected('malformed')
         ws.close(4400, 'malformed frame')
         return
       }
@@ -291,8 +304,13 @@ export class ShimListener {
   > {
     const review = await this.deps.verifier.reviewToken(token, [SHIM_TOKEN_AUDIENCE])
     if (!review.authenticated || !review.podName || !review.podUid) {
+      // The API server did not accept the token: an identity failure, counted apart from our
+      // own fencing refusals below, which are this daemon working as designed.
+      this.metrics.tokenReviewRejected()
+      this.metrics.handshakeRejected('unauthenticated')
       this.deps.log.warn(
-        `shim: rejected an unauthenticated callback from ${remoteAddress}${review.error ? ` (${review.error})` : ''}`
+        `shim: rejected an unauthenticated callback from ${remoteAddress}` +
+          `${review.error ? ` (${withoutToken(review.error, token)})` : ''}`
       )
       return {
         ok: false,
@@ -304,6 +322,7 @@ export class ShimListener {
     if (!record) {
       // Authenticated, but not a pod this daemon launched — or one whose spawn record is
       // gone. Either way there is nothing to bind it to.
+      this.metrics.handshakeRejected('unknown_pod')
       this.deps.log.warn(`shim: no spawn record for pod ${pod.name} (${remoteAddress})`)
       return { ok: false, rejected: { type: 'shim/rejected', reason: 'unknown_pod', message: 'pod not recognized' } }
     }
@@ -314,6 +333,7 @@ export class ShimListener {
     if (!bound.ok) {
       // A newer launch already holds this sandbox. Refusing without mutating is what stops
       // a terminating pod from reclaiming the channel during overlap.
+      this.metrics.handshakeRejected('stale_generation')
       this.deps.log.warn(
         `shim: refused generation ${record.generation} for agent ${record.agentId} — ` +
           `generation ${bound.current} already holds the channel`

--- a/packages/daemon/test/cluster-metrics.test.ts
+++ b/packages/daemon/test/cluster-metrics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { FakeClock } from '@agentconnect.md/connection'
-import { ClusterSpawnDriver, DRAIN_REQUESTED_ANNOTATION } from '../src/k8s/cluster-driver.js'
+import { ClusterSpawnDriver, DRAIN_REQUESTED_ANNOTATION, type ClusterDriverDeps } from '../src/k8s/cluster-driver.js'
 import { LaunchTimer, type ClusterMetrics, type LaunchPath, type LaunchStage } from '../src/k8s/cluster-metrics.js'
 import { K8sApiError } from '../src/k8s/http.js'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
@@ -114,19 +114,44 @@ function driverFor(
   metrics: ClusterMetrics,
   api: ReturnType<typeof fakeApi>,
   open: 'ok' | 'error' | 'timeout' = 'ok',
-  clock: FakeClock = new FakeClock()
+  clock: FakeClock = new FakeClock(),
+  awaitChannel?: ClusterDriverDeps['awaitChannel']
 ) {
   return new ClusterSpawnDriver({
     api: api.api as never,
     orgId: 'org-1',
     warmPoolName: 'pool',
     publishSpawnRecord: () => {},
-    awaitChannel: async () => respondingConnection(open) as never,
+    awaitChannel: awaitChannel ?? (async () => respondingConnection(open) as never),
     clock,
     metrics,
     readyTimeoutMs: 5_000,
     log: { info: () => {}, warn: () => {}, debug: () => {} }
   })
+}
+
+/**
+ * Launch while driving the fake clock forward.
+ *
+ * The claim-bind and pod-ready waits sleep on the driver's clock, so a FakeClock that nobody
+ * advances makes their deadline unreachable — the test would hang rather than observe a timeout.
+ */
+async function launchAdvancing(driver: ClusterSpawnDriver, clock: FakeClock): Promise<Error | 'resolved'> {
+  let outcome: Error | 'resolved' | undefined
+  const inflight = driver.launch(launchRequest).then(
+    () => {
+      outcome = 'resolved'
+    },
+    (err: Error) => {
+      outcome = err
+    }
+  )
+  for (let step = 0; step < 400 && outcome === undefined; step += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    clock.advance(1_000)
+  }
+  await inflight
+  return outcome ?? new Error('launch never settled')
 }
 
 async function settled(predicate: () => boolean, timeoutMs = 5_000): Promise<boolean> {
@@ -225,6 +250,72 @@ describe('cluster launch metrics', () => {
     expect(await settled(() => stuck.launches.length > 0)).toBe(true)
     expect(stuck.launches).toEqual([expect.objectContaining({ path: 'resume', outcome: 'timeout' })])
     expect(stuck.stages.map((entry) => entry.stage)).not.toContain('runtime_ready')
+  })
+
+  it('puts ALL THREE launch deadlines in the timeout bucket, by type not by wording', async () => {
+    // Claim bind, pod readiness and channel bind are three separate deadlines, and the message
+    // regex this replaced silently stopped covering the channel wait as soon as its wording
+    // changed — recording a genuine timeout as an error. Type-based classification cannot drift
+    // that way, and asserting all three is what stops one of them slipping out again.
+    const claimStuck = recorder()
+    const noClaim = fakeApi({ claimExists: false, mode: 'Suspended' })
+    noClaim.api.getClaim = async () => {
+      throw new K8sApiError(404, 'NotFound', 'no claim')
+    }
+    noClaim.api.ensureClaim = async (claim: SandboxClaim & { metadata: { name: string } }) => ({
+      claim,
+      created: true
+    })
+    const claimClock = new FakeClock()
+    const claimOutcome = await launchAdvancing(driverFor(claimStuck.metrics, noClaim, 'ok', claimClock), claimClock)
+    expect(String(claimOutcome)).toMatch(/did not bind/)
+    expect(claimStuck.launches).toEqual([expect.objectContaining({ outcome: 'timeout' })])
+
+    const podStuck = recorder()
+    const notReady = fakeApi({ claimExists: true, mode: 'Suspended' })
+    notReady.api.getSandbox = async () =>
+      ({
+        metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
+        spec: { operatingMode: notReady.state.mode },
+        status: { conditions: [{ type: 'Ready', status: 'False' }] }
+      }) as Sandbox
+    const podClock = new FakeClock()
+    const podOutcome = await launchAdvancing(driverFor(podStuck.metrics, notReady, 'ok', podClock), podClock)
+    expect(String(podOutcome)).toMatch(/did not become ready/)
+    expect(podStuck.launches).toEqual([expect.objectContaining({ path: 'resume', outcome: 'timeout' })])
+
+    // The channel wait is the one the regex missed. Its host-supplied rejection lands at the
+    // deadline we passed, which is the fact this driver owns.
+    const channelStuck = recorder()
+    const clock = new FakeClock()
+    const late: ClusterDriverDeps['awaitChannel'] = async (_agentId, _generation, timeoutMs) => {
+      clock.advance(timeoutMs)
+      throw new Error('no channel bound in time')
+    }
+    await expect(
+      driverFor(channelStuck.metrics, fakeApi({ claimExists: true, mode: 'Suspended' }), 'ok', clock, late).launch(
+        launchRequest
+      )
+    ).rejects.toThrow(/no shim channel bound/)
+    expect(channelStuck.launches).toEqual([expect.objectContaining({ path: 'resume', outcome: 'timeout' })])
+  })
+
+  it('still calls a channel failure BEFORE the deadline an error', async () => {
+    // Otherwise every channel problem would read as a missed latency target.
+    const early = recorder()
+    const failing: ClusterDriverDeps['awaitChannel'] = async () => {
+      throw new Error('shim registry refused the bind')
+    }
+    await expect(
+      driverFor(
+        early.metrics,
+        fakeApi({ claimExists: true, mode: 'Suspended' }),
+        'ok',
+        new FakeClock(),
+        failing
+      ).launch(launchRequest)
+    ).rejects.toThrow(/registry refused/)
+    expect(early.launches).toEqual([expect.objectContaining({ outcome: 'error' })])
   })
 
   it('records every stage of the launch, in order', async () => {

--- a/packages/daemon/test/cluster-metrics.test.ts
+++ b/packages/daemon/test/cluster-metrics.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
 import { FakeClock } from '@agentconnect.md/connection'
 import { ClusterSpawnDriver, DRAIN_REQUESTED_ANNOTATION } from '../src/k8s/cluster-driver.js'
 import { LaunchTimer, type ClusterMetrics, type LaunchPath, type LaunchStage } from '../src/k8s/cluster-metrics.js'
@@ -81,25 +82,52 @@ function fakeApi(options: { claimExists: boolean; mode: 'Running' | 'Suspended' 
   }
 }
 
-function driverFor(metrics: ClusterMetrics, api: ReturnType<typeof fakeApi>) {
+/**
+ * A connection that ANSWERS the ACP open, because the runtime-ready stage closes when the open
+ * resolves — not when `launch()` returns. A silent fake made that stage measure the cost of
+ * constructing a stream pair, which is how a runtime that never started looked like a success.
+ */
+function respondingConnection(outcome: 'ok' | 'error') {
+  const listeners: Array<(text: string) => void> = []
+  return {
+    binding: { agentId: 'agent-a', generation: 1, grants: ['acp'], podName: 'p', podUid: 'u' },
+    issuedCredential: 'cred',
+    send: (frame: { type: string; id: string }) => {
+      if (frame.type !== 'shim/request') return
+      const reply =
+        outcome === 'ok'
+          ? { type: 'shim/response', id: frame.id, ok: true, payload: { streamId: randomUUID() } }
+          : { type: 'shim/response', id: frame.id, ok: false, error: 'runtime exited immediately' }
+      setTimeout(() => {
+        for (const listen of listeners) listen(JSON.stringify(reply))
+      }, 0)
+    },
+    onFrame: (listen: (text: string) => void) => listeners.push(listen),
+    close: () => {}
+  }
+}
+
+function driverFor(metrics: ClusterMetrics, api: ReturnType<typeof fakeApi>, open: 'ok' | 'error' = 'ok') {
   return new ClusterSpawnDriver({
     api: api.api as never,
     orgId: 'org-1',
     warmPoolName: 'pool',
     publishSpawnRecord: () => {},
-    awaitChannel: async () =>
-      ({
-        binding: { agentId: 'agent-a', generation: 1, grants: ['acp'], podName: 'p', podUid: 'u' },
-        issuedCredential: 'cred',
-        send: () => {},
-        onFrame: () => {},
-        close: () => {}
-      }) as never,
+    awaitChannel: async () => respondingConnection(open) as never,
     clock: new FakeClock(),
     metrics,
     readyTimeoutMs: 5_000,
     log: { info: () => {}, warn: () => {}, debug: () => {} }
   })
+}
+
+async function settled(predicate: () => boolean, timeoutMs = 5_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  return predicate()
 }
 
 const launchRequest = { command: 'x', args: [], env: { AC_AGENT_ID: 'agent-a' }, cwd: '/agent' } as never
@@ -111,11 +139,13 @@ describe('cluster launch metrics', () => {
     // could not settle either number.
     const cold = recorder()
     await driverFor(cold.metrics, fakeApi({ claimExists: false, mode: 'Suspended' })).launch(launchRequest)
+    expect(await settled(() => cold.launches.length > 0)).toBe(true)
     expect(new Set(cold.stages.map((entry) => entry.path))).toEqual(new Set(['cold']))
     expect(cold.launches).toEqual([expect.objectContaining({ path: 'cold', outcome: 'ok' })])
 
     const resume = recorder()
     await driverFor(resume.metrics, fakeApi({ claimExists: true, mode: 'Suspended' })).launch(launchRequest)
+    expect(await settled(() => resume.launches.length > 0)).toBe(true)
     expect(new Set(resume.stages.map((entry) => entry.path))).toEqual(new Set(['resume']))
     expect(resume.launches).toEqual([expect.objectContaining({ path: 'resume', outcome: 'ok' })])
 
@@ -123,12 +153,50 @@ describe('cluster launch metrics', () => {
     // distribution down with launches that paid nothing.
     const warm = recorder()
     await driverFor(warm.metrics, fakeApi({ claimExists: true, mode: 'Running' })).launch(launchRequest)
+    expect(await settled(() => warm.launches.length > 0)).toBe(true)
     expect(new Set(warm.stages.map((entry) => entry.path))).toEqual(new Set(['warm']))
+  })
+
+  it('tags the ORDINARY resume — launch, suspend, launch on one daemon — as a resume', async () => {
+    // The common path, and the one the first version got wrong. `suspend()` keeps the cached
+    // launch on purpose, so the second launch returns from ensureSandbox before any sandbox read:
+    // the timer never saw a path and reported `warm`, excluding real resumes from resume p95.
+    const seen = recorder()
+    const driver = driverFor(seen.metrics, fakeApi({ claimExists: true, mode: 'Running' }))
+    await driver.launch(launchRequest)
+    expect(await settled(() => seen.launches.length === 1)).toBe(true)
+    expect(seen.launches[0]?.path).toBe('warm')
+
+    await driver.suspend('agent-a')
+    await driver.launch(launchRequest)
+    expect(await settled(() => seen.launches.length === 2)).toBe(true)
+    expect(seen.launches[1]).toEqual(expect.objectContaining({ path: 'resume', outcome: 'ok' }))
+    // No claim was submitted on this path, so there is no claim → bound duration to report.
+    // Emitting a zero would put a sample in the distribution that never happened.
+    const secondStages = seen.stages.slice(seen.stages.findIndex((entry) => entry.path === 'resume'))
+    expect(secondStages.map((entry) => entry.stage)).not.toContain('claim_bound')
+    expect(secondStages.every((entry) => entry.path === 'resume')).toBe(true)
+  })
+
+  it('closes runtime_ready when the ACP open resolves, and calls a failed open an error', async () => {
+    // createRemoteRuntime only STARTS the open. Recording the stage on return measured the cost
+    // of constructing a stream pair — a near-zero success for a runtime that never came up.
+    const failed = recorder()
+    const driver = driverFor(failed.metrics, fakeApi({ claimExists: true, mode: 'Suspended' }), 'error')
+    await driver.launch(launchRequest)
+    expect(await settled(() => failed.launches.length > 0)).toBe(true)
+    expect(failed.launches).toEqual([expect.objectContaining({ path: 'resume', outcome: 'error' })])
+
+    // And exactly one sample: the failure path may also report, and two samples for one launch
+    // is a corrupted distribution rather than a lost one.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(failed.launches).toHaveLength(1)
   })
 
   it('records every stage of the launch, in order', async () => {
     const seen = recorder()
     await driverFor(seen.metrics, fakeApi({ claimExists: true, mode: 'Suspended' })).launch(launchRequest)
+    expect(await settled(() => seen.launches.length > 0)).toBe(true)
     // A missing stage is worse than a wrong one: the dashboard silently attributes its time to
     // the next stage, which is how "the pull is slow" becomes "the pod is slow".
     expect(seen.stages.map((entry) => entry.stage)).toEqual([

--- a/packages/daemon/test/cluster-metrics.test.ts
+++ b/packages/daemon/test/cluster-metrics.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FakeClock } from '@agentconnect.md/connection'
+import { ClusterSpawnDriver, DRAIN_REQUESTED_ANNOTATION } from '../src/k8s/cluster-driver.js'
+import { LaunchTimer, type ClusterMetrics, type LaunchPath, type LaunchStage } from '../src/k8s/cluster-metrics.js'
+import { K8sApiError } from '../src/k8s/http.js'
+import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
+
+// The acceptance criterion for D9 is a dashboard that settles "resume p95 ≤ 15s, cold start
+// p95 ≤ 60s" without log archaeology. That is only true if the cold/resume tag is right and the
+// stages actually fire, so this asserts the recorded series rather than that the code runs.
+
+function recorder(): {
+  metrics: ClusterMetrics
+  stages: Array<{ stage: LaunchStage; path: LaunchPath; durationMs: number }>
+  launches: Array<{ path: string; outcome: string; durationMs: number }>
+  rejections: string[]
+  channels: string[]
+  retries: string[]
+  relists: string[]
+  tokenReviews: number
+  drains: number
+} {
+  const state = {
+    stages: [] as Array<{ stage: LaunchStage; path: LaunchPath; durationMs: number }>,
+    launches: [] as Array<{ path: string; outcome: string; durationMs: number }>,
+    rejections: [] as string[],
+    channels: [] as string[],
+    retries: [] as string[],
+    relists: [] as string[],
+    tokenReviews: 0,
+    drains: 0
+  }
+  const metrics: ClusterMetrics = {
+    stage: (stage, path, durationMs) => state.stages.push({ stage, path, durationMs }),
+    launch: (path, outcome, durationMs) => state.launches.push({ path, outcome, durationMs }),
+    handshakeRejected: (reason) => state.rejections.push(reason),
+    tokenReviewRejected: () => (state.tokenReviews += 1),
+    writeRetry: (kind) => state.retries.push(kind),
+    watchRelist: (source) => state.relists.push(source),
+    channel: (event) => state.channels.push(event),
+    drainTimeout: () => (state.drains += 1)
+  }
+  return { metrics, ...state }
+}
+
+/** A cluster whose claim either already exists (resume/warm) or is created (cold). */
+function fakeApi(options: { claimExists: boolean; mode: 'Running' | 'Suspended' }) {
+  const state = {
+    mode: options.mode,
+    claim: options.claimExists
+      ? ({ metadata: { name: 'agent-a' }, status: { sandbox: { name: 'sb-1' } } } as SandboxClaim)
+      : undefined
+  }
+  return {
+    state,
+    api: {
+      ensureClaim: async (claim: SandboxClaim & { metadata: { name: string } }) => {
+        const created = state.claim === undefined
+        state.claim = { ...claim, status: { sandbox: { name: 'sb-1' } } }
+        return { claim: state.claim, created }
+      },
+      getClaim: async () => {
+        if (!state.claim) throw new K8sApiError(404, 'NotFound', 'no claim')
+        return state.claim
+      },
+      deleteClaim: async () => undefined,
+      getSandbox: async () =>
+        ({
+          metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
+          spec: { operatingMode: state.mode },
+          status: { conditions: [{ type: 'Ready', status: 'True' }] }
+        }) as Sandbox,
+      setOperatingMode: async (_name: string, desired: 'Running' | 'Suspended') => {
+        state.mode = desired
+        return {} as Sandbox
+      },
+      watchClaims: vi.fn(),
+      watchSandboxes: vi.fn(),
+      reviewToken: vi.fn()
+    }
+  }
+}
+
+function driverFor(metrics: ClusterMetrics, api: ReturnType<typeof fakeApi>) {
+  return new ClusterSpawnDriver({
+    api: api.api as never,
+    orgId: 'org-1',
+    warmPoolName: 'pool',
+    publishSpawnRecord: () => {},
+    awaitChannel: async () =>
+      ({
+        binding: { agentId: 'agent-a', generation: 1, grants: ['acp'], podName: 'p', podUid: 'u' },
+        issuedCredential: 'cred',
+        send: () => {},
+        onFrame: () => {},
+        close: () => {}
+      }) as never,
+    clock: new FakeClock(),
+    metrics,
+    readyTimeoutMs: 5_000,
+    log: { info: () => {}, warn: () => {}, debug: () => {} }
+  })
+}
+
+const launchRequest = { command: 'x', args: [], env: { AC_AGENT_ID: 'agent-a' }, cwd: '/agent' } as never
+
+describe('cluster launch metrics', () => {
+  it('tags a first launch COLD and a re-launch of a suspended sandbox RESUME', async () => {
+    // These are the two targets, and they are different paths: a first claim pays PVC
+    // provisioning and an image pull, a resume pays a re-attach. One distribution over both
+    // could not settle either number.
+    const cold = recorder()
+    await driverFor(cold.metrics, fakeApi({ claimExists: false, mode: 'Suspended' })).launch(launchRequest)
+    expect(new Set(cold.stages.map((entry) => entry.path))).toEqual(new Set(['cold']))
+    expect(cold.launches).toEqual([expect.objectContaining({ path: 'cold', outcome: 'ok' })])
+
+    const resume = recorder()
+    await driverFor(resume.metrics, fakeApi({ claimExists: true, mode: 'Suspended' })).launch(launchRequest)
+    expect(new Set(resume.stages.map((entry) => entry.path))).toEqual(new Set(['resume']))
+    expect(resume.launches).toEqual([expect.objectContaining({ path: 'resume', outcome: 'ok' })])
+
+    // A sandbox already Running is neither: counting it as a resume would drag the resume
+    // distribution down with launches that paid nothing.
+    const warm = recorder()
+    await driverFor(warm.metrics, fakeApi({ claimExists: true, mode: 'Running' })).launch(launchRequest)
+    expect(new Set(warm.stages.map((entry) => entry.path))).toEqual(new Set(['warm']))
+  })
+
+  it('records every stage of the launch, in order', async () => {
+    const seen = recorder()
+    await driverFor(seen.metrics, fakeApi({ claimExists: true, mode: 'Suspended' })).launch(launchRequest)
+    // A missing stage is worse than a wrong one: the dashboard silently attributes its time to
+    // the next stage, which is how "the pull is slow" becomes "the pod is slow".
+    expect(seen.stages.map((entry) => entry.stage)).toEqual([
+      'claim_bound',
+      'mode_running',
+      'pod_ready',
+      'shim_handshake',
+      'runtime_ready'
+    ])
+    expect(seen.channels).toContain('bound')
+  })
+
+  it('distinguishes a draining refusal from a timeout and from an error', async () => {
+    const drained = recorder()
+    const api = fakeApi({ claimExists: true, mode: 'Suspended' })
+    const driver = driverFor(drained.metrics, api)
+    driver.onSandboxObserved('agent-a', { [DRAIN_REQUESTED_ANNOTATION]: 'rollout-1' })
+    await expect(driver.launch(launchRequest)).rejects.toThrow(/draining/)
+    // Held-for-rollout is not a missed target, and pooling it with errors would make a rollout
+    // look like an outage on the dashboard.
+    expect(drained.launches).toEqual([expect.objectContaining({ outcome: 'draining' })])
+  })
+
+  it('counts a rejected guarded write as a retry rather than losing it in debug logs', async () => {
+    const retried = recorder()
+    const api = fakeApi({ claimExists: true, mode: 'Suspended' })
+    let attempts = 0
+    api.api.setOperatingMode = async (_name: string, desired: 'Running' | 'Suspended') => {
+      attempts += 1
+      if (attempts === 1) {
+        const { OperatingModeRejectedError } = await import('../src/k8s/sandbox-api.js')
+        throw new OperatingModeRejectedError('sb-1', 'Suspended', desired, new K8sApiError(422, 'Invalid', 'no'))
+      }
+      api.state.mode = desired
+      return {} as Sandbox
+    }
+    await driverFor(retried.metrics, api).launch(launchRequest)
+    expect(retried.retries).toEqual(['rejected_precondition'])
+  })
+
+  it('counts a channel drop and a re-establishment separately', async () => {
+    const churn = recorder()
+    const driver = driverFor(churn.metrics, fakeApi({ claimExists: true, mode: 'Suspended' }))
+    await driver.launch(launchRequest)
+    driver.onChannelLost('agent-a', 'socket closed')
+    driver.onChannelBound({
+      binding: { agentId: 'agent-a', generation: 1, grants: ['acp'], podName: 'p', podUid: 'u' },
+      issuedCredential: 'cred-2',
+      send: () => {},
+      onFrame: () => {},
+      close: () => {}
+    } as never)
+    // A re-establishment rate is the signal that renewals or pod churn exceed expectations,
+    // which pooling it with the first bind would hide.
+    expect(churn.channels).toEqual(['bound', 'dropped', 'reestablished'])
+  })
+})
+
+describe('LaunchTimer', () => {
+  it('measures each stage from the previous boundary, not from the start', () => {
+    // Cumulative timings answer "which stage is slow" only by subtraction, and a dashboard that
+    // has to subtract is a dashboard nobody trusts.
+    const seen = recorder()
+    let now = 1_000
+    const timer = new LaunchTimer(seen.metrics, () => now)
+    timer.observedPath('resume')
+    now = 1_400
+    timer.mark('claim_bound')
+    now = 1_900
+    timer.mark('pod_ready')
+    timer.finish('ok')
+    expect(seen.stages).toEqual([
+      { stage: 'claim_bound', path: 'resume', durationMs: 400 },
+      { stage: 'pod_ready', path: 'resume', durationMs: 500 }
+    ])
+    // The total is recorded independently, so it does not depend on the stages being complete.
+    expect(seen.launches).toEqual([{ path: 'resume', outcome: 'ok', durationMs: 900 }])
+  })
+
+  it('holds a stage measured before the path is known, then emits it under that path', () => {
+    // claim → bound is the stage that carries PVC provisioning, and it completes BEFORE the
+    // sandbox read that reveals the path. Emitting it provisionally filed cold-start time under
+    // `warm` — the first version of this did exactly that, and this test is why it is not shipped.
+    const seen = recorder()
+    let now = 0
+    const timer = new LaunchTimer(seen.metrics, () => now)
+    now = 50
+    timer.mark('claim_bound')
+    expect(seen.stages).toEqual([])
+    timer.observedPath('cold')
+    expect(seen.stages).toEqual([{ stage: 'claim_bound', path: 'cold', durationMs: 50 }])
+  })
+
+  it('reports a launch that failed before its path was known as neither cold nor resume', () => {
+    const seen = recorder()
+    let now = 0
+    const timer = new LaunchTimer(seen.metrics, () => now)
+    now = 30
+    timer.mark('claim_bound')
+    now = 40
+    timer.finish('timeout')
+    // Nothing was created and nothing resumed, so charging it to either target would be a claim
+    // the daemon cannot support.
+    expect(seen.stages).toEqual([{ stage: 'claim_bound', path: 'warm', durationMs: 30 }])
+    expect(seen.launches).toEqual([{ path: 'warm', outcome: 'timeout', durationMs: 40 }])
+  })
+})

--- a/packages/daemon/test/cluster-metrics.test.ts
+++ b/packages/daemon/test/cluster-metrics.test.ts
@@ -87,13 +87,16 @@ function fakeApi(options: { claimExists: boolean; mode: 'Running' | 'Suspended' 
  * resolves — not when `launch()` returns. A silent fake made that stage measure the cost of
  * constructing a stream pair, which is how a runtime that never started looked like a success.
  */
-function respondingConnection(outcome: 'ok' | 'error') {
+function respondingConnection(outcome: 'ok' | 'error' | 'timeout') {
   const listeners: Array<(text: string) => void> = []
   return {
     binding: { agentId: 'agent-a', generation: 1, grants: ['acp'], podName: 'p', podUid: 'u' },
     issuedCredential: 'cred',
     send: (frame: { type: string; id: string }) => {
       if (frame.type !== 'shim/request') return
+      // A timeout is modelled by never answering, which is what a wedged runtime actually does.
+      // Answering with an error would exercise the failure path instead.
+      if (outcome === 'timeout') return
       const reply =
         outcome === 'ok'
           ? { type: 'shim/response', id: frame.id, ok: true, payload: { streamId: randomUUID() } }
@@ -107,14 +110,19 @@ function respondingConnection(outcome: 'ok' | 'error') {
   }
 }
 
-function driverFor(metrics: ClusterMetrics, api: ReturnType<typeof fakeApi>, open: 'ok' | 'error' = 'ok') {
+function driverFor(
+  metrics: ClusterMetrics,
+  api: ReturnType<typeof fakeApi>,
+  open: 'ok' | 'error' | 'timeout' = 'ok',
+  clock: FakeClock = new FakeClock()
+) {
   return new ClusterSpawnDriver({
     api: api.api as never,
     orgId: 'org-1',
     warmPoolName: 'pool',
     publishSpawnRecord: () => {},
     awaitChannel: async () => respondingConnection(open) as never,
-    clock: new FakeClock(),
+    clock,
     metrics,
     readyTimeoutMs: 5_000,
     log: { info: () => {}, warn: () => {}, debug: () => {} }
@@ -191,6 +199,32 @@ describe('cluster launch metrics', () => {
     // is a corrupted distribution rather than a lost one.
     await new Promise((resolve) => setTimeout(resolve, 50))
     expect(failed.launches).toHaveLength(1)
+  })
+
+  it('records NO runtime_ready stage for an open that never succeeded', async () => {
+    // The stage histogram has no outcome attribute, so a failed open recorded as a completed
+    // stage sits in the runtime-ready latency distribution as a fast success and cannot be
+    // filtered back out. Only a successful open crossed that boundary.
+    const failed = recorder()
+    await driverFor(failed.metrics, fakeApi({ claimExists: true, mode: 'Suspended' }), 'error').launch(launchRequest)
+    expect(await settled(() => failed.launches.length > 0)).toBe(true)
+    expect(failed.stages.map((entry) => entry.stage)).not.toContain('runtime_ready')
+    expect(failed.launches).toEqual([expect.objectContaining({ outcome: 'error' })])
+  })
+
+  it('calls a runtime open that never answers a TIMEOUT, not an error', async () => {
+    // A wedged runtime and one that refuses to start are different operational stories, and the
+    // request deadline is what separates them — matched by type rather than by message text.
+    const stuck = recorder()
+    const clock = new FakeClock()
+    await driverFor(stuck.metrics, fakeApi({ claimExists: true, mode: 'Suspended' }), 'timeout', clock).launch(
+      launchRequest
+    )
+    // The channel's own deadline is driven by this clock, so advancing past it is what fires.
+    clock.advance(31_000)
+    expect(await settled(() => stuck.launches.length > 0)).toBe(true)
+    expect(stuck.launches).toEqual([expect.objectContaining({ path: 'resume', outcome: 'timeout' })])
+    expect(stuck.stages.map((entry) => entry.stage)).not.toContain('runtime_ready')
   })
 
   it('records every stage of the launch, in order', async () => {

--- a/packages/daemon/test/k8s-client.test.ts
+++ b/packages/daemon/test/k8s-client.test.ts
@@ -360,12 +360,29 @@ describe('SandboxApi', () => {
       return { json: { metadata: { name: 'agent-a' }, status: { sandbox: { name: 'sb-7' } } } }
     })
     const api = new SandboxApi(new K8sHttp(config), 'org-test')
-    const claim = await api.ensureClaim({ metadata: { name: 'agent-a' }, spec: { warmPoolRef: { name: 'pool' } } })
+    const ensured = await api.ensureClaim({ metadata: { name: 'agent-a' }, spec: { warmPoolRef: { name: 'pool' } } })
     expect(posts).toBe(1)
     // The claim names the bound Sandbox and nothing more; its UID comes from that
     // object's metadata, which is what the spawn record has to key on.
-    expect(claim.status?.sandbox?.name).toBe('sb-7')
+    expect(ensured.claim.status?.sandbox?.name).toBe('sb-7')
     expect(requests.at(-1)?.pathname).toContain('/sandboxclaims/agent-a')
+    // AlreadyExists is NOT a cold start: this launch pays no PVC provisioning and no image
+    // pull, and reporting it as one would put resume latencies in the cold-start distribution.
+    expect(ensured.created).toBe(false)
+  })
+
+  it('reports a first claim as CREATED, which is the cold-start signal', async () => {
+    // The cold/resume split has to come from a fact, not from elapsed time — a latency metric
+    // whose own bucketing is inferred from latency cannot settle a latency target.
+    const { config } = await fakeApiServer(({ method }) =>
+      method === 'POST'
+        ? { status: 201, json: { metadata: { name: 'agent-b', uid: 'claim-uid' } } }
+        : { json: { metadata: { name: 'agent-b' } } }
+    )
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const ensured = await api.ensureClaim({ metadata: { name: 'agent-b' }, spec: { warmPoolRef: { name: 'pool' } } })
+    expect(ensured.created).toBe(true)
+    expect(ensured.claim.metadata?.uid).toBe('claim-uid')
   })
 
   it('sends a claim body carrying the pool reference and no per-agent env', async () => {

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
 import { WebSocket } from 'ws'
 import { ShimBindingRegistry, type SpawnRecord } from '../src/shim/binding.js'
+import { noopClusterMetrics, type ClusterMetrics } from '../src/k8s/cluster-metrics.js'
 import { ShimListener, type PodIdentityVerifier } from '../src/shim/listener.js'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import {
@@ -43,6 +44,8 @@ async function listener(deps: {
   now?: () => number
   clock?: FakeClock
   credentialTtlMs?: number
+  metrics?: ClusterMetrics
+  log?: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
 }): Promise<{ instance: ShimListener; endpoint: string }> {
   const instance = new ShimListener({
     verifier: deps.verifier,
@@ -50,7 +53,8 @@ async function listener(deps: {
     now: deps.now ?? (() => Date.now()),
     ...(deps.clock ? { clock: deps.clock } : {}),
     ...(deps.credentialTtlMs !== undefined ? { credentialTtlMs: deps.credentialTtlMs } : {}),
-    log: { info: () => {}, warn: () => {} }
+    ...(deps.metrics ? { metrics: deps.metrics } : {}),
+    log: deps.log ?? { info: () => {}, warn: () => {} }
   })
   listeners.push(instance)
   const port = await instance.start(0, '127.0.0.1')
@@ -88,6 +92,130 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void
     await new Promise((resolve) => setTimeout(resolve, 10))
   }
 }
+
+/** Records only what these tests assert on; the rest is a no-op. */
+function countingMetrics(): { metrics: ClusterMetrics; rejections: string[]; tokenReviews: () => number } {
+  const rejections: string[] = []
+  let tokenReviews = 0
+  return {
+    rejections,
+    tokenReviews: () => tokenReviews,
+    metrics: {
+      ...noopClusterMetrics,
+      handshakeRejected: (reason) => rejections.push(reason),
+      tokenReviewRejected: () => (tokenReviews += 1)
+    }
+  }
+}
+
+describe('handshake operability counters', () => {
+  it('counts an API-server token rejection apart from this daemon fencing a frame', async () => {
+    // D7 shipped a bug from conflating these: an identity failure and our own fencing working as
+    // designed are different events, and one counter cannot tell an operator which is happening.
+    const counted = countingMetrics()
+    const { endpoint } = await listener({
+      verifier: verifier({ authenticated: false, error: 'expired' }),
+      metrics: counted.metrics
+    })
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 'bad' })
+    await waitFor(() => counted.tokenReviews() > 0)
+    expect(counted.tokenReviews()).toBe(1)
+    expect(counted.rejections).toEqual(['unauthenticated'])
+  })
+
+  it('counts an unknown pod and a stale generation as their own reasons', async () => {
+    const unknown = countingMetrics()
+    const noRecord = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-x', podUid: 'pod-x' }),
+      spawnRecordForPod: () => undefined,
+      metrics: unknown.metrics
+    })
+    const first = await rawConnect(noRecord.endpoint)
+    first.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => unknown.rejections.length > 0)
+    // Authenticated but not ours is a different operational story from a token failure — usually
+    // a stale pod rather than a broken identity.
+    expect(unknown.rejections).toEqual(['unknown_pod'])
+    expect(unknown.tokenReviews()).toBe(0)
+
+    const stale = countingMetrics()
+    // The newer pod binds first, then the OLDER launch's pod tries the same sandbox. Both are
+    // genuinely authenticated, so the refusal is the fencing working rather than an identity
+    // failure — which is the distinction the two counters exist to keep.
+    const pods = ['pod-new', 'pod-old']
+    let call = 0
+    const generations = new Map([
+      ['pod-new', 4],
+      ['pod-old', 2]
+    ])
+    const superseded = await listener({
+      verifier: {
+        reviewToken: vi.fn(async () => ({
+          authenticated: true,
+          podName: 'runtime',
+          podUid: pods[Math.min(call++, pods.length - 1)]!
+        }))
+      },
+      spawnRecordForPod: (pod) => record({ generation: generations.get(pod.uid) ?? 1 }),
+      metrics: stale.metrics
+    })
+    const newer = await rawConnect(superseded.endpoint)
+    newer.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => newer.frames.length > 0)
+    expect(stale.rejections).toEqual([])
+
+    const older = await rawConnect(superseded.endpoint)
+    older.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => stale.rejections.length > 0 || older.frames.length > 0)
+    expect(stale.rejections).toEqual(['stale_generation'])
+    expect(stale.tokenReviews()).toBe(0)
+  })
+
+  it('never writes the presented token or the issued credential into a log line', async () => {
+    // The hygiene requirement, checked rather than asserted in a comment: these two strings are
+    // the whole authorization surface, and a log is the one place they leak without anyone
+    // noticing until the logs are already somewhere else.
+    const lines: string[] = []
+    const token = 'TOKEN-c8f2a1d4e7b9'
+    const { endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' }),
+      log: { info: (m) => lines.push(m), warn: (m) => lines.push(m), debug: (m) => lines.push(m) }
+    })
+    const bound = await rawConnect(endpoint)
+    bound.send({ type: 'shim/hello', token })
+    await waitFor(() => bound.frames.length > 0)
+    const credential = (bound.frames[0] as ShimBound).sessionCredential
+    expect(credential.length).toBeGreaterThan(8)
+
+    // And a rejection path too, which is where a diagnostic is most tempting to over-share.
+    const refused = await listener({
+      verifier: verifier({ authenticated: false, error: `token ${token} was not accepted` }),
+      log: { info: (m) => lines.push(m), warn: (m) => lines.push(m), debug: (m) => lines.push(m) }
+    })
+    const rejectedClient = await rawConnect(refused.endpoint)
+    rejectedClient.send({ type: 'shim/hello', token })
+    await waitFor(() => lines.some((line) => /unauthenticated/.test(line)))
+
+    expect(lines.length).toBeGreaterThan(0)
+    for (const line of lines) {
+      expect(line).not.toContain(token)
+      expect(line).not.toContain(credential)
+    }
+  })
+
+  it('counts a malformed frame rather than only closing the socket', async () => {
+    const malformed = countingMetrics()
+    const { endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' }),
+      metrics: malformed.metrics
+    })
+    const client = await rawConnect(endpoint)
+    client.socket.send('{not a frame')
+    await waitFor(() => malformed.rejections.length > 0)
+    expect(malformed.rejections).toEqual(['malformed'])
+  })
+})
 
 describe('shim handshake', () => {
   it('binds a pod whose token verifies against a spawn record, and issues only then', async () => {

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -204,6 +204,26 @@ describe('handshake operability counters', () => {
     }
   })
 
+  it('counts the unavailable rejection it sends, rather than sending one silently', async () => {
+    // Every reason the listener SENDS must have a counter, or a dashboard shows a healthy
+    // handshake rate while peers are being turned away. This one had none: the first version's
+    // edit missed the site and nothing failed, because no test asserted the pairing.
+    const unavailable = countingMetrics()
+    const { endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-abc', podUid: 'pod-uid-1' }),
+      spawnRecordForPod: () => {
+        throw new Error('registry unavailable')
+      },
+      metrics: unavailable.metrics
+    })
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => client.frames.length > 0 || unavailable.rejections.length > 0)
+    const rejected = client.frames[0] as ShimRejected | undefined
+    expect(rejected?.reason).toBe('unavailable')
+    expect(unavailable.rejections).toEqual(['unavailable'])
+  })
+
   it('counts a malformed frame rather than only closing the socket', async () => {
     const malformed = countingMetrics()
     const { endpoint } = await listener({


### PR DESCRIPTION
Closes #819 (D9).

## What

Staged latency histograms for the cluster launch — `claim → bound`, `resume → Running`, `pod → Ready`, `pod → shim handshake`, `channel → runtime ready` — each tagged with the launch path, plus end-to-end duration by path and outcome. Counters for handshake rejections by reason, TokenReview rejections, rejected guarded writes, watch re-lists, channel bind/drop/re-establish, and drain handshakes that never confirmed.

**Cold vs resume comes from a fact, not from elapsed time.** `ensureClaim` now reports whether it *created* the claim — that is the launch paying PVC provisioning and an image pull. A metric whose own bucketing is inferred from latency cannot settle a latency target. A sandbox already `Running` is neither, and is tagged `warm` so it doesn't drag the resume distribution down with launches that paid nothing.

Counters keep the distinctions an operator actually needs:

- a **TokenReview rejection** (identity failure) is counted apart from our own **fencing refusals** (the daemon working as designed) — D7 shipped a bug from exactly that conflation
- a **draining** refusal is a separate launch outcome from a timeout or an error, so a rollout doesn't read as an outage
- a channel **re-establishment** is separate from the first bind, since the re-establishment rate is the churn signal

Attributes are a closed set of daemon-authored enums — no agent id, pod, sandbox, or org. Those are unbounded in a multi-tenant deployment, and a tenant identifier in a metric label sits somewhere nobody audits.

## Two defects the tests found rather than confirmed

1. **`claim → bound` was tagged wrong.** It completes *before* the sandbox read that reveals the path, so the first version emitted it under a provisional tag — filing cold-start provisioning time under `warm`, which is precisely the number the target is about. `LaunchTimer` now holds stages until the path is known and flushes them under it; a launch that fails before the path is known is charged to neither target.

2. **The hygiene requirement was not met.** The listener interpolated the verifier's `error` verbatim into a warning — an unbounded string from an external system landing in a log — and the new test proved a token can ride it. The diagnostic is kept with the presented token redacted.

Both fixes were confirmed load-bearing by reverting them and watching their own tests fail.

## Verification

- 111 tests across the metrics, handshake, k8s-client, cluster-driver, cluster ACP e2e, supervisor, cancellation and channel suites
- the handshake counters run against the existing **real-socket** harness rather than a new stand-in
- typecheck, eslint, prettier, build clean; shim bundle still `node:`-only

## Note on the acceptance criterion

This delivers the instrumentation that makes `resume p95 ≤ 15s` / `cold start p95 ≤ 60s` answerable from a dashboard. The dashboard itself is a deployment artifact rather than repo code — the series and their tags are what it needs, and the cold/resume split is the part that had to be right for either number to mean anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)