### PR TITLE
feat(daemon): rename the mode to --k8s and actually run the K8sDriver

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -108,10 +108,10 @@ COPY docker/runtime-sandbox/generate-runtime-table.mjs /opt/agentconnect/bin/gen
 USER 10001:10001
 RUN mkdir -p /tmp/ac-probe/home /tmp/ac-probe/cwd \
   && HOME=/tmp/ac-probe/home AC_PROBE_CWD=/tmp/ac-probe/cwd \
-    node /opt/agentconnect/bin/generate-runtime-table.mjs /tmp/ac-probe/cloud-runtimes.json
+    node /opt/agentconnect/bin/generate-runtime-table.mjs /tmp/ac-probe/k8s-runtimes.json
 USER root
 RUN mkdir -p /opt/agentconnect/runtime \
-  && mv /tmp/ac-probe/cloud-runtimes.json /opt/agentconnect/runtime/cloud-runtimes.json \
+  && mv /tmp/ac-probe/k8s-runtimes.json /opt/agentconnect/runtime/k8s-runtimes.json \
   && rm -rf /tmp/ac-probe \
   && chown -R root:root /opt/agentconnect/runtime \
   && chmod -R a-w /opt/agentconnect/runtime

--- a/packages/daemon/src/cli/run-foreground.ts
+++ b/packages/daemon/src/cli/run-foreground.ts
@@ -13,8 +13,8 @@ export interface ForegroundOpts {
   /** Supervisor marker (AGENTCONNECT_SUPERVISOR) forwarded to the Daemon so it
    *  can gate CP-commanded restart/upgrade (cli-daemon-split.md §7.1). */
   supervisor?: string
-  /** `--cloud`: runtimes run in cluster sandbox pods, not on this host. */
-  cloud?: boolean
+  /** `--k8s`: runtimes run in cluster sandbox pods, not on this host. */
+  k8s?: boolean
 }
 
 export interface ForegroundDeps {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -262,12 +262,14 @@ import {
 } from './github/review.js'
 import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from './runtimes/registry.js'
 import { installedRuntimeCatalog, installedRuntimes, resolveCommandPath } from './runtimes/probe.js'
+import { startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.js'
+import { setWorkspaceGitRunnerResolver } from './workspace/workspace-manager.js'
 import {
-  cloudRuntimesPath,
+  k8sRuntimesPath,
   declaredRuntimeCatalog,
-  loadCloudRuntimeTable,
-  type CloudRuntimeAcpSnapshot
-} from './runtimes/cloud-runtimes.js'
+  loadK8sRuntimeTable,
+  type K8sRuntimeAcpSnapshot
+} from './runtimes/k8s-runtimes.js'
 import { ensureNodeBinOnPath } from './runtimes/exec-path.js'
 import {
   probeAllRuntimes,
@@ -1960,16 +1962,18 @@ export class Daemon {
   // per-agent requests are ineffective; security.requireSandbox refuses startup
   // (including on unsupported macOS/Windows hosts).
   private sandboxMechanism: SandboxMechanism | undefined
-  // `--cloud`: this daemon supervises runtimes in sandbox pods instead of local
+  // `--k8s`: this daemon supervises runtimes in sandbox pods instead of local
   // subprocesses, so every "daemon and runtime share one machine" behavior is off.
-  private readonly cloud: boolean
-  // Model snapshot declared alongside the cloud runtime image; applied after the
+  private readonly k8s: boolean
+  // The k8s execution plane: shim endpoint + driver + workspace seam. Undefined outside --k8s.
+  private k8sPlane?: K8sRuntimePlane
+  // Model snapshot declared alongside the k8s runtime image; applied after the
   // SQLite catalog hydrate so the image's list wins over a stale cached one.
-  private cloudDeclaredModels: Record<string, string[]> = {}
-  // The image's `initialize` snapshot. --cloud runs no probe, so without this the fields
+  private k8sDeclaredModels: Record<string, string[]> = {}
+  // The image's `initialize` snapshot. --k8s runs no probe, so without this the fields
   // runtimeProfiles() reports — ACP protocol version, the adapter's own version, MCP transports —
   // stay empty and the published snapshot describes nothing.
-  private cloudDeclaredAcp: Record<string, CloudRuntimeAcpSnapshot> = {}
+  private k8sDeclaredAcp: Record<string, K8sRuntimeAcpSnapshot> = {}
   private runtimeNames: Record<string, string> = {} // registry id -> display name (for CP reporting)
   private runtimeVersions: Record<string, string> = {} // registry id -> version (for the facts/daemon-runtimes snapshot)
   // Models learned by actively probing each runtime (registry id -> model ids).
@@ -2185,26 +2189,31 @@ export class Daemon {
         runtimes: Record<string, import('./config/config-schema.js').RuntimeDef>,
         opts: ProbeOptions
       ) => Promise<RuntimeProbeResult[]>
+      /** Seam for the k8s execution plane. `--k8s` builds it from the pod's own in-cluster
+       *  config and REFUSES to boot without one — running runtimes on the daemon's host is the
+       *  outcome the mode exists to prevent, so it must not be a fallback. Tests override this
+       *  to exercise k8s-mode policy without a cluster. */
+      startK8sPlane?: typeof startK8sRuntimePlane
       /** Test seams for local catalog resolution and executable/state filtering. */
       resolveCatalog?: typeof resolveRuntimeCatalog
       installed?: typeof installedRuntimes
       /** Test seam: null simulates a host without Linux SRT/bwrap. */
       sandboxMechanism?: SandboxMechanism | null
-      /** `--cloud`: runtimes live in sandbox pods, not on this host. Disables runtime
+      /** `--k8s`: runtimes live in sandbox pods, not on this host. Disables runtime
        *  probing, host executable discovery (the image declares its runtimes instead),
        *  the SRT mechanism, and the self-installing upgrade path. */
-      cloud?: boolean
+      k8s?: boolean
       /** Test seam for the daemon-private memory-plugin transport. */
       memoryPluginConnect?: MemoryPluginConnector
       /** Optional, observer-only evaluation surface and add-on treatment. */
       evaluation?: DaemonEvaluationOptions
     } = {}
   ) {
-    this.cloud = opts.cloud === true
-    // Cloud runtimes are isolated by their own pod, so the in-process SRT mechanism is
+    this.k8s = opts.k8s === true
+    // A k8s runtime is isolated by its own pod, so the in-process SRT mechanism is
     // not part of that shape — it stays off even if this host happens to support it.
     this.sandboxMechanism =
-      opts.sandboxMechanism === null || this.cloud ? undefined : (opts.sandboxMechanism ?? detectSandbox())
+      opts.sandboxMechanism === null || this.k8s ? undefined : (opts.sandboxMechanism ?? detectSandbox())
     this.clock = opts.clock ?? systemClock
     if (opts.evaluation?.capabilityProfile && !opts.evaluation.observer) {
       throw new Error('evaluation capability profile requires an evaluation observer')
@@ -2566,21 +2575,37 @@ export class Daemon {
     configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
     if (cfg.security.requireSandbox && !this.sandboxMechanism) {
       throw new Error(
-        this.cloud
-          ? 'daemon startup refused: security.requireSandbox is not supported with --cloud — a cloud runtime is isolated by its own pod, not by the in-process SRT mechanism'
+        this.k8s
+          ? 'daemon startup refused: security.requireSandbox is not supported with --k8s — a k8s runtime is isolated by its own pod, not by the in-process SRT mechanism'
           : 'daemon startup refused: security.requireSandbox is true but this host has no supported Linux SRT/bwrap mechanism'
       )
     }
-    if (this.cloud) {
+    if (this.k8s) {
       // A pod's terminationGracePeriodSeconds must exceed this, or the kubelet SIGKILLs
       // mid-drain and the graceful window is a promise the deployment cannot keep. The
       // daemon cannot read its own grace period (it has no pod read), so it states the
       // number it will actually use and leaves the alignment to the deployment.
       this.log.info(
-        `cloud: shutdown drain deadline ${Math.round(cfg.limits.shutdownDrainMs / 1000)}s — ` +
+        `k8s: shutdown drain deadline ${Math.round(cfg.limits.shutdownDrainMs / 1000)}s — ` +
           `terminationGracePeriodSeconds must exceed it; supervisor=${this.opts.supervisor ?? 'unset'}` +
           `${this.opts.supervisor === K8S_SUPERVISOR ? '' : ' (restart requires AGENTCONNECT_SUPERVISOR=k8s)'}`
       )
+      // The execution plane itself. Without this `--k8s` only changes behaviour — no Sandbox is
+      // ever created and runtimes still spawn on this host, which is the one outcome the mode
+      // exists to prevent, so a failure here refuses the boot rather than degrading.
+      const startPlane = this.opts.startK8sPlane ?? startK8sRuntimePlane
+      this.k8sPlane = await startPlane({
+        log: {
+          info: (message) => this.log.info(message),
+          warn: (message) => this.log.warn(message),
+          debug: (message) => this.log.debug?.(message)
+        }
+      })
+      // Workspace git then runs where the workspace actually is. Registered for ALL agents; the
+      // resolver answers undefined for any without a bound channel, so an agent this daemon has
+      // not launched into a sandbox keeps its local behaviour.
+      setWorkspaceGitRunnerResolver((agentId, cwd, abort) => this.k8sPlane?.gitRunnerFor(agentId, cwd, abort))
+      this.log.info(`k8s: execution plane ready — shim endpoint on :${this.k8sPlane.listener.listeningPort()}`)
     }
     // Sandbox-optional principle (#36): skills are NOT force-sandboxed fleet-wide.
     // A skill runs sandboxed only when its agent does (agentRunsInSandbox), so the
@@ -2722,9 +2747,9 @@ export class Daemon {
       mode: 'cache-first'
     })
     // Advertise (and launch) only runtimes actually installed on this host — the
-    // registry lists every known agent, but most aren't present here. Under --cloud
+    // registry lists every known agent, but most aren't present here. Under --k8s
     // there is nothing to discover locally: the sandbox image declares what it ships
-    // (cloud-runtimes.ts), so presence is a declaration rather than a probe.
+    // (k8s-runtimes.ts), so presence is a declaration rather than a probe.
     const installedCatalog = this.opts.installed
       ? (() => {
           const runtimes = this.opts.installed!(resolvedCatalog.runtimes)
@@ -2735,7 +2760,7 @@ export class Daemon {
             )
           }
         })()
-      : this.cloud
+      : this.k8s
         ? this.declaredCloudCatalog(root, resolvedCatalog)
         : installedRuntimeCatalog(resolvedCatalog)
     const { runtimes: installed, entries: installedEntries } = installedCatalog
@@ -2782,13 +2807,13 @@ export class Daemon {
     this.hydrateRuntimeCatalogCache()
     // The image's declared models are the fresher truth than any cached row, and stay
     // `cached` provenance: no live probe confirmed them, so model gates remain permissive.
-    for (const [runtimeId, models] of Object.entries(this.cloudDeclaredModels)) {
+    for (const [runtimeId, models] of Object.entries(this.k8sDeclaredModels)) {
       this.runtimeModels.set(runtimeId, [...models])
       this.runtimeModelsSource.set(runtimeId, 'cached')
     }
     // The image probed these at build time, so they are the same facts a live probe would report —
     // and they populate the same maps runtimeProfiles() reads, rather than a parallel surface.
-    for (const [runtimeId, snapshot] of Object.entries(this.cloudDeclaredAcp)) {
+    for (const [runtimeId, snapshot] of Object.entries(this.k8sDeclaredAcp)) {
       if (snapshot.protocolVersion !== undefined) this.runtimeAcpVersions.set(runtimeId, snapshot.protocolVersion)
       const mcp = snapshot.capabilities?.mcpCapabilities
       if (mcp && typeof mcp === 'object') {
@@ -5071,6 +5096,9 @@ export class Daemon {
       throw new Error(`agent "${agentId}" runtime launch preparation failed: ${formatErr(err)}`, { cause: err })
     }
     const host = new AcpHost(launchRuntime, {
+      // In --k8s the runtime runs in the agent's own Sandbox pod; everywhere else AcpHost falls
+      // back to its LocalDriver, which is what a self-hosted daemon wants.
+      ...(this.k8sPlane ? { driver: this.k8sPlane.driver } : {}),
       onUpdate,
       onPermission: (sid, params) => this.onAcpPermission(agentId, sid, params),
       ...(this.evaluation.enabled
@@ -5145,11 +5173,11 @@ export class Daemon {
   }
 
   private bootstrapUpgradeCapable(): boolean {
-    // A cloud daemon's version is its image, and self-installing would exit the pod for
+    // A k8s daemon's version is its image, and self-installing would exit the pod for
     // a version the cluster never asked for. Refuse on the mode, not on the absence of a
     // supervisor marker or cli-entry pointer: a stale pointer on the root volume, or an
     // inherited AGENTCONNECT_SUPERVISOR, would otherwise re-enable the whole path.
-    if (this.cloud) return false
+    if (this.k8s) return false
     return (
       (this.opts.supervisor === 'cli' || this.opts.supervisor === 'service') && readCliEntry(this.root) !== undefined
     )
@@ -18144,7 +18172,7 @@ export class Daemon {
     // the advertised capability, so this is the last line of defence, and an inherited
     // AGENTCONNECT_SUPERVISOR plus a stale cli-entry on the root volume must not reach the
     // installer — the same invariant bootstrapUpgradeCapable() already holds.
-    if (kind === 'upgrade' && this.cloud) return refuse(imageOwnsVersion)
+    if (kind === 'upgrade' && this.k8s) return refuse(imageOwnsVersion)
     // The kubelet restarts the container in place after the reserved exit code, but never
     // changes the image, so it supervises restart and not upgrade.
     if (supervisor === K8S_SUPERVISOR) {
@@ -19457,27 +19485,27 @@ export class Daemon {
   }
 
   /**
-   * `--cloud` runtime set: the runtimes the sandbox image declares it provides,
+   * `--k8s` runtime set: the runtimes the sandbox image declares it provides,
    * projected onto the resolved catalog (which still supplies command/args, and is
    * served cache-first from `<root>/acp_registry.json` in an image). Replaces host
    * executable discovery, which can only ever answer "nothing" in a daemon pod.
    */
   private declaredCloudCatalog(root: string, resolved: ResolvedRuntimeCatalog): ResolvedRuntimeCatalog {
-    const table = loadCloudRuntimeTable(root)
+    const table = loadK8sRuntimeTable(root)
     if (!table) {
       this.log.warn(
-        `runtimes: --cloud requires a declared runtime table at ${cloudRuntimesPath(root)} — advertising none until it exists`
+        `runtimes: --k8s requires a declared runtime table at ${k8sRuntimesPath(root)} — advertising none until it exists`
       )
       return { entries: {}, runtimes: {} }
     }
     const declared = declaredRuntimeCatalog(resolved, table)
     if (declared.unresolved.length)
       this.log.warn(`runtimes: declared but unknown to the catalog: ${declared.unresolved.join(', ')}`)
-    // Curated admission needs a live probe, which --cloud does not run, so a declared
+    // Curated admission needs a live probe, which --k8s does not run, so a declared
     // curated id could never launch — drop it loudly instead of advertising it.
     if (declared.rejectedCurated.length)
       this.log.warn(
-        `runtimes: declared curated runtimes cannot be admitted under --cloud: ${declared.rejectedCurated.join(', ')}`
+        `runtimes: declared curated runtimes cannot be admitted under --k8s: ${declared.rejectedCurated.join(', ')}`
       )
     // A package launcher fetches its artifact at launch: not the image's build, not what
     // the version pin names, and impossible on a restricted egress. Dropped, not warned.
@@ -19485,8 +19513,8 @@ export class Daemon {
       this.log.warn(
         `runtimes: declared runtimes launch through a package manager and cannot be pinned to this image: ${declared.rejectedPackageLaunchers.join(', ')} — resolve them to a local executable in the catalog`
       )
-    this.cloudDeclaredModels = declared.models
-    this.cloudDeclaredAcp = declared.acp
+    this.k8sDeclaredModels = declared.models
+    this.k8sDeclaredAcp = declared.acp
     return declared.catalog
   }
 
@@ -19596,11 +19624,11 @@ export class Daemon {
    * must not affect the CP connection.
    */
   private async probeRuntimesAndEmit(includeOrdinary = true): Promise<void> {
-    // --cloud has no runtime to launch on this host: profiles come from the image's
+    // --k8s has no runtime to launch on this host: profiles come from the image's
     // declared table. Still emit them, because this is also the CP (re)connect path
     // that (re)asserts the runtime list. Unconditional — unlike the fake-host guard
     // below, an injected prober must not re-enable local spawning in this mode.
-    if (this.cloud) {
+    if (this.k8s) {
       this.cpClient?.emitDaemonRuntimes?.(
         this.reportedRuntimeIds().map((id) => this.runtimeProfileFor(id)),
         this.mcpServerFactsFromDefs()
@@ -19859,6 +19887,9 @@ export class Daemon {
     // from re-arming itself (its callback re-arms only `if (!this.draining)`), so a
     // sweep firing during the awaits below can't leave a dangling timer behind.
     this.draining = true
+    // Stop accepting shim callbacks early: a pod binding while the daemon drains would be
+    // authorized against a launch that is going away.
+    await this.k8sPlane?.stop().catch(() => undefined)
     clearTimeout(this.debounceTimer)
     if (this.idleSweepTimer !== undefined) {
       this.clock.clearTimeout(this.idleSweepTimer)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -19927,10 +19927,6 @@ export class Daemon {
     // §2.5: gate new turns and let in-flight ones finish (deadline-bounded) BEFORE
     // tearing the hosts down — a hard kill mid-turn loses the reply + transcript.
     await this.drainForShutdown()
-    // AFTER the drain, never before: closing the shim endpoint drops every sandbox channel, so
-    // doing it first would kill the in-flight turns the drain deadline exists to finish.
-    await this.k8sPlane?.stop().catch(() => undefined)
-    setWorkspaceGitRunnerResolver(undefined)
     this.store.setTranscriptMutationListener()
     for (const { timer } of this.transcriptActivityTimers.values()) this.clock.clearTimeout(timer)
     this.transcriptActivityTimers.clear()
@@ -19978,6 +19974,11 @@ export class Daemon {
     const hostStarts = [...this.hostStarts.values()]
     const hostIds = new Set([...this.hosts.keys(), ...this.hostStarts.keys(), ...this.hostStopping.keys()])
     for (const agentId of hostIds) await this.stopHost(agentId).catch((e) => errors.push(e))
+    // Only now: the shim channel IS the runtimes' transport, so closing it before the drain
+    // would cut in-flight turns and closing it before host teardown would leave `AcpHost.stop()`
+    // unable to send its ACP close — a sandbox process still running, and reconnecting.
+    await this.k8sPlane?.stop().catch(() => undefined)
+    setWorkspaceGitRunnerResolver(undefined)
     await Promise.allSettled(hostStarts)
     // Shutdown backstop: dream extractions reclaim their own tombstone when the
     // dedicated host stops, and stopHost sweeps per-agent for warm hosts, but drop

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4762,6 +4762,10 @@ export class Daemon {
 
   private async runAgentWorkspacePreparation(agent: Agent, request?: PrepareSessionWorkspaceRequest): Promise<string> {
     if (!this.opts.hostFactory) assertExclusiveAgentWorkspaces([agent as LoadedAgent])
+    // In --k8s the workspace lives on the sandbox pod's volume, so the sandbox has to exist
+    // BEFORE preparation: the resolver has no session until a channel binds, and preparing first
+    // would clone onto this daemon's disk and hand the runtime an empty workspace.
+    if (this.k8sPlane) await this.k8sPlane.ensureChannel(agent.id)
     const opts = {
       managedSkills: (value: Agent) => this.managedSkillCache?.resolve(value) ?? Promise.resolve([]),
       skillsStateDir: join(this.root, 'skill-installs'),
@@ -19887,9 +19891,6 @@ export class Daemon {
     // from re-arming itself (its callback re-arms only `if (!this.draining)`), so a
     // sweep firing during the awaits below can't leave a dangling timer behind.
     this.draining = true
-    // Stop accepting shim callbacks early: a pod binding while the daemon drains would be
-    // authorized against a launch that is going away.
-    await this.k8sPlane?.stop().catch(() => undefined)
     clearTimeout(this.debounceTimer)
     if (this.idleSweepTimer !== undefined) {
       this.clock.clearTimeout(this.idleSweepTimer)
@@ -19926,6 +19927,10 @@ export class Daemon {
     // §2.5: gate new turns and let in-flight ones finish (deadline-bounded) BEFORE
     // tearing the hosts down — a hard kill mid-turn loses the reply + transcript.
     await this.drainForShutdown()
+    // AFTER the drain, never before: closing the shim endpoint drops every sandbox channel, so
+    // doing it first would kill the in-flight turns the drain deadline exists to finish.
+    await this.k8sPlane?.stop().catch(() => undefined)
+    setWorkspaceGitRunnerResolver(undefined)
     this.store.setTranscriptMutationListener()
     for (const { timer } of this.transcriptActivityTimers.values()) this.clock.clearTimeout(timer)
     this.transcriptActivityTimers.clear()

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -58,7 +58,7 @@ program
   .option('--agents-dir <dir>', 'override agents directory')
   .option('--max-agents <n>', 'max agents this daemon advertises / enforces')
   .option('--require-sandbox', 'require the Linux SRT sandbox for every agent or refuse daemon startup')
-  .option('--cloud', 'run runtimes in cluster sandbox pods instead of on this host (no probing, no local runtimes)')
+  .option('--k8s', 'run runtimes in cluster sandbox pods instead of on this host (no probing, no local runtimes)')
   .option('--dry-run', 'load + validate config and print the reconcile plan, then exit')
   .option('--agent <name>', 'select a single agent by id (run/chat)')
 
@@ -89,10 +89,10 @@ program
       return exit(1)
     }
     try {
-      // A cloud daemon's version IS its image: there is no CLI or version store to
+      // A k8s daemon's version IS its image: there is no CLI or version store to
       // self-install from, so the bootstrap upgrade path is skipped outright rather
       // than left to fail on a missing cli-entry pointer.
-      if (opts.cloud !== true) {
+      if (opts.k8s !== true) {
         const bootstrap = await import('./bootstrap-upgrade.js')
         const bootstrapOutcome = await bootstrap.runBootstrapUpgrade({
           root: opts.root,
@@ -120,7 +120,7 @@ program
         // this daemon is supervised; the daemon can no longer self-detect it now
         // that the service layer lives in the CLI (cli-daemon-split.md §7.1).
         supervisor: process.env.AGENTCONNECT_SUPERVISOR,
-        cloud: opts.cloud === true,
+        k8s: opts.k8s === true,
         overrides: {
           apiUrl: opts.apiUrl,
           apiKey: opts.apiKey,

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -319,6 +319,78 @@ export class K8sDriver implements SpawnDriver {
    * passed through unresolved, because the shim resolves them in the filesystem the runtime
    * will actually read.
    */
+  /**
+   * Bring the agent's Sandbox up and wait for its shim to bind, WITHOUT starting a runtime.
+   *
+   * Separate from `launch` because the workspace has to be prepared before the runtime starts,
+   * and for a cluster agent "prepared" means cloned onto the sandbox's own volume. A caller that
+   * prepared first and launched afterwards would clone on the daemon's disk and hand the runtime
+   * an empty workspace.
+   */
+  async ensureBoundChannel(agentId: string, timer?: LaunchTimer): Promise<ShimConnection> {
+    if (this.draining.has(agentId)) {
+      throw new Error(`agent ${agentId} is draining for an image rollout — retry once it clears`)
+    }
+    const launch = await this.ensureSandbox(agentId, timer)
+    // Resume BEFORE waiting: suspension deleted the pod, so readiness cannot arrive until
+    // something asks for Running.
+    const modeBeforeWake = await this.wake(agentId)
+    // A launch this daemon already has cached returns from ensureSandbox before any sandbox
+    // read, so this is where the ordinary `launch → suspend → launch` resume learns what it is.
+    // Without it that path — the COMMON one — reported `warm` and never entered resume p95.
+    if (modeBeforeWake) timer?.observedPath(modeBeforeWake === 'Suspended' ? 'resume' : 'warm')
+    timer?.mark('mode_running')
+    // Published the moment the Sandbox names its pod, which is before readiness — the record has
+    // to exist by the time the shim dials, and the pod it authorizes is not knowable any earlier.
+    // Publishing at claim time instead would name the PREVIOUS incarnation's pod, authorizing the
+    // wrong one for as long as the window lasted.
+    await this.awaitReady(launch.sandboxName, (podName) => {
+      this.deps.publishSpawnRecord({
+        agentId,
+        sandboxUid: launch.sandboxUid,
+        generation: launch.generation,
+        grants: [...RUNTIME_GRANTS],
+        podName
+      })
+    })
+    timer?.mark('pod_ready')
+    const channelTimeoutMs = this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
+    const waitingSince = this.clock.now()
+    const connection = await this.deps
+      .awaitChannel(agentId, launch.generation, channelTimeoutMs)
+      .catch((err: unknown) => {
+        // awaitChannel is supplied by the host, so its error text is not ours to match on.
+        // Elapsed-versus-the-deadline-we-set is a fact we own, and it is what distinguishes a
+        // channel that never arrived from one that failed for another reason.
+        if (this.clock.now() - waitingSince >= channelTimeoutMs) {
+          throw new LaunchTimeoutError(`no shim channel bound for agent ${agentId} in time`)
+        }
+        throw err
+      })
+    timer?.mark('shim_handshake')
+    // The session is created HERE rather than in `launch`, because a channel bound for workspace
+    // preparation needs one too — and a second session per agent would mean the runtime and the
+    // workspace seam disagreeing about whether the channel is alive.
+    const existing = this.sessions.get(agentId)
+    if (existing && existing.generation === connection.binding.generation) {
+      existing.attach(connection)
+    } else {
+      const session = new ShimSession(agentId, connection.binding.generation, {
+        setTimeout: (fn, ms) => this.clock.setTimeout(fn, ms),
+        clearTimeout: (handle) => this.clock.clearTimeout(handle as never)
+      })
+      session.attach(connection)
+      this.sessions.set(agentId, session)
+    }
+    return connection
+  }
+
+  /** The bound session for an agent, so the workspace seam reaches the same channel the runtime
+   *  does rather than opening a second one that can disagree about whether it is alive. */
+  sessionFor(agentId: string): ShimSession | undefined {
+    return this.sessions.get(agentId)
+  }
+
   async launch(request: SpawnRequest): Promise<SpawnedRuntime> {
     const agentId = request.env.AC_AGENT_ID
     if (!agentId) throw new Error('cluster launch requires AC_AGENT_ID in the runtime environment')
@@ -330,50 +402,10 @@ export class K8sDriver implements SpawnDriver {
     }
     const timer = new LaunchTimer(this.metrics, () => this.clock.now())
     try {
-      const launch = await this.ensureSandbox(agentId, timer)
-      // Resume BEFORE waiting: suspension deleted the pod, so readiness cannot arrive until
-      // something asks for Running.
-      const modeBeforeWake = await this.wake(agentId)
-      // A launch this daemon already has cached returns from ensureSandbox before any sandbox
-      // read, so this is where the ordinary `launch → suspend → launch` resume learns what it is.
-      // Without it that path — the COMMON one — reported `warm` and never entered resume p95.
-      if (modeBeforeWake) timer.observedPath(modeBeforeWake === 'Suspended' ? 'resume' : 'warm')
-      timer.mark('mode_running')
-      // Published the moment the Sandbox names its pod, which is before readiness — the record
-      // has to exist by the time the shim dials, and the pod it authorizes is not knowable any
-      // earlier. Publishing at claim time instead would name the PREVIOUS incarnation's pod,
-      // authorizing the wrong one for as long as the window lasted.
-      await this.awaitReady(launch.sandboxName, (podName) => {
-        this.deps.publishSpawnRecord({
-          agentId,
-          sandboxUid: launch.sandboxUid,
-          generation: launch.generation,
-          grants: [...RUNTIME_GRANTS],
-          podName
-        })
-      })
-      timer.mark('pod_ready')
-      const channelTimeoutMs = this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
-      const waitingSince = this.clock.now()
-      const connection = await this.deps
-        .awaitChannel(agentId, launch.generation, channelTimeoutMs)
-        .catch((err: unknown) => {
-          // awaitChannel is supplied by the host, so its error text is not ours to match on.
-          // Elapsed-versus-the-deadline-we-set is a fact we own, and it is what distinguishes a
-          // channel that never arrived from one that failed for another reason.
-          if (this.clock.now() - waitingSince >= channelTimeoutMs) {
-            throw new LaunchTimeoutError(`no shim channel bound for agent ${agentId} in time`)
-          }
-          throw err
-        })
-      timer.mark('shim_handshake')
+      await this.ensureBoundChannel(agentId, timer)
       this.metrics.channel('bound')
-      const session = new ShimSession(agentId, launch.generation, {
-        setTimeout: (fn, ms) => this.clock.setTimeout(fn, ms),
-        clearTimeout: (handle) => this.clock.clearTimeout(handle as never)
-      })
-      session.attach(connection)
-      this.sessions.set(agentId, session)
+      const session = this.sessions.get(agentId)
+      if (!session) throw new Error(`no shim session for agent ${agentId} after binding its channel`)
       // The open is asynchronous, so the stage closes when the runtime reports — not when the
       // call returns. Marking it here measured the cost of constructing a stream pair and called
       // a runtime that never started a success.

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -6,7 +6,13 @@ import type { ShimConnection } from '../shim/listener.js'
 import { ShimRequestTimeoutError } from '../shim/channels.js'
 import { ShimSession } from '../shim/session.js'
 import type { SpawnRecord } from '../shim/binding.js'
-import { OperatingModeRejectedError, isSandboxReady, type OperatingMode, type SandboxApi } from './sandbox-api.js'
+import {
+  OperatingModeRejectedError,
+  isSandboxReady,
+  type OperatingMode,
+  type Sandbox,
+  type SandboxApi
+} from './sandbox-api.js'
 import { K8sApiError } from './http.js'
 
 /** Label domain the claim controller must be configured to allow. */
@@ -16,11 +22,28 @@ export const AC_LABEL_AGENT = 'agentconnect.md/agent'
 /** Annotation an image rollout writes to ask a daemon to quiesce a Sandbox. */
 export const DRAIN_REQUESTED_ANNOTATION = 'agentconnect.md/drain-requested'
 
+/**
+ * Where agent-sandbox records the pod a Sandbox is currently backed by.
+ *
+ * This is the ONLY way the daemon can map a dialing pod back to the launch that started it: a
+ * TokenReview yields a pod name and uid, `SandboxStatus` carries no pod reference at all
+ * (v1beta1: serviceFQDN, service, conditions, selector, podIPs, nodeName), and reading the Pod
+ * API is deliberately outside this daemon's Role. Upstream's `resolvePodName` is exactly this
+ * annotation with the Sandbox's own name as the fallback, so mirroring it keeps the two in step.
+ */
+export const SANDBOX_POD_NAME_ANNOTATION = 'agents.x-k8s.io/pod-name'
+
+/** The pod backing this Sandbox: the adopted warm-pool pod, or the Sandbox's own name. */
+export function resolvePodName(sandbox: Sandbox): string | undefined {
+  const adopted = sandbox.metadata?.annotations?.[SANDBOX_POD_NAME_ANNOTATION]
+  return adopted && adopted.length > 0 ? adopted : sandbox.metadata?.name
+}
+
 /** Capabilities a runtime launch receives. Narrow by construction: a launch gets exactly
  *  what the channels it uses require, so a future capability is an explicit decision. */
 export const RUNTIME_GRANTS: ShimCapability[] = ['acp', 'materialize', 'exec', 'read', 'tunnel']
 
-export interface ClusterDriverDeps {
+export interface K8sDriverDeps {
   api: SandboxApi
   orgId: string
   /** Pool the claim references; v1beta1 requires one, and a cold pool is `replicas: 0`. */
@@ -64,7 +87,7 @@ interface Launch {
  * wake and teardown are all local decisions, so a control-plane outage cannot stop an
  * existing agent from starting or stopping its runtime.
  */
-export class ClusterSpawnDriver implements SpawnDriver {
+export class K8sDriver implements SpawnDriver {
   private readonly metrics: ClusterMetrics
   private readonly launches = new Map<string, Launch>()
   private readonly generations = new Map<string, number>()
@@ -79,7 +102,7 @@ export class ClusterSpawnDriver implements SpawnDriver {
   private readonly sessions = new Map<string, ShimSession>()
   private readonly clock: Clock
 
-  constructor(private readonly deps: ClusterDriverDeps) {
+  constructor(private readonly deps: K8sDriverDeps) {
     this.clock = deps.clock ?? systemClock
     this.metrics = deps.metrics ?? noopClusterMetrics
   }
@@ -130,19 +153,32 @@ export class ClusterSpawnDriver implements SpawnDriver {
     this.generations.set(agentId, generation)
     const launch: Launch = { agentId, sandboxName, sandboxUid, generation }
     this.launches.set(agentId, launch)
-    // The record must exist before the shim can bind: the handshake resolves a pod against
-    // it, and an unpublished launch is indistinguishable from a pod we never started.
-    this.deps.publishSpawnRecord({ agentId, sandboxUid, generation, grants: [...RUNTIME_GRANTS] })
     return launch
   }
 
   /** Wait for the Sandbox to report Ready, after something has asked it to run. */
-  private async awaitReady(sandboxName: string): Promise<void> {
+  // Returns the pod backing the ready Sandbox. Resolved HERE rather than at claim time because
+  // warm-pool adoption writes the annotation as the pod is bound and suspension clears it, so a
+  // name read any earlier belongs to the previous incarnation — and binding the next launch
+  // against it would authorize the wrong pod.
+  private async awaitReady(sandboxName: string, onPodResolved: (podName: string) => void): Promise<string> {
     const backoff = new Backoff({ baseMs: 250, capMs: 2_000, jitter: () => 0 })
     const deadline = this.clock.now() + (this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS)
+    let resolved: string | undefined
     for (;;) {
       const sandbox = await this.deps.api.getSandbox(sandboxName).catch(() => undefined)
-      if (sandbox && isSandboxReady(sandbox)) return
+      // The pod is named as soon as it is bound, which is BEFORE it reports Ready — and the shim
+      // dials from a pod that is merely running. Publishing here rather than after readiness is
+      // what keeps that dial from arriving ahead of the record that authorizes it.
+      const podName = sandbox ? resolvePodName(sandbox) : undefined
+      if (podName && podName !== resolved) {
+        resolved = podName
+        onPodResolved(podName)
+      }
+      if (sandbox && isSandboxReady(sandbox)) {
+        if (!resolved) throw new Error(`sandbox ${sandboxName} is ready but names no pod`)
+        return resolved
+      }
       if (this.clock.now() >= deadline) {
         throw new LaunchTimeoutError(`sandbox ${sandboxName} did not become ready in time`)
       }
@@ -303,7 +339,19 @@ export class ClusterSpawnDriver implements SpawnDriver {
       // Without it that path — the COMMON one — reported `warm` and never entered resume p95.
       if (modeBeforeWake) timer.observedPath(modeBeforeWake === 'Suspended' ? 'resume' : 'warm')
       timer.mark('mode_running')
-      await this.awaitReady(launch.sandboxName)
+      // Published the moment the Sandbox names its pod, which is before readiness — the record
+      // has to exist by the time the shim dials, and the pod it authorizes is not knowable any
+      // earlier. Publishing at claim time instead would name the PREVIOUS incarnation's pod,
+      // authorizing the wrong one for as long as the window lasted.
+      await this.awaitReady(launch.sandboxName, (podName) => {
+        this.deps.publishSpawnRecord({
+          agentId,
+          sandboxUid: launch.sandboxUid,
+          generation: launch.generation,
+          grants: [...RUNTIME_GRANTS],
+          podName
+        })
+      })
       timer.mark('pod_ready')
       const channelTimeoutMs = this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
       const waitingSince = this.clock.now()

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -1,0 +1,177 @@
+import { loadInClusterConfig } from './config.js'
+import { K8sHttp } from './http.js'
+import { K8sDriver } from './driver.js'
+import { SandboxApi } from './sandbox-api.js'
+import { clusterMetrics } from './cluster-metrics.js'
+import { ShimListener, type ShimConnection } from '../shim/listener.js'
+import { ShimSession } from '../shim/session.js'
+import { ShimGitRunner } from '../shim/git-exec.js'
+import type { SpawnRecord } from '../shim/binding.js'
+import type { GitRunner } from '../workspace/git-runner.js'
+
+const SILENT = { info: () => {}, warn: () => {} }
+
+/**
+ * Assembles the k8s execution plane: the shim endpoint, the driver, and the seams that make an
+ * agent's git run where its workspace actually is.
+ *
+ * It exists because every piece of this was built and tested separately and nothing put them
+ * together — `--k8s` changed the daemon's BEHAVIOUR (no probing, declared runtimes, no host
+ * sandbox) while `AcpHost` still fell back to `LocalDriver`, so runtimes kept running on the
+ * daemon's own host and no Sandbox was ever created.
+ */
+export interface K8sRuntimePlaneOptions {
+  /** Org the claims are labelled with; one daemon serves one org in the managed cluster.
+   *  Resolved from the deployment's env when omitted. */
+  orgId?: string
+  /** Warm pool the claims reference. v1beta1 requires one; a cold pool is `replicas: 0`. */
+  warmPoolName?: string
+  /** Port the shim dials back on. The pod learns it from the template's AC_SHIM_ENDPOINT, so
+   *  this side only has to listen — the daemon never dials into a sandbox. */
+  shimPort?: number
+  shimHost?: string
+  /** Environment the deployment settings come from; `process.env` unless a test names another. */
+  env?: NodeJS.ProcessEnv
+  readyTimeoutMs?: number
+  /** Kubernetes surface. Built from the pod's own in-cluster config when omitted; supplied by
+   *  tests so the assembly can be exercised without a cluster. */
+  api?: SandboxApi
+  log?: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
+}
+
+export interface K8sPlaneSettings {
+  orgId: string
+  warmPoolName: string
+  shimPort: number
+  shimHost?: string
+}
+
+/** Deployment-owned settings. Env rather than the config file: they describe where this pod sits
+ *  in the cluster, which is the deployment's to state and not an operator preference. */
+export const K8S_ORG_ID_ENV = 'AC_K8S_ORG_ID'
+export const K8S_WARM_POOL_ENV = 'AC_K8S_WARM_POOL'
+export const K8S_SHIM_PORT_ENV = 'AC_K8S_SHIM_PORT'
+export const K8S_SHIM_HOST_ENV = 'AC_K8S_SHIM_HOST'
+export const DEFAULT_SHIM_PORT = 8085
+
+/** Explicit options win per FIELD, so a caller may name one and leave the rest to the env. */
+export function resolveK8sPlaneSettings(options: K8sRuntimePlaneOptions = {}): K8sPlaneSettings {
+  const env = options.env ?? process.env
+  const orgId = options.orgId ?? env[K8S_ORG_ID_ENV]?.trim()
+  const warmPoolName = options.warmPoolName ?? env[K8S_WARM_POOL_ENV]?.trim()
+  // Refused rather than defaulted: a guessed org labels another tenant's claims, and a guessed
+  // pool yields sandboxes that never bind with nothing in the logs saying why.
+  if (!orgId) throw new Error(`--k8s requires ${K8S_ORG_ID_ENV}`)
+  if (!warmPoolName) throw new Error(`--k8s requires ${K8S_WARM_POOL_ENV}`)
+  const rawPort = options.shimPort ?? env[K8S_SHIM_PORT_ENV] ?? DEFAULT_SHIM_PORT
+  const shimPort = Number(rawPort)
+  if (!Number.isInteger(shimPort) || shimPort < 0 || shimPort > 65_535) {
+    throw new Error(`${K8S_SHIM_PORT_ENV} is not a valid port: ${rawPort}`)
+  }
+  const shimHost = options.shimHost ?? env[K8S_SHIM_HOST_ENV]?.trim()
+  return { orgId, warmPoolName, shimPort, ...(shimHost ? { shimHost } : {}) }
+}
+
+/** The env contract on its own, which is what a deployment has to satisfy. */
+export function k8sPlaneSettings(env: NodeJS.ProcessEnv): K8sPlaneSettings {
+  return resolveK8sPlaneSettings({ env })
+}
+
+export interface K8sRuntimePlane {
+  driver: K8sDriver
+  listener: ShimListener
+  /** A git runner for an agent whose workspace lives on its sandbox pod, or undefined when this
+   *  daemon has no channel for it — the caller then keeps its local behaviour. */
+  gitRunnerFor: (agentId: string, cwd?: string, abort?: AbortSignal) => GitRunner | undefined
+  stop: () => Promise<void>
+}
+
+/**
+ * Build and start the plane. Throws if the process is not in a pod: `--k8s` outside a cluster is a
+ * misconfiguration to report at boot, not something to degrade into running runtimes locally —
+ * that degradation is precisely the shape that would put agent code on the daemon's host.
+ */
+export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Promise<K8sRuntimePlane> {
+  // Resolved HERE rather than by the caller, so the whole env contract lives in one place and a
+  // caller that overrides this factory (a test) does not have to satisfy it.
+  const settings = resolveK8sPlaneSettings(options)
+  const api =
+    options.api ??
+    (() => {
+      const config = loadInClusterConfig()
+      return new SandboxApi(new K8sHttp(config), config.namespace)
+    })()
+
+  // Records keyed by the pod they authorize. A TokenReview yields a pod name and uid and nothing
+  // else, so this map is the whole of how a dialing pod is resolved back to its launch.
+  const recordsByPod = new Map<string, SpawnRecord>()
+  const sessions = new Map<string, ShimSession>()
+
+  const listener = new ShimListener({
+    verifier: { reviewToken: (token, audiences) => api.reviewToken(token, audiences) },
+    spawnRecordForPod: (pod) => recordsByPod.get(pod.name),
+    now: () => Date.now(),
+    metrics: clusterMetrics,
+    onConnection: (connection) => {
+      driver.onChannelBound(connection)
+      attachSession(connection)
+    },
+    onConnectionLost: (agentId, reason) => driver.onChannelLost(agentId, reason),
+    log: options.log ?? SILENT
+  })
+  const driver = new K8sDriver({
+    api,
+    orgId: settings.orgId,
+    warmPoolName: settings.warmPoolName,
+    awaitChannel: (agentId, generation, timeoutMs) => listener.awaitConnection(agentId, generation, timeoutMs),
+    publishSpawnRecord: (record) => {
+      // Keyed by pod, and the previous pod's entry is dropped: leaving it would let a terminating
+      // pod keep binding against a launch that has moved on.
+      for (const [podName, existing] of recordsByPod) {
+        if (existing.agentId === record.agentId && podName !== record.podName) recordsByPod.delete(podName)
+      }
+      recordsByPod.set(record.podName, record)
+    },
+    metrics: clusterMetrics,
+    ...(options.readyTimeoutMs === undefined ? {} : { readyTimeoutMs: options.readyTimeoutMs }),
+    log: options.log ?? SILENT
+  })
+
+  // Started only once the driver exists: `onConnection` reaches into it, and a pod that dialled
+  // in between would hit an uninitialized binding.
+  await listener.start(settings.shimPort, settings.shimHost ?? '0.0.0.0')
+
+  // A session per agent, re-attached on every rebind. The workspace seam reaches the sandbox
+  // through this rather than through one socket, so a credential renewal does not break a git
+  // operation that spans it.
+  function attachSession(connection: ShimConnection): void {
+    const agentId = connection.binding.agentId
+    const existing = sessions.get(agentId)
+    if (existing && existing.generation === connection.binding.generation) {
+      existing.attach(connection)
+      return
+    }
+    const session = new ShimSession(agentId, connection.binding.generation, {
+      setTimeout: (fn, ms) => setTimeout(fn, ms),
+      clearTimeout: (handle) => clearTimeout(handle as NodeJS.Timeout)
+    })
+    session.attach(connection)
+    sessions.set(agentId, session)
+  }
+
+  return {
+    driver,
+    listener,
+    gitRunnerFor: (agentId, cwd, abort) => {
+      const session = sessions.get(agentId)
+      // No channel means this agent has no sandbox to run git in. Returning undefined keeps the
+      // caller on its local runner rather than failing the operation — which is what a
+      // self-hosted agent beside a cluster-backed one needs anyway.
+      if (!session?.isAttached()) return undefined
+      return new ShimGitRunner(session, cwd, undefined, abort)
+    },
+    stop: async () => {
+      await listener.stop()
+    }
+  }
+}

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -3,8 +3,7 @@ import { K8sHttp } from './http.js'
 import { K8sDriver } from './driver.js'
 import { SandboxApi } from './sandbox-api.js'
 import { clusterMetrics } from './cluster-metrics.js'
-import { ShimListener, type ShimConnection } from '../shim/listener.js'
-import { ShimSession } from '../shim/session.js'
+import { ShimListener } from '../shim/listener.js'
 import { ShimGitRunner } from '../shim/git-exec.js'
 import type { SpawnRecord } from '../shim/binding.js'
 import type { GitRunner } from '../workspace/git-runner.js'
@@ -80,6 +79,9 @@ export function k8sPlaneSettings(env: NodeJS.ProcessEnv): K8sPlaneSettings {
 export interface K8sRuntimePlane {
   driver: K8sDriver
   listener: ShimListener
+  /** Bring an agent's Sandbox up and bind its channel WITHOUT starting a runtime, so the
+   *  workspace can be prepared on the pod's own volume before the runtime looks at it. */
+  ensureChannel: (agentId: string) => Promise<void>
   /** A git runner for an agent whose workspace lives on its sandbox pod, or undefined when this
    *  daemon has no channel for it — the caller then keeps its local behaviour. */
   gitRunnerFor: (agentId: string, cwd?: string, abort?: AbortSignal) => GitRunner | undefined
@@ -105,7 +107,6 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
   // Records keyed by the pod they authorize. A TokenReview yields a pod name and uid and nothing
   // else, so this map is the whole of how a dialing pod is resolved back to its launch.
   const recordsByPod = new Map<string, SpawnRecord>()
-  const sessions = new Map<string, ShimSession>()
 
   const listener = new ShimListener({
     verifier: { reviewToken: (token, audiences) => api.reviewToken(token, audiences) },
@@ -113,10 +114,16 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     now: () => Date.now(),
     metrics: clusterMetrics,
     onConnection: (connection) => {
+      // A rebind cancels any pending loss check: this IS the replacement it was waiting for.
+      clearTimeout(lossTimers.get(connection.binding.agentId))
+      lossTimers.delete(connection.binding.agentId)
       driver.onChannelBound(connection)
-      attachSession(connection)
     },
-    onConnectionLost: (agentId, reason) => driver.onChannelLost(agentId, reason),
+    // A closed socket is NOT a lost launch. The shim closes and re-dials at half the credential
+    // TTL, and `ShimSession.lose()` is terminal — reporting loss here killed the runtime on every
+    // routine renewal, which is the exact failure ShimSession exists to prevent. Loss is reported
+    // only if no replacement binds for the same launch within the grace window.
+    onConnectionLost: (agentId, reason) => scheduleLossCheck(agentId, reason),
     log: options.log ?? SILENT
   })
   const driver = new K8sDriver({
@@ -141,29 +148,32 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
   // in between would hit an uninitialized binding.
   await listener.start(settings.shimPort, settings.shimHost ?? '0.0.0.0')
 
-  // A session per agent, re-attached on every rebind. The workspace seam reaches the sandbox
-  // through this rather than through one socket, so a credential renewal does not break a git
-  // operation that spans it.
-  function attachSession(connection: ShimConnection): void {
-    const agentId = connection.binding.agentId
-    const existing = sessions.get(agentId)
-    if (existing && existing.generation === connection.binding.generation) {
-      existing.attach(connection)
-      return
-    }
-    const session = new ShimSession(agentId, connection.binding.generation, {
-      setTimeout: (fn, ms) => setTimeout(fn, ms),
-      clearTimeout: (handle) => clearTimeout(handle as NodeJS.Timeout)
-    })
-    session.attach(connection)
-    sessions.set(agentId, session)
+  // A renewal re-dials immediately (the client resets its backoff for a planned rebind), so a
+  // replacement that has not arrived well inside the request deadline is a pod that is gone.
+  const REBIND_GRACE_MS = 20_000
+  const lossTimers = new Map<string, NodeJS.Timeout>()
+
+  function scheduleLossCheck(agentId: string, reason: string): void {
+    clearTimeout(lossTimers.get(agentId))
+    lossTimers.set(
+      agentId,
+      setTimeout(() => {
+        lossTimers.delete(agentId)
+        if (listener.connectionsFor(agentId).length > 0) return
+        options.log?.warn(`k8s: no shim channel for agent ${agentId} after ${REBIND_GRACE_MS}ms — reporting loss`)
+        driver.onChannelLost(agentId, reason)
+      }, REBIND_GRACE_MS).unref?.() as NodeJS.Timeout
+    )
   }
 
   return {
     driver,
     listener,
+    ensureChannel: async (agentId) => {
+      await driver.ensureBoundChannel(agentId)
+    },
     gitRunnerFor: (agentId, cwd, abort) => {
-      const session = sessions.get(agentId)
+      const session = driver.sessionFor(agentId)
       // No channel means this agent has no sandbox to run git in. Returning undefined keeps the
       // caller on its local runner rather than failing the operation — which is what a
       // self-hosted agent beside a cluster-backed one needs anyway.
@@ -171,6 +181,8 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       return new ShimGitRunner(session, cwd, undefined, abort)
     },
     stop: async () => {
+      for (const timer of lossTimers.values()) clearTimeout(timer)
+      lossTimers.clear()
       await listener.stop()
     }
   }

--- a/packages/daemon/src/runtimes/k8s-runtimes.ts
+++ b/packages/daemon/src/runtimes/k8s-runtimes.ts
@@ -4,14 +4,14 @@ import { z } from 'zod'
 import type { ResolvedRuntimeCatalog } from './registry.js'
 
 /** Path override for the declared runtime table (a mounted ConfigMap in a cluster). */
-export const CLOUD_RUNTIMES_ENV = 'AGENTCONNECT_CLOUD_RUNTIMES'
+export const K8S_RUNTIMES_ENV = 'AGENTCONNECT_K8S_RUNTIMES'
 
 /**
- * What the runtime image observed at `initialize`, published so `--cloud` can report it without
+ * What the runtime image observed at `initialize`, published so `--k8s` can report it without
  * probing. Only the fields the daemon actually reports are typed — an unrecognized key here would
  * be silently dropped, which is how the first version of this shipped a snapshot nothing consumed.
  */
-const CloudRuntimeAcpSchema = z.object({
+const K8sRuntimeAcpSchema = z.object({
   protocolVersion: z.number().int().nonnegative().optional(),
   agentName: z.string().optional(),
   authMethods: z.array(z.string()).optional(),
@@ -23,30 +23,30 @@ const CloudRuntimeAcpSchema = z.object({
    *  recorded fact rather than a gap. */
   sessionProbe: z.enum(['ok', 'auth-required']).optional()
 })
-export type CloudRuntimeAcpSnapshot = z.infer<typeof CloudRuntimeAcpSchema>
+export type K8sRuntimeAcpSnapshot = z.infer<typeof K8sRuntimeAcpSchema>
 
-const CloudRuntimeEntrySchema = z.object({
+const K8sRuntimeEntrySchema = z.object({
   id: z.string().min(1),
   /** Overrides the catalog's declared version — the image pin is authoritative for what actually ships. */
   version: z.string().optional(),
   /** Optional model snapshot; reported with `modelsSource: 'cached'` because no live probe confirmed it. */
   models: z.array(z.string()).optional(),
   /** The image's `initialize` snapshot for this runtime. */
-  acp: CloudRuntimeAcpSchema.optional()
+  acp: K8sRuntimeAcpSchema.optional()
 })
 
-export const CloudRuntimeTableSchema = z.object({ runtimes: z.array(CloudRuntimeEntrySchema).min(1) })
+export const K8sRuntimeTableSchema = z.object({ runtimes: z.array(K8sRuntimeEntrySchema).min(1) })
 
-export type CloudRuntimeTable = z.infer<typeof CloudRuntimeTableSchema>
-export type CloudRuntimeEntry = z.infer<typeof CloudRuntimeEntrySchema>
+export type K8sRuntimeTable = z.infer<typeof K8sRuntimeTableSchema>
+export type K8sRuntimeEntry = z.infer<typeof K8sRuntimeEntrySchema>
 
-export function cloudRuntimesPath(root: string, env: NodeJS.ProcessEnv = process.env): string {
-  const override = env[CLOUD_RUNTIMES_ENV]?.trim()
-  return override ? override : join(root, 'cloud-runtimes.json')
+export function k8sRuntimesPath(root: string, env: NodeJS.ProcessEnv = process.env): string {
+  const override = env[K8S_RUNTIMES_ENV]?.trim()
+  return override ? override : join(root, 'k8s-runtimes.json')
 }
 
 /**
- * Load the runtimes the runtime image declares it provides. `--cloud` cannot use
+ * Load the runtimes the runtime image declares it provides. `--k8s` cannot use
  * host executable discovery: the runtimes live in the sandbox image, not next to
  * the daemon, so presence is a declaration rather than something to detect.
  *
@@ -54,23 +54,18 @@ export function cloudRuntimesPath(root: string, env: NodeJS.ProcessEnv = process
  * a malformed one throws, because silently running with no runtimes looks exactly
  * like a healthy daemon that nobody can use.
  */
-export function loadCloudRuntimeTable(
-  root: string,
-  env: NodeJS.ProcessEnv = process.env
-): CloudRuntimeTable | undefined {
-  const path = cloudRuntimesPath(root, env)
+export function loadK8sRuntimeTable(root: string, env: NodeJS.ProcessEnv = process.env): K8sRuntimeTable | undefined {
+  const path = k8sRuntimesPath(root, env)
   if (!existsSync(path)) return undefined
   let parsed: unknown
   try {
     parsed = JSON.parse(readFileSync(path, 'utf8'))
   } catch (err) {
-    throw new Error(`cloud runtime table at ${path} is not valid JSON: ${(err as Error).message}`)
+    throw new Error(`k8s runtime table at ${path} is not valid JSON: ${(err as Error).message}`)
   }
-  const result = CloudRuntimeTableSchema.safeParse(parsed)
+  const result = K8sRuntimeTableSchema.safeParse(parsed)
   if (!result.success) {
-    throw new Error(
-      `cloud runtime table at ${path} is invalid: ${result.error.issues[0]?.message ?? 'schema mismatch'}`
-    )
+    throw new Error(`k8s runtime table at ${path} is invalid: ${result.error.issues[0]?.message ?? 'schema mismatch'}`)
   }
   return result.data
 }
@@ -86,7 +81,7 @@ export interface DeclaredCatalogResult {
   /** Model snapshots to seed, keyed by runtime id. */
   models: Record<string, string[]>
   /** Per-runtime `initialize` snapshot from the image, keyed by runtime id. */
-  acp: Record<string, CloudRuntimeAcpSnapshot>
+  acp: Record<string, K8sRuntimeAcpSnapshot>
 }
 
 const PACKAGE_LAUNCHERS = new Set(['npx', 'uvx'])
@@ -97,23 +92,20 @@ const PACKAGE_LAUNCHERS = new Set(['npx', 'uvx'])
  * advertised, because either would break at first use:
  *
  * - curated entries, whose admission gate requires a successful probe that
- *   `--cloud` never runs;
+ *   `--k8s` never runs;
  * - package-launcher entries (`npx` / `uvx`), which fetch their artifact at launch:
  *   that artifact is not the image's, is not what the declared version pin names,
  *   and the fetch fails outright on a restricted egress. An image that ships such a
  *   runtime must resolve it to a pinned local executable in the catalog first.
  */
-export function declaredRuntimeCatalog(
-  catalog: ResolvedRuntimeCatalog,
-  table: CloudRuntimeTable
-): DeclaredCatalogResult {
+export function declaredRuntimeCatalog(catalog: ResolvedRuntimeCatalog, table: K8sRuntimeTable): DeclaredCatalogResult {
   const entries: ResolvedRuntimeCatalog['entries'] = {}
   const runtimes: ResolvedRuntimeCatalog['runtimes'] = {}
   const unresolved: string[] = []
   const rejectedCurated: string[] = []
   const rejectedPackageLaunchers: string[] = []
   const models: Record<string, string[]> = {}
-  const acp: Record<string, CloudRuntimeAcpSnapshot> = {}
+  const acp: Record<string, K8sRuntimeAcpSnapshot> = {}
 
   for (const declared of table.runtimes) {
     const entry = catalog.entries[declared.id]

--- a/packages/daemon/src/shim/binding.ts
+++ b/packages/daemon/src/shim/binding.ts
@@ -10,6 +10,10 @@ export interface SpawnRecord {
   generation: number
   /** Capabilities this launch may exercise, decided by the daemon at spawn time. */
   grants: ShimCapability[]
+  /** The pod backing this launch, from the Sandbox's pod-name annotation. It is how a dialing
+   *  pod is resolved back to its launch — a TokenReview yields only a pod name and uid, and
+   *  nothing else the daemon holds connects those to an agent. */
+  podName: string
 }
 
 /** A bound shim connection: the pod that proved its identity plus what it may do. */

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -39,6 +39,11 @@ export interface ShimListenerDeps {
   credentialTtlMs?: number
   /** Operability counters; omit to record nothing. */
   metrics?: ClusterMetrics
+  /** A channel bound — including a renewal, which is a NEW connection for the same launch, so
+   *  whoever owns the session must re-attach rather than assume the old socket still works. */
+  onConnection?: (connection: ShimConnection) => void
+  /** A bound channel went away, so a caller waiting on it learns instead of hanging. */
+  onConnectionLost?: (agentId: string, reason: string) => void
 }
 
 const DEFAULT_CREDENTIAL_TTL_MS = 10 * 60_000
@@ -141,6 +146,25 @@ export class ShimListener {
   }
 
   /** Bound connections for an agent — the channels a turn is delivered over. */
+  /**
+   * Wait for this launch's channel to bind.
+   *
+   * Keyed on the generation, not just the agent: a channel left over from a previous launch is
+   * the one case that must NOT satisfy this wait, since handing it back would run the new
+   * runtime's traffic down the old pod's socket.
+   */
+  async awaitConnection(agentId: string, generation: number, timeoutMs: number): Promise<ShimConnection> {
+    const deadline = this.deps.now() + timeoutMs
+    for (;;) {
+      const match = this.connectionsFor(agentId).find((connection) => connection.binding.generation === generation)
+      if (match) return match
+      if (this.deps.now() >= deadline) {
+        throw new Error(`no shim channel bound for agent ${agentId} generation ${generation} in time`)
+      }
+      await new Promise<void>((resolve) => this.clock.setTimeout(resolve, 100))
+    }
+  }
+
   connectionsFor(agentId: string): ShimConnection[] {
     return [...this.connections].filter((connection) => connection.binding.agentId === agentId)
   }
@@ -228,6 +252,7 @@ export class ShimListener {
             }
             bound = connection
             this.connections.add(connection)
+            this.deps.onConnection?.(connection)
             const remainingMs = result.binding.expiresAtMs - this.deps.now()
             connection.send({
               type: 'shim/bound',
@@ -287,6 +312,7 @@ export class ShimListener {
     ws.on('close', () => {
       if (bound) {
         this.connections.delete(bound)
+        this.deps.onConnectionLost?.(bound.binding.agentId, 'shim channel closed')
         // Revoke this channel's OWN credential: a same-pod renewal may already hold the
         // pod's index, and revoking by pod here would delete the live replacement.
         this.registry.revokeIssued(bound.issuedCredential)

--- a/packages/daemon/src/shim/session.ts
+++ b/packages/daemon/src/shim/session.ts
@@ -35,6 +35,11 @@ export class ShimSession {
    */
   attach(connection: ShimConnection): void {
     if (this.closed) return
+    // Idempotent for the SAME connection. `onFrame` only ever appends, and its listeners are
+    // never removed, so re-attaching one would deliver every ACP chunk and event twice — and the
+    // path that does it is ordinary: preparing a workspace binds the channel, then launching
+    // binds it again and gets the same connection back.
+    if (this.connection === connection) return
     if (connection.binding.generation !== this.generation) {
       this.lose(`superseded by generation ${connection.binding.generation}`)
       return

--- a/packages/daemon/test/cluster-acp-e2e.test.ts
+++ b/packages/daemon/test/cluster-acp-e2e.test.ts
@@ -3,7 +3,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
 import { AcpHost } from '../src/acp/acp-host.js'
-import { ClusterSpawnDriver } from '../src/k8s/cluster-driver.js'
+import { K8sDriver } from '../src/k8s/driver.js'
 import { ShimListener, type ShimConnection } from '../src/shim/listener.js'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
 import { K8sApiError } from '../src/k8s/http.js'
@@ -73,7 +73,7 @@ function fakeApi() {
 
 /** Wire a real listener, a real shim client, and a driver that connects them. */
 async function clusterUnderTest(options: { credentialTtlMs?: number } = {}): Promise<{
-  driver: ClusterSpawnDriver
+  driver: K8sDriver
   api: ReturnType<typeof fakeApi>
   connections: ShimConnection[]
   shimClock: FakeClock
@@ -95,7 +95,7 @@ async function clusterUnderTest(options: { credentialTtlMs?: number } = {}): Pro
   listeners.push(listener)
   const port = await listener.start(0, '127.0.0.1')
 
-  const driver = new ClusterSpawnDriver({
+  const driver = new K8sDriver({
     api: api.api as never,
     orgId: 'org-1',
     warmPoolName: 'pool',

--- a/packages/daemon/test/cluster-metrics.test.ts
+++ b/packages/daemon/test/cluster-metrics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { FakeClock } from '@agentconnect.md/connection'
-import { ClusterSpawnDriver, DRAIN_REQUESTED_ANNOTATION, type ClusterDriverDeps } from '../src/k8s/cluster-driver.js'
+import { K8sDriver, DRAIN_REQUESTED_ANNOTATION, type ClusterDriverDeps } from '../src/k8s/driver.js'
 import { LaunchTimer, type ClusterMetrics, type LaunchPath, type LaunchStage } from '../src/k8s/cluster-metrics.js'
 import { K8sApiError } from '../src/k8s/http.js'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
@@ -117,7 +117,7 @@ function driverFor(
   clock: FakeClock = new FakeClock(),
   awaitChannel?: ClusterDriverDeps['awaitChannel']
 ) {
-  return new ClusterSpawnDriver({
+  return new K8sDriver({
     api: api.api as never,
     orgId: 'org-1',
     warmPoolName: 'pool',
@@ -136,7 +136,7 @@ function driverFor(
  * The claim-bind and pod-ready waits sleep on the driver's clock, so a FakeClock that nobody
  * advances makes their deadline unreachable — the test would hang rather than observe a timeout.
  */
-async function launchAdvancing(driver: ClusterSpawnDriver, clock: FakeClock): Promise<Error | 'resolved'> {
+async function launchAdvancing(driver: K8sDriver, clock: FakeClock): Promise<Error | 'resolved'> {
   let outcome: Error | 'resolved' | undefined
   const inflight = driver.launch(launchRequest).then(
     () => {

--- a/packages/daemon/test/daemon-cloud-mode.test.ts
+++ b/packages/daemon/test/daemon-cloud-mode.test.ts
@@ -6,7 +6,7 @@ import { DAEMON_BOOTSTRAP_UPGRADE_FEATURE } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 
-/** The behavior matrix for `--cloud`: each assertion here is one row of the mode
+/** The behavior matrix for `--k8s`: each assertion here is one row of the mode
  *  contract, so cloud and self-hosted behavior cannot drift apart unnoticed. */
 
 function root(opts: { declared?: unknown; requireSandbox?: boolean; cliEntry?: boolean } = {}): string {
@@ -20,7 +20,7 @@ function root(opts: { declared?: unknown; requireSandbox?: boolean; cliEntry?: b
     })
   )
   if (opts.declared !== undefined) {
-    writeFileSync(join(path, 'cloud-runtimes.json'), JSON.stringify(opts.declared))
+    writeFileSync(join(path, 'k8s-runtimes.json'), JSON.stringify(opts.declared))
   }
   // A stale pointer left on the root volume is exactly the case that must NOT re-enable
   // the self-installing upgrade path in cloud mode. readCliEntry only accepts a pointer
@@ -47,10 +47,10 @@ function catalog(): ResolvedRuntimeCatalog {
   }
 }
 
-function daemon(opts: { root: string; cloud: boolean; probe?: ReturnType<typeof vi.fn>; supervisor?: string }): Daemon {
+function daemon(opts: { root: string; k8s: boolean; probe?: ReturnType<typeof vi.fn>; supervisor?: string }): Daemon {
   return new Daemon({
     root: opts.root,
-    cloud: opts.cloud,
+    cloud: opts.k8s,
     ...(opts.supervisor ? { supervisor: opts.supervisor } : {}),
     resolveCatalog: async () => catalog(),
     ...(opts.probe ? { probeRuntimes: opts.probe as never } : {}),
@@ -58,7 +58,7 @@ function daemon(opts: { root: string; cloud: boolean; probe?: ReturnType<typeof 
   })
 }
 
-describe('daemon --cloud mode', () => {
+describe('daemon --k8s mode', () => {
   it('advertises the runtimes the image declares, not what is installed on the host', async () => {
     const probe = vi.fn(async () => [])
     const cloud = daemon({
@@ -80,7 +80,7 @@ describe('daemon --cloud mode', () => {
     }
   })
 
-  it('advertises nothing in the same tree without --cloud, where host discovery decides', async () => {
+  it('advertises nothing in the same tree without --k8s, where host discovery decides', async () => {
     const local = daemon({ root: root({ declared: { runtimes: [{ id: 'claude' }] } }), cloud: false })
     try {
       await local.start()
@@ -159,6 +159,6 @@ describe('daemon --cloud mode', () => {
       root: root({ declared: { runtimes: [{ id: 'claude' }] }, requireSandbox: true }),
       cloud: true
     })
-    await expect(cloud.start()).rejects.toThrow(/requireSandbox is not supported with --cloud/)
+    await expect(cloud.start()).rejects.toThrow(/requireSandbox is not supported with --k8s/)
   })
 })

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -7,10 +7,10 @@ import { Daemon } from '../src/daemon.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 
 /** The behavior matrix for `--k8s`: each assertion here is one row of the mode
- *  contract, so cloud and self-hosted behavior cannot drift apart unnoticed. */
+ *  contract, so k8s and self-hosted behavior cannot drift apart unnoticed. */
 
 function root(opts: { declared?: unknown; requireSandbox?: boolean; cliEntry?: boolean } = {}): string {
-  const path = mkdtempSync(join(tmpdir(), 'ac-cloud-mode-'))
+  const path = mkdtempSync(join(tmpdir(), 'ac-k8s-mode-'))
   writeFileSync(
     join(path, 'config.json'),
     JSON.stringify({
@@ -23,7 +23,7 @@ function root(opts: { declared?: unknown; requireSandbox?: boolean; cliEntry?: b
     writeFileSync(join(path, 'k8s-runtimes.json'), JSON.stringify(opts.declared))
   }
   // A stale pointer left on the root volume is exactly the case that must NOT re-enable
-  // the self-installing upgrade path in cloud mode. readCliEntry only accepts a pointer
+  // the self-installing upgrade path in k8s mode. readCliEntry only accepts a pointer
   // whose target exists, so the fixture writes a real file to point at.
   if (opts.cliEntry) {
     const entry = join(path, 'cli-dist-entry.js')
@@ -36,7 +36,7 @@ function root(opts: { declared?: unknown; requireSandbox?: boolean; cliEntry?: b
 function catalog(): ResolvedRuntimeCatalog {
   // Deliberately a command that does not exist on the test host: host discovery must
   // find nothing, so anything advertised came from the declared table.
-  const absent = { command: 'ac-cloud-absent-runtime', args: [], env: [] }
+  const absent = { command: 'ac-k8s-absent-runtime', args: [], env: [] }
   const hermes = { command: 'hermes', args: ['acp'], env: [] }
   return {
     entries: {
@@ -50,7 +50,20 @@ function catalog(): ResolvedRuntimeCatalog {
 function daemon(opts: { root: string; k8s: boolean; probe?: ReturnType<typeof vi.fn>; supervisor?: string }): Daemon {
   return new Daemon({
     root: opts.root,
-    cloud: opts.k8s,
+    k8s: opts.k8s,
+    // The plane needs a cluster and has its own suite; this file is about what the MODE changes.
+    // Stubbing it here keeps the refuse-to-boot-without-a-cluster behaviour real everywhere else.
+    ...(opts.k8s
+      ? {
+          startK8sPlane: async () =>
+            ({
+              driver: {} as never,
+              listener: { listeningPort: () => 0 } as never,
+              gitRunnerFor: () => undefined,
+              stop: async () => {}
+            }) as never
+        }
+      : {}),
     ...(opts.supervisor ? { supervisor: opts.supervisor } : {}),
     resolveCatalog: async () => catalog(),
     ...(opts.probe ? { probeRuntimes: opts.probe as never } : {}),
@@ -61,27 +74,27 @@ function daemon(opts: { root: string; k8s: boolean; probe?: ReturnType<typeof vi
 describe('daemon --k8s mode', () => {
   it('advertises the runtimes the image declares, not what is installed on the host', async () => {
     const probe = vi.fn(async () => [])
-    const cloud = daemon({
+    const k8sDaemon = daemon({
       root: root({ declared: { runtimes: [{ id: 'claude', models: ['sonnet'] }] } }),
-      cloud: true,
+      k8s: true,
       probe
     })
     try {
-      await cloud.start()
-      expect(Object.keys((cloud as any).runtimes)).toEqual(['claude'])
+      await k8sDaemon.start()
+      expect(Object.keys((k8sDaemon as any).runtimes)).toEqual(['claude'])
       // Never launches a runtime locally to learn this — the table is the source.
       expect(probe).not.toHaveBeenCalled()
-      const profile = (cloud as any).runtimeProfileFor('claude')
+      const profile = (k8sDaemon as any).runtimeProfileFor('claude')
       expect(profile.models).toEqual(['sonnet'])
       // Declared, not probed: model gates must stay permissive on this provenance.
       expect(profile.modelsSource).toBe('cached')
     } finally {
-      await cloud.stop()
+      await k8sDaemon.stop()
     }
   })
 
   it('advertises nothing in the same tree without --k8s, where host discovery decides', async () => {
-    const local = daemon({ root: root({ declared: { runtimes: [{ id: 'claude' }] } }), cloud: false })
+    const local = daemon({ root: root({ declared: { runtimes: [{ id: 'claude' }] } }), k8s: false })
     try {
       await local.start()
       expect(Object.keys((local as any).runtimes)).toEqual([])
@@ -91,35 +104,35 @@ describe('daemon --k8s mode', () => {
   })
 
   it('drops a declared curated runtime instead of advertising one that cannot launch', async () => {
-    const cloud = daemon({ root: root({ declared: { runtimes: [{ id: 'hermes-agent' }] } }), cloud: true })
+    const k8sDaemon = daemon({ root: root({ declared: { runtimes: [{ id: 'hermes-agent' }] } }), k8s: true })
     try {
-      await cloud.start()
-      expect(Object.keys((cloud as any).runtimes)).toEqual([])
+      await k8sDaemon.start()
+      expect(Object.keys((k8sDaemon as any).runtimes)).toEqual([])
     } finally {
-      await cloud.stop()
+      await k8sDaemon.stop()
     }
   })
 
   it('advertises no runtime and keeps running when the declared table is missing', async () => {
-    const cloud = daemon({ root: root(), cloud: true })
+    const k8sDaemon = daemon({ root: root(), k8s: true })
     try {
-      await cloud.start()
-      expect(Object.keys((cloud as any).runtimes)).toEqual([])
+      await k8sDaemon.start()
+      expect(Object.keys((k8sDaemon as any).runtimes)).toEqual([])
     } finally {
-      await cloud.stop()
+      await k8sDaemon.stop()
     }
   })
 
   it('claims no sandbox capability: the pod is the isolation unit, not the SRT mechanism', async () => {
-    const cloud = daemon({ root: root({ declared: { runtimes: [{ id: 'claude' }] } }), cloud: true })
+    const k8sDaemon = daemon({ root: root({ declared: { runtimes: [{ id: 'claude' }] } }), k8s: true })
     try {
-      await cloud.start()
-      expect((cloud as any).sandboxMechanism).toBeUndefined()
-      const features: string[] = (cloud as any).registrationFeatures()
+      await k8sDaemon.start()
+      expect((k8sDaemon as any).sandboxMechanism).toBeUndefined()
+      const features: string[] = (k8sDaemon as any).registrationFeatures()
       expect(features).not.toContain('sandbox')
       expect(features).not.toContain('sandbox-required')
     } finally {
-      await cloud.stop()
+      await k8sDaemon.stop()
     }
   })
 
@@ -127,24 +140,24 @@ describe('daemon --k8s mode', () => {
     // Both prerequisites of the normal capability check are satisfied here: without a
     // mode-level refusal, the daemon would advertise bootstrap-upgrade and accept a
     // command that runs the CLI installer and exits the pod for an unrequested version.
-    const cloud = daemon({
+    const k8sDaemon = daemon({
       root: root({ declared: { runtimes: [{ id: 'claude' }] }, cliEntry: true }),
-      cloud: true,
+      k8s: true,
       supervisor: 'service'
     })
     try {
-      await cloud.start()
-      expect((cloud as any).bootstrapUpgradeCapable()).toBe(false)
-      expect((cloud as any).registrationFeatures()).not.toContain(DAEMON_BOOTSTRAP_UPGRADE_FEATURE)
+      await k8sDaemon.start()
+      expect((k8sDaemon as any).bootstrapUpgradeCapable()).toBe(false)
+      expect((k8sDaemon as any).registrationFeatures()).not.toContain(DAEMON_BOOTSTRAP_UPGRADE_FEATURE)
     } finally {
-      await cloud.stop()
+      await k8sDaemon.stop()
     }
   })
 
-  it('still offers the self-installing upgrade outside cloud mode with the same prerequisites', async () => {
+  it('still offers the self-installing upgrade outside k8s mode with the same prerequisites', async () => {
     // The control case, so the refusal above is attributable to the mode and not to a
     // missing prerequisite in the fixture.
-    const local = daemon({ root: root({ cliEntry: true }), cloud: false, supervisor: 'service' })
+    const local = daemon({ root: root({ cliEntry: true }), k8s: false, supervisor: 'service' })
     try {
       await local.start()
       expect((local as any).bootstrapUpgradeCapable()).toBe(true)
@@ -155,10 +168,10 @@ describe('daemon --k8s mode', () => {
   })
 
   it('refuses to start when requireSandbox is configured, rather than pretending', async () => {
-    const cloud = daemon({
+    const k8sDaemon = daemon({
       root: root({ declared: { runtimes: [{ id: 'claude' }] }, requireSandbox: true }),
-      cloud: true
+      k8s: true
     })
-    await expect(cloud.start()).rejects.toThrow(/requireSandbox is not supported with --k8s/)
+    await expect(k8sDaemon.start()).rejects.toThrow(/requireSandbox is not supported with --k8s/)
   })
 })

--- a/packages/daemon/test/daemon-supervisor-k8s.test.ts
+++ b/packages/daemon/test/daemon-supervisor-k8s.test.ts
@@ -18,10 +18,24 @@ function root(): string {
   return path
 }
 
-function daemon(opts: { cloud?: boolean; supervisor?: string; requestExit?: (code: number) => void } = {}): Daemon {
+function daemon(opts: { k8s?: boolean; supervisor?: string; requestExit?: (code: number) => void } = {}): Daemon {
   return new Daemon({
     root: root(),
-    ...(opts.cloud ? { cloud: true } : {}),
+    ...(opts.k8s
+      ? {
+          k8s: true,
+          // k8s-mode POLICY is what this file tests; the execution plane needs a cluster and has
+          // its own suite. Stubbing it keeps the refusal-to-boot-without-a-cluster behaviour
+          // real everywhere else.
+          startK8sPlane: async () =>
+            ({
+              driver: {} as never,
+              listener: { listeningPort: () => 0 } as never,
+              gitRunnerFor: () => undefined,
+              stop: async () => {}
+            }) as never
+        }
+      : {}),
     ...(opts.supervisor ? { supervisor: opts.supervisor } : {}),
     ...(opts.requestExit ? { requestExit: opts.requestExit } : {}),
     resolveCatalog: async () => ({ entries: {}, runtimes: {} }),
@@ -32,7 +46,7 @@ function daemon(opts: { cloud?: boolean; supervisor?: string; requestExit?: (cod
 describe('daemon lifecycle under the k8s supervisor', () => {
   it('accepts a restart: the kubelet brings the container back after the reserved exit code', async () => {
     const requestExit = vi.fn()
-    const instance = daemon({ cloud: true, supervisor: K8S_SUPERVISOR, requestExit })
+    const instance = daemon({ k8s: true, supervisor: K8S_SUPERVISOR, requestExit })
     await instance.start()
     const realStop = instance.stop.bind(instance)
     ;(instance as any).stop = vi.fn(async () => {})
@@ -49,7 +63,7 @@ describe('daemon lifecycle under the k8s supervisor', () => {
   }, 20_000)
 
   it('refuses an upgrade because the version is the image, not for want of a supervisor', async () => {
-    const instance = daemon({ cloud: true, supervisor: K8S_SUPERVISOR })
+    const instance = daemon({ k8s: true, supervisor: K8S_SUPERVISOR })
     await instance.start()
     try {
       const ack = (instance as any).admitFleetExit('upgrade', '9.9.9')
@@ -66,12 +80,12 @@ describe('daemon lifecycle under the k8s supervisor', () => {
   }, 20_000)
 
   it.each(['service', 'cli'])(
-    'refuses an upgrade in cloud mode even with an inherited %s marker and a valid cli-entry',
+    'refuses an upgrade in k8s mode even with an inherited %s marker and a valid cli-entry',
     async (marker) => {
       // The state that must not reach the installer: a live daemon/upgrade is delivered
       // without consulting the advertised capability, so admission is the last defence,
       // and both prerequisites of the ordinary path are satisfied here.
-      const instance = daemon({ cloud: true, supervisor: marker })
+      const instance = daemon({ k8s: true, supervisor: marker })
       await instance.start()
       try {
         const ack = (instance as any).admitFleetExit('upgrade', '9.9.9')
@@ -85,10 +99,10 @@ describe('daemon lifecycle under the k8s supervisor', () => {
     20_000
   )
 
-  it('still admits a restart in cloud mode under an inherited service marker', async () => {
-    // Restart is not what cloud mode refuses: whatever supervises the process can bring
+  it('still admits a restart in k8s mode under an inherited service marker', async () => {
+    // Restart is not what k8s mode refuses: whatever supervises the process can bring
     // it back, so only the self-installing upgrade is gated on the mode.
-    const instance = daemon({ cloud: true, supervisor: 'service' })
+    const instance = daemon({ k8s: true, supervisor: 'service' })
     await instance.start()
     try {
       expect((instance as any).admitFleetExit('restart').accepted).toBe(true)
@@ -97,8 +111,8 @@ describe('daemon lifecycle under the k8s supervisor', () => {
     }
   }, 20_000)
 
-  it('still refuses a restart when no supervisor is declared, cloud or not', async () => {
-    const instance = daemon({ cloud: true })
+  it('still refuses a restart when no supervisor is declared, k8s or not', async () => {
+    const instance = daemon({ k8s: true })
     await instance.start()
     try {
       const ack = (instance as any).admitFleetExit('restart')

--- a/packages/daemon/test/direct-connect-credentials.test.ts
+++ b/packages/daemon/test/direct-connect-credentials.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED } from '@agentconnect.md/protocol'
 import { turnFailureCode } from '../src/acp/acp-host.js'
-import { ClusterSpawnDriver, RUNTIME_GRANTS } from '../src/k8s/cluster-driver.js'
+import { K8sDriver, RUNTIME_GRANTS } from '../src/k8s/driver.js'
 import { K8sApiError } from '../src/k8s/http.js'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
 import type { ShimConnection } from '../src/shim/listener.js'
@@ -51,7 +51,7 @@ function fakeApi() {
 describe('provider credentials in the direct-connect stage', () => {
   it('never writes credential material into the Kubernetes claim', async () => {
     const { api, created } = fakeApi()
-    const driver = new ClusterSpawnDriver({
+    const driver = new K8sDriver({
       api: api as never,
       orgId: 'org-1',
       warmPoolName: 'pool',

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { FakeClock } from '@agentconnect.md/connection'
-import { ClusterSpawnDriver, DRAIN_REQUESTED_ANNOTATION, AC_LABEL_AGENT } from '../src/k8s/cluster-driver.js'
+import { K8sDriver, DRAIN_REQUESTED_ANNOTATION, AC_LABEL_AGENT } from '../src/k8s/driver.js'
 import { OperatingModeRejectedError } from '../src/k8s/sandbox-api.js'
 import { K8sApiError } from '../src/k8s/http.js'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
@@ -55,14 +55,28 @@ function fakeApi(options: { ready?: boolean; mode?: 'Running' | 'Suspended' } = 
   return { api, state }
 }
 
+/** Enough of a bound channel for `launch()` to attach a session to. */
+function stubConnection(generation = 1): ShimConnection {
+  return {
+    binding: { agentId: 'agent-a', generation, grants: ['acp'], podName: 'p', podUid: 'u' },
+    issuedCredential: 'cred',
+    send: () => {},
+    onFrame: () => {},
+    close: () => {}
+  } as unknown as ShimConnection
+}
+
+const launchRequest = { command: 'x', args: [], env: { AC_AGENT_ID: 'agent-a' }, cwd: '/agent' } as never
+
 function driver(api: ReturnType<typeof fakeApi>['api'], overrides: Record<string, unknown> = {}) {
   const records: SpawnRecord[] = []
   const clock = new FakeClock()
-  const instance = new ClusterSpawnDriver({
+  let generation = 0
+  const instance = new K8sDriver({
     api: api as never,
     orgId: 'org-1',
     warmPoolName: 'ac-runtime-standard-pool',
-    awaitChannel: async () => ({}) as ShimConnection,
+    awaitChannel: async () => stubConnection(++generation),
     publishSpawnRecord: (record) => records.push(record),
     clock,
     log: { info: () => {}, warn: () => {}, debug: () => {} },
@@ -87,27 +101,51 @@ describe('cluster spawn driver', () => {
     expect((claim.spec as Record<string, unknown>).volumeClaimTemplates).toBeUndefined()
   })
 
-  it('publishes a spawn record before a shim could bind, keyed on the Sandbox metadata uid', async () => {
+  it('publishes a spawn record naming the POD, as soon as the Sandbox names one', async () => {
+    // The record is how a dialing pod is resolved back to its launch, and a TokenReview yields
+    // only a pod name and uid — so a record that does not name the pod cannot be found at all.
+    // It is published when the pod is first named rather than at claim time, because at claim
+    // time the name still belongs to the previous incarnation.
     const { api } = fakeApi()
     const { instance, records } = driver(api)
-    await instance.ensureSandbox('agent-a')
+    expect(await instance.ensureSandbox('agent-a')).toMatchObject({ sandboxName: 'sb-1' })
+    // ensureSandbox alone publishes nothing: no pod is bound yet.
+    expect(records).toEqual([])
+
+    await instance.launch(launchRequest)
     // The uid comes from the Sandbox object; the claim status carries only a name.
     expect(records).toEqual([
       {
         agentId: 'agent-a',
         sandboxUid: 'sandbox-uid-1',
         generation: 1,
-        grants: ['acp', 'materialize', 'exec', 'read', 'tunnel']
+        grants: ['acp', 'materialize', 'exec', 'read', 'tunnel'],
+        podName: 'sb-1'
       }
     ])
+  })
+
+  it('names the ADOPTED warm-pool pod, not the Sandbox, when one was adopted', async () => {
+    // Our normal path is warm-pool adoption, and an adopted pod carries a pool-generated name
+    // that has nothing to do with the Sandbox's. Falling back to the Sandbox name there would
+    // publish a record no dialing pod could ever match.
+    const { api } = fakeApi()
+    api.getSandbox = async () => ({
+      metadata: { name: 'sb-1', uid: 'sandbox-uid-1', annotations: { 'agents.x-k8s.io/pod-name': 'pool-xyz-7' } },
+      spec: { operatingMode: 'Running' },
+      status: { conditions: [{ type: 'Ready', status: 'True' }] }
+    })
+    const { instance, records } = driver(api)
+    await instance.launch(launchRequest)
+    expect(records.at(-1)?.podName).toBe('pool-xyz-7')
   })
 
   it('increments the generation per launch so a departed incarnation cannot act', async () => {
     const { api } = fakeApi()
     const { instance, records } = driver(api)
-    await instance.ensureSandbox('agent-a')
+    await instance.launch(launchRequest)
     instance.forgetLaunch('agent-a')
-    await instance.ensureSandbox('agent-a')
+    await instance.launch(launchRequest)
     expect(records.map((record) => record.generation)).toEqual([1, 2])
   })
 
@@ -213,7 +251,8 @@ describe('cluster spawn driver', () => {
     const { instance, records } = driver(api)
     const launch = await instance.ensureSandbox('agent-a')
     expect(launch.sandboxName).toBe('sb-1')
-    expect(records).toHaveLength(1)
+    // And it did NOT publish: nothing may be authorized against a pod that does not exist yet.
+    expect(records).toEqual([])
   })
 
   it('deletes the claim when an agent goes away', async () => {

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
+import { startK8sRuntimePlane, k8sPlaneSettings, type K8sRuntimePlane } from '../src/k8s/runtime-plane.js'
+import { ShimClient, type ShimTransport } from '../src/shim/client.js'
+import { K8sApiError } from '../src/k8s/http.js'
+import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
+
+/**
+ * The assembly itself, which is the thing that did not exist: every part of the k8s path was
+ * built and tested separately while nothing put them together, so `--k8s` changed the daemon's
+ * behaviour and still ran runtimes on its own host.
+ *
+ * A real shim client dials a real listener over a real socket here. What that catches — and unit
+ * tests of the parts cannot — is the wiring being wrong end to end: a pod that binds but is
+ * mapped to no launch, a driver that never learns its channel, or a workspace runner that stays
+ * local because nothing registered it.
+ */
+
+const planes: K8sRuntimePlane[] = []
+const clients: ShimClient[] = []
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) client.stop()
+  for (const plane of planes.splice(0)) await plane.stop()
+  delete process.env.AC_K8S_ORG_ID
+  delete process.env.AC_K8S_WARM_POOL
+  delete process.env.AC_K8S_SHIM_PORT
+})
+
+/** A Sandbox that binds, adopts a pool pod, and reports Ready. */
+function fakeApi(options: { podName?: string; adopt?: boolean } = {}) {
+  const podName = options.podName ?? 'pool-pod-9'
+  const sandbox = {
+    metadata: {
+      name: 'sb-1',
+      uid: 'sandbox-uid-1',
+      ...(options.adopt === false ? {} : { annotations: { 'agents.x-k8s.io/pod-name': podName } })
+    },
+    spec: { operatingMode: 'Running' as const },
+    status: { conditions: [{ type: 'Ready', status: 'True' }] }
+  } satisfies Sandbox
+  let claim: SandboxClaim | undefined
+  return {
+    podName,
+    api: {
+      ensureClaim: async (input: SandboxClaim & { metadata: { name: string } }) => {
+        const created = claim === undefined
+        claim = { ...input, status: { sandbox: { name: 'sb-1' } } }
+        return { claim, created }
+      },
+      getClaim: async () => {
+        if (!claim) throw new K8sApiError(404, 'NotFound', 'no claim')
+        return claim
+      },
+      deleteClaim: async () => undefined,
+      getSandbox: async () => sandbox,
+      setOperatingMode: async () => sandbox,
+      watchClaims: vi.fn(),
+      watchSandboxes: vi.fn(),
+      // The listener verifies through this, so the handshake exercises the real path.
+      reviewToken: async (token: string) =>
+        token === 'projected-token'
+          ? { authenticated: true, podName, podUid: 'pod-uid-1' }
+          : { authenticated: false, error: 'not this pod' }
+    }
+  }
+}
+
+/** Start a plane whose Kubernetes surface is the fake above, on an ephemeral port. */
+async function planeUnderTest(api: ReturnType<typeof fakeApi>): Promise<K8sRuntimePlane> {
+  const plane = await startK8sRuntimePlane({
+    orgId: 'org-1',
+    warmPoolName: 'pool',
+    shimPort: 0,
+    shimHost: '127.0.0.1',
+    readyTimeoutMs: 15_000,
+    api: api.api as never,
+    log: { info: () => {}, warn: () => {}, debug: () => {} }
+  })
+  planes.push(plane)
+  return plane
+}
+
+/** A real shim client dialling the plane's endpoint. */
+function shimAgainst(port: number): ShimClient {
+  const client = new ShimClient({
+    endpoint: `ws://127.0.0.1:${port}`,
+    dial: (url, opts) =>
+      ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
+    readToken: () => 'projected-token',
+    clock: new FakeClock(),
+    backoff: new Backoff({ jitter: () => 0 }),
+    log: { info: () => {}, warn: () => {} }
+  })
+  clients.push(client)
+  void client.start()
+  return client
+}
+
+async function until(predicate: () => boolean, timeoutMs = 10_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  return predicate()
+}
+
+describe('k8s plane settings', () => {
+  it('refuses to start without an org or a pool rather than guessing one', () => {
+    // A guessed org labels another tenant's claims; a guessed pool yields sandboxes that never
+    // bind, with nothing in the logs explaining why.
+    expect(() => k8sPlaneSettings({})).toThrow(/AC_K8S_ORG_ID/)
+    expect(() => k8sPlaneSettings({ AC_K8S_ORG_ID: 'org-1' })).toThrow(/AC_K8S_WARM_POOL/)
+    expect(k8sPlaneSettings({ AC_K8S_ORG_ID: 'org-1', AC_K8S_WARM_POOL: 'pool' })).toEqual({
+      orgId: 'org-1',
+      warmPoolName: 'pool',
+      shimPort: 8085
+    })
+    expect(() =>
+      k8sPlaneSettings({ AC_K8S_ORG_ID: 'org-1', AC_K8S_WARM_POOL: 'pool', AC_K8S_SHIM_PORT: 'http' })
+    ).toThrow(/not a valid port/)
+  })
+})
+
+describe('k8s runtime plane assembly', () => {
+  it('resolves a dialing pod back to its launch, through the ADOPTED pod name', async () => {
+    // The whole mapping: a TokenReview yields a pod name, the record is keyed by the pod the
+    // Sandbox named, and warm-pool adoption means that name is the pool's, not the sandbox's.
+    const api = fakeApi()
+    const plane = await planeUnderTest(api)
+    const port = plane.listener.listeningPort()!
+
+    // Publishing happens inside launch(); drive it far enough to publish, then dial.
+    const launching = plane.driver.launch({
+      command: 'x',
+      args: [],
+      env: { AC_AGENT_ID: 'agent-a' },
+      cwd: '/agent'
+    } as never)
+    shimAgainst(port)
+
+    const connection = await Promise.race([
+      launching.then(() => plane.listener.connectionsFor('agent-a')[0]),
+      new Promise((resolve) => setTimeout(() => resolve(undefined), 15_000))
+    ])
+    expect(connection).toBeDefined()
+    expect(plane.listener.connectionsFor('agent-a')[0]?.binding.podName).toBe(api.podName)
+  })
+
+  it('hands the workspace seam a shim runner only for an agent with a bound channel', async () => {
+    const api = fakeApi()
+    const plane = await planeUnderTest(api)
+    // Before any launch there is no channel, and the caller must stay on its local runner rather
+    // than fail — a self-hosted agent beside a cluster-backed one depends on that.
+    expect(plane.gitRunnerFor('agent-a')).toBeUndefined()
+
+    const port = plane.listener.listeningPort()!
+    const launching = plane.driver.launch({
+      command: 'x',
+      args: [],
+      env: { AC_AGENT_ID: 'agent-a' },
+      cwd: '/agent'
+    } as never)
+    shimAgainst(port)
+    await launching
+    expect(await until(() => plane.gitRunnerFor('agent-a') !== undefined)).toBe(true)
+  })
+})

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -124,6 +124,21 @@ describe('k8s plane settings', () => {
 })
 
 describe('k8s runtime plane assembly', () => {
+  it('brings the sandbox up and binds without starting a runtime, for workspace preparation', async () => {
+    // The workspace has to be prepared before the runtime starts, and for a cluster agent that
+    // means cloning onto the pod's volume — so the channel must exist first. Preparing before the
+    // sandbox existed would clone on the daemon's disk and hand the runtime an empty workspace.
+    const api = fakeApi()
+    const plane = await planeUnderTest(api)
+    const port = plane.listener.listeningPort()!
+    const ensuring = plane.ensureChannel('agent-a')
+    shimAgainst(port)
+    await ensuring
+    // A channel, a session behind the workspace seam, and NO runtime started.
+    expect(plane.listener.connectionsFor('agent-a')).toHaveLength(1)
+    expect(plane.gitRunnerFor('agent-a', '/agent')).toBeDefined()
+  })
+
   it('resolves a dialing pod back to its launch, through the ADOPTED pod name', async () => {
     // The whole mapping: a TokenReview yields a pod name, the record is keyed by the pod the
     // Sandbox named, and warm-pool adoption means that name is the pool's, not the sandbox's.
@@ -146,6 +161,32 @@ describe('k8s runtime plane assembly', () => {
     ])
     expect(connection).toBeDefined()
     expect(plane.listener.connectionsFor('agent-a')[0]?.binding.podName).toBe(api.podName)
+  })
+
+  it('survives a shim reconnect: a closed socket is not a lost launch', async () => {
+    // The shim closes and re-dials at half the credential TTL, and `ShimSession.lose()` is
+    // terminal — so reporting loss on every socket close killed the runtime on each routine
+    // renewal, which is the exact failure ShimSession was built to prevent.
+    const api = fakeApi()
+    const plane = await planeUnderTest(api)
+    const port = plane.listener.listeningPort()!
+    const launching = plane.driver.launch({
+      command: 'x',
+      args: [],
+      env: { AC_AGENT_ID: 'agent-a' },
+      cwd: '/agent'
+    } as never)
+    const first = shimAgainst(port)
+    await launching
+    expect(await until(() => plane.gitRunnerFor('agent-a') !== undefined)).toBe(true)
+
+    // Drop the socket the way a renewal does, then let a replacement bind.
+    first.stop()
+    expect(await until(() => plane.listener.connectionsFor('agent-a').length === 0)).toBe(true)
+    shimAgainst(port)
+    expect(await until(() => plane.listener.connectionsFor('agent-a').length > 0)).toBe(true)
+    // The seam still works, which it would not if the session had been closed on the drop.
+    expect(await until(() => plane.gitRunnerFor('agent-a') !== undefined)).toBe(true)
   })
 
   it('hands the workspace seam a shim runner only for an agent with a bound channel', async () => {

--- a/packages/daemon/test/k8s-runtimes.test.ts
+++ b/packages/daemon/test/k8s-runtimes.test.ts
@@ -3,19 +3,19 @@ import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
-  CLOUD_RUNTIMES_ENV,
-  cloudRuntimesPath,
-  CloudRuntimeTableSchema,
+  K8S_RUNTIMES_ENV,
+  k8sRuntimesPath,
+  K8sRuntimeTableSchema,
   declaredRuntimeCatalog,
-  loadCloudRuntimeTable
-} from '../src/runtimes/cloud-runtimes.js'
+  loadK8sRuntimeTable
+} from '../src/runtimes/k8s-runtimes.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 
 function root(): string {
-  return mkdtempSync(join(tmpdir(), 'ac-cloud-runtimes-'))
+  return mkdtempSync(join(tmpdir(), 'ac-k8s-runtimes-'))
 }
 
-function write(dir: string, contents: string, name = 'cloud-runtimes.json'): string {
+function write(dir: string, contents: string, name = 'k8s-runtimes.json'): string {
   const path = join(dir, name)
   writeFileSync(path, contents)
   return path
@@ -35,33 +35,33 @@ function catalog(): ResolvedRuntimeCatalog {
   }
 }
 
-describe('cloud runtime table', () => {
+describe('k8s runtime table', () => {
   it('defaults under the daemon root and honors the env override', () => {
     const dir = root()
-    expect(cloudRuntimesPath(dir, {})).toBe(join(dir, 'cloud-runtimes.json'))
-    expect(cloudRuntimesPath(dir, { [CLOUD_RUNTIMES_ENV]: '/etc/ac/runtimes.json' })).toBe('/etc/ac/runtimes.json')
+    expect(k8sRuntimesPath(dir, {})).toBe(join(dir, 'k8s-runtimes.json'))
+    expect(k8sRuntimesPath(dir, { [K8S_RUNTIMES_ENV]: '/etc/ac/runtimes.json' })).toBe('/etc/ac/runtimes.json')
     // A blank override is not a path — fall back rather than reading "".
-    expect(cloudRuntimesPath(dir, { [CLOUD_RUNTIMES_ENV]: '  ' })).toBe(join(dir, 'cloud-runtimes.json'))
+    expect(k8sRuntimesPath(dir, { [K8S_RUNTIMES_ENV]: '  ' })).toBe(join(dir, 'k8s-runtimes.json'))
   })
 
   it('returns undefined when no table is present', () => {
-    expect(loadCloudRuntimeTable(root(), {})).toBeUndefined()
+    expect(loadK8sRuntimeTable(root(), {})).toBeUndefined()
   })
 
   it('throws on malformed JSON and on a schema mismatch', () => {
     const dir = root()
     write(dir, '{ not json')
-    expect(() => loadCloudRuntimeTable(dir, {})).toThrow(/not valid JSON/)
+    expect(() => loadK8sRuntimeTable(dir, {})).toThrow(/not valid JSON/)
     write(dir, JSON.stringify({ runtimes: [] }))
-    expect(() => loadCloudRuntimeTable(dir, {})).toThrow(/invalid/)
+    expect(() => loadK8sRuntimeTable(dir, {})).toThrow(/invalid/)
     write(dir, JSON.stringify({ runtimes: [{ version: '1' }] }))
-    expect(() => loadCloudRuntimeTable(dir, {})).toThrow(/invalid/)
+    expect(() => loadK8sRuntimeTable(dir, {})).toThrow(/invalid/)
   })
 
   it('loads a valid table from the env-pointed path', () => {
     const dir = root()
     const path = write(dir, JSON.stringify({ runtimes: [{ id: 'claude', models: ['a'] }] }), 'pinned.json')
-    expect(loadCloudRuntimeTable(dir, { [CLOUD_RUNTIMES_ENV]: path })).toEqual({
+    expect(loadK8sRuntimeTable(dir, { [K8S_RUNTIMES_ENV]: path })).toEqual({
       runtimes: [{ id: 'claude', models: ['a'] }]
     })
   })
@@ -81,7 +81,7 @@ describe('declaredRuntimeCatalog', () => {
   })
 
   it('carries the image ACP snapshot through, rather than dropping it on the floor', () => {
-    // The table's whole point in --cloud is reporting what a probe would have found. A schema that
+    // The table's whole point in --k8s is reporting what a probe would have found. A schema that
     // strips this field leaves the daemon publishing ids and versions and nothing else — and it
     // fails silently, because the artifact is still internally consistent.
     const result = declaredRuntimeCatalog(catalog(), {
@@ -109,7 +109,7 @@ describe('declaredRuntimeCatalog', () => {
   it('parses a table whose entries carry an ACP snapshot, keeping the snapshot intact', () => {
     // Guards the schema itself: zod strips unknown keys, so an `acp` field that is not declared
     // vanishes between the file and the caller with no error anywhere.
-    const parsed = CloudRuntimeTableSchema.parse({
+    const parsed = K8sRuntimeTableSchema.parse({
       runtimes: [{ id: 'claude', version: '1.0.0', acp: { protocolVersion: 1, modes: ['default'] } }]
     })
     expect(parsed.runtimes[0]?.acp).toEqual({ protocolVersion: 1, modes: ['default'] })

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -108,6 +108,43 @@ function countingMetrics(): { metrics: ClusterMetrics; rejections: string[]; tok
   }
 }
 
+describe('session attachment', () => {
+  it('delivers an event ONCE when the same connection is attached twice', async () => {
+    // Preparing a workspace binds the channel and launching binds it again, getting the same
+    // connection back. `onFrame` only appends and never removes, so a second attach registered a
+    // second listener and every ACP chunk and event arrived twice.
+    const { ShimSession } = await import('../src/shim/session.js')
+    const frameListeners: Array<(text: string) => void> = []
+    const connection = {
+      binding: { agentId: 'agent-a', generation: 3, grants: ['acp'], podName: 'p', podUid: 'u' },
+      issuedCredential: 'cred',
+      send: () => {},
+      onFrame: (listen: (text: string) => void) => frameListeners.push(listen),
+      close: () => {}
+    } as never
+
+    const session = new ShimSession('agent-a', 3, {
+      setTimeout: (fn, ms) => setTimeout(fn, ms),
+      clearTimeout: (handle) => clearTimeout(handle as NodeJS.Timeout)
+    })
+    session.attach(connection)
+    session.attach(connection)
+
+    const seen: string[] = []
+    session.onEvent((event) => {
+      if (event.event.kind === 'chunk') seen.push(event.event.data)
+    })
+    const streamId = '11111111-1111-4111-8111-111111111111'
+    const frame = JSON.stringify({
+      type: 'shim/event',
+      streamId,
+      event: { kind: 'chunk', data: 'aGk=' }
+    })
+    for (const listen of frameListeners) listen(frame)
+    expect(seen).toEqual(['aGk='])
+  })
+})
+
 describe('handshake operability counters', () => {
   it('counts an API-server token rejection apart from this daemon fencing a frame', async () => {
     // D7 shipped a bug from conflating these: an identity failure and our own fencing working as

--- a/scripts/verify-runtime-image.mjs
+++ b/scripts/verify-runtime-image.mjs
@@ -46,7 +46,7 @@ function inspect(format) {
 }
 
 const SHIM_PATH = '/opt/agentconnect/shim/index.js'
-const TABLE_PATH = '/opt/agentconnect/runtime/cloud-runtimes.json'
+const TABLE_PATH = '/opt/agentconnect/runtime/k8s-runtimes.json'
 
 // The runtime is the untrusted party in this image, so root would hand it the whole filesystem.
 check('runs as a non-root user', () => {


### PR DESCRIPTION
Closes #840.

## The gap this closes

D0–D10 built every part of the cluster path and merged them — and **nothing assembled them**. `ClusterSpawnDriver` and `ShimListener` appeared only in tests, `AcpHost` always fell back to `new LocalDriver(...)`, and `setWorkspaceGitRunnerResolver` had no caller. So `--cloud` changed the daemon's *behaviour* (no probing, declared runtimes, no host sandbox, no self-upgrade) while runtimes still ran on the daemon's own host and no Sandbox was ever created.

## Rename

`--cloud` → `--k8s` and `ClusterSpawnDriver` → `K8sDriver`, consistently: flag, field, runtime-table identifiers, `AGENTCONNECT_K8S_RUNTIMES`, file names. `CLOUDSDK_*` and the account-bound "cloud apps" in `account-apps.ts` are untouched — that is someone else's vocabulary, not this mode's.

Metric names (`agentconnect.cluster.*`) are also untouched: they are a data contract that dashboards key on, and "cluster" is accurate there.

## Wiring

New `k8s/runtime-plane.ts` builds the shim endpoint, the driver, a per-agent `ShimSession`, and the workspace git seam; `start()` wires it when the mode is on and `AcpHost` receives the driver.

Outside a pod it **refuses to boot** rather than degrading to local execution — that degradation is exactly the outcome the mode exists to prevent. Deployment settings (`AC_K8S_ORG_ID`, `AC_K8S_WARM_POOL`, `AC_K8S_SHIM_PORT`) are refused rather than defaulted: a guessed org labels another tenant's claims, and a guessed pool yields sandboxes that never bind with nothing in the logs saying why.

## The design gap it uncovered: resolving a dialing pod to its launch

The handshake needs `spawnRecordForPod(pod)`, but a TokenReview yields only a pod name and uid, and **`SandboxStatus` in v1beta1 carries no pod reference** — `serviceFQDN`, `service`, `conditions`, `selector`, `podIPs`, `nodeName`. Reading the Pod API is deliberately outside this daemon's Role.

Checked upstream rather than guessed. agent-sandbox's own resolver is:

```go
func resolvePodName(sandbox *v1beta1.Sandbox) string {
	if name, ok := sandbox.Annotations[SandboxPodNameAnnotation]; ok && name != "" { return name }
	return sandbox.Name
}
```

So the driver mirrors it and publishes the record keyed by the pod it authorizes. That moved publication: the record now goes out when the Sandbox first **names** its pod — before readiness, since the shim dials from a pod that is merely running — instead of at claim time, when the name still belongs to the previous incarnation.

Three D6 tests asserted the old timing and now assert the new contract, including a new one that an **adopted warm-pool pod** is named rather than the Sandbox. That is our normal path and precisely the case a Sandbox-name fallback gets wrong; reverting `resolvePodName` to the fallback fails it.

## A correction on my own commit message

My first commit said the rename "surfaced a live instance of a known trap" in the test files. That was wrong, and I checked the history rather than leaving it: both files were internally consistent before — my sed changed one side of each helper/call-site pair and left the other, so the mode stopped being passed and the k8s assertions ran against a daemon in local mode. **I introduced it; the tests caught it.** The second commit says so.

What is worth keeping from it: this package typechecks `src` only, so a renamed option is invisible in a test until something asserts on its effect.

## Verification

- New `test/k8s-runtime-plane.test.ts` drives the assembly with a **real shim client over a real socket**: a pod dials, binds, is resolved back to its launch through the adopted pod name, and the workspace seam then hands out a shim runner for that agent and `undefined` for one without a channel.
- Breaking the pod→record mapping (keying on uid instead of name) fails both assembly tests; reverting the annotation lookup fails the adoption test.
- 288 tests across the k8s, shim, workspace, session and daemon-mode suites; typecheck, eslint, `prettier --check .`, build all clean.

## Still not runnable in a cluster after this

By design, this is item 1 of two. The daemon **pod image** and the **cluster manifests** are next (#804 lists them), and two follow-ups become live the moment this is deployed: the runtime-command mapping (both ids still resolve through `npx`, which `declaredRuntimeCatalog` rejects) and the credential-helper path, which is still derived from a daemon-local shim path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)