### PR TITLE
chore: ignore local Codex configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ data/*
 
 # Local agent instructions and settings
 AGENTS.override.md
+.codex/
 .claude/settings.local.json
 .claude/worktrees/
 CLAUDE.local.md


### PR DESCRIPTION
## Summary

- Ignore the repository-local `.codex/` directory.
- Keep local Codex settings from appearing as untracked files.

## Impact

No runtime behavior changes; this only affects local Git status.

## Validation

- `git diff --check`
- `git check-ignore -v .codex/`
- Pre-push `eslint .`
