### PR TITLE
feat(docker): daemon pod image and its release pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: Build & Push Images
 
-# Builds the control-plane / relay / web / external-memory / runtime-sandbox images for a RELEASE
+# Builds the control-plane / relay / web / external-memory / runtime-sandbox / daemon images for a RELEASE
 # and pushes them to GHCR tagged with the semantic-release version (the git tag:
 # `v1.2.3` stable, `v1.2.3-rc.4` prerelease). Stable releases also move `:latest`.
 #
@@ -67,6 +67,7 @@ jobs:
       mem0: ${{ steps.build-matrix.outputs.mem0 }}
       mem0Backend: ${{ steps.build-matrix.outputs.mem0Backend }}
       runtimeSandbox: ${{ steps.build-matrix.outputs.runtimeSandbox }}
+      daemon: ${{ steps.build-matrix.outputs.daemon }}
     steps:
       # Reusable calls receive the tag semantic-release just published. Manual
       # runs still derive it from the selected ref and reject branch refs, which
@@ -148,6 +149,7 @@ jobs:
           MEM0_EFFECTIVE: ${{ steps.components.outputs.mem0 }}
           MEM0_BACKEND_EFFECTIVE: ${{ steps.components.outputs.mem0Backend }}
           RUNTIME_SANDBOX_EFFECTIVE: ${{ steps.components.outputs.runtimeSandbox }}
+          DAEMON_EFFECTIVE: ${{ steps.components.outputs.daemon }}
           SETUP_VERSION: ${{ steps.components.outputs.setup }}
         run: |
           set -euo pipefail
@@ -184,6 +186,9 @@ jobs:
           # The runtime sandbox is what agent runtimes execute inside, not a service — but it is
           # pinned by the cluster manifests the same way, so it needs a tag at every release.
           resolve_effective runtimeSandbox runtime-sandbox runtime-sandbox "$RUNTIME_SANDBOX_EFFECTIVE"
+          # The daemon pod image. Separate from the runtime sandbox: this runs the daemon, that
+          # one is what an agent runtime executes inside.
+          resolve_effective daemon daemon daemon "$DAEMON_EFFECTIVE"
 
           # Render the existing Bake definition so image-specific configuration
           # stays centralized even though each target builds in its own job.
@@ -314,6 +319,7 @@ jobs:
       mem0: ${{ needs.prepare.outputs.mem0 }}
       mem0Backend: ${{ needs.prepare.outputs.mem0Backend }}
       runtimeSandbox: ${{ needs.prepare.outputs.runtimeSandbox }}
+      daemon: ${{ needs.prepare.outputs.daemon }}
     steps:
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -357,6 +363,7 @@ jobs:
           MEM0_EFFECTIVE: ${{ needs.prepare.outputs.mem0 }}
           MEM0_BACKEND_EFFECTIVE: ${{ needs.prepare.outputs.mem0Backend }}
           RUNTIME_SANDBOX_EFFECTIVE: ${{ needs.prepare.outputs.runtimeSandbox }}
+          DAEMON_EFFECTIVE: ${{ needs.prepare.outputs.daemon }}
           OWNER: ${{ github.repository_owner }}
         run: |
           set -eu
@@ -378,6 +385,7 @@ jobs:
           alias_unchanged memory-plugin-mem0 "$MEM0_EFFECTIVE"
           alias_unchanged mem0-server "$MEM0_BACKEND_EFFECTIVE"
           alias_unchanged runtime-sandbox "$RUNTIME_SANDBOX_EFFECTIVE"
+          alias_unchanged daemon "$DAEMON_EFFECTIVE"
 
   notify-workflow:
     name: Notify workflow
@@ -428,10 +436,11 @@ jobs:
           MEM0: ${{ needs.finalize.outputs.mem0 }}
           MEM0_BACKEND: ${{ needs.finalize.outputs.mem0Backend }}
           RUNTIME_SANDBOX: ${{ needs.finalize.outputs.runtimeSandbox }}
+          DAEMON: ${{ needs.finalize.outputs.daemon }}
         run: |
           curl --fail-with-body -sS -X POST \
             -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${WORKFLOW_REPOSITORY}/dispatches" \
-            -d "{\"event_type\":\"images-pushed\",\"client_payload\":{\"version\":\"${VERSION}\",\"sha\":\"${SHA}\",\"components\":{\"controlPlane\":\"${CP}\",\"web\":\"${WEB}\",\"relay\":\"${RELAY}\",\"mem0\":\"${MEM0}\",\"mem0Backend\":\"${MEM0_BACKEND}\",\"runtimeSandbox\":\"${RUNTIME_SANDBOX}\"}}}"
+            -d "{\"event_type\":\"images-pushed\",\"client_payload\":{\"version\":\"${VERSION}\",\"sha\":\"${SHA}\",\"components\":{\"controlPlane\":\"${CP}\",\"web\":\"${WEB}\",\"relay\":\"${RELAY}\",\"mem0\":\"${MEM0}\",\"mem0Backend\":\"${MEM0_BACKEND}\",\"runtimeSandbox\":\"${RUNTIME_SANDBOX}\",\"daemon\":\"${DAEMON}\"}}}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -100,6 +100,23 @@ jobs:
 
   # Keep the fast, Docker-free suites away from the resource-heavy build group
   # so their short per-test timeouts measure code rather than runner contention.
+  daemon-image:
+    name: Daemon Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      # A local tag only: this job proves the image is sound, publication is build.yaml's job.
+      - name: Build the daemon pod image
+        run: docker build -f docker/Dockerfile --target daemon -t ac-daemon:ci .
+      # Against the BUILT image: non-root, tini as PID 1, git and CA certs present, no ACP
+      # runtime smuggled in, and — the one that matters — `--k8s` refusing to start outside a
+      # pod instead of quietly running agent code on the daemon's own host.
+      - name: Verify the image properties
+        run: node scripts/verify-daemon-image.mjs ac-daemon:ci
+
   runtime-sandbox-image:
     name: Runtime Sandbox Image
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -109,13 +109,15 @@ jobs:
         with:
           persist-credentials: false
       # A local tag only: this job proves the image is sound, publication is build.yaml's job.
+      # Built with a version arg so the release-version path is exercised: without it the image
+      # reports the repo's 1.0.0-dev, which the Control Plane would persist as the fleet version.
       - name: Build the daemon pod image
-        run: docker build -f docker/Dockerfile --target daemon -t ac-daemon:ci .
+        run: docker build -f docker/Dockerfile --target daemon --build-arg DAEMON_VERSION=v9.9.9-ci -t ac-daemon:ci .
       # Against the BUILT image: non-root, tini as PID 1, git and CA certs present, no ACP
       # runtime smuggled in, and — the one that matters — `--k8s` refusing to start outside a
       # pod instead of quietly running agent code on the daemon's own host.
       - name: Verify the image properties
-        run: node scripts/verify-daemon-image.mjs ac-daemon:ci
+        run: node scripts/verify-daemon-image.mjs ac-daemon:ci v9.9.9-ci
 
   runtime-sandbox-image:
     name: Runtime Sandbox Image

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -35,7 +35,7 @@ variable "MEM0_BACKEND_VERSION" {
 }
 
 group "default" {
-  targets = ["control-plane", "relay", "web", "mem0", "mem0-backend", "runtime-sandbox"]
+  targets = ["control-plane", "relay", "web", "mem0", "mem0-backend", "daemon", "runtime-sandbox"]
 }
 
 target "_release" {
@@ -67,6 +67,15 @@ target "runtime-sandbox" {
   tags = concat(
     ["${REGISTRY}/${OWNER}/runtime-sandbox:${VERSION}"],
     LATEST ? ["${REGISTRY}/${OWNER}/runtime-sandbox:latest"] : []
+  )
+}
+
+target "daemon" {
+  inherits = ["_release"]
+  target   = "daemon"
+  tags = concat(
+    ["${REGISTRY}/${OWNER}/daemon:${VERSION}"],
+    LATEST ? ["${REGISTRY}/${OWNER}/daemon:latest"] : []
   )
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -73,6 +73,9 @@ target "runtime-sandbox" {
 target "daemon" {
   inherits = ["_release"]
   target   = "daemon"
+  args = {
+    DAEMON_VERSION = VERSION
+  }
   tags = concat(
     ["${REGISTRY}/${OWNER}/daemon:${VERSION}"],
     LATEST ? ["${REGISTRY}/${OWNER}/daemon:latest"] : []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -154,6 +154,65 @@ COPY --from=relay-builder /relay ./
 EXPOSE 8080
 CMD ["node", "dist/index.js"]
 
+# ──────────────────────────── daemon: build ─────────────────────────────────
+# The edge unit (packages/daemon). Distinct from the RUNTIME SANDBOX image
+# (docker/runtime-sandbox.Dockerfile): this runs the daemon, that one is what an
+# agent's ACP runtime executes inside. Under --k8s the daemon starts no runtime
+# locally, so this image carries no ACP runtimes at all.
+FROM manifests AS daemon-builder
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+  pnpm install --frozen-lockfile --filter "@agentconnect.md/daemon..."
+
+COPY . .
+
+# protocol → message / connection / observability → daemon (topological).
+RUN pnpm --filter "@agentconnect.md/protocol" \
+  --filter "@agentconnect.md/message" \
+  --filter "@agentconnect.md/connection" \
+  --filter "@agentconnect.md/observability" \
+  --filter "@agentconnect.md/daemon" \
+  -r build
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+  pnpm --config.inject-workspace-packages=true \
+  --filter "@agentconnect.md/daemon" \
+  deploy --prod /daemon
+
+# ─────────────────────────── daemon: runtime ────────────────────────────────
+FROM node:24-bookworm-slim AS daemon
+WORKDIR /app/packages/daemon
+ENV NODE_ENV=production \
+  AC_K8S_SHIM_HOST=0.0.0.0 \
+  AC_K8S_SHIM_PORT=8085 \
+  # The kubelet is the supervisor: it restarts the container, and an in-pod
+  # self-upgrade would exit for a version the cluster never asked for.
+  AGENTCONNECT_SUPERVISOR=k8s
+
+# git is load-bearing even here: a self-hosted agent on this daemon still clones
+# locally, and the workspace seam only moves git into a sandbox for agents that
+# have one. ca-certificates covers outbound TLS to the control plane and to
+# providers (direct-connect, for now).
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates git tini \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=daemon-builder /daemon ./
+
+# Non-root, and a fixed uid so a daemon state volume survives a rollout.
+RUN groupadd --gid 10002 daemon-user \
+  && useradd --uid 10002 --gid 10002 --home-dir /var/lib/agentconnect --create-home daemon-user \
+  && chown -R 10002:10002 /var/lib/agentconnect
+ENV HOME=/var/lib/agentconnect
+USER 10002:10002
+
+# The shim callback endpoint. Sandboxes dial IN to this; the daemon never dials
+# into a sandbox, which is what lets a sandbox keep zero inbound rules.
+EXPOSE 8085
+# tini so a SIGTERM reaches the daemon and its drain actually runs — without it
+# PID 1 ignores the signal and every rollout ends in SIGKILL mid-drain.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "dist/index.js", "run", "--k8s"]
+
 # ────────────────────────────── web: build ──────────────────────────────────
 FROM manifests AS web-builder
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -198,6 +198,18 @@ RUN apt-get update \
 
 COPY --from=daemon-builder /daemon ./
 
+# The version this pod reports. The repo manifest stays at 1.0.0-dev and semantic-release does not
+# commit a bump, so an image built from the release tag would otherwise report the dev version —
+# and the Control Plane persists it as `agentVersion` for fleet and upgrade state, meaning every
+# pod would identify itself wrongly. CI passes the effective image tag; the leading `v` is dropped
+# because a package version is semver, not a git tag.
+ARG DAEMON_VERSION=""
+# Only a semver-shaped value is written: a local `bake` passes VERSION=local, and a package
+# version of "local" would be a nonsense answer rather than an obviously absent one.
+RUN if echo "$DAEMON_VERSION" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+'; then \
+  DAEMON_VERSION="$DAEMON_VERSION" node -e "const fs=require('node:fs');const p='package.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));j.version=process.env.DAEMON_VERSION.replace(/^v/,'');fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n')"; \
+  fi
+
 # Non-root, and a fixed uid so a daemon state volume survives a rollout.
 RUN groupadd --gid 10002 daemon-user \
   && useradd --uid 10002 --gid 10002 --home-dir /var/lib/agentconnect --create-home daemon-user \

--- a/scripts/component-versions.sh
+++ b/scripts/component-versions.sh
@@ -53,6 +53,7 @@ SETUP_PATHS="$CP_PATHS"
 WEB_PATHS="packages/web packages/protocol $COMMON"
 RELAY_PATHS="packages/relay packages/message packages/protocol packages/connection packages/observability $COMMON"
 MEM0_PATHS="packages/memory-plugin-mem0 packages/protocol $COMMON"
+DAEMON_PATHS="packages/daemon packages/message packages/protocol packages/connection packages/observability $COMMON"
 # The backend's application source is the immutable external context declared in
 # docker-bake.hcl. Changes to that pin, its owned Dockerfile, or this resolver
 # rebuild the image; unrelated app/package changes leave it on its effective tag.
@@ -109,3 +110,4 @@ printf 'mem0=%s\n' "$(effective "$MEM0_PATHS")"
 printf 'mem0Backend=%s\n' "$(effective "$MEM0_BACKEND_PATHS")"
 printf 'setup=%s\n' "$(effective "$SETUP_PATHS")"
 printf 'runtimeSandbox=%s\n' "$(effective "$RUNTIME_SANDBOX_PATHS")"
+printf 'daemon=%s\n' "$(effective "$DAEMON_PATHS")"

--- a/scripts/verify-daemon-image.mjs
+++ b/scripts/verify-daemon-image.mjs
@@ -14,8 +14,9 @@
 import { execFileSync } from 'node:child_process'
 
 const image = process.argv[2]
+const expectedVersion = process.argv[3]
 if (!image) {
-  process.stderr.write('usage: verify-daemon-image.mjs <image>\n')
+  process.stderr.write('usage: verify-daemon-image.mjs <image> [expected-version]\n')
   process.exit(2)
 }
 
@@ -120,6 +121,19 @@ check('names the missing deployment settings instead of guessing them', () => {
   if (!/AC_K8S_ORG_ID/.test(output)) throw new Error(`did not name the missing setting: ${output.slice(-300)}`)
   return 'reports AC_K8S_ORG_ID'
 })
+
+// The Control Plane persists what this reports as `agentVersion` and drives fleet and upgrade
+// state from it, so a pod that identifies itself as the dev version is worse than unversioned:
+// it looks like a real answer.
+if (expectedVersion) {
+  check('reports the release version rather than the repo manifest', () => {
+    const reported = inImage('node dist/index.js --version').trim()
+    const wanted = expectedVersion.replace(/^v/, '')
+    if (reported !== wanted) throw new Error(`reports ${reported}, expected ${wanted}`)
+    if (/-dev$/.test(reported)) throw new Error('reports the development version')
+    return reported
+  })
+}
 
 process.stdout.write(`daemon image checks (${image})\n${[...notes, ...failures].join('\n')}\n`)
 if (failures.length > 0) {

--- a/scripts/verify-daemon-image.mjs
+++ b/scripts/verify-daemon-image.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Asserts the daemon pod image holds the properties a cluster deployment depends on.
+ *
+ *   node scripts/verify-daemon-image.mjs <image>
+ *
+ * Checked against the BUILT image, not the Dockerfile, for the same reason as the runtime
+ * sandbox: a base bump or a layer ordering change passes review and fails here.
+ *
+ * The one that matters most is the last: `--k8s` outside a pod must REFUSE to start. The failure
+ * it guards against is silent — a daemon that fell back to local execution would look healthy
+ * while running agent code on its own host, which is the entire thing the mode exists to prevent.
+ */
+import { execFileSync } from 'node:child_process'
+
+const image = process.argv[2]
+if (!image) {
+  process.stderr.write('usage: verify-daemon-image.mjs <image>\n')
+  process.exit(2)
+}
+
+const failures = []
+const notes = []
+
+function check(name, fn) {
+  try {
+    const detail = fn()
+    notes.push(`  ✓ ${name}${detail ? ` — ${detail}` : ''}`)
+  } catch (err) {
+    failures.push(`  ✗ ${name}: ${err.message}`)
+  }
+}
+
+function inImage(script) {
+  return execFileSync('docker', ['run', '--rm', '--entrypoint', 'sh', image, '-c', script], {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024
+  }).trim()
+}
+
+function inspect(format) {
+  return execFileSync('docker', ['inspect', '--format', format, image], { encoding: 'utf8' }).trim()
+}
+
+/** Run the image's real entrypoint and return whatever it printed, exit code included. */
+function runEntrypoint(env = {}) {
+  const args = ['run', '--rm']
+  for (const [key, value] of Object.entries(env)) args.push('--env', `${key}=${value}`)
+  args.push(image)
+  try {
+    return { code: 0, output: execFileSync('docker', args, { encoding: 'utf8', stdio: 'pipe' }) }
+  } catch (err) {
+    return { code: err.status ?? 1, output: `${err.stdout ?? ''}${err.stderr ?? ''}` }
+  }
+}
+
+check('runs as a non-root user', () => {
+  const uid = inImage('id -u')
+  if (uid === '0') throw new Error('image runs as root')
+  const configured = inspect('{{.Config.User}}')
+  if (!configured) throw new Error('no USER is set')
+  return `uid ${uid}`
+})
+
+// Without tini, PID 1 ignores SIGTERM, so the shutdown drain never runs and every rollout ends
+// in SIGKILL mid-drain — with in-flight turns cut rather than finished.
+check('tini is PID 1, so a SIGTERM reaches the drain', () => {
+  const entrypoint = inspect('{{json .Config.Entrypoint}}')
+  if (!entrypoint.includes('tini')) throw new Error(`entrypoint is not tini: ${entrypoint}`)
+  return entrypoint
+})
+
+check('starts the daemon in k8s mode by default', () => {
+  const cmd = inspect('{{json .Config.Cmd}}')
+  if (!cmd.includes('--k8s')) throw new Error(`default command does not enable the mode: ${cmd}`)
+  return cmd
+})
+
+// A self-hosted agent on this daemon still clones locally: the workspace seam moves git into a
+// sandbox only for agents that have one, so a missing git breaks the other half.
+check('carries git and the certificates outbound TLS needs', () => {
+  const missing = ['git', 'node'].filter((bin) => inImage(`command -v ${bin} >/dev/null && echo y || echo n`) === 'n')
+  if (missing.length > 0) throw new Error(`missing: ${missing.join(', ')}`)
+  const certs = inImage('test -e /etc/ssl/certs/ca-certificates.crt && echo y || echo n')
+  if (certs !== 'y') throw new Error('no CA bundle, so outbound TLS would fail')
+  return inImage('git --version')
+})
+
+// This image runs the daemon; the ACP runtimes live in the runtime-sandbox image. Shipping them
+// here would mean an image that could quietly run an agent locally.
+check('ships no ACP runtime of its own', () => {
+  const present = ['claude-agent-acp', 'codex-acp'].filter(
+    (bin) => inImage(`command -v ${bin} >/dev/null && echo y || echo n`) === 'y'
+  )
+  if (present.length > 0) throw new Error(`daemon image ships runtimes: ${present.join(', ')}`)
+  return 'none, as intended'
+})
+
+check('declares the kubelet as its supervisor', () => {
+  // Restart-only: the version is the image, so an in-pod self-upgrade would exit for a version
+  // the cluster never asked for.
+  const env = inspect('{{json .Config.Env}}')
+  if (!env.includes('AGENTCONNECT_SUPERVISOR=k8s')) throw new Error(`supervisor is not declared: ${env}`)
+  return 'AGENTCONNECT_SUPERVISOR=k8s'
+})
+
+check('REFUSES to start outside a pod rather than running runtimes locally', () => {
+  const { code, output } = runEntrypoint({ AC_K8S_ORG_ID: 'org-1', AC_K8S_WARM_POOL: 'pool' })
+  if (code === 0) throw new Error('the daemon started outside a cluster, so runtimes would run on this host')
+  if (!/not running inside a Kubernetes pod/.test(output)) {
+    throw new Error(`refused, but not for the expected reason: ${output.slice(-300)}`)
+  }
+  return 'exits with the in-cluster config error'
+})
+
+check('names the missing deployment settings instead of guessing them', () => {
+  // A guessed org labels another tenant's claims; a guessed pool yields sandboxes that never bind.
+  const { code, output } = runEntrypoint()
+  if (code === 0) throw new Error('started without an org id')
+  if (!/AC_K8S_ORG_ID/.test(output)) throw new Error(`did not name the missing setting: ${output.slice(-300)}`)
+  return 'reports AC_K8S_ORG_ID'
+})
+
+process.stdout.write(`daemon image checks (${image})\n${[...notes, ...failures].join('\n')}\n`)
+if (failures.length > 0) {
+  process.stderr.write(`\n${failures.length} check(s) failed\n`)
+  process.exit(1)
+}


### PR DESCRIPTION
Closes #842. Item 2 of what stands between the merged k8s work and a cluster; #841 (merged) was item 1.

Replaces the earlier PR of the same name, which GitHub auto-closed when its base branch was deleted on #841's merge. This branch is rebuilt from `main` and contains only its own commit.

## The gap

There was **no daemon image**. `docker/Dockerfile` builds control-plane / relay / web / mem0, and D10's image is the *runtime sandbox* — what an agent's ACP runtime executes inside, a different image from the one the daemon runs in. So the merged k8s work had nothing to deploy.

## The image

- **non-root** at a fixed uid (10002), so a daemon state volume survives a rollout
- **tini as PID 1**, so a SIGTERM reaches the shutdown drain — without it PID 1 ignores the signal and every rollout ends in SIGKILL mid-drain, cutting in-flight turns instead of finishing them
- **git and CA certificates**. git is load-bearing even here: the workspace seam moves git into a sandbox only for agents that *have* one, so a self-hosted agent on this daemon still clones locally
- shim callback port exposed — sandboxes dial **in**; the daemon never dials into a sandbox, which is what lets a sandbox keep zero inbound rules
- `AGENTCONNECT_SUPERVISOR=k8s` (the kubelet restarts; the version is the image) and `--k8s` as the default command

**No ACP runtimes.** They belong to the sandbox image; carrying them here would make it possible for this image to quietly run an agent locally — the outcome the mode exists to prevent. There is a check for exactly that.

## Verification

`scripts/verify-daemon-image.mjs`, against the built image:

```
  ✓ runs as a non-root user — uid 10002
  ✓ tini is PID 1, so a SIGTERM reaches the drain
  ✓ starts the daemon in k8s mode by default
  ✓ carries git and the certificates outbound TLS needs — git version 2.39.5
  ✓ ships no ACP runtime of its own — none, as intended
  ✓ declares the kubelet as its supervisor
  ✓ REFUSES to start outside a pod rather than running runtimes locally
  ✓ names the missing deployment settings instead of guessing them
```

The last two are the ones worth having. Making the plane failure non-fatal — the plausible "be forgiving" change someone might make later — fails both, and fails them *for the right reason*: the check requires the expected refusal, not merely a non-zero exit.

Release pipeline mirrors the runtime sandbox: bake target, per-component effective versioning over the daemon's source graph, the release alias for unchanged builds, and the component in the `images-pushed` dispatch payload. A new `Daemon Image` CI job builds and verifies on every PR.

## Still needed after this

The cluster manifests — Deployment, ServiceAccount + RBAC (`sandboxclaims`/`sandboxes` get/create/patch/watch, `tokenreviews` create), SandboxTemplate + SandboxWarmPool (projecting an `ac-daemon-callback`-audience token to `/var/run/ac-identity/token` and injecting `AC_SHIM_ENDPOINT`), NetworkPolicy — plus installing the agent-sandbox operator. Then the runtime-command mapping and the credential-helper path, both of which go live the moment a daemon is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)