### PR TITLE
feat(shim): accept provider base URL / API key from the sandbox pod env

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -115,6 +115,10 @@ RUN mkdir -p /opt/agentconnect/runtime \
   && rm -rf /tmp/ac-probe \
   && chown -R root:root /opt/agentconnect/runtime \
   && chmod -R a-w /opt/agentconnect/runtime
+# Provider config accepted from the pod env (interim until the managed egress proxy): the shim
+# maps AC_CLAUDE_BASE_URL/AC_CLAUDE_API_KEY → ANTHROPIC_BASE_URL/ANTHROPIC_API_KEY and
+# AC_CODEX_BASE_URL/AC_CODEX_API_KEY → OPENAI_BASE_URL/OPENAI_API_KEY onto the matching runtime
+# only, and a value the daemon already sent for that runtime wins (src/shim/acp-runner.ts).
 ENV HOME=/agent \
   AC_SHIM_WORKSPACE_ROOT=/agent \
   npm_config_update_notifier=false \

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -10,7 +10,11 @@ runtimeClass, admission policy, egress control, and a managed egress proxy so a 
 key never enters the sandbox — is a separate, later plan. Until it lands, the pod and the
 per-org namespace are the only isolation boundaries, and a provider key is present inside
 the sandbox, so this shape suits internal dogfooding and self-hosted
-bring-your-own-key.
+bring-your-own-key. As an interim step the runtime image accepts deployment-owned provider
+config from the pod environment — `AC_CLAUDE_BASE_URL`/`AC_CLAUDE_API_KEY` and
+`AC_CODEX_BASE_URL`/`AC_CODEX_API_KEY`, which the shim maps onto the matching runtime's
+`ANTHROPIC_*`/`OPENAI_*` variables at spawn (fill-in only; a daemon-sent value wins) — so
+the key can live in the SandboxTemplate instead of traveling over the shim channel.
 
 ## 1. Why a seam at all
 

--- a/packages/daemon/src/shim/acp-runner.ts
+++ b/packages/daemon/src/shim/acp-runner.ts
@@ -8,6 +8,31 @@ export type EmitEvent = (event: ShimEvent['event']) => void
 /** Resolve an executable in THIS filesystem — the sandbox's, which is the whole point. */
 export type ResolveCommand = (command: string, env: Record<string, string>) => string | undefined
 
+/** Pod-env names the runtime image accepts, mapped onto the matching runtime's own provider
+ *  variables. Interim until the managed egress proxy lands: the key stays deployment-owned
+ *  (SandboxTemplate env) instead of traveling from the daemon, and only the runtime whose
+ *  vendor the variable names ever sees it. */
+export const SANDBOX_PROVIDER_ENV: Readonly<Record<'claude' | 'codex', Readonly<Record<string, string>>>> = {
+  claude: { AC_CLAUDE_BASE_URL: 'ANTHROPIC_BASE_URL', AC_CLAUDE_API_KEY: 'ANTHROPIC_API_KEY' },
+  codex: { AC_CODEX_BASE_URL: 'OPENAI_BASE_URL', AC_CODEX_API_KEY: 'OPENAI_API_KEY' }
+}
+
+/** Provider env for the REQUESTED command (its registry identity, not the resolved path). */
+export function sandboxProviderEnv(
+  command: string,
+  podEnv: Record<string, string | undefined>
+): Record<string, string> {
+  const base = command.split(/[\\/]/).pop() ?? ''
+  const profile = /^claude(?:$|[-.@])/i.test(base) ? 'claude' : /^codex(?:$|[-.@])/i.test(base) ? 'codex' : undefined
+  if (!profile) return {}
+  const env: Record<string, string> = {}
+  for (const [source, target] of Object.entries(SANDBOX_PROVIDER_ENV[profile])) {
+    const value = podEnv[source]?.trim()
+    if (value) env[target] = value
+  }
+  return env
+}
+
 /**
  * Runs the ACP runtime inside the sandbox and relays its stdio.
  *
@@ -23,6 +48,8 @@ export class AcpRunner {
     private readonly deps: {
       emit: EmitEvent
       resolveCommand?: ResolveCommand
+      /** Pod environment consulted for SANDBOX_PROVIDER_ENV fill-ins; absent means none. */
+      podEnv?: Record<string, string | undefined>
       log?: { info: (m: string) => void; warn: (m: string) => void }
     }
   ) {}
@@ -51,6 +78,10 @@ export class AcpRunner {
       if (env[hint.envVar]) continue
       const resolved = this.deps.resolveCommand?.(hint.command, env)
       if (resolved) env[hint.envVar] = resolved
+    }
+    // Fill-in only, like hints: an env the daemon decided (per-agent key/gateway) stays authoritative.
+    for (const [name, value] of Object.entries(sandboxProviderEnv(payload.command, this.deps.podEnv ?? {}))) {
+      if (!env[name]) env[name] = value
     }
     const command = this.deps.resolveCommand?.(payload.command, env) ?? payload.command
     const child = spawn(command, payload.args, {

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -41,6 +41,8 @@ export interface ShimClientDeps {
   handle?: (capability: ShimCapability, payload: unknown, abort?: AbortSignal) => Promise<unknown>
   /** Resolves executables in THIS filesystem for the ACP runner. */
   resolveCommand?: ResolveCommand
+  /** Pod environment the ACP runner consults for provider fill-ins (SANDBOX_PROVIDER_ENV). */
+  podEnv?: Record<string, string | undefined>
   clock?: Clock
   backoff?: Backoff
   log?: { info: (m: string) => void; warn: (m: string) => void }
@@ -269,6 +271,7 @@ export class ShimClient {
         // a captured reference would send every later byte into it.
         emit: (event) => this.emitEvent(streamId, event),
         ...(this.deps.resolveCommand ? { resolveCommand: this.deps.resolveCommand } : {}),
+        ...(this.deps.podEnv ? { podEnv: this.deps.podEnv } : {}),
         ...(this.deps.log ? { log: this.deps.log } : {})
       })
       this.acpStreams.set(streamId, runner)

--- a/packages/daemon/src/shim/index.ts
+++ b/packages/daemon/src/shim/index.ts
@@ -25,6 +25,8 @@ async function main(): Promise<number> {
     // Without this the runner skips executable hints entirely, so CLAUDE_CODE_EXECUTABLE and
     // path-qualified registry commands would never resolve in the sandbox.
     resolveCommand: resolveCommandInPath,
+    // Image-accepted provider config (AC_CLAUDE_*/AC_CODEX_* → the runtime's BASE_URL/API_KEY).
+    podEnv: process.env,
     // Serves materialize and git exec, and ENFORCES the declared inventory here rather than
     // trusting that the daemon sent only permitted subcommands.
     handle: createExecHandler({ workspaceRoot: process.env[SHIM_WORKSPACE_ROOT_ENV] ?? '/agent', log }),

--- a/packages/daemon/test/shim-provider-env.test.ts
+++ b/packages/daemon/test/shim-provider-env.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { AcpRunner, sandboxProviderEnv, type EmitEvent } from '../src/shim/acp-runner.js'
+import type { ShimEvent } from '../src/shim/protocol.js'
+
+const POD_ENV = {
+  AC_CLAUDE_BASE_URL: 'https://claude-egress.internal',
+  AC_CLAUDE_API_KEY: 'sk-claude-pod',
+  AC_CODEX_BASE_URL: 'https://codex-egress.internal',
+  AC_CODEX_API_KEY: 'sk-codex-pod'
+}
+
+describe('sandboxProviderEnv', () => {
+  it('maps only the claude pod vars for a claude runtime command', () => {
+    expect(sandboxProviderEnv('claude-agent-acp', POD_ENV)).toEqual({
+      ANTHROPIC_BASE_URL: 'https://claude-egress.internal',
+      ANTHROPIC_API_KEY: 'sk-claude-pod'
+    })
+  })
+
+  it('maps only the codex pod vars for a codex runtime command, including path-qualified', () => {
+    expect(sandboxProviderEnv('/usr/local/bin/codex-acp', POD_ENV)).toEqual({
+      OPENAI_BASE_URL: 'https://codex-egress.internal',
+      OPENAI_API_KEY: 'sk-codex-pod'
+    })
+  })
+
+  it('gives an unrecognized runtime nothing — no vendor sees another vendor key', () => {
+    expect(sandboxProviderEnv('zeroclaw', POD_ENV)).toEqual({})
+    expect(sandboxProviderEnv('hermes', POD_ENV)).toEqual({})
+  })
+
+  it('skips empty or whitespace pod values instead of injecting blanks', () => {
+    expect(sandboxProviderEnv('claude-agent-acp', { AC_CLAUDE_API_KEY: '  ', AC_CLAUDE_BASE_URL: '' })).toEqual({})
+  })
+})
+
+// Spawn through the real runner: resolveCommand maps the registry command to node so the
+// child can print the environment it actually received.
+async function spawnAndReadEnv(command: string, requestEnv: Record<string, string>): Promise<Record<string, string>> {
+  const chunks: string[] = []
+  let onExit: (() => void) | undefined
+  const exited = new Promise<void>((resolve) => (onExit = resolve))
+  const emit: EmitEvent = (event: ShimEvent['event']) => {
+    if (event.kind === 'chunk') chunks.push(Buffer.from(event.data, 'base64').toString('utf8'))
+    if (event.kind === 'exit') onExit?.()
+  }
+  const runner = new AcpRunner({ emit, resolveCommand: () => process.execPath, podEnv: POD_ENV })
+  await runner.apply({
+    op: 'open',
+    command,
+    args: [
+      '-e',
+      'process.stdout.write(JSON.stringify({A: process.env.ANTHROPIC_API_KEY ?? null, B: process.env.ANTHROPIC_BASE_URL ?? null, O: process.env.OPENAI_API_KEY ?? null}))'
+    ],
+    env: requestEnv
+  })
+  await exited
+  return JSON.parse(chunks.join('')) as Record<string, string>
+}
+
+describe('AcpRunner provider env fill-in', () => {
+  it('fills pod provider vars into a claude spawn and keeps codex vars out', async () => {
+    const seen = await spawnAndReadEnv('claude-agent-acp', { PATH: process.env.PATH ?? '' })
+    expect(seen).toEqual({ A: 'sk-claude-pod', B: 'https://claude-egress.internal', O: null })
+  })
+
+  it('lets a daemon-sent value win over the pod value', async () => {
+    const seen = await spawnAndReadEnv('claude-agent-acp', {
+      PATH: process.env.PATH ?? '',
+      ANTHROPIC_API_KEY: 'sk-from-daemon'
+    })
+    expect(seen.A).toBe('sk-from-daemon')
+    expect(seen.B).toBe('https://claude-egress.internal')
+  })
+})


### PR DESCRIPTION
## What

Interim provider egress configuration for the runtime sandbox (until the managed egress proxy from cluster-spawn-and-shim.md's staged scope lands): the runtime image now accepts deployment-owned provider config from the pod environment, mapped by the shim onto the matching runtime at ACP spawn.

| Pod env (SandboxTemplate) | Injected as | Visible to |
|---|---|---|
| `AC_CLAUDE_BASE_URL` | `ANTHROPIC_BASE_URL` | claude runtime only |
| `AC_CLAUDE_API_KEY` | `ANTHROPIC_API_KEY` | claude runtime only |
| `AC_CODEX_BASE_URL` | `OPENAI_BASE_URL` | codex runtime only |
| `AC_CODEX_API_KEY` | `OPENAI_API_KEY` | codex runtime only |

## Why this shape

- **AC_-prefixed, mapped at the one spawn seam** rather than passed through by provider name: the key never rides along into the shim's other children (workspace git exec, tunnels), only into the ACP runtime spawn.
- **Scoped per runtime** by the requested command's registry identity — claude only ever sees `ANTHROPIC_*`, codex only `OPENAI_*`, an unrecognized runtime nothing.
- **Fill-in only, same semantics as executable hints**: a daemon-decided env (per-agent secrets, `runtime.env` gateway config) stays authoritative on collision, so existing configurations are unaffected.
- Empty/whitespace pod values are skipped instead of injecting blanks.

## Changes

- `shim/acp-runner.ts`: `SANDBOX_PROVIDER_ENV` map + `sandboxProviderEnv()`; fill-in in `open()`
- `shim/client.ts` / `shim/index.ts`: `podEnv` dep wired from `process.env`
- `docker/runtime-sandbox.Dockerfile`: documents the accepted env contract
- `docs/designs/cluster-spawn-and-shim.md`: staged-scope paragraph records the interim step
- `test/shim-provider-env.test.ts`: mapping, vendor isolation, path-qualified commands, blank skipping, real-spawn fill-in and daemon-wins precedence (6 tests)

## Testing

- New test file: 6/6 pass
- All shim suites (`shim-channels`, `shim-cancellation`, `shim-handshake`, `shim-exec-handler`, `shim-provider-env`): 75/75 pass
- Daemon typecheck clean; shim bundle rebuilds self-contained at 289 kB

🤖 Generated with [Claude Code](https://claude.com/claude-code)