### PR TITLE
feat(docker): ship OpenCode in the runtime sandbox image

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -5,16 +5,17 @@ Applies to the `agentconnect` namespace. The agent-sandbox CRDs
 
 ## Why the `runtimes` block in the config is not optional
 
-`--k8s` refuses package launchers. The public ACP registry distributes both
-runtimes as `npx` packages, and a runtime fetched at spawn time would mean the
-image pin says nothing about what actually runs — and would need registry egress
-from a sandbox that should have none. So the ids have to be mapped to the
-executables the runtime image really ships:
+`--k8s` refuses package launchers. The public ACP registry distributes the
+runtimes as `npx` packages or downloaded archives, and a runtime fetched at
+spawn time would mean the image pin says nothing about what actually runs — and
+would need registry egress from a sandbox that should have none. So the ids
+have to be mapped to the executables the runtime image really ships:
 
 ```json
 "runtimes": {
   "claude-acp": { "command": "claude-agent-acp", "args": [], "env": [] },
-  "codex-acp":  { "command": "codex-acp",        "args": [], "env": [] }
+  "codex-acp":  { "command": "codex-acp",        "args": [], "env": [] },
+  "opencode":   { "command": "opencode",         "args": ["acp"], "env": [] }
 }
 ```
 

--- a/deploy/k8s/config.example.json
+++ b/deploy/k8s/config.example.json
@@ -7,6 +7,7 @@
   },
   "runtimes": {
     "claude-acp": { "command": "claude-agent-acp", "args": [], "env": [] },
-    "codex-acp": { "command": "codex-acp", "args": [], "env": [] }
+    "codex-acp": { "command": "codex-acp", "args": [], "env": [] },
+    "opencode": { "command": "opencode", "args": ["acp"], "env": [] }
   }
 }

--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -64,6 +64,7 @@ FROM node:24-bookworm-slim AS runtime-sandbox
 # names these versions, and a floating tag would make the table a claim about the past.
 ARG CLAUDE_ACP_VERSION=0.66.0
 ARG CODEX_ACP_VERSION=1.1.14
+ARG OPENCODE_VERSION=1.18.16
 
 # git and ca-certificates are load-bearing — the workspace surface runs git IN here over the
 # shim's exec channel. openssh-client is for ssh remotes; tini is PID 1. Nothing else: every
@@ -76,9 +77,13 @@ RUN apt-get update \
 # refuses package-launcher (npx/uvx) entries: fetching a runtime at spawn time would mean the
 # image pin says nothing about what actually runs, and would need registry egress from a
 # sandbox that should have none.
+# opencode-ai NEEDS its postinstall (it copies the platform binary over a failing placeholder),
+# so no --ignore-scripts here; claude/codex resolve their binaries from optionalDeps instead.
 RUN npm install --global --no-fund --no-audit \
   "@agentclientprotocol/claude-agent-acp@${CLAUDE_ACP_VERSION}" \
   "@agentclientprotocol/codex-acp@${CODEX_ACP_VERSION}" \
+  "opencode-ai@${OPENCODE_VERSION}" \
+  && opencode --version \
   && npm cache clean --force
 
 # Root-owned and read-only: the runtime is the untrusted party in this image, and a shim it can

--- a/docker/runtime-sandbox/generate-runtime-table.mjs
+++ b/docker/runtime-sandbox/generate-runtime-table.mjs
@@ -16,10 +16,11 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-/** Runtime ids this image provides and the executable each is launched as. */
+/** Runtime ids this image provides and the executable (plus args) each is launched as. */
 const PROVIDED = [
   { id: 'claude-acp', bin: 'claude-agent-acp' },
-  { id: 'codex-acp', bin: 'codex-acp' }
+  { id: 'codex-acp', bin: 'codex-acp' },
+  { id: 'opencode', bin: 'opencode', args: ['acp'] }
 ]
 
 const PROBE_TIMEOUT_MS = 60_000
@@ -37,11 +38,11 @@ export function isAuthRequired(error) {
 const PROBE_CWD = process.env.AC_PROBE_CWD ?? process.cwd()
 
 /** Drive one runtime over stdio far enough to learn what it is: initialize, then a session. */
-async function probe(bin) {
+async function probe(bin, args = []) {
   // Ambient HOME and cwd, NOT a pinned /agent: a runtime writes state into both, so whoever runs
   // this decides where that lands. Pinning the workspace meant the build-time probe left
   // root-owned .claude/.codex state in /agent that the runtime user could not then write.
-  const child = spawn(bin, [], { stdio: ['pipe', 'pipe', 'ignore'], env: process.env, cwd: PROBE_CWD })
+  const child = spawn(bin, args, { stdio: ['pipe', 'pipe', 'ignore'], env: process.env, cwd: PROBE_CWD })
   const replies = new Map()
   let buffered = ''
   child.stdout.on('data', (chunk) => {
@@ -118,7 +119,7 @@ function stable(value) {
 export async function buildTable() {
   const runtimes = []
   for (const entry of PROVIDED) {
-    const { initialized, session, sessionProbe } = await probe(entry.bin)
+    const { initialized, session, sessionProbe } = await probe(entry.bin, entry.args ?? [])
     const version = initialized?.agentInfo?.version
     if (typeof version !== 'string' || version.length === 0) {
       throw new Error(`${entry.bin} reported no agentInfo.version at initialize`)

--- a/scripts/verify-runtime-image.mjs
+++ b/scripts/verify-runtime-image.mjs
@@ -139,7 +139,7 @@ check('the published runtime table matches a fresh ACP probe of this image', () 
 // The workspace surface runs git INSIDE the sandbox over the shim's exec channel, so a missing
 // git is not a degraded feature — it is every workspace operation failing at the far end.
 check('provides the executables the shim must resolve', () => {
-  const required = ['git', 'node', 'claude-agent-acp', 'codex-acp']
+  const required = ['git', 'node', 'claude-agent-acp', 'codex-acp', 'opencode']
   const missing = required.filter((bin) => inImage(`command -v ${bin} >/dev/null && echo y || echo n`) === 'n')
   if (missing.length > 0) throw new Error(`missing: ${missing.join(', ')}`)
   return required.join(' ')


### PR DESCRIPTION
## What

Adds **OpenCode** as the third ACP runtime the runtime-sandbox image provides, pinned like the other two: `opencode-ai@1.18.16` (matches the public ACP registry's declared version).

## Key points

- **Lifecycle scripts stay enabled for the npm install**: `opencode-ai`'s real platform binary is copied over a failing placeholder by its postinstall — `--ignore-scripts` would ship a stub that exits 1. The build asserts `opencode --version` right after install so a silent stub can never ship.
- **The table generator learns per-runtime launch args**: opencode is launched as `opencode acp` (the binary is the agent itself, ACP is a subcommand). `PROVIDED` entries now carry optional `args`.
- **verify-runtime-image.mjs** requires the `opencode` executable alongside the existing ones; the published-table-vs-fresh-probe check covers the new entry automatically.
- **Deploy docs** (`deploy/k8s/config.example.json` + README) gain the third `runtimes` mapping. The `opencode` id resolves through the public ACP registry to a downloaded-archive command (`./opencode`) — exactly the class `--k8s` refuses — so the executable mapping is as non-optional as for the npx-distributed pair.

## Probed behavior (validated against a local install of all three pins)

```
claude-acp 0.66.0 | sessionProbe: ok            | protocol: 1
codex-acp  1.1.14 | sessionProbe: auth-required | protocol: 1
opencode  1.18.16 | sessionProbe: ok            | protocol: 1
```

opencode's `initialize` reports `agentInfo.version`, and `session/new` succeeds unauthenticated (free-tier catalog in `configOptions`), so the build-time probe needs no new failure tolerance.

## Testing

- Generator run end-to-end locally with all three runtimes on PATH (output above)
- `runtime-table-generator`, `k8s-runtimes`, `k8s-runtime-plane` suites: 18/18 pass
- eslint + prettier clean; CI's Runtime Sandbox Image job builds the image and re-runs the same generator against it

🤖 Generated with [Claude Code](https://claude.com/claude-code)