### PR TITLE
fix(daemon): send the ACP cwd in the pod's coordinates, not the daemon's

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -204,6 +204,7 @@ import {
 import { ChannelNameResolver } from './messages/channel-name-resolver.js'
 import {
   cleanupStaleWorkspaceClones,
+  clusterWorkspaceCwd,
   convergeGithubAppWorkspaceRename,
   ensureWorkspaceMaterialization,
   isWorkspaceEmpty,
@@ -3135,7 +3136,13 @@ export class Daemon {
       agentById: (id) => this.agents.get(id),
       prepareWorkspace: (agent, expectedWarmHost, request) =>
         this.prepareAgentWorkspace(agent, expectedWarmHost, request),
-      resolvePreparedWorkspace: (agent) => resolvePreparedWorkspaceCwd(agent),
+      // Cluster agents resolve to POD coordinates — the local resolver would hand back the
+      // daemon-disk path the runtime cannot see. Called only after hostFor's cold gate, so
+      // the channel (and with it the pod's reported mount) has already bound.
+      resolvePreparedWorkspace: (agent) =>
+        this.k8sPlane
+          ? clusterWorkspaceCwd(agent, this.k8sPlane.workspaceRootFor(agent.id))
+          : resolvePreparedWorkspaceCwd(agent),
       memory: this.memory,
       onMemoryRecallError: (agentId, error) =>
         this.log.warn(
@@ -4767,11 +4774,16 @@ export class Daemon {
   }
 
   private async runAgentWorkspacePreparation(agent: Agent, request?: PrepareSessionWorkspaceRequest): Promise<string> {
+    // In --k8s the workspace lives on the sandbox pod's volume, in the POD's coordinates: the
+    // sandbox has to exist before anything else (the channel reports where the volume mounts),
+    // and none of the local preparation below may run — its mkdir/existsSync/skills work would
+    // land on this daemon's disk, describing a filesystem the runtime never sees. Skills and
+    // git-repo checkouts for cluster agents arrive with the materialize/runner phases.
+    if (this.k8sPlane) {
+      await this.k8sPlane.ensureChannel(agent.id)
+      return clusterWorkspaceCwd(agent, this.k8sPlane.workspaceRootFor(agent.id), request)
+    }
     if (!this.opts.hostFactory) assertExclusiveAgentWorkspaces([agent as LoadedAgent])
-    // In --k8s the workspace lives on the sandbox pod's volume, so the sandbox has to exist
-    // BEFORE preparation: the resolver has no session until a channel binds, and preparing first
-    // would clone onto this daemon's disk and hand the runtime an empty workspace.
-    if (this.k8sPlane) await this.k8sPlane.ensureChannel(agent.id)
     const opts = {
       managedSkills: (value: Agent) => this.managedSkillCache?.resolve(value) ?? Promise.resolve([]),
       skillsStateDir: join(this.root, 'skill-installs'),
@@ -4781,6 +4793,9 @@ export class Daemon {
   }
 
   private runAgentWorkspacePrefetch(agent: Agent): Promise<void> {
+    // A cluster workspace materializes on the pod's volume at session time; a local prefetch
+    // would clone the repository onto this daemon's own disk instead.
+    if (this.k8sPlane) return Promise.resolve()
     return prefetchWorkspace(agent)
   }
 

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -410,8 +410,12 @@ export class K8sDriver implements SpawnDriver {
     return this.workspaceRoots.get(agentId)
   }
 
+  // Mirrors the CURRENT pod, absence included: a root kept from a previous incarnation (an image
+  // rollback to a shim that reports none) names a mount this pod may not have — the exact failure
+  // this seam exists to remove. Unset ⇒ callers fall back to the historical mount.
   private recordWorkspaceRoot(agentId: string, connection: ShimConnection): void {
     if (connection.workspaceRoot) this.workspaceRoots.set(agentId, connection.workspaceRoot)
+    else this.workspaceRoots.delete(agentId)
   }
 
   async launch(request: SpawnRequest): Promise<SpawnedRuntime> {

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -105,6 +105,8 @@ export class K8sDriver implements SpawnDriver {
   private readonly modeQueue = new Map<string, Promise<void>>()
   /** Logical channels per agent, which survive the shim's credential renewals. */
   private readonly sessions = new Map<string, ShimSession>()
+  /** Workspace mount per agent, as the bound pod's shim reported it. */
+  private readonly workspaceRoots = new Map<string, string>()
   private readonly clock: Clock
 
   constructor(private readonly deps: K8sDriverDeps) {
@@ -283,6 +285,7 @@ export class K8sDriver implements SpawnDriver {
   async removeAgent(agentId: string): Promise<void> {
     this.launches.delete(agentId)
     this.draining.delete(agentId)
+    this.workspaceRoots.delete(agentId)
     await this.deps.api.deleteClaim(this.claimName(agentId))
   }
 
@@ -377,6 +380,7 @@ export class K8sDriver implements SpawnDriver {
         throw err
       })
     timer?.mark('shim_handshake')
+    this.recordWorkspaceRoot(agentId, connection)
     // The session is created HERE rather than in `launch`, because a channel bound for workspace
     // preparation needs one too — and a second session per agent would mean the runtime and the
     // workspace seam disagreeing about whether the channel is alive.
@@ -398,6 +402,16 @@ export class K8sDriver implements SpawnDriver {
    *  does rather than opening a second one that can disagree about whether it is alive. */
   sessionFor(agentId: string): ShimSession | undefined {
     return this.sessions.get(agentId)
+  }
+
+  /** Where the agent's bound pod mounts its workspace, or undefined before a bind (or when a
+   *  legacy shim reported nothing — callers fall back to the historical mount). */
+  workspaceRootFor(agentId: string): string | undefined {
+    return this.workspaceRoots.get(agentId)
+  }
+
+  private recordWorkspaceRoot(agentId: string, connection: ShimConnection): void {
+    if (connection.workspaceRoot) this.workspaceRoots.set(agentId, connection.workspaceRoot)
   }
 
   async launch(request: SpawnRequest): Promise<SpawnedRuntime> {
@@ -444,6 +458,7 @@ export class K8sDriver implements SpawnDriver {
 
   /** Re-attach a renewed or replacement connection to the launch it belongs to. */
   onChannelBound(connection: ShimConnection): void {
+    this.recordWorkspaceRoot(connection.binding.agentId, connection)
     const session = this.sessions.get(connection.binding.agentId)
     if (!session) return
     // Counted apart from the first bind: a re-establishment rate is the signal that renewals or

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -94,6 +94,9 @@ export interface K8sRuntimePlane {
   /** A git runner for an agent whose workspace lives on its sandbox pod, or undefined when this
    *  daemon has no channel for it — the caller then keeps its local behaviour. */
   gitRunnerFor: (agentId: string, cwd?: string, abort?: AbortSignal) => GitRunner | undefined
+  /** Where the agent's bound pod mounts its workspace, as its shim reported; undefined before a
+   *  bind or from a legacy shim (callers fall back to DEFAULT_SHIM_WORKSPACE_ROOT). */
+  workspaceRootFor: (agentId: string) => string | undefined
   stop: () => Promise<void>
 }
 
@@ -206,6 +209,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       if (!session?.isAttached()) return undefined
       return new ShimGitRunner(session, cwd, undefined, abort)
     },
+    workspaceRootFor: (agentId) => driver.workspaceRootFor(agentId),
     stop: async () => {
       for (const timer of lossTimers.values()) clearTimeout(timer)
       lossTimers.clear()

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -43,6 +43,8 @@ export interface ShimClientDeps {
   resolveCommand?: ResolveCommand
   /** Pod environment the ACP runner consults for provider fill-ins (SANDBOX_PROVIDER_ENV). */
   podEnv?: Record<string, string | undefined>
+  /** This pod's workspace mount, reported in the hello so the daemon builds pod paths on it. */
+  workspaceRoot?: string
   clock?: Clock
   backoff?: Backoff
   log?: { info: (m: string) => void; warn: (m: string) => void }
@@ -245,8 +247,14 @@ export class ShimClient {
         if (frame.type === 'shim/request') void this.serve(transport, frame)
         if (frame.type === 'shim/cancel') this.cancel(frame)
       })
-      // The token is the whole proof; nothing else about this pod is asserted.
-      transport.send(JSON.stringify({ type: 'shim/hello', token } satisfies Extract<ShimFrame, { type: 'shim/hello' }>))
+      // The token is the whole proof of identity; the workspace root is a filesystem fact.
+      transport.send(
+        JSON.stringify({
+          type: 'shim/hello',
+          token,
+          ...(this.deps.workspaceRoot ? { workspaceRoot: this.deps.workspaceRoot } : {})
+        } satisfies Extract<ShimFrame, { type: 'shim/hello' }>)
+      )
     })
   }
 

--- a/packages/daemon/src/shim/index.ts
+++ b/packages/daemon/src/shim/index.ts
@@ -5,7 +5,7 @@ import { ClientTransport } from '@agentconnect.md/connection'
 import { ShimClient, type ShimTransport } from './client.js'
 import { createExecHandler } from './exec-handler.js'
 import { resolveCommandInPath } from './path-resolve.js'
-import { SHIM_ENDPOINT_ENV, SHIM_WORKSPACE_ROOT_ENV } from './protocol.js'
+import { DEFAULT_SHIM_WORKSPACE_ROOT, SHIM_ENDPOINT_ENV, SHIM_WORKSPACE_ROOT_ENV } from './protocol.js'
 
 const log = {
   info: (message: string) => console.error(`[shim] ${message}`),
@@ -18,6 +18,7 @@ async function main(): Promise<number> {
     log.warn(`${SHIM_ENDPOINT_ENV} is not set — nothing to dial`)
     return 2
   }
+  const workspaceRoot = process.env[SHIM_WORKSPACE_ROOT_ENV] ?? DEFAULT_SHIM_WORKSPACE_ROOT
   const client = new ShimClient({
     endpoint,
     dial: (url, opts) =>
@@ -29,7 +30,9 @@ async function main(): Promise<number> {
     podEnv: process.env,
     // Serves materialize and git exec, and ENFORCES the declared inventory here rather than
     // trusting that the daemon sent only permitted subcommands.
-    handle: createExecHandler({ workspaceRoot: process.env[SHIM_WORKSPACE_ROOT_ENV] ?? '/agent', log }),
+    handle: createExecHandler({ workspaceRoot, log }),
+    // Reported in the hello: daemon-built pod paths (ACP cwd, git cwd) are anchored on it.
+    workspaceRoot,
     log
   })
   // A signal is the pod being torn down; drop the channel rather than racing the

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server } from 'node:http'
+import { isAbsolute, normalize } from 'node:path'
 import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
 import { noopClusterMetrics, type ClusterMetrics } from '../k8s/cluster-metrics.js'
 import { systemClock, type Clock } from '@agentconnect.md/connection'
@@ -55,12 +56,22 @@ function withoutToken(message: string, token: string): string {
   return token.length > 0 ? message.split(token).join('[redacted]') : message
 }
 
+/** A usable pod workspace root: absolute, normalized, never `/`. Anything else ⇒ unreported. */
+function sanitizeWorkspaceRoot(reported: string | undefined): string | undefined {
+  if (!reported || !isAbsolute(reported)) return undefined
+  const normalized = normalize(reported).replace(/\/+$/, '')
+  return normalized.length > 0 ? normalized : undefined
+}
+
 /** A bound shim connection the daemon can send requests on. */
 export interface ShimConnection {
   binding: Binding
   /** The credential issued to THIS channel, so teardown can revoke exactly it rather than
    *  whatever the pod currently holds — a renewal may already have replaced that. */
   issuedCredential: string
+  /** The pod's workspace mount as the shim reported it; absent on legacy shims. Pod-reported
+   *  and only ever used to build paths sent back INTO that pod, never on this filesystem. */
+  workspaceRoot?: string
   send(frame: ShimFrame): void
   /** Observe inbound frames — how a ShimChannel receives the replies to its requests. */
   onFrame(listener: (text: string) => void): void
@@ -223,6 +234,11 @@ export class ShimListener {
           return
         }
         binding = true
+        // Sanitized here, once, so no consumer has to re-decide what a usable root looks like.
+        const workspaceRoot = sanitizeWorkspaceRoot(frame.workspaceRoot)
+        if (frame.workspaceRoot && !workspaceRoot) {
+          this.deps.log.warn(`shim: ignoring a non-absolute workspace root from ${remoteAddress}`)
+        }
         void this.bindFrom(frame.token, remoteAddress, () => socketOpen).then(
           (result) => {
             binding = false
@@ -246,6 +262,7 @@ export class ShimListener {
             const connection: ShimConnection = {
               binding: result.binding,
               issuedCredential: result.credential,
+              ...(workspaceRoot ? { workspaceRoot } : {}),
               send: (outbound) => ws.send(JSON.stringify(outbound)),
               onFrame: (listener) => frameListeners.push(listener),
               close: (reason) => ws.close(4000, reason)

--- a/packages/daemon/src/shim/protocol.ts
+++ b/packages/daemon/src/shim/protocol.ts
@@ -21,6 +21,10 @@ export const SHIM_ENDPOINT_ENV = 'AC_SHIM_ENDPOINT'
  *  cwd that escapes it. */
 export const SHIM_WORKSPACE_ROOT_ENV = 'AC_SHIM_WORKSPACE_ROOT'
 
+/** The shim's own fallback for that env, and the daemon's assumption for a legacy shim that
+ *  predates workspace-root reporting — every such image mounted the volume here. */
+export const DEFAULT_SHIM_WORKSPACE_ROOT = '/agent'
+
 /** Operations the daemon may ask a bound shim to perform. Every one is authorized
  *  individually against the binding's grants — a channel is not a blanket permission.
  *  The bodies land in #814 / #815; this is the authorization vocabulary they use. */
@@ -43,13 +47,18 @@ export const ShimCapabilitySchema = z.enum([
 ])
 export type ShimCapability = z.infer<typeof ShimCapabilitySchema>
 
-/** The shim's opening frame: it proves which pod it is and nothing more. */
+/** The shim's opening frame: it proves which pod it is, plus one filesystem fact. */
 export const ShimHelloSchema = z.object({
   type: z.literal('shim/hello'),
   /** Projected ServiceAccount token, audience-restricted to {@link SHIM_TOKEN_AUDIENCE}. */
   token: z.string().min(1),
   /** Shim build, for operator diagnosis only — never an authorization input. */
-  shimVersion: z.string().max(64).optional()
+  shimVersion: z.string().max(64).optional(),
+  /** Where THIS pod mounts its workspace volume — the daemon cannot name a path on a machine
+   *  it is not on, and every path it later sends into the pod (ACP cwd, git cwd) is built on
+   *  this. Pod-reported and only ever echoed back into the same pod, so a lying shim gains
+   *  nothing daemon-side. Absent on legacy shims ⇒ {@link DEFAULT_SHIM_WORKSPACE_ROOT}. */
+  workspaceRoot: z.string().min(1).max(4096).optional()
 })
 
 /** The daemon's answer once the token is verified and mapped to a spawn record. */

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -37,6 +37,7 @@ import {
 } from './git-injection.js'
 import { LocalGitRunner, type GitRunner } from './git-runner.js'
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
+import { DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
 
 const skillsLog = makeLogger('info')
 
@@ -671,6 +672,33 @@ export async function prepareSessionWorkspace(
   }
   const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
   return withSkills(agent, resolveAcpCwd(cwd, agentDir), opts)
+}
+
+/**
+ * The ACP cwd for a CLUSTER agent, in the sandbox pod's own coordinates.
+ *
+ * `agent.workspace.path` names a directory on the DAEMON's filesystem and stays its
+ * bookkeeping identity; the runtime and every shim-executed operation live in the pod,
+ * whose volume mounts wherever the image says. Sending the daemon path across (which is
+ * what happened before this split) hands the runtime a cwd that exists on no machine it
+ * can see. The root comes from the bound shim's hello; a legacy shim that reported none
+ * gets the one mount layout such images ever had.
+ */
+export function clusterWorkspaceCwd(
+  agent: Agent,
+  runtimeRoot: string | undefined,
+  request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
+): string {
+  if (agent.workspace.mode !== 'from-scratch') {
+    // Refused loudly rather than half-working: the clone/pull/audit flow still mixes daemon
+    // and pod coordinates for git-repo workspaces, and a clear error beats a mystery one
+    // from git inside the sandbox.
+    throw new Error(`git-repo workspaces are not supported with --k8s yet (agent "${agent.id}")`)
+  }
+  if (request?.isolation === 'session') {
+    throw new Error(`session-isolated workspaces are not supported with --k8s yet (agent "${agent.id}")`)
+  }
+  return runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
 }
 
 /** Resolve the already-prepared ACP cwd without pulling, acquiring sources, or

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -280,6 +280,21 @@ describe('cluster spawn driver', () => {
     expect(instance.workspaceRootFor('agent-a')).toBeUndefined()
   })
 
+  it('forgets a custom root when the replacement pod reports none, rather than keeping a stale mount', async () => {
+    // An image rollback puts a shim that reports nothing on the agent's next pod. Retaining the
+    // previous incarnation's root would send it a path only the OLD image mounted, which is the
+    // failure this reporting exists to remove — the fallback has to become reachable again.
+    const { api } = fakeApi()
+    let generation = 0
+    const { instance } = driver(api, {
+      awaitChannel: async () => stubConnection(++generation, '/mnt/agent')
+    })
+    await instance.launch(launchRequest)
+    expect(instance.workspaceRootFor('agent-a')).toBe('/mnt/agent')
+    instance.onChannelBound(stubConnection(generation))
+    expect(instance.workspaceRootFor('agent-a')).toBeUndefined()
+  })
+
   it('deletes the claim when an agent goes away', async () => {
     const { api, state } = fakeApi()
     const { instance } = driver(api)

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -56,10 +56,11 @@ function fakeApi(options: { ready?: boolean; mode?: 'Running' | 'Suspended' } = 
 }
 
 /** Enough of a bound channel for `launch()` to attach a session to. */
-function stubConnection(generation = 1): ShimConnection {
+function stubConnection(generation = 1, workspaceRoot?: string): ShimConnection {
   return {
     binding: { agentId: 'agent-a', generation, grants: ['acp'], podName: 'p', podUid: 'u' },
     issuedCredential: 'cred',
+    ...(workspaceRoot ? { workspaceRoot } : {}),
     send: () => {},
     onFrame: () => {},
     close: () => {}
@@ -253,6 +254,30 @@ describe('cluster spawn driver', () => {
     expect(launch.sandboxName).toBe('sb-1')
     // And it did NOT publish: nothing may be authorized against a pod that does not exist yet.
     expect(records).toEqual([])
+  })
+
+  it('remembers where the bound pod mounts its workspace, until the agent goes away', async () => {
+    const { api } = fakeApi()
+    let generation = 0
+    const { instance } = driver(api, {
+      awaitChannel: async () => stubConnection(++generation, '/agent')
+    })
+    // Unknown before any bind: the daemon cannot name a path on a machine it has not heard from.
+    expect(instance.workspaceRootFor('agent-a')).toBeUndefined()
+    await instance.launch(launchRequest)
+    expect(instance.workspaceRootFor('agent-a')).toBe('/agent')
+    // A renewal reporting a root keeps it current on the replacement connection too.
+    instance.onChannelBound(stubConnection(generation, '/mnt/agent'))
+    expect(instance.workspaceRootFor('agent-a')).toBe('/mnt/agent')
+    await instance.removeAgent('agent-a')
+    expect(instance.workspaceRootFor('agent-a')).toBeUndefined()
+  })
+
+  it('keeps no workspace root from a legacy shim that reports none', async () => {
+    const { api } = fakeApi()
+    const { instance } = driver(api)
+    await instance.launch(launchRequest)
+    expect(instance.workspaceRootFor('agent-a')).toBeUndefined()
   })
 
   it('deletes the claim when an agent goes away', async () => {

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -82,7 +82,7 @@ async function planeUnderTest(api: ReturnType<typeof fakeApi>): Promise<K8sRunti
 }
 
 /** A real shim client dialling the plane's endpoint, optionally serving capabilities. */
-function shimAgainst(port: number, handlers: { probe?: unknown } = {}): ShimClient {
+function shimAgainst(port: number, handlers: { probe?: unknown; workspaceRoot?: string } = {}): ShimClient {
   const client = new ShimClient({
     ...(handlers.probe === undefined
       ? {}
@@ -92,6 +92,7 @@ function shimAgainst(port: number, handlers: { probe?: unknown } = {}): ShimClie
             throw new Error(`unexpected capability ${capability}`)
           }
         }),
+    ...(handlers.workspaceRoot === undefined ? {} : { workspaceRoot: handlers.workspaceRoot }),
     endpoint: `ws://127.0.0.1:${port}`,
     dial: (url, opts) =>
       ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
@@ -168,11 +169,13 @@ describe('k8s runtime plane assembly', () => {
     const plane = await planeUnderTest(api)
     const port = plane.listener.listeningPort()!
     const ensuring = plane.ensureChannel('agent-a')
-    shimAgainst(port)
+    shimAgainst(port, { workspaceRoot: '/agent' })
     await ensuring
     // A channel, a session behind the workspace seam, and NO runtime started.
     expect(plane.listener.connectionsFor('agent-a')).toHaveLength(1)
     expect(plane.gitRunnerFor('agent-a', '/agent')).toBeDefined()
+    // The pod's reported mount arrived with the bind — the fact every pod path is built on.
+    expect(plane.workspaceRootFor('agent-a')).toBe('/agent')
   })
 
   it('resolves a dialing pod back to its launch, through the ADOPTED pod name', async () => {

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -585,6 +585,41 @@ function mustBind(
   return { credential: result.credential }
 }
 
+describe('workspace root reporting', () => {
+  it('carries a normalized absolute root onto the bound connection', async () => {
+    const { instance, endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-a', podUid: 'pod-a' })
+    })
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 't', workspaceRoot: '/agent//' })
+    await waitFor(() => instance.connectionsFor('agent-a').length > 0)
+    expect(instance.connectionsFor('agent-a')[0]!.workspaceRoot).toBe('/agent')
+  })
+
+  it('leaves the root unset for a legacy hello that reports none', async () => {
+    const { instance, endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-a', podUid: 'pod-a' })
+    })
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 't' })
+    await waitFor(() => instance.connectionsFor('agent-a').length > 0)
+    expect(instance.connectionsFor('agent-a')[0]!.workspaceRoot).toBeUndefined()
+  })
+
+  it('ignores a non-absolute root rather than building pod paths on it', async () => {
+    const warnings: string[] = []
+    const { instance, endpoint } = await listener({
+      verifier: verifier({ authenticated: true, podName: 'runtime-a', podUid: 'pod-a' }),
+      log: { info: () => {}, warn: (message) => warnings.push(message) }
+    })
+    const client = await rawConnect(endpoint)
+    client.send({ type: 'shim/hello', token: 't', workspaceRoot: 'workspace' })
+    await waitFor(() => instance.connectionsFor('agent-a').length > 0)
+    expect(instance.connectionsFor('agent-a')[0]!.workspaceRoot).toBeUndefined()
+    expect(warnings.some((message) => message.includes('non-absolute workspace root'))).toBe(true)
+  })
+})
+
 describe('shim binding registry', () => {
   const clock = { value: 1_000 }
   const registry = (): ShimBindingRegistry => new ShimBindingRegistry(() => clock.value, 60_000)
@@ -730,6 +765,28 @@ describe('shim client', () => {
     const bound = await started
     expect(bound.agentId).toBe('agent-a')
     expect(client.binding()?.sessionCredential).toBe('cred-1')
+  })
+
+  it('reports its workspace mount in the hello when configured', async () => {
+    // The daemon cannot name a path on a machine it is not on; this field is where it learns one.
+    const sent: unknown[] = []
+    const transport: ShimTransport = {
+      send: (text) => sent.push(JSON.parse(text)),
+      onMessage: () => {},
+      onClose: () => {},
+      close: () => {}
+    }
+    const client = new ShimClient({
+      endpoint: 'ws://daemon:9000',
+      dial: async () => transport,
+      readToken: () => 't',
+      workspaceRoot: '/agent',
+      log: { info: () => {}, warn: () => {} }
+    })
+    void client.start()
+    await waitFor(() => sent.length > 0)
+    expect(sent[0]).toEqual({ type: 'shim/hello', token: 't', workspaceRoot: '/agent' })
+    client.stop()
   })
 
   it('re-dials after the channel drops instead of staying alive but detached', async () => {

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -41,6 +41,7 @@ vi.mock('simple-git', () => ({
 // Imported after vi.mock so the mock is in effect.
 const {
   additionalWorkspaceDirectories,
+  clusterWorkspaceCwd,
   convergeGithubAppWorkspaceRename,
   ensureWorkspaceMaterialization,
   prepareSessionWorkspace,
@@ -926,5 +927,27 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       'https://github.com/acme/repo'
     ])
     expect(pullMock).toHaveBeenCalled()
+  })
+})
+
+describe('clusterWorkspaceCwd (--k8s pod coordinates)', () => {
+  it('hands a from-scratch agent the pod root, never the daemon-disk workspace path', () => {
+    const agent = fromScratchAgent('/var/lib/agentconnect/agents/bot-a/workspace')
+    expect(clusterWorkspaceCwd(agent, '/agent')).toBe('/agent')
+  })
+
+  it('falls back to the historical mount for a legacy shim that reported none', () => {
+    const agent = fromScratchAgent('/var/lib/agentconnect/agents/bot-a/workspace')
+    expect(clusterWorkspaceCwd(agent, undefined)).toBe('/agent')
+  })
+
+  it('refuses a git-repo workspace loudly instead of half-working across two filesystems', () => {
+    const agent = gitRepoAgent('/var/lib/agentconnect/agents/bot-git/workspace')
+    expect(() => clusterWorkspaceCwd(agent, '/agent')).toThrow(/git-repo workspaces are not supported with --k8s/)
+  })
+
+  it('refuses session isolation, whose worktrees still assume the daemon filesystem', () => {
+    const agent = fromScratchAgent('/var/lib/agentconnect/agents/bot-a/workspace')
+    expect(() => clusterWorkspaceCwd(agent, '/agent', { isolation: 'session' })).toThrow(/session-isolated/)
   })
 })


### PR DESCRIPTION
A cluster agent's `session/new` carried `agent.workspace.path` — `/var/lib/agentconnect/agents/<id>/workspace`, a path on the **daemon's** filesystem. The runtime lives in a sandbox pod that mounts its volume at `/agent`, so the cwd named a directory existing on no machine the runtime can see. There was no k8s path translation anywhere: grep found the shim's `/agent` default and nothing at all on the daemon side.

|               | daemon believed                              | pod actually has            |
| ------------- | -------------------------------------------- | --------------------------- |
| HOME          | `/var/lib/agentconnect`                      | `/agent` (fixed in 90e490fc) |
| workspace cwd | `/var/lib/agentconnect/agents/<id>/workspace` | `/agent` ← this PR          |

The root cause is that `agent.workspace.path` had quietly taken on two jobs — "where this lives on the daemon" and "where the runtime sees it" — the same string locally, different machines in the cluster.

## The pod reports its own mount

The pod is the only party that knows where its volume lands, so it says so: the shim sends `workspaceRoot` in its hello, the listener sanitizes it (absolute, normalized, never `/`), and the driver keeps it per agent across credential renewals.

Taking it from the pod rather than restating the image layout in daemon config keeps one source of truth — the image can move its mount without a daemon release. It is only ever echoed back into the same pod, so a lying shim gains nothing daemon-side.

## The daemon stops preparing on the wrong disk

`runAgentWorkspacePreparation` resolves cluster agents through `clusterWorkspaceCwd()` and runs **none** of the local preparation: its `mkdir`, `existsSync(.git)` and skills installation all land on this daemon's disk and describe a filesystem the runtime never reads.

`resolvePreparedWorkspace` gets the same treatment. It is the **warm-session** path — leaving it local would have fixed cold starts and left every resumed session on the old daemon path. Prefetch becomes a no-op under `--k8s` for the same reason: it would clone onto the wrong disk.

## What now refuses instead of half-working

`git-repo` workspaces and session isolation throw a clear error. Both still mix coordinates: the clone target is passed as argv (never checked against the shim's `/agent` fence), and every local `existsSync`/`realpathSync` reads the wrong disk — so a git-repo cluster agent would re-clone every session and then fail inside the sandbox. A clear error beats a mystery one from git in the pod; the remaining migration is the rest of #815.

## Compatibility

A legacy shim that reports nothing falls back to `/agent`, which is what every image with this layout ever mounted — so this lands without waiting on an image rollout, and new images stop having it hardcoded on the daemon side.

## Testing

- `shim-handshake` — hello with/without a root, and a non-absolute root ignored with a warning
- `k8s-driver` — root remembered across a renewal, dropped on `removeAgent`, absent for a legacy shim
- `k8s-runtime-plane` — a real shim dialling a real listener reports its mount through `workspaceRootFor`
- `workspace` — `clusterWorkspaceCwd` pod root, legacy fallback, and both refusals
- Full suites green: `shim-*`, `k8s-*`, `workspace*`, `daemon-k8s-mode`, `daemon-supervisor-k8s` (215 tests), plus `typecheck` / `eslint` / `prettier`

Refs #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
