### PR TITLE
feat(tasks): show a session's background tasks in the dock

### DIFF
--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -24,7 +24,7 @@ Today the session detail page is `[nav · body · rail]`, where the rail is a fi
 | Files    | `folder-tree`           | —                  | `refresh-cw`    | workspace tree with git status tags, path search, branch + workdir header                                                       |
 | Git      | `git-commit-horizontal` | changed count      | `refresh-cw`    | branch + ahead/behind, staged / unstaged with `+/−` and per-row stage toggle, commit box with AI message generation, commit log |
 | PR       | `git-pull-request`      | unresolved threads | `external-link` | PR state, head→base, checks, reviews, unresolved threads with a single Auto-fix action, merge box with auto-merge               |
-| Tasks    | `list-checks`           | running count      | `refresh-cw`    | background tasks with state, elapsed, step, cancel/rerun                                                                        |
+| Tasks    | `list-checks`           | running count      | `refresh-cw`    | background tasks with state and elapsed, read-only (§3.5 — no per-task cancel exists to wire)                                   |
 
 Dock geometry: width **380–760px, default 480px**, drag handle on the left edge
 (brand-colored while dragging), tab strip with zero gap between tabs. Tab labels
@@ -163,9 +163,36 @@ completion announce, deferred wake with a re-arm budget
 it is exposed — there is no `task/*` frame, no CP route, no console surface.
 
 Revision 2 **removed the progress bar** that revision 1 drew, which settles the
-question revision 1 left open: the panel renders state, elapsed, and a step line,
-and does not invent a percentage the daemon cannot supply. The "Logs" link still
-maps to nothing today and stays deferred.
+question revision 1 left open: the panel renders state and elapsed, and does not
+invent a percentage the daemon cannot supply. The "Logs" link still maps to
+nothing today and stays deferred.
+
+**The step line is unbacked too, and the panel is read-only.** Measured against
+the shipped daemon and `@agentclientprotocol/sdk@1.3.0` while building M4:
+
+- The lease's per-task record was `{ description?, isSubagent }` — no start time,
+  no step, no history of a finished task (`settle()` deleted the entry). M4 adds
+  a `startedAt` and a bounded settled-task history; there is still no step text
+  anywhere in the `_claude/sdkMessage` feed, so the panel renders the
+  `description` and nothing beside it.
+- There is no `queued` state to render. The feed's only start edge is
+  `task_started`, so a task is either live in the lease or gone.
+- **`task/cancel` is not implementable and is not built.** `CancelNotification`
+  carries only `{ sessionId }` (`session/cancel` cancels a whole prompt turn),
+  `AcpHost` has no ext-request sender so no `_claude/*` kill-by-id can be sent,
+  and the daemon advertises no terminal capability so the agent owns its own
+  shells. The only hard stop is `AcpHost.stop()`, which kills the agent's shared
+  adapter and every session on it. Worse, `interruptTurn` is a no-op exactly when
+  the panel matters: a background task outlives its turn, so there is no
+  `pending` entry and no cancel is sent at all. A per-row control could therefore
+  only cancel unrelated work or report a cancellation it did not perform. It
+  becomes possible with upstream work (a task-addressed ACP cancel, or a Claude
+  adapter `_claude/*` kill-by-id request) — see §12.8.
+- An absent lease is a real answer, not an empty one: a non-Claude runtime, an
+  adapter without the lifecycle extension, and a session that has emitted no
+  accepted lifecycle event all have none. `task/list` reports it as
+  `tracked:false` so the panel can say "not reported for this session" instead of
+  "no background tasks".
 
 ## 4. Gap analysis — the inline viewer
 
@@ -294,11 +321,20 @@ detail? }`. Failure is data, not an error frame.
 
 **`task.ts` — new file**
 
-- `task/list` REQ → `task/list/result`: `{ agentId, sessionId }` → `{ tasks: [{
-id, description, state: 'queued'|'running'|'done'|'failed', startedAt,
-endedAt?, detail? }], truncated }`.
-- `task/cancel` REQ → `task/cancel/result`: `{ agentId, sessionId, taskId }` →
-  `{ ok, detail? }`.
+- `task/list` REQ → `task/list/result`: `{ agentId, sessionId }` → `{ agentId,
+sessionId, tracked, tasks: [{ id, description?, state:
+'running'|'done'|'failed', subagent, startedAt, endedAt?, detail? }], truncated
+}`. `sessionId` is REQUIRED (the lease is per (agent, ACP session) and there is
+  no per-agent aggregate but a boolean). No `queued` — nothing upstream reports
+  one. `done` means "settled with no reported failure", because most settle edges
+  carry no status at all; `detail` carries the reported status when there was
+  one, and a later status-bearing terminal edge refines a retained row without
+  re-announcing. `subagent` rows are CARRIED, not filtered at the source: the
+  same records fence host reclaim, so a panel that dropped them here would show
+  "no tasks" beside a host refusing to be reclaimed. Filter at render.
+- **No `task/cancel`.** §3.5 records why no ACP primitive can address one
+  background task. The panel's escape hatch is the composer's existing
+  turn-scoped stop.
 
 All of them follow the workspace convention: unknown agent → `BAD_PAYLOAD`,
 unexpected failure → `INTERNAL`, everything else is data.
@@ -317,9 +353,26 @@ All following the existing workspace-route shape in `agents.ts`: `getOrgAgent` �
 | POST   | `/agents/:id/workspace/gitstage` \| `gitunstage` \| `gitcommit` \| `gitpush` | write frames                         |
 | POST   | `/agents/:id/workspace/gitmessage`                                           | `workspace/gitmessage`               |
 | GET    | `/agents/:id/tasks`                                                          | `task/list`                          |
-| POST   | `/agents/:id/tasks/:taskId/cancel`                                           | `task/cancel`                        |
 | GET    | `/sessions/:id/pull-request`                                                 | GitHub API via installation token    |
 | POST   | `/sessions/:id/pull-request/auto-merge`                                      | GraphQL `enablePullRequestAutoMerge` |
+
+**`GET /agents/:id/tasks` does NOT use `canReadWorkspaceScope`**, and this
+paragraph's earlier claim that it would was wrong. That gate requires
+`workspaceIsolation === 'session'`, because a shared checkout has no per-session
+worktree and the daemon answers `BAD_PAYLOAD` for one. Background tasks are not a
+checkout: a session on a shared workspace runs them exactly the same, so reusing
+the worktree gate would have 404'd the Tasks panel for most sessions. M4 split the
+session half of that gate out as `visibleAgentSession` — the row must be this
+agent's, un-purged, and pass the session's own private/external visibility rule —
+and `canReadWorkspaceScope` is now that plus the isolation check. The tasks route
+uses `getOrgAgent` → `visibleAgentSession` (404 `session not found`) →
+`agent.daemonId` (503) → `requireTasks` (409 `DAEMON_FEATURE_MISSING`, on the new
+`task-list-v1` marker) → `deps.control.taskList` → `toAgentTasksDto`. `sessionId`
+is a REQUIRED querystring parameter, so an unscoped list is a 400 rather than a
+guess, and `requireSessionWorkspaceRead` does not appear at all — it gates
+worktree browsing, which this read is not. A daemon-named `unknown-agent` maps to
+404 under its own `TASK_` code prefix; there is no 409 arm, because the read
+mutates nothing.
 
 The two `/sessions/:id/pull-request*` routes are the odd ones out — they are not
 daemon proxies. Each resolves the session's `HookRun`, checks the viewer can see
@@ -343,7 +396,7 @@ SessionsPanel.tsx      the ex-SessionRail row / pin / filter body, re-hosted
 FilesPanel.tsx         narrow single-column tree over WorkspaceFiles' read model
 GitPanel.tsx           status + numstat + staging + commit box + log
 PullRequestPanel.tsx   the /sessions/:id/pull-request projection + Auto-fix / auto-merge actions
-TasksPanel.tsx         task list + cancel
+TasksPanel.tsx         task list (read-only — §3.5); polls only while visible and something runs
 ```
 
 and `packages/web/src/components/console/viewer/`:
@@ -735,9 +788,64 @@ Known M3 follow-ups:
   which the runner preflight now classifies correctly and earlier. The guard stays for the failures
   that do reach it; its coverage is the classification, not the timeout.
 
-**M4 — Tasks.** `task/list` + `task/cancel` frames over the existing lease
-bookkeeping, `GET /agents/:id/tasks` + cancel route, panel with state, elapsed
-and step. _Exit:_ background tasks are visible and cancellable.
+**M4 — Tasks.** `task/list` over the lease, which M4 first extends with a
+`startedAt` and a bounded settled-task history (kept in a `settled` array, never
+in `lease.tasks`, so no reclaim decision can see it —
+[`background-task-aware-reclaim.md`](background-task-aware-reclaim.md) and §3.5),
+plus `GET /agents/:id/tasks` and a panel with state and elapsed. No cancel frame,
+route or control: §3.5 records that none can be built honestly. _Exit:_ background
+tasks are visible, and a settled one is showable without holding a session,
+a host, or a workspace mutation open.
+
+Two scope choices the panel makes that the other tabs do not, both because a lease
+is not a checkout:
+
+- **No isolation gate.** Files and Git withhold their read until the focused
+  session's `workspaceIsolation` has answered, because reading early reads the
+  wrong worktree. Tasks needs neither that round trip nor the `hasSessionWorktree`
+  gate `filesSessionId` applies — a session's background tasks exist whatever it
+  is checked out into, which is what the CP route says too. What it does need is
+  the CANONICAL session id the lease is keyed by, so a playground session the
+  daemon has not created yet gets no tab rather than a 404 notice.
+- **Polling is gated on visible-AND-running, plus one read on the tab's own
+  activation edge.** A settled list has no transition left for a read to reveal,
+  and a hidden panel is a request nobody is looking at — but the panel is mounted
+  from the moment the session page opens, so without the activation read a tab
+  opened ten minutes later would draw a ten-minute-old list and no timer would
+  ever correct it (nothing was running when it was read). Elapsed ticks
+  client-side from `startedAt`, so the 1s redraw costs no request. The
+  consequence, accepted: the tab's running badge is only as fresh as the last read
+  while the tab is closed — exactly what the Git tab's changed-count badge already
+  is.
+
+Known M4 follow-ups, none of which change what the code does today:
+
+- The panel counts its own rows for the header census rather than trusting a
+  separate total, so a `truncated` history makes the census describe what is on
+  screen instead of what the daemon holds. That is the honest reading of a bounded
+  list, but it does mean "3 done" can undercount a long-running session.
+- `subagent` rows are shown and marked rather than filtered, because the same
+  records fence host reclaim and hiding them would show "no tasks" beside a host
+  refusing to be reclaimed. If they turn out to be noise in practice, the filter
+  belongs behind a toggle, not in the default render.
+- The panel's read is one effect keyed by `(agentId, sessionId, revision)` whose
+  answer is HELD PER SCOPE and whose pending state is derived from it, not reset
+  from a second effect. That shape is not cosmetic: the first version kept the
+  poll count in its own state and zeroed it whenever the scope or the refresh tick
+  moved, and zeroing it re-triggered the read effect it was there to describe — so
+  past the first poll, every session switch and every press of the tab's refresh
+  action issued TWO reads of the lease. Measured with a probe, then pinned by
+  "re-reads ONCE for a scope switch and ONCE for a refresh, even after a poll has
+  fired". Any future per-scope value here belongs inside that record, not beside it
+  — the same rule M3 wrote down for `CommitBox`.
+- The 1s elapsed redraw is **unpinned**: the tests pin `formatTaskElapsed` and the
+  read cadence, not the interval that re-renders the row. Breaking the tick leaves
+  a frozen elapsed and a green suite.
+- All three of the route's 404s — agent invisible, session invisible, and the
+  daemon's own `TASK_UNKNOWN_AGENT` — fold into one sentence in the panel. They are
+  three ways for the scope to be unreadable and the reader's next action is the
+  same for each, but a future need to tell them apart has to start at the code, not
+  at the status.
 
 **M5 — PR read.** Session DTO exposes its GitHub subject; `GET
 /sessions/:id/pull-request` projection with a short in-memory TTL cache for
@@ -766,8 +874,10 @@ mutation.
   `additions`/`deletions` absent case (old daemon).
 - **daemon** — numstat, unified-diff and log parsing against a fixture repo;
   stage/unstage/commit/push against a scratch worktree including the dirty and
-  diverged paths; task list over a lease with queued/running/done/failed
-  members; cancel of an already-settled task is a no-op, not an error.
+  diverged paths; task list over a lease with running/done/failed members; and
+  the reclaim-safety pair that the retention exists to keep true — a settled task
+  retained for the panel neither keeps its session open nor spends the
+  background-task wake budget.
 - **web** — the unified-diff parser is the highest-value unit test in the whole
   plan (hunk-header line-number arithmetic, no-newline-at-EOF, renames, binary);
   dock width clamp and persistence; tab-label collapse threshold; the
@@ -817,12 +927,21 @@ location, body, and the review state that already comes from `HookRun.verdict`.
 4. **Path search.** A client-side filter over the loaded tree is a visibly
    partial answer at 1,284 files. Does Files need a `workspace/search` frame in
    M1, or can it wait?
-5. **Tasks scope.** Per _agent_ or per open _session_? The design implies
-   session and the daemon's leases are per ACP session, so session is the cheap
-   answer — confirm it is the useful one.
+5. ~~**Tasks scope.**~~ Settled: per ACP session. `sdkLease` is keyed by
+   `sdkLeaseKey(agentId, acpSessionId)` and the only per-agent aggregate is the
+   `agentHasLiveSdkWork` boolean, so `task/list` requires a `sessionId`.
 6. **PR tab visibility.** Hide entirely for non-PR sessions, or show an empty
    state? Hiding keeps the dock honest but makes the tab strip change shape
    between sessions.
 7. **Write authorization.** Committing as the agent and resolving GitHub threads
    from the console are new classes of action. Does workspace-write access plus
    the existing token clamp cover them, or do they need their own permission?
+8. **Per-task cancel.** Blocked upstream, not by this plan (§3.5). It needs either
+   a task-addressed cancel in ACP or a Claude adapter `_claude/*` kill-by-id
+   request; until one exists, the honest control is the composer's turn-scoped
+   stop. Revisit when the adapter grows one.
+9. **Task history depth.** Settled tasks are retained per lease, capped at 20, and
+   are erased with the lease on TTL-close, host reclaim and retention GC — so the
+   panel cannot show what a reclaimed host was doing. Durable task history would
+   mean persisting model-authored strings, which body-locality puts on the daemon,
+   not the CP. Worth revisiting only if operators actually ask for it.

--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -396,7 +396,7 @@ SessionsPanel.tsx      the ex-SessionRail row / pin / filter body, re-hosted
 FilesPanel.tsx         narrow single-column tree over WorkspaceFiles' read model
 GitPanel.tsx           status + numstat + staging + commit box + log
 PullRequestPanel.tsx   the /sessions/:id/pull-request projection + Auto-fix / auto-merge actions
-TasksPanel.tsx         task list (read-only — §3.5); polls only while visible and something runs
+TasksPanel.tsx         task list (read-only — §3.5); polls while visible, backed off when idle
 ```
 
 and `packages/web/src/components/console/viewer/`:
@@ -807,16 +807,24 @@ is not a checkout:
   is checked out into, which is what the CP route says too. What it does need is
   the CANONICAL session id the lease is keyed by, so a playground session the
   daemon has not created yet gets no tab rather than a 404 notice.
-- **Polling is gated on visible-AND-running, plus one read on the tab's own
-  activation edge.** A settled list has no transition left for a read to reveal,
-  and a hidden panel is a request nobody is looking at — but the panel is mounted
-  from the moment the session page opens, so without the activation read a tab
-  opened ten minutes later would draw a ten-minute-old list and no timer would
-  ever correct it (nothing was running when it was read). Elapsed ticks
-  client-side from `startedAt`, so the 1s redraw costs no request. The
-  consequence, accepted: the tab's running badge is only as fresh as the last read
-  while the tab is closed — exactly what the Git tab's changed-count badge already
-  is.
+- **Polling is gated on VISIBILITY alone, backed off when idle, plus one read on
+  the tab's own activation edge.** Visibility is the whole gate because a hidden
+  panel is a request nobody is looking at, while a visible one always has
+  something left to discover. The first version also required a running task, on
+  the reasoning that a settled list has no transition left to reveal — that was
+  wrong about what the panel watches. It watches a **session**, not the rows on
+  screen, and a session starts new background tasks: most directly when the reader
+  leaves this tab open and sends another prompt from the composer beside it.
+  Nothing in that path bumps the panel's revision, so an idle panel that stopped
+  polling never observed the `0 → running` edge and the new task stayed invisible
+  until a manual refresh. Found in review of #854. The idle cadence is backed off
+  (20s vs 5s) rather than equal, because an idle session usually stays idle. The
+  activation read stays for a different reason: the panel is mounted from the
+  moment the session page opens, so a tab opened ten minutes later would otherwise
+  draw a ten-minute-old list until the next interval. Elapsed ticks client-side
+  from `startedAt`, so the 1s redraw costs no request. The consequence, accepted:
+  the tab's running badge is only as fresh as the last read while the tab is
+  closed — exactly what the Git tab's changed-count badge already is.
 
 Known M4 follow-ups, none of which change what the code does today:
 

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -27,6 +27,7 @@ import {
   MAX_WORKSPACE_STAGE_PATHS,
   MAX_WORKSPACE_STAGE_PATH_BYTES,
   WorkspaceGitWriteReason,
+  TaskState,
   MAX_GIT_REPO_LENGTH,
   MAX_ENVIRONMENT_VALUE_LENGTH,
   normalizeGitHubSkillSource,
@@ -3075,6 +3076,38 @@ export const WorkspaceGitMessageResultDto = z.object({
   detail: z.string().nullable() // human explanation of a refusal
 })
 
+// ── agent background tasks (projected live from the owning daemon's lease; nothing stored) ──
+/** `GET /agents/:id/tasks` query. `sessionId` is REQUIRED, unlike every workspace read: the
+ *  daemon's background-task lease is keyed per (agent, ACP session) and there is no per-agent
+ *  aggregate but a boolean, so an unscoped list would have nothing to answer with. */
+export const AgentTasksQueryDto = z.object({
+  sessionId: z.string().min(1) // ACP session id (== the CP session row's id)
+})
+
+/** One background task of one ACP session. `state` is the daemon's closed vocabulary: no
+ *  `queued` (the lifecycle feed's only start edge is `task_started`), and `done` means
+ *  "settled with no reported failure" because most settle edges carry no status at all. */
+export const AgentTaskDto = z.object({
+  id: z.string(), // runtime-local task id
+  description: z.string().nullable(), // null ⇒ the runtime named none
+  state: TaskState,
+  subagent: z.boolean(), // the runtime's own internal Task invocation — carried, filtered at render
+  startedAt: z.string(), // RFC3339
+  endedAt: z.string().nullable(), // RFC3339; null ⇒ still running
+  detail: z.string().nullable() // the terminal status the runtime reported, when it named one
+})
+
+/** `GET /agents/:id/tasks` — live tasks first, then the daemon's bounded settled history.
+ *  `tracked:false` means the owning daemon holds no lease for this session (a non-Claude
+ *  runtime, an adapter without the lifecycle extension, or nothing emitted yet), which is a
+ *  different statement from "this session has no background tasks". */
+export const AgentTasksDto = z.object({
+  sessionId: z.string(),
+  tracked: z.boolean(),
+  tasks: z.array(AgentTaskDto),
+  truncated: z.boolean() // true ⇒ the daemon held more tasks than this page carries
+})
+
 // ── usage dashboard (aggregated from the persisted per-session usage store) ──
 export const UsageRange = z.enum(['d1', 'd7', 'd30', 'd90'])
 export const UsageQueryDto = z.object({
@@ -3198,4 +3231,5 @@ export type WorkspaceGitPullDtoT = z.infer<typeof WorkspaceGitPullDto>
 export type WorkspaceGitCommitResultDtoT = z.infer<typeof WorkspaceGitCommitResultDto>
 export type WorkspaceGitPushResultDtoT = z.infer<typeof WorkspaceGitPushResultDto>
 export type WorkspaceGitMessageResultDtoT = z.infer<typeof WorkspaceGitMessageResultDto>
+export type AgentTasksDtoT = z.infer<typeof AgentTasksDto>
 export type ErrorDtoT = z.infer<typeof ErrorDto>

--- a/packages/control-plane/src/http/routes/agents.test.ts
+++ b/packages/control-plane/src/http/routes/agents.test.ts
@@ -22,9 +22,12 @@ import {
   toWorkspaceGitCommitDto,
   toWorkspaceGitPushDto,
   toWorkspaceGitMessageDto,
+  toAgentTasksDto,
   workspaceGitConfigOf,
   workspaceErrorCode,
   workspaceFailure,
+  taskErrorCode,
+  taskFailure,
   toDreamDto,
   toDreamListDto,
   toDreamFilesDto,
@@ -695,5 +698,132 @@ describe('toDreamListDto / toDreamFilesDto / toDreamFileDto', () => {
         truncated: true
       })
     ).toMatchObject({ exists: true, content: '- uses tabs', nextOffset: 11, truncated: true })
+  })
+})
+
+describe('toAgentTasksDto', () => {
+  it('keeps the daemon’s order and null-coalesces every optional a running task lacks', () => {
+    expect(
+      toAgentTasksDto({
+        agentId: 'a1',
+        sessionId: 'acp-1',
+        tracked: true,
+        tasks: [
+          { id: 't2', state: 'running', subagent: false, startedAt: '2026-08-10T10:00:02Z' },
+          {
+            id: 't1',
+            description: 'run the integration suite',
+            state: 'failed',
+            subagent: false,
+            startedAt: '2026-08-10T10:00:00Z',
+            endedAt: '2026-08-10T10:04:00Z',
+            detail: 'failed'
+          },
+          {
+            id: 't0',
+            state: 'done',
+            subagent: true,
+            startedAt: '2026-08-10T09:00:00Z',
+            endedAt: '2026-08-10T09:01:00Z'
+          }
+        ],
+        truncated: true
+      })
+    ).toEqual({
+      sessionId: 'acp-1',
+      tracked: true,
+      tasks: [
+        {
+          id: 't2',
+          description: null,
+          state: 'running',
+          subagent: false,
+          startedAt: '2026-08-10T10:00:02Z',
+          endedAt: null,
+          detail: null
+        },
+        {
+          id: 't1',
+          description: 'run the integration suite',
+          state: 'failed',
+          subagent: false,
+          startedAt: '2026-08-10T10:00:00Z',
+          endedAt: '2026-08-10T10:04:00Z',
+          detail: 'failed'
+        },
+        {
+          id: 't0',
+          description: null,
+          state: 'done',
+          subagent: true,
+          startedAt: '2026-08-10T09:00:00Z',
+          endedAt: '2026-08-10T09:01:00Z',
+          detail: null
+        }
+      ],
+      truncated: true
+    })
+  })
+
+  it('keeps an untracked session apart from a tracked one holding no tasks', () => {
+    const untracked = toAgentTasksDto({
+      agentId: 'a1',
+      sessionId: 'acp-9',
+      tracked: false,
+      tasks: [],
+      truncated: false
+    })
+    expect(untracked).toEqual({ sessionId: 'acp-9', tracked: false, tasks: [], truncated: false })
+    expect(
+      toAgentTasksDto({ agentId: 'a1', sessionId: 'acp-9', tracked: true, tasks: [], truncated: false }).tracked
+    ).toBe(true)
+  })
+})
+
+describe('taskErrorCode / taskFailure', () => {
+  const badPayload = (reason?: string): ProtocolError =>
+    new ProtocolError('BAD_PAYLOAD', 'task/list failed: unknown agent "a1"', {
+      ...(reason ? { details: { reason } } : {})
+    })
+
+  it('screaming-snakes the daemon reason under its OWN prefix and ignores a foreign vocabulary', () => {
+    expect(taskErrorCode(badPayload('unknown-agent'))).toBe('TASK_UNKNOWN_AGENT')
+    // A workspace-only reason is not a task reason: the two enums move independently.
+    expect(taskErrorCode(badPayload('path-escape'))).toBeNull()
+    expect(taskErrorCode(badPayload())).toBeNull()
+  })
+
+  it('answers an agent its daemon does not hold with 404 + code, not the offline 503', () => {
+    expect(taskFailure(badPayload('unknown-agent'))).toEqual({
+      status: 404,
+      error: 'Not Found',
+      message: 'agent not found on its daemon',
+      code: 'TASK_UNKNOWN_AGENT'
+    })
+  })
+
+  it('keeps the 503 for a reasonless rejection, an offline daemon, and rethrows a CP bug', () => {
+    expect(taskFailure(badPayload())).toEqual({
+      status: 503,
+      error: 'Service Unavailable',
+      message: 'daemon rejected the request: task/list failed: unknown agent "a1"'
+    })
+    expect(taskFailure(new Error('connection closed'))).toEqual({
+      status: 503,
+      error: 'Service Unavailable',
+      message: 'owning daemon is offline'
+    })
+    expect(taskFailure(new TypeError('rep.tasks is not iterable'))).toBeNull()
+  })
+
+  it('does not invent a 409: the read mutates nothing, so a CONFLICT is not a task answer', () => {
+    const conflict = new ProtocolError('CONFLICT', 'the agent is working in this workspace', {
+      details: { reason: 'unknown-agent' }
+    })
+    expect(taskFailure(conflict)).toEqual({
+      status: 503,
+      error: 'Service Unavailable',
+      message: 'daemon rejected the request: the agent is working in this workspace'
+    })
   })
 })

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -17,6 +17,7 @@ import type {
   WorkspaceGitCommitResult,
   WorkspaceGitPushResult,
   WorkspaceGitMessageResult,
+  TaskList,
   MemoryReadContent,
   MemoryListPage,
   MemoryHistoryPage,
@@ -41,7 +42,9 @@ import {
   WORKSPACE_GIT_MESSAGE_FEATURE,
   WORKSPACE_GIT_REVIEW_FEATURE,
   WORKSPACE_GIT_WRITE_FEATURE,
+  TASK_LIST_FEATURE,
   WorkspaceErrorReason,
+  TaskErrorReason,
   gitRepoLabel,
   normalizeGitUrl
 } from '@agentconnect.md/protocol'
@@ -118,6 +121,8 @@ import {
   WorkspaceGitCommitResultDto,
   WorkspaceGitPushResultDto,
   WorkspaceGitMessageResultDto,
+  AgentTasksQueryDto,
+  AgentTasksDto,
   AgentMemoryDto,
   MemoryFilesDto,
   MemoryFilesQueryDto,
@@ -161,6 +166,7 @@ import {
   type WorkspaceGitCommitResultDtoT,
   type WorkspaceGitPushResultDtoT,
   type WorkspaceGitMessageResultDtoT,
+  type AgentTasksDtoT,
   type AgentMemoryDtoT,
   type MemoryFilesDtoT,
   type MemoryHistoryPageDtoT,
@@ -569,6 +575,27 @@ export function toWorkspaceGitMessageDto(rep: WorkspaceGitMessageResult): Worksp
   return { ok: rep.ok, message: rep.message ?? null, detail: rep.detail ?? null }
 }
 
+/** Wire REP → HTTP body for one ACP session's background tasks. The CP proxies the daemon's
+ *  order (live first, then its bounded settled history) and stores nothing; `tracked:false`
+ *  stays data so the console can say "this runtime reports no tasks" rather than "none are
+ *  running". Absent optionals become explicit nulls for the response schema. */
+export function toAgentTasksDto(rep: TaskList): AgentTasksDtoT {
+  return {
+    sessionId: rep.sessionId,
+    tracked: rep.tracked,
+    tasks: rep.tasks.map((task) => ({
+      id: task.id,
+      description: task.description ?? null,
+      state: task.state,
+      subagent: task.subagent,
+      startedAt: task.startedAt,
+      endedAt: task.endedAt ?? null,
+      detail: task.detail ?? null
+    })),
+    truncated: rep.truncated
+  }
+}
+
 /** Map a daemon-edge failure to a 503 message, or null to rethrow. Covers: no
  *  live connection, the socket dropping mid-flight ('connection closed'), and a
  *  daemon-side `error` frame (ProtocolError — e.g. path containment
@@ -645,6 +672,42 @@ function sendWorkspaceMutationFailure(reply: FastifyReply, err: unknown): boolea
   return false
 }
 
+/** The daemon's task `reason` as the HTTP `code` the console branches on; null when it named
+ *  none (older daemon), so the caller keeps its generic answer. Kept separate from
+ *  {@link workspaceErrorCode} because the two enums are independent — a reason added to one
+ *  must not silently start being emitted under the other's prefix. */
+export function taskErrorCode(err: ProtocolError): string | null {
+  const reason = TaskErrorReason.safeParse(err.details?.reason)
+  return reason.success ? `TASK_${reason.data.toUpperCase().replaceAll('-', '_')}` : null
+}
+
+/** Status a console can act on instead of the 503 that reads as an offline daemon: an agent the
+ *  daemon does not hold is 404 (stale placement), and there is no 409 arm because the read
+ *  mutates nothing. Reasonless ⇒ {@link daemonEdgeFailure}; null ⇒ rethrow. */
+export function taskFailure(err: unknown): { status: 404 | 503; error: string; message: string; code?: string } | null {
+  if (err instanceof ProtocolError && err.code === 'BAD_PAYLOAD') {
+    const code = taskErrorCode(err)
+    if (code === 'TASK_UNKNOWN_AGENT') {
+      return { status: 404, error: 'Not Found', message: 'agent not found on its daemon', code }
+    }
+  }
+  const unavailable = daemonEdgeFailure(err)
+  return unavailable === null ? null : { status: 503, error: 'Service Unavailable', message: unavailable }
+}
+
+/** Send {@link taskFailure}'s answer; false ⇒ not a daemon-edge failure, rethrow. */
+function sendTaskFailure(reply: FastifyReply, err: unknown): boolean {
+  const failure = taskFailure(err)
+  if (!failure) return false
+  void reply.code(failure.status).send({
+    error: failure.error,
+    statusCode: failure.status,
+    message: failure.message,
+    ...(failure.code ? { code: failure.code } : {})
+  })
+  return true
+}
+
 function memoryAdminFailure(
   err: unknown
 ): { status: 400 | 409 | 503; error: 'Bad Request' | 'Conflict' | 'Service Unavailable'; message: string } | null {
@@ -675,22 +738,25 @@ export function agentRoutes(deps: HttpDeps) {
     // caller must pass both the owning-agent gate above and the session's own
     // private/external visibility rule before its daemon-local files are read.
     const sessionAccess = makeSessionAccessResolver(deps)
+    // The session half of that gate, shared with the tasks read: the row must be THIS agent's,
+    // still hold its content, and pass the session's own private/external visibility rule.
+    // Isolation is deliberately not part of it — that is a worktree question, and a session's
+    // background tasks exist whatever checkout it runs in. null ⇒ refuse as absent.
+    const visibleAgentSession = async (req: FastifyRequest, agentId: string, sessionId: string) => {
+      const session = await deps.repos.session.get(orgOf(req), SessionId(sessionId))
+      if (!session || session.agentId !== agentId || session.contentPurgedAt) return null
+      const access = await sessionAccess.forSessions(req, [session])
+      return canViewSession(session, ctxOf(req), access.identitySet, access.externalAccess) ? session : null
+    }
     const canReadWorkspaceScope = async (
       req: FastifyRequest,
       agentId: string,
       sessionId: string | undefined
     ): Promise<boolean> => {
       if (!sessionId) return true
-      const session = await deps.repos.session.get(orgOf(req), SessionId(sessionId))
-      if (
-        !session ||
-        session.agentId !== agentId ||
-        session.workspaceIsolation !== 'session' ||
-        session.contentPurgedAt
-      )
-        return false
-      const access = await sessionAccess.forSessions(req, [session])
-      return canViewSession(session, ctxOf(req), access.identitySet, access.externalAccess)
+      const session = await visibleAgentSession(req, agentId, sessionId)
+      // A shared checkout has no per-session worktree, so the daemon would answer BAD_PAYLOAD.
+      return session?.workspaceIsolation === 'session'
     }
 
     const requireSessionWorkspaceRead = async (
@@ -752,6 +818,17 @@ export function agentRoutes(deps: HttpDeps) {
         daemonId,
         WORKSPACE_GIT_MESSAGE_FEATURE,
         'this agent version cannot draft commit messages; upgrade its daemon'
+      )
+
+    // Separate from every git gate: a daemon can serve the Tasks panel without serving git
+    // review, and the console hides exactly the tabs a given daemon cannot answer.
+    const requireTasks = (reply: FastifyReply, orgId: OrgId, daemonId: DaemonId): Promise<boolean> =>
+      requireDaemonFeature(
+        reply,
+        orgId,
+        daemonId,
+        TASK_LIST_FEATURE,
+        'this agent version does not report background tasks; upgrade its daemon'
       )
 
     const resolvePolicyAgentIds = async (
@@ -4383,6 +4460,51 @@ export function agentRoutes(deps: HttpDeps) {
           return toWorkspaceGitMessageDto(rep)
         } catch (err) {
           if (sendWorkspaceMutationFailure(reply, err)) return
+          throw err
+        }
+      }
+    )
+
+    // One ACP session's background tasks, projected live from the owning daemon's in-memory
+    // lease. A READ: there is no cancel counterpart, because no ACP primitive can address one
+    // background task (webchat-side-panels.md §3.5). The CP stores nothing.
+    r.get(
+      '/agents/:id/tasks',
+      {
+        schema: {
+          tags: [Tag.Agents],
+          summary: 'List a session’s background tasks',
+          description:
+            'Proxy the background tasks of ONE of the agent’s ACP sessions live from the owning daemon, live ones first and then the daemon’s bounded settled history. sessionId is REQUIRED, unlike the workspace reads: the daemon tracks tasks per (agent, ACP session) and has no per-agent aggregate to answer with. Both the session’s own visibility rule and the agent’s apply, so a session the caller cannot see reads as absent (404) — but the session’s workspace isolation does not, because tasks are not a checkout. tracked:false means the daemon holds no tracking for that session (a runtime that reports no task lifecycle, or one that has not yet), which is data and different from an empty list; a settled task stays listed for a bounded while with its outcome. There is no cancel counterpart: no agent-protocol primitive can address a single background task, so the escape hatch is cancelling the turn. 409 when the daemon is too old to report tasks, 503 when the agent is unplaced or its daemon is offline. The control plane persists none of this.',
+          operationId: 'listAgentSessionTasks',
+          params: IdParam,
+          querystring: AgentTasksQueryDto,
+          response: { 200: AgentTasksDto, 400: ErrorDto, 404: ErrorDto, 409: ErrorDto, 503: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        // Route through getOrgAgent (org boundary + canView) — a bare repo.get here would leak
+        // a restricted / cross-org agent's work, and task descriptions are model-authored text.
+        const agent = await getOrgAgent(req, req.params.id)
+        if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+        if (!(await visibleAgentSession(req, agent.id, req.query.sessionId))) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
+        }
+        if (!agent.daemonId) {
+          return reply
+            .code(503)
+            .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
+        }
+        if (!(await requireTasks(reply, agent.orgId, agent.daemonId))) return
+
+        try {
+          const rep = await deps.control.taskList(agent.daemonId, {
+            agentId: agent.id,
+            sessionId: req.query.sessionId
+          })
+          return toAgentTasksDto(rep)
+        } catch (err) {
+          if (sendTaskFailure(reply, err)) return
           throw err
         }
       }

--- a/packages/control-plane/src/orchestrator/outbound.task-list.test.ts
+++ b/packages/control-plane/src/orchestrator/outbound.task-list.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The console's background-task read over the WS edge (unit, no socket): it must issue its own
+ * frame type, stamp the live connection's fencing epoch, keep the DEFAULT request budget (the
+ * daemon answers from memory, so no in-flight pass can be duplicated by a retransmit), and
+ * refuse to invent an answer when the daemon is not connected.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type { LaunchRepo } from '../persistence/ports.js'
+import { ConnectionRegistry, type ConnChannel, type DaemonConnState } from '../ws/registry.js'
+import { ControlSender, NoConnection } from './outbound.js'
+
+const DAEMON = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const OFFLINE = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+/** A sender over one READY connection at epoch 7, recording every issued REQ. */
+function senderWith(): {
+  sender: ControlSender
+  sent: Array<{ type: string; payload: unknown; ext: unknown; budget: unknown }>
+} {
+  const sent: Array<{ type: string; payload: unknown; ext: unknown; budget: unknown }> = []
+  const request = vi.fn(async (type: string, payload: unknown, ext?: unknown, budget?: unknown) => {
+    sent.push({ type, payload, ext, budget })
+    return {}
+  })
+  const conn = { daemonId: DAEMON, request, send: vi.fn(), close: vi.fn() } as unknown as ConnChannel
+  const registry = new ConnectionRegistry()
+  const state: DaemonConnState = {
+    daemonId: DAEMON,
+    conn,
+    sessionEpoch: 7,
+    state: 'READY',
+    maxAgents: 2,
+    load: { cpu: 0, mem: 0, agents: 1 },
+    health: 'ok',
+    lastBeatAt: 0,
+    reachable: true,
+    assignments: new Set(),
+    launches: new Map()
+  }
+  registry.add(state)
+  return { sender: new ControlSender(registry, {} as LaunchRepo), sent }
+}
+
+describe('ControlSender.taskList', () => {
+  it('issues task/list under the connection’s epoch fence on the default budget', async () => {
+    const { sender, sent } = senderWith()
+
+    await sender.taskList(DAEMON, { agentId: 'a1', sessionId: 'acp-1' })
+
+    expect(sent).toEqual([
+      { type: 'task/list', payload: { agentId: 'a1', sessionId: 'acp-1' }, ext: { epoch: 7 }, budget: undefined }
+    ])
+  })
+
+  it('throws NoConnection for a daemon that is not connected — nothing reaches a socket', async () => {
+    const { sender, sent } = senderWith()
+
+    await expect(sender.taskList(OFFLINE, { agentId: 'a1', sessionId: 'acp-1' })).rejects.toBeInstanceOf(NoConnection)
+    expect(sent).toEqual([])
+  })
+})

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -63,6 +63,8 @@ import type {
   WorkspaceGitPushResult,
   WorkspaceGitMessageReq,
   WorkspaceGitMessageResult,
+  TaskListReq,
+  TaskList,
   MemoryChannelsReq,
   MemoryChannelsPage,
   MemoryListReq,
@@ -877,5 +879,19 @@ export class ControlSender {
       { epoch: c.sessionEpoch },
       { ackTimeoutMs: WORKSPACE_GIT_MESSAGE_BUDGET_MS, maxTries: 1 }
     )
+  }
+
+  /**
+   * List the background tasks of ONE ACP session from the owning daemon's in-memory lease
+   * (REQ → `task/list/result`). Read-only, and a pure projection on the daemon side, so it
+   * cannot disturb a reclaim decision. The CP proxies the snapshot and stores none of it —
+   * descriptions are model-authored (body-locality, webchat-side-panels.md §2). A session
+   * the daemon holds no lease for (`tracked:false`) and a lease with nothing in it are both
+   * DATA; only an unknown agent is an error. Default request budget: the daemon answers
+   * from memory, so there is no in-flight pass a retransmit could duplicate.
+   */
+  async taskList(daemonId: string, req: TaskListReq): Promise<TaskList> {
+    const c = this.must(daemonId)
+    return c.conn.request<TaskList>('task/list', req, { epoch: c.sessionEpoch })
   }
 }

--- a/packages/control-plane/test/integration/agents.tasks.route.test.ts
+++ b/packages/control-plane/test/integration/agents.tasks.route.test.ts
@@ -1,0 +1,314 @@
+/**
+ * `GET /agents/:id/tasks` — the Tasks panel's read of ONE ACP session's background tasks.
+ * The CP authorizes the agent, the SESSION (not its worktree) and the daemon's capability,
+ * proxies the daemon's snapshot, and persists nothing. Every degraded answer the daemon can
+ * give is data: an untracked session, a tracked session with nothing running, a settled task.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { TASK_LIST_FEATURE, WORKSPACE_GIT_REVIEW_FEATURE } from '@agentconnect.md/protocol'
+import type { TaskList, TaskListReq } from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { seedAgent, seedDaemon, seedSessionMeta } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import type { ControlSender } from '../../src/orchestrator/outbound.js'
+import { NoConnection } from '../../src/orchestrator/outbound.js'
+import type { DaemonLiveness } from '../../src/ports.js'
+import { ProtocolError } from '../../src/domain/errors.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
+import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
+import type { OrgMemberRole } from '../../src/persistence/ports.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const DAEMON = 'd4d4d4d4-dddd-4ddd-8ddd-dddddddddddd'
+const AGENT = 'a4a4a4a4-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TASK_CAPABILITIES = {
+  platforms: ['slack'],
+  runtimes: ['claude'],
+  acp: true,
+  features: [TASK_LIST_FEATURE]
+}
+const LIVE: DaemonLiveness = {
+  get: (id) => (id === DAEMON ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined)
+}
+
+const opened: HttpApp[] = []
+afterEach(async () => {
+  await Promise.all(opened.splice(0).map((app) => app.close()))
+})
+
+/** The one read seam under test, recording every forwarded REQ. */
+class TaskSpy {
+  calls: Array<{ daemonId: string; req: TaskListReq }> = []
+  /** Set to answer the next read as an untracked session (no lease on the daemon). */
+  untracked = false
+  /** Set to make the next read fail the way a daemon `error` frame would. */
+  failure: Error | null = null
+
+  async taskList(daemonId: string, req: TaskListReq): Promise<TaskList> {
+    this.calls.push({ daemonId, req })
+    if (this.failure) throw this.failure
+    if (this.untracked) {
+      return { agentId: req.agentId, sessionId: req.sessionId, tracked: false, tasks: [], truncated: false }
+    }
+    return {
+      agentId: req.agentId,
+      sessionId: req.sessionId,
+      tracked: true,
+      tasks: [
+        { id: 't2', state: 'running', subagent: false, startedAt: '2026-08-10T10:00:02Z' },
+        {
+          id: 't1',
+          description: 'run the integration suite',
+          state: 'failed',
+          subagent: true,
+          startedAt: '2026-08-10T10:00:00Z',
+          endedAt: '2026-08-10T10:04:00Z',
+          detail: 'failed'
+        }
+      ],
+      truncated: true
+    }
+  }
+}
+
+function app(control: TaskSpy, userId?: string): HttpApp {
+  const running = buildHttpApp(
+    prisma,
+    userId ? { DEFAULT_OWNER_ID: userId } : undefined,
+    LIVE,
+    control as unknown as ControlSender
+  )
+  opened.push(running)
+  return running
+}
+
+async function makeUser(sub: string, role: OrgMemberRole): Promise<string> {
+  const users = new PgUserRepo(prisma)
+  const email = `${sub}@acme.dev`
+  const { userId } = await users.provisionOidcUser({ oidcSubject: sub, email, emailVerified: true })
+  await users.addMemberByEmail(DEFAULT_ORG_ID, email, role)
+  return userId
+}
+
+/** A task-capable daemon holding one agent. */
+async function seedTaskAgent(features: string[] = TASK_CAPABILITIES.features): Promise<void> {
+  await seedDaemon(prisma, DAEMON, { capabilities: { ...TASK_CAPABILITIES, features } })
+  await seedAgent(prisma, AGENT, { daemonId: DAEMON, gitRepo: 'https://github.com/acme/repo' })
+}
+
+/** An org-visible session of AGENT. Left at the default SHARED workspace isolation on
+ *  purpose: a shared checkout still runs background tasks, so the tasks read must not
+ *  inherit the worktree gate. */
+async function seedSession(agentId = AGENT): Promise<string> {
+  const id = randomUUID()
+  await seedSessionMeta(prisma, id, agentId, { daemonId: DAEMON })
+  return id
+}
+
+describe('GET /agents/:id/tasks', () => {
+  it('proxies a SHARED-workspace session and projects the daemon’s order and nulls', async () => {
+    await seedTaskAgent()
+    const session = await seedSession()
+    const control = new TaskSpy()
+
+    const res = await app(control).app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${AGENT}/tasks?sessionId=${session}`
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({
+      sessionId: session,
+      tracked: true,
+      tasks: [
+        {
+          id: 't2',
+          description: null,
+          state: 'running',
+          subagent: false,
+          startedAt: '2026-08-10T10:00:02Z',
+          endedAt: null,
+          detail: null
+        },
+        {
+          id: 't1',
+          description: 'run the integration suite',
+          state: 'failed',
+          subagent: true,
+          startedAt: '2026-08-10T10:00:00Z',
+          endedAt: '2026-08-10T10:04:00Z',
+          detail: 'failed'
+        }
+      ],
+      truncated: true
+    })
+    expect(control.calls).toEqual([{ daemonId: DAEMON, req: { agentId: AGENT, sessionId: session } }])
+  })
+
+  it('answers an untracked session with data, not an error — and refuses an unscoped read', async () => {
+    await seedTaskAgent()
+    const session = await seedSession()
+    const control = new TaskSpy()
+    control.untracked = true
+    const running = app(control)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/tasks?sessionId=${session}` })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ sessionId: session, tracked: false, tasks: [], truncated: false })
+
+    // The lease is per (agent, ACP session) and there is no per-agent aggregate, so an
+    // unscoped list is refused by the schema rather than answered with a guess.
+    const unscoped = await running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/tasks` })
+    expect(unscoped.statusCode).toBe(400)
+    const blank = await running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/tasks?sessionId=` })
+    expect(blank.statusCode).toBe(400)
+    expect(control.calls).toHaveLength(1)
+  })
+
+  it('reads a viewer’s request too — listing tasks is a read, so no write gate applies', async () => {
+    await seedTaskAgent()
+    const session = await seedSession()
+    const viewer = await makeUser(`tasks-viewer-${randomUUID()}`, 'viewer')
+    const control = new TaskSpy()
+
+    const res = await app(control, viewer).app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${AGENT}/tasks?sessionId=${session}`
+    })
+    expect(res.statusCode).toBe(200)
+    expect(control.calls).toHaveLength(1)
+  })
+
+  it('refuses every session the gate does not authorize, before any daemon I/O', async () => {
+    await seedTaskAgent()
+    const otherAgent = randomUUID()
+    await seedAgent(prisma, otherAgent, { daemonId: DAEMON })
+    const foreign = await seedSession(otherAgent) // a real session, but not this agent's
+    const purged = await seedSession()
+    await prisma.sessionMeta.update({
+      where: { id: purged },
+      data: { contentPurgedAt: new Date(), contentPurgedReason: 'retention' }
+    })
+    const control = new TaskSpy()
+    const running = app(control)
+
+    for (const sessionId of [foreign, purged, randomUUID()]) {
+      const res = await running.app.inject({
+        method: 'GET',
+        url: `${ORG}/agents/${AGENT}/tasks?sessionId=${sessionId}`
+      })
+      expect(res.statusCode).toBe(404)
+      expect(res.json()).toMatchObject({ message: 'session not found' })
+    }
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('hides another member’s private session behind the same 404', async () => {
+    await seedTaskAgent()
+    const mine = await makeUser(`tasks-mine-${randomUUID()}`, 'collaborator')
+    const theirs = await makeUser(`tasks-theirs-${randomUUID()}`, 'collaborator')
+    const session = randomUUID()
+    await seedSessionMeta(prisma, session, AGENT, {
+      daemonId: DAEMON,
+      visibility: 'private',
+      ownerIdentity: `user:${theirs}`
+    })
+    const control = new TaskSpy()
+
+    const denied = await app(control, mine).app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${AGENT}/tasks?sessionId=${session}`
+    })
+    expect(denied.statusCode).toBe(404)
+    expect(control.calls).toHaveLength(0)
+
+    const owner = await app(control, theirs).app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${AGENT}/tasks?sessionId=${session}`
+    })
+    expect(owner.statusCode).toBe(200)
+    expect(control.calls).toHaveLength(1)
+  })
+
+  it('reads a restricted agent and a foreign org’s agent as absent', async () => {
+    const other = await makeUser(`tasks-other-${randomUUID()}`, 'collaborator')
+    await seedDaemon(prisma, DAEMON, { capabilities: TASK_CAPABILITIES })
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON, visibility: 'restricted', sharedWith: [DEFAULT_OWNER_ID] })
+    const session = await seedSession()
+    const foreignOrg = `org-foreign-${randomUUID().slice(0, 8)}`
+    const foreignAgent = randomUUID()
+    await prisma.org.create({ data: { id: foreignOrg, slug: foreignOrg } })
+    await prisma.agent.create({
+      data: { id: foreignAgent, orgId: foreignOrg, name: 'foreign-bot', runtime: 'claude', daemonId: null }
+    })
+    const control = new TaskSpy()
+
+    const restricted = await app(control, other).app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${AGENT}/tasks?sessionId=${session}`
+    })
+    expect(restricted.statusCode).toBe(404)
+    expect(restricted.json()).toMatchObject({ message: 'agent not found' })
+
+    const crossOrg = await app(control).app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${foreignAgent}/tasks?sessionId=${session}`
+    })
+    expect(crossOrg.statusCode).toBe(404)
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('answers an unplaced agent 503 without touching the wire', async () => {
+    await seedDaemon(prisma, DAEMON, { capabilities: TASK_CAPABILITIES })
+    await seedAgent(prisma, AGENT) // no daemonId
+    const session = await seedSession()
+    const control = new TaskSpy()
+
+    const res = await app(control).app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${AGENT}/tasks?sessionId=${session}`
+    })
+    expect(res.statusCode).toBe(503)
+    expect(res.json()).toMatchObject({ message: 'agent has no live daemon' })
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('refuses a daemon that does not report tasks, rather than sending a frame it would drop', async () => {
+    await seedTaskAgent([WORKSPACE_GIT_REVIEW_FEATURE]) // git-capable, task-blind
+    const session = await seedSession()
+    const control = new TaskSpy()
+
+    const res = await app(control).app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${AGENT}/tasks?sessionId=${session}`
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.json()).toMatchObject({ code: 'DAEMON_FEATURE_MISSING' })
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('maps a daemon rejection to the status its reason names, and keeps 503 otherwise', async () => {
+    await seedTaskAgent()
+    const session = await seedSession()
+    const control = new TaskSpy()
+    const running = app(control)
+    const read = () => running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/tasks?sessionId=${session}` })
+
+    control.failure = new ProtocolError('BAD_PAYLOAD', 'task/list failed: unknown agent "a4"', {
+      details: { reason: 'unknown-agent' }
+    })
+    const unknown = await read()
+    expect(unknown.statusCode).toBe(404)
+    expect(unknown.json()).toMatchObject({ message: 'agent not found on its daemon', code: 'TASK_UNKNOWN_AGENT' })
+
+    // An older daemon names no reason, so the read keeps the honest "may be offline" 503
+    // instead of the CP inventing a status from a prose message.
+    control.failure = new ProtocolError('BAD_PAYLOAD', 'task/list failed')
+    expect((await read()).statusCode).toBe(503)
+
+    control.failure = new NoConnection(DAEMON)
+    const offline = await read()
+    expect(offline.statusCode).toBe(503)
+    expect(offline.json()).toMatchObject({ message: 'owning daemon is offline' })
+  })
+})

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -45,6 +45,7 @@ import type {
   WorkspaceGitCommitReq,
   WorkspaceGitPushReq,
   WorkspaceGitMessageReq,
+  TaskListReq,
   WorkspaceGitMessageResult,
   GitCredRequest,
   GitCredGrant,
@@ -120,6 +121,8 @@ import {
   type MemoryReader
 } from './memory-reader.js'
 import type { WorkspaceGit } from './workspace-git.js'
+import type { TaskReader } from './task-reader.js'
+import { TaskViolationError } from './task-reader.js'
 import type { DreamReader } from './dream-reader.js'
 import type { LocalSkillsReader } from './local-skills-reader.js'
 import { DreamViolationError, DreamStateError } from '../agents/dream-runner.js'
@@ -184,6 +187,8 @@ export interface CpClientDeps {
   workspaceRead: WorkspaceReader
   /** Git status/pull seam over the agents' git-repo workspace dirs (§1/§12). */
   workspaceGit: WorkspaceGit
+  /** Read-only projection of the in-memory background-task lease (§3.5 of webchat-side-panels.md). */
+  taskReader: TaskReader
   /** Read/write seam over the agents' memory dirs (`<agent-root>/memory/`, §1/§12). */
   memoryReader: MemoryReader
   /** Dream-job lifecycle + staged-output review seam (docs/designs/memory-dreaming.md §10). */
@@ -1402,6 +1407,15 @@ export class CpClient {
           .catch((err) => this.workspaceError(frame.id, 'workspace/gitmessage', err))
         return
       }
+      case 'task/list': {
+        // Background tasks of ONE ACP session, projected live from the lease. A session with no
+        // lease and a session with no tasks are both results (`tracked` tells them apart).
+        this.deps.taskReader
+          .list(frame.payload as TaskListReq)
+          .then((result) => this.reply(frame, 'task/list/result', result))
+          .catch((err) => this.taskError(frame.id, 'task/list', err))
+        return
+      }
       case 'memory/channels': {
         this.deps.memoryReader
           .channels(frame.payload as MemoryChannelsReq)
@@ -1620,6 +1634,18 @@ export class CpClient {
       return
     }
     if (err instanceof WorkspaceViolationError) {
+      this.sendError(corr, 'BAD_PAYLOAD', `${op} failed: ${err.message}`, false, { reason: err.reason })
+      return
+    }
+    this.deps.log.warn(`cp: ${op} failed: ${(err as Error)?.message}`)
+    this.sendError(corr, 'INTERNAL', `${op} failed`, false)
+  }
+
+  /** Unknown agent → BAD_PAYLOAD with the machine reason; anything else → INTERNAL with a generic
+   *  message. There is no CONFLICT arm because `task/list` reads in-memory state and mutates
+   *  nothing, so no lifecycle state can make it a legal-but-refused request. */
+  private taskError(corr: string, op: string, err: unknown): void {
+    if (err instanceof TaskViolationError) {
       this.sendError(corr, 'BAD_PAYLOAD', `${op} failed: ${err.message}`, false, { reason: err.reason })
       return
     }

--- a/packages/daemon/src/cp/task-reader.ts
+++ b/packages/daemon/src/cp/task-reader.ts
@@ -1,0 +1,31 @@
+/**
+ * `TaskReader` — the daemon-local seam answering the CP's `task/list` REQ for the console's
+ * Tasks panel. Task ids, descriptions and states live only in the daemon's in-memory
+ * background-task lease (background-task-aware-reclaim.md §7); the CP proxies one snapshot and
+ * never persists it.
+ *
+ * Read-only by construction: there is no cancel counterpart, because no ACP primitive can
+ * address one background task (see `frames/task.ts`). So this seam cannot touch the lease at
+ * all — it projects it, which is also what keeps the panel off the reclaim path.
+ *
+ * Everything except an unknown agent is DATA: a session with no lease answers
+ * `tracked:false`, a lease with nothing in it answers an empty list.
+ */
+import type { TaskErrorReason, TaskList, TaskListReq } from '@agentconnect.md/protocol'
+
+/** Bad-request violation → `BAD_PAYLOAD` on the wire. `reason` rides along in the error frame's
+ *  `details` so the CP can answer with a status the console can branch on rather than the 503
+ *  that reads as an offline daemon. */
+export class TaskViolationError extends Error {
+  readonly reason: TaskErrorReason
+  constructor(message: string, reason: TaskErrorReason) {
+    super(message)
+    this.name = 'TaskViolationError'
+    this.reason = reason
+  }
+}
+
+/** The seam the CP client dispatches `task/list` to. */
+export interface TaskReader {
+  list(req: TaskListReq): Promise<TaskList>
+}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -306,6 +306,10 @@ import {
   SESSION_METADATA_ACK_FEATURE,
   SESSION_VISIBILITY_FEATURE,
   SLACK_SESSION_AUDIENCE_FEATURE,
+  MAX_TASK_DESCRIPTION,
+  MAX_TASK_DETAIL,
+  MAX_TASK_LIST_TASKS,
+  TASK_LIST_FEATURE,
   WORKSPACE_GIT_MESSAGE_FEATURE,
   WORKSPACE_GIT_REVIEW_FEATURE,
   WORKSPACE_GIT_WRITE_FEATURE,
@@ -327,6 +331,7 @@ import {
 import { isNoResponseBody, isNoResponsePrefix } from './session/no-response.js'
 import { createSessionReader } from './cp/session-reader.js'
 import { createWorkspaceReader, WorkspaceConflictError } from './cp/workspace-reader.js'
+import { TaskViolationError } from './cp/task-reader.js'
 import { createMemoryReader } from './cp/memory-reader.js'
 import {
   createMemoryProvider,
@@ -468,7 +473,9 @@ import type {
   WebchatRemoteMcpEntitlement,
   ExternalSessionAudience,
   ExternalSessionOrigin,
-  ChannelAgentsOk
+  ChannelAgentsOk,
+  TaskList,
+  TaskListReq
 } from '@agentconnect.md/protocol'
 
 /** Format an error for logs, surfacing a JSON-RPC/ACP RequestError's `code` and
@@ -883,6 +890,23 @@ function sdkLeaseKey(agentId: string, acpSessionId: string): string {
   return pendingTurnKey(agentId, acpSessionId)
 }
 
+/** One LIVE background task — a member of the lease's liveness set. `startedAt` is when the
+ *  `task_started` edge arrived, which is the only start time the feed offers. */
+interface LiveSdkTask {
+  description?: string
+  isSubagent: boolean
+  startedAt: number
+}
+
+/** One SETTLED background task, retained for the console's `task/list` read. Display history and
+ *  nothing else: it lives in the lease's `settled` array, never in `tasks`, so no reclaim
+ *  decision can see it. `status` is the terminal status a runtime edge reported, when any. */
+interface SettledSdkTask extends LiveSdkTask {
+  id: string
+  endedAt: number
+  status?: string
+}
+
 // Cap on agent→agent hop depth (design §2.4/§4.5) — reject a `messageAgent` whose
 // outgoing hopCount reaches this boundary, so an A↔B wake loop can't run away.
 // send-message-routing-rework.md §4.1 puts a platform `@mention` delivery on this SAME
@@ -943,6 +967,13 @@ const MAX_BG_TASK_WAKE_REARMS = 15
  *  budget is the only backstop against a self-feeding wake loop. Counted over the
  *  lease's life (i.e. until the host is reclaimed), not per turn. */
 const MAX_BG_TASK_WAKES_PER_SESSION = 20
+
+/** How many SETTLED background tasks one lease retains for the console's `task/list` read. The
+ *  daemon keeps no task history anywhere else, so without this a finished task is unshowable;
+ *  with it, a `done`/`failed` row survives until the 21st task settles, the session TTL-closes
+ *  or the host is reclaimed. 20 is a display depth, not a durability promise — the panel is a
+ *  live view, and the retained records are strictly outside the liveness set (see `settled`). */
+const MAX_SETTLED_TASKS_PER_SESSION = 20
 
 /**
  * DAEMON-PRIVATE trusted metadata for an agent-originated delivery. Authoritative
@@ -1793,7 +1824,18 @@ export class Daemon {
     string,
     {
       agentId: string
-      tasks: Map<string, { description?: string; isSubagent: boolean }>
+      /** The LIVENESS set. Membership means "still owed a terminal edge" and is what every
+       *  reclaim decision reads (see the 7 consumers of `tasks.size`/`get`/`delete`). A settled
+       *  task is deleted from here BEFORE any notification, which is also the dedup against the
+       *  three overlapping terminal edges the runtime really sends. */
+      tasks: Map<string, LiveSdkTask>
+      /** Settled tasks retained for the console's `task/list` read — DISPLAY history, never
+       *  liveness. Deliberately a separate array rather than entries left in `tasks`: nothing
+       *  that gates reclaim, the wake budget, session TTL-close, retention GC, secret-file
+       *  cleanup or workspace mutations reads this field, so a retained record cannot be
+       *  mistaken for live work by construction rather than by remembering to filter. Oldest
+       *  first, capped at {@link MAX_SETTLED_TASKS_PER_SESSION}. */
+      settled: SettledSdkTask[]
       sdkState: 'idle' | 'running'
       /** Background-task wakes already spent on this session — see
        *  {@link MAX_BG_TASK_WAKES_PER_SESSION}. */
@@ -5159,6 +5201,7 @@ export class Daemon {
       'workspace-file-edit-v1',
       'workspace-file-delete-v1',
       WORKSPACE_SESSION_READ_FEATURE,
+      TASK_LIST_FEATURE,
       WORKSPACE_GIT_MESSAGE_FEATURE,
       WORKSPACE_GIT_REVIEW_FEATURE,
       WORKSPACE_GIT_WRITE_FEATURE,
@@ -17001,7 +17044,8 @@ export class Daemon {
     const leaseKey = sdkLeaseKey(agentId, acpSessionId)
     const lease = this.sdkLease.get(leaseKey) ?? {
       agentId,
-      tasks: new Map<string, { description?: string; isSubagent: boolean }>(),
+      tasks: new Map<string, LiveSdkTask>(),
+      settled: [] as SettledSdkTask[],
       sdkState: 'idle' as const,
       bgWakes: 0,
       armedWakes: 0,
@@ -17012,8 +17056,22 @@ export class Daemon {
     // and hand the completion back to the model so the work is not stranded.
     const settle = (taskId: string, status?: string) => {
       const rec = lease.tasks.get(taskId)
-      if (!rec) return // already settled — dedup the near-simultaneous edges
-      lease.tasks.delete(taskId)
+      if (!rec) {
+        // Already settled: still dedup announce + wake, but let a later terminal edge fill in the
+        // outcome the first one could not carry — the snapshot and task_notification paths supply
+        // no status, so this is how `failed` becomes reachable at all. Display only.
+        if (status) {
+          const prior = lease.settled.find((t) => t.id === taskId) // at most one: retention dedups by id
+          if (prior && !prior.status) prior.status = status
+        }
+        return
+      }
+      lease.tasks.delete(taskId) // liveness removal FIRST — see the `tasks` field docblock
+      // Retained OUTSIDE the liveness set, and before the subagent bail so the panel's data set
+      // equals the set that fences reclaim (subagents are filtered at render, never at the source).
+      lease.settled = lease.settled.filter((t) => t.id !== taskId)
+      lease.settled.push({ id: taskId, ...rec, endedAt: this.clock.now(), status })
+      if (lease.settled.length > MAX_SETTLED_TASKS_PER_SESSION) lease.settled.shift()
       if (rec.isSubagent) return
       this.announceBackgroundTaskDone(agentId, acpSessionId, rec.description, status)
       this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, rec.description, status)
@@ -17029,7 +17087,9 @@ export class Daemon {
         if (typeof m.task_id === 'string')
           lease.tasks.set(m.task_id, {
             description: typeof m.description === 'string' ? m.description : undefined,
-            isSubagent: typeof m.subagent_type === 'string' && m.subagent_type.length > 0
+            isSubagent: typeof m.subagent_type === 'string' && m.subagent_type.length > 0,
+            // The feed carries no start time; this edge's arrival is the only one there is.
+            startedAt: this.clock.now()
           })
         break
       case 'task_notification':
@@ -17061,6 +17121,51 @@ export class Daemon {
     }
     lease.agentId = agentId
     this.sdkLease.set(leaseKey, lease)
+  }
+
+  /** Project one (agent, ACP session) background-task lease for the console's `task/list` read
+   *  (webchat-side-panels.md §3.5). A pure READ: it never touches the lease, so it cannot
+   *  disturb a reclaim decision. Live tasks come first (newest start first) because they are the
+   *  ones fencing the host; then the retained settled ones (newest end first). Only an unknown
+   *  agent is an error — no lease answers `tracked:false`, which is a different statement from
+   *  "no background tasks" and the console says so. */
+  private listBackgroundTasks(req: TaskListReq): TaskList {
+    if (!this.agents.has(req.agentId)) throw new TaskViolationError(`unknown agent "${req.agentId}"`, 'unknown-agent')
+    const lease = this.sdkLease.get(sdkLeaseKey(req.agentId, req.sessionId))
+    const iso = (ms: number) => new Date(ms).toISOString()
+    // Model-authored, so bounded here rather than trusted; the row survives, the tail does not.
+    const described = (description: string | undefined) =>
+      description ? { description: description.slice(0, MAX_TASK_DESCRIPTION) } : {}
+    const live = [...(lease?.tasks ?? new Map<string, LiveSdkTask>()).entries()]
+      .map(([id, rec]) => ({
+        id,
+        ...described(rec.description),
+        state: 'running' as const,
+        subagent: rec.isSubagent,
+        startedAt: iso(rec.startedAt)
+      }))
+      .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+    // `failed` needs a REPORTED failure; a settle edge that carried no status is not evidence of
+    // one, and most of them carry none (the snapshot and task_notification paths supply nothing).
+    const done = [...(lease?.settled ?? [])]
+      .sort((a, b) => b.endedAt - a.endedAt)
+      .map((rec) => ({
+        id: rec.id,
+        ...described(rec.description),
+        state: rec.status === 'failed' || rec.status === 'killed' ? ('failed' as const) : ('done' as const),
+        subagent: rec.isSubagent,
+        startedAt: iso(rec.startedAt),
+        endedAt: iso(rec.endedAt),
+        ...(rec.status ? { detail: rec.status.slice(0, MAX_TASK_DETAIL) } : {})
+      }))
+    const all = [...live, ...done]
+    return {
+      agentId: req.agentId,
+      sessionId: req.sessionId,
+      tracked: !!lease,
+      tasks: all.slice(0, MAX_TASK_LIST_TASKS),
+      truncated: all.length > MAX_TASK_LIST_TASKS
+    }
   }
 
   /** Proactively announce a completed background task to its session's channel/thread
@@ -19600,6 +19705,9 @@ export class Daemon {
         // data, not an error, because a workspace write is exactly when the answer would be stale.
         message: (req) => workspaceGit.message(req)
       },
+      // A pure projection of the in-memory lease — no I/O, no runtime, and nothing it can do to a
+      // reclaim decision, so it needs neither of the workspace coordinators.
+      taskReader: { list: async (req) => this.listBackgroundTasks(req) },
       memoryReader: createMemoryReader((id) => this.agents.get(id)?.dir, this.memory),
       dreamReader: createDreamReader(this.dreamRunner()),
       localSkillsReader: createLocalSkillsReader(

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { buildEnvelope, decodeEnvelope, MAX_FRAME_BYTES, SESSION_LIVE_TAIL_FEATURE } from '@agentconnect.md/protocol'
 import { CpClient, type CpClientDeps } from '../../src/cp/client.js'
 import { WorkspaceConflictError, WorkspaceViolationError } from '../../src/cp/workspace-reader.js'
+import { TaskViolationError } from '../../src/cp/task-reader.js'
 import { FakeTransport } from './fake-transport.js'
 import { FakeClock } from './fake-clock.js'
 
@@ -26,6 +27,7 @@ async function readyClient(over: Partial<CpClientDeps> = {}, serverFeatures: str
     sessionRead: _sessionReadOver,
     workspaceRead: _workspaceReadOver,
     workspaceGit: _workspaceGitOver,
+    taskReader: _taskReaderOver,
     ...overRest
   } = over
   const configApply = {
@@ -82,6 +84,10 @@ async function readyClient(over: Partial<CpClientDeps> = {}, serverFeatures: str
     pull: vi.fn(async () => ({ agentId: 'a', isRepo: false, ok: false })),
     ...((over.workspaceGit as any) ?? {})
   }
+  const taskReader = {
+    list: vi.fn(async () => ({ agentId: 'a', sessionId: 'acp-1', tracked: false, tasks: [], truncated: false })),
+    ...((over.taskReader as any) ?? {})
+  }
   const deps: CpClientDeps = {
     url: 'wss://cp/daemon/ws',
     token: 't',
@@ -99,6 +105,7 @@ async function readyClient(over: Partial<CpClientDeps> = {}, serverFeatures: str
     sessionRead,
     workspaceRead,
     workspaceGit,
+    taskReader,
     clock,
     connect: async () => t,
     log: silent,
@@ -144,7 +151,7 @@ async function readyClient(over: Partial<CpClientDeps> = {}, serverFeatures: str
   await tick()
   t.sent.length = 0 // clear handshake frames
   vi.clearAllMocks() // reset mock call counts after handshake
-  return { t, clock, client, configApply, workspaceRead, workspaceGit }
+  return { t, clock, client, configApply, workspaceRead, workspaceGit, taskReader }
 }
 
 describe('CpClient dispatch', () => {
@@ -833,6 +840,53 @@ describe('CpClient dispatch', () => {
       } as any
     })
     const f = JSON.parse(frame('workspace/gitstatus', { agentId: 'nope' }, { epoch: 5 }))
+    t.pushInbound(JSON.stringify(f))
+    await tick()
+    const err = JSON.parse(t.sent[0]!)
+    expect(err.type).toBe('error')
+    expect(err.corr).toBe(f.id)
+    expect(err.payload.code).toBe('BAD_PAYLOAD')
+    expect(err.payload.details).toEqual({ reason: 'unknown-agent' })
+  })
+
+  it('replies task/list/result from the taskReader seam', async () => {
+    const list = vi.fn(async () => ({
+      agentId: 'a1',
+      sessionId: 'acp-1',
+      tracked: true,
+      truncated: false,
+      tasks: [
+        {
+          id: 't1',
+          description: 'Sleep 15',
+          state: 'running' as const,
+          subagent: false,
+          startedAt: '2026-06-26T00:00:00.000Z'
+        }
+      ]
+    }))
+    const { t, taskReader } = await readyClient({ taskReader: { list } as any })
+    const payload = { agentId: 'a1', sessionId: 'acp-1' }
+    const f = JSON.parse(frame('task/list', payload, { epoch: 5 }))
+    t.pushInbound(JSON.stringify(f))
+    await tick()
+    expect(taskReader.list).toHaveBeenCalledWith(payload)
+    const rep = JSON.parse(t.sent[0]!)
+    expect(rep.type).toBe('task/list/result')
+    expect(rep.corr).toBe(f.id)
+    expect(rep.payload.tasks[0].state).toBe('running')
+    expect(rep.payload.tracked).toBe(true)
+  })
+
+  it('maps an unknown-agent task violation to BAD_PAYLOAD with its reason', async () => {
+    const { t } = await readyClient({
+      taskReader: {
+        list: async () => {
+          throw new TaskViolationError('unknown agent "nope"', 'unknown-agent')
+        }
+      } as any
+    })
+    const f = JSON.parse(frame('task/list', { agentId: 'nope', sessionId: 'acp-1' }, { epoch: 5 }))
     t.pushInbound(JSON.stringify(f))
     await tick()
     const err = JSON.parse(t.sent[0]!)

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -3,7 +3,9 @@ import { createHash } from 'node:crypto'
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { MAX_TASK_LIST_TASKS } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
+import { TaskViolationError } from '../src/cp/task-reader.js'
 import { configFilesDir } from '../src/agents/config-file-env.js'
 import { readSkillLedger, skillLedgerLocation } from '../src/skills/skill-install-ledger.js'
 import { sessionKey } from '../src/store/local-store.js'
@@ -1646,6 +1648,154 @@ describe('Daemon idle sweep — background-task lease', () => {
     ;(daemon as any).onSdkLifecycle('bot-b', 'acp-1', evt('task_notification', { task_id: 't1' }))
     expect((daemon as any).sdkLease.get(LEASE_KEY)?.tasks.size).toBe(1)
     expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(false)
+    await daemon.stop()
+  }, 15_000)
+
+  // `task/list` needs settled tasks to exist at all, and the ONLY safe place to keep them is
+  // outside `lease.tasks`: every reclaim decision reads that map as the liveness set. These four
+  // cases pin that the retained record is inert — it neither announces, nor wakes, nor spends the
+  // wake budget, nor keeps a session or a host or a workspace mutation fenced.
+  it('retains a settled task for the panel while keeping it out of every liveness read', async () => {
+    const clock = new FakeClock()
+    const { daemon, host, conn } = await bootWithTurn(clock, {
+      agentIdleTimeoutMs: 1000,
+      agentMaxLifetimeMs: 10_000_000,
+      idleSweepMs: 10_000_000
+    })
+    ;(daemon as any).store.setOutputModeOverride(KEY, 'medium')
+    const lease = () => (daemon as any).sdkLease.get(LEASE_KEY)
+    const announces = () =>
+      (conn.postMessage as any).mock.calls.filter((call: any[]) => String(call[1]).includes('Sleep 15')).length
+
+    ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1', description: 'Sleep 15' }))
+    expect((daemon as any).agentHasLiveSdkWork('bot-a')).toBe(true)
+    expect((daemon as any).workspaceMutationBusy('bot-a')).toBe(true) // console edits refused while it runs
+
+    // Settled: released from the liveness set, retained for the panel.
+    ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+    expect(lease().tasks.size).toBe(0)
+    expect(lease().settled.map((t: any) => t.id)).toEqual(['t1'])
+    expect(announces()).toBe(1)
+
+    // Its wake delivers once; the fence clears with the retained record still in place.
+    clock.advance(4000)
+    await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false), WAIT)
+    expect(lease().bgWakes).toBe(1)
+
+    // The next authoritative snapshot no longer lists it. Re-settling a retained record is what
+    // would re-announce, re-wake, and burn the 20-wake budget on EVERY subsequent snapshot.
+    ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('background_tasks_changed', { tasks: [] }))
+    expect(lease().bgWakes).toBe(1)
+    expect(wakeFenceHeld(daemon)).toBe(false)
+    expect(announces()).toBe(1)
+    expect(lease().settled).toHaveLength(1)
+
+    // Quiescent WITH the record retained, so the session TTL-closes and the host is reclaimed.
+    expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(true)
+    expect((daemon as any).agentHasLiveSdkWork('bot-a')).toBe(false)
+    expect((daemon as any).workspaceMutationBusy('bot-a')).toBe(false)
+    await vi.waitFor(() => expect((daemon as any).store.getSession(KEY)?.state).toBe('idle'), WAIT)
+    clock.advance(1001)
+    ;(daemon as any).sweepIdle()
+    await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false), WAIT)
+    expect(host.stop).toHaveBeenCalled()
+    expect((daemon as any).store.getSession(KEY)?.state).toBe('closed')
+
+    await daemon.stop()
+  }, 15_000)
+
+  it('projects the lease for task/list — running, done, and a failure refined by a later edge', async () => {
+    const clock = new FakeClock()
+    const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+    const list = () => (daemon as any).listBackgroundTasks({ agentId: 'bot-a', sessionId: 'acp-1' })
+
+    ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1', description: 'Sleep 15' }))
+    clock.advance(1000)
+    ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't2', subagent_type: 'general' }))
+
+    // Live rows, newest start first. The internal subagent is CARRIED, not filtered at the source:
+    // it fences reclaim exactly like a real task, so hiding it here would make the panel and the
+    // thing deferring reclaim disagree. Consumers filter at render.
+    expect(list().tasks.map((t: any) => [t.id, t.state, t.subagent])).toEqual([
+      ['t2', 'running', true],
+      ['t1', 'running', false]
+    ])
+    expect(list().tracked).toBe(true)
+    expect(list().truncated).toBe(false)
+    expect(list().tasks[1].description).toBe('Sleep 15')
+    expect(list().tasks[1].startedAt).toBe(new Date(0).toISOString()) // the task_started edge's arrival
+    expect(list().tasks[1].endedAt).toBeUndefined() // a live task has not ended
+    expect(list().tasks[0].description).toBeUndefined() // the runtime omitted it
+
+    // The snapshot settles both and carries NO status, which is the common case — so `done` means
+    // "settled without a reported failure", and `detail` stays absent rather than claiming success.
+    clock.advance(1000)
+    ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('background_tasks_changed', { tasks: [] }))
+    expect(list().tasks.map((t: any) => [t.id, t.state, t.endedAt, t.detail])).toEqual([
+      ['t1', 'done', new Date(2000).toISOString(), undefined],
+      ['t2', 'done', new Date(2000).toISOString(), undefined]
+    ])
+
+    // A later terminal edge DOES carry a status. Refining the retained row is the only way `failed`
+    // is reachable at all, and it must stay display-only: no re-announce, no liveness change.
+    ;(daemon as any).onSdkLifecycle(
+      'bot-a',
+      'acp-1',
+      evt('task_updated', { task_id: 't1', patch: { status: 'failed' } })
+    )
+    const refined = list().tasks.find((t: any) => t.id === 't1')
+    expect([refined.state, refined.detail]).toEqual(['failed', 'failed'])
+    expect((daemon as any).sdkLease.get(LEASE_KEY).tasks.size).toBe(0)
+    expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(false) // t1's own wake, not the record
+
+    await daemon.stop()
+  }, 15_000)
+
+  it('bounds the retained history and the page, and neither bound touches the liveness set', async () => {
+    const clock = new FakeClock()
+    const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+    const list = () => (daemon as any).listBackgroundTasks({ agentId: 'bot-a', sessionId: 'acp-1' })
+    // Subagent tasks, so the sweep of settles below neither announces nor wakes — they are retained
+    // and counted as live exactly like any other task, which is the point.
+    const ids = Array.from({ length: MAX_TASK_LIST_TASKS + 1 }, (_unused, i) => `t${i}`)
+    for (const id of ids) {
+      clock.advance(1)
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: id, subagent_type: 'general' }))
+    }
+    expect((daemon as any).sdkLease.get(LEASE_KEY).tasks.size).toBe(MAX_TASK_LIST_TASKS + 1)
+    expect(list().tasks).toHaveLength(MAX_TASK_LIST_TASKS)
+    expect(list().truncated).toBe(true)
+
+    // All settle on one snapshot. Retention keeps the newest MAX_SETTLED_TASKS_PER_SESSION (20) and
+    // the liveness set empties completely — the cap evicts history, never a live task.
+    ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('background_tasks_changed', { tasks: [] }))
+    expect((daemon as any).sdkLease.get(LEASE_KEY).tasks.size).toBe(0)
+    expect(list().tasks).toHaveLength(20)
+    expect(list().truncated).toBe(false)
+    expect(list().tasks.map((t: any) => t.id)).not.toContain('t0') // oldest settle evicted first
+    expect(list().tasks.every((t: any) => t.state === 'done' && t.subagent)).toBe(true)
+    expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(true) // 20 retained rows, still quiescent
+
+    await daemon.stop()
+  }, 15_000)
+
+  it('answers a session with no lease as tracked:false, and an unknown agent as a violation', async () => {
+    const clock = new FakeClock()
+    const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+
+    // No lease is NOT "no background tasks": a non-Claude runtime and an adapter without the
+    // lifecycle extension both land here, and the console says so rather than claiming idleness.
+    expect((daemon as any).listBackgroundTasks({ agentId: 'bot-a', sessionId: 'acp-9' })).toEqual({
+      agentId: 'bot-a',
+      sessionId: 'acp-9',
+      tracked: false,
+      tasks: [],
+      truncated: false
+    })
+    expect(() => (daemon as any).listBackgroundTasks({ agentId: 'nope', sessionId: 'acp-1' })).toThrow(
+      TaskViolationError
+    )
+
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/daemon-workspace-git-review-feature.test.ts
+++ b/packages/daemon/test/daemon-workspace-git-review-feature.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  TASK_LIST_FEATURE,
   WORKSPACE_GIT_MESSAGE_FEATURE,
   WORKSPACE_GIT_REVIEW_FEATURE,
   WORKSPACE_GIT_WRITE_FEATURE
@@ -43,7 +44,7 @@ function scaffold(): string {
   return root
 }
 
-describe('registrationFeatures — workspace git review + write + AI message', () => {
+describe('registrationFeatures — the console dock reads (git review + write + AI message + tasks)', () => {
   it('advertises the git reads, writes AND the message pass unconditionally (daemon code, not a runtime probe)', async () => {
     const daemon = new Daemon({
       root: scaffold(),
@@ -59,5 +60,8 @@ describe('registrationFeatures — workspace git review + write + AI message', (
     // The wand is gated separately: it is not a write, and whether the agent's RUNTIME can actually
     // draft a message is data the pass reports — not something a register-time flag can promise.
     expect(features).toContain(WORKSPACE_GIT_MESSAGE_FEATURE)
+    // `task/list` is likewise unconditional daemon code — whether the agent's runtime actually
+    // emits the SDK lifecycle feed is data the REP reports (`tracked`), not a register-time promise.
+    expect(features).toContain(TASK_LIST_FEATURE)
   }, 20_000)
 })

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -18,6 +18,11 @@ import {
   MAX_WORKSPACE_COMMIT_MESSAGE,
   MAX_WORKSPACE_STAGE_PATHS,
   MAX_WORKSPACE_STAGE_PATH_BYTES,
+  MAX_TASK_DESCRIPTION,
+  MAX_TASK_DETAIL,
+  MAX_TASK_LIST_TASKS,
+  TaskErrorReason,
+  TaskState,
   WorkspaceErrorReason,
   WorkspaceGitWriteReason,
   FRAME_SCHEMAS,
@@ -1742,6 +1747,136 @@ describe('workspace git review frames (status counts, diff, log)', () => {
     expect(WorkspaceErrorReason.options).toContain('path-escape')
     expect(WorkspaceErrorReason.safeParse('not-a-file').success).toBe(true)
     expect(WorkspaceErrorReason.safeParse('offline').success).toBe(false)
+  })
+})
+
+describe('background-task frames (console Tasks panel)', () => {
+  it('task/list REQ requires the ACP session id — the lease is per (agent, ACP session)', () => {
+    const req = decodeEnvelope(envelope('task/list', { agentId: 'local-agent-1', sessionId: 'acp-1' }, { epoch: 3 }))
+    expect(req.ok).toBe(true)
+    if (!req.ok || !isFrame('task/list')(req.frame)) throw new Error('expected task/list')
+    expect(req.frame.payload.sessionId).toBe('acp-1')
+    expect(req.ext).toEqual({ epoch: 3 })
+
+    // Unlike the workspace reads, `sessionId` is not optional: there is no per-agent lease to fall
+    // back to, only a boolean rollup, so an agent-wide task list would be a different question.
+    expect(decodeEnvelope(envelope('task/list', { agentId: 'local-agent-1' })).ok).toBe(false)
+    expect(decodeEnvelope(envelope('task/list', { agentId: 'local-agent-1', sessionId: '' })).ok).toBe(false)
+  })
+
+  it('task/list/result round-trips running / done / failed, a subagent row, and an untracked session', () => {
+    const rep = decodeEnvelope(
+      envelope(
+        'task/list/result',
+        {
+          agentId: 'local-agent-1',
+          sessionId: 'acp-1',
+          tracked: true,
+          truncated: true,
+          tasks: [
+            { id: 't1', description: 'Sleep for 15 seconds', state: 'running', subagent: false, startedAt: TS },
+            { id: 't2', state: 'done', subagent: false, startedAt: TS, endedAt: TS },
+            { id: 't3', state: 'failed', subagent: false, startedAt: TS, endedAt: TS, detail: 'killed' },
+            { id: 't4', description: 'general', state: 'running', subagent: true, startedAt: TS }
+          ]
+        },
+        { corr: ID }
+      )
+    )
+    expect(rep.ok).toBe(true)
+    if (!rep.ok || !isFrame('task/list/result')(rep.frame)) throw new Error('expected task/list/result')
+    expect(rep.frame.corr).toBe(ID)
+    expect(rep.frame.payload.tasks.map((t) => t.state)).toEqual(['running', 'done', 'failed', 'running'])
+    expect(rep.frame.payload.tasks[0]!.endedAt).toBeUndefined() // a live task has not ended
+    expect(rep.frame.payload.tasks[1]!.description).toBeUndefined() // the runtime omitted it
+    expect(rep.frame.payload.tasks[3]!.subagent).toBe(true) // carried, not filtered at the source
+    expect(rep.frame.payload.truncated).toBe(true)
+
+    // No lease for the session is DATA and is NOT the same statement as "no tasks".
+    const untracked = decodeEnvelope(
+      envelope('task/list/result', {
+        agentId: 'local-agent-1',
+        sessionId: 'acp-1',
+        tracked: false,
+        tasks: [],
+        truncated: false
+      })
+    )
+    expect(untracked.ok).toBe(true)
+    if (!untracked.ok || !isFrame('task/list/result')(untracked.frame)) throw new Error('expected result')
+    expect(untracked.frame.payload.tracked).toBe(false)
+  })
+
+  it('bounds the task page, the description and the detail', () => {
+    const task = { id: 't', state: 'done' as const, subagent: false, startedAt: TS, endedAt: TS }
+    const base = { agentId: 'local-agent-1', sessionId: 'acp-1', tracked: true, truncated: true }
+    expect(
+      decodeEnvelope(
+        envelope('task/list/result', { ...base, tasks: Array.from({ length: MAX_TASK_LIST_TASKS }, () => task) })
+      ).ok
+    ).toBe(true)
+    expect(
+      decodeEnvelope(
+        envelope('task/list/result', { ...base, tasks: Array.from({ length: MAX_TASK_LIST_TASKS + 1 }, () => task) })
+      ).ok
+    ).toBe(false)
+    expect(
+      decodeEnvelope(
+        envelope('task/list/result', {
+          ...base,
+          tasks: [{ ...task, description: 'x'.repeat(MAX_TASK_DESCRIPTION + 1) }]
+        })
+      ).ok
+    ).toBe(false)
+    expect(
+      decodeEnvelope(
+        envelope('task/list/result', { ...base, tasks: [{ ...task, detail: 'x'.repeat(MAX_TASK_DETAIL + 1) }] })
+      ).ok
+    ).toBe(false)
+  })
+
+  it('the task state vocabulary is closed and carries NO `queued`', () => {
+    expect(TaskState.options).toEqual(['running', 'done', 'failed'])
+    // `task_started` is the feed's only start edge, so nothing upstream can report a queued task.
+    expect(TaskState.safeParse('queued').success).toBe(false)
+    expect(TaskErrorReason.options).toEqual(['unknown-agent'])
+  })
+
+  it('registers no task/cancel — no ACP primitive can address one background task', () => {
+    // `session/cancel` carries only `{ sessionId }` and the only hard stop is killing the agent's
+    // shared adapter, so a per-task cancel could only cancel unrelated work or lie about having
+    // acted. The absence is the design decision, and this is where it is pinned.
+    expect(FRAME_TYPES.some((t) => t.startsWith('task/'))).toBe(true)
+    expect(FRAME_TYPES.filter((t) => t.startsWith('task/'))).toEqual(['task/list', 'task/list/result'])
+  })
+
+  it('keeps a worst-case escaped task page below the wire cap', () => {
+    // NUL is the largest ordinary JSON string expansion (six wire bytes per input character), so
+    // filling every display cap with it covers the maxima of a full page.
+    const escaped = '\u0000'
+    const task = {
+      id: escaped.repeat(64),
+      description: escaped.repeat(MAX_TASK_DESCRIPTION),
+      state: 'failed' as const,
+      subagent: false,
+      startedAt: TS,
+      endedAt: TS,
+      detail: escaped.repeat(MAX_TASK_DETAIL)
+    }
+    const encoded = encode(
+      buildEnvelope('task/list/result', {
+        agentId: escaped.repeat(255),
+        sessionId: escaped.repeat(255),
+        tracked: true,
+        truncated: true,
+        tasks: Array.from({ length: MAX_TASK_LIST_TASKS }, () => task)
+      })
+    )
+    expect(Buffer.byteLength(encoded)).toBeLessThanOrEqual(MAX_FRAME_BYTES)
+    const decoded = decodeEnvelope(encoded)
+    expect(decoded.ok).toBe(true)
+    if (!decoded.ok || !isFrame('task/list/result')(decoded.frame)) throw new Error('expected task/list/result')
+    expect(decoded.frame.payload.tasks).toHaveLength(MAX_TASK_LIST_TASKS)
   })
 })
 

--- a/packages/protocol/src/consts.ts
+++ b/packages/protocol/src/consts.ts
@@ -75,6 +75,12 @@ export const WORKSPACE_GIT_WRITE_FEATURE = 'workspace-git-write-v1'
  * retransmit budget before reading as an offline daemon. */
 export const WORKSPACE_GIT_MESSAGE_FEATURE = 'workspace-git-message-v1'
 
+/** Daemon serves `task/list` — the console Tasks panel's read of one ACP session's background-task
+ * lease. Checked before sending, like every other new frame: an older daemon ignores it silently, so
+ * the REQ would burn its whole retransmit budget and then read as an offline daemon. The console
+ * hides the Tasks tab on a daemon without it rather than showing a tab that can never answer. */
+export const TASK_LIST_FEATURE = 'task-list-v1'
+
 /** How long the CP must let ONE `workspace/gitmessage` REQ run before giving up, and it must send it
  * single-shot (`{ ackTimeoutMs: WORKSPACE_GIT_MESSAGE_BUDGET_MS, maxTries: 1 }`). The default 5s ack
  * timeout would retransmit an in-flight model pass four times: identical frame ids, so the daemon

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -80,6 +80,7 @@ import {
   WorkspaceGitMessageReq,
   WorkspaceGitMessageResult
 } from './frames/workspace.js'
+import { TaskListReq, TaskList } from './frames/task.js'
 import {
   MemoryChannelsReq,
   MemoryChannelsPage,
@@ -321,6 +322,9 @@ export const FRAME_SCHEMAS = {
   // ── AI commit message: a bounded model pass on the DAEMON's runtime, no write of any kind.
   'workspace/gitmessage': WorkspaceGitMessageReq,
   'workspace/gitmessage/result': WorkspaceGitMessageResult,
+  // ── background tasks: a read of the daemon's in-memory lease. No cancel frame — see task.ts.
+  'task/list': TaskListReq,
+  'task/list/result': TaskList,
   'memory/channels': MemoryChannelsReq,
   'memory/channels/page': MemoryChannelsPage,
   'memory/list': MemoryListReq,
@@ -544,6 +548,8 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('workspace/gitpush/result', FRAME_SCHEMAS['workspace/gitpush/result']),
   frame('workspace/gitmessage', FRAME_SCHEMAS['workspace/gitmessage']),
   frame('workspace/gitmessage/result', FRAME_SCHEMAS['workspace/gitmessage/result']),
+  frame('task/list', FRAME_SCHEMAS['task/list']),
+  frame('task/list/result', FRAME_SCHEMAS['task/list/result']),
   frame('memory/channels', FRAME_SCHEMAS['memory/channels']),
   frame('memory/channels/page', FRAME_SCHEMAS['memory/channels/page']),
   frame('memory/list', FRAME_SCHEMAS['memory/list']),

--- a/packages/protocol/src/frames/task.ts
+++ b/packages/protocol/src/frames/task.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod'
+
+/**
+ * Agent background tasks (C→D REQ → REP) — the console Tasks panel's on-demand read.
+ *
+ * The CP stores NO task data: descriptions are model-authored strings and states live only
+ * in the owning daemon's in-memory background-task lease, pulled live and proxied, never
+ * persisted (body-locality — webchat-side-panels.md §2).
+ *
+ * Scoped per (agent, ACP session) because the lease already is: ACP session ids are
+ * runtime-local, so two agents can each expose an `acp-1`
+ * (background-task-aware-reclaim.md §3).
+ *
+ * `task/list` is the ONLY frame here. There is deliberately no `task/cancel`: the single
+ * cancellation primitive an ACP runtime exposes is `session/cancel`, whose payload is
+ * `{ sessionId }` — it cancels a whole prompt turn, and the only hard stop is killing the
+ * agent's shared adapter process. Neither can address one background task, so a per-task
+ * cancel could only report a cancellation it did not perform or silently cancel unrelated
+ * work. It becomes possible when a task-addressed cancel exists upstream.
+ */
+
+/** Machine-readable `reason` on a task `BAD_PAYLOAD` error frame's `details`, so the CP can
+ * answer with a status and a code the console can branch on instead of the 503 that reads as
+ * an offline daemon. Everything else about tasks is DATA: an untracked session, a session
+ * with no tasks and a runtime that reports none are all normal answers. */
+export const TaskErrorReason = z.enum([
+  'unknown-agent' // no such agent on this daemon
+])
+export type TaskErrorReason = z.infer<typeof TaskErrorReason>
+
+/** Tasks per REP. The lease holds every live task plus a bounded settled history, so this is a
+ * display ceiling rather than a pagination cursor — a panel showing 50 rows is already past
+ * useful, and `truncated` says the daemon had more. */
+export const MAX_TASK_LIST_TASKS = 50
+
+/** Display ceiling for one task's description. Model-authored, so it is bounded on the wire
+ * rather than trusted; the daemon truncates rather than dropping the row. */
+export const MAX_TASK_DESCRIPTION = 500
+
+/** Display ceiling for the `detail` line beside a settled task. */
+export const MAX_TASK_DETAIL = 200
+
+/**
+ * What the daemon can actually know about a task, and nothing more.
+ *
+ * - `running` — the task is in the lease's live set, i.e. it is the thing fencing host reclaim.
+ * - `done` — the task settled and no terminal edge reported a failure.
+ * - `failed` — a terminal edge reported `failed` or `killed`.
+ *
+ * There is NO `queued`: the SDK lifecycle feed's only start signal is `task_started`, so a task
+ * is either live in the lease or gone. Most settle edges (the authoritative snapshot, and
+ * `task_notification`) carry no status at all, which is why `done` means "settled without a
+ * reported failure" rather than "reported successful"; `detail` carries the reported status
+ * when there was one.
+ */
+export const TaskState = z.enum(['running', 'done', 'failed'])
+export type TaskState = z.infer<typeof TaskState>
+
+/** C→D REQ: the background tasks of ONE ACP session of one agent. */
+export const TaskListReq = z.object({
+  agentId: z.string().min(1), // local agent id (NOT a wire UUID)
+  /** ACP session id — the lease's own scope, so this is required rather than optional. */
+  sessionId: z.string().min(1)
+})
+export type TaskListReq = z.infer<typeof TaskListReq>
+
+/** One background task. `subagent` is the runtime's own internal Task/subagent invocation: it
+ *  is carried rather than filtered out, because the same records are what fence host reclaim —
+ *  a panel that hid them at the SOURCE would show "no tasks" beside a host refusing to be
+ *  reclaimed. Consumers filter at RENDER. */
+export const TaskEntry = z.object({
+  id: z.string(), // runtime-local task id
+  description: z.string().max(MAX_TASK_DESCRIPTION).optional(), // absent when the runtime omitted it
+  state: TaskState,
+  subagent: z.boolean(),
+  startedAt: z.string(), // RFC3339, from the `task_started` edge
+  endedAt: z.string().optional(), // RFC3339; present iff the task settled
+  detail: z.string().max(MAX_TASK_DETAIL).optional() // the terminal status the runtime reported, when any
+})
+export type TaskEntry = z.infer<typeof TaskEntry>
+
+/** D→C REP (corr = the req id): live tasks newest-first, then the retained settled ones
+ *  newest-first. `tracked:false` means this daemon holds no lease for the session — a
+ *  non-Claude runtime, an adapter without the lifecycle extension, or a session that has not
+ *  emitted an accepted lifecycle event yet. That is a different statement from "this session
+ *  has no background tasks", and the console says so. */
+export const TaskList = z.object({
+  agentId: z.string(),
+  sessionId: z.string(),
+  tracked: z.boolean(),
+  tasks: z.array(TaskEntry).max(MAX_TASK_LIST_TASKS),
+  truncated: z.boolean() // true ⇒ the daemon held more tasks than this REP carries
+})
+export type TaskList = z.infer<typeof TaskList>

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -28,6 +28,7 @@ export {
   SESSION_PURGE_FEATURE,
   SESSION_VISIBILITY_FEATURE,
   SLACK_SESSION_AUDIENCE_FEATURE,
+  TASK_LIST_FEATURE,
   WORKSPACE_GIT_MESSAGE_BUDGET_MS,
   WORKSPACE_GIT_MESSAGE_FEATURE,
   WORKSPACE_GIT_REVIEW_FEATURE,
@@ -58,6 +59,7 @@ export * from './frames/secrets.js'
 export * from './frames/session.js'
 export * from './frames/channel.js'
 export * from './frames/workspace.js'
+export * from './frames/task.js'
 export * from './frames/memory.js'
 export * from './frames/organization-knowledge.js'
 export * from './frames/telemetry.js'

--- a/packages/web/src/components/console/dock/TasksPanel.test.tsx
+++ b/packages/web/src/components/console/dock/TasksPanel.test.tsx
@@ -334,16 +334,54 @@ describe('TasksPanel polling', () => {
     expect(wire.calls).toHaveLength(1)
   })
 
-  it('does NOT poll an idle list, because a settled task has no transition left to find', async () => {
+  // PREMISE CORRECTED (review of #854): this case previously asserted that an idle VISIBLE panel
+  // stops polling, on the reasoning that a settled task has no transition left to find. That was
+  // wrong about what the panel watches. It watches a SESSION, not the rows on screen, and the
+  // session starts new background tasks — most directly when the reader leaves this tab open and
+  // sends another prompt from the composer beside it. Nothing in that path bumps the panel's
+  // revision, so the old behavior meant the 0 -> running edge was never observed and a new task
+  // stayed invisible until a manual refresh. The assertion is re-aimed at the backed-off cadence,
+  // not deleted: the thing worth protecting is that an idle panel polls LESS, not that it stops.
+  it('keeps polling an idle VISIBLE list at the backed-off cadence, so a task starting later shows up', async () => {
     vi.useFakeTimers()
     wire.data = tasks({ tasks: [task({ state: 'done', endedAt: NOW_ISO })] })
     await render({ active: true })
     expect(wire.calls).toHaveLength(1)
 
+    // Slower than the running cadence: the running interval would have fired by now, the idle one
+    // has not. This is what pins the two apart rather than just "it polls sometimes".
     await act(async () => {
-      vi.advanceTimersByTime(30_000)
+      vi.advanceTimersByTime(5_000)
     })
     expect(wire.calls).toHaveLength(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(15_000)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(wire.calls).toHaveLength(2)
+  })
+
+  it('discovers a task that starts while an untracked session sits open, with no refresh press', async () => {
+    // The reviewer's exact scenario: Tasks opened over an empty/untracked lease, then a prompt sent
+    // from the composer starts a background task. `running` is 0 the whole time the panel is
+    // waiting, so a poll gated on `running > 0` would never fire and the badge would stay empty.
+    vi.useFakeTimers()
+    wire.data = tasks({ tracked: false })
+    await render({ active: true })
+    expect(last()).toEqual({ settled: true, running: null })
+
+    wire.data = tasks({ tasks: [task()] })
+    await act(async () => {
+      vi.advanceTimersByTime(20_000)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(rows()).toHaveLength(1)
+    expect(last()).toEqual({ settled: true, running: 1 })
   })
 
   it('re-reads on the tab action, without waiting for a poll', async () => {

--- a/packages/web/src/components/console/dock/TasksPanel.test.tsx
+++ b/packages/web/src/components/console/dock/TasksPanel.test.tsx
@@ -1,0 +1,429 @@
+// @vitest-environment happy-dom
+
+// The dock's Tasks panel: what it reports to its tab, the two DIFFERENT answers it refuses to collapse into one empty state (a daemon that tracks no lease for the session versus a tracked session with nothing running), and what it draws for every degraded answer the task wire can give — a daemon too old to report tasks, a session this reader cannot see, and an offline daemon.
+// It also pins the two absences §3.5 argued for, so a later change has to argue with them rather than drift past: there is NO per-task cancel control (no agent-protocol primitive can address one background task, so a row-level stop could only cancel unrelated work or report one it did not perform), and NO progress bar or step line (the runtime reports neither, and inventing them would be a lie the reader cannot check).
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const wire = vi.hoisted(() => ({
+  data: null as unknown,
+  failure: null as null | { status: number; code?: string },
+  calls: [] as Array<{ agentId: string; sessionId: string }>,
+  // Set to hand back a promise the test resolves by hand, so the panel is observable WHILE its first read is in flight.
+  hold: null as null | (() => Promise<unknown>)
+}))
+
+vi.mock('@/lib/api', () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+      readonly code?: string
+    ) {
+      super(message)
+      this.name = 'ApiError'
+    }
+  }
+  return {
+    ApiError,
+    fetchAgentTasks: vi.fn((agentId: string, sessionId: string) => {
+      wire.calls.push({ agentId, sessionId })
+      if (wire.failure) return Promise.reject(new ApiError('nope', wire.failure.status, wire.failure.code))
+      if (wire.hold) return wire.hold()
+      return Promise.resolve(wire.data)
+    })
+  }
+})
+
+import { TasksPanel, formatTaskElapsed, tasksTabStatus, type TasksPanelVerdict } from './TasksPanel'
+import type { AgentTaskDto, AgentTasksDto } from '@/lib/api'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let container: HTMLDivElement | undefined
+let root: ReturnType<typeof createRoot> | undefined
+let verdicts: TasksPanelVerdict[] = []
+
+const NOW = Date.parse('2026-08-11T12:00:00.000Z')
+const NOW_ISO = '2026-08-11T11:59:30.000Z'
+
+function task(overrides: Partial<AgentTaskDto> = {}): AgentTaskDto {
+  return {
+    id: 't1',
+    description: 'Reindex the workspace',
+    state: 'running',
+    subagent: false,
+    startedAt: '2026-08-11T11:58:00.000Z',
+    endedAt: null,
+    detail: null,
+    ...overrides
+  }
+}
+
+function tasks(overrides: Partial<AgentTasksDto> = {}): AgentTasksDto {
+  return { sessionId: 'session-1', tracked: true, tasks: [], truncated: false, ...overrides }
+}
+
+type PanelProps = Parameters<typeof TasksPanel>[0]
+
+function panel(props: Partial<PanelProps> = {}) {
+  return (
+    <TasksPanel
+      agentId="agent-a"
+      sessionId="session-1"
+      onVerdictChange={(verdict) => verdicts.push(verdict)}
+      {...props}
+    />
+  )
+}
+
+async function render(props: Partial<PanelProps> = {}) {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(panel(props))
+    await Promise.resolve()
+  })
+}
+
+async function rerender(props: Partial<PanelProps> = {}) {
+  await act(async () => {
+    root?.render(panel(props))
+    await Promise.resolve()
+  })
+}
+
+const text = () => container?.textContent ?? ''
+const rows = () => Array.from(container?.querySelectorAll<HTMLElement>('[data-task-row]') ?? [])
+const states = () => rows().map((row) => row.dataset.taskRow ?? '')
+const last = () => verdicts.at(-1)
+
+beforeEach(() => {
+  wire.data = tasks()
+  wire.failure = null
+  wire.calls = []
+  wire.hold = null
+  verdicts = []
+  vi.spyOn(Date, 'now').mockReturnValue(NOW)
+})
+
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  container?.remove()
+  container = undefined
+  root = undefined
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('tasksTabStatus', () => {
+  it('is loading until the read answers, and never empty', () => {
+    // Never `empty`: an untracked session and an idle one each have a sentence explaining themselves, and `empty` would trade that for the dock's centred placeholder — and put `vacant` back in reach, where the dock withholds its whole tab strip.
+    expect(tasksTabStatus(false)).toBe('loading')
+    expect(tasksTabStatus(true)).toBe('ready')
+  })
+})
+
+describe('formatTaskElapsed', () => {
+  it('reads seconds, then minutes-and-seconds, then hours-and-minutes', () => {
+    expect(formatTaskElapsed('2026-08-11T11:59:19.000Z', NOW)).toBe('41s')
+    expect(formatTaskElapsed('2026-08-11T11:57:46.000Z', NOW)).toBe('2m 14s')
+    expect(formatTaskElapsed('2026-08-11T10:56:00.000Z', NOW)).toBe('1h 04m')
+  })
+
+  it('clamps a start in the future to zero rather than reading backwards', () => {
+    // The daemon's clock is not ours, so a task can be stamped a few seconds ahead. `-3s` would be a bug the reader cannot distinguish from a bug in the agent.
+    expect(formatTaskElapsed('2026-08-11T12:00:03.000Z', NOW)).toBe('0s')
+  })
+
+  it('says nothing at all for an unparseable stamp', () => {
+    expect(formatTaskElapsed('not a date', NOW)).toBe('')
+  })
+})
+
+describe('TasksPanel scope', () => {
+  it('reads the lease by (agent, session) and reports settled once it answers', async () => {
+    await render()
+    expect(wire.calls).toEqual([{ agentId: 'agent-a', sessionId: 'session-1' }])
+    expect(last()).toEqual({ settled: true, running: 0 })
+    // Reported on the EDGE, against an unstable callback like the fresh closure this harness passes per render: re-reporting the held verdict would write parent state once per render, and a parent that re-renders on it would hand back another fresh closure — a loop.
+    const heard = verdicts.length
+    await rerender()
+    await rerender()
+    expect(verdicts).toHaveLength(heard)
+  })
+
+  it('reports its running count, not its row count, for the tab badge', async () => {
+    wire.data = tasks({
+      tasks: [task({ id: 'a' }), task({ id: 'b' }), task({ id: 'c', state: 'done', endedAt: NOW_ISO })]
+    })
+    await render()
+    expect(rows()).toHaveLength(3)
+    expect(last()).toEqual({ settled: true, running: 2 })
+  })
+})
+
+describe('TasksPanel answers that are not rows', () => {
+  it('says the runtime reports no tasks for an UNTRACKED session, not that there are none', async () => {
+    // The distinction the `tracked` field exists for: a non-Claude runtime and an adapter without the lifecycle extension both have no lease, which is a different statement from "idle".
+    wire.data = tasks({ tracked: false })
+    await render()
+    expect(text()).toContain('doesn’t report background tasks')
+    expect(rows()).toHaveLength(0)
+    // Null rather than 0: an unknown count must not wear a badge saying "none running".
+    expect(last()).toEqual({ settled: true, running: null })
+  })
+
+  it('says the session is idle when it IS tracked and has nothing', async () => {
+    await render()
+    expect(text()).toContain('No background tasks in this session')
+    expect(text()).not.toContain('doesn’t report background tasks')
+  })
+
+  it('names the version answer for a daemon too old to report tasks', async () => {
+    wire.failure = { status: 409, code: 'DAEMON_FEATURE_MISSING' }
+    await render()
+    expect(text()).toContain('cannot report background tasks')
+    expect(text()).toContain('Update the agent')
+    expect(last()).toEqual({ settled: true, running: null })
+  })
+
+  it('says a session it cannot read is unavailable, and folds everything else into the offline story', async () => {
+    wire.failure = { status: 404 }
+    await render()
+    expect(text()).toContain('not available to read')
+
+    await act(async () => root?.unmount())
+    container?.remove()
+    wire.failure = { status: 503 }
+    await render()
+    expect(text()).toContain('owning daemon may be offline')
+  })
+
+  it('says older tasks are withheld when the daemon truncated its history', async () => {
+    wire.data = tasks({ tasks: [task()], truncated: true })
+    await render()
+    expect(text()).toContain('bounded history')
+  })
+})
+
+describe('TasksPanel rows', () => {
+  it('draws each state with its own row marker', async () => {
+    wire.data = tasks({
+      tasks: [
+        task({ id: 'a' }),
+        task({ id: 'b', state: 'done', endedAt: NOW_ISO }),
+        task({ id: 'c', state: 'failed', endedAt: NOW_ISO, detail: 'exit 1' })
+      ]
+    })
+    await render()
+    expect(states()).toEqual(['running', 'done', 'failed'])
+  })
+
+  it('shows the terminal status the runtime reported, and nothing when it named none', async () => {
+    // `done` never asserts success on its own — most settle edges carry no status at all, which is exactly why `detail` is the only place a reported outcome may appear.
+    wire.data = tasks({
+      tasks: [task({ id: 'a', state: 'failed', endedAt: NOW_ISO, detail: 'killed' }), task({ id: 'b' })]
+    })
+    await render()
+    expect(text()).toContain('killed')
+  })
+
+  it('keeps a task the runtime did not name, and says so instead of dropping the row', async () => {
+    // An unnamed task is still the thing fencing host reclaim, so a panel that hid it would show "no tasks" beside a host refusing to be reclaimed.
+    wire.data = tasks({ tasks: [task({ description: null })] })
+    await render()
+    expect(rows()).toHaveLength(1)
+    expect(text()).toContain('Unnamed task')
+  })
+
+  it('CARRIES subagent rows and marks them, rather than filtering them out', async () => {
+    // Same reason: the wire deliberately does not filter them at the source because the same records fence reclaim, so hiding them at render would recreate the lie one layer down.
+    wire.data = tasks({ tasks: [task({ subagent: true })] })
+    await render()
+    expect(rows()).toHaveLength(1)
+    expect(text()).toContain('subagent')
+  })
+
+  it('counts what is on screen in its header, so the census cannot disagree with the rows', async () => {
+    wire.data = tasks({
+      tasks: [
+        task({ id: 'a' }),
+        task({ id: 'b', state: 'done', endedAt: NOW_ISO }),
+        task({ id: 'c', state: 'failed', endedAt: NOW_ISO })
+      ]
+    })
+    await render()
+    // Read off the census line itself rather than the panel's whole text, so a row that happens to carry the same words cannot satisfy it.
+    expect(container?.querySelector('[data-tasks-census]')?.textContent).toBe('1 running · 1 done · 1 failed')
+  })
+
+  it('says how many are running even when nothing has finished, and stays silent about the states with none', async () => {
+    wire.data = tasks({ tasks: [task({ id: 'a' }), task({ id: 'b' })] })
+    await render()
+    expect(container?.querySelector('[data-tasks-census]')?.textContent).toBe('2 running')
+  })
+
+  it('shows elapsed for a running task and a settled-ago for a finished one', async () => {
+    wire.data = tasks({
+      tasks: [
+        task({ id: 'a', startedAt: '2026-08-11T11:57:46.000Z' }),
+        task({ id: 'b', state: 'done', endedAt: '2026-08-11T11:48:00.000Z' })
+      ]
+    })
+    await render()
+    expect(text()).toContain('2m 14s')
+    expect(text()).toContain('12m ago')
+  })
+})
+
+describe('TasksPanel withheld controls (§3.5)', () => {
+  it('offers NO cancel, stop, rerun or clear control on any row or in the header', async () => {
+    // PREMISE: no ACP primitive can address one background task. `session/cancel` cancels a whole prompt turn, the only hard stop kills the agent's shared adapter and every session on it, and a background task outlives its turn so the turn-scoped interrupt is a no-op exactly when this panel matters. A row control could therefore only cancel unrelated work or report a cancellation it did not perform. If a task-addressed cancel ever lands upstream, re-aim this assertion at the new control — do not delete it.
+    wire.data = tasks({ tasks: [task(), task({ id: 'b', state: 'failed', endedAt: NOW_ISO })] })
+    await render()
+    expect(container?.querySelectorAll('button')).toHaveLength(0)
+    expect(text().toLowerCase()).not.toContain('cancel')
+    expect(text().toLowerCase()).not.toContain('rerun')
+    expect(text().toLowerCase()).not.toContain('clear finished')
+  })
+
+  it('draws NO progress bar and NO step line, because the runtime reports neither', async () => {
+    // The design drew both. Nothing in the lifecycle feed carries a percentage or a step, so a bar here would be a number the reader cannot check against anything.
+    wire.data = tasks({ tasks: [task()] })
+    await render()
+    expect(container?.querySelector('progress')).toBeNull()
+    expect(container?.querySelector('[role="progressbar"]')).toBeNull()
+    // A progress track is the only thing in this design that would need a percentage width.
+    const widths = Array.from(container?.querySelectorAll<HTMLElement>('[style]') ?? []).map((node) => node.style.width)
+    expect(widths.filter((width) => width.endsWith('%'))).toHaveLength(0)
+  })
+})
+
+describe('TasksPanel polling', () => {
+  it('re-reads while it is VISIBLE and something is running', async () => {
+    vi.useFakeTimers()
+    wire.data = tasks({ tasks: [task()] })
+    await render({ active: true })
+    expect(wire.calls).toHaveLength(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(wire.calls.length).toBeGreaterThan(1)
+    // A poll REPLACES the rows rather than clearing them first: dropping back to `loading` every five seconds would strobe the list and pull the tab out of `ready` on a timer.
+    expect(last()?.settled).toBe(true)
+    expect(rows()).toHaveLength(1)
+  })
+
+  it('does NOT poll while it is hidden, however much is running', async () => {
+    vi.useFakeTimers()
+    wire.data = tasks({ tasks: [task()] })
+    await render({ active: false })
+    expect(wire.calls).toHaveLength(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+    })
+    expect(wire.calls).toHaveLength(1)
+  })
+
+  it('does NOT poll an idle list, because a settled task has no transition left to find', async () => {
+    vi.useFakeTimers()
+    wire.data = tasks({ tasks: [task({ state: 'done', endedAt: NOW_ISO })] })
+    await render({ active: true })
+    expect(wire.calls).toHaveLength(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+    })
+    expect(wire.calls).toHaveLength(1)
+  })
+
+  it('re-reads on the tab action, without waiting for a poll', async () => {
+    await render({ refreshTick: 0 })
+    expect(wire.calls).toHaveLength(1)
+    await rerender({ refreshTick: 1 })
+    expect(wire.calls).toHaveLength(2)
+  })
+
+  it('re-reads for a new session rather than showing the previous one’s tasks', async () => {
+    // Constructs the switch WINDOW itself: the new scope's read is held open, so serving the held answer of the OLD scope — the M3 bug class — would leave its rows on screen and its census on the new tab's badge for as long as the read takes.
+    wire.data = tasks({ tasks: [task()] })
+    await render()
+    expect(wire.calls).toHaveLength(1)
+    expect(rows()).toHaveLength(1)
+
+    let release: ((value: unknown) => void) | undefined
+    wire.hold = () => new Promise((resolve) => (release = resolve))
+    await rerender({ sessionId: 'session-2' })
+    expect(wire.calls.at(-1)).toEqual({ agentId: 'agent-a', sessionId: 'session-2' })
+    // Pending for the scope on screen, not answered with the previous one: no rows, and a verdict that pulls the badge rather than carrying session-1's count over.
+    expect(rows()).toHaveLength(0)
+    expect(last()).toEqual({ settled: false, running: null })
+
+    await act(async () => {
+      release?.(tasks({ sessionId: 'session-2', tasks: [task({ id: 't2', description: 'the new scope’s task' })] }))
+      await Promise.resolve()
+    })
+    expect(text()).toContain('the new scope’s task')
+    expect(last()).toEqual({ settled: true, running: 1 })
+  })
+
+  it('re-reads ONCE for a scope switch and ONCE for a refresh, even after a poll has fired', async () => {
+    // MEASURED, not hypothetical: the first version of this panel kept the poll count in its own state and zeroed it whenever the scope or the refresh tick moved. Zeroing it re-triggered the read effect it was there to describe, so past the first poll every session switch and every press of the tab's refresh action issued TWO reads of the daemon's lease instead of one.
+    vi.useFakeTimers()
+    wire.data = tasks({ tasks: [task()] })
+    await render({ active: true })
+    await act(async () => {
+      vi.advanceTimersByTime(5_000)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(wire.calls).toHaveLength(2)
+
+    await rerender({ sessionId: 'session-2' })
+    expect(wire.calls).toEqual([
+      { agentId: 'agent-a', sessionId: 'session-1' },
+      { agentId: 'agent-a', sessionId: 'session-1' },
+      { agentId: 'agent-a', sessionId: 'session-2' }
+    ])
+
+    await rerender({ sessionId: 'session-2', refreshTick: 1 })
+    expect(wire.calls).toHaveLength(4)
+  })
+
+  it('re-reads when the reader OPENS the tab, on the edge and not per render', async () => {
+    // A list read when the session page mounted is not an answer about now, and the panel is mounted the whole time the reader is on some other tab (the dock never unmounts it).
+    await render({ active: false })
+    expect(wire.calls).toHaveLength(1)
+    await rerender({ active: true })
+    expect(wire.calls).toHaveLength(2)
+    // Still visible, nothing running: an edge that fired once must not fire again per render.
+    await rerender({ active: true })
+    expect(wire.calls).toHaveLength(2)
+  })
+
+  it('draws nothing at all until the first read of a scope answers, so the dock speaks alone', async () => {
+    // The dock draws its own centred "Loading…" over a non-ready tab AND the panel's body beneath it, so a panel with a loading state of its own would put two on screen at once. The verdict is what makes the tab non-ready, so it has to be reported from the unrendered state.
+    let release: ((value: unknown) => void) | undefined
+    wire.hold = () => new Promise((resolve) => (release = resolve))
+    await render()
+    expect(container?.querySelector('[data-tasks-panel]')).toBeNull()
+    expect(last()).toEqual({ settled: false, running: null })
+
+    await act(async () => {
+      release?.(tasks({ tasks: [task()] }))
+      await Promise.resolve()
+    })
+    expect(container?.querySelector('[data-tasks-panel]')).not.toBeNull()
+    expect(last()).toEqual({ settled: true, running: 1 })
+  })
+})

--- a/packages/web/src/components/console/dock/TasksPanel.tsx
+++ b/packages/web/src/components/console/dock/TasksPanel.tsx
@@ -1,0 +1,287 @@
+'use client'
+
+// The dock's Tasks tab (§3.5): the open session's background tasks, live ones first and then the daemon's bounded settled history, each with its state, its description, how long it has been running or how long ago it ended, and the outcome the runtime reported when it named one.
+// A READ-ONLY surface, by measurement rather than by omission: no agent-protocol primitive can address ONE background task, so a per-row control could only cancel unrelated work or report a stop it did not perform. There is no cancel frame or route to wire, and the escape hatch is the composer's own turn-scoped stop.
+// The lease lives only in the owning daemon's memory and is proxied through the CP without being stored (body-locality, §2), so an offline daemon, a daemon too old for the frame, a runtime that reports no task lifecycle, and a session that simply has no tasks are all expected answers drawn as data.
+// What the design asked for and the runtime cannot supply is absent rather than faked: no progress bar, no step line, no command line, and no "Logs" link (§3.5 records the measurement behind each).
+
+import { useEffect, useRef, useState } from 'react'
+import { Spinner } from '@/components/marks'
+import { Icon } from '@/components/ui'
+import { formatFileMtime } from '@/components/console/FileBrowser'
+import { ApiError, fetchAgentTasks, type AgentTaskDto, type AgentTasksDto } from '@/lib/api'
+import type { DockTabStatus } from './SessionDock'
+
+const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
+const statusOf = (e: unknown) => (e instanceof ApiError ? e.status : null)
+const codeOf = (e: unknown) => (e instanceof ApiError && e.code ? e.code : null)
+
+/** How often a visible panel re-reads while something is running. A state transition is the only thing a read can reveal — elapsed ticks from `startedAt` without one. */
+const POLL_MS = 5_000
+
+/** How often a running row's elapsed time redraws. Client-side arithmetic, no request. */
+const TICK_MS = 1_000
+
+/** What the Tasks tab reports upward. The caller owns the tab descriptor, so the panel reports its verdict rather than applying it — the same shape the Files and Git tabs use. */
+export interface TasksPanelVerdict {
+  /** The scoped read has answered, one way or another. */
+  settled: boolean
+  /** Running tasks for the tab's badge; null while unknown, and for a session the daemon does not track. */
+  running: number | null
+}
+
+/** The Tasks tab's status: `loading` covers the first read of a scope only. */
+// Never `empty` — and here, unlike the Files and Git tabs that inherit the choice for a corner case, it is the decision about this panel's NORMAL state. `empty` costs four things, measured against the dock: the dock's centred "Nothing to show" replaces the body, and it cannot tell an untracked session from an idle one; it only reads correctly if the panel returns null there, which throws away the sentence that draws exactly that distinction; it marks the steady state as non-ready in the strip, so a reader who opens Tasks is told nothing is there rather than that nothing is running; and it puts `vacant` (every tab non-ready) back in reach, where the dock withholds its whole tab strip and the tab a reader asked for cannot be opened at all. What `ready` costs instead is one click to learn nothing is running — the cheaper half, because the answer is a sentence and a sentence needs a panel to draw it.
+export function tasksTabStatus(settled: boolean): DockTabStatus {
+  return settled ? 'ready' : 'loading'
+}
+
+/** How long a running task has been running. Seconds below a minute, `m s` below an hour, `h m` above it — the shape the design draws, and never a negative from a daemon clock ahead of ours. */
+export function formatTaskElapsed(startedAt: string, now: number): string {
+  const started = new Date(startedAt).getTime()
+  if (Number.isNaN(started)) return ''
+  const seconds = Math.max(0, Math.round((now - started) / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ${String(seconds % 60).padStart(2, '0')}s`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ${String(minutes % 60).padStart(2, '0')}m`
+}
+
+interface TasksRead {
+  loading: boolean
+  err: string | null
+  errStatus: number | null
+  errCode: string | null
+  data: AgentTasksDto | null
+}
+
+const PENDING: TasksRead = { loading: true, err: null, errStatus: null, errCode: null, data: null }
+
+// Why the list is missing. 409 `DAEMON_FEATURE_MISSING` is the version answer the CP added for the task frame; 404 is an agent or session this reader cannot see, or one whose content was purged. Everything else (503 for both an offline daemon and an unplaced agent, plus network failures) is the offline story.
+function noticeText(status: number | null, code: string | null): string {
+  if (status === 409 && code === 'DAEMON_FEATURE_MISSING') {
+    return 'This agent runs a daemon version that cannot report background tasks. Update the agent to watch them here.'
+  }
+  if (status === 409) return 'This agent runs a daemon version that cannot report background tasks.'
+  if (status === 404) return 'This session’s tasks are not available to read.'
+  return 'Background tasks are unavailable — the owning daemon may be offline.'
+}
+
+/** One scoped read, re-issued whenever `revision` moves. The answer is held PER SCOPE and the pending state DERIVED from it rather than reset by an effect: a new scope reads as pending on the very render that changes it, so the previous session's rows are never on screen and its census can never reach the tab's badge, while a re-read of the SAME scope replaces the rows in place instead of strobing the list back to a spinner on every poll. */
+// Deriving it is also what keeps one read per revision. Measured on the version that reset from an effect and zeroed a separate poll counter beside it: after any poll had fired, a scope switch and a tab-action refresh each issued TWO reads, because zeroing the counter re-triggered the read it was there to describe.
+function useAgentTasks(agentId: string, sessionId: string, revision: number): TasksRead {
+  const scope = `${agentId}\n${sessionId}`
+  const [answered, setAnswered] = useState<{ scope: string; read: TasksRead } | null>(null)
+  useEffect(() => {
+    let live = true
+    const settle = (read: TasksRead) => {
+      if (live) setAnswered({ scope, read })
+    }
+    fetchAgentTasks(agentId, sessionId).then(
+      (data) => settle({ ...PENDING, loading: false, data }),
+      (e) => settle({ ...PENDING, loading: false, err: msg(e), errStatus: statusOf(e), errCode: codeOf(e) })
+    )
+    return () => {
+      live = false
+    }
+  }, [agentId, revision, scope, sessionId])
+  return answered?.scope === scope ? answered.read : PENDING
+}
+
+export function TasksPanel({
+  agentId,
+  sessionId,
+  active = true,
+  refreshTick = 0,
+  onVerdictChange
+}: {
+  agentId: string
+  /** The ACP session whose lease this reads. REQUIRED, unlike the workspace panels' optional scope: the daemon tracks tasks per (agent, ACP session) and holds no per-agent aggregate to answer with, so an unscoped read would be a 400 rather than a guess. */
+  sessionId: string
+  /** Whether this tab is the visible one. A hidden panel neither polls nor ticks nor re-reads; its rows are then as fresh as its last read, which is what the Git tab's changed count already is. */
+  active?: boolean
+  /** Bumped by the tab's `refresh-cw` action: re-reads without remounting. */
+  refreshTick?: number
+  /** The inputs to {@link tasksTabStatus} and the tab's badge. */
+  onVerdictChange?: (verdict: TasksPanelVerdict) => void
+}) {
+  // Reads the panel asks for ITSELF: one per poll interval while something runs, and one on the edge where the reader opens the tab, because a list read ten minutes ago is not an answer about now. Only ever increasing, and summed with the tab action's counter, so every source names one distinct read.
+  const [ownTick, setOwnTick] = useState(0)
+  const [now, setNow] = useState(() => Date.now())
+  const read = useAgentTasks(agentId, sessionId, refreshTick + ownTick)
+  const tasks = read.data?.tasks ?? []
+  const running = tasks.filter((task) => task.state === 'running').length
+  const settled = !read.loading
+
+  // The activation EDGE, not the state: re-reading on `active` itself would re-read on every render while the tab is open.
+  const wasActive = useRef(active)
+  useEffect(() => {
+    if (active && !wasActive.current) setOwnTick((tick) => tick + 1)
+    wasActive.current = active
+  }, [active])
+
+  // Only a VISIBLE panel with something running polls. An idle list has no transition to find, and a hidden one is a request nobody is looking at.
+  useEffect(() => {
+    if (!active || running === 0) return
+    const timer = setInterval(() => setOwnTick((tick) => tick + 1), POLL_MS)
+    return () => clearInterval(timer)
+  }, [active, running])
+
+  // Elapsed redraws from `startedAt` alone, so it ticks without a request.
+  useEffect(() => {
+    if (!active || running === 0) return
+    const timer = setInterval(() => setNow(Date.now()), TICK_MS)
+    return () => clearInterval(timer)
+  }, [active, running])
+
+  // `running` is null for anything that is not a counted answer — a failed read AND an untracked session. A `0` there would assert "nothing is running" about a lease we were never shown.
+  const counted = read.data?.tracked ? running : null
+  // Reported on the EDGE: the caller's callback is a fresh closure per render and a poll usually finds the same census, so re-reporting the verdict the tab already holds would write parent state — re-rendering the whole session page — once per interval.
+  const reported = useRef<string | null>(null)
+  useEffect(() => {
+    const key = `${settled}:${counted ?? ''}`
+    if (reported.current === key) return
+    reported.current = key
+    onVerdictChange?.({ settled, running: counted })
+  }, [counted, onVerdictChange, settled])
+
+  // Withheld until the first read of this scope answers, so the dock's own "Loading…" placeholder speaks alone rather than beside a second one of the panel's making.
+  if (!settled) return null
+
+  const body = () => {
+    if (read.err) return <PanelNotice text={noticeText(read.errStatus, read.errCode)} warn={read.errStatus !== 503} />
+    // Two different answers the design would otherwise collapse into one empty state: a runtime that reports no task lifecycle at all has NO lease, which is not the same statement as a tracked session that happens to be idle.
+    if (!read.data?.tracked) {
+      return (
+        <PanelNotice text="This agent’s runtime doesn’t report background tasks, so there is nothing to watch here. Its work still streams into the conversation." />
+      )
+    }
+    if (tasks.length === 0) {
+      return (
+        <PanelNotice text="No background tasks in this session — everything the agent ran finished inside its turn." />
+      )
+    }
+    return (
+      <>
+        {tasks.map((task) => (
+          <TaskRow key={task.id} task={task} now={now} />
+        ))}
+        {read.data.truncated ? (
+          <div className="px-3 pt-1 pb-[10px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+            Older tasks are not shown — the daemon keeps a bounded history.
+          </div>
+        ) : null}
+      </>
+    )
+  }
+
+  return (
+    <div data-tasks-panel="" className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-none items-center gap-2 border-b border-(--border-subtle) px-3 py-[10px]">
+        <span
+          data-tasks-census=""
+          className="min-w-0 flex-1 font-sans text-[11px] font-normal leading-normal text-(--text-secondary)"
+        >
+          {summaryText(read.data, tasks)}
+        </span>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-[6px] overflow-auto px-3 py-[10px]">{body()}</div>
+    </div>
+  )
+}
+
+/** The header's one-line census. Counts what is on screen, so it can never disagree with the rows. */
+function summaryText(data: AgentTasksDto | null, tasks: AgentTaskDto[]): string {
+  if (!data?.tracked) return 'Background tasks'
+  if (tasks.length === 0) return 'No background tasks'
+  const running = tasks.filter((task) => task.state === 'running').length
+  const failed = tasks.filter((task) => task.state === 'failed').length
+  const done = tasks.length - running - failed
+  const parts = [`${running} running`]
+  if (done > 0) parts.push(`${done} done`)
+  if (failed > 0) parts.push(`${failed} failed`)
+  return parts.join(' · ')
+}
+
+/** The accent that carries a row's state, as tokens rather than a colour decision per row. */
+// `circle-check` and `circle-x` are names THIS lucide version has; `check-circle-2`, which §8's icon list names, is not one of them and would render nothing at all.
+const ACCENT: Record<AgentTaskDto['state'], string> = {
+  running: 'var(--status-info)',
+  done: 'var(--status-online)',
+  failed: 'var(--red-600)'
+}
+
+// The row's left edge, coloured per state. Every side is named explicitly rather than painting all four and overriding the left: two colour utilities for the same edge would leave which one wins to the order Tailwind happens to emit them in.
+const BORDER: Record<AgentTaskDto['state'], string> = {
+  running: 'border-l-(--status-info)',
+  done: 'border-l-(--status-online)',
+  failed: 'border-l-(--red-600)'
+}
+
+function TaskRow({ task, now }: { task: AgentTaskDto; now: number }) {
+  const running = task.state === 'running'
+  return (
+    <div
+      data-task-row={task.state}
+      className={`flex flex-none flex-col gap-[5px] rounded-md border-y border-r border-l-2 border-y-(--border-subtle) border-r-(--border-subtle) bg-(--surface-card) px-[10px] py-2 ${BORDER[task.state]}`}
+    >
+      <div className="flex items-center gap-2">
+        {running ? (
+          <span className="flex flex-none items-center">
+            <Spinner size={12} />
+          </span>
+        ) : (
+          <Icon
+            name={task.state === 'failed' ? 'circle-x' : 'circle-check'}
+            size={13}
+            color={ACCENT[task.state]}
+            className="flex-none"
+          />
+        )}
+        {/* A runtime that named no description still gets a row — it is the thing fencing host reclaim, and an unnamed task is exactly what a reader needs to be told about. */}
+        <span
+          className={`min-w-0 flex-1 truncate font-sans text-[12.5px] leading-normal ${
+            task.description ? 'font-medium text-(--text-primary)' : 'font-normal italic text-(--text-tertiary)'
+          }`}
+          title={task.description ?? undefined}
+        >
+          {task.description ?? 'Unnamed task'}
+        </span>
+        {/* Subagent rows are CARRIED rather than filtered: the same records fence reclaim, so hiding them here would show "no tasks" beside a host refusing to be reclaimed. Marked instead. */}
+        {task.subagent ? (
+          <span
+            className="flex-none rounded-xs bg-(--surface-active) px-[5px] py-px font-sans text-[10px] font-medium leading-normal text-(--text-tertiary)"
+            title="The runtime’s own internal subagent invocation"
+          >
+            subagent
+          </span>
+        ) : null}
+        <span className="mono flex-none text-[11px] leading-normal text-(--text-tertiary)">
+          {running ? formatTaskElapsed(task.startedAt, now) : formatFileMtime(task.endedAt)}
+        </span>
+      </div>
+      {/* The terminal status the runtime reported, when it named one. Most settle edges carry none, which is why `done` never asserts success on its own. */}
+      {task.detail ? (
+        <div className="pl-[21px] font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-secondary)">
+          {task.detail}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+// A degraded or empty state, drawn calmly: a session nobody can read tasks for still has something to say about why.
+function PanelNotice({ text, warn = false }: { text: string; warn?: boolean }) {
+  return (
+    <div className="flex items-start gap-2 px-3 py-[10px] font-sans text-[12px] font-normal leading-[1.55] text-(--text-secondary)">
+      <Icon
+        name={warn ? 'triangle-alert' : 'list-checks'}
+        size={14}
+        color={warn ? 'var(--amber-500)' : 'var(--text-tertiary)'}
+        className="mt-[2px] flex-none"
+      />
+      <span>{text}</span>
+    </div>
+  )
+}

--- a/packages/web/src/components/console/dock/TasksPanel.tsx
+++ b/packages/web/src/components/console/dock/TasksPanel.tsx
@@ -16,8 +16,17 @@ const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
 const statusOf = (e: unknown) => (e instanceof ApiError ? e.status : null)
 const codeOf = (e: unknown) => (e instanceof ApiError && e.code ? e.code : null)
 
-/** How often a visible panel re-reads while something is running. A state transition is the only thing a read can reveal — elapsed ticks from `startedAt` without one. */
+/** How often a visible panel re-reads while something is running. */
 const POLL_MS = 5_000
+
+/** How often a visible panel re-reads while NOTHING is running. A visible panel must keep reading
+ *  even from an idle snapshot: what it watches is a SESSION, not the rows it happens to be showing,
+ *  and the session starts new background tasks — most directly when the reader leaves this tab open
+ *  and sends another prompt from the composer beside it. Nothing in that path bumps this panel's
+ *  revision, so an idle panel that stopped polling would never observe the 0 -> running edge and
+ *  the new task would stay invisible until a manual refresh. Backed off rather than equal to
+ *  {@link POLL_MS} because an idle session usually stays idle. */
+const IDLE_POLL_MS = 20_000
 
 /** How often a running row's elapsed time redraws. Client-side arithmetic, no request. */
 const TICK_MS = 1_000
@@ -121,10 +130,12 @@ export function TasksPanel({
     wasActive.current = active
   }, [active])
 
-  // Only a VISIBLE panel with something running polls. An idle list has no transition to find, and a hidden one is a request nobody is looking at.
+  // A VISIBLE panel always polls; only the cadence depends on what it is showing. Visibility is the
+  // whole gate because a hidden panel is a request nobody is looking at, whereas an idle VISIBLE one
+  // still has the 0 -> running edge to discover (see {@link IDLE_POLL_MS}).
   useEffect(() => {
-    if (!active || running === 0) return
-    const timer = setInterval(() => setOwnTick((tick) => tick + 1), POLL_MS)
+    if (!active) return
+    const timer = setInterval(() => setOwnTick((tick) => tick + 1), running > 0 ? POLL_MS : IDLE_POLL_MS)
     return () => clearInterval(timer)
   }, [active, running])
 

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -102,6 +102,7 @@ import { DockPanel, SessionDock, SessionDockSlot, type DockTab } from '@/compone
 import { SessionsPanel, sessionsTabStatus } from '@/components/console/dock/SessionsPanel'
 import { FilesPanel, filesTabStatus } from '@/components/console/dock/FilesPanel'
 import { GitPanel, gitTabStatus, type GitPanelVerdict } from '@/components/console/dock/GitPanel'
+import { TasksPanel, tasksTabStatus, type TasksPanelVerdict } from '@/components/console/dock/TasksPanel'
 import { SessionViewer, viewerModeFromParam, type ViewerMode } from '@/components/console/viewer/SessionViewer'
 import {
   EMPTY_RAIL_AGENT_FILTER,
@@ -1185,6 +1186,13 @@ const DOCK_TABS: DockTab[] = [
     icon: 'git-commit-horizontal',
     actionIcon: 'refresh-cw',
     actionLabel: 'Refresh git status'
+  },
+  {
+    key: 'tasks',
+    label: 'Tasks',
+    icon: 'list-checks',
+    actionIcon: 'refresh-cw',
+    actionLabel: 'Refresh background tasks'
   }
 ]
 
@@ -1826,6 +1834,9 @@ export default function SessionDetailView() {
     focusedSession?.workspaceIsolation !== undefined
   // A REJECTED isolation read is not a pending one. The checkout still may not be read — the answer is unknown either way — but a spinner that never resolves is a worse lie than saying so, so this state gets its own copy and the tab counts as answered.
   const filesScopeFailed = !filesScopeReady && extraHeaderDetailError !== undefined
+  // Which lease the Tasks tab reads. Tasks are NOT a checkout, so this waits on neither the worktree gate `filesSessionId` applies nor the isolation round trip Files and Git hold for — a session's background tasks exist whatever it is checked out into, and the CP says so. What it does need is the CANONICAL session id the lease is keyed by, which is what the focus options already carry. A playground session the daemon has not created yet has no canonical id and no tasks either, so it gets no tab rather than a 404 notice.
+  const tasksSessionId =
+    headerFocusSessionId && !(syntheticPlayground && headerFocusSessionId === session?.id) ? headerFocusSessionId : null
   const focusedAgentRuntime = focusedSession?.runtime || focusedAgent?.runtime || ''
   const focusedRuntimeMeta = acpRuntime(acpRegistry, focusedAgentRuntime)
 
@@ -1880,6 +1891,9 @@ export default function SessionDetailView() {
     setFilesRefreshTick((tick) => tick + 1)
   }, [])
   const [gitVerdict, setGitVerdict] = useState<GitPanelVerdict>({ settled: false, changed: null })
+  // The Tasks tab's own `refresh-cw` and verdict. Its settle state feeds the tab status, its running count the badge.
+  const [tasksRefreshTick, setTasksRefreshTick] = useState(0)
+  const [tasksVerdict, setTasksVerdict] = useState<TasksPanelVerdict>({ settled: false, running: null })
   // A seed narrowed to the conversation already on screen hides the list AND the picker that could widen it, so re-ask it unfiltered.
   const railSeedKeyNow = railSeedKey(railFilter)
   // Waited on because an in-flight family reads as EMPTY, not `undefined`: latching there widens a list about to grow a Related tree.
@@ -1905,11 +1919,16 @@ export default function SessionDetailView() {
   const filesStatus = filesScopeFailed ? 'ready' : filesScopeReady ? filesTabStatus(filesRootSettled) : 'loading'
   // Same three states for Git, and for the same reasons: an unknown checkout is `loading`, a failed isolation read is answered copy.
   const gitStatus = filesScopeFailed ? 'ready' : filesScopeReady ? gitTabStatus(gitVerdict.settled) : 'loading'
+  // Tasks has no isolation branch to wait on, so its status is only ever "has the read answered".
+  const tasksStatus = tasksTabStatus(tasksVerdict.settled)
   // Each tab's own verdict, spliced onto the static descriptors. Files is dropped outright rather than left `loading` forever when there is no agent behind it — a tab that can never answer is not a tab — and the demo tour has no daemon to read a checkout from at all, so it does not get one either.
   const dockTabs = useMemo<DockTab[]>(
     () =>
-      DOCK_TABS.filter(
-        (tab) => (tab.key !== 'files' && tab.key !== 'git') || (filesAgentId !== null && !MOCK_MODE)
+      DOCK_TABS.filter((tab) =>
+        tab.key === 'files' || tab.key === 'git'
+          ? filesAgentId !== null && !MOCK_MODE
+          : // Dropped on the same terms and for the same reason, but against its OWN scope: no agent to ask, or no canonical session for the lease to be keyed by.
+            tab.key !== 'tasks' || (filesAgentId !== null && tasksSessionId !== null && !MOCK_MODE)
       ).map((tab) =>
         tab.key === 'sessions'
           ? { ...tab, status: sessionsStatus }
@@ -1922,9 +1941,25 @@ export default function SessionDetailView() {
                   // The badge is the changed-file count, omitted rather than shown as `0`: a clean tree wears no pill, and neither does a workspace whose status could not be read.
                   ...(gitVerdict.changed ? { badge: gitVerdict.changed } : {})
                 }
-              : tab
+              : tab.key === 'tasks'
+                ? {
+                    ...tab,
+                    status: tasksStatus,
+                    // Running tasks only, and omitted rather than shown as `0`: an idle session wears no pill, and neither does an untracked one, whose count is null rather than zero.
+                    ...(tasksVerdict.running ? { badge: tasksVerdict.running } : {})
+                  }
+                : tab
       ),
-    [filesAgentId, filesStatus, gitStatus, gitVerdict.changed, sessionsStatus]
+    [
+      filesAgentId,
+      filesStatus,
+      gitStatus,
+      gitVerdict.changed,
+      sessionsStatus,
+      tasksSessionId,
+      tasksStatus,
+      tasksVerdict.running
+    ]
   )
   // The active tab has to be one that exists: a Files tab dropped under the reader would otherwise leave the dock with no active tab and an unlabelled panel.
   const dockTabKey = dockTabs.some((tab) => tab.key === dockTab) ? dockTab : DOCK_TABS[0]!.key
@@ -4483,6 +4518,7 @@ export default function SessionDetailView() {
         onTabAction={(key) => {
           if (key === 'files') setFilesRefreshTick((tick) => tick + 1)
           if (key === 'git') setGitRefreshTick((tick) => tick + 1)
+          if (key === 'tasks') setTasksRefreshTick((tick) => tick + 1)
         }}
         overlayKey={`${session.id}:${viewerPath ?? ''}`}
         label="Panels"
@@ -4553,6 +4589,18 @@ export default function SessionDetailView() {
                 setViewerFile(path, filesAgentId, untracked ? 'file' : staged ? 'staged' : 'diff')
               }
               onVerdictChange={setGitVerdict}
+            />
+          ) : null}
+        </DockPanel>
+        {/* No isolation gate and no withheld state: the lease is keyed by the session, not by a checkout, so there is nothing to resolve first. `active` is what keeps a hidden panel from polling. */}
+        <DockPanel active={dockTabKey === 'tasks'}>
+          {filesAgentId && tasksSessionId ? (
+            <TasksPanel
+              agentId={filesAgentId}
+              sessionId={tasksSessionId}
+              active={dockTabKey === 'tasks'}
+              refreshTick={tasksRefreshTick}
+              onVerdictChange={setTasksVerdict}
             />
           ) : null}
         </DockPanel>

--- a/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
@@ -26,7 +26,12 @@ const wire = vi.hoisted(() => ({
   stageCalls: [] as Array<{ kind: 'stage' | 'unstage'; paths: string[]; sessionId?: string }>,
   /** A session with no agent behind it at all — there is no checkout to offer a workspace tab for. */
   agentless: false,
-  rail: [] as unknown[]
+  rail: [] as unknown[],
+  /** The Tasks tab's read. Scoped by SESSION rather than by worktree, so its calls are recorded with the scope they asked for. */
+  tasks: { sessionId: 'session-1', tracked: true, tasks: [] as unknown[], truncated: false } as unknown,
+  taskCalls: [] as Array<{ agentId: string; sessionId: string }>,
+  /** A synthetic playground session the daemon has not created yet — its route id names no canonical session the lease could be keyed by. */
+  playground: false
 }))
 
 // The reader's role in the org. `viewer` is what the CP 403s on every git-write route, so the console withholds those controls.
@@ -117,6 +122,10 @@ vi.mock('@/lib/api', async (importOriginal) => {
         truncated: false
       })
     }),
+    fetchAgentTasks: vi.fn((agentId: string, sessionId: string) => {
+      wire.taskCalls.push({ agentId, sessionId })
+      return Promise.resolve(wire.tasks)
+    }),
     fetchSessionMessages: vi.fn(() => Promise.resolve({ messages: [], nextCursor: null })),
     fetchSessionDetail: vi.fn(() => Promise.reject(new Error('no detail'))),
     fetchMySessionIdentity: vi.fn(() => Promise.reject(new Error('no identity'))),
@@ -162,7 +171,12 @@ vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({
     agents: [agent],
     allSessions: [
-      { ...session, workspaceIsolation: wire.isolation, ...(wire.agentless ? { agentId: '', agentName: '' } : {}) }
+      {
+        ...session,
+        workspaceIsolation: wire.isolation,
+        ...(wire.agentless ? { agentId: '', agentName: '' } : {}),
+        ...(wire.playground ? { platform: 'playground' } : {})
+      }
     ],
     getSessions: () => [session],
     sessionsLoading: false,
@@ -287,7 +301,10 @@ beforeEach(() => {
   wire.stageCalls = []
   org.role = 'collaborator'
   wire.agentless = false
+  wire.playground = false
   wire.rail = []
+  wire.tasks = { sessionId: 'session-1', tracked: true, tasks: [], truncated: false }
+  wire.taskCalls = []
   window.localStorage.clear()
   window.matchMedia = ((query: string) => ({
     matches: false,
@@ -747,6 +764,98 @@ describe('the Git tab', () => {
   })
 })
 
+describe('the Tasks tab', () => {
+  const openTab = async (key: string) => {
+    await act(async () => {
+      container?.querySelector<HTMLElement>(`[data-dock-tab="${key}"]`)?.click()
+      await Promise.resolve()
+    })
+    await render()
+  }
+  const runningTask = (id: string) => ({
+    id,
+    description: `background ${id}`,
+    state: 'running',
+    subagent: false,
+    startedAt: '2026-08-10T10:59:00.000Z',
+    endedAt: null,
+    detail: null
+  })
+
+  it('sits beside Files and Git with its own refresh action, and mounts its panel with them', async () => {
+    await render()
+    expect(container?.querySelector('[data-dock-tab="tasks"]')).not.toBeNull()
+    // Mounted rather than lazily created on first visit: like the others, its verdict is what keeps its own tab reachable.
+    expect(container?.querySelector('[data-tasks-panel]')).not.toBeNull()
+
+    await openTab('tasks')
+    expect(container?.querySelector('[data-dock-action="tasks"]')?.getAttribute('aria-label')).toBe(
+      'Refresh background tasks'
+    )
+    expect(container?.querySelector('[data-dock-empty]')).toBeNull()
+  })
+
+  it('reads the FOCUSED SESSION’s lease even on a shared workspace, where the worktree scope is empty', async () => {
+    // The divergence M4 rewrote the CP gate for: a background task is not a checkout, so a session that shares its agent's workspace still runs them and still has a lease keyed by (agent, session). Files and Git must pass no sessionId here — the daemon rejects one for a shared workspace — and Tasks must pass one anyway, or the panel reads a scope the daemon has nothing to answer with.
+    wire.isolation = 'shared'
+    wire.tasks = { sessionId: 'session-1', tracked: true, tasks: [runningTask('t1')], truncated: false }
+    await render()
+    expect(wire.listCalls.every((call) => call.sessionId === undefined)).toBe(true)
+    expect(wire.taskCalls).toEqual([{ agentId: 'agent-1', sessionId: 'session-1' }])
+    expect(container?.querySelector('[data-tasks-panel]')?.textContent).toContain('background t1')
+  })
+
+  it('badges the tab with the running count, and drops the badge when its refresh finds them finished', async () => {
+    wire.tasks = {
+      sessionId: 'session-1',
+      tracked: true,
+      tasks: [runningTask('t1'), runningTask('t2')],
+      truncated: false
+    }
+    await render()
+    expect(container?.querySelector('[data-dock-tab="tasks"]')?.textContent).toContain('2')
+
+    // Opened FIRST, so the panel's own on-activation read is already spent and cannot be what makes the badge move below. The tab's refresh action is then the only thing left that can.
+    await openTab('tasks')
+    expect(wire.taskCalls).toHaveLength(2)
+    expect(container?.querySelector('[data-dock-tab="tasks"]')?.textContent).toContain('2')
+
+    wire.tasks = {
+      sessionId: 'session-1',
+      tracked: true,
+      tasks: [{ ...runningTask('t1'), state: 'done', endedAt: '2026-08-10T11:00:00.000Z' }],
+      truncated: false
+    }
+    await act(async () => {
+      container?.querySelector<HTMLElement>('[data-dock-action="tasks"]')?.click()
+      await Promise.resolve()
+    })
+    await render()
+    expect(container?.querySelector('[data-dock-tab="tasks"]')?.textContent).not.toContain('2')
+    expect(container?.querySelector('[data-tasks-panel]')?.textContent).toContain('1 done')
+  })
+
+  it('offers no Tasks tab for a synthetic playground session, whose canonical id does not exist yet', async () => {
+    // The lease is keyed by the daemon's OWN session id. A playground session it has not created yet has no such id and no tasks either, so asking with the synthetic route id would only manufacture a 404 notice; Files and Git keep their tabs — the checkout is real even while the session is not.
+    wire.playground = true
+    await render()
+    expect(container?.querySelector('[data-dock-tab="files"]')).not.toBeNull()
+    expect(container?.querySelector('[data-dock-tab="tasks"]')).toBeNull()
+    expect(container?.querySelector('[data-tasks-panel]')).toBeNull()
+    expect(wire.taskCalls).toEqual([])
+  })
+
+  it('draws an untracked session as data, with no badge and no error', async () => {
+    // A runtime that publishes no task lifecycle holds no lease at all. That is an answer, not a failure, and it is a different sentence from "nothing is running".
+    wire.tasks = { sessionId: 'session-1', tracked: false, tasks: [], truncated: false }
+    await render()
+    await openTab('tasks')
+    expect(container?.querySelector('[data-tasks-panel]')?.textContent).toContain('doesn’t report background tasks')
+    expect(container?.querySelector('[data-dock-tab="tasks"]')?.textContent).toBe('Tasks')
+    expect(container?.querySelector('[data-dock-empty]')).toBeNull()
+  })
+})
+
 describe('a session with no agent behind it', () => {
   it('offers neither workspace tab, because a tab that can never answer is not a tab', async () => {
     wire.agentless = true
@@ -757,9 +866,13 @@ describe('a session with no agent behind it', () => {
     expect(container?.querySelector('[data-dock-tab="sessions"]')).not.toBeNull()
     expect(container?.querySelector('[data-dock-tab="files"]')).toBeNull()
     expect(container?.querySelector('[data-dock-tab="git"]')).toBeNull()
+    // Tasks goes with them: with no agent there is no daemon to ask for a lease either.
+    expect(container?.querySelector('[data-dock-tab="tasks"]')).toBeNull()
     // And no panel was mounted to read a checkout that does not exist.
     expect(container?.querySelector('[data-git-panel]')).toBeNull()
     expect(container?.querySelector('[data-files-panel]')).toBeNull()
+    expect(container?.querySelector('[data-tasks-panel]')).toBeNull()
+    expect(wire.taskCalls).toEqual([])
   })
 
   it('falls back to a tab that exists when the open one is dropped under the reader', async () => {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3074,6 +3074,45 @@ export async function draftWorkspaceCommitMessage(
   )
 }
 
+// ── session background tasks (proxied live from the owning daemon's lease) ────
+// What the daemon can know about a task, and nothing more. No `queued`: the runtime lifecycle
+// feed's only start edge is `task_started`, so a task is either live in the lease or gone. `done`
+// means "settled with no reported failure" rather than "reported successful", because most settle
+// edges carry no status at all — `detail` carries one when the runtime named it.
+export type AgentTaskState = 'running' | 'done' | 'failed'
+
+// One background task of one ACP session. `subagent` is the runtime's own internal Task
+// invocation; the wire carries those rather than filtering them, because the same records fence
+// host reclaim — so this panel shows them marked instead of hiding them (webchat-side-panels.md §3.5).
+export interface AgentTaskDto {
+  id: string
+  description: string | null // null ⇒ the runtime named none
+  state: AgentTaskState
+  subagent: boolean
+  startedAt: string // RFC3339
+  endedAt: string | null // RFC3339; null ⇒ still running
+  detail: string | null // the terminal status the runtime reported, when it named one
+}
+
+// GET /agents/:id/tasks?sessionId=… — live tasks first, then the daemon's bounded settled
+// history. `tracked:false` means that daemon holds no lease for the session (a runtime that
+// reports no task lifecycle, or one that has not yet), which is a different answer from an empty
+// list and the panel says so.
+export interface AgentTasksDto {
+  sessionId: string
+  tracked: boolean
+  tasks: AgentTaskDto[]
+  truncated: boolean // true ⇒ the daemon held more tasks than this page carries
+}
+
+// Read one ACP session's background tasks. `sessionId` is REQUIRED, unlike the workspace reads:
+// the lease is per (agent, ACP session) and there is no per-agent aggregate to answer with. There
+// is no cancel counterpart — no agent-protocol primitive can address a single background task.
+export async function fetchAgentTasks(agentId: string, sessionId: string): Promise<AgentTasksDto> {
+  const q = new URLSearchParams({ sessionId })
+  return apiGet<AgentTasksDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/tasks?${q.toString()}`)
+}
+
 // ── usage dashboard (GET /usage) — real historical aggregates from the CP's
 // persisted per-session usage store, summed over the selected range. ──
 export type UsageRange = 'd1' | 'd7' | 'd30' | 'd90'


### PR DESCRIPTION
Milestone M4 of [`docs/designs/webchat-side-panels.md`](../blob/dev/yulong/webchat-dock-m4/docs/designs/webchat-side-panels.md) — the dock's fifth tab, after M0 (#808), M1 (#824), M2 (#833) and M3 (#849).

`task/list` reads one ACP session's background tasks live from the owning daemon's in-memory lease. The CP proxies one snapshot and persists none of it: task descriptions are model-authored text, so they fall under body-locality like a transcript does.

## Scope

Per **(agent, ACP session)**, because the lease already is — ACP session ids are runtime-local, so two agents can each expose an `acp-1`. `sessionId` is therefore **required**, not optional, and the only per-agent aggregate that exists is a boolean.

Unlike the workspace reads, this is **not** gated on workspace isolation. A lease is not a checkout, and a session's background tasks exist whatever it runs in — so the panel uses the canonical session id directly rather than the worktree-gated scope `Files` and `Git` wait for.

The daemon's lease gains a `startedAt` and a **bounded settled-task history**, kept in a separate `settled` array rather than in `lease.tasks`, so no reclaim decision can observe it. A task retained for the panel must not keep its session open or spend the background-task wake budget ([`background-task-aware-reclaim.md`](../blob/dev/yulong/webchat-dock-m4/docs/designs/background-task-aware-reclaim.md)); there is a test for exactly that pair.

## What the design asked for and is deliberately absent

Measured against the shipped daemon and `@agentclientprotocol/sdk@1.3.0` while building this, not assumed:

**No `task/cancel` — no frame, no route, no control.** `CancelNotification` carries only `{ sessionId }` and cancels a whole prompt turn. There is no ext-request sender, so no `_claude/*` kill-by-id can be sent. The daemon advertises no terminal capability, so the agent owns its own shells. The only hard stop is killing the agent's shared adapter, which takes every session on it. And the turn-scoped interrupt is a no-op *exactly* when this panel matters, because a background task outlives its turn — there is no `pending` entry left to interrupt. A per-row control could therefore only cancel unrelated work or report a stop it did not perform. The escape hatch is the composer's existing turn-scoped stop. This becomes buildable if a task-addressed cancel lands upstream.

**No `queued` state.** The lifecycle feed's only start edge is `task_started`, so a task is either live in the lease or gone.

**No progress bar and no step line.** Nothing upstream reports either. The design drew both; inventing them would be a number the reader cannot check.

## Two answers the panel refuses to collapse

`tracked:false` means the daemon holds no lease for the session — a non-Claude runtime, an adapter without the lifecycle extension, or a session that has emitted nothing yet. That is a different statement from "this session has no background tasks", and the panel says so instead of drawing an empty list.

`subagent` rows are carried on the wire and marked at render rather than filtered at the source, because the same records fence host reclaim: a panel that hid them would show "no tasks" beside a host refusing to be reclaimed.

`done` means "settled with no reported failure" rather than "reported successful", because most settle edges carry no status at all. `detail` carries the reported status when the runtime named one.

## Verification

| Suite | Result |
| --- | --- |
| `protocol` | 306 / 306 |
| `control-plane test:unit` | 1478 / 1478 |
| `control-plane test:int` | 77 files / 1101 tests (incl. the new tasks-route integration test) |
| `web` | 137 files / 1443 tests |
| `daemon` (files this touches, plus the two from the rebased-in #851) | 124 / 124 |
| repo `typecheck` / `lint` / `format:check` | clean (2 pre-existing lint warnings in `daemon/test/workspace-git-write.test.ts` from the M3 era) |

Also fixed along the way: `SessionDetailView.viewer.test.tsx` was not mocking the new task read, so that suite was letting a real fetch escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
