### PR TITLE
refactor(daemon): make git credential pointers a function of where git runs

### DIFF
--- a/packages/daemon/src/cli/gh-token.ts
+++ b/packages/daemon/src/cli/gh-token.ts
@@ -18,7 +18,7 @@
 import { createConnection } from 'node:net'
 import { gitRepoLabel } from '@agentconnect.md/protocol'
 import { resolveRoot } from '../paths.js'
-import { GITCRED_CAPABILITY_ENV, gitcredSocketPath } from '../cp/gitcred-server.js'
+import { GITCRED_CAPABILITY_ENV, gitcredSocketFrom } from '../cp/gitcred-server.js'
 
 export async function runGhToken(agentId: string, repoRaw?: string): Promise<void> {
   const target = normalizeRepoArg(repoRaw)
@@ -80,7 +80,7 @@ interface IpcReply {
 }
 
 function ipc(msg: unknown): Promise<IpcReply> {
-  const path = gitcredSocketPath(resolveRoot())
+  const path = gitcredSocketFrom(process.env, resolveRoot())
   return new Promise((resolve) => {
     const sock = createConnection(path)
     let buf = ''

--- a/packages/daemon/src/cli/git-credential.ts
+++ b/packages/daemon/src/cli/git-credential.ts
@@ -22,7 +22,7 @@
  */
 import { createConnection } from 'node:net'
 import { resolveRoot } from '../paths.js'
-import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV, gitcredSocketPath } from '../cp/gitcred-server.js'
+import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV, gitcredSocketFrom } from '../cp/gitcred-server.js'
 
 interface HelperInput {
   protocol?: string
@@ -143,7 +143,7 @@ interface IpcReply {
 }
 
 function ipc(msg: unknown): Promise<IpcReply> {
-  const path = gitcredSocketPath(resolveRoot())
+  const path = gitcredSocketFrom(process.env, resolveRoot())
   return new Promise((resolve) => {
     const sock = createConnection(path)
     let buf = ''

--- a/packages/daemon/src/cp/gitcred-server.ts
+++ b/packages/daemon/src/cp/gitcred-server.ts
@@ -40,6 +40,17 @@ export const GITCRED_CAPABILITY_ENV = 'AC_GITCRED_CAPABILITY'
  *  `.git/config` helper line, which goes stale when an agent is deleted and
  *  recreated under the same name over a surviving checkout. */
 export const GITCRED_AGENT_ENV = 'AC_GITCRED_AGENT'
+/** Where a helper finds the socket, when that is not under this daemon's own root. A helper
+ *  running in a sandbox pod reaches the daemon through the shim's tunnel instead, and the pod's
+ *  filesystem has no daemon root to derive a path from. Non-secret: it is a path, and the
+ *  capability above is what authorizes the request that travels over it. */
+export const GITCRED_SOCKET_ENV = 'AC_GITCRED_SOCKET'
+
+/** The socket a helper should dial: an explicit override, else this daemon's own. */
+export function gitcredSocketFrom(env: NodeJS.ProcessEnv, root: string): string {
+  const override = env[GITCRED_SOCKET_ENV]?.trim()
+  return override && override.length > 0 ? override : gitcredSocketPath(root)
+}
 
 export function gitcredSocketPath(root: string): string {
   return join(root, 'run', 'gitcred.sock')

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -88,9 +88,11 @@ import {
 import { writeGhShim } from './cp/gh-shim.js'
 import { GitCredServer, gitcredShimPath, gitcredSocketPath, writeGitcredShim } from './cp/gitcred-server.js'
 import {
+  daemonGitCredentialTarget,
   gitCredentialEnv,
   initGitInjection,
   probeGitVersion,
+  sandboxGitCredentialTarget,
   sessionGitEnv,
   sessionGitPolicyEnv
 } from './workspace/git-injection.js'
@@ -2666,9 +2668,16 @@ export class Daemon {
         return gitRepoLabel(ws.gitRepo) ?? undefined
       }
     })
-    initGitInjection({
+    const daemonCredentialTarget = daemonGitCredentialTarget({
       shimPath: writeGitcredShim(root, daemonEntryForShims(root)),
-      runDir: join(root, 'run'),
+      runDir: join(root, 'run')
+    })
+    initGitInjection({
+      // Off the SAME predicate the workspace git runner uses, so the pointers always describe the
+      // filesystem the git that reads them will run in. Derived per call rather than fixed at boot:
+      // a cluster agent's channel comes and goes, and both resolvers follow it together.
+      targetFor: (agentId) =>
+        this.k8sPlane?.runsInSandbox(agentId) ? sandboxGitCredentialTarget() : daemonCredentialTarget,
       capabilityFor: (agentId) => this.gitCredServer!.capabilityFor(agentId),
       preWarm: async (agentId, reason) => {
         await this.gitCreds.get(agentId, reason)

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -109,6 +109,10 @@ export interface K8sRuntimePlane {
   /** A git runner for an agent whose workspace lives on its sandbox pod, or undefined when this
    *  daemon has no channel for it — the caller then keeps its local behaviour. */
   gitRunnerFor: (agentId: string, cwd?: string, abort?: AbortSignal) => GitRunner | undefined
+  /** Whether this agent's work runs in a pod right now — the SAME condition `gitRunnerFor`
+   *  answers on. Callers that build paths for that work read it here rather than re-deriving it,
+   *  so an environment can never describe one filesystem while the execution happens in another. */
+  runsInSandbox: (agentId: string) => boolean
   /** Where the agent's bound pod mounts its workspace, as its shim reported; undefined before a
    *  bind or from a legacy shim (callers fall back to DEFAULT_SHIM_WORKSPACE_ROOT). */
   workspaceRootFor: (agentId: string) => string | undefined
@@ -154,6 +158,10 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     ...(options.credentialTtlMs === undefined ? {} : { credentialTtlMs: options.credentialTtlMs }),
     log: options.log ?? SILENT
   })
+  // The one condition that means "this agent's work happens in a pod". Defined once because two
+  // callers must agree on it: the git runner, and the credential pointers that git will read.
+  const runsInSandbox = (agentId: string): boolean => driver.sessionFor(agentId)?.isAttached() === true
+
   // One proxy per agent, replaced when a NEW launch binds: its streams belong to a pod, and a
   // proxy kept across incarnations would answer connections for a sandbox that no longer exists.
   const proxies = new Map<string, { generation: number; proxy: TunnelProxy }>()
@@ -251,13 +259,13 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       }
     },
     gitRunnerFor: (agentId, cwd, abort) => {
-      const session = driver.sessionFor(agentId)
       // No channel means this agent has no sandbox to run git in. Returning undefined keeps the
       // caller on its local runner rather than failing the operation — which is what a
       // self-hosted agent beside a cluster-backed one needs anyway.
-      if (!session?.isAttached()) return undefined
-      return new ShimGitRunner(session, cwd, undefined, abort)
+      if (!runsInSandbox(agentId)) return undefined
+      return new ShimGitRunner(driver.sessionFor(agentId)!, cwd, undefined, abort)
     },
+    runsInSandbox,
     workspaceRootFor: (agentId) => driver.workspaceRootFor(agentId),
     stop: async () => {
       for (const timer of lossTimers.values()) clearTimeout(timer)

--- a/packages/daemon/src/shim/sandbox-paths.ts
+++ b/packages/daemon/src/shim/sandbox-paths.ts
@@ -1,0 +1,17 @@
+/**
+ * Paths the RUNTIME IMAGE fixes, as opposed to paths this daemon owns.
+ *
+ * They live in their own module because the distinction is the whole point: a daemon-derived path
+ * means nothing inside a sandbox, and the bugs that come from mixing the two coordinate systems
+ * are silent — git asks a credential helper that exists on a machine it is not on, and the failure
+ * surfaces as an authentication error. Anything here has a counterpart in
+ * `docker/runtime-sandbox.Dockerfile`, and changing one without the other breaks the pod.
+ */
+
+/** The credential helper git runs inside the pod. Root-owned and read-only, like the shim. */
+export const SANDBOX_GIT_CREDENTIAL_HELPER = '/opt/agentconnect/bin/git-credential'
+
+/** Where daemon-written, per-agent git configuration is materialized in the pod. Under /run rather
+ *  than the workspace volume: it is regenerated per launch and belongs to the POD, so a resumed
+ *  workspace must not carry a previous incarnation's copy. */
+export const SANDBOX_GIT_CONFIG_DIR = '/run/agentconnect/git'

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -30,11 +30,13 @@ import { execFile } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import type { GitPullSummary, GitRunner } from './git-runner.js'
 import { simpleGit, type SimpleGit } from 'simple-git'
 import { normalizeGitCloneUrl, type GitCommitIdentity } from '@agentconnect.md/protocol'
-import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../cp/gitcred-server.js'
+import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV, GITCRED_SOCKET_ENV } from '../cp/gitcred-server.js'
+import { SANDBOX_GIT_CONFIG_DIR, SANDBOX_GIT_CREDENTIAL_HELPER } from '../shim/sandbox-paths.js'
+import { SANDBOX_TUNNEL_PATHS } from '../shim/tunnel.js'
 
 /**
  * simple-git ≥3.36 vulnerability-checks argv AND any child env passed via
@@ -84,6 +86,7 @@ export function gitFor(cwd?: string, abort?: AbortSignal): SimpleGit {
 const HOST_ENV_STRIP = new Set([
   GITCRED_CAPABILITY_ENV,
   GITCRED_AGENT_ENV,
+  GITCRED_SOCKET_ENV,
   'EDITOR',
   'VISUAL',
   'PAGER',
@@ -344,38 +347,96 @@ export async function pullWorkspaceRef(git: GitRunner, remote: string, branch: s
   return git.pull(remote, refspec, ['--ff-only', '--no-recurse-submodules'])
 }
 
+/**
+ * Where the git that will READ these pointers runs.
+ *
+ * Every value this module writes is a path, and a path only means something in one filesystem. A
+ * cluster agent's git runs in its sandbox pod, so a helper line derived from the daemon's own root
+ * names an executable that pod has never had — the failure mode being an authentication error
+ * rather than a missing file, which is why this is a type and not a convention.
+ */
+export interface GitCredentialTarget {
+  /** `daemon` may write files as it goes; `sandbox` must be materialized through the shim. */
+  kind: 'daemon' | 'sandbox'
+  /** The credential-helper executable, in that filesystem. */
+  helper: string
+  /** Directory holding the per-agent gitconfig, in that filesystem. */
+  configDir: string
+  /** The daemon operator's own ~/.gitconfig, included first. Omitted for a sandbox: its git has
+   *  never seen the daemon's home, and pointing at it would silently include nothing. */
+  hostConfig?: string
+  /** Socket the helper must dial, when it is not the one under the daemon's root. */
+  socketPath?: string
+}
+
 /** Module-level init (workspace-manager is functional; mirrors cloneInFlight). */
-let shimPath: string | undefined
-let runDir: string | undefined
+let targetFor: ((agentId: string) => GitCredentialTarget) | undefined
 let preWarm: ((agentId: string, reason: 'clone' | 'pull') => Promise<void>) | undefined
 let capabilityFor: ((agentId: string) => string) | undefined
 
 export function initGitInjection(opts: {
-  shimPath: string
-  runDir: string
+  /**
+   * Resolves the filesystem an agent's git runs in.
+   *
+   * It has to answer with the SAME predicate `setWorkspaceGitRunnerResolver` uses, or the
+   * environment and the execution disagree: a remote runner running with daemon-local pointers is
+   * exactly the bug this seam exists to remove.
+   */
+  targetFor: (agentId: string) => GitCredentialTarget
   /** Warm the daemon credential cache BEFORE a timed git op (never inside its budget). */
   preWarm: (agentId: string, reason: 'clone' | 'pull') => Promise<void>
   /** Runtime-only local socket capability. Never written to a config file. */
   capabilityFor: (agentId: string) => string
 }): void {
-  shimPath = opts.shimPath
-  runDir = opts.runDir
+  targetFor = opts.targetFor
   preWarm = opts.preWarm
   capabilityFor = opts.capabilityFor
+}
+
+/** This daemon's own filesystem: the helper shim and run dir it (re)writes on every boot. */
+export function daemonGitCredentialTarget(opts: { shimPath: string; runDir: string }): GitCredentialTarget {
+  return {
+    kind: 'daemon',
+    helper: opts.shimPath,
+    configDir: join(opts.runDir, 'gitcred'),
+    hostConfig: join(homedir(), '.gitconfig')
+  }
+}
+
+/** A sandbox pod: the image's fixed helper path, and the socket the shim tunnels to the daemon. */
+export function sandboxGitCredentialTarget(): GitCredentialTarget {
+  return {
+    kind: 'sandbox',
+    helper: SANDBOX_GIT_CREDENTIAL_HELPER,
+    configDir: SANDBOX_GIT_CONFIG_DIR,
+    socketPath: SANDBOX_TUNNEL_PATHS.gitcred
+  }
+}
+
+function targetOf(agentId: string): GitCredentialTarget {
+  if (!targetFor) throw new Error('git credential injection is not initialized')
+  return targetFor(agentId)
 }
 
 /** Auth for helper subprocesses. Keep separate from the persisted config pointers.
  *  Identity and capability are minted as a PAIR: the helper prefers this env
  *  identity over the agentId baked into a `.git/config` helper line, so a stale
- *  repo-local pin (previous agent generation) can never desync the two. */
+ *  repo-local pin (previous agent generation) can never desync the two.
+ *  The socket rides along for a target that is not this daemon's filesystem: the helper cannot
+ *  derive a daemon root it does not have. */
 export function gitCredentialEnv(agentId: string): Record<string, string> {
   if (!capabilityFor) throw new Error('git credential injection is not initialized')
-  return { [GITCRED_CAPABILITY_ENV]: capabilityFor(agentId), [GITCRED_AGENT_ENV]: agentId }
+  const target = targetOf(agentId)
+  return {
+    [GITCRED_CAPABILITY_ENV]: capabilityFor(agentId),
+    [GITCRED_AGENT_ENV]: agentId,
+    ...(target.socketPath ? { [GITCRED_SOCKET_ENV]: target.socketPath } : {})
+  }
 }
 
 function quotedHelper(agentId: string): string {
-  if (!shimPath) throw new Error('git credential injection is not initialized')
-  return `!'${shimPath.replaceAll("'", "'\\''")}' ${agentId}`
+  const { helper } = targetOf(agentId)
+  return `!'${helper.replaceAll("'", "'\\''")}' ${agentId}`
 }
 
 /** The three github.com-scoped config pairs both channels share. */
@@ -403,34 +464,59 @@ export function cloneGitEnv(agentId: string, repository?: string): Record<string
 }
 
 /**
- * Session-env channel: (re)write the per-agent gitconfig and return the env to
- * inject into the agent's ACP runtime process. Regenerated on every host spawn
- * (#251 retries rebuild the host ⇒ this re-runs).
+ * The session-env channel as DATA: where the per-agent gitconfig belongs, what goes in it, and the
+ * env that points the agent's runtime at it.
+ *
+ * Separated from the write because only one of the two targets can be written by this process. A
+ * sandbox's copy has to travel through the shim's materialize channel, and a `writeFileSync` to
+ * `/run/agentconnect/git/...` would land on the DAEMON's disk — creating the file the check would
+ * look for while the pod still has nothing.
  */
-export function sessionGitEnv(agentId: string, commitIdentity?: GitCommitIdentity): Record<string, string> {
-  if (!runDir) throw new Error('git credential injection is not initialized')
-  const dir = join(runDir, 'gitcred')
-  mkdirSync(dir, { recursive: true, mode: 0o700 })
-  const file = join(dir, `${agentId}.gitconfig`)
+export function sessionGitConfig(
+  agentId: string,
+  commitIdentity?: GitCommitIdentity
+): { path: string; content: string; env: Record<string, string> } {
+  const target = targetOf(agentId)
+  const file = join(target.configDir, `${agentId}.gitconfig`)
   const lines = [
     '# agentconnect session git config — regenerated on agent start; NO secrets.',
     '# Keeps non-identity host config, then pins github.com credentials to the daemon helper.',
-    '[include]',
-    `\tpath = ${join(homedir(), '.gitconfig')}`,
+    ...(target.hostConfig ? ['[include]', `\tpath = ${target.hostConfig}`] : []),
     '[credential "https://github.com"]',
     '\thelper = ', // reset the accumulated helper list for github.com
     `\thelper = ${quotedHelper(agentId)}`,
     '\tuseHttpPath = true',
     ''
   ]
-  writeFileSync(file, lines.join('\n'), { mode: 0o644 })
   return {
-    ...gitCredentialEnv(agentId),
-    ...sessionGitPolicyEnv(),
-    GIT_CONFIG_GLOBAL: file,
-    GIT_TERMINAL_PROMPT: '0',
-    ...(commitIdentity ? gitCommitIdentityEnv(commitIdentity) : {})
+    path: file,
+    content: lines.join('\n'),
+    env: {
+      ...gitCredentialEnv(agentId),
+      ...sessionGitPolicyEnv(),
+      GIT_CONFIG_GLOBAL: file,
+      GIT_TERMINAL_PROMPT: '0',
+      ...(commitIdentity ? gitCommitIdentityEnv(commitIdentity) : {})
+    }
   }
+}
+
+/**
+ * Session-env channel: (re)write the per-agent gitconfig and return the env to
+ * inject into the agent's ACP runtime process. Regenerated on every host spawn
+ * (#251 retries rebuild the host ⇒ this re-runs).
+ *
+ * Refuses a sandbox target rather than writing one: this is a synchronous local write, and the
+ * caller that owns a pod's files is the async materialization path.
+ */
+export function sessionGitEnv(agentId: string, commitIdentity?: GitCommitIdentity): Record<string, string> {
+  if (targetOf(agentId).kind !== 'daemon') {
+    throw new Error(`agent ${agentId} runs its git in a sandbox — materialize its gitconfig instead of writing it`)
+  }
+  const { path: file, content, env } = sessionGitConfig(agentId, commitIdentity)
+  mkdirSync(dirname(file), { recursive: true, mode: 0o700 })
+  writeFileSync(file, content, { mode: 0o644 })
+  return env
 }
 
 /** The four env vars that make a commit's attribution explicit. The ONLY channel a daemon-run

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -1,26 +1,32 @@
 import { execFileSync } from 'node:child_process'
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { simpleGit } from 'simple-git'
-import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../src/cp/gitcred-server.js'
+import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV, GITCRED_SOCKET_ENV } from '../src/cp/gitcred-server.js'
 import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
 import {
   assertSafeWorkspaceGitConfig,
   cloneGitEnv,
   gitEnvBase,
   gitFor,
+  daemonGitCredentialTarget,
   initGitInjection,
   parseGitVersion,
   pullWorkspaceRef,
+  sandboxGitCredentialTarget,
+  sessionGitConfig,
   sessionGitEnv,
   sessionGitPolicyEnv,
   workspaceGitEnvBase,
   workspaceGitLocalEnv,
   workspaceGitPullTarget,
-  workspaceGitPushTarget
+  workspaceGitPushTarget,
+  writeRepoHelperConfig
 } from '../src/workspace/git-injection.js'
+import { SANDBOX_GIT_CONFIG_DIR, SANDBOX_GIT_CREDENTIAL_HELPER } from '../src/shim/sandbox-paths.js'
+import { SANDBOX_TUNNEL_PATHS } from '../src/shim/tunnel.js'
 
 // simple-git ≥3.36 refuses a NAME blocklist of env vars (presence-based, value
 // never read) and requires opt-ins for credential.helper / GIT_CONFIG_COUNT.
@@ -78,8 +84,12 @@ beforeAll(() => {
   }
   tmpRun = mkdtempSync(join(tmpdir(), 'gitcred-test-'))
   initGitInjection({
-    shimPath: join(tmpRun, 'helper.sh'),
-    runDir: tmpRun,
+    // Per agent, as the daemon's own resolver is: an agent whose git runs in a pod gets the
+    // image's paths, and one that runs here gets this daemon's. `pod-` ids pick the former.
+    targetFor: (agentId) =>
+      agentId.startsWith('pod-')
+        ? sandboxGitCredentialTarget()
+        : daemonGitCredentialTarget({ shimPath: join(tmpRun, 'helper.sh'), runDir: tmpRun }),
     preWarm: async () => undefined,
     capabilityFor: (agentId) => `cap-${agentId}`
   })
@@ -665,6 +675,72 @@ describe('sessionGitEnv', () => {
     const env = sessionGitEnv('agent-1')
     expect(env).not.toHaveProperty('GIT_AUTHOR_NAME')
     expect(env).not.toHaveProperty('GIT_COMMITTER_NAME')
+  })
+})
+
+describe('pointers for an agent whose git runs in a sandbox pod', () => {
+  // The bug every case here is about: a path is only meaningful in one filesystem, and a helper
+  // line built from this daemon's root names an executable the pod has never had. What makes it
+  // expensive is the failure mode — git reports an authentication failure, not a missing file.
+  it('names the image helper and the tunnelled socket, never a daemon path', () => {
+    const pairs = configPairs(cloneGitEnv('pod-agent', 'https://github.com/acme/repo.git'))
+    expect(pairs).toContainEqual([
+      'credential.https://github.com.helper',
+      `!'${SANDBOX_GIT_CREDENTIAL_HELPER}' pod-agent`
+    ])
+    // The helper has no daemon root to derive a socket from, so the tunnel's path travels with it.
+    expect(cloneGitEnv('pod-agent')[GITCRED_SOCKET_ENV]).toBe(SANDBOX_TUNNEL_PATHS.gitcred)
+    expect(JSON.stringify(pairs)).not.toContain(tmpRun)
+  })
+
+  it('keeps the daemon-local pointers exactly as they were', () => {
+    // The regression guard for every self-hosted daemon: this path is the one in production today.
+    const pairs = configPairs(cloneGitEnv('agent-1', 'https://github.com/acme/repo.git'))
+    expect(pairs).toContainEqual(['credential.https://github.com.helper', `!'${join(tmpRun, 'helper.sh')}' agent-1`])
+    expect(cloneGitEnv('agent-1')).not.toHaveProperty(GITCRED_SOCKET_ENV)
+  })
+
+  it('puts the session gitconfig in the pod and drops the daemon operator home include', () => {
+    const local = sessionGitConfig('agent-1')
+    expect(local.path).toBe(join(tmpRun, 'gitcred', 'agent-1.gitconfig'))
+    // The host's own config still rides along for a daemon-run git — that is where a self-hosting
+    // operator's non-identity settings live.
+    expect(local.content).toContain(join(homedir(), '.gitconfig'))
+
+    const pod = sessionGitConfig('pod-agent')
+    expect(pod.path).toBe(`${SANDBOX_GIT_CONFIG_DIR}/pod-agent.gitconfig`)
+    expect(pod.env.GIT_CONFIG_GLOBAL).toBe(pod.path)
+    // Including a path from the daemon's home would resolve to nothing in the pod and read as if
+    // the operator simply had no config — a silent difference rather than an error.
+    expect(pod.content).not.toContain('[include]')
+    expect(pod.content).not.toContain(homedir())
+  })
+
+  it('refuses to WRITE a pod gitconfig, rather than writing it here', () => {
+    // The whole class of bug in one assertion: a synchronous write of `/run/agentconnect/...`
+    // lands on the daemon's disk, creating the file a check would look for while the pod has none.
+    expect(() => sessionGitEnv('pod-agent')).toThrow(/materialize its gitconfig/)
+    expect(existsSync(join(SANDBOX_GIT_CONFIG_DIR, 'pod-agent.gitconfig'))).toBe(false)
+  })
+
+  it('writes the repo-local helper in the coordinates of the git that will read it', async () => {
+    const argv: string[][] = []
+    const runner = {
+      withEnv: () => runner,
+      raw: async (args: string[]) => {
+        argv.push(args)
+        return ''
+      }
+    } as unknown as GitRunner
+    await writeRepoHelperConfig(runner, 'pod-agent')
+    // `.git/config` outlives a launch, so this is the pointer a later agent-run git in the pod
+    // finds on disk — it has to name the image's helper too, not just the spawn env.
+    expect(argv).toContainEqual([
+      'config',
+      '--add',
+      'credential.https://github.com.helper',
+      `!'${SANDBOX_GIT_CREDENTIAL_HELPER}' pod-agent`
+    ])
   })
 })
 

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -174,6 +174,11 @@ describe('k8s runtime plane assembly', () => {
     // A channel, a session behind the workspace seam, and NO runtime started.
     expect(plane.listener.connectionsFor('agent-a')).toHaveLength(1)
     expect(plane.gitRunnerFor('agent-a', '/agent')).toBeDefined()
+    // The same condition, readable on its own: the credential pointers git will read are built
+    // from this, so an answer that disagreed with the runner would describe the wrong filesystem.
+    expect(plane.runsInSandbox('agent-a')).toBe(true)
+    expect(plane.runsInSandbox('agent-b')).toBe(false)
+    expect(plane.gitRunnerFor('agent-b', '/agent')).toBeUndefined()
     // The pod's reported mount arrived with the bind — the fact every pod path is built on.
     expect(plane.workspaceRootFor('agent-a')).toBe('/agent')
   })

--- a/packages/daemon/test/skill-git-source.test.ts
+++ b/packages/daemon/test/skill-git-source.test.ts
@@ -14,7 +14,7 @@ import {
   resolveBoundedGitSkillSource,
   type GitSkillCredentialRequest
 } from '../src/skills/skill-git-source.js'
-import { initGitInjection } from '../src/workspace/git-injection.js'
+import { daemonGitCredentialTarget, initGitInjection } from '../src/workspace/git-injection.js'
 import { configureWorkspaceGitOrigins } from '../src/workspace/git-origin-policy.js'
 
 const entry = (source: string, githubRepoId = '42') => ({
@@ -732,8 +732,7 @@ describe('Git skill source policy boundary', () => {
 
   it('scopes the daemon credential capability to canonical GitHub HTTPS only', () => {
     initGitInjection({
-      shimPath: '/daemon/git-credential-helper',
-      runDir: '/private/run',
+      targetFor: () => daemonGitCredentialTarget({ shimPath: '/daemon/git-credential-helper', runDir: '/private/run' }),
       preWarm: async () => {},
       capabilityFor: (agentId) => `cap-${agentId}`
     })

--- a/packages/daemon/test/workspace-git-write.test.ts
+++ b/packages/daemon/test/workspace-git-write.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
 import { createWorkspaceGit } from '../src/cp/workspace-git.js'
 import { WorkspaceViolationError } from '../src/cp/workspace-reader.js'
-import { initGitInjection, workspaceGitLocalEnv } from '../src/workspace/git-injection.js'
+import { daemonGitCredentialTarget, initGitInjection, workspaceGitLocalEnv } from '../src/workspace/git-injection.js'
 import type { GitRunner } from '../src/workspace/git-runner.js'
 import { parsePorcelainV2 } from '../src/shim/git-exec.js'
 import { setWorkspaceGitRunnerResolver } from '../src/workspace/workspace-manager.js'
@@ -22,8 +22,7 @@ const IDENTITY = { name: 'acme-bot[bot]', email: '1234+acme-bot[bot]@users.norep
 // are minted from this registration, exactly as the daemon registers them at boot.
 const SHIM = join(mkdtempSync(join(tmpdir(), 'ac-gitwrite-shim-')), 'git-credential-helper.sh')
 initGitInjection({
-  shimPath: SHIM,
-  runDir: join(SHIM, '..'),
+  targetFor: () => daemonGitCredentialTarget({ shimPath: SHIM, runDir: join(SHIM, '..') }),
   preWarm: async () => undefined,
   capabilityFor: (agentId) => `cap-${agentId}`
 })

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -53,7 +53,12 @@ const {
   sessionWorktreePath,
   sessionWorktreeRoot
 } = await import('../src/workspace/workspace-manager.js')
-const { initGitInjection } = await import('../src/workspace/git-injection.js')
+const { daemonGitCredentialTarget, initGitInjection } = await import('../src/workspace/git-injection.js')
+
+// Made once and reused: `targetFor` is called on every pointer build, so minting a directory
+// inside it would leave one behind per resolution.
+let gitcredRunDirPath: string | undefined
+const gitcredRunDir = (): string => (gitcredRunDirPath ??= mkdtempSync(join(tmpdir(), 'ac-ws-gitcred-')))
 
 function fromScratchAgent(path: string): Agent {
   return {
@@ -634,8 +639,7 @@ describe('prepareWorkspaceForActivation', () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-edit-')), 'workspace')
     const current = githubAppAgent(path)
     initGitInjection({
-      shimPath: '/run/helper.sh',
-      runDir: mkdtempSync(join(tmpdir(), 'ac-ws-gitcred-')),
+      targetFor: () => daemonGitCredentialTarget({ shimPath: '/run/helper.sh', runDir: gitcredRunDir() }),
       preWarm: async () => undefined,
       capabilityFor: (agentId) => `cap-${agentId}`
     })
@@ -673,8 +677,7 @@ describe('prepareWorkspaceForActivation', () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-edit-')), 'workspace')
     const agent = githubAppAgent(path)
     initGitInjection({
-      shimPath: '/run/helper.sh',
-      runDir: mkdtempSync(join(tmpdir(), 'ac-ws-gitcred-')),
+      targetFor: () => daemonGitCredentialTarget({ shimPath: '/run/helper.sh', runDir: gitcredRunDir() }),
       preWarm: async () => undefined,
       capabilityFor: (agentId) => `cap-${agentId}`
     })
@@ -771,8 +774,7 @@ describe('prepareWorkspaceForActivation', () => {
 describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
   beforeEach(() => {
     initGitInjection({
-      shimPath: '/run/helper.sh',
-      runDir: mkdtempSync(join(tmpdir(), 'ac-ws-gitcred-')),
+      targetFor: () => daemonGitCredentialTarget({ shimPath: '/run/helper.sh', runDir: gitcredRunDir() }),
       preWarm: async () => undefined,
       capabilityFor: (agentId) => `cap-${agentId}`
     })


### PR DESCRIPTION
> Stacked on #855 (base is `feat/shim-tunnel-channel`). Second of four PRs closing the private-repo gap under `--k8s`.

## Why

Every value `git-injection.ts` writes into a config file or an environment is a **path**, and a path only means something in one filesystem. The module held one daemon-local `shimPath` and one `runDir`, minted at boot:

```ts
function quotedHelper(agentId: string): string {
  if (!shimPath) throw new Error('git credential injection is not initialized')
  return `!'${shimPath.replaceAll("'", "'\\''")}' ${agentId}`
}
```

A cluster agent's git runs in a sandbox pod, so that line names an executable the pod has never had, and `GIT_CONFIG_GLOBAL` points into the daemon's own run directory. What makes this expensive is the failure mode: git reports an **authentication failure**, not a missing file. It is the same class of bug as #853 (the ACP cwd in the daemon's coordinates), on the credential channel.

## The design point: one predicate, not two

`GitCredentialTarget` replaces both module variables, and `targetFor(agentId)` resolves it per agent. The thing worth reviewing is *what it resolves off*: the plane's new `runsInSandbox`, which is nothing but `gitRunnerFor`'s own condition given a name.

```ts
const runsInSandbox = (agentId: string): boolean => driver.sessionFor(agentId)?.isAttached() === true
```

`setWorkspaceGitRunnerResolver` already decides *where git executes* on exactly that condition. If the pointers were derived from anything else — a boot-time "am I in `--k8s`" flag, say — then a channel dropping mid-session would leave a remote runner running with daemon-local pointers, or the reverse. Reading the same predicate makes them follow a channel together, which is the property that matters rather than the paths themselves.

## Data and write, separated

`sessionGitEnv` did both: render the per-agent gitconfig and `writeFileSync` it. Only one of the two targets can be written by this process, so:

- `sessionGitConfig(agentId, identity)` → `{ path, content, env }`
- `sessionGitEnv(agentId, identity)` writes it, and now **refuses a sandbox target**

The refusal is the interesting half. A synchronous write of `/run/agentconnect/git/<id>.gitconfig` succeeds — on the **daemon's** disk. That creates the file any check would look for while the pod still has nothing, which is a silent wrong answer rather than an error. The pod's copy has to travel through the shim's materialize channel, and that caller is PR 4.

## Two things the pod side needs

- **No `[include]` of the operator's `~/.gitconfig`.** In a pod that path resolves to nothing, so git would behave as if the operator simply had no config — a silent difference. It stays for a daemon target, where a self-hosting operator's non-identity settings actually live.
- **`AC_GITCRED_SOCKET`.** A helper in a pod has no daemon root to derive a socket path from, so the tunnel's path travels with the capability pair. Both CLI helpers (`git-credential`, `gh-token`) now resolve through one `gitcredSocketFrom(env, root)` — an explicit override, else this daemon's own. This is what lets PR 3 bundle the *same* helper source for the image instead of writing a second implementation.

## No behaviour change today

Worth being explicit, because it shapes how much of this is exercised in production right now: **none of it.** Every caller of these pointers is gated on a git-repo workspace, and `clusterWorkspaceCwd` still refuses those under `--k8s`. So for a self-hosted daemon this is a pure refactor (the daemon target reproduces today's paths exactly, asserted below), and for a cluster daemon the sandbox target is reachable only from PR 4.

The one live change is the `AC_GITCRED_SOCKET` override existing at all; nothing sets it outside a pod.

## Tests

`git-injection.test.ts` gains a per-agent resolver in setup — `pod-` ids get the sandbox target — mirroring how the daemon resolves per agent, plus 5 cases:

- a pod agent's helper pair names the image helper and carries the tunnel socket, and **no** string in its config pairs contains the daemon's run dir
- a daemon agent's pointers are byte-identical to today's, and carry no socket override (the regression guard for every self-hosted daemon)
- the session gitconfig lands under `/run/agentconnect/git` for a pod with no `[include]` and no `homedir()` anywhere in it, while the local one keeps both
- `sessionGitEnv` throws for a pod target **and** leaves no file behind
- `writeRepoHelperConfig` writes the image helper through the runner — `.git/config` outlives a launch, so the on-disk pointer a later agent-run git finds has to be in the pod's coordinates too, not just the spawn env

`k8s-runtime-plane.test.ts` pins `runsInSandbox` against `gitRunnerFor` for both a bound and an unbound agent, so the two cannot drift apart.

The four existing `initGitInjection` call sites move to the new shape. In `workspace.test.ts` the `mkdtempSync` had to be hoisted out of the resolver closure — `targetFor` is called on every pointer build, so leaving it inline would mint a temp directory per resolution.

Full daemon suite: 3269 passed, 1 failed — `evaluation-runner › records a raw ACP baseline`, which fails on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
