### PR TITLE
fix(daemon): skip replies to deleted Slack roots

### DIFF
--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -33,6 +33,7 @@ const EXEMPT: Record<string, string> = {
   rememberMissingScopes: 'private scope-error bookkeeping',
   permissionUpdateUrl: 'private permission-card helper',
   postPermissionUpdateCard: 'private permission-card helper',
+  postIfThreadExists: 'private Slack root-existence guard',
   postChatMessage: 'private shared post boundary behind postMessage/postBlocks',
   // Interactive Slack surfaces (Block Kit actions / modals) are driven by
   // Bolt callbacks the virtual transport never receives; the daemon only

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -355,6 +355,7 @@ type AppLike = {
     }
     chat: {
       postMessage: (a: unknown) => Promise<{ ts?: string }>
+      getPermalink: (a: unknown) => Promise<{ permalink?: string }>
       update: (a: unknown) => Promise<{ ts?: string }>
       delete: (a: unknown) => Promise<unknown>
     }
@@ -483,6 +484,14 @@ function missingScopesFrom(err: unknown): string[] {
  * retried and cannot duplicate a message whose first result was ambiguous. */
 function isMissingCustomizeScope(err: unknown): boolean {
   return missingScopesFrom(err).includes('chat:write.customize')
+}
+
+function slackApiErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== 'object') return undefined
+  const data = (err as { data?: unknown }).data
+  if (!data || typeof data !== 'object') return undefined
+  const code = (data as { error?: unknown }).error
+  return typeof code === 'string' ? code : undefined
 }
 
 // Re-probe periodically so granting chat:write.customize to an existing Slack app
@@ -853,9 +862,7 @@ export class SlackConnection implements PlatformConnection {
       : `https://api.slack.com/apps/${appId}/install-on-team?`
   }
 
-  /** Post the Devin-style reauthorization notice once for this connection.
-   * This bypasses `postChatMessage` deliberately: the card must use the Slack App
-   * identity and must not recursively trigger itself. */
+  /** Post the reauthorization notice once with the Slack App identity. */
   private async postPermissionUpdateCard(channel: string, threadTs?: string): Promise<void> {
     if (this.permissionUpdateAnnounced || this.missingScopes.size === 0) return
     const updateUrl = this.permissionUpdateUrl()
@@ -866,7 +873,7 @@ export class SlackConnection implements PlatformConnection {
     const text =
       'Permissions update required. Please update and re-authorize this Slack app to ensure all features work correctly.'
     try {
-      await this.app.client.chat.postMessage({
+      const posted = await this.postIfThreadExists(channel, threadTs, {
         channel,
         thread_ts: threadTs,
         text,
@@ -875,6 +882,7 @@ export class SlackConnection implements PlatformConnection {
         unfurl_media: false,
         metadata: { event_type: SLACK_CHROME_EVENT_TYPE, event_payload: {} }
       })
+      if (!posted) this.permissionUpdateAnnounced = false
     } catch (err) {
       this.permissionUpdateAnnounced = false
       this.rememberMissingScopes(err)
@@ -882,36 +890,50 @@ export class SlackConnection implements PlatformConnection {
     }
   }
 
-  /** Shared chat.postMessage boundary for plain/markdown and Block Kit messages.
-   *  `username` + `icon_url` are the per-message identity overrides — both gated by
-   *  the same `chat:write.customize` scope, so they share one probe/cooldown. A
-   *  missing customize scope is safe to retry because Slack rejected the first
-   *  request before creating a message; every other error is propagated. */
+  /** Post only while a threaded reply's root remains extant. */
+  private async postIfThreadExists(
+    channel: string,
+    threadTs: string | undefined,
+    payload: Record<string, unknown>
+  ): Promise<{ ts?: string } | undefined> {
+    if (threadTs) {
+      try {
+        await this.app.client.chat.getPermalink({ channel, message_ts: threadTs })
+      } catch (err) {
+        if (slackApiErrorCode(err) !== 'message_not_found') throw err
+        this.deps.log?.info(`slack: skipped reply to deleted root ch=${channel} thread=${threadTs}`)
+        return undefined
+      }
+    }
+    return this.app.client.chat.postMessage(payload)
+  }
+
+  /** Shared chat.postMessage boundary with optional per-message identity. */
   private async postChatMessage(
     channel: string,
     threadTs: string | undefined,
     payload: Record<string, unknown>,
     options?: SlackPostOptions
-  ): Promise<{ ts?: string }> {
+  ): Promise<{ ts?: string } | undefined> {
     const customize: Record<string, unknown> = {}
     const username = options?.username?.trim()
     const iconUrl = options?.icon_url?.trim()
     if (username) customize.username = username
     if (iconUrl) customize.icon_url = iconUrl
     try {
-      let result: { ts?: string }
+      let result: { ts?: string } | undefined
       if (Object.keys(customize).length === 0 || Date.now() < this.customUsernameRetryAt) {
-        result = await this.app.client.chat.postMessage(payload)
+        result = await this.postIfThreadExists(channel, threadTs, payload)
       } else {
         try {
-          result = await this.app.client.chat.postMessage({ ...payload, ...customize })
+          result = await this.postIfThreadExists(channel, threadTs, { ...payload, ...customize })
           this.customUsernameRetryAt = 0
         } catch (err) {
           this.rememberMissingScopes(err)
           if (!isMissingCustomizeScope(err)) throw err
           this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
           this.deps.log?.debug('slack: chat:write.customize missing — retrying with the app default identity')
-          result = await this.app.client.chat.postMessage(payload)
+          result = await this.postIfThreadExists(channel, threadTs, payload)
         }
       }
       await this.postPermissionUpdateCard(channel, threadTs)

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -46,7 +46,7 @@ function fakeAppWith(
     shortcut() {},
     client: {
       auth: { test: async () => ({ user_id: 'U1', team_id: 'T123' }) },
-      chat: { postMessage },
+      chat: { postMessage, getPermalink: async () => ({ permalink: 'https://example.slack.com/thread' }) },
       assistant: { threads: { setStatus, setTitle } }
     },
     start: async () => {},
@@ -1104,15 +1104,55 @@ describe('SlackConnection.updateBlocks', () => {
   })
 })
 
-describe('SlackConnection custom message username', () => {
-  const withPostMessage = (postMessage: (payload: any) => Promise<{ ts?: string }>) => ({
+describe('SlackConnection chat.postMessage boundary', () => {
+  const withPostMessage = (
+    postMessage: (payload: any) => Promise<{ ts?: string }>,
+    getPermalink: (payload: any) => Promise<{ permalink?: string }> = async () => ({
+      permalink: 'https://example.slack.com/thread'
+    })
+  ) => ({
     message() {},
     event() {},
     action() {},
     shortcut() {},
-    client: { chat: { postMessage } },
+    client: { chat: { postMessage, getPermalink } },
     start: async () => {},
     stop: async () => {}
+  })
+
+  it('silently skips a reply when its thread root was deleted', async () => {
+    const postMessage = vi.fn(async () => ({ ts: '100.2' }))
+    const missingRoot = Object.assign(new Error('An API error occurred: message_not_found'), {
+      data: { error: 'message_not_found' }
+    })
+    const getPermalink = vi.fn(async () => {
+      throw missingRoot
+    })
+    const conn = new SlackConnection(
+      { ...deps(), sendIntervalMs: 0 } as any,
+      () => withPostMessage(postMessage, getPermalink) as any
+    )
+
+    await expect(conn.postMessage('C1', 'body', '100.1')).resolves.toBeUndefined()
+    expect(getPermalink).toHaveBeenCalledWith({ channel: 'C1', message_ts: '100.1' })
+    expect(postMessage).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when root existence cannot be verified', async () => {
+    const postMessage = vi.fn(async () => ({ ts: '100.2' }))
+    const rateLimited = Object.assign(new Error('An API error occurred: ratelimited'), {
+      data: { error: 'ratelimited' }
+    })
+    const conn = new SlackConnection(
+      { ...deps(), sendIntervalMs: 0 } as any,
+      () =>
+        withPostMessage(postMessage, async () => {
+          throw rateLimited
+        }) as any
+    )
+
+    await expect(conn.postMessage('C1', 'body', '100.1')).rejects.toBe(rateLimited)
+    expect(postMessage).not.toHaveBeenCalled()
   })
 
   it('persists the stable agent author in Slack message metadata', async () => {


### PR DESCRIPTION
## Summary

- verify that a Slack thread root still exists immediately before every threaded `chat.postMessage`
- silently skip delivery when Slack reports `message_not_found`, while propagating transient or permission failures so delivery fails closed
- cover both ordinary Agent replies and permission-update cards at the shared outbound boundary

## Root cause

A delayed Slack Events API retry can reach AgentConnect after the user has deleted the original root message. Slack may accept a subsequent `chat.postMessage` with that stale `thread_ts` and surface the orphaned reply in the channel, so the outbound adapter must validate the root rather than trust the stored timestamp.

The guard uses `chat.getPermalink`, which checks for an extant message, requires no additional scope, and avoids the restrictive `conversations.replies` history rate tier.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/connection.test.ts` — 42 passed
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec eslint packages/daemon/src/slack/connection.ts packages/daemon/test/connection.test.ts`
- `pnpm exec prettier --check packages/daemon/src/slack/connection.ts packages/daemon/test/connection.test.ts`
- pre-push `eslint .` — passed with two pre-existing warnings in `workspace-git-write.test.ts`
- daemon full test suite was attempted but cannot complete in this sandbox because socket-backed tests fail with `listen EPERM` and live ACP runtimes are unavailable

Created by Codex . gpt-5.6-sol