### PR TITLE
fix(daemon): keep Slack peer handoffs in thread

### DIFF
--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -120,9 +120,7 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
       'already in, just write your ordinary reply.'
   }
 
-  // Mode 1 — toAgent: wake one AgentConnect agent. Two forms: postless (no channel, peers
-  // only) and channel root (channel, peers or self). There is no in-thread form — an ordinary
-  // reply that mentions the peer is how you address it in the current thread (§2.1).
+  // Mode 1 — toAgent wakes one peer postlessly or opens a channel-root conversation; it never continues this thread.
   const agentTarget = {
     title: 'toAgent — send to an agent',
     description:
@@ -131,20 +129,23 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
       '(`{"toAgent":"<id>","channel":"<C>","message":"..."}`) also posts one visible message at the channel root, ' +
       '@-mentions the target in it, and anchors the target to that post. The channel-root form may target YOURSELF: ' +
       'use your own AgentConnect ID from the # Agent block (never your Slack `U…` bot identity) to open and activate ' +
-      'one new conversation there. The direct form may not target yourself. To reach an agent in the thread you are ' +
-      'ALREADY in, do not use this tool — @-mention it in your ordinary reply instead. Either form takes ' +
-      '`needsReply` (see `toAgent`), and you need it whenever you expect an answer back: the peer answers in ITS ' +
-      'OWN conversation, so without `needsReply` nothing comes back to you.',
+      'one new conversation there. The direct form may not target yourself. To hand the next turn to an agent in ' +
+      'the thread you are ALREADY in, do not use any `SendMessage` tool — @-mention it in your ordinary reply ' +
+      'instead. A direct `toAgent` call without `channel` is private and would hide that exchange from the thread. ' +
+      'After intentionally choosing either `toAgent` form, use `needsReply` (see `toAgent`) when its answer must ' +
+      'return to this session: the peer answers in ITS OWN conversation, so without `needsReply` nothing comes back.',
     ...obj(
       {
         toAgent: {
           description:
-            'The AgentConnect agent to wake. For a peer, use the BARE agent id only for fire-and-forget work whose ' +
-            'outcome you never need; ' +
-            'use `{"agentId":"<agent id>","needsReply":true}` whenever you expect anything back. Set `needsReply` ' +
-            'if your `message` asks a question or requests a result, if you were asked to relay the peer’s answer ' +
-            'to someone, or if you intend to act on the outcome — "reply to me", "tell me", "check X and report" ' +
-            'all qualify. A woken peer answers inside ITS OWN conversation, so without `needsReply` its answer ' +
+            'The AgentConnect agent to wake in a different or intentionally private conversation. Do not start a ' +
+            '`toAgent` call merely because a peer should answer next in the current conversation; @-mention it in ' +
+            'your ordinary reply there. For a chosen peer call, use the BARE agent id only for fire-and-forget work ' +
+            'whose outcome you never need; use `{"agentId":"<agent id>","needsReply":true}` if its answer must ' +
+            'return to this session. Set `needsReply` if your `message` asks a question or requests a result, if you ' +
+            'were asked to relay the peer’s answer to someone, or if you intend to act on the outcome — "reply to ' +
+            'me", "tell me", "check X and report" all qualify. A woken peer answers inside ITS OWN conversation, ' +
+            'so without `needsReply` its answer ' +
             'never reaches you or the humans waiting in yours, and you are not even told that it failed. With it, ' +
             'the peer’s session carries a standing instruction to reply into YOUR session when it finishes or ' +
             'fails. The result tells you to end the current turn and wait; use `viewSessionStatus` on the returned ' +
@@ -174,8 +175,9 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
                   needsReply: {
                     type: 'boolean',
                     description:
-                      'Set true whenever you expect an answer, a result, or a completion signal: the woken session ' +
-                      'is told to report back into this session (done or failed) when it completes. Defaults to ' +
+                      'For an intentional `toAgent` call, set true when you expect an answer, result, or completion ' +
+                      'signal back in this session. It tells the woken session to report here when it completes or ' +
+                      'fails; it does not make the exchange visible in your current conversation. Defaults to ' +
                       'false, which is fire-and-forget — the peer’s answer stays in its own conversation and you ' +
                       'learn nothing, not even that it failed.'
                   }
@@ -286,11 +288,12 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
     description:
       'Send one message using exactly one target mode: an AgentConnect agent (`toAgent`), human users (`toUser`), a channel ' +
       'with no recipient, or the parent-session reply.\n' +
-      'TO SPEAK IN THE CONVERSATION YOU ARE ALREADY IN — including to address a peer agent or a human there — do ' +
-      'NOT use this tool. Write your ordinary turn reply and @-mention them in it (use `listAgents` to get an ' +
-      'agent’s exact `mention` token). That reply already goes to the right thread as you. This tool is only for ' +
-      'what it cannot do: reaching a DIFFERENT conversation, a direct message, a postless agent call, or a reply ' +
-      'into the parent session.\n' +
+      'TO SPEAK IN THE CONVERSATION YOU ARE ALREADY IN — including when another agent or human should answer next — ' +
+      'do NOT use this tool or any similarly named `SendMessage` tool. Write your ordinary turn reply and @-mention ' +
+      'them in it (use `listAgents` to get an agent’s exact `mention` token). That visible reply is the hand-off. A ' +
+      'direct `toAgent` call without `channel` would hide the exchange from this conversation. This tool is only ' +
+      'for what the ordinary reply cannot do: reaching a DIFFERENT conversation, a direct message, a postless ' +
+      'agent call, or a reply into the parent session.\n' +
       '- toAgent — wake exactly one AgentConnect agent (id from listAgents or your own # Agent ID; never a ' +
       'platform member id):\n' +
       '  • direct: `{"toAgent":"<agent id>","message":"..."}` — postless PEER wake: nothing is posted anywhere; ' +
@@ -298,9 +301,10 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
       '  • channel root: `{"toAgent":"<agent id>","channel":"<channel id>","message":"..."}` — also posts one ' +
       'visible message at that channel’s ROOT, @-mentions the target, and anchors it to that post. This form MAY ' +
       'target yourself: use your own # Agent ID to open and activate one new conversation there.\n' +
-      '  Use `{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}` WHENEVER you expect an answer ' +
-      'back — your message asks a question or requests a result, or someone asked you to relay the peer’s answer. ' +
-      'The peer replies in its own conversation, so without `needsReply` its answer never reaches you. Follow the ' +
+      '  After intentionally choosing a `toAgent` form, use ' +
+      '`{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}` when its answer must return here — ' +
+      'for example, your message asks a question or requests a result, or someone asked you to relay the peer’s ' +
+      'answer. The peer replies in its own conversation, so without `needsReply` its answer never reaches you. Follow the ' +
       'returned `nextAction`; use `viewSessionStatus` only for optional diagnostics.\n' +
       '- toUser — reach HUMAN users (Slack only for now), never an AgentConnect agent or your own bot identity:\n' +
       '  • dm: `{"toUser":"<Slack user id>","message":"..."}` — direct message; do not set `channel`.\n' +

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -813,25 +813,21 @@ export class SessionManager {
         : [])
     ].join('\n')
 
-    // Standing guidance for agent↔agent collaboration. `sendMessage` can wake a peer,
-    // reach humans, post at a channel root, or reply into a parent session. It has no
-    // visible in-thread form: speaking in the current conversation is an ordinary reply.
-    // `toAgent` without a `channel` is the postless, channel-invisible wake.
-    // The precedence bullet leads for a measured reason (issue #800): on the Claude
-    // Code runtime the session also carries the runtime's own built-in `SendMessage`
-    // (agent-teams messaging) — a literal name match for a report-back instruction —
-    // and a child that picks it loses its parent report silently. Costs ~80 standing
-    // tokens per session.
+    // Standing collaboration guidance leads with current-thread delivery, then disambiguates AgentConnect from runtime tools.
     const collabAppend =
       `# Collaborating with other agents\n` +
-      `- AgentConnect's tools (the \`agentconnect\` MCP server, e.g. \`mcp__agentconnect__sendMessage\`) are the ` +
-      `ONLY channel that reaches other agents and humans here. Your runtime may offer built-in tools with similar ` +
-      `names (e.g. a bare \`SendMessage\`) — those do NOT reach AgentConnect and anything sent through them is ` +
-      `lost. Never use them for messaging, reporting back, or collaboration.\n` +
+      `- To speak in the conversation you are already in — including when another agent or human should answer ` +
+      `next — do NOT call any \`SendMessage\` or \`sendMessage\` tool. Write your ordinary turn reply and @-mention ` +
+      `them in it (use \`listAgents\` to get a peer's exact \`mention\` token). That visible reply is the hand-off; ` +
+      `a direct \`toAgent\` call without \`channel\` would hide the exchange from this conversation.\n` +
+      `- When a rule below tells you to call AgentConnect's \`sendMessage\`, use the \`agentconnect\` MCP tool ` +
+      `(e.g. \`mcp__agentconnect__sendMessage\`). A similarly named runtime tool such as a bare \`SendMessage\` ` +
+      `does NOT reach AgentConnect; anything sent through it is lost. Never substitute it for an AgentConnect tool.\n` +
       `- To reach a specific agent privately, call \`sendMessage\` with ` +
       `\`{"toAgent":"<agent id>","message":"..."}\` — it wakes ONLY that agent, delivered directly to it ` +
       `(nothing is posted to the channel). That bare form is FIRE-AND-FORGET: the peer answers inside its own ` +
-      `conversation and nothing comes back to you, not even a failure. Whenever you expect an answer — your ` +
+      `conversation and nothing comes back to you, not even a failure. If you intentionally choose this private ` +
+      `form and expect an answer — your ` +
       `message asks a question or requests a result, or you were asked to relay that agent's answer to someone ` +
       `— send \`{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}\` instead, which obliges ` +
       `it to report into YOUR session when it finishes or fails. Add a \`channel\` ` +
@@ -840,9 +836,7 @@ export class SessionManager {
       `That channel-root form may target YOURSELF to open and activate one new conversation there: use your own ` +
       `ID from the # Agent block (also included by \`listAgents\`), never your platform bot identity. A direct ` +
       `\`toAgent\` call without \`channel\` may not target yourself. ` +
-      `To speak in the conversation you are already in — including to address a peer or human there — do NOT ` +
-      `call \`sendMessage\`: write your ordinary turn reply and @-mention them in it (use \`listAgents\` to get ` +
-      `a peer's exact \`mention\` token). To reach HUMAN users elsewhere, use the \`toUser\` mode — never put ` +
+      `To reach HUMAN users elsewhere, use the \`toUser\` mode — never put ` +
       `an AgentConnect agent or your own bot identity in \`toUser\`: ` +
       `\`{"toUser":"<Slack user id>","message":"..."}\` DMs that person, and adding \`channel\` posts an ` +
       `@-mention at the channel root. In that channel form, pass ` +

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -1923,7 +1923,7 @@ describe('SessionManager — collaboration preamble', () => {
     expect(first).toContain('{"toUser":"<Slack user id>","message":"..."}')
     expect(first).toContain('"toUser":["<user id 1>","<user id 2>"]')
     expect(first).toContain('Every visible `sendMessage` lands at a channel root')
-    expect(first).toContain('write your ordinary turn reply and @-mention them in it')
+    expect(first).toContain('ordinary turn reply and @-mention them in it')
     expect(first).not.toContain('"thread":"<thread id>"')
     expect(first).not.toContain('in-thread form')
     expect(first).not.toContain('`to.toAgent`')
@@ -1934,36 +1934,33 @@ describe('SessionManager — collaboration preamble', () => {
     store.close()
   })
 
-  it('leads the guidance with the tool-precedence rule naming the built-in SendMessage hazard (issue #800)', async () => {
-    // Measured (tool-surface A/B, 2026-08-09): a Claude Code child session also
-    // carries the runtime's own built-in `SendMessage` — a literal name match
-    // for a report-back instruction — and a child that picks it loses its
-    // parent report silently. The standing context must say, before anything
-    // else about collaboration, that AgentConnect's MCP tools are the only
-    // channel that reaches anyone and that similarly-named built-ins are lost.
+  it('leads with visible current-conversation delivery before disambiguating AgentConnect tools', async () => {
+    // The current-thread rule must win without removing issue #800's warning about Claude's built-in SendMessage.
     const store = newStore()
     const host = { newSession: vi.fn(async () => 'acp-1') } as any
     const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
     const { blocks } = await sm.handle('bot-a', msg({ ts: '100.1', text: 'hi' }))
     const first = (blocks[0] as any).text as string
-    expect(first).toContain('ONLY channel that reaches other agents and humans')
+    expect(first).toContain('including when another agent or human should answer next')
+    expect(first).toContain('That visible reply is the hand-off')
+    expect(first).toContain('would hide the exchange from this conversation')
     expect(first).toContain('mcp__agentconnect__sendMessage')
     expect(first).toContain('a bare `SendMessage`')
-    expect(first).toContain('do NOT reach AgentConnect')
-    expect(first).toContain('Never use them for messaging, reporting back, or collaboration')
-    // It LEADS the collaboration section: the collision fires exactly when the
-    // model is choosing a messaging tool, so the warning must come first.
+    expect(first).toContain('does NOT reach AgentConnect')
+    expect(first).toContain('Never substitute it for an AgentConnect tool')
+    expect(first).not.toContain('ONLY channel that reaches other agents and humans')
     const section = first.slice(first.indexOf('# Collaborating with other agents'))
-    expect(section.indexOf('ONLY channel that reaches')).toBeLessThan(section.indexOf('To reach a specific agent'))
+    expect(section.indexOf('To speak in the conversation')).toBeLessThan(
+      section.indexOf("When a rule below tells you to call AgentConnect's")
+    )
+    expect(section.indexOf("When a rule below tells you to call AgentConnect's")).toBeLessThan(
+      section.indexOf('To reach a specific agent privately')
+    )
     store.close()
   })
 
   it('states the needsReply rule in the standing context, not only in the tool descriptor', async () => {
-    // The descriptor is one input among many; this context is ALWAYS present and used to
-    // present the bare `toAgent` form as the normal way to reach a peer privately, with no
-    // hint that an answer never comes back. A caller reading only that omitted `needsReply`
-    // for a question in production (#628) — so the rule has to be stated in both places, and
-    // in the SAME terms the descriptor uses.
+    // Standing context preserves #628's private-call report rule while keeping it subordinate to current-thread delivery.
     const store = newStore()
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
     const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
@@ -1971,7 +1968,9 @@ describe('SessionManager — collaboration preamble', () => {
     const metaArg = host.newSession.mock.calls[0][3] as string
     expect(metaArg).toContain('{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}')
     expect(metaArg).toContain('FIRE-AND-FORGET')
-    // The trigger, so the rule is actionable rather than a definition of the flag.
+    expect(metaArg).toContain('intentionally choose this private form')
+    expect(metaArg).not.toContain('Whenever you expect an answer')
+    // Keep an actionable trigger, not merely a flag definition.
     expect(metaArg).toMatch(/asks a question or requests a result/)
     store.close()
   })


### PR DESCRIPTION
## Summary
- lead collaboration guidance with the visible current-thread reply rule so Claude does not turn Slack handoffs into postless agent calls
- retain the AgentConnect MCP namespace warning for Claude runtime tool-name collisions
- scope needsReply guidance to intentionally selected private or different-conversation calls

## Tests
- daemon session-manager and MCP tool tests: 115 passed
- daemon TypeScript typecheck
- targeted ESLint and Prettier checks
- pre-push repository lint: 0 errors

Created by Codex . GPT-5