### PR TITLE
revert(daemon): drop the #801 tool-precedence bullet after a live in-thread regression

### DIFF
--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -817,17 +817,8 @@ export class SessionManager {
     // reach humans, post at a channel root, or reply into a parent session. It has no
     // visible in-thread form: speaking in the current conversation is an ordinary reply.
     // `toAgent` without a `channel` is the postless, channel-invisible wake.
-    // The precedence bullet leads for a measured reason (issue #800): on the Claude
-    // Code runtime the session also carries the runtime's own built-in `SendMessage`
-    // (agent-teams messaging) — a literal name match for a report-back instruction —
-    // and a child that picks it loses its parent report silently. Costs ~80 standing
-    // tokens per session.
     const collabAppend =
       `# Collaborating with other agents\n` +
-      `- AgentConnect's tools (the \`agentconnect\` MCP server, e.g. \`mcp__agentconnect__sendMessage\`) are the ` +
-      `ONLY channel that reaches other agents and humans here. Your runtime may offer built-in tools with similar ` +
-      `names (e.g. a bare \`SendMessage\`) — those do NOT reach AgentConnect and anything sent through them is ` +
-      `lost. Never use them for messaging, reporting back, or collaboration.\n` +
       `- To reach a specific agent privately, call \`sendMessage\` with ` +
       `\`{"toAgent":"<agent id>","message":"..."}\` — it wakes ONLY that agent, delivered directly to it ` +
       `(nothing is posted to the channel). That bare form is FIRE-AND-FORGET: the peer answers inside its own ` +

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -1934,30 +1934,6 @@ describe('SessionManager — collaboration preamble', () => {
     store.close()
   })
 
-  it('leads the guidance with the tool-precedence rule naming the built-in SendMessage hazard (issue #800)', async () => {
-    // Measured (tool-surface A/B, 2026-08-09): a Claude Code child session also
-    // carries the runtime's own built-in `SendMessage` — a literal name match
-    // for a report-back instruction — and a child that picks it loses its
-    // parent report silently. The standing context must say, before anything
-    // else about collaboration, that AgentConnect's MCP tools are the only
-    // channel that reaches anyone and that similarly-named built-ins are lost.
-    const store = newStore()
-    const host = { newSession: vi.fn(async () => 'acp-1') } as any
-    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
-    const { blocks } = await sm.handle('bot-a', msg({ ts: '100.1', text: 'hi' }))
-    const first = (blocks[0] as any).text as string
-    expect(first).toContain('ONLY channel that reaches other agents and humans')
-    expect(first).toContain('mcp__agentconnect__sendMessage')
-    expect(first).toContain('a bare `SendMessage`')
-    expect(first).toContain('do NOT reach AgentConnect')
-    expect(first).toContain('Never use them for messaging, reporting back, or collaboration')
-    // It LEADS the collaboration section: the collision fires exactly when the
-    // model is choosing a messaging tool, so the warning must come first.
-    const section = first.slice(first.indexOf('# Collaborating with other agents'))
-    expect(section.indexOf('ONLY channel that reaches')).toBeLessThan(section.indexOf('To reach a specific agent'))
-    store.close()
-  })
-
   it('states the needsReply rule in the standing context, not only in the tool descriptor', async () => {
     // The descriptor is one input among many; this context is ALWAYS present and used to
     // present the bare `toAgent` form as the normal way to reach a peer privately, with no


### PR DESCRIPTION
Reverts #801 (commit 29feb9b6) on the user's direct order, after a live in-thread regression traced to the tool-precedence bullet it added to the standing collaboration guidance.

## The live regression

In a real Slack channel, a turn-taking counting game was started in a thread ("@test @test2 你们轮流报数, 报到30 停" — take turns counting to 30). The `test` agent (Claude Agent runtime) stopped playing through ordinary thread replies and instead routed every turn through `sendMessage`, "handing off" each next number to its peer and posting only meta-narration into the thread, e.g.:

> Count so far: 1, 2, 3 (@test2) → 4 (me). Handing off for 5

The visible count skipped and duplicated numbers (1 → 4 → 6 → "8****8") instead of a clean 1..30 alternation.

## Mechanism

The bullet said AgentConnect's MCP tools are the **ONLY** channel that reaches other agents and humans. That over-generalizes: the product convention is that current-thread communication is the ordinary reply — `sendMessage` deliberately has no in-thread form. The bullet taught the model that plain replies reach nobody, so it routed in-thread turns through `sendMessage` too.

The A/B measurements that validated #801 only exercised the parent-session report-back scenario, never an in-thread conversation — which is exactly how this escaped.

## What this restores / costs

- The standing collaboration guidance in `packages/daemon/src/session/session-manager.ts` is byte-identical to its pre-#801 form (verified against the parent of 29feb9b6).
- The contract test pinning the bullet is removed (it was the only #801 addition to `session-manager.test.ts`).
- The #800 hazard (built-in `SendMessage` swallowing parent reports; measured 10/10 delivery with the bullet vs 4/6 without) returns. Follow-ups are tracked on #800: a scoped rewrite of the bullet validated against both scenarios, and the mechanism-level fixes with no prompt blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
