### PR TITLE
feat(daemon): prepare a git-repo workspace on the sandbox pod's own volume

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -210,6 +210,7 @@ import {
   convergeGithubAppWorkspaceRename,
   ensureWorkspaceMaterialization,
   isWorkspaceEmpty,
+  prepareClusterWorkspace,
   prepareWorkspace,
   prepareSessionWorkspace,
   prepareWorkspaceForActivation,
@@ -266,7 +267,7 @@ import {
 import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from './runtimes/registry.js'
 import { installedRuntimeCatalog, installedRuntimes, resolveCommandPath } from './runtimes/probe.js'
 import { startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.js'
-import { setWorkspaceGitRunnerResolver } from './workspace/workspace-manager.js'
+import { setWorkspaceGitRunnerResolver, setWorkspacePathClearer } from './workspace/workspace-manager.js'
 import { declaredRuntimeCatalog, loadK8sRuntimeTable, type K8sRuntimeAcpSnapshot } from './runtimes/k8s-runtimes.js'
 import { ensureNodeBinOnPath } from './runtimes/exec-path.js'
 import {
@@ -2671,6 +2672,9 @@ export class Daemon {
       // resolver answers undefined for any without a bound channel, so an agent this daemon has
       // not launched into a sandbox keeps its local behaviour.
       setWorkspaceGitRunnerResolver((agentId, cwd, abort) => this.k8sPlane?.gitRunnerFor(agentId, cwd, abort))
+      // And the one destructive operation a cluster workspace needs, for the same reason: a
+      // partial clone sits on a volume no `rmSync` here can reach.
+      setWorkspacePathClearer((agentId, root) => this.k8sPlane!.clearPath(agentId, root))
       this.log.info(`k8s: execution plane ready — shim endpoint on :${this.k8sPlane.listener.listeningPort()}`)
     }
     // Sandbox-optional principle (#36): skills are NOT force-sandboxed fleet-wide.
@@ -4840,7 +4844,10 @@ export class Daemon {
     // git-repo checkouts for cluster agents arrive with the materialize/runner phases.
     if (this.k8sPlane) {
       await this.k8sPlane.ensureChannel(agent.id)
-      return clusterWorkspaceCwd(agent, this.k8sPlane.workspaceRootFor(agent.id), request)
+      // The pod's own preparation: clone and pull happen on its volume through the runner, and none
+      // of the local work below runs — its mkdir, `existsSync(.git)` and skills installation all
+      // land on this daemon's disk, describing a filesystem the runtime never reads.
+      return await prepareClusterWorkspace(agent, this.k8sPlane.workspaceRootFor(agent.id), request)
     }
     if (!this.opts.hostFactory) assertExclusiveAgentWorkspaces([agent as LoadedAgent])
     const opts = {
@@ -20401,6 +20408,7 @@ export class Daemon {
     // unable to send its ACP close — a sandbox process still running, and reconnecting.
     await this.k8sPlane?.stop().catch(() => undefined)
     setWorkspaceGitRunnerResolver(undefined)
+    setWorkspacePathClearer(undefined)
     await Promise.allSettled(hostStarts)
     // Shutdown backstop: dream extractions reclaim their own tombstone when the
     // dedicated host stops, and stopHost sweeps per-agent for warm hosts, but drop

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -267,7 +267,11 @@ import {
 import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from './runtimes/registry.js'
 import { installedRuntimeCatalog, installedRuntimes, resolveCommandPath } from './runtimes/probe.js'
 import { startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.js'
-import { setWorkspaceGitRunnerResolver, setWorkspacePathClearer } from './workspace/workspace-manager.js'
+import {
+  setSandboxWorkspaceMode,
+  setWorkspaceGitRunnerResolver,
+  setWorkspacePathClearer
+} from './workspace/workspace-manager.js'
 import { declaredRuntimeCatalog, loadK8sRuntimeTable, type K8sRuntimeAcpSnapshot } from './runtimes/k8s-runtimes.js'
 import { ensureNodeBinOnPath } from './runtimes/exec-path.js'
 import {
@@ -2675,6 +2679,9 @@ export class Daemon {
       // And the one destructive operation a cluster workspace needs, for the same reason: a
       // partial clone sits on a volume no `rmSync` here can reach.
       setWorkspacePathClearer((agentId, root) => this.k8sPlane!.clearPath(agentId, root))
+      // And the mode itself, which decides what workspace operations are available at all: an
+      // in-place conversion has no pod-side implementation of its rollback contract.
+      setSandboxWorkspaceMode(true)
       this.log.info(`k8s: execution plane ready — shim endpoint on :${this.k8sPlane.listener.listeningPort()}`)
     }
     // Sandbox-optional principle (#36): skills are NOT force-sandboxed fleet-wide.
@@ -20409,6 +20416,7 @@ export class Daemon {
     await this.k8sPlane?.stop().catch(() => undefined)
     setWorkspaceGitRunnerResolver(undefined)
     setWorkspacePathClearer(undefined)
+    setSandboxWorkspaceMode(false)
     await Promise.allSettled(hostStarts)
     // Shutdown backstop: dream extractions reclaim their own tombstone when the
     // dedicated host stops, and stopHost sweeps per-agent for warm hosts, but drop

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -6,6 +6,7 @@ import { clusterMetrics } from './cluster-metrics.js'
 import { ShimListener } from '../shim/listener.js'
 import { ShimGitRunner } from '../shim/git-exec.js'
 import { TunnelProxy } from '../shim/tunnel-proxy.js'
+import { ShimFileSink } from '../shim/channels.js'
 import type { TunnelName } from '../shim/tunnel.js'
 import type { ShimSession } from '../shim/session.js'
 import type { SpawnRecord } from '../shim/binding.js'
@@ -113,6 +114,10 @@ export interface K8sRuntimePlane {
    *  answers on. Callers that build paths for that work read it here rather than re-deriving it,
    *  so an environment can never describe one filesystem while the execution happens in another. */
   runsInSandbox: (agentId: string) => boolean
+  /** Empty a directory on the agent's pod volume, reporting why not rather than throwing. The one
+   *  destructive operation a cluster workspace needs — a partial clone — and it cannot be an
+   *  `rmSync`, because the directory is on a filesystem the daemon cannot see. */
+  clearPath: (agentId: string, root: string) => Promise<string | undefined>
   /** Where the agent's bound pod mounts its workspace, as its shim reported; undefined before a
    *  bind or from a legacy shim (callers fall back to DEFAULT_SHIM_WORKSPACE_ROOT). */
   workspaceRootFor: (agentId: string) => string | undefined
@@ -266,6 +271,11 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       return new ShimGitRunner(driver.sessionFor(agentId)!, cwd, undefined, abort)
     },
     runsInSandbox,
+    clearPath: async (agentId, root) => {
+      const session = driver.sessionFor(agentId)
+      if (!session?.isAttached()) return `agent ${agentId} has no bound sandbox channel`
+      return await new ShimFileSink(session).clear(root)
+    },
     workspaceRootFor: (agentId) => driver.workspaceRootFor(agentId),
     stop: async () => {
       for (const timer of lossTimers.values()) clearTimeout(timer)

--- a/packages/daemon/src/shim/exec-handler.ts
+++ b/packages/daemon/src/shim/exec-handler.ts
@@ -127,6 +127,21 @@ function canonical(path: string): string {
   }
 }
 
+/**
+ * Refuse an absolute path that escapes the workspace root, for a path that does not exist yet.
+ *
+ * Lexical rather than `realpath`, because a clone target is precisely a path that is not there:
+ * containment is decided on the normalized form, and the ROOT is canonicalized so a symlinked mount
+ * still compares correctly.
+ */
+function assertInsideRoot(root: string, requested: string): void {
+  const base = canonical(root)
+  const target = normalize(resolve(requested))
+  if (target !== base && !target.startsWith(base + sep)) {
+    throw new ExecRefusedError(`path escapes the workspace root: ${requested}`)
+  }
+}
+
 /** Refuse a cwd that escapes the workspace root, whatever the daemon asked for. */
 function resolveCwd(root: string, requested: string | undefined): string {
   const base = canonical(root)
@@ -214,6 +229,15 @@ async function runGit(payload: unknown, deps: ExecHandlerDeps, abort?: AbortSign
     }
   }
   const cwd = resolveCwd(deps.workspaceRoot, parsed.cwd)
+  // A clone WRITES to a path in argv, which the cwd fence above never looks at. The daemon sends a
+  // relative target for exactly that reason, so an absolute one is either a mistake or an attempt to
+  // write outside the workspace — and this side is the one holding the filesystem.
+  if (subcommand === 'clone') {
+    for (const argument of rest) {
+      if (argument.startsWith('-') || !isAbsolute(argument)) continue
+      assertInsideRoot(deps.workspaceRoot, argument)
+    }
+  }
   // The caller's deadline governs, bounded by this side's ceiling: a compromised daemon must not
   // be able to pin a child here indefinitely, and a child outliving the request that asked for
   // it keeps holding index.lock after the caller has given up.

--- a/packages/daemon/src/shim/sandbox-paths.ts
+++ b/packages/daemon/src/shim/sandbox-paths.ts
@@ -17,6 +17,17 @@ export const SANDBOX_GIT_CREDENTIAL_HELPER = '/opt/agentconnect/bin/git-credenti
 export const SANDBOX_GIT_CONFIG_DIR = '/run/agentconnect/git'
 
 /**
+ * Where a git-repo workspace is checked out, relative to the pod's workspace mount.
+ *
+ * A subdirectory rather than the mount itself, because the mount is also the runtime's HOME: a
+ * checkout at the root would put the repository's working tree on top of `.claude`, `.codex` and
+ * `.config`, where `git status` reports them as untracked and `git clean` would delete them. A
+ * from-scratch workspace keeps using the root — it has no working tree to confuse with HOME, and
+ * moving it would strand every volume already provisioned.
+ */
+export const SANDBOX_CHECKOUT_DIR = 'repo'
+
+/**
  * The daemon-side servers the shim serves locally, and the in-pod path of each.
  *
  * A plain record here rather than beside the tunnel's schemas, because the credential helper needs

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -985,26 +985,38 @@ export async function prepareWorkspaceForActivation(
   }: { allowExistingCheckout?: boolean; reconcileMaterialization?: boolean } = {}
 ): Promise<() => void> {
   const cwd = agent.workspace.path
-  // Activation REPLACES a workspace, and its whole contract is local-filesystem: a staged clone
-  // beside the target, `renameSync` for an atomic swap, `readdirSync` to prove the destination is
-  // still empty at the boundary, and a rollback that restores the previous tree. A pod offers none
-  // of those — the shim can write and clear, not rename, list or stat — so there is no way to keep
-  // the rollback guarantee across the channel yet. Refused loudly, in the same spirit as session
-  // isolation: the alternative is a staged clone at a daemon-absolute path, which the shim's target
-  // fence rejects with an error about containment that explains nothing about what was attempted.
-  if (workspacesLiveInSandboxes && agent.workspace.mode === 'git-repo') {
-    throw new Error(
-      `a git-repo workspace cannot be converted or repaired in place with --k8s yet (agent "${agent.id}") — ` +
-        `recreate the agent to provision a fresh volume`
-    )
-  }
-  mkdirSync(cwd, { recursive: true })
   const previousMaterialization = reconcileMaterialization ? readMaterialization(agent) : undefined
   const targetMaterialization = materializationKey(agent)
   let replace = reconcileMaterialization && !sameMaterialization(agent, previousMaterialization, targetMaterialization)
   const restoreMarker = () => {
     if (reconcileMaterialization) restoreWorkspaceMaterialization(agent, previousMaterialization)
   }
+
+  // A cluster agent's checkout is on its pod volume, so this function has nothing local to do —
+  // and, for the one case that would need to do something, no way to do it safely.
+  //
+  // The distinction is REPLACING AN EXISTING CHECKOUT versus everything else, because only the
+  // former needs the contract a pod cannot offer: a staged clone beside the target, `renameSync`
+  // for an atomic swap, `readdirSync` to prove the destination is still empty at the boundary, and
+  // a rollback that restores the previous tree. The shim can write and clear — not rename, list or
+  // stat — so that is refused, and pointedly not the rest: activation is ALSO how a rejected edit
+  // is rolled back, how a staged agent is recovered, and how a same-workspace repair runs, each
+  // arriving here with `reconcileWorkspace` set. Refusing those left an agent staged and offline,
+  // because the rollback's own restoration hit the refusal too.
+  //
+  // Everything else is a no-op that keeps the marker honest. Session preparation is what converges
+  // the volume — origin, helper pin, pull — and it runs before the runtime sees the workspace.
+  if (workspacesLiveInSandboxes && agent.workspace.mode === 'git-repo') {
+    if (replace && previousMaterialization !== undefined) {
+      throw new Error(
+        `a git-repo workspace cannot be converted in place with --k8s yet (agent "${agent.id}") — ` +
+          `recreate the agent to provision a fresh volume`
+      )
+    }
+    if (reconcileMaterialization) recordWorkspaceMaterialization(agent)
+    return restoreMarker
+  }
+  mkdirSync(cwd, { recursive: true })
 
   if (agent.workspace.mode === 'from-scratch') {
     if (replace) {

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -186,6 +186,19 @@ export function setWorkspacePathClearer(clearer: WorkspacePathClearer | undefine
   clearWorkspacePathInSandbox = clearer
 }
 
+/**
+ * Whether this daemon places workspaces in sandbox pods at all.
+ *
+ * Deliberately NOT `resolveWorkspaceGitRunner?.(id) !== undefined`: that answers per agent and is
+ * false before a channel binds, so an operation guarded by it would take the local path for a
+ * cluster agent that simply has no pod yet — and clone onto the daemon's disk.
+ */
+let workspacesLiveInSandboxes = false
+
+export function setSandboxWorkspaceMode(enabled: boolean): void {
+  workspacesLiveInSandboxes = enabled
+}
+
 /** Empty a path belonging to a cluster agent. A daemon with no clearer registered has no sandbox to
  *  reach, so there is nothing to empty — the local path never calls this. */
 async function clearSandboxPath(agentId: string, root: string): Promise<void> {
@@ -837,12 +850,19 @@ async function cloneRepoInSandbox(agent: Agent, root: string, repository: string
   // Single-flight like the local clone. Per-agent workspace preparation is already serialized by the
   // daemon's own queue, so this is the belt to that braces: two clones into one volume would be a
   // half-written checkout, and the cost of preventing it is a map lookup.
-  const inflight = cloneInFlight.get(cloneKey(agent.id, checkout))
+  //
+  // The key is captured ONCE and reused for get/set/delete. `cloneKey` is deliberately
+  // state-dependent — it includes the agent id only while a sandbox runner is attached — so a clone
+  // that fails BECAUSE the channel dropped would otherwise compute a different key on the way out,
+  // delete nothing, and leave its own rejection cached under the old one. Every retry after
+  // reattachment would then re-await that dead promise until the daemon restarted.
+  const key = cloneKey(agent.id, checkout)
+  const inflight = cloneInFlight.get(key)
   if (inflight) return await inflight
   const started = cloneInSandbox(agent, root, repository, checkout).finally(() => {
-    cloneInFlight.delete(cloneKey(agent.id, checkout))
+    cloneInFlight.delete(key)
   })
-  cloneInFlight.set(cloneKey(agent.id, checkout), started)
+  cloneInFlight.set(key, started)
   return await started
 }
 
@@ -965,6 +985,19 @@ export async function prepareWorkspaceForActivation(
   }: { allowExistingCheckout?: boolean; reconcileMaterialization?: boolean } = {}
 ): Promise<() => void> {
   const cwd = agent.workspace.path
+  // Activation REPLACES a workspace, and its whole contract is local-filesystem: a staged clone
+  // beside the target, `renameSync` for an atomic swap, `readdirSync` to prove the destination is
+  // still empty at the boundary, and a rollback that restores the previous tree. A pod offers none
+  // of those — the shim can write and clear, not rename, list or stat — so there is no way to keep
+  // the rollback guarantee across the channel yet. Refused loudly, in the same spirit as session
+  // isolation: the alternative is a staged clone at a daemon-absolute path, which the shim's target
+  // fence rejects with an error about containment that explains nothing about what was attempted.
+  if (workspacesLiveInSandboxes && agent.workspace.mode === 'git-repo') {
+    throw new Error(
+      `a git-repo workspace cannot be converted or repaired in place with --k8s yet (agent "${agent.id}") — ` +
+        `recreate the agent to provision a fresh volume`
+    )
+  }
   mkdirSync(cwd, { recursive: true })
   const previousMaterialization = reconcileMaterialization ? readMaterialization(agent) : undefined
   const targetMaterialization = materializationKey(agent)

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -817,6 +817,23 @@ export async function prepareClusterWorkspace(
       clearTimeout(timer)
     }
   }
+  // The marker records what the VOLUME now holds, and this is the only place that knows.
+  //
+  // Ordinary placement activation does not ask for reconciliation, so nothing else refreshes it on
+  // this daemon: an agent that moves away, has its repository renamed elsewhere, and moves back
+  // would leave a marker naming the old URL while preparation had already converged the volume to
+  // the new one. A later repair reads that stale marker as a materialization CHANGE and is refused
+  // — staging an agent whose checkout was already correct.
+  //
+  // Best-effort: the volume is prepared either way, and failing a session over bookkeeping would
+  // trade a stale marker for no session at all.
+  try {
+    recordWorkspaceMaterialization(agent)
+  } catch (err) {
+    workspaceLog.warn(
+      `workspace: could not record the materialization marker for agent "${agent.id}" (${(err as Error).message})`
+    )
+  }
   return acpCwd
 }
 

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -38,8 +38,10 @@ import {
 import { LocalGitRunner, type GitRunner } from './git-runner.js'
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
 import { DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
+import { SANDBOX_CHECKOUT_DIR } from '../shim/sandbox-paths.js'
 
 const skillsLog = makeLogger('info')
+const workspaceLog = makeLogger('info')
 
 /**
  * Post-clone skills step (docs/designs/shared-skills.md §6). Installs the agent's
@@ -167,6 +169,30 @@ function runnerFor(agentId: string, cwd?: string, abort?: AbortSignal): GitRunne
     resolveWorkspaceGitRunner?.(agentId, cwd, abort) ??
     new LocalGitRunner(gitFor(cwd, abort), cwd, (env) => gitFor(cwd, abort).env(env))
   )
+}
+
+/**
+ * Empties a directory in the filesystem that agent's work happens in; undefined ⇒ this daemon's.
+ *
+ * Registered like the git runner above, and for the same reason: the one destructive path a cluster
+ * workspace needs (a partial clone) cannot be an `rmSync`, because the directory is on a volume this
+ * process cannot see.
+ */
+export type WorkspacePathClearer = (agentId: string, root: string) => Promise<string | undefined>
+
+let clearWorkspacePathInSandbox: WorkspacePathClearer | undefined
+
+export function setWorkspacePathClearer(clearer: WorkspacePathClearer | undefined): void {
+  clearWorkspacePathInSandbox = clearer
+}
+
+/** Empty a path belonging to a cluster agent. A daemon with no clearer registered has no sandbox to
+ *  reach, so there is nothing to empty — the local path never calls this. */
+async function clearSandboxPath(agentId: string, root: string): Promise<void> {
+  const error = await clearWorkspacePathInSandbox?.(agentId, root).catch((err: unknown) => (err as Error).message)
+  if (error) {
+    workspaceLog.warn(`workspace: could not empty ${root} for agent "${agentId}" after a failed clone (${error})`)
+  }
 }
 
 /** The same resolution for git run OUTSIDE this module — the console's workspace git seam. Exported
@@ -689,16 +715,124 @@ export function clusterWorkspaceCwd(
   runtimeRoot: string | undefined,
   request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
 ): string {
-  if (agent.workspace.mode !== 'from-scratch') {
-    // Refused loudly rather than half-working: the clone/pull/audit flow still mixes daemon
-    // and pod coordinates for git-repo workspaces, and a clear error beats a mystery one
-    // from git inside the sandbox.
-    throw new Error(`git-repo workspaces are not supported with --k8s yet (agent "${agent.id}")`)
-  }
   if (request?.isolation === 'session') {
+    // Still refused loudly: a logical-session worktree needs a daemon-owned parent beside the
+    // checkout, `worktree add` in the sandbox, and a retention GC that reads the pod's tree — a
+    // separate migration, and a clear error beats a mystery one from git inside the sandbox.
     throw new Error(`session-isolated workspaces are not supported with --k8s yet (agent "${agent.id}")`)
   }
-  return runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
+  const root = runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
+  if (agent.workspace.mode === 'from-scratch') return root
+  // A git-repo workspace checks out one level down, away from the runtime's HOME. The configured
+  // working subdirectory is applied LEXICALLY here: validating it means resolving symlinks and
+  // stat-ing, which only means something in the filesystem that holds it — so the shim does that
+  // when it refuses a cwd outside its own root.
+  const checkout = join(root, SANDBOX_CHECKOUT_DIR)
+  const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
+  return agentDir === undefined ? checkout : join(checkout, ...agentDir.split('/'))
+}
+
+/**
+ * Prepare a CLUSTER agent's workspace on its sandbox pod's volume.
+ *
+ * A separate function from {@link prepareWorkspace} rather than a branch inside it, because the two
+ * differ in every step that touches a filesystem: `existsSync(.git)` becomes a question asked of the
+ * POD, `mkdirSync` is the mounted volume's job, and a failed clone cannot be cleaned up with
+ * `rmSync`. Sharing the body would mean a conditional at each of those, and the local path — the one
+ * every self-hosted daemon runs — is the one that must not acquire new ways to be wrong.
+ *
+ * Skills are NOT installed here. Their acquisition, ledger and executable-content removal are all
+ * local-filesystem work, and pointing them at a pod path would write them onto this daemon's disk;
+ * that migration is its own change, so a cluster agent runs with none.
+ */
+export async function prepareClusterWorkspace(
+  agent: Agent,
+  runtimeRoot: string | undefined,
+  request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
+): Promise<string> {
+  const acpCwd = clusterWorkspaceCwd(agent, runtimeRoot, request)
+  if (agent.workspace.mode === 'from-scratch') return acpCwd
+  // Validated at the execution boundary, exactly as the local path does: a hand-edited agent.json
+  // must not turn daemon-managed git into a local-path or remote-helper launcher.
+  const repository = gitRepoOf(agent)
+  const root = runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
+  const checkout = join(root, SANDBOX_CHECKOUT_DIR)
+  const githubApp = usesGithubApp(agent)
+
+  if (!(await clusterCheckoutExists(agent.id, checkout))) {
+    await cloneRepoInSandbox(agent, root, repository)
+  } else if (githubApp) {
+    // The helper line in `.git/config` outlives the launch that wrote it, and a resumed volume
+    // carries the previous generation's id. Re-pinned through the runner so it lands in the pod.
+    await writeRepoHelperConfig(runnerFor(agent.id, checkout), agent.id).catch(() => undefined)
+  }
+
+  if (agent.workspace.pullOnNewSession) {
+    if (githubApp) await preWarmGitCred(agent.id, 'pull').catch(() => undefined)
+    const abort = new AbortController()
+    const timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
+    try {
+      await assertSafeWorkspaceGitConfig(runnerFor(agent.id, checkout))
+      const pullTarget = workspaceGitPullTarget(repository)
+      const git = runnerFor(agent.id, checkout, abort.signal).withEnv({
+        ...workspaceGitLocalEnv(),
+        ...pullTarget.env,
+        ...(githubApp ? gitCredentialEnv(agent.id) : {}),
+        GIT_TERMINAL_PROMPT: '0'
+      })
+      await pullWorkspaceRef(git, pullTarget.remote, agent.workspace.gitBranch)
+    } catch {
+      // offline / timed out / non-fast-forward: proceed with the checkout on the volume, which is
+      // the same degradation the local path accepts.
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+  return acpCwd
+}
+
+/**
+ * Whether the pod already holds a checkout — asked of the pod, because that is where it would be.
+ *
+ * `rev-parse --git-dir` rather than a file test: it is in the shim's permitted inventory, and it
+ * answers the question that matters (a USABLE repository) instead of the one a `.git` entry answers.
+ * A half-written clone has a `.git` and fails this, which is the case that would otherwise make
+ * every later session believe the checkout exists.
+ */
+async function clusterCheckoutExists(agentId: string, checkout: string): Promise<boolean> {
+  try {
+    await runnerFor(agentId, checkout).withEnv(workspaceGitLocalEnv()).raw(['rev-parse', '--git-dir'])
+    return true
+  } catch {
+    // Missing directory, empty directory, or a partial clone — all "clone it".
+    return false
+  }
+}
+
+/**
+ * Clone into the pod, with the target RELATIVE to the fenced working directory.
+ *
+ * That is what keeps it inside the sandbox: the shim validates the `cwd` it is given and refuses one
+ * outside its workspace root, so a relative target cannot land anywhere else. An absolute target
+ * would be argv the fence never looks at.
+ */
+async function cloneRepoInSandbox(agent: Agent, root: string, repository: string): Promise<void> {
+  const githubApp = usesGithubApp(agent)
+  if (githubApp) await preWarmGitCred(agent.id, 'clone')
+  const env = githubApp
+    ? { ...workspaceGitEnvBase(repository), ...cloneGitEnv(agent.id, repository) }
+    : { ...workspaceGitEnvBase(repository), GIT_TERMINAL_PROMPT: '0' }
+  try {
+    await runnerFor(agent.id, root)
+      .withEnv(env)
+      .clone(repository, SANDBOX_CHECKOUT_DIR, ['--branch', agent.workspace.gitBranch, '--single-branch'])
+  } catch (err) {
+    // A partial checkout would fail the probe above forever after, since git refuses to clone into
+    // a non-empty directory. Emptying it is the pod's own job — there is no rmSync to reach it.
+    await clearSandboxPath(agent.id, join(root, SANDBOX_CHECKOUT_DIR))
+    throw err
+  }
+  if (githubApp) await writeRepoHelperConfig(runnerFor(agent.id, join(root, SANDBOX_CHECKOUT_DIR)), agent.id)
 }
 
 /** Resolve the already-prepared ACP cwd without pulling, acquiring sources, or

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -206,6 +206,17 @@ async function convergeWorkspaceOrigin(agent: Agent, cwd = agent.workspace.path)
   const clone = cloneInFlight.get(cloneKey(agent.id, cwd))
   if (clone) await clone
   if (!existsSync(join(cwd, '.git'))) return
+  await convergeOriginInPlace(agent, cwd)
+}
+
+/**
+ * The convergence itself, for a checkout the caller has already established exists.
+ *
+ * Split out because establishing that is where the two filesystems differ: locally it is a file
+ * test, and for a pod it is a question asked over the channel. What follows is identical, and has to
+ * be — this is where a repository rename is followed and where an untrusted origin is refused.
+ */
+async function convergeOriginInPlace(agent: Agent, cwd: string): Promise<void> {
   const expected = gitRepoOf(agent)
   const git = runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
   let current: string
@@ -761,10 +772,15 @@ export async function prepareClusterWorkspace(
 
   if (!(await clusterCheckoutExists(agent.id, checkout))) {
     await cloneRepoInSandbox(agent, root, repository)
-  } else if (githubApp) {
-    // The helper line in `.git/config` outlives the launch that wrote it, and a resumed volume
-    // carries the previous generation's id. Re-pinned through the runner so it lands in the pod.
-    await writeRepoHelperConfig(runnerFor(agent.id, checkout), agent.id).catch(() => undefined)
+  } else {
+    // A resumed volume carries the PREVIOUS launch's checkout, so the same two things the local
+    // path does to one: follow a repository rename onto the canonical URL (and refuse an origin
+    // that is not a trusted GitHub remote, which is fail-closed), and re-pin the helper line in
+    // `.git/config`, whose agent id goes stale when an agent is recreated over a surviving volume.
+    await convergeOriginInPlace(agent, checkout)
+    if (githubApp) {
+      await writeRepoHelperConfig(runnerFor(agent.id, checkout), agent.id).catch(() => undefined)
+    }
   }
 
   if (agent.workspace.pullOnNewSession) {
@@ -817,6 +833,20 @@ async function clusterCheckoutExists(agentId: string, checkout: string): Promise
  * would be argv the fence never looks at.
  */
 async function cloneRepoInSandbox(agent: Agent, root: string, repository: string): Promise<void> {
+  const checkout = join(root, SANDBOX_CHECKOUT_DIR)
+  // Single-flight like the local clone. Per-agent workspace preparation is already serialized by the
+  // daemon's own queue, so this is the belt to that braces: two clones into one volume would be a
+  // half-written checkout, and the cost of preventing it is a map lookup.
+  const inflight = cloneInFlight.get(cloneKey(agent.id, checkout))
+  if (inflight) return await inflight
+  const started = cloneInSandbox(agent, root, repository, checkout).finally(() => {
+    cloneInFlight.delete(cloneKey(agent.id, checkout))
+  })
+  cloneInFlight.set(cloneKey(agent.id, checkout), started)
+  return await started
+}
+
+async function cloneInSandbox(agent: Agent, root: string, repository: string, checkout: string): Promise<void> {
   const githubApp = usesGithubApp(agent)
   if (githubApp) await preWarmGitCred(agent.id, 'clone')
   const env = githubApp
@@ -829,10 +859,10 @@ async function cloneRepoInSandbox(agent: Agent, root: string, repository: string
   } catch (err) {
     // A partial checkout would fail the probe above forever after, since git refuses to clone into
     // a non-empty directory. Emptying it is the pod's own job — there is no rmSync to reach it.
-    await clearSandboxPath(agent.id, join(root, SANDBOX_CHECKOUT_DIR))
+    await clearSandboxPath(agent.id, checkout)
     throw err
   }
-  if (githubApp) await writeRepoHelperConfig(runnerFor(agent.id, join(root, SANDBOX_CHECKOUT_DIR)), agent.id)
+  if (githubApp) await writeRepoHelperConfig(runnerFor(agent.id, checkout), agent.id)
 }
 
 /** Resolve the already-prepared ACP cwd without pulling, acquiring sources, or

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -281,6 +281,30 @@ describe('replacing a cluster workspace in place', () => {
     await expect(prepareWorkspaceForActivation(agent)).resolves.toBeTypeOf('function')
   })
 
+  it('refreshes the marker after preparation, so a rename elsewhere does not strand a repair', async () => {
+    // move away → repository renamed while the agent is on another daemon → move back. Ordinary
+    // placement activation asks for no reconciliation, so nothing else refreshes this daemon's
+    // marker; preparation converges the shared volume to the new URL and has to record that, or a
+    // later repair reads the old marker as a CHANGE and refuses an agent whose checkout is correct.
+    const agent = bookkeepingAgent()
+    await prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
+
+    // Renamed elsewhere. Preparation converges the volume — and now the marker too.
+    const renamed = {
+      ...agent,
+      workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/renamed.git' }
+    } as Agent
+    checkoutExists = true
+    originUrl = 'https://github.com/acme/private.git'
+    await prepareClusterWorkspace(renamed, POD_ROOT)
+    expect(calls.some((call) => call.args[0] === 'remote' && call.args[1] === 'set-url')).toBe(true)
+
+    // The repair that used to be refused: same workspace as the volume now holds.
+    await expect(prepareWorkspaceForActivation(renamed, { reconcileMaterialization: true })).resolves.toBeTypeOf(
+      'function'
+    )
+  })
+
   it('refuses only a conversion of an EXISTING checkout, which has no rollback in a pod', async () => {
     // The one case that needs the contract a pod cannot offer: a staged clone, an atomic swap, and a
     // rollback that restores the previous tree. Unrefused, it stages a clone at a daemon-absolute

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -42,6 +42,8 @@ let cleared: string[] = []
 /** Answers the `rev-parse --git-dir` probe; false ⇒ the pod holds no usable checkout. */
 let checkoutExists = false
 let cloneFails = false
+/** What the pod's checkout reports as its origin — a resumed volume carries the previous launch's. */
+let originUrl = 'https://github.com/acme/private.git'
 
 function recordingRunner(cwd: string | undefined, env: Record<string, string> = {}): GitRunner {
   const run = async (args: string[]): Promise<string> => {
@@ -50,6 +52,7 @@ function recordingRunner(cwd: string | undefined, env: Record<string, string> = 
       if (!checkoutExists) throw new Error('cwd does not resolve: no checkout in the pod')
       return '.git'
     }
+    if (args[0] === 'remote' && args[1] === 'get-url') return originUrl
     return ''
   }
   const runner: GitRunner = {
@@ -101,6 +104,7 @@ beforeEach(() => {
   cleared = []
   checkoutExists = false
   cloneFails = false
+  originUrl = 'https://github.com/acme/private.git'
   // Every agent here runs in a pod, so both seams resolve to the sandbox.
   setWorkspaceGitRunnerResolver((_agentId, cwd) => recordingRunner(cwd))
   setWorkspacePathClearer(async (_agentId, root) => {
@@ -192,6 +196,29 @@ describe('preparing a cluster git-repo workspace', () => {
     expect(pull!.env).toMatchObject({ AC_GITCRED_AGENT: 'agent-cluster' })
     // And the audit ran against the POD's config, not a directory on this disk.
     expect(calls.some((call) => call.cwd === CHECKOUT && call.args.includes('--includes'))).toBe(true)
+  })
+
+  it('follows a repository rename on a resumed volume, in the pod', async () => {
+    // The CP tracks a repository by numeric id, so a rename shows up as a new canonical URL. A
+    // resumed volume still points at the old one, and repointing it is what keeps that from being
+    // treated as a different workspace.
+    checkoutExists = true
+    originUrl = 'https://github.com/acme/old-name.git'
+    await prepareClusterWorkspace(clusterAgent(), POD_ROOT)
+    const setUrl = calls.find((call) => call.args[0] === 'remote' && call.args[1] === 'set-url')
+    expect(setUrl).toMatchObject({
+      cwd: CHECKOUT,
+      args: ['remote', 'set-url', 'origin', 'https://github.com/acme/private.git']
+    })
+  })
+
+  it('refuses a checkout on the volume whose origin is not a trusted GitHub remote', async () => {
+    // Fail-closed, exactly as the local path is: a volume that survived from somewhere else must not
+    // have daemon-managed git run against whatever origin it carries.
+    checkoutExists = true
+    originUrl = 'https://evil.example/acme/private.git'
+    await expect(prepareClusterWorkspace(clusterAgent(), POD_ROOT)).rejects.toThrow(/not a trusted GitHub remote/)
+    expect(calls.some((call) => call.args[0] === 'pull')).toBe(false)
   })
 
   it('empties a partial checkout in the pod when a clone fails, then reports the failure', async () => {

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { existsSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
 import {
   clusterWorkspaceCwd,
   prepareClusterWorkspace,
+  prepareWorkspaceForActivation,
+  setSandboxWorkspaceMode,
   setWorkspaceGitRunnerResolver,
   setWorkspacePathClearer
 } from '../src/workspace/workspace-manager.js'
@@ -111,6 +115,7 @@ beforeEach(() => {
     cleared.push(root)
     return undefined
   })
+  setSandboxWorkspaceMode(true)
   initGitInjection({
     targetFor: (agentId) =>
       agentId.startsWith('local-')
@@ -124,6 +129,7 @@ beforeEach(() => {
 afterEach(() => {
   setWorkspaceGitRunnerResolver(undefined)
   setWorkspacePathClearer(undefined)
+  setSandboxWorkspaceMode(false)
 })
 
 describe('clusterWorkspaceCwd', () => {
@@ -238,5 +244,34 @@ describe('preparing a cluster git-repo workspace', () => {
   it('falls back to the historical mount when a legacy shim reported none', async () => {
     const cwd = await prepareClusterWorkspace(clusterAgent(), undefined)
     expect(cwd).toBe(CHECKOUT)
+  })
+})
+
+describe('replacing a cluster workspace in place', () => {
+  it('refuses a git-repo conversion or repair, instead of staging a clone at a daemon path', async () => {
+    // `prepareWorkspaceForActivation` is reached by every workspace edit and by staged/reconnect
+    // repair, and it bypasses the preparation above entirely. Its contract is local-filesystem —
+    // a staged clone beside the target, `renameSync` to swap, `readdirSync` to prove the destination
+    // is still empty at the boundary, and a rollback that restores the previous tree — and the shim
+    // can write and clear, not rename, list or stat. Unrefused, it stages a clone at a
+    // daemon-absolute path, which the target fence rejects with an error about containment that says
+    // nothing about what was attempted.
+    await expect(prepareWorkspaceForActivation(clusterAgent())).rejects.toThrow(
+      /cannot be converted or repaired in place with --k8s yet/
+    )
+    // Nothing was staged on either filesystem before the refusal.
+    expect(calls).toEqual([])
+    expect(cleared).toEqual([])
+  })
+
+  it('leaves a from-scratch cluster workspace alone, whose activation touches only bookkeeping', async () => {
+    // It creates and empties the daemon-side directory that IS the bookkeeping identity; the pod's
+    // volume is not involved, so refusing here would break the mode that already works. A real path,
+    // because this one legitimately does touch this disk.
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-cluster-scratch-')), 'workspace')
+    await expect(prepareWorkspaceForActivation(clusterAgent({ mode: 'from-scratch', path }))).resolves.toBeTypeOf(
+      'function'
+    )
+    rmSync(dirname(path), { recursive: true, force: true })
   })
 })

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -248,20 +248,51 @@ describe('preparing a cluster git-repo workspace', () => {
 })
 
 describe('replacing a cluster workspace in place', () => {
-  it('refuses a git-repo conversion or repair, instead of staging a clone at a daemon path', async () => {
-    // `prepareWorkspaceForActivation` is reached by every workspace edit and by staged/reconnect
-    // repair, and it bypasses the preparation above entirely. Its contract is local-filesystem —
-    // a staged clone beside the target, `renameSync` to swap, `readdirSync` to prove the destination
-    // is still empty at the boundary, and a rollback that restores the previous tree — and the shim
-    // can write and clear, not rename, list or stat. Unrefused, it stages a clone at a
-    // daemon-absolute path, which the target fence rejects with an error about containment that says
-    // nothing about what was attempted.
-    await expect(prepareWorkspaceForActivation(clusterAgent())).rejects.toThrow(
-      /cannot be converted or repaired in place with --k8s yet/
+  /** Activation reads and writes its materialization marker beside the daemon-side bookkeeping
+   *  path, so these need a real one — it is the only local state this function keeps. */
+  function bookkeepingAgent(overrides: Partial<Agent['workspace']> = {}): Agent {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-cluster-act-')), 'workspace')
+    return clusterAgent({ path, ...overrides })
+  }
+
+  it('is a no-op for a first activation, leaving the clone to session preparation', async () => {
+    // No marker means nothing to replace: the volume either has no checkout, which preparation
+    // clones, or has one that convergence fixes. Refusing here would make a git-repo cluster agent
+    // impossible to create at all, since `replace` is true whenever there is no previous marker.
+    const agent = bookkeepingAgent()
+    await expect(prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })).resolves.toBeTypeOf(
+      'function'
     )
-    // Nothing was staged on either filesystem before the refusal.
+    // And it staged nothing on either filesystem.
     expect(calls).toEqual([])
-    expect(cleared).toEqual([])
+    expect(existsSync(`${agent.workspace.path}.clone-`)).toBe(false)
+  })
+
+  it('lets a rollback and a same-workspace repair through, which a blanket refusal stranded', async () => {
+    // The sequence that matters: a rejected git→git edit restores the original row and re-activates
+    // it with `reconcileWorkspace`. When that restoration was refused too, the agent stayed staged
+    // and offline — the failure the refusal was supposed to prevent, made permanent.
+    const agent = bookkeepingAgent()
+    await prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
+    // Same workspace, marker already recorded: repair and restoration both look like this.
+    await expect(prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })).resolves.toBeTypeOf(
+      'function'
+    )
+    await expect(prepareWorkspaceForActivation(agent)).resolves.toBeTypeOf('function')
+  })
+
+  it('refuses only a conversion of an EXISTING checkout, which has no rollback in a pod', async () => {
+    // The one case that needs the contract a pod cannot offer: a staged clone, an atomic swap, and a
+    // rollback that restores the previous tree. Unrefused, it stages a clone at a daemon-absolute
+    // path, which the shim's target fence rejects with an error about containment that says nothing
+    // about what was attempted.
+    const agent = bookkeepingAgent()
+    await prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
+    const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
+    await expect(prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })).rejects.toThrow(
+      /cannot be converted in place with --k8s yet/
+    )
+    expect(calls).toEqual([])
   })
 
   it('leaves a from-scratch cluster workspace alone, whose activation touches only bookkeeping', async () => {

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync } from 'node:fs'
+import {
+  clusterWorkspaceCwd,
+  prepareClusterWorkspace,
+  setWorkspaceGitRunnerResolver,
+  setWorkspacePathClearer
+} from '../src/workspace/workspace-manager.js'
+import {
+  daemonGitCredentialTarget,
+  initGitInjection,
+  sandboxGitCredentialTarget
+} from '../src/workspace/git-injection.js'
+import { SANDBOX_CHECKOUT_DIR } from '../src/shim/sandbox-paths.js'
+import type { GitRunner } from '../src/workspace/git-runner.js'
+import type { Agent } from '../src/agents/agent-schema.js'
+
+/**
+ * Preparing a git-repo workspace for a CLUSTER agent, which `--k8s` refused outright until now.
+ *
+ * Every assertion here is about coordinates. The checkout lives on the pod's volume, so the
+ * questions the local path answers with `existsSync` and `mkdirSync` have to be asked of the POD
+ * instead — and the failure mode when they are not is silent: the daemon inspects its own empty
+ * directory, concludes there is no checkout, and clones on every session while the runtime sees a
+ * workspace nobody prepared.
+ *
+ * The runner is a recording stand-in for the shim's exec channel, because what is under test is
+ * WHICH git the daemon asks for and where, not git itself.
+ */
+
+const POD_ROOT = '/agent'
+const CHECKOUT = `${POD_ROOT}/${SANDBOX_CHECKOUT_DIR}`
+
+interface Invocation {
+  cwd: string | undefined
+  args: string[]
+  env: Record<string, string>
+}
+
+let calls: Invocation[] = []
+let cleared: string[] = []
+/** Answers the `rev-parse --git-dir` probe; false ⇒ the pod holds no usable checkout. */
+let checkoutExists = false
+let cloneFails = false
+
+function recordingRunner(cwd: string | undefined, env: Record<string, string> = {}): GitRunner {
+  const run = async (args: string[]): Promise<string> => {
+    calls.push({ cwd, args, env })
+    if (args[0] === 'rev-parse' && args[1] === '--git-dir') {
+      if (!checkoutExists) throw new Error('cwd does not resolve: no checkout in the pod')
+      return '.git'
+    }
+    return ''
+  }
+  const runner: GitRunner = {
+    withEnv: (next) => recordingRunner(cwd, next),
+    raw: run,
+    clone: async (repo, target, options = []) => {
+      calls.push({ cwd, args: ['clone', repo, target, ...options], env })
+      if (cloneFails) throw new Error('remote hung up')
+    },
+    pull: async (remote, branch, options = []) => {
+      calls.push({ cwd, args: ['pull', remote, branch, ...options], env })
+      return { files: [], insertions: 0, deletions: 0 }
+    },
+    status: async () => ({ current: 'main', tracking: null, ahead: 0, behind: 0, files: [], clean: true }),
+    log: async () => [],
+    readBounded: async () => ({ out: Buffer.alloc(0), overflow: false })
+  }
+  return runner
+}
+
+function clusterAgent(overrides: Partial<Agent['workspace']> = {}, id = 'agent-cluster'): Agent {
+  return {
+    id,
+    name: id,
+    runtime: 'claude-acp',
+    dir: `/daemon/agents/${id}`,
+    mcpServers: [],
+    managedSkills: [],
+    workspace: {
+      mode: 'git-repo',
+      // The DAEMON's bookkeeping path, which must never be used as a pod coordinate.
+      path: `/daemon/agents/${id}/workspace`,
+      gitRepo: 'https://github.com/acme/private.git',
+      gitBranch: 'main',
+      gitCredential: 'github-app',
+      pullOnNewSession: true,
+      skills: [],
+      ...overrides
+    },
+    integrations: [],
+    output: { mode: 'medium' },
+    permissions: { policy: 'ask', autoApprove: [] },
+    crons: []
+  } as unknown as Agent
+}
+
+beforeEach(() => {
+  calls = []
+  cleared = []
+  checkoutExists = false
+  cloneFails = false
+  // Every agent here runs in a pod, so both seams resolve to the sandbox.
+  setWorkspaceGitRunnerResolver((_agentId, cwd) => recordingRunner(cwd))
+  setWorkspacePathClearer(async (_agentId, root) => {
+    cleared.push(root)
+    return undefined
+  })
+  initGitInjection({
+    targetFor: (agentId) =>
+      agentId.startsWith('local-')
+        ? daemonGitCredentialTarget({ shimPath: '/daemon/run/helper.sh', runDir: '/daemon/run' })
+        : sandboxGitCredentialTarget(),
+    preWarm: async () => undefined,
+    capabilityFor: (agentId) => `cap-${agentId}`
+  })
+})
+
+afterEach(() => {
+  setWorkspaceGitRunnerResolver(undefined)
+  setWorkspacePathClearer(undefined)
+})
+
+describe('clusterWorkspaceCwd', () => {
+  it('puts a checkout one level below the mount, away from the runtime HOME', () => {
+    // The mount is also HOME=/agent: a working tree at the root would sit on top of `.claude` and
+    // `.codex`, where git reports them as untracked and `git clean` would delete them.
+    expect(clusterWorkspaceCwd(clusterAgent(), POD_ROOT)).toBe(CHECKOUT)
+    // A from-scratch workspace keeps the root — it has no tree to confuse with HOME, and moving it
+    // would strand every volume already provisioned.
+    expect(clusterWorkspaceCwd(clusterAgent({ mode: 'from-scratch' }), POD_ROOT)).toBe(POD_ROOT)
+  })
+
+  it('applies the configured working subdirectory inside the pod', () => {
+    expect(clusterWorkspaceCwd(clusterAgent({ agentDir: 'services/api' }), POD_ROOT)).toBe(`${CHECKOUT}/services/api`)
+  })
+
+  it('still refuses session isolation rather than half-supporting it', () => {
+    // A logical-session worktree needs a daemon-owned parent, `worktree add` in the sandbox, and a
+    // retention GC that reads the pod's tree — none of which this change provides.
+    expect(() => clusterWorkspaceCwd(clusterAgent(), POD_ROOT, { isolation: 'session' })).toThrow(
+      /session-isolated workspaces are not supported/
+    )
+  })
+})
+
+describe('preparing a cluster git-repo workspace', () => {
+  it('asks the POD whether a checkout exists, and clones inside its fence when it does not', async () => {
+    const cwd = await prepareClusterWorkspace(clusterAgent(), POD_ROOT)
+    expect(cwd).toBe(CHECKOUT)
+
+    // The existence question went to the pod as git, not to this daemon as a file test.
+    expect(calls[0]).toMatchObject({ cwd: CHECKOUT, args: ['rev-parse', '--git-dir'] })
+
+    // And the clone target is RELATIVE to a cwd the shim fences: an absolute target would be argv
+    // the fence never inspects, so it could land anywhere on the volume.
+    const clone = calls.find((call) => call.args[0] === 'clone')
+    expect(clone).toMatchObject({
+      cwd: POD_ROOT,
+      args: [
+        'clone',
+        'https://github.com/acme/private.git',
+        SANDBOX_CHECKOUT_DIR,
+        '--branch',
+        'main',
+        '--single-branch'
+      ]
+    })
+    // Nothing was created on the daemon's own disk — the whole point of the split.
+    expect(existsSync(POD_ROOT)).toBe(false)
+  })
+
+  it('pins the repo-local helper in the pod after cloning', async () => {
+    await prepareClusterWorkspace(clusterAgent(), POD_ROOT)
+    // `.git/config` outlives the launch, so the helper a later agent-run git finds has to be the
+    // image's path — written through the runner, in the checkout.
+    const helper = calls.filter((call) => call.args[0] === 'config' && call.args.includes('--add'))
+    expect(helper).toHaveLength(1)
+    expect(helper[0]).toMatchObject({ cwd: CHECKOUT })
+    expect(helper[0]!.args.at(-1)).toContain('/opt/agentconnect/bin/git-credential')
+  })
+
+  it('pulls an existing checkout instead of cloning over it', async () => {
+    checkoutExists = true
+    await prepareClusterWorkspace(clusterAgent(), POD_ROOT)
+
+    expect(calls.some((call) => call.args[0] === 'clone')).toBe(false)
+    const pull = calls.find((call) => call.args[0] === 'pull')
+    expect(pull).toMatchObject({ cwd: CHECKOUT })
+    // The pull carries the credential pair, or a private repo's fetch has nothing to authenticate with.
+    expect(pull!.env).toMatchObject({ AC_GITCRED_AGENT: 'agent-cluster' })
+    // And the audit ran against the POD's config, not a directory on this disk.
+    expect(calls.some((call) => call.cwd === CHECKOUT && call.args.includes('--includes'))).toBe(true)
+  })
+
+  it('empties a partial checkout in the pod when a clone fails, then reports the failure', async () => {
+    // Left behind, git would refuse to clone into a non-empty directory forever after, while the
+    // probe kept saying there is no usable checkout. There is no `rmSync` that can reach it.
+    cloneFails = true
+    await expect(prepareClusterWorkspace(clusterAgent(), POD_ROOT)).rejects.toThrow(/remote hung up/)
+    expect(cleared).toEqual([CHECKOUT])
+  })
+
+  it('does no git at all for a from-scratch cluster workspace', async () => {
+    const cwd = await prepareClusterWorkspace(clusterAgent({ mode: 'from-scratch' }), POD_ROOT)
+    expect(cwd).toBe(POD_ROOT)
+    expect(calls).toEqual([])
+  })
+
+  it('falls back to the historical mount when a legacy shim reported none', async () => {
+    const cwd = await prepareClusterWorkspace(clusterAgent(), undefined)
+    expect(cwd).toBe(CHECKOUT)
+  })
+})

--- a/packages/daemon/test/shim-exec-handler.test.ts
+++ b/packages/daemon/test/shim-exec-handler.test.ts
@@ -118,6 +118,37 @@ describe('sandbox exec handler', () => {
     expect(inside.code).toBe(0)
   })
 
+  it('refuses a clone TARGET outside the workspace root, which the cwd fence never sees', async () => {
+    // A clone writes to a path in argv. The daemon sends a relative target precisely so the fenced
+    // cwd contains it, but this side holds the filesystem, so it re-checks rather than trusting that.
+    const root = repository()
+    const outside = mkdtempSync(join(tmpdir(), 'ac-clone-outside-'))
+    roots.push(outside)
+    await expect(
+      handler(root)('exec', {
+        tool: 'git',
+        args: ['clone', 'https://github.com/acme/repo.git', join(outside, 'stolen')],
+        cwd: root
+      })
+    ).rejects.toBeInstanceOf(ExecRefusedError)
+    await expect(
+      handler(root)('exec', {
+        tool: 'git',
+        args: ['clone', 'https://github.com/acme/repo.git', join(root, '..', 'escaped')],
+        cwd: root
+      })
+    ).rejects.toBeInstanceOf(ExecRefusedError)
+    // An absolute target INSIDE the root is allowed: the check is containment, not a ban on
+    // absolute paths — and it must not refuse the URL argument either.
+    await expect(
+      handler(root)('exec', {
+        tool: 'git',
+        args: ['clone', 'https://github.com/acme/repo.git', join(root, 'nested')],
+        cwd: root
+      })
+    ).resolves.toMatchObject({ code: expect.any(Number) })
+  })
+
   it('applies the request env as given rather than merging the sandbox environment', async () => {
     // Verified through `config`, which IS in the inventory. An earlier version of this test used
     // `commit` — and the guard refused it, correctly: the daemon never commits, so `commit` is

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -943,9 +943,12 @@ describe('clusterWorkspaceCwd (--k8s pod coordinates)', () => {
     expect(clusterWorkspaceCwd(agent, undefined)).toBe('/agent')
   })
 
-  it('refuses a git-repo workspace loudly instead of half-working across two filesystems', () => {
+  it('checks a git-repo workspace out below the mount, never at the daemon-disk path', () => {
+    // The mount is also the runtime's HOME, so a working tree at the root would sit on top of its
+    // `.claude`/`.codex` state. What must never appear is the daemon's own workspace path.
     const agent = gitRepoAgent('/var/lib/agentconnect/agents/bot-git/workspace')
-    expect(() => clusterWorkspaceCwd(agent, '/agent')).toThrow(/git-repo workspaces are not supported with --k8s/)
+    expect(clusterWorkspaceCwd(agent, '/agent')).toBe('/agent/repo')
+    expect(clusterWorkspaceCwd(agent, '/agent')).not.toContain('/var/lib/agentconnect')
   })
 
   it('refuses session isolation, whose worktrees still assume the daemon filesystem', () => {


### PR DESCRIPTION
> Fourth of four PRs closing the private-repo gap under `--k8s`. #855 and #858 (which absorbed #857) are merged; this is the one that turns the chain on.

## Why

`clusterWorkspaceCwd` refused git-repo workspaces outright:

```ts
throw new Error(`git-repo workspaces are not supported with --k8s yet (agent "${agent.id}")`)
```

That refusal — not credentials — is what made a private repository unreachable in cluster mode. #853 put it there deliberately, because the clone/pull/audit flow still mixed daemon and pod coordinates and a clear error beats a mystery one from git inside a sandbox. With the socket reachable (#855) and the helper in the image (#857), lifting it is what remains.

## Why a separate function, not a branch

`prepareClusterWorkspace` sits beside `prepareWorkspace` rather than inside it. The two differ at **every step that touches a filesystem** — `existsSync`, `mkdirSync`, `rmSync` — so sharing the body would mean a conditional at each, in the function every self-hosted daemon runs. That path is the one that must not acquire new ways to be wrong.

Four coordinate decisions, each with a silent failure mode if taken the other way:

- **Existence is asked of the POD**, as `rev-parse --git-dir` through the runner. A file test answers about the daemon's own empty directory, and the consequence is not an error: the daemon concludes there is no checkout and clones on every session, while the runtime sees a workspace nobody prepared. `rev-parse` also answers the *useful* question — a half-written clone has a `.git` and fails it.
- **The clone target is RELATIVE to a fenced cwd.** The shim validates the `cwd` it is handed and refuses one outside its workspace root, so a relative target cannot land anywhere else. An absolute target is argv the fence never looks at.
- **A failed clone is emptied through the materialize channel.** There is no `rmSync` that reaches a pod. Left behind, a partial checkout makes git refuse to clone into a non-empty directory forever, while the probe keeps reporting no checkout — a permanent, self-inflicted failure. This is also the first production caller of `ShimFileSink`, which existed and was tested but wired to nothing.
- **The checkout goes one level below the mount** (`/agent/repo`). The mount is also the runtime's `HOME`, so a working tree at the root would sit on top of `.claude`, `.codex` and `.config`, where `git status` reports them as untracked and `git clean` would delete them. from-scratch keeps the root: it has no tree to confuse with HOME, and moving it would strand every volume already provisioned.

## Shim-side re-check for clone targets

The exec handler already fences `cwd`; a clone also writes to a path in **argv**, which that fence never inspects. Now checked on the shim side too, in the file's own stated tradition ("a check that only runs on the far side of a channel protects nothing on this side"). The relative target makes it moot in practice, which is exactly when it is cheap to enforce.

## What this deliberately does NOT do

Both now stated where an operator will look (`deploy/k8s/README.md`, in the docs PR that follows):

- **Skills are not installed for a cluster agent.** Acquisition, the ledger and stale-executable removal are all local-filesystem work; pointing them at a pod path would write them onto the daemon's own disk. Its own migration.
- **Session isolation stays refused.** Its worktrees need a daemon-owned parent beside the checkout, `worktree add` in the sandbox, and a retention GC that reads the pod's tree.

## Tests

`test/cluster-workspace-prepare.test.ts` — 9 cases against a recording stand-in for the shim's exec channel, because what is under test is *which* git the daemon asks for and *where*, not git itself:

- the first call is the pod-side `rev-parse` probe, and the clone is `cwd=/agent` + target `repo` (relative)
- `existsSync('/agent')` is **false** afterwards — nothing was created on the daemon's disk
- an existing checkout pulls instead of cloning, with the credential pair in the env and the config audit run against the pod's checkout
- a failed clone empties `/agent/repo` through the clearer and re-raises
- from-scratch issues no git at all; a legacy shim that reported no mount still resolves
- the checkout path, the working subdirectory applied inside the pod, and the surviving session-isolation refusal

`shim-exec-handler.test.ts` gains the clone-target fence: outside the root and `..`-escaping are refused, an absolute target inside it is allowed, and the URL argument is not mistaken for a path.

The `workspace.test.ts` case that pinned the refusal now pins the new behaviour, including that the result never contains the daemon's own workspace path.

Full daemon suite: 3292 passed, 1 failed — `evaluation-runner › records a raw ACP baseline`, which fails on a clean tree.

## Not verified against a real cluster

Worth stating plainly: I have no cluster here, so everything above is exercised in-process. What that cannot cover is the volume's real behaviour on a resumed sandbox and whether `/agent/repo` survives a warm-pool adoption as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
