### PR TITLE
fix(daemon): keep GitHub reviews current

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -770,6 +770,23 @@ then updated through queued, in-progress, and terminal states; the previous run 
 historical. A request that supersedes an incomplete generation keeps that active Check
 instead of leaving it permanently unfinished.
 
+Automatic PR revision reviews are latest-wins while active or queued. When a newer
+`pull_request:synchronize` delivery for the same Agent, integration, repository, and pull
+request is durably admitted, the daemon cancels the older active review, suppresses all of
+its remaining output, and removes intermediate queued heads. Relay ingest time determines
+recency even if asynchronous authorization reorders delivery; the delivery key breaks
+same-timestamp ties deterministically. Explicit comments, review requests, and Check reruns
+remain ordered work and are never discarded by revision supersession.
+The trusted pull-request lane spans per-delivery anchor session keys but remains isolated by
+the configured output platform, channel, and integration.
+
+GitHub emits every root inline comment in one submitted PR review as a separate webhook.
+The daemon groups those roots by the trusted review id during a bounded quiet window, runs
+one model turn over the shared review context, and requires one independently authored reply
+for every trusted thread root. A later reply inside any one thread remains a separate turn.
+The open batch can span per-delivery anchor session keys; it, its individual publish fences,
+and revision ordering survive daemon restarts.
+
 ## GitHub maintainer trigger authorization
 
 GitHub Issue and pull-request integrations treat current repository permission—not the

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -76,7 +76,9 @@ import type {
   StartOrchestrationResult,
   OrchestrationOwnerReq,
   SetSessionTitleReq,
-  SubmitGithubReviewReq
+  SubmitGithubReviewReq,
+  ReplyGithubReviewThreadsReq,
+  ReplyGithubReviewThreadsResult
 } from './mcp/ops.js'
 import { GitCredentialCache } from './cp/git-credential.js'
 import {
@@ -1077,7 +1079,7 @@ interface CallMeta {
   parentPrivate?: boolean
 }
 
-type TurnInterruptReason = 'pause' | 'loop protection' | 'stop' | 'cancel' | 'shutdown'
+type TurnInterruptReason = 'pause' | 'loop protection' | 'stop' | 'cancel' | 'shutdown' | 'superseded'
 
 /** One durable loop-guard scope shared by every agent on one physical bot.
  *  DMs are keyed at channel level because malformed platform wrappers may lose
@@ -1125,9 +1127,24 @@ interface GithubReplyTarget {
   reviewThreadRootCommentId?: string
 }
 
-/** Durable, daemon-private identity for one accepted hook delivery. Unlike the
- * model-visible NormalizedMessage, this contains only relay-verified metadata
- * and the exact CP-compiled dispatch fence. */
+interface GithubReviewBatchItem {
+  deliveryKey: string
+  firedAt: string
+  text: string
+  reply: GithubReplyTarget & { reviewThreadRootCommentId: string }
+  publishState?: 'not_started' | 'in_flight' | 'settled'
+  publishedComment?: GithubPublishedComment
+}
+
+interface GithubReviewBatch {
+  reviewId: string
+  openedAt: number
+  updatedAt: number
+  sealed?: boolean
+  items: GithubReviewBatchItem[]
+}
+
+/** Durable daemon-private hook identity; coalesced prompt excerpts stay local and HookReport omits them. */
 interface HookDispatchContext {
   hookId: string
   agentId: string
@@ -1137,6 +1154,7 @@ interface HookDispatchContext {
   snapshot?: HookConfigSnapshot
   github?: GithubHookMetadata
   githubReply?: GithubReplyTarget
+  githubReviewBatch?: GithubReviewBatch
   turnStartedAt?: string
   reviewAttemptId?: string
   reviewRequestedEvent?: GithubReviewEvent
@@ -1161,6 +1179,99 @@ const GITHUB_DELETED_HOOK_EVENTS = new Set([
 
 function githubDeletedHookEvent(hook: Pick<HookDispatchContext, 'event'> | undefined): boolean {
   return hook?.event !== undefined && GITHUB_DELETED_HOOK_EVENTS.has(hook.event)
+}
+
+interface GithubHookCoordinates {
+  agentId: string
+  platform: string
+  channel: string
+  integrationId?: string
+}
+
+type GithubCoordinatedHook = Pick<HookDispatchContext, 'hookId' | 'agentId' | 'event' | 'github'>
+
+function githubHookCoordinates(
+  agentId: string,
+  msg: Pick<NormalizedMessage, 'platform' | 'channel'>,
+  integrationId?: string
+): GithubHookCoordinates {
+  return {
+    agentId,
+    platform: msg.platform,
+    channel: msg.channel,
+    ...(integrationId !== undefined ? { integrationId } : {})
+  }
+}
+
+function githubPullRequestLane(
+  hook: GithubCoordinatedHook | undefined,
+  coords: GithubHookCoordinates
+): string | undefined {
+  const github = hook?.github
+  if (hook?.agentId !== coords.agentId || github?.subjectKind !== 'pull_request' || github.pullNumber === undefined)
+    return undefined
+  return JSON.stringify([
+    hook.hookId,
+    hook.agentId,
+    github.repoId,
+    github.pullNumber,
+    coords.platform,
+    coords.channel,
+    coords.integrationId ?? null
+  ])
+}
+
+function githubPullRevisionStream(
+  hook: GithubCoordinatedHook | undefined,
+  coords: GithubHookCoordinates
+): string | undefined {
+  const lane = githubPullRequestLane(hook, coords)
+  if (!lane || hook?.event !== 'pull_request:synchronize' || !hook.github?.headSha) return undefined
+  return JSON.stringify(['revision', lane])
+}
+
+function githubReviewBatchStream(
+  hook: GithubCoordinatedHook | undefined,
+  coords: GithubHookCoordinates
+): string | undefined {
+  const github = hook?.github
+  const lane = githubPullRequestLane(hook, coords)
+  if (
+    !github ||
+    !lane ||
+    hook?.event !== 'pull_request_review_comment:created' ||
+    github.pullRequestReviewId === undefined ||
+    github.reviewCommentId === undefined ||
+    github.reviewThreadRootCommentId === undefined ||
+    github.reviewCommentId !== github.reviewThreadRootCommentId
+  ) {
+    return undefined
+  }
+  return JSON.stringify(['review', lane, github.pullRequestReviewId])
+}
+
+function renderGithubReviewBatchPrompt(batch: GithubReviewBatch): string {
+  const items = [...batch.items].sort(
+    (a, b) => a.firedAt.localeCompare(b.firedAt) || a.deliveryKey.localeCompare(b.deliveryKey)
+  )
+  return [
+    `GitHub submitted-review inline comment batch (review ${batch.reviewId})`,
+    `Authorized thread roots: ${items.map((item) => item.reply.reviewThreadRootCommentId).join(', ')}`,
+    '',
+    ...items.flatMap((item, index) => [
+      `===== REVIEW THREAD ${index + 1} · ROOT ${item.reply.reviewThreadRootCommentId} =====`,
+      item.text,
+      `===== END REVIEW THREAD ${index + 1} =====`,
+      ''
+    ]),
+    'Inspect shared PR context once, then call `replyGithubReviewThreads` exactly once with one complete answer for every authorized root above. Do not omit, combine, or add roots. The tool owns all public replies; keep the final answer transcript-only.'
+  ].join('\n')
+}
+
+function compareGithubPullRevisionRecency(a: HookDispatchContext, b: HookDispatchContext): number {
+  if (a.firedAt !== b.firedAt) return a.firedAt < b.firedAt ? -1 : 1
+  if (a.deliveryKey === b.deliveryKey) return 0
+  return a.deliveryKey < b.deliveryKey ? -1 : 1
 }
 
 /** Relay-authored lifecycle events that remove the isolated checkout without
@@ -1247,6 +1358,16 @@ interface ActiveGithubTurnMeta {
   sessionId: string
   reviewState: 'idle' | 'submitting' | 'done'
 }
+
+interface ActiveGithubReplyBatchMeta {
+  entry: QueueEntry
+  sessionId: string
+  called: boolean
+}
+
+const GITHUB_REVIEW_BATCH_QUIET_MS = 5_000
+const GITHUB_REVIEW_BATCH_MAX_WAIT_MS = 30_000
+const GITHUB_REVIEW_BATCH_MAX_COMMENTS = 25
 
 /** Review-comment follow-ups already belong to one existing inline thread.
  * They may receive exactly one daemon-owned inline reply, but must never gain
@@ -1354,10 +1475,23 @@ interface QueueEntry {
    *  pause/loop state, this survives a quick pause→unpause or trip→!resume race while
    *  a cold sessions.handle() call is still initializing. */
   cancelledReason?: TurnInterruptReason
+  /** Cross-session GitHub coordination must settle before this durable entry can start. */
+  coordinationWait?: Promise<void>
   posterPublishState?: 'not_started' | 'in_flight' | 'settled'
   /** The live inbox row was redacted into a durable terminal HookReport
    * receipt; removeInbox must retain it for restart-safe redelivery dedup. */
   hookTerminalReceipt?: boolean
+}
+
+interface GithubQueueCandidate {
+  key: string
+  entry: QueueEntry
+  state: 'active' | 'queued' | 'incoming'
+}
+
+interface GithubRevisionAdmissionPlan {
+  winner: GithubQueueCandidate
+  superseded: GithubQueueCandidate[]
 }
 
 /** The narrow persistence ownership needed to terminalize a hook delivery.
@@ -2103,9 +2237,9 @@ export class Daemon {
   // Daemon-side cache of the bot-agnostic collaboration snapshot (agent-collaboration
   // §2.3/§6.2) — the terminal-verify source for forwarded REMOTE agent callers.
   private readonly cpCollab = new CpCollabRoutes()
-  /** One active PR hook turn per logical session key. Long-lived ACP sessions
-   * may span deliveries, so authorization must never live in SessionContext. */
+  /** Active GitHub effect authority is turn-local and keyed by logical session. */
   private readonly activeGithubTurnMeta = new Map<string, ActiveGithubTurnMeta>()
+  private readonly activeGithubReplyBatchMeta = new Map<string, ActiveGithubReplyBatchMeta>()
   private readonly githubReviewClient = new GithubReviewClient()
   // ── lifecycle (§2.5/§5.3/§7.2/§7.3) ──
   private clock: Clock
@@ -2133,6 +2267,8 @@ export class Daemon {
   private safetyDrainingAgents = new Set<string>()
   private safetyDrainWaits = new Map<string, Set<Promise<void>>>()
   private safetyDrainRuns = new Map<string, symbol>()
+  private safetyDrainAdmissionKeys = new Map<string, Set<string>>()
+  private safetyDrainGithubLanes = new Map<string, Set<string>>()
   // Cold-move staging is distinct from an ordinary agent/stop gate: staged
   // agents are excluded from the effective roster, so restoring an old archive
   // during bootstrap cannot reopen stale platform credentials before activate
@@ -3160,6 +3296,7 @@ export class Daemon {
       getOrchestration: (req) => Promise.resolve(this.getOrchestrationForOwner(req)),
       cancelOrchestration: (req) => Promise.resolve(this.cancelOrchestrationForOwner(req)),
       submitGithubReview: (req) => this.submitGithubReview(req),
+      replyGithubReviewThreads: (req) => this.replyGithubReviewThreads(req),
       memory: this.memory,
       // Every session may READ shared agent memory; only a non-isolated session
       // may WRITE it, so a private DM/A2A turn can use existing memory but cannot
@@ -9924,7 +10061,23 @@ export class Daemon {
       this.log.info(`hook: agent "${msg.agentId}" is paused — rejecting fire ${msg.msgId}`)
       return { msgId: msg.msgId, accepted: false, reason: 'paused' }
     }
-    if (!maintenance && this.safetyDrainingAgents.has(msg.agentId)) {
+    const normalized = buildHookMessage(msg, 'safety-drain-probe')
+    const normalizedKey = sessionKey(
+      normalized.platform,
+      normalized.channel,
+      normalized.thread ?? normalized.msgId,
+      msg.agentId,
+      normalized.transportScope
+    )
+    const githubLane = githubPullRequestLane(
+      msg,
+      githubHookCoordinates(msg.agentId, normalized, msg.target?.integrationId)
+    )
+    if (
+      !maintenance &&
+      this.safetyDrainingAgents.has(msg.agentId) &&
+      !this.safetyDrainAllows(msg.agentId, normalizedKey, githubLane)
+    ) {
       this.log.info(`hook: agent "${msg.agentId}" is stopping an interrupted turn — rejecting fire ${msg.msgId}`)
       return { msgId: msg.msgId, accepted: false, reason: 'busy' }
     }
@@ -10018,14 +10171,43 @@ export class Daemon {
         ? { hookId: msg.hookId, repo: c.repo, number: c.number }
         : undefined)
     if (githubReply) hookContext.githubReply = githubReply
+    const githubLane = githubPullRequestLane(
+      hookContext,
+      githubHookCoordinates(msg.agentId, nmsg, msg.target?.integrationId)
+    )
     const anchored = await this.anchorTrigger(
       msg.agentId,
       nmsg,
       msg.target,
       hookAnchorText(msg),
-      `hook "${msg.hookId}"`
+      `hook "${msg.hookId}"`,
+      githubLane
     )
     if (!anchored) return { accepted: false, reason: 'dropped' }
+    const batchReply =
+      githubReviewBatchStream(hookContext, githubHookCoordinates(msg.agentId, anchored, msg.target?.integrationId)) &&
+      githubReply &&
+      'reviewThreadRootCommentId' in githubReply &&
+      githubReply.reviewThreadRootCommentId
+        ? githubReply
+        : undefined
+    if (batchReply) {
+      const now = this.clock.now()
+      hookContext.githubReviewBatch = {
+        reviewId: hookContext.github!.pullRequestReviewId!,
+        openedAt: now,
+        updatedAt: now,
+        items: [
+          {
+            deliveryKey: hookContext.deliveryKey,
+            firedAt: hookContext.firedAt,
+            text: anchored.text,
+            reply: { ...batchReply, reviewThreadRootCommentId: batchReply.reviewThreadRootCommentId },
+            publishState: 'not_started'
+          }
+        ]
+      }
+    }
     let admission: { accepted: boolean; reason?: string; duplicate?: boolean } | undefined
     const turn = this.dispatch(
       msg.agentId,
@@ -10522,6 +10704,58 @@ export class Daemon {
       this.log.warn(`github review: immediate result report failed (${formatErr(err)})`)
     }
     return effect
+  }
+
+  private async replyGithubReviewThreads(req: ReplyGithubReviewThreadsReq): Promise<ReplyGithubReviewThreadsResult> {
+    const key = sessionKey(req.platform, req.channel, req.thread, req.agentId, req.transportScope)
+    const active = this.activeGithubReplyBatchMeta.get(key)
+    const batch = active?.entry.hookContext?.githubReviewBatch
+    if (!active || !batch?.sealed || batch.items.length < 2 || active.entry.agentId !== req.agentId) {
+      throw new Error('batched GitHub replies are only available during the active submitted-review comment turn')
+    }
+    if (active.called) throw new Error('this GitHub review-comment batch already used its reply tool')
+    const expected = new Set(batch.items.map((item) => item.reply.reviewThreadRootCommentId))
+    const supplied = new Map<string, string>()
+    for (const reply of req.replies) {
+      if (supplied.has(reply.threadRootCommentId)) {
+        throw new Error(`duplicate GitHub review thread root ${reply.threadRootCommentId}`)
+      }
+      supplied.set(reply.threadRootCommentId, reply.body)
+    }
+    if (supplied.size !== expected.size || [...supplied].some(([root]) => !expected.has(root))) {
+      throw new Error(`reply exactly once to every authorized GitHub review thread: ${[...expected].join(', ')}`)
+    }
+    active.called = true
+    const results: ReplyGithubReviewThreadsResult['replies'] = []
+    for (const item of batch.items) {
+      const root = item.reply.reviewThreadRootCommentId
+      if (item.publishState === 'in_flight') {
+        results.push({ threadRootCommentId: root, state: 'ambiguous' })
+        continue
+      }
+      if (item.publishState === 'settled') {
+        results.push({
+          threadRootCommentId: root,
+          state: 'settled',
+          ...(item.publishedComment ? { commentId: item.publishedComment.commentId } : {})
+        })
+        continue
+      }
+      item.publishState = 'in_flight'
+      this.persistHookState(active.entry, undefined, true)
+      const published = await this.makeGithubReply(req.agentId, item.reply, active.sessionId).poster.publish(
+        supplied.get(root)!
+      )
+      if (published) item.publishedComment = published
+      item.publishState = 'settled'
+      this.persistHookState(active.entry, undefined, true)
+      results.push({
+        threadRootCommentId: root,
+        state: published ? 'published' : 'settled',
+        ...(published ? { commentId: published.commentId } : {})
+      })
+    }
+    return { replies: results }
   }
 
   /** The op-switch behind {@link handleRelayMsg} (dedup handled by the caller). */
@@ -11035,6 +11269,217 @@ export class Daemon {
       this.log.info(`turn context: coalesced ${count} queued activation(s) into ${key}`)
     }
     return count
+  }
+
+  private githubQueueCandidates(): GithubQueueCandidate[] {
+    const candidates: GithubQueueCandidate[] = []
+    for (const [key, entry] of this.activeGateEntries) candidates.push({ key, entry, state: 'active' })
+    for (const [key, queue] of this.serialQueue) {
+      for (const entry of queue) candidates.push({ key, entry, state: 'queued' })
+    }
+    return candidates
+  }
+
+  /** Pick the newest relay-fired revision across every session key in one trusted GitHub lane. */
+  private githubRevisionAdmissionPlan(key: string, incoming: QueueEntry): GithubRevisionAdmissionPlan | undefined {
+    const stream = githubPullRevisionStream(
+      incoming.hookContext,
+      githubHookCoordinates(incoming.agentId, incoming.msg, incoming.integrationId)
+    )
+    if (!stream) return undefined
+    const revisions = [
+      ...this.githubQueueCandidates().filter(
+        (candidate) =>
+          !candidate.entry.cancelledReason &&
+          githubPullRevisionStream(
+            candidate.entry.hookContext,
+            githubHookCoordinates(candidate.entry.agentId, candidate.entry.msg, candidate.entry.integrationId)
+          ) === stream
+      ),
+      { key, entry: incoming, state: 'incoming' as const }
+    ]
+    const winner = revisions.reduce((latest, candidate) =>
+      compareGithubPullRevisionRecency(candidate.entry.hookContext!, latest.entry.hookContext!) > 0 ? candidate : latest
+    )
+    return {
+      winner,
+      superseded: revisions.filter((candidate) => candidate !== winner)
+    }
+  }
+
+  private removeQueuedGithubRevisions(candidates: readonly GithubQueueCandidate[]): void {
+    const removals = new Map<string, Set<QueueEntry>>()
+    for (const candidate of candidates) {
+      if (candidate.state !== 'queued') continue
+      const entries = removals.get(candidate.key) ?? new Set<QueueEntry>()
+      entries.add(candidate.entry)
+      removals.set(candidate.key, entries)
+    }
+    for (const [key, entries] of removals) {
+      const next = (this.serialQueue.get(key) ?? []).filter((entry) => !entries.has(entry))
+      if (next.length > 0) this.serialQueue.set(key, next)
+      else this.serialQueue.delete(key)
+    }
+  }
+
+  private settleSupersededGithubRevisions(entries: readonly QueueEntry[], successor: QueueEntry): void {
+    if (entries.length === 0) return
+    for (const entry of entries) {
+      this.terminateQueuedSink(entry)
+      if (entry.hookContext) this.emitHookCompletion(entry.hookContext, 'failed', { reason: 'superseded' }, entry)
+      this.removeInbox(entry)
+      entry.resolve(null)
+      this.emitEvaluation({
+        type: 'turn.cancelled',
+        agentId: entry.agentId,
+        turnId: this.evaluationTurnIdFor(entry.agentId, entry.msg),
+        platform: entry.msg.platform,
+        channel: entry.msg.channel,
+        data: { reason: 'superseded_by_newer_revision' }
+      })
+    }
+    defaultTurnOutputMetrics.queueCoalesced(successor.msg.platform, entries.length)
+    this.log.info(`github review: superseded ${entries.length} queued or incoming revision(s)`)
+  }
+
+  private extendGithubCoordinationWait(entry: QueueEntry, waits: readonly Promise<void>[]): void {
+    const pending = [...(entry.coordinationWait ? [entry.coordinationWait] : []), ...waits]
+    if (pending.length > 0) entry.coordinationWait = Promise.all(pending).then(() => undefined)
+  }
+
+  private applyGithubRevisionAdmissionPlan(plan: GithubRevisionAdmissionPlan, incoming: QueueEntry): boolean {
+    const activeLosers = plan.superseded.filter((candidate) => candidate.state === 'active')
+    const terminalLosers = plan.superseded.filter((candidate) => candidate.state !== 'active')
+    this.removeQueuedGithubRevisions(terminalLosers)
+    this.settleSupersededGithubRevisions(
+      terminalLosers.map((candidate) => candidate.entry),
+      plan.winner.entry
+    )
+    const waits: Promise<void>[] = []
+    const winnerLane = githubPullRequestLane(
+      plan.winner.entry.hookContext,
+      githubHookCoordinates(plan.winner.entry.agentId, plan.winner.entry.msg, plan.winner.entry.integrationId)
+    )
+    for (const candidate of activeLosers) {
+      if (candidate.entry.coordinationWait) waits.push(candidate.entry.coordinationWait)
+      const activeDone = this.activeDispatchDoneByKey.get(candidate.key)
+      if (activeDone) waits.push(activeDone)
+      if (candidate.entry.cancelledReason) continue
+      this.interruptTurn(candidate.entry.agentId, candidate.key, 'superseded', undefined, {
+        preserveQueued: true,
+        allowSameKeyAdmissions: true,
+        ...(winnerLane ? { allowGithubLane: winnerLane } : {})
+      })
+    }
+    if (this.safetyDrainingAgents.has(plan.winner.entry.agentId)) {
+      waits.push(this.waitForSafetyDrain(plan.winner.entry.agentId))
+    }
+    if (plan.winner.state !== 'active') this.extendGithubCoordinationWait(plan.winner.entry, waits)
+    return plan.winner.entry === incoming
+  }
+
+  private githubReviewBatchLeader(incoming: QueueEntry): QueueEntry | undefined {
+    const batchStream = githubReviewBatchStream(
+      incoming.hookContext,
+      githubHookCoordinates(incoming.agentId, incoming.msg, incoming.integrationId)
+    )
+    if (!batchStream) return undefined
+    return this.githubQueueCandidates()
+      .map((candidate) => candidate.entry)
+      .filter((candidate) => {
+        const batch = candidate.hookContext?.githubReviewBatch
+        return (
+          !candidate.cancelledReason &&
+          githubReviewBatchStream(
+            candidate.hookContext,
+            githubHookCoordinates(candidate.agentId, candidate.msg, candidate.integrationId)
+          ) === batchStream &&
+          batch !== undefined &&
+          !batch.sealed &&
+          batch.items.length < GITHUB_REVIEW_BATCH_MAX_COMMENTS
+        )
+      })
+      .sort((a, b) => compareGithubPullRevisionRecency(a.hookContext!, b.hookContext!))[0]
+  }
+
+  private coalesceGithubReviewBatch(leader: QueueEntry, follower: QueueEntry): boolean {
+    const leaderHook = leader.hookContext
+    const followerHook = follower.hookContext
+    const leaderBatch = leaderHook?.githubReviewBatch
+    const followerItem = followerHook?.githubReviewBatch?.items[0]
+    if (!leaderHook || !followerHook || !leaderBatch || !followerItem || !leader.inboxId || !follower.inboxId) {
+      return false
+    }
+    if (
+      leaderBatch.sealed ||
+      leaderBatch.items.length >= GITHUB_REVIEW_BATCH_MAX_COMMENTS ||
+      leaderBatch.items.some(
+        (item) => item.reply.reviewThreadRootCommentId === followerItem.reply.reviewThreadRootCommentId
+      )
+    ) {
+      return false
+    }
+    const nextHook: HookDispatchContext = {
+      ...leaderHook,
+      githubReviewBatch: {
+        ...leaderBatch,
+        updatedAt: this.clock.now(),
+        items: [...leaderBatch.items, followerItem]
+      }
+    }
+    const report = this.buildHookReport(followerHook, 'success', { reason: 'coalesced_review_batch' })
+    try {
+      const committed = this.store.coalesceHookInbox({
+        leaderId: leader.inboxId,
+        leaderMsg: JSON.stringify(leader.msg),
+        leaderHookContext: JSON.stringify(nextHook),
+        followerId: follower.inboxId,
+        followerTerminalReport: JSON.stringify(report),
+        completedAt: this.clock.now()
+      })
+      if (!committed) return false
+    } catch (err) {
+      this.log.warn(`github review batch: durable coalesce failed (${formatErr(err)})`)
+      return false
+    }
+    leader.hookContext = nextHook
+    follower.hookTerminalReceipt = true
+    this.liveInboxIds.delete(follower.inboxId)
+    this.sendHookReport(report, follower.inboxId)
+    defaultTurnOutputMetrics.queueCoalesced(follower.msg.platform, 1)
+    this.log.info(
+      `github review batch: coalesced thread ${followerItem.reply.reviewThreadRootCommentId} into review ${leaderBatch.reviewId}`
+    )
+    return true
+  }
+
+  private async settleGithubReviewBatch(entry: QueueEntry): Promise<void> {
+    while (true) {
+      const batch = entry.hookContext?.githubReviewBatch
+      if (!batch) return
+      if (batch.sealed) {
+        if (batch.items.length > 1) entry.githubReply = undefined
+        return
+      }
+      if (entry.cancelledReason) return
+      const deadline = Math.min(
+        batch.updatedAt + GITHUB_REVIEW_BATCH_QUIET_MS,
+        batch.openedAt + GITHUB_REVIEW_BATCH_MAX_WAIT_MS
+      )
+      const delay = deadline - this.clock.now()
+      if (delay > 0) {
+        await new Promise<void>((resolve) => this.clock.setTimeout(resolve, delay))
+        continue
+      }
+      const sealed: GithubReviewBatch = { ...batch, sealed: true }
+      entry.hookContext = { ...entry.hookContext!, githubReviewBatch: sealed }
+      if (sealed.items.length > 1) {
+        entry.msg = { ...entry.msg, text: renderGithubReviewBatchPrompt(sealed) }
+        entry.githubReply = undefined
+      }
+      this.persistHookPayload(entry, true)
+      return
+    }
   }
 
   /** Move only the accepted generation through the existing renderer. This call and
@@ -11858,16 +12303,32 @@ export class Daemon {
     }
   }
 
-  private emitHookCompletion(
+  private persistHookPayload(entry: QueueEntry, required = false): void {
+    if (!entry.inboxId || !entry.hookContext) {
+      if (required) throw new Error('hook payload has no durable inbox row')
+      return
+    }
+    try {
+      const updated = this.store.updateInboxHookPayload(
+        entry.inboxId,
+        JSON.stringify(entry.msg),
+        JSON.stringify(entry.hookContext)
+      )
+      if (!updated) throw new Error('durable inbox row is missing')
+    } catch (err) {
+      if (required) throw err
+      this.log.warn(`durable inbox: hook payload update failed for ${entry.inboxId}: ${(err as Error).message}`)
+    }
+  }
+
+  private buildHookReport(
     hook: HookDispatchContext,
     status: 'success' | 'failed',
-    extra: { sessionId?: string; reason?: string } = {},
-    owner?: HookCompletionOwner
-  ): void {
-    if (owner?.hookTerminalReceipt) return
+    extra: { sessionId?: string; reason?: string } = {}
+  ): HookReport {
     const start = Date.parse(hook.turnStartedAt ?? hook.firedAt)
     const review = githubReviewResultForCompletion(hook)
-    const report: HookReport = {
+    return {
       hookId: hook.hookId,
       agentId: hook.agentId,
       deliveryKey: hook.deliveryKey,
@@ -11880,6 +12341,16 @@ export class Daemon {
       ...(review ? { reviewAttemptId: review.attemptId, reviewResult: review.result } : {}),
       ...(hook.publishedComment ? { publishedComment: hook.publishedComment } : {})
     }
+  }
+
+  private emitHookCompletion(
+    hook: HookDispatchContext,
+    status: 'success' | 'failed',
+    extra: { sessionId?: string; reason?: string } = {},
+    owner?: HookCompletionOwner
+  ): void {
+    if (owner?.hookTerminalReceipt) return
+    const report = this.buildHookReport(hook, status, extra)
     let reportInboxId: string | undefined
     if (owner?.inboxId) {
       try {
@@ -12174,6 +12645,9 @@ export class Daemon {
       this.recordObservedInbound(msg, agentId)
     }
     return new Promise<string | null>((resolve, reject) => {
+      const key = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, agentId, msg.transportScope)
+      const githubLane = githubPullRequestLane(hookContext, githubHookCoordinates(agentId, msg, integrationId))
+      const safetyDrainByKey = this.safetyDrainAdmissionKeys.get(agentId)?.has(key) === true
       let admissionSettled = false
       const settleAdmission = (result: { accepted: boolean; reason?: string; duplicate?: boolean }): void => {
         if (admissionSettled) return
@@ -12231,7 +12705,7 @@ export class Daemon {
       // selected old dispatches fully unwind. Live platform arrivals are intentionally
       // dropped; a DURABLE startup replay cannot be lost/dormant, so retry that same row
       // after the transient drain closes (its inbox id has not been adopted yet).
-      if (this.safetyDrainingAgents.has(agentId)) {
+      if (this.safetyDrainingAgents.has(agentId) && !this.safetyDrainAllows(agentId, key, githubLane)) {
         if (opts?.fromInboxReplay) {
           void this.waitForSafetyDrain(agentId)
             .then(() => {
@@ -12266,7 +12740,6 @@ export class Daemon {
         }
         return
       }
-      const key = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, agentId, msg.transportScope)
       const loopScope = loopGuardScope(msg)
       // A latched circuit is checked at the common dispatch seam, so startup replay,
       // cron/hook turns, webchat, and agent→agent calls cannot bypass it. Purging here
@@ -12316,15 +12789,25 @@ export class Daemon {
         ...(opts?.isQueueCmd ? { isQueueCmd: true } : {}),
         ...(githubReply ? { githubReply } : {}),
         ...(posterPublishState ? { posterPublishState } : {}),
+        ...(this.safetyDrainingAgents.has(agentId) && !safetyDrainByKey
+          ? { coordinationWait: this.waitForSafetyDrain(agentId) }
+          : {}),
         resolve,
         reject
       }
+      const batchLeader = this.githubReviewBatchLeader(entry)
+      const revisionPlan = this.githubRevisionAdmissionPlan(key, entry)
       // ── atomic claim-or-enqueue (single synchronous tick, no await before add) ──
       if (this.inflight.has(key)) {
         const q = this.serialQueue.get(key) ?? []
+        const supersededQueued =
+          revisionPlan?.superseded.filter((candidate) => candidate.state === 'queued' && candidate.key === key)
+            .length ?? 0
+        const queueIncoming = revisionPlan === undefined || revisionPlan.winner.entry === entry
+        const projectedDepth = batchLeader ? q.length : q.length - supersededQueued + (queueIncoming ? 1 : 0)
         // §4.4 backpressure: per-session queue-depth cap → queue_full fast-fail. The
         // rejected entry settles its OWN promise; nothing is admitted or persisted.
-        if (q.length >= MAX_QUEUED_PER_SESSION) {
+        if (projectedDepth > MAX_QUEUED_PER_SESSION) {
           this.log.warn(`dispatch: queue full for session ${key} (${q.length}) — rejecting (queue_full)`)
           settleAdmission({ accepted: false, reason: 'queue_full' })
           reject(new QueueFullError(key))
@@ -12361,10 +12844,23 @@ export class Daemon {
           resolve(null)
           return
         }
-        q.push(entry)
-        this.serialQueue.set(key, q)
         settleAdmission({ accepted: true })
-        this.log.debug(`dispatch: queued behind in-flight turn for session ${key} (depth ${q.length})`)
+        if (batchLeader && this.coalesceGithubReviewBatch(batchLeader, entry)) {
+          entry.resolve(null)
+          return
+        }
+        if (revisionPlan) {
+          if (!this.applyGithubRevisionAdmissionPlan(revisionPlan, entry)) return
+          const next = this.serialQueue.get(key) ?? []
+          next.push(entry)
+          this.serialQueue.set(key, next)
+        } else {
+          q.push(entry)
+          this.serialQueue.set(key, q)
+        }
+        this.log.debug(
+          `dispatch: queued behind in-flight turn for session ${key} (depth ${this.serialQueue.get(key)?.length ?? 0})`
+        )
         return
       }
       // Claim ownership of the key in the SAME tick as the check, before any await.
@@ -12392,8 +12888,13 @@ export class Daemon {
         resolve(null)
         return
       }
-      this.inflight.add(key)
       settleAdmission({ accepted: true })
+      if (batchLeader && this.coalesceGithubReviewBatch(batchLeader, entry)) {
+        entry.resolve(null)
+        return
+      }
+      if (revisionPlan && !this.applyGithubRevisionAdmissionPlan(revisionPlan, entry)) return
+      this.inflight.add(key)
       void this.runLoop(key, entry)
     })
   }
@@ -12420,10 +12921,39 @@ export class Daemon {
     }
   }
 
+  private safetyDrainAllows(agentId: string, key: string, githubLane?: string): boolean {
+    return (
+      this.safetyDrainAdmissionKeys.get(agentId)?.has(key) === true ||
+      (githubLane !== undefined && this.safetyDrainGithubLanes.get(agentId)?.has(githubLane) === true)
+    )
+  }
+
+  private intersectSafetyDrainAdmissions(
+    map: Map<string, Set<string>>,
+    agentId: string,
+    incoming: Iterable<string> | undefined
+  ): void {
+    const allowed = new Set(incoming ?? [])
+    const current = map.get(agentId)
+    if (!current) {
+      map.set(agentId, allowed)
+      return
+    }
+    for (const value of current) {
+      if (!allowed.has(value)) current.delete(value)
+    }
+  }
+
   /** Gate new work until the selected active dispatches have fully unwound. Waits are
    *  additive: overlapping interrupts on different keys of one agent join the same drain
    *  instead of letting the first completion reopen admission too early. */
-  private beginSafetyDrain(agentId: string, reason: TurnInterruptReason, keys?: Iterable<string>): void {
+  private beginSafetyDrain(
+    agentId: string,
+    reason: TurnInterruptReason,
+    keys?: Iterable<string>,
+    admissionKeys?: Iterable<string>,
+    admissionGithubLanes?: Iterable<string>
+  ): void {
     const selected =
       keys === undefined
         ? [...(this.activeDispatchesByAgent.get(agentId) ?? [])]
@@ -12431,6 +12961,8 @@ export class Daemon {
             .map((key) => this.activeDispatchDoneByKey.get(key))
             .filter((done): done is Promise<void> => done !== undefined)
     if (selected.length === 0) return
+    this.intersectSafetyDrainAdmissions(this.safetyDrainAdmissionKeys, agentId, admissionKeys)
+    this.intersectSafetyDrainAdmissions(this.safetyDrainGithubLanes, agentId, admissionGithubLanes)
     const waits = this.safetyDrainWaits.get(agentId) ?? new Set<Promise<void>>()
     for (const done of selected) waits.add(done)
     this.safetyDrainWaits.set(agentId, waits)
@@ -12454,6 +12986,8 @@ export class Daemon {
         this.safetyDrainWaits.delete(agentId)
         this.safetyDrainRuns.delete(agentId)
         this.safetyDrainingAgents.delete(agentId)
+        this.safetyDrainAdmissionKeys.delete(agentId)
+        this.safetyDrainGithubLanes.delete(agentId)
         this.log.info(`${reason}: interrupted turns fully stopped for agent "${agentId}"`)
       }
     })()
@@ -12633,9 +13167,14 @@ export class Daemon {
           return
         }
         try {
+          if (entry.coordinationWait) {
+            await entry.coordinationWait
+            entry.coordinationWait = undefined
+          }
           const releaseDispatch = await this.admitActiveDispatch(entry.agentId, key)
           let sessionId: string | null
           try {
+            await this.settleGithubReviewBatch(entry)
             sessionId = await this.dispatchOne(entry, key)
           } finally {
             releaseDispatch()
@@ -13186,6 +13725,10 @@ export class Daemon {
       return undefined
     })
     if (activeGithub) this.activeGithubTurnMeta.set(key, activeGithub)
+    const githubReplyBatch = hookContext?.githubReviewBatch
+    const activeGithubReplyBatch =
+      githubReplyBatch?.sealed && githubReplyBatch.items.length > 1 ? { entry, sessionId, called: false } : undefined
+    if (activeGithubReplyBatch) this.activeGithubReplyBatchMeta.set(key, activeGithubReplyBatch)
     let finalPhase: EventSession['phase'] = 'end'
     let turnModel: string | undefined
     let propagatingTurnError = false
@@ -13856,6 +14399,9 @@ export class Daemon {
       // the map is keyed by sessionKey and the gate guarantees one active turn per key.
       if (callMeta) this.activeTurnCallMeta.delete(key)
       if (activeGithub && this.activeGithubTurnMeta.get(key) === activeGithub) this.activeGithubTurnMeta.delete(key)
+      if (activeGithubReplyBatch && this.activeGithubReplyBatchMeta.get(key) === activeGithubReplyBatch) {
+        this.activeGithubReplyBatchMeta.delete(key)
+      }
       // Anything other than no attempt or a correlated definite no-effect
       // result is fail-closed: GitHub may already own the public response.
       const formalReviewOwnsResponse = githubReply !== undefined && !githubFallbackAllowed(hookContext)
@@ -13935,7 +14481,23 @@ export class Daemon {
     // Turn finished cleanly. Draining the next queued message for this sessionKey is
     // runLoop's job (it holds ownership across turns) — NOT here. On a throw, the catch
     // above rethrows and runLoop applies fail-stop (§6.9 #378).
-    if (hookContext) this.emitHookCompletion(hookContext, 'success', { sessionId }, entry)
+    if (hookContext) {
+      const batch = hookContext.githubReviewBatch
+      const batchFailure =
+        batch && batch.items.length > 1
+          ? batch.items.some((item) => item.publishState === 'in_flight')
+            ? 'review_batch_publish_ambiguous'
+            : batch.items.some((item) => item.publishState !== 'settled')
+              ? 'review_batch_replies_missing'
+              : undefined
+          : undefined
+      this.emitHookCompletion(
+        hookContext,
+        batchFailure ? 'failed' : 'success',
+        { sessionId, ...(batchFailure ? { reason: batchFailure } : {}) },
+        entry
+      )
+    }
     return sessionId
   }
 
@@ -13953,25 +14515,39 @@ export class Daemon {
     key: string,
     reason: TurnInterruptReason,
     acpSessionId?: string,
-    opts: { dropQueued?: boolean } = {}
+    opts: {
+      dropQueued?: boolean
+      preserveQueued?: boolean
+      allowSameKeyAdmissions?: boolean
+      allowGithubLane?: string
+    } = {}
   ): void {
     // The force-cancel fallback is host-wide. Hold NEW admissions until this exact
     // dispatch is gone so a quick retry cannot be killed by the old turn's backstop.
-    this.beginSafetyDrain(agentId, reason, [key])
+    this.beginSafetyDrain(
+      agentId,
+      reason,
+      [key],
+      opts.allowSameKeyAdmissions ? [key] : undefined,
+      opts.allowGithubLane ? [opts.allowGithubLane] : undefined
+    )
     // Latch the current head even during the cold pre-Pending window. A quick reset
     // must not let pre-interrupt work resume once sessions.handle() returns.
     const activeEntry = this.activeGateEntries.get(key)
     if (activeEntry) {
       activeEntry.cancelledReason ??= reason
-      // An explicit interrupt makes the head terminal. Delete its durable row now,
-      // not only after ACP unwinds, so an immediate daemon stop cannot replay it.
-      this.removeInbox(activeEntry)
+      // Terminalize before cancellation unwinds so a crash cannot replay the head; superseded hooks retain the reason.
+      if (reason === 'superseded' && activeEntry.hookContext) {
+        this.emitHookCompletion(activeEntry.hookContext, 'failed', { reason }, activeEntry)
+      } else {
+        this.removeInbox(activeEntry)
+      }
     }
     // Drop everything buffered behind this turn first (one unified queue) and settle each
     // waiter's own promise, so `!cancel`/`!stop` doesn't leave queued dispatch() promises
     // hanging and the drained queue can't later chain onto the cancelled turn.
     const queued = this.serialQueue.get(key)
-    if (queued && queued.length > 0) {
+    if (!opts.preserveQueued && queued && queued.length > 0) {
       this.serialQueue.delete(key)
       for (const e of queued) {
         this.terminateQueuedSink(e, opts.dropQueued ? undefined : reason)
@@ -19254,8 +19830,10 @@ export class Daemon {
     msg: NormalizedMessage,
     target: { channel?: string; integrationId?: string } | undefined,
     anchorText: string,
-    label: string
+    label: string,
+    safetyGithubLane?: string
   ): Promise<NormalizedMessage | null> {
+    const key = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, agentId, msg.transportScope)
     // Gate BEFORE the anchor side effect. Cron scheduling remains registered while an
     // agent is paused, but a paused/draining/safety-stopping agent must publish nothing
     // and start no turn.
@@ -19263,7 +19841,7 @@ export class Daemon {
       this.draining ||
       this.drainingAgents.has(agentId) ||
       this.paused(agentId) ||
-      this.safetyDrainingAgents.has(agentId)
+      (this.safetyDrainingAgents.has(agentId) && !this.safetyDrainAllows(agentId, key, safetyGithubLane))
     ) {
       this.log.info(`${label}: skipped for agent "${agentId}" (paused or draining)`)
       return null

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -360,6 +360,23 @@ export interface SubmitGithubReviewReq extends SubmitGithubReviewInput {
   transportScope?: string
 }
 
+export interface ReplyGithubReviewThreadsReq {
+  agentId: string
+  platform: string
+  channel: string
+  thread: string
+  transportScope?: string
+  replies: Array<{ threadRootCommentId: string; body: string }>
+}
+
+export interface ReplyGithubReviewThreadsResult {
+  replies: Array<{
+    threadRootCommentId: string
+    state: 'published' | 'settled' | 'ambiguous'
+    commentId?: string
+  }>
+}
+
 /** Refusal surfaced to the model when an isolated session tries to access
  *  agent memory shared with other users. Phrased so the agent stops retrying
  *  instead of attempting to reconstruct or persist the content another way. */
@@ -539,6 +556,8 @@ export interface OpsDeps {
    * turn. The implementation owns action-time CP authorization and head/base
    * fencing; ordinary sessions fail closed. */
   submitGithubReview?: (req: SubmitGithubReviewReq) => Promise<GithubReviewEffect>
+  /** Publish the independently authored replies for one trusted inline-review batch. */
+  replyGithubReviewThreads?: (req: ReplyGithubReviewThreadsReq) => Promise<ReplyGithubReviewThreadsResult>
   /** The agent memory provider — backs the `readMemory`/`writeMemory` tools.
    *  Universal (every agent has memory), independent of the platform. */
   memory: MemoryProvider
@@ -1365,6 +1384,18 @@ export async function executeTool(
     })
   }
 
+  if (name === 'replyGithubReviewThreads') {
+    if (!deps.replyGithubReviewThreads) throw new Error('batched GitHub review replies are unavailable on this daemon')
+    return deps.replyGithubReviewThreads({
+      agentId: ctx.agentId,
+      platform: ctx.platform,
+      channel: ctx.channel,
+      thread: ctx.thread,
+      ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
+      replies: parseGithubReviewThreadReplies(args.replies)
+    })
+  }
+
   // (Outbound send is handled by the unified `sendMessage` branch above — it merged the
   // former `sendPlatformMessage` + `messageAgent` tools, session-concept §3.)
 
@@ -1615,5 +1646,23 @@ function parseReviewComments(value: unknown): GithubInlineReviewComment[] | unde
       ...(startLine !== undefined ? { startLine } : {}),
       ...(startSide !== undefined ? { startSide } : {})
     }
+  })
+}
+
+function parseGithubReviewThreadReplies(value: unknown): Array<{ threadRootCommentId: string; body: string }> {
+  if (!Array.isArray(value) || value.length === 0) throw new Error('argument replies must be a non-empty array')
+  if (value.length > 25) throw new Error('argument replies may contain at most 25 entries')
+  return value.map((item, index) => {
+    if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+      throw new Error(`replies[${index}] must be an object`)
+    }
+    const row = item as Record<string, unknown>
+    const threadRootCommentId = requireString(row, 'threadRootCommentId')
+    if (!/^[1-9]\d*$/.test(threadRootCommentId)) {
+      throw new Error(`replies[${index}].threadRootCommentId must be a positive decimal string`)
+    }
+    const body = requireString(row, 'body')
+    if (!body.trim()) throw new Error(`replies[${index}].body must be non-empty`)
+    return { threadRootCommentId, body }
   })
 }

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -805,6 +805,34 @@ export const GITHUB_REVIEW_TOOLS: ToolDescriptor[] = [
       },
       ['event', 'verdict', 'body']
     )
+  },
+  {
+    name: 'replyGithubReviewThreads',
+    description:
+      'Reply to every inline thread in the active batched GitHub review-comment turn. The authorized thread roots ' +
+      'are fixed by signature-verified webhook metadata: supply exactly one non-empty reply for every root listed ' +
+      'in the prompt, with no extra roots. This tool is unavailable outside that active batch and can be called at most once.',
+    inputSchema: obj(
+      {
+        replies: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 25,
+          items: obj(
+            {
+              threadRootCommentId: {
+                type: 'string',
+                pattern: '^[1-9][0-9]*$',
+                description: 'Trusted decimal thread-root id copied from the active batch prompt.'
+              },
+              body: { type: 'string', minLength: 1, description: 'Complete public reply for this review thread.' }
+            },
+            ['threadRootCommentId', 'body']
+          )
+        }
+      },
+      ['replies']
+    )
   }
 ]
 

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -214,9 +214,14 @@ function githubReplyHint(
   const event = c.action ? `${c.event}:${c.action}` : (c.event ?? '')
   const reviewGeneration = githubOpensReviewGeneration(event, github, reviewPolicy)
   if (inlineTarget) {
+    const batchedReview = github?.pullRequestReviewId !== undefined
     return [
       '',
-      `Return one self-contained final answer for the triggering inline review conversation. The daemon posts that final back to the existing review thread on ${where} automatically and exclusively owns the inline reply. Do NOT create, update, or delete GitHub comments or formal reviews through a tool, \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return the final answer for the daemon-owned inline reply.${githubWorkspaceCheckHint(github, false)}`
+      `Answer the triggering inline review conversation on ${where}. ${
+        batchedReview
+          ? 'The daemon may group root comments from the same submitted review into one prompt. For a single comment, return one self-contained final answer; when the prompt lists multiple review threads, use the structured `replyGithubReviewThreads` tool exactly once with one answer per listed root and keep the final reply transcript-only.'
+          : 'Return one self-contained final answer; the daemon posts it back to the existing review thread automatically.'
+      } The daemon exclusively owns every inline reply. Do NOT create, update, or delete GitHub comments or formal reviews through \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files).${githubWorkspaceCheckHint(github, false)}`
     ].join('\n')
   }
   if (c.event === 'pull_request_review_comment') {

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -3071,6 +3071,66 @@ export class LocalStore {
     return result.changes === 1
   }
 
+  /** Persist a hook prompt rewrite and its matching trusted context together. */
+  updateInboxHookPayload(id: string, msg: string, hookContext: string): boolean {
+    const result = this.db
+      .prepare(
+        `UPDATE inbox
+         SET msg = @msg, hookContext = @hookContext
+         WHERE id = @id AND hookContext IS NOT NULL AND completedAt IS NULL`
+      )
+      .run({ id, msg, hookContext })
+    return result.changes === 1
+  }
+
+  /** Atomically fold one live hook delivery into another and retain the follower as a terminal receipt. */
+  coalesceHookInbox(input: {
+    leaderId: string
+    leaderMsg: string
+    leaderHookContext: string
+    followerId: string
+    followerTerminalReport: string
+    completedAt: number
+  }): boolean {
+    if (input.leaderId === input.followerId) return false
+    this.db.exec('BEGIN IMMEDIATE')
+    try {
+      const leader = this.db
+        .prepare(
+          `UPDATE inbox
+           SET msg = @leaderMsg, hookContext = @leaderHookContext
+           WHERE id = @leaderId AND hookContext IS NOT NULL AND completedAt IS NULL`
+        )
+        .run({
+          leaderId: input.leaderId,
+          leaderMsg: input.leaderMsg,
+          leaderHookContext: input.leaderHookContext
+        })
+      const follower = this.db
+        .prepare(
+          `UPDATE inbox
+           SET msg = '{}', integrationId = NULL, callMeta = NULL, hookContext = NULL,
+               posterPublishState = 'settled', terminalReport = @followerTerminalReport,
+               completedAt = @completedAt, isQueueCmd = NULL
+           WHERE id = @followerId AND hookContext IS NOT NULL AND completedAt IS NULL`
+        )
+        .run({
+          followerId: input.followerId,
+          followerTerminalReport: input.followerTerminalReport,
+          completedAt: input.completedAt
+        })
+      if (leader.changes !== 1 || follower.changes !== 1) {
+        this.db.exec('ROLLBACK')
+        return false
+      }
+      this.db.exec('COMMIT')
+      return true
+    } catch (err) {
+      this.db.exec('ROLLBACK')
+      throw err
+    }
+  }
+
   /** Atomically turn a live hook inbox row into a redacted terminal receipt.
    * The stable id remains present to absorb relay redelivery after restart;
    * startup re-emits only the metadata report, never the model prompt. The CAS

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -29,6 +29,7 @@ import { GithubReplyCollector } from '../src/github/poster.js'
 import { transcriptCoords } from '../src/session/session-manager.js'
 import { sessionKey } from '../src/store/local-store.js'
 import { sessionWorktreePath } from '../src/workspace/workspace-manager.js'
+import { FakeClock } from '@agentconnect.md/connection'
 
 // vi.waitFor defaults to a 1000ms budget — too tight on a loaded CI runner, where a
 // cold session boot (workspace + host + session/new) can stall well past a second.
@@ -398,6 +399,157 @@ describe('Daemon rd/msg hook fires', () => {
     })
     await daemon.stop()
   }, 15_000)
+
+  it.each([
+    { mode: 'headless', target: undefined },
+    {
+      mode: 'targeted',
+      target: { platform: 'slack' as const, channel: 'C-alerts', integrationId: 'int-a' }
+    }
+  ])(
+    'batches one submitted review into one turn and replies independently to every root thread ($mode)',
+    async ({ target }) => {
+      const clock = new FakeClock(Date.parse('2026-08-12T00:00:00.000Z'))
+      let onUpdate!: (sid: string, update: unknown) => void
+      let sessionNumber = 0
+      const prompts: string[] = []
+      const published: Array<{ root?: string; body: string }> = []
+      const host = {
+        start: vi.fn(async () => {}),
+        newSession: vi.fn(async () => `acp-review-batch-${++sessionNumber}`),
+        modelOptions: vi.fn(() => null),
+        hasSession: vi.fn(() => true),
+        prompt: vi.fn(async (sid: string, blocks: unknown) => {
+          prompts.push(JSON.stringify(blocks))
+          if (prompts.length === 1) {
+            await (daemon as any).replyGithubReviewThreads({
+              agentId: AGENT_ID,
+              platform: target?.platform ?? 'hook',
+              channel: target?.channel ?? 'acme/infra',
+              thread: target ? 'anchor-1' : '42',
+              ...(target ? {} : { transportScope: 'github:123' }),
+              replies: [
+                { threadRootCommentId: '101', body: 'Answer for the first thread.' },
+                { threadRootCommentId: '102', body: 'Answer for the second thread.' }
+              ]
+            })
+            onUpdate(sid, {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'Batch replies posted.' }
+            })
+          } else {
+            onUpdate(sid, {
+              sessionUpdate: 'agent_message_chunk',
+              messageId: 'follow-up-final',
+              _meta: { codex: { phase: 'final_answer' } },
+              content: { type: 'text', text: 'Follow-up answer.' }
+            })
+          }
+          return { stopReason: 'end_turn' }
+        }),
+        cancel: vi.fn(async () => {}),
+        stop: vi.fn(async () => {})
+      }
+      const daemon = new Daemon({
+        root: scaffold(),
+        clock,
+        hostFactory: (_agent, cb) => {
+          onUpdate = cb
+          return host as never
+        }
+      })
+      await daemon.start()
+      const cp = fakeCpClient()
+      ;(daemon as never as { cpClient: unknown }).cpClient = cp
+      let anchorNumber = 0
+      if (target) {
+        ;(daemon as any).connByIntegration.set(target.integrationId, {
+          postMessage: vi.fn(async () => `anchor-${++anchorNumber}`),
+          postContext: vi.fn(async () => {}),
+          setStatus: vi.fn(async () => {})
+        })
+      }
+      ;(daemon as any).makeGithubReply = vi.fn((_agentId: string, ref: { reviewThreadRootCommentId?: string }) => ({
+        collector: new GithubReplyCollector(),
+        poster: {
+          publish: vi.fn(async (body: string) => {
+            published.push({ root: ref.reviewThreadRootCommentId, body })
+            return { kind: 'review_comment' as const, commentId: String(9000 + published.length) }
+          })
+        }
+      }))
+
+      const reviewComment = (deliveryKey: string, commentId: string, rootId: string, body: string): RdMsgHook =>
+        fire({
+          sessionKey: 'acme/infra#42',
+          ...(target ? { target } : {}),
+          msgId: `${HOOK_ID}:${deliveryKey}`,
+          deliveryKey,
+          firedAt: `2026-08-12T00:00:0${deliveryKey === 'root-1' ? '0' : deliveryKey === 'root-2' ? '1' : '2'}.000Z`,
+          event: 'pull_request_review_comment:created',
+          github: {
+            repoId: '123',
+            repoFullName: 'acme/infra',
+            sourceInstallationId: '456',
+            subjectKind: 'pull_request',
+            pullNumber: 42,
+            pullRequestReviewId: '900',
+            reviewCommentId: commentId,
+            reviewThreadRootCommentId: rootId
+          },
+          context: {
+            source: 'github',
+            event: 'pull_request_review_comment',
+            action: 'created',
+            repo: 'acme/infra',
+            number: 42,
+            senderLogin: 'reviewer',
+            bodyExcerpt: body,
+            truncated: false
+          }
+        })
+
+      await expect(
+        (daemon as any).handleRelayMsg(reviewComment('root-1', '101', '101', 'First finding.'), () => {})
+      ).resolves.toMatchObject({ accepted: true })
+      await vi.waitFor(() => expect((daemon as any).activeGateEntries.size).toBe(1), WAIT)
+      await expect(
+        (daemon as any).handleRelayMsg(reviewComment('root-2', '102', '102', 'Second finding.'), () => {})
+      ).resolves.toMatchObject({ accepted: true })
+      expect(host.prompt).not.toHaveBeenCalled()
+
+      clock.advance(5_000)
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledOnce(), WAIT)
+      await vi.waitFor(() => expect(published).toHaveLength(2), WAIT)
+      expect(prompts[0]).toContain('Authorized thread roots: 101, 102')
+      expect(prompts[0]).toContain('First finding.')
+      expect(prompts[0]).toContain('Second finding.')
+      expect(published).toEqual([
+        { root: '101', body: 'Answer for the first thread.' },
+        { root: '102', body: 'Answer for the second thread.' }
+      ])
+      await vi.waitFor(
+        () =>
+          expect(cp.hookReports).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ deliveryKey: 'root-2', reason: 'coalesced_review_batch' }),
+              expect.objectContaining({ deliveryKey: 'root-1', status: 'success' })
+            ])
+          ),
+        WAIT
+      )
+
+      await expect(
+        (daemon as any).handleRelayMsg(reviewComment('reply-1', '103', '101', 'One later thread reply.'), () => {})
+      ).resolves.toMatchObject({ accepted: true })
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
+      await vi.waitFor(() => expect(published).toHaveLength(3), WAIT)
+      expect(prompts[1]).not.toContain('Authorized thread roots')
+      expect(published[2]).toEqual({ root: '101', body: 'Follow-up answer.' })
+      await daemon.stop()
+    },
+    15_000
+  )
 
   it('grants formal-review authority only when an issue_comment explicitly requests review', async () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: streamingHost().factory })
@@ -1650,6 +1802,270 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.stop()
   }, 15_000)
 
+  it('keeps only the newest relay-fired PR revision without reordering explicit GitHub turns', async () => {
+    let onUpdate!: (sid: string, update: unknown) => void
+    const releases: Array<(error?: Error) => void> = []
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-pr-review'),
+      modelOptions: vi.fn(() => null),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sid: string) => {
+        await new Promise<void>((resolve, reject) => releases.push((error) => (error ? reject(error) : resolve())))
+        onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'done' } })
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => releases.shift()?.(new Error('cancelled by shutdown'))),
+      stop: vi.fn(async () => {})
+    }
+    const root = scaffold()
+    const daemon = new Daemon({
+      root,
+      hostFactory: (_agent, cb) => {
+        onUpdate = cb
+        return host as never
+      }
+    })
+    await daemon.start()
+    ;(daemon as any).cfg.limits.shutdownDrainMs = 0
+    const cp = fakeCpClient()
+    ;(daemon as never as { cpClient: unknown }).cpClient = cp
+    ;(daemon as any).makeGithubReply = vi.fn(() => ({
+      poster: { publish: vi.fn(async () => {}) },
+      collector: new GithubReplyCollector()
+    }))
+
+    const revision = (deliveryKey: string, head: string, firedAt: string): RdMsgHook =>
+      fire({
+        sessionKey: 'acme/infra#42',
+        msgId: `${HOOK_ID}:${deliveryKey}`,
+        deliveryKey,
+        firedAt,
+        event: 'pull_request:synchronize',
+        github: {
+          repoId: '123',
+          repoFullName: 'acme/infra',
+          sourceInstallationId: '456',
+          subjectKind: 'pull_request',
+          pullNumber: 42,
+          headSha: head.repeat(40),
+          baseSha: '0'.repeat(40),
+          reportSha: head.repeat(40)
+        },
+        context: {
+          source: 'github',
+          event: 'pull_request',
+          action: 'synchronize',
+          repo: 'acme/infra',
+          number: 42,
+          title: 'Keep revision reviews current',
+          senderLogin: 'alice',
+          truncated: false
+        }
+      })
+    const comment = fire({
+      sessionKey: 'acme/infra#42',
+      msgId: `${HOOK_ID}:comment`,
+      deliveryKey: 'comment',
+      event: 'issue_comment:created',
+      github: {
+        repoId: '123',
+        repoFullName: 'acme/infra',
+        sourceInstallationId: '456',
+        subjectKind: 'pull_request',
+        pullNumber: 42,
+        headSha: 'b'.repeat(40),
+        baseSha: '0'.repeat(40),
+        reportSha: 'b'.repeat(40)
+      },
+      context: {
+        source: 'github',
+        event: 'issue_comment',
+        action: 'created',
+        repo: 'acme/infra',
+        number: 42,
+        senderLogin: 'maintainer',
+        bodyExcerpt: '@agent please focus on cancellation',
+        truncated: false
+      }
+    })
+
+    await expect(
+      (daemon as any).handleRelayMsg(revision('active', 'a', '2026-08-12T00:00:00.000Z'), () => {})
+    ).resolves.toMatchObject({
+      accepted: true
+    })
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledOnce(), WAIT)
+    await expect(
+      (daemon as any).handleRelayMsg(revision('old', 'b', '2026-08-12T00:00:01.000Z'), () => {})
+    ).resolves.toMatchObject({
+      accepted: true
+    })
+    await expect((daemon as any).handleRelayMsg(comment, () => {})).resolves.toMatchObject({ accepted: true })
+    await expect(
+      (daemon as any).handleRelayMsg(revision('newest', 'c', '2026-08-12T00:00:03.000Z'), () => {})
+    ).resolves.toMatchObject({
+      accepted: true
+    })
+    await expect(
+      (daemon as any).handleRelayMsg(revision('delayed-older', 'b', '2026-08-12T00:00:02.000Z'), () => {})
+    ).resolves.toMatchObject({
+      accepted: true
+    })
+
+    const queued = [...(daemon as any).serialQueue.values()].flat() as Array<{
+      hookContext?: { deliveryKey: string }
+    }>
+    expect(queued.map((entry) => entry.hookContext?.deliveryKey)).toEqual(['comment', 'newest'])
+    await vi.waitFor(
+      () =>
+        expect(cp.hookReports.filter((report) => ['old', 'delayed-older'].includes(report.deliveryKey))).toEqual([
+          expect.objectContaining({ deliveryKey: 'old', status: 'failed', reason: 'superseded' }),
+          expect.objectContaining({ deliveryKey: 'delayed-older', status: 'failed', reason: 'superseded' })
+        ]),
+      WAIT
+    )
+    expect(cp.hookReports).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ deliveryKey: 'active', status: 'failed', reason: 'superseded' })
+      ])
+    )
+    expect(host.cancel).toHaveBeenCalled()
+
+    await daemon.stop()
+
+    const restartedHost = streamingHost()
+    const restarted = new Daemon({ root, hostFactory: restartedHost.factory })
+    const restartedCp = fakeCpClient()
+    ;(restarted as never as { cpClient: unknown }).cpClient = restartedCp
+    ;(restarted as any).makeGithubReply = vi.fn(() => ({
+      poster: { publish: vi.fn(async () => {}) },
+      collector: new GithubReplyCollector()
+    }))
+    await restarted.start()
+
+    await vi.waitFor(
+      () =>
+        expect(
+          restartedCp.hookReports.filter((report) => !['old', 'delayed-older'].includes(report.deliveryKey))
+        ).toHaveLength(2),
+      WAIT
+    )
+    expect(
+      restartedCp.hookReports
+        .filter((report) => !['old', 'delayed-older'].includes(report.deliveryKey))
+        .map((report) => report.deliveryKey)
+    ).toEqual(['comment', 'newest'])
+    expect(restartedHost.host.prompt).toHaveBeenCalledTimes(2)
+    await restarted.stop()
+  }, 15_000)
+
+  it('keeps targeted PR revision reviews latest-wins across distinct anchor session keys', async () => {
+    let onUpdate!: (sid: string, update: unknown) => void
+    let sessionNumber = 0
+    let activePrompts = 0
+    let maxActivePrompts = 0
+    const pending = new Map<string, { resolve: () => void; reject: (error: Error) => void }>()
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => `acp-targeted-review-${++sessionNumber}`),
+      modelOptions: vi.fn(() => null),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sid: string) => {
+        activePrompts += 1
+        maxActivePrompts = Math.max(maxActivePrompts, activePrompts)
+        try {
+          await new Promise<void>((resolve, reject) => pending.set(sid, { resolve, reject }))
+          onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'done' } })
+          return { stopReason: 'end_turn' }
+        } finally {
+          activePrompts -= 1
+        }
+      }),
+      cancel: vi.fn(async (sid: string) => pending.get(sid)?.reject(new Error('superseded'))),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      root: scaffold(),
+      hostFactory: (_agent, cb) => {
+        onUpdate = cb
+        return host as never
+      }
+    })
+    await daemon.start()
+    const cp = fakeCpClient()
+    ;(daemon as never as { cpClient: unknown }).cpClient = cp
+    let anchorNumber = 0
+    ;(daemon as any).connByIntegration.set('int-a', {
+      postMessage: vi.fn(async () => `anchor-${++anchorNumber}`),
+      postContext: vi.fn(async () => {}),
+      setStatus: vi.fn(async () => {})
+    })
+    ;(daemon as any).makeGithubReply = vi.fn(() => ({
+      poster: { publish: vi.fn(async () => {}) },
+      collector: new GithubReplyCollector()
+    }))
+    const target = { platform: 'slack' as const, channel: 'C-alerts', integrationId: 'int-a' }
+    const revision = (deliveryKey: string, head: string, firedAt: string): RdMsgHook =>
+      fire({
+        sessionKey: 'acme/infra#42',
+        msgId: `${HOOK_ID}:${deliveryKey}`,
+        deliveryKey,
+        firedAt,
+        target,
+        event: 'pull_request:synchronize',
+        github: {
+          repoId: '123',
+          repoFullName: 'acme/infra',
+          sourceInstallationId: '456',
+          subjectKind: 'pull_request',
+          pullNumber: 42,
+          headSha: head.repeat(40),
+          baseSha: '0'.repeat(40),
+          reportSha: head.repeat(40)
+        },
+        context: {
+          source: 'github',
+          event: 'pull_request',
+          action: 'synchronize',
+          repo: 'acme/infra',
+          number: 42,
+          title: 'Keep targeted revisions current',
+          senderLogin: 'alice',
+          truncated: false
+        }
+      })
+
+    await expect(
+      (daemon as any).handleRelayMsg(revision('active-target', 'a', '2026-08-12T00:00:00.000Z'), () => {})
+    ).resolves.toMatchObject({ accepted: true })
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledOnce(), WAIT)
+    await expect(
+      (daemon as any).handleRelayMsg(revision('newest-target', 'c', '2026-08-12T00:00:02.000Z'), () => {})
+    ).resolves.toMatchObject({ accepted: true })
+    await expect(
+      (daemon as any).handleRelayMsg(revision('delayed-target', 'b', '2026-08-12T00:00:01.000Z'), () => {})
+    ).resolves.toMatchObject({ accepted: true })
+
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
+    expect(host.cancel).toHaveBeenCalledWith('acp-targeted-review-1')
+    expect(maxActivePrompts).toBe(1)
+    pending.get('acp-targeted-review-2')?.resolve()
+    await vi.waitFor(
+      () =>
+        expect(cp.hookReports).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ deliveryKey: 'active-target', status: 'failed', reason: 'superseded' }),
+            expect.objectContaining({ deliveryKey: 'delayed-target', status: 'failed', reason: 'superseded' }),
+            expect.objectContaining({ deliveryKey: 'newest-target', status: 'success' })
+          ])
+        ),
+      WAIT
+    )
+    expect(host.prompt).toHaveBeenCalledTimes(2)
+    await daemon.stop()
+  }, 15_000)
+
   it.each([
     {
       lifecycle: 'pause',
@@ -2207,12 +2623,30 @@ describe('buildHookMessage', () => {
           }
         )
       )
-      expect(inlineReply).toContain(
-        'posts that final back to the existing review thread on acme/infra#42 automatically'
-      )
-      expect(inlineReply).toContain('daemon-owned inline reply')
+      expect(inlineReply).toContain('daemon posts it back to the existing review thread automatically')
+      expect(inlineReply).toContain('exclusively owns every inline reply')
       expect(inlineReply).not.toContain('submitGithubReview')
       expect(inlineReply).not.toContain('ordinary GitHub comment')
+      const batchableInline = buildHookText(
+        ghFire(
+          { event: 'pull_request_review_comment', action: 'created' },
+          {
+            event: 'pull_request_review_comment:created',
+            github: {
+              repoId: '123',
+              repoFullName: 'acme/infra',
+              sourceInstallationId: '456',
+              subjectKind: 'pull_request',
+              pullNumber: 42,
+              pullRequestReviewId: '900',
+              reviewCommentId: '3565656411',
+              reviewThreadRootCommentId: '3565656411'
+            }
+          }
+        )
+      )
+      expect(batchableInline).toContain('replyGithubReviewThreads')
+      expect(batchableInline).toContain('root comments from the same submitted review')
       // During a rolling relay upgrade the event family is still known, but
       // an old relay cannot provide the trusted thread root. Promise only the
       // ordinary fallback and keep formal-review guidance disabled.

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -113,6 +113,51 @@ describe('LocalStore inbox', () => {
     s.close()
   })
 
+  it('atomically persists a coalesced hook leader and terminalizes its follower', () => {
+    const s = store()
+    const key = sessionKey('hook', 'acme/repo', '42', 'bot-a')
+    expect(s.appendInbox({ ...row('leader', key, '100'), hookContext: '{"batch":["first"]}' })).toBe(true)
+    expect(s.appendInbox({ ...row('follower', key, '200'), hookContext: '{"batch":["second"]}' })).toBe(true)
+
+    expect(
+      s.coalesceHookInbox({
+        leaderId: 'leader',
+        leaderMsg: '{"text":"first and second"}',
+        leaderHookContext: '{"batch":["first","second"]}',
+        followerId: 'follower',
+        followerTerminalReport: '{"status":"success","reason":"coalesced_review_batch"}',
+        completedAt: 123
+      })
+    ).toBe(true)
+    const rows = s.listInboxBySessionKeyFifo()
+    expect(rows.find((entry) => entry.id === 'leader')).toMatchObject({
+      msg: '{"text":"first and second"}',
+      hookContext: '{"batch":["first","second"]}',
+      completedAt: null
+    })
+    expect(rows.find((entry) => entry.id === 'follower')).toMatchObject({
+      msg: '{}',
+      hookContext: null,
+      terminalReport: '{"status":"success","reason":"coalesced_review_batch"}',
+      completedAt: 123
+    })
+
+    expect(
+      s.coalesceHookInbox({
+        leaderId: 'leader',
+        leaderMsg: '{"text":"must roll back"}',
+        leaderHookContext: '{"batch":["wrong"]}',
+        followerId: 'missing',
+        followerTerminalReport: '{}',
+        completedAt: 999
+      })
+    ).toBe(false)
+    expect(s.listInboxBySessionKeyFifo().find((entry) => entry.id === 'leader')?.msg).toBe(
+      '{"text":"first and second"}'
+    )
+    s.close()
+  })
+
   it('capacity-prunes only CP-acknowledged receipts, never pending reports', () => {
     const s = store()
     const k = sessionKey('hook', 'hook-1', 'delivery', 'bot-a')

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -1496,3 +1496,44 @@ describe('executeTool: submitGithubReview', () => {
     expect(submitGithubReview).not.toHaveBeenCalled()
   })
 })
+
+describe('executeTool: replyGithubReviewThreads', () => {
+  it('takes session identity from trusted context and validates decimal roots', async () => {
+    const replyGithubReviewThreads = vi.fn(async () => ({
+      replies: [{ threadRootCommentId: '123', state: 'published' as const, commentId: '999' }]
+    }))
+    const { deps: d } = deps(fakeGateway())
+    d.replyGithubReviewThreads = replyGithubReviewThreads
+
+    await expect(
+      executeTool(
+        ctx,
+        'replyGithubReviewThreads',
+        {
+          repo: 'evil/repo',
+          number: 1,
+          replies: [{ threadRootCommentId: '123', body: 'Fixed in the latest push.' }]
+        },
+        d
+      )
+    ).resolves.toMatchObject({ replies: [{ commentId: '999' }] })
+    expect(replyGithubReviewThreads).toHaveBeenCalledWith({
+      agentId: 'bot-a',
+      platform: 'slack',
+      channel: 'C_CURRENT',
+      thread: '111.1',
+      replies: [{ threadRootCommentId: '123', body: 'Fixed in the latest push.' }]
+    })
+
+    await expect(
+      executeTool(
+        ctx,
+        'replyGithubReviewThreads',
+        {
+          replies: [{ threadRootCommentId: '01', body: 'bad target' }]
+        },
+        d
+      )
+    ).rejects.toThrow(/positive decimal string/)
+  })
+})

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -405,7 +405,7 @@ describe('toolsForIntegrations', () => {
   })
 
   it('formal review descriptor has no model-selectable GitHub target', () => {
-    const tool = GITHUB_REVIEW_TOOLS[0]!
+    const tool = GITHUB_REVIEW_TOOLS.find((candidate) => candidate.name === 'submitGithubReview')!
     expect(tool.name).toBe('submitGithubReview')
     const properties = (tool.inputSchema.properties ?? {}) as Record<string, unknown>
     expect(Object.keys(properties)).toEqual(['event', 'verdict', 'body', 'comments'])
@@ -414,5 +414,15 @@ describe('toolsForIntegrations', () => {
     expect(properties).not.toHaveProperty('commitId')
     expect(properties.body).toMatchObject({ minLength: 1 })
     expect(tool.description).toContain('only a definite not_submitted result preserves')
+  })
+
+  it('batched review replies select only trusted thread roots exposed by the prompt', () => {
+    const tool = GITHUB_REVIEW_TOOLS.find((candidate) => candidate.name === 'replyGithubReviewThreads')!
+    const properties = (tool.inputSchema.properties ?? {}) as Record<string, any>
+    expect(Object.keys(properties)).toEqual(['replies'])
+    expect(properties.replies).toMatchObject({ minItems: 1, maxItems: 25 })
+    expect(properties.replies.items.properties).toHaveProperty('threadRootCommentId')
+    expect(properties.replies.items.properties).not.toHaveProperty('repo')
+    expect(properties.replies.items.properties).not.toHaveProperty('number')
   })
 })

--- a/packages/protocol/src/frames/hook.test.ts
+++ b/packages/protocol/src/frames/hook.test.ts
@@ -52,6 +52,7 @@ describe('R1/R2a hook control schemas', () => {
     expect(
       GithubHookMetadata.safeParse({
         ...github,
+        pullRequestReviewId: '3565283000',
         reviewCommentId: '3565656411',
         reviewThreadRootCommentId: '3565283658'
       }).success
@@ -70,6 +71,7 @@ describe('R1/R2a hook control schemas', () => {
     expect(GithubHookMetadata.safeParse({ ...github, pullNumber: undefined }).success).toBe(false)
     expect(GithubHookMetadata.safeParse({ ...github, headSha: undefined }).success).toBe(false)
     expect(GithubHookMetadata.safeParse({ ...github, reportSha: 'test-merge-sha' }).success).toBe(false)
+    expect(GithubHookMetadata.safeParse({ ...github, pullRequestReviewId: '0' }).success).toBe(false)
     expect(GithubHookMetadata.safeParse({ ...github, reviewCommentId: '-1' }).success).toBe(false)
     expect(GithubHookMetadata.safeParse({ ...github, reviewThreadRootCommentId: '01' }).success).toBe(false)
   })

--- a/packages/protocol/src/frames/hook.ts
+++ b/packages/protocol/src/frames/hook.ts
@@ -40,18 +40,7 @@ export type HookConfigSnapshot = z.infer<typeof HookConfigSnapshot>
 export const OptionalHookConfigSnapshot = HookConfigSnapshot.partial()
 export type OptionalHookConfigSnapshot = z.infer<typeof OptionalHookConfigSnapshot>
 
-/**
- * Trusted, body-free GitHub subject/revision metadata. It is deliberately
- * separate from HookContext: HookContext contains attacker-authored prompt
- * excerpts, whereas this object is cut from a signature-verified payload and
- * fenced to the CP-compiled numeric repo/installation rule.
- *
- * `headSha` is absent for PR issue_comment deliveries because GitHub omits the
- * revision there; the daemon resolves it before `hook/start`. R2a informational
- * checks use `reportSha=headSha` once known. Review-comment deliveries may also
- * identify the triggering comment and its normalized thread root; both remain
- * optional so mixed-version relay/daemon rollouts continue to decode.
- */
+/** Signature-verified, body-free GitHub subject/revision metadata; optional review and comment ids preserve mixed-version decoding. */
 export const GithubHookMetadata = z
   .object({
     repoId: HookBigIntString,
@@ -71,6 +60,7 @@ export const GithubHookMetadata = z
     // enables formal reviews. The body stays off the CP wire; only this
     // trusted routing fact reopens the review generation.
     explicitReviewRequest: z.boolean().optional(),
+    pullRequestReviewId: HookBigIntString.refine((value) => value !== '0').optional(),
     reviewCommentId: HookBigIntString.optional(),
     reviewThreadRootCommentId: HookBigIntString.optional()
   })

--- a/packages/relay/src/hooks/github-ingress.test.ts
+++ b/packages/relay/src/hooks/github-ingress.test.ts
@@ -2168,14 +2168,18 @@ describe('github ingress', () => {
 })
 
 describe('buildTrustedGithubMetadata review comment ids', () => {
-  const metadata = (id: number, inReplyToId: number | null | undefined) =>
+  const metadata = (id: number, inReplyToId: number | null | undefined, reviewId: number = 456) =>
     buildTrustedGithubMetadata(
       'pull_request_review_comment',
       {
         installation: { id: INSTALLATION },
         repository: { id: REPO_ID, full_name: 'acme/infra' },
         pull_request: { number: 7 },
-        comment: { id, ...(inReplyToId !== undefined ? { in_reply_to_id: inReplyToId } : {}) }
+        comment: {
+          id,
+          pull_request_review_id: reviewId,
+          ...(inReplyToId !== undefined ? { in_reply_to_id: inReplyToId } : {})
+        }
       },
       rule({}, { events: ['issue_comment:created'] })
     )
@@ -2183,6 +2187,7 @@ describe('buildTrustedGithubMetadata review comment ids', () => {
   it('accepts Number.MAX_SAFE_INTEGER for both a triggering comment and its root', () => {
     const max = Number.MAX_SAFE_INTEGER
     expect(metadata(max, null)).toMatchObject({
+      pullRequestReviewId: '456',
       reviewCommentId: String(max),
       reviewThreadRootCommentId: String(max)
     })
@@ -2196,6 +2201,10 @@ describe('buildTrustedGithubMetadata review comment ids', () => {
       expect(github?.reviewThreadRootCommentId).toBeUndefined()
     }
   )
+
+  it.each([Number.MAX_SAFE_INTEGER + 1, -1, 1.5])('omits an invalid review id (%s)', (reviewId) => {
+    expect(metadata(123, null, reviewId)?.pullRequestReviewId).toBeUndefined()
+  })
 
   it.each([Number.MAX_SAFE_INTEGER + 1, -1, 1.5])(
     'does not fall back to the child id when a present root id is invalid (%s)',

--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -91,6 +91,7 @@ interface GithubPayload {
   pull_request?: GithubSubject
   comment?: {
     id?: number
+    pull_request_review_id?: number
     in_reply_to_id?: number | null
     body?: string
     html_url?: string
@@ -410,6 +411,12 @@ export function buildTrustedGithubMetadata(
   const pr = payload.pull_request
   const headSha = pr?.head?.sha
   const rawReviewCommentId = event === 'pull_request_review_comment' ? payload.comment?.id : undefined
+  const rawPullRequestReviewId =
+    event === 'pull_request_review_comment' ? payload.comment?.pull_request_review_id : undefined
+  const pullRequestReviewId =
+    rawPullRequestReviewId !== undefined && Number.isSafeInteger(rawPullRequestReviewId) && rawPullRequestReviewId > 0
+      ? rawPullRequestReviewId
+      : undefined
   const reviewCommentId =
     rawReviewCommentId !== undefined && Number.isSafeInteger(rawReviewCommentId) && rawReviewCommentId > 0
       ? rawReviewCommentId
@@ -438,6 +445,7 @@ export function buildTrustedGithubMetadata(
     ...(pr?.merge_commit_sha ? { mergeCommitSha: pr.merge_commit_sha } : {}),
     ...(pr?.draft !== undefined ? { isDraft: pr.draft } : {}),
     ...(explicitReviewRequest ? { explicitReviewRequest: true } : {}),
+    ...(pullRequestReviewId !== undefined ? { pullRequestReviewId: String(pullRequestReviewId) } : {}),
     ...(reviewCommentId !== undefined ? { reviewCommentId: String(reviewCommentId) } : {}),
     ...(reviewThreadRootCommentId !== undefined ? { reviewThreadRootCommentId: String(reviewThreadRootCommentId) } : {})
   }


### PR DESCRIPTION
## Summary

- Make automatic GitHub PR revision reviews latest-wins across both the active turn and the durable queue: a newer synchronize delivery cancels the older turn, suppresses its remaining output, and removes only superseded revisions.
- Preserve explicit GitHub comments, requested reviews, reruns, and their FIFO position while revision cancellation unwinds.
- Group root inline comments from one signature-verified submitted review into a bounded durable batch, run one model turn, and publish one independently authored reply to every original thread.
- Keep later replies inside an existing inline thread as independent turns, and persist batch membership plus per-thread publish fences across daemon restarts.

## Validation

- Daemon hook suite: 69 passed
- Daemon durability and MCP suites: 151 passed
- Relay GitHub ingress suite: 100 passed
- Protocol hook suite: 6 passed
- Daemon, relay, and protocol typechecks
- Relay dependency build and changed-file ESLint
- Pre-push full-repository ESLint: 0 errors, 2 pre-existing duplicate-import warnings

Created by Codex . GPT-5.6