### PR TITLE
test(cp): retry the integration truncate when it loses a deadlock

### DIFF
--- a/packages/control-plane/test/setup.db.ts
+++ b/packages/control-plane/test/setup.db.ts
@@ -90,23 +90,13 @@ function isDeadlock(error: unknown): boolean {
   const cause = (
     error as { meta?: { driverAdapterError?: { cause?: { originalCode?: string; code?: string } } } } | null
   )?.meta?.driverAdapterError?.cause
-  // `originalCode` is set for every driver error; `code` only when the adapter leaves the
-  // SQLSTATE unmapped, which is today's path for 40P01 but not a promise.
+  // `originalCode` is always set; `code` only while the adapter leaves 40P01 unmapped.
   if (cause?.originalCode === DEADLOCK_DETECTED || cause?.code === DEADLOCK_DETECTED) return true
   // Shape of `meta` is not part of Prisma's public contract; the message is the fallback.
   return error instanceof Error && error.message.includes('deadlock detected')
 }
 
-/**
- * A previous test's app can still have a query in flight on another pooled
- * connection when the next test starts — background loops outlive the request
- * that started them. That reader holds AccessShareLock on one table and wants
- * another; this TRUNCATE holds AccessExclusiveLock on the second and wants the
- * first, so Postgres kills one of the two. Ordering the table list cannot fix
- * it (the reader's lock order is not ours to choose), so the truncate simply
- * retries when it is the victim: the reader always finishes, and the retry then
- * takes every lock uncontended.
- */
+/** A leftover in-flight reader and this TRUNCATE can want each other's table locks, so retry when we lose. */
 async function truncateAll(): Promise<void> {
   const list = TABLES.map((t) => `"${t}"`).join(', ')
   for (let attempt = 1; ; attempt += 1) {

--- a/packages/control-plane/test/setup.db.ts
+++ b/packages/control-plane/test/setup.db.ts
@@ -87,9 +87,12 @@ const TRUNCATE_ATTEMPTS = 5
 
 /** Prisma reports the raw-query failure as P2010 and carries the driver's SQLSTATE underneath. */
 function isDeadlock(error: unknown): boolean {
-  const cause = (error as { meta?: { driverAdapterError?: { cause?: { code?: string } } } } | null)?.meta
-    ?.driverAdapterError?.cause
-  if (cause?.code === DEADLOCK_DETECTED) return true
+  const cause = (
+    error as { meta?: { driverAdapterError?: { cause?: { originalCode?: string; code?: string } } } } | null
+  )?.meta?.driverAdapterError?.cause
+  // `originalCode` is set for every driver error; `code` only when the adapter leaves the
+  // SQLSTATE unmapped, which is today's path for 40P01 but not a promise.
+  if (cause?.originalCode === DEADLOCK_DETECTED || cause?.code === DEADLOCK_DETECTED) return true
   // Shape of `meta` is not part of Prisma's public contract; the message is the fallback.
   return error instanceof Error && error.message.includes('deadlock detected')
 }

--- a/packages/control-plane/test/setup.db.ts
+++ b/packages/control-plane/test/setup.db.ts
@@ -81,9 +81,40 @@ const TABLES = [
   'org'
 ] as const
 
+/** Postgres deadlock_detected — the truncate lost the tie-break, not a schema fault. */
+const DEADLOCK_DETECTED = '40P01'
+const TRUNCATE_ATTEMPTS = 5
+
+/** Prisma reports the raw-query failure as P2010 and carries the driver's SQLSTATE underneath. */
+function isDeadlock(error: unknown): boolean {
+  const cause = (error as { meta?: { driverAdapterError?: { cause?: { code?: string } } } } | null)?.meta
+    ?.driverAdapterError?.cause
+  if (cause?.code === DEADLOCK_DETECTED) return true
+  // Shape of `meta` is not part of Prisma's public contract; the message is the fallback.
+  return error instanceof Error && error.message.includes('deadlock detected')
+}
+
+/**
+ * A previous test's app can still have a query in flight on another pooled
+ * connection when the next test starts — background loops outlive the request
+ * that started them. That reader holds AccessShareLock on one table and wants
+ * another; this TRUNCATE holds AccessExclusiveLock on the second and wants the
+ * first, so Postgres kills one of the two. Ordering the table list cannot fix
+ * it (the reader's lock order is not ours to choose), so the truncate simply
+ * retries when it is the victim: the reader always finishes, and the retry then
+ * takes every lock uncontended.
+ */
 async function truncateAll(): Promise<void> {
   const list = TABLES.map((t) => `"${t}"`).join(', ')
-  await prisma.$executeRawUnsafe(`TRUNCATE TABLE ${list} RESTART IDENTITY CASCADE;`)
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await prisma.$executeRawUnsafe(`TRUNCATE TABLE ${list} RESTART IDENTITY CASCADE;`)
+      return
+    } catch (error) {
+      if (!isDeadlock(error) || attempt === TRUNCATE_ATTEMPTS) throw error
+      await new Promise((resolve) => setTimeout(resolve, 50 * attempt))
+    }
+  }
 }
 
 beforeEach(async () => {


### PR DESCRIPTION
## Summary

The `beforeEach` TRUNCATE in the control-plane integration harness deadlocks intermittently in CI (`40P01`), failing one shard with an error that has nothing to do with the code under test — [an example from #867](https://github.com/agentconnect-md/agentconnect/pull/867), where the shard passed on a plain rerun.

**Why it happens:** a previous test's app can still have a query in flight on another pooled connection when the next test starts — background loops outlive the request that started them. That reader holds `AccessShareLock` on one table and wants a second; the TRUNCATE holds `AccessExclusiveLock` on the second and wants the first, so Postgres kills one of the pair. The CI failure detail shows exactly that shape:

```
Process 1368 waits for AccessExclusiveLock on relation 17137; blocked by process 1370.
Process 1370 waits for AccessShareLock on relation 17087; blocked by process 1368.
```

**Why not reorder the table list:** the deadlock is between two different statements, and the reader's lock order is not ours to choose — no ordering of the TRUNCATE alone removes the cycle.

**Fix:** the truncate retries when it is the victim. The reader always completes, so the retry takes every lock uncontended. Bounded at five attempts with a small linear backoff, and gated on the deadlock SQLSTATE, so any real failure still surfaces immediately instead of being retried into a timeout.

This makes the harness resilient rather than eliminating the leftover in-flight query; a test whose app leaks a background loop past its own lifetime is still worth fixing where it is found.

## Verification

`INTEGRATION_TEST_WORKERS=4 vitest run --project integration` locally: 77 files / 1101 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)