### PR TITLE
fix(web): retry runtime config after startup failure

### DIFF
--- a/packages/web/src/lib/public-env.tsx
+++ b/packages/web/src/lib/public-env.tsx
@@ -95,15 +95,16 @@ async function resolve(): Promise<Record<string, string>> {
   const relayUrl = process.env.RELAY_URL ?? process.env.PUBLIC_RELAY_URL ?? process.env.NEXT_PUBLIC_RELAY_URL
   if (relayUrl) env.RELAY_URL = relayUrl
 
-  // CP_INTERNAL_URL is deployment topology and remains a bootstrap env value.
-  // The CP snapshot supplies only DB-owned auth state. Browser-facing service
-  // routes stay owned by this Web process because their public path can differ
-  // from the CP's daemon/control origin (for example apiHost /v1 rewrites to
-  // the CP's internal /api/v1 mount). Cache the first attempt, including absence
-  // or failure, so configuration never hot-reloads between requests.
+  // Cache a successful CP snapshot (including configured absence) but retry transient startup failures.
   if (process.env.CP_INTERNAL_URL) {
-    deploymentEnv ??= loadDeploymentEnv().catch(() => null)
-    const persisted = await deploymentEnv
+    deploymentEnv ??= loadDeploymentEnv()
+    const pending = deploymentEnv
+    let persisted: Record<string, string> | null = null
+    try {
+      persisted = await pending
+    } catch {
+      if (deploymentEnv === pending) deploymentEnv = undefined
+    }
     if (persisted) {
       for (const key of ['LOGTO_ENDPOINT', 'LOGTO_APP_ID', 'LOGTO_API_RESOURCE', 'SOCIAL_PROVIDERS']) {
         delete env[key]


### PR DESCRIPTION
## Summary

- retry the Control Plane runtime-config fetch after a transient startup failure
- continue caching successful snapshots, including an explicitly unconfigured auth state

## Root cause

The web server cached the first rejected runtime-config request as `null`. If Web became ready before the Control Plane during a rollout, every later request omitted the public Logto configuration until Web was restarted.

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web exec eslint src/lib/public-env.tsx`
- pre-push repository lint (zero errors; two unrelated existing warnings)

Created by Codex . GPT-5.6
