### PR TITLE
feat(operator): separate a missing credential Secret from pod startup delay

### DIFF
--- a/charts/operator/templates/operator-rbac.yaml
+++ b/charts/operator/templates/operator-rbac.yaml
@@ -63,6 +63,10 @@ rules:
   - apiGroups: ['']
     resources: ['pods']
     verbs: ['get', 'list', 'watch']
+  # FailedMount events are the only place the kubelet names a Secret it could not mount.
+  - apiGroups: ['']
+    resources: ['events']
+    verbs: ['get', 'list']
   - apiGroups: ['apps']
     resources: ['deployments']
     verbs: ['get', 'list', 'watch', 'create', 'patch', 'delete']

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -70,7 +70,7 @@ only if CRD conversion webhooks become necessary.
 | `config.ts`                   | zod env, fail-fast: prefix + tokenreview ClusterRole (required), master template prefix, resync interval, lease name, watch timeout.                                                                                     | done          |
 | `crd/types.ts`                | Group/kind/finalizer/annotation/condition constants + zod spec/status schemas.                                                                                                                                           | done          |
 | `crd/api.ts`                  | Typed verbs over the thin client: get/list/own-namespace watch, merge-patch meta (finalizers), `/status` patch.                                                                                                          | done          |
-| `workqueue.ts`                | Per-key serialized, coalescing queue with per-key failure backoff.                                                                                                                                                       | done          |
+| `workqueue.ts`                | Per-key serialized, coalescing queue with per-key failure backoff, plus the delayed follow-up a pass asks for when its own reading was provisional.                                                                      | done          |
 | `controller.ts`               | Leader-gated term: CR watch + secondary Deployment/Pod watches (label `agentconnect.md/org`, mapped to the owning CR, filtered to known CRs) + bounded resync ticker.                                                    | done          |
 | `reconcile/reconcile.ts`      | Dispatch: deletion path vs ensure-finalizer → envelope → rollout → gateway policies → status.                                                                                                                            | done          |
 | `reconcile/resources.ts`      | Server-side-apply/get/delete primitives, path builders, and the envelope's fixed object names.                                                                                                                           | done          |
@@ -145,8 +145,20 @@ reconcile pass:
 8. `ensureDaemonPvc` — ReadWriteOncePod (the Recreate strategy assumes
    single-attach).
 9. `ensureDaemonDeployment` — strategy Recreate; required credential Secret
-   volume (kubelet gates startup; `CredentialReady` derives from pod state);
-   `credentialRevision` annotation forces rotation rollouts.
+   volume (kubelet gates startup); `credentialRevision` annotation forces
+   rotation rollouts. `CredentialReady` derives from pod state plus the pod's
+   `FailedMount` events, which is where the kubelet — and only the kubelet —
+   names a Secret it could not mount: a blocked mount reads
+   `False/CredentialSecretMissing`, an unplaced pod
+   `Unknown/DaemonPodUnschedulable`, any other stall `False/DaemonPodNotReady`.
+   An Event is only believed while it is still being re-emitted and the pod is
+   still awaiting container creation, so one retained past its fix cannot
+   describe a mount that now works. Reading Events keeps the no-Secret-verbs
+   boundary intact, and a forbidden events read only costs the nuance, never
+   the status pass. An Event can also be written after the pod's last update,
+   which no watch would wake the operator for, so the provisional verdict asks
+   the queue for one follow-up pass a minute later rather than waiting for the
+   full resync.
 10. `ensureDaemonService` — ClusterIP for relay ingress and shim dial-in.
 
 Deletion (finalizer `agentconnect.md/org-envelope`): quiesce → delete

--- a/packages/operator/src/controller.ts
+++ b/packages/operator/src/controller.ts
@@ -3,7 +3,7 @@ import { watchCollection, type K8sHttp, type K8sObject } from '@agentconnect.md/
 import type { OperatorConfig } from './config.js'
 import type { AgentConnectOrgApi } from './crd/api.js'
 import { ORG_LABEL } from './crd/types.js'
-import { WorkQueue } from './workqueue.js'
+import { WorkQueue, type WorkResult } from './workqueue.js'
 
 interface LabeledObject extends K8sObject {
   metadata?: K8sObject['metadata'] & { labels?: Record<string, string> }
@@ -13,7 +13,7 @@ export interface ControllerOptions {
   http: K8sHttp
   orgApi: AgentConnectOrgApi
   config: OperatorConfig
-  reconcile: (name: string) => Promise<void>
+  reconcile: (name: string) => Promise<WorkResult | void>
   clock?: Clock
   log?: { debug?: (message: string) => void; warn?: (message: string) => void }
 }
@@ -47,7 +47,8 @@ interface Term {
 /**
  * Leader-gated control loop: the primary CR watch in the control namespace,
  * secondary Deployment/Pod watches mapped back to the owning CR (status
- * timeliness — CredentialReady must not wait for resync), and the bounded
+ * timeliness — CredentialReady must not wait for resync), the short follow-up
+ * a pass can ask for when its own reading was provisional, and the bounded
  * full-resync ticker that converges everything else. All term-scoped: losing
  * the lease aborts every watch and drains the queue.
  */

--- a/packages/operator/src/reconcile/context.ts
+++ b/packages/operator/src/reconcile/context.ts
@@ -28,7 +28,9 @@ export interface Observations {
   daemon?: { ready: boolean; image?: string }
   /** Deployment has not converged to its desired replica count yet. */
   progressing: boolean
-  credential?: { status: 'True' | 'False' | 'Unknown'; reason: string }
+  credential?: { status: 'True' | 'False' | 'Unknown'; reason: string; message?: string }
+  /** This pass read a provisional state; ask the queue for one more look after this delay. */
+  recheckAfterMs?: number
   sandboxes?: { total: number; running: number; suspended: number }
   pools?: AgentConnectOrgStatus['pools']
   rollout?: AgentConnectOrgStatus['rollout']

--- a/packages/operator/src/reconcile/reconcile.ts
+++ b/packages/operator/src/reconcile/reconcile.ts
@@ -6,19 +6,20 @@ import { daemonPodsGone, reconcileDeletion, suspendAllSandboxes } from './finali
 import { renderGatewayPolicies } from './gateway-limits.js'
 import { reconcileRollout } from './rollout.js'
 import { observeWorkloads, writeStatus } from './status.js'
+import type { WorkResult } from '../workqueue.js'
 
 /** One level-triggered pass for one org: read live state, dispatch, publish status. */
-export async function reconcile(ctx: ReconcileContext, name: string): Promise<void> {
+export async function reconcile(ctx: ReconcileContext, name: string): Promise<WorkResult> {
   let org: AgentConnectOrg
   try {
     org = await ctx.orgApi.get(name)
   } catch (error) {
-    if (error instanceof K8sApiError && error.isNotFound) return
+    if (error instanceof K8sApiError && error.isNotFound) return {}
     throw error
   }
   if (org.metadata?.deletionTimestamp) {
     await reconcileDeletion(ctx, org)
-    return
+    return {}
   }
   if (!(org.metadata?.finalizers ?? []).includes(FINALIZER)) {
     org = await ctx.orgApi.updateFinalizer(name, FINALIZER, 'add')
@@ -29,7 +30,7 @@ export async function reconcile(ctx: ReconcileContext, name: string): Promise<vo
   if (!parsed.success) {
     obs.degraded = { reason: 'InvalidSpec', message: parsed.error.issues.map((issue) => issue.message).join('; ') }
     await writeStatus(ctx, org, obs)
-    return
+    return {}
   }
   const input: EnvelopeInputs = { orgName: name, spec: parsed.data }
   await reconcileEnvelope(ctx, input, obs)
@@ -47,4 +48,6 @@ export async function reconcile(ctx: ReconcileContext, name: string): Promise<vo
   await renderGatewayPolicies(ctx, input, obs)
   if (obs.namespaceReady) await observeWorkloads(ctx, input, obs)
   await writeStatus(ctx, org, obs)
+  // A provisional observation asks for one more look; no watch fires for a state only an Event describes.
+  return obs.recheckAfterMs !== undefined ? { requeueAfterMs: obs.recheckAfterMs } : {}
 }

--- a/packages/operator/src/reconcile/status.test.ts
+++ b/packages/operator/src/reconcile/status.test.ts
@@ -5,7 +5,7 @@ import { loadConfig } from '../config.js'
 import { AgentConnectOrgApi } from '../crd/api.js'
 import type { AgentConnectOrg, Condition } from '../crd/types.js'
 import { newObservations, type Observations } from './context.js'
-import { buildStatus, setCondition, writeStatus } from './status.js'
+import { buildStatus, setCondition, writeStatus, CREDENTIAL_RECHECK_MS } from './status.js'
 
 afterEach(closeFakeApiServers)
 
@@ -80,6 +80,19 @@ describe('buildStatus', () => {
     expect(byType(third, 'Ready')?.lastTransitionTime).toBe(LATER)
   })
 
+  it('carries the credential message onto the CredentialReady condition', () => {
+    const obs = healthyObs()
+    obs.credential = {
+      status: 'False',
+      reason: 'CredentialSecretMissing',
+      message: 'daemon pod cannot mount credential secret ac-daemon-token'
+    }
+    const condition = byType(buildStatus(orgOf(), obs, NOW), 'CredentialReady')
+    expect(condition?.status).toBe('False')
+    expect(condition?.reason).toBe('CredentialSecretMissing')
+    expect(condition?.message).toContain('ac-daemon-token')
+  })
+
   it('marks Progressing during a runtime rollout and carries the rollout record', () => {
     const obs = healthyObs()
     obs.rollout = { rolloutId: 'abc123', targetImage: 'ghcr.io/example/runtime:v2', pending: ['sb-1'], failed: [] }
@@ -91,19 +104,36 @@ describe('buildStatus', () => {
 })
 
 describe('observeWorkloads', () => {
-  async function observe(deployment: unknown, extra: (path: string) => object | undefined = () => undefined) {
-    const { config: cluster } = await fakeApiServer(({ url }) => {
+  interface ObserveOptions {
+    pods?: unknown[]
+    events?: unknown[]
+    /** Non-2xx status for the events endpoint — an install whose RBAC predates the read. */
+    eventsStatus?: number
+    daemonSpec?: Record<string, unknown>
+    suspend?: boolean
+    /** Any other collection this case cares about, keyed off the request path. */
+    extra?: (path: string) => object | undefined
+  }
+
+  async function observe(deployment: unknown, options: ObserveOptions = {}) {
+    const { pods = [], events = [], eventsStatus, daemonSpec = {}, suspend = false } = options
+    const extra = options.extra ?? (() => undefined)
+    const { config: cluster, requests } = await fakeApiServer(({ url }) => {
       const path = url.pathname
       if (path.endsWith('/deployments/ac-daemon')) return { json: deployment as object }
+      if (path.endsWith('/pods')) return { json: { items: pods } }
+      if (path.endsWith('/events'))
+        return eventsStatus ? { status: eventsStatus, json: { message: 'forbidden' } } : { json: { items: events } }
       return { json: extra(path) ?? { items: [] } }
     })
     const http = new K8sHttp(cluster)
+    const warnings: string[] = []
     const ctx = {
       http,
       orgApi: new AgentConnectOrgApi(http, cluster.namespace),
       config: loadConfig({ AC_ORG_NAMESPACE_PREFIX: 'test-ac-org-', AC_TOKENREVIEW_CLUSTERROLE: 'x' }),
       controlNamespace: cluster.namespace,
-      log: {}
+      log: { warn: (message: string) => warnings.push(message) }
     }
     const obs = newObservations()
     const { AgentConnectOrgSpecSchema } = await import('../crd/types.js')
@@ -111,18 +141,43 @@ describe('observeWorkloads', () => {
       orgName: 'acme',
       spec: AgentConnectOrgSpecSchema.parse({
         targetNamespace: 'test-ac-org-acme',
-        daemon: { image: 'ghcr.io/example/daemon:v2', tier: 'small' },
+        suspend,
+        daemon: { image: 'ghcr.io/example/daemon:v2', tier: 'small', ...daemonSpec },
         runtime: { image: 'x', tiers: [] }
       })
     }
     const { observeWorkloads } = await import('./status.js')
     await observeWorkloads(ctx, input, obs)
-    return obs
+    return { obs, requests, warnings }
   }
+
+  /** The kubelet's own wording for a Secret-backed volume it cannot mount; re-emitted while it keeps failing. */
+  const failedMountEvent = (podName: string, message: string, agoMs = 30_000) => ({
+    reason: 'FailedMount',
+    involvedObject: { kind: 'Pod', name: podName },
+    message,
+    lastTimestamp: new Date(Date.now() - agoMs).toISOString()
+  })
+
+  const convergedDeployment = {
+    metadata: { generation: 2 },
+    spec: { replicas: 1, template: { spec: { containers: [{ image: 'ghcr.io/example/daemon:v2' }] } } },
+    status: { observedGeneration: 2, readyReplicas: 1, updatedReplicas: 1 }
+  }
+
+  /** A pod the kubelet has accepted but whose containers are still not up. */
+  const startingPod = (name = 'ac-daemon-0') => ({
+    metadata: { name },
+    status: {
+      phase: 'Pending',
+      conditions: [{ type: 'PodScheduled', status: 'True' }],
+      containerStatuses: [{ ready: false, state: { waiting: { reason: 'ContainerCreating' } } }]
+    }
+  })
 
   it('does not report the target image Ready off the old pod`s stale readyReplicas', async () => {
     // Image just swapped: generation advanced, but readyReplicas still counts the old pod.
-    const obs = await observe({
+    const { obs } = await observe({
       metadata: { generation: 2 },
       spec: { replicas: 1, template: { spec: { containers: [{ image: 'ghcr.io/example/daemon:v2' }] } } },
       status: { observedGeneration: 1, readyReplicas: 1, updatedReplicas: 0 }
@@ -132,7 +187,7 @@ describe('observeWorkloads', () => {
   })
 
   it('reports Ready once the updated pod itself is the ready one', async () => {
-    const obs = await observe({
+    const { obs } = await observe({
       metadata: { generation: 2 },
       spec: { replicas: 1, template: { spec: { containers: [{ image: 'ghcr.io/example/daemon:v2' }] } } },
       status: { observedGeneration: 2, readyReplicas: 1, updatedReplicas: 1 }
@@ -142,27 +197,32 @@ describe('observeWorkloads', () => {
   })
 
   it('summarizes warm pools from readyReplicas and counts bound claims per pool', async () => {
-    const obs = await observe({ spec: { replicas: 1 } }, (path) => {
-      if (path.endsWith('/sandboxwarmpools'))
-        return {
-          items: [
-            { metadata: { name: 'ac-runtime-small' }, status: { replicas: 3, readyReplicas: 2 } },
-            // A pool the vendor has not populated yet: status carries the selector only.
-            { metadata: { name: 'ac-runtime-large' }, status: { selector: 'warm-pool-sandbox=abc' } }
-          ]
+    const { obs } = await observe(
+      { spec: { replicas: 1 } },
+      {
+        extra: (path) => {
+          if (path.endsWith('/sandboxwarmpools'))
+            return {
+              items: [
+                { metadata: { name: 'ac-runtime-small' }, status: { replicas: 3, readyReplicas: 2 } },
+                // A pool the vendor has not populated yet: status carries the selector only.
+                { metadata: { name: 'ac-runtime-large' }, status: { selector: 'warm-pool-sandbox=abc' } }
+              ]
+            }
+          if (path.endsWith('/sandboxclaims'))
+            return {
+              items: [
+                { spec: { warmPoolRef: { name: 'ac-runtime-small' } }, status: { sandbox: { name: 'sb-1' } } },
+                { spec: { warmPoolRef: { name: 'ac-runtime-small' } }, status: { sandbox: { name: 'sb-2' } } },
+                // Not bound yet — it holds no Sandbox, so it is not claimed capacity.
+                { spec: { warmPoolRef: { name: 'ac-runtime-small' } }, status: {} },
+                { spec: { warmPoolRef: { name: 'ac-runtime-large' } }, status: { sandbox: { name: 'sb-3' } } }
+              ]
+            }
+          return undefined
         }
-      if (path.endsWith('/sandboxclaims'))
-        return {
-          items: [
-            { spec: { warmPoolRef: { name: 'ac-runtime-small' } }, status: { sandbox: { name: 'sb-1' } } },
-            { spec: { warmPoolRef: { name: 'ac-runtime-small' } }, status: { sandbox: { name: 'sb-2' } } },
-            // Not bound yet — it holds no Sandbox, so it is not claimed capacity.
-            { spec: { warmPoolRef: { name: 'ac-runtime-small' } }, status: {} },
-            { spec: { warmPoolRef: { name: 'ac-runtime-large' } }, status: { sandbox: { name: 'sb-3' } } }
-          ]
-        }
-      return undefined
-    })
+      }
+    )
     expect(obs.pools).toEqual([
       { name: 'ac-runtime-small', warmAvailable: 2, claimed: 2 },
       { name: 'ac-runtime-large', warmAvailable: 0, claimed: 1 }
@@ -170,13 +230,219 @@ describe('observeWorkloads', () => {
   })
 
   it('does not list claims when the namespace has no warm pools', async () => {
-    const seen: string[] = []
-    const obs = await observe({ spec: { replicas: 1 } }, (path) => {
-      seen.push(path)
-      return undefined
-    })
+    const { obs, requests } = await observe({ spec: { replicas: 1 } })
     expect(obs.pools).toEqual([])
-    expect(seen.some((path) => path.endsWith('/sandboxclaims'))).toBe(false)
+    expect(requests.some((url) => url.pathname.endsWith('/sandboxclaims'))).toBe(false)
+  })
+
+  it('reports CredentialReady Unknown when no daemon pod exists yet', async () => {
+    const { obs } = await observe(convergedDeployment)
+    expect(obs.credential).toEqual({ status: 'Unknown', reason: 'NoDaemonPod' })
+  })
+
+  it('reports CredentialReady True once every container of a pod is ready', async () => {
+    const pod = {
+      metadata: { name: 'ac-daemon-0' },
+      status: { phase: 'Running', containerStatuses: [{ ready: true }] }
+    }
+    const { obs } = await observe(convergedDeployment, { pods: [pod] })
+    expect(obs.credential).toEqual({ status: 'True', reason: 'DaemonRunning' })
+  })
+
+  it('names the credential secret when the kubelet cannot build the container config', async () => {
+    const pod = {
+      metadata: { name: 'ac-daemon-0' },
+      status: {
+        phase: 'Pending',
+        initContainerStatuses: [{ ready: false, state: { waiting: { reason: 'CreateContainerConfigError' } } }]
+      }
+    }
+    const { obs } = await observe(convergedDeployment, {
+      pods: [pod],
+      daemonSpec: { credentialSecretName: 'org-daemon-credentials' }
+    })
+    expect(obs.credential?.status).toBe('False')
+    expect(obs.credential?.reason).toBe('CredentialSecretMissing')
+    expect(obs.credential?.message).toContain('org-daemon-credentials')
+  })
+
+  it('reads the pod`s FailedMount event as the missing credential secret, not a startup delay', async () => {
+    const { obs, requests } = await observe(convergedDeployment, {
+      pods: [startingPod()],
+      events: [
+        failedMountEvent(
+          'ac-daemon-0',
+          'MountVolume.SetUp failed for volume "config" : secret "ac-daemon-token" not found'
+        )
+      ]
+    })
+    expect(obs.credential?.status).toBe('False')
+    expect(obs.credential?.reason).toBe('CredentialSecretMissing')
+    expect(obs.credential?.message).toContain('ac-daemon-token')
+    // Scoped server-side to the one reason worth reading, so the pass never lists a namespace's whole event stream.
+    const eventQuery = requests.find((url) => url.pathname.endsWith('/events'))?.searchParams.get('fieldSelector')
+    expect(eventQuery).toBe('involvedObject.kind=Pod,reason=FailedMount')
+  })
+
+  it('does not blame the credential for another volume`s mount failure', async () => {
+    const { obs } = await observe(convergedDeployment, {
+      pods: [startingPod()],
+      events: [
+        failedMountEvent(
+          'ac-daemon-0',
+          'MountVolume.SetUp failed for volume "state" : timed out waiting for the condition'
+        )
+      ]
+    })
+    expect(obs.credential).toEqual({ status: 'False', reason: 'DaemonPodNotReady' })
+  })
+
+  it('accepts the events.k8s.io series heartbeat as the occurrence time', async () => {
+    const { obs } = await observe(convergedDeployment, {
+      pods: [startingPod()],
+      events: [
+        {
+          reason: 'FailedMount',
+          involvedObject: { kind: 'Pod', name: 'ac-daemon-0' },
+          message: 'MountVolume.SetUp failed for volume "config" : secret "ac-daemon-token" not found',
+          eventTime: new Date(Date.now() - 20 * 60_000).toISOString(),
+          series: { lastObservedTime: new Date(Date.now() - 30_000).toISOString() }
+        }
+      ]
+    })
+    expect(obs.credential?.reason).toBe('CredentialSecretMissing')
+  })
+
+  it('still believes a persistent failure whose events the recorder has throttled', async () => {
+    // Correlator burst drained: one admitted update per five minutes, so ~6 min between visible timestamps.
+    const { obs } = await observe(convergedDeployment, {
+      pods: [startingPod()],
+      events: [
+        failedMountEvent(
+          'ac-daemon-0',
+          'MountVolume.SetUp failed for volume "config" : secret "ac-daemon-token" not found',
+          6 * 60_000
+        )
+      ]
+    })
+    expect(obs.credential?.reason).toBe('CredentialSecretMissing')
+  })
+
+  it('lets a retained event go stale instead of describing a mount that was fixed', async () => {
+    const { obs } = await observe(convergedDeployment, {
+      pods: [startingPod()],
+      events: [
+        failedMountEvent(
+          'ac-daemon-0',
+          'MountVolume.SetUp failed for volume "config" : secret "ac-daemon-token" not found',
+          30 * 60_000
+        )
+      ]
+    })
+    expect(obs.credential).toEqual({ status: 'False', reason: 'DaemonPodNotReady' })
+  })
+
+  it('drops the event once the pod is stuck on something other than creating its containers', async () => {
+    // Secret created, mount succeeded, image is the new blocker — the retained event must not keep the old reason.
+    const pulling = {
+      metadata: { name: 'ac-daemon-0' },
+      status: {
+        phase: 'Pending',
+        conditions: [{ type: 'PodScheduled', status: 'True' }],
+        initContainerStatuses: [{ ready: false, state: { waiting: { reason: 'ImagePullBackOff' } } }]
+      }
+    }
+    const { obs } = await observe(convergedDeployment, {
+      pods: [pulling],
+      events: [
+        failedMountEvent(
+          'ac-daemon-0',
+          'MountVolume.SetUp failed for volume "config" : secret "ac-daemon-token" not found'
+        )
+      ]
+    })
+    expect(obs.credential).toEqual({ status: 'False', reason: 'DaemonPodNotReady' })
+  })
+
+  it('does not blame a credential whose name merely appears in another object`s failure', async () => {
+    // A Secret named `state` shares its name with the daemon PVC's volume; only a Secret reference counts.
+    const { obs } = await observe(convergedDeployment, {
+      pods: [startingPod()],
+      daemonSpec: { credentialSecretName: 'state' },
+      events: [
+        failedMountEvent(
+          'ac-daemon-0',
+          'MountVolume.SetUp failed for volume "state" : persistentvolumeclaim "ac-daemon-state" not found'
+        )
+      ]
+    })
+    expect(obs.credential).toEqual({ status: 'False', reason: 'DaemonPodNotReady' })
+  })
+
+  it('accepts the namespaced wording the kubelet also uses for an unreadable secret', async () => {
+    const { obs } = await observe(convergedDeployment, {
+      pods: [startingPod()],
+      events: [failedMountEvent('ac-daemon-0', "Couldn't get secret test-ac-org-acme/ac-daemon-token: not found")]
+    })
+    expect(obs.credential?.reason).toBe('CredentialSecretMissing')
+  })
+
+  it('ignores a FailedMount event belonging to some other pod', async () => {
+    const { obs } = await observe(convergedDeployment, {
+      pods: [startingPod()],
+      events: [
+        failedMountEvent(
+          'ac-runtime-7',
+          'MountVolume.SetUp failed for volume "config" : secret "ac-daemon-token" not found'
+        )
+      ]
+    })
+    expect(obs.credential).toEqual({ status: 'False', reason: 'DaemonPodNotReady' })
+  })
+
+  it('keeps the status pass alive when the events read is forbidden', async () => {
+    const { obs, warnings } = await observe(convergedDeployment, { pods: [startingPod()], eventsStatus: 403 })
+    expect(obs.credential).toEqual({ status: 'False', reason: 'DaemonPodNotReady' })
+    expect(warnings.some((warning) => warning.includes('FailedMount'))).toBe(true)
+    // The rest of the pass still ran.
+    expect(obs.daemon?.ready).toBe(true)
+  })
+
+  it('reports an unscheduled pod as Unknown rather than blaming the credential', async () => {
+    const pod = {
+      metadata: { name: 'ac-daemon-0' },
+      status: { phase: 'Pending', conditions: [{ type: 'PodScheduled', status: 'False', reason: 'Unschedulable' }] }
+    }
+    const { obs, requests } = await observe(convergedDeployment, { pods: [pod] })
+    expect(obs.credential?.status).toBe('Unknown')
+    expect(obs.credential?.reason).toBe('DaemonPodUnschedulable')
+    // No kubelet ever saw the pod, so the events read is skipped entirely.
+    expect(requests.some((url) => url.pathname.endsWith('/events'))).toBe(false)
+  })
+
+  it('keeps an ordinary not-ready pod on DaemonPodNotReady and asks for one more look', async () => {
+    const { obs } = await observe(convergedDeployment, { pods: [startingPod()] })
+    expect(obs.credential).toEqual({ status: 'False', reason: 'DaemonPodNotReady' })
+    // The FailedMount event can be written after the pod's last update, which no watch would wake us for.
+    expect(obs.recheckAfterMs).toBe(CREDENTIAL_RECHECK_MS)
+  })
+
+  it('asks for no follow-up once the verdict is settled', async () => {
+    const ready = {
+      metadata: { name: 'ac-daemon-0' },
+      status: { phase: 'Running', containerStatuses: [{ ready: true }] }
+    }
+    expect((await observe(convergedDeployment, { pods: [ready] })).obs.recheckAfterMs).toBeUndefined()
+    const blocked = await observe(convergedDeployment, {
+      pods: [startingPod()],
+      events: [failedMountEvent('ac-daemon-0', 'secret "ac-daemon-token" not found')]
+    })
+    expect(blocked.obs.recheckAfterMs).toBeUndefined()
+  })
+
+  it('reports a suspended org as Unknown without inspecting pods', async () => {
+    const { obs } = await observe(convergedDeployment, { pods: [startingPod()], suspend: true })
+    expect(obs.credential).toEqual({ status: 'Unknown', reason: 'Suspended' })
   })
 })
 

--- a/packages/operator/src/reconcile/status.ts
+++ b/packages/operator/src/reconcile/status.ts
@@ -35,8 +35,35 @@ interface DeploymentRead {
   status?: { observedGeneration?: number; readyReplicas?: number; updatedReplicas?: number }
 }
 
+interface ContainerStatusRead {
+  ready?: boolean
+  state?: { waiting?: { reason?: string } }
+}
+
+interface PodRead {
+  metadata?: { name?: string }
+  status?: {
+    phase?: string
+    conditions?: Array<{ type?: string; status?: string }>
+    containerStatuses?: ContainerStatusRead[]
+    initContainerStatuses?: ContainerStatusRead[]
+  }
+}
+
 interface PodList {
-  items?: Array<{ status?: { phase?: string; containerStatuses?: Array<{ ready?: boolean }> } }>
+  items?: PodRead[]
+}
+
+interface EventRead {
+  involvedObject?: { name?: string }
+  message?: string
+  lastTimestamp?: string
+  eventTime?: string
+  series?: { lastObservedTime?: string }
+}
+
+interface EventList {
+  items?: EventRead[]
 }
 
 interface SandboxList {
@@ -50,6 +77,126 @@ interface WarmPoolList {
 
 interface ClaimList {
   items?: Array<{ spec?: { warmPoolRef?: { name?: string } }; status?: { sandbox?: { name?: string } } }>
+}
+
+/** Every declared container reported ready — an empty list means the kubelet has not started any yet. */
+function isPodReady(pod: PodRead): boolean {
+  const containers = pod.status?.containerStatuses ?? []
+  return containers.length > 0 && containers.every((status) => status.ready === true)
+}
+
+/** The kubelet cannot build a container config it cannot resolve; the daemon pod's only such reference is the Secret. */
+function hasCredentialConfigError(pod: PodRead): boolean {
+  const containers = [...(pod.status?.initContainerStatuses ?? []), ...(pod.status?.containerStatuses ?? [])]
+  return containers.some((status) => status.state?.waiting?.reason === 'CreateContainerConfigError')
+}
+
+/** Pending with the scheduler refusing to place the pod — nothing has read the Secret yet. */
+function isUnschedulable(pod: PodRead): boolean {
+  return (
+    pod.status?.phase === 'Pending' &&
+    (pod.status.conditions ?? []).some((condition) => condition.type === 'PodScheduled' && condition.status === 'False')
+  )
+}
+
+/** Sized to the recorder, not the kubelet: mounts retry about every two minutes, but once the correlator's
+ *  burst drains it admits one update per five minutes per object, so API-visible ones can be ~6 min apart. */
+const FAILED_MOUNT_FRESH_MS = 15 * 60_000
+
+/** Newest occurrence across both Event shapes: core aggregation and the events.k8s.io series. Absent reads as stale. */
+function lastOccurrenceMs(event: EventRead): number {
+  const stamps = [event.series?.lastObservedTime, event.lastTimestamp, event.eventTime]
+    .map((value) => (value ? Date.parse(value) : Number.NaN))
+    .filter((ms) => !Number.isNaN(ms))
+  return stamps.length > 0 ? Math.max(...stamps) : 0
+}
+
+/** No container has been created yet — the state a blocked mount leaves the pod in, and the corroboration
+ *  that keeps a retained Event from outliving the fault it described. */
+function isAwaitingContainerCreate(pod: PodRead): boolean {
+  const containers = [...(pod.status?.initContainerStatuses ?? []), ...(pod.status?.containerStatuses ?? [])]
+  return containers.length === 0 || containers.some((status) => status.state?.waiting?.reason === 'ContainerCreating')
+}
+
+/** The name has to appear as the Secret the kubelet could not read — the wordings it uses to say so.
+ *  A bare substring would blame the credential for a PVC that merely shares the name. */
+function namesCredentialSecret(message: string, namespace: string, secretName: string): boolean {
+  return [`secret "${secretName}"`, `secrets "${secretName}"`, `secret ${namespace}/${secretName}`].some((form) =>
+    message.includes(form)
+  )
+}
+
+/** A Secret-backed volume the kubelet cannot mount surfaces only as a FailedMount Event; pod.status never names it. */
+async function hasFailedCredentialMount(
+  ctx: ReconcileContext,
+  namespace: string,
+  pods: PodRead[],
+  secretName: string
+): Promise<boolean> {
+  const names = new Set(
+    pods
+      .filter(isAwaitingContainerCreate)
+      .map((pod) => pod.metadata?.name)
+      .filter((name): name is string => Boolean(name))
+  )
+  if (names.size === 0) return false
+  let events: EventList
+  try {
+    events = await ctx.http.json<EventList>({
+      method: 'GET',
+      path: corePath(namespace, 'events'),
+      query: { fieldSelector: 'involvedObject.kind=Pod,reason=FailedMount' }
+    })
+  } catch (error) {
+    // Best-effort: an install whose RBAC predates this read must lose the nuance, not the whole status pass.
+    ctx.log.warn?.(`${namespace}: FailedMount events unreadable: ${(error as Error).message}`)
+    return false
+  }
+  // Matched on how the message names the Secret, so the daemon's own PVC is never read as a credential fault,
+  // and on the newest occurrence so an Event retained past its fix cannot keep describing a resolved mount.
+  const cutoff = Date.now() - FAILED_MOUNT_FRESH_MS
+  return (events.items ?? []).some(
+    (event) =>
+      names.has(event.involvedObject?.name ?? '') &&
+      namesCredentialSecret(event.message ?? '', namespace, secretName) &&
+      lastOccurrenceMs(event) >= cutoff
+  )
+}
+
+/** A FailedMount Event can be written after the pod's last update, which no watch would wake us for. */
+export const CREDENTIAL_RECHECK_MS = 60_000
+
+interface CredentialVerdict {
+  credential: NonNullable<Observations['credential']>
+  /** Set when the verdict is provisional: the pod is up to nothing yet and only an Event can refine it. */
+  recheckAfterMs?: number
+}
+
+/** CredentialReady exists to report the Secret mount, so separate it from ordinary scheduling and startup delay. */
+async function observeCredential(
+  ctx: ReconcileContext,
+  namespace: string,
+  pods: PodRead[],
+  secretName: string
+): Promise<CredentialVerdict> {
+  if (pods.length === 0) return { credential: { status: 'Unknown', reason: 'NoDaemonPod' } }
+  if (pods.some(isPodReady)) return { credential: { status: 'True', reason: 'DaemonRunning' } }
+  const missing = {
+    credential: {
+      status: 'False',
+      reason: 'CredentialSecretMissing',
+      message: `daemon pod cannot mount credential secret ${secretName}`
+    }
+  } as const
+  if (pods.some(hasCredentialConfigError)) return missing
+  // An unplaced pod never reached a kubelet, so no mount was attempted and there is no Event worth reading.
+  // The scheduler keeps updating the PodScheduled condition while it retries, so a watch wakes the next pass.
+  if (pods.every(isUnschedulable))
+    return {
+      credential: { status: 'Unknown', reason: 'DaemonPodUnschedulable', message: 'daemon pod is not scheduled yet' }
+    }
+  if (await hasFailedCredentialMount(ctx, namespace, pods, secretName)) return missing
+  return { credential: { status: 'False', reason: 'DaemonPodNotReady' }, recheckAfterMs: CREDENTIAL_RECHECK_MS }
 }
 
 /** Read the live workload state the status summaries derive from. */
@@ -79,11 +226,11 @@ export async function observeWorkloads(ctx: ReconcileContext, input: EnvelopeInp
   })
   const daemonPods = pods.items ?? []
   // CredentialReady derives from pod state: the required Secret mount is the only startup gate.
-  if (input.spec.suspend) obs.credential = { status: 'Unknown', reason: 'Suspended' }
-  else if (daemonPods.some((pod) => pod.status?.containerStatuses?.every((status) => status.ready)))
-    obs.credential = { status: 'True', reason: 'DaemonRunning' }
-  else if (daemonPods.length > 0) obs.credential = { status: 'False', reason: 'DaemonPodNotReady' }
-  else obs.credential = { status: 'Unknown', reason: 'NoDaemonPod' }
+  const verdict: CredentialVerdict = input.spec.suspend
+    ? { credential: { status: 'Unknown', reason: 'Suspended' } }
+    : await observeCredential(ctx, ns, daemonPods, input.spec.daemon.credentialSecretName)
+  obs.credential = verdict.credential
+  if (verdict.recheckAfterMs !== undefined) obs.recheckAfterMs = verdict.recheckAfterMs
   const sandboxes = await getOrNull<SandboxList>(ctx.http, groupPath(SANDBOX_GROUP, ns, 'sandboxes'))
   const items = sandboxes?.items ?? []
   const suspended = items.filter((sandbox) => sandbox.spec?.operatingMode === 'Suspended').length
@@ -134,7 +281,8 @@ export function buildStatus(org: AgentConnectOrg, obs: Observations, nowIso: str
   put({
     type: CONDITION_CREDENTIAL_READY,
     status: obs.credential?.status ?? 'Unknown',
-    reason: obs.credential?.reason ?? 'NotObserved'
+    reason: obs.credential?.reason ?? 'NotObserved',
+    message: obs.credential?.message
   })
   put({
     type: CONDITION_PROGRESSING,

--- a/packages/operator/src/workqueue.test.ts
+++ b/packages/operator/src/workqueue.test.ts
@@ -100,6 +100,70 @@ describe('WorkQueue', () => {
     await queue.shutdown()
   })
 
+  it('runs a key again after the delay its own pass asked for', async () => {
+    const clock = new FakeClock()
+    let runs = 0
+    const queue = new WorkQueue(
+      async () => {
+        runs += 1
+        // Only the first pass reads a provisional state; the follow-up settles it.
+        return runs === 1 ? { requeueAfterMs: 60_000 } : {}
+      },
+      { clock }
+    )
+    queue.add('a')
+    await waitUntil(() => runs === 1)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(runs).toBe(1)
+    expect(queue.size).toBe(1)
+    clock.advance(60_000)
+    await waitUntil(() => runs === 2)
+    // The settled pass asks for nothing, so the key goes idle.
+    await waitUntil(() => queue.size === 0)
+    await queue.shutdown()
+  })
+
+  it('lets a watch event supersede a pending follow-up instead of running twice', async () => {
+    const clock = new FakeClock()
+    let runs = 0
+    const queue = new WorkQueue(
+      async () => {
+        runs += 1
+        return runs === 1 ? { requeueAfterMs: 60_000 } : {}
+      },
+      { clock }
+    )
+    queue.add('a')
+    await waitUntil(() => runs === 1)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    // A pod update arrives first: it runs now and cancels the timer armed for later.
+    queue.add('a')
+    await waitUntil(() => runs === 2)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    clock.advance(60_000)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(runs).toBe(2)
+    await queue.shutdown()
+  })
+
+  it('shutdown drops pending follow-ups and waits for in-flight work', async () => {
+    const clock = new FakeClock()
+    let runs = 0
+    const queue = new WorkQueue(
+      async () => {
+        runs += 1
+        return { requeueAfterMs: 60_000 }
+      },
+      { clock }
+    )
+    queue.add('a')
+    await waitUntil(() => runs === 1)
+    await queue.shutdown()
+    clock.advance(60_000)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(runs).toBe(1)
+  })
+
   it('shutdown drops pending retries and waits for in-flight work', async () => {
     const clock = new FakeClock()
     let attempts = 0

--- a/packages/operator/src/workqueue.ts
+++ b/packages/operator/src/workqueue.ts
@@ -13,13 +13,21 @@ interface KeyState {
   dirty: boolean
   backoff: Backoff
   retryTimer?: TimerHandle
+  /** A handler-requested follow-up pass; any earlier wake supersedes it. */
+  requeueTimer?: TimerHandle
+}
+
+/** What one pass reports back: a delay after which the key is worth looking at again. */
+export interface WorkResult {
+  requeueAfterMs?: number
 }
 
 /**
  * Per-key serialized, coalescing work queue with failure backoff — the
  * controller-runtime rate-limited-queue equivalent for a level-triggered
- * reconciler: N adds while running collapse into one follow-up pass, and a
- * failing key retries alone on its own growing delay.
+ * reconciler: N adds while running collapse into one follow-up pass, a failing
+ * key retries alone on its own growing delay, and a pass may ask to be run
+ * again after a delay when it knows its own reading was provisional.
  */
 export class WorkQueue {
   private readonly states = new Map<string, KeyState>()
@@ -30,7 +38,7 @@ export class WorkQueue {
   private readonly inFlight = new Set<Promise<void>>()
 
   constructor(
-    private readonly handler: (key: string) => Promise<void>,
+    private readonly handler: (key: string) => Promise<WorkResult | void>,
     options: WorkQueueOptions = {}
   ) {
     this.clock = options.clock ?? systemClock
@@ -42,10 +50,7 @@ export class WorkQueue {
     if (this.shuttingDown) return
     const state = this.states.get(key) ?? { running: false, dirty: false, backoff: this.newBackoff() }
     this.states.set(key, state)
-    if (state.retryTimer !== undefined) {
-      this.clock.clearTimeout(state.retryTimer)
-      state.retryTimer = undefined
-    }
+    this.clearTimers(state)
     if (state.running) {
       state.dirty = true
       return
@@ -53,12 +58,30 @@ export class WorkQueue {
     this.run(key, state)
   }
 
-  /** Stops retry timers and waits for in-flight passes to finish. */
+  /** Run the key again after `delayMs` unless a watch, a retry, or another add gets there first. */
+  addAfter(key: string, delayMs: number): void {
+    if (this.shuttingDown) return
+    const state = this.states.get(key) ?? { running: false, dirty: false, backoff: this.newBackoff() }
+    this.states.set(key, state)
+    if (state.running || state.dirty || state.retryTimer !== undefined || state.requeueTimer !== undefined) return
+    state.requeueTimer = this.clock.setTimeout(() => {
+      state.requeueTimer = undefined
+      this.add(key)
+    }, delayMs)
+  }
+
+  private clearTimers(state: KeyState): void {
+    for (const slot of ['retryTimer', 'requeueTimer'] as const) {
+      if (state[slot] !== undefined) this.clock.clearTimeout(state[slot])
+      state[slot] = undefined
+    }
+  }
+
+  /** Stops pending timers and waits for in-flight passes to finish. */
   async shutdown(): Promise<void> {
     this.shuttingDown = true
     for (const state of this.states.values()) {
-      if (state.retryTimer !== undefined) this.clock.clearTimeout(state.retryTimer)
-      state.retryTimer = undefined
+      this.clearTimers(state)
       state.dirty = false
     }
     await Promise.allSettled([...this.inFlight])
@@ -67,9 +90,10 @@ export class WorkQueue {
   private run(key: string, state: KeyState): void {
     state.running = true
     const pass = this.handler(key)
-      .then(() => {
+      .then((result) => {
         state.backoff = this.newBackoff()
         this.finish(key, state)
+        if (result?.requeueAfterMs !== undefined) this.addAfter(key, result.requeueAfterMs)
       })
       .catch((error: unknown) => {
         this.log?.warn?.(`reconcile of ${key} failed: ${String(error)}`)
@@ -99,7 +123,7 @@ export class WorkQueue {
     this.states.delete(key)
   }
 
-  /** Live key states — retry timers and in-flight passes only. */
+  /** Live key states — pending timers and in-flight passes only. */
   get size(): number {
     return this.states.size
   }


### PR DESCRIPTION
## Why

`CredentialReady` exists for one reason: the daemon Deployment mounts its credential Secret non-optionally, so the kubelet gates pod startup on that Secret existing. But `observeWorkloads` collapsed every not-ready daemon pod into `False/DaemonPodNotReady` — a Secret that was never written looked exactly like a pod that is still pulling its image or waiting for a node.

## What

`observeWorkloads` now classifies the observed daemon pods, in precedence order:

| Observation | Condition |
| --- | --- |
| No daemon pod | `Unknown/NoDaemonPod` (unchanged) |
| Every container of some pod ready | `True/DaemonRunning` (unchanged) |
| `CreateContainerConfigError` waiting reason (init or app container) | `False/CredentialSecretMissing`, message naming `spec.daemon.credentialSecretName` |
| All pods `Pending` with `PodScheduled=False` | `Unknown/DaemonPodUnschedulable` |
| A `FailedMount` Event on one of those pods whose message names the credential Secret | `False/CredentialSecretMissing` |
| Anything else | `False/DaemonPodNotReady` (unchanged) |

A Secret-backed volume the kubelet cannot mount is only ever visible as a `FailedMount` **Event** — the pod just sits `Pending` with `ContainerCreating` and ordinary conditions — so that read is the one that makes the distinction real. It is scoped server-side (`fieldSelector=involvedObject.kind=Pod,reason=FailedMount`), matched to the daemon pods by `involvedObject.name`, and to the credential by the Secret name appearing in the message, so the daemon's own PVC failing to mount is never mislabeled. A failing events read warns and falls back to `DaemonPodNotReady` rather than losing the whole status pass.

**Waking up for it.** An Event is an independent object, and the controller watches only Deployments and Pods, so the Event can land after the pod's last update and no watch fires. The queue therefore grows a delayed follow-up: a pass may return `{ requeueAfterMs }`, and any earlier wake (watch event, failure retry, resync, another add) cancels it. Only the provisional `DaemonPodNotReady` verdict asks for one, 60s out — a ready, unschedulable, or already-blamed pod asks for nothing, so a settled org never polls. The unschedulable branch needs no follow-up either: the scheduler keeps updating `PodScheduled` as it retries, which the Pod watch already sees.

`Suspended` still short-circuits before any pod is inspected. Readiness now also requires a non-empty container-status list, so a pod whose kubelet has not reported any container yet cannot vacuously satisfy `every`.

The envelope ClusterRole gains `events: [get, list]` — no Secret verbs and no cluster-wide event watch, so the operator's no-Secret-read boundary and its watch footprint are both intact. `docs/designs/agentconnect-org-operator.md` §3/§4.9 record the reason set, the Event read, and the follow-up pass.

## Verification

- `pnpm --filter @agentconnect.md/operator test` (72 tests) — `observeWorkloads` cases for each branch against the fake API server (matching event, another volume's failure, another pod's event, forbidden read, the field selector, the skipped read for an unschedulable pod, the follow-up hint), plus three `WorkQueue` cases for the delayed re-run, an add superseding it, and shutdown dropping it.
- `pnpm --filter @agentconnect.md/operator typecheck`, `pnpm lint`, `prettier --check`, `helm lint charts/operator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)