### PR TITLE
fix(operator): read warm-pool summaries from the real SandboxWarmPool status

### DIFF
--- a/packages/operator/src/reconcile/status.test.ts
+++ b/packages/operator/src/reconcile/status.test.ts
@@ -91,12 +91,11 @@ describe('buildStatus', () => {
 })
 
 describe('observeWorkloads', () => {
-  async function observe(deployment: unknown) {
+  async function observe(deployment: unknown, extra: (path: string) => object | undefined = () => undefined) {
     const { config: cluster } = await fakeApiServer(({ url }) => {
       const path = url.pathname
       if (path.endsWith('/deployments/ac-daemon')) return { json: deployment as object }
-      if (path.endsWith('/pods')) return { json: { items: [] } }
-      return { json: { items: [] } }
+      return { json: extra(path) ?? { items: [] } }
     })
     const http = new K8sHttp(cluster)
     const ctx = {
@@ -140,6 +139,44 @@ describe('observeWorkloads', () => {
     })
     expect(obs.daemon?.ready).toBe(true)
     expect(obs.progressing).toBe(false)
+  })
+
+  it('summarizes warm pools from readyReplicas and counts bound claims per pool', async () => {
+    const obs = await observe({ spec: { replicas: 1 } }, (path) => {
+      if (path.endsWith('/sandboxwarmpools'))
+        return {
+          items: [
+            { metadata: { name: 'ac-runtime-small' }, status: { replicas: 3, readyReplicas: 2 } },
+            // A pool the vendor has not populated yet: status carries the selector only.
+            { metadata: { name: 'ac-runtime-large' }, status: { selector: 'warm-pool-sandbox=abc' } }
+          ]
+        }
+      if (path.endsWith('/sandboxclaims'))
+        return {
+          items: [
+            { spec: { warmPoolRef: { name: 'ac-runtime-small' } }, status: { sandbox: { name: 'sb-1' } } },
+            { spec: { warmPoolRef: { name: 'ac-runtime-small' } }, status: { sandbox: { name: 'sb-2' } } },
+            // Not bound yet — it holds no Sandbox, so it is not claimed capacity.
+            { spec: { warmPoolRef: { name: 'ac-runtime-small' } }, status: {} },
+            { spec: { warmPoolRef: { name: 'ac-runtime-large' } }, status: { sandbox: { name: 'sb-3' } } }
+          ]
+        }
+      return undefined
+    })
+    expect(obs.pools).toEqual([
+      { name: 'ac-runtime-small', warmAvailable: 2, claimed: 2 },
+      { name: 'ac-runtime-large', warmAvailable: 0, claimed: 1 }
+    ])
+  })
+
+  it('does not list claims when the namespace has no warm pools', async () => {
+    const seen: string[] = []
+    const obs = await observe({ spec: { replicas: 1 } }, (path) => {
+      seen.push(path)
+      return undefined
+    })
+    expect(obs.pools).toEqual([])
+    expect(seen.some((path) => path.endsWith('/sandboxclaims'))).toBe(false)
   })
 })
 

--- a/packages/operator/src/reconcile/status.ts
+++ b/packages/operator/src/reconcile/status.ts
@@ -43,11 +43,13 @@ interface SandboxList {
   items?: Array<{ spec?: { operatingMode?: string } }>
 }
 
+// SandboxWarmPool status is exactly {replicas, readyReplicas, selector} — there is no claimed count on the pool.
 interface WarmPoolList {
-  items?: Array<{
-    metadata?: { name?: string }
-    status?: { availableReplicas?: number; readyReplicas?: number; claimedReplicas?: number }
-  }>
+  items?: Array<{ metadata?: { name?: string }; status?: { readyReplicas?: number } }>
+}
+
+interface ClaimList {
+  items?: Array<{ spec?: { warmPoolRef?: { name?: string } }; status?: { sandbox?: { name?: string } } }>
 }
 
 /** Read the live workload state the status summaries derive from. */
@@ -87,12 +89,26 @@ export async function observeWorkloads(ctx: ReconcileContext, input: EnvelopeInp
   const suspended = items.filter((sandbox) => sandbox.spec?.operatingMode === 'Suspended').length
   obs.sandboxes = { total: items.length, running: items.length - suspended, suspended }
   const pools = await getOrNull<WarmPoolList>(ctx.http, groupPath(SANDBOX_EXTENSIONS_GROUP, ns, 'sandboxwarmpools'))
+  const poolItems = pools?.items ?? []
+  // Adoption strips the warm-pool label, so readyReplicas counts only unclaimed members — claimed comes from the claims.
+  const claimed = poolItems.length > 0 ? await countBoundClaims(ctx, ns) : new Map<string, number>()
   // Observation record only: absent vendor status fields read as 0, never as a guess.
-  obs.pools = (pools?.items ?? []).map((pool) => ({
-    name: pool.metadata?.name ?? '',
-    warmAvailable: pool.status?.availableReplicas ?? pool.status?.readyReplicas ?? 0,
-    claimed: pool.status?.claimedReplicas ?? 0
-  }))
+  obs.pools = poolItems.map((pool) => {
+    const name = pool.metadata?.name ?? ''
+    return { name, warmAvailable: pool.status?.readyReplicas ?? 0, claimed: claimed.get(name) ?? 0 }
+  })
+}
+
+/** Bound SandboxClaims per warm pool — a claim counts only once it actually holds a Sandbox. */
+async function countBoundClaims(ctx: ReconcileContext, ns: string): Promise<Map<string, number>> {
+  const claims = await getOrNull<ClaimList>(ctx.http, groupPath(SANDBOX_EXTENSIONS_GROUP, ns, 'sandboxclaims'))
+  const counts = new Map<string, number>()
+  for (const claim of claims?.items ?? []) {
+    const pool = claim.spec?.warmPoolRef?.name
+    if (!pool || !claim.status?.sandbox?.name) continue
+    counts.set(pool, (counts.get(pool) ?? 0) + 1)
+  }
+  return counts
 }
 
 /** Build the full status from this pass's observations; the operator is the only status writer. */


### PR DESCRIPTION
Verified the two agent-sandbox vendor-API assumptions the operator's status and rollout paths make, against a live cluster running `agent-sandbox-controller:v0.5.4`.

## `SandboxWarmPool` status field names were wrong

`kubectl explain` and the CRD's own OpenAPI schema agree with upstream `SandboxWarmPoolStatus`: the status is exactly

```
replicas       int32
readyReplicas  int32
selector       string
```

There is no `availableReplicas` and no `claimedReplicas`. The CRD schema sets no `x-kubernetes-preserve-unknown-fields`, so those two names could never appear — `claimed` was pinned to `0` in every published `AgentConnectOrg` status, and `warmAvailable` only worked by falling through to its second choice.

This reads `warmAvailable` from `readyReplicas`. That is the right source rather than a rename of convenience: claim adoption removes the warm-pool label from the sandbox so it drops out of the pool selector, which means `readyReplicas` already counts only ready, unclaimed members.

`claimed` has no source on the pool, so it now comes from the `SandboxClaim`s that reference it — counted only once a claim actually holds a Sandbox (`status.sandbox.name` set), so a pending claim is not reported as consumed capacity. The extra list is skipped when the namespace has no pools, and the operator Role already grants `list` on `sandboxclaims`, so no RBAC change is needed.

## The Sandbox image patch was already correct — no change

The conditioned JSON patch in `reconcile/rollout.ts` was checked end to end on a throwaway Sandbox in a scratch namespace, which was deleted afterwards:

- `spec.podTemplate` carries no immutability rule. The only CEL transition rule on `Sandbox.spec` is `volumeClaimTemplates is immutable`, and no admission webhook for `agents.x-k8s.io` is installed.
- The patch applied to a `Suspended` Sandbox was accepted, bumped `generation`, and the controller did **not** revert it.
- Resuming that Sandbox produced a pod running the patched image, so the mutation is honored rather than ignored.
- The same patch against a `Running` Sandbox failed on the `test` op with **HTTP 422 Unprocessable Entity** — exactly the status `K8sApiError.isUnprocessable` already swallows, so the concurrent-wake-up race is handled as intended.

## Verification

`pnpm --filter @agentconnect.md/operator test` (59 passed) and `typecheck`, plus `pnpm lint` and `prettier --check` on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
