### PR TITLE
fix(k8s-client): stamp Lease times as MicroTime so leader election works

### DIFF
--- a/packages/k8s-client/src/lease.test.ts
+++ b/packages/k8s-client/src/lease.test.ts
@@ -19,6 +19,20 @@ interface StoredLease {
   spec: Record<string, unknown>
 }
 
+/** MicroTime as the API server parses it: RFC3339 with exactly six fractional digits. */
+const MICRO_TIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/
+
+/** A stamp shaped the way the API server would have stored it, for seeded holders. */
+const EPOCH_MICRO = '1970-01-01T00:00:00.000000Z'
+
+/** The real server 400s a mistyped stamp; the fake must too, or the wire format goes untested. */
+function malformedStamp(spec: Record<string, unknown>): string | undefined {
+  return ['acquireTime', 'renewTime'].find((field) => {
+    const value = spec[field]
+    return typeof value === 'string' && !MICRO_TIME.test(value)
+  })
+}
+
 /** Tiny stateful Lease endpoint: 404 until created, resourceVersion-guarded writes. */
 function leaseStore(initial?: StoredLease['spec']): { route: FakeRoute; current: () => StoredLease | undefined } {
   let lease: StoredLease | undefined = initial
@@ -30,6 +44,8 @@ function leaseStore(initial?: StoredLease['spec']): { route: FakeRoute; current:
       return lease ? { json: lease } : { status: 404, json: { kind: 'Status', reason: 'NotFound' } }
     }
     const incoming = JSON.parse(body) as { metadata?: { resourceVersion?: string }; spec: Record<string, unknown> }
+    const bad = malformedStamp(incoming.spec)
+    if (bad) return { status: 400, json: { kind: 'Status', reason: 'BadRequest', message: `${bad} is not MicroTime` } }
     if (method === 'POST') {
       if (lease) return { status: 409, json: { kind: 'Status', reason: 'AlreadyExists' } }
       lease = { metadata: { name: 'op', namespace: 'org-test', resourceVersion: `${++version}` }, spec: incoming.spec }
@@ -72,6 +88,21 @@ describe('LeaseElector', () => {
     await run
   })
 
+  it('stamps acquireTime and renewTime as MicroTime', async () => {
+    const { route, current } = leaseStore()
+    const { config } = await fakeApiServer(route)
+    const clock = new FakeClock(1_700_000_000_123)
+    const events: string[] = []
+    const lease = elector(new K8sHttp(config), clock, events)
+    const run = lease.start()
+    await waitUntil(() => events.includes('started'))
+    // Six fractional digits, not Date#toISOString's three — the API server rejects the latter outright.
+    expect(current()?.spec.renewTime).toBe('2023-11-14T22:13:20.123000Z')
+    expect(current()?.spec.acquireTime).toBe('2023-11-14T22:13:20.123000Z')
+    await lease.stop()
+    await run
+  })
+
   it('renews while holding without re-firing onStartedLeading', async () => {
     const { route, current } = leaseStore()
     const { config } = await fakeApiServer(route)
@@ -93,7 +124,7 @@ describe('LeaseElector', () => {
     const held = {
       holderIdentity: 'pod-b',
       leaseDurationSeconds: 15,
-      renewTime: new Date(0).toISOString(),
+      renewTime: EPOCH_MICRO,
       leaseTransitions: 0
     }
     const { route, current } = leaseStore(held)
@@ -114,7 +145,7 @@ describe('LeaseElector', () => {
     const held = {
       holderIdentity: 'pod-b',
       leaseDurationSeconds: 15,
-      renewTime: new Date(0).toISOString(),
+      renewTime: EPOCH_MICRO,
       leaseTransitions: 3
     }
     const { route, current } = leaseStore(held)
@@ -140,7 +171,7 @@ describe('LeaseElector', () => {
         return {
           json: {
             metadata: { name: 'op', namespace: 'org-test', resourceVersion: `${gets}` },
-            spec: { holderIdentity: 'pod-b', leaseDurationSeconds: 15, renewTime: new Date(0).toISOString() }
+            spec: { holderIdentity: 'pod-b', leaseDurationSeconds: 15, renewTime: EPOCH_MICRO }
           }
         }
       }

--- a/packages/k8s-client/src/lease.ts
+++ b/packages/k8s-client/src/lease.ts
@@ -30,6 +30,11 @@ export interface LeaseElectorOptions {
 
 const DEFAULT_LEASE_DURATION_SECONDS = 15
 
+/** Lease stamps are MicroTime — the API server demands exactly six fractional digits, toISOString gives three. */
+function microTime(epochMs: number): string {
+  return new Date(epochMs).toISOString().replace(/\.(\d{3})Z$/, '.$1000Z')
+}
+
 /** Clock-driven abortable delay; mirrors the watch loop's listener-safe sleep. */
 function sleep(clock: Clock, ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) return Promise.resolve()
@@ -150,7 +155,7 @@ export class LeaseElector {
   }
 
   private heldSpec(nowMs: number, transitions: number): Lease['spec'] {
-    const stamp = new Date(nowMs).toISOString()
+    const stamp = microTime(nowMs)
     return {
       holderIdentity: this.identity,
       leaseDurationSeconds: this.leaseDurationSeconds,


### PR DESCRIPTION
## The bug

`LeaseElector` never acquires a Lease against a real API server, so the operator elects no leader and its control loop never runs.

A Lease's `spec.acquireTime` / `spec.renewTime` are `MicroTime`, which the API server parses with the layout `2006-01-02T15:04:05.000000Z07:00` — exactly six fractional digits. `Date#toISOString()` emits three, and Go's parser rejects the short form outright rather than zero-filling it:

```
Lease in version "v1" cannot be handled as a Lease:
parsing time "2026-08-11T19:37:19.103Z" as "2006-01-02T15:04:05.000000Z07:00":
cannot parse ".103Z" as ".000000"
```

Every create and every renew returns 400, so no Lease object is ever written. The elector treats the failure as a tick error and retries forever, which is why the pods look healthy: they stay `Running`, `1/1`, with zero restarts.

## How it surfaced

Installing `charts/operator` (`1.41.0-rc.57`) on a live cluster. Both replicas came up `Running` and logged the parse error once per renew interval, while `kubectl get lease -n <ns>` stayed empty and no reconcile ever ran.

## The fix

Pad the stamp to six digits. `Date` only carries millisecond resolution, so this widens the format without claiming precision we do not have; `Date.parse` reads the six-digit form back unchanged, so the follower's takeover comparison is unaffected.

## Verification

Re-running the same chart install with the patched `lease.js` mounted over the published image, on the same cluster:

- a `coordination.k8s.io` Lease appears with one holder and an advancing `renewTime`
- the leader watches its CRs — an applied `AgentConnectOrg` gets the `agentconnect.md/org-envelope` finalizer, and `status.observedGeneration` tracks `metadata.generation` across spec edits
- deleting the CR removes the finalizer and the object goes away in ~1.6s, exercising the conflict-safe `updateFinalizer` path
- deleting the leader pod hands off to the survivor in under 2s with `leaseTransitions` incrementing; the new leader re-enqueues and reconciles

## Why no test caught it

The fake API server stored timestamps as opaque strings, so the wire format was never asserted. It now returns 400 on a mistyped `acquireTime`/`renewTime` exactly as the real server does. That alone fails six of the existing election tests against the old code; the added test pins the emitted format directly.

Seeded holder fixtures move to a `MicroTime` literal so they match what a real server would have stored.