### PR TITLE
feat(operator-chart): fence the operator SA and sandbox pods with admission policies

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -2,6 +2,8 @@ apiVersion: v2
 name: agentconnect-operator
 description: AgentConnect cluster operator — reconciles AgentConnectOrg resources into per-org execution envelopes. One release per environment; multiple releases share one cluster via install-time constants.
 type: application
+# ValidatingAdmissionPolicy went GA in 1.30; the install's isolation fences are built on it.
+kubeVersion: '>=1.30.0-0'
 version: 0.1.0
 appVersion: 1.0.0-dev
 keywords:

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -14,6 +14,9 @@ constants — the release namespace and `orgNamespacePrefix`. Prefixes must not
 overlap between installs (in either direction), and must not be a prefix of any
 control namespace.
 
+Kubernetes 1.30 or newer is required (`kubeVersion` in `Chart.yaml`): the
+isolation fences below are `ValidatingAdmissionPolicy` objects, GA since 1.30.
+
 `installCRD` gates the cluster-shared pieces (the `AgentConnectOrg` CRD today;
 vendored agent-sandbox CRDs/controllers later):
 
@@ -23,6 +26,38 @@ vendored agent-sandbox CRDs/controllers later):
 
 The CRD template carries `helm.sh/resource-policy: keep`: uninstalling the
 release that installed it leaves the CRD (and every org) in place.
+
+## Admission policies
+
+Each release renders its own release-prefixed pair of `ValidatingAdmissionPolicy`
+objects from its two install-time constants. Both deny on failure — an
+expression that cannot be evaluated rejects the request.
+
+- **`<release>-ac-envelope-fence`** bounds this install's operator ServiceAccount.
+  Every write it makes must land in a namespace carrying `orgNamespacePrefix`;
+  the only exceptions are its own `AgentConnectOrg` resources and election Lease
+  in the release namespace. Namespaces it creates must carry the envelope org
+  labels and a `baseline`-or-stricter Pod Security level, and the only other
+  cluster-scoped objects it may write are the per-org TokenReview bindings.
+  RBAC already scopes the verbs; this scopes _where_ they may be used.
+- **`<release>-ac-sandbox-baseline`** applies to every pod in an org namespace
+  (selected by the `agentconnect.md/org-namespace` claim label, narrowed to this
+  install's prefix): no privileged containers, no host namespaces, no `hostPath`
+  volumes, and — for every pod except the daemon supervisor —
+  `automountServiceAccountToken: false`, with a projected token restricted to the
+  daemon callback audience as the only service-account token it may carry.
+
+**Marking control namespaces.** On a cluster shared by several installs, label
+each control namespace so no install's operator can write into another's, even
+if a prefix is later misconfigured to overlap it:
+
+```bash
+kubectl label namespace CONTROL_NAMESPACE agentconnect.md/control-namespace=''
+```
+
+The fence only tests for the key, so the value is free. Prefixes must still not
+overlap a control namespace name — the label is the second line of defense, not
+the first.
 
 ## Dependencies
 

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -36,7 +36,8 @@ expression that cannot be evaluated rejects the request.
 - **`<release>-ac-envelope-fence`** bounds this install's operator ServiceAccount.
   Every write it makes must land in a namespace carrying `orgNamespacePrefix`;
   the only exceptions are its own `AgentConnectOrg` resources and election Lease
-  in the release namespace. Namespaces it creates must carry the envelope org
+  in the release namespace. A namespace marked as a control namespace is neither
+  a write target nor an object it may delete or strip the marker from. Namespaces it creates must carry the envelope org
   labels and a `baseline`-or-stricter Pod Security level, and the only other
   cluster-scoped objects it may write are the per-org TokenReview bindings.
   RBAC already scopes the verbs; this scopes _where_ they may be used.

--- a/charts/operator/templates/NOTES.txt
+++ b/charts/operator/templates/NOTES.txt
@@ -15,6 +15,11 @@ The agent-sandbox CRDs and controllers (agents.x-k8s.io) are a required
 dependency that is not yet vendored by this chart — see deploy/k8s/README.md
 in the repository for the current manual installation steps.
 
+Sharing this cluster with another install? Mark every control namespace so no
+install's operator can write into another's:
+
+  kubectl label namespace {{ .Release.Namespace }} agentconnect.md/control-namespace=''
+
 Onboard an org by applying an AgentConnectOrg into {{ .Release.Namespace }}
 together with its daemon credential Secret in the target namespace.
 

--- a/charts/operator/templates/operator-rbac.yaml
+++ b/charts/operator/templates/operator-rbac.yaml
@@ -38,9 +38,10 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 # Cluster-scoped permissions for the org envelopes this install owns. Every
-# write is admission-fenced to the install's namespace prefix (TODO: VAPs);
-# no Secret verbs, ever. Server-side apply needs create+patch on everything
-# the operator stamps; delete covers the finalizer teardown.
+# write is admission-fenced to the install's namespace prefix by the envelope
+# fence in validating-admission-policies.yaml; no Secret verbs, ever. Server-side
+# apply needs create+patch on everything the operator stamps; delete covers the
+# finalizer teardown.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/operator/templates/validating-admission-policies.yaml
+++ b/charts/operator/templates/validating-admission-policies.yaml
@@ -1,12 +1,173 @@
-# TODO(chart): the install's ValidatingAdmissionPolicies, rendered from the two
-# install-time constants (operator SA identity, org namespace prefix):
-#   1. Envelope write fence for the operator SA — target namespace must start
-#      with {{ .Values.orgNamespacePrefix }}, never a namespace carrying the
-#      control marker label; required envelope labels present.
-#   2. Secure-sandbox workload baseline for org namespaces (no privileged /
-#      host namespaces / hostPath / SA-token automount; pinned image sources
-#      and runtimeClass), with the audience-scoped projected-token volume as
-#      the single shape-exact exception.
-#   3. Daemon SA Sandbox patches restricted to spec.operatingMode field-wise;
-#      rollout image/annotation writes allowed only for the operator SA.
-# Objects are release-prefixed; each install owns its own copies.
+{{- $operatorSa := printf "system:serviceaccount:%s:%s-operator" .Release.Namespace .Release.Name -}}
+{{- $prefix := .Values.orgNamespacePrefix -}}
+# Both policies are rendered from this install's two constants (operator SA identity,
+# org namespace prefix) and are release-prefixed: every install owns its own copies.
+# TODO(chart): a third fence — daemon SA Sandbox patches restricted to spec.operatingMode,
+# plus pinned image sources / runtimeClass — needs the vendored agent-sandbox schema.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ .Release.Name }}-ac-envelope-fence
+  labels:
+    app.kubernetes.io/name: agentconnect-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  # A fence that fails open is not a fence: an unevaluable request is denied.
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      # `*/*` covers subresources too, so a status write cannot slip past the prefix check.
+      - apiGroups: ['*']
+        apiVersions: ['*']
+        operations: ['CREATE', 'UPDATE', 'DELETE']
+        resources: ['*/*']
+        scope: '*'
+  matchConditions:
+    # Only this install's operator identity; every other writer is out of scope.
+    - name: operator-identity
+      expression: request.userInfo.username == '{{ $operatorSa }}'
+    # Its own control-namespace objects: the CRs it reconciles and its election Lease.
+    - name: exclude-own-control-objects
+      expression: >-
+        !(request.namespace == '{{ .Release.Namespace }}' && ((request.resource.group == 'agentconnect.md' &&
+        request.resource.resource == 'agentconnectorgs') || (request.resource.group == 'coordination.k8s.io' &&
+        request.resource.resource == 'leases')))
+  variables:
+    - name: isNamespace
+      expression: request.resource.group == '' && request.resource.resource == 'namespaces'
+    # DELETE carries the object in oldObject; CREATE/UPDATE in object.
+    - name: target
+      expression: 'object == null ? oldObject : object'
+    - name: labels
+      expression: 'has(variables.target.metadata.labels) ? variables.target.metadata.labels : {}'
+  validations:
+    - expression: request.namespace == '' || request.namespace.startsWith('{{ $prefix }}')
+      message: this install's operator may only write into namespaces carrying its org namespace prefix
+      reason: Forbidden
+    # Cross-install guard: another environment's control namespace is never a write target,
+    # even if a misconfigured prefix would otherwise match it. Namespace objects are checked
+    # by their own labels below, where namespaceObject is not populated.
+    - expression: >-
+        request.namespace == '' || variables.isNamespace ||
+        !('agentconnect.md/control-namespace' in (has(namespaceObject.metadata.labels) ?
+        namespaceObject.metadata.labels : {}))
+      message: this install's operator may not write into a namespace marked as a control namespace
+      reason: Forbidden
+    - expression: '!variables.isNamespace || variables.target.metadata.name.startsWith(''{{ $prefix }}'')'
+      message: this install's operator may only create, change or delete namespaces carrying its org namespace prefix
+      reason: Forbidden
+    # Envelope labels on the namespaces it stamps — the claim label the operator adopts by,
+    # the org label its list/watch selectors use, and Pod Security enforcement.
+    - expression: >-
+        !variables.isNamespace || object == null || ('agentconnect.md/org' in variables.labels &&
+        'agentconnect.md/org-namespace' in variables.labels &&
+        !('agentconnect.md/control-namespace' in variables.labels) &&
+        ('pod-security.kubernetes.io/enforce' in variables.labels) &&
+        variables.labels['pod-security.kubernetes.io/enforce'] in ['baseline', 'restricted'])
+      message: an org namespace must carry the envelope org labels and a baseline-or-stricter Pod Security level
+      reason: Forbidden
+    # The only cluster-scoped object the envelope owns besides the namespace is the per-org
+    # TokenReview binding (`ac-tokenreview-<targetNamespace>`, packages/operator/src/reconcile/resources.ts).
+    - expression: >-
+        request.namespace != '' || variables.isNamespace || (request.resource.group == 'rbac.authorization.k8s.io' &&
+        request.resource.resource == 'clusterrolebindings' &&
+        variables.target.metadata.name.startsWith('ac-tokenreview-{{ $prefix }}'))
+      message: the only cluster-scoped objects this install's operator may write are its org namespaces and their TokenReview bindings
+      reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ .Release.Name }}-ac-envelope-fence
+  labels:
+    app.kubernetes.io/name: agentconnect-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  policyName: {{ .Release.Name }}-ac-envelope-fence
+  validationActions: ['Deny']
+---
+# The workload baseline every pod in one of this install's org namespaces must meet.
+# Pods are the enforcement point rather than their controllers: agent-sandbox creates
+# sandbox pods from a template the operator copied, so a controller-level rule would
+# have to be written once per creating kind and would still miss a direct pod create.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ .Release.Name }}-ac-sandbox-baseline
+  labels:
+    app.kubernetes.io/name: agentconnect-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      # The ephemeralcontainers subresource carries a full pod object, so the same
+      # validations cover the one path that can add a container after creation.
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE', 'UPDATE']
+        resources: ['pods', 'pods/ephemeralcontainers']
+        scope: Namespaced
+  matchConditions:
+    # The binding selects org namespaces by claim label; this keeps each install to its own.
+    - name: this-installs-org-namespaces
+      expression: request.namespace.startsWith('{{ $prefix }}')
+  variables:
+    - name: containers
+      expression: >-
+        object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) +
+        (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+    - name: volumes
+      expression: 'has(object.spec.volumes) ? object.spec.volumes : []'
+    # The daemon supervisor is the one pod in the envelope with a real API identity: it
+    # creates SandboxClaims and reviews shim tokens. Keying on "not the daemon" rather than
+    # on the runtime SA name is deliberate — a pod naming no SA falls back to `default`,
+    # which automounts, and that pod must be caught too. Names: reconcile/resources.ts.
+    - name: isDaemonPod
+      expression: has(object.spec.serviceAccountName) && object.spec.serviceAccountName == 'ac-daemon'
+  validations:
+    - expression: >-
+        variables.containers.all(c, !has(c.securityContext) || !has(c.securityContext.privileged) ||
+        c.securityContext.privileged == false)
+      message: privileged containers are not allowed in an AgentConnect org namespace
+      reason: Forbidden
+    - expression: >-
+        (!has(object.spec.hostNetwork) || object.spec.hostNetwork == false) &&
+        (!has(object.spec.hostPID) || object.spec.hostPID == false) &&
+        (!has(object.spec.hostIPC) || object.spec.hostIPC == false)
+      message: host namespaces are not allowed in an AgentConnect org namespace
+      reason: Forbidden
+    - expression: variables.volumes.all(v, !has(v.hostPath))
+      message: hostPath volumes are not allowed in an AgentConnect org namespace
+      reason: Forbidden
+    - expression: >-
+        variables.isDaemonPod || (has(object.spec.automountServiceAccountToken) &&
+        object.spec.automountServiceAccountToken == false)
+      message: a sandbox pod must set automountServiceAccountToken false
+      reason: Forbidden
+    # The exception the shim handshake depends on, shape-exact: a projected token restricted
+    # to the daemon's audience (SHIM_TOKEN_AUDIENCE, packages/daemon/src/shim/protocol.ts) is
+    # useless anywhere else, so it is the only service-account token a sandbox may carry.
+    - expression: >-
+        variables.isDaemonPod || variables.volumes.all(v, !has(v.projected) || !has(v.projected.sources) ||
+        v.projected.sources.all(s, !has(s.serviceAccountToken) ||
+        s.serviceAccountToken.audience == 'ac-daemon-callback'))
+      message: a sandbox pod may only project a service-account token restricted to the daemon callback audience
+      reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ .Release.Name }}-ac-sandbox-baseline
+  labels:
+    app.kubernetes.io/name: agentconnect-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  policyName: {{ .Release.Name }}-ac-sandbox-baseline
+  validationActions: ['Deny']
+  matchResources:
+    # Org namespaces identify themselves by the claim label the operator stamps.
+    namespaceSelector:
+      matchExpressions:
+        - key: agentconnect.md/org-namespace
+          operator: Exists

--- a/charts/operator/templates/validating-admission-policies.yaml
+++ b/charts/operator/templates/validating-admission-policies.yaml
@@ -40,18 +40,29 @@ spec:
       expression: 'object == null ? oldObject : object'
     - name: labels
       expression: 'has(variables.target.metadata.labels) ? variables.target.metadata.labels : {}'
+    # The labels as they stand in the cluster; empty on CREATE, where nothing stands yet.
+    - name: oldLabels
+      expression: 'oldObject == null ? {} : (has(oldObject.metadata.labels) ? oldObject.metadata.labels : {})'
   validations:
     - expression: request.namespace == '' || request.namespace.startsWith('{{ $prefix }}')
       message: this install's operator may only write into namespaces carrying its org namespace prefix
       reason: Forbidden
     # Cross-install guard: another environment's control namespace is never a write target,
-    # even if a misconfigured prefix would otherwise match it. Namespace objects are checked
-    # by their own labels below, where namespaceObject is not populated.
+    # even if a misconfigured prefix would otherwise match it.
     - expression: >-
         request.namespace == '' || variables.isNamespace ||
         !('agentconnect.md/control-namespace' in (has(namespaceObject.metadata.labels) ?
         namespaceObject.metadata.labels : {}))
       message: this install's operator may not write into a namespace marked as a control namespace
+      reason: Forbidden
+    # The same guard for the Namespace object itself: it is cluster-scoped, so it carries no
+    # namespaceObject and an empty request.namespace, and the check above never sees it. Both
+    # sides are tested — oldObject so a marked namespace can be neither deleted nor stripped of
+    # its marker, object so a marked one cannot be created and later written into.
+    - expression: >-
+        !variables.isNamespace || (!('agentconnect.md/control-namespace' in variables.oldLabels) &&
+        !('agentconnect.md/control-namespace' in variables.labels))
+      message: this install's operator may not create, change or delete a namespace marked as a control namespace
       reason: Forbidden
     - expression: '!variables.isNamespace || variables.target.metadata.name.startsWith(''{{ $prefix }}'')'
       message: this install's operator may only create, change or delete namespaces carrying its org namespace prefix
@@ -61,7 +72,6 @@ spec:
     - expression: >-
         !variables.isNamespace || object == null || ('agentconnect.md/org' in variables.labels &&
         'agentconnect.md/org-namespace' in variables.labels &&
-        !('agentconnect.md/control-namespace' in variables.labels) &&
         ('pod-security.kubernetes.io/enforce' in variables.labels) &&
         variables.labels['pod-security.kubernetes.io/enforce'] in ['baseline', 'restricted'])
       message: an org namespace must carry the envelope org labels and a baseline-or-stricter Pod Security level

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -149,9 +149,11 @@ renders its own release-prefixed copies from its own constants (Kubernetes
   the only exceptions; namespaces it stamps must carry the org/claim labels and
   a `baseline`-or-stricter Pod Security level; the per-org TokenReview binding
   is the only other cluster-scoped object it may write. A control namespace
-  marked `agentconnect.md/control-namespace` is never a write target, which is
-  what protects a _neighbouring_ install from a prefix misconfigured to overlap
-  it.
+  marked `agentconnect.md/control-namespace` is never a write target, and the
+  marked namespace object itself can be neither deleted nor unmarked — that pair
+  is what protects a _neighbouring_ install from a prefix misconfigured to
+  overlap it. The Namespace object needs its own check because it is
+  cluster-scoped: no `namespaceObject`, and an empty `request.namespace`.
 - **sandbox baseline** — pods in an org namespace (claim label, narrowed to the
   install's prefix) may not be privileged, share host namespaces, or mount
   `hostPath`; every pod but the daemon supervisor must set

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -134,10 +134,31 @@ pieces (the CRD today, vendored agent-sandbox CRDs/controllers later); the CRD
 is a _templated_ resource (conditional + upgradable) carrying
 `helm.sh/resource-policy: keep` so no release uninstall can cascade-delete
 every org. Everything else is per-install: operator Deployment (2 replicas) +
-SA/RBAC, the release-prefixed tokenreview ClusterRole, admission policies
-(TODO), and a pre-delete hook that refuses uninstall while CRs remain —
-removing the operator would strand every finalizer. Publishing to the OCI
-registry rides the release pipeline (not yet wired).
+SA/RBAC, the release-prefixed tokenreview ClusterRole, two
+ValidatingAdmissionPolicies, and a pre-delete hook that refuses uninstall while
+CRs remain — removing the operator would strand every finalizer. Publishing to
+the OCI registry rides the release pipeline (not yet wired).
+
+The policies are the static half of the isolation story RBAC cannot express —
+RBAC grants verbs, admission bounds where they may be used — and each install
+renders its own release-prefixed copies from its own constants (Kubernetes
+≥ 1.30, both `failurePolicy: Fail`):
+
+- **envelope fence** — every write by the install's operator SA must target a
+  namespace carrying its prefix, its own control-namespace CRs and Lease being
+  the only exceptions; namespaces it stamps must carry the org/claim labels and
+  a `baseline`-or-stricter Pod Security level; the per-org TokenReview binding
+  is the only other cluster-scoped object it may write. A control namespace
+  marked `agentconnect.md/control-namespace` is never a write target, which is
+  what protects a _neighbouring_ install from a prefix misconfigured to overlap
+  it.
+- **sandbox baseline** — pods in an org namespace (claim label, narrowed to the
+  install's prefix) may not be privileged, share host namespaces, or mount
+  `hostPath`; every pod but the daemon supervisor must set
+  `automountServiceAccountToken: false`, and the audience-scoped projected token
+  the shim handshake needs is the only service-account token it may carry.
+  Pods are the enforcement point, so a sandbox created from an operator-copied
+  template is covered without teaching the policy about its controller.
 
 ## 6. Verification
 


### PR DESCRIPTION
Section 4 of the operator-chart follow-ups: the two ValidatingAdmissionPolicies that replace the TODO in `charts/operator/templates/validating-admission-policies.yaml`. RBAC grants verbs; it cannot say *where* they may be used, and that gap is the whole reason several environments can share a cluster only by convention today.

Both policies are rendered per install from its two constants (operator SA identity, `orgNamespacePrefix`) and are release-prefixed, so an install owns its own copies and never validates a neighbour's writes with its own constants. Both are `failurePolicy: Fail` — a fence that fails open is not a fence.

## `<release>-ac-envelope-fence`

Matched to `*/*` on CREATE/UPDATE/DELETE, then narrowed by a match condition to this install's operator ServiceAccount. `*/*` rather than `*` so a subresource write cannot slip past the prefix check.

A second match condition excludes the operator's own control-namespace objects — its `AgentConnectOrg` resources (including `/status`) and its election Lease. Without it the fence would deny the operator's own status patches and leader election, since the control namespace does not carry the org prefix. Those two are the complete set of control-namespace writes the operator makes; everything else it writes is either in a target namespace or cluster-scoped (verified against `reconcile/*.ts`, `crd/api.ts`, and the Lease elector).

Validations:

1. every namespaced write targets a namespace carrying `orgNamespacePrefix`;
2. never a namespace labelled `agentconnect.md/control-namespace` — the cross-install guard, which is what makes a *neighbouring* install safe from a prefix later misconfigured to overlap its control namespace;
3. namespace objects it creates, changes or deletes carry the prefix in their own name (checked on `object`, falling back to `oldObject` for DELETE);
4. namespaces it stamps carry `agentconnect.md/org` + `agentconnect.md/org-namespace`, no control marker, and `pod-security.kubernetes.io/enforce` of `baseline` or `restricted` — the operator cannot create an org namespace with Pod Security switched off;
5. the only cluster-scoped objects it may write are those namespaces and the per-org `ac-tokenreview-<targetNamespace>` bindings.

The control marker is applied by an administrator (`kubectl label namespace … agentconnect.md/control-namespace=''`); the chart cannot stamp it itself, because a release does not own its own namespace object — rendering one would break every install into a pre-existing namespace on Helm's ownership check. README and NOTES.txt both document the command, and the fence tests only for the key so the value is free.

## `<release>-ac-sandbox-baseline`

Bound to namespaces carrying the `agentconnect.md/org-namespace` claim label, narrowed by a match condition to this install's prefix. Pods are the enforcement point rather than their controllers: sandbox pods are created by agent-sandbox from a template the operator copied, so a controller-level rule would have to be written once per creating kind and would still miss a direct pod create. `pods/ephemeralcontainers` is matched too — it carries a full pod object, so the same validations cover the one path that can add a container after creation.

No privileged containers (containers + init + ephemeral), no `hostNetwork`/`hostPID`/`hostIPC`, no `hostPath` volumes, `automountServiceAccountToken: false`, and the audience-scoped projected token (`ac-daemon-callback`, `SHIM_TOKEN_AUDIENCE`) as the single allowed service-account-token shape — the shape `deploy/k8s/40-sandbox-pool.yaml` already uses.

The last two exempt the daemon supervisor, which is the one pod in an envelope with a real API identity. **Deliberate divergence worth reviewing:** the exemption is keyed on "is not `ac-daemon`" rather than on "uses the runtime SA". A pod that names no ServiceAccount falls back to `default`, which *does* automount — keying on the runtime SA name would let exactly that pod through with a live token.

## Also here

- `kubeVersion: '>=1.30.0-0'` in `Chart.yaml` — ValidatingAdmissionPolicy is GA since 1.30, and this is now a hard requirement rather than a nice-to-have.
- The chart README grows an "Admission policies" section (including the marker-label command); NOTES.txt prints the command on install; the RBAC template's `TODO: VAPs` comment now points at the rendered fence; design doc §5 replaces "admission policies (TODO)" with what they actually enforce.
- One TODO survives at the top of the template: the third fence sketched in the original comment (daemon SA `Sandbox` patches restricted field-wise to `spec.operatingMode`, plus pinned image sources / runtimeClass) needs the agent-sandbox schema, which arrives with the vendoring work.

## Verification

`helm lint charts/operator` passes; `helm template` renders under default values and under a non-default set (different release name, namespace, prefix, `installCRD=false`), and the rendered CEL was parsed back out of the YAML and read expression by expression to confirm the folded scalars join cleanly. `pnpm format:check` passes.

No cluster in the loop, so the CEL has **not** been compiled by an API server — the expressions were written against the documented VAP variable set (`object` null on DELETE, `oldObject` null on CREATE, `namespaceObject` null for cluster-scoped requests, `has()` guards on every optional field) and reviewed by hand. The one construct worth a second reader's eye is validation 2's `namespaceObject` access, guarded by `request.namespace == '' || variables.isNamespace ||` so it is never reached on a request where `namespaceObject` can be absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
