### PR TITLE
feat(cluster): complete the runtime-image drain handshake

### DIFF
--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -1,6 +1,7 @@
 # AgentConnectOrg CRD + Operator
 
-**Status:** Envelope, status, deletion, and rollout reconcile logic implemented; gateway policy rendering waits on the gateway spike.
+**Status:** Envelope, status, deletion, and rollout reconcile logic implemented — including the
+drain handshake with the daemon and its timeout; gateway policy rendering waits on the gateway spike.
 
 The managed execution plane provisions one _org envelope_ per organization on a
 Kubernetes cluster: a namespace, RBAC, network policies, sandbox templates and
@@ -63,21 +64,44 @@ only if CRD conversion webhooks become necessary.
 
 ## 3. Operator modules (`packages/operator/src/`)
 
-| Module                        | Role                                                                                                                                                                                                                                                                   | State         |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `index.ts`                    | Bin entry: config → in-cluster client → elector → controller; SIGTERM drains.                                                                                                                                                                                          | done          |
-| `config.ts`                   | zod env, fail-fast: prefix + tokenreview ClusterRole (required), master template prefix, resync interval, lease name, watch timeout.                                                                                                                                   | done          |
-| `crd/types.ts`                | Group/kind/finalizer/annotation/condition constants + zod spec/status schemas.                                                                                                                                                                                         | done          |
-| `crd/api.ts`                  | Typed verbs over the thin client: get/list/own-namespace watch, merge-patch meta (finalizers), `/status` patch.                                                                                                                                                        | done          |
-| `workqueue.ts`                | Per-key serialized, coalescing queue with per-key failure backoff.                                                                                                                                                                                                     | done          |
-| `controller.ts`               | Leader-gated term: CR watch + secondary Deployment/Pod watches (label `agentconnect.md/org`, mapped to the owning CR, filtered to known CRs) + bounded resync ticker.                                                                                                  | done          |
-| `reconcile/reconcile.ts`      | Dispatch: deletion path vs ensure-finalizer → envelope → rollout → gateway policies → status.                                                                                                                                                                          | done          |
-| `reconcile/resources.ts`      | Server-side-apply/get/delete primitives, path builders, and the envelope's fixed object names.                                                                                                                                                                         | done          |
-| `reconcile/envelope.ts`       | The ordered inventory implemented over SSA (see §4).                                                                                                                                                                                                                   | done          |
-| `reconcile/status.ts`         | `setCondition`, live workload observation, and the full condition/summary builder.                                                                                                                                                                                     | done          |
-| `reconcile/finalizer.ts`      | Deletion order implemented; only claimed, prefix-owned namespaces are touched.                                                                                                                                                                                         | done          |
-| `reconcile/rollout.ts`        | Conditioned image patch for Suspended instances; Running ones are reported `pending` and converge when they naturally sleep. The drain-requested handshake (producer + daemon consumer) lands together with the daemon milestone; drain timeouts → `failed` also TODO. | partial       |
-| `reconcile/gateway-limits.ts` | llmLimits/llmDeny → gateway policy kinds (pinned by the gateway spike).                                                                                                                                                                                                | **TODO stub** |
+| Module                        | Role                                                                                                                                                                                                                     | State         |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `index.ts`                    | Bin entry: config → in-cluster client → elector → controller; SIGTERM drains.                                                                                                                                            | done          |
+| `config.ts`                   | zod env, fail-fast: prefix + tokenreview ClusterRole (required), master template prefix, resync interval, lease name, watch timeout.                                                                                     | done          |
+| `crd/types.ts`                | Group/kind/finalizer/annotation/condition constants + zod spec/status schemas.                                                                                                                                           | done          |
+| `crd/api.ts`                  | Typed verbs over the thin client: get/list/own-namespace watch, merge-patch meta (finalizers), `/status` patch.                                                                                                          | done          |
+| `workqueue.ts`                | Per-key serialized, coalescing queue with per-key failure backoff.                                                                                                                                                       | done          |
+| `controller.ts`               | Leader-gated term: CR watch + secondary Deployment/Pod watches (label `agentconnect.md/org`, mapped to the owning CR, filtered to known CRs) + bounded resync ticker.                                                    | done          |
+| `reconcile/reconcile.ts`      | Dispatch: deletion path vs ensure-finalizer → envelope → rollout → gateway policies → status.                                                                                                                            | done          |
+| `reconcile/resources.ts`      | Server-side-apply/get/delete primitives, path builders, and the envelope's fixed object names.                                                                                                                           | done          |
+| `reconcile/envelope.ts`       | The ordered inventory implemented over SSA (see §4).                                                                                                                                                                     | done          |
+| `reconcile/status.ts`         | `setCondition`, live workload observation, and the full condition/summary builder.                                                                                                                                       | done          |
+| `reconcile/finalizer.ts`      | Deletion order implemented; only claimed, prefix-owned namespaces are touched.                                                                                                                                           | done          |
+| `reconcile/rollout.ts`        | The runtime-image rollout: conditioned image patch for Suspended instances, drain-requested handshake for Running ones, stale-request sweep, and the drain deadline that moves a stuck instance to `failed` (see below). | done          |
+| `reconcile/gateway-limits.ts` | llmLimits/llmDeny → gateway policy kinds (pinned by the gateway spike).                                                                                                                                                  | **TODO stub** |
+
+**Runtime-image rollout.** Changing `spec.runtime.image` rolls every bound Sandbox
+onto it without ever killing a live turn, through a two-party handshake:
+
+- A **Suspended** instance has no pod, so the operator patches its image directly.
+  The patch is conditioned (`test` on `spec.operatingMode`) so a wake-up racing the
+  swap rejects it and the next pass re-decides.
+- A **Running** instance is _asked_ to drain: the operator writes
+  `agentconnect.md/drain-requested: <rolloutId>/<image>` plus
+  `agentconnect.md/drain-requested-at`. The owning daemon watches its namespace's
+  Sandboxes ([`cluster-spawn-and-shim.md`](cluster-spawn-and-shim.md)), keeps new
+  launches off a drained instance, and suspends it as soon as the work already on it
+  ends — immediately when it is idle. The next pass then patches the image as above,
+  and the pass after that sweeps both annotations once the instance runs the target.
+  The operator never suspends a Running instance itself.
+- An instance still Running `DRAIN_TIMEOUT_MS` (30 minutes, an exported constant
+  rather than a knob) after its request is reported in `status.rollout.failed`. It
+  stays listed and nothing is re-requested for that target: a drain that has not
+  landed in half an hour will not land by being asked again. A new target image is a
+  new `rolloutId`, which starts the handshake over.
+
+The request time lives on the object rather than in operator memory, so a leader
+change does not restart every drain's clock.
 
 Shared plumbing lives in `@agentconnect.md/k8s-client` (also used by the
 daemon's K8sDriver): in-cluster config with per-request token re-read, bare

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -94,11 +94,13 @@ onto it without ever killing a live turn, through a two-party handshake:
   ends — immediately when it is idle. The next pass then patches the image as above,
   and the pass after that sweeps both annotations once the instance runs the target.
   The operator never suspends a Running instance itself.
-- An instance still Running `DRAIN_TIMEOUT_MS` (30 minutes, an exported constant
-  rather than a knob) after its request is reported in `status.rollout.failed`. It
-  stays listed and nothing is re-requested for that target: a drain that has not
-  landed in half an hour will not land by being asked again. A new target image is a
-  new `rolloutId`, which starts the handshake over.
+- An instance still Running `DRAIN_TIMEOUT_MS` after its request is reported in
+  `status.rollout.failed`. It stays listed and nothing is re-requested for that
+  target: a drain that has not landed by then will not land by being asked again. A
+  new target image is a new `rolloutId`, which starts the handshake over. The bound
+  is 30 minutes — an exported constant rather than a knob, set comfortably past the
+  daemon's 15-minute idle host reclaim, which is what makes a quiet instance drain
+  in the first place.
 
 The request time lives on the object rather than in operator memory, so a leader
 change does not restart every drain's clock.

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -187,9 +187,13 @@ Three properties this shape buys:
 - **No launch record required.** Requests are keyed by Sandbox name, not by agent, so an instance
   this daemon has not bound in this process — after a restart, or for an agent that has been quiet
   — is still drained. Keying by agent would have made exactly the idle case unreachable.
-- **In-flight work is held, not raced.** A bind and the runtime it starts hold the Sandbox from
-  before the resume until the runtime exits, so a request arriving mid-launch waits its turn
-  instead of pulling the pod out from under it.
+- **In-flight work is held, not raced.** Work leases its Sandbox: the bind, the cold workspace
+  preparation that runs in the pod after it (clone, pull, skill materialization — one lease around
+  the whole of it, not around the bind alone), and the runtime until it exits. A request that
+  arrives while a lease is held waits for it instead of pulling the pod out from under it.
+  Taking a lease on an already-draining instance is refused instead, by type
+  (`SandboxDrainingError` → the `draining` launch outcome): nothing has started yet, so the
+  rollout wins that decision and the caller retries once the request clears.
 
 A drain the daemon never completes is the rollout's to give up on, not the daemon's to force:
 the operator marks the instance `failed` after its own deadline, and the pod keeps serving.

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -166,3 +166,30 @@ The helper git runs in the pod is the runtime image's own executable, root-owned
 unwritable by the runtime — one it could rewrite is one it could replace with a helper that
 asks the daemon for credentials in its name. It shares its implementation with the daemon's
 CLI helper and differs only in which socket it dials.
+
+## 7. Draining for a runtime-image rollout
+
+The daemon owns when an agent's pod runs, so an image rollout cannot simply replace it — a
+forced suspend would kill whatever turn is in flight. Instead the operator _asks_, by writing
+`agentconnect.md/drain-requested` on the Sandbox
+([`agentconnect-org-operator.md`](agentconnect-org-operator.md)), and the daemon answers with
+the one action that is its to take: it stops placing new work on that instance and suspends it
+once the work already there ends — immediately when there is none. The operator's conditioned
+image patch then applies, because the instance is Suspended.
+
+The consumer is a list-then-watch over the namespace's Sandboxes, started with the runtime
+plane rather than by a launch: the instance a rollout waits on is usually the idle one nobody
+is about to launch, and a request nothing reads would stall the rollout until its deadline.
+Three properties this shape buys:
+
+- **Snapshots converge.** Each re-LIST replaces the whole drain set, so a watch gap that swallowed
+  a request's removal cannot hold an instance down forever.
+- **No launch record required.** Requests are keyed by Sandbox name, not by agent, so an instance
+  this daemon has not bound in this process — after a restart, or for an agent that has been quiet
+  — is still drained. Keying by agent would have made exactly the idle case unreachable.
+- **In-flight work is held, not raced.** A bind and the runtime it starts hold the Sandbox from
+  before the resume until the runtime exits, so a request arriving mid-launch waits its turn
+  instead of pulling the pod out from under it.
+
+A drain the daemon never completes is the rollout's to give up on, not the daemon's to force:
+the operator marks the instance `failed` after its own deadline, and the pod keeps serving.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4850,11 +4850,17 @@ export class Daemon {
     // land on this daemon's disk, describing a filesystem the runtime never sees. Skills and
     // git-repo checkouts for cluster agents arrive with the materialize/runner phases.
     if (this.k8sPlane) {
-      await this.k8sPlane.ensureChannel(agent.id)
-      // The pod's own preparation: clone and pull happen on its volume through the runner, and none
-      // of the local work below runs — its mkdir, `existsSync(.git)` and skills installation all
-      // land on this daemon's disk, describing a filesystem the runtime never reads.
-      return await prepareClusterWorkspace(agent, this.k8sPlane.workspaceRootFor(agent.id), request)
+      const plane = this.k8sPlane
+      // One Sandbox lease around the WHOLE preparation, not just the bind: everything below runs
+      // in the pod, so a rollout's drain request landing mid-clone would otherwise suspend the pod
+      // underneath a turn this daemon already admitted.
+      return await plane.withSandbox(agent.id, async () => {
+        await plane.ensureChannel(agent.id)
+        // The pod's own preparation: clone and pull happen on its volume through the runner, and
+        // none of the local work below runs — its mkdir, `existsSync(.git)` and skills installation
+        // all land on this daemon's disk, describing a filesystem the runtime never reads.
+        return await prepareClusterWorkspace(agent, plane.workspaceRootFor(agent.id), request)
+      })
     }
     if (!this.opts.hostFactory) assertExclusiveAgentWorkspaces([agent as LoadedAgent])
     const opts = {

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -122,8 +122,9 @@ export class K8sDriver implements SpawnDriver {
   /** Sandboxes carrying a drain request, by name → the value that requested it. New work stays
    *  off them, and each is suspended as soon as the work already on it ends. */
   private readonly draining = new Map<string, string>()
-  /** Live work per Sandbox: binds in flight plus runtimes that have not exited. A drain waits
-   *  for this to reach zero, which is what keeps a rollout from pulling a pod out mid-turn. */
+  /** Live work per Sandbox: binds in flight, workspace preparation, and runtimes that have not
+   *  exited. A drain waits for this to reach zero — that is what keeps a rollout from pulling a
+   *  pod out mid-turn. */
   private readonly busy = new Map<string, number>()
   /** Per-SANDBOX transition queue. A guarded write protects competing writes, but it cannot
    *  protect a decision that performs NO write: a later wake could observe Running and
@@ -418,6 +419,25 @@ export class K8sDriver implements SpawnDriver {
       this.deps.log.warn(
         `cluster: sandbox ${sandboxName} did not suspend for its drain request — ${(err as Error).message}`
       )
+    }
+  }
+
+  /**
+   * Hold the agent's Sandbox for the duration of `work` — it is bound first, and a drain request
+   * then waits for the work instead of suspending the pod underneath it.
+   *
+   * The daemon's cold workspace preparation is exactly this case: the clone, pull and skill
+   * materialization all run IN the pod over the shim, between the bind and the launch they are
+   * preparing for, and a bind-scoped hold would leave that whole stretch drainable.
+   */
+  async withSandbox<T>(agentId: string, work: () => Promise<T>): Promise<T> {
+    const launch = await this.ensureSandbox(agentId)
+    this.refuseWhenDraining(agentId, launch.sandboxName)
+    this.retain(launch.sandboxName)
+    try {
+      return await work()
+    } finally {
+      this.release(launch.sandboxName)
     }
   }
 

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -19,7 +19,8 @@ import { K8sApiError } from '@agentconnect.md/k8s-client'
 export const AC_LABEL_ORG = 'agentconnect.md/org'
 export const AC_LABEL_AGENT = 'agentconnect.md/agent'
 
-/** Annotation an image rollout writes to ask a daemon to quiesce a Sandbox. */
+/** Annotation an image rollout writes to ask a daemon to quiesce a Sandbox (`<rolloutId>/<image>`).
+ *  The operator is the producer (`packages/operator/src/crd/types.ts`); this is the consumer. */
 export const DRAIN_REQUESTED_ANNOTATION = 'agentconnect.md/drain-requested'
 
 /**
@@ -83,8 +84,21 @@ export class LaunchTimeoutError extends Error {
   }
 }
 
+/** Work refused because its Sandbox is draining for an image rollout. Typed for the same reason:
+ *  a deliberate hold is not a missed target, and pooling the two makes a rollout look like an outage. */
+export class SandboxDrainingError extends Error {
+  constructor(agentId: string) {
+    super(`agent ${agentId} is draining for an image rollout — retry once it clears`)
+    this.name = 'SandboxDrainingError'
+  }
+}
+
 const DEFAULT_READY_TIMEOUT_MS = 90_000
 const MAX_MODE_ATTEMPTS = 5
+/** Restart delay bounds for the sandbox watch; watchCollection handles its own reconnects, so
+ *  this only covers a stream that ended some other way. */
+const WATCH_RESTART_BASE_MS = 500
+const WATCH_RESTART_CAP_MS = 30_000
 
 /** Per-agent launch state the driver keeps: the Sandbox it bound and which launch it is. */
 interface Launch {
@@ -105,13 +119,19 @@ export class K8sDriver implements SpawnDriver {
   private readonly metrics: ClusterMetrics
   private readonly launches = new Map<string, Launch>()
   private readonly generations = new Map<string, number>()
-  /** Agents whose Sandbox carries a drain request: hold off waking until it clears. */
-  private readonly draining = new Set<string>()
-  /** Per-agent transition queue. A guarded write protects competing writes, but it cannot
+  /** Sandboxes carrying a drain request, by name → the value that requested it. New work stays
+   *  off them, and each is suspended as soon as the work already on it ends. */
+  private readonly draining = new Map<string, string>()
+  /** Live work per Sandbox: binds in flight plus runtimes that have not exited. A drain waits
+   *  for this to reach zero, which is what keeps a rollout from pulling a pod out mid-turn. */
+  private readonly busy = new Map<string, number>()
+  /** Per-SANDBOX transition queue. A guarded write protects competing writes, but it cannot
    *  protect a decision that performs NO write: a later wake could observe Running and
    *  return while an earlier suspend patch was still in flight, and the older write would
    *  then land last and reverse the newer decision. Serializing removes that entirely. */
   private readonly modeQueue = new Map<string, Promise<void>>()
+  /** Term of the sandbox watch, so the plane can stop following on shutdown. */
+  private watch?: AbortController
   /** Logical channels per agent, which survive the shim's credential renewals. */
   private readonly sessions = new Map<string, ShimSession>()
   /** Workspace mount per agent, as the bound pod's shim reported it. */
@@ -205,7 +225,7 @@ export class K8sDriver implements SpawnDriver {
   /** Wake a suspended Sandbox, or confirm it is already running. Reports the mode it found, which
    *  is the only place a CACHED launch can learn whether it is resuming or already warm. */
   async wake(agentId: string): Promise<OperatingMode | undefined> {
-    if (this.draining.has(agentId)) {
+    if (this.isDraining(agentId)) {
       // A drain request is in flight: new messages queue rather than reviving the instance,
       // or one message would resurrect the image the rollout is replacing.
       this.deps.log.info(`cluster: holding agent ${agentId} suspended — a drain request is pending`)
@@ -227,11 +247,19 @@ export class K8sDriver implements SpawnDriver {
    * invalid patch would otherwise loop forever.
    */
   private setMode(agentId: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
-    const previous = this.modeQueue.get(agentId) ?? Promise.resolve()
-    const next = previous.catch(() => undefined).then(() => this.applyMode(agentId, desired))
+    const launch = this.launches.get(agentId)
+    if (!launch) return Promise.reject(new Error(`no sandbox launch recorded for agent ${agentId}`))
+    return this.queueMode(launch.sandboxName, desired)
+  }
+
+  /** Queued per SANDBOX rather than per agent: the drain path writes without an agent in hand,
+   *  and the object being serialized is the one both decisions patch. */
+  private queueMode(sandboxName: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
+    const previous = this.modeQueue.get(sandboxName) ?? Promise.resolve()
+    const next = previous.catch(() => undefined).then(() => this.applyMode(sandboxName, desired))
     // Keep the chain even when a link rejects, so a failed transition cannot strand the queue.
     this.modeQueue.set(
-      agentId,
+      sandboxName,
       next.then(
         () => undefined,
         () => undefined
@@ -240,60 +268,195 @@ export class K8sDriver implements SpawnDriver {
     return next
   }
 
-  private async applyMode(agentId: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
-    const launch = this.launches.get(agentId)
-    if (!launch) throw new Error(`no sandbox launch recorded for agent ${agentId}`)
+  private async applyMode(sandboxName: string, desired: OperatingMode): Promise<OperatingMode | undefined> {
     // The mode observed on the FIRST read, before this call changed anything. A later attempt
     // sees the state we produced, which would say nothing about where the launch started.
     let first: OperatingMode | undefined
     for (let attempt = 1; attempt <= MAX_MODE_ATTEMPTS; attempt += 1) {
-      const sandbox = await this.deps.api.getSandbox(launch.sandboxName)
+      const sandbox = await this.deps.api.getSandbox(sandboxName)
       const observed = sandbox.spec?.operatingMode ?? 'Running'
       if (observed === desired) return first ?? observed
       first ??= observed
       try {
-        await this.deps.api.setOperatingMode(launch.sandboxName, desired, observed)
-        this.deps.log.info(`cluster: agent ${agentId} sandbox ${launch.sandboxName} → ${desired}`)
+        await this.deps.api.setOperatingMode(sandboxName, desired, observed)
+        this.deps.log.info(`cluster: sandbox ${sandboxName} → ${desired}`)
         return first
       } catch (err) {
         if (!(err instanceof OperatingModeRejectedError)) throw err
         this.metrics.writeRetry('rejected_precondition')
-        this.deps.log.debug?.(
-          `cluster: ${desired} write for ${launch.sandboxName} rejected (attempt ${attempt}) — re-reading`
-        )
+        this.deps.log.debug?.(`cluster: ${desired} write for ${sandboxName} rejected (attempt ${attempt}) — re-reading`)
       }
     }
     throw new Error(
-      `sandbox ${launch.sandboxName} would not accept ${desired} after ${MAX_MODE_ATTEMPTS} attempts — ` +
+      `sandbox ${sandboxName} would not accept ${desired} after ${MAX_MODE_ATTEMPTS} attempts — ` +
         `something else is changing its mode`
     )
   }
 
   /**
-   * Observe a Sandbox's drain annotation. While it is present the daemon must not wake the
-   * instance: the rollout is waiting for it to stay down long enough to change its image,
-   * and a single arriving message would otherwise revive the old one.
+   * Follow this namespace's Sandboxes, which is how a drain request is noticed without polling.
+   *
+   * Started by the runtime plane rather than the constructor: a driver a test builds by hand has
+   * no cluster to watch, and the watch is a term with an end (`stopSandboxWatch`) rather than a
+   * side effect of existing.
    */
-  onSandboxObserved(agentId: string, annotations: Record<string, string> | undefined): void {
-    const requested = annotations?.[DRAIN_REQUESTED_ANNOTATION]
-    if (requested && !this.draining.has(agentId)) {
-      this.draining.add(agentId)
-      this.deps.log.info(`cluster: drain requested for agent ${agentId} (${requested})`)
-      return
-    }
-    if (!requested && this.draining.delete(agentId)) {
-      this.deps.log.info(`cluster: drain request cleared for agent ${agentId} — resuming normally`)
+  startSandboxWatch(): void {
+    if (this.watch) return
+    const controller = new AbortController()
+    this.watch = controller
+    void this.runSandboxWatch(controller.signal)
+  }
+
+  stopSandboxWatch(): void {
+    this.watch?.abort()
+    this.watch = undefined
+  }
+
+  // `watchCollection` reconnects and re-LISTs on its own, so this only covers a stream that ended
+  // some other way — and it must be covered, because a daemon that quietly stopped watching would
+  // stall every rollout until the operator's drain deadline failed each instance in turn.
+  private async runSandboxWatch(signal: AbortSignal): Promise<void> {
+    const backoff = new Backoff({ baseMs: WATCH_RESTART_BASE_MS, capMs: WATCH_RESTART_CAP_MS })
+    while (!signal.aborted) {
+      try {
+        const source = this.deps.api.watchSandboxes({
+          signal,
+          clock: this.clock,
+          metrics: this.metrics,
+          log: this.deps.log
+        })
+        for await (const event of source) {
+          backoff.reset()
+          if (event.kind === 'synced') this.onSandboxesSynced(event.items)
+          else if (event.kind === 'deleted') this.onSandboxGone(event.object)
+          else this.onSandboxObserved(event.object)
+        }
+      } catch (err) {
+        if (signal.aborted) return
+        this.deps.log.warn(`cluster: sandbox watch failed (${(err as Error).message})`)
+      }
+      if (signal.aborted) return
+      await this.pause(backoff.next(), signal)
     }
   }
 
+  /** A snapshot decides the whole drain set: a watch gap can drop a request or its removal, so
+   *  what the list says wins over the events we happened to see. */
+  private onSandboxesSynced(items: Sandbox[]): void {
+    const seen = new Set<string>()
+    for (const sandbox of items) {
+      const name = sandbox.metadata?.name
+      if (name) seen.add(name)
+      this.onSandboxObserved(sandbox)
+    }
+    for (const name of [...this.draining.keys()]) if (!seen.has(name)) this.clearDrain(name)
+  }
+
+  /**
+   * Observe a Sandbox's drain annotation. While it is present the daemon must not wake the
+   * instance: the rollout is waiting for it to stay down long enough to change its image,
+   * and a single arriving message would otherwise revive the old one. An instance with no work
+   * left on it is suspended right here — that suspension is what lets the rollout proceed.
+   */
+  onSandboxObserved(sandbox: Sandbox): void {
+    const name = sandbox.metadata?.name
+    if (!name) return
+    const requested = sandbox.metadata?.annotations?.[DRAIN_REQUESTED_ANNOTATION]
+    if (!requested) {
+      this.clearDrain(name)
+      return
+    }
+    if (this.draining.get(name) !== requested) {
+      this.draining.set(name, requested)
+      this.deps.log.info(`cluster: drain requested for sandbox ${name} (${requested})`)
+    }
+    // Already down — including the object our own suspend just produced — so nothing to quiesce.
+    if ((sandbox.spec?.operatingMode ?? 'Running') === 'Suspended') return
+    void this.quiesceIfIdle(name)
+  }
+
+  /** A Sandbox that is gone takes its drain request with it; nothing may be written to it again. */
+  private onSandboxGone(sandbox: Sandbox): void {
+    const name = sandbox.metadata?.name
+    if (!name) return
+    this.forgetSandbox(name)
+  }
+
+  /** Whether this agent's bound Sandbox is holding a drain request. */
   isDraining(agentId: string): boolean {
-    return this.draining.has(agentId)
+    const launch = this.launches.get(agentId)
+    return launch !== undefined && this.draining.has(launch.sandboxName)
+  }
+
+  private clearDrain(name: string): void {
+    if (this.draining.delete(name)) {
+      this.deps.log.info(`cluster: drain request cleared for sandbox ${name} — waking normally again`)
+    }
+  }
+
+  private forgetSandbox(name: string): void {
+    this.clearDrain(name)
+    this.busy.delete(name)
+    this.modeQueue.delete(name)
+  }
+
+  /**
+   * Suspend a draining Sandbox once nothing this daemon started is still running on it.
+   *
+   * Suspension is what lets the rollout swap the image, and it is never forced: a live turn keeps
+   * its instance up until the work ends, and an instance that never goes quiet is the rollout's
+   * own deadline to give up on, not ours to kill.
+   */
+  private async quiesceIfIdle(sandboxName: string): Promise<void> {
+    if (!this.draining.has(sandboxName) || (this.busy.get(sandboxName) ?? 0) > 0) return
+    try {
+      await this.queueMode(sandboxName, 'Suspended')
+    } catch (err) {
+      // applyMode already spent its bounded re-read/re-decide budget, so this is a drain that did
+      // not land — say so and let the rollout's deadline report the instance failed.
+      this.metrics.drainTimeout()
+      this.deps.log.warn(
+        `cluster: sandbox ${sandboxName} did not suspend for its drain request — ${(err as Error).message}`
+      )
+    }
+  }
+
+  /** Count work on a Sandbox, so a drain request waits for it instead of pulling the pod out. */
+  private retain(sandboxName: string): void {
+    this.busy.set(sandboxName, (this.busy.get(sandboxName) ?? 0) + 1)
+  }
+
+  private release(sandboxName: string): void {
+    const left = (this.busy.get(sandboxName) ?? 0) - 1
+    if (left > 0) {
+      this.busy.set(sandboxName, left)
+      return
+    }
+    this.busy.delete(sandboxName)
+    // The last work on it just ended, which is when a pending drain gets its suspend.
+    void this.quiesceIfIdle(sandboxName)
+  }
+
+  /** Abortable delay on the driver's clock, so shutdown does not wait out a watch restart. */
+  private pause(ms: number, signal: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const onAbort = (): void => {
+        this.clock.clearTimeout(handle)
+        resolve()
+      }
+      const handle = this.clock.setTimeout(() => {
+        signal.removeEventListener('abort', onAbort)
+        resolve()
+      }, ms)
+      signal.addEventListener('abort', onAbort, { once: true })
+    })
   }
 
   /** Forget an agent and delete its claim; the volume goes with it, which is the intent. */
   async removeAgent(agentId: string): Promise<void> {
+    const launch = this.launches.get(agentId)
     this.launches.delete(agentId)
-    this.draining.delete(agentId)
+    if (launch) this.forgetSandbox(launch.sandboxName)
     this.workspaceRoots.delete(agentId)
     await this.deps.api.deleteClaim(this.claimName(agentId))
   }
@@ -349,13 +512,30 @@ export class K8sDriver implements SpawnDriver {
     timer?: LaunchTimer,
     grants: ShimCapability[] = RUNTIME_GRANTS
   ): Promise<ShimConnection> {
-    if (this.draining.has(agentId)) {
-      throw new Error(`agent ${agentId} is draining for an image rollout — retry once it clears`)
-    }
     const launch = await this.ensureSandbox(agentId, timer)
+    // Checked against the SANDBOX, and only once it is known: an agent this daemon has not bound
+    // yet cannot be matched to a drain request any earlier. Held across the bind so a request
+    // arriving mid-flight waits for it rather than suspending the pod we are waiting on.
+    this.refuseWhenDraining(agentId, launch.sandboxName)
+    this.retain(launch.sandboxName)
+    try {
+      return await this.bindChannel(agentId, launch, timer, grants)
+    } finally {
+      this.release(launch.sandboxName)
+    }
+  }
+
+  private async bindChannel(
+    agentId: string,
+    launch: Launch,
+    timer: LaunchTimer | undefined,
+    grants: ShimCapability[]
+  ): Promise<ShimConnection> {
     // Resume BEFORE waiting: suspension deleted the pod, so readiness cannot arrive until
-    // something asks for Running.
-    const modeBeforeWake = await this.wake(agentId)
+    // something asks for Running. Deliberately not `wake()`: this bind already passed the drain
+    // gate and holds the Sandbox, so a request landing mid-flight waits for the work instead of
+    // stranding it against a pod nothing will resume.
+    const modeBeforeWake = await this.setMode(agentId, 'Running')
     // A launch this daemon already has cached returns from ensureSandbox before any sandbox
     // read, so this is where the ordinary `launch → suspend → launch` resume learns what it is.
     // Without it that path — the COMMON one — reported `warm` and never entered resume p95.
@@ -439,14 +619,15 @@ export class K8sDriver implements SpawnDriver {
   async launch(request: SpawnRequest): Promise<SpawnedRuntime> {
     const agentId = request.env.AC_AGENT_ID
     if (!agentId) throw new Error('cluster launch requires AC_AGENT_ID in the runtime environment')
-    if (this.draining.has(agentId)) {
-      // Launching now would wait out the readiness timeout against a sandbox we are
-      // deliberately holding down. Say so instead of timing out.
-      this.metrics.launch('warm', 'draining', 0)
-      throw new Error(`agent ${agentId} is draining for an image rollout — retry once it clears`)
-    }
     const timer = new LaunchTimer(this.metrics, () => this.clock.now())
+    // The Sandbox this launch holds, from before the bind until the runtime exits. Released on
+    // every failure path too, or one failed launch would hold a drain open forever.
+    let held: string | undefined
     try {
+      const bound = await this.ensureSandbox(agentId, timer)
+      this.refuseWhenDraining(agentId, bound.sandboxName)
+      this.retain(bound.sandboxName)
+      held = bound.sandboxName
       await this.ensureBoundChannel(agentId, timer)
       this.metrics.channel('bound')
       const session = this.sessions.get(agentId)
@@ -467,15 +648,29 @@ export class K8sDriver implements SpawnDriver {
           timer.finish(outcome)
         }
       })
+      // The runtime's exit is what makes the Sandbox idle, so it is where a pending drain lands.
+      const sandboxName = held
+      held = undefined
+      runtime.onExit(() => this.release(sandboxName))
       return runtime
     } catch (err) {
+      if (held) this.release(held)
       // Timeouts are the interesting failure — they are what a missed target looks like — so they
       // are distinguished from an outright error. By TYPE: all three launch deadlines (claim bind,
       // pod readiness, channel bind) throw LaunchTimeoutError, and the message regex this replaced
-      // silently stopped covering the channel wait the moment its wording changed.
-      timer.finish(err instanceof LaunchTimeoutError ? 'timeout' : 'error')
+      // silently stopped covering the channel wait the moment its wording changed. A held-for-
+      // rollout refusal is neither: pooling it with errors would make a rollout look like an outage.
+      timer.finish(
+        err instanceof SandboxDrainingError ? 'draining' : err instanceof LaunchTimeoutError ? 'timeout' : 'error'
+      )
       throw err
     }
+  }
+
+  private refuseWhenDraining(agentId: string, sandboxName: string): void {
+    // Launching now would wait out the readiness timeout against a sandbox we are deliberately
+    // holding down. Say so instead of timing out.
+    if (this.draining.has(sandboxName)) throw new SandboxDrainingError(agentId)
   }
 
   /** Re-attach a renewed or replacement connection to the launch it belongs to. */

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -104,6 +104,9 @@ export interface K8sRuntimePlane {
   /** Bring an agent's Sandbox up and bind its channel WITHOUT starting a runtime, so the
    *  workspace can be prepared on the pod's own volume before the runtime looks at it. */
   ensureChannel: (agentId: string) => Promise<void>
+  /** Run `work` holding the agent's Sandbox, so a rollout's drain request waits for it rather
+   *  than suspending the pod while work this daemon already admitted runs inside it. */
+  withSandbox: <T>(agentId: string, work: () => Promise<T>) => Promise<T>
   /** Ask a sandbox which runtimes the image actually provides, and tear it down again. */
   probeRuntimes: () => Promise<K8sRuntimeTable>
   /** A git runner for an agent whose workspace lives on its sandbox pod, or undefined when this
@@ -250,6 +253,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     ensureChannel: async (agentId) => {
       await driver.ensureBoundChannel(agentId)
     },
+    withSandbox: (agentId, work) => driver.withSandbox(agentId, work),
     probeRuntimes: async () => {
       // A sandbox of its own, under a reserved id, so a probe never adopts or disturbs an
       // agent's instance — and is torn down afterwards rather than left holding a pod.

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -221,6 +221,11 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
   // in between would hit an uninitialized binding.
   await listener.start(settings.shimPort, settings.shimHost ?? '0.0.0.0')
 
+  // Follows this namespace's Sandboxes for the rollout's drain requests. Part of starting the
+  // plane rather than of the first launch: an instance whose agent is idle is exactly the one a
+  // rollout is waiting on, and nothing else would ever look at it.
+  driver.startSandboxWatch()
+
   // A renewal re-dials immediately (the client resets its backoff for a planned rebind), so a
   // replacement that has not arrived well inside the request deadline is a pod that is gone.
   const REBIND_GRACE_MS = 20_000
@@ -277,6 +282,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     },
     workspaceRootFor: (agentId) => driver.workspaceRootFor(agentId),
     stop: async () => {
+      driver.stopSandboxWatch()
       for (const timer of lossTimers.values()) clearTimeout(timer)
       lossTimers.clear()
       for (const { proxy } of proxies.values()) proxy.stop('daemon is shutting down')

--- a/packages/daemon/test/cluster-metrics.test.ts
+++ b/packages/daemon/test/cluster-metrics.test.ts
@@ -338,7 +338,10 @@ describe('cluster launch metrics', () => {
     const drained = recorder()
     const api = fakeApi({ claimExists: true, mode: 'Suspended' })
     const driver = driverFor(drained.metrics, api)
-    driver.onSandboxObserved('agent-a', { [DRAIN_REQUESTED_ANNOTATION]: 'rollout-1' })
+    driver.onSandboxObserved({
+      metadata: { name: 'sb-1', annotations: { [DRAIN_REQUESTED_ANNOTATION]: 'rollout-1/img' } },
+      spec: { operatingMode: 'Suspended' }
+    })
     await expect(driver.launch(launchRequest)).rejects.toThrow(/draining/)
     // Held-for-rollout is not a missed target, and pooling it with errors would make a rollout
     // look like an outage on the dashboard.

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { FakeClock } from '@agentconnect.md/connection'
 import { K8sDriver, DRAIN_REQUESTED_ANNOTATION, AC_LABEL_AGENT } from '../src/k8s/driver.js'
 import { OperatingModeRejectedError } from '../src/k8s/sandbox-api.js'
-import { K8sApiError } from '@agentconnect.md/k8s-client'
+import { K8sApiError, type ResourceEvent } from '@agentconnect.md/k8s-client'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
 import type { ShimConnection } from '../src/shim/listener.js'
@@ -53,6 +53,36 @@ function fakeApi(options: { ready?: boolean; mode?: 'Running' | 'Suspended' } = 
     reviewToken: vi.fn()
   }
   return { api, state }
+}
+
+/** The Sandbox as a watch reports it, optionally carrying a rollout's drain request. */
+function observed(mode: 'Running' | 'Suspended', requested?: string): Sandbox {
+  return {
+    metadata: {
+      name: 'sb-1',
+      uid: 'sandbox-uid-1',
+      ...(requested ? { annotations: { [DRAIN_REQUESTED_ANNOTATION]: requested } } : {})
+    },
+    spec: { operatingMode: mode }
+  }
+}
+
+/** A watch a test drives by hand, so events land in a decided order rather than a raced one. */
+function watchSource() {
+  const queue: ResourceEvent<Sandbox>[] = []
+  let wake: (() => void) | undefined
+  return {
+    push(event: ResourceEvent<Sandbox>) {
+      queue.push(event)
+      wake?.()
+    },
+    async *stream(): AsyncGenerator<ResourceEvent<Sandbox>> {
+      for (;;) {
+        while (queue.length > 0) yield queue.shift()!
+        await new Promise<void>((resolve) => (wake = resolve))
+      }
+    }
+  }
 }
 
 /** Enough of a bound channel for `launch()` to attach a session to. */
@@ -193,17 +223,59 @@ describe('cluster spawn driver', () => {
     const { api, state } = fakeApi({ mode: 'Suspended' })
     const { instance } = driver(api)
     await instance.ensureSandbox('agent-a')
-    instance.onSandboxObserved('agent-a', { [DRAIN_REQUESTED_ANNOTATION]: 'rollout-7/image:v2' })
+    instance.onSandboxObserved(observed('Suspended', 'rollout-7/image:v2'))
     expect(instance.isDraining('agent-a')).toBe(true)
     await instance.wake('agent-a')
     // One arriving message must not revive the image the rollout is replacing; the message
     // queues instead.
     expect(state.modeWrites).toEqual([])
 
-    instance.onSandboxObserved('agent-a', {})
+    instance.onSandboxObserved(observed('Suspended'))
     expect(instance.isDraining('agent-a')).toBe(false)
     await instance.wake('agent-a')
     expect(state.modeWrites).toEqual([{ desired: 'Running', observed: 'Suspended' }])
+  })
+
+  it('suspends an idle sandbox as soon as a drain is requested, launch or no launch', async () => {
+    // Nothing bound it in this process — the daemon restarted, or the agent has been quiet — and
+    // that instance is exactly the one a rollout is waiting on. Suspension is what lets it swap
+    // the image, so it happens on the observation itself rather than on the next launch.
+    const { api, state } = fakeApi({ mode: 'Running' })
+    const { instance } = driver(api)
+    instance.onSandboxObserved(observed('Running', 'rollout-7/image:v2'))
+    await vi.waitFor(() => expect(state.modeWrites).toEqual([{ desired: 'Suspended', observed: 'Running' }]))
+  })
+
+  it('waits for the work on a draining sandbox to end before suspending it', async () => {
+    const { api, state } = fakeApi({ mode: 'Running' })
+    const { instance } = driver(api)
+    await instance.launch(launchRequest)
+    instance.onSandboxObserved(observed('Running', 'rollout-7/image:v2'))
+    await Promise.resolve()
+    // A live runtime keeps its pod: the rollout waits for the turn rather than the daemon
+    // killing it, and gives up on its own deadline if it never goes quiet.
+    expect(state.modeWrites).toEqual([])
+
+    // The runtime is gone, so the sandbox is idle — which is when the pending drain lands.
+    instance.onChannelLost('agent-a', 'shim channel gone')
+    await vi.waitFor(() => expect(state.modeWrites).toEqual([{ desired: 'Suspended', observed: 'Running' }]))
+  })
+
+  it('takes drain requests off the watch and converges on each snapshot', async () => {
+    const { api } = fakeApi({ mode: 'Running' })
+    const source = watchSource()
+    api.watchSandboxes = vi.fn(() => source.stream()) as never
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    instance.startSandboxWatch()
+    source.push({ kind: 'modified', object: observed('Running', 'rollout-7/image:v2') })
+    await vi.waitFor(() => expect(instance.isDraining('agent-a')).toBe(true))
+
+    // A snapshot is the whole truth: a watch gap can drop a request's removal, so a sandbox the
+    // re-LIST no longer reports must not stay held down forever.
+    source.push({ kind: 'synced', items: [] })
+    await vi.waitFor(() => expect(instance.isDraining('agent-a')).toBe(false))
+    instance.stopSandboxWatch()
   })
 
   it('orders concurrent wake and suspend decisions so the newer one wins', async () => {
@@ -237,7 +309,7 @@ describe('cluster spawn driver', () => {
     const { api } = fakeApi({ mode: 'Suspended' })
     const { instance } = driver(api)
     await instance.ensureSandbox('agent-a')
-    instance.onSandboxObserved('agent-a', { [DRAIN_REQUESTED_ANNOTATION]: 'rollout-1/img' })
+    instance.onSandboxObserved(observed('Suspended', 'rollout-1/img'))
     // wake() holds the sandbox down deliberately, so launching would block until the readiness
     // deadline elapsed. Failing fast says what is actually happening.
     await expect(instance.launch({ command: 'x', args: [], env: { AC_AGENT_ID: 'agent-a' } })).rejects.toThrow(

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -239,7 +239,7 @@ describe('cluster spawn driver', () => {
   it('suspends an idle sandbox as soon as a drain is requested, launch or no launch', async () => {
     // Nothing bound it in this process — the daemon restarted, or the agent has been quiet — and
     // that instance is exactly the one a rollout is waiting on. Suspension is what lets it swap
-    // the image, so it happens on the observation itself rather than on the next launch.
+    // the image, so it comes off the observation itself rather than off the next launch.
     const { api, state } = fakeApi({ mode: 'Running' })
     const { instance } = driver(api)
     instance.onSandboxObserved(observed('Running', 'rollout-7/image:v2'))
@@ -259,6 +259,37 @@ describe('cluster spawn driver', () => {
     // The runtime is gone, so the sandbox is idle — which is when the pending drain lands.
     instance.onChannelLost('agent-a', 'shim channel gone')
     await vi.waitFor(() => expect(state.modeWrites).toEqual([{ desired: 'Suspended', observed: 'Running' }]))
+  })
+
+  it('holds the sandbox across workspace preparation, not merely across the bind', async () => {
+    // Cold preparation clones, pulls and materializes IN the pod, over the shim, between the bind
+    // and the launch it is preparing for. A hold that ended with the bind would leave that whole
+    // stretch drainable, and the suspend would pull the pod out from under an admitted turn.
+    const { api, state } = fakeApi({ mode: 'Running' })
+    const { instance } = driver(api)
+    let finishPreparing!: () => void
+    const preparing = new Promise<void>((resolve) => (finishPreparing = resolve))
+    const held = instance.withSandbox('agent-a', async () => {
+      await instance.ensureBoundChannel('agent-a')
+      await preparing
+    })
+    await vi.waitFor(() => expect(instance.currentLaunch('agent-a')).toBeDefined())
+    instance.onSandboxObserved(observed('Running', 'rollout-7/image:v2'))
+    await Promise.resolve()
+    expect(state.modeWrites).toEqual([])
+
+    finishPreparing()
+    await held
+    await vi.waitFor(() => expect(state.modeWrites).toEqual([{ desired: 'Suspended', observed: 'Running' }]))
+  })
+
+  it('refuses to take a lease on a sandbox that is already draining', async () => {
+    // The preparation has not started yet, so the drain wins the decision — fast, and by type.
+    const { api } = fakeApi({ mode: 'Running' })
+    const { instance } = driver(api)
+    await instance.ensureSandbox('agent-a')
+    instance.onSandboxObserved(observed('Suspended', 'rollout-7/image:v2'))
+    await expect(instance.withSandbox('agent-a', async () => 'prepared')).rejects.toThrow(/draining/)
   })
 
   it('takes drain requests off the watch and converges on each snapshot', async () => {

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -27,6 +27,11 @@ afterEach(async () => {
   delete process.env.AC_K8S_SHIM_PORT
 })
 
+/** A sandbox watch that reports nothing and ends when the plane aborts it. */
+async function* idleSandboxWatch(signal?: AbortSignal): AsyncGenerator<never> {
+  await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve(), { once: true }))
+}
+
 /** A Sandbox that binds, adopts a pool pod, and reports Ready. */
 function fakeApi(options: { podName?: string; adopt?: boolean } = {}) {
   const podName = options.podName ?? 'pool-pod-9'
@@ -56,7 +61,8 @@ function fakeApi(options: { podName?: string; adopt?: boolean } = {}) {
       getSandbox: async () => sandbox,
       setOperatingMode: async () => sandbox,
       watchClaims: vi.fn(),
-      watchSandboxes: vi.fn(),
+      // The plane follows Sandboxes for a rollout's drain requests; this one reports none.
+      watchSandboxes: ({ signal }: { signal?: AbortSignal }) => idleSandboxWatch(signal),
       // The listener verifies through this, so the handshake exercises the real path.
       reviewToken: async (token: string) =>
         token === 'projected-token'

--- a/packages/daemon/test/shim-tunnel.test.ts
+++ b/packages/daemon/test/shim-tunnel.test.ts
@@ -52,6 +52,11 @@ function scratchDir(): string {
   return dir
 }
 
+/** A sandbox watch that reports nothing and ends when the plane aborts it. */
+async function* idleSandboxWatch(signal?: AbortSignal): AsyncGenerator<never> {
+  await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve(), { once: true }))
+}
+
 /** A Sandbox that binds, is Ready, and names its pod. */
 function fakeApi() {
   const sandbox = {
@@ -74,7 +79,8 @@ function fakeApi() {
     getSandbox: async () => sandbox,
     setOperatingMode: async () => sandbox,
     watchClaims: vi.fn(),
-    watchSandboxes: vi.fn(),
+    // The plane follows Sandboxes for a rollout's drain requests; this one reports none.
+    watchSandboxes: ({ signal }: { signal?: AbortSignal }) => idleSandboxWatch(signal),
     reviewToken: async () => ({ authenticated: true, podName: 'pool-pod-9', podUid: 'pod-uid-1' })
   }
 }

--- a/packages/operator/src/crd/types.ts
+++ b/packages/operator/src/crd/types.ts
@@ -11,6 +11,9 @@ export const FINALIZER = 'agentconnect.md/org-envelope'
 
 /** Rollout drain handshake annotation on runtime Sandboxes (value: `<rolloutId>/<image>`). */
 export const DRAIN_REQUESTED_ANNOTATION = 'agentconnect.md/drain-requested'
+/** When the request above was written (RFC 3339). The drain deadline is measured from it, on the
+ *  object rather than in the operator, so a leader change does not restart every drain's clock. */
+export const DRAIN_REQUESTED_AT_ANNOTATION = 'agentconnect.md/drain-requested-at'
 /** Pod-template annotation the operator bumps to force a Recreate on credential rotation. */
 export const CREDENTIAL_REVISION_ANNOTATION = 'agentconnect.md/credential-revision'
 /** Label mapping envelope workloads (Deployments/Pods) back to their owning org CR. */

--- a/packages/operator/src/reconcile/context.ts
+++ b/packages/operator/src/reconcile/context.ts
@@ -1,3 +1,4 @@
+import type { Clock } from '@agentconnect.md/connection'
 import type { K8sHttp } from '@agentconnect.md/k8s-client'
 import type { OperatorConfig } from '../config.js'
 import type { AgentConnectOrgApi } from '../crd/api.js'
@@ -10,6 +11,8 @@ export interface ReconcileContext {
   config: OperatorConfig
   /** The install's control namespace — master templates live here, CRs are watched here. */
   controlNamespace: string
+  /** Time source for deadlines a pass measures (drain timeouts); system clock when omitted. */
+  clock?: Clock
   log: { debug?: (message: string) => void; warn?: (message: string) => void }
 }
 

--- a/packages/operator/src/reconcile/rollout.test.ts
+++ b/packages/operator/src/reconcile/rollout.test.ts
@@ -1,17 +1,19 @@
 import { afterEach, describe, expect, it } from 'vitest'
+import { FakeClock } from '@agentconnect.md/connection'
 import { K8sHttp } from '@agentconnect.md/k8s-client'
 import { closeFakeApiServers, fakeApiServer, type FakeRoute } from '@agentconnect.md/k8s-client/testing'
 import { loadConfig } from '../config.js'
 import { AgentConnectOrgApi } from '../crd/api.js'
-import { AgentConnectOrgSpecSchema } from '../crd/types.js'
+import { AgentConnectOrgSpecSchema, DRAIN_REQUESTED_ANNOTATION, DRAIN_REQUESTED_AT_ANNOTATION } from '../crd/types.js'
 import { newObservations, type ReconcileContext } from './context.js'
 import type { EnvelopeInputs } from './envelope.js'
-import { reconcileRollout } from './rollout.js'
+import { DRAIN_TIMEOUT_MS, reconcileRollout } from './rollout.js'
 
 afterEach(closeFakeApiServers)
 
 const NS = 'test-ac-org-acme'
 const TARGET = 'ghcr.io/example/runtime:v2'
+const START = Date.parse('2026-01-01T00:00:00.000Z')
 
 function inputOf(): EnvelopeInputs {
   return {
@@ -24,9 +26,9 @@ function inputOf(): EnvelopeInputs {
   }
 }
 
-function sandbox(name: string, image: string, mode?: string) {
+function sandbox(name: string, image: string, mode?: string, annotations?: Record<string, string>) {
   return {
-    metadata: { name },
+    metadata: { name, ...(annotations ? { annotations } : {}) },
     spec: { ...(mode ? { operatingMode: mode } : {}), podTemplate: { spec: { containers: [{ image }] } } }
   }
 }
@@ -38,7 +40,8 @@ interface RecordedPatch {
 }
 
 async function run(
-  sandboxes: unknown[]
+  sandboxes: unknown[],
+  clock: FakeClock = new FakeClock(START)
 ): Promise<{ patches: RecordedPatch[]; obs: ReturnType<typeof newObservations> }> {
   const patches: RecordedPatch[] = []
   const route: FakeRoute = ({ method, url, body, headers }) => {
@@ -58,12 +61,18 @@ async function run(
     orgApi: new AgentConnectOrgApi(http, cluster.namespace),
     config: loadConfig({ AC_ORG_NAMESPACE_PREFIX: 'test-ac-org-', AC_TOKENREVIEW_CLUSTERROLE: 'x' }),
     controlNamespace: cluster.namespace,
+    clock,
     log: {}
   }
   const obs = newObservations()
   obs.namespaceReady = true
   await reconcileRollout(ctx, inputOf(), obs)
   return { patches, obs }
+}
+
+/** The annotations a drain request wrote, read back off the recorded merge patch. */
+function requestedAnnotations(patch: RecordedPatch): Record<string, string | null> {
+  return (patch.body as { metadata: { annotations: Record<string, string | null> } }).metadata.annotations
 }
 
 describe('reconcileRollout', () => {
@@ -79,11 +88,91 @@ describe('reconcileRollout', () => {
     expect(obs.rollout?.targetImage).toBe(TARGET)
   })
 
-  it('only reports a Running sandbox pending — no write until the daemon drain consumer lands', async () => {
+  it('asks a Running sandbox to drain via the annotation handshake, never a forced suspend', async () => {
     const { patches, obs } = await run([sandbox('sb-1', 'ghcr.io/example/runtime:v1', 'Running')])
-    // It converges when the sandbox naturally sleeps and the next pass patches it.
-    expect(patches).toEqual([])
+    expect(patches).toHaveLength(1)
+    const annotations = requestedAnnotations(patches[0])
+    expect(annotations[DRAIN_REQUESTED_ANNOTATION]?.endsWith(`/${TARGET}`)).toBe(true)
+    // The deadline is measured from a time on the OBJECT, so a leader change does not restart it.
+    expect(annotations[DRAIN_REQUESTED_AT_ANNOTATION]).toBe(new Date(START).toISOString())
     expect(obs.rollout?.pending).toEqual(['sb-1'])
+    expect(obs.rollout?.failed).toEqual([])
+  })
+
+  it('does not repeat an annotation that is already requested', async () => {
+    const first = await run([sandbox('sb-1', 'ghcr.io/example/runtime:v1', 'Running')])
+    const annotated = requestedAnnotations(first.patches[0]) as Record<string, string>
+    const { patches } = await run([sandbox('sb-1', 'ghcr.io/example/runtime:v1', 'Running', annotated)])
+    expect(patches).toEqual([])
+  })
+
+  it('starts the deadline now when the request carries no readable time', async () => {
+    // An older operator, or a hand-edited object: expiring against a time nobody wrote would
+    // either fail the instance instantly or never.
+    const { patches, obs } = await run([
+      sandbox('sb-1', 'ghcr.io/example/runtime:v1', 'Running', {
+        [DRAIN_REQUESTED_ANNOTATION]: `${'0'.repeat(8)}/${TARGET}`
+      })
+    ])
+    expect(requestedAnnotations(patches[0])[DRAIN_REQUESTED_AT_ANNOTATION]).toBe(new Date(START).toISOString())
+    expect(obs.rollout?.pending).toEqual(['sb-1'])
+  })
+
+  it('fails an instance that is still Running when its drain deadline passes', async () => {
+    const clock = new FakeClock(START)
+    const requested = await run([sandbox('sb-1', 'ghcr.io/example/runtime:v1', 'Running')], clock)
+    const annotated = requestedAnnotations(requested.patches[0]) as Record<string, string>
+    clock.advance(DRAIN_TIMEOUT_MS)
+    const { patches, obs } = await run([sandbox('sb-1', 'ghcr.io/example/runtime:v1', 'Running', annotated)], clock)
+    // Failed is terminal for this target: nothing is re-requested, and it stays listed.
+    expect(patches).toEqual([])
+    expect(obs.rollout?.failed).toEqual(['sb-1'])
+    expect(obs.rollout?.pending).toEqual([])
+  })
+
+  it('keeps a drain pending right up to its deadline', async () => {
+    const clock = new FakeClock(START)
+    const requested = await run([sandbox('sb-1', 'ghcr.io/example/runtime:v1', 'Running')], clock)
+    const annotated = requestedAnnotations(requested.patches[0]) as Record<string, string>
+    clock.advance(DRAIN_TIMEOUT_MS - 1)
+    const { obs } = await run([sandbox('sb-1', 'ghcr.io/example/runtime:v1', 'Running', annotated)], clock)
+    expect(obs.rollout?.pending).toEqual(['sb-1'])
+    expect(obs.rollout?.failed).toEqual([])
+  })
+
+  it('re-requests a failed instance when the target image changes', async () => {
+    // A new target is a new rolloutId, so the handshake starts over rather than staying failed
+    // against an image nobody is rolling out any more.
+    const clock = new FakeClock(START)
+    clock.advance(DRAIN_TIMEOUT_MS * 2)
+    const { patches, obs } = await run(
+      [
+        sandbox('sb-1', 'ghcr.io/example/runtime:v1', 'Running', {
+          [DRAIN_REQUESTED_ANNOTATION]: 'older001/ghcr.io/example/runtime:v0',
+          [DRAIN_REQUESTED_AT_ANNOTATION]: new Date(START).toISOString()
+        })
+      ],
+      clock
+    )
+    expect(requestedAnnotations(patches[0])[DRAIN_REQUESTED_ANNOTATION]?.endsWith(`/${TARGET}`)).toBe(true)
+    expect(obs.rollout?.pending).toEqual(['sb-1'])
+    expect(obs.rollout?.failed).toEqual([])
+  })
+
+  it('sweeps a stale annotation once the sandbox reaches the target image', async () => {
+    const { patches, obs } = await run([
+      sandbox('sb-1', TARGET, 'Running', {
+        [DRAIN_REQUESTED_ANNOTATION]: `old/ghcr.io/example/runtime:v1`,
+        [DRAIN_REQUESTED_AT_ANNOTATION]: new Date(START).toISOString()
+      })
+    ])
+    expect(patches).toHaveLength(1)
+    // Both halves go: a left-over request would keep the daemon refusing to wake the instance.
+    expect(requestedAnnotations(patches[0])).toEqual({
+      [DRAIN_REQUESTED_ANNOTATION]: null,
+      [DRAIN_REQUESTED_AT_ANNOTATION]: null
+    })
+    expect(obs.rollout).toBeUndefined()
   })
 
   it('reports no rollout when every sandbox is on the target image', async () => {

--- a/packages/operator/src/reconcile/rollout.test.ts
+++ b/packages/operator/src/reconcile/rollout.test.ts
@@ -91,6 +91,8 @@ describe('reconcileRollout', () => {
   it('asks a Running sandbox to drain via the annotation handshake, never a forced suspend', async () => {
     const { patches, obs } = await run([sandbox('sb-1', 'ghcr.io/example/runtime:v1', 'Running')])
     expect(patches).toHaveLength(1)
+    // A PATCH that does not name its patch type is a 415 from a real API server.
+    expect(patches[0].contentType).toBe('application/merge-patch+json')
     const annotations = requestedAnnotations(patches[0])
     expect(annotations[DRAIN_REQUESTED_ANNOTATION]?.endsWith(`/${TARGET}`)).toBe(true)
     // The deadline is measured from a time on the OBJECT, so a leader change does not restart it.
@@ -167,6 +169,7 @@ describe('reconcileRollout', () => {
       })
     ])
     expect(patches).toHaveLength(1)
+    expect(patches[0].contentType).toBe('application/merge-patch+json')
     // Both halves go: a left-over request would keep the daemon refusing to wake the instance.
     expect(requestedAnnotations(patches[0])).toEqual({
       [DRAIN_REQUESTED_ANNOTATION]: null,

--- a/packages/operator/src/reconcile/rollout.ts
+++ b/packages/operator/src/reconcile/rollout.ts
@@ -23,12 +23,14 @@ function imageOf(sandbox: SandboxRead): string | undefined {
   return sandbox.spec?.podTemplate?.spec?.containers?.[0]?.image
 }
 
+// A PATCH must name its patch type — the API server answers `application/json` with 415 — so the
+// annotation writes take the merge-patch default and the conditioned image swap names JSON Patch.
 async function patchSandbox(
   ctx: ReconcileContext,
   ns: string,
   name: string,
   body: unknown,
-  contentType?: string
+  contentType = 'application/merge-patch+json'
 ): Promise<boolean> {
   try {
     await ctx.http.json({ method: 'PATCH', path: groupPath(SANDBOX_GROUP, ns, 'sandboxes', name), body, contentType })

--- a/packages/operator/src/reconcile/rollout.ts
+++ b/packages/operator/src/reconcile/rollout.ts
@@ -7,7 +7,8 @@ import type { EnvelopeInputs } from './envelope.js'
 import { SANDBOX_GROUP, getOrNull, groupPath } from './resources.js'
 
 /** How long a Running instance may sit on a drain request before the rollout gives up on it.
- *  A constant, not a knob: the only sane value is "longer than a turn, shorter than a shift". */
+ *  Comfortably past the daemon's own idle host reclaim (15 min by default), which is what makes
+ *  a quiet instance drain at all — an instance still up after twice that is not going quiet. */
 export const DRAIN_TIMEOUT_MS = 30 * 60_000
 
 interface SandboxRead {

--- a/packages/operator/src/reconcile/rollout.ts
+++ b/packages/operator/src/reconcile/rollout.ts
@@ -1,11 +1,17 @@
 import { createHash } from 'node:crypto'
+import { systemClock } from '@agentconnect.md/connection'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
+import { DRAIN_REQUESTED_ANNOTATION, DRAIN_REQUESTED_AT_ANNOTATION } from '../crd/types.js'
 import type { Observations, ReconcileContext } from './context.js'
 import type { EnvelopeInputs } from './envelope.js'
 import { SANDBOX_GROUP, getOrNull, groupPath } from './resources.js'
 
+/** How long a Running instance may sit on a drain request before the rollout gives up on it.
+ *  A constant, not a knob: the only sane value is "longer than a turn, shorter than a shift". */
+export const DRAIN_TIMEOUT_MS = 30 * 60_000
+
 interface SandboxRead {
-  metadata?: { name?: string }
+  metadata?: { name?: string; annotations?: Record<string, string> }
   spec?: {
     operatingMode?: string
     podTemplate?: { spec?: { containers?: Array<{ image?: string }> } }
@@ -16,45 +22,92 @@ function imageOf(sandbox: SandboxRead): string | undefined {
   return sandbox.spec?.podTemplate?.spec?.containers?.[0]?.image
 }
 
+async function patchSandbox(
+  ctx: ReconcileContext,
+  ns: string,
+  name: string,
+  body: unknown,
+  contentType?: string
+): Promise<boolean> {
+  try {
+    await ctx.http.json({ method: 'PATCH', path: groupPath(SANDBOX_GROUP, ns, 'sandboxes', name), body, contentType })
+    return true
+  } catch (error) {
+    // A failed test op or a lost race means the mode moved — the next pass re-decides.
+    if (error instanceof K8sApiError && (error.isUnprocessable || error.isConflict)) return false
+    throw error
+  }
+}
+
 /**
- * Runtime-image rollout over bound Sandboxes. Suspended instances get a
- * conditioned image patch. Running instances are only reported pending: they
- * converge when they naturally sleep (the daemon suspends idle sandboxes) and
- * the next pass patches them. The drain-requested handshake — producer AND
- * daemon-side consumer — lands together with the daemon milestone, so no
- * annotation is written that nothing consumes yet.
+ * Runtime-image rollout over bound Sandboxes: Suspended instances get a conditioned image patch,
+ * Running instances are asked to drain through the annotation handshake — never a forced suspend,
+ * which would kill a live turn. The daemon holds a drained instance down and suspends it once its
+ * work ends, so the next pass swaps the image. An instance still Running {@link DRAIN_TIMEOUT_MS}
+ * after its request is reported `failed`: it stays listed and nothing is re-requested for this
+ * target, because a drain that has not landed in half an hour will not land by being asked again.
  */
 export async function reconcileRollout(ctx: ReconcileContext, input: EnvelopeInputs, obs: Observations): Promise<void> {
   if (!obs.namespaceReady || input.spec.suspend) return
   const ns = input.spec.targetNamespace
   const target = input.spec.runtime.image
   const rolloutId = createHash('sha256').update(target).digest('hex').slice(0, 8)
+  const now = (ctx.clock ?? systemClock).now()
   const list = await getOrNull<{ items?: SandboxRead[] }>(ctx.http, groupPath(SANDBOX_GROUP, ns, 'sandboxes'))
   const pending: string[] = []
+  const failed: string[] = []
   for (const sandbox of list?.items ?? []) {
     const name = sandbox.metadata?.name
     if (!name) continue
+    const annotations = sandbox.metadata?.annotations ?? {}
     const image = imageOf(sandbox)
     // Warm-pool sandboxes without a pod template image inherit it from the template rollout.
-    if (!image || image === target) continue
-    pending.push(name)
-    if (sandbox.spec?.operatingMode !== 'Suspended') continue
-    // Conditioned: the test op makes a concurrent wake-up reject the image swap.
-    try {
-      await ctx.http.json({
-        method: 'PATCH',
-        path: groupPath(SANDBOX_GROUP, ns, 'sandboxes', name),
-        contentType: 'application/json-patch+json',
-        body: [
+    if (!image || image === target) {
+      // The handshake is over the moment the instance runs the target; a left-over request would
+      // keep the daemon refusing to wake it.
+      if (annotations[DRAIN_REQUESTED_ANNOTATION]) {
+        await patchSandbox(ctx, ns, name, {
+          metadata: { annotations: { [DRAIN_REQUESTED_ANNOTATION]: null, [DRAIN_REQUESTED_AT_ANNOTATION]: null } }
+        })
+      }
+      continue
+    }
+    if (sandbox.spec?.operatingMode === 'Suspended') {
+      pending.push(name)
+      // Conditioned: the test op makes a concurrent wake-up reject the image swap.
+      await patchSandbox(
+        ctx,
+        ns,
+        name,
+        [
           { op: 'test', path: '/spec/operatingMode', value: 'Suspended' },
           { op: 'replace', path: '/spec/podTemplate/spec/containers/0/image', value: target }
-        ]
-      })
-    } catch (error) {
-      // A failed test op or a lost race means the mode moved — the next pass re-decides.
-      if (!(error instanceof K8sApiError && (error.isUnprocessable || error.isConflict))) throw error
+        ],
+        'application/json-patch+json'
+      )
+      continue
     }
+    const want = `${rolloutId}/${target}`
+    const requestedAt = Date.parse(annotations[DRAIN_REQUESTED_AT_ANNOTATION] ?? '')
+    // A request for another target, or one whose time is missing or unreadable (an older operator,
+    // a hand-edited object), starts the deadline now rather than expiring against a time nobody wrote.
+    if (annotations[DRAIN_REQUESTED_ANNOTATION] !== want || !Number.isFinite(requestedAt)) {
+      await patchSandbox(ctx, ns, name, {
+        metadata: {
+          annotations: {
+            [DRAIN_REQUESTED_ANNOTATION]: want,
+            [DRAIN_REQUESTED_AT_ANNOTATION]: new Date(now).toISOString()
+          }
+        }
+      })
+      pending.push(name)
+      continue
+    }
+    if (now - requestedAt >= DRAIN_TIMEOUT_MS) failed.push(name)
+    else pending.push(name)
   }
-  // TODO(operator): drain timeouts move stuck instances from pending to failed.
-  obs.rollout = pending.length > 0 ? { rolloutId, targetImage: target, pending: pending.sort(), failed: [] } : undefined
+  obs.rollout =
+    pending.length + failed.length > 0
+      ? { rolloutId, targetImage: target, pending: pending.sort(), failed: failed.sort() }
+      : undefined
 }


### PR DESCRIPTION
The drain-requested handshake ships as one unit, producer and consumer together — the follow-up promised when the producer was pulled from #869 because nothing consumed it yet.

## Daemon — the consumer

- `K8sDriver` follows its namespace's Sandboxes over the shared list-then-watch (resume + 410 re-LIST from `@agentconnect.md/k8s-client`), started with the runtime plane and aborted on `stop()`. A restart of the stream itself is backed off, because a daemon that quietly stopped watching would stall every rollout.
- A Sandbox carrying `agentconnect.md/drain-requested` is held down: no new launch or wake is placed on it, and it is suspended through the guarded `setOperatingMode('Suspended', observed)` — re-read and re-decide on rejection, bounded attempts — as soon as no work is left on it. An already-idle instance is suspended on the observation itself.
- Work is counted **per Sandbox**: a bind in flight holds it, then the runtime does until it exits. That is what makes a request arriving mid-launch wait rather than pull the pod out from under a live turn. The daemon never forces a suspend; an instance that never goes quiet is the rollout's deadline to give up on.
- Requests are keyed by **Sandbox name, not agent**, so an instance this daemon has not bound in this process — after a restart, or for an agent that has been quiet — is still drained. Keying by agent made exactly the idle case, the common one for a rollout, unreachable.
- Every `synced` snapshot converges the whole drain set, so a watch gap that swallowed a request's removal cannot hold an instance down forever.

## Operator — the producer, plus drain timeouts

- Restored: the annotation write (`<rolloutId>/<image>`) for Running instances off the target image, the conditioned image patch for Suspended ones, and the stale-request sweep once an instance reaches the target.
- New `agentconnect.md/drain-requested-at`, written with the request. The deadline is measured from a time **on the object**, so a leader change does not restart every drain's clock.
- New `DRAIN_TIMEOUT_MS` — 30 minutes, an exported constant rather than a config knob. An instance still Running past it is reported in `status.rollout.failed`: it stays listed and nothing is re-requested for that target, because a drain that has not landed in half an hour will not land by being asked again. A new target image is a new `rolloutId`, which starts the handshake over.

## Docs

`agentconnect-org-operator.md`: the rollout row goes partial → done, with the handshake and its deadline written out. `cluster-spawn-and-shim.md` gains §7 for the daemon half — why the watch starts with the plane, why requests are Sandbox-keyed, and how in-flight work is held.

## Test

- operator: restored producer / sweep tests, plus deadline coverage driven by `FakeClock` (pending right up to the deadline, failed past it, re-requested on a new target, unreadable request time starts the clock).
- daemon: idle instance suspended on observation with no launch record, suspend held until the runtime exits, watch events and snapshot convergence.
- `pnpm --filter @agentconnect.md/operator test`, `pnpm --filter @agentconnect.md/daemon test`, typecheck on both, `pnpm lint`, prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)