### PR TITLE
feat(operator): block helm uninstall while AgentConnectOrg resources remain

### DIFF
--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -82,3 +82,12 @@ until then install from this directory.)
 Delete every `AgentConnectOrg` first and wait for finalizers to complete — the
 pre-delete hook refuses to uninstall while CRs remain, because removing the
 operator strands their finalizers.
+
+The hook is a Job running the operator image's `preflight-uninstall` subcommand
+under the operator's own ServiceAccount: it lists the CRs in the release
+namespace and exits non-zero, naming them, if any are left. A failed hook Job is
+kept, so its log is the diagnosis:
+
+```bash
+kubectl -n CONTROL_NAMESPACE logs job/RELEASE_NAME-operator-pre-delete
+```

--- a/charts/operator/templates/NOTES.txt
+++ b/charts/operator/templates/NOTES.txt
@@ -24,4 +24,7 @@ Onboard an org by applying an AgentConnectOrg into {{ .Release.Namespace }}
 together with its daemon credential Secret in the target namespace.
 
 Before uninstalling: delete every AgentConnectOrg and wait for finalizers —
-the pre-delete hook refuses to remove the operator while CRs remain.
+the pre-delete hook refuses to remove the operator while CRs remain. When it
+does, it names them here:
+
+  kubectl -n {{ .Release.Namespace }} logs job/{{ .Release.Name }}-operator-pre-delete

--- a/charts/operator/templates/pre-delete-hook.yaml
+++ b/charts/operator/templates/pre-delete-hook.yaml
@@ -11,9 +11,12 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
     helm.sh/hook: pre-delete
+    # A failed hook Job survives on purpose: `kubectl logs` on it is the diagnosis.
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 0
+  # An unreachable API server must fail the uninstall, not hang it.
+  activeDeadlineSeconds: 120
   template:
     metadata:
       labels:
@@ -21,10 +24,18 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       restartPolicy: Never
+      # The operator's own SA: listing the CRs is a permission it already holds.
       serviceAccountName: {{ .Release.Name }}-operator
       containers:
         - name: guard
           image: '{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}'
-          # TODO(chart): replace with a real check — list agentconnectorgs in this
-          # namespace and exit non-zero (failing the uninstall) when any remain.
-          command: ['node', '-e', 'console.log("TODO: fail when AgentConnectOrg resources remain"); process.exit(0)']
+          # tini is ENTRYPOINT, so args must name the interpreter. The subcommand reads
+          # nothing but the in-cluster identity, hence no env from the operator's install.
+          args: ['node', 'dist/index.js', 'preflight-uninstall']
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -136,8 +136,12 @@ is a _templated_ resource (conditional + upgradable) carrying
 every org. Everything else is per-install: operator Deployment (2 replicas) +
 SA/RBAC, the release-prefixed tokenreview ClusterRole, two
 ValidatingAdmissionPolicies, and a pre-delete hook that refuses uninstall while
-CRs remain — removing the operator would strand every finalizer. Publishing to
-the OCI registry rides the release pipeline (not yet wired).
+CRs remain — removing the operator would strand every finalizer. That hook is a
+Job running the operator image's hidden `preflight-uninstall` subcommand under
+the operator's own SA: it lists the CRs in the release namespace and exits
+non-zero naming them, so the check runs the same client the controller does
+instead of a second, drifting copy in shell. Publishing to the OCI registry
+rides the release pipeline (not yet wired).
 
 The policies are the static half of the isolation story RBAC cannot express —
 RBAC grants verbs, admission bounds where they may be used — and each install

--- a/packages/operator/src/index.ts
+++ b/packages/operator/src/index.ts
@@ -5,10 +5,28 @@ import { K8sHttp, LeaseElector, loadInClusterConfig } from '@agentconnect.md/k8s
 import { loadConfig } from './config.js'
 import { Controller } from './controller.js'
 import { AgentConnectOrgApi } from './crd/api.js'
+import { preflightUninstall } from './preflight.js'
 import { reconcile } from './reconcile/reconcile.js'
 import type { ReconcileContext } from './reconcile/context.js'
 
-export async function main(): Promise<void> {
+/** Hidden subcommand: the chart's pre-delete hook runs it, nobody types it. */
+const PREFLIGHT_UNINSTALL = 'preflight-uninstall'
+
+// No loadConfig(): the guard only needs the in-cluster identity, so the hook Job
+// carries none of the operator's install-time env.
+async function runPreflightUninstall(): Promise<void> {
+  const cluster = loadInClusterConfig()
+  const result = await preflightUninstall(new AgentConnectOrgApi(new K8sHttp(cluster), cluster.namespace))
+  if (result.remaining.length === 0) {
+    console.log(result.message)
+    return
+  }
+  console.error(result.message)
+  process.exit(1)
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
+  if (argv[0] === PREFLIGHT_UNINSTALL) return runPreflightUninstall()
   const config = loadConfig()
   const cluster = loadInClusterConfig()
   const http = new K8sHttp(cluster)

--- a/packages/operator/src/preflight.test.ts
+++ b/packages/operator/src/preflight.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { K8sHttp } from '@agentconnect.md/k8s-client'
+import { closeFakeApiServers, fakeApiServer, type FakeRoute } from '@agentconnect.md/k8s-client/testing'
+import { AgentConnectOrgApi } from './crd/api.js'
+import { preflightUninstall } from './preflight.js'
+
+afterEach(closeFakeApiServers)
+
+/** A control namespace holding these orgs, plus the URLs the guard actually asked for. */
+async function apiFor(names: string[]): Promise<{ api: AgentConnectOrgApi; requests: URL[] }> {
+  const route: FakeRoute = () => ({ json: { items: names.map((name) => ({ metadata: { name } })) } })
+  const { config, requests } = await fakeApiServer(route)
+  return { api: new AgentConnectOrgApi(new K8sHttp(config), config.namespace), requests }
+}
+
+describe('preflightUninstall', () => {
+  it('clears the uninstall when the control namespace holds no orgs', async () => {
+    const { api } = await apiFor([])
+    const result = await preflightUninstall(api)
+    expect(result.remaining).toEqual([])
+    expect(result.message).toContain('can be removed')
+  })
+
+  it('blocks and names every org that remains, so the hook log is the diagnosis', async () => {
+    const { api } = await apiFor(['zeta', 'acme'])
+    const result = await preflightUninstall(api)
+    expect(result.remaining).toEqual(['acme', 'zeta'])
+    expect(result.message).toContain('refusing to uninstall: 2 AgentConnectOrg(s)')
+    expect(result.message).toContain('acme, zeta')
+  })
+
+  it('asks only about its own control namespace', async () => {
+    const { api, requests } = await apiFor(['acme'])
+    await preflightUninstall(api)
+    expect(requests.map((url) => url.pathname)).toEqual([
+      '/apis/agentconnect.md/v1alpha1/namespaces/org-test/agentconnectorgs'
+    ])
+  })
+
+  it('surfaces an API failure instead of reporting a clear namespace', async () => {
+    const { config } = await fakeApiServer(() => ({ status: 500, json: { kind: 'Status', message: 'boom' } }))
+    const api = new AgentConnectOrgApi(new K8sHttp(config), config.namespace)
+    await expect(preflightUninstall(api)).rejects.toThrow()
+  })
+})

--- a/packages/operator/src/preflight.ts
+++ b/packages/operator/src/preflight.ts
@@ -1,0 +1,27 @@
+import type { AgentConnectOrgApi } from './crd/api.js'
+
+/** What the uninstall guard found; a non-empty `remaining` must fail the hook. */
+export interface PreflightResult {
+  /** Names of the AgentConnectOrgs still living in the control namespace, sorted. */
+  remaining: string[]
+  /** The one line the hook prints — the only diagnosis a helm user gets. */
+  message: string
+}
+
+// The operator is the only actor that runs the envelope finalizer: uninstalling it
+// while CRs remain leaves every org stuck in Terminating with nothing left to clean up.
+/** The check behind the chart's pre-delete hook: are there orgs this operator still owns? */
+export async function preflightUninstall(api: AgentConnectOrgApi): Promise<PreflightResult> {
+  const orgs = await api.list()
+  const remaining = orgs.map((org) => org.metadata?.name ?? '<unnamed>').sort()
+  if (remaining.length === 0) {
+    return { remaining, message: `no AgentConnectOrg remains in ${api.namespace}; the operator can be removed` }
+  }
+  return {
+    remaining,
+    message:
+      `refusing to uninstall: ${remaining.length} AgentConnectOrg(s) still in ${api.namespace} ` +
+      `(${remaining.join(', ')}). Delete them and wait for their finalizers to complete first — ` +
+      'removing the operator now would strand every envelope.'
+  }
+}


### PR DESCRIPTION
Second of the operator-chart follow-ups. `charts/operator/templates/pre-delete-hook.yaml` shipped as a stub that printed a TODO and exited 0, so `helm uninstall` sailed straight through — and it removes the only actor able to run the `agentconnect.md/org-envelope` finalizer. Every org left behind would sit in `Terminating` forever with nothing to clean it up.

## The check lives in the image

A hidden `preflight-uninstall` subcommand on the operator bin (`packages/operator/src/preflight.ts`), dispatched from `main()` before anything else happens. It lists the CRs in its own control namespace through `AgentConnectOrgApi` — the same typed client the controller reconciles with — and returns `{ remaining, message }`; the bin prints and exits 1 when `remaining` is non-empty.

Two reasons for a subcommand rather than a `kubectl`/`curl` one-liner in the Job:

- "which orgs does this install own" is already answered by one collection path in `crd/api.ts`. A second copy in shell drifts the moment the group, version or plural moves.
- It is unit-testable against the in-process fake API server, which is how the rest of this package is tested.

It deliberately does **not** call `loadConfig()` — the guard needs only the in-cluster identity, so the hook Job carries none of the operator's install-time env and cannot fail for a missing constant while it is trying to tell you something else. Outside a pod it exits non-zero with `KUBERNETES_SERVICE_HOST is not set`, which fails the uninstall rather than silently allowing it.

## The hook

Runs the operator image under the operator's own ServiceAccount — its Role already grants `list` on `agentconnectorgs`, so no new permission is introduced. `args:` rather than `command:` so tini stays PID 1, matching how the operator stamps the daemon Deployment. `backoffLimit: 0`, and `activeDeadlineSeconds: 120` so an unreachable API server fails the uninstall on a deadline instead of hanging it until Helm's own timeout. The hook-delete-policy keeps a *failed* Job, which is the point: its log names the orgs, and the chart README and NOTES.txt both print the `kubectl logs job/<release>-operator-pre-delete` line that reads it. The container gets the same securityContext as the operator Deployment.

## Verification

`pnpm --filter @agentconnect.md/operator test` (63 tests, 4 new) and `typecheck` pass; `pnpm lint` is clean (two pre-existing daemon-test warnings only); `pnpm format:check` passes. `helm lint charts/operator` passes and the hook renders as expected under default and non-default values. The subcommand was also run for real outside a cluster to confirm the dispatch reaches it and fails fast for the right reason.

Not covered by tests: the Job's own wiring (image, SA, args) — that needs a cluster, and the repo has no chart-test harness yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
