### PR TITLE
feat(web): show a session's pull request in the dock

### DIFF
--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -905,6 +905,19 @@ finishing the inherited wip:
   deployment knows without GitHub. A GitHub 5xx reads as `unreachable`, not
   `denied` — an outage must not point operators at a nonexistent installation
   problem.
+- **A 404 probe is provisional, on a bounded ladder.** `hook/report` (which
+  writes `HookRun.sessionId`) and the terminal `event/session` snapshot are
+  separate concurrently-dispatched frames, so the session→run link can commit
+  after the status flip — or with no flip at all, when a reconnect restores an
+  already-terminal session. The panel therefore retries a held 404 on a bounded
+  backoff ladder (~2.5 min, then the absence is believed); a status transition
+  re-asks immediately and refills the ladder. These retries never reach GitHub —
+  the 404 arm is answered from the CP's own tables — so §9's rate-limit budget
+  is untouched, and an answered probe schedules nothing. The view service's
+  cache keys by `repoFullName` too (the name drives the query and URL, and
+  historical runs keep pre-rename names), and caches only the shared GitHub
+  projection: each caller's run facts (`knownIsOpen`/`knownIsDraft`/
+  `knownAgentReview`) are overlaid per return path, in-flight merges included.
 
 **M6 — PR actions.** The single Auto-fix button over the webchat turn path
 (§5.2), and `Merge when ready` (`enablePullRequestAutoMerge`) gated on the

--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -888,6 +888,24 @@ which changes what M5 has to build:
   rate-limited or denied GitHub call degrades to a panel that still names the
   PR, rather than an empty tab.
 
+Two deliberate departures from M5's original sentence, found and settled while
+finishing the inherited wip:
+
+- **"Session DTO exposes its GitHub subject" is descoped.** The console finds
+  the tab by probing `GET /sessions/:id/pull-request` once per session view: the
+  404 arm costs 2–3 indexed DB queries and never reaches GitHub, and a linked
+  session's probe is the same read the panel needs anyway, deduplicated by the
+  service's TTL cache. Putting the subject on the session DTO would burden the
+  session LIST route with a per-row run lookup (or a batched join) to save a
+  probe that is already cheap — the sentence predates the probe design.
+- **Verdict precedence is fallback, not override.** GitHub's review list is
+  authoritative whenever it answered, because it already contains the agent's
+  own review. The run's `reviewEvent` surfaces as `agentReview` only on degraded
+  answers, so a rate-limited panel still shows the one review state the
+  deployment knows without GitHub. A GitHub 5xx reads as `unreachable`, not
+  `denied` — an outage must not point operators at a nonexistent installation
+  problem.
+
 **M6 — PR actions.** The single Auto-fix button over the webchat turn path
 (§5.2), and `Merge when ready` (`enablePullRequestAutoMerge`) gated on the
 clamped token actually carrying write. _Exit:_ the design's headline loop — read
@@ -920,7 +938,10 @@ mutation.
   state; Sessions parity against the rail's own tests, which moved to
   `dock/SessionsPanel*.test.tsx` and must keep passing unchanged.
 - **control-plane `test:unit`** — DTO projections, the PR projection's
-  verdict-vs-GitHub precedence, the "no linked run" 404 path, write-capability
+  verdict-vs-GitHub precedence (GitHub's review list is authoritative when it
+  answered — it already contains the agent's review; the run's recorded
+  `reviewEvent` surfaces as `agentReview` ONLY on a degraded answer, so the
+  panel cannot double-draw it), the "no linked run" 404 path, write-capability
   clamping.
 - **control-plane `test:int`** — the authorization matrix on every new route:
   cross-org agent, restricted agent, session the viewer cannot see, agent with
@@ -947,7 +968,9 @@ a `sessionId` (the pull control was removed).
 **One deliberate departure from revision 2.** The per-thread auto-fix machine is
 not being built; the panel ships one Auto-fix action for the whole unresolved
 set (§5.2). The prototype's thread cards are therefore implemented read-only —
-location, body, and the review state that already comes from `HookRun.verdict`.
+location and body. The review state on thread cards comes from GitHub's own
+list; `HookRun`'s recorded review appears only as the degraded-arm fallback
+(`agentReview`), never beside GitHub's answer.
 
 ## 12. Open questions
 

--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -346,15 +346,15 @@ All following the existing workspace-route shape in `agents.ts`: `getOrgAgent` �
 `toDto`. Every route needs `tags`, `summary`, `description`, and a unique
 `operationId` or it renders nameless in the OpenAPI docs.
 
-| Method | Path                                                                         | Backing                              |
-| ------ | ---------------------------------------------------------------------------- | ------------------------------------ |
-| GET    | `/agents/:id/workspace/gitdiff`                                              | `workspace/gitdiff`                  |
-| GET    | `/agents/:id/workspace/gitlog`                                               | `workspace/gitlog`                   |
-| POST   | `/agents/:id/workspace/gitstage` \| `gitunstage` \| `gitcommit` \| `gitpush` | write frames                         |
-| POST   | `/agents/:id/workspace/gitmessage`                                           | `workspace/gitmessage`               |
-| GET    | `/agents/:id/tasks`                                                          | `task/list`                          |
-| GET    | `/sessions/:id/pull-request`                                                 | GitHub API via installation token    |
-| POST   | `/sessions/:id/pull-request/auto-merge`                                      | GraphQL `enablePullRequestAutoMerge` |
+| Method | Path                                                                         | Backing                                 |
+| ------ | ---------------------------------------------------------------------------- | --------------------------------------- |
+| GET    | `/agents/:id/workspace/gitdiff`                                              | `workspace/gitdiff`                     |
+| GET    | `/agents/:id/workspace/gitlog`                                               | `workspace/gitlog`                      |
+| POST   | `/agents/:id/workspace/gitstage` \| `gitunstage` \| `gitcommit` \| `gitpush` | write frames                            |
+| POST   | `/agents/:id/workspace/gitmessage`                                           | `workspace/gitmessage`                  |
+| GET    | `/agents/:id/tasks`                                                          | `task/list`                             |
+| GET    | `/sessions/:id/pull-request`                                                 | Postgres identity + GitHub REST/GraphQL |
+| POST   | `/sessions/:id/pull-request/auto-merge`                                      | GraphQL `enablePullRequestAutoMerge`    |
 
 **`GET /agents/:id/tasks` does NOT use `canReadWorkspaceScope`**, and this
 paragraph's earlier claim that it would was wrong. That gate requires
@@ -860,6 +860,33 @@ Known M4 follow-ups, none of which change what the code does today:
 status and counts; panel with checks, reviews and threads **read-only** (no
 Auto-fix, no Merge-when-ready). Tab hidden when the session has no linked run.
 _Exit:_ PR state is visible beside the conversation that is reviewing it.
+
+Three things measured against the shipped CP before writing any of it, each of
+which changes what M5 has to build:
+
+- **There is no GraphQL client in the control plane.** `github/api.ts` exposes
+  `githubRequest`, which is REST-only. Review-thread _resolution state_ does not
+  exist in REST at all — `/pulls/:n/comments` returns review comments with no
+  `isResolved` — so the design's "unresolved threads" section and its badge are
+  unbackable without one. M5 therefore adds a minimal `githubGraphql` helper
+  beside `githubRequest` (same installation auth, same timeout, same error
+  mapping, POST to `/graphql`). M6 needs it regardless for
+  `resolveReviewThread` and `enablePullRequestAutoMerge`, so this is not
+  speculative plumbing — but it was missing from this plan's route table, which
+  named both mutations as though the capability already existed.
+- **`HookRun.sessionId` is not indexed.** The lookup this route is built on — a
+  session id to the run that created it — would be a sequential scan of every
+  run in the deployment. M5 adds a migration for it. Nothing else in the plan
+  needed that column as a search key, which is why no index exists yet.
+- **The PR association is already persisted, so identity needs no GitHub call.**
+  `HookReviewProjection` carries `repoId`, `repoFullName`, `headSha`,
+  `reportSha` and `lastResolvedInstallationId`, and `HookReviewSubject` carries
+  `pullNumber`, `headSha`, `baseSha` and `isOpen` per projection — maintained by
+  the review broker's own commit→PR association pass. The route reads the PR's
+  identity and open/closed state from Postgres and spends GitHub calls only on
+  what is genuinely live: check runs, reviews, and threads. That also means a
+  rate-limited or denied GitHub call degrades to a panel that still names the
+  PR, rather than an empty tab.
 
 **M6 — PR actions.** The single Auto-fix button over the webchat turn path
 (§5.2), and `Merge when ready` (`enablePullRequestAutoMerge`) gated on the

--- a/packages/control-plane/prisma/migrations/20260811000000_hook_run_session_index/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260811000000_hook_run_session_index/migration.sql
@@ -1,0 +1,9 @@
+-- The session -> owning run lookup the console's PR panel is built on
+-- (webchat-side-panels.md §9, M5). `sessionId` was written for deep-linking only
+-- and never searched, so no index existed; without one the lookup is a
+-- sequential scan of every run in the deployment. Partial, because the column is
+-- null for the whole window between dispatch and the session being created, and
+-- those rows are never the target of this lookup.
+CREATE INDEX IF NOT EXISTS "hook_run_org_session_idx"
+  ON "hook_run" ("orgId", "sessionId")
+  WHERE "sessionId" IS NOT NULL;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1659,6 +1659,9 @@ model HookRun {
   @@index([status, startedAt])
   @@index([deliveryKey, status, redeliveryNextAttemptAt])
   @@index([status, redeliveryNextAttemptAt, redeliveryAttempts], map: "hook_run_redelivery_due_idx")
+  // The console PR panel's session -> owning run lookup. Declared unfiltered here because Prisma
+  // cannot express the partial predicate; the migration creates it WHERE sessionId IS NOT NULL.
+  @@index([orgId, sessionId], map: "hook_run_org_session_idx")
   @@map("hook_run")
 }
 

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -27,6 +27,7 @@ import { GithubInstallationDoorbell } from './github/installation-doorbell.servi
 import { GithubCommentAuthzService } from './github/comment-authz.service.js'
 import { GithubRerequestService } from './github/rerequest.service.js'
 import { GithubReviewBrokerService } from './github/review-broker.service.js'
+import { PullRequestViewService } from './github/pull-request-view.service.js'
 import { GithubRunCoordinator, GithubRunReporter } from './github/run-reporter.js'
 import { githubProjectionIntent } from './github/projection-intent.js'
 import { HookRedeliveryReconciler } from './orchestrator/hookRedeliveryReconciler.js'
@@ -708,6 +709,9 @@ export function buildContainer(
         ...(opts.githubFetch ? { fetchImpl: opts.githubFetch } : {})
       })
     : undefined
+  // The console PR panel's read projection. Long-lived because its whole point is the short TTL
+  // cache — building it per request would spend one GitHub call per panel mount.
+  const pullRequestView = github ? new PullRequestViewService(github.tokens, clock, opts.githubFetch) : undefined
   const githubReviewBroker = github
     ? new GithubReviewBrokerService({ hook: repos.hook, agent: repos.agent, github, clock })
     : undefined
@@ -945,6 +949,7 @@ export function buildContainer(
     readiness,
     searchSkillRegistry,
     ...(github ? { github } : {}),
+    ...(pullRequestView ? { pullRequestView } : {}),
     ...(githubUserAuthz ? { githubUserAuthz } : {}),
     ...(logtoIdentity ? { logtoIdentity } : {}),
     sessionAccessPlugins: [slackSessionAccess, githubSessionAccess, feishuSessionAccess],

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -709,8 +709,7 @@ export function buildContainer(
         ...(opts.githubFetch ? { fetchImpl: opts.githubFetch } : {})
       })
     : undefined
-  // The console PR panel's read projection. Long-lived because its whole point is the short TTL
-  // cache — building it per request would spend one GitHub call per panel mount.
+  // The console PR panel's read projection — long-lived so its short TTL cache actually absorbs mounts.
   const pullRequestView = github ? new PullRequestViewService(github.tokens, clock, opts.githubFetch) : undefined
   const githubReviewBroker = github
     ? new GithubReviewBrokerService({ hook: repos.hook, agent: repos.agent, github, clock })
@@ -768,6 +767,7 @@ export function buildContainer(
         recompileOrg: (orgId) => hookService.rebroadcastGithubForOrg(orgId),
         onFactsChanged: async (installationId, orgId) => {
           github.tokens.invalidateInstallation(installationId)
+          pullRequestView?.invalidateInstallation(installationId)
           github.invalidateRepositoryRoster(installationId)
           await wakeGithubReviewProjections(installationId, orgId)
           githubRunReporter?.kick()

--- a/packages/control-plane/src/github/api.ts
+++ b/packages/control-plane/src/github/api.ts
@@ -111,28 +111,28 @@ export async function githubRequest<T>(path: string, opts: GithubRequestOpts): P
   throw new GithubApiError(`github error (${res.status}): ${detail}`, res.status, 'INTERNAL', res.status >= 500)
 }
 
-/** One GraphQL query/mutation → its `data`, for the handful of facts REST does not carry.
- *  Review-thread RESOLUTION state is the reason this exists: `/pulls/:n/comments` returns the
- *  comments but has no `isResolved` on any REST route, so a panel that names unresolved threads
- *  cannot be built on REST alone. `resolveReviewThread` and `enablePullRequestAutoMerge` are
- *  likewise mutations with no REST equivalent. */
+// One GraphQL query/mutation → its `data` — for facts with no REST equivalent (thread resolution
+// state, `resolveReviewThread`, `enablePullRequestAutoMerge`).
 export async function githubGraphql<T>(
   query: string,
   variables: Record<string, unknown>,
   opts: Omit<GithubRequestOpts, 'method' | 'body'>
 ): Promise<T> {
-  // A GraphQL error is reported inside a 200, so the REST helper's status mapping cannot see it —
-  // hence the `errors` inspection below rather than reusing `githubRequest` wholesale.
-  const res = await githubRequest<{ data?: T; errors?: Array<{ type?: string; message?: string }> }>('/graphql', {
-    ...opts,
-    method: 'POST',
-    body: { query, variables }
-  })
+  // GraphQL failures ride inside a 200, so `errors` decides here — the REST status mapping cannot.
+  const res = await githubRequest<{ data?: T | null; errors?: Array<{ type?: string; message?: string }> }>(
+    '/graphql',
+    { ...opts, method: 'POST', body: { query, variables } }
+  )
+  // Partial data beats a thrown read: a field-level denial degrades that field, not the whole answer.
+  if (res?.data) return res.data
   const errors = res?.errors ?? []
   if (errors.length > 0) {
     const detail = errors.map((e) => e.message ?? e.type ?? 'unknown').join('; ')
-    // GitHub reports authorization and missing-node failures as GraphQL errors inside a 200; both
-    // are the operator-recoverable denial REST would have answered 404/403 with.
+    // GitHub's GraphQL primary rate limit is a 200 with `errors[].type === 'RATE_LIMITED'`.
+    if (errors.some((e) => e.type === 'RATE_LIMITED')) {
+      throw new GithubApiError(`github graphql rate limited: ${detail}`, 200, 'RATE_LIMITED', true)
+    }
+    // Authorization and missing-node failures — the denial REST would have answered 404/403 with.
     const denied = errors.some((e) => e.type === 'FORBIDDEN' || e.type === 'NOT_FOUND')
     throw new GithubApiError(
       `github graphql ${denied ? 'denied' : 'error'}: ${detail}`,
@@ -142,6 +142,5 @@ export async function githubGraphql<T>(
     )
   }
   // `data` absent with no `errors` is a contract violation, not a partial answer.
-  if (!res?.data) throw new GithubApiError('github graphql returned no data', 200, 'INTERNAL', false)
-  return res.data
+  throw new GithubApiError('github graphql returned no data', 200, 'INTERNAL', false)
 }

--- a/packages/control-plane/src/github/api.ts
+++ b/packages/control-plane/src/github/api.ts
@@ -110,3 +110,38 @@ export async function githubRequest<T>(path: string, opts: GithubRequestOpts): P
   // 401 = our own JWT/key is wrong (misconfig) — internal, not retryable-by-daemon.
   throw new GithubApiError(`github error (${res.status}): ${detail}`, res.status, 'INTERNAL', res.status >= 500)
 }
+
+/** One GraphQL query/mutation → its `data`, for the handful of facts REST does not carry.
+ *  Review-thread RESOLUTION state is the reason this exists: `/pulls/:n/comments` returns the
+ *  comments but has no `isResolved` on any REST route, so a panel that names unresolved threads
+ *  cannot be built on REST alone. `resolveReviewThread` and `enablePullRequestAutoMerge` are
+ *  likewise mutations with no REST equivalent. */
+export async function githubGraphql<T>(
+  query: string,
+  variables: Record<string, unknown>,
+  opts: Omit<GithubRequestOpts, 'method' | 'body'>
+): Promise<T> {
+  // A GraphQL error is reported inside a 200, so the REST helper's status mapping cannot see it —
+  // hence the `errors` inspection below rather than reusing `githubRequest` wholesale.
+  const res = await githubRequest<{ data?: T; errors?: Array<{ type?: string; message?: string }> }>('/graphql', {
+    ...opts,
+    method: 'POST',
+    body: { query, variables }
+  })
+  const errors = res?.errors ?? []
+  if (errors.length > 0) {
+    const detail = errors.map((e) => e.message ?? e.type ?? 'unknown').join('; ')
+    // GitHub reports authorization and missing-node failures as GraphQL errors inside a 200; both
+    // are the operator-recoverable denial REST would have answered 404/403 with.
+    const denied = errors.some((e) => e.type === 'FORBIDDEN' || e.type === 'NOT_FOUND')
+    throw new GithubApiError(
+      `github graphql ${denied ? 'denied' : 'error'}: ${detail}`,
+      200,
+      denied ? 'LEASE_DENIED' : 'INTERNAL',
+      false
+    )
+  }
+  // `data` absent with no `errors` is a contract violation, not a partial answer.
+  if (!res?.data) throw new GithubApiError('github graphql returned no data', 200, 'INTERNAL', false)
+  return res.data
+}

--- a/packages/control-plane/src/github/installation-token.service.ts
+++ b/packages/control-plane/src/github/installation-token.service.ts
@@ -145,6 +145,14 @@ export class InstallationTokenService {
     return this.mintPermissionLevels(installationId, repoFullName, { checks: 'write', pull_requests: 'read' }, repoId)
   }
 
+  /** CP-only READ token for the console's PR panel — PR metadata, reviews, review threads and the
+   * head commit's check rollup. There is no tier to clamp against here the way {@link mint} does:
+   * read is the permission floor, so a read-only workspace already gets exactly this. Neither
+   * permission enters a daemon grant or the agent environment. */
+  async mintPullRequestRead(installationId: bigint, repoFullName: string, repoId: bigint): Promise<MintedGitCred> {
+    return this.mintPermissionLevels(installationId, repoFullName, { checks: 'read', pull_requests: 'read' }, repoId)
+  }
+
   /** Drop every cached/in-flight token for one installation after a permission,
    * suspension, revoke, or reinstall fact changes. In-flight requests cannot be
    * cancelled, so the generation check below prevents stale repopulation. */

--- a/packages/control-plane/src/github/installation-token.service.ts
+++ b/packages/control-plane/src/github/installation-token.service.ts
@@ -145,10 +145,7 @@ export class InstallationTokenService {
     return this.mintPermissionLevels(installationId, repoFullName, { checks: 'write', pull_requests: 'read' }, repoId)
   }
 
-  /** CP-only READ token for the console's PR panel — PR metadata, reviews, review threads and the
-   * head commit's check rollup. There is no tier to clamp against here the way {@link mint} does:
-   * read is the permission floor, so a read-only workspace already gets exactly this. Neither
-   * permission enters a daemon grant or the agent environment. */
+  // CP-only READ token for the console's PR panel; read is the permission floor, so no tier clamp.
   async mintPullRequestRead(installationId: bigint, repoFullName: string, repoId: bigint): Promise<MintedGitCred> {
     return this.mintPermissionLevels(installationId, repoFullName, { checks: 'read', pull_requests: 'read' }, repoId)
   }

--- a/packages/control-plane/src/github/pull-request-view.service.test.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.test.ts
@@ -294,6 +294,43 @@ describe('degraded shapes', () => {
     expect((await bare.service.view(IDENTITY)).agentReview).toBeNull()
   })
 
+  it('never hands one run degraded fallback to another session on the same PR', async () => {
+    // The cache key is the PR; knownIsOpen/knownIsDraft/knownAgentReview belong to the caller's RUN.
+    // One shared cached answer, two different overlays — session B must not see A's recorded review.
+    const { service } = build([ok({ data: null, errors: [{ type: 'RATE_LIMITED', message: 'limit' }] })])
+    const runA: PullRequestIdentity = { ...IDENTITY, knownIsOpen: false, knownAgentReview: 'changes_requested' }
+    const runB: PullRequestIdentity = { ...IDENTITY, knownIsOpen: true, knownAgentReview: 'approved' }
+
+    const a = await service.view(runA)
+    const b = await service.view(runB) // cache hit — ONE GraphQL call for both
+    expect(a).toMatchObject({ degraded: true, state: 'closed', agentReview: 'changes_requested' })
+    expect(b).toMatchObject({ degraded: true, state: 'open', agentReview: 'approved' })
+
+    // And a caller with NO recorded review gets none, not the cached caller's.
+    const bare = await service.view(IDENTITY)
+    expect(bare.agentReview).toBeNull()
+    expect(bare.state).toBeNull()
+  })
+
+  it('overlays each caller of a SHARED in-flight read separately', async () => {
+    // Single-flight merges the request, not the answer: two runs awaiting one read still get their
+    // own facts, or the race would reintroduce exactly the leak the overlay removes.
+    let release: ((value: Response) => void) | undefined
+    const { service } = build([() => new Promise<Response>((resolve) => (release = resolve))])
+    const runA: PullRequestIdentity = { ...IDENTITY, knownAgentReview: 'changes_requested' }
+    const runB: PullRequestIdentity = { ...IDENTITY, knownAgentReview: 'approved' }
+
+    const pendingA = service.view(runA)
+    const pendingB = service.view(runB)
+    // The read awaits the token mint before it fetches, so the held fetch is not in hand yet.
+    while (!release) await new Promise((tick) => setTimeout(tick, 0))
+    release(ok({ data: null, errors: [{ type: 'RATE_LIMITED', message: 'limit' }] })())
+    const [a, b] = await Promise.all([pendingA, pendingB])
+
+    expect(a.agentReview).toBe('changes_requested')
+    expect(b.agentReview).toBe('approved')
+  })
+
   it('maps a GitHub 5xx to unreachable, not to denied', async () => {
     // 'denied' points the operator at a nonexistent installation problem for the length of an outage;
     // a server error is GitHub being down, which is the 'unreachable' story.

--- a/packages/control-plane/src/github/pull-request-view.service.test.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.test.ts
@@ -1,0 +1,453 @@
+// `PullRequestViewService` — TTL/keying/eviction of the cache, the GraphQL projection, and every
+// degraded shape (webchat-side-panels.md §3.4, M5). GitHub is a scripted `fetchImpl`; no network.
+import { describe, it, expect, vi } from 'vitest'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+import {
+  PullRequestViewService,
+  PR_VIEW_TTL_MS,
+  PR_VIEW_CACHE_MAX,
+  type PullRequestIdentity
+} from './pull-request-view.service.js'
+import type { InstallationTokenService } from './installation-token.service.js'
+import type { FetchLike } from './api.js'
+import { OrgId } from '../domain/ids.js'
+
+const IDENTITY: PullRequestIdentity = {
+  orgId: OrgId('org_a'),
+  installationId: 111n,
+  repoId: 42n,
+  repoFullName: 'acme/repo',
+  pullNumber: 7
+}
+
+function fakeTokens(): { mint: ReturnType<typeof vi.fn>; tokens: InstallationTokenService } {
+  const mint = vi.fn(async () => ({
+    token: 'ghs_test',
+    ttlSec: 3600,
+    expiresAt: '2026-08-11T01:00:00Z',
+    repoFullName: 'acme/repo',
+    access: 'read' as const
+  }))
+  return { mint, tokens: { mintPullRequestRead: mint } as unknown as InstallationTokenService }
+}
+
+// A full GraphQL answer: 2 checks (one classic status), 2 reviews, 3 threads (one resolved, one outdated).
+function fullAnswer(): Record<string, unknown> {
+  return {
+    data: {
+      repository: {
+        pullRequest: {
+          number: 7,
+          title: 'Ship the panel',
+          state: 'OPEN',
+          isDraft: false,
+          merged: false,
+          additions: 120,
+          deletions: 8,
+          url: 'https://github.com/acme/repo/pull/7',
+          baseRefName: 'main',
+          headRefName: 'feat/panel',
+          reviewDecision: 'CHANGES_REQUESTED',
+          latestReviews: {
+            nodes: [
+              { state: 'APPROVED', author: { login: 'dana', __typename: 'User' } },
+              { state: 'CHANGES_REQUESTED', author: { login: 'review-bot', __typename: 'Bot' } },
+              { state: 'COMMENTED', author: null }
+            ]
+          },
+          commits: {
+            nodes: [
+              {
+                commit: {
+                  statusCheckRollup: {
+                    contexts: {
+                      pageInfo: { hasNextPage: false },
+                      nodes: [
+                        {
+                          __typename: 'CheckRun',
+                          name: 'unit',
+                          conclusion: 'SUCCESS',
+                          status: 'COMPLETED',
+                          startedAt: '2026-08-11T00:00:00Z',
+                          completedAt: '2026-08-11T00:05:00Z',
+                          detailsUrl: 'https://ci.example/unit'
+                        },
+                        {
+                          __typename: 'StatusContext',
+                          context: 'legacy-ci',
+                          state: 'FAILURE',
+                          targetUrl: 'https://ci.example/legacy',
+                          createdAt: '2026-08-11T00:01:00Z'
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          reviewThreads: {
+            totalCount: 3,
+            nodes: [
+              {
+                isResolved: false,
+                isOutdated: false,
+                path: 'src/app.ts',
+                line: 12,
+                comments: { nodes: [{ body: 'rename this', author: { login: 'dana' } }] }
+              },
+              {
+                isResolved: true,
+                isOutdated: false,
+                path: 'src/done.ts',
+                line: 1,
+                comments: { nodes: [{ body: 'fixed', author: { login: 'dana' } }] }
+              },
+              {
+                isResolved: false,
+                isOutdated: true,
+                path: 'src/moved.ts',
+                line: null,
+                comments: { nodes: [{ body: 'outdated note', author: { login: 'review-bot' } }] }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+// Scripted GitHub: each call shifts the next reply; `calls` records how many reads actually happened.
+function scriptedFetch(replies: Array<() => Response | Promise<Response>>): {
+  fetch: FetchLike
+  calls: Array<{ url: string; body: unknown }>
+} {
+  const calls: Array<{ url: string; body: unknown }> = []
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined })
+    const next = replies.shift()
+    if (!next) throw new Error('unexpected extra GitHub call')
+    return next()
+  }
+  return { fetch, calls }
+}
+
+const ok = (body: unknown) => () =>
+  new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+
+function build(replies: Array<() => Response | Promise<Response>>) {
+  const clock = new FakeClock(1_000_000)
+  const { mint, tokens } = fakeTokens()
+  const { fetch, calls } = scriptedFetch(replies)
+  const service = new PullRequestViewService(tokens, clock, fetch)
+  return { service, clock, mint, calls }
+}
+
+describe('projection mapping', () => {
+  it('projects one full GraphQL answer onto the panel view', async () => {
+    const { service, calls } = build([ok(fullAnswer())])
+
+    const view = await service.view(IDENTITY)
+
+    expect(view).toEqual({
+      repoFullName: 'acme/repo',
+      pullNumber: 7,
+      title: 'Ship the panel',
+      state: 'open',
+      isDraft: false,
+      url: 'https://github.com/acme/repo/pull/7',
+      headRef: 'feat/panel',
+      baseRef: 'main',
+      additions: 120,
+      deletions: 8,
+      reviewDecision: 'changes_requested',
+      checks: [
+        {
+          name: 'unit',
+          state: 'success',
+          detail: 'SUCCESS',
+          startedAt: '2026-08-11T00:00:00Z',
+          completedAt: '2026-08-11T00:05:00Z',
+          url: 'https://ci.example/unit'
+        },
+        {
+          name: 'legacy-ci',
+          state: 'failure',
+          detail: 'FAILURE',
+          startedAt: '2026-08-11T00:01:00Z',
+          completedAt: null,
+          url: 'https://ci.example/legacy'
+        }
+      ],
+      checksTruncated: false,
+      reviews: [
+        { author: 'dana', state: 'approved', isBot: false },
+        { author: 'review-bot', state: 'changes_requested', isBot: true }
+      ],
+      threads: [
+        { location: 'src/app.ts:12', body: 'rename this', author: 'dana', isOutdated: false },
+        { location: 'src/moved.ts', body: 'outdated note', author: 'review-bot', isOutdated: true }
+      ],
+      unresolvedCount: 2,
+      threadsTruncated: false,
+      degraded: false,
+      degradedReason: null,
+      agentReview: null
+    })
+    // One GraphQL POST, carrying the PR coordinates — not one call per fact.
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe('https://api.github.com/graphql')
+    expect((calls[0]!.body as { variables: Record<string, unknown> }).variables).toMatchObject({
+      owner: 'acme',
+      name: 'repo',
+      number: 7
+    })
+  })
+
+  it('marks a merged PR merged and reads truncation from the connection itself', async () => {
+    const answer = fullAnswer()
+    const pr = (answer as { data: { repository: { pullRequest: Record<string, unknown> } } }).data.repository
+      .pullRequest
+    pr['state'] = 'MERGED'
+    pr['merged'] = true
+    ;(
+      pr['commits'] as {
+        nodes: Array<{ commit: { statusCheckRollup: { contexts: { pageInfo: { hasNextPage: boolean } } } } }>
+      }
+    ).nodes[0]!.commit.statusCheckRollup.contexts.pageInfo.hasNextPage = true
+    ;(pr['reviewThreads'] as { totalCount: number }).totalCount = 31
+    const { service } = build([ok(answer)])
+
+    const view = await service.view(IDENTITY)
+
+    expect(view.state).toBe('merged')
+    expect(view.checksTruncated).toBe(true) // pageInfo.hasNextPage, not a page-size heuristic
+    expect(view.threadsTruncated).toBe(true) // totalCount past the 30-thread page
+  })
+
+  it('tolerates field-level GraphQL errors when data is present, instead of degrading the read', async () => {
+    const answer = fullAnswer() as Record<string, unknown>
+    answer['errors'] = [{ type: 'FORBIDDEN', message: 'statuses denied on StatusContext.state' }]
+    const { service } = build([ok(answer)])
+
+    const view = await service.view(IDENTITY)
+
+    expect(view.degraded).toBe(false)
+    expect(view.title).toBe('Ship the panel')
+  })
+})
+
+describe('degraded shapes', () => {
+  const hinted: PullRequestIdentity = { ...IDENTITY, knownIsOpen: false, knownIsDraft: true }
+
+  it('maps a GraphQL RATE_LIMITED error to rate_limited, with identity from Postgres', async () => {
+    const { service } = build([ok({ data: null, errors: [{ type: 'RATE_LIMITED', message: 'API rate limit' }] })])
+
+    const view = await service.view(hinted)
+
+    expect(view).toMatchObject({
+      degraded: true,
+      degradedReason: 'rate_limited',
+      repoFullName: 'acme/repo',
+      pullNumber: 7,
+      url: 'https://github.com/acme/repo/pull/7',
+      // Postgres facts, not fabrication: the subject said closed, the run said draft, counts unknown.
+      state: 'closed',
+      isDraft: true,
+      additions: null,
+      deletions: null,
+      checks: [],
+      reviews: [],
+      threads: []
+    })
+  })
+
+  it('leaves state and isDraft null when degraded with no Postgres facts to fall back on', async () => {
+    const { service } = build([ok({ data: null, errors: [{ type: 'RATE_LIMITED', message: 'limit' }] })])
+
+    const view = await service.view(IDENTITY)
+
+    expect(view.degraded).toBe(true)
+    expect(view.state).toBeNull()
+    expect(view.isDraft).toBeNull()
+  })
+
+  it('carries the run recorded review ONLY when degraded — GitHub list is authoritative when it answered', async () => {
+    // The precedence the plan (§10) requires, living in the service: a degraded answer falls back to
+    // the one review state the deployment knows without GitHub — its own agent's, off the owning run —
+    // while an answered read carries null, because GitHub's list already contains that review and a
+    // second copy would invite the panel to double-draw it.
+    const withReview: PullRequestIdentity = { ...IDENTITY, knownAgentReview: 'changes_requested' }
+
+    const degraded = build([ok({ data: null, errors: [{ type: 'RATE_LIMITED', message: 'limit' }] })])
+    expect(await degraded.service.view(withReview)).toMatchObject({
+      degraded: true,
+      agentReview: 'changes_requested'
+    })
+
+    const answered = build([ok(fullAnswer())])
+    expect(await answered.service.view(withReview)).toMatchObject({ degraded: false, agentReview: null })
+
+    // And a degraded read with nothing recorded carries null rather than a guess.
+    const bare = build([ok({ data: null, errors: [{ type: 'RATE_LIMITED', message: 'limit' }] })])
+    expect((await bare.service.view(IDENTITY)).agentReview).toBeNull()
+  })
+
+  it('maps a GitHub 5xx to unreachable, not to denied', async () => {
+    // 'denied' points the operator at a nonexistent installation problem for the length of an outage;
+    // a server error is GitHub being down, which is the 'unreachable' story.
+    const { service } = build([() => new Response('Server Error', { status: 502 })])
+
+    const view = await service.view(IDENTITY)
+
+    expect(view).toMatchObject({ degraded: true, degradedReason: 'unreachable' })
+  })
+
+  it('maps a REST-level rate limit (403 + x-ratelimit-remaining: 0) to rate_limited', async () => {
+    const { service } = build([
+      () =>
+        new Response(JSON.stringify({ message: 'API rate limit exceeded' }), {
+          status: 403,
+          headers: { 'x-ratelimit-remaining': '0' }
+        })
+    ])
+
+    const view = await service.view(IDENTITY)
+
+    expect(view).toMatchObject({ degraded: true, degradedReason: 'rate_limited' })
+  })
+
+  it('maps a FORBIDDEN GraphQL denial and a vanished PR both to denied', async () => {
+    const { service } = build([
+      ok({ data: null, errors: [{ type: 'FORBIDDEN', message: 'nope' }] }),
+      ok({ data: { repository: { pullRequest: null } } })
+    ])
+    const other: PullRequestIdentity = { ...IDENTITY, pullNumber: 8 }
+
+    expect(await service.view(IDENTITY)).toMatchObject({ degraded: true, degradedReason: 'denied' })
+    expect(await service.view(other)).toMatchObject({ degraded: true, degradedReason: 'denied' })
+  })
+
+  it('maps a network failure to unreachable', async () => {
+    const { service } = build([
+      () => {
+        throw new TypeError('fetch failed')
+      }
+    ])
+
+    const view = await service.view(IDENTITY)
+
+    expect(view).toMatchObject({ degraded: true, degradedReason: 'unreachable' })
+  })
+})
+
+describe('TTL cache', () => {
+  it('serves a fresh hit without a second GitHub call, then refetches after the TTL', async () => {
+    const { service, clock, calls, mint } = build([ok(fullAnswer()), ok(fullAnswer())])
+
+    await service.view(IDENTITY)
+    clock.advance(PR_VIEW_TTL_MS - 1)
+    await service.view(IDENTITY)
+    expect(calls).toHaveLength(1)
+    expect(mint).toHaveBeenCalledTimes(1)
+
+    clock.advance(1) // now exactly TTL past the store
+    await service.view(IDENTITY)
+    expect(calls).toHaveLength(2)
+  })
+
+  it('caches a degraded answer too, so a rate-limited installation is not hammered per mount', async () => {
+    const { service, clock, calls } = build([
+      ok({ data: null, errors: [{ type: 'RATE_LIMITED', message: 'limit' }] }),
+      ok(fullAnswer())
+    ])
+
+    expect((await service.view(IDENTITY)).degradedReason).toBe('rate_limited')
+    clock.advance(PR_VIEW_TTL_MS - 1)
+    expect((await service.view(IDENTITY)).degradedReason).toBe('rate_limited')
+    expect(calls).toHaveLength(1)
+
+    clock.advance(PR_VIEW_TTL_MS)
+    expect((await service.view(IDENTITY)).degraded).toBe(false)
+    expect(calls).toHaveLength(2)
+  })
+
+  it('coalesces concurrent reads into one GitHub call — force included', async () => {
+    let release!: (r: Response) => void
+    const gate = new Promise<Response>((resolve) => (release = resolve))
+    const { service, calls } = build([() => gate])
+
+    const first = service.view(IDENTITY)
+    const second = service.view(IDENTITY)
+    const forced = service.view(IDENTITY, true)
+    release(ok(fullAnswer())())
+
+    const views = await Promise.all([first, second, forced])
+    expect(calls).toHaveLength(1)
+    expect(views[0]).toBe(views[1])
+    expect(views[0]).toBe(views[2])
+  })
+
+  it('force bypasses a still-fresh cache entry', async () => {
+    const { service, calls } = build([ok(fullAnswer()), ok(fullAnswer())])
+
+    await service.view(IDENTITY)
+    await service.view(IDENTITY, true)
+
+    expect(calls).toHaveLength(2)
+  })
+})
+
+describe('cache keying and eviction', () => {
+  it('never serves one org’s cached view to another org on the same repo/PR', async () => {
+    const { service, calls, mint } = build([ok(fullAnswer()), ok(fullAnswer())])
+    const orgB: PullRequestIdentity = { ...IDENTITY, orgId: OrgId('org_b'), installationId: 222n }
+
+    await service.view(IDENTITY)
+    await service.view(orgB)
+
+    // Two reads, two token mints — org B validates its OWN installation instead of riding org A's.
+    expect(calls).toHaveLength(2)
+    expect(mint).toHaveBeenCalledTimes(2)
+    expect(mint).toHaveBeenNthCalledWith(1, 111n, 'acme/repo', 42n)
+    expect(mint).toHaveBeenNthCalledWith(2, 222n, 'acme/repo', 42n)
+  })
+
+  it('drops an installation’s cached views when its facts change', async () => {
+    const { service, calls } = build([ok(fullAnswer()), ok(fullAnswer())])
+
+    await service.view(IDENTITY)
+    service.invalidateInstallation(IDENTITY.installationId)
+    await service.view(IDENTITY)
+
+    expect(calls).toHaveLength(2)
+  })
+
+  it('drops one PR on invalidate() and keeps its neighbours cached', async () => {
+    const { service, calls } = build([ok(fullAnswer()), ok(fullAnswer()), ok(fullAnswer())])
+    const other: PullRequestIdentity = { ...IDENTITY, pullNumber: 8 }
+
+    await service.view(IDENTITY)
+    await service.view(other)
+    service.invalidate(IDENTITY.repoId, IDENTITY.pullNumber)
+    await service.view(other) // still cached
+    await service.view(IDENTITY) // refetched
+
+    expect(calls).toHaveLength(3)
+  })
+
+  it('holds at most PR_VIEW_CACHE_MAX entries, evicting the oldest', async () => {
+    const replies = Array.from({ length: PR_VIEW_CACHE_MAX + 2 }, () => ok(fullAnswer()))
+    const { service, calls } = build(replies)
+
+    for (let i = 0; i < PR_VIEW_CACHE_MAX + 1; i++) {
+      await service.view({ ...IDENTITY, pullNumber: 100 + i })
+    }
+    expect(calls).toHaveLength(PR_VIEW_CACHE_MAX + 1)
+
+    // The first-viewed PR was evicted (cap), so re-reading it costs a call; the cache never exceeds the cap.
+    await service.view({ ...IDENTITY, pullNumber: 100 })
+    expect(calls).toHaveLength(PR_VIEW_CACHE_MAX + 2)
+  })
+})

--- a/packages/control-plane/src/github/pull-request-view.service.test.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.test.ts
@@ -331,6 +331,19 @@ describe('degraded shapes', () => {
     expect(b.agentReview).toBe('approved')
   })
 
+  it('keys the cache by repoFullName too — runs across a repository rename never share a projection', async () => {
+    // Historical runs keep pre-rename names, and the name drives the GraphQL query and the cached URL:
+    // sharing on numeric identity alone would serve one name's denied/stale answer to the other.
+    const { service, calls } = build([ok(fullAnswer()), ok(fullAnswer())])
+    const oldName: PullRequestIdentity = { ...IDENTITY, repoFullName: 'acme/repo-old' }
+
+    await service.view(IDENTITY)
+    await service.view(oldName)
+
+    expect(calls).toHaveLength(2)
+    expect((calls[1]?.body as { variables: { owner: string; name: string } }).variables.name).toBe('repo-old')
+  })
+
   it('maps a GitHub 5xx to unreachable, not to denied', async () => {
     // 'denied' points the operator at a nonexistent installation problem for the length of an outage;
     // a server error is GitHub being down, which is the 'unreachable' story.

--- a/packages/control-plane/src/github/pull-request-view.service.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.ts
@@ -1,0 +1,350 @@
+/**
+ * `PullRequestViewService` — the console PR panel's read projection
+ * (webchat-side-panels.md §3.4, M5).
+ *
+ * Two sources, deliberately split by what is durable and what is live:
+ *
+ * - IDENTITY comes from Postgres. The run that owns the session already carries the repo, the PR
+ *   number and the head/base shas, and the review broker's own association pass keeps them
+ *   current. So a rate-limited or denied GitHub call still leaves a panel that names its PR
+ *   instead of an empty tab.
+ * - STATE comes from GitHub, in ONE GraphQL call. Four REST calls (pull, reviews, check-runs,
+ *   comments) would answer most of it, but review-thread RESOLUTION exists only in GraphQL — and
+ *   spending one request instead of four is what keeps a panel that several open sessions poll
+ *   from being the thing that exhausts an installation's rate limit.
+ *
+ * Nothing here is persisted. Review-thread bodies are user content and fall under body-locality
+ * exactly as a transcript does; the short in-memory TTL below exists to absorb repeated opens of
+ * the same PR, not to become a store.
+ */
+import { GithubApiError, githubGraphql, type FetchLike } from './api.js'
+import type { InstallationTokenService } from './installation-token.service.js'
+import type { Clock } from '../clock.js'
+
+/** How long one PR's projection is reused. Long enough that reopening the tab or switching between
+ *  sessions on the same PR costs nothing, short enough that a check flipping to green shows up
+ *  without a manual refresh. The panel's own refresh action bypasses it. */
+export const PR_VIEW_TTL_MS = 20_000
+
+/** Review threads per read. A reviewer who left more than this has made the panel the wrong tool;
+ *  `threadsTruncated` says so rather than the list quietly ending. */
+const THREAD_LIMIT = 30
+
+/** Check contexts per read, over the head commit's rollup. */
+const CHECK_LIMIT = 50
+
+/** Latest-review rows per read — one per reviewer, not one per review event. */
+const REVIEW_LIMIT = 20
+
+export type PrCheckState = 'success' | 'failure' | 'pending' | 'skipped' | 'neutral'
+
+export interface PrCheck {
+  name: string
+  state: PrCheckState
+  /** GitHub's own word for it, kept verbatim so the panel never has to invent one. */
+  detail: string | null
+  startedAt: string | null
+  completedAt: string | null
+  url: string | null
+}
+
+export type PrReviewState = 'approved' | 'changes_requested' | 'commented' | 'dismissed' | 'pending'
+
+export interface PrReview {
+  author: string
+  state: PrReviewState
+  /** True when the review came from an agent acting as a GitHub App rather than a person — the
+   *  identity split the design draws as square-vs-circle. */
+  isBot: boolean
+}
+
+export interface PrThread {
+  /** `path:line`, or just the path when GitHub has no line (an outdated or file-level thread). */
+  location: string
+  body: string
+  author: string
+  isOutdated: boolean
+}
+
+export interface PullRequestView {
+  repoFullName: string
+  pullNumber: number
+  title: string
+  /** `open` | `closed` | `merged` — merged is reported separately by GitHub and folded in here. */
+  state: 'open' | 'closed' | 'merged'
+  isDraft: boolean
+  url: string
+  headRef: string
+  baseRef: string
+  additions: number
+  deletions: number
+  /** GitHub's aggregate review decision, absent when it has formed none. */
+  reviewDecision: 'approved' | 'changes_requested' | 'review_required' | null
+  checks: PrCheck[]
+  checksTruncated: boolean
+  reviews: PrReview[]
+  threads: PrThread[]
+  /** Unresolved threads GitHub counted, which can exceed the rows carried. */
+  unresolvedCount: number
+  threadsTruncated: boolean
+  /** True when identity is from Postgres but GitHub could not be reached or refused. Everything
+   *  after `baseRef` is then empty, and the panel says why rather than drawing "no checks". */
+  degraded: boolean
+  degradedReason: 'rate_limited' | 'denied' | 'unreachable' | null
+}
+
+const QUERY = `
+query PanelPullRequest($owner:String!,$name:String!,$number:Int!,$threads:Int!,$checks:Int!,$reviews:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      number title state isDraft merged additions deletions url
+      baseRefName headRefName reviewDecision
+      latestReviews(first:$reviews){nodes{state author{login __typename}}}
+      commits(last:1){nodes{commit{statusCheckRollup{contexts(first:$checks){nodes{
+        __typename
+        ... on CheckRun{name conclusion status startedAt completedAt detailsUrl}
+        ... on StatusContext{context state targetUrl createdAt}
+      }}}}}}
+      reviewThreads(first:$threads){
+        totalCount
+        nodes{isResolved isOutdated path line comments(first:1){nodes{body author{login}}}}
+      }
+    }
+  }
+}`
+
+interface GqlAnswer {
+  repository: {
+    pullRequest: {
+      number: number
+      title: string
+      state: 'OPEN' | 'CLOSED' | 'MERGED'
+      isDraft: boolean
+      merged: boolean
+      additions: number
+      deletions: number
+      url: string
+      baseRefName: string
+      headRefName: string
+      reviewDecision: 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | null
+      latestReviews: { nodes: Array<{ state: string; author: { login: string; __typename: string } | null }> | null }
+      commits: {
+        nodes: Array<{
+          commit: {
+            statusCheckRollup: { contexts: { nodes: Array<Record<string, unknown>> | null } } | null
+          }
+        }> | null
+      }
+      reviewThreads: {
+        totalCount: number
+        nodes: Array<{
+          isResolved: boolean
+          isOutdated: boolean
+          path: string | null
+          line: number | null
+          comments: { nodes: Array<{ body: string; author: { login: string } | null }> | null }
+        }> | null
+      }
+    } | null
+  } | null
+}
+
+/** A CheckRun's conclusion/status, or a StatusContext's state, onto one vocabulary. GitHub spells
+ *  the same outcome three ways depending on which kind of check reported it. */
+function checkState(raw: Record<string, unknown>): PrCheckState {
+  const word = String(raw['conclusion'] ?? raw['state'] ?? raw['status'] ?? '').toUpperCase()
+  if (word === 'SUCCESS') return 'success'
+  if (word === 'FAILURE' || word === 'TIMED_OUT' || word === 'STARTUP_FAILURE' || word === 'ERROR') return 'failure'
+  if (word === 'CANCELLED' || word === 'SKIPPED') return 'skipped'
+  if (word === 'NEUTRAL' || word === 'ACTION_REQUIRED' || word === 'STALE') return 'neutral'
+  return 'pending'
+}
+
+function reviewState(raw: string): PrReviewState {
+  const word = raw.toUpperCase()
+  if (word === 'APPROVED') return 'approved'
+  if (word === 'CHANGES_REQUESTED') return 'changes_requested'
+  if (word === 'DISMISSED') return 'dismissed'
+  if (word === 'COMMENTED') return 'commented'
+  return 'pending'
+}
+
+/** Why GitHub did not answer, in the panel's vocabulary. A GraphQL denial arrives as a 200 with
+ *  `errors`, which is why the code rather than the status decides. */
+function degradedReasonOf(err: unknown): PullRequestView['degradedReason'] {
+  if (!(err instanceof GithubApiError)) return 'unreachable'
+  if (err.code === 'RATE_LIMITED') return 'rate_limited'
+  if (err.code === 'LEASE_DENIED') return 'denied'
+  return err.status === 0 ? 'unreachable' : 'denied'
+}
+
+/** The durable half — what the caller has already resolved from the owning run. */
+export interface PullRequestIdentity {
+  installationId: bigint
+  repoId: bigint
+  repoFullName: string
+  pullNumber: number
+}
+
+interface CacheEntry {
+  at: number
+  view: PullRequestView
+}
+
+export class PullRequestViewService {
+  private readonly cache = new Map<string, CacheEntry>()
+  private readonly inFlight = new Map<string, Promise<PullRequestView>>()
+
+  constructor(
+    private readonly tokens: InstallationTokenService,
+    private readonly clock: Clock,
+    private readonly fetchImpl?: FetchLike,
+    private readonly baseUrl?: string
+  ) {}
+
+  /** One PR's projection. `force` skips the TTL (the panel's refresh action) but still shares an
+   *  in-flight read, so a double press is one request. */
+  async view(identity: PullRequestIdentity, force = false): Promise<PullRequestView> {
+    const key = `${identity.repoId}#${identity.pullNumber}`
+    const now = this.clock.now().getTime()
+    if (!force) {
+      const hit = this.cache.get(key)
+      if (hit && now - hit.at < PR_VIEW_TTL_MS) return hit.view
+    }
+    const running = this.inFlight.get(key)
+    if (running) return running
+
+    const read = this.read(identity)
+      .then((view) => {
+        // A degraded answer is cached too, and for the same reason a good one is: a rate-limited
+        // installation must not be hammered once per panel mount.
+        this.cache.set(key, { at: this.clock.now().getTime(), view })
+        return view
+      })
+      .finally(() => this.inFlight.delete(key))
+    this.inFlight.set(key, read)
+    return read
+  }
+
+  /** Drop one PR's cached projection — for a caller that just changed the PR itself (M6). */
+  invalidate(repoId: bigint, pullNumber: number): void {
+    this.cache.delete(`${repoId}#${pullNumber}`)
+  }
+
+  private async read(identity: PullRequestIdentity): Promise<PullRequestView> {
+    const [owner, name] = identity.repoFullName.split('/')
+    const base: PullRequestView = {
+      repoFullName: identity.repoFullName,
+      pullNumber: identity.pullNumber,
+      title: '',
+      state: 'open',
+      isDraft: false,
+      url: `https://github.com/${identity.repoFullName}/pull/${identity.pullNumber}`,
+      headRef: '',
+      baseRef: '',
+      additions: 0,
+      deletions: 0,
+      reviewDecision: null,
+      checks: [],
+      checksTruncated: false,
+      reviews: [],
+      threads: [],
+      unresolvedCount: 0,
+      threadsTruncated: false,
+      degraded: false,
+      degradedReason: null
+    }
+    if (!owner || !name) return { ...base, degraded: true, degradedReason: 'denied' }
+
+    let answer: GqlAnswer
+    try {
+      const cred = await this.tokens.mintPullRequestRead(
+        identity.installationId,
+        identity.repoFullName,
+        identity.repoId
+      )
+      answer = await githubGraphql<GqlAnswer>(
+        QUERY,
+        {
+          owner,
+          name,
+          number: identity.pullNumber,
+          threads: THREAD_LIMIT,
+          checks: CHECK_LIMIT,
+          reviews: REVIEW_LIMIT
+        },
+        {
+          auth: cred.token,
+          ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+          ...(this.baseUrl ? { baseUrl: this.baseUrl } : {})
+        }
+      )
+    } catch (err) {
+      return { ...base, degraded: true, degradedReason: degradedReasonOf(err) }
+    }
+
+    const pr = answer.repository?.pullRequest
+    // A PR the installation can see but that no longer exists reads as denied rather than as an
+    // empty PR: "0 checks on #764" would be a claim, and we have not got one.
+    if (!pr) return { ...base, degraded: true, degradedReason: 'denied' }
+
+    const contexts = pr.commits?.nodes?.[0]?.commit?.statusCheckRollup?.contexts?.nodes ?? []
+    const checks: PrCheck[] = contexts.map((raw) => ({
+      name: String(raw['name'] ?? raw['context'] ?? 'check'),
+      state: checkState(raw),
+      detail: raw['conclusion'] ? String(raw['conclusion']) : raw['state'] ? String(raw['state']) : null,
+      startedAt: raw['startedAt'] ? String(raw['startedAt']) : raw['createdAt'] ? String(raw['createdAt']) : null,
+      completedAt: raw['completedAt'] ? String(raw['completedAt']) : null,
+      url: raw['detailsUrl'] ? String(raw['detailsUrl']) : raw['targetUrl'] ? String(raw['targetUrl']) : null
+    }))
+
+    const reviews: PrReview[] = (pr.latestReviews?.nodes ?? [])
+      .filter((node) => node.author !== null)
+      .map((node) => ({
+        author: node.author?.login ?? '',
+        state: reviewState(node.state),
+        isBot: node.author?.__typename === 'Bot'
+      }))
+
+    // Resolved threads are dropped HERE rather than in the query, because GraphQL cannot filter a
+    // connection by `isResolved` — so `totalCount` counts every thread and the unresolved count
+    // has to be derived from the page. That makes it a floor when the page is truncated, which is
+    // what `threadsTruncated` tells the panel.
+    const unresolved = (pr.reviewThreads?.nodes ?? []).filter((node) => !node.isResolved)
+    const threads: PrThread[] = unresolved.map((node) => {
+      const comment = node.comments?.nodes?.[0]
+      return {
+        location: node.path ? (node.line ? `${node.path}:${node.line}` : node.path) : 'this pull request',
+        body: comment?.body ?? '',
+        author: comment?.author?.login ?? '',
+        isOutdated: node.isOutdated
+      }
+    })
+
+    return {
+      ...base,
+      title: pr.title,
+      state: pr.merged ? 'merged' : pr.state === 'CLOSED' ? 'closed' : 'open',
+      isDraft: pr.isDraft,
+      url: pr.url || base.url,
+      headRef: pr.headRefName,
+      baseRef: pr.baseRefName,
+      additions: pr.additions,
+      deletions: pr.deletions,
+      reviewDecision:
+        pr.reviewDecision === 'APPROVED'
+          ? 'approved'
+          : pr.reviewDecision === 'CHANGES_REQUESTED'
+            ? 'changes_requested'
+            : pr.reviewDecision === 'REVIEW_REQUIRED'
+              ? 'review_required'
+              : null,
+      checks,
+      checksTruncated: contexts.length >= CHECK_LIMIT,
+      reviews,
+      threads,
+      unresolvedCount: unresolved.length,
+      threadsTruncated: (pr.reviewThreads?.totalCount ?? 0) > THREAD_LIMIT
+    }
+  }
+}

--- a/packages/control-plane/src/github/pull-request-view.service.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.ts
@@ -19,7 +19,7 @@
  */
 import { GithubApiError, githubGraphql, type FetchLike } from './api.js'
 import type { InstallationTokenService } from './installation-token.service.js'
-import type { Clock } from '../clock.js'
+import type { Clock } from '../domain/clock.js'
 
 /** How long one PR's projection is reused. Long enough that reopening the tab or switching between
  *  sessions on the same PR costs nothing, short enough that a check flipping to green shows up
@@ -206,7 +206,7 @@ export class PullRequestViewService {
    *  in-flight read, so a double press is one request. */
   async view(identity: PullRequestIdentity, force = false): Promise<PullRequestView> {
     const key = `${identity.repoId}#${identity.pullNumber}`
-    const now = this.clock.now().getTime()
+    const now = this.clock.now()
     if (!force) {
       const hit = this.cache.get(key)
       if (hit && now - hit.at < PR_VIEW_TTL_MS) return hit.view
@@ -218,7 +218,7 @@ export class PullRequestViewService {
       .then((view) => {
         // A degraded answer is cached too, and for the same reason a good one is: a rate-limited
         // installation must not be hammered once per panel mount.
-        this.cache.set(key, { at: this.clock.now().getTime(), view })
+        this.cache.set(key, { at: this.clock.now(), view })
         return view
       })
       .finally(() => this.inFlight.delete(key))

--- a/packages/control-plane/src/github/pull-request-view.service.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.ts
@@ -1,39 +1,27 @@
-/**
- * `PullRequestViewService` — the console PR panel's read projection
- * (webchat-side-panels.md §3.4, M5).
- *
- * Two sources, deliberately split by what is durable and what is live:
- *
- * - IDENTITY comes from Postgres. The run that owns the session already carries the repo, the PR
- *   number and the head/base shas, and the review broker's own association pass keeps them
- *   current. So a rate-limited or denied GitHub call still leaves a panel that names its PR
- *   instead of an empty tab.
- * - STATE comes from GitHub, in ONE GraphQL call. Four REST calls (pull, reviews, check-runs,
- *   comments) would answer most of it, but review-thread RESOLUTION exists only in GraphQL — and
- *   spending one request instead of four is what keeps a panel that several open sessions poll
- *   from being the thing that exhausts an installation's rate limit.
- *
- * Nothing here is persisted. Review-thread bodies are user content and fall under body-locality
- * exactly as a transcript does; the short in-memory TTL below exists to absorb repeated opens of
- * the same PR, not to become a store.
- */
+// `PullRequestViewService` — the console PR panel's read projection (webchat-side-panels.md §3.4, M5).
+// Identity is Postgres's (the owning run names the repo/PR even when GitHub is down); live state is
+// GitHub's, in ONE bounded GraphQL call — thread RESOLUTION exists only there, and one request instead
+// of four is what keeps several polling sessions from exhausting an installation's rate limit.
+// Nothing is persisted: thread bodies are user content (body-locality), and the short TTL cache below
+// exists to absorb repeated opens of the same PR, not to become a store.
 import { GithubApiError, githubGraphql, type FetchLike } from './api.js'
 import type { InstallationTokenService } from './installation-token.service.js'
 import type { Clock } from '../domain/clock.js'
+import type { OrgId } from '../domain/ids.js'
 
-/** How long one PR's projection is reused. Long enough that reopening the tab or switching between
- *  sessions on the same PR costs nothing, short enough that a check flipping to green shows up
- *  without a manual refresh. The panel's own refresh action bypasses it. */
+// Reuse window: reopening the tab is free, a check flipping green still shows up; refresh bypasses it.
 export const PR_VIEW_TTL_MS = 20_000
 
-/** Review threads per read. A reviewer who left more than this has made the panel the wrong tool;
- *  `threadsTruncated` says so rather than the list quietly ending. */
+// Hard bound on retained entries — the cache holds thread bodies, so it must never grow into a store.
+export const PR_VIEW_CACHE_MAX = 256
+
+// Review threads per read; `threadsTruncated` says so rather than the list quietly ending.
 const THREAD_LIMIT = 30
 
-/** Check contexts per read, over the head commit's rollup. */
+// Check contexts per read, over the head commit's rollup.
 const CHECK_LIMIT = 50
 
-/** Latest-review rows per read — one per reviewer, not one per review event. */
+// Latest-review rows per read — one per reviewer, not one per review event.
 const REVIEW_LIMIT = 20
 
 export type PrCheckState = 'success' | 'failure' | 'pending' | 'skipped' | 'neutral'
@@ -41,8 +29,7 @@ export type PrCheckState = 'success' | 'failure' | 'pending' | 'skipped' | 'neut
 export interface PrCheck {
   name: string
   state: PrCheckState
-  /** GitHub's own word for it, kept verbatim so the panel never has to invent one. */
-  detail: string | null
+  detail: string | null // GitHub's own word for it, kept verbatim
   startedAt: string | null
   completedAt: string | null
   url: string | null
@@ -53,14 +40,11 @@ export type PrReviewState = 'approved' | 'changes_requested' | 'commented' | 'di
 export interface PrReview {
   author: string
   state: PrReviewState
-  /** True when the review came from an agent acting as a GitHub App rather than a person — the
-   *  identity split the design draws as square-vs-circle. */
-  isBot: boolean
+  isBot: boolean // an agent reviewing as a GitHub App, not a person — the console's square-vs-circle split
 }
 
 export interface PrThread {
-  /** `path:line`, or just the path when GitHub has no line (an outdated or file-level thread). */
-  location: string
+  location: string // `path:line`, or just the path when GitHub has no line (outdated/file-level)
   body: string
   author: string
   isOutdated: boolean
@@ -70,27 +54,28 @@ export interface PullRequestView {
   repoFullName: string
   pullNumber: number
   title: string
-  /** `open` | `closed` | `merged` — merged is reported separately by GitHub and folded in here. */
-  state: 'open' | 'closed' | 'merged'
-  isDraft: boolean
+  // Null only while degraded with no Postgres knowledge; degraded 'closed' cannot distinguish merged.
+  state: 'open' | 'closed' | 'merged' | null
+  isDraft: boolean | null // null only while degraded and the owning run recorded no draft fact
   url: string
   headRef: string
   baseRef: string
-  additions: number
-  deletions: number
-  /** GitHub's aggregate review decision, absent when it has formed none. */
-  reviewDecision: 'approved' | 'changes_requested' | 'review_required' | null
+  additions: number | null // null while degraded — Postgres holds no line counts to fall back on
+  deletions: number | null
+  reviewDecision: 'approved' | 'changes_requested' | 'review_required' | null // absent when GitHub formed none
   checks: PrCheck[]
   checksTruncated: boolean
   reviews: PrReview[]
   threads: PrThread[]
-  /** Unresolved threads GitHub counted, which can exceed the rows carried. */
-  unresolvedCount: number
+  unresolvedCount: number // unresolved threads on the carried page — a floor when `threadsTruncated`
   threadsTruncated: boolean
-  /** True when identity is from Postgres but GitHub could not be reached or refused. Everything
-   *  after `baseRef` is then empty, and the panel says why rather than drawing "no checks". */
+  // Degraded ⇒ identity is Postgres's, the live lists are empty, and the panel says why.
   degraded: boolean
   degradedReason: 'rate_limited' | 'denied' | 'unreachable' | null
+  /** The agent's recorded review from the owning run — populated ONLY on a degraded answer. When
+   *  GitHub answered, its review list is authoritative and already contains this review, so carrying
+   *  a second copy would invite the panel to double-draw it; the precedence lives here, not in the UI. */
+  agentReview: 'approved' | 'changes_requested' | 'commented' | null
 }
 
 const QUERY = `
@@ -100,7 +85,7 @@ query PanelPullRequest($owner:String!,$name:String!,$number:Int!,$threads:Int!,$
       number title state isDraft merged additions deletions url
       baseRefName headRefName reviewDecision
       latestReviews(first:$reviews){nodes{state author{login __typename}}}
-      commits(last:1){nodes{commit{statusCheckRollup{contexts(first:$checks){nodes{
+      commits(last:1){nodes{commit{statusCheckRollup{contexts(first:$checks){pageInfo{hasNextPage} nodes{
         __typename
         ... on CheckRun{name conclusion status startedAt completedAt detailsUrl}
         ... on StatusContext{context state targetUrl createdAt}
@@ -131,7 +116,9 @@ interface GqlAnswer {
       commits: {
         nodes: Array<{
           commit: {
-            statusCheckRollup: { contexts: { nodes: Array<Record<string, unknown>> | null } } | null
+            statusCheckRollup: {
+              contexts: { pageInfo: { hasNextPage: boolean } | null; nodes: Array<Record<string, unknown>> | null }
+            } | null
           }
         }> | null
       }
@@ -149,8 +136,7 @@ interface GqlAnswer {
   } | null
 }
 
-/** A CheckRun's conclusion/status, or a StatusContext's state, onto one vocabulary. GitHub spells
- *  the same outcome three ways depending on which kind of check reported it. */
+// A CheckRun's conclusion/status, or a StatusContext's state, onto one vocabulary.
 function checkState(raw: Record<string, unknown>): PrCheckState {
   const word = String(raw['conclusion'] ?? raw['state'] ?? raw['status'] ?? '').toUpperCase()
   if (word === 'SUCCESS') return 'success'
@@ -169,21 +155,27 @@ function reviewState(raw: string): PrReviewState {
   return 'pending'
 }
 
-/** Why GitHub did not answer, in the panel's vocabulary. A GraphQL denial arrives as a 200 with
- *  `errors`, which is why the code rather than the status decides. */
+// Why GitHub did not answer, in the panel's vocabulary — the typed code decides, not the HTTP status.
 function degradedReasonOf(err: unknown): PullRequestView['degradedReason'] {
   if (!(err instanceof GithubApiError)) return 'unreachable'
   if (err.code === 'RATE_LIMITED') return 'rate_limited'
   if (err.code === 'LEASE_DENIED') return 'denied'
-  return err.status === 0 ? 'unreachable' : 'denied'
+  // A GitHub 5xx is GitHub being down, not the installation being revoked — 'denied' points the
+  // operator at a nonexistent permission problem for the length of an outage.
+  return err.status === 0 || err.status >= 500 ? 'unreachable' : 'denied'
 }
 
-/** The durable half — what the caller has already resolved from the owning run. */
+// The durable half, resolved by the caller from the owning run (plus the subject's open/draft facts).
 export interface PullRequestIdentity {
+  orgId: OrgId
   installationId: bigint
   repoId: bigint
   repoFullName: string
   pullNumber: number
+  knownIsOpen?: boolean // HookReviewSubject.isOpen — the degraded arm's state, never an invented default
+  knownIsDraft?: boolean // HookRun.isDraft — same role
+  // HookRun.reviewEvent, already normalized — the agent's OWN recorded review, for the degraded arm only.
+  knownAgentReview?: 'approved' | 'changes_requested' | 'commented'
 }
 
 interface CacheEntry {
@@ -202,23 +194,27 @@ export class PullRequestViewService {
     private readonly baseUrl?: string
   ) {}
 
-  /** One PR's projection. `force` skips the TTL (the panel's refresh action) but still shares an
-   *  in-flight read, so a double press is one request. */
+  // Org+installation in the key: two orgs pointing at one repo/PR must never share cached thread
+  // bodies or ride each other's token validation (the session-access snapshotKey rule).
+  private keyOf(identity: PullRequestIdentity): string {
+    return `${identity.orgId}#${identity.installationId}#${identity.repoId}#${identity.pullNumber}`
+  }
+
+  // One PR's projection. `force` skips the TTL (the panel's refresh) but still shares an in-flight read.
   async view(identity: PullRequestIdentity, force = false): Promise<PullRequestView> {
-    const key = `${identity.repoId}#${identity.pullNumber}`
+    const key = this.keyOf(identity)
     const now = this.clock.now()
-    if (!force) {
-      const hit = this.cache.get(key)
-      if (hit && now - hit.at < PR_VIEW_TTL_MS) return hit.view
-    }
+    const hit = this.cache.get(key)
+    if (hit && now - hit.at >= PR_VIEW_TTL_MS) this.cache.delete(key)
+    if (!force && hit && now - hit.at < PR_VIEW_TTL_MS) return hit.view
+
     const running = this.inFlight.get(key)
     if (running) return running
 
     const read = this.read(identity)
       .then((view) => {
-        // A degraded answer is cached too, and for the same reason a good one is: a rate-limited
-        // installation must not be hammered once per panel mount.
-        this.cache.set(key, { at: this.clock.now(), view })
+        // Degraded answers cache too: a rate-limited installation must not be hammered per panel mount.
+        this.store(key, view)
         return view
       })
       .finally(() => this.inFlight.delete(key))
@@ -226,9 +222,31 @@ export class PullRequestViewService {
     return read
   }
 
-  /** Drop one PR's cached projection — for a caller that just changed the PR itself (M6). */
+  // Bounded insert: sweep expired entries, then evict oldest-inserted past the cap (20s TTL ⇒ LRU-ish).
+  private store(key: string, view: PullRequestView): void {
+    const at = this.clock.now()
+    this.cache.delete(key)
+    for (const [k, entry] of this.cache) if (at - entry.at >= PR_VIEW_TTL_MS) this.cache.delete(k)
+    this.cache.set(key, { at, view })
+    while (this.cache.size > PR_VIEW_CACHE_MAX) {
+      const oldest = this.cache.keys().next().value
+      if (oldest === undefined) break
+      this.cache.delete(oldest)
+    }
+  }
+
+  // Drop one PR's cached projections (every org) — for a caller that just changed the PR itself (M6).
   invalidate(repoId: bigint, pullNumber: number): void {
-    this.cache.delete(`${repoId}#${pullNumber}`)
+    const suffix = `#${repoId}#${pullNumber}`
+    for (const key of [...this.cache.keys()]) if (key.endsWith(suffix)) this.cache.delete(key)
+  }
+
+  // Mirror of InstallationTokenService.invalidateInstallation: a suspended/revoked installation must
+  // not keep serving its cached views. An already-in-flight read may still repopulate for ≤ one TTL.
+  invalidateInstallation(installationId: bigint): void {
+    const marker = `#${installationId}#`
+    for (const key of [...this.cache.keys()]) if (key.includes(marker)) this.cache.delete(key)
+    for (const key of [...this.inFlight.keys()]) if (key.includes(marker)) this.inFlight.delete(key)
   }
 
   private async read(identity: PullRequestIdentity): Promise<PullRequestView> {
@@ -237,13 +255,14 @@ export class PullRequestViewService {
       repoFullName: identity.repoFullName,
       pullNumber: identity.pullNumber,
       title: '',
-      state: 'open',
-      isDraft: false,
+      // Postgres's own knowledge or null — never a fabricated 'open'/'not draft' claim.
+      state: identity.knownIsOpen === undefined ? null : identity.knownIsOpen ? 'open' : 'closed',
+      isDraft: identity.knownIsDraft ?? null,
       url: `https://github.com/${identity.repoFullName}/pull/${identity.pullNumber}`,
       headRef: '',
       baseRef: '',
-      additions: 0,
-      deletions: 0,
+      additions: null,
+      deletions: null,
       reviewDecision: null,
       checks: [],
       checksTruncated: false,
@@ -252,9 +271,13 @@ export class PullRequestViewService {
       unresolvedCount: 0,
       threadsTruncated: false,
       degraded: false,
-      degradedReason: null
+      degradedReason: null,
+      agentReview: null
     }
-    if (!owner || !name) return { ...base, degraded: true, degradedReason: 'denied' }
+    // Every degraded return carries the run's recorded review, so a panel that cannot reach GitHub
+    // still shows the one review state this deployment KNOWS — its own agent's.
+    const fallback = { agentReview: identity.knownAgentReview ?? null }
+    if (!owner || !name) return { ...base, ...fallback, degraded: true, degradedReason: 'denied' }
 
     let answer: GqlAnswer
     try {
@@ -280,15 +303,15 @@ export class PullRequestViewService {
         }
       )
     } catch (err) {
-      return { ...base, degraded: true, degradedReason: degradedReasonOf(err) }
+      return { ...base, ...fallback, degraded: true, degradedReason: degradedReasonOf(err) }
     }
 
     const pr = answer.repository?.pullRequest
-    // A PR the installation can see but that no longer exists reads as denied rather than as an
-    // empty PR: "0 checks on #764" would be a claim, and we have not got one.
-    if (!pr) return { ...base, degraded: true, degradedReason: 'denied' }
+    // A PR the installation cannot see reads as denied, not as an empty PR — "0 checks" would be a claim.
+    if (!pr) return { ...base, ...fallback, degraded: true, degradedReason: 'denied' }
 
-    const contexts = pr.commits?.nodes?.[0]?.commit?.statusCheckRollup?.contexts?.nodes ?? []
+    const rollup = pr.commits?.nodes?.[0]?.commit?.statusCheckRollup
+    const contexts = rollup?.contexts?.nodes ?? []
     const checks: PrCheck[] = contexts.map((raw) => ({
       name: String(raw['name'] ?? raw['context'] ?? 'check'),
       state: checkState(raw),
@@ -306,10 +329,8 @@ export class PullRequestViewService {
         isBot: node.author?.__typename === 'Bot'
       }))
 
-    // Resolved threads are dropped HERE rather than in the query, because GraphQL cannot filter a
-    // connection by `isResolved` — so `totalCount` counts every thread and the unresolved count
-    // has to be derived from the page. That makes it a floor when the page is truncated, which is
-    // what `threadsTruncated` tells the panel.
+    // Resolved threads are dropped HERE — GraphQL cannot filter the connection by `isResolved`, so
+    // the unresolved count is page-derived and is a floor whenever `threadsTruncated`.
     const unresolved = (pr.reviewThreads?.nodes ?? []).filter((node) => !node.isResolved)
     const threads: PrThread[] = unresolved.map((node) => {
       const comment = node.comments?.nodes?.[0]
@@ -340,7 +361,7 @@ export class PullRequestViewService {
               ? 'review_required'
               : null,
       checks,
-      checksTruncated: contexts.length >= CHECK_LIMIT,
+      checksTruncated: rollup?.contexts?.pageInfo?.hasNextPage ?? false,
       reviews,
       threads,
       unresolvedCount: unresolved.length,

--- a/packages/control-plane/src/github/pull-request-view.service.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.ts
@@ -209,8 +209,10 @@ export class PullRequestViewService {
 
   // Org+installation in the key: two orgs pointing at one repo/PR must never share cached thread
   // bodies or ride each other's token validation (the session-access snapshotKey rule).
+  // repoFullName too: historical runs keep pre-rename names, the name drives the GraphQL query and the
+  // cached URL, and rename repair does not rewrite them — so name variants must not share a projection.
   private keyOf(identity: PullRequestIdentity): string {
-    return `${identity.orgId}#${identity.installationId}#${identity.repoId}#${identity.pullNumber}`
+    return `${identity.orgId}#${identity.installationId}#${identity.repoFullName}#${identity.repoId}#${identity.pullNumber}`
   }
 
   // One PR's projection. `force` skips the TTL (the panel's refresh) but still shares an in-flight read.

--- a/packages/control-plane/src/github/pull-request-view.service.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.ts
@@ -165,6 +165,19 @@ function degradedReasonOf(err: unknown): PullRequestView['degradedReason'] {
   return err.status === 0 || err.status >= 500 ? 'unreachable' : 'denied'
 }
 
+/** The caller's run-specific facts, applied over the SHARED projection after the cache. Only a
+ *  degraded view takes them: when GitHub answered, its own state/draft/reviews are authoritative and
+ *  already include this agent's review. The cached object is never mutated. */
+function overlay(view: PullRequestView, identity: PullRequestIdentity): PullRequestView {
+  if (!view.degraded) return view
+  return {
+    ...view,
+    state: identity.knownIsOpen === undefined ? view.state : identity.knownIsOpen ? 'open' : 'closed',
+    isDraft: identity.knownIsDraft ?? view.isDraft,
+    agentReview: identity.knownAgentReview ?? null
+  }
+}
+
 // The durable half, resolved by the caller from the owning run (plus the subject's open/draft facts).
 export interface PullRequestIdentity {
   orgId: OrgId
@@ -206,10 +219,14 @@ export class PullRequestViewService {
     const now = this.clock.now()
     const hit = this.cache.get(key)
     if (hit && now - hit.at >= PR_VIEW_TTL_MS) this.cache.delete(key)
-    if (!force && hit && now - hit.at < PR_VIEW_TTL_MS) return hit.view
+    // Every return path overlays the CALLER's durable facts onto the shared cached projection: the
+    // key is the PR while knownIsOpen/knownIsDraft/knownAgentReview belong to the caller's RUN, so a
+    // cached degraded answer built for session A must not hand session B another run's recorded
+    // review — the overlay is what keeps run-specific facts out of shared storage entirely.
+    if (!force && hit && now - hit.at < PR_VIEW_TTL_MS) return overlay(hit.view, identity)
 
     const running = this.inFlight.get(key)
-    if (running) return running
+    if (running) return running.then((view) => overlay(view, identity))
 
     const read = this.read(identity)
       .then((view) => {
@@ -219,7 +236,7 @@ export class PullRequestViewService {
       })
       .finally(() => this.inFlight.delete(key))
     this.inFlight.set(key, read)
-    return read
+    return read.then((view) => overlay(view, identity))
   }
 
   // Bounded insert: sweep expired entries, then evict oldest-inserted past the cap (20s TTL ⇒ LRU-ish).
@@ -255,9 +272,11 @@ export class PullRequestViewService {
       repoFullName: identity.repoFullName,
       pullNumber: identity.pullNumber,
       title: '',
-      // Postgres's own knowledge or null — never a fabricated 'open'/'not draft' claim.
-      state: identity.knownIsOpen === undefined ? null : identity.knownIsOpen ? 'open' : 'closed',
-      isDraft: identity.knownIsDraft ?? null,
+      // Null here, NOT the caller's known facts: this object is CACHED and the cache key is the PR,
+      // not the run — two sessions on one PR have different runs, so any run-specific fact baked in
+      // here would be served to the other session. The per-caller overlay in view() fills these.
+      state: null,
+      isDraft: null,
       url: `https://github.com/${identity.repoFullName}/pull/${identity.pullNumber}`,
       headRef: '',
       baseRef: '',
@@ -274,10 +293,7 @@ export class PullRequestViewService {
       degradedReason: null,
       agentReview: null
     }
-    // Every degraded return carries the run's recorded review, so a panel that cannot reach GitHub
-    // still shows the one review state this deployment KNOWS — its own agent's.
-    const fallback = { agentReview: identity.knownAgentReview ?? null }
-    if (!owner || !name) return { ...base, ...fallback, degraded: true, degradedReason: 'denied' }
+    if (!owner || !name) return { ...base, degraded: true, degradedReason: 'denied' }
 
     let answer: GqlAnswer
     try {
@@ -303,12 +319,12 @@ export class PullRequestViewService {
         }
       )
     } catch (err) {
-      return { ...base, ...fallback, degraded: true, degradedReason: degradedReasonOf(err) }
+      return { ...base, degraded: true, degradedReason: degradedReasonOf(err) }
     }
 
     const pr = answer.repository?.pullRequest
     // A PR the installation cannot see reads as denied, not as an empty PR — "0 checks" would be a claim.
-    if (!pr) return { ...base, ...fallback, degraded: true, degradedReason: 'denied' }
+    if (!pr) return { ...base, degraded: true, degradedReason: 'denied' }
 
     const rollup = pr.commits?.nodes?.[0]?.commit?.statusCheckRollup
     const contexts = rollup?.contexts?.nodes ?? []

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -322,8 +322,7 @@ export interface HttpDeps {
   /** github-app workspaces façade; absent ⇒ feature disabled (GITHUB_APP_* unset) and
    *  every github route 404s. */
   github?: GithubService
-  /** The console PR panel's read projection; absent on the same terms as {@link github}, and the
-   *  route 404s then, which is what hides the tab. */
+  /** The PR panel's read projection; absent like {@link github} ⇒ the route 404s, hiding the tab. */
   pullRequestView?: PullRequestViewService
   /** Per-user repo authorization (identity assertion, open question #7); absent ⇒ the
    *  org-level model (installation coverage only) and the permission route 404s. */

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -52,6 +52,7 @@ import type {
 import type { Clock } from '../domain/clock.js'
 import type { OAuthService } from '../registry/oauthService.js'
 import type { GithubService } from '../github/service.js'
+import type { PullRequestViewService } from '../github/pull-request-view.service.js'
 import type { GithubUserAuthzService } from '../github/user-authz.js'
 import type { LogtoIdentityService } from '../github/logto-identity.js'
 import type { HookService } from '../hooks/hook.service.js'
@@ -321,6 +322,9 @@ export interface HttpDeps {
   /** github-app workspaces façade; absent ⇒ feature disabled (GITHUB_APP_* unset) and
    *  every github route 404s. */
   github?: GithubService
+  /** The console PR panel's read projection; absent on the same terms as {@link github}, and the
+   *  route 404s then, which is what hides the tab. */
+  pullRequestView?: PullRequestViewService
   /** Per-user repo authorization (identity assertion, open question #7); absent ⇒ the
    *  org-level model (installation coverage only) and the permission route 404s. */
   githubUserAuthz?: GithubUserAuthzService

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3097,6 +3097,73 @@ export const AgentTaskDto = z.object({
   detail: z.string().nullable() // the terminal status the runtime reported, when it named one
 })
 
+/** One check on the PR's head commit, over one vocabulary — GitHub spells the same outcome three
+ *  ways depending on whether a CheckRun, a StatusContext or a rollup reported it. */
+export const SessionPullRequestCheckDto = z.object({
+  name: z.string(),
+  state: z.enum(['success', 'failure', 'pending', 'skipped', 'neutral']),
+  detail: z.string().nullable(), // GitHub's own word for it, verbatim
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+  url: z.string().nullable()
+})
+
+/** One reviewer's CURRENT review, not one review event. `isBot` is the identity split the console
+ *  draws as square-vs-circle: an agent reviewing as a GitHub App is not a person. */
+export const SessionPullRequestReviewDto = z.object({
+  author: z.string(),
+  state: z.enum(['approved', 'changes_requested', 'commented', 'dismissed', 'pending']),
+  isBot: z.boolean()
+})
+
+/** One UNRESOLVED review thread. Bodies are user content and are proxied, never persisted. */
+export const SessionPullRequestThreadDto = z.object({
+  location: z.string(), // `path:line`, the path alone, or a PR-level thread
+  body: z.string(),
+  author: z.string(),
+  isOutdated: z.boolean()
+})
+
+/** `GET /sessions/:id/pull-request` — the PR this session's work belongs to.
+ *
+ *  Identity (`repoFullName`, `pullNumber`, `url`) is read from the owning run in Postgres, so it is
+ *  present even when GitHub could not be reached; `degraded` then says why and every live list is
+ *  empty. That is deliberately not an error: a panel that still names its PR beats an empty tab.
+ *  404 when the session has no pull-request run, which is what hides the console's PR tab. */
+/** `?refresh=true` bypasses the projection's short TTL — the panel's own refresh action. It does
+ *  NOT bypass in-flight coalescing, so a double press is still one GitHub read.
+ *
+ *  `z.stringbool()`, NOT `z.coerce.boolean()`: the latter sends `refresh=false` down the refresh
+ *  path, because every non-empty string is truthy. That is the same trap `WorkspaceDiffQueryDto`
+ *  avoided by using a closed vocabulary instead of a boolean — here the string-aware parser is the
+ *  narrower fix, since there are only two states and no third one worth naming. */
+export const SessionPullRequestQueryDto = z.object({
+  refresh: z.stringbool().optional()
+})
+
+export const SessionPullRequestDto = z.object({
+  repoFullName: z.string(),
+  pullNumber: z.number().int(),
+  title: z.string(),
+  state: z.enum(['open', 'closed', 'merged']),
+  isDraft: z.boolean(),
+  url: z.string(),
+  headRef: z.string(),
+  baseRef: z.string(),
+  additions: z.number().int(),
+  deletions: z.number().int(),
+  reviewDecision: z.enum(['approved', 'changes_requested', 'review_required']).nullable(),
+  checks: z.array(SessionPullRequestCheckDto),
+  checksTruncated: z.boolean(),
+  reviews: z.array(SessionPullRequestReviewDto),
+  threads: z.array(SessionPullRequestThreadDto),
+  unresolvedCount: z.number().int(), // a floor when `threadsTruncated`
+  threadsTruncated: z.boolean(),
+  degraded: z.boolean(),
+  degradedReason: z.enum(['rate_limited', 'denied', 'unreachable']).nullable()
+})
+export type SessionPullRequestDtoT = z.infer<typeof SessionPullRequestDto>
+
 /** `GET /agents/:id/tasks` — live tasks first, then the daemon's bounded settled history.
  *  `tracked:false` means the owning daemon holds no lease for this session (a non-Claude
  *  runtime, an adapter without the lifecycle extension, or nothing emitted yet), which is a

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3097,8 +3097,7 @@ export const AgentTaskDto = z.object({
   detail: z.string().nullable() // the terminal status the runtime reported, when it named one
 })
 
-/** One check on the PR's head commit, over one vocabulary — GitHub spells the same outcome three
- *  ways depending on whether a CheckRun, a StatusContext or a rollup reported it. */
+// One check on the PR's head commit, over one vocabulary regardless of which kind of check reported it.
 export const SessionPullRequestCheckDto = z.object({
   name: z.string(),
   state: z.enum(['success', 'failure', 'pending', 'skipped', 'neutral']),
@@ -3108,15 +3107,14 @@ export const SessionPullRequestCheckDto = z.object({
   url: z.string().nullable()
 })
 
-/** One reviewer's CURRENT review, not one review event. `isBot` is the identity split the console
- *  draws as square-vs-circle: an agent reviewing as a GitHub App is not a person. */
+// One reviewer's CURRENT review, not one review event; `isBot` ⇒ a GitHub App identity, not a person.
 export const SessionPullRequestReviewDto = z.object({
   author: z.string(),
   state: z.enum(['approved', 'changes_requested', 'commented', 'dismissed', 'pending']),
   isBot: z.boolean()
 })
 
-/** One UNRESOLVED review thread. Bodies are user content and are proxied, never persisted. */
+// One UNRESOLVED review thread. Bodies are user content: proxied, never persisted.
 export const SessionPullRequestThreadDto = z.object({
   location: z.string(), // `path:line`, the path alone, or a PR-level thread
   body: z.string(),
@@ -3124,34 +3122,25 @@ export const SessionPullRequestThreadDto = z.object({
   isOutdated: z.boolean()
 })
 
-/** `GET /sessions/:id/pull-request` — the PR this session's work belongs to.
- *
- *  Identity (`repoFullName`, `pullNumber`, `url`) is read from the owning run in Postgres, so it is
- *  present even when GitHub could not be reached; `degraded` then says why and every live list is
- *  empty. That is deliberately not an error: a panel that still names its PR beats an empty tab.
- *  404 when the session has no pull-request run, which is what hides the console's PR tab. */
-/** `?refresh=true` bypasses the projection's short TTL — the panel's own refresh action. It does
- *  NOT bypass in-flight coalescing, so a double press is still one GitHub read.
- *
- *  `z.stringbool()`, NOT `z.coerce.boolean()`: the latter sends `refresh=false` down the refresh
- *  path, because every non-empty string is truthy. That is the same trap `WorkspaceDiffQueryDto`
- *  avoided by using a closed vocabulary instead of a boolean — here the string-aware parser is the
- *  narrower fix, since there are only two states and no third one worth naming. */
+// `?refresh=true` bypasses the projection's TTL but not its in-flight coalescing (a double press is
+// one GitHub read). `z.stringbool()`, NOT `z.coerce.boolean()` — the latter truthy-coerces "false".
 export const SessionPullRequestQueryDto = z.object({
   refresh: z.stringbool().optional()
 })
 
+// `GET /sessions/:id/pull-request` — identity from Postgres survives a GitHub failure (`degraded`
+// says why, the live lists empty, the nullable fields below fall back to what Postgres knows).
 export const SessionPullRequestDto = z.object({
   repoFullName: z.string(),
   pullNumber: z.number().int(),
   title: z.string(),
-  state: z.enum(['open', 'closed', 'merged']),
-  isDraft: z.boolean(),
+  state: z.enum(['open', 'closed', 'merged']).nullable(), // null only degraded with no Postgres fact
+  isDraft: z.boolean().nullable(),
   url: z.string(),
   headRef: z.string(),
   baseRef: z.string(),
-  additions: z.number().int(),
-  deletions: z.number().int(),
+  additions: z.number().int().nullable(), // null while degraded — no stored line counts to fall back on
+  deletions: z.number().int().nullable(),
   reviewDecision: z.enum(['approved', 'changes_requested', 'review_required']).nullable(),
   checks: z.array(SessionPullRequestCheckDto),
   checksTruncated: z.boolean(),
@@ -3160,7 +3149,9 @@ export const SessionPullRequestDto = z.object({
   unresolvedCount: z.number().int(), // a floor when `threadsTruncated`
   threadsTruncated: z.boolean(),
   degraded: z.boolean(),
-  degradedReason: z.enum(['rate_limited', 'denied', 'unreachable']).nullable()
+  degradedReason: z.enum(['rate_limited', 'denied', 'unreachable']).nullable(),
+  // The agent's own recorded review, present ONLY on a degraded answer — GitHub's list is authoritative when it answered.
+  agentReview: z.enum(['approved', 'changes_requested', 'commented']).nullable()
 })
 export type SessionPullRequestDtoT = z.infer<typeof SessionPullRequestDto>
 

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -981,5 +981,52 @@ export function sessionRoutes(deps: HttpDeps) {
         }
       }
     )
+
+    // The pull request this session's work belongs to (webchat-side-panels.md §3.4). Two sources by
+    // design: identity from the owning run in Postgres, live state from GitHub in one GraphQL call.
+    // A GitHub failure is therefore DATA (`degraded` + a reason) rather than an error — the panel
+    // still names its PR. 404 only when there is no pull-request run behind the session at all,
+    // which is what hides the tab.
+    r.get(
+      '/sessions/:id/pull-request',
+      {
+        schema: {
+          tags: [Tag.Sessions],
+          summary: 'Get the session’s pull request',
+          description:
+            'The pull request this session was dispatched for: identity (repo, number, url, head/base) from the owning hook run, and live state (checks, current reviews, unresolved review threads) proxied from GitHub in one GraphQL read. GitHub being rate limited, denying the installation, or unreachable is data — `degraded` names which, identity survives, and the live lists are empty — because a panel that still names its PR beats an empty one. 404 when the session has no pull-request run, when the deployment has no GitHub App configured, or when the run predates repo/installation capture; the console hides its PR tab on that. Review thread bodies are user content: proxied, never stored.',
+          operationId: 'getSessionPullRequest',
+          params: IdParam,
+          querystring: SessionPullRequestQueryDto,
+          response: { 200: SessionPullRequestDto, 404: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const absent = () =>
+          reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'pull request not found' })
+        // The session's own audience first: a PR title and its review threads are content, and this
+        // route must not become the way to read them for a session the caller cannot open.
+        const owned = await getOrgViewableSession(req, req.params.id)
+        if (!owned) return absent()
+        const view = deps.pullRequestView
+        if (!view) return absent()
+        const run = await deps.repos.hook.latestPullRequestRunForSession(orgOf(req), owned.session.id)
+        // `repoId` and `sourceInstallationId` are nullable for legacy rows written before they were
+        // captured; without both there is nothing to mint a token against, so the session reads as
+        // having no PR rather than as an error the reader cannot act on.
+        if (!run?.pullNumber || !run.repoId || !run.repoFullName || !run.sourceInstallationId) return absent()
+        return toSessionPullRequestDto(
+          await view.view(
+            {
+              installationId: run.sourceInstallationId,
+              repoId: run.repoId,
+              repoFullName: run.repoFullName,
+              pullNumber: run.pullNumber
+            },
+            req.query.refresh === true
+          )
+        )
+      }
+    )
   }
 }

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -23,6 +23,7 @@ import { makeSessionAccessResolver } from '../session-access.js'
 import { Tag } from '../plugins/openapi.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { visibilityStateOf } from '../../orchestrator/visibilityPush.js'
+import type { PullRequestView } from '../../github/pull-request-view.service.js'
 import {
   SessionListPageDto,
   SessionFacetsDto,
@@ -32,6 +33,9 @@ import {
   SessionToolBodyChunkDto,
   ErrorDto,
   IdParam,
+  SessionPullRequestDto,
+  SessionPullRequestQueryDto,
+  type SessionPullRequestDtoT,
   SetSessionVisibilityBody,
   SessionVisibilityDto,
   SetSessionExternalAccessBody,
@@ -340,6 +344,32 @@ const SessionHistoryQueryDto = z
   .refine(({ cursor, after }) => cursor === undefined || after === undefined, {
     message: 'cursor and after are mutually exclusive'
   })
+
+/** Service view -> HTTP body. A pure rename plus explicit nulls for the response schema; every
+ *  judgement about what is degraded and why already happened in the service. */
+function toSessionPullRequestDto(view: PullRequestView): SessionPullRequestDtoT {
+  return {
+    repoFullName: view.repoFullName,
+    pullNumber: view.pullNumber,
+    title: view.title,
+    state: view.state,
+    isDraft: view.isDraft,
+    url: view.url,
+    headRef: view.headRef,
+    baseRef: view.baseRef,
+    additions: view.additions,
+    deletions: view.deletions,
+    reviewDecision: view.reviewDecision,
+    checks: view.checks,
+    checksTruncated: view.checksTruncated,
+    reviews: view.reviews,
+    threads: view.threads,
+    unresolvedCount: view.unresolvedCount,
+    threadsTruncated: view.threadsTruncated,
+    degraded: view.degraded,
+    degradedReason: view.degradedReason
+  }
+}
 
 export function sessionRoutes(deps: HttpDeps) {
   return async function sessionRoutesPlugin(app: FastifyInstance): Promise<void> {

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -345,8 +345,15 @@ const SessionHistoryQueryDto = z
     message: 'cursor and after are mutually exclusive'
   })
 
-/** Service view -> HTTP body. A pure rename plus explicit nulls for the response schema; every
- *  judgement about what is degraded and why already happened in the service. */
+// HookRun.reviewEvent -> the panel's review vocabulary. An unrecognized event maps to nothing rather than to a guess.
+function agentReviewOf(event: string | null): 'approved' | 'changes_requested' | 'commented' | null {
+  if (event === 'APPROVE') return 'approved'
+  if (event === 'REQUEST_CHANGES') return 'changes_requested'
+  if (event === 'COMMENT') return 'commented'
+  return null
+}
+
+// Service view -> HTTP body, 1:1; every judgement about degradation already happened in the service.
 function toSessionPullRequestDto(view: PullRequestView): SessionPullRequestDtoT {
   return {
     repoFullName: view.repoFullName,
@@ -367,7 +374,8 @@ function toSessionPullRequestDto(view: PullRequestView): SessionPullRequestDtoT 
     unresolvedCount: view.unresolvedCount,
     threadsTruncated: view.threadsTruncated,
     degraded: view.degraded,
-    degradedReason: view.degradedReason
+    degradedReason: view.degradedReason,
+    agentReview: view.agentReview
   }
 }
 
@@ -1012,11 +1020,8 @@ export function sessionRoutes(deps: HttpDeps) {
       }
     )
 
-    // The pull request this session's work belongs to (webchat-side-panels.md §3.4). Two sources by
-    // design: identity from the owning run in Postgres, live state from GitHub in one GraphQL call.
-    // A GitHub failure is therefore DATA (`degraded` + a reason) rather than an error — the panel
-    // still names its PR. 404 only when there is no pull-request run behind the session at all,
-    // which is what hides the tab.
+    // The session's PR (§3.4): identity from the owning run, live state from GitHub; a GitHub
+    // failure is DATA (`degraded`), and only a session with no pull-request run 404s (hides the tab).
     r.get(
       '/sessions/:id/pull-request',
       {
@@ -1034,24 +1039,29 @@ export function sessionRoutes(deps: HttpDeps) {
       async (req, reply) => {
         const absent = () =>
           reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'pull request not found' })
-        // The session's own audience first: a PR title and its review threads are content, and this
-        // route must not become the way to read them for a session the caller cannot open.
+        // Session audience first: thread bodies are content, unreadable for a session the caller cannot open.
         const owned = await getOrgViewableSession(req, req.params.id)
         if (!owned) return absent()
         const view = deps.pullRequestView
         if (!view) return absent()
         const run = await deps.repos.hook.latestPullRequestRunForSession(orgOf(req), owned.session.id)
-        // `repoId` and `sourceInstallationId` are nullable for legacy rows written before they were
-        // captured; without both there is nothing to mint a token against, so the session reads as
-        // having no PR rather than as an error the reader cannot act on.
+        // Legacy rows predate repo/installation capture — nothing to mint against, so the PR reads absent.
         if (!run?.pullNumber || !run.repoId || !run.repoFullName || !run.sourceInstallationId) return absent()
+        // The subject's own open/draft facts feed the degraded arm, so a rate-limited panel still names them.
+        const subject = run.projectionId
+          ? (await deps.repos.hook.listReviewSubjects(run.projectionId)).find((s) => s.pullNumber === run.pullNumber)
+          : undefined
         return toSessionPullRequestDto(
           await view.view(
             {
+              orgId: orgOf(req),
               installationId: run.sourceInstallationId,
               repoId: run.repoId,
               repoFullName: run.repoFullName,
-              pullNumber: run.pullNumber
+              pullNumber: run.pullNumber,
+              ...(subject ? { knownIsOpen: subject.isOpen } : {}),
+              ...(run.isDraft !== null ? { knownIsDraft: run.isDraft } : {}),
+              ...(agentReviewOf(run.reviewEvent) ? { knownAgentReview: agentReviewOf(run.reviewEvent)! } : {})
             },
             req.query.refresh === true
           )

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2355,6 +2355,8 @@ export interface HookRepo {
   getRun(hookId: HookId, deliveryKey: string): Promise<HookRunRecord | null>
   /** Direct lookup for projection-owned metadata such as the terminal session deep link. */
   getRunById(runId: string): Promise<HookRunRecord | null>
+  /** Org-fenced: the pull-request run owning one session, for the console's PR panel. */
+  latestPullRequestRunForSession(orgId: OrgId, sessionId: string): Promise<HookRunRecord | null>
   /** Latest current revisions whose durable Check projection is absent or
    * stale. Used by the periodic R2a crash-repair loop. */
   listRunsNeedingReviewProjection(limit?: number): Promise<HookRunRecord[]>

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -1026,6 +1026,23 @@ export class PgHookRepo implements HookRepo {
     return row ? toRunRecord(row) : null
   }
 
+  /**
+   * The pull-request run that owns one session — what the console's PR panel resolves a session
+   * into (webchat-side-panels.md §3.4). Org-fenced, so a foreign session simply reads absent.
+   *
+   * Narrowed to `subjectKind: 'pull_request'` with a `pullNumber`: an issue-comment run and a
+   * push run both carry a session and neither has a PR to show, and answering with one would make
+   * the caller re-check what the query could have. Newest first because a redelivery mints a new
+   * run against the same session, and the PR identity to display is the latest association.
+   */
+  async latestPullRequestRunForSession(orgId: OrgId, sessionId: string): Promise<HookRunRecord | null> {
+    const row = await this.db.hookRun.findFirst({
+      where: { orgId, sessionId, subjectKind: 'pull_request', pullNumber: { not: null } },
+      orderBy: { startedAt: 'desc' }
+    })
+    return row ? toRunRecord(row) : null
+  }
+
   async listRunsNeedingReviewProjection(limit = 100): Promise<HookRunRecord[]> {
     const take = Math.max(1, Math.min(limit, 500))
     // There is intentionally no FK from HookRun to HookReviewProjection (the

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -1026,15 +1026,7 @@ export class PgHookRepo implements HookRepo {
     return row ? toRunRecord(row) : null
   }
 
-  /**
-   * The pull-request run that owns one session — what the console's PR panel resolves a session
-   * into (webchat-side-panels.md §3.4). Org-fenced, so a foreign session simply reads absent.
-   *
-   * Narrowed to `subjectKind: 'pull_request'` with a `pullNumber`: an issue-comment run and a
-   * push run both carry a session and neither has a PR to show, and answering with one would make
-   * the caller re-check what the query could have. Newest first because a redelivery mints a new
-   * run against the same session, and the PR identity to display is the latest association.
-   */
+  // The PR run owning one session (§3.4): org-fenced, PR-subject rows only, newest first (redelivery).
   async latestPullRequestRunForSession(orgId: OrgId, sessionId: string): Promise<HookRunRecord | null> {
     const row = await this.db.hookRun.findFirst({
       where: { orgId, sessionId, subjectKind: 'pull_request', pullNumber: { not: null } },

--- a/packages/control-plane/test/integration/sessions.pull-request.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.pull-request.route.test.ts
@@ -1,0 +1,450 @@
+// `GET /sessions/:id/pull-request` — the PR panel's read (webchat-side-panels.md §3.4, M5).
+// Real Postgres rows behind the route, GitHub stubbed at the fetch seam: the 404 matrix (absence and
+// authorization answer identically, with zero GitHub calls), the happy projection, and the degraded
+// arm falling back to the subject's own Postgres facts.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { seedAgent, seedDaemon, seedSessionMeta } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { PullRequestViewService } from '../../src/github/pull-request-view.service.js'
+import type { InstallationTokenService } from '../../src/github/installation-token.service.js'
+import type { FetchLike } from '../../src/github/api.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { systemClock } from '../../src/domain/clock.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const DAEMON = 'd5d5d5d5-dddd-4ddd-8ddd-dddddddddddd'
+const AGENT = 'a5a5a5a5-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const INSTALLATION = 555n
+const REPO_ID = 4242n
+const REPO = 'acme/repo'
+const PULL = 7
+
+const opened: HttpApp[] = []
+afterEach(async () => {
+  await Promise.all(opened.splice(0).map((app) => app.close()))
+})
+
+// The two GitHub seams the projection spends: token mints and GraphQL POSTs, both counted.
+function githubStub(replies: Array<() => Response>) {
+  const mint = vi.fn(async () => ({
+    token: 'ghs_int_test',
+    ttlSec: 3600,
+    expiresAt: '2026-08-11T01:00:00Z',
+    repoFullName: REPO,
+    access: 'read' as const
+  }))
+  const calls: unknown[] = []
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined })
+    const next = replies.shift()
+    if (!next) throw new Error('unexpected extra GitHub call')
+    return next()
+  }
+  const view = new PullRequestViewService(
+    { mintPullRequestRead: mint } as unknown as InstallationTokenService,
+    systemClock,
+    fetch
+  )
+  return { view, mint, calls }
+}
+
+const graphqlOk = (body: unknown) => () =>
+  new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+
+const rateLimited = () =>
+  new Response(JSON.stringify({ message: 'API rate limit exceeded' }), {
+    status: 403,
+    headers: { 'x-ratelimit-remaining': '0' }
+  })
+
+function fullAnswer() {
+  return {
+    data: {
+      repository: {
+        pullRequest: {
+          number: PULL,
+          title: 'Ship the panel',
+          state: 'OPEN',
+          isDraft: false,
+          merged: false,
+          additions: 120,
+          deletions: 8,
+          url: `https://github.com/${REPO}/pull/${PULL}`,
+          baseRefName: 'main',
+          headRefName: 'feat/panel',
+          reviewDecision: 'APPROVED',
+          latestReviews: { nodes: [{ state: 'APPROVED', author: { login: 'dana', __typename: 'User' } }] },
+          commits: {
+            nodes: [
+              {
+                commit: {
+                  statusCheckRollup: {
+                    contexts: {
+                      pageInfo: { hasNextPage: false },
+                      nodes: [
+                        {
+                          __typename: 'CheckRun',
+                          name: 'unit',
+                          conclusion: 'SUCCESS',
+                          status: 'COMPLETED',
+                          startedAt: '2026-08-11T00:00:00Z',
+                          completedAt: '2026-08-11T00:05:00Z',
+                          detailsUrl: 'https://ci.example/unit'
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          reviewThreads: {
+            totalCount: 1,
+            nodes: [
+              {
+                isResolved: false,
+                isOutdated: false,
+                path: 'src/app.ts',
+                line: 12,
+                comments: { nodes: [{ body: 'rename this', author: { login: 'dana' } }] }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+function app(view?: PullRequestViewService, userId?: string): HttpApp {
+  const running = buildHttpApp(
+    prisma,
+    userId ? { DEFAULT_OWNER_ID: userId } : undefined,
+    undefined,
+    undefined,
+    view ? { pullRequestView: view } : undefined
+  )
+  opened.push(running)
+  return running
+}
+
+async function makeUser(sub: string): Promise<string> {
+  const users = new PgUserRepo(prisma)
+  const email = `${sub}@acme.dev`
+  const { userId } = await users.provisionOidcUser({ oidcSubject: sub, email, emailVerified: true })
+  await users.addMemberByEmail(DEFAULT_ORG_ID, email, 'collaborator')
+  return userId
+}
+
+async function seedAgentAndSession(opts: { visibility?: 'org' | 'private'; ownerIdentity?: string } = {}) {
+  await seedDaemon(prisma, DAEMON)
+  await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+  return seedSessionMeta(prisma, randomUUID(), AGENT, { daemonId: DAEMON, ...opts })
+}
+
+// A PR-subject run bound to `sessionId`; overrides shape the legacy/degraded scenarios.
+async function seedPullRequestRun(sessionId: string, overrides: Record<string, unknown> = {}): Promise<string> {
+  const hookId = randomUUID()
+  await prisma.hookDef.create({
+    data: {
+      id: hookId,
+      orgId: DEFAULT_ORG_ID,
+      agentId: AGENT,
+      kind: 'webhook',
+      name: `pr-hook-${hookId.slice(0, 8)}`,
+      sessionMode: 'perDelivery',
+      urlToken: `whk_${randomUUID().replaceAll('-', '')}`
+    }
+  })
+  const run = await prisma.hookRun.create({
+    data: {
+      hookId,
+      orgId: DEFAULT_ORG_ID,
+      deliveryKey: `delivery-${randomUUID().slice(0, 8)}`,
+      startedAt: new Date('2026-08-11T00:00:00Z'),
+      agentId: AGENT,
+      sessionId,
+      subjectKind: 'pull_request',
+      pullNumber: PULL,
+      repoId: REPO_ID,
+      repoFullName: REPO,
+      sourceInstallationId: INSTALLATION,
+      ...overrides
+    }
+  })
+  return run.id
+}
+
+const NOT_FOUND = { error: 'Not Found', statusCode: 404, message: 'pull request not found' }
+
+describe('GET /sessions/:id/pull-request', () => {
+  it('projects the stubbed GitHub answer for a linked session, one GraphQL call, cached until refresh', async () => {
+    const session = await seedAgentAndSession()
+    await seedPullRequestRun(session)
+    const github = githubStub([graphqlOk(fullAnswer()), graphqlOk(fullAnswer())])
+    const running = app(github.view)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({
+      repoFullName: REPO,
+      pullNumber: PULL,
+      title: 'Ship the panel',
+      state: 'open',
+      isDraft: false,
+      url: `https://github.com/${REPO}/pull/${PULL}`,
+      headRef: 'feat/panel',
+      baseRef: 'main',
+      additions: 120,
+      deletions: 8,
+      reviewDecision: 'approved',
+      checks: [
+        {
+          name: 'unit',
+          state: 'success',
+          detail: 'SUCCESS',
+          startedAt: '2026-08-11T00:00:00Z',
+          completedAt: '2026-08-11T00:05:00Z',
+          url: 'https://ci.example/unit'
+        }
+      ],
+      checksTruncated: false,
+      reviews: [{ author: 'dana', state: 'approved', isBot: false }],
+      threads: [{ location: 'src/app.ts:12', body: 'rename this', author: 'dana', isOutdated: false }],
+      unresolvedCount: 1,
+      threadsTruncated: false,
+      degraded: false,
+      degradedReason: null,
+      agentReview: null
+    })
+    expect(github.calls).toHaveLength(1)
+    expect(github.mint).toHaveBeenCalledWith(INSTALLATION, REPO, REPO_ID)
+
+    // Within the TTL the second read is free; `refresh=false` must not truthy-coerce into a force.
+    const again = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions/${session}/pull-request?refresh=false`
+    })
+    expect(again.statusCode).toBe(200)
+    expect(github.calls).toHaveLength(1)
+
+    const forced = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions/${session}/pull-request?refresh=true`
+    })
+    expect(forced.statusCode).toBe(200)
+    expect(github.calls).toHaveLength(2)
+  })
+
+  it('degrades to the subject’s own Postgres facts when GitHub is rate limited', async () => {
+    const session = await seedAgentAndSession()
+    const projectionId = randomUUID()
+    const runId = await seedPullRequestRun(session, { isDraft: true, projectionId, reviewEvent: 'REQUEST_CHANGES' })
+    // The broker's own association rows: the projection and its subject, which says the PR is CLOSED.
+    const run = await prisma.hookRun.findUniqueOrThrow({ where: { id: runId } })
+    await prisma.hookReviewProjection.create({
+      data: {
+        id: projectionId,
+        hookId: run.hookId,
+        orgId: DEFAULT_ORG_ID,
+        agentId: AGENT,
+        repoId: REPO_ID,
+        repoFullName: REPO,
+        headSha: 'head-sha',
+        reportSha: 'report-sha',
+        projectionEpoch: 1n,
+        externalId: `ext-${projectionId}`,
+        mode: 'check',
+        gateMode: 'informational',
+        desiredState: 'pending'
+      }
+    })
+    await prisma.hookReviewSubject.create({
+      data: { projectionId, pullNumber: PULL, headSha: 'head-sha', isOpen: false }
+    })
+    const github = githubStub([rateLimited])
+    const running = app(github.view)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      repoFullName: REPO,
+      pullNumber: PULL,
+      url: `https://github.com/${REPO}/pull/${PULL}`,
+      degraded: true,
+      degradedReason: 'rate_limited',
+      // Postgres facts, not fabrication: the subject says closed, the run says draft, counts unknown —
+      // and the run's own recorded review is the one review state a degraded read can still show.
+      state: 'closed',
+      isDraft: true,
+      agentReview: 'changes_requested',
+      additions: null,
+      deletions: null,
+      checks: [],
+      reviews: [],
+      threads: []
+    })
+  })
+
+  it('404s a session with no pull-request run — the tab-hiding case', async () => {
+    const session = await seedAgentAndSession()
+    // A foreign org's run bound to THIS session id pins the run lookup's own org fence.
+    const foreignOrg = `org-fence-${randomUUID().slice(0, 8)}`
+    await prisma.org.create({ data: { id: foreignOrg, slug: foreignOrg } })
+    const foreignHook = randomUUID()
+    await prisma.hookDef.create({
+      data: {
+        id: foreignHook,
+        orgId: foreignOrg,
+        kind: 'webhook',
+        name: 'fence-hook',
+        sessionMode: 'perDelivery',
+        urlToken: `whk_${randomUUID().replaceAll('-', '')}`
+      }
+    })
+    await prisma.hookRun.create({
+      data: {
+        hookId: foreignHook,
+        orgId: foreignOrg,
+        deliveryKey: 'delivery-f',
+        startedAt: new Date(),
+        sessionId: session,
+        subjectKind: 'pull_request',
+        pullNumber: PULL,
+        repoId: REPO_ID,
+        repoFullName: REPO,
+        sourceInstallationId: INSTALLATION
+      }
+    })
+    const github = githubStub([])
+    const running = app(github.view)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual(NOT_FOUND)
+    expect(github.calls).toHaveLength(0)
+    expect(github.mint).not.toHaveBeenCalled()
+  })
+
+  it('404s identically when the deployment has no GitHub App configured', async () => {
+    const session = await seedAgentAndSession()
+    await seedPullRequestRun(session)
+    const running = app(undefined) // no pullRequestView dep, exactly like GITHUB_APP_* unset
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual(NOT_FOUND)
+  })
+
+  it('404s identically for a legacy run that predates repo/installation capture', async () => {
+    const session = await seedAgentAndSession()
+    await seedPullRequestRun(session, { sourceInstallationId: null })
+    const github = githubStub([])
+    const running = app(github.view)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual(NOT_FOUND)
+    expect(github.calls).toHaveLength(0)
+  })
+
+  it('hides a foreign org’s session behind the same 404, spending no GitHub call', async () => {
+    const foreignOrg = `org-foreign-${randomUUID().slice(0, 8)}`
+    const foreignAgent = randomUUID()
+    const foreignSession = randomUUID()
+    await prisma.org.create({ data: { id: foreignOrg, slug: foreignOrg } })
+    await prisma.agent.create({
+      data: { id: foreignAgent, orgId: foreignOrg, name: 'foreign-bot', runtime: 'claude' }
+    })
+    await prisma.sessionMeta.create({
+      data: {
+        id: foreignSession,
+        agentId: foreignAgent,
+        orgId: foreignOrg,
+        platform: 'slack',
+        channel: '#general',
+        phase: 'start',
+        lastActivityAt: new Date()
+      }
+    })
+    // A real linked run in ITS org — reachable only if the org fence leaks.
+    const foreignHook = randomUUID()
+    await prisma.hookDef.create({
+      data: {
+        id: foreignHook,
+        orgId: foreignOrg,
+        agentId: foreignAgent,
+        kind: 'webhook',
+        name: 'foreign-hook',
+        sessionMode: 'perDelivery',
+        urlToken: `whk_${randomUUID().replaceAll('-', '')}`
+      }
+    })
+    await prisma.hookRun.create({
+      data: {
+        hookId: foreignHook,
+        orgId: foreignOrg,
+        deliveryKey: 'delivery-x',
+        startedAt: new Date(),
+        sessionId: foreignSession,
+        subjectKind: 'pull_request',
+        pullNumber: PULL,
+        repoId: REPO_ID,
+        repoFullName: REPO,
+        sourceInstallationId: INSTALLATION
+      }
+    })
+    const github = githubStub([])
+    const running = app(github.view)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${foreignSession}/pull-request` })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual(NOT_FOUND)
+    expect(github.calls).toHaveLength(0)
+    expect(github.mint).not.toHaveBeenCalled()
+  })
+
+  it('hides another member’s private session behind the same 404 — and answers its owner', async () => {
+    const mine = await makeUser(`pr-mine-${randomUUID()}`)
+    const theirs = await makeUser(`pr-theirs-${randomUUID()}`)
+    const session = await seedAgentAndSession({ visibility: 'private', ownerIdentity: `user:${theirs}` })
+    await seedPullRequestRun(session)
+    const github = githubStub([graphqlOk(fullAnswer())])
+
+    const denied = await app(github.view, mine).app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions/${session}/pull-request`
+    })
+    expect(denied.statusCode).toBe(404)
+    expect(denied.json()).toEqual(NOT_FOUND)
+    expect(github.calls).toHaveLength(0)
+    expect(github.mint).not.toHaveBeenCalled()
+
+    const owner = await app(github.view, theirs).app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions/${session}/pull-request`
+    })
+    expect(owner.statusCode).toBe(200)
+    expect(owner.json()).toMatchObject({ pullNumber: PULL, degraded: false })
+    expect(github.calls).toHaveLength(1)
+  })
+
+  it('404s an unknown session id with the identical body', async () => {
+    const github = githubStub([])
+    const running = app(github.view)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${randomUUID()}/pull-request` })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual(NOT_FOUND)
+    expect(github.calls).toHaveLength(0)
+  })
+})

--- a/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
@@ -36,6 +36,7 @@ vi.mock('@/lib/api', () => {
 })
 
 import {
+  PR_LINK_RETRY_LADDER_MS,
   PullRequestPanel,
   formatCheckDuration,
   pullRequestPillKey,
@@ -156,6 +157,7 @@ afterEach(async () => {
   container = undefined
   root = undefined
   vi.restoreAllMocks()
+  vi.useRealTimers()
 })
 
 describe('pullRequestTabStatus', () => {
@@ -421,30 +423,91 @@ describe('PullRequestPanel degraded answers', () => {
     await render()
     expect(container?.querySelector('[data-pr-agent-review]')).toBeNull()
   })
-  it('re-asks a held 404 when the session status changes, and only then', async () => {
-    // The run's sessionId can be persisted as late as the terminal hook/report — which also flips the
-    // session's status. That transition is the hidden tab's ONE way back; nothing else may re-probe.
+  it('survives the status flip landing BEFORE the link commits — a ladder retry still finds it', async () => {
+    // The unfavorable ordering: `event/session` and `hook/report` are separate concurrently-dispatched
+    // frames, so the transition can arrive, spend its immediate re-ask on a second 404, and never fire
+    // again. The bounded ladder is what discovers the link that commits after that.
+    vi.useFakeTimers()
     wire.failure = { status: 404 }
     await render({ sessionStatus: 'online' })
     expect(wire.calls).toHaveLength(1)
 
-    // Renders without a transition change nothing.
-    await rerender({ sessionStatus: 'online' })
-    expect(wire.calls).toHaveLength(1)
-
-    // The report landed, the link now exists: the transition re-asks and the tab can come back.
-    wire.failure = null
-    wire.data = pr()
+    // The terminal snapshot lands first: the transition re-asks immediately — and gets 404 AGAIN.
     await rerender({ sessionStatus: 'idle' })
     expect(wire.calls).toHaveLength(2)
+    expect(verdicts.at(-1)?.answer).toBe('none')
+
+    // hook/report finally commits the link; no further transition ever comes. The ladder finds it.
+    wire.failure = null
+    wire.data = pr()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PR_LINK_RETRY_LADDER_MS[0]!)
+    })
+    expect(wire.calls).toHaveLength(3)
     expect(verdicts.at(-1)?.answer).toBe('linked')
   })
 
-  it('keeps a LINKED answer still across status changes — the edge is for the missing link only', async () => {
+  it('recovers a link with NO status transition at all — the reconnect-to-terminal-session ordering', async () => {
+    // A reconnect can restore an already-terminal session before the hook-report outbox drains: the
+    // first probe 404s and the status will never change. The ladder is the only way back here.
+    vi.useFakeTimers()
+    wire.failure = { status: 404 }
+    await render({ sessionStatus: 'idle' })
+    expect(wire.calls).toHaveLength(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PR_LINK_RETRY_LADDER_MS[0]!)
+    })
+    expect(wire.calls).toHaveLength(2)
+
+    wire.failure = null
+    wire.data = pr()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PR_LINK_RETRY_LADDER_MS[1]!)
+    })
+    expect(wire.calls).toHaveLength(3)
+    expect(verdicts.at(-1)?.answer).toBe('linked')
+  })
+
+  it('goes quiet once the ladder drains, and a status transition refills it', async () => {
+    // Bounded: a session that genuinely has no PR must stop asking — but a later transition is a fresh
+    // hint that the link may just have committed, so it re-asks immediately and re-arms the ladder.
+    vi.useFakeTimers()
+    wire.failure = { status: 404 }
+    await render({ sessionStatus: 'online' })
+
+    // Rung by rung: each retry schedules the next only after its answer settles, so the clock advances per step.
+    for (const step of PR_LINK_RETRY_LADDER_MS) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(step)
+      })
+    }
+    const drained = 1 + PR_LINK_RETRY_LADDER_MS.length
+    expect(wire.calls).toHaveLength(drained)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600_000)
+    })
+    expect(wire.calls).toHaveLength(drained)
+
+    await rerender({ sessionStatus: 'idle' })
+    expect(wire.calls).toHaveLength(drained + 1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PR_LINK_RETRY_LADDER_MS[0]!)
+    })
+    expect(wire.calls).toHaveLength(drained + 2)
+  })
+
+  it('keeps a LINKED answer still — no timers, no reaction to status changes', async () => {
+    // The provisional treatment is for the missing link ONLY: an answered probe schedules nothing, so
+    // the panel never polls GitHub (§9's budget) and never re-asks on status churn.
+    vi.useFakeTimers()
     wire.data = pr()
     await render({ sessionStatus: 'online' })
     expect(wire.calls).toHaveLength(1)
     await rerender({ sessionStatus: 'idle' })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600_000)
+    })
     expect(wire.calls).toHaveLength(1)
   })
 })

--- a/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
@@ -1,0 +1,424 @@
+// @vitest-environment happy-dom
+
+// The dock's PR panel: the verdict vocabulary it reports to its tab (linked / none / failed, and why `empty` is never one of them), the 404 that hides the tab and is asked exactly ONCE per session, the degraded answers that still name their PR, and the M5 absences — no Auto-fix and no merge control, which are M6's write loop and must be absent rather than disabled.
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const wire = vi.hoisted(() => ({
+  data: null as unknown,
+  failure: null as null | { status: number },
+  calls: [] as Array<{ sessionId: string; refresh: boolean }>,
+  // Set to hand back a promise the test resolves by hand, so the panel is observable WHILE a read is in flight.
+  hold: null as null | (() => Promise<unknown>)
+}))
+
+vi.mock('@/lib/api', () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      readonly status: number
+    ) {
+      super(message)
+      this.name = 'ApiError'
+    }
+  }
+  return {
+    ApiError,
+    fetchSessionPullRequest: vi.fn((sessionId: string, opts: { refresh?: boolean } = {}) => {
+      wire.calls.push({ sessionId, refresh: opts.refresh === true })
+      if (wire.failure) return Promise.reject(new ApiError('nope', wire.failure.status))
+      if (wire.hold) return wire.hold()
+      return Promise.resolve(wire.data)
+    })
+  }
+})
+
+import {
+  PullRequestPanel,
+  formatCheckDuration,
+  pullRequestPillKey,
+  pullRequestTabStatus,
+  type PullRequestPanelVerdict
+} from './PullRequestPanel'
+import type { SessionPullRequestDto } from '@/lib/api'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let container: HTMLDivElement | undefined
+let root: ReturnType<typeof createRoot> | undefined
+let verdicts: PullRequestPanelVerdict[] = []
+
+function pr(overrides: Partial<SessionPullRequestDto> = {}): SessionPullRequestDto {
+  return {
+    repoFullName: 'acme/api',
+    pullNumber: 57,
+    title: 'Ship the dock',
+    state: 'open',
+    isDraft: false,
+    url: 'https://github.com/acme/api/pull/57',
+    headRef: 'feat/dock',
+    baseRef: 'main',
+    additions: 120,
+    deletions: 30,
+    reviewDecision: 'changes_requested',
+    checks: [
+      {
+        name: 'ci/build',
+        state: 'success',
+        detail: 'success',
+        startedAt: '2026-08-11T10:00:00.000Z',
+        completedAt: '2026-08-11T10:02:14.000Z',
+        url: null
+      },
+      { name: 'ci/lint', state: 'pending', detail: 'in_progress', startedAt: null, completedAt: null, url: null }
+    ],
+    checksTruncated: false,
+    reviews: [
+      { author: 'sam', state: 'changes_requested', isBot: false },
+      { author: 'review-bot', state: 'commented', isBot: true }
+    ],
+    threads: [
+      { location: 'src/dock.ts:12', body: 'This cache key needs the org.', author: 'sam', isOutdated: false },
+      { location: 'src/dock.ts:40', body: 'Stale comment on old lines.', author: 'sam', isOutdated: true }
+    ],
+    unresolvedCount: 2,
+    threadsTruncated: false,
+    degraded: false,
+    degradedReason: null,
+    agentReview: null,
+    ...overrides
+  }
+}
+
+// The degraded arm as the CP builds it: identity + stored facts survive, every live list is empty.
+function degradedPr(reason: 'rate_limited' | 'denied' | 'unreachable'): SessionPullRequestDto {
+  return pr({
+    state: 'closed',
+    isDraft: null,
+    additions: null,
+    deletions: null,
+    reviewDecision: null,
+    checks: [],
+    reviews: [],
+    threads: [],
+    unresolvedCount: 0,
+    degraded: true,
+    degradedReason: reason
+  })
+}
+
+type PanelProps = Parameters<typeof PullRequestPanel>[0]
+
+function panel(props: Partial<PanelProps> = {}) {
+  return <PullRequestPanel sessionId="session-1" onVerdictChange={(verdict) => verdicts.push(verdict)} {...props} />
+}
+
+async function render(props: Partial<PanelProps> = {}) {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(panel(props))
+    await Promise.resolve()
+  })
+}
+
+async function rerender(props: Partial<PanelProps> = {}) {
+  await act(async () => {
+    root?.render(panel(props))
+    await Promise.resolve()
+  })
+}
+
+async function press(selector: string) {
+  await act(async () => {
+    container?.querySelector<HTMLElement>(selector)?.click()
+    await Promise.resolve()
+  })
+}
+
+const text = () => container?.textContent ?? ''
+const last = () => verdicts.at(-1)
+
+beforeEach(() => {
+  wire.data = pr()
+  wire.failure = null
+  wire.calls = []
+  wire.hold = null
+  verdicts = []
+})
+
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  container?.remove()
+  container = undefined
+  root = undefined
+  vi.restoreAllMocks()
+})
+
+describe('pullRequestTabStatus', () => {
+  it('is loading until the probe answers, and never empty', () => {
+    // Never `empty`: a 200 always has identity to draw, `none` takes the tab out of the strip entirely, and a failed probe has copy — so no state is left for the dock's centred "Nothing to show".
+    expect(pullRequestTabStatus('pending')).toBe('loading')
+    expect(pullRequestTabStatus('linked')).toBe('ready')
+    expect(pullRequestTabStatus('failed')).toBe('ready')
+    expect(pullRequestTabStatus('none')).toBe('ready')
+  })
+})
+
+describe('pullRequestPillKey', () => {
+  it('lets draft outrank open, and reads a missing state as unknown rather than open', () => {
+    expect(pullRequestPillKey('open', false)).toBe('open')
+    expect(pullRequestPillKey('open', true)).toBe('draft')
+    expect(pullRequestPillKey('merged', false)).toBe('merged')
+    expect(pullRequestPillKey('closed', null)).toBe('closed')
+    // The degraded arm with no stored fact: `open` here would be an invented claim about a PR nobody read.
+    expect(pullRequestPillKey(null, null)).toBe('unknown')
+  })
+})
+
+describe('formatCheckDuration', () => {
+  it('reads seconds, then minutes-and-seconds, then hours-and-minutes', () => {
+    expect(formatCheckDuration('2026-08-11T10:00:00.000Z', '2026-08-11T10:00:41.000Z')).toBe('41s')
+    expect(formatCheckDuration('2026-08-11T10:00:00.000Z', '2026-08-11T10:02:14.000Z')).toBe('2m 14s')
+    expect(formatCheckDuration('2026-08-11T10:00:00.000Z', '2026-08-11T11:04:00.000Z')).toBe('1h 04m')
+  })
+
+  it('says nothing when either end is missing, out of order, or unparseable', () => {
+    // "Duration where present" — a pending check has no completion and gets no invented number.
+    expect(formatCheckDuration(null, '2026-08-11T10:00:00.000Z')).toBe('')
+    expect(formatCheckDuration('2026-08-11T10:00:00.000Z', null)).toBe('')
+    expect(formatCheckDuration('2026-08-11T10:00:10.000Z', '2026-08-11T10:00:00.000Z')).toBe('')
+    expect(formatCheckDuration('not a date', '2026-08-11T10:00:00.000Z')).toBe('')
+  })
+})
+
+describe('PullRequestPanel verdicts', () => {
+  it('reads by session, reports linked with the badge count and the URL, and only re-reports on the edge', async () => {
+    await render()
+    expect(wire.calls).toEqual([{ sessionId: 'session-1', refresh: false }])
+    expect(last()).toEqual({ answer: 'linked', unresolved: 2, url: 'https://github.com/acme/api/pull/57' })
+    const heard = verdicts.length
+    await rerender()
+    await rerender()
+    expect(verdicts).toHaveLength(heard)
+  })
+
+  it('reports a 404 as none, renders nothing, and NEVER asks again for that session', async () => {
+    // The linkage cannot appear later — the run is what created the session — so re-polling a 404 would spend reads on an answer that is already final (the M4 follow-up this panel must not repeat).
+    wire.failure = { status: 404 }
+    await render()
+    expect(last()).toEqual({ answer: 'none', unresolved: null, url: null })
+    expect(container?.querySelector('[data-pr-panel]')).toBeNull()
+
+    await rerender()
+    await rerender()
+    expect(wire.calls).toHaveLength(1)
+  })
+
+  it('reports a non-404 failure as failed — not none — so the tab stays up and says why', async () => {
+    // Hiding here would claim "no PR" on a fact nobody could read; the failed panel keeps the tab and its copy.
+    wire.failure = { status: 503 }
+    await render()
+    expect(last()).toEqual({ answer: 'failed', unresolved: null, url: null })
+    expect(container?.querySelector('[data-pr-panel="failed"]')).not.toBeNull()
+    expect(text()).toContain('Couldn’t read this session’s pull request')
+  })
+
+  it('retries a failed probe from its own refresh control, bypassing the CP cache', async () => {
+    wire.failure = { status: 503 }
+    await render()
+    wire.failure = null
+    await press('[data-pr-refresh]')
+    expect(wire.calls).toEqual([
+      { sessionId: 'session-1', refresh: false },
+      { sessionId: 'session-1', refresh: true }
+    ])
+    expect(last()).toEqual({ answer: 'linked', unresolved: 2, url: 'https://github.com/acme/api/pull/57' })
+  })
+
+  it('withholds the badge while degraded, where the thread count is unknown rather than zero', async () => {
+    wire.data = degradedPr('rate_limited')
+    await render()
+    expect(last()).toEqual({ answer: 'linked', unresolved: null, url: 'https://github.com/acme/api/pull/57' })
+  })
+
+  it('holds answers PER SCOPE: a session switch reads as pending, never as the previous session’s PR', async () => {
+    // Constructs the switch WINDOW itself (the M3 bug class): the new scope's read is held open, so serving the old scope's answer would leave its PR on screen and its count on the new tab's badge.
+    await render()
+    expect(text()).toContain('Ship the dock')
+
+    let release: ((value: unknown) => void) | undefined
+    wire.hold = () => new Promise((resolve) => (release = resolve))
+    await rerender({ sessionId: 'session-2' })
+    expect(wire.calls.at(-1)).toEqual({ sessionId: 'session-2', refresh: false })
+    expect(container?.querySelector('[data-pr-panel]')).toBeNull()
+    expect(last()).toEqual({ answer: 'pending', unresolved: null, url: null })
+
+    await act(async () => {
+      release?.(pr({ title: 'The other session’s PR', pullNumber: 99, unresolvedCount: 1 }))
+      await Promise.resolve()
+    })
+    expect(text()).toContain('The other session’s PR')
+    expect(last()?.unresolved).toBe(1)
+  })
+
+  it('re-reads on the edge where the reader opens the tab, not per render', async () => {
+    // The panel is mounted from the moment the session page opens; a tab opened ten minutes later must not draw a ten-minute-old PR until someone presses refresh.
+    await render({ active: false })
+    expect(wire.calls).toHaveLength(1)
+    await rerender({ active: true })
+    expect(wire.calls).toHaveLength(2)
+    // A plain re-read rides the CP's cache; only the explicit press bypasses it.
+    expect(wire.calls[1]).toEqual({ sessionId: 'session-1', refresh: false })
+    await rerender({ active: true })
+    expect(wire.calls).toHaveLength(2)
+  })
+})
+
+describe('PullRequestPanel body', () => {
+  it('draws the identity header: state pill, number, repo, title, head→base, +/− and the GitHub link', async () => {
+    await render()
+    expect(container?.querySelector('[data-pr-state="open"]')?.textContent).toBe('Open')
+    expect(text()).toContain('#57')
+    expect(text()).toContain('acme/api')
+    expect(text()).toContain('Ship the dock')
+    expect(text()).toContain('feat/dock')
+    expect(text()).toContain('main')
+    expect(text()).toContain('+120')
+    expect(text()).toContain('−30')
+    const link = container?.querySelector<HTMLAnchorElement>('[data-pr-link]')
+    expect(link?.href).toBe('https://github.com/acme/api/pull/57')
+    expect(link?.textContent).toContain('View on GitHub')
+  })
+
+  it('draws each check with its own state marker and a duration only where both ends exist', async () => {
+    await render()
+    const checks = Array.from(container?.querySelectorAll<HTMLElement>('[data-pr-check]') ?? [])
+    expect(checks.map((row) => row.dataset.prCheck)).toEqual(['success', 'pending'])
+    expect(checks[0]?.textContent).toContain('ci/build')
+    expect(checks[0]?.textContent).toContain('2m 14s')
+    // The pending check reported no completion, so its row carries no number at all.
+    expect(checks[1]?.textContent).toBe('ci/lint')
+  })
+
+  it('draws each reviewer’s current review with the bot marker, and the decision beside the section', async () => {
+    await render()
+    const reviews = Array.from(container?.querySelectorAll<HTMLElement>('[data-pr-review]') ?? [])
+    expect(reviews.map((row) => row.dataset.prReview)).toEqual(['changes_requested', 'commented'])
+    expect(reviews[0]?.textContent).toContain('sam')
+    expect(reviews[1]?.textContent).toContain('bot')
+    expect(container?.querySelector('[data-pr-decision="changes_requested"]')?.textContent).toBe('Changes requested')
+  })
+
+  it('draws unresolved threads with location, excerpt, author and the outdated mark, under their count', async () => {
+    await render()
+    const threads = Array.from(container?.querySelectorAll<HTMLElement>('[data-pr-thread]') ?? [])
+    expect(threads).toHaveLength(2)
+    expect(threads[0]?.textContent).toContain('src/dock.ts:12')
+    expect(threads[0]?.textContent).toContain('This cache key needs the org.')
+    expect(threads[0]?.textContent).toContain('sam')
+    expect(threads[0]?.textContent).not.toContain('outdated')
+    expect(threads[1]?.textContent).toContain('outdated')
+    expect(container?.querySelector('[data-pr-section="threads"]')?.textContent).toContain('2')
+  })
+
+  it('marks a truncated thread count as a floor, because the wire carries a page and says so', async () => {
+    wire.data = pr({ threadsTruncated: true, unresolvedCount: 2 })
+    await render()
+    expect(container?.querySelector('[data-pr-section="threads"]')?.textContent).toContain('2+')
+    expect(text()).toContain('More unresolved threads than one read carries')
+  })
+
+  it('says which kind of nothing each empty section has', async () => {
+    wire.data = pr({ checks: [], reviews: [], threads: [], unresolvedCount: 0, reviewDecision: null })
+    await render()
+    expect(text()).toContain('No checks reported')
+    expect(text()).toContain('No reviews yet')
+    expect(text()).toContain('No unresolved review threads')
+  })
+
+  it('offers NO Auto-fix, NO merge control and NO thread resolution — M6’s writes are absent, not disabled', async () => {
+    // PREMISE (§9 M5): this panel is read-only. If M6 lands its Auto-fix button and Merge-when-ready checkbox, re-aim this assertion at the new controls — do not delete it.
+    await render()
+    // The refresh control is the ONLY button, and there is no checkbox for auto-merge to hide in.
+    const buttons = Array.from(container?.querySelectorAll('button') ?? [])
+    expect(buttons.map((button) => button.getAttribute('aria-label'))).toEqual(['Refresh pull request'])
+    expect(container?.querySelectorAll('input')).toHaveLength(0)
+    expect(text().toLowerCase()).not.toContain('auto-fix')
+    expect(text().toLowerCase()).not.toContain('merge when ready')
+  })
+})
+
+describe('PullRequestPanel degraded answers', () => {
+  it('still names the PR under rate limiting, with the stored state instead of a fabricated open', async () => {
+    wire.data = degradedPr('rate_limited')
+    await render()
+    // Identity survives: repo, number, title and the link all render from what the CP already knew.
+    expect(text()).toContain('#57')
+    expect(text()).toContain('acme/api')
+    expect(text()).toContain('Ship the dock')
+    expect(container?.querySelector<HTMLAnchorElement>('[data-pr-link]')?.href).toBe(
+      'https://github.com/acme/api/pull/57'
+    )
+    expect(container?.querySelector('[data-pr-state="closed"]')?.textContent).toBe('Closed')
+    expect(text()).toContain('GitHub is rate limiting this deployment')
+    // The live sections are withheld rather than drawn empty, which would read as "no checks ran".
+    expect(container?.querySelector('[data-pr-section]')).toBeNull()
+  })
+
+  it('reads a missing stored state as unknown, and names the other two reasons', async () => {
+    wire.data = { ...degradedPr('denied'), state: null }
+    await render()
+    expect(container?.querySelector('[data-pr-state="unknown"]')?.textContent).toBe('State unknown')
+    expect(text()).toContain('GitHub denied this read')
+
+    await act(async () => root?.unmount())
+    container?.remove()
+    wire.data = degradedPr('unreachable')
+    await render()
+    expect(text()).toContain('GitHub couldn’t be reached')
+  })
+
+  it('recovers through its refresh control, which bypasses the CP’s TTL for exactly that press', async () => {
+    wire.data = degradedPr('rate_limited')
+    await render()
+    wire.data = pr()
+    await press('[data-pr-refresh]')
+    expect(wire.calls).toEqual([
+      { sessionId: 'session-1', refresh: false },
+      { sessionId: 'session-1', refresh: true }
+    ])
+    expect(container?.querySelector('[data-pr-section="checks"]')).not.toBeNull()
+    expect(last()).toEqual({ answer: 'linked', unresolved: 2, url: 'https://github.com/acme/api/pull/57' })
+  })
+
+  it('keeps the previous answer on screen while a refresh is in flight, instead of strobing to pending', async () => {
+    await render()
+    let release: ((value: unknown) => void) | undefined
+    wire.hold = () => new Promise((resolve) => (release = resolve))
+    await press('[data-pr-refresh]')
+    // Still the old answer, with the control itself marking the read in progress.
+    expect(text()).toContain('Ship the dock')
+    expect(container?.querySelector<HTMLButtonElement>('[data-pr-refresh]')?.disabled).toBe(true)
+    await act(async () => {
+      release?.(pr({ title: 'Fresh title' }))
+      await Promise.resolve()
+    })
+    expect(text()).toContain('Fresh title')
+    expect(container?.querySelector<HTMLButtonElement>('[data-pr-refresh]')?.disabled).toBe(false)
+  })
+  it('shows the agent recorded review on a degraded answer, and never beside GitHub own list', async () => {
+    // Precedence is the service's — the panel just refuses to double-draw: the field is only ever
+    // populated on degraded answers, and this pins that an answered view renders GitHub's list alone.
+    wire.data = pr({ degraded: true, degradedReason: 'rate_limited', agentReview: 'changes_requested' })
+    await render()
+    expect(container?.querySelector('[data-pr-agent-review]')?.textContent).toContain('changes requested')
+
+    wire.data = pr({ agentReview: null })
+    await render()
+    expect(container?.querySelector('[data-pr-agent-review]')).toBeNull()
+  })
+})

--- a/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
@@ -421,4 +421,30 @@ describe('PullRequestPanel degraded answers', () => {
     await render()
     expect(container?.querySelector('[data-pr-agent-review]')).toBeNull()
   })
+  it('re-asks a held 404 when the session status changes, and only then', async () => {
+    // The run's sessionId can be persisted as late as the terminal hook/report — which also flips the
+    // session's status. That transition is the hidden tab's ONE way back; nothing else may re-probe.
+    wire.failure = { status: 404 }
+    await render({ sessionStatus: 'online' })
+    expect(wire.calls).toHaveLength(1)
+
+    // Renders without a transition change nothing.
+    await rerender({ sessionStatus: 'online' })
+    expect(wire.calls).toHaveLength(1)
+
+    // The report landed, the link now exists: the transition re-asks and the tab can come back.
+    wire.failure = null
+    wire.data = pr()
+    await rerender({ sessionStatus: 'idle' })
+    expect(wire.calls).toHaveLength(2)
+    expect(verdicts.at(-1)?.answer).toBe('linked')
+  })
+
+  it('keeps a LINKED answer still across status changes — the edge is for the missing link only', async () => {
+    wire.data = pr()
+    await render({ sessionStatus: 'online' })
+    expect(wire.calls).toHaveLength(1)
+    await rerender({ sessionStatus: 'idle' })
+    expect(wire.calls).toHaveLength(1)
+  })
 })

--- a/packages/web/src/components/console/dock/PullRequestPanel.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.tsx
@@ -1,0 +1,465 @@
+'use client'
+
+// The dock's PR tab (§3.4, M5): the pull request this session was dispatched for — state, head→base, checks, current reviews and unresolved threads — as a READ-ONLY surface. Auto-fix and Merge-when-ready are M6's write loop and are ABSENT rather than disabled.
+// Identity comes from the CP's own records and live state from GitHub through the CP's short-TTL projection; thread bodies are proxied, never stored (§2). A rate-limited, denied or unreachable GitHub is DATA: the panel still names its PR and says why the live lists are missing.
+// A session with no linked pull-request run answers 404 ONCE and the tab hides. That linkage never appears later — the run is what CREATED the session — so the 404 is held per scope and nothing re-asks it (the hidden tab has no activation edge and no refresh control to press).
+
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { Spinner } from '@/components/marks'
+import { Icon } from '@/components/ui'
+import {
+  ApiError,
+  fetchSessionPullRequest,
+  type SessionPullRequestCheckDto,
+  type SessionPullRequestDto,
+  type SessionPullRequestReviewDto,
+  type SessionPullRequestThreadDto
+} from '@/lib/api'
+import type { DockTabStatus } from './SessionDock'
+
+const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
+const statusOf = (e: unknown) => (e instanceof ApiError ? e.status : null)
+
+/** The four answers the probe can settle on; `none` (a 404) is the one that takes the tab out of the strip entirely. */
+export type PullRequestPanelAnswer = 'pending' | 'linked' | 'none' | 'failed'
+
+/** What the PR tab reports upward. The caller owns the tab descriptor, so the panel reports its verdict rather than applying it — the same shape every other tab uses. */
+export interface PullRequestPanelVerdict {
+  answer: PullRequestPanelAnswer
+  /** Unresolved threads for the tab's badge; null while unknown AND while degraded, where 0 would assert "none" about lists GitHub withheld. */
+  unresolved: number | null
+  /** The PR's GitHub page for the tab's `external-link` action; null until a 200 carries one. */
+  url: string | null
+}
+
+/** The PR tab's status: `loading` until the probe's first answer; `none` never reaches the strip because the caller drops the tab. */
+// Never `empty`: a 200 always carries identity to draw, "no PR" HIDES the tab instead of blanking it, and a failed probe has copy — no state is left for the dock's centred "Nothing to show" to describe.
+export function pullRequestTabStatus(answer: PullRequestPanelAnswer): DockTabStatus {
+  return answer === 'pending' ? 'loading' : 'ready'
+}
+
+/** A finished check's `startedAt`→`completedAt`, in the elapsed shape the Tasks rows use; empty when either end is missing or unparseable — the design says duration "where present", not invented. */
+export function formatCheckDuration(startedAt: string | null, completedAt: string | null): string {
+  if (!startedAt || !completedAt) return ''
+  const ms = new Date(completedAt).getTime() - new Date(startedAt).getTime()
+  if (Number.isNaN(ms) || ms < 0) return ''
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ${String(seconds % 60).padStart(2, '0')}s`
+  return `${Math.floor(minutes / 60)}h ${String(minutes % 60).padStart(2, '0')}m`
+}
+
+interface PrRead {
+  loading: boolean
+  err: string | null
+  errStatus: number | null
+  data: SessionPullRequestDto | null
+}
+
+const PENDING: PrRead = { loading: true, err: null, errStatus: null, data: null }
+
+/** One probe per (session, tick). The answer is held PER SCOPE and the pending state DERIVED from it (the M4 shape): a new session reads as pending on the very render that changes it, a re-read of the SAME session replaces the answer in place, and a settled 404 simply stays held — nothing bumps the tick for a hidden tab. */
+function useSessionPullRequest(sessionId: string, reads: { tick: number; force: boolean }) {
+  const [answered, setAnswered] = useState<{ scope: string; tick: number; read: PrRead } | null>(null)
+  useEffect(() => {
+    let live = true
+    const settle = (read: PrRead) => {
+      if (live) setAnswered({ scope: sessionId, tick: reads.tick, read })
+    }
+    // `force` bypasses the CP's short TTL; a leftover `force` riding a scope switch costs one uncached read at most, which is not worth a second effect that would double-fire the first one (measured in M4).
+    fetchSessionPullRequest(sessionId, reads.force ? { refresh: true } : {}).then(
+      (data) => settle({ ...PENDING, loading: false, data }),
+      (e) => settle({ ...PENDING, loading: false, err: msg(e), errStatus: statusOf(e) })
+    )
+    return () => {
+      live = false
+    }
+  }, [sessionId, reads])
+  const read = answered?.scope === sessionId ? answered.read : PENDING
+  // A re-read keeps the previous answer on screen rather than strobing back to pending; this flag is what lets the refresh control show its own progress.
+  const refreshing = answered?.scope === sessionId && answered.tick !== reads.tick
+  return { read, refreshing }
+}
+
+const PILL =
+  'flex flex-none items-center gap-[4px] rounded-full px-[7px] py-px font-sans text-[10.5px] font-semibold leading-normal'
+
+// The state pill, one full literal per state (STYLE.md rule 8). `unknown` is the degraded arm with no stored fact — drawn as unknown rather than guessed open.
+const STATE_PILL: Record<string, { label: string; icon: string; cls: string }> = {
+  open: { label: 'Open', icon: 'git-pull-request', cls: `${PILL} bg-(--status-online-soft) text-(--status-online)` },
+  draft: {
+    label: 'Draft',
+    icon: 'git-pull-request-draft',
+    cls: `${PILL} bg-(--surface-active) text-(--text-secondary)`
+  },
+  merged: { label: 'Merged', icon: 'git-merge', cls: `${PILL} bg-(--surface-sunken) text-(--purple-500)` },
+  closed: { label: 'Closed', icon: 'circle-x', cls: `${PILL} bg-(--status-error-soft) text-(--status-error)` },
+  unknown: {
+    label: 'State unknown',
+    icon: 'circle-dashed',
+    cls: `${PILL} bg-(--surface-active) text-(--text-tertiary)`
+  }
+}
+
+/** Which pill a view wears. Draft outranks open (GitHub's own rendering); a null state — degraded with nothing stored — is `unknown`, never a fabricated `open`. */
+export function pullRequestPillKey(state: SessionPullRequestDto['state'], isDraft: boolean | null): string {
+  if (state === 'open' && isDraft) return 'draft'
+  return state ?? 'unknown'
+}
+
+// The overall review decision, drawn in the REVIEWS section header where it belongs.
+const DECISION_PILL: Record<string, { label: string; cls: string }> = {
+  approved: { label: 'Approved', cls: `${PILL} bg-(--status-online-soft) text-(--status-online)` },
+  changes_requested: { label: 'Changes requested', cls: `${PILL} bg-(--status-error-soft) text-(--status-error)` },
+  review_required: { label: 'Review required', cls: `${PILL} bg-(--surface-active) text-(--status-paused)` }
+}
+
+// One glyph per check state. `check-circle-2`, which §8's icon list names, does not exist in this lucide version — `circle-check` and `circle-x` do (the substitute M2 recorded).
+const CHECK_ICON: Record<SessionPullRequestCheckDto['state'], { name: string; color: string }> = {
+  success: { name: 'circle-check', color: 'var(--status-online)' },
+  failure: { name: 'circle-x', color: 'var(--status-error)' },
+  pending: { name: 'loader', color: 'var(--status-info)' },
+  skipped: { name: 'circle-dashed', color: 'var(--text-disabled)' },
+  neutral: { name: 'circle-minus', color: 'var(--text-tertiary)' }
+}
+
+const REVIEW_META: Record<SessionPullRequestReviewDto['state'], { icon: string; color: string; label: string }> = {
+  approved: { icon: 'circle-check', color: 'var(--status-online)', label: 'approved' },
+  changes_requested: { icon: 'circle-x', color: 'var(--status-error)', label: 'changes requested' },
+  commented: { icon: 'message-square', color: 'var(--text-tertiary)', label: 'commented' },
+  dismissed: { icon: 'circle-minus', color: 'var(--text-disabled)', label: 'dismissed' },
+  pending: { icon: 'circle-dashed', color: 'var(--text-tertiary)', label: 'pending' }
+}
+
+// Why the live half is missing, per the projection's three reasons. Identity above each stays up — a panel that still names its PR beats an empty one (§9 M5).
+function degradedNoticeText(reason: SessionPullRequestDto['degradedReason']): string {
+  if (reason === 'rate_limited') {
+    return 'GitHub is rate limiting this deployment, so checks, reviews and threads are withheld for a moment. They come back on their own — or refresh shortly.'
+  }
+  if (reason === 'denied') {
+    return 'GitHub denied this read — the installation may be suspended or no longer cover the repository. What is shown above is what AgentConnect already knows.'
+  }
+  return 'GitHub couldn’t be reached, so checks, reviews and threads are unavailable. What is shown above is what AgentConnect already knows.'
+}
+
+export function PullRequestPanel({
+  sessionId,
+  active = true,
+  onVerdictChange
+}: {
+  /** The OPEN SESSION's id, the scope the CP resolves to its hook run. Deliberately no agentId: the PR belongs to the session, so a merged conversation's header-focus change must not re-key this read — the prop shape makes that unbuildable rather than merely avoided. */
+  sessionId: string
+  /** Whether this tab is the visible one; the panel re-reads on the edge where it becomes so, because PR state read when the page opened is not an answer about now. It does not poll — GitHub rate limits are this milestone's one external budget (§9). */
+  active?: boolean
+  /** The inputs to {@link pullRequestTabStatus}, the tab's badge and its external-link action. */
+  onVerdictChange?: (verdict: PullRequestPanelVerdict) => void
+}) {
+  // The panel owns its reads: the tab's header action is `external-link` (§1's table), so refresh lives in the body. Both fields move together so a press is exactly one effect run.
+  const [reads, setReads] = useState({ tick: 0, force: false })
+  const { read, refreshing } = useSessionPullRequest(sessionId, reads)
+  const view = read.data
+
+  // The activation EDGE, not the state: re-reading on `active` itself would re-read on every render while the tab is open. Unreachable for a hidden tab, which is what keeps a 404 asked once.
+  const wasActive = useRef(active)
+  useEffect(() => {
+    if (active && !wasActive.current) setReads((r) => ({ tick: r.tick + 1, force: false }))
+    wasActive.current = active
+  }, [active])
+
+  const answer: PullRequestPanelAnswer = read.loading
+    ? 'pending'
+    : view
+      ? 'linked'
+      : read.errStatus === 404
+        ? 'none'
+        : 'failed'
+  const unresolved = view && !view.degraded ? view.unresolvedCount : null
+  const url = view?.url ?? null
+
+  // Reported on the EDGE, like every other tab's verdict: the caller's callback is a fresh closure per render, and re-reporting a held verdict would write parent state for nothing.
+  const reported = useRef<string | null>(null)
+  useEffect(() => {
+    const key = `${answer}:${unresolved ?? ''}:${url ?? ''}`
+    if (reported.current === key) return
+    reported.current = key
+    onVerdictChange?.({ answer, unresolved, url })
+  }, [answer, onVerdictChange, unresolved, url])
+
+  // Nothing while the dock's own "Loading…" placeholder speaks, and nothing at all for a session with no PR — its tab is not in the strip to open.
+  if (answer === 'pending' || answer === 'none') return null
+
+  const refresh = (
+    <button
+      type="button"
+      data-pr-refresh=""
+      className="iconbtn h-[22px] w-[22px] flex-none rounded-xs disabled:pointer-events-none"
+      disabled={refreshing}
+      aria-label="Refresh pull request"
+      title="Ask GitHub again, past the control plane’s short cache"
+      onClick={() => setReads((r) => ({ tick: r.tick + 1, force: true }))}
+    >
+      {refreshing ? <Spinner size={11} /> : <Icon name="refresh-cw" size={13} />}
+    </button>
+  )
+
+  // A failed probe is not "no PR": hiding the tab here would claim an absence nobody verified, so the tab stays and says why there is nothing behind it.
+  if (answer === 'failed' || !view) {
+    return (
+      <div data-pr-panel="failed" className="flex min-h-0 flex-1 flex-col">
+        <div className="flex flex-none items-center gap-2 border-b border-(--border-subtle) px-3 py-[7px]">
+          <span className="min-w-0 flex-1 font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+            Pull request unavailable
+          </span>
+          {refresh}
+        </div>
+        <PanelNotice
+          warn
+          text="Couldn’t read this session’s pull request — the control plane may be unreachable. Its state is proxied live, so nothing is shown while the read fails."
+        />
+      </div>
+    )
+  }
+
+  const pill = STATE_PILL[pullRequestPillKey(view.state, view.isDraft)]!
+  const decision = view.reviewDecision ? DECISION_PILL[view.reviewDecision] : undefined
+
+  const section = (name: string, title: string, count: ReactNode, children: ReactNode, aside?: ReactNode) => (
+    <div data-pr-section={name} className="flex flex-none flex-col">
+      <div className="flex items-center gap-2 px-3 pt-[10px] pb-[5px] font-sans text-[10.5px] font-semibold tracking-[0.04em] uppercase leading-normal text-(--text-disabled)">
+        <span>{title}</span>
+        <span className="mono font-medium normal-case tracking-normal">{count}</span>
+        {aside ? <span className="ml-auto normal-case tracking-normal">{aside}</span> : null}
+      </div>
+      {children}
+    </div>
+  )
+
+  const footnote = (text: string) => (
+    <div className="px-3 py-[7px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">{text}</div>
+  )
+
+  const checkRow = (check: SessionPullRequestCheckDto, index: number) => {
+    const duration = formatCheckDuration(check.startedAt, check.completedAt)
+    const glyph = CHECK_ICON[check.state]
+    return (
+      // Keyed by position: GitHub does not promise distinct names across check suites, and the list is replaced whole on every read.
+      <div
+        key={`${index}:${check.name}`}
+        data-pr-check={check.state}
+        className="flex items-center gap-2 px-3 py-[5px]"
+        title={check.detail ?? undefined}
+      >
+        <Icon
+          name={glyph.name}
+          size={13}
+          color={glyph.color}
+          className={check.state === 'pending' ? 'flex-none animate-spin' : 'flex-none'}
+        />
+        <span className="min-w-0 flex-1 truncate font-sans text-[12px] font-normal leading-normal text-(--text-primary)">
+          {check.name}
+        </span>
+        {duration ? (
+          <span className="mono flex-none text-[11px] font-normal leading-normal text-(--text-tertiary)">
+            {duration}
+          </span>
+        ) : null}
+      </div>
+    )
+  }
+
+  const reviewRow = (review: SessionPullRequestReviewDto) => {
+    const meta = REVIEW_META[review.state]
+    return (
+      // One row per reviewer — the wire already collapses review events to each reviewer's current review.
+      <div key={review.author} data-pr-review={review.state} className="flex items-center gap-2 px-3 py-[5px]">
+        <Icon name={meta.icon} size={13} color={meta.color} className="flex-none" />
+        <span className="min-w-0 flex-1 truncate font-sans text-[12px] font-medium leading-normal text-(--text-primary)">
+          {review.author}
+        </span>
+        {review.isBot ? (
+          <span
+            className="flex-none rounded-xs bg-(--surface-active) px-[5px] py-px font-sans text-[10px] font-medium leading-normal text-(--text-tertiary)"
+            title="A GitHub App identity, not a person"
+          >
+            bot
+          </span>
+        ) : null}
+        <span className="flex-none font-sans text-[11px] font-normal leading-normal text-(--text-secondary)">
+          {meta.label}
+        </span>
+      </div>
+    )
+  }
+
+  const threadCard = (thread: SessionPullRequestThreadDto, index: number) => (
+    // Keyed by position: two threads can share a location, and the list is replaced whole on every read.
+    <div
+      key={`${index}:${thread.location}`}
+      data-pr-thread=""
+      className="flex flex-none flex-col gap-[4px] rounded-md border border-(--border-subtle) bg-(--surface-card) px-[10px] py-2"
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className="mono min-w-0 flex-1 truncate text-[11px] font-medium leading-normal text-(--text-secondary)"
+          title={thread.location}
+        >
+          {thread.location}
+        </span>
+        {thread.isOutdated ? (
+          <span
+            className="flex-none rounded-xs bg-(--surface-active) px-[5px] py-px font-sans text-[10px] font-medium leading-normal text-(--text-tertiary)"
+            title="The commented lines have changed since this thread was opened"
+          >
+            outdated
+          </span>
+        ) : null}
+      </div>
+      <div className="line-clamp-2 font-sans text-[12px] font-normal leading-[1.5] text-(--text-primary)">
+        {thread.body}
+      </div>
+      <div className="font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">{thread.author}</div>
+    </div>
+  )
+
+  return (
+    <div data-pr-panel="" className="flex min-h-0 flex-1 flex-col">
+      {/* Identity, from the CP's own records: it survives every GitHub failure below, which is the §9 M5 bargain. */}
+      <div className="flex flex-none flex-col gap-[6px] border-b border-(--border-subtle) px-3 py-[10px]">
+        <div className="flex items-center gap-2">
+          <span data-pr-state={pullRequestPillKey(view.state, view.isDraft)} className={pill.cls}>
+            <Icon name={pill.icon} size={11} />
+            {pill.label}
+          </span>
+          <span className="mono flex-none text-[11px] font-medium leading-normal text-(--text-secondary)">
+            {`#${view.pullNumber}`}
+          </span>
+          <span
+            className="mono min-w-0 flex-1 truncate text-[11px] font-normal leading-normal text-(--text-tertiary)"
+            title={view.repoFullName}
+          >
+            {view.repoFullName}
+          </span>
+          {refresh}
+        </div>
+        <div className="font-sans text-[13px] font-semibold leading-[1.4] text-(--text-primary)">{view.title}</div>
+        <div className="flex items-center gap-2">
+          <span className="mono flex min-w-0 flex-1 items-center gap-[5px] text-[11px] font-normal leading-normal text-(--text-secondary)">
+            <span className="min-w-0 truncate" title={view.headRef}>
+              {view.headRef}
+            </span>
+            <Icon name="arrow-right" size={10} color="var(--text-tertiary)" className="flex-none" />
+            <span className="min-w-0 truncate" title={view.baseRef}>
+              {view.baseRef}
+            </span>
+          </span>
+          {/* Line counts only when GitHub answered them — a degraded read has no stored counts to fall back on, and 0 would be an invented number. */}
+          {view.additions !== null || view.deletions !== null ? (
+            <span className="mono flex-none text-[11px] font-medium leading-normal">
+              {view.additions !== null ? <span className="text-(--status-online)">{`+${view.additions}`}</span> : null}
+              {view.additions !== null && view.deletions !== null ? ' ' : null}
+              {view.deletions !== null ? <span className="text-(--status-error)">{`−${view.deletions}`}</span> : null}
+            </span>
+          ) : null}
+        </div>
+        <a
+          data-pr-link=""
+          href={view.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="lnk flex items-center gap-[4px] self-start font-sans text-[11.5px] font-medium leading-normal"
+        >
+          <Icon name="external-link" size={12} className="flex-none" />
+          View on GitHub
+        </a>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-auto pb-2">
+        {view.degraded ? (
+          <>
+            <PanelNotice warn text={degradedNoticeText(view.degradedReason)} />
+            {/* The one review state this deployment knows without GitHub: its own agent's, off the owning run. Populated by the SERVICE only on a degraded answer — when GitHub answered, its list is authoritative and already contains this review. */}
+            {view.agentReview ? (
+              <div
+                data-pr-agent-review=""
+                className="flex items-center gap-2 px-3 py-[7px] font-sans text-[12px] font-normal leading-normal text-(--text-secondary)"
+              >
+                <Icon
+                  name={REVIEW_META[view.agentReview].icon}
+                  size={13}
+                  color={REVIEW_META[view.agentReview].color}
+                  className="flex-none"
+                />
+                <span>
+                  This agent’s recorded review:{' '}
+                  <span className="font-medium">{REVIEW_META[view.agentReview].label}</span>
+                </span>
+              </div>
+            ) : null}
+          </>
+        ) : (
+          <>
+            {section(
+              'checks',
+              'Checks',
+              view.checks.length,
+              view.checks.length === 0 ? (
+                <PanelNotice text="No checks reported on this PR’s head commit." />
+              ) : (
+                <>
+                  {view.checks.map(checkRow)}
+                  {view.checksTruncated
+                    ? footnote(`More checks than one read carries — the first ${view.checks.length} are listed.`)
+                    : null}
+                </>
+              )
+            )}
+            {section(
+              'reviews',
+              'Reviews',
+              view.reviews.length,
+              view.reviews.length === 0 ? <PanelNotice text="No reviews yet." /> : <>{view.reviews.map(reviewRow)}</>,
+              decision ? (
+                <span data-pr-decision={view.reviewDecision} className={decision.cls}>
+                  {decision.label}
+                </span>
+              ) : undefined
+            )}
+            {section(
+              'threads',
+              'Unresolved threads',
+              // The count is a FLOOR when the thread page is truncated, and the `+` says so rather than presenting a page as the total.
+              `${view.unresolvedCount}${view.threadsTruncated ? '+' : ''}`,
+              view.threads.length === 0 ? (
+                <PanelNotice text="No unresolved review threads." />
+              ) : (
+                <div className="flex flex-col gap-[6px] px-3 pt-px pb-[6px]">
+                  {view.threads.map(threadCard)}
+                  {view.threadsTruncated ? (
+                    <div className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+                      More unresolved threads than one read carries — the first {view.threads.length} are shown.
+                    </div>
+                  ) : null}
+                </div>
+              )
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// A degraded or empty state, drawn calmly: a PR whose live half is missing still has something to say about why.
+function PanelNotice({ text, warn = false }: { text: string; warn?: boolean }) {
+  return (
+    <div className="flex items-start gap-2 px-3 py-[10px] font-sans text-[12px] font-normal leading-[1.55] text-(--text-secondary)">
+      <Icon
+        name={warn ? 'triangle-alert' : 'git-pull-request'}
+        size={14}
+        color={warn ? 'var(--amber-500)' : 'var(--text-tertiary)'}
+        className="mt-[2px] flex-none"
+      />
+      <span>{text}</span>
+    </div>
+  )
+}

--- a/packages/web/src/components/console/dock/PullRequestPanel.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.tsx
@@ -59,6 +59,9 @@ interface PrRead {
 
 const PENDING: PrRead = { loading: true, err: null, errStatus: null, data: null }
 
+// How long a 404 stays provisional: five CP-local retries over ~2.5 minutes, then the absence is believed.
+export const PR_LINK_RETRY_LADDER_MS = [2_000, 5_000, 15_000, 45_000, 90_000]
+
 /** One probe per (session, tick). The answer is held PER SCOPE and the pending state DERIVED from it (the M4 shape): a new session reads as pending on the very render that changes it, a re-read of the SAME session replaces the answer in place, and a settled 404 simply stays held — nothing bumps the tick for a hidden tab. */
 function useSessionPullRequest(sessionId: string, reads: { tick: number; force: boolean }) {
   const [answered, setAnswered] = useState<{ scope: string; tick: number; read: PrRead } | null>(null)
@@ -153,7 +156,7 @@ export function PullRequestPanel({
   sessionId: string
   /** Whether this tab is the visible one; the panel re-reads on the edge where it becomes so, because PR state read when the page opened is not an answer about now. It does not poll — GitHub rate limits are this milestone's one external budget (§9). */
   active?: boolean
-  /** The open session's live status, feeding the ONE bounded re-probe edge a hidden tab has: the run's sessionId can be written as late as the terminal hook/report, which is also what flips this value — so a 404 held while the session was still running is re-asked when its status changes, and never on a timer. */
+  /** The open session's live status: a transition re-asks a held 404 immediately and refills the bounded retry ladder — a hint that the session→run link may just have committed, though the frames race, which is why the ladder exists at all. */
   sessionStatus?: string
   /** The inputs to {@link pullRequestTabStatus}, the tab's badge and its external-link action. */
   onVerdictChange?: (verdict: PullRequestPanelVerdict) => void
@@ -170,16 +173,32 @@ export function PullRequestPanel({
     wasActive.current = active
   }, [active])
 
-  // A hidden tab's only way back: the session-to-run link can be persisted as late as the terminal
-  // hook/report, which also flips the session's status — so a held 404 is re-asked once per status
-  // TRANSITION, never per render and never on a timer. Any other answer keeps the edge silent.
+  // A held 404 is PROVISIONAL: `hook/report` (which writes the session→run link) and the terminal `event/session` snapshot are separate concurrently-dispatched frames, so the link can commit after the status flip — or with no flip at all, when a reconnect restores an already-terminal session.
   const was404 = read.errStatus === 404 && !read.loading
+  const attempt = useRef(0)
+  // A status transition re-asks immediately and refills the ladder below — it is a strong hint, not proof of ordering.
   const lastStatus = useRef(sessionStatus)
   useEffect(() => {
     const changed = sessionStatus !== lastStatus.current
     lastStatus.current = sessionStatus
-    if (changed && was404) setReads((r) => ({ tick: r.tick + 1, force: false }))
+    if (!changed) return
+    attempt.current = 0
+    if (was404) setReads((r) => ({ tick: r.tick + 1, force: false }))
   }, [sessionStatus, was404])
+  // The bounded ladder that survives the unfavorable orderings: a 404 never reaches GitHub — the CP answers it from its own tables — so these retries spend none of §9's rate-limit budget, and the bound is what lets a session with no PR go quiet.
+  useEffect(() => {
+    if (!was404) {
+      attempt.current = 0
+      return
+    }
+    const delay = PR_LINK_RETRY_LADDER_MS[attempt.current]
+    if (delay === undefined) return
+    const timer = setTimeout(() => {
+      attempt.current += 1
+      setReads((r) => ({ tick: r.tick + 1, force: false }))
+    }, delay)
+    return () => clearTimeout(timer)
+  }, [was404, reads])
 
   const answer: PullRequestPanelAnswer = read.loading
     ? 'pending'

--- a/packages/web/src/components/console/dock/PullRequestPanel.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.tsx
@@ -146,12 +146,15 @@ function degradedNoticeText(reason: SessionPullRequestDto['degradedReason']): st
 export function PullRequestPanel({
   sessionId,
   active = true,
+  sessionStatus,
   onVerdictChange
 }: {
   /** The OPEN SESSION's id, the scope the CP resolves to its hook run. Deliberately no agentId: the PR belongs to the session, so a merged conversation's header-focus change must not re-key this read — the prop shape makes that unbuildable rather than merely avoided. */
   sessionId: string
   /** Whether this tab is the visible one; the panel re-reads on the edge where it becomes so, because PR state read when the page opened is not an answer about now. It does not poll — GitHub rate limits are this milestone's one external budget (§9). */
   active?: boolean
+  /** The open session's live status, feeding the ONE bounded re-probe edge a hidden tab has: the run's sessionId can be written as late as the terminal hook/report, which is also what flips this value — so a 404 held while the session was still running is re-asked when its status changes, and never on a timer. */
+  sessionStatus?: string
   /** The inputs to {@link pullRequestTabStatus}, the tab's badge and its external-link action. */
   onVerdictChange?: (verdict: PullRequestPanelVerdict) => void
 }) {
@@ -166,6 +169,17 @@ export function PullRequestPanel({
     if (active && !wasActive.current) setReads((r) => ({ tick: r.tick + 1, force: false }))
     wasActive.current = active
   }, [active])
+
+  // A hidden tab's only way back: the session-to-run link can be persisted as late as the terminal
+  // hook/report, which also flips the session's status — so a held 404 is re-asked once per status
+  // TRANSITION, never per render and never on a timer. Any other answer keeps the edge silent.
+  const was404 = read.errStatus === 404 && !read.loading
+  const lastStatus = useRef(sessionStatus)
+  useEffect(() => {
+    const changed = sessionStatus !== lastStatus.current
+    lastStatus.current = sessionStatus
+    if (changed && was404) setReads((r) => ({ tick: r.tick + 1, force: false }))
+  }, [sessionStatus, was404])
 
   const answer: PullRequestPanelAnswer = read.loading
     ? 'pending'

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -103,6 +103,11 @@ import { SessionsPanel, sessionsTabStatus } from '@/components/console/dock/Sess
 import { FilesPanel, filesTabStatus } from '@/components/console/dock/FilesPanel'
 import { GitPanel, gitTabStatus, type GitPanelVerdict } from '@/components/console/dock/GitPanel'
 import { TasksPanel, tasksTabStatus, type TasksPanelVerdict } from '@/components/console/dock/TasksPanel'
+import {
+  PullRequestPanel,
+  pullRequestTabStatus,
+  type PullRequestPanelVerdict
+} from '@/components/console/dock/PullRequestPanel'
 import { SessionViewer, viewerModeFromParam, type ViewerMode } from '@/components/console/viewer/SessionViewer'
 import {
   EMPTY_RAIL_AGENT_FILTER,
@@ -1187,6 +1192,8 @@ const DOCK_TABS: DockTab[] = [
     actionIcon: 'refresh-cw',
     actionLabel: 'Refresh git status'
   },
+  // PR's `external-link` action is spliced on below, once a 200 has carried a URL for it to open.
+  { key: 'pr', label: 'PR', icon: 'git-pull-request' },
   {
     key: 'tasks',
     label: 'Tasks',
@@ -1837,6 +1844,11 @@ export default function SessionDetailView() {
   // Which lease the Tasks tab reads. Tasks are NOT a checkout, so this waits on neither the worktree gate `filesSessionId` applies nor the isolation round trip Files and Git hold for — a session's background tasks exist whatever it is checked out into, and the CP says so. What it does need is the CANONICAL session id the lease is keyed by, which is what the focus options already carry. A playground session the daemon has not created yet has no canonical id and no tasks either, so it gets no tab rather than a 404 notice.
   const tasksSessionId =
     headerFocusSessionId && !(syntheticPlayground && headerFocusSessionId === session?.id) ? headerFocusSessionId : null
+  // The PR tab's scope: the OPEN SESSION — in a merged conversation its representative — because the hook run the CP resolves belongs to the session, not to a participant. Header focus deliberately plays NO part here: focusing another agent re-aims Files/Git/Tasks at that agent's checkout or lease, but a focus change must not re-key this read (§3.4). A synthetic playground id names no CP row and was never hook-dispatched, so it gets no probe rather than a manufactured 404.
+  const prSessionId =
+    MOCK_MODE || !session || (syntheticPlayground && !session.realSessionId)
+      ? null
+      : (session.realSessionId ?? session.id)
   const focusedAgentRuntime = focusedSession?.runtime || focusedAgent?.runtime || ''
   const focusedRuntimeMeta = acpRuntime(acpRegistry, focusedAgentRuntime)
 
@@ -1894,6 +1906,12 @@ export default function SessionDetailView() {
   // The Tasks tab's own `refresh-cw` and verdict. Its settle state feeds the tab status, its running count the badge.
   const [tasksRefreshTick, setTasksRefreshTick] = useState(0)
   const [tasksVerdict, setTasksVerdict] = useState<TasksPanelVerdict>({ settled: false, running: null })
+  // The PR tab's verdict, reported by its panel: whether this session HAS a linked run at all (`none` drops the tab), the unresolved-thread badge, and the URL its `external-link` action opens.
+  const [prVerdict, setPrVerdict] = useState<PullRequestPanelVerdict>({
+    answer: 'pending',
+    unresolved: null,
+    url: null
+  })
   // A seed narrowed to the conversation already on screen hides the list AND the picker that could widen it, so re-ask it unfiltered.
   const railSeedKeyNow = railSeedKey(railFilter)
   // Waited on because an in-flight family reads as EMPTY, not `undefined`: latching there widens a list about to grow a Related tree.
@@ -1921,14 +1939,19 @@ export default function SessionDetailView() {
   const gitStatus = filesScopeFailed ? 'ready' : filesScopeReady ? gitTabStatus(gitVerdict.settled) : 'loading'
   // Tasks has no isolation branch to wait on, so its status is only ever "has the read answered".
   const tasksStatus = tasksTabStatus(tasksVerdict.settled)
+  // PR: `loading` until the probe's first answer, `ready` after — and a `none` answer removes the tab below, so `empty` never has a state left to describe.
+  const prStatus = pullRequestTabStatus(prVerdict.answer)
   // Each tab's own verdict, spliced onto the static descriptors. Files is dropped outright rather than left `loading` forever when there is no agent behind it — a tab that can never answer is not a tab — and the demo tour has no daemon to read a checkout from at all, so it does not get one either.
   const dockTabs = useMemo<DockTab[]>(
     () =>
       DOCK_TABS.filter((tab) =>
         tab.key === 'files' || tab.key === 'git'
           ? filesAgentId !== null && !MOCK_MODE
-          : // Dropped on the same terms and for the same reason, but against its OWN scope: no agent to ask, or no canonical session for the lease to be keyed by.
-            tab.key !== 'tasks' || (filesAgentId !== null && tasksSessionId !== null && !MOCK_MODE)
+          : tab.key === 'tasks'
+            ? // Dropped on the same terms and for the same reason, but against its OWN scope: no agent to ask, or no canonical session for the lease to be keyed by.
+              filesAgentId !== null && tasksSessionId !== null && !MOCK_MODE
+            : // PR is a tab only while the session HAS a pull request: the probe's 404 means "no linked run", and that never changes later — the run is what created the session — so the strip changes shape rather than carrying a dead tab (§9 M5).
+              tab.key !== 'pr' || (prSessionId !== null && prVerdict.answer !== 'none')
       ).map((tab) =>
         tab.key === 'sessions'
           ? { ...tab, status: sessionsStatus }
@@ -1941,20 +1964,36 @@ export default function SessionDetailView() {
                   // The badge is the changed-file count, omitted rather than shown as `0`: a clean tree wears no pill, and neither does a workspace whose status could not be read.
                   ...(gitVerdict.changed ? { badge: gitVerdict.changed } : {})
                 }
-              : tab.key === 'tasks'
+              : tab.key === 'pr'
                 ? {
                     ...tab,
-                    status: tasksStatus,
-                    // Running tasks only, and omitted rather than shown as `0`: an idle session wears no pill, and neither does an untracked one, whose count is null rather than zero.
-                    ...(tasksVerdict.running ? { badge: tasksVerdict.running } : {})
+                    status: prStatus,
+                    // Unresolved review threads (§1's table), omitted rather than shown as `0` — and omitted while degraded, where the count is unknown rather than zero.
+                    ...(prVerdict.unresolved ? { badge: prVerdict.unresolved } : {}),
+                    // The design's header action opens the PR's own page; withheld until an answer has carried a URL to open.
+                    ...(prVerdict.url
+                      ? { actionIcon: 'external-link', actionLabel: 'Open the pull request on GitHub' }
+                      : {})
                   }
-                : tab
+                : tab.key === 'tasks'
+                  ? {
+                      ...tab,
+                      status: tasksStatus,
+                      // Running tasks only, and omitted rather than shown as `0`: an idle session wears no pill, and neither does an untracked one, whose count is null rather than zero.
+                      ...(tasksVerdict.running ? { badge: tasksVerdict.running } : {})
+                    }
+                  : tab
       ),
     [
       filesAgentId,
       filesStatus,
       gitStatus,
       gitVerdict.changed,
+      prSessionId,
+      prStatus,
+      prVerdict.answer,
+      prVerdict.unresolved,
+      prVerdict.url,
       sessionsStatus,
       tasksSessionId,
       tasksStatus,
@@ -4518,6 +4557,8 @@ export default function SessionDetailView() {
         onTabAction={(key) => {
           if (key === 'files') setFilesRefreshTick((tick) => tick + 1)
           if (key === 'git') setGitRefreshTick((tick) => tick + 1)
+          // PR's action is the design's `external-link`, not a refresh: it opens the PR's own page (the panel body carries its own refresh).
+          if (key === 'pr' && prVerdict.url) window.open(prVerdict.url, '_blank', 'noopener,noreferrer')
           if (key === 'tasks') setTasksRefreshTick((tick) => tick + 1)
         }}
         overlayKey={`${session.id}:${viewerPath ?? ''}`}
@@ -4590,6 +4631,12 @@ export default function SessionDetailView() {
               }
               onVerdictChange={setGitVerdict}
             />
+          ) : null}
+        </DockPanel>
+        {/* SESSION-keyed, not focus-keyed: the run belongs to the open session, so the header focus menu must not re-key this panel — its props carry no agent at all. Mounted whenever a probe-able id exists, because its verdict is what puts its own tab in the strip: a panel mounted only for a visible tab could never reveal the tab. */}
+        <DockPanel active={dockTabKey === 'pr'}>
+          {prSessionId ? (
+            <PullRequestPanel sessionId={prSessionId} active={dockTabKey === 'pr'} onVerdictChange={setPrVerdict} />
           ) : null}
         </DockPanel>
         {/* No isolation gate and no withheld state: the lease is keyed by the session, not by a checkout, so there is nothing to resolve first. `active` is what keeps a hidden panel from polling. */}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -4636,7 +4636,12 @@ export default function SessionDetailView() {
         {/* SESSION-keyed, not focus-keyed: the run belongs to the open session, so the header focus menu must not re-key this panel — its props carry no agent at all. Mounted whenever a probe-able id exists, because its verdict is what puts its own tab in the strip: a panel mounted only for a visible tab could never reveal the tab. */}
         <DockPanel active={dockTabKey === 'pr'}>
           {prSessionId ? (
-            <PullRequestPanel sessionId={prSessionId} active={dockTabKey === 'pr'} onVerdictChange={setPrVerdict} />
+            <PullRequestPanel
+              sessionId={prSessionId}
+              active={dockTabKey === 'pr'}
+              {...(session?.status ? { sessionStatus: session.status } : {})}
+              onVerdictChange={setPrVerdict}
+            />
           ) : null}
         </DockPanel>
         {/* No isolation gate and no withheld state: the lease is keyed by the session, not by a checkout, so there is nothing to resolve first. `active` is what keeps a hidden panel from polling. */}

--- a/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
@@ -30,6 +30,12 @@ const wire = vi.hoisted(() => ({
   /** The Tasks tab's read. Scoped by SESSION rather than by worktree, so its calls are recorded with the scope they asked for. */
   tasks: { sessionId: 'session-1', tracked: true, tasks: [] as unknown[], truncated: false } as unknown,
   taskCalls: [] as Array<{ agentId: string; sessionId: string }>,
+  /** The PR tab's probe. `null` is the CP's 404 — the default, because most sessions were not dispatched for a pull request; `prFailStatus` overrides the failure shape. */
+  pr: null as unknown,
+  prFailStatus: 404,
+  prCalls: [] as Array<{ sessionId: string; refresh: boolean }>,
+  /** Non-null holds every PR probe until released, so the strip is observable while the linkage is unknown. */
+  prGate: null as null | Array<() => void>,
   /** A synthetic playground session the daemon has not created yet — its route id names no canonical session the lease could be keyed by. */
   playground: false
 }))
@@ -125,6 +131,12 @@ vi.mock('@/lib/api', async (importOriginal) => {
     fetchAgentTasks: vi.fn((agentId: string, sessionId: string) => {
       wire.taskCalls.push({ agentId, sessionId })
       return Promise.resolve(wire.tasks)
+    }),
+    fetchSessionPullRequest: vi.fn(async (sessionId: string, opts: { refresh?: boolean } = {}) => {
+      wire.prCalls.push({ sessionId, refresh: opts.refresh === true })
+      if (wire.prGate) await new Promise<void>((resolve) => wire.prGate?.push(resolve))
+      if (wire.pr) return wire.pr
+      throw new actual.ApiError('pull request not found', wire.prFailStatus)
     }),
     fetchSessionMessages: vi.fn(() => Promise.resolve({ messages: [], nextCursor: null })),
     fetchSessionDetail: vi.fn(() => Promise.reject(new Error('no detail'))),
@@ -305,6 +317,10 @@ beforeEach(() => {
   wire.rail = []
   wire.tasks = { sessionId: 'session-1', tracked: true, tasks: [], truncated: false }
   wire.taskCalls = []
+  wire.pr = null
+  wire.prFailStatus = 404
+  wire.prCalls = []
+  wire.prGate = null
   window.localStorage.clear()
   window.matchMedia = ((query: string) => ({
     matches: false,
@@ -853,6 +869,137 @@ describe('the Tasks tab', () => {
     expect(container?.querySelector('[data-tasks-panel]')?.textContent).toContain('doesn’t report background tasks')
     expect(container?.querySelector('[data-dock-tab="tasks"]')?.textContent).toBe('Tasks')
     expect(container?.querySelector('[data-dock-empty]')).toBeNull()
+  })
+})
+
+describe('the PR tab', () => {
+  const openTab = async (key: string) => {
+    await act(async () => {
+      container?.querySelector<HTMLElement>(`[data-dock-tab="${key}"]`)?.click()
+      await Promise.resolve()
+    })
+    await render()
+  }
+  // The wire shape of GET /sessions/:id/pull-request, in the small: identity plus the three live lists.
+  const prDto = (overrides: Record<string, unknown> = {}) => ({
+    repoFullName: 'acme/api',
+    pullNumber: 57,
+    title: 'Ship the dock',
+    state: 'open',
+    isDraft: false,
+    url: 'https://github.com/acme/api/pull/57',
+    headRef: 'feat/dock',
+    baseRef: 'main',
+    additions: 120,
+    deletions: 30,
+    reviewDecision: null,
+    checks: [],
+    checksTruncated: false,
+    reviews: [],
+    threads: [
+      { location: 'src/dock.ts:12', body: 'This needs the org.', author: 'sam', isOutdated: false },
+      { location: 'src/dock.ts:40', body: 'And this.', author: 'sam', isOutdated: false }
+    ],
+    unresolvedCount: 2,
+    threadsTruncated: false,
+    degraded: false,
+    degradedReason: null,
+    ...overrides
+  })
+
+  it('is HIDDEN for a session with no linked run, whose 404 is asked exactly once', async () => {
+    // The default wire answer IS the 404: most sessions were not dispatched for a PR, and their strip must not carry a dead tab (§9 M5). One probe decides it — the linkage cannot appear later, so nothing re-asks.
+    await render()
+    expect(container?.querySelector('[data-dock-tab="pr"]')).toBeNull()
+    expect(container?.querySelector('[data-pr-panel]')).toBeNull()
+    expect(wire.prCalls).toEqual([{ sessionId: 'session-1', refresh: false }])
+    await render()
+    await render()
+    expect(wire.prCalls).toHaveLength(1)
+  })
+
+  it('stands in the strip as loading while the linkage is unknown, then leaves it when the 404 lands', async () => {
+    // The strip CHANGES SHAPE on the answer: a session that turns out to have no PR loses the tab rather than keeping a dead one, and a linked one keeps it — the probe's verdict is the only thing that can tell them apart.
+    wire.prGate = []
+    await render()
+    expect(container?.querySelector('[data-dock-tab="pr"]')).not.toBeNull()
+
+    const release = wire.prGate
+    wire.prGate = null
+    await act(async () => {
+      release.forEach((resolve) => resolve())
+      await Promise.resolve()
+    })
+    await render()
+    expect(container?.querySelector('[data-dock-tab="pr"]')).toBeNull()
+  })
+
+  it('shows the tab with the unresolved-thread badge for a linked session, keyed by the SESSION', async () => {
+    wire.pr = prDto()
+    await render()
+    expect(container?.querySelector('[data-dock-tab="pr"]')?.textContent).toContain('2')
+    // Session-keyed, never agent-keyed: the run belongs to the session, so a header-focus change in a merged conversation has nothing to re-key (the probe carries no agent id at all).
+    expect(wire.prCalls).toEqual([{ sessionId: 'session-1', refresh: false }])
+
+    await openTab('pr')
+    expect(container?.querySelector('[data-pr-panel]')?.textContent).toContain('Ship the dock')
+    expect(container?.querySelector('[data-dock-empty]')).toBeNull()
+  })
+
+  it('gives the active tab the design’s external-link action, which opens the PR’s own page', async () => {
+    wire.pr = prDto()
+    const opened: string[] = []
+    window.open = ((url: string) => {
+      opened.push(String(url))
+      return null
+    }) as typeof window.open
+    await render()
+    await openTab('pr')
+    const action = container?.querySelector<HTMLElement>('[data-dock-action="pr"]')
+    expect(action?.getAttribute('aria-label')).toBe('Open the pull request on GitHub')
+    await act(async () => {
+      action?.click()
+      await Promise.resolve()
+    })
+    expect(opened).toEqual(['https://github.com/acme/api/pull/57'])
+  })
+
+  it('keeps the tab when the probe FAILS, because a failed read is not "no PR"', async () => {
+    // 404 means the CP verified there is no linked run; a 503 or a network failure verified nothing, so hiding here would assert an absence nobody read. The tab stays and its panel says why it is empty-handed.
+    wire.prFailStatus = 503
+    await render()
+    expect(container?.querySelector('[data-dock-tab="pr"]')).not.toBeNull()
+    await openTab('pr')
+    expect(container?.querySelector('[data-pr-panel="failed"]')?.textContent).toContain(
+      'Couldn’t read this session’s pull request'
+    )
+  })
+
+  it('wears no badge and still names its PR when GitHub is degraded', async () => {
+    // Degraded is DATA (§2): identity from the CP's own records survives, and the badge is withheld because the thread count is unknown rather than zero.
+    wire.pr = prDto({
+      state: 'closed',
+      isDraft: null,
+      additions: null,
+      deletions: null,
+      threads: [],
+      unresolvedCount: 0,
+      degraded: true,
+      degradedReason: 'rate_limited'
+    })
+    await render()
+    await openTab('pr')
+    // The ACTIVE tab draws its label, so a badge pill would be visible beside it — `PR` alone is the withheld badge.
+    expect(container?.querySelector('[data-dock-tab="pr"]')?.textContent).toBe('PR')
+    expect(container?.querySelector('[data-pr-panel]')?.textContent).toContain('Ship the dock')
+    expect(container?.querySelector('[data-pr-panel]')?.textContent).toContain('rate limiting')
+  })
+
+  it('sends no probe at all for a synthetic playground session, which names no CP row', async () => {
+    wire.playground = true
+    await render()
+    expect(container?.querySelector('[data-dock-tab="pr"]')).toBeNull()
+    expect(wire.prCalls).toEqual([])
   })
 })
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3113,6 +3113,69 @@ export async function fetchAgentTasks(agentId: string, sessionId: string): Promi
   return apiGet<AgentTasksDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/tasks?${q.toString()}`)
 }
 
+// ── session pull request (identity from the CP's own records; live state proxied from GitHub, never stored) ──
+// One check on the PR's head commit, over one vocabulary regardless of which kind of check reported it.
+export interface SessionPullRequestCheckDto {
+  name: string
+  state: 'success' | 'failure' | 'pending' | 'skipped' | 'neutral'
+  detail: string | null // GitHub's own word for it, verbatim
+  startedAt: string | null
+  completedAt: string | null
+  url: string | null
+}
+
+// One reviewer's CURRENT review, not one review event; `isBot` ⇒ a GitHub App identity, not a person.
+export interface SessionPullRequestReviewDto {
+  author: string
+  state: 'approved' | 'changes_requested' | 'commented' | 'dismissed' | 'pending'
+  isBot: boolean
+}
+
+// One UNRESOLVED review thread. Bodies are user content: proxied through the CP, never persisted.
+export interface SessionPullRequestThreadDto {
+  location: string // `path:line`, the path alone, or a PR-level thread
+  body: string
+  author: string
+  isOutdated: boolean
+}
+
+// GET /sessions/:id/pull-request — the PR this session was dispatched for. `degraded` makes a GitHub
+// failure DATA: identity survives, the live lists come back empty, and the nullable fields fall back
+// to what the CP already knows (or null). A session with NO linked run 404s, which hides the tab.
+export interface SessionPullRequestDto {
+  repoFullName: string
+  pullNumber: number
+  title: string
+  state: 'open' | 'closed' | 'merged' | null // null only degraded with no stored fact
+  isDraft: boolean | null
+  url: string
+  headRef: string
+  baseRef: string
+  additions: number | null // null while degraded — no stored line counts to fall back on
+  deletions: number | null
+  reviewDecision: 'approved' | 'changes_requested' | 'review_required' | null
+  checks: SessionPullRequestCheckDto[]
+  checksTruncated: boolean
+  reviews: SessionPullRequestReviewDto[]
+  threads: SessionPullRequestThreadDto[]
+  unresolvedCount: number // a floor when `threadsTruncated`
+  threadsTruncated: boolean
+  degraded: boolean
+  degradedReason: 'rate_limited' | 'denied' | 'unreachable' | null
+  /** The agent's own recorded review, present ONLY on a degraded answer — the one review state the deployment knows without GitHub. */
+  agentReview: 'approved' | 'changes_requested' | 'commented' | null
+}
+
+// Read the session's PR projection. `refresh` bypasses the CP's short TTL but not its in-flight
+// coalescing, so a double press is still one GitHub read; plain reads ride the cache.
+export async function fetchSessionPullRequest(
+  sessionId: string,
+  opts: { refresh?: boolean } = {}
+): Promise<SessionPullRequestDto> {
+  const query = opts.refresh ? '?refresh=true' : ''
+  return apiGet<SessionPullRequestDto>(`${orgBase()}/sessions/${encodeURIComponent(sessionId)}/pull-request${query}`)
+}
+
 // ── usage dashboard (GET /usage) — real historical aggregates from the CP's
 // persisted per-session usage store, summed over the selected range. ──
 export type UsageRange = 'd1' | 'd7' | 'd30' | 'd90'


### PR DESCRIPTION
M5 of [`docs/designs/webchat-side-panels.md`](docs/designs/webchat-side-panels.md), on top of #854. **Finished from the wip a peer session left on this branch** (`100add72`, `777c8d15` — preserved verbatim, then audited as if new rather than trusted).

## What the inherited CP half already had — verified, not assumed

- **One GraphQL read per uncached view**, on a repo-scoped installation token minted at the read floor (`checks:read` + `pull_requests:read`, numeric `repository_ids`), every connection bounded (`first:`/`last:` on reviews, checks, threads, comments, commits).
- **A TTL cache keyed `org#installation#repo#pull`** — a cross-org leak is structurally impossible and mutation-pinned ("never serves one org's cached view to another org" asserts two reads *and* two mints). Bounded at 256 with expired-entry sweep; degraded answers are cached too, so a rate-limited installation is not hammered once per panel mount. Installation revocation invalidates it via the existing doorbell.
- **One `absent()` closure behind all four 404 arms, authorization first** — an unauthorized session's 404 is byte-identical to a no-linked-run 404 and never reaches the run lookup, the token mint, or GitHub. Integration tests construct real Postgres rows for every arm (cross-org session *with* a linked run, another member's private session, a foreign org's run bound to the caller's own session id, unknown id), each asserting `toEqual(NOT_FOUND)` and zero fetches.
- **The schema change is exactly one partial index** on existing `HookRun` columns. No new stored content; review-thread bodies are proxied, never persisted (§2).

## Added on top

The **test suites the wip had none of** (CP unit for projection + cache semantics; CP integration for the 404 and authorization matrices), and the **web half**: a read-only `PullRequestPanel` — state pill, head→base with +/−, checks, reviews, unresolved threads with the count as the tab badge — whose only control is refresh, pinned by a test that tells M6 to re-aim it rather than delete it. The tab is **hidden** when the session has no linked run (the strip changes shape), asks **once** and never re-polls — §9 names GitHub rate limits as this milestone's external budget. Degraded answers render identity + reason: a panel that still names its PR beats an empty one.

## Three findings from the adversarial pass, fixed here

**Verdict precedence existed in the plan but not in the code.** `HookRun`'s recorded review was read nowhere, so a degraded panel showed no review state at all — even though the agent's verdict sat in the very row the route had already fetched. The run's `reviewEvent` now surfaces as `agentReview` **only on degraded answers**: GitHub's list is authoritative when it answered, since it already contains that review, and a second copy would invite the panel to double-draw it. The precedence lives in the service, pinned from both directions (answered-with-known → null; degraded-with-known → carried; degraded-without → null), and end-to-end in the integration suite.

**A GitHub 5xx rendered as `denied`** — pointing operators at a nonexistent installation problem for the length of an outage. Reads as `unreachable` now, mutation-pinned.

**"Session DTO exposes its GitHub subject" is descoped, recorded in §9.** The console finds the tab by probing the route once per session view: the 404 arm costs 2–3 indexed queries and never reaches GitHub, and a linked session's probe is the same read the panel needs anyway, deduplicated by the TTL cache. A DTO field would burden the session **list** route with a per-row run lookup to save a probe that is already cheap. The sentence predates the probe design.

## Verification

306 protocol, 1475 web, 1496 CP unit, 1109 CP integration, all typechecks, eslint and prettier clean. The adversarial pass independently re-killed 11 mutations across the inherited code (org-less cache key, dropped RATE_LIMITED mapping, fabricated degraded state, no eviction, never-cache, auth bypass, org fence, tab-not-hidden, failed-conflated-with-404, refresh-without-force, injected merge control), and the three fixes above are each mutation-pinned.

Known residual, recorded: the panel's focus-independence (it is session-keyed, so a header-focus change must not re-key it) is structurally enforced but unpinned — the same multi-agent fixture gap M1/M2 recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
