### PR TITLE
fix(deploy): give the k8s daemon a durable state volume

### DIFF
--- a/deploy/k8s/30-deployment.yaml
+++ b/deploy/k8s/30-deployment.yaml
@@ -99,6 +99,26 @@ spec:
           secret:
             secretName: agentconnect-daemon-config
         - name: state
-          # emptyDir for a first test environment: agent state is re-fetched from the Control
-          # Plane on register. Swap for a PVC once a restart losing local state matters.
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: ac-daemon-state
+---
+# The daemon's durable root: `state/local.sqlite` (sessions + transcripts), the agents dir, and the
+# installed config. An emptyDir here loses the sessions table on every pod replacement, and that
+# table is the ONLY map from a logical conversation to its ACP session id — so a restart cannot
+# resume, it can only create a second session for the same thread.
+#
+# ReadWriteOncePod is load-bearing, exactly as it is in the operator's envelope: the Recreate
+# strategy above assumes the volume can never double-attach.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ac-daemon-state
+  namespace: agentconnect
+spec:
+  accessModes: ['ReadWriteOncePod']
+  resources:
+    requests:
+      storage: 10Gi
+  # A cluster-wide CSI rather than the default `local-path`, for the same reason the sandbox pool
+  # states it: local-path pins the volume to one node for its life.
+  storageClassName: standard

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -116,7 +116,8 @@ an apply would revoke whatever is already there — including the controller's o
 relocated to the controller's with `-n`. Upstream installs the controller into
 `agent-sandbox-system`; this cluster runs it in `agentconnect`.
 
-**The storage class.** `40-sandbox-pool.yaml` pins `standard` (a cluster-wide
+**The storage class.** `40-sandbox-pool.yaml` and the daemon's own
+`ac-daemon-state` claim in `30-deployment.yaml` both pin `standard` (a cluster-wide
 CSI). The cluster default here is `local-path`, which failed with
 `no local path available on node sea-admin` — a local provisioner has no path on
 every node, so the workspace fails to bind wherever the scheduler happens to put


### PR DESCRIPTION
## What broke

The k8s daemon's `/var/lib/agentconnect` was an `emptyDir`. That directory holds
`state/local.sqlite` — the `sessions` table, which is the **only** map from a logical
conversation (platform/channel/thread) to its ACP session id, plus the whole transcript.

So every pod replacement silently made every existing conversation unresumable.
`SessionManager.handle` looks the conversation up, finds nothing, and takes the
create branch — `session/load` is never even attempted, because the resume branch
needs the row it just lost.

Observed on the test cluster: one webchat conversation with two `session_meta` rows —

| session id | title | window | status |
| --- | --- | --- | --- |
| `7fe35a82…` | Say hello | 10:30 → 10:45 | closed (idle TTL), now unopenable |
| `30b30f4c…` | Inquire about email account | 21:41 | created fresh for the same conversation |

The daemon's sqlite at that point held 3 transcript rows with `seq` starting at 1 and an
empty `session_purges` — a brand-new database, not a retention GC. `session_gates` had
~70 rows, because those get re-pushed by the Control Plane on READY: everything the CP
could rebuild came back, and only the daemon-owned session state did not.

The sandbox half was never the problem — `HOME=/agent` is the workspace PVC and the
runtime's own history sits on it (`~/.claude/projects/-agent/<sessionId>.jsonl`), so
`session/load` works fine across a pod recycle as long as the daemon remembers the id.

## The fix

Mount the daemon root from a `ReadWriteOncePod` PVC instead.

This is not a new shape: the operator's envelope already renders exactly this
(`ensureDaemonPvc` — RWOP, 10Gi, `packages/operator/src/reconcile/envelope.ts`). The
hand-applied manifest was the outlier, which is what let the divergence go unnoticed.

RWOP is load-bearing rather than decorative. This file already sets `strategy: Recreate`
for one reason — never two daemons briefly sharing one org's sandboxes and shim channels
— and an access mode the kubelet enforces is what makes that assumption true rather than
merely intended.

`storageClassName: standard` for the same reason `40-sandbox-pool.yaml` states: the
cluster default `local-path` has no path on every node and pins the volume to one node
for its life.

## Verified

Applied to the test namespace: PVC binds `RWOP`, the daemon comes back on it
(`/dev/nvme12n1 → /var/lib/agentconnect`), re-adopts its daemon id from `auth/ok`, and
reconciles its agent. Sessions created from here survive a pod replacement.

## Not fixed here

Sessions already orphaned by an emptyDir restart stay orphaned — their transcripts went
with the volume, so the CP rows are all that is left of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
