### PR TITLE
feat(console): PR actions — one Auto-fix turn and Merge-when-ready auto-merge (M6)

### DIFF
--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -860,6 +860,7 @@ Known M4 follow-ups, none of which change what the code does today:
 status and counts; panel with checks, reviews and threads **read-only** (no
 Auto-fix, no Merge-when-ready). Tab hidden when the session has no linked run.
 _Exit:_ PR state is visible beside the conversation that is reviewing it.
+**Landed.**
 
 Three things measured against the shipped CP before writing any of it, each of
 which changes what M5 has to build:
@@ -923,6 +924,27 @@ finishing the inherited wip:
 (§5.2), and `Merge when ready` (`enablePullRequestAutoMerge`) gated on the
 clamped token actually carrying write. _Exit:_ the design's headline loop — read
 the review, hand it to the agent, arm the merge — works end to end.
+
+Decisions recorded while building it:
+
+- **No Merge button.** The route table backs exactly one write —
+  `POST /sessions/:id/pull-request/auto-merge` — so the merge box draws the
+  checkbox as the action and nothing else; a direct-merge button would be
+  unbacked and M3's rule (absent rather than inert) applies. The checkbox is
+  disabled below write tier via the read projection's per-caller
+  `canArmAutoMerge` flag (Postgres-only, computed in the route like the overlay
+  facts — never cached), and GitHub declining the state change (a PR whose
+  checks already pass) relays as a 409 the box shows as data. The CP route is
+  idempotent — a fresh node read decides whether the mutation runs — and the
+  mint carries `contents: write` beside `pull_requests: write` because GitHub
+  performs the eventual merge under the same grant; the additional-repo comment
+  tier is deliberately excluded (arming merges code).
+- **Auto-fix's only follow-up is one forced re-read on the turn's falling
+  edge.** The panel never watches the turn; it takes a `turnActive` prop, and a
+  pressed Auto-fix arms a per-scope wait that the next falling edge consumes —
+  one `refresh=true` read, because the write-back it waits for (resolved
+  threads) happened on GitHub inside the turn and the CP TTL would hide it. No
+  `onAutoFix` prop (a hook session with no live composer) means no button.
 
 **Sequencing rationale.** M0 unblocks everything and is pure front-end. M1 is
 nearly free and proves the dock at width. M2 makes the dock genuinely useful

--- a/packages/control-plane/src/github/api.ts
+++ b/packages/control-plane/src/github/api.ts
@@ -112,11 +112,13 @@ export async function githubRequest<T>(path: string, opts: GithubRequestOpts): P
 }
 
 // One GraphQL query/mutation → its `data` — for facts with no REST equivalent (thread resolution
-// state, `resolveReviewThread`, `enablePullRequestAutoMerge`).
+// state, `resolveReviewThread`, `enablePullRequestAutoMerge`). `strictErrors` is for MUTATIONS:
+// GitHub rejects one as `{ data: { <mutation>: null }, errors: [...] }` — truthy data beside the
+// refusal — and reporting that as success would claim a write that never happened.
 export async function githubGraphql<T>(
   query: string,
   variables: Record<string, unknown>,
-  opts: Omit<GithubRequestOpts, 'method' | 'body'>
+  opts: Omit<GithubRequestOpts, 'method' | 'body'> & { strictErrors?: boolean }
 ): Promise<T> {
   // GraphQL failures ride inside a 200, so `errors` decides here — the REST status mapping cannot.
   const res = await githubRequest<{ data?: T | null; errors?: Array<{ type?: string; message?: string }> }>(
@@ -124,7 +126,7 @@ export async function githubGraphql<T>(
     { ...opts, method: 'POST', body: { query, variables } }
   )
   // Partial data beats a thrown read: a field-level denial degrades that field, not the whole answer.
-  if (res?.data) return res.data
+  if (res?.data && !(opts.strictErrors && res.errors?.length)) return res.data
   const errors = res?.errors ?? []
   if (errors.length > 0) {
     const detail = errors.map((e) => e.message ?? e.type ?? 'unknown').join('; ')

--- a/packages/control-plane/src/github/github.test.ts
+++ b/packages/control-plane/src/github/github.test.ts
@@ -1223,6 +1223,40 @@ describe('GithubService.mintReviewForAgent — persisted installation permission
       permissions: { metadata: 'read', pull_requests: 'write' }
     })
   })
+
+  // M6 auto-merge: arming merges code, so only write tier + accepted pull_requests:write qualify.
+  it('mints the auto-merge token with pull_requests + contents write for a write-tier agent', async () => {
+    const { svc, agent, mintBodies } = reviewHarness({ pull_requests: 'write', contents: 'write' })
+    await expect(svc.mintAutoMergeForAgent(agent, 123n, 'acme/infra')).resolves.toMatchObject({ token: 'ghs_2' })
+    expect(mintBodies[1]).toMatchObject({
+      repository_ids: [123],
+      permissions: { pull_requests: 'write', contents: 'write' }
+    })
+    await expect(svc.canArmAutoMerge(agent, 123n, 'acme/infra')).resolves.toBe(true)
+  })
+
+  it('refuses auto-merge below write tier and on a missing installation grant, and canArmAutoMerge mirrors it', async () => {
+    const readTier = reviewHarness({ pull_requests: 'write', contents: 'write' })
+    const readAgent = {
+      ...(readTier.agent as Record<string, unknown>),
+      workspace: {
+        mode: 'github',
+        gitRepo: 'https://github.com/acme/infra',
+        installationId: 'row-1',
+        gitAccess: 'read'
+      }
+    } as never
+    await expect(readTier.svc.mintAutoMergeForAgent(readAgent, 123n, 'acme/infra')).rejects.toMatchObject({
+      code: 'SCOPE_DENIED'
+    })
+    await expect(readTier.svc.canArmAutoMerge(readAgent, 123n, 'acme/infra')).resolves.toBe(false)
+
+    const noGrant = reviewHarness({ pull_requests: 'read' })
+    await expect(noGrant.svc.mintAutoMergeForAgent(noGrant.agent, 123n, 'acme/infra')).rejects.toMatchObject({
+      code: 'LEASE_DENIED'
+    })
+    await expect(noGrant.svc.canArmAutoMerge(noGrant.agent, 123n, 'acme/infra')).resolves.toBe(false)
+  })
 })
 
 describe('GithubService.refreshInstallationFacts', () => {

--- a/packages/control-plane/src/github/pull-request-view.service.test.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.test.ts
@@ -569,3 +569,39 @@ describe('setAutoMerge (M6)', () => {
     expect((await degraded.service.view(IDENTITY)).autoMergeArmed).toBeNull()
   })
 })
+
+describe('write-side correctness (M6 review findings)', () => {
+  const TARGET = { repoId: IDENTITY.repoId, repoFullName: IDENTITY.repoFullName, pullNumber: IDENTITY.pullNumber }
+
+  it('treats a refused mutation as FAILURE even when GitHub wraps it in truthy partial data', async () => {
+    // GitHub rejects a mutation as `{ data: { enablePullRequestAutoMerge: null }, errors: [...] }` —
+    // reporting `{ armed: true }` off the truthy half would claim a write that never happened.
+    const { service } = build([
+      ok({ data: { repository: { pullRequest: { id: 'PR_node1', autoMergeRequest: null } } } }),
+      ok({
+        data: { enablePullRequestAutoMerge: null },
+        errors: [{ type: 'UNPROCESSABLE', message: 'Pull request is in clean status' }]
+      })
+    ])
+
+    await expect(service.setAutoMerge(TARGET, 'ghs_write', true)).rejects.toMatchObject({
+      message: expect.stringContaining('clean status')
+    })
+  })
+
+  it('fences a read that started BEFORE invalidate() out of the cache — and out of later joins', async () => {
+    let release: ((value: Response) => void) | undefined
+    const { service, calls } = build([() => new Promise<Response>((resolve) => (release = resolve)), ok(fullAnswer())])
+
+    const before = service.view(IDENTITY)
+    while (!release) await new Promise((tick) => setTimeout(tick, 0))
+    // The write lands mid-read: everything this PR cached, joined or later stored is now pre-write state.
+    service.invalidate(IDENTITY.repoId, IDENTITY.pullNumber)
+    release(ok(fullAnswer())())
+    await before // its own awaiter still gets the answer it asked for…
+
+    // …but the next view must ask GitHub again: no cache hit off the fenced store, no join on the old read.
+    await service.view(IDENTITY)
+    expect(calls).toHaveLength(2)
+  })
+})

--- a/packages/control-plane/src/github/pull-request-view.service.test.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.test.ts
@@ -48,6 +48,7 @@ function fullAnswer(): Record<string, unknown> {
           baseRefName: 'main',
           headRefName: 'feat/panel',
           reviewDecision: 'CHANGES_REQUESTED',
+          autoMergeRequest: null,
           latestReviews: {
             nodes: [
               { state: 'APPROVED', author: { login: 'dana', __typename: 'User' } },
@@ -191,6 +192,7 @@ describe('projection mapping', () => {
       ],
       unresolvedCount: 2,
       threadsTruncated: false,
+      autoMergeArmed: false,
       degraded: false,
       degradedReason: null,
       agentReview: null
@@ -499,5 +501,71 @@ describe('cache keying and eviction', () => {
     // The first-viewed PR was evicted (cap), so re-reading it costs a call; the cache never exceeds the cap.
     await service.view({ ...IDENTITY, pullNumber: 100 })
     expect(calls).toHaveLength(PR_VIEW_CACHE_MAX + 2)
+  })
+})
+
+describe('setAutoMerge (M6)', () => {
+  const TARGET = { repoId: IDENTITY.repoId, repoFullName: IDENTITY.repoFullName, pullNumber: IDENTITY.pullNumber }
+  const nodeAnswer = (armed: boolean) =>
+    ok({
+      data: { repository: { pullRequest: { id: 'PR_node1', autoMergeRequest: armed ? { enabledAt: 'now' } : null } } }
+    })
+
+  it('arms with the CALLER-minted token, mutates by node id, and drops the cached view', async () => {
+    const { service, calls, mint } = build([
+      ok(fullAnswer()), // seed the cache via view()
+      nodeAnswer(false),
+      ok({ data: { enablePullRequestAutoMerge: { clientMutationId: null } } }),
+      ok(fullAnswer()) // the re-read after invalidation
+    ])
+    await service.view(IDENTITY)
+
+    const result = await service.setAutoMerge(TARGET, 'ghs_write', true)
+
+    expect(result).toEqual({ armed: true })
+    // The write rides the passed token, never this service's read-floor mint facility.
+    expect(mint).toHaveBeenCalledTimes(1)
+    const mutation = calls[2]!.body as { query: string; variables: Record<string, unknown> }
+    expect(mutation.query).toContain('enablePullRequestAutoMerge')
+    expect(mutation.query).toContain('mergeMethod:SQUASH')
+    expect(mutation.variables).toEqual({ id: 'PR_node1' })
+    // The cached view is gone: the next read asks GitHub again rather than serving the pre-write state.
+    await service.view(IDENTITY)
+    expect(calls).toHaveLength(4)
+  })
+
+  it('disarms via disablePullRequestAutoMerge', async () => {
+    const { service, calls } = build([
+      nodeAnswer(true),
+      ok({ data: { disablePullRequestAutoMerge: { clientMutationId: null } } })
+    ])
+
+    expect(await service.setAutoMerge(TARGET, 'ghs_write', false)).toEqual({ armed: false })
+    expect((calls[1]!.body as { query: string }).query).toContain('disablePullRequestAutoMerge')
+  })
+
+  it('is idempotent: asking for the state the PR is already in mutates nothing', async () => {
+    const { service, calls } = build([nodeAnswer(true)])
+
+    expect(await service.setAutoMerge(TARGET, 'ghs_write', true)).toEqual({ armed: true })
+    expect(calls).toHaveLength(1) // the node read only — no mutation call scripted, none made
+  })
+
+  it('throws denied when the installation cannot see the PR', async () => {
+    const { service } = build([ok({ data: { repository: { pullRequest: null } } })])
+
+    await expect(service.setAutoMerge(TARGET, 'ghs_write', true)).rejects.toMatchObject({ code: 'LEASE_DENIED' })
+  })
+
+  it('projects autoMergeRequest onto autoMergeArmed, and degraded answers carry null', async () => {
+    const armed = fullAnswer()
+    ;(armed as { data: { repository: { pullRequest: Record<string, unknown> } } }).data.repository.pullRequest[
+      'autoMergeRequest'
+    ] = { enabledAt: '2026-08-11T00:00:00Z' }
+    const { service } = build([ok(armed)])
+    expect((await service.view(IDENTITY)).autoMergeArmed).toBe(true)
+
+    const degraded = build([ok({ data: null, errors: [{ type: 'RATE_LIMITED', message: 'limit' }] })])
+    expect((await degraded.service.view(IDENTITY)).autoMergeArmed).toBeNull()
   })
 })

--- a/packages/control-plane/src/github/pull-request-view.service.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.ts
@@ -202,6 +202,15 @@ interface CacheEntry {
 export class PullRequestViewService {
   private readonly cache = new Map<string, CacheEntry>()
   private readonly inFlight = new Map<string, Promise<PullRequestView>>()
+  // The invalidation fence: bumped per key, snapshotted when a read starts, checked before it stores.
+  // Without it a read that started BEFORE a write finishes after and repopulates the pre-write state,
+  // absorbing the console's immediate verification read for a full TTL. Entries are permanent by
+  // design — deleting one would reset it to 0 and re-admit exactly the stale read it fenced out.
+  private readonly epochs = new Map<string, number>()
+
+  private epochOf(key: string): number {
+    return this.epochs.get(key) ?? 0
+  }
 
   constructor(
     private readonly tokens: InstallationTokenService,
@@ -233,13 +242,18 @@ export class PullRequestViewService {
     const running = this.inFlight.get(key)
     if (running) return running.then((view) => overlay(view, identity))
 
+    const startEpoch = this.epochOf(key)
     const read = this.read(identity)
       .then((view) => {
         // Degraded answers cache too: a rate-limited installation must not be hammered per panel mount.
-        this.store(key, view)
+        // Stored only when no invalidation crossed this read — a fenced-out answer is served to its own
+        // awaiters (it was true when asked) but never becomes the cache's post-write truth.
+        if (this.epochOf(key) === startEpoch) this.store(key, view)
         return view
       })
-      .finally(() => this.inFlight.delete(key))
+      .finally(() => {
+        if (this.inFlight.get(key) === read) this.inFlight.delete(key)
+      })
     this.inFlight.set(key, read)
     return read.then((view) => overlay(view, identity))
   }
@@ -257,18 +271,28 @@ export class PullRequestViewService {
     }
   }
 
-  // Drop one PR's cached projections (every org) — for a caller that just changed the PR itself (M6).
+  // Drop one PR's projections (every org) — for a caller that just changed the PR itself (M6).
+  // Settled cache, in-flight joins AND late stores all go: the epoch bump is what keeps a read that
+  // started before the write from finishing after it and reinstating the pre-write state.
   invalidate(repoId: bigint, pullNumber: number): void {
     const suffix = `#${repoId}#${pullNumber}`
-    for (const key of [...this.cache.keys()]) if (key.endsWith(suffix)) this.cache.delete(key)
+    this.drop((key) => key.endsWith(suffix))
   }
 
   // Mirror of InstallationTokenService.invalidateInstallation: a suspended/revoked installation must
-  // not keep serving its cached views. An already-in-flight read may still repopulate for ≤ one TTL.
+  // not keep serving its cached views — and the same epoch fence keeps its in-flight reads from repopulating.
   invalidateInstallation(installationId: bigint): void {
     const marker = `#${installationId}#`
-    for (const key of [...this.cache.keys()]) if (key.includes(marker)) this.cache.delete(key)
-    for (const key of [...this.inFlight.keys()]) if (key.includes(marker)) this.inFlight.delete(key)
+    this.drop((key) => key.includes(marker))
+  }
+
+  private drop(matches: (key: string) => boolean): void {
+    for (const key of new Set([...this.cache.keys(), ...this.inFlight.keys(), ...this.epochs.keys()])) {
+      if (!matches(key)) continue
+      this.epochs.set(key, this.epochOf(key) + 1)
+      this.cache.delete(key)
+      this.inFlight.delete(key)
+    }
   }
 
   private async read(identity: PullRequestIdentity): Promise<PullRequestView> {
@@ -416,17 +440,18 @@ export class PullRequestViewService {
     if (!pr) throw new GithubApiError('pull request not visible to the installation', 200, 'LEASE_DENIED', false)
     try {
       if (enabled === (pr.autoMergeRequest != null)) return { armed: enabled }
+      // strictErrors: a refused mutation is `{ data: { …: null }, errors: [...] }` — success must not be claimed off the truthy half.
       if (enabled) {
         await githubGraphql(
           'mutation($id:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:SQUASH}){clientMutationId}}',
           { id: pr.id },
-          opts
+          { ...opts, strictErrors: true }
         )
       } else {
         await githubGraphql(
           'mutation($id:ID!){disablePullRequestAutoMerge(input:{pullRequestId:$id}){clientMutationId}}',
           { id: pr.id },
-          opts
+          { ...opts, strictErrors: true }
         )
       }
       return { armed: enabled }

--- a/packages/control-plane/src/github/pull-request-view.service.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.ts
@@ -69,6 +69,7 @@ export interface PullRequestView {
   threads: PrThread[]
   unresolvedCount: number // unresolved threads on the carried page — a floor when `threadsTruncated`
   threadsTruncated: boolean
+  autoMergeArmed: boolean | null // null while degraded — only GitHub holds the auto-merge fact
   // Degraded ⇒ identity is Postgres's, the live lists are empty, and the panel says why.
   degraded: boolean
   degradedReason: 'rate_limited' | 'denied' | 'unreachable' | null
@@ -84,6 +85,7 @@ query PanelPullRequest($owner:String!,$name:String!,$number:Int!,$threads:Int!,$
     pullRequest(number:$number){
       number title state isDraft merged additions deletions url
       baseRefName headRefName reviewDecision
+      autoMergeRequest{enabledAt}
       latestReviews(first:$reviews){nodes{state author{login __typename}}}
       commits(last:1){nodes{commit{statusCheckRollup{contexts(first:$checks){pageInfo{hasNextPage} nodes{
         __typename
@@ -112,6 +114,7 @@ interface GqlAnswer {
       baseRefName: string
       headRefName: string
       reviewDecision: 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | null
+      autoMergeRequest: { enabledAt: string | null } | null
       latestReviews: { nodes: Array<{ state: string; author: { login: string; __typename: string } | null }> | null }
       commits: {
         nodes: Array<{
@@ -291,6 +294,7 @@ export class PullRequestViewService {
       threads: [],
       unresolvedCount: 0,
       threadsTruncated: false,
+      autoMergeArmed: null,
       degraded: false,
       degradedReason: null,
       agentReview: null
@@ -383,7 +387,55 @@ export class PullRequestViewService {
       reviews,
       threads,
       unresolvedCount: unresolved.length,
-      threadsTruncated: (pr.reviewThreads?.totalCount ?? 0) > THREAD_LIMIT
+      threadsTruncated: (pr.reviewThreads?.totalCount ?? 0) > THREAD_LIMIT,
+      autoMergeArmed: pr.autoMergeRequest != null
     }
   }
+
+  /** Arm or disarm GitHub auto-merge, with a token the CALLER minted under the agent's clamp — this
+   *  service's own token facility is the read floor and must never sign a write. Idempotent: the fresh
+   *  node read decides whether the mutation runs at all, and the cached view is dropped either way. */
+  async setAutoMerge(
+    target: { repoId: bigint; repoFullName: string; pullNumber: number },
+    token: string,
+    enabled: boolean
+  ): Promise<{ armed: boolean }> {
+    const [owner, name] = target.repoFullName.split('/')
+    if (!owner || !name) throw new GithubApiError('malformed repository name', 0, 'LEASE_DENIED', false)
+    const opts = {
+      auth: token,
+      ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+      ...(this.baseUrl ? { baseUrl: this.baseUrl } : {})
+    }
+    const node = await githubGraphql<AutoMergeNodeAnswer>(
+      'query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){id autoMergeRequest{enabledAt}}}}',
+      { owner, name, number: target.pullNumber },
+      opts
+    )
+    const pr = node.repository?.pullRequest
+    if (!pr) throw new GithubApiError('pull request not visible to the installation', 200, 'LEASE_DENIED', false)
+    try {
+      if (enabled === (pr.autoMergeRequest != null)) return { armed: enabled }
+      if (enabled) {
+        await githubGraphql(
+          'mutation($id:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:SQUASH}){clientMutationId}}',
+          { id: pr.id },
+          opts
+        )
+      } else {
+        await githubGraphql(
+          'mutation($id:ID!){disablePullRequestAutoMerge(input:{pullRequestId:$id}){clientMutationId}}',
+          { id: pr.id },
+          opts
+        )
+      }
+      return { armed: enabled }
+    } finally {
+      this.invalidate(target.repoId, target.pullNumber)
+    }
+  }
+}
+
+interface AutoMergeNodeAnswer {
+  repository: { pullRequest: { id: string; autoMergeRequest: { enabledAt: string | null } | null } | null } | null
 }

--- a/packages/control-plane/src/github/service.ts
+++ b/packages/control-plane/src/github/service.ts
@@ -823,6 +823,46 @@ export class GithubService {
     }
   }
 
+  /** Whether the console may arm auto-merge for this agent's PR — the GET projection's per-caller
+   *  capability flag, Postgres-only (no GitHub call): a read/comment tier renders a disabled control. */
+  async canArmAutoMerge(agent: AgentRecord, repoId: bigint, repoFullName: string): Promise<boolean> {
+    try {
+      const resolved = await this.resolveAgentRepoAuthorization(agent, repoId, repoFullName)
+      return resolved.access === 'write' && resolved.installation.permissions?.pull_requests === 'write'
+    } catch {
+      return false
+    }
+  }
+
+  /** Auto-merge arm/disarm capability: arming merges code, so nothing below write tier qualifies —
+   *  the additional-repo comment tier that may COMMENT-review is deliberately excluded here. */
+  async mintAutoMergeForAgent(
+    agent: AgentRecord,
+    repoId: bigint,
+    repoFullName: string
+  ): Promise<MintedGitCred & { installationId: bigint }> {
+    const resolved = await this.resolveAgentRepoAuthorization(agent, repoId, repoFullName)
+    if (resolved.access !== 'write') {
+      throw new GitCredDeniedError('repository authorization does not allow auto-merge', 'SCOPE_DENIED', false)
+    }
+    if (resolved.installation.permissions?.pull_requests !== 'write') {
+      throw new GitCredDeniedError('GitHub installation has not accepted pull_requests:write', 'LEASE_DENIED', false)
+    }
+    try {
+      // contents rides along because GitHub performs the eventual merge under this app's grant.
+      const cred = await this.tokens.mintLevels(
+        resolved.installation.installationId,
+        resolved.repoFullName,
+        { pull_requests: 'write', contents: 'write' },
+        resolved.repoId
+      )
+      return { ...cred, installationId: resolved.installation.installationId }
+    } catch (e) {
+      if (e instanceof GithubApiError) throw new GitCredDeniedError(e.message, e.code, e.retryable)
+      throw e
+    }
+  }
+
   /** CP-only reporter capability. Reporting always requires write-level agent
    * authorization plus exact checks:write and pull_requests:read-or-write
    * installation facts. The latter gates the live commit -> PR barrier. */

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3148,12 +3148,20 @@ export const SessionPullRequestDto = z.object({
   threads: z.array(SessionPullRequestThreadDto),
   unresolvedCount: z.number().int(), // a floor when `threadsTruncated`
   threadsTruncated: z.boolean(),
+  autoMergeArmed: z.boolean().nullable(), // null while degraded — only GitHub holds the auto-merge fact
+  // Whether THIS caller may arm auto-merge: the owning agent is write-tier and the installation accepted
+  // pull_requests:write. Postgres-only, so a read-tier agent renders a disabled control, not a failed call.
+  canArmAutoMerge: z.boolean(),
   degraded: z.boolean(),
   degradedReason: z.enum(['rate_limited', 'denied', 'unreachable']).nullable(),
   // The agent's own recorded review, present ONLY on a degraded answer — GitHub's list is authoritative when it answered.
   agentReview: z.enum(['approved', 'changes_requested', 'commented']).nullable()
 })
 export type SessionPullRequestDtoT = z.infer<typeof SessionPullRequestDto>
+
+export const SessionPullRequestAutoMergeBodyDto = z.object({ enabled: z.boolean() })
+/** `POST /sessions/:id/pull-request/auto-merge` — the armed state after the call (idempotent). */
+export const SessionPullRequestAutoMergeDto = z.object({ armed: z.boolean() })
 
 /** `GET /agents/:id/tasks` — live tasks first, then the daemon's bounded settled history.
  *  `tracked:false` means the owning daemon holds no lease for this session (a non-Claude

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -24,6 +24,8 @@ import { Tag } from '../plugins/openapi.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { visibilityStateOf } from '../../orchestrator/visibilityPush.js'
 import type { PullRequestView } from '../../github/pull-request-view.service.js'
+import { GithubApiError } from '../../github/api.js'
+import { GitCredDeniedError } from '../../github/service.js'
 import {
   SessionListPageDto,
   SessionFacetsDto,
@@ -35,6 +37,8 @@ import {
   IdParam,
   SessionPullRequestDto,
   SessionPullRequestQueryDto,
+  SessionPullRequestAutoMergeBodyDto,
+  SessionPullRequestAutoMergeDto,
   type SessionPullRequestDtoT,
   SetSessionVisibilityBody,
   SessionVisibilityDto,
@@ -353,9 +357,11 @@ function agentReviewOf(event: string | null): 'approved' | 'changes_requested' |
   return null
 }
 
-// Service view -> HTTP body, 1:1; every judgement about degradation already happened in the service.
-function toSessionPullRequestDto(view: PullRequestView): SessionPullRequestDtoT {
+// Service view -> HTTP body, 1:1 plus the caller's write capability; degradation judgements are the service's.
+function toSessionPullRequestDto(view: PullRequestView, canArmAutoMerge: boolean): SessionPullRequestDtoT {
   return {
+    canArmAutoMerge,
+    autoMergeArmed: view.autoMergeArmed,
     repoFullName: view.repoFullName,
     pullNumber: view.pullNumber,
     title: view.title,
@@ -1051,6 +1057,10 @@ export function sessionRoutes(deps: HttpDeps) {
         const subject = run.projectionId
           ? (await deps.repos.hook.listReviewSubjects(run.projectionId)).find((s) => s.pullNumber === run.pullNumber)
           : undefined
+        // The caller's write capability, Postgres-only: per-run like the overlay facts, so never cached.
+        const agent = run.agentId ? await deps.repos.agent.get(orgOf(req), AgentId(run.agentId)) : null
+        const canArm =
+          agent && deps.github ? await deps.github.canArmAutoMerge(agent, run.repoId, run.repoFullName) : false
         return toSessionPullRequestDto(
           await view.view(
             {
@@ -1064,9 +1074,81 @@ export function sessionRoutes(deps: HttpDeps) {
               ...(agentReviewOf(run.reviewEvent) ? { knownAgentReview: agentReviewOf(run.reviewEvent)! } : {})
             },
             req.query.refresh === true
-          )
+          ),
+          canArm
         )
       }
     )
+
+    // ── POST /sessions/:id/pull-request/auto-merge ───────────────────────────
+    // The M6 write: arm/disarm GitHub auto-merge under the owning agent's clamped grant. The token is
+    // minted per call and never stored; the view cache is dropped so the next read shows the new state.
+    r.post(
+      '/sessions/:id/pull-request/auto-merge',
+      {
+        schema: {
+          tags: [Tag.Sessions],
+          summary: 'Arm or disarm auto-merge on the session’s pull request',
+          description:
+            'Enables or disables GitHub auto-merge (squash) for the pull request this session was dispatched for, using an installation token clamped to the owning agent’s repository tier — the write requires that clamp to actually carry `pull_requests: write`, so a read- or comment-tier agent is refused (403) rather than escalated. Idempotent: asking for the state the PR is already in succeeds without a mutation. 404 mirrors the GET; 409 relays GitHub declining the state change (for example a pull request whose checks already pass, which GitHub arms nothing for); 429 is GitHub rate limiting; 502 is GitHub unreachable.',
+          operationId: 'setSessionPullRequestAutoMerge',
+          params: IdParam,
+          body: SessionPullRequestAutoMergeBodyDto,
+          response: {
+            200: SessionPullRequestAutoMergeDto,
+            403: ErrorDto,
+            404: ErrorDto,
+            409: ErrorDto,
+            429: ErrorDto,
+            502: ErrorDto
+          }
+        }
+      },
+      async (req, reply) => {
+        const absent = () =>
+          reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'pull request not found' })
+        const owned = await getOrgViewableSession(req, req.params.id)
+        if (!owned) return absent()
+        const view = deps.pullRequestView
+        const github = deps.github
+        if (!view || !github) return absent()
+        const run = await deps.repos.hook.latestPullRequestRunForSession(orgOf(req), owned.session.id)
+        if (!run?.pullNumber || !run.repoId || !run.repoFullName || !run.sourceInstallationId) return absent()
+        // The capability is the RUN's agent — the write rides that agent's authorization, not the viewer's.
+        const agent = run.agentId ? await deps.repos.agent.get(orgOf(req), AgentId(run.agentId)) : null
+        if (!agent) {
+          return reply
+            .code(403)
+            .send({ error: 'Forbidden', statusCode: 403, message: 'the owning agent no longer exists' })
+        }
+        try {
+          const cred = await github.mintAutoMergeForAgent(agent, run.repoId, run.repoFullName)
+          return await view.setAutoMerge(
+            { repoId: run.repoId, repoFullName: run.repoFullName, pullNumber: run.pullNumber },
+            cred.token,
+            req.body.enabled
+          )
+        } catch (err) {
+          return autoMergeErrorReply(reply, err)
+        }
+      }
+    )
   }
+}
+
+// GitHub/clamp failures onto HTTP: capability and installation denials are 403, rate limits 429, GitHub
+// down 502 — and GitHub declining the state change itself (clean status, closed PR) is a 409, not a 5xx.
+function autoMergeErrorReply(reply: { code: (c: number) => { send: (b: unknown) => unknown } }, err: unknown) {
+  const body = (statusCode: number, error: string, message: string) => ({ error, statusCode, message })
+  if (err instanceof GitCredDeniedError) {
+    if (err.code === 'RATE_LIMITED') return reply.code(429).send(body(429, 'Too Many Requests', err.message))
+    return reply.code(403).send(body(403, 'Forbidden', err.message))
+  }
+  if (err instanceof GithubApiError) {
+    if (err.code === 'RATE_LIMITED') return reply.code(429).send(body(429, 'Too Many Requests', err.message))
+    if (err.code === 'LEASE_DENIED') return reply.code(403).send(body(403, 'Forbidden', err.message))
+    if (err.status === 0 || err.status >= 500) return reply.code(502).send(body(502, 'Bad Gateway', err.message))
+    return reply.code(409).send(body(409, 'Conflict', err.message))
+  }
+  throw err
 }

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -1129,26 +1129,34 @@ export function sessionRoutes(deps: HttpDeps) {
             req.body.enabled
           )
         } catch (err) {
-          return autoMergeErrorReply(reply, err)
+          const failure = autoMergeFailureOf(err)
+          if (!failure) throw err
+          return reply.code(failure.statusCode).send(failure)
         }
       }
     )
   }
 }
 
-// GitHub/clamp failures onto HTTP: capability and installation denials are 403, rate limits 429, GitHub
-// down 502 — and GitHub declining the state change itself (clean status, closed PR) is a 409, not a 5xx.
-function autoMergeErrorReply(reply: { code: (c: number) => { send: (b: unknown) => unknown } }, err: unknown) {
-  const body = (statusCode: number, error: string, message: string) => ({ error, statusCode, message })
+// GitHub/clamp failures onto HTTP, as DATA: capability and installation denials are 403, rate limits
+// 429, GitHub down 502 — and GitHub declining the state change itself (clean status, closed PR) is a
+// 409, not a 5xx. Null means "not ours" and the caller rethrows.
+function autoMergeFailureOf(
+  err: unknown
+): { error: string; statusCode: 403 | 409 | 429 | 502; message: string } | null {
+  const failure = (statusCode: 403 | 409 | 429 | 502, error: string) => ({
+    error,
+    statusCode,
+    message: err instanceof Error ? err.message : String(err)
+  })
   if (err instanceof GitCredDeniedError) {
-    if (err.code === 'RATE_LIMITED') return reply.code(429).send(body(429, 'Too Many Requests', err.message))
-    return reply.code(403).send(body(403, 'Forbidden', err.message))
+    return err.code === 'RATE_LIMITED' ? failure(429, 'Too Many Requests') : failure(403, 'Forbidden')
   }
   if (err instanceof GithubApiError) {
-    if (err.code === 'RATE_LIMITED') return reply.code(429).send(body(429, 'Too Many Requests', err.message))
-    if (err.code === 'LEASE_DENIED') return reply.code(403).send(body(403, 'Forbidden', err.message))
-    if (err.status === 0 || err.status >= 500) return reply.code(502).send(body(502, 'Bad Gateway', err.message))
-    return reply.code(409).send(body(409, 'Conflict', err.message))
+    if (err.code === 'RATE_LIMITED') return failure(429, 'Too Many Requests')
+    if (err.code === 'LEASE_DENIED') return failure(403, 'Forbidden')
+    if (err.status === 0 || err.status >= 500) return failure(502, 'Bad Gateway')
+    return failure(409, 'Conflict')
   }
-  throw err
+  return null
 }

--- a/packages/control-plane/test/integration/sessions.pull-request.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.pull-request.route.test.ts
@@ -8,6 +8,7 @@ import { prisma } from '../setup.db.js'
 import { seedAgent, seedDaemon, seedSessionMeta } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PullRequestViewService } from '../../src/github/pull-request-view.service.js'
+import { GitCredDeniedError, type GithubService } from '../../src/github/service.js'
 import type { InstallationTokenService } from '../../src/github/installation-token.service.js'
 import type { FetchLike } from '../../src/github/api.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
@@ -119,16 +120,31 @@ function fullAnswer() {
   }
 }
 
-function app(view?: PullRequestViewService, userId?: string): HttpApp {
-  const running = buildHttpApp(
-    prisma,
-    userId ? { DEFAULT_OWNER_ID: userId } : undefined,
-    undefined,
-    undefined,
-    view ? { pullRequestView: view } : undefined
-  )
+function app(view?: PullRequestViewService, userId?: string, github?: GithubService): HttpApp {
+  const running = buildHttpApp(prisma, userId ? { DEFAULT_OWNER_ID: userId } : undefined, undefined, undefined, {
+    ...(view ? { pullRequestView: view } : {}),
+    ...(github ? { github } : {})
+  })
   opened.push(running)
   return running
+}
+
+// The clamp seam as the route sees it: capability answers and a write-purpose mint, no real GithubService.
+function fakeGithub(deny?: 'SCOPE_DENIED' | 'LEASE_DENIED'): GithubService {
+  return {
+    canArmAutoMerge: async () => deny === undefined,
+    mintAutoMergeForAgent: async () => {
+      if (deny) throw new GitCredDeniedError(`denied by clamp: ${deny}`, deny, false)
+      return {
+        token: 'ghs_write',
+        ttlSec: 3600,
+        expiresAt: '2026-08-11T01:00:00Z',
+        repoFullName: REPO,
+        access: 'write' as const,
+        installationId: INSTALLATION
+      }
+    }
+  } as unknown as GithubService
 }
 
 async function makeUser(sub: string): Promise<string> {
@@ -216,6 +232,8 @@ describe('GET /sessions/:id/pull-request', () => {
       threads: [{ location: 'src/app.ts:12', body: 'rename this', author: 'dana', isOutdated: false }],
       unresolvedCount: 1,
       threadsTruncated: false,
+      autoMergeArmed: false,
+      canArmAutoMerge: false,
       degraded: false,
       degradedReason: null,
       agentReview: null
@@ -443,6 +461,104 @@ describe('GET /sessions/:id/pull-request', () => {
 
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${randomUUID()}/pull-request` })
 
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual(NOT_FOUND)
+    expect(github.calls).toHaveLength(0)
+  })
+})
+
+// The M6 write (§7): auto-merge armed under the owning agent's clamp, refusals as data-bearing statuses.
+describe('POST /sessions/:id/pull-request/auto-merge', () => {
+  const nodeAnswer = (armed: boolean) =>
+    graphqlOk({
+      data: { repository: { pullRequest: { id: 'PR_node1', autoMergeRequest: armed ? { enabledAt: 'now' } : null } } }
+    })
+  const post = (running: HttpApp, sessionId: string, enabled = true) =>
+    running.app.inject({
+      method: 'POST',
+      url: `${ORG}/sessions/${sessionId}/pull-request/auto-merge`,
+      payload: { enabled }
+    })
+
+  it('arms auto-merge end to end and reports canArmAutoMerge on the read', async () => {
+    const session = await seedAgentAndSession()
+    await seedPullRequestRun(session)
+    const github = githubStub([
+      nodeAnswer(false),
+      graphqlOk({ data: { enablePullRequestAutoMerge: { clientMutationId: null } } }),
+      graphqlOk(fullAnswer())
+    ])
+    const running = app(github.view, undefined, fakeGithub())
+
+    const res = await post(running, session)
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ armed: true })
+    expect((github.calls[1] as { body: { query: string } }).body.query).toContain('enablePullRequestAutoMerge')
+
+    // The write-capable caller reads canArmAutoMerge: true — the flag behind the panel's enabled control.
+    const read = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+    expect(read.json()).toMatchObject({ canArmAutoMerge: true })
+  })
+
+  it('refuses a read-tier agent with 403 before any GitHub call — the disabled-control contract', async () => {
+    const session = await seedAgentAndSession()
+    await seedPullRequestRun(session)
+    const github = githubStub([graphqlOk(fullAnswer())])
+    const running = app(github.view, undefined, fakeGithub('SCOPE_DENIED'))
+
+    const res = await post(running, session)
+    expect(res.statusCode).toBe(403)
+    expect(github.calls).toHaveLength(0)
+
+    // And the read-side flag agrees, so the console never offered the control in the first place.
+    const read = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${session}/pull-request` })
+    expect(read.json()).toMatchObject({ canArmAutoMerge: false })
+  })
+
+  it('relays GitHub declining the state change as 409, not a 5xx', async () => {
+    const session = await seedAgentAndSession()
+    await seedPullRequestRun(session)
+    const github = githubStub([
+      nodeAnswer(false),
+      graphqlOk({ data: null, errors: [{ type: 'UNPROCESSABLE', message: 'Pull request is in clean status' }] })
+    ])
+    const running = app(github.view, undefined, fakeGithub())
+
+    const res = await post(running, session)
+    expect(res.statusCode).toBe(409)
+    expect(res.json().message).toContain('clean status')
+  })
+
+  it('403s a run whose owning agent is gone — the write rides the agent authorization, which no longer exists', async () => {
+    const session = await seedAgentAndSession()
+    await seedPullRequestRun(session, { agentId: null })
+    const github = githubStub([])
+    const running = app(github.view, undefined, fakeGithub())
+
+    const res = await post(running, session)
+    expect(res.statusCode).toBe(403)
+    expect(github.calls).toHaveLength(0)
+  })
+
+  it('404s a session with no linked run, with the GET route\u2019s exact body', async () => {
+    const github = githubStub([])
+    const running = app(github.view, undefined, fakeGithub())
+    const bare = await seedAgentAndSession()
+
+    const res = await post(running, bare)
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual(NOT_FOUND)
+    expect(github.calls).toHaveLength(0)
+  })
+
+  it('hides another member\u2019s private session behind the same 404, spending nothing', async () => {
+    const github = githubStub([])
+    const running = app(github.view, undefined, fakeGithub())
+    const owner = await makeUser(`owner-${randomUUID().slice(0, 8)}`)
+    const priv = await seedAgentAndSession({ visibility: 'private', ownerIdentity: `user:${owner}` })
+    await seedPullRequestRun(priv)
+
+    const res = await post(running, priv)
     expect(res.statusCode).toBe(404)
     expect(res.json()).toEqual(NOT_FOUND)
     expect(github.calls).toHaveLength(0)

--- a/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
@@ -11,7 +11,10 @@ const wire = vi.hoisted(() => ({
   failure: null as null | { status: number },
   calls: [] as Array<{ sessionId: string; refresh: boolean }>,
   // Set to hand back a promise the test resolves by hand, so the panel is observable WHILE a read is in flight.
-  hold: null as null | (() => Promise<unknown>)
+  hold: null as null | (() => Promise<unknown>),
+  // The auto-merge write seam: every POST recorded, failing with `mergeFailure` when set.
+  mergeCalls: [] as Array<{ sessionId: string; enabled: boolean }>,
+  mergeFailure: null as null | Error
 }))
 
 vi.mock('@/lib/api', () => {
@@ -31,6 +34,11 @@ vi.mock('@/lib/api', () => {
       if (wire.failure) return Promise.reject(new ApiError('nope', wire.failure.status))
       if (wire.hold) return wire.hold()
       return Promise.resolve(wire.data)
+    }),
+    setSessionPullRequestAutoMerge: vi.fn((sessionId: string, enabled: boolean) => {
+      wire.mergeCalls.push({ sessionId, enabled })
+      if (wire.mergeFailure) return Promise.reject(wire.mergeFailure)
+      return Promise.resolve({ armed: enabled })
     })
   }
 })
@@ -86,6 +94,8 @@ function pr(overrides: Partial<SessionPullRequestDto> = {}): SessionPullRequestD
     ],
     unresolvedCount: 2,
     threadsTruncated: false,
+    autoMergeArmed: false,
+    canArmAutoMerge: true,
     degraded: false,
     degradedReason: null,
     agentReview: null,
@@ -148,6 +158,8 @@ beforeEach(() => {
   wire.failure = null
   wire.calls = []
   wire.hold = null
+  wire.mergeCalls = []
+  wire.mergeFailure = null
   verdicts = []
 })
 
@@ -342,15 +354,86 @@ describe('PullRequestPanel body', () => {
     expect(text()).toContain('No unresolved review threads')
   })
 
-  it('offers NO Auto-fix, NO merge control and NO thread resolution — M6’s writes are absent, not disabled', async () => {
-    // PREMISE (§9 M5): this panel is read-only. If M6 lands its Auto-fix button and Merge-when-ready checkbox, re-aim this assertion at the new controls — do not delete it.
+  it('gates M6’s writes: Auto-fix is ABSENT without a live composer, the merge toggle disabled below write tier', async () => {
+    // Re-aimed from M5's read-only premise (§9), as that test asked: the writes exist now, but each is
+    // earned. No onAutoFix (a hook session with no composer) means NO button — absent, not disabled.
     await render()
-    // The refresh control is the ONLY button, and there is no checkbox for auto-merge to hide in.
-    const buttons = Array.from(container?.querySelectorAll('button') ?? [])
-    expect(buttons.map((button) => button.getAttribute('aria-label'))).toEqual(['Refresh pull request'])
-    expect(container?.querySelectorAll('input')).toHaveLength(0)
-    expect(text().toLowerCase()).not.toContain('auto-fix')
-    expect(text().toLowerCase()).not.toContain('merge when ready')
+    expect(container?.querySelector('[data-pr-autofix]')).toBeNull()
+    // The write-capable fixture's merge toggle is live; a read-tier caller's is disabled, not hidden —
+    // the CP's canArmAutoMerge flag is exactly the "disabled control, not a failed call" contract.
+    expect(container?.querySelector<HTMLInputElement>('[data-pr-automerge]')?.disabled).toBe(false)
+
+    wire.data = pr({ canArmAutoMerge: false })
+    await render()
+    expect(container?.querySelector<HTMLInputElement>('[data-pr-automerge]')?.disabled).toBe(true)
+
+    // No merge box at all where there is nothing to arm: closed/merged PRs and degraded answers.
+    wire.data = pr({ state: 'merged' })
+    await render()
+    expect(container?.querySelector('[data-pr-merge]')).toBeNull()
+    wire.data = degradedPr('rate_limited')
+    await render()
+    expect(container?.querySelector('[data-pr-merge]')).toBeNull()
+  })
+
+  it('Auto-fix posts ONE instruction carrying every unresolved thread, then re-reads once when the turn settles', async () => {
+    // §5.2: one action over the whole set, a real webchat turn — and the panel's ONLY follow-up is a
+    // single forced re-read on the turn's FALLING edge, where the agent's GitHub write-back landed.
+    const posted: string[] = []
+    await render({ onAutoFix: (text) => posted.push(text), turnActive: false })
+    expect(wire.calls).toHaveLength(1)
+
+    await press('[data-pr-autofix]')
+    expect(posted).toHaveLength(1)
+    expect(posted[0]).toContain('#57')
+    expect(posted[0]).toContain('src/dock.ts:12 — sam: This cache key needs the org.')
+    expect(posted[0]).toContain('src/dock.ts:40')
+    expect(posted[0]).toContain('resolve the threads')
+    // Pressed = in flight: the button disables rather than double-posting the same set.
+    expect(container?.querySelector<HTMLButtonElement>('[data-pr-autofix]')?.disabled).toBe(true)
+
+    // The turn starts streaming, then settles: exactly one re-read, forced past the CP's TTL.
+    await rerender({ onAutoFix: (text) => posted.push(text), turnActive: true })
+    expect(wire.calls).toHaveLength(1)
+    wire.data = pr({ threads: [], unresolvedCount: 0 })
+    await rerender({ onAutoFix: (text) => posted.push(text), turnActive: false })
+    expect(wire.calls).toHaveLength(2)
+    expect(wire.calls[1]).toMatchObject({ refresh: true })
+    // A LATER turn settling re-reads nothing — the wait was consumed.
+    await rerender({ onAutoFix: (text) => posted.push(text), turnActive: true })
+    await rerender({ onAutoFix: (text) => posted.push(text), turnActive: false })
+    expect(wire.calls).toHaveLength(2)
+  })
+
+  it('arms auto-merge through the CP and re-reads the view it invalidated', async () => {
+    await render()
+    expect(wire.calls).toHaveLength(1)
+
+    wire.data = pr({ autoMergeArmed: true })
+    await press('[data-pr-automerge]')
+
+    expect(wire.mergeCalls).toEqual([{ sessionId: 'session-1', enabled: true }])
+    expect(wire.calls).toHaveLength(2) // the post-write re-read, riding the CP's own invalidation
+    expect(container?.querySelector<HTMLInputElement>('[data-pr-automerge]')?.checked).toBe(true)
+    expect(text()).toContain('Auto-merge armed')
+    expect(text()).toContain('after checks + approvals')
+
+    // Unchecking disarms with the same round trip.
+    wire.data = pr({ autoMergeArmed: false })
+    await press('[data-pr-automerge]')
+    expect(wire.mergeCalls[1]).toEqual({ sessionId: 'session-1', enabled: false })
+  })
+
+  it('surfaces a refused arm as data in the merge box and keeps the toggle usable', async () => {
+    // GitHub declining the state change (the CP's 409) is an answer the operator acts on, not a crash.
+    wire.mergeFailure = new Error('Pull request is in clean status')
+    await render()
+
+    await press('[data-pr-automerge]')
+
+    expect(container?.querySelector('[data-pr-merge-error]')?.textContent).toContain('clean status')
+    expect(container?.querySelector<HTMLInputElement>('[data-pr-automerge]')?.disabled).toBe(false)
+    expect(wire.calls).toHaveLength(1) // no re-read: nothing changed behind the failed write
   })
 })
 

--- a/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
@@ -405,6 +405,16 @@ describe('PullRequestPanel body', () => {
     expect(wire.calls).toHaveLength(2)
   })
 
+  it('holds Auto-fix while ANY turn streams — a queued post would let that turn eat the wait', async () => {
+    // The composer QUEUES a send during a running turn; the running turn's falling edge would then
+    // consume `awaitingTurn` before the Auto-fix turn dispatched, and its real settle would refresh nothing.
+    await render({ onAutoFix: () => {}, turnActive: true })
+    expect(container?.querySelector<HTMLButtonElement>('[data-pr-autofix]')?.disabled).toBe(true)
+
+    await rerender({ onAutoFix: () => {}, turnActive: false })
+    expect(container?.querySelector<HTMLButtonElement>('[data-pr-autofix]')?.disabled).toBe(false)
+  })
+
   it('arms auto-merge through the CP and re-reads the view it invalidated', async () => {
     await render()
     expect(wire.calls).toHaveLength(1)

--- a/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.test.tsx
@@ -120,6 +120,13 @@ function degradedPr(reason: 'rate_limited' | 'denied' | 'unreachable'): SessionP
   })
 }
 
+function accept(posted: string[]) {
+  return (text: string) => {
+    posted.push(text)
+    return true
+  }
+}
+
 type PanelProps = Parameters<typeof PullRequestPanel>[0]
 
 function panel(props: Partial<PanelProps> = {}) {
@@ -380,7 +387,7 @@ describe('PullRequestPanel body', () => {
     // §5.2: one action over the whole set, a real webchat turn — and the panel's ONLY follow-up is a
     // single forced re-read on the turn's FALLING edge, where the agent's GitHub write-back landed.
     const posted: string[] = []
-    await render({ onAutoFix: (text) => posted.push(text), turnActive: false })
+    await render({ onAutoFix: accept(posted), turnActive: false })
     expect(wire.calls).toHaveLength(1)
 
     await press('[data-pr-autofix]')
@@ -393,25 +400,39 @@ describe('PullRequestPanel body', () => {
     expect(container?.querySelector<HTMLButtonElement>('[data-pr-autofix]')?.disabled).toBe(true)
 
     // The turn starts streaming, then settles: exactly one re-read, forced past the CP's TTL.
-    await rerender({ onAutoFix: (text) => posted.push(text), turnActive: true })
+    await rerender({ onAutoFix: accept(posted), turnActive: true })
     expect(wire.calls).toHaveLength(1)
     wire.data = pr({ threads: [], unresolvedCount: 0 })
-    await rerender({ onAutoFix: (text) => posted.push(text), turnActive: false })
+    await rerender({ onAutoFix: accept(posted), turnActive: false })
     expect(wire.calls).toHaveLength(2)
     expect(wire.calls[1]).toMatchObject({ refresh: true })
     // A LATER turn settling re-reads nothing — the wait was consumed.
-    await rerender({ onAutoFix: (text) => posted.push(text), turnActive: true })
-    await rerender({ onAutoFix: (text) => posted.push(text), turnActive: false })
+    await rerender({ onAutoFix: accept(posted), turnActive: true })
+    await rerender({ onAutoFix: accept(posted), turnActive: false })
     expect(wire.calls).toHaveLength(2)
+  })
+
+  it('does not arm the wait on a REFUSED send — the button stays pressable and no edge is owed', async () => {
+    // onPgSend refuses synchronously while an image prepares or a mention joins; an armed wait there
+    // would disable the button forever, since the refused send produces no turn and no falling edge.
+    await render({ onAutoFix: () => false, turnActive: false })
+
+    await press('[data-pr-autofix]')
+    expect(container?.querySelector<HTMLButtonElement>('[data-pr-autofix]')?.disabled).toBe(false)
+
+    // And no stale wait rides a later, unrelated turn into a phantom re-read.
+    await rerender({ onAutoFix: () => false, turnActive: true })
+    await rerender({ onAutoFix: () => false, turnActive: false })
+    expect(wire.calls).toHaveLength(1)
   })
 
   it('holds Auto-fix while ANY turn streams — a queued post would let that turn eat the wait', async () => {
     // The composer QUEUES a send during a running turn; the running turn's falling edge would then
     // consume `awaitingTurn` before the Auto-fix turn dispatched, and its real settle would refresh nothing.
-    await render({ onAutoFix: () => {}, turnActive: true })
+    await render({ onAutoFix: () => true, turnActive: true })
     expect(container?.querySelector<HTMLButtonElement>('[data-pr-autofix]')?.disabled).toBe(true)
 
-    await rerender({ onAutoFix: () => {}, turnActive: false })
+    await rerender({ onAutoFix: () => true, turnActive: false })
     expect(container?.querySelector<HTMLButtonElement>('[data-pr-autofix]')?.disabled).toBe(false)
   })
 

--- a/packages/web/src/components/console/dock/PullRequestPanel.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-// The dock's PR tab (§3.4, M5): the pull request this session was dispatched for — state, head→base, checks, current reviews and unresolved threads — as a READ-ONLY surface. Auto-fix and Merge-when-ready are M6's write loop and are ABSENT rather than disabled.
+// The dock's PR tab (§3.4): the pull request this session was dispatched for — state, head→base, checks, current reviews and unresolved threads — plus M6's two writes: ONE Auto-fix post over the whole unresolved set (§5.2, a webchat turn, no CP route) and the Merge-when-ready auto-merge toggle.
 // Identity comes from the CP's own records and live state from GitHub through the CP's short-TTL projection; thread bodies are proxied, never stored (§2). A rate-limited, denied or unreachable GitHub is DATA: the panel still names its PR and says why the live lists are missing.
-// A session with no linked pull-request run answers 404 ONCE and the tab hides. That linkage never appears later — the run is what CREATED the session — so the 404 is held per scope and nothing re-asks it (the hidden tab has no activation edge and no refresh control to press).
+// A 404 from the probe is PROVISIONAL on a bounded ladder (the session→run link can commit after the status flip, or with no flip at all), then the absence is believed and the tab stays hidden.
 
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Spinner } from '@/components/marks'
@@ -10,6 +10,7 @@ import { Icon } from '@/components/ui'
 import {
   ApiError,
   fetchSessionPullRequest,
+  setSessionPullRequestAutoMerge,
   type SessionPullRequestCheckDto,
   type SessionPullRequestDto,
   type SessionPullRequestReviewDto,
@@ -36,6 +37,20 @@ export interface PullRequestPanelVerdict {
 // Never `empty`: a 200 always carries identity to draw, "no PR" HIDES the tab instead of blanking it, and a failed probe has copy — no state is left for the dock's centred "Nothing to show" to describe.
 export function pullRequestTabStatus(answer: PullRequestPanelAnswer): DockTabStatus {
   return answer === 'pending' ? 'loading' : 'ready'
+}
+
+/** §5.2's one structured instruction: every unresolved thread (location + body), one turn, the agent resolves what it fixes. Exported so the post's exact content is pinned, not approximated. */
+export function autoFixInstruction(view: SessionPullRequestDto): string {
+  const threads = view.threads
+    .map((thread, index) => `${index + 1}. ${thread.location} — ${thread.author}: ${thread.body}`)
+    .join('\n')
+  return [
+    `Fix the unresolved review threads on pull request #${view.pullNumber} (${view.repoFullName}):`,
+    '',
+    threads,
+    '',
+    'Address each thread in this session’s worktree, commit and push the fixes, then resolve the threads you fixed on GitHub.'
+  ].join('\n')
 }
 
 /** A finished check's `startedAt`→`completedAt`, in the elapsed shape the Tasks rows use; empty when either end is missing or unparseable — the design says duration "where present", not invented. */
@@ -150,6 +165,8 @@ export function PullRequestPanel({
   sessionId,
   active = true,
   sessionStatus,
+  turnActive = false,
+  onAutoFix,
   onVerdictChange
 }: {
   /** The OPEN SESSION's id, the scope the CP resolves to its hook run. Deliberately no agentId: the PR belongs to the session, so a merged conversation's header-focus change must not re-key this read — the prop shape makes that unbuildable rather than merely avoided. */
@@ -158,6 +175,10 @@ export function PullRequestPanel({
   active?: boolean
   /** The open session's live status: a transition re-asks a held 404 immediately and refills the bounded retry ladder — a hint that the session→run link may just have committed, though the frames race, which is why the ladder exists at all. */
   sessionStatus?: string
+  /** Whether a turn is streaming right now. After Auto-fix posts one, the FALLING edge is the panel's cue to force one re-read — the agent's GitHub write-back (resolved threads, pushed fixes) lands with the turn, and the CP's short TTL would otherwise hide it. */
+  turnActive?: boolean
+  /** Posts one webchat message into the open session (§5.2's browser→relay→daemon path — no CP route). Absent when the session has no live composer, and the Auto-fix action renders ABSENT with it, not disabled. */
+  onAutoFix?: (text: string) => void
   /** The inputs to {@link pullRequestTabStatus}, the tab's badge and its external-link action. */
   onVerdictChange?: (verdict: PullRequestPanelVerdict) => void
 }) {
@@ -209,6 +230,37 @@ export function PullRequestPanel({
         : 'failed'
   const unresolved = view && !view.degraded ? view.unresolvedCount : null
   const url = view?.url ?? null
+
+  // Auto-fix hands the set to the agent as ONE turn (§5.2): `awaitingTurn` survives until that turn's
+  // falling edge, where the panel forces one re-read past the CP TTL — the write-back it waits for
+  // (resolved threads) happened on GitHub inside the turn. Reset per scope: a session switch mid-fix
+  // must not graft the old session's wait onto the new one's reads.
+  const [awaitingTurn, setAwaitingTurn] = useState(false)
+  useEffect(() => setAwaitingTurn(false), [sessionId])
+  const wasTurnActive = useRef(turnActive)
+  useEffect(() => {
+    const settled = wasTurnActive.current && !turnActive
+    wasTurnActive.current = turnActive
+    if (settled && awaitingTurn) {
+      setAwaitingTurn(false)
+      setReads((r) => ({ tick: r.tick + 1, force: true }))
+    }
+  }, [turnActive, awaitingTurn])
+
+  // The auto-merge toggle's own in-flight/error state; the armed FACT stays on the view, re-read after every write.
+  const [merge, setMerge] = useState<{ busy: boolean; err: string | null }>({ busy: false, err: null })
+  useEffect(() => setMerge({ busy: false, err: null }), [sessionId])
+  const toggleAutoMerge = (enabled: boolean) => {
+    setMerge({ busy: true, err: null })
+    setSessionPullRequestAutoMerge(sessionId, enabled).then(
+      () => {
+        setMerge({ busy: false, err: null })
+        // The CP invalidated its cached view on the write, so a plain re-read already sees the new state.
+        setReads((r) => ({ tick: r.tick + 1, force: false }))
+      },
+      (e) => setMerge({ busy: false, err: msg(e) })
+    )
+  }
 
   // Reported on the EDGE, like every other tab's verdict: the caller's callback is a fresh closure per render, and re-reporting a held verdict would write parent state for nothing.
   const reported = useRef<string | null>(null)
@@ -473,11 +525,68 @@ export function PullRequestPanel({
                     </div>
                   ) : null}
                 </div>
-              )
+              ),
+              // ONE Auto-fix over the whole set (§5.2) — a real agent turn on the webchat path, absent (not disabled) when the session has no live composer to post through.
+              onAutoFix && view.threads.length > 0 ? (
+                <button
+                  type="button"
+                  data-pr-autofix=""
+                  className="dsbtn dsbtn-secondary sm flex-none disabled:pointer-events-none disabled:opacity-50"
+                  disabled={awaitingTurn}
+                  title="Hand every unresolved thread to the agent as one turn; it edits this session’s worktree and resolves the threads it fixes"
+                  onClick={() => {
+                    onAutoFix(autoFixInstruction(view))
+                    setAwaitingTurn(true)
+                  }}
+                >
+                  {awaitingTurn ? <Spinner size={11} /> : <Icon name="wand-sparkles" size={12} />}
+                  Auto-fix
+                </button>
+              ) : undefined
             )}
           </>
         )}
       </div>
+      {/* The merge box (§3.4): the checkbox IS the action — there is no direct-merge route to back a Merge button, so none is drawn. Open PRs only; a degraded read has no armed fact to draw a control over. */}
+      {!view.degraded && view.state === 'open' ? (
+        <div data-pr-merge="" className="flex flex-none flex-col gap-[3px] border-t border-(--border-subtle) px-3 py-2">
+          <label
+            className={`flex items-center gap-[7px] font-sans text-[12px] font-medium leading-normal text-(--text-primary) ${view.canArmAutoMerge ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'}`}
+            title={
+              view.canArmAutoMerge
+                ? 'GitHub merges automatically once checks and approvals pass'
+                : 'The owning agent’s repository access is below write tier, so arming the merge is not available'
+            }
+          >
+            <input
+              type="checkbox"
+              data-pr-automerge=""
+              className="accent-(--brand)"
+              checked={view.autoMergeArmed ?? false}
+              disabled={!view.canArmAutoMerge || merge.busy}
+              onChange={(event) => toggleAutoMerge(event.target.checked)}
+            />
+            Merge when ready
+            {merge.busy ? <Spinner size={11} /> : null}
+            {view.autoMergeArmed ? (
+              <span className="flex-none rounded-full bg-(--brand-soft) px-[7px] py-px font-sans text-[10.5px] font-semibold leading-normal text-(--brand)">
+                Auto-merge armed
+              </span>
+            ) : null}
+          </label>
+          <div className="font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+            {view.autoMergeArmed ? 'Squash · after checks + approvals' : 'Squash and merge'}
+          </div>
+          {merge.err ? (
+            <div
+              data-pr-merge-error=""
+              className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--status-error)"
+            >
+              {merge.err}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/packages/web/src/components/console/dock/PullRequestPanel.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.tsx
@@ -532,8 +532,14 @@ export function PullRequestPanel({
                   type="button"
                   data-pr-autofix=""
                   className="dsbtn dsbtn-secondary sm flex-none disabled:pointer-events-none disabled:opacity-50"
-                  disabled={awaitingTurn}
-                  title="Hand every unresolved thread to the agent as one turn; it edits this session’s worktree and resolves the threads it fixes"
+                  // Disabled while ANY turn streams: the composer would QUEUE the post, and the running
+                  // turn's falling edge would consume the wait before the Auto-fix turn even dispatched.
+                  disabled={awaitingTurn || turnActive}
+                  title={
+                    turnActive && !awaitingTurn
+                      ? 'A turn is already running — Auto-fix posts its own turn, so wait for this one to settle'
+                      : 'Hand every unresolved thread to the agent as one turn; it edits this session’s worktree and resolves the threads it fixes'
+                  }
                   onClick={() => {
                     onAutoFix(autoFixInstruction(view))
                     setAwaitingTurn(true)

--- a/packages/web/src/components/console/dock/PullRequestPanel.tsx
+++ b/packages/web/src/components/console/dock/PullRequestPanel.tsx
@@ -177,8 +177,8 @@ export function PullRequestPanel({
   sessionStatus?: string
   /** Whether a turn is streaming right now. After Auto-fix posts one, the FALLING edge is the panel's cue to force one re-read — the agent's GitHub write-back (resolved threads, pushed fixes) lands with the turn, and the CP's short TTL would otherwise hide it. */
   turnActive?: boolean
-  /** Posts one webchat message into the open session (§5.2's browser→relay→daemon path — no CP route). Absent when the session has no live composer, and the Auto-fix action renders ABSENT with it, not disabled. */
-  onAutoFix?: (text: string) => void
+  /** Posts one webchat message into the open session (§5.2's browser→relay→daemon path — no CP route), returning whether the send was ACCEPTED. Absent when the session has no usable composer (none at all, or a persisted webchat that cannot resume), and the Auto-fix action renders ABSENT with it, not disabled. */
+  onAutoFix?: (text: string) => boolean
   /** The inputs to {@link pullRequestTabStatus}, the tab's badge and its external-link action. */
   onVerdictChange?: (verdict: PullRequestPanelVerdict) => void
 }) {
@@ -541,8 +541,8 @@ export function PullRequestPanel({
                       : 'Hand every unresolved thread to the agent as one turn; it edits this session’s worktree and resolves the threads it fixes'
                   }
                   onClick={() => {
-                    onAutoFix(autoFixInstruction(view))
-                    setAwaitingTurn(true)
+                    // The wait arms only on an ACCEPTED send: a synchronous refusal (image preparing, mention joining) produces no turn, so an armed wait would disable the button forever with no edge to clear it.
+                    if (onAutoFix(autoFixInstruction(view))) setAwaitingTurn(true)
                   }}
                 >
                   {awaitingTurn ? <Spinner size={11} /> : <Icon name="wand-sparkles" size={12} />}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2718,8 +2718,10 @@ export default function SessionDetailView() {
 
   // Resume the webchat conversation by its id (session.channelId == the conversationId);
   // a synthetic playground turn omits it (the CP mints a fresh id).
-  const onPgSend = (text?: string) => {
-    if (imagePreparing || mentionJoining) return
+  // Returns ACCEPTANCE: callers that arm follow-up state (the PR panel's Auto-fix wait) must know a
+  // synchronous refusal — image preparing, mention joining, nothing to send — from an accepted send.
+  const onPgSend = (text?: string): boolean => {
+    if (imagePreparing || mentionJoining) return false
     setImageError(null)
     // Pass the fetched roster: an adopted webchat session has no provider-side
     // state, and without it a multi-agent send can't pre-create stream lanes or
@@ -2740,6 +2742,7 @@ export default function SessionDetailView() {
     // turn is still streaming, sends nothing, and yanking a reader out of
     // history for a no-op would break the very guarantee this makes.
     if (sent) stickToBottom()
+    return sent
   }
   const onImageFile = async (file: File | undefined): Promise<void> => {
     if (!file || imagePreparing) return
@@ -4641,8 +4644,8 @@ export default function SessionDetailView() {
               active={dockTabKey === 'pr'}
               {...(session?.status ? { sessionStatus: session.status } : {})}
               turnActive={sessionBusy}
-              // Auto-fix rides the LIVE composer path (§5.2, browser→relay→daemon); a hook session with no composer gets no button rather than a dead one.
-              {...(isLive ? { onAutoFix: (text: string) => onPgSend(text) } : {})}
+              // Auto-fix rides the LIVE composer path (§5.2) behind the composer's OWN availability fence: a hook session has no composer, and a persisted webchat under `resumeDisabled` (agent moved, resume check pending) deliberately renders the composer inert — this callback must not exist as a way around that.
+              {...(isLive && !resumeDisabled ? { onAutoFix: (text: string) => onPgSend(text) } : {})}
               onVerdictChange={setPrVerdict}
             />
           ) : null}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -4640,6 +4640,9 @@ export default function SessionDetailView() {
               sessionId={prSessionId}
               active={dockTabKey === 'pr'}
               {...(session?.status ? { sessionStatus: session.status } : {})}
+              turnActive={sessionBusy}
+              // Auto-fix rides the LIVE composer path (§5.2, browser→relay→daemon); a hook session with no composer gets no button rather than a dead one.
+              {...(isLive ? { onAutoFix: (text: string) => onPgSend(text) } : {})}
               onVerdictChange={setPrVerdict}
             />
           ) : null}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3160,6 +3160,8 @@ export interface SessionPullRequestDto {
   threads: SessionPullRequestThreadDto[]
   unresolvedCount: number // a floor when `threadsTruncated`
   threadsTruncated: boolean
+  autoMergeArmed: boolean | null // null while degraded — only GitHub holds the auto-merge fact
+  canArmAutoMerge: boolean // the owning agent's clamp allows the write; false renders a disabled control
   degraded: boolean
   degradedReason: 'rate_limited' | 'denied' | 'unreachable' | null
   /** The agent's own recorded review, present ONLY on a degraded answer — the one review state the deployment knows without GitHub. */
@@ -3174,6 +3176,14 @@ export async function fetchSessionPullRequest(
 ): Promise<SessionPullRequestDto> {
   const query = opts.refresh ? '?refresh=true' : ''
   return apiGet<SessionPullRequestDto>(`${orgBase()}/sessions/${encodeURIComponent(sessionId)}/pull-request${query}`)
+}
+
+// Arm/disarm GitHub auto-merge (squash) on the session's PR, under the owning agent's clamped grant.
+// Idempotent on the CP; a 409 relays GitHub declining the state change (e.g. checks already pass).
+export async function setSessionPullRequestAutoMerge(sessionId: string, enabled: boolean): Promise<{ armed: boolean }> {
+  return apiPost<{ armed: boolean }>(`${orgBase()}/sessions/${encodeURIComponent(sessionId)}/pull-request/auto-merge`, {
+    enabled
+  })
 }
 
 // ── usage dashboard (GET /usage) — real historical aggregates from the CP's


### PR DESCRIPTION
## What

The final milestone of the webchat dock plan ([`docs/designs/webchat-side-panels.md`](../blob/dev/yulong/webchat-dock-m6/docs/designs/webchat-side-panels.md) M6, §5.2): the PR panel gains its two writes, closing the design's headline loop — read the review, hand it to the agent, arm the merge.

### Auto-fix — one action, one turn, no CP route (§5.2)

- The threads section header gains ONE **Auto-fix** button over the whole unresolved set — the per-thread state machine the prototype drew is deliberately not built (§5.2's scope decision, recorded in the plan).
- Pressing it posts one structured instruction (every thread's `location`, author and body) through the **live composer path** (browser→relay→daemon, CP off the path). The turn streams into the transcript like any other work; thread resolution rides the agent's own GitHub write-back.
- The panel's only follow-up: a single `refresh=true` re-read on the turn's **falling edge**, where the write-back landed and the CP TTL would hide it. The wait is armed per press, consumed once, reset per scope. A session with no live composer (hook platform) gets **no button** — absent, not disabled.

### Merge when ready — the one backed write

- New route `POST /sessions/:id/pull-request/auto-merge` (`{enabled}` → `{armed}`): `getOrgViewableSession` → owning run → the **run's** agent → installation token clamped to that agent's repository tier → `enable`/`disablePullRequestAutoMerge` by node id. Idempotent — a fresh node read decides whether the mutation runs; the cached view drops either way.
- The mint requires **write tier** (the additional-repo `comment` tier that may COMMENT-review is excluded — arming merges code) and carries `contents: write` beside `pull_requests: write`, because GitHub performs the eventual merge under the same grant.
- The read projection gains `autoMergeArmed` (shared — GitHub's fact) and `canArmAutoMerge` (**per-caller**, Postgres-only, computed in the route like the M5 overlay facts — never cached), so a read-tier agent renders a **disabled checkbox, not a failed call**.
- Refusals are statuses the merge box shows as data: 403 clamp, **409 GitHub declining the state change** (e.g. checks already pass), 429 rate limit, 502 outage.
- There is deliberately **no Merge button**: nothing backs a direct merge, and M3's absent-rather-than-inert rule applies. The checkbox IS the action; the armed state wears `--brand-soft` per §8's token table.

## Verification

- CP unit 1544 + integration 1131 green; web 1482 green; both typechecks and lint clean.
- Mutation-pinned, each direction reddening its own named test:
  - falling-edge re-read never fires / rides the TTL instead of forcing / wait never consumed / merge write forgets its re-read (web);
  - `setAutoMerge` uses the caller's token only, mutates by node id, idempotent no-mutation, denied-PR throw, cache dropped after the write (CP unit);
  - tier gates on both `mintAutoMergeForAgent` and `canArmAutoMerge` (write tier + accepted `pull_requests:write`, fails closed on a legacy empty snapshot);
  - route matrix: happy arm end-to-end, 403 before any GitHub call for a read tier, 409 relay, 403 for a vanished owning agent, 404s identical to the GET (no run, foreign org fence, another member's private session — zero GitHub spend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
