### PR TITLE
docs(designs): mark M6 landed — webchat dock plan complete

### DIFF
--- a/docs/designs/webchat-side-panels.md
+++ b/docs/designs/webchat-side-panels.md
@@ -924,6 +924,7 @@ finishing the inherited wip:
 (§5.2), and `Merge when ready` (`enablePullRequestAutoMerge`) gated on the
 clamped token actually carrying write. _Exit:_ the design's headline loop — read
 the review, hand it to the agent, arm the merge — works end to end.
+**Landed.**
 
 Decisions recorded while building it:
 


### PR DESCRIPTION
One-line bookkeeping after #884 merged: the M6 paragraph in `webchat-side-panels.md` gains its **Landed.** marker, matching every other milestone. All seven milestones (M0 #808 → M6 #884) are now merged and marked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)