### PR TITLE
feat(web): cluster execution settings and envelope status

### DIFF
--- a/packages/web/src/components/console/ClusterExecutionCard.test.tsx
+++ b/packages/web/src/components/console/ClusterExecutionCard.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { SWRConfig } from 'swr'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, setApiOrgId, type ClusterEnvelopeStatusDto, type ClusterExecutionSettingsDto } from '@/lib/api'
+
+let settingsAnswer: ClusterExecutionSettingsDto | Error
+let statusAnswer: ClusterEnvelopeStatusDto | Error
+const issued = vi.fn()
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    fetchClusterExecution: async () => {
+      if (settingsAnswer instanceof Error) throw settingsAnswer
+      return settingsAnswer
+    },
+    fetchClusterExecutionStatus: async () => {
+      if (statusAnswer instanceof Error) throw statusAnswer
+      return statusAnswer
+    },
+    issueClusterExecutionCredential: (...args: unknown[]) => issued(...args)
+  }
+})
+
+import { ClusterExecutionCard } from './ClusterExecutionCard'
+
+const SETTINGS: ClusterExecutionSettingsDto = {
+  enabled: true,
+  targetNamespace: 'ac-org-acme',
+  controlNamespace: 'agentconnect-control',
+  suspend: false,
+  daemonImage: 'registry.example.test/daemon:1',
+  daemonTier: 'small',
+  credentialSecretName: 'ac-daemon-token',
+  runtimeImage: 'registry.example.test/runtime:1',
+  runtimeTiers: [{ name: 'small', warmReplicas: 1 }],
+  quota: { maxAgents: 0, cpu: '0', memory: '0', storage: '0' },
+  egressPolicy: 'curated',
+  updatedAt: '2026-01-01T00:00:00.000Z'
+}
+
+const STATUS: ClusterEnvelopeStatusDto = {
+  present: true,
+  conditions: [
+    { type: 'Ready', status: 'True' },
+    { type: 'CredentialReady', status: 'False', reason: 'Pending' },
+    { type: 'Degraded', status: 'False' }
+  ],
+  daemon: { ready: true },
+  sandboxes: { total: 3, running: 2, suspended: 1 },
+  pools: [{ name: 'small', warmAvailable: 1, claimed: 2 }]
+}
+
+let host: HTMLDivElement
+let root: Root
+
+async function render(node: ReactNode) {
+  await act(async () => {
+    root.render(<SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{node}</SWRConfig>)
+  })
+  // One more turn for the settings read and the status read behind it to settle.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return [...host.querySelectorAll('button')].find((element) => element.textContent === label)
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  setApiOrgId('org-test')
+  settingsAnswer = SETTINGS
+  statusAnswer = STATUS
+  issued.mockReset()
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+  setApiOrgId(null)
+})
+
+describe('cluster execution card', () => {
+  it('renders nothing where the deployment mounts no cluster routes', async () => {
+    settingsAnswer = new ApiError('not found', 404)
+    await render(<ClusterExecutionCard orgId="org-test" isOwner />)
+    expect(host.textContent).toBe('')
+  })
+
+  it('renders nothing for a non-owner', async () => {
+    await render(<ClusterExecutionCard orgId="org-test" isOwner={false} />)
+    expect(host.textContent).toBe('')
+  })
+
+  it('shows the operator’s conditions, not the stored row', async () => {
+    await render(<ClusterExecutionCard orgId="org-test" isOwner />)
+
+    expect(host.textContent).toContain('Ready')
+    expect(host.textContent).toContain('Credential')
+    // A fault condition that is False is not news, so it is left out.
+    expect(host.textContent).not.toContain('Degraded')
+    expect(host.textContent).toContain('ac-org-acme')
+  })
+
+  it('offers to issue a first credential, and never shows a key', async () => {
+    await render(<ClusterExecutionCard orgId="org-test" isOwner />)
+
+    expect(host.textContent).toContain('Not issued')
+    expect(button('Issue')).toBeDefined()
+    expect(button('Rotate')).toBeUndefined()
+  })
+
+  it('confirms before rotating, because a rotation recreates the daemon pod', async () => {
+    settingsAnswer = { ...SETTINGS, credentialRevision: 'rev-1' }
+    await render(<ClusterExecutionCard orgId="org-test" isOwner />)
+    expect(host.textContent).toContain('rev-1')
+
+    await act(async () => {
+      button('Rotate')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(host.textContent).toContain('Rotate the daemon credential?')
+    expect(issued).not.toHaveBeenCalled()
+  })
+
+  it('says the envelope is not there yet rather than reporting it as unhealthy', async () => {
+    statusAnswer = { present: false, conditions: [] }
+    await render(<ClusterExecutionCard orgId="org-test" isOwner />)
+    expect(host.textContent).toContain('No envelope in the cluster yet')
+  })
+})

--- a/packages/web/src/components/console/ClusterExecutionCard.test.tsx
+++ b/packages/web/src/components/console/ClusterExecutionCard.test.tsx
@@ -139,4 +139,13 @@ describe('cluster execution card', () => {
     await render(<ClusterExecutionCard orgId="org-test" isOwner />)
     expect(host.textContent).toContain('No envelope in the cluster yet')
   })
+
+  it('says the cluster read failed rather than loading forever', async () => {
+    statusAnswer = new ApiError('cluster API rejected the request', 502)
+    await render(<ClusterExecutionCard orgId="org-test" isOwner />)
+
+    expect(host.textContent).toContain("Couldn't read the envelope status from the cluster.")
+    // Never a condition from a read that did not happen.
+    expect(host.textContent).not.toContain('Ready')
+  })
 })

--- a/packages/web/src/components/console/ClusterExecutionCard.tsx
+++ b/packages/web/src/components/console/ClusterExecutionCard.tsx
@@ -211,7 +211,7 @@ export function ClusterExecutionCard({ orgId, isOwner }: { orgId: string | undef
                 <div className="min-w-0 flex-1">
                   <div className="font-sans text-[13px] font-medium leading-normal">Daemon credential</div>
                   <div className={`${HELP} mt-[3px]`}>
-                    Published into the <span className="mono">{settings.credentialSecretName}</span> Secret in the
+                    Published into the <span className="mono">{settings.credentialSecretName}</span>&#32;Secret in the
                     envelope namespace. The key is never shown here; rotating recreates the daemon pod on the new one.
                   </div>
                 </div>

--- a/packages/web/src/components/console/ClusterExecutionCard.tsx
+++ b/packages/web/src/components/console/ClusterExecutionCard.tsx
@@ -1,0 +1,551 @@
+'use client'
+
+// Settings → "Cluster execution": the organization's managed-execution envelope
+// (docs/designs/agentconnect-org-operator.md). The control plane owns the spec
+// and the operator owns everything after it, so this card WRITES settings and
+// READS status live from the AgentConnectOrg resource — a stored field is never
+// presented as cluster truth.
+//
+// Three things it deliberately does not do:
+//
+//  1. It never shows the daemon key. Issuing publishes the key into a cluster
+//     Secret and answers with a revision handle only, so there is nothing to
+//     reveal and no copy button to offer.
+//  2. It renders nothing where the deployment has no cluster configured. The
+//     whole surface 404s there, which is an absent feature, not an error.
+//  3. It is owner-only, like every other write on this page.
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import useSWR from 'swr'
+import {
+  ApiError,
+  fetchClusterExecution,
+  fetchClusterExecutionStatus,
+  issueClusterExecutionCredential,
+  updateClusterExecution,
+  type ClusterConditionDto,
+  type ClusterEgressPolicy,
+  type ClusterEnvelopeStatusDto,
+  type ClusterExecutionSettingsDto,
+  type ClusterRuntimeTierDto,
+  type UpdateClusterExecutionBody
+} from '@/lib/api'
+import { consoleKeys } from '@/lib/swr-keys'
+import { Button, Icon, Toggle } from '@/components/ui'
+import { ConfirmationDialog } from '@/components/console/ConfirmationDialog'
+import { LoadingState } from '@/components/marks'
+
+/** The envelope moves on the operator's clock, not on a request's. */
+const STATUS_REFRESH_MS = 10_000
+
+/** The CRD's own bound on `runtime.tiers[]`. */
+const MAX_TIERS = 16
+
+const FIELD =
+  'w-full min-w-0 rounded-md border border-(--border-default) bg-(--surface-card) px-[9px] font-mono text-[12px] font-medium text-(--text-primary) outline-none focus:border-(--border-focus) focus:ring-[3px] focus:ring-(--brand-ring)'
+const INPUT = `h-8 ${FIELD}`
+const LABEL = 'font-sans text-[12px] font-semibold leading-normal text-(--text-primary)'
+const HELP = 'font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-tertiary)'
+const ROW = 'flex flex-col gap-3 px-4 py-[15px] desktop:flex-row desktop:items-center desktop:gap-4'
+
+/** Operator-owned condition types, named the way this page reads them. */
+const CONDITION_LABELS: Record<string, string> = {
+  Ready: 'Ready',
+  NamespaceReady: 'Namespace',
+  CredentialReady: 'Credential',
+  LimitsApplied: 'Limits',
+  Progressing: 'Progressing',
+  Degraded: 'Degraded'
+}
+
+/** Conditions that are news only while TRUE — a steady envelope is neither. */
+const TRANSIENT = new Set(['Progressing', 'Degraded'])
+
+const EGRESS_POLICIES: { value: ClusterEgressPolicy; label: string; detail: string }[] = [
+  { value: 'locked', label: 'Locked', detail: 'Sandboxes reach nothing outside the cluster.' },
+  { value: 'curated', label: 'Curated', detail: 'Sandboxes reach the destinations this deployment allows.' },
+  { value: 'open', label: 'Open', detail: 'Sandboxes reach the internet.' }
+]
+
+/** The refusals this surface answers with, in the console's own words. */
+const REFUSALS: Record<string, string> = {
+  CLUSTER_NOT_ENABLED: 'Cluster execution is switched off for this organization.',
+  CLUSTER_NAMESPACE_NOT_READY: 'The envelope namespace does not exist yet. Try again once Namespace reads ready.',
+  CLUSTER_ROTATION_IN_PROGRESS: 'Another credential rotation is already running for this organization.'
+}
+
+function errorMessage(err: unknown): string {
+  const refusal = err instanceof ApiError && err.code ? REFUSALS[err.code] : undefined
+  if (refusal) return refusal
+  return err instanceof Error ? err.message : String(err)
+}
+
+/** 404 ⇒ this deployment mounts no cluster routes at all. */
+function isAbsentFeature(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404
+}
+
+export function ClusterExecutionCard({ orgId, isOwner }: { orgId: string | undefined; isOwner: boolean }) {
+  const key = isOwner ? consoleKeys.clusterExecution(orgId) : null
+  const {
+    data: settings,
+    error: loadError,
+    mutate
+  } = useSWR<ClusterExecutionSettingsDto>(key, ([, id]) => fetchClusterExecution(id as string))
+  // Status exists only once a resource does, and it is the operator's to answer.
+  const statusKey = settings?.enabled ? consoleKeys.clusterExecutionStatus(orgId) : null
+  const { data: status } = useSWR<ClusterEnvelopeStatusDto>(
+    statusKey,
+    ([, id]) => fetchClusterExecutionStatus(id as string),
+    { refreshInterval: STATUS_REFRESH_MS }
+  )
+
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [disabling, setDisabling] = useState(false)
+  const [rotating, setRotating] = useState(false)
+  const [configuring, setConfiguring] = useState(false)
+
+  useEffect(() => {
+    setError(null)
+    setDisabling(false)
+    setRotating(false)
+    setConfiguring(false)
+  }, [orgId])
+
+  if (!isOwner) return null
+  if (loadError && isAbsentFeature(loadError)) return null
+
+  const save = async (patch: UpdateClusterExecutionBody) => {
+    if (!orgId || busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      await mutate(await updateClusterExecution(patch, orgId), { revalidate: false })
+      setDisabling(false)
+    } catch (err) {
+      setError(errorMessage(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const issue = async () => {
+    if (!orgId || busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      await issueClusterExecutionCredential(orgId)
+      setRotating(false)
+      await mutate()
+    } catch (err) {
+      setError(errorMessage(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="card mt-[18px]" id="cluster-execution">
+      <div className="cardhead justify-between">
+        <span className="inline-flex min-w-0 items-baseline gap-[7px]">
+          <span className="cardtitle">Cluster execution</span>
+          {settings?.enabled && (
+            <span className="mono truncate text-[11px] text-(--text-tertiary)">{settings.targetNamespace}</span>
+          )}
+        </span>
+        {settings?.enabled && (
+          <Button variant="secondary" size="xs" onClick={() => setConfiguring(true)}>
+            <Icon name="sliders-horizontal" size={14} />
+            Configure
+          </Button>
+        )}
+      </div>
+
+      {settings === undefined && !loadError ? (
+        <LoadingState size={22} padding={20} />
+      ) : !settings ? (
+        <div className="px-4 py-[15px] font-sans text-[12.5px] font-normal leading-normal text-(--status-error)">
+          Couldn&apos;t load the cluster execution settings.
+        </div>
+      ) : (
+        <>
+          <div className={ROW}>
+            <div className="min-w-0 flex-1">
+              <div className="font-sans text-[13px] font-medium leading-normal">
+                Run this organization in the cluster
+              </div>
+              <div className={`${HELP} mt-[3px]`}>
+                The operator provisions a namespace, a daemon, and the sandbox pools this organization&apos;s agents run
+                in. Switching it off deletes the envelope.
+              </div>
+            </div>
+            <Toggle
+              checked={settings.enabled}
+              disabled={busy}
+              ariaLabel="Run this organization in the cluster"
+              onChange={(next) => (next ? void save({ enabled: true }) : setDisabling(true))}
+            />
+          </div>
+
+          {settings.enabled && (
+            <>
+              <div className={`${ROW} border-t border-(--border-subtle)`}>
+                <div className="min-w-0 flex-1">
+                  <div className="font-sans text-[13px] font-medium leading-normal">Suspend</div>
+                  <div className={`${HELP} mt-[3px]`}>
+                    Quiesce without tearing down — the daemon goes to zero and the sandboxes drain. The envelope stays.
+                  </div>
+                </div>
+                <Toggle
+                  checked={settings.suspend}
+                  disabled={busy}
+                  ariaLabel="Suspend"
+                  onChange={(next) => void save({ suspend: next })}
+                />
+              </div>
+
+              <EnvelopeStatus status={status} />
+
+              <div className={`${ROW} border-t border-(--border-subtle)`}>
+                <div className="min-w-0 flex-1">
+                  <div className="font-sans text-[13px] font-medium leading-normal">Daemon credential</div>
+                  <div className={`${HELP} mt-[3px]`}>
+                    Published into the <span className="mono">{settings.credentialSecretName}</span> Secret in the
+                    envelope namespace. The key is never shown here; rotating recreates the daemon pod on the new one.
+                  </div>
+                </div>
+                <span className="mono truncate text-[11px] text-(--text-tertiary)">
+                  {settings.credentialRevision ?? 'Not issued'}
+                </span>
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  disabled={busy}
+                  onClick={() => (settings.credentialRevision ? setRotating(true) : void issue())}
+                >
+                  {settings.credentialRevision ? 'Rotate' : 'Issue'}
+                </Button>
+              </div>
+            </>
+          )}
+
+          {error && !disabling && !rotating && (
+            <div
+              role="alert"
+              className="border-t border-(--border-subtle) px-4 py-[13px] font-sans text-[12px] font-normal leading-normal text-(--status-error)"
+            >
+              {error}
+            </div>
+          )}
+        </>
+      )}
+
+      {disabling && (
+        <ConfirmationDialog
+          title="Switch off cluster execution?"
+          confirmLabel="Switch off"
+          busy={busy}
+          busyLabel="Switching off…"
+          error={error}
+          onConfirm={() => void save({ enabled: false })}
+          onClose={() => (busy ? undefined : setDisabling(false))}
+        >
+          The operator removes this organization&apos;s envelope — its namespace, its daemon, and every sandbox in it —
+          and the daemon credential is revoked. Agents placed there stop running until it is switched back on.
+        </ConfirmationDialog>
+      )}
+
+      {rotating && (
+        <ConfirmationDialog
+          title="Rotate the daemon credential?"
+          confirmLabel="Rotate"
+          busy={busy}
+          busyLabel="Rotating…"
+          error={error}
+          onConfirm={() => void issue()}
+          onClose={() => (busy ? undefined : setRotating(false))}
+        >
+          The new key is published before the old one is revoked, and the daemon pod is recreated on it. Turns running
+          at that moment are interrupted; the organization&apos;s agents, sessions, and history are kept.
+        </ConfirmationDialog>
+      )}
+
+      {configuring && settings && (
+        <ConfigureSheet
+          settings={settings}
+          orgId={orgId}
+          onClose={() => setConfiguring(false)}
+          onSaved={async (next) => {
+            setConfiguring(false)
+            await mutate(next, { revalidate: false })
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+/** What the operator says about the envelope — never what the settings row says. */
+function EnvelopeStatus({ status }: { status: ClusterEnvelopeStatusDto | undefined }) {
+  if (!status) return <LoadingState size={20} padding={16} />
+  if (!status.present) {
+    return (
+      <div className="border-t border-(--border-subtle) px-4 py-[15px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+        No envelope in the cluster yet — the operator creates one from the resource that was just applied.
+      </div>
+    )
+  }
+  const shown = status.conditions.filter((condition) => !TRANSIENT.has(condition.type) || condition.status === 'True')
+  const warm = status.pools?.reduce((sum, pool) => sum + pool.warmAvailable, 0)
+  return (
+    <div className="border-t border-(--border-subtle) px-4 py-[15px]">
+      <div className="flex flex-wrap items-center gap-[6px]">
+        {shown.length === 0 ? (
+          <span className="badge bg-(--surface-sunken) text-(--text-tertiary)">No conditions reported</span>
+        ) : (
+          shown.map((condition) => <ConditionBadge key={condition.type} condition={condition} />)
+        )}
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-3 desktop:grid-cols-4">
+        <Stat label="Daemon" value={status.daemon ? (status.daemon.ready ? 'Ready' : 'Not ready') : '—'} />
+        <Stat label="Sandboxes" value={status.sandboxes ? String(status.sandboxes.total) : '—'} />
+        <Stat label="Running" value={status.sandboxes ? String(status.sandboxes.running) : '—'} />
+        <Stat label="Warm" value={warm === undefined ? '—' : String(warm)} />
+      </div>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="eyebrow">{label}</div>
+      <div className="mt-[2px] font-sans text-[13px] font-medium leading-normal">{value}</div>
+    </div>
+  )
+}
+
+/** True is good for a readiness condition and bad for a fault one. */
+function ConditionBadge({ condition }: { condition: ClusterConditionDto }) {
+  const label = CONDITION_LABELS[condition.type] ?? condition.type
+  const fault = condition.type === 'Degraded'
+  const neutral = 'bg-(--surface-sunken) text-(--text-tertiary)'
+  const tone =
+    condition.status === 'Unknown'
+      ? neutral
+      : condition.status === 'True'
+        ? fault
+          ? 'bg-(--status-error-soft) text-(--status-error)'
+          : 'bg-(--status-online-soft) text-(--status-online)'
+        : fault
+          ? neutral
+          : 'bg-(--status-paused-soft) text-(--status-paused)'
+  const detail = [condition.reason, condition.message].filter(Boolean).join(' — ')
+  return (
+    <span className={`badge ${tone}`} title={detail || undefined}>
+      <span aria-hidden="true">{label}</span>
+      <span className="sr-only">
+        {label}: {condition.status}
+        {detail ? `. ${detail}` : ''}
+      </span>
+    </span>
+  )
+}
+
+/** The spec fields the control plane owns. `targetNamespace` and the Secret name
+ *  are fixed at first enable — the CRD marks both immutable — so neither is here. */
+function ConfigureSheet({
+  settings,
+  orgId,
+  onClose,
+  onSaved
+}: {
+  settings: ClusterExecutionSettingsDto
+  orgId: string | undefined
+  onClose: () => void
+  onSaved: (next: ClusterExecutionSettingsDto) => Promise<void>
+}) {
+  const [daemonImage, setDaemonImage] = useState(settings.daemonImage)
+  const [daemonTier, setDaemonTier] = useState(settings.daemonTier)
+  const [runtimeImage, setRuntimeImage] = useState(settings.runtimeImage)
+  const [tiers, setTiers] = useState<ClusterRuntimeTierDto[]>(settings.runtimeTiers)
+  const [maxAgents, setMaxAgents] = useState(String(settings.quota.maxAgents))
+  const [cpu, setCpu] = useState(settings.quota.cpu)
+  const [memory, setMemory] = useState(settings.quota.memory)
+  const [storage, setStorage] = useState(settings.quota.storage)
+  const [egressPolicy, setEgressPolicy] = useState<ClusterEgressPolicy>(settings.egressPolicy)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // The same bounds the CP enforces, so a bad value fails inline, not as a 400.
+  const validation = useMemo(() => {
+    if (!daemonImage.trim() || !runtimeImage.trim()) return 'Both images are required.'
+    if (!daemonTier.trim()) return 'The daemon tier is required.'
+    if (tiers.length < 1) return 'At least one runtime tier is required.'
+    if (tiers.some((tier) => !tier.name.trim())) return 'Every runtime tier needs a name.'
+    if (!/^\d+$/.test(maxAgents.trim())) return 'Max agents must be a whole number — 0 means unlimited.'
+    return null
+  }, [daemonImage, daemonTier, runtimeImage, tiers, maxAgents])
+
+  const submit = async () => {
+    if (busy || validation) return
+    setBusy(true)
+    setError(null)
+    try {
+      const next = await updateClusterExecution(
+        {
+          daemonImage: daemonImage.trim(),
+          daemonTier: daemonTier.trim(),
+          runtimeImage: runtimeImage.trim(),
+          runtimeTiers: tiers.map((tier) => ({ name: tier.name.trim(), warmReplicas: tier.warmReplicas })),
+          quota: {
+            maxAgents: Number(maxAgents.trim()),
+            cpu: cpu.trim(),
+            memory: memory.trim(),
+            storage: storage.trim()
+          },
+          egressPolicy
+        },
+        orgId
+      )
+      await onSaved(next)
+    } catch (err) {
+      setError(errorMessage(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="scrim" onClick={() => (busy ? undefined : onClose())}>
+      <div className="modal" role="dialog" aria-modal="true" onClick={(event) => event.stopPropagation()}>
+        <div className="modalhead">
+          <span className="cardtitle">Configure cluster execution</span>
+        </div>
+        <div className="modalbody flex flex-col gap-[18px]">
+          <div className="grid grid-cols-1 gap-3 desktop:grid-cols-2">
+            <Field label="Daemon image">
+              <input className={INPUT} value={daemonImage} onChange={(event) => setDaemonImage(event.target.value)} />
+            </Field>
+            <Field label="Daemon tier">
+              <input className={INPUT} value={daemonTier} onChange={(event) => setDaemonTier(event.target.value)} />
+            </Field>
+            <Field label="Runtime image" wide>
+              <input className={INPUT} value={runtimeImage} onChange={(event) => setRuntimeImage(event.target.value)} />
+            </Field>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <span className={LABEL}>Runtime tiers</span>
+            <span className={HELP}>A tier is a sandbox size and how many of it the operator keeps warm.</span>
+            {tiers.map((tier, index) => (
+              <div key={index} className="flex items-center gap-2">
+                <input
+                  className={INPUT}
+                  value={tier.name}
+                  aria-label={`Runtime tier ${index + 1} name`}
+                  onChange={(event) =>
+                    setTiers(tiers.map((row, i) => (i === index ? { ...row, name: event.target.value } : row)))
+                  }
+                />
+                <input
+                  className={`${INPUT} w-[92px] flex-none`}
+                  type="number"
+                  min={0}
+                  value={String(tier.warmReplicas)}
+                  aria-label={`Runtime tier ${index + 1} warm replicas`}
+                  onChange={(event) =>
+                    setTiers(
+                      tiers.map((row, i) =>
+                        i === index ? { ...row, warmReplicas: Math.max(0, Number(event.target.value)) } : row
+                      )
+                    )
+                  }
+                />
+                <button
+                  type="button"
+                  className="iconbtn flex-none"
+                  aria-label={`Remove runtime tier ${index + 1}`}
+                  title="Remove tier"
+                  disabled={tiers.length <= 1}
+                  onClick={() => setTiers(tiers.filter((_, i) => i !== index))}
+                >
+                  <Icon name="trash-2" size={14} />
+                </button>
+              </div>
+            ))}
+            {tiers.length < MAX_TIERS && (
+              <div>
+                <Button variant="ghost" size="xs" onClick={() => setTiers([...tiers, { name: '', warmReplicas: 0 }])}>
+                  <Icon name="plus" size={14} />
+                  Add tier
+                </Button>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <div className="grid grid-cols-1 gap-3 desktop:grid-cols-2">
+              <Field label="Max agents">
+                <input className={INPUT} value={maxAgents} onChange={(event) => setMaxAgents(event.target.value)} />
+              </Field>
+              <Field label="CPU">
+                <input className={INPUT} value={cpu} onChange={(event) => setCpu(event.target.value)} />
+              </Field>
+              <Field label="Memory">
+                <input className={INPUT} value={memory} onChange={(event) => setMemory(event.target.value)} />
+              </Field>
+              <Field label="Storage">
+                <input className={INPUT} value={storage} onChange={(event) => setStorage(event.target.value)} />
+              </Field>
+            </div>
+            <span className={HELP}>Quotas are Kubernetes quantities, and zero means unlimited.</span>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <span className={LABEL}>Sandbox egress</span>
+            <div className="pillbar" role="radiogroup" aria-label="Sandbox egress">
+              {EGRESS_POLICIES.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={egressPolicy === option.value}
+                  className={egressPolicy === option.value ? 'pill on' : 'pill'}
+                  title={option.detail}
+                  onClick={() => setEgressPolicy(option.value)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {(error ?? validation) && (
+            <div role="alert" className="font-sans text-[12px] font-normal leading-normal text-(--status-error)">
+              {error ?? validation}
+            </div>
+          )}
+        </div>
+        <div className="modalfoot">
+          <Button variant="ghost" onClick={() => (busy ? undefined : onClose())}>
+            Cancel
+          </Button>
+          <Button disabled={busy || Boolean(validation)} onClick={() => void submit()}>
+            {busy ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, wide = false, children }: { label: string; wide?: boolean; children: ReactNode }) {
+  return (
+    <label className={wide ? 'flex flex-col gap-[6px] desktop:col-span-2' : 'flex flex-col gap-[6px]'}>
+      <span className={LABEL}>{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/packages/web/src/components/console/ClusterExecutionCard.tsx
+++ b/packages/web/src/components/console/ClusterExecutionCard.tsx
@@ -94,7 +94,7 @@ export function ClusterExecutionCard({ orgId, isOwner }: { orgId: string | undef
   } = useSWR<ClusterExecutionSettingsDto>(key, ([, id]) => fetchClusterExecution(id as string))
   // Status exists only once a resource does, and it is the operator's to answer.
   const statusKey = settings?.enabled ? consoleKeys.clusterExecutionStatus(orgId) : null
-  const { data: status } = useSWR<ClusterEnvelopeStatusDto>(
+  const { data: status, error: statusError } = useSWR<ClusterEnvelopeStatusDto>(
     statusKey,
     ([, id]) => fetchClusterExecutionStatus(id as string),
     { refreshInterval: STATUS_REFRESH_MS }
@@ -205,7 +205,7 @@ export function ClusterExecutionCard({ orgId, isOwner }: { orgId: string | undef
                 />
               </div>
 
-              <EnvelopeStatus status={status} />
+              <EnvelopeStatus status={status} error={statusError} />
 
               <div className={`${ROW} border-t border-(--border-subtle)`}>
                 <div className="min-w-0 flex-1">
@@ -286,33 +286,54 @@ export function ClusterExecutionCard({ orgId, isOwner }: { orgId: string | undef
   )
 }
 
-/** What the operator says about the envelope — never what the settings row says. */
-function EnvelopeStatus({ status }: { status: ClusterEnvelopeStatusDto | undefined }) {
-  if (!status) return <LoadingState size={20} padding={16} />
-  if (!status.present) {
+/**
+ * What the operator says about the envelope — never what the settings row says.
+ * Because this panel IS the live read, a failed one is never rendered as
+ * loading, and a snapshot SWR retained across a failure is never rendered as
+ * current: a stale `Ready` with nothing marking it is the one wrong answer here.
+ */
+function EnvelopeStatus({ status, error }: { status: ClusterEnvelopeStatusDto | undefined; error: unknown }) {
+  if (error && !status) {
     return (
-      <div className="border-t border-(--border-subtle) px-4 py-[15px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-        No envelope in the cluster yet — the operator creates one from the resource that was just applied.
+      <div className="border-t border-(--border-subtle) px-4 py-[15px] font-sans text-[12.5px] font-normal leading-normal text-(--status-error)">
+        Couldn&apos;t read the envelope status from the cluster.
       </div>
     )
   }
+  if (!status) return <LoadingState size={20} padding={16} />
   const shown = status.conditions.filter((condition) => !TRANSIENT.has(condition.type) || condition.status === 'True')
   const warm = status.pools?.reduce((sum, pool) => sum + pool.warmAvailable, 0)
   return (
     <div className="border-t border-(--border-subtle) px-4 py-[15px]">
-      <div className="flex flex-wrap items-center gap-[6px]">
-        {shown.length === 0 ? (
-          <span className="badge bg-(--surface-sunken) text-(--text-tertiary)">No conditions reported</span>
-        ) : (
-          shown.map((condition) => <ConditionBadge key={condition.type} condition={condition} />)
-        )}
-      </div>
-      <div className="mt-3 grid grid-cols-2 gap-3 desktop:grid-cols-4">
-        <Stat label="Daemon" value={status.daemon ? (status.daemon.ready ? 'Ready' : 'Not ready') : '—'} />
-        <Stat label="Sandboxes" value={status.sandboxes ? String(status.sandboxes.total) : '—'} />
-        <Stat label="Running" value={status.sandboxes ? String(status.sandboxes.running) : '—'} />
-        <Stat label="Warm" value={warm === undefined ? '—' : String(warm)} />
-      </div>
+      {Boolean(error) && (
+        <div
+          role="status"
+          className="mb-[10px] font-sans text-[11.5px] font-normal leading-[1.45] text-(--status-paused)"
+        >
+          The cluster read is failing — this is the last status it answered, not the current one.
+        </div>
+      )}
+      {!status.present ? (
+        <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+          No envelope in the cluster yet — the operator creates one from the resource that was just applied.
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-[6px]">
+            {shown.length === 0 ? (
+              <span className="badge bg-(--surface-sunken) text-(--text-tertiary)">No conditions reported</span>
+            ) : (
+              shown.map((condition) => <ConditionBadge key={condition.type} condition={condition} />)
+            )}
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-3 desktop:grid-cols-4">
+            <Stat label="Daemon" value={status.daemon ? (status.daemon.ready ? 'Ready' : 'Not ready') : '—'} />
+            <Stat label="Sandboxes" value={status.sandboxes ? String(status.sandboxes.total) : '—'} />
+            <Stat label="Running" value={status.sandboxes ? String(status.sandboxes.running) : '—'} />
+            <Stat label="Warm" value={warm === undefined ? '—' : String(warm)} />
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/packages/web/src/components/console/GlobalSearch.test.tsx
+++ b/packages/web/src/components/console/GlobalSearch.test.tsx
@@ -15,11 +15,26 @@ vi.mock('@/lib/org-context', () => ({
 // GlobalSearch reads the three session-access states through SWR to decide
 // whether the Session access card would render at all.
 const sessionAccess = vi.fn(() => ({ available: true, enabled: false }))
+// …and the cluster-execution settings read, to decide the same for that card.
+const clusterExecution = vi.fn<() => { data?: unknown; error?: unknown }>(() => ({ data: {} }))
 vi.mock('swr', () => ({
-  default: (key: unknown) => ({ data: key ? sessionAccess() : undefined })
+  default: (key: unknown) => {
+    if (!key) return { data: undefined }
+    if (Array.isArray(key) && key[2] === 'cluster-execution') return clusterExecution()
+    return { data: sessionAccess() }
+  }
 }))
 vi.mock('@/lib/api', () => ({
-  fetchSessionExternalAccess: vi.fn()
+  fetchSessionExternalAccess: vi.fn(),
+  fetchClusterExecution: vi.fn(),
+  ApiError: class ApiError extends Error {
+    constructor(
+      message: string,
+      readonly status: number
+    ) {
+      super(message)
+    }
+  }
 }))
 vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({ agents: [], daemons: [], crons: [], allSessions: [] })
@@ -35,6 +50,7 @@ vi.mock('@/components/marks', () => ({
   AgentIconView: () => <span data-agent-icon />
 }))
 
+import { ApiError } from '@/lib/api'
 import { GlobalSearch } from './GlobalSearch'
 import { NAV_GROUPS, SEARCH_PAGES } from './nav'
 
@@ -46,6 +62,7 @@ beforeEach(() => {
   authConfigured.mockReturnValue(true)
   myRole.mockReturnValue('owner')
   sessionAccess.mockReturnValue({ available: true, enabled: false })
+  clusterExecution.mockReturnValue({ data: {} })
   host = document.createElement('div')
   document.body.appendChild(host)
   root = createRoot(host)
@@ -163,6 +180,25 @@ describe('GlobalSearch pages & settings', () => {
     sessionAccess.mockReturnValue({ available: false, enabled: false })
     type('session acces')
     type('session access')
+    expect(host.textContent).toContain('No results')
+  })
+
+  it('hides the Cluster execution entry once the deployment is KNOWN to run no cluster', () => {
+    render()
+    type('cluster execution')
+    expect(host.textContent).toContain('/settings#cluster-execution')
+
+    // A read that merely failed keeps the entry — the card renders then too.
+    clusterExecution.mockReturnValue({ data: undefined, error: new Error('offline') })
+    type('cluster executio')
+    type('cluster execution')
+    expect(host.textContent).toContain('/settings#cluster-execution')
+
+    // A 404 is the deployment saying it mounts no cluster routes at all, which
+    // is what makes the card render nothing and the anchor not exist.
+    clusterExecution.mockReturnValue({ data: undefined, error: new ApiError('not found', 404) })
+    type('cluster executio')
+    type('cluster execution')
     expect(host.textContent).toContain('No results')
   })
 

--- a/packages/web/src/components/console/GlobalSearch.test.tsx
+++ b/packages/web/src/components/console/GlobalSearch.test.tsx
@@ -96,6 +96,7 @@ describe('SEARCH_PAGES index', () => {
       '/settings#agent-visibility',
       '/settings#session-access',
       '/settings#environment',
+      '/settings#cluster-execution',
       '/settings#members',
       '/settings#invite-links',
       '/profile'

--- a/packages/web/src/components/console/GlobalSearch.tsx
+++ b/packages/web/src/components/console/GlobalSearch.tsx
@@ -19,7 +19,7 @@ import { useOrgs } from '@/lib/org-context'
 import { agentLabel, effectiveAgentStatus, presentedDaemonStatus, status } from '@/lib/data'
 import { cronHuman } from '@/lib/cron'
 import { isAuthConfigured } from '@/lib/auth'
-import { fetchSessionExternalAccess, type SessionAccessProvider } from '@/lib/api'
+import { ApiError, fetchClusterExecution, fetchSessionExternalAccess, type SessionAccessProvider } from '@/lib/api'
 import { consoleKeys } from '@/lib/swr-keys'
 import { Icon } from '@/components/ui'
 import { AgentIconView } from '@/components/marks'
@@ -122,6 +122,14 @@ export function GlobalSearch({
     ({ data }) => data === undefined || data.available || data.enabled
   )
 
+  // Same shape for Cluster execution: a deployment that runs no cluster mounts
+  // none of its routes, so the card renders nothing there. Only a KNOWN 404
+  // hides the entry — a pending or transiently failing read keeps it, as the
+  // card also renders then.
+  const clusterKey = open && authed && myRole === 'owner' ? consoleKeys.clusterExecution(activeOrg?.id) : null
+  const { error: clusterError } = useSWR(clusterKey, ([, scopedOrgId]) => fetchClusterExecution(scopedOrgId))
+  const clusterExecutionRenders = !(clusterError instanceof ApiError && clusterError.status === 404)
+
   const groups = useMemo<SearchGroup[]>(() => {
     // `hit('')` matches everything, so an empty query yields every entity. That's
     // deliberate: the chip COUNTS use it (a filter row you can see before typing,
@@ -215,6 +223,7 @@ export function GlobalSearch({
             p.kind === 'setting' &&
             (!p.ownerOnly || myRole === 'owner') &&
             (p.href !== '/settings#session-access' || sessionAccessRenders) &&
+            (p.href !== '/settings#cluster-execution' || clusterExecutionRenders) &&
             pageHit(p)
         )
       : []
@@ -239,7 +248,20 @@ export function GlobalSearch({
         items: settingMatches.slice(0, CAP).map(toItem)
       }
     ]
-  }, [query, agents, daemons, crons, allSessions, daemonById, agentById, orgPath, authed, myRole, sessionAccessRenders])
+  }, [
+    query,
+    agents,
+    daemons,
+    crons,
+    allSessions,
+    daemonById,
+    agentById,
+    orgPath,
+    authed,
+    myRole,
+    sessionAccessRenders,
+    clusterExecutionRenders
+  ])
 
   const totalCount = useMemo(() => groups.reduce((n, g) => n + g.count, 0), [groups])
   // Chips: "All" + every kind with at least one match.

--- a/packages/web/src/components/console/nav.ts
+++ b/packages/web/src/components/console/nav.ts
@@ -118,6 +118,14 @@ const SETTING_CARDS: ConsolePage[] = [
     ownerOnly: true
   },
   {
+    href: '/settings#cluster-execution',
+    label: 'Cluster execution',
+    icon: 'boxes',
+    kind: 'setting',
+    keywords: ['settings', 'kubernetes', 'envelope', 'sandbox'],
+    ownerOnly: true
+  },
+  {
     href: '/settings#members',
     label: 'Members & roles',
     icon: 'users',

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -43,6 +43,7 @@ import { inviteLinkStatus, inviteLinkUrl } from '@/lib/org-invite-link'
 import EditMemberModal, { type MemberTarget } from '@/components/console/modals/EditMemberModal'
 import InviteMembersModal from '@/components/console/modals/InviteMembersModal'
 import { OrganizationEnvironmentCard } from '@/components/console/OrganizationEnvironmentCard'
+import { ClusterExecutionCard } from '@/components/console/ClusterExecutionCard'
 
 // A session-access row is a platform name and its switch. What the switch does is
 // said once, in the card header — restating it per row ("People with Slack access"
@@ -726,6 +727,10 @@ export default function SettingsView() {
       {/* Sits with the other organization-wide agent policies. Owner-only, so the
           card renders nothing at all for collaborators and viewers (§8.1). */}
       <OrganizationEnvironmentCard orgId={activeOrg?.id} isOwner={isOwner} agents={agents} />
+
+      {/* Owner-only, and absent entirely where the deployment runs no cluster —
+          the whole surface 404s there, so the card renders nothing at all. */}
+      <ClusterExecutionCard orgId={activeOrg?.id} isOwner={isOwner} />
 
       <div className="card mt-[18px]" id="members">
         <div className="cardhead justify-between">

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2227,6 +2227,105 @@ export function putSessionExternalAccess(
   return apiPut<SessionExternalAccessDto>(`${orgBase(orgId)}/session-access/${provider}`, { enabled })
 }
 
+// ── managed cluster execution (docs/designs/agentconnect-org-operator.md) ───
+// The control plane owns the envelope SPEC and the operator owns everything
+// after it, so settings are read and written here while status is read live
+// from the `AgentConnectOrg` resource — the two never come from the same place.
+// A deployment with no cluster configured mounts none of these routes, so every
+// call below 404s there and the console reads that as an absent feature.
+
+export type ClusterEgressPolicy = 'locked' | 'curated' | 'open'
+
+export interface ClusterRuntimeTierDto {
+  name: string
+  warmReplicas: number
+}
+
+export interface ClusterQuotaDto {
+  maxAgents: number
+  cpu: string
+  memory: string
+  storage: string
+}
+
+export interface ClusterExecutionSettingsDto {
+  enabled: boolean
+  /** Derived once at first enable; immutable afterwards, like the Secret name. */
+  targetNamespace: string
+  controlNamespace: string
+  suspend: boolean
+  daemonImage: string
+  daemonTier: string
+  credentialSecretName: string
+  /** Opaque handle for the published credential; absent until one is issued. */
+  credentialRevision?: string
+  runtimeImage: string
+  runtimeTiers: ClusterRuntimeTierDto[]
+  quota: ClusterQuotaDto
+  egressPolicy: ClusterEgressPolicy
+  updatedAt: string
+}
+
+export interface UpdateClusterExecutionBody {
+  enabled?: boolean
+  suspend?: boolean
+  daemonImage?: string
+  daemonTier?: string
+  runtimeImage?: string
+  runtimeTiers?: ClusterRuntimeTierDto[]
+  quota?: Partial<ClusterQuotaDto>
+  egressPolicy?: ClusterEgressPolicy
+}
+
+export interface ClusterConditionDto {
+  type: string
+  status: 'True' | 'False' | 'Unknown'
+  reason?: string
+  message?: string
+  lastTransitionTime?: string
+}
+
+export interface ClusterEnvelopeStatusDto {
+  /** False ⇒ no resource exists yet; the operator has not been asked for one. */
+  present: boolean
+  observedGeneration?: number
+  namespace?: string
+  conditions: ClusterConditionDto[]
+  daemon?: { ready: boolean; image?: string }
+  sandboxes?: { total: number; running: number; suspended: number }
+  pools?: { name: string; warmAvailable: number; claimed: number }[]
+  rollout?: { rolloutId: string; targetImage: string; pending: string[]; failed: string[] }
+}
+
+/** What issuing a credential answers with — the key never leaves the cluster. */
+export interface ClusterCredentialDto {
+  daemonId: string
+  secretName: string
+  revision: string
+  rotated: boolean
+}
+
+export function fetchClusterExecution(orgId?: string): Promise<ClusterExecutionSettingsDto> {
+  return apiGet<ClusterExecutionSettingsDto>(`${orgBase(orgId)}/cluster-execution`)
+}
+
+export function updateClusterExecution(
+  patch: UpdateClusterExecutionBody,
+  orgId?: string
+): Promise<ClusterExecutionSettingsDto> {
+  return apiPut<ClusterExecutionSettingsDto>(`${orgBase(orgId)}/cluster-execution`, patch)
+}
+
+export function fetchClusterExecutionStatus(orgId?: string): Promise<ClusterEnvelopeStatusDto> {
+  return apiGet<ClusterEnvelopeStatusDto>(`${orgBase(orgId)}/cluster-execution/status`)
+}
+
+/** Mint or rotate the envelope's daemon credential. The key is published into a
+ *  cluster Secret and is never returned, so there is nothing here to display. */
+export function issueClusterExecutionCredential(orgId?: string): Promise<ClusterCredentialDto> {
+  return apiPost<ClusterCredentialDto>(`${orgBase(orgId)}/cluster-execution/credential`, {})
+}
+
 // One page of a session's transcript, proxied live from the daemon recorded on
 // SessionMeta. Content ownership stays pinned there when the agent moves.
 export async function fetchSessionMessages(

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -20,6 +20,10 @@ export const consoleKeys = {
   managedSkills: (orgId: string | null | undefined, includeArchived: boolean) =>
     consoleKey(orgId, 'managed-skills', includeArchived ? 'include-archived' : 'active'),
   organizationEnvironment: (orgId: string | null | undefined) => consoleKey(orgId, 'organization-environment'),
+  /** The org's managed-execution envelope: settings from the row, status from the
+   *  cluster. Separate keys because they have different owners and lifetimes. */
+  clusterExecution: (orgId: string | null | undefined) => consoleKey(orgId, 'cluster-execution'),
+  clusterExecutionStatus: (orgId: string | null | undefined) => consoleKey(orgId, 'cluster-execution-status'),
   /** The install wizard's deployment-capability probe (`GET /slack/config`) —
    *  Slack-NAMED but answered per organization AND per caller, so it is
    *  org-scoped like every other row here. */


### PR DESCRIPTION
Follows #876 (the provisioner) and #881 (the key authority). Both landed a complete control-plane surface for the org's managed-execution envelope — and nothing in the console could see or touch any of it. This is the owner-facing half.

## Two owners, two reads

The card never presents a stored field as cluster truth. Settings come from `GET /orgs/:orgId/cluster-execution` (the row the control plane owns); status comes from `GET .../status`, which is read live off the `AgentConnectOrg` resource and never served from the database. So the operator's conditions, the daemon/sandbox/warm-pool summary, and the spec form are three separate things with three separate owners, and the card says which is which.

Conditions render as chips, with `reason`/`message` as hover copy and full sentences for screen readers. `Progressing` and `Degraded` appear **only while true** — a steady envelope is neither, and a permanent grey "Degraded: False" chip is noise that trains people to stop reading the row.

## The credential

`POST .../credential` mints or rotates the org's daemon key. It publishes the key into a cluster Secret and answers with `{daemonId, secretName, revision, rotated}` — **the key itself is never returned**, so the card shows the revision handle and says where the key lives. There is no reveal and no copy button, because there is nothing to copy.

Rotating confirms first: a rotation recreates the daemon pod, so turns running at that moment are interrupted. Switching cluster execution off confirms too, and describes the actual effect — the envelope, its namespace, and every sandbox in it are removed and the credential is revoked.

## Absent, not broken

A deployment with no cluster configured mounts none of these routes, so every call 404s there. That is an absent feature rather than an error, and the card renders **nothing at all** — the same judgement the session-access rows make about a provider the deployment cannot offer. It is owner-only besides, like every other write on this page.

## Where it lives

A card on `/settings`, not a new nav route: a top-level destination that is empty for most deployments is worse than a card that knows to disappear. Registered in `SETTING_CARDS` so global search can reach it.

Follows `packages/web/STYLE.md` throughout (token var-shorthand, the single `desktop:` breakpoint, `font:`-shorthand decomposition, semantic `card`/`badge`/`modal` classes), and renders one responsive tree rather than an `isMobile` fork.

## Tests

`ClusterExecutionCard.test.tsx` — renders nothing on a 404 and nothing for a non-owner; shows the operator's conditions and leaves a false `Degraded` out; offers `Issue` before a credential exists and `Rotate` after, with the rotation gated behind confirmation; and reads an absent resource as "not there yet" rather than as unhealthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
