### PR TITLE
fix(daemon): surface external tool failures

### DIFF
--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -844,8 +844,11 @@ export class SessionManager {
       `visible \`sendMessage\` lands at a channel root and opens a new conversation there.\n` +
       `- Act only on what is asked of YOU. Do not relay a message onward or start your own broadcast to other ` +
       `agents unless a human explicitly tells you to.\n` +
-      `- Be quiet about mechanics: don't narrate each step or post a message per action, and don't restate tool ` +
-      `results like "delivered: true". Take the action, add at most one short status line if needed, then end your turn.\n` +
+      `- Be quiet about successful mechanics: don't narrate each step or post a message per action, and don't restate ` +
+      `successful tool results like "delivered: true". For a requested operation that fails or returns a structured ` +
+      `error, say what failed, include a safe provider error code when available, and give the next actionable step. ` +
+      `Treat an explicit error marker as failure even if a wrapper command exits 0. Never expose credentials, tokens, ` +
+      `or raw secret-bearing output. Take the action, add at most one short status line if needed, then end your turn.\n` +
       `- When another agent introduces itself to you, record it in your memory (a peer roster — id, name, what it ` +
       `does, how to reach it) so you know who to delegate to later. Then just acknowledge briefly; do NOT re-introduce ` +
       `yourself back or broadcast to everyone.`

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -1929,7 +1929,8 @@ describe('SessionManager — collaboration preamble', () => {
     expect(first).not.toContain('`to.toAgent`')
     expect(first).not.toContain('`to.sessionId`')
     expect(first).not.toContain('`messageAgent`')
-    expect(first).toContain('Be quiet about mechanics') // conciseness guidance
+    expect(first).toContain('Be quiet about successful mechanics') // conciseness guidance
+    expect(first).toContain('For a requested operation that fails or returns a structured error') // surface failures
     expect(first).toContain('introduces itself to you') // record-newcomer-in-memory guidance
     store.close()
   })


### PR DESCRIPTION
## Summary

- Keep successful tool activity concise without hiding failures.
- Require agents to report requested-operation failures with a safe provider error code and next action.
- Treat structured error markers as failures even when a wrapper command exits successfully, without exposing credentials or raw secret-bearing output.

## Root cause

The affected turn converted Slack's `account_inactive` response into ordinary command output with exit code 0. The standing prompt told the agent not to restate tool results but did not require explicit reporting of failed operations, so the user received only a generic channel-history limitation.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/session-manager.test.ts -t "collaboration preamble"`
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec prettier --check packages/daemon/src/session/session-manager.ts packages/daemon/test/session-manager.test.ts`
- Pre-push `eslint .` passed with two existing warnings in `packages/daemon/test/workspace-git-write.test.ts`.

Created by Codex . GPT-5
