### PR TITLE
fix(operator-chart): stop the envelope fence denying every cluster-scoped write

### DIFF
--- a/charts/operator/templates/validating-admission-policies.yaml
+++ b/charts/operator/templates/validating-admission-policies.yaml
@@ -29,10 +29,16 @@ spec:
     # Its own control-namespace objects: the CRs it reconciles and its election Lease.
     - name: exclude-own-control-objects
       expression: >-
-        !(request.namespace == '{{ .Release.Namespace }}' && ((request.resource.group == 'agentconnect.md' &&
+        !(has(request.namespace) && request.namespace == '{{ .Release.Namespace }}' &&
+        ((request.resource.group == 'agentconnect.md' &&
         request.resource.resource == 'agentconnectorgs') || (request.resource.group == 'coordination.k8s.io' &&
         request.resource.resource == 'leases')))
   variables:
+    # A cluster-scoped request carries no `namespace` key at all, and reading an absent key is a
+    # CEL error this fail-closed policy turns into a denial — which would hit the per-org
+    # TokenReview binding, the one cluster-scoped write the fence exists to permit.
+    - name: ns
+      expression: "has(request.namespace) ? request.namespace : ''"
     - name: isNamespace
       expression: request.resource.group == '' && request.resource.resource == 'namespaces'
     # DELETE carries the object in oldObject; CREATE/UPDATE in object.
@@ -44,19 +50,19 @@ spec:
     - name: oldLabels
       expression: 'oldObject == null ? {} : (has(oldObject.metadata.labels) ? oldObject.metadata.labels : {})'
   validations:
-    - expression: request.namespace == '' || request.namespace.startsWith('{{ $prefix }}')
+    - expression: variables.ns == '' || variables.ns.startsWith('{{ $prefix }}')
       message: this install's operator may only write into namespaces carrying its org namespace prefix
       reason: Forbidden
     # Cross-install guard: another environment's control namespace is never a write target,
     # even if a misconfigured prefix would otherwise match it.
     - expression: >-
-        request.namespace == '' || variables.isNamespace ||
+        variables.ns == '' || variables.isNamespace ||
         !('agentconnect.md/control-namespace' in (has(namespaceObject.metadata.labels) ?
         namespaceObject.metadata.labels : {}))
       message: this install's operator may not write into a namespace marked as a control namespace
       reason: Forbidden
     # The same guard for the Namespace object itself: it is cluster-scoped, so it carries no
-    # namespaceObject and an empty request.namespace, and the check above never sees it. Both
+    # namespaceObject and an empty variables.ns, and the check above never sees it. Both
     # sides are tested — oldObject so a marked namespace can be neither deleted nor stripped of
     # its marker, object so a marked one cannot be created and later written into.
     - expression: >-
@@ -79,7 +85,7 @@ spec:
     # The only cluster-scoped object the envelope owns besides the namespace is the per-org
     # TokenReview binding (`ac-tokenreview-<targetNamespace>`, packages/operator/src/reconcile/resources.ts).
     - expression: >-
-        request.namespace != '' || variables.isNamespace || (request.resource.group == 'rbac.authorization.k8s.io' &&
+        variables.ns != '' || variables.isNamespace || (request.resource.group == 'rbac.authorization.k8s.io' &&
         request.resource.resource == 'clusterrolebindings' &&
         variables.target.metadata.name.startsWith('ac-tokenreview-{{ $prefix }}'))
       message: the only cluster-scoped objects this install's operator may write are its org namespaces and their TokenReview bindings


### PR DESCRIPTION
Found by the first install of this chart on a real cluster.

## The bug

The envelope fence's validations were written as `request.namespace == '' || …`, on the assumption that a cluster-scoped request reports an empty namespace. It does not — the `namespace` key is **absent** from the admission request, and reading an absent key is a CEL evaluation error. Both policies are fail-closed, so the error became a denial:

```
clusterrolebindings.rbac.authorization.k8s.io "ac-tokenreview-<ns>" is forbidden:
ValidatingAdmissionPolicy 'ac-envelope-fence' denied request:
expression 'request.namespace == '' || request.namespace.startsWith('<prefix>')'
resulted in error: no such key: namespace
```

The denied object is the per-org TokenReview ClusterRoleBinding — precisely the cluster-scoped write the fence exists to allow. Every envelope stalled three objects in (ServiceAccounts and the daemon Role/RoleBinding land, then nothing), the reconcile threw before `writeStatus`, so the CR carried no conditions at all and the failure was visible only in operator logs.

## The fix

A `ns` variable guards the key once, and the three validations read it:

```yaml
- name: ns
  expression: "has(request.namespace) ? request.namespace : ''"
```

The `exclude-own-control-objects` matchCondition gets an inline `has()` guard too. It was not failing in practice, but only because CEL absorbs `error && false` into `false` — its safety depended on the resource groups in the other conjunct, not on anything the expression states. A cluster-scoped write of one of those resources would have flipped it to a denial.

The sandbox-baseline policy is untouched: its matchConstraints are `scope: Namespaced` on pods, so its `request.namespace` always exists.

## Verification

On a real 1.30+ API server:

- Both policies report `status.typeChecking: {}` — zero type-check warnings. (This also closes the caveat left in #874, where the CEL had never been compiled by an API server.)
- Before: envelope stuck at 3 objects, CR status empty.
- After: the full inventory provisions — both ServiceAccounts, Role/RoleBinding, the TokenReview ClusterRoleBinding, both daemon NetworkPolicies, the state PVC, the shim Service, the daemon Deployment, and the per-tier SandboxTemplate/SandboxWarmPool stamped from the master — and the CR publishes `status.namespace` with the full condition set.
- `helm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)