### PR TITLE
feat(operator): give the daemon state PVC an install-level storage class and size

### DIFF
--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -98,6 +98,26 @@ them forward (`keep` only holds them back from an uninstall). A release that
 moves the stored API version is the exception: upstream ships a storage
 migration for it, and skipping that is how CRs become unreadable.
 
+## Daemon state volume
+
+Every org envelope carries one `ReadWriteOncePod` PVC for its daemon's
+transcripts and local state, provisioned from `daemonStorage`:
+
+```yaml
+daemonStorage:
+  className: '' # empty = the cluster default StorageClass
+  size: 10Gi
+```
+
+Leave `className` empty only when the cluster default is a cluster-wide
+(network-attached) class. A node-local default provisioner binds a volume to
+whichever node has a path for it, so the claim fails wherever the scheduler
+places the daemon — the pod then never starts, with the PVC stuck `Pending`.
+
+Both settings apply when the claim is created. Kubernetes rejects a class change
+on an existing PVC, so changing them moves new orgs only; an org already
+provisioned keeps its volume until that volume is deleted.
+
 ## Install
 
 ```bash

--- a/charts/operator/templates/operator-deployment.yaml
+++ b/charts/operator/templates/operator-deployment.yaml
@@ -30,6 +30,13 @@ spec:
               value: {{ .Release.Name }}-ac-tokenreview
             - name: AC_MASTER_TEMPLATE_PREFIX
               value: {{ .Values.masterTemplatePrefix | quote }}
+            {{- /* Unset when empty: the operator then leaves the daemon PVC on the cluster default class. */}}
+            {{- with .Values.daemonStorage.className }}
+            - name: AC_DAEMON_STORAGE_CLASS
+              value: {{ . | quote }}
+            {{- end }}
+            - name: AC_DAEMON_STORAGE_SIZE
+              value: {{ .Values.daemonStorage.size | quote }}
             - name: AC_RESYNC_INTERVAL_SECONDS
               value: {{ .Values.operator.resyncIntervalSeconds | quote }}
             - name: AC_LEASE_NAME

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -13,6 +13,18 @@ orgNamespacePrefix: ac-org-
 # the operator stamps a per-org copy for every tier in spec.runtime.tiers.
 masterTemplatePrefix: ac-runtime-
 
+# The per-org daemon state volume (transcripts + local state). Both settings are
+# properties of the cluster, not of an org, and both apply when the claim is
+# first created: Kubernetes rejects a class change on an existing PVC, so an
+# org already provisioned keeps its volume until that volume is deleted.
+daemonStorage:
+  # StorageClass for the claim. Empty leaves it off, so the cluster default
+  # applies. Set it when that default is a node-local provisioner: such a class
+  # only binds where it has a path, so the claim fails wherever the scheduler
+  # puts the daemon and the pod never starts. Name a cluster-wide class instead.
+  className: ''
+  size: 10Gi
+
 operator:
   image:
     repository: ghcr.io/agentconnect-md/operator

--- a/packages/operator/src/config.test.ts
+++ b/packages/operator/src/config.test.ts
@@ -9,6 +9,8 @@ describe('loadConfig', () => {
     expect(config.orgNamespacePrefix).toBe('test-ac-org-')
     expect(config.tokenreviewClusterRole).toBe('test-ac-tokenreview')
     expect(config.masterTemplatePrefix).toBe('ac-runtime-')
+    expect(config.daemonStorageClass).toBeUndefined()
+    expect(config.daemonStorageSize).toBe('10Gi')
     expect(config.resyncIntervalMs).toBe(600_000)
     expect(config.leaseName).toBe('agentconnect-operator')
     expect(config.watchTimeoutSeconds).toBe(300)
@@ -18,6 +20,11 @@ describe('loadConfig', () => {
     expect(() => loadConfig({})).toThrow(/AC_ORG_NAMESPACE_PREFIX/)
     expect(() => loadConfig({ ...REQUIRED, AC_ORG_NAMESPACE_PREFIX: '' })).toThrow(/AC_ORG_NAMESPACE_PREFIX/)
     expect(() => loadConfig({ AC_ORG_NAMESPACE_PREFIX: 'p-' })).toThrow(/AC_TOKENREVIEW_CLUSTERROLE/)
+  })
+
+  it('reads a blank storage class as unset so the cluster default still applies', () => {
+    expect(loadConfig({ ...REQUIRED, AC_DAEMON_STORAGE_CLASS: '  ' }).daemonStorageClass).toBeUndefined()
+    expect(loadConfig({ ...REQUIRED, AC_DAEMON_STORAGE_CLASS: 'cluster-wide' }).daemonStorageClass).toBe('cluster-wide')
   })
 
   it('coerces numeric overrides', () => {

--- a/packages/operator/src/config.ts
+++ b/packages/operator/src/config.ts
@@ -7,6 +7,8 @@ const EnvSchema = z.object({
     .string()
     .min(1, "AC_TOKENREVIEW_CLUSTERROLE must name this install's tokenreview ClusterRole"),
   AC_MASTER_TEMPLATE_PREFIX: z.string().min(1).default('ac-runtime-'),
+  AC_DAEMON_STORAGE_CLASS: z.string().trim().optional(),
+  AC_DAEMON_STORAGE_SIZE: z.string().trim().min(1).default('10Gi'),
   AC_RESYNC_INTERVAL_SECONDS: z.coerce.number().int().positive().default(600),
   AC_LEASE_NAME: z.string().min(1).default('agentconnect-operator'),
   AC_WATCH_TIMEOUT_SECONDS: z.coerce.number().int().positive().default(300)
@@ -19,6 +21,10 @@ export interface OperatorConfig {
   tokenreviewClusterRole: string
   /** Master SandboxTemplates in the control namespace are named `<prefix><tier>`. */
   masterTemplatePrefix: string
+  /** StorageClass for the daemon state PVC; undefined leaves the claim on the cluster default. */
+  daemonStorageClass?: string
+  /** Requested size of the daemon state PVC. */
+  daemonStorageSize: string
   /** Bounded full-resync interval — the drift-convergence backstop for envelope objects. */
   resyncIntervalMs: number
   leaseName: string
@@ -35,6 +41,9 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): OperatorConfig
     orgNamespacePrefix: parsed.data.AC_ORG_NAMESPACE_PREFIX,
     tokenreviewClusterRole: parsed.data.AC_TOKENREVIEW_CLUSTERROLE,
     masterTemplatePrefix: parsed.data.AC_MASTER_TEMPLATE_PREFIX,
+    // Blank reads as unset: an env rendered from an empty chart value must mean the default, not a class named ''.
+    daemonStorageClass: parsed.data.AC_DAEMON_STORAGE_CLASS || undefined,
+    daemonStorageSize: parsed.data.AC_DAEMON_STORAGE_SIZE,
     resyncIntervalMs: parsed.data.AC_RESYNC_INTERVAL_SECONDS * 1000,
     leaseName: parsed.data.AC_LEASE_NAME,
     watchTimeoutSeconds: parsed.data.AC_WATCH_TIMEOUT_SECONDS

--- a/packages/operator/src/reconcile/envelope.test.ts
+++ b/packages/operator/src/reconcile/envelope.test.ts
@@ -40,13 +40,17 @@ function recorder() {
   return { gets, writes, route }
 }
 
-async function contextFor(route: FakeRoute): Promise<ReconcileContext> {
+async function contextFor(route: FakeRoute, env: NodeJS.ProcessEnv = {}): Promise<ReconcileContext> {
   const { config: cluster } = await fakeApiServer(route)
   const http = new K8sHttp(cluster)
   return {
     http,
     orgApi: new AgentConnectOrgApi(http, cluster.namespace),
-    config: loadConfig({ AC_ORG_NAMESPACE_PREFIX: 'test-ac-org-', AC_TOKENREVIEW_CLUSTERROLE: 'test-ac-tokenreview' }),
+    config: loadConfig({
+      AC_ORG_NAMESPACE_PREFIX: 'test-ac-org-',
+      AC_TOKENREVIEW_CLUSTERROLE: 'test-ac-tokenreview',
+      ...env
+    }),
     controlNamespace: cluster.namespace,
     log: {}
   }
@@ -193,6 +197,34 @@ describe('reconcileEnvelope', () => {
     expect(deployment.spec.replicas).toBe(0)
     const pool = byPath(writes, '/sandboxwarmpools/ac-runtime-std')?.body as { spec: { replicas: number } }
     expect(pool.spec.replicas).toBe(0)
+  })
+
+  it('provisions the daemon state PVC from the install`s storage class and size', async () => {
+    const { gets, writes, route } = recorder()
+    const ctx = await contextFor(route, { AC_DAEMON_STORAGE_CLASS: 'cluster-wide', AC_DAEMON_STORAGE_SIZE: '20Gi' })
+    gets.set(masterPath(ctx.controlNamespace), MASTER_TEMPLATE)
+    await reconcileEnvelope(ctx, inputOf(), newObservations())
+    const pvc = byPath(writes, '/persistentvolumeclaims/ac-daemon-state')?.body as {
+      spec: { storageClassName?: string; resources: { requests: { storage: string } } }
+    }
+    expect(pvc.spec.storageClassName).toBe('cluster-wide')
+    expect(pvc.spec.resources.requests.storage).toBe('20Gi')
+  })
+
+  it.each([
+    ['no class is configured', {}],
+    ['the chart renders the class blank', { AC_DAEMON_STORAGE_CLASS: '' }]
+  ])('leaves the PVC on the cluster default when %s', async (_case, env) => {
+    const { gets, writes, route } = recorder()
+    const ctx = await contextFor(route, env)
+    gets.set(masterPath(ctx.controlNamespace), MASTER_TEMPLATE)
+    await reconcileEnvelope(ctx, inputOf(), newObservations())
+    const pvc = byPath(writes, '/persistentvolumeclaims/ac-daemon-state')?.body as {
+      spec: Record<string, unknown> & { resources: { requests: { storage: string } } }
+    }
+    // Absent, not '': an empty class asks for no provisioner at all instead of the cluster default.
+    expect('storageClassName' in pvc.spec).toBe(false)
+    expect(pvc.spec.resources.requests.storage).toBe('10Gi')
   })
 
   it('renders spec.quota into ResourceQuota hard limits plus a LimitRange', async () => {

--- a/packages/operator/src/reconcile/envelope.ts
+++ b/packages/operator/src/reconcile/envelope.ts
@@ -43,9 +43,6 @@ const DAEMON_TIERS: Record<string, { requests: Record<string, string>; limits: R
   large: { requests: { cpu: '1', memory: '2Gi' }, limits: { memory: '8Gi' } }
 }
 
-/** Default daemon state volume size until the CRD grows a knob for it. */
-const DAEMON_STORAGE = '10Gi'
-
 function envelopeLabels(orgName: string, extra: Record<string, string> = {}): Record<string, string> {
   return { [ORG_LABEL]: orgName, ...extra }
 }
@@ -355,9 +352,10 @@ async function pruneRemovedTiers(ctx: ReconcileContext, input: EnvelopeInputs): 
   }
 }
 
-/** The daemon's ReadWriteOncePod PVC (transcripts + state). */
+/** The daemon's ReadWriteOncePod PVC (transcripts + state), sized and classed by the install. */
 export async function ensureDaemonPvc(ctx: ReconcileContext, input: EnvelopeInputs, obs: Observations): Promise<void> {
   const ns = input.spec.targetNamespace
+  const storageClass = ctx.config.daemonStorageClass
   // RWOP is load-bearing: the Recreate strategy assumes the volume can never double-attach.
   await applyObject(ctx.http, corePath(ns, 'persistentvolumeclaims', DAEMON_PVC_NAME), {
     apiVersion: 'v1',
@@ -365,7 +363,9 @@ export async function ensureDaemonPvc(ctx: ReconcileContext, input: EnvelopeInpu
     metadata: { name: DAEMON_PVC_NAME, namespace: ns, labels: envelopeLabels(input.orgName) },
     spec: {
       accessModes: ['ReadWriteOncePod'],
-      resources: { requests: { storage: DAEMON_STORAGE } }
+      // Omitted rather than emptied when unset: an empty string pins "no class", not the cluster default.
+      ...(storageClass ? { storageClassName: storageClass } : {}),
+      resources: { requests: { storage: ctx.config.daemonStorageSize } }
     }
   })
   void obs


### PR DESCRIPTION
## The defect

The first real-cluster install of `charts/operator` never got a daemon running for an org. `ensureDaemonPvc` stamped the state PVC with `accessModes: ['ReadWriteOncePod']` and a hardcoded `10Gi`, and **no `storageClassName`** — so the claim fell to whatever the cluster's default StorageClass happens to be. Where that default is a node-local provisioner, provisioning fails (`no local path available on node …`), the PVC stays `Pending`, and the daemon pod never starts.

This is a known trap, not a new one: the hand-written sandbox pool manifests already pinned a cluster-wide CSI class instead of the cluster default, for exactly this reason plus the node affinity a node-local volume imposes. The operator repeated the mistake only because it had no knob.

## The knobs

Storage is a property of the **cluster**, not of an org, so this is deployment-level configuration and **not** a CRD field — the same shape as `AC_MASTER_TEMPLATE_PREFIX`:

| env | values.yaml | default |
| --- | --- | --- |
| `AC_DAEMON_STORAGE_CLASS` | `daemonStorage.className` | unset |
| `AC_DAEMON_STORAGE_SIZE` | `daemonStorage.size` | `10Gi` |

Unset means unset all the way down: the chart omits the env entirely when `className` is empty, `loadConfig` reads a blank value as `undefined`, and `ensureDaemonPvc` omits the field from the claim rather than sending `''` — an empty `storageClassName` asks for *no* provisioner, which is not the same as falling back to the cluster default.

`values.yaml` and the chart README document both settings, including that they apply at claim creation: Kubernetes rejects a class change on an existing PVC, so changing them moves new orgs only.

## Verification

- `pnpm --filter @agentconnect.md/operator test` (98 passing) — new cases: class set → present in the applied PVC with the configured size; class unset **and** rendered blank by the chart → field absent, not empty; plus `loadConfig` defaults and blank handling.
- `pnpm --filter @agentconnect.md/operator typecheck`, `pnpm lint` (0 errors), `prettier --check`.
- `helm lint charts/operator`, plus `helm template` rendered both ways — with `--set daemonStorage.className=cluster-wide` the env appears, and by default only `AC_DAEMON_STORAGE_SIZE` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)