### PR TITLE
fix(operator): report CredentialSecretMissing while the daemon pod is stuck at init

### DIFF
--- a/packages/operator/src/reconcile/status.test.ts
+++ b/packages/operator/src/reconcile/status.test.ts
@@ -175,6 +175,20 @@ describe('observeWorkloads', () => {
     }
   })
 
+  /** A daemon pod blocked at Init:0/1: with an init container declared, every uncreated one reads PodInitializing. */
+  const initBlockedPod = (name = 'ac-daemon-0') => ({
+    metadata: { name },
+    status: {
+      phase: 'Pending',
+      conditions: [
+        { type: 'PodScheduled', status: 'True' },
+        { type: 'Initialized', status: 'False', reason: 'ContainersNotInitialized' }
+      ],
+      initContainerStatuses: [{ ready: false, state: { waiting: { reason: 'PodInitializing' } } }],
+      containerStatuses: [{ ready: false, state: { waiting: { reason: 'PodInitializing' } } }]
+    }
+  })
+
   it('does not report the target image Ready off the old pod`s stale readyReplicas', async () => {
     // Image just swapped: generation advanced, but readyReplicas still counts the old pod.
     const { obs } = await observe({
@@ -249,12 +263,14 @@ describe('observeWorkloads', () => {
     expect(obs.credential).toEqual({ status: 'True', reason: 'DaemonRunning' })
   })
 
-  it('names the credential secret when the kubelet cannot build the container config', async () => {
+  it('names the credential secret when the kubelet cannot build the init container config', async () => {
+    // The Secret is mounted by the init container alone, so only its status carries the error.
     const pod = {
       metadata: { name: 'ac-daemon-0' },
       status: {
         phase: 'Pending',
-        initContainerStatuses: [{ ready: false, state: { waiting: { reason: 'CreateContainerConfigError' } } }]
+        initContainerStatuses: [{ ready: false, state: { waiting: { reason: 'CreateContainerConfigError' } } }],
+        containerStatuses: [{ ready: false, state: { waiting: { reason: 'PodInitializing' } } }]
       }
     }
     const { obs } = await observe(convergedDeployment, {
@@ -264,6 +280,60 @@ describe('observeWorkloads', () => {
     expect(obs.credential?.status).toBe('False')
     expect(obs.credential?.reason).toBe('CredentialSecretMissing')
     expect(obs.credential?.message).toContain('org-daemon-credentials')
+  })
+
+  it('reads the FailedMount event while the pod is still stuck at init', async () => {
+    // The live shape: containers all PodInitializing, the mount failure named only by the kubelet's event.
+    const { obs } = await observe(convergedDeployment, {
+      pods: [initBlockedPod()],
+      events: [
+        failedMountEvent(
+          'ac-daemon-0',
+          'MountVolume.SetUp failed for volume "config" : secret "ac-daemon-token" not found'
+        )
+      ]
+    })
+    expect(obs.credential?.status).toBe('False')
+    expect(obs.credential?.reason).toBe('CredentialSecretMissing')
+    expect(obs.credential?.message).toContain('ac-daemon-token')
+    expect(obs.recheckAfterMs).toBeUndefined()
+  })
+
+  it('reads the FailedMount event before the kubelet reports any container at all', async () => {
+    const bare = { metadata: { name: 'ac-daemon-0' }, status: { phase: 'Pending' } }
+    const { obs } = await observe(convergedDeployment, {
+      pods: [bare],
+      events: [
+        failedMountEvent(
+          'ac-daemon-0',
+          'MountVolume.SetUp failed for volume "config" : secret "ac-daemon-token" not found'
+        )
+      ]
+    })
+    expect(obs.credential?.reason).toBe('CredentialSecretMissing')
+  })
+
+  it('drops the event when the init container is stuck on a blocker of its own', async () => {
+    // Mount fixed, the init image is the new blocker; the main container's PodInitializing must not re-blame it.
+    const pulling = {
+      metadata: { name: 'ac-daemon-0' },
+      status: {
+        phase: 'Pending',
+        conditions: [{ type: 'PodScheduled', status: 'True' }],
+        initContainerStatuses: [{ ready: false, state: { waiting: { reason: 'ImagePullBackOff' } } }],
+        containerStatuses: [{ ready: false, state: { waiting: { reason: 'PodInitializing' } } }]
+      }
+    }
+    const { obs } = await observe(convergedDeployment, {
+      pods: [pulling],
+      events: [
+        failedMountEvent(
+          'ac-daemon-0',
+          'MountVolume.SetUp failed for volume "config" : secret "ac-daemon-token" not found'
+        )
+      ]
+    })
+    expect(obs.credential).toEqual({ status: 'False', reason: 'DaemonPodNotReady' })
   })
 
   it('reads the pod`s FailedMount event as the missing credential secret, not a startup delay', async () => {

--- a/packages/operator/src/reconcile/status.ts
+++ b/packages/operator/src/reconcile/status.ts
@@ -111,11 +111,14 @@ function lastOccurrenceMs(event: EventRead): number {
   return stamps.length > 0 ? Math.max(...stamps) : 0
 }
 
-/** No container has been created yet — the state a blocked mount leaves the pod in, and the corroboration
- *  that keeps a retained Event from outliving the fault it described. */
+/** Uncreated-container waiting reasons: a pod with an init container reports PodInitializing, not ContainerCreating. */
+const NOT_YET_CREATED_REASONS = new Set(['ContainerCreating', 'PodInitializing'])
+
+/** No container created yet: where a blocked mount leaves the pod, and what stops a retained Event outliving it. */
 function isAwaitingContainerCreate(pod: PodRead): boolean {
   const containers = [...(pod.status?.initContainerStatuses ?? []), ...(pod.status?.containerStatuses ?? [])]
-  return containers.length === 0 || containers.some((status) => status.state?.waiting?.reason === 'ContainerCreating')
+  // Every, not some: a container stuck on its own blocker means the kubelet got past the mount.
+  return containers.every((status) => NOT_YET_CREATED_REASONS.has(status.state?.waiting?.reason ?? ''))
 }
 
 /** The name has to appear as the Secret the kubelet could not read — the wordings it uses to say so.


### PR DESCRIPTION
## The defect

Observed on a real-cluster install with the org's credential Secret not yet created: the kubelet emitted

```
Warning  FailedMount  MountVolume.SetUp failed for volume "config" : secret "ac-daemon-token" not found
```

and the CR still reported `CredentialReady=False (DaemonPodNotReady)` — the one condition whose entire purpose is naming this failure.

## Why the #871 machinery missed it

`ensureDaemonDeployment` mounts the credential Secret on the **`install-config` initContainer** only. A missing Secret therefore parks the pod at `Init:0/1` with no container ever created, and `pod.status` never names the Secret — only the Event does. Reading that Event is gated on `isAwaitingContainerCreate`, which matched the waiting reason `ContainerCreating`.

That reason never appears on this pod. Once a pod declares an init container, the kubelet's default waiting state for **every** uncreated container — init and main alike — is `PodInitializing`, not `ContainerCreating`. The gate was written against the shape of a pod with no init containers, so it closed on the exact pod it exists to classify and the verdict fell through to the generic `DaemonPodNotReady`.

## The fix

`isAwaitingContainerCreate` now accepts both reasons, and requires **every** container status to carry one rather than any:

- `every`, not `some`, because a pod whose init container is stuck on its own blocker (say `ImagePullBackOff`) has already mounted the Secret, yet its main container still reads `PodInitializing`. Matching on any one container would keep blaming the credential off a retained Event.
- An empty status list still counts — the kubelet has reported nothing at all yet.

`CreateContainerConfigError` was already read off `initContainerStatuses` as well as `containerStatuses`, so that path needed no change; a test now pins the real mixed shape (error on the init container, `PodInitializing` on the main one). Condition precedence, the Event field selector, the Secret-naming match, and the 15-minute freshness bound are all unchanged. RBAC for the Events read was granted with #871.

## Verification

- `pnpm --filter @agentconnect.md/operator test` (101 passing). Reverting only `status.ts` fails exactly one new test — *reads the FailedMount event while the pod is still stuck at init* — which is the live defect; the other new cases pin behavior the change must preserve (bare pod with no statuses, init container stuck on its own blocker, init `CreateContainerConfigError`).
- `pnpm --filter @agentconnect.md/operator typecheck`, `pnpm lint` (0 errors), `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)