### PR TITLE
feat(operator): derive the org envelope namespace from the CR name

### DIFF
--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -5,6 +5,14 @@ resources in the release namespace (the environment's _control namespace_)
 into per-org execution envelopes: namespace, RBAC, network policies, sandbox
 templates and warm pools, and the org's daemon supervisor.
 
+An envelope's namespace is **derived by default**: `orgNamespacePrefix` plus the
+`AgentConnectOrg`'s own name, which is unique in the control namespace — so two
+CRs cannot collide on one namespace. A deployment that needs a specific namespace
+sets `spec.targetNamespace`, which is immutable and must still start with the
+install's prefix. Either way the operator publishes the result on
+`status.namespace`, which is where every consumer — including the credential
+writer — reads it.
+
 ## Layout
 
 One release per environment. Several environments can share a cluster: each

--- a/charts/operator/templates/NOTES.txt
+++ b/charts/operator/templates/NOTES.txt
@@ -22,8 +22,10 @@ install's operator can write into another's:
 
   kubectl label namespace {{ .Release.Namespace }} agentconnect.md/control-namespace=''
 
-Onboard an org by applying an AgentConnectOrg into {{ .Release.Namespace }}
-together with its daemon credential Secret in the target namespace.
+Onboard an org by applying an AgentConnectOrg into {{ .Release.Namespace }}. Its
+envelope namespace defaults to {{ .Values.orgNamespacePrefix }}<CR name> (override
+with spec.targetNamespace, which must still carry that prefix) and is published on
+.status.namespace once claimed — put the daemon credential Secret there.
 
 Before uninstalling: delete every AgentConnectOrg and wait for finalizers —
 the pre-delete hook refuses to remove the operator while CRs remain. When it

--- a/charts/operator/templates/crd.yaml
+++ b/charts/operator/templates/crd.yaml
@@ -24,9 +24,9 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-        - name: Target
+        - name: Namespace
           type: string
-          jsonPath: .spec.targetNamespace
+          jsonPath: .status.namespace
         - name: Ready
           type: string
           jsonPath: .status.conditions[?(@.type=="Ready")].status
@@ -42,11 +42,12 @@ spec:
             spec:
               type: object
               required:
-                - targetNamespace
                 - daemon
                 - runtime
               x-kubernetes-validations:
-                - rule: self.targetNamespace == oldSelf.targetNamespace
+                # Optional, so both sides are tested for presence: an org's namespace must never
+                # move, and that includes moving between derived and overridden.
+                - rule: has(self.targetNamespace) == has(oldSelf.targetNamespace) && (!has(self.targetNamespace) || self.targetNamespace == oldSelf.targetNamespace)
                   message: targetNamespace is immutable
                 - rule: self.daemon.credentialSecretName == oldSelf.daemon.credentialSecretName
                   message: daemon.credentialSecretName is immutable
@@ -55,7 +56,7 @@ spec:
                   type: string
                   maxLength: 63
                   pattern: '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$'
-                  description: Namespace the org envelope is reconciled into. Shape-only validation here; the operator and admission policies enforce install ownership (prefix).
+                  description: Optional override for the envelope namespace, immutable once set. Omitted — the normal path, and what the control plane always writes — means the operator derives it as <org namespace prefix><CR name>, which cannot collide with another CR. Shape-only validation here; install ownership (prefix) is enforced by the operator and admission either way.
                 displayName:
                   type: string
                   description: Human-readable org name, display only.
@@ -186,7 +187,7 @@ spec:
                   type: integer
                 namespace:
                   type: string
-                  description: Published together with NamespaceReady, only after successful create-or-adopt and label validation.
+                  description: The envelope namespace the operator resolved — spec.targetNamespace when set, otherwise <org namespace prefix><CR name>. Published together with NamespaceReady, only after successful create-or-adopt and label validation, and the only place a consumer learns the namespace.
                 conditions:
                   type: array
                   items:

--- a/charts/operator/templates/validating-admission-policies.yaml
+++ b/charts/operator/templates/validating-admission-policies.yaml
@@ -83,7 +83,7 @@ spec:
       message: an org namespace must carry the envelope org labels and a baseline-or-stricter Pod Security level
       reason: Forbidden
     # The only cluster-scoped object the envelope owns besides the namespace is the per-org
-    # TokenReview binding (`ac-tokenreview-<targetNamespace>`, packages/operator/src/reconcile/resources.ts).
+    # TokenReview binding (`ac-tokenreview-<org namespace>`, packages/operator/src/reconcile/resources.ts).
     - expression: >-
         variables.ns != '' || variables.isNamespace || (request.resource.group == 'rbac.authorization.k8s.io' &&
         request.resource.resource == 'clusterrolebindings' &&

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -16,8 +16,9 @@ agent-sandbox stack it builds on is documented in `deploy/k8s/README.md`.
 
 - **`AgentConnectOrg`** (`agentconnect.md/v1alpha1`, namespaced, short name
   `acorg`) — one CR per org, living in the install's _control namespace_ (the
-  Helm release namespace). `spec.targetNamespace` names the org's envelope
-  namespace. The CR is the sole desired-state carrier for the envelope; who
+  Helm release namespace). The org's envelope namespace is **derived by default**
+  — `<AC_ORG_NAMESPACE_PREFIX><CR name>` — and published on `status.namespace`.
+  The CR is the sole desired-state carrier for the envelope; who
   writes it is deployment policy (an administrator or GitOps statically, a
   control plane programmatically), and the operator does not care.
 - **Operator** (`@agentconnect.md/operator`, container bin
@@ -37,24 +38,42 @@ openAPIV3Schema with per-field descriptions and CEL transition rules). The
 zod schemas in `packages/operator/src/crd/types.ts` are the operator's runtime
 guard; a parity unit test asserts the two field trees stay identical.
 
-| spec field                    | Notes                                                                                                                                                                                |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `targetNamespace`             | DNS label, **immutable** (CEL). Shape-only at CRD level; install ownership (prefix) is enforced by the operator and admission.                                                       |
-| `suspend`                     | Quiesce the org: daemon to zero, sandboxes drained, gateway denies LLM calls.                                                                                                        |
-| `daemon.image`, `daemon.tier` | Supervisor image (change ⇒ Recreate rollout) and resource tier name.                                                                                                                 |
-| `daemon.credentialSecretName` | **Immutable**, default `ac-daemon-token`. A reference only — the Secret is written by the key authority, mounted required so the kubelet gates startup; the operator never reads it. |
-| `daemon.credentialRevision`   | Opaque; bumped after Secret rotation, projected into a pod-template annotation to force a Recreate.                                                                                  |
-| `runtime.image`               | Sandbox image; change starts the drain-based rollout.                                                                                                                                |
-| `runtime.tiers[]`             | `{name, warmReplicas}` referencing cluster master template/pool pairs; 0 keeps a cold pool.                                                                                          |
-| `quota`                       | `maxAgents`/`cpu`/`memory`/`storage`; zero values mean unlimited.                                                                                                                    |
-| `llmLimits`                   | Per-session and per-org token/request rate bounds, rendered into egress-gateway policies.                                                                                            |
-| `egressPolicy`                | `locked \| curated \| open` sandbox egress tier.                                                                                                                                     |
-| `llmDeny`                     | Emergency LLM shutoff (`all` or per-agent).                                                                                                                                          |
-| `deletionPolicy`              | `Delete` only in v1alpha1; `Archive` joins when its semantics exist.                                                                                                                 |
+**The namespace is configurable at two levels** (`reconcile/namespace.ts` resolves
+both, and every reader takes the resolved value):
 
-Status is operator-owned: `observedGeneration`, `namespace` (published
-atomically with `NamespaceReady`, only after create-or-adopt plus label
-validation), conditions (`Ready`, `NamespaceReady`, `CredentialReady`,
+1. _Install_ — `AC_ORG_NAMESPACE_PREFIX` fences every org namespace, always.
+2. _Per org_ — `spec.targetNamespace` is an optional override. **Unset** (the
+   normal path, and what the control plane always writes) derives
+   `<prefix><CR name>`: the name is unique within the control namespace, so two
+   CRs cannot collide on a namespace and none can name one outside its install —
+   by construction rather than by validation. **Set** still has to start with the
+   install's prefix, or the org lands `Degraded/NamespaceOutsidePrefix` with
+   nothing written.
+
+Either way the resolved name must be a DNS label: a CR name legal for a
+Kubernetes object (a DNS _subdomain_) can still derive an illegal namespace, and
+that lands `Degraded/InvalidNamespaceName` and writes no envelope objects. Two
+orgs aimed at one namespace are caught by the claim label
+(`Degraded/NamespaceClaimConflict`) — the operator degrades, never adopts.
+
+| spec field                    | Notes                                                                                                                                                                                 |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `targetNamespace`             | Optional DNS-label override, **immutable** (CEL). Unset ⇒ derived `<prefix><CR name>`. Shape-only at CRD level; install ownership (prefix) is enforced by the operator and admission. |
+| `suspend`                     | Quiesce the org: daemon to zero, sandboxes drained, gateway denies LLM calls.                                                                                                         |
+| `daemon.image`, `daemon.tier` | Supervisor image (change ⇒ Recreate rollout) and resource tier name.                                                                                                                  |
+| `daemon.credentialSecretName` | **Immutable**, default `ac-daemon-token`. A reference only — the Secret is written by the key authority, mounted required so the kubelet gates startup; the operator never reads it.  |
+| `daemon.credentialRevision`   | Opaque; bumped after Secret rotation, projected into a pod-template annotation to force a Recreate.                                                                                   |
+| `runtime.image`               | Sandbox image; change starts the drain-based rollout.                                                                                                                                 |
+| `runtime.tiers[]`             | `{name, warmReplicas}` referencing cluster master template/pool pairs; 0 keeps a cold pool.                                                                                           |
+| `quota`                       | `maxAgents`/`cpu`/`memory`/`storage`; zero values mean unlimited.                                                                                                                     |
+| `llmLimits`                   | Per-session and per-org token/request rate bounds, rendered into egress-gateway policies.                                                                                             |
+| `egressPolicy`                | `locked \| curated \| open` sandbox egress tier.                                                                                                                                      |
+| `llmDeny`                     | Emergency LLM shutoff (`all` or per-agent).                                                                                                                                           |
+| `deletionPolicy`              | `Delete` only in v1alpha1; `Archive` joins when its semantics exist.                                                                                                                  |
+
+Status is operator-owned: `observedGeneration`, `namespace` (the resolved name,
+published atomically with `NamespaceReady`, only after create-or-adopt plus label
+validation — and the only place a consumer learns the namespace), conditions (`Ready`, `NamespaceReady`, `CredentialReady`,
 `LimitsApplied`, `Progressing`, `Degraded`), daemon/sandboxes/pools summaries,
 `appliedLimits` (an _observation record_ of the gateway policy API — possibly
 `Unknown`, never an enforcement proof), and `rollout` progress.
@@ -79,7 +98,7 @@ only if CRD conversion webhooks become necessary.
 | `reconcile/resources.ts`      | Server-side-apply/get/delete primitives, path builders, and the envelope's fixed object names.                                                                                                                           | done          |
 | `reconcile/envelope.ts`       | The ordered inventory implemented over SSA (see §4).                                                                                                                                                                     | done          |
 | `reconcile/status.ts`         | `setCondition`, live workload observation, and the full condition/summary builder.                                                                                                                                       | done          |
-| `reconcile/finalizer.ts`      | Deletion order implemented; only claimed, prefix-owned namespaces are touched.                                                                                                                                           | done          |
+| `reconcile/finalizer.ts`      | Deletion order implemented; only the claimed, prefix-owned namespace is touched.                                                                                                                                         | done          |
 | `reconcile/rollout.ts`        | The runtime-image rollout: conditioned image patch for Suspended instances, drain-requested handshake for Running ones, stale-request sweep, and the drain deadline that moves a stuck instance to `failed` (see below). | done          |
 | `reconcile/gateway-limits.ts` | llmLimits/llmDeny → gateway policy kinds (pinned by the gateway spike).                                                                                                                                                  | **TODO stub** |
 
@@ -129,7 +148,8 @@ resource tiers are a built-in small/medium/large table, unknown names falling
 back to `small` with a warning. Order is policy-before-workload within one
 reconcile pass:
 
-1. `ensureNamespace` — create-or-adopt `targetNamespace` via claim label;
+1. `ensureNamespace` — resolve the namespace (§2), then create-or-adopt it via
+   claim label; an out-of-prefix override, a name that is no DNS label, or a
    label mismatch ⇒ `Degraded`, never adopt.
 2. `ensureServiceAccounts` — daemon SA; runtime SA with
    `automountServiceAccountToken: false` and zero bindings.
@@ -223,8 +243,13 @@ differ (`CLUSTER_ORG_NAMESPACE_PREFIX`, which must equal the operator install's
 - `org_cluster_execution` (one row per org) holds only the spec fields the
   control plane owns. Status is never mirrored there: the console reads it live
   off the CR, so a row can never disagree with the cluster.
-- `targetNamespace` is derived once as `<prefix><org id folded to a DNS label>`
-  and stored, because the CRD marks the field immutable.
+- `resourceName` — the CR's name — is derived once as the org id folded to a DNS
+  label, truncated so the operator's `<prefix><CR name>` still fits in 63
+  characters, and stored: it is the handle every later call addresses the
+  envelope by. The control plane never writes `spec.targetNamespace`, so the
+  namespace is the operator's to derive; anything that needs it (the credential
+  Secret write) reads `status.namespace` off the CR. Server-side apply only
+  prunes fields this manager owns, so an override written by hand survives.
 - Writes are server-side apply under field manager
   `agentconnect-control-plane`, so the operator's own manager is untouched;
   the control plane never writes `/status`, finalizers, or envelope objects.
@@ -238,8 +263,8 @@ differ (`CLUSTER_ORG_NAMESPACE_PREFIX`, which must equal the operator install's
   operator reconciles the CR and nothing here re-reads on a timer.
 - Deleting an organization records its envelope in `pending_envelope_teardown`
   **inside the delete transaction**, because the cascade removes the only copy
-  of the immutable `targetNamespace` and after that nothing could name the
-  namespace and workloads the operator is still keeping alive. Reading the row
+  of its `resourceName` and after that nothing could name the resource, namespace
+  and workloads the operator is still keeping alive. Reading the row
   there is also what serializes the boundary: an enable that committed first is
   visible, and one that has not is blocked by the org row's `FOR UPDATE` and
   then fails its foreign key. The delete route retires the CR immediately, and a
@@ -333,8 +358,9 @@ Four orderings carry the rest:
 
 - **Secret before revision.** A failed write leaves the running pod on its old,
   still-valid key instead of rolling it onto a credential that was never
-  published. The namespace not existing yet is the ordinary "just enabled" state
-  and answers 409 rather than recording anything.
+  published. The namespace not existing yet — or `status.namespace` not being
+  published yet, which is read BEFORE the key is minted — is the ordinary "just
+  enabled" state and answers 409 rather than recording anything.
 - **Identity before publication.** A first issue records the provisioned
   `credentialDaemonId` before anything can fail, and revokes its own key if
   publication does — so a retry re-keys that daemon instead of provisioning

--- a/packages/control-plane/prisma/migrations/20260814000000_org_envelope_resource_name/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260814000000_org_envelope_resource_name/migration.sql
@@ -1,0 +1,23 @@
+-- The envelope namespace is no longer control-plane input: the operator derives
+-- it from the install prefix and the CR name and publishes it on status.namespace.
+-- What the control plane still owns is the CR NAME, which is what these columns
+-- have really held — rename them to say so.
+--
+-- v1alpha1 has no production consumers and cluster execution is off by default.
+-- A row written before this migration still carries the old, prefix-INCLUDING
+-- value, and the name is only ever written on insert. Its CR also carries the
+-- spec.targetNamespace the old writer set, which this one no longer sends — and
+-- since server-side apply would drop a field this manager owns, the CRD's
+-- immutability rule REJECTS that apply rather than letting the org silently move
+-- to a doubly-prefixed namespace. So such a row is retired, not migrated: disable
+-- cluster execution (which tears the envelope down under the stored name), delete
+-- the row, and enable again.
+
+-- AlterTable
+ALTER TABLE "org_cluster_execution" RENAME COLUMN "targetNamespace" TO "resourceName";
+
+-- AlterIndex
+ALTER INDEX "org_cluster_execution_targetNamespace_key" RENAME TO "org_cluster_execution_resourceName_key";
+
+-- AlterTable
+ALTER TABLE "pending_envelope_teardown" RENAME COLUMN "targetNamespace" TO "resourceName";

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2756,9 +2756,11 @@ enum ClusterEgressPolicy {
 /// there. Status is never mirrored here: it is read live from the CR, so a row
 /// can never disagree with the cluster.
 ///
-/// `targetNamespace` is derived once from the deployment's namespace prefix and
-/// the org id, and is IMMUTABLE afterwards — the CRD marks the field immutable
-/// too, so a rewrite here could never be applied.
+/// `resourceName` — the CR's name in the control namespace — is derived once
+/// from the org id and never rewritten: it is the handle every later call
+/// addresses the envelope by. The envelope NAMESPACE is not stored at all; the
+/// operator derives it as `<install prefix><CR name>` and publishes it on
+/// `status.namespace`, which is the only place a consumer learns it.
 model OrgClusterExecution {
   orgId String @id
   /// False ⇒ the org has no CR in the control namespace. Flipping to false
@@ -2770,7 +2772,7 @@ model OrgClusterExecution {
   /// interleaved writes can leave the row and the resource permanently apart —
   /// the operator reconciles the CR, not this table.
   specRevision         Int                 @default(1)
-  targetNamespace      String              @unique
+  resourceName         String              @unique
   /// Quiesce without tearing down: daemon to zero, sandboxes drained.
   suspend              Boolean             @default(false)
   daemonImage          String
@@ -2829,9 +2831,9 @@ model OrgClusterExecution {
 
 /// One row per deleted organization that still owns an `AgentConnectOrg`.
 /// Deleting the CR is a remote effect that cannot join the delete transaction,
-/// and the cascade above removes the only record of the immutable
-/// `targetNamespace` — so without this tombstone the operator would keep a
-/// namespace, daemon, and sandboxes alive that nothing left could name.
+/// and the cascade above removes the only record of its `resourceName` — so
+/// without this tombstone the operator would keep a namespace, daemon, and
+/// sandboxes alive that nothing left could name.
 ///
 /// Written inside the same transaction that deletes the organization, which is
 /// what makes it airtight: an enable that commits first is visible to that read,
@@ -2843,9 +2845,9 @@ model OrgClusterExecution {
 /// Deliberately NO foreign key: the row's whole purpose is to outlive the
 /// organization it names.
 model PendingEnvelopeTeardown {
-  orgId           String   @id // the deleted org (identity + idempotency key)
-  targetNamespace String // the envelope namespace, which is also the CR name
-  createdAt       DateTime @default(now()) @db.Timestamptz(6)
+  orgId        String   @id // the deleted org (identity + idempotency key)
+  resourceName String // the AgentConnectOrg to delete, in the control namespace
+  createdAt    DateTime @default(now()) @db.Timestamptz(6)
 
   @@map("pending_envelope_teardown")
 }

--- a/packages/control-plane/src/cluster/crd.test.ts
+++ b/packages/control-plane/src/cluster/crd.test.ts
@@ -18,7 +18,7 @@ type JsonSchema = { type?: string; properties?: Record<string, JsonSchema>; item
 const SETTINGS: ClusterExecutionSettings = {
   orgId: 'org_example',
   enabled: true,
-  targetNamespace: 'ac-org-example',
+  resourceName: 'example',
   suspend: false,
   daemonImage: 'registry.example.test/daemon:1',
   daemonTier: 'small',
@@ -116,6 +116,13 @@ describe('AgentConnectOrg CRD parity', () => {
     for (const path of valuePaths(body)) {
       expect(declared, `status.${path} is not declared by the CRD`).toContain(path)
     }
+  })
+
+  // The CRD keeps the field as a deployment-level override; the control plane never
+  // writes one, so the operator derives `<prefix><CR name>` for every org it provisions.
+  it('never writes the namespace override the CRD still offers', () => {
+    expect(propertyPaths(crd.spec)).toContain('targetNamespace')
+    expect(valuePaths(buildSpec(SETTINGS, 'Example Org'))).not.toContain('targetNamespace')
   })
 
   it('names the credential secret default the CRD carries', () => {

--- a/packages/control-plane/src/cluster/crd.ts
+++ b/packages/control-plane/src/cluster/crd.ts
@@ -34,8 +34,14 @@ export const CONDITION_TYPES = [
 
 export type ConditionType = (typeof CONDITION_TYPES)[number]
 
+/**
+ * What the control plane emits. `targetNamespace` is deliberately absent: the CRD
+ * offers it as a deployment-level override, but an org provisioned from here takes
+ * the operator's derived `<install prefix><CR name>`. Server-side apply only prunes
+ * fields this manager previously owned, so an override written by hand survives
+ * every apply below — and the resolved name comes back on `status.namespace`.
+ */
 export interface AgentConnectOrgSpec {
-  targetNamespace: string
   displayName?: string
   suspend: boolean
   daemon: {
@@ -63,6 +69,8 @@ export interface AgentConnectOrgCondition {
 
 export interface AgentConnectOrgStatus {
   observedGeneration?: number
+  /** The envelope namespace the operator resolved — `<install prefix><CR name>` unless
+   *  the CR overrides it — published here, the only place a consumer learns it. */
   namespace?: string
   conditions?: AgentConnectOrgCondition[]
   daemon?: { ready: boolean; image?: string }

--- a/packages/control-plane/src/cluster/index.ts
+++ b/packages/control-plane/src/cluster/index.ts
@@ -18,7 +18,7 @@ export {
 } from './secret-api.js'
 export { buildDaemonConfigJson, type DaemonCredentialInput } from './credential.js'
 export { ClusterMaintenanceLoop, type ClusterMaintenanceWork } from './maintenance-loop.js'
-export { ClusterNamingError, orgNamespace, orgResourceName, type ClusterEnvelopeStatus } from './spec.js'
+export { ClusterNamingError, orgResourceName, type ClusterEnvelopeStatus } from './spec.js'
 export {
   ClusterExecutionService,
   ClusterNotEnabledError,

--- a/packages/control-plane/src/cluster/secret-api.ts
+++ b/packages/control-plane/src/cluster/secret-api.ts
@@ -41,11 +41,25 @@ export interface OrgSecretApi {
   delete(namespace: string, name: string): Promise<void>
 }
 
-/** The envelope namespace does not exist yet — the operator creates it from the CR. */
+/** The envelope namespace is not usable yet — the operator creates it, and publishes its name, from the CR. */
 export class NamespaceNotReadyError extends Error {
-  constructor(readonly namespace: string) {
-    super(`namespace ${namespace} does not exist yet — the operator creates it once the resource is applied`)
+  constructor(message: string) {
+    super(message)
     this.name = 'NamespaceNotReadyError'
+  }
+
+  /** The namespace the CR names has not been created yet. */
+  static missing(namespace: string): NamespaceNotReadyError {
+    return new NamespaceNotReadyError(
+      `namespace ${namespace} does not exist yet — the operator creates it once the resource is applied`
+    )
+  }
+
+  /** The operator has not derived and published `status.namespace` yet, so nothing names a namespace. */
+  static unpublished(resourceName: string): NamespaceNotReadyError {
+    return new NamespaceNotReadyError(
+      `AgentConnectOrg ${resourceName} has no status.namespace yet — the operator publishes it once the envelope namespace is claimed`
+    )
   }
 }
 
@@ -107,7 +121,7 @@ export class ClusterSecretApi implements OrgSecretApi {
         return
       } catch (error) {
         if (!(error instanceof K8sApiError)) throw error
-        if (error.isNotFound) throw new NamespaceNotReadyError(namespace)
+        if (error.isNotFound) throw NamespaceNotReadyError.missing(namespace)
         // Lost the race (409 Conflict on the resourceVersion, or AlreadyExists on
         // a create): re-read and re-decide, which is where a newer seq is caught.
         if (error.isConflict && attempt < PUBLISH_ATTEMPTS - 1) continue

--- a/packages/control-plane/src/cluster/service.test.ts
+++ b/packages/control-plane/src/cluster/service.test.ts
@@ -150,7 +150,7 @@ class FakeRepo implements OrgClusterExecutionRepo {
     }
     this.releaseHeld()
     this.rolloutPending = false
-    this.tombstones.push({ orgId: this.row.orgId, targetNamespace: this.row.targetNamespace })
+    this.tombstones.push({ orgId: this.row.orgId, resourceName: this.row.resourceName })
     this.row = {
       ...this.row,
       specRevision: this.row.specRevision + 1,
@@ -240,8 +240,15 @@ class FakeApi implements OrgResourceApi {
     return { spec }
   }
 
+  /** The namespace is the OPERATOR's to derive and publish; absent until it has. */
+  namespaceStatus: string | undefined = 'ac-org-acme'
+
   async get(): Promise<AgentConnectOrg | null> {
-    return this.present ? { metadata: { uid: 'uid-1', resourceVersion: '1' } } : null
+    if (!this.present) return null
+    return {
+      metadata: { uid: 'uid-1', resourceVersion: '1' },
+      ...(this.namespaceStatus ? { status: { namespace: this.namespaceStatus } } : {})
+    }
   }
 
   failDelete = false
@@ -265,7 +272,7 @@ class FakeSecrets implements OrgSecretApi {
   duringApply?: () => void
 
   async publishCredential(namespace: string, name: string, seq: number, configJson: string): Promise<void> {
-    if (this.namespaceMissing) throw new NamespaceNotReadyError(namespace)
+    if (this.namespaceMissing) throw NamespaceNotReadyError.missing(namespace)
     this.duringApply?.()
     // Same cluster-side ordering guard the real client enforces.
     if (seq < this.publishedSeq_) throw new StaleCredentialWriteError(seq, this.publishedSeq_)
@@ -338,7 +345,7 @@ describe('ClusterExecutionService.configure', () => {
     const settings = await service.configure(ORG, { enabled: true })
     expect(settings.enabled).toBe(true)
     expect(api.applied).toHaveLength(1)
-    expect(api.applied[0]).toMatchObject({ targetNamespace: 'ac-org-acme', displayName: 'acme' })
+    expect(api.applied[0]).toMatchObject({ displayName: 'acme' })
   })
 
   it('re-applies when a concurrent write superseded the snapshot it just applied', async () => {
@@ -370,7 +377,7 @@ describe('ClusterExecutionService.configure', () => {
     const { service, api } = build()
     await service.configure(ORG, { enabled: true })
     await service.configure(ORG, { enabled: false })
-    expect(api.deleted).toEqual(['ac-org-acme'])
+    expect(api.deleted).toEqual(['acme'])
     expect(api.applied).toHaveLength(1)
   })
 
@@ -384,7 +391,7 @@ describe('ClusterExecutionService.configure', () => {
     const settings = await service.configure(ORG, { enabled: true })
 
     expect(api.applied).toHaveLength(1)
-    expect(api.deleted).toEqual(['ac-org-acme'])
+    expect(api.deleted).toEqual(['acme'])
     expect(settings.enabled).toBe(false)
   })
 
@@ -402,7 +409,7 @@ describe('ClusterExecutionService.configure', () => {
     expect(settings).toMatchObject({
       enabled: false,
       specRevision: 0,
-      targetNamespace: 'ac-org-acme',
+      resourceName: 'acme',
       daemonImage: POLICY.daemonImage,
       runtimeImage: POLICY.runtimeImage
     })
@@ -451,6 +458,17 @@ describe('ClusterExecutionService.issueCredential', () => {
     // Daemon keys never expire, so an unpublished one must not survive.
     expect(keys.revoked).toEqual(['key-1'])
     expect(repo.revocations).toEqual([])
+  })
+
+  it('refuses to publish before the operator has derived and published the namespace', async () => {
+    const { service, api, secrets, keys } = build()
+    await service.configure(ORG, { enabled: true })
+    api.namespaceStatus = undefined // the envelope namespace is not claimed yet
+
+    await expect(service.issueCredential(ORG)).rejects.toThrow(NamespaceNotReadyError)
+    expect(secrets.written).toEqual([])
+    // Read before minting: a key with nowhere to be published is a key to leak.
+    expect(keys.minted).toBe(0)
   })
 
   it('reuses the daemon a failed first attempt provisioned, rather than making another', async () => {
@@ -735,7 +753,7 @@ describe('ClusterExecutionService.issueCredential', () => {
     keys.failRevoke = false
     expect(await service.drainTeardowns()).toBe(1)
     expect(await service.drainKeyRevocations()).toBe(1)
-    expect(api.deleted).toContain('ac-org-acme')
+    expect(api.deleted).toContain('acme')
     expect(keys.revoked).toEqual([issued.revision])
   })
 
@@ -757,17 +775,17 @@ describe('ClusterExecutionService.drainTeardowns', () => {
   it('deletes each deleted org’s resource and drops its tombstone', async () => {
     const { service, repo, api } = build()
     repo.tombstones = [
-      { orgId: 'gone-1', targetNamespace: 'ac-org-gone-1' },
-      { orgId: 'gone-2', targetNamespace: 'ac-org-gone-2' }
+      { orgId: 'gone-1', resourceName: 'gone-1' },
+      { orgId: 'gone-2', resourceName: 'gone-2' }
     ]
     expect(await service.drainTeardowns()).toBe(2)
-    expect(api.deleted).toEqual(['ac-org-gone-1', 'ac-org-gone-2'])
+    expect(api.deleted).toEqual(['gone-1', 'gone-2'])
     expect(repo.tombstones).toEqual([])
   })
 
   it('keeps a tombstone whose resource could not be deleted, for the next pass', async () => {
     const { service, repo, api } = build()
-    repo.tombstones = [{ orgId: 'gone', targetNamespace: 'ac-org-gone' }]
+    repo.tombstones = [{ orgId: 'gone', resourceName: 'gone' }]
     api.failDelete = true
     // Swallowed per row: one unreachable envelope must not hold up the others,
     // and callers that only recorded an intent must not fail on the sweep.
@@ -796,7 +814,7 @@ describe('ClusterExecutionService.drainTeardowns', () => {
     api.deleted.length = 0
 
     // A drain that had already listed the entry must not act on it now.
-    repo.tombstones = [{ orgId: ORG, targetNamespace: 'ac-org-acme' }]
+    repo.tombstones = [{ orgId: ORG, resourceName: 'acme' }]
     expect(await service.drainTeardowns()).toBe(0)
     expect(api.deleted).toEqual([])
   })
@@ -806,12 +824,12 @@ describe('ClusterExecutionService.drainTeardowns', () => {
     await service.configure(ORG, { enabled: true })
     await service.configure(ORG, { enabled: false })
     api.deleted.length = 0
-    repo.tombstones = [{ orgId: ORG, targetNamespace: 'ac-org-acme' }]
+    repo.tombstones = [{ orgId: ORG, resourceName: 'acme' }]
     await repo.beginCredentialRotation(ORG, 'peer-token', new Date(), 60_000)
 
     expect(await service.drainTeardowns()).toBe(0)
     await repo.endCredentialRotation(ORG, 'peer-token')
     expect(await service.drainTeardowns()).toBe(1)
-    expect(api.deleted).toEqual(['ac-org-acme'])
+    expect(api.deleted).toEqual(['acme'])
   })
 })

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -25,14 +25,7 @@ import type {
 } from '../persistence/ports.js'
 import { DEFAULT_CREDENTIAL_SECRET_NAME } from './crd.js'
 import type { OrgResourceApi } from './org-api.js'
-import {
-  ABSENT_ENVELOPE,
-  buildSpec,
-  orgNamespace,
-  orgResourceName,
-  projectStatus,
-  type ClusterEnvelopeStatus
-} from './spec.js'
+import { ABSENT_ENVELOPE, buildSpec, orgResourceName, projectStatus, type ClusterEnvelopeStatus } from './spec.js'
 
 /** Bounded re-apply passes; each concurrent writer runs its own, so this only
  *  has to outlast a burst, not an unbounded stream of edits. */
@@ -204,7 +197,7 @@ export class ClusterExecutionService {
       await this.repo.retireCredential(orgId, token, 'cluster execution disabled')
       // Directly, not through the drain: this call already owns the claim the
       // drain would try to take.
-      await this.deleteEnvelopeResource(orgId, claimed.targetNamespace)
+      await this.deleteEnvelopeResource(orgId, claimed.resourceName)
       await this.drainKeyRevocations()
     } finally {
       await this.repo.endCredentialRotation(orgId, token)
@@ -234,7 +227,7 @@ export class ClusterExecutionService {
       // longer exists — and the deletion's tombstone was written before it. Undo
       // it here rather than leave the operator holding an ownerless envelope.
       if (!after) {
-        await this.api.delete(orgResourceName(current.targetNamespace))
+        await this.api.delete(current.resourceName)
         return this.unconfigured(orgId)
       }
       if (after.specRevision === current.specRevision) return current
@@ -245,7 +238,7 @@ export class ClusterExecutionService {
 
   /** Apply one snapshot of the org's settings to the cluster. */
   async reconcile(settings: ClusterExecutionSettings): Promise<void> {
-    const name = orgResourceName(settings.targetNamespace)
+    const name = settings.resourceName
     if (!settings.enabled) return this.api.delete(name)
     // `displayName` is display-only on the CR, so the slug (always present) is
     // enough and costs one indexed read instead of a whole org projection.
@@ -256,9 +249,9 @@ export class ClusterExecutionService {
   /**
    * Delete the resources of organizations that are already gone, then drop
    * their tombstones. The tombstone is written inside the org's delete
-   * transaction because the cascade removes the only record of the immutable
-   * `targetNamespace` — after that, nothing else could name the namespace,
-   * daemon, and sandboxes the operator is still keeping alive.
+   * transaction because the cascade removes the only record of the envelope's
+   * `resourceName` — after that, nothing else could name the namespace, daemon,
+   * and sandboxes the operator is still keeping alive.
    *
    * Best-effort per row and safe to run at any time: a resource that is already
    * gone reads as deleted, and a row whose delete fails simply stays for the
@@ -268,7 +261,7 @@ export class ClusterExecutionService {
     const pending = await this.repo.listPendingTeardowns(limit)
     let retired = 0
     for (const entry of pending) {
-      const retiredOne = await this.retireEnvelope(OrgId(entry.orgId), entry.targetNamespace)
+      const retiredOne = await this.retireEnvelope(OrgId(entry.orgId), entry.resourceName)
       if (retiredOne) retired += 1
     }
     return retired
@@ -282,7 +275,7 @@ export class ClusterExecutionService {
    * re-enable just created. An org whose row is gone (deleted) has no claim to
    * take and no re-enable to race, so it is deleted directly.
    */
-  private async retireEnvelope(orgId: OrgId, targetNamespace: string): Promise<boolean> {
+  private async retireEnvelope(orgId: OrgId, resourceName: string): Promise<boolean> {
     const row = await this.repo.get(orgId)
     let token: string | undefined
     if (row) {
@@ -302,7 +295,7 @@ export class ClusterExecutionService {
       }
     }
     try {
-      return await this.deleteEnvelopeResource(orgId, targetNamespace)
+      return await this.deleteEnvelopeResource(orgId, resourceName)
     } finally {
       if (token) await this.repo.endCredentialRotation(orgId, token)
     }
@@ -315,8 +308,7 @@ export class ClusterExecutionService {
    * generation in the meantime makes the API server reject it rather than
    * removing what the re-enable just created.
    */
-  private async deleteEnvelopeResource(orgId: OrgId, targetNamespace: string): Promise<boolean> {
-    const name = orgResourceName(targetNamespace)
+  private async deleteEnvelopeResource(orgId: OrgId, name: string): Promise<boolean> {
     try {
       const existing = await this.api.get(name)
       if (existing) {
@@ -378,6 +370,9 @@ export class ClusterExecutionService {
     )
     if (!settings) throw new ClusterRotationInProgressError()
     try {
+      // Read BEFORE minting: the namespace is the operator's to derive and publish,
+      // so a pass that cannot learn it yet must not leave a key behind either.
+      const namespace = await this.envelopeNamespace(settings)
       const previousApiKeyId = settings.credentialApiKeyId
       const minted = await this.mintFor(orgId, token, settings.credentialDaemonId, actorUserId)
 
@@ -390,7 +385,7 @@ export class ClusterExecutionService {
       }
       try {
         await this.secrets.publishCredential(
-          settings.targetNamespace,
+          namespace,
           settings.credentialSecretName,
           settings.credentialRotationSeq,
           buildDaemonConfigJson({
@@ -400,7 +395,7 @@ export class ClusterExecutionService {
           })
         )
       } catch (error) {
-        const landed = await this.publishLanded(settings, error)
+        const landed = await this.publishLanded(namespace, settings, error)
         if (!landed) {
           // Definitely not published: clear the staged slot when this pass still
           // owns it, and queue the key either way — if the claim was taken over
@@ -458,10 +453,10 @@ export class ClusterExecutionService {
    * since the cost of keeping a key alive one rotation longer is far lower than
    * the cost of killing a live one.
    */
-  private async publishLanded(settings: ClusterExecutionSettings, error: unknown): Promise<boolean> {
+  private async publishLanded(namespace: string, settings: ClusterExecutionSettings, error: unknown): Promise<boolean> {
     if (error instanceof NamespaceNotReadyError || error instanceof StaleCredentialWriteError) return false
     try {
-      const published = await this.secrets.publishedSeq(settings.targetNamespace, settings.credentialSecretName)
+      const published = await this.secrets.publishedSeq(namespace, settings.credentialSecretName)
       return published >= settings.credentialRotationSeq
     } catch {
       return true
@@ -557,17 +552,29 @@ export class ClusterExecutionService {
     return revoked
   }
 
+  /**
+   * The envelope namespace, read off the CR the operator publishes it on. The
+   * control plane never derives it: the operator owns `<prefix><CR name>`, and
+   * `status.namespace` appears only once the namespace has actually been created
+   * and claim-validated. Absent ⇒ there is nothing to publish a Secret into yet.
+   */
+  private async envelopeNamespace(settings: ClusterExecutionSettings): Promise<string> {
+    const namespace = (await this.api.get(settings.resourceName))?.status?.namespace
+    if (!namespace) throw NamespaceNotReadyError.unpublished(settings.resourceName)
+    return namespace
+  }
+
   /** Live envelope status from the resource; absent ⇒ `present: false`. */
   async status(orgId: OrgId): Promise<ClusterEnvelopeStatus> {
     const settings = await this.repo.get(orgId)
     if (!settings) return ABSENT_ENVELOPE
-    const resource = await this.api.get(orgResourceName(settings.targetNamespace))
+    const resource = await this.api.get(settings.resourceName)
     return resource ? projectStatus(resource.status) : ABSENT_ENVELOPE
   }
 
   private defaults(orgId: OrgId): ClusterExecutionDefaults {
     return {
-      targetNamespace: orgNamespace(this.policy.namespacePrefix, orgId),
+      resourceName: orgResourceName(this.policy.namespacePrefix, orgId),
       daemonImage: this.policy.daemonImage,
       daemonTier: this.policy.daemonTier,
       credentialSecretName: DEFAULT_CREDENTIAL_SECRET_NAME,

--- a/packages/control-plane/src/cluster/spec.test.ts
+++ b/packages/control-plane/src/cluster/spec.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { ABSENT_ENVELOPE, ClusterNamingError, buildSpec, orgNamespace, orgResourceName, projectStatus } from './spec.js'
+import { ABSENT_ENVELOPE, ClusterNamingError, buildSpec, orgResourceName, projectStatus } from './spec.js'
 import type { ClusterExecutionSettings } from '../persistence/ports.js'
 
 const SETTINGS: ClusterExecutionSettings = {
   orgId: 'cm5exampleorgid0000000001',
   enabled: true,
-  targetNamespace: 'ac-org-cm5exampleorgid0000000001',
+  resourceName: 'cm5exampleorgid0000000001',
   suspend: false,
   daemonImage: 'registry.example.test/daemon:1.2.3',
   daemonTier: 'small',
@@ -18,38 +18,39 @@ const SETTINGS: ClusterExecutionSettings = {
   updatedAt: new Date(0)
 }
 
-describe('orgNamespace', () => {
-  it('joins the install prefix to the org id', () => {
-    expect(orgNamespace('ac-org-', 'cm5exampleorgid0000000001')).toBe('ac-org-cm5exampleorgid0000000001')
+describe('orgResourceName', () => {
+  it('names the resource after the org id, without the install prefix', () => {
+    expect(orgResourceName('ac-org-', 'cm5exampleorgid0000000001')).toBe('cm5exampleorgid0000000001')
   })
 
   it('folds an id that is not already a DNS label', () => {
-    expect(orgNamespace('ac-org-', 'Org_ID.42')).toBe('ac-org-org-id-42')
+    expect(orgResourceName('ac-org-', 'Org_ID.42')).toBe('org-id-42')
   })
 
-  it('truncates to 63 characters without leaving a trailing dash', () => {
-    const name = orgNamespace('ac-org-', `${'a'.repeat(55)}-tail`)
-    expect(name).toHaveLength(62)
+  // The operator prefixes this name to make the namespace, so the prefix's own
+  // length has to come out of the 63 a DNS label allows.
+  it('truncates so the prefixed namespace still fits, without a trailing dash', () => {
+    const name = orgResourceName('ac-org-', `${'a'.repeat(55)}-tail`)
+    expect(`ac-org-${name}`).toHaveLength(62)
     expect(name.endsWith('-')).toBe(false)
   })
 
-  it('is stable — the same org always derives the same namespace', () => {
-    expect(orgNamespace('ac-org-', 'abc')).toBe(orgNamespace('ac-org-', 'abc'))
+  it('is stable — the same org always derives the same name', () => {
+    expect(orgResourceName('ac-org-', 'abc')).toBe(orgResourceName('ac-org-', 'abc'))
   })
 
   it('refuses an org id that folds to nothing usable', () => {
-    expect(() => orgNamespace('ac-org-', '___')).toThrow(ClusterNamingError)
+    expect(() => orgResourceName('ac-org-', '___')).toThrow(ClusterNamingError)
   })
 
-  it('names the resource after the namespace it targets', () => {
-    expect(orgResourceName('ac-org-acme')).toBe('ac-org-acme')
+  it.each([63, 64, 80])('refuses a prefix of %i that leaves no room for a name', (length) => {
+    expect(() => orgResourceName('p'.repeat(length), 'acme')).toThrow(ClusterNamingError)
   })
 })
 
 describe('buildSpec', () => {
   it('projects every control-plane-owned field', () => {
     expect(buildSpec(SETTINGS, 'acme')).toEqual({
-      targetNamespace: 'ac-org-cm5exampleorgid0000000001',
       displayName: 'acme',
       suspend: false,
       daemon: {

--- a/packages/control-plane/src/cluster/spec.ts
+++ b/packages/control-plane/src/cluster/spec.ts
@@ -1,8 +1,10 @@
 /**
  * Pure projections between the stored cluster-execution settings and the
  * `AgentConnectOrg` resource (docs/designs/agentconnect-org-operator.md §2):
- * the org namespace name, the spec the control plane applies, and the status
- * shape the console reads back.
+ * the CR name, the spec the control plane applies, and the status shape the
+ * console reads back. The envelope NAMESPACE is deliberately not among them —
+ * the control plane never sets the CRD's override, so the operator derives it
+ * from the CR name and publishes it on `status`.
  */
 import type { ClusterExecutionSettings } from '../persistence/ports.js'
 import { CONDITION_TYPES, type AgentConnectOrgSpec, type AgentConnectOrgStatus, type ConditionType } from './crd.js'
@@ -19,38 +21,33 @@ export class ClusterNamingError extends Error {
 }
 
 /**
- * The org's envelope namespace: the install's prefix plus the org id, folded to
- * a DNS label. The prefix is what an install claims ownership by — the operator
- * and its admission policies refuse a namespace outside it — so it is never
- * derived from the org, and a truncated tail keeps the id's leading (unique)
- * characters. Derived ONCE at enable time and stored, because the CRD marks
- * `targetNamespace` immutable: re-deriving it after a prefix change would
- * produce a name no write could ever apply.
+ * The org's CR name in the control namespace: the org id folded to a DNS label.
+ * The operator derives the envelope namespace as `<install prefix><CR name>`, so
+ * the name is truncated to leave the prefix room and a truncated tail keeps the
+ * id's leading (unique) characters. Derived ONCE at enable time and stored,
+ * because the name is the durable handle everything else addresses the envelope
+ * by — including the tombstone that outlives the organization row.
  */
-export function orgNamespace(prefix: string, orgId: string): string {
+export function orgResourceName(prefix: string, orgId: string): string {
   const slug = orgId
     .toLowerCase()
     .replace(/[^a-z0-9-]/g, '-')
     .replace(/^-+|-+$/g, '')
-  // An empty fold would collapse every such org onto the bare prefix — one
-  // namespace for many orgs is the one outcome worse than refusing the write.
-  if (!slug) throw new ClusterNamingError(`org id "${orgId}" has no characters usable in a namespace`)
-  const name = `${prefix}${slug}`.slice(0, MAX_DNS_LABEL).replace(/-+$/, '')
+  // An empty fold would collapse every such org onto one name — one envelope for
+  // many orgs is the one outcome worse than refusing the write.
+  if (!slug) throw new ClusterNamingError(`org id "${orgId}" has no characters usable in a resource name`)
+  // Clamped: a negative budget would make slice() trim from the END and quietly
+  // return a name whose prefixed namespace is longer than a label allows.
+  const name = slug.slice(0, Math.max(0, MAX_DNS_LABEL - prefix.length)).replace(/-+$/, '')
   if (!DNS_LABEL.test(name)) {
-    throw new ClusterNamingError(`derived namespace "${name}" is not a DNS label`)
+    throw new ClusterNamingError(`derived resource name "${name}" is not a DNS label under prefix "${prefix}"`)
   }
   return name
-}
-
-/** The CR name in the control namespace; one per org, matching its namespace. */
-export function orgResourceName(targetNamespace: string): string {
-  return targetNamespace
 }
 
 /** The desired `spec` for an org — everything the control plane owns, nothing else. */
 export function buildSpec(settings: ClusterExecutionSettings, displayName?: string): AgentConnectOrgSpec {
   return {
-    targetNamespace: settings.targetNamespace,
     ...(displayName ? { displayName } : {}),
     suspend: settings.suspend,
     daemon: {

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3253,8 +3253,10 @@ export const ClusterQuotaDto = z.object({
 
 export const ClusterExecutionSettingsDto = z.object({
   enabled: z.boolean(),
-  /** Derived once from the install prefix and the org id; immutable afterwards. */
-  targetNamespace: z.string(),
+  /** The organization's AgentConnectOrg name, derived once from the org id. The
+   *  envelope namespace is NOT here — the operator derives it and publishes it on
+   *  the resource, so the status endpoint is where a caller reads it. */
+  resourceName: z.string(),
   /** The operator install's control namespace, where the resource lives. */
   controlNamespace: z.string(),
   suspend: z.boolean(),

--- a/packages/control-plane/src/http/routes/cluster-execution.ts
+++ b/packages/control-plane/src/http/routes/cluster-execution.ts
@@ -38,7 +38,7 @@ import {
 function settingsDto(settings: ClusterExecutionSettings, controlNamespace: string): ClusterExecutionSettingsDtoT {
   return {
     enabled: settings.enabled,
-    targetNamespace: settings.targetNamespace,
+    resourceName: settings.resourceName,
     controlNamespace,
     suspend: settings.suspend,
     daemonImage: settings.daemonImage,
@@ -81,7 +81,7 @@ export function clusterExecutionRoutes(deps: HttpDeps) {
           tags: [Tag.Cluster],
           summary: 'Update cluster execution settings',
           description:
-            'Owner-only. Persists the settings and reconciles the organization’s AgentConnectOrg resource. `enabled: true` creates or converges it; `enabled: false` DELETES it, which hands the envelope — namespace included — to the operator’s deletion finalizer. Use `suspend` to quiesce without tearing down. `targetNamespace` and `credentialSecretName` are fixed at first enable and cannot be changed.',
+            'Owner-only. Persists the settings and reconciles the organization’s AgentConnectOrg resource. `enabled: true` creates or converges it; `enabled: false` DELETES it, which hands the envelope — namespace included — to the operator’s deletion finalizer. Use `suspend` to quiesce without tearing down. `resourceName` and `credentialSecretName` are fixed at first enable and cannot be changed; the envelope namespace is derived by the operator and read back from the status endpoint.',
           operationId: 'updateClusterExecution',
           body: UpdateClusterExecutionBody,
           response: { 200: ClusterExecutionSettingsDto, 403: ErrorDto, 502: ErrorDto }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4929,8 +4929,9 @@ export interface ClusterExecutionSettings {
   /** Bumped on every write; the provisioner's fence against a concurrent writer
    *  reverting the resource to an older spec. */
   specRevision: number
-  /** Derived once from the install prefix and the org id; immutable afterwards. */
-  targetNamespace: string
+  /** The org's `AgentConnectOrg` name in the control namespace, derived once from
+   *  the org id; the operator derives the envelope namespace from it. */
+  resourceName: string
   suspend: boolean
   daemonImage: string
   daemonTier: string
@@ -4968,7 +4969,7 @@ export interface ClusterExecutionPatch {
 
 /** The values a first write fills in for anything the caller left unset. */
 export interface ClusterExecutionDefaults {
-  targetNamespace: string
+  resourceName: string
   daemonImage: string
   daemonTier: string
   credentialSecretName: string
@@ -4981,7 +4982,7 @@ export interface ClusterExecutionDefaults {
 /** A deleted org's envelope, still waiting for its resource to be removed. */
 export interface PendingEnvelopeTeardown {
   orgId: string
-  targetNamespace: string
+  resourceName: string
 }
 
 /** A daemon key the provisioner has finished with and must still revoke. */
@@ -5066,9 +5067,9 @@ export interface OrgClusterExecutionRepo {
    *  winner's row backwards. Idempotent. */
   createIfAbsent(orgId: OrgId, defaults: ClusterExecutionDefaults): Promise<void>
   /** Create from `defaults` merged with `patch`, or apply `patch` to the existing
-   *  row, always bumping `specRevision`. `targetNamespace` and
-   *  `credentialSecretName` are only ever written by the create branch — the CRD
-   *  marks both immutable. */
+   *  row, always bumping `specRevision`. `resourceName` and
+   *  `credentialSecretName` are only ever written by the create branch — the CR
+   *  name addresses a live envelope and the CRD marks the Secret name immutable. */
   upsert(
     orgId: OrgId,
     defaults: ClusterExecutionDefaults,

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -3027,17 +3027,17 @@ export class PgHookRepo implements HookRepo {
         })
         // Same reasoning for a managed-execution envelope: deleting its
         // AgentConnectOrg is a remote effect, and the cascade below drops the
-        // only record of the namespace that names it. Reading the row HERE is
+        // only record of the name that addresses it. Reading the row HERE is
         // what makes the tombstone authoritative — an enable that committed
         // first is visible, and one that has not is blocked by the org row's
         // FOR UPDATE above and then fails its foreign key.
         const envelope = await tx.orgClusterExecution.findUnique({
           where: { orgId },
-          select: { targetNamespace: true }
+          select: { resourceName: true }
         })
         if (envelope) {
           await tx.pendingEnvelopeTeardown.createMany({
-            data: [{ orgId, targetNamespace: envelope.targetNamespace }],
+            data: [{ orgId, resourceName: envelope.resourceName }],
             skipDuplicates: true
           })
         }

--- a/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
@@ -4,9 +4,10 @@
  * One row per organization holding the spec fields the control plane owns. The
  * row is desired state only — envelope status is read live from the
  * `AgentConnectOrg` resource, so nothing here can go stale against the cluster.
- * `targetNamespace` and `credentialSecretName` are written exactly once, by the
- * create branch of {@link PgOrgClusterExecutionRepo.upsert}: the CRD marks both
- * immutable, so a later rewrite could never be applied.
+ * `resourceName` and `credentialSecretName` are written exactly once, by the
+ * create branch of {@link PgOrgClusterExecutionRepo.upsert}: the CR name addresses
+ * a live envelope and the CRD marks the Secret name immutable, so a later rewrite
+ * could never be applied.
  */
 import { Prisma, type OrgClusterExecution, type PrismaClient } from '../../generated/prisma/client.js'
 import type {
@@ -56,7 +57,7 @@ function toRecord(row: OrgClusterExecution): ClusterExecutionSettings {
     enabled: row.enabled,
     specRevision: row.specRevision,
     credentialRotationSeq: row.credentialRotationSeq,
-    targetNamespace: row.targetNamespace,
+    resourceName: row.resourceName,
     suspend: row.suspend,
     daemonImage: row.daemonImage,
     daemonTier: row.daemonTier,
@@ -89,7 +90,7 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
 
   async listPendingTeardowns(limit: number): Promise<PendingEnvelopeTeardown[]> {
     return this.prisma.pendingEnvelopeTeardown.findMany({
-      select: { orgId: true, targetNamespace: true },
+      select: { orgId: true, resourceName: true },
       orderBy: { createdAt: 'asc' },
       take: limit
     })
@@ -266,7 +267,7 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
       // The resource must go too, and the cluster call can fail — so record the
       // intent here, where it is atomic with the credential being dropped.
       await tx.pendingEnvelopeTeardown.createMany({
-        data: [{ orgId, targetNamespace: current.targetNamespace }],
+        data: [{ orgId, resourceName: current.resourceName }],
         skipDuplicates: true
       })
       return true
@@ -298,7 +299,7 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
         {
           orgId,
           enabled: false,
-          targetNamespace: defaults.targetNamespace,
+          resourceName: defaults.resourceName,
           daemonImage: defaults.daemonImage,
           daemonTier: defaults.daemonTier,
           credentialSecretName: defaults.credentialSecretName,
@@ -327,7 +328,7 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
       create: {
         orgId,
         enabled: patch.enabled ?? false,
-        targetNamespace: defaults.targetNamespace,
+        resourceName: defaults.resourceName,
         suspend: patch.suspend ?? false,
         daemonImage: patch.daemonImage ?? defaults.daemonImage,
         daemonTier: patch.daemonTier ?? defaults.daemonTier,

--- a/packages/control-plane/test/integration/cluster-execution.route.test.ts
+++ b/packages/control-plane/test/integration/cluster-execution.route.test.ts
@@ -10,7 +10,12 @@ import { K8sHttp } from '@agentconnect.md/k8s-client'
 import { closeFakeApiServers, fakeApiServer, type FakeRoute } from '@agentconnect.md/k8s-client/testing'
 import { prisma } from '../setup.db.js'
 import { buildHttpApp, TEST_API_KEY_PEPPER, type HttpApp } from '../fakes/build-http.js'
-import { AgentConnectOrgApi, ClusterExecutionService, ClusterSecretApi, orgNamespace } from '../../src/cluster/index.js'
+import {
+  AgentConnectOrgApi,
+  ClusterExecutionService,
+  ClusterSecretApi,
+  orgResourceName
+} from '../../src/cluster/index.js'
 import { ApiKeyCodec } from '../../src/registry/apiKey.js'
 import { ApiKeyService } from '../../src/registry/apiKeyService.js'
 import { systemClock } from '../../src/domain/clock.js'
@@ -35,10 +40,12 @@ const POLICY = {
   runtimeTiers: [{ name: 'small', warmReplicas: 0 }],
   controlPlaneUrl: 'wss://api.example.test/daemon/ws'
 }
-const TARGET_NAMESPACE = orgNamespace(POLICY.namespacePrefix, DEFAULT_ORG_ID)
+const RESOURCE_NAME = orgResourceName(POLICY.namespacePrefix, DEFAULT_ORG_ID)
+/** What the OPERATOR derives from the CR name; the fake server below publishes it on status. */
+const TARGET_NAMESPACE = `${POLICY.namespacePrefix}${RESOURCE_NAME}`
 /** What the service derives for an org that has never configured anything. */
 const DEFAULTS: ClusterExecutionDefaults = {
-  targetNamespace: TARGET_NAMESPACE,
+  resourceName: RESOURCE_NAME,
   daemonImage: POLICY.daemonImage,
   daemonTier: POLICY.daemonTier,
   credentialSecretName: 'ac-daemon-token',
@@ -47,7 +54,7 @@ const DEFAULTS: ClusterExecutionDefaults = {
   quota: { maxAgents: 0, cpu: '0', memory: '0', storage: '0' },
   egressPolicy: 'curated'
 }
-const RESOURCE_PATH = `/apis/agentconnect.md/v1alpha1/namespaces/${CONTROL_NAMESPACE}/agentconnectorgs/${TARGET_NAMESPACE}`
+const RESOURCE_PATH = `/apis/agentconnect.md/v1alpha1/namespaces/${CONTROL_NAMESPACE}/agentconnectorgs/${RESOURCE_NAME}`
 
 /** A per-request override; undefined falls through to the harness's default store. */
 type MaybeRoute = (req: Parameters<FakeRoute>[0]) => ReturnType<FakeRoute> | undefined
@@ -117,7 +124,8 @@ async function clusterApp(
     if (req.method === 'PATCH') {
       const body = JSON.parse(req.body) as { spec?: Record<string, unknown> }
       applied.push(body)
-      stored = { ...body, status: { observedGeneration: applied.length } }
+      // Standing in for the operator: it derives the namespace and publishes it on status.
+      stored = { ...body, status: { observedGeneration: applied.length, namespace: TARGET_NAMESPACE } }
     }
     if (req.method === 'DELETE' && !isSecret) stored = null
     const custom = options.route?.(req)
@@ -185,7 +193,7 @@ describe('GET /cluster-execution', () => {
       enabled: false,
       suspend: false,
       controlNamespace: CONTROL_NAMESPACE,
-      targetNamespace: TARGET_NAMESPACE,
+      resourceName: RESOURCE_NAME,
       daemonImage: POLICY.daemonImage,
       runtimeImage: POLICY.runtimeImage,
       credentialSecretName: 'ac-daemon-token',
@@ -223,7 +231,6 @@ describe('PUT /cluster-execution', () => {
 
     expect(calls).toContain(`PATCH ${RESOURCE_PATH}`)
     expect(applied.at(-1)?.spec).toMatchObject({
-      targetNamespace: TARGET_NAMESPACE,
       suspend: false,
       daemon: { image: 'registry.example.test/daemon:2.0.0', tier: 'small', credentialSecretName: 'ac-daemon-token' },
       runtime: { image: POLICY.runtimeImage, tiers: [{ name: 'medium', warmReplicas: 2 }] },
@@ -233,15 +240,18 @@ describe('PUT /cluster-execution', () => {
 
     const row = await prisma.orgClusterExecution.findUnique({ where: { orgId: DEFAULT_ORG_ID } })
     expect(row?.enabled).toBe(true)
-    expect(row?.targetNamespace).toBe(TARGET_NAMESPACE)
+    expect(row?.resourceName).toBe(RESOURCE_NAME)
+    // The namespace is the operator's alone: the applied spec never names one.
+    expect(applied.at(-1)?.spec).not.toHaveProperty('targetNamespace')
   })
 
-  it('keeps the derived namespace across later edits', async () => {
-    const { http, applied } = await clusterApp()
+  it('keeps addressing the same resource across later edits', async () => {
+    const { http, calls, applied } = await clusterApp()
     await http.app.inject({ method: 'PUT', url: CLUSTER, payload: { enabled: true } })
     await http.app.inject({ method: 'PUT', url: CLUSTER, payload: { suspend: true } })
     expect(applied).toHaveLength(2)
-    expect(applied[1]?.spec).toMatchObject({ targetNamespace: TARGET_NAMESPACE, suspend: true })
+    expect(applied[1]?.spec).toMatchObject({ suspend: true })
+    expect(calls.filter((call) => call === `PATCH ${RESOURCE_PATH}`)).toHaveLength(2)
   })
 
   it('applies a partial patch without resetting the untouched fields', async () => {
@@ -612,7 +622,7 @@ describe('DELETE /orgs/:orgId', () => {
     expect(await prisma.pendingEnvelopeTeardown.count()).toBe(0)
   })
 
-  it('keeps the tombstone — the only surviving record of the namespace — when the cluster refuses', async () => {
+  it('keeps the tombstone — the only surviving record of the envelope — when the cluster refuses', async () => {
     const { http } = await clusterApp({
       route: (req) =>
         req.method === 'DELETE'
@@ -626,7 +636,7 @@ describe('DELETE /orgs/:orgId', () => {
     const res = await http.app.inject({ method: 'DELETE', url: ORG })
     expect(res.statusCode).toBe(204)
     const pending = await prisma.pendingEnvelopeTeardown.findMany()
-    expect(pending.map((row) => row.targetNamespace)).toEqual([TARGET_NAMESPACE])
+    expect(pending.map((row) => row.resourceName)).toEqual([RESOURCE_NAME])
   })
 
   it('records the envelope even when this process has no cluster credentials', async () => {
@@ -641,7 +651,7 @@ describe('DELETE /orgs/:orgId', () => {
 
     const pending = await prisma.pendingEnvelopeTeardown.findMany()
     expect(pending.map((row) => row.orgId)).toEqual([DEFAULT_ORG_ID])
-    expect(pending[0]?.targetNamespace).toBe(TARGET_NAMESPACE)
+    expect(pending[0]?.resourceName).toBe(RESOURCE_NAME)
   })
 
   it('writes no tombstone for an org that never enabled cluster execution', async () => {

--- a/packages/operator/src/crd/types.test.ts
+++ b/packages/operator/src/crd/types.test.ts
@@ -30,10 +30,11 @@ describe('AgentConnectOrg schemas', () => {
 
   it('fills the documented defaults', () => {
     const parsed = AgentConnectOrgSpecSchema.parse({
-      targetNamespace: 'test-ac-org-acme',
       daemon: { image: 'i', tier: 't' },
       runtime: { image: 'r', tiers: [{ name: 'small' }] }
     })
+    // Unset is the normal path: the operator derives the namespace from the CR name.
+    expect(parsed.targetNamespace).toBeUndefined()
     expect(parsed.suspend).toBe(false)
     expect(parsed.daemon.credentialSecretName).toBe('ac-daemon-token')
     expect(parsed.runtime.tiers[0]?.warmReplicas).toBe(0)

--- a/packages/operator/src/crd/types.ts
+++ b/packages/operator/src/crd/types.ts
@@ -35,7 +35,8 @@ const DNS_LABEL = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/
 // charts/operator is authoritative for the API server. A parity test keeps
 // the two field sets aligned.
 export const AgentConnectOrgSpecSchema = z.object({
-  targetNamespace: z.string().regex(DNS_LABEL, 'targetNamespace must be a DNS label'),
+  // Optional override; unset means the operator derives `<install prefix><CR name>`.
+  targetNamespace: z.string().regex(DNS_LABEL, 'targetNamespace must be a DNS label').optional(),
   displayName: z.string().optional(),
   suspend: z.boolean().default(false),
   daemon: z.object({

--- a/packages/operator/src/reconcile/envelope.test.ts
+++ b/packages/operator/src/reconcile/envelope.test.ts
@@ -6,7 +6,7 @@ import { AgentConnectOrgApi } from '../crd/api.js'
 import { NAMESPACE_CLAIM_LABEL, type AgentConnectOrgSpec } from '../crd/types.js'
 import { AgentConnectOrgSpecSchema } from '../crd/types.js'
 import { newObservations, type ReconcileContext } from './context.js'
-import { reconcileEnvelope, type EnvelopeInputs } from './envelope.js'
+import { envelopeInputs, reconcileEnvelope, type EnvelopeInputs } from './envelope.js'
 import { SANDBOX_EXTENSIONS_GROUP, groupPath, namespacePath } from './resources.js'
 
 afterEach(closeFakeApiServers)
@@ -60,15 +60,18 @@ const NS = 'test-ac-org-acme'
 
 function specOf(overrides: Partial<AgentConnectOrgSpec> = {}): AgentConnectOrgSpec {
   return AgentConnectOrgSpecSchema.parse({
-    targetNamespace: NS,
     daemon: { image: 'ghcr.io/example/daemon:v1', tier: 'small' },
     runtime: { image: 'ghcr.io/example/runtime:v1', tiers: [{ name: 'std', warmReplicas: 2 }] },
     ...overrides
   })
 }
 
-function inputOf(overrides: Partial<AgentConnectOrgSpec> = {}): EnvelopeInputs {
-  return { orgName: 'acme', spec: specOf(overrides) }
+function inputOf(
+  ctx: ReconcileContext,
+  overrides: Partial<AgentConnectOrgSpec> = {},
+  orgName = 'acme'
+): EnvelopeInputs {
+  return envelopeInputs(ctx, orgName, specOf(overrides))
 }
 
 const MASTER_TEMPLATE = {
@@ -97,12 +100,13 @@ const byPath = (writes: RecordedWrite[], suffix: string): RecordedWrite | undefi
   writes.find((write) => write.path.endsWith(suffix))
 
 describe('reconcileEnvelope', () => {
+  // No targetNamespace anywhere below unless a test sets one: NS is what the CR name derives.
   it('stamps the full inventory into a fresh namespace', async () => {
     const { gets, writes, route } = recorder()
     const ctx = await contextFor(route)
     gets.set(masterPath(ctx.controlNamespace), MASTER_TEMPLATE)
     const obs = newObservations()
-    await reconcileEnvelope(ctx, inputOf(), obs)
+    await reconcileEnvelope(ctx, inputOf(ctx), obs)
 
     expect(obs.namespaceReady).toBe(true)
     expect(obs.namespace).toBe(NS)
@@ -169,12 +173,46 @@ describe('reconcileEnvelope', () => {
     expect(byPath(writes, '/services/ac-daemon-shim')).toBeDefined()
   })
 
-  it('refuses a namespace outside the install prefix without writing anything', async () => {
+  it('honours a targetNamespace override that stays inside the install prefix', async () => {
+    const override = 'test-ac-org-legacy'
+    const { gets, writes, route } = recorder()
+    const ctx = await contextFor(route)
+    gets.set(masterPath(ctx.controlNamespace), MASTER_TEMPLATE)
+    const obs = newObservations()
+    await reconcileEnvelope(ctx, inputOf(ctx, { targetNamespace: override }), obs)
+
+    expect(obs.namespace).toBe(override)
+    expect(byPath(writes, `/namespaces/${override}`)).toBeDefined()
+    expect(byPath(writes, `/clusterrolebindings/ac-tokenreview-${override}`)).toBeDefined()
+    expect(writes.some((write) => write.path.includes(`/namespaces/${NS}/`))).toBe(false)
+  })
+
+  it('refuses an override outside the install prefix without writing anything', async () => {
     const { writes, route } = recorder()
     const ctx = await contextFor(route)
     const obs = newObservations()
-    await reconcileEnvelope(ctx, inputOf({ targetNamespace: 'other-prefix-acme' }), obs)
+    await reconcileEnvelope(ctx, inputOf(ctx, { targetNamespace: 'other-prefix-acme' }), obs)
     expect(obs.degraded?.reason).toBe('NamespaceOutsidePrefix')
+    expect(writes).toEqual([])
+  })
+
+  // Object names are DNS subdomains, so a legal CR name can still derive an illegal namespace.
+  it('refuses a CR name whose derived namespace is not a DNS label, without writing anything', async () => {
+    const { writes, route } = recorder()
+    const ctx = await contextFor(route)
+    const obs = newObservations()
+    await reconcileEnvelope(ctx, inputOf(ctx, {}, 'acme.example'), obs)
+    expect(obs.degraded?.reason).toBe('InvalidNamespaceName')
+    expect(writes).toEqual([])
+  })
+
+  it('refuses a CR name whose derived namespace exceeds the DNS label length', async () => {
+    const { writes, route } = recorder()
+    const ctx = await contextFor(route)
+    const obs = newObservations()
+    await reconcileEnvelope(ctx, inputOf(ctx, {}, 'a'.repeat(64)), obs)
+    expect(obs.degraded?.reason).toBe('InvalidNamespaceName')
+    expect(obs.degraded?.message).toContain('63')
     expect(writes).toEqual([])
   })
 
@@ -183,7 +221,7 @@ describe('reconcileEnvelope', () => {
     const ctx = await contextFor(route)
     gets.set(namespacePath(NS), { metadata: { name: NS, labels: { [NAMESPACE_CLAIM_LABEL]: 'someone-else' } } })
     const obs = newObservations()
-    await reconcileEnvelope(ctx, inputOf(), obs)
+    await reconcileEnvelope(ctx, inputOf(ctx), obs)
     expect(obs.degraded?.reason).toBe('NamespaceClaimConflict')
     expect(writes).toEqual([])
   })
@@ -192,7 +230,7 @@ describe('reconcileEnvelope', () => {
     const { gets, writes, route } = recorder()
     const ctx = await contextFor(route)
     gets.set(masterPath(ctx.controlNamespace), MASTER_TEMPLATE)
-    await reconcileEnvelope(ctx, inputOf({ suspend: true }), newObservations())
+    await reconcileEnvelope(ctx, inputOf(ctx, { suspend: true }), newObservations())
     const deployment = byPath(writes, '/deployments/ac-daemon')?.body as { spec: { replicas: number } }
     expect(deployment.spec.replicas).toBe(0)
     const pool = byPath(writes, '/sandboxwarmpools/ac-runtime-std')?.body as { spec: { replicas: number } }
@@ -203,7 +241,7 @@ describe('reconcileEnvelope', () => {
     const { gets, writes, route } = recorder()
     const ctx = await contextFor(route, { AC_DAEMON_STORAGE_CLASS: 'cluster-wide', AC_DAEMON_STORAGE_SIZE: '20Gi' })
     gets.set(masterPath(ctx.controlNamespace), MASTER_TEMPLATE)
-    await reconcileEnvelope(ctx, inputOf(), newObservations())
+    await reconcileEnvelope(ctx, inputOf(ctx), newObservations())
     const pvc = byPath(writes, '/persistentvolumeclaims/ac-daemon-state')?.body as {
       spec: { storageClassName?: string; resources: { requests: { storage: string } } }
     }
@@ -218,7 +256,7 @@ describe('reconcileEnvelope', () => {
     const { gets, writes, route } = recorder()
     const ctx = await contextFor(route, env)
     gets.set(masterPath(ctx.controlNamespace), MASTER_TEMPLATE)
-    await reconcileEnvelope(ctx, inputOf(), newObservations())
+    await reconcileEnvelope(ctx, inputOf(ctx), newObservations())
     const pvc = byPath(writes, '/persistentvolumeclaims/ac-daemon-state')?.body as {
       spec: Record<string, unknown> & { resources: { requests: { storage: string } } }
     }
@@ -233,7 +271,7 @@ describe('reconcileEnvelope', () => {
     gets.set(masterPath(ctx.controlNamespace), MASTER_TEMPLATE)
     await reconcileEnvelope(
       ctx,
-      inputOf({ quota: { maxAgents: 5, cpu: '8', memory: '16Gi', storage: '0' } }),
+      inputOf(ctx, { quota: { maxAgents: 5, cpu: '8', memory: '16Gi', storage: '0' } }),
       newObservations()
     )
     const quota = byPath(writes, '/resourcequotas/ac-quota')?.body as { spec: { hard: Record<string, string> } }
@@ -249,7 +287,7 @@ describe('reconcileEnvelope', () => {
     const { writes, route } = recorder()
     const ctx = await contextFor(route)
     const obs = newObservations()
-    await reconcileEnvelope(ctx, inputOf(), obs)
+    await reconcileEnvelope(ctx, inputOf(ctx), obs)
     expect(obs.warnings.some((warning) => warning.includes('ac-runtime-std'))).toBe(true)
     expect(byPath(writes, '/sandboxtemplates/ac-runtime-std')).toBeUndefined()
     expect(byPath(writes, '/deployments/ac-daemon')).toBeDefined()
@@ -269,7 +307,7 @@ describe('reconcileEnvelope', () => {
     }
     gets.set(groupPath(SANDBOX_EXTENSIONS_GROUP, NS, 'sandboxwarmpools'), leftovers)
     gets.set(groupPath(SANDBOX_EXTENSIONS_GROUP, NS, 'sandboxtemplates'), leftovers)
-    await reconcileEnvelope(ctx, inputOf(), newObservations())
+    await reconcileEnvelope(ctx, inputOf(ctx), newObservations())
     const deletes = writes.filter((write) => write.method === 'DELETE').map((write) => write.path)
     expect(deletes).toContain(groupPath(SANDBOX_EXTENSIONS_GROUP, NS, 'sandboxwarmpools', 'ac-runtime-old'))
     expect(deletes).toContain(groupPath(SANDBOX_EXTENSIONS_GROUP, NS, 'sandboxtemplates', 'ac-runtime-old'))
@@ -284,7 +322,7 @@ describe('reconcileEnvelope', () => {
     gets.set(groupPath(SANDBOX_EXTENSIONS_GROUP, NS, 'sandboxwarmpools'), existing)
     gets.set(groupPath(SANDBOX_EXTENSIONS_GROUP, NS, 'sandboxtemplates'), existing)
     const obs = newObservations()
-    await reconcileEnvelope(ctx, inputOf(), obs)
+    await reconcileEnvelope(ctx, inputOf(ctx), obs)
     expect(obs.warnings.some((warning) => warning.includes('ac-runtime-std'))).toBe(true)
     expect(writes.filter((write) => write.method === 'DELETE' && write.path.includes('ac-runtime-std'))).toEqual([])
   })
@@ -293,7 +331,7 @@ describe('reconcileEnvelope', () => {
     const { gets, writes, route } = recorder()
     const ctx = await contextFor(route)
     gets.set(masterPath(ctx.controlNamespace), MASTER_TEMPLATE)
-    await reconcileEnvelope(ctx, inputOf({ egressPolicy: 'locked' }), newObservations())
+    await reconcileEnvelope(ctx, inputOf(ctx, { egressPolicy: 'locked' }), newObservations())
     const template = byPath(writes, `/namespaces/${NS}/sandboxtemplates/ac-runtime-std`)?.body as {
       spec: { networkPolicy: { egress: unknown[] } }
     }

--- a/packages/operator/src/reconcile/envelope.ts
+++ b/packages/operator/src/reconcile/envelope.ts
@@ -5,6 +5,7 @@ import {
   type AgentConnectOrgSpec
 } from '../crd/types.js'
 import type { Observations, ReconcileContext } from './context.js'
+import { namespaceFault, orgNamespace } from './namespace.js'
 import {
   APP_LABEL_KEY,
   RUNTIME_TIER_PREFIX,
@@ -34,6 +35,13 @@ import {
 export interface EnvelopeInputs {
   orgName: string
   spec: AgentConnectOrgSpec
+  /** Resolved once per pass — see {@link orgNamespace}. Validated by `ensureNamespace`. */
+  namespace: string
+}
+
+/** The one place envelope inputs are built, so the namespace is resolved exactly once per pass. */
+export function envelopeInputs(ctx: ReconcileContext, orgName: string, spec: AgentConnectOrgSpec): EnvelopeInputs {
+  return { orgName, spec, namespace: orgNamespace(ctx.config.orgNamespacePrefix, orgName, spec.targetNamespace) }
 }
 
 /** Daemon supervisor resource tiers; unknown tier names fall back to `small` with a warning. */
@@ -47,14 +55,14 @@ function envelopeLabels(orgName: string, extra: Record<string, string> = {}): Re
   return { [ORG_LABEL]: orgName, ...extra }
 }
 
-/** Create-or-adopt spec.targetNamespace: claim by label, reject a label-mismatched existing namespace as Degraded. */
+/** Create-or-adopt the resolved namespace: claim by label, reject a label-mismatched existing namespace as Degraded. */
 export async function ensureNamespace(ctx: ReconcileContext, input: EnvelopeInputs, obs: Observations): Promise<void> {
-  const name = input.spec.targetNamespace
-  if (!name.startsWith(ctx.config.orgNamespacePrefix)) {
-    obs.degraded = {
-      reason: 'NamespaceOutsidePrefix',
-      message: `targetNamespace ${name} is outside this install's prefix ${ctx.config.orgNamespacePrefix}`
-    }
+  const name = input.namespace
+  // An override can name a namespace this install does not own; a CR name legal for a
+  // Kubernetes object can still make an illegal namespace once prefixed.
+  const fault = namespaceFault(ctx.config.orgNamespacePrefix, name)
+  if (fault) {
+    obs.degraded = fault
     return
   }
   const existing = await getOrNull<K8sResource>(ctx.http, namespacePath(name))
@@ -87,7 +95,7 @@ export async function ensureServiceAccounts(
   input: EnvelopeInputs,
   obs: Observations
 ): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   await applyObject(ctx.http, corePath(ns, 'serviceaccounts', DAEMON_NAME), {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
@@ -109,7 +117,7 @@ export async function ensureRoleAndBinding(
   input: EnvelopeInputs,
   obs: Observations
 ): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   const rbac = 'rbac.authorization.k8s.io/v1'
   await applyObject(ctx.http, groupPath(rbac, ns, 'roles', DAEMON_NAME), {
     apiVersion: rbac,
@@ -141,7 +149,7 @@ export async function ensureTokenReviewClusterRoleBinding(
   input: EnvelopeInputs,
   obs: Observations
 ): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   // Cluster-scoped, so no namespace cascade covers it — the finalizer deletes it explicitly.
   await applyObject(ctx.http, clusterRoleBindingPath(tokenReviewBindingName(ns)), {
     apiVersion: 'rbac.authorization.k8s.io/v1',
@@ -163,7 +171,7 @@ export async function ensureNetworkPolicies(
   input: EnvelopeInputs,
   obs: Observations
 ): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   const netv1 = 'networking.k8s.io/v1'
   const daemonPods = { podSelector: { matchLabels: { [APP_LABEL_KEY]: DAEMON_NAME } } }
   await applyObject(ctx.http, groupPath(netv1, ns, 'networkpolicies', DAEMON_EGRESS_POLICY_NAME), {
@@ -212,7 +220,7 @@ export async function ensureQuotaAndLimitRange(
   input: EnvelopeInputs,
   obs: Observations
 ): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   const quota = input.spec.quota
   const hard: Record<string, string> = {}
   if (quota.maxAgents > 0) hard['count/sandboxclaims.extensions.agents.x-k8s.io'] = String(quota.maxAgents)
@@ -287,7 +295,7 @@ export async function ensureSandboxTemplates(
   input: EnvelopeInputs,
   obs: Observations
 ): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   for (const tier of input.spec.runtime.tiers) {
     const masterName = `${ctx.config.masterTemplatePrefix}${tier.name}`
     const master = await getOrNull<SandboxTemplateResource>(
@@ -333,7 +341,7 @@ export async function ensureSandboxTemplates(
 
 /** The CR is the sole desired-state carrier: tiers removed from spec lose their pool and template. */
 async function pruneRemovedTiers(ctx: ReconcileContext, input: EnvelopeInputs): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   // A still-desired tier keeps its objects even when its master vanished: they are the
   // last-known-good render, and a control-namespace hiccup must not tear down a live pool.
   const desired = new Set(input.spec.runtime.tiers.map((tier) => runtimeTierName(tier.name)))
@@ -354,7 +362,7 @@ async function pruneRemovedTiers(ctx: ReconcileContext, input: EnvelopeInputs): 
 
 /** The daemon's ReadWriteOncePod PVC (transcripts + state), sized and classed by the install. */
 export async function ensureDaemonPvc(ctx: ReconcileContext, input: EnvelopeInputs, obs: Observations): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   const storageClass = ctx.config.daemonStorageClass
   // RWOP is load-bearing: the Recreate strategy assumes the volume can never double-attach.
   await applyObject(ctx.http, corePath(ns, 'persistentvolumeclaims', DAEMON_PVC_NAME), {
@@ -377,7 +385,7 @@ export async function ensureDaemonDeployment(
   input: EnvelopeInputs,
   obs: Observations
 ): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   const daemon = input.spec.daemon
   const tier = DAEMON_TIERS[daemon.tier]
   if (!tier) obs.warnings.push(`unknown daemon tier ${daemon.tier}; using small`)
@@ -465,7 +473,7 @@ export async function ensureDaemonService(
   input: EnvelopeInputs,
   obs: Observations
 ): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   await applyObject(ctx.http, corePath(ns, 'services', SHIM_SERVICE_NAME), {
     apiVersion: 'v1',
     kind: 'Service',

--- a/packages/operator/src/reconcile/finalizer.test.ts
+++ b/packages/operator/src/reconcile/finalizer.test.ts
@@ -12,11 +12,11 @@ afterEach(closeFakeApiServers)
 
 const NS = 'test-ac-org-acme'
 
-function orgOf(targetNamespace = NS): AgentConnectOrg {
+function orgOf(name = 'acme', targetNamespace?: string): AgentConnectOrg {
   return {
-    metadata: { name: 'acme', resourceVersion: '1', deletionTimestamp: 'now', finalizers: [FINALIZER] },
+    metadata: { name, resourceVersion: '1', deletionTimestamp: 'now', finalizers: [FINALIZER] },
     spec: {
-      targetNamespace,
+      ...(targetNamespace ? { targetNamespace } : {}),
       daemon: { image: 'x', tier: 'small', credentialSecretName: 'ac-daemon-token' },
       runtime: { image: 'x', tiers: [] },
       suspend: false,
@@ -179,7 +179,14 @@ describe('reconcileDeletion', () => {
   })
 
   it('touches nothing outside the install prefix except the finalizer', async () => {
-    const { recorded } = await run({ org: orgOf('other-prefix-acme') })
+    const { recorded } = await run({ org: orgOf('acme', 'other-prefix-acme') })
+    expect(recorded).toHaveLength(1)
+    expect(recorded[0].path.includes('/agentconnectorgs/')).toBe(true)
+  })
+
+  // A CR name is a DNS subdomain, so dots are legal on the object and illegal in the namespace it derives.
+  it('touches nothing but the finalizer when the name derives no legal namespace', async () => {
+    const { recorded } = await run({ org: orgOf('acme.example') })
     expect(recorded).toHaveLength(1)
     expect(recorded[0].path.includes('/agentconnectorgs/')).toBe(true)
   })

--- a/packages/operator/src/reconcile/finalizer.ts
+++ b/packages/operator/src/reconcile/finalizer.ts
@@ -1,6 +1,7 @@
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import { NAMESPACE_CLAIM_LABEL, FINALIZER, ORG_LABEL, type AgentConnectOrg } from '../crd/types.js'
 import type { ReconcileContext } from './context.js'
+import { namespaceFault, orgNamespace } from './namespace.js'
 import {
   APP_LABEL_KEY,
   DAEMON_NAME,
@@ -122,9 +123,10 @@ export async function removeFinalizer(ctx: ReconcileContext, org: AgentConnectOr
 
 /** The envelope deletion order; steps must be idempotent — deletion reconciles can repeat. */
 export async function reconcileDeletion(ctx: ReconcileContext, org: AgentConnectOrg): Promise<void> {
-  const ns = org.spec?.targetNamespace
-  // Outside our prefix nothing was ever provisioned: only the finalizer is ours.
-  if (!ns || !ns.startsWith(ctx.config.orgNamespacePrefix)) {
+  const orgName = org.metadata?.name
+  const ns = orgName ? orgNamespace(ctx.config.orgNamespacePrefix, orgName, org.spec?.targetNamespace) : undefined
+  // Outside our prefix, or no legal namespace at all, nothing was ever provisioned: only the finalizer is ours.
+  if (!ns || namespaceFault(ctx.config.orgNamespacePrefix, ns)) {
     await removeFinalizer(ctx, org)
     return
   }

--- a/packages/operator/src/reconcile/namespace.test.ts
+++ b/packages/operator/src/reconcile/namespace.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { namespaceFault, orgNamespace } from './namespace.js'
+
+const PREFIX = 'test-ac-org-'
+
+describe('orgNamespace', () => {
+  it('derives the install prefix followed by the CR name when nothing is declared', () => {
+    expect(orgNamespace(PREFIX, 'acme')).toBe('test-ac-org-acme')
+  })
+
+  it('honours a declared override', () => {
+    expect(orgNamespace(PREFIX, 'acme', 'test-ac-org-legacy')).toBe('test-ac-org-legacy')
+  })
+
+  // Two CRs in one control namespace cannot share a name, and the prefix is per install.
+  it('separates two orgs under one install', () => {
+    expect(orgNamespace(PREFIX, 'acme')).not.toBe(orgNamespace(PREFIX, 'globex'))
+  })
+})
+
+describe('namespaceFault', () => {
+  it('accepts a derived name', () => {
+    expect(namespaceFault(PREFIX, orgNamespace(PREFIX, 'acme'))).toBeUndefined()
+  })
+
+  it('accepts an override inside the install prefix', () => {
+    expect(namespaceFault(PREFIX, 'test-ac-org-legacy')).toBeUndefined()
+  })
+
+  it('rejects an override outside the install prefix', () => {
+    expect(namespaceFault(PREFIX, 'other-prefix-acme')?.reason).toBe('NamespaceOutsidePrefix')
+  })
+
+  // Object names are DNS subdomains, so dots reach this check from a perfectly legal CR.
+  it('rejects a resolved name that is not a DNS label', () => {
+    expect(namespaceFault(PREFIX, orgNamespace(PREFIX, 'acme.example'))?.reason).toBe('InvalidNamespaceName')
+  })
+
+  it('rejects a resolved name longer than a DNS label', () => {
+    const fault = namespaceFault(PREFIX, orgNamespace(PREFIX, 'a'.repeat(64)))
+    expect(fault?.reason).toBe('InvalidNamespaceName')
+    expect(fault?.message).toContain('63')
+  })
+})

--- a/packages/operator/src/reconcile/namespace.ts
+++ b/packages/operator/src/reconcile/namespace.ts
@@ -1,0 +1,39 @@
+/** Kubernetes namespaces are DNS labels: ≤63 chars, lowercase alphanumeric and dashes (RFC 1123). */
+const DNS_LABEL = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/
+const MAX_DNS_LABEL = 63
+
+/** Degraded reason for a resolved name that could never be a namespace. */
+export const REASON_INVALID_NAMESPACE_NAME = 'InvalidNamespaceName'
+/** Degraded reason for an override naming a namespace this install does not own. */
+export const REASON_NAMESPACE_OUTSIDE_PREFIX = 'NamespaceOutsidePrefix'
+
+/**
+ * The org's envelope namespace. Normally derived — the install's prefix plus the
+ * CR name, which is unique within the control namespace, so nothing has to be
+ * declared and nothing can collide. `spec.targetNamespace` is the deployment's
+ * escape hatch when a specific namespace is required; it is fenced by the same
+ * prefix and validated below.
+ */
+export function orgNamespace(prefix: string, orgName: string, declared?: string): string {
+  return declared ?? `${prefix}${orgName}`
+}
+
+/** Why the resolved namespace is unusable, or undefined when it is fine. */
+export function namespaceFault(prefix: string, namespace: string): { reason: string; message: string } | undefined {
+  if (!namespace.startsWith(prefix)) {
+    return {
+      reason: REASON_NAMESPACE_OUTSIDE_PREFIX,
+      message: `namespace ${namespace} is outside this install's prefix ${prefix}`
+    }
+  }
+  if (namespace.length > MAX_DNS_LABEL) {
+    return {
+      reason: REASON_INVALID_NAMESPACE_NAME,
+      message: `namespace ${namespace} is longer than the ${MAX_DNS_LABEL}-character DNS label limit`
+    }
+  }
+  if (!DNS_LABEL.test(namespace)) {
+    return { reason: REASON_INVALID_NAMESPACE_NAME, message: `namespace ${namespace} is not a DNS label` }
+  }
+  return undefined
+}

--- a/packages/operator/src/reconcile/reconcile.test.ts
+++ b/packages/operator/src/reconcile/reconcile.test.ts
@@ -16,7 +16,6 @@ function orgOf(suspend: boolean): AgentConnectOrg {
   return {
     metadata: { name: 'acme', resourceVersion: '1', generation: 1, finalizers: [FINALIZER] },
     spec: {
-      targetNamespace: NS,
       suspend,
       daemon: { image: 'ghcr.io/example/daemon:v1', tier: 'small', credentialSecretName: 'ac-daemon-token' },
       runtime: { image: 'ghcr.io/example/runtime:v1', tiers: [] },

--- a/packages/operator/src/reconcile/reconcile.ts
+++ b/packages/operator/src/reconcile/reconcile.ts
@@ -1,7 +1,7 @@
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import { AgentConnectOrgSpecSchema, FINALIZER, type AgentConnectOrg } from '../crd/types.js'
 import { newObservations, type ReconcileContext } from './context.js'
-import { reconcileEnvelope, type EnvelopeInputs } from './envelope.js'
+import { envelopeInputs, reconcileEnvelope, type EnvelopeInputs } from './envelope.js'
 import { daemonPodsGone, reconcileDeletion, suspendAllSandboxes } from './finalizer.js'
 import { renderGatewayPolicies } from './gateway-limits.js'
 import { reconcileRollout } from './rollout.js'
@@ -32,14 +32,14 @@ export async function reconcile(ctx: ReconcileContext, name: string): Promise<Wo
     await writeStatus(ctx, org, obs)
     return {}
   }
-  const input: EnvelopeInputs = { orgName: name, spec: parsed.data }
+  const input: EnvelopeInputs = envelopeInputs(ctx, name, parsed.data)
   await reconcileEnvelope(ctx, input, obs)
   // suspend also quiesces bound Sandboxes — but only after the daemon pod finished draining,
   // since suspension deletes the runtime pod a mid-drain daemon may still be using. The
   // org-labeled pod deletion event re-enqueues this CR the moment the daemon is gone.
   if (input.spec.suspend && obs.namespaceReady) {
-    if (await daemonPodsGone(ctx, input.spec.targetNamespace)) {
-      await suspendAllSandboxes(ctx, input.spec.targetNamespace)
+    if (await daemonPodsGone(ctx, input.namespace)) {
+      await suspendAllSandboxes(ctx, input.namespace)
     } else {
       obs.progressing = true
     }

--- a/packages/operator/src/reconcile/resources.ts
+++ b/packages/operator/src/reconcile/resources.ts
@@ -23,8 +23,8 @@ export const SANDBOX_GROUP = 'agents.x-k8s.io/v1beta1'
 export const SANDBOX_EXTENSIONS_GROUP = 'extensions.agents.x-k8s.io/v1beta1'
 
 /** The per-org ClusterRoleBinding name; unique because namespaces are prefix-disjoint per install. */
-export function tokenReviewBindingName(targetNamespace: string): string {
-  return `ac-tokenreview-${targetNamespace}`
+export function tokenReviewBindingName(namespace: string): string {
+  return `ac-tokenreview-${namespace}`
 }
 
 export function runtimeTierName(tier: string): string {

--- a/packages/operator/src/reconcile/rollout.test.ts
+++ b/packages/operator/src/reconcile/rollout.test.ts
@@ -18,8 +18,8 @@ const START = Date.parse('2026-01-01T00:00:00.000Z')
 function inputOf(): EnvelopeInputs {
   return {
     orgName: 'acme',
+    namespace: NS,
     spec: AgentConnectOrgSpecSchema.parse({
-      targetNamespace: NS,
       daemon: { image: 'ghcr.io/example/daemon:v1', tier: 'small' },
       runtime: { image: TARGET, tiers: [{ name: 'std' }] }
     })

--- a/packages/operator/src/reconcile/rollout.ts
+++ b/packages/operator/src/reconcile/rollout.ts
@@ -52,7 +52,7 @@ async function patchSandbox(
  */
 export async function reconcileRollout(ctx: ReconcileContext, input: EnvelopeInputs, obs: Observations): Promise<void> {
   if (!obs.namespaceReady || input.spec.suspend) return
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   const target = input.spec.runtime.image
   const rolloutId = createHash('sha256').update(target).digest('hex').slice(0, 8)
   const now = (ctx.clock ?? systemClock).now()

--- a/packages/operator/src/reconcile/status.test.ts
+++ b/packages/operator/src/reconcile/status.test.ts
@@ -139,8 +139,8 @@ describe('observeWorkloads', () => {
     const { AgentConnectOrgSpecSchema } = await import('../crd/types.js')
     const input = {
       orgName: 'acme',
+      namespace: 'test-ac-org-acme',
       spec: AgentConnectOrgSpecSchema.parse({
-        targetNamespace: 'test-ac-org-acme',
         suspend,
         daemon: { image: 'ghcr.io/example/daemon:v2', tier: 'small', ...daemonSpec },
         runtime: { image: 'x', tiers: [] }

--- a/packages/operator/src/reconcile/status.ts
+++ b/packages/operator/src/reconcile/status.ts
@@ -204,7 +204,7 @@ async function observeCredential(
 
 /** Read the live workload state the status summaries derive from. */
 export async function observeWorkloads(ctx: ReconcileContext, input: EnvelopeInputs, obs: Observations): Promise<void> {
-  const ns = input.spec.targetNamespace
+  const ns = input.namespace
   const deployment = await getOrNull<DeploymentRead>(ctx.http, groupPath('apps/v1', ns, 'deployments', DAEMON_NAME))
   if (deployment) {
     const desired = deployment.spec?.replicas ?? 0

--- a/packages/web/src/components/console/ClusterExecutionCard.test.tsx
+++ b/packages/web/src/components/console/ClusterExecutionCard.test.tsx
@@ -30,7 +30,7 @@ import { ClusterExecutionCard } from './ClusterExecutionCard'
 
 const SETTINGS: ClusterExecutionSettingsDto = {
   enabled: true,
-  targetNamespace: 'ac-org-acme',
+  resourceName: 'acme',
   controlNamespace: 'agentconnect-control',
   suspend: false,
   daemonImage: 'registry.example.test/daemon:1',
@@ -45,6 +45,7 @@ const SETTINGS: ClusterExecutionSettingsDto = {
 
 const STATUS: ClusterEnvelopeStatusDto = {
   present: true,
+  namespace: 'ac-org-acme',
   conditions: [
     { type: 'Ready', status: 'True' },
     { type: 'CredentialReady', status: 'False', reason: 'Pending' },

--- a/packages/web/src/components/console/ClusterExecutionCard.tsx
+++ b/packages/web/src/components/console/ClusterExecutionCard.tsx
@@ -150,8 +150,8 @@ export function ClusterExecutionCard({ orgId, isOwner }: { orgId: string | undef
       <div className="cardhead justify-between">
         <span className="inline-flex min-w-0 items-baseline gap-[7px]">
           <span className="cardtitle">Cluster execution</span>
-          {settings?.enabled && (
-            <span className="mono truncate text-[11px] text-(--text-tertiary)">{settings.targetNamespace}</span>
+          {settings?.enabled && status?.namespace && (
+            <span className="mono truncate text-[11px] text-(--text-tertiary)">{status.namespace}</span>
           )}
         </span>
         {settings?.enabled && (
@@ -374,8 +374,8 @@ function ConditionBadge({ condition }: { condition: ClusterConditionDto }) {
   )
 }
 
-/** The spec fields the control plane owns. `targetNamespace` and the Secret name
- *  are fixed at first enable — the CRD marks both immutable — so neither is here. */
+/** The spec fields the control plane owns. The resource name and the Secret name
+ *  are fixed at first enable, and the namespace is the operator's, so none is here. */
 function ConfigureSheet({
   settings,
   orgId,

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2250,8 +2250,9 @@ export interface ClusterQuotaDto {
 
 export interface ClusterExecutionSettingsDto {
   enabled: boolean
-  /** Derived once at first enable; immutable afterwards, like the Secret name. */
-  targetNamespace: string
+  /** The org's AgentConnectOrg name, derived once at first enable. The envelope
+   *  namespace is not here — the operator publishes it on the resource status. */
+  resourceName: string
   controlNamespace: string
   suspend: boolean
   daemonImage: string


### PR DESCRIPTION
## Why

`AgentConnectOrg.spec.targetNamespace` was **required**, so every CR named its own envelope namespace. Two CRs could name the same one, or one outside the install's prefix, and the operator could only notice after the fact (`NamespaceOutsidePrefix` → `Degraded`). The namespace should be a function of install-time constants plus the CR's identity, so a collision is impossible by construction.

## What changed

**The namespace is configurable at two levels, and derived by default.**

1. _Install_ — `AC_ORG_NAMESPACE_PREFIX` / chart `orgNamespacePrefix` fences every org namespace, unchanged.
2. _Per org_ — `spec.targetNamespace` becomes **optional**:
   - **unset** (the normal path, and what the control plane always writes) ⇒ the operator resolves `<prefix><CR name>`. The CR name is unique within the control namespace and the prefix is unique per install, so two envelopes can never collide;
   - **set** ⇒ still fenced by the prefix, so today's `NamespaceOutsidePrefix` → `Degraded` branch stays. Still immutable — the CEL rule now tests presence on both sides, so an org can move neither between namespaces nor between derived and overridden.

`reconcile/namespace.ts` is the one helper that resolves (`spec.targetNamespace ?? prefix + CR name`) and validates. The resolved name lands on `EnvelopeInputs`, so a pass derives it exactly once and `envelope` / `rollout` / `status` / `reconcile` all read that one value; `finalizer` resolves it the same way for the deletion path.

A resolved name must be a DNS label — a CR name that is legal for a Kubernetes object (a DNS *subdomain*) can still derive an illegal namespace — and an illegal one lands `Degraded/InvalidNamespaceName` with **no envelope objects written**, exactly like the prefix violation. The claim-label guard (`NamespaceClaimConflict`) and the whole deletion-path claim fencing are untouched.

`status.namespace` still publishes atomically with `NamespaceReady` and is now the only place a consumer learns the namespace, so the CRD's printer column reads it instead of the spec.

**Control plane** (`src/cluster/`) stops sending the field and reads the namespace back from `status.namespace` — including the credential authority's Secret publish, which now resolves it **before** minting, so a key is never minted with nowhere to be published (a CR without `status.namespace` yet answers the same `409 CLUSTER_NAMESPACE_NOT_READY` an uncreated namespace already did). Server-side apply only prunes fields this manager owns, so an override written by hand survives every apply.

**The stored column is renamed, not kept vestigial.** What the control plane still owns is the CR *name* — which is what `targetNamespace` really held, since the CR name equalled the namespace. It is now `resourceName` on `org_cluster_execution` and `pending_envelope_teardown`, holding the folded org id *without* the prefix, truncated so the operator's prefixed namespace still fits 63 characters. I chose the rename over keeping a column whose name lies about its contents; `20260814000000_org_envelope_resource_name` is a pure `RENAME COLUMN` + index rename, and v1alpha1 has no production consumers (cluster execution is off by default).

A row written *before* the migration keeps its old prefixed value, and its CR still carries the `spec.targetNamespace` the old writer set. Because server-side apply drops a field its own manager stops sending, the CRD's immutability rule **rejects** that apply rather than letting the org silently move to a doubly-prefixed namespace — so such a row is retired, not migrated (disable, delete the row, enable again). The migration says so in place.

The console shows the live `status.namespace` instead of the stored value, and the settings DTO carries `resourceName` in place of `targetNamespace`.

## Tests

All three paths are covered: derived (field unset), honoured override (set, in-prefix — writes land in the override and not in the derived namespace), and rejected override (set, out-of-prefix ⇒ `Degraded`, zero writes), plus two `InvalidNamespaceName` cases (a dotted CR name, an over-long one) and the finalizer's equivalents. New unit file for the helper; CP tests gain "the emitted spec never carries the override the CRD still offers" and "refuses to publish before the operator has published the namespace".

Verified: `pnpm --filter @agentconnect.md/operator test`, control-plane `test:unit` + `test:int` (Docker), `pnpm typecheck`, `pnpm lint`, `prettier --check`, `helm lint charts/operator`, plus `helm template` to confirm the rendered CRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
