### PR TITLE
fix(web): support browsers without randomUUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ references.
 Open `http://localhost:3000`. The default stack listens only on `127.0.0.1`,
 uses local no-auth mode, and is intended for local evaluation.
 
+Use HTTPS when exposing the console beyond loopback; authentication and daemon
+traffic still rely on a secure deployment boundary. The Web console does not,
+however, require the secure-context-only `crypto.randomUUID()` API to mint its
+non-secret client request IDs, so browsers without that API can still use the
+local evaluation flow.
+
 The Compose stack does not run agent daemons. Add a daemon from the Web console,
 then run its generated command on each machine that should host agents,
 workspaces, and runtime credentials.

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -37,6 +37,7 @@ import {
   type SessionMessageDto
 } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
+import { randomUuid } from '@/lib/random-uuid'
 import { resolveRoster, typedMentionIds, wireMentions } from '@/lib/conversation-addressing'
 import { sessionAfterModelSelection } from '@/lib/session-runtime-controls'
 import { reconcilePersistedLiveSteps } from '@/lib/session-transcript'
@@ -176,11 +177,7 @@ function liveActivityStamp(): Pick<Session, 'lastActivityAt' | 'time'> {
 }
 
 function newPlaygroundSessionId(agentId: string): string {
-  const entropy =
-    typeof crypto !== 'undefined' && crypto.randomUUID
-      ? crypto.randomUUID()
-      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
-  return `${PG_PREFIX}${agentId}_${entropy}`
+  return `${PG_PREFIX}${agentId}_${randomUuid()}`
 }
 
 function stampStep(step: SessionStep, observedAtMs = Date.now()): SessionStep {
@@ -1129,7 +1126,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       conversationId?: string,
       knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>
     ): void => {
-      const requestedTurnId = crypto.randomUUID()
+      const requestedTurnId = randomUuid()
       pushStep(id, { kind: 'msg', who: '@you', turnId: requestedTurnId, text, ...(image ? { image } : {}) })
       setBusy(id, true)
       // Targeting (webchat-multi-agents.md §4.2): conversation membership is a
@@ -1242,7 +1239,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       // between a turn's end and the dispatch of the queue head stays FIFO.
       if (busyRef.current[id] || (pgQueueRef.current[id]?.length ?? 0) > 0) {
         const queued: QueuedTurn = {
-          queueId: crypto.randomUUID(),
+          queueId: randomUuid(),
           text,
           ...(image ? { image } : {}),
           agentId: agentForId,

--- a/packages/web/src/components/console/modals/AddCronModal.tsx
+++ b/packages/web/src/components/console/modals/AddCronModal.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/cron'
 import { useConsoleData } from '@/lib/data-context'
 import { useProfile } from '@/lib/profile'
+import { randomUuid } from '@/lib/random-uuid'
 import { AgentIconView, PlatformMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { VisibilityField, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
@@ -201,7 +202,7 @@ export default function AddCronModal({ cron, onClose }: { cron?: CronDto | null;
         ? { integrationId: selectedOpt.integrationId, channel: selectedOpt.channelId, platform: selectedOpt.platform }
         : target
       const creating = !cron
-      const cronId = cron?.id ?? crypto.randomUUID()
+      const cronId = cron?.id ?? randomUuid()
       const existingInput = cron ? cronUpdateInput(cron) : null
       await saveCron(cronId, {
         ...(existingInput ?? {}),

--- a/packages/web/src/components/console/platforms/telegram/Body.tsx
+++ b/packages/web/src/components/console/platforms/telegram/Body.tsx
@@ -6,6 +6,7 @@ import { PlatformMark } from '@/components/marks'
 import { Icon } from '@/components/ui'
 import { checkTelegramBot, type TelegramBotCheckDto } from '@/lib/api'
 import type { Agent } from '@/lib/data'
+import { randomUuid } from '@/lib/random-uuid'
 import type { WizardHost } from '../contract'
 import { usePublishedFooter } from '../publish'
 import { TokenGuidePane } from '../wizard-chrome'
@@ -89,7 +90,7 @@ export function TelegramWizardBody({ agent, host }: { agent: Agent; host: Wizard
   const tokenTrim = botToken.trim()
   const telegramOk = /^\d+:[A-Za-z0-9_-]{20,}$/.test(tokenTrim)
 
-  const [checkScope] = useState(() => crypto.randomUUID())
+  const [checkScope] = useState(randomUuid)
   const checkSequence = useRef(0)
   const [checkRequest, setCheckRequest] = useState<{ token: string; sequence: number } | null>(null)
   const checkEnabled = host.mode === 'create' && telegramOk

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -12,6 +12,7 @@ import useSWR, { useSWRConfig } from 'swr'
 import { useOrgs } from '@/lib/org-context'
 import { consoleKeys } from '@/lib/swr-keys'
 import { useSessionList } from '@/lib/use-session-list'
+import { randomUuid } from '@/lib/random-uuid'
 import { accessNotificationSnapshot, type AccessNotificationSnapshot } from '@/lib/access-notification-snapshot'
 import {
   AGENTS,
@@ -1350,7 +1351,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   // just mints a fresh client-side UUID (the CP keys the row on it).
   const saveCron = useCallback(
     async (id: string | null, body: UpsertCronInput) => {
-      await apiUpsertCron(id ?? crypto.randomUUID(), body)
+      await apiUpsertCron(id ?? randomUuid(), body)
       settleInBackground(mutateCrons())
     },
     [mutateCrons]

--- a/packages/web/src/lib/random-uuid.test.ts
+++ b/packages/web/src/lib/random-uuid.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { randomUuid } from './random-uuid'
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('randomUuid', () => {
+  it('uses the native implementation when available', () => {
+    const native = '11111111-1111-4111-8111-111111111111'
+    vi.stubGlobal('crypto', { randomUUID: vi.fn(() => native) })
+
+    expect(randomUuid()).toBe(native)
+  })
+
+  it('generates a UUIDv4 with getRandomValues when randomUUID is unavailable', () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.fill(0xab)
+        return bytes
+      }
+    })
+
+    expect(randomUuid()).toBe('abababab-abab-4bab-abab-abababababab')
+  })
+
+  it('still generates a UUIDv4 when Web Crypto is unavailable', () => {
+    vi.stubGlobal('crypto', undefined)
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    expect(randomUuid()).toMatch(UUID_V4)
+  })
+})

--- a/packages/web/src/lib/random-uuid.ts
+++ b/packages/web/src/lib/random-uuid.ts
@@ -1,0 +1,23 @@
+/**
+ * Mint a UUID in browsers where `crypto.randomUUID()` is unavailable, notably
+ * pages served over a non-secure HTTP origin. IDs produced here are identifiers,
+ * not credentials: Web Crypto entropy is preferred, with Math.random as the
+ * last-resort compatibility path.
+ */
+export function randomUuid(): string {
+  const webCrypto = globalThis.crypto
+  if (typeof webCrypto?.randomUUID === 'function') return webCrypto.randomUUID()
+
+  const bytes = new Uint8Array(16)
+  if (typeof webCrypto?.getRandomValues === 'function') {
+    webCrypto.getRandomValues(bytes)
+  } else {
+    for (let i = 0; i < bytes.length; i += 1) bytes[i] = Math.floor(Math.random() * 256)
+  }
+
+  // RFC 4122 / RFC 9562 UUIDv4 version and variant bits.
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}


### PR DESCRIPTION
## What changed

- add a shared browser UUID helper that prefers `crypto.randomUUID()`
- fall back to `crypto.getRandomValues()` and, only when Web Crypto is absent, a non-cryptographic UUIDv4-compatible identifier
- use the helper for playground sessions and turns, queued messages, cron IDs, and Telegram probe scopes
- document the HTTP compatibility behavior while continuing to recommend HTTPS beyond loopback

## Why

`crypto.randomUUID()` is restricted to secure contexts in browsers. Opening a self-hosted AgentConnect console over plain HTTP from another LAN machine made message sending and other client-ID flows throw `TypeError: crypto.randomUUID is not a function`.

These values are correlation identifiers rather than credentials, so a compatibility fallback keeps the console functional without weakening secret generation.

## Impact

Self-hosted users can use the affected console flows in browsers where `crypto.randomUUID()` is unavailable. HTTPS remains the recommended deployment boundary for non-loopback access.

## Validation

- `pnpm --filter @agentconnect.md/web test` — 1,448 tests passed
- `pnpm --filter @agentconnect.md/web typecheck`
- ESLint on all touched Web source and test files
- focused UUID fallback tests — 3 passed
