### PR TITLE
fix(operator): let the org daemon reach its own control namespace

### DIFF
--- a/packages/operator/src/reconcile/envelope.test.ts
+++ b/packages/operator/src/reconcile/envelope.test.ts
@@ -130,6 +130,15 @@ describe('reconcileEnvelope', () => {
     expect(byPath(writes, '/networkpolicies/ac-daemon-egress')).toBeDefined()
     expect(byPath(writes, '/networkpolicies/ac-daemon-ingress')).toBeDefined()
 
+    // Without this the daemon's registration WebSocket to an in-cluster control plane
+    // never completes — its service port is not 443.
+    const egress = byPath(writes, '/networkpolicies/ac-daemon-egress')?.body as {
+      spec: { egress: Array<{ to?: Array<{ namespaceSelector?: { matchLabels: Record<string, string> } }> }> }
+    }
+    expect(egress.spec.egress).toContainEqual({
+      to: [{ namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': ctx.controlNamespace } } }]
+    })
+
     // All-zero quota means unlimited: the objects are deleted, not written.
     expect(byPath(writes, '/resourcequotas/ac-quota')?.method).toBe('DELETE')
     expect(byPath(writes, '/limitranges/ac-limits')?.method).toBe('DELETE')

--- a/packages/operator/src/reconcile/envelope.ts
+++ b/packages/operator/src/reconcile/envelope.ts
@@ -188,7 +188,11 @@ export async function ensureNetworkPolicies(
             { protocol: 'TCP', port: 53 }
           ]
         },
-        // 443 covers CP/relay/platform/provider APIs; 6443 is the apiserver on most CNIs (CNI-dependent).
+        // The control plane and relay live in the control namespace and are reached on their own
+        // service ports, so 443 alone strands an in-cluster deployment — the daemon's registration
+        // WebSocket never completes and the org is orphaned from its control plane.
+        { to: [{ namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': ctx.controlNamespace } } }] },
+        // 443 covers platform and provider APIs, plus a CP reached over public HTTPS.
         { ports: [{ protocol: 'TCP', port: 443 }] },
         { ports: [{ protocol: 'TCP', port: 6443 }] }
       ]


### PR DESCRIPTION
Found while driving a real org envelope end to end on a cluster.

## The bug

`ensureNetworkPolicies` gave the daemon egress to DNS, TCP/443 and TCP/6443, with the comment "443 covers CP/relay/platform/provider APIs". That only holds when the control plane sits behind a public HTTPS endpoint. In an in-cluster deployment the CP and relay are ordinary Services on their own ports, so every daemon connection attempt was dropped:

```
[agentconnect] INFO  cp: connecting to http://<cp-service>.<control-ns>.svc.cluster.local:<port>…
[agentconnect] WARN  cp: connect/handshake failed: Opening handshake has timed out
```

The failure is quiet in the worst way. The pod is `Running`, `CredentialReady` is True, `Ready` is `EnvelopeReady` — the envelope looks healthy from the CR — while the org is orphaned from its control plane and only daemon logs say otherwise.

## The fix

One egress rule to the control namespace, the mirror of the ingress rule already present so the relay can forward in:

```ts
{ to: [{ namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': ctx.controlNamespace } } }] }
```

No port list: the CP and relay service ports are deployment properties the operator has no knob for, and the control namespace is already the trust boundary the ingress rule uses. The 443 and 6443 rules stay for platform/provider APIs and the apiserver; the comment now says what 443 is actually for.

## Verification

On a real cluster, with everything else already provisioned, the daemon looped on `Opening handshake has timed out`. Adding exactly this rule to the live policy — and nothing else — let it through:

```
[agentconnect] INFO  cp: adopted daemonId <id> from auth/ok
[agentconnect] INFO  cp: READY (epoch=1, routingEpoch=0)
```

A DNS + TCP probe from inside the pod showed the path open at layer 4 once the rule existed, and an HTTP GET to the CP's `/health` returned 200. The sandbox side is unaffected — the daemon had already claimed a sandbox, bound its shim channel, and probed the runtimes inside it.

113 operator tests pass, including a new assertion that the egress list carries the control-namespace rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)