### PR TITLE
fix: let a cluster agent's workspace be edited, and make a rejected edit recoverable

### DIFF
--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -296,15 +296,22 @@ back edit takes its intent with it, and a repository **rename** — the same cha
 without `reconcileWorkspace` — writes no intent at all and keeps its existing behaviour of
 repointing the checkout rather than replacing it.
 
-**A rejected activation gives back its intent, never its marker.** `ensureHostAsync` runs before
-the ACK, so preparation may already have replaced the volume when the activation is rejected —
-for an ACP failure, a supersession, or a staging-commit failure — and nothing reaches a pod's tree
-to put the old checkout back. Restoring the marker there would claim the volume still holds the
-previous workspace, and the CP's own rollback would then be ACKed onto the rejected repository
-with a pull failure degrading quietly. Left alone, the marker keeps describing what the volume
-actually holds, the restored definition's activation sees a changed workspace, and the reverse
-conversion is armed by the ordinary rule — so the recovery does not depend on the rollback closure
-running at all.
+**A rejected activation gives back nothing — and that is the point.** `ensureHostAsync` runs
+before the ACK, so preparation may already be replacing the volume when the activation is rejected
+— for an ACP failure, a supersession, or a staging-commit failure — and nothing reaches a pod's
+tree to undo it. Withdrawing the intent, or restoring the marker, would tell the CP's restored
+definition that nothing changed, and it would repoint the rejected tree and be ACKed onto it with
+a pull failure degrading quietly. Left standing, the pair says the volume is unattributable and
+whichever definition arrives next re-materializes it — so the recovery needs no rollback to run at
+all. A stale intent costs nothing: a marker that proves the target ends the conversion.
+
+**The marker is dropped before the checkout is, not after.** Everything between the two — the
+clone, its repo-local helper pin, the marker write itself — can fail, and every one of those leaves
+a volume holding the new tree that nothing has proved. A marker still naming the emptied workspace
+during that stretch is the same lie as restoring one, so it goes first and the destructive step is
+ordered after it. Which is also why the intent's PRESENCE is the gate rather than the workspace it
+names: at that point the volume matches no definition, and the one that arrives next is as likely
+to be the rollback as a retry of the edit.
 
 What this does not cover is a **session-isolated** (worktree) git-repo workspace: that needs
 `worktree add` in the sandbox and a retention GC that reads the pod's tree, and is still refused

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -296,6 +296,16 @@ back edit takes its intent with it, and a repository **rename** — the same cha
 without `reconcileWorkspace` — writes no intent at all and keeps its existing behaviour of
 repointing the checkout rather than replacing it.
 
+**A rejected activation gives back its intent, never its marker.** `ensureHostAsync` runs before
+the ACK, so preparation may already have replaced the volume when the activation is rejected —
+for an ACP failure, a supersession, or a staging-commit failure — and nothing reaches a pod's tree
+to put the old checkout back. Restoring the marker there would claim the volume still holds the
+previous workspace, and the CP's own rollback would then be ACKed onto the rejected repository
+with a pull failure degrading quietly. Left alone, the marker keeps describing what the volume
+actually holds, the restored definition's activation sees a changed workspace, and the reverse
+conversion is armed by the ordinary rule — so the recovery does not depend on the rollback closure
+running at all.
+
 What this does not cover is a **session-isolated** (worktree) git-repo workspace: that needs
 `worktree add` in the sandbox and a retention GC that reads the pod's tree, and is still refused
 by name at session preparation.

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -270,3 +270,32 @@ still goes, through the idle rule above, which is where the cost actually is.
 The delete is best-effort by construction: the durable local removal has already succeeded, and
 failing the lifecycle ACK over a leaked claim would leave the CP and the daemon disagreeing
 about whether the agent exists. A failure is reported with the command that finishes the job.
+
+## 9. Editing the workspace of an agent that already has a volume
+
+A workspace edit is a **replacement**: the console says so, and the local path implements it that
+way — clone beside the target, `renameSync` for an atomic swap, and a rollback that restores the
+previous tree if the activation is refused. None of those three exist through the shim, and the
+step that would need them runs at `agent/activate`, _before_ the CP has acknowledged the edit. So
+the cluster path splits the operation across the two places that can each do half of it.
+
+**Activation records an intent.** It writes the target materialization to a daemon-side file beside
+the marker and returns; it destroys nothing, which is what makes the CP's rollback able to undo it
+by simply activating the original definition again. The marker is deliberately not advanced —
+it says what the volume HOLDS, and preparation reads it back as attestation of the repository.
+
+**Preparation performs it,** inside the bound sandbox, from the pod's own side: empty the checkout,
+then materialize the configured workspace — a clone for a git-repo target, nothing for a scratch
+one, since the checkout's absence IS the scratch workspace. Emptying is fail-closed; a clear that
+did not happen would leave the previous repository's tree serving as the new workspace.
+
+The two disagreeing is what "still due" means, so retries are free and repeats impossible: a failed
+clone leaves an empty checkout that the next preparation clones again, and a marker that has
+advanced to the target ends the conversion whether or not the intent file was cleaned up. A rolled
+back edit takes its intent with it, and a repository **rename** — the same changed URL, arriving
+without `reconcileWorkspace` — writes no intent at all and keeps its existing behaviour of
+repointing the checkout rather than replacing it.
+
+What this does not cover is a **session-isolated** (worktree) git-repo workspace: that needs
+`worktree add` in the sandbox and a retention GC that reads the pod's tree, and is still refused
+by name at session preparation.

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -145,6 +145,7 @@ function make(
     changeBundleAfterFirstActivate?: boolean
     moveOwnershipAfterFirstActivate?: boolean
     rejectWorkspaceActivate?: boolean
+    rejectWorkspaceRestore?: boolean
     workspacePersistenceFailsBeforeCommit?: boolean
     workspacePersistenceFailsAfterCommit?: boolean
     unplaced?: boolean
@@ -179,7 +180,8 @@ function make(
         ...current,
         workspace,
         workspaceRepoId,
-        lastModifiedAt: new Date(current.lastModifiedAt.getTime() + 1)
+        lastModifiedAt: new Date(current.lastModifiedAt.getTime() + 1),
+        configRevision: current.configRevision + 1n
       }
       if (opts.workspacePersistenceFailsAfterCommit) throw new Error('database response lost')
       return current
@@ -193,11 +195,14 @@ function make(
       workspace: AgentRecord['workspace'],
       workspaceRepoId?: bigint
     ) => {
+      // Like the real rollback: it is an edit of its own, so it ADVANCES the revision rather than
+      // rewinding to the rejected edit's predecessor — which is what the target's fence compares.
       current = {
         ...current,
         workspace,
         workspaceRepoId,
-        lastModifiedAt: new Date(current.lastModifiedAt.getTime() + 1)
+        lastModifiedAt: new Date(current.lastModifiedAt.getTime() + 1),
+        configRevision: current.configRevision + 1n
       }
       return current
     },
@@ -209,6 +214,7 @@ function make(
     }
   } as unknown as AgentRepo
   const ack = (ok = true, reason?: string): Ack => ({ ok, ...(reason ? { reason } : {}) })
+  const appliedRevisions = new Map<string, bigint>()
   let targetDetachCount = 0
   const control = {
     agentDetach: async (daemonId: string, value: AgentDetach) => {
@@ -227,8 +233,20 @@ function make(
     agentActivate: async (daemonId: string, value: AgentActivate) => {
       calls.push(`activate:${daemonId}`)
       activations.push(value)
+      // The target's own revision fence, which the CP cannot see and must not violate: a bundle
+      // older than the one this daemon already applied activates stale credentials and is refused.
+      // A rejected activation still leaves its spec applied, so a rollback has to be newer.
+      const incoming = BigInt(value.spec.configRevision ?? '0')
+      const seen = appliedRevisions.get(daemonId) ?? -1n
+      if (incoming < seen) {
+        return ack(false, `agent/activate: spec revision ${incoming} is not newer than the applied configuration`)
+      }
+      appliedRevisions.set(daemonId, incoming)
       if (value.reconcileWorkspace && opts.rejectWorkspaceActivate && activations.length === 1) {
         return ack(false, 'clone failed')
+      }
+      if (value.reconcileWorkspace && opts.rejectWorkspaceRestore && activations.length === 2) {
+        return ack(false, 'workspace is not empty')
       }
       if (daemonId === TARGET && activations.filter((a) => a.agentId === AGENT).length === 1) {
         if (opts.changeBundleAfterFirstActivate) cronRows = [{ ...cron, schedule: '5 * * * *' }]
@@ -367,8 +385,12 @@ describe('AgentMoveService', () => {
   it('rolls the database and daemon back to scratch after a known clone rejection', async () => {
     const t = make({ rejectWorkspaceActivate: true })
 
+    // The rejection itself, not a fail-closed report of a rollback that never landed. The daemon
+    // keeps the applied revision of the bundle it rejected, so restoring the pre-edit ROW would be
+    // refused as stale — and the agent would stay staged and offline with its edit undone in the
+    // database only. The reason the daemon gave rides along, or an operator sees neither failure.
     await expect(t.service.setWorkspace(t.current(), GITHUB_WORKSPACE, WORKSPACE_REPO_ID)).rejects.toThrow(
-      AgentMoveFailed
+      'workspace edit rejected: clone failed'
     )
     expect(t.current().workspace).toEqual({ mode: 'scratch' })
     expect(t.activations).toHaveLength(2)
@@ -379,6 +401,19 @@ describe('AgentMoveService', () => {
       isolation: 'shared',
       gitCredential: 'github-app'
     })
+    expect(BigInt(t.activations[1]!.spec.configRevision!)).toBeGreaterThan(
+      BigInt(t.activations[0]!.spec.configRevision!)
+    )
+  })
+
+  it('reports both failures when the restoration is refused too', async () => {
+    // Fail-closed is the right outcome once the original workspace cannot be brought back — but the
+    // message an operator reads has to name the rejection that started it, which was dropped.
+    const t = make({ rejectWorkspaceActivate: true, rejectWorkspaceRestore: true })
+
+    await expect(t.service.setWorkspace(t.current(), GITHUB_WORKSPACE, WORKSPACE_REPO_ID)).rejects.toThrow(
+      'workspace activation rejection (clone failed) and the original workspace could not be reactivated'
+    )
   })
 
   it('continues from durable GitHub state when the persistence response is lost after commit', async () => {

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -504,7 +504,8 @@ export class AgentMoveService {
     agent: AgentRecord,
     bundle: MoveBundle,
     moveId: string,
-    after: string
+    after: string,
+    detail?: string
   ): Promise<void> {
     try {
       requireAck(
@@ -516,7 +517,12 @@ export class AgentMoveService {
         })
       )
     } catch (err) {
-      throw new AgentMoveFailClosed(`${after} and the original workspace could not be reactivated`, err)
+      // The rejection that started this is what an operator has to act on; the restoration failure
+      // is the reason it is fail-closed. Dropping the first left the message naming only the second.
+      throw new AgentMoveFailClosed(
+        `${after}${detail ? ` (${detail})` : ''} and the original workspace could not be reactivated`,
+        err
+      )
     }
   }
 
@@ -546,7 +552,18 @@ export class AgentMoveService {
         'workspace edit was rejected but the agent changed before rollback; manual recovery is required'
       )
     }
-    await this.restoreDetachedWorkspace(converted.daemonId!, original, bundle, moveId, 'workspace activation rejection')
+    // The RESTORED row, not the pre-edit copy: the rollback advanced its revision past the rejected
+    // edit's, and the daemon's fence refuses a bundle whose spec is not newer than the one it just
+    // applied. Replaying `original` therefore could not restore anything the target had accepted —
+    // every rejected edit ended fail-closed with the agent staged and offline.
+    await this.restoreDetachedWorkspace(
+      converted.daemonId!,
+      restored,
+      bundle,
+      moveId,
+      'workspace activation rejection',
+      reason
+    )
     await this.convergeDerived(restored, bundle.httpBotIds)
     throw new AgentMoveFailed(`workspace edit rejected${reason ? `: ${reason}` : ''}`)
   }

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -344,17 +344,21 @@ function readMaterialization(agent: Agent): string | undefined {
 }
 
 /**
- * The workspace an acknowledged edit asked this agent's POD volume to hold.
+ * That an edit asked this agent's POD volume to be replaced, and which workspace it asked for.
  *
  * A cluster conversion cannot happen where every other one does. The tree is in the pod, the shim
  * offers no rename and no rollback, and activation runs before the edit is even acknowledged — so
  * activation records the intent here and the pod's own preparation carries it out, inside a bound
  * sandbox, where a failed clone is retried like any other. It is deliberately NOT the marker: the
- * marker says what the volume HOLDS, and the two disagreeing is exactly what "still due" means.
+ * marker says what the volume HOLDS, and this says the volume is due to stop holding it.
  *
  * It also separates a conversion from a repository RENAME, which reaches this daemon as the same
  * changed URL but asks for the opposite treatment — repoint the checkout, never replace it. Only a
  * `reconcileWorkspace` activation writes this file, and a rename does not carry one.
+ *
+ * Its PRESENCE is what gates the replacement; the key it records is for diagnosis. A conversion
+ * that cannot be attributed to a workspace is still a conversion — the volume is unattributable
+ * from the moment its checkout is emptied until preparation proves the new one.
  */
 function conversionFile(agent: Agent): string {
   const cwd = agent.workspace.path
@@ -380,13 +384,20 @@ function writePendingConversion(agent: Agent, key: string | undefined): void {
   writeFileSync(file, JSON.stringify({ version: 1, key }, null, 2) + '\n')
 }
 
-/** Whether the pod still has to replace its checkout: an edit asked for THIS workspace and the
- *  marker says the volume holds another. Stays true across retries, false once preparation proved
- *  the new one — so a leftover intent cannot re-wipe a volume that already converged. */
+/**
+ * Whether the pod still has to replace its checkout: a replacement was asked for, and the marker
+ * does not prove the volume already holds what this preparation is for.
+ *
+ * Deliberately not "the intent names THIS workspace". A conversion that emptied the checkout and
+ * then failed — a clone that threw, its helper pin, even the marker write — leaves a volume no
+ * marker can describe, and the definition that arrives next is as likely to be the CP's rollback as
+ * a retry of the edit. Either one has to re-materialize, so presence is the gate and the marker is
+ * the release: it is written only when preparation proved the volume, which is also when the intent
+ * is cleared. That makes a leftover intent inert rather than a repeated wipe.
+ */
 function clusterConversionDue(agent: Agent, stored: string | undefined, target: string): boolean {
   if (sameMaterialization(agent, stored, target)) return false
-  const pending = readPendingConversion(agent)
-  return pending !== undefined && sameMaterialization(agent, pending, target)
+  return readPendingConversion(agent) !== undefined
 }
 
 function sameMaterialization(agent: Agent, previous: string | undefined, target: string): boolean {
@@ -440,6 +451,13 @@ export async function convergeGithubAppWorkspaceRename(agent: Agent): Promise<vo
  * while the checkout still belongs to the recorded source. */
 export function ensureWorkspaceMaterialization(agent: Agent): void {
   if (!existsSync(materializationFile(agent))) recordWorkspaceMaterialization(agent)
+}
+
+/** Say that nothing is known about the volume, for the stretch where nothing IS: a cluster
+ *  conversion between emptying the checkout and proving its replacement. Throws rather than
+ *  leaving a stale marker behind — the destructive step is ordered after it for that reason. */
+function forgetWorkspaceMaterialization(agent: Agent): void {
+  rmSync(materializationFile(agent), { force: true })
 }
 
 function restoreWorkspaceMaterialization(agent: Agent, key: string | undefined): void {
@@ -922,8 +940,17 @@ export async function prepareClusterWorkspace(
   // the volume. Emptying the checkout IS the replacement: a git-repo target then clones below, and a
   // from-scratch one is simply the absence of it. Fail-closed — a clear that did not happen would
   // otherwise leave the previous repository's tree serving as the new workspace.
+  //
+  // The marker is dropped FIRST, and that order is the whole safety property. Everything from the
+  // clear to the proof can fail — the clone, its helper pin, the marker write itself — and a marker
+  // left describing the emptied workspace would tell the CP's rollback that nothing changed, so it
+  // would repoint the rejected tree and ACK an agent running the wrong repository. Unproven instead:
+  // whichever definition arrives next re-materializes the volume before anything runs on it.
   const conversionDue = clusterConversionDue(agent, stored, targetMarker)
-  if (conversionDue) await requireEmptiedSandboxPath(agent.id, checkout)
+  if (conversionDue) {
+    forgetWorkspaceMaterialization(agent)
+    await requireEmptiedSandboxPath(agent.id, checkout)
+  }
 
   if (agent.workspace.mode === 'from-scratch') {
     // Provable by construction: the checkout is gone, so the volume holds exactly the scratch
@@ -1220,26 +1247,21 @@ export async function prepareWorkspaceForActivation(
   // preparation then reads back as proof of the repository, in a circle. Seeding at detach is a
   // different thing and stays: it names the definition the agent has been RUNNING on.
   if (workspacesLiveInSandboxes) {
-    const previousConversion = readPendingConversion(agent)
-    // No marker means no proven volume to replace, so nothing is due — the pod either has no
-    // checkout, which preparation clones, or has one that convergence fixes.
-    if (reconcileMaterialization) {
-      writePendingConversion(
-        agent,
-        replace && previousMaterialization !== undefined ? targetMaterialization : undefined
-      )
+    // Set, never taken back — not by the else branch of this condition, and not by the rollback
+    // below, which is why there is nothing to roll back. `ensureHostAsync` runs before the ACK, so
+    // preparation may already be replacing the volume when this activation is rejected, and no
+    // rollback reaches a pod's tree to undo it. Withdrawing the intent (or restoring the marker)
+    // there would tell the CP's restored definition that nothing changed, and it would be ACKed onto
+    // the rejected tree. Left standing, the pair says the volume is unattributable and whichever
+    // definition arrives next re-materializes it — so recovery needs no rollback to run at all.
+    // A stale intent costs nothing: a marker that proves the target ends the conversion.
+    //
+    // No previous marker means no proven volume to replace, so nothing is asked for — the pod either
+    // has no checkout, which preparation clones, or has one that convergence fixes.
+    if (reconcileMaterialization && replace && previousMaterialization !== undefined) {
+      writePendingConversion(agent, targetMaterialization)
     }
-    // Rolling this back takes the intent, and pointedly NOT the marker. `ensureHostAsync` runs
-    // before the ACK, so preparation may already have replaced the volume when the activation is
-    // rejected — and no rollback reaches a pod's tree to put the old one back. Restoring the marker
-    // would then claim the volume still holds the previous workspace, and the restored definition's
-    // own activation would read that as "nothing changed" and be ACKed onto the rejected repository.
-    // Left alone, the marker keeps saying what the volume ACTUALLY holds, so that activation sees a
-    // changed workspace and arms the reverse conversion by the ordinary rule — which also means the
-    // recovery does not depend on this closure running at all.
-    return () => {
-      if (reconcileMaterialization) writePendingConversion(agent, previousConversion)
-    }
+    return () => {}
   }
   mkdirSync(cwd, { recursive: true })
 

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -109,6 +109,7 @@ async function withSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOp
 const PULL_TIMEOUT_MS = 4500
 const REVIEW_FETCH_TIMEOUT_MS = 15_000
 const MATERIALIZATION_FILE = 'workspace-materialization.json'
+const CONVERSION_FILE = 'workspace-conversion.json'
 /** Word-pair branch names to try before falling back to a random suffix. */
 const SESSION_BRANCH_DRAWS = 5
 const GIT_OBJECT_ID = /^[0-9a-f]{40,64}$/i
@@ -212,6 +213,13 @@ async function clearSandboxPath(agentId: string, root: string): Promise<void> {
   if (error) {
     workspaceLog.warn(`workspace: could not empty ${root} for agent "${agentId}" after a failed clone (${error})`)
   }
+}
+
+/** Empty a cluster path the caller cannot proceed without. A conversion that kept the old checkout
+ *  would clone into a non-empty directory, or converge the new origin onto the previous tree. */
+async function requireEmptiedSandboxPath(agentId: string, root: string): Promise<void> {
+  const error = await clearWorkspacePathInSandbox?.(agentId, root).catch((err: unknown) => (err as Error).message)
+  if (error) throw new Error(`workspace: could not replace ${root} for agent "${agentId}" (${error})`)
 }
 
 /** The same resolution for git run OUTSIDE this module — the console's workspace git seam. Exported
@@ -333,6 +341,52 @@ function readMaterialization(agent: Agent): string | undefined {
   } catch {
     return undefined
   }
+}
+
+/**
+ * The workspace an acknowledged edit asked this agent's POD volume to hold.
+ *
+ * A cluster conversion cannot happen where every other one does. The tree is in the pod, the shim
+ * offers no rename and no rollback, and activation runs before the edit is even acknowledged — so
+ * activation records the intent here and the pod's own preparation carries it out, inside a bound
+ * sandbox, where a failed clone is retried like any other. It is deliberately NOT the marker: the
+ * marker says what the volume HOLDS, and the two disagreeing is exactly what "still due" means.
+ *
+ * It also separates a conversion from a repository RENAME, which reaches this daemon as the same
+ * changed URL but asks for the opposite treatment — repoint the checkout, never replace it. Only a
+ * `reconcileWorkspace` activation writes this file, and a rename does not carry one.
+ */
+function conversionFile(agent: Agent): string {
+  const cwd = agent.workspace.path
+  return join(dirname(cwd), `.${basename(cwd)}.${CONVERSION_FILE}`)
+}
+
+function readPendingConversion(agent: Agent): string | undefined {
+  try {
+    const value = JSON.parse(readFileSync(conversionFile(agent), 'utf8')) as { key?: unknown }
+    return typeof value.key === 'string' ? value.key : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function writePendingConversion(agent: Agent, key: string | undefined): void {
+  const file = conversionFile(agent)
+  if (key === undefined) {
+    rmSync(file, { force: true })
+    return
+  }
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, JSON.stringify({ version: 1, key }, null, 2) + '\n')
+}
+
+/** Whether the pod still has to replace its checkout: an edit asked for THIS workspace and the
+ *  marker says the volume holds another. Stays true across retries, false once preparation proved
+ *  the new one — so a leftover intent cannot re-wipe a volume that already converged. */
+function clusterConversionDue(agent: Agent, stored: string | undefined, target: string): boolean {
+  if (sameMaterialization(agent, stored, target)) return false
+  const pending = readPendingConversion(agent)
+  return pending !== undefined && sameMaterialization(agent, pending, target)
 }
 
 function sameMaterialization(agent: Agent, previous: string | undefined, target: string): boolean {
@@ -860,19 +914,33 @@ export async function prepareClusterWorkspace(
   request?: Pick<PrepareSessionWorkspaceRequest, 'isolation'>
 ): Promise<string> {
   const acpCwd = clusterWorkspaceCwd(agent, runtimeRoot, request)
-  if (agent.workspace.mode === 'from-scratch') return acpCwd
+  const root = runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
+  const checkout = join(root, SANDBOX_CHECKOUT_DIR)
+  const targetMarker = materializationKey(agent)
+  const stored = readMaterialization(agent)
+  // The acknowledged edit's replacement, executed here because this is the only code that reaches
+  // the volume. Emptying the checkout IS the replacement: a git-repo target then clones below, and a
+  // from-scratch one is simply the absence of it. Fail-closed — a clear that did not happen would
+  // otherwise leave the previous repository's tree serving as the new workspace.
+  const conversionDue = clusterConversionDue(agent, stored, targetMarker)
+  if (conversionDue) await requireEmptiedSandboxPath(agent.id, checkout)
+
+  if (agent.workspace.mode === 'from-scratch') {
+    // Provable by construction: the checkout is gone, so the volume holds exactly the scratch
+    // workspace the configuration asks for. Recording it is what ends the conversion.
+    if (conversionDue) recordMaterializationBestEffort(agent)
+    return acpCwd
+  }
   // Validated at the execution boundary, exactly as the local path does: a hand-edited agent.json
   // must not turn daemon-managed git into a local-path or remote-helper launcher.
   const repository = gitRepoOf(agent)
-  const root = runtimeRoot ?? DEFAULT_SHIM_WORKSPACE_ROOT
-  const checkout = join(root, SANDBOX_CHECKOUT_DIR)
   const githubApp = usesGithubApp(agent)
 
   // Whether the volume can be PROVEN to hold what the marker would claim. A fresh clone can, by
   // construction (`--branch` at clone time). An existing one has to be interrogated.
   let volumeMatchesConfig = false
-  const targetMarker = materializationKey(agent)
-  const repositoryAttested = markerAttestsRepository(readMaterialization(agent), targetMarker)
+  // A conversion just emptied the checkout, so nothing the old marker attested survives it.
+  const repositoryAttested = !conversionDue && markerAttestsRepository(stored, targetMarker)
   if (!(await clusterCheckoutExists(agent.id, checkout))) {
     await cloneRepoInSandbox(agent, root, repository)
     volumeMatchesConfig = true
@@ -938,16 +1006,22 @@ export async function prepareClusterWorkspace(
     )
     return acpCwd
   }
-  // Best-effort from here: the volume IS prepared, and failing a session over bookkeeping would
-  // trade a stale marker for no session at all.
+  recordMaterializationBestEffort(agent)
+  return acpCwd
+}
+
+/** Cluster preparation's marker write: best-effort, because the volume IS prepared and failing a
+ *  session over bookkeeping would trade a stale marker for no session at all. The pending
+ *  conversion goes with it — the marker now says the volume holds what the edit asked for. */
+function recordMaterializationBestEffort(agent: Agent): void {
   try {
     recordWorkspaceMaterialization(agent)
+    writePendingConversion(agent, undefined)
   } catch (err) {
     workspaceLog.warn(
       `workspace: could not record the materialization marker for agent "${agent.id}" (${(err as Error).message})`
     )
   }
-  return acpCwd
 }
 
 /**
@@ -1036,6 +1110,14 @@ export function additionalWorkspaceDirectories(
   request?: Pick<PrepareSessionWorkspaceRequest, 'sessionKey' | 'isolation'>
 ): string[] {
   if (agent.workspace.mode !== 'git-repo') return []
+  if (workspacesLiveInSandboxes) {
+    // `cwd` is in the POD's coordinates, which this daemon cannot `realpathSync` — the path exists
+    // on no filesystem it can see, so the check below throws on the workspace it was handed. Undo
+    // the lexical join `clusterWorkspaceCwd` made instead; the shim re-checks containment itself.
+    const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
+    if (agentDir === undefined) return []
+    return [agentDir.split('/').reduce((path) => dirname(path), cwd)]
+  }
   const expectedRoot =
     request?.isolation === 'session' ? sessionWorktreePath(agent, request.sessionKey) : agent.workspace.path
   const root = realpathSync(expectedRoot)
@@ -1122,32 +1204,35 @@ export async function prepareWorkspaceForActivation(
     if (reconcileMaterialization) restoreWorkspaceMaterialization(agent, previousMaterialization)
   }
 
-  // A cluster agent's checkout is on its pod volume, so this function has nothing local to do —
-  // and, for the one case that would need to do something, no way to do it safely.
+  // A cluster agent's checkout is on its pod volume, so this function has nothing local to do — and
+  // the one case that would need to do something, replacing an existing checkout, cannot be done
+  // from here at all: it needs a staged clone beside the target, `renameSync` for an atomic swap,
+  // `readdirSync` to prove the destination is still empty, and a rollback that restores the previous
+  // tree. The shim offers none of those, and this runs BEFORE the CP has acknowledged the edit, so
+  // anything destructive here would have to survive a rollback that cannot restore it.
   //
-  // The distinction is REPLACING AN EXISTING CHECKOUT versus everything else, because only the
-  // former needs the contract a pod cannot offer: a staged clone beside the target, `renameSync`
-  // for an atomic swap, `readdirSync` to prove the destination is still empty at the boundary, and
-  // a rollback that restores the previous tree. The shim can write and clear — not rename, list or
-  // stat — so that is refused, and pointedly not the rest: activation is ALSO how a rejected edit
-  // is rolled back, how a staged agent is recovered, and how a same-workspace repair runs, each
-  // arriving here with `reconcileWorkspace` set. Refusing those left an agent staged and offline,
-  // because the rollback's own restoration hit the refusal too.
+  // So activation records the intent and returns. `prepareClusterWorkspace` carries it out on the
+  // volume — after the acknowledgement, inside a bound sandbox, where a failed clone is retried like
+  // any other and an empty checkout is the recovery state, not a lost one.
   //
-  // Everything else is a no-op that keeps the marker honest. Session preparation is what converges
-  // the volume — origin, helper pin, pull — and it runs before the runtime sees the workspace.
-  if (workspacesLiveInSandboxes && agent.workspace.mode === 'git-repo') {
-    if (replace && previousMaterialization !== undefined) {
-      throw new Error(
-        `a git-repo workspace cannot be converted in place with --k8s yet (agent "${agent.id}") — ` +
-          `recreate the agent to provision a fresh volume`
+  // The marker is deliberately NOT advanced. For a cluster agent it means "the volume held this",
+  // and writing the TARGET here would say it about a volume nothing has inspected — which cluster
+  // preparation then reads back as proof of the repository, in a circle. Seeding at detach is a
+  // different thing and stays: it names the definition the agent has been RUNNING on.
+  if (workspacesLiveInSandboxes) {
+    const previousConversion = readPendingConversion(agent)
+    // No marker means no proven volume to replace, so nothing is due — the pod either has no
+    // checkout, which preparation clones, or has one that convergence fixes.
+    if (reconcileMaterialization) {
+      writePendingConversion(
+        agent,
+        replace && previousMaterialization !== undefined ? targetMaterialization : undefined
       )
     }
-    // Deliberately does NOT record. For a cluster agent the marker means "the volume held this", and
-    // writing the TARGET here would say it about a volume nothing has inspected — which cluster
-    // preparation then reads back as proof of the repository, in a circle. Seeding at detach is a
-    // different thing and stays: it names the definition the agent has been RUNNING on.
-    return restoreMarker
+    return () => {
+      if (reconcileMaterialization) writePendingConversion(agent, previousConversion)
+      restoreMarker()
+    }
   }
   mkdirSync(cwd, { recursive: true })
 

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -1229,9 +1229,16 @@ export async function prepareWorkspaceForActivation(
         replace && previousMaterialization !== undefined ? targetMaterialization : undefined
       )
     }
+    // Rolling this back takes the intent, and pointedly NOT the marker. `ensureHostAsync` runs
+    // before the ACK, so preparation may already have replaced the volume when the activation is
+    // rejected — and no rollback reaches a pod's tree to put the old one back. Restoring the marker
+    // would then claim the volume still holds the previous workspace, and the restored definition's
+    // own activation would read that as "nothing changed" and be ACKed onto the rejected repository.
+    // Left alone, the marker keeps saying what the volume ACTUALLY holds, so that activation sees a
+    // changed workspace and arms the reverse conversion by the ordinary rule — which also means the
+    // recovery does not depend on this closure running at all.
     return () => {
       if (reconcileMaterialization) writePendingConversion(agent, previousConversion)
-      restoreMarker()
     }
   }
   mkdirSync(cwd, { recursive: true })

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -465,6 +465,46 @@ describe('replacing a cluster workspace in place', () => {
     expect(cleared).toEqual([])
   })
 
+  /** An activation rejected AFTER its preparation already replaced the volume: `ensureHostAsync`
+   *  runs before the ACK, so an ACP failure, a supersession or a staging-commit failure all land
+   *  here. Returns the daemon state the CP's rollback then activates the original definition into. */
+  async function rejectedAfterConversion(runRollback: boolean): Promise<Agent> {
+    const agent = await withProvenMarker()
+    const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
+    const rollback = await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    checkoutExists = true
+    await prepareClusterWorkspace(moved, POD_ROOT)
+    if (runRollback) rollback()
+    cleared.length = 0
+    calls.length = 0
+    return agent
+  }
+
+  it('does not tell the restored definition that the volume never changed', async () => {
+    // Nothing reaches a pod's tree to put the old checkout back, so a marker restored to the previous
+    // workspace would be a claim about a volume that now holds the REJECTED repository — and the CP's
+    // own rollback would be ACKed onto it, silently, with pull failures degrading as usual.
+    const original = await rejectedAfterConversion(true)
+
+    await prepareWorkspaceForActivation(original, { reconcileMaterialization: true })
+    checkoutExists = true
+    await prepareClusterWorkspace(original, POD_ROOT)
+    expect(cleared).toEqual([CHECKOUT])
+    expect(calls.find((call) => call.args[0] === 'clone')?.args).toContain('https://github.com/acme/private.git')
+  })
+
+  it('recovers the same way when the activation rollback never ran', async () => {
+    // The marker describing the volume is what arms the reverse conversion, so recovery does not
+    // depend on a rollback closure that a crash — or a failure path that forgets it — never calls.
+    const original = await rejectedAfterConversion(false)
+
+    await prepareWorkspaceForActivation(original, { reconcileMaterialization: true })
+    checkoutExists = true
+    await prepareClusterWorkspace(original, POD_ROOT)
+    expect(cleared).toEqual([CHECKOUT])
+    expect(calls.find((call) => call.args[0] === 'clone')?.args).toContain('https://github.com/acme/private.git')
+  })
+
   it('fails closed when the pod will not empty the checkout', async () => {
     // Proceeding would clone into a non-empty directory — or, worse, converge the new origin onto
     // the previous repository's tree and serve it as the new workspace.

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import {
+  additionalWorkspaceDirectories,
   clusterWorkspaceCwd,
   prepareClusterWorkspace,
   prepareWorkspaceForActivation,
@@ -52,6 +53,8 @@ let originUrl = 'https://github.com/acme/private.git'
  *  the configured one — which is exactly the case a marker must not paper over. */
 let headBranch = 'main'
 let pullFails = false
+/** The pod refusing to empty a path — a conversion that proceeded anyway would serve the old tree. */
+let clearFails = false
 
 function recordingRunner(cwd: string | undefined, env: Record<string, string> = {}): GitRunner {
   const run = async (args: string[]): Promise<string> => {
@@ -118,10 +121,14 @@ beforeEach(() => {
   originUrl = 'https://github.com/acme/private.git'
   headBranch = 'main'
   pullFails = false
+  clearFails = false
   // Every agent here runs in a pod, so both seams resolve to the sandbox.
   setWorkspaceGitRunnerResolver((_agentId, cwd) => recordingRunner(cwd))
   setWorkspacePathClearer(async (_agentId, root) => {
     cleared.push(root)
+    // Emptying the checkout is precisely what makes the pod's probe stop finding one.
+    if (root === CHECKOUT) checkoutExists = false
+    if (clearFails) return 'permission denied'
     return undefined
   })
   setSandboxWorkspaceMode(true)
@@ -153,6 +160,16 @@ describe('clusterWorkspaceCwd', () => {
 
   it('applies the configured working subdirectory inside the pod', () => {
     expect(clusterWorkspaceCwd(clusterAgent({ agentDir: 'services/api' }), POD_ROOT)).toBe(`${CHECKOUT}/services/api`)
+  })
+
+  it('names the enclosing checkout in the POD coordinates the cwd is in', () => {
+    // The runtime gets the repository root separately so repo-wide tools can reach `.git` and
+    // siblings. Deriving it the local way means `realpathSync` on a path that exists on no
+    // filesystem this daemon can see — which throws, and takes every cluster session with it.
+    const agent = clusterAgent({ agentDir: 'services/api' })
+    expect(additionalWorkspaceDirectories(agent, clusterWorkspaceCwd(agent, POD_ROOT))).toEqual([CHECKOUT])
+    // No subdirectory means the cwd already IS the root, and a second copy of it says nothing.
+    expect(additionalWorkspaceDirectories(clusterAgent(), CHECKOUT)).toEqual([])
   })
 
   it('still refuses session isolation rather than half-supporting it', () => {
@@ -349,9 +366,13 @@ describe('replacing a cluster workspace in place', () => {
     pullFails = true
     await prepareClusterWorkspace(moved, POD_ROOT)
 
-    await expect(prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })).rejects.toThrow(
-      /cannot be converted in place with --k8s yet/
-    )
+    // Unproven, so the edit's replacement is still due: the next preparation empties the checkout
+    // and clones the configured branch rather than serving `main` forever.
+    await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    calls.length = 0
+    await prepareClusterWorkspace(moved, POD_ROOT)
+    expect(cleared).toEqual([CHECKOUT])
+    expect(calls.find((call) => call.args[0] === 'clone')?.args).toContain('release')
   })
 
   it('records the marker once the volume is provably on the configured branch', async () => {
@@ -385,10 +406,8 @@ describe('replacing a cluster workspace in place', () => {
     // no pull has ever reached.
     originUrl = 'https://github.com/acme/renamed.git'
     await prepareClusterWorkspace(renamed, POD_ROOT)
-
-    await expect(prepareWorkspaceForActivation(renamed, { reconcileMaterialization: true })).rejects.toThrow(
-      /cannot be converted in place with --k8s yet/
-    )
+    // Nothing an EDIT asked for, so the unproven volume is left in place rather than replaced.
+    expect(cleared).toEqual([])
 
     // And once a pull from the new origin does succeed, it is proven and recorded.
     pullFails = false
@@ -396,19 +415,82 @@ describe('replacing a cluster workspace in place', () => {
     await expect(prepareWorkspaceForActivation(renamed, { reconcileMaterialization: true })).resolves.toBeTypeOf(
       'function'
     )
+    expect(cleared).toEqual([])
   })
 
-  it('refuses only a conversion of an EXISTING checkout, which has no rollback in a pod', async () => {
-    // The one case that needs the contract a pod cannot offer: a staged clone, an atomic swap, and a
-    // rollback that restores the previous tree. Unrefused, it stages a clone at a daemon-absolute
-    // path, which the shim's target fence rejects with an error about containment that says nothing
-    // about what was attempted.
+  it('records a conversion of an EXISTING checkout instead of refusing it', async () => {
+    // Activation cannot do the replacement itself: it has no atomic swap through the shim and runs
+    // before the CP has acknowledged the edit, so anything destructive here would have to survive a
+    // rollback that cannot restore it. It records the intent; the pod's preparation carries it out.
     const agent = await withProvenMarker()
     const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
-    await expect(prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })).rejects.toThrow(
-      /cannot be converted in place with --k8s yet/
+    await expect(prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })).resolves.toBeTypeOf(
+      'function'
     )
     expect(calls).toEqual([])
+    expect(cleared).toEqual([])
+
+    checkoutExists = true
+    await prepareClusterWorkspace(moved, POD_ROOT)
+    // Emptied, then re-cloned from the new repository — the replacement the edit asked for.
+    expect(cleared).toEqual([CHECKOUT])
+    expect(calls.find((call) => call.args[0] === 'clone')?.args).toContain('https://github.com/acme/other.git')
+    // Never converged onto the previous tree, which is what a rewritten origin alone would do.
+    expect(calls.some((call) => call.args[1] === 'set-url')).toBe(false)
+  })
+
+  it('does not replace the volume twice for one edit', async () => {
+    // The marker advances when preparation proves the new workspace, and that — not the intent
+    // file — is what ends the conversion. A leftover intent must not re-wipe a converged volume.
+    const agent = await withProvenMarker()
+    const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
+    await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    checkoutExists = true
+    await prepareClusterWorkspace(moved, POD_ROOT)
+    checkoutExists = true
+    await prepareClusterWorkspace(moved, POD_ROOT)
+    expect(cleared).toEqual([CHECKOUT])
+  })
+
+  it('takes the intent back when the activation it belongs to fails', async () => {
+    // The rollback the daemon runs when the host will not start. The edit never became authoritative,
+    // so the volume must not be replaced on some later session as if it had.
+    const agent = await withProvenMarker()
+    const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
+    const rollback = await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    rollback()
+
+    checkoutExists = true
+    await prepareClusterWorkspace(moved, POD_ROOT)
+    expect(cleared).toEqual([])
+  })
+
+  it('fails closed when the pod will not empty the checkout', async () => {
+    // Proceeding would clone into a non-empty directory — or, worse, converge the new origin onto
+    // the previous repository's tree and serve it as the new workspace.
+    const agent = await withProvenMarker()
+    const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
+    await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    checkoutExists = true
+    clearFails = true
+    await expect(prepareClusterWorkspace(moved, POD_ROOT)).rejects.toThrow(/could not replace/)
+    expect(calls.some((call) => call.args[0] === 'clone')).toBe(false)
+  })
+
+  it('removes the checkout when the workspace converts back to from-scratch', async () => {
+    // The pod's volume outlives the mode, and the runtime's cwd becomes the mount root: a `repo/`
+    // left behind would sit in the scratch workspace as the previous repository's working tree.
+    const agent = await withProvenMarker()
+    const scratch = { ...agent, workspace: { ...agent.workspace, mode: 'from-scratch' } } as Agent
+    await prepareWorkspaceForActivation(scratch, { reconcileMaterialization: true })
+    checkoutExists = true
+    expect(await prepareClusterWorkspace(scratch, POD_ROOT)).toBe(POD_ROOT)
+    expect(cleared).toEqual([CHECKOUT])
+    expect(calls).toEqual([])
+
+    // And the marker now says scratch, so the next session does not empty it again.
+    await prepareClusterWorkspace(scratch, POD_ROOT)
+    expect(cleared).toEqual([CHECKOUT])
   })
 
   it('leaves a from-scratch cluster workspace alone, whose activation touches only bookkeeping', async () => {

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -55,6 +55,9 @@ let headBranch = 'main'
 let pullFails = false
 /** The pod refusing to empty a path — a conversion that proceeded anyway would serve the old tree. */
 let clearFails = false
+/** The repo-local helper pin failing AFTER a successful clone — it runs outside the clone's own
+ *  cleanup, so the checkout survives while nothing has proved it. */
+let helperWriteFails = false
 
 function recordingRunner(cwd: string | undefined, env: Record<string, string> = {}): GitRunner {
   const run = async (args: string[]): Promise<string> => {
@@ -63,6 +66,7 @@ function recordingRunner(cwd: string | undefined, env: Record<string, string> = 
       if (!checkoutExists) throw new Error('cwd does not resolve: no checkout in the pod')
       return '.git'
     }
+    if (args[0] === 'config' && args.includes('--add') && helperWriteFails) throw new Error('helper pin refused')
     if (args[0] === 'remote' && args[1] === 'get-url') return originUrl
     if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return headBranch
     return ''
@@ -122,6 +126,7 @@ beforeEach(() => {
   headBranch = 'main'
   pullFails = false
   clearFails = false
+  helperWriteFails = false
   // Every agent here runs in a pod, so both seams resolve to the sandbox.
   setWorkspaceGitRunnerResolver((_agentId, cwd) => recordingRunner(cwd))
   setWorkspacePathClearer(async (_agentId, root) => {
@@ -452,17 +457,44 @@ describe('replacing a cluster workspace in place', () => {
     expect(cleared).toEqual([CHECKOUT])
   })
 
-  it('takes the intent back when the activation it belongs to fails', async () => {
-    // The rollback the daemon runs when the host will not start. The edit never became authoritative,
-    // so the volume must not be replaced on some later session as if it had.
+  it('leaves an intent inert once the marker proves the workspace', async () => {
+    // An activation rejected before its preparation touched anything: the intent stands, because
+    // withdrawing it is unsafe in the case where preparation HAD started. It costs nothing here —
+    // the restored definition's marker still proves the volume, so nothing is replaced.
     const agent = await withProvenMarker()
     const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
     const rollback = await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
     rollback()
 
     checkoutExists = true
-    await prepareClusterWorkspace(moved, POD_ROOT)
+    await prepareClusterWorkspace(agent, POD_ROOT)
     expect(cleared).toEqual([])
+    expect(calls.some((call) => call.args[0] === 'clone')).toBe(false)
+  })
+
+  it('re-materializes when the conversion failed between emptying the checkout and proving it', async () => {
+    // `cloneRepoInSandbox` can create the checkout and still throw — the repo-local helper pin runs
+    // after the clone's own cleanup — and the marker write after it is best-effort. Either way the
+    // volume holds the new tree while nothing has proved it, and the definition that arrives next is
+    // as likely to be the CP's rollback as a retry. A marker still naming the emptied workspace
+    // would send that rollback down the converge-and-pull path over the rejected tree.
+    const agent = await withProvenMarker()
+    const moved = { ...agent, workspace: { ...agent.workspace, gitRepo: 'https://github.com/acme/other.git' } } as Agent
+    await prepareWorkspaceForActivation(moved, { reconcileMaterialization: true })
+    checkoutExists = true
+    helperWriteFails = true
+    await expect(prepareClusterWorkspace(moved, POD_ROOT)).rejects.toThrow(/helper pin refused/)
+
+    helperWriteFails = false
+    cleared.length = 0
+    calls.length = 0
+    await prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
+    checkoutExists = true
+    await prepareClusterWorkspace(agent, POD_ROOT)
+    expect(cleared).toEqual([CHECKOUT])
+    expect(calls.find((call) => call.args[0] === 'clone')?.args).toContain('https://github.com/acme/private.git')
+    // Never the alternative: repointing the rejected tree at the original origin and pulling.
+    expect(calls.some((call) => call.args[1] === 'set-url')).toBe(false)
   })
 
   /** An activation rejected AFTER its preparation already replaced the volume: `ensureHostAsync`


### PR DESCRIPTION
Editing the workspace of an agent on a `--k8s` daemon failed twice over, and the second failure made the first permanent — the console reported `workspace activation rejection and the original workspace could not be reactivated`, and the agent was left staged and offline with its edit undone in the database only.

## The daemon refused every conversion

A workspace edit is a *replacement*, and the local path implements it with a staged clone beside the target, `renameSync` for an atomic swap, and a rollback that restores the previous tree. None of those exist through the shim, and the step that needs them runs at `agent/activate` — **before** the CP has acknowledged the edit, so anything destructive there would have to survive a rollback that cannot restore it. So `--k8s` refused outright.

This splits the operation across the two places that can each do half of it:

- **Activation records an intent** — the target materialization, written beside the marker. It destroys nothing, which is what lets the CP's rollback undo it by activating the original definition again. The marker is deliberately not advanced: it says what the volume *holds*, and preparation reads it back as attestation of the repository.
- **Cluster preparation performs it**, inside the bound sandbox, from the pod's own side: empty the checkout, then materialize the configured workspace — a clone for a git-repo target, nothing for a scratch one, since the checkout's absence *is* the scratch workspace. Emptying is fail-closed; a clear that did not happen would leave the previous repository's tree serving as the new workspace.

Intent and marker disagreeing is what "still due" means, so retries are free and repeats impossible: a failed clone leaves an empty checkout the next preparation clones again, and a marker that reached the target ends the conversion. A rolled-back edit takes its intent with it, and a repository **rename** — the same changed URL, arriving without `reconcileWorkspace` — writes no intent and keeps its existing repoint behaviour.

Also fixes `additionalWorkspaceDirectories`, which `realpathSync`'d a POD path on the daemon's own filesystem: it threw on every `newSession`/`loadSession` for a cluster git-repo agent, so the mode this PR unblocks could not have started a session anyway.

## The CP's rollback could never land

The daemon records an activation's revision when it applies the bundle, and a later failure re-stages the agent without rewinding it. The rollback replayed the **pre-edit row**, whose revision is older than the one the target had just applied, so the revision fence refused it:

```
agent/activate: spec revision 2 is not newer than the applied configuration
```

Structural, not incidental: once the daemon applied the bundle, *any* failure after that point ended fail-closed. Now it replays the restored row — the rollback is an edit of its own and advances the revision past the rejected one — and carries the daemon's rejection reason into the fail-closed message, which previously named only the restoration failure and never the rejection an operator has to act on.

## Tests

- `agentMove.test.ts`: the fake repo advances `configRevision` like the real one and the fake daemon now enforces the revision fence — the absence of both is what let this ship. The existing rollback test fails without the fix; one test added for reporting both failures.
- `cluster-workspace-prepare.test.ts`: three refusal assertions become behaviour assertions, plus six new ones — records intent rather than refusing, replaces once per edit, takes the intent back when its activation fails, fails closed when the pod will not empty the checkout, removes the checkout when converting back to from-scratch, and derives the enclosing checkout in pod coordinates.
- `docs/designs/cluster-spawn-and-shim.md` §9 records the mechanism.

Run locally: CP `test:unit` (1576 passed), daemon `cluster-workspace-prepare`, `workspace`, `workspace-git*`, `workspace-reader`, `cluster-acp-e2e`, `k8s-*`, `session-manager`, `skill-workspace-lock`, `daemon-workspace-git-review-feature` — all green. Typecheck + lint clean.

## Not in scope

A **session-isolated** (worktree) git-repo workspace on `--k8s` is still refused by name at session preparation — it needs `worktree add` in the sandbox and a retention GC that reads the pod's tree. Deliberately not moved into `activationCapabilityError`: that gate runs on every activation including placement repair and rollback, so refusing there would strand an existing agent rather than merely failing its sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)