### PR TITLE
fix(release): build the control plane's workspace deps before bundling setup

### DIFF
--- a/scripts/publish-setup-if-changed.sh
+++ b/scripts/publish-setup-if-changed.sh
@@ -48,9 +48,13 @@ fi
 
 if [ "$MODE" = prepare ]; then
   cd "$REPO_ROOT"
-  pnpm --filter @agentconnect.md/protocol build
-  pnpm --filter @agentconnect.md/observability build
-  pnpm --filter @agentconnect.md/control-plane build
+  # `<pkg>...` is the control plane AND its workspace dependencies, built in topological
+  # order. It replaced a hand-written list of those dependencies, which is a list that
+  # silently rots: tsc resolves a workspace import through the dependency's BUILT types,
+  # so the first release after the cluster provisioner started importing `k8s-client`
+  # failed the whole run with TS2307 — the dependency was real, it just never got built
+  # here. Nothing to keep in sync now; pnpm reads the dependency graph itself.
+  pnpm --filter "@agentconnect.md/control-plane..." build
   cd "$REPO_ROOT/packages/setup"
   pnpm exec json -I -f package.json -e "this.version='$VALUE'"
   pnpm run build


### PR DESCRIPTION
## What broke

The `prepare` step of `scripts/publish-setup-if-changed.sh` built a hand-written list of the control plane's workspace dependencies:

```sh
pnpm --filter @agentconnect.md/protocol build
pnpm --filter @agentconnect.md/observability build
pnpm --filter @agentconnect.md/control-plane build
```

That list had rotted. The control plane's cluster provisioner now imports `@agentconnect.md/k8s-client`, which is a real `workspace:*` dependency but was never built here — so tsc had no built types to resolve it through:

```
src/cluster/access.ts(15,59): error TS2307: Cannot find module '@agentconnect.md/k8s-client' …
src/cluster/org-api.ts(60,43): error TS18046: 'error' is of type 'unknown'.
```

The TS18046 errors are a cascade of the same cause: with `K8sApiError` unresolved, `error instanceof K8sApiError` no longer narrows `unknown`.

## Why it matters

This runs inside semantic-release's `prepare`, so the failure takes down the **whole release run** — no version tagged, no images pushed. A release carrying the dependency can therefore never ship, and the tree stays green while it happens: every `Test /` job passes, because none of them runs this script.

The change-detection half of the same file already lists `packages/k8s-client` in `SETUP_PATHS`/`SETUP_IMPORTERS`; only the build half was missed.

## The fix

Replace the hand-written list with pnpm's dependency filter:

```sh
pnpm --filter "@agentconnect.md/control-plane..." build
```

`<pkg>...` selects the package **and its workspace dependencies**, built in topological order. It is the same idiom `k8s-client`'s own build script already uses (`pnpm --filter '{.}^...' build`). pnpm reads the dependency graph, so the next dependency added to the control plane cannot rot this list again.

## Verification

Against a clean worktree at the failing commit:

- **Repro** — old sequence, with `packages/k8s-client/dist` absent, reproduces the exact TS2307 + TS18046 set from the failed run.
- **Fix** — `pnpm --filter "@agentconnect.md/control-plane..." build` builds all five deps in topological order (protocol, observability, connection, k8s-client, control-plane) and the control plane compiles.
- **End to end** — `sh scripts/publish-setup-if-changed.sh "v1.41.0-rc.69" "1.41.0-rc.70" prepare` exits 0 and emits `packages/setup/dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)