### PR TITLE
feat(daemon): check session worktrees out on a named branch

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -891,7 +891,11 @@ options or vocabulary.
 GitHub workspace settings expose one boolean named `Worktree`. When enabled, each
 logical session runs in its own stable Git worktree under the Agent directory, so one
 Agent can work on several sessions concurrently without sharing branch or file state.
-When disabled, sessions use the primary checkout. New GitHub Agents default to enabled;
+When disabled, sessions use the primary checkout. Each worktree checks out its own
+generated branch, `dev/<user>/<word>-<word>`, naming the user who opened the session, so
+the work a session produces can be pushed and reviewed under a name a human recognizes.
+Retention cleanup deletes that branch with the worktree, and only ever one under `dev/`
+whose commits are all already reachable from a remote. New GitHub Agents default to enabled;
 existing Agents retain the shared-checkout behavior after upgrade. A fresh manual
 Playground may override `Worktree` before its first turn without changing the Agent;
 automatic triggers use the Agent setting.

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -66,6 +66,7 @@
     "systeminformation": "^5.33.1",
     "tar": "7.5.22",
     "undici": "^7.29.0",
+    "unique-names-generator": "^4.7.1",
     "ws": "^8.21.1",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -590,8 +590,8 @@ export function createWorkspaceGit(
       try {
         const git = base.withEnv(workspaceGitLocalEnv())
         const branch = await currentBranch(git)
-        // Every session worktree is `worktree add --detach`, so this is the ordinary answer there —
-        // and naming a branch for one is a product decision this milestone does not make.
+        // A session worktree now checks out its own `dev/<user>/<words>` branch, so this
+        // answers only a worktree created before that, or one the agent detached itself.
         if (!branch) {
           return pushRefusal(
             agentId,
@@ -773,7 +773,7 @@ function stopReasonDetail(answer: { output: string; stopReason: string }): strin
   }
 }
 
-/** The checked-out branch, or null when HEAD is detached — which every session worktree is. */
+/** The checked-out branch, or null when HEAD is detached. */
 async function currentBranch(git: GitRunner): Promise<string | null> {
   try {
     const out = await git.readBounded(['rev-parse', '--abbrev-ref', 'HEAD'], 4096)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -274,6 +274,7 @@ import {
   setWorkspaceGitRunnerResolver,
   setWorkspacePathClearer
 } from './workspace/workspace-manager.js'
+import { initiatorLabel } from './workspace/session-branch.js'
 import { declaredRuntimeCatalog, loadK8sRuntimeTable, type K8sRuntimeAcpSnapshot } from './runtimes/k8s-runtimes.js'
 import { ensureNodeBinOnPath } from './runtimes/exec-path.js'
 import {
@@ -10360,6 +10361,15 @@ export class Daemon {
     }
   }
 
+  /** Display label of the user a session is opened by — it names the session
+   * worktree's branch (`dev/<user>/<words>`). Presentation only. */
+  private sessionInitiatorLabel(msg: NormalizedMessage): string {
+    // The routing identity a session is keyed by, which for a GitHub hook is the hook —
+    // `initiatorLabel` then falls through to the actor who fired it.
+    const initiator = msg.sessionTriggerId ?? msg.sender?.id ?? ''
+    return initiatorLabel(initiator, this.store.getDisplayNames([initiator]).get(initiator), msg.sender)
+  }
+
   /** Prepare an exact, isolated checkout before a formal review generation. A
    * formal review may use GitHub read-only inspection when its configured local
    * repo differs, but it must never silently fall back to a stale checkout.
@@ -10390,6 +10400,7 @@ export class Daemon {
         const preparedWorkspaceCwd = await this.prepareAgentWorkspace(agent, warmHost, {
           sessionKey: key,
           isolation: 'session',
+          initiatedBy: this.sessionInitiatorLabel(entry.msg),
           githubReviewRevisionOnly: true
         })
         return { workspaceIsolation: 'session' as const, forceWorkspaceIsolation: true as const, preparedWorkspaceCwd }
@@ -10412,6 +10423,7 @@ export class Daemon {
       const preparedWorkspaceCwd = await this.prepareAgentWorkspace(agent, warmHost, {
         sessionKey: key,
         isolation: 'session',
+        initiatedBy: this.sessionInitiatorLabel(entry.msg),
         review: {
           pullNumber: github.pullNumber,
           baseSha: github.baseSha,

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -3,6 +3,7 @@ import { LocalStore, sessionKey, transcriptChannelKey, type TranscriptEntry } fr
 import { monotonicTs } from '../store/monotonic-ts.js'
 import { SLACK_RESPONSE_FINAL_EVENT_TAG } from '@agentconnect.md/message'
 import { additionalWorkspaceDirectories, prepareWorkspace } from '../workspace/workspace-manager.js'
+import { initiatorLabel } from '../workspace/session-branch.js'
 import { memoryKindOf, type MemoryProvider, type MemoryScope } from '../agents/memory-provider.js'
 import { MAX_INDEX_INJECT_BYTES } from '../agents/memory.js'
 import { agentChildEnv } from '../agents/agent-env.js'
@@ -248,7 +249,7 @@ export class SessionManager {
       prepareWorkspace?: (
         agent: Agent,
         expectedWarmHost?: AcpHost,
-        request?: { sessionKey: string; isolation: 'shared' | 'session' }
+        request?: { sessionKey: string; isolation: 'shared' | 'session'; initiatedBy?: string }
       ) => Promise<string>
       /** Resolve the cwd produced by hostFor's cold preparation without
        * repeating pull/source acquisition/reconciliation. Production supplies
@@ -585,6 +586,16 @@ export class SessionManager {
         (originSessionId !== undefined &&
           rec?.originSessionId !== undefined &&
           originSessionId !== rec.originSessionId))
+    // Names a session worktree's branch: the user who OPENED the session (`triggeredBy`,
+    // first-wins in the store), not whoever's turn this is — a shared thread must not
+    // change branch owner when someone else replies.
+    const initiator = rec?.triggeredBy ?? msg.sessionTriggerId ?? msg.sender.id
+    const initiatedBy = initiatorLabel(
+      initiator,
+      this.deps.store.getDisplayNames([initiator]).get(initiator),
+      msg.sender
+    )
+    const workspaceRequest = { sessionKey: key, isolation: workspaceIsolation, initiatedBy }
     // Production hostFor owns the single cold-host preparation gate before spawn.
     // After it resolves, consume that already-prepared cwd through the pure resolver.
     // Lightweight embedders without that contract retain the legacy pre-host fallback.
@@ -594,9 +605,7 @@ export class SessionManager {
     let preparedCwd =
       hostCold && !this.deps.resolvePreparedWorkspace
         ? await abortable(
-            () =>
-              this.deps.prepareWorkspace?.(agent, undefined, { sessionKey: key, isolation: workspaceIsolation }) ??
-              prepareWorkspace(agent),
+            () => this.deps.prepareWorkspace?.(agent, undefined, workspaceRequest) ?? prepareWorkspace(agent),
             signal
           )
         : undefined
@@ -897,9 +906,7 @@ export class SessionManager {
         options.preparedWorkspaceCwd ??
         (workspaceIsolation === 'shared' ? preparedCwd : undefined) ??
         (await abortable(
-          () =>
-            this.deps.prepareWorkspace?.(agent, expectedWarmHost, { sessionKey: key, isolation: workspaceIsolation }) ??
-            prepareWorkspace(agent),
+          () => this.deps.prepareWorkspace?.(agent, expectedWarmHost, workspaceRequest) ?? prepareWorkspace(agent),
           signal
         ))
       const ordinaryMcpServers =
@@ -960,9 +967,7 @@ export class SessionManager {
         options.preparedWorkspaceCwd ??
         (workspaceIsolation === 'shared' ? preparedCwd : undefined) ??
         (await abortable(
-          () =>
-            this.deps.prepareWorkspace?.(agent, expectedWarmHost, { sessionKey: key, isolation: workspaceIsolation }) ??
-            prepareWorkspace(agent),
+          () => this.deps.prepareWorkspace?.(agent, expectedWarmHost, workspaceRequest) ?? prepareWorkspace(agent),
           signal
         ))
       // Resolved once, shared by both paths: session/load must re-attach the same

--- a/packages/daemon/src/workspace/session-branch.ts
+++ b/packages/daemon/src/workspace/session-branch.ts
@@ -1,0 +1,72 @@
+import { randomBytes } from 'node:crypto'
+import { adjectives, animals, uniqueNamesGenerator } from 'unique-names-generator'
+
+/** Namespace every session-worktree branch is created under; see {@link isSessionBranch}. */
+export const SESSION_BRANCH_PREFIX = 'dev'
+
+/** Used when the initiator has no usable label at all — a cron/agent-triggered
+ * session, or a display name that sanitizes away to nothing. */
+const ANONYMOUS_USER = 'agent'
+
+const MAX_USER_SEGMENT = 24
+
+/** One Git ref path component from an arbitrary platform display name. Unicode
+ * letters and digits survive (a Feishu display name is routinely CJK, and a
+ * branch named `agent` for every one of them defeats the point); everything
+ * else — the space, dot, `~^:?*[\` and control characters Git rejects — becomes
+ * a separator. */
+function userSegment(raw: string | undefined): string {
+  const slug = (raw ?? '')
+    .normalize('NFC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, MAX_USER_SEGMENT)
+    .replace(/-$/, '')
+  return slug || ANONYMOUS_USER
+}
+
+/** The branch one session worktree checks out: `dev/<user>/<adjective>-<animal>`.
+ * Two words rather than a hash because this name reaches humans — it is what a
+ * reviewer reads on a pushed branch and what the agent types in `git` commands.
+ * The pair is drawn fresh per call, so a caller that finds the name taken simply
+ * asks again; `unique` ends the search, but 1202x355 combinations only make a collision
+ * unlikely, never impossible. */
+export function sessionBranchName(user: string | undefined, unique = false): string {
+  const words = uniqueNamesGenerator({ dictionaries: [adjectives, animals], separator: '-', length: 2 })
+  // The escape hatch for a repository that keeps colliding: random bytes end the search.
+  const suffix = unique ? `-${randomBytes(3).toString('hex')}` : ''
+  return `${SESSION_BRANCH_PREFIX}/${userSegment(user)}/${words}${suffix}`
+}
+
+/** The label {@link sessionBranchName} takes, from the session's initiator id and
+ * this turn's sender. The initiator's cached display name wins: it is the person
+ * who OPENED the session, so a thread does not change branch owner when someone
+ * else speaks. Without one, this turn's sender stands in — the id alone may be a
+ * routing identity rather than a person (a hook session is triggered by
+ * `hook:<hookId>`, which would put the hook's UUID in the branch name). */
+export function initiatorLabel(
+  initiator: string,
+  displayName: string | undefined,
+  sender: { id?: string; name?: string } | undefined
+): string {
+  if (displayName) return displayName
+  if (initiator === sender?.id) return sender.name ?? initiator
+  return sender?.name ?? sender?.id ?? initiator
+}
+
+const WORDS = { adjective: new Set(adjectives), animal: new Set(animals) }
+
+/** Whether this branch is one this daemon generated for a session worktree, and so may be
+ * deleted with it. The namespace alone is NOT enough of a guard — `dev/<user>/<topic>` is a
+ * convention humans use too, and an agent can leave a worktree checked out on a branch of
+ * theirs — so the last component must be a pair this generator could have drawn: a word from
+ * each dictionary, plus at most the collision suffix. `dev/yulong/gurnard` is then not ours. */
+export function isSessionBranch(branch: string | undefined): boolean {
+  const [namespace, user, generated, ...rest] = (branch ?? '').split('/')
+  if (namespace !== SESSION_BRANCH_PREFIX || !user || !generated || rest.length > 0) return false
+  const [adjective, animal, suffix, ...extra] = generated.split('-')
+  if (extra.length > 0 || (suffix !== undefined && !/^[0-9a-f]{6}$/.test(suffix))) return false
+  return WORDS.adjective.has(adjective ?? '') && WORDS.animal.has(animal ?? '')
+}

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -37,6 +37,7 @@ import {
 } from './git-injection.js'
 import { LocalGitRunner, type GitRunner } from './git-runner.js'
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
+import { isSessionBranch, sessionBranchName } from './session-branch.js'
 import { DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
 import { SANDBOX_CHECKOUT_DIR } from '../shim/sandbox-paths.js'
 
@@ -68,6 +69,9 @@ export interface GithubReviewWorkspaceRevision {
 export interface PrepareSessionWorkspaceRequest {
   sessionKey: string
   isolation: 'shared' | 'session'
+  /** Display label of the user who OPENED this logical session — it names the
+   * worktree's branch. Presentation only; never an identity or auth input. */
+  initiatedBy?: string
   review?: GithubReviewWorkspaceRevision
   /** Use an empty daemon-owned cwd when an exact local review checkout is
    * unavailable. The model must inspect the trusted revision through GitHub. */
@@ -105,6 +109,8 @@ async function withSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOp
 const PULL_TIMEOUT_MS = 4500
 const REVIEW_FETCH_TIMEOUT_MS = 15_000
 const MATERIALIZATION_FILE = 'workspace-materialization.json'
+/** Word-pair branch names to try before falling back to a random suffix. */
+const SESSION_BRANCH_DRAWS = 5
 const GIT_OBJECT_ID = /^[0-9a-f]{40,64}$/i
 
 // Single-flight clone lock. Two concurrent sessions (especially multiple agents sharing one repo
@@ -570,7 +576,10 @@ export async function removeSessionWorktree(agent: Agent, sessionKey: string): P
     if ((await worktreeGit.raw(['status', '--porcelain'])).trim() !== '') {
       return { outcome: 'retained', reason: 'dirty' }
     }
-    // Session worktrees are detached, so there is no upstream to compare against:
+    // The generated branch this worktree checks out, read BEFORE the removal that
+    // unregisters it. Empty for a worktree created before session branches existed.
+    const branch = (await worktreeGit.raw(['symbolic-ref', '--quiet', '--short', 'HEAD']).catch(() => '')).trim()
+    // A session branch tracks nothing, so there is no upstream to compare against:
     // a commit is "unique" when no remote ref (and no fetched review ref of this
     // worktree) can reach it.
     const unique = (
@@ -588,6 +597,15 @@ export async function removeSessionWorktree(agent: Agent, sessionKey: string): P
     // and the failure keeps the session.
     await primaryGit().raw(['worktree', 'remove', cwd])
     await cleanupRegistrations()
+    // Only a branch this daemon generated for a session worktree, and only after
+    // the check above proved every commit on it is reachable from a remote — so
+    // the forced delete can drop no work. Best-effort: a surviving ref is clutter,
+    // not a reason to report a removed worktree as retained.
+    if (isSessionBranch(branch)) {
+      await primaryGit()
+        .raw(['branch', '-D', branch])
+        .catch(() => undefined)
+    }
     return { outcome: 'removed' }
   } catch (err) {
     return { outcome: 'failed', error: (err as Error).message }
@@ -710,6 +728,26 @@ function prepareGithubRevisionOnlyWorkspace(agent: Agent, id: string): string {
   return realpathSync(cwd)
 }
 
+/** Check out a session worktree on its OWN generated branch rather than at a
+ * detached HEAD, so the work a session produces has a name it can be pushed and
+ * reviewed under. A drawn name can already exist in the repository, which
+ * `worktree add -b` refuses — so ask git first and draw again, then let random
+ * bytes end the search rather than failing the session over a word pair. */
+async function addSessionWorktree(agent: Agent, cwd: string, target: string, initiatedBy?: string): Promise<void> {
+  const git = () => runnerFor(agent.id, agent.workspace.path).withEnv(workspaceGitLocalEnv())
+  let branch = ''
+  for (let attempt = 0; ; attempt++) {
+    branch = sessionBranchName(initiatedBy, attempt >= SESSION_BRANCH_DRAWS)
+    if (attempt >= SESSION_BRANCH_DRAWS) break
+    const taken = await git()
+      .raw(['show-ref', '--verify', '--quiet', `refs/heads/${branch}`])
+      .then(() => true)
+      .catch(() => false)
+    if (!taken) break
+  }
+  await git().raw(['worktree', 'add', '-b', branch, cwd, target])
+}
+
 /** Prepare the stable cwd for one logical session. Ordinary worktrees preserve
  * their working state between turns. Review worktrees are daemon-owned snapshots
  * and are reset on every delivery after an exact remote fetch. */
@@ -751,9 +789,7 @@ export async function prepareSessionWorkspace(
     // checkout runs in the daemon process. Unsafe executable config must gate
     // the worktree operation itself instead of being swallowed as a pull error.
     await assertSafeWorkspaceGitConfig(runnerFor(agent.id, agent.workspace.path))
-    await runnerFor(agent.id, agent.workspace.path)
-      .withEnv(workspaceGitLocalEnv())
-      .raw(['worktree', 'add', '--detach', cwd, target])
+    await addSessionWorktree(agent, cwd, target, request.initiatedBy)
   } else if (review) {
     // Re-audit at the checkout boundary rather than relying on the earlier
     // network fetch audit; repository config may have changed while fetching.

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -745,7 +745,11 @@ async function addSessionWorktree(agent: Agent, cwd: string, target: string, ini
       .catch(() => false)
     if (!taken) break
   }
-  await git().raw(['worktree', 'add', '-b', branch, cwd, target])
+  // --no-track: the start point is a remote-tracking ref, so git's own `branch.autoSetupMerge`
+  // would otherwise make `origin/<base>` this branch's upstream. That upstream is what the console's
+  // push authorizes against — it would turn the push button into a remote-branch creator — and it
+  // leaves a plain `git push` failing under push.default=simple on the name mismatch.
+  await git().raw(['worktree', 'add', '-b', branch, '--no-track', cwd, target])
 }
 
 /** Prepare the stable cwd for one logical session. Ordinary worktrees preserve

--- a/packages/daemon/test/session-branch.test.ts
+++ b/packages/daemon/test/session-branch.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { initiatorLabel, isSessionBranch, sessionBranchName } from '../src/workspace/session-branch.js'
+
+/** The user segment of `dev/<user>/<adjective>-<animal>`. */
+const userOf = (branch: string) => branch.split('/')[1]!
+
+describe('sessionBranchName', () => {
+  it('names the session worktree dev/<user>/<two words>', () => {
+    const branch = sessionBranchName('yulong')
+    expect(branch).toMatch(/^dev\/yulong\/[a-zA-Z]+-[a-zA-Z]+$/)
+  })
+
+  it('draws a different word pair per call', () => {
+    const drawn = new Set(Array.from({ length: 20 }, () => sessionBranchName('yulong')))
+    // 1202x355 combinations: 20 identical draws would mean the generator is not drawing at all.
+    expect(drawn.size).toBeGreaterThan(1)
+  })
+
+  it('appends random bytes only when asked for a unique name', () => {
+    expect(sessionBranchName('yulong', true)).toMatch(/^dev\/yulong\/[a-zA-Z]+-[a-zA-Z]+-[0-9a-f]{6}$/)
+  })
+
+  it('turns a display name into one ref path component', () => {
+    expect(userOf(sessionBranchName('Yu Long'))).toBe('yu-long')
+    expect(userOf(sessionBranchName('  .Ada  '))).toBe('ada')
+    expect(userOf(sessionBranchName('a..b'))).toBe('a-b')
+  })
+
+  it('keeps a CJK display name rather than flattening every such user to one branch', () => {
+    expect(userOf(sessionBranchName('张伟'))).toBe('张伟')
+  })
+
+  it('falls back to `agent` when the label sanitizes away to nothing', () => {
+    expect(userOf(sessionBranchName(undefined))).toBe('agent')
+    expect(userOf(sessionBranchName(''))).toBe('agent')
+    expect(userOf(sessionBranchName('!!!'))).toBe('agent')
+  })
+
+  it('bounds the user segment, and never ends it on the separator', () => {
+    const user = userOf(sessionBranchName('a'.repeat(80)))
+    expect(user).toHaveLength(24)
+    const trimmed = userOf(sessionBranchName(`${'b'.repeat(23)} tail`))
+    expect(trimmed.endsWith('-')).toBe(false)
+  })
+
+  it('produces a name git itself accepts, from labels built to break ref syntax', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-branch-'))
+    execFileSync('git', ['init', '-q'], { cwd: dir })
+    for (const label of ['yulong', '张伟', 'a b', '..', '-lead-', 'name.lock', 'x~^:?*[\\y', '@{', '/././', '!!!']) {
+      const branch = sessionBranchName(label)
+      // check-ref-format is the authority the daemon's push path also consults.
+      expect(() => execFileSync('git', ['check-ref-format', '--branch', branch], { cwd: dir })).not.toThrow()
+    }
+  })
+})
+
+describe('isSessionBranch (the retention GC delete guard)', () => {
+  it('accepts a generated session branch', () => {
+    expect(isSessionBranch(sessionBranchName('yulong'))).toBe(true)
+    expect(isSessionBranch(sessionBranchName('张伟', true))).toBe(true)
+  })
+
+  it('refuses anything outside the three-component dev namespace', () => {
+    for (const branch of ['main', 'dev', 'dev/yulong', 'dev/yulong/a/b', 'devel/yulong/x', 'feature/dev/x/y', '']) {
+      expect(isSessionBranch(branch)).toBe(false)
+    }
+    expect(isSessionBranch(undefined)).toBe(false)
+  })
+
+  it('refuses a human branch that merely shares the namespace', () => {
+    // Deleting one of these — an agent left the worktree on a teammate's branch — is the failure this guard exists to prevent.
+    for (const branch of [
+      'dev/yulong/gurnard',
+      'dev/yulong/fix-parser',
+      'dev/yulong/brave-otter-x',
+      'dev/yulong/brave-otter-12345',
+      'dev/yulong/otter-brave',
+      'dev/yulong/brave'
+    ]) {
+      expect(isSessionBranch(branch)).toBe(false)
+    }
+  })
+})
+
+describe('initiatorLabel', () => {
+  it('prefers the cached display name of the session initiator', () => {
+    expect(initiatorLabel('U07', 'Yu Long', { id: 'U07', name: 'stale' })).toBe('Yu Long')
+  })
+
+  it('names the initiator even when only this turn`s sender carries the name', () => {
+    expect(initiatorLabel('U07', undefined, { id: 'U07', name: 'Yu Long' })).toBe('Yu Long')
+  })
+
+  it('stands this turn`s sender in for an initiator id that names no human', () => {
+    // A hook session is keyed by the hook, so the GitHub actor who fired it is the person to name.
+    expect(initiatorLabel('hook:2f0c-uuid', undefined, { id: 'spacedragon' })).toBe('spacedragon')
+    expect(initiatorLabel('hook:2f0c-uuid', undefined, { id: 'gh', name: 'Yu Long' })).toBe('Yu Long')
+  })
+
+  it('falls back to the platform id, and to the initiator when there is no sender at all', () => {
+    expect(initiatorLabel('U07', undefined, { id: 'U07' })).toBe('U07')
+    expect(initiatorLabel('U07', undefined, undefined)).toBe('U07')
+    expect(initiatorLabel('U07', undefined, {})).toBe('U07')
+  })
+})

--- a/packages/daemon/test/session-branch.test.ts
+++ b/packages/daemon/test/session-branch.test.ts
@@ -59,16 +59,25 @@ describe('sessionBranchName', () => {
 })
 
 describe('the worktree branch git actually creates', () => {
+  // Carried explicitly: a CI runner configures no identity, and `git commit` refuses without one.
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'Ada Lovelace',
+    GIT_AUTHOR_EMAIL: 'ada@example.invalid',
+    GIT_COMMITTER_NAME: 'Ada Lovelace',
+    GIT_COMMITTER_EMAIL: 'ada@example.invalid'
+  }
+
   /** A clone with an `origin/main` to start a worktree from, as an agent workspace has. */
   function clone() {
     const root = mkdtempSync(join(tmpdir(), 'ac-branch-repo-'))
     const origin = join(root, 'origin')
     const dir = join(root, 'clone')
-    execFileSync('git', ['init', '-q', '--bare', origin])
-    execFileSync('git', ['clone', '-q', origin, dir], { stdio: 'ignore' })
-    execFileSync('git', ['commit', '-q', '--allow-empty', '-m', 'init'], { cwd: dir })
-    execFileSync('git', ['push', '-q', 'origin', 'HEAD:main'], { cwd: dir })
-    execFileSync('git', ['fetch', '-q', 'origin'], { cwd: dir })
+    execFileSync('git', ['init', '-q', '--bare', origin], { env, stdio: 'ignore' })
+    execFileSync('git', ['clone', '-q', origin, dir], { env, stdio: 'ignore' })
+    execFileSync('git', ['commit', '-q', '--allow-empty', '-m', 'init'], { cwd: dir, env, stdio: 'ignore' })
+    execFileSync('git', ['push', '-q', 'origin', 'HEAD:main'], { cwd: dir, env, stdio: 'ignore' })
+    execFileSync('git', ['fetch', '-q', 'origin'], { cwd: dir, env, stdio: 'ignore' })
     return { root, dir }
   }
   const upstreamOf = (cwd: string) => {
@@ -89,6 +98,7 @@ describe('the worktree branch git actually creates', () => {
     // The exact command shape workspace-manager issues.
     execFileSync('git', ['worktree', 'add', '-b', branch, '--no-track', wt, 'refs/remotes/origin/main'], {
       cwd: dir,
+      env,
       stdio: 'ignore'
     })
 

--- a/packages/daemon/test/session-branch.test.ts
+++ b/packages/daemon/test/session-branch.test.ts
@@ -58,6 +58,47 @@ describe('sessionBranchName', () => {
   })
 })
 
+describe('the worktree branch git actually creates', () => {
+  /** A clone with an `origin/main` to start a worktree from, as an agent workspace has. */
+  function clone() {
+    const root = mkdtempSync(join(tmpdir(), 'ac-branch-repo-'))
+    const origin = join(root, 'origin')
+    const dir = join(root, 'clone')
+    execFileSync('git', ['init', '-q', '--bare', origin])
+    execFileSync('git', ['clone', '-q', origin, dir], { stdio: 'ignore' })
+    execFileSync('git', ['commit', '-q', '--allow-empty', '-m', 'init'], { cwd: dir })
+    execFileSync('git', ['push', '-q', 'origin', 'HEAD:main'], { cwd: dir })
+    execFileSync('git', ['fetch', '-q', 'origin'], { cwd: dir })
+    return { root, dir }
+  }
+  const upstreamOf = (cwd: string) => {
+    try {
+      return execFileSync('git', ['rev-parse', '--abbrev-ref', '@{u}'], { cwd, stdio: ['ignore', 'pipe', 'ignore'] })
+        .toString()
+        .trim()
+    } catch {
+      return null
+    }
+  }
+
+  it('starts with NO upstream — git would otherwise adopt the remote-tracking start point', () => {
+    const { root, dir } = clone()
+    const branch = sessionBranchName('yulong')
+    const wt = join(root, 'wt')
+
+    // The exact command shape workspace-manager issues.
+    execFileSync('git', ['worktree', 'add', '-b', branch, '--no-track', wt, 'refs/remotes/origin/main'], {
+      cwd: dir,
+      stdio: 'ignore'
+    })
+
+    expect(execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], { cwd: wt }).toString().trim()).toBe(branch)
+    // With `branch.autoSetupMerge` at its default this would be `origin/main`, which the console's
+    // push authorizes against and a plain `push.default=simple` push then refuses by name mismatch.
+    expect(upstreamOf(wt)).toBeNull()
+  })
+})
+
 describe('isSessionBranch (the retention GC delete guard)', () => {
   it('accepts a generated session branch', () => {
     expect(isSessionBranch(sessionBranchName('yulong'))).toBe(true)

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -90,8 +90,34 @@ describe('SessionManager', () => {
 
     expect(prepareWorkspace).toHaveBeenCalledWith(agent, host, {
       sessionKey: 'slack:C1:100.2:bot-a',
-      isolation: 'shared'
+      isolation: 'shared',
+      // Names a session worktree's branch. No display name is cached for this sender, so the platform id stands in.
+      initiatedBy: 'U1'
     })
+    store.close()
+  })
+
+  it('labels workspace preparation with the session OPENER, by display name, on every turn', async () => {
+    const store = newStore()
+    store.setDisplayName('U1', 'Yu Long', Date.now())
+    store.setDisplayName('U2', 'Someone Else', Date.now())
+    const host = fakeHost()
+    const prepareWorkspace = vi.fn(async () => agent.workspace.path)
+    // A cold host prepares on EVERY turn, which is what makes the second turn's label observable.
+    const sm = new SessionManager({
+      store,
+      hostFor: async () => host,
+      isHostRunning: () => false,
+      agentById: () => agent,
+      prepareWorkspace,
+      memory
+    })
+
+    await sm.handle('bot-a', msg({ ts: '200.1', thread: '200.1', text: 'opened by U1' }))
+    // A second user replying in the same thread must not rename the branch the worktree already carries.
+    await sm.handle('bot-a', msg({ ts: '200.2', thread: '200.1', text: 'reply', sender: { id: 'U2', isBot: false } }))
+
+    expect(prepareWorkspace.mock.calls.map((call) => (call as any[])[2].initiatedBy)).toEqual(['Yu Long', 'Yu Long'])
     store.close()
   })
 

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -299,8 +299,9 @@ describe('prepareSessionWorkspace', () => {
       if (args[0] === 'fetch' && args.some((value) => value.includes('/merge:'))) {
         throw new Error('merge ref unavailable')
       }
+      if (args[0] === 'show-ref') throw new Error('no such ref')
       if (args[0] === 'worktree' && args[1] === 'add') {
-        mkdirSync(join(args[3]!, '.git'), { recursive: true })
+        mkdirSync(join(args[4]!, '.git'), { recursive: true })
       }
       return ''
     })
@@ -317,9 +318,10 @@ describe('prepareSessionWorkspace', () => {
     const addCall = rawMock.mock.calls
       .map((call) => call[0] as string[])
       .find((args) => args[0] === 'worktree' && args[1] === 'add')
-    expect(addCall?.slice(0, 3)).toEqual(['worktree', 'add', '--detach'])
-    expect(realpathSync(addCall![3]!)).toBe(cwd)
-    expect(addCall?.[4]).toBe(head)
+    expect(addCall?.slice(0, 3)).toEqual(['worktree', 'add', '-b'])
+    expect(addCall?.[3]).toMatch(/^dev\/[^/]+\/[a-z]+-[a-z]+$/)
+    expect(realpathSync(addCall![4]!)).toBe(cwd)
+    expect(addCall?.[5]).toBe(head)
     expect(
       rawMock.mock.calls.some(
         ([args, baseDir]) =>
@@ -379,9 +381,10 @@ describe('prepareSessionWorkspace', () => {
     agent.workspace.pullOnNewSession = false
     rawMock.mockImplementation(async (args: string[]) => {
       if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/repo.git\n'
+      if (args[0] === 'show-ref') throw new Error('no such ref')
       if (args[0] === 'worktree' && args[1] === 'add') {
-        mkdirSync(join(args[3]!, '.git'), { recursive: true })
-        mkdirSync(join(args[3]!, 'agents', 'node-operator'), { recursive: true })
+        mkdirSync(join(args[4]!, '.git'), { recursive: true })
+        mkdirSync(join(args[4]!, 'agents', 'node-operator'), { recursive: true })
       }
       return args[0] === 'rev-parse' ? `${'c'.repeat(40)}\n` : ''
     })
@@ -398,6 +401,53 @@ describe('prepareSessionWorkspace', () => {
     expect(additionalWorkspaceDirectories(agent, second, { sessionKey: 'session-b', isolation: 'session' })).toEqual([
       realpathSync(sessionWorktreePath(agent, 'session-b'))
     ])
+  })
+
+  /** A session worktree on `dev/<user>/<words>`, with control over which branch
+   *  names the repository already holds. */
+  function branchFixture(taken: string[] = []) {
+    const root = mkdtempSync(join(tmpdir(), 'ac-session-branch-'))
+    const path = join(root, 'workspace')
+    mkdirSync(join(path, '.git'), { recursive: true })
+    const agent = gitRepoAgent(path)
+    agent.workspace.pullOnNewSession = false
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/repo.git\n'
+      // `show-ref --verify --quiet` exits non-zero for a ref that does not exist.
+      if (args[0] === 'show-ref') {
+        if (!taken.includes(args.at(-1)!.replace('refs/heads/', ''))) throw new Error('no such ref')
+        return ''
+      }
+      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(join(args[4]!, '.git'), { recursive: true })
+      return args[0] === 'rev-parse' ? `${'c'.repeat(40)}\n` : ''
+    })
+    const addCall = () =>
+      rawMock.mock.calls.map((call) => call[0] as string[]).find((args) => args[0] === 'worktree' && args[1] === 'add')
+    return { agent, addCall }
+  }
+
+  it('checks the worktree out on its own branch, named for the user who opened the session', async () => {
+    const { agent, addCall } = branchFixture()
+
+    await prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session', initiatedBy: 'Yu Long' })
+
+    expect(addCall()?.[2]).toBe('-b')
+    expect(addCall()?.[3]).toMatch(/^dev\/yu-long\/[a-zA-Z]+-[a-zA-Z]+$/)
+  })
+
+  it('draws another name when the repository already holds the one it drew', async () => {
+    // Every word pair is taken, so the draws are exhausted and the random-suffix name ends the search.
+    const { agent, addCall } = branchFixture()
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/repo.git\n'
+      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(join(args[4]!, '.git'), { recursive: true })
+      return args[0] === 'rev-parse' ? `${'c'.repeat(40)}\n` : ''
+    })
+
+    await prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session', initiatedBy: 'yulong' })
+
+    expect(rawMock.mock.calls.filter(([args]) => (args as string[])[0] === 'show-ref')).toHaveLength(5)
+    expect(addCall()?.[3]).toMatch(/^dev\/yulong\/[a-zA-Z]+-[a-zA-Z]+-[0-9a-f]{6}$/)
   })
 })
 
@@ -447,6 +497,60 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
       '--remotes',
       `--glob=refs/agentconnect/reviews/${id}`
     ])
+  })
+
+  it('deletes the generated branch with the worktree, after the removal that unregisters it', async () => {
+    const { agent, cwd } = fixture()
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-list') return '0\n'
+      if (args[0] === 'symbolic-ref') return 'dev/yulong/brave-otter\n'
+      return ''
+    })
+
+    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+
+    const calls = gitCalls()
+    const readAt = calls.findIndex((args) => args[0] === 'symbolic-ref')
+    const removeAt = calls.findIndex((args) => args[0] === 'worktree' && args[1] === 'remove' && args[2] === cwd)
+    // The branch has to be read BEFORE the removal — afterwards there is no worktree to ask.
+    expect(readAt).toBeGreaterThanOrEqual(0)
+    expect(readAt).toBeLessThan(removeAt)
+    expect(calls.findIndex((args) => args[0] === 'branch')).toBeGreaterThan(removeAt)
+    expect(calls).toContainEqual(['branch', '-D', 'dev/yulong/brave-otter'])
+  })
+
+  it('never deletes a branch outside the session namespace, nor one on a retained worktree', async () => {
+    const { agent } = fixture()
+    // A worktree left on a branch of the repository's own — the agent switched to it.
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-list') return '0\n'
+      if (args[0] === 'symbolic-ref') return 'main\n'
+      return ''
+    })
+    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(gitCalls().some((args) => args[0] === 'branch')).toBe(false)
+
+    // Unique commits keep the worktree, so its branch must survive with them.
+    rawMock.mockClear()
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-list') return '3\n'
+      if (args[0] === 'symbolic-ref') return 'dev/yulong/brave-otter\n'
+      return ''
+    })
+    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'retained', reason: 'unique-commits' })
+    expect(gitCalls().some((args) => args[0] === 'branch')).toBe(false)
+  })
+
+  it('removes a pre-branch worktree that is still at a detached HEAD', async () => {
+    const { agent } = fixture()
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-list') return '0\n'
+      if (args[0] === 'symbolic-ref') throw new Error('ref HEAD is not a symbolic ref')
+      return ''
+    })
+
+    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(gitCalls().some((args) => args[0] === 'branch')).toBe(false)
   })
 
   it('retains a worktree with dirty/untracked files and never calls worktree remove', async () => {

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -301,7 +301,7 @@ describe('prepareSessionWorkspace', () => {
       }
       if (args[0] === 'show-ref') throw new Error('no such ref')
       if (args[0] === 'worktree' && args[1] === 'add') {
-        mkdirSync(join(args[4]!, '.git'), { recursive: true })
+        mkdirSync(join(args.at(-2)!, '.git'), { recursive: true })
       }
       return ''
     })
@@ -320,8 +320,10 @@ describe('prepareSessionWorkspace', () => {
       .find((args) => args[0] === 'worktree' && args[1] === 'add')
     expect(addCall?.slice(0, 3)).toEqual(['worktree', 'add', '-b'])
     expect(addCall?.[3]).toMatch(/^dev\/[^/]+\/[a-z]+-[a-z]+$/)
-    expect(realpathSync(addCall![4]!)).toBe(cwd)
-    expect(addCall?.[5]).toBe(head)
+    // --no-track, or git makes the remote-tracking start point this branch's upstream.
+    expect(addCall?.[4]).toBe('--no-track')
+    expect(realpathSync(addCall!.at(-2)!)).toBe(cwd)
+    expect(addCall?.at(-1)).toBe(head)
     expect(
       rawMock.mock.calls.some(
         ([args, baseDir]) =>
@@ -383,8 +385,8 @@ describe('prepareSessionWorkspace', () => {
       if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/repo.git\n'
       if (args[0] === 'show-ref') throw new Error('no such ref')
       if (args[0] === 'worktree' && args[1] === 'add') {
-        mkdirSync(join(args[4]!, '.git'), { recursive: true })
-        mkdirSync(join(args[4]!, 'agents', 'node-operator'), { recursive: true })
+        mkdirSync(join(args.at(-2)!, '.git'), { recursive: true })
+        mkdirSync(join(args.at(-2)!, 'agents', 'node-operator'), { recursive: true })
       }
       return args[0] === 'rev-parse' ? `${'c'.repeat(40)}\n` : ''
     })
@@ -418,7 +420,7 @@ describe('prepareSessionWorkspace', () => {
         if (!taken.includes(args.at(-1)!.replace('refs/heads/', ''))) throw new Error('no such ref')
         return ''
       }
-      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(join(args[4]!, '.git'), { recursive: true })
+      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(join(args.at(-2)!, '.git'), { recursive: true })
       return args[0] === 'rev-parse' ? `${'c'.repeat(40)}\n` : ''
     })
     const addCall = () =>
@@ -440,7 +442,7 @@ describe('prepareSessionWorkspace', () => {
     const { agent, addCall } = branchFixture()
     rawMock.mockImplementation(async (args: string[]) => {
       if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/repo.git\n'
-      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(join(args[4]!, '.git'), { recursive: true })
+      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(join(args.at(-2)!, '.git'), { recursive: true })
       return args[0] === 'rev-parse' ? `${'c'.repeat(40)}\n` : ''
     })
 

--- a/packages/protocol/src/frames/workspace.ts
+++ b/packages/protocol/src/frames/workspace.ts
@@ -344,7 +344,7 @@ export const WorkspaceGitWriteReason = z.enum([
   'nothing-staged', // commit with an empty index diff
   'empty-message', // commit message is blank once trimmed
   'no-identity', // no `gitCommitIdentity` was registered, so the commit would take the host operator's
-  'detached-head', // push from a worktree with no branch (every session worktree is detached)
+  'detached-head', // push from a worktree with no branch checked out
   'no-upstream', // the branch tracks nothing, so there is no ref to push to
   'unsafe-origin', // the checkout's `origin` is not the daemon-authorized remote
   'unsafe-config', // the checkout's local config carries a disallowed override (audit refused)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,7 +277,7 @@ importers:
         version: 0.0.67
       '@larksuiteoapi/node-sdk':
         specifier: ^1.71.1
-        version: 1.71.1
+        version: 1.71.1(debug@4.3.4)
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0
@@ -341,6 +341,9 @@ importers:
       undici:
         specifier: ^7.29.0
         version: 7.29.0
+      unique-names-generator:
+        specifier: ^4.7.1
+        version: 4.7.1
       ws:
         specifier: ^8.21.1
         version: 8.21.1
@@ -8490,6 +8493,10 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
+  unique-names-generator@4.7.1:
+    resolution: {integrity: sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==}
+    engines: {node: '>=8'}
+
   unique-string@3.0.0:
     resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
     engines: {node: '>=12'}
@@ -10225,9 +10232,9 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@larksuiteoapi/node-sdk@1.71.1':
+  '@larksuiteoapi/node-sdk@1.71.1(debug@4.3.4)':
     dependencies:
-      axios: 1.18.1
+      axios: 1.18.1(debug@4.3.4)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -11585,7 +11592,7 @@ snapshots:
       '@slack/types': 2.22.0
       '@types/node': 24.13.3
       '@types/retry': 0.12.0
-      axios: 1.18.1
+      axios: 1.18.1(debug@4.3.4)
       eventemitter3: 5.0.4
       form-data: 4.0.6
       is-electron: 2.2.2
@@ -12605,7 +12612,7 @@ snapshots:
       - supports-color
     optional: true
 
-  axios@1.18.1:
+  axios@1.18.1(debug@4.3.4):
     dependencies:
       follow-redirects: 1.16.0(debug@4.3.4)
       form-data: 4.0.6
@@ -17512,6 +17519,8 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
+
+  unique-names-generator@4.7.1: {}
 
   unique-string@3.0.0:
     dependencies:


### PR DESCRIPTION
## What

A session worktree was created with `worktree add --detach`, so the work a session produced had no name it could be pushed or reviewed under, and the console's push button could only answer `detached-head`. Each one now checks out its own generated branch:

```
dev/yulong/brave-otter
dev/张伟/crimson-tiger
```

Two dictionary words rather than a hash, because this name reaches humans — it is what a reviewer reads on a pushed branch and what the agent types in `git` commands. `unique-names-generator` (MIT, zero deps) supplies them; it ships an ESM build, so tsdown tree-shakes down to the two dictionaries imported.

## Who the branch is named for

The user who **opened** the session — `triggeredBy`, first-wins in the store — not whoever's turn it is, so a shared thread does not change branch owner when someone else replies. The cached display name wins over the platform id. A hook session is keyed by `hook:<hookId>`, which names no human, so those fall through to the GitHub actor who fired it rather than putting a UUID in the branch name.

The user segment is sanitized to one ref path component. Unicode letters and digits survive: a Feishu display name is routinely CJK, and collapsing every such user to `agent` defeats the point.

## Collisions

A drawn name can already exist in the repository, which `worktree add -b` refuses. The daemon asks `show-ref` first and redraws (5 draws), then ends the search with a 6-hex suffix rather than failing the session over a word pair.

## Deleting the branch with the worktree

Retention GC reads the branch before `worktree remove`, then `branch -D` after. **The namespace alone is not a safe guard** — `dev/<user>/<topic>` is a convention humans here use too (this very branch is one), and an agent can leave a session worktree checked out on a branch of theirs. So the guard requires the last component to be a pair this generator could have drawn, a word from each dictionary plus at most the collision suffix; `dev/yulong/gurnard` and `dev/yulong/fix-parser` are refused. Deletion also only runs after the pre-existing check proved every commit is reachable from a remote, so the forced delete can drop no work.

A worktree created before this change stays detached and is still removed correctly.

## Test

- New `test/session-branch.test.ts` (15 tests): naming, sanitization of hostile and CJK labels, the initiator-label precedence, and the GC guard. Every generated name is run through real `git check-ref-format`.
- `test/workspace.test.ts`: worktree creation on a branch, the redraw path, branch deletion ordered after removal, and the three cases that must NOT delete — a foreign branch, a retained worktree, a pre-branch detached one.
- `test/session-manager.test.ts`: the label is the session opener on every turn, by display name.
- Verified against a real git repo, not only the mocks: `show-ref --verify --quiet` exit codes, `worktree add -b` with a CJK branch name, and the full remove → prune → `branch -D` sequence.
- Full daemon suite: 3365 pass. `acp-matrix` (live provider calls) and `evaluation-runner` fail identically with these changes stashed — pre-existing.

## Not in scope

The web console still hardcodes "a session worktree is always detached" and shows the *primary* checkout's branch in session scope (`GitPanel.tsx`, `FilesPanel.tsx`, `workspace-tree.tsx`, `git-write.ts`). That copy is now stale; the push button's own behavior is unchanged and still accurate ("tracks no remote branch"). Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)