### PR TITLE
fix(daemon): scope the #800 SendMessage-collision fix to the parent-report directive

### DIFF
--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -858,12 +858,26 @@ export class SessionManager {
     // guidance rather than in the delivered text (which the model may summarize away). Deliberately
     // scoped to a terminal report: nothing here asks for progress narration, which would turn every
     // delegated task into channel chatter.
+    //
+    // The full-name/built-in warning and the this-call-is-complete sentence live HERE, not in the
+    // standing collaboration guidance, on purpose (issue #800): on the Claude Code runtime the
+    // session also carries the runtime's own built-in `SendMessage` — a literal name match for a
+    // report-back instruction — and a child that picks it loses its parent report silently; children
+    // also tended to shotgun a redundant direct `toAgent` wake around the correct parent reply.
+    // Both hazards exist exactly (and only) in needsParentReply sessions, so the directive is the
+    // niche injection point: in-thread conversations never see this text, which is what makes the
+    // #801 regression class ("plain replies reach nobody" taught session-wide, reverted by #861)
+    // structurally impossible here.
     const parentReplyAppend = needsReplyToParent
       ? `# Reporting back to your parent session\n` +
         `Another session delegated this work to you and is waiting on the outcome. When you finish — or when you ` +
         `cannot finish — reply to it with ` +
         `\`sendMessage\` \`{"sessionId":"${effectiveOriginSessionId}","message":"..."}\`, saying whether you ` +
-        `succeeded or failed and what the result was (on failure, what went wrong). Send it exactly once, at the ` +
+        `succeeded or failed and what the result was (on failure, what went wrong). Use exactly this tool — ` +
+        `\`mcp__agentconnect__sendMessage\` — by its full name: your runtime may offer a similarly-named ` +
+        `built-in (a bare \`SendMessage\`) that does NOT reach AgentConnect, and anything sent through it is ` +
+        `lost. The parent session IS the agent that delegated this to you, and this one call is the complete ` +
+        `delivery — do not also message that agent directly (no \`toAgent\` wake, no DM). Send it exactly once, at the ` +
         `end; do not report progress along the way, and do not skip it because the task was small or unsuccessful. ` +
         `Your ordinary assistant response in this child session is not delivered to the parent. Do not write the ` +
         `result before or after the tool call; after the tool reports successful delivery, end your turn immediately ` +

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -737,6 +737,16 @@ describe('SessionManager', () => {
       expect(metaArg).toContain('{"sessionId":"origin-sess-9","message":"..."}')
       expect(metaArg).toContain('after the tool reports successful delivery, end your turn immediately')
       expect(metaArg).toContain('without repeating the message')
+      // #800 collision warning, scoped to THIS directive (niche: only needsParentReply
+      // sessions carry it — never the session-wide guidance, per the #801/#861 lesson):
+      // the full tool name, and the runtime's similarly-named built-in reaches nothing.
+      expect(metaArg).toContain('`mcp__agentconnect__sendMessage` — by its full name')
+      expect(metaArg).toContain('a bare `SendMessage`')
+      expect(metaArg).toContain('anything sent through it is lost')
+      // Dual-identity clarification: the parent session IS the delegating agent, and the
+      // one sessionId call is the complete delivery — no redundant direct wake or DM.
+      expect(metaArg).toContain('this one call is the complete delivery')
+      expect(metaArg).toContain('do not also message that agent directly')
       // Persisted, so later turns and resumes keep it.
       expect(store.getSession(sessionKey('slack', 'C1', '100.1', 'bot-a'))?.needsParentReply).toBe(1)
       store.close()


### PR DESCRIPTION
## What

The niche re-land of the #800 fix after #801's revert (#861): two sentences added to the `needsParentReply` report-back directive in `session-manager.ts` — nothing added to any standing session-wide context.

1. **Collision warning**: use exactly `mcp__agentconnect__sendMessage` by its full name; the runtime's similarly-named built-in (a bare `SendMessage`) does NOT reach AgentConnect and anything sent through it is lost.
2. **Dual-identity / complete-delivery**: the parent session IS the agent that delegated this to you and this one call is the complete delivery — do not also message that agent directly (no `toAgent` wake, no DM).

The directive is injected exactly (and only) into sessions created with `needsParentReply` — the population where the collision occurs. In-thread conversations never see it, so the #801 regression class ("plain replies reach nobody" taught session-wide) is structurally impossible. Diff: `session-manager.ts` + its test pin, nothing else.

## Prompt-change gate (§4.2, both scenarios measured before opening this PR)

Pre-registered criteria, fixed before the runs: parent-session 5 trials/arm → built-in `SendMessage` attempts 0 across all trials, zero lost replies, success ≥ 4/5 per arm; in-thread-count 3 trials/arm stays clean. Harness: PR #791 A/B apparatus + this change cherry-picked (measurement state preserved as branch `claude/ab-800-measurement`); real local Claude Code over ACP (`claude-agent-acp` 0.64.0, `sonnet`, `permissionMode: default`); artifacts under `~/arena-runs/parent-report-fix-2026-08-12/` on the measurement host.

### parent-session, new directive (2026-08-12)

| Arm | Valid trials | Success | First attempt | Built-in attempts | Lost replies | Redundant direct sends | Mean tool calls |
| --- | --- | --- | --- | --- | --- | --- | --- |
| A (`sendMessage`, the shipped surface) | 5/5 | **5/5** | **5/5** | **0** | **0** | **0** | **1.0** |
| B (eval-only `post` façade) | 3/5 | 2/3 | 0/3 | 0 child-side; 12 calls by the CALLER in the 2 invalid trials | 1 (B-5) | 3/3 trials led with one | 3.0 |

Historical: pre-#801 4/6 success, 3/6 built-in attempts, 0/6 first-attempt, 6/10 redundant double-sends; #801 (session-wide bullet) 10/10 success but 4/10 first-attempt — and a live in-thread regression.

### in-thread-count, same tree

| Arm | Pass | Messaging-tool calls | Duplicates / skips | Meta-narration |
| --- | --- | --- | --- | --- |
| A | **3/3** | **0** | 0 / 0 | 0 |
| B | **3/3** | **0** | 2 / 0 (soft) | 0.67 mean (soft) |

## Honest verdict: pre-registered criteria NOT all met — do not merge yet

- **Arm A — the surface this fix actually ships on — met every criterion, perfectly**: 5/5 success, 5/5 first-attempt single-call reports, zero built-in attempts, zero losses, zero redundant sends (vs 6/10 historical), and the in-thread gate untouched.
- **Arm B missed**: only 3/5 trials valid (2 callers lost their *delegation* to the built-in `SendMessage` — the #800 hazard in a population this directive deliberately does not cover, invalid per the harness's pre-registered validity rule but a real finding); B-5's child answered only via redundant direct private posts and the parent never received the answer (a lost reply); success 2/3.

Reading: the niche directive works where it is injected (arm A n=5 flawless), but this sample surfaced that the collision also fires at the **caller** side, which no needsParentReply directive can reach — that population needs the mechanism-level fixes still open on #800 (adapter-level built-in suppression, inferred reply). Arm B's child-side failures are façade-surface behavior worth its own look in #791.

Per the pre-registration: leaving this PR open, not merging. Full per-trial artifacts preserved; measurement tree on `claude/ab-800-measurement`.

Refs #800. Context: #801 (reverted by #861), gate scenario PR #791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)