### PR TITLE
fix(control-plane): adopt an envelope's existing daemon record on first token auth

### DIFF
--- a/packages/control-plane/src/cluster/daemon-identity.test.ts
+++ b/packages/control-plane/src/cluster/daemon-identity.test.ts
@@ -47,13 +47,16 @@ function orgApi(publishedNamespace: string | undefined): OrgResourceApi {
   }
 }
 
-/** Records the identity it was asked to bind, so the binding argument itself is assertable. */
+/** Records what it was asked to bind, so the binding arguments themselves are assertable. */
 function daemons(record: Partial<DaemonRecord> | null = { id: DaemonId(DAEMON_ID) }) {
   const seen: string[] = []
+  const adopt: (string | undefined)[] = []
   return {
     seen,
-    resolveClusterIdentity: async (_orgId: OrgId, identity: string) => {
+    adopt,
+    resolveClusterIdentity: async (_orgId: OrgId, identity: string, opts?: { adoptDaemonId?: string }) => {
       seen.push(identity)
+      adopt.push(opts?.adoptDaemonId)
       return record as DaemonRecord | null
     }
   }
@@ -112,6 +115,19 @@ describe('ClusterDaemonIdentityService', () => {
     expect(await svc.verify('token')).toEqual({ daemonId: DAEMON_ID, orgId: ORG_ID })
     // The binding key is exactly the subject the API server reported.
     expect(store.seen).toEqual([`system:serviceaccount:${NAMESPACE}:${ENVELOPE_DAEMON_SA_NAME}`])
+    expect(store.adopt).toEqual([undefined])
+  })
+
+  it('offers the key path’s pinned daemon for adoption, so an existing envelope keeps it', async () => {
+    const { svc, store } = await service({
+      review: reviewed({
+        audiences: [CP_TOKEN_AUDIENCE],
+        username: clusterIdentityOf(NAMESPACE, ENVELOPE_DAEMON_SA_NAME)
+      }),
+      settings: { ...SETTINGS, credentialDaemonId: DAEMON_ID }
+    })
+    await svc.verify('token')
+    expect(store.adopt).toEqual([DAEMON_ID])
   })
 
   it('sends the control-plane audience on the TokenReview', async () => {

--- a/packages/control-plane/src/cluster/daemon-identity.ts
+++ b/packages/control-plane/src/cluster/daemon-identity.ts
@@ -93,7 +93,11 @@ export class ClusterDaemonIdentityService implements ClusterDaemonIdentity {
     const published = (await this.api.get(resourceName))?.status?.namespace
     if (published !== namespace) return null
     const orgId = OrgId(settings.orgId)
-    const daemon = await this.daemons.resolveClusterIdentity(orgId, clusterIdentityOf(namespace, serviceAccount))
+    const daemon = await this.daemons.resolveClusterIdentity(orgId, clusterIdentityOf(namespace, serviceAccount), {
+      // An envelope provisioned through the API-key path already has a daemon record; the
+      // first token connect adopts it rather than stranding its placements beside a new one.
+      ...(settings.credentialDaemonId ? { adoptDaemonId: settings.credentialDaemonId } : {})
+    })
     if (!daemon) return null
     return { daemonId: DaemonId(daemon.id), orgId }
   }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -191,11 +191,21 @@ export interface DaemonRepo {
    * with two records competing for its placements; the identity is namespace-derived, so
    * a rebuilt envelope resolves back to the same row and keeps its history.
    *
+   * `adoptDaemonId` names the record the retired API-key path already pinned for this
+   * envelope. On the first token connect it is bound to the identity rather than left
+   * beside a fresh one, so an org provisioned before this path keeps its placements and
+   * history. Ignored once the identity is bound, or if that record is another org's or
+   * already carries an identity.
+   *
    * Null when the identity is already bound to a daemon in ANOTHER org: an identity may
    * not move tenants, and refusing is the only answer that cannot leak one org's
    * placements to another.
    */
-  resolveClusterIdentity(orgId: OrgId, clusterIdentity: string): Promise<DaemonRecord | null>
+  resolveClusterIdentity(
+    orgId: OrgId,
+    clusterIdentity: string,
+    opts?: { adoptDaemonId?: string }
+  ): Promise<DaemonRecord | null>
   /**
    * Idempotent on `daemonId`. Bumps `sessionEpoch` (the fencing root) in ONE
    * transaction and sets status `authenticating`. Returns the new strictly-

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -88,9 +88,15 @@ export class PgDaemonRepo implements DaemonRepo {
     })
   }
 
-  async resolveClusterIdentity(orgId: OrgId, clusterIdentity: string): Promise<DaemonRecord | null> {
+  async resolveClusterIdentity(
+    orgId: OrgId,
+    clusterIdentity: string,
+    opts: { adoptDaemonId?: string } = {}
+  ): Promise<DaemonRecord | null> {
     const existing = await this.db.daemon.findUnique({ where: { clusterIdentity }, include: withUsers })
     if (existing) return existing.orgId === orgId ? toRecord(existing) : null
+    const adopted = opts.adoptDaemonId ? await this.adoptForIdentity(orgId, clusterIdentity, opts.adoptDaemonId) : null
+    if (adopted) return adopted
     try {
       return await withAmbientTx(this.db, async (tx) => {
         await lockResourceWriteMemberships(tx, { orgId, visibility: 'org' })
@@ -107,6 +113,30 @@ export class PgDaemonRepo implements DaemonRepo {
       if (!raced) throw error
       return raced.orgId === orgId ? toRecord(raced) : null
     }
+  }
+
+  /** Bind an envelope's existing daemon record — the one the API-key path pinned — to the
+   *  identity now authenticating for it, so an org provisioned before the token path keeps
+   *  its placements and history instead of gaining a second record beside them. Conditional
+   *  on the row being this org's and still unbound; anything else falls through to a create. */
+  private async adoptForIdentity(
+    orgId: OrgId,
+    clusterIdentity: string,
+    daemonId: string
+  ): Promise<DaemonRecord | null> {
+    try {
+      const claimed = await this.db.daemon.updateMany({
+        where: { id: daemonId, orgId, clusterIdentity: null },
+        data: { clusterIdentity }
+      })
+      if (claimed.count !== 1) return null
+    } catch (error) {
+      // Another identity claimed this record first; it is not this envelope's to adopt.
+      if ((error as { code?: string }).code !== 'P2002') throw error
+      return null
+    }
+    const daemon = await this.db.daemon.findUnique({ where: { id: daemonId }, include: withUsers })
+    return daemon ? toRecord(daemon) : null
   }
 
   async upsertOnAuth(input: AuthReqInput): Promise<{ daemon: DaemonRecord; sessionEpoch: bigint }> {

--- a/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
+++ b/packages/control-plane/test/repo/daemon-cluster-identity.repo.test.ts
@@ -54,6 +54,46 @@ describe('DaemonRepo.resolveClusterIdentity', () => {
     expect(await prisma.daemon.count({ where: { clusterIdentity: IDENTITY } })).toBe(1)
   })
 
+  it('adopts the record the key path already pinned, instead of stranding it', async () => {
+    const repo = new PgDaemonRepo(prisma)
+    // An envelope provisioned before the token path: its daemon record exists and carries
+    // the placements and history the key-backed connection built up.
+    const keyBacked = DaemonId('55555555-5555-4555-8555-555555555555')
+    await repo.provision(keyBacked, DEF_ORG)
+    await repo.upsertOnAuth({ daemonId: keyBacked, orgId: DEF_ORG, agentVersion: '1.0.0' })
+
+    const bound = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY, { adoptDaemonId: keyBacked })
+
+    expect(bound?.id).toBe(keyBacked)
+    expect(bound?.sessionEpoch).toBe(1n)
+    expect(await prisma.daemon.count({ where: { orgId: DEFAULT_ORG_ID } })).toBe(1)
+  })
+
+  it('ignores an adoption candidate that already carries another identity', async () => {
+    const repo = new PgDaemonRepo(prisma)
+    const taken = await repo.resolveClusterIdentity(DEF_ORG, 'system:serviceaccount:ac-org-other:ac-daemon')
+
+    const bound = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY, { adoptDaemonId: taken!.id })
+
+    expect(bound).not.toBeNull()
+    expect(bound!.id).not.toBe(taken!.id)
+    expect(await prisma.daemon.findUnique({ where: { id: taken!.id } })).toMatchObject({
+      clusterIdentity: 'system:serviceaccount:ac-org-other:ac-daemon'
+    })
+  })
+
+  it('ignores an adoption candidate belonging to another org', async () => {
+    const repo = new PgDaemonRepo(prisma)
+    const other = await prisma.org.create({ data: { slug: 'adoption-other-org' } })
+    const theirs = DaemonId('66666666-6666-4666-8666-666666666666')
+    await repo.provision(theirs, OrgId(other.id))
+
+    const bound = await repo.resolveClusterIdentity(DEF_ORG, IDENTITY, { adoptDaemonId: theirs })
+
+    expect(bound!.id).not.toBe(theirs)
+    expect(await prisma.daemon.findUnique({ where: { id: theirs } })).toMatchObject({ clusterIdentity: null })
+  })
+
   it('gives distinct identities distinct records within one org', async () => {
     const repo = new PgDaemonRepo(prisma)
 

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -376,8 +376,10 @@ export class CpClient {
       ...(this.deps.onBootstrapUpgrade ? { bootstrapProtocolVersion: DAEMON_BOOTSTRAP_PROTOCOL_VERSION } : {})
     }
     // Send daemonId only if configured; otherwise the CP derives it from the
-    // token's `sub` and returns it in auth/ok (token-only onboarding).
-    if (this.deps.daemonId) {
+    // token's `sub` and returns it in auth/ok (token-only onboarding). Never echoed on the
+    // identity-token path: the CP re-derives the daemon from the token each connect, so an
+    // id adopted from an earlier auth/ok could only contradict it — and a mismatch is fatal.
+    if (this.deps.daemonId && !identityToken) {
       authPayload.daemonId = this.deps.daemonId
     }
     if (this.lastAuthedEpoch > 0) {

--- a/packages/daemon/test/cp/client-cluster-identity.test.ts
+++ b/packages/daemon/test/cp/client-cluster-identity.test.ts
@@ -96,6 +96,16 @@ describe('CpClient auth credential', () => {
     expect(t.lastSent().payload.serviceAccountToken).toBeUndefined()
   })
 
+  it('never echoes a daemonId on the identity path, where the CP re-derives it', async () => {
+    const t = new FakeTransport()
+    const client = new CpClient(
+      makeDeps(t, { daemonId: '22222222-2222-4222-8222-222222222222', clusterIdentityToken: () => 'projected-token' })
+    )
+    client.start()
+    await tick()
+    expect(t.lastSent().payload.daemonId).toBeUndefined()
+  })
+
   it('re-reads the token per connect, so an hourly rotation is picked up', async () => {
     const reads: string[] = []
     let current = 'token-1'


### PR DESCRIPTION
Follow-up to #907, which merged while these were in flight. Both are review-bot's
non-blocking findings on that PR, and both are about an org that already ran on an API
key meeting the identity path for the first time.

**Adopt the envelope's existing daemon record.** An envelope provisioned through the key
path already has a daemon record, pinned as `credentialDaemonId`. Its first token connect
would have created a second one beside it and left the placements and session history on
the first — the opposite of the "re-provisioning keeps history" property the binding is
supposed to hold. The identity now offers that record for adoption, and the store binds it
under conditions that cannot cross a boundary: the row must be this org's and still
unbound, so a record already carrying another identity, or another org's record, still
falls through to a fresh one.

**Stop echoing the adopted `daemonId` on the identity path.** The control plane re-derives
the daemon from the token on every connect, so the echo can only ever agree — until the
binding row is recreated under a surviving pod, where the mismatch is a fatal `4401` the
daemon never retries. Suppressing it makes "identity is re-derived each connect" true of
the wire and not just of the control plane.

## Tests

- `test/repo/daemon-cluster-identity.repo.test.ts` — adoption keeps the record and its
  epoch, and is ignored for a candidate that already carries another identity or belongs
  to another org.
- `src/cluster/daemon-identity.test.ts` — the pinned daemon is offered for adoption only
  when the settings row has one.
- `test/cp/client-cluster-identity.test.ts` — no `daemonId` on the auth frame when a
  projected token is presented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
