### PR TITLE
feat(operator): render the master SandboxTemplates from chart values

### DIFF
--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -140,6 +140,60 @@ Both settings apply when the claim is created. Kubernetes rejects a class change
 on an existing PVC, so changing them moves new orgs only; an org already
 provisioned keeps its volume until that volume is deleted.
 
+## Runtime tiers — the master SandboxTemplates
+
+`runtimeTiers` renders one `SandboxTemplate` per entry into the release
+namespace, named `<masterTemplatePrefix><name>` — `ac-runtime-small` and friends
+by default:
+
+```yaml
+runtimeTiers:
+  - name: small
+    image: ghcr.io/agentconnect-md/runtime-sandbox:latest
+    resources:
+      requests: { cpu: 500m, memory: 1Gi }
+      limits: { cpu: '2', memory: 4Gi }
+    workspace:
+      className: '' # empty = the cluster default StorageClass
+      size: 10Gi
+```
+
+**These are blueprints, not per-org objects.** Nothing claims against them and no
+pod is ever born from one directly. When an `AgentConnectOrg` names a tier in
+`spec.runtime.tiers[]`, the operator deep-copies that master into the org's
+namespace as `ac-runtime-<tier>`, pairs it with a `SandboxWarmPool`, and
+overrides exactly three things:
+
+| Replaced per org            | With                                                                             |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| the first container's image | the org's `spec.runtime.image`                                                   |
+| `AC_SHIM_ENDPOINT`          | that org daemon's shim Service, which has no address until the envelope exists   |
+| `spec.networkPolicy`        | the egress rules for the org's `spec.egressPolicy`, wholesale rather than merged |
+
+Everything else is inherited verbatim, so the master is where an install states
+what a sandbox pod actually is: `automountServiceAccountToken: false` and a
+projected, audience-restricted `serviceAccountToken` (the pod's only credential,
+and the only one the `ac-sandbox-baseline` policy admits), a non-root
+`securityContext` matching the runtime image's fixed uid, the workspace
+`volumeClaimTemplates` entry mounted at the workspace root the image fixes, and
+`volumeClaimTemplatesPolicy: Disallowed` — a `SandboxClaim` carrying volumes of
+its own would bypass warm-pool adoption, and pool pods are stamped before any
+user exists.
+
+A tier an org names with **no master** is not survivable: the operator skips it
+with a warning, so that org gets no template and no warm pool and can never
+launch a sandbox. The names here are therefore the menu
+`spec.runtime.tiers[].name` chooses from, and the control plane's
+`CLUSTER_DEFAULT_RUNTIME_TIER` (falling back to `CLUSTER_DEFAULT_TIER`, `small`)
+must name one of them.
+
+**First install on a cluster with no agent-sandbox.** Helm resolves every kind in
+a manifest before it creates anything, so one release cannot both install the
+`SandboxTemplate` CRD and create SandboxTemplates against it. Install once with
+`--set runtimeTiers=null`, then `helm upgrade` with the tiers; the second pass
+sees the CRD the first one installed. Clusters that already run agent-sandbox —
+the `installCRD: false` case — are unaffected.
+
 ## Install
 
 ```bash

--- a/charts/operator/templates/sandbox-templates.yaml
+++ b/charts/operator/templates/sandbox-templates.yaml
@@ -1,0 +1,89 @@
+{{- range .Values.runtimeTiers }}
+{{- $tier := required "each runtimeTiers entry needs a name" .name }}
+{{- $workspace := required (printf "runtimeTiers[%s] needs a workspace block" $tier) .workspace }}
+---
+# Master SandboxTemplate for the `{{ $tier }}` tier — a blueprint in the control namespace,
+# never an org's own object and never claimed against directly. The operator deep-copies it
+# into an org namespace when that org's spec.runtime.tiers names this tier, overriding the
+# container image, AC_SHIM_ENDPOINT and the whole networkPolicy; everything else here is
+# inherited verbatim, so this is where an install states what a sandbox pod actually is.
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: {{ $.Values.masterTemplatePrefix }}{{ $tier }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: agentconnect-operator
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  # A SandboxClaim may not add volumes of its own: pool pods are stamped before any user
+  # exists, and a claim carrying volumeClaimTemplates bypasses warm-pool adoption entirely.
+  volumeClaimTemplatesPolicy: Disallowed
+  networkPolicyManagement: Managed
+  # Placeholder: the operator rewrites this wholesale from the org's spec.egressPolicy, and
+  # an empty egress list is the safe thing for a blueprint to carry until it does.
+  networkPolicy:
+    egress: []
+  # One claim per sandbox, mounted below at the workspace root the runtime image fixes.
+  volumeClaimTemplates:
+    - metadata:
+        name: workspace
+      spec:
+        accessModes: ['ReadWriteOnce']
+        {{- with $workspace.className }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ required (printf "runtimeTiers[%s] needs workspace.size" $tier) $workspace.size | quote }}
+  podTemplate:
+    spec:
+      # Created per org by the operator with zero RoleBindings: the token below proves which
+      # pod this is to its own daemon, and grants nothing at the Kubernetes API.
+      serviceAccountName: ac-runtime
+      # Required by the install's ac-sandbox-baseline admission policy, which admits exactly
+      # one service-account token in a sandbox pod — the projected one at the bottom.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        # So the provisioned workspace volume is writable by the runtime user.
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        # First container by position — that is the one the operator retargets per org.
+        - name: runtime
+          # Placeholder: the operator replaces it with the org's spec.runtime.image.
+          image: {{ required (printf "runtimeTiers[%s] needs an image" $tier) .image | quote }}
+          env:
+            # Placeholder: rewritten per org to that org daemon's shim Service.
+            - name: AC_SHIM_ENDPOINT
+              value: ''
+          {{- with .resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ['ALL']
+          volumeMounts:
+            # /agent is HOME and workspace root in the runtime image (AC_SHIM_WORKSPACE_ROOT).
+            - name: workspace
+              mountPath: /agent
+            - name: ac-identity
+              mountPath: /var/run/ac-identity
+              readOnly: true
+      volumes:
+        # The pod's whole credential: audience-restricted, kubelet-rotated, and useless
+        # anywhere but the shim endpoint of the daemon that launched this pod.
+        - name: ac-identity
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  audience: ac-daemon-callback
+                  expirationSeconds: 3600
+{{- end }}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -13,6 +13,58 @@ orgNamespacePrefix: ac-org-
 # the operator stamps a per-org copy for every tier in spec.runtime.tiers.
 masterTemplatePrefix: ac-runtime-
 
+# The master SandboxTemplates themselves, one per entry, rendered into the release
+# namespace as `<masterTemplatePrefix><name>`. They are BLUEPRINTS, never an org's
+# own objects: the operator deep-copies the master a tier names into that org's
+# namespace and overrides only the container image, the shim endpoint and the
+# network policy, so everything else below is what that org's sandbox pods run
+# with. A tier an AgentConnectOrg names with no master here is skipped with a
+# warning — that org gets no warm pool and can never launch a sandbox — so these
+# names are the menu `spec.runtime.tiers[].name` chooses from. They mirror the
+# operator's built-in daemon tiers, which is what the control plane's
+# CLUSTER_DEFAULT_RUNTIME_TIER falls back to when it is left unset.
+runtimeTiers:
+  - name: small
+    # Placeholder: the operator replaces it with the org's spec.runtime.image.
+    image: ghcr.io/agentconnect-md/runtime-sandbox:latest
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: '2'
+        memory: 4Gi
+    # The per-sandbox workspace claim (also the runtime's HOME). Same className
+    # caveat as daemonStorage: empty means the cluster default StorageClass, which
+    # must be a cluster-wide class rather than a node-local provisioner.
+    workspace:
+      className: ''
+      size: 10Gi
+  - name: medium
+    image: ghcr.io/agentconnect-md/runtime-sandbox:latest
+    resources:
+      requests:
+        cpu: '1'
+        memory: 2Gi
+      limits:
+        cpu: '4'
+        memory: 8Gi
+    workspace:
+      className: ''
+      size: 20Gi
+  - name: large
+    image: ghcr.io/agentconnect-md/runtime-sandbox:latest
+    resources:
+      requests:
+        cpu: '2'
+        memory: 4Gi
+      limits:
+        cpu: '8'
+        memory: 16Gi
+    workspace:
+      className: ''
+      size: 40Gi
+
 # Namespaces an org's daemon may reach on any port — where this deployment's
 # control plane and relay actually run. This is network REACHABILITY and nothing
 # else: the control plane's ADDRESS reaches the daemon on the AgentConnectOrg,

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -143,7 +143,8 @@ diffing. Object names are fixed per-namespace constants (`ac-daemon`,
 `ac-daemon-shim`, `ac-daemon-state`, `ac-runtime-<tier>`, `ac-quota`,
 `ac-limits`); the namespace is per-org, so they never collide. Master
 SandboxTemplates live in the control namespace as
-`<AC_MASTER_TEMPLATE_PREFIX><tier>` (default `ac-runtime-<tier>`); daemon
+`<AC_MASTER_TEMPLATE_PREFIX><tier>` (default `ac-runtime-<tier>`), rendered by
+the chart from its `runtimeTiers` value; daemon
 resource tiers are a built-in small/medium/large table, unknown names falling
 back to `small` with a warning. Order is policy-before-workload within one
 reconcile pass:
@@ -190,7 +191,10 @@ carrying `helm.sh/resource-policy: keep` so no release uninstall can
 cascade-delete every org or every live Sandbox. The one thing the chart adds to
 the vendored stack is the controller's label-domain allowlist, which replaces
 rather than extends its default and without which every SandboxClaim is
-rejected. Everything else is per-install: operator Deployment (2 replicas) +
+rejected. Everything else is per-install: the master SandboxTemplates rendered
+from `runtimeTiers` (blueprints in the control namespace — the operator inherits
+each one wholesale except the image, the shim endpoint and the network policy),
+operator Deployment (2 replicas) +
 SA/RBAC, the release-prefixed tokenreview ClusterRole, two
 ValidatingAdmissionPolicies, and a pre-delete hook that refuses uninstall while
 CRs remain — removing the operator would strand every finalizer. That hook is a


### PR DESCRIPTION
`ensureSandboxTemplates` deep-copies a master `SandboxTemplate` named
`<AC_MASTER_TEMPLATE_PREFIX><tier>` out of the control namespace into each org
namespace, overriding only the image, the shim endpoint and the network policy.
**Nothing created those masters.** The first end-to-end run used a hand-written one,
and a tier whose master is missing is skipped with a warning — so that org gets no
template, no warm pool, and its daemon has nothing to claim from.

## What changed

`runtimeTiers` is a new chart value: a list whose entries carry a tier name, a
container image, resource requests/limits, and the workspace claim's size and
StorageClass. One `SandboxTemplate` is rendered per entry into the release namespace,
named `<masterTemplatePrefix><name>` — exactly what the operator looks up.

The default ships `small` / `medium` / `large`, mirroring the operator's built-in
daemon tier names, so the control plane's `CLUSTER_DEFAULT_RUNTIME_TIER` (which falls
back to `CLUSTER_DEFAULT_TIER`, `small`) resolves against a real master when left unset.

## The shape, and why each part is there

The rendered spec is what the operator **inherits**, not what it replaces:

- `automountServiceAccountToken: false` plus a projected, audience-restricted
  `serviceAccountToken` (`ac-daemon-callback`, one hour) on the `ac-runtime`
  ServiceAccount the operator creates with zero RoleBindings — that pair is the pod's
  whole credential, and the only service-account token `<release>-ac-sandbox-baseline`
  admits in an org namespace.
- A non-root `securityContext` on uid/gid 10001, the uid `docker/runtime-sandbox.Dockerfile`
  fixes; `fsGroup` so the provisioned workspace is writable.
- A `workspace` `volumeClaimTemplates` entry mounted at `/agent`, the workspace root the
  runtime image fixes (`AC_SHIM_WORKSPACE_ROOT`).
- `volumeClaimTemplatesPolicy: Disallowed` — a `SandboxClaim` that adds volumes of its own
  bypasses warm-pool adoption, and pool pods are stamped before any user exists.

The three fields the operator rewrites per org (first container's image,
`AC_SHIM_ENDPOINT`, `spec.networkPolicy`) carry placeholders; the README says so in a
table, and explains that these objects are blueprints that nothing ever claims against.

Also documented: a first install on a cluster that has never run agent-sandbox needs
`--set runtimeTiers=null` and then an upgrade with the tiers, because Helm resolves every
kind in a manifest before creating anything and so cannot install the `SandboxTemplate`
CRD and create SandboxTemplates in one pass.

## Verification

`helm lint charts/operator` clean. `helm template` rendered with `installCRD` true and
false and with default, custom and `null` `runtimeTiers`: 3 templates by default, 3 with
`installCRD: false`, 0 with `runtimeTiers=null`; a custom single-tier values file renders
its own name, image, resources, `storageClassName` and size. The output parses back to the
asserted shape (`Disallowed`, `automountServiceAccountToken: false`, the projected token,
the `/agent` mount). Entries missing `name`, `image`, `workspace` or `workspace.size` fail
the render with a named error. `pnpm --filter @agentconnect.md/operator test` (96),
`pnpm lint`, `pnpm format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
