### PR TITLE
feat(control-plane): limit non-admin organization creation

### DIFF
--- a/packages/control-plane/prisma/migrations/20260817000000_org_creation_provenance/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260817000000_org_creation_provenance/migration.sql
@@ -1,0 +1,21 @@
+-- Persist who created each organization so creation quotas do not count an org
+-- where somebody else later granted the user the owner role.
+ALTER TABLE "public"."org" ADD COLUMN "createdByUserId" TEXT;
+
+-- Existing application-created orgs had their creator's membership inserted first,
+-- including personal orgs. Preserve that provenance for the new quota semantics.
+UPDATE "public"."org" AS org
+SET "createdByUserId" = first_membership."userId"
+FROM (
+  SELECT DISTINCT ON ("orgId") "orgId", "userId"
+  FROM "public"."membership"
+  ORDER BY "orgId", "createdAt", "id"
+) AS first_membership
+WHERE org."id" = first_membership."orgId";
+
+CREATE INDEX "org_createdByUserId_idx" ON "public"."org"("createdByUserId" ASC);
+
+ALTER TABLE "public"."org"
+  ADD CONSTRAINT "org_createdByUserId_fkey"
+  FOREIGN KEY ("createdByUserId") REFERENCES "public"."app_user"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -69,6 +69,8 @@ model Org {
   // Optional display name; when absent the console falls back to `slug`.
   name                   String?
   slug                   String          @unique
+  // Immutable provenance: the user credited with creating the org; personal orgs use their recipient.
+  createdByUserId        String?
   // Console avatar descriptor (protocol AgentIcon): {kind:'runtime'} | {kind:'glyph',glyph,color}
   // | {kind:'image'}. Null ⇒ generated default (glyph plate keyed off the org id). An `image`
   // icon's bytes live in the object store (docs/designs/icon-uploads.md), served by GET
@@ -80,6 +82,7 @@ model Org {
   createdAt              DateTime        @default(now()) @db.Timestamptz(6)
   updatedAt              DateTime        @updatedAt @db.Timestamptz(6)
 
+  createdBy                 User?                         @relation("OrgCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
   members                   Membership[]
   daemons                   Daemon[]
   agents                    Agent[]
@@ -106,6 +109,7 @@ model Org {
   environmentEntries        OrganizationEnvironmentEntry[]
   clusterExecution          OrgClusterExecution?
 
+  @@index([createdByUserId])
   @@map("org")
 }
 
@@ -128,6 +132,7 @@ model User {
   createdAt               DateTime  @default(now()) @db.Timestamptz(6)
 
   memberships                      Membership[]
+  createdOrgs                       Org[]                      @relation("OrgCreatedBy")
   apiKeys                          ApiKey[]
   createdAgents                    Agent[]                    @relation("AgentCreatedBy")
   modifiedAgents                   Agent[]                    @relation("AgentModifiedBy")
@@ -2837,4 +2842,3 @@ model PendingEnvelopeTeardown {
 
   @@map("pending_envelope_teardown")
 }
-

--- a/packages/control-plane/src/config/deployment.test.ts
+++ b/packages/control-plane/src/config/deployment.test.ts
@@ -17,7 +17,7 @@ function runtime(overrides: Partial<DeploymentConfigRuntime> = {}): DeploymentCo
       github: null,
       slack: null,
       logto: null,
-      features: { presetAgentsEnabled: true }
+      features: { presetAgentsEnabled: true, maxOrgsPerNonAdminUser: 1 }
     },
     secrets: {},
     updatedAt: new Date(0),
@@ -103,7 +103,7 @@ describe('applyDeploymentEnvironment', () => {
               browser: null,
               githubConnector: null
             },
-            features: { presetAgentsEnabled: false }
+            features: { presetAgentsEnabled: false, maxOrgsPerNonAdminUser: 1 }
           },
           secrets: {
             'github.privateKeyB64': 'github-key',

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -932,6 +932,7 @@ export function buildContainer(
           }
         }
       : {},
+    maxOrgsPerNonAdminUser: opts.deploymentConfig?.values.features.maxOrgsPerNonAdminUser ?? 1,
     clock,
     // The same late-bound façade the orchestrators above hold (see its
     // definition): the providers below are constructed WITH `httpDeps` — their

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -128,6 +128,8 @@ export interface HttpServerConfig extends HumanAuthConfig {
 export interface HttpDeps {
   /** Secret-free startup snapshot served to the prebuilt browser image. */
   runtimeConfig: RuntimeConfigRouteDeps
+  /** Deployment quota for non-ADMIN organization creation; absent defaults to one. */
+  maxOrgsPerNonAdminUser?: number
   /** Shared process clock: delegated MCP execution uses the same timer seam as its reaper. */
   clock: Clock
   repos: {

--- a/packages/control-plane/src/http/plugins/auth.test.ts
+++ b/packages/control-plane/src/http/plugins/auth.test.ts
@@ -186,7 +186,7 @@ describe('humanAuthPlugin identity warm trigger (oidc path)', () => {
   // shape the OIDC integration tests use, without any database behind it.
   let oidcServer: Server
   let oidcIssuer = ''
-  let mintBearer: (subject: string) => Promise<string>
+  let mintBearer: (subject: string, claims?: Record<string, unknown>) => Promise<string>
 
   beforeAll(async () => {
     const { privateKey, publicKey } = await generateKeyPair('RS256')
@@ -210,8 +210,8 @@ describe('humanAuthPlugin identity warm trigger (oidc path)', () => {
     })
     const { port } = oidcServer.address() as AddressInfo
     oidcIssuer = `http://127.0.0.1:${port}`
-    mintBearer = (subject) =>
-      new SignJWT({})
+    mintBearer = (subject, claims = {}) =>
+      new SignJWT(claims)
         .setProtectedHeader({ alg: 'RS256', kid: 'warm-test' })
         .setIssuer(oidcIssuer)
         .setSubject(subject)
@@ -243,6 +243,19 @@ describe('humanAuthPlugin identity warm trigger (oidc path)', () => {
 
     expect(response.statusCode).toBe(200)
     expect(warm).toHaveBeenCalledWith({ userId: 'local-sub-42', oidcSubject: 'sub-42' })
+  })
+
+  it('surfaces the verified ADMIN role on the human principal', async () => {
+    const app = await appWithOptions({ OIDC_ISSUER: oidcIssuer, resolveUser: async () => ({ userId: 'local-sub-42' }) })
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/probe',
+      headers: { authorization: `Bearer ${await mintBearer('sub-42', { roles: ['ADMIN'] })}` }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().principal).toEqual({ userId: 'local-sub-42', isAdmin: true })
   })
 
   it('a throwing trigger does not 401 a valid token', async () => {

--- a/packages/control-plane/src/http/plugins/auth.ts
+++ b/packages/control-plane/src/http/plugins/auth.ts
@@ -25,6 +25,16 @@ import type { InternalInvocationAuth } from '../mcp/internal-invocation-auth.js'
 export interface HumanPrincipal {
   userId: string
   email?: string
+  /** True only when a verified OIDC token carries the deployment ADMIN role. */
+  isAdmin?: boolean
+}
+
+const ADMIN_ROLE = 'ADMIN'
+
+function hasAdminRole(claim: unknown): boolean {
+  if (Array.isArray(claim)) return claim.some((role) => role === ADMIN_ROLE)
+  if (typeof claim === 'string') return claim.split(/[\s,]+/).includes(ADMIN_ROLE)
+  return false
 }
 
 export interface HumanAuthConfig {
@@ -303,6 +313,7 @@ function oidcAuth(cfg: HumanAuthOptions & { OIDC_ISSUER: string }): preHandlerHo
       })
       if (!payload.sub) return unauthorized(reply, 'token missing subject')
       const sub = payload.sub
+      let isAdmin = hasAdminRole(payload.roles)
       // Was this subject's account deleted? Anything issued at or before that moment
       // — including the bearer that was live when it happened — stays rejected, so no
       // amount of retrying re-provisions it. A token with no `iat` cannot prove it is
@@ -344,10 +355,11 @@ function oidcAuth(cfg: HumanAuthOptions & { OIDC_ISSUER: string }): preHandlerHo
       let picture = typeof payload.picture === 'string' ? payload.picture : undefined
       const rawIdTokenHint = req.headers['x-ac-id-token']
       const idTokenHint = (Array.isArray(rawIdTokenHint) ? rawIdTokenHint[0] : rawIdTokenHint)?.trim() || undefined
-      if (!email && idTokenHint) {
+      if (idTokenHint) {
         try {
           const { payload: idClaims } = await jwtVerify(idTokenHint, await getJwks(), { issuer })
           if (idClaims.sub === sub) {
+            isAdmin ||= hasAdminRole(idClaims.roles)
             if (typeof idClaims.email === 'string') email = idClaims.email
             if (!displayName && typeof idClaims.name === 'string') displayName = idClaims.name
             if (!picture && typeof idClaims.picture === 'string') picture = idClaims.picture
@@ -407,7 +419,11 @@ function oidcAuth(cfg: HumanAuthOptions & { OIDC_ISSUER: string }): preHandlerHo
       }
       // Identity only — which org the request acts on is the URL's business
       // (`/orgs/:orgId/…`, verified by the org-scope guard).
-      req.principal = { userId: identity.userId, email: email ?? headerEmail }
+      req.principal = {
+        userId: identity.userId,
+        email: email ?? headerEmail,
+        ...(isAdmin ? { isAdmin: true } : {})
+      }
       req.oidcSubject = sub
       // Warm the identity projection behind this response (cold-visit §3). Contained:
       // a throw here must not fall into the outer catch and 401 a valid token.

--- a/packages/control-plane/src/http/routes/orgs.ts
+++ b/packages/control-plane/src/http/routes/orgs.ts
@@ -33,6 +33,7 @@ import { detachDaemon } from '../daemon-removal.js'
 import { Tag } from '../plugins/openapi.js'
 import { resolveOrgIconUrl, type IconUrlBases } from '../../agents/agent-icon.js'
 import { OrgDto, OrgListDto, CreateOrgBody, UpdateOrgBody, ErrorDto, type OrgDtoT } from '../dto/index.js'
+import { OrgCreationLimitReached } from '../../persistence/errors.js'
 
 function toDto(o: OrgRecord, deps: HttpDeps): OrgDtoT {
   const bases: IconUrlBases = {
@@ -90,7 +91,7 @@ export function orgRoutes(deps: HttpDeps) {
       }
     )
 
-    // Any authenticated user can create an org — they own what they create.
+    // ADMIN accounts bypass the deployment quota; local no-auth mode is the admin path.
     // A slug collision surfaces as 409 via the P2002 branch in the error mapper.
     r.post(
       '/orgs',
@@ -120,11 +121,26 @@ export function orgRoutes(deps: HttpDeps) {
             })
           }
         }
-        const org = await deps.repos.org.create({
-          name: req.body.name ?? null,
-          slug: req.body.slug,
-          ownerUserId: req.principal!.userId
-        })
+        const isAdmin = !deps.config.OIDC_ISSUER || req.principal!.isAdmin === true
+        let org: OrgRecord
+        try {
+          org = await deps.repos.org.create({
+            name: req.body.name ?? null,
+            slug: req.body.slug,
+            ownerUserId: req.principal!.userId,
+            ...(isAdmin ? {} : { maxOrgsPerUser: deps.maxOrgsPerNonAdminUser ?? 1 })
+          })
+        } catch (error) {
+          if (error instanceof OrgCreationLimitReached) {
+            return reply.code(403).send({
+              error: 'Forbidden',
+              statusCode: 403,
+              message: error.message,
+              code: error.code
+            })
+          }
+          throw error
+        }
         // Managed execution, where the deployment runs it: the envelope is part
         // of what an organization IS here, so it is provisioned with the org
         // rather than waiting for an owner to find a toggle. Deliberately NOT

--- a/packages/control-plane/src/persistence/deployment-config.test.ts
+++ b/packages/control-plane/src/persistence/deployment-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1,
+  DeploymentConfigValuesV1Schema,
   deploymentSecretsRequiringRefresh,
   type DeploymentConfigValuesV1
 } from './deployment-config.js'
@@ -16,6 +17,22 @@ const base: DeploymentConfigValuesV1 = {
     githubConnector: null
   }
 }
+
+describe('DeploymentConfigValuesV1Schema', () => {
+  it('defaults the non-admin organization quota and accepts zero', () => {
+    const legacy = DeploymentConfigValuesV1Schema.parse({
+      ...DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1,
+      features: { presetAgentsEnabled: true }
+    })
+    expect(legacy.features.maxOrgsPerNonAdminUser).toBe(1)
+
+    const zero = DeploymentConfigValuesV1Schema.parse({
+      ...DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1,
+      features: { presetAgentsEnabled: true, maxOrgsPerNonAdminUser: 0 }
+    })
+    expect(zero.features.maxOrgsPerNonAdminUser).toBe(0)
+  })
+})
 
 describe('deploymentSecretsRequiringRefresh', () => {
   it('binds write-only secrets only to provider identity fields', () => {

--- a/packages/control-plane/src/persistence/deployment-config.ts
+++ b/packages/control-plane/src/persistence/deployment-config.ts
@@ -152,7 +152,7 @@ export const DeploymentConfigValuesV1Schema = z
       .nullable(),
     features: z.strictObject({
       presetAgentsEnabled: z.boolean(),
-      /** Maximum organizations a non-ADMIN account may own through the console. */
+      /** Maximum organizations a non-ADMIN account may create through the console. */
       maxOrgsPerNonAdminUser: z.number().int().nonnegative().default(1)
     })
   })

--- a/packages/control-plane/src/persistence/deployment-config.ts
+++ b/packages/control-plane/src/persistence/deployment-config.ts
@@ -151,7 +151,9 @@ export const DeploymentConfigValuesV1Schema = z
       })
       .nullable(),
     features: z.strictObject({
-      presetAgentsEnabled: z.boolean()
+      presetAgentsEnabled: z.boolean(),
+      /** Maximum organizations a non-ADMIN account may own through the console. */
+      maxOrgsPerNonAdminUser: z.number().int().nonnegative().default(1)
     })
   })
   .superRefine((values, ctx) => {
@@ -192,7 +194,7 @@ export const DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1: DeploymentConfigValuesV1 = {
   github: null,
   slack: null,
   logto: null,
-  features: { presetAgentsEnabled: true }
+  features: { presetAgentsEnabled: true, maxOrgsPerNonAdminUser: 1 }
 }
 
 export const DEPLOYMENT_SECRET_KEYS = [

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -237,7 +237,7 @@ export class OrgCreationLimitReached extends Error {
     super(
       limit === 0
         ? 'organization creation is disabled for non-admin accounts'
-        : `non-admin accounts may own at most ${limit} organizations`
+        : `non-admin accounts may create at most ${limit} organizations`
     )
     this.name = 'OrgCreationLimitReached'
   }

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -229,6 +229,20 @@ export class OrgOwnerRequired extends Error {
   }
 }
 
+/** A non-admin account reached the deployment's organization creation quota. */
+export class OrgCreationLimitReached extends Error {
+  readonly code = 'ORG_CREATION_LIMIT_REACHED' as const
+
+  constructor(readonly limit: number) {
+    super(
+      limit === 0
+        ? 'organization creation is disabled for non-admin accounts'
+        : `non-admin accounts may own at most ${limit} organizations`
+    )
+    this.name = 'OrgCreationLimitReached'
+  }
+}
+
 /** Selected visibility must never commit without a current organization member
  * in its explicit audience. */
 export class ResourceAudienceEmpty extends Error {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3908,7 +3908,7 @@ export interface OrgRepo {
     name: string | null
     slug: string
     ownerUserId: string
-    /** Optional deployment quota; checked atomically against owner memberships. */
+    /** Optional deployment quota; checked atomically against orgs created by this user. */
     maxOrgsPerUser?: number
   }): Promise<OrgRecord>
   /** Update org settings. Throws P2025 when absent, P2002 on a slug collision. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3904,7 +3904,13 @@ export interface OrgRepo {
    * membership no longer exists. */
   selectForUser(orgId: string, userId: string, selectedAt: Date): Promise<void>
   /** Create an org with `ownerUserId` as its first owner (one transaction). */
-  create(input: { name: string | null; slug: string; ownerUserId: string }): Promise<OrgRecord>
+  create(input: {
+    name: string | null
+    slug: string
+    ownerUserId: string
+    /** Optional deployment quota; checked atomically against owner memberships. */
+    maxOrgsPerUser?: number
+  }): Promise<OrgRecord>
   /** Update org settings. Throws P2025 when absent, P2002 on a slug collision. */
   update(
     orgId: string,

--- a/packages/control-plane/src/persistence/repositories/org.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org.repo.ts
@@ -80,11 +80,16 @@ export class PgOrgRepo implements OrgRepo {
     const org = await this.transaction(async (tx) => {
       if (input.maxOrgsPerUser !== undefined) {
         await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "app_user" WHERE "id" = ${input.ownerUserId} FOR UPDATE`)
-        const owned = await tx.membership.count({ where: { userId: input.ownerUserId, role: 'owner' } })
-        if (owned >= input.maxOrgsPerUser) throw new OrgCreationLimitReached(input.maxOrgsPerUser)
+        const created = await tx.org.count({ where: { createdByUserId: input.ownerUserId } })
+        if (created >= input.maxOrgsPerUser) throw new OrgCreationLimitReached(input.maxOrgsPerUser)
       }
       const created = await tx.org.create({
-        data: { name: input.name, slug: input.slug, icon: icon as Prisma.InputJsonValue }
+        data: {
+          name: input.name,
+          slug: input.slug,
+          icon: icon as Prisma.InputJsonValue,
+          createdByUserId: input.ownerUserId
+        }
       })
       await tx.membership.create({ data: { orgId: created.id, userId: input.ownerUserId, role: 'owner' } })
       if (this.presetAgents) {

--- a/packages/control-plane/src/persistence/repositories/org.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org.repo.ts
@@ -12,6 +12,7 @@ import { OrgId } from '../../domain/ids.js'
 import { PgHookRepo } from './hook.repo.js'
 import { parseAgentIcon, randomGlyphIcon } from '../../agents/agent-icon.js'
 import { provisionPresetAgents } from '../preset-agents.js'
+import { OrgCreationLimitReached } from '../errors.js'
 
 export class PgOrgRepo implements OrgRepo {
   constructor(
@@ -64,7 +65,12 @@ export class PgOrgRepo implements OrgRepo {
     })
   }
 
-  async create(input: { name: string | null; slug: string; ownerUserId: string }): Promise<OrgRecord> {
+  async create(input: {
+    name: string | null
+    slug: string
+    ownerUserId: string
+    maxOrgsPerUser?: number
+  }): Promise<OrgRecord> {
     // New orgs get a random glyph+color by default (mirrors agents), so the console
     // always has a real avatar to show before any upload.
     const icon = randomGlyphIcon()
@@ -72,6 +78,11 @@ export class PgOrgRepo implements OrgRepo {
     // seam, preset-agents.md §3.2) commit or roll back together — an org is never
     // observable without its preset row.
     const org = await this.transaction(async (tx) => {
+      if (input.maxOrgsPerUser !== undefined) {
+        await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "app_user" WHERE "id" = ${input.ownerUserId} FOR UPDATE`)
+        const owned = await tx.membership.count({ where: { userId: input.ownerUserId, role: 'owner' } })
+        if (owned >= input.maxOrgsPerUser) throw new OrgCreationLimitReached(input.maxOrgsPerUser)
+      }
       const created = await tx.org.create({
         data: { name: input.name, slug: input.slug, icon: icon as Prisma.InputJsonValue }
       })

--- a/packages/control-plane/src/persistence/repositories/user.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/user.repo.ts
@@ -315,7 +315,10 @@ export async function ensurePersonalOrg(
       // this statement waited on) — move to the next candidate with the transaction
       // still healthy. `count: 1` ⇒ the row is OURS, and `slug` is unique, so reading it
       // back by slug cannot pick up someone else's org.
-      const { count } = await tx.org.createMany({ data: [{ name, slug }], skipDuplicates: true })
+      const { count } = await tx.org.createMany({
+        data: [{ name, slug, createdByUserId: userId }],
+        skipDuplicates: true
+      })
       if (count === 0) continue
       const org = await tx.org.findUniqueOrThrow({ where: { slug }, select: { id: true } })
       await tx.membership.create({ data: { orgId: org.id, userId, role: 'owner' } })

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -338,6 +338,7 @@ export function buildHttpApp(
 
   const deps: HttpDeps = {
     runtimeConfig: {},
+    maxOrgsPerNonAdminUser: 1,
     clock,
     repos: {
       agent: agentRepo,

--- a/packages/control-plane/test/integration/orgs.route.test.ts
+++ b/packages/control-plane/test/integration/orgs.route.test.ts
@@ -3,8 +3,11 @@
  * the org-scoping seams the multi-tenant model hangs off: cross-org reads come
  * back empty/404 and the RBAC guards bite on write routes.
  */
-import { describe, it, expect } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
 import { randomUUID } from 'node:crypto'
+import { exportJWK, generateKeyPair, SignJWT } from 'jose'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { buildHttpApp } from '../fakes/build-http.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
@@ -13,6 +16,51 @@ import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 
 // Console routes are org-scoped: /orgs/:orgId/… (devAuth = seeded owner of the default org).
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const OIDC_AUDIENCE = 'org-quota-test'
+
+let oidcServer: Server
+let oidcIssuer = ''
+let mintBearer: (subject: string, claims?: Record<string, unknown>) => Promise<string>
+
+beforeAll(async () => {
+  const { privateKey, publicKey } = await generateKeyPair('RS256')
+  const jwk = { ...(await exportJWK(publicKey)), alg: 'RS256', kid: 'org-quota-test', use: 'sig' }
+  oidcServer = createServer((req, res) => {
+    res.setHeader('content-type', 'application/json')
+    if (req.url === '/.well-known/openid-configuration') {
+      res.end(JSON.stringify({ issuer: oidcIssuer, jwks_uri: `${oidcIssuer}/jwks` }))
+      return
+    }
+    if (req.url === '/jwks') {
+      res.end(JSON.stringify({ keys: [jwk] }))
+      return
+    }
+    res.statusCode = 404
+    res.end('{}')
+  })
+  await new Promise<void>((resolve, reject) => {
+    oidcServer.once('error', reject)
+    oidcServer.listen(0, '127.0.0.1', resolve)
+  })
+  const { port } = oidcServer.address() as AddressInfo
+  oidcIssuer = `http://127.0.0.1:${port}`
+  mintBearer = (subject, claims = {}) =>
+    new SignJWT(claims)
+      .setProtectedHeader({ alg: 'RS256', kid: 'org-quota-test' })
+      .setIssuer(oidcIssuer)
+      .setAudience(OIDC_AUDIENCE)
+      .setSubject(subject)
+      .setIssuedAt()
+      .setExpirationTime('10m')
+      .sign(privateKey)
+})
+
+afterAll(
+  () =>
+    new Promise<void>((resolve, reject) => {
+      oidcServer.close((err) => (err ? reject(err) : resolve()))
+    })
+)
 
 interface OrgBody {
   id: string
@@ -75,6 +123,39 @@ describe('GET /orgs', () => {
 })
 
 describe('POST /orgs', () => {
+  it('enforces the deployment quota for non-admins while ADMIN accounts bypass it', async () => {
+    const { app, close } = buildHttpApp(prisma, { OIDC_ISSUER: oidcIssuer, OIDC_AUDIENCE }, undefined, undefined, {
+      maxOrgsPerNonAdminUser: 0
+    })
+    try {
+      const denied = await app.inject({
+        method: 'POST',
+        url: '/api/v1/orgs',
+        headers: {
+          authorization: `Bearer ${await mintBearer('org-quota-user', { email: 'quota-route@example.com' })}`
+        },
+        payload: { slug: 'quota-route-denied' }
+      })
+      expect(denied.statusCode).toBe(403)
+      expect(denied.json()).toMatchObject({ code: 'ORG_CREATION_LIMIT_REACHED' })
+
+      const allowed = await app.inject({
+        method: 'POST',
+        url: '/api/v1/orgs',
+        headers: {
+          authorization: `Bearer ${await mintBearer('org-admin-user', {
+            email: 'admin-route@example.com',
+            roles: ['ADMIN']
+          })}`
+        },
+        payload: { slug: 'quota-route-admin' }
+      })
+      expect(allowed.statusCode).toBe(201)
+    } finally {
+      await close()
+    }
+  })
+
   it('creates an org owned by the caller; duplicate slug → 409', async () => {
     const { app, close } = buildHttpApp(prisma)
     try {

--- a/packages/control-plane/test/integration/waitlist.route.test.ts
+++ b/packages/control-plane/test/integration/waitlist.route.test.ts
@@ -241,7 +241,7 @@ describe('waitlist admission — GET /me/access', () => {
 })
 
 describe('waitlist admission — POST /waitlist/redeem', () => {
-  it('activates the matching user, creates their personal org, and unlocks org creation', async () => {
+  it('activates the matching user, creates their personal org, and enforces the org quota', async () => {
     const token = await approveAndMint('wl-redeem@acme.dev')
     const { app, close } = buildApp()
     try {
@@ -267,14 +267,15 @@ describe('waitlist admission — POST /waitlist/redeem', () => {
       expect(entry!.redeemedByUserId).toBe(user!.id)
       expect(entry!.redeemedAt).not.toBeNull()
 
-      // Now org creation is allowed.
+      // The automatically created personal org consumes the default quota of one.
       const create = await app.inject({
         method: 'POST',
         url: '/api/v1/orgs',
         headers: h,
         payload: { slug: 'wl-redeem-second' }
       })
-      expect(create.statusCode).toBe(201)
+      expect(create.statusCode).toBe(403)
+      expect(create.json()).toMatchObject({ code: 'ORG_CREATION_LIMIT_REACHED' })
 
       // Repeat redeem is idempotent.
       const again = await app.inject({ method: 'POST', url: '/api/v1/waitlist/redeem', headers: h, payload: { token } })

--- a/packages/control-plane/test/repo/user.repo.test.ts
+++ b/packages/control-plane/test/repo/user.repo.test.ts
@@ -295,4 +295,24 @@ describe('PgOrgRepo', () => {
     expect(def.role).toBe('collaborator')
     expect(def.memberCount).toBe(2) // seeded owner + this user
   })
+
+  it('enforces the non-admin organization quota inside the creation transaction', async () => {
+    const { userId } = await repo().provisionOidcUser({
+      oidcSubject: 'sub-org-quota',
+      email: 'quota@acme.com',
+      emailVerified: true
+    })
+    const orgs = new PgOrgRepo(prisma)
+
+    await expect(
+      orgs.create({ name: null, slug: 'quota-denied', ownerUserId: userId, maxOrgsPerUser: 1 })
+    ).rejects.toMatchObject({ code: 'ORG_CREATION_LIMIT_REACHED' })
+
+    await expect(
+      orgs.create({ name: null, slug: 'quota-allowed', ownerUserId: userId, maxOrgsPerUser: 2 })
+    ).resolves.toMatchObject({ slug: 'quota-allowed' })
+    await expect(
+      orgs.create({ name: null, slug: 'quota-denied-again', ownerUserId: userId, maxOrgsPerUser: 2 })
+    ).rejects.toMatchObject({ code: 'ORG_CREATION_LIMIT_REACHED' })
+  })
 })

--- a/packages/control-plane/test/repo/user.repo.test.ts
+++ b/packages/control-plane/test/repo/user.repo.test.ts
@@ -303,11 +303,15 @@ describe('PgOrgRepo', () => {
       emailVerified: true
     })
     const orgs = new PgOrgRepo(prisma)
+    const other = await prisma.user.create({ data: { email: 'quota-other@acme.com' } })
+    const invitedOrg = await orgs.create({ name: null, slug: 'quota-invited', ownerUserId: other.id })
+    await prisma.membership.create({ data: { orgId: invitedOrg.id, userId, role: 'owner' } })
 
     await expect(
       orgs.create({ name: null, slug: 'quota-denied', ownerUserId: userId, maxOrgsPerUser: 1 })
     ).rejects.toMatchObject({ code: 'ORG_CREATION_LIMIT_REACHED' })
 
+    // An owner membership granted by somebody else does not consume this user's creation quota.
     await expect(
       orgs.create({ name: null, slug: 'quota-allowed', ownerUserId: userId, maxOrgsPerUser: 2 })
     ).resolves.toMatchObject({ slug: 'quota-allowed' })

--- a/packages/setup/src/server/html.ts
+++ b/packages/setup/src/server/html.ts
@@ -355,7 +355,7 @@ export const SETUP_HTML = String.raw`<!doctype html>
       <h2>Deployment options</h2>
       <div class="panel">
         <label class="field"><span><input id="preset-agents-enabled" type="checkbox"> Enable preset Agents</span></label>
-        <label class="field">Max organizations per non-ADMIN user<input id="max-orgs-per-non-admin-user" type="number" min="0" step="1" value="1"></label>
+        <label class="field">Max organizations created per non-ADMIN user<input id="max-orgs-per-non-admin-user" type="number" min="0" step="1" value="1"></label>
         <div class="row"><button id="save-options">Save options</button></div>
       </div>
     </section>

--- a/packages/setup/src/server/html.ts
+++ b/packages/setup/src/server/html.ts
@@ -355,6 +355,7 @@ export const SETUP_HTML = String.raw`<!doctype html>
       <h2>Deployment options</h2>
       <div class="panel">
         <label class="field"><span><input id="preset-agents-enabled" type="checkbox"> Enable preset Agents</span></label>
+        <label class="field">Max organizations per non-ADMIN user<input id="max-orgs-per-non-admin-user" type="number" min="0" step="1" value="1"></label>
         <div class="row"><button id="save-options">Save options</button></div>
       </div>
     </section>
@@ -573,6 +574,7 @@ export const SETUP_HTML = String.raw`<!doctype html>
       );
 
       el('preset-agents-enabled').checked = values.features.presetAgentsEnabled;
+      el('max-orgs-per-non-admin-user').value = String(values.features.maxOrgsPerNonAdminUser);
 
       const github = values.github;
       const webhookStored = byKey.get('github.webhookSecret') && byKey.get('github.webhookSecret').configured;
@@ -1396,7 +1398,8 @@ export const SETUP_HTML = String.raw`<!doctype html>
       const values = {
         ...currentStatus.values,
         features: {
-          presetAgentsEnabled: el('preset-agents-enabled').checked
+          presetAgentsEnabled: el('preset-agents-enabled').checked,
+          maxOrgsPerNonAdminUser: Number(el('max-orgs-per-non-admin-user').value)
         }
       };
       const saved = await json(await fetch(api + '/deployment-config', {

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -20,7 +20,8 @@ vi.mock('@logto/browser', () => ({
   UserScope: {
     Email: 'email',
     Profile: 'profile',
-    Identities: 'identities'
+    Identities: 'identities',
+    Roles: 'roles'
   },
   isLogtoRequestError: (error: unknown) => error instanceof Error && error.name === 'LogtoRequestError'
 }))
@@ -99,6 +100,6 @@ describe('getToken', () => {
     await expect(getAccountToken()).resolves.toBe('opaque-account-token')
 
     expect(logto.getAccessToken).toHaveBeenCalledWith()
-    expect(logto.clientConfig).toMatchObject({ scopes: ['email', 'profile', 'identities'] })
+    expect(logto.clientConfig).toMatchObject({ scopes: ['email', 'profile', 'identities', 'roles'] })
   })
 })

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -77,7 +77,7 @@ function getClient(): LogtoClient | undefined {
       appId,
       // Request the profile claims so the CP can read email/name (from the token or
       // its /userinfo endpoint), plus identities for the user-facing Account API.
-      scopes: [UserScope.Email, UserScope.Profile, UserScope.Identities],
+      scopes: [UserScope.Email, UserScope.Profile, UserScope.Identities, UserScope.Roles],
       ...(apiResource ? { resources: [apiResource] } : {})
     })
   }


### PR DESCRIPTION
## Summary
- Persist `features.maxOrgsPerNonAdminUser` in the deployment PG document, defaulting to 1 and allowing 0.
- Persist each organization creator, attribute system-created personal organizations to their recipient, and backfill legacy organizations from their first membership.
- Count only organizations created by the non-ADMIN account; an owner membership granted by another creator does not consume the quota.
- Expose the setting in Setup Server, enforce it atomically, recognize verified `ADMIN` roles, keep ADMIN/no-auth bypasses, and return a structured 403 when the quota is reached.

## Tests
- Control Plane typecheck
- Control Plane unit tests (148 files, 1595 tests)
- Organization route integration tests (22 tests)
- Waitlist route integration tests (22 tests)
- Organization repository integration tests (14 tests)
- Repository and root formatting checks
- Web auth test and Web typecheck
- Pre-push lint could not start because the local ESLint toolchain could not load `eslint-import-resolver-typescript`.

Created by Codex . GPT-5