### PR TITLE
fix(control-plane): re-apply AgentConnectOrg specs on a timer so drift converges

### DIFF
--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -283,8 +283,9 @@ _where_ the CRs live.
   redeem is created in repository code that has no business knowing about
   Kubernetes. So `POST …/cluster-execution/ensure` (owner-only, idempotent) is
   the same operation as a request, and the console's Daemons page fires it once
-  per org per session. Between them, every org converges — including ones that
-  predate the feature — without a reconciler sweeping the whole table.
+  per org per session. Between them, every org gets a settings row — including
+  ones that predate the feature — without a reconciler deciding on anyone's
+  behalf which orgs should have an envelope at all.
   `ensureProvisioned` enables only an org with NO settings row: a row that reads
   disabled is an owner's decision, and re-applying would undo it. An org that is
   enabled gets its spec re-applied, which recreates a CR that went missing.
@@ -295,8 +296,28 @@ _where_ the CRs live.
   work owed by an otherwise successful pass.)
 - Every write bumps `specRevision`, and a write applies the CURRENT row and
   then re-reads that revision: two concurrent writers would otherwise be able to
-  leave the row at one spec and the CR at an older one forever, since the
-  operator reconciles the CR and nothing here re-reads on a timer.
+  leave the row at one spec and the CR at an older one until the next re-apply
+  pass, since the operator reconciles the CR, not the row.
+- **Writing the CR is level-triggered**, on the same maintenance loop as the
+  teardown drain: each pass re-applies a bounded, rotating slice of the enabled
+  envelopes. A settings write cannot be the only trigger, because part of the
+  spec is rendered from control-plane CONFIGURATION rather than from the org's
+  row — `spec.controlPlane.url` is the whole of it today. An edge-triggered
+  writer makes such a field true only for envelopes written after the
+  configuration changed; every older envelope keeps a CR that no edit to that
+  org will ever revisit, and the failure is silent by construction. A CR with no
+  `controlPlane.url` gives the operator nothing to inject, so the daemon pod
+  comes up with no `AC_CP_URL` and runs local — `Ready` on the CR, `1/1 Running`
+  on the pod, one log line as the only evidence. (Hence the daemon logs that
+  state at error when it was started with `--k8s`: in an envelope, local mode is
+  a fault, not a mode.) Each envelope goes through the same convergence loop a
+  request takes, so it applies the row as it reads NOW and a row switched off or
+  deleted since the slice was listed is reconciled to that instead. The listing
+  skips orgs under a live transition claim, and re-applying an unchanged spec is
+  a server-side-apply no-op: no `specRevision` bump, no new resource version.
+  `spec.daemon.image` is deliberately NOT swept back to the deployment default —
+  it is pinned per org at creation, and whether a fleet-wide upgrade should move
+  it is a separate product decision.
 - Enabling, disabling, and the teardown drain take a leased per-org **transition
   claim**, and it outlives the credential it was introduced for: those three
   still create and destroy one envelope from three directions. The claim is what

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2775,8 +2775,8 @@ model OrgClusterExecution {
   /// Bumped on every write. The provisioner applies the current row and then
   /// re-reads this: a changed value means a concurrent writer superseded the
   /// snapshot it just applied, so it applies again. Without the fence two
-  /// interleaved writes can leave the row and the resource permanently apart —
-  /// the operator reconciles the CR, not this table.
+  /// interleaved writes leave the row and the resource apart until the periodic
+  /// re-apply's next rotation — the operator reconciles the CR, not this table.
   specRevision         Int                 @default(1)
   resourceName         String              @unique
   /// Quiesce without tearing down: daemon to zero, sandboxes drained.

--- a/packages/control-plane/src/cluster/index.ts
+++ b/packages/control-plane/src/cluster/index.ts
@@ -10,4 +10,9 @@ export { AgentConnectOrgApi, type OrgResourceApi } from './org-api.js'
 export { ClusterDaemonIdentityService, clusterIdentityOf, parseServiceAccountSubject } from './daemon-identity.js'
 export { ClusterMaintenanceLoop, type ClusterMaintenanceWork } from './maintenance-loop.js'
 export { ClusterNamingError, orgResourceName, type ClusterEnvelopeStatus } from './spec.js'
-export { ClusterExecutionService, ClusterTransitionInProgressError, type ClusterExecutionPolicy } from './service.js'
+export {
+  ClusterExecutionService,
+  ClusterTransitionInProgressError,
+  type ClusterExecutionPolicy,
+  type EnvelopeResyncOutcome
+} from './service.js'

--- a/packages/control-plane/src/cluster/maintenance-loop.test.ts
+++ b/packages/control-plane/src/cluster/maintenance-loop.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The provisioner's periodic pass. Two pieces of work share one timer, and
+ * neither may cost the other: a drain that throws must not stop the re-apply,
+ * and an envelope the re-apply cannot write must be named rather than counted.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { ClusterMaintenanceLoop, type ClusterMaintenanceLog, type ClusterMaintenanceWork } from './maintenance-loop.js'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+
+const INTERVAL_MS = 5 * 60 * 1000
+
+function fakeLog(): ClusterMaintenanceLog & {
+  info: ReturnType<typeof vi.fn>
+  warn: ReturnType<typeof vi.fn>
+  error: ReturnType<typeof vi.fn>
+} {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}
+
+function work(overrides: Partial<ClusterMaintenanceWork> = {}): ClusterMaintenanceWork {
+  return {
+    drainTeardowns: async () => 0,
+    resyncEnvelopes: async () => ({ converged: 0, failures: [] }),
+    ...overrides
+  }
+}
+
+describe('ClusterMaintenanceLoop', () => {
+  it('drains teardowns and re-applies envelopes in the same pass', async () => {
+    const drainTeardowns = vi.fn(async () => 1)
+    const resyncEnvelopes = vi.fn(async () => ({ converged: 3, failures: [] }))
+    const loop = new ClusterMaintenanceLoop(work({ drainTeardowns, resyncEnvelopes }), new FakeClock(), INTERVAL_MS)
+
+    await loop.tick()
+
+    expect(drainTeardowns).toHaveBeenCalledOnce()
+    expect(resyncEnvelopes).toHaveBeenCalledOnce()
+    loop.stop()
+  })
+
+  it('says nothing when every envelope converged — the steady state is silence', async () => {
+    const log = fakeLog()
+    const loop = new ClusterMaintenanceLoop(
+      work({ resyncEnvelopes: async () => ({ converged: 12, failures: [] }) }),
+      new FakeClock(),
+      INTERVAL_MS,
+      log
+    )
+
+    await loop.tick()
+
+    expect(log.error).not.toHaveBeenCalled()
+    expect(log.warn).not.toHaveBeenCalled()
+    loop.stop()
+  })
+
+  it('reports each envelope it could not apply, at error', async () => {
+    const log = fakeLog()
+    const loop = new ClusterMaintenanceLoop(
+      work({
+        resyncEnvelopes: async () => ({
+          converged: 1,
+          failures: [
+            { orgId: 'org-a', error: new Error('cluster unreachable') },
+            { orgId: 'org-b', error: new Error('cluster unreachable') }
+          ]
+        })
+      }),
+      new FakeClock(),
+      INTERVAL_MS,
+      log
+    )
+
+    await loop.tick()
+
+    // Per envelope and not per pass: an operator has to know WHICH one is stuck,
+    // and it stays stuck — on whatever spec it has — until someone acts.
+    expect(log.error).toHaveBeenCalledTimes(2)
+    expect(log.error.mock.calls.map((call) => (call[0] as { orgId: string }).orgId)).toEqual(['org-a', 'org-b'])
+    loop.stop()
+  })
+
+  it('keeps the re-apply running when the teardown drain throws', async () => {
+    const log = fakeLog()
+    const resyncEnvelopes = vi.fn(async () => ({ converged: 1, failures: [] }))
+    const loop = new ClusterMaintenanceLoop(
+      work({
+        drainTeardowns: async () => {
+          throw new Error('db down')
+        },
+        resyncEnvelopes
+      }),
+      new FakeClock(),
+      INTERVAL_MS,
+      log
+    )
+
+    await expect(loop.tick()).resolves.toBeUndefined()
+
+    expect(resyncEnvelopes).toHaveBeenCalledOnce()
+    expect(log.warn).toHaveBeenCalledOnce()
+    loop.stop()
+  })
+
+  it('swallows a re-apply pass that fails outright and keeps the loop alive', async () => {
+    const log = fakeLog()
+    const clock = new FakeClock()
+    const resyncEnvelopes = vi.fn(async () => {
+      throw new Error('db down')
+    })
+    const loop = new ClusterMaintenanceLoop(work({ resyncEnvelopes }), clock, INTERVAL_MS, log)
+
+    await expect(loop.tick()).resolves.toBeUndefined()
+    // One line, not one per envelope: nothing was selected, so nothing is named.
+    expect(log.warn).toHaveBeenCalledOnce()
+    expect(log.error).not.toHaveBeenCalled()
+
+    // Re-armed by the failed pass, so drift still converges on the next one.
+    clock.advance(INTERVAL_MS)
+    await new Promise((resolve) => setImmediate(resolve)) // let the async tick settle
+    expect(resyncEnvelopes).toHaveBeenCalledTimes(2)
+    loop.stop()
+  })
+
+  it('does nothing at all when cluster execution is off', async () => {
+    const loop = new ClusterMaintenanceLoop(undefined, new FakeClock(), INTERVAL_MS)
+    loop.start()
+    await expect(loop.tick()).resolves.toBeUndefined()
+    loop.stop()
+  })
+})

--- a/packages/control-plane/src/cluster/maintenance-loop.test.ts
+++ b/packages/control-plane/src/cluster/maintenance-loop.test.ts
@@ -77,6 +77,9 @@ describe('ClusterMaintenanceLoop', () => {
     // and it stays stuck — on whatever spec it has — until someone acts.
     expect(log.error).toHaveBeenCalledTimes(2)
     expect(log.error.mock.calls.map((call) => (call[0] as { orgId: string }).orgId)).toEqual(['org-a', 'org-b'])
+    // With the pass totals, so "one bad envelope" and "the API server is down"
+    // do not read identically.
+    expect(log.error.mock.calls[0]?.[0]).toMatchObject({ converged: 1, failed: 2 })
     loop.stop()
   })
 

--- a/packages/control-plane/src/cluster/maintenance-loop.ts
+++ b/packages/control-plane/src/cluster/maintenance-loop.ts
@@ -92,9 +92,14 @@ export class ClusterMaintenanceLoop {
    */
   private async resync(): Promise<void> {
     try {
-      const { failures } = await this.work!.resyncEnvelopes()
+      const { converged, failures } = await this.work!.resyncEnvelopes()
       for (const failure of failures) {
-        this.log?.error({ orgId: failure.orgId, err: failure.error }, 'cluster-execution: envelope re-apply failed')
+        // The pass totals ride along, so one bad envelope reads differently from
+        // an API server that is refusing everything.
+        this.log?.error(
+          { orgId: failure.orgId, converged, failed: failures.length, err: failure.error },
+          'cluster-execution: envelope re-apply failed'
+        )
       }
     } catch (err) {
       // The listing itself failed, so no envelope was even selected: one line.

--- a/packages/control-plane/src/cluster/maintenance-loop.ts
+++ b/packages/control-plane/src/cluster/maintenance-loop.ts
@@ -1,22 +1,30 @@
 /**
- * The periodic half of the provisioner's cleanup — the backstop for the one
- * thing it can owe the world after a request has already returned.
+ * The periodic half of the provisioner — the backstop for what it can owe the
+ * world after a request has already returned.
  *
  * Deleting an organization records its `AgentConnectOrg` for removal inside the
  * delete transaction, and the delete route retires it immediately; this loop
  * covers what inline cannot — an unreachable cluster, a process that crashed
  * between the record and the act, or a deployment that had cluster execution
  * switched off when the organization was deleted and turned it on later.
+ *
+ * It also re-applies the enabled envelopes, because part of the spec comes from
+ * control-plane configuration and not from the org's row: an envelope written
+ * before that configuration changed is owed a write that no settings edit will
+ * ever make. Same reason as above — work owed after every request has returned.
  */
 import type { Clock, TimerHandle } from '../domain/clock.js'
+import type { EnvelopeResyncOutcome } from './service.js'
 
 export interface ClusterMaintenanceLog {
   info(obj: Record<string, unknown>, msg: string): void
   warn(obj: Record<string, unknown>, msg: string): void
+  error(obj: Record<string, unknown>, msg: string): void
 }
 
 export interface ClusterMaintenanceWork {
   drainTeardowns(): Promise<number>
+  resyncEnvelopes(): Promise<EnvelopeResyncOutcome>
 }
 
 export class ClusterMaintenanceLoop {
@@ -54,8 +62,9 @@ export class ClusterMaintenanceLoop {
   }
 
   /**
-   * One pass over the queue. Errors are logged and swallowed, and every record
-   * survives for the next pass. Exposed for tests.
+   * One pass: retire what deletion left owed, then re-apply a slice of the live
+   * envelopes. Errors are logged and swallowed, and everything either pass could
+   * not finish survives for the next one. Exposed for tests.
    */
   async tick(): Promise<void> {
     this.timer = undefined
@@ -66,8 +75,30 @@ export class ClusterMaintenanceLoop {
         'cluster-execution: retired deleted organizations’ envelopes',
         'cluster-execution: envelope teardown drain failed'
       )
+      await this.resync()
     } finally {
       this.arm()
+    }
+  }
+
+  /**
+   * Re-apply pass. A converged envelope logs nothing — the steady state is every
+   * pass doing nothing visible, and saying so 288 times a day would bury the case
+   * that matters. Each envelope it could NOT apply is reported on its own, at
+   * error: it is stuck on whatever spec it already has, it will stay stuck until
+   * someone acts, and repeating that every pass is the only signal an operator
+   * gets. The stale spec this loop exists to fix went unnoticed precisely because
+   * the one line describing it was informational.
+   */
+  private async resync(): Promise<void> {
+    try {
+      const { failures } = await this.work!.resyncEnvelopes()
+      for (const failure of failures) {
+        this.log?.error({ orgId: failure.orgId, err: failure.error }, 'cluster-execution: envelope re-apply failed')
+      }
+    } catch (err) {
+      // The listing itself failed, so no envelope was even selected: one line.
+      this.log?.warn({ err }, 'cluster-execution: envelope re-apply pass failed')
     }
   }
 

--- a/packages/control-plane/src/cluster/service.test.ts
+++ b/packages/control-plane/src/cluster/service.test.ts
@@ -1,9 +1,10 @@
 /**
  * The provisioner's convergence fence. The operator reconciles the CR, not the
- * settings row, and nothing here re-reads on a timer — so a write that applies
- * an older spec after a newer one would leave the two permanently apart. These
- * tests drive exactly that interleaving, plus the transition claim that keeps
- * enable, disable and the teardown drain from undoing each other.
+ * settings row, so a write that applies an older spec after a newer one leaves
+ * the two apart until something re-applies. These tests drive exactly that
+ * interleaving, the transition claim that keeps enable, disable and the teardown
+ * drain from undoing each other, and the periodic pass that is the only thing
+ * covering a spec field the org's row does not own.
  */
 import { describe, expect, it } from 'vitest'
 import { ClusterExecutionService, ClusterTransitionInProgressError, type ClusterExecutionPolicy } from './service.js'
@@ -29,25 +30,46 @@ const POLICY: ClusterExecutionPolicy = {
   controlPlaneUrl: 'wss://api.example.test/daemon/ws'
 }
 
-/** In-memory settings row with the repo's revision-bump-on-every-write contract. */
+/** In-memory settings rows with the repo's revision-bump-on-every-write contract. */
 class FakeRepo implements OrgClusterExecutionRepo {
-  row: ClusterExecutionSettings | null = null
+  rows = new Map<string, ClusterExecutionSettings>()
+  claims = new Map<string, { at: Date; token: string }>()
   tombstones: PendingEnvelopeTeardown[] = []
-  transitionAt: Date | null = null
-  transitionToken: string | null = null
   /** Simulates a write whose row is cascaded away before anything reads it. */
   swallowUpsert = false
 
-  async get(): Promise<ClusterExecutionSettings | null> {
-    return this.row ? { ...this.row } : null
+  /** The single-org view most tests drive; the rotation ones use `rows` directly. */
+  get row(): ClusterExecutionSettings | null {
+    return this.rows.get(ORG) ?? null
+  }
+
+  set row(next: ClusterExecutionSettings | null) {
+    if (next) this.rows.set(ORG, next)
+    else this.rows.delete(ORG)
+  }
+
+  async get(orgId: OrgId = ORG): Promise<ClusterExecutionSettings | null> {
+    const row = this.rows.get(orgId)
+    return row ? { ...row } : null
   }
 
   async getByResourceName(resourceName: string): Promise<ClusterExecutionSettings | null> {
-    return this.row?.resourceName === resourceName ? { ...this.row } : null
+    const row = [...this.rows.values()].find((entry) => entry.resourceName === resourceName)
+    return row ? { ...row } : null
   }
 
   async listPendingTeardowns(limit: number): Promise<PendingEnvelopeTeardown[]> {
     return this.tombstones.slice(0, limit)
+  }
+
+  /** Enabled, unclaimed, keyed forward from `afterOrgId` — the pass's selection. */
+  async listResyncableOrgIds(afterOrgId: string | null, limit: number, now: Date, leaseMs: number): Promise<string[]> {
+    return [...this.rows.values()]
+      .filter((row) => row.enabled && !this.claimHeld(row.orgId, now, leaseMs))
+      .map((row) => row.orgId)
+      .filter((orgId) => afterOrgId === null || orgId > afterOrgId)
+      .sort()
+      .slice(0, limit)
   }
 
   async clearPendingTeardown(orgId: string): Promise<void> {
@@ -55,36 +77,34 @@ class FakeRepo implements OrgClusterExecutionRepo {
   }
 
   async beginTransition(
-    _orgId: OrgId,
+    orgId: OrgId,
     token: string,
     now: Date,
     leaseMs: number
   ): Promise<ClusterExecutionSettings | null> {
-    if (!this.row) return null
-    const held = this.transitionAt
-    if (held && this.transitionToken && held.getTime() > now.getTime() - leaseMs) return null
-    this.transitionAt = now
-    this.transitionToken = token
-    return { ...this.row }
+    const row = this.rows.get(orgId)
+    if (!row) return null
+    if (this.claimHeld(orgId, now, leaseMs)) return null
+    this.claims.set(orgId, { at: now, token })
+    return { ...row }
   }
 
-  async endTransition(_orgId: OrgId, token: string): Promise<void> {
-    if (this.transitionToken !== token) return
-    this.transitionAt = null
-    this.transitionToken = null
+  async endTransition(orgId: OrgId, token: string): Promise<void> {
+    if (this.claims.get(orgId)?.token === token) this.claims.delete(orgId)
   }
 
-  async disableAndRecordTeardown(_orgId: OrgId, token: string): Promise<boolean> {
-    if (this.transitionToken !== token || !this.row) return false
-    this.tombstones.push({ orgId: this.row.orgId, resourceName: this.row.resourceName })
-    this.row = { ...this.row, enabled: false, specRevision: this.row.specRevision + 1 }
+  async disableAndRecordTeardown(orgId: OrgId, token: string): Promise<boolean> {
+    const row = this.rows.get(orgId)
+    if (this.claims.get(orgId)?.token !== token || !row) return false
+    this.tombstones.push({ orgId: row.orgId, resourceName: row.resourceName })
+    this.rows.set(orgId, { ...row, enabled: false, specRevision: row.specRevision + 1 })
     return true
   }
 
   /** Insert-only, like the repo's `ON CONFLICT DO NOTHING`. */
   async createIfAbsent(orgId: OrgId, defaults: ClusterExecutionDefaults): Promise<void> {
-    if (this.row || this.swallowUpsert) return
-    this.row = {
+    if (this.rows.has(orgId) || this.swallowUpsert) return
+    this.rows.set(orgId, {
       orgId,
       enabled: false,
       specRevision: 1,
@@ -92,7 +112,7 @@ class FakeRepo implements OrgClusterExecutionRepo {
       ...defaults,
       createdAt: new Date(0),
       updatedAt: new Date(0)
-    }
+    })
   }
 
   async upsert(
@@ -100,7 +120,7 @@ class FakeRepo implements OrgClusterExecutionRepo {
     defaults: ClusterExecutionDefaults,
     patch: ClusterExecutionPatch
   ): Promise<ClusterExecutionSettings> {
-    const base: ClusterExecutionSettings = this.row ?? {
+    const base: ClusterExecutionSettings = this.rows.get(orgId) ?? {
       orgId,
       enabled: false,
       specRevision: 0,
@@ -116,26 +136,36 @@ class FakeRepo implements OrgClusterExecutionRepo {
       ...(patch.suspend !== undefined ? { suspend: patch.suspend } : {}),
       ...(patch.daemonImage !== undefined ? { daemonImage: patch.daemonImage } : {})
     }
-    if (!this.swallowUpsert) this.row = next
+    if (!this.swallowUpsert) this.rows.set(orgId, next)
     return next
+  }
+
+  private claimHeld(orgId: string, now: Date, leaseMs: number): boolean {
+    const claim = this.claims.get(orgId)
+    return !!claim && claim.at.getTime() > now.getTime() - leaseMs
   }
 }
 
 class FakeApi implements OrgResourceApi {
   readonly namespace = 'agentconnect-control'
   applied: AgentConnectOrgSpec[] = []
+  /** The names behind `applied`, in lockstep — which envelope a multi-org pass touched. */
+  appliedNames: string[] = []
   deleted: string[] = []
   /** Runs inside `apply`, so a test can land a peer write mid-flight. */
   duringApply?: () => Promise<void>
 
   failApply = false
+  /** Per-envelope failure, for a pass that must survive one bad org. */
+  failApplyFor = new Set<string>()
 
-  async apply(_name: string, spec: AgentConnectOrgSpec): Promise<AgentConnectOrg> {
+  async apply(name: string, spec: AgentConnectOrgSpec): Promise<AgentConnectOrg> {
     const hook = this.duringApply
     this.duringApply = undefined
     if (hook) await hook()
-    if (this.failApply) throw new Error('cluster unreachable')
+    if (this.failApply || this.failApplyFor.has(name)) throw new Error('cluster unreachable')
     this.applied.push(spec)
+    this.appliedNames.push(name)
     return { spec }
   }
 
@@ -175,14 +205,18 @@ interface Harness {
   repo: FakeRepo
   api: FakeApi
   daemons: FakeDaemons
+  /** Held by reference, so mutating it models a control-plane configuration
+   *  change — the kind of spec edit no organization's row can see coming. */
+  policy: ClusterExecutionPolicy
 }
 
 function build(): Harness {
   const repo = new FakeRepo()
   const api = new FakeApi()
   const daemons = new FakeDaemons()
-  const service = new ClusterExecutionService(repo, api, { slugById: async () => 'acme' }, POLICY, daemons, systemClock)
-  return { service, repo, api, daemons }
+  const policy: ClusterExecutionPolicy = { ...POLICY }
+  const service = new ClusterExecutionService(repo, api, { slugById: async () => 'acme' }, policy, daemons, systemClock)
+  return { service, repo, api, daemons, policy }
 }
 
 describe('ClusterExecutionService.configure', () => {
@@ -360,6 +394,105 @@ describe('ClusterExecutionService.drainTeardowns', () => {
     expect(await service.drainTeardowns()).toBe(0)
     await repo.endTransition(ORG, 'peer-token')
     expect(await service.drainTeardowns()).toBe(1)
+    expect(api.deleted).toEqual(['acme'])
+  })
+})
+
+/**
+ * The periodic re-apply. Part of the spec is rendered from control-plane
+ * configuration rather than from the org's row, so an edge-triggered writer can
+ * only ever make it true for envelopes created after the configuration changed;
+ * every older one keeps a CR nobody will rewrite. These cover the drift itself,
+ * the fences the pass must not run over, and its bound.
+ */
+describe('ClusterExecutionService.resyncEnvelopes', () => {
+  it('converges an envelope whose CR predates a control-plane configuration change', async () => {
+    const { service, repo, api, policy } = build()
+    await service.ensureProvisioned(ORG)
+    expect(api.applied[0]?.controlPlane.url).toBe(POLICY.controlPlaneUrl)
+    const revision = repo.row?.specRevision
+    api.applied.length = 0
+
+    // The deployment now addresses its daemons differently. Nothing about the
+    // org's row changed, so no settings write will ever revisit its CR.
+    policy.controlPlaneUrl = 'wss://cp.example.test/daemon/ws'
+    const outcome = await service.resyncEnvelopes()
+
+    expect(outcome).toMatchObject({ converged: 1, failures: [] })
+    expect(api.applied.map((spec) => spec.controlPlane.url)).toEqual(['wss://cp.example.test/daemon/ws'])
+    // Applying is not a write: the row — and the fence built on it — must not move.
+    expect(repo.row?.specRevision).toBe(revision)
+  })
+
+  it('leaves an org whose owner switched cluster execution off alone', async () => {
+    const { service, api } = build()
+    await service.ensureProvisioned(ORG)
+    await service.configure(ORG, { enabled: false })
+    api.applied.length = 0
+    api.deleted.length = 0
+
+    expect(await service.resyncEnvelopes()).toMatchObject({ converged: 0, failures: [] })
+    expect(api.applied).toEqual([])
+    expect(api.deleted).toEqual([])
+  })
+
+  it('skips an org whose transition someone else owns, and takes it next pass', async () => {
+    const { service, repo, api } = build()
+    await service.ensureProvisioned(ORG)
+    api.appliedNames.length = 0
+    // Enable, disable and the drain create and destroy the envelope; a re-apply
+    // must not act on one while its owner is mid-transition.
+    await repo.beginTransition(ORG, 'peer-token', new Date(), 60_000)
+
+    expect(await service.resyncEnvelopes()).toMatchObject({ converged: 0 })
+    expect(api.appliedNames).toEqual([])
+
+    await repo.endTransition(ORG, 'peer-token')
+    expect(await service.resyncEnvelopes()).toMatchObject({ converged: 1 })
+    expect(api.appliedNames).toEqual(['acme'])
+  })
+
+  it('rotates across passes, so a fleet larger than one slice still converges', async () => {
+    const { service, api } = build()
+    for (const id of ['org-a', 'org-b', 'org-c']) await service.ensureProvisioned(OrgId(id))
+    api.appliedNames.length = 0
+
+    await service.resyncEnvelopes(2)
+    expect(api.appliedNames).toEqual(['org-a', 'org-b'])
+    // The next pass takes the tail rather than sweeping the head again.
+    await service.resyncEnvelopes(2)
+    expect(api.appliedNames).toEqual(['org-a', 'org-b', 'org-c'])
+    // A short slice IS the tail, so the pass after it starts over from the top.
+    await service.resyncEnvelopes(2)
+    expect(api.appliedNames).toEqual(['org-a', 'org-b', 'org-c', 'org-a', 'org-b'])
+  })
+
+  it('keeps going when one envelope cannot be applied, and reports which', async () => {
+    const { service, api } = build()
+    for (const id of ['org-a', 'org-b']) await service.ensureProvisioned(OrgId(id))
+    api.appliedNames.length = 0
+    api.failApplyFor.add('org-a')
+
+    const outcome = await service.resyncEnvelopes()
+
+    // Swallowed per envelope like the drain — but named, because an envelope
+    // stuck on a stale spec is exactly what silence already cost once.
+    expect(outcome.converged).toBe(1)
+    expect(outcome.failures.map((failure) => failure.orgId)).toEqual(['org-a'])
+    expect(api.appliedNames).toEqual(['org-b'])
+  })
+
+  it('removes the resource it re-created when the org was deleted under the pass', async () => {
+    const { service, repo, api } = build()
+    await service.ensureProvisioned(ORG)
+    api.applied.length = 0
+    api.deleted.length = 0
+    // The same window `configure` has, reached from the sweep instead.
+    api.duringApply = async () => {
+      repo.row = null
+    }
+
+    await service.resyncEnvelopes()
     expect(api.deleted).toEqual(['acme'])
   })
 })

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -10,9 +10,11 @@
  * daemon authenticates with the token the kubelet projects into its pod, so
  * there is no key to mint, publish, roll out or revoke here.
  *
- * Nothing here re-applies the spec on a timer: the operator is level-triggered
- * and re-reads the CR on its own resync, so the control plane only has to make
- * the spec true at the moment it changes. The periodic work it does own is
+ * Writing the CR is level-triggered too, for the reason the operator's own
+ * reconcile is: part of the spec is rendered from control-plane CONFIGURATION
+ * rather than from the org's row, and an edge-triggered writer can only make
+ * that true for envelopes written after the configuration changed. See
+ * {@link ClusterExecutionService.resyncEnvelopes}. The other periodic work is
  * cleanup it may still owe after a request returned — see the drain below.
  */
 import { randomUUID } from 'node:crypto'
@@ -36,6 +38,10 @@ const CONVERGE_ATTEMPTS = 5
 /** Tombstones retired per drain pass; a backlog is rare and drains over passes. */
 const TEARDOWN_BATCH = 50
 
+/** Envelopes re-applied per pass. A slice rather than the fleet, so one pass costs a
+ *  bounded number of requests; the rotation below is what still covers everyone. */
+const RESYNC_BATCH = 100
+
 /** How long one caller may own an envelope transition before it is taken over.
  *  Generous against a slow API server, short enough that a crashed process does
  *  not lock an operator out of switching the envelope on or off for long. */
@@ -54,6 +60,14 @@ export interface ClusterExecutionPolicy {
   controlPlaneUrl: string
 }
 
+/** What one re-apply pass did. Failures are returned rather than swallowed: an
+ *  envelope that cannot be applied is stuck, and nothing else would ever say so. */
+export interface EnvelopeResyncOutcome {
+  /** Envelopes re-applied without error — mostly no-ops, which is the point. */
+  converged: number
+  failures: { orgId: string; error: unknown }[]
+}
+
 /** Raised when another caller already owns the org's envelope transition. */
 export class ClusterTransitionInProgressError extends Error {
   constructor() {
@@ -63,6 +77,11 @@ export class ClusterTransitionInProgressError extends Error {
 }
 
 export class ClusterExecutionService {
+  /** Where the last re-apply pass stopped; null ⇒ start from the top of the fleet.
+   *  Per process, deliberately: two replicas sweeping from different offsets both
+   *  converge, and a restart that starts over costs no-ops, not correctness. */
+  private resyncCursor: string | null = null
+
   constructor(
     private readonly repo: OrgClusterExecutionRepo,
     private readonly api: OrgResourceApi,
@@ -199,13 +218,15 @@ export class ClusterExecutionService {
   /**
    * Apply the current row, then confirm it is still current — the fence against
    * two concurrent writers reverting each other. Without it, A-upsert →
-   * B-upsert → B-apply → A-apply leaves the row at B and the resource
-   * permanently at A: the operator reconciles the CR, not the row, and nothing
-   * here re-reads on a timer, so that divergence would never heal.
+   * B-upsert → B-apply → A-apply leaves the row at B and the resource at A: the
+   * operator reconciles the CR, not the row, so only the re-apply pass would
+   * heal that, and only on its next rotation.
    *
    * Every writer runs this loop, so a request that gives up at the attempt
    * ceiling is one whose value was superseded — and the writer that superseded
-   * it is itself converging on the newer row.
+   * it is itself converging on the newer row. It is also what makes the periodic
+   * pass safe on a stale selection: a row switched off or deleted since is read
+   * here, and reconciled to, before anything is applied.
    */
   private async converge(orgId: OrgId): Promise<ClusterExecutionSettings> {
     let current = await this.repo.get(orgId)
@@ -235,6 +256,51 @@ export class ClusterExecutionService {
     // enough and costs one indexed read instead of a whole org projection.
     const slug = await this.orgs.slugById(settings.orgId)
     await this.api.apply(name, buildSpec(settings, this.policy.controlPlaneUrl, slug ?? undefined))
+  }
+
+  /**
+   * Re-apply a bounded slice of the enabled envelopes, so a CR converges on a
+   * change the org's own row never saw. `spec.controlPlane.url` is the case that
+   * forced this: it is rendered from control-plane CONFIGURATION, so a deployment
+   * that changes it — or a build that learns to write a field at all — leaves
+   * every existing envelope on a spec no settings write would ever revisit, and
+   * an operator with nothing to inject reports the stale CR `Ready`.
+   *
+   * Each org goes through {@link ClusterExecutionService.converge}, which applies
+   * the CURRENT row under the same revision fence every request path uses — so a
+   * row disabled or deleted since the listing is reconciled to what it says now,
+   * not to the snapshot this pass selected. The listing skips orgs under a live
+   * transition claim for the same reason enable, disable and the drain take one:
+   * a re-apply must not act on an envelope someone is creating or destroying.
+   *
+   * Bounded and rotating: one slice per pass, keyed forward from where the last
+   * stopped, so a fleet of any size converges over consecutive passes without one
+   * pass holding the API server. Re-applying an unchanged spec is a server-side
+   * apply no-op — nothing writes the row, so `specRevision` does not move, and the
+   * API server stores no new resource version — which is what makes running this
+   * against everyone, forever, cost a request rather than a change.
+   */
+  async resyncEnvelopes(limit = RESYNC_BATCH): Promise<EnvelopeResyncOutcome> {
+    const orgIds = await this.repo.listResyncableOrgIds(
+      this.resyncCursor,
+      limit,
+      new Date(this.clock.now()),
+      TRANSITION_LEASE_MS
+    )
+    // A short slice is the fleet's tail; the next pass starts from the top again.
+    this.resyncCursor = orgIds.length === limit ? (orgIds.at(-1) ?? null) : null
+    const outcome: EnvelopeResyncOutcome = { converged: 0, failures: [] }
+    for (const orgId of orgIds) {
+      try {
+        await this.converge(OrgId(orgId))
+        outcome.converged += 1
+      } catch (error) {
+        // Best-effort per envelope, like the drain: one unreachable org must not
+        // cost the rest of the pass, and the next pass retries it.
+        outcome.failures.push({ orgId, error })
+      }
+    }
+    return outcome
   }
 
   /**

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1059,7 +1059,9 @@ export function buildContainer(
   // durably before the act, so this loop is the backstop for a cluster that was
   // unreachable, a process that died between the two, or a deployment that had
   // cluster execution switched off at the time; the delete route kicks the same
-  // work inline for latency. Inert when off.
+  // work inline for latency. It also re-applies a slice of the live envelopes
+  // each pass, so a spec field rendered from THIS process's configuration
+  // converges on envelopes written before that configuration. Inert when off.
   const clusterMaintenance = new ClusterMaintenanceLoop(
     clusterExecution,
     clock,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5008,6 +5008,14 @@ export interface OrgClusterExecutionRepo {
   getByResourceName(resourceName: string): Promise<ClusterExecutionSettings | null>
   /** Oldest-first batch of envelopes whose organization is already gone. */
   listPendingTeardowns(limit: number): Promise<PendingEnvelopeTeardown[]>
+  /**
+   * One bounded slice of the periodic re-apply's rotation: enabled orgs with no
+   * live transition claim, ordered by `orgId` and keyed forward from
+   * `afterOrgId` (null ⇒ from the start). The claim filter is
+   * {@link OrgClusterExecutionRepo.beginTransition}'s own takeover predicate, so
+   * an expired claim is swept rather than excluded until someone notices.
+   */
+  listResyncableOrgIds(afterOrgId: string | null, limit: number, now: Date, leaseMs: number): Promise<string[]>
   /** Drop a tombstone once its resource is confirmed gone. Idempotent. */
   clearPendingTeardown(orgId: string): Promise<void>
   /**

--- a/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
@@ -76,6 +76,26 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
     })
   }
 
+  /** The claim predicate is `beginTransition`'s, negated: an org someone owns
+   *  right now is left to them, and an expired claim is swept like any other. */
+  async listResyncableOrgIds(afterOrgId: string | null, limit: number, now: Date, leaseMs: number): Promise<string[]> {
+    const rows = await this.prisma.orgClusterExecution.findMany({
+      where: {
+        enabled: true,
+        ...(afterOrgId === null ? {} : { orgId: { gt: afterOrgId } }),
+        OR: [
+          { envelopeTransitionToken: null },
+          { envelopeTransitionAt: null },
+          { envelopeTransitionAt: { lt: new Date(now.getTime() - leaseMs) } }
+        ]
+      },
+      select: { orgId: true },
+      orderBy: { orgId: 'asc' },
+      take: limit
+    })
+    return rows.map((row) => row.orgId)
+  }
+
   async clearPendingTeardown(orgId: string): Promise<void> {
     await this.prisma.pendingEnvelopeTeardown.deleteMany({ where: { orgId } })
   }

--- a/packages/control-plane/test/repo/org-cluster-execution.repo.test.ts
+++ b/packages/control-plane/test/repo/org-cluster-execution.repo.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The selection behind the provisioner's periodic re-apply. It needs real
+ * Postgres because all three properties ARE the query: only enabled envelopes,
+ * never one whose transition someone currently owns, and a keyset page that
+ * rotates through a fleet larger than one pass.
+ */
+import { describe, it, expect } from 'vitest'
+import { prisma } from '../setup.db.js'
+import { PgOrgClusterExecutionRepo } from '../../src/persistence/repositories/org-cluster-execution.repo.js'
+import { OrgId } from '../../src/domain/ids.js'
+import type { ClusterExecutionDefaults } from '../../src/persistence/ports.js'
+
+const NOW = new Date('2026-01-01T00:00:00.000Z')
+const LEASE_MS = 2 * 60 * 1000
+
+function defaults(name: string): ClusterExecutionDefaults {
+  return {
+    resourceName: name,
+    daemonImage: 'registry.example.test/daemon:1',
+    daemonTier: 'small',
+    runtimeImage: 'registry.example.test/runtime:1',
+    runtimeTiers: [{ name: 'small', warmReplicas: 0 }],
+    quota: { maxAgents: 0, cpu: '0', memory: '0', storage: '0' },
+    egressPolicy: 'curated'
+  }
+}
+
+/** An org with an envelope row, id fixed so the keyset order is the test's to state. */
+async function seedEnvelope(repo: PgOrgClusterExecutionRepo, id: string, enabled: boolean): Promise<OrgId> {
+  await prisma.org.create({ data: { id, slug: id } })
+  const orgId = OrgId(id)
+  await repo.createIfAbsent(orgId, defaults(id))
+  if (enabled) await repo.upsert(orgId, defaults(id), { enabled: true })
+  return orgId
+}
+
+describe('OrgClusterExecutionRepo.listResyncableOrgIds', () => {
+  it('names the enabled envelopes and nothing else', async () => {
+    const repo = new PgOrgClusterExecutionRepo(prisma)
+    await seedEnvelope(repo, 'env-a', true)
+    // A row that reads disabled is an owner's decision; re-applying would undo it.
+    await seedEnvelope(repo, 'env-b', false)
+
+    expect(await repo.listResyncableOrgIds(null, 10, NOW, LEASE_MS)).toEqual(['env-a'])
+  })
+
+  it('leaves an envelope whose transition someone owns, until the lease expires', async () => {
+    const repo = new PgOrgClusterExecutionRepo(prisma)
+    const orgId = await seedEnvelope(repo, 'env-a', true)
+    await repo.beginTransition(orgId, 'peer-token', NOW, LEASE_MS)
+
+    expect(await repo.listResyncableOrgIds(null, 10, NOW, LEASE_MS)).toEqual([])
+
+    // A claim older than the lease is taken over everywhere else, so a crashed
+    // holder must not exclude its org from convergence forever either.
+    const afterLease = new Date(NOW.getTime() + LEASE_MS + 1)
+    expect(await repo.listResyncableOrgIds(null, 10, afterLease, LEASE_MS)).toEqual(['env-a'])
+
+    await repo.endTransition(orgId, 'peer-token')
+    expect(await repo.listResyncableOrgIds(null, 10, NOW, LEASE_MS)).toEqual(['env-a'])
+  })
+
+  it('pages forward by org id, so consecutive passes cover the whole fleet', async () => {
+    const repo = new PgOrgClusterExecutionRepo(prisma)
+    for (const id of ['env-a', 'env-b', 'env-c']) await seedEnvelope(repo, id, true)
+
+    const first = await repo.listResyncableOrgIds(null, 2, NOW, LEASE_MS)
+    expect(first).toEqual(['env-a', 'env-b'])
+    expect(await repo.listResyncableOrgIds(first.at(-1)!, 2, NOW, LEASE_MS)).toEqual(['env-c'])
+  })
+
+  it('is empty for a deployment with no envelopes at all', async () => {
+    const repo = new PgOrgClusterExecutionRepo(prisma)
+    expect(await repo.listResyncableOrgIds(null, 10, NOW, LEASE_MS)).toEqual([])
+  })
+})

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -307,6 +307,7 @@ import {
   encodeSharedSlackStatusTarget,
   HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED,
   HookReport,
+  CP_URL_ENV,
   RELAY_DAEMON_SUBPROTOCOL,
   RELAY_DAEMON_WS_PATH,
   RESERVED_RESTART_CODE,
@@ -20403,7 +20404,20 @@ export class Daemon {
   private startCpClient(root: string): void {
     const cp = this.cfg.controlPlane
     if (!configuredControlPlane(cp, !!this.clusterIdentityToken)) {
-      this.log.info('cp: not connecting (disabled or missing url/token) — running local')
+      // Url first: an envelope daemon has no config file, so a missing address is
+      // ALSO why the connection reads disabled, and naming the cause beats the effect.
+      const missing = !cp.url ? 'no url' : !cp.enabled ? 'disabled' : 'no key and no projected identity'
+      // Local mode is a CHOICE on a host and a FAULT in a cluster: `--k8s` says this
+      // process is an envelope the control plane provisioned, so a missing address is
+      // a CR that never carried `spec.controlPlane.url`, not an operator's decision.
+      // At info it reads as normal, which is how a whole fleet of them goes unnoticed.
+      if (this.k8s) {
+        this.log.error(
+          `cp: not connecting (${missing}) — an in-cluster daemon has no local mode; expected ${CP_URL_ENV} from its AgentConnectOrg spec.controlPlane.url`
+        )
+      } else {
+        this.log.info(`cp: not connecting (${missing}) — running local`)
+      }
       return
     }
     if (this.clusterIdentityToken) this.log.info("cp: authenticating with this pod's projected identity token")


### PR DESCRIPTION
## The bug

`ClusterExecutionService.reconcile()` is the only thing that applies an org's
`AgentConnectOrg`, and it ran only from a settings write (`PUT …/cluster-execution`),
from `ensure`, and from the teardown drain. Nothing re-applied an envelope whose row
had not changed.

`buildSpec()` renders `spec.controlPlane.url` from `policy.controlPlaneUrl` — control-plane
**configuration**, not the org's stored row. So when a deployment upgraded to a build that
had learned to write that field, every envelope created before the upgrade kept a CR with
no `spec.controlPlane.url`. The operator had nothing to inject, the daemon pods came up
with no `AC_CP_URL`, and each one sat in local mode.

Nothing surfaced it. The CR reported `Ready`, the pods were `1/1 Running` with zero
restarts, and the only evidence was one INFO line per daemon. Several organizations sat
like that until someone read a daemon's log.

## The fix

CR writing becomes level-triggered, the way the operator's own reconcile already is. The
existing five-minute maintenance loop — already framed as the backstop for what inline
work can owe the world after a request returns — gains a second pass that re-applies the
enabled envelopes.

**Interval and bound.** No new timer: the pass rides the existing five-minute maintenance
tick, and takes **100 envelopes per pass**, keyed forward by org id from where the last
pass stopped. A short slice is the fleet's tail, so the next pass starts over from the top.
That bounds one pass at ~100 no-op PATCHes (well under one request per second averaged over
the interval) while still converging a fleet of any size — 1000 orgs inside an hour. The
cursor is per process on purpose: two replicas sweeping from different offsets both
converge, and a restart that starts over costs no-ops, not correctness.

**Transition claims are respected.** The listing skips orgs under a live claim, using
`beginTransition`'s own takeover predicate — so a crashed holder cannot exclude its org
from convergence forever, matching how every other transition treats an expired lease
(design §6).

**Idempotent, and no write amplification.** Each org goes through the same `converge()`
loop a request takes, so the pass applies the row as it reads *now* — a row disabled or
deleted since the slice was listed is reconciled to that instead of to a stale snapshot,
including the existing "the org was deleted mid-flight, remove what we just created" undo.
Nothing writes the settings row, so `specRevision` does not move; server-side apply of an
unchanged spec stores no new resource version.

**Failures are legible.** Per envelope, like the drain: one unreachable org costs the rest
of the pass nothing. But it is reported rather than swallowed — each failing envelope is
logged at `error` with its org id, every pass, until it converges. A converged pass logs
nothing, so the steady state stays quiet and a stuck envelope is the only thing that
speaks. That is the deliberate answer to "logging and moving on": an envelope stuck on a
stale spec is exactly what silence already cost once, and a line that repeats every five
minutes forever is what an operator's error-rate alert can actually catch.

## Daemon log level

Raised, and I do think the daemon can tell. `--k8s` asserts this process is an envelope the
control plane provisioned, so a refused control-plane connection there is a CR that never
carried `spec.controlPlane.url` — a misconfiguration, not a chosen shape. A `--k8s` daemon
now logs it at `error` and names the missing piece (`no url` / `disabled` / `no key and no
projected identity`); a host daemon keeps the INFO line, because local mode is a legitimate
choice there. Url is diagnosed first: an envelope daemon has no config file, so a missing
address is also *why* the connection reads disabled.

## Out of scope

`spec.daemon.image` is rendered from the row, not from `CLUSTER_DAEMON_IMAGE`, and the new
pass does not change that — whether fleet-wide daemon upgrades should follow the deployment
default is a product decision that has not been made.

## Tests

- `service.test.ts` — the drift case: an envelope applied under one `controlPlaneUrl`
  converges on a changed one **with no settings write**, and `specRevision` does not move.
  Plus: a disabled org is left alone, a claimed org is skipped and taken next pass, the
  rotation covers a fleet larger than one slice and wraps, one failing envelope does not
  stop the rest and is named, and an org deleted under the pass has its re-created resource
  removed. The fake repo is now multi-org so rotation is testable.
- `maintenance-loop.test.ts` (new) — both passes run on one tick, a converged pass is
  silent, each unapplied envelope is reported at error, a throwing drain does not cost the
  re-apply, and a pass that fails outright re-arms.
- `test/repo/org-cluster-execution.repo.test.ts` (new) — the SQL itself against real
  Postgres: enabled-only, the claim filter including lease expiry, and keyset paging.

`test:unit` (1605), `test:int` (1151), `pnpm lint`, `pnpm typecheck` and prettier all pass.
`usage.route` failed once under full-suite parallelism and passes standalone; it touches
nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
