### PR TITLE
fix(shared-bot): route direct conversations to one owner

### DIFF
--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -895,6 +895,9 @@ remains forbidden for gated agents.
     ungated sibling's unscoped rungs are still in the same table, so on a
     mixed-visibility bot a bare `@bot` would otherwise reach the public default
     in a channel the console shows as Off.
+    An enabled conversation whose canonical owner is active but unplaced is
+    also muted until that owner has a daemon placement; it must not fall
+    through to another agent's unscoped default.
 - Because the relay fence covers both, it also has to say which Off conversations
   still deserve the §14.3 notice. `gatedOffChannels` carries that subset — the
   muted conversations whose owner is gated, i.e. Off because nobody has enabled them

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -728,7 +728,10 @@ So authorization must live in AgentConnect's own routing layer.
 integration card groups rows into **Channels** and **Direct messages**; 1:1 DM
 rows are binary (Off / On — a DM needs no mention distinction). Org-visible
 agents default new DMs On; restricted agents default them Off. Both expose the
-same control, and both enforce it.
+same control, and both enforce it. Classic integrations keep these controls per
+integration. A shared HTTP bot converges each observed conversation to one
+default owner and projects its trigger across all sibling integrations, the same
+way it handles an enumerated channel.
 
 **Behavior of an Off conversation.**
 
@@ -833,8 +836,10 @@ counterpart's display name where available. An optional boot-time sweep
 _Shared bots:_ the relay's membership snapshot drops IMs, so direct rows take
 the incremental path there too — every human DM (and addressed group DM) makes
 the relay emit `rc/bot-conversation` (conversation id + best-effort `users.info`
-counterpart name), which the CP fans across **every install**. Restricted rows
-start Off; org-visible 1:1 DMs start On and group DMs on Mention. The relay also
+counterpart name), which the CP fans across **every install** and converges to
+one owner plus one effective trigger. A new conversation uses the earliest
+active install as owner; restricted rows start Off, org-visible 1:1 DMs start On,
+and group DMs start on Mention. The relay also
 posts the one-time
 per-conversation notice (chrome-marked; the unrouted @-mention case included)
 since no daemon is involved before arbitration. Because a channel mention
@@ -849,12 +854,10 @@ is the **`noticedDmConversations`** set, which records notices ACTUALLY
 DELIVERED (reported via `rc/notice-posted` after the post, then re-stamped to
 every pod) — deliberately not derived from conversation rows, since a mixed
 bot's DM routed by its public default creates a row with no notice and must
-still receive one if it later becomes unroutable. Enabling the row compiles a
-conversation-scoped `auto` route plus a conversation-scoped **slug keyword**
-route — arbitration ranks scoped mention → keyword → auto — so a DM enabled
-for several gated agents can be addressed by slug while an unslugged DM falls
-to the first enabled agent. Unscoped keyword remains forbidden for gated
-agents.
+still receive one if it later becomes unroutable. Enabling a shared conversation
+compiles one conversation-scoped route for its selected owner; it does not fan
+out to every install or create per-agent DM slug routes. Unscoped keyword
+remains forbidden for gated agents.
 
 **Control-plane and web.**
 
@@ -862,9 +865,9 @@ agents.
   gains `off`; new `kind` column (`channel` | `im` | `mpim`). Row creation
   derives the default from visibility and kind: restricted conversations Off,
   org-visible 1:1 DMs On, and other org-visible rooms Mention.
-- The existing per-channel trigger PATCH route accepts `off` and reuses the
+- The existing per-conversation trigger PATCH route accepts `off` and reuses the
   existing recompute-bindRules-and-push flow. A direct integration requires edit
-  rights on its parent agent. A shared bot's channel state is bot-scoped, so the
+  rights on its parent agent. A shared bot's conversation state is bot-scoped, so the
   route additionally requires edit rights on the effective owner and on a newly
   selected owner; changing a visible sibling cannot enable a hidden restricted
   owner. Mutations are serialized per bot/channel and fenced to the owner that
@@ -872,7 +875,7 @@ agents.
   request retry instead of applying its trigger to the new owner.
 - `gated` is **derived** from `agent.visibility === 'restricted'` at spec
   assembly; there is no separate stored toggle (see §14.7).
-- Web `IntegrationChannelList`: tri-state segmented control per channel row
+- Web `IntegrationChannelList`: tri-state segmented control per conversation row
   (Off / Mention / All messages) — offered for every agent, not only a gated
   one — a Direct-messages section with binary rows, pending badges, and a
   banner on restricted agents' integration cards explaining the gate.
@@ -887,18 +890,18 @@ agents.
     no unscoped defaults at all, so its Off already is the absence of a scoped
     rule, and stating the same fact twice would let the two drift apart.
   - **Relay** (`rc/bot-assign` / `rc/routes`, per bot): every bot-scoped Off
-    channel, plus a direct conversation when no placed install has it enabled.
+    conversation, including an observed DM or group DM.
     A gated owner's missing route is not enough here: an
     ungated sibling's unscoped rungs are still in the same table, so on a
     mixed-visibility bot a bare `@bot` would otherwise reach the public default
     in a channel the console shows as Off.
-- Because the relay fence covers both, it also has to say which Off channels
+- Because the relay fence covers both, it also has to say which Off conversations
   still deserve the §14.3 notice. `gatedOffChannels` carries that subset — the
-  muted channels whose owner is gated, i.e. Off because nobody has enabled them
+  muted conversations whose owner is gated, i.e. Off because nobody has enabled them
   rather than because an operator silenced them. The relay posts the notice only
-  for those; an operator's Off is silent (see "Per-channel trigger" in
+  for those; an operator's Off is silent (see "Per-conversation trigger" in
   product-conventions.md). The two states share a trigger value and the relay
-  cannot infer channel ownership from a table that holds no route for them, so
+  cannot infer conversation ownership from a table that holds no route for them, so
   this is explicit wire state rather than something derived.
 
 ### 14.4 Visibility transitions

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -897,7 +897,9 @@ remains forbidden for gated agents.
     in a channel the console shows as Off.
     An enabled conversation whose canonical owner is active but unplaced is
     also muted until that owner has a daemon placement; it must not fall
-    through to another agent's unscoped default.
+    through to another agent's unscoped default. This availability fence is
+    not included in `gatedOffChannels`, because the conversation is On rather
+    than Off and must not receive the gated-owner notice.
 - Because the relay fence covers both, it also has to say which Off conversations
   still deserve the §14.3 notice. `gatedOffChannels` carries that subset — the
   muted conversations whose owner is gated, i.e. Off because nobody has enabled them

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -207,9 +207,10 @@ store. Lark / Feishu HTTP bots require `appId`, `appSecret`, Verification Token,
 optional Encrypt Key. Secret reads and writes pass through the configured
 `SecretCipher`; list and metadata APIs do not select secret material.
 
-`IntegrationChannel.agentId` represents a channel-scoped default agent. Exactly one
-active integration row carries that owner for each shared channel; sibling rows are
-null because channel membership is repeated per integration.
+`IntegrationChannel.agentId` represents a conversation-scoped default agent. Exactly
+one active integration row carries that owner for each shared conversation, including
+an observed DM or group DM; sibling rows are null because membership is repeated per
+integration.
 `SharedThreadAgent` is the durable fallback for relay-local thread affinity. It
 contains routing metadata only, never message text.
 `SharedThreadParticipant` is the independently durable participant set. It lets
@@ -368,18 +369,20 @@ socket cannot be authenticated until the CP verification path recovers.
 ### 10.1 Slack arbitration
 
 CP compiles attributed routes from active integrations, placed agents, and
-channel settings. The relay applies the shared routing ladder:
+conversation settings. The relay applies the shared routing ladder:
 
-1. an explicit agent selection or scoped channel owner;
+1. an explicit agent selection or scoped conversation owner;
 2. existing thread affinity;
 3. agent-slug keyword disambiguation;
 4. the bot's default agent for a bare mention or direct message.
 
-Before compiling routes, CP converges each channel to one canonical owner row and
-replicates its effective trigger across the sibling membership rows, backfilling a
-missing row when a new install has not reported membership yet. A new or ownerless
-channel uses the earliest active integration, and a Console owner change preserves
-the trigger. An in-Slack move or automatic fallback to a restricted agent stays Off.
+Before compiling routes, CP converges each observed conversation to one canonical
+owner row and replicates its effective trigger across the sibling membership rows,
+backfilling a missing row when a new install has not reported membership yet. A new
+or ownerless conversation uses the earliest active integration, and a Console owner
+change preserves the trigger. An in-Slack move or automatic fallback to a restricted
+agent stays Off. Shared DMs and group DMs therefore have one scoped route, not one
+route per installed agent or a per-agent slug fan-out.
 This also preserves state and repairs ownership when an integration is removed;
 `No default` is not an operator state.
 
@@ -471,7 +474,7 @@ block at the daemon, and is never persisted by the relay or Control Plane.
   relay connection.
 
 Slack rate limits are global to a bot while send queues are local to member
-daemons. Each daemon respects `429` and `Retry-After`; channel ownership reduces
+daemons. Each daemon respects `429` and `Retry-After`; conversation ownership reduces
 but does not eliminate concurrent sends from different daemons.
 
 ## 12. Delivery Semantics
@@ -596,7 +599,7 @@ The smallest useful evidence for this design includes:
 - HTTP ingress tests for raw-body HMAC verification, replay timestamps,
   challenge handling, body limits, event deduplication, and interaction
   responses;
-- routing tests for channel ownership, keyword selection, default target,
+- routing tests for conversation ownership, keyword selection, default target,
   managed-bot echo suppression, thread report/broadcast/lookup, and session
   actions;
 - orchestration tests proving HTTP bot assignments and updates reach every

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -384,7 +384,8 @@ change preserves the trigger. An in-Slack move or automatic fallback to a restri
 agent stays Off. Shared DMs and group DMs therefore have one scoped route, not one
 route per installed agent or a per-agent slug fan-out. If that owner is active but
 currently unplaced, CP emits no scoped route and adds the conversation to the relay
-mute fence so it cannot fall through to another agent's unscoped default.
+mute fence so it cannot fall through to another agent's unscoped default. This
+availability fence does not count as `gatedOffChannels`; the trigger remains On.
 This also preserves state and repairs ownership when an integration is removed;
 `No default` is not an operator state.
 

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -382,7 +382,9 @@ backfilling a missing row when a new install has not reported membership yet. A 
 or ownerless conversation uses the earliest active integration, and a Console owner
 change preserves the trigger. An in-Slack move or automatic fallback to a restricted
 agent stays Off. Shared DMs and group DMs therefore have one scoped route, not one
-route per installed agent or a per-agent slug fan-out.
+route per installed agent or a per-agent slug fan-out. If that owner is active but
+currently unplaced, CP emits no scoped route and adds the conversation to the relay
+mute fence so it cannot fall through to another agent's unscoped default.
 This also preserves state and repairs ownership when an integration is removed;
 `No default` is not an operator state.
 

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -279,16 +279,17 @@ A reply whose parent lives on another daemon behaves identically. If that daemon
 old to understand the delivery kind, the reply **fails** rather than being dispatched into
 the wrong session.
 
-## Per-channel trigger
+## Per-conversation trigger
 
-Every channel a bot is in carries a trigger, and every agent gets all three settings —
-Off, every message, or @-mention (the default). Off is not a gating feature: an
-org-visible agent is entitled to the same control as a restricted one.
+Every conversation a bot is in carries a trigger. Channels and group DMs expose all
+three settings — Off, every message, or @-mention (the default); a 1:1 DM presents the
+equivalent compact Off / On control. Off is not a gating feature: an org-visible agent
+is entitled to the same control as a restricted one.
 
-Off means the agent does not respond in that channel at all. Not to an @-mention, not to
+Off means the agent does not respond in that conversation at all. Not to an @-mention, not to
 a follow-up in a thread it had already joined, not to a control command, and not through
 a shared bot's slug or default-dispatch fallback. It leaves everything else intact: the
-bot stays in the channel, the channel keeps its row and its owner, past sessions keep
+bot stays in the conversation, the conversation keeps its row and its owner, past sessions keep
 their transcripts, and an agent may still post there when something else — a scheduled
 task, another agent's hand-off — directs it to.
 
@@ -372,21 +373,20 @@ A platform's refusal is shown as the platform worded it. A missing scope, a
 last-member channel, or a lost right is usually something the operator can act on, and
 collapsing it into a generic failure would throw away the only useful part.
 
-## Shared-bot channel ownership
+## Shared-bot conversation ownership
 
-Every active channel served by a shared bot has exactly one default agent. A newly
-observed or ownerless channel converges to the bot's earliest active agent, and removing
-the current owner immediately transfers ownership to the earliest remaining agent.
-Console surfaces must show the same effective owner and trigger from every member
-agent's integration; they must not expose a `No default` state. The trigger is
+Every active conversation served by a shared bot has exactly one default agent. A newly
+observed or ownerless conversation converges to the bot's earliest active agent, and
+removing the current owner immediately transfers ownership to the earliest remaining
+agent. Console surfaces must show the same effective owner and trigger from every
+member agent's integration; they must not expose a `No default` state. The trigger is
 replicated across every active membership row, backfilling a missing sibling, so
-removing the owner does not discard the channel or its trigger.
+removing the owner does not discard the conversation or its trigger.
 
-A Console owner change preserves the channel's trigger. An in-Slack owner change or
-automatic fallback to a restricted agent instead leaves the channel Off, because only
-an authorized Console editor may enable it. Direct messages remain per-agent rather
-than bot-scoped: every agent may independently enable or disable its own conversation
-row.
+A Console owner change preserves the conversation's trigger. An in-Slack owner change
+or automatic fallback to a restricted agent instead leaves the conversation Off,
+because only an authorized Console editor may enable it. This same owner boundary
+applies to observed 1:1 and group DMs; classic integrations remain per-agent.
 
 ## Direct messages
 
@@ -403,9 +403,13 @@ Visibility determines the initial state, not whether the control exists:
   until a Console editor enables it.
 
 Direct rows are observed incrementally because platforms do not enumerate them as bot
-membership. Switching Everyone → Restricted closes every known direct row before the
-gated routing configuration is pushed. Switching back keeps the stored choices; the
-rows stay visible and configurable.
+membership. For a shared bot, the row is repeated for each install but owner and trigger
+are bot-scoped, and the Console offers the same default-dispatch picker as a channel.
+Removing or leaving a shared conversation clears the repeated rows together; a classic
+integration still removes only its own listing.
+Switching Everyone → Restricted closes every known direct row before the gated routing
+configuration is pushed. Switching back keeps the stored choices; the rows stay visible
+and configurable.
 
 ## Group direct messages
 
@@ -426,10 +430,10 @@ three-way trigger as a channel:
   unroutable until a Console editor enables it.
 
 A shared bot is one Slack identity, so a mention in a group DM cannot name which agent
-behind it is meant, and the slug that disambiguates a shared DM does not apply — a DM
-activates on any message, which a slug can outrank, while a group DM activates on the
-mention itself. A group DM served by a shared bot therefore converges on exactly one
-agent: the bot's earliest active install among those whose row is enabled.
+behind it is meant. A group DM served by a shared bot therefore converges on exactly one
+selected owner; its trigger is replicated to every sibling row and its route targets
+that owner. Shared 1:1 DMs follow the same owner boundary, with no per-agent DM slug
+fan-out.
 
 A conversation first mistaken for a channel converts to a group DM once resolved, and
 that conversion receives the visibility-appropriate group-DM default (Mention for

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/fuyaoz/Library/pnpm/store/workspace-node-modules/agentconnect

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/fuyaoz/Library/pnpm/store/workspace-node-modules/agentconnect

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2033,13 +2033,13 @@ model IntegrationChannel {
   space         String?
   isPrivate     Boolean          @default(false)
   kind          ConversationKind @default(channel)
-  // Relay-backed channel rows repeat the effective trigger across each active
-  // integration so deleting the canonical owner does not discard channel state.
-  // Direct rows remain independently configurable per integration.
+  // Relay-backed shared-bot rows repeat the effective trigger across each active
+  // integration so deleting the canonical owner does not discard conversation state.
+  // Classic integrations keep their trigger per integration.
   trigger       ChannelTrigger   @default(mention)
-  // Per-channel default/owning agent for a SHARED bot (shared-bot-relay.md §10.1
-  // channel ownership — the primary disambiguation path). Exactly one active
-  // integration row per shared channel carries the owner; sibling rows are null.
+  // Per-conversation default/owning agent for a SHARED bot (shared-bot-relay.md §10.1
+  // conversation ownership — the primary disambiguation path). Exactly one active
+  // integration row per shared conversation carries the owner; sibling rows are null.
   // Irrelevant for a classic integration, where its agent is the only target.
   agentId       String?          @db.Uuid
   firstSeenAt   DateTime         @default(now()) @db.Timestamptz(6)
@@ -2837,4 +2837,3 @@ model PendingEnvelopeTeardown {
 
   @@map("pending_envelope_teardown")
 }
-

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -156,7 +156,7 @@ export interface HttpDeps {
     waitlist: WaitlistRepo
     /** Platform integration metadata (never tokens). */
     integration: IntegrationRepo
-    /** Daemon-reported channel membership + the per-channel trigger choice. */
+    /** Daemon-reported conversation membership + the per-conversation trigger choice. */
     integrationChannel: IntegrationChannelRepo
     /** Durable bot identities — outlive their integration, reusable after uninstall. */
     bot: BotRepo

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -750,7 +750,7 @@ export const IntegrationChannelDto = z.object({
   isPrivate: z.boolean(),
   kind: z.enum(['channel', 'im', 'mpim']),
   trigger: z.enum(['off', 'mention', 'any']),
-  /** Effective per-channel owner for a shared bot (§10.1); null before convergence
+  /** Effective per-conversation owner for a shared bot (§10.1); null before convergence
    *  or when ownership does not apply. */
   agentId: z.string().nullable()
 })

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -233,7 +233,7 @@ export const MCP_TOOLS: McpToolDef[] = [
   },
   {
     name: 'listIntegrations',
-    description: 'List platform integrations (bot ↔ agent bindings) with their per-channel triggers.',
+    description: 'List platform integrations (bot ↔ agent bindings) with their conversation triggers.',
     schema: NoArgs,
     call: (ctx) => ctx.get(org(ctx, '/integrations'))
   },
@@ -410,7 +410,7 @@ export const MCP_TOOLS: McpToolDef[] = [
   {
     name: 'setChannelTrigger',
     description:
-      'Change how an integration behaves in one conversation: the trigger mode (off / mention-only / any message; off disables the conversation) and/or the channel’s owning agent (null clears the per-channel override).',
+      'Change how an integration behaves in one conversation: the trigger mode (off / mention-only / any message; off disables the conversation) and/or the conversation’s owning agent (null clears the override).',
     write: true,
     schema: z
       .object({

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -27,8 +27,7 @@ import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
 import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
-import { pickChannelOwner } from '../../orchestrator/httpBot.js'
-import { isDirectConversationKind } from '../../persistence/ports.js'
+import { pickConversationOwner } from '../../orchestrator/httpBot.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewBot } from '../install-bot.js'
 import { BotExternalIdentityTaken } from '../../persistence/errors.js'
@@ -97,7 +96,7 @@ export function integrationRoutes(deps: HttpDeps) {
       return current
     }
 
-    // Push the full spec (metadata + tokens + per-channel bindRules) to the owning
+    // Push the full spec (metadata + tokens + per-conversation bindRules) to the owning
     // daemon. Best-effort: if the daemon is offline the reconcile roster carries it
     // on the next connect. Token-bearing — never log the spec.
     const replicateUpsert = async (i: IntegrationRecord, daemonId: string): Promise<void> => {
@@ -509,7 +508,7 @@ export function integrationRoutes(deps: HttpDeps) {
         schema: {
           tags: [Tag.Integrations],
           summary: 'List integrations',
-          description: 'Every platform integration in the active organization, each with its per-channel bindings.',
+          description: 'Every platform integration in the active organization, each with its conversation bindings.',
           operationId: 'listIntegrations',
           response: { 200: IntegrationListDto }
         }
@@ -526,8 +525,7 @@ export function integrationRoutes(deps: HttpDeps) {
         )
         // Membership is repeated per shareable-bot integration, while only the
         // canonical owner row persists agentId. Read effective state from every
-        // active install of each visible bot — not only viewer-visible integrations
-        // — so a sibling never disagrees with the relay's route table.
+        // active install of each visible bot so every conversation copy agrees.
         const effective = new Map<string, IntegrationChannelRecord>()
         const bots = new Map((await deps.repos.bot.listForOrg(orgIdOf(req))).map((bot) => [bot.id, bot]))
         const botStates = await Promise.all(
@@ -538,7 +536,7 @@ export function integrationRoutes(deps: HttpDeps) {
               deps.repos.integration.listForBot(botId),
               deps.repos.integrationChannel.listForBot(botId)
             ])
-            return { botId, installs, channels: channels.filter((channel) => channel.kind === 'channel') }
+            return { botId, installs, channels }
           })
         )
         for (const state of botStates) {
@@ -550,7 +548,7 @@ export function integrationRoutes(deps: HttpDeps) {
             byChannel.set(channel.channelId, channels)
           }
           for (const [channelId, channels] of byChannel) {
-            const owner = pickChannelOwner(state.installs, channels)
+            const owner = pickConversationOwner(state.installs, channels)
             if (!owner) continue
             const channel =
               channels.find((row) => row.agentId === owner.agentId) ??
@@ -571,7 +569,6 @@ export function integrationRoutes(deps: HttpDeps) {
           toDto(
             integration,
             channels.map((channel) => {
-              if (channel.kind !== 'channel') return channel
               const state = effective.get(`${integration.botId}\u0000${channel.channelId}`)
               return state ? { ...channel, agentId: state.agentId, trigger: state.trigger } : channel
             })
@@ -581,7 +578,7 @@ export function integrationRoutes(deps: HttpDeps) {
     )
 
     /**
-     * Shared admission for the per-channel routes: the integration must be in this
+     * Shared admission for the per-conversation routes: the integration must be in this
      * org, its owning agent visible AND editable, and the row must exist. Replies on
      * the failure paths and returns null, so a caller that gets a value is cleared.
      *
@@ -685,13 +682,13 @@ export function integrationRoutes(deps: HttpDeps) {
     }
 
     /**
-     * A shared bot's channel is bot-scoped: one owner, and a trigger replicated across
-     * every install. Ending its listing therefore reaches agents beyond the one whose
+     * A shared bot's conversation is bot-scoped: one owner, and a trigger replicated
+     * across every install. Ending its listing therefore reaches agents beyond the one whose
      * page this is, so it takes the SAME authorization the trigger/owner PATCH takes —
      * edit rights on the effective owner — instead of only on this integration's agent.
      * Returns an error envelope to send, or null when the action may proceed.
      */
-    const resolveBotScopedChannel = async (
+    const resolveBotScopedConversation = async (
       req: { params: { id: string; channelId?: string } },
       integration: IntegrationRecord,
       bot: BotRecord,
@@ -702,39 +699,36 @@ export function integrationRoutes(deps: HttpDeps) {
     > => {
       const rows = await deps.repos.integrationChannel.listForIntegration(integration.id)
       const row = rows.find((candidate) => candidate.channelId === channelId)
-      // A DIRECT row is per-agent even on a shared bot (§14.3: each gated install gets
-      // its own DM row), so it is never fanned out and needs no owner check — sharing
-      // one would let an editor of one agent silently drop another agent's DM.
-      if (bot.transport !== 'http' || (row && isDirectConversationKind(row.kind))) {
+      if (bot.transport !== 'http' || !row) {
         return { ok: true, botScoped: false }
       }
-      const [installs, channelRows] = await Promise.all([
+      const [installs, conversationRows] = await Promise.all([
         deps.repos.integration.listForBot(bot.id),
         deps.repos.integrationChannel.listForBot(bot.id)
       ])
-      const owner = pickChannelOwner(
+      const owner = pickConversationOwner(
         installs,
-        channelRows.filter((candidate) => candidate.kind === 'channel' && candidate.channelId === channelId)
+        conversationRows.filter((candidate) => candidate.channelId === channelId)
       )
       const ownerAgent = owner ? await deps.repos.agent.get(owner.orgId, owner.agentId) : null
       if (!ownerAgent) {
         return {
           ok: false,
           code: 409,
-          body: { error: 'Conflict', statusCode: 409, message: 'channel owner changed; refresh and retry' }
+          body: { error: 'Conflict', statusCode: 409, message: 'conversation owner changed; refresh and retry' }
         }
       }
       if (!canEdit(ownerAgent, ctxOf(req as never))) {
         return {
           ok: false,
           code: 403,
-          body: { error: 'Forbidden', statusCode: 403, message: 'cannot edit this channel’s owning agent' }
+          body: { error: 'Forbidden', statusCode: 403, message: 'cannot edit this conversation’s owning agent' }
         }
       }
       return { ok: true, botScoped: true, ownerAgentId: ownerAgent.id }
     }
 
-    // Per-channel trigger choice (@-mention vs any message). Persist, then push the
+    // Per-conversation trigger choice (@-mention vs any message). Persist, then push the
     // integration's recomputed bindRules to the owning daemon (integration/upsert,
     // best-effort — the reconcile roster converges an offline daemon later).
     r.patch(
@@ -742,8 +736,8 @@ export function integrationRoutes(deps: HttpDeps) {
       {
         schema: {
           tags: [Tag.Integrations],
-          summary: 'Update a channel',
-          description: "Set a channel's trigger or default agent, then push the updated routing configuration.",
+          summary: 'Update a conversation',
+          description: "Set a conversation's trigger or default agent, then push the updated routing configuration.",
           operationId: 'updateIntegrationChannel',
           params: IdParam.extend({ channelId: z.string().min(1) }),
           body: UpdateIntegrationChannelBody,
@@ -776,10 +770,10 @@ export function integrationRoutes(deps: HttpDeps) {
         if (!bot) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
-        const botScopedChannel = bot.transport === 'http' && existingChannel.kind === 'channel'
+        const botScopedConversation = bot.transport === 'http'
         let effectiveOwner: AgentRecord | null = null
         let selectedOwner: AgentRecord | null = null
-        if (botScopedChannel) {
+        if (botScopedConversation) {
           if (req.body.agentId !== undefined && !bot.agentIds.includes(AgentId(req.body.agentId))) {
             return reply.code(409).send({
               error: 'Conflict',
@@ -787,13 +781,13 @@ export function integrationRoutes(deps: HttpDeps) {
               message: 'default agent must be an agent that uses this bot'
             })
           }
-          const [installs, channelRows] = await Promise.all([
+          const [installs, conversationRows] = await Promise.all([
             deps.repos.integration.listForBot(bot.id),
             deps.repos.integrationChannel.listForBot(bot.id)
           ])
-          const owner = pickChannelOwner(
+          const owner = pickConversationOwner(
             installs,
-            channelRows.filter((channel) => channel.kind === 'channel' && channel.channelId === req.params.channelId)
+            conversationRows.filter((channel) => channel.channelId === req.params.channelId)
           )
           effectiveOwner = owner ? await deps.repos.agent.get(orgOf(req), owner.agentId) : null
           selectedOwner =
@@ -804,14 +798,14 @@ export function integrationRoutes(deps: HttpDeps) {
             return reply.code(409).send({
               error: 'Conflict',
               statusCode: 409,
-              message: 'channel owner changed; refresh and retry the integration change'
+              message: 'conversation owner changed; refresh and retry the integration change'
             })
           }
           if (!canEdit(effectiveOwner, ctxOf(req)) || !canEdit(selectedOwner, ctxOf(req))) {
             return reply.code(403).send({
               error: 'Forbidden',
               statusCode: 403,
-              message: 'cannot edit the current or selected channel owner'
+              message: 'cannot edit the current or selected conversation owner'
             })
           }
         }
@@ -844,13 +838,13 @@ export function integrationRoutes(deps: HttpDeps) {
             refreshed.set(current.id, current)
           }
           agent = refreshed.get(agent.id)!
-          // HTTP channel ownership is bot-scoped even though membership rows are
+          // HTTP conversation ownership is bot-scoped even though membership rows are
           // stored per integration. Route the whole patch through the orchestrator
           // so every agent detail shows the same owner/trigger and exactly one row
           // remains authoritative.
           let updated: IntegrationChannelRecord | null = null
           let routesSynced = false
-          if (botScopedChannel) {
+          if (botScopedConversation) {
             updated = await deps.httpBot.updateChannel(
               bot.id,
               req.params.channelId,
@@ -867,7 +861,7 @@ export function integrationRoutes(deps: HttpDeps) {
               return reply.code(409).send({
                 error: 'Conflict',
                 statusCode: 409,
-                message: 'channel owner changed; refresh and retry the integration change'
+                message: 'conversation owner changed; refresh and retry the integration change'
               })
             }
             routesSynced = true
@@ -876,7 +870,7 @@ export function integrationRoutes(deps: HttpDeps) {
               return reply.code(400).send({
                 error: 'Bad Request',
                 statusCode: 400,
-                message: 'default agent applies only to shared channels'
+                message: 'default agent applies only to shared bot conversations'
               })
             }
             updated = await deps.repos.integrationChannel.setTrigger(
@@ -918,7 +912,7 @@ export function integrationRoutes(deps: HttpDeps) {
       {
         schema: {
           tags: [Tag.Integrations],
-          summary: 'Forget a channel',
+          summary: 'Forget a conversation',
           description:
             'Remove a conversation row from AgentConnect without touching the platform. Intended for a conversation the bot has already left where the platform cannot report its own departure. The row returns on the next authoritative listing if the bot is still a member.',
           operationId: 'deleteIntegrationChannel',
@@ -931,7 +925,7 @@ export function integrationRoutes(deps: HttpDeps) {
         const admitted = await admitChannelAction(req, reply)
         if (!admitted) return
         const { integration, agent, bot } = admitted
-        const scope = await resolveBotScopedChannel(req, integration, bot, req.params.channelId)
+        const scope = await resolveBotScopedConversation(req, integration, bot, req.params.channelId)
         if (!scope.ok) return reply.code(scope.code).send(scope.body)
         // The owner joins the lease, not just the authorization: a bot-wide action
         // decided against one owner must not commit while a move re-places that owner.
@@ -945,12 +939,12 @@ export function integrationRoutes(deps: HttpDeps) {
         try {
           // Ownership can change between resolving it and holding the lease, so the
           // verdict is re-taken under the lease and must still name the same owner.
-          const fenced = await resolveBotScopedChannel(req, integration, bot, req.params.channelId)
+          const fenced = await resolveBotScopedConversation(req, integration, bot, req.params.channelId)
           if (!fenced.ok) return reply.code(fenced.code).send(fenced.body)
           if (fenced.ownerAgentId !== scope.ownerAgentId) {
             return reply
               .code(409)
-              .send({ error: 'Conflict', statusCode: 409, message: 'channel owner changed; refresh and retry' })
+              .send({ error: 'Conflict', statusCode: 409, message: 'conversation owner changed; refresh and retry' })
           }
           const rows = await deps.repos.integrationChannel.listForIntegration(integration.id)
           if (!rows.some((row) => row.channelId === req.params.channelId)) {
@@ -964,10 +958,8 @@ export function integrationRoutes(deps: HttpDeps) {
           // suppression. Same order the leave route uses: confirm, then touch local state.
           const suppressed = await pushForget(integration, agent, [req.params.channelId])
           if (!suppressed.ok) return reply.code(502).send(suppressed.body)
-          // A shared bot's CHANNEL state is bot-scoped — ownership and trigger are
-          // replicated across every install — so forgetting it on one install alone
-          // would leave siblings listing it and let the compiler resurrect the row. A
-          // direct row is per-agent and stays on this install only (§14.3).
+          // A shared bot's conversation state is bot-scoped, so delete every sibling
+          // row or the compiler can resurrect it on the next convergence.
           const installs = scope.botScoped ? await deps.repos.integration.listForBot(bot.id) : [integration]
           for (const install of installs) {
             await deps.repos.integrationChannel.deleteChannel(install.id, req.params.channelId)
@@ -1039,7 +1031,7 @@ export function integrationRoutes(deps: HttpDeps) {
         }
         const scope =
           target.kind === 'conversation'
-            ? await resolveBotScopedChannel(req, integration, bot, target.channel)
+            ? await resolveBotScopedConversation(req, integration, bot, target.channel)
             : ({ ok: true, botScoped: false, ownerAgentId: undefined } as const)
         if (!scope.ok) return reply.code(scope.code).send(scope.body)
         // Held across the whole request, not just the row writes. A cold move
@@ -1059,12 +1051,12 @@ export function integrationRoutes(deps: HttpDeps) {
         }
         try {
           if (target.kind === 'conversation') {
-            const fenced = await resolveBotScopedChannel(req, integration, bot, target.channel)
+            const fenced = await resolveBotScopedConversation(req, integration, bot, target.channel)
             if (!fenced.ok) return reply.code(fenced.code).send(fenced.body)
             if (fenced.ownerAgentId !== scope.ownerAgentId) {
               return reply
                 .code(409)
-                .send({ error: 'Conflict', statusCode: 409, message: 'channel owner changed; refresh and retry' })
+                .send({ error: 'Conflict', statusCode: 409, message: 'conversation owner changed; refresh and retry' })
             }
           }
           // Placement may have changed between admission and taking the lease, so the

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -27,7 +27,7 @@ import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
 import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { canView, canEdit } from '../../authorization/policy.js'
 import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
-import { pickConversationOwner } from '../../orchestrator/httpBot.js'
+import { conversationOwnerRow, pickConversationOwner } from '../../orchestrator/httpBot.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewBot } from '../install-bot.js'
 import { BotExternalIdentityTaken } from '../../persistence/errors.js'
@@ -550,10 +550,7 @@ export function integrationRoutes(deps: HttpDeps) {
           for (const [channelId, channels] of byChannel) {
             const owner = pickConversationOwner(state.installs, channels)
             if (!owner) continue
-            const channel =
-              channels.find((row) => row.agentId === owner.agentId) ??
-              channels.find((row) => row.integrationId === owner.id) ??
-              channels[0]
+            const channel = conversationOwnerRow(owner, channels)
             if (channel) {
               const persistedOwner = channels.some((row) => row.agentId === owner.agentId)
               const ownerAgent = persistedOwner ? null : await deps.repos.agent.get(orgOf(req), owner.agentId)
@@ -845,7 +842,7 @@ export function integrationRoutes(deps: HttpDeps) {
           let updated: IntegrationChannelRecord | null = null
           let routesSynced = false
           if (botScopedConversation) {
-            updated = await deps.httpBot.updateChannel(
+            updated = await deps.httpBot.updateConversation(
               bot.id,
               req.params.channelId,
               {

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -247,13 +247,11 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
             channelId: conversation.id,
             name: conversation.name ?? null,
             kind: conversation.kind ?? 'channel',
-            trigger: opts?.defaultTrigger ?? 'mention',
-            agentId: opts?.agentId ?? null
+            trigger: opts?.defaultTrigger ?? 'mention'
           })
           channels.push(row)
         } else {
           if (conversation.name) row.name = conversation.name
-          if (opts?.agentId !== undefined) row.agentId = opts.agentId
         }
         return row
       },
@@ -763,7 +761,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(bobRow?.trigger).toBe('off')
     })
 
-    it('reportConversation fans an owned DM row to every install with visibility-aware defaults', async () => {
+    it('reportConversation converges a DM to one owner and one trigger', async () => {
       gatedAgents = new Set([ALICE])
       channels = []
       const orch = makeOrch()
@@ -771,7 +769,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       const aliceRow = channels.find((c) => c.integrationId === INT_A && c.channelId === 'D42')
       const bobRow = channels.find((c) => c.integrationId === INT_B && c.channelId === 'D42')
       expect(aliceRow).toMatchObject({ kind: 'im', trigger: 'off', agentId: ALICE, name: '@Alice' })
-      expect(bobRow).toMatchObject({ kind: 'im', trigger: 'any', agentId: BOB, name: '@Alice' })
+      expect(bobRow).toMatchObject({ kind: 'im', trigger: 'off', agentId: null, name: '@Alice' })
 
       // Editor enables it; a re-report must keep the trigger (name refresh only).
       aliceRow!.trigger = 'any'
@@ -780,18 +778,12 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(bobRow).toMatchObject({ trigger: 'any', name: '@Alice Smith' })
 
       const assign = ch.sends.filter((s) => s.type === 'rc/routes').at(-1)!.payload as RcBotAssign
-      expect(assign.routes.filter((route) => route.scope?.channel === 'D42')).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } }),
-          expect.objectContaining({ agentId: BOB, match: { kind: 'auto' } })
-        ])
-      )
+      expect(assign.routes.filter((route) => route.scope?.channel === 'D42')).toEqual([
+        expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } })
+      ])
     })
 
-    // A group DM must survive the fan-out as itself. Stamping it 'im' would compile an
-    // `auto` route once enabled — the agent answering every message in a room full of
-    // people — instead of the mention rule a channel-like conversation gets.
-    it('reportConversation preserves a group DM and compiles a MENTION route once enabled', async () => {
+    it('reportConversation preserves a group DM and converges it like a channel', async () => {
       gatedAgents = new Set([ALICE])
       channels = []
       const orch = makeOrch()
@@ -799,7 +791,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       const aliceRow = channels.find((c) => c.integrationId === INT_A && c.channelId === 'G42')
       const bobRow = channels.find((c) => c.integrationId === INT_B && c.channelId === 'G42')
       expect(aliceRow).toMatchObject({ kind: 'mpim', trigger: 'off', agentId: ALICE })
-      expect(bobRow).toMatchObject({ kind: 'mpim', trigger: 'mention', agentId: BOB })
+      expect(bobRow).toMatchObject({ kind: 'mpim', trigger: 'off', agentId: null })
 
       ch.sends.length = 0
       aliceRow!.trigger = 'mention'
@@ -807,7 +799,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       await orch.syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
       const compiled = assign.routes.filter((r) => r.scope?.channel === 'G42')
-      // A mention rule, and none of the `auto` / slug-keyword pair an 'im' row gets.
+      // The owner and trigger match the channel-style path.
       expect(compiled).toEqual([expect.objectContaining({ agentId: ALICE, match: { kind: 'mention' } })])
     })
 
@@ -865,33 +857,22 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(ch.sends.length).toBe(before)
     })
 
-    it('an enabled gated DM row compiles a scoped auto route PLUS a scoped slug keyword (§14.3)', async () => {
+    it('an enabled gated DM row compiles one scoped auto route', async () => {
       gatedAgents = new Set([ALICE])
       channels = [channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', agentId: ALICE, trigger: 'any' })]
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
       const d42 = assign.routes.filter((r) => r.scope?.channel === 'D42')
-      expect(d42).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } }),
-          expect.objectContaining({ agentId: ALICE, match: { kind: 'keyword', value: 'alice' } })
-        ])
-      )
+      expect(d42).toEqual([expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } })])
     })
 
-    it('an enabled public DM compiles scoped auto and slug routes for every target', async () => {
+    it('an enabled public DM compiles one scoped auto route for its owner', async () => {
       channels = [channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', agentId: ALICE, trigger: 'any' })]
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
-      expect(assign.routes.filter((r) => r.scope?.channel === 'D42')).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } }),
-          expect.objectContaining({ agentId: ALICE, match: { kind: 'keyword', value: 'alice' } }),
-          // BOB has not observed the row yet, so his public default remains On.
-          expect.objectContaining({ agentId: BOB, match: { kind: 'auto' } }),
-          expect.objectContaining({ agentId: BOB, match: { kind: 'keyword', value: 'bob' } })
-        ])
-      )
+      expect(assign.routes.filter((r) => r.scope?.channel === 'D42')).toEqual([
+        expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } })
+      ])
     })
 
     it('mutes a public DM when every placed install switched it Off', async () => {

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -676,6 +676,15 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(assign.mutedChannels).toEqual(['C9'])
     })
 
+    it("mutes an enabled DM whose owner isn't placed before unscoped fallback", async () => {
+      channels = [channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', agentId: ALICE, trigger: 'any' })]
+      unplacedAgents = new Set([ALICE])
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.routes.filter((r) => r.scope?.channel === 'D42')).toEqual([])
+      expect(assign.mutedChannels).toContain('D42')
+    })
+
     // The fence covers every Off channel: dropping the route is not enough, because
     // the keyword and defaultAgentId rungs are unscoped and would hand a bare @bot to
     // a mixed bot's public default in a channel the console shows as Off.

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -677,12 +677,14 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     })
 
     it("mutes an enabled DM whose owner isn't placed before unscoped fallback", async () => {
+      gatedAgents = new Set([ALICE])
       channels = [channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', agentId: ALICE, trigger: 'any' })]
       unplacedAgents = new Set([ALICE])
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
       expect(assign.routes.filter((r) => r.scope?.channel === 'D42')).toEqual([])
       expect(assign.mutedChannels).toContain('D42')
+      expect(assign.gatedOffChannels).not.toContain('D42')
     })
 
     // The fence covers every Off channel: dropping the route is not enough, because
@@ -983,7 +985,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
 
     const slackMove = orch.setChannelAgent(BOT, 'C7', BOB)
     await reached
-    const consoleUpdate = orch.updateChannel(
+    const consoleUpdate = orch.updateConversation(
       BOT,
       'C7',
       { trigger: 'any' },

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -68,10 +68,10 @@ interface Compiled {
   defaultDaemonId?: string
   /** Members whose ingress is conversation-gated (resource-visibility.md §14). */
   gatedAgentIds: string[]
-  /** Every Off channel — the relay's subtractive fence over the rungs no missing
+  /** Every Off conversation — the relay's subtractive fence over the rungs no missing
    *  route can suppress (keyword, `defaultAgentId`, thread continuity). */
   mutedChannels: string[]
-  /** The muted channels whose owner is GATED: Off because §14 has not enabled them,
+  /** The muted conversations whose owner is GATED: Off because §14 has not enabled them,
    *  so they keep the one-time notice. Every other muted channel is silent. */
   gatedOffChannels: string[]
   /** Every membership row of the bot, read once for the compile and reused by the
@@ -95,8 +95,19 @@ export function pickConversationOwner(
   return installs.find((integration) => assigned.has(integration.agentId)) ?? installs[0]
 }
 
+export function conversationOwnerRow(
+  owner: IntegrationRecord | undefined,
+  rows: IntegrationChannelRecord[]
+): IntegrationChannelRecord | undefined {
+  return owner
+    ? (rows.find((row) => row.agentId === owner.agentId) ??
+        rows.find((row) => row.integrationId === owner.id) ??
+        rows[0])
+    : undefined
+}
+
 export class HttpBotOrchestrator {
-  private readonly channelMutationChains = new Map<string, Promise<unknown>>()
+  private readonly conversationMutationChains = new Map<string, Promise<unknown>>()
 
   constructor(
     /** Every bot read here is `getUnscoped`: this is the orchestration trust
@@ -558,13 +569,13 @@ export class HttpBotOrchestrator {
    * agent becomes the sole owner, and the conversation trigger follows the conversation when
    * ownership changes instead of reverting to a stale per-install value.
    */
-  async updateChannel(
+  async updateConversation(
     botId: string,
     channelId: string,
     patch: { agentId?: string; trigger?: ChannelTrigger },
     options: { expectedOwnerAgentId?: string; source?: 'console' | 'slack' } = {}
   ): Promise<IntegrationChannelRecord | null> {
-    return this.serializeChannelMutation(botId, channelId, async () => {
+    return this.serializeConversationMutation(botId, channelId, async () => {
       const bot = await this.bots.getUnscoped(BotId(botId))
       if (bot?.transport !== 'http') {
         this.log.warn({ botId }, 'http-bot: update-channel for a non-http/unknown bot — ignored')
@@ -590,10 +601,7 @@ export class HttpBotOrchestrator {
         return null
       }
 
-      const currentRow = currentOwner
-        ? (rows.find((row) => row.agentId === currentOwner.agentId) ??
-          rows.find((row) => row.integrationId === currentOwner.id))
-        : undefined
+      const currentRow = conversationOwnerRow(currentOwner, rows)
       const targetAgent = options.source === 'slack' ? await this.agents.getUnscoped(owner.agentId) : null
       let updated = await this.persistConversationOwner(installs, channelId, owner, rows[0])
       const trigger =
@@ -610,7 +618,7 @@ export class HttpBotOrchestrator {
   /** The in-Slack config modal changes only the owner. A workspace user must
    * never enable a restricted agent, so that target always starts Off. */
   async setChannelAgent(botId: string, channelId: string, agentId: string): Promise<void> {
-    await this.updateChannel(botId, channelId, { agentId }, { source: 'slack' })
+    await this.updateConversation(botId, channelId, { agentId }, { source: 'slack' })
   }
 
   /** Preserve bot-scoped conversation state before an owner integration is deleted. */
@@ -626,17 +634,17 @@ export class HttpBotOrchestrator {
   /** Serialize the owner check and write per conversation. Console authorization
    * happens before this boundary and supplies the owner it authorized; a queued
    * Slack move therefore makes that Console mutation fail closed. */
-  private serializeChannelMutation<T>(botId: string, channelId: string, run: () => Promise<T>): Promise<T> {
+  private serializeConversationMutation<T>(botId: string, channelId: string, run: () => Promise<T>): Promise<T> {
     const key = `${botId}\u0000${channelId}`
-    const previous = this.channelMutationChains.get(key) ?? Promise.resolve()
+    const previous = this.conversationMutationChains.get(key) ?? Promise.resolve()
     const result = previous.then(run, run)
     const settled = result.then(
       () => undefined,
       () => undefined
     )
-    this.channelMutationChains.set(key, settled)
+    this.conversationMutationChains.set(key, settled)
     void settled.finally(() => {
-      if (this.channelMutationChains.get(key) === settled) this.channelMutationChains.delete(key)
+      if (this.conversationMutationChains.get(key) === settled) this.conversationMutationChains.delete(key)
     })
     return result
   }
@@ -705,10 +713,8 @@ export class HttpBotOrchestrator {
       const owner = pickConversationOwner(installs, conversationRows)
       if (!owner) continue
       const persistedOwner = conversationRows.some((row) => row.agentId === owner.agentId)
-      let trigger =
-        conversationRows.find((row) => row.agentId === owner.agentId)?.trigger ??
-        conversationRows.find((row) => row.integrationId === owner.id)?.trigger ??
-        conversationRows[0]?.trigger
+      const ownerRow = conversationOwnerRow(owner, conversationRows)
+      let trigger = ownerRow?.trigger
       if (!persistedOwner) {
         const ownerAgent = await this.agents.getUnscoped(owner.agentId)
         if (ownerAgent && isGatedAgent(ownerAgent)) trigger = 'off'
@@ -764,19 +770,21 @@ export class HttpBotOrchestrator {
     for (const c of chans) {
       if (c.agentId && !conversationOwner.has(c.channelId)) conversationOwner.set(c.channelId, c.agentId)
     }
-    // Off closes unscoped fallback rungs; gated ownership also enables the one-time notice.
-    const offChannels = chans.filter((c) => c.trigger === 'off')
-    const ownerGated = (channelId: string): boolean => {
-      const owner = conversationOwner.get(channelId)
-      const agent = owner ? agentById.get(owner) : undefined
-      return !!agent && isGatedAgent(agent)
-    }
-    const muted = new Set(offChannels.map((c) => c.channelId))
-    // An enabled conversation with an unplaced owner must not fall through to unscoped rungs.
+    // Off or unavailable ownership closes unscoped fallback rungs.
+    const offConversationIds = new Set(chans.filter((c) => c.trigger === 'off').map((c) => c.channelId))
+    const muted = new Set(offConversationIds)
     for (const [channelId, ownerId] of conversationOwner) {
       if (!byAgent.has(ownerId)) muted.add(channelId)
     }
-    const gatedOff = new Set([...muted].filter(ownerGated))
+    const gatedOff = new Set(
+      chans
+        .filter((c) => c.trigger === 'off')
+        .filter((c) => {
+          const agent = c.agentId ? agentById.get(c.agentId) : undefined
+          return !!agent && isGatedAgent(agent)
+        })
+        .map((c) => c.channelId)
+    )
 
     for (const c of chans) {
       if (!c.agentId) continue

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -760,7 +760,7 @@ export class HttpBotOrchestrator {
     // 1. conversation ownership (§10.1, the primary path): an observed conversation
     //    routes to one owner, respecting its trigger. Emit scoped rules first.
     const chans = await this.channels.listForBot(bot.id)
-    const conversationOwner = new Map<string, string>()
+    const conversationOwner = new Map<string, AgentId>()
     for (const c of chans) {
       if (c.agentId && !conversationOwner.has(c.channelId)) conversationOwner.set(c.channelId, c.agentId)
     }
@@ -772,6 +772,10 @@ export class HttpBotOrchestrator {
       return !!agent && isGatedAgent(agent)
     }
     const muted = new Set(offChannels.map((c) => c.channelId))
+    // An enabled conversation with an unplaced owner must not fall through to unscoped rungs.
+    for (const [channelId, ownerId] of conversationOwner) {
+      if (!byAgent.has(ownerId)) muted.add(channelId)
+    }
     const gatedOff = new Set([...muted].filter(ownerGated))
 
     for (const c of chans) {

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -1,13 +1,13 @@
 /**
  * `HttpBotOrchestrator` (shared-bot-relay.md §4.2 / §5 / §10) — the CP convergence
  * seam for HTTP-transport bots. It broadcasts each bot's ingress assignment to the
- * relay pool, compiles the ATTRIBUTED routing table (channel ownership → keyword →
+ * relay pool, compiles the ATTRIBUTED routing table (conversation ownership → keyword →
  * default agent), and delivers the send-only integration spec (wire mode `shared`)
  * to each member agent's daemon.
  *
  * It is invoked on every event that can change an HTTP bot's assignment or routes:
  * an install / uninstall, a transport or shareable toggle, a
- * per-channel default-agent change, and — for failover — a relay (re)register or
+ * per-conversation default-agent change, and — for failover — a relay (re)register or
  * sweep. Every method is idempotent: it recomputes from the DB and pushes the
  * result, so a missed push self-heals on the next call.
  *
@@ -44,7 +44,6 @@ import type {
 } from '../persistence/ports.js'
 import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 import { ControlSender, NoConnection } from './outbound.js'
-import { isDirectConversationKind } from '../persistence/ports.js'
 import { isGatedAgent, httpIntegrationToSpec } from './placement.js'
 import type { CpPlatformRegistry } from '../platforms/provider.js'
 import { AgentId, BotId, DaemonId } from '../domain/ids.js'
@@ -87,8 +86,8 @@ interface Compiled {
 }
 
 /** Resolve a persisted owner marker to its active integration, falling back to
- * the earliest active install for new or legacy ownerless channels. */
-export function pickChannelOwner(
+ * the earliest active install for new or legacy ownerless conversations. */
+export function pickConversationOwner(
   installs: IntegrationRecord[],
   rows: IntegrationChannelRecord[]
 ): IntegrationRecord | undefined {
@@ -182,7 +181,7 @@ export class HttpBotOrchestrator {
   }
 
   /**
-   * A routes-only change (a per-channel default agent, a trigger flip) on an
+   * A routes-only change (a per-conversation default agent, a trigger flip) on an
    * already-placed bot: hot-update the relay's table via `rc/routes` (no ingest
    * re-open). Falls back to a full `syncBot` if the bot isn't placed on a
    * connected relay yet.
@@ -523,11 +522,10 @@ export class HttpBotOrchestrator {
   }
 
   /**
-   * Fan an INCREMENTAL direct-conversation report across every install as an owned
-   * `kind:'im'` / `kind:'mpim'` row. Restricted installs default Off; Everyone installs
-   * default a 1:1 DM On and a group DM to Mention. The reported kind is preserved so a
-   * group DM never accidentally receives an auto rule. Idempotent; route state is
-   * recompiled because a newly observed public row is immediately active.
+   * Fan an INCREMENTAL direct-conversation report across every install as a
+   * `kind:'im'` / `kind:'mpim'` membership row. The shared bot converges the rows to
+   * one owner and trigger, just like an enumerated channel; restricted installs still
+   * start Off and public installs default a 1:1 DM On or a group DM to Mention.
    */
   async reportConversation(botId: string, conversation: ReportedChannel): Promise<void> {
     const bot = await this.bots.getUnscoped(BotId(botId))
@@ -548,7 +546,6 @@ export class HttpBotOrchestrator {
         install.id,
         { ...conversation, kind },
         {
-          agentId: AgentId(install.agentId),
           defaultTrigger: isGatedAgent(agent) ? 'off' : kind === 'im' ? 'any' : 'mention'
         }
       )
@@ -557,8 +554,8 @@ export class HttpBotOrchestrator {
   }
 
   /**
-   * Update a multi-agent channel through its bot-level ownership boundary. The selected
-   * agent becomes the sole owner, and the channel trigger follows the channel when
+   * Update a multi-agent conversation through its bot-level ownership boundary. The selected
+   * agent becomes the sole owner, and the conversation trigger follows the conversation when
    * ownership changes instead of reverting to a stale per-install value.
    */
   async updateChannel(
@@ -575,20 +572,21 @@ export class HttpBotOrchestrator {
       }
       const installs = await this.integrations.listForBot(bot.id)
       if (installs.length === 0) return null
-      const rows = (await this.channels.listForBot(bot.id)).filter(
-        (row) => row.kind === 'channel' && row.channelId === channelId
-      )
-      const currentOwner = pickChannelOwner(installs, rows)
+      const rows = (await this.channels.listForBot(bot.id)).filter((row) => row.channelId === channelId)
+      const currentOwner = pickConversationOwner(installs, rows)
       if (options.expectedOwnerAgentId && currentOwner?.agentId !== options.expectedOwnerAgentId) {
         this.log.warn(
           { botId, channelId, expectedOwnerAgentId: options.expectedOwnerAgentId },
-          'http-bot: channel owner changed before update — ignored'
+          'http-bot: conversation owner changed before update — ignored'
         )
         return null
       }
       const owner = patch.agentId ? installs.find((i) => i.agentId === patch.agentId) : currentOwner
       if (!owner) {
-        this.log.warn({ botId, agentId: patch.agentId }, 'http-bot: update-channel for a non-member agent — ignored')
+        this.log.warn(
+          { botId, agentId: patch.agentId },
+          'http-bot: update-conversation for a non-member agent — ignored'
+        )
         return null
       }
 
@@ -597,12 +595,12 @@ export class HttpBotOrchestrator {
           rows.find((row) => row.integrationId === currentOwner.id))
         : undefined
       const targetAgent = options.source === 'slack' ? await this.agents.getUnscoped(owner.agentId) : null
-      let updated = await this.persistChannelOwner(installs, channelId, owner)
+      let updated = await this.persistConversationOwner(installs, channelId, owner, rows[0])
       const trigger =
         targetAgent && isGatedAgent(targetAgent)
           ? ('off' as const)
           : (patch.trigger ?? currentRow?.trigger ?? rows[0]?.trigger ?? updated.trigger)
-      await this.syncChannelTrigger(installs, channelId, trigger, rows)
+      await this.syncConversationTrigger(installs, channelId, trigger, rows)
       updated = { ...updated, trigger }
       await this.syncRoutes(botId)
       return updated
@@ -615,17 +613,17 @@ export class HttpBotOrchestrator {
     await this.updateChannel(botId, channelId, { agentId }, { source: 'slack' })
   }
 
-  /** Preserve bot-scoped channel state before an owner integration is deleted. */
+  /** Preserve bot-scoped conversation state before an owner integration is deleted. */
   async prepareIntegrationRemoval(botId: string): Promise<void> {
     const bot = await this.bots.getUnscoped(BotId(botId))
     if (bot?.transport !== 'http') return
     const installs = await this.integrations.listForBot(bot.id)
-    await this.ensureChannelOwners(bot.id, installs)
+    await this.ensureConversationOwners(bot.id, installs)
   }
 
   // ── internals ──────────────────────────────────────────────────────────────
 
-  /** Serialize the owner check and write per channel. Console authorization
+  /** Serialize the owner check and write per conversation. Console authorization
    * happens before this boundary and supplies the owner it authorized; a queued
    * Slack move therefore makes that Console mutation fail closed. */
   private serializeChannelMutation<T>(botId: string, channelId: string, run: () => Promise<T>): Promise<T> {
@@ -644,21 +642,20 @@ export class HttpBotOrchestrator {
   }
 
   /** Store one canonical owner row and clear every sibling install's copy. */
-  private async persistChannelOwner(
+  private async persistConversationOwner(
     installs: IntegrationRecord[],
     channelId: string,
-    owner: IntegrationRecord
+    owner: IntegrationRecord,
+    template?: IntegrationChannelRecord
   ): Promise<IntegrationChannelRecord> {
     const ownerAgent = await this.agents.getUnscoped(owner.agentId)
     const defaultTrigger = ownerAgent && isGatedAgent(ownerAgent) ? ('off' as const) : undefined
-    const updated = await this.channels.upsertAgent(
-      owner.id,
-      channelId,
-      owner.agentId,
-      defaultTrigger ? { defaultTrigger } : undefined
-    )
+    const updated = await this.channels.upsertAgent(owner.id, channelId, owner.agentId, {
+      ...(defaultTrigger ? { defaultTrigger } : {}),
+      ...(template ? { kind: template.kind } : {})
+    })
     // Establish the replacement before clearing stale markers: even if a later
-    // cleanup write fails, the channel never regresses to having no owner.
+    // cleanup write fails, the conversation never regresses to having no owner.
     for (const integration of installs) {
       if (integration.id === owner.id) continue
       await this.channels.setAgent(integration.id, channelId, null)
@@ -667,10 +664,10 @@ export class HttpBotOrchestrator {
   }
 
   /** Keep the effective trigger on every active membership row, creating a
-   * missing sibling from the best available channel metadata. Ownership is
+   * missing sibling from the best available conversation metadata. Ownership is
    * canonical, but complete repeated state lets owner deletion preserve the
    * channel and trigger even before a new install reports its own snapshot. */
-  private async syncChannelTrigger(
+  private async syncConversationTrigger(
     installs: IntegrationRecord[],
     channelId: string,
     trigger: ChannelTrigger,
@@ -688,7 +685,7 @@ export class HttpBotOrchestrator {
             id: channelId,
             ...(template?.name ? { name: template.name } : {}),
             isPrivate: template?.isPrivate ?? false,
-            kind: 'channel'
+            kind: template?.kind ?? 'channel'
           },
           { defaultTrigger: trigger }
         )
@@ -698,43 +695,39 @@ export class HttpBotOrchestrator {
     }
   }
 
-  /**
-   * Converge every channel to one canonical owner. This repairs owner deletion,
-   * legacy ownerless rows, and older Web writes that stored an owner on the wrong
-   * integration. Direct rows are intentionally excluded because every install owns
-   * its own trigger.
-   */
-  private async ensureChannelOwners(botId: BotId, installs: IntegrationRecord[]): Promise<void> {
+  /** Converge every observed conversation to one canonical owner. */
+  private async ensureConversationOwners(botId: BotId, installs: IntegrationRecord[]): Promise<void> {
     if (installs.length === 0) return
-    const rows = (await this.channels.listForBot(botId)).filter((row) => row.kind === 'channel')
-    const channelIds = [...new Set(rows.map((row) => row.channelId))]
-    for (const channelId of channelIds) {
-      const channelRows = rows.filter((row) => row.channelId === channelId)
-      const owner = pickChannelOwner(installs, channelRows)
+    const rows = await this.channels.listForBot(botId)
+    const conversationIds = [...new Set(rows.map((row) => row.channelId))]
+    for (const channelId of conversationIds) {
+      const conversationRows = rows.filter((row) => row.channelId === channelId)
+      const owner = pickConversationOwner(installs, conversationRows)
       if (!owner) continue
-      const persistedOwner = channelRows.some((row) => row.agentId === owner.agentId)
+      const persistedOwner = conversationRows.some((row) => row.agentId === owner.agentId)
       let trigger =
-        channelRows.find((row) => row.agentId === owner.agentId)?.trigger ??
-        channelRows.find((row) => row.integrationId === owner.id)?.trigger ??
-        channelRows[0]?.trigger
+        conversationRows.find((row) => row.agentId === owner.agentId)?.trigger ??
+        conversationRows.find((row) => row.integrationId === owner.id)?.trigger ??
+        conversationRows[0]?.trigger
       if (!persistedOwner) {
         const ownerAgent = await this.agents.getUnscoped(owner.agentId)
         if (ownerAgent && isGatedAgent(ownerAgent)) trigger = 'off'
       }
-      const canonical = channelRows.some((row) => row.integrationId === owner.id && row.agentId === owner.agentId)
-      const conflicting = channelRows.some(
+      const canonical = conversationRows.some((row) => row.integrationId === owner.id && row.agentId === owner.agentId)
+      const conflicting = conversationRows.some(
         (row) => row.agentId !== null && (row.integrationId !== owner.id || row.agentId !== owner.agentId)
       )
-      if (!canonical || conflicting) await this.persistChannelOwner(installs, channelId, owner)
-      if (trigger !== undefined) await this.syncChannelTrigger(installs, channelId, trigger, channelRows)
+      if (!canonical || conflicting)
+        await this.persistConversationOwner(installs, channelId, owner, conversationRows[0])
+      if (trigger !== undefined) await this.syncConversationTrigger(installs, channelId, trigger, conversationRows)
     }
   }
 
-  /** Compile the attributed routing table after converging channel ownership. */
+  /** Compile the attributed routing table after converging conversation ownership. */
   private async compile(bot: BotRecord): Promise<Compiled | null> {
     const integrations = await this.integrations.listForBot(bot.id)
     if (integrations.length === 0) return null
-    await this.ensureChannelOwners(bot.id, integrations)
+    await this.ensureConversationOwners(bot.id, integrations)
     const agentById = new Map<string, AgentRecord>()
     for (const i of integrations) {
       const a = await this.agents.getUnscoped(i.agentId)
@@ -764,105 +757,27 @@ export class HttpBotOrchestrator {
     const byAgent = new Map(placed.map((p) => [p.integration.agentId, p]))
     const routes: AttributedRoute[] = []
 
-    // 1. channel ownership (§10.1, the primary path): a channel with a default agent
-    //    routes to that agent, respecting the channel's trigger (any → auto rule,
-    //    mention → mention rule). Emitted FIRST so a scoped rule wins arbitration.
+    // 1. conversation ownership (§10.1, the primary path): an observed conversation
+    //    routes to one owner, respecting its trigger. Emit scoped rules first.
     const chans = await this.channels.listForBot(bot.id)
-    const channelRows = chans.filter((c) => !isDirectConversationKind(c.kind))
-    // The channel's owning agent — the one row of the fan-out that carries it (§10.1).
-    const channelOwner = new Map<string, string>()
-    for (const c of channelRows) {
-      if (c.agentId && !channelOwner.has(c.channelId)) channelOwner.set(c.channelId, c.agentId)
+    const conversationOwner = new Map<string, string>()
+    for (const c of chans) {
+      if (c.agentId && !conversationOwner.has(c.channelId)) conversationOwner.set(c.channelId, c.agentId)
     }
-    // Off conversations split into two facts the relay needs separately.
-    //
-    // ROUTING (`mutedChannels`): every Off channel, whoever owns it. The trigger is
-    // bot-scoped — replicated across every membership row — so Off means this bot does
-    // not answer here, and a route being absent is not enough to say so: the keyword slug
-    // and `defaultAgentId` rungs are unscoped, and on a mixed bot they would hand a bare
-    // @bot to the public default in a channel the console shows as Off. Any row states
-    // the trigger, including one whose owner is not currently placed. Direct rows are
-    // per-agent: the conversation is muted only when no placed install is enabled.
-    //
-    // NOTICE (`gatedOffChannels`): of those, the ones owned by a GATED agent. Their Off
-    // is §14's fail-closed default for a conversation nobody has enabled yet, and it owns
-    // the one-time "ask an admin to enable it" reply — someone who had no way to know the
-    // agent is private must not meet a dead bot. An OPERATOR's Off says nothing: they
-    // already decided, and that advice would be the opposite of what happened. The two
-    // states share a trigger value, so only ownership tells them apart.
-    const offChannels = channelRows.filter((c) => c.trigger === 'off')
+    // Off closes unscoped fallback rungs; gated ownership also enables the one-time notice.
+    const offChannels = chans.filter((c) => c.trigger === 'off')
     const ownerGated = (channelId: string): boolean => {
-      const owner = channelOwner.get(channelId)
+      const owner = conversationOwner.get(channelId)
       const agent = owner ? agentById.get(owner) : undefined
       return !!agent && isGatedAgent(agent)
     }
     const muted = new Set(offChannels.map((c) => c.channelId))
     const gatedOff = new Set([...muted].filter(ownerGated))
 
-    // Direct rows are independent per install. Once a conversation is observed, emit
-    // scoped routes for every enabled 1:1 DM row so those controls outrank the public
-    // keyword/default fallbacks. A missing public row keeps the pre-observation default
-    // (On for a DM, Mention for a group DM); a missing restricted row stays Off.
-    const directByConversation = new Map<string, IntegrationChannelRecord[]>()
     for (const c of chans) {
-      if (!isDirectConversationKind(c.kind)) continue
-      const rows = directByConversation.get(c.channelId)
-      if (rows) rows.push(c)
-      else directByConversation.set(c.channelId, [c])
-    }
-    for (const [channelId, rows] of directByConversation) {
-      // Prefer the safer room classification if rolling reporters briefly disagree.
-      const kind = rows.some((row) => row.kind === 'mpim') ? ('mpim' as const) : ('im' as const)
-      const enabled = placed.flatMap((p) => {
-        const row = rows.find((candidate) => candidate.integrationId === p.integration.id)
-        const trigger = row?.trigger ?? (p.gated ? 'off' : kind === 'im' ? 'any' : 'mention')
-        return trigger === 'off' ? [] : [{ p, trigger }]
-      })
-      if (enabled.length === 0) {
-        muted.add(channelId)
-        if (placed.some((p) => p.gated)) gatedOff.add(channelId)
-        continue
-      }
-      // A group DM carries one shared @bot identity. Multiple identical mention routes
-      // would make relay order choose silently, so its earliest enabled install owns it.
-      const targets = kind === 'mpim' ? enabled.slice(0, 1) : enabled
-      for (const { p, trigger } of targets) {
-        const match: BindMatch = kind === 'im' || trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }
-        routes.push({
-          agentId: p.integration.agentId,
-          daemonId: p.daemonId,
-          integrationId: p.integration.id,
-          scope: { channel: channelId },
-          match
-        })
-        // A shared 1:1 DM may have several enabled installs. Emit every target's
-        // scoped slug so arbitration can evaluate it ahead of scoped auto: naming a
-        // non-default public agent still selects that agent, and gated targets use
-        // the same disambiguation.
-        if (kind === 'im') {
-          const slug = p.agent.name
-          if (slug) {
-            routes.push({
-              agentId: p.integration.agentId,
-              daemonId: p.daemonId,
-              integrationId: p.integration.id,
-              scope: { channel: channelId },
-              match: { kind: 'keyword', value: slug }
-            })
-          }
-        }
-      }
-    }
-
-    // Member channels have one bot-scoped owner and trigger.
-    for (const c of channelRows) {
       if (!c.agentId) continue
       const p = byAgent.get(c.agentId)
-      if (!p) continue // channel assigned to an agent not (yet) placed — skip
-      // Off compiles no route for ANY owner. That alone does not make the channel
-      // unreachable — `mutedChannels` above is what closes the unscoped rungs, for a
-      // gated owner just as much as an ungated one (a mixed bot's public default
-      // would otherwise answer a bare @bot in a channel the console shows as Off).
+      if (!p) continue
       if (c.trigger === 'off') continue
       const match: BindMatch = c.trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }
       routes.push({

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3480,7 +3480,7 @@ export type ChannelTrigger = 'off' | 'mention' | 'any'
 export type ConversationKind = 'channel' | 'im' | 'mpim'
 
 /** A conversation the bot was never invited to and that is never enumerated — a DM or a
- *  Slack group DM. Observation creates a visible, independently configurable row. */
+ *  Slack group DM. Observation creates a visible row for each bot membership. */
 export function isDirectConversationKind(kind: ConversationKind | undefined): boolean {
   return kind === 'im' || kind === 'mpim'
 }
@@ -3497,9 +3497,9 @@ export interface IntegrationChannelRecord {
   space: string | null
   isPrivate: boolean
   kind: ConversationKind
-  /** Repeated across shared-channel sibling rows; integration-scoped for DMs. */
+  /** Repeated across shared-bot sibling rows; per-integration for non-shared bots. */
   trigger: ChannelTrigger
-  /** Per-channel owner for a shared bot (§10.1); null on sibling non-owner rows. */
+  /** Per-conversation owner for a shared bot (§10.1); null on sibling non-owner rows. */
   agentId: AgentId | null
 }
 
@@ -3555,39 +3555,39 @@ export interface IntegrationChannelRepo {
   deleteChannel(integrationId: IntegrationId, channelId: string): Promise<boolean>
   listForIntegration(integrationId: IntegrationId): Promise<IntegrationChannelRecord[]>
   /** Incremental conversation upsert (§14.3, direct rows): create the row (kind,
-   *  name, `agentId`, `defaultTrigger`) when absent; when it exists refresh metadata
-   *  and a supplied agent attribution while preserving the operator-owned trigger. */
+   *  name, `defaultTrigger`) when absent; when it exists refresh metadata while
+   *  preserving the operator-owned trigger. */
   upsertConversation(
     integrationId: IntegrationId,
     conversation: ReportedChannel,
-    opts?: { agentId?: AgentId | null; defaultTrigger?: ChannelTrigger }
+    opts?: { defaultTrigger?: ChannelTrigger }
   ): Promise<IntegrationChannelRecord>
-  /** Channels across EVERY integration of a shared bot — the route compiler's
-   *  channel-ownership source. */
+  /** Conversations across EVERY integration of a shared bot — the route compiler's
+   *  ownership source. */
   listForBot(botId: BotId): Promise<IntegrationChannelRecord[]>
-  /** Per-channel trigger choice; returns null when the channel row doesn't exist. */
+  /** Per-conversation trigger choice; returns null when the row doesn't exist. */
   setTrigger(
     integrationId: IntegrationId,
     channelId: string,
     trigger: ChannelTrigger
   ): Promise<IntegrationChannelRecord | null>
   /** Set or clear this integration row's owner marker. The orchestrator keeps
-   *  exactly one row marked per shared channel. Returns null when missing. */
+   *  exactly one row marked per shared conversation. Returns null when missing. */
   setAgent(
     integrationId: IntegrationId,
     channelId: string,
     agentId: AgentId | null
   ): Promise<IntegrationChannelRecord | null>
-  /** Set the channel's owning agent, CREATING the row if absent. A shared bot's
-   *  ingest is on the relay, so the daemon never reports its channels — the config
-   *  modal must be able to name a channel the CP has never seen. `defaultTrigger`
+  /** Set the conversation's owning agent, CREATING the row if absent. A shared bot's
+   *  ingest is on the relay, so the daemon never reports its conversations — the config
+   *  modal must be able to name a conversation the CP has never seen. `defaultTrigger`
    *  seeds a CREATED row only ('off' for a gated owner, §14); an existing row
-   *  keeps its trigger. */
+   *  keeps its trigger. `kind` preserves observed DM/group-DM rows on backfill. */
   upsertAgent(
     integrationId: IntegrationId,
     channelId: string,
     agentId: AgentId,
-    opts?: { defaultTrigger?: ChannelTrigger }
+    opts?: { defaultTrigger?: ChannelTrigger; kind?: ConversationKind }
   ): Promise<IntegrationChannelRecord>
 }
 

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -800,7 +800,7 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
   async upsertConversation(
     integrationId: IntegrationId,
     conversation: ReportedChannel,
-    opts?: { agentId?: AgentId | null; defaultTrigger?: ChannelTrigger }
+    opts?: { defaultTrigger?: ChannelTrigger }
   ): Promise<IntegrationChannelRecord> {
     const row = await this.db.integrationChannel.upsert({
       where: { integrationId_channelId: { integrationId, channelId: conversation.id } },
@@ -814,16 +814,13 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         kind: conversation.kind ?? 'channel',
         // Restricted installs supply Off. Otherwise 1:1 DMs start On and rooms use
         // Mention, matching replaceSnapshot and the controls shown in the Console.
-        trigger: opts?.defaultTrigger ?? (conversation.kind === 'im' ? 'any' : 'mention'),
-        ...(opts?.agentId !== undefined ? { agentId: opts.agentId } : {})
+        trigger: opts?.defaultTrigger ?? (conversation.kind === 'im' ? 'any' : 'mention')
       },
-      // Refresh only a KNOWN name — a nameless re-report must not clobber a
-      // previously resolved counterpart name; trigger/agentId stay operator-owned.
+      // Refresh only known metadata; trigger/agentId stay operator-owned.
       update: {
         ...(conversation.name ? { name: conversation.name } : {}),
         ...(conversation.spaceId ? { spaceId: conversation.spaceId } : {}),
-        ...(conversation.space ? { space: conversation.space } : {}),
-        ...(opts?.agentId !== undefined ? { agentId: opts.agentId } : {})
+        ...(conversation.space ? { space: conversation.space } : {})
       }
     })
     return toChannelRecord(row)
@@ -866,7 +863,7 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
     integrationId: IntegrationId,
     channelId: string,
     agentId: AgentId,
-    opts?: { defaultTrigger?: ChannelTrigger }
+    opts?: { defaultTrigger?: ChannelTrigger; kind?: ConversationKind }
   ): Promise<IntegrationChannelRecord> {
     const row = await this.db.integrationChannel.upsert({
       where: { integrationId_channelId: { integrationId, channelId } },
@@ -874,6 +871,7 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         integrationId,
         channelId,
         agentId,
+        ...(opts?.kind ? { kind: opts.kind } : {}),
         ...(opts?.defaultTrigger ? { trigger: opts.defaultTrigger } : {})
       },
       update: { agentId }

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -811,6 +811,22 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
           name: 'deploys',
           trigger: 'mention',
           agentId: null
+        },
+        {
+          integrationId: aliceIntegration,
+          channelId: 'D1',
+          name: '@Alice',
+          kind: 'im',
+          trigger: 'off',
+          agentId: alice
+        },
+        {
+          integrationId: bobIntegration,
+          channelId: 'D1',
+          name: '@Alice',
+          kind: 'im',
+          trigger: 'any',
+          agentId: bob
         }
       ]
     })
@@ -818,11 +834,32 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
 
     let listed = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     let shared = (
-      listed.json() as Array<{ botId: string; channels: Array<{ agentId: string; trigger: string }> }>
+      listed.json() as Array<{
+        botId: string
+        channels: Array<{ channelId: string; agentId: string; trigger: string }>
+      }>
     ).filter((integration) => integration.botId === botId)
     expect(shared).toHaveLength(2)
-    expect(shared.every((integration) => integration.channels[0]?.agentId === alice)).toBe(true)
-    expect(shared.every((integration) => integration.channels[0]?.trigger === 'any')).toBe(true)
+    expect(
+      shared.every(
+        (integration) => integration.channels.find((channel) => channel.channelId === 'C1')?.agentId === alice
+      )
+    ).toBe(true)
+    expect(
+      shared.every(
+        (integration) => integration.channels.find((channel) => channel.channelId === 'C1')?.trigger === 'any'
+      )
+    ).toBe(true)
+    expect(
+      shared.every(
+        (integration) => integration.channels.find((channel) => channel.channelId === 'D1')?.agentId === alice
+      )
+    ).toBe(true)
+    expect(
+      shared.every(
+        (integration) => integration.channels.find((channel) => channel.channelId === 'D1')?.trigger === 'off'
+      )
+    ).toBe(true)
 
     const changed = await running.app.inject({
       method: 'PATCH',
@@ -841,12 +878,50 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
       trigger: 'any'
     })
 
+    await prisma.integrationChannel.delete({
+      where: { integrationId_channelId: { integrationId: bobIntegration, channelId: 'D1' } }
+    })
+    const directChanged = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${aliceIntegration}/channels/D1`,
+      payload: { agentId: bob }
+    })
+    expect(directChanged.statusCode).toBe(200)
+    expect(directChanged.json()).toMatchObject({ kind: 'im', agentId: bob, trigger: 'off' })
+
+    const directStored = await prisma.integrationChannel.findMany({
+      where: { integration: { botId }, channelId: 'D1' }
+    })
+    expect(directStored.find((channel) => channel.integrationId === aliceIntegration)?.agentId).toBeNull()
+    expect(directStored.find((channel) => channel.integrationId === bobIntegration)).toMatchObject({
+      kind: 'im',
+      agentId: bob,
+      trigger: 'off'
+    })
+
     listed = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
-    shared = (listed.json() as Array<{ botId: string; channels: Array<{ agentId: string; trigger: string }> }>).filter(
-      (integration) => integration.botId === botId
-    )
-    expect(shared.every((integration) => integration.channels[0]?.agentId === bob)).toBe(true)
-    expect(shared.every((integration) => integration.channels[0]?.trigger === 'any')).toBe(true)
+    shared = (
+      listed.json() as Array<{
+        botId: string
+        channels: Array<{ channelId: string; agentId: string; trigger: string }>
+      }>
+    ).filter((integration) => integration.botId === botId)
+    expect(
+      shared.every((integration) => integration.channels.find((channel) => channel.channelId === 'C1')?.agentId === bob)
+    ).toBe(true)
+    expect(
+      shared.every(
+        (integration) => integration.channels.find((channel) => channel.channelId === 'C1')?.trigger === 'any'
+      )
+    ).toBe(true)
+    expect(
+      shared.every((integration) => integration.channels.find((channel) => channel.channelId === 'D1')?.agentId === bob)
+    ).toBe(true)
+    expect(
+      shared.every(
+        (integration) => integration.channels.find((channel) => channel.channelId === 'D1')?.trigger === 'off'
+      )
+    ).toBe(true)
 
     const cleared = await running.app.inject({
       method: 'PATCH',

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -2,7 +2,7 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import {
-  channelOwners,
+  conversationOwners,
   groupBySpace,
   IntegrationChannelList,
   placePopover,
@@ -18,16 +18,25 @@ vi.mock('@/lib/data-context', () => ({
     setChannelAgent: vi.fn(),
     forgetChannel: vi.fn(),
     leaveConversation: vi.fn(),
-    bots: [],
-    agents: [],
-    integrations: []
+    bots: [{ id: 'bot_shared', agentIds: ['alice', 'bob'] }],
+    agents: [
+      { id: 'alice', name: 'alice', displayName: 'Alice', runtime: 'claude' },
+      { id: 'bob', name: 'bob', displayName: 'Bob', runtime: 'codex' }
+    ],
+    integrations: [
+      {
+        id: 'int_bob',
+        botId: 'bot_shared',
+        channels: [{ channelId: 'D1', name: '@Alice', kind: 'im', trigger: 'any', agentId: 'bob' }]
+      }
+    ]
   })
 }))
 
 // A shared bot fans its membership snapshot out to one integration per member
-// agent, but persists the per-channel owner on a single canonical row. Every
+// agent, but persists the per-conversation owner on a single canonical row. Every
 // member's page must therefore read ownership bot-wide, not off its own row.
-describe('channelOwners', () => {
+describe('conversationOwners', () => {
   const install = (id: string, agentId: string, channels: IntegrationChannelRow[]): IntegrationRow => ({
     id,
     agentId,
@@ -51,7 +60,7 @@ describe('channelOwners', () => {
   })
 
   it('finds an owner persisted on a different member installation', () => {
-    const owners = channelOwners('bot_shared', [
+    const owners = conversationOwners('bot_shared', [
       install('int_alice', 'alice', [chan('C-deploys', null)]),
       install('int_bob', 'bob', [chan('C-deploys', 'bob')])
     ])
@@ -59,21 +68,25 @@ describe('channelOwners', () => {
     expect(owners.get('C-deploys')).toBe('bob')
   })
 
-  it('ignores installs of other bots and direct-conversation rows', () => {
+  it('ignores installs of other bots but includes direct-conversation rows', () => {
     const other = { ...install('int_other', 'zoe', [chan('C-deploys', 'zoe')]), botId: 'bot_other' }
-    // Neither a DM nor a group DM is a channel a shared bot can hand out ownership of.
+    // DM and group DM owners use the same bot-wide projection as channels.
     const dm = install('int_dm', 'bob', [
       { ...chan('D-bob', 'bob'), kind: 'im' as const },
       { ...chan('G-team', 'bob'), kind: 'mpim' as const }
     ])
-    const owners = channelOwners('bot_shared', [other, dm, install('int_bob', 'bob', [chan('C-deploys', 'bob')])])
-    expect([...owners]).toEqual([['C-deploys', 'bob']])
+    const owners = conversationOwners('bot_shared', [other, dm, install('int_bob', 'bob', [chan('C-deploys', 'bob')])])
+    expect([...owners]).toEqual([
+      ['D-bob', 'bob'],
+      ['G-team', 'bob'],
+      ['C-deploys', 'bob']
+    ])
   })
 
   it('keeps the first explicit owner when installs disagree', () => {
     // Legacy state can leave two rows claiming a channel; the console must be
     // deterministic rather than depending on install iteration luck.
-    const owners = channelOwners('bot_shared', [
+    const owners = conversationOwners('bot_shared', [
       install('int_bob', 'bob', [chan('C-deploys', 'bob')]),
       install('int_alice', 'alice', [chan('C-deploys', 'alice')])
     ])
@@ -81,7 +94,7 @@ describe('channelOwners', () => {
   })
 
   it('reports nothing for a channel no install has claimed', () => {
-    const owners = channelOwners('bot_shared', [install('int_alice', 'alice', [chan('C-deploys', null)])])
+    const owners = conversationOwners('bot_shared', [install('int_alice', 'alice', [chan('C-deploys', null)])])
     expect(owners.has('C-deploys')).toBe(false)
   })
 })
@@ -315,5 +328,19 @@ describe('IntegrationChannelList direct rows', () => {
     expect(html).toContain('Direct messages')
     expect(html).toContain('>off</button>')
     expect(html).toContain('>on</button>')
+  })
+
+  it('renders shared-bot default dispatch for a DM', () => {
+    const html = renderToStaticMarkup(
+      createElement(IntegrationChannelList, {
+        integrationId: 'int_alice',
+        botId: 'bot_shared',
+        agentId: 'alice',
+        platform: 'slack',
+        shareable: true,
+        channels: [{ channelId: 'D1', name: '@Alice', kind: 'im', trigger: 'any', agentId: 'bob' }]
+      })
+    )
+    expect(html).toContain('Default dispatch — Bob')
   })
 })

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -440,7 +440,7 @@ function RowActions({
  * names the owner. The CP already resolves this bot-wide (GET /integrations
  * stamps the effective owner onto every install, from ALL installs including
  * ones the viewer can't see, and PATCH …/channels/:id routes ownership through
- * `httpBot.updateChannel`), so this is the client-side safety net for a row
+ * `httpBot.updateConversation`), so this is the client-side safety net for a row
  * whose owner the CP couldn't resolve — never the only thing keeping the two
  * pages agreeing. Mirrors `botChannels` in SettingsView.
  */
@@ -702,7 +702,7 @@ export function IntegrationChannelList({
                   ownership of a shared (http) conversation is bot-scoped server-side —
                   the route resolves the effective owner across every install,
                   fences on it (`expectedOwnerAgentId`) and hands the write to
-                  `httpBot.updateChannel`, so exactly one row stays canonical no
+                  `httpBot.updateConversation`, so exactly one row stays canonical no
                   matter which install the console patched. */}
               <DefaultAgentPicker
                 current={def}

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -12,8 +12,8 @@ import { chatPlatformName } from '@/lib/platform-labels'
 
 /** The per-conversation trigger toggle: a ⚡ marker followed by the segmented
  *  bar. Channels: "off" / "any message" / "@-mention" (the default, so it sits
- *  last). DM rows are binary off/on for every agent — resource-visibility.md
- *  §14. Every segment carries hover copy. */
+ *  last). DM rows are binary off/on; shared bots project that state across every
+ *  membership row. Every segment carries hover copy. */
 function TriggerToggle({
   channel,
   platform,
@@ -260,7 +260,7 @@ export const canLeaveRow = (kind: IntegrationChannelRow['kind'], platform?: stri
  *
  * Three cases hide behind "cannot leave", and they call for different sentences:
  * a Discord bot belongs to a SERVER, so the way out is the band heading above the row,
- * and naming Discord would send the operator hunting for a per-channel control that
+ * and naming Discord would send the operator hunting for a per-conversation control that
  * does not exist; a direct conversation is not somewhere the bot was ever ADDED, so
  * there is nothing to be shown out of and the row is only a listing; everything else
  * has a real membership the operator ends in the chat app.
@@ -432,7 +432,7 @@ function RowActions({
 }
 
 /**
- * Explicit per-channel owners of one bot, merged across every install of it.
+ * Explicit per-conversation owners of one bot, merged across every install of it.
  *
  * A shared bot fans its membership snapshot out to one integration per agent,
  * while the owner is persisted on a single canonical row — so the row this
@@ -444,26 +444,26 @@ function RowActions({
  * whose owner the CP couldn't resolve — never the only thing keeping the two
  * pages agreeing. Mirrors `botChannels` in SettingsView.
  */
-export function channelOwners(botId: string, integrations: IntegrationRow[]): Map<string, string> {
+export function conversationOwners(botId: string, integrations: IntegrationRow[]): Map<string, string> {
   const owners = new Map<string, string>()
   for (const i of integrations) {
     if (i.botId !== botId) continue
     for (const c of i.channels) {
-      if (isDirectConversation(c.kind) || !c.agentId || owners.has(c.channelId)) continue
+      if (!c.agentId || owners.has(c.channelId)) continue
       owners.set(c.channelId, c.agentId)
     }
   }
   return owners
 }
 
-/** Per-channel default dispatch for a SHARED bot (§10.1). Every active shared
- *  channel has exactly one owner: the agent that answers whatever the channel's
+/** Per-conversation default dispatch for a SHARED bot (§10.1). Every active shared
+ *  conversation has exactly one owner: the agent that answers whatever its
  *  routing rules don't hand to someone else.
  *
  *  The design keeps this strictly apart from the trigger toggle ("切换 default 和
  *  trigger 是两类控制，不要混一起") — a compact avatar + chevron whose popover
  *  READS the current default and offers exactly one action, claiming the channel
- *  for the agent whose page this is. Handing a channel to some third agent stays
+ *  for the agent whose page this is. Handing a conversation to some third agent stays
  *  in Settings → Bots, where the whole roster is in view. */
 function DefaultAgentPicker({
   current,
@@ -584,7 +584,7 @@ function DefaultAgentPicker({
 /**
  * The conversation rows of one integration — one row per channel the bot is in
  * (plus one row per reported direct conversation), each
- * with its trigger toggle (and, for a SHARED bot, the per-channel default-dispatch
+ * with its trigger toggle (and, for a SHARED bot, the per-conversation default-dispatch
  * popover ahead of it), closed by the "invite the bot" hint. Render inside a
  * padding-less card whose header row sits above. Demo rows (no `integrationId`)
  * are inert.
@@ -601,14 +601,14 @@ export function IntegrationChannelList({
 }: {
   integrationId?: string
   channels: IntegrationChannelRow[]
-  /** The backing bot id — resolves the member agents offered as per-channel defaults. */
+  /** The backing bot id — resolves the member agents offered as per-conversation defaults. */
   botId?: string
   /** Which platform this integration talks to. Decides what "leave" can even mean:
    *  one conversation (Slack, Telegram), a whole server (Discord), or nothing. */
   platform?: string
   /** The agent whose page this is — the "Make … default" target of the default-dispatch popover. */
   agentId?: string
-  /** When true (shared bot), show the per-channel default-agent picker. */
+  /** When true (shared bot), show the per-conversation default-agent picker. */
   shareable?: boolean
   /** Restricted-agent integration (resource-visibility.md §14): conversations are
    *  gated — new ones start off and the banner explains the gate. */
@@ -630,26 +630,26 @@ export function IntegrationChannelList({
       setError(cause instanceof Error ? cause.message : String(cause))
     }
   }, [])
-  // The agents that share this bot — the candidate per-channel defaults.
+  // The agents that share this bot — the candidate per-conversation defaults.
   const memberIds = shareable && botId ? (bots.find((b) => b.id === botId)?.agentIds ?? []) : []
   const member = (id: string): MemberAgent => {
     const a = agents.find((x) => x.id === id)
     return { id, label: a ? agentLabel(a) : id, runtime: a?.runtime ?? a?.model ?? '', icon: a?.icon }
   }
-  // The agents that share this bot. A channel's default is its explicit owner —
+  // The agents that share this bot. A conversation's default is its explicit owner —
   // this row's when the CP stamped it, else whichever sibling install of the bot
   // persists it — falling back to the earliest install, the same ordering
-  // httpBot.ts's compiler uses for a channel nobody has ever claimed.
+  // httpBot.ts's compiler uses for a conversation nobody has ever claimed.
   const members = memberIds.map(member)
-  const owners = shareable && botId ? channelOwners(botId, integrations) : undefined
+  const owners = shareable && botId ? conversationOwners(botId, integrations) : undefined
   const viewer = agentId && memberIds.includes(agentId) ? member(agentId) : undefined
   const defaultAgent = (c: IntegrationChannelRow) => {
     const explicit = c.agentId ?? owners?.get(c.channelId)
     return (explicit ? members.find((m) => m.id === explicit) : undefined) ?? members[0]
   }
   const channelRows = channels.filter((c) => !isDirectConversation(c.kind))
-  // Direct conversations are independently configurable for every agent. A 1:1 DM
-  // gets the binary Off/On control above; a group DM keeps the channel-style trigger.
+  // Direct rows keep their compact On/Off trigger control; shared bots project it
+  // bot-wide just like channels.
   const dmRows = channels.filter((c) => isDirectConversation(c.kind))
   const grouped = groupBySpace(channelRows)
   /**
@@ -684,7 +684,7 @@ export function IntegrationChannelList({
     )
   }
   const row = (c: IntegrationChannelRow) => {
-    const def = !isDirectConversation(c.kind) && shareable ? defaultAgent(c) : undefined
+    const def = shareable ? defaultAgent(c) : undefined
     return (
       <div
         key={c.channelId}
@@ -699,7 +699,7 @@ export function IntegrationChannelList({
           {def && (
             <>
               {/* The PATCH goes through THIS agent's integration on purpose:
-                  ownership of a shared (http) channel is bot-scoped server-side —
+                  ownership of a shared (http) conversation is bot-scoped server-side —
                   the route resolves the effective owner across every install,
                   fences on it (`expectedOwnerAgentId`) and hands the write to
                   `httpBot.updateChannel`, so exactly one row stays canonical no
@@ -780,9 +780,9 @@ export function IntegrationChannelList({
               where leaving is done instead. It deliberately no longer narrates the
               menu's own items: those explain themselves on screen, and repeating them
               here in different words was most of what made this card read oddly. */}
-          {`A ${roomNoun(platform)} appears here once the bot is added to it, and its trigger is set per ${roomNoun(platform)}.`}
+          {`A ${roomNoun(platform)} appears here once the bot is added to it, and its trigger is set per conversation.`}
           {' Direct messages appear when someone writes to the bot.'}
-          {shareable && ' Default dispatch is the agent who handles unmatched messages.'}
+          {shareable && ' Default dispatch is the agent who handles unmatched messages in the conversation.'}
           {/* The platform's own tail, when it has one: Discord's servers-not-channels
               note, Slack's remove-it-in-Slack note (which encodes an authoritative
               membership snapshot — the list updates by itself). */}

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -79,19 +79,19 @@ function botRosterRows(bots: BotDto[]): BotRosterRow[] {
   ])
 }
 
-// One merged channel row for a bot's expandable roster.
+// One merged conversation row for a bot's expandable roster.
 interface BotChannelView {
   channelId: string
   name: string
   kind: 'channel' | 'im' | 'mpim'
-  /** Effective per-channel owner; null only before legacy state converges. */
+  /** Effective per-conversation owner; null only before legacy state converges. */
   agentId: string | null
   /** Any integration whose snapshot row backs this channel; ownership PATCHes
    *  are bot-scoped. */
   integrationId: string | null
 }
 
-// The bot's channel roster, merged across its installs (a shared bot fans out to
+// The bot's conversation roster, merged across its installs (a shared bot fans out to
 // one integration per agent, each reporting its own membership snapshot).
 function botChannels(bot: BotDto, integrations: IntegrationRow[]): BotChannelView[] {
   const merged = new Map<string, BotChannelView>()
@@ -123,12 +123,11 @@ function botChannels(bot: BotDto, integrations: IntegrationRow[]): BotChannelVie
   })
 }
 
-/** Per-channel default dispatch for a SHARED bot (design: the Bots card's
- *  expanded channel rows) — the agent a channel's unmatched messages go to.
+/** Per-conversation default dispatch for a SHARED bot — the agent a conversation's
+ *  unmatched messages go to.
  *  Shows the current one and opens a menu of every agent installed on the bot;
- *  picking one PATCHes the channel's explicit owner. This is the full-roster
- *  picker: the agent page's own popover (IntegrationChannelList) only claims the
- *  channel for the agent being viewed. */
+ *  picking one PATCHes the conversation's explicit owner. This is the full-roster
+ *  picker: the agent page's own popover only claims it for the agent being viewed. */
 function DefaultDispatchPicker({
   options,
   activeId,
@@ -153,7 +152,7 @@ function DefaultDispatchPicker({
     <span className="relative justify-self-end" onClick={(e) => e.stopPropagation()}>
       <button
         onClick={() => !disabled && setOpen((v) => !v)}
-        title="Default dispatch — the agent this channel's unmatched messages go to"
+        title="Default dispatch — the agent this conversation's unmatched messages go to"
         className={`flex items-center gap-2 rounded-[7px] border-0 bg-transparent px-[5px] py-1 hover:bg-(--surface-hover) ${
           disabled ? 'cursor-default' : 'cursor-pointer'
         } ${saving ? 'opacity-60' : ''}`}
@@ -444,8 +443,7 @@ function BotsCard({
           const free = b.agentIds.length === 0
           const open = openBotId === b.id
           const channels = open ? botChannels(b, integrations) : []
-          const hasChannelRows = channels.some((c) => c.kind === 'channel')
-          const showDefaultDispatch = b.shareable && hasChannelRows
+          const showDefaultDispatch = b.shareable && channels.length > 0
           const chanGrid = showDefaultDispatch ? 'grid-cols-[1fr_auto]' : 'grid-cols-[1fr]'
           // The picker's choices: every agent installed on the bot.
           const agentOptions = b.agentIds.map((id) => {
@@ -599,7 +597,7 @@ function BotsCard({
                                   {isDirectConversation(c.kind) ? c.name.replace(/^@+/, '') : c.name}
                                 </span>
                               </span>
-                              {showDefaultDispatch && c.kind === 'channel' && (
+                              {showDefaultDispatch && (
                                 <DefaultDispatchPicker
                                   options={agentOptions}
                                   activeId={c.agentId ?? b.agentIds[0] ?? null}
@@ -614,7 +612,7 @@ function BotsCard({
                     </>
                   ) : (
                     <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-                      Not in any channel yet — invite the bot to a channel and it shows up here.
+                      No conversations observed yet — invite the bot to a channel or message it directly.
                     </div>
                   )}
                 </div>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -820,7 +820,7 @@ export interface IntegrationChannelDto {
   isPrivate: boolean
   kind: 'channel' | 'im' | 'mpim'
   trigger: ChannelTrigger
-  agentId: string | null // effective shared-channel owner; null before convergence / when not applicable
+  agentId: string | null // effective shared-conversation owner; null before convergence / when not applicable
 }
 
 // `/integrations` list/create row — control-plane metadata only, NEVER tokens.
@@ -3755,7 +3755,7 @@ export async function fetchHookRuns(id: string, orgId?: string): Promise<HookRun
   return apiGet<HookRunDto[]>(`${orgBase(orgId)}/hooks/${encodeURIComponent(id)}/runs`)
 }
 
-// Per-channel trigger choice (`PATCH /integrations/:id/channels/:channelId`). The CP
+// Per-conversation trigger choice (`PATCH /integrations/:id/channels/:channelId`). The CP
 // persists it and pushes the integration's recomputed bind rules to the owning daemon.
 export async function updateIntegrationChannel(
   integrationId: string,

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -209,9 +209,9 @@ interface ConsoleData {
   createGithubHook: (input: CreateGithubHookInput) => Promise<CreatedHookDto>
   /** Delete a hook (its ingress URL dies with it), then invalidate its agent's hook cache. */
   deleteHook: (id: string, agentId?: string | null) => Promise<void>
-  /** Per-channel trigger choice (PATCH), applied to the local row on success. */
+  /** Per-conversation trigger choice (PATCH), applied to the local row on success. */
   setChannelTrigger: (integrationId: string, channelId: string, trigger: ChannelTrigger) => Promise<void>
-  /** Per-channel default agent for a shared bot (PATCH), applied locally. */
+  /** Per-conversation default agent for a shared bot (PATCH), applied locally. */
   setChannelAgent: (integrationId: string, channelId: string, agentId: string) => Promise<void>
   /** Forget a conversation row without touching the platform. */
   forgetChannel: (integrationId: string, channelId: string) => Promise<void>
@@ -1218,8 +1218,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     [mutateSkillSources]
   )
 
-  // Flip one conversation's trigger. Shared channels project bot-wide; direct rows
-  // remain integration-scoped. Avoid a full re-pull so the toggle does not flash.
+  // Flip one conversation's trigger. Shared bots project it bot-wide. Avoid a full
+  // re-pull so the toggle does not flash.
   const setChannelTrigger = useCallback(
     async (integrationId: string, channelId: string, trigger: ChannelTrigger) => {
       await apiUpdateIntegrationChannel(integrationId, channelId, { trigger })
@@ -1228,9 +1228,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
           (rows) => {
             const source = rows?.find((row) => row.id === integrationId)
             if (!rows || !source) return rows
-            const channel = source.channels.find((item) => item.channelId === channelId)
-            const botWide =
-              channel?.kind === 'channel' && realBots.some((bot) => bot.id === source.botId && bot.shareable)
+            const botWide = realBots.some((bot) => bot.id === source.botId && bot.shareable)
             return rows.map((row) =>
               (botWide ? row.botId === source.botId : row.id === integrationId)
                 ? {
@@ -1303,7 +1301,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     [dropChannelsFromCache, integrations]
   )
 
-  // Set a shared channel's sole owner. The API projects the effective bot-level
+  // Set a shared conversation's sole owner. The API projects the effective bot-level
   // state onto every integration copy, so keep those cached copies in sync.
   const setChannelAgent = useCallback(
     async (integrationId: string, channelId: string, agentId: string) => {

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1717,7 +1717,7 @@ export interface IntegrationChannelRow {
   /** 'im' = a DM conversation row, 'mpim' = a Slack group DM; absent = channel. */
   kind?: 'channel' | 'im' | 'mpim'
   trigger: 'off' | 'mention' | 'any'
-  /** Effective per-channel owner for a shared bot. */
+  /** Effective per-conversation owner for a shared bot. */
   agentId?: string | null
 }
 
@@ -1736,7 +1736,7 @@ export interface IntegrationRow {
   agentId?: string
   /** The bot's identity id — needed to toggle sharing / find sibling installs. */
   botId?: string
-  /** Whether the backing bot is shared (may serve many agents; per-channel default agents apply). */
+  /** Whether the backing bot is shared (may serve many agents; per-conversation defaults apply). */
   shareable?: boolean
   /** Discord application (client) id from the backing bot — builds the "Add to Discord" invite URL. Null/absent for non-Discord or when unknown. */
   discordAppId?: string | null


### PR DESCRIPTION
## Summary
- Treat observed Slack DMs and group DMs for shared HTTP bots like channels: one persisted default owner and one projected trigger.
- Add default-dispatch pickers for direct conversations in both Console surfaces and project sibling rows consistently.
- Preserve DM kind on owner backfill and update routing documentation and regression coverage.

## Validation
- Control Plane typecheck
- Web typecheck
- HttpBot unit tests: 61 passed
- Console IntegrationChannelList tests: 31 passed
- Shared-bot integration test: passed
- Repository pre-push eslint was blocked by the existing worktree eslint-import-resolver-typescript lookup; focused checks above passed.

Created by Codex . GPT-5