### PR TITLE
feat(daemon): add paginated Slack channel history

### DIFF
--- a/evals/games/world.ts
+++ b/evals/games/world.ts
@@ -268,6 +268,14 @@ export class ArenaWorld implements VirtualConnectionWorldPort {
     return { id: user, name: user, isBot: false }
   }
 
+  channelHistory(channel: string): readonly VirtualThreadMessage[] {
+    const prefix = `${channel}\u001f`
+    return [...this.history.entries()]
+      .filter(([key]) => key.startsWith(prefix))
+      .flatMap(([, messages]) => messages)
+      .sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0))
+  }
+
   // ── world log + effect stream ─────────────────────────────────────────────
 
   drainOutboundEffects(): readonly RecordedOutboundEffect[] {

--- a/evals/test/virtual-connections.test.ts
+++ b/evals/test/virtual-connections.test.ts
@@ -86,4 +86,33 @@ describe('VirtualSlackConnection — the concrete-connection surface the daemon 
     await expect(conn.getUserProfile('U-UNKNOWN')).resolves.toEqual({ id: 'U-UNKNOWN' })
     await expect(conn.downloadFile()).resolves.toBeNull()
   })
+
+  it('provides bounded channel history pages from the virtual world', async () => {
+    const { port } = worldStub({
+      channelHistory: () => [
+        { ts: '1700000000.000001', text: 'older', sender: 'U1', isBot: false },
+        { ts: '1700000000.000002', text: 'newer', sender: 'UBOT', isBot: true }
+      ]
+    })
+    const conn = new VirtualSlackConnection('int-1', { workspaceId: 'T-EVAL' }, port)
+    await expect(conn.getChannelHistory('C-KNOWN', { limit: 1 })).resolves.toEqual({
+      messages: [{ ts: '1700000000.000002', text: 'newer', sender: 'UBOT', isBot: true }],
+      hasMore: true,
+      nextCursor: '1'
+    })
+    await expect(conn.getChannelHistory('C-KNOWN', { cursor: '1', limit: 1 })).resolves.toEqual({
+      messages: [{ ts: '1700000000.000001', text: 'older', sender: 'U1', isBot: false }],
+      hasMore: false
+    })
+    const bounded = await conn.getChannelHistory('C-KNOWN', {
+      oldest: '1700000000.000001',
+      latest: '1700000000.000002'
+    })
+    expect(bounded.messages).toEqual(
+      expect.arrayContaining([
+        { ts: '1700000000.000001', text: 'older', sender: 'U1', isBot: false },
+        { ts: '1700000000.000002', text: 'newer', sender: 'UBOT', isBot: true }
+      ])
+    )
+  })
 })

--- a/packages/daemon/src/evaluation/virtual-connections.ts
+++ b/packages/daemon/src/evaluation/virtual-connections.ts
@@ -14,7 +14,12 @@
  * that authorizes — not merely records — every attempted effect.
  */
 import type { SendIdentity } from '../mcp/ops.js'
-import type { PlatformConnection } from '../platforms/contract.js'
+import type {
+  PlatformChannelHistoryMessage,
+  PlatformChannelHistoryOptions,
+  PlatformChannelHistoryPage,
+  PlatformConnection
+} from '../platforms/contract.js'
 
 /** Slack post options subset the virtual transport interprets. Structurally
  *  compatible with the real connection's `SlackPostOptions`: `chrome` marks
@@ -127,6 +132,8 @@ export interface VirtualConnectionWorldPort {
   members(channel: string): readonly VirtualMember[]
   channels(integrationId: string): readonly VirtualChannelInfo[]
   profile(user: string): VirtualProfile | undefined
+  /** Provider channel history; absent ⇒ the virtual world has no history source. */
+  channelHistory?(channel: string): readonly VirtualThreadMessage[]
   /** Provider thread history in ts order, optionally windowed — backs
    *  `getThreadReplies`. Absent ⇒ the connection reports no history adapter and
    *  the daemon degrades to observed-only rows, exactly as on a platform
@@ -356,6 +363,36 @@ export class VirtualSlackConnection implements PlatformConnection {
       chrome: message.chrome ?? false,
       attachments: [] as never[]
     }))
+  }
+
+  /** Provider channel history with the same bounded, cursor-paginated shape as Slack. */
+  async getChannelHistory(
+    channel: string,
+    options: PlatformChannelHistoryOptions = {}
+  ): Promise<PlatformChannelHistoryPage> {
+    const limit = Math.min(Math.max(options.limit ?? 100, 1), 200)
+    const offset = Math.max(Number.parseInt(options.cursor ?? '0', 10) || 0, 0)
+    const oldest = options.oldest || undefined
+    const latest = options.latest || undefined
+    const messages = [...(this.world.channelHistory?.(channel) ?? [])]
+      .filter(
+        (message) => (oldest === undefined || message.ts >= oldest) && (latest === undefined || message.ts <= latest)
+      )
+      .sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0))
+    const page = messages.slice(offset, offset + limit)
+    const nextOffset = offset + page.length
+    const nextCursor = nextOffset < messages.length ? String(nextOffset) : undefined
+    const result: PlatformChannelHistoryMessage[] = page.map((message) => ({
+      sender: message.sender,
+      ts: message.ts,
+      text: message.text,
+      isBot: message.isBot
+    }))
+    return {
+      messages: result,
+      hasMore: nextCursor !== undefined,
+      ...(nextCursor !== undefined ? { nextCursor } : {})
+    }
   }
 
   /** Ephemeral presence (assistant status) — not a message; not recorded. */

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -68,6 +68,8 @@ import {
 } from './ops/code-host.js'
 import {
   getCurrentChannel,
+  getChannelHistory,
+  GET_CHANNEL_HISTORY_ARGS,
   getUserProfile,
   GET_USER_PROFILE_ARGS,
   listChannelMembers,
@@ -180,7 +182,8 @@ const HANDLERS: Map<string, ToolHandler<OpsDeps>> = new Map<string, ToolHandler<
   ['listKnownUsers', listKnownUsers],
   ['listChannels', listChannels],
   ['listChannelMembers', listChannelMembers],
-  ['getUserProfile', getUserProfile]
+  ['getUserProfile', getUserProfile],
+  ['getChannelHistory', getChannelHistory]
 ])
 
 /**
@@ -223,6 +226,7 @@ export const TOOL_ARG_SCHEMAS: Map<string, ZodType> = new Map<string, ZodType>([
   ['listChannels', LIST_CHANNELS_ARGS],
   ['listChannelMembers', LIST_CHANNEL_MEMBERS_ARGS],
   ['getUserProfile', GET_USER_PROFILE_ARGS],
+  ['getChannelHistory', GET_CHANNEL_HISTORY_ARGS],
   // The session's own conversation is read from trusted context alone — no arguments.
   ['getCurrentChannel', z.object({})],
   // One body serves every platform's credentialed attachment read, so one schema does too.

--- a/packages/daemon/src/mcp/ops/context.ts
+++ b/packages/daemon/src/mcp/ops/context.ts
@@ -1,6 +1,7 @@
 import type { MemoryWriteSource } from '../../memory/store.js'
 import type { MemoryScope } from '../../memory/types.js'
 import type { ToolDescriptor } from '../../tool-schema/descriptor.js'
+import type { PlatformChannelHistoryOptions, PlatformChannelHistoryPage } from '../../platforms/contract.js'
 
 /**
  * The platform-neutral slice a session's tools need. `SlackConnection` and
@@ -67,6 +68,8 @@ export interface MessageGateway {
   listMembers(channel: string): Promise<{ id: string; name?: string; isBot?: boolean }[]>
   listChannels(): Promise<{ id: string; name?: string; isPrivate?: boolean }[]>
   getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }>
+  /** Read one bounded page from the conversation bound to the current session. */
+  getChannelHistory?(channel: string, options?: PlatformChannelHistoryOptions): Promise<PlatformChannelHistoryPage>
   /** Download an auth-gated file (Slack url_private / Telegram file_id) with the
    *  bot credentials; null on failure / over-cap. Backs the `read*File` tools so
    *  the agent can read attachments without ever holding the token. */

--- a/packages/daemon/src/mcp/ops/platform-reads.ts
+++ b/packages/daemon/src/mcp/ops/platform-reads.ts
@@ -6,7 +6,7 @@ import {
   resolveGatewayForPlatform,
   type GatewayDeps
 } from './gateway.js'
-import { optionalString, parseArgs, requiredString } from './args.js'
+import { optionalBoundedInt, optionalString, parseArgs, requiredString } from './args.js'
 
 const DEFAULT_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024
 
@@ -31,6 +31,14 @@ export const GET_USER_PROFILE_ARGS = z.object({
   platform: optionalString('platform'),
   integrationId: optionalString('integrationId'),
   user: requiredString('user')
+})
+
+/** `getChannelHistory` arguments; the channel is always the current context channel. */
+export const GET_CHANNEL_HISTORY_ARGS = z.object({
+  cursor: optionalString('cursor'),
+  limit: optionalBoundedInt('limit', 1, 200),
+  oldest: optionalString('oldest'),
+  latest: optionalString('latest')
 })
 
 /** Every platform's credentialed attachment read (`readSlackFile`, `readTelegramFile`, …). */
@@ -147,6 +155,31 @@ export async function getUserProfile(
   const platform = parsed.platform ?? ctx.platform
   const { gw } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   return { platform, ...(await gw.getUserProfile(parsed.user)) }
+}
+
+/** Read one bounded page from the current session's channel only. */
+export async function getChannelHistory(
+  ctx: SessionContext,
+  args: Record<string, unknown>,
+  deps: PlatformReadDeps
+): Promise<unknown> {
+  const parsed = parseArgs(GET_CHANNEL_HISTORY_ARGS, args)
+  const gw = ctx.integrationId ? deps.gatewayFor(ctx.integrationId) : undefined
+  if (!gw) throw new Error(`no live platform connection for integration ${ctx.integrationId ?? '(none)'}`)
+  if (!gw.getChannelHistory) throw new Error('channel history is unavailable on this connection')
+  const page = await gw.getChannelHistory(ctx.channel, {
+    ...(parsed.cursor ? { cursor: parsed.cursor } : {}),
+    ...(parsed.limit !== undefined ? { limit: parsed.limit } : {}),
+    ...(parsed.oldest ? { oldest: parsed.oldest } : {}),
+    ...(parsed.latest ? { latest: parsed.latest } : {})
+  })
+  return {
+    platform: ctx.platform,
+    channel: ctx.channel,
+    messages: page.messages,
+    hasMore: page.hasMore,
+    ...(page.nextCursor ? { nextCursor: page.nextCursor } : {})
+  }
 }
 
 // Any platform's CREDENTIALED attachment read (`readSlackFile`, `readTelegramFile`, …).

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -1,7 +1,12 @@
 import type { Integration } from '../agents/agent-schema.js'
 import { obj, unionOf, type ToolDescriptor } from '../tool-schema/descriptor.js'
 import { SESSION_TITLE_TOOL_NAME } from './session-title-tool.js'
-import { allAttachmentReadTools, attachmentReadToolsFor } from '../platforms/read-ports.js'
+import {
+  allAttachmentReadTools,
+  allChannelHistoryPlatforms,
+  attachmentReadToolsFor,
+  channelHistoryPlatformsFor
+} from '../platforms/read-ports.js'
 import { EXTERNAL_MEMORY_TOOL_NAMES, MEMORY_TOOLS } from '../memory/tools.js'
 import { BROKER_PIPELINE_STATUSES } from '../gitlab/broker.js'
 
@@ -360,6 +365,7 @@ function buildReadTools(platforms: string[]): ToolDescriptor[] {
     type: 'string',
     description: 'Optional. Pick a specific bot when the agent has multiple integrations on the target platform.'
   }
+  const historyPlatforms = channelHistoryPlatformsFor(platforms)
   return [
     {
       name: 'getCurrentChannel',
@@ -378,6 +384,29 @@ function buildReadTools(platforms: string[]): ToolDescriptor[] {
         'has multiple bots on the platform (history is not attributable to one bot).',
       inputSchema: obj({ platform, integrationId })
     },
+    ...(historyPlatforms.length > 0
+      ? [
+          {
+            name: 'getChannelHistory',
+            description:
+              'Read one bounded page of messages from the channel bound to this conversation. This tool is ' +
+              'intentionally limited to the current context channel and accepts no channel, platform, or ' +
+              'integration selector. Results are newest-first; pass nextCursor as cursor to continue with older ' +
+              'messages. This returns channel messages, not replies inside a thread.',
+            inputSchema: obj({
+              cursor: { type: 'string', description: 'Cursor returned by the previous page.' },
+              limit: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 200,
+                description: 'Number of messages to request, capped at 200 per page.'
+              },
+              oldest: { type: 'string', description: 'Inclusive oldest message timestamp bound.' },
+              latest: { type: 'string', description: 'Inclusive latest message timestamp bound.' }
+            })
+          }
+        ]
+      : []),
     {
       name: 'listKnownUsers',
       description:
@@ -860,7 +889,7 @@ export const ALL_TOOL_NAMES = [
       // are stable and belong in the permission auto-allow set.
       buildSendMessageTool([]),
       buildShareFileTool(),
-      ...buildReadTools([]),
+      ...buildReadTools(allChannelHistoryPlatforms()),
       // Every platform's credentialed attachment tool, whatever this agent has:
       // the auto-allow set is about NAMES, and a name a platform can inject must
       // be listed even for an agent that will never see it.

--- a/packages/daemon/src/platforms/contract.ts
+++ b/packages/daemon/src/platforms/contract.ts
@@ -106,6 +106,29 @@ export interface PlatformThreadWindow {
   readState?: { truncated: boolean }
 }
 
+/** One bounded page of channel messages from a provider history read. */
+export interface PlatformChannelHistoryMessage {
+  sender: string
+  ts: string
+  text: string
+  isBot: boolean
+  threadTs?: string
+  replyCount?: number
+}
+
+export interface PlatformChannelHistoryOptions {
+  cursor?: string
+  limit?: number
+  oldest?: string
+  latest?: string
+}
+
+export interface PlatformChannelHistoryPage {
+  messages: PlatformChannelHistoryMessage[]
+  hasMore: boolean
+  nextCursor?: string
+}
+
 /**
  * The Layer-1 contract every chat-platform connection satisfies.
  *
@@ -144,6 +167,8 @@ export interface PlatformConnection {
   downloadFile(ref: string, maxBytes?: number): Promise<Buffer | null>
 
   // ── optional facets: what core PROBES for today ──
+  /** Fetch one provider-paginated page of channel messages. */
+  getChannelHistory?(channel: string, options?: PlatformChannelHistoryOptions): Promise<PlatformChannelHistoryPage>
   /** Provider thread history — backs mid-thread context recovery. Absent ⇒ the
    *  daemon degrades to observed-only transcript rows. */
   getThreadReplies?(

--- a/packages/daemon/src/platforms/read-ports.ts
+++ b/packages/daemon/src/platforms/read-ports.ts
@@ -42,9 +42,9 @@ import { SLACK_ATTACHMENT_TOOL } from './slack/attachments.js'
 import { TELEGRAM_ATTACHMENT_TOOL } from './telegram/attachments.js'
 
 /** The optional {@link import('./contract.js').PlatformConnection} facets core
- *  branches on. Deliberately only the two this seam covers: a port earns a name
+ *  branches on. A port earns a name
  *  here when a branch retires onto it, never speculatively. */
-export type ReadPort = 'getThreadReplies' | 'openDirectMessage'
+export type ReadPort = 'getThreadReplies' | 'openDirectMessage' | 'getChannelHistory'
 
 /** Anything that MAY carry read ports: a real connection, the `MessageGateway`
  *  slice the MCP tools hold, or a duck-typed test fake. Deliberately `object`
@@ -72,6 +72,8 @@ export interface PlatformReadPorts {
    *  id to the app's own 1:1 conversation, so `sendMessage`'s `toUser` form has
    *  somewhere to post. */
   readonly openDirectMessage?: boolean
+  /** The agent-facing channel history tool backed by this platform's cursor API. */
+  readonly channelHistory?: boolean
   /** The agent-facing tool that surfaces this platform's CREDENTIALED attachment
    *  read. Present when the platform's file references cannot be fetched without
    *  the bot token, so the agent needs a tool instead of its own network access.
@@ -99,6 +101,7 @@ const READ_PORTS = new Map<string, PlatformReadPorts>([
       platform: 'slack',
       label: 'Slack',
       openDirectMessage: true,
+      channelHistory: true,
       attachmentReadTool: SLACK_ATTACHMENT_TOOL
     }
   ],
@@ -167,6 +170,17 @@ export function attachmentReadToolsFor(platforms: Iterable<string>): ToolDescrip
   return [...READ_PORTS.values()].flatMap((d) =>
     wanted.has(d.platform) && d.attachmentReadTool ? [d.attachmentReadTool] : []
   )
+}
+
+/** The platforms in the input list that expose the bounded channel-history port. */
+export function channelHistoryPlatformsFor(platforms: Iterable<string>): string[] {
+  const wanted = new Set(platforms)
+  return [...READ_PORTS.values()].filter((d) => d.channelHistory && wanted.has(d.platform)).map((d) => d.platform)
+}
+
+/** Every platform that exposes the bounded channel-history port, in registry order. */
+export function allChannelHistoryPlatforms(): string[] {
+  return [...READ_PORTS.values()].filter((d) => d.channelHistory).map((d) => d.platform)
 }
 
 /** Is `name` some platform's attachment-read tool? The MCP dispatcher runs ONE

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -27,7 +27,12 @@ import {
   type StatusBarInfo,
   type StatusModalIdentity
 } from './render.js'
-import type { InteractionActor, PlatformConnection } from '../platforms/contract.js'
+import type {
+  InteractionActor,
+  PlatformChannelHistoryOptions,
+  PlatformChannelHistoryPage,
+  PlatformConnection
+} from '../platforms/contract.js'
 
 export interface ConsolidatedGroup {
   appToken: string
@@ -392,6 +397,22 @@ export type AppLike = {
         has_more?: boolean
         response_metadata?: { next_cursor?: string }
       }>
+      history: (a: unknown) => Promise<{
+        messages?: {
+          user?: string
+          bot_id?: string
+          app_id?: string
+          bot_profile?: { app_id?: string }
+          ts?: string
+          text?: string
+          blocks?: unknown
+          attachments?: unknown
+          thread_ts?: string
+          reply_count?: number
+        }[]
+        has_more?: boolean
+        response_metadata?: { next_cursor?: string }
+      }>
     }
     users: {
       info: (a: unknown) => Promise<{ user?: SlackUserResult }>
@@ -453,6 +474,8 @@ function isRoutableMessageEvent(ev: SlackMessageEvent): boolean {
 
 /** Cap on members enriched per `listChannelMembers` call (bounds users.info fan-out). */
 const MEMBER_ENRICH_CAP = 50
+const SLACK_CHANNEL_HISTORY_DEFAULT_LIMIT = 100
+const SLACK_CHANNEL_HISTORY_MAX_LIMIT = 200
 const SLACK_FILE_ORIGIN = 'https://files.slack.com'
 
 /**
@@ -1255,6 +1278,54 @@ export class SlackConnection implements PlatformConnection {
       if (window?.throwOnError) throw err
     }
     return out
+  }
+
+  /** Fetch one bounded, cursor-paginated page of Slack channel messages. */
+  async getChannelHistory(
+    channel: string,
+    options: PlatformChannelHistoryOptions = {}
+  ): Promise<PlatformChannelHistoryPage> {
+    const limit = Math.min(
+      Math.max(options.limit ?? SLACK_CHANNEL_HISTORY_DEFAULT_LIMIT, 1),
+      SLACK_CHANNEL_HISTORY_MAX_LIMIT
+    )
+    const hasTimeBounds = Boolean(options.oldest || options.latest)
+    try {
+      const res = await this.app.client.conversations.history({
+        channel,
+        limit,
+        ...(options.cursor ? { cursor: options.cursor } : {}),
+        ...(options.oldest ? { oldest: options.oldest } : {}),
+        ...(options.latest ? { latest: options.latest } : {}),
+        ...(hasTimeBounds ? { inclusive: true } : {})
+      })
+      const nextCursor = res.response_metadata?.next_cursor?.trim() || undefined
+      const messages = (res.messages ?? []).flatMap((m) => {
+        if (!m.ts) return []
+        const appId = m.app_id ?? m.bot_profile?.app_id
+        const replyCount = typeof m.reply_count === 'number' && m.reply_count > 0 ? m.reply_count : undefined
+        return [
+          {
+            sender: m.bot_id ?? m.user ?? 'unknown',
+            ts: m.ts,
+            text: extractSlackMessageText(m),
+            isBot: Boolean(m.bot_id || appId),
+            ...(m.thread_ts ? { threadTs: m.thread_ts } : {}),
+            ...(replyCount !== undefined ? { replyCount } : {})
+          }
+        ]
+      })
+      return {
+        messages,
+        hasMore: Boolean(res.has_more || nextCursor),
+        ...(nextCursor ? { nextCursor } : {})
+      }
+    } catch (err) {
+      const code = slackApiErrorCode(err)
+      const safeCode = code && /^[a-z0-9._:-]{1,64}$/i.test(code) ? code : undefined
+      this.deps.log?.debug('slack: conversations.history failed (ch=' + channel + '): ' + (safeCode ?? 'unknown'))
+      throw new Error(safeCode ? 'Slack channel history failed: ' + safeCode : 'Slack channel history failed')
+    }
   }
 
   /**

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -437,6 +437,72 @@ describe('SlackConnection.getThreadReplies', () => {
   })
 })
 
+describe('SlackConnection.getChannelHistory', () => {
+  it('forwards the official cursor and time bounds and returns one page', async () => {
+    const history = vi.fn(async () => ({
+      messages: [
+        { ts: '100.5', user: 'U1', text: 'latest', thread_ts: '100.1', reply_count: 2 },
+        { ts: '100.4', bot_id: 'B1', text: 'bot message' }
+      ],
+      has_more: true,
+      response_metadata: { next_cursor: 'next-page' }
+    }))
+    const conn = new SlackConnection(
+      deps() as any,
+      () =>
+        ({
+          message() {},
+          event() {},
+          action() {},
+          shortcut() {},
+          client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { history } },
+          start: async () => {},
+          stop: async () => {}
+        }) as any
+    )
+
+    await expect(
+      conn.getChannelHistory('C1', { cursor: 'previous-page', limit: 2, oldest: '100.0', latest: '100.5' })
+    ).resolves.toEqual({
+      messages: [
+        { sender: 'U1', ts: '100.5', text: 'latest', isBot: false, threadTs: '100.1', replyCount: 2 },
+        { sender: 'B1', ts: '100.4', text: 'bot message', isBot: true }
+      ],
+      hasMore: true,
+      nextCursor: 'next-page'
+    })
+    expect(history).toHaveBeenCalledWith({
+      channel: 'C1',
+      cursor: 'previous-page',
+      limit: 2,
+      oldest: '100.0',
+      latest: '100.5',
+      inclusive: true
+    })
+  })
+
+  it('surfaces a bounded Slack API error code to the caller', async () => {
+    const history = vi.fn(async () => {
+      throw { data: { error: 'missing_scope' } }
+    })
+    const conn = new SlackConnection(
+      deps() as any,
+      () =>
+        ({
+          message() {},
+          event() {},
+          action() {},
+          shortcut() {},
+          client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { history } },
+          start: async () => {},
+          stop: async () => {}
+        }) as any
+    )
+
+    await expect(conn.getChannelHistory('C1')).rejects.toThrow('Slack channel history failed: missing_scope')
+  })
+})
+
 describe('SlackConnection membership events', () => {
   const fakeAppWithEvents = (
     handlers: Map<string, (a: { event: unknown }) => unknown>,

--- a/packages/daemon/test/fakes/slack-app.ts
+++ b/packages/daemon/test/fakes/slack-app.ts
@@ -56,7 +56,8 @@ export function fakeSlackAppFactory(identity: FakeSlackIdentity = {}): SlackAppF
           members: async () => ({ members: [] }),
           leave: ok,
           list: async () => ({ channels: [] }),
-          replies: async () => ({ messages: [] })
+          replies: async () => ({ messages: [] }),
+          history: async () => ({ messages: [] })
         },
         users: {
           info: async () => ({}),

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -916,6 +916,39 @@ describe('executeTool: read tools', () => {
     expect(res.members).toEqual([{ id: 'U1', name: 'alice', isBot: false }])
   })
 
+  it('reads one channel-history page and forwards Slack pagination arguments', async () => {
+    const getChannelHistory = vi.fn(async () => ({
+      messages: [{ sender: 'U1', ts: '100.5', text: 'hello', isBot: false }],
+      hasMore: true,
+      nextCursor: 'next-page'
+    }))
+    const gw = fakeGateway({ getChannelHistory })
+    const { deps: d } = deps(gw)
+
+    const res = (await executeTool(
+      ctx,
+      'getChannelHistory',
+      { cursor: 'previous-page', limit: 2, oldest: '100.0', latest: '100.5' },
+      d
+    )) as Record<string, unknown>
+
+    expect(getChannelHistory).toHaveBeenCalledWith('C_CURRENT', {
+      cursor: 'previous-page',
+      limit: 2,
+      oldest: '100.0',
+      latest: '100.5'
+    })
+    expect(res).toMatchObject({
+      platform: 'slack',
+      channel: 'C_CURRENT',
+      hasMore: true,
+      nextCursor: 'next-page'
+    })
+
+    await executeTool(ctx, 'getChannelHistory', { channel: 'C_OTHER' }, d)
+    expect(getChannelHistory).toHaveBeenLastCalledWith('C_CURRENT', {})
+  })
+
   it('routes a read to another connected platform via the `platform` arg', async () => {
     // Slack session; agent also has a Telegram bot. Ask for Telegram channels — the
     // read must resolve the Telegram gateway, not the current Slack one.

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -66,6 +66,7 @@ describe('toolsForIntegrations', () => {
         'listChannelMembers',
         'listChannels',
         'getUserProfile',
+        'getChannelHistory',
         'readSlackFile'
       ])
     )
@@ -106,6 +107,8 @@ describe('toolsForIntegrations', () => {
     for (const n of ['listChannels', 'listChannelMembers', 'getUserProfile']) {
       expect(props(readTool([slackInt, telegramInt], n))).toHaveProperty('integrationId')
     }
+    const historyProps = props(readTool([slackInt, telegramInt], 'getChannelHistory'))
+    expect(Object.keys(historyProps).sort()).toEqual(['cursor', 'latest', 'limit', 'oldest'])
     expect(props(readTool([slackInt, telegramInt], 'listKnownUsers'))).not.toHaveProperty('integrationId')
   })
 
@@ -382,6 +385,7 @@ describe('toolsForIntegrations', () => {
         'setSessionTitle',
         'sendMessage',
         'listChannels',
+        'getChannelHistory',
         'readTelegramFile',
         'searchMemory',
         'saveMemory',

--- a/packages/daemon/test/platform-contract.test.ts
+++ b/packages/daemon/test/platform-contract.test.ts
@@ -62,6 +62,7 @@ describe('Layer-1 platform contract (§7.1)', () => {
     // (`membershipEnumeration: 'authoritative'`) and provider thread history.
     expect(has(SlackConnection, 'listBotChannels')).toBe(true)
     expect(has(SlackConnection, 'getThreadReplies')).toBe(true)
+    expect(has(SlackConnection, 'getChannelHistory')).toBe(true)
     expect(has(SlackConnection, 'openDirectMessage')).toBe(true)
     for (const ctor of [TelegramConnection, DiscordConnection, FeishuConnection]) {
       expect(has(ctor, 'listBotChannels')).toBe(false)
@@ -82,6 +83,7 @@ describe('Layer-1 platform contract (§7.1)', () => {
     // The interface was lifted FROM these, so a drift on either side breaks the
     // eval suite's ability to substitute for a real platform.
     expect(has(VirtualSlackConnection, 'getThreadReplies')).toBe(true)
+    expect(has(VirtualSlackConnection, 'getChannelHistory')).toBe(true)
     expect(has(VirtualSlackConnection, 'listBotChannels')).toBe(true)
     expect(has(VirtualSlackConnection, 'openDirectMessage')).toBe(true)
     expect(has(VirtualSlackConnection, 'leaveChannel')).toBe(true)


### PR DESCRIPTION
## Summary

- expose Slack conversations.history as a bounded daemon read port and MCP getChannelHistory tool
- forward cursor and timestamp bounds, returning hasMore and nextCursor for agent-driven pagination
- surface only bounded Slack API error codes to the agent

## Validation

- daemon typecheck
- 169 focused daemon tests passed
- Prettier check passed
- pre-push ESLint passed with two existing warnings in workspace-git-write.test.ts

Created by Codex . GPT-5