### PR TITLE
feat(cluster): upgrade an envelope daemon by moving its image

### DIFF
--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -545,9 +545,19 @@ next pass, and by the next ordinary settings write before that.
 One version, two spellings, and they must not be concatenated. npm reports
 `1.5.0`; the image is tagged with the GIT tag, `v1.5.0` — `build.yaml` refuses a
 release version that is not `vX.Y.Z(-rc.N)`. So composing a reference translates,
-and it translates the way the reference being replaced is already spelled: a tag
-carrying no `v` belongs to an install that built its own images, and a tag that
-deployment never published is not an upgrade for it.
+and the convention it translates into has to be **observed, never assumed**: only
+a tag that is itself a version demonstrates one. The org's own tag is that evidence
+when it has it; when it does not, the install's configured reference is, but only
+for the SAME repository — a convention seen on one registry says nothing about
+another's tags. With neither, the write is refused.
+
+That last case is the one worth being strict about. An envelope sitting on a
+floating tag (`latest`) tells you which image to run and nothing about spelling, so
+reading its absent `v` as "no prefix" would compose `:1.5.0` against a registry
+that publishes only `:v1.5.0` — a tag that does not exist. The pod would land in
+ImagePullBackOff, which is a worse answer than telling the caller no. A digest pin
+is refused for the neighbouring reason: it names no version either, and replacing
+it with a tag would discard an exact pin somebody chose.
 
 A refused apply is **not** a failed upgrade, and this is the one place the ordering
 matters. The row is written first, so the change is already durable and the

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -579,12 +579,28 @@ past that leaves the operation reported `failed` while the pass goes on to repla
 the pod — the same contradiction as closing it early, only deferred.
 
 So a command **abandons** the intent: the envelope is restored to the image it had,
-and failure becomes the truth rather than a description that expires. The restore is
-fenced on the revision the failed write produced, so a peer that has since edited the
-row keeps their value — and that still counts as abandoned, because what will be
-applied is theirs, not this command's. The one case that keeps the op open is the
-restore ITSELF failing: the image is then still durable and still coming, so calling
-it failed would be the very error being avoided.
+and failure becomes the truth rather than a description that expires.
+
+Two properties make that a guarantee rather than a hope. The restore is fenced on the
+**image** this command wrote, not on the settings revision — a revision moves for any
+edit at all (quota, tier, suspension), so a revision fence would decline the restore on
+a row whose image still needed it, and report success over a change the re-apply pass
+would go on to enact. And the outcome is **read back**: a conditional update that
+matched nothing is silent, so the only safe basis for closing the op is the observed
+fact that the row no longer names this command's image — restored, or replaced by a peer
+whose image is what will be applied instead.
+
+When that fact cannot be established, the op stays open and a bounded background
+recovery keeps trying, closing it only once the rollback is observed. It re-reads the op
+first and stops if it is no longer pending, so a cluster that recovered meanwhile — pod
+replaced, op settled `succeeded` — is not rolled back afterwards.
+
+What remains: a process exit between the image write and the rollback leaves a durable
+image under a pending op. If the cluster recovers within the deadline the pod arrives on
+target and the op settles `succeeded`; if it does not, the op expires failed and the
+change lands later. Closing that needs a rollback intent persisted atomically with the
+command, which is a durable-saga shape and its own change rather than a detail of this
+one.
 
 The refusals checked _before_ any write — a disabled envelope, a digest pin, an
 unusable tag, a non-version target — close the op directly, and can, because nothing

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -528,16 +528,35 @@ next pass, and by the next ordinary settings write before that.
   a machine upgrade opens: the op is armed with the epoch the image was written
   under and settles when the replacement pod registers READY on the target
   version — the fence already used for a drain-and-relaunch, and a new pod always
-  re-auths to a strictly greater epoch. Reachability is deliberately not required,
-  because rescuing a pod crash-looping on a bad image is most of the value.
-  Restart is refused with `DAEMON_CLUSTER_MANAGED`, and the console renders it
-  disabled rather than absent so an operator learns where it went.
+  re-auths to a strictly greater epoch. Arming is followed by a re-check, because
+  the replacement can reach READY inside the request: an unarmed op ignores that
+  READY on purpose, and nothing would look again, so the op would sit pending to
+  its deadline after a successful upgrade. Reachability is deliberately not
+  required, because rescuing a pod crash-looping on a bad image is most of the
+  value. Restart is refused with `DAEMON_CLUSTER_MANAGED`, and the console renders
+  it disabled rather than absent so an operator learns where it went.
 - **A boot sweep** moves the whole fleet onto the newest version the deployment's
   release channel names (`DAEMON_DIST_TAG` — `rc` on a test control plane,
   `latest` in production), which is sound because one release publishes the npm
   package and the image from one version. It runs once per boot: it is the
   catch-up for a release published while the process was down, and a timer would
   additionally fight an operator who just pinned an org.
+
+One version, two spellings, and they must not be concatenated. npm reports
+`1.5.0`; the image is tagged with the GIT tag, `v1.5.0` — `build.yaml` refuses a
+release version that is not `vX.Y.Z(-rc.N)`. So composing a reference translates,
+and it translates the way the reference being replaced is already spelled: a tag
+carrying no `v` belongs to an install that built its own images, and a tag that
+deployment never published is not an upgrade for it.
+
+A refused apply is **not** a failed upgrade, and this is the one place the ordering
+matters. The row is written first, so the change is already durable and the
+re-apply pass will push it. The request therefore reports the cluster's refusal
+(502, so an operator sees it) while leaving the op open and armed — reporting
+`failed` for a command that the next pass then executes is the one answer that
+cannot be reconciled with what the operator afterwards observes. Only the refusals
+checked _before_ any write — a disabled envelope, a digest pin, an unusable tag —
+close the op, and they can, because nothing was left behind to enact.
 
 The sweep's risk is doing too much, so it refuses three envelopes: one whose image
 names another repository than this install configured, one whose tag is not a

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -551,6 +551,15 @@ when it has it; when it does not, the install's configured reference is, but onl
 for the SAME repository — a convention seen on one registry says nothing about
 another's tags. With neither, the write is refused.
 
+The target is canonicalized before any of that, to the spelling the pod itself
+reports — npm's, since the Dockerfile strips the `v` when it stamps
+`package.json`. It has to be, because the target feeds two things that must agree:
+the image tag composed from it, and the version the replacement pod is compared
+against for the op to settle. An already-prefixed `v1.5.0` normalizes rather than
+composing `vv1.5.0`, and a dist-tag such as `latest` is refused — the daemon's own
+npm path can resolve one, but no image tag follows from it and no pod would ever
+report it, so the op could not settle even if the image existed.
+
 That last case is the one worth being strict about. An envelope sitting on a
 floating tag (`latest`) tells you which image to run and nothing about spelling, so
 reading its absent `v` as "no prefix" would compose `:1.5.0` against a registry

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -568,14 +568,31 @@ ImagePullBackOff, which is a worse answer than telling the caller no. A digest p
 is refused for the neighbouring reason: it names no version either, and replacing
 it with a tag would discard an exact pin somebody chose.
 
-A refused apply is **not** a failed upgrade, and this is the one place the ordering
-matters. The row is written first, so the change is already durable and the
-re-apply pass will push it. The request therefore reports the cluster's refusal
-(502, so an operator sees it) while leaving the op open and armed — reporting
-`failed` for a command that the next pass then executes is the one answer that
-cannot be reconciled with what the operator afterwards observes. Only the refusals
-checked _before_ any write — a disabled envelope, a digest pin, an unusable tag —
-close the op, and they can, because nothing was left behind to enact.
+A refused apply needs care, and the two callers resolve it **differently** for one
+reason: only one of them owns a deadline.
+
+The row is written first, so a refused apply leaves a change the re-apply pass will
+push anyway. For the **fleet sweep** that is the desired outcome — it has nothing
+waiting on it, so the envelope simply converges on a later pass. For a **console
+upgrade** it is not: the op expires after fifteen minutes, so a cluster unreachable
+past that leaves the operation reported `failed` while the pass goes on to replace
+the pod — the same contradiction as closing it early, only deferred.
+
+So a command **abandons** the intent: the envelope is restored to the image it had,
+and failure becomes the truth rather than a description that expires. The restore is
+fenced on the revision the failed write produced, so a peer that has since edited the
+row keeps their value — and that still counts as abandoned, because what will be
+applied is theirs, not this command's. The one case that keeps the op open is the
+restore ITSELF failing: the image is then still durable and still coming, so calling
+it failed would be the very error being avoided.
+
+The refusals checked _before_ any write — a disabled envelope, a digest pin, an
+unusable tag, a non-version target — close the op directly, and can, because nothing
+was left behind to enact.
+
+Abandoning lives with the caller rather than in the seam, which is the point worth
+keeping: the same failure is correctly durable for one and correctly rolled back for
+the other, and only the caller knows which it is.
 
 The sweep's risk is doing too much, so it refuses three envelopes: one whose image
 names another repository than this install configured, one whose tag is not a

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -315,9 +315,10 @@ _where_ the CRs live.
   deleted since the slice was listed is reconciled to that instead. The listing
   skips orgs under a live transition claim, and re-applying an unchanged spec is
   a server-side-apply no-op: no `specRevision` bump, no new resource version.
-  `spec.daemon.image` is deliberately NOT swept back to the deployment default —
-  it is pinned per org at creation, and whether a fleet-wide upgrade should move
-  it is a separate product decision.
+  `spec.daemon.image` is deliberately NOT swept back to the deployment default by
+  this pass — it is pinned per org at creation, and it moves only through the two
+  paths that mean to move it, which write the ROW and let this pass render the
+  spec from it (see "Which version an envelope daemon runs" below).
 - Enabling, disabling, and the teardown drain take a leased per-org **transition
   claim**, and it outlives the credential it was introduced for: those three
   still create and destroy one envelope from three directions. The claim is what
@@ -499,6 +500,55 @@ control plane, but the release train ships them together, which bounds it.
 The shim audience is the precedent and the counter-example: it is a constant in
 the daemon with a comment on the sandbox template asking that they be kept equal.
 That works, and it is exactly the kind of agreement an import should be carrying.
+
+#### Which version an envelope daemon runs
+
+A machine daemon's version is an npm install it can replace, so the control plane
+tells it to (`cli-daemon-split.md` §6.2) and the daemon does the work. An envelope
+daemon's version is its **container image**, so neither of those commands means
+anything: it has no install to swap and no supervisor to exit to — the daemon
+refuses both already. The version therefore moves the only way a pod's version
+can: `spec.daemon.image` is rewritten and the operator's `Recreate` rollout
+replaces the pod.
+
+The register frame carries `cluster` so the control plane knows which of the two
+a daemon is. That is deliberately **not** read off the identity binding, even
+though a bound `clusterIdentity` implies one today: the binding answers _who_ a
+daemon is, and this question is _what its lifecycle is_ — a distinction that only
+the daemon can answer, since only it knows which `SpawnDriver` it runs. The stored
+flag is OR-ed with the binding so an envelope daemon that predates the field still
+reads correctly, and the console's read model exposes one boolean.
+
+Two paths write the image, and both go **through the settings row**, never
+straight to the CR. The row is desired state, and the periodic re-apply renders
+the spec from it — so an image written onto the resource alone is reverted by the
+next pass, and by the next ordinary settings write before that.
+
+- **A console upgrade** repoints one org, tracked by the same `DaemonLifecycleOp`
+  a machine upgrade opens: the op is armed with the epoch the image was written
+  under and settles when the replacement pod registers READY on the target
+  version — the fence already used for a drain-and-relaunch, and a new pod always
+  re-auths to a strictly greater epoch. Reachability is deliberately not required,
+  because rescuing a pod crash-looping on a bad image is most of the value.
+  Restart is refused with `DAEMON_CLUSTER_MANAGED`, and the console renders it
+  disabled rather than absent so an operator learns where it went.
+- **A boot sweep** moves the whole fleet onto the newest version the deployment's
+  release channel names (`DAEMON_DIST_TAG` — `rc` on a test control plane,
+  `latest` in production), which is sound because one release publishes the npm
+  package and the image from one version. It runs once per boot: it is the
+  catch-up for a release published while the process was down, and a timer would
+  additionally fight an operator who just pinned an org.
+
+The sweep's risk is doing too much, so it refuses three envelopes: one whose image
+names another repository than this install configured, one whose tag is not a
+parseable version (a floating tag or a digest is a pin somebody chose), and one
+already at or ahead of the target. **Rolling a fleet backwards on a restart is the
+one outcome worse than staying stale.** An explicit console upgrade has no such
+guard — offering every published version is how a bad release gets rolled back.
+
+The runtime image is left alone by both. It rolls through the drain handshake
+(§3), not a pod replacement, and moving it is a separate decision from moving the
+daemon.
 
 #### Verifying the token
 

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -604,11 +604,22 @@ compensation exists to withdraw. In-request rollback and a bounded background re
 as the fast paths, but the pass is what makes it a guarantee, because it is reconstructed
 from disk and runs however long the cluster stays broken.
 
-Two rules keep it one-directional. An op becomes terminal only once its image is
-**observed** absent from the row — one still durable is left pending, because it is still
-going to be applied and that is exactly when reporting failure would be a lie. And an op
-that stopped being pending is skipped: a recovered cluster's replacement pod settles it
-`succeeded`, and compensating after that would revert an upgrade that completed.
+A rollback identifies the **write**, not the value that write produced. The forward write
+stamps the row with the operation's id (`daemonImageOwner`), and only that operation's
+compensation matches it; every other writer clears it. Without that, matching on the image
+alone would revert an identical image somebody else had written — and "somebody else" is the
+common case, not an exotic one: an operator's chosen target and the release channel's newest
+version are usually the same version, so an obligation left by a crashed command would
+silently downgrade the org the fleet sweep had just upgraded.
+
+Failing the operation and restoring the row are **one transaction, in that order**, with the
+operation's own status as the gate. Restoring first would let a concurrent READY settle it
+`succeeded` in between, leaving an operation reporting success over an image it had already
+reverted. So the op transitions first, guarded on `pending`: if that loses, someone else
+decided this operation and nothing is touched — which is also what makes a recovered
+cluster's completed upgrade safe from a late compensation. A row whose owner has changed is
+not this operation's to revert, and failing it without touching that row is then correct,
+because its own write is not what the envelope is running either way.
 
 Because the obligation decides terminality, an op carrying one is **excluded from the
 ordinary deadline sweep** and from the read model's expiry projection. Both exist to stop

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -590,17 +590,31 @@ matched nothing is silent, so the only safe basis for closing the op is the obse
 fact that the row no longer names this command's image — restored, or replaced by a peer
 whose image is what will be applied instead.
 
-When that fact cannot be established, the op stays open and a bounded background
-recovery keeps trying, closing it only once the rollback is observed. It re-reads the op
-first and stops if it is no longer pending, so a cluster that recovered meanwhile — pod
-replaced, op settled `succeeded` — is not rolled back afterwards.
+The rollback is an **obligation on the operation**, not an intention in a process. Both
+halves — the image the command asked for and the image to restore — are written onto the
+op row when it opens, BEFORE the forward write. That ordering is the whole guarantee: a
+process that dies at any point after opening leaves a record from which any later one can
+tell what happened and finish it. A crash before the write leaves an op whose image was
+never durable (nothing to undo, so it fails cleanly); a crash after it leaves one whose
+image is durable, and the obligation says what to put back.
 
-What remains: a process exit between the image write and the rollback leaves a durable
-image under a pending op. If the cluster recovers within the deadline the pod arrives on
-target and the op settles `succeeded`; if it does not, the op expires failed and the
-change lands later. Closing that needs a rollback intent persisted atomically with the
-command, which is a durable-saga shape and its own change rather than a detail of this
-one.
+Discharging it is the cluster maintenance pass, ahead of the re-apply in the same tick —
+undo before anything pushes that image again, or the pass enacts the change the
+compensation exists to withdraw. In-request rollback and a bounded background retry stay
+as the fast paths, but the pass is what makes it a guarantee, because it is reconstructed
+from disk and runs however long the cluster stays broken.
+
+Two rules keep it one-directional. An op becomes terminal only once its image is
+**observed** absent from the row — one still durable is left pending, because it is still
+going to be applied and that is exactly when reporting failure would be a lie. And an op
+that stopped being pending is skipped: a recovered cluster's replacement pod settles it
+`succeeded`, and compensating after that would revert an upgrade that completed.
+
+Because the obligation decides terminality, an op carrying one is **excluded from the
+ordinary deadline sweep** and from the read model's expiry projection. Both exist to stop
+a stuck op reading as in-flight; here they would do the opposite — report failure for a
+change still on its way. `commandImage` being non-null is what marks the difference, in
+the store and in the DTO alike.
 
 The refusals checked _before_ any write — a disabled envelope, a digest pin, an
 unusable tag, a non-version target — close the op directly, and can, because nothing

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -604,6 +604,14 @@ compensation exists to withdraw. In-request rollback and a bounded background re
 as the fast paths, but the pass is what makes it a guarantee, because it is reconstructed
 from disk and runs however long the cluster stays broken.
 
+The forward write is a **compare-and-set** on the baseline the plan read. Resolution and
+writing are separate steps — they have to be, so the obligation can be recorded between them
+— and an unconditional write across that gap would do two wrong things at once: discard
+whatever a peer wrote there, and record a baseline that a later rollback would restore over
+their value. Conditioning the write makes losing that race visible instead of destructive:
+the command closes cleanly (409, retry), and nothing was touched. The fleet sweep treats the
+same loss as a skip — the peer's value stands, and the next boot re-evaluates it.
+
 A rollback identifies the **write**, not the value that write produced. The forward write
 stamps the row with the operation's id (`daemonImageOwner`), and only that operation's
 compensation matches it; every other writer clears it. Without that, matching on the image

--- a/docs/designs/cli-daemon-split.md
+++ b/docs/designs/cli-daemon-split.md
@@ -339,6 +339,14 @@ Remote completion is determined by the later `READY` registration. Unlike a
 local `upgrade --restart`, the remote flow does not perform process-level
 automatic rollback after the old daemon exits.
 
+Neither this nor §6.1 applies to a daemon that registered `cluster: true`. Its
+version is its container image, so nothing is sent over the WebSocket: the control
+plane rewrites the image tag on that organization's `AgentConnectOrg` and the
+operator replaces the pod. The op, its arming epoch, and the `READY`-on-target
+settlement are identical — only the delivery differs. Restart is refused outright.
+See "Which version an envelope daemon runs" in
+[agentconnect-org-operator.md](agentconnect-org-operator.md).
+
 ### 6.3 Auth-time bootstrap recovery
 
 The installed daemon entry performs a bounded auth-only bootstrap check before

--- a/packages/control-plane/prisma/migrations/20260817000000_daemon_cluster_flag/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260817000000_daemon_cluster_flag/migration.sql
@@ -1,0 +1,13 @@
+-- `RegisterReq.cluster` — a daemon's own report that it runs as an operator-managed
+-- pod, so its version is its container image rather than an npm install it can
+-- replace. `clusterIdentity` already says WHO an in-cluster daemon is; this says what
+-- its lifecycle is, which is the question the console's restart/upgrade controls ask.
+-- Defaults false so every existing row reads as the machine it is until it re-registers.
+
+-- AlterTable
+ALTER TABLE "daemon" ADD COLUMN "cluster" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill: an envelope daemon already bound to a Kubernetes identity is a cluster
+-- daemon by construction, and its next register would set this anyway — do it now so a
+-- console opened before that reconnect does not offer it an npm upgrade.
+UPDATE "daemon" SET "cluster" = true WHERE "clusterIdentity" IS NOT NULL;

--- a/packages/control-plane/prisma/migrations/20260818000000_lifecycle_op_compensation/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260818000000_lifecycle_op_compensation/migration.sql
@@ -1,0 +1,19 @@
+-- A cluster daemon upgrade writes its new image to the settings row and lets the
+-- envelope re-apply pass push it, so a refused apply leaves a change that is still
+-- coming. Undoing it needs two facts that only the request held: which image it asked
+-- for, and which one to restore. Persisting them on the operation — written when it
+-- opens, before the forward write — turns that from an in-memory intention into an
+-- obligation any later process can discharge.
+--
+-- Non-null also marks an operation whose terminality belongs to the compensation pass:
+-- the ordinary deadline sweep must not report it failed while its image is still the
+-- durable desired state, because the change would then execute after the report.
+
+-- AlterTable
+ALTER TABLE "daemon_lifecycle_op" ADD COLUMN "commandImage" TEXT;
+ALTER TABLE "daemon_lifecycle_op" ADD COLUMN "rollbackImage" TEXT;
+
+-- Overdue pending operations are swept by status + deadline; the pass that discharges a
+-- compensation selects on these columns too, so index the pending ones that carry them.
+CREATE INDEX "daemon_lifecycle_op_compensation_idx" ON "daemon_lifecycle_op"("status", "deadline")
+  WHERE "commandImage" IS NOT NULL;

--- a/packages/control-plane/prisma/migrations/20260819000000_daemon_image_owner/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260819000000_daemon_image_owner/migration.sql
@@ -1,0 +1,12 @@
+-- A cluster upgrade's rollback has to identify the WRITE it is undoing, not merely the
+-- value that write produced. Identifying it by image alone is ambiguous: an operator's
+-- chosen target and the release channel's newest version are usually the SAME version, so
+-- an obligation left by a crashed command would happily revert the identical image the
+-- fleet version sweep had since written on its own — a silent downgrade.
+--
+-- This column names the lifecycle operation that wrote the current image, and only that
+-- operation's compensation matches it. Every other writer clears it, so an independent
+-- write is never mistaken for a command's.
+
+-- AlterTable
+ALTER TABLE "org_cluster_execution" ADD COLUMN "daemonImageOwner" TEXT;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -484,6 +484,15 @@ model DaemonLifecycleOp {
   deadline      DateTime                @db.Timestamptz(6) // drain+relaunch budget; a lapse closes the op `failed`
   outcome       String? // short closure detail (decline reason / "version mismatch" / "expired")
   settledAt     DateTime?               @db.Timestamptz(6) // when it left `pending`
+  // A cluster upgrade's COMPENSATION OBLIGATION, both halves. `commandImage` is the image
+  // this op asked the envelope to run; `rollbackImage` is what to restore if the op has to
+  // be undone. Written when the op opens — BEFORE the forward write — so a process that
+  // dies mid-command still leaves the obligation on disk for maintenance to discharge.
+  // Non-null therefore also MARKS an op whose terminality is the compensation pass's to
+  // decide: the ordinary deadline sweep must not fail it while its image is still durable,
+  // or the command reads failed and then executes.
+  commandImage  String?
+  rollbackImage String?
   createdAt     DateTime                @default(now()) @db.Timestamptz(6)
 
   daemon Daemon @relation(fields: [daemonId], references: [id], onDelete: Cascade)

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -373,6 +373,11 @@ model Daemon {
   /// from the org, so an envelope torn down and rebuilt presents the same identity and resolves
   /// back to this row — its placements and session history survive re-provisioning.
   clusterIdentity String? @unique
+  /// `RegisterReq.cluster` — the daemon's own report that it is an operator-managed pod, so its
+  /// version is its container image. Separate from `clusterIdentity` (which says WHO it is): this
+  /// says what its lifecycle is, and it is what the console reads to route upgrades through the
+  /// org's `AgentConnectOrg` instead of an npm command.
+  cluster       Boolean @default(false)
   attestationFp String? // 🅼 last accepted attestation digest
   capabilities  Json    @default("{}") @db.JsonB // {platforms[],runtimes[],acp,features[]}
   mcpServers    Json    @default("[]") @db.JsonB // facts/daemon-runtimes MCP-server list (FactsMcpServer[] = {name,transport}); replaced whole per frame

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2796,6 +2796,11 @@ model OrgClusterExecution {
   /// Quiesce without tearing down: daemon to zero, sandboxes drained.
   suspend              Boolean             @default(false)
   daemonImage          String
+  /// The `daemon_lifecycle_op.id` whose command wrote `daemonImage`, or null when anything
+  /// else did (a settings edit, the fleet version sweep, the first enable). It is what makes
+  /// a rollback name a WRITE rather than a value: an identical image written independently
+  /// carries no owner, so a stale obligation cannot revert somebody else's upgrade.
+  daemonImageOwner     String?
   daemonTier           String              @default("small")
   /// The daemon record the retired API-key path minted this envelope's key for.
   /// Nothing writes it any more: an in-cluster daemon authenticates with its

--- a/packages/control-plane/src/cluster/image-sync.test.ts
+++ b/packages/control-plane/src/cluster/image-sync.test.ts
@@ -53,6 +53,7 @@ class FakeRepo implements OrgClusterExecutionRepo {
       resourceName: orgId,
       suspend: false,
       daemonImage,
+      daemonImageOwner: null,
       daemonTier: 'small',
       runtimeImage: POLICY.runtimeImage,
       runtimeTiers: POLICY.runtimeTiers,
@@ -74,16 +75,6 @@ class FakeRepo implements OrgClusterExecutionRepo {
   }
 
   /** Conditional on the image, and reports what the row ends up holding. */
-  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedImage: string): Promise<string | null> {
-    const row = this.rows.get(orgId)
-    if (!row) return null
-    if (row.daemonImage === expectedImage) {
-      this.rows.set(orgId, { ...row, daemonImage, specRevision: row.specRevision + 1 })
-      return daemonImage
-    }
-    return row.daemonImage
-  }
-
   async listEnabled(): Promise<ClusterExecutionSettings[]> {
     return [...this.rows.values()].filter((r) => r.enabled).map((r) => ({ ...r }))
   }
@@ -126,7 +117,9 @@ class FakeRepo implements OrgClusterExecutionRepo {
       ...base,
       specRevision: base.specRevision + 1,
       ...(patch.suspend !== undefined ? { suspend: patch.suspend } : {}),
-      ...(patch.daemonImage !== undefined ? { daemonImage: patch.daemonImage } : {})
+      ...(patch.daemonImage !== undefined
+        ? { daemonImage: patch.daemonImage, daemonImageOwner: patch.daemonImageOwner ?? null }
+        : {})
     }
     this.rows.set(orgId, next)
     return next
@@ -154,17 +147,33 @@ class FakeApi implements OrgResourceApi {
 /** The compensation worklist plus a record of what got settled. */
 class FakeOps {
   owed: OverdueUpgradeCompensation[] = []
-  settled: { opId: string; status: string; outcome: string | null }[] = []
+  settled: string[] = []
   /** Ops a peer closed between the listing and the settle. */
   alreadyClosed = new Set<string>()
+  /** Orgs whose compensating transaction cannot run at all. */
+  failFor = new Set<string>()
+
+  constructor(private readonly rows: FakeRepo) {}
 
   async listOverdueCompensations(): Promise<OverdueUpgradeCompensation[]> {
     return [...this.owed]
   }
 
-  async settle(opId: string, status: 'succeeded' | 'failed', outcome: string | null): Promise<boolean> {
-    if (this.alreadyClosed.has(opId)) return false
-    this.settled.push({ opId, status, outcome })
+  /** The op transitions first and gates the restore, and the restore is owner-guarded —
+   *  the two properties the real transaction provides. */
+  async settleWithCompensation(input: { opId: string; orgId: string; rollbackImage: string }): Promise<boolean> {
+    if (this.failFor.has(input.orgId)) throw new Error('transaction unavailable')
+    if (this.alreadyClosed.has(input.opId)) return false
+    this.settled.push(input.opId)
+    const row = this.rows.rows.get(input.orgId)
+    if (row?.daemonImageOwner === input.opId) {
+      this.rows.rows.set(input.orgId, {
+        ...row,
+        daemonImage: input.rollbackImage,
+        daemonImageOwner: null,
+        specRevision: row.specRevision + 1
+      })
+    }
     return true
   }
 }
@@ -172,7 +181,7 @@ class FakeOps {
 function build(policy: Partial<ClusterExecutionPolicy> = {}) {
   const repo = new FakeRepo()
   const api = new FakeApi()
-  const ops = new FakeOps()
+  const ops = new FakeOps(repo)
   const service = new ClusterExecutionService(
     repo,
     api,
@@ -280,82 +289,91 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
 
   /**
    * Converging on its own is right for the fleet sweep and wrong for a command, which has a
-   * deadline it would outlive. Abandoning restores the previous image so "failed" is the
-   * truth rather than a description that expires.
+   * deadline it would outlive. Compensating restores the previous image so "failed" is the
+   * truth rather than a description that expires — and it does both in one transaction, the
+   * operation's own status gating the restore.
    */
-  it('abandons a deferred image back to the previous one', async () => {
-    const { repo, api, service } = build()
+  it('compensates a deferred image back to the previous one', async () => {
+    const { repo, api, ops, service } = build()
     repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
     api.failFor.add('acme')
-    const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
-    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred.image, deferred.previousImage)).toBe(true)
+    await service.setDaemonVersion(OrgId('acme'), '1.5.0', 'op-1').catch(() => undefined)
+
+    expect(
+      await service.compensateUpgrade(OrgId('acme'), 'op-1', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    ).toBe(true)
     expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.4.0')
+    expect(ops.settled).toEqual(['op-1'])
   })
 
   /**
-   * A peer that replaced the image owns it, so reverting blindly would discard their value.
-   * It still counts as abandoned: what will be applied is their image, not this call's, so
-   * the caller's operation is genuinely not going to happen.
+   * The race an image-only fence could not see. An operator's chosen target and the release
+   * channel's newest version are usually the SAME version, so a stale obligation matching on
+   * the value alone would revert the identical image the fleet sweep had since written on its
+   * own — a silent downgrade. Ownership is what distinguishes the write from the value.
    */
-  it('leaves a peer’s later image alone and still reports abandoned', async () => {
-    const { repo, api, service } = build()
+  it('does not revert an identical image another writer owns', async () => {
+    const { repo, ops, service } = build()
     repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
-    api.failFor.add('acme')
-    const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
-    await repo.upsert(OrgId('acme'), {} as never, {
-      daemonImage: 'registry.example.test/agentconnect/daemon:v1.7.0'
-    })
-    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred.image, deferred.previousImage)).toBe(true)
-    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.7.0')
+    // The command's own write never landed (it died first); the sweep then wrote the same
+    // version independently, so the row carries no owner.
+    await service.setDaemonVersion(OrgId('acme'), '1.5.0')
+
+    expect(
+      await service.compensateUpgrade(OrgId('acme'), 'op-1', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    ).toBe(true)
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
+    // The operation is still failed — its OWN write is not what the envelope is running.
+    expect(ops.settled).toEqual(['op-1'])
   })
 
   /**
-   * The hole a revision fence left open. Any unrelated settings edit — quota here — bumps
-   * the revision while leaving this command's image exactly where it was, so a
-   * revision-fenced restore matched nothing and reported success over a change that the
-   * re-apply pass would still enact. Fencing on the IMAGE is what closes it.
+   * An unrelated settings edit must not cost the rollback. It bumps the revision and leaves
+   * the image alone, so ownership survives it — which a revision fence could not express.
    */
-  it('still rolls back after an unrelated settings edit bumped the revision', async () => {
+  it('still compensates after an unrelated settings edit', async () => {
     const { repo, api, service } = build()
     repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
     api.failFor.add('acme')
-    const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
+    await service.setDaemonVersion(OrgId('acme'), '1.5.0', 'op-1').catch(() => undefined)
     await repo.upsert(OrgId('acme'), {} as never, { suspend: true })
 
-    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred.image, deferred.previousImage)).toBe(true)
+    expect(
+      await service.compensateUpgrade(OrgId('acme'), 'op-1', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    ).toBe(true)
     expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.4.0')
   })
 
-  // Verified, not assumed: a restore that silently matched nothing must not read as success.
-  it('reports not-abandoned when the image survives the restore', async () => {
-    const { repo, api, service } = build()
+  /**
+   * The other race: a concurrent READY settling the op `succeeded`. The op transitions FIRST
+   * and gates the restore, so a decision made elsewhere leaves the image untouched — no
+   * succeeded operation over an image that was already reverted.
+   */
+  it('touches nothing when the operation is no longer pending', async () => {
+    const { repo, api, ops, service } = build()
     repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
     api.failFor.add('acme')
-    const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
-    // A store whose conditional update lands nowhere and says nothing about it.
-    repo.restoreDaemonImage = async () => 'registry.example.test/agentconnect/daemon:v1.5.0'
-    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred.image, deferred.previousImage)).toBe(false)
+    await service.setDaemonVersion(OrgId('acme'), '1.5.0', 'op-1').catch(() => undefined)
+    ops.alreadyClosed.add('op-1')
+
+    expect(
+      await service.compensateUpgrade(OrgId('acme'), 'op-1', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    ).toBe(false)
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
   })
 
-  // The restore failing is the one case where the image really is still coming.
-  it('reports not-abandoned when the restore itself fails', async () => {
-    const { repo, api, service } = build()
+  // A transaction that cannot run changes nothing, so the obligation is still owed.
+  it('propagates a transaction failure rather than reporting success', async () => {
+    const { repo, api, ops, service } = build()
     repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
     api.failFor.add('acme')
-    const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
-    repo.restoreDaemonImage = async () => {
-      throw new Error('database unavailable')
-    }
-    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred.image, deferred.previousImage)).toBe(false)
-  })
+    await service.setDaemonVersion(OrgId('acme'), '1.5.0', 'op-1').catch(() => undefined)
+    ops.failFor.add('acme')
 
-  // The refusals above are checked BEFORE any write, which is what makes them safe to
-  // report as terminal — nothing is left behind for a later pass to enact.
-  it('writes nothing when it refuses', async () => {
-    const { repo, service } = build()
-    repo.seed('acme', INSTALL_IMAGE, false)
-    await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterEnvelopeNotEnabledError)
-    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe(INSTALL_IMAGE)
+    await expect(
+      service.compensateUpgrade(OrgId('acme'), 'op-1', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    ).rejects.toThrow()
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
   })
 })
 
@@ -496,9 +514,15 @@ describe('ClusterExecutionService.drainUpgradeCompensations', () => {
     rollbackImage: rollback
   })
 
+  /** An envelope whose row still carries the write `op-<orgId>` made. */
+  const seedOwned = (repo: FakeRepo, orgId: string, image: string): void => {
+    repo.seed(orgId, image)
+    repo.rows.set(orgId, { ...repo.rows.get(orgId)!, daemonImageOwner: `op-${orgId}` })
+  }
+
   it('restores the envelope and settles the operation failed', async () => {
     const { repo, ops, service } = build()
-    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.5.0')
+    seedOwned(repo, 'acme', 'registry.example.test/agentconnect/daemon:v1.5.0')
     ops.owed = [
       owed(
         'acme',
@@ -509,31 +533,14 @@ describe('ClusterExecutionService.drainUpgradeCompensations', () => {
 
     expect(await service.drainUpgradeCompensations()).toBe(1)
     expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.4.0')
-    expect(ops.settled).toEqual([{ opId: 'op-acme', status: 'failed', outcome: expect.any(String) }])
-  })
-
-  // The whole point: an operation whose change is still coming stays pending.
-  it('leaves an operation pending while its image is still durable', async () => {
-    const { repo, ops, service } = build()
-    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.5.0')
-    repo.restoreDaemonImage = async () => 'registry.example.test/agentconnect/daemon:v1.5.0'
-    ops.owed = [
-      owed(
-        'acme',
-        'registry.example.test/agentconnect/daemon:v1.5.0',
-        'registry.example.test/agentconnect/daemon:v1.4.0'
-      )
-    ]
-
-    expect(await service.drainUpgradeCompensations()).toBe(0)
-    expect(ops.settled).toEqual([])
+    expect(ops.settled).toEqual(['op-acme'])
   })
 
   // A peer that closed the op between the listing and here keeps its verdict — notably the
   // `succeeded` a recovered cluster's replacement pod would have written.
   it('does not count an operation a peer already closed', async () => {
     const { repo, ops, service } = build()
-    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.5.0')
+    seedOwned(repo, 'acme', 'registry.example.test/agentconnect/daemon:v1.5.0')
     ops.owed = [
       owed(
         'acme',
@@ -544,17 +551,16 @@ describe('ClusterExecutionService.drainUpgradeCompensations', () => {
     ops.alreadyClosed.add('op-acme')
 
     expect(await service.drainUpgradeCompensations()).toBe(0)
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
   })
 
-  it('keeps draining past an organization it cannot restore', async () => {
+  // A transaction that cannot run leaves the obligation owed, and the pass moves on: one
+  // stuck organization must not stop the rest from being resolved.
+  it('keeps draining past an organization whose transaction fails', async () => {
     const { repo, ops, service } = build()
-    repo.seed('stuck', 'registry.example.test/agentconnect/daemon:v1.5.0')
-    repo.seed('fine', 'registry.example.test/agentconnect/daemon:v1.5.0')
-    const realRestore = repo.restoreDaemonImage.bind(repo)
-    repo.restoreDaemonImage = async (orgId, image, expected) => {
-      if (orgId === 'stuck') throw new Error('database unavailable')
-      return realRestore(orgId, image, expected)
-    }
+    seedOwned(repo, 'stuck', 'registry.example.test/agentconnect/daemon:v1.5.0')
+    seedOwned(repo, 'fine', 'registry.example.test/agentconnect/daemon:v1.5.0')
+    ops.failFor.add('stuck')
     ops.owed = [
       owed(
         'stuck',
@@ -569,6 +575,7 @@ describe('ClusterExecutionService.drainUpgradeCompensations', () => {
     ]
 
     expect(await service.drainUpgradeCompensations()).toBe(1)
-    expect(ops.settled.map((s) => s.opId)).toEqual(['op-fine'])
+    expect(ops.settled).toEqual(['op-fine'])
+    expect((await repo.get(OrgId('stuck')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
   })
 })

--- a/packages/control-plane/src/cluster/image-sync.test.ts
+++ b/packages/control-plane/src/cluster/image-sync.test.ts
@@ -14,6 +14,7 @@ import {
   ClusterEnvelopeNotEnabledError,
   ClusterExecutionService,
   ClusterImageNotVersionedError,
+  ClusterImageSupersededError,
   ClusterImageWriteDeferredError,
   ClusterVersionNotPublishedError,
   type ClusterExecutionPolicy
@@ -75,6 +76,19 @@ class FakeRepo implements OrgClusterExecutionRepo {
   }
 
   /** Conditional on the image, and reports what the row ends up holding. */
+  /** Compare-and-set, like the repo's conditional UPDATE. */
+  async claimDaemonImage(
+    orgId: OrgId,
+    daemonImage: string,
+    owner: string | null,
+    expectedImage: string
+  ): Promise<boolean> {
+    const row = this.rows.get(orgId)
+    if (!row || row.daemonImage !== expectedImage) return false
+    this.rows.set(orgId, { ...row, daemonImage, daemonImageOwner: owner, specRevision: row.specRevision + 1 })
+    return true
+  }
+
   async listEnabled(): Promise<ClusterExecutionSettings[]> {
     return [...this.rows.values()].filter((r) => r.enabled).map((r) => ({ ...r }))
   }
@@ -377,6 +391,30 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
   })
 })
 
+describe('ClusterExecutionService.applyDaemonVersion', () => {
+  /**
+   * The lost update the split plan/write seam allowed. The baseline is read before the
+   * operation opens, so an unconditional write would both discard whatever landed in that gap
+   * and record a baseline a later rollback would restore over it.
+   */
+  it('refuses when the image moved since the plan was resolved', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    const plan = await service.planDaemonVersion(OrgId('acme'), '1.5.0')
+    // A peer writes in the gap between resolving and applying.
+    await repo.upsert(OrgId('acme'), {} as never, {
+      daemonImage: 'registry.example.test/agentconnect/daemon:v1.6.0'
+    })
+
+    await expect(service.applyDaemonVersion(OrgId('acme'), plan, 'op-1')).rejects.toThrow(ClusterImageSupersededError)
+    // Neither overwritten nor mis-owned: the peer's value stands, untouched.
+    const row = (await repo.get(OrgId('acme')))!
+    expect(row.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.6.0')
+    expect(row.daemonImageOwner).toBeNull()
+    expect(api.applied).toHaveLength(0)
+  })
+})
+
 describe('ClusterExecutionService.alignDaemonVersion', () => {
   it('moves only the envelopes that are behind', async () => {
     const { repo, api, service } = build()
@@ -431,12 +469,36 @@ describe('ClusterExecutionService.alignDaemonVersion', () => {
   it('records an envelope whose row could not be written as failed', async () => {
     const { repo, service } = build()
     repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
-    repo.upsert = async () => {
+    repo.claimDaemonImage = async () => {
       throw new Error('database unavailable')
     }
     const sweep = await service.alignDaemonVersion('1.5.0')
     expect(sweep.moved).toEqual([])
     expect(sweep.failed.map((f) => f.orgId)).toEqual(['acme'])
+  })
+
+  /**
+   * A peer wrote the envelope between this pass reading it and writing. Their value stands:
+   * the write is conditional on the baseline the pass captured, so losing costs nothing
+   * instead of discarding what they wrote.
+   */
+  it('skips an envelope a peer wrote while the pass was working', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    const claim = repo.claimDaemonImage.bind(repo)
+    repo.claimDaemonImage = async (orgId, image, owner, expected) => {
+      // Stand in for the peer landing in exactly that gap.
+      const row = repo.rows.get(orgId)!
+      repo.rows.set(orgId, { ...row, daemonImage: 'registry.example.test/agentconnect/daemon:v1.6.0' })
+      return claim(orgId, image, owner, expected)
+    }
+
+    const sweep = await service.alignDaemonVersion('1.5.0')
+    expect(sweep.moved).toEqual([])
+    expect(sweep.failed).toEqual([])
+    expect(sweep.skipped).toBe(1)
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.6.0')
+    expect(api.applied).toHaveLength(0)
   })
 })
 

--- a/packages/control-plane/src/cluster/image-sync.test.ts
+++ b/packages/control-plane/src/cluster/image-sync.test.ts
@@ -72,6 +72,13 @@ class FakeRepo implements OrgClusterExecutionRepo {
     return null
   }
 
+  /** Revision-fenced, like the repo's conditional UPDATE. */
+  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedRevision: number): Promise<void> {
+    const row = this.rows.get(orgId)
+    if (!row || row.specRevision !== expectedRevision) return
+    this.rows.set(orgId, { ...row, daemonImage, specRevision: row.specRevision + 1 })
+  }
+
   async listEnabled(): Promise<ClusterExecutionSettings[]> {
     return [...this.rows.values()].filter((r) => r.enabled).map((r) => ({ ...r }))
   }
@@ -243,6 +250,50 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
     await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterImageWriteDeferredError)
     // The distinguishing fact: the desired state survived the failure.
     expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
+  })
+
+  /**
+   * Converging on its own is right for the fleet sweep and wrong for a command, which has a
+   * deadline it would outlive. Abandoning restores the previous image so "failed" is the
+   * truth rather than a description that expires.
+   */
+  it('abandons a deferred image back to the previous one', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    api.failFor.add('acme')
+    const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
+    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(true)
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.4.0')
+  })
+
+  /**
+   * A peer that edited the row since owns it, so reverting blindly would discard their
+   * value. It still counts as abandoned: what will be applied is their image, not this
+   * call's, so the caller's operation is genuinely not going to happen.
+   */
+  it('leaves a peer’s later edit alone and still reports abandoned', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    api.failFor.add('acme')
+    const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
+    // A peer writes after the failed apply, bumping the revision the fence compares.
+    await repo.upsert(OrgId('acme'), {} as never, {
+      daemonImage: 'registry.example.test/agentconnect/daemon:v1.7.0'
+    })
+    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(true)
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.7.0')
+  })
+
+  // The restore failing is the one case where the image really is still coming.
+  it('reports not-abandoned when the restore itself fails', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    api.failFor.add('acme')
+    const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
+    repo.restoreDaemonImage = async () => {
+      throw new Error('database unavailable')
+    }
+    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(false)
   })
 
   // The refusals above are checked BEFORE any write, which is what makes them safe to

--- a/packages/control-plane/src/cluster/image-sync.test.ts
+++ b/packages/control-plane/src/cluster/image-sync.test.ts
@@ -14,6 +14,7 @@ import {
   ClusterEnvelopeNotEnabledError,
   ClusterExecutionService,
   ClusterImageNotVersionedError,
+  ClusterImageWriteDeferredError,
   type ClusterExecutionPolicy
 } from './service.js'
 import type { OrgResourceApi } from './org-api.js'
@@ -28,11 +29,11 @@ import type {
   PendingEnvelopeTeardown
 } from '../persistence/ports.js'
 
-const INSTALL_IMAGE = 'registry.example.test/agentconnect/daemon:1.4.0'
+const INSTALL_IMAGE = 'registry.example.test/agentconnect/daemon:v1.4.0'
 const POLICY: ClusterExecutionPolicy = {
   namespacePrefix: 'ac-org-',
   daemonImage: INSTALL_IMAGE,
-  runtimeImage: 'registry.example.test/agentconnect/runtime:1.4.0',
+  runtimeImage: 'registry.example.test/agentconnect/runtime:v1.4.0',
   daemonTier: 'small',
   runtimeTiers: [{ name: 'small', warmReplicas: 0 }],
   controlPlaneUrl: 'wss://api.example.test/daemon/ws'
@@ -157,21 +158,21 @@ const appliedImage = (api: FakeApi, name: string): string | undefined =>
 describe('ClusterExecutionService.setDaemonVersion', () => {
   it('rewrites the tag and applies the CR', async () => {
     const { repo, api, service } = build()
-    repo.seed('acme', 'registry.example.test/agentconnect/daemon:1.4.0')
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
     const image = await service.setDaemonVersion(OrgId('acme'), '1.5.0')
-    expect(image).toBe('registry.example.test/agentconnect/daemon:1.5.0')
-    expect(appliedImage(api, 'acme')).toBe('registry.example.test/agentconnect/daemon:1.5.0')
+    expect(image).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
+    expect(appliedImage(api, 'acme')).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
     // Through the row, not around it: the periodic re-apply would revert a CR-only write.
-    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:1.5.0')
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
   })
 
   // Unlike the sweep, an explicit command may move backwards — the picker offers every
   // published version, and an operator rolling back a bad release is the point.
   it('allows an explicit downgrade', async () => {
     const { repo, service } = build()
-    repo.seed('acme', 'registry.example.test/agentconnect/daemon:1.5.0')
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.5.0')
     expect(await service.setDaemonVersion(OrgId('acme'), '1.4.0')).toBe(
-      'registry.example.test/agentconnect/daemon:1.4.0'
+      'registry.example.test/agentconnect/daemon:v1.4.0'
     )
   })
 
@@ -188,29 +189,52 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
     await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterImageNotVersionedError)
     expect(api.applied).toHaveLength(0)
   })
+
+  /**
+   * An apply that fails AFTER the row was written is not a failed upgrade: the periodic
+   * re-apply renders the spec from the row, so the pod is still going to be replaced.
+   * Saying "failed" here is what would let a caller close an operation that then executes.
+   */
+  it('reports a durable write the cluster refused as deferred, not failed', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    api.failFor.add('acme')
+    await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterImageWriteDeferredError)
+    // The distinguishing fact: the desired state survived the failure.
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
+  })
+
+  // The refusals above are checked BEFORE any write, which is what makes them safe to
+  // report as terminal — nothing is left behind for a later pass to enact.
+  it('writes nothing when it refuses', async () => {
+    const { repo, service } = build()
+    repo.seed('acme', INSTALL_IMAGE, false)
+    await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterEnvelopeNotEnabledError)
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe(INSTALL_IMAGE)
+  })
 })
 
 describe('ClusterExecutionService.alignDaemonVersion', () => {
   it('moves only the envelopes that are behind', async () => {
     const { repo, api, service } = build()
-    repo.seed('behind', 'registry.example.test/agentconnect/daemon:1.4.0')
-    repo.seed('current', 'registry.example.test/agentconnect/daemon:1.5.0')
-    repo.seed('ahead', 'registry.example.test/agentconnect/daemon:1.6.0')
-    repo.seed('off', 'registry.example.test/agentconnect/daemon:1.4.0', false)
+    repo.seed('behind', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    repo.seed('current', 'registry.example.test/agentconnect/daemon:v1.5.0')
+    repo.seed('ahead', 'registry.example.test/agentconnect/daemon:v1.6.0')
+    repo.seed('off', 'registry.example.test/agentconnect/daemon:v1.4.0', false)
 
     const sweep = await service.alignDaemonVersion('1.5.0')
     expect(sweep.moved).toEqual(['behind'])
     expect(sweep.scanned).toBe(3) // the disabled envelope is not even listed
     expect(sweep.skipped).toBe(2)
-    expect(appliedImage(api, 'behind')).toBe('registry.example.test/agentconnect/daemon:1.5.0')
+    expect(appliedImage(api, 'behind')).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
     expect(appliedImage(api, 'ahead')).toBeUndefined()
-    expect((await repo.get(OrgId('ahead')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:1.6.0')
+    expect((await repo.get(OrgId('ahead')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.6.0')
   })
 
   // Somebody pointed this org at their own registry; this channel says nothing about it.
   it('leaves an envelope on another repository alone', async () => {
     const { repo, api, service } = build()
-    repo.seed('elsewhere', 'other.registry.test/fork/daemon:1.4.0')
+    repo.seed('elsewhere', 'other.registry.test/fork/daemon:v1.4.0')
     const sweep = await service.alignDaemonVersion('1.5.0')
     expect(sweep.moved).toEqual([])
     expect(api.applied).toHaveLength(0)
@@ -226,15 +250,30 @@ describe('ClusterExecutionService.alignDaemonVersion', () => {
     expect(api.applied).toHaveLength(0)
   })
 
-  it('keeps sweeping past an organization whose apply fails', async () => {
+  // Both orgs move: the one whose apply failed had its row written, and that row is what
+  // the re-apply pass renders from — so it converges without a second sweep.
+  it('counts an unappliable envelope as moved and keeps going', async () => {
     const { repo, api, service } = build()
-    repo.seed('broken', 'registry.example.test/agentconnect/daemon:1.4.0')
-    repo.seed('fine', 'registry.example.test/agentconnect/daemon:1.4.0')
+    repo.seed('broken', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    repo.seed('fine', 'registry.example.test/agentconnect/daemon:v1.4.0')
     api.failFor.add('broken')
 
     const sweep = await service.alignDaemonVersion('1.5.0')
-    expect(sweep.moved).toEqual(['fine'])
-    expect(sweep.failed.map((f) => f.orgId)).toEqual(['broken'])
+    expect(sweep.moved).toEqual(['broken', 'fine'])
+    expect(sweep.failed).toEqual([])
+    expect((await repo.get(OrgId('broken')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.5.0')
+  })
+
+  // A row that could not be written IS a failure — nothing durable, nothing to converge.
+  it('records an envelope whose row could not be written as failed', async () => {
+    const { repo, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    repo.upsert = async () => {
+      throw new Error('database unavailable')
+    }
+    const sweep = await service.alignDaemonVersion('1.5.0')
+    expect(sweep.moved).toEqual([])
+    expect(sweep.failed.map((f) => f.orgId)).toEqual(['acme'])
   })
 })
 
@@ -250,14 +289,14 @@ describe('ClusterDaemonImageSync', () => {
 
   it('sweeps the fleet onto the channel version', async () => {
     const { repo, api, service } = build()
-    repo.seed('acme', 'registry.example.test/agentconnect/daemon:1.4.0')
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
     const log = logs()
     await new ClusterDaemonImageSync(
       service,
       { resolve: async () => ({ channel: 'rc', latestVersion: '1.5.0-rc.2', availableVersions: [] }) },
       log
     ).run()
-    expect(appliedImage(api, 'acme')).toBe('registry.example.test/agentconnect/daemon:1.5.0-rc.2')
+    expect(appliedImage(api, 'acme')).toBe('registry.example.test/agentconnect/daemon:v1.5.0-rc.2')
     expect(log.entries.at(-1)).toMatchObject({ level: 'info', obj: { moved: 1, version: '1.5.0-rc.2' } })
   })
 
@@ -265,7 +304,7 @@ describe('ClusterDaemonImageSync', () => {
   // thing this must not do.
   it('touches nothing when the channel has no published version', async () => {
     const { repo, api, service } = build()
-    repo.seed('acme', 'registry.example.test/agentconnect/daemon:1.4.0')
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
     const log = logs()
     await new ClusterDaemonImageSync(
       service,

--- a/packages/control-plane/src/cluster/image-sync.test.ts
+++ b/packages/control-plane/src/cluster/image-sync.test.ts
@@ -20,13 +20,14 @@ import {
 } from './service.js'
 import type { OrgResourceApi } from './org-api.js'
 import type { AgentConnectOrg, AgentConnectOrgSpec } from './crd.js'
-import { OrgId } from '../domain/ids.js'
+import { DaemonId, OrgId } from '../domain/ids.js'
 import { systemClock } from '../domain/clock.js'
 import type {
   ClusterExecutionDefaults,
   ClusterExecutionPatch,
   ClusterExecutionSettings,
   OrgClusterExecutionRepo,
+  OverdueUpgradeCompensation,
   PendingEnvelopeTeardown
 } from '../persistence/ports.js'
 
@@ -150,18 +151,38 @@ class FakeApi implements OrgResourceApi {
   async delete(): Promise<void> {}
 }
 
+/** The compensation worklist plus a record of what got settled. */
+class FakeOps {
+  owed: OverdueUpgradeCompensation[] = []
+  settled: { opId: string; status: string; outcome: string | null }[] = []
+  /** Ops a peer closed between the listing and the settle. */
+  alreadyClosed = new Set<string>()
+
+  async listOverdueCompensations(): Promise<OverdueUpgradeCompensation[]> {
+    return [...this.owed]
+  }
+
+  async settle(opId: string, status: 'succeeded' | 'failed', outcome: string | null): Promise<boolean> {
+    if (this.alreadyClosed.has(opId)) return false
+    this.settled.push({ opId, status, outcome })
+    return true
+  }
+}
+
 function build(policy: Partial<ClusterExecutionPolicy> = {}) {
   const repo = new FakeRepo()
   const api = new FakeApi()
+  const ops = new FakeOps()
   const service = new ClusterExecutionService(
     repo,
     api,
     { slugById: async () => 'acme' },
     { ...POLICY, ...policy },
     { clusterBoundIds: async () => [] },
+    ops,
     systemClock
   )
-  return { repo, api, service }
+  return { repo, api, ops, service }
 }
 
 /** The image the CR was last applied with, for one org. */
@@ -267,7 +288,7 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
     repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
     api.failFor.add('acme')
     const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
-    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(true)
+    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred.image, deferred.previousImage)).toBe(true)
     expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.4.0')
   })
 
@@ -284,7 +305,7 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
     await repo.upsert(OrgId('acme'), {} as never, {
       daemonImage: 'registry.example.test/agentconnect/daemon:v1.7.0'
     })
-    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(true)
+    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred.image, deferred.previousImage)).toBe(true)
     expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.7.0')
   })
 
@@ -301,7 +322,7 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
     const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
     await repo.upsert(OrgId('acme'), {} as never, { suspend: true })
 
-    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(true)
+    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred.image, deferred.previousImage)).toBe(true)
     expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.4.0')
   })
 
@@ -313,7 +334,7 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
     const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
     // A store whose conditional update lands nowhere and says nothing about it.
     repo.restoreDaemonImage = async () => 'registry.example.test/agentconnect/daemon:v1.5.0'
-    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(false)
+    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred.image, deferred.previousImage)).toBe(false)
   })
 
   // The restore failing is the one case where the image really is still coming.
@@ -325,7 +346,7 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
     repo.restoreDaemonImage = async () => {
       throw new Error('database unavailable')
     }
-    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(false)
+    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred.image, deferred.previousImage)).toBe(false)
   })
 
   // The refusals above are checked BEFORE any write, which is what makes them safe to
@@ -454,5 +475,100 @@ describe('ClusterDaemonImageSync', () => {
       ).run()
     ).resolves.toBeUndefined()
     expect(log.entries.at(-1)?.level).toBe('warn')
+  })
+})
+
+/**
+ * The durable half of the rollback. An in-request abandon is one process's intention; this is
+ * the same decision reconstructed from the obligation stored on the operation, so a control
+ * plane that exited mid-command — or one whose bounded retries ran out — still finishes it.
+ *
+ * The rule under test is one-directional: an operation becomes terminal only once its image
+ * is OBSERVED gone. While the image is still durable it is still going to be applied, and
+ * that is exactly when reporting failure would be the contradiction.
+ */
+describe('ClusterExecutionService.drainUpgradeCompensations', () => {
+  const owed = (orgId: string, command: string, rollback: string): OverdueUpgradeCompensation => ({
+    opId: `op-${orgId}`,
+    daemonId: DaemonId('11111111-1111-4111-8111-111111111111'),
+    orgId,
+    commandImage: command,
+    rollbackImage: rollback
+  })
+
+  it('restores the envelope and settles the operation failed', async () => {
+    const { repo, ops, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.5.0')
+    ops.owed = [
+      owed(
+        'acme',
+        'registry.example.test/agentconnect/daemon:v1.5.0',
+        'registry.example.test/agentconnect/daemon:v1.4.0'
+      )
+    ]
+
+    expect(await service.drainUpgradeCompensations()).toBe(1)
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.4.0')
+    expect(ops.settled).toEqual([{ opId: 'op-acme', status: 'failed', outcome: expect.any(String) }])
+  })
+
+  // The whole point: an operation whose change is still coming stays pending.
+  it('leaves an operation pending while its image is still durable', async () => {
+    const { repo, ops, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.5.0')
+    repo.restoreDaemonImage = async () => 'registry.example.test/agentconnect/daemon:v1.5.0'
+    ops.owed = [
+      owed(
+        'acme',
+        'registry.example.test/agentconnect/daemon:v1.5.0',
+        'registry.example.test/agentconnect/daemon:v1.4.0'
+      )
+    ]
+
+    expect(await service.drainUpgradeCompensations()).toBe(0)
+    expect(ops.settled).toEqual([])
+  })
+
+  // A peer that closed the op between the listing and here keeps its verdict — notably the
+  // `succeeded` a recovered cluster's replacement pod would have written.
+  it('does not count an operation a peer already closed', async () => {
+    const { repo, ops, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.5.0')
+    ops.owed = [
+      owed(
+        'acme',
+        'registry.example.test/agentconnect/daemon:v1.5.0',
+        'registry.example.test/agentconnect/daemon:v1.4.0'
+      )
+    ]
+    ops.alreadyClosed.add('op-acme')
+
+    expect(await service.drainUpgradeCompensations()).toBe(0)
+  })
+
+  it('keeps draining past an organization it cannot restore', async () => {
+    const { repo, ops, service } = build()
+    repo.seed('stuck', 'registry.example.test/agentconnect/daemon:v1.5.0')
+    repo.seed('fine', 'registry.example.test/agentconnect/daemon:v1.5.0')
+    const realRestore = repo.restoreDaemonImage.bind(repo)
+    repo.restoreDaemonImage = async (orgId, image, expected) => {
+      if (orgId === 'stuck') throw new Error('database unavailable')
+      return realRestore(orgId, image, expected)
+    }
+    ops.owed = [
+      owed(
+        'stuck',
+        'registry.example.test/agentconnect/daemon:v1.5.0',
+        'registry.example.test/agentconnect/daemon:v1.4.0'
+      ),
+      owed(
+        'fine',
+        'registry.example.test/agentconnect/daemon:v1.5.0',
+        'registry.example.test/agentconnect/daemon:v1.4.0'
+      )
+    ]
+
+    expect(await service.drainUpgradeCompensations()).toBe(1)
+    expect(ops.settled.map((s) => s.opId)).toEqual(['op-fine'])
   })
 })

--- a/packages/control-plane/src/cluster/image-sync.test.ts
+++ b/packages/control-plane/src/cluster/image-sync.test.ts
@@ -137,14 +137,14 @@ class FakeApi implements OrgResourceApi {
   async delete(): Promise<void> {}
 }
 
-function build() {
+function build(policy: Partial<ClusterExecutionPolicy> = {}) {
   const repo = new FakeRepo()
   const api = new FakeApi()
   const service = new ClusterExecutionService(
     repo,
     api,
     { slugById: async () => 'acme' },
-    POLICY,
+    { ...POLICY, ...policy },
     { clusterBoundIds: async () => [] },
     systemClock
   )
@@ -186,6 +186,35 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
   it('refuses a digest-pinned image rather than discarding the pin', async () => {
     const { repo, api, service } = build()
     repo.seed('acme', `registry.example.test/agentconnect/daemon@sha256:${'a'.repeat(64)}`)
+    await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterImageNotVersionedError)
+    expect(api.applied).toHaveLength(0)
+  })
+
+  /**
+   * A floating tag says which image to run, never how the repository spells a version. The
+   * install's own reference does say, for its own repository — so an org that drifted onto
+   * `:latest` upgrades to the tag this deployment actually publishes.
+   */
+  it('takes the convention from the install reference when the org tag is floating', async () => {
+    const { repo, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:latest')
+    expect(await service.setDaemonVersion(OrgId('acme'), '1.5.0')).toBe(
+      'registry.example.test/agentconnect/daemon:v1.5.0'
+    )
+  })
+
+  // Neither side names a version, so composing one would invent a tag nothing published.
+  it('refuses a floating tag when the install reference is floating too', async () => {
+    const { repo, api, service } = build({ daemonImage: 'registry.example.test/agentconnect/daemon:latest' })
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:latest')
+    await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterImageNotVersionedError)
+    expect(api.applied).toHaveLength(0)
+  })
+
+  // A convention observed on one registry says nothing about another's tags.
+  it('refuses a floating tag on a repository the install did not configure', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'other.registry.test/fork/daemon:latest')
     await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterImageNotVersionedError)
     expect(api.applied).toHaveLength(0)
   })

--- a/packages/control-plane/src/cluster/image-sync.test.ts
+++ b/packages/control-plane/src/cluster/image-sync.test.ts
@@ -15,6 +15,7 @@ import {
   ClusterExecutionService,
   ClusterImageNotVersionedError,
   ClusterImageWriteDeferredError,
+  ClusterVersionNotPublishedError,
   type ClusterExecutionPolicy
 } from './service.js'
 import type { OrgResourceApi } from './org-api.js'
@@ -188,6 +189,17 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
     repo.seed('acme', `registry.example.test/agentconnect/daemon@sha256:${'a'.repeat(64)}`)
     await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterImageNotVersionedError)
     expect(api.applied).toHaveLength(0)
+  })
+
+  // The seam re-checks its own input: it composes the tag, and an unnormalized `v1.5.0`
+  // arriving here would become `vv1.5.0` in a registry reference.
+  it('normalizes an image-spelled target and refuses a dist-tag', async () => {
+    const { repo, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    expect(await service.setDaemonVersion(OrgId('acme'), 'v1.5.0')).toBe(
+      'registry.example.test/agentconnect/daemon:v1.5.0'
+    )
+    await expect(service.setDaemonVersion(OrgId('acme'), 'latest')).rejects.toThrow(ClusterVersionNotPublishedError)
   })
 
   /**

--- a/packages/control-plane/src/cluster/image-sync.test.ts
+++ b/packages/control-plane/src/cluster/image-sync.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Moving envelopes onto a published daemon version: the console's per-org command
+ * (`setDaemonVersion`) and the boot-time deployment sweep (`alignDaemonVersion` behind
+ * `ClusterDaemonImageSync`).
+ *
+ * The sweep's whole risk is doing too much — rolling a fleet backwards, or stomping an
+ * org somebody pointed elsewhere — so most of what is asserted here is what it leaves
+ * alone. It writes through the settings row on purpose: the periodic re-apply renders the
+ * spec from that row, so an image applied only to the CR would be reverted.
+ */
+import { describe, expect, it } from 'vitest'
+import { ClusterDaemonImageSync } from './image-sync.js'
+import {
+  ClusterEnvelopeNotEnabledError,
+  ClusterExecutionService,
+  ClusterImageNotVersionedError,
+  type ClusterExecutionPolicy
+} from './service.js'
+import type { OrgResourceApi } from './org-api.js'
+import type { AgentConnectOrg, AgentConnectOrgSpec } from './crd.js'
+import { OrgId } from '../domain/ids.js'
+import { systemClock } from '../domain/clock.js'
+import type {
+  ClusterExecutionDefaults,
+  ClusterExecutionPatch,
+  ClusterExecutionSettings,
+  OrgClusterExecutionRepo,
+  PendingEnvelopeTeardown
+} from '../persistence/ports.js'
+
+const INSTALL_IMAGE = 'registry.example.test/agentconnect/daemon:1.4.0'
+const POLICY: ClusterExecutionPolicy = {
+  namespacePrefix: 'ac-org-',
+  daemonImage: INSTALL_IMAGE,
+  runtimeImage: 'registry.example.test/agentconnect/runtime:1.4.0',
+  daemonTier: 'small',
+  runtimeTiers: [{ name: 'small', warmReplicas: 0 }],
+  controlPlaneUrl: 'wss://api.example.test/daemon/ws'
+}
+
+/** Multi-org in-memory rows — the sweep's unit of work is the whole enabled set. */
+class FakeRepo implements OrgClusterExecutionRepo {
+  rows = new Map<string, ClusterExecutionSettings>()
+
+  seed(orgId: string, daemonImage: string, enabled = true): void {
+    this.rows.set(orgId, {
+      orgId,
+      enabled,
+      specRevision: 1,
+      resourceName: orgId,
+      suspend: false,
+      daemonImage,
+      daemonTier: 'small',
+      runtimeImage: POLICY.runtimeImage,
+      runtimeTiers: POLICY.runtimeTiers,
+      quota: { maxAgents: 0, cpu: '0', memory: '0', storage: '0' },
+      egressPolicy: 'curated',
+      createdAt: new Date(0),
+      updatedAt: new Date(0)
+    })
+  }
+
+  async get(orgId: OrgId): Promise<ClusterExecutionSettings | null> {
+    const row = this.rows.get(orgId)
+    return row ? { ...row } : null
+  }
+
+  async getByResourceName(name: string): Promise<ClusterExecutionSettings | null> {
+    for (const row of this.rows.values()) if (row.resourceName === name) return { ...row }
+    return null
+  }
+
+  async listEnabled(): Promise<ClusterExecutionSettings[]> {
+    return [...this.rows.values()].filter((r) => r.enabled).map((r) => ({ ...r }))
+  }
+
+  async listPendingTeardowns(): Promise<PendingEnvelopeTeardown[]> {
+    return []
+  }
+
+  /** Nothing here claims a transition, so the periodic pass sees every enabled org. */
+  async listResyncableOrgIds(afterOrgId: string | null, limit: number): Promise<string[]> {
+    return [...this.rows.values()]
+      .filter((row) => row.enabled)
+      .map((row) => row.orgId)
+      .filter((orgId) => afterOrgId === null || orgId > afterOrgId)
+      .sort()
+      .slice(0, limit)
+  }
+
+  async clearPendingTeardown(): Promise<void> {}
+
+  async beginTransition(orgId: OrgId): Promise<ClusterExecutionSettings | null> {
+    return this.get(orgId)
+  }
+
+  async endTransition(): Promise<void> {}
+
+  async disableAndRecordTeardown(): Promise<boolean> {
+    return true
+  }
+
+  async createIfAbsent(): Promise<void> {}
+
+  async upsert(
+    orgId: OrgId,
+    _defaults: ClusterExecutionDefaults,
+    patch: ClusterExecutionPatch
+  ): Promise<ClusterExecutionSettings> {
+    const base = this.rows.get(orgId)!
+    const next: ClusterExecutionSettings = {
+      ...base,
+      specRevision: base.specRevision + 1,
+      ...(patch.daemonImage !== undefined ? { daemonImage: patch.daemonImage } : {})
+    }
+    this.rows.set(orgId, next)
+    return next
+  }
+}
+
+class FakeApi implements OrgResourceApi {
+  readonly namespace = 'agentconnect-control'
+  applied: { name: string; spec: AgentConnectOrgSpec }[] = []
+  failFor = new Set<string>()
+
+  async apply(name: string, spec: AgentConnectOrgSpec): Promise<AgentConnectOrg> {
+    if (this.failFor.has(name)) throw new Error('cluster unreachable')
+    this.applied.push({ name, spec })
+    return { spec }
+  }
+
+  async get(): Promise<AgentConnectOrg | null> {
+    return { metadata: { uid: 'uid-1', resourceVersion: '1' } }
+  }
+
+  async delete(): Promise<void> {}
+}
+
+function build() {
+  const repo = new FakeRepo()
+  const api = new FakeApi()
+  const service = new ClusterExecutionService(
+    repo,
+    api,
+    { slugById: async () => 'acme' },
+    POLICY,
+    { clusterBoundIds: async () => [] },
+    systemClock
+  )
+  return { repo, api, service }
+}
+
+/** The image the CR was last applied with, for one org. */
+const appliedImage = (api: FakeApi, name: string): string | undefined =>
+  [...api.applied].reverse().find((a) => a.name === name)?.spec.daemon.image
+
+describe('ClusterExecutionService.setDaemonVersion', () => {
+  it('rewrites the tag and applies the CR', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:1.4.0')
+    const image = await service.setDaemonVersion(OrgId('acme'), '1.5.0')
+    expect(image).toBe('registry.example.test/agentconnect/daemon:1.5.0')
+    expect(appliedImage(api, 'acme')).toBe('registry.example.test/agentconnect/daemon:1.5.0')
+    // Through the row, not around it: the periodic re-apply would revert a CR-only write.
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:1.5.0')
+  })
+
+  // Unlike the sweep, an explicit command may move backwards — the picker offers every
+  // published version, and an operator rolling back a bad release is the point.
+  it('allows an explicit downgrade', async () => {
+    const { repo, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:1.5.0')
+    expect(await service.setDaemonVersion(OrgId('acme'), '1.4.0')).toBe(
+      'registry.example.test/agentconnect/daemon:1.4.0'
+    )
+  })
+
+  it('refuses an organization with no live envelope', async () => {
+    const { repo, service } = build()
+    repo.seed('acme', INSTALL_IMAGE, false)
+    await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterEnvelopeNotEnabledError)
+    await expect(service.setDaemonVersion(OrgId('nobody'), '1.5.0')).rejects.toThrow(ClusterEnvelopeNotEnabledError)
+  })
+
+  it('refuses a digest-pinned image rather than discarding the pin', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', `registry.example.test/agentconnect/daemon@sha256:${'a'.repeat(64)}`)
+    await expect(service.setDaemonVersion(OrgId('acme'), '1.5.0')).rejects.toThrow(ClusterImageNotVersionedError)
+    expect(api.applied).toHaveLength(0)
+  })
+})
+
+describe('ClusterExecutionService.alignDaemonVersion', () => {
+  it('moves only the envelopes that are behind', async () => {
+    const { repo, api, service } = build()
+    repo.seed('behind', 'registry.example.test/agentconnect/daemon:1.4.0')
+    repo.seed('current', 'registry.example.test/agentconnect/daemon:1.5.0')
+    repo.seed('ahead', 'registry.example.test/agentconnect/daemon:1.6.0')
+    repo.seed('off', 'registry.example.test/agentconnect/daemon:1.4.0', false)
+
+    const sweep = await service.alignDaemonVersion('1.5.0')
+    expect(sweep.moved).toEqual(['behind'])
+    expect(sweep.scanned).toBe(3) // the disabled envelope is not even listed
+    expect(sweep.skipped).toBe(2)
+    expect(appliedImage(api, 'behind')).toBe('registry.example.test/agentconnect/daemon:1.5.0')
+    expect(appliedImage(api, 'ahead')).toBeUndefined()
+    expect((await repo.get(OrgId('ahead')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:1.6.0')
+  })
+
+  // Somebody pointed this org at their own registry; this channel says nothing about it.
+  it('leaves an envelope on another repository alone', async () => {
+    const { repo, api, service } = build()
+    repo.seed('elsewhere', 'other.registry.test/fork/daemon:1.4.0')
+    const sweep = await service.alignDaemonVersion('1.5.0')
+    expect(sweep.moved).toEqual([])
+    expect(api.applied).toHaveLength(0)
+  })
+
+  it('leaves a floating tag and a digest pin alone', async () => {
+    const { repo, api, service } = build()
+    repo.seed('floating', 'registry.example.test/agentconnect/daemon:latest')
+    repo.seed('pinned', `registry.example.test/agentconnect/daemon@sha256:${'b'.repeat(64)}`)
+    const sweep = await service.alignDaemonVersion('1.5.0')
+    expect(sweep.moved).toEqual([])
+    expect(sweep.skipped).toBe(2)
+    expect(api.applied).toHaveLength(0)
+  })
+
+  it('keeps sweeping past an organization whose apply fails', async () => {
+    const { repo, api, service } = build()
+    repo.seed('broken', 'registry.example.test/agentconnect/daemon:1.4.0')
+    repo.seed('fine', 'registry.example.test/agentconnect/daemon:1.4.0')
+    api.failFor.add('broken')
+
+    const sweep = await service.alignDaemonVersion('1.5.0')
+    expect(sweep.moved).toEqual(['fine'])
+    expect(sweep.failed.map((f) => f.orgId)).toEqual(['broken'])
+  })
+})
+
+describe('ClusterDaemonImageSync', () => {
+  const logs = () => {
+    const entries: { level: string; obj: Record<string, unknown>; msg: string }[] = []
+    return {
+      entries,
+      info: (obj: Record<string, unknown>, msg: string) => entries.push({ level: 'info', obj, msg }),
+      warn: (obj: Record<string, unknown>, msg: string) => entries.push({ level: 'warn', obj, msg })
+    }
+  }
+
+  it('sweeps the fleet onto the channel version', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:1.4.0')
+    const log = logs()
+    await new ClusterDaemonImageSync(
+      service,
+      { resolve: async () => ({ channel: 'rc', latestVersion: '1.5.0-rc.2', availableVersions: [] }) },
+      log
+    ).run()
+    expect(appliedImage(api, 'acme')).toBe('registry.example.test/agentconnect/daemon:1.5.0-rc.2')
+    expect(log.entries.at(-1)).toMatchObject({ level: 'info', obj: { moved: 1, version: '1.5.0-rc.2' } })
+  })
+
+  // Nothing is known to be newer, so guessing a version onto every envelope is the one
+  // thing this must not do.
+  it('touches nothing when the channel has no published version', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:1.4.0')
+    const log = logs()
+    await new ClusterDaemonImageSync(
+      service,
+      { resolve: async () => ({ channel: 'rc', latestVersion: null, availableVersions: [] }) },
+      log
+    ).run()
+    expect(api.applied).toHaveLength(0)
+    expect(log.entries.at(-1)?.level).toBe('warn')
+  })
+
+  it('never throws — the control plane must boot regardless', async () => {
+    const { service } = build()
+    const log = logs()
+    await expect(
+      new ClusterDaemonImageSync(
+        service,
+        {
+          resolve: async () => {
+            throw new Error('npm unreachable')
+          }
+        },
+        log
+      ).run()
+    ).resolves.toBeUndefined()
+    expect(log.entries.at(-1)?.level).toBe('warn')
+  })
+})

--- a/packages/control-plane/src/cluster/image-sync.test.ts
+++ b/packages/control-plane/src/cluster/image-sync.test.ts
@@ -72,11 +72,15 @@ class FakeRepo implements OrgClusterExecutionRepo {
     return null
   }
 
-  /** Revision-fenced, like the repo's conditional UPDATE. */
-  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedRevision: number): Promise<void> {
+  /** Conditional on the image, and reports what the row ends up holding. */
+  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedImage: string): Promise<string | null> {
     const row = this.rows.get(orgId)
-    if (!row || row.specRevision !== expectedRevision) return
-    this.rows.set(orgId, { ...row, daemonImage, specRevision: row.specRevision + 1 })
+    if (!row) return null
+    if (row.daemonImage === expectedImage) {
+      this.rows.set(orgId, { ...row, daemonImage, specRevision: row.specRevision + 1 })
+      return daemonImage
+    }
+    return row.daemonImage
   }
 
   async listEnabled(): Promise<ClusterExecutionSettings[]> {
@@ -120,6 +124,7 @@ class FakeRepo implements OrgClusterExecutionRepo {
     const next: ClusterExecutionSettings = {
       ...base,
       specRevision: base.specRevision + 1,
+      ...(patch.suspend !== undefined ? { suspend: patch.suspend } : {}),
       ...(patch.daemonImage !== undefined ? { daemonImage: patch.daemonImage } : {})
     }
     this.rows.set(orgId, next)
@@ -267,21 +272,48 @@ describe('ClusterExecutionService.setDaemonVersion', () => {
   })
 
   /**
-   * A peer that edited the row since owns it, so reverting blindly would discard their
-   * value. It still counts as abandoned: what will be applied is their image, not this
-   * call's, so the caller's operation is genuinely not going to happen.
+   * A peer that replaced the image owns it, so reverting blindly would discard their value.
+   * It still counts as abandoned: what will be applied is their image, not this call's, so
+   * the caller's operation is genuinely not going to happen.
    */
-  it('leaves a peer’s later edit alone and still reports abandoned', async () => {
+  it('leaves a peer’s later image alone and still reports abandoned', async () => {
     const { repo, api, service } = build()
     repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
     api.failFor.add('acme')
     const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
-    // A peer writes after the failed apply, bumping the revision the fence compares.
     await repo.upsert(OrgId('acme'), {} as never, {
       daemonImage: 'registry.example.test/agentconnect/daemon:v1.7.0'
     })
     expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(true)
     expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.7.0')
+  })
+
+  /**
+   * The hole a revision fence left open. Any unrelated settings edit — quota here — bumps
+   * the revision while leaving this command's image exactly where it was, so a
+   * revision-fenced restore matched nothing and reported success over a change that the
+   * re-apply pass would still enact. Fencing on the IMAGE is what closes it.
+   */
+  it('still rolls back after an unrelated settings edit bumped the revision', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    api.failFor.add('acme')
+    const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
+    await repo.upsert(OrgId('acme'), {} as never, { suspend: true })
+
+    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(true)
+    expect((await repo.get(OrgId('acme')))!.daemonImage).toBe('registry.example.test/agentconnect/daemon:v1.4.0')
+  })
+
+  // Verified, not assumed: a restore that silently matched nothing must not read as success.
+  it('reports not-abandoned when the image survives the restore', async () => {
+    const { repo, api, service } = build()
+    repo.seed('acme', 'registry.example.test/agentconnect/daemon:v1.4.0')
+    api.failFor.add('acme')
+    const deferred = await service.setDaemonVersion(OrgId('acme'), '1.5.0').catch((e) => e)
+    // A store whose conditional update lands nowhere and says nothing about it.
+    repo.restoreDaemonImage = async () => 'registry.example.test/agentconnect/daemon:v1.5.0'
+    expect(await service.abandonDaemonVersion(OrgId('acme'), deferred)).toBe(false)
   })
 
   // The restore failing is the one case where the image really is still coming.

--- a/packages/control-plane/src/cluster/image-sync.ts
+++ b/packages/control-plane/src/cluster/image-sync.ts
@@ -1,0 +1,70 @@
+/**
+ * The boot-time daemon-version sweep: every enabled envelope is pointed at the newest
+ * daemon image the deployment's release channel names.
+ *
+ * A release publishes the npm package and the container image together, so the dist-tag
+ * this install pins (`DAEMON_DIST_TAG` — `rc` on a test control plane, `latest` in
+ * production) already answers "which image should an envelope daemon run". A machine
+ * daemon learns that answer from the console's upgrade hint and reinstalls itself; a pod
+ * cannot, so the control plane moves it.
+ *
+ * It runs once per boot rather than on a timer, which is the whole design: the sweep is
+ * the catch-up for a release that landed while this process was down, and an operator who
+ * wants an envelope moved sooner has the console's upgrade control. A timer would also
+ * fight an owner who just pinned an org deliberately — see `alignDaemonVersion` for the
+ * two cases it refuses to touch.
+ */
+import type { ClusterExecutionService } from './service.js'
+import type { DaemonRelease } from '../registry/daemonRelease.js'
+
+export interface ClusterImageSyncLog {
+  info(obj: Record<string, unknown>, msg: string): void
+  warn(obj: Record<string, unknown>, msg: string): void
+}
+
+/** Just enough of the resolver to await one channel lookup. */
+export interface DaemonReleaseLookup {
+  resolve(): Promise<DaemonRelease>
+}
+
+export class ClusterDaemonImageSync {
+  constructor(
+    private readonly cluster: ClusterExecutionService,
+    private readonly release: DaemonReleaseLookup,
+    private readonly log?: ClusterImageSyncLog
+  ) {}
+
+  /** One pass. Never throws — a control plane must boot whether or not npm answered. */
+  async run(): Promise<void> {
+    try {
+      const { channel, latestVersion } = await this.release.resolve()
+      // No answer from the registry ⇒ nothing is known to be newer, so nothing moves.
+      // Doing anything else here would mean guessing a version onto every envelope.
+      if (!latestVersion) {
+        this.log?.warn({ channel }, 'cluster-execution: no published daemon version for the channel; skipping sweep')
+        return
+      }
+      const sweep = await this.cluster.alignDaemonVersion(latestVersion)
+      for (const failure of sweep.failed) {
+        this.log?.warn(
+          { orgId: failure.orgId, err: failure.err },
+          'cluster-execution: could not move an envelope onto the current daemon image'
+        )
+      }
+      this.log?.info(
+        {
+          channel,
+          version: latestVersion,
+          image: sweep.target,
+          scanned: sweep.scanned,
+          moved: sweep.moved.length,
+          skipped: sweep.skipped,
+          failed: sweep.failed.length
+        },
+        'cluster-execution: swept envelopes onto the current daemon image'
+      )
+    } catch (err) {
+      this.log?.warn({ err }, 'cluster-execution: daemon image sweep failed')
+    }
+  }
+}

--- a/packages/control-plane/src/cluster/image-sync.ts
+++ b/packages/control-plane/src/cluster/image-sync.ts
@@ -55,7 +55,6 @@ export class ClusterDaemonImageSync {
         {
           channel,
           version: latestVersion,
-          image: sweep.target,
           scanned: sweep.scanned,
           moved: sweep.moved.length,
           skipped: sweep.skipped,

--- a/packages/control-plane/src/cluster/image.test.ts
+++ b/packages/control-plane/src/cluster/image.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { imageRepository, imageTag, withImageTag, isNewerVersion, parseVersion, InvalidImageTagError } from './image.js'
+import {
+  imageRepository,
+  imageTag,
+  withImageTag,
+  isNewerVersion,
+  parseVersion,
+  versionImageTag,
+  InvalidImageTagError
+} from './image.js'
 
 describe('image reference arithmetic', () => {
   it('splits a plain tagged reference', () => {
@@ -45,14 +53,29 @@ describe('parseVersion', () => {
     expect(parseVersion('1.5.0-rc.2')).toEqual({ release: ['1', '5', '0'], prerelease: ['rc', '2'] })
   })
 
+  // The `v` prefix is accepted because one version is spelled two ways: npm reports
+  // `1.5.0` and the released image is tagged `v1.5.0`, and these get compared.
+  it('accepts the image tag spelling of the same version', () => {
+    expect(parseVersion('v1.4.0')).toEqual({ release: ['1', '4', '0'], prerelease: null })
+    expect(parseVersion('v1.5.0-rc.2')).toEqual({ release: ['1', '5', '0'], prerelease: ['rc', '2'] })
+  })
+
   it('rejects a floating tag', () => {
     expect(parseVersion('latest')).toBeNull()
     expect(parseVersion('rc')).toBeNull()
-    expect(parseVersion('v1.4.0')).toBeNull()
+    expect(parseVersion('release-1.4.0')).toBeNull()
   })
 })
 
 describe('isNewerVersion', () => {
+  // What the sweep actually asks: is the channel's npm version newer than this image tag?
+  it('compares an npm version against an image tag of the same release', () => {
+    expect(isNewerVersion('1.5.0', 'v1.4.0')).toBe(true)
+    expect(isNewerVersion('1.4.0', 'v1.4.0')).toBe(false)
+    expect(isNewerVersion('1.4.0', 'v1.5.0')).toBe(false)
+    expect(isNewerVersion('1.5.0-rc.2', 'v1.5.0-rc.1')).toBe(true)
+  })
+
   it('orders release versions numerically, not lexicographically', () => {
     expect(isNewerVersion('1.10.0', '1.9.0')).toBe(true)
     expect(isNewerVersion('1.9.0', '1.10.0')).toBe(false)
@@ -77,5 +100,20 @@ describe('isNewerVersion', () => {
   it('never calls an unparseable version newer or older', () => {
     expect(isNewerVersion('1.5.0', 'latest')).toBe(false)
     expect(isNewerVersion('latest', '1.5.0')).toBe(false)
+  })
+})
+
+describe('versionImageTag', () => {
+  // The release train tags images with the GIT tag, so an npm version has to be
+  // translated: `.github/workflows/build.yaml` refuses anything but `vX.Y.Z(-rc.N)`.
+  it('prefixes a released version the way the release train tags it', () => {
+    expect(versionImageTag('v1.4.0', '1.5.0')).toBe('v1.5.0')
+    expect(versionImageTag('v1.4.0', '1.5.0-rc.2')).toBe('v1.5.0-rc.2')
+  })
+
+  // A bespoke build tagged without the prefix keeps its own convention: a tag this
+  // deployment never published is not an upgrade for it.
+  it('keeps an unprefixed convention unprefixed', () => {
+    expect(versionImageTag('1.4.0', '1.5.0')).toBe('1.5.0')
   })
 })

--- a/packages/control-plane/src/cluster/image.test.ts
+++ b/packages/control-plane/src/cluster/image.test.ts
@@ -6,6 +6,7 @@ import {
   isNewerVersion,
   parseVersion,
   versionImageTag,
+  versionTagStyle,
   InvalidImageTagError
 } from './image.js'
 
@@ -103,17 +104,32 @@ describe('isNewerVersion', () => {
   })
 })
 
-describe('versionImageTag', () => {
-  // The release train tags images with the GIT tag, so an npm version has to be
-  // translated: `.github/workflows/build.yaml` refuses anything but `vX.Y.Z(-rc.N)`.
-  it('prefixes a released version the way the release train tags it', () => {
-    expect(versionImageTag('v1.4.0', '1.5.0')).toBe('v1.5.0')
-    expect(versionImageTag('v1.4.0', '1.5.0-rc.2')).toBe('v1.5.0-rc.2')
+describe('versionTagStyle', () => {
+  it('reads the convention off a tag that is itself a version', () => {
+    expect(versionTagStyle('v1.4.0')).toBe('v-prefixed')
+    expect(versionTagStyle('v1.5.0-rc.2')).toBe('v-prefixed')
+    expect(versionTagStyle('1.4.0')).toBe('bare')
   })
 
-  // A bespoke build tagged without the prefix keeps its own convention: a tag this
-  // deployment never published is not an upgrade for it.
-  it('keeps an unprefixed convention unprefixed', () => {
-    expect(versionImageTag('1.4.0', '1.5.0')).toBe('1.5.0')
+  /**
+   * A floating tag is NOT evidence. Reading its missing `v` as "bare" is how an upgrade
+   * composes `:1.5.0` for a registry that only publishes `:v1.5.0` — a tag that does not
+   * exist, so the pod lands in ImagePullBackOff instead of the caller being told no.
+   */
+  it('learns nothing from a floating or absent tag', () => {
+    expect(versionTagStyle('latest')).toBeNull()
+    expect(versionTagStyle('rc')).toBeNull()
+    expect(versionTagStyle('main')).toBeNull()
+    expect(versionTagStyle(null)).toBeNull()
+  })
+})
+
+describe('versionImageTag', () => {
+  // The release train tags images with the GIT tag, so an npm version is translated:
+  // `.github/workflows/build.yaml` refuses anything but `vX.Y.Z(-rc.N)`.
+  it('spells a version in the given convention', () => {
+    expect(versionImageTag('v-prefixed', '1.5.0')).toBe('v1.5.0')
+    expect(versionImageTag('v-prefixed', '1.5.0-rc.2')).toBe('v1.5.0-rc.2')
+    expect(versionImageTag('bare', '1.5.0')).toBe('1.5.0')
   })
 })

--- a/packages/control-plane/src/cluster/image.test.ts
+++ b/packages/control-plane/src/cluster/image.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { imageRepository, imageTag, withImageTag, isNewerVersion, parseVersion, InvalidImageTagError } from './image.js'
+
+describe('image reference arithmetic', () => {
+  it('splits a plain tagged reference', () => {
+    expect(imageRepository('ghcr.io/acme/daemon:1.4.0')).toBe('ghcr.io/acme/daemon')
+    expect(imageTag('ghcr.io/acme/daemon:1.4.0')).toBe('1.4.0')
+  })
+
+  it('does not mistake a registry port for a tag', () => {
+    expect(imageRepository('registry.example:5000/acme/daemon')).toBe('registry.example:5000/acme/daemon')
+    expect(imageTag('registry.example:5000/acme/daemon')).toBeNull()
+    expect(imageTag('registry.example:5000/acme/daemon:1.4.0')).toBe('1.4.0')
+    expect(withImageTag('registry.example:5000/acme/daemon:1.4.0', '1.5.0')).toBe(
+      'registry.example:5000/acme/daemon:1.5.0'
+    )
+  })
+
+  it('reads an untagged reference as having no tag', () => {
+    expect(imageTag('daemon')).toBeNull()
+    expect(withImageTag('daemon', '1.4.0')).toBe('daemon:1.4.0')
+  })
+
+  // The guard that keeps a substituted tag from naming somebody else's image. It lives
+  // here because this is the one place a registry reference is composed.
+  it('refuses a tag that could repoint the reference', () => {
+    for (const bad of ['1.5.0/evil', 'evil.test/fork/daemon:1.5.0', '1.5.0:latest', 'a@b', '', ' 1.5.0', '-1.5.0']) {
+      expect(() => withImageTag('ghcr.io/acme/daemon:1.4.0', bad)).toThrow(InvalidImageTagError)
+    }
+    expect(withImageTag('ghcr.io/acme/daemon:1.4.0', '1.5.0-rc.2')).toBe('ghcr.io/acme/daemon:1.5.0-rc.2')
+  })
+
+  // A digest is an exact pin; rewriting it to a tag would discard what an operator chose.
+  it('leaves a digest reference alone', () => {
+    const digest = 'ghcr.io/acme/daemon@sha256:' + 'a'.repeat(64)
+    expect(imageTag(digest)).toBeNull()
+    expect(imageRepository(digest)).toBe(digest)
+    expect(withImageTag(digest, '1.5.0')).toBe(digest)
+  })
+})
+
+describe('parseVersion', () => {
+  it('accepts a release and a prerelease', () => {
+    expect(parseVersion('1.4.0')).toEqual({ release: ['1', '4', '0'], prerelease: null })
+    expect(parseVersion('1.5.0-rc.2')).toEqual({ release: ['1', '5', '0'], prerelease: ['rc', '2'] })
+  })
+
+  it('rejects a floating tag', () => {
+    expect(parseVersion('latest')).toBeNull()
+    expect(parseVersion('rc')).toBeNull()
+    expect(parseVersion('v1.4.0')).toBeNull()
+  })
+})
+
+describe('isNewerVersion', () => {
+  it('orders release versions numerically, not lexicographically', () => {
+    expect(isNewerVersion('1.10.0', '1.9.0')).toBe(true)
+    expect(isNewerVersion('1.9.0', '1.10.0')).toBe(false)
+    expect(isNewerVersion('2.0.0', '1.99.99')).toBe(true)
+    expect(isNewerVersion('1.4.0', '1.4.0')).toBe(false)
+  })
+
+  it('ranks a release above its own prereleases', () => {
+    expect(isNewerVersion('1.5.0', '1.5.0-rc.9')).toBe(true)
+    expect(isNewerVersion('1.5.0-rc.9', '1.5.0')).toBe(false)
+  })
+
+  it('orders prereleases of one release', () => {
+    expect(isNewerVersion('1.5.0-rc.2', '1.5.0-rc.1')).toBe(true)
+    expect(isNewerVersion('1.5.0-rc.10', '1.5.0-rc.2')).toBe(true)
+    expect(isNewerVersion('1.5.0-rc', '1.5.0-rc.1')).toBe(false)
+    expect(isNewerVersion('1.5.0-rc.1', '1.4.9')).toBe(true)
+  })
+
+  // The whole point of the guard: an unparseable side is never "older", so a sweep
+  // cannot roll a deliberately floated or digest-pinned envelope backwards.
+  it('never calls an unparseable version newer or older', () => {
+    expect(isNewerVersion('1.5.0', 'latest')).toBe(false)
+    expect(isNewerVersion('latest', '1.5.0')).toBe(false)
+  })
+})

--- a/packages/control-plane/src/cluster/image.test.ts
+++ b/packages/control-plane/src/cluster/image.test.ts
@@ -7,6 +7,7 @@ import {
   parseVersion,
   versionImageTag,
   versionTagStyle,
+  canonicalVersion,
   InvalidImageTagError
 } from './image.js'
 
@@ -131,5 +132,28 @@ describe('versionImageTag', () => {
     expect(versionImageTag('v-prefixed', '1.5.0')).toBe('v1.5.0')
     expect(versionImageTag('v-prefixed', '1.5.0-rc.2')).toBe('v1.5.0-rc.2')
     expect(versionImageTag('bare', '1.5.0')).toBe('1.5.0')
+  })
+})
+
+describe('canonicalVersion', () => {
+  /**
+   * The target feeds two things that must agree: the composed image tag, and the version
+   * the replacement pod reports for the op to settle against. The pod reports the npm
+   * spelling (the Dockerfile strips the `v` when it stamps package.json), so that is the
+   * canonical form — and `v1.5.0` must normalize rather than compose `vv1.5.0`.
+   */
+  it('strips the image spelling back to what a pod reports', () => {
+    expect(canonicalVersion('v1.5.0')).toBe('1.5.0')
+    expect(canonicalVersion('1.5.0')).toBe('1.5.0')
+    expect(canonicalVersion('v1.5.0-rc.2')).toBe('1.5.0-rc.2')
+    expect(canonicalVersion('  1.5.0  ')).toBe('1.5.0')
+  })
+
+  // A dist-tag names no version: no image tag can be derived from it, and no pod would
+  // ever report it, so the op could not settle even if such an image existed.
+  it('rejects a token that is not a version', () => {
+    expect(canonicalVersion('latest')).toBeNull()
+    expect(canonicalVersion('rc')).toBeNull()
+    expect(canonicalVersion('')).toBeNull()
   })
 })

--- a/packages/control-plane/src/cluster/image.ts
+++ b/packages/control-plane/src/cluster/image.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure arithmetic on a daemon image reference and on the versions behind it.
+ *
+ * A release publishes the npm package and the container image from one version
+ * (`docker-bake.hcl`: `<registry>/<owner>/daemon:${VERSION}`), so the deployment's
+ * dist-tag channel already names the image tag the envelope should run. What is left
+ * is textual: swap the tag while keeping the registry and repository the install
+ * configured, and refuse to touch a reference that does not name a version at all.
+ */
+
+/** A tag is everything after the LAST `:` — but only when that colon is in the final
+ *  path segment, so `registry.example:5000/daemon` reads as untagged, not as tag `5000/daemon`. */
+function tagStart(image: string): number {
+  const colon = image.lastIndexOf(':')
+  return colon > image.lastIndexOf('/') ? colon : -1
+}
+
+/** The reference without its tag; a digest reference keeps the digest and is returned whole. */
+export function imageRepository(image: string): string {
+  if (image.includes('@')) return image
+  const at = tagStart(image)
+  return at === -1 ? image : image.slice(0, at)
+}
+
+/** The tag, or null for an untagged or digest-pinned reference. */
+export function imageTag(image: string): string | null {
+  if (image.includes('@')) return null
+  const at = tagStart(image)
+  return at === -1 ? null : image.slice(at + 1)
+}
+
+/** What Docker accepts as a tag, which is also what keeps a substituted tag from
+ *  naming a different image: no `/`, `:`, `@`, or whitespace can get through. */
+const TAG = /^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$/
+
+export class InvalidImageTagError extends Error {
+  constructor(readonly tag: string) {
+    super(`"${tag}" is not a usable image tag`)
+    this.name = 'InvalidImageTagError'
+  }
+}
+
+/**
+ * The same image at `tag`. A DIGEST reference is returned unchanged: a digest is an
+ * exact pin, and rewriting it to a tag would silently discard the pin an operator
+ * chose. Callers decide whether that no-op is a reason to skip the write.
+ *
+ * The tag is validated here rather than trusted from the caller: this is the one place
+ * that composes a registry reference, so a value carrying `/` or `:` would repoint an
+ * envelope at somebody else's image, and refusing at the seam does not depend on every
+ * route remembering to check first.
+ */
+export function withImageTag(image: string, tag: string): string {
+  if (!TAG.test(tag)) throw new InvalidImageTagError(tag)
+  if (image.includes('@')) return image
+  return `${imageRepository(image)}:${tag}`
+}
+
+/** Numeric-then-lexicographic comparison of one dot-separated identifier list. */
+function compareParts(a: string[], b: string[]): number {
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const l = a[i]
+    const r = b[i]
+    // A shorter prerelease sorts BEFORE a longer one with the same prefix (semver §11):
+    // `1.0.0-rc` precedes `1.0.0-rc.1`. For the release triple the parts are equal-length.
+    if (l === undefined) return -1
+    if (r === undefined) return 1
+    const ln = /^\d+$/.test(l)
+    const rn = /^\d+$/.test(r)
+    // Numeric identifiers always compare lower than alphanumeric ones (semver §11).
+    if (ln && rn) {
+      if (Number(l) !== Number(r)) return Number(l) < Number(r) ? -1 : 1
+    } else if (ln !== rn) {
+      return ln ? -1 : 1
+    } else if (l !== r) {
+      return l < r ? -1 : 1
+    }
+  }
+  return 0
+}
+
+/** `x.y.z` with an optional `-prerelease`; build metadata is out of scope (never published). */
+const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/
+
+interface Parsed {
+  release: string[]
+  prerelease: string[] | null
+}
+
+/** Parse a published version, or null for anything that is not one (`latest`, `rc`, a sha). */
+export function parseVersion(version: string): Parsed | null {
+  const m = SEMVER.exec(version.trim())
+  if (!m) return null
+  return { release: [m[1]!, m[2]!, m[3]!], prerelease: m[4] ? m[4].split('.') : null }
+}
+
+/**
+ * True when `candidate` is a strictly newer published version than `current`. Null on
+ * either side (an unparseable tag) is NOT newer — a floating tag or a digest is a pin
+ * somebody chose, and guessing its ordering is how an automated sweep downgrades a fleet.
+ */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const a = parseVersion(candidate)
+  const b = parseVersion(current)
+  if (!a || !b) return false
+  const release = compareParts(a.release, b.release)
+  if (release !== 0) return release > 0
+  // Same release triple: a release outranks any of its prereleases (semver §11).
+  if (!a.prerelease) return b.prerelease !== null
+  if (!b.prerelease) return false
+  return compareParts(a.prerelease, b.prerelease) > 0
+}

--- a/packages/control-plane/src/cluster/image.ts
+++ b/packages/control-plane/src/cluster/image.ts
@@ -103,6 +103,24 @@ export function parseVersion(version: string): Parsed | null {
   return { release: [m[1]!, m[2]!, m[3]!], prerelease: m[4] ? m[4].split('.') : null }
 }
 
+/**
+ * The canonical spelling of a published version — the one npm reports and, because the
+ * Dockerfile strips the `v` when it stamps `package.json`, the one a pod reports as its
+ * `agentVersion`. Null for anything that is not a version at all.
+ *
+ * Every cluster upgrade target passes through here, and both things it feeds need it. The
+ * image tag is composed from it, so an already-prefixed `v1.5.0` would otherwise become
+ * `vv1.5.0`; and the lifecycle op settles by comparing the target against what the
+ * replacement pod reports, so a target spelled any other way could never settle even if
+ * such an image existed. A floating token like `latest` is rejected rather than turned into
+ * `vlatest` — the daemon's own npm path can resolve a dist-tag, but an image tag cannot be
+ * guessed from one and no pod would ever report it.
+ */
+export function canonicalVersion(version: string): string | null {
+  const trimmed = version.trim()
+  return parseVersion(trimmed) ? trimmed.replace(/^v/, '') : null
+}
+
 /** How a repository spells a released version, learned from one tag that IS a version. */
 export type VersionTagStyle = 'v-prefixed' | 'bare'
 

--- a/packages/control-plane/src/cluster/image.ts
+++ b/packages/control-plane/src/cluster/image.ts
@@ -103,14 +103,25 @@ export function parseVersion(version: string): Parsed | null {
   return { release: [m[1]!, m[2]!, m[3]!], prerelease: m[4] ? m[4].split('.') : null }
 }
 
+/** How a repository spells a released version, learned from one tag that IS a version. */
+export type VersionTagStyle = 'v-prefixed' | 'bare'
+
 /**
- * The image tag a published `version` was released under, spelled the way the reference
- * being replaced spells it. The release train tags images `vX.Y.Z(-rc.N)`, so that is the
- * default; an install whose current tag carries no `v` built its own images and keeps that
- * convention, because a tag this deployment never published is not an upgrade for it.
+ * The convention a tag demonstrates, or null when it demonstrates nothing.
+ *
+ * Only a tag that already names a version is evidence. A floating tag (`latest`, `rc`) is
+ * not: it says which image to run, never how this repository spells a version, and reading
+ * a missing `v` off it as "bare" is how an upgrade fabricates `:1.5.0` for a registry that
+ * only publishes `:v1.5.0` — a tag that does not exist, and a pod in ImagePullBackOff.
  */
-export function versionImageTag(currentTag: string, version: string): string {
-  return currentTag.startsWith('v') ? `v${version}` : version
+export function versionTagStyle(tag: string | null): VersionTagStyle | null {
+  if (!tag || !parseVersion(tag)) return null
+  return tag.startsWith('v') ? 'v-prefixed' : 'bare'
+}
+
+/** Spell `version` as a tag in the given convention. */
+export function versionImageTag(style: VersionTagStyle, version: string): string {
+  return style === 'v-prefixed' ? `v${version}` : version
 }
 
 /**

--- a/packages/control-plane/src/cluster/image.ts
+++ b/packages/control-plane/src/cluster/image.ts
@@ -1,11 +1,16 @@
 /**
  * Pure arithmetic on a daemon image reference and on the versions behind it.
  *
- * A release publishes the npm package and the container image from one version
- * (`docker-bake.hcl`: `<registry>/<owner>/daemon:${VERSION}`), so the deployment's
- * dist-tag channel already names the image tag the envelope should run. What is left
- * is textual: swap the tag while keeping the registry and repository the install
- * configured, and refuse to touch a reference that does not name a version at all.
+ * A release publishes the npm package and the container image from one version, so the
+ * deployment's dist-tag channel already answers which image an envelope should run — but
+ * the two spell that version differently. npm reports `1.5.0`; the image is tagged with
+ * the GIT tag, `v1.5.0` (`.github/workflows/build.yaml` refuses a version that is not
+ * `vX.Y.Z(-rc.N)`, and `docker-bake.hcl` passes it through as `VERSION`). Composing an
+ * image reference therefore means translating, not concatenating — see
+ * {@link versionImageTag}.
+ *
+ * What is left is textual: swap the tag while keeping the registry and repository the
+ * install configured, and refuse to touch a reference that does not name a version.
  */
 
 /** A tag is everything after the LAST `:` — but only when that colon is in the final
@@ -79,8 +84,12 @@ function compareParts(a: string[], b: string[]): number {
   return 0
 }
 
-/** `x.y.z` with an optional `-prerelease`; build metadata is out of scope (never published). */
-const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/
+/**
+ * `x.y.z` with an optional `-prerelease` and an optional `v` prefix; build metadata is out
+ * of scope (never published). The prefix is accepted because the two things compared here
+ * spell one version two ways: an npm version (`1.5.0`) against an image tag (`v1.5.0`).
+ */
+const SEMVER = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/
 
 interface Parsed {
   release: string[]
@@ -92,6 +101,16 @@ export function parseVersion(version: string): Parsed | null {
   const m = SEMVER.exec(version.trim())
   if (!m) return null
   return { release: [m[1]!, m[2]!, m[3]!], prerelease: m[4] ? m[4].split('.') : null }
+}
+
+/**
+ * The image tag a published `version` was released under, spelled the way the reference
+ * being replaced spells it. The release train tags images `vX.Y.Z(-rc.N)`, so that is the
+ * default; an install whose current tag carries no `v` built its own images and keeps that
+ * convention, because a tag this deployment never published is not an upgrade for it.
+ */
+export function versionImageTag(currentTag: string, version: string): string {
+  return currentTag.startsWith('v') ? `v${version}` : version
 }
 
 /**

--- a/packages/control-plane/src/cluster/index.ts
+++ b/packages/control-plane/src/cluster/index.ts
@@ -12,7 +12,12 @@ export { ClusterMaintenanceLoop, type ClusterMaintenanceWork } from './maintenan
 export { ClusterNamingError, orgResourceName, type ClusterEnvelopeStatus } from './spec.js'
 export {
   ClusterExecutionService,
+  ClusterEnvelopeNotEnabledError,
+  ClusterImageNotVersionedError,
   ClusterTransitionInProgressError,
   type ClusterExecutionPolicy,
+  type ClusterVersionSweep,
   type EnvelopeResyncOutcome
 } from './service.js'
+export { ClusterDaemonImageSync, type DaemonReleaseLookup } from './image-sync.js'
+export { InvalidImageTagError, imageRepository, imageTag, isNewerVersion, withImageTag } from './image.js'

--- a/packages/control-plane/src/cluster/index.ts
+++ b/packages/control-plane/src/cluster/index.ts
@@ -19,6 +19,7 @@ export {
   ClusterVersionNotPublishedError,
   type ClusterExecutionPolicy,
   type ClusterVersionSweep,
+  type DaemonVersionPlan,
   type EnvelopeResyncOutcome
 } from './service.js'
 export { ClusterDaemonImageSync, type DaemonReleaseLookup } from './image-sync.js'

--- a/packages/control-plane/src/cluster/index.ts
+++ b/packages/control-plane/src/cluster/index.ts
@@ -14,10 +14,18 @@ export {
   ClusterExecutionService,
   ClusterEnvelopeNotEnabledError,
   ClusterImageNotVersionedError,
+  ClusterImageWriteDeferredError,
   ClusterTransitionInProgressError,
   type ClusterExecutionPolicy,
   type ClusterVersionSweep,
   type EnvelopeResyncOutcome
 } from './service.js'
 export { ClusterDaemonImageSync, type DaemonReleaseLookup } from './image-sync.js'
-export { InvalidImageTagError, imageRepository, imageTag, isNewerVersion, withImageTag } from './image.js'
+export {
+  InvalidImageTagError,
+  imageRepository,
+  imageTag,
+  isNewerVersion,
+  versionImageTag,
+  withImageTag
+} from './image.js'

--- a/packages/control-plane/src/cluster/index.ts
+++ b/packages/control-plane/src/cluster/index.ts
@@ -27,5 +27,7 @@ export {
   imageTag,
   isNewerVersion,
   versionImageTag,
-  withImageTag
+  versionTagStyle,
+  withImageTag,
+  type VersionTagStyle
 } from './image.js'

--- a/packages/control-plane/src/cluster/index.ts
+++ b/packages/control-plane/src/cluster/index.ts
@@ -14,6 +14,7 @@ export {
   ClusterExecutionService,
   ClusterEnvelopeNotEnabledError,
   ClusterImageNotVersionedError,
+  ClusterImageSupersededError,
   ClusterImageWriteDeferredError,
   ClusterTransitionInProgressError,
   ClusterVersionNotPublishedError,

--- a/packages/control-plane/src/cluster/index.ts
+++ b/packages/control-plane/src/cluster/index.ts
@@ -16,6 +16,7 @@ export {
   ClusterImageNotVersionedError,
   ClusterImageWriteDeferredError,
   ClusterTransitionInProgressError,
+  ClusterVersionNotPublishedError,
   type ClusterExecutionPolicy,
   type ClusterVersionSweep,
   type EnvelopeResyncOutcome
@@ -23,6 +24,7 @@ export {
 export { ClusterDaemonImageSync, type DaemonReleaseLookup } from './image-sync.js'
 export {
   InvalidImageTagError,
+  canonicalVersion,
   imageRepository,
   imageTag,
   isNewerVersion,

--- a/packages/control-plane/src/cluster/maintenance-loop.test.ts
+++ b/packages/control-plane/src/cluster/maintenance-loop.test.ts
@@ -20,6 +20,7 @@ function fakeLog(): ClusterMaintenanceLog & {
 function work(overrides: Partial<ClusterMaintenanceWork> = {}): ClusterMaintenanceWork {
   return {
     drainTeardowns: async () => 0,
+    drainUpgradeCompensations: async () => 0,
     resyncEnvelopes: async () => ({ converged: 0, failures: [] }),
     ...overrides
   }

--- a/packages/control-plane/src/cluster/maintenance-loop.ts
+++ b/packages/control-plane/src/cluster/maintenance-loop.ts
@@ -24,6 +24,7 @@ export interface ClusterMaintenanceLog {
 
 export interface ClusterMaintenanceWork {
   drainTeardowns(): Promise<number>
+  drainUpgradeCompensations(): Promise<number>
   resyncEnvelopes(): Promise<EnvelopeResyncOutcome>
 }
 
@@ -62,9 +63,10 @@ export class ClusterMaintenanceLoop {
   }
 
   /**
-   * One pass: retire what deletion left owed, then re-apply a slice of the live
-   * envelopes. Errors are logged and swallowed, and everything either pass could
-   * not finish survives for the next one. Exposed for tests.
+   * One pass: retire what deletion left owed, discharge the upgrade obligations that
+   * outlived their command, then re-apply a slice of the live envelopes. Errors are logged
+   * and swallowed, and everything any pass could not finish survives for the next one.
+   * Exposed for tests.
    */
   async tick(): Promise<void> {
     this.timer = undefined
@@ -74,6 +76,14 @@ export class ClusterMaintenanceLoop {
         () => this.work!.drainTeardowns(),
         'cluster-execution: retired deleted organizations’ envelopes',
         'cluster-execution: envelope teardown drain failed'
+      )
+      // BEFORE the re-apply below, deliberately: an upgrade that has to be undone must be
+      // undone before anything pushes its image again, or the pass would enact the very
+      // change the compensation exists to withdraw.
+      await this.step(
+        () => this.work!.drainUpgradeCompensations(),
+        'cluster-execution: rolled back daemon upgrades the cluster never accepted',
+        'cluster-execution: upgrade compensation drain failed'
       )
       await this.resync()
     } finally {

--- a/packages/control-plane/src/cluster/service.test.ts
+++ b/packages/control-plane/src/cluster/service.test.ts
@@ -58,6 +58,10 @@ class FakeRepo implements OrgClusterExecutionRepo {
     return row ? { ...row } : null
   }
 
+  async listEnabled(): Promise<ClusterExecutionSettings[]> {
+    return this.row?.enabled ? [{ ...this.row }] : []
+  }
+
   async listPendingTeardowns(limit: number): Promise<PendingEnvelopeTeardown[]> {
     return this.tombstones.slice(0, limit)
   }

--- a/packages/control-plane/src/cluster/service.test.ts
+++ b/packages/control-plane/src/cluster/service.test.ts
@@ -229,7 +229,15 @@ function build(): Harness {
   const api = new FakeApi()
   const daemons = new FakeDaemons()
   const policy: ClusterExecutionPolicy = { ...POLICY }
-  const service = new ClusterExecutionService(repo, api, { slugById: async () => 'acme' }, policy, daemons, systemClock)
+  const service = new ClusterExecutionService(
+    repo,
+    api,
+    { slugById: async () => 'acme' },
+    policy,
+    daemons,
+    { listOverdueCompensations: async () => [], settle: async () => true },
+    systemClock
+  )
   return { service, repo, api, daemons, policy }
 }
 

--- a/packages/control-plane/src/cluster/service.test.ts
+++ b/packages/control-plane/src/cluster/service.test.ts
@@ -58,16 +58,6 @@ class FakeRepo implements OrgClusterExecutionRepo {
     return row ? { ...row } : null
   }
 
-  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedImage: string): Promise<string | null> {
-    const row = this.rows.get(orgId)
-    if (!row) return null
-    if (row.daemonImage === expectedImage) {
-      this.rows.set(orgId, { ...row, daemonImage, specRevision: row.specRevision + 1 })
-      return daemonImage
-    }
-    return row.daemonImage
-  }
-
   async listEnabled(): Promise<ClusterExecutionSettings[]> {
     return this.row?.enabled ? [{ ...this.row }] : []
   }
@@ -123,6 +113,7 @@ class FakeRepo implements OrgClusterExecutionRepo {
       enabled: false,
       specRevision: 1,
       suspend: false,
+      daemonImageOwner: null,
       ...defaults,
       createdAt: new Date(0),
       updatedAt: new Date(0)
@@ -139,6 +130,7 @@ class FakeRepo implements OrgClusterExecutionRepo {
       enabled: false,
       specRevision: 0,
       suspend: false,
+      daemonImageOwner: null,
       ...defaults,
       createdAt: new Date(0),
       updatedAt: new Date(0)
@@ -148,7 +140,9 @@ class FakeRepo implements OrgClusterExecutionRepo {
       specRevision: base.specRevision + 1,
       ...(patch.enabled !== undefined ? { enabled: patch.enabled } : {}),
       ...(patch.suspend !== undefined ? { suspend: patch.suspend } : {}),
-      ...(patch.daemonImage !== undefined ? { daemonImage: patch.daemonImage } : {})
+      ...(patch.daemonImage !== undefined
+        ? { daemonImage: patch.daemonImage, daemonImageOwner: patch.daemonImageOwner ?? null }
+        : {})
     }
     if (!this.swallowUpsert) this.rows.set(orgId, next)
     return next
@@ -235,7 +229,7 @@ function build(): Harness {
     { slugById: async () => 'acme' },
     policy,
     daemons,
-    { listOverdueCompensations: async () => [], settle: async () => true },
+    { listOverdueCompensations: async () => [], settleWithCompensation: async () => true },
     systemClock
   )
   return { service, repo, api, daemons, policy }

--- a/packages/control-plane/src/cluster/service.test.ts
+++ b/packages/control-plane/src/cluster/service.test.ts
@@ -58,6 +58,19 @@ class FakeRepo implements OrgClusterExecutionRepo {
     return row ? { ...row } : null
   }
 
+  /** Compare-and-set, like the repo's conditional UPDATE. */
+  async claimDaemonImage(
+    orgId: OrgId,
+    daemonImage: string,
+    owner: string | null,
+    expectedImage: string
+  ): Promise<boolean> {
+    const row = this.rows.get(orgId)
+    if (!row || row.daemonImage !== expectedImage) return false
+    this.rows.set(orgId, { ...row, daemonImage, daemonImageOwner: owner, specRevision: row.specRevision + 1 })
+    return true
+  }
+
   async listEnabled(): Promise<ClusterExecutionSettings[]> {
     return this.row?.enabled ? [{ ...this.row }] : []
   }

--- a/packages/control-plane/src/cluster/service.test.ts
+++ b/packages/control-plane/src/cluster/service.test.ts
@@ -58,10 +58,14 @@ class FakeRepo implements OrgClusterExecutionRepo {
     return row ? { ...row } : null
   }
 
-  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedRevision: number): Promise<void> {
+  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedImage: string): Promise<string | null> {
     const row = this.rows.get(orgId)
-    if (!row || row.specRevision !== expectedRevision) return
-    this.rows.set(orgId, { ...row, daemonImage, specRevision: row.specRevision + 1 })
+    if (!row) return null
+    if (row.daemonImage === expectedImage) {
+      this.rows.set(orgId, { ...row, daemonImage, specRevision: row.specRevision + 1 })
+      return daemonImage
+    }
+    return row.daemonImage
   }
 
   async listEnabled(): Promise<ClusterExecutionSettings[]> {

--- a/packages/control-plane/src/cluster/service.test.ts
+++ b/packages/control-plane/src/cluster/service.test.ts
@@ -58,6 +58,12 @@ class FakeRepo implements OrgClusterExecutionRepo {
     return row ? { ...row } : null
   }
 
+  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedRevision: number): Promise<void> {
+    const row = this.rows.get(orgId)
+    if (!row || row.specRevision !== expectedRevision) return
+    this.rows.set(orgId, { ...row, daemonImage, specRevision: row.specRevision + 1 })
+  }
+
   async listEnabled(): Promise<ClusterExecutionSettings[]> {
     return this.row?.enabled ? [{ ...this.row }] : []
   }

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -29,7 +29,7 @@ import type {
   OrgRepo
 } from '../persistence/ports.js'
 import type { OrgResourceApi } from './org-api.js'
-import { imageRepository, imageTag, isNewerVersion, withImageTag } from './image.js'
+import { imageRepository, imageTag, isNewerVersion, versionImageTag, withImageTag } from './image.js'
 import { ABSENT_ENVELOPE, buildSpec, orgResourceName, projectStatus, type ClusterEnvelopeStatus } from './spec.js'
 
 /** Bounded re-apply passes; each concurrent writer runs its own, so this only
@@ -93,12 +93,31 @@ export class ClusterImageNotVersionedError extends Error {
   }
 }
 
+/**
+ * Raised when the new image is DURABLE but this pass could not push it to the cluster.
+ *
+ * It is not a failure and must not be reported as one: the row is desired state and the
+ * re-apply pass renders the spec from it, so the change is still going to happen. A caller
+ * tracking the upgrade therefore keeps waiting rather than closing it — reporting "failed"
+ * for a command that later executes is the one answer that cannot be reconciled with what
+ * the operator then observes.
+ */
+export class ClusterImageWriteDeferredError extends Error {
+  constructor(
+    readonly image: string,
+    override readonly cause: unknown
+  ) {
+    super(`the daemon image "${image}" is recorded but the cluster refused this apply`)
+    this.name = 'ClusterImageWriteDeferredError'
+  }
+}
+
 /** What one deployment-wide version sweep did; `skipped` counts envelopes left deliberately alone. */
 export interface ClusterVersionSweep {
-  /** The image every moved envelope was pointed at. */
-  target: string
+  /** The published version every moved envelope was pointed at. */
+  version: string
   scanned: number
-  /** Org ids whose envelope now names `target`. */
+  /** Org ids whose envelope now names that version. */
   moved: string[]
   skipped: number
   failed: { orgId: string; err: unknown }[]
@@ -166,11 +185,20 @@ export class ClusterExecutionService {
   async setDaemonVersion(orgId: OrgId, version: string): Promise<string> {
     const settings = await this.repo.get(orgId)
     if (!settings?.enabled) throw new ClusterEnvelopeNotEnabledError()
+    const currentTag = imageTag(settings.daemonImage)
     // A digest pin has no tag to move, and silently replacing it with one would discard
     // an exact pin somebody chose. Refuse instead of pretending the upgrade happened.
-    if (imageTag(settings.daemonImage) === null) throw new ClusterImageNotVersionedError(settings.daemonImage)
-    const daemonImage = withImageTag(settings.daemonImage, version)
-    if (daemonImage !== settings.daemonImage) await this.configure(orgId, { daemonImage })
+    if (currentTag === null) throw new ClusterImageNotVersionedError(settings.daemonImage)
+    const daemonImage = withImageTag(settings.daemonImage, versionImageTag(currentTag, version))
+    if (daemonImage === settings.daemonImage) return daemonImage
+    // The two halves of `configure`, split so the caller can tell them apart: everything
+    // above here wrote nothing, and everything below runs with the change already durable.
+    await this.repo.upsert(orgId, this.defaults(orgId), { daemonImage })
+    try {
+      await this.converge(orgId)
+    } catch (err) {
+      throw new ClusterImageWriteDeferredError(daemonImage, err)
+    }
     return daemonImage
   }
 
@@ -189,9 +217,8 @@ export class ClusterExecutionService {
    */
   async alignDaemonVersion(version: string): Promise<ClusterVersionSweep> {
     const installRepository = imageRepository(this.policy.daemonImage)
-    const target = withImageTag(this.policy.daemonImage, version)
     const rows = await this.repo.listEnabled()
-    const sweep: ClusterVersionSweep = { target, scanned: rows.length, moved: [], skipped: 0, failed: [] }
+    const sweep: ClusterVersionSweep = { version, scanned: rows.length, moved: [], skipped: 0, failed: [] }
     for (const row of rows) {
       const current = imageTag(row.daemonImage)
       if (
@@ -203,13 +230,14 @@ export class ClusterExecutionService {
         continue
       }
       // Per-org and best-effort: one unreachable API server, or one org whose envelope is
-      // mid-transition, must not stop the rest of the fleet from moving.
+      // mid-transition, must not stop the rest of the fleet from moving. A deferred write
+      // counts as moved — the row is what the re-apply pass renders from.
       try {
-        await this.configure(OrgId(row.orgId), { daemonImage: target })
+        await this.setDaemonVersion(OrgId(row.orgId), version)
         sweep.moved.push(row.orgId)
       } catch (err) {
-        // The next boot re-runs the sweep; nothing durable is owed in between.
-        sweep.failed.push({ orgId: row.orgId, err })
+        if (err instanceof ClusterImageWriteDeferredError) sweep.moved.push(row.orgId)
+        else sweep.failed.push({ orgId: row.orgId, err })
       }
     }
     return sweep

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -30,6 +30,7 @@ import type {
 } from '../persistence/ports.js'
 import type { OrgResourceApi } from './org-api.js'
 import {
+  canonicalVersion,
   imageRepository,
   imageTag,
   isNewerVersion,
@@ -106,6 +107,14 @@ export class ClusterImageNotVersionedError extends Error {
   constructor(readonly image: string) {
     super(`the envelope's daemon image "${image}" does not name a version, so there is no release tag to follow`)
     this.name = 'ClusterImageNotVersionedError'
+  }
+}
+
+/** Raised when an upgrade target is not a published version, so no image tag names it. */
+export class ClusterVersionNotPublishedError extends Error {
+  constructor(readonly version: string) {
+    super(`"${version}" is not a published version; an envelope daemon upgrade needs an exact version such as 1.5.0`)
+    this.name = 'ClusterVersionNotPublishedError'
   }
 }
 
@@ -199,9 +208,13 @@ export class ClusterExecutionService {
    * lives in `withImageTag`, so this cannot be reached by forgetting to validate a route.
    */
   async setDaemonVersion(orgId: OrgId, version: string): Promise<string> {
+    // Re-canonicalized here even though the route already did: this seam composes the tag,
+    // and `v1.5.0` arriving unnormalized would become `vv1.5.0` in a registry reference.
+    const canonical = canonicalVersion(version)
+    if (!canonical) throw new ClusterVersionNotPublishedError(version)
     const settings = await this.repo.get(orgId)
     if (!settings?.enabled) throw new ClusterEnvelopeNotEnabledError()
-    const daemonImage = withImageTag(settings.daemonImage, versionImageTag(this.tagStyleFor(settings), version))
+    const daemonImage = withImageTag(settings.daemonImage, versionImageTag(this.tagStyleFor(settings), canonical))
     if (daemonImage === settings.daemonImage) return daemonImage
     // The two halves of `configure`, split so the caller can tell them apart: everything
     // above here wrote nothing, and everything below runs with the change already durable.

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -184,7 +184,7 @@ export class ClusterExecutionService {
     private readonly daemons: Pick<DaemonRepo, 'clusterBoundIds'>,
     /** Carries cluster upgrades' compensation obligations; see
      *  {@link ClusterExecutionService.drainUpgradeCompensations}. */
-    private readonly lifecycleOps: Pick<DaemonLifecycleOpRepo, 'listOverdueCompensations' | 'settle'>,
+    private readonly lifecycleOps: Pick<DaemonLifecycleOpRepo, 'listOverdueCompensations' | 'settleWithCompensation'>,
     /** Drives the transition lease; the same seam every other timed CP path uses. */
     private readonly clock: Clock
   ) {}
@@ -230,9 +230,9 @@ export class ClusterExecutionService {
    * Throws `InvalidImageTagError` for a `version` that is not a usable tag — the guard
    * lives in `withImageTag`, so this cannot be reached by forgetting to validate a route.
    */
-  async setDaemonVersion(orgId: OrgId, version: string): Promise<string> {
+  async setDaemonVersion(orgId: OrgId, version: string, ownerOpId?: string): Promise<string> {
     const plan = await this.planDaemonVersion(orgId, version)
-    await this.applyDaemonVersion(orgId, plan)
+    await this.applyDaemonVersion(orgId, plan, ownerOpId)
     return plan.image
   }
 
@@ -262,9 +262,15 @@ export class ClusterExecutionService {
    * the row is desired state, so the envelope re-apply pass will enact it regardless of
    * this attempt, and only a caller that owns a deadline needs to undo that.
    */
-  async applyDaemonVersion(orgId: OrgId, plan: DaemonVersionPlan): Promise<void> {
+  async applyDaemonVersion(orgId: OrgId, plan: DaemonVersionPlan, ownerOpId?: string): Promise<void> {
     if (plan.image === plan.previousImage) return
-    await this.repo.upsert(orgId, this.defaults(orgId), { daemonImage: plan.image })
+    // The owner is written WITH the image, so a rollback can name this write rather than the
+    // value it produced: the fleet sweep frequently writes the same version an operator asked
+    // for, and an unowned match would let a stale obligation revert it.
+    await this.repo.upsert(orgId, this.defaults(orgId), {
+      daemonImage: plan.image,
+      ...(ownerOpId ? { daemonImageOwner: ownerOpId } : {})
+    })
     try {
       await this.converge(orgId)
     } catch (err) {
@@ -273,40 +279,31 @@ export class ClusterExecutionService {
   }
 
   /**
-   * Give up a deferred image so it cannot land later, and report whether it worked.
+   * Discharge one upgrade's obligation: fail the operation and put its envelope's image
+   * back, atomically and owner-guarded (see `settleWithCompensation`).
    *
    * A durable-but-unapplied image converges on its own, which is right for the fleet sweep
    * and wrong for a COMMAND: a command carries a deadline, and a cluster that stays
    * unreachable past it leaves the operation reported failed while the re-apply pass goes on
-   * to replace the pod anyway — the very contradiction keeping the operation open was meant
-   * to avoid. So the caller that owns a deadline abandons the intent instead, making failure
-   * the truth rather than a temporary description.
-   *
-   * The fence is the IMAGE this call wrote, and the answer is READ BACK rather than inferred
-   * from the absence of an error. Both matter: a revision fence would decline the restore
-   * whenever any unrelated settings edit had bumped the revision — leaving the image durable
-   * while reporting success — and a conditional update that matched nothing is silent, so
-   * assuming it worked is how a command gets closed over a change that is still coming.
-   *
-   * True therefore means one observed fact: the row no longer names this call's image. It is
-   * restored, or a peer replaced it with their own — and a peer's image is what will be
-   * applied, not this one's, so the command is genuinely not going to happen either way.
+   * to replace the pod anyway. So the caller that owns a deadline withdraws the intent
+   * instead, making failure the truth rather than a temporary description.
    *
    * The CR was never changed (that is what failed), so restoring the row is all it takes.
    * The exception is an apply whose REPLY was lost after landing: the resource then holds
    * the new image and the next re-apply pass returns it to the restored row — a brief flap
    * ending on the version this operation reported, which is the consistent outcome.
    *
-   * False ⇒ the image is still the durable desired state, so it is still coming; the caller
-   * must keep its operation open rather than call it failed.
+   * False ⇒ the operation was no longer pending, so somebody else decided it and nothing was
+   * touched. Throws only if the transaction itself could not run, and then nothing changed.
    */
-  async abandonDaemonVersion(orgId: OrgId, commandImage: string, rollbackImage: string): Promise<boolean> {
-    try {
-      const current = await this.repo.restoreDaemonImage(orgId, rollbackImage, commandImage)
-      return current !== commandImage
-    } catch {
-      return false
-    }
+  async compensateUpgrade(orgId: OrgId, opId: string, rollbackImage: string): Promise<boolean> {
+    return this.lifecycleOps.settleWithCompensation({
+      opId,
+      orgId,
+      rollbackImage,
+      outcome: COMPENSATED_OUTCOME,
+      at: new Date(this.clock.now())
+    })
   }
 
   /**
@@ -318,23 +315,18 @@ export class ClusterExecutionService {
    * retries ran out, still finishes what the command started. Each op carries both halves of
    * its obligation, recorded before the forward write, so nothing has to be inferred.
    *
-   * An op is settled `failed` only once its image is OBSERVED absent from the row. One whose
-   * image is still durable is left pending for the next pass — it is still going to be
-   * applied, and that is precisely when calling it failed would be a lie. An op that stopped
-   * being pending in the meantime (the cluster recovered, the pod arrived, it settled
-   * `succeeded`) is skipped, because rolling back then would revert a completed upgrade.
-   *
-   * Returns how many it settled.
+   * Per-entry and best-effort: one org whose transaction fails costs the rest of the pass
+   * nothing and is retried next time. Returns how many operations it settled.
    */
   async drainUpgradeCompensations(limit = COMPENSATION_BATCH): Promise<number> {
-    const now = new Date(this.clock.now())
-    const owed = await this.lifecycleOps.listOverdueCompensations(now, limit)
+    const owed = await this.lifecycleOps.listOverdueCompensations(new Date(this.clock.now()), limit)
     let settled = 0
     for (const entry of owed) {
-      if (!(await this.abandonDaemonVersion(OrgId(entry.orgId), entry.commandImage, entry.rollbackImage))) continue
-      // `settle` transitions only a still-pending row, so a peer that closed this op between
-      // the listing and here keeps its verdict.
-      if (await this.lifecycleOps.settle(entry.opId, 'failed', COMPENSATED_OUTCOME, now)) settled += 1
+      try {
+        if (await this.compensateUpgrade(OrgId(entry.orgId), entry.opId, entry.rollbackImage)) settled += 1
+      } catch {
+        // Nothing changed — the obligation is still on the op for the next pass.
+      }
     }
     return settled
   }
@@ -699,6 +691,7 @@ export class ClusterExecutionService {
       enabled: false,
       specRevision: 0,
       suspend: false,
+      daemonImageOwner: null,
       ...defaults,
       createdAt: epoch,
       updatedAt: epoch

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -29,7 +29,15 @@ import type {
   OrgRepo
 } from '../persistence/ports.js'
 import type { OrgResourceApi } from './org-api.js'
-import { imageRepository, imageTag, isNewerVersion, versionImageTag, withImageTag } from './image.js'
+import {
+  imageRepository,
+  imageTag,
+  isNewerVersion,
+  versionImageTag,
+  versionTagStyle,
+  withImageTag,
+  type VersionTagStyle
+} from './image.js'
 import { ABSENT_ENVELOPE, buildSpec, orgResourceName, projectStatus, type ClusterEnvelopeStatus } from './spec.js'
 
 /** Bounded re-apply passes; each concurrent writer runs its own, so this only
@@ -85,10 +93,18 @@ export class ClusterEnvelopeNotEnabledError extends Error {
   }
 }
 
-/** Raised when an envelope's daemon image is pinned by digest, so there is no tag to move. */
+/**
+ * Raised when an envelope's daemon image gives no tag to move to.
+ *
+ * Two shapes reach it, for one reason: nothing in scope says which tag a released version
+ * would be. A DIGEST is an exact pin, and replacing it with a tag would discard the pin an
+ * operator chose. A FLOATING tag (`latest`, `rc`) says which image to run but never how
+ * this repository spells a version — and guessing produces a tag that does not exist, so
+ * the upgrade would land the pod in ImagePullBackOff instead of failing here.
+ */
 export class ClusterImageNotVersionedError extends Error {
   constructor(readonly image: string) {
-    super(`the envelope's daemon image "${image}" is not version-tagged`)
+    super(`the envelope's daemon image "${image}" does not name a version, so there is no release tag to follow`)
     this.name = 'ClusterImageNotVersionedError'
   }
 }
@@ -185,11 +201,7 @@ export class ClusterExecutionService {
   async setDaemonVersion(orgId: OrgId, version: string): Promise<string> {
     const settings = await this.repo.get(orgId)
     if (!settings?.enabled) throw new ClusterEnvelopeNotEnabledError()
-    const currentTag = imageTag(settings.daemonImage)
-    // A digest pin has no tag to move, and silently replacing it with one would discard
-    // an exact pin somebody chose. Refuse instead of pretending the upgrade happened.
-    if (currentTag === null) throw new ClusterImageNotVersionedError(settings.daemonImage)
-    const daemonImage = withImageTag(settings.daemonImage, versionImageTag(currentTag, version))
+    const daemonImage = withImageTag(settings.daemonImage, versionImageTag(this.tagStyleFor(settings), version))
     if (daemonImage === settings.daemonImage) return daemonImage
     // The two halves of `configure`, split so the caller can tell them apart: everything
     // above here wrote nothing, and everything below runs with the change already durable.
@@ -200,6 +212,24 @@ export class ClusterExecutionService {
       throw new ClusterImageWriteDeferredError(daemonImage, err)
     }
     return daemonImage
+  }
+
+  /**
+   * How this envelope's repository spells a released version.
+   *
+   * The org's own tag is the evidence when it is itself a version. When it is not — a
+   * floating tag somebody pinned deliberately — the install's configured reference is the
+   * fallback, but ONLY for the same repository: a convention observed on one registry says
+   * nothing about another, and this deployment declared that one for its own image. With
+   * neither, there is nothing to infer from and the write is refused rather than guessed.
+   */
+  private tagStyleFor(settings: ClusterExecutionSettings): VersionTagStyle {
+    const sameRepository = imageRepository(settings.daemonImage) === imageRepository(this.policy.daemonImage)
+    const style =
+      versionTagStyle(imageTag(settings.daemonImage)) ??
+      (sameRepository ? versionTagStyle(imageTag(this.policy.daemonImage)) : null)
+    if (!style) throw new ClusterImageNotVersionedError(settings.daemonImage)
+    return style
   }
 
   /**

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -118,6 +118,19 @@ export class ClusterImageNotVersionedError extends Error {
   }
 }
 
+/**
+ * Raised when a peer wrote the daemon image between a command resolving its baseline and
+ * writing. Nothing was touched: the write is conditional on that baseline precisely so losing
+ * the race is visible rather than destructive — an unconditional write would discard the
+ * peer's value and then record a baseline a later rollback would restore over it.
+ */
+export class ClusterImageSupersededError extends Error {
+  constructor(readonly expectedImage: string) {
+    super(`the envelope's daemon image changed from "${expectedImage}" while this command was resolving`)
+    this.name = 'ClusterImageSupersededError'
+  }
+}
+
 /** Raised when an upgrade target is not a published version, so no image tag names it. */
 export class ClusterVersionNotPublishedError extends Error {
   constructor(readonly version: string) {
@@ -264,13 +277,14 @@ export class ClusterExecutionService {
    */
   async applyDaemonVersion(orgId: OrgId, plan: DaemonVersionPlan, ownerOpId?: string): Promise<void> {
     if (plan.image === plan.previousImage) return
-    // The owner is written WITH the image, so a rollback can name this write rather than the
-    // value it produced: the fleet sweep frequently writes the same version an operator asked
-    // for, and an unowned match would let a stale obligation revert it.
-    await this.repo.upsert(orgId, this.defaults(orgId), {
-      daemonImage: plan.image,
-      ...(ownerOpId ? { daemonImageOwner: ownerOpId } : {})
-    })
+    // Conditional on the baseline the plan read, so a peer that wrote in between is neither
+    // overwritten nor mis-recorded as this write's rollback target. The owner goes in the same
+    // statement, so a rollback can name this WRITE rather than the value it produced — the
+    // fleet sweep frequently writes the same version an operator asked for, and an unowned
+    // match would let a stale obligation revert it.
+    if (!(await this.repo.claimDaemonImage(orgId, plan.image, ownerOpId ?? null, plan.previousImage))) {
+      throw new ClusterImageSupersededError(plan.previousImage)
+    }
     try {
       await this.converge(orgId)
     } catch (err) {
@@ -383,7 +397,11 @@ export class ClusterExecutionService {
         await this.setDaemonVersion(OrgId(row.orgId), version)
         sweep.moved.push(row.orgId)
       } catch (err) {
+        // A deferred write is durable, so it counts as moved: the row is what the re-apply
+        // pass renders from. A superseded one means a peer wrote this envelope while the pass
+        // was working — their value stands, and the next boot re-evaluates it.
         if (err instanceof ClusterImageWriteDeferredError) sweep.moved.push(row.orgId)
+        else if (err instanceof ClusterImageSupersededError) sweep.skipped += 1
         else sweep.failed.push({ orgId: row.orgId, err })
       }
     }

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -132,8 +132,6 @@ export class ClusterImageWriteDeferredError extends Error {
     readonly image: string,
     /** What the envelope named before this write — what abandoning the intent restores. */
     readonly previousImage: string,
-    /** The revision this write produced; the fence that keeps an abandon from clobbering a peer. */
-    readonly specRevision: number,
     override readonly cause: unknown
   ) {
     super(`the daemon image "${image}" is recorded but the cluster refused this apply`)
@@ -222,11 +220,11 @@ export class ClusterExecutionService {
     if (daemonImage === settings.daemonImage) return daemonImage
     // The two halves of `configure`, split so the caller can tell them apart: everything
     // above here wrote nothing, and everything below runs with the change already durable.
-    const written = await this.repo.upsert(orgId, this.defaults(orgId), { daemonImage })
+    await this.repo.upsert(orgId, this.defaults(orgId), { daemonImage })
     try {
       await this.converge(orgId)
     } catch (err) {
-      throw new ClusterImageWriteDeferredError(daemonImage, settings.daemonImage, written.specRevision, err)
+      throw new ClusterImageWriteDeferredError(daemonImage, settings.daemonImage, err)
     }
     return daemonImage
   }
@@ -241,22 +239,28 @@ export class ClusterExecutionService {
    * to avoid. So the caller that owns a deadline abandons the intent instead, making failure
    * the truth rather than a temporary description.
    *
-   * The restore is fenced on the revision this write produced: a peer that has since edited
-   * the row owns it, and reverting blindly would discard their value. A fenced-out revision
-   * still counts as abandoned — a peer's image is what will be applied, not this call's.
+   * The fence is the IMAGE this call wrote, and the answer is READ BACK rather than inferred
+   * from the absence of an error. Both matter: a revision fence would decline the restore
+   * whenever any unrelated settings edit had bumped the revision — leaving the image durable
+   * while reporting success — and a conditional update that matched nothing is silent, so
+   * assuming it worked is how a command gets closed over a change that is still coming.
+   *
+   * True therefore means one observed fact: the row no longer names this call's image. It is
+   * restored, or a peer replaced it with their own — and a peer's image is what will be
+   * applied, not this one's, so the command is genuinely not going to happen either way.
    *
    * The CR was never changed (that is what failed), so restoring the row is all it takes.
    * The exception is an apply whose REPLY was lost after landing: the resource then holds
    * the new image and the next re-apply pass returns it to the restored row — a brief flap
    * ending on the version this operation reported, which is the consistent outcome.
    *
-   * False ⇒ the restore itself failed, so the image is still durable and still coming; the
-   * caller must keep its operation open rather than call it failed.
+   * False ⇒ the image is still the durable desired state, so it is still coming; the caller
+   * must keep its operation open rather than call it failed.
    */
   async abandonDaemonVersion(orgId: OrgId, deferred: ClusterImageWriteDeferredError): Promise<boolean> {
     try {
-      await this.repo.restoreDaemonImage(orgId, deferred.previousImage, deferred.specRevision)
-      return true
+      const current = await this.repo.restoreDaemonImage(orgId, deferred.previousImage, deferred.image)
+      return current !== deferred.image
     } catch {
       return false
     }

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -29,6 +29,7 @@ import type {
   OrgRepo
 } from '../persistence/ports.js'
 import type { OrgResourceApi } from './org-api.js'
+import { imageRepository, imageTag, isNewerVersion, withImageTag } from './image.js'
 import { ABSENT_ENVELOPE, buildSpec, orgResourceName, projectStatus, type ClusterEnvelopeStatus } from './spec.js'
 
 /** Bounded re-apply passes; each concurrent writer runs its own, so this only
@@ -76,6 +77,33 @@ export class ClusterTransitionInProgressError extends Error {
   }
 }
 
+/** Raised when an org has no live envelope to repoint at another daemon version. */
+export class ClusterEnvelopeNotEnabledError extends Error {
+  constructor() {
+    super('cluster execution is not enabled for this organization')
+    this.name = 'ClusterEnvelopeNotEnabledError'
+  }
+}
+
+/** Raised when an envelope's daemon image is pinned by digest, so there is no tag to move. */
+export class ClusterImageNotVersionedError extends Error {
+  constructor(readonly image: string) {
+    super(`the envelope's daemon image "${image}" is not version-tagged`)
+    this.name = 'ClusterImageNotVersionedError'
+  }
+}
+
+/** What one deployment-wide version sweep did; `skipped` counts envelopes left deliberately alone. */
+export interface ClusterVersionSweep {
+  /** The image every moved envelope was pointed at. */
+  target: string
+  scanned: number
+  /** Org ids whose envelope now names `target`. */
+  moved: string[]
+  skipped: number
+  failed: { orgId: string; err: unknown }[]
+}
+
 export class ClusterExecutionService {
   /** Where the last re-apply pass stopped; null ⇒ start from the top of the fleet.
    *  Per process, deliberately: two replicas sweeping from different offsets both
@@ -119,6 +147,72 @@ export class ClusterExecutionService {
     if (patch.enabled === true) return this.enable(orgId, patch)
     await this.repo.upsert(orgId, this.defaults(orgId), patch)
     return this.converge(orgId)
+  }
+
+  /**
+   * Repoint one org's envelope daemon at a published version — the cluster half of a
+   * console-commanded daemon upgrade. A machine daemon reinstalls itself from npm; a pod
+   * cannot, so the version moves by rewriting the tag on its image and letting the
+   * operator's `Recreate` rollout replace the pod.
+   *
+   * It goes through `configure` rather than patching the CR directly, and that is the
+   * point: the row is desired state and {@link ClusterExecutionService.resyncEnvelopes}
+   * renders the spec from it, so an image written onto the resource alone would be
+   * reverted by the next pass. Returns the applied image reference.
+   *
+   * Throws `InvalidImageTagError` for a `version` that is not a usable tag — the guard
+   * lives in `withImageTag`, so this cannot be reached by forgetting to validate a route.
+   */
+  async setDaemonVersion(orgId: OrgId, version: string): Promise<string> {
+    const settings = await this.repo.get(orgId)
+    if (!settings?.enabled) throw new ClusterEnvelopeNotEnabledError()
+    // A digest pin has no tag to move, and silently replacing it with one would discard
+    // an exact pin somebody chose. Refuse instead of pretending the upgrade happened.
+    if (imageTag(settings.daemonImage) === null) throw new ClusterImageNotVersionedError(settings.daemonImage)
+    const daemonImage = withImageTag(settings.daemonImage, version)
+    if (daemonImage !== settings.daemonImage) await this.configure(orgId, { daemonImage })
+    return daemonImage
+  }
+
+  /**
+   * Move every enabled envelope onto `version` — the deployment-wide sweep the control
+   * plane runs at boot, so a release published while it was down reaches the fleet
+   * without an operator visiting each organization.
+   *
+   * Two envelopes are deliberately left alone: one whose daemon image names another
+   * repository than this install configured (somebody pointed that org elsewhere, and
+   * this channel says nothing about that registry's tags), and one whose current tag is
+   * not older than the target — a floating tag, a digest, or a version already ahead.
+   * Rolling a fleet BACKWARDS on a restart is the one outcome worse than staying stale.
+   *
+   * Returns a tally for the caller to log.
+   */
+  async alignDaemonVersion(version: string): Promise<ClusterVersionSweep> {
+    const installRepository = imageRepository(this.policy.daemonImage)
+    const target = withImageTag(this.policy.daemonImage, version)
+    const rows = await this.repo.listEnabled()
+    const sweep: ClusterVersionSweep = { target, scanned: rows.length, moved: [], skipped: 0, failed: [] }
+    for (const row of rows) {
+      const current = imageTag(row.daemonImage)
+      if (
+        current === null ||
+        imageRepository(row.daemonImage) !== installRepository ||
+        !isNewerVersion(version, current)
+      ) {
+        sweep.skipped += 1
+        continue
+      }
+      // Per-org and best-effort: one unreachable API server, or one org whose envelope is
+      // mid-transition, must not stop the rest of the fleet from moving.
+      try {
+        await this.configure(OrgId(row.orgId), { daemonImage: target })
+        sweep.moved.push(row.orgId)
+      } catch (err) {
+        // The next boot re-runs the sweep; nothing durable is owed in between.
+        sweep.failed.push({ orgId: row.orgId, err })
+      }
+    }
+    return sweep
   }
 
   /**

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -130,6 +130,10 @@ export class ClusterVersionNotPublishedError extends Error {
 export class ClusterImageWriteDeferredError extends Error {
   constructor(
     readonly image: string,
+    /** What the envelope named before this write — what abandoning the intent restores. */
+    readonly previousImage: string,
+    /** The revision this write produced; the fence that keeps an abandon from clobbering a peer. */
+    readonly specRevision: number,
     override readonly cause: unknown
   ) {
     super(`the daemon image "${image}" is recorded but the cluster refused this apply`)
@@ -218,13 +222,44 @@ export class ClusterExecutionService {
     if (daemonImage === settings.daemonImage) return daemonImage
     // The two halves of `configure`, split so the caller can tell them apart: everything
     // above here wrote nothing, and everything below runs with the change already durable.
-    await this.repo.upsert(orgId, this.defaults(orgId), { daemonImage })
+    const written = await this.repo.upsert(orgId, this.defaults(orgId), { daemonImage })
     try {
       await this.converge(orgId)
     } catch (err) {
-      throw new ClusterImageWriteDeferredError(daemonImage, err)
+      throw new ClusterImageWriteDeferredError(daemonImage, settings.daemonImage, written.specRevision, err)
     }
     return daemonImage
+  }
+
+  /**
+   * Give up a deferred image so it cannot land later, and report whether it worked.
+   *
+   * A durable-but-unapplied image converges on its own, which is right for the fleet sweep
+   * and wrong for a COMMAND: a command carries a deadline, and a cluster that stays
+   * unreachable past it leaves the operation reported failed while the re-apply pass goes on
+   * to replace the pod anyway — the very contradiction keeping the operation open was meant
+   * to avoid. So the caller that owns a deadline abandons the intent instead, making failure
+   * the truth rather than a temporary description.
+   *
+   * The restore is fenced on the revision this write produced: a peer that has since edited
+   * the row owns it, and reverting blindly would discard their value. A fenced-out revision
+   * still counts as abandoned — a peer's image is what will be applied, not this call's.
+   *
+   * The CR was never changed (that is what failed), so restoring the row is all it takes.
+   * The exception is an apply whose REPLY was lost after landing: the resource then holds
+   * the new image and the next re-apply pass returns it to the restored row — a brief flap
+   * ending on the version this operation reported, which is the consistent outcome.
+   *
+   * False ⇒ the restore itself failed, so the image is still durable and still coming; the
+   * caller must keep its operation open rather than call it failed.
+   */
+  async abandonDaemonVersion(orgId: OrgId, deferred: ClusterImageWriteDeferredError): Promise<boolean> {
+    try {
+      await this.repo.restoreDaemonImage(orgId, deferred.previousImage, deferred.specRevision)
+      return true
+    } catch {
+      return false
+    }
   }
 
   /**

--- a/packages/control-plane/src/cluster/service.ts
+++ b/packages/control-plane/src/cluster/service.ts
@@ -24,6 +24,7 @@ import type {
   ClusterExecutionDefaults,
   ClusterExecutionPatch,
   ClusterExecutionSettings,
+  DaemonLifecycleOpRepo,
   DaemonRepo,
   OrgClusterExecutionRepo,
   OrgRepo
@@ -51,6 +52,13 @@ const TEARDOWN_BATCH = 50
 /** Envelopes re-applied per pass. A slice rather than the fleet, so one pass costs a
  *  bounded number of requests; the rotation below is what still covers everyone. */
 const RESYNC_BATCH = 100
+
+/** Overdue upgrade obligations discharged per pass; a backlog is rare and drains over passes. */
+const COMPENSATION_BATCH = 50
+
+/** What a compensated operation reports. It names the fact an operator can act on — the
+ *  envelope is back where it was — rather than the transport error that caused it. */
+const COMPENSATED_OUTCOME = 'the cluster did not accept the new daemon image; the envelope was rolled back'
 
 /** How long one caller may own an envelope transition before it is taken over.
  *  Generous against a slow API server, short enough that a crashed process does
@@ -139,6 +147,16 @@ export class ClusterImageWriteDeferredError extends Error {
   }
 }
 
+/** What an upgrade would write, resolved from a read so the obligation can be recorded first. */
+export interface DaemonVersionPlan {
+  /** The canonical (npm-spelled) version, which is also what the replacement pod reports. */
+  version: string
+  /** The image reference to write — the version translated into this repository's tag style. */
+  image: string
+  /** What the envelope names now; the value a compensation restores. */
+  previousImage: string
+}
+
 /** What one deployment-wide version sweep did; `skipped` counts envelopes left deliberately alone. */
 export interface ClusterVersionSweep {
   /** The published version every moved envelope was pointed at. */
@@ -164,6 +182,9 @@ export class ClusterExecutionService {
     private readonly policy: ClusterExecutionPolicy,
     /** Names the envelope's own daemon; see {@link ClusterExecutionService.envelopeDaemonIds}. */
     private readonly daemons: Pick<DaemonRepo, 'clusterBoundIds'>,
+    /** Carries cluster upgrades' compensation obligations; see
+     *  {@link ClusterExecutionService.drainUpgradeCompensations}. */
+    private readonly lifecycleOps: Pick<DaemonLifecycleOpRepo, 'listOverdueCompensations' | 'settle'>,
     /** Drives the transition lease; the same seam every other timed CP path uses. */
     private readonly clock: Clock
   ) {}
@@ -210,23 +231,45 @@ export class ClusterExecutionService {
    * lives in `withImageTag`, so this cannot be reached by forgetting to validate a route.
    */
   async setDaemonVersion(orgId: OrgId, version: string): Promise<string> {
-    // Re-canonicalized here even though the route already did: this seam composes the tag,
-    // and `v1.5.0` arriving unnormalized would become `vv1.5.0` in a registry reference.
+    const plan = await this.planDaemonVersion(orgId, version)
+    await this.applyDaemonVersion(orgId, plan)
+    return plan.image
+  }
+
+  /**
+   * Resolve what an upgrade WOULD write, reading only. Split from the write so a caller can
+   * record the compensation obligation in between: every refusal is raised here, before
+   * anything durable exists, and `applyDaemonVersion` below runs only once the obligation is
+   * on disk. Ordering the two that way is what lets a process die mid-command without
+   * stranding a change nobody can undo.
+   *
+   * Throws `ClusterVersionNotPublishedError` for a target that is not a version — re-checked
+   * here even when a route already normalized, because this seam composes the tag and
+   * `v1.5.0` arriving unnormalized would become `vv1.5.0` in a registry reference.
+   */
+  async planDaemonVersion(orgId: OrgId, version: string): Promise<DaemonVersionPlan> {
     const canonical = canonicalVersion(version)
     if (!canonical) throw new ClusterVersionNotPublishedError(version)
     const settings = await this.repo.get(orgId)
     if (!settings?.enabled) throw new ClusterEnvelopeNotEnabledError()
-    const daemonImage = withImageTag(settings.daemonImage, versionImageTag(this.tagStyleFor(settings), canonical))
-    if (daemonImage === settings.daemonImage) return daemonImage
-    // The two halves of `configure`, split so the caller can tell them apart: everything
-    // above here wrote nothing, and everything below runs with the change already durable.
-    await this.repo.upsert(orgId, this.defaults(orgId), { daemonImage })
+    const image = withImageTag(settings.daemonImage, versionImageTag(this.tagStyleFor(settings), canonical))
+    return { version: canonical, image, previousImage: settings.daemonImage }
+  }
+
+  /**
+   * Make a plan durable and push it. Everything here runs with the change already recorded,
+   * which is why a failure is `ClusterImageWriteDeferredError` rather than a plain error:
+   * the row is desired state, so the envelope re-apply pass will enact it regardless of
+   * this attempt, and only a caller that owns a deadline needs to undo that.
+   */
+  async applyDaemonVersion(orgId: OrgId, plan: DaemonVersionPlan): Promise<void> {
+    if (plan.image === plan.previousImage) return
+    await this.repo.upsert(orgId, this.defaults(orgId), { daemonImage: plan.image })
     try {
       await this.converge(orgId)
     } catch (err) {
-      throw new ClusterImageWriteDeferredError(daemonImage, settings.daemonImage, err)
+      throw new ClusterImageWriteDeferredError(plan.image, plan.previousImage, err)
     }
-    return daemonImage
   }
 
   /**
@@ -257,13 +300,43 @@ export class ClusterExecutionService {
    * False ⇒ the image is still the durable desired state, so it is still coming; the caller
    * must keep its operation open rather than call it failed.
    */
-  async abandonDaemonVersion(orgId: OrgId, deferred: ClusterImageWriteDeferredError): Promise<boolean> {
+  async abandonDaemonVersion(orgId: OrgId, commandImage: string, rollbackImage: string): Promise<boolean> {
     try {
-      const current = await this.repo.restoreDaemonImage(orgId, deferred.previousImage, deferred.image)
-      return current !== deferred.image
+      const current = await this.repo.restoreDaemonImage(orgId, rollbackImage, commandImage)
+      return current !== commandImage
     } catch {
       return false
     }
+  }
+
+  /**
+   * Discharge the compensation obligations of overdue cluster upgrades — the durable half of
+   * the rollback, and the only half that survives a restart.
+   *
+   * An in-request rollback is an intention held in one process; this is the same decision
+   * reconstructed from disk, so a control plane that exited mid-command, or one whose bounded
+   * retries ran out, still finishes what the command started. Each op carries both halves of
+   * its obligation, recorded before the forward write, so nothing has to be inferred.
+   *
+   * An op is settled `failed` only once its image is OBSERVED absent from the row. One whose
+   * image is still durable is left pending for the next pass — it is still going to be
+   * applied, and that is precisely when calling it failed would be a lie. An op that stopped
+   * being pending in the meantime (the cluster recovered, the pod arrived, it settled
+   * `succeeded`) is skipped, because rolling back then would revert a completed upgrade.
+   *
+   * Returns how many it settled.
+   */
+  async drainUpgradeCompensations(limit = COMPENSATION_BATCH): Promise<number> {
+    const now = new Date(this.clock.now())
+    const owed = await this.lifecycleOps.listOverdueCompensations(now, limit)
+    let settled = 0
+    for (const entry of owed) {
+      if (!(await this.abandonDaemonVersion(OrgId(entry.orgId), entry.commandImage, entry.rollbackImage))) continue
+      // `settle` transitions only a still-pending row, so a peer that closed this op between
+      // the listing and here keeps its verdict.
+      if (await this.lifecycleOps.settle(entry.opId, 'failed', COMPENSATED_OUTCOME, now)) settled += 1
+    }
+    return settled
   }
 
   /**

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -497,6 +497,7 @@ export function buildContainer(
             controlPlaneUrl: daemonWsUrl(httpServerConfigFrom(config, { DEFAULT_OWNER_ID, relayStaleMs }))
           },
           repos.daemon,
+          repos.daemonLifecycleOp,
           clock
         )
       : undefined

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -38,6 +38,7 @@ import { K8sHttp } from '@agentconnect.md/k8s-client'
 import {
   AgentConnectOrgApi,
   ClusterDaemonIdentityService,
+  ClusterDaemonImageSync,
   ClusterExecutionService,
   ClusterMaintenanceLoop,
   loadClusterAccess
@@ -1069,6 +1070,15 @@ export function buildContainer(
     http.log
   )
 
+  // Boot-time only: point every enabled envelope at the newest daemon image the
+  // deployment's release channel names, so a release published while this process was
+  // down reaches the fleet. Needs both halves — no envelopes to move without cluster
+  // execution, and no notion of "newest" without the release resolver (inert in tests).
+  const clusterImageSync =
+    clusterExecution && daemonRelease
+      ? new ClusterDaemonImageSync(clusterExecution, daemonRelease, http.log)
+      : undefined
+
   // Durable one-time assertion recovery. Invocation rows are reaped before
   // expired delegations so a parent is never removed while cached/recoverable
   // invocation state still depends on it.
@@ -1638,6 +1648,9 @@ export function buildContainer(
       // One-shot (not a re-arming loop): the worklist empties itself; a partially
       // failed boot resumes on the next one. Never blocks listen.
       void presetBackfill?.run().catch((err) => http.log.error({ err }, 'preset-backfill: sweep failed'))
+      // Also one-shot, and deliberately so: this is the catch-up for a daemon release
+      // published while the process was down, not a policy that re-asserts on a timer.
+      void clusterImageSync?.run()
     },
     async shutdown() {
       clusterMaintenance.stop()

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -179,6 +179,10 @@ export const DaemonViewDto = z.object({
   /** Human-assigned display name (console-set); null until named. */
   name: z.string().nullable(),
   agentVersion: z.string().nullable(),
+  /** True ⇒ an operator-managed pod in the org's execution envelope. Its version IS its
+   *  container image, so the console offers no restart (Kubernetes owns that) and an
+   *  upgrade repoints the org's `AgentConnectOrg` rather than commanding an npm install. */
+  cluster: z.boolean(),
   /** The deployment's daemon release channel (npm dist-tag, e.g. `latest`/`rc`) that
    *  `latestVersion` was resolved from. Same for every daemon in the deployment. */
   releaseChannel: z.string(),

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -38,7 +38,7 @@ import { provisionDaemonConnect } from '../onboarding.js'
 import { detachDaemon } from '../daemon-removal.js'
 import { Tag } from '../plugins/openapi.js'
 import { CLUSTER_API_ERROR_CODE, sendClusterFailure } from '../cluster-failure.js'
-import type { ClusterExecutionService } from '../../cluster/index.js'
+import type { ClusterExecutionService, DaemonVersionPlan } from '../../cluster/index.js'
 import {
   canonicalVersion,
   ClusterEnvelopeNotEnabledError,
@@ -104,16 +104,16 @@ export async function retryArm(
  * meanwhile applies the image, the replacement pod settles the op `succeeded`, and rolling
  * back after that would revert an upgrade that did complete.
  *
- * Fire-and-forget and bounded, like {@link retryArm}. Exhausting the delays leaves a pending
- * op whose image is durable — the one state that can still expire as failed while the change
- * later lands, and the reason a durable rollback intent is the next thing this would need.
+ * Fire-and-forget and bounded, like {@link retryArm} — a fast path, not the guarantee. The
+ * guarantee is the obligation persisted on the op row, which the cluster maintenance pass
+ * discharges however long it takes and whichever process is running by then.
  */
 export async function retryAbandon(
   cluster: Pick<ClusterExecutionService, 'abandonDaemonVersion'>,
   ops: DaemonLifecycleOpRepo,
   opId: string,
   orgId: OrgId,
-  deferred: ClusterImageWriteDeferredError,
+  owed: { commandImage: string; rollbackImage: string; cause: unknown },
   delaysMs: number[],
   log?: { warn: (obj: unknown, msg?: string) => void }
 ): Promise<boolean> {
@@ -125,8 +125,8 @@ export async function retryAbandon(
     try {
       const op = await ops.getById(opId)
       if (!op || op.status !== 'pending') return true // decided elsewhere; leave the state alone
-      if (!(await cluster.abandonDaemonVersion(orgId, deferred))) continue
-      await ops.settle(opId, 'failed', clusterUpgradeFailure(deferred.cause), new Date())
+      if (!(await cluster.abandonDaemonVersion(orgId, owed.commandImage, owed.rollbackImage))) continue
+      await ops.settle(opId, 'failed', clusterUpgradeFailure(owed.cause), new Date())
       return true
     } catch (err) {
       log?.warn({ opId, orgId, err }, 'cluster daemon upgrade: rollback recovery attempt failed')
@@ -160,6 +160,13 @@ function sendApplyFailure(reply: FastifyReply, cause: unknown, note: string): Fa
     message: `cluster API rejected the daemon image change: ${detail}${note}`,
     code: CLUSTER_API_ERROR_CODE
   })
+}
+
+/** Whether a pending op should READ as failed for having passed its deadline. An op still
+ *  owing a compensation must not: it is terminal only once that is discharged. */
+function isOpExpired(op: DaemonLifecycleOpRecord | null, nowMs: number): boolean {
+  if (!op || op.status !== 'pending' || op.deadline.getTime() > nowMs) return false
+  return op.commandImage === null
 }
 
 /** Outcome text recorded on an op whose image change never landed. */
@@ -209,7 +216,12 @@ function toDto(
   // Read-time expiry projection: a still-`pending` op past its deadline is reported as
   // `failed` (timed out) even before the sweep/next-command persists that — so the
   // console never renders a dead op as in-flight, and a stuck op reads terminal.
-  const expired = latestOp?.status === 'pending' && latestOp.deadline.getTime() <= nowMs
+  //
+  // Except one carrying a compensation obligation: its image may still be the durable desired
+  // state, so it is genuinely still in flight until the compensation pass either withdraws it
+  // or the replacement pod arrives. Showing `failed` first is the contradiction itself, in the
+  // read model rather than the database.
+  const expired = isOpExpired(latestOp, nowMs)
   return {
     daemonId: view.daemonId,
     host: view.host,
@@ -475,7 +487,9 @@ export function daemonRoutes(deps: HttpDeps) {
       id: string,
       op: 'restart' | 'upgrade',
       commandEpoch: bigint,
-      targetVersion?: string
+      targetVersion?: string,
+      /** A cluster upgrade's compensation obligation, recorded before the forward write. */
+      plan?: DaemonVersionPlan
     ): Promise<DaemonLifecycleOpRecord | null> => {
       // Expire stale operations before the partial unique index admits another command.
       await deps.repos.daemonLifecycleOp.expireOverdue(new Date(), DaemonId(id))
@@ -492,7 +506,8 @@ export function daemonRoutes(deps: HttpDeps) {
         ...(targetVersion ? { targetVersion } : {}),
         ...(req.principal?.userId ? { initiator: req.principal.userId } : {}),
         commandEpoch,
-        deadline: new Date(Date.now() + LIFECYCLE_DEADLINE_MS)
+        deadline: new Date(Date.now() + LIFECYCLE_DEADLINE_MS),
+        ...(plan ? { commandImage: plan.image, rollbackImage: plan.previousImage } : {})
       })
     }
 
@@ -566,15 +581,35 @@ export function daemonRoutes(deps: HttpDeps) {
       // The pod is replaced, so it re-auths and its epoch strictly exceeds this one —
       // which is exactly the fence `settleLifecycleOpOnReady` closes the op on.
       const commandEpoch = BigInt(deps.liveness.get(id)?.sessionEpoch ?? existing.sessionEpoch)
-      const opRow = await openLifecycleOp(req, reply, id, 'upgrade', commandEpoch, version)
+      // Resolved BEFORE the op opens, so every refusal happens with nothing durable behind it
+      // and the op can carry the images its compensation would need.
+      let plan
+      try {
+        plan = await cluster.planDaemonVersion(orgOf(req), version)
+      } catch (error) {
+        if (isBadUpgradeTarget(error)) {
+          return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: (error as Error).message })
+        }
+        if (isClusterRefusal(error)) {
+          return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: (error as Error).message })
+        }
+        return sendClusterFailure(reply, error, 'cluster API rejected the daemon image change')
+      }
+      if (plan.image === plan.previousImage) {
+        return reply
+          .code(409)
+          .send({ error: 'Conflict', statusCode: 409, message: `the envelope already names ${plan.image}` })
+      }
+      const opRow = await openLifecycleOp(req, reply, id, 'upgrade', commandEpoch, version, plan)
       if (!opRow) return reply
       // Set only when the apply failed AND the rollback below could not undo it, so the image
       // is still durable and still coming. That is the one outcome this op must not call
-      // failed, and the only one it keeps waiting on.
+      // failed, and the only one it keeps waiting on — and the op row carries the obligation
+      // durably, so the maintenance pass finishes it even if this process does not.
       let deferred: ClusterImageWriteDeferredError | undefined
       try {
-        const image = await cluster.setDaemonVersion(orgOf(req), version)
-        req.log.info({ daemonId: id, opId: opRow.id, image }, 'cluster daemon upgrade: envelope repointed')
+        await cluster.applyDaemonVersion(orgOf(req), plan)
+        req.log.info({ daemonId: id, opId: opRow.id, image: plan.image }, 'cluster daemon upgrade: envelope repointed')
       } catch (error) {
         if (error instanceof ClusterImageWriteDeferredError) {
           // The image is durable and would converge on the re-apply pass — but this op has a
@@ -582,7 +617,7 @@ export function daemonRoutes(deps: HttpDeps) {
           // while the pass replaced the pod anyway. So the intent is abandoned and failure
           // becomes the truth. Only when the rollback ITSELF fails is the image still coming,
           // and then the op has to stay open, because it is going to happen after all.
-          const abandoned = await cluster.abandonDaemonVersion(orgOf(req), error)
+          const abandoned = await cluster.abandonDaemonVersion(orgOf(req), plan.image, plan.previousImage)
           if (!abandoned) {
             deferred = error
             req.log.warn(
@@ -596,7 +631,7 @@ export function daemonRoutes(deps: HttpDeps) {
               deps.repos.daemonLifecycleOp,
               opRow.id,
               orgOf(req),
-              error,
+              { commandImage: plan.image, rollbackImage: plan.previousImage, cause: error.cause },
               ARM_RECOVERY_DELAYS_MS,
               req.log
             )
@@ -611,20 +646,11 @@ export function daemonRoutes(deps: HttpDeps) {
             return sendApplyFailure(reply, error.cause, '; the envelope was rolled back')
           }
         } else {
-          // Everything else was refused BEFORE anything durable was written, so the command
-          // did not happen and never will — terminal-fail it.
+          // The write itself failed, so nothing durable exists and no obligation is owed.
           await deps.repos.daemonLifecycleOp
             .settle(opRow.id, 'failed', clusterUpgradeFailure(error), new Date())
             .catch(() => {})
-          // Already normalized above, so these are the seams re-checking their own inputs;
-          // mapped anyway so a guard firing can never read as a 500.
-          if (isBadUpgradeTarget(error)) {
-            return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: (error as Error).message })
-          }
-          if (isClusterRefusal(error)) {
-            return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: (error as Error).message })
-          }
-          return sendClusterFailure(reply, error, 'cluster API rejected the daemon image change')
+          return sendApplyFailure(reply, error, '')
         }
       }
       // Armed with the same epoch the desired state was written under: the CR is the
@@ -880,7 +906,7 @@ export function daemonRoutes(deps: HttpDeps) {
         if (!opRow || opRow.daemonId !== req.params.id) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'lifecycle op not found' })
         }
-        const expired = opRow.status === 'pending' && opRow.deadline.getTime() <= Date.now()
+        const expired = isOpExpired(opRow, Date.now())
         return {
           id: opRow.id,
           op: opRow.op,

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -17,7 +17,7 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import type { DaemonView, DaemonLiveness, DaemonRegistry } from '../../ports.js'
 import { isSyntheticEmail } from '../../persistence/ports.js'
-import { DaemonId } from '../../domain/ids.js'
+import { DaemonId, type OrgId } from '../../domain/ids.js'
 import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView, canEdit, canManageSharing, type ViewCtx } from '../../authorization/policy.js'
 import { resolveShareSet } from '../sharing.js'
@@ -38,6 +38,7 @@ import { provisionDaemonConnect } from '../onboarding.js'
 import { detachDaemon } from '../daemon-removal.js'
 import { Tag } from '../plugins/openapi.js'
 import { CLUSTER_API_ERROR_CODE, sendClusterFailure } from '../cluster-failure.js'
+import type { ClusterExecutionService } from '../../cluster/index.js'
 import {
   canonicalVersion,
   ClusterEnvelopeNotEnabledError,
@@ -89,6 +90,46 @@ export async function retryArm(
       return true
     } catch (err) {
       log?.warn({ opId, daemonId, err }, 'lifecycle op arm recovery attempt failed')
+    }
+  }
+  return false
+}
+
+/**
+ * Background recovery for an abandonment that could not be confirmed in-request. An image
+ * still durable will be applied by the re-apply pass, so the op must not be closed failed
+ * until the rollback is OBSERVED — this keeps retrying until it is, then closes it.
+ *
+ * It re-reads the op first and stops if it is no longer pending: a cluster that recovered
+ * meanwhile applies the image, the replacement pod settles the op `succeeded`, and rolling
+ * back after that would revert an upgrade that did complete.
+ *
+ * Fire-and-forget and bounded, like {@link retryArm}. Exhausting the delays leaves a pending
+ * op whose image is durable — the one state that can still expire as failed while the change
+ * later lands, and the reason a durable rollback intent is the next thing this would need.
+ */
+export async function retryAbandon(
+  cluster: Pick<ClusterExecutionService, 'abandonDaemonVersion'>,
+  ops: DaemonLifecycleOpRepo,
+  opId: string,
+  orgId: OrgId,
+  deferred: ClusterImageWriteDeferredError,
+  delaysMs: number[],
+  log?: { warn: (obj: unknown, msg?: string) => void }
+): Promise<boolean> {
+  for (const delay of delaysMs) {
+    await new Promise<void>((r) => {
+      const t = setTimeout(r, delay)
+      t.unref?.() // a dangling recovery must never keep the process alive
+    })
+    try {
+      const op = await ops.getById(opId)
+      if (!op || op.status !== 'pending') return true // decided elsewhere; leave the state alone
+      if (!(await cluster.abandonDaemonVersion(orgId, deferred))) continue
+      await ops.settle(opId, 'failed', clusterUpgradeFailure(deferred.cause), new Date())
+      return true
+    } catch (err) {
+      log?.warn({ opId, orgId, err }, 'cluster daemon upgrade: rollback recovery attempt failed')
     }
   }
   return false
@@ -546,7 +587,18 @@ export function daemonRoutes(deps: HttpDeps) {
             deferred = error
             req.log.warn(
               { daemonId: id, opId: opRow.id, image: error.image, err: error.cause },
-              'cluster daemon upgrade: image recorded, rollback failed; the re-apply pass will converge it'
+              'cluster daemon upgrade: image still durable after rollback; scheduling recovery'
+            )
+            // The op stays open because the change is still coming. Recovery closes it once
+            // the rollback is observed — never on the assumption that it worked.
+            void retryAbandon(
+              cluster,
+              deps.repos.daemonLifecycleOp,
+              opRow.id,
+              orgOf(req),
+              error,
+              ARM_RECOVERY_DELAYS_MS,
+              req.log
             )
           } else {
             req.log.warn(

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -37,6 +37,13 @@ import type { DaemonLifecycleOpRecord, DaemonLifecycleOpRepo } from '../../persi
 import { provisionDaemonConnect } from '../onboarding.js'
 import { detachDaemon } from '../daemon-removal.js'
 import { Tag } from '../plugins/openapi.js'
+import { sendClusterFailure } from '../cluster-failure.js'
+import {
+  ClusterEnvelopeNotEnabledError,
+  ClusterImageNotVersionedError,
+  ClusterTransitionInProgressError,
+  InvalidImageTagError
+} from '../../cluster/index.js'
 
 /** Drain + (install +) relaunch + re-register budget for a CP-commanded lifecycle op.
  *  A still-`pending` op older than this reads as no-longer-in-flight and is closed
@@ -82,6 +89,22 @@ export async function retryArm(
     }
   }
   return false
+}
+
+/** A refusal the caller can act on (a disabled envelope, a digest pin, a peer mid-transition)
+ *  rather than an upstream fault — 409, not 502. */
+function isClusterRefusal(error: unknown): boolean {
+  return (
+    error instanceof ClusterEnvelopeNotEnabledError ||
+    error instanceof ClusterImageNotVersionedError ||
+    error instanceof ClusterTransitionInProgressError
+  )
+}
+
+/** Outcome text recorded on an op whose image change never landed. */
+function clusterUpgradeFailure(error: unknown): string {
+  const detail = error instanceof Error ? error.message : 'unknown error'
+  return `the control plane could not repoint the envelope: ${detail}`
 }
 
 /**
@@ -131,6 +154,7 @@ function toDto(
     host: view.host,
     name: view.name,
     agentVersion: view.agentVersion,
+    cluster: view.cluster,
     // Deployment-wide daemon release channel + its latest published version (same
     // for every row); the console flags a daemon whose agentVersion trails it.
     releaseChannel: release.channel,
@@ -383,6 +407,120 @@ export function daemonRoutes(deps: HttpDeps) {
       }
     )
 
+    /** Open the op, refusing when one is already in flight for this daemon. Null ⇒ replied. */
+    const openLifecycleOp = async (
+      req: FastifyRequest,
+      reply: FastifyReply,
+      id: string,
+      op: 'restart' | 'upgrade',
+      commandEpoch: bigint,
+      targetVersion?: string
+    ): Promise<DaemonLifecycleOpRecord | null> => {
+      // Expire stale operations before the partial unique index admits another command.
+      await deps.repos.daemonLifecycleOp.expireOverdue(new Date(), DaemonId(id))
+      // The pre-check gives a clear 409; the partial unique index backstops races.
+      if (await deps.repos.daemonLifecycleOp.pendingForDaemon(DaemonId(id))) {
+        reply
+          .code(409)
+          .send({ error: 'Conflict', statusCode: 409, message: 'a restart or upgrade is already in progress' })
+        return null
+      }
+      return deps.repos.daemonLifecycleOp.open({
+        daemonId: DaemonId(id),
+        op,
+        ...(targetVersion ? { targetVersion } : {}),
+        ...(req.principal?.userId ? { initiator: req.principal.userId } : {}),
+        commandEpoch,
+        deadline: new Date(Date.now() + LIFECYCLE_DEADLINE_MS)
+      })
+    }
+
+    const opDto = (row: DaemonLifecycleOpRecord) => ({
+      id: row.id,
+      op: row.op,
+      status: row.status,
+      targetVersion: row.targetVersion,
+      outcome: row.outcome
+    })
+
+    /**
+     * The cluster daemon's lifecycle: its version is its pod's image, so nothing is sent
+     * over the WebSocket. An upgrade rewrites the tag on `AgentConnectOrg.spec.daemon.image`
+     * and the operator's `Recreate` rollout replaces the pod; a restart is refused outright,
+     * because relaunching a pod is Kubernetes' job and the daemon would decline the command
+     * anyway (it has no supervisor to exit to).
+     *
+     * Reachability is deliberately NOT required: the whole value of this path is that it
+     * also rescues an envelope whose daemon is crash-looping on a bad image.
+     */
+    const clusterLifecycle = async (
+      req: FastifyRequest,
+      reply: FastifyReply,
+      existing: DaemonView,
+      op: 'restart' | 'upgrade',
+      targetVersion?: string
+    ) => {
+      const id = existing.daemonId
+      if (op === 'restart') {
+        return reply.code(409).send({
+          error: 'Conflict',
+          statusCode: 409,
+          message: 'a cluster daemon is relaunched by its operator; change its image instead of restarting it',
+          code: 'DAEMON_CLUSTER_MANAGED'
+        })
+      }
+      const cluster = deps.clusterExecution
+      if (!cluster) {
+        return reply.code(503).send({
+          error: 'Service Unavailable',
+          statusCode: 503,
+          message: 'cluster execution is not configured on this control plane'
+        })
+      }
+      if (!targetVersion) {
+        return reply.code(400).send({
+          error: 'Bad Request',
+          statusCode: 400,
+          message: 'upgrading a cluster daemon requires a target version'
+        })
+      }
+      // Nothing to roll: re-applying the image the pod already runs would change no
+      // generation, so the op could only ever expire. Say so now instead.
+      if (existing.agentVersion === targetVersion) {
+        return reply
+          .code(409)
+          .send({ error: 'Conflict', statusCode: 409, message: `daemon already runs ${targetVersion}` })
+      }
+      // The pod is replaced, so it re-auths and its epoch strictly exceeds this one —
+      // which is exactly the fence `settleLifecycleOpOnReady` closes the op on.
+      const commandEpoch = BigInt(deps.liveness.get(id)?.sessionEpoch ?? existing.sessionEpoch)
+      const opRow = await openLifecycleOp(req, reply, id, 'upgrade', commandEpoch, targetVersion)
+      if (!opRow) return reply
+      try {
+        const image = await cluster.setDaemonVersion(orgOf(req), targetVersion)
+        req.log.info({ daemonId: id, opId: opRow.id, image }, 'cluster daemon upgrade: envelope repointed')
+      } catch (error) {
+        await deps.repos.daemonLifecycleOp
+          .settle(opRow.id, 'failed', clusterUpgradeFailure(error), new Date())
+          .catch(() => {})
+        // Unreachable through `DaemonUpgradeBody`, which already rejects anything that is
+        // not a plain version — mapped anyway so the seam's own guard cannot read as a 500.
+        if (error instanceof InvalidImageTagError) {
+          return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: error.message })
+        }
+        if (isClusterRefusal(error)) {
+          return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: (error as Error).message })
+        }
+        return sendClusterFailure(reply, error, 'cluster API rejected the daemon image change')
+      }
+      // Armed with the same epoch the desired state was written under: the CR is the
+      // command, and the op now waits for the replacement pod's READY.
+      await deps.repos.daemonLifecycleOp.markAccepted(opRow.id, new Date(), commandEpoch).catch((err: unknown) => {
+        req.log.warn({ daemonId: id, opId: opRow.id, err }, 'lifecycle op arm write failed')
+      })
+      return reply.code(202).send(opDto((await deps.repos.daemonLifecycleOp.getById(opRow.id)) ?? opRow))
+    }
+
     // Open a fleet lifecycle op; bootstrap-capable upgrades may wait durably for the next auth.
     const commandLifecycle = async (
       req: FastifyRequest,
@@ -400,6 +538,9 @@ export function daemonRoutes(deps: HttpDeps) {
       if (!canEdit(existing, ctxOf(req))) {
         return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot manage this daemon' })
       }
+      // An operator-managed pod has no npm install to replace and no supervisor to exit
+      // to; its lifecycle runs through the org's resource instead of this connection.
+      if (existing.cluster) return clusterLifecycle(req, reply, existing, op, targetVersion)
       const liveConn = deps.liveness.get(id)
       // Direct delivery requires READY; only advertised bootstrap upgrades can queue offline.
       const liveReady = Boolean(liveConn?.reachable && liveConn.state === 'READY')
@@ -408,23 +549,16 @@ export function daemonRoutes(deps: HttpDeps) {
       if (!liveReady && !bootstrapUpgrade) {
         return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: 'daemon is not ready' })
       }
-      // Expire stale operations before the partial unique index admits another command.
-      await deps.repos.daemonLifecycleOp.expireOverdue(new Date(), DaemonId(id))
-      // The pre-check gives a clear 409; the partial unique index backstops races.
-      if (await deps.repos.daemonLifecycleOp.pendingForDaemon(DaemonId(id))) {
-        return reply
-          .code(409)
-          .send({ error: 'Conflict', statusCode: 409, message: 'a restart or upgrade is already in progress' })
-      }
-      const opRow = await deps.repos.daemonLifecycleOp.open({
-        daemonId: DaemonId(id),
+      // Live delivery replaces this estimate with the sender's actual connection epoch.
+      const opRow = await openLifecycleOp(
+        req,
+        reply,
+        id,
         op,
-        ...(targetVersion ? { targetVersion } : {}),
-        ...(req.principal?.userId ? { initiator: req.principal.userId } : {}),
-        // Live delivery replaces this estimate with the sender's actual connection epoch.
-        commandEpoch: BigInt(liveConn?.sessionEpoch ?? existing.sessionEpoch),
-        deadline: new Date(Date.now() + LIFECYCLE_DEADLINE_MS)
-      })
+        BigInt(liveConn?.sessionEpoch ?? existing.sessionEpoch),
+        targetVersion
+      )
+      if (!opRow) return reply
 
       // Re-resolve after open: READY receives direct control; pre-READY reconnects through auth.
       const deliveryConn = deps.liveness.get(id)
@@ -433,13 +567,7 @@ export function daemonRoutes(deps: HttpDeps) {
         if (deliveryConn?.reachable) {
           deps.liveness.reconnectForBootstrap?.(id, deliveryConn.sessionEpoch)
         }
-        return reply.code(202).send({
-          id: opRow.id,
-          op: opRow.op,
-          status: opRow.status,
-          targetVersion: opRow.targetVersion,
-          outcome: opRow.outcome
-        })
+        return reply.code(202).send(opDto(opRow))
       }
 
       // Arm with the exact sent epoch; background recovery handles exhausted write retries.
@@ -521,13 +649,7 @@ export function daemonRoutes(deps: HttpDeps) {
         void retryArm(deps.repos.daemonLifecycleOp, deps.registry, opRow.id, id, epoch, ARM_RECOVERY_DELAYS_MS, req.log)
       }
       const latest = (await deps.repos.daemonLifecycleOp.getById(opRow.id).catch(() => null)) ?? opRow
-      return reply.code(202).send({
-        id: latest.id,
-        op: latest.op,
-        status: latest.status,
-        targetVersion: latest.targetVersion,
-        outcome: latest.outcome
-      })
+      return reply.code(202).send(opDto(latest))
     }
 
     // Install a target daemon version, then drain + relaunch onto it (§7).
@@ -538,12 +660,13 @@ export function daemonRoutes(deps: HttpDeps) {
           tags: [Tag.Daemons],
           summary: 'Upgrade a daemon',
           description:
-            'Open an upgrade op for a daemon. A ready daemon receives it immediately; an offline daemon that previously advertised bootstrap recovery consumes it during its next auth. The 202 means accepted or durably queued, while success requires READY on the target version.',
+            'Open an upgrade op for a daemon. A ready daemon receives it immediately; an offline daemon that previously advertised bootstrap recovery consumes it during its next auth. A CLUSTER daemon (`cluster: true`) takes neither path: the control plane rewrites the version tag on its organization’s AgentConnectOrg daemon image and the operator replaces the pod, so the command is accepted even while that daemon is offline. The 202 means accepted or durably queued, while success requires READY on the target version.',
           operationId: 'upgradeDaemon',
           params: IdParam,
           body: DaemonUpgradeBody,
           response: {
             202: DaemonLifecycleOpDto,
+            400: ErrorDto,
             403: ErrorDto,
             404: ErrorDto,
             409: ErrorDto,
@@ -563,7 +686,7 @@ export function daemonRoutes(deps: HttpDeps) {
           tags: [Tag.Daemons],
           summary: 'Restart a daemon',
           description:
-            'Command a daemon to drain and exit so its supervisor relaunches it (same version). The 202 returns the opened lifecycle op (with its id) and only means the daemon accepted the command; success is confirmed when it re-registers — track the op by id via the fleet read model’s lifecycleOp.',
+            'Command a daemon to drain and exit so its supervisor relaunches it (same version). The 202 returns the opened lifecycle op (with its id) and only means the daemon accepted the command; success is confirmed when it re-registers — track the op by id via the fleet read model’s lifecycleOp. Refused with 409 `DAEMON_CLUSTER_MANAGED` for a cluster daemon: relaunching that pod belongs to its Kubernetes operator.',
           operationId: 'restartDaemon',
           params: IdParam,
           response: {

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -43,6 +43,7 @@ import {
   canonicalVersion,
   ClusterEnvelopeNotEnabledError,
   ClusterImageNotVersionedError,
+  ClusterImageSupersededError,
   ClusterImageWriteDeferredError,
   ClusterTransitionInProgressError,
   ClusterVersionNotPublishedError,
@@ -622,10 +623,22 @@ export function daemonRoutes(deps: HttpDeps) {
             return sendApplyFailure(reply, error.cause, `; it will be rolled back — track operation ${opRow.id}`)
           }
         } else {
-          // The write itself failed, so nothing durable exists and no obligation is owed.
+          // The write itself failed, so nothing durable exists and no obligation is owed. The
+          // op is closed here rather than left for the compensation pass, which would find
+          // nothing to undo.
           await deps.repos.daemonLifecycleOp
             .settle(opRow.id, 'failed', clusterUpgradeFailure(error), new Date())
             .catch(() => {})
+          // A peer wrote this envelope while the command was resolving. Their value stands, so
+          // this is a retry rather than a fault: nothing was overwritten and nothing is owed.
+          if (error instanceof ClusterImageSupersededError) {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              message: `${error.message} — retry`,
+              code: 'CLUSTER_IMAGE_SUPERSEDED'
+            })
+          }
           return sendApplyFailure(reply, error, '')
         }
       }

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -39,10 +39,12 @@ import { detachDaemon } from '../daemon-removal.js'
 import { Tag } from '../plugins/openapi.js'
 import { CLUSTER_API_ERROR_CODE, sendClusterFailure } from '../cluster-failure.js'
 import {
+  canonicalVersion,
   ClusterEnvelopeNotEnabledError,
   ClusterImageNotVersionedError,
   ClusterImageWriteDeferredError,
   ClusterTransitionInProgressError,
+  ClusterVersionNotPublishedError,
   InvalidImageTagError
 } from '../../cluster/index.js'
 
@@ -100,6 +102,11 @@ function isClusterRefusal(error: unknown): boolean {
     error instanceof ClusterImageNotVersionedError ||
     error instanceof ClusterTransitionInProgressError
   )
+}
+
+/** A malformed target, mapped to 400 — the caller's input, not a cluster or policy state. */
+function isBadUpgradeTarget(error: unknown): boolean {
+  return error instanceof InvalidImageTagError || error instanceof ClusterVersionNotPublishedError
 }
 
 /** Outcome text recorded on an op whose image change never landed. */
@@ -485,17 +492,28 @@ export function daemonRoutes(deps: HttpDeps) {
           message: 'upgrading a cluster daemon requires a target version'
         })
       }
+      // Normalized before anything durable is written, because the target feeds two things
+      // that must agree: the composed image tag, and the version the replacement pod reports
+      // for the op to settle against. `DaemonUpgradeBody` admits `v1.5.0` and `latest`; the
+      // first is the same version spelled the image's way, the second names no version at
+      // all and an image tag cannot be guessed from a dist-tag.
+      const version = canonicalVersion(targetVersion)
+      if (!version) {
+        return reply.code(400).send({
+          error: 'Bad Request',
+          statusCode: 400,
+          message: new ClusterVersionNotPublishedError(targetVersion).message
+        })
+      }
       // Nothing to roll: re-applying the image the pod already runs would change no
       // generation, so the op could only ever expire. Say so now instead.
-      if (existing.agentVersion === targetVersion) {
-        return reply
-          .code(409)
-          .send({ error: 'Conflict', statusCode: 409, message: `daemon already runs ${targetVersion}` })
+      if (existing.agentVersion === version) {
+        return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: `daemon already runs ${version}` })
       }
       // The pod is replaced, so it re-auths and its epoch strictly exceeds this one —
       // which is exactly the fence `settleLifecycleOpOnReady` closes the op on.
       const commandEpoch = BigInt(deps.liveness.get(id)?.sessionEpoch ?? existing.sessionEpoch)
-      const opRow = await openLifecycleOp(req, reply, id, 'upgrade', commandEpoch, targetVersion)
+      const opRow = await openLifecycleOp(req, reply, id, 'upgrade', commandEpoch, version)
       if (!opRow) return reply
       // Set when the image is durable but this pass could not reach the API server. NOT a
       // failure: the re-apply pass renders the spec from the row, so the pod is still going
@@ -503,7 +521,7 @@ export function daemonRoutes(deps: HttpDeps) {
       // executes. The op stays open and the caller is told the outcome is unconfirmed.
       let deferred: ClusterImageWriteDeferredError | undefined
       try {
-        const image = await cluster.setDaemonVersion(orgOf(req), targetVersion)
+        const image = await cluster.setDaemonVersion(orgOf(req), version)
         req.log.info({ daemonId: id, opId: opRow.id, image }, 'cluster daemon upgrade: envelope repointed')
       } catch (error) {
         if (error instanceof ClusterImageWriteDeferredError) {
@@ -518,10 +536,10 @@ export function daemonRoutes(deps: HttpDeps) {
           await deps.repos.daemonLifecycleOp
             .settle(opRow.id, 'failed', clusterUpgradeFailure(error), new Date())
             .catch(() => {})
-          // Unreachable through `DaemonUpgradeBody`, which already rejects anything that is
-          // not a plain version — mapped anyway so the seam's own guard cannot read as a 500.
-          if (error instanceof InvalidImageTagError) {
-            return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: error.message })
+          // Already normalized above, so these are the seams re-checking their own inputs;
+          // mapped anyway so a guard firing can never read as a 500.
+          if (isBadUpgradeTarget(error)) {
+            return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: (error as Error).message })
           }
           if (isClusterRefusal(error)) {
             return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: (error as Error).message })
@@ -719,7 +737,7 @@ export function daemonRoutes(deps: HttpDeps) {
           tags: [Tag.Daemons],
           summary: 'Upgrade a daemon',
           description:
-            'Open an upgrade op for a daemon. A ready daemon receives it immediately; an offline daemon that previously advertised bootstrap recovery consumes it during its next auth. A CLUSTER daemon (`cluster: true`) takes neither path: the control plane rewrites the version tag on its organization’s AgentConnectOrg daemon image and the operator replaces the pod, so the command is accepted even while that daemon is offline. The 202 means accepted or durably queued, while success requires READY on the target version.',
+            'Open an upgrade op for a daemon. A ready daemon receives it immediately; an offline daemon that previously advertised bootstrap recovery consumes it during its next auth. A CLUSTER daemon (`cluster: true`) takes neither path: the control plane rewrites the version tag on its organization’s AgentConnectOrg daemon image and the operator replaces the pod, so the command is accepted even while that daemon is offline. That path needs an exact published version (`1.5.0`, or the equivalent `v1.5.0`) because the version becomes an image tag; a dist-tag such as `latest` is refused with 400. The 202 means accepted or durably queued, while success requires READY on the target version.',
           operationId: 'upgradeDaemon',
           params: IdParam,
           body: DaemonUpgradeBody,

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -37,10 +37,11 @@ import type { DaemonLifecycleOpRecord, DaemonLifecycleOpRepo } from '../../persi
 import { provisionDaemonConnect } from '../onboarding.js'
 import { detachDaemon } from '../daemon-removal.js'
 import { Tag } from '../plugins/openapi.js'
-import { sendClusterFailure } from '../cluster-failure.js'
+import { CLUSTER_API_ERROR_CODE, sendClusterFailure } from '../cluster-failure.js'
 import {
   ClusterEnvelopeNotEnabledError,
   ClusterImageNotVersionedError,
+  ClusterImageWriteDeferredError,
   ClusterTransitionInProgressError,
   InvalidImageTagError
 } from '../../cluster/index.js'
@@ -496,29 +497,87 @@ export function daemonRoutes(deps: HttpDeps) {
       const commandEpoch = BigInt(deps.liveness.get(id)?.sessionEpoch ?? existing.sessionEpoch)
       const opRow = await openLifecycleOp(req, reply, id, 'upgrade', commandEpoch, targetVersion)
       if (!opRow) return reply
+      // Set when the image is durable but this pass could not reach the API server. NOT a
+      // failure: the re-apply pass renders the spec from the row, so the pod is still going
+      // to be replaced — closing the op here would report "failed" for a command that then
+      // executes. The op stays open and the caller is told the outcome is unconfirmed.
+      let deferred: ClusterImageWriteDeferredError | undefined
       try {
         const image = await cluster.setDaemonVersion(orgOf(req), targetVersion)
         req.log.info({ daemonId: id, opId: opRow.id, image }, 'cluster daemon upgrade: envelope repointed')
       } catch (error) {
-        await deps.repos.daemonLifecycleOp
-          .settle(opRow.id, 'failed', clusterUpgradeFailure(error), new Date())
-          .catch(() => {})
-        // Unreachable through `DaemonUpgradeBody`, which already rejects anything that is
-        // not a plain version — mapped anyway so the seam's own guard cannot read as a 500.
-        if (error instanceof InvalidImageTagError) {
-          return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: error.message })
+        if (error instanceof ClusterImageWriteDeferredError) {
+          deferred = error
+          req.log.warn(
+            { daemonId: id, opId: opRow.id, image: error.image, err: error.cause },
+            'cluster daemon upgrade: image recorded but not applied; the re-apply pass will converge it'
+          )
+        } else {
+          // Everything else was refused BEFORE anything durable was written, so the command
+          // did not happen and never will — terminal-fail it.
+          await deps.repos.daemonLifecycleOp
+            .settle(opRow.id, 'failed', clusterUpgradeFailure(error), new Date())
+            .catch(() => {})
+          // Unreachable through `DaemonUpgradeBody`, which already rejects anything that is
+          // not a plain version — mapped anyway so the seam's own guard cannot read as a 500.
+          if (error instanceof InvalidImageTagError) {
+            return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: error.message })
+          }
+          if (isClusterRefusal(error)) {
+            return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: (error as Error).message })
+          }
+          return sendClusterFailure(reply, error, 'cluster API rejected the daemon image change')
         }
-        if (isClusterRefusal(error)) {
-          return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: (error as Error).message })
-        }
-        return sendClusterFailure(reply, error, 'cluster API rejected the daemon image change')
       }
       // Armed with the same epoch the desired state was written under: the CR is the
-      // command, and the op now waits for the replacement pod's READY.
-      await deps.repos.daemonLifecycleOp.markAccepted(opRow.id, new Date(), commandEpoch).catch((err: unknown) => {
-        req.log.warn({ daemonId: id, opId: opRow.id, err }, 'lifecycle op arm write failed')
-      })
-      return reply.code(202).send(opDto((await deps.repos.daemonLifecycleOp.getById(opRow.id)) ?? opRow))
+      // command, and the op now waits for the replacement pod's READY. An unarmed op
+      // ignores every later READY, so a transient write failure hands off to the same
+      // bounded recovery the machine path uses rather than being logged and dropped.
+      let armed = true
+      try {
+        await deps.repos.daemonLifecycleOp.markAccepted(opRow.id, new Date(), commandEpoch)
+      } catch (err) {
+        armed = false
+        req.log.warn({ daemonId: id, opId: opRow.id, err }, 'lifecycle op arm write failed; scheduling recovery')
+        void retryArm(
+          deps.repos.daemonLifecycleOp,
+          deps.registry,
+          opRow.id,
+          id,
+          commandEpoch,
+          ARM_RECOVERY_DELAYS_MS,
+          req.log
+        )
+      }
+      // Re-check for a completion already observed: the replacement pod can register READY
+      // between `open()` and the arm above, and that READY was ignored because the op was
+      // not yet armed. Without this the op would sit pending until its deadline.
+      if (armed) {
+        try {
+          await deps.registry.settleLifecycleOpOnReady(DaemonId(id))
+        } catch (err) {
+          req.log.warn({ daemonId: id, opId: opRow.id, err }, 'lifecycle op READY re-check failed; scheduling recovery')
+          void retryArm(
+            deps.repos.daemonLifecycleOp,
+            deps.registry,
+            opRow.id,
+            id,
+            commandEpoch,
+            ARM_RECOVERY_DELAYS_MS,
+            req.log
+          )
+        }
+      }
+      const latest = (await deps.repos.daemonLifecycleOp.getById(opRow.id).catch(() => null)) ?? opRow
+      if (deferred) {
+        return reply.code(502).send({
+          error: 'Bad Gateway',
+          statusCode: 502,
+          message: `${deferred.message}; it will be re-applied — track operation ${latest.id}`,
+          code: CLUSTER_API_ERROR_CODE
+        })
+      }
+      return reply.code(202).send(opDto(latest))
     }
 
     // Open a fleet lifecycle op; bootstrap-capable upgrades may wait durably for the next auth.

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -109,6 +109,18 @@ function isBadUpgradeTarget(error: unknown): boolean {
   return error instanceof InvalidImageTagError || error instanceof ClusterVersionNotPublishedError
 }
 
+/** A refused apply, always 502: the change is upstream's to accept, and the cause may be a
+ *  plain error rather than a `K8sApiError`, which `sendClusterFailure` would rethrow as a 500. */
+function sendApplyFailure(reply: FastifyReply, cause: unknown, note: string): FastifyReply {
+  const detail = cause instanceof Error ? cause.message : 'unknown error'
+  return reply.code(502).send({
+    error: 'Bad Gateway',
+    statusCode: 502,
+    message: `cluster API rejected the daemon image change: ${detail}${note}`,
+    code: CLUSTER_API_ERROR_CODE
+  })
+}
+
 /** Outcome text recorded on an op whose image change never landed. */
 function clusterUpgradeFailure(error: unknown): string {
   const detail = error instanceof Error ? error.message : 'unknown error'
@@ -515,21 +527,37 @@ export function daemonRoutes(deps: HttpDeps) {
       const commandEpoch = BigInt(deps.liveness.get(id)?.sessionEpoch ?? existing.sessionEpoch)
       const opRow = await openLifecycleOp(req, reply, id, 'upgrade', commandEpoch, version)
       if (!opRow) return reply
-      // Set when the image is durable but this pass could not reach the API server. NOT a
-      // failure: the re-apply pass renders the spec from the row, so the pod is still going
-      // to be replaced — closing the op here would report "failed" for a command that then
-      // executes. The op stays open and the caller is told the outcome is unconfirmed.
+      // Set only when the apply failed AND the rollback below could not undo it, so the image
+      // is still durable and still coming. That is the one outcome this op must not call
+      // failed, and the only one it keeps waiting on.
       let deferred: ClusterImageWriteDeferredError | undefined
       try {
         const image = await cluster.setDaemonVersion(orgOf(req), version)
         req.log.info({ daemonId: id, opId: opRow.id, image }, 'cluster daemon upgrade: envelope repointed')
       } catch (error) {
         if (error instanceof ClusterImageWriteDeferredError) {
-          deferred = error
-          req.log.warn(
-            { daemonId: id, opId: opRow.id, image: error.image, err: error.cause },
-            'cluster daemon upgrade: image recorded but not applied; the re-apply pass will converge it'
-          )
+          // The image is durable and would converge on the re-apply pass — but this op has a
+          // deadline, and a cluster unreachable past it would leave the op reported failed
+          // while the pass replaced the pod anyway. So the intent is abandoned and failure
+          // becomes the truth. Only when the rollback ITSELF fails is the image still coming,
+          // and then the op has to stay open, because it is going to happen after all.
+          const abandoned = await cluster.abandonDaemonVersion(orgOf(req), error)
+          if (!abandoned) {
+            deferred = error
+            req.log.warn(
+              { daemonId: id, opId: opRow.id, image: error.image, err: error.cause },
+              'cluster daemon upgrade: image recorded, rollback failed; the re-apply pass will converge it'
+            )
+          } else {
+            req.log.warn(
+              { daemonId: id, opId: opRow.id, image: error.image, err: error.cause },
+              'cluster daemon upgrade: cluster refused the apply; the envelope was rolled back'
+            )
+            await deps.repos.daemonLifecycleOp
+              .settle(opRow.id, 'failed', clusterUpgradeFailure(error.cause), new Date())
+              .catch(() => {})
+            return sendApplyFailure(reply, error.cause, '; the envelope was rolled back')
+          }
         } else {
           // Everything else was refused BEFORE anything durable was written, so the command
           // did not happen and never will — terminal-fail it.
@@ -588,12 +616,7 @@ export function daemonRoutes(deps: HttpDeps) {
       }
       const latest = (await deps.repos.daemonLifecycleOp.getById(opRow.id).catch(() => null)) ?? opRow
       if (deferred) {
-        return reply.code(502).send({
-          error: 'Bad Gateway',
-          statusCode: 502,
-          message: `${deferred.message}; it will be re-applied — track operation ${latest.id}`,
-          code: CLUSTER_API_ERROR_CODE
-        })
+        return sendApplyFailure(reply, deferred.cause, `; it will be re-applied — track operation ${latest.id}`)
       }
       return reply.code(202).send(opDto(latest))
     }

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -96,24 +96,17 @@ export async function retryArm(
 }
 
 /**
- * Background recovery for an abandonment that could not be confirmed in-request. An image
- * still durable will be applied by the re-apply pass, so the op must not be closed failed
- * until the rollback is OBSERVED — this keeps retrying until it is, then closes it.
- *
- * It re-reads the op first and stops if it is no longer pending: a cluster that recovered
- * meanwhile applies the image, the replacement pod settles the op `succeeded`, and rolling
- * back after that would revert an upgrade that did complete.
+ * Background recovery for a compensation whose transaction could not run in-request.
  *
  * Fire-and-forget and bounded, like {@link retryArm} — a fast path, not the guarantee. The
  * guarantee is the obligation persisted on the op row, which the cluster maintenance pass
  * discharges however long it takes and whichever process is running by then.
  */
-export async function retryAbandon(
-  cluster: Pick<ClusterExecutionService, 'abandonDaemonVersion'>,
-  ops: DaemonLifecycleOpRepo,
+export async function retryCompensation(
+  cluster: Pick<ClusterExecutionService, 'compensateUpgrade'>,
   opId: string,
   orgId: OrgId,
-  owed: { commandImage: string; rollbackImage: string; cause: unknown },
+  rollbackImage: string,
   delaysMs: number[],
   log?: { warn: (obj: unknown, msg?: string) => void }
 ): Promise<boolean> {
@@ -123,10 +116,9 @@ export async function retryAbandon(
       t.unref?.() // a dangling recovery must never keep the process alive
     })
     try {
-      const op = await ops.getById(opId)
-      if (!op || op.status !== 'pending') return true // decided elsewhere; leave the state alone
-      if (!(await cluster.abandonDaemonVersion(orgId, owed.commandImage, owed.rollbackImage))) continue
-      await ops.settle(opId, 'failed', clusterUpgradeFailure(owed.cause), new Date())
+      // Settling and restoring are one owner-guarded transaction, so a `false` here means the
+      // op was decided elsewhere — nothing was touched and nothing more is owed.
+      await cluster.compensateUpgrade(orgId, opId, rollbackImage)
       return true
     } catch (err) {
       log?.warn({ opId, orgId, err }, 'cluster daemon upgrade: rollback recovery attempt failed')
@@ -602,48 +594,32 @@ export function daemonRoutes(deps: HttpDeps) {
       }
       const opRow = await openLifecycleOp(req, reply, id, 'upgrade', commandEpoch, version, plan)
       if (!opRow) return reply
-      // Set only when the apply failed AND the rollback below could not undo it, so the image
-      // is still durable and still coming. That is the one outcome this op must not call
-      // failed, and the only one it keeps waiting on — and the op row carries the obligation
-      // durably, so the maintenance pass finishes it even if this process does not.
-      let deferred: ClusterImageWriteDeferredError | undefined
       try {
-        await cluster.applyDaemonVersion(orgOf(req), plan)
+        await cluster.applyDaemonVersion(orgOf(req), plan, opRow.id)
         req.log.info({ daemonId: id, opId: opRow.id, image: plan.image }, 'cluster daemon upgrade: envelope repointed')
       } catch (error) {
         if (error instanceof ClusterImageWriteDeferredError) {
           // The image is durable and would converge on the re-apply pass — but this op has a
           // deadline, and a cluster unreachable past it would leave the op reported failed
-          // while the pass replaced the pod anyway. So the intent is abandoned and failure
-          // becomes the truth. Only when the rollback ITSELF fails is the image still coming,
-          // and then the op has to stay open, because it is going to happen after all.
-          const abandoned = await cluster.abandonDaemonVersion(orgOf(req), plan.image, plan.previousImage)
-          if (!abandoned) {
-            deferred = error
-            req.log.warn(
-              { daemonId: id, opId: opRow.id, image: error.image, err: error.cause },
-              'cluster daemon upgrade: image still durable after rollback; scheduling recovery'
-            )
-            // The op stays open because the change is still coming. Recovery closes it once
-            // the rollback is observed — never on the assumption that it worked.
-            void retryAbandon(
-              cluster,
-              deps.repos.daemonLifecycleOp,
-              opRow.id,
-              orgOf(req),
-              { commandImage: plan.image, rollbackImage: plan.previousImage, cause: error.cause },
-              ARM_RECOVERY_DELAYS_MS,
-              req.log
-            )
-          } else {
+          // while the pass replaced the pod anyway. So the intent is withdrawn here: the op is
+          // failed and its write undone in one owner-guarded transaction.
+          try {
+            await cluster.compensateUpgrade(orgOf(req), opRow.id, plan.previousImage)
             req.log.warn(
               { daemonId: id, opId: opRow.id, image: error.image, err: error.cause },
               'cluster daemon upgrade: cluster refused the apply; the envelope was rolled back'
             )
-            await deps.repos.daemonLifecycleOp
-              .settle(opRow.id, 'failed', clusterUpgradeFailure(error.cause), new Date())
-              .catch(() => {})
             return sendApplyFailure(reply, error.cause, '; the envelope was rolled back')
+          } catch (err) {
+            // The transaction could not run, so nothing changed and the op is still pending
+            // with its obligation on disk. A retry follows, and the maintenance pass is the
+            // backstop that survives this process.
+            req.log.warn(
+              { daemonId: id, opId: opRow.id, image: error.image, err },
+              'cluster daemon upgrade: rollback could not be recorded; scheduling recovery'
+            )
+            void retryCompensation(cluster, opRow.id, orgOf(req), plan.previousImage, ARM_RECOVERY_DELAYS_MS, req.log)
+            return sendApplyFailure(reply, error.cause, `; it will be rolled back — track operation ${opRow.id}`)
           }
         } else {
           // The write itself failed, so nothing durable exists and no obligation is owed.
@@ -693,9 +669,6 @@ export function daemonRoutes(deps: HttpDeps) {
         }
       }
       const latest = (await deps.repos.daemonLifecycleOp.getById(opRow.id).catch(() => null)) ?? opRow
-      if (deferred) {
-        return sendApplyFailure(reply, deferred.cause, `; it will be re-applied — track operation ${latest.id}`)
-      }
       return reply.code(202).send(opDto(latest))
     }
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -370,6 +370,29 @@ export interface DaemonLifecycleOpRepo {
   /** Overdue `pending` ops that still carry an obligation, oldest first — the compensation
    *  pass's worklist, joined to the org whose envelope has to be restored. */
   listOverdueCompensations(now: Date, limit: number): Promise<OverdueUpgradeCompensation[]>
+  /**
+   * Discharge an upgrade's obligation: fail the op and restore its envelope's image, in ONE
+   * transaction, with the op's own status as the gate.
+   *
+   * Both halves being one statement pair is the point. Rolling the image back and then
+   * settling would let a concurrent READY settle the op `succeeded` in between, leaving an
+   * operation that reports success over an image it had already reverted. So the op
+   * transitions FIRST, guarded on `pending` — if that loses, someone else decided this
+   * operation and nothing is touched.
+   *
+   * The image restore is guarded on `daemonImageOwner = opId`, so it only ever undoes the
+   * write this operation made. A row whose owner has changed is a write this operation does
+   * not own, and failing the op without touching it is then the correct answer.
+   *
+   * Returns whether the op transitioned; false ⇒ it was no longer pending.
+   */
+  settleWithCompensation(input: {
+    opId: string
+    orgId: string
+    rollbackImage: string
+    outcome: string
+    at: Date
+  }): Promise<boolean>
   /** Close an op to a terminal status with an optional detail. Transitions ONLY a row
    *  still `pending` (so a late register can't reopen one a decline already failed).
    *  Returns whether a row was transitioned. */
@@ -4997,6 +5020,9 @@ export interface ClusterExecutionSettings {
   resourceName: string
   suspend: boolean
   daemonImage: string
+  /** The lifecycle-op id whose command wrote `daemonImage`; null when anything else did.
+   *  A rollback matches on THIS, so an identical image written independently is safe. */
+  daemonImageOwner: string | null
   daemonTier: string
   /** The daemon record the retired API-key path minted this envelope's key for.
    *  Never written any more; it is how an envelope provisioned before the token
@@ -5015,6 +5041,9 @@ export interface ClusterExecutionPatch {
   enabled?: boolean
   suspend?: boolean
   daemonImage?: string
+  /** Who owns the `daemonImage` being written — a lifecycle-op id for a command, absent for
+   *  every other writer, which is what clears a previous owner. Ignored without `daemonImage`. */
+  daemonImageOwner?: string
   daemonTier?: string
   runtimeImage?: string
   runtimeTiers?: ClusterRuntimeTier[]
@@ -5044,17 +5073,7 @@ export interface OrgClusterExecutionRepo {
   /** The org that owns a CR name — the reverse lookup an authenticating in-cluster
    *  daemon needs, since a token names its namespace and nothing else. */
   getByResourceName(resourceName: string): Promise<ClusterExecutionSettings | null>
-  /**
-   * Put `daemonImage` back if and only if the row still names `expectedImage`, then report
-   * the image the row ends up holding (null ⇒ no row).
-   *
-   * The fence is the IMAGE, not the revision: a revision moves for any settings edit —
-   * quota, tier, suspension — while leaving this caller's image exactly where it was, so a
-   * revision fence would decline the restore on a row that still needs it. And the current
-   * image is returned because the caller must VERIFY the outcome rather than infer it from
-   * the absence of an error; a conditional update that matched nothing is silent.
-   */
-  restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedImage: string): Promise<string | null>
+
   /** Every org whose envelope is switched on — what a deployment-wide sweep iterates.
    *  Unbounded on purpose: it is one row per organization with cluster execution enabled,
    *  and a sweep that silently stopped at a limit would leave part of the fleet stale. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5074,6 +5074,17 @@ export interface OrgClusterExecutionRepo {
    *  daemon needs, since a token names its namespace and nothing else. */
   getByResourceName(resourceName: string): Promise<ClusterExecutionSettings | null>
 
+  /**
+   * Compare-and-set the daemon image: write `daemonImage` (and `daemonImageOwner`) only while
+   * the row still names `expectedImage`. False ⇒ somebody wrote in between and nothing was
+   * touched.
+   *
+   * A command resolves its rollback baseline by reading, then writes; an unconditional write
+   * would overwrite whatever landed in that gap AND record a baseline that is no longer
+   * true, so a later rollback would restore a value nobody asked for. Conditioning the write
+   * on the baseline it captured makes losing the race visible instead of destructive.
+   */
+  claimDaemonImage(orgId: OrgId, daemonImage: string, owner: string | null, expectedImage: string): Promise<boolean>
   /** Every org whose envelope is switched on — what a deployment-wide sweep iterates.
    *  Unbounded on purpose: it is one row per organization with cluster execution enabled,
    *  and a sweep that silently stopped at a limit would leave part of the fleet stale. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -141,6 +141,7 @@ export interface RegisterReqInput {
   host: RegisterReq['host']
   capabilities: RegisterReq['capabilities']
   maxAgents: RegisterReq['maxAgents']
+  cluster: RegisterReq['cluster']
 }
 
 export interface DaemonRecord {
@@ -150,6 +151,9 @@ export interface DaemonRecord {
   /** Human-assigned display name (console-set); null until a user names it. */
   name: string | null
   agentVersion: string | null
+  /** True ⇒ an operator-managed pod whose version is its container image, so its
+   *  lifecycle runs through the org's `AgentConnectOrg`, not an npm command. */
+  cluster: boolean
   capabilities: unknown
   /** Stored `facts/daemon-runtimes.mcpServers` snapshot (FactsMcpServer[] as JSON; `[]` until reported). */
   mcpServers: unknown
@@ -5008,6 +5012,10 @@ export interface OrgClusterExecutionRepo {
   /** The org that owns a CR name — the reverse lookup an authenticating in-cluster
    *  daemon needs, since a token names its namespace and nothing else. */
   getByResourceName(resourceName: string): Promise<ClusterExecutionSettings | null>
+  /** Every org whose envelope is switched on — what a deployment-wide sweep iterates.
+   *  Unbounded on purpose: it is one row per organization with cluster execution enabled,
+   *  and a sweep that silently stopped at a limit would leave part of the fleet stale. */
+  listEnabled(): Promise<ClusterExecutionSettings[]>
   /** Oldest-first batch of envelopes whose organization is already gone. */
   listPendingTeardowns(limit: number): Promise<PendingEnvelopeTeardown[]>
   /**

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5013,12 +5013,16 @@ export interface OrgClusterExecutionRepo {
    *  daemon needs, since a token names its namespace and nothing else. */
   getByResourceName(resourceName: string): Promise<ClusterExecutionSettings | null>
   /**
-   * Put `daemonImage` back, but only while the row is still at `expectedRevision` — the
-   * fence that keeps abandoning a failed apply from discarding a peer's later edit. A
-   * no-op (revision moved) is not an error: it means this caller's value is no longer the
-   * durable desired state, which is exactly what abandoning wanted.
+   * Put `daemonImage` back if and only if the row still names `expectedImage`, then report
+   * the image the row ends up holding (null ⇒ no row).
+   *
+   * The fence is the IMAGE, not the revision: a revision moves for any settings edit —
+   * quota, tier, suspension — while leaving this caller's image exactly where it was, so a
+   * revision fence would decline the restore on a row that still needs it. And the current
+   * image is returned because the caller must VERIFY the outcome rather than infer it from
+   * the absence of an error; a conditional update that matched nothing is silent.
    */
-  restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedRevision: number): Promise<void>
+  restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedImage: string): Promise<string | null>
   /** Every org whose envelope is switched on — what a deployment-wide sweep iterates.
    *  Unbounded on purpose: it is one row per organization with cluster execution enabled,
    *  and a sweep that silently stopped at a limit would leave part of the fleet stale. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -5012,6 +5012,13 @@ export interface OrgClusterExecutionRepo {
   /** The org that owns a CR name — the reverse lookup an authenticating in-cluster
    *  daemon needs, since a token names its namespace and nothing else. */
   getByResourceName(resourceName: string): Promise<ClusterExecutionSettings | null>
+  /**
+   * Put `daemonImage` back, but only while the row is still at `expectedRevision` — the
+   * fence that keeps abandoning a failed apply from discarding a peer's later edit. A
+   * no-op (revision moved) is not an error: it means this caller's value is no longer the
+   * durable desired state, which is exactly what abandoning wanted.
+   */
+  restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedRevision: number): Promise<void>
   /** Every org whose envelope is switched on — what a deployment-wide sweep iterates.
    *  Unbounded on purpose: it is one row per organization with cluster execution enabled,
    *  and a sweep that silently stopped at a limit would leave part of the fleet stale. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -296,6 +296,13 @@ export interface OpenLifecycleOpInput {
   commandEpoch: bigint
   /** When a still-`pending` op is considered failed (drain + relaunch budget). */
   deadline: Date
+  /** A cluster upgrade's compensation obligation: the image this op asks the envelope to
+   *  run, and the one to restore if it must be undone. Recorded HERE — as the op opens,
+   *  before the forward write — so a process that dies mid-command still leaves both halves
+   *  on disk. Omitted for every other op, and their absence is what marks an op the ordinary
+   *  deadline sweep may fail. */
+  commandImage?: string
+  rollbackImage?: string
 }
 
 export interface DaemonLifecycleOpRecord {
@@ -313,6 +320,20 @@ export interface DaemonLifecycleOpRecord {
   deadline: Date
   outcome: string | null
   settledAt: Date | null
+  /** The image this op asked for; non-null ⇒ it carries a compensation obligation and only
+   *  the compensation pass may make it terminal. */
+  commandImage: string | null
+  /** The image to restore when compensating. */
+  rollbackImage: string | null
+}
+
+/** One overdue cluster upgrade whose obligation is still owed, joined to its org. */
+export interface OverdueUpgradeCompensation {
+  opId: string
+  daemonId: DaemonId
+  orgId: string
+  commandImage: string
+  rollbackImage: string
 }
 
 export interface DaemonLifecycleOpRepo {
@@ -334,10 +355,21 @@ export interface DaemonLifecycleOpRepo {
   latestForDaemon(daemonId: DaemonId): Promise<DaemonLifecycleOpRecord | null>
   /** The most recent op per daemon across a set (ANY status) — the batched fleet read (no N+1). */
   latestForDaemons(daemonIds: DaemonId[]): Promise<DaemonLifecycleOpRecord[]>
-  /** Fail every `pending` op past its `deadline` (optionally scoped to one daemon) — the
-   *  clock-driven expiry that unblocks a daemon whose command was accepted but which never
-   *  re-registered. Returns the number expired. */
+  /**
+   * Fail every `pending` op past its `deadline` (optionally scoped to one daemon) — the
+   * clock-driven expiry that unblocks a daemon whose command was accepted but which never
+   * re-registered. Returns the number expired.
+   *
+   * Ops carrying a compensation obligation (`commandImage` set) are DELIBERATELY excluded:
+   * their image may still be the durable desired state, so failing them here would report a
+   * failure for a change the envelope re-apply pass then enacts. Their terminality belongs
+   * to {@link DaemonLifecycleOpRepo.listOverdueCompensations}'s pass, which can discharge
+   * the obligation first.
+   */
   expireOverdue(now: Date, daemonId?: DaemonId): Promise<number>
+  /** Overdue `pending` ops that still carry an obligation, oldest first — the compensation
+   *  pass's worklist, joined to the org whose envelope has to be restored. */
+  listOverdueCompensations(now: Date, limit: number): Promise<OverdueUpgradeCompensation[]>
   /** Close an op to a terminal status with an optional detail. Transitions ONLY a row
    *  still `pending` (so a late register can't reopen one a decline already failed).
    *  Returns whether a row was transitioned. */

--- a/packages/control-plane/src/persistence/repositories/daemon-lifecycle-op.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon-lifecycle-op.repo.ts
@@ -7,7 +7,7 @@
  * route), and the row is closed out-of-band by the register→READY closure or a decline.
  */
 import type { DaemonLifecycleOp } from '../../generated/prisma/client.js'
-import type { PrismaLike } from '../prisma.js'
+import { withAmbientTx, type PrismaLike } from '../prisma.js'
 import type {
   DaemonLifecycleOpRepo,
   DaemonLifecycleOpRecord,
@@ -153,6 +153,33 @@ export class PgDaemonLifecycleOpRepo implements DaemonLifecycleOpRepo {
           ]
         : []
     )
+  }
+
+  /** The op transitions FIRST and gates the restore, and both are one transaction — see the
+   *  port doc: rolling the image back before settling lets a concurrent READY report success
+   *  over an image that was already reverted. */
+  async settleWithCompensation(input: {
+    opId: string
+    orgId: string
+    rollbackImage: string
+    outcome: string
+    at: Date
+  }): Promise<boolean> {
+    return withAmbientTx(this.db, async (tx) => {
+      const settled = await tx.daemonLifecycleOp.updateMany({
+        where: { id: input.opId, status: 'pending' },
+        data: { status: 'failed', outcome: input.outcome, settledAt: input.at }
+      })
+      if (settled.count === 0) return false
+      // Owner-guarded, so this only undoes the write this operation made. A row somebody
+      // else now owns is not this operation's to revert, and the op still fails: its image
+      // is not the durable desired state either way.
+      await tx.orgClusterExecution.updateMany({
+        where: { orgId: input.orgId, daemonImageOwner: input.opId },
+        data: { daemonImage: input.rollbackImage, daemonImageOwner: null, specRevision: { increment: 1 } }
+      })
+      return true
+    })
   }
 
   async settle(id: string, status: 'succeeded' | 'failed', outcome: string | null, at: Date): Promise<boolean> {

--- a/packages/control-plane/src/persistence/repositories/daemon-lifecycle-op.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon-lifecycle-op.repo.ts
@@ -13,7 +13,8 @@ import type {
   DaemonLifecycleOpRecord,
   DaemonLifecycleOpType,
   DaemonLifecycleOpStatus,
-  OpenLifecycleOpInput
+  OpenLifecycleOpInput,
+  OverdueUpgradeCompensation
 } from '../ports.js'
 import { DaemonId } from '../../domain/ids.js'
 
@@ -30,7 +31,9 @@ function toRecord(o: DaemonLifecycleOp): DaemonLifecycleOpRecord {
     startedAt: o.startedAt,
     deadline: o.deadline,
     outcome: o.outcome,
-    settledAt: o.settledAt
+    settledAt: o.settledAt,
+    commandImage: o.commandImage,
+    rollbackImage: o.rollbackImage
   }
 }
 
@@ -46,6 +49,8 @@ export class PgDaemonLifecycleOpRepo implements DaemonLifecycleOpRepo {
         initiator: input.initiator ?? null,
         commandEpoch: input.commandEpoch,
         deadline: input.deadline,
+        commandImage: input.commandImage ?? null,
+        rollbackImage: input.rollbackImage ?? null,
         status: 'pending'
       }
     })
@@ -99,9 +104,17 @@ export class PgDaemonLifecycleOpRepo implements DaemonLifecycleOpRepo {
     return out
   }
 
+  /** `commandImage: null` is the exclusion, not an oversight: an op carrying a compensation
+   *  obligation may still have its image durable, and reporting it failed here is exactly the
+   *  contradiction the obligation exists to prevent. The compensation pass owns those. */
   async expireOverdue(now: Date, daemonId?: DaemonId): Promise<number> {
     const res = await this.db.daemonLifecycleOp.updateMany({
-      where: { status: 'pending', deadline: { lt: now }, ...(daemonId ? { daemonId } : {}) },
+      where: {
+        status: 'pending',
+        deadline: { lt: now },
+        commandImage: null,
+        ...(daemonId ? { daemonId } : {})
+      },
       data: {
         status: 'failed',
         outcome: 'timed out — the daemon did not re-register before the deadline',
@@ -109,6 +122,37 @@ export class PgDaemonLifecycleOpRepo implements DaemonLifecycleOpRepo {
       }
     })
     return res.count
+  }
+
+  /** Oldest first, so a backlog drains in the order the commands were issued. */
+  async listOverdueCompensations(now: Date, limit: number): Promise<OverdueUpgradeCompensation[]> {
+    const rows = await this.db.daemonLifecycleOp.findMany({
+      where: { status: 'pending', deadline: { lt: now }, commandImage: { not: null } },
+      select: {
+        id: true,
+        daemonId: true,
+        commandImage: true,
+        rollbackImage: true,
+        daemon: { select: { orgId: true } }
+      },
+      orderBy: { startedAt: 'asc' },
+      take: limit
+    })
+    return rows.flatMap((row) =>
+      // Both halves or nothing: half an obligation cannot be discharged, and skipping it
+      // leaves the op for a human rather than guessing an image to restore.
+      row.commandImage && row.rollbackImage
+        ? [
+            {
+              opId: row.id,
+              daemonId: DaemonId(row.daemonId),
+              orgId: row.daemon.orgId,
+              commandImage: row.commandImage,
+              rollbackImage: row.rollbackImage
+            }
+          ]
+        : []
+    )
   }
 
   async settle(id: string, status: 'succeeded' | 'failed', outcome: string | null, at: Date): Promise<boolean> {

--- a/packages/control-plane/src/persistence/repositories/daemon.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon.repo.ts
@@ -36,6 +36,9 @@ function toRecord(d: DaemonWithUsers): DaemonRecord {
     host: d.host,
     name: d.name,
     agentVersion: d.agentVersion,
+    // The register self-report OR a bound Kubernetes identity: an envelope daemon that
+    // authenticated with a projected token is one whatever its (older) register said.
+    cluster: d.cluster || d.clusterIdentity !== null,
     capabilities: d.capabilities,
     mcpServers: d.mcpServers,
     maxAgents: d.maxAgents,
@@ -178,6 +181,7 @@ export class PgDaemonRepo implements DaemonRepo {
         host: reg.host,
         capabilities: reg.capabilities as Prisma.InputJsonValue,
         maxAgents: reg.maxAgents,
+        cluster: reg.cluster,
         status: 'ready',
         // The `facts/daemon-runtimes.seq` counter is per-connection: reset the
         // fence so the reconnecting daemon's fresh count is accepted from 1.

--- a/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
@@ -68,12 +68,18 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
     return row ? toRecord(row) : null
   }
 
-  /** One conditional statement, so a peer's edit between the read and this write wins. */
-  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedRevision: number): Promise<void> {
+  /** Conditional on the image, then read back what the row actually holds — the caller
+   *  settles a command on this answer, so it must be observed rather than assumed. */
+  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedImage: string): Promise<string | null> {
     await this.prisma.orgClusterExecution.updateMany({
-      where: { orgId, specRevision: expectedRevision },
+      where: { orgId, daemonImage: expectedImage },
       data: { daemonImage, specRevision: { increment: 1 } }
     })
+    const row = await this.prisma.orgClusterExecution.findUnique({
+      where: { orgId },
+      select: { daemonImage: true }
+    })
+    return row?.daemonImage ?? null
   }
 
   /** Stable `orgId` order so a sweep's log reads the same across boots. */

--- a/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
@@ -68,6 +68,14 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
     return row ? toRecord(row) : null
   }
 
+  /** One conditional statement, so a peer's edit between the read and this write wins. */
+  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedRevision: number): Promise<void> {
+    await this.prisma.orgClusterExecution.updateMany({
+      where: { orgId, specRevision: expectedRevision },
+      data: { daemonImage, specRevision: { increment: 1 } }
+    })
+  }
+
   /** Stable `orgId` order so a sweep's log reads the same across boots. */
   async listEnabled(): Promise<ClusterExecutionSettings[]> {
     const rows = await this.prisma.orgClusterExecution.findMany({

--- a/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
@@ -68,6 +68,15 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
     return row ? toRecord(row) : null
   }
 
+  /** Stable `orgId` order so a sweep's log reads the same across boots. */
+  async listEnabled(): Promise<ClusterExecutionSettings[]> {
+    const rows = await this.prisma.orgClusterExecution.findMany({
+      where: { enabled: true },
+      orderBy: { orgId: 'asc' }
+    })
+    return rows.map(toRecord)
+  }
+
   async listPendingTeardowns(limit: number): Promise<PendingEnvelopeTeardown[]> {
     return this.prisma.pendingEnvelopeTeardown.findMany({
       select: { orgId: true, resourceName: true },

--- a/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
@@ -39,6 +39,7 @@ function toRecord(row: OrgClusterExecution): ClusterExecutionSettings {
     resourceName: row.resourceName,
     suspend: row.suspend,
     daemonImage: row.daemonImage,
+    daemonImageOwner: row.daemonImageOwner,
     daemonTier: row.daemonTier,
     ...(row.legacyKeyDaemonId ? { legacyKeyDaemonId: row.legacyKeyDaemonId } : {}),
     runtimeImage: row.runtimeImage,
@@ -66,20 +67,6 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
   async getByResourceName(resourceName: string): Promise<ClusterExecutionSettings | null> {
     const row = await this.prisma.orgClusterExecution.findUnique({ where: { resourceName } })
     return row ? toRecord(row) : null
-  }
-
-  /** Conditional on the image, then read back what the row actually holds — the caller
-   *  settles a command on this answer, so it must be observed rather than assumed. */
-  async restoreDaemonImage(orgId: OrgId, daemonImage: string, expectedImage: string): Promise<string | null> {
-    await this.prisma.orgClusterExecution.updateMany({
-      where: { orgId, daemonImage: expectedImage },
-      data: { daemonImage, specRevision: { increment: 1 } }
-    })
-    const row = await this.prisma.orgClusterExecution.findUnique({
-      where: { orgId },
-      select: { daemonImage: true }
-    })
-    return row?.daemonImage ?? null
   }
 
   /** Stable `orgId` order so a sweep's log reads the same across boots. */
@@ -214,6 +201,7 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
         resourceName: defaults.resourceName,
         suspend: patch.suspend ?? false,
         daemonImage: patch.daemonImage ?? defaults.daemonImage,
+        daemonImageOwner: patch.daemonImage !== undefined ? (patch.daemonImageOwner ?? null) : null,
         daemonTier: patch.daemonTier ?? defaults.daemonTier,
         runtimeImage: patch.runtimeImage ?? defaults.runtimeImage,
         runtimeTiers: tiers,
@@ -230,7 +218,12 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
         specRevision: { increment: 1 },
         ...(patch.enabled !== undefined ? { enabled: patch.enabled } : {}),
         ...(patch.suspend !== undefined ? { suspend: patch.suspend } : {}),
-        ...(patch.daemonImage !== undefined ? { daemonImage: patch.daemonImage } : {}),
+        // Written together, always: an image and who owns it are one fact, and a writer that
+        // set the image while leaving a previous owner behind would hand its write to someone
+        // else's rollback. Every non-command writer therefore clears it by omitting the id.
+        ...(patch.daemonImage !== undefined
+          ? { daemonImage: patch.daemonImage, daemonImageOwner: patch.daemonImageOwner ?? null }
+          : {}),
         ...(patch.daemonTier !== undefined ? { daemonTier: patch.daemonTier } : {}),
         ...(patch.runtimeImage !== undefined ? { runtimeImage: patch.runtimeImage } : {}),
         ...(patch.runtimeTiers !== undefined ? { runtimeTiers: tiers } : {}),

--- a/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org-cluster-execution.repo.ts
@@ -69,6 +69,20 @@ export class PgOrgClusterExecutionRepo implements OrgClusterExecutionRepo {
     return row ? toRecord(row) : null
   }
 
+  /** One conditional statement, so a writer that lost the race changes nothing at all. */
+  async claimDaemonImage(
+    orgId: OrgId,
+    daemonImage: string,
+    owner: string | null,
+    expectedImage: string
+  ): Promise<boolean> {
+    const claimed = await this.prisma.orgClusterExecution.updateMany({
+      where: { orgId, daemonImage: expectedImage },
+      data: { daemonImage, daemonImageOwner: owner, specRevision: { increment: 1 } }
+    })
+    return claimed.count > 0
+  }
+
   /** Stable `orgId` order so a sweep's log reads the same across boots. */
   async listEnabled(): Promise<ClusterExecutionSettings[]> {
     const rows = await this.prisma.orgClusterExecution.findMany({

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -210,6 +210,9 @@ export interface DaemonView {
   /** Human-assigned display name (console-set); null until named. */
   name: string | null
   agentVersion: string | null
+  /** True ⇒ an operator-managed pod: its version is its container image, so the console
+   *  offers no restart and an upgrade repoints the org's `AgentConnectOrg` instead. */
+  cluster: boolean
   status: DaemonStatus
   health: HealthState
   capabilities: DaemonCapabilities

--- a/packages/control-plane/src/registry/daemonRelease.ts
+++ b/packages/control-plane/src/registry/daemonRelease.ts
@@ -65,6 +65,20 @@ export class DaemonReleaseResolver {
     return { channel: this.channel, latestVersion: this.version, availableVersions: this.availableVersions() }
   }
 
+  /**
+   * Await a refresh attempt, then report the best-known release. `get()` deliberately
+   * never blocks because it serves a request; a one-shot boot task has nobody waiting on
+   * it and everything to lose from reading an empty cache, so it uses this instead. Still
+   * best-effort: a failed fetch resolves to whatever was already known (possibly null).
+   */
+  async resolve(): Promise<DaemonRelease> {
+    const now = this.clock.now()
+    if (!this.inFlight && (this.lastAttemptMs === 0 || now - this.lastAttemptMs > this.ttlMs)) {
+      await this.refresh(now)
+    }
+    return { channel: this.channel, latestVersion: this.version, availableVersions: this.availableVersions() }
+  }
+
   /** Distinct versions behind the published dist-tags, channel version first, then the
    *  rest in a stable descending order — the console's upgrade-target options.
    *

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -71,6 +71,7 @@ function toView(d: DaemonRecord, profiles: RuntimeProfileRecord[]): DaemonView {
     host: d.host,
     name: d.name,
     agentVersion: d.agentVersion,
+    cluster: d.cluster,
     status: d.status,
     health: d.health,
     capabilities: normCapabilities(d.capabilities),
@@ -104,7 +105,8 @@ export class DaemonRegistryService implements DaemonRegistry {
     await this.daemons.applyRegister(daemonId, {
       host: req.host,
       capabilities: req.capabilities,
-      maxAgents: req.maxAgents
+      maxAgents: req.maxAgents,
+      cluster: req.cluster
     })
   }
 

--- a/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
+++ b/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
@@ -87,14 +87,14 @@ async function clusterApp(options: { afterApply?: () => Promise<void> } = {}): P
     new PgOrgRepo(prisma),
     POLICY,
     new PgDaemonRepo(prisma),
+    new PgDaemonLifecycleOpRepo(prisma),
     systemClock
   )
   if (options.afterApply) {
-    const write = cluster.setDaemonVersion.bind(cluster)
-    cluster.setDaemonVersion = async (orgId, version) => {
-      const image = await write(orgId, version)
+    const write = cluster.applyDaemonVersion.bind(cluster)
+    cluster.applyDaemonVersion = async (orgId, plan) => {
+      await write(orgId, plan)
       await options.afterApply!()
-      return image
     }
   }
   const http = buildHttpApp(prisma, undefined, undefined, undefined, { clusterExecution: cluster })
@@ -248,6 +248,8 @@ describe('POST /daemons/:id/upgrade — cluster daemon', () => {
     expect(await new PgDaemonLifecycleOpRepo(prisma).latestForDaemon(DaemonId(DAEMON))).toBeNull()
   })
 
+  // Refused while resolving, which happens before the op opens — so there is no operation
+  // to close, and none is left behind for the console to explain.
   it('refuses when the organization has no live envelope', async () => {
     const { http } = await clusterApp()
     await seedDaemon(true)
@@ -257,9 +259,7 @@ describe('POST /daemons/:id/upgrade — cluster daemon', () => {
       payload: { version: '1.5.0' }
     })
     expect(res.statusCode).toBe(409)
-    // The op is opened before the write is attempted, so it must be closed on failure.
-    const op = await new PgDaemonLifecycleOpRepo(prisma).latestForDaemon(DaemonId(DAEMON))
-    expect(op).toMatchObject({ status: 'failed' })
+    expect(await new PgDaemonLifecycleOpRepo(prisma).latestForDaemon(DaemonId(DAEMON))).toBeNull()
   })
 })
 
@@ -363,5 +363,113 @@ describe('cluster daemon upgrade — settlement and durability', () => {
     expect(applied.at(-1)?.spec?.daemon?.image).toBe('registry.example.test/daemon:v1.5.0')
     const settings = await http.app.inject({ method: 'GET', url: CLUSTER })
     expect(settings.json()).toMatchObject({ daemonImage: 'registry.example.test/daemon:v1.5.0' })
+  })
+})
+
+/**
+ * The obligation is what survives the process. Everything above tests a request that stayed
+ * alive long enough to undo its own work; these test the case it cannot cover — the control
+ * plane exiting between the forward write and the rollback, which is why the images are
+ * recorded on the operation before the write rather than held in memory.
+ */
+describe('cluster daemon upgrade — durable compensation', () => {
+  const ops = () => new PgDaemonLifecycleOpRepo(prisma)
+  const past = () => new Date(Date.now() - 60_000)
+
+  it('records both halves of the obligation on the operation', async () => {
+    const { http } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+    const res = await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '1.5.0' }
+    })
+    expect(res.statusCode).toBe(202)
+    expect(await ops().pendingForDaemon(DaemonId(DAEMON))).toMatchObject({
+      commandImage: 'registry.example.test/daemon:v1.5.0',
+      rollbackImage: 'registry.example.test/daemon:v1.4.0'
+    })
+  })
+
+  /**
+   * The deadline sweep must leave it alone. Failing it here is the contradiction itself: the
+   * image is still the durable desired state, so the re-apply pass would enact the change
+   * after the operation had reported failure.
+   */
+  it('is not failed by the ordinary deadline sweep', async () => {
+    const { http } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+    const op = await ops().open({
+      daemonId: DaemonId(DAEMON),
+      op: 'upgrade',
+      targetVersion: '1.5.0',
+      commandEpoch: 1n,
+      deadline: past(),
+      commandImage: 'registry.example.test/daemon:v1.5.0',
+      rollbackImage: 'registry.example.test/daemon:v1.4.0'
+    })
+
+    expect(await ops().expireOverdue(new Date(), DaemonId(DAEMON))).toBe(0)
+    expect(await ops().getById(op.id)).toMatchObject({ status: 'pending' })
+    // And the console must not fabricate `failed` at read time either.
+    const list = await http.app.inject({ method: 'GET', url: `${ORG}/daemons` })
+    expect(list.json()[0].lifecycleOp).toMatchObject({ status: 'pending' })
+  })
+
+  // The process that opened it is gone; a later one reconstructs the rollback from disk.
+  it('is discharged by the maintenance pass, which restores the image and fails the op', async () => {
+    const { http, cluster } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+    // The forward write survived the exit, so the envelope names the requested image.
+    await http.app.inject({
+      method: 'PUT',
+      url: CLUSTER,
+      payload: { daemonImage: 'registry.example.test/daemon:v1.5.0' }
+    })
+    const op = await ops().open({
+      daemonId: DaemonId(DAEMON),
+      op: 'upgrade',
+      targetVersion: '1.5.0',
+      commandEpoch: 1n,
+      deadline: past(),
+      commandImage: 'registry.example.test/daemon:v1.5.0',
+      rollbackImage: 'registry.example.test/daemon:v1.4.0'
+    })
+
+    expect(await cluster.drainUpgradeCompensations()).toBe(1)
+    expect(await ops().getById(op.id)).toMatchObject({ status: 'failed' })
+    const settings = await http.app.inject({ method: 'GET', url: CLUSTER })
+    expect(settings.json()).toMatchObject({ daemonImage: 'registry.example.test/daemon:v1.4.0' })
+  })
+
+  // A pod that arrived on target already settled the op; compensating after that would
+  // revert an upgrade that completed.
+  it('leaves an operation a recovered pod already settled', async () => {
+    const { http, cluster } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+    await http.app.inject({
+      method: 'PUT',
+      url: CLUSTER,
+      payload: { daemonImage: 'registry.example.test/daemon:v1.5.0' }
+    })
+    const op = await ops().open({
+      daemonId: DaemonId(DAEMON),
+      op: 'upgrade',
+      targetVersion: '1.5.0',
+      commandEpoch: 1n,
+      deadline: past(),
+      commandImage: 'registry.example.test/daemon:v1.5.0',
+      rollbackImage: 'registry.example.test/daemon:v1.4.0'
+    })
+    await ops().settle(op.id, 'succeeded', null, new Date())
+
+    // It restores the row it was asked to (the obligation is still listed), but the verdict
+    // stands: `settle` transitions only a pending row, so nothing is counted or overwritten.
+    expect(await cluster.drainUpgradeCompensations()).toBe(0)
+    expect(await ops().getById(op.id)).toMatchObject({ status: 'succeeded' })
   })
 })

--- a/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
+++ b/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
@@ -374,7 +374,18 @@ describe('cluster daemon upgrade — settlement and durability', () => {
  */
 describe('cluster daemon upgrade — durable compensation', () => {
   const ops = () => new PgDaemonLifecycleOpRepo(prisma)
+  const settingsRepo = new PgOrgClusterExecutionRepo(prisma)
   const past = () => new Date(Date.now() - 60_000)
+  /** Only `daemonImage`/`daemonImageOwner` are read from a patch; the rest is the row's. */
+  const DEFAULTS = {
+    resourceName: RESOURCE_NAME,
+    daemonImage: POLICY.daemonImage,
+    daemonTier: POLICY.daemonTier,
+    runtimeImage: POLICY.runtimeImage,
+    runtimeTiers: POLICY.runtimeTiers,
+    quota: { maxAgents: 0, cpu: '0', memory: '0', storage: '0' },
+    egressPolicy: 'curated' as const
+  }
 
   it('records both halves of the obligation on the operation', async () => {
     const { http } = await clusterApp()
@@ -423,12 +434,6 @@ describe('cluster daemon upgrade — durable compensation', () => {
     const { http, cluster } = await clusterApp()
     await enableEnvelope(http)
     await seedDaemon(true)
-    // The forward write survived the exit, so the envelope names the requested image.
-    await http.app.inject({
-      method: 'PUT',
-      url: CLUSTER,
-      payload: { daemonImage: 'registry.example.test/daemon:v1.5.0' }
-    })
     const op = await ops().open({
       daemonId: DaemonId(DAEMON),
       op: 'upgrade',
@@ -437,6 +442,12 @@ describe('cluster daemon upgrade — durable compensation', () => {
       deadline: past(),
       commandImage: 'registry.example.test/daemon:v1.5.0',
       rollbackImage: 'registry.example.test/daemon:v1.4.0'
+    })
+    // The forward write survived the exit, owner and all — that pairing is what lets the
+    // rollback name this operation's write instead of merely the image it produced.
+    await settingsRepo.upsert(OrgId(DEFAULT_ORG_ID), DEFAULTS, {
+      daemonImage: 'registry.example.test/daemon:v1.5.0',
+      daemonImageOwner: op.id
     })
 
     expect(await cluster.drainUpgradeCompensations()).toBe(1)
@@ -451,11 +462,6 @@ describe('cluster daemon upgrade — durable compensation', () => {
     const { http, cluster } = await clusterApp()
     await enableEnvelope(http)
     await seedDaemon(true)
-    await http.app.inject({
-      method: 'PUT',
-      url: CLUSTER,
-      payload: { daemonImage: 'registry.example.test/daemon:v1.5.0' }
-    })
     const op = await ops().open({
       daemonId: DaemonId(DAEMON),
       op: 'upgrade',
@@ -464,6 +470,10 @@ describe('cluster daemon upgrade — durable compensation', () => {
       deadline: past(),
       commandImage: 'registry.example.test/daemon:v1.5.0',
       rollbackImage: 'registry.example.test/daemon:v1.4.0'
+    })
+    await settingsRepo.upsert(OrgId(DEFAULT_ORG_ID), DEFAULTS, {
+      daemonImage: 'registry.example.test/daemon:v1.5.0',
+      daemonImageOwner: op.id
     })
     await ops().settle(op.id, 'succeeded', null, new Date())
 

--- a/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
+++ b/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
@@ -213,6 +213,41 @@ describe('POST /daemons/:id/upgrade — cluster daemon', () => {
     expect(applied).toHaveLength(before)
   })
 
+  /**
+   * `DaemonUpgradeBody` admits any plain token, so the route normalizes before anything
+   * durable is written: `v1.5.0` is the same version spelled the image's way (and would
+   * otherwise compose `vv1.5.0`), while `latest` names no version an image tag or a pod
+   * report could ever match.
+   */
+  it('accepts the image spelling of a version and stores the canonical one', async () => {
+    const { http, applied } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+    const res = await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: 'v1.5.0' }
+    })
+    expect(res.statusCode).toBe(202)
+    expect(res.json()).toMatchObject({ targetVersion: '1.5.0' }) // what the pod will report
+    expect(applied.at(-1)?.spec?.daemon?.image).toBe('registry.example.test/daemon:v1.5.0')
+  })
+
+  it('refuses a dist-tag before writing anything', async () => {
+    const { http, applied } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+    const before = applied.length
+    const res = await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: 'latest' }
+    })
+    expect(res.statusCode).toBe(400)
+    expect(applied).toHaveLength(before)
+    expect(await new PgDaemonLifecycleOpRepo(prisma).latestForDaemon(DaemonId(DAEMON))).toBeNull()
+  })
+
   it('refuses when the organization has no live envelope', async () => {
     const { http } = await clusterApp()
     await seedDaemon(true)

--- a/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
+++ b/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
@@ -1,0 +1,205 @@
+/**
+ * The cluster daemon's lifecycle surface. A machine daemon is commanded over its
+ * WebSocket; an operator-managed pod has no npm install to replace and no supervisor to
+ * exit to, so the same two routes mean something different for it: restart is refused,
+ * and upgrade rewrites the version tag on its organization's `AgentConnectOrg`.
+ *
+ * The two invariants worth a real database and a real API server are that the image
+ * change lands on BOTH the resource and the settings row (the periodic re-apply renders
+ * the spec from the row, so a CR-only write would be reverted), and that none of it
+ * requires the daemon to be reachable — rescuing a pod crash-looping on a bad image is
+ * the point.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { K8sHttp } from '@agentconnect.md/k8s-client'
+import { closeFakeApiServers, fakeApiServer } from '@agentconnect.md/k8s-client/testing'
+import { prisma } from '../setup.db.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { AgentConnectOrgApi, ClusterExecutionService, orgResourceName } from '../../src/cluster/index.js'
+import { systemClock } from '../../src/domain/clock.js'
+import { PgOrgClusterExecutionRepo } from '../../src/persistence/repositories/org-cluster-execution.repo.js'
+import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
+import { PgDaemonLifecycleOpRepo } from '../../src/persistence/repositories/daemon-lifecycle-op.repo.js'
+import { PgOrgRepo } from '../../src/persistence/repositories/org.repo.js'
+import { DaemonId, OrgId } from '../../src/domain/ids.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const DAEMON = '11111111-1111-4111-8111-111111111111'
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const CLUSTER = `${ORG}/cluster-execution`
+const CONTROL_NAMESPACE = 'agentconnect-control'
+const POLICY = {
+  namespacePrefix: 'ac-org-',
+  daemonImage: 'registry.example.test/daemon:1.4.0',
+  runtimeImage: 'registry.example.test/runtime:1.4.0',
+  daemonTier: 'small',
+  runtimeTiers: [{ name: 'small', warmReplicas: 0 }],
+  controlPlaneUrl: 'wss://api.example.test/daemon/ws'
+}
+const RESOURCE_NAME = orgResourceName(POLICY.namespacePrefix, DEFAULT_ORG_ID)
+
+const opened: HttpApp[] = []
+afterEach(async () => {
+  await Promise.all(opened.splice(0).map((a) => a.close()))
+  await closeFakeApiServers()
+})
+
+interface Harness {
+  http: HttpApp
+  /** Bodies of the apply PATCHes, newest last. */
+  applied: { spec?: { daemon?: { image?: string } } }[]
+  cluster: ClusterExecutionService
+}
+
+/** An app whose provisioner talks to a fake API server that stores what it is applied. */
+async function clusterApp(): Promise<Harness> {
+  const applied: { spec?: { daemon?: { image?: string } } }[] = []
+  let stored: unknown = null
+  const server = await fakeApiServer((req) => {
+    if (req.method === 'PATCH') {
+      const body = JSON.parse(req.body) as { spec?: { daemon?: { image?: string } } }
+      applied.push(body)
+      // Standing in for the operator, which derives and publishes the namespace.
+      stored = { ...body, status: { namespace: `${POLICY.namespacePrefix}${RESOURCE_NAME}` } }
+    }
+    if (req.method === 'DELETE') stored = null
+    if (req.method === 'GET') {
+      return stored
+        ? { json: stored }
+        : { status: 404, json: { kind: 'Status', reason: 'NotFound', message: 'not found' } }
+    }
+    return { json: stored ?? {} }
+  })
+  const cluster = new ClusterExecutionService(
+    new PgOrgClusterExecutionRepo(prisma),
+    new AgentConnectOrgApi(new K8sHttp(server.config), CONTROL_NAMESPACE),
+    new PgOrgRepo(prisma),
+    POLICY,
+    new PgDaemonRepo(prisma),
+    systemClock
+  )
+  const http = buildHttpApp(prisma, undefined, undefined, undefined, { clusterExecution: cluster })
+  opened.push(http)
+  return { http, applied, cluster }
+}
+
+/** A registered daemon row, never connected — `cluster` is what `register` reported. */
+async function seedDaemon(cluster: boolean, agentVersion = '1.4.0'): Promise<void> {
+  const repo = new PgDaemonRepo(prisma)
+  await repo.upsertOnAuth({ daemonId: DaemonId(DAEMON), orgId: OrgId(DEFAULT_ORG_ID), agentVersion })
+  await repo.applyRegister(DaemonId(DAEMON), {
+    host: 'ac-daemon',
+    capabilities: { platforms: [], runtimes: ['claude'], acp: true, features: [] },
+    maxAgents: 4,
+    cluster
+  })
+}
+
+/** Switch cluster execution on for the org so there is an envelope to repoint. */
+async function enableEnvelope(http: HttpApp): Promise<void> {
+  const res = await http.app.inject({ method: 'PUT', url: CLUSTER, payload: { enabled: true } })
+  expect(res.statusCode).toBe(200)
+}
+
+describe('GET /daemons', () => {
+  it('reports a registered cluster daemon as one', async () => {
+    const { http } = await clusterApp()
+    await seedDaemon(true)
+    const res = await http.app.inject({ method: 'GET', url: `${ORG}/daemons` })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()[0]).toMatchObject({ daemonId: DAEMON, cluster: true })
+  })
+
+  it('reports a machine daemon as not one', async () => {
+    const { http } = await clusterApp()
+    await seedDaemon(false)
+    const res = await http.app.inject({ method: 'GET', url: `${ORG}/daemons` })
+    expect(res.json()[0]).toMatchObject({ cluster: false })
+  })
+})
+
+describe('POST /daemons/:id/upgrade — cluster daemon', () => {
+  it('repoints the envelope and opens an op, with the daemon offline', async () => {
+    const { http, applied } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+
+    const res = await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '1.5.0' }
+    })
+    // 202 even though nothing is connected: the image change IS the command.
+    expect(res.statusCode).toBe(202)
+    expect(res.json()).toMatchObject({ op: 'upgrade', status: 'pending', targetVersion: '1.5.0' })
+
+    expect(applied.at(-1)?.spec?.daemon?.image).toBe('registry.example.test/daemon:1.5.0')
+    // And through the settings row, so the next ordinary write does not revert it.
+    const settings = await http.app.inject({ method: 'GET', url: CLUSTER })
+    expect(settings.json()).toMatchObject({ daemonImage: 'registry.example.test/daemon:1.5.0' })
+
+    // Armed, so the replacement pod's READY can settle it (a bare `pending` never would).
+    const op = await new PgDaemonLifecycleOpRepo(prisma).pendingForDaemon(DaemonId(DAEMON))
+    expect(op?.acceptedAt).not.toBeNull()
+  })
+
+  it('refuses a second command while one is in flight', async () => {
+    const { http } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+    const first = await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '1.5.0' }
+    })
+    expect(first.statusCode).toBe(202)
+    const second = await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '1.6.0' }
+    })
+    expect(second.statusCode).toBe(409)
+  })
+
+  // Re-applying the running image changes no generation, so the op could only expire.
+  it('refuses the version the daemon already runs', async () => {
+    const { http, applied } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true, '1.5.0')
+    const before = applied.length
+    const res = await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '1.5.0' }
+    })
+    expect(res.statusCode).toBe(409)
+    expect(applied).toHaveLength(before)
+  })
+
+  it('refuses when the organization has no live envelope', async () => {
+    const { http } = await clusterApp()
+    await seedDaemon(true)
+    const res = await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '1.5.0' }
+    })
+    expect(res.statusCode).toBe(409)
+    // The op is opened before the write is attempted, so it must be closed on failure.
+    const op = await new PgDaemonLifecycleOpRepo(prisma).latestForDaemon(DaemonId(DAEMON))
+    expect(op).toMatchObject({ status: 'failed' })
+  })
+})
+
+describe('POST /daemons/:id/restart — cluster daemon', () => {
+  it('is refused: relaunching the pod belongs to the operator', async () => {
+    const { http } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+    const res = await http.app.inject({ method: 'POST', url: `${ORG}/daemons/${DAEMON}/restart` })
+    expect(res.statusCode).toBe(409)
+    expect(res.json()).toMatchObject({ code: 'DAEMON_CLUSTER_MANAGED' })
+    // Refused before anything durable: no op row to leave behind.
+    expect(await new PgDaemonLifecycleOpRepo(prisma).latestForDaemon(DaemonId(DAEMON))).toBeNull()
+  })
+})

--- a/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
+++ b/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
@@ -21,6 +21,8 @@ import { PgOrgClusterExecutionRepo } from '../../src/persistence/repositories/or
 import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
 import { PgDaemonLifecycleOpRepo } from '../../src/persistence/repositories/daemon-lifecycle-op.repo.js'
 import { PgOrgRepo } from '../../src/persistence/repositories/org.repo.js'
+import { PgRuntimeProfileRepo } from '../../src/persistence/repositories/runtime-profile.repo.js'
+import { DaemonRegistryService } from '../../src/registry/registryService.js'
 import { DaemonId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
@@ -30,8 +32,8 @@ const CLUSTER = `${ORG}/cluster-execution`
 const CONTROL_NAMESPACE = 'agentconnect-control'
 const POLICY = {
   namespacePrefix: 'ac-org-',
-  daemonImage: 'registry.example.test/daemon:1.4.0',
-  runtimeImage: 'registry.example.test/runtime:1.4.0',
+  daemonImage: 'registry.example.test/daemon:v1.4.0',
+  runtimeImage: 'registry.example.test/runtime:v1.4.0',
   daemonTier: 'small',
   runtimeTiers: [{ name: 'small', warmReplicas: 0 }],
   controlPlaneUrl: 'wss://api.example.test/daemon/ws'
@@ -49,14 +51,23 @@ interface Harness {
   /** Bodies of the apply PATCHes, newest last. */
   applied: { spec?: { daemon?: { image?: string } } }[]
   cluster: ClusterExecutionService
+  /** Flip to make every later apply fail — the cluster refusing a durable change. */
+  refuseApply: { on: boolean }
 }
 
-/** An app whose provisioner talks to a fake API server that stores what it is applied. */
-async function clusterApp(): Promise<Harness> {
+/**
+ * An app whose provisioner talks to a fake API server that stores what it is applied.
+ *
+ * `afterApply` runs between the image write and the route's arming step, which is the only
+ * way to land the replacement pod's READY inside that window from a test.
+ */
+async function clusterApp(options: { afterApply?: () => Promise<void> } = {}): Promise<Harness> {
   const applied: { spec?: { daemon?: { image?: string } } }[] = []
+  const refuseApply = { on: false }
   let stored: unknown = null
   const server = await fakeApiServer((req) => {
     if (req.method === 'PATCH') {
+      if (refuseApply.on) return { status: 500, json: { kind: 'Status', message: 'apply refused' } }
       const body = JSON.parse(req.body) as { spec?: { daemon?: { image?: string } } }
       applied.push(body)
       // Standing in for the operator, which derives and publishes the namespace.
@@ -78,9 +89,35 @@ async function clusterApp(): Promise<Harness> {
     new PgDaemonRepo(prisma),
     systemClock
   )
+  if (options.afterApply) {
+    const write = cluster.setDaemonVersion.bind(cluster)
+    cluster.setDaemonVersion = async (orgId, version) => {
+      const image = await write(orgId, version)
+      await options.afterApply!()
+      return image
+    }
+  }
   const http = buildHttpApp(prisma, undefined, undefined, undefined, { clusterExecution: cluster })
   opened.push(http)
-  return { http, applied, cluster }
+  return { http, applied, cluster, refuseApply }
+}
+
+/** The pod the operator replaced, coming back: a fresh auth (higher epoch) then READY. */
+async function replacementRegisters(agentVersion: string): Promise<void> {
+  const daemons = new PgDaemonRepo(prisma)
+  await daemons.upsertOnAuth({ daemonId: DaemonId(DAEMON), orgId: OrgId(DEFAULT_ORG_ID), agentVersion })
+  await daemons.applyRegister(DaemonId(DAEMON), {
+    host: 'ac-daemon',
+    capabilities: { platforms: [], runtimes: ['claude'], acp: true, features: [] },
+    maxAgents: 4,
+    cluster: true
+  })
+  await new DaemonRegistryService(
+    daemons,
+    new PgRuntimeProfileRepo(prisma),
+    new PgDaemonLifecycleOpRepo(prisma),
+    systemClock
+  ).settleLifecycleOpOnReady(DaemonId(DAEMON))
 }
 
 /** A registered daemon row, never connected — `cluster` is what `register` reported. */
@@ -133,10 +170,10 @@ describe('POST /daemons/:id/upgrade — cluster daemon', () => {
     expect(res.statusCode).toBe(202)
     expect(res.json()).toMatchObject({ op: 'upgrade', status: 'pending', targetVersion: '1.5.0' })
 
-    expect(applied.at(-1)?.spec?.daemon?.image).toBe('registry.example.test/daemon:1.5.0')
+    expect(applied.at(-1)?.spec?.daemon?.image).toBe('registry.example.test/daemon:v1.5.0')
     // And through the settings row, so the next ordinary write does not revert it.
     const settings = await http.app.inject({ method: 'GET', url: CLUSTER })
-    expect(settings.json()).toMatchObject({ daemonImage: 'registry.example.test/daemon:1.5.0' })
+    expect(settings.json()).toMatchObject({ daemonImage: 'registry.example.test/daemon:v1.5.0' })
 
     // Armed, so the replacement pod's READY can settle it (a bare `pending` never would).
     const op = await new PgDaemonLifecycleOpRepo(prisma).pendingForDaemon(DaemonId(DAEMON))
@@ -201,5 +238,74 @@ describe('POST /daemons/:id/restart — cluster daemon', () => {
     expect(res.json()).toMatchObject({ code: 'DAEMON_CLUSTER_MANAGED' })
     // Refused before anything durable: no op row to leave behind.
     expect(await new PgDaemonLifecycleOpRepo(prisma).latestForDaemon(DaemonId(DAEMON))).toBeNull()
+  })
+})
+
+describe('cluster daemon upgrade — settlement and durability', () => {
+  /**
+   * The replacement pod can reach READY before the route finishes arming the op, and an
+   * unarmed op ignores that READY on purpose (the command may still be declined). Nothing
+   * would look again, so the op would sit pending until its 15-minute deadline even though
+   * the upgrade succeeded. The route therefore re-checks after arming.
+   */
+  it('settles an upgrade whose pod came back before the op was armed', async () => {
+    const { http } = await clusterApp({ afterApply: () => replacementRegisters('1.5.0') })
+    await enableEnvelope(http)
+    await seedDaemon(true)
+
+    const res = await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '1.5.0' }
+    })
+    expect(res.statusCode).toBe(202)
+    expect(res.json()).toMatchObject({ status: 'succeeded' })
+    expect(await new PgDaemonLifecycleOpRepo(prisma).pendingForDaemon(DaemonId(DAEMON))).toBeNull()
+  })
+
+  /**
+   * The row is written before the apply, and the periodic re-apply renders the spec from
+   * the row — so a refused apply is a change that is still going to happen. Closing the op
+   * `failed` here would report a failure for a command the next pass then executes.
+   */
+  it('keeps the op open when the image is recorded but the cluster refuses the apply', async () => {
+    const { http, refuseApply } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+    refuseApply.on = true
+
+    const res = await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '1.5.0' }
+    })
+    // Reported as an upstream failure, so an operator sees it — but not as a closed op.
+    expect(res.statusCode).toBe(502)
+    expect(res.json()).toMatchObject({ code: 'CLUSTER_API_ERROR' })
+
+    const op = await new PgDaemonLifecycleOpRepo(prisma).pendingForDaemon(DaemonId(DAEMON))
+    expect(op).toMatchObject({ op: 'upgrade', status: 'pending', targetVersion: '1.5.0' })
+    expect(op?.acceptedAt).not.toBeNull() // armed, so the replacement pod can still settle it
+    // And the desired state survived, which is what makes the re-apply converge it.
+    const settings = await http.app.inject({ method: 'GET', url: CLUSTER })
+    expect(settings.json()).toMatchObject({ daemonImage: 'registry.example.test/daemon:v1.5.0' })
+  })
+
+  // The whole point of writing the ROW: the periodic pass pushes what the request could not.
+  it('converges the recorded image on the next re-apply pass', async () => {
+    const { http, cluster, applied, refuseApply } = await clusterApp()
+    await enableEnvelope(http)
+    await seedDaemon(true)
+    refuseApply.on = true
+    await http.app.inject({
+      method: 'POST',
+      url: `${ORG}/daemons/${DAEMON}/upgrade`,
+      payload: { version: '1.5.0' }
+    })
+    refuseApply.on = false
+
+    const outcome = await cluster.resyncEnvelopes()
+    expect(outcome.failures).toEqual([])
+    expect(applied.at(-1)?.spec?.daemon?.image).toBe('registry.example.test/daemon:v1.5.0')
   })
 })

--- a/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
+++ b/packages/control-plane/test/integration/cluster-daemon-lifecycle.route.test.ts
@@ -299,11 +299,13 @@ describe('cluster daemon upgrade — settlement and durability', () => {
   })
 
   /**
-   * The row is written before the apply, and the periodic re-apply renders the spec from
-   * the row — so a refused apply is a change that is still going to happen. Closing the op
-   * `failed` here would report a failure for a command the next pass then executes.
+   * The row is written before the apply, so a refused apply leaves a change that the
+   * re-apply pass would eventually push — outliving this operation's deadline and landing
+   * under an op already reported failed. A COMMAND cannot leave that behind, so the intent
+   * is abandoned: the envelope goes back to the image it had, and failure is then simply
+   * true rather than a description that expires.
    */
-  it('keeps the op open when the image is recorded but the cluster refuses the apply', async () => {
+  it('rolls the envelope back and fails the op when the cluster refuses the apply', async () => {
     const { http, refuseApply } = await clusterApp()
     await enableEnvelope(http)
     await seedDaemon(true)
@@ -314,20 +316,20 @@ describe('cluster daemon upgrade — settlement and durability', () => {
       url: `${ORG}/daemons/${DAEMON}/upgrade`,
       payload: { version: '1.5.0' }
     })
-    // Reported as an upstream failure, so an operator sees it — but not as a closed op.
     expect(res.statusCode).toBe(502)
     expect(res.json()).toMatchObject({ code: 'CLUSTER_API_ERROR' })
 
-    const op = await new PgDaemonLifecycleOpRepo(prisma).pendingForDaemon(DaemonId(DAEMON))
-    expect(op).toMatchObject({ op: 'upgrade', status: 'pending', targetVersion: '1.5.0' })
-    expect(op?.acceptedAt).not.toBeNull() // armed, so the replacement pod can still settle it
-    // And the desired state survived, which is what makes the re-apply converge it.
+    const ops = new PgDaemonLifecycleOpRepo(prisma)
+    expect(await ops.pendingForDaemon(DaemonId(DAEMON))).toBeNull()
+    expect(await ops.latestForDaemon(DaemonId(DAEMON))).toMatchObject({ status: 'failed' })
+    // The decisive assertion: nothing durable survives, so no later pass can enact it.
     const settings = await http.app.inject({ method: 'GET', url: CLUSTER })
-    expect(settings.json()).toMatchObject({ daemonImage: 'registry.example.test/daemon:v1.5.0' })
+    expect(settings.json()).toMatchObject({ daemonImage: 'registry.example.test/daemon:v1.4.0' })
   })
 
-  // The whole point of writing the ROW: the periodic pass pushes what the request could not.
-  it('converges the recorded image on the next re-apply pass', async () => {
+  // And with the intent abandoned, a recovered cluster converges on the OLD image — the
+  // version the failed operation reported, not a surprise upgrade after the fact.
+  it('does not apply the abandoned image once the cluster recovers', async () => {
     const { http, cluster, applied, refuseApply } = await clusterApp()
     await enableEnvelope(http)
     await seedDaemon(true)
@@ -341,6 +343,25 @@ describe('cluster daemon upgrade — settlement and durability', () => {
 
     const outcome = await cluster.resyncEnvelopes()
     expect(outcome.failures).toEqual([])
+    expect(applied.at(-1)?.spec?.daemon?.image).toBe('registry.example.test/daemon:v1.4.0')
+  })
+
+  /**
+   * The fleet sweep has no deadline to outlive, so it keeps the durable intent and lets the
+   * re-apply pass push what its own attempt could not. Same failure, opposite decision —
+   * which is why abandoning lives with the caller that owns a deadline, not in the seam.
+   */
+  it('keeps a sweep’s durable intent and converges it on the next pass', async () => {
+    const { http, cluster, applied, refuseApply } = await clusterApp()
+    await enableEnvelope(http)
+    refuseApply.on = true
+    const sweep = await cluster.alignDaemonVersion('1.5.0')
+    expect(sweep.moved).toEqual([DEFAULT_ORG_ID])
+    refuseApply.on = false
+
+    await cluster.resyncEnvelopes()
     expect(applied.at(-1)?.spec?.daemon?.image).toBe('registry.example.test/daemon:v1.5.0')
+    const settings = await http.app.inject({ method: 'GET', url: CLUSTER })
+    expect(settings.json()).toMatchObject({ daemonImage: 'registry.example.test/daemon:v1.5.0' })
   })
 })

--- a/packages/control-plane/test/integration/cluster-execution.route.test.ts
+++ b/packages/control-plane/test/integration/cluster-execution.route.test.ts
@@ -14,6 +14,7 @@ import { AgentConnectOrgApi, ClusterExecutionService, orgResourceName } from '..
 import { systemClock } from '../../src/domain/clock.js'
 import { PgOrgClusterExecutionRepo } from '../../src/persistence/repositories/org-cluster-execution.repo.js'
 import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
+import { PgDaemonLifecycleOpRepo } from '../../src/persistence/repositories/daemon-lifecycle-op.repo.js'
 import { PgOrgRepo } from '../../src/persistence/repositories/org.repo.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import type { ClusterExecutionDefaults, OrgMemberRole } from '../../src/persistence/ports.js'
@@ -98,6 +99,7 @@ async function clusterApp(options: { route?: MaybeRoute; userId?: string } = {})
     new PgOrgRepo(prisma),
     POLICY,
     new PgDaemonRepo(prisma),
+    new PgDaemonLifecycleOpRepo(prisma),
     systemClock
   )
   const http = buildHttpApp(

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -62,7 +62,8 @@ async function seedDaemon(features = ['worktree-iso']) {
   await repo.applyRegister(DaemonId(DAEMON), {
     host: 'macbook-pro',
     capabilities: { platforms: ['slack'], runtimes: ['claude', 'codex'], acp: true, features },
-    maxAgents: 3
+    maxAgents: 3,
+    cluster: false
   })
 }
 
@@ -1002,6 +1003,7 @@ describe('lifecycle op closure on register→READY', () => {
     host: 'macbook-pro',
     capabilities: { platforms: [] as never[], runtimes: [] as string[], acp: true, features: [] as string[] },
     maxAgents: 3,
+    cluster: false,
     localState: { assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }
   }
   const makeRegistry = (ops: PgDaemonLifecycleOpRepo) =>

--- a/packages/control-plane/test/repo/launch-runtime-audit.repo.test.ts
+++ b/packages/control-plane/test/repo/launch-runtime-audit.repo.test.ts
@@ -178,7 +178,8 @@ describe('RuntimeProfileRepo — snapshot seq fence (real Postgres)', () => {
     await new PgDaemonRepo(prisma).applyRegister(DaemonId(DAEMON), {
       host: 'host-1',
       capabilities: { platforms: ['slack'], runtimes: ['claude'], acp: true, features: [] },
-      maxAgents: 4
+      maxAgents: 4,
+      cluster: false
     })
     expect(await storedSeq()).toBeNull()
     expect(await profiles.replaceAll(DaemonId(DAEMON), [profile('claude')], at, 1)).toBe(true)

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -169,6 +169,8 @@ export interface CpClientDeps {
   host: string
   heartbeatDefaultMs: number
   maxAgents: number
+  /** True ⇒ registered as an operator-managed pod, whose version is its image. Defaults to false. */
+  cluster?: boolean
   capabilities: () => RegisterReq['capabilities']
   /** Observed runtime profiles, emitted as one `facts/daemon-runtimes` snapshot after each register. */
   runtimeProfiles: () => FactsRuntimeProfile[]
@@ -434,6 +436,7 @@ export class CpClient {
       host: this.deps.host,
       capabilities: registerCapabilities,
       maxAgents: this.deps.maxAgents,
+      cluster: this.deps.cluster === true,
       localState: this.deps.localState()
     })
     const barrier: RegisterControlBarrier = {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -20529,6 +20529,9 @@ export class Daemon {
       host: hostname(),
       heartbeatDefaultMs: cp.heartbeatMs,
       maxAgents: this.cfg.limits.maxAgents,
+      // The operator-managed pod shape, so the CP knows this daemon's version is its
+      // image and rolls the org's CR instead of commanding an npm upgrade or a restart.
+      cluster: this.k8s,
       capabilities: () => ({
         platforms: this.registrationPlatforms(),
         // Report the human-facing tool name (e.g. "Claude Agent"), not the

--- a/packages/protocol/src/frames/register.ts
+++ b/packages/protocol/src/frames/register.ts
@@ -26,6 +26,12 @@ export const RegisterReq = z.object({
     features: z.array(z.string()).default([]) // e.g. ["cli-wrapper-fallback","worktree-iso"]
   }),
   maxAgents: z.number().int(), // concurrency ceiling for placement (C3)
+  // True ⇒ this daemon is an operator-managed pod inside an org's execution envelope, so
+  // its version IS its container image: npm self-upgrade and supervisor restart do not
+  // apply, and the CP repoints `AgentConnectOrg.spec.daemon.image` instead. Self-reported
+  // because only the daemon knows which SpawnDriver it runs; defaulted so an older daemon
+  // still registers as the machine it is (agentconnect-org-operator.md).
+  cluster: z.boolean().default(false),
   localState: z.object({
     // what the daemon currently believes it owns (for reconcile)
     assignments: z.array(z.string()), // sessionKeys it is actively serving

--- a/packages/web/src/components/console/modals/DaemonLifecycleModal.tsx
+++ b/packages/web/src/components/console/modals/DaemonLifecycleModal.tsx
@@ -87,6 +87,9 @@ export default function DaemonLifecycleModal({
   }
 
   const isUpgrade = mode === 'upgrade'
+  // A cluster daemon upgrades by image, not by install-then-relaunch: the control plane
+  // repoints the org's envelope and its operator replaces the pod. Same op tracking.
+  const isClusterUpgrade = isUpgrade && daemon.cluster
   const title = isUpgrade ? 'Upgrade daemon' : 'Restart daemon'
   const icon = isUpgrade ? 'arrow-up-circle' : 'refresh-cw'
   const noTargets = isUpgrade && options.length === 0
@@ -110,7 +113,13 @@ export default function DaemonLifecycleModal({
             <div className="mb-[14px] flex items-start gap-[9px] rounded-md border border-(--amber-500) bg-(--status-paused-soft) px-3 py-[11px]">
               <Icon name="alert-triangle" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
               <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
-                {isUpgrade ? (
+                {isClusterUpgrade ? (
+                  <>
+                    <span className="mono text-(--text-primary)">{daemon.name}</span> runs in the cluster: its
+                    organization’s execution envelope is repointed at the target image and the operator replaces the
+                    pod. Active sessions end with the pod, and it re-registers once the new one is up.
+                  </>
+                ) : isUpgrade ? (
                   <>
                     <span className="mono text-(--text-primary)">{daemon.name}</span> will install the target version,
                     then drain its active sessions and relaunch onto it. Established sessions finish first; brief
@@ -192,10 +201,15 @@ export default function DaemonLifecycleModal({
                 </span>
                 <div className="flex-1">
                   <div className="font-sans text-[13px] font-semibold leading-normal">
-                    {isUpgrade ? 'Installing and relaunching…' : 'Draining and relaunching…'}
+                    {isClusterUpgrade
+                      ? 'Rolling the pod onto the new image…'
+                      : isUpgrade
+                        ? 'Installing and relaunching…'
+                        : 'Draining and relaunching…'}
                   </div>
                   <div className="mono text-[11px] text-(--text-tertiary)">
-                    {daemon.name} will re-register once its supervisor brings it back.
+                    {daemon.name} will re-register once{' '}
+                    {isClusterUpgrade ? 'its operator brings the new pod up' : 'its supervisor brings it back'}.
                   </div>
                 </div>
               </>

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -32,6 +32,10 @@ import { useOrgs } from '@/lib/org-context'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 
+/** Why Restart is inert on a cluster daemon; the CP refuses it with the same reason. */
+const CLUSTER_RESTART_HINT =
+  'This daemon runs in the cluster — its operator relaunches the pod. Upgrade its version instead.'
+
 // Bar colour tracks the hotter reading (matches the daemons list).
 function barColor(pct: number): string {
   return pct >= 80 ? 'var(--status-paused)' : pct >= 60 ? 'var(--amber-500)' : 'var(--brand)'
@@ -102,8 +106,14 @@ export default function DaemonDetailView() {
   // Restart/upgrade are owner-only fleet ops (server denyNonOwner) — gate the controls on
   // the DTO capability so non-owners never see an action they'd 403 on. Restart needs the
   // daemon live; upgrade additionally needs the resolver to have surfaced other versions.
-  const canRestart = online && !pending && daemon.canManageLifecycle
-  const canUpgrade = canRestart && daemon.availableVersions.some((v) => v !== daemon.version)
+  // A cluster daemon has no restart to command — its operator relaunches the pod — and its
+  // upgrade is an image change, so it stays available while the daemon is offline.
+  const canRestart = online && !pending && daemon.canManageLifecycle && !daemon.cluster
+  // Rendered disabled rather than dropped: an operator looking for Restart should learn
+  // that the cluster owns it, not find the control silently missing.
+  const clusterRestartBlocked = daemon.cluster && !pending && daemon.canManageLifecycle
+  const versionsToOffer = daemon.availableVersions.some((v) => v !== daemon.version)
+  const canUpgrade = !pending && daemon.canManageLifecycle && versionsToOffer && (daemon.cluster || online)
 
   const hosted = agents.filter((a) => a.daemon === daemon.daemonId)
   const runtimes = daemon.runtimeModels.length
@@ -200,10 +210,12 @@ export default function DaemonDetailView() {
               Reconnect
             </button>
           )}
-          {canRestart && (
+          {(canRestart || clusterRestartBlocked) && (
             <button
-              onClick={() => openModal('restartDaemon', daemon)}
-              className="flex h-11 flex-1 cursor-pointer items-center justify-center gap-2 rounded-md border border-(--border-default) bg-(--surface-card) font-sans text-[14px] font-semibold leading-normal text-(--text-primary)"
+              onClick={canRestart ? () => openModal('restartDaemon', daemon) : undefined}
+              disabled={!canRestart}
+              title={canRestart ? undefined : CLUSTER_RESTART_HINT}
+              className="flex h-11 flex-1 cursor-pointer items-center justify-center gap-2 rounded-md border border-(--border-default) bg-(--surface-card) font-sans text-[14px] font-semibold leading-normal text-(--text-primary) disabled:cursor-default disabled:opacity-50"
             >
               <Icon name="refresh-cw" size={16} />
               Restart
@@ -553,9 +565,11 @@ export default function DaemonDetailView() {
                     Edit
                   </button>
                 )}
-                {canRestart && (
+                {(canRestart || clusterRestartBlocked) && (
                   <button
-                    className="dmi"
+                    className="dmi disabled:cursor-default disabled:opacity-50"
+                    disabled={!canRestart}
+                    title={canRestart ? undefined : CLUSTER_RESTART_HINT}
                     onClick={() => {
                       setMenuOpen(false)
                       openModal('restartDaemon', daemon)

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -160,9 +160,11 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
   const offline = m.status === 'offline'
   // Restart is an edit offered while the daemon is online + no op in flight; upgrade
   // additionally needs a newer published version. Both gated on canManageLifecycle.
+  // A cluster daemon is never restartable here (its operator owns relaunching the pod)
+  // and IS upgradable while offline — the image change is what rescues a bad rollout.
   const pending = m.lifecycleOp?.status === 'pending'
-  const canRestart = online && !pending && m.canManageLifecycle
-  const canUpgrade = canRestart && m.upgradeAvailable
+  const canRestart = online && !pending && m.canManageLifecycle && !m.cluster
+  const canUpgrade = !pending && m.canManageLifecycle && m.upgradeAvailable && (m.cluster || online)
 
   const beginEdit = () => {
     setDraft(m.name)
@@ -304,6 +306,18 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
                       setMenuOpen(false)
                       openModal('restartDaemon', m)
                     }}
+                  >
+                    <Icon name="refresh-cw" size={15} />
+                    Restart
+                  </button>
+                )}
+                {/* Shown disabled rather than hidden: an operator looking for Restart should
+                    learn that Kubernetes owns it here, not that the option vanished. */}
+                {m.cluster && m.canManageLifecycle && (
+                  <button
+                    className="dmi disabled:cursor-default disabled:opacity-50"
+                    disabled
+                    title="This daemon runs in the cluster — its operator relaunches the pod. Upgrade its version instead."
                   >
                     <Icon name="refresh-cw" size={15} />
                     Restart

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1027,6 +1027,10 @@ export interface DaemonViewDto {
   canManageSharing: boolean
   /** Whether the caller may command restart/upgrade on this daemon (org owner only). */
   canManageLifecycle: boolean
+  /** True ⇒ an operator-managed pod: no restart to command, and an upgrade repoints the
+   *  org's execution envelope instead of reinstalling from npm. Optional so a console
+   *  built against an older control plane still parses the row. */
+  cluster?: boolean
 }
 
 /** The console-settable "Expire sessions" window (PATCH /daemons/:id):
@@ -1960,6 +1964,7 @@ export function daemonFromDto(d: DaemonViewDto): DaemonRow {
     lifecycleOp: d.lifecycleOp ?? null,
     lifecycleStatus: lifecycleStatus(d.lifecycleOp) ?? null,
     canManageLifecycle: d.canManageLifecycle ?? false,
+    cluster: d.cluster ?? false,
     // Flag an available upgrade only when both versions parse and latest > running.
     upgradeAvailable: isUpgradeAvailable(d.agentVersion, d.latestVersion),
     // Keep connection/readiness operational. Presentation surfaces combine this

--- a/packages/web/src/lib/daemon-notifications.test.tsx
+++ b/packages/web/src/lib/daemon-notifications.test.tsx
@@ -30,6 +30,7 @@ const mockDaemon = (id: string, name: string, op?: DaemonRow['lifecycleOp']): Da
   daemonId: id,
   name,
   version: '1.0.0',
+  cluster: false,
   latestVersion: '1.1.0',
   releaseChannel: 'latest',
   upgradeAvailable: true,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1845,6 +1845,10 @@ export interface DaemonRow {
   lifecycleOp: DaemonLifecycleOp | null
   /** Whether the caller may command restart/upgrade on this daemon (org owner only). */
   canManageLifecycle: boolean
+  /** True ⇒ an operator-managed pod in this org's cluster envelope. Its version is its
+   *  container image, so Restart is not offered (Kubernetes relaunches it) and Upgrade
+   *  repoints the envelope rather than reinstalling from npm — including while offline. */
+  cluster: boolean
   /** Actual daemon connection/readiness. Never replaced by a presentation-only lifecycle state. */
   status: ConnectionStatusKey
   /** Planned lifecycle presentation while the durable operation is pending. */


### PR DESCRIPTION
## Why

An envelope daemon's version **is its container image**. The two lifecycle commands the console offers meant nothing for it — there is no npm install to replace and no supervisor to exit to, and the daemon refused both — yet the console still rendered Restart and routed Upgrade over the WebSocket. The only way to move a cluster daemon was to hand-edit its organization's cluster-execution settings.

## What changed

**1. The control plane knows which kind of daemon it is talking to.** `RegisterReq` gains `cluster`, self-reported by a daemon running with `--k8s`. Deliberately *not* read off the identity binding even though a bound `clusterIdentity` implies one today: the binding answers *who* a daemon is, and this asks *what its lifecycle is* — which only the daemon can answer, since only it knows which `SpawnDriver` it runs. The stored flag is OR-ed with the binding so an envelope daemon that predates the field reads correctly before its next register, and the migration backfills the same way. Surfaced as one boolean on the daemon read model.

**2. A console upgrade repoints the envelope.** `POST /daemons/:id/upgrade` on a cluster daemon rewrites the version tag on `AgentConnectOrg.spec.daemon.image`; the operator's `Recreate` rollout replaces the pod. The `DaemonLifecycleOp`, its arming epoch, and the READY-on-target settlement are the machine path's unchanged — a new pod always re-auths to a strictly greater epoch, which is the fence a drain-and-relaunch already uses. **Reachability is not required**: rescuing a pod crash-looping on a bad image is most of the value. Restart is refused with `409 DAEMON_CLUSTER_MANAGED`, and the console renders it **disabled rather than absent** so an operator learns where it went.

**3. A boot sweep catches the fleet up.** At startup the control plane moves every enabled envelope onto the newest version its release channel names (`DAEMON_DIST_TAG` — `rc` on the test CP, `latest` in production), which is sound because one release publishes the npm package and the image from one version. Once per boot, not on a timer: it is the catch-up for a release published while the process was down, and a timer would fight an operator who just pinned an org.

## Two decisions worth reviewing

**Both paths write the settings ROW, never the CR directly.** The periodic re-apply added in #918 renders the spec from that row, so a CR-only write would be reverted by the next pass. This also answers the question #918 explicitly deferred (`spec.daemon.image` "is a separate product decision") — the design doc is updated so the two read as one story rather than two.

**The sweep refuses three envelopes rather than doing too much:** one on a different repository than this install configured, one whose tag is not a parseable version (a floating tag or a digest is a pin somebody chose), and one already at or ahead of the target. *Rolling a fleet backwards on a restart is the one outcome worse than staying stale.* An explicit console upgrade keeps no such guard — offering every published version is how a bad release gets rolled back.

## Notes

- Tag substitution is validated in `withImageTag`, the one place that composes a registry reference, so a value carrying `/` or `:` cannot repoint an envelope at somebody else's image even if a future route forgets to check first. (`DaemonUpgradeBody` already rejects it at the edge; this is the seam's own guard.)
- **The runtime image is untouched by both paths.** It rolls through the drain handshake (§3), not a pod replacement, and moving it is a separate decision — flagging in case reviewers expect the two to move together.
- The boot sweep opens **no** lifecycle op, so the console shows no "upgrading" badge for it — the daemon's reported version simply changes. A per-org op for an automatic fleet action seemed like noise; say the word if you'd rather see it.
- Forward-only in the usual sense only: the migration adds one defaulted column.

## Testing

- `pnpm --filter @agentconnect.md/control-plane test:unit` — 151 files / 1637 tests green, including new `cluster/image.test.ts` (tag arithmetic, semver ordering, the substitution guard) and `cluster/image-sync.test.ts` (per-org move, the three refusals, per-org failure isolation, the sweep's no-published-version and never-throws paths).
- `pnpm --filter @agentconnect.md/control-plane test:int` — 81 files / 1154 tests green, including new `cluster-daemon-lifecycle.route.test.ts`: the image lands on both the resource and the row, it works with the daemon offline, the op is armed, restart 409s with no op row left behind.
- `protocol` (307) and `web` (1499) suites green; `pnpm typecheck` and `pnpm lint` clean.
- Daemon suite: 3395 passed, 4 failed under full-suite parallel load; each failing file passes in isolation (known load flakiness in that suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
