### PR TITLE
fix(github): allow internal app pull request reviews

### DIFF
--- a/docs/designs/github-pr-review-checks.md
+++ b/docs/designs/github-pr-review-checks.md
@@ -423,7 +423,7 @@ Installation-token reviews are authored by one deployment-level App bot, not age
 
 - Multiple AgentConnect agents cannot produce distinct reviewer identities; conflicting reviews share bot actor.
 - App bot cannot approve its own PR. If last push is also by bot, it cannot satisfy "last push must be approved by someone else." No CODEOWNERS promise.
-- Relay rejects all `sender.type === 'Bot'`, so App/Dependabot-authored PR does not trigger hook; bot events from formal review cannot loop.
+- Relay rejects bot comments/review-comments and unrelated bot events, so formal-review events cannot loop. PR `opened|synchronize` revisions authored by the configured App are the lifecycle exception: same-repository revisions are the internal CI lane and may start review without human-author authorization; fork revisions still require the maintainer workflow-approval path.
 - On hook creation, PR review menu is collapsed by default and defaults to `Details` (`full` + informational Check). `None` maps to review/reporting `off` without changing trigger or output routing, while `Brief` permits only a formal `COMMENT` review and no Check. Expanded Details shows four side-by-side capability checkboxes projected from config: Inline comments → Request changes → Approve hierarchy, plus independent Status check.
 - Put public-repo/untrusted-input, self-review, and CODEOWNERS limits in capability hover text rather than permanent warning stack. After repository selection, show repository-access blocker immediately in red with authorization entry; App-installation permission blocker shows settings link. Scratch may authorize any covered repository; manual GitHub workspace may explicitly authorize only its own workspace repository. Show nothing before repository selection.
 

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -205,8 +205,12 @@ filters require at least one current subject label to match.
 `commentFamilies` distinguishes issue comments from pull-request conversation
 comments because GitHub sends both through `issue_comment`.
 
-The matcher always rejects `sender.type === "Bot"` to prevent self-reply loops
-and agent-to-agent mention loops.
+The matcher rejects bot-authored comments and review comments, plus unrelated bot
+events, to prevent self-reply loops and agent-to-agent mention loops. PR `opened` and
+`synchronize` revisions authored by the configured App are admitted as the lifecycle
+exception: same-repository PRs are treated as an internal CI lane and may start review
+without a human-author permission lookup, while fork PRs remain on the maintainer
+workflow-approval path.
 
 Closed, deleted, reopened, and edited issue or pull-request lifecycle events do
 not start turns. Signed issue-close, issue-delete, and merged-pull-request

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -824,9 +824,12 @@ are present, broadcast wins; mentioning an unrelated GitHub user does not change
 the configured review cadence.
 
 Mention routing does not bypass the integration's event family, label filter,
-installation attribution, live maintainer authorization, or bot-sender veto. A
-targeted agent mention narrows an otherwise broader `updated` fan-out, while an
-event with no AgentConnect mention continues to follow its configured cadence.
+installation attribution, or live maintainer authorization. Bot-sender veto still
+applies to comments and review comments. An `opened`/`synchronize` PR authored by
+the installed App is admitted as a lifecycle event: same-repository PRs follow the
+internal CI review lane, while fork PRs wait for workflow approval. A targeted agent
+mention narrows an otherwise broader `updated` fan-out, while an event with no
+AgentConnect mention continues to follow its configured cadence.
 In a pull request conversation, an authorized explicit AgentConnect mention
 starts a new review generation for the current revision when the integration
 allows formal reviews, so its informational Check reopens and enters in progress

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/fuyaoz/Library/pnpm/store/workspace-node-modules/agentconnect

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/fuyaoz/Library/pnpm/store/workspace-node-modules/agentconnect

--- a/packages/relay/src/hooks/github-ingress.test.ts
+++ b/packages/relay/src/hooks/github-ingress.test.ts
@@ -965,6 +965,62 @@ describe('github ingress', () => {
       }
     )
 
+    it.each(['opened', 'synchronize'] as const)(
+      'dispatches a same-repository PR %s authored by this App without human-author authorization',
+      async (action) => {
+        h.table.upsert(rule({}, { events: ['pull_request:*'], appSlug: 'example-review-app' }))
+        h.authzResult = false
+        const pullRequest = pullPayload().pull_request as Record<string, unknown>
+        const appBot = 'example-review-app[bot]'
+
+        await post(
+          'pull_request',
+          pullPayload({
+            action,
+            sender: { login: 'release-manager', type: 'User' },
+            pull_request: {
+              ...pullRequest,
+              user: { login: appBot, type: 'Bot' },
+              head: { sha: 'a'.repeat(40), repo: { full_name: 'acme/infra' } },
+              base: { sha: 'b'.repeat(40), repo: { full_name: 'acme/infra' } }
+            }
+          })
+        )
+        await flush()
+
+        expect(h.authzRequests).toHaveLength(0)
+        expect(h.sent).toHaveLength(1)
+        expect(h.sent[0]).toMatchObject({ event: `pull_request:${action}`, agentId: AGENT })
+        expect(h.reports).toEqual([expect.objectContaining({ status: 'accepted' })])
+      }
+    )
+
+    it('keeps an App-authored fork PR behind the workflow-approval marker', async () => {
+      h.table.upsert(rule({}, { events: ['pull_request:*'], appSlug: 'example-review-app' }))
+      h.authzResult = false
+      const pullRequest = pullPayload().pull_request as Record<string, unknown>
+
+      await post(
+        'pull_request',
+        pullPayload({
+          sender: { login: 'example-review-app[bot]', type: 'Bot' },
+          pull_request: {
+            ...pullRequest,
+            user: { login: 'example-review-app[bot]', type: 'Bot' },
+            head: { sha: 'a'.repeat(40), repo: { full_name: 'example-fork/infra' } },
+            base: { sha: 'b'.repeat(40), repo: { full_name: 'acme/infra' } }
+          }
+        })
+      )
+      await flush()
+
+      expect(h.authzRequests).toEqual([expect.objectContaining({ senderLogin: 'example-review-app[bot]' })])
+      expect(h.sent).toHaveLength(0)
+      expect(h.reports).toEqual([
+        expect.objectContaining({ reason: HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED, status: 'failed' })
+      ])
+    })
+
     it.each(['OWNER', 'MEMBER', 'COLLABORATOR'] as const)(
       'live-checks a PR author even when the payload association is %s',
       async (authorAssociation) => {
@@ -2402,6 +2458,27 @@ describe('githubRuleVerdict (pure predicate)', () => {
     const pr = { ...ctx, event: 'pull_request' }
     expect(githubRuleVerdict(r, { ...pr, eventAction: 'pull_request:synchronize' })).toBe('needs-authz')
     expect(matches(r, { ...pr, eventAction: 'pull_request:edited' })).toBe(false)
+  })
+
+  it('trusts only same-repository revisions authored by this App', () => {
+    const r = rule({}, { events: ['pull_request:*'], appSlug: 'example-review-app' })
+    const appPr = {
+      ...ctx,
+      event: 'pull_request',
+      eventAction: 'pull_request:synchronize',
+      subjectAuthorLogin: 'example-review-app[bot]',
+      subjectAuthorType: 'Bot',
+      headRepoFullName: 'acme/infra',
+      baseRepoFullName: 'acme/infra'
+    }
+
+    expect(githubRuleVerdict(r, appPr)).toBe('trusted')
+    expect(githubRuleVerdict(r, { ...appPr, headRepoFullName: 'fork/infra', baseRepoFullName: 'acme/infra' })).toBe(
+      'needs-authz'
+    )
+    expect(githubRuleVerdict(r, { ...appPr, senderType: 'Bot', subjectAuthorLogin: 'dependabot[bot]' })).toBe(
+      'no-match'
+    )
   })
 
   it('applies comment subject scope only when commentFamilies is non-empty', () => {

--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -16,9 +16,11 @@
  * facts from GitHub (decision 11). Subscription events (`issues`,
  * `pull_request`, `issue_comment`) match against the CP-compiled rules by
  * NUMERIC repo id, gated per rule by the org's installation set (decision 6),
- * with an unconditional `[bot]`-sender veto (decision 10). Every matching hook
- * fires its own `rd/msg` (msgId is hookId-prefixed, so fan-out of one delivery
- * to several hooks never self-dedups at the daemon).
+ * with a bot-sender veto except for PR revisions authored by this App (decision
+ * 10). Same-repository revisions enter the internal CI lane; fork revisions
+ * remain behind workflow approval. Every matching hook fires its own `rd/msg`
+ * (msgId is hookId-prefixed, so fan-out of one delivery to several hooks never
+ * self-dedups at the daemon).
  */
 import { randomUUID } from 'node:crypto'
 import type { FastifyInstance } from 'fastify'
@@ -129,7 +131,7 @@ interface GithubSubject {
   title?: string
   body?: string | null
   html_url?: string
-  user?: { login?: string }
+  user?: { login?: string; type?: string }
   author_association?: string
   labels?: Array<{ name?: string }>
   head?: { sha?: string; repo?: { full_name?: string } | null }
@@ -153,6 +155,9 @@ export interface GithubMatchCtx {
   // comment body, else issue/PR body, else the head commit message. Handles are
   // matched locally, but actor permission is always resolved live by the CP.
   subjectAuthorLogin?: string
+  subjectAuthorType?: string
+  headRepoFullName?: string
+  baseRepoFullName?: string
   commentAuthorLogin?: string
   mentionText: string | undefined
   /** GitHub's native reviewer request target. Only this App's `[bot]` login
@@ -208,6 +213,29 @@ function githubRuleSupportsPullRequests(rule: RcHookAssign): boolean {
   )
 }
 
+function isConfiguredAppPullRequest(rule: RcHookAssign, ctx: GithubMatchCtx): boolean {
+  if (
+    ctx.event !== 'pull_request' ||
+    !EXTERNAL_PR_REVISION_EVENTS.has(ctx.eventAction) ||
+    !rule.github?.appSlug ||
+    ctx.subjectAuthorType !== 'Bot' ||
+    !ctx.subjectAuthorLogin
+  )
+    return false
+  return ctx.subjectAuthorLogin.toLowerCase() === `${rule.github.appSlug}[bot]`.toLowerCase()
+}
+
+/** A same-repository App-authored revision is the internal CI lane. It may
+ * trigger review without treating the App bot as a human maintainer. */
+function isInternalAppPullRequest(rule: RcHookAssign, ctx: GithubMatchCtx): boolean {
+  return Boolean(
+    isConfiguredAppPullRequest(rule, ctx) &&
+    ctx.headRepoFullName &&
+    ctx.baseRepoFullName &&
+    ctx.headRepoFullName.toLowerCase() === ctx.baseRepoFullName.toLowerCase()
+  )
+}
+
 function isGithubThreadComment(ctx: GithubMatchCtx): boolean {
   return ctx.event === 'issue_comment' || ctx.event === 'pull_request_review_comment'
 }
@@ -256,9 +284,9 @@ export function githubRuleVerdict(rule: RcHookAssign, ctx: GithubMatchCtx): Gith
         ctx.eventAction === 'pull_request:converted_to_draft'))
   )
     return 'no-match'
-  // Decision 10: any [bot] sender is vetoed unconditionally — kills the agent's
-  // own comment echo and two agents' mutual-@ oscillation alike.
-  if (ctx.senderType === 'Bot') return 'no-match'
+  // Decision 10: bot-authored comments/review-comments and unrelated bot PRs
+  // remain vetoed; only this App's same-repository PR revisions enter review.
+  if (ctx.senderType === 'Bot' && !isConfiguredAppPullRequest(rule, ctx)) return 'no-match'
   // Decision 6(a): the org-attribution gate. An event that cannot prove its
   // installation does not fire.
   if (!ctx.installationId || !rule.github.installationIds.includes(ctx.installationId)) return 'no-match'
@@ -327,7 +355,7 @@ export function githubRuleVerdict(rule: RcHookAssign, ctx: GithubMatchCtx): Gith
   // GitHub's relationship labels are descriptive, not an authorization proof:
   // MEMBER and COLLABORATOR may still have only read/triage access. Every
   // numbered-thread event therefore resolves current write/admin authority.
-  return ctx.event === 'push' ? 'trusted' : 'needs-authz'
+  return ctx.event === 'push' || isInternalAppPullRequest(rule, ctx) ? 'trusted' : 'needs-authz'
 }
 
 /** Truncate on a UTF-8 BYTE budget, cutting at a code-point boundary — the
@@ -844,6 +872,9 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
         labels: (subject?.labels ?? []).map((l) => l.name ?? '').filter(Boolean),
         senderType: payload.sender?.type,
         subjectAuthorLogin: subject?.user?.login,
+        subjectAuthorType: subject?.user?.type,
+        headRepoFullName: subject?.head?.repo?.full_name,
+        baseRepoFullName: subject?.base?.repo?.full_name,
         commentAuthorLogin: payload.comment?.user?.login,
         requestedReviewerLogin: payload.requested_reviewer?.login,
         commentSubjectFamily:
@@ -1055,8 +1086,13 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
         ctx.event === 'issues' ||
         (ctx.event === 'pull_request' && ctx.eventAction !== 'pull_request:review_requested')
       ) {
+        for (const rule of matched.filter((candidate) => candidate.verdict === 'trusted').map(({ rule }) => rule)) {
+          dispatchRule(rule, true)
+        }
+        const needsAuthz = matched.filter((candidate) => candidate.verdict === 'needs-authz').map(({ rule }) => rule)
+        if (needsAuthz.length === 0) return reply.code(202).send({ deliveryKey })
         void authorizeAndDispatch(
-          matched.map((candidate) => candidate.rule),
+          needsAuthz,
           { senderLogin: ctx.subjectAuthorLogin },
           ctx.event === 'pull_request' ? 'request-review' : 'skip'
         ).catch((err) => {


### PR DESCRIPTION
## What changed

- Admit pull request opened and synchronize events authored by the configured GitHub App.
- Same-repository App-authored PRs enter the internal CI review lane without human-author authorization.
- App-authored fork PRs retain the durable workflow-approval path.
- Bot comments, review comments, unrelated bot events, and review loops remain vetoed.

## Validation

- 109 GitHub ingress tests passed.
- Relay typecheck passed.
- Prettier check passed.
- Pre-push ESLint passed with two existing warnings in packages/daemon/test/workspace-git-write.test.ts.

## Boundary

The GitHub actor is still the deployment App, so APPROVE is not expected to count for an App-authored PR. Trusted origin-agent provenance for preventing the same AgentConnect agent from creating and reviewing the same PR remains a follow-up.

Created by Codex . GPT-5