### PR TITLE
fix(web): refresh access tokens rejected as expired

### DIFF
--- a/packages/control-plane/src/http/plugins/auth.test.ts
+++ b/packages/control-plane/src/http/plugins/auth.test.ts
@@ -186,7 +186,11 @@ describe('humanAuthPlugin identity warm trigger (oidc path)', () => {
   // shape the OIDC integration tests use, without any database behind it.
   let oidcServer: Server
   let oidcIssuer = ''
-  let mintBearer: (subject: string, claims?: Record<string, unknown>) => Promise<string>
+  let mintBearer: (
+    subject: string,
+    claims?: Record<string, unknown>,
+    expiration?: Parameters<SignJWT['setExpirationTime']>[0]
+  ) => Promise<string>
 
   beforeAll(async () => {
     const { privateKey, publicKey } = await generateKeyPair('RS256')
@@ -210,13 +214,13 @@ describe('humanAuthPlugin identity warm trigger (oidc path)', () => {
     })
     const { port } = oidcServer.address() as AddressInfo
     oidcIssuer = `http://127.0.0.1:${port}`
-    mintBearer = (subject, claims = {}) =>
+    mintBearer = (subject, claims = {}, expiration = '10m') =>
       new SignJWT(claims)
         .setProtectedHeader({ alg: 'RS256', kid: 'warm-test' })
         .setIssuer(oidcIssuer)
         .setSubject(subject)
         .setIssuedAt()
-        .setExpirationTime('10m')
+        .setExpirationTime(expiration)
         .sign(privateKey)
   })
 
@@ -286,5 +290,19 @@ describe('humanAuthPlugin identity warm trigger (oidc path)', () => {
 
     expect(response.statusCode).toBe(401)
     expect(warm).not.toHaveBeenCalled()
+  })
+
+  it('marks an expired bearer so the browser can refresh it once', async () => {
+    const app = await appWithOptions({ OIDC_ISSUER: oidcIssuer })
+    const expired = await mintBearer('sub-42', {}, Math.floor(Date.now() / 1000) - 60)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/probe',
+      headers: { authorization: `Bearer ${expired}` }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toMatchObject({ code: 'TOKEN_EXPIRED', message: 'access token expired' })
   })
 })

--- a/packages/control-plane/src/http/plugins/auth.ts
+++ b/packages/control-plane/src/http/plugins/auth.ts
@@ -162,6 +162,15 @@ function unauthorized(reply: FastifyReply, message: string): FastifyReply {
   return reply.code(401).send({ error: 'Unauthorized', statusCode: 401, message })
 }
 
+function tokenExpired(reply: FastifyReply): FastifyReply {
+  return reply.code(401).send({
+    error: 'Unauthorized',
+    statusCode: 401,
+    code: 'TOKEN_EXPIRED',
+    message: 'access token expired'
+  })
+}
+
 /** The token is valid but the account behind it was deleted. A distinct `code` so
  *  the console can tell this apart from an expired/invalid token and force a
  *  sign-out instead of retrying with the same (now identity-less) session. */
@@ -440,6 +449,7 @@ function oidcAuth(cfg: HumanAuthOptions & { OIDC_ISSUER: string }): preHandlerHo
       // bare 401 and the reason is unknowable from the logs.
       const e = err as { code?: string; claim?: string; message?: string }
       req.log.warn({ code: e.code, claim: e.claim, reason: e.message }, 'humanAuth: bearer token rejected')
+      if (e.code === 'ERR_JWT_EXPIRED') return tokenExpired(reply)
       return unauthorized(reply, 'invalid token')
     }
   }

--- a/packages/web/src/lib/api-token-refresh.test.ts
+++ b/packages/web/src/lib/api-token-refresh.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const auth = vi.hoisted(() => ({
+  getToken: vi.fn(),
+  forceRefreshToken: vi.fn(),
+  getIdTokenRaw: vi.fn(),
+  getUser: vi.fn(),
+  signOutDeletedAccount: vi.fn()
+}))
+
+vi.mock('@/lib/auth', () => auth)
+
+import { getMyAccess } from './api'
+
+describe('Control Plane token expiry recovery', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('evicts the stale token and retries once when the CP marks it expired', async () => {
+    auth.getToken.mockResolvedValueOnce('stale-token').mockResolvedValue('fresh-token')
+    auth.forceRefreshToken.mockResolvedValue('fresh-token')
+    auth.getIdTokenRaw.mockResolvedValue(undefined)
+    auth.getUser.mockResolvedValue(null)
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 'TOKEN_EXPIRED', message: 'access token expired' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ waitlistMode: false, status: 'active', activated: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getMyAccess()).resolves.toMatchObject({ status: 'active' })
+
+    expect(auth.forceRefreshToken).toHaveBeenCalledOnce()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get('authorization')).toBe('Bearer stale-token')
+    expect(new Headers(fetchMock.mock.calls[1]?.[1]?.headers).get('authorization')).toBe('Bearer fresh-token')
+  })
+
+  it('does not retry an unrelated unauthorized response', async () => {
+    auth.getToken.mockResolvedValue('token')
+    auth.getIdTokenRaw.mockResolvedValue(undefined)
+    auth.getUser.mockResolvedValue(null)
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'invalid token' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' }
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getMyAccess()).rejects.toMatchObject({ status: 401 })
+
+    expect(auth.forceRefreshToken).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -18,7 +18,7 @@ import type {
 import { isSelfSender, lifecycleStatus, MOCK_MODE } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
-import { getToken, getIdTokenRaw, getUser, signOutDeletedAccount } from '@/lib/auth'
+import { forceRefreshToken, getToken, getIdTokenRaw, getUser, signOutDeletedAccount } from '@/lib/auth'
 import { track } from '@/lib/analytics'
 import { createSseParser } from '@/lib/sse'
 import { isUpgradeAvailable } from '@/lib/version'
@@ -1253,8 +1253,26 @@ async function authHeaders(extra?: Record<string, string>): Promise<Record<strin
   return h
 }
 
+async function fetchWithTokenRefresh(input: string, init: RequestInit = {}): Promise<Response> {
+  const extra = Object.fromEntries(new Headers(init.headers).entries())
+  const request = async () => fetch(input, { ...init, headers: await authHeaders(extra) })
+  const response = await request()
+  if (response.status !== 401) return response
+  const body = (await response
+    .clone()
+    .json()
+    .catch(() => undefined)) as { code?: unknown } | undefined
+  if (body?.code !== 'TOKEN_EXPIRED') return response
+
+  // The CP validates the JWT's authoritative exp. If it has expired while the
+  // SDK's cached expiresAt still says otherwise, evict that cache and retry the
+  // request once with a token minted from the refresh token.
+  await forceRefreshToken()
+  return request()
+}
+
 async function apiGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${cpBase()}${path}`, { headers: await authHeaders(), cache: 'no-store' })
+  const res = await fetchWithTokenRefresh(`${cpBase()}${path}`, { cache: 'no-store' })
   // Parse the denial body like the write helpers do: reads carry machine-readable
   // `code`s too (e.g. DAEMON_FEATURE_MISSING on a capability-gated route), and a
   // status-only ApiError silently drops them.
@@ -1309,8 +1327,8 @@ async function readSessionEventStream(
   }, SESSION_STREAM_REAUTH_MS)
   const path = `/orgs/${encodeURIComponent(orgId)}/stream`
   try {
-    const res = await fetch(`${cpBase()}${path}`, {
-      headers: await authHeaders({ accept: 'text/event-stream' }),
+    const res = await fetchWithTokenRefresh(`${cpBase()}${path}`, {
+      headers: { accept: 'text/event-stream' },
       cache: 'no-store',
       signal: request.signal
     })
@@ -1402,9 +1420,9 @@ export function subscribeSessionEvents(
 }
 
 async function apiPost<T>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${cpBase()}${path}`, {
+  const res = await fetchWithTokenRefresh(`${cpBase()}${path}`, {
     method: 'POST',
-    headers: await authHeaders({ 'content-type': 'application/json' }),
+    headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body)
   })
   if (!res.ok) throw await apiErrorFromResponse('POST', path, res)
@@ -1426,9 +1444,9 @@ async function apiErrorFromResponse(method: string, path: string, res: Response)
 }
 
 async function apiPatch<T>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${cpBase()}${path}`, {
+  const res = await fetchWithTokenRefresh(`${cpBase()}${path}`, {
     method: 'PATCH',
-    headers: await authHeaders({ 'content-type': 'application/json' }),
+    headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body)
   })
   if (!res.ok) {
@@ -1440,9 +1458,9 @@ async function apiPatch<T>(path: string, body: unknown): Promise<T> {
 }
 
 async function apiPut<T>(path: string, body?: unknown): Promise<T> {
-  const res = await fetch(`${cpBase()}${path}`, {
+  const res = await fetchWithTokenRefresh(`${cpBase()}${path}`, {
     method: 'PUT',
-    headers: await authHeaders(body === undefined ? undefined : { 'content-type': 'application/json' }),
+    headers: body === undefined ? undefined : { 'content-type': 'application/json' },
     ...(body === undefined ? {} : { body: JSON.stringify(body) })
   })
   if (!res.ok) throw await apiErrorFromResponse('PUT', path, res)
@@ -1451,9 +1469,9 @@ async function apiPut<T>(path: string, body?: unknown): Promise<T> {
 }
 
 async function apiDelete<T>(path: string, body?: unknown): Promise<T> {
-  const res = await fetch(`${cpBase()}${path}`, {
+  const res = await fetchWithTokenRefresh(`${cpBase()}${path}`, {
     method: 'DELETE',
-    headers: await authHeaders(body === undefined ? undefined : { 'content-type': 'application/json' }),
+    headers: body === undefined ? undefined : { 'content-type': 'application/json' },
     ...(body === undefined ? {} : { body: JSON.stringify(body) })
   })
   if (!res.ok) throw await apiErrorFromResponse('DELETE', path, res)

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -4,6 +4,7 @@ const logto = vi.hoisted(() => ({
   isAuthenticated: vi.fn(),
   getAccessToken: vi.fn(),
   clearAllTokens: vi.fn(),
+  clearAccessToken: vi.fn(),
   replace: vi.fn(),
   clientConfig: undefined as unknown
 }))
@@ -16,6 +17,7 @@ vi.mock('@logto/browser', () => ({
     isAuthenticated = logto.isAuthenticated
     getAccessToken = logto.getAccessToken
     clearAllTokens = logto.clearAllTokens
+    clearAccessToken = logto.clearAccessToken
   },
   UserScope: {
     Email: 'email',
@@ -36,6 +38,7 @@ describe('getToken', () => {
     logto.isAuthenticated.mockReset().mockResolvedValue(true)
     logto.getAccessToken.mockReset()
     logto.clearAllTokens.mockReset().mockResolvedValue(undefined)
+    logto.clearAccessToken.mockReset().mockResolvedValue(undefined)
     logto.replace.mockReset()
     logto.clientConfig = undefined
     vi.stubGlobal('window', {
@@ -101,5 +104,15 @@ describe('getToken', () => {
 
     expect(logto.getAccessToken).toHaveBeenCalledWith()
     expect(logto.clientConfig).toMatchObject({ scopes: ['email', 'profile', 'identities', 'roles'] })
+  })
+
+  it('evicts the access-token cache before forcing a resource token refresh', async () => {
+    logto.getAccessToken.mockResolvedValue('fresh-resource-token')
+    const { forceRefreshToken } = await import('./auth')
+
+    await expect(forceRefreshToken()).resolves.toBe('fresh-resource-token')
+
+    expect(logto.clearAccessToken).toHaveBeenCalledOnce()
+    expect(logto.getAccessToken).toHaveBeenCalledWith('https://api.example.test')
   })
 })

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -149,6 +149,11 @@ let cachedUser: AuthUser | null = null
 // one cleanup so they do not race several redirects to the login page.
 let invalidGrantCleanup: Promise<void> | undefined
 
+// Coalesce the recovery path when a page fan-out discovers the same server-side
+// expiry at once. The SDK normally refreshes from its cached expiresAt; this is
+// the escape hatch when the JWT's authoritative exp is already past that cache.
+let forcedAccessTokenRefresh: Promise<string | undefined> | undefined
+
 function clearLocalSessionMetadata(): void {
   cachedUser = null
   resetAnalytics()
@@ -274,6 +279,24 @@ export async function getToken(): Promise<string | undefined> {
     return accessToken(c, apiResource)
   }
   return (await c.getIdToken()) ?? undefined
+}
+
+/** Evict the SDK's access-token cache and mint a replacement from its refresh token. */
+export async function forceRefreshToken(): Promise<string | undefined> {
+  const c = getClient()
+  if (!c || !(await c.isAuthenticated())) return undefined
+  forcedAccessTokenRefresh ??= (async () => {
+    await c.clearAccessToken()
+    const { apiResource } = readConfig()
+    if (apiResource) return accessToken(c, apiResource)
+    // Refreshing the default access token also rotates the ID token when Logto
+    // returns one; CP calls without an API resource use that signed ID token.
+    await accessToken(c)
+    return (await c.getIdToken()) ?? undefined
+  })().finally(() => {
+    forcedAccessTokenRefresh = undefined
+  })
+  return forcedAccessTokenRefresh
 }
 
 /**


### PR DESCRIPTION
## Summary

Recover automatically when the Control Plane rejects a browser access token as expired.

## Root cause

The Logto browser SDK decides whether to refresh from its cached `expiresAt` metadata. The Control Plane validates the JWT’s authoritative `exp` claim. If those values diverge, the SDK can keep returning a token that the Control Plane already considers expired.

The Control Plane previously returned the same generic 401 for expiry and other invalid-token failures, so the Web client could not safely distinguish a refreshable expiry. It surfaced downstream failures such as “Could not reach the agent” even while the daemon was healthy.

## What changed

- return `code: TOKEN_EXPIRED` when JWT verification fails with `ERR_JWT_EXPIRED`
- add a Web auth recovery method that evicts the Logto access-token cache and obtains a replacement through the stored refresh token
- coalesce concurrent forced refreshes into one operation
- retry standard Control Plane REST requests and the session SSE connection once after a recognized expiry
- leave unrelated 401 responses unchanged and avoid retry loops
- add Control Plane and Web regression tests

## User impact

Long-lived Web sessions recover without requiring users to clear local storage or sign in again, provided their Logto refresh token remains valid. An invalid refresh grant continues to clear the local session and return the user to login.

## Validation

- Control Plane auth tests: 12 passed
- Web auth/token recovery tests: 7 passed
- Control Plane TypeScript typecheck passed
- Web TypeScript typecheck passed
- targeted ESLint passed
- repository pre-commit formatter passed
- repository pre-push ESLint: 0 errors; 2 pre-existing duplicate-import warnings in `packages/daemon/test/workspace-git-write.test.ts`