### PR TITLE
feat(cluster): let daemons dial sandbox shims

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -148,12 +148,14 @@ RUN mkdir -p /opt/agentconnect/runtime \
 # only, and a value the daemon already sent for that runtime wins (src/shim/acp-runner.ts).
 ENV HOME=/agent \
   AC_SHIM_WORKSPACE_ROOT=/agent \
+  AC_SHIM_PORT=8085 \
   npm_config_update_notifier=false \
   NODE_OPTIONS=--dns-result-order=ipv4first
+EXPOSE 8085
 WORKDIR /agent
 USER 10001:10001
 
 # tini reaps the runtime's children and forwards SIGTERM, which is what makes a graceful drain
-# possible. The shim is the only process this image starts: it dials the daemon out, and the
-# runtime is spawned by it rather than by an entrypoint that would run before any binding exists.
+# possible. The shim is the only process this image starts: it listens for its daemon, then spawns
+# the runtime only after the channel is bound.
 ENTRYPOINT ["/usr/bin/tini", "--", "node", "/opt/agentconnect/shim/index.js"]

--- a/docs/designs/agentconnect-org-operator.md
+++ b/docs/designs/agentconnect-org-operator.md
@@ -140,7 +140,7 @@ plus the Deployment/Pod secondary watches that keep status conditions prompt.
 Everything is stamped by server-side apply (field manager
 `agentconnect-operator`, force) — one PATCH per object per pass, no read-back
 diffing. Object names are fixed per-namespace constants (`ac-daemon`,
-`ac-daemon-shim`, `ac-daemon-state`, `ac-runtime-<tier>`, `ac-quota`,
+`ac-daemon-state`, `ac-runtime-<tier>`, `ac-quota`,
 `ac-limits`); the namespace is per-org, so they never collide. Master
 SandboxTemplates live in the control namespace as
 `<AC_MASTER_TEMPLATE_PREFIX><tier>` (default `ac-runtime-<tier>`), rendered by
@@ -161,8 +161,10 @@ reconcile pass:
    release-prefixed tokenreview ClusterRole (TokenReview is cluster-scoped;
    a namespaced Role cannot grant it). No namespace ownerReference — the
    finalizer deletes it explicitly.
-5. `ensureNetworkPolicies` — sandbox egress (gateway + git only) and daemon
-   egress (control plane/relay/platform APIs + kube-apiserver + DNS).
+5. `ensureNetworkPolicies` — sandbox ingress from daemon-labelled pods in either
+   the current dedicated namespace or the install's control/pool namespace, plus configured
+   egress, and daemon egress (sandboxes + control plane/relay/platform APIs +
+   kube-apiserver + DNS). Daemon ingress stays closed.
 6. `ensureQuotaAndLimitRange` — from `spec.quota`; omit when unlimited.
 7. `ensureSandboxTemplates` — stamp per-org SandboxTemplate + one
    SandboxWarmPool per tier from the cluster master templates.
@@ -175,11 +177,11 @@ reconcile pass:
    install, and the token is a file the kubelet keeps current. The pod therefore
    starts whether or not it can authenticate, which is the trade the key path's
    kubelet gate bought and this one gives back.
-10. `ensureDaemonService` — ClusterIP for relay ingress and shim dial-in.
-
-Deletion (finalizer `agentconnect.md/org-envelope`): quiesce → delete
-workloads → (future: archive) → delete namespace + cluster-scoped bindings →
-remove finalizer. Steps must be idempotent.
+10. `removeLegacyDaemonService` — delete the callback Service from the old shim
+    dial-out topology; relay traffic already uses daemon-initiated WebSockets.
+    Deletion (finalizer `agentconnect.md/org-envelope`): quiesce → delete
+    workloads → (future: archive) → delete namespace + cluster-scoped bindings →
+    remove finalizer. Steps must be idempotent.
 
 ## 5. Chart (`charts/operator`, name `agentconnect-operator`)
 
@@ -193,7 +195,7 @@ the vendored stack is the controller's label-domain allowlist, which replaces
 rather than extends its default and without which every SandboxClaim is
 rejected. Everything else is per-install: the master SandboxTemplates rendered
 from `runtimeTiers` (blueprints in the control namespace — the operator inherits
-each one wholesale except the image, the shim endpoint and the network policy),
+each one wholesale except the image, shim listen port and network policy),
 operator Deployment (2 replicas) +
 SA/RBAC, the release-prefixed tokenreview ClusterRole, two
 ValidatingAdmissionPolicies, and a pre-delete hook that refuses uninstall while

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -44,7 +44,7 @@ which filesystem the runtime will see — a daemon-side lookup would hand a sand
 absolute paths from the daemon pod. The host states the policy as a declarative hint; the
 driver performs the lookup where it applies.
 
-## 2. The shim, and why it dials out
+## 2. The shim, and why the daemon dials it
 
 Once the runtime is in another pod, everything the daemon used to do by sharing a
 filesystem and a set of unix sockets needs an explicit protocol: materializing secrets and
@@ -58,12 +58,15 @@ with the credential helper: a second name would be a second in-pod path onto one
 `mcp` is declared but not yet opened — the in-pod bridge that would dial it is not in the
 image, so a listener for it would be a socket nothing can use.
 
-**The shim dials out; the daemon listens.** The sandbox therefore needs zero inbound: its
-NetworkPolicy keeps an empty ingress list and no per-sandbox Service exists. The reverse
-direction would need a Service per sandbox, an ingress allowance, and a readiness probe —
-all surface for nothing.
+**The shim listens; the daemon dials the ready pod's IP.** The Sandbox status already reports
+the backing pod's addresses, so no per-sandbox Service is required. During migration, the
+sandbox NetworkPolicy admits daemon-labelled pods from either its dedicated namespace or the
+install's pool namespace on the fixed shim port; the pooled tier can narrow this to the pool
+namespace once tiered envelopes land. The daemon no longer exposes a shim listener. This
+direction also makes a future daemon pool possible: the duty holder can dial the
+sandbox it owns without publishing a callback endpoint for every daemon.
 
-## 3. Binding: proving which pod is calling
+## 3. Binding: proving which pod accepted the connection
 
 A shim connection must be bound to the pod it claims to be, before it is given anything.
 
@@ -73,11 +76,9 @@ Two tempting shortcuts are wrong, and both were rejected explicitly:
   warm-pool adoption, and claim env does not propagate to a rebuilt pod — so after a
   resume or an eviction the pod would hold only an exhausted token and the wake path would
   deadlock.
-- **Reverse-looking the source IP.** Pod IPs are reusable and the Sandbox status that
-  mirrors them is asynchronous. Inside that stale window, a sibling sandbox in the same
-  namespace could present a just-recycled IP and claim a victim agent's channel. The
-  connection's source address is therefore a logging and correlation hint only, never a
-  trust input.
+- **Trusting the dial target's IP.** Pod IPs are reusable and the Sandbox status that mirrors
+  them is asynchronous. The address selects where to connect, but never authenticates the
+  peer; the projected token and exact launch-record match remain the trust inputs.
 
 What is used instead is the pod's own Kubernetes credential:
 
@@ -86,21 +87,22 @@ What is used instead is the pod's own Kubernetes credential:
    a dedicated runtime ServiceAccount that holds **no RoleBindings**. Audience-restricted
    plus permissionless means the token is useless anywhere except proving "I am this pod"
    to this endpoint;
-2. the shim reads it and dials the daemon, presenting it as its only claim;
-3. the daemon calls **TokenReview** with the expected audience — omitting the audience
+2. after the Sandbox is Ready, the daemon reads its pod name and IP and connects to the shim;
+3. the daemon sends the agent id and generation it expects, and the shim answers with its
+   projected token;
+4. the daemon calls **TokenReview** with the expected audience — omitting the audience
    would accept a token minted for something else entirely — and takes the bound pod
    name/UID from the response;
-4. the daemon maps that pod to its own spawn record. No match, no binding: an
-   authenticated pod that this daemon did not launch binds to nothing;
-5. **only then** is a session credential issued, short-lived and bound to this pod and
+5. the reviewed pod name must exactly match the launch record used for this dial. No match,
+   no binding: an authenticated sibling pod binds to nothing;
+6. **only then** is a session credential issued, short-lived and bound to this pod and
    generation.
 
 Because the identity is the pod's own rotating credential, first bind, resume from
 suspension, and eviction/rescheduling are indistinguishable to the protocol: each new pod
 simply presents its own token. There is no one-shot token that can be revived.
 
-Rejections carry one coarse reason and a message that names no pod, token, or agent, so
-the endpoint cannot be probed for valid identities.
+Rejections carry one coarse reason and a message that names no pod, token, or agent.
 
 The same proof runs in the other direction one hop up: a daemon the operator
 provisioned authenticates to the control plane with its own audience-scoped
@@ -150,9 +152,10 @@ requests only ever flow daemon → shim. So the pod announces each accepted conn
 `connect` event on a stream id it mints, and the daemon answers by dialling its own socket;
 bytes then travel as events one way and `data` requests the other.
 
-Its listeners belong to the **pod**, not to a channel. The shim re-dials at half the
-credential TTL, and a socket torn down on every renewal would break any client mid-request —
-so `listen` is idempotent and the socket lives as long as the pod does.
+Its Unix-socket listeners belong to the **pod**, not to a channel. At half the credential
+TTL the shim closes the channel and the daemon reconnects; tearing down those listeners on
+every renewal would break any client mid-request, so `listen` is idempotent and each socket
+lives as long as the pod does.
 
 A frame that was travelling when the socket was replaced is a different matter, and the
 resolution is deliberate: the renewal aborts requests in flight, and that abort says a
@@ -256,14 +259,9 @@ what makes the next turn claim a **fresh generation** — the fence the replacem
 against. `forgetLaunch` describes exactly this recovery and was, until this rule existed,
 called by nothing.
 
-The narrow case this leaves is a socket that comes back _after_ loss was reported while its pod
-stayed alive — a blip longer than the rebind grace. That connection is bound to a generation
-nothing is waiting for any more, so it simply sits there, and the launch recovers when the shim
-next re-dials at credential renewal. Closing it to force an immediate re-dial is deliberately
-NOT done: a first bind is indistinguishable from it at that point (the session is created after
-the channel arrives), and every pod would re-dial into a close loop after a daemon restart.
-Recovering at renewal is slower than that would be, and strictly better than the alternative it
-replaced, which was a channel that could never serve again until the daemon restarted.
+After loss is reported, the driver revokes the outbound dial and forgets the launch. A late
+socket therefore cannot reattach to the terminal session; the next turn creates a fresh
+generation and dials the pod through the ordinary wake path.
 
 **Removed ⇒ delete the claim, and the volume with it.** Where the local path deletes the
 agent's checkout, the cluster path deletes its SandboxClaim; the volume is not reachable from

--- a/packages/daemon/scripts/smoke-runtime-image.mts
+++ b/packages/daemon/scripts/smoke-runtime-image.mts
@@ -4,13 +4,13 @@
  *   pnpm --filter @agentconnect.md/daemon exec tsx scripts/smoke-runtime-image.mts <image>
  *
  * Proves the four things the image exists to do, against a REAL container running the REAL shim:
- * the pod starts, the shim dials the daemon back and binds, the ACP runtime starts inside it, and
+ * the pod starts, the daemon dials its shim and binds, the ACP runtime starts inside it, and
  * a session can be created through the channel. Nothing here is stubbed on the sandbox side —
  * unit tests already cover the protocol, and what this catches is the class of defect they
  * cannot: a shim that cannot resolve its own imports in the image, a runtime that is not on PATH,
  * an entrypoint that never reaches the shim, a non-root user that cannot write its workspace.
  *
- * The daemon side is deliberately minimal: a real ShimListener with a verifier that accepts this
+ * The daemon side is deliberately minimal: a real ShimDialer with a verifier that accepts this
  * run's token. Pod identity is verified against the API server in production and is unit-tested;
  * re-deriving it here would mean standing up Kubernetes to test a container image.
  */
@@ -18,7 +18,7 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ShimListener } from '../src/shim/listener.js'
+import { ShimDialer } from '../src/shim/dialer.js'
 import { ShimSession } from '../src/shim/session.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
 
@@ -34,7 +34,7 @@ const tokenPath = join(scratch, 'token')
 writeFileSync(tokenPath, TOKEN)
 
 let container: string | undefined
-let listener: ShimListener | undefined
+let dialer: ShimDialer | undefined
 
 function step(message: string): void {
   console.log(`  ✓ ${message}`)
@@ -68,45 +68,45 @@ try {
     agentId: 'smoke-agent',
     sandboxUid: 'smoke-sandbox-uid',
     generation: 1,
-    grants: ['acp']
-  } as SpawnRecord
+    grants: ['acp'],
+    podName: 'smoke-pod'
+  }
 
-  listener = new ShimListener({
+  dialer = new ShimDialer({
     verifier: {
       reviewToken: async (token) =>
         token === TOKEN
           ? { authenticated: true, podName: 'smoke-pod', podUid: 'smoke-pod-uid' }
           : { authenticated: false, error: 'not this run' }
     },
-    spawnRecordForPod: () => record,
     now: () => Date.now(),
-    log: { info: (m) => console.log(`    [listener] ${m}`), warn: (m) => console.warn(`    [listener] ${m}`) }
+    log: { info: (m) => console.log(`    [dialer] ${m}`), warn: (m) => console.warn(`    [dialer] ${m}`) }
   })
-  const port = await listener.start(0, '0.0.0.0')
-  step(`daemon-side shim listener on port ${port}`)
 
-  // --network host so the container reaches the listener on the loopback address the daemon bound.
-  // In a cluster this is a Service address; here it is the smallest thing that is still a real
-  // network hop rather than an in-process call.
   container = execFileSync(
     'docker',
     [
       'run',
       '--detach',
-      '--network',
-      'host',
+      '--publish',
+      '127.0.0.1::8085',
       '--volume',
       `${tokenPath}:/var/run/ac-identity/token:ro`,
-      '--env',
-      `AC_SHIM_ENDPOINT=ws://127.0.0.1:${port}`,
       image
     ],
     { encoding: 'utf8' }
   ).trim()
   step(`container started (${container.slice(0, 12)})`)
 
-  const connection = await until(() => listener?.connectionsFor('smoke-agent')[0], 'the shim to dial back and bind')
-  step(`shim dialled back and bound as generation ${connection.binding.generation}`)
+  const published = await until(() => {
+    try {
+      return execFileSync('docker', ['port', container!, '8085/tcp'], { encoding: 'utf8' }).trim() || undefined
+    } catch {
+      return undefined
+    }
+  }, 'the shim port to publish')
+  const connection = await dialer.connect(`ws://${published}`, record, 90_000)
+  step(`daemon dialled the shim and bound generation ${connection.binding.generation}`)
 
   const session = new ShimSession('smoke-agent', record.generation, {
     setTimeout: (fn, ms) => setTimeout(fn, ms),
@@ -181,10 +181,10 @@ try {
     }
   }
   cleanup()
-  await listener?.stop()
+  dialer?.stop()
   process.exit(1)
 }
 
 cleanup()
-await listener?.stop()
+dialer?.stop()
 process.exit(0)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2178,7 +2178,7 @@ export class Daemon {
   /** Reads this pod's projected CP-audience token; undefined unless the daemon runs
    *  in-cluster AND the volume is actually mounted (decided once, at boot). */
   private readonly clusterIdentityToken?: () => string | undefined
-  // The k8s execution plane: shim endpoint + driver + workspace seam. Undefined outside --k8s.
+  // The k8s execution plane: shim dialer + driver + workspace seam. Undefined outside --k8s.
   private k8sPlane?: K8sRuntimePlane
   // The resolved catalog the probed table is projected onto; it supplies command/args, which the
   // table never does — the table only says which ids this image provides.
@@ -2840,7 +2840,7 @@ export class Daemon {
       // And the mode itself, which decides what workspace operations are available at all: an
       // in-place conversion has no pod-side implementation of its rollback contract.
       setSandboxWorkspaceMode(true)
-      this.log.info(`k8s: execution plane ready — shim endpoint on :${this.k8sPlane.listener.listeningPort()}`)
+      this.log.info('k8s: execution plane ready — daemon-to-sandbox shim dialing enabled')
     }
     // Sandbox-optional principle (#36): skills are NOT force-sandboxed fleet-wide.
     // A skill runs sandboxed only when its agent does (agentRunsInSandbox), so the

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -26,7 +26,7 @@ export const DRAIN_REQUESTED_ANNOTATION = 'agentconnect.md/drain-requested'
 /**
  * Where agent-sandbox records the pod a Sandbox is currently backed by.
  *
- * This is the ONLY way the daemon can map a dialing pod back to the launch that started it: a
+ * This is the ONLY way the daemon can bind the dial target to the launch that started it: a
  * TokenReview yields a pod name and uid, `SandboxStatus` carries no pod reference at all
  * (v1beta1: serviceFQDN, service, conditions, selector, podIPs, nodeName), and reading the Pod
  * API is deliberately outside this daemon's Role. Upstream's `resolvePodName` is exactly this
@@ -38,6 +38,15 @@ export const SANDBOX_POD_NAME_ANNOTATION = 'agents.x-k8s.io/pod-name'
 export function resolvePodName(sandbox: Sandbox): string | undefined {
   const adopted = sandbox.metadata?.annotations?.[SANDBOX_POD_NAME_ANNOTATION]
   return adopted && adopted.length > 0 ? adopted : sandbox.metadata?.name
+}
+
+/** The first routable address reported for the pod backing this Sandbox. */
+export function resolvePodIp(sandbox: Sandbox): string | undefined {
+  for (const entry of sandbox.status?.podIPs ?? []) {
+    const ip = typeof entry === 'string' ? entry : entry.ip
+    if (ip?.trim()) return ip.trim()
+  }
+  return undefined
 }
 
 /** Capabilities a runtime launch receives. Narrow by construction: a launch gets exactly
@@ -54,10 +63,10 @@ export interface K8sDriverDeps {
   orgId: string
   /** Pool the claim references; v1beta1 requires one, and a cold pool is `replicas: 0`. */
   warmPoolName: string
-  /** Waits for a bound shim channel for this agent's current launch. */
-  awaitChannel: (agentId: string, generation: number, timeoutMs: number) => Promise<ShimConnection>
-  /** Publishes the spawn record the shim handshake resolves a pod against. */
-  publishSpawnRecord: (record: SpawnRecord) => void
+  /** Dials the ready pod and binds the shim channel for this launch. */
+  connectChannel: (record: SpawnRecord, podIp: string, timeoutMs: number) => Promise<ShimConnection>
+  /** Stops any outbound channel when a launch is forgotten or deliberately suspended. */
+  revokeChannel?: (agentId: string) => void
   /**
    * Prepare a freshly bound channel before anything runs on it — today, opening the unix-socket
    * tunnels the agent's runtime expects to find in its pod.
@@ -203,29 +212,25 @@ export class K8sDriver implements SpawnDriver {
   }
 
   /** Wait for the Sandbox to report Ready, after something has asked it to run. */
-  // Returns the pod backing the ready Sandbox. Resolved HERE rather than at claim time because
-  // warm-pool adoption writes the annotation as the pod is bound and suspension clears it, so a
-  // name read any earlier belongs to the previous incarnation — and binding the next launch
-  // against it would authorize the wrong pod.
-  private async awaitReady(sandboxName: string, onPodResolved: (podName: string) => void): Promise<string> {
+  // Pod identity and address are resolved only after readiness so a resumed launch cannot reuse
+  // the previous incarnation's annotation or IP.
+  private async awaitReady(sandboxName: string): Promise<{ podName: string; podIp: string }> {
     const backoff = new Backoff({ baseMs: 250, capMs: 2_000, jitter: () => 0 })
     const deadline = this.clock.now() + (this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS)
-    let resolved: string | undefined
     for (;;) {
       const sandbox = await this.deps.api.getSandbox(sandboxName).catch(() => undefined)
-      // The pod is named as soon as it is bound, which is BEFORE it reports Ready — and the shim
-      // dials from a pod that is merely running. Publishing here rather than after readiness is
-      // what keeps that dial from arriving ahead of the record that authorizes it.
       const podName = sandbox ? resolvePodName(sandbox) : undefined
-      if (podName && podName !== resolved) {
-        resolved = podName
-        onPodResolved(podName)
-      }
       if (sandbox && isSandboxReady(sandbox)) {
-        if (!resolved) throw new Error(`sandbox ${sandboxName} is ready but names no pod`)
-        return resolved
+        const podIp = resolvePodIp(sandbox)
+        if (podName && podIp) return { podName, podIp }
       }
       if (this.clock.now() >= deadline) {
+        if (sandbox && isSandboxReady(sandbox) && !podName) {
+          throw new LaunchTimeoutError(`sandbox ${sandboxName} became ready but never named its pod`)
+        }
+        if (sandbox && isSandboxReady(sandbox) && !resolvePodIp(sandbox)) {
+          throw new LaunchTimeoutError(`sandbox ${sandboxName} became ready but never reported a pod IP`)
+        }
         throw new LaunchTimeoutError(`sandbox ${sandboxName} did not become ready in time`)
       }
       await new Promise<void>((resolve) => this.clock.setTimeout(resolve, backoff.next()))
@@ -538,6 +543,7 @@ export class K8sDriver implements SpawnDriver {
     // The session outlives the claim otherwise, and `runsInSandbox` would keep answering true for
     // an agent whose pod is being deleted — sending the workspace seam into a sandbox that is gone.
     this.sessions.delete(agentId)
+    this.deps.revokeChannel?.(agentId)
     await this.deps.api.deleteClaim(this.claimName(agentId))
   }
 
@@ -548,6 +554,7 @@ export class K8sDriver implements SpawnDriver {
    */
   forgetLaunch(agentId: string): void {
     this.launches.delete(agentId)
+    this.deps.revokeChannel?.(agentId)
   }
 
   currentLaunch(agentId: string): Launch | undefined {
@@ -621,26 +628,24 @@ export class K8sDriver implements SpawnDriver {
     // Without it that path — the COMMON one — reported `warm` and never entered resume p95.
     if (modeBeforeWake) timer?.observedPath(modeBeforeWake === 'Suspended' ? 'resume' : 'warm')
     timer?.mark('mode_running')
-    // Published the moment the Sandbox names its pod, which is before readiness — the record has
-    // to exist by the time the shim dials, and the pod it authorizes is not knowable any earlier.
-    // Publishing at claim time instead would name the PREVIOUS incarnation's pod, authorizing the
-    // wrong one for as long as the window lasted.
-    await this.awaitReady(launch.sandboxName, (podName) => {
-      this.deps.publishSpawnRecord({
-        agentId,
-        sandboxUid: launch.sandboxUid,
-        generation: launch.generation,
-        grants: [...grants],
-        podName
-      })
-    })
+    const pod = await this.awaitReady(launch.sandboxName)
     timer?.mark('pod_ready')
     const channelTimeoutMs = this.deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
     const waitingSince = this.clock.now()
     const connection = await this.deps
-      .awaitChannel(agentId, launch.generation, channelTimeoutMs)
+      .connectChannel(
+        {
+          agentId,
+          sandboxUid: launch.sandboxUid,
+          generation: launch.generation,
+          grants: [...grants],
+          podName: pod.podName
+        },
+        pod.podIp,
+        channelTimeoutMs
+      )
       .catch((err: unknown) => {
-        // awaitChannel is supplied by the host, so its error text is not ours to match on.
+        // connectChannel is supplied by the host, so its error text is not ours to match on.
         // Elapsed-versus-the-deadline-we-set is a fact we own, and it is what distinguishes a
         // channel that never arrived from one that failed for another reason.
         if (this.clock.now() - waitingSince >= channelTimeoutMs) {

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -2,13 +2,13 @@ import { K8sHttp, loadInClusterConfig } from '@agentconnect.md/k8s-client'
 import { K8sDriver, PROBE_GRANTS } from './driver.js'
 import { SandboxApi } from './sandbox-api.js'
 import { clusterMetrics } from './cluster-metrics.js'
-import { ShimListener } from '../shim/listener.js'
+import { ShimDialer } from '../shim/dialer.js'
 import { ShimGitRunner } from '../shim/git-exec.js'
 import { TunnelProxy } from '../shim/tunnel-proxy.js'
 import { ShimFileSink } from '../shim/channels.js'
+import { DEFAULT_SHIM_LISTEN_PORT } from '../shim/protocol.js'
 import type { TunnelName } from '../shim/tunnel.js'
 import type { ShimSession } from '../shim/session.js'
-import type { SpawnRecord } from '../shim/binding.js'
 import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-runtimes.js'
 import type { GitRunner } from '../workspace/git-runner.js'
 
@@ -21,7 +21,7 @@ export const PROBE_AGENT_ID = 'ac-runtime-probe'
 const PROBE_TIMEOUT_MS = 180_000
 
 /**
- * Assembles the k8s execution plane: the shim endpoint, the driver, and the seams that make an
+ * Assembles the k8s execution plane: the shim dialer, the driver, and the seams that make an
  * agent's git run where its workspace actually is.
  *
  * It exists because every piece of this was built and tested separately and nothing put them
@@ -35,10 +35,8 @@ export interface K8sRuntimePlaneOptions {
   orgId?: string
   /** Warm pool the claims reference. v1beta1 requires one; a cold pool is `replicas: 0`. */
   warmPoolName?: string
-  /** Port the shim dials back on. The pod learns it from the template's AC_SHIM_ENDPOINT, so
-   *  this side only has to listen — the daemon never dials into a sandbox. */
+  /** Port the sandbox shim listens on; the daemon combines it with the ready pod's IP. */
   shimPort?: number
-  shimHost?: string
   /** Environment the deployment settings come from; `process.env` unless a test names another. */
   env?: NodeJS.ProcessEnv
   readyTimeoutMs?: number
@@ -64,7 +62,6 @@ export interface K8sPlaneSettings {
   orgId: string
   warmPoolName: string
   shimPort: number
-  shimHost?: string
 }
 
 /** Deployment-owned settings. Env rather than the config file: they describe where this pod sits
@@ -72,8 +69,7 @@ export interface K8sPlaneSettings {
 export const K8S_ORG_ID_ENV = 'AC_K8S_ORG_ID'
 export const K8S_WARM_POOL_ENV = 'AC_K8S_WARM_POOL'
 export const K8S_SHIM_PORT_ENV = 'AC_K8S_SHIM_PORT'
-export const K8S_SHIM_HOST_ENV = 'AC_K8S_SHIM_HOST'
-export const DEFAULT_SHIM_PORT = 8085
+export const DEFAULT_SHIM_PORT = DEFAULT_SHIM_LISTEN_PORT
 
 /** Explicit options win per FIELD, so a caller may name one and leave the rest to the env. */
 export function resolveK8sPlaneSettings(options: K8sRuntimePlaneOptions = {}): K8sPlaneSettings {
@@ -86,11 +82,10 @@ export function resolveK8sPlaneSettings(options: K8sRuntimePlaneOptions = {}): K
   if (!warmPoolName) throw new Error(`--k8s requires ${K8S_WARM_POOL_ENV}`)
   const rawPort = options.shimPort ?? env[K8S_SHIM_PORT_ENV] ?? DEFAULT_SHIM_PORT
   const shimPort = Number(rawPort)
-  if (!Number.isInteger(shimPort) || shimPort < 0 || shimPort > 65_535) {
+  if (!Number.isInteger(shimPort) || shimPort < 1 || shimPort > 65_535) {
     throw new Error(`${K8S_SHIM_PORT_ENV} is not a valid port: ${rawPort}`)
   }
-  const shimHost = options.shimHost ?? env[K8S_SHIM_HOST_ENV]?.trim()
-  return { orgId, warmPoolName, shimPort, ...(shimHost ? { shimHost } : {}) }
+  return { orgId, warmPoolName, shimPort }
 }
 
 /** The env contract on its own, which is what a deployment has to satisfy. */
@@ -100,7 +95,7 @@ export function k8sPlaneSettings(env: NodeJS.ProcessEnv): K8sPlaneSettings {
 
 export interface K8sRuntimePlane {
   driver: K8sDriver
-  listener: ShimListener
+  dialer: ShimDialer
   /** Bring an agent's Sandbox up and bind its channel WITHOUT starting a runtime, so the
    *  workspace can be prepared on the pod's own volume before the runtime looks at it. */
   ensureChannel: (agentId: string) => Promise<void>
@@ -152,13 +147,8 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       return new SandboxApi(new K8sHttp(config), config.namespace)
     })()
 
-  // Records keyed by the pod they authorize. A TokenReview yields a pod name and uid and nothing
-  // else, so this map is the whole of how a dialing pod is resolved back to its launch.
-  const recordsByPod = new Map<string, SpawnRecord>()
-
-  const listener = new ShimListener({
+  const dialer = new ShimDialer({
     verifier: { reviewToken: (token, audiences) => api.reviewToken(token, audiences) },
-    spawnRecordForPod: (pod) => recordsByPod.get(pod.name),
     now: () => Date.now(),
     metrics: clusterMetrics,
     onConnection: (connection) => {
@@ -167,8 +157,8 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       lossTimers.delete(connection.binding.agentId)
       driver.onChannelBound(connection)
     },
-    // A closed socket is NOT a lost launch. The shim closes and re-dials at half the credential
-    // TTL, and `ShimSession.lose()` is terminal — reporting loss here killed the runtime on every
+    // A closed socket is not a lost launch; renewals reconnect underneath the logical session.
+    // `ShimSession.lose()` is terminal — reporting loss here killed the runtime on every
     // routine renewal, which is the exact failure ShimSession exists to prevent. Loss is reported
     // only if no replacement binds for the same launch within the grace window.
     onConnectionLost: (agentId, reason) => scheduleLossCheck(agentId, reason),
@@ -216,30 +206,20 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     orgId: settings.orgId,
     warmPoolName: settings.warmPoolName,
     onChannelReady: ensureTunnels,
-    awaitChannel: (agentId, generation, timeoutMs) => listener.awaitConnection(agentId, generation, timeoutMs),
-    publishSpawnRecord: (record) => {
-      // Keyed by pod, and the previous pod's entry is dropped: leaving it would let a terminating
-      // pod keep binding against a launch that has moved on.
-      for (const [podName, existing] of recordsByPod) {
-        if (existing.agentId === record.agentId && podName !== record.podName) recordsByPod.delete(podName)
-      }
-      recordsByPod.set(record.podName, record)
-    },
+    connectChannel: (record, podIp, timeoutMs) =>
+      dialer.connect(shimEndpoint(podIp, settings.shimPort), record, timeoutMs),
+    revokeChannel: (agentId) => dialer.revokeAgent(agentId),
     metrics: clusterMetrics,
     ...(options.readyTimeoutMs === undefined ? {} : { readyTimeoutMs: options.readyTimeoutMs }),
     log: options.log ?? SILENT
   })
-
-  // Started only once the driver exists: `onConnection` reaches into it, and a pod that dialled
-  // in between would hit an uninitialized binding.
-  await listener.start(settings.shimPort, settings.shimHost ?? '0.0.0.0')
 
   // Follows this namespace's Sandboxes for the rollout's drain requests. Part of starting the
   // plane rather than of the first launch: an instance whose agent is idle is exactly the one a
   // rollout is waiting on, and nothing else would ever look at it.
   driver.startSandboxWatch()
 
-  // A renewal re-dials immediately (the client resets its backoff for a planned rebind), so a
+  // A renewal reconnects immediately, so a
   // replacement that has not arrived well inside the request deadline is a pod that is gone.
   const REBIND_GRACE_MS = 20_000
   const lossTimers = new Map<string, NodeJS.Timeout>()
@@ -250,7 +230,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       agentId,
       setTimeout(() => {
         lossTimers.delete(agentId)
-        if (listener.connectionsFor(agentId).length > 0) return
+        if (dialer.connectionsFor(agentId).length > 0) return
         options.log?.warn(`k8s: no shim channel for agent ${agentId} after ${REBIND_GRACE_MS}ms — reporting loss`)
         driver.onChannelLost(agentId, reason)
       }, REBIND_GRACE_MS).unref?.() as NodeJS.Timeout
@@ -259,7 +239,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
 
   return {
     driver,
-    listener,
+    dialer,
     ensureChannel: async (agentId) => {
       await driver.ensureBoundChannel(agentId)
     },
@@ -307,7 +287,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     discardAgent: async (agentId) => {
       // Close and forget the pod's channel before the claim goes: the pod has its whole
       // termination grace to keep using a binding this daemon no longer means to honour.
-      listener.revokeAgent(agentId)
+      dialer.revokeAgent(agentId)
       // Ordered after the revoke, whose close schedules one: a loss check for an agent that no
       // longer exists would report a lost launch nobody is waiting for.
       clearTimeout(lossTimers.get(agentId))
@@ -322,7 +302,13 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
       lossTimers.clear()
       for (const { proxy } of proxies.values()) proxy.stop('daemon is shutting down')
       proxies.clear()
-      await listener.stop()
+      dialer.stop()
     }
   }
+}
+
+/** WebSocket URL for a Pod IP, including the brackets an IPv6 literal requires. */
+export function shimEndpoint(podIp: string, port: number): string {
+  const host = podIp.includes(':') && !podIp.startsWith('[') ? `[${podIp}]` : podIp
+  return `ws://${host}:${port}`
 }

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -15,7 +15,10 @@ export type OperatingMode = 'Running' | 'Suspended'
 
 export interface Sandbox extends K8sObject {
   spec?: { operatingMode?: OperatingMode; podTemplate?: unknown }
-  status?: { conditions?: Array<{ type?: string; status?: string }> }
+  status?: {
+    conditions?: Array<{ type?: string; status?: string }>
+    podIPs?: Array<string | { ip?: string }>
+  }
 }
 
 /** The claim's status names the bound Sandbox; the Sandbox UID comes from that

--- a/packages/daemon/src/shim/binding.ts
+++ b/packages/daemon/src/shim/binding.ts
@@ -1,7 +1,7 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
 import type { ShimCapability } from './protocol.js'
 
-/** What the daemon knows about a sandbox it launched, before any shim dials in. */
+/** What the daemon knows about a sandbox it launched before dialing its shim. */
 export interface SpawnRecord {
   agentId: string
   /** Sandbox object UID — from the Sandbox's own `metadata.uid`; the claim has none. */
@@ -10,9 +10,7 @@ export interface SpawnRecord {
   generation: number
   /** Capabilities this launch may exercise, decided by the daemon at spawn time. */
   grants: ShimCapability[]
-  /** The pod backing this launch, from the Sandbox's pod-name annotation. It is how a dialing
-   *  pod is resolved back to its launch — a TokenReview yields only a pod name and uid, and
-   *  nothing else the daemon holds connects those to an agent. */
+  /** The pod backing this launch, matched exactly against the dialed shim's TokenReview identity. */
   podName: string
 }
 

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from 'node:fs'
-import { Backoff, systemClock, type Clock } from '@agentconnect.md/connection'
+import { Backoff, systemClock, type Clock, type TimerHandle } from '@agentconnect.md/connection'
 import { AcpRunner, type ResolveCommand } from './acp-runner.js'
 
 /** Bounded so a long outage cannot grow the buffer without limit. */
 const MAX_BUFFERED_EVENTS = 2_000
+const HANDSHAKE_TIMEOUT_MS = 10_000
 import {
   SHIM_IDENTITY_TOKEN_PATH,
   SHIM_SUBPROTOCOL,
@@ -32,6 +33,8 @@ interface Channel {
 
 export interface ShimClientDeps {
   endpoint: string
+  /** Wait for a daemon hello on an accepted socket instead of initiating the handshake. */
+  acceptDialIn?: boolean
   /** Dial the daemon. Injected so tests need no real WebSocket. */
   dial: (url: string, opts: { subprotocol: string; path: string }) => Promise<ShimTransport>
   /** Reads the projected token. Injected for tests; defaults to the mounted path. */
@@ -55,7 +58,7 @@ export interface ShimClientDeps {
  * operations the daemon authorizes. Everything it carries is short-lived and re-obtained
  * by re-handshaking, so a compromised sandbox yields no lasting credential.
  *
- * It re-reads the projected token on every dial. The kubelet rotates that token and
+ * It re-reads the projected token on every accepted connection. The kubelet rotates that token and
  * invalidates it when the pod goes away, which is what makes first bind, resume from
  * suspension, and eviction indistinguishable here: each new pod simply presents its own.
  */
@@ -80,6 +83,7 @@ export class ShimClient {
    *  mutating shared state: a delayed close from a transport being replaced must not tear
    *  down the healthy replacement that already bound. */
   private channel?: Channel
+  private highestBinding?: { agentId: string; generation: number }
   private readonly clock: Clock
   private readonly backoff: Backoff
 
@@ -95,7 +99,7 @@ export class ShimClient {
   /**
    * Run the channel for the pod's lifetime, resolving once the FIRST binding succeeds so a
    * caller can wait for readiness. The supervision loop keeps running after that: a
-   * dropped socket re-dials with backoff, and the credential is renewed by re-handshaking
+   * dropped socket reconnects with backoff, and the credential is renewed by re-handshaking
    * before it expires.
    *
    * Both halves matter. Returning after the first bind and stopping there left a live
@@ -122,15 +126,15 @@ export class ShimClient {
             // from a close or from the renewal deadline coming due.
             const reason = await this.runUntilRebindNeeded(bound, channel)
             if (reason === 'renew') {
-              // A planned renewal is not a failure: re-dial at once, and keep the backoff
+              // A planned renewal is not a failure: reconnect at once, and keep the backoff
               // counter clean so a later genuine drop starts from its base delay.
               this.backoff.reset()
               continue
             }
             // A drop IS a failure signal, so it goes through backoff — the daemon may be
-            // rolling, and hammering it with immediate re-dials is what backoff prevents.
+            // rolling, and hammering it with immediate reconnects is what backoff prevents.
             const delay = this.backoff.next()
-            this.deps.log?.warn(`shim: channel dropped, re-dialing in ${delay}ms`)
+            this.deps.log?.warn(`shim: channel dropped, reconnecting in ${delay}ms`)
             await new Promise<void>((settle) => this.clock.setTimeout(settle, delay))
           } catch (err) {
             if (this.stopped) {
@@ -138,7 +142,7 @@ export class ShimClient {
               return
             }
             const delay = this.backoff.next()
-            this.deps.log?.warn(`shim: channel lost, re-dialing in ${delay}ms (${(err as Error).message})`)
+            this.deps.log?.warn(`shim: channel lost, reconnecting in ${delay}ms (${(err as Error).message})`)
             await new Promise<void>((settle) => this.clock.setTimeout(settle, delay))
           }
         }
@@ -159,7 +163,7 @@ export class ShimClient {
   /**
    * Resolve when the channel needs rebuilding: the socket closed, or the credential is
    * close enough to expiry to renew. Renewing at half the lifetime leaves a full half as
-   * margin for a slow TokenReview or a re-dial.
+   * margin for a slow TokenReview or a reconnect.
    */
   private runUntilRebindNeeded(bound: ShimBound, channel: Channel): Promise<'renew' | 'lost'> {
     if (channel.ended) {
@@ -188,7 +192,9 @@ export class ShimClient {
   }
 
   private async connectOnce(): Promise<{ bound: ShimBound; channel: Channel }> {
-    const token = (this.deps.readToken ?? (() => readFileSync(SHIM_IDENTITY_TOKEN_PATH, 'utf8').trim()))()
+    const legacyToken = this.deps.acceptDialIn
+      ? undefined
+      : (this.deps.readToken ?? (() => readFileSync(SHIM_IDENTITY_TOKEN_PATH, 'utf8').trim()))()
     const transport = await this.deps.dial(this.deps.endpoint, {
       subprotocol: SHIM_SUBPROTOCOL,
       path: SHIM_WS_PATH
@@ -198,11 +204,22 @@ export class ShimClient {
     this.channel = channel
     return await new Promise<{ bound: ShimBound; channel: typeof channel }>((resolve, reject) => {
       let settled = false
+      let expected: { agentId: string; generation: number } | undefined
+      let handshakeTimer: TimerHandle | undefined
+      const clearHandshakeTimer = (): void => {
+        if (handshakeTimer !== undefined) this.clock.clearTimeout(handshakeTimer)
+        handshakeTimer = undefined
+      }
       const fail = (message: string): void => {
         if (settled) return
         settled = true
+        clearHandshakeTimer()
         reject(new Error(message))
       }
+      handshakeTimer = this.clock.setTimeout(() => {
+        transport.close(4408, 'binding timeout')
+        fail('binding timed out')
+      }, HANDSHAKE_TIMEOUT_MS)
       transport.onClose((code, reason) => {
         // Unconditionally, and before the channel guard below: this transport's work is dead
         // whichever channel is current, because its replies had this socket as their only route.
@@ -214,7 +231,7 @@ export class ShimClient {
         this.bound = undefined
         if (this.transport === transport) this.transport = undefined
         // Before binding this fails the dial; after binding it ends the channel so the
-        // supervision loop re-dials instead of leaving the process alive but detached.
+        // supervision loop reconnects instead of leaving the process alive but detached.
         fail(`connection closed (${code}${reason ? ` ${reason}` : ''})`)
         // A close can land between binding and the loop arming `end`. Recording it means
         // the wait below observes it instead of parking on a channel that is already gone.
@@ -227,9 +244,40 @@ export class ShimClient {
           transport.close(4400, 'malformed frame')
           return
         }
+        if (frame.type === 'shim/hello' && 'agentId' in frame) {
+          if (!this.deps.acceptDialIn || expected || this.bound) {
+            transport.close(4400, 'unexpected hello')
+            return
+          }
+          const highest = this.highestBinding
+          if (highest && (highest.agentId !== frame.agentId || frame.generation < highest.generation)) {
+            transport.close(4403, 'stale generation')
+            return
+          }
+          expected = { agentId: frame.agentId, generation: frame.generation }
+          const token = (this.deps.readToken ?? (() => readFileSync(SHIM_IDENTITY_TOKEN_PATH, 'utf8').trim()))()
+          transport.send(
+            JSON.stringify({
+              type: 'shim/identity',
+              token,
+              ...(this.deps.workspaceRoot ? { workspaceRoot: this.deps.workspaceRoot } : {})
+            } satisfies Extract<ShimFrame, { type: 'shim/identity' }>)
+          )
+          return
+        }
         if (frame.type === 'shim/bound') {
+          if (
+            this.deps.acceptDialIn &&
+            (!expected || expected.agentId !== frame.agentId || expected.generation !== frame.generation)
+          ) {
+            transport.close(4403, 'binding mismatch')
+            fail('binding did not match the daemon hello')
+            return
+          }
           this.bound = frame
+          this.highestBinding = { agentId: frame.agentId, generation: frame.generation }
           this.backoff.reset()
+          clearHandshakeTimer()
           // A live stream's output resumes here rather than being lost with the old socket.
           this.flushPendingEvents(transport)
           if (!settled) {
@@ -247,14 +295,15 @@ export class ShimClient {
         if (frame.type === 'shim/request') void this.serve(transport, frame)
         if (frame.type === 'shim/cancel') this.cancel(frame)
       })
-      // The token is the whole proof of identity; the workspace root is a filesystem fact.
-      transport.send(
-        JSON.stringify({
-          type: 'shim/hello',
-          token,
-          ...(this.deps.workspaceRoot ? { workspaceRoot: this.deps.workspaceRoot } : {})
-        } satisfies Extract<ShimFrame, { type: 'shim/hello' }>)
-      )
+      if (!this.deps.acceptDialIn) {
+        transport.send(
+          JSON.stringify({
+            type: 'shim/hello',
+            token: legacyToken!,
+            ...(this.deps.workspaceRoot ? { workspaceRoot: this.deps.workspaceRoot } : {})
+          } satisfies Extract<ShimFrame, { type: 'shim/hello' }>)
+        )
+      }
     })
   }
 

--- a/packages/daemon/src/shim/dialer.ts
+++ b/packages/daemon/src/shim/dialer.ts
@@ -30,6 +30,7 @@ interface SupervisedDial {
   endpoint: string
   stopped: boolean
   readySettled: boolean
+  inFlight?: ShimTransport
   current?: ShimConnection
   ready: Promise<ShimConnection>
   resolveReady: (connection: ShimConnection) => void
@@ -72,7 +73,7 @@ export class ShimDialer {
       existing.endpoint === endpoint &&
       existing.record.generation === record.generation
     ) {
-      return existing.current ? Promise.resolve(existing.current) : existing.ready
+      return existing.current ? Promise.resolve(existing.current) : this.awaitReady(existing, timeoutMs)
     }
     if (existing) this.stopDial(existing, 'superseded by a newer launch')
     let resolveReady: (connection: ShimConnection) => void = () => {}
@@ -92,7 +93,7 @@ export class ShimDialer {
     }
     this.dials.set(record.agentId, dial)
     void this.supervise(dial, timeoutMs)
-    return ready
+    return this.awaitReady(dial, timeoutMs)
   }
 
   connectionsFor(agentId: string): ShimConnection[] {
@@ -119,6 +120,8 @@ export class ShimDialer {
   private stopDial(dial: SupervisedDial, reason: string): void {
     if (dial.stopped) return
     dial.stopped = true
+    dial.inFlight?.close(4408, reason)
+    dial.inFlight = undefined
     dial.current?.close(reason)
     dial.current = undefined
     if (!dial.readySettled) {
@@ -133,11 +136,7 @@ export class ShimDialer {
     let first = true
     while (!dial.stopped) {
       try {
-        const transport = await (this.deps.dial ?? defaultDial)(dial.endpoint, {
-          subprotocol: SHIM_SUBPROTOCOL,
-          path: SHIM_WS_PATH
-        })
-        const { connection, closed } = await this.bind(transport, dial.record)
+        const { connection, closed } = await this.dialAndBind(dial, timeoutMs)
         if (dial.stopped) {
           connection.close('dial no longer current')
           return
@@ -151,7 +150,10 @@ export class ShimDialer {
         }
         this.deps.onConnection?.(connection)
         const close = await closed
-        if (dial.current === connection) dial.current = undefined
+        if (dial.current === connection) {
+          dial.current = undefined
+          this.resetReady(dial)
+        }
         this.registry.revokeIssued(connection.issuedCredential)
         if (dial.stopped) return
         this.deps.onConnectionLost?.(dial.record.agentId, `shim channel closed (${close.code})`)
@@ -174,6 +176,81 @@ export class ShimDialer {
         await this.delay(delay)
       }
     }
+  }
+
+  private dialAndBind(
+    dial: SupervisedDial,
+    timeoutMs: number
+  ): Promise<{ connection: ShimConnection; closed: Promise<{ code: number; reason: string }> }> {
+    const boundedMs = Math.max(1, timeoutMs)
+    let transport: ShimTransport | undefined
+    let timedOut = false
+    let timeoutHandle: ReturnType<Clock['setTimeout']> | undefined
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timeoutHandle = this.clock.setTimeout(() => {
+        timedOut = true
+        transport?.close(4408, 'binding timeout')
+        reject(new Error(`binding timed out after ${boundedMs}ms`))
+      }, boundedMs)
+    })
+    const attempt = (async () => {
+      transport = await (this.deps.dial ?? defaultDial)(dial.endpoint, {
+        subprotocol: SHIM_SUBPROTOCOL,
+        path: SHIM_WS_PATH
+      })
+      if (timedOut || dial.stopped) {
+        transport.close(4408, timedOut ? 'binding timeout' : 'dial no longer current')
+        throw new Error(timedOut ? `binding timed out after ${boundedMs}ms` : 'dial no longer current')
+      }
+      dial.inFlight = transport
+      try {
+        return await this.bind(transport, dial.record)
+      } finally {
+        if (dial.inFlight === transport) dial.inFlight = undefined
+      }
+    })()
+    return Promise.race([attempt, timeout]).finally(() => {
+      if (timeoutHandle !== undefined) this.clock.clearTimeout(timeoutHandle)
+    })
+  }
+
+  private awaitReady(dial: SupervisedDial, timeoutMs: number): Promise<ShimConnection> {
+    const boundedMs = Math.max(1, timeoutMs)
+    return new Promise((resolve, reject) => {
+      let settled = false
+      const timer = this.clock.setTimeout(() => {
+        if (settled) return
+        settled = true
+        dial.inFlight?.close(4408, 'binding timeout')
+        reject(new Error(`could not connect to sandbox shim: binding timed out after ${boundedMs}ms`))
+      }, boundedMs)
+      void dial.ready.then(
+        (connection) => {
+          if (settled) return
+          settled = true
+          this.clock.clearTimeout(timer)
+          resolve(connection)
+        },
+        (error: Error) => {
+          if (settled) return
+          settled = true
+          this.clock.clearTimeout(timer)
+          reject(error)
+        }
+      )
+    })
+  }
+
+  private resetReady(dial: SupervisedDial): void {
+    let resolveReady: (connection: ShimConnection) => void = () => {}
+    let rejectReady: (error: Error) => void = () => {}
+    dial.ready = new Promise<ShimConnection>((resolve, reject) => {
+      resolveReady = resolve
+      rejectReady = reject
+    })
+    dial.resolveReady = resolveReady
+    dial.rejectReady = rejectReady
+    dial.readySettled = false
   }
 
   private bind(

--- a/packages/daemon/src/shim/dialer.ts
+++ b/packages/daemon/src/shim/dialer.ts
@@ -1,0 +1,333 @@
+import { isAbsolute, normalize } from 'node:path'
+import { Backoff, ClientTransport, systemClock, type Clock } from '@agentconnect.md/connection'
+import { noopClusterMetrics, type ClusterMetrics } from '../k8s/cluster-metrics.js'
+import { ShimBindingRegistry, type Binding, type SpawnRecord } from './binding.js'
+import type { PodIdentityVerifier, ShimConnection } from './listener.js'
+import {
+  SHIM_SUBPROTOCOL,
+  SHIM_TOKEN_AUDIENCE,
+  SHIM_WS_PATH,
+  parseShimFrame,
+  type ShimFrame,
+  type ShimRejected
+} from './protocol.js'
+import type { ShimTransport } from './client.js'
+
+export interface ShimDialerDeps {
+  verifier: PodIdentityVerifier
+  now?: () => number
+  clock?: Clock
+  dial?: (url: string, opts: { subprotocol: string; path: string }) => Promise<ShimTransport>
+  credentialTtlMs?: number
+  metrics?: ClusterMetrics
+  log: { info: (message: string) => void; warn: (message: string) => void }
+  onConnection?: (connection: ShimConnection) => void
+  onConnectionLost?: (agentId: string, reason: string) => void
+}
+
+interface SupervisedDial {
+  record: SpawnRecord
+  endpoint: string
+  stopped: boolean
+  readySettled: boolean
+  current?: ShimConnection
+  ready: Promise<ShimConnection>
+  resolveReady: (connection: ShimConnection) => void
+  rejectReady: (error: Error) => void
+}
+
+const DEFAULT_CREDENTIAL_TTL_MS = 10 * 60_000
+
+function withoutToken(message: string, token: string): string {
+  return token.length > 0 ? message.split(token).join('[redacted]') : message
+}
+
+function sanitizeWorkspaceRoot(reported: string | undefined): string | undefined {
+  if (!reported || !isAbsolute(reported)) return undefined
+  const normalized = normalize(reported).replace(/\/+$/, '')
+  return normalized.length > 0 ? normalized : undefined
+}
+
+/** The daemon-side owner of outbound sandbox channels. */
+export class ShimDialer {
+  private readonly registry: ShimBindingRegistry
+  private readonly metrics: ClusterMetrics
+  private readonly clock: Clock
+  private readonly now: () => number
+  private readonly dials = new Map<string, SupervisedDial>()
+
+  constructor(private readonly deps: ShimDialerDeps) {
+    const now = deps.now ?? (() => Date.now())
+    this.now = now
+    this.registry = new ShimBindingRegistry(now, deps.credentialTtlMs ?? DEFAULT_CREDENTIAL_TTL_MS)
+    this.metrics = deps.metrics ?? noopClusterMetrics
+    this.clock = deps.clock ?? systemClock
+  }
+
+  connect(endpoint: string, record: SpawnRecord, timeoutMs: number): Promise<ShimConnection> {
+    const existing = this.dials.get(record.agentId)
+    if (
+      existing &&
+      !existing.stopped &&
+      existing.endpoint === endpoint &&
+      existing.record.generation === record.generation
+    ) {
+      return existing.current ? Promise.resolve(existing.current) : existing.ready
+    }
+    if (existing) this.stopDial(existing, 'superseded by a newer launch')
+    let resolveReady: (connection: ShimConnection) => void = () => {}
+    let rejectReady: (error: Error) => void = () => {}
+    const ready = new Promise<ShimConnection>((resolve, reject) => {
+      resolveReady = resolve
+      rejectReady = reject
+    })
+    const dial: SupervisedDial = {
+      endpoint,
+      record,
+      stopped: false,
+      readySettled: false,
+      ready,
+      resolveReady,
+      rejectReady
+    }
+    this.dials.set(record.agentId, dial)
+    void this.supervise(dial, timeoutMs)
+    return ready
+  }
+
+  connectionsFor(agentId: string): ShimConnection[] {
+    const current = this.dials.get(agentId)?.current
+    return current ? [current] : []
+  }
+
+  authorize(input: Parameters<ShimBindingRegistry['authorize']>[0]): ReturnType<ShimBindingRegistry['authorize']> {
+    return this.registry.authorize(input)
+  }
+
+  revokeAgent(agentId: string): void {
+    const dial = this.dials.get(agentId)
+    if (dial) this.stopDial(dial, 'binding revoked')
+    this.dials.delete(agentId)
+    this.registry.revokeAgent(agentId)
+  }
+
+  stop(): void {
+    for (const dial of this.dials.values()) this.stopDial(dial, 'daemon shutting down')
+    this.dials.clear()
+  }
+
+  private stopDial(dial: SupervisedDial, reason: string): void {
+    if (dial.stopped) return
+    dial.stopped = true
+    dial.current?.close(reason)
+    dial.current = undefined
+    if (!dial.readySettled) {
+      dial.readySettled = true
+      dial.rejectReady(new Error(reason))
+    }
+  }
+
+  private async supervise(dial: SupervisedDial, timeoutMs: number): Promise<void> {
+    const deadline = this.clock.now() + timeoutMs
+    const backoff = new Backoff()
+    let first = true
+    while (!dial.stopped) {
+      try {
+        const transport = await (this.deps.dial ?? defaultDial)(dial.endpoint, {
+          subprotocol: SHIM_SUBPROTOCOL,
+          path: SHIM_WS_PATH
+        })
+        const { connection, closed } = await this.bind(transport, dial.record)
+        if (dial.stopped) {
+          connection.close('dial no longer current')
+          return
+        }
+        dial.current = connection
+        backoff.reset()
+        first = false
+        if (!dial.readySettled) {
+          dial.readySettled = true
+          dial.resolveReady(connection)
+        }
+        this.deps.onConnection?.(connection)
+        const close = await closed
+        if (dial.current === connection) dial.current = undefined
+        this.registry.revokeIssued(connection.issuedCredential)
+        if (dial.stopped) return
+        this.deps.onConnectionLost?.(dial.record.agentId, `shim channel closed (${close.code})`)
+        const delay = close.reason === 'rebinding' ? 0 : backoff.next()
+        if (delay > 0) await this.delay(delay)
+      } catch (error) {
+        if (dial.stopped) return
+        if (this.clock.now() >= deadline && first) {
+          const failure = new Error(`could not connect to sandbox shim: ${(error as Error).message}`)
+          if (!dial.readySettled) {
+            dial.readySettled = true
+            dial.rejectReady(failure)
+          }
+          dial.stopped = true
+          if (this.dials.get(dial.record.agentId) === dial) this.dials.delete(dial.record.agentId)
+          return
+        }
+        const delay = backoff.next()
+        this.deps.log.warn(`shim: sandbox dial failed, retrying in ${delay}ms (${(error as Error).message})`)
+        await this.delay(delay)
+      }
+    }
+  }
+
+  private bind(
+    transport: ShimTransport,
+    record: SpawnRecord
+  ): Promise<{ connection: ShimConnection; closed: Promise<{ code: number; reason: string }> }> {
+    let resolveClosed: (value: { code: number; reason: string }) => void = () => {}
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => (resolveClosed = resolve))
+    return new Promise((resolve, reject) => {
+      let settled = false
+      let binding = false
+      const frameListeners: Array<(text: string) => void> = []
+      const fail = (error: Error): void => {
+        if (settled) return
+        settled = true
+        reject(error)
+      }
+      const rejectPeer = (frame: ShimRejected): void => {
+        try {
+          transport.send(JSON.stringify(frame))
+        } catch {
+          // The peer is already gone.
+        }
+        transport.close(4403, frame.reason)
+      }
+      transport.onClose((code, reason) => {
+        resolveClosed({ code, reason })
+        fail(new Error(`connection closed (${code}${reason ? ` ${reason}` : ''})`))
+      })
+      transport.onMessage((text) => {
+        const frame = parseShimFrame(text)
+        if (!frame) {
+          this.metrics.handshakeRejected('malformed')
+          transport.close(4400, 'malformed frame')
+          fail(new Error('malformed shim frame'))
+          return
+        }
+        if (frame.type === 'shim/rejected') {
+          fail(new Error(`rejected: ${frame.reason}`))
+          return
+        }
+        if (frame.type === 'shim/identity' || (frame.type === 'shim/hello' && 'token' in frame)) {
+          if (settled || binding) {
+            transport.close(4400, 'already binding')
+            return
+          }
+          binding = true
+          void this.bindHello(frame.token, record)
+            .then((result) => {
+              binding = false
+              if (settled) {
+                if (result.ok) this.registry.revokeIssued(result.credential)
+                return
+              }
+              if (!result.ok) {
+                rejectPeer(result.rejected)
+                fail(new Error(result.rejected.message))
+                return
+              }
+              const workspaceRoot = sanitizeWorkspaceRoot(frame.workspaceRoot)
+              const connection: ShimConnection = {
+                binding: result.binding,
+                issuedCredential: result.credential,
+                ...(workspaceRoot ? { workspaceRoot } : {}),
+                send: (outbound) => transport.send(JSON.stringify(outbound)),
+                onFrame: (listener) => frameListeners.push(listener),
+                close: (reason) => transport.close(4000, reason)
+              }
+              const remainingMs = result.binding.expiresAtMs - this.now()
+              try {
+                connection.send({
+                  type: 'shim/bound',
+                  sessionCredential: result.credential,
+                  expiresInSeconds: Math.max(1, Math.floor(remainingMs / 1000)),
+                  agentId: result.binding.agentId,
+                  generation: result.binding.generation,
+                  grants: result.binding.grants
+                })
+              } catch (error) {
+                this.registry.revokeIssued(result.credential)
+                throw error
+              }
+              settled = true
+              const expiry = this.clock.setTimeout(
+                () => connection.close('credential expired'),
+                Math.max(0, remainingMs)
+              )
+              void closed.then(() => this.clock.clearTimeout(expiry))
+              this.deps.log.info(
+                `shim: bound agent ${result.binding.agentId} generation ${result.binding.generation} at ${record.podName}`
+              )
+              resolve({ connection, closed })
+            })
+            .catch((error: unknown) => {
+              binding = false
+              if (settled) return
+              this.metrics.handshakeRejected('unavailable')
+              rejectPeer({ type: 'shim/rejected', reason: 'unavailable', message: 'binding unavailable' })
+              fail(error as Error)
+            })
+          return
+        }
+        if (!settled) {
+          transport.close(4403, 'not bound')
+          fail(new Error('shim did not present its identity'))
+          return
+        }
+        if (frame.type === 'shim/response' || frame.type === 'shim/event') {
+          for (const listener of frameListeners) listener(text)
+        }
+      })
+      transport.send(
+        JSON.stringify({
+          type: 'shim/hello',
+          agentId: record.agentId,
+          generation: record.generation
+        } satisfies Extract<ShimFrame, { type: 'shim/hello' }>)
+      )
+    })
+  }
+
+  private async bindHello(
+    token: string,
+    record: SpawnRecord
+  ): Promise<
+    { ok: true; credential: string; binding: Binding; superseded: Binding[] } | { ok: false; rejected: ShimRejected }
+  > {
+    const review = await this.deps.verifier.reviewToken(token, [SHIM_TOKEN_AUDIENCE])
+    if (!review.authenticated || !review.podName || !review.podUid) {
+      this.metrics.tokenReviewRejected()
+      this.metrics.handshakeRejected('unauthenticated')
+      this.deps.log.warn(
+        `shim: sandbox token was not accepted${review.error ? ` (${withoutToken(review.error, token)})` : ''}`
+      )
+      return { ok: false, rejected: { type: 'shim/rejected', reason: 'unauthenticated', message: 'not accepted' } }
+    }
+    if (review.podName !== record.podName) {
+      this.metrics.handshakeRejected('unknown_pod')
+      this.deps.log.warn(`shim: dialed pod ${record.podName} presented identity for ${review.podName}`)
+      return { ok: false, rejected: { type: 'shim/rejected', reason: 'unknown_pod', message: 'not accepted' } }
+    }
+    const bound = this.registry.bind(record, { name: review.podName, uid: review.podUid })
+    if (!bound.ok) {
+      this.metrics.handshakeRejected('stale_generation')
+      return { ok: false, rejected: { type: 'shim/rejected', reason: 'stale_generation', message: 'superseded' } }
+    }
+    return bound
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => this.clock.setTimeout(resolve, ms))
+  }
+}
+
+function defaultDial(url: string, opts: { subprotocol: string; path: string }): Promise<ShimTransport> {
+  return ClientTransport.dial(url, opts) as Promise<ShimTransport>
+}

--- a/packages/daemon/src/shim/index.ts
+++ b/packages/daemon/src/shim/index.ts
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 /** The in-sandbox shim executable. Lives at a fixed path in the runtime image
  *  (`/opt/agentconnect/shim`), root-owned and read-only, with tini as PID 1. */
-import { ClientTransport } from '@agentconnect.md/connection'
-import { ShimClient, type ShimTransport } from './client.js'
+import { ShimClient } from './client.js'
 import { createExecHandler } from './exec-handler.js'
 import { resolveCommandInPath } from './path-resolve.js'
-import { DEFAULT_SHIM_WORKSPACE_ROOT, SHIM_ENDPOINT_ENV, SHIM_WORKSPACE_ROOT_ENV } from './protocol.js'
+import {
+  DEFAULT_SHIM_LISTEN_PORT,
+  DEFAULT_SHIM_WORKSPACE_ROOT,
+  SHIM_LISTEN_PORT_ENV,
+  SHIM_WORKSPACE_ROOT_ENV
+} from './protocol.js'
+import { ShimServer } from './server.js'
 import { TunnelHost } from './tunnel-host.js'
 
 const log = {
@@ -14,20 +19,20 @@ const log = {
 }
 
 async function main(): Promise<number> {
-  const endpoint = process.env[SHIM_ENDPOINT_ENV]?.trim()
-  if (!endpoint) {
-    log.warn(`${SHIM_ENDPOINT_ENV} is not set — nothing to dial`)
+  const port = Number(process.env[SHIM_LISTEN_PORT_ENV] ?? DEFAULT_SHIM_LISTEN_PORT)
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    log.warn(`${SHIM_LISTEN_PORT_ENV} is not a valid port`)
     return 2
   }
   const workspaceRoot = process.env[SHIM_WORKSPACE_ROOT_ENV] ?? DEFAULT_SHIM_WORKSPACE_ROOT
   const exec = createExecHandler({ workspaceRoot, log })
-  // Its listeners belong to the POD, not to a channel, so it is built once here rather than per
-  // binding — a socket torn down on each credential renewal would break any client mid-request.
+  const server = new ShimServer({ log })
+  // Tunnel listeners follow pod lifetime so credential renewal cannot break client sockets.
   const tunnels = new TunnelHost({ emit: (streamId, event) => client.emit(streamId, event), log })
   const client = new ShimClient({
-    endpoint,
-    dial: (url, opts) =>
-      ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
+    endpoint: 'accepted-daemon-channel',
+    acceptDialIn: true,
+    dial: () => server.nextTransport(),
     // Without this the runner skips executable hints entirely, so CLAUDE_CODE_EXECUTABLE and
     // path-qualified registry commands would never resolve in the sandbox.
     resolveCommand: resolveCommandInPath,
@@ -38,17 +43,16 @@ async function main(): Promise<number> {
     // because they own long-lived sockets rather than answering one request.
     handle: (capability, payload, abort) =>
       capability === 'tunnel' ? tunnels.handle(payload) : exec(capability, payload, abort),
-    // Reported in the hello: daemon-built pod paths (ACP cwd, git cwd) are anchored on it.
+    // Reported in the hello so daemon-built pod paths are anchored on this filesystem.
     workspaceRoot,
     log
   })
-  // A signal is the pod being torn down; drop the channel rather than racing the
-  // container's exit, since every credential we hold is re-obtained on the next bind.
+  await server.start(port)
   for (const signal of ['SIGTERM', 'SIGINT'] as const) {
     process.on(signal, () => {
       tunnels.close()
       client.stop()
-      process.exit(0)
+      void server.stop().finally(() => process.exit(0))
     })
   }
   await client.start()

--- a/packages/daemon/src/shim/listener.ts
+++ b/packages/daemon/src/shim/listener.ts
@@ -79,7 +79,7 @@ export interface ShimConnection {
 }
 
 /**
- * The daemon's shim endpoint: the shim dials out, this listens.
+ * Legacy daemon-side dial-out endpoint, retained for staged compatibility tests.
  *
  * Direction is deliberate — the sandbox needs zero inbound, so its NetworkPolicy keeps
  * an empty ingress list and no per-sandbox Service exists. Binding is proved by the
@@ -226,7 +226,7 @@ export class ShimListener {
         ws.close(4400, 'malformed frame')
         return
       }
-      if (frame.type === 'shim/hello') {
+      if (frame.type === 'shim/hello' && 'token' in frame) {
         // Single-flight: a second hello arriving while TokenReview is in flight would bind
         // twice and leave a stale connection entry behind.
         if (bound || binding) {

--- a/packages/daemon/src/shim/protocol.ts
+++ b/packages/daemon/src/shim/protocol.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { TunnelNameSchema } from './tunnel.js'
 
-/** WS subprotocol and path the shim dials the daemon on. */
+/** WS subprotocol and path the daemon uses when dialing the sandbox shim. */
 export const SHIM_SUBPROTOCOL = 'agentconnect.shim.v1'
 export const SHIM_WS_PATH = '/shim/v1'
 
@@ -13,9 +13,12 @@ export const SHIM_TOKEN_AUDIENCE = 'ac-daemon-callback'
 /** Where the pod template projects that token, and where the shim reads it from. */
 export const SHIM_IDENTITY_TOKEN_PATH = '/var/run/ac-identity/token'
 
-/** The env var carrying the daemon's shim endpoint into the sandbox. Non-secret, so it
- *  is safe in a SandboxTemplate whose pods are stamped before any user exists. */
+/** Legacy dial-out endpoint, retained only for compatibility while old images are tested. */
 export const SHIM_ENDPOINT_ENV = 'AC_SHIM_ENDPOINT'
+
+/** Port the in-sandbox shim listens on for daemon dial-in. */
+export const SHIM_LISTEN_PORT_ENV = 'AC_SHIM_PORT'
+export const DEFAULT_SHIM_LISTEN_PORT = 8085
 
 /** Root the sandbox permits filesystem work inside — the mounted agent volume. Also non-secret,
  *  and fixed by the image rather than chosen per request, since the shim uses it to refuse a
@@ -48,19 +51,26 @@ export const ShimCapabilitySchema = z.enum([
 ])
 export type ShimCapability = z.infer<typeof ShimCapabilitySchema>
 
-/** The shim's opening frame: it proves which pod it is, plus one filesystem fact. */
-export const ShimHelloSchema = z.object({
+/** The daemon opens a dial-in channel with the launch it expects to bind. */
+export const ShimDialHelloSchema = z.object({
   type: z.literal('shim/hello'),
+  agentId: z.string().min(1),
+  generation: z.number().int().nonnegative()
+})
+
+/** The shim answers the dialer's hello by proving which pod accepted it. */
+export const ShimIdentitySchema = z.object({
+  type: z.literal('shim/identity'),
   /** Projected ServiceAccount token, audience-restricted to {@link SHIM_TOKEN_AUDIENCE}. */
   token: z.string().min(1),
   /** Shim build, for operator diagnosis only — never an authorization input. */
   shimVersion: z.string().max(64).optional(),
-  /** Where THIS pod mounts its workspace volume — the daemon cannot name a path on a machine
-   *  it is not on, and every path it later sends into the pod (ACP cwd, git cwd) is built on
-   *  this. Pod-reported and only ever echoed back into the same pod, so a lying shim gains
-   *  nothing daemon-side. Absent on legacy shims ⇒ {@link DEFAULT_SHIM_WORKSPACE_ROOT}. */
+  /** This pod's workspace mount; absent on legacy shims means {@link DEFAULT_SHIM_WORKSPACE_ROOT}. */
   workspaceRoot: z.string().min(1).max(4096).optional()
 })
+
+/** Legacy dial-out identity, accepted only by the old listener during the staged migration. */
+export const LegacyShimHelloSchema = ShimIdentitySchema.extend({ type: z.literal('shim/hello') })
 
 /** The daemon's answer once the token is verified and mapped to a spawn record. */
 export const ShimBoundSchema = z.object({
@@ -132,8 +142,10 @@ export const ShimEventSchema = z.object({
   ])
 })
 
-export const ShimFrameSchema = z.discriminatedUnion('type', [
-  ShimHelloSchema,
+export const ShimFrameSchema = z.union([
+  ShimDialHelloSchema,
+  ShimIdentitySchema,
+  LegacyShimHelloSchema,
   ShimBoundSchema,
   ShimRejectedSchema,
   ShimRequestSchema,
@@ -142,7 +154,7 @@ export const ShimFrameSchema = z.discriminatedUnion('type', [
   ShimEventSchema
 ])
 
-export type ShimHello = z.infer<typeof ShimHelloSchema>
+export type ShimHello = z.infer<typeof LegacyShimHelloSchema>
 export type ShimBound = z.infer<typeof ShimBoundSchema>
 export type ShimRejected = z.infer<typeof ShimRejectedSchema>
 export type ShimRequest = z.infer<typeof ShimRequestSchema>
@@ -150,6 +162,8 @@ export type ShimCancel = z.infer<typeof ShimCancelSchema>
 export type ShimResponse = z.infer<typeof ShimResponseSchema>
 export type ShimEvent = z.infer<typeof ShimEventSchema>
 export type ShimFrame = z.infer<typeof ShimFrameSchema>
+export type ShimDialHello = z.infer<typeof ShimDialHelloSchema>
+export type ShimIdentity = z.infer<typeof ShimIdentitySchema>
 
 /** Parse an inbound frame, returning undefined rather than throwing: a malformed frame
  *  from a half-trusted peer is a close-the-connection event, not an exception path. */

--- a/packages/daemon/src/shim/server.ts
+++ b/packages/daemon/src/shim/server.ts
@@ -1,0 +1,120 @@
+import { createServer, type Server } from 'node:http'
+import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import { WebSocketServer } from 'ws'
+import { WsServerTransport } from '@agentconnect.md/connection'
+import { SHIM_SUBPROTOCOL, SHIM_WS_PATH } from './protocol.js'
+import type { ShimTransport } from './client.js'
+
+export interface ShimServerDeps {
+  log?: { info: (message: string) => void; warn: (message: string) => void }
+}
+
+/** The sandbox-side WebSocket endpoint; one daemon channel may be active at a time. */
+export class ShimServer {
+  private server?: Server
+  private wss?: WebSocketServer
+  private active?: ShimTransport
+  private queued?: ShimTransport
+  private waiter?: { resolve: (transport: ShimTransport) => void; reject: (error: Error) => void }
+  private port?: number
+
+  constructor(private readonly deps: ShimServerDeps = {}) {}
+
+  async start(port: number, host = '0.0.0.0'): Promise<number> {
+    const server = createServer((_req, res) => {
+      res.statusCode = 404
+      res.end()
+    })
+    const wss = new WebSocketServer({
+      noServer: true,
+      maxPayload: MAX_FRAME_BYTES,
+      handleProtocols: (protocols) => (protocols.has(SHIM_SUBPROTOCOL) ? SHIM_SUBPROTOCOL : false)
+    })
+    server.on('upgrade', (req, socket, head) => {
+      if ((req.url ?? '').split('?', 1)[0] !== SHIM_WS_PATH) {
+        socket.destroy()
+        return
+      }
+      const offered = (req.headers['sec-websocket-protocol'] ?? '')
+        .toString()
+        .split(',')
+        .map((value) => value.trim())
+      if (!offered.includes(SHIM_SUBPROTOCOL)) {
+        socket.destroy()
+        return
+      }
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        const raw = new WsServerTransport(ws, req.socket.remoteAddress ?? 'unknown')
+        const transport: ShimTransport = {
+          send: (text) => raw.send(text),
+          onMessage: (listener) => raw.onMessage(listener),
+          onClose: (listener) => raw.onClose(listener),
+          close: (code, reason) => {
+            if (this.active === transport) this.active = undefined
+            if (this.queued === transport) this.queued = undefined
+            raw.close(code, reason)
+          }
+        }
+        if (this.active || this.queued) {
+          this.deps.log?.warn('shim: refusing a second daemon connection')
+          transport.close(4403, 'unavailable')
+          return
+        }
+        transport.onClose(() => {
+          if (this.active === transport) this.active = undefined
+          if (this.queued === transport) this.queued = undefined
+        })
+        if (this.waiter) {
+          const { resolve } = this.waiter
+          this.waiter = undefined
+          this.active = transport
+          resolve(transport)
+        } else {
+          this.queued = transport
+        }
+      })
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(port, host, () => {
+        server.removeListener('error', reject)
+        resolve()
+      })
+    })
+    this.server = server
+    this.wss = wss
+    this.port = (server.address() as { port: number }).port
+    this.deps.log?.info(`shim: listening on ${host}:${this.port}${SHIM_WS_PATH}`)
+    return this.port
+  }
+
+  /** Supply the next accepted daemon socket to the existing sandbox channel FSM. */
+  nextTransport(): Promise<ShimTransport> {
+    if (this.queued) {
+      const transport = this.queued
+      this.queued = undefined
+      this.active = transport
+      return Promise.resolve(transport)
+    }
+    if (this.waiter) return Promise.reject(new Error('shim: already waiting for a daemon connection'))
+    return new Promise<ShimTransport>((resolve, reject) => (this.waiter = { resolve, reject }))
+  }
+
+  listeningPort(): number | undefined {
+    return this.port
+  }
+
+  async stop(): Promise<void> {
+    this.active?.close(1000, 'shim stopping')
+    this.queued?.close(1000, 'shim stopping')
+    this.active = undefined
+    this.queued = undefined
+    this.waiter?.reject(new Error('shim: server stopped'))
+    this.waiter = undefined
+    this.wss?.close()
+    await new Promise<void>((resolve) => (this.server ? this.server.close(() => resolve()) : resolve()))
+    this.server = undefined
+    this.wss = undefined
+    this.port = undefined
+  }
+}

--- a/packages/daemon/src/shim/session.ts
+++ b/packages/daemon/src/shim/session.ts
@@ -6,8 +6,8 @@ import { parseShimFrame } from './protocol.js'
 /**
  * A logical channel to one agent's sandbox that survives the physical connection.
  *
- * A runtime lives for hours; a shim connection does not. The shim renews its credential by
- * dialing a replacement at half the TTL, and the listener closes the superseded socket — so
+ * A runtime lives for hours; a shim connection does not. The shim closes at half the TTL and
+ * the daemon dials a replacement — so
  * anything holding one `ShimConnection` for a runtime's lifetime is stranded on the first
  * ordinary renewal. This tracks the current connection instead, re-attaching when the same
  * launch rebinds and reporting a genuine loss when a NEW launch takes over.

--- a/packages/daemon/src/shim/tunnel-host.ts
+++ b/packages/daemon/src/shim/tunnel-host.ts
@@ -48,7 +48,7 @@ export interface TunnelHostDeps {
  * which of its own sockets each reaches; this side only knows that something in the pod
  * connected and that its bytes belong to a stream id.
  *
- * Listeners outlive the channel deliberately. The shim re-dials at half the credential TTL, and
+ * Listeners outlive the channel deliberately. The channel reconnects at half the credential TTL, and
  * a listener torn down on every renewal would break any client that happened to be mid-request
  * — so `listen` is idempotent and the socket belongs to the pod's lifetime.
  */

--- a/packages/daemon/src/shim/tunnel-proxy.ts
+++ b/packages/daemon/src/shim/tunnel-proxy.ts
@@ -50,7 +50,7 @@ export class TunnelProxy {
   constructor(private readonly deps: TunnelProxyDeps) {
     deps.session.onEvent(this.onEvent)
     // The pod's listener and its live client connections outlive a physical channel — the shim
-    // re-dials at half the credential TTL — but a frame that was travelling when the socket was
+    // reconnects at half the credential TTL — but a frame that was travelling when the socket was
     // replaced does not. See dropUnaccountedStreams.
     deps.session.onAttach(this.onAttach)
     // A lost channel takes every stream with it: the pod that held the other end is gone, and a

--- a/packages/daemon/test/cluster-acp-e2e.test.ts
+++ b/packages/daemon/test/cluster-acp-e2e.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
+import { Backoff, FakeClock } from '@agentconnect.md/connection'
 import { AcpHost } from '../src/acp/acp-host.js'
 import { K8sDriver } from '../src/k8s/driver.js'
-import { ShimListener, type ShimConnection } from '../src/shim/listener.js'
+import type { ShimConnection } from '../src/shim/listener.js'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
+import { ShimDialer } from '../src/shim/dialer.js'
+import { ShimServer } from '../src/shim/server.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
 import type { SpawnRecord } from '../src/shim/binding.js'
@@ -23,14 +25,14 @@ import type { SpawnRecord } from '../src/shim/binding.js'
 const here = dirname(fileURLToPath(import.meta.url))
 const fakeAgent = join(here, 'fixtures', 'fake-acp-agent.mjs')
 
-const listeners: ShimListener[] = []
+const servers: ShimServer[] = []
+const dialers: ShimDialer[] = []
 const clients: ShimClient[] = []
-const intervals: NodeJS.Timeout[] = []
 
 afterEach(async () => {
-  for (const timer of intervals.splice(0)) clearInterval(timer)
   for (const client of clients.splice(0)) client.stop()
-  await Promise.all(listeners.splice(0).map((instance) => instance.stop()))
+  for (const dialer of dialers.splice(0)) dialer.stop()
+  await Promise.all(servers.splice(0).map((instance) => instance.stop()))
 })
 
 /** Minimal SandboxApi: one claim, one always-ready Sandbox, mode held in memory. */
@@ -38,9 +40,13 @@ function fakeApi() {
   const state = {
     mode: 'Suspended' as 'Running' | 'Suspended',
     sandbox: {
-      metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
+      metadata: {
+        name: 'sb-1',
+        uid: 'sandbox-uid-1',
+        annotations: { 'agents.x-k8s.io/pod-name': 'runtime-1' }
+      },
       spec: { operatingMode: 'Suspended' as 'Running' | 'Suspended' },
-      status: { conditions: [{ type: 'Ready', status: 'True' }] }
+      status: { conditions: [{ type: 'Ready', status: 'True' }], podIPs: ['127.0.0.1'] }
     } as Sandbox,
     claim: undefined as SandboxClaim | undefined
   }
@@ -71,81 +77,60 @@ function fakeApi() {
   }
 }
 
-/** Wire a real listener, a real shim client, and a driver that connects them. */
+/** Wire a real sandbox listener, daemon dialer, and driver. */
 async function clusterUnderTest(options: { credentialTtlMs?: number } = {}): Promise<{
   driver: K8sDriver
   api: ReturnType<typeof fakeApi>
   connections: ShimConnection[]
   shimClock: FakeClock
-  listener: ShimListener
   bindCount: () => number
 }> {
   const api = fakeApi()
-  let record: SpawnRecord | undefined
   const connections: ShimConnection[] = []
   const shimClock = new FakeClock()
   let binds = 0
-  const listener = new ShimListener({
+  const server = new ShimServer()
+  servers.push(server)
+  const port = await server.start(0, '127.0.0.1')
+  let driver: K8sDriver
+  const dialer = new ShimDialer({
     verifier: { reviewToken: async () => ({ authenticated: true, podName: 'runtime-1', podUid: 'pod-uid-1' }) },
-    spawnRecordForPod: () => record,
     now: () => Date.now(),
     ...(options.credentialTtlMs !== undefined ? { credentialTtlMs: options.credentialTtlMs } : {}),
+    onConnection: (connection) => {
+      if (!connections.includes(connection)) {
+        connections.push(connection)
+        binds += 1
+      }
+      driver.onChannelBound(connection)
+    },
     log: { info: () => (binds += 0), warn: () => {} }
   })
-  listeners.push(listener)
-  const port = await listener.start(0, '127.0.0.1')
+  dialers.push(dialer)
 
-  const driver = new K8sDriver({
+  const client = new ShimClient({
+    endpoint: 'accepted-daemon-channel',
+    acceptDialIn: true,
+    dial: () => server.nextTransport() as Promise<ShimTransport>,
+    readToken: () => 'projected-token',
+    clock: shimClock,
+    backoff: new Backoff({ jitter: () => 0 }),
+    log: { info: () => {}, warn: () => {} }
+  })
+  clients.push(client)
+  void client.start()
+
+  driver = new K8sDriver({
     api: api.api as never,
     orgId: 'org-1',
     warmPoolName: 'pool',
-    publishSpawnRecord: (published) => {
-      record = published
-      // The shim can only dial once a record exists, so start it here — the same ordering the
-      // real driver depends on.
-      const client = new ShimClient({
-        endpoint: `ws://127.0.0.1:${port}`,
-        dial: (url, opts) =>
-          ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
-        readToken: () => 'projected-token',
-        clock: shimClock,
-        backoff: new Backoff({ jitter: () => 0 }),
-        log: { info: () => {}, warn: () => {} }
-      })
-      clients.push(client)
-      void client.start()
-    },
-    awaitChannel: async (agentId, generation, timeoutMs) => {
-      const deadline = Date.now() + timeoutMs
-      for (;;) {
-        const match = listener
-          .connectionsFor(agentId)
-          .find((connection) => connection.binding.generation === generation)
-        if (match && !connections.includes(match)) {
-          connections.push(match)
-          binds += 1
-          return match
-        }
-        if (match) return match
-        if (Date.now() > deadline) throw new Error('no channel bound in time')
-        await new Promise((resolve) => setTimeout(resolve, 20))
-      }
-    },
+    connectChannel: (record: SpawnRecord, _podIp, timeoutMs) =>
+      dialer.connect(`ws://127.0.0.1:${port}`, record, timeoutMs),
+    revokeChannel: (agentId) => dialer.revokeAgent(agentId),
     readyTimeoutMs: 15_000,
     log: { info: () => {}, warn: () => {}, debug: () => {} }
   })
-  // Whoever owns the listener re-attaches a rebound channel; the daemon does this in
-  // production, and the test stands in for it.
-  const watchBinds = setInterval(() => {
-    for (const connection of listener.connectionsFor('agent-a')) {
-      if (connections.includes(connection)) continue
-      connections.push(connection)
-      binds += 1
-      driver.onChannelBound(connection)
-    }
-  }, 20)
-  intervals.push(watchBinds)
-  return { driver, api, connections, shimClock, listener, bindCount: () => binds }
+  return { driver, api, connections, shimClock, bindCount: () => binds }
 }
 
 describe('a full ACP turn over the cluster driver', () => {

--- a/packages/daemon/test/cluster-acp-e2e.test.ts
+++ b/packages/daemon/test/cluster-acp-e2e.test.ts
@@ -92,7 +92,6 @@ async function clusterUnderTest(options: { credentialTtlMs?: number } = {}): Pro
   const server = new ShimServer()
   servers.push(server)
   const port = await server.start(0, '127.0.0.1')
-  let driver: K8sDriver
   const dialer = new ShimDialer({
     verifier: { reviewToken: async () => ({ authenticated: true, podName: 'runtime-1', podUid: 'pod-uid-1' }) },
     now: () => Date.now(),
@@ -120,7 +119,7 @@ async function clusterUnderTest(options: { credentialTtlMs?: number } = {}): Pro
   clients.push(client)
   void client.start()
 
-  driver = new K8sDriver({
+  const driver = new K8sDriver({
     api: api.api as never,
     orgId: 'org-1',
     warmPoolName: 'pool',

--- a/packages/daemon/test/cluster-metrics.test.ts
+++ b/packages/daemon/test/cluster-metrics.test.ts
@@ -69,7 +69,7 @@ function fakeApi(options: { claimExists: boolean; mode: 'Running' | 'Suspended' 
         ({
           metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
           spec: { operatingMode: state.mode },
-          status: { conditions: [{ type: 'Ready', status: 'True' }] }
+          status: { conditions: [{ type: 'Ready', status: 'True' }], podIPs: ['10.0.0.8'] }
         }) as Sandbox,
       setOperatingMode: async (_name: string, desired: 'Running' | 'Suspended') => {
         state.mode = desired
@@ -132,8 +132,9 @@ function driverFor(
     api: api.api as never,
     orgId: 'org-1',
     warmPoolName: 'pool',
-    publishSpawnRecord: () => {},
-    awaitChannel: awaitChannel ?? (async () => respondingConnection(open) as never),
+    connectChannel: awaitChannel
+      ? async (record, _podIp, timeoutMs) => await awaitChannel(record.agentId, record.generation, timeoutMs)
+      : async () => respondingConnection(open) as never,
     clock,
     metrics,
     readyTimeoutMs: 5_000,
@@ -380,7 +381,7 @@ describe('cluster launch metrics', () => {
     const churn = recorder()
     const driver = driverFor(churn.metrics, fakeApi({ claimExists: true, mode: 'Suspended' }))
     await driver.launch(launchRequest)
-    // The routine half-TTL renewal: the shim re-dials and the listener hands the SAME launch its
+    // The routine half-TTL renewal: the daemon reconnects and hands the SAME launch its
     // replacement socket, with no loss reported in between. A re-establishment rate is the signal
     // that renewals or pod churn exceed expectations, which pooling it with the first bind hides.
     driver.onChannelBound(rebind())

--- a/packages/daemon/test/direct-connect-credentials.test.ts
+++ b/packages/daemon/test/direct-connect-credentials.test.ts
@@ -38,7 +38,7 @@ function fakeApi() {
         ({
           metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
           spec: { operatingMode: 'Running' },
-          status: { conditions: [{ type: 'Ready', status: 'True' }] }
+          status: { conditions: [{ type: 'Ready', status: 'True' }], podIPs: ['10.0.0.8'] }
         }) as Sandbox,
       setOperatingMode: async () => ({}) as Sandbox,
       watchClaims: vi.fn(),
@@ -55,8 +55,7 @@ describe('provider credentials in the direct-connect stage', () => {
       api: api as never,
       orgId: 'org-1',
       warmPoolName: 'pool',
-      awaitChannel: async () => ({}) as ShimConnection,
-      publishSpawnRecord: () => {},
+      connectChannel: async () => ({}) as ShimConnection,
       log: { info: () => {}, warn: () => {}, debug: () => {} }
     })
     // launch() must be what creates the claim: pre-creating it would take the existing-launch

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -14,7 +14,10 @@ function fakeApi(options: { ready?: boolean; mode?: 'Running' | 'Suspended' } = 
     sandbox: {
       metadata: { name: 'sb-1', uid: 'sandbox-uid-1' },
       spec: { operatingMode: options.mode ?? 'Running' },
-      status: { conditions: [{ type: 'Ready', status: options.ready === false ? 'False' : 'True' }] }
+      status: {
+        conditions: [{ type: 'Ready', status: options.ready === false ? 'False' : 'True' }],
+        podIPs: ['10.0.0.8']
+      }
     } as Sandbox,
     modeWrites: [] as Array<{ desired: string; observed: string }>,
     rejectNextModeWrites: 0,
@@ -103,15 +106,19 @@ function driver(api: ReturnType<typeof fakeApi>['api'], overrides: Record<string
   const records: SpawnRecord[] = []
   const clock = new FakeClock()
   let generation = 0
+  const customConnect = overrides.connectChannel as
+    ((record: SpawnRecord, podIp: string, timeoutMs: number) => Promise<ShimConnection>) | undefined
   const instance = new K8sDriver({
     api: api as never,
     orgId: 'org-1',
     warmPoolName: 'ac-runtime-standard-pool',
-    awaitChannel: async () => stubConnection(++generation),
-    publishSpawnRecord: (record) => records.push(record),
     clock,
     log: { info: () => {}, warn: () => {}, debug: () => {} },
-    ...overrides
+    ...overrides,
+    connectChannel: async (record: SpawnRecord, podIp: string, timeoutMs: number) => {
+      records.push(record)
+      return customConnect ? await customConnect(record, podIp, timeoutMs) : stubConnection(++generation)
+    }
   })
   return { instance, records, clock }
 }
@@ -132,15 +139,12 @@ describe('cluster spawn driver', () => {
     expect((claim.spec as Record<string, unknown>).volumeClaimTemplates).toBeUndefined()
   })
 
-  it('publishes a spawn record naming the POD, as soon as the Sandbox names one', async () => {
-    // The record is how a dialing pod is resolved back to its launch, and a TokenReview yields
-    // only a pod name and uid — so a record that does not name the pod cannot be found at all.
-    // It is published when the pod is first named rather than at claim time, because at claim
-    // time the name still belongs to the previous incarnation.
+  it('dials the ready pod IP with a launch record naming that pod', async () => {
     const { api } = fakeApi()
-    const { instance, records } = driver(api)
+    const connectChannel = vi.fn(async (record: SpawnRecord) => stubConnection(record.generation))
+    const { instance, records } = driver(api, { connectChannel })
     expect(await instance.ensureSandbox('agent-a')).toMatchObject({ sandboxName: 'sb-1' })
-    // ensureSandbox alone publishes nothing: no pod is bound yet.
+    // ensureSandbox alone dials nothing: the backing pod is not ready yet.
     expect(records).toEqual([])
 
     await instance.launch(launchRequest)
@@ -154,17 +158,16 @@ describe('cluster spawn driver', () => {
         podName: 'sb-1'
       }
     ])
+    expect(connectChannel).toHaveBeenCalledWith(expect.objectContaining({ podName: 'sb-1' }), '10.0.0.8', 90_000)
   })
 
   it('names the ADOPTED warm-pool pod, not the Sandbox, when one was adopted', async () => {
-    // Our normal path is warm-pool adoption, and an adopted pod carries a pool-generated name
-    // that has nothing to do with the Sandbox's. Falling back to the Sandbox name there would
-    // publish a record no dialing pod could ever match.
+    // An adopted pod's pool-generated name is the identity TokenReview must return.
     const { api } = fakeApi()
     api.getSandbox = async () => ({
       metadata: { name: 'sb-1', uid: 'sandbox-uid-1', annotations: { 'agents.x-k8s.io/pod-name': 'pool-xyz-7' } },
       spec: { operatingMode: 'Running' },
-      status: { conditions: [{ type: 'Ready', status: 'True' }] }
+      status: { conditions: [{ type: 'Ready', status: 'True' }], podIPs: ['10.0.0.9'] }
     })
     const { instance, records } = driver(api)
     await instance.launch(launchRequest)
@@ -226,7 +229,7 @@ describe('cluster spawn driver', () => {
     // to end the launch, which is what makes the next turn claim a fresh generation.
     const { api } = fakeApi()
     const { instance } = driver(api, {
-      awaitChannel: async (_a: string, generation: number) => stubConnection(generation)
+      connectChannel: async (record: SpawnRecord) => stubConnection(record.generation)
     })
     await instance.ensureBoundChannel('agent-a')
     expect(instance.sessionFor('agent-a')?.isAttached()).toBe(true)
@@ -241,7 +244,7 @@ describe('cluster spawn driver', () => {
   it('suspends an idle agent, keeps its claim, and resumes it at a new generation', async () => {
     const { api, state } = fakeApi()
     const { instance, records } = driver(api, {
-      awaitChannel: async (_a: string, generation: number) => stubConnection(generation)
+      connectChannel: async (record: SpawnRecord) => stubConnection(record.generation)
     })
     await instance.ensureBoundChannel('agent-a')
 
@@ -283,7 +286,7 @@ describe('cluster spawn driver', () => {
       return setOperatingMode(name as never, desired as never, observed as never)
     }) as never
     const { instance, records } = driver(api, {
-      awaitChannel: async (_a: string, generation: number) => stubConnection(generation)
+      connectChannel: async (record: SpawnRecord) => stubConnection(record.generation)
     })
     await instance.ensureBoundChannel('agent-a')
 
@@ -449,7 +452,7 @@ describe('cluster spawn driver', () => {
     const { api } = fakeApi()
     let generation = 0
     const { instance } = driver(api, {
-      awaitChannel: async () => stubConnection(++generation, '/agent')
+      connectChannel: async () => stubConnection(++generation, '/agent')
     })
     // Unknown before any bind: the daemon cannot name a path on a machine it has not heard from.
     expect(instance.workspaceRootFor('agent-a')).toBeUndefined()
@@ -476,7 +479,7 @@ describe('cluster spawn driver', () => {
     const { api } = fakeApi()
     let generation = 0
     const { instance } = driver(api, {
-      awaitChannel: async () => stubConnection(++generation, '/mnt/agent')
+      connectChannel: async () => stubConnection(++generation, '/mnt/agent')
     })
     await instance.launch(launchRequest)
     expect(instance.workspaceRootFor('agent-a')).toBe('/mnt/agent')

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
+import { Backoff, FakeClock } from '@agentconnect.md/connection'
 import { startK8sRuntimePlane, k8sPlaneSettings, type K8sRuntimePlane } from '../src/k8s/runtime-plane.js'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
+import { ShimServer } from '../src/shim/server.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
 
@@ -10,7 +11,7 @@ import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
  * built and tested separately while nothing put them together, so `--k8s` changed the daemon's
  * behaviour and still ran runtimes on its own host.
  *
- * A real shim client dials a real listener over a real socket here. What that catches — and unit
+ * A real daemon dialer reaches a real sandbox listener over a real socket here. What that catches — and unit
  * tests of the parts cannot — is the wiring being wrong end to end: a pod that binds but is
  * mapped to no launch, a driver that never learns its channel, or a workspace runner that stays
  * local because nothing registered it.
@@ -18,10 +19,15 @@ import type { Sandbox, SandboxClaim } from '../src/k8s/sandbox-api.js'
 
 const planes: K8sRuntimePlane[] = []
 const clients: ShimClient[] = []
+const servers: ShimServer[] = []
+const serverByPort = new Map<number, ShimServer>()
+const portByPlane = new WeakMap<K8sRuntimePlane, number>()
 
 afterEach(async () => {
   for (const client of clients.splice(0)) client.stop()
   for (const plane of planes.splice(0)) await plane.stop()
+  for (const server of servers.splice(0)) await server.stop()
+  serverByPort.clear()
   delete process.env.AC_K8S_ORG_ID
   delete process.env.AC_K8S_WARM_POOL
   delete process.env.AC_K8S_SHIM_PORT
@@ -42,7 +48,7 @@ function fakeApi(options: { podName?: string; adopt?: boolean } = {}) {
       ...(options.adopt === false ? {} : { annotations: { 'agents.x-k8s.io/pod-name': podName } })
     },
     spec: { operatingMode: 'Running' as const },
-    status: { conditions: [{ type: 'Ready', status: 'True' }] }
+    status: { conditions: [{ type: 'Ready', status: 'True' }], podIPs: ['127.0.0.1'] }
   } satisfies Sandbox
   let claim: SandboxClaim | undefined
   return {
@@ -63,7 +69,7 @@ function fakeApi(options: { podName?: string; adopt?: boolean } = {}) {
       watchClaims: vi.fn(),
       // The plane follows Sandboxes for a rollout's drain requests; this one reports none.
       watchSandboxes: ({ signal }: { signal?: AbortSignal }) => idleSandboxWatch(signal),
-      // The listener verifies through this, so the handshake exercises the real path.
+      // The dialer verifies through this, so the handshake exercises the real path.
       reviewToken: async (token: string) =>
         token === 'projected-token'
           ? { authenticated: true, podName, podUid: 'pod-uid-1' }
@@ -74,21 +80,27 @@ function fakeApi(options: { podName?: string; adopt?: boolean } = {}) {
 
 /** Start a plane whose Kubernetes surface is the fake above, on an ephemeral port. */
 async function planeUnderTest(api: ReturnType<typeof fakeApi>): Promise<K8sRuntimePlane> {
+  const server = new ShimServer()
+  const port = await server.start(0, '127.0.0.1')
+  servers.push(server)
+  serverByPort.set(port, server)
   const plane = await startK8sRuntimePlane({
     orgId: 'org-1',
     warmPoolName: 'pool',
-    shimPort: 0,
-    shimHost: '127.0.0.1',
+    shimPort: port,
     readyTimeoutMs: 15_000,
     api: api.api as never,
     log: { info: () => {}, warn: () => {}, debug: () => {} }
   })
   planes.push(plane)
+  portByPlane.set(plane, port)
   return plane
 }
 
-/** A real shim client dialling the plane's endpoint, optionally serving capabilities. */
+/** A real passive shim client accepting the plane's dial, optionally serving capabilities. */
 function shimAgainst(port: number, handlers: { probe?: unknown; workspaceRoot?: string } = {}): ShimClient {
+  const server = serverByPort.get(port)
+  if (!server) throw new Error(`no sandbox shim server on ${port}`)
   const client = new ShimClient({
     ...(handlers.probe === undefined
       ? {}
@@ -102,9 +114,9 @@ function shimAgainst(port: number, handlers: { probe?: unknown; workspaceRoot?: 
           }
         }),
     ...(handlers.workspaceRoot === undefined ? {} : { workspaceRoot: handlers.workspaceRoot }),
-    endpoint: `ws://127.0.0.1:${port}`,
-    dial: (url, opts) =>
-      ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
+    endpoint: 'accepted-daemon-channel',
+    acceptDialIn: true,
+    dial: () => server.nextTransport() as Promise<ShimTransport>,
     readToken: () => 'projected-token',
     clock: new FakeClock(),
     backoff: new Backoff({ jitter: () => 0 }),
@@ -113,6 +125,12 @@ function shimAgainst(port: number, handlers: { probe?: unknown; workspaceRoot?: 
   clients.push(client)
   void client.start()
   return client
+}
+
+function shimPort(plane: K8sRuntimePlane): number {
+  const port = portByPlane.get(plane)
+  if (!port) throw new Error('plane has no shim port')
+  return port
 }
 
 async function until(predicate: () => boolean, timeoutMs = 10_000): Promise<boolean> {
@@ -138,6 +156,9 @@ describe('k8s plane settings', () => {
     expect(() =>
       k8sPlaneSettings({ AC_K8S_ORG_ID: 'org-1', AC_K8S_WARM_POOL: 'pool', AC_K8S_SHIM_PORT: 'http' })
     ).toThrow(/not a valid port/)
+    expect(() => k8sPlaneSettings({ AC_K8S_ORG_ID: 'org-1', AC_K8S_WARM_POOL: 'pool', AC_K8S_SHIM_PORT: '0' })).toThrow(
+      /not a valid port/
+    )
   })
 })
 
@@ -153,18 +174,24 @@ describe('k8s runtime plane assembly', () => {
       deleted.push(name)
     }
     const plane = await planeUnderTest(api)
-    const port = plane.listener.listeningPort()!
+    const port = shimPort(plane)
 
-    // A shim that answers `probe` the way the image's generator does.
     const probing = plane.probeRuntimes()
+    let requested: () => void = () => {}
+    const inFlight = new Promise<void>((resolve) => (requested = resolve))
+    let answer: (table: unknown) => void = () => {}
+    const generated = new Promise<unknown>((resolve) => (answer = resolve))
     shimAgainst(port, {
-      probe: { runtimes: [{ id: 'claude-acp', version: '0.66.0', acp: { protocolVersion: 1 } }] }
+      probe: () => {
+        requested()
+        return generated
+      }
     })
+    await inFlight
+    expect(plane.dialer.connectionsFor('ac-runtime-probe')[0]?.binding.grants ?? []).toEqual(['probe'])
+    answer({ runtimes: [{ id: 'claude-acp', version: '0.66.0', acp: { protocolVersion: 1 } }] })
     const table = await probing
     expect(table.runtimes.map((entry) => `${entry.id}@${entry.version}`)).toEqual(['claude-acp@0.66.0'])
-    // The probe sandbox runs no runtime and touches no workspace, so it gets ONE channel. Granting
-    // it the runtime set would hand a throwaway pod exec, materialize and tunnel for no reason.
-    expect(plane.listener.connectionsFor('ac-runtime-probe')[0]?.binding.grants ?? []).toEqual(['probe'])
     // And the probe sandbox is gone: one leaked pod per daemon restart would be a slow leak that
     // nothing else cleans up.
     expect(deleted).toContain('agent-ac-runtime-probe')
@@ -176,7 +203,7 @@ describe('k8s runtime plane assembly', () => {
     // probe — and a daemon that failed its probe advertises no runtimes and does not retry.
     const api = fakeApi()
     const plane = await planeUnderTest(api)
-    const port = plane.listener.listeningPort()!
+    const port = shimPort(plane)
 
     const probing = plane.probeRuntimes()
     // A shim that has dialled in and is still generating its table. Waiting for the REQUEST rather
@@ -206,12 +233,12 @@ describe('k8s runtime plane assembly', () => {
     // sandbox existed would clone on the daemon's disk and hand the runtime an empty workspace.
     const api = fakeApi()
     const plane = await planeUnderTest(api)
-    const port = plane.listener.listeningPort()!
+    const port = shimPort(plane)
     const ensuring = plane.ensureChannel('agent-a')
     shimAgainst(port, { workspaceRoot: '/agent' })
     await ensuring
     // A channel, a session behind the workspace seam, and NO runtime started.
-    expect(plane.listener.connectionsFor('agent-a')).toHaveLength(1)
+    expect(plane.dialer.connectionsFor('agent-a')).toHaveLength(1)
     expect(plane.gitRunnerFor('agent-a', '/agent')).toBeDefined()
     // The same condition, readable on its own: the credential pointers git will read are built
     // from this, so an answer that disagreed with the runner would describe the wrong filesystem.
@@ -227,7 +254,7 @@ describe('k8s runtime plane assembly', () => {
     // Sandbox named, and warm-pool adoption means that name is the pool's, not the sandbox's.
     const api = fakeApi()
     const plane = await planeUnderTest(api)
-    const port = plane.listener.listeningPort()!
+    const port = shimPort(plane)
 
     // Publishing happens inside launch(); drive it far enough to publish, then dial.
     const launching = plane.driver.launch({
@@ -239,20 +266,20 @@ describe('k8s runtime plane assembly', () => {
     shimAgainst(port)
 
     const connection = await Promise.race([
-      launching.then(() => plane.listener.connectionsFor('agent-a')[0]),
+      launching.then(() => plane.dialer.connectionsFor('agent-a')[0]),
       new Promise((resolve) => setTimeout(() => resolve(undefined), 15_000))
     ])
     expect(connection).toBeDefined()
-    expect(plane.listener.connectionsFor('agent-a')[0]?.binding.podName).toBe(api.podName)
+    expect(plane.dialer.connectionsFor('agent-a')[0]?.binding.podName).toBe(api.podName)
   })
 
   it('survives a shim reconnect: a closed socket is not a lost launch', async () => {
-    // The shim closes and re-dials at half the credential TTL, and `ShimSession.lose()` is
+    // The shim closes at half the credential TTL and the daemon reconnects; `ShimSession.lose()` is
     // terminal — so reporting loss on every socket close killed the runtime on each routine
     // renewal, which is the exact failure ShimSession was built to prevent.
     const api = fakeApi()
     const plane = await planeUnderTest(api)
-    const port = plane.listener.listeningPort()!
+    const port = shimPort(plane)
     const launching = plane.driver.launch({
       command: 'x',
       args: [],
@@ -265,9 +292,9 @@ describe('k8s runtime plane assembly', () => {
 
     // Drop the socket the way a renewal does, then let a replacement bind.
     first.stop()
-    expect(await until(() => plane.listener.connectionsFor('agent-a').length === 0)).toBe(true)
+    expect(await until(() => plane.dialer.connectionsFor('agent-a').length === 0)).toBe(true)
     shimAgainst(port)
-    expect(await until(() => plane.listener.connectionsFor('agent-a').length > 0)).toBe(true)
+    expect(await until(() => plane.dialer.connectionsFor('agent-a').length > 0)).toBe(true)
     // The seam still works, which it would not if the session had been closed on the drop.
     expect(await until(() => plane.gitRunnerFor('agent-a') !== undefined)).toBe(true)
   })
@@ -279,7 +306,7 @@ describe('k8s runtime plane assembly', () => {
     // than fail — a self-hosted agent beside a cluster-backed one depends on that.
     expect(plane.gitRunnerFor('agent-a')).toBeUndefined()
 
-    const port = plane.listener.listeningPort()!
+    const port = shimPort(plane)
     const launching = plane.driver.launch({
       command: 'x',
       args: [],
@@ -297,7 +324,7 @@ describe('k8s runtime plane assembly', () => {
     api.api.deleteClaim = async (name: string) => void deleted.push(name)
     const plane = await planeUnderTest(api)
 
-    const port = plane.listener.listeningPort()!
+    const port = shimPort(plane)
     const launching = plane.driver.launch({
       command: 'x',
       args: [],

--- a/packages/daemon/test/shim-dial-in.test.ts
+++ b/packages/daemon/test/shim-dial-in.test.ts
@@ -34,6 +34,14 @@ async function sandbox(options: { handle?: (capability: string, payload: unknown
   return { endpoint: `ws://127.0.0.1:${port}`, client }
 }
 
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('condition not met in time')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
 function record(generation = 1): SpawnRecord {
   return {
     agentId: 'agent-a',
@@ -96,6 +104,37 @@ describe('sandbox shim dial-in', () => {
     dialers.push(dialer)
 
     await expect(dialer.connect(endpoint, record(), 1)).rejects.toThrow(/pod identity|not accepted|connect/)
+    expect(dialer.connectionsFor('agent-a')).toEqual([])
+  })
+
+  it('waits for the replacement connection while a bound channel is reconnecting', async () => {
+    const { endpoint } = await sandbox()
+    const dialer = new ShimDialer({
+      verifier: {
+        reviewToken: async () => ({ authenticated: true, podName: 'sandbox-pod-1', podUid: 'pod-uid-1' })
+      },
+      log: { info: () => {}, warn: () => {} }
+    })
+    dialers.push(dialer)
+
+    const first = await dialer.connect(endpoint, record(), 8_000)
+    first.close('force reconnect')
+    await waitFor(() => dialer.connectionsFor('agent-a').length === 0)
+
+    const replacement = await dialer.connect(endpoint, record(), 8_000)
+    expect(replacement).not.toBe(first)
+    expect(dialer.connectionsFor('agent-a')).toEqual([replacement])
+  }, 10_000)
+
+  it('times out an accepted socket whose identity verification never completes', async () => {
+    const { endpoint } = await sandbox()
+    const dialer = new ShimDialer({
+      verifier: { reviewToken: () => new Promise(() => {}) },
+      log: { info: () => {}, warn: () => {} }
+    })
+    dialers.push(dialer)
+
+    await expect(dialer.connect(endpoint, record(), 25)).rejects.toThrow(/binding timed out/)
     expect(dialer.connectionsFor('agent-a')).toEqual([])
   })
 })

--- a/packages/daemon/test/shim-dial-in.test.ts
+++ b/packages/daemon/test/shim-dial-in.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ShimClient, type ShimTransport } from '../src/shim/client.js'
+import { ShimDialer } from '../src/shim/dialer.js'
+import { ShimServer } from '../src/shim/server.js'
+import { ShimSession } from '../src/shim/session.js'
+import type { SpawnRecord } from '../src/shim/binding.js'
+import { SHIM_TOKEN_AUDIENCE } from '../src/shim/protocol.js'
+
+const clients: ShimClient[] = []
+const dialers: ShimDialer[] = []
+const servers: ShimServer[] = []
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) client.stop()
+  for (const dialer of dialers.splice(0)) dialer.stop()
+  await Promise.all(servers.splice(0).map((server) => server.stop()))
+})
+
+async function sandbox(options: { handle?: (capability: string, payload: unknown) => Promise<unknown> } = {}) {
+  const server = new ShimServer()
+  servers.push(server)
+  const port = await server.start(0, '127.0.0.1')
+  const client = new ShimClient({
+    endpoint: 'accepted-daemon-channel',
+    acceptDialIn: true,
+    dial: () => server.nextTransport() as Promise<ShimTransport>,
+    readToken: () => 'projected-token',
+    workspaceRoot: '/agent',
+    ...(options.handle ? { handle: options.handle as never } : {}),
+    log: { info: () => {}, warn: () => {} }
+  })
+  clients.push(client)
+  void client.start().catch(() => undefined)
+  return { endpoint: `ws://127.0.0.1:${port}`, client }
+}
+
+function record(generation = 1): SpawnRecord {
+  return {
+    agentId: 'agent-a',
+    sandboxUid: 'sandbox-uid-1',
+    generation,
+    grants: ['materialize'],
+    podName: 'sandbox-pod-1'
+  }
+}
+
+describe('sandbox shim dial-in', () => {
+  it('lets the daemon dial a pod IP, TokenReviews its identity, and serves a granted request', async () => {
+    const served: unknown[] = []
+    const { endpoint } = await sandbox({
+      handle: async (_capability, payload) => {
+        served.push(payload)
+        return { written: true }
+      }
+    })
+    const reviewToken = vi.fn(async () => ({
+      authenticated: true,
+      podName: 'sandbox-pod-1',
+      podUid: 'pod-uid-1'
+    }))
+    const dialer = new ShimDialer({
+      verifier: { reviewToken },
+      log: { info: () => {}, warn: () => {} }
+    })
+    dialers.push(dialer)
+
+    const connection = await dialer.connect(endpoint, record(), 5_000)
+    const session = new ShimSession('agent-a', 1, {
+      setTimeout: (fn, ms) => setTimeout(fn, ms),
+      clearTimeout: (handle) => clearTimeout(handle as NodeJS.Timeout)
+    })
+    session.attach(connection)
+
+    await expect(session.request('materialize', { path: 'config.json' })).resolves.toEqual({ written: true })
+    expect(served).toEqual([{ path: 'config.json' }])
+    expect(reviewToken).toHaveBeenCalledWith('projected-token', [SHIM_TOKEN_AUDIENCE])
+    expect(connection.binding).toMatchObject({ podName: 'sandbox-pod-1', podUid: 'pod-uid-1', generation: 1 })
+    expect(connection.workspaceRoot).toBe('/agent')
+    expect(
+      dialer.authorize({
+        credential: connection.issuedCredential,
+        generation: 1,
+        capability: 'materialize'
+      }).ok
+    ).toBe(true)
+  })
+
+  it('refuses a pod whose reviewed identity does not match the Pod IP launch record', async () => {
+    const { endpoint } = await sandbox()
+    const dialer = new ShimDialer({
+      verifier: {
+        reviewToken: async () => ({ authenticated: true, podName: 'different-pod', podUid: 'pod-uid-2' })
+      },
+      log: { info: () => {}, warn: () => {} }
+    })
+    dialers.push(dialer)
+
+    await expect(dialer.connect(endpoint, record(), 1)).rejects.toThrow(/pod identity|not accepted|connect/)
+    expect(dialer.connectionsFor('agent-a')).toEqual([])
+  })
+})

--- a/packages/daemon/test/shim-tunnel.test.ts
+++ b/packages/daemon/test/shim-tunnel.test.ts
@@ -4,9 +4,10 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { createConnection, createServer, Socket, type Server } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { Backoff, ClientTransport, FakeClock } from '@agentconnect.md/connection'
+import { Backoff, FakeClock } from '@agentconnect.md/connection'
 import { startK8sRuntimePlane, type K8sRuntimePlane } from '../src/k8s/runtime-plane.js'
 import { ShimClient, type ShimTransport } from '../src/shim/client.js'
+import { ShimServer } from '../src/shim/server.js'
 import { TunnelHost } from '../src/shim/tunnel-host.js'
 import { TunnelProxy } from '../src/shim/tunnel-proxy.js'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
@@ -31,17 +32,17 @@ import type { TunnelName } from '../src/shim/tunnel.js'
 const planes: K8sRuntimePlane[] = []
 const clients: ShimClient[] = []
 const servers: Server[] = []
+const shimServers: ShimServer[] = []
 const hosts: TunnelHost[] = []
 const sockets: Socket[] = []
 const dirs: string[] = []
-const intervals: NodeJS.Timeout[] = []
 
 afterEach(async () => {
-  for (const timer of intervals.splice(0)) clearInterval(timer)
   for (const socket of sockets.splice(0)) socket.destroy()
   for (const host of hosts.splice(0)) host.close()
   for (const client of clients.splice(0)) client.stop()
   for (const plane of planes.splice(0)) await plane.stop()
+  for (const server of shimServers.splice(0)) await server.stop()
   await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))))
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
 })
@@ -62,7 +63,7 @@ function fakeApi() {
   const sandbox = {
     metadata: { name: 'sb-1', uid: 'sandbox-uid-1', annotations: { 'agents.x-k8s.io/pod-name': 'pool-pod-9' } },
     spec: { operatingMode: 'Running' as const },
-    status: { conditions: [{ type: 'Ready', status: 'True' }] }
+    status: { conditions: [{ type: 'Ready', status: 'True' }], podIPs: ['127.0.0.1'] }
   } satisfies Sandbox
   let claim: SandboxClaim | undefined
   return {
@@ -128,11 +129,13 @@ async function clusterWithTunnel(
   const warnings: string[] = []
   const shimClock = new FakeClock()
   const podSocketPath = join(scratchDir(), 'pod-gitcred.sock')
+  const shimServer = new ShimServer()
+  const shimPort = await shimServer.start(0, '127.0.0.1')
+  shimServers.push(shimServer)
   const plane = await startK8sRuntimePlane({
     orgId: 'org-1',
     warmPoolName: 'pool',
-    shimPort: 0,
-    shimHost: '127.0.0.1',
+    shimPort,
     readyTimeoutMs: 15_000,
     api: fakeApi() as never,
     tunnelsFor: () => options.tunnels ?? ['gitcred'],
@@ -141,7 +144,12 @@ async function clusterWithTunnel(
     log: { info: () => {}, warn: (message) => warnings.push(message), debug: () => {} }
   })
   planes.push(plane)
-  const port = plane.listener.listeningPort()!
+  let binds = 0
+  const onBound = plane.driver.onChannelBound.bind(plane.driver)
+  plane.driver.onChannelBound = (connection) => {
+    binds += 1
+    onBound(connection)
+  }
 
   const ensuring = plane.ensureChannel('agent-a')
   const host = new TunnelHost({
@@ -151,9 +159,9 @@ async function clusterWithTunnel(
   })
   hosts.push(host)
   const client = new ShimClient({
-    endpoint: `ws://127.0.0.1:${port}`,
-    dial: (url, opts) =>
-      ClientTransport.dial(url, { subprotocol: opts.subprotocol, path: opts.path }) as Promise<ShimTransport>,
+    endpoint: 'accepted-daemon-channel',
+    acceptDialIn: true,
+    dial: () => shimServer.nextTransport() as Promise<ShimTransport>,
     readToken: () => 'projected-token',
     handle: async (capability, payload) => {
       if (capability !== 'tunnel') throw new Error(`unexpected capability ${capability}`)
@@ -169,18 +177,7 @@ async function clusterWithTunnel(
   clients.push(client)
   void client.start()
   await ensuring
-  // Whoever owns the listener re-attaches a rebound channel; the daemon does that in production,
-  // and this stands in for it so a renewal reaches the driver's session.
-  const seen: unknown[] = []
-  const watch = setInterval(() => {
-    for (const connection of plane.listener.connectionsFor('agent-a')) {
-      if (seen.includes(connection)) continue
-      seen.push(connection)
-      plane.driver.onChannelBound(connection)
-    }
-  }, 10)
-  intervals.push(watch)
-  return { plane, podSocketPath, warnings, shimClock, bindCount: () => seen.length }
+  return { plane, podSocketPath, warnings, shimClock, bindCount: () => binds }
 }
 
 /**
@@ -289,7 +286,7 @@ describe('the shim tunnel', () => {
 
   it('keeps a live connection working across a real credential renewal', async () => {
     // The pod's listener and its open connections belong to the POD, not to a channel: the shim
-    // re-dials at half the credential TTL, and a helper that was mid-conversation must not care.
+    // reconnects at half the credential TTL, and a helper that was mid-conversation must not care.
     const daemonSocketPath = daemonSideServer((chunk, socket) => socket.write(`echo:${chunk.toString('utf8')}`))
     const { podSocketPath, shimClock, bindCount } = await clusterWithTunnel({
       daemonSocketPath,
@@ -311,7 +308,7 @@ describe('the shim tunnel', () => {
   }, 40_000)
 
   it('ends an interrupted stream through the real renewal, so the pod client sees EOF', async () => {
-    // The production ordering, which a stubbed session cannot show: `ShimListener` used to announce
+    // The production ordering, which a stubbed session cannot show: the old listener announced
     // a new connection BEFORE sending `shim/bound`, so the daemon's cleanup of an interrupted
     // stream reached a shim that had no binding yet and was refused as `not bound` — with the
     // stream already dropped on this side, leaving the in-pod client waiting on nothing.

--- a/packages/operator/src/reconcile/envelope.test.ts
+++ b/packages/operator/src/reconcile/envelope.test.ts
@@ -134,6 +134,9 @@ describe('reconcileEnvelope', () => {
 
     expect(byPath(writes, '/networkpolicies/ac-daemon-egress')).toBeDefined()
     expect(byPath(writes, '/networkpolicies/ac-daemon-ingress')).toBeDefined()
+    expect(
+      (byPath(writes, '/networkpolicies/ac-daemon-ingress')?.body as { spec: { ingress: unknown[] } }).spec.ingress
+    ).toEqual([])
 
     // Without this the daemon's registration WebSocket to an in-cluster control plane
     // never completes — its service port is not 443.
@@ -150,14 +153,22 @@ describe('reconcileEnvelope', () => {
 
     const template = byPath(writes, `/namespaces/${NS}/sandboxtemplates/ac-runtime-std`)?.body as {
       spec: {
-        podTemplate: { spec: { containers: Array<{ image: string; env: Array<{ name: string; value: string }> }> } }
+        podTemplate: {
+          spec: {
+            containers: Array<{
+              image: string
+              env: Array<{ name: string; value: string }>
+              ports: Array<{ name: string; containerPort: number; protocol: string }>
+            }>
+          }
+        }
       }
     }
     const container = template.spec.podTemplate.spec.containers[0]
     expect(container.image).toBe('ghcr.io/example/runtime:v1')
-    expect(container.env.find((entry) => entry.name === 'AC_SHIM_ENDPOINT')?.value).toBe(
-      `ws://ac-daemon-shim.${NS}.svc.cluster.local:8085`
-    )
+    expect(container.env.find((entry) => entry.name === 'AC_SHIM_ENDPOINT')).toBeUndefined()
+    expect(container.env.find((entry) => entry.name === 'AC_SHIM_PORT')?.value).toBe('8085')
+    expect(container.ports).toContainEqual({ name: 'shim', containerPort: 8085, protocol: 'TCP' })
 
     const pool = byPath(writes, '/sandboxwarmpools/ac-runtime-std')?.body as { spec: { replicas: number } }
     expect(pool.spec.replicas).toBe(2)
@@ -205,7 +216,7 @@ describe('reconcileEnvelope', () => {
     expect(JSON.stringify(deployment.spec.template.spec)).not.toContain('install-config')
     expect(JSON.stringify(deployment.spec.template.spec.volumes)).not.toContain('secret')
 
-    expect(byPath(writes, '/services/ac-daemon-shim')).toBeDefined()
+    expect(byPath(writes, '/services/ac-daemon-shim')?.method).toBe('DELETE')
   })
 
   // A control plane in another namespace is reachable only if the policy says so, and a
@@ -224,7 +235,7 @@ describe('reconcileEnvelope', () => {
         to: [{ namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': namespace } } }]
       })
     }
-    expect(egress.spec.egress.filter((rule) => rule.to)).toHaveLength(2)
+    expect(egress.spec.egress.filter((rule) => rule.to?.some((peer) => peer.namespaceSelector))).toHaveLength(2)
   })
 
   it('names no namespace at all when the install has no in-cluster peer', async () => {
@@ -236,7 +247,9 @@ describe('reconcileEnvelope', () => {
     const egress = byPath(writes, '/networkpolicies/ac-daemon-egress')?.body as {
       spec: { egress: Array<{ to?: unknown[]; ports?: Array<{ port: number }> }> }
     }
-    expect(egress.spec.egress.filter((rule) => rule.to)).toEqual([])
+    expect(egress.spec.egress.every((rule) => rule.to?.every((peer) => !('namespaceSelector' in peer)) ?? true)).toBe(
+      true
+    )
     // A control plane outside the cluster is already covered by the 443 rule.
     expect(egress.spec.egress.some((rule) => rule.ports?.some((port) => port.port === 443))).toBe(true)
   })
@@ -411,14 +424,37 @@ describe('reconcileEnvelope', () => {
     expect(writes.filter((write) => write.method === 'DELETE' && write.path.includes('ac-runtime-std'))).toEqual([])
   })
 
-  it('locked egress restricts the sandbox template to daemon and DNS', async () => {
+  it('locked sandbox networking admits only daemon dial-in and DNS egress', async () => {
     const { gets, writes, route } = recorder()
     const ctx = await contextFor(route)
     gets.set(masterPath(ctx.controlNamespace), MASTER_TEMPLATE)
     await reconcileEnvelope(ctx, inputOf(ctx, { egressPolicy: 'locked' }), newObservations())
     const template = byPath(writes, `/namespaces/${NS}/sandboxtemplates/ac-runtime-std`)?.body as {
-      spec: { networkPolicy: { egress: unknown[] } }
+      spec: { networkPolicy: { ingress: unknown[]; egress: unknown[] } }
     }
-    expect(template.spec.networkPolicy.egress).toHaveLength(2)
+    expect(template.spec.networkPolicy).toEqual({
+      ingress: [
+        {
+          from: [
+            { podSelector: { matchLabels: { app: 'ac-daemon' } } },
+            {
+              namespaceSelector: {
+                matchLabels: { 'kubernetes.io/metadata.name': ctx.controlNamespace }
+              },
+              podSelector: { matchLabels: { app: 'ac-daemon' } }
+            }
+          ],
+          ports: [{ protocol: 'TCP', port: 8085 }]
+        }
+      ],
+      egress: [
+        {
+          ports: [
+            { protocol: 'UDP', port: 53 },
+            { protocol: 'TCP', port: 53 }
+          ]
+        }
+      ]
+    })
   })
 })

--- a/packages/operator/src/reconcile/envelope.ts
+++ b/packages/operator/src/reconcile/envelope.ts
@@ -201,6 +201,10 @@ export async function ensureNetworkPolicies(
         ...ctx.config.daemonEgressNamespaces.map((namespace) => ({
           to: [{ namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': namespace } } }]
         })),
+        {
+          to: [{ podSelector: { matchExpressions: [{ key: 'agentconnect.md/agent', operator: 'Exists' }] } }],
+          ports: [{ protocol: 'TCP', port: SHIM_PORT }]
+        },
         // 443 covers platform and provider APIs, plus a CP reached over public HTTPS.
         { ports: [{ protocol: 'TCP', port: 443 }] },
         { ports: [{ protocol: 'TCP', port: 6443 }] }
@@ -214,14 +218,7 @@ export async function ensureNetworkPolicies(
     spec: {
       ...daemonPods,
       policyTypes: ['Ingress'],
-      ingress: [
-        // Shim dial-in from this org's sandboxes plus relay forward from the control namespace.
-        { from: [{ podSelector: {} }], ports: [{ protocol: 'TCP', port: SHIM_PORT }] },
-        {
-          from: [{ namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': ctx.controlNamespace } } }],
-          ports: [{ protocol: 'TCP', port: SHIM_PORT }]
-        }
-      ]
+      ingress: []
     }
   })
   void obs
@@ -277,7 +274,14 @@ interface SandboxTemplateResource extends K8sResource {
   spec?: {
     networkPolicy?: unknown
     podTemplate?: {
-      spec?: { containers?: Array<{ name?: string; image?: string; env?: Array<{ name: string; value?: string }> }> }
+      spec?: {
+        containers?: Array<{
+          name?: string
+          image?: string
+          env?: Array<{ name: string; value?: string }>
+          ports?: Array<{ name?: string; containerPort: number; protocol?: string }>
+        }>
+      }
     }
     [key: string]: unknown
   }
@@ -285,11 +289,7 @@ interface SandboxTemplateResource extends K8sResource {
 
 /** The sandbox egress rule set for one org, keyed by spec.egressPolicy. */
 function sandboxEgress(policy: AgentConnectOrgSpec['egressPolicy']): unknown[] {
-  const daemonAndDns = [
-    {
-      to: [{ podSelector: { matchLabels: { [APP_LABEL_KEY]: DAEMON_NAME } } }],
-      ports: [{ protocol: 'TCP', port: SHIM_PORT }]
-    },
+  const dns = [
     {
       ports: [
         { protocol: 'UDP', port: 53 },
@@ -297,8 +297,8 @@ function sandboxEgress(policy: AgentConnectOrgSpec['egressPolicy']): unknown[] {
       ]
     }
   ]
-  if (policy === 'locked') return daemonAndDns
-  if (policy === 'curated') return [...daemonAndDns, { ports: [{ protocol: 'TCP', port: 443 }] }]
+  if (policy === 'locked') return dns
+  if (policy === 'curated') return [...dns, { ports: [{ protocol: 'TCP', port: 443 }] }]
   return [{}]
 }
 
@@ -323,14 +323,34 @@ export async function ensureSandboxTemplates(
     const container = spec.podTemplate?.spec?.containers?.[0]
     if (container) {
       container.image = input.spec.runtime.image
-      const endpoint = `ws://${SHIM_SERVICE_NAME}.${ns}.svc.cluster.local:${SHIM_PORT}`
-      const env = (container.env ??= [])
-      const shim = env.find((entry) => entry.name === 'AC_SHIM_ENDPOINT')
-      if (shim) shim.value = endpoint
-      else env.push({ name: 'AC_SHIM_ENDPOINT', value: endpoint })
+      const env = (container.env ??= []).filter((entry) => entry.name !== 'AC_SHIM_ENDPOINT')
+      container.env = env
+      const shimPort = env.find((entry) => entry.name === 'AC_SHIM_PORT')
+      if (shimPort) shimPort.value = String(SHIM_PORT)
+      else env.push({ name: 'AC_SHIM_PORT', value: String(SHIM_PORT) })
+      const ports = (container.ports ??= [])
+      const declared = ports.find((entry) => entry.name === 'shim')
+      if (declared) declared.containerPort = SHIM_PORT
+      else ports.push({ name: 'shim', containerPort: SHIM_PORT, protocol: 'TCP' })
     }
-    // The org's egress tier overrides the master's networkPolicy wholesale — deterministic, not merged.
-    spec.networkPolicy = { egress: sandboxEgress(input.spec.egressPolicy) }
+    // Transitional policy: dedicated daemon or install-level pool, always daemon-labelled and port-scoped.
+    spec.networkPolicy = {
+      ingress: [
+        {
+          from: [
+            { podSelector: { matchLabels: { [APP_LABEL_KEY]: DAEMON_NAME } } },
+            {
+              namespaceSelector: {
+                matchLabels: { 'kubernetes.io/metadata.name': ctx.controlNamespace }
+              },
+              podSelector: { matchLabels: { [APP_LABEL_KEY]: DAEMON_NAME } }
+            }
+          ],
+          ports: [{ protocol: 'TCP', port: SHIM_PORT }]
+        }
+      ],
+      egress: sandboxEgress(input.spec.egressPolicy)
+    }
     const name = runtimeTierName(tier.name)
     await applyObject(ctx.http, groupPath(SANDBOX_EXTENSIONS_GROUP, ns, 'sandboxtemplates', name), {
       apiVersion: SANDBOX_EXTENSIONS_GROUP,
@@ -446,7 +466,6 @@ export async function ensureDaemonDeployment(
                 { name: 'AC_K8S_SHIM_PORT', value: String(SHIM_PORT) },
                 ...(controlPlaneUrl ? [{ name: CP_URL_ENV, value: controlPlaneUrl }] : [])
               ],
-              ports: [{ name: 'shim', containerPort: SHIM_PORT }],
               volumeMounts: [
                 { name: 'state', mountPath: stateRoot },
                 { name: 'cp-identity', mountPath: identityTokenDir, readOnly: true }
@@ -480,23 +499,9 @@ export async function ensureDaemonDeployment(
   })
 }
 
-/** Daemon Service for relay ingress and shim dial-in. */
-export async function ensureDaemonService(
-  ctx: ReconcileContext,
-  input: EnvelopeInputs,
-  obs: Observations
-): Promise<void> {
-  const ns = input.namespace
-  await applyObject(ctx.http, corePath(ns, 'services', SHIM_SERVICE_NAME), {
-    apiVersion: 'v1',
-    kind: 'Service',
-    metadata: { name: SHIM_SERVICE_NAME, namespace: ns, labels: envelopeLabels(input.orgName) },
-    spec: {
-      selector: { [APP_LABEL_KEY]: DAEMON_NAME },
-      ports: [{ name: 'shim', port: SHIM_PORT, targetPort: 'shim', protocol: 'TCP' }]
-    }
-  })
-  void obs
+/** Remove the dial-out callback Service left by an older envelope. */
+export async function removeLegacyDaemonService(ctx: ReconcileContext, input: EnvelopeInputs): Promise<void> {
+  await deleteIgnoreMissing(ctx.http, corePath(input.namespace, 'services', SHIM_SERVICE_NAME))
 }
 
 /** The full envelope inventory in its policy-before-workload order (see the operator design doc). */
@@ -516,5 +521,5 @@ export async function reconcileEnvelope(
   await ensureSandboxTemplates(ctx, input, obs)
   await ensureDaemonPvc(ctx, input, obs)
   await ensureDaemonDeployment(ctx, input, obs)
-  await ensureDaemonService(ctx, input, obs)
+  await removeLegacyDaemonService(ctx, input)
 }


### PR DESCRIPTION
## Summary

- turn the runtime sandbox shim into a bounded WebSocket listener
- make the cluster daemon wait for the ready Sandbox Pod IP and dial the shim directly
- preserve TokenReview, generation fencing, capability grants, credential renewal, and reconnect behavior
- update runtime image configuration and operator NetworkPolicies for dedicated and cross-namespace pool daemons
- remove the legacy daemon shim callback Service and document the migration

## Why

The cloud daemon pool design cannot have a sandbox choose a daemon callback endpoint because ownership belongs to the current duty holder. The daemon must initiate the execution connection so ingress ownership and sandbox execution stay co-located.

## Impact

Sandbox images now listen on `AC_SHIM_PORT` (default 8085) instead of reading `AC_SHIM_ENDPOINT`. Cluster daemons use `Sandbox.status.podIPs` to connect. During migration, sandbox ingress permits daemon-labelled pods in the dedicated namespace or install control/pool namespace, only on TCP 8085.

## Validation

- daemon and operator typecheck
- daemon shim/cluster tests: 132 passed
- operator envelope/finalizer tests: 26 passed
- full daemon and operator builds
- ESLint and formatting checks
- self-contained shim bundle verification
- real runtime-sandbox image smoke: daemon dial, TokenReview bind, ACP initialize, and session/new
