### PR TITLE
feat(daemon): persist cloud transcripts in PostgreSQL

### DIFF
--- a/docs/designs/cloud-data-plane-postgres.md
+++ b/docs/designs/cloud-data-plane-postgres.md
@@ -28,4 +28,4 @@ Migration rules:
 3. Add nullable columns or a compatible default before readers require them; destructive cleanup belongs in a later release.
 4. Exercise the shared-schema integration test with `DATA_PLANE_TEST_DATABASE_URL` before release.
 
-The PostgreSQL transcript tables preserve the SQLite transcript's insertion sequence, mutation revision, per-agent recipients, tool bodies, attachment/quote sidecars, and chronological event-time index. Sequence and revision allocation happen in PostgreSQL, so concurrent daemon members do not mint colliding cursors.
+The PostgreSQL transcript tables preserve the SQLite transcript's insertion sequence, mutation revision, per-agent recipients, tool bodies, attachment/quote sidecars, and chronological event-time index. Transcript mutation transactions hold a per-org advisory lock while assigning revisions, making revision order commit-safe across daemon members. History pages and their terminal revision watermark come from one repeatable-read snapshot, so a concurrent commit cannot be skipped by the next live cursor.

--- a/docs/designs/cloud-data-plane-postgres.md
+++ b/docs/designs/cloud-data-plane-postgres.md
@@ -1,0 +1,31 @@
+# Cloud daemon data-plane PostgreSQL
+
+Cloud daemons started with `--k8s` require a data-plane PostgreSQL connection. Local and self-hosted daemons keep SQLite and never read this configuration.
+
+The daemon accepts no database CLI flag or environment variable. The deployment must mount a Kubernetes Secret at `/var/run/ac-data-plane/config.json`:
+
+```json
+{
+  "version": 1,
+  "databaseUrl": "postgresql://daemon:password@data-plane-postgres:5432/agentconnect",
+  "schema": "org_01abc234",
+  "maxConnections": 4
+}
+```
+
+`databaseUrl` is an install-level execution-data credential. `schema` is the org locator supplied by deployment orchestration. Every daemon may connect to the same database, but each org uses a separate schema; store queries set `search_path` to exactly that validated schema. The connection file should therefore be mounted from a Secret, not a ConfigMap.
+
+The daemon refuses `--k8s` startup when the file is absent, invalid, unreachable, or cannot be migrated. Non-Kubernetes startup does not inspect the file, even if it exists.
+
+## Schema upgrades
+
+Data-plane migrations are independent from the Control Plane Prisma migrations. Each org schema contains `_agentconnect_schema_migrations`. First touch runs pending migrations inside one transaction while holding a transaction-scoped PostgreSQL advisory lock derived from the schema name. This makes concurrent first touch by several daemon members safe. A migration failure rolls back startup; a schema newer than the daemon is refused.
+
+Migration rules:
+
+1. Append a migration; never edit one already released.
+2. Keep each version transactional and safe under a rolling deployment.
+3. Add nullable columns or a compatible default before readers require them; destructive cleanup belongs in a later release.
+4. Exercise the shared-schema integration test with `DATA_PLANE_TEST_DATABASE_URL` before release.
+
+The PostgreSQL transcript tables preserve the SQLite transcript's insertion sequence, mutation revision, per-agent recipients, tool bodies, attachment/quote sidecars, and chronological event-time index. Sequence and revision allocation happen in PostgreSQL, so concurrent daemon members do not mint colliding cursors.

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -61,6 +61,7 @@
     "discord.js": "^14.27.0",
     "fflate": "^0.8.3",
     "grammy": "^1.45.1",
+    "pg": "^8.22.0",
     "simple-git": "^3.36.0",
     "skills": "1.5.21",
     "systeminformation": "^5.33.1",
@@ -73,6 +74,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
+    "@types/pg": "^8.20.0",
     "@types/ws": "^8.18.1",
     "json": "^11.0.0",
     "tsdown": "^0.22.14",

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -1269,14 +1269,15 @@ export class CpClient {
         return
       }
       case 'session/history': {
-        try {
-          const req = frame.payload as SessionHistoryReq
-          if (!req.agentId)
-            this.deps.log.warn('cp: legacy session/history request omitted agentId; owner binding is unavailable')
-          this.reply(frame, 'session/history/page', this.deps.sessionRead.history(req))
-        } catch (err) {
-          this.sendError(frame.id, 'INTERNAL', `session/history failed: ${(err as Error).message}`, false)
-        }
+        const req = frame.payload as SessionHistoryReq
+        if (!req.agentId)
+          this.deps.log.warn('cp: legacy session/history request omitted agentId; owner binding is unavailable')
+        Promise.resolve()
+          .then(() => this.deps.sessionRead.history(req))
+          .then((page) => this.reply(frame, 'session/history/page', page))
+          .catch((err) =>
+            this.sendError(frame.id, 'INTERNAL', `session/history failed: ${(err as Error).message}`, false)
+          )
         return
       }
       case 'session/child-status/probe': {
@@ -1292,14 +1293,15 @@ export class CpClient {
         return
       }
       case 'session/tool-body': {
-        try {
-          const req = frame.payload as SessionToolBodyReq
-          if (!req.agentId)
-            this.deps.log.warn('cp: legacy session/tool-body request omitted agentId; owner binding is unavailable')
-          this.reply(frame, 'session/tool-body/chunk', this.deps.sessionRead.toolBody(req))
-        } catch (err) {
-          this.sendError(frame.id, 'INTERNAL', `session/tool-body failed: ${(err as Error).message}`, false)
-        }
+        const req = frame.payload as SessionToolBodyReq
+        if (!req.agentId)
+          this.deps.log.warn('cp: legacy session/tool-body request omitted agentId; owner binding is unavailable')
+        Promise.resolve()
+          .then(() => this.deps.sessionRead.toolBody(req))
+          .then((chunk) => this.reply(frame, 'session/tool-body/chunk', chunk))
+          .catch((err) =>
+            this.sendError(frame.id, 'INTERNAL', `session/tool-body failed: ${(err as Error).message}`, false)
+          )
         return
       }
       case 'workspace/list': {

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -187,8 +187,23 @@ function previewBody(full: ToolBody): ToolBody {
 
 export interface SessionReader {
   list(req: SessionListReq): SessionListPage
-  history(req: SessionHistoryReq): SessionHistoryPage
-  toolBody(req: SessionToolBodyReq): SessionToolBodyChunk
+  history(req: SessionHistoryReq): SessionHistoryPage | Promise<SessionHistoryPage>
+  toolBody(req: SessionToolBodyReq): SessionToolBodyChunk | Promise<SessionToolBodyChunk>
+}
+
+type TranscriptReadStore = Pick<
+  LocalStore,
+  | 'transcriptTailForAgent'
+  | 'transcriptPageForAgentByEventTime'
+  | 'transcriptPageForAgent'
+  | 'currentTranscriptRevision'
+  | 'getToolBodyForAgent'
+>
+
+type AsyncTranscriptReadStore = {
+  [Method in keyof TranscriptReadStore]: (
+    ...args: Parameters<TranscriptReadStore[Method]>
+  ) => Promise<ReturnType<TranscriptReadStore[Method]>>
 }
 
 /**
@@ -198,7 +213,8 @@ export interface SessionReader {
  */
 export function createSessionReader(
   store: LocalStore,
-  threadUrlFor?: (session: SessionRecord) => string | undefined
+  threadUrlFor?: (session: SessionRecord) => string | undefined,
+  transcriptRead: TranscriptReadStore | AsyncTranscriptReadStore = store
 ): SessionReader {
   return {
     list(req) {
@@ -251,7 +267,7 @@ export function createSessionReader(
       })
       return { sessions }
     },
-    history(req) {
+    async history(req) {
       const rec = sessionForRead(store, req.agentId, req.sessionId)
       if (!rec) return { sessionId: req.sessionId, messages: [] }
       const tailing = req.after !== undefined
@@ -275,16 +291,28 @@ export function createSessionReader(
       // to it (context isolation), so the view must not leak other participants' cross-talk.
       const page =
         afterRevision !== null
-          ? store.transcriptTailForAgent(transcriptChannel, rec.thread, rec.agentId, afterRevision, req.limit)
+          ? await transcriptRead.transcriptTailForAgent(
+              transcriptChannel,
+              rec.thread,
+              rec.agentId,
+              afterRevision,
+              req.limit
+            )
           : chronological
-            ? store.transcriptPageForAgentByEventTime(
+            ? await transcriptRead.transcriptPageForAgentByEventTime(
                 transcriptChannel,
                 rec.thread,
                 rec.agentId,
                 eventCursor,
                 req.limit
               )
-            : store.transcriptPageForAgent(transcriptChannel, rec.thread, rec.agentId, legacyBefore, req.limit)
+            : await transcriptRead.transcriptPageForAgent(
+                transcriptChannel,
+                rec.thread,
+                rec.agentId,
+                legacyBefore,
+                req.limit
+              )
       const { rows, hasMore } = page
       // rows are newest-first; the page itself is oldest→newest.
       const ordered = tailing ? rows : rows.slice().reverse()
@@ -357,7 +385,7 @@ export function createSessionReader(
         const liveCursor =
           liveMore && lastMutationRow
             ? lastMutationRow.revision
-            : (page as ReturnType<LocalStore['transcriptTailForAgent']>).cursor
+            : (page as Awaited<ReturnType<AsyncTranscriptReadStore['transcriptTailForAgent']>>).cursor
         // Mutation order and display order differ when a warm-thread backfill inserts
         // an older platform message — possible only where message ids order natively.
         // Return a chronological page while the revision cursor above remains anchored
@@ -404,7 +432,7 @@ export function createSessionReader(
       return {
         sessionId: req.sessionId,
         messages: kept,
-        liveCursor: String(store.currentTranscriptRevision()),
+        liveCursor: String(await transcriptRead.currentTranscriptRevision()),
         ...(hasOlder && oldestKept
           ? {
               nextCursor:
@@ -415,7 +443,7 @@ export function createSessionReader(
           : {})
       }
     },
-    toolBody(req) {
+    async toolBody(req) {
       const rec = sessionForRead(store, req.agentId, req.sessionId)
       const empty: SessionToolBodyChunk = {
         sessionId: req.sessionId,
@@ -424,7 +452,7 @@ export function createSessionReader(
         totalBytes: 0
       }
       if (!rec) return empty
-      const body = store.getToolBodyForAgent(
+      const body = await transcriptRead.getToolBodyForAgent(
         transcriptChannelKey(rec.channel, rec.transportScope),
         rec.thread,
         rec.agentId,

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -206,6 +206,12 @@ type AsyncTranscriptReadStore = {
   ) => Promise<ReturnType<TranscriptReadStore[Method]>>
 }
 
+function transcriptPageCursor(page: unknown): number | undefined {
+  if (!page || typeof page !== 'object' || !('cursor' in page)) return undefined
+  const cursor = (page as { cursor?: unknown }).cursor
+  return typeof cursor === 'number' && Number.isSafeInteger(cursor) ? cursor : undefined
+}
+
 /**
  * @param threadUrlFor Best-effort platform strategy for legacy/dynamic links that
  *   were not persisted on the session itself (Slack workspace permalinks today).
@@ -383,9 +389,7 @@ export function createSessionReader(
         const liveMore = hasMore || droppedToBudget
         const lastMutationRow = kept.length > 0 ? rows[kept.length - 1] : undefined
         const liveCursor =
-          liveMore && lastMutationRow
-            ? lastMutationRow.revision
-            : (page as Awaited<ReturnType<AsyncTranscriptReadStore['transcriptTailForAgent']>>).cursor
+          liveMore && lastMutationRow ? lastMutationRow.revision : (transcriptPageCursor(page) ?? afterRevision)
         // Mutation order and display order differ when a warm-thread backfill inserts
         // an older platform message — possible only where message ids order natively.
         // Return a chronological page while the revision cursor above remains anchored
@@ -432,7 +436,7 @@ export function createSessionReader(
       return {
         sessionId: req.sessionId,
         messages: kept,
-        liveCursor: String(await transcriptRead.currentTranscriptRevision()),
+        liveCursor: String(transcriptPageCursor(page) ?? (await transcriptRead.currentTranscriptRevision())),
         ...(hasOlder && oldestKept
           ? {
               nextCursor:

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -376,6 +376,7 @@ import { CpMcpDefs } from './mcp/cp-mcp-defs.js'
 import { CpMemoryConnectionRegistry, type MemoryPluginConnector } from './cp/memory-connection-registry.js'
 import { MemoryCaptureOutbox } from './memory-plugin/outbox.js'
 import { defaultMemoryPluginMetrics } from './memory-plugin/metrics.js'
+import { openMountedPostgresDataPlane, type PostgresDataPlane } from './store/postgres-transcript-store.js'
 import {
   EvaluationCapabilityProfileSchema,
   EvaluationEventEmitter,
@@ -1872,6 +1873,7 @@ export class Daemon {
   private readonly evaluation: EvaluationEventEmitter
   private readonly evaluationProfile: EvaluationCapabilityProfile
   private store!: LocalStore
+  private dataPlane?: PostgresDataPlane
   private mcp!: McpControlServer
   // The agent memory provider. Per-agent: it dispatches each call to the agent's
   // configured backend (managed = our <agent-root>/memory/ dir; native = the
@@ -2412,6 +2414,8 @@ export class Daemon {
        *  outcome the mode exists to prevent, so it must not be a fallback. Tests override this
        *  to exercise k8s-mode policy without a cluster. */
       startK8sPlane?: typeof startK8sRuntimePlane
+      /** Test seam only; production `--k8s` always reads the fixed Secret mount. */
+      openDataPlane?: typeof openMountedPostgresDataPlane
       /** Test seams for local catalog resolution and executable/state filtering. */
       resolveCatalog?: typeof resolveRuntimeCatalog
       installed?: typeof installedRuntimes
@@ -2802,6 +2806,12 @@ export class Daemon {
       )
     }
     if (this.k8s) {
+      const openDataPlane = this.opts.openDataPlane ?? openMountedPostgresDataPlane
+      this.dataPlane = await openDataPlane((error) => {
+        this.log.error(`data-plane: PostgreSQL persistence failed — ${formatErr(error)}`)
+        this.draining = true
+        this.requestExit(1)
+      })
       // A pod's terminationGracePeriodSeconds must exceed this, or the kubelet SIGKILLs
       // mid-drain and the graceful window is a promise the deployment cannot keep. The
       // daemon cannot read its own grace period (it has no pod read), so it states the
@@ -2815,21 +2825,27 @@ export class Daemon {
       // ever created and runtimes still spawn on this host, which is the one outcome the mode
       // exists to prevent, so a failure here refuses the boot rather than degrading.
       const startPlane = this.opts.startK8sPlane ?? startK8sRuntimePlane
-      this.k8sPlane = await startPlane({
-        // Which sockets this agent's pod needs, and where this daemon serves them. A GitHub-App
-        // workspace is the one case today: its git reaches the credential helper over a unix
-        // socket that, without a tunnel, exists only on the daemon's own filesystem. MCP is
-        // deliberately absent — the in-pod bridge that would dial it is not in the image yet, so
-        // a listener for it would be a socket nobody can use.
-        tunnelsFor: (agentId) =>
-          this.agents.get(agentId)?.workspace.gitCredential === 'github-app' ? ['gitcred'] : [],
-        tunnelSocketPath: (tunnel) => (tunnel === 'gitcred' ? gitcredSocketPath(root) : undefined),
-        log: {
-          info: (message) => this.log.info(message),
-          warn: (message) => this.log.warn(message),
-          debug: (message) => this.log.debug?.(message)
-        }
-      })
+      try {
+        this.k8sPlane = await startPlane({
+          // Which sockets this agent's pod needs, and where this daemon serves them. A GitHub-App
+          // workspace is the one case today: its git reaches the credential helper over a unix
+          // socket that, without a tunnel, exists only on the daemon's own filesystem. MCP is
+          // deliberately absent — the in-pod bridge that would dial it is not in the image yet, so
+          // a listener for it would be a socket nobody can use.
+          tunnelsFor: (agentId) =>
+            this.agents.get(agentId)?.workspace.gitCredential === 'github-app' ? ['gitcred'] : [],
+          tunnelSocketPath: (tunnel) => (tunnel === 'gitcred' ? gitcredSocketPath(root) : undefined),
+          log: {
+            info: (message) => this.log.info(message),
+            warn: (message) => this.log.warn(message),
+            debug: (message) => this.log.debug?.(message)
+          }
+        })
+      } catch (error) {
+        await this.dataPlane.close().catch(() => undefined)
+        this.dataPlane = undefined
+        throw error
+      }
       // Workspace git then runs where the workspace actually is. Registered for ALL agents; the
       // resolver answers undefined for any without a bound channel, so an agent this daemon has
       // not launched into a sandbox keeps its local behaviour.
@@ -3038,6 +3054,7 @@ export class Daemon {
     })
 
     this.store = new LocalStore(statePath(root))
+    this.store.setTranscriptReplica(this.dataPlane?.transcripts)
     this.store.setTranscriptMutationListener((mutation) => this.scheduleSessionActivity(mutation))
     this.memoryOutbox = new MemoryCaptureOutbox(this.store, this.memoryConnections, {
       log: { warn: (message) => this.log.warn(message) }
@@ -20591,7 +20608,11 @@ export class Daemon {
       activeSessions: () => this.pending.size,
       degradedScopes: () => this.cpDegradedScopes(),
       configApply: this.cpConfigApply(),
-      sessionRead: createSessionReader(this.store, (session) => this.sessionThreadUrl(session)),
+      sessionRead: createSessionReader(
+        this.store,
+        (session) => this.sessionThreadUrl(session),
+        this.dataPlane?.transcripts
+      ),
       // §5.4: serve a CP-forwarded status probe for a child session we own. Authorization is
       // re-done here (the lineage rule lives where the session lives), not trusted from the CP.
       childSessionStatusProbe: (probe) => this.childSessionStatusProbe(probe),
@@ -21295,6 +21316,8 @@ export class Daemon {
     // so server.close() isn't left waiting on a live bridge connection.
     await Promise.resolve(this.mcp?.stop()).catch((e) => errors.push(e))
     this.gitCredServer?.stop()
+    this.store?.setTranscriptReplica()
+    await this.dataPlane?.close().catch((e) => errors.push(e))
     this.store?.close()
     if (errors.length) throw new AggregateError(errors, 'stop: partial failure')
   }

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -31,7 +31,7 @@ type SqlParams = Record<string, SQLInputValue>
  * Unknown/unsafe values fall back to 0. They remain stable via the `seq` tie-breaker
  * and sort before real timestamps instead of blocking an in-place store migration.
  */
-function transcriptEventTimeUs(ts: string | null | undefined): number {
+export function transcriptEventTimeUs(ts: string | null | undefined): number {
   let raw = ts?.trim() ?? ''
   if (!raw) return 0
   const local = raw.startsWith('local-')
@@ -587,6 +587,7 @@ export class LocalStore {
   private db: DatabaseSync
   private transcriptRevision = 0
   private transcriptMutationListener?: (mutation: TranscriptMutation) => void
+  private transcriptReplica?: import('./postgres-transcript-store.js').TranscriptReplicaSink
 
   constructor(dbPath: string) {
     // This database holds every platform message body, agent reply, tool payload and
@@ -1278,6 +1279,11 @@ export class LocalStore {
 
   setTranscriptMutationListener(listener?: (mutation: TranscriptMutation) => void): void {
     this.transcriptMutationListener = listener
+  }
+
+  /** Cloud persistence seam; SQLite remains the synchronous local/self-hosted driver. */
+  setTranscriptReplica(replica?: import('./postgres-transcript-store.js').TranscriptReplicaSink): void {
+    this.transcriptReplica = replica
   }
 
   /**
@@ -2645,6 +2651,7 @@ export class LocalStore {
       ).map((r) => r.agentId)
       this.notifyTranscriptMutation(e.channel, e.thread, [e.sender, e.recipient, ...sharedRecipients], deliveryRevision)
     }
+    this.transcriptReplica?.appendTranscript(e)
   }
 
   /** First sight of a tool call: insert its kind='tool' row (title in `text`, the
@@ -2682,6 +2689,7 @@ export class LocalStore {
       this.transcriptRevision = revision
       this.notifyTranscriptMutation(e.channel, e.thread, [e.sender], revision)
     }
+    this.transcriptReplica?.insertToolCall(e)
   }
 
   /** Later update for one agent's tool call. `seq`/`ts` keep their first-seen
@@ -2705,6 +2713,7 @@ export class LocalStore {
       this.transcriptRevision = revision
       this.notifyTranscriptMutation(channel, thread, [agentId], revision)
     }
+    this.transcriptReplica?.updateToolCall(channel, thread, agentId, toolCallId, patch)
   }
 
   private notifyTranscriptMutation(

--- a/packages/daemon/src/store/postgres-config.ts
+++ b/packages/daemon/src/store/postgres-config.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { z } from 'zod'
+
+/** Kubernetes Secret mount consumed only by `--k8s`; no CLI/env credential surface exists. */
+export const DATA_PLANE_CONFIG_PATH = '/var/run/ac-data-plane/config.json'
+
+const PostgresUrl = z
+  .string()
+  .min(1)
+  .superRefine((value, ctx) => {
+    try {
+      const url = new URL(value)
+      if (url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') throw new Error('scheme')
+    } catch {
+      ctx.addIssue({ code: 'custom', message: 'databaseUrl must be a PostgreSQL URL' })
+    }
+  })
+
+export const DataPlaneConfigSchema = z
+  .object({
+    version: z.literal(1),
+    databaseUrl: PostgresUrl,
+    /** CP-issued org locator; schema isolation makes a missing org predicate impossible. */
+    schema: z.string().regex(/^[a-z][a-z0-9_]{0,62}$/),
+    maxConnections: z.number().int().min(1).max(32).default(4)
+  })
+  .strict()
+
+export type DataPlaneConfig = z.infer<typeof DataPlaneConfigSchema>
+
+export function readDataPlaneConfig(path = DATA_PLANE_CONFIG_PATH): DataPlaneConfig {
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(path, 'utf8'))
+  } catch (error) {
+    const reason = error instanceof SyntaxError ? 'is not valid JSON' : 'is not readable'
+    throw new Error(`data-plane configuration ${reason} at ${path}`)
+  }
+  const parsed = DataPlaneConfigSchema.safeParse(raw)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    throw new Error(
+      `invalid data-plane configuration at ${path}: ${issue?.path.join('.') || 'document'} ${issue?.message}`
+    )
+  }
+  return parsed.data
+}

--- a/packages/daemon/src/store/postgres-migrations.ts
+++ b/packages/daemon/src/store/postgres-migrations.ts
@@ -1,0 +1,92 @@
+import type { PoolClient } from 'pg'
+
+/** Quote only identifiers already accepted by postgres-config's conservative regex. */
+export function quotePgIdentifier(identifier: string): string {
+  if (!/^[a-z][a-z0-9_]{0,62}$/.test(identifier)) throw new Error('invalid PostgreSQL schema identifier')
+  return `"${identifier}"`
+}
+
+const MIGRATIONS: readonly string[] = [
+  `
+    CREATE SEQUENCE transcript_revision_seq;
+
+    CREATE TABLE transcript (
+      seq BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      channel TEXT NOT NULL,
+      thread TEXT NOT NULL,
+      ts TEXT,
+      sender TEXT NOT NULL,
+      kind TEXT NOT NULL CHECK (kind IN ('text', 'tool', 'reasoning')),
+      text TEXT NOT NULL,
+      tool_call_id TEXT,
+      body TEXT,
+      recipient TEXT,
+      event_time_us BIGINT NOT NULL DEFAULT 0,
+      attachments_json TEXT,
+      quote_json TEXT,
+      trusted_agent_bot BOOLEAN,
+      revision BIGINT NOT NULL DEFAULT nextval('transcript_revision_seq'),
+      post_id TEXT
+    );
+    CREATE INDEX transcript_thread_seq ON transcript (channel, thread, seq);
+    CREATE UNIQUE INDEX transcript_text_ts ON transcript (channel, thread, ts) WHERE kind = 'text';
+    CREATE UNIQUE INDEX transcript_agent_tool_call
+      ON transcript (channel, thread, sender, tool_call_id) WHERE tool_call_id IS NOT NULL;
+    CREATE INDEX transcript_thread_event_time ON transcript (channel, thread, event_time_us DESC, seq DESC);
+    CREATE INDEX transcript_thread_revision ON transcript (channel, thread, revision);
+
+    CREATE TABLE transcript_recipient (
+      channel TEXT NOT NULL,
+      thread TEXT NOT NULL,
+      ts TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      PRIMARY KEY (channel, thread, ts, agent_id)
+    );
+  `
+]
+
+export const DATA_PLANE_SCHEMA_VERSION = MIGRATIONS.length
+
+/** Upgrade one org schema under a transaction-scoped cross-daemon advisory lock. */
+export async function migrateDataPlaneSchema(client: PoolClient, schema: string): Promise<void> {
+  const quoted = quotePgIdentifier(schema)
+  await client.query('BEGIN')
+  try {
+    await client.query("SELECT pg_advisory_xact_lock(hashtext($1), hashtext('agentconnect-data-plane'))", [schema])
+    await client.query(`CREATE SCHEMA IF NOT EXISTS ${quoted}`)
+    await client.query(`SET LOCAL search_path TO ${quoted}, pg_catalog`)
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS _agentconnect_schema_migrations (
+        version INTEGER PRIMARY KEY,
+        applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `)
+    const result = await client.query<{ version: number }>(
+      'SELECT version FROM _agentconnect_schema_migrations ORDER BY version'
+    )
+    const applied = new Set(result.rows.map((row) => Number(row.version)))
+    const newest = Math.max(0, ...applied)
+    if (newest > DATA_PLANE_SCHEMA_VERSION) {
+      throw new Error(
+        `data-plane schema ${schema} is version ${newest}, newer than supported version ${DATA_PLANE_SCHEMA_VERSION}`
+      )
+    }
+    for (let version = 1; version <= newest; version += 1) {
+      if (!applied.has(version))
+        throw new Error(`data-plane schema ${schema} has a migration gap before version ${newest}`)
+    }
+    let expected = newest + 1
+    for (let index = 0; index < MIGRATIONS.length; index += 1) {
+      const version = index + 1
+      if (applied.has(version)) continue
+      if (version !== expected) throw new Error(`data-plane schema ${schema} has a migration gap`)
+      await client.query(MIGRATIONS[index]!)
+      await client.query('INSERT INTO _agentconnect_schema_migrations (version) VALUES ($1)', [version])
+      expected += 1
+    }
+    await client.query('COMMIT')
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => undefined)
+    throw error
+  }
+}

--- a/packages/daemon/src/store/postgres-transcript-store.ts
+++ b/packages/daemon/src/store/postgres-transcript-store.ts
@@ -1,0 +1,399 @@
+import { Pool, type PoolClient, type QueryResultRow } from 'pg'
+import { SESSION_TITLE_TOOL_TITLES } from '../mcp/session-title-tool.js'
+import {
+  transcriptEventTimeUs,
+  type TranscriptEntry,
+  type TranscriptEventCursor,
+  type TranscriptRow
+} from './local-store.js'
+import { readDataPlaneConfig, type DataPlaneConfig } from './postgres-config.js'
+import { migrateDataPlaneSchema, quotePgIdentifier } from './postgres-migrations.js'
+
+export interface TranscriptToolCall {
+  channel: string
+  thread: string
+  ts: string
+  sender: string
+  toolCallId: string
+  title: string
+  body: string
+}
+
+export interface TranscriptReplicaSink {
+  appendTranscript(entry: TranscriptEntry): void
+  insertToolCall(entry: TranscriptToolCall): void
+  updateToolCall(
+    channel: string,
+    thread: string,
+    agentId: string,
+    toolCallId: string,
+    patch: { title: string; body: string }
+  ): void
+}
+
+type PgTranscriptRow = QueryResultRow & {
+  seq: string
+  channel: string
+  thread: string
+  ts: string
+  sender: string
+  kind: TranscriptRow['kind']
+  text: string
+  tool_call_id: string | null
+  body: string | null
+  recipient: string | null
+  event_time_us: string
+  attachments_json: string | null
+  quote_json: string | null
+  trusted_agent_bot: boolean | null
+  revision: string
+  post_id: string | null
+}
+
+function safeInteger(value: string, field: string): number {
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed)) throw new Error(`PostgreSQL ${field} exceeds JavaScript's safe integer range`)
+  return parsed
+}
+
+function transcriptRow(row: PgTranscriptRow): TranscriptRow {
+  return {
+    seq: safeInteger(row.seq, 'transcript.seq'),
+    channel: row.channel,
+    thread: row.thread,
+    ts: row.ts,
+    sender: row.sender,
+    kind: row.kind,
+    text: row.text,
+    ...(row.tool_call_id ? { toolCallId: row.tool_call_id } : {}),
+    body: row.body,
+    ...(row.recipient ? { recipient: row.recipient } : {}),
+    eventTimeUs: safeInteger(row.event_time_us, 'transcript.event_time_us'),
+    attachmentsJson: row.attachments_json,
+    quoteJson: row.quote_json,
+    ...(row.trusted_agent_bot ? { trustedAgentBot: true } : {}),
+    revision: safeInteger(row.revision, 'transcript.revision'),
+    ...(row.post_id ? { postId: row.post_id } : {})
+  }
+}
+
+export class PostgresTranscriptStore implements TranscriptReplicaSink {
+  private tail: Promise<void> = Promise.resolve()
+  private failure?: Error
+
+  constructor(
+    private readonly pool: Pool,
+    private readonly schema: string,
+    private readonly onFailure: (error: Error) => void = () => undefined
+  ) {}
+
+  private enqueue(operation: () => Promise<void>): void {
+    if (this.failure) throw this.failure
+    this.tail = this.tail.then(operation).catch((error: unknown) => {
+      this.failure = error instanceof Error ? error : new Error(String(error))
+      this.onFailure(this.failure)
+      throw this.failure
+    })
+    void this.tail.catch(() => undefined)
+  }
+
+  appendTranscript(entry: TranscriptEntry): void {
+    this.enqueue(() => this.writeTranscript(entry))
+  }
+
+  insertToolCall(entry: TranscriptToolCall): void {
+    this.enqueue(() => this.writeToolCall(entry))
+  }
+
+  updateToolCall(
+    channel: string,
+    thread: string,
+    agentId: string,
+    toolCallId: string,
+    patch: { title: string; body: string }
+  ): void {
+    this.enqueue(async () => {
+      await this.withSchema((client) =>
+        client.query(
+          `UPDATE transcript
+           SET text = $1, body = $2, revision = nextval('transcript_revision_seq')
+           WHERE channel = $3 AND thread = $4 AND sender = $5 AND tool_call_id = $6
+             AND (text IS DISTINCT FROM $1 OR body IS DISTINCT FROM $2)`,
+          [patch.title, patch.body, channel, thread, agentId, toolCallId]
+        )
+      )
+    })
+  }
+
+  async flush(): Promise<void> {
+    await this.tail
+    if (this.failure) throw this.failure
+  }
+
+  private async withSchema<T>(operation: (client: PoolClient) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect()
+    try {
+      await client.query(`SET search_path TO ${quotePgIdentifier(this.schema)}, pg_catalog`)
+      return await operation(client)
+    } finally {
+      client.release()
+    }
+  }
+
+  private async writeTranscript(entry: TranscriptEntry): Promise<void> {
+    const quoteJson = entry.quoted?.text ? JSON.stringify(entry.quoted) : (entry.quoteJson ?? null)
+    const attachmentsJson = entry.attachments?.length ? JSON.stringify(entry.attachments) : null
+    await this.withSchema(async (client) => {
+      await client.query('BEGIN')
+      try {
+        const inserted = await client.query<{ inserted: boolean }>(
+          `INSERT INTO transcript
+             (channel, thread, ts, sender, kind, text, recipient, event_time_us,
+              attachments_json, quote_json, trusted_agent_bot, post_id)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+           ON CONFLICT (channel, thread, ts) WHERE kind = 'text' DO NOTHING
+           RETURNING true AS inserted`,
+          [
+            entry.channel,
+            entry.thread,
+            entry.ts,
+            entry.sender,
+            entry.kind,
+            entry.text,
+            entry.recipient ?? null,
+            entry.eventTimeUs ?? transcriptEventTimeUs(entry.ts),
+            attachmentsJson,
+            quoteJson,
+            entry.trustedAgentBot || null,
+            entry.postId ?? null
+          ]
+        )
+        if (inserted.rowCount === 0 && entry.kind === 'text') {
+          await client.query(
+            `UPDATE transcript SET
+               text = CASE WHEN $1 THEN $2 ELSE text END,
+               event_time_us = CASE WHEN $3::bigint IS NOT NULL THEN $3 ELSE event_time_us END,
+               attachments_json = COALESCE(attachments_json, $4),
+               quote_json = CASE WHEN $5::text IS NOT NULL THEN $5 ELSE quote_json END,
+               trusted_agent_bot = CASE WHEN $6 THEN true ELSE trusted_agent_bot END,
+               post_id = COALESCE(post_id, $7),
+               revision = nextval('transcript_revision_seq')
+             WHERE channel = $8 AND thread = $9 AND ts = $10 AND kind = 'text'
+               AND (($1 AND text IS DISTINCT FROM $2)
+                 OR ($3::bigint IS NOT NULL AND event_time_us IS DISTINCT FROM $3)
+                 OR (attachments_json IS NULL AND $4::text IS NOT NULL)
+                 OR ($5::text IS NOT NULL AND quote_json IS DISTINCT FROM $5)
+                 OR ($6 AND trusted_agent_bot IS DISTINCT FROM true)
+                 OR (post_id IS NULL AND $7::text IS NOT NULL))`,
+            [
+              entry.authoritative === true,
+              entry.text,
+              entry.eventTimeUs ?? null,
+              attachmentsJson,
+              quoteJson,
+              entry.trustedAgentBot === true,
+              entry.postId ?? null,
+              entry.channel,
+              entry.thread,
+              entry.ts
+            ]
+          )
+        }
+        if (entry.recipient && entry.ts) {
+          const delivered = await client.query(
+            `INSERT INTO transcript_recipient (channel, thread, ts, agent_id)
+             VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING RETURNING agent_id`,
+            [entry.channel, entry.thread, entry.ts, entry.recipient]
+          )
+          if (inserted.rowCount === 0 && delivered.rowCount === 1) {
+            await client.query(
+              `UPDATE transcript SET revision = nextval('transcript_revision_seq')
+               WHERE channel = $1 AND thread = $2 AND ts = $3 AND kind = 'text'`,
+              [entry.channel, entry.thread, entry.ts]
+            )
+          }
+        }
+        await client.query('COMMIT')
+      } catch (error) {
+        await client.query('ROLLBACK').catch(() => undefined)
+        throw error
+      }
+    })
+  }
+
+  private async writeToolCall(entry: TranscriptToolCall): Promise<void> {
+    await this.withSchema(async (client) => {
+      await client.query(
+        `INSERT INTO transcript
+           (channel, thread, ts, sender, kind, text, tool_call_id, body, event_time_us)
+         VALUES ($1,$2,$3,$4,'tool',$5,$6,$7,$8)
+         ON CONFLICT (channel, thread, sender, tool_call_id) WHERE tool_call_id IS NOT NULL DO NOTHING`,
+        [
+          entry.channel,
+          entry.thread,
+          entry.ts,
+          entry.sender,
+          entry.title,
+          entry.toolCallId,
+          entry.body,
+          transcriptEventTimeUs(entry.ts)
+        ]
+      )
+    })
+  }
+
+  private scopeSql(): string {
+    return `(sender = $3 OR recipient = $3 OR (transcript.kind = 'text' AND EXISTS (
+      SELECT 1 FROM transcript_recipient tr
+      WHERE tr.channel = transcript.channel AND tr.thread = transcript.thread
+        AND tr.ts = transcript.ts AND tr.agent_id = $3)))`
+  }
+
+  async transcriptPageForAgent(
+    channel: string,
+    thread: string,
+    agentId: string,
+    beforeSeq: number | null,
+    limit: number
+  ): Promise<{ rows: TranscriptRow[]; hasMore: boolean }> {
+    await this.flush()
+    const hidden = [...SESSION_TITLE_TOOL_TITLES]
+    const values: unknown[] = [channel, thread, agentId, ...hidden]
+    const before = beforeSeq === null ? '' : `AND seq < $${values.push(beforeSeq)}`
+    const limitParam = `$${values.push(limit + 1)}`
+    return this.page(
+      `SELECT * FROM transcript WHERE channel = $1 AND thread = $2 ${before}
+         AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($4,$5))
+       ORDER BY seq DESC LIMIT ${limitParam}`,
+      values,
+      limit
+    )
+  }
+
+  async transcriptPageForAgentByEventTime(
+    channel: string,
+    thread: string,
+    agentId: string,
+    before: TranscriptEventCursor | null,
+    limit: number
+  ): Promise<{ rows: TranscriptRow[]; hasMore: boolean }> {
+    await this.flush()
+    const hidden = [...SESSION_TITLE_TOOL_TITLES]
+    const values: unknown[] = [channel, thread, agentId, ...hidden]
+    const cursor =
+      before === null
+        ? ''
+        : `AND (event_time_us < $${values.push(before.eventTimeUs)} OR (event_time_us = $${values.push(before.eventTimeUs)} AND seq < $${values.push(before.seq)}))`
+    const limitParam = `$${values.push(limit + 1)}`
+    return this.page(
+      `SELECT * FROM transcript WHERE channel = $1 AND thread = $2 ${cursor}
+         AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($4,$5))
+       ORDER BY event_time_us DESC, seq DESC LIMIT ${limitParam}`,
+      values,
+      limit
+    )
+  }
+
+  async transcriptTailForAgent(
+    channel: string,
+    thread: string,
+    agentId: string,
+    afterRevision: number,
+    limit: number
+  ): Promise<{ rows: TranscriptRow[]; hasMore: boolean; cursor: number }> {
+    await this.flush()
+    const hidden = [...SESSION_TITLE_TOOL_TITLES]
+    const result = await this.page(
+      `SELECT * FROM transcript WHERE channel = $1 AND thread = $2 AND revision > $6
+         AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($4,$5))
+       ORDER BY revision ASC LIMIT $7`,
+      [channel, thread, agentId, ...hidden, afterRevision, limit + 1],
+      limit
+    )
+    const revision = await this.currentTranscriptRevision()
+    return { ...result, cursor: result.hasMore ? (result.rows.at(-1)?.revision ?? afterRevision) : revision }
+  }
+
+  async currentTranscriptRevision(): Promise<number> {
+    await this.flush()
+    return this.withSchema(async (client) => {
+      const result = await client.query<{ revision: string }>(
+        'SELECT COALESCE(MAX(revision), 0)::text AS revision FROM transcript'
+      )
+      return safeInteger(result.rows[0]?.revision ?? '0', 'transcript.revision')
+    })
+  }
+
+  async getToolBodyForAgent(
+    channel: string,
+    thread: string,
+    agentId: string,
+    toolCallId: string
+  ): Promise<string | undefined> {
+    await this.flush()
+    return this.withSchema(async (client) => {
+      const result = await client.query<{ body: string | null }>(
+        `SELECT body FROM transcript
+         WHERE channel = $1 AND thread = $2 AND sender = $3 AND tool_call_id = $4`,
+        [channel, thread, agentId, toolCallId]
+      )
+      return result.rows[0]?.body ?? undefined
+    })
+  }
+
+  private async page(
+    sql: string,
+    values: unknown[],
+    limit: number
+  ): Promise<{ rows: TranscriptRow[]; hasMore: boolean }> {
+    return this.withSchema(async (client) => {
+      const result = await client.query<PgTranscriptRow>(sql, values)
+      const rows = result.rows.map(transcriptRow)
+      const hasMore = rows.length > limit
+      return { rows: hasMore ? rows.slice(0, limit) : rows, hasMore }
+    })
+  }
+}
+
+export class PostgresDataPlane {
+  readonly transcripts: PostgresTranscriptStore
+
+  private constructor(
+    private readonly pool: Pool,
+    config: DataPlaneConfig,
+    onFailure?: (error: Error) => void
+  ) {
+    this.transcripts = new PostgresTranscriptStore(pool, config.schema, onFailure)
+  }
+
+  static async open(config: DataPlaneConfig, onFailure?: (error: Error) => void): Promise<PostgresDataPlane> {
+    const pool = new Pool({
+      connectionString: config.databaseUrl,
+      max: config.maxConnections,
+      application_name: 'agentconnect-daemon',
+      connectionTimeoutMillis: 10_000
+    })
+    pool.on('error', (error) => onFailure?.(error))
+    try {
+      const client = await pool.connect()
+      try {
+        await migrateDataPlaneSchema(client, config.schema)
+      } finally {
+        client.release()
+      }
+    } catch (error) {
+      await pool.end().catch(() => undefined)
+      throw error
+    }
+    return new PostgresDataPlane(pool, config, onFailure)
+  }
+
+  async close(): Promise<void> {
+    await this.transcripts.flush()
+    await this.pool.end()
+  }
+}
+
+export async function openMountedPostgresDataPlane(onFailure?: (error: Error) => void): Promise<PostgresDataPlane> {
+  return PostgresDataPlane.open(readDataPlaneConfig(), onFailure)
+}

--- a/packages/daemon/src/store/postgres-transcript-store.ts
+++ b/packages/daemon/src/store/postgres-transcript-store.ts
@@ -113,7 +113,7 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     patch: { title: string; body: string }
   ): void {
     this.enqueue(async () => {
-      await this.withSchema((client) =>
+      await this.withRevisionTransaction((client) =>
         client.query(
           `UPDATE transcript
            SET text = $1, body = $2, revision = nextval('transcript_revision_seq')
@@ -140,37 +140,52 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     }
   }
 
+  private async withRevisionTransaction<T>(operation: (client: PoolClient) => Promise<T>): Promise<T> {
+    return this.withSchema(async (client) => {
+      await client.query('BEGIN')
+      try {
+        await client.query("SELECT pg_advisory_xact_lock(hashtext($1), hashtext('agentconnect-transcript-revision'))", [
+          this.schema
+        ])
+        const result = await operation(client)
+        await client.query('COMMIT')
+        return result
+      } catch (error) {
+        await client.query('ROLLBACK').catch(() => undefined)
+        throw error
+      }
+    })
+  }
+
   private async writeTranscript(entry: TranscriptEntry): Promise<void> {
     const quoteJson = entry.quoted?.text ? JSON.stringify(entry.quoted) : (entry.quoteJson ?? null)
     const attachmentsJson = entry.attachments?.length ? JSON.stringify(entry.attachments) : null
-    await this.withSchema(async (client) => {
-      await client.query('BEGIN')
-      try {
-        const inserted = await client.query<{ inserted: boolean }>(
-          `INSERT INTO transcript
+    await this.withRevisionTransaction(async (client) => {
+      const inserted = await client.query<{ inserted: boolean }>(
+        `INSERT INTO transcript
              (channel, thread, ts, sender, kind, text, recipient, event_time_us,
               attachments_json, quote_json, trusted_agent_bot, post_id)
            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
            ON CONFLICT (channel, thread, ts) WHERE kind = 'text' DO NOTHING
            RETURNING true AS inserted`,
-          [
-            entry.channel,
-            entry.thread,
-            entry.ts,
-            entry.sender,
-            entry.kind,
-            entry.text,
-            entry.recipient ?? null,
-            entry.eventTimeUs ?? transcriptEventTimeUs(entry.ts),
-            attachmentsJson,
-            quoteJson,
-            entry.trustedAgentBot || null,
-            entry.postId ?? null
-          ]
-        )
-        if (inserted.rowCount === 0 && entry.kind === 'text') {
-          await client.query(
-            `UPDATE transcript SET
+        [
+          entry.channel,
+          entry.thread,
+          entry.ts,
+          entry.sender,
+          entry.kind,
+          entry.text,
+          entry.recipient ?? null,
+          entry.eventTimeUs ?? transcriptEventTimeUs(entry.ts),
+          attachmentsJson,
+          quoteJson,
+          entry.trustedAgentBot || null,
+          entry.postId ?? null
+        ]
+      )
+      if (inserted.rowCount === 0 && entry.kind === 'text') {
+        await client.query(
+          `UPDATE transcript SET
                text = CASE WHEN $1 THEN $2 ELSE text END,
                event_time_us = CASE WHEN $3::bigint IS NOT NULL THEN $3 ELSE event_time_us END,
                attachments_json = COALESCE(attachments_json, $4),
@@ -185,44 +200,39 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
                  OR ($5::text IS NOT NULL AND quote_json IS DISTINCT FROM $5)
                  OR ($6 AND trusted_agent_bot IS DISTINCT FROM true)
                  OR (post_id IS NULL AND $7::text IS NOT NULL))`,
-            [
-              entry.authoritative === true,
-              entry.text,
-              entry.eventTimeUs ?? null,
-              attachmentsJson,
-              quoteJson,
-              entry.trustedAgentBot === true,
-              entry.postId ?? null,
-              entry.channel,
-              entry.thread,
-              entry.ts
-            ]
-          )
-        }
-        if (entry.recipient && entry.ts) {
-          const delivered = await client.query(
-            `INSERT INTO transcript_recipient (channel, thread, ts, agent_id)
+          [
+            entry.authoritative === true,
+            entry.text,
+            entry.eventTimeUs ?? null,
+            attachmentsJson,
+            quoteJson,
+            entry.trustedAgentBot === true,
+            entry.postId ?? null,
+            entry.channel,
+            entry.thread,
+            entry.ts
+          ]
+        )
+      }
+      if (entry.recipient && entry.ts) {
+        const delivered = await client.query(
+          `INSERT INTO transcript_recipient (channel, thread, ts, agent_id)
              VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING RETURNING agent_id`,
-            [entry.channel, entry.thread, entry.ts, entry.recipient]
-          )
-          if (inserted.rowCount === 0 && delivered.rowCount === 1) {
-            await client.query(
-              `UPDATE transcript SET revision = nextval('transcript_revision_seq')
+          [entry.channel, entry.thread, entry.ts, entry.recipient]
+        )
+        if (inserted.rowCount === 0 && delivered.rowCount === 1) {
+          await client.query(
+            `UPDATE transcript SET revision = nextval('transcript_revision_seq')
                WHERE channel = $1 AND thread = $2 AND ts = $3 AND kind = 'text'`,
-              [entry.channel, entry.thread, entry.ts]
-            )
-          }
+            [entry.channel, entry.thread, entry.ts]
+          )
         }
-        await client.query('COMMIT')
-      } catch (error) {
-        await client.query('ROLLBACK').catch(() => undefined)
-        throw error
       }
     })
   }
 
   private async writeToolCall(entry: TranscriptToolCall): Promise<void> {
-    await this.withSchema(async (client) => {
+    await this.withRevisionTransaction(async (client) => {
       await client.query(
         `INSERT INTO transcript
            (channel, thread, ts, sender, kind, text, tool_call_id, body, event_time_us)
@@ -255,19 +265,20 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     agentId: string,
     beforeSeq: number | null,
     limit: number
-  ): Promise<{ rows: TranscriptRow[]; hasMore: boolean }> {
+  ): Promise<{ rows: TranscriptRow[]; hasMore: boolean; cursor: number }> {
     await this.flush()
     const hidden = [...SESSION_TITLE_TOOL_TITLES]
     const values: unknown[] = [channel, thread, agentId, ...hidden]
     const before = beforeSeq === null ? '' : `AND seq < $${values.push(beforeSeq)}`
     const limitParam = `$${values.push(limit + 1)}`
-    return this.page(
+    const page = await this.snapshotPage(
       `SELECT * FROM transcript WHERE channel = $1 AND thread = $2 ${before}
          AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($4,$5))
        ORDER BY seq DESC LIMIT ${limitParam}`,
       values,
       limit
     )
+    return { rows: page.rows, hasMore: page.hasMore, cursor: page.watermark }
   }
 
   async transcriptPageForAgentByEventTime(
@@ -276,7 +287,7 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     agentId: string,
     before: TranscriptEventCursor | null,
     limit: number
-  ): Promise<{ rows: TranscriptRow[]; hasMore: boolean }> {
+  ): Promise<{ rows: TranscriptRow[]; hasMore: boolean; cursor: number }> {
     await this.flush()
     const hidden = [...SESSION_TITLE_TOOL_TITLES]
     const values: unknown[] = [channel, thread, agentId, ...hidden]
@@ -285,13 +296,14 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
         ? ''
         : `AND (event_time_us < $${values.push(before.eventTimeUs)} OR (event_time_us = $${values.push(before.eventTimeUs)} AND seq < $${values.push(before.seq)}))`
     const limitParam = `$${values.push(limit + 1)}`
-    return this.page(
+    const page = await this.snapshotPage(
       `SELECT * FROM transcript WHERE channel = $1 AND thread = $2 ${cursor}
          AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($4,$5))
        ORDER BY event_time_us DESC, seq DESC LIMIT ${limitParam}`,
       values,
       limit
     )
+    return { rows: page.rows, hasMore: page.hasMore, cursor: page.watermark }
   }
 
   async transcriptTailForAgent(
@@ -303,15 +315,18 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
   ): Promise<{ rows: TranscriptRow[]; hasMore: boolean; cursor: number }> {
     await this.flush()
     const hidden = [...SESSION_TITLE_TOOL_TITLES]
-    const result = await this.page(
+    const result = await this.snapshotPage(
       `SELECT * FROM transcript WHERE channel = $1 AND thread = $2 AND revision > $6
          AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($4,$5))
        ORDER BY revision ASC LIMIT $7`,
       [channel, thread, agentId, ...hidden, afterRevision, limit + 1],
       limit
     )
-    const revision = await this.currentTranscriptRevision()
-    return { ...result, cursor: result.hasMore ? (result.rows.at(-1)?.revision ?? afterRevision) : revision }
+    return {
+      rows: result.rows,
+      hasMore: result.hasMore,
+      cursor: result.hasMore ? (result.rows.at(-1)?.revision ?? afterRevision) : result.watermark
+    }
   }
 
   async currentTranscriptRevision(): Promise<number> {
@@ -341,16 +356,30 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     })
   }
 
-  private async page(
+  private async snapshotPage(
     sql: string,
     values: unknown[],
     limit: number
-  ): Promise<{ rows: TranscriptRow[]; hasMore: boolean }> {
+  ): Promise<{ rows: TranscriptRow[]; hasMore: boolean; watermark: number }> {
     return this.withSchema(async (client) => {
-      const result = await client.query<PgTranscriptRow>(sql, values)
-      const rows = result.rows.map(transcriptRow)
-      const hasMore = rows.length > limit
-      return { rows: hasMore ? rows.slice(0, limit) : rows, hasMore }
+      await client.query('BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY')
+      try {
+        const result = await client.query<PgTranscriptRow>(sql, values)
+        const revision = await client.query<{ watermark: string }>(
+          'SELECT COALESCE(MAX(revision), 0)::text AS watermark FROM transcript'
+        )
+        await client.query('COMMIT')
+        const rows = result.rows.map(transcriptRow)
+        const hasMore = rows.length > limit
+        return {
+          rows: hasMore ? rows.slice(0, limit) : rows,
+          hasMore,
+          watermark: safeInteger(revision.rows[0]?.watermark ?? '0', 'transcript.revision')
+        }
+      } catch (error) {
+        await client.query('ROLLBACK').catch(() => undefined)
+        throw error
+      }
     })
   }
 }

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -68,6 +68,7 @@ async function readyClient(over: Partial<CpClientDeps> = {}, serverFeatures: str
   const sessionRead = {
     list: vi.fn(() => ({ sessions: [] })),
     history: vi.fn(() => ({ sessionId: DAEMON_ID, messages: [] })),
+    toolBody: vi.fn(() => ({ sessionId: DAEMON_ID, toolCallId: 'tool', data: '', totalBytes: 0 })),
     ...((over.sessionRead as any) ?? {})
   }
   const workspaceRead = {
@@ -938,6 +939,7 @@ describe('CpClient dispatch', () => {
       frame('session/history', { agentId: CRON_AGENT_ID, sessionId: DAEMON_ID, limit: 50 }, { epoch: 5 })
     )
     t.pushInbound(JSON.stringify(f))
+    await tick()
     const rep = JSON.parse(t.sent[0]!)
     expect(rep.type).toBe('session/history/page')
     expect(rep.corr).toBe(f.id)

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -54,6 +54,7 @@ function daemon(opts: {
   supervisor?: string
   /** Extra plane members for the rows that are ABOUT the plane the mode installs. */
   plane?: Record<string, unknown>
+  dataPlane?: boolean
 }): Daemon {
   return new Daemon({
     root: opts.root,
@@ -62,6 +63,24 @@ function daemon(opts: {
     // Stubbing it here keeps the refuse-to-boot-without-a-cluster behaviour real everywhere else.
     ...(opts.k8s
       ? {
+          ...(opts.dataPlane === false
+            ? {}
+            : {
+                openDataPlane: async () =>
+                  ({
+                    transcripts: {
+                      appendTranscript: () => {},
+                      insertToolCall: () => {},
+                      updateToolCall: () => {},
+                      transcriptTailForAgent: async () => ({ rows: [], hasMore: false, cursor: 0 }),
+                      transcriptPageForAgentByEventTime: async () => ({ rows: [], hasMore: false }),
+                      transcriptPageForAgent: async () => ({ rows: [], hasMore: false }),
+                      currentTranscriptRevision: async () => 0,
+                      getToolBodyForAgent: async () => undefined
+                    },
+                    close: async () => {}
+                  }) as never
+              }),
           startK8sPlane: async () =>
             ({
               driver: { claimName: (id: string) => `agent-${id}` } as never,
@@ -83,6 +102,11 @@ function daemon(opts: {
 }
 
 describe('daemon --k8s mode', () => {
+  it('requires the mounted PostgreSQL configuration before starting the execution plane', async () => {
+    const k8sDaemon = daemon({ root: root(), k8s: true, dataPlane: false })
+    await expect(k8sDaemon.start()).rejects.toThrow(/data-plane configuration is not readable/)
+  })
+
   it('advertises the runtimes the image declares, not what is installed on the host', async () => {
     const probe = vi.fn(async () => [])
     const k8sDaemon = daemon({

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -55,6 +55,7 @@ function daemon(opts: {
   /** Extra plane members for the rows that are ABOUT the plane the mode installs. */
   plane?: Record<string, unknown>
   dataPlane?: boolean
+  openDataPlane?: ReturnType<typeof vi.fn>
 }): Daemon {
   return new Daemon({
     root: opts.root,
@@ -94,6 +95,7 @@ function daemon(opts: {
             }) as never
         }
       : {}),
+    ...(opts.openDataPlane ? { openDataPlane: opts.openDataPlane as never } : {}),
     ...(opts.supervisor ? { supervisor: opts.supervisor } : {}),
     resolveCatalog: async () => catalog(),
     ...(opts.probe ? { probeRuntimes: opts.probe as never } : {}),
@@ -102,6 +104,17 @@ function daemon(opts: {
 }
 
 describe('daemon --k8s mode', () => {
+  it('does not inspect or open the PostgreSQL data plane outside k8s mode', async () => {
+    const openDataPlane = vi.fn()
+    const local = daemon({ root: root(), k8s: false, openDataPlane })
+    try {
+      await local.start()
+      expect(openDataPlane).not.toHaveBeenCalled()
+    } finally {
+      await local.stop()
+    }
+  })
+
   it('requires the mounted PostgreSQL configuration before starting the execution plane', async () => {
     const k8sDaemon = daemon({ root: root(), k8s: true, dataPlane: false })
     await expect(k8sDaemon.start()).rejects.toThrow(/data-plane configuration is not readable/)

--- a/packages/daemon/test/daemon-supervisor-k8s.test.ts
+++ b/packages/daemon/test/daemon-supervisor-k8s.test.ts
@@ -24,9 +24,16 @@ function daemon(opts: { k8s?: boolean; supervisor?: string; requestExit?: (code:
     ...(opts.k8s
       ? {
           k8s: true,
-          // k8s-mode POLICY is what this file tests; the execution plane needs a cluster and has
-          // its own suite. Stubbing it keeps the refusal-to-boot-without-a-cluster behaviour
-          // real everywhere else.
+          // This suite tests k8s lifecycle policy; cluster and data-plane behavior have dedicated suites.
+          openDataPlane: async () =>
+            ({
+              transcripts: {
+                appendTranscript: () => {},
+                insertToolCall: () => {},
+                updateToolCall: () => {}
+              },
+              close: async () => {}
+            }) as never,
           startK8sPlane: async () =>
             ({
               driver: {} as never,

--- a/packages/daemon/test/postgres-config.test.ts
+++ b/packages/daemon/test/postgres-config.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { readDataPlaneConfig } from '../src/store/postgres-config.js'
+
+function configFile(value: unknown): string {
+  const file = join(mkdtempSync(join(tmpdir(), 'ac-data-plane-')), 'config.json')
+  writeFileSync(file, JSON.stringify(value))
+  return file
+}
+
+describe('mounted data-plane configuration', () => {
+  it('accepts a PostgreSQL DSN and an isolated org schema', () => {
+    expect(
+      readDataPlaneConfig(
+        configFile({ version: 1, databaseUrl: 'postgresql://daemon:secret@postgres/data_plane', schema: 'org_a1' })
+      )
+    ).toEqual({
+      version: 1,
+      databaseUrl: 'postgresql://daemon:secret@postgres/data_plane',
+      schema: 'org_a1',
+      maxConnections: 4
+    })
+  })
+
+  it('rejects non-PostgreSQL URLs and unsafe schema identifiers', () => {
+    expect(() =>
+      readDataPlaneConfig(configFile({ version: 1, databaseUrl: 'https://postgres/data_plane', schema: 'org-a' }))
+    ).toThrow(/databaseUrl must be a PostgreSQL URL/)
+    expect(() =>
+      readDataPlaneConfig(configFile({ version: 1, databaseUrl: 'postgresql://postgres/data_plane', schema: 'org-a' }))
+    ).toThrow(/schema/)
+  })
+
+  it('does not include a missing file error or credential material in its message', () => {
+    expect(() => readDataPlaneConfig('/definitely/missing/ac-data-plane.json')).toThrow(
+      'data-plane configuration is not readable at /definitely/missing/ac-data-plane.json'
+    )
+  })
+})

--- a/packages/daemon/test/postgres-migrations.test.ts
+++ b/packages/daemon/test/postgres-migrations.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PoolClient } from 'pg'
+import { DATA_PLANE_SCHEMA_VERSION, migrateDataPlaneSchema } from '../src/store/postgres-migrations.js'
+
+function clientWithVersions(versions: number[]) {
+  const queries: Array<{ text: string; values?: unknown[] }> = []
+  const query = vi.fn(async (text: string, values?: unknown[]) => {
+    queries.push({ text, values })
+    return text.startsWith('SELECT version') ? { rows: versions.map((version) => ({ version })) } : { rows: [] }
+  })
+  return { client: { query } as unknown as PoolClient, queries }
+}
+
+describe('PostgreSQL data-plane migrations', () => {
+  it('serializes first touch and records every migration before commit', async () => {
+    const { client, queries } = clientWithVersions([])
+    await migrateDataPlaneSchema(client, 'org_a')
+    expect(queries.map(({ text }) => text.trim().split(/\s+/, 2).join(' '))).toEqual([
+      'BEGIN',
+      'SELECT pg_advisory_xact_lock(hashtext($1),',
+      'CREATE SCHEMA',
+      'SET LOCAL',
+      'CREATE TABLE',
+      'SELECT version',
+      'CREATE SEQUENCE',
+      'INSERT INTO',
+      'COMMIT'
+    ])
+    expect(queries[1]?.values).toEqual(['org_a'])
+    expect(queries.at(-2)?.values).toEqual([DATA_PLANE_SCHEMA_VERSION])
+  })
+
+  it('is idempotent when the current version is already installed', async () => {
+    const { client, queries } = clientWithVersions([DATA_PLANE_SCHEMA_VERSION])
+    await migrateDataPlaneSchema(client, 'org_a')
+    expect(queries.some(({ text }) => text.includes('CREATE SEQUENCE transcript_revision_seq'))).toBe(false)
+    expect(queries.at(-1)?.text).toBe('COMMIT')
+  })
+
+  it('rolls back instead of opening a schema written by a newer daemon', async () => {
+    const { client, queries } = clientWithVersions([DATA_PLANE_SCHEMA_VERSION + 1])
+    await expect(migrateDataPlaneSchema(client, 'org_a')).rejects.toThrow(/newer than supported/)
+    expect(queries.at(-1)?.text).toBe('ROLLBACK')
+  })
+})

--- a/packages/daemon/test/postgres-transcript-store.int.test.ts
+++ b/packages/daemon/test/postgres-transcript-store.int.test.ts
@@ -49,8 +49,60 @@ describe.skipIf(!databaseUrl)('PostgreSQL transcript store', () => {
       ])
       expect(forA.rows.map((row) => row.text)).toEqual(['shared durable row'])
       expect(forB.rows.map((row) => row.text)).toEqual(['shared durable row'])
+      expect(forA.cursor).toBe(forA.rows[0]!.revision)
       expect(await first.transcripts.currentTranscriptRevision()).toBeGreaterThan(0)
     } finally {
+      await Promise.all([first.close(), second.close()])
+    }
+  })
+
+  it('serializes revision assignment through commit across daemon pools', async () => {
+    const schema = `org_test_${randomUUID().replaceAll('-', '')}`
+    schemas.push(schema)
+    const config = { version: 1 as const, databaseUrl: databaseUrl!, schema, maxConnections: 2 }
+    const [first, second] = await Promise.all([PostgresDataPlane.open(config), PostgresDataPlane.open(config)])
+    const setup = new Pool({ connectionString: databaseUrl })
+    try {
+      await setup.query(`SET search_path TO ${quotePgIdentifier(schema)}, pg_catalog`)
+      await setup.query(`
+        CREATE FUNCTION delay_slow_transcript() RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+          IF NEW.sender = 'slow-writer' THEN PERFORM pg_sleep(0.4); END IF;
+          RETURN NEW;
+        END $$;
+        CREATE TRIGGER delay_slow_transcript BEFORE INSERT ON transcript
+          FOR EACH ROW EXECUTE FUNCTION delay_slow_transcript();
+      `)
+      first.transcripts.appendTranscript({
+        channel: 'C2',
+        thread: 'T2',
+        ts: '2.000001',
+        sender: 'slow-writer',
+        recipient: 'agent-a',
+        kind: 'text',
+        text: 'commits first'
+      })
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      second.transcripts.appendTranscript({
+        channel: 'C2',
+        thread: 'T2',
+        ts: '2.000002',
+        sender: 'fast-writer',
+        recipient: 'agent-a',
+        kind: 'text',
+        text: 'commits second'
+      })
+      const firstCommit = await Promise.race([
+        first.transcripts.flush().then(() => 'slow'),
+        second.transcripts.flush().then(() => 'fast')
+      ])
+      expect(firstCommit).toBe('slow')
+      await Promise.all([first.transcripts.flush(), second.transcripts.flush()])
+      const tail = await first.transcripts.transcriptTailForAgent('C2', 'T2', 'agent-a', 0, 10)
+      expect(tail.rows.map((row) => row.text)).toEqual(['commits first', 'commits second'])
+      expect(tail.cursor).toBe(tail.rows.at(-1)!.revision)
+    } finally {
+      await setup.end()
       await Promise.all([first.close(), second.close()])
     }
   })

--- a/packages/daemon/test/postgres-transcript-store.int.test.ts
+++ b/packages/daemon/test/postgres-transcript-store.int.test.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from 'node:crypto'
+import { Pool } from 'pg'
+import { afterAll, describe, expect, it } from 'vitest'
+import { PostgresDataPlane } from '../src/store/postgres-transcript-store.js'
+import { quotePgIdentifier } from '../src/store/postgres-migrations.js'
+
+const databaseUrl = process.env.DATA_PLANE_TEST_DATABASE_URL
+const schemas: string[] = []
+
+afterAll(async () => {
+  if (!databaseUrl || schemas.length === 0) return
+  const pool = new Pool({ connectionString: databaseUrl })
+  try {
+    for (const schema of schemas) await pool.query(`DROP SCHEMA ${quotePgIdentifier(schema)} CASCADE`)
+  } finally {
+    await pool.end()
+  }
+})
+
+describe.skipIf(!databaseUrl)('PostgreSQL transcript store', () => {
+  it('shares one org schema safely across daemon pools and upgrades it once', async () => {
+    const schema = `org_test_${randomUUID().replaceAll('-', '')}`
+    schemas.push(schema)
+    const config = { version: 1 as const, databaseUrl: databaseUrl!, schema, maxConnections: 2 }
+    const [first, second] = await Promise.all([PostgresDataPlane.open(config), PostgresDataPlane.open(config)])
+    try {
+      first.transcripts.appendTranscript({
+        channel: 'C1',
+        thread: 'T1',
+        ts: '1.000001',
+        sender: 'U1',
+        recipient: 'agent-a',
+        kind: 'text',
+        text: 'shared durable row'
+      })
+      second.transcripts.appendTranscript({
+        channel: 'C1',
+        thread: 'T1',
+        ts: '1.000001',
+        sender: 'U1',
+        recipient: 'agent-b',
+        kind: 'text',
+        text: 'shared durable row'
+      })
+      await Promise.all([first.transcripts.flush(), second.transcripts.flush()])
+      const [forA, forB] = await Promise.all([
+        first.transcripts.transcriptPageForAgent('C1', 'T1', 'agent-a', null, 10),
+        second.transcripts.transcriptPageForAgent('C1', 'T1', 'agent-b', null, 10)
+      ])
+      expect(forA.rows.map((row) => row.text)).toEqual(['shared durable row'])
+      expect(forB.rows.map((row) => row.text)).toEqual(['shared durable row'])
+      expect(await first.transcripts.currentTranscriptRevision()).toBeGreaterThan(0)
+    } finally {
+      await Promise.all([first.close(), second.close()])
+    }
+  })
+})

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -29,7 +29,7 @@ function seedHistorySession(s: LocalStore, { platform = 'slack', channel = 'C1',
 }
 
 describe('SessionReader', () => {
-  it('reads only the transcript namespace persisted on the session', () => {
+  it('reads only the transcript namespace persisted on the session', async () => {
     const s = store()
     s.upsertSession({
       key: sessionKey('telegram', '42', 'dm', AGENT),
@@ -62,7 +62,7 @@ describe('SessionReader', () => {
       text: 'private to bot B'
     })
 
-    const history = createSessionReader(s).history({
+    const history = await createSessionReader(s).history({
       agentId: AGENT,
       sessionId: 'acp-scoped',
       limit: 20
@@ -71,7 +71,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('list joins cached channel/triggeredBy names; unresolved ids omit the fields', () => {
+  it('list joins cached channel/triggeredBy names; unresolved ids omit the fields', async () => {
     const s = store()
     s.upsertSession({
       key: sessionKey('slack', 'C1', 'T1', AGENT),
@@ -121,7 +121,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('falls back to the first user message as the title when the runtime pushed none', () => {
+  it('falls back to the first user message as the title when the runtime pushed none', async () => {
     const s = store()
     // A webchat/playground session: the runtime never pushed a session/info title.
     s.upsertSession({
@@ -181,7 +181,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('first-message fallback takes one line, caps length, and rewrites <@U…> mentions', () => {
+  it('first-message fallback takes one line, caps length, and rewrites <@U…> mentions', async () => {
     const s = store()
     s.upsertSession({
       key: sessionKey('slack', 'C1', 'T1', AGENT),
@@ -214,7 +214,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('uses persisted source URLs and derives the Slack fallback from the owning workspace', () => {
+  it('uses persisted source URLs and derives the Slack fallback from the owning workspace', async () => {
     const s = store()
     // Slack session with a realistic thread-root ts.
     s.upsertSession({
@@ -281,7 +281,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('history labels senders with cached names and leaves unknown ids raw', () => {
+  it('history labels senders with cached names and leaves unknown ids raw', async () => {
     const s = store()
     const transportScope = 'slack:one'
     const transcriptChannel = transcriptChannelKey('C1', transportScope)
@@ -319,7 +319,7 @@ describe('SessionReader', () => {
     s.setProfileAvatar(transportScope, 'U1', 'https://avatars.example.test/dana.png', 1)
 
     const reader = createSessionReader(s)
-    const { messages } = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
+    const { messages } = await reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
     expect(messages.map((m) => [m.sender, m.senderName, m.senderAvatarUrl])).toEqual([
       ['U1', 'Dana Reyes', 'https://avatars.example.test/dana.png'],
       [AGENT, undefined, undefined] // agent-id senders have no cached provider profile → omitted
@@ -327,7 +327,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('history restores a daemon-local webchat image without the synthetic attachment suffix', () => {
+  it('history restores a daemon-local webchat image without the synthetic attachment suffix', async () => {
     const s = store()
     seedHistorySession(s, { platform: 'webchat', channel: 'conv-1', thread: 'webchat:conv-1' })
     s.appendTranscript({
@@ -341,7 +341,7 @@ describe('SessionReader', () => {
       attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: 'aW1hZ2U=' }]
     })
 
-    expect(createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+    expect((await createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })).messages).toEqual([
       expect.objectContaining({
         text: 'Identify this',
         attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: 'aW1hZ2U=' }]
@@ -350,7 +350,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('strips a label the row does not literally agree with (observer wrote it pre-download)', () => {
+  it('strips a label the row does not literally agree with (observer wrote it pre-download)', async () => {
     // recordObservedInbound recorded the Feishu label before any download settled the
     // type, so the row says application/octet-stream while the stored image is a PNG.
     const s = store()
@@ -366,7 +366,7 @@ describe('SessionReader', () => {
       attachments: [{ name: 'img_v3_abc', mimeType: 'image/png', data: 'aW1hZ2U=' }]
     })
 
-    expect(createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+    expect((await createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })).messages).toEqual([
       expect.objectContaining({
         text: 'look',
         attachments: [{ name: 'img_v3_abc', mimeType: 'image/png', data: 'aW1hZ2U=' }]
@@ -375,7 +375,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('keeps the label for files it could not inline beside the one image it did', () => {
+  it('keeps the label for files it could not inline beside the one image it did', async () => {
     // Only the first small image is stored; the PDF and the over-cap second image must
     // still be visible as their labels rather than vanishing with the whole suffix.
     const s = store()
@@ -391,7 +391,7 @@ describe('SessionReader', () => {
       attachments: [{ name: 'small.png', mimeType: 'image/png', data: 'aW1hZ2U=' }]
     })
 
-    expect(createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+    expect((await createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })).messages).toEqual([
       // The comma inside `report, final.pdf` is part of the file NAME, not a separator.
       expect.objectContaining({
         text: 'review these\n[attached: report, final.pdf (application/pdf), huge.png (image/png)]',
@@ -401,7 +401,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('leaves the row alone when the label names nothing the attachment matches', () => {
+  it('leaves the row alone when the label names nothing the attachment matches', async () => {
     const s = store()
     seedHistorySession(s)
     s.appendTranscript({
@@ -415,13 +415,13 @@ describe('SessionReader', () => {
       attachments: [{ name: 'shot.png', mimeType: 'image/png', data: 'aW1hZ2U=' }]
     })
 
-    expect(createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+    expect((await createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })).messages).toEqual([
       expect.objectContaining({ text: 'see\n[attached: other.pdf (application/pdf)]' })
     ])
     s.close()
   })
 
-  it('carries daemon-verified Slack bot provenance to the session DTO', () => {
+  it('carries daemon-verified Slack bot provenance to the session DTO', async () => {
     const s = store()
     seedHistorySession(s)
     s.appendTranscript({
@@ -435,13 +435,13 @@ describe('SessionReader', () => {
       text: 'legacy agent reply'
     })
 
-    expect(createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+    expect((await createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })).messages).toEqual([
       expect.objectContaining({ sender: 'UAPPBOT', trustedAgentBot: true })
     ])
     s.close()
   })
 
-  it('binds session and tool-body reads to the authorized agent in a shared thread', () => {
+  it('binds session and tool-body reads to the authorized agent in a shared thread', async () => {
     const s = store()
     seedHistorySession(s)
     s.upsertSession({
@@ -469,20 +469,22 @@ describe('SessionReader', () => {
     const reader = createSessionReader(s)
     // A peer's private tool row is absent from both the visible agent's history
     // and its direct full-body lookup, even though the sessions share a thread.
-    expect(reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([])
-    expect(reader.toolBody({ agentId: AGENT, sessionId: 'acp-1', toolCallId: 'peer-tc', offset: 0 }).data).toBe('')
-    // The session itself is also bound to its agent, while the peer owner can read its body.
-    expect(reader.history({ agentId: OTHER_AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([])
-    expect(reader.toolBody({ agentId: OTHER_AGENT, sessionId: 'acp-1', toolCallId: 'peer-tc', offset: 0 }).data).toBe(
+    expect((await reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })).messages).toEqual([])
+    expect((await reader.toolBody({ agentId: AGENT, sessionId: 'acp-1', toolCallId: 'peer-tc', offset: 0 })).data).toBe(
       ''
     )
+    // The session itself is also bound to its agent, while the peer owner can read its body.
+    expect((await reader.history({ agentId: OTHER_AGENT, sessionId: 'acp-1', limit: 50 })).messages).toEqual([])
     expect(
-      reader.toolBody({ agentId: OTHER_AGENT, sessionId: 'acp-peer', toolCallId: 'peer-tc', offset: 0 }).data
+      (await reader.toolBody({ agentId: OTHER_AGENT, sessionId: 'acp-1', toolCallId: 'peer-tc', offset: 0 })).data
+    ).toBe('')
+    expect(
+      (await reader.toolBody({ agentId: OTHER_AGENT, sessionId: 'acp-peer', toolCallId: 'peer-tc', offset: 0 })).data
     ).toBe(body)
     s.close()
   })
 
-  it('keeps session reads available for a rolling upgrade from a legacy CP', () => {
+  it('keeps session reads available for a rolling upgrade from a legacy CP', async () => {
     const s = store()
     seedHistorySession(s)
     const body = JSON.stringify({ toolCallId: 'tc-1', rawOutput: 'ok' })
@@ -497,12 +499,12 @@ describe('SessionReader', () => {
     })
 
     const reader = createSessionReader(s)
-    expect(reader.history({ sessionId: 'acp-1', limit: 50 }).messages).toHaveLength(1)
-    expect(reader.toolBody({ sessionId: 'acp-1', toolCallId: 'tc-1', offset: 0 }).data).toBe(body)
+    expect((await reader.history({ sessionId: 'acp-1', limit: 50 })).messages).toHaveLength(1)
+    expect((await reader.toolBody({ sessionId: 'acp-1', toolCallId: 'tc-1', offset: 0 })).data).toBe(body)
     s.close()
   })
 
-  it('history scopes to what THIS agent received or produced (no peer cross-talk)', () => {
+  it('history scopes to what THIS agent received or produced (no peer cross-talk)', async () => {
     const s = store()
     s.upsertSession({
       key: sessionKey('slack', 'C1', 'T1', AGENT),
@@ -555,16 +557,16 @@ describe('SessionReader', () => {
     })
 
     const reader = createSessionReader(s)
-    const { messages } = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
+    const { messages } = await reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
     expect(messages.map((m) => m.text)).toEqual(['to-me', 'my-reply'])
     s.close()
   })
 
-  it('tails inserts, same-seq tool updates, and newly visible shared deliveries', () => {
+  it('tails inserts, same-seq tool updates, and newly visible shared deliveries', async () => {
     const s = store()
     seedHistorySession(s)
     const reader = createSessionReader(s)
-    const initial = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
+    const initial = await reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
     expect(initial.liveCursor).toBe('0')
 
     s.appendTranscript({
@@ -586,7 +588,7 @@ describe('SessionReader', () => {
       body: JSON.stringify({ toolCallId: 'tc-live', status: 'in_progress' })
     })
 
-    const inserted = reader.history({
+    const inserted = await reader.history({
       agentId: AGENT,
       sessionId: 'acp-1',
       after: initial.liveCursor!,
@@ -600,7 +602,7 @@ describe('SessionReader', () => {
       title: 'Complete',
       body: JSON.stringify({ toolCallId: 'tc-live', status: 'completed' })
     })
-    const updated = reader.history({
+    const updated = await reader.history({
       agentId: AGENT,
       sessionId: 'acp-1',
       after: inserted.liveCursor!,
@@ -618,7 +620,7 @@ describe('SessionReader', () => {
       kind: 'reasoning',
       text: 'peer-private'
     })
-    const privateAdvance = reader.history({
+    const privateAdvance = await reader.history({
       agentId: AGENT,
       sessionId: 'acp-1',
       after: updated.liveCursor!,
@@ -637,7 +639,7 @@ describe('SessionReader', () => {
         text: 'shared-later'
       })
     }
-    const shared = reader.history({
+    const shared = await reader.history({
       agentId: AGENT,
       sessionId: 'acp-1',
       after: privateAdvance.liveCursor!,
@@ -647,7 +649,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('orders Slack history by event time when older thread rows are backfilled after the trigger', () => {
+  it('orders Slack history by event time when older thread rows are backfilled after the trigger', async () => {
     const s = store()
     seedHistorySession(s)
 
@@ -669,7 +671,7 @@ describe('SessionReader', () => {
       })
     }
 
-    const { messages } = createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
+    const { messages } = await createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
     expect(messages.map((m) => m.text)).toEqual([
       'first request',
       'first backfilled reply',
@@ -680,7 +682,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('keeps chronological Slack order across history page boundaries', () => {
+  it('keeps chronological Slack order across history page boundaries', async () => {
     const s = store()
     seedHistorySession(s)
 
@@ -702,7 +704,12 @@ describe('SessionReader', () => {
     const all: string[] = []
     let cursor: string | undefined
     for (let pageNo = 0; pageNo < 10; pageNo++) {
-      const page = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 2, ...(cursor ? { cursor } : {}) })
+      const page = await reader.history({
+        agentId: AGENT,
+        sessionId: 'acp-1',
+        limit: 2,
+        ...(cursor ? { cursor } : {})
+      })
       all.unshift(...page.messages.map((m) => m.text))
       if (!page.nextCursor) break
       cursor = page.nextCursor
@@ -712,7 +719,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('uses seq as a deterministic cross-page tie-breaker for equal event times', () => {
+  it('uses seq as a deterministic cross-page tie-breaker for equal event times', async () => {
     const s = store()
     seedHistorySession(s)
     for (const text of ['same-time-1', 'same-time-2', 'same-time-3']) {
@@ -730,7 +737,12 @@ describe('SessionReader', () => {
     const all: string[] = []
     let cursor: string | undefined
     do {
-      const page = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 1, ...(cursor ? { cursor } : {}) })
+      const page = await reader.history({
+        agentId: AGENT,
+        sessionId: 'acp-1',
+        limit: 1,
+        ...(cursor ? { cursor } : {})
+      })
       all.unshift(...page.messages.map((m) => m.text))
       cursor = page.nextCursor
     } while (cursor)
@@ -739,7 +751,7 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('finishes an in-flight legacy numeric-cursor walk in seq order', () => {
+  it('finishes an in-flight legacy numeric-cursor walk in seq order', async () => {
     const s = store()
     seedHistorySession(s)
     for (const n of [1, 4, 2, 3]) {
@@ -756,13 +768,18 @@ describe('SessionReader', () => {
 
     // Cursor "3" means the old client already saw seq >= 3. Do not reinterpret it
     // as an event-time cursor partway through that request's pagination loop.
-    const page = createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', cursor: '3', limit: 50 })
+    const page = await createSessionReader(s).history({
+      agentId: AGENT,
+      sessionId: 'acp-1',
+      cursor: '3',
+      limit: 50
+    })
     expect(page.messages.map((m) => m.text)).toEqual(['seq-1', 'seq-4'])
     expect(page.nextCursor).toBeUndefined()
     s.close()
   })
 
-  it('preserves insertion ordering for non-Slack platform message ids', () => {
+  it('preserves insertion ordering for non-Slack platform message ids', async () => {
     const s = store()
     seedHistorySession(s, { platform: 'telegram', channel: 'chat-1', thread: 'T1' })
     for (const row of [
@@ -779,22 +796,22 @@ describe('SessionReader', () => {
     }
 
     expect(
-      createSessionReader(s)
-        .history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
-        .messages.map((m) => m.text)
+      (await createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })).messages.map(
+        (m) => m.text
+      )
     ).toEqual(['telegram message 100', 'reasoning after 100', 'telegram message 101'])
     s.close()
   })
 
-  it('tails in mutation order where message ids are opaque, in event order where they are not', () => {
+  it('tails in mutation order where message ids are opaque, in event order where they are not', async () => {
     // Same two rows, observed newest-first, on two platforms. Mutation order and
     // display order can only diverge where the ids carry a native order — which is
     // exactly what platforms/message-ordering.ts answers.
-    const tailFor = (platform: string): string[] => {
+    const tailFor = async (platform: string): Promise<string[]> => {
       const s = store()
       seedHistorySession(s, { platform, channel: 'chat-1', thread: 'T1' })
       const reader = createSessionReader(s)
-      const initial = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
+      const initial = await reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
       for (const [ts, text] of [
         ['101', 'observed first'],
         ['100', 'older, backfilled after']
@@ -809,12 +826,17 @@ describe('SessionReader', () => {
           text: text!
         })
       }
-      const tail = reader.history({ agentId: AGENT, sessionId: 'acp-1', after: initial.liveCursor!, limit: 50 })
+      const tail = await reader.history({
+        agentId: AGENT,
+        sessionId: 'acp-1',
+        after: initial.liveCursor!,
+        limit: 50
+      })
       s.close()
       return tail.messages.map((m) => m.text)
     }
 
-    expect(tailFor('telegram')).toEqual(['observed first', 'older, backfilled after'])
-    expect(tailFor('slack')).toEqual(['older, backfilled after', 'observed first'])
+    expect(await tailFor('telegram')).toEqual(['observed first', 'older, backfilled after'])
+    expect(await tailFor('slack')).toEqual(['older, backfilled after', 'observed first'])
   })
 })

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -29,6 +29,22 @@ function seedHistorySession(s: LocalStore, { platform = 'slack', channel = 'C1',
 }
 
 describe('SessionReader', () => {
+  it('uses the history page snapshot watermark as the initial live cursor', async () => {
+    const s = store()
+    seedHistorySession(s)
+    const currentTranscriptRevision = vi.fn(async () => 99)
+    const history = await createSessionReader(s, undefined, {
+      transcriptPageForAgentByEventTime: async () => ({ rows: [], hasMore: false, cursor: 17 }),
+      transcriptPageForAgent: async () => ({ rows: [], hasMore: false, cursor: 17 }),
+      transcriptTailForAgent: async () => ({ rows: [], hasMore: false, cursor: 17 }),
+      currentTranscriptRevision,
+      getToolBodyForAgent: async () => undefined
+    } as never).history({ agentId: AGENT, sessionId: 'acp-1', limit: 20 })
+    expect(history.liveCursor).toBe('17')
+    expect(currentTranscriptRevision).not.toHaveBeenCalled()
+    s.close()
+  })
+
   it('reads only the transcript namespace persisted on the session', async () => {
     const s = store()
     s.upsertSession({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,7 +277,7 @@ importers:
         version: 0.0.67
       '@larksuiteoapi/node-sdk':
         specifier: ^1.71.1
-        version: 1.71.1
+        version: 1.71.1(debug@4.3.4)
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0
@@ -326,6 +326,9 @@ importers:
       grammy:
         specifier: ^1.45.1
         version: 1.45.1
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
       simple-git:
         specifier: ^3.36.0
         version: 3.36.0
@@ -357,6 +360,9 @@ importers:
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -10235,9 +10241,9 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@larksuiteoapi/node-sdk@1.71.1':
+  '@larksuiteoapi/node-sdk@1.71.1(debug@4.3.4)':
     dependencies:
-      axios: 1.18.1
+      axios: 1.18.1(debug@4.3.4)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -11595,7 +11601,7 @@ snapshots:
       '@slack/types': 2.22.0
       '@types/node': 24.13.3
       '@types/retry': 0.12.0
-      axios: 1.18.1
+      axios: 1.18.1(debug@4.3.4)
       eventemitter3: 5.0.4
       form-data: 4.0.6
       is-electron: 2.2.2
@@ -12615,7 +12621,7 @@ snapshots:
       - supports-color
     optional: true
 
-  axios@1.18.1:
+  axios@1.18.1(debug@4.3.4):
     dependencies:
       follow-redirects: 1.16.0(debug@4.3.4)
       form-data: 4.0.6

--- a/scripts/verify-daemon-image.mjs
+++ b/scripts/verify-daemon-image.mjs
@@ -105,21 +105,22 @@ check('declares the kubelet as its supervisor', () => {
   return 'AGENTCONNECT_SUPERVISOR=k8s'
 })
 
-check('REFUSES to start outside a pod rather than running runtimes locally', () => {
+check('REFUSES to start without the mandatory data-plane Secret mount', () => {
   const { code, output } = runEntrypoint({ AC_K8S_ORG_ID: 'org-1', AC_K8S_WARM_POOL: 'pool' })
   if (code === 0) throw new Error('the daemon started outside a cluster, so runtimes would run on this host')
-  if (!/not running inside a Kubernetes pod/.test(output)) {
+  if (!/data-plane configuration is not readable at \/var\/run\/ac-data-plane\/config\.json/.test(output)) {
     throw new Error(`refused, but not for the expected reason: ${output.slice(-300)}`)
   }
-  return 'exits with the in-cluster config error'
+  return 'exits before opening the execution plane'
 })
 
 check('names the missing deployment settings instead of guessing them', () => {
-  // A guessed org labels another tenant's claims; a guessed pool yields sandboxes that never bind.
   const { code, output } = runEntrypoint()
-  if (code === 0) throw new Error('started without an org id')
-  if (!/AC_K8S_ORG_ID/.test(output)) throw new Error(`did not name the missing setting: ${output.slice(-300)}`)
-  return 'reports AC_K8S_ORG_ID'
+  if (code === 0) throw new Error('started without the data-plane Secret')
+  if (!/\/var\/run\/ac-data-plane\/config\.json/.test(output)) {
+    throw new Error(`did not name the missing setting: ${output.slice(-300)}`)
+  }
+  return 'reports /var/run/ac-data-plane/config.json'
 })
 
 // The Control Plane persists what this reports as `agentVersion` and drives fleet and upgrade


### PR DESCRIPTION
## Summary

- require a mounted PostgreSQL data-plane configuration whenever the daemon starts with `--k8s`
- persist and read cloud transcripts through a shared, per-org PostgreSQL schema
- add transactionally locked, append-only schema migrations for concurrent daemon startup
- document the Secret mount contract and rolling-upgrade rules

## Why

Cloud daemon members can move between pods and share ownership, so their transcript data cannot remain tied to one daemon's local SQLite file. The Control Plane must also remain outside the message-content data path.

## Behavior

Local and self-hosted daemons continue using SQLite. Kubernetes daemons fail closed when the mounted PostgreSQL configuration is missing, invalid, unreachable, or cannot be migrated. Multiple daemon pools can safely write the same org schema.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- daemon build and self-contained bundle assertion
- targeted daemon unit tests
- PostgreSQL 16 integration test with two independent pools
- `pnpm lint`
- `git diff --check`
