### PR TITLE
fix(daemon): post an agent wake's inbound message to the live webchat view

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7380,6 +7380,28 @@ export class Daemon {
     }
   }
 
+  /** The inbound half of an agent-initiated webchat wake: post the SENDER's message live
+   *  at admission (#807 posted only the woken reply, so this message reached the browser
+   *  only via a page refresh). Shares `msg.transcriptPostId` with the transcript row the
+   *  turn writes, so the browser drops the live step once the canonical row lands. */
+  private postAgentWakeInbound(webchat: WebchatTurnContext | undefined, msg: NormalizedMessage): void {
+    if (webchat?.initiator !== 'agent' || !webchat.postSink) return
+    if (!msg.transcriptPostId || !UUID_RE.test(msg.sender.id)) return
+    msg.transcriptTs ??= monotonicTs() // every wake site sets it; keep row ts == post.at regardless
+    webchat.postSink({
+      conversationId: webchat.conversationId,
+      agentId: msg.sender.id,
+      post: {
+        postId: msg.transcriptPostId,
+        conversationId: webchat.conversationId,
+        author: { kind: 'agent', agentId: msg.sender.id },
+        text: msg.text,
+        at: Number(msg.transcriptTs)
+      },
+      initiator: 'agent'
+    })
+  }
+
   /** Buffer before sending so a transport gap is recoverable even when the live
    * write is lost. The terminal frame carries the final output index for browser
    * gap detection. */
@@ -11437,6 +11459,9 @@ export class Daemon {
         thread,
         ts,
         sender: entry.msg.sender.id,
+        // Carried so a live agent-wake post (postAgentWakeInbound) reconciles against
+        // this row even when its turn was coalesced into an in-flight generation.
+        ...(entry.msg.transcriptPostId ? { postId: entry.msg.transcriptPostId } : {}),
         recipient: entry.agentId,
         kind: 'text',
         text: mention ? `${entry.msg.text}\n${mention}`.trim() : entry.msg.text
@@ -12830,6 +12855,13 @@ export class Daemon {
     if (integrationId !== undefined) {
       msg.transportScope ??= this.transportScopeForIntegrationIds([integrationId])
     }
+    // An agent-initiated wake's INBOUND message posts live too (#807 only posted the woken
+    // REPLY, so the sender's message appeared on refresh but never in the live view). Mint
+    // its canonical post identity before the inbox row persists so a replay reuses it and
+    // the transcript row SessionManager writes carries the same postId (browser reconcile).
+    if (webchat?.initiator === 'agent' && UUID_RE.test(msg.sender.id)) {
+      msg.transcriptPostId ??= randomUUID()
+    }
     if (msg.sender.avatarUrl && msg.transportScope)
       this.store.setProfileAvatar(msg.transportScope, msg.sender.id, msg.sender.avatarUrl, Date.now())
     if (this.cfg.features.turnFinalContextRefresh && originKindOf(msg.platform) === 'chat') {
@@ -12852,6 +12884,9 @@ export class Daemon {
             channel: msg.channel,
             data: { source: msg.source }
           })
+          // NOT for §5.2a continuation wakes: their inbound IS a committed peer post the
+          // browser already rendered — re-posting it would duplicate that reply.
+          if (callMeta?.conversationContinuation !== true) this.postAgentWakeInbound(webchat, msg)
         }
         // §8.6, the ONE place every delivery path settles — live dispatch, queued
         // dispatch, and startup replay alike. Completing the rendezvous here rather than

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11250,6 +11250,9 @@ export class Daemon {
       thread,
       ts,
       sender: msg.sender.id,
+      // The canonical webchat post identity must survive whichever writer wins the
+      // first insert, or the browser's live frame cannot reconcile against the row.
+      ...(msg.transcriptPostId ? { postId: msg.transcriptPostId } : {}),
       ...(recipient ? { recipient } : {}),
       // The observer often wins the INSERT race against SessionManager's
       // authoritative append — the provider send time must ride the FIRST

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1140,6 +1140,59 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     await daemon.stop()
   }, 15_000)
 
+  // #807 follow-up: the fix posted only the woken agent's REPLY live — the SENDER's own
+  // message reached the browser only via refresh (history), never in the live view.
+  it('an agent-initiated wake posts the INBOUND message live, postId shared with its transcript row', async () => {
+    const { factory } = streamingHost([text('forwarding: B says hi')])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    const cp = fakeCpClient()
+    ;(daemon as any).cpClient = cp
+    const posts: any[] = []
+    ;(daemon as any).relays = { stop: vi.fn(async () => {}), sendWebchatPost: (p: any) => posts.push(p) }
+
+    const SENDER = '99999999-9999-4999-8999-999999999999'
+    const thread = `webchat:${CONV}`
+    const msg = {
+      msgId: `agentcall:${CONV}:d-1`,
+      traceId: 'd-1',
+      source: 'agent' as const,
+      platform: 'webchat' as const,
+      channel: CONV,
+      thread,
+      transcriptTs: String(Date.now()),
+      sender: { id: SENDER, isBot: true },
+      text: 'hi from B',
+      mentionedBots: [] as string[],
+      isDm: false
+    }
+    await (daemon as any).dispatch(AGENT_ID, msg, undefined, (daemon as any).webchatWakeContext('webchat', CONV))
+
+    // Two live posts: the inbound sender message first, then the woken reply.
+    expect(posts).toHaveLength(2)
+    expect(posts[0]).toMatchObject({
+      conversationId: CONV,
+      agentId: SENDER,
+      initiator: 'agent',
+      post: { author: { kind: 'agent', agentId: SENDER }, text: 'hi from B', at: Number(msg.transcriptTs) }
+    })
+    expect(posts[1]).toMatchObject({
+      agentId: AGENT_ID,
+      initiator: 'agent',
+      post: { author: { kind: 'agent', agentId: AGENT_ID }, text: 'forwarding: B says hi' }
+    })
+    // The transcript row carries the same postId, so a later transcript refetch
+    // reconciles the live step instead of double-rendering it.
+    const rows = (daemon as any).store.threadTranscript(CONV, thread) as {
+      sender: string
+      postId?: string
+      text: string
+    }[]
+    const inbound = rows.find((r) => r.sender === SENDER)
+    expect(inbound?.postId).toBe(posts[0].post.postId)
+    await daemon.stop()
+  }, 15_000)
+
   it('records EVERY user turn — a stable per-conversation msgId must not dedup follow-ups', async () => {
     // Regression: webchat's msgId is stable per conversation, so a naive transcript ts
     // (derived from the msgId) is identical for every turn — the (channel,thread,ts) unique

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -895,18 +895,28 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 // wake, #753): it never streamed output/done to this socket, so the
                 // completed post IS its first and only rendering here.
                 const agentId = m.post.author.agentId
-                pushStep(id, {
-                  kind: 'done',
-                  turnId: m.post.postId,
-                  // The daemon persists this reply before the post frame ever arrives, so
-                  // `postId` is what lets `reconcilePersistedLiveSteps` drop this step once
-                  // the canonical row lands in a later transcript refresh (#753) — text/time
-                  // matching (the prompt-turn heuristic) has nothing to anchor on here.
-                  postId: m.post.postId,
-                  agentId,
-                  ...(participantName(id, agentId) ? { who: participantName(id, agentId) } : {}),
-                  text: m.post.text
-                })
+                const post = m.post
+                // Keyed by postId so a daemon re-broadcast (inbox replay, relay fan-out
+                // echo) upserts instead of duplicating the step.
+                mutateSteps(id, (steps) =>
+                  steps.some((step) => step.postId === post.postId)
+                    ? steps
+                    : [
+                        ...steps,
+                        stampStep({
+                          kind: 'done',
+                          turnId: post.postId,
+                          // The daemon persists this reply before the post frame ever arrives, so
+                          // `postId` is what lets `reconcilePersistedLiveSteps` drop this step once
+                          // the canonical row lands in a later transcript refresh (#753) — text/time
+                          // matching (the prompt-turn heuristic) has nothing to anchor on here.
+                          postId: post.postId,
+                          agentId,
+                          ...(participantName(id, agentId) ? { who: participantName(id, agentId) } : {}),
+                          text: post.text
+                        })
+                      ]
+                )
               } else if (m.type === 'ack' && m.ack?.accepted !== false) {
                 let key = cursorKeyFor(id, m.ack?.agentId)
                 // The relay may target participants the client did not lane (a

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -27,7 +27,12 @@ vi.mock('@/lib/api', () => ({
   agentApiRelayUrl: () => 'wss://relay.test',
   fetchSessionMessages: vi.fn(async () => ({ messages: [] })),
   mintWebchatConversation: vi.fn(async () => ({ conversationId: 'c1' })),
-  webchatSocketUrl: () => 'wss://relay.test/ws'
+  webchatSocketUrl: () => 'wss://relay.test/ws',
+  // Rejects by default so the acceptance tests keep their fail-fast send path
+  // (busy clears, the queue dispatcher runs); the post-frame tests resolve it.
+  webchatWsUrl: vi.fn(async () => {
+    throw new Error('no relay in this test')
+  })
 }))
 
 const { PlaygroundProvider, usePlayground } = await import('./PlaygroundProvider')
@@ -206,5 +211,48 @@ describe('pgSend acceptance', () => {
   // probe wiring is real and not a partially-mocked stand-in.
   it('exposes the real provider surface', () => {
     expect(typeof openPlayground).toBe('function')
+  })
+})
+
+// #807 follow-up: an agent-initiated post renders once per postId — the daemon may
+// re-broadcast the same canonical post (inbox replay, relay fan-out echo).
+describe('agent-initiated post frames', () => {
+  class CapturingSocket extends StubSocket {
+    static instances: CapturingSocket[] = []
+    onopen?: () => void
+    onmessage?: (e: { data: string }) => void
+    onerror?: (e: unknown) => void
+    onclose?: () => void
+    constructor() {
+      super()
+      CapturingSocket.instances.push(this)
+    }
+  }
+
+  it('dedups a re-broadcast post by postId', async () => {
+    CapturingSocket.instances = []
+    Reflect.set(globalThis, 'WebSocket', CapturingSocket)
+    const api = await import('@/lib/api')
+    vi.mocked(api.webchatWsUrl).mockResolvedValue('wss://relay.test/ws')
+    await act(async () => {
+      pgSend('s1', 'agent-1', 'hello', 'c1')
+    })
+    const sock = CapturingSocket.instances[0]!
+    await act(async () => {
+      sock.readyState = 1
+      sock.onopen?.()
+    })
+    const frame = JSON.stringify({
+      type: 'post',
+      initiator: 'agent',
+      post: { postId: 'post-9', author: { kind: 'agent', agentId: 'agent-2' }, text: 'hi from B' }
+    })
+    await act(async () => {
+      sock.onmessage?.({ data: frame })
+      sock.onmessage?.({ data: frame })
+    })
+    const posts = getLiveSteps('s1').filter((s) => s.postId === 'post-9')
+    expect(posts).toHaveLength(1)
+    expect(posts[0]).toMatchObject({ kind: 'done', agentId: 'agent-2', text: 'hi from B' })
   })
 })

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1832,8 +1832,11 @@ export default function SessionDetailView() {
 
     // Live parity with relatedTranscriptAgentIds: a visible agent that spoke via a live
     // agent-initiated post (#753) joins the roster now, not on the next full refresh.
-    if (session?.platform === 'webchat' && session.id) {
-      for (const step of getLiveSteps(session.id)) {
+    // Adopted webchat keeps its live tail in getLiveSteps; a synthetic Playground
+    // session carries its steps on the session row itself.
+    if (session && (session.platform === 'webchat' || session.platform === 'playground')) {
+      const liveTail = session.platform === 'webchat' ? getLiveSteps(session.id) : session.steps
+      for (const step of liveTail) {
         if (step.agentId && agentById.has(step.agentId)) candidates.push({ agentId: step.agentId })
       }
     }

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1830,6 +1830,14 @@ export default function SessionDetailView() {
       }
     }
 
+    // Live parity with relatedTranscriptAgentIds: a visible agent that spoke via a live
+    // agent-initiated post (#753) joins the roster now, not on the next full refresh.
+    if (session?.platform === 'webchat' && session.id) {
+      for (const step of getLiveSteps(session.id)) {
+        if (step.agentId && agentById.has(step.agentId)) candidates.push({ agentId: step.agentId })
+      }
+    }
+
     const seen = new Set<string>()
     return candidates.flatMap((candidate) => {
       if (!candidate.agentId || seen.has(candidate.agentId)) return []
@@ -1859,6 +1867,7 @@ export default function SessionDetailView() {
     conversationMembers,
     currentSessionDetail,
     flatView,
+    getLiveSteps,
     orgPath,
     relatedTranscriptAgentIds,
     session


### PR DESCRIPTION
## Summary

Follow-up to #807, which didn't fully close #753: it delivered only the **woken agent's completed reply** to the live browser view. The wake's **inbound message itself** — e.g. Agent B's lineage reply landing back in Agent A's webchat origin session — produced no live frame at all. Reproduced with a session whose prompt was *"Send Hello to Agent B and forward reply"*: live mode showed only A's forwarded text; after a refresh, history mode showed B's chat message and the header agents list gained B.

Root cause: the inbound message only ever reached the transcript (written by `SessionManager.handle` at turn start). It has no `rd/chat` stream of its own, and #807's `webchatWakeContext` posts only at the turn-completion boundary — so nothing ever told the browser that B had spoken.

### daemon

- `dispatch()` mints a canonical post identity (`msg.transcriptPostId`) for `initiator:'agent'` wakes **before** the inbox row persists, so a startup replay reuses it and the transcript row `SessionManager` writes carries the same id.
- New `postAgentWakeInbound()`: at admission (queued turns included, so the message is visible while the target is still busy), the inbound message goes out as an `rd/webchat-post` (`author` = sending agent, `initiator:'agent'`) over the same #807 relay machinery. Shared `postId` is what lets the browser's `reconcilePersistedLiveSteps` drop the live step once the canonical row lands — no double-render after a transcript refetch.
- A queue-coalesced entry's transcript row (`coalesceQueuedContext`) now carries the `postId` too, keeping that guarantee when the wake folds into an in-flight generation.
- **§5.2a interplay (#906):** `conversationContinuation` wakes are explicitly excluded — their inbound *is* a committed peer post the browser already rendered; re-posting would duplicate it. The existing continuation tests assert exact post counts and pass unchanged. Conversely, the new inbound post carries no `author.hopCount`, so its context fan-out stays transcript-only for peers (`maybeActivateWebchatContinuation`'s depth gate) — exactly the pre-existing activation semantics.

### web

- `PlaygroundProvider` dedups agent-initiated post frames by `postId`, so a daemon re-broadcast (inbox replay, relay echo) upserts instead of duplicating a step.
- `SessionDetailView`'s header focus roster now includes visible agents that authored live steps — live parity with what `relatedTranscriptAgentIds` derives from the persisted transcript after a refresh, so Agent B appears in the header the moment its post arrives.

No protocol or relay changes: the #807 `initiator` marker and forwarding path are reused as-is.

## Test plan

- [x] New daemon regression test: an agent-initiated wake emits **two** live posts (inbound first, then the reply), and the inbound transcript row shares the inbound post's `postId` (`daemon-webchat.test.ts`)
- [x] New web regression test: a re-broadcast post frame with the same `postId` renders once (`PlaygroundSend.test.tsx`)
- [x] `daemon-webchat`, `daemon-webchat-continuation`, `daemon-message-agent`, `durable-inbox`, `webchat-turn-refresh` — 197 tests pass
- [x] Full web suite — 1514 tests pass
- [x] `typecheck` clean on daemon and web; `eslint` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)