### PR TITLE
test(evals): cross-surface activation parity suite (one spec, per-surface legs)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -214,6 +214,14 @@ jobs:
         env:
           CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/unit-test-summary.md
         run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm eval:collab:contracts
+      # Cross-surface activation parity (docs/designs/activation-parity.md):
+      # one scenario spec, per-surface legs — a PR that changes "who does this
+      # message activate" on one surface must either keep every leg green or
+      # declare the divergence in evals/parity/spec.ts with a citation.
+      - name: Activation parity contracts
+        env:
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/unit-test-summary.md
+        run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm eval:parity
       - name: Merge unit test summaries
         if: ${{ !cancelled() }}
         env:

--- a/docs/designs/activation-parity.md
+++ b/docs/designs/activation-parity.md
@@ -1,0 +1,119 @@
+# Activation Parity Across Surfaces
+
+Companion to [`send-message-routing-rework.md`](send-message-routing-rework.md)
+(the platform ladder), [`webchat-multi-agents.md`](webchat-multi-agents.md)
+(webchat activation), and
+[`collaboration-arena-baseline.md`](collaboration-arena-baseline.md) (the
+measured behavior of the platform ladder). This document defines the **parity
+suite** and the governance rule attached to it.
+
+## 1. Why this exists
+
+"Who does this message activate" is implemented more than once:
+
+1. **The daemon platform ladder** —
+   `packages/daemon/src/router/routing-table.ts` (`routeRules`, kind precedence
+   mention > dm > keyword > auto) plus the verified agent-author ladder in
+   `packages/daemon/src/daemon.ts` (`routeVerifiedAgentMessage` /
+   `fanOutToThreadPeers`), including the #549 rung: a verified agent-authored
+   message naming nobody continues the conversation with the author excluded,
+   hop-bounded.
+2. **The relay's arbitration** for relayed platform ingress —
+   `packages/relay/src/bot-arbitration.ts`, the "same rules" per
+   send-message-routing-rework.md §6, but a separate implementation over
+   already-attributed routes.
+3. **Webchat multi-agent activation** — roster/standing-mention semantics
+   (webchat-multi-agents.md §4.2), with agent-continuation parity added by
+   PR #906 (`maybeActivateWebchatContinuation`, §5.2a).
+
+Copy 3 missed the #549 policy change **for months**: after #549 flipped the
+platform ladders to conversation continuation, webchat kept treating agent
+posts as pure context, so an alternating multi-agent conversation ran to
+completion on Slack and stalled after one round on webchat (issue #904, fixed
+by PR #906). Nothing failed while the copies drifted — that silence is the
+defect this suite removes.
+
+The shared machinery **below** the ladders — sessions/turns, the regeneration
+fence, the hop cap (`MAX_AGENT_CALL_HOPS`), the durable loop guard, the
+activation rendezvous — is single-implementation and is _not_ re-pinned here
+beyond what the scenarios observe through it.
+
+## 2. The suite
+
+One surface-agnostic scenario spec, several per-surface legs:
+
+- **Spec:** [`evals/parity/spec.ts`](../../evals/parity/spec.ts) — each
+  scenario is data: an invariant sentence plus per-surface expected outcomes in
+  one vocabulary (`mentioned-only`, `roster`, `participants-minus-author`,
+  `named-peer-exactly-once`, `parent-exactly-once`, `nobody`, chain-refusal
+  reasons). Where surfaces intentionally differ, the spec carries a
+  **declared divergence** with design-doc citations.
+- **Slack-shaped leg:** `evals/test/parity-slack.test.ts` — the arena routing
+  fixture (`evals/test/routing-fixture.ts`): a real daemon, one mention-gated
+  Slack-shaped room, scripted hosts, production-style platform echo.
+- **Webchat leg:** `evals/test/parity-webchat.test.ts` — the daemon-level seam
+  the #906 tests drive (`handleRelayMsg` + played relay fan-out), via the
+  shared fixture `packages/daemon/test/webchat-continuation-fixture.ts`.
+- **Spec guard:** `evals/test/parity-spec.test.ts` — the spec itself stays
+  well-formed (unique ids, expectation xor declared-not-applicable per surface,
+  undeclared cross-surface differences fail, citations point into
+  `docs/designs/`).
+
+Each leg iterates the spec and must implement a driver for every scenario the
+spec declares for its surface — a scenario added to the spec without a driver
+fails the leg's coverage guard. All of it is credential-free and runs in the
+Unit Test CI gate: `pnpm eval:parity`.
+
+The relay's arbitrate ladder has no leg yet; it is pinned by its own unit suite
+(`packages/relay/src/bot-arbitration.test.ts`) and inherits the daemon
+expectations by construction ("same rules", §6). It gains a leg when the
+single policy module lands and the relay consumes it.
+
+### 2.1 Declared per-surface divergences (as of this writing)
+
+- **Human kickoff** — channels are mention-gated per message
+  (shared-channel convention); webchat roster membership _is_ the standing
+  mention, so an unnarrowed kickoff activates the whole roster
+  (webchat-multi-agents.md §4.2).
+- **Which protection terminates an unattended chain** — both surfaces charge
+  the same +1 hop per edge against `MAX_AGENT_CALL_HOPS`, but channels _also_
+  charge the durable loop guard, whose automatic-turn budget binds first
+  (16 edges for a two-agent room, refusal reason `gated`;
+  collaboration-arena-baseline.md §6.1). Webchat deliberately charges only the
+  exact hop cap — it has no in-band `!resume` to reset a guard latch — so the
+  same chain runs to the cap and is refused there (`hop_limit`;
+  webchat-multi-agents.md §5.2a).
+
+## 3. Governance rule
+
+**Any PR that changes activation/routing behavior — the daemon ladder, the
+relay arbitration, webchat activation, or the verified-author continuation —
+must update the parity spec.** Concretely, one of:
+
+1. every applicable leg still passes against the unchanged spec (a pure
+   refactor), or
+2. the spec's expected outcomes change **for every surface together**, and
+   every leg passes against the new expectations, or
+3. the change is intentionally per-surface, and the spec records it as a
+   **declared divergence** with a citation into `docs/designs/`.
+
+A leg failing while the others pass is the incident shape of #549/#904/#906 —
+the fix is never to loosen the failing leg locally, it is to decide (1)–(3)
+explicitly in the spec. Reviewers: treat a diff that touches
+`packages/daemon/src/router/`, the daemon's verified-author ladder,
+`packages/relay/src/bot-arbitration.ts`, or
+`maybeActivateWebchatContinuation` without touching `evals/parity/spec.ts` as
+requiring an explanation.
+
+## 4. Running it
+
+```bash
+pnpm eval:parity # spec guard + both legs (credential-free)
+```
+
+The legs also run file-by-file:
+
+```bash
+pnpm exec vitest run evals/test/parity-slack.test.ts
+pnpm exec vitest run evals/test/parity-webchat.test.ts
+```

--- a/docs/designs/activation-parity.md
+++ b/docs/designs/activation-parity.md
@@ -45,7 +45,7 @@ One surface-agnostic scenario spec, several per-surface legs:
 - **Spec:** [`evals/parity/spec.ts`](../../evals/parity/spec.ts) — each
   scenario is data: an invariant sentence plus per-surface expected outcomes in
   one vocabulary (`mentioned-only`, `roster`, `participants-minus-author`,
-  `named-peer-exactly-once`, `parent-exactly-once`, `nobody`, chain-refusal
+  `target-exactly-once`, `parent-exactly-once`, `nobody`, chain-refusal
   reasons). Where surfaces intentionally differ, the spec carries a
   **declared divergence** with design-doc citations.
 - **Slack-shaped leg:** `evals/test/parity-slack.test.ts` — the arena routing

--- a/docs/designs/activation-parity.md
+++ b/docs/designs/activation-parity.md
@@ -53,7 +53,11 @@ One surface-agnostic scenario spec, several per-surface legs:
   Slack-shaped room, scripted hosts, production-style platform echo.
 - **Webchat leg:** `evals/test/parity-webchat.test.ts` — the daemon-level seam
   the #906 tests drive (`handleRelayMsg` + played relay fan-out), via the
-  shared fixture `packages/daemon/test/webchat-continuation-fixture.ts`.
+  shared fixture `packages/daemon/test/webchat-continuation-fixture.ts`. The
+  kickoff scenario computes its turn-vs-context split with the relay's
+  PRODUCTION target choice (`selectTurnTargets`,
+  `packages/relay/src/relay-browser-connection.ts`), so the roster-wide vs
+  mention-narrowed decision is the deployed code, not a re-implementation.
 - **Spec guard:** `evals/test/parity-spec.test.ts` — the spec itself stays
   well-formed (unique ids, expectation xor declared-not-applicable per surface,
   undeclared cross-surface differences fail, citations point into
@@ -61,8 +65,12 @@ One surface-agnostic scenario spec, several per-surface legs:
 
 Each leg iterates the spec and must implement a driver for every scenario the
 spec declares for its surface — a scenario added to the spec without a driver
-fails the leg's coverage guard. All of it is credential-free and runs in the
-Unit Test CI gate: `pnpm eval:parity`.
+fails the leg's coverage guard. Every driver additionally **pins its
+scenario's declared outcome with an exact `toEqual`**
+(`declaredOutcome(scenario.expect[surface])`), so the spec is load-bearing in
+both directions: editing an expectation fails the driver that demonstrates the
+old outcome, and a behavior change fails the driver's measured assertions. All
+of it is credential-free and runs in the Unit Test CI gate: `pnpm eval:parity`.
 
 The relay's arbitrate ladder has no leg yet; it is pinned by its own unit suite
 (`packages/relay/src/bot-arbitration.test.ts`) and inherits the daemon

--- a/docs/designs/collaboration-arena-baseline.md
+++ b/docs/designs/collaboration-arena-baseline.md
@@ -92,6 +92,13 @@ pins the behavior rather than the design's wording.
 Every suite also carries a regression pin that no turn is lost to
 `session_source_mismatch` (issue #583, fixed by #568).
 
+The same activation invariants are additionally pinned **per surface** by the
+cross-surface parity suite ([`activation-parity.md`](activation-parity.md)):
+one scenario spec (`evals/parity/spec.ts`), a Slack-shaped leg reusing this
+routing fixture, and a webchat leg — with the governance rule that any
+activation/routing change either keeps every leg green or declares the
+divergence in the spec.
+
 ## 3. The games
 
 ### 3.1 Peer-driven counting (§10.1 / §3.3)

--- a/evals/parity/spec.ts
+++ b/evals/parity/spec.ts
@@ -277,3 +277,18 @@ export const PARITY_SCENARIOS: readonly ParityScenario[] = [
 export function scenariosFor(surface: ParitySurface): readonly ParityScenario[] {
   return PARITY_SCENARIOS.filter((scenario) => scenario.expect[surface] !== undefined)
 }
+
+/**
+ * The COMPARABLE outcome of an expectation — every field except `notes`, which
+ * is commentary rather than contract.
+ *
+ * Every leg driver pins `declaredOutcome(scenario.expect[surface])` with an
+ * exact `toEqual` before demonstrating the behavior, so the spec is
+ * load-bearing in both directions: editing an expectation here fails the
+ * driver that demonstrates the old outcome, and a behavior change fails the
+ * driver's measured assertions. The divergence guard compares the same shape.
+ */
+export function declaredOutcome(expectation: SurfaceExpectation): Omit<SurfaceExpectation, 'notes'> {
+  const { notes: _notes, ...outcome } = expectation
+  return outcome
+}

--- a/evals/parity/spec.ts
+++ b/evals/parity/spec.ts
@@ -45,20 +45,20 @@ export const AUTOMATIC_TURNS_PER_WINDOW = 8
  *  - `roster`           — every conversation participant (standing mention);
  *  - `participants-minus-author` — everyone already in the conversation except
  *                          the (verified agent) author;
- *  - `named-peer-exactly-once`   — the one named peer, admitted exactly once
- *                          across echoes/retries/duplicate frames;
+ *  - `target-exactly-once`       — the delivery's target, admitted exactly
+ *                          once across echoes/retries/duplicate frames. How
+ *                          the target is ADDRESSED is surface mechanics: an
+ *                          explicit mention where the surface has mention
+ *                          addressing (channels), the pre-addressed roster
+ *                          fan-out where it does not (webchat agent posts
+ *                          carry no structured mentions);
  *  - `parent-exactly-once`       — the delegating parent session, woken exactly
  *                          once by the child's report;
  *  - `nobody`           — no activation at all (transcript-only where the
  *                          surface records transcripts).
  */
 export type ActivationSet =
-  | 'mentioned-only'
-  | 'roster'
-  | 'participants-minus-author'
-  | 'named-peer-exactly-once'
-  | 'parent-exactly-once'
-  | 'nobody'
+  'mentioned-only' | 'roster' | 'participants-minus-author' | 'target-exactly-once' | 'parent-exactly-once' | 'nobody'
 
 export interface ChainRefusal {
   /** Which protection terminates the scenario's agent-to-agent chain. */
@@ -154,18 +154,25 @@ export const PARITY_SCENARIOS: readonly ParityScenario[] = [
     }
   },
   {
-    id: 'explicit-mention-exactly-once',
-    title: 'an explicit mention activates the named peer exactly once',
+    id: 'delivery-exactly-once',
+    title: 'one committed agent message admits each target exactly once',
     invariant:
-      'One finalized agent message naming one peer produces exactly one activation for that peer — duplicate frames, echoes, and retries are absorbed by the durable rendezvous.',
+      'One committed agent message produces exactly one activation per (message, target) — duplicate frames, echoes, and retries are absorbed by the durable rendezvous.',
     expect: {
+      // The addressed EDGE differs per surface by construction, and that is
+      // mechanics, not outcome: channels address a peer with an explicit
+      // mention; a webchat agent post carries no structured mentions, so its
+      // addressed edge IS the relay's pre-addressed fan-out copy. Both must
+      // collapse duplicates to one admission.
       slack: {
-        activates: 'named-peer-exactly-once',
-        notes: 'the streaming echo and the finalized echo of the same message collapse to one admission'
+        activates: 'target-exactly-once',
+        notes:
+          'the explicit-mention edge: the streaming echo and the finalized echo of one response collapse to one admission for the named peer'
       },
       webchat: {
-        activates: 'named-peer-exactly-once',
-        notes: 'a re-fanned identical context copy under a fresh relay msgId does not double-wake'
+        activates: 'target-exactly-once',
+        notes:
+          'the pre-addressed fan-out edge: a re-fanned identical context copy under a fresh relay msgId does not double-wake the target'
       }
     }
   },
@@ -176,12 +183,12 @@ export const PARITY_SCENARIOS: readonly ParityScenario[] = [
       'Streaming/partial agent output never activates anyone; activation happens only on the committed (finalized) message.',
     expect: {
       slack: {
-        activates: 'named-peer-exactly-once',
+        activates: 'target-exactly-once',
         streamingNeverRoutes: true,
         notes: 'every streaming echo admission is refused; only the response-closing edit routes'
       },
       webchat: {
-        activates: 'named-peer-exactly-once',
+        activates: 'target-exactly-once',
         streamingNeverRoutes: true,
         notes: 'structural on this surface: rd/webchat-post exists only for committed replies, streaming rides rd/chat'
       }

--- a/evals/parity/spec.ts
+++ b/evals/parity/spec.ts
@@ -1,0 +1,279 @@
+/**
+ * Cross-surface activation parity spec.
+ *
+ * "Who does this message activate" is implemented more than once — the daemon
+ * platform ladder (`packages/daemon/src/router/routing-table.ts` + the verified
+ * agent-author ladder in `daemon.ts`), the relay's arbitration for relayed
+ * platform ingress (`packages/relay/src/bot-arbitration.ts`, "same rules" per
+ * send-message-routing-rework.md §6), and webchat multi-agent activation
+ * (roster/standing-mention semantics, webchat-multi-agents.md §4.2/§5.2a).
+ * The webchat copy missed the #549 policy change for months (issue #904, fixed
+ * by PR #906) — this spec exists so that can't happen silently again.
+ *
+ * One scenario vocabulary, several legs: each scenario is DATA (an invariant
+ * plus per-surface expected outcomes); the per-surface test legs
+ * (`evals/test/parity-slack.test.ts`, `evals/test/parity-webchat.test.ts`)
+ * consume this module and assert the declared outcome from the daemon's own
+ * records. Where surfaces intentionally differ, the divergence is DECLARED
+ * here with a design-doc citation — an undeclared divergence is a failing leg.
+ *
+ * Governance (docs/designs/activation-parity.md): any PR touching activation/
+ * routing behavior must update this spec — either every applicable leg passes
+ * with the same expectation, or the divergence is declared here with a
+ * citation. Silent per-surface drift is the failure mode this file pins.
+ */
+import { MAX_AGENT_CALL_HOPS } from '../../packages/protocol/src/consts.js'
+
+/** Surfaces a leg exists for today. The relay's arbitrate ladder is exercised
+ *  indirectly (its rungs mirror the daemon ladder, §6) and gains its own leg
+ *  when the policy module lands — the spec vocabulary already fits it. */
+export type ParitySurface = 'slack' | 'webchat'
+
+export const PARITY_SURFACES: readonly ParitySurface[] = ['slack', 'webchat']
+
+/** Mirrors the daemon's private `MAX_AUTOMATIC_TURNS_PER_WINDOW`
+ *  (packages/daemon/src/daemon.ts): automatic turns admitted per agent per
+ *  `LOOP_GUARD_WINDOW_MS`. Kept as a mirrored literal for the same reason
+ *  `evals/test/routing-acceptance.test.ts` mirrors it — the constant is
+ *  deliberately not exported from the daemon. */
+export const AUTOMATIC_TURNS_PER_WINDOW = 8
+
+/**
+ * The activation set a scenario's probe message produces, in role terms:
+ *
+ *  - `mentioned-only`   — exactly the agents the message explicitly named;
+ *  - `roster`           — every conversation participant (standing mention);
+ *  - `participants-minus-author` — everyone already in the conversation except
+ *                          the (verified agent) author;
+ *  - `named-peer-exactly-once`   — the one named peer, admitted exactly once
+ *                          across echoes/retries/duplicate frames;
+ *  - `parent-exactly-once`       — the delegating parent session, woken exactly
+ *                          once by the child's report;
+ *  - `nobody`           — no activation at all (transcript-only where the
+ *                          surface records transcripts).
+ */
+export type ActivationSet =
+  | 'mentioned-only'
+  | 'roster'
+  | 'participants-minus-author'
+  | 'named-peer-exactly-once'
+  | 'parent-exactly-once'
+  | 'nobody'
+
+export interface ChainRefusal {
+  /** Which protection terminates the scenario's agent-to-agent chain. */
+  reason: 'hop_limit' | 'automatic_turn_budget'
+  /** Agent-to-agent edges the chain runs before the refusal. */
+  afterEdges: number
+}
+
+export interface SurfaceExpectation {
+  activates: ActivationSet
+  /** Set when the scenario runs a chain to a protection limit. */
+  refusal?: ChainRefusal
+  /** The leg must prove streaming/partial output produced no activation. */
+  streamingNeverRoutes?: true
+  /** The leg must prove the woken agent's silent decline posted nothing. */
+  silentDeclinePostsNothing?: true
+  /** Surface-mechanics footnote the leg additionally pins. */
+  notes?: string
+}
+
+/** A per-surface difference that is intentional, with its design citation.
+ *  Anything not declared here is a parity bug. */
+export interface DeclaredDivergence {
+  reason: string
+  cites: readonly string[]
+}
+
+export interface ParityScenario {
+  id: string
+  title: string
+  /** The invariant in one surface-agnostic sentence. */
+  invariant: string
+  expect: Partial<Record<ParitySurface, SurfaceExpectation>>
+  /** Surfaces the scenario structurally cannot run on, and why. A surface
+   *  listed here must not also carry an expectation. */
+  notApplicable?: Partial<Record<ParitySurface, string>>
+  divergence?: DeclaredDivergence
+}
+
+export const PARITY_SCENARIOS: readonly ParityScenario[] = [
+  {
+    id: 'human-kickoff-activation',
+    title: 'human kickoff activates the right set',
+    invariant:
+      'A human message entering a multi-agent conversation activates the set the surface convention defines — and only that set.',
+    expect: {
+      // Production shared-channel convention: mention-gated, never `auto`
+      // (collaboration-arena-baseline.md §1). Only the explicitly mentioned
+      // agent runs; the other channel member stays idle.
+      slack: { activates: 'mentioned-only' },
+      // Webchat membership is a standing mention (webchat-multi-agents.md
+      // §4.2): an unnarrowed kickoff activates the whole roster, and a user
+      // post's `context` copy to a non-target never activates (§5.2 —
+      // user turns activate exclusively through pre-addressed `turn` frames).
+      webchat: {
+        activates: 'roster',
+        notes: 'mention-narrowing reduces the set to the named participants; user context copies stay transcript-only'
+      }
+    },
+    // DECLARED divergence, not a bug: a shared channel is opt-in per message
+    // (mention-gated), while pulling agents into a webchat conversation is
+    // "equivalent to having @-mentioned them all in its first message".
+    divergence: {
+      reason:
+        'Channel agents are addressed per message (mention-gated shared-channel convention); webchat roster membership IS the standing mention, so a bare kickoff addresses everyone.',
+      cites: ['docs/designs/webchat-multi-agents.md §4.2', 'docs/designs/collaboration-arena-baseline.md §1']
+    }
+  },
+  {
+    id: 'agent-continuation-minus-author',
+    title: 'verified agent continuation activates participants minus author',
+    invariant:
+      'A verified agent-authored message naming nobody continues the conversation: every other participant is activated, the author never is (#549).',
+    expect: {
+      slack: { activates: 'participants-minus-author' },
+      webchat: { activates: 'participants-minus-author' }
+    }
+  },
+  {
+    id: 'author-never-self-activates',
+    title: 'the author never self-activates',
+    invariant:
+      'No delivery path lets an agent wake itself on its own message — not via its own mention token, not via a mis-addressed fan-out copy. This is unconditional (not a loop the hop cap merely slows).',
+    expect: {
+      slack: {
+        activates: 'nobody',
+        notes: 'a finalized reply carrying the author’s own mention token routes to no one'
+      },
+      webchat: {
+        activates: 'nobody',
+        notes: 'a context frame mis-addressed to the post’s own author is dropped with no rendezvous record'
+      }
+    }
+  },
+  {
+    id: 'explicit-mention-exactly-once',
+    title: 'an explicit mention activates the named peer exactly once',
+    invariant:
+      'One finalized agent message naming one peer produces exactly one activation for that peer — duplicate frames, echoes, and retries are absorbed by the durable rendezvous.',
+    expect: {
+      slack: {
+        activates: 'named-peer-exactly-once',
+        notes: 'the streaming echo and the finalized echo of the same message collapse to one admission'
+      },
+      webchat: {
+        activates: 'named-peer-exactly-once',
+        notes: 'a re-fanned identical context copy under a fresh relay msgId does not double-wake'
+      }
+    }
+  },
+  {
+    id: 'streaming-never-routes',
+    title: 'only finalized messages route',
+    invariant:
+      'Streaming/partial agent output never activates anyone; activation happens only on the committed (finalized) message.',
+    expect: {
+      slack: {
+        activates: 'named-peer-exactly-once',
+        streamingNeverRoutes: true,
+        notes: 'every streaming echo admission is refused; only the response-closing edit routes'
+      },
+      webchat: {
+        activates: 'named-peer-exactly-once',
+        streamingNeverRoutes: true,
+        notes: 'structural on this surface: rd/webchat-post exists only for committed replies, streaming rides rd/chat'
+      }
+    }
+  },
+  {
+    id: 'hop-transition-and-refusal',
+    title: 'each agent-to-agent edge charges one hop; the chain terminates at a recorded limit',
+    invariant:
+      'An unattended agent-to-agent chain advances exactly one hop per edge and terminates by hitting a protection limit with a recorded refusal — never by running unboundedly.',
+    expect: {
+      // The durable loop guard's automatic-turn budget binds BEFORE the hop
+      // cap on channels: 2 agents × 8 automatic turns per window = 16 edges,
+      // then a `gated` refusal with hop budget to spare
+      // (collaboration-arena-baseline.md §6.1, pinned since #628).
+      slack: {
+        activates: 'participants-minus-author',
+        refusal: { reason: 'automatic_turn_budget', afterEdges: AUTOMATIC_TURNS_PER_WINDOW * 2 }
+      },
+      // Webchat mirrors Slack's agent-continuation accounting — the exact
+      // trusted hop cap is the budget and the coarse loop guard is not
+      // charged (webchat-multi-agents.md §5.2a "Loop accounting") — so the
+      // same chain runs to the cap and the +1 transition is refused there.
+      // The kickoff post is depth 0, continuations land at depths 1..cap-1,
+      // so cap-1 agent-to-agent edges are admitted and the next is refused.
+      webchat: {
+        activates: 'participants-minus-author',
+        refusal: { reason: 'hop_limit', afterEdges: MAX_AGENT_CALL_HOPS - 1 }
+      }
+    },
+    // DECLARED divergence: which protection binds first, not whether one does.
+    // Both surfaces charge the same +1 per edge against MAX_AGENT_CALL_HOPS;
+    // channels ALSO charge the coarse loop guard, and at the current constants
+    // that budget binds first, so the cap is unreachable for a two-agent room.
+    divergence: {
+      reason:
+        'Channels charge the durable loop guard as well as the hop budget and the guard binds first (16 < 20); webchat deliberately charges only the exact hop cap because it has no in-band !resume surface to reset a guard latch with.',
+      cites: [
+        'docs/designs/collaboration-arena-baseline.md §6.1',
+        'docs/designs/webchat-multi-agents.md §5.2a',
+        'docs/designs/send-message-routing-rework.md §4.1'
+      ]
+    }
+  },
+  {
+    id: 'silent-decline-absorbs-wake',
+    title: 'a silent decline absorbs a wake without posting',
+    invariant:
+      'A woken participant that declines to respond produces no visible post and no transcript reply row — the wake is absorbed, and nothing further fans out from it.',
+    expect: {
+      slack: { activates: 'participants-minus-author', silentDeclinePostsNothing: true },
+      webchat: {
+        activates: 'participants-minus-author',
+        silentDeclinePostsNothing: true,
+        notes: 'the AC_NO_RESPONSE sentinel commits no canonical post, so nothing fans out'
+      }
+    }
+  },
+  {
+    id: 'needs-reply-round-trip',
+    title: 'a needsReply delegation round-trips to the parent exactly once',
+    invariant:
+      'A child’s report back to its delegating parent session wakes the parent exactly once, and the report body itself is never published to the conversation.',
+    expect: {
+      slack: { activates: 'parent-exactly-once' }
+    },
+    notApplicable: {
+      webchat:
+        'The sendMessage {sessionId: parent} report seam is the shared sessions machinery below the activation ladders; webchat conversations expose no per-scenario surface for it at the daemon-level harness. Single-implementation machinery is outside parity scope.'
+    }
+  },
+  {
+    id: 'unverified-author-no-agent-rungs',
+    title: 'an unverifiable author cannot activate through agent rungs',
+    invariant:
+      'Only a VERIFIED agent author reaches the implicit continuation rungs. An unverifiable claim fails closed: transcript-only, no implicit activation.',
+    expect: {
+      slack: {
+        activates: 'nobody',
+        notes:
+          'an unmentioned third-party bot message activates no one (no thread affinity for bot traffic); an explicit mention from it still activates on Slack, whose manifest admits bot senders — verification, not bot-ness, is the boundary (send-message-routing-rework.md §2.3)'
+      },
+      webchat: {
+        activates: 'nobody',
+        notes:
+          'an agent post with no usable depth stamp (pre-parity daemon, or an authorship claim the relay could not bind and therefore stripped) stays transcript-only — a missing depth never coerces to zero (webchat-multi-agents.md §5.2a)'
+      }
+    }
+  }
+]
+
+/** Scenario ids a leg for `surface` must implement. */
+export function scenariosFor(surface: ParitySurface): readonly ParityScenario[] {
+  return PARITY_SCENARIOS.filter((scenario) => scenario.expect[surface] !== undefined)
+}

--- a/evals/test/parity-slack.test.ts
+++ b/evals/test/parity-slack.test.ts
@@ -112,12 +112,13 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
     expect(leg.activations('agent2')).toBe(0)
   },
 
-  // (d) One finalized reply naming one peer → exactly one admitted delivery
-  // for it; the streaming echo and any duplicate collapse in the rendezvous.
-  'explicit-mention-exactly-once': async (scenario) => {
+  // (d) Exactly one admission per (message, target). This surface's addressed
+  // edge is the explicit mention: one finalized reply naming one peer, whose
+  // streaming echo and finalized echo collapse to one admission.
+  'delivery-exactly-once': async (scenario) => {
     // The spec is load-bearing: editing this scenario's declared outcome
     // fails this pin; changing the behavior fails the measured asserts below.
-    expect(declaredOutcome(scenario.expect.slack!)).toEqual({ activates: 'named-peer-exactly-once' })
+    expect(declaredOutcome(scenario.expect.slack!)).toEqual({ activates: 'target-exactly-once' })
     const leg = await startRoom({
       agent1: (ctx) => {
         if (/START/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent2')}> please review the rollout`)
@@ -141,7 +142,7 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
     // The spec is load-bearing: editing this scenario's declared outcome
     // fails this pin; changing the behavior fails the measured asserts below.
     expect(declaredOutcome(scenario.expect.slack!)).toEqual({
-      activates: 'named-peer-exactly-once',
+      activates: 'target-exactly-once',
       streamingNeverRoutes: true
     })
     const leg = await startRoom({

--- a/evals/test/parity-slack.test.ts
+++ b/evals/test/parity-slack.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Slack-shaped leg of the cross-surface activation parity suite
+ * (`evals/parity/spec.ts` — read its header for the governance rule).
+ *
+ * Reuses the arena routing fixture (`routing-fixture.ts`): a REAL daemon
+ * against one mention-gated Slack-shaped room, scripted hosts, and platform
+ * echo fidelity — every delivered agent post fans back as real platform
+ * ingress under the author's managed bot identity, so whether an echo
+ * activates anyone is the daemon's routing decision, never the fixture's.
+ * Credential-free. Assertions read the daemon's own records: turn activations
+ * (evaluation events), delivered/attempted outbound effects, and per-echo
+ * admission outcomes.
+ *
+ * Every scenario the spec declares for this surface MUST have a driver here;
+ * the coverage guard at the bottom fails otherwise.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { MAX_AGENT_CALL_HOPS } from '../../packages/protocol/src/consts.js'
+import { AUTOMATIC_TURNS_PER_WINDOW, scenariosFor, type ParityScenario } from '../parity/spec.js'
+import { RoutingFixture, type RoutingScriptContext } from './routing-fixture.js'
+
+let fixture: RoutingFixture | undefined
+
+afterEach(async () => {
+  await fixture?.stop()
+  fixture = undefined
+})
+
+/** Start the standard two-agent mention-gated room. Scripts default to
+ *  SILENCE (an unmatched prompt posts nothing — the scripted stand-in for a
+ *  production agent declining with the no-response sentinel). */
+async function startRoom(scripts: {
+  agent1?: (ctx: RoutingScriptContext) => Promise<void> | void
+  agent2?: (ctx: RoutingScriptContext) => Promise<void> | void
+}): Promise<RoutingFixture> {
+  fixture = await RoutingFixture.start({
+    agents: ['agent1', 'agent2'],
+    scripts: {
+      agent1: scripts.agent1 ?? (() => {}),
+      agent2: scripts.agent2 ?? (() => {})
+    }
+  })
+  return fixture
+}
+
+const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
+  // (a) Mention-gated shared channel: a human kickoff activates exactly the
+  // mentioned agent; the other channel member stays idle even after the
+  // author's (unmentioning) reply echoes back. DECLARED divergence from the
+  // webchat roster convention — see the spec entry.
+  'human-kickoff-activation': async () => {
+    const leg = await startRoom({
+      agent1: (ctx) => {
+        if (/HELLO ROOM/.test(ctx.text)) ctx.reply('hello back, no mentions here')
+      }
+    })
+    const trigger = leg.injectHuman(`<@${leg.botUserId('agent1')}> HELLO ROOM`, {
+      mentions: [leg.botUserId('agent1')]
+    })
+    await leg.settle(trigger.handles)
+    expect(leg.activations('agent1')).toBe(1)
+    expect(leg.activations('agent2')).toBe(0)
+  },
+
+  // (b) #549: a verified agent-authored reply naming NOBODY continues the
+  // conversation — the thread's other participant is woken exactly once, the
+  // author is excluded.
+  'agent-continuation-minus-author': async () => {
+    const leg = await startRoom({
+      agent1: (ctx) => {
+        if (/START/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent2')}> please review the rollout`)
+        // Silence on the continuation wake ends the exchange.
+      },
+      agent2: (ctx) => {
+        if (/please review/.test(ctx.text)) ctx.reply('reviewing now')
+      }
+    })
+    const trigger = leg.injectHuman(`<@${leg.botUserId('agent1')}> START`, {
+      mentions: [leg.botUserId('agent1')]
+    })
+    await leg.settle(trigger.handles)
+    // agent2 joined by mention; its unmentioning reply continues the
+    // conversation through the implicit ladder, waking the thread peer
+    // (agent1) exactly once — participants minus author.
+    expect(leg.activations('agent2')).toBe(1)
+    expect(leg.activations('agent1')).toBe(2)
+    expect(leg.turnInputs('agent1')[1]).toContain('reviewing now')
+  },
+
+  // (c) The author never self-activates, even with its own mention token in
+  // the finalized reply.
+  'author-never-self-activates': async () => {
+    const leg = await startRoom({
+      agent1: (ctx) => {
+        if (/SAY SELF/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent1')}> note to self`)
+      }
+    })
+    const trigger = leg.injectHuman(`<@${leg.botUserId('agent1')}> SAY SELF`, {
+      mentions: [leg.botUserId('agent1')]
+    })
+    await leg.settle(trigger.handles)
+    expect(leg.activations('agent1')).toBe(1)
+    expect(leg.activations('agent2')).toBe(0)
+  },
+
+  // (d) One finalized reply naming one peer → exactly one admitted delivery
+  // for it; the streaming echo and any duplicate collapse in the rendezvous.
+  'explicit-mention-exactly-once': async () => {
+    const leg = await startRoom({
+      agent1: (ctx) => {
+        if (/START/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent2')}> please review the rollout`)
+      }
+      // agent2 stays silent — the named peer's wake is the scenario's endpoint.
+    })
+    const trigger = leg.injectHuman(`<@${leg.botUserId('agent1')}> START`, {
+      mentions: [leg.botUserId('agent1')]
+    })
+    await leg.settle(trigger.handles)
+    expect(leg.activations('agent2')).toBe(1)
+    expect(leg.turnInputs('agent2')[0]).toContain('please review the rollout')
+    const admissions = await leg.echoAdmissions()
+    const finalized = admissions.filter((record) => record.ingressEventTag !== undefined)
+    expect(finalized.filter((record) => record.admission.admitted)).toHaveLength(1)
+  },
+
+  // (e) Streaming never routes: every streaming echo admission is refused;
+  // only the response-closing (finalized) edit routes, once.
+  'streaming-never-routes': async () => {
+    const leg = await startRoom({
+      agent1: (ctx) => {
+        if (/START/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent2')}> please review the rollout`)
+      }
+    })
+    const trigger = leg.injectHuman(`<@${leg.botUserId('agent1')}> START`, {
+      mentions: [leg.botUserId('agent1')]
+    })
+    await leg.settle(trigger.handles)
+    const admissions = await leg.echoAdmissions()
+    const streaming = admissions.filter((record) => record.ingressEventTag === undefined)
+    const finalized = admissions.filter((record) => record.ingressEventTag !== undefined)
+    expect(streaming.length).toBeGreaterThan(0)
+    expect(streaming.every((record) => record.admission.admitted === false)).toBe(true)
+    expect(finalized.some((record) => record.admission.admitted === true)).toBe(true)
+    expect(leg.activations('agent2')).toBe(1)
+  },
+
+  // (f) Each edge charges one hop, in strict alternation — and on THIS surface
+  // the durable loop guard's automatic-turn budget binds before the hop cap
+  // (declared divergence; collaboration-arena-baseline.md §6.1): 16 edges,
+  // then a recorded `gated` refusal with hop budget to spare.
+  'hop-transition-and-refusal': async (scenario) => {
+    const refusal = scenario.expect.slack!.refusal!
+    expect(refusal).toEqual({ reason: 'automatic_turn_budget', afterEdges: AUTOMATIC_TURNS_PER_WINDOW * 2 })
+    const script = (self: 'agent1' | 'agent2') => (ctx: RoutingScriptContext) => {
+      const other = self === 'agent1' ? 'agent2' : 'agent1'
+      const numbers = [...ctx.text.matchAll(/your turn (\d+)/g)]
+      const chain = numbers.length > 0 ? numbers[numbers.length - 1]! : undefined
+      if (chain) {
+        ctx.reply(`<@${fixture!.botUserId(other)}> your turn ${Number(chain[1]) + 1}`)
+        return
+      }
+      if (/START CHAIN/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId(other)}> your turn 1`)
+    }
+    const leg = await startRoom({ agent1: script('agent1'), agent2: script('agent2') })
+    const trigger = leg.injectHuman(`<@${leg.botUserId('agent1')}> START CHAIN`, {
+      mentions: [leg.botUserId('agent1')]
+    })
+    await leg.settle(trigger.handles)
+    // Exactly one dispatch per edge, alternating, until the budget refusal.
+    const agentActivations = leg.activations('agent1') + leg.activations('agent2') - 1 // minus the human trigger
+    expect(agentActivations).toBe(refusal.afterEdges)
+    expect(leg.activations('agent2')).toBe(AUTOMATIC_TURNS_PER_WINDOW)
+    // The hop cap is NOT what stopped it — the chain ends with budget to spare.
+    expect(refusal.afterEdges).toBeLessThan(MAX_AGENT_CALL_HOPS)
+    const finalizedAdmissions = (await leg.echoAdmissions()).filter((record) => record.ingressEventTag !== undefined)
+    expect(finalizedAdmissions.filter((record) => record.admission.admitted)).toHaveLength(refusal.afterEdges)
+    // The refusal past the budget is the dispatch GATE's verdict (§7.1 `gated`
+    // — the loop guard's bucket), recorded rather than silently dropped.
+    expect(finalizedAdmissions.at(-1)!.admission).toMatchObject({ admitted: false, reason: 'gated' })
+  },
+
+  // (g) A silent decline absorbs the wake: the woken participant posts
+  // nothing, and nothing further fans out from its silent turn.
+  'silent-decline-absorbs-wake': async () => {
+    const leg = await startRoom({
+      agent1: (ctx) => {
+        if (/START/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent2')}> please review the rollout`)
+        // The continuation wake lands here — and is declined silently.
+      },
+      agent2: (ctx) => {
+        if (/please review/.test(ctx.text)) ctx.reply('reviewing now')
+      }
+    })
+    const trigger = leg.injectHuman(`<@${leg.botUserId('agent1')}> START`, {
+      mentions: [leg.botUserId('agent1')]
+    })
+    await leg.settle(trigger.handles)
+    // agent1 was woken by agent2's reply (activation 2) and declined silently:
+    // its only delivered post remains the initial mention.
+    expect(leg.activations('agent1')).toBe(2)
+    const agent1Posts = leg.deliveredPosts().filter((post) => leg.aliasOf(post.agentId!) === 'agent1')
+    expect(agent1Posts).toHaveLength(1)
+    // The silence terminated the exchange: no further wake for agent2.
+    expect(leg.activations('agent2')).toBe(1)
+  },
+
+  // (h) needsReply round trip: the child's report wakes the parent session
+  // exactly once, and the report body is never published anywhere.
+  'needs-reply-round-trip': async () => {
+    const leg = await startRoom({
+      agent1: async (ctx) => {
+        const wake = /WAKE ([0-9a-f-]{36})/.exec(ctx.text)
+        if (wake) {
+          const result = await ctx.callTool('sendMessage', {
+            toAgent: { agentId: wake[1]!, needsReply: true },
+            channel: fixture!.room.channel,
+            message: 'please handle task T-1'
+          })
+          ctx.reply(result.ok ? 'delegated' : `delegation failed: ${result.error ?? 'unknown'}`)
+          return
+        }
+        if (/RESULT R-42/.test(ctx.text)) ctx.reply('thanks, result noted')
+      },
+      agent2: async (ctx) => {
+        const parent = /Parent session: (\S+)/.exec(ctx.text)
+        if (parent && /task T-1/.test(ctx.text)) {
+          const result = await ctx.callTool('sendMessage', {
+            sessionId: parent[1]!,
+            message: 'RESULT R-42: task complete'
+          })
+          ctx.reply(result.ok ? 'reported to parent' : `report failed: ${result.error ?? 'unknown'}`)
+        }
+      }
+    })
+    const trigger = leg.injectHuman(`<@${leg.botUserId('agent1')}> WAKE ${leg.agentId('agent2')}`, {
+      mentions: [leg.botUserId('agent1')]
+    })
+    await leg.settle(trigger.handles)
+    // The parent was resumed by the report EXACTLY once (kickoff + resume).
+    expect(leg.activations('agent1')).toBe(2)
+    expect(leg.turnInputs('agent1')[1]).toContain('RESULT R-42')
+    // The report itself never became a platform message — nothing anyone
+    // attempted, delivered or rejected, carries the injected text.
+    const published = leg.world.allEffects().filter((effect) => /RESULT R-42/.test(effect.text ?? ''))
+    expect(published).toEqual([])
+  },
+
+  // (i) Verification, not bot-ness, is the boundary: an UNVERIFIED third-party
+  // bot message never activates through the implicit agent rungs (no thread
+  // affinity, no fan-out) — while an explicit mention from it still activates
+  // on Slack, whose manifest admits bot senders.
+  'unverified-author-no-agent-rungs': async () => {
+    const leg = await startRoom({
+      agent1: (ctx) => {
+        if (/START/.test(ctx.text)) ctx.reply('anchored in this thread')
+      }
+    })
+    // Anchor agent1's session in a thread.
+    const trigger = leg.injectHuman(`<@${leg.botUserId('agent1')}> START`, {
+      mentions: [leg.botUserId('agent1')]
+    })
+    await leg.settle(trigger.handles)
+    expect(leg.activations('agent1')).toBe(1)
+
+    // An UNMENTIONED third-party bot message in that live thread: no thread
+    // affinity, no participant fan-out — bot traffic without a verified
+    // author stops before every implicit rung.
+    const chatter = leg.injectThirdPartyBot('external bot chatter, mentioning nobody', {
+      thread: trigger.messageId
+    })
+    await leg.settle(chatter.handles)
+    expect(leg.activations('agent1')).toBe(1)
+    expect(leg.activations('agent2')).toBe(0)
+
+    // An EXPLICIT mention from the same unverified bot still activates on
+    // Slack — the platform's manifest admits bot senders at the mention rung.
+    const addressed = leg.injectThirdPartyBot(`<@${leg.botUserId('agent2')}> ping from an external bot`, {
+      mentions: [leg.botUserId('agent2')]
+    })
+    await leg.settle(addressed.handles)
+    expect(leg.activations('agent2')).toBe(1)
+    expect(leg.activations('agent1')).toBe(1)
+  }
+}
+
+describe('activation parity — Slack-shaped leg', () => {
+  const scenarios = scenariosFor('slack')
+
+  it('covers every scenario the spec declares for this surface', () => {
+    expect(new Set(scenarios.map((s) => s.id))).toEqual(new Set(Object.keys(drivers)))
+  })
+
+  for (const scenario of scenarios) {
+    it(`${scenario.id} — ${scenario.title}`, async () => {
+      const driver = drivers[scenario.id]
+      expect(driver, `no Slack driver for spec scenario "${scenario.id}"`).toBeDefined()
+      await driver!(scenario)
+    }, 120_000)
+  }
+})

--- a/evals/test/parity-slack.test.ts
+++ b/evals/test/parity-slack.test.ts
@@ -16,7 +16,7 @@
  */
 import { afterEach, describe, expect, it } from 'vitest'
 import { MAX_AGENT_CALL_HOPS } from '../../packages/protocol/src/consts.js'
-import { AUTOMATIC_TURNS_PER_WINDOW, scenariosFor, type ParityScenario } from '../parity/spec.js'
+import { AUTOMATIC_TURNS_PER_WINDOW, declaredOutcome, scenariosFor, type ParityScenario } from '../parity/spec.js'
 import { RoutingFixture, type RoutingScriptContext } from './routing-fixture.js'
 
 let fixture: RoutingFixture | undefined
@@ -48,7 +48,10 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
   // mentioned agent; the other channel member stays idle even after the
   // author's (unmentioning) reply echoes back. DECLARED divergence from the
   // webchat roster convention — see the spec entry.
-  'human-kickoff-activation': async () => {
+  'human-kickoff-activation': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.slack!)).toEqual({ activates: 'mentioned-only' })
     const leg = await startRoom({
       agent1: (ctx) => {
         if (/HELLO ROOM/.test(ctx.text)) ctx.reply('hello back, no mentions here')
@@ -65,7 +68,10 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
   // (b) #549: a verified agent-authored reply naming NOBODY continues the
   // conversation — the thread's other participant is woken exactly once, the
   // author is excluded.
-  'agent-continuation-minus-author': async () => {
+  'agent-continuation-minus-author': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.slack!)).toEqual({ activates: 'participants-minus-author' })
     const leg = await startRoom({
       agent1: (ctx) => {
         if (/START/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent2')}> please review the rollout`)
@@ -89,7 +95,10 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
 
   // (c) The author never self-activates, even with its own mention token in
   // the finalized reply.
-  'author-never-self-activates': async () => {
+  'author-never-self-activates': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.slack!)).toEqual({ activates: 'nobody' })
     const leg = await startRoom({
       agent1: (ctx) => {
         if (/SAY SELF/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent1')}> note to self`)
@@ -105,7 +114,10 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
 
   // (d) One finalized reply naming one peer → exactly one admitted delivery
   // for it; the streaming echo and any duplicate collapse in the rendezvous.
-  'explicit-mention-exactly-once': async () => {
+  'explicit-mention-exactly-once': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.slack!)).toEqual({ activates: 'named-peer-exactly-once' })
     const leg = await startRoom({
       agent1: (ctx) => {
         if (/START/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent2')}> please review the rollout`)
@@ -125,7 +137,13 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
 
   // (e) Streaming never routes: every streaming echo admission is refused;
   // only the response-closing (finalized) edit routes, once.
-  'streaming-never-routes': async () => {
+  'streaming-never-routes': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.slack!)).toEqual({
+      activates: 'named-peer-exactly-once',
+      streamingNeverRoutes: true
+    })
     const leg = await startRoom({
       agent1: (ctx) => {
         if (/START/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent2')}> please review the rollout`)
@@ -149,8 +167,13 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
   // (declared divergence; collaboration-arena-baseline.md §6.1): 16 edges,
   // then a recorded `gated` refusal with hop budget to spare.
   'hop-transition-and-refusal': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.slack!)).toEqual({
+      activates: 'participants-minus-author',
+      refusal: { reason: 'automatic_turn_budget', afterEdges: AUTOMATIC_TURNS_PER_WINDOW * 2 }
+    })
     const refusal = scenario.expect.slack!.refusal!
-    expect(refusal).toEqual({ reason: 'automatic_turn_budget', afterEdges: AUTOMATIC_TURNS_PER_WINDOW * 2 })
     const script = (self: 'agent1' | 'agent2') => (ctx: RoutingScriptContext) => {
       const other = self === 'agent1' ? 'agent2' : 'agent1'
       const numbers = [...ctx.text.matchAll(/your turn (\d+)/g)]
@@ -181,7 +204,13 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
 
   // (g) A silent decline absorbs the wake: the woken participant posts
   // nothing, and nothing further fans out from its silent turn.
-  'silent-decline-absorbs-wake': async () => {
+  'silent-decline-absorbs-wake': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.slack!)).toEqual({
+      activates: 'participants-minus-author',
+      silentDeclinePostsNothing: true
+    })
     const leg = await startRoom({
       agent1: (ctx) => {
         if (/START/.test(ctx.text)) ctx.reply(`<@${fixture!.botUserId('agent2')}> please review the rollout`)
@@ -206,7 +235,10 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
 
   // (h) needsReply round trip: the child's report wakes the parent session
   // exactly once, and the report body is never published anywhere.
-  'needs-reply-round-trip': async () => {
+  'needs-reply-round-trip': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.slack!)).toEqual({ activates: 'parent-exactly-once' })
     const leg = await startRoom({
       agent1: async (ctx) => {
         const wake = /WAKE ([0-9a-f-]{36})/.exec(ctx.text)
@@ -249,7 +281,10 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
   // bot message never activates through the implicit agent rungs (no thread
   // affinity, no fan-out) — while an explicit mention from it still activates
   // on Slack, whose manifest admits bot senders.
-  'unverified-author-no-agent-rungs': async () => {
+  'unverified-author-no-agent-rungs': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.slack!)).toEqual({ activates: 'nobody' })
     const leg = await startRoom({
       agent1: (ctx) => {
         if (/START/.test(ctx.text)) ctx.reply('anchored in this thread')

--- a/evals/test/parity-spec.test.ts
+++ b/evals/test/parity-spec.test.ts
@@ -5,7 +5,7 @@
  * docs/designs/activation-parity.md.
  */
 import { describe, expect, it } from 'vitest'
-import { PARITY_SCENARIOS, PARITY_SURFACES } from '../parity/spec.js'
+import { PARITY_SCENARIOS, PARITY_SURFACES, declaredOutcome } from '../parity/spec.js'
 
 describe('activation parity spec', () => {
   it('scenario ids are unique', () => {
@@ -39,9 +39,9 @@ describe('activation parity spec', () => {
         const expectation = scenario.expect[surface]
         if (expectation === undefined) return []
         // Compare the outcome fields that define parity; notes are per-surface
-        // mechanics footnotes and may legitimately differ.
-        const { notes: _notes, ...outcome } = expectation
-        return [JSON.stringify(outcome)]
+        // mechanics footnotes and may legitimately differ. Same shape every
+        // leg driver pins with an exact toEqual.
+        return [JSON.stringify(declaredOutcome(expectation))]
       })
       const diverges = new Set(expectations).size > 1
       if (diverges) {

--- a/evals/test/parity-spec.test.ts
+++ b/evals/test/parity-spec.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Structural guard over the activation parity spec (`evals/parity/spec.ts`):
+ * the governance rule ("all legs pass or the divergence is declared") only
+ * works if the spec itself stays well-formed. See
+ * docs/designs/activation-parity.md.
+ */
+import { describe, expect, it } from 'vitest'
+import { PARITY_SCENARIOS, PARITY_SURFACES } from '../parity/spec.js'
+
+describe('activation parity spec', () => {
+  it('scenario ids are unique', () => {
+    const ids = PARITY_SCENARIOS.map((scenario) => scenario.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('every scenario runs somewhere: at least one surface expectation each', () => {
+    for (const scenario of PARITY_SCENARIOS) {
+      expect(Object.keys(scenario.expect).length, scenario.id).toBeGreaterThan(0)
+    }
+  })
+
+  it('a surface is either expected or declared not-applicable, never both — and a skip carries its reason', () => {
+    for (const scenario of PARITY_SCENARIOS) {
+      for (const surface of PARITY_SURFACES) {
+        const expected = scenario.expect[surface] !== undefined
+        const skipped = scenario.notApplicable?.[surface]
+        expect(expected && skipped !== undefined, `${scenario.id} declares ${surface} both ways`).toBe(false)
+        expect(
+          expected || (skipped !== undefined && skipped.length > 0),
+          `${scenario.id} says nothing about ${surface}`
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('a per-surface difference in expectations is a DECLARED divergence with design citations', () => {
+    for (const scenario of PARITY_SCENARIOS) {
+      const expectations = PARITY_SURFACES.flatMap((surface) => {
+        const expectation = scenario.expect[surface]
+        if (expectation === undefined) return []
+        // Compare the outcome fields that define parity; notes are per-surface
+        // mechanics footnotes and may legitimately differ.
+        const { notes: _notes, ...outcome } = expectation
+        return [JSON.stringify(outcome)]
+      })
+      const diverges = new Set(expectations).size > 1
+      if (diverges) {
+        expect(scenario.divergence, `${scenario.id} diverges across surfaces without a declaration`).toBeDefined()
+      }
+      if (scenario.divergence) {
+        expect(scenario.divergence.cites.length, `${scenario.id} divergence cites nothing`).toBeGreaterThan(0)
+        for (const cite of scenario.divergence.cites) {
+          expect(cite, `${scenario.id} divergence citation must point into docs/designs`).toMatch(/^docs\/designs\//)
+        }
+      }
+    }
+  })
+})

--- a/evals/test/parity-webchat.test.ts
+++ b/evals/test/parity-webchat.test.ts
@@ -29,7 +29,8 @@ import {
   settle,
   userPost
 } from '../../packages/daemon/test/webchat-continuation-fixture.js'
-import { scenariosFor, type ParityScenario } from '../parity/spec.js'
+import { selectTurnTargets } from '../../packages/relay/src/relay-browser-connection.js'
+import { declaredOutcome, scenariosFor, type ParityScenario } from '../parity/spec.js'
 import type { RdWebchatPost } from '../../packages/protocol/src/index.js'
 
 const P1 = 'bot-a'
@@ -91,6 +92,40 @@ function injectTurn(
   )
 }
 
+/**
+ * Play the relay's §5.2 user-turn fan-out for a target set the PRODUCTION
+ * choice (`selectTurnTargets`) computed: a pre-addressed `turn` frame per
+ * target, and a transcript-only user `context` copy to every other roster
+ * member — exactly what `RelayBrowserConnection.sendTurn` emits.
+ */
+function playRelayUserTurn(
+  leg: WebchatLeg,
+  roster: readonly string[],
+  targets: readonly string[],
+  text: string,
+  options: { mentions?: string[]; postId: string; at: number; msgPrefix: string }
+): void {
+  for (const [index, agentId] of targets.entries()) {
+    expect(
+      injectTurn(leg, agentId, text, {
+        msgId: `${options.msgPrefix}-t${index}`,
+        ...(options.mentions !== undefined ? { mentions: options.mentions } : {}),
+        postId: options.postId,
+        at: options.at
+      })
+    ).toMatchObject({ accepted: true })
+  }
+  for (const [index, peer] of roster.filter((agentId) => !targets.includes(agentId)).entries()) {
+    ;(leg.daemon as any).handleRelayMsg(
+      rd(
+        { op: 'context', post: userPost(CONV, text, options.at, options.postId) },
+        { agentId: peer, msgId: `${options.msgPrefix}-c${index}` }
+      ),
+      () => {}
+    )
+  }
+}
+
 /** Reply rows a given sender committed into the shared conversation log. */
 function transcriptRowsBy(leg: WebchatLeg, sender: string): unknown[] {
   return (leg.daemon as any).store
@@ -103,50 +138,44 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
   // (every participant gets a pre-addressed `turn` frame); mention-narrowing
   // reduces the set to the named participants, and a user post's `context`
   // copy to a non-target never activates.
-  'human-kickoff-activation': async () => {
+  'human-kickoff-activation': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.webchat!)).toEqual({ activates: 'roster' })
     const leg = await startLeg([P1, P2, REF], {
       [P1]: () => NO_RESPONSE,
       [P2]: () => NO_RESPONSE,
       [REF]: () => NO_RESPONSE
     })
+    const roster = [P1, P2, REF]
     try {
-      // Unnarrowed kickoff → the relay addresses every roster member.
-      for (const [agentId, msgId] of [
-        [P1, 't-a'],
-        [P2, 't-b'],
-        [REF, 't-c']
-      ] as const) {
-        expect(injectTurn(leg, agentId, 'hello everyone', { msgId })).toMatchObject({ accepted: true })
-      }
+      // Unnarrowed kickoff: the PRODUCTION choice (relay `selectTurnTargets`)
+      // picks the whole roster, so every member gets a `turn` frame.
+      const unnarrowed = selectTurnTargets(roster, {})
+      expect(unnarrowed).toEqual({ valid: roster, invalid: [] })
+      playRelayUserTurn(leg, roster, unnarrowed.valid, 'hello everyone', {
+        postId: KICKOFF_TURN,
+        at: 1_000,
+        msgPrefix: 'kick'
+      })
       await vi.waitFor(() => {
         expect(leg.prompts.get(P1)).toHaveLength(1)
         expect(leg.prompts.get(P2)).toHaveLength(1)
         expect(leg.prompts.get(REF)).toHaveLength(1)
       }, WAIT)
 
-      // Mention-narrowed follow-up → only the named participant activates;
-      // the others get the user post as context, which never activates.
+      // Mention-narrowed follow-up: the production choice reduces the set to
+      // the named participant; the others get the user post as a `context`
+      // copy, which never activates.
+      const narrowed = selectTurnTargets(roster, { mentions: [P1] })
+      expect(narrowed).toEqual({ valid: [P1], invalid: [] })
       const narrowedId = '11111111-0000-4000-8000-000000000001'
-      expect(
-        injectTurn(leg, P1, 'just you, player one', {
-          msgId: 't-narrow',
-          mentions: [P1],
-          postId: narrowedId,
-          at: 2_000
-        })
-      ).toMatchObject({ accepted: true })
-      for (const [peer, msgId] of [
-        [P2, 'uctx-b'],
-        [REF, 'uctx-c']
-      ] as const) {
-        ;(leg.daemon as any).handleRelayMsg(
-          rd(
-            { op: 'context', post: userPost(CONV, 'just you, player one', 2_000, narrowedId) },
-            { agentId: peer, msgId }
-          ),
-          () => {}
-        )
-      }
+      playRelayUserTurn(leg, roster, narrowed.valid, 'just you, player one', {
+        mentions: [P1],
+        postId: narrowedId,
+        at: 2_000,
+        msgPrefix: 'narrow'
+      })
       await vi.waitFor(() => expect(leg.prompts.get(P1)).toHaveLength(2), WAIT)
       await settle()
       expect(leg.prompts.get(P2)).toHaveLength(1)
@@ -157,7 +186,10 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
   },
 
   // (b) A committed agent post wakes every other participant, never its author.
-  'agent-continuation-minus-author': async () => {
+  'agent-continuation-minus-author': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.webchat!)).toEqual({ activates: 'participants-minus-author' })
     const leg = await startLeg([P1, P2, REF], {
       [P1]: (text) => (/kick off/.test(text) ? 'the one committed post' : NO_RESPONSE),
       [P2]: () => NO_RESPONSE,
@@ -190,7 +222,10 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
 
   // (c) A context frame mis-addressed to the post's own author is dropped —
   // no prompt, no rendezvous record.
-  'author-never-self-activates': async () => {
+  'author-never-self-activates': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.webchat!)).toEqual({ activates: 'nobody' })
     const leg = await startLeg([P1], { [P1]: () => 'should never run' })
     try {
       const post = agentPost(CONV, P1, 'my own words', 2_000, '00000003-0000-4000-8000-000000000003', 0)
@@ -205,7 +240,10 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
 
   // (d) Exactly-once per (post, target): a re-fanned identical copy under a
   // fresh relay msgId is absorbed by the durable rendezvous.
-  'explicit-mention-exactly-once': async () => {
+  'explicit-mention-exactly-once': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.webchat!)).toEqual({ activates: 'named-peer-exactly-once' })
     const leg = await startLeg([P1], { [P1]: () => NO_RESPONSE })
     try {
       seedCallPolicy(leg.daemon, [P1, P2]) // the author lives on another daemon — only the edge matters
@@ -222,7 +260,13 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
 
   // (e) Streaming never routes: while the author is still generating nothing
   // fans out and no peer wakes; the committed post is what activates.
-  'streaming-never-routes': async () => {
+  'streaming-never-routes': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.webchat!)).toEqual({
+      activates: 'named-peer-exactly-once',
+      streamingNeverRoutes: true
+    })
     let releaseP1!: () => void
     const p1Blocked = new Promise<void>((resolve) => (releaseP1 = resolve))
     const leg = await startLeg([P1, P2], {
@@ -251,8 +295,13 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
   // at the cap is refused with a recorded hop_limit reason. (Declared
   // divergence: channels ALSO charge the loop guard, which binds first.)
   'hop-transition-and-refusal': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.webchat!)).toEqual({
+      activates: 'participants-minus-author',
+      refusal: { reason: 'hop_limit', afterEdges: MAX_AGENT_CALL_HOPS - 1 }
+    })
     const refusal = scenario.expect.webchat!.refusal!
-    expect(refusal).toEqual({ reason: 'hop_limit', afterEdges: MAX_AGENT_CALL_HOPS - 1 })
     let n = 0
     const always = () => String(++n)
     const leg = await startLeg([P1, P2], { [P1]: always, [P2]: always })
@@ -277,7 +326,13 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
 
   // (g) A silent decline absorbs the wake: no post, no transcript reply row,
   // nothing further fans out.
-  'silent-decline-absorbs-wake': async () => {
+  'silent-decline-absorbs-wake': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.webchat!)).toEqual({
+      activates: 'participants-minus-author',
+      silentDeclinePostsNothing: true
+    })
     const leg = await startLeg([P1, REF], {
       [P1]: (text) => (/kick off/.test(text) ? 'observed post' : NO_RESPONSE),
       [REF]: () => NO_RESPONSE
@@ -299,7 +354,10 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
   // (i) Fail closed on an unverifiable author: an agent post with no usable
   // depth stamp (pre-parity daemon, or a claim the relay could not bind and
   // therefore stripped — §5.2a) is transcript-only.
-  'unverified-author-no-agent-rungs': async () => {
+  'unverified-author-no-agent-rungs': async (scenario) => {
+    // The spec is load-bearing: editing this scenario's declared outcome
+    // fails this pin; changing the behavior fails the measured asserts below.
+    expect(declaredOutcome(scenario.expect.webchat!)).toEqual({ activates: 'nobody' })
     const leg = await startLeg([P1], { [P1]: () => 'should never run' })
     try {
       seedCallPolicy(leg.daemon, [P1, P2])

--- a/evals/test/parity-webchat.test.ts
+++ b/evals/test/parity-webchat.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Webchat leg of the cross-surface activation parity suite
+ * (`evals/parity/spec.ts` — read its header for the governance rule).
+ *
+ * Drives the SAME daemon seam PR #906's tests drive — `handleRelayMsg` fed the
+ * relay's pre-addressed `turn` frames, with the §5.2 roster fan-out of
+ * committed posts played by the leg (`webchat-continuation-fixture.ts`) — and
+ * asserts each spec scenario's declared outcome from the daemon's own records:
+ * scripted-host prompt logs, committed `rd/webchat-post` frames, the durable
+ * activation rendezvous, and the shared conversation transcript.
+ *
+ * Every scenario the spec declares for this surface MUST have a driver here;
+ * the coverage guard at the bottom fails otherwise.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { MAX_AGENT_CALL_HOPS } from '../../packages/protocol/src/consts.js'
+import { Daemon } from '../../packages/daemon/src/daemon.js'
+import { transcriptChannelKey } from '../../packages/daemon/src/store/local-store.js'
+import {
+  NO_RESPONSE,
+  agentPost,
+  fakeCpClient,
+  fakeRelay,
+  rdFactory,
+  rendezvousKey,
+  scaffold,
+  scriptedHosts,
+  seedCallPolicy,
+  settle,
+  userPost
+} from '../../packages/daemon/test/webchat-continuation-fixture.js'
+import { scenariosFor, type ParityScenario } from '../parity/spec.js'
+import type { RdWebchatPost } from '../../packages/protocol/src/index.js'
+
+const P1 = 'bot-a'
+const P2 = 'bot-b'
+const REF = 'bot-ref'
+const CONV = '99999999-9999-4999-8999-999999999999'
+const KICKOFF_TURN = '66666666-6666-4666-8666-666666666666'
+const WAIT = { timeout: 10_000 }
+
+const rd = rdFactory(CONV, P1)
+
+interface WebchatLeg {
+  daemon: Daemon
+  prompts: Map<string, string[]>
+  posts: RdWebchatPost[]
+  fanOut: (p: RdWebchatPost) => void
+  stop: () => Promise<void>
+}
+
+/** Boot one control-plane-less daemon hosting `agents`, with the leg playing
+ *  the relay (`fanOut`) and an open call policy across the roster. */
+async function startLeg(agents: string[], replies: Record<string, (prompt: string) => string | Promise<string>>) {
+  const { factory, prompts } = scriptedHosts(replies)
+  const daemon = new Daemon({ root: scaffold(agents), hostFactory: factory })
+  await daemon.start()
+  ;(daemon as any).cpClient = fakeCpClient()
+  seedCallPolicy(daemon, agents)
+  const holder = { current: daemon }
+  const { posts, fanOut } = fakeRelay(holder, agents, CONV)
+  ;(daemon as any).relays = { sendWebchatPost: fanOut, stop: async () => {} }
+  const leg: WebchatLeg = { daemon, prompts, posts, fanOut, stop: () => daemon.stop() }
+  return leg
+}
+
+/** One pre-addressed relay `turn` frame — how the relay activates ONE target
+ *  of a user turn (webchat-multi-agents.md §4.3). */
+function injectTurn(
+  leg: WebchatLeg,
+  agentId: string,
+  text: string,
+  options: { msgId: string; mentions?: string[]; postId?: string; at?: number; withPostSink?: boolean } = {
+    msgId: 'turn-1'
+  }
+): unknown {
+  return (leg.daemon as any).handleRelayMsg(
+    rd(
+      {
+        op: 'turn',
+        text,
+        user: 'owner',
+        turnId: options.postId ?? KICKOFF_TURN,
+        ...(options.mentions !== undefined ? { mentions: options.mentions } : {}),
+        post: { postId: options.postId ?? KICKOFF_TURN, at: options.at ?? 1_000 }
+      },
+      { agentId, msgId: options.msgId }
+    ),
+    () => {},
+    options.withPostSink === false ? undefined : leg.fanOut
+  )
+}
+
+/** Reply rows a given sender committed into the shared conversation log. */
+function transcriptRowsBy(leg: WebchatLeg, sender: string): unknown[] {
+  return (leg.daemon as any).store
+    .transcriptSince(transcriptChannelKey(CONV, undefined), `webchat:${CONV}`, null)
+    .filter((row: { sender: string }) => row.sender === sender)
+}
+
+const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
+  // (a) Standing mention: an unnarrowed kickoff activates the WHOLE roster
+  // (every participant gets a pre-addressed `turn` frame); mention-narrowing
+  // reduces the set to the named participants, and a user post's `context`
+  // copy to a non-target never activates.
+  'human-kickoff-activation': async () => {
+    const leg = await startLeg([P1, P2, REF], {
+      [P1]: () => NO_RESPONSE,
+      [P2]: () => NO_RESPONSE,
+      [REF]: () => NO_RESPONSE
+    })
+    try {
+      // Unnarrowed kickoff → the relay addresses every roster member.
+      for (const [agentId, msgId] of [
+        [P1, 't-a'],
+        [P2, 't-b'],
+        [REF, 't-c']
+      ] as const) {
+        expect(injectTurn(leg, agentId, 'hello everyone', { msgId })).toMatchObject({ accepted: true })
+      }
+      await vi.waitFor(() => {
+        expect(leg.prompts.get(P1)).toHaveLength(1)
+        expect(leg.prompts.get(P2)).toHaveLength(1)
+        expect(leg.prompts.get(REF)).toHaveLength(1)
+      }, WAIT)
+
+      // Mention-narrowed follow-up → only the named participant activates;
+      // the others get the user post as context, which never activates.
+      const narrowedId = '11111111-0000-4000-8000-000000000001'
+      expect(
+        injectTurn(leg, P1, 'just you, player one', {
+          msgId: 't-narrow',
+          mentions: [P1],
+          postId: narrowedId,
+          at: 2_000
+        })
+      ).toMatchObject({ accepted: true })
+      for (const [peer, msgId] of [
+        [P2, 'uctx-b'],
+        [REF, 'uctx-c']
+      ] as const) {
+        ;(leg.daemon as any).handleRelayMsg(
+          rd(
+            { op: 'context', post: userPost(CONV, 'just you, player one', 2_000, narrowedId) },
+            { agentId: peer, msgId }
+          ),
+          () => {}
+        )
+      }
+      await vi.waitFor(() => expect(leg.prompts.get(P1)).toHaveLength(2), WAIT)
+      await settle()
+      expect(leg.prompts.get(P2)).toHaveLength(1)
+      expect(leg.prompts.get(REF)).toHaveLength(1)
+    } finally {
+      await leg.stop()
+    }
+  },
+
+  // (b) A committed agent post wakes every other participant, never its author.
+  'agent-continuation-minus-author': async () => {
+    const leg = await startLeg([P1, P2, REF], {
+      [P1]: (text) => (/kick off/.test(text) ? 'the one committed post' : NO_RESPONSE),
+      [P2]: () => NO_RESPONSE,
+      [REF]: () => NO_RESPONSE
+    })
+    try {
+      expect(injectTurn(leg, P1, 'kick off, please', { msgId: 't-1', mentions: [P1] })).toMatchObject({
+        accepted: true
+      })
+      await vi.waitFor(() => expect(leg.posts.map((p) => p.post.text)).toEqual(['the one committed post']), WAIT)
+      await vi.waitFor(() => {
+        expect(leg.prompts.get(P2)).toHaveLength(1)
+        expect(leg.prompts.get(REF)).toHaveLength(1)
+      }, WAIT)
+      await settle()
+      // The author was activated by the human turn only — never by its own post.
+      expect(leg.prompts.get(P1)).toHaveLength(1)
+      const postId = leg.posts[0]!.post.postId
+      expect((leg.daemon as any).store.getActivation(rendezvousKey(postId, P1))).toBeUndefined()
+      // Each delivered edge is an admitted exactly-once record.
+      for (const target of [P2, REF]) {
+        expect((leg.daemon as any).store.getActivation(rendezvousKey(postId, target))?.state).toBe('admitted')
+      }
+      // The woken peer's prompt names the author of the post that woke it.
+      expect(leg.prompts.get(P2)![0]).toContain(`[${P1}] the one committed post`)
+    } finally {
+      await leg.stop()
+    }
+  },
+
+  // (c) A context frame mis-addressed to the post's own author is dropped —
+  // no prompt, no rendezvous record.
+  'author-never-self-activates': async () => {
+    const leg = await startLeg([P1], { [P1]: () => 'should never run' })
+    try {
+      const post = agentPost(CONV, P1, 'my own words', 2_000, '00000003-0000-4000-8000-000000000003', 0)
+      ;(leg.daemon as any).handleRelayMsg(rd({ op: 'context', post }, { agentId: P1, msgId: 'c-1' }), () => {})
+      await settle()
+      expect(leg.prompts.get(P1)).toHaveLength(0)
+      expect((leg.daemon as any).store.getActivation(rendezvousKey(post.postId, P1))).toBeUndefined()
+    } finally {
+      await leg.stop()
+    }
+  },
+
+  // (d) Exactly-once per (post, target): a re-fanned identical copy under a
+  // fresh relay msgId is absorbed by the durable rendezvous.
+  'explicit-mention-exactly-once': async () => {
+    const leg = await startLeg([P1], { [P1]: () => NO_RESPONSE })
+    try {
+      seedCallPolicy(leg.daemon, [P1, P2]) // the author lives on another daemon — only the edge matters
+      const post = agentPost(CONV, P2, 'peer says hi', 2_000, '00000001-0000-4000-8000-000000000001', 0)
+      ;(leg.daemon as any).handleRelayMsg(rd({ op: 'context', post }, { msgId: 'c-1' }), () => {})
+      ;(leg.daemon as any).handleRelayMsg(rd({ op: 'context', post }, { msgId: 'c-2' }), () => {})
+      await vi.waitFor(() => expect(leg.prompts.get(P1)).toHaveLength(1), WAIT)
+      await settle()
+      expect(leg.prompts.get(P1)).toHaveLength(1)
+    } finally {
+      await leg.stop()
+    }
+  },
+
+  // (e) Streaming never routes: while the author is still generating nothing
+  // fans out and no peer wakes; the committed post is what activates.
+  'streaming-never-routes': async () => {
+    let releaseP1!: () => void
+    const p1Blocked = new Promise<void>((resolve) => (releaseP1 = resolve))
+    const leg = await startLeg([P1, P2], {
+      [P1]: async () => {
+        await p1Blocked
+        return 'the committed answer'
+      },
+      [P2]: () => NO_RESPONSE
+    })
+    try {
+      injectTurn(leg, P1, 'go', { msgId: 't-1', mentions: [P1] })
+      await vi.waitFor(() => expect(leg.prompts.get(P1)).toHaveLength(1), WAIT)
+      await settle()
+      // Mid-generation: nothing committed, nothing fanned, peer untouched.
+      expect(leg.posts).toHaveLength(0)
+      expect(leg.prompts.get(P2)).toHaveLength(0)
+      releaseP1()
+      await vi.waitFor(() => expect(leg.prompts.get(P2)).toHaveLength(1), WAIT)
+      expect(leg.posts.map((p) => p.post.text)).toEqual(['the committed answer'])
+    } finally {
+      await leg.stop()
+    }
+  },
+
+  // (f) One +1 per edge against MAX_AGENT_CALL_HOPS; the edge that would run
+  // at the cap is refused with a recorded hop_limit reason. (Declared
+  // divergence: channels ALSO charge the loop guard, which binds first.)
+  'hop-transition-and-refusal': async (scenario) => {
+    const refusal = scenario.expect.webchat!.refusal!
+    expect(refusal).toEqual({ reason: 'hop_limit', afterEdges: MAX_AGENT_CALL_HOPS - 1 })
+    let n = 0
+    const always = () => String(++n)
+    const leg = await startLeg([P1, P2], { [P1]: always, [P2]: always })
+    try {
+      const infoSpy = vi.spyOn((leg.daemon as any).log, 'info')
+      injectTurn(leg, P1, 'count forever, alternating', { msgId: 't-1' })
+      // Kickoff post at depth 0, one continuation per admitted edge at depths
+      // 1..cap-1 — afterEdges + 1 posts in total, then the recorded refusal.
+      await vi.waitFor(() => expect(leg.posts).toHaveLength(refusal.afterEdges + 1), { timeout: 25_000 })
+      await settle()
+      expect(leg.posts).toHaveLength(refusal.afterEdges + 1)
+      expect(leg.posts.map((p) => (p.post.author.kind === 'agent' ? p.post.author.hopCount : undefined))).toEqual(
+        Array.from({ length: refusal.afterEdges + 1 }, (_, depth) => depth)
+      )
+      expect(infoSpy.mock.calls.map((c) => c[0])).toContainEqual(
+        expect.stringContaining(`hop_limit: source depth ${MAX_AGENT_CALL_HOPS - 1} + 1 reaches ${MAX_AGENT_CALL_HOPS}`)
+      )
+    } finally {
+      await leg.stop()
+    }
+  },
+
+  // (g) A silent decline absorbs the wake: no post, no transcript reply row,
+  // nothing further fans out.
+  'silent-decline-absorbs-wake': async () => {
+    const leg = await startLeg([P1, REF], {
+      [P1]: (text) => (/kick off/.test(text) ? 'observed post' : NO_RESPONSE),
+      [REF]: () => NO_RESPONSE
+    })
+    try {
+      injectTurn(leg, P1, 'kick off, please', { msgId: 't-1', mentions: [P1] })
+      await vi.waitFor(() => expect(leg.prompts.get(REF)).toHaveLength(1), WAIT)
+      await settle()
+      // Woken, silent: no committed post by the decliner, no reply row, and
+      // the exchange ends (nothing further woke the author).
+      expect(leg.posts.map((p) => p.agentId)).toEqual([P1])
+      expect(transcriptRowsBy(leg, REF)).toEqual([])
+      expect(leg.prompts.get(P1)).toHaveLength(1)
+    } finally {
+      await leg.stop()
+    }
+  },
+
+  // (i) Fail closed on an unverifiable author: an agent post with no usable
+  // depth stamp (pre-parity daemon, or a claim the relay could not bind and
+  // therefore stripped — §5.2a) is transcript-only.
+  'unverified-author-no-agent-rungs': async () => {
+    const leg = await startLeg([P1], { [P1]: () => 'should never run' })
+    try {
+      seedCallPolicy(leg.daemon, [P1, P2])
+      const post = agentPost(CONV, P2, 'legacy peer post', 2_000, '00000002-0000-4000-8000-000000000002')
+      ;(leg.daemon as any).handleRelayMsg(rd({ op: 'context', post }, { msgId: 'c-1' }), () => {})
+      await settle()
+      // Recorded for §8.5 catch-up…
+      expect(transcriptRowsBy(leg, P2).map((row) => (row as { text: string }).text)).toEqual(['legacy peer post'])
+      // …but no activation.
+      expect(leg.prompts.get(P1)).toHaveLength(0)
+    } finally {
+      await leg.stop()
+    }
+  }
+}
+
+describe('activation parity — webchat leg', () => {
+  const scenarios = scenariosFor('webchat')
+
+  it('covers every scenario the spec declares for this surface', () => {
+    expect(new Set(scenarios.map((s) => s.id))).toEqual(new Set(Object.keys(drivers)))
+  })
+
+  for (const scenario of scenarios) {
+    it(`${scenario.id} — ${scenario.title}`, async () => {
+      const driver = drivers[scenario.id]
+      expect(driver, `no webchat driver for spec scenario "${scenario.id}"`).toBeDefined()
+      await driver!(scenario)
+    }, 60_000)
+  }
+})

--- a/evals/test/parity-webchat.test.ts
+++ b/evals/test/parity-webchat.test.ts
@@ -238,12 +238,14 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
     }
   },
 
-  // (d) Exactly-once per (post, target): a re-fanned identical copy under a
-  // fresh relay msgId is absorbed by the durable rendezvous.
-  'explicit-mention-exactly-once': async (scenario) => {
+  // (d) Exactly one admission per (message, target). This surface's addressed
+  // edge is the relay's pre-addressed fan-out copy — webchat agent posts carry
+  // no structured mentions — and a re-fanned identical copy under a fresh
+  // relay msgId is absorbed by the durable rendezvous.
+  'delivery-exactly-once': async (scenario) => {
     // The spec is load-bearing: editing this scenario's declared outcome
     // fails this pin; changing the behavior fails the measured asserts below.
-    expect(declaredOutcome(scenario.expect.webchat!)).toEqual({ activates: 'named-peer-exactly-once' })
+    expect(declaredOutcome(scenario.expect.webchat!)).toEqual({ activates: 'target-exactly-once' })
     const leg = await startLeg([P1], { [P1]: () => NO_RESPONSE })
     try {
       seedCallPolicy(leg.daemon, [P1, P2]) // the author lives on another daemon — only the edge matters
@@ -264,7 +266,7 @@ const drivers: Record<string, (scenario: ParityScenario) => Promise<void>> = {
     // The spec is load-bearing: editing this scenario's declared outcome
     // fails this pin; changing the behavior fails the measured asserts below.
     expect(declaredOutcome(scenario.expect.webchat!)).toEqual({
-      activates: 'named-peer-exactly-once',
+      activates: 'target-exactly-once',
       streamingNeverRoutes: true
     })
     let releaseP1!: () => void

--- a/evals/test/routing-fixture.ts
+++ b/evals/test/routing-fixture.ts
@@ -287,6 +287,38 @@ export class RoutingFixture {
     return { messageId, handles }
   }
 
+  /** Inject one THIRD-PARTY bot platform message — a bot user this deployment
+   *  does not manage, carrying NO AgentConnect authorship claim. What (if
+   *  anything) it activates is the daemon's decision, the thing under test. */
+  injectThirdPartyBot(
+    text: string,
+    options: { thread?: string; mentions?: string[]; sender?: string } = {}
+  ): { messageId: string; handles: DeliveryHandle[] } {
+    const sender = options.sender ?? 'UEXTBOT9'
+    const messageId = this.world.mintMessageId('slack')
+    this.world.registerRoomMessage(this.room.channel, messageId)
+    this.world.recordThreadMessage(this.room.channel, options.thread ?? messageId, {
+      ts: messageId,
+      text,
+      sender,
+      isBot: true
+    })
+    const handles = this.room.memberIntegrationIds.map((integrationId) =>
+      this.harness.inject({
+        integrationId,
+        payload: {
+          channel: this.room.channel,
+          thread: options.thread ?? messageId,
+          messageId,
+          text,
+          sender: { id: sender, isBot: true },
+          ...(options.mentions !== undefined ? { mentions: options.mentions } : {})
+        }
+      })
+    )
+    return { messageId, handles }
+  }
+
   /** Settle everything in flight: await injected handles, drain echo cascades
    *  generation by generation, then wait for daemon idleness. */
   async settle(handles: DeliveryHandle[] = []): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eval:collab:routing": "vitest run evals/test/routing-acceptance.test.ts evals/test/connection-surface.test.ts",
     "eval:collab:view": "promptfoo view -n",
     "eval:contracts": "vitest run packages/daemon/test/evaluation-events.test.ts packages/daemon/test/evaluation-atif.test.ts packages/daemon/test/evaluation-permission.test.ts packages/daemon/test/evaluation-runner.test.ts packages/daemon/test/daemon-evaluation.test.ts evals/test/outcome.test.ts evals/test/provider.test.ts evals/test/paired-summary.test.ts",
+    "eval:parity": "vitest run evals/test/parity-spec.test.ts evals/test/parity-slack.test.ts evals/test/parity-webchat.test.ts",
     "eval:validate": "node evals/run-validate.mjs && tsc -p evals/tsconfig.json",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/packages/daemon/test/daemon-webchat-continuation.test.ts
+++ b/packages/daemon/test/daemon-webchat-continuation.test.ts
@@ -1,11 +1,21 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import { transcriptChannelKey } from '../src/store/local-store.js'
-import type { RdChatEvent, RdMsgWebchat, RdWebchatPost, WebchatPost } from '@agentconnect.md/protocol'
+import {
+  NO_RESPONSE,
+  agentPost as agentPostIn,
+  fakeCpClient,
+  fakeRelay as fakeRelayIn,
+  rdFactory,
+  rendezvousKey,
+  scaffold,
+  scriptedHosts,
+  seedCallPolicy,
+  settle,
+  userPost as userPostIn
+} from './webchat-continuation-fixture.js'
+import type { RdChatEvent, WebchatPost } from '@agentconnect.md/protocol'
 
 // #549 parity for multi-agent webchat (webchat-multi-agents.md §5.2a, issue #904):
 // a peer agent's COMMITTED conversation post — delivered to this participant as a
@@ -15,144 +25,22 @@ import type { RdChatEvent, RdMsgWebchat, RdWebchatPost, WebchatPost } from '@age
 // activation rendezvous, final-events-only (structural), author exclusion, and the
 // directional call policy. These tests drive the daemon exactly the way the relay
 // does (handleRelayMsg) and play the relay's roster fan-out themselves.
+//
+// The setup helpers live in `webchat-continuation-fixture.ts`, shared with the
+// cross-surface activation parity leg (`evals/test/parity-webchat.test.ts`).
 
 const P1 = 'bot-a'
 const P2 = 'bot-b'
 const REF = 'bot-ref'
 const CONV = '88888888-8888-4888-8888-888888888888'
 const KICKOFF_TURN = '77777777-7777-4777-8777-777777777777'
-const NO_RESPONSE = 'AC_NO_RESPONSE'
 const WAIT = { timeout: 10_000 }
 
-function scaffold(agentIds: string[]): string {
-  const root = mkdtempSync(join(tmpdir(), 'ac-wc-cont-'))
-  writeFileSync(
-    join(root, 'config.json'),
-    JSON.stringify({
-      version: 1,
-      controlPlane: { enabled: false },
-      features: { turnFinalContextRefresh: true },
-      runtimes: { claude: { command: 'node', args: ['unused'] } }
-    })
-  )
-  for (const id of agentIds) {
-    const adir = join(root, 'agents', id)
-    mkdirSync(adir, { recursive: true })
-    writeFileSync(
-      join(adir, 'agent.json'),
-      JSON.stringify({
-        id,
-        name: id,
-        status: 'active',
-        runtime: 'claude',
-        workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
-        integrations: [],
-        output: { mode: 'medium' }
-      })
-    )
-  }
-  return root
-}
-
-/** One scripted per-agent ACP host: every prompt resolves immediately with
- *  `reply(promptText)` streamed as a single message chunk. */
-function scriptedHosts(replies: Record<string, (prompt: string) => string | Promise<string>>) {
-  // Eagerly seeded so "was never prompted" asserts read an empty list, not undefined.
-  const prompts = new Map<string, string[]>(Object.keys(replies).map((id) => [id, []]))
-  let sessionSeq = 0
-  const factory = (agent: { id: string }, onUpdate: (sid: string, u: unknown) => void) => {
-    const agentId = agent.id
-    if (!prompts.has(agentId)) prompts.set(agentId, [])
-    return {
-      start: vi.fn(async () => {}),
-      newSession: vi.fn(async () => `acp-cont-${agentId}-${++sessionSeq}`),
-      hasSession: vi.fn(() => true),
-      prompt: vi.fn(async (sid: string, blocks: { text?: string }[]) => {
-        const text = blocks.map((b) => b.text ?? '').join('\n')
-        prompts.get(agentId)!.push(text)
-        const reply = await replies[agentId]!(text)
-        onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: reply } })
-        return { stopReason: 'end_turn' }
-      }),
-      cancel: vi.fn(async () => {}),
-      stop: vi.fn(async () => {})
-    } as any
-  }
-  return { factory, prompts }
-}
-
-function fakeCpClient() {
-  return { emitUsageReport: vi.fn(), emitSessionActivity: vi.fn(), stop: vi.fn(async () => {}) }
-}
-
-const rd = (payload: RdMsgWebchat['payload'], over: Partial<RdMsgWebchat> = {}): RdMsgWebchat => ({
-  source: 'webchat',
-  agentId: P1,
-  sessionKey: CONV,
-  msgId: 'm-1',
-  chatId: CONV,
-  payload,
-  ...over
-})
-
-/** Seed the flat org directory so `admits()` (checked per continuation edge, like the
- *  platform ladder) passes for every roster pair. */
-function seedCallPolicy(daemon: Daemon, agentIds: string[], over: Record<string, object> = {}): void {
-  ;(daemon as any).cpCollab.replace({
-    generation: 1,
-    channels: [],
-    agents: agentIds.map((agentId) => ({
-      agentId,
-      orgId: 'org-1',
-      callPolicy: 'all',
-      allowedCallerAgentIds: [],
-      outboundPolicy: 'all',
-      allowedTargetAgentIds: [],
-      ...(over[agentId] ?? {})
-    }))
-  })
-}
-
-/** Play the relay: deliver a committed post to the browser log (posts[]) and fan a
- *  pre-addressed `context` copy to every OTHER roster member — the §5.2 fan-out. */
-function fakeRelay(daemonRef: { current?: Daemon }, roster: string[]) {
-  const posts: RdWebchatPost[] = []
-  let ctxSeq = 0
-  const fanOut = (p: RdWebchatPost): void => {
-    posts.push(p)
-    for (const peer of roster) {
-      if (peer === p.agentId) continue
-      ;(daemonRef.current as any).handleRelayMsg(
-        rd({ op: 'context', post: p.post }, { agentId: peer, msgId: `ctx-${ctxSeq++}` }),
-        () => {}
-      )
-    }
-  }
-  return { posts, fanOut }
-}
-
-const userPost = (text: string, at: number, postId: string): WebchatPost => ({
-  postId,
-  conversationId: CONV,
-  author: { kind: 'user', user: 'owner' },
-  text,
-  at
-})
-
-const agentPost = (agentId: string, text: string, at: number, postId: string, hopCount?: number): WebchatPost => ({
-  postId,
-  conversationId: CONV,
-  author: { kind: 'agent', agentId, ...(hopCount !== undefined ? { hopCount } : {}) },
-  text,
-  at
-})
-
-const settle = () => new Promise((r) => setTimeout(r, 300))
-
-// Mirrors daemon.ts `activationKey(platform, transportScope, platformMessageId, target)`.
-const rendezvousKey = (postId: string, targetAgentId: string): string =>
-  ['webchat', '', postId, targetAgentId].join('\u0000')
-
+const rd = rdFactory(CONV, P1)
+const fakeRelay = (daemonRef: { current?: Daemon }, roster: string[]) => fakeRelayIn(daemonRef, roster, CONV)
+const userPost = (text: string, at: number, postId: string): WebchatPost => userPostIn(CONV, text, at, postId)
+const agentPost = (agentId: string, text: string, at: number, postId: string, hopCount?: number): WebchatPost =>
+  agentPostIn(CONV, agentId, text, at, postId, hopCount)
 describe('webchat multi-agent continuation (#549 parity)', () => {
   it('runs the counting relay: kickoff activates, each committed post wakes roster-minus-author, the silent referee absorbs its wakes', async () => {
     // player-1 counts odds, player-2 evens; both decline past 6; the referee

--- a/packages/daemon/test/webchat-continuation-fixture.ts
+++ b/packages/daemon/test/webchat-continuation-fixture.ts
@@ -1,0 +1,165 @@
+/**
+ * Reusable daemon-level webchat multi-agent fixture, extracted from the #906
+ * continuation tests (`daemon-webchat-continuation.test.ts`) so the
+ * cross-surface activation parity leg (`evals/test/parity-webchat.test.ts`)
+ * can drive the exact same seam: `handleRelayMsg` fed the relay's
+ * pre-addressed `turn` frames, with the §5.2 roster fan-out of committed
+ * posts (`context` frames) played by the caller — no relay process, no
+ * platform SDKs, no credentials.
+ *
+ * The helpers deliberately stay 1:1 with what the #906 tests inlined; the
+ * behavior under test is the DAEMON's (webchat-multi-agents.md §5.2a).
+ */
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { vi } from 'vitest'
+import type { Daemon } from '../src/daemon.js'
+import type { RdMsgWebchat, RdWebchatPost, WebchatPost } from '@agentconnect.md/protocol'
+
+/** The standing response-choice sentinel (product-conventions §No-response). */
+export const NO_RESPONSE = 'AC_NO_RESPONSE'
+
+/** Scaffold a control-plane-less daemon root with one stub agent per id. */
+export function scaffold(agentIds: string[]): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-wc-cont-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      features: { turnFinalContextRefresh: true },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  for (const id of agentIds) {
+    const adir = join(root, 'agents', id)
+    mkdirSync(adir, { recursive: true })
+    writeFileSync(
+      join(adir, 'agent.json'),
+      JSON.stringify({
+        id,
+        name: id,
+        status: 'active',
+        runtime: 'claude',
+        workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+        integrations: [],
+        output: { mode: 'medium' }
+      })
+    )
+  }
+  return root
+}
+
+/** One scripted per-agent ACP host: every prompt resolves immediately with
+ *  `reply(promptText)` streamed as a single message chunk. */
+export function scriptedHosts(replies: Record<string, (prompt: string) => string | Promise<string>>) {
+  // Eagerly seeded so "was never prompted" asserts read an empty list, not undefined.
+  const prompts = new Map<string, string[]>(Object.keys(replies).map((id) => [id, []]))
+  let sessionSeq = 0
+  const factory = (agent: { id: string }, onUpdate: (sid: string, u: unknown) => void) => {
+    const agentId = agent.id
+    if (!prompts.has(agentId)) prompts.set(agentId, [])
+    return {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => `acp-cont-${agentId}-${++sessionSeq}`),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sid: string, blocks: { text?: string }[]) => {
+        const text = blocks.map((b) => b.text ?? '').join('\n')
+        prompts.get(agentId)!.push(text)
+        const reply = await replies[agentId]!(text)
+        onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: reply } })
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    } as any
+  }
+  return { factory, prompts }
+}
+
+export function fakeCpClient() {
+  return { emitUsageReport: vi.fn(), emitSessionActivity: vi.fn(), stop: vi.fn(async () => {}) }
+}
+
+/** Frame factory bound to one conversation id — mirrors the relay's
+ *  pre-addressed `rd/msg` shape. `defaultAgentId` is the addressee used when a
+ *  call does not override it. */
+export function rdFactory(conversationId: string, defaultAgentId: string) {
+  return (payload: RdMsgWebchat['payload'], over: Partial<RdMsgWebchat> = {}): RdMsgWebchat => ({
+    source: 'webchat',
+    agentId: defaultAgentId,
+    sessionKey: conversationId,
+    msgId: 'm-1',
+    chatId: conversationId,
+    payload,
+    ...over
+  })
+}
+
+/** Seed the flat org directory so `admits()` (checked per continuation edge, like the
+ *  platform ladder) passes for every roster pair. */
+export function seedCallPolicy(daemon: Daemon, agentIds: string[], over: Record<string, object> = {}): void {
+  ;(daemon as any).cpCollab.replace({
+    generation: 1,
+    channels: [],
+    agents: agentIds.map((agentId) => ({
+      agentId,
+      orgId: 'org-1',
+      callPolicy: 'all',
+      allowedCallerAgentIds: [],
+      outboundPolicy: 'all',
+      allowedTargetAgentIds: [],
+      ...(over[agentId] ?? {})
+    }))
+  })
+}
+
+/** Play the relay: deliver a committed post to the browser log (posts[]) and fan a
+ *  pre-addressed `context` copy to every OTHER roster member — the §5.2 fan-out. */
+export function fakeRelay(daemonRef: { current?: Daemon }, roster: string[], conversationId: string) {
+  // Every fan-out frame overrides `agentId` with the receiving peer.
+  const rd = rdFactory(conversationId, 'fan-out-peer')
+  const posts: RdWebchatPost[] = []
+  let ctxSeq = 0
+  const fanOut = (p: RdWebchatPost): void => {
+    posts.push(p)
+    for (const peer of roster) {
+      if (peer === p.agentId) continue
+      ;(daemonRef.current as any).handleRelayMsg(
+        rd({ op: 'context', post: p.post }, { agentId: peer, msgId: `ctx-${ctxSeq++}` }),
+        () => {}
+      )
+    }
+  }
+  return { posts, fanOut }
+}
+
+export const userPost = (conversationId: string, text: string, at: number, postId: string): WebchatPost => ({
+  postId,
+  conversationId,
+  author: { kind: 'user', user: 'owner' },
+  text,
+  at
+})
+
+export const agentPost = (
+  conversationId: string,
+  agentId: string,
+  text: string,
+  at: number,
+  postId: string,
+  hopCount?: number
+): WebchatPost => ({
+  postId,
+  conversationId,
+  author: { kind: 'agent', agentId, ...(hopCount !== undefined ? { hopCount } : {}) },
+  text,
+  at
+})
+
+export const settle = () => new Promise((r) => setTimeout(r, 300))
+
+/** Mirrors daemon.ts `activationKey(platform, transportScope, platformMessageId, target)`. */
+export const rendezvousKey = (postId: string, targetAgentId: string): string =>
+  ['webchat', '', postId, targetAgentId].join('\u0000')

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -170,6 +170,37 @@ export function parseBrowserFrame(msg: unknown, user: string): ParsedBrowserOp |
   }
 }
 
+/**
+ * Which participants one user turn ACTIVATES (pure — the production choice,
+ * exported so the activation parity suite exercises this exact seam rather
+ * than a re-implementation; evals/parity/spec.ts `human-kickoff-activation`).
+ *
+ * Conversation membership is a STANDING mention (webchat-multi-agents.md
+ * §4.2): an unmentioned message activates the WHOLE roster — each agent may
+ * still decline via the no-response contract — while explicit @mentions (or an
+ * explicit `targets` list) narrow the turn to the named participants.
+ *
+ * `valid` preserves the chosen list's order filtered to roster members;
+ * `invalid` are the chosen non-members, each of which is nacked
+ * `not_participant`. Roster members outside `valid` receive the turn as a
+ * transcript-only `context` copy instead.
+ */
+export function selectTurnTargets(
+  roster: readonly string[],
+  options: { mentions?: readonly string[]; requestedTargets?: readonly string[] } = {}
+): { valid: string[]; invalid: string[] } {
+  const chosen = options.requestedTargets?.length
+    ? options.requestedTargets
+    : options.mentions?.length
+      ? options.mentions
+      : roster
+  const members = new Set(roster)
+  return {
+    valid: chosen.filter((agentId) => members.has(agentId)),
+    invalid: chosen.filter((agentId) => !members.has(agentId))
+  }
+}
+
 export class RelayBrowserConnection implements ChatSink {
   private closed = false
   private readonly remoteMcp?: Readonly<WebchatRemoteMcpEntitlement>
@@ -267,23 +298,16 @@ export class RelayBrowserConnection implements ChatSink {
 
   /** Fan one user turn out to its targeted participants + context to the rest. */
   private async sendTurn(op: Extract<RelayWebchatOp, { op: 'turn' }>, requestedTargets?: string[]): Promise<void> {
-    // Conversation membership is a STANDING mention (webchat-multi-agents.md
-    // §4.2): an unmentioned message activates the WHOLE roster — each agent may
-    // still decline via the no-response contract — while explicit @mentions (or
-    // an explicit `targets` list) narrow the turn to the named participants.
-    const targets = requestedTargets?.length
-      ? requestedTargets
-      : op.mentions?.length
-        ? op.mentions
-        : [...this.byAgentId.keys()]
+    const { valid, invalid } = selectTurnTargets([...this.byAgentId.keys()], {
+      ...(op.mentions !== undefined ? { mentions: op.mentions } : {}),
+      ...(requestedTargets !== undefined ? { requestedTargets } : {})
+    })
     const turnId = op.turnId ?? randomUUID()
     this.lastPostAt = Math.max(Date.now(), this.lastPostAt + 1)
     const post = { postId: randomUUID(), at: this.lastPostAt }
-    const invalid = targets.filter((t) => !this.byAgentId.has(t))
     for (const t of invalid) {
       this.send({ type: 'ack', ack: { accepted: false, turnId, agentId: t, reason: 'not_participant' } })
     }
-    const valid = targets.filter((t) => this.byAgentId.has(t))
     if (valid.length === 0) return
 
     const turn: RelayWebchatOp = { ...op, turnId, post }


### PR DESCRIPTION
## What

Phase 1 of the activation-policy unification plan (motivated by #904): a **cross-surface parity suite** that pins today's "who does this message activate" behavior behind one scenario spec, so the three implementations (daemon platform ladder, relay arbitrate, webchat roster activation) can no longer drift silently.

- **Spec** — `evals/parity/spec.ts`: 9 scenarios as data (invariant + per-surface expected outcomes in one vocabulary). Intentional per-surface differences are **declared divergences** with design-doc citations; an undeclared difference fails the spec guard.
- **Slack-shaped leg** — `evals/test/parity-slack.test.ts`: reuses the arena routing fixture (real daemon path, scripted hosts, production-style platform echo, credential-free). The fixture gains `injectThirdPartyBot` for the unverified-author scenario.
- **Webchat leg** — `evals/test/parity-webchat.test.ts`: drives the same `handleRelayMsg` seam the #906 tests drive; the #906 setup is extracted into `packages/daemon/test/webchat-continuation-fixture.ts` and `daemon-webchat-continuation.test.ts` now imports it (behavior unchanged, suite still green).
- **Spec guard** — `evals/test/parity-spec.test.ts`: well-formedness + divergence-declaration enforcement.
- **CI** — new credential-free gate `pnpm eval:parity`, added as its own step in the Unit Test job (same bucket as `eval:collab:contracts`).
- **Docs** — `docs/designs/activation-parity.md` states the governance rule (any PR touching activation/routing updates the spec: all legs pass, or the divergence is declared with a citation — the #549/#904/#906 incident shape is the thing this forbids), plus a pointer from `collaboration-arena-baseline.md` §2.

## Scenarios

(a) human kickoff activation set — **declared divergence**: mention-gated channel vs webchat standing-mention roster; (b) verified agent continuation activates participants minus author (#549); (c) author never self-activates; (d) delivery admitted exactly once per (message, target) — the explicit-mention edge on channels, the pre-addressed fan-out edge on webchat; (e) streaming never routes; (f) hop transition +1 per edge with a recorded refusal — **declared divergence**: the channel automatic-turn budget binds at 16 edges (`gated`) while webchat runs to the hop cap (`hop_limit`), per arena-baseline §6.1 / webchat §5.2a; (g) silent decline absorbs a wake without posting; (h) needsReply round trip wakes the parent exactly once (Slack leg; declared not-applicable on webchat); (i) an unverified author cannot activate through agent rungs.

Each leg iterates the spec and has a coverage guard: a scenario added to the spec without a driver fails the leg.

## Verification

- `pnpm eval:parity` — 23 tests green (spec guard 4, Slack leg 10, webchat leg 9)
- `pnpm eval:collab:contracts` — 115 green; `pnpm eval:contracts` — 46 green
- `packages/daemon` `daemon-webchat-continuation.test.ts` — 8 green after the fixture extraction
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm eval:validate` — clean

Phase 2 (extracting the daemon ladder into one pure policy module, zero behavior change) will be stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
