### PR TITLE
fix(daemon): share cloud transcript database across orgs

### DIFF
--- a/docs/designs/cloud-data-plane-postgres.md
+++ b/docs/designs/cloud-data-plane-postgres.md
@@ -8,24 +8,24 @@ The daemon accepts no database CLI flag or environment variable. The deployment 
 {
   "version": 1,
   "databaseUrl": "postgresql://daemon:password@data-plane-postgres:5432/agentconnect",
-  "schema": "org_01abc234",
   "maxConnections": 4
 }
 ```
 
-`databaseUrl` is an install-level execution-data credential. `schema` is the org locator supplied by deployment orchestration. Every daemon may connect to the same database, but each org uses a separate schema; store queries set `search_path` to exactly that validated schema. The connection file should therefore be mounted from a Secret, not a ConfigMap.
+`databaseUrl` is the install-level execution-data credential. Every cloud daemon connects to this one database and shares one table set for every organization managed by the Control Plane. Organization identity is resolved from the CP agent registry at each store boundary; `org_id` is mandatory in every transcript key, index, and query. There is no per-org database or schema setting. The connection file should therefore be mounted from a Secret, not a ConfigMap.
 
 The daemon refuses `--k8s` startup when the file is absent, invalid, unreachable, or cannot be migrated. Non-Kubernetes startup does not inspect the file, even if it exists.
 
 ## Schema upgrades
 
-Data-plane migrations are independent from the Control Plane Prisma migrations. Each org schema contains `_agentconnect_schema_migrations`. First touch runs pending migrations inside one transaction while holding a transaction-scoped PostgreSQL advisory lock derived from the schema name. This makes concurrent first touch by several daemon members safe. A migration failure rolls back startup; a schema newer than the daemon is refused.
+Data-plane migrations are independent from the Control Plane Prisma migrations. The install-wide `agentconnect_data_plane` schema contains one `_agentconnect_schema_migrations` history. Startup runs pending migrations inside one transaction while holding an install-wide PostgreSQL advisory lock. This makes concurrent startup by several daemon members safe. A migration failure rolls back startup; a schema newer than the daemon is refused.
 
 Migration rules:
 
 1. Append a migration; never edit one already released.
 2. Keep each version transactional and safe under a rolling deployment.
 3. Add nullable columns or a compatible default before readers require them; destructive cleanup belongs in a later release.
-4. Exercise the shared-schema integration test with `DATA_PLANE_TEST_DATABASE_URL` before release.
+4. Keep old and new daemon versions compatible throughout rolling deployment.
+5. Exercise the shared-database integration test with `DATA_PLANE_TEST_DATABASE_URL` before release.
 
-The PostgreSQL transcript tables preserve the SQLite transcript's insertion sequence, mutation revision, per-agent recipients, tool bodies, attachment/quote sidecars, and chronological event-time index. Transcript mutation transactions hold a per-org advisory lock while assigning revisions, making revision order commit-safe across daemon members. History pages and their terminal revision watermark come from one repeatable-read snapshot, so a concurrent commit cannot be skipped by the next live cursor.
+The PostgreSQL transcript tables preserve the SQLite transcript's insertion sequence, mutation revision, per-agent recipients, tool bodies, attachment/quote sidecars, and chronological event-time index. Every uniqueness constraint is organization-scoped, so identical platform identifiers in different organizations cannot collide. Transcript mutation transactions hold a per-org advisory lock while assigning revisions, making revision order commit-safe across daemon members without serializing unrelated organizations. History pages and their organization-scoped terminal revision watermark come from one repeatable-read snapshot, so a concurrent commit cannot be skipped by the next live cursor.

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -193,12 +193,8 @@ export interface SessionReader {
 
 type TranscriptReadStore = Pick<
   LocalStore,
-  | 'transcriptTailForAgent'
-  | 'transcriptPageForAgentByEventTime'
-  | 'transcriptPageForAgent'
-  | 'currentTranscriptRevision'
-  | 'getToolBodyForAgent'
->
+  'transcriptTailForAgent' | 'transcriptPageForAgentByEventTime' | 'transcriptPageForAgent' | 'getToolBodyForAgent'
+> & { currentTranscriptRevision(agentId: string): number }
 
 type AsyncTranscriptReadStore = {
   [Method in keyof TranscriptReadStore]: (
@@ -436,7 +432,7 @@ export function createSessionReader(
       return {
         sessionId: req.sessionId,
         messages: kept,
-        liveCursor: String(transcriptPageCursor(page) ?? (await transcriptRead.currentTranscriptRevision())),
+        liveCursor: String(transcriptPageCursor(page) ?? (await transcriptRead.currentTranscriptRevision(rec.agentId))),
         ...(hasOlder && oldestKept
           ? {
               nextCursor:

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2416,6 +2416,8 @@ export class Daemon {
       startK8sPlane?: typeof startK8sRuntimePlane
       /** Test seam only; production `--k8s` always reads the fixed Secret mount. */
       openDataPlane?: typeof openMountedPostgresDataPlane
+      /** Test seam for the cloud startup barrier; production waits for CP register/ok. */
+      startControlPlane?: (root: string) => Promise<void> | undefined
       /** Test seams for local catalog resolution and executable/state filtering. */
       resolveCatalog?: typeof resolveRuntimeCatalog
       installed?: typeof installedRuntimes
@@ -3518,14 +3520,17 @@ export class Daemon {
       warn: (m) => this.log.warn(m)
     })
 
-    // open consolidated Slack connections, resolve bot user ids (merged rules are per-message)
     const groups = consolidate(this.transportAgents(agents))
     this.botUserIds = {}
-    // Collaboration Arena (§5): project the evaluation environment's effective
-    // integrations into `agent.integrations` + the connection maps BEFORE any
-    // routing/dispatch can observe them, and AFTER physical Slack consolidation
-    // was computed — virtual transports never open sockets.
+    // Install synthetic evaluation integrations before routing observes them; they never open sockets.
     this.installEvaluationEnvironment()
+    const startControlPlane = this.opts.startControlPlane ?? ((cpRoot: string) => this.startCpClient(cpRoot))
+    const cloudCpReady = this.k8s ? startControlPlane(root) : undefined
+    if (this.k8s && !cloudCpReady)
+      throw new Error('daemon startup refused: --k8s requires an authoritative CP organization registry')
+    if (cloudCpReady) this.log.info('data-plane: waiting for the initial CP organization registry before ingress')
+    await cloudCpReady
+    // open consolidated Slack connections, resolve bot user ids (merged rules are per-message)
     if (groups.size === 0) this.log.info('slack: no slack integrations configured')
     else this.log.info(`slack: opening ${groups.size} socket connection(s)`)
     for (const group of groups.values()) {
@@ -3629,7 +3634,7 @@ export class Daemon {
     // Curated admission belongs to local runtime resolution, not CP readiness.
     // Start it even when the control plane is disabled or still unreachable.
     void this.probeRuntimesAndEmit(false).finally(() => this.armRuntimeProbeRefresh())
-    this.startCpClient(root)
+    if (!this.k8s) startControlPlane(root)
     this.armIdleSweep()
     this.log.info('daemon ready')
   }
@@ -19640,8 +19645,8 @@ export class Daemon {
             .map(({ name, ...def }) => [name, def])
         )
         this.mcpServerDefs = this.cpMcpDefs?.effective() ?? this.mcpServerDefs
-        this.convergeRelays(snap.relays) // set-converge relay dial-out sockets (DOES prune) + persist for boot re-dial
         this.cpCollab.replace(snap.collabRoutes) // baseline collaboration routing snapshot (P2 terminal-verify)
+        this.convergeRelays(snap.relays) // connect ingress only after its organization authority is installed
         this.cpRouting?.converge({
           routingEpoch: snap.routingEpoch,
           assignments: snap.assignments,
@@ -20459,7 +20464,7 @@ export class Daemon {
     }
   }
 
-  private startCpClient(root: string): void {
+  private startCpClient(root: string): Promise<void> | undefined {
     const cp = this.cfg.controlPlane
     if (!configuredControlPlane(cp, !!this.clusterIdentityToken)) {
       // Url first: an envelope daemon has no config file, so a missing address is
@@ -20476,7 +20481,7 @@ export class Daemon {
       } else {
         this.log.info(`cp: not connecting (${missing}) — running local`)
       }
-      return
+      return undefined
     }
     if (this.clusterIdentityToken) this.log.info("cp: authenticating with this pod's projected identity token")
     // Start host-load sampling only now — the snapshot exists solely to feed the CP
@@ -20517,11 +20522,13 @@ export class Daemon {
       // A forwarded cross-daemon agent-call — terminal-verify + dispatch (P2).
       onRelayAgentMsg: (msg) => this.handleRelayAgentMsg(msg)
     })
-    // Boot-dial the persisted roster before the CP is even reachable: it survives a
-    // CP outage in config.json, so webchat ingress keeps working across a daemon
-    // restart while the CP is down (graceful degradation). register/ok re-converges
-    // authoritatively — and prunes any relay the CP has since dropped — once connected.
-    if (this.cfg.relays.length) this.relays.converge(this.cfg.relays)
+    // Self-hosted daemons boot-dial persisted relays; cloud ingress waits for fresh org authority.
+    if (this.cfg.relays.length && !this.k8s) this.relays.converge(this.cfg.relays)
+
+    let resolveInitialRegistry!: () => void
+    const initialRegistry = new Promise<void>((resolve) => {
+      resolveInitialRegistry = resolve
+    })
 
     const workspaceLocation = (id: string, sessionId?: string) => {
       const agent = this.agents.get(id)
@@ -20610,6 +20617,7 @@ export class Daemon {
       // and re-assert each integration's cached channel-membership snapshot (the CP
       // may have missed emits while we were disconnected; latest-wins upsert).
       onReady: () => {
+        resolveInitialRegistry()
         void this.probeRuntimesAndEmit()
         void this.syncOrganizationSuggestions().catch((err) =>
           this.log.warn(`cp: organization suggestion replay failed (${err instanceof Error ? err.name : 'unknown'})`)
@@ -20717,6 +20725,7 @@ export class Daemon {
     if (orphaned) this.log.info(`remote MCP: queued ${orphaned} orphaned grant revocation(s) from previous run`)
     this.cpClient.start()
     this.log.info(`cp: connecting to ${url}…`)
+    return initialRegistry
   }
 
   /** Build the current profile entry for a runtime (one element of the

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2807,11 +2807,14 @@ export class Daemon {
     }
     if (this.k8s) {
       const openDataPlane = this.opts.openDataPlane ?? openMountedPostgresDataPlane
-      this.dataPlane = await openDataPlane((error) => {
-        this.log.error(`data-plane: PostgreSQL persistence failed — ${formatErr(error)}`)
-        this.draining = true
-        this.requestExit(1)
-      })
+      this.dataPlane = await openDataPlane(
+        (agentId) => this.cpCollab.orgForAgent(agentId),
+        (error) => {
+          this.log.error(`data-plane: PostgreSQL persistence failed — ${formatErr(error)}`)
+          this.draining = true
+          this.requestExit(1)
+        }
+      )
       // A pod's terminationGracePeriodSeconds must exceed this, or the kubelet SIGKILLs
       // mid-drain and the graceful window is a promise the deployment cannot keep. The
       // daemon cannot read its own grace period (it has no pod read), so it states the

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1273,7 +1273,7 @@ export class LocalStore {
       .map((row) => row.acpSessionId)
   }
 
-  currentTranscriptRevision(): number {
+  currentTranscriptRevision(_agentId?: string): number {
     return this.transcriptRevision
   }
 

--- a/packages/daemon/src/store/postgres-config.ts
+++ b/packages/daemon/src/store/postgres-config.ts
@@ -20,8 +20,6 @@ export const DataPlaneConfigSchema = z
   .object({
     version: z.literal(1),
     databaseUrl: PostgresUrl,
-    /** CP-issued org locator; schema isolation makes a missing org predicate impossible. */
-    schema: z.string().regex(/^[a-z][a-z0-9_]{0,62}$/),
     maxConnections: z.number().int().min(1).max(32).default(4)
   })
   .strict()

--- a/packages/daemon/src/store/postgres-migrations.ts
+++ b/packages/daemon/src/store/postgres-migrations.ts
@@ -1,10 +1,6 @@
 import type { PoolClient } from 'pg'
 
-/** Quote only identifiers already accepted by postgres-config's conservative regex. */
-export function quotePgIdentifier(identifier: string): string {
-  if (!/^[a-z][a-z0-9_]{0,62}$/.test(identifier)) throw new Error('invalid PostgreSQL schema identifier')
-  return `"${identifier}"`
-}
+export const DATA_PLANE_SCHEMA = 'agentconnect_data_plane'
 
 const MIGRATIONS: readonly string[] = [
   `
@@ -12,6 +8,7 @@ const MIGRATIONS: readonly string[] = [
 
     CREATE TABLE transcript (
       seq BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      org_id TEXT NOT NULL,
       channel TEXT NOT NULL,
       thread TEXT NOT NULL,
       ts TEXT,
@@ -28,33 +25,34 @@ const MIGRATIONS: readonly string[] = [
       revision BIGINT NOT NULL DEFAULT nextval('transcript_revision_seq'),
       post_id TEXT
     );
-    CREATE INDEX transcript_thread_seq ON transcript (channel, thread, seq);
-    CREATE UNIQUE INDEX transcript_text_ts ON transcript (channel, thread, ts) WHERE kind = 'text';
+    CREATE INDEX transcript_thread_seq ON transcript (org_id, channel, thread, seq);
+    CREATE UNIQUE INDEX transcript_text_ts ON transcript (org_id, channel, thread, ts) WHERE kind = 'text';
     CREATE UNIQUE INDEX transcript_agent_tool_call
-      ON transcript (channel, thread, sender, tool_call_id) WHERE tool_call_id IS NOT NULL;
-    CREATE INDEX transcript_thread_event_time ON transcript (channel, thread, event_time_us DESC, seq DESC);
-    CREATE INDEX transcript_thread_revision ON transcript (channel, thread, revision);
+      ON transcript (org_id, channel, thread, sender, tool_call_id) WHERE tool_call_id IS NOT NULL;
+    CREATE INDEX transcript_thread_event_time
+      ON transcript (org_id, channel, thread, event_time_us DESC, seq DESC);
+    CREATE INDEX transcript_thread_revision ON transcript (org_id, channel, thread, revision);
 
     CREATE TABLE transcript_recipient (
+      org_id TEXT NOT NULL,
       channel TEXT NOT NULL,
       thread TEXT NOT NULL,
       ts TEXT NOT NULL,
       agent_id TEXT NOT NULL,
-      PRIMARY KEY (channel, thread, ts, agent_id)
+      PRIMARY KEY (org_id, channel, thread, ts, agent_id)
     );
   `
 ]
 
 export const DATA_PLANE_SCHEMA_VERSION = MIGRATIONS.length
 
-/** Upgrade one org schema under a transaction-scoped cross-daemon advisory lock. */
-export async function migrateDataPlaneSchema(client: PoolClient, schema: string): Promise<void> {
-  const quoted = quotePgIdentifier(schema)
+/** Upgrade the install-wide data-plane schema under a cross-daemon advisory lock. */
+export async function migrateDataPlaneSchema(client: PoolClient): Promise<void> {
   await client.query('BEGIN')
   try {
-    await client.query("SELECT pg_advisory_xact_lock(hashtext($1), hashtext('agentconnect-data-plane'))", [schema])
-    await client.query(`CREATE SCHEMA IF NOT EXISTS ${quoted}`)
-    await client.query(`SET LOCAL search_path TO ${quoted}, pg_catalog`)
+    await client.query("SELECT pg_advisory_xact_lock(hashtext('agentconnect-data-plane-migration'))")
+    await client.query(`CREATE SCHEMA IF NOT EXISTS ${DATA_PLANE_SCHEMA}`)
+    await client.query(`SET LOCAL search_path TO ${DATA_PLANE_SCHEMA}, pg_catalog`)
     await client.query(`
       CREATE TABLE IF NOT EXISTS _agentconnect_schema_migrations (
         version INTEGER PRIMARY KEY,
@@ -68,18 +66,17 @@ export async function migrateDataPlaneSchema(client: PoolClient, schema: string)
     const newest = Math.max(0, ...applied)
     if (newest > DATA_PLANE_SCHEMA_VERSION) {
       throw new Error(
-        `data-plane schema ${schema} is version ${newest}, newer than supported version ${DATA_PLANE_SCHEMA_VERSION}`
+        `data-plane schema is version ${newest}, newer than supported version ${DATA_PLANE_SCHEMA_VERSION}`
       )
     }
     for (let version = 1; version <= newest; version += 1) {
-      if (!applied.has(version))
-        throw new Error(`data-plane schema ${schema} has a migration gap before version ${newest}`)
+      if (!applied.has(version)) throw new Error(`data-plane schema has a migration gap before version ${newest}`)
     }
     let expected = newest + 1
     for (let index = 0; index < MIGRATIONS.length; index += 1) {
       const version = index + 1
       if (applied.has(version)) continue
-      if (version !== expected) throw new Error(`data-plane schema ${schema} has a migration gap`)
+      if (version !== expected) throw new Error('data-plane schema has a migration gap')
       await client.query(MIGRATIONS[index]!)
       await client.query('INSERT INTO _agentconnect_schema_migrations (version) VALUES ($1)', [version])
       expected += 1

--- a/packages/daemon/src/store/postgres-transcript-store.ts
+++ b/packages/daemon/src/store/postgres-transcript-store.ts
@@ -7,7 +7,9 @@ import {
   type TranscriptRow
 } from './local-store.js'
 import { readDataPlaneConfig, type DataPlaneConfig } from './postgres-config.js'
-import { migrateDataPlaneSchema, quotePgIdentifier } from './postgres-migrations.js'
+import { DATA_PLANE_SCHEMA, migrateDataPlaneSchema } from './postgres-migrations.js'
+
+export type OrgForAgent = (agentId: string) => string | undefined
 
 export interface TranscriptToolCall {
   channel: string
@@ -83,9 +85,33 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
 
   constructor(
     private readonly pool: Pool,
-    private readonly schema: string,
+    private readonly orgForAgent: OrgForAgent,
     private readonly onFailure: (error: Error) => void = () => undefined
   ) {}
+
+  private requireAgentOrg(agentId: string): string {
+    const orgId = this.orgForAgent(agentId)
+    if (!orgId) throw new Error(`cannot resolve transcript organization for agent ${agentId}`)
+    return orgId
+  }
+
+  private requireTranscriptOrg(entry: Pick<TranscriptEntry, 'sender' | 'recipient'>): string {
+    const senderOrg = this.orgForAgent(entry.sender)
+    const recipientOrg = entry.recipient ? this.orgForAgent(entry.recipient) : undefined
+    if (senderOrg && recipientOrg && senderOrg !== recipientOrg)
+      throw new Error('transcript sender and recipient belong to different organizations')
+    const orgId = recipientOrg ?? senderOrg
+    if (!orgId) throw new Error('cannot resolve transcript organization from agent ownership')
+    return orgId
+  }
+
+  private rejectWrite(error: unknown): never {
+    if (!this.failure) {
+      this.failure = error instanceof Error ? error : new Error(String(error))
+      this.onFailure(this.failure)
+    }
+    throw this.failure
+  }
 
   private enqueue(operation: () => Promise<void>): void {
     if (this.failure) throw this.failure
@@ -98,11 +124,21 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
   }
 
   appendTranscript(entry: TranscriptEntry): void {
-    this.enqueue(() => this.writeTranscript(entry))
+    try {
+      const orgId = this.requireTranscriptOrg(entry)
+      this.enqueue(() => this.writeTranscript(orgId, entry))
+    } catch (error) {
+      this.rejectWrite(error)
+    }
   }
 
   insertToolCall(entry: TranscriptToolCall): void {
-    this.enqueue(() => this.writeToolCall(entry))
+    try {
+      const orgId = this.requireAgentOrg(entry.sender)
+      this.enqueue(() => this.writeToolCall(orgId, entry))
+    } catch (error) {
+      this.rejectWrite(error)
+    }
   }
 
   updateToolCall(
@@ -112,17 +148,22 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     toolCallId: string,
     patch: { title: string; body: string }
   ): void {
-    this.enqueue(async () => {
-      await this.withRevisionTransaction((client) =>
-        client.query(
-          `UPDATE transcript
-           SET text = $1, body = $2, revision = nextval('transcript_revision_seq')
-           WHERE channel = $3 AND thread = $4 AND sender = $5 AND tool_call_id = $6
-             AND (text IS DISTINCT FROM $1 OR body IS DISTINCT FROM $2)`,
-          [patch.title, patch.body, channel, thread, agentId, toolCallId]
+    try {
+      const orgId = this.requireAgentOrg(agentId)
+      this.enqueue(async () => {
+        await this.withRevisionTransaction(orgId, (client) =>
+          client.query(
+            `UPDATE transcript
+             SET text = $1, body = $2, revision = nextval('transcript_revision_seq')
+             WHERE org_id = $3 AND channel = $4 AND thread = $5 AND sender = $6 AND tool_call_id = $7
+               AND (text IS DISTINCT FROM $1 OR body IS DISTINCT FROM $2)`,
+            [patch.title, patch.body, orgId, channel, thread, agentId, toolCallId]
+          )
         )
-      )
-    })
+      })
+    } catch (error) {
+      this.rejectWrite(error)
+    }
   }
 
   async flush(): Promise<void> {
@@ -133,19 +174,19 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
   private async withSchema<T>(operation: (client: PoolClient) => Promise<T>): Promise<T> {
     const client = await this.pool.connect()
     try {
-      await client.query(`SET search_path TO ${quotePgIdentifier(this.schema)}, pg_catalog`)
+      await client.query(`SET search_path TO ${DATA_PLANE_SCHEMA}, pg_catalog`)
       return await operation(client)
     } finally {
       client.release()
     }
   }
 
-  private async withRevisionTransaction<T>(operation: (client: PoolClient) => Promise<T>): Promise<T> {
+  private async withRevisionTransaction<T>(orgId: string, operation: (client: PoolClient) => Promise<T>): Promise<T> {
     return this.withSchema(async (client) => {
       await client.query('BEGIN')
       try {
         await client.query("SELECT pg_advisory_xact_lock(hashtext($1), hashtext('agentconnect-transcript-revision'))", [
-          this.schema
+          orgId
         ])
         const result = await operation(client)
         await client.query('COMMIT')
@@ -157,18 +198,19 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     })
   }
 
-  private async writeTranscript(entry: TranscriptEntry): Promise<void> {
+  private async writeTranscript(orgId: string, entry: TranscriptEntry): Promise<void> {
     const quoteJson = entry.quoted?.text ? JSON.stringify(entry.quoted) : (entry.quoteJson ?? null)
     const attachmentsJson = entry.attachments?.length ? JSON.stringify(entry.attachments) : null
-    await this.withRevisionTransaction(async (client) => {
+    await this.withRevisionTransaction(orgId, async (client) => {
       const inserted = await client.query<{ inserted: boolean }>(
         `INSERT INTO transcript
-             (channel, thread, ts, sender, kind, text, recipient, event_time_us,
+             (org_id, channel, thread, ts, sender, kind, text, recipient, event_time_us,
               attachments_json, quote_json, trusted_agent_bot, post_id)
-           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
-           ON CONFLICT (channel, thread, ts) WHERE kind = 'text' DO NOTHING
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+           ON CONFLICT (org_id, channel, thread, ts) WHERE kind = 'text' DO NOTHING
            RETURNING true AS inserted`,
         [
+          orgId,
           entry.channel,
           entry.thread,
           entry.ts,
@@ -186,21 +228,22 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
       if (inserted.rowCount === 0 && entry.kind === 'text') {
         await client.query(
           `UPDATE transcript SET
-               text = CASE WHEN $1 THEN $2 ELSE text END,
-               event_time_us = CASE WHEN $3::bigint IS NOT NULL THEN $3 ELSE event_time_us END,
-               attachments_json = COALESCE(attachments_json, $4),
-               quote_json = CASE WHEN $5::text IS NOT NULL THEN $5 ELSE quote_json END,
-               trusted_agent_bot = CASE WHEN $6 THEN true ELSE trusted_agent_bot END,
-               post_id = COALESCE(post_id, $7),
+               text = CASE WHEN $2 THEN $3 ELSE text END,
+               event_time_us = CASE WHEN $4::bigint IS NOT NULL THEN $4 ELSE event_time_us END,
+               attachments_json = COALESCE(attachments_json, $5),
+               quote_json = CASE WHEN $6::text IS NOT NULL THEN $6 ELSE quote_json END,
+               trusted_agent_bot = CASE WHEN $7 THEN true ELSE trusted_agent_bot END,
+               post_id = COALESCE(post_id, $8),
                revision = nextval('transcript_revision_seq')
-             WHERE channel = $8 AND thread = $9 AND ts = $10 AND kind = 'text'
-               AND (($1 AND text IS DISTINCT FROM $2)
-                 OR ($3::bigint IS NOT NULL AND event_time_us IS DISTINCT FROM $3)
-                 OR (attachments_json IS NULL AND $4::text IS NOT NULL)
-                 OR ($5::text IS NOT NULL AND quote_json IS DISTINCT FROM $5)
-                 OR ($6 AND trusted_agent_bot IS DISTINCT FROM true)
-                 OR (post_id IS NULL AND $7::text IS NOT NULL))`,
+             WHERE org_id = $1 AND channel = $9 AND thread = $10 AND ts = $11 AND kind = 'text'
+               AND (($2 AND text IS DISTINCT FROM $3)
+                 OR ($4::bigint IS NOT NULL AND event_time_us IS DISTINCT FROM $4)
+                 OR (attachments_json IS NULL AND $5::text IS NOT NULL)
+                 OR ($6::text IS NOT NULL AND quote_json IS DISTINCT FROM $6)
+                 OR ($7 AND trusted_agent_bot IS DISTINCT FROM true)
+                 OR (post_id IS NULL AND $8::text IS NOT NULL))`,
           [
+            orgId,
             entry.authoritative === true,
             entry.text,
             entry.eventTimeUs ?? null,
@@ -216,29 +259,31 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
       }
       if (entry.recipient && entry.ts) {
         const delivered = await client.query(
-          `INSERT INTO transcript_recipient (channel, thread, ts, agent_id)
-             VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING RETURNING agent_id`,
-          [entry.channel, entry.thread, entry.ts, entry.recipient]
+          `INSERT INTO transcript_recipient (org_id, channel, thread, ts, agent_id)
+             VALUES ($1,$2,$3,$4,$5) ON CONFLICT DO NOTHING RETURNING agent_id`,
+          [orgId, entry.channel, entry.thread, entry.ts, entry.recipient]
         )
         if (inserted.rowCount === 0 && delivered.rowCount === 1) {
           await client.query(
             `UPDATE transcript SET revision = nextval('transcript_revision_seq')
-               WHERE channel = $1 AND thread = $2 AND ts = $3 AND kind = 'text'`,
-            [entry.channel, entry.thread, entry.ts]
+               WHERE org_id = $1 AND channel = $2 AND thread = $3 AND ts = $4 AND kind = 'text'`,
+            [orgId, entry.channel, entry.thread, entry.ts]
           )
         }
       }
     })
   }
 
-  private async writeToolCall(entry: TranscriptToolCall): Promise<void> {
-    await this.withRevisionTransaction(async (client) => {
+  private async writeToolCall(orgId: string, entry: TranscriptToolCall): Promise<void> {
+    await this.withRevisionTransaction(orgId, async (client) => {
       await client.query(
         `INSERT INTO transcript
-           (channel, thread, ts, sender, kind, text, tool_call_id, body, event_time_us)
-         VALUES ($1,$2,$3,$4,'tool',$5,$6,$7,$8)
-         ON CONFLICT (channel, thread, sender, tool_call_id) WHERE tool_call_id IS NOT NULL DO NOTHING`,
+           (org_id, channel, thread, ts, sender, kind, text, tool_call_id, body, event_time_us)
+         VALUES ($1,$2,$3,$4,$5,'tool',$6,$7,$8,$9)
+         ON CONFLICT (org_id, channel, thread, sender, tool_call_id)
+           WHERE tool_call_id IS NOT NULL DO NOTHING`,
         [
+          orgId,
           entry.channel,
           entry.thread,
           entry.ts,
@@ -253,10 +298,10 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
   }
 
   private scopeSql(): string {
-    return `(sender = $3 OR recipient = $3 OR (transcript.kind = 'text' AND EXISTS (
+    return `(sender = $4 OR recipient = $4 OR (transcript.kind = 'text' AND EXISTS (
       SELECT 1 FROM transcript_recipient tr
-      WHERE tr.channel = transcript.channel AND tr.thread = transcript.thread
-        AND tr.ts = transcript.ts AND tr.agent_id = $3)))`
+      WHERE tr.org_id = transcript.org_id AND tr.channel = transcript.channel
+        AND tr.thread = transcript.thread AND tr.ts = transcript.ts AND tr.agent_id = $4)))`
   }
 
   async transcriptPageForAgent(
@@ -267,16 +312,18 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     limit: number
   ): Promise<{ rows: TranscriptRow[]; hasMore: boolean; cursor: number }> {
     await this.flush()
+    const orgId = this.requireAgentOrg(agentId)
     const hidden = [...SESSION_TITLE_TOOL_TITLES]
-    const values: unknown[] = [channel, thread, agentId, ...hidden]
+    const values: unknown[] = [orgId, channel, thread, agentId, ...hidden]
     const before = beforeSeq === null ? '' : `AND seq < $${values.push(beforeSeq)}`
     const limitParam = `$${values.push(limit + 1)}`
     const page = await this.snapshotPage(
-      `SELECT * FROM transcript WHERE channel = $1 AND thread = $2 ${before}
-         AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($4,$5))
+      `SELECT * FROM transcript WHERE org_id = $1 AND channel = $2 AND thread = $3 ${before}
+         AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($5,$6))
        ORDER BY seq DESC LIMIT ${limitParam}`,
       values,
-      limit
+      limit,
+      orgId
     )
     return { rows: page.rows, hasMore: page.hasMore, cursor: page.watermark }
   }
@@ -289,19 +336,21 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     limit: number
   ): Promise<{ rows: TranscriptRow[]; hasMore: boolean; cursor: number }> {
     await this.flush()
+    const orgId = this.requireAgentOrg(agentId)
     const hidden = [...SESSION_TITLE_TOOL_TITLES]
-    const values: unknown[] = [channel, thread, agentId, ...hidden]
+    const values: unknown[] = [orgId, channel, thread, agentId, ...hidden]
     const cursor =
       before === null
         ? ''
         : `AND (event_time_us < $${values.push(before.eventTimeUs)} OR (event_time_us = $${values.push(before.eventTimeUs)} AND seq < $${values.push(before.seq)}))`
     const limitParam = `$${values.push(limit + 1)}`
     const page = await this.snapshotPage(
-      `SELECT * FROM transcript WHERE channel = $1 AND thread = $2 ${cursor}
-         AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($4,$5))
+      `SELECT * FROM transcript WHERE org_id = $1 AND channel = $2 AND thread = $3 ${cursor}
+         AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($5,$6))
        ORDER BY event_time_us DESC, seq DESC LIMIT ${limitParam}`,
       values,
-      limit
+      limit,
+      orgId
     )
     return { rows: page.rows, hasMore: page.hasMore, cursor: page.watermark }
   }
@@ -314,13 +363,15 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     limit: number
   ): Promise<{ rows: TranscriptRow[]; hasMore: boolean; cursor: number }> {
     await this.flush()
+    const orgId = this.requireAgentOrg(agentId)
     const hidden = [...SESSION_TITLE_TOOL_TITLES]
     const result = await this.snapshotPage(
-      `SELECT * FROM transcript WHERE channel = $1 AND thread = $2 AND revision > $6
-         AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($4,$5))
-       ORDER BY revision ASC LIMIT $7`,
-      [channel, thread, agentId, ...hidden, afterRevision, limit + 1],
-      limit
+      `SELECT * FROM transcript WHERE org_id = $1 AND channel = $2 AND thread = $3 AND revision > $7
+         AND ${this.scopeSql()} AND NOT (kind = 'tool' AND text IN ($5,$6))
+       ORDER BY revision ASC LIMIT $8`,
+      [orgId, channel, thread, agentId, ...hidden, afterRevision, limit + 1],
+      limit,
+      orgId
     )
     return {
       rows: result.rows,
@@ -329,11 +380,13 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     }
   }
 
-  async currentTranscriptRevision(): Promise<number> {
+  async currentTranscriptRevision(agentId: string): Promise<number> {
     await this.flush()
+    const orgId = this.requireAgentOrg(agentId)
     return this.withSchema(async (client) => {
       const result = await client.query<{ revision: string }>(
-        'SELECT COALESCE(MAX(revision), 0)::text AS revision FROM transcript'
+        'SELECT COALESCE(MAX(revision), 0)::text AS revision FROM transcript WHERE org_id = $1',
+        [orgId]
       )
       return safeInteger(result.rows[0]?.revision ?? '0', 'transcript.revision')
     })
@@ -346,11 +399,12 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
     toolCallId: string
   ): Promise<string | undefined> {
     await this.flush()
+    const orgId = this.requireAgentOrg(agentId)
     return this.withSchema(async (client) => {
       const result = await client.query<{ body: string | null }>(
         `SELECT body FROM transcript
-         WHERE channel = $1 AND thread = $2 AND sender = $3 AND tool_call_id = $4`,
-        [channel, thread, agentId, toolCallId]
+         WHERE org_id = $1 AND channel = $2 AND thread = $3 AND sender = $4 AND tool_call_id = $5`,
+        [orgId, channel, thread, agentId, toolCallId]
       )
       return result.rows[0]?.body ?? undefined
     })
@@ -359,14 +413,16 @@ export class PostgresTranscriptStore implements TranscriptReplicaSink {
   private async snapshotPage(
     sql: string,
     values: unknown[],
-    limit: number
+    limit: number,
+    orgId: string
   ): Promise<{ rows: TranscriptRow[]; hasMore: boolean; watermark: number }> {
     return this.withSchema(async (client) => {
       await client.query('BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY')
       try {
         const result = await client.query<PgTranscriptRow>(sql, values)
         const revision = await client.query<{ watermark: string }>(
-          'SELECT COALESCE(MAX(revision), 0)::text AS watermark FROM transcript'
+          'SELECT COALESCE(MAX(revision), 0)::text AS watermark FROM transcript WHERE org_id = $1',
+          [orgId]
         )
         await client.query('COMMIT')
         const rows = result.rows.map(transcriptRow)
@@ -390,12 +446,17 @@ export class PostgresDataPlane {
   private constructor(
     private readonly pool: Pool,
     config: DataPlaneConfig,
+    orgForAgent: OrgForAgent,
     onFailure?: (error: Error) => void
   ) {
-    this.transcripts = new PostgresTranscriptStore(pool, config.schema, onFailure)
+    this.transcripts = new PostgresTranscriptStore(pool, orgForAgent, onFailure)
   }
 
-  static async open(config: DataPlaneConfig, onFailure?: (error: Error) => void): Promise<PostgresDataPlane> {
+  static async open(
+    config: DataPlaneConfig,
+    orgForAgent: OrgForAgent,
+    onFailure?: (error: Error) => void
+  ): Promise<PostgresDataPlane> {
     const pool = new Pool({
       connectionString: config.databaseUrl,
       max: config.maxConnections,
@@ -406,7 +467,7 @@ export class PostgresDataPlane {
     try {
       const client = await pool.connect()
       try {
-        await migrateDataPlaneSchema(client, config.schema)
+        await migrateDataPlaneSchema(client)
       } finally {
         client.release()
       }
@@ -414,7 +475,7 @@ export class PostgresDataPlane {
       await pool.end().catch(() => undefined)
       throw error
     }
-    return new PostgresDataPlane(pool, config, onFailure)
+    return new PostgresDataPlane(pool, config, orgForAgent, onFailure)
   }
 
   async close(): Promise<void> {
@@ -423,6 +484,9 @@ export class PostgresDataPlane {
   }
 }
 
-export async function openMountedPostgresDataPlane(onFailure?: (error: Error) => void): Promise<PostgresDataPlane> {
-  return PostgresDataPlane.open(readDataPlaneConfig(), onFailure)
+export async function openMountedPostgresDataPlane(
+  orgForAgent: OrgForAgent,
+  onFailure?: (error: Error) => void
+): Promise<PostgresDataPlane> {
+  return PostgresDataPlane.open(readDataPlaneConfig(), orgForAgent, onFailure)
 }

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -56,6 +56,7 @@ function daemon(opts: {
   plane?: Record<string, unknown>
   dataPlane?: boolean
   openDataPlane?: ReturnType<typeof vi.fn>
+  startControlPlane?: ReturnType<typeof vi.fn>
 }): Daemon {
   return new Daemon({
     root: opts.root,
@@ -96,6 +97,7 @@ function daemon(opts: {
         }
       : {}),
     ...(opts.openDataPlane ? { openDataPlane: opts.openDataPlane as never } : {}),
+    startControlPlane: (opts.startControlPlane ?? vi.fn(() => Promise.resolve())) as never,
     ...(opts.supervisor ? { supervisor: opts.supervisor } : {}),
     resolveCatalog: async () => catalog(),
     ...(opts.probe ? { probeRuntimes: opts.probe as never } : {}),
@@ -118,6 +120,39 @@ describe('daemon --k8s mode', () => {
   it('requires the mounted PostgreSQL configuration before starting the execution plane', async () => {
     const k8sDaemon = daemon({ root: root(), k8s: true, dataPlane: false })
     await expect(k8sDaemon.start()).rejects.toThrow(/data-plane configuration is not readable/)
+  })
+
+  it('waits for the initial CP organization registry before completing cloud startup', async () => {
+    let release!: () => void
+    const registryReady = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const startControlPlane = vi.fn(() => registryReady)
+    const instance = daemon({ root: root(), k8s: true, startControlPlane })
+    const starting = instance.start()
+    let settled = false
+    void starting.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+    await vi.waitFor(() => expect(startControlPlane).toHaveBeenCalledOnce())
+    expect(settled).toBe(false)
+    release()
+    try {
+      await starting
+    } finally {
+      await instance.stop()
+    }
+  })
+
+  it('refuses cloud startup when no authoritative CP organization registry is available', async () => {
+    const instance = daemon({ root: root(), k8s: true, startControlPlane: vi.fn(() => undefined) })
+    await expect(instance.start()).rejects.toThrow(/requires an authoritative CP organization registry/)
+    await instance.stop()
   })
 
   it('advertises the runtimes the image declares, not what is installed on the host', async () => {

--- a/packages/daemon/test/daemon-supervisor-k8s.test.ts
+++ b/packages/daemon/test/daemon-supervisor-k8s.test.ts
@@ -34,6 +34,7 @@ function daemon(opts: { k8s?: boolean; supervisor?: string; requestExit?: (code:
               },
               close: async () => {}
             }) as never,
+          startControlPlane: async () => {},
           startK8sPlane: async () =>
             ({
               driver: {} as never,

--- a/packages/daemon/test/postgres-config.test.ts
+++ b/packages/daemon/test/postgres-config.test.ts
@@ -11,26 +11,23 @@ function configFile(value: unknown): string {
 }
 
 describe('mounted data-plane configuration', () => {
-  it('accepts a PostgreSQL DSN and an isolated org schema', () => {
+  it('accepts one install-wide PostgreSQL DSN', () => {
     expect(
-      readDataPlaneConfig(
-        configFile({ version: 1, databaseUrl: 'postgresql://daemon:secret@postgres/data_plane', schema: 'org_a1' })
-      )
+      readDataPlaneConfig(configFile({ version: 1, databaseUrl: 'postgresql://daemon:secret@postgres/data_plane' }))
     ).toEqual({
       version: 1,
       databaseUrl: 'postgresql://daemon:secret@postgres/data_plane',
-      schema: 'org_a1',
       maxConnections: 4
     })
   })
 
-  it('rejects non-PostgreSQL URLs and unsafe schema identifiers', () => {
-    expect(() =>
-      readDataPlaneConfig(configFile({ version: 1, databaseUrl: 'https://postgres/data_plane', schema: 'org-a' }))
-    ).toThrow(/databaseUrl must be a PostgreSQL URL/)
+  it('rejects non-PostgreSQL URLs and per-org schema configuration', () => {
+    expect(() => readDataPlaneConfig(configFile({ version: 1, databaseUrl: 'https://postgres/data_plane' }))).toThrow(
+      /databaseUrl must be a PostgreSQL URL/
+    )
     expect(() =>
       readDataPlaneConfig(configFile({ version: 1, databaseUrl: 'postgresql://postgres/data_plane', schema: 'org-a' }))
-    ).toThrow(/schema/)
+    ).toThrow(/unrecognized key/i)
   })
 
   it('does not include a missing file error or credential material in its message', () => {

--- a/packages/daemon/test/postgres-migrations.test.ts
+++ b/packages/daemon/test/postgres-migrations.test.ts
@@ -14,10 +14,10 @@ function clientWithVersions(versions: number[]) {
 describe('PostgreSQL data-plane migrations', () => {
   it('serializes first touch and records every migration before commit', async () => {
     const { client, queries } = clientWithVersions([])
-    await migrateDataPlaneSchema(client, 'org_a')
+    await migrateDataPlaneSchema(client)
     expect(queries.map(({ text }) => text.trim().split(/\s+/, 2).join(' '))).toEqual([
       'BEGIN',
-      'SELECT pg_advisory_xact_lock(hashtext($1),',
+      "SELECT pg_advisory_xact_lock(hashtext('agentconnect-data-plane-migration'))",
       'CREATE SCHEMA',
       'SET LOCAL',
       'CREATE TABLE',
@@ -26,20 +26,19 @@ describe('PostgreSQL data-plane migrations', () => {
       'INSERT INTO',
       'COMMIT'
     ])
-    expect(queries[1]?.values).toEqual(['org_a'])
     expect(queries.at(-2)?.values).toEqual([DATA_PLANE_SCHEMA_VERSION])
   })
 
   it('is idempotent when the current version is already installed', async () => {
     const { client, queries } = clientWithVersions([DATA_PLANE_SCHEMA_VERSION])
-    await migrateDataPlaneSchema(client, 'org_a')
+    await migrateDataPlaneSchema(client)
     expect(queries.some(({ text }) => text.includes('CREATE SEQUENCE transcript_revision_seq'))).toBe(false)
     expect(queries.at(-1)?.text).toBe('COMMIT')
   })
 
   it('rolls back instead of opening a schema written by a newer daemon', async () => {
     const { client, queries } = clientWithVersions([DATA_PLANE_SCHEMA_VERSION + 1])
-    await expect(migrateDataPlaneSchema(client, 'org_a')).rejects.toThrow(/newer than supported/)
+    await expect(migrateDataPlaneSchema(client)).rejects.toThrow(/newer than supported/)
     expect(queries.at(-1)?.text).toBe('ROLLBACK')
   })
 })

--- a/packages/daemon/test/postgres-transcript-store.int.test.ts
+++ b/packages/daemon/test/postgres-transcript-store.int.test.ts
@@ -2,76 +2,104 @@ import { randomUUID } from 'node:crypto'
 import { Pool } from 'pg'
 import { afterAll, describe, expect, it } from 'vitest'
 import { PostgresDataPlane } from '../src/store/postgres-transcript-store.js'
-import { quotePgIdentifier } from '../src/store/postgres-migrations.js'
+import { DATA_PLANE_SCHEMA } from '../src/store/postgres-migrations.js'
 
 const databaseUrl = process.env.DATA_PLANE_TEST_DATABASE_URL
-const schemas: string[] = []
+const orgIds = new Set<string>()
+
+function testOrg(): string {
+  const orgId = `org-test-${randomUUID()}`
+  orgIds.add(orgId)
+  return orgId
+}
 
 afterAll(async () => {
-  if (!databaseUrl || schemas.length === 0) return
+  if (!databaseUrl || orgIds.size === 0) return
   const pool = new Pool({ connectionString: databaseUrl })
   try {
-    for (const schema of schemas) await pool.query(`DROP SCHEMA ${quotePgIdentifier(schema)} CASCADE`)
+    await pool.query(`SET search_path TO ${DATA_PLANE_SCHEMA}, pg_catalog`)
+    await pool.query('DELETE FROM transcript_recipient WHERE org_id = ANY($1)', [[...orgIds]])
+    await pool.query('DELETE FROM transcript WHERE org_id = ANY($1)', [[...orgIds]])
   } finally {
     await pool.end()
   }
 })
 
 describe.skipIf(!databaseUrl)('PostgreSQL transcript store', () => {
-  it('shares one org schema safely across daemon pools and upgrades it once', async () => {
-    const schema = `org_test_${randomUUID().replaceAll('-', '')}`
-    schemas.push(schema)
-    const config = { version: 1 as const, databaseUrl: databaseUrl!, schema, maxConnections: 2 }
-    const [first, second] = await Promise.all([PostgresDataPlane.open(config), PostgresDataPlane.open(config)])
+  it('shares one table set across daemon pools while isolating organizations', async () => {
+    const orgA = testOrg()
+    const orgB = testOrg()
+    const config = { version: 1 as const, databaseUrl: databaseUrl!, maxConnections: 2 }
+    const orgForAgent = (agentId: string) =>
+      agentId === 'agent-a1' || agentId === 'agent-a2' ? orgA : agentId === 'agent-b' ? orgB : undefined
+    const [first, second] = await Promise.all([
+      PostgresDataPlane.open(config, orgForAgent),
+      PostgresDataPlane.open(config, orgForAgent)
+    ])
     try {
       first.transcripts.appendTranscript({
-        channel: 'C1',
-        thread: 'T1',
+        channel: 'same-channel',
+        thread: 'same-thread',
         ts: '1.000001',
-        sender: 'U1',
-        recipient: 'agent-a',
+        sender: 'user-a',
+        recipient: 'agent-a1',
         kind: 'text',
-        text: 'shared durable row'
+        text: 'org A row'
       })
       second.transcripts.appendTranscript({
-        channel: 'C1',
-        thread: 'T1',
+        channel: 'same-channel',
+        thread: 'same-thread',
         ts: '1.000001',
-        sender: 'U1',
+        sender: 'user-a',
+        recipient: 'agent-a2',
+        kind: 'text',
+        text: 'org A row'
+      })
+      second.transcripts.appendTranscript({
+        channel: 'same-channel',
+        thread: 'same-thread',
+        ts: '1.000001',
+        sender: 'user-b',
         recipient: 'agent-b',
         kind: 'text',
-        text: 'shared durable row'
+        text: 'org B row'
       })
       await Promise.all([first.transcripts.flush(), second.transcripts.flush()])
-      const [forA, forB] = await Promise.all([
-        first.transcripts.transcriptPageForAgent('C1', 'T1', 'agent-a', null, 10),
-        second.transcripts.transcriptPageForAgent('C1', 'T1', 'agent-b', null, 10)
+      const [forA1, forA2, forB] = await Promise.all([
+        first.transcripts.transcriptPageForAgent('same-channel', 'same-thread', 'agent-a1', null, 10),
+        second.transcripts.transcriptPageForAgent('same-channel', 'same-thread', 'agent-a2', null, 10),
+        first.transcripts.transcriptPageForAgent('same-channel', 'same-thread', 'agent-b', null, 10)
       ])
-      expect(forA.rows.map((row) => row.text)).toEqual(['shared durable row'])
-      expect(forB.rows.map((row) => row.text)).toEqual(['shared durable row'])
-      expect(forA.cursor).toBe(forA.rows[0]!.revision)
-      expect(await first.transcripts.currentTranscriptRevision()).toBeGreaterThan(0)
+      expect(forA1.rows.map((row) => row.text)).toEqual(['org A row'])
+      expect(forA2.rows.map((row) => row.text)).toEqual(['org A row'])
+      expect(forB.rows.map((row) => row.text)).toEqual(['org B row'])
+      expect(await first.transcripts.currentTranscriptRevision('agent-a1')).toBe(forA1.cursor)
+      expect(await first.transcripts.currentTranscriptRevision('agent-b')).toBe(forB.cursor)
     } finally {
       await Promise.all([first.close(), second.close()])
     }
   })
 
   it('serializes revision assignment through commit across daemon pools', async () => {
-    const schema = `org_test_${randomUUID().replaceAll('-', '')}`
-    schemas.push(schema)
-    const config = { version: 1 as const, databaseUrl: databaseUrl!, schema, maxConnections: 2 }
-    const [first, second] = await Promise.all([PostgresDataPlane.open(config), PostgresDataPlane.open(config)])
+    const orgId = testOrg()
+    const suffix = randomUUID().replaceAll('-', '')
+    const config = { version: 1 as const, databaseUrl: databaseUrl!, maxConnections: 2 }
+    const orgForAgent = (agentId: string) => (agentId === 'agent-a' ? orgId : undefined)
+    const [first, second] = await Promise.all([
+      PostgresDataPlane.open(config, orgForAgent),
+      PostgresDataPlane.open(config, orgForAgent)
+    ])
     const setup = new Pool({ connectionString: databaseUrl })
     try {
-      await setup.query(`SET search_path TO ${quotePgIdentifier(schema)}, pg_catalog`)
+      await setup.query(`SET search_path TO ${DATA_PLANE_SCHEMA}, pg_catalog`)
       await setup.query(`
-        CREATE FUNCTION delay_slow_transcript() RETURNS trigger LANGUAGE plpgsql AS $$
+        CREATE FUNCTION delay_slow_transcript_${suffix}() RETURNS trigger LANGUAGE plpgsql AS $$
         BEGIN
-          IF NEW.sender = 'slow-writer' THEN PERFORM pg_sleep(0.4); END IF;
+          IF NEW.org_id = '${orgId}' AND NEW.sender = 'slow-writer' THEN PERFORM pg_sleep(0.4); END IF;
           RETURN NEW;
         END $$;
-        CREATE TRIGGER delay_slow_transcript BEFORE INSERT ON transcript
-          FOR EACH ROW EXECUTE FUNCTION delay_slow_transcript();
+        CREATE TRIGGER delay_slow_transcript_${suffix} BEFORE INSERT ON transcript
+          FOR EACH ROW EXECUTE FUNCTION delay_slow_transcript_${suffix}();
       `)
       first.transcripts.appendTranscript({
         channel: 'C2',
@@ -102,6 +130,8 @@ describe.skipIf(!databaseUrl)('PostgreSQL transcript store', () => {
       expect(tail.rows.map((row) => row.text)).toEqual(['commits first', 'commits second'])
       expect(tail.cursor).toBe(tail.rows.at(-1)!.revision)
     } finally {
+      await setup.query(`DROP TRIGGER IF EXISTS delay_slow_transcript_${suffix} ON transcript`).catch(() => undefined)
+      await setup.query(`DROP FUNCTION IF EXISTS delay_slow_transcript_${suffix}()`).catch(() => undefined)
       await setup.end()
       await Promise.all([first.close(), second.close()])
     }

--- a/packages/daemon/test/postgres-transcript-store.test.ts
+++ b/packages/daemon/test/postgres-transcript-store.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Pool } from 'pg'
+import { PostgresTranscriptStore } from '../src/store/postgres-transcript-store.js'
+
+const noPool = {} as Pool
+
+describe('PostgreSQL transcript tenant boundary', () => {
+  it('refuses a write whose organization cannot be resolved', () => {
+    const onFailure = vi.fn()
+    const store = new PostgresTranscriptStore(noPool, () => undefined, onFailure)
+    expect(() =>
+      store.appendTranscript({
+        channel: 'C1',
+        thread: 'T1',
+        ts: '1',
+        sender: 'user',
+        recipient: 'unknown-agent',
+        kind: 'text',
+        text: 'must not be unscoped'
+      })
+    ).toThrow(/cannot resolve transcript organization/)
+    expect(onFailure).toHaveBeenCalledOnce()
+  })
+
+  it('refuses a cross-organization sender and recipient', () => {
+    const onFailure = vi.fn()
+    const store = new PostgresTranscriptStore(
+      noPool,
+      (agentId) => (agentId === 'sender' ? 'org-a' : agentId === 'recipient' ? 'org-b' : undefined),
+      onFailure
+    )
+    expect(() =>
+      store.appendTranscript({
+        channel: 'C1',
+        thread: 'T1',
+        ts: '1',
+        sender: 'sender',
+        recipient: 'recipient',
+        kind: 'text',
+        text: 'must not cross tenants'
+      })
+    ).toThrow(/different organizations/)
+    expect(onFailure).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

- use one install-wide PostgreSQL database and one shared data-plane schema for all Control Plane organizations
- scope every transcript key, index, mutation, history read, tool-body read, and revision watermark by `org_id` resolved from the CP agent registry
- remove the per-org schema field from the mounted Secret and fail closed on unresolved or cross-org transcript ownership
- keep schema upgrades install-wide and advisory-lock concurrent daemon startup

## Root cause

#925 interpreted the deployment as one configured schema per daemon, which incorrectly bound a cloud daemon to one organization. A cloud daemon pool serves all CP organizations through one shared database.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- targeted ESLint on changed daemon files
- 42 focused unit/session/k8s tests
- PostgreSQL 16 integration tests for concurrent migration, multi-daemon revision ordering, and same-key cross-org isolation
- repository pre-push `pnpm lint`