### PR TITLE
refactor(daemon): extract the pure activation policy into @agentconnect.md/activation-policy

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -232,6 +232,7 @@ jobs:
             'Unit test report' \
             'message=@agentconnect.md/message' \
             'protocol=@agentconnect.md/protocol' \
+            'activation-policy=@agentconnect.md/activation-policy' \
             'connection=@agentconnect.md/connection' \
             'control-plane=@agentconnect.md/control-plane' \
             'relay=@agentconnect.md/relay' \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN printf 'fetch-retries=5\nfetch-retry-maxtimeout=600000\nfetch-retry-mintimeo
 FROM base AS manifests
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .pnpmfile.mjs ./
 COPY scripts/ scripts/
+COPY packages/activation-policy/package.json packages/activation-policy/
 COPY packages/message/package.json packages/message/
 COPY packages/protocol/package.json packages/protocol/
 COPY packages/connection/package.json packages/connection/
@@ -169,8 +170,9 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 
 COPY . .
 
-# protocol → message / connection / observability → daemon (topological).
+# protocol → activation-policy / message / connection / observability → daemon (topological).
 RUN pnpm --filter "@agentconnect.md/protocol" \
+  --filter "@agentconnect.md/activation-policy" \
   --filter "@agentconnect.md/message" \
   --filter "@agentconnect.md/connection" \
   --filter "@agentconnect.md/observability" \

--- a/docs/designs/activation-parity.md
+++ b/docs/designs/activation-parity.md
@@ -11,10 +11,12 @@ suite** and the governance rule attached to it.
 
 "Who does this message activate" is implemented more than once:
 
-1. **The daemon platform ladder** —
-   `packages/daemon/src/router/routing-table.ts` (`routeRules`, kind precedence
-   mention > dm > keyword > auto) plus the verified agent-author ladder in
-   `packages/daemon/src/daemon.ts` (`routeVerifiedAgentMessage` /
+1. **The daemon platform ladder** — the pure decision logic now lives in
+   `@agentconnect.md/activation-policy` (`routeRules`, kind precedence
+   mention > dm > keyword > auto, the conversation-peer selection, and the
+   §4.1 hop gates), consumed through the thin adapter
+   `packages/daemon/src/router/routing-table.ts` by the verified agent-author
+   ladder in `packages/daemon/src/daemon.ts` (`routeVerifiedAgentMessage` /
    `fanOutToThreadPeers`), including the #549 rung: a verified agent-authored
    message naming nobody continues the conversation with the author excluded,
    hop-bounded.
@@ -74,8 +76,11 @@ of it is credential-free and runs in the Unit Test CI gate: `pnpm eval:parity`.
 
 The relay's arbitrate ladder has no leg yet; it is pinned by its own unit suite
 (`packages/relay/src/bot-arbitration.test.ts`) and inherits the daemon
-expectations by construction ("same rules", §6). It gains a leg when the
-single policy module lands and the relay consumes it.
+expectations by construction ("same rules", §6). The single policy module now
+exists (`@agentconnect.md/activation-policy`, consumed by the daemon); the
+relay leg lands when the relay is folded onto it — the module's header
+documents how `AttributedRoute`s and the affinity map plug into the same
+functions.
 
 ### 2.1 Declared per-surface divergences (as of this writing)
 

--- a/packages/activation-policy/package.json
+++ b/packages/activation-policy/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@agentconnect.md/activation-policy",
+  "version": "1.0.0-dev",
+  "description": "AgentConnect pure activation policy — who does this message activate — shared by every routing surface",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "prepack": "pnpm run build",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "sideEffects": false,
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@agentconnect.md/protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  },
+  "keywords": [
+    "activation",
+    "agentconnect",
+    "policy",
+    "routing"
+  ],
+  "engines": {
+    "node": ">=24.12.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/activation-policy/src/index.ts
+++ b/packages/activation-policy/src/index.ts
@@ -1,0 +1,378 @@
+/**
+ * `@agentconnect.md/activation-policy` — the PURE activation policy: "who does
+ * this message activate", extracted from the daemon's platform ladder
+ * (send-message-routing-rework.md §6/§2.3, PR #549) so every surface can
+ * eventually consume ONE implementation instead of keeping copies in sync by
+ * hand (the #549 → #904 → #906 incident; see
+ * docs/designs/activation-parity.md).
+ *
+ * Everything here is a pure function over:
+ *  - normalized MESSAGE FACTS ({@link ActivationMessageFacts} — a structural
+ *    subset of the daemon's `NormalizedMessage` and the wire
+ *    `NormalizedPlatformMessage`, so both satisfy it without adapters);
+ *  - resolved ROUTING RULES ({@link ActivationRule} — the daemon's merged
+ *    local ∪ CP rule set; structurally satisfied by the daemon's
+ *    `RoutingRule`);
+ *  - verified AUTHORSHIP facts (the author's agent id and stamped hop depth —
+ *    verification itself stays with the caller, since it needs I/O);
+ *  - narrow context PROVIDERS passed as plain values or callbacks
+ *    (`threadOwner`, thread participants), never as live objects.
+ *
+ * NO I/O, no daemon imports, no platform SDKs. The daemon's
+ * `router/routing-table.ts` re-exports the ladder and its call sites act as
+ * thin adapters supplying the providers; behavior is byte-for-byte what the
+ * daemon shipped before the extraction.
+ *
+ * How the OTHER surfaces plug in (future work, deliberately not folded yet):
+ *
+ *  - **Relay** (`packages/relay/src/bot-arbitration.ts`): an
+ *    `AttributedRoute` maps structurally onto {@link ActivationRule}
+ *    (`agentId`/`scope`/`match`, integration + daemon attribution carried in
+ *    the caller's own map), the assignment's `mutedChannels` become the rules'
+ *    `mutedChannels`, and its thread-affinity map is the `threadOwner`
+ *    provider. Its extra rungs (conversation-scoped keyword, `defaultAgentId`)
+ *    are relay-specific selection AFTER this ladder declines, exactly as
+ *    documented in shared-bot-relay.md §10.
+ *  - **Webchat** (`daemon.ts` `maybeActivateWebchatContinuation`): the roster
+ *    fan-out already chose the target, so it consumes only the edge gates —
+ *    {@link isUsableSourceDepth} and {@link hopTransition} — plus the author
+ *    exclusion those helpers assume the caller enforces absolutely.
+ */
+import { MAX_AGENT_CALL_HOPS, hasReachedAgentCallHopLimit } from '@agentconnect.md/protocol'
+
+/** A routing rule's trigger — structurally identical to the daemon's
+ *  `BindMatch` (agent.json bindRules) and the wire route match. */
+export type RuleMatch = { kind: 'mention' } | { kind: 'dm' } | { kind: 'keyword'; value: string } | { kind: 'auto' }
+
+/**
+ * One resolved routing rule of the merged (local ∪ CP) set. Structurally
+ * satisfied by the daemon's `RoutingRule` (router/routing-rule.ts), which
+ * remains the documented owner of how these are BUILT from integrations and
+ * CP frames — building rules needs config/wire knowledge this package must
+ * not have.
+ */
+export interface ActivationRule {
+  agentId: string
+  integrationId: string
+  botUserId: string // for `mention` matching ("" when unknown)
+  scope: { channel?: string; thread?: string }
+  match: RuleMatch
+  /** Channels its integration is switched OFF in — the subtractive fence a
+   *  purely additive rule set cannot express. Carried per rule so the ladder
+   *  stays pure and every rung is fenced by the one scope filter. */
+  mutedChannels?: string[]
+  source: 'config' | 'cp'
+  epoch?: number // cp layer only
+  /** Platform this rule belongs to. Undefined = matches any platform
+   *  (legacy/tests); rules built from integrations always set it. */
+  platform?: string
+}
+
+/** The message facts the policy reads — a structural subset of the daemon's
+ *  `NormalizedMessage`, so callers pass their message object directly. */
+export interface ActivationMessageFacts {
+  platform: string
+  channel: string
+  thread?: string | undefined
+  text: string
+  isDm: boolean
+  mentionedBots: string[]
+  sender: { isBot: boolean }
+}
+
+// ─── routeRules: arbitration ladder over the merged (local ∪ CP) rule set ───
+
+const KIND_ORDER = ['mention', 'dm', 'keyword', 'auto'] as const
+
+function channelInScope(scopeChannel: string | undefined, msg: ActivationMessageFacts): boolean {
+  if (scopeChannel === undefined) return true
+  return scopeChannel === msg.channel
+}
+
+function scopeMatches(r: ActivationRule, msg: ActivationMessageFacts): boolean {
+  // A platform-tagged rule only serves its own platform, so an unscoped Slack
+  // `dm`/`auto` rule can't route a Telegram message (and vice-versa). Undefined
+  // platform (legacy/tests) matches any.
+  if (r.platform !== undefined && r.platform !== msg.platform) return false
+  // A channel the operator switched OFF silences its integration outright. Applied
+  // here, in the ONE scope filter, so no rung can slip past it: not an unscoped
+  // mention default, not thread continuity (which reads the same candidate set), not
+  // a CP session placement. Threads inherit the enclosing channel's Off through the
+  // same predicate the positive scope uses.
+  if (r.mutedChannels?.some((muted) => channelInScope(muted, msg))) return false
+  if (!channelInScope(r.scope.channel, msg)) return false
+  if (r.scope.thread !== undefined && r.scope.thread !== msg.thread) return false
+  return true
+}
+
+function kindMatches(r: ActivationRule, msg: ActivationMessageFacts): boolean {
+  switch (r.match.kind) {
+    case 'mention':
+      return r.botUserId !== '' && msg.mentionedBots.includes(r.botUserId)
+    case 'dm':
+      return msg.isDm
+    case 'keyword':
+      return msg.text.toLowerCase().includes(r.match.value.toLowerCase())
+    case 'auto':
+      return true
+  }
+}
+
+/** Which ladder rung matched. `mention` is the only *explicit address* — the daemon
+ *  uses it to clear (and bypass) a `!stop` thread mute; everything else is implicit
+ *  routing and is suppressed while the session is muted. */
+export type RouteVia = 'mention' | 'thread' | 'dm' | 'keyword' | 'auto'
+
+const pickRule = (r: ActivationRule, via: RouteVia) => ({ agentId: r.agentId, integrationId: r.integrationId, via })
+
+/**
+ * Every agent this connection serves that the message's mentions actually NAME.
+ *
+ * `routeRules` returns one primary target because its callers need one; this returns the
+ * whole named set, because a mention is a JOIN and a body can name several agents. Using
+ * it removes the only place mention handling depended on which rule `find` saw first —
+ * the shape that made a shared bot resolve the same event differently.
+ */
+export function mentionedAgents(msg: ActivationMessageFacts, rules: ActivationRule[], exclude?: string): string[] {
+  if (msg.mentionedBots.length === 0) return []
+  const named = new Set<string>()
+  for (const r of rules) {
+    if (r.match.kind !== 'mention' || !scopeMatches(r, msg)) continue
+    if (r.botUserId === '' || !msg.mentionedBots.includes(r.botUserId)) continue
+    if (r.agentId !== exclude) named.add(r.agentId)
+  }
+  return [...named]
+}
+
+/** Agents this connection serves that are ALREADY in the thread, minus `exclude`. Scope
+ *  (including the Off fence) is applied here so a participant in a silenced channel is
+ *  not revived by conversation it can no longer take part in. */
+export function participantAgents(
+  msg: ActivationMessageFacts,
+  rules: ActivationRule[],
+  participants: readonly string[],
+  exclude?: string
+): string[] {
+  if (participants.length === 0) return []
+  const servable = new Set(rules.filter((r) => scopeMatches(r, msg)).map((r) => r.agentId))
+  return participants.filter((id) => id !== exclude && servable.has(id))
+}
+
+/** Agents whose `auto` rule makes them participants in every conversation covered by
+ * that rule. Unlike `routeRules`, this returns the whole set: channel-wide participation
+ * is not an arbitration tie that should collapse to whichever rule happens to be first. */
+export function automaticAgents(msg: ActivationMessageFacts, rules: ActivationRule[], exclude?: string): string[] {
+  return [
+    ...new Set(
+      rules
+        .filter((r) => r.match.kind === 'auto' && scopeMatches(r, msg) && r.agentId !== exclude)
+        .map((r) => r.agentId)
+    )
+  ]
+}
+
+/**
+ * Arbitrate the merged (local ∪ CP) rule set for an inbound message (design §8.2/§8.3).
+ * Ladder: (1) explicit @bot mention (cross-layer; overrides thread affinity) →
+ * (2) thread affinity (highest after explicit @; bypasses the kind filter, gated on
+ * reachable-bot count) → (3) CP per-sessionKey override → (4/5) kind precedence
+ * mention > dm > keyword > auto within the chosen layer.
+ *
+ * `explicitAgentId` short-circuits the whole ladder: a relay webchat turn names its
+ * target agent in the `rd/msg` payload, so there is nothing to arbitrate — it routes
+ * directly to that agent (integrationId '' because webchat ingress arrives over the
+ * relay data plane rather than a platform integration). Null if that agentId isn't a
+ * servable rule here.
+ *
+ * `verifiedAgentAuthor` opens the implicit rungs to an AgentConnect-authored message
+ * (send-message-routing-rework.md §2.3): the message routes through THIS ladder exactly
+ * as a human's would, with the author removed from the candidate set so it can never
+ * wake itself. Set only after the caller has VERIFIED authorship — an unverified bot,
+ * including a third-party one, still stops at the explicit-mention rung below.
+ */
+export function routeRules(
+  msg: ActivationMessageFacts,
+  rules: ActivationRule[],
+  threadOwner: (channel: string, thread: string) => string | null,
+  explicitAgentId?: string,
+  verifiedAgentAuthor?: string
+): { agentId: string; integrationId: string; via: RouteVia } | null {
+  if (explicitAgentId !== undefined) {
+    // Direct address (webchat): the message names its agent, so bypass mention/thread/
+    // keyword/auto arbitration entirely. No Slack integration is involved.
+    return { agentId: explicitAgentId, integrationId: '', via: 'mention' }
+  }
+  // Scope candidates are KIND-AGNOSTIC (used for reachability + thread continuity).
+  // A verified agent author is removed here, once, so EVERY rung below inherits the
+  // exclusion — an agent that could match its own rule would wake itself on its own
+  // reply, which is an unconditional self-loop rather than a conversation.
+  const scopeCandidates = rules.filter(
+    (r) => scopeMatches(r, msg) && (verifiedAgentAuthor === undefined || r.agentId !== verifiedAgentAuthor)
+  )
+  // kind-candidates: also match the message kind.
+  const kindCandidates = scopeCandidates.filter((r) => kindMatches(r, msg))
+
+  // 1. explicit @bot mention — across layers; overrides thread affinity (§8.3).
+  const mention = kindCandidates.find((r) => r.match.kind === 'mention')
+  // A third-party Slack bot may explicitly address an agent. Bot-authored traffic
+  // never falls through to DM/thread/keyword/auto; AgentConnect-managed bot apps are
+  // removed by the daemon before this pure routing boundary.
+  //
+  // A mention JOINS an agent to this thread — it does not pick between agents. The
+  // difference matters on a bot serving several agent routes: `mentionedAgents`
+  // returns every rule the body actually named, so nothing depends on which one `find`
+  // happened to see first, and everyone already in the thread receives the message
+  // regardless (`threadParticipants`).
+  if (mention && verifiedAgentAuthor === undefined && (!msg.sender.isBot || msg.platform === 'slack')) {
+    return pickRule(mention, 'mention')
+  }
+  // A VERIFIED AgentConnect author continues into the implicit rungs; every other bot
+  // still stops here. That difference is the whole of §2.3: we know exactly which agent
+  // wrote this and have already checked its policy, so it is treated as a participant
+  // rather than as anonymous bot traffic.
+  if (msg.sender.isBot && verifiedAgentAuthor === undefined) return null
+  // An unmatched mention in a channel belongs to another bot (or a human). Do not let
+  // local thread affinity claim it: dedicated Slack apps each see the channel event,
+  // and every daemon otherwise believes its own agent is the sole local thread owner.
+  // A one-to-one DM is already addressed to this bot, though, so mentioning the bot (or
+  // another participant) must not suppress its dm rule. Group DMs are channel-like and
+  // normalize with isDm=false, so they remain mention-gated here.
+  //
+  // A VERIFIED agent author is exempt: its peers are meant to see what it said and judge
+  // for themselves whether to answer, so a `<@…>` aimed at anyone — a human, another app,
+  // a peer whose token this directory cannot resolve — must not silence the conversation.
+  // Unverified traffic keeps the old rule, because for it an unresolved mention really is
+  // "addressed to someone else".
+  if (!msg.isDm && msg.mentionedBots.length > 0 && verifiedAgentAuthor === undefined) return null
+
+  // 2. thread affinity (§8.2 step 2 — highest after explicit @; bypasses kind filter).
+  if (msg.thread) {
+    const owner = threadOwner(msg.channel, msg.thread)
+    if (owner) {
+      // threadOwner returns the sole agent with an OPEN session in this thread, and
+      // null when 2+ agents actively share it (→ mention-gated via fallthrough). Thread
+      // PARTICIPATION, not channel reachability, is the disambiguator (§8.5): route an
+      // un-mentioned follow-up to that owner if it's reachable here, regardless of how
+      // many other bots are also bound to the channel.
+      const ownerRule = scopeCandidates.find((x) => x.agentId === owner)
+      if (ownerRule) return pickRule(ownerRule, 'thread') // continuity, kind-agnostic
+    }
+  }
+
+  // 3. CP per-sessionKey override (§8.3: CP authoritative).
+  // A rule scoped to the channel this message sits in (its enclosing channel counts —
+  // same predicate as the scope filter), NOT an unscoped global CP rule.
+  const cpInChannel = kindCandidates.some(
+    (r) =>
+      r.source === 'cp' &&
+      r.scope.channel !== undefined &&
+      channelInScope(r.scope.channel, msg) &&
+      (r.scope.thread === undefined || r.scope.thread === msg.thread)
+  )
+  const layer = cpInChannel ? kindCandidates.filter((r) => r.source === 'cp') : kindCandidates
+
+  // 4/5. kind precedence within the chosen layer (mention already handled).
+  for (const kind of KIND_ORDER) {
+    if (kind === 'mention') continue
+    const r = layer.find((x) => x.match.kind === kind)
+    if (r) return pickRule(r, kind)
+  }
+  return null
+}
+
+// ─── conversation-delivery selection and verified-agent edge gates ───
+
+/**
+ * Does this conversation admit an activation for `agentId` at all?
+ *
+ * The per-channel trigger is an operator fence, not a routing preference: "Off means the
+ * agent does not respond in that channel at all. Not to an @-mention, not to a follow-up
+ * in a thread it had already joined, not to a control command" (product-conventions).
+ * The human ladder gets this from `routeRules`' scope filter, which the verified-agent
+ * ladder deliberately bypasses — so the fence is re-applied through this predicate
+ * rather than inherited.
+ *
+ * Implemented as "some rule for this agent covers this channel and none mutes it",
+ * which is the same data `routeRules` consults, minus the kind/trigger matching that
+ * would be wrong here (an agent mention is explicit by construction).
+ */
+export function conversationAdmitsAgent(rules: readonly ActivationRule[], agentId: string, channel: string): boolean {
+  const agentRules = rules.filter((rule) => rule.agentId === agentId)
+  if (agentRules.length === 0) return false
+  const covers = (scopeChannel: string | undefined): boolean => scopeChannel === undefined || scopeChannel === channel
+  if (agentRules.some((rule) => rule.mutedChannels?.some((muted) => covers(muted)))) return false
+  return agentRules.some((rule) => covers(rule.scope.channel))
+}
+
+/** Is a stamped source depth usable at all? §4.1 rule 1 / §5.2a fail-closed: a
+ *  missing, non-integer, or negative depth must never coerce to zero — the
+ *  message stays transcript-only instead. */
+export function isUsableSourceDepth(value: number | undefined): value is number {
+  return value !== undefined && Number.isInteger(value) && value >= 0
+}
+
+/**
+ * The §4.1 trusted hop transition: ONE +1 per agent-to-agent delivery, against
+ * the SAME `MAX_AGENT_CALL_HOPS` cap an internal call spends — so a mention
+ * chain, a `messageAgent` chain, and a webchat continuation all consume the
+ * one budget at the same rate. `refusal` is set when the edge must not run;
+ * the caller records the message transcript-only and logs the refusal.
+ */
+export function hopTransition(sourceHopCount: number): {
+  deliveryHopCount: number
+  refusal?: { reason: 'hop_limit'; cap: number }
+} {
+  const deliveryHopCount = sourceHopCount + 1
+  if (hasReachedAgentCallHopLimit(deliveryHopCount)) {
+    return { deliveryHopCount, refusal: { reason: 'hop_limit', cap: MAX_AGENT_CALL_HOPS } }
+  }
+  return { deliveryHopCount }
+}
+
+/**
+ * Everyone a conversation event is DELIVERED to beyond the arbitration
+ * primary (send-message-routing-rework.md §2.3/§6): agents already in the
+ * thread, every agent the body explicitly names, the verified final's exact
+ * recipient joins, and channel-`auto` agents — author and primary excluded.
+ *
+ * Pure selection only: each returned peer is still an INDEPENDENT delivery
+ * whose edge gates (call policy, Off fence, `!stop` mute, hop budget,
+ * exactly-once rendezvous) the caller applies per target. Insertion order is
+ * part of the contract — participants, then explicit joins, then automatic —
+ * because callers dispatch in iteration order.
+ */
+export function conversationPeers(
+  msg: ActivationMessageFacts,
+  rules: ActivationRule[],
+  /** Agents with an open session in this thread (the caller's session state). */
+  participants: readonly string[],
+  options: {
+    /** The arbitration primary, excluded from the peer set. */
+    primaryAgentId?: string | undefined
+    /** Verified agent authorship: the author is excluded absolutely, and the
+     *  final's exact resolved recipients JOIN even where provider bot-user
+     *  metadata alone cannot map the mention back to an agent. */
+    verified?: { authorAgentId: string; recipients: readonly string[] } | undefined
+  } = {}
+): { peers: string[]; explicitlyMentioned: ReadonlySet<string> } {
+  const explicitlyMentioned = new Set(mentionedAgents(msg, rules, options.primaryAgentId))
+  // A verified final carries the exact agent ids resolved before provider
+  // splitting/echo. They are joins, not the complete delivery set: include them
+  // so a shared-bot peer with an unscoped slug route can enter the room even when
+  // provider bot-user metadata alone cannot map the mention back to that agent.
+  if (options.verified) {
+    for (const agentId of options.verified.recipients) {
+      if (agentId !== options.primaryAgentId && agentId !== options.verified.authorAgentId) {
+        explicitlyMentioned.add(agentId)
+      }
+    }
+  }
+  const peers = new Set([
+    ...participantAgents(msg, rules, participants, options.primaryAgentId),
+    ...explicitlyMentioned,
+    ...automaticAgents(msg, rules, options.primaryAgentId)
+  ])
+  if (options.primaryAgentId !== undefined) peers.delete(options.primaryAgentId)
+  if (options.verified) peers.delete(options.verified.authorAgentId)
+  return { peers: [...peers], explicitlyMentioned }
+}

--- a/packages/activation-policy/test/policy.test.ts
+++ b/packages/activation-policy/test/policy.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
+import {
+  conversationAdmitsAgent,
+  conversationPeers,
+  hopTransition,
+  isUsableSourceDepth,
+  routeRules,
+  type ActivationMessageFacts,
+  type ActivationRule
+} from '../src/index.js'
+
+// The deep ladder behavior is pinned where it always was — the daemon's
+// router suites (route-rules/router/telegram-threading, consuming this
+// package through the routing-table adapter) and the cross-surface parity
+// suite (evals/parity). These tests cover the package's own contract: the
+// composed selectors and gates the daemon call sites now delegate to.
+
+const msg = (over: Partial<ActivationMessageFacts> = {}): ActivationMessageFacts => ({
+  platform: 'slack',
+  channel: 'C1',
+  text: 'hello',
+  isDm: false,
+  mentionedBots: [],
+  sender: { isBot: false },
+  ...over
+})
+
+const rule = (over: Partial<ActivationRule> = {}): ActivationRule => ({
+  agentId: 'a1',
+  integrationId: 'i1',
+  botUserId: 'U1',
+  scope: {},
+  match: { kind: 'mention' },
+  source: 'config',
+  ...over
+})
+
+describe('routeRules (ladder smoke — deep coverage lives in the daemon suites)', () => {
+  it('kind precedence: mention > dm > keyword > auto', () => {
+    const rules = [
+      rule({ agentId: 'auto', match: { kind: 'auto' } }),
+      rule({ agentId: 'kw', match: { kind: 'keyword', value: 'deploy' } }),
+      rule({ agentId: 'named', match: { kind: 'mention' }, botUserId: 'U9' })
+    ]
+    expect(routeRules(msg({ mentionedBots: ['U9'], text: 'deploy <@U9>' }), rules, () => null)).toMatchObject({
+      agentId: 'named',
+      via: 'mention'
+    })
+    expect(routeRules(msg({ text: 'please deploy now' }), rules, () => null)).toMatchObject({
+      agentId: 'kw',
+      via: 'keyword'
+    })
+    expect(routeRules(msg(), rules, () => null)).toMatchObject({ agentId: 'auto', via: 'auto' })
+  })
+
+  it('excludes a verified agent author from every rung', () => {
+    const rules = [
+      rule({ agentId: 'author', match: { kind: 'auto' } }),
+      rule({ agentId: 'peer', match: { kind: 'auto' } })
+    ]
+    const routed = routeRules(msg({ sender: { isBot: true } }), rules, () => null, undefined, 'author')
+    expect(routed).toMatchObject({ agentId: 'peer' })
+  })
+
+  it('unverified bot traffic stops after the explicit-mention rung', () => {
+    const rules = [rule({ agentId: 'a1', match: { kind: 'auto' } })]
+    expect(routeRules(msg({ sender: { isBot: true } }), rules, () => null)).toBeNull()
+  })
+})
+
+describe('conversationAdmitsAgent (the Off/gated fence predicate)', () => {
+  const rules = [
+    rule({ agentId: 'a1', scope: { channel: 'C1' } }),
+    rule({ agentId: 'a2', mutedChannels: ['C1'] }),
+    rule({ agentId: 'a3', scope: { channel: 'C2' } })
+  ]
+  it('admits an agent whose rule covers the channel', () => {
+    expect(conversationAdmitsAgent(rules, 'a1', 'C1')).toBe(true)
+  })
+  it('refuses a muted channel outright', () => {
+    expect(conversationAdmitsAgent(rules, 'a2', 'C1')).toBe(false)
+  })
+  it('refuses a channel no rule covers, and an unknown agent', () => {
+    expect(conversationAdmitsAgent(rules, 'a3', 'C1')).toBe(false)
+    expect(conversationAdmitsAgent(rules, 'missing', 'C1')).toBe(false)
+  })
+})
+
+describe('hop gates (§4.1)', () => {
+  it('isUsableSourceDepth fails closed on missing / non-integer / negative depths', () => {
+    expect(isUsableSourceDepth(undefined)).toBe(false)
+    expect(isUsableSourceDepth(-1)).toBe(false)
+    expect(isUsableSourceDepth(0.5)).toBe(false)
+    expect(isUsableSourceDepth(0)).toBe(true)
+    expect(isUsableSourceDepth(MAX_AGENT_CALL_HOPS)).toBe(true) // usable; the TRANSITION refuses it
+  })
+
+  it('hopTransition charges exactly +1 and refuses at the shared cap', () => {
+    expect(hopTransition(0)).toEqual({ deliveryHopCount: 1 })
+    expect(hopTransition(MAX_AGENT_CALL_HOPS - 2)).toEqual({ deliveryHopCount: MAX_AGENT_CALL_HOPS - 1 })
+    expect(hopTransition(MAX_AGENT_CALL_HOPS - 1)).toEqual({
+      deliveryHopCount: MAX_AGENT_CALL_HOPS,
+      refusal: { reason: 'hop_limit', cap: MAX_AGENT_CALL_HOPS }
+    })
+  })
+})
+
+describe('conversationPeers (§2.3/§6 delivery selection)', () => {
+  const rules = [
+    rule({ agentId: 'p1' }),
+    rule({ agentId: 'p2' }),
+    rule({ agentId: 'named', botUserId: 'U9' }),
+    rule({ agentId: 'auto', match: { kind: 'auto' } }),
+    rule({ agentId: 'author', match: { kind: 'auto' } })
+  ]
+
+  it('unions participants, explicit joins, and channel-auto — in that insertion order', () => {
+    const { peers, explicitlyMentioned } = conversationPeers(
+      msg({ thread: 't1', mentionedBots: ['U9'] }),
+      rules,
+      ['p1', 'p2'],
+      {}
+    )
+    expect(peers).toEqual(['p1', 'p2', 'named', 'auto', 'author'])
+    expect([...explicitlyMentioned]).toEqual(['named'])
+  })
+
+  it('excludes the primary everywhere', () => {
+    const { peers } = conversationPeers(msg({ thread: 't1', mentionedBots: ['U9'] }), rules, ['p1', 'p2'], {
+      primaryAgentId: 'p1'
+    })
+    expect(peers).toEqual(['p2', 'named', 'auto', 'author'])
+  })
+
+  it('a verified agent call joins the exact resolved recipients and excludes the author absolutely', () => {
+    const { peers, explicitlyMentioned } = conversationPeers(msg({ thread: 't1' }), rules, ['p1', 'author'], {
+      verified: { authorAgentId: 'author', recipients: ['p2', 'author'] }
+    })
+    // p2 joined via the verified recipient set even with no provider mention;
+    // the author never appears, not even via its own recipients entry.
+    expect(peers).toEqual(['p1', 'p2', 'auto'])
+    expect(explicitlyMentioned.has('p2')).toBe(true)
+    expect(peers).not.toContain('author')
+  })
+
+  it('an unserved participant (no rule in scope) is not revived', () => {
+    const { peers } = conversationPeers(
+      msg({ channel: 'C1', thread: 't1' }),
+      [rule({ agentId: 'p1' })],
+      ['p1', 'ghost'],
+      {}
+    )
+    expect(peers).toEqual(['p1'])
+  })
+})

--- a/packages/activation-policy/tsconfig.json
+++ b/packages/activation-policy/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/packages/activation-policy/vitest.config.ts
+++ b/packages/activation-policy/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import { githubActionsReporters } from '../../scripts/vitest-github-reporters.js'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    reporters: githubActionsReporters('activation-policy.md')
+  }
+})

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.3.0",
+    "@agentconnect.md/activation-policy": "workspace:*",
     "@agentconnect.md/connection": "workspace:*",
     "@agentconnect.md/k8s-client": "workspace:*",
     "@agentconnect.md/message": "workspace:*",

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -120,9 +120,10 @@ import {
 import { createDreamReader } from './cp/dream-reader.js'
 import { createLocalSkillsReader } from './cp/local-skills-reader.js'
 import {
-  automaticAgents,
-  mentionedAgents,
-  participantAgents,
+  conversationAdmitsAgent,
+  conversationPeers,
+  hopTransition,
+  isUsableSourceDepth,
   routeRules,
   type RouteVia
 } from './router/routing-table.js'
@@ -6492,7 +6493,7 @@ export class Daemon {
     if (msg.sender.appId !== undefined && placement.botAppId !== undefined && placement.botAppId !== msg.sender.appId) {
       return null
     }
-    if (!Number.isInteger(claim.hopCount) || claim.hopCount < 0) return null
+    if (!isUsableSourceDepth(claim.hopCount)) return null
     return {
       authorAgentId: claim.authorAgentId,
       orgId,
@@ -6532,12 +6533,14 @@ export class Daemon {
       return { kind: 'rejected', reason: 'unrouted' }
     }
     // §4.1: ONE transition per agent-to-agent delivery, against the SAME cap as an
-    // internal call. Computed once here and installed on the admitted turn, so a mention
-    // chain and a `messageAgent` chain consume the same budget at the same rate.
-    const deliveryHopCount = verified.sourceHopCount + 1
-    if (hasReachedAgentCallHopLimit(deliveryHopCount)) {
-      return transcriptOnly(`hop_limit: source depth ${verified.sourceHopCount} + 1 reaches ${MAX_AGENT_CALL_HOPS}`)
+    // internal call (policy `hopTransition`). Computed once here and installed on the
+    // admitted turn, so a mention chain and a `messageAgent` chain consume the same
+    // budget at the same rate.
+    const transition = hopTransition(verified.sourceHopCount)
+    if (transition.refusal) {
+      return transcriptOnly(`hop_limit: source depth ${verified.sourceHopCount} + 1 reaches ${transition.refusal.cap}`)
     }
+    const deliveryHopCount = transition.deliveryHopCount
     // The VISIBLE half of a paired `toAgent + channel` send is the one case whose target
     // is structured rather than parsed: `sendMessage` named the agent id outright, and the
     // rendezvous only converges if both halves name the SAME target. Route it to exactly
@@ -6663,12 +6666,7 @@ export class Daemon {
   }
 
   private agentConversationAdmits(agentId: string, msg: NormalizedMessage): boolean {
-    const rules = this.mergedRules().filter((rule) => rule.agentId === agentId)
-    if (rules.length === 0) return false
-    const covers = (scopeChannel: string | undefined): boolean =>
-      scopeChannel === undefined || scopeChannel === msg.channel
-    if (rules.some((rule) => rule.mutedChannels?.some((muted) => covers(muted)))) return false
-    return rules.some((rule) => covers(rule.scope.channel))
+    return conversationAdmitsAgent(this.mergedRules(), agentId, msg.channel)
   }
 
   /**
@@ -7055,23 +7053,16 @@ export class Daemon {
   ): Array<{ kind: 'rejected'; reason: DeliveryRejectionReason } | { kind: 'dispatched'; handle: DeliveryHandle }> {
     const thread = msg.thread
     const participants = thread ? this.sessions.threadParticipants(msg.channel, thread, msg.transportScope) : []
-    const explicitlyMentioned = new Set(mentionedAgents(msg, rules, primaryAgentId))
-    // A verified final carries the exact agent ids resolved before provider
-    // splitting/echo. They are joins, not the complete delivery set: include them
-    // so a shared-bot peer with an unscoped slug route can enter the room even when
-    // provider bot-user metadata alone cannot map the mention back to that agent.
-    if (agentCall) {
-      for (const agentId of agentCall.verified.recipients) {
-        if (agentId !== primaryAgentId && agentId !== agentCall.verified.authorAgentId) {
-          explicitlyMentioned.add(agentId)
-        }
-      }
-    }
-    const peers = new Set([
-      ...participantAgents(msg, rules, participants, primaryAgentId),
-      ...explicitlyMentioned,
-      ...automaticAgents(msg, rules, primaryAgentId)
-    ])
+    // Pure selection (policy `conversationPeers`): participants ∪ explicit joins
+    // (including the verified final's exact recipient joins) ∪ channel-auto,
+    // minus primary and (for agent calls) the author. Every edge gate below —
+    // policy, Off, mute, hop, rendezvous — remains per-target in this loop.
+    const { peers, explicitlyMentioned } = conversationPeers(msg, rules, participants, {
+      primaryAgentId,
+      verified: agentCall
+        ? { authorAgentId: agentCall.verified.authorAgentId, recipients: agentCall.verified.recipients }
+        : undefined
+    })
     const outcomes: Array<
       { kind: 'rejected'; reason: DeliveryRejectionReason } | { kind: 'dispatched'; handle: DeliveryHandle }
     > = []
@@ -11085,22 +11076,24 @@ export class Daemon {
     const authorAgentId = contextPost.author.agentId
     if (authorAgentId === targetAgentId) return // author-never-self-activates, the one absolute
     const sourceHopCount = contextPost.author.hopCount
-    if (sourceHopCount === undefined || !Number.isInteger(sourceHopCount) || sourceHopCount < 0) {
+    if (!isUsableSourceDepth(sourceHopCount)) {
       this.log.debug(
         `webchat: peer post ${contextPost.postId} carries no usable depth — transcript-only (pre-parity author daemon)`
       )
       return
     }
-    // §4.1: ONE transition per delivery, against the same cap as an internal call.
-    const deliveryHopCount = sourceHopCount + 1
-    if (hasReachedAgentCallHopLimit(deliveryHopCount)) {
+    // §4.1: ONE transition per delivery, against the same cap as an internal call —
+    // the same policy `hopTransition` the platform ladder charges.
+    const transition = hopTransition(sourceHopCount)
+    if (transition.refusal) {
       this.log.info(
         `webchat: continuation refused for "${targetAgentId}" in conversation ${chatId} ` +
-          `(hop_limit: source depth ${sourceHopCount} + 1 reaches ${MAX_AGENT_CALL_HOPS}); ` +
+          `(hop_limit: source depth ${sourceHopCount} + 1 reaches ${transition.refusal.cap}); ` +
           `peer post ${contextPost.postId} stays transcript-only`
       )
       return
     }
+    const deliveryHopCount = transition.deliveryHopCount
     if (!this.agents.has(targetAgentId) || this.drainingAgents.has(targetAgentId)) return
     if (!this.cpCollab.admits(authorAgentId, targetAgentId)) {
       this.log.debug(`webchat: agent edge ${authorAgentId} → ${targetAgentId} denied by call policy`)

--- a/packages/daemon/src/router/routing-rule.ts
+++ b/packages/daemon/src/router/routing-rule.ts
@@ -9,27 +9,20 @@
  */
 import type { Agent, BindMatch, BindRuleConfig, Integration } from '../agents/agent-schema.js'
 import { configuredBotSelfId, integrationCore } from '../platforms/integration-config.js'
+import type { ActivationRule } from '@agentconnect.md/activation-policy'
 import type { RouteAssign, RouteUpdate } from '@agentconnect.md/protocol'
 
 export type RoutingMatch = BindMatch
 
-export interface RoutingRule {
-  agentId: string
-  integrationId: string
-  botUserId: string // for `mention` matching ("" when unknown)
-  scope: { channel?: string; thread?: string }
+/**
+ * The daemon's resolved routing rule — the policy package's `ActivationRule`
+ * (field docs live there) with the daemon's own `BindMatch` as the match
+ * vocabulary. `extends` is the compile-time guarantee that what this module
+ * BUILDS stays consumable by the pure ladder without adaptation; if either
+ * shape drifts, this declaration breaks instead of the routing behavior.
+ */
+export interface RoutingRule extends ActivationRule {
   match: RoutingMatch
-  // Channels its integration is switched OFF in — the subtractive fence a purely
-  // additive rule set cannot express. Carried per rule (rather than consulted
-  // separately) so `routeRules` stays pure and every rung — mention, thread
-  // continuity, CP override, keyword, auto — is fenced by the one scope filter.
-  mutedChannels?: string[]
-  source: 'config' | 'cp'
-  epoch?: number // cp layer only
-  // Platform this rule belongs to ('slack' | 'telegram'). Undefined = matches any
-  // platform (legacy/tests); rules built from integrations always set it, so a
-  // Slack `dm`/`auto` rule can't route a Telegram message and vice-versa.
-  platform?: string
 }
 
 /**

--- a/packages/daemon/src/router/routing-table.ts
+++ b/packages/daemon/src/router/routing-table.ts
@@ -1,202 +1,32 @@
-import type { NormalizedMessage } from '../messages/normalized.js'
-import type { RoutingRule } from './routing-rule.js'
-
-// ─── routeRules: arbitration ladder over the merged (local ∪ CP) rule set ───
-
-const KIND_ORDER = ['mention', 'dm', 'keyword', 'auto'] as const
-
-function channelInScope(scopeChannel: string | undefined, msg: NormalizedMessage): boolean {
-  if (scopeChannel === undefined) return true
-  return scopeChannel === msg.channel
-}
-
-function scopeMatches(r: RoutingRule, msg: NormalizedMessage): boolean {
-  // A platform-tagged rule only serves its own platform, so an unscoped Slack
-  // `dm`/`auto` rule can't route a Telegram message (and vice-versa). Undefined
-  // platform (legacy/tests) matches any.
-  if (r.platform !== undefined && r.platform !== msg.platform) return false
-  // A channel the operator switched OFF silences its integration outright. Applied
-  // here, in the ONE scope filter, so no rung can slip past it: not an unscoped
-  // mention default, not thread continuity (which reads the same candidate set), not
-  // a CP session placement. Threads inherit the enclosing channel's Off through the
-  // same predicate the positive scope uses.
-  if (r.mutedChannels?.some((muted) => channelInScope(muted, msg))) return false
-  if (!channelInScope(r.scope.channel, msg)) return false
-  if (r.scope.thread !== undefined && r.scope.thread !== msg.thread) return false
-  return true
-}
-
-function kindMatches(r: RoutingRule, msg: NormalizedMessage): boolean {
-  switch (r.match.kind) {
-    case 'mention':
-      return r.botUserId !== '' && msg.mentionedBots.includes(r.botUserId)
-    case 'dm':
-      return msg.isDm
-    case 'keyword':
-      return msg.text.toLowerCase().includes(r.match.value.toLowerCase())
-    case 'auto':
-      return true
-  }
-}
-
-/** Which ladder rung matched. `mention` is the only *explicit address* — the daemon
- *  uses it to clear (and bypass) a `!stop` thread mute; everything else is implicit
- *  routing and is suppressed while the session is muted. */
-export type RouteVia = 'mention' | 'thread' | 'dm' | 'keyword' | 'auto'
-
-const pickRule = (r: RoutingRule, via: RouteVia) => ({ agentId: r.agentId, integrationId: r.integrationId, via })
-
 /**
- * Arbitrate the merged (local ∪ CP) rule set for an inbound message (design §8.2/§8.3).
- * Ladder: (1) explicit @bot mention (cross-layer; overrides thread affinity) →
- * (2) thread affinity (highest after explicit @; bypasses the kind filter, gated on
- * reachable-bot count) → (3) CP per-sessionKey override → (4/5) kind precedence
- * mention > dm > keyword > auto within the chosen layer.
+ * The daemon's routing-ladder surface — since the activation-policy extraction
+ * a thin adapter over `@agentconnect.md/activation-policy`, which owns the
+ * PURE decision logic ("who does this message activate"): the arbitration
+ * ladder (`routeRules`), the set selectors (`mentionedAgents`,
+ * `participantAgents`, `automaticAgents`, `conversationPeers`), the
+ * conversation Off/gated fence predicate, and the §4.1 hop-transition gates.
  *
- * `explicitAgentId` short-circuits the whole ladder: a relay webchat turn names its
- * target agent in the `rd/msg` payload, so there is nothing to arbitrate — it routes
- * directly to that agent (integrationId '' because webchat ingress arrives over the
- * relay data plane rather than a platform integration). Null if that agentId isn't a
- * servable rule here.
+ * The daemon stays the owner of everything that is NOT pure decision: building
+ * `RoutingRule`s from integrations and CP frames (routing-rule.ts), session
+ * state (the `threadOwner` / participants providers), authorship VERIFICATION,
+ * mute latches, the durable activation rendezvous, and dispatch. Those call
+ * sites pass their facts and providers into the policy functions.
  *
- * `verifiedAgentAuthor` opens the implicit rungs to an AgentConnect-authored message
- * (send-message-routing-rework.md §2.3): the message routes through THIS ladder exactly
- * as a human's would, with the author removed from the candidate set so it can never
- * wake itself. Set only after the caller has VERIFIED authorship — an unverified bot,
- * including a third-party one, still stops at the explicit-mention rung below.
+ * `NormalizedMessage` structurally satisfies the policy package's
+ * `ActivationMessageFacts`, and `RoutingRule` extends its `ActivationRule`
+ * (routing-rule.ts), so no adaptation happens at the call sites — this module
+ * exists to keep the daemon-side import path and to document the boundary.
  */
-/**
- * Every agent this connection serves that the message's mentions actually NAME.
- *
- * `routeRules` returns one primary target because its callers need one; this returns the
- * whole named set, because a mention is a JOIN and a body can name several agents. Using
- * it removes the only place mention handling depended on which rule `find` saw first —
- * the shape that made a shared bot resolve the same event differently.
- */
-export function mentionedAgents(msg: NormalizedMessage, rules: RoutingRule[], exclude?: string): string[] {
-  if (msg.mentionedBots.length === 0) return []
-  const named = new Set<string>()
-  for (const r of rules) {
-    if (r.match.kind !== 'mention' || !scopeMatches(r, msg)) continue
-    if (r.botUserId === '' || !msg.mentionedBots.includes(r.botUserId)) continue
-    if (r.agentId !== exclude) named.add(r.agentId)
-  }
-  return [...named]
-}
-
-/** Agents this connection serves that are ALREADY in the thread, minus `exclude`. Scope
- *  (including the Off fence) is applied here so a participant in a silenced channel is
- *  not revived by conversation it can no longer take part in. */
-export function participantAgents(
-  msg: NormalizedMessage,
-  rules: RoutingRule[],
-  participants: readonly string[],
-  exclude?: string
-): string[] {
-  if (participants.length === 0) return []
-  const servable = new Set(rules.filter((r) => scopeMatches(r, msg)).map((r) => r.agentId))
-  return participants.filter((id) => id !== exclude && servable.has(id))
-}
-
-/** Agents whose `auto` rule makes them participants in every conversation covered by
- * that rule. Unlike `routeRules`, this returns the whole set: channel-wide participation
- * is not an arbitration tie that should collapse to whichever rule happens to be first. */
-export function automaticAgents(msg: NormalizedMessage, rules: RoutingRule[], exclude?: string): string[] {
-  return [
-    ...new Set(
-      rules
-        .filter((r) => r.match.kind === 'auto' && scopeMatches(r, msg) && r.agentId !== exclude)
-        .map((r) => r.agentId)
-    )
-  ]
-}
-
-export function routeRules(
-  msg: NormalizedMessage,
-  rules: RoutingRule[],
-  threadOwner: (channel: string, thread: string) => string | null,
-  explicitAgentId?: string,
-  verifiedAgentAuthor?: string
-): { agentId: string; integrationId: string; via: RouteVia } | null {
-  if (explicitAgentId !== undefined) {
-    // Direct address (webchat): the message names its agent, so bypass mention/thread/
-    // keyword/auto arbitration entirely. No Slack integration is involved.
-    return { agentId: explicitAgentId, integrationId: '', via: 'mention' }
-  }
-  // Scope candidates are KIND-AGNOSTIC (used for reachability + thread continuity).
-  // A verified agent author is removed here, once, so EVERY rung below inherits the
-  // exclusion — an agent that could match its own rule would wake itself on its own
-  // reply, which is an unconditional self-loop rather than a conversation.
-  const scopeCandidates = rules.filter(
-    (r) => scopeMatches(r, msg) && (verifiedAgentAuthor === undefined || r.agentId !== verifiedAgentAuthor)
-  )
-  // kind-candidates: also match the message kind.
-  const kindCandidates = scopeCandidates.filter((r) => kindMatches(r, msg))
-
-  // 1. explicit @bot mention — across layers; overrides thread affinity (§8.3).
-  const mention = kindCandidates.find((r) => r.match.kind === 'mention')
-  // A third-party Slack bot may explicitly address an agent. Bot-authored traffic
-  // never falls through to DM/thread/keyword/auto; AgentConnect-managed bot apps are
-  // removed by the daemon before this pure routing boundary.
-  //
-  // A mention JOINS an agent to this thread — it does not pick between agents. The
-  // difference matters on a bot serving several agent routes: `mentionedAgents` below
-  // returns every rule the body actually named, so nothing depends on which one `find`
-  // happened to see first, and everyone already in the thread receives the message
-  // regardless (`threadParticipants`).
-  if (mention && verifiedAgentAuthor === undefined && (!msg.sender.isBot || msg.platform === 'slack')) {
-    return pickRule(mention, 'mention')
-  }
-  // A VERIFIED AgentConnect author continues into the implicit rungs; every other bot
-  // still stops here. That difference is the whole of §2.3: we know exactly which agent
-  // wrote this and have already checked its policy, so it is treated as a participant
-  // rather than as anonymous bot traffic.
-  if (msg.sender.isBot && verifiedAgentAuthor === undefined) return null
-  // An unmatched mention in a channel belongs to another bot (or a human). Do not let
-  // local thread affinity claim it: dedicated Slack apps each see the channel event,
-  // and every daemon otherwise believes its own agent is the sole local thread owner.
-  // A one-to-one DM is already addressed to this bot, though, so mentioning the bot (or
-  // another participant) must not suppress its dm rule. Group DMs are channel-like and
-  // normalize with isDm=false, so they remain mention-gated here.
-  //
-  // A VERIFIED agent author is exempt: its peers are meant to see what it said and judge
-  // for themselves whether to answer, so a `<@…>` aimed at anyone — a human, another app,
-  // a peer whose token this directory cannot resolve — must not silence the conversation.
-  // Unverified traffic keeps the old rule, because for it an unresolved mention really is
-  // "addressed to someone else".
-  if (!msg.isDm && msg.mentionedBots.length > 0 && verifiedAgentAuthor === undefined) return null
-
-  // 2. thread affinity (§8.2 step 2 — highest after explicit @; bypasses kind filter).
-  if (msg.thread) {
-    const owner = threadOwner(msg.channel, msg.thread)
-    if (owner) {
-      // threadOwner returns the sole agent with an OPEN session in this thread, and
-      // null when 2+ agents actively share it (→ mention-gated via fallthrough). Thread
-      // PARTICIPATION, not channel reachability, is the disambiguator (§8.5): route an
-      // un-mentioned follow-up to that owner if it's reachable here, regardless of how
-      // many other bots are also bound to the channel.
-      const ownerRule = scopeCandidates.find((x) => x.agentId === owner)
-      if (ownerRule) return pickRule(ownerRule, 'thread') // continuity, kind-agnostic
-    }
-  }
-
-  // 3. CP per-sessionKey override (§8.3: CP authoritative).
-  // A rule scoped to the channel this message sits in (its enclosing channel counts —
-  // same predicate as the scope filter), NOT an unscoped global CP rule.
-  const cpInChannel = kindCandidates.some(
-    (r) =>
-      r.source === 'cp' &&
-      r.scope.channel !== undefined &&
-      channelInScope(r.scope.channel, msg) &&
-      (r.scope.thread === undefined || r.scope.thread === msg.thread)
-  )
-  const layer = cpInChannel ? kindCandidates.filter((r) => r.source === 'cp') : kindCandidates
-
-  // 4/5. kind precedence within the chosen layer (mention already handled).
-  for (const kind of KIND_ORDER) {
-    if (kind === 'mention') continue
-    const r = layer.find((x) => x.match.kind === kind)
-    if (r) return pickRule(r, kind)
-  }
-  return null
-}
+export {
+  automaticAgents,
+  conversationAdmitsAgent,
+  conversationPeers,
+  hopTransition,
+  isUsableSourceDepth,
+  mentionedAgents,
+  participantAgents,
+  routeRules,
+  type ActivationMessageFacts,
+  type ActivationRule,
+  type RouteVia
+} from '@agentconnect.md/activation-policy'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,19 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
 
+  packages/activation-policy:
+    dependencies:
+      '@agentconnect.md/protocol':
+        specifier: workspace:*
+        version: link:../protocol
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/cli:
     dependencies:
       '@agentconnect.md/connection':
@@ -260,6 +273,9 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: ^1.3.0
         version: 1.3.0(zod@4.4.3)
+      '@agentconnect.md/activation-policy':
+        specifier: workspace:*
+        version: link:../activation-policy
       '@agentconnect.md/connection':
         specifier: workspace:*
         version: link:../connection
@@ -277,7 +293,7 @@ importers:
         version: 0.0.67
       '@larksuiteoapi/node-sdk':
         specifier: ^1.71.1
-        version: 1.71.1(debug@4.3.4)
+        version: 1.71.1
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0
@@ -6188,20 +6204,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  lightningcss-android-arm64@1.33.0:
-    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-arm64@1.33.0:
-    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -6212,20 +6216,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.33.0:
-    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  lightningcss-freebsd-x64@1.33.0:
-    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -6236,21 +6228,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm-gnueabihf@1.33.0:
-    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
-
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  lightningcss-linux-arm64-gnu@1.33.0:
-    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -6263,22 +6242,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  lightningcss-linux-arm64-musl@1.33.0:
-    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  lightningcss-linux-x64-gnu@1.33.0:
-    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -6291,33 +6256,14 @@ packages:
     os: [linux]
     libc: [musl]
 
-  lightningcss-linux-x64-musl@1.33.0:
-    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-arm64-msvc@1.33.0:
-    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
   lightningcss-win32-x64-msvc@1.32.0:
     resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  lightningcss-win32-x64-msvc@1.33.0:
-    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
@@ -10241,9 +10187,9 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@larksuiteoapi/node-sdk@1.71.1(debug@4.3.4)':
+  '@larksuiteoapi/node-sdk@1.71.1':
     dependencies:
-      axios: 1.18.1(debug@4.3.4)
+      axios: 1.18.1
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -11601,7 +11547,7 @@ snapshots:
       '@slack/types': 2.22.0
       '@types/node': 24.13.3
       '@types/retry': 0.12.0
-      axios: 1.18.1(debug@4.3.4)
+      axios: 1.18.1
       eventemitter3: 5.0.4
       form-data: 4.0.6
       is-electron: 2.2.2
@@ -12621,7 +12567,7 @@ snapshots:
       - supports-color
     optional: true
 
-  axios@1.18.1(debug@4.3.4):
+  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0(debug@4.3.4)
       form-data: 4.0.6
@@ -14729,67 +14675,34 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
-  lightningcss-android-arm64@1.33.0:
-    optional: true
-
   lightningcss-darwin-arm64@1.32.0:
-    optional: true
-
-  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
-  lightningcss-darwin-x64@1.33.0:
-    optional: true
-
   lightningcss-freebsd-x64@1.32.0:
-    optional: true
-
-  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.33.0:
-    optional: true
-
   lightningcss-linux-arm64-gnu@1.32.0:
-    optional: true
-
-  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.33.0:
-    optional: true
-
   lightningcss-linux-x64-gnu@1.32.0:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.33.0:
-    optional: true
-
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.33.0:
-    optional: true
-
   lightningcss-win32-x64-msvc@1.32.0:
-    optional: true
-
-  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.32.0:
@@ -14811,18 +14724,6 @@ snapshots:
   lightningcss@1.33.0:
     dependencies:
       detect-libc: 2.1.2
-    optionalDependencies:
-      lightningcss-android-arm64: 1.33.0
-      lightningcss-darwin-arm64: 1.33.0
-      lightningcss-darwin-x64: 1.33.0
-      lightningcss-freebsd-x64: 1.33.0
-      lightningcss-linux-arm-gnueabihf: 1.33.0
-      lightningcss-linux-arm64-gnu: 1.33.0
-      lightningcss-linux-arm64-musl: 1.33.0
-      lightningcss-linux-x64-gnu: 1.33.0
-      lightningcss-linux-x64-musl: 1.33.0
-      lightningcss-win32-arm64-msvc: 1.33.0
-      lightningcss-win32-x64-msvc: 1.33.0
 
   lines-and-columns@1.2.4: {}
 

--- a/scripts/component-versions.sh
+++ b/scripts/component-versions.sh
@@ -53,7 +53,7 @@ SETUP_PATHS="$CP_PATHS"
 WEB_PATHS="packages/web packages/protocol $COMMON"
 RELAY_PATHS="packages/relay packages/message packages/protocol packages/connection packages/observability $COMMON"
 MEM0_PATHS="packages/memory-plugin-mem0 packages/protocol $COMMON"
-DAEMON_PATHS="packages/daemon packages/message packages/protocol packages/connection packages/observability packages/k8s-client $COMMON"
+DAEMON_PATHS="packages/daemon packages/activation-policy packages/message packages/protocol packages/connection packages/observability packages/k8s-client $COMMON"
 OPERATOR_PATHS="packages/operator packages/k8s-client packages/connection packages/protocol packages/observability $COMMON"
 # The backend's application source is the immutable external context declared in
 # docker-bake.hcl. Changes to that pin, its owned Dockerfile, or this resolver

--- a/scripts/lockfile-closure-changed.test.mjs
+++ b/scripts/lockfile-closure-changed.test.mjs
@@ -7,6 +7,7 @@ import { lockfileClosureChanged } from './lockfile-closure-changed.mjs'
 
 const DAEMON_IMPORTERS = [
   'packages/daemon',
+  'packages/activation-policy',
   'packages/message',
   'packages/protocol',
   'packages/connection',
@@ -41,6 +42,7 @@ const baseLock = () => ({
     },
     'packages/daemon': {
       dependencies: {
+        '@agentconnect.md/activation-policy': { specifier: 'workspace:*', version: 'link:../activation-policy' },
         '@agentconnect.md/connection': { specifier: 'workspace:*', version: 'link:../connection' },
         '@agentconnect.md/k8s-client': { specifier: 'workspace:*', version: 'link:../k8s-client' },
         '@agentconnect.md/message': { specifier: 'workspace:*', version: 'link:../message' },
@@ -49,6 +51,14 @@ const baseLock = () => ({
       },
       devDependencies: {
         tsdown: { specifier: '^0.22.3', version: '0.22.3(typescript@6.0.3)' }
+      }
+    },
+    'packages/activation-policy': {
+      dependencies: {
+        '@agentconnect.md/protocol': { specifier: 'workspace:*', version: 'link:../protocol' }
+      },
+      devDependencies: {
+        typescript: { specifier: '^6.0.3', version: '6.0.3' }
       }
     },
     'packages/k8s-client': {
@@ -119,6 +129,22 @@ test('web-only dependency bump does not affect the daemon closure', () => {
       lock.snapshots['lucide-react@0.501.0(react@19.0.0)'] = { dependencies: { react: '19.0.0' } }
     }),
     false
+  )
+})
+
+test('an activation-policy dependency bump reaches the daemon closure', () => {
+  assert.equal(
+    changed((lock) => {
+      lock.importers['packages/activation-policy'].devDependencies.typescript = {
+        specifier: '^6.0.4',
+        version: '6.0.4'
+      }
+      delete lock.packages['typescript@6.0.3']
+      delete lock.snapshots['typescript@6.0.3']
+      lock.packages['typescript@6.0.4'] = { resolution: { integrity: 'sha512-ts2' } }
+      lock.snapshots['typescript@6.0.4'] = {}
+    }),
+    true
   )
 })
 

--- a/scripts/publish-daemon-if-changed.sh
+++ b/scripts/publish-daemon-if-changed.sh
@@ -49,8 +49,8 @@ esac
 # republished the daemon whenever ANY package touched a dependency (a web
 # icons bump, say). It is checked separately below, scoped to the daemon's
 # importers.
-DAEMON_PATHS="packages/daemon packages/message packages/protocol packages/connection packages/k8s-client tsconfig.base.json"
-DAEMON_IMPORTERS="packages/daemon packages/message packages/protocol packages/connection packages/k8s-client"
+DAEMON_PATHS="packages/daemon packages/activation-policy packages/message packages/protocol packages/connection packages/k8s-client tsconfig.base.json"
+DAEMON_IMPORTERS="packages/daemon packages/activation-policy packages/message packages/protocol packages/connection packages/k8s-client"
 
 if [ -n "$LAST_TAG" ] && git rev-parse -q --verify "${LAST_TAG}^{commit}" > /dev/null; then
   # Word-splitting DAEMON_PATHS is deliberate: it is a list of pathspecs.


### PR DESCRIPTION
## What

Phase 2 of the activation-policy unification plan, **stacked on #927** (the parity suite is this PR's harness — do not merge before it). Zero behavior change.

Extracts the daemon ladder's decision logic — "who does this message activate" — into a new small workspace package, **`@agentconnect.md/activation-policy`**: pure functions over structural message facts, resolved rules, verified-authorship facts, and narrow providers (`threadOwner`, thread participants). No I/O, no daemon imports.

**Module contents** (`packages/activation-policy/src/index.ts`):
- `routeRules` + `mentionedAgents` / `participantAgents` / `automaticAgents` — the arbitration ladder, moved verbatim from `router/routing-table.ts`;
- `conversationPeers` — the §2.3/§6 delivery selection previously inline in `fanOutToThreadPeers` (participants ∪ explicit joins ∪ verified recipient joins ∪ channel-auto, minus primary/author, insertion order preserved);
- `conversationAdmitsAgent` — the Off/gated conversation fence previously inline in `agentConversationAdmits`;
- `hopTransition` + `isUsableSourceDepth` — the §4.1 hop gates (+1 per edge against `MAX_AGENT_CALL_HOPS`, fail-closed depth validation), now consumed by BOTH the platform ladder (`routeVerifiedAgentMessage`, `verifyAgentAuthor`) and the webchat continuation seam (`maybeActivateWebchatContinuation`) — the first two surfaces on one policy function.

**Adapters**: `router/routing-table.ts` is now a thin re-export; the daemon call sites supply providers and keep every side-effectful edge gate (mute latches, rendezvous claims, dispatch) exactly where it was, with identical log strings. `RoutingRule` now `extends ActivationRule`, making rule-shape assignability a compile-time guarantee. The module header documents how the relay's `AttributedRoute` ladder and webchat plug in later (deliberately not folded in this phase).

**Why a new package rather than `packages/protocol`**: protocol is the zod wire contract — schema-only, consumed by every wire endpoint; activation policy is product decision logic with a different change cadence and review audience. A separate package keeps protocol's "single source of truth for the wire" role clean, while daemon and (later) relay consume policy the same way they already consume protocol. The package depends only on `@agentconnect.md/protocol` (the shared hop-cap constants).

## Proof of zero behavior change

- **Activation parity suite** (#927): 23/23 unmodified.
- **Routing acceptance** (`eval:collab:routing`): 13/13; full `eval:collab:contracts` 115/115; `eval:contracts` 46/46.
- **Daemon routing suites** unmodified and green: route-rules, router, routing-rule, telegram-threading, cp-routing-layer, cp/daemon-integration, daemon-webchat-continuation, daemon-message-agent — 209/209.
- Full daemon suite: failures on the dev machine are byte-identical to clean `main` (known local flaky files only, verified by running the same files on a detached `origin/main` checkout: identical counts for daemon-agent-mention-routing (10), daemon-platform-authorship (2), and the shim/cp-reconcile/acp-matrix machine flakes).
- `pnpm typecheck` (all packages), `pnpm lint`, `pnpm format:check` clean; `pnpm install --frozen-lockfile` passes with the updated lockfile.

New package unit tests (12) cover the package's own contract: ladder smoke, the fence predicate, hop gates, and `conversationPeers` ordering/exclusions; the deep behavior remains pinned by the daemon suites and the parity legs. CI: the package is wired into the unit-test summary merge.

Lockfile note: `pnpm install` with pnpm 11.9 deduplicates a few pre-existing duplicate resolutions (lightningcss, one larksuiteoapi variant) while adding the workspace link — deterministic re-resolution, `--frozen-lockfile` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)